### PR TITLE
Parse URL s= parameter as point style

### DIFF
--- a/map/api_mark_container.cpp
+++ b/map/api_mark_container.cpp
@@ -3,8 +3,6 @@
 
 #include "framework.hpp"
 
-////////////////////////////////////////////////////////////////////////
-
 
 ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)
   : UserMarkContainer(layerDepth, framework)
@@ -25,5 +23,3 @@ UserMark * ApiUserMarkContainer::AllocateUserMark(const m2::PointD & ptOrg)
 {
   return new ApiMarkPoint(ptOrg, this);
 }
-
-

--- a/map/api_mark_container.cpp
+++ b/map/api_mark_container.cpp
@@ -3,21 +3,14 @@
 
 #include "framework.hpp"
 
-
 ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)
   : UserMarkContainer(layerDepth, framework)
 {
 }
 
-string ApiUserMarkContainer::GetTypeName() const
-{
-  return "api-result";
-}
+string ApiUserMarkContainer::GetTypeName() const { return "api-result"; }
 
-string ApiUserMarkContainer::GetActiveTypeName() const
-{
-  return "search-result-active";
-}
+string ApiUserMarkContainer::GetActiveTypeName() const { return "search-result-active"; }
 
 UserMark * ApiUserMarkContainer::AllocateUserMark(const m2::PointD & ptOrg)
 {

--- a/map/api_mark_container.cpp
+++ b/map/api_mark_container.cpp
@@ -1,7 +1,7 @@
-#include "api_mark_container.hpp"
-#include "api_mark_point.hpp"
+#include "map/api_mark_container.hpp"
+#include "map/api_mark_point.hpp"
 
-#include "framework.hpp"
+#include "map/framework.hpp"
 
 ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)
   : UserMarkContainer(layerDepth, framework)

--- a/map/api_mark_container.cpp
+++ b/map/api_mark_container.cpp
@@ -1,6 +1,6 @@
 #include "map/api_mark_container.hpp"
-#include "map/api_mark_point.hpp"
 
+#include "map/api_mark_point.hpp"
 #include "map/framework.hpp"
 
 ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)

--- a/map/api_mark_container.cpp
+++ b/map/api_mark_container.cpp
@@ -1,0 +1,29 @@
+#include "api_mark_container.hpp"
+#include "api_mark_point.hpp"
+
+#include "framework.hpp"
+
+////////////////////////////////////////////////////////////////////////
+
+
+ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)
+  : UserMarkContainer(layerDepth, framework)
+{
+}
+
+string ApiUserMarkContainer::GetTypeName() const
+{
+  return "api-result";
+}
+
+string ApiUserMarkContainer::GetActiveTypeName() const
+{
+  return "search-result-active";
+}
+
+UserMark * ApiUserMarkContainer::AllocateUserMark(const m2::PointD & ptOrg)
+{
+  return new ApiMarkPoint(ptOrg, this);
+}
+
+

--- a/map/api_mark_container.hpp
+++ b/map/api_mark_container.hpp
@@ -11,8 +11,8 @@ public:
   virtual Type GetType() const { return API_MARK; }
 
   virtual string GetActiveTypeName() const;
+
 protected:
   virtual string GetTypeName() const;
   virtual UserMark * AllocateUserMark(m2::PointD const & ptOrg);
 };
-

--- a/map/api_mark_container.hpp
+++ b/map/api_mark_container.hpp
@@ -1,18 +1,19 @@
 #pragma once
 
-#include "user_mark_container.hpp"
-#include "api_mark_point.hpp"
+#include "map/api_mark_point.hpp"
+#include "map/user_mark_container.hpp"
 
 class ApiUserMarkContainer : public UserMarkContainer
 {
 public:
   ApiUserMarkContainer(double layerDepth, Framework & framework);
 
-  virtual Type GetType() const { return API_MARK; }
-
-  virtual string GetActiveTypeName() const;
+  // UserMarkContainer overrides:
+  Type GetType() const override { return API_MARK; }
+  string GetActiveTypeName() const override;
 
 protected:
-  virtual string GetTypeName() const;
-  virtual UserMark * AllocateUserMark(m2::PointD const & ptOrg);
+  // UserMarkContainer overrides:
+  string GetTypeName() const override;
+  UserMark * AllocateUserMark(m2::PointD const & ptOrg) override;
 };

--- a/map/api_mark_container.hpp
+++ b/map/api_mark_container.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "user_mark_container.hpp"
+#include "api_mark_point.hpp"
+
+class ApiUserMarkContainer : public UserMarkContainer
+{
+public:
+  ApiUserMarkContainer(double layerDepth, Framework & framework);
+
+  virtual Type GetType() const { return API_MARK; }
+
+  virtual string GetActiveTypeName() const;
+protected:
+  virtual string GetTypeName() const;
+  virtual UserMark * AllocateUserMark(m2::PointD const & ptOrg);
+};
+

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -3,7 +3,7 @@
 #include "map/user_mark.hpp"
 #include "map/styled_point.hpp"
 
