### PR TITLE
[drape] Fixed POI bounding rect calculation. Fixed index buffer updating. Fixed pivot calculation.

### DIFF
--- a/drape/overlay_handle.cpp
+++ b/drape/overlay_handle.cpp
@@ -46,14 +46,14 @@ m2::PointD OverlayHandle::GetPivot(ScreenBase const & screen) const
   m2::PointD result = r.Center();
 
   if (m_anchor & dp::Left)
-    result.x += size.x;
-  else if (m_anchor & dp::Right)
     result.x -= size.x;
+  else if (m_anchor & dp::Right)
+    result.x += size.x;
 
   if (m_anchor & dp::Top)
-    result.y += size.y;
-  else if (m_anchor & dp::Bottom)
     result.y -= size.y;
+  else if (m_anchor & dp::Bottom)
+    result.y += size.y;
 
   return result;
 }

--- a/drape/render_bucket.cpp
+++ b/drape/render_bucket.cpp
@@ -85,9 +85,10 @@ void RenderBucket::Render(ScreenBase const & screen)
     bool hasIndexMutation = false;
     for (drape_ptr<OverlayHandle> const & handle : m_overlay)
     {
-      if (handle->IndexesRequired() && handle->IsVisible())
+      if (handle->IndexesRequired())
       {
-        handle->GetElementIndexes(rfpIndex);
+        if (handle->IsVisible())
+          handle->GetElementIndexes(rfpIndex);
         hasIndexMutation = true;
       }
 

--- a/drape_frontend/poi_symbol_shape.cpp
+++ b/drape_frontend/poi_symbol_shape.cpp
@@ -52,7 +52,7 @@ void PoiSymbolShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManag
   provider.InitStream(0, gpu::SolidTexturingVertex::GetBindingInfo(), make_ref(vertexes));
 
   drape_ptr<dp::OverlayHandle> handle = make_unique_dp<dp::SquareHandle>(m_params.m_id,
-                                                                         dp::Bottom,
+                                                                         dp::Center,
                                                                          m_pt,
                                                                          pixelSize,
                                                                          m_params.m_depth);


### PR DESCRIPTION
Исправлено определение прямоугольника POI при отсечении.
Добавлено обновление индексного буфера при перерисовке, раньше могли продолжать отображаться объекты, которые уже были вытеснены.
Исправлена функция определения точки привязки, которая используется при поиске объекта для выделения.