### PR TITLE
Mac OS X El Capitan: fixed http download error introduced by Apple for more security.

### DIFF
--- a/qt/res/Info.plist
+++ b/qt/res/Info.plist
@@ -31,5 +31,28 @@
 
     <key>NSHighResolutionCapable</key>
     <string>True</string>
+
+    <key>NSAppTransportSecurity</key>
+    <dict>
+      <key>NSAllowsArbitraryLoads</key>
+      <true/>
+      <key>NSExceptionDomains</key>
+      <dict>
+        <key>maps.me</key>
+        <dict>
+          <key>NSExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+          <key>NSIncludesSubdomains</key>
+          <true/>
+        </dict>
+        <key>mapswithme.com</key>
+        <dict>
+          <key>NSExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+          <key>NSIncludesSubdomains</key>
+          <true/>
+        </dict>
+      </dict>
+    </dict>
   </dict>
 </plist>


### PR DESCRIPTION
Delete either build folder or MAPS.ME.app folder and rebuild for it to work.