### PR TITLE
[generator] Replace params.flats with metadata string

### DIFF
--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -207,9 +207,6 @@ bool FeatureBuilder1::PreSerialize()
   if (!m_params.IsValid())
     return false;
 
-  /// @todo Do not use flats info. Maybe in future.
-  m_params.flats.clear();
-
   switch (m_params.GetGeomType())
   {
   case GEOM_POINT:

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -117,6 +117,12 @@ public:
       if (!value.empty())
         md.Add(Metadata::FMD_WIKIPEDIA, value);
     }
+    else if (k == "addr:flats")
+    {
+      string const & value = ValidateAndFormat_flats(v);
+      if (!value.empty())
+        md.Add(Metadata::FMD_FLATS, value);
+    }
     return false;
   }
 
@@ -200,6 +206,10 @@ protected:
     return v;
   }
   string ValidateAndFormat_postcode(string const & v) const
+  {
+    return v;
+  }
+  string ValidateAndFormat_flats(string const & v) const
   {
     return v;
   }

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -524,7 +524,6 @@ namespace ftype
       { "building", "entrance", [](string & k, string & v) { k.swap(v); v = "yes"; }},
       { "addr:housename", "*", [&params](string & k, string & v) { params.AddHouseName(v); k.clear(); v.clear(); }},
       { "addr:street", "*", [&params](string & k, string & v) { params.AddStreetAddress(v); k.clear(); v.clear(); }},
-      { "addr:flats", "*", [&params](string & k, string & v) { params.flats = v; k.clear(); v.clear(); }},
       { "addr:housenumber", "*", [&params](string & k, string & v)
         {
           // Treat "numbers" like names if it's not an actual number.

--- a/generator/osm_element.cpp
+++ b/generator/osm_element.cpp
@@ -43,7 +43,6 @@ void OsmElement::AddTag(string const & k, string const & v)
 
   // Skip tags for speedup, now we don't use it
   SKIP_KEY("not:");
-  SKIP_KEY("seamark"); // http://wiki.openstreetmap.org/wiki/OpenSeaMap/Seamark_Tag_Values
   SKIP_KEY("artist_name");
   SKIP_KEY("whitewater"); // http://wiki.openstreetmap.org/wiki/Whitewater_sports
 

--- a/indexer/feature_data.hpp
+++ b/indexer/feature_data.hpp
@@ -121,7 +121,6 @@ struct FeatureParamsBase
   StringUtf8Multilang name;
   StringNumericOptimal house;
   string ref;
-  string flats;
   int8_t layer;
   uint8_t rank;
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -36,6 +36,7 @@ namespace feature
       FMD_POSTCODE = 15,
       FMD_WIKIPEDIA = 16,
       FMD_MAXSPEED = 17,
+      FMD_FLATS = 18,
       FMD_COUNT
     };
 


### PR DESCRIPTION
В общем, оказалось, `addr:flats` у нас не используется вообще нигде. Страннота. Выпилил `params.flats` и все его упоминания, добавил поле метаданных.

Заодно убрал пропуск тега seamark, чтобы потенциально можно было сделать морские карты.