### PR TITLE
Buildscript

### DIFF
--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -67,7 +67,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
   PROCESSES=4
 else
   SPEC=linux-clang-libc++
-  PROCESSES=$(($(nproc) / 2))
+  PROCESSES=$(nproc)
 fi
 
 build_conf()

--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -66,7 +66,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
   SPEC=macx-clang
   PROCESSES=4
 else
-  SPEC=linux-clang
+  SPEC=linux-clang-libc++
   PROCESSES=$(($(nproc) / 2))
 fi
 


### PR DESCRIPTION
Two minor fixes for Linux builds
Linux Qt target should change to linux-clang-libc++ as g++ stdlib headers gave some problems with thread model. This was at least with gcc 4.8.4. AFAIK libc++ is standard library for clang anyway, so might be best to avoid the mixup on systems where clang and g++ are found.
Second is a problem with smaller machines where only one processor is available. The build script terminates with command line 'make -j 0', as 1/2 processors gets rounded to 0. I'm working in a VM, so only one proc here. Could be extended to avoid the 0 instead, but having PROCESSES at num_proc seems more suitable.