-class ApiMarkPoint : public StyledPoint
+class ApiMarkPoint : public style::StyledPoint
 {
 public:
   ApiMarkPoint(m2::PointD const & ptOrg, UserMarkContainer * container)

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -28,7 +28,8 @@ public:
 
   unique_ptr<UserMarkCopy> Copy() const override
   {
-    return make_unique<UserMarkCopy>(new ApiMarkPoint(m_name, m_id, GetStyle(), m_ptOrg, m_container));
+    return make_unique<UserMarkCopy>(
+        new ApiMarkPoint(m_name, m_id, GetStyle(), m_ptOrg, m_container));
   }
 
   void FillLogEvent(TEventContainer & details) const override

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "map/user_mark.hpp"
+
+class ApiMarkPoint : public UserMark
+{
+public:
+  ApiMarkPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
+    : UserMark(ptOrg, container)
+  {
+  }
+
+  ApiMarkPoint(string const & name,
+           string const & id,
+           m2::PointD const & ptOrg,
+           UserMarkContainer * container)
+    : UserMark(ptOrg, container)
+    , m_name(name)
+    , m_id(id)
+  {
+  }
+
+  UserMark::Type GetMarkType() const override { return UserMark::Type::API; }
+
+  string const & GetName() const { return m_name; }
+  void SetName(string const & name) { m_name = name; }
+
+  string const & GetID() const   { return m_id; }
+  void SetID(string const & id)  { m_id = id; }
+
+  unique_ptr<UserMarkCopy> Copy() const override
+  {
+    return unique_ptr<UserMarkCopy>(
+        new UserMarkCopy(new ApiMarkPoint(m_name, m_id, m_ptOrg, m_container)));
+  }
+
+  virtual void FillLogEvent(TEventContainer & details) const override
+  {
+    UserMark::FillLogEvent(details);
+    details["markType"] = "API";
+    details["name"] = GetName();
+  }
+
+private:
+  string m_name;
+  string m_id;
+};
+

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
 #include "map/user_mark.hpp"
+#include "map/styled_point.hpp"
 
-class ApiMarkPoint : public UserMark
+class ApiMarkPoint : public StyledPoint
 {
 public:
   ApiMarkPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : UserMark(ptOrg, container)
+    : StyledPoint(ptOrg, container)
   {
   }
 
   ApiMarkPoint(string const & name,
            string const & id,
+           string const & style,
            m2::PointD const & ptOrg,
            UserMarkContainer * container)
-    : UserMark(ptOrg, container)
+    : StyledPoint(style, ptOrg, container)
     , m_name(name)
     , m_id(id)
   {
@@ -31,7 +33,7 @@ public:
   unique_ptr<UserMarkCopy> Copy() const override
   {
     return unique_ptr<UserMarkCopy>(
-        new UserMarkCopy(new ApiMarkPoint(m_name, m_id, m_ptOrg, m_container)));
+        new UserMarkCopy(new ApiMarkPoint(m_name, m_id, GetStyle(), m_ptOrg, m_container)));
   }
 
   virtual void FillLogEvent(TEventContainer & details) const override

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -13,7 +13,7 @@ public:
 
   ApiMarkPoint(string const & name, string const & id, string const & style,
                m2::PointD const & ptOrg, UserMarkContainer * container)
-    : StyledPoint(style, ptOrg, container), m_name(name), m_id(id)
+    : StyledPoint(ptOrg, container), m_name(name), m_id(id), m_style(style)
   {
   }
 
@@ -22,6 +22,11 @@ public:
 
   string const & GetID() const { return m_id; }
   void SetID(string const & id) { m_id = id; }
+
+  void SetStyle(string const & style) { m_style = style; }
+
+  // StyledPoint overrides:
+  string const & GetStyle() const override { return m_style; }
 
   // UserMark overrides:
   UserMark::Type GetMarkType() const override { return UserMark::Type::API; }
@@ -42,4 +47,5 @@ public:
 private:
   string m_name;
   string m_id;
+  string m_style;
 };

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -11,14 +11,9 @@ public:
   {
   }
 
-  ApiMarkPoint(string const & name,
-           string const & id,
-           string const & style,
-           m2::PointD const & ptOrg,
-           UserMarkContainer * container)
-    : StyledPoint(style, ptOrg, container)
-    , m_name(name)
-    , m_id(id)
+  ApiMarkPoint(string const & name, string const & id, string const & style,
+               m2::PointD const & ptOrg, UserMarkContainer * container)
+    : StyledPoint(style, ptOrg, container), m_name(name), m_id(id)
   {
   }
 
@@ -27,8 +22,8 @@ public:
   string const & GetName() const { return m_name; }
   void SetName(string const & name) { m_name = name; }
 
-  string const & GetID() const   { return m_id; }
-  void SetID(string const & id)  { m_id = id; }
+  string const & GetID() const { return m_id; }
+  void SetID(string const & id) { m_id = id; }
 
   unique_ptr<UserMarkCopy> Copy() const override
   {
@@ -47,4 +42,3 @@ private:
   string m_name;
   string m_id;
 };
-

--- a/map/api_mark_point.hpp
+++ b/map/api_mark_point.hpp
@@ -17,21 +17,21 @@ public:
   {
   }
 
-  UserMark::Type GetMarkType() const override { return UserMark::Type::API; }
-
   string const & GetName() const { return m_name; }
   void SetName(string const & name) { m_name = name; }
 
   string const & GetID() const { return m_id; }
   void SetID(string const & id) { m_id = id; }
 
+  // UserMark overrides:
+  UserMark::Type GetMarkType() const override { return UserMark::Type::API; }
+
   unique_ptr<UserMarkCopy> Copy() const override
   {
-    return unique_ptr<UserMarkCopy>(
-        new UserMarkCopy(new ApiMarkPoint(m_name, m_id, GetStyle(), m_ptOrg, m_container)));
+    return make_unique<UserMarkCopy>(new ApiMarkPoint(m_name, m_id, GetStyle(), m_ptOrg, m_container));
   }
 
-  virtual void FillLogEvent(TEventContainer & details) const override
+  void FillLogEvent(TEventContainer & details) const override
   {
     UserMark::FillLogEvent(details);
     details["markType"] = "API";

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -31,22 +31,6 @@ unique_ptr<UserMarkCopy> Bookmark::Copy() const
   return unique_ptr<UserMarkCopy>(new UserMarkCopy(this, false));
 }
 
-graphics::DisplayList * Bookmark::GetDisplayList(UserMarkDLCache * cache) const
-{
-  return cache->FindUserMark(UserMarkDLCache::Key(GetType(), graphics::EPosAbove, GetContainer()->GetDepth()));
-}
-
-double Bookmark::GetAnimScaleFactor() const
-{
-  return m_animScaleFactor;
-}
-
-m2::PointD const & Bookmark::GetPixelOffset() const
-{
-  static m2::PointD s_offset(0.0, 3.0);
-  return s_offset;
-}
-
 shared_ptr<anim::Task> Bookmark::CreateAnimTask(Framework & fm)
 {
   m_animScaleFactor = 0.0;
@@ -211,12 +195,6 @@ namespace
     LINE
   };
 
-  static char const * s_arrSupportedColors[] =
-  {
-    "placemark-red", "placemark-blue", "placemark-purple", "placemark-yellow",
-    "placemark-pink", "placemark-brown", "placemark-green", "placemark-orange"
-  };
-
   class KMLParser
   {
     // Fixes icons which are not supported by MapsWithMe
@@ -224,13 +202,7 @@ namespace
     {
       // Remove leading '#' symbol
       string const result = s.substr(1);
-      for (size_t i = 0; i < ARRAY_SIZE(s_arrSupportedColors); ++i)
-        if (result == s_arrSupportedColors[i])
-          return result;
-
-      // Not recognized symbols are replaced with default one
-      LOG(LWARNING, ("Icon", result, "for bookmark", m_name, "is not supported"));
-      return s_arrSupportedColors[0];
+      return style::GetSupportedStyle(result, m_name);
     }
 
     BookmarkCategory & m_category;
@@ -565,7 +537,7 @@ namespace
 
 string BookmarkCategory::GetDefaultType()
 {
-  return s_arrSupportedColors[0];
+  return style::GetDefaultStyle();
 }
 
 namespace

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -202,7 +202,7 @@ namespace
     {
       // Remove leading '#' symbol
       string const result = s.substr(1);
-      return style::GetSupportedStyle(result, m_name);
+      return style::GetSupportedStyle(result, m_name, style::GetDefaultStyle());
     }
 
     BookmarkCategory & m_category;

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -166,15 +166,14 @@ size_t BookmarkCategory::FindBookmark(Bookmark const * bookmark) const
 
 namespace
 {
+string const kPlacemark = "Placemark";
+string const kStyle = "Style";
+string const kDocument = "Document";
+string const kStyleMap = "StyleMap";
+string const kStyleUrl = "styleUrl";
+string const kPair = "Pair";
 
-  string const kPlacemark = "Placemark";
-  string const kStyle = "Style";
-  string const kDocument =  "Document";
-  string const kStyleMap = "StyleMap";
-  string const kStyleUrl = "styleUrl";
-  string const kPair = "Pair";
-
-  graphics::Color const kDefaultTrackColor = graphics::Color::fromARGB(0xFF33CCFF);
+graphics::Color const kDefaultTrackColor = graphics::Color::fromARGB(0xFF33CCFF);
 
   string PointToString(m2::PointD const & org)
   {
@@ -293,7 +292,7 @@ namespace
     }
 
     bool MakeValid()
-    { 
+    {
       if (GEOMETRY_TYPE_POINT == m_geometryType)
       {
         if (MercatorBounds::ValidX(m_org.x) && MercatorBounds::ValidY(m_org.y))
@@ -457,7 +456,8 @@ namespace
         {
           ParseColor(value);
         }
-        else if (ppTag == kStyleMap && prevTag == kPair && currTag == kStyleUrl && m_styleUrlKey == "normal")
+        else if (ppTag == kStyleMap && prevTag == kPair && currTag == kStyleUrl &&
+                 m_styleUrlKey == "normal")
         {
           if (!m_mapStyleId.empty())
             m_mapStyle2Style[m_mapStyleId] = value;

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -2,6 +2,7 @@
 
 #include "map/user_mark.hpp"
 #include "map/user_mark_container.hpp"
+#include "map/styled_point.hpp"
 
 #include "coding/reader.hpp"
 
@@ -65,14 +66,14 @@ private:
   time_t m_timeStamp;
 };
 
-class Bookmark : public ICustomDrawable
+class Bookmark : public StyledPoint
 {
   BookmarkData m_data;
   double m_animScaleFactor;
 
 public:
   Bookmark(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container)
+    : StyledPoint(ptOrg, container)
     , m_animScaleFactor(1.0)
   {
   }
@@ -80,13 +81,13 @@ public:
   Bookmark(BookmarkData const & data,
            m2::PointD const & ptOrg,
            UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container)
+    : StyledPoint(data.GetType(), ptOrg, container)
     , m_data(data)
     , m_animScaleFactor(1.0)
   {
   }
 
-  void SetData(BookmarkData const & data) { m_data = data; }
+  void SetData(BookmarkData const & data) { m_data = data; SetStyle(m_data.GetType()); }
   BookmarkData const & GetData() const { return m_data; }
 
   virtual Type GetMarkType() const override { return UserMark::Type::BOOKMARK; }
@@ -96,7 +97,7 @@ public:
   void SetName(string const & name) { m_data.SetName(name); }
   /// @return Now its a bookmark color - name of icon file
   string const & GetType() const { return m_data.GetType(); }
-  void SetType(string const & type) { m_data.SetType(type); }
+  void SetType(string const & type) { m_data.SetType(type); SetStyle(type); }
   m2::RectD GetViewport() const { return m2::RectD(GetOrg(), GetOrg()); }
 
   string const & GetDescription() const { return m_data.GetDescription(); }

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -87,7 +87,12 @@ public:
   {
   }
 
-  void SetData(BookmarkData const & data) { m_data = data; SetStyle(m_data.GetType()); }
+  void SetData(BookmarkData const & data)
+  {
+    m_data = data;
+    SetStyle(m_data.GetType());
+  }
+
   BookmarkData const & GetData() const { return m_data; }
 
   virtual Type GetMarkType() const override { return UserMark::Type::BOOKMARK; }
@@ -97,7 +102,13 @@ public:
   void SetName(string const & name) { m_data.SetName(name); }
   /// @return Now its a bookmark color - name of icon file
   string const & GetType() const { return m_data.GetType(); }
-  void SetType(string const & type) { m_data.SetType(type); SetStyle(type); }
+
+  void SetType(string const & type)
+  {
+    m_data.SetType(type);
+    SetStyle(type);
+  }
+
   m2::RectD GetViewport() const { return m2::RectD(GetOrg(), GetOrg()); }
 
   string const & GetDescription() const { return m_data.GetDescription(); }

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -203,8 +203,8 @@ private:
   
 private:
   bool m_blockAnimation;
-  typedef pair<UserMark *, shared_ptr<anim::Task> > anim_node_t;
-  vector<anim_node_t> m_anims;
+  using TAnimNode = pair<UserMark *, shared_ptr<anim::Task> >;
+  vector<TAnimNode> m_anims;
 };
 
 /// <category index, bookmark index>

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -78,15 +78,11 @@ public:
   }
 
   Bookmark(BookmarkData const & data, m2::PointD const & ptOrg, UserMarkContainer * container)
-    : StyledPoint(data.GetType(), ptOrg, container), m_data(data), m_animScaleFactor(1.0)
+    : StyledPoint(ptOrg, container), m_data(data), m_animScaleFactor(1.0)
   {
   }
 
-  void SetData(BookmarkData const & data)
-  {
-    m_data = data;
-    SetStyle(m_data.GetType());
-  }
+  void SetData(BookmarkData const & data) { m_data = data; }
 
   BookmarkData const & GetData() const { return m_data; }
 
@@ -98,11 +94,7 @@ public:
   /// @return Now its a bookmark color - name of icon file
   string const & GetType() const { return m_data.GetType(); }
 
-  void SetType(string const & type)
-  {
-    m_data.SetType(type);
-    SetStyle(type);
-  }
+  void SetType(string const & type) { m_data.SetType(type); }
 
   m2::RectD GetViewport() const { return m2::RectD(GetOrg(), GetOrg()); }
 
@@ -119,6 +111,9 @@ public:
   unique_ptr<UserMarkCopy> Copy() const override;
 
   shared_ptr<anim::Task> CreateAnimTask(Framework & fm);
+
+  // StyledPoint overrides:
+  string const & GetStyle() const override { return m_data.GetType(); }
 };
 
 class BookmarkCategory : public UserMarkContainer

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -112,9 +112,6 @@ public:
 
   unique_ptr<UserMarkCopy> Copy() const override;
 
-  virtual graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const override;
-  virtual double GetAnimScaleFactor() const override;
-  virtual m2::PointD const & GetPixelOffset() const override;
   shared_ptr<anim::Task> CreateAnimTask(Framework & fm);
 };
 

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -66,7 +66,7 @@ private:
   time_t m_timeStamp;
 };
 
-class Bookmark : public StyledPoint
+class Bookmark : public style::StyledPoint
 {
   BookmarkData m_data;
   double m_animScaleFactor;

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -73,17 +73,12 @@ class Bookmark : public StyledPoint
 
 public:
   Bookmark(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : StyledPoint(ptOrg, container)
-    , m_animScaleFactor(1.0)
+    : StyledPoint(ptOrg, container), m_animScaleFactor(1.0)
   {
   }
 
-  Bookmark(BookmarkData const & data,
-           m2::PointD const & ptOrg,
-           UserMarkContainer * container)
-    : StyledPoint(data.GetType(), ptOrg, container)
-    , m_data(data)
-    , m_animScaleFactor(1.0)
+  Bookmark(BookmarkData const & data, m2::PointD const & ptOrg, UserMarkContainer * container)
+    : StyledPoint(data.GetType(), ptOrg, container), m_data(data), m_animScaleFactor(1.0)
   {
   }
 

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -203,7 +203,7 @@ private:
   
 private:
   bool m_blockAnimation;
-  using TAnimNode = pair<UserMark *, shared_ptr<anim::Task> >;
+  using TAnimNode = pair<UserMark *, shared_ptr<anim::Task>>;
   vector<TAnimNode> m_anims;
 };
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -8,6 +8,8 @@
 
 #include "map/bookmark.hpp"
 #include "map/bookmark_manager.hpp"
+#include "map/api_mark_point.hpp"
+#include "map/api_mark_container.hpp"
 #include "map/pin_click_manager.hpp"
 
 #include "map/mwm_url.hpp"

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -6,10 +6,10 @@
 #include "map/navigator.hpp"
 #include "map/animator.hpp"
 
+#include "map/api_mark_container.hpp"
+#include "map/api_mark_point.hpp"
 #include "map/bookmark.hpp"
 #include "map/bookmark_manager.hpp"
-#include "map/api_mark_point.hpp"
-#include "map/api_mark_container.hpp"
 #include "map/pin_click_manager.hpp"
 
 #include "map/mwm_url.hpp"

--- a/map/map.pro
+++ b/map/map.pro
@@ -20,6 +20,7 @@ HEADERS += \
     benchmark_engine.hpp \
     ruler.hpp \
     bookmark.hpp \
+    styled_point.hpp \
     geourl_process.hpp \
     country_status_display.hpp \
     rotate_screen_task.hpp \
@@ -53,6 +54,7 @@ SOURCES += \
     address_finder.cpp \
     geourl_process.cpp \
     bookmark.cpp \
+    styled_point.cpp \
     country_status_display.cpp \
     rotate_screen_task.cpp \
     compass_arrow.cpp \

--- a/map/map.pro
+++ b/map/map.pro
@@ -36,6 +36,8 @@ HEADERS += \
     user_mark_container.hpp \
     user_mark.hpp \
     user_mark_dl_cache.hpp \
+    api_mark_container.hpp \
+    api_mark_point.hpp \
     anim_phase_chain.hpp \
     pin_click_manager.hpp \
     country_tree.hpp \
@@ -69,6 +71,7 @@ SOURCES += \
     alfa_animation_task.cpp \
     user_mark_container.cpp \
     user_mark_dl_cache.cpp \
+    api_mark_container.cpp \
     anim_phase_chain.cpp \
     pin_click_manager.cpp \
     country_tree.cpp \

--- a/map/map.pro
+++ b/map/map.pro
@@ -11,72 +11,72 @@ INCLUDEPATH *= $$ROOT_DIR/3party/protobuf/src $$ROOT_DIR/3party/expat/lib $$ROOT
 include($$ROOT_DIR/common.pri)
 
 HEADERS += \
-    framework.hpp \
-    feature_vec_model.hpp \
-    navigator.hpp \
-    information_display.hpp \
-    location_state.hpp \
-    benchmark_provider.hpp \
-    benchmark_engine.hpp \
-    ruler.hpp \
-    bookmark.hpp \
-    styled_point.hpp \
-    geourl_process.hpp \
-    country_status_display.hpp \
-    rotate_screen_task.hpp \
-    compass_arrow.hpp \
-    animator.hpp \
-    move_screen_task.hpp \
-    change_viewport_task.hpp \
-    mwm_url.hpp \
-    bookmark_manager.hpp \
-    ge0_parser.hpp \
-    track.hpp \
+    active_maps_layout.hpp \
     alfa_animation_task.hpp \
-    user_mark_container.hpp \
-    user_mark.hpp \
-    user_mark_dl_cache.hpp \
+    anim_phase_chain.hpp \
+    animator.hpp \
     api_mark_container.hpp \
     api_mark_point.hpp \
-    anim_phase_chain.hpp \
-    pin_click_manager.hpp \
+    benchmark_engine.hpp \
+    benchmark_provider.hpp \
+    bookmark.hpp \
+    bookmark_manager.hpp \
+    change_viewport_task.hpp \
+    compass_arrow.hpp \
+    country_status_display.hpp \
     country_tree.hpp \
-    active_maps_layout.hpp \
+    feature_vec_model.hpp \
+    framework.hpp \
+    ge0_parser.hpp \
+    geourl_process.hpp \
+    information_display.hpp \
+    location_state.hpp \
+    move_screen_task.hpp \
+    mwm_url.hpp \
+    navigator.hpp \
     navigator_utils.hpp \
+    pin_click_manager.hpp \
+    rotate_screen_task.hpp \
+    ruler.hpp \
+    styled_point.hpp \
+    track.hpp \
+    user_mark.hpp \
+    user_mark_container.hpp \
+    user_mark_dl_cache.hpp \
 
 SOURCES += \
+    ../api/src/c/api-client.c \
+    active_maps_layout.cpp \
+    address_finder.cpp \
+    alfa_animation_task.cpp \
+    anim_phase_chain.cpp \
+    animator.cpp \
+    api_mark_container.cpp \
+    benchmark_engine.cpp \
+    benchmark_provider.cpp \
+    bookmark.cpp \
+    bookmark_manager.cpp \
+    change_viewport_task.cpp \
+    compass_arrow.cpp \
+    country_status_display.cpp \
+    country_tree.cpp \
     feature_vec_model.cpp \
     framework.cpp \
-    navigator.cpp \
+    ge0_parser.cpp \
+    geourl_process.cpp \
     information_display.cpp \
     location_state.cpp \
-    benchmark_provider.cpp \
-    benchmark_engine.cpp \
-    ruler.cpp \
-    address_finder.cpp \
-    geourl_process.cpp \
-    bookmark.cpp \
-    styled_point.cpp \
-    country_status_display.cpp \
-    rotate_screen_task.cpp \
-    compass_arrow.cpp \
-    animator.cpp \
     move_screen_task.cpp \
-    change_viewport_task.cpp \
     mwm_url.cpp \
-    bookmark_manager.cpp \
-    ge0_parser.cpp \
-    ../api/src/c/api-client.c \
+    navigator.cpp \
+    navigator_utils.cpp \
+    pin_click_manager.cpp \
+    rotate_screen_task.cpp \
+    ruler.cpp \
+    styled_point.cpp \
     track.cpp \
-    alfa_animation_task.cpp \
     user_mark_container.cpp \
     user_mark_dl_cache.cpp \
-    api_mark_container.cpp \
-    anim_phase_chain.cpp \
-    pin_click_manager.cpp \
-    country_tree.cpp \
-    active_maps_layout.cpp \
-    navigator_utils.cpp \
 
 !iphone*:!tizen*:!android* {
   HEADERS += qgl_render_context.hpp

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -70,7 +70,7 @@ bool ParsedMapApi::Parse(Uri const & uri)
     ApiMarkPoint * mark = static_cast<ApiMarkPoint *>(m_controller->CreateUserMark(glPoint));
     mark->SetName(p.m_name);
     mark->SetID(p.m_id);
-    mark->SetStyle(style::GetSupportedStyle(p.m_style, p.m_name));
+    mark->SetStyle(style::GetSupportedStyle(p.m_style, p.m_name, ""));
   }
 
   return true;

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -70,6 +70,7 @@ bool ParsedMapApi::Parse(Uri const & uri)
     ApiMarkPoint * mark = static_cast<ApiMarkPoint *>(m_controller->CreateUserMark(glPoint));
     mark->SetName(p.m_name);
     mark->SetID(p.m_id);
+    mark->SetStyle(style::GetSupportedStyle(p.m_style, p.m_name));
   }
 
   return true;
@@ -133,6 +134,13 @@ void ParsedMapApi::AddKeyValue(string key, string const & value, vector<ApiPoint
       points.back().m_id = value;
     else
       LOG(LWARNING, ("Map API: Point url with no point. 'll' should come first!"));
+  }
+  else if (key == "s")
+  {
+    if (!points.empty())
+      points.back().m_style = value;
+    else
+      LOG(LWARNING, ("Map API: Point style with no point. 'll' should come first!"));
   }
   else if (key == "backurl")
   {

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -17,6 +17,7 @@ struct ApiPoint
   double m_lon;
   string m_name;
   string m_id;
+  string m_style;
 };
 
 class Uri;

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "user_mark_container.hpp"
+#include "api_mark_container.hpp"
 
 #include "geometry/rect2d.hpp"
 

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -7,6 +7,8 @@ char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",  "place
                                    "placemark-green",  "placemark-orange"};
 }
 
