### PR TITLE
iOS. Changing TTS volume all the time MAPS.ME is in foreground.

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Sound/MWMTextToSpeech.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Sound/MWMTextToSpeech.mm
@@ -20,6 +20,14 @@ extern NSString * const kMwmTextToSpeechDisable = @"MWMTEXTTOSPEECH_DISABLE";
   self = [super init];
   if (self)
   {
+    // Activating audio session.
+    NSError * err = nil;
+    AVAudioSession * audioSession = [AVAudioSession sharedInstance];
+    if (![audioSession setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&err])
+      LOG(LWARNING, ("[ setCategory]] error.", [err localizedDescription]));
+    if (![audioSession setActive:YES error:&err])
+      LOG(LWARNING, ("[[AVAudioSession sharedInstance] setActive]] error.", [err localizedDescription]));
+    
     // Before 9.0 version iOS has an issue with speechRate. AVSpeechUtteranceDefaultSpeechRate does not work correctly.
     // It's a work around for iOS 7.x and 8.x.
     self.speechRate = isIOSVersionLessThan(@"7.1.1") ? 0.3 : (isIOSVersionLessThan(@"9.0.0") ? 0.15 : AVSpeechUtteranceDefaultSpeechRate);


### PR DESCRIPTION
1. Changing TTS volume all the time MAPS.ME is in foreground.
https://trello.com/c/WrHgKK0M/1987-ios-maps-me-foreground

2. Recovering playing background music after TTS notification.
https://trello.com/c/WrHgKK0M/1987-ios-maps-me-foreground