### PR TITLE
Fixed crash on Android in debug mode when World maps are absent (not downloaded yet).

### DIFF
--- a/platform/local_country_file_utils.cpp
+++ b/platform/local_country_file_utils.cpp
@@ -195,7 +195,10 @@ void FindAllLocalMaps(vector<LocalCountryFile> & localFiles)
     catch (RootException const & ex)
     {
       if (i == localFiles.end())
-        LOG(LERROR, ("Can't find any:", file, "Reason:", ex.Msg()));
+      {
+        // This warning is possible on android devices without pre-downloaded Worlds/fonts files.
+        LOG(LWARNING, ("Can't find any:", file, "Reason:", ex.Msg()));
+      }
     }
   }
 }


### PR DESCRIPTION
Discovered this crash when tried to send debug version to our users.