### PR TITLE
[styles] Do not draw international name for path

### DIFF
--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -237,11 +237,9 @@ string const & CaptionDescription::GetRoadNumber() const
 
 string CaptionDescription::GetPathName() const
 {
-  // Always concat names for linear features because we process only one draw rule now.
-  if (m_mainText.empty())
+  if (!m_mainText.empty())
     return m_mainText;
-  else
-    return m_mainText + "   " + m_auxText;
+  return m_auxText;
 }
 
 bool CaptionDescription::IsNameExists() const


### PR DESCRIPTION
The same as https://github.com/mapsme/omim/pull/380, but port on the DRAPE.
https://trello.com/c/VuS6GW4A/1997--