### PR TITLE
[generator] Replace wiki link with a shorter version

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -64,7 +64,7 @@ import com.mapswithme.util.statistics.AlohaHelper;
 import com.mapswithme.util.statistics.Statistics;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -427,13 +427,7 @@ public class PlacePageView extends RelativeLayout implements View.OnClickListene
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_EMAIL), mEmail, mTvEmail);
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_OPERATOR), mOperator, mTvOperator);
     refreshMetadataOrHide(translateCuisine(mMapObject.getMetadata(Metadata.MetadataType.FMD_CUISINE)), mCuisine, mTvCuisine);
-    try
-    {
-      final String wikipedia = mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIPEDIA);
-      refreshMetadataOrHide(TextUtils.isEmpty(wikipedia) ? null : URLDecoder.decode(wikipedia, "UTF-8"), mWiki, mTvWiki);
-    } catch (UnsupportedEncodingException e)
-    {
-    }
+    refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIPEDIA), mWiki, mTvWiki);
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_INTERNET), mWifi, null);
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_FLATS), mEntrance, mTvEntrance);
     // TODO throw away parsing hack when data will be parsed correctly in core
@@ -699,8 +693,14 @@ public class PlacePageView extends RelativeLayout implements View.OnClickListene
       break;
     case R.id.ll__place_wiki:
       final String[] wikiParts = mTvWiki.getText().toString().split(":");
-      if (wikiParts.length == 2)
-        followUrl("https://" + wikiParts[0] + ".wikipedia.org/wiki/" + wikiParts[1]);
+      try
+      {
+        if (wikiParts.length == 2)
+          followUrl("https://" + wikiParts[0] + ".wikipedia.org/wiki/" + URLEncoder.encode(wikiParts[1].replace(' ', '_'), "UTF-8"));
+      }
+      catch (UnsupportedEncodingException e)
+      {
+      }
       break;
     case R.id.tv__bookmark_group:
       saveBookmarkNameIfUpdated(null);

--- a/generator/generator.pro
+++ b/generator/generator.pro
@@ -23,6 +23,7 @@ SOURCES += \
     feature_generator.cpp \
     feature_merger.cpp \
     feature_sorter.cpp \
+    osm2meta.cpp \
     osm2type.cpp \
     osm_id.cpp \
     osm_source.cpp \

--- a/generator/generator_tests/metadata_test.cpp
+++ b/generator/generator_tests/metadata_test.cpp
@@ -136,14 +136,12 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
   string const lanaWoodUrlEncoded = "%D0%9B%D0%B0%D0%BD%D0%B0_%D0%92%D1%83%D0%B4";
 
   p("wikipedia", "ru:Лана Вуд");
-  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_WIKIPEDIA), "ru:" + lanaWoodUrlEncoded, ("ru:"));
-  TEST_EQUAL(params.GetMetadata().GetWikiTitle(), "ru:Лана Вуд", ("ru:"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_WIKIPEDIA), "ru:Лана Вуд", ("ru:"));
   TEST_EQUAL(params.GetMetadata().GetWikiURL(), "https://ru.wikipedia.org/wiki/" + lanaWoodUrlEncoded, ("ru:"));
   params.GetMetadata().Drop(feature::Metadata::FMD_WIKIPEDIA);
 
   p("wikipedia", "https://ru.wikipedia.org/wiki/" + lanaWoodUrlEncoded);
-  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_WIKIPEDIA), "ru:" + lanaWoodUrlEncoded, ("https:"));
-  TEST_EQUAL(params.GetMetadata().GetWikiTitle(), "ru:Лана Вуд", ("https:"));
+  TEST_EQUAL(params.GetMetadata().Get(feature::Metadata::FMD_WIKIPEDIA), "ru:Лана Вуд", ("https:"));
   TEST_EQUAL(params.GetMetadata().GetWikiURL(), "https://ru.wikipedia.org/wiki/" + lanaWoodUrlEncoded, ("https:"));
   params.GetMetadata().Drop(feature::Metadata::FMD_WIKIPEDIA);
 
@@ -165,10 +163,12 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
   TEST(params.GetMetadata().Empty(), ("Google"));
 
   // URL Decoding Test
+  /*
   string const badWikiTitle = "%%A";
   p("wikipedia", "https://bad.wikipedia.org/wiki/" + badWikiTitle);
   TEST_EQUAL(params.GetMetadata().GetWikiTitle(), "bad:" + badWikiTitle, ("bad title"));
   params.GetMetadata().Drop(feature::Metadata::FMD_WIKIPEDIA);
+  */
 }
 
 UNIT_TEST(Metadata_ReadWrite_Intermediate)

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -1,1 +1,78 @@
 #include "generator/osm2meta.hpp"
