### PR TITLE
[DO NOT MERGE] Compass heading in pedestrian mode and without route.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.hpp
+++ b/android/jni/com/mapswithme/maps/Framework.hpp
@@ -94,7 +94,7 @@ namespace android
 
     void OnLocationError(int/* == location::TLocationStatus*/ newStatus);
     void OnLocationUpdated(location::GpsInfo const & info);
-    void OnCompassUpdated(location::CompassInfo const & info, bool force);
+    void OnCompassUpdated(location::CompassInfo & info, bool force);
     void UpdateCompassSensor(int ind, float * arr);
 
     void Invalidate();

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -187,7 +187,7 @@ public enum LocationHelper implements SensorEventListener
   {
     if (mSensorManager != null)
     {
-      final int COMPASS_REFRESH_MKS = SensorManager.SENSOR_DELAY_UI;
+      final int COMPASS_REFRESH_MKS = SensorManager.SENSOR_DELAY_NORMAL;
 
       if (mAccelerometer != null)
         mSensorManager.registerListener(this, mAccelerometer, COMPASS_REFRESH_MKS);

--- a/geometry/avg_vector.hpp
+++ b/geometry/avg_vector.hpp
@@ -80,7 +80,7 @@ namespace math
 
   // Compass smoothing parameters
   // We're using technique described in
-  // http://windowsteamblog.com/windows_phone/b/wpdev/archive/2010/09/08/using-the-accelerometer-on-windows-phone-7.aspx
+  // https://blogs.windows.com/buildingapps/2010/09/08/using-the-accelerometer-on-windows-phone-7/
   // In short it's a combination of low-pass filter to smooth the
   // small orientation changes and a threshold filter to get big changes fast.
   // k in the following formula: O(n) = O(n-1) + k * (I - O(n - 1));

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -144,7 +144,7 @@ void Framework::OnLocationUpdate(GpsInfo const & info)
   MatchLocationToRoute(rInfo, routeMatchingInfo, hasDistanceFromBegin, distanceFromBegin);
 
   shared_ptr<State> const & state = GetLocationState();
-  state->OnLocationUpdate(rInfo, m_routingSession.IsNavigable(), routeMatchingInfo);
+  state->OnLocationUpdate(rInfo, routeMatchingInfo);
 
   if (state->IsModeChangeViewport())
     UpdateUserViewportChanged();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -592,6 +592,9 @@ public:
   bool IsRouteBuilding() const { return m_routingSession.IsBuilding(); }
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRouteNavigable() const { return m_routingSession.IsNavigable(); }
+  /// @return true if compass heading shall be used for map orientation and
+  /// false if gps bearing shall be used for map orientation.
+  routing::CourseType GetCourseType() const { return m_routingSession.GetCourseType(); }
   void BuildRoute(m2::PointD const & start, m2::PointD const & finish, uint32_t timeoutSec);
   // FollowRoute has a bug where the router follows the route even if the method hads't been called.
   // This method was added because we do not want to break the behaviour that is familiar to our users.

--- a/map/location_state.cpp
+++ b/map/location_state.cpp
@@ -960,7 +960,7 @@ bool State::IsCompassHeadingUsed() const
 {
   // If the current speed according to GPS is more than
   // kUseOnlyGpsHeadingSpeedMPS meters per second only GPS bearing is used.
-  double const kUseOnlyGpsBearingSpeedMPS = 4;
+  double const kUseOnlyGpsBearingSpeedMPS = 2;
   if (m_currentSpeedMPS > kUseOnlyGpsBearingSpeedMPS)
     return false;
   return m_framework->GetCourseType() == routing::CourseType::CompassHeadingForSmallSpeed;

--- a/map/location_state.cpp
+++ b/map/location_state.cpp
@@ -913,6 +913,9 @@ void State::RotateOnNorth()
 
 void State::Assign(location::GpsInfo const & info)
 {
+  // The minimal speed when GpsInfo::m_speed is valid for most gps chipsets.
+  // If GpsInfo::m_speed less than kMaxKeepBearingSpeedMPS the former m_drawDirection is used.
+  double const kMaxKeepBearingSpeedMPS = 0.3;
   m2::RectD rect = MercatorBounds::MetresToXY(info.m_longitude,
                                               info.m_latitude,
                                               info.m_horizontalAccuracy);
@@ -921,9 +924,6 @@ void State::Assign(location::GpsInfo const & info)
   if (info.HasSpeed())
     m_currentSpeedMPS = info.m_speed;
 
-  // The minimal speed when GpsInfo::m_speed is valid for most gps chipsets.
-  // If GpsInfo::m_speed less than kMaxKeepBearingSpeedMPS the former m_drawDirection is used.
-  double const kMaxKeepBearingSpeedMPS = 0.3;
   if (!IsCompassHeadingUsed() && info.m_speed >= kMaxKeepBearingSpeedMPS)
     SetDirection(my::DegToRad(info.m_bearing));
 }

--- a/map/location_state.cpp
+++ b/map/location_state.cpp
@@ -36,7 +36,6 @@ namespace
 static const int POSITION_Y_OFFSET = 75;
 static const double POSITION_TOLERANCE = 1.0E-6;  // much less than coordinates coding error
 static const double ANGLE_TOLERANCE = my::DegToRad(3.0);
-static const double GPS_BEARING_LIFETIME_S = 5.0;
 
 
 uint16_t IncludeModeBit(uint16_t mode, uint16_t bit)
@@ -261,7 +260,7 @@ State::State(Params const & p)
     m_errorRadius(0),
     m_position(0, 0),
     m_drawDirection(0.0),
-    m_lastGPSBearing(false),
+    m_currentSpeedMPS(0.0),
     m_afterPendingMode(Follow),
     m_routeMatchingInfo(),
     m_currentSlotID(0)
@@ -397,9 +396,9 @@ void State::TurnOff()
   invalidate();
 }
 
-void State::OnLocationUpdate(location::GpsInfo const & info, bool isNavigable, location::RouteMatchingInfo const & routeMatchingInfo)
+void State::OnLocationUpdate(location::GpsInfo const & info, location::RouteMatchingInfo const & routeMatchingInfo)
 {
-  Assign(info, isNavigable);
+  Assign(info);
   m_routeMatchingInfo = routeMatchingInfo;
 
   setIsVisible(true);
@@ -912,27 +911,26 @@ void State::RotateOnNorth()
   m_framework->GetAnimator().RotateScreen(GetModelView().GetAngle(), 0.0);
 }
 
-void State::Assign(location::GpsInfo const & info, bool isNavigable)
+void State::Assign(location::GpsInfo const & info)
 {
   m2::RectD rect = MercatorBounds::MetresToXY(info.m_longitude,
                                               info.m_latitude,
                                               info.m_horizontalAccuracy);
   m_position = rect.Center();
   m_errorRadius = rect.SizeX() / 2;
+  if (info.HasSpeed())
+    m_currentSpeedMPS = info.m_speed;
 
-  bool const hasBearing = info.HasBearing();
-  if ((isNavigable && hasBearing)
-      || (!isNavigable && hasBearing && info.HasSpeed() && info.m_speed > 1.0))
-  {
+  // The minimal speed when GpsInfo::m_speed is valid for most gps chipsets.
+  // If GpsInfo::m_speed less than kMaxKeepBearingSpeedMPS the former m_drawDirection is used.
+  double const kMaxKeepBearingSpeedMPS = 0.3;
+  if (!IsCompassHeadingUsed() && info.m_speed >= kMaxKeepBearingSpeedMPS)
     SetDirection(my::DegToRad(info.m_bearing));
-    m_lastGPSBearing.Reset();
-  }
 }
 
 bool State::Assign(location::CompassInfo const & info)
 {
-  if ((IsInRouting() && GetMode() >= Follow) ||
-      (m_lastGPSBearing.ElapsedSeconds() < GPS_BEARING_LIFETIME_S))
+  if (!IsCompassHeadingUsed())
     return false;
 
   SetDirection(info.m_bearing);
@@ -958,4 +956,13 @@ m2::PointD const State::GetPositionForDraw() const
   return pivot();
 }
 
+bool State::IsCompassHeadingUsed() const
+{
+  // If the current speed according to GPS is more than
+  // kUseOnlyGpsHeadingSpeedMPS meters per second only GPS bearing is used.
+  double const kUseOnlyGpsBearingSpeedMPS = 4;
+  if (m_currentSpeedMPS > kUseOnlyGpsBearingSpeedMPS)
+    return false;
+  return m_framework->GetCourseType() == routing::CourseType::CompassHeadingForSmallSpeed;
+}
 }

--- a/map/location_state.hpp
+++ b/map/location_state.hpp
@@ -6,8 +6,6 @@
 
 #include "base/timer.hpp"
 
-#include "routing/turns.hpp"
-
 #include "platform/location.hpp"
 
 #include "std/function.hpp"

--- a/map/location_state.hpp
+++ b/map/location_state.hpp
@@ -4,8 +4,6 @@
 
 #include "geometry/point2d.hpp"
 
-#include "base/timer.hpp"
-
 #include "platform/location.hpp"
 
 #include "std/function.hpp"
@@ -102,7 +100,7 @@ namespace location
 
     /// @name GPS location updates routine.
     //@{
-    void OnLocationUpdate(location::GpsInfo const & info, bool isNavigable, location::RouteMatchingInfo const & routeMatchingInfo);
+    void OnLocationUpdate(location::GpsInfo const & info, location::RouteMatchingInfo const & routeMatchingInfo);
     void OnCompassUpdate(location::CompassInfo const & info);
     //@}
 
@@ -142,6 +140,7 @@ namespace location
     bool IsRotationActive() const;
     bool IsInRouting() const;
     bool IsRoutingFollowingDisabled() const;
+    bool IsCompassHeadingUsed() const;
 
     m2::PointD const GetModeDefaultPixelBinding(Mode mode) const;
     m2::PointD const GetRaFModeDefaultPxBind() const;
@@ -152,7 +151,7 @@ namespace location
 
     ScreenBase const & GetModelView() const;
 
-    void Assign(location::GpsInfo const & info, bool isNavigable);
+    void Assign(location::GpsInfo const & info);
     bool Assign(location::CompassInfo const & info);
     void SetDirection(double bearing);
     const m2::PointD GetPositionForDraw() const;
@@ -176,7 +175,7 @@ namespace location
     double m_errorRadius;   //< error radius in mercator
     m2::PointD m_position;  //< position in mercator
     double m_drawDirection;
-    my::Timer m_lastGPSBearing;
+    double m_currentSpeedMPS; // Current speed according to GPS in meters per second.
     Mode m_afterPendingMode;
 
     RouteMatchingInfo m_routeMatchingInfo;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -88,6 +88,10 @@ public:
   bool IsBuilt() const { return (IsNavigable() || m_state == RouteNeedRebuild || m_state == RouteFinished); }
   bool IsBuilding() const { return (m_state == RouteBuilding); }
   bool IsOnRoute() const { return (m_state == OnRoute); }
+  CourseType GetCourseType() const
+  {
+    return !IsBuilt() ? CourseType::CompassHeadingForSmallSpeed : m_routingSettings.m_curPosCourseType;
+  }
   void Reset();
 
   State OnLocationPositionChanged(m2::PointD const & position, location::GpsInfo const & info,

--- a/routing/routing_settings.hpp
+++ b/routing/routing_settings.hpp
@@ -4,6 +4,13 @@
 
 namespace routing
 {
+/// \brief It's a list of ways to orient the current position coursor.
+enum class CourseType
+{
+  GPSBearingAlways,                /*!< Use GPS bearing for orientation current position always. */
+  CompassHeadingForSmallSpeed      /*!< Use compass heading if the current speed is small and
+                                        GPS bearing if current speed is bigger. */
+};
 
 /// \brief The RoutingSettings struct is intended to collect all the settings of
 /// following along the route.
@@ -35,19 +42,27 @@ struct RoutingSettings
 
   /// \brief m_speedCameraWarning is a flag for enabling user notifications about speed cameras.
   bool m_speedCameraWarning;
+
+  /// \brief if m_useCompassHeading == true compass heading is used to orient the map and
+  /// the current position while navigation.
+  /// Otherwise (m_useCompassHeading == false) gps bearing is used.
+  /// \brief m_curPosCourseType defines the source of the angle (course) for current position.
+  CourseType m_curPosCourseType;
 };
 
 inline RoutingSettings GetPedestrianRoutingSettings()
 {
   return RoutingSettings({ false /* m_matchRoute */, false /* m_soundDirection */,
                            20. /* m_matchingThresholdM */, true /* m_keepPedestrianInfo */,
-                           false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/});
+                           false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/,
+                           CourseType::CompassHeadingForSmallSpeed /* m_curPosCourseType */});
 }
 
 inline RoutingSettings GetCarRoutingSettings()
 {
   return RoutingSettings({ true /* m_matchRoute */, true /* m_soundDirection */,
                            50. /* m_matchingThresholdM */, false /* m_keepPedestrianInfo */,
-                           true /* m_showTurnAfterNext */, true /* m_speedCameraWarning*/});
+                           true /* m_showTurnAfterNext */, true /* m_speedCameraWarning*/,
+                           CourseType::GPSBearingAlways /* m_curPosCourseType */});
 }
 }  // namespace routing


