### PR TITLE
[search] Fixed rank-table creation for World and WorldCoasts.

### DIFF
--- a/indexer/index.cpp
+++ b/indexer/index.cpp
@@ -65,7 +65,7 @@ unique_ptr<MwmSet::MwmValueBase> Index::CreateValue(MwmInfo & info) const
   {
     search::RankTableBuilder::CreateIfNotExists(localFile);
   }
-  catch (Reader::OpenException const & e)
+  catch (RootException const & e)
   {
     LOG(LWARNING, ("Can't create rank table for:", localFile, ":", e.Msg()));
   }

--- a/indexer/rank_table.cpp
+++ b/indexer/rank_table.cpp
@@ -7,6 +7,7 @@
 #include "indexer/types_skipper.hpp"
 
 #include "platform/local_country_file.hpp"
+#include "platform/local_country_file_utils.hpp"
 
 #include "coding/endianness.hpp"
 #include "coding/file_container.hpp"
@@ -268,11 +269,17 @@ void RankTableBuilder::CalcSearchRanks(FilesContainerR & rcont, vector<uint8_t> 
 // static
 void RankTableBuilder::CreateIfNotExists(platform::LocalCountryFile const & localFile)
 {
-  string const mapPath = localFile.GetPath(MapOptions::Map);
+  string mapPath;
 
   unique_ptr<RankTable> table;
   {
-    FilesContainerR rcont(mapPath);
+    ModelReaderPtr reader = platform::GetCountryReader(localFile, MapOptions::Map);
+    if (!reader.GetPtr())
+      return;
+
+    mapPath = reader.GetName();
+
+    FilesContainerR rcont(reader);
     if (rcont.IsExist(RANKS_FILE_TAG))
     {
       switch (CheckEndianness(rcont.GetReader(RANKS_FILE_TAG)))


### PR DESCRIPTION
Fixed rank table creation for World and WorldCoasts, since it's wrong to access them via LocalCountryFile::GetPath() method - the proper way is to use GetCountryReader() which handles them separately.

https://trello.com/c/NEiEPt8Y/30-searchengine
