### PR TITLE
[ios] Add homebrew path to qt5

### DIFF
--- a/tools/autobuild/detect_qmake.sh
+++ b/tools/autobuild/detect_qmake.sh
@@ -14,6 +14,7 @@ KNOWN_QMAKE_PATHS=( \
   ~/Qt5.3.0/5.3/clang_64/bin/qmake \
   ~/Developer/Qt/5.4/clang_64/bin/qmake \
   ~/Developer/Qt/5.5/clang_64/bin/qmake \
+  /usr/local/opt/qt5/bin/qmake \
   /cygdrive/c/Qt/5.5/msvc2013_64/bin/qmake.exe \
 )
 


### PR DESCRIPTION
Оказалось, наш `detect_qmake.sh` не ищёт qt5 там, куда его устанавливает homebrew. Как вы вообще раньше работали?
