### PR TITLE
[DO NOT MERGE] Removing fixing GPS bearing with compass heading.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -144,7 +144,7 @@ void Framework::OnLocationUpdate(GpsInfo const & info)
   MatchLocationToRoute(rInfo, routeMatchingInfo, hasDistanceFromBegin, distanceFromBegin);
 
   shared_ptr<State> const & state = GetLocationState();
-  state->OnLocationUpdate(rInfo, m_routingSession.IsNavigable(), routeMatchingInfo);
+  state->OnLocationUpdate(rInfo, routeMatchingInfo);
 
   if (state->IsModeChangeViewport())
     UpdateUserViewportChanged();
@@ -157,11 +157,7 @@ void Framework::OnCompassUpdate(CompassInfo const & info)
 #ifdef FIXED_LOCATION
   CompassInfo rInfo(info);
   m_fixedPos.GetNorth(rInfo.m_bearing);
-#else
-  CompassInfo const & rInfo = info;
 #endif
-
-  GetLocationState()->OnCompassUpdate(rInfo);
 }
 
 void Framework::StopLocationFollow()

--- a/map/location_state.hpp
+++ b/map/location_state.hpp
@@ -103,7 +103,7 @@ namespace location
 
     /// @name GPS location updates routine.
     //@{
-    void OnLocationUpdate(location::GpsInfo const & info, bool isNavigable, location::RouteMatchingInfo const & routeMatchingInfo);
+    void OnLocationUpdate(location::GpsInfo const & info, location::RouteMatchingInfo const & routeMatchingInfo);
     void OnCompassUpdate(location::CompassInfo const & info);
     //@}
 
@@ -152,7 +152,7 @@ namespace location
 
     ScreenBase const & GetModelView() const;
 
-    void Assign(location::GpsInfo const & info, bool isNavigable);
+    void Assign(location::GpsInfo const & info);
     bool Assign(location::CompassInfo const & info);
     void SetDirection(double bearing);
     const m2::PointD GetPositionForDraw() const;


### PR DESCRIPTION
Отказ от использования значения сенсора компас для подмены gps bearing.
Обоснование. 
В некотрые моменты времени, у нас вместо GPS bearing используется значение сенсора COMPASS heading.
Считаю, что это не правильно и черевато ошибками. 
Сейчас часть из них не заметна за счет routematching-га.
GPS bearing - направление, куда девайс перемещается в пространстве (Т.е. направление стрелки на карте);
COMPASS heading -  то как повернут девайс относительно севера;
По сути - это разные значение.

Сейчас я переделал на такой принцип: 
использовать всегда GPR bearing для рисования стрелки на карте, если скорость больше, чем 0.3 м/с.
если нет использовать последний валидный GPR bearing.
Затем, при наличии маршрута, применять route matching.

@vng @deathbaba @yunikkk PTAL
https://trello.com/c/Qw8xSwx8/2001-gps-bearing-compass-heading

Пока пометил PR [DO NOT MERGE]. Посмотрю как выглядит "в поле" на iOS и Android, что получилось.