+namespace style
+{
 graphics::DisplayList * StyledPoint::GetDisplayList(UserMarkDLCache * cache) const
 {
   UserMarkContainer const * container = GetContainer();
@@ -33,8 +35,6 @@ m2::PointD const & StyledPoint::GetPixelOffset() const
   return GetStyle().empty() ? s_centre : s_offset;
 }
 
-namespace style
-{
 string GetSupportedStyle(string const & s, string const & context, string const & fallback)
 {
   if (s.empty())

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -3,10 +3,11 @@
 
 graphics::DisplayList * StyledPoint::GetDisplayList(UserMarkDLCache * cache) const
 {
-  UserMarkDLCache::Key key = GetStyle().empty() ? GetContainer()->GetDefaultKey()
-                                                : UserMarkDLCache::Key(GetStyle(),
-                                                                       graphics::EPosAbove,
-                                                                       GetContainer()->GetDepth());
+  UserMarkContainer const * container = GetContainer();
+  UserMarkDLCache::Key const key = GetStyle().empty() ? container->GetDefaultKey()
+                                                      : UserMarkDLCache::Key(GetStyle(),
+                                                                             graphics::EPosAbove,
+                                                                             container->GetDepth());
   return cache->FindUserMark(key);
 }
 

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -7,3 +7,48 @@
 #include "std/algorithm.hpp"
 #include "std/auto_ptr.hpp"
 
+
+graphics::DisplayList * StyledPoint::GetDisplayList(UserMarkDLCache * cache) const
+{
+  return cache->FindUserMark(UserMarkDLCache::Key(GetStyle(), graphics::EPosAbove, GetContainer()->GetDepth()));
+}
+
+double StyledPoint::GetAnimScaleFactor() const
+{
+  return 1.0;
+}
+
+m2::PointD const & StyledPoint::GetPixelOffset() const
+{
+  static m2::PointD s_offset(0.0, 3.0);
+  return s_offset;
+}
+
+static char const * s_arrSupportedColors[] =
+{
+  "placemark-red", "placemark-blue", "placemark-purple", "placemark-yellow",
+  "placemark-pink", "placemark-brown", "placemark-green", "placemark-orange"
+};
+
+namespace style
+{
+  string GetSupportedStyle(string const & s, string const & context)
+  {
+    if (s.empty())
+      return s_arrSupportedColors[0];
+
+    for (size_t i = 0; i < ARRAY_SIZE(s_arrSupportedColors); ++i)
+      if (s == s_arrSupportedColors[i])
+        return s;
+
+    // Not recognized symbols are replaced with default one
+    LOG(LWARNING, ("Icon", s, "for point", context, "is not supported"));
+    return s_arrSupportedColors[0];
+  }
+
+  string GetDefaultStyle()
+  {
+    return s_arrSupportedColors[0];
+  }
+
+} // namespace style

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -26,9 +26,12 @@ m2::PointD const & StyledPoint::GetPixelOffset() const
   return GetStyle().empty() ? s_centre : s_offset;
 }
 
-static char const * s_arrSupportedColors[] = {
+namespace
+{
+  char const * kSupportedColors[] = {
     "placemark-red",  "placemark-blue",  "placemark-purple", "placemark-yellow",
     "placemark-pink", "placemark-brown", "placemark-green",  "placemark-orange"};
+}
 
 namespace style
 {
@@ -37,15 +40,17 @@ string GetSupportedStyle(string const & s, string const & context, string const 
   if (s.empty())
     return fallback;
 
-  for (size_t i = 0; i < ARRAY_SIZE(s_arrSupportedColors); ++i)
-    if (s == s_arrSupportedColors[i])
+  for (size_t i = 0; i < ARRAY_SIZE(kSupportedColors); ++i)
+  {
+    if (s == kSupportedColors[i])
       return s;
+  }
 
   // Not recognized symbols are replaced with default one
   LOG(LWARNING, ("Icon", s, "for point", context, "is not supported"));
   return fallback;
 }
 
-string GetDefaultStyle() { return s_arrSupportedColors[0]; }
+string GetDefaultStyle() { return kSupportedColors[0]; }
 
 }  // namespace style

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -1,5 +1,12 @@
 #include "map/styled_point.hpp"
 
+namespace
+{
+char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",  "placemark-purple",
+                                   "placemark-yellow", "placemark-pink",  "placemark-brown",
+                                   "placemark-green",  "placemark-orange"};
+}
+
 graphics::DisplayList * StyledPoint::GetDisplayList(UserMarkDLCache * cache) const
 {
   UserMarkContainer const * container = GetContainer();
@@ -26,13 +33,6 @@ m2::PointD const & StyledPoint::GetPixelOffset() const
   return GetStyle().empty() ? s_centre : s_offset;
 }
 
-namespace
-{
-char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",  "placemark-purple",
-                                   "placemark-yellow", "placemark-pink",  "placemark-brown",
-                                   "placemark-green",  "placemark-orange"};
-}
-
 namespace style
 {
 string GetSupportedStyle(string const & s, string const & context, string const & fallback)
@@ -52,5 +52,4 @@ string GetSupportedStyle(string const & s, string const & context, string const 
 }
 
 string GetDefaultStyle() { return kSupportedColors[0]; }
-
 }  // namespace style

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -1,0 +1,9 @@
+#include "map/styled_point.hpp"
+
+#include "base/stl_add.hpp"
+#include "base/string_utils.hpp"
+
+#include "std/fstream.hpp"
+#include "std/algorithm.hpp"
+#include "std/auto_ptr.hpp"
+

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -1,13 +1,12 @@
 #include "map/styled_point.hpp"
 
-
 graphics::DisplayList * StyledPoint::GetDisplayList(UserMarkDLCache * cache) const
 {
   UserMarkContainer const * container = GetContainer();
-  UserMarkDLCache::Key const key = GetStyle().empty() ? container->GetDefaultKey()
-                                                      : UserMarkDLCache::Key(GetStyle(),
-                                                                             graphics::EPosAbove,
-                                                                             container->GetDepth());
+  UserMarkDLCache::Key const key =
+      GetStyle().empty()
+          ? container->GetDefaultKey()
+          : UserMarkDLCache::Key(GetStyle(), graphics::EPosAbove, container->GetDepth());
   return cache->FindUserMark(key);
 }
 
@@ -27,31 +26,26 @@ m2::PointD const & StyledPoint::GetPixelOffset() const
   return GetStyle().empty() ? s_centre : s_offset;
 }
 
