### PR TITLE
[routing] OSRM candidates filter fix.

### DIFF
--- a/routing/osrm_helpers.cpp
+++ b/routing/osrm_helpers.cpp
@@ -44,7 +44,7 @@ void Point2PhantomNode::operator()(FeatureType const & ft)
 
   FindNearestSegment(ft, m_point, res);
 
-  if (res.m_fid != kInvalidFid)
+  if (res.m_fid != kInvalidFid && !m_routingMapping.m_segMapping.GetNodeIdByFid(res.m_fid).empty())
     m_candidates.push_back(res);
 }
 

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -8,6 +8,19 @@ using namespace routing;
 
 namespace
 {
+  // Node filtering test. SVO has many restricted service roads that absent in a OSRM index.
+  UNIT_TEST(MoscowToSVOAirport)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+          integration::GetOsrmComponents(),
+          MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
+          MercatorBounds::FromLatLon(55.97310, 37.41460), 30470.);
+    integration::CalculateRouteAndTestRouteLength(
+          integration::GetOsrmComponents(),
+          MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
+          MercatorBounds::FromLatLon(55.75100, 37.61790), 30470.);
+  }
+
   // Restrictions tests. Check restrictions generation, if there are any errors.
   UNIT_TEST(RestrictionTestNeatBaumanAndTTK)
   {


### PR DESCRIPTION
https://trello.com/c/oYT0xiwa/1609--
Фиксит выборку ближайших OSRM вершин при поиске начальной и конечной точек. До этого случались сбои (например, в Штутгарте или Шереметьево), если в районе точек находилось много дорог, которые по каким-либо причинам не попадали в OSRM. Например, потому что они закрыты для общего пользования. 
Добавлен специальный интеграционный тест MoscowToSVOAirport, который проверяет эту функциональность.