### PR TITLE
[drape] Fixed crash on assert in UserEventStream.

### DIFF
--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -575,13 +575,14 @@ bool UserEventStream::EndDrag(Touch const & t, double timestamp, bool cancelled)
 
 void UserEventStream::BeginScale(Touch const & t1, Touch const & t2)
 {
+  TEST_CALL(BEGIN_SCALE);
+
   if (m_state == STATE_SCALE)
   {
     Scale(t1, t2);
     return;
   }
 
-  TEST_CALL(BEGIN_SCALE);
   ASSERT_EQUAL(m_state, STATE_EMPTY, ());
   m_state = STATE_SCALE;
   m2::PointD touch1 = t1.m_location;

--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -575,6 +575,12 @@ bool UserEventStream::EndDrag(Touch const & t, double timestamp, bool cancelled)
 
 void UserEventStream::BeginScale(Touch const & t1, Touch const & t2)
 {
+  if (m_state == STATE_SCALE)
+  {
+    Scale(t1, t2);
+    return;
+  }
+
   TEST_CALL(BEGIN_SCALE);
   ASSERT_EQUAL(m_state, STATE_EMPTY, ());
   m_state = STATE_SCALE;


### PR DESCRIPTION
Краш возникал во время масштабирования, когда добавлялось касание еще одним пальцем.