-static char const * s_arrSupportedColors[] =
-{
-  "placemark-red", "placemark-blue", "placemark-purple", "placemark-yellow",
-  "placemark-pink", "placemark-brown", "placemark-green", "placemark-orange"
-};
+static char const * s_arrSupportedColors[] = {
+    "placemark-red",  "placemark-blue",  "placemark-purple", "placemark-yellow",
+    "placemark-pink", "placemark-brown", "placemark-green",  "placemark-orange"};
 
 namespace style
 {
-  string GetSupportedStyle(string const & s, string const & context, string const & fallback)
-  {
-    if (s.empty())
-      return fallback;
-
-    for (size_t i = 0; i < ARRAY_SIZE(s_arrSupportedColors); ++i)
-      if (s == s_arrSupportedColors[i])
-        return s;
-
-    // Not recognized symbols are replaced with default one
-    LOG(LWARNING, ("Icon", s, "for point", context, "is not supported"));
+string GetSupportedStyle(string const & s, string const & context, string const & fallback)
+{
+  if (s.empty())
     return fallback;
-  }
 
-  string GetDefaultStyle()
-  {
-    return s_arrSupportedColors[0];
-  }
+  for (size_t i = 0; i < ARRAY_SIZE(s_arrSupportedColors); ++i)
+    if (s == s_arrSupportedColors[i])
+      return s;
 
-} // namespace style
+  // Not recognized symbols are replaced with default one
+  LOG(LWARNING, ("Icon", s, "for point", context, "is not supported"));
+  return fallback;
+}
+
+string GetDefaultStyle() { return s_arrSupportedColors[0]; }
+
+}  // namespace style

