### PR TITLE
[build] Exit with 0 code when build is successful

### DIFF
--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -155,3 +155,4 @@ build()
 [ -n "$OPT_DEBUG" ]   && build debug
 [ -n "$OPT_RELEASE" ] && build release
 [ -n "$OPT_OSRM" -a -z "$OPT_DEBUG$OPT_RELEASE" ] && build_osrm release
+exit 0


### PR DESCRIPTION
Последняя проверка (что запустили с ключом `-o` без остальных) почти никогда не срабатывала, и код возврата был не 0, а результатом этой проверки, т.е. 1. Поэтому `build_omim.sh` почти никогда не возвращал нулевого кода.