### PR TITLE
Using enum Units through all the application for meters and feet.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1636,11 +1636,8 @@ void Framework::SetupMeasurementSystem()
 {
   Settings::Units units = Settings::Metric;
   Settings::Get("Units", units);
-  // @TODO(vbykoianko) Rewrites code to use enum class LengthUnits only.
-  m_routingSession.SetTurnNotificationsUnits(units == Settings::Foot ?
-                                             routing::turns::sound::LengthUnits::Feet :
-                                             routing::turns::sound::LengthUnits::Meters);
 
+  m_routingSession.SetTurnNotificationsUnits(units);
   m_informationDisplay.measurementSystemChanged();
   Invalidate();
 }

--- a/platform/settings.hpp
+++ b/platform/settings.hpp
@@ -46,8 +46,6 @@ namespace Settings
     StringStorage::Instance().DeleteKeyAndValue(key);
   }
 
-  // @TODO(vbykoianko) For the time being two enums which are reflected length units are used.
-  // This enum should be replaced with enum class LengthUnits.
   enum Units { Metric = 0, Foot };
 
   /// Use this function for running some stuff once according to date.

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -403,7 +403,7 @@ bool RoutingSession::AreTurnNotificationsEnabled() const
   return m_turnsSound.IsEnabled();
 }
 
-void RoutingSession::SetTurnNotificationsUnits(routing::turns::sound::LengthUnits const & units)
+void RoutingSession::SetTurnNotificationsUnits(Settings::Units const units)
 {
   threads::MutexGuard guard(m_routeSessionMutex);
   UNUSED_VALUE(guard);

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -103,7 +103,7 @@ public:
   // Sound notifications for turn instructions.
   void EnableTurnNotifications(bool enable);
   bool AreTurnNotificationsEnabled() const;
-  void SetTurnNotificationsUnits(routing::turns::sound::LengthUnits const & units);
+  void SetTurnNotificationsUnits(Settings::Units const units);
   void SetTurnNotificationsLocale(string const & locale);
   string GetTurnNotificationsLocale() const;
   void GenerateTurnSound(vector<string> & turnNotifications);

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -27,7 +27,7 @@ UNIT_TEST(TurnNotificationSettingsMetersTest)
                           200 /* minNotificationDistanceUnits */,
                           700 /* maxNotificationDistanceUnits */,
                           {100, 200, 300, 400, 500, 600, 700} /* soundedDistancesUnits */,
-                          LengthUnits::Meters /* lengthUnits */);
+                          ::Settings::Metric /* lengthUnits */);
 
   TEST(settings.IsValid(), ());
   TEST(my::AlmostEqualAbs(
@@ -51,7 +51,7 @@ UNIT_TEST(TurnNotificationSettingsFeetTest)
                           500 /* minNotificationDistanceUnits */,
                           2000 /* maxNotificationDistanceUnits */,
                           {200, 400, 600, 800, 1000, 1500, 2000} /* soundedDistancesUnits */,
-                          LengthUnits::Feet /* lengthUnits */);
+                          ::Settings::Foot /* lengthUnits */);
 
   TEST(settings.IsValid(), ());
   TEST(my::AlmostEqualAbs(
@@ -74,19 +74,16 @@ UNIT_TEST(TurnNotificationSettingsNotValidTest)
   Settings settings1(20 /* notificationTimeSeconds */, 500 /* minNotificationDistanceUnits */,
                      2000 /* maxNotificationDistanceUnits */,
                      {200, 400, 800, 600, 1000, 1500, 2000} /* soundedDistancesUnits */,
-                     LengthUnits::Feet /* lengthUnits */);
+                     ::Settings::Foot /* lengthUnits */);
   TEST(!settings1.IsValid(), ());
 
-  Settings settings2(20 /* notificationTimeSeconds */, 500 /* minNotificationDistanceUnits */,
+  Settings settings2(20 /* notificationTimeSeconds */, 5000 /* minNotificationDistanceUnits */,
                      2000 /* maxNotificationDistanceUnits */,
                      {200, 400, 600, 800, 1000, 1500, 2000} /* soundedDistancesUnits */,
-                     LengthUnits::Undefined /* lengthUnits */);
+                     ::Settings::Metric /* lengthUnits */);
   TEST(!settings2.IsValid(), ());
 
-  Settings settings3(20 /* notificationTimeSeconds */, 5000 /* minNotificationDistanceUnits */,
-                     2000 /* maxNotificationDistanceUnits */,
-                     {200, 400, 600, 800, 1000, 1500, 2000} /* soundedDistancesUnits */,
-                     LengthUnits::Meters /* lengthUnits */);
+  Settings settings3;
   TEST(!settings3.IsValid(), ());
 }
 
