### PR TITLE
[generator] Revert regions fix, warning on low disk space

### DIFF
--- a/docs/MAPS.md
+++ b/docs/MAPS.md
@@ -135,8 +135,8 @@ but if this flag is set (e.g. to `1`), they are built asynchronously. But
 it can fail due to low memory.
 * `MERGE_INTERVAL`: delay in minutes between attempts to merge a coast line.
 Default is 40.
-* `REGIONS`: a list of `.poly` files for regions to be built. Can be empty.
-Example: `../../data/borders/UK* ../../data/borders/*Ireland*`.
+* `REGIONS`: a list of `.poly` files for regions to be built. One for each line.
+Can be empty. Example: `$(ls ../../data/borders/{UK*,Ireland}.poly)`.
 
 ### Testing
 

--- a/tools/unix/generate_planet_routing.sh
+++ b/tools/unix/generate_planet_routing.sh
@@ -51,7 +51,7 @@ if [ "$1" == "pbf" ]; then
   export OSMCTOOLS
   export PLANET
   export INTDIR
-  find "$TMPBORDERS" -name '*.poly' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
+  find "$TMPBORDERS" -maxdepth 1 -name '*.poly' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
     sh -c '"$OSMCTOOLS/osmconvert" "$PLANET" --hash-memory=2000 -B="%" --complex-ways --out-pbf -o="$INTDIR/$(basename "%" .poly).pbf"'
   [ $? != 0 ] && fail "Failed to process all the regions"
   rm -r "$TMPBORDERS"
@@ -111,7 +111,7 @@ elif [ "$1" == "mwm" ]; then
   export TARGET
   export LOG_PATH
   export DATA_PATH="$OMIM_PATH/data/"
-  find "$INTDIR" -name '*.osrm' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
+  find "$INTDIR" -maxdepth 1 -name '*.osrm' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
     sh -c 'O="%"; B="$(basename "$O" .osrm)"; "$G" $K --osrm_file_name="$O" --data_path="$TARGET" --user_resource_path="$DATA_PATH" --output="$B" 2>> "$LOG_PATH/$B.log"'
 
   if [ -n "${POLY_DIR-}" ]; then


### PR DESCRIPTION
Поспешил, не почитал свою же документацию и сломал функцию передачи списка регионов. Вернул, и уточнил документацию. Также:

* Добавил проверку, чтобы было не меньше 250 гигабайт на диске под промежуточные данные.
* Больше не шлём письмо при нажатии Ctrl+C, но шлём при возникновении ошибки (странно, раньше не было, и не замечал).
* Скрипт генерации роутинга находил «спрятанные» в подкаталоге промежуточные файлы. Теперь не будет.