### PR TITLE
Added text style property support, fixed misprints

### DIFF
--- a/drape_frontend/stylist.hpp
+++ b/drape_frontend/stylist.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "indexer/feature_data.hpp"
+#include "indexer/drawing_rule_def.hpp"
 
 #include "base/buffer_vector.hpp"
 
@@ -21,6 +22,7 @@ struct CaptionDescription
 
   void FormatCaptions(FeatureType const & f,
                       feature::EGeomType type,
+                      drule::text_type_t mainTextType,
                       bool auxCaptionExists);
 
   string const & GetMainText() const;
@@ -54,7 +56,7 @@ public:
 
   using TRuleWrapper = pair<drule::BaseRule const *, double>;
   using TRuleCallback = function<void (TRuleWrapper const &)>;
-  void ForEachRule(TRuleCallback const & fn);
+  void ForEachRule(TRuleCallback const & fn) const;
 
   bool IsEmpty() const;
 


### PR DESCRIPTION
Added text styles property support (https://trello.com/c/aPuwQXzh/35-- port to the Drape).

plus minor changes:
- Fixed misprints "Finded" -> "Found";
- Added method const.