--- a/map/styled_point.cpp
+++ b/map/styled_point.cpp
@@ -28,9 +28,9 @@ m2::PointD const & StyledPoint::GetPixelOffset() const
 
 namespace
 {
-  char const * kSupportedColors[] = {
-    "placemark-red",  "placemark-blue",  "placemark-purple", "placemark-yellow",
-    "placemark-pink", "placemark-brown", "placemark-green",  "placemark-orange"};
+char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",  "placemark-purple",
+                                   "placemark-yellow", "placemark-pink",  "placemark-brown",
+                                   "placemark-green",  "placemark-orange"};
 }
 
 namespace style

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -13,28 +13,24 @@
 #include "std/unique_ptr.hpp"
 #include "std/utility.hpp"
 
-
 namespace style
 {
-  // Fixes icons which are not supported by MapsWithMe.
-  string GetSupportedStyle(string const & s, string const & context, string const & fallback);
-  // Default icon.
-  string GetDefaultStyle();
+// Fixes icons which are not supported by MapsWithMe.
+string GetSupportedStyle(string const & s, string const & context, string const & fallback);
+// Default icon.
+string GetDefaultStyle();
 }  // namespace style
-
 
 class StyledPoint : public ICustomDrawable
 {
 public:
   StyledPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container)
-    , m_style(style::GetDefaultStyle())
+    : ICustomDrawable(ptOrg, container), m_style(style::GetDefaultStyle())
   {
   }
 
   StyledPoint(string const & style, m2::PointD const & ptOrg, UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container)
