### PR TITLE
Using English in TTS if sound.txt doesn't contain the current languag

### DIFF
--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -605,10 +605,12 @@ public:
   inline bool AreTurnNotificationsEnabled() const { return m_routingSession.AreTurnNotificationsEnabled(); }
   /// \brief Sets a locale for TTS.
   /// \param locale is a string with locale code. For example "en", "ru", "zh-Hant" and so on.
-  /// See sound/tts/languages.txt for the full list.
+  /// \note ee sound/tts/languages.txt for the full list of available locales.
   inline void SetTurnNotificationsLocale(string const & locale) { m_routingSession.SetTurnNotificationsLocale(locale); }
   /// @return current TTS locale. For example "en", "ru", "zh-Hant" and so on.
   /// In case of error returns an empty string.
+  /// \note The method returns correct locale after SetTurnNotificationsLocale has been called.
+  /// If not, it returns an empty string.
   inline string GetTurnNotificationsLocale() const { return m_routingSession.GetTurnNotificationsLocale(); }
   /// \brief When an end user is going to a turn he gets sound turn instructions.
   /// If C++ part wants the client to pronounce an instruction GenerateTurnSound (in turnNotifications) returns

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -605,7 +605,7 @@ public:
   inline bool AreTurnNotificationsEnabled() const { return m_routingSession.AreTurnNotificationsEnabled(); }
   /// \brief Sets a locale for TTS.
   /// \param locale is a string with locale code. For example "en", "ru", "zh-Hant" and so on.
-  /// \note ee sound/tts/languages.txt for the full list of available locales.
+  /// \note See sound/tts/languages.txt for the full list of available locales.
   inline void SetTurnNotificationsLocale(string const & locale) { m_routingSession.SetTurnNotificationsLocale(locale); }
   /// @return current TTS locale. For example "en", "ru", "zh-Hant" and so on.
   /// In case of error returns an empty string.

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -603,7 +603,12 @@ public:
   // Sound notifications for turn instructions.
   inline void EnableTurnNotifications(bool enable) { m_routingSession.EnableTurnNotifications(enable); }
   inline bool AreTurnNotificationsEnabled() const { return m_routingSession.AreTurnNotificationsEnabled(); }
+  /// \brief Sets a locale for TTS.
+  /// \param locale is a string with locale code. For example "en", "ru", "zh-Hant" and so on.
+  /// See sound/tts/languages.txt for the full list.
   inline void SetTurnNotificationsLocale(string const & locale) { m_routingSession.SetTurnNotificationsLocale(locale); }
+  /// @return current TTS locale. For example "en", "ru", "zh-Hant" and so on.
+  /// In case of error returns an empty string.
   inline string GetTurnNotificationsLocale() const { return m_routingSession.GetTurnNotificationsLocale(); }
   /// \brief When an end user is going to a turn he gets sound turn instructions.
   /// If C++ part wants the client to pronounce an instruction GenerateTurnSound (in turnNotifications) returns

--- a/platform/get_text_by_id.cpp
+++ b/platform/get_text_by_id.cpp
@@ -29,6 +29,7 @@ string GetTextSourceString(platform::TextSource textSource)
   }
 #endif
   ASSERT(false, ());
+  return string();
 }
 
 bool GetJsonBuffer(platform::TextSource textSource, string const & localeName, string & jsonBuffer)
@@ -58,7 +59,7 @@ TGetTextByIdPtr MakeGetTextById(string const & jsonBuffer, string const & locale
   TGetTextByIdPtr result(new GetTextById(jsonBuffer, localeName));
   if (!result->IsValid())
   {
-    ASSERT(false, ());
+    ASSERT(false, ("Can't create a GetTextById instance from a json file. localeName=", localeName));
     return nullptr;
   }
   return result;

--- a/platform/get_text_by_id.cpp
+++ b/platform/get_text_by_id.cpp
@@ -15,23 +15,18 @@ string const kDefaultLanguage = "en";
 
 string GetTextSourceString(platform::TextSource textSource)
 {
-#if defined(OMIM_OS_ANDROID) || defined(OMIM_OS_IPHONE)
   switch (textSource)
   {
     case platform::TextSource::TtsSound:
-      return "sound-strings";
+      return string("sound-strings");
   }
-#else
-  switch (textSource)
-  {
-    case platform::TextSource::TtsSound:
-      return "../data/sound-strings";
-  }
-#endif
   ASSERT(false, ());
   return string();
 }
+}  // namespace
 
