### PR TITLE
Fix warnings for clang build 

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -130,9 +130,9 @@ win32-msvc201* {
 # unix also works for Android
 unix|win32-g++ {
   LIBS *= -lz
-  QMAKE_CXXFLAGS_WARN_ON += -Wno-sign-compare -Wno-strict-aliasing -Wno-unused-parameter \
-                            -Wno-unused-local-typedef
-  *-clang {
+  QMAKE_CXXFLAGS_WARN_ON += -Wno-sign-compare -Wno-strict-aliasing -Wno-unused-parameter
+
+  *-clang* {
     QMAKE_CXXFLAGS_WARN_ON += -Wno-sign-conversion -Werror=return-type -Wno-deprecated-register
   }
 


### PR DESCRIPTION
Instead #511
Fix clang detection
Remove -Wno-unused-local-typedef