### PR TITLE
[android] Fixed jni crash when statistics was disabled.

### DIFF
--- a/android/src/com/mapswithme/util/statistics/Statistics.java
+++ b/android/src/com/mapswithme/util/statistics/Statistics.java
@@ -258,7 +258,6 @@ public enum Statistics
     }
   }
 
-  // This method is not called at all if statistics was disabled.
   private void configure(Context context)
   {
     if (mEnabled)


### PR DESCRIPTION
Reproduced when jni part is not initialized and HTTP code is reused from C++.