+namespace platform
+{
 bool GetJsonBuffer(platform::TextSource textSource, string const & localeName, string & jsonBuffer)
 {
   string const pathToJson = my::JoinFoldersToPath(
@@ -50,10 +45,7 @@ bool GetJsonBuffer(platform::TextSource textSource, string const & localeName, s
   }
   return true;
 }
-}  // namespace
 
-namespace platform
-{
 TGetTextByIdPtr MakeGetTextById(string const & jsonBuffer, string const & localeName)
 {
   TGetTextByIdPtr result(new GetTextById(jsonBuffer, localeName));

--- a/platform/get_text_by_id.cpp
+++ b/platform/get_text_by_id.cpp
@@ -43,9 +43,9 @@ bool GetJsonBuffer(platform::TextSource textSource, string const & localeName, s
   }
   catch (RootException const & ex)
   {
-    LOG(LWARNING, ("Can't open", localeName,"sound instructions file. pathToJson is",
-                   pathToJson, ex.what()));
-    return false; // No json file for localeName
+    LOG(LWARNING, ("Can't open", localeName, "sound instructions file. pathToJson is", pathToJson,
+                   ex.what()));
+    return false;  // No json file for localeName
   }
   return true;
 }
@@ -82,7 +82,8 @@ TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer, string c
   return MakeGetTextById(jsonBuffer, localeName);
 }
 
-GetTextById::GetTextById(string const & jsonBuffer, string const & localeName) : m_locale(localeName)
+GetTextById::GetTextById(string const & jsonBuffer, string const & localeName)
+  : m_locale(localeName)
 {
   InitFromJson(jsonBuffer);
 }

--- a/platform/get_text_by_id.hpp
+++ b/platform/get_text_by_id.hpp
@@ -15,7 +15,7 @@ enum class TextSource
 };
 
 class GetTextById;
-typedef unique_ptr<GetTextById> TGetTextByIdPtr;
+using TGetTextByIdPtr = unique_ptr<GetTextById>;
 
 /// GetTextById represents text messages which are saved in textsDir
 /// in a specified locale.
@@ -45,7 +45,7 @@ private:
 
 /// Factories to create GetTextById instances.
 /// If TGetTextByIdPtr is created by GetTextByIdFactory or ForTestingGetTextByIdFactory
-/// threre are only two possibities:
+/// there are only two possibities:
 /// * a factory returns a valid instance
 /// * a factory returns nullptr
 TGetTextByIdPtr GetTextByIdFactory(TextSource textSource, string const & localeName);

--- a/platform/get_text_by_id.hpp
+++ b/platform/get_text_by_id.hpp
@@ -50,4 +50,8 @@ private:
 /// * a factory returns nullptr
 TGetTextByIdPtr GetTextByIdFactory(TextSource textSource, string const & localeName);
 TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
+
+/// \bried fills jsonBuffer with json file in twine format with strings in a language of localeName.
+/// @return true if no error was happened and false otherwise.
+bool GetJsonBuffer(platform::TextSource textSource, string const & localeName, string & jsonBuffer);
 }  // namespace platform

--- a/platform/get_text_by_id.hpp
+++ b/platform/get_text_by_id.hpp
@@ -27,9 +27,11 @@ public:
   /// The boolean flag is set to false otherwise.
   string operator()(string const & textId) const;
   string GetLocale() const { return m_locale; }
+
 private:
   friend TGetTextByIdPtr GetTextByIdFactory(TextSource textSource, string const & localeName);