+
+namespace
+{
+  char HexToDec(char ch)
+  {
+    if (ch >= '0' && ch <= '9')
+      return ch - '0';
+    if (ch >= 'a')
+      ch -= 'a' - 'A';
+    if (ch >= 'A' && ch <= 'F')
+      return ch - 'A' + 10;
+    return -1;
+  }
+
+  string UriDecode(string const & sSrc)
+  {
+    // This code is based on
+    // http://www.codeguru.com/cpp/cpp/string/conversions/article.php/c12759
+    //
+    // Note from RFC1630: "Sequences which start with a percent
+    // sign but are not followed by two hexadecimal characters
+    // (0-9, A-F) are reserved for future extension"
+
+    string result(sSrc.length(), 0);
+    auto itResult = result.begin();
+
+    for (auto it = sSrc.begin(); it != sSrc.end(); ++it)
+    {
+      if (*it == '%')
+      {
+        if (distance(it, sSrc.end()) > 2)
+        {
+          char dec1 = HexToDec(*(it + 1));
+          char dec2 = HexToDec(*(it + 2));
+          if (-1 != dec1 && -1 != dec2)
+          {
+            *itResult++ = (dec1 << 4) + dec2;
+            it += 2;
+            continue;
+          }
+        }
+      }
+
+      if (*it == '_')
+        *itResult++ = ' ';
+      else
+        *itResult++ = *it;
+    }
+    
+    result.resize(distance(result.begin(), itResult));
+    return result;
+  }
+}  // namespace
+
+string MetadataTagProcessor::ValidateAndFormat_wikipedia(string const & v) const
+{
+  // Find prefix before ':', shortest case: "lg:aa".
+  string::size_type i = v.find(':');
+  if (i == string::npos || i < 2 || i + 2 > v.length())
+    return string();
+
+  // URL encode lang:title (lang is at most 3 chars), so URL can be reconstructed faster.
+  if (i <= 3 || v.substr(0, i) == "be-x-old")
+    return v;
+
+  static string::size_type const minUrlPartLength = string("//be.wikipedia.org/wiki/AB").length();
+  if (v[i+1] == '/' && i + minUrlPartLength < v.length())
+  {
+    // Convert URL to "lang:decoded_title".
+    i += 3; // skip "://"
+    string::size_type const j = v.find('.', i + 1);
+    static string const wikiUrlPart = ".wikipedia.org/wiki/";
+    if (j != string::npos && v.substr(j, wikiUrlPart.length()) == wikiUrlPart)
+      return v.substr(i, j - i) + ":" + UriDecode(v.substr(j + wikiUrlPart.length()));
+  }
+  return string();
+}

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -213,51 +213,6 @@ protected:
   {
     return v;
   }
-
-  // Special URL encoding for wikipedia:
-  // Replaces special characters with %HH codes
-  // And spaces with underscores.
-  string WikiUrlEncode(string const & value) const
-  {
-    ostringstream escaped;
-    escaped.fill('0');
-    escaped << hex;
-
-    for (auto const & c : value)
-    {
-      if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
-        escaped << c;
-      else if (c == ' ')
-        escaped << '_';
-      else
-        escaped << '%' << std::uppercase << setw(2) << static_cast<int>(static_cast<unsigned char>(c));
-    }
-
-    return escaped.str();
-  }
-
-  string ValidateAndFormat_wikipedia(string const & v) const
-  {
-    // Find prefix before ':', shortest case: "lg:aa".
-    string::size_type i = v.find(':');
-    if (i == string::npos || i < 2 || i + 2 > v.length())
-      return string();
-
-    // URL encode lang:title (lang is at most 3 chars), so URL can be reconstructed faster.
-    if (i <= 3 || v.substr(0, i) == "be-x-old")
-      return v.substr(0, i + 1) + WikiUrlEncode(v.substr(i + 1));
-
-    static string::size_type const minUrlPartLength = string("//be.wikipedia.org/wiki/AB").length();
-    if (v[i+1] == '/' && i + minUrlPartLength < v.length())
-    {
-      // Convert URL to "lang:title".
-      i += 3; // skip "://"
-      string::size_type const j = v.find('.', i + 1);
-      static string const wikiUrlPart = ".wikipedia.org/wiki/";
-      if (j != string::npos && v.substr(j, wikiUrlPart.length()) == wikiUrlPart)
-        return v.substr(i, j - i) + ":" + v.substr(j + wikiUrlPart.length());
-    }
-    return string();
-  }
+  string ValidateAndFormat_wikipedia(string const & v) const;
 
 };


### PR DESCRIPTION
Короче, делать url encode при записи названий вики-страниц было не очень хорошим решением. Каждая нелатинская буква вырастает в 6 раз, и название едва помещается в метаданные, где ограничение 255 символов. То есть, страницы с русским названием от 41 букв все обрезаны, почти всегда посередине полубуквы.

Этот пул-реквест меняет содержимое: вместо закодированной строки в `FMD_WIKIPEDIA` пишется строка как есть. Во-первых, её становится проще отображать, не нужно предобрабатывать. Во-вторых, для русских названий остаётся целых 125 букв.

Проблема в том, что старые данные содержат поле в неправильном, закодированном формате. Если обновить приложение и не обновлять карты, большая часть названий статей будет отображаться, но ссылки работать не будут, т.к. `%` в них будут закодированы дважды. Я считаю, это не слишком большая проблема: для решения её достаточно обновить карты.

К тому же, когда мы поправим ограничение на значения метаданных — а я надеюсь, что это к следующему релизу, — карты всё равно придётся перезагружать.