### PR TITLE
Bugfix. Using atomic instead of direct calls for RoutingSession::m_state which is used at least from 3 threads.

### DIFF
--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -14,6 +14,7 @@
 #include "base/deferred_task.hpp"
 #include "base/mutex.hpp"
 
+#include "std/atomic.hpp"
 #include "std/limits.hpp"
 #include "std/unique_ptr.hpp"
 
@@ -144,7 +145,7 @@ private:
 private:
   unique_ptr<AsyncRouter> m_router;
   Route m_route;
-  State m_state;
+  atomic<State> m_state;
   m2::PointD m_endPoint;
   size_t m_lastWarnedSpeedCameraIndex;
   SpeedCameraRestriction m_lastCheckedCamera;


### PR DESCRIPTION
Судя по тесту мы обращаемся к RoutingSession::m_state  из 3 потоков. Вот результаты теста на Андроид.

10-29 18:03:37.959 14940 14940 I MapsWithMe_JNI: routing/routing_session.cpp:109 RemoveRouteImpl()  MSTATE. thread id is -1225434316
10-29 18:03:44.716 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:109 RemoveRouteImpl()  MSTATE. thread id is -1649907408
10-29 18:03:48.141 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:76 RebuildRoute()  MSTATE. thread id is -1649907408
10-29 18:03:48.141 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:109 RemoveRouteImpl()  MSTATE. thread id is -1649907408
10-29 18:03:50.401 14940 15325 I MapsWithMe_JNI: routing/routing_session.cpp:319 AssignRoute()  MSTATE. thread id is -1452279504
10-29 18:03:52.943 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:146 OnLocationPositionChanged()  MSTATE. thread id is -1649907408
10-29 18:03:52.948 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:350 MatchLocationToRoute()  MSTATE. thread id is -1649907408
10-29 18:03:54.364 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:146 OnLocationPositionChanged()  MSTATE. thread id is -1649907408
10-29 18:03:54.364 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:350 MatchLocationToRoute()  MSTATE. thread id is -1649907408
10-29 18:03:56.218 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:146 OnLocationPositionChanged()  MSTATE. thread id is -1649907408
10-29 18:03:56.219 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:350 MatchLocationToRoute()  MSTATE. thread id is -1649907408
10-29 18:03:56.997 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:146 OnLocationPositionChanged()  MSTATE. thread id is -1649907408
10-29 18:03:56.997 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:350 MatchLocationToRoute()  MSTATE. thread id is -1649907408
10-29 18:04:00.401 14940 15364 I MapsWithMe_JNI: routing/routing_session.cpp:109 RemoveRouteImpl()  MSTATE. thread id is -1649907408

https://trello.com/c/X44GGsbS/2011-routingsession-m-state