-  friend TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
+  friend TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer,
+                                                      string const & localeName);
   friend TGetTextByIdPtr MakeGetTextById(string const & jsonBuffer, string const & localeName);
 
   GetTextById(string const & jsonBuffer, string const & localeName);

--- a/platform/get_text_by_id.hpp
+++ b/platform/get_text_by_id.hpp
@@ -14,6 +14,9 @@ enum class TextSource
   TtsSound = 0
 };
 
+class GetTextById;
+typedef unique_ptr<GetTextById> TGetTextByIdPtr;
+
 /// GetTextById represents text messages which are saved in textsDir
 /// in a specified locale.
 class GetTextById
@@ -25,9 +28,9 @@ public:
   string operator()(string const & textId) const;
   string GetLocale() const { return m_locale; }
 private:
-  friend unique_ptr<GetTextById> GetTextByIdFactory(TextSource textSouce, string const & localeName);
-  friend unique_ptr<GetTextById> ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
-  friend unique_ptr<GetTextById> MakeGetTextById(string const & jsonBuffer, string const & localeName);
+  friend TGetTextByIdPtr GetTextByIdFactory(TextSource textSource, string const & localeName);
+  friend TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
+  friend TGetTextByIdPtr MakeGetTextById(string const & jsonBuffer, string const & localeName);
 
   GetTextById(string const & jsonBuffer, string const & localeName);
   void InitFromJson(string const & jsonBuffer);
@@ -38,11 +41,11 @@ private:
   unordered_map<string, string> m_localeTexts;
 };
 
-/// Factoris to create intances of GetTextById.
-/// If unique_ptr<GetTextById> is created by GetTextByIdFactory or ForTestingGetTextByIdFactory
-/// threre are only two possibities.
+/// Factories to create GetTextById instances.
+/// If TGetTextByIdPtr is created by GetTextByIdFactory or ForTestingGetTextByIdFactory
+/// threre are only two possibities:
 /// * a factory returns a valid instance
 /// * a factory returns nullptr
-unique_ptr<GetTextById> GetTextByIdFactory(TextSource textSouce, string const & localeName);
-unique_ptr<GetTextById> ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
+TGetTextByIdPtr GetTextByIdFactory(TextSource textSource, string const & localeName);
+TGetTextByIdPtr ForTestingGetTextByIdFactory(string const & jsonBuffer, string const & localeName);
 }  // namespace platform

--- a/platform/platform_tests/get_text_by_id_tests.cpp
+++ b/platform/platform_tests/get_text_by_id_tests.cpp
@@ -15,7 +15,7 @@ UNIT_TEST(GetTextByIdEnglishTest)
       \"in_1_mile\":\"In one mile.\"\
       }";
 
-  unique_ptr<platform::GetTextById> getEnglish = platform::ForTestingGetTextByIdFactory(shortJson, "en");
+  auto getEnglish = platform::ForTestingGetTextByIdFactory(shortJson, "en");
   TEST_EQUAL((*getEnglish)("make_a_slight_right_turn"), "Make a slight right turn.", ());
   TEST_EQUAL((*getEnglish)("in_900_meters"), "In nine hundred meters.", ());
   TEST_EQUAL((*getEnglish)("then"), "Then.", ());
@@ -38,7 +38,7 @@ UNIT_TEST(GetTextByIdRussianTest)
       \"in_1_mile\":\"Через одну милю.\"\
       }";
 
-  unique_ptr<platform::GetTextById> getRussian = platform::ForTestingGetTextByIdFactory(shortJson, "ru");
+  auto getRussian = platform::ForTestingGetTextByIdFactory(shortJson, "ru");
   TEST_EQUAL((*getRussian)("in_800_meters"), "Через восемьсот метров.", ());
   TEST_EQUAL((*getRussian)("make_a_slight_right_turn"), "Плавный поворот направо.", ());
   TEST_EQUAL((*getRussian)("take_the_6th_exit"), "Шестой поворот с кольца.", ());
