### PR TITLE
Fix library path: prepend local lib path instead of appending

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -61,7 +61,7 @@ RCC_DIR = $$TEMP_PATH
 MOC_DIR = $$TEMP_PATH
 UI_DIR = $$TEMP_PATH
 
-QMAKE_LIBDIR *= $$BINARIES_PATH
+QMAKE_LIBDIR = $$BINARIES_PATH $$QMAKE_LIBDIR
 
 # By default, do not include base QT classes in any project.
 QT -= core gui


### PR DESCRIPTION
This fixes picking up system libraries instead of ones from 3party/