### PR TITLE
Minor install docs fixes

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -57,6 +57,11 @@ Do a git clone:
     cd omim
     echo | ./configure.sh
 
+On Ubuntu 14.04, you'll need a PPA with an up-to-date version of libc++.
+You shouldn't need this on newer versions.
+
+    sudo add-apt-repository ppa:jhe/llvm-toolchain
+
 Then:
 
     sudo apt-get install clang-3.5 libc++-dev libboost-iostreams-dev libglu1-mesa-dev

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -49,6 +49,9 @@ Install Qt 5.5:
     sudo add-apt-repository ppa:beineri/opt-qt55-trusty
     sudo apt-get update
     sudo apt-get install qt55base
+
+Set up the Qt 5.5 environment:
+
     source /opt/qt55/bin/qt55-env.sh
 
 Do a git clone:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -72,6 +72,9 @@ Then:
 Prepend with `CONFIG=gtool` if only generator_tool is needed. You would need 1.5 GB of memory
 to compile `stats` module.
 
+The generated binaries appear in `omim-build-<flavour>/out/<flavour>/`.
+Run tests from this directory with `../../../omim/tools/unix/run_tests.sh`.
+
 To build and run OSRM binaries:
 
     sudo apt-get install libtbb2 libluabind0.9.1 liblua50 libstxxl1


### PR DESCRIPTION
* The Qt 5.5 env setup has to be done each time, not just once, so separate it from the other Qt commands.
* For Ubuntu 14.04 I needed a PPA for libc++.
* Explain where the output of the build goes.

Based on my experience of beikng a first-time MAPS.ME developer, these would have helped me. Also mentioning libc++-dev, but I see that's already been added - thank you.