@@ -61,7 +61,7 @@ UNIT_TEST(GetTextByIdKoreanTest)
       \"in_5000_feet\":\"5000피트 앞\"\
       }";
 
-  unique_ptr<platform::GetTextById> getKorean = platform::ForTestingGetTextByIdFactory(shortJson, "ko");
+  auto getKorean = platform::ForTestingGetTextByIdFactory(shortJson, "ko");
   TEST_EQUAL((*getKorean)("in_700_meters"), "700 미터 앞", ());
   TEST_EQUAL((*getKorean)("make_a_right_turn"), "우회전입니다.", ());
   TEST_EQUAL((*getKorean)("take_the_5th_exit"), "다섯 번째 출구입니다.", ());
@@ -84,7 +84,7 @@ UNIT_TEST(GetTextByIdArabicTest)
       \"in_4000_feet\":\"بعد 4000 قدم\"\
       }";
 
-  unique_ptr<platform::GetTextById> getArabic = platform::ForTestingGetTextByIdFactory(shortJson, "ar");
+  auto getArabic = platform::ForTestingGetTextByIdFactory(shortJson, "ar");
   TEST_EQUAL((*getArabic)("in_1_kilometer"), "بعد كيلو متر واحدٍ", ());
   TEST_EQUAL((*getArabic)("leave_the_roundabout"), "اخرج من الطريق الدوار", ());
   TEST_EQUAL((*getArabic)("take_the_3rd_exit"), "اسلك المخرج الثالث", ());
@@ -107,7 +107,7 @@ UNIT_TEST(GetTextByIdFrenchTest)
       \"in_3500_feet\":\"Dans trois mille cinq cents pieds.\"\
       }";
 
-  unique_ptr<platform::GetTextById> getFrench = platform::ForTestingGetTextByIdFactory(shortJson, "fr");
+  auto getFrench = platform::ForTestingGetTextByIdFactory(shortJson, "fr");
   TEST_EQUAL((*getFrench)("in_1_5_kilometers"), "Dans un virgule cinq kilomètre.", ());
   TEST_EQUAL((*getFrench)("enter_the_roundabout"), "Prenez le rond-point.", ());
   TEST_EQUAL((*getFrench)("take_the_2nd_exit"), "Prenez la deuxième sortie.", ());

--- a/platform/platform_tests/get_text_by_id_tests.cpp
+++ b/platform/platform_tests/get_text_by_id_tests.cpp
@@ -15,16 +15,16 @@ UNIT_TEST(GetTextByIdEnglishTest)
       \"in_1_mile\":\"In one mile.\"\
       }";
 
-  platform::GetTextById getEnglish(shortJson);
-  TEST_EQUAL(getEnglish("make_a_slight_right_turn"), "Make a slight right turn.", ());
-  TEST_EQUAL(getEnglish("in_900_meters"), "In nine hundred meters.", ());
-  TEST_EQUAL(getEnglish("then"), "Then.", ());
-  TEST_EQUAL(getEnglish("in_1_mile"), "In one mile.", ());
+  unique_ptr<platform::GetTextById> getEnglish = platform::ForTestingGetTextByIdFactory(shortJson, "en");
+  TEST_EQUAL((*getEnglish)("make_a_slight_right_turn"), "Make a slight right turn.", ());
+  TEST_EQUAL((*getEnglish)("in_900_meters"), "In nine hundred meters.", ());
+  TEST_EQUAL((*getEnglish)("then"), "Then.", ());
+  TEST_EQUAL((*getEnglish)("in_1_mile"), "In one mile.", ());
 
-  TEST_EQUAL(getEnglish("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getEnglish("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getEnglish(""), "", ());
-  TEST_EQUAL(getEnglish(" "), "", ());
+  TEST_EQUAL((*getEnglish)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getEnglish)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getEnglish)(""), "", ());
+  TEST_EQUAL((*getEnglish)(" "), "", ());
 }
 
 UNIT_TEST(GetTextByIdRussianTest)
@@ -38,16 +38,16 @@ UNIT_TEST(GetTextByIdRussianTest)
       \"in_1_mile\":\"Через одну милю.\"\
       }";
 
