### PR TITLE
Update documentation, git modules and configure.sh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git://github.com/mapsme/kothic.git
 [submodule "3party/Alohalytics"]
 	path = 3party/Alohalytics
-	url = git@github.com:mapsme/Alohalytics.git
+	url = git://github.com/mapsme/Alohalytics.git

--- a/configure.sh
+++ b/configure.sh
@@ -4,12 +4,13 @@
 # Stop on the first error.
 set -e -u
 
-PRIVATE_HEADER="private.h"
-PRIVATE_PROPERTIES="android/secure.properties"
-SAVED_PRIVATE_REPO_FILE=".private_repository_url"
-TMP_REPO_DIR=".tmp.private.repo"
+BASE_PATH=`dirname "$0"`
+PRIVATE_HEADER="$BASE_PATH/private.h"
+PRIVATE_PROPERTIES="$BASE_PATH/android/secure.properties"
+SAVED_PRIVATE_REPO_FILE="$BASE_PATH/.private_repository_url"
+TMP_REPO_DIR="$BASE_PATH/.tmp.private.repo"
 
-if [ ! -f "./omim.pro" ]; then
+if [ ! -f "$BASE_PATH/omim.pro" ]; then
   echo "Please run this script from the root repository folder."
   exit -1
 fi

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,23 +51,27 @@ Install Qt 5.5:
     sudo apt-get install qt55base
     source /opt/qt55/bin/qt55-env.sh
 
-To run OSRM binaries, you'll need:
-
-    sudo apt-get install libtbb2 libluabind0.9.1 liblua50 libstxxl1
-
 Do a git clone:
 
-    git clone git@github.com:mapsme/omim.git
+    git clone --depth=1 --recursive https://github.com/mapsme/omim.git
     cd omim
     echo | ./configure.sh
 
 Then:
 
-    sudo apt-get install clang-3.5 libboost-iostreams-dev libglu1-mesa-dev
-    sudo apt-get install libtbb-dev libluabind-dev libstxxl-dev libosmpbf-dev libprotobuf-dev
+    sudo apt-get install clang-3.5 libc++-dev libboost-iostreams-dev libglu1-mesa-dev
     sudo ln -s /usr/lib/llvm-3.5/bin/clang /usr/bin/clang
     sudo ln -s /usr/lib/llvm-3.5/bin/clang++ /usr/bin/clang++
-    omim/tools/unix/build_omim.sh
+    tools/unix/build_omim.sh
+
+Prepend with `CONFIG=gtool` if only generator_tool is needed. You would need 1.5 GB of memory
+to compile `stats` module.
+
+To build and run OSRM binaries:
+
+    sudo apt-get install libtbb2 libluabind0.9.1 liblua50 libstxxl1
+    sudo apt-get install libtbb-dev libluabind-dev libstxxl-dev libosmpbf-dev libprotobuf-dev
+    tools/unix/build_omim.sh -o
 
 ### Windows
 


### PR DESCRIPTION
Попробовал сейчас собрать проект под Ubuntu 14.04, обнаружил, что пропустил один пакет.

Также, подмодуль Alohalytics был встроен через ssh-ссылку, которая не позволяет клонировать анонимно. Поправил ссылку, но хз, как теперь обновление отработает.

Ещё добавил определение пути в `configure.sh`, так что его не обязательно теперь запускать из каталога репы.