### PR TITLE
Routing rebuild fix

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2303,7 +2303,8 @@ void Framework::CheckLocationForRouting(GpsInfo const & info)
         GetPlatform().RunOnGuiThread(bind(&Framework::InsertRoute, this, route));
     };
 
-    m_routingSession.RebuildRoute(position, readyCallback, m_progressCallback, 0 /* timeoutSec */);
+    m_routingSession.RebuildRoute(MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude),
+                                  readyCallback, m_progressCallback, 0 /* timeoutSec */);
   }
 }
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -228,12 +228,6 @@ bool Route::MoveIterator(location::GpsInfo const & info) const
   return res.IsValid();
 }
 
-double Route::GetCurrentSqDistance(m2::PointD const & pt) const
-{
-  ASSERT(m_poly.IsValid(), ());
-  return pt.SquareLength(m_poly.GetCurrentIter().m_pt);
-}
-
 double Route::GetPolySegAngle(size_t ind) const
 {
   size_t const polySz = m_poly.GetPolyline().GetSize();

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -94,8 +94,6 @@ public:
   /// @return true  If position was updated successfully (projection within gps error radius).
   bool MoveIterator(location::GpsInfo const & info) const;
 
-  /// Square distance to current projection in mercator.
-  double GetCurrentSqDistance(m2::PointD const & pt) const;
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 
   bool IsCurrentOnEnd() const;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -195,7 +195,8 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(m2::PointD const
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).
-    double const dist = MercatorBounds::DistanceOnEarth(m_route.GetFollowedPolyline().GetCurrentIter().m_pt, position);
+    double const dist = MercatorBounds::DistanceOnEarth(m_route.GetFollowedPolyline().GetCurrentIter().m_pt,
+                                                        MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude));
     if (my::AlmostEqualAbs(dist, m_lastDistance, kRunawayDistanceSensitivityMeters))
         return m_state;
     if (dist > m_lastDistance)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -195,7 +195,7 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(m2::PointD const
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).
-    double const dist = m_route.GetCurrentSqDistance(position);
+    double const dist = MercatorBounds::DistanceOnEarth(m_route.GetFollowedPolyline().GetCurrentIter().m_pt, position);
     if (my::AlmostEqualAbs(dist, m_lastDistance, kRunawayDistanceSensitivityMeters))
         return m_state;
     if (dist > m_lastDistance)

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -1,0 +1,127 @@
+#include "testing/testing.hpp"
+
+#include "routing/route.hpp"
+#include "routing/router.hpp"
+#include "routing/routing_session.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/logging.hpp"
+
+#include "std/string.hpp"
+#include "std/vector.hpp"
+
+namespace routing {
+// Simple router. It returns route given to him on creation.
+class DummyRouter : public IRouter
+{
+private:
+  Route & m_route;
+  ResultCode m_code;
+  size_t & m_buildCount;
+
+public:
+  DummyRouter(Route & route, ResultCode code, size_t & buildCounter)
+    : m_route(route), m_code(code), m_buildCount(buildCounter)
+  {
+  }
+  string GetName() const override { return "dummy"; }
+  void ClearState() override {}
+  ResultCode CalculateRoute(m2::PointD const & /* startPoint */,
+                            m2::PointD const & /* startDirection */,
+                            m2::PointD const & /* finalPoint */,
+                            RouterDelegate const & /* delegate */, Route & route) override
+  {
+    ++m_buildCount;
+    route = m_route;
+    return m_code;
+  }
+};
+
+static vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 2.}, {0., 3.}, {0., 4.}};
+
+UNIT_TEST(TestRouteBuilding)
+{
+  RoutingSession session;
+  session.Init(nullptr, nullptr);
+  vector<m2::PointD> routePoints = kTestRoute;
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  size_t counter = 0;
+  atomic<bool> routeBuilded(false);
+  unique_ptr<DummyRouter> router = make_unique<DummyRouter>(masterRoute, DummyRouter::NoError, counter);
+  session.SetRouter(move(router), nullptr);
+  session.BuildRoute(kTestRoute.front(), kTestRoute.back(),
+                     [&routeBuilded](Route const &, IRouter::ResultCode)
+                     {
+                       routeBuilded = true;
+                     },
+                     nullptr, 0);
+  while (!routeBuilded)
+  {
+  }
+  TEST_EQUAL(counter, 1, ());
+}
+
+UNIT_TEST(TestRouteRebuilding)
+{
+  Index index;
+  RoutingSession session;
+  session.Init(nullptr, nullptr);
+  vector<m2::PointD> routePoints = kTestRoute;
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  size_t counter = 0;
+  atomic<bool> routeBuilded(false);
+  unique_ptr<DummyRouter> router = make_unique<DummyRouter>(masterRoute, DummyRouter::NoError, counter);
+  session.SetRouter(move(router), nullptr);
+
+  // Go along the route.
+  session.BuildRoute(kTestRoute.front(), kTestRoute.back(),
+                     [&routeBuilded](Route const &, IRouter::ResultCode)
+                     {
+                       routeBuilded = true;
+                     },
+                     nullptr, 0);
+  while (!routeBuilded)
+  {
+  }
+
+  location::GpsInfo info;
+  info.m_horizontalAccuracy = 0.01;
+  info.m_verticalAccuracy = 0.01;
+  info.m_longitude = 0.;
+  info.m_latitude = 1.;
+  RoutingSession::State code = session.OnLocationPositionChanged(
+      MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude), info, index);
+  while (info.m_latitude < kTestRoute.back().y)
+  {
+    code = session.OnLocationPositionChanged(
+        MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude), info, index);
+    TEST_EQUAL(code, RoutingSession::State::OnRoute, ());
+    info.m_latitude += 0.01;
+  }
+  TEST_EQUAL(counter, 1, ());
+
+  // Rebuild route and go in opposite direction. So initiate a route rebuilding flag.
+  counter = 0;
+  routeBuilded = false;
+  session.BuildRoute(kTestRoute.front(), kTestRoute.back(),
+                     [&routeBuilded](Route const &, IRouter::ResultCode)
+                     {
+                       routeBuilded = true;
+                     },
+                     nullptr, 0);
+  info.m_longitude = 0.;
+  info.m_latitude = 1.;
+  while (!routeBuilded)
+  {
+  }
+
+  for (size_t i = 0; i < 10; ++i)
+  {
+    code = session.OnLocationPositionChanged(
+        MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude), info, index);
+    info.m_latitude -= 0.1;
+  }
+  TEST_EQUAL(code, RoutingSession::State::RouteNeedRebuild, ());
+}
+}  // namespace routing

--- a/routing/routing_tests/routing_tests.pro
+++ b/routing/routing_tests/routing_tests.pro
@@ -34,6 +34,7 @@ SOURCES += \
   road_graph_nearest_edges_test.cpp \
   route_tests.cpp \
   routing_mapping_test.cpp \
+  routing_session_test.cpp \
   turns_generator_test.cpp \
   turns_sound_test.cpp \
   turns_tts_text_tests.cpp \

--- a/std/mutex.hpp
+++ b/std/mutex.hpp
@@ -8,6 +8,7 @@
 
 using std::lock_guard;
 using std::mutex;
+using std::timed_mutex;
 using std::unique_lock;
 
 #ifdef DEBUG_NEW


### PR DESCRIPTION
Фиксит баг неперестроения маршрута при уходе с него https://trello.com/c/9CzZo4fR/2029--
и покрывает этот кейс юнит тестом. Чтобы больше такого не повторялось.