### PR TITLE
Comment London ferry integration test.

### DIFF
--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -115,18 +115,17 @@ namespace
         MercatorBounds::FromLatLon(48.86123, 2.34129), 2840940.);
   }
 
-// @TODO This test is failed to create a route for the time being with data from 12.09.2015.
-// Now it's impossible to create a vehicle route from Paris to London.
-// The assumed reason is some tags of the tunnel were changed and we stop working with
-// the situation correctly.
-// At the same time OSRM manages to create routes through the tunnel.
-  UNIT_TEST(FranceParisCenternglandLondonCenterRouteTest)
-  {
-    integration::CalculateRouteAndTestRouteLength(
-        integration::GetOsrmComponents(),
-        MercatorBounds::FromLatLon(48.86123, 2.34129), {0., 0.},
-        MercatorBounds::FromLatLon(51.49884, -0.10438), 0./* Some unknown value*/);
-  }
+// TODO(gardster) repair routing to London.
+// https://trello.com/c/WPSQUu9J/1932-francepariscenternglandlondoncenterroutetest
+// OSRM routes through a OSM way with tag render:no. So we have no geometry in the
+// mwm and we can not obtain a cross section exit point.
+//  UNIT_TEST(FranceParisCenternglandLondonCenterRouteTest)
+//  {
+//    integration::CalculateRouteAndTestRouteLength(
+//        integration::GetOsrmComponents(),
+//        MercatorBounds::FromLatLon(48.86123, 2.34129), {0., 0.},
+//        MercatorBounds::FromLatLon(51.49884, -0.10438), 0./* Some unknown value*/);
+//  }
 
   // Strange map edits in Africa borders. Routing not linked now.
   /*


### PR DESCRIPTION
Сейчас мы не можем его починить. Путь в Лондон проходит по туннелю со свойством render:no. В итоге в mwm не попадает геометрия переправы и межмвмный роутинг не может найти точку выхода с карты. Для ремонта нужно либо научиться включать в mwm нерисуемую геометрию, либо придумать что-либо ещё. Таск на ремонт: https://trello.com/c/WPSQUu9J/1932-francepariscenternglandlondoncenterroutetest