### PR TITLE
[routing] No following router mode.

### DIFF
--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -591,9 +591,8 @@ public:
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRouteNavigable() const { return m_routingSession.IsNavigable(); }
   void BuildRoute(m2::PointD const & start, m2::PointD const & finish, uint32_t timeoutSec);
-  /// There were a bug inside FollowRoute method. Router follows route even it wasn't call.
-  /// So we deside to add special method to disable following mode, because we dont want to break
-  /// behavior users familiar to.
+  // FollowRoute has a bug where the router follows the route even if the method hads't been called.
+  // This method was added because we do not want to break the behaviour that is familiar to our users.
   bool DisableFollowMode() { return m_routingSession.DisableFollowMode(); }
   void SetRouteBuildingListener(TRouteBuildingCallback const & buildingCallback) { m_routingCallback = buildingCallback; }
   void SetRouteProgressListener(TRouteProgressCallback const & progressCallback) { m_progressCallback = progressCallback; }

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -591,6 +591,10 @@ public:
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRouteNavigable() const { return m_routingSession.IsNavigable(); }
   void BuildRoute(m2::PointD const & start, m2::PointD const & finish, uint32_t timeoutSec);
+  /// There were a bug inside FollowRoute method. Router follows route even it wasn't call.
+  /// So we deside to add special method to disable following mode, because we dont want to break
+  /// behavior users familiar to.
+  bool DisableFollowMode() { return m_routingSession.DisableFollowMode(); }
   void SetRouteBuildingListener(TRouteBuildingCallback const & buildingCallback) { m_routingCallback = buildingCallback; }
   void SetRouteProgressListener(TRouteProgressCallback const & progressCallback) { m_progressCallback = progressCallback; }
   void FollowRoute();

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -143,7 +143,7 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(m2::PointD const
   ASSERT(m_router != nullptr, ());
 
   if (m_state == RouteNeedRebuild || m_state == RouteFinished || m_state == RouteBuilding ||
-      m_state == RouteNotReady || m_state == RouteNoFollow)
+      m_state == RouteNotReady || m_state == RouteNoFollowing)
     return m_state;
 
   threads::MutexGuard guard(m_routeSessionMutex);
@@ -366,7 +366,7 @@ bool RoutingSession::DisableFollowMode()
 {
   if (m_state == RouteNotStarted || m_state == OnRoute)
   {
-    m_state = RouteNoFollow;
+    m_state = RouteNoFollowing;
     return true;
   }
   return false;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -143,7 +143,7 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(m2::PointD const
   ASSERT(m_router != nullptr, ());
 
   if (m_state == RouteNeedRebuild || m_state == RouteFinished || m_state == RouteBuilding ||
-      m_state == RouteNotReady)
+      m_state == RouteNotReady || m_state == RouteNoFollow)
     return m_state;
 
   threads::MutexGuard guard(m_routeSessionMutex);
@@ -362,6 +362,15 @@ bool RoutingSession::GetMercatorDistanceFromBegin(double & distance) const
   return true;
 }
 
+bool RoutingSession::DisableFollowMode()
+{
+  if (m_state == RouteNotStarted || m_state == OnRoute)
+  {
+    m_state = RouteNoFollow;
+    return true;
+  }
+  return false;
+}
 void RoutingSession::SetRoutingSettings(RoutingSettings const & routingSettings)
 {
   threads::MutexGuard guard(m_routeSessionMutex);

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -44,7 +44,8 @@ public:
     RouteNotStarted,   // route is builded but the user isn't on it
     OnRoute,           // user follows the route
     RouteNeedRebuild,  // user left the route
-    RouteFinished      // destination point is reached but the session isn't closed
+    RouteFinished,     // destination point is reached but the session isn't closed
+    RouteNoFollow      // route is builded but following mode were disabled
   };
 
   /*
@@ -54,6 +55,7 @@ public:
    * RouteNotStarted -> OnRoute           // user started following the route
    * RouteNotStarted -> RouteNeedRebuild  // user doesn't like the route.
    * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
+   * OnRoute -> RouteNoFollow             // following mode was disabled. Router don't track position.
    * OnRoute -> RouteFinished             // user reached the end of route
    * RouteNeedRebuild -> RouteNotReady    // start rebuild route
    * RouteFinished -> RouteNotReady       // start new route
@@ -97,6 +99,11 @@ public:
   bool GetMercatorDistanceFromBegin(double & distance) const;
 
   void ActivateAdditionalFeatures() {}
+
+  /// Disable following mode on GPS updates. Following mode disables only for the current route.
+  /// If routed will be rebuilt you must call DisableFollowMode again.
+  /// Returns truw if following were disabled, false if route not ready yet.
+  bool DisableFollowMode();
 
   void SetRoutingSettings(RoutingSettings const & routingSettings);
 

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -45,7 +45,7 @@ public:
     OnRoute,           // user follows the route
     RouteNeedRebuild,  // user left the route
     RouteFinished,     // destination point is reached but the session isn't closed
-    RouteNoFollow      // route is builded but following mode were disabled
+    RouteNoFollowing   // route is built but following mode has been disabled
   };
 
   /*
@@ -55,7 +55,7 @@ public:
    * RouteNotStarted -> OnRoute           // user started following the route
    * RouteNotStarted -> RouteNeedRebuild  // user doesn't like the route.
    * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
-   * OnRoute -> RouteNoFollow             // following mode was disabled. Router don't track position.
+   * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position.
    * OnRoute -> RouteFinished             // user reached the end of route
    * RouteNeedRebuild -> RouteNotReady    // start rebuild route
    * RouteFinished -> RouteNotReady       // start new route
@@ -100,9 +100,9 @@ public:
 
   void ActivateAdditionalFeatures() {}
 
-  /// Disable following mode on GPS updates. Following mode disables only for the current route.
-  /// If routed will be rebuilt you must call DisableFollowMode again.
-  /// Returns truw if following were disabled, false if route not ready yet.
+  /// Disable following mode on GPS updates. Following mode is disabled only for the current route.
+  /// If a route is rebuilt you must call DisableFollowMode again.
+  /// Returns true if following was disabled, false if a route is not ready for the following yet.
   bool DisableFollowMode();
 
   void SetRoutingSettings(RoutingSettings const & routingSettings);


### PR DESCRIPTION
Возможность не сопровождать по маршруту от роутера. Чтобы включить этот режим нужно вызвать метод DisableFollowMode.
Заменяет PR https://github.com/mapsme/omim/pull/327
https://trello.com/c/zUWVOrZX/2000-gps