### PR TITLE
[DO NOT MERGE][generator] Store description tag values

### DIFF
--- a/generator/generator_tests/metadata_test.cpp
+++ b/generator/generator_tests/metadata_test.cpp
@@ -171,6 +171,46 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
   params.GetMetadata().Drop(feature::Metadata::FMD_WIKIPEDIA);
 }
 
+UNIT_TEST(Metadata_ValidateAndFormat_description)
+{
+  FeatureParams params;
+  MetadataTagProcessor p(params);
+
+  p("description", "");
+  TEST(params.GetMetadata().Empty(), ("Empty"));
+
+  string line25("1двадцатьдва23");
+  TEST_EQUAL(line25.length(), 25, ("str length"));
+  string line63 = line25 + " 12345678901 " + line25;
+  string line255 = line63 + " " + line63 + " " + line63 + " " + line63;
+
+  p("description", line255);
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line255, ("255 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION2), "", ("255 chars"));
+  // We don't need to clear metadata, since description is always overwritten.
+
+  p("description", line255 + "ABC");
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line255 + "ABC", ("258 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION2), "ABC", ("258 chars"));
+
+  p("description", line255 + line255 + line255 + line255 + "A");
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line255 + line255 + line255 + line255, ("1021 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION),  line255, ("1021 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION2), line255, ("1021 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION3), line255, ("1021 chars"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_DESCRIPTION4), line255, ("1021 chars"));
+
+  string line254 = line255.substr(0, 254);
+  p("description", line254 + "Ж");
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line254 + "Ж", ("255 chars w/uni"));
+
+  p("description", line254 + "Ж" + line254 + line254 + line254 + "Й");
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line254 + "Ж" + line254 + line254 + line254 + "Й", ("1020 chars w/uni"));
+
+  p("description", line254 + "Ж" + line254 + line254 + line254 + "QЙ");
+  TEST_EQUAL(params.GetMetadata().GetDescription(), line254 + "Ж" + line254 + line254 + line254 + "Q", ("1020 chars w/uni split"));
+}
+
 UNIT_TEST(Metadata_ReadWrite_Intermediate)
 {
   FeatureParams params;

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -123,6 +123,12 @@ public:
       if (!value.empty())
         md.Add(Metadata::FMD_FLATS, value);
     }
+    else if (k == "description")
+    {
+      string const & value = ValidateAndFormat_description(v);
+      if (!value.empty())
+        md.Add(Metadata::FMD_DESCRIPTION, value);
+    }
     return false;
   }
 
@@ -210,6 +216,10 @@ protected:
     return v;
   }
   string ValidateAndFormat_flats(string const & v) const
+  {
+    return v;
+  }
+  string ValidateAndFormat_description(string const & v) const
   {
     return v;
   }

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -127,7 +127,7 @@ public:
     {
       string const & value = ValidateAndFormat_description(v);
       if (!value.empty())
-        md.Add(Metadata::FMD_DESCRIPTION, value);
+        md.SetDescription(value);
     }
     return false;
   }

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -69,4 +69,21 @@ string Metadata::GetWikiTitle() const
   string value = this->Get(FMD_WIKIPEDIA);
   return UriDecode(value);
 }
+
+void Metadata::SetDescription(string const & s)
+{
+  this->Set(FMD_DESCRIPTION, s.substr(0, kMaxStringLength));
+  if (s.length() > kMaxStringLength)
+    this->Set(FMD_DESCRIPTION2, s.substr(kMaxStringLength, kMaxStringLength));
+  if (s.length() > kMaxStringLength * 2)
+    this->Set(FMD_DESCRIPTION3, s.substr(kMaxStringLength * 2, kMaxStringLength));
+  if (s.length() > kMaxStringLength * 3)
+    this->Set(FMD_DESCRIPTION4, s.substr(kMaxStringLength * 3, kMaxStringLength));
+}
+
+string Metadata::GetDescription() const
+{
+  return this->Get(FMD_DESCRIPTION) + this->Get(FMD_DESCRIPTION2) +
+    this->Get(FMD_DESCRIPTION3) + this->Get(FMD_DESCRIPTION4);
+}
 }  // namespace feature

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -51,6 +51,30 @@ string UriDecode(string const & sSrc)
   result.resize(distance(result.begin(), itResult));
   return result;
 }