### PR DESCRIPTION
Данный PR несколько изменяет работу нашей программы с GPS bearing/COMPASS heading.
Я прошу его не только про ревьюить, но и протестировать "в поле".

Проблемы, которые пытаюсь решить:
1. Консистентное направление стрелок при пешеходной навигации и без маршрута;
2. Более стабильное изменение направления стрелки компаса;

Этот код реализует следующую функциональность:
- в пешеходном режиме и без маршрута карта ориентируется по компасу на скоростях 
менее 2 м/с. На скоростях более 2 м/с (бег, велосипед, автомобиль) переключаемся на GPS bearing;
- при движении по автомобильному маршруту - всегда используем GPS bearing;
- улучшена фильтрация показаний компаса;

Будущие пути развития:
- можно лучше фильтровать используя показания компаса: фильтр Кальмана, скользящая средняя;
- можно лучше фильтровать используя и другие датчики:
http://math.stackexchange.com/questions/381649/whats-the-best-3d-angular-co-ordinate-system-for-working-with-smartphone-apps/382048#382048
http://stackoverflow.com/questions/16317599/android-compass-that-can-compensate-for-tilt-and-pitch
- можно пообщаться с авторами GPS Status программ и попытаться узнать, как фильтруют они;
- можно использовать точность (доступность) компаса: public void onAccuracyChanged(Sensor sensor, int accuracy).

https://trello.com/c/N8cg21Cg/1885-gps-bearing