@@ -94,7 +91,7 @@ UNIT_TEST(TurnsSoundMetersTest)
 {
   TurnsSound turnSound;
   turnSound.Enable(true);
-  turnSound.SetLengthUnits(routing::turns::sound::LengthUnits::Meters);
+  turnSound.SetLengthUnits(::Settings::Metric);
   string const engShortJson =
       "\
       {\
@@ -180,7 +177,7 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
 {
   TurnsSound turnSound;
   turnSound.Enable(true);
-  turnSound.SetLengthUnits(routing::turns::sound::LengthUnits::Meters);
+  turnSound.SetLengthUnits(::Settings::Metric);
   string const engShortJson =
       "\
       {\
@@ -253,7 +250,7 @@ UNIT_TEST(TurnsSoundFeetTest)
 {
   TurnsSound turnSound;
   turnSound.Enable(true);
-  turnSound.SetLengthUnits(routing::turns::sound::LengthUnits::Feet);
+  turnSound.SetLengthUnits(::Settings::Foot);
   string const engShortJson =
       "\
       {\
@@ -334,7 +331,7 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
 {
   TurnsSound turnSound;
   turnSound.Enable(true);
-  turnSound.SetLengthUnits(routing::turns::sound::LengthUnits::Meters);
+  turnSound.SetLengthUnits(::Settings::Metric);
   string const engShortJson =
       "\
       {\
@@ -403,7 +400,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
 {
   TurnsSound turnSound;
   turnSound.Enable(true);
-  turnSound.SetLengthUnits(routing::turns::sound::LengthUnits::Meters);
+  turnSound.SetLengthUnits(::Settings::Metric);
   string const engShortJson =
       "\
       {\

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -19,36 +19,36 @@ bool PairDistEquals(PairDist const & lhs, PairDist const & rhs)
 UNIT_TEST(GetDistanceTextIdMetersTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, LengthUnits lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, LengthUnits::Meters);
+  //    TurnDirection turnDir, Settings::Units lengthUnits)
+  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
   TEST_EQUAL(GetDistanceTextId(notifiation1), "in_500_meters", ());
-  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, LengthUnits::Meters);
+  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, ::Settings::Metric);
   TEST_EQUAL(GetDistanceTextId(notifiation2), "then", ());
-  Notification const notifiation3(200, 0, false, TurnDirection::TurnRight, LengthUnits::Meters);
+  Notification const notifiation3(200, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
   TEST_EQUAL(GetDistanceTextId(notifiation3), "in_200_meters", ());
-  Notification const notifiation4(2000, 0, false, TurnDirection::TurnRight, LengthUnits::Meters);
+  Notification const notifiation4(2000, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
   TEST_EQUAL(GetDistanceTextId(notifiation4), "in_2_kilometers", ());
 }
 
 UNIT_TEST(GetDistanceTextIdFeetTest)
 {
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, LengthUnits::Feet);
+  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
   TEST_EQUAL(GetDistanceTextId(notifiation1), "in_500_feet", ());
-  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, LengthUnits::Feet);
+  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, ::Settings::Foot);
   TEST_EQUAL(GetDistanceTextId(notifiation2), "then", ());
-  Notification const notifiation3(800, 0, false, TurnDirection::TurnRight, LengthUnits::Feet);
+  Notification const notifiation3(800, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
   TEST_EQUAL(GetDistanceTextId(notifiation3), "in_800_feet", ());
-  Notification const notifiation4(5000, 0, false, TurnDirection::TurnRight, LengthUnits::Feet);
+  Notification const notifiation4(5000, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
   TEST_EQUAL(GetDistanceTextId(notifiation4), "in_5000_feet", ());
 }
 
 UNIT_TEST(GetDirectionTextIdTest)
 {
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, LengthUnits::Feet);
+  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
   TEST_EQUAL(GetDirectionTextId(notifiation1), "make_a_right_turn", ());
-  Notification const notifiation2(1000, 0, false, TurnDirection::GoStraight, LengthUnits::Meters);
+  Notification const notifiation2(1000, 0, false, TurnDirection::GoStraight, ::Settings::Metric);
   TEST_EQUAL(GetDirectionTextId(notifiation2), "go_straight", ());
-  Notification const notifiation3(700, 0, false, TurnDirection::UTurn, LengthUnits::Meters);
+  Notification const notifiation3(700, 0, false, TurnDirection::UTurn, ::Settings::Metric);
   TEST_EQUAL(GetDirectionTextId(notifiation3), "make_a_u_turn", ());
 }
 
@@ -78,12 +78,12 @@ UNIT_TEST(GetTtsTextTest)
 
   GetTtsText getTtsText;
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, LengthUnits lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, LengthUnits::Meters);
-  Notification const notifiation2(300, 0, false, TurnDirection::TurnLeft, LengthUnits::Meters);
+  //    TurnDirection turnDir, Settings::Units lengthUnits)
+  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
+  Notification const notifiation2(300, 0, false, TurnDirection::TurnLeft, ::Settings::Metric);
   Notification const notifiation3(0, 0, false, TurnDirection::ReachedYourDestination,
-                                  LengthUnits::Meters);
-  Notification const notifiation4(0, 0, true, TurnDirection::TurnLeft, LengthUnits::Meters);
+                                  ::Settings::Metric);
+  Notification const notifiation4(0, 0, true, TurnDirection::TurnLeft, ::Settings::Metric);
 
   getTtsText.ForTestingSetLocaleWithJson(engShortJson);
   TEST_EQUAL(getTtsText(notifiation1), "In 500 meters. Make a right turn.", ());

