### PR TITLE
Routing integration test fix.

### DIFF
--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -14,7 +14,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
           integration::GetOsrmComponents(),
           MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
-          MercatorBounds::FromLatLon(55.77198, 37.68782), 900.);
+          MercatorBounds::FromLatLon(55.77198, 37.68782), 700.);
   }
 
   UNIT_TEST(RestrictionTestNearMetroShodnenskaya)


### PR DESCRIPTION
Тест начал падать из-за изменения графа.
https://www.openstreetmap.org/way/375695929
С появлением новой дороги (места для разворота) итоговый маршрут стал короче.