### PR TITLE
[search] Fixed split of retrieved features to suggest/not suggest features.

### DIFF
--- a/search/search_query.cpp
+++ b/search/search_query.cpp
@@ -894,10 +894,11 @@ void Query::ProcessSuggestions(vector<T> & vec, Results & res) const
       if (!suggest.empty() && added < MAX_SUGGESTS_COUNT)
       {
         if (res.AddResult((Result(MakeResult(r), suggest))))
+        {
           ++added;
-
-        i = vec.erase(i);
-        continue;
+          i = vec.erase(i);
+          continue;
+        }
       }
     }
     ++i;


### PR DESCRIPTION
For instance, when searching for "улица правды" only two results are displayed in the results list, while there are around 100 of them in Russia_Central and Russia_Southern. The problem is that some retrieved results are removed by mistake from the search output during suggestions process.