--- a/routing/turns_sound.cpp
+++ b/routing/turns_sound.cpp
@@ -50,7 +50,7 @@ namespace turns
 namespace sound
 {
 string TurnsSound::GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-                                    TurnDirection turnDir, LengthUnits lengthUnits) const
+                                    TurnDirection turnDir, ::Settings::Units lengthUnits) const
 {
   Notification const notification(distanceUnits, exitNum, useThenInsteadOfDistance, turnDir, lengthUnits);
   return m_getTtsText(notification);
@@ -169,25 +169,22 @@ void TurnsSound::Enable(bool enable)
   m_enabled = enable;
 }
 
-void TurnsSound::SetLengthUnits(LengthUnits units)
+void TurnsSound::SetLengthUnits(::Settings::Units units)
 {
   m_settings.SetLengthUnits(units);
   switch(units)
   {
-  case LengthUnits::Undefined:
-    ASSERT(false, ());
-    return;
-  case LengthUnits::Meters:
+  case ::Settings::Metric:
     m_settings = Settings(30 /* notificationTimeSeconds */, 200 /* minNotificationDistanceUnits */,
                           2000 /* maxNotificationDistanceUnits */,
                           GetSoundedDistMeters() /* soundedDistancesUnits */,
-                          LengthUnits::Meters /* lengthUnits */);
+                          ::Settings::Metric /* lengthUnits */);
     return;
-  case LengthUnits::Feet:
+  case ::Settings::Foot:
     m_settings = Settings(30 /* notificationTimeSeconds */, 500 /* minNotificationDistanceUnits */,
                           5000 /* maxNotificationDistanceUnits */,
                           GetSoundedDistFeet() /* soundedDistancesUnits */,
-                          LengthUnits::Feet /* lengthUnits */);
+                          ::Settings::Foot /* lengthUnits */);
     return;
   }
 }

--- a/routing/turns_sound.hpp
+++ b/routing/turns_sound.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "routing/turns.hpp"
 #include "routing/turns_sound_settings.hpp"
 #include "routing/turns_tts_text.hpp"
+
+#include "platform/settings.hpp"
 
 #include "std/string.hpp"
 
@@ -69,7 +70,7 @@ class TurnsSound
   GetTtsText m_getTtsText;
 
   string GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-                          TurnDirection turnDir, LengthUnits lengthUnits) const;
+                          TurnDirection turnDir, ::Settings::Units lengthUnits) const;
   /// Generates turn sound notification for the nearest to the current position turn.
   string GenerateFirstTurnSound(TurnItem const & turn, double distanceToTurnMeters);
   /// Changes the state of the class to emulate that first turn notification is pronouned
@@ -83,8 +84,8 @@ public:
 
   bool IsEnabled() const { return m_enabled; }
   void Enable(bool enable);
-  void SetLengthUnits(LengthUnits units);
-  inline LengthUnits GetLengthUnits() const { return m_settings.GetLengthUnits(); }
+  void SetLengthUnits(::Settings::Units units);
+  inline ::Settings::Units GetLengthUnits() const { return m_settings.GetLengthUnits(); }
   inline void SetLocale(string const & locale) { m_getTtsText.SetLocale(locale); }
   inline string GetLocale() const { return m_getTtsText.GetLocale(); }
   void SetSpeedMetersPerSecond(double speed);