-  platform::GetTextById getRussian(shortJson);
-  TEST_EQUAL(getRussian("in_800_meters"), "Через восемьсот метров.", ());
-  TEST_EQUAL(getRussian("make_a_slight_right_turn"), "Плавный поворот направо.", ());
-  TEST_EQUAL(getRussian("take_the_6th_exit"), "Шестой поворот с кольца.", ());
-  TEST_EQUAL(getRussian("in_1_mile"), "Через одну милю.", ());
+  unique_ptr<platform::GetTextById> getRussian = platform::ForTestingGetTextByIdFactory(shortJson, "ru");
+  TEST_EQUAL((*getRussian)("in_800_meters"), "Через восемьсот метров.", ());
+  TEST_EQUAL((*getRussian)("make_a_slight_right_turn"), "Плавный поворот направо.", ());
+  TEST_EQUAL((*getRussian)("take_the_6th_exit"), "Шестой поворот с кольца.", ());
+  TEST_EQUAL((*getRussian)("in_1_mile"), "Через одну милю.", ());
 
-  TEST_EQUAL(getRussian("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getRussian("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getRussian(""), "", ());
-  TEST_EQUAL(getRussian(" "), "", ());
+  TEST_EQUAL((*getRussian)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getRussian)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getRussian)(""), "", ());
+  TEST_EQUAL((*getRussian)(" "), "", ());
 }
 
 UNIT_TEST(GetTextByIdKoreanTest)
@@ -61,16 +61,16 @@ UNIT_TEST(GetTextByIdKoreanTest)
       \"in_5000_feet\":\"5000피트 앞\"\
       }";
 
-  platform::GetTextById getKorean(shortJson);
-  TEST_EQUAL(getKorean("in_700_meters"), "700 미터 앞", ());
-  TEST_EQUAL(getKorean("make_a_right_turn"), "우회전입니다.", ());
-  TEST_EQUAL(getKorean("take_the_5th_exit"), "다섯 번째 출구입니다.", ());
-  TEST_EQUAL(getKorean("in_5000_feet"), "5000피트 앞", ());
+  unique_ptr<platform::GetTextById> getKorean = platform::ForTestingGetTextByIdFactory(shortJson, "ko");
+  TEST_EQUAL((*getKorean)("in_700_meters"), "700 미터 앞", ());
+  TEST_EQUAL((*getKorean)("make_a_right_turn"), "우회전입니다.", ());
+  TEST_EQUAL((*getKorean)("take_the_5th_exit"), "다섯 번째 출구입니다.", ());
+  TEST_EQUAL((*getKorean)("in_5000_feet"), "5000피트 앞", ());
 
-  TEST_EQUAL(getKorean("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getKorean("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getKorean(""), "", ());
-  TEST_EQUAL(getKorean(" "), "", ());
+  TEST_EQUAL((*getKorean)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getKorean)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getKorean)(""), "", ());
+  TEST_EQUAL((*getKorean)(" "), "", ());
 }
 
 UNIT_TEST(GetTextByIdArabicTest)
@@ -84,16 +84,16 @@ UNIT_TEST(GetTextByIdArabicTest)
       \"in_4000_feet\":\"بعد 4000 قدم\"\
       }";
 
-  platform::GetTextById getArabic(shortJson);
-  TEST_EQUAL(getArabic("in_1_kilometer"), "بعد كيلو متر واحدٍ", ());
-  TEST_EQUAL(getArabic("leave_the_roundabout"), "اخرج من الطريق الدوار", ());
-  TEST_EQUAL(getArabic("take_the_3rd_exit"), "اسلك المخرج الثالث", ());
-  TEST_EQUAL(getArabic("in_4000_feet"), "بعد 4000 قدم", ());
+  unique_ptr<platform::GetTextById> getArabic = platform::ForTestingGetTextByIdFactory(shortJson, "ar");
+  TEST_EQUAL((*getArabic)("in_1_kilometer"), "بعد كيلو متر واحدٍ", ());
+  TEST_EQUAL((*getArabic)("leave_the_roundabout"), "اخرج من الطريق الدوار", ());
+  TEST_EQUAL((*getArabic)("take_the_3rd_exit"), "اسلك المخرج الثالث", ());
+  TEST_EQUAL((*getArabic)("in_4000_feet"), "بعد 4000 قدم", ());
 
