### PR TITLE
Fixes for new tests

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -39,7 +39,7 @@ string MetadataTagProcessor::ValidateAndFormat_wikipedia(string v) const
     return string();
   }
   // Check if it's not a random/invalid link.
-  if (v.find("//") != string::npos)
+  if (v.find("//") != string::npos || v.find(".org") != string::npos)
   {
     LOG(LINFO, ("Invalid Wikipedia tag value:", v));
     return string();

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -27,7 +27,7 @@ string MetadataTagProcessor::ValidateAndFormat_wikipedia(string v) const
         return v.substr(slashIndex + 1, baseIndex - slashIndex - 1) + ":" + title;
       }
     }
-    LOG(LWARNING, ("Invalid Wikipedia tag value:", v));
+    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Standard case: "lang:Article Name With Spaces".
@@ -35,13 +35,13 @@ string MetadataTagProcessor::ValidateAndFormat_wikipedia(string v) const
   auto const colonIndex = v.find(':');
   if (colonIndex == string::npos || colonIndex < 2 || colonIndex + 2 > v.size())
   {
-    LOG(LWARNING, ("Invalid Wikipedia tag value:", v));
+    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Check if it's not a random/invalid link.
-  if (v.find('/') != string::npos)
+  if (v.find("//") != string::npos)
   {
-    LOG(LWARNING, ("Invalid Wikipedia tag value:", v));
+    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Normalize to OSM standards.

--- a/tools/unix/diff_features.py
+++ b/tools/unix/diff_features.py
@@ -21,7 +21,7 @@ with open(sys.argv[1], 'r') as f:
   for line in f:
     parse_and_add(data2, line)
 
-threshold = (int(sys.argv[3]) if len(sys.argv) > 3 else 50) / 100.0 + 1
+threshold = (int(sys.argv[3]) if len(sys.argv) > 3 else 100) / 100.0 + 1
 min_diff = 40
 
 for k in data1:

--- a/tools/unix/diff_size.py
+++ b/tools/unix/diff_size.py
@@ -11,7 +11,7 @@ old_path = sys.argv[2]
 threshold = (int(sys.argv[3]) if len(sys.argv) > 3 else 10) / 100.0 + 1
 min_diff = 1024 * 1024
 
-for f in os.listdir(new_path):
+for f in sorted(os.listdir(old_path)):
   new_file = os.path.join(new_path, f)
   old_file = os.path.join(old_path, f)
   if os.path.isfile(new_file) and os.path.isfile(old_file):
@@ -19,6 +19,6 @@ for f in os.listdir(new_path):
     old_size = os.path.getsize(old_file)
     if new_size + old_size > 0:
       if new_size == 0 or old_size == 0 or max(new_size, old_size) / float(min(new_size, old_size)) > threshold and abs(new_size - old_size) > min_diff:
-          print '{0}: {1} to {2} MB'.format(f, old_size / 1024 / 1024, new_size / 1024 / 1024)
+          print '{0}: {1} {2} to {3} MB'.format(f, old_size / 1024 / 1024, 'up' if new_size > old_size else 'down', new_size / 1024 / 1024)
   else:
     print 'Not found a mirror for {0}'.format(f)


### PR DESCRIPTION
Собралась планета, я получил гигантский отчёт, и этот пул-реквест его немного подсжимает.

* Предупреждение про неправильное значение тега википедии понижено до `LINFO`.
* И убрана проверка на слэш в названии викистатьи: слэши там допустимы.
* Файлы сравниваются в алфавитном порядке.
* И явно пишется, увеличился размер или уменьшился, чтобы быстрее сканировать глазами.
* Промежуточные роутинговые файлы убираются чуть раньше, до тестов.
* Обновление countries.txt сделано опциональным шагов: скрипт не вываливается, если не прошло.
* Повысил грань проблемы в сравнивалке количества фич по типам до 100% (изменение вдвое в любую сторону). Но, конечно, придётся смириться, что пока картостиль допиливается, эта новая секция будет занимать три четверти отчёта.