--- a/routing/turns_sound_settings.cpp
+++ b/routing/turns_sound_settings.cpp
@@ -14,8 +14,7 @@ namespace sound
 {
 bool Settings::IsValid() const
 {
-  return m_lengthUnits != LengthUnits::Undefined &&
-         m_minDistanceUnits <= m_maxDistanceUnits &&
+  return m_minDistanceUnits <= m_maxDistanceUnits &&
          !m_soundedDistancesUnits.empty() &&
          is_sorted(m_soundedDistancesUnits.cbegin(), m_soundedDistancesUnits.cend());
 }
@@ -46,12 +45,9 @@ double Settings::ConvertMetersPerSecondToUnitsPerSecond(double speedInMetersPerS
 {
   switch (m_lengthUnits)
   {
-    case LengthUnits::Undefined:
-      ASSERT(false, ());
-      return 0.;
-    case LengthUnits::Meters:
+    case ::Settings::Metric:
       return speedInMetersPerSecond;
-    case LengthUnits::Feet:
+    case ::Settings::Foot:
       return MeasurementUtils::MetersToFeet(speedInMetersPerSecond);
   }
 
@@ -63,12 +59,9 @@ double Settings::ConvertUnitsToMeters(double distanceInUnits) const
 {
   switch (m_lengthUnits)
   {
-    case LengthUnits::Undefined:
-      ASSERT(false, ());
-      return 0.;
-    case LengthUnits::Meters:
+    case ::Settings::Metric:
       return distanceInUnits;
-    case LengthUnits::Feet:
+    case ::Settings::Foot:
       return MeasurementUtils::FeetToMeters(distanceInUnits);
   }
 
@@ -80,34 +73,14 @@ double Settings::ConvertMetersToUnits(double distanceInMeters) const
 {
   switch (m_lengthUnits)
   {
-    case LengthUnits::Undefined:
-      ASSERT(false, ());
-      return 0.;
-    case LengthUnits::Meters:
+    case ::Settings::Metric:
       return distanceInMeters;
-    case LengthUnits::Feet:
+    case ::Settings::Foot:
       return MeasurementUtils::MetersToFeet(distanceInMeters);
   }
 
   ASSERT(false, ());
   return 0.;
-}
-
-string DebugPrint(LengthUnits const & lengthUnits)
-{
-  switch (lengthUnits)
-  {
-    case LengthUnits::Undefined:
-      return "LengthUnits::Undefined";
-    case LengthUnits::Meters:
-      return "LengthUnits::Meters";
-    case LengthUnits::Feet:
-      return "LengthUnits::Feet";
-  }
-
-  stringstream out;
-  out << "Unknown LengthUnits value: " << static_cast<int>(lengthUnits);
-  return out.str();
 }
 
 string DebugPrint(Notification const & notification)
@@ -117,7 +90,7 @@ string DebugPrint(Notification const & notification)
       << ", m_exitNum == " << notification.m_exitNum
       << ", m_useThenInsteadOfDistance == " << notification.m_useThenInsteadOfDistance
       << ", m_turnDir == " << DebugPrint(notification.m_turnDir)
-      << ", m_lengthUnits == " << DebugPrint(notification.m_lengthUnits) << " ]" << endl;
+      << ", m_lengthUnits == " << notification.m_lengthUnits << " ]" << endl;
   return out.str();
 }
 

--- a/routing/turns_sound_settings.hpp
+++ b/routing/turns_sound_settings.hpp
@@ -2,21 +2,16 @@
 
 #include "routing/turns.hpp"
 
+#include "platform/settings.hpp"
+
+#include "std/vector.hpp"
+
 namespace routing
 {
 namespace turns
 {
 namespace sound
 {
-enum class LengthUnits
-{
-  Undefined,
-  Meters,
-  Feet
-};
-
-string DebugPrint(LengthUnits const & lengthUnits);
-
 /// \brief The Settings struct is a structure for gathering information about turn sound
 /// notifications settings.
 /// All distance parameters shall be set in m_lengthUnits. (Meters of feet for the time being.)
@@ -29,17 +24,17 @@ class Settings
   /// \brief m_distancesToPronounce is a list of distances in m_lengthUnits
   ///  which are ready to be pronounced.
   vector<uint32_t> m_soundedDistancesUnits;
-  LengthUnits m_lengthUnits;
+  ::Settings::Units m_lengthUnits;
 
 public:
   Settings()
       : m_minDistanceUnits(0),
         m_maxDistanceUnits(0),
         m_soundedDistancesUnits(),
-        m_lengthUnits(LengthUnits::Undefined) {}
+        m_lengthUnits(::Settings::Metric) {}
   Settings(uint32_t notificationTimeSeconds, uint32_t minNotificationDistanceUnits,
            uint32_t maxNotificationDistanceUnits, vector<uint32_t> const & soundedDistancesUnits,
-           LengthUnits lengthUnits)
+           ::Settings::Units lengthUnits)
       : m_timeSeconds(notificationTimeSeconds),
         m_minDistanceUnits(minNotificationDistanceUnits),
         m_maxDistanceUnits(maxNotificationDistanceUnits),
@@ -51,6 +46,7 @@ public:
 
   /// \brief IsValid checks if Settings data is consistent.
   /// \warning The complexity is up to linear in size of m_soundedDistancesUnits.
+  /// \note For any instance created by default constructor IsValid() returns false.
   bool IsValid() const;
 
   /// \brief computes the distance an end user shall be informed about the future turn
@@ -68,8 +64,8 @@ public:
   /// The result will be one of the m_soundedDistancesUnits values.
   uint32_t RoundByPresetSoundedDistancesUnits(uint32_t turnNotificationUnits) const;
 
-  inline LengthUnits GetLengthUnits() const { return m_lengthUnits; }
-  inline void SetLengthUnits(LengthUnits units) { m_lengthUnits = units; }
+  inline ::Settings::Units GetLengthUnits() const { return m_lengthUnits; }
+  inline void SetLengthUnits(::Settings::Units units) { m_lengthUnits = units; }
   double ConvertMetersPerSecondToUnitsPerSecond(double speedInMetersPerSecond) const;
   double ConvertUnitsToMeters(double distanceInUnits) const;
   double ConvertMetersToUnits(double distanceInMeters) const;
@@ -84,10 +80,10 @@ struct Notification
   uint8_t m_exitNum;
   bool m_useThenInsteadOfDistance;
   TurnDirection m_turnDir;
-  LengthUnits m_lengthUnits;
+  ::Settings::Units m_lengthUnits;
 
   Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-               TurnDirection turnDir, LengthUnits lengthUnits)
+               TurnDirection turnDir, ::Settings::Units lengthUnits)
       : m_distanceUnits(distanceUnits),
         m_exitNum(exitNum),
         m_useThenInsteadOfDistance(useThenInsteadOfDistance),
@@ -101,8 +97,6 @@ struct Notification
            m_useThenInsteadOfDistance == rhv.m_useThenInsteadOfDistance &&
            m_turnDir == rhv.m_turnDir && m_lengthUnits == rhv.m_lengthUnits;
   }
-
-  inline bool IsValid() const { return m_lengthUnits != LengthUnits::Undefined; }
 };
 
 string DebugPrint(Notification const & turnGeom);

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -77,24 +77,15 @@ string GetTtsText::GetTextById(string const & textId) const
 
 string GetDistanceTextId(Notification const & notification)
 {
-  if (!notification.IsValid())
-  {
-    ASSERT(false, ());
-    return string();
-  }
-
   if (notification.m_useThenInsteadOfDistance)
     return "then";
 
   switch (notification.m_lengthUnits)
   {
-    case LengthUnits::Undefined:
-      ASSERT(false, ());
-      return string();
-    case LengthUnits::Meters:
+    case ::Settings::Metric:
       return DistToTextId(GetAllSoundedDistMeters().cbegin(), GetAllSoundedDistMeters().cend(),
                           notification.m_distanceUnits);
-    case LengthUnits::Feet:
+    case ::Settings::Foot:
       return DistToTextId(GetAllSoundedDistFeet().cbegin(), GetAllSoundedDistFeet().cend(),
                           notification.m_distanceUnits);
   }


### PR DESCRIPTION
Использование enum Units по всем приложению для единиц измерения.
Ранее я ввел enum class LengthUnits, который обладал дефолтным значением для использования в TTS для выражения единиц измерения. В последствии, дефолтного значения не потребовалось. Чтоб не  плодить сущности теперь по все подсистеме озвучки используются старый emum Units.

https://trello.com/c/pN1344WJ/1902-enum-units