### PR TITLE
[drape] Back buffer format changed to RGB8

### DIFF
--- a/android/jni/com/mapswithme/opengl/androidoglcontextfactory.cpp
+++ b/android/jni/com/mapswithme/opengl/androidoglcontextfactory.cpp
@@ -13,7 +13,22 @@
 namespace android
 {
 
-static EGLint * getConfigAttributesList()
+static EGLint * getConfigAttributesListRGB8()
+{
+  static EGLint attr_list[] = {
+    EGL_RED_SIZE, 8,
+    EGL_GREEN_SIZE, 8,
+    EGL_BLUE_SIZE, 8,
+    EGL_STENCIL_SIZE, 0,
+    EGL_DEPTH_SIZE, 16,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+    EGL_SURFACE_TYPE, EGL_PBUFFER_BIT | EGL_WINDOW_BIT,
+    EGL_NONE
+  };
+  return attr_list;
+}
+
+static EGLint * getConfigAttributesListR5G6B5()
 {
   static EGLint attr_list[] = {
     EGL_RED_SIZE, 5,
@@ -211,9 +226,18 @@ bool AndroidOGLContextFactory::isUploadContextCreated() const
 
 bool AndroidOGLContextFactory::createWindowSurface()
 {
-  EGLConfig configs[40];
+  int const kMaxConfigCount = 40;
+  EGLConfig configs[kMaxConfigCount];
   int count = 0;
-  VERIFY(eglChooseConfig(m_display, getConfigAttributesList(), configs, 40, &count) == EGL_TRUE, ());
+  if (eglChooseConfig(m_display, getConfigAttributesListRGB8(), configs, kMaxConfigCount, &count) != EGL_TRUE)
+  {
+    VERIFY(eglChooseConfig(m_display, getConfigAttributesListR5G6B5(), configs, kMaxConfigCount, &count) == EGL_TRUE, ());
+    LOG(LDEBUG, ("Backbuffer format: R5G6B5"));
+  }
+  else
+  {
+    LOG(LDEBUG, ("Backbuffer format: RGB8"));
+  }
   ASSERT(count > 0, ("Didn't find any configs."));
 
   sort(&configs[0], &configs[count], ConfigComparator(m_display));

--- a/drape/font_texture.hpp
+++ b/drape/font_texture.hpp
@@ -108,9 +108,6 @@ public:
   ref_ptr<Texture::ResourceInfo> MapResource(GlyphKey const & key, bool & newResource);
   void UploadResources(ref_ptr<Texture> texture);
 
-  glConst GetMinFilter() const { return gl_const::GLLinear; }
-  glConst GetMagFilter() const { return gl_const::GLLinear; }
-
   bool HasAsyncRoutines() const;
 
 private:

--- a/drape/stipple_pen_resource.cpp
+++ b/drape/stipple_pen_resource.cpp
@@ -194,16 +194,6 @@ void StipplePenIndex::UploadResources(ref_ptr<Texture> texture)
   mng.freeSharedBuffer(reserveBufferSize, ptr);
 }
 
-glConst StipplePenIndex::GetMinFilter() const
-{
-  return gl_const::GLNearest;
-}
-
-glConst StipplePenIndex::GetMagFilter() const
-{
-  return gl_const::GLNearest;
-}
-
 void StipplePenTexture::ReservePattern(buffer_vector<uint8_t, 8> const & pattern)
 {
   bool newResource = false;

--- a/drape/stipple_pen_resource.hpp
+++ b/drape/stipple_pen_resource.hpp
@@ -101,8 +101,6 @@ public:
   ref_ptr<Texture::ResourceInfo> ReserveResource(bool predefined, StipplePenKey const & key, bool & newResource);
   ref_ptr<Texture::ResourceInfo> MapResource(StipplePenKey const & key, bool & newResource);
   void UploadResources(ref_ptr<Texture> texture);
-  glConst GetMinFilter() const;
-  glConst GetMagFilter() const;
 
 private:
   typedef map<StipplePenHandle, StipplePenResourceInfo> TResourceMapping;

--- a/drape/texture_manager.cpp
+++ b/drape/texture_manager.cpp
@@ -400,6 +400,7 @@ void TextureManager::Init(Params const & params)
   });
 
   uint32_t colorTextureSize = max(my::NextPowOf2(floor(sqrt(colors.size() + kReservedColors))), kMinColorTextureSize);
+  colorTextureSize *= ColorTexture::GetColorSizeInPixels();
   colorTextureSize = min(m_maxTextureSize, colorTextureSize);
   m_colorTexture = make_unique_dp<ColorTexture>(m2::PointU(colorTextureSize, colorTextureSize),
                                                 make_ref(m_textureAllocator));

--- a/drape/texture_of_colors.cpp
+++ b/drape/texture_of_colors.cpp
@@ -147,12 +147,12 @@ void ColorPalette::UploadResources(ref_ptr<Texture> texture)
 
       for (size_t row = 0; row < kResourceSize; row++)
       {
-        for (size_t colomn = 0; colomn < kResourceSize; colomn++)
+        for (size_t column = 0; column < kResourceSize; column++)
         {
-          pointer[row * byteStride + colomn * kBytesPerPixel] = red;
-          pointer[row * byteStride + colomn * kBytesPerPixel + 1] = green;
-          pointer[row * byteStride + colomn * kBytesPerPixel + 2] = blue;
-          pointer[row * byteStride + colomn * kBytesPerPixel + 3] = alpha;
+          pointer[row * byteStride + column * kBytesPerPixel] = red;
+          pointer[row * byteStride + column * kBytesPerPixel + 1] = green;
+          pointer[row * byteStride + column * kBytesPerPixel + 2] = blue;
+          pointer[row * byteStride + column * kBytesPerPixel + 3] = alpha;
         }
       }
 

--- a/drape/texture_of_colors.hpp
+++ b/drape/texture_of_colors.hpp
@@ -35,13 +35,8 @@ public:
   ref_ptr<Texture::ResourceInfo> ReserveResource(bool predefined, ColorKey const & key, bool & newResource);
   ref_ptr<Texture::ResourceInfo> MapResource(ColorKey const & key, bool & newResource);
   void UploadResources(ref_ptr<Texture> texture);
-  glConst GetMinFilter() const;
-  glConst GetMagFilter() const;
 
   void SetIsDebug(bool isDebug) { m_isDebug = isDebug; }
-
-private:
-  void MoveCursor();
 
 private:
   typedef map<Color, ColorResourceInfo> TPalette;
@@ -80,6 +75,8 @@ public:
   void ReserveColor(dp::Color const & color);
 
   ~ColorTexture() { TBase::Reset(); }
+
+  static int GetColorSizeInPixels();
 
 private:
   ColorPalette m_pallete;

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -32,9 +32,8 @@
     CAEAGLLayer * eaglLayer = (CAEAGLLayer *)self.layer;
 
     eaglLayer.opaque = YES;
-    // ColorFormat : RGB565
-    // Backbuffer : YES, (to prevent from loosing content when mixing with ordinary layers).
-    eaglLayer.drawableProperties = @{kEAGLDrawablePropertyRetainedBacking : @NO, kEAGLDrawablePropertyColorFormat : kEAGLColorFormatRGB565};
+    eaglLayer.drawableProperties = @{kEAGLDrawablePropertyRetainedBacking : @NO,
+                                     kEAGLDrawablePropertyColorFormat : kEAGLColorFormatRGBA8};
     
     // Correct retina display support in opengl renderbuffer
     self.contentScaleFactor = [self correctContentScale];


### PR DESCRIPTION
Формат заднего буфера изменен в R5G6B5 на RGB8 для всех устройств. На Андроидах, если устройство вдруг не поддерживает RGB8 (что практически невероятно, но китайским телефонам законы не писаны), будет произведен фолбэк на R5G6B5.