### PR TITLE
[turns][sound] Using for turn notification a real distance to the closest turn instead of a distance based on speed.

### DIFF
--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -184,7 +184,7 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
   string const engShortJson =
       "\
       {\
-      \"in_700_meters\":\"In 700 meters.\",\
+      \"in_600_meters\":\"In 600 meters.\",\
       \"make_a_sharp_right_turn\":\"Make a sharp right turn.\",\
       \"enter_the_roundabout\":\"Enter the roundabout.\"\
       }";
@@ -203,9 +203,13 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
   TEST(turnNotifications.empty(), ());
 
   // 700 meters till the turn. It's time to pronounce the first voice notification.
+  // The speed is high.
+  // The compensation of kStartBeforeSeconds/kMinStartBeforeMeters/kMaxStartBeforeMeters is not enough.
+  // The user will be closer to the turn while pronouncing despite the compensation.
+  // So it should be pronounced "In 600 meters."
   turns.front().m_distMeters = 700.;
   turnSound.GenerateTurnSound(turns, turnNotifications);
-  vector<string> const expectedNotification1 = {{"In 700 meters. Make a sharp right turn."}};
+  vector<string> const expectedNotification1 = {{"In 600 meters. Make a sharp right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification1, ());
 
   turnSound.SetSpeedMetersPerSecond(32.);

--- a/routing/turns_sound.cpp
+++ b/routing/turns_sound.cpp
@@ -123,11 +123,19 @@ string TurnsSound::GenerateFirstTurnSound(TurnItem const & turn, double distance
         }
         else
         {
+          double const distToPronounceMeters = distanceToTurnMeters - distanceToPronounceNotificationMeters;
+          if (distToPronounceMeters < 0)
+          {
+            FastForwardFirstTurnNotification();
+            return string(); // The current position is too close to the turn for the first notification.
+          }
+
           // Pronouncing first turn sound notification.
-          uint32_t const distToPronounce =
-              m_settings.RoundByPresetSoundedDistancesUnits(turnNotificationDistUnits);
+          double const distToPronounceUnits = m_settings.ConvertMetersToUnits(distToPronounceMeters);
+          uint32_t const roundedDistToPronounceUnits =
+              m_settings.RoundByPresetSoundedDistancesUnits(distToPronounceUnits);
           m_nextTurnNotificationProgress = PronouncedNotification::First;
-          return GenerateTurnText(distToPronounce, turn.m_exitNum, false /* useThenInsteadOfDistance */,
+          return GenerateTurnText(roundedDistToPronounceUnits, turn.m_exitNum, false /* useThenInsteadOfDistance */,
                                   turn.m_turn, m_settings.GetLengthUnits());
         }
       }

--- a/routing/turns_sound_settings.cpp
+++ b/routing/turns_sound_settings.cpp
@@ -55,7 +55,6 @@ double Settings::ConvertMetersPerSecondToUnitsPerSecond(double speedInMetersPerS
       return MeasurementUtils::MetersToFeet(speedInMetersPerSecond);
   }
 
-  // m_lengthUnits is equal to LengthUnits::Undefined or to unknown value.
   ASSERT(false, ("m_lengthUnits is equal to unknown value."));
   return 0.;
 }
@@ -73,7 +72,23 @@ double Settings::ConvertUnitsToMeters(double distanceInUnits) const
       return MeasurementUtils::FeetToMeters(distanceInUnits);
   }
 
-  // m_lengthUnits is equal to LengthUnits::Undefined or to unknown value.
+  ASSERT(false, ());
+  return 0.;
+}
+
+double Settings::ConvertMetersToUnits(double distanceInMeters) const
+{
+  switch (m_lengthUnits)
+  {
+    case LengthUnits::Undefined:
+      ASSERT(false, ());
+      return 0.;
+    case LengthUnits::Meters:
+      return distanceInMeters;
+    case LengthUnits::Feet:
+      return MeasurementUtils::MetersToFeet(distanceInMeters);
+  }
+
   ASSERT(false, ());
   return 0.;
 }

--- a/routing/turns_sound_settings.hpp
+++ b/routing/turns_sound_settings.hpp
@@ -72,6 +72,7 @@ public:
   inline void SetLengthUnits(LengthUnits units) { m_lengthUnits = units; }
   double ConvertMetersPerSecondToUnitsPerSecond(double speedInMetersPerSecond) const;
   double ConvertUnitsToMeters(double distanceInUnits) const;
+  double ConvertMetersToUnits(double distanceInMeters) const;
   void ForTestingSetNotificationTimeSecond(uint32_t time) { m_timeSeconds = time; }
 };
 


### PR DESCRIPTION
При проигрывании поворота правильно использовать расстояние оставшееся до поворота, а не расстояние, которое вычисляется из скорости и времени активации оповещения.
Бывают случаи (после перестроения маршрута), когда эти расстояния могут сильно различаться.

PR помечен DO NOT MERGE, поскольку я жду, когда в мастер попадет https://github.com/mapsme/omim/pull/164 и я смогу доделать юнит тесты без конфликтов.

https://trello.com/c/xTfj3uHV/1898--