### PR TITLE
[base, std] Followup fix - replace base/regexp.hpp by base/regex.hpp

### DIFF
--- a/platform/platform_android.cpp
+++ b/platform/platform_android.cpp
@@ -8,8 +8,9 @@
 
 #include "base/logging.hpp"
 #include "base/thread.hpp"
-#include "base/regexp.hpp"
 #include "base/string_utils.hpp"
+
+#include "std/regex.hpp"
 
 #include <unistd.h>     // for sysconf
 #include <sys/stat.h>
@@ -196,13 +197,12 @@ void Platform::GetFilesByRegExp(string const & directory, string const & regexp,
     FilesT fList;
     ZipFileReader::FilesList(directory, fList);
 
-    regexp::RegExpT exp;
-    regexp::Create(regexp, exp);
+    regex exp(regexp);
 
     for (FilesT::iterator it = fList.begin(); it != fList.end(); ++it)
     {
       string & name = it->first;
-      if (regexp::IsExist(name, exp))
+      if (regex_search(name.begin(), name.end(), exp))
       {
         // Remove assets/ prefix - clean files are needed for fonts white/blacklisting logic
         size_t const ASSETS_LENGTH = 7;


### PR DESCRIPTION
This is a follow-up fix for Android build.
https://trello.com/c/AUFaxzkF/2037-boost-xpressive