-  TEST_EQUAL(getArabic("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getArabic("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getArabic(""), "", ());
-  TEST_EQUAL(getArabic(" "), "", ());
+  TEST_EQUAL((*getArabic)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getArabic)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getArabic)(""), "", ());
+  TEST_EQUAL((*getArabic)(" "), "", ());
 }
 
 UNIT_TEST(GetTextByIdFrenchTest)
@@ -107,14 +107,14 @@ UNIT_TEST(GetTextByIdFrenchTest)
       \"in_3500_feet\":\"Dans trois mille cinq cents pieds.\"\
       }";
 
-  platform::GetTextById getFrench(shortJson);
-  TEST_EQUAL(getFrench("in_1_5_kilometers"), "Dans un virgule cinq kilomètre.", ());
-  TEST_EQUAL(getFrench("enter_the_roundabout"), "Prenez le rond-point.", ());
-  TEST_EQUAL(getFrench("take_the_2nd_exit"), "Prenez la deuxième sortie.", ());
-  TEST_EQUAL(getFrench("in_3500_feet"), "Dans trois mille cinq cents pieds.", ());
+  unique_ptr<platform::GetTextById> getFrench = platform::ForTestingGetTextByIdFactory(shortJson, "fr");
+  TEST_EQUAL((*getFrench)("in_1_5_kilometers"), "Dans un virgule cinq kilomètre.", ());
+  TEST_EQUAL((*getFrench)("enter_the_roundabout"), "Prenez le rond-point.", ());
+  TEST_EQUAL((*getFrench)("take_the_2nd_exit"), "Prenez la deuxième sortie.", ());
+  TEST_EQUAL((*getFrench)("in_3500_feet"), "Dans trois mille cinq cents pieds.", ());
 
-  TEST_EQUAL(getFrench("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getFrench("some_nonexistent_key"), "", ());
-  TEST_EQUAL(getFrench(""), "", ());
-  TEST_EQUAL(getFrench(" "), "", ());
+  TEST_EQUAL((*getFrench)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getFrench)("some_nonexistent_key"), "", ());
+  TEST_EQUAL((*getFrench)(""), "", ());
+  TEST_EQUAL((*getFrench)(" "), "", ());
 }

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -503,6 +503,19 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
   turnSound.GenerateTurnSound(turns9, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification9, ());
 }
+
+UNIT_TEST(GetJsonBufferTest)
+{
+  string const localeNameEn = "en";
+  string jsonBuffer;
+  TEST(GetJsonBuffer(platform::TextSource::TtsSound, localeNameEn, jsonBuffer), ());
+  TEST(!jsonBuffer.empty(), ());
+
+  string const localeNameRu = "ru";
+  jsonBuffer.clear();
+  TEST(GetJsonBuffer(platform::TextSource::TtsSound, localeNameRu, jsonBuffer), ());
+  TEST(!jsonBuffer.empty(), ());
+}
 }  // namespace sound
 }  // namespace turns
 }  // namespace routing

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -98,7 +98,7 @@ UNIT_TEST(TurnsSoundMetersTest)
       \"in_600_meters\":\"In 600 meters.\",\
       \"make_a_right_turn\":\"Make a right turn.\"\
       }";
-  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   turnSound.m_settings.ForTestingSetNotificationTimeSecond(20);
 
   turnSound.Reset();
@@ -185,7 +185,7 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
       \"make_a_sharp_right_turn\":\"Make a sharp right turn.\",\
       \"enter_the_roundabout\":\"Enter the roundabout.\"\
       }";
-  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   turnSound.m_settings.ForTestingSetNotificationTimeSecond(20);
 
   turnSound.Reset();