-    , m_style(style)
+    : ICustomDrawable(ptOrg, container), m_style(style)
   {
   }
 
@@ -48,4 +44,3 @@ public:
 private:
   string m_style;  ///< Point style (name of icon), or empty string for plain circle.
 };
-

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -34,9 +34,10 @@ public:
   {
   }
 
-  virtual graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const override;
-  virtual double GetAnimScaleFactor() const override;
-  virtual m2::PointD const & GetPixelOffset() const override;
+  // ICustomDrawable overrides:
+  graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const override;
+  double GetAnimScaleFactor() const override;
+  m2::PointD const & GetPixelOffset() const override;
 
   string const & GetStyle() const { return m_style; }
   void SetStyle(const string & style) { m_style = style; }

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -14,11 +14,20 @@
 #include "std/utility.hpp"
 
 
+namespace style
+{
+  // Fixes icons which are not supported by MapsWithMe
+  string GetSupportedStyle(string const & s, string const & context);
+  string GetDefaultStyle();
+}  // namespace style
+
+
 class StyledPoint : public ICustomDrawable
 {
 public:
   StyledPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
     : ICustomDrawable(ptOrg, container)
+    , m_style(style::GetDefaultStyle())
   {
   }
 
@@ -28,9 +37,9 @@ public:
   {
   }
 
-  virtual graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const = 0;
-  virtual double GetAnimScaleFactor() const = 0;
-  virtual m2::PointD const & GetPixelOffset() const = 0;
+  virtual graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const override;
+  virtual double GetAnimScaleFactor() const override;
+  virtual m2::PointD const & GetPixelOffset() const override;
 
   string const & GetStyle() const { return m_style; }
   void SetStyle(const string & style) { m_style = style; }
@@ -38,3 +47,4 @@ public:
 private:
   string m_style;  ///< Point style (name of icon).
 };
