### PR TITLE
[build] Restore CONFIG+=ordered

### DIFF
--- a/omim.pro
+++ b/omim.pro
@@ -17,6 +17,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 cache()
 
 TEMPLATE = subdirs
+CONFIG += ordered
 
 HEADERS += defines.hpp
 

--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -149,6 +149,7 @@ build()
 {
   build_conf $1
   [ -n "$OPT_OSRM" ] && build_osrm $1
+  return 0
 }
 
 [ -n "$OPT_DEBUG" ]   && build debug


### PR DESCRIPTION
Поспешили убрать `CONFIG+=ordered` в #469: теперь не собираются исполняемые файлы, причём каждый раз разные. При этом сборка завершается без ошибки, т.е. не отследить никак. Нужно, конечно, умное решение, но пока его нет, а работать надо, — сделаем так. Все остальные правки в `omim.pro` выглядят нормально (хотя, конечно, вспоминаю, как меня ругали, что `omim.pro` стал сложен для восприятия, и ээээ).

Также, походя правлю тут ошибку в `build_omim.sh`, которая не позволяла собрать одновременно релиз и дебаг. И из-за которой скрипт всё время возвращал ненулевой код выхода.