+
+// Strip broken multibyte character from the tail.
+string StripMultiByte(string const & s)
+{
+  if (s.length() < 5)
+    return s;
+  string::size_type pos = s.length() - 5;
+  string::size_type next = pos;
+  while (next < s.length())
+  {
+    if ((s[next] & 0xE0) == 0xC0)
+      next += 2;
+    else if ((s[next] & 0xF0) == 0xE0)
+      next += 3;
+    else if ((s[next] & 0xF8) == 0xF0)
+      next += 4;
+    else
+      next++;
+    if (next <= s.length())
+      pos = next;
+  }
+
+  return s.substr(0, pos);
+}
 }  // namespace
 
 namespace feature
@@ -73,17 +97,22 @@ string Metadata::GetWikiTitle() const
 void Metadata::SetDescription(string const & s)
 {
   this->Set(FMD_DESCRIPTION, s.substr(0, kMaxStringLength));
-  if (s.length() > kMaxStringLength)
-    this->Set(FMD_DESCRIPTION2, s.substr(kMaxStringLength, kMaxStringLength));
-  if (s.length() > kMaxStringLength * 2)
-    this->Set(FMD_DESCRIPTION3, s.substr(kMaxStringLength * 2, kMaxStringLength));
-  if (s.length() > kMaxStringLength * 3)
-    this->Set(FMD_DESCRIPTION4, s.substr(kMaxStringLength * 3, kMaxStringLength));
+  this->Set(FMD_DESCRIPTION2, s.length() <= kMaxStringLength ? string() : s.substr(kMaxStringLength, kMaxStringLength));
+  this->Set(FMD_DESCRIPTION3, s.length() <= kMaxStringLength * 2 ? string() : s.substr(kMaxStringLength * 2, kMaxStringLength));
+  this->Set(FMD_DESCRIPTION4, s.length() <= kMaxStringLength * 3 ? string() : StripMultiByte(s.substr(kMaxStringLength * 3, kMaxStringLength)));
 }
 
 string Metadata::GetDescription() const
 {
   return this->Get(FMD_DESCRIPTION) + this->Get(FMD_DESCRIPTION2) +
     this->Get(FMD_DESCRIPTION3) + this->Get(FMD_DESCRIPTION4);
+}
+
+void Metadata::DropDescription()
+{
+  this->Drop(FMD_DESCRIPTION);
+  this->Drop(FMD_DESCRIPTION2);
+  this->Drop(FMD_DESCRIPTION3);
+  this->Drop(FMD_DESCRIPTION4);
 }
 }  // namespace feature

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -38,6 +38,9 @@ namespace feature
       FMD_MAXSPEED = 17,
       FMD_FLATS = 18,
       FMD_DESCRIPTION = 19,
+      FMD_DESCRIPTION2 = 20,
+      FMD_DESCRIPTION3 = 21,
+      FMD_DESCRIPTION4 = 22,
       FMD_COUNT
     };
 
@@ -50,6 +53,13 @@ namespace feature
         val = s;
       else
         val = val + ", " + s;
+      return true;
+    }
+
+    bool Set(EType type, string const & s)
+    {
+      string & val = m_metadata[type];
+      val = s;
       return true;
     }
 
@@ -80,6 +90,8 @@ namespace feature
 
     string GetWikiURL() const;
     string GetWikiTitle() const;
+    void SetDescription(string const & s);
+    string GetDescription() const;
 
     template <class ArchiveT> void SerializeToMWM(ArchiveT & ar) const
     {

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -37,6 +37,7 @@ namespace feature
       FMD_WIKIPEDIA = 16,
       FMD_MAXSPEED = 17,
       FMD_FLATS = 18,
+      FMD_DESCRIPTION = 19,
       FMD_COUNT
     };
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -92,6 +92,7 @@ namespace feature
     string GetWikiTitle() const;
     void SetDescription(string const & s);
     string GetDescription() const;
+    void DropDescription();
 
     template <class ArchiveT> void SerializeToMWM(ArchiveT & ar) const
     {


### PR DESCRIPTION
Думаю, пришла пора хранить в данных содержимое тега [description](http://wiki.openstreetmap.org/wiki/RU:Key:description). Всего их около 700 тысяч на планете, средняя длина 38,2 символа, т.е. суммарный размер всех файлов mwm увеличится примерно на 30 мегабайт. По-моему, тег полезный, а прирост незначительный.

Кроме того, это будет первый тег, значения которого мы будем выводить в place page на несколько строк.

Вас удивит, что реквест добавлят не один, а целых четыре description в метаданные. Таким образом я обхожу ограничение на 255 байт: описание может быть до килобайта. В данных OSM такое не встречается, но повышение ограничения позволит подмешивать в данные длинные описательные фичи.