@@ -257,7 +257,7 @@ UNIT_TEST(TurnsSoundFeetTest)
       \"in_2000_feet\":\"In 2000 feet.\",\
       \"enter_the_roundabout\":\"Enter the roundabout.\"\
       }";
-  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   turnSound.m_settings.ForTestingSetNotificationTimeSecond(20);
 
   turnSound.Reset();
@@ -341,7 +341,7 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
       \"then\":\"Then.\",\
       \"you_have_reached_the_destination\":\"You have reached the destination.\"\
       }";
-  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   turnSound.m_settings.ForTestingSetNotificationTimeSecond(30);
 
   turnSound.Reset();
@@ -412,7 +412,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
       \"in_600_meters\":\"In 600 meters.\",\
       \"then\":\"Then.\"\
       }";
-  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  turnSound.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   turnSound.m_settings.ForTestingSetNotificationTimeSecond(30);
 
   turnSound.Reset();

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -85,13 +85,13 @@ UNIT_TEST(GetTtsTextTest)
                                   ::Settings::Metric);
   Notification const notifiation4(0, 0, true, TurnDirection::TurnLeft, ::Settings::Metric);
 
-  getTtsText.ForTestingSetLocaleWithJson(engShortJson);
+  getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
   TEST_EQUAL(getTtsText(notifiation1), "In 500 meters. Make a right turn.", ());
   TEST_EQUAL(getTtsText(notifiation2), "In 300 meters. Make a left turn.", ());
   TEST_EQUAL(getTtsText(notifiation3), "You have reached the destination.", ());
   TEST_EQUAL(getTtsText(notifiation4), "Then. Make a left turn.", ());
 
