### PR TITLE
Router freezing fix.

### DIFF
--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -148,6 +148,8 @@ private:
   m2::PointD m_endPoint;
   size_t m_lastWarnedSpeedCameraIndex;
   SpeedCameraRestriction m_lastCheckedCamera;
+  size_t m_lastCheckedSpeedCameraIndex;
+
   // TODO (ldragunov) Rewrite UI interop to message queue and avoid mutable.
   /// This field is mutable because it's modified in a constant getter. Note that the notification
   /// about camera will be sent at most once.

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -147,7 +147,8 @@ private:
   State m_state;
   m2::PointD m_endPoint;
   size_t m_lastWarnedSpeedCameraIndex;
-  SpeedCameraRestriction m_lastCheckedCamera;
+  SpeedCameraRestriction m_lastFoundCamera;
+  // Index of a last point on a route checked for a speed camera.
   size_t m_lastCheckedSpeedCameraIndex;
 
   // TODO (ldragunov) Rewrite UI interop to message queue and avoid mutable.


### PR DESCRIPTION
https://trello.com/c/pALZvBhF/2021--
Фикс подтормаживания роутинга после первого обновления позиции на длинных маршрутах.
Фикс связан с ограничением глубины просмотра точек маршрута, где мы ищем камеры. Раньше такого ограничения не было и при первом поиске мог быть проверен и весь маршрут, если на нём не было ни одной камеры.
Сейчас проверяется только kSpeedCameraLookAheadCount количество точек (50). Количество точек менее надёжная проверка, чем длина проверенного участка, но она значительно более быстрая. Каждое обновление позиции будут проверяться новые 50 точек пока не найдётся камера или маршрут не закончится. Таким образом за несколько обновлений позиции алгоритм сможет просмотреть весь маршрут.