### PR TITLE
[drape]

### DIFF
--- a/drape_frontend/drape_frontend_tests/memory_feature_index_tests.cpp
+++ b/drape_frontend/drape_frontend_tests/memory_feature_index_tests.cpp
@@ -155,6 +155,7 @@ namespace
     virtual void Do()
     {
       vector<FeatureID> result;
+      df::MemoryFeatureIndex::Lock lock(m_index);
       m_index.ReadFeaturesRequest(m_features, result);
       MarkNodesAsReaded(m_features, result);
     }

--- a/drape_frontend/memory_feature_index.cpp
+++ b/drape_frontend/memory_feature_index.cpp
@@ -5,7 +5,7 @@ namespace df
 
 void MemoryFeatureIndex::ReadFeaturesRequest(TFeaturesInfo & features, vector<FeatureID> & featuresToRead)
 {
-  threads::MutexGuard lock(m_mutex);
+  ASSERT(m_isLocked, ());
 
   for (size_t i = 0; i < features.size(); ++i)
   {
@@ -21,7 +21,7 @@ void MemoryFeatureIndex::ReadFeaturesRequest(TFeaturesInfo & features, vector<Fe
 
 void MemoryFeatureIndex::RemoveFeatures(TFeaturesInfo & features)
 {
-  threads::MutexGuard lock(m_mutex);
+  ASSERT(m_isLocked, ());
 
   for (size_t i = 0; i < features.size(); ++i)
   {

--- a/drape_frontend/memory_feature_index.hpp
+++ b/drape_frontend/memory_feature_index.hpp
@@ -39,10 +39,29 @@ using TFeaturesInfo = buffer_vector<FeatureInfo, AverageFeaturesCount>;
 class MemoryFeatureIndex : private noncopyable
 {
 public:
+  class Lock
+  {
+    threads::MutexGuard lock;
+    MemoryFeatureIndex & m_index;
+  public:
+    Lock(MemoryFeatureIndex & index)
+      : lock(index.m_mutex)
+      , m_index(index)
+    {
+      m_index.m_isLocked = true;
+    }
+
+    ~Lock()
+    {
+      m_index.m_isLocked = false;
+    }
+  };
+
   void ReadFeaturesRequest(TFeaturesInfo & features, vector<FeatureID> & featuresToRead);
   void RemoveFeatures(TFeaturesInfo & features);
 
 private:
+  bool m_isLocked = false;
   threads::Mutex m_mutex;
   set<FeatureID> m_features;
 };

--- a/drape_frontend/read_mwm_task.cpp
+++ b/drape_frontend/read_mwm_task.cpp
@@ -27,6 +27,14 @@ void ReadMWMTask::Reset()
   m_tileInfo.reset();
 }
 
+bool ReadMWMTask::IsCancelled() const
+{
+  if (m_tileInfo == nullptr)
+    return true;
+
+  return m_tileInfo->IsCancelled() || IRoutine::IsCancelled();
+}
+
 void ReadMWMTask::Do()
 {
 #ifdef DEBUG

--- a/drape_frontend/read_mwm_task.hpp
+++ b/drape_frontend/read_mwm_task.hpp
@@ -23,6 +23,7 @@ public:
 
   void Init(shared_ptr<TileInfo> const & tileInfo);
   void Reset();
+  bool IsCancelled() const override;
   TileKey GetTileKey() const;
 
 private:

--- a/drape_frontend/tile_info.cpp
+++ b/drape_frontend/tile_info.cpp
@@ -27,8 +27,6 @@ m2::RectD TileInfo::GetGlobalRect() const
 
 void TileInfo::ReadFeatureIndex(MapDataProvider const & model)
 {
-  lock_guard<mutex> lock(m_mutex);
-
   if (DoNeedReadIndex())
   {
     CheckCanceled();
@@ -48,7 +46,9 @@ void TileInfo::ReadFeatures(MapDataProvider const & model, MemoryFeatureIndex & 
 
   vector<FeatureID> featuresToRead;
   {
-    lock_guard<mutex> g(m_mutex);
+    MemoryFeatureIndex::Lock lock(memIndex);
+    UNUSED_VALUE(lock);
+
     CheckCanceled();
     featuresToRead.reserve(AverageFeaturesCount);
     memIndex.ReadFeaturesRequest(m_featureInfo, featuresToRead);
@@ -64,8 +64,14 @@ void TileInfo::ReadFeatures(MapDataProvider const & model, MemoryFeatureIndex & 
 void TileInfo::Cancel(MemoryFeatureIndex & memIndex)
 {
   m_isCanceled = true;
-  lock_guard<mutex> lock(m_mutex);
+  MemoryFeatureIndex::Lock lock(memIndex);
+  UNUSED_VALUE(lock);
   memIndex.RemoveFeatures(m_featureInfo);
+}
+
+bool TileInfo::IsCancelled() const
+{
+  return m_isCanceled;
 }
 
 void TileInfo::ProcessID(FeatureID const & id)

--- a/drape_frontend/tile_info.cpp
+++ b/drape_frontend/tile_info.cpp
@@ -42,13 +42,12 @@ void TileInfo::ReadFeatures(MapDataProvider const & model, MemoryFeatureIndex & 
   // Reading can be interrupted by exception throwing
   MY_SCOPE_GUARD(ReleaseReadTile, bind(&EngineContext::EndReadTile, m_context.get()));
 
-  ReadFeatureIndex(model);
-
   vector<FeatureID> featuresToRead;
   {
     MemoryFeatureIndex::Lock lock(memIndex);
     UNUSED_VALUE(lock);
 
+    ReadFeatureIndex(model);
     CheckCanceled();
     featuresToRead.reserve(AverageFeaturesCount);
     memIndex.ReadFeaturesRequest(m_featureInfo, featuresToRead);
@@ -77,7 +76,6 @@ bool TileInfo::IsCancelled() const
 void TileInfo::ProcessID(FeatureID const & id)
 {
   m_featureInfo.push_back(id);
-  CheckCanceled();
 }
 
 void TileInfo::InitStylist(FeatureType const & f, Stylist & s)

--- a/drape_frontend/tile_info.hpp
+++ b/drape_frontend/tile_info.hpp
@@ -29,6 +29,7 @@ public:
 
   void ReadFeatures(MapDataProvider const & model, MemoryFeatureIndex & memIndex);
   void Cancel(MemoryFeatureIndex & memIndex);
+  bool IsCancelled() const;
 
   m2::RectD GetGlobalRect() const;
   TileKey const & GetTileKey() const { return m_context->GetTileKey(); }
@@ -48,7 +49,6 @@ private:
   TFeaturesInfo m_featureInfo;
 
   atomic<bool> m_isCanceled;
-  mutex m_mutex;
 };
 
 } // namespace df


### PR DESCRIPTION
- remove mutex from TileInfo. Now TileInfo use mutex of MemoryFeatureIndex to sync with BR thread.
- ReadMWMTask bug. Before this fix we canceled only TileInfo, but ReadMWMTask state did't take account of TileInfo state.

JT TP
JTTP
test this please
протестируй меня! полностью!