-  getTtsText.ForTestingSetLocaleWithJson(rusShortJson);
+  getTtsText.ForTestingSetLocaleWithJson(rusShortJson, "ru");
   TEST_EQUAL(getTtsText(notifiation1), "Через 500 метров. Поворот направо.", ());
   TEST_EQUAL(getTtsText(notifiation2), "Через 300 метров. Поворот налево.", ());
   TEST_EQUAL(getTtsText(notifiation3), "Вы достигли конца маршрута.", ());

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -61,7 +61,7 @@ string GetTtsText::operator()(Notification const & notification) const
 
 string GetTtsText::GetLocale() const
 {
-  if (m_getCurLang)
+  if (m_getCurLang == nullptr)
   {
     ASSERT(false, ());
     return string();
@@ -73,7 +73,7 @@ string GetTtsText::GetTextById(string const & textId) const
 {
   ASSERT(!textId.empty(), ());
 
-  if (!m_getCurLang)
+  if (m_getCurLang == nullptr)
   {
     ASSERT(false, ());
     return "";

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -76,7 +76,7 @@ string GetTtsText::GetTextById(string const & textId) const
   if (m_getCurLang == nullptr)
   {
     ASSERT(false, ());
-    return "";
+    return string();
   }
   return (*m_getCurLang)(textId);
 }

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -37,13 +37,11 @@ namespace sound
 void GetTtsText::SetLocale(string const & locale)
 {
   m_getCurLang = platform::GetTextByIdFactory(platform::TextSource::TtsSound, locale);
-  ASSERT(m_getCurLang, ());
 }
 
 void GetTtsText::ForTestingSetLocaleWithJson(string const & jsonBuffer, string const & locale)
 {
   m_getCurLang = platform::ForTestingGetTextByIdFactory(jsonBuffer, locale);
-  ASSERT(m_getCurLang, ());
 }
 
 string GetTtsText::operator()(Notification const & notification) const

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -36,16 +36,14 @@ namespace sound
 {
 void GetTtsText::SetLocale(string const & locale)
 {
-  m_locale = locale;
-  m_getCurLang.reset(new platform::GetTextById(platform::TextSource::TtsSound, locale));
-  /// @todo Factor out file check from constructor and do not create m_getCurLang object in case of error.
+  m_getCurLang = platform::GetTextByIdFactory(platform::TextSource::TtsSound, locale);
   ASSERT(m_getCurLang, ());
 }
 
-void GetTtsText::ForTestingSetLocaleWithJson(string const & jsonBuffer)
+void GetTtsText::ForTestingSetLocaleWithJson(string const & jsonBuffer, string const & locale)
 {
-  m_getCurLang.reset(new platform::GetTextById(jsonBuffer));
-  ASSERT(m_getCurLang && m_getCurLang->IsValid(), ());
+  m_getCurLang = platform::ForTestingGetTextByIdFactory(jsonBuffer, locale);
+  ASSERT(m_getCurLang, ());
 }
 
 string GetTtsText::operator()(Notification const & notification) const
@@ -63,11 +61,21 @@ string GetTtsText::operator()(Notification const & notification) const
   return distStr + " " + dirStr;
 }
 
+string GetTtsText::GetLocale() const
+{
+  if (m_getCurLang)
+  {
+    ASSERT(false, ());
+    return string();
+  }
+  return m_getCurLang->GetLocale();
+}
+
 string GetTtsText::GetTextById(string const & textId) const
 {
   ASSERT(!textId.empty(), ());
 
-  if (!m_getCurLang || !m_getCurLang->IsValid())
+  if (!m_getCurLang)
   {
     ASSERT(false, ());
     return "";

--- a/routing/turns_tts_text.hpp
+++ b/routing/turns_tts_text.hpp
@@ -22,16 +22,14 @@ class GetTtsText
 {
 public:
   string operator()(Notification const & notification) const;
-  /// TODO(vbykoianko) Check if locale is available. If not use default (en) locale.
   void SetLocale(string const & locale);
-  inline string GetLocale() const { return m_locale; }
-  void ForTestingSetLocaleWithJson(string const & jsonBuffer);
+  string GetLocale() const;
+  void ForTestingSetLocaleWithJson(string const & jsonBuffer, string const & locale);
 
 private:
   string GetTextById(string const & textId) const;
 
   unique_ptr<platform::GetTextById> m_getCurLang;
-  string m_locale;
 };
 
 /// Generates text message id about the distance of the notification. For example: In 300 meters.

--- a/routing/turns_tts_text.hpp
+++ b/routing/turns_tts_text.hpp
@@ -24,7 +24,7 @@ public:
   string operator()(Notification const & notification) const;
   /// \brief Sets a locale.
   /// @param locale is a string representation of locale. For example "en", "ru", "zh-Hant" and so on.
-  /// \note ee sound/tts/languages.txt for the full list of available locales.
+  /// \note See sound/tts/languages.txt for the full list of available locales.
   void SetLocale(string const & locale);
   /// @return current TTS locale. For example "en", "ru", "zh-Hant" and so on.
   /// \note The method returns correct locale after SetLocale has been called.

--- a/routing/turns_tts_text.hpp
+++ b/routing/turns_tts_text.hpp
@@ -22,8 +22,15 @@ class GetTtsText
 {
 public:
   string operator()(Notification const & notification) const;
+  /// \brief Sets a locale.
+  /// @param locale is a string representation of locale. For example "en", "ru", "zh-Hant" and so on.
+  /// \note ee sound/tts/languages.txt for the full list of available locales.
   void SetLocale(string const & locale);
+  /// @return current TTS locale. For example "en", "ru", "zh-Hant" and so on.
+  /// \note The method returns correct locale after SetLocale has been called.
+  /// If not, it returns an empty string.
   string GetLocale() const;
+
   void ForTestingSetLocaleWithJson(string const & jsonBuffer, string const & locale);
 
 private:


### PR DESCRIPTION
1. Если sound.txt не содержит язык установленный по средствам SetLocale, то в качестве языка по умолчанию используем английский;
2. Рефакторинг, связанный с тем, что экземпляры GetTextById не создаются не валидными. Или создаются. Или возвращается unitque_ptr от нуля.

https://trello.com/c/3CTbz09t/1923-tts