+

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -19,7 +19,6 @@ namespace style
 string GetSupportedStyle(string const & s, string const & context, string const & fallback);
 // Default icon.
 string GetDefaultStyle();
-}  // namespace style
 
 class StyledPoint : public ICustomDrawable
 {
@@ -37,3 +36,4 @@ public:
   /// @return name of icon, or empty string for plain circle.
   virtual string const & GetStyle() const = 0;
 };
+}  // namespace style

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -25,12 +25,7 @@ class StyledPoint : public ICustomDrawable
 {
 public:
   StyledPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container), m_style(style::GetDefaultStyle())
-  {
-  }
-
-  StyledPoint(string const & style, m2::PointD const & ptOrg, UserMarkContainer * container)
-    : ICustomDrawable(ptOrg, container), m_style(style)
+    : ICustomDrawable(ptOrg, container)
   {
   }
 
@@ -39,9 +34,6 @@ public:
   double GetAnimScaleFactor() const override;
   m2::PointD const & GetPixelOffset() const override;
 
-  string const & GetStyle() const { return m_style; }
-  void SetStyle(const string & style) { m_style = style; }
-
-private:
-  string m_style;  ///< Point style (name of icon), or empty string for plain circle.
+  /// @return name of icon, or empty string for plain circle.
+  virtual string const & GetStyle() const = 0;
 };

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -16,8 +16,9 @@
 
 namespace style
 {
-  // Fixes icons which are not supported by MapsWithMe
-  string GetSupportedStyle(string const & s, string const & context);
+  // Fixes icons which are not supported by MapsWithMe.
+  string GetSupportedStyle(string const & s, string const & context, string const & fallback);
+  // Default icon.
   string GetDefaultStyle();
 }  // namespace style
 
@@ -45,6 +46,6 @@ public:
   void SetStyle(const string & style) { m_style = style; }
 
 private:
-  string m_style;  ///< Point style (name of icon).
+  string m_style;  ///< Point style (name of icon), or empty string for plain circle.
 };
 

--- a/map/styled_point.hpp
+++ b/map/styled_point.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "map/user_mark.hpp"
+#include "map/user_mark_container.hpp"
+
+#include "search/result.hpp"
+
+#include "indexer/feature.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "std/string.hpp"
+#include "std/unique_ptr.hpp"
+#include "std/utility.hpp"
+
+
+class StyledPoint : public ICustomDrawable
+{
+public:
+  StyledPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
+    : ICustomDrawable(ptOrg, container)
+  {
+  }
+
+  StyledPoint(string const & style, m2::PointD const & ptOrg, UserMarkContainer * container)
+    : ICustomDrawable(ptOrg, container)
+    , m_style(style)
+  {
+  }
+
+  virtual graphics::DisplayList * GetDisplayList(UserMarkDLCache * cache) const = 0;
+  virtual double GetAnimScaleFactor() const = 0;
+  virtual m2::PointD const & GetPixelOffset() const = 0;
+
+  string const & GetStyle() const { return m_style; }
+  void SetStyle(const string & style) { m_style = style; }
+
+private:
+  string m_style;  ///< Point style (name of icon).
+};

--- a/map/user_mark.hpp
+++ b/map/user_mark.hpp
@@ -92,50 +92,6 @@ private:
   bool m_needDestroy;
 };
 
-class ApiMarkPoint : public UserMark
-{
-public:
-  ApiMarkPoint(m2::PointD const & ptOrg, UserMarkContainer * container)
-    : UserMark(ptOrg, container)
-  {
-  }
-
-  ApiMarkPoint(string const & name,
-           string const & id,
-           m2::PointD const & ptOrg,
-           UserMarkContainer * container)
-    : UserMark(ptOrg, container)
-    , m_name(name)
-    , m_id(id)
-  {
-  }
-
-  UserMark::Type GetMarkType() const override { return UserMark::Type::API; }
-
-  string const & GetName() const { return m_name; }
-  void SetName(string const & name) { m_name = name; }
-
-  string const & GetID() const   { return m_id; }
-  void SetID(string const & id)  { m_id = id; }
-
-  unique_ptr<UserMarkCopy> Copy() const override
-  {
-    return unique_ptr<UserMarkCopy>(
-        new UserMarkCopy(new ApiMarkPoint(m_name, m_id, m_ptOrg, m_container)));
-  }
-
-  virtual void FillLogEvent(TEventContainer & details) const override
-  {
-    UserMark::FillLogEvent(details);
-    details["markType"] = "API";
-    details["name"] = GetName();
-  }
-
-private:
-  string m_name;
-  string m_id;
-};
-
 class DebugMarkPoint : public UserMark
 {
 public:

--- a/map/user_mark_container.cpp
+++ b/map/user_mark_container.cpp
@@ -267,27 +267,6 @@ UserMark * SearchUserMarkContainer::AllocateUserMark(const m2::PointD & ptOrg)
   return new SearchMarkPoint(ptOrg, this);
 }
 
-ApiUserMarkContainer::ApiUserMarkContainer(double layerDepth, Framework & framework)
-  : UserMarkContainer(layerDepth, framework)
-{
-}
-
-string ApiUserMarkContainer::GetTypeName() const
-{
-  return "api-result";
-}
-
-string ApiUserMarkContainer::GetActiveTypeName() const
-{
-  return "search-result-active";
-}
-
-UserMark * ApiUserMarkContainer::AllocateUserMark(const m2::PointD & ptOrg)
-{
-  return new ApiMarkPoint(ptOrg, this);
-}
-
-
 DebugUserMarkContainer::DebugUserMarkContainer(double layerDepth, Framework & framework)
   : UserMarkContainer(layerDepth, framework)
 {

--- a/map/user_mark_container.cpp
+++ b/map/user_mark_container.cpp
@@ -173,8 +173,8 @@ void UserMarkContainer::Clear(size_t skipCount/* = 0*/)
 
 namespace
 {
-  unique_ptr<PoiMarkPoint> g_selectionUserMark;
-  unique_ptr<MyPositionMarkPoint> g_myPosition;
+unique_ptr<PoiMarkPoint> g_selectionUserMark;
+unique_ptr<MyPositionMarkPoint> g_myPosition;
 }
 
 UserMarkDLCache::Key UserMarkContainer::GetDefaultKey() const

--- a/map/user_mark_container.cpp
+++ b/map/user_mark_container.cpp
@@ -177,6 +177,13 @@ namespace
   static unique_ptr<MyPositionMarkPoint> s_myPosition;
 }
 
+UserMarkDLCache::Key UserMarkContainer::GetDefaultKey() const
+{
+  return UserMarkDLCache::Key(GetTypeName(),
+                              graphics::EPosCenter,
+                              GetDepth());
+}
+
 void UserMarkContainer::InitStaticMarks(UserMarkContainer * container)
 {
   if (s_selectionUserMark == NULL)

--- a/map/user_mark_container.cpp
+++ b/map/user_mark_container.cpp
@@ -179,9 +179,7 @@ namespace
 
 UserMarkDLCache::Key UserMarkContainer::GetDefaultKey() const
 {
-  return UserMarkDLCache::Key(GetTypeName(),
-                              graphics::EPosCenter,
-                              GetDepth());
+  return UserMarkDLCache::Key(GetTypeName(), graphics::EPosCenter, GetDepth());
 }
 
 void UserMarkContainer::InitStaticMarks(UserMarkContainer * container)

--- a/map/user_mark_container.cpp
+++ b/map/user_mark_container.cpp
@@ -173,8 +173,8 @@ void UserMarkContainer::Clear(size_t skipCount/* = 0*/)
 
 namespace
 {
-  static unique_ptr<PoiMarkPoint> s_selectionUserMark;
-  static unique_ptr<MyPositionMarkPoint> s_myPosition;
+  unique_ptr<PoiMarkPoint> g_selectionUserMark;
+  unique_ptr<MyPositionMarkPoint> g_myPosition;
 }
 
 UserMarkDLCache::Key UserMarkContainer::GetDefaultKey() const
@@ -184,23 +184,23 @@ UserMarkDLCache::Key UserMarkContainer::GetDefaultKey() const
 
 void UserMarkContainer::InitStaticMarks(UserMarkContainer * container)
 {
-  if (s_selectionUserMark == NULL)
-    s_selectionUserMark.reset(new PoiMarkPoint(container));
+  if (g_selectionUserMark == NULL)
+    g_selectionUserMark.reset(new PoiMarkPoint(container));
 
-  if (s_myPosition == NULL)
-    s_myPosition.reset(new MyPositionMarkPoint(container));
+  if (g_myPosition == NULL)
+    g_myPosition.reset(new MyPositionMarkPoint(container));
 }
 
 PoiMarkPoint * UserMarkContainer::UserMarkForPoi()
 {
-  ASSERT(s_selectionUserMark != NULL, ());
-  return s_selectionUserMark.get();
+  ASSERT(g_selectionUserMark != NULL, ());
+  return g_selectionUserMark.get();
 }
 
 MyPositionMarkPoint * UserMarkContainer::UserMarkForMyPostion()
 {
-  ASSERT(s_myPosition != NULL, ());
-  return s_myPosition.get();
+  ASSERT(g_myPosition != NULL, ());
+  return g_myPosition.get();
 }
 
 UserMark * UserMarkContainer::CreateUserMark(m2::PointD const & ptOrg)

--- a/map/user_mark_container.hpp
+++ b/map/user_mark_container.hpp
@@ -133,19 +133,6 @@ protected:
   virtual UserMark * AllocateUserMark(m2::PointD const & ptOrg);
 };
 
-class ApiUserMarkContainer : public UserMarkContainer
-{
-public:
-  ApiUserMarkContainer(double layerDepth, Framework & framework);
-
-  virtual Type GetType() const { return API_MARK; }
-
-  virtual string GetActiveTypeName() const;
-protected:
-  virtual string GetTypeName() const;
-  virtual UserMark * AllocateUserMark(m2::PointD const & ptOrg);
-};
-
 class DebugUserMarkContainer : public UserMarkContainer
 {
 public:

--- a/map/user_mark_container.hpp
+++ b/map/user_mark_container.hpp
@@ -84,6 +84,8 @@ public:
 
   double GetDepth() const { return m_layerDepth; }
 
+  virtual UserMarkDLCache::Key GetDefaultKey() const;
+
   static void InitStaticMarks(UserMarkContainer * container);
   static PoiMarkPoint * UserMarkForPoi();
   static MyPositionMarkPoint * UserMarkForMyPostion();


### PR DESCRIPTION
As outlined in #238:
* Introduce StyledPoint class, and move style handling from Bookmark up to it.
* Make ApiMarkPoint a StyledPoint.
* Parse s= optional parameter in URL as the style.

Before and after shot below, for the same URL. The uppermost point is not styled (so defaults to red on the right). The original code (on left) ignores the style parameter and always shows a pink circle. After this PR (on right) the style parameter controls the appearance of the place marker.

![omim-add-style](https://cloud.githubusercontent.com/assets/587036/10652691/8e036662-7850-11e5-88a0-a5d0eb8d462d.png)

Existing tests all pass. Which tests should I be modifying to regression-test this fix?