### PR TITLE
Calculation visualScale based on more exact dpi.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -150,6 +150,7 @@ namespace android
     }
 
     params.m_density = dens[bestRangeIndex].second;
+    params.m_exactDensityDPI = densityDpi;
   }
 
   bool Framework::InitRenderPolicyImpl(int densityDpi, int screenWidth, int screenHeight)
@@ -158,6 +159,7 @@ namespace android
 
     rmParams.m_videoMemoryLimit = 30 * 1024 * 1024;
     rmParams.m_texFormat = graphics::Data4Bpp;
+    rmParams.m_exactDensityDPI = densityDpi;
 
     RenderPolicy::Params rpParams;
 

--- a/android/src/com/nvidia/devtech/NvEventQueueFragment.java
+++ b/android/src/com/nvidia/devtech/NvEventQueueFragment.java
@@ -76,10 +76,11 @@ public abstract class NvEventQueueFragment extends BaseMwmFragment implements Vi
   public void onCreate(Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-
-    final DisplayMetrics metrics = new DisplayMetrics();
-    getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
-    mDisplayDensity = metrics.densityDpi;
+    
+    final DisplayMetrics dm = getActivity().getResources().getDisplayMetrics();
+    final float exactDensityDpi = (dm.xdpi + dm.ydpi) / 2;
+    mDisplayDensity = (int)exactDensityDpi;
+    
     mIsNativeLaunched = true;
     onCreateNative();
     if (getActivity().isChangingConfigurations())

--- a/graphics/defines.cpp
+++ b/graphics/defines.cpp
@@ -83,6 +83,12 @@ namespace graphics
     return vs[density];
   }
 
+  double visualScaleExact(int exactDensity)
+  {
+    double const mdpiDensityDPI = 160.;
+    return exactDensity / mdpiDensityDPI;
+  }
+
   DataIS s_semantics[] = {
     {ESemPosition, "Position"},
     {ESemNormal, "Normal"},

--- a/graphics/defines.cpp
+++ b/graphics/defines.cpp
@@ -77,12 +77,6 @@ namespace graphics
     density = static_cast<EDensity>(FindFirstBySecond(s_density, name, EqualStrings()));
   }
 
-  double visualScale(EDensity density)
-  {
-    static double const vs [6] = { 0.75, 1, 1.5, 2, 3, 2.4 };
-    return vs[density];
-  }
-
   double visualScaleExact(int exactDensity)
   {
     double const mdpiDensityDPI = 160.;

--- a/graphics/defines.cpp
+++ b/graphics/defines.cpp
@@ -77,14 +77,14 @@ namespace graphics
     density = static_cast<EDensity>(FindFirstBySecond(s_density, name, EqualStrings()));
   }
 
-  double visualScaleExact(int exactDensity)
+  double visualScaleExact(int exactDensityDPI)
   {
     double const mdpiDensityDPI = 160.;
     // For some old devices (for example iPad 2) the density could be less than 160 DPI.
     // Returns one in that case to keep readable text on the map.
-    if (exactDensity <= mdpiDensityDPI)
+    if (exactDensityDPI <= mdpiDensityDPI)
       return 1.;
-    return exactDensity / mdpiDensityDPI;
+    return exactDensityDPI / mdpiDensityDPI;
   }
 
   DataIS s_semantics[] = {

--- a/graphics/defines.cpp
+++ b/graphics/defines.cpp
@@ -80,6 +80,10 @@ namespace graphics
   double visualScaleExact(int exactDensity)
   {
     double const mdpiDensityDPI = 160.;
+    // For some old devices (for example iPad 2) the density could be less than 160 DPI.
+    // Returns one in that case to keep readable text on the map.
+    if (exactDensity <= mdpiDensityDPI)
+      return 1.;
     return exactDensity / mdpiDensityDPI;
   }
 

--- a/graphics/defines.hpp
+++ b/graphics/defines.hpp
@@ -28,7 +28,6 @@ namespace graphics
   void convert(char const * name, EDensity & density);
 
   /// get scaling koefficient for specified density
-  double visualScale(EDensity density);
   double visualScaleExact(int exactDensity);
 
   /// When adding values here,

--- a/graphics/defines.hpp
+++ b/graphics/defines.hpp
@@ -29,6 +29,7 @@ namespace graphics
 
   /// get scaling koefficient for specified density
   double visualScale(EDensity density);
+  double visualScaleExact(int exactDensity);
 
   /// When adding values here,
   /// please check constructor of ResourceManager,

--- a/graphics/defines.hpp
+++ b/graphics/defines.hpp
@@ -27,8 +27,8 @@ namespace graphics
   /// get density from name
   void convert(char const * name, EDensity & density);
 
-  /// get scaling koefficient for specified density
-  double visualScaleExact(int exactDensity);
+  /// Gets visual scale by exact density in dpi.
+  double visualScaleExact(int exactDensityDPI);
 
   /// When adding values here,
   /// please check constructor of ResourceManager,

--- a/graphics/glyph_cache.cpp
+++ b/graphics/glyph_cache.cpp
@@ -47,12 +47,14 @@ namespace graphics
                              string const & blackListFile,
                              size_t maxSize,
                              EDensity density,
+                             int exactDensityDPI,
                              bool isDebugging)
     : m_blocksFile(blocksFile),
       m_whiteListFile(whiteListFile),
       m_blackListFile(blackListFile),
       m_maxSize(maxSize),
       m_density(density),
+      m_exactDensityDPI(exactDensityDPI),
       m_isDebugging(isDebugging)
   {}
 

--- a/graphics/glyph_cache.hpp
+++ b/graphics/glyph_cache.hpp
@@ -72,12 +72,15 @@ namespace graphics
       string m_blackListFile;
       size_t m_maxSize;
       EDensity m_density;
+      int    m_exactDensityDPI;
       bool   m_isDebugging;
+
       Params(string const & blocksFile,
              string const & whiteListFile,
              string const & blackListFile,
              size_t maxSize,
              EDensity density,
+             int exactDensityDPI,
              bool isDebugging);
     };
 

--- a/graphics/glyph_cache_impl.cpp
+++ b/graphics/glyph_cache_impl.cpp
@@ -379,7 +379,7 @@ namespace graphics
 
       /// Initializing stroker
       FREETYPE_CHECK(FT_Stroker_New(m_lib, &m_stroker));
-      FT_Stroker_Set(m_stroker, FT_Fixed(graphics::visualScale(params.m_density) * 2 * 64), FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
+      FT_Stroker_Set(m_stroker, FT_Fixed(visualScaleExact(params.m_exactDensityDPI) * 2 * 64), FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
 
       FREETYPE_CHECK(FTC_CMapCache_New(m_manager, &m_charMapCache));
     }

--- a/graphics/resource_manager.cpp
+++ b/graphics/resource_manager.cpp
@@ -330,6 +330,7 @@ namespace
                              gccp.m_blackListFile,
                              gccp.m_glyphCacheMemoryLimit / p.m_threadSlotsCount,
                              gccp.m_density,
+                             p.m_exactDensityDPI,
                              false);
 
       m_threadSlots[i].m_glyphCache.reset(new GlyphCache(gcp));

--- a/graphics/resource_manager.hpp
+++ b/graphics/resource_manager.hpp
@@ -215,6 +215,7 @@ namespace graphics
       unsigned m_threadSlotsCount;
 
       bool m_rgba4RenderBuffer;
+      int m_exactDensityDPI;
 
       Params();
 

--- a/gui/controller.cpp
+++ b/gui/controller.cpp
@@ -9,7 +9,7 @@
 namespace gui
 {
   Controller::RenderParams::RenderParams()
-    : m_Density(graphics::EDensityMDPI), m_GlyphCache(0)
+    : m_Density(graphics::EDensityMDPI), m_exactDensityDPI(0), m_GlyphCache(0)
   {}
 
   Controller::Controller()
@@ -17,10 +17,12 @@ namespace gui
   {}
 
   Controller::RenderParams::RenderParams(graphics::EDensity density,
+                                         int exactDensityDPI,
                                          TInvalidateFn invalidateFn,
                                          graphics::GlyphCache * glyphCache,
                                          graphics::Screen * cacheScreen)
     : m_Density(density),
+      m_exactDensityDPI(exactDensityDPI),
       m_InvalidateFn(invalidateFn),
       m_GlyphCache(glyphCache),
       m_CacheScreen(cacheScreen)
@@ -162,7 +164,7 @@ namespace gui
     m_GlyphCache = p.m_GlyphCache;
     m_InvalidateFn = p.m_InvalidateFn;
     m_Density = p.m_Density;
-    m_VisualScale = graphics::visualScale(p.m_Density);
+    m_VisualScale = graphics::visualScaleExact(p.m_exactDensityDPI);
     m_CacheScreen = p.m_CacheScreen;
 
     m_DisplayListCache.reset(new DisplayListCache(m_CacheScreen, m_GlyphCache));

--- a/gui/controller.hpp
+++ b/gui/controller.hpp
@@ -36,11 +36,13 @@ namespace gui
     struct RenderParams
     {
       graphics::EDensity m_Density;
+      int m_exactDensityDPI;
       TInvalidateFn m_InvalidateFn;
       graphics::GlyphCache * m_GlyphCache;
       graphics::Screen * m_CacheScreen;
       RenderParams();
       RenderParams(graphics::EDensity density,
+                   int exactDensityDPI,
                    TInvalidateFn invalidateFn,
                    graphics::GlyphCache * glyphCache,
                    graphics::Screen * cacheScreen);

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -28,34 +28,26 @@
 
 namespace
 {
-  // returns DPI as exact as possible. It works for iPhone, iPad and iWatch.
-  double getExactDPI()
+// Returns DPI as exact as possible. It works for iPhone, iPad and iWatch.
+double getExactDPI()
+{
+  float const iPadDPI = 132.f;
+  float const iPhoneDPI = 163.f;
+  float const mDPI = 160.f;
+
+  UIScreen * screen = [UIScreen mainScreen];
+  float const scale = [screen respondsToSelector:@selector(scale)] ? [screen scale] : 1.f;
+    
+  switch (UI_USER_INTERFACE_IDIOM())
   {
-    float const iPadDPI = 132.;
-    float const iPhoneDPI = 163.;
-    float const mDPI = 160;
-    
-    float scale = 1;
-    if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
-    {
-      scale = [[UIScreen mainScreen] scale];
-    }
-    
-    float dpi;
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
-    {
-      dpi = iPadDPI * scale;
-    }
-    else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)
-    {
-      dpi = iPhoneDPI * scale;
-    }
-    else
-    {
-      dpi = mDPI * scale;
-    };
-    return dpi;
+    case UIUserInterfaceIdiomPhone:
+      return iPhoneDPI * scale;
+    case UIUserInterfaceIdiomPad:
+      return iPadDPI * scale;
+    default:
+      return mDPI * scale;
   }
+}
 } //  namespace
 
 // You must implement this method
@@ -113,7 +105,7 @@ namespace
   NSLog(@"EAGLView initRenderPolicy Started");
   
 #ifndef USE_DRAPE
-  float const dpi = getExactDPI();
+  int const dpi = static_cast<int>(getExactDPI());
   
   graphics::ResourceManager::Params rmParams;
   rmParams.m_videoMemoryLimit = GetPlatform().VideoMemoryLimit();

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -26,6 +26,37 @@
 
 @implementation EAGLView
 
+namespace
+{
+  // returns DPI as exact as possible. It works for iPhone, iPad and iWatch.
+  double getExactDPI()
+  {
+    float const iPadDPI = 132.;
+    float const iPhoneDPI = 163.;
+    float const mDPI = 160;
+    
+    float scale = 1;
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
+    {
+      scale = [[UIScreen mainScreen] scale];
+    }
+    
+    float dpi;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    {
+      dpi = iPadDPI * scale;
+    }
+    else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)
+    {
+      dpi = iPhoneDPI * scale;
+    }
+    else
+    {
+      dpi = mDPI * scale;
+    };
+    return dpi;
+  }
+} //  namespace
 
 // You must implement this method
 + (Class)layerClass
@@ -82,9 +113,12 @@
   NSLog(@"EAGLView initRenderPolicy Started");
   
 #ifndef USE_DRAPE
+  float const dpi = getExactDPI();
+  
   graphics::ResourceManager::Params rmParams;
   rmParams.m_videoMemoryLimit = GetPlatform().VideoMemoryLimit();
   rmParams.m_texFormat = graphics::Data4Bpp;
+  rmParams.m_exactDensityDPI = dpi;
 
   RenderPolicy::Params rpParams;
 
@@ -104,6 +138,7 @@
     rpParams.m_density = graphics::EDensityIPhone6Plus;
   else
     rpParams.m_density = graphics::EDensityXHDPI;
+  rpParams.m_exactDensityDPI = dpi;
 
   rpParams.m_videoTimer = videoTimer;
   rpParams.m_useDefaultFB = false;

--- a/iphone/Maps/maps.me WatchKit Extension/FrameworkUtils/MWMFrameworkUtils.mm
+++ b/iphone/Maps/maps.me WatchKit Extension/FrameworkUtils/MWMFrameworkUtils.mm
@@ -56,9 +56,10 @@ extern NSString * const kSearchResultPointKey;
 
 + (void)initSoftwareRenderer
 {
+  int const xhdpi = 320;
   Framework & f = GetFramework();
   if (!f.IsSingleFrameRendererInited())
-    f.InitSingleFrameRenderer(graphics::EDensityXHDPI);
+    f.InitSingleFrameRenderer(graphics::EDensityXHDPI, xhdpi);
 }
 
 + (void)releaseSoftwareRenderer

--- a/iphone/Maps/maps.me WatchKit Extension/FrameworkUtils/MWMFrameworkUtils.mm
+++ b/iphone/Maps/maps.me WatchKit Extension/FrameworkUtils/MWMFrameworkUtils.mm
@@ -56,10 +56,11 @@ extern NSString * const kSearchResultPointKey;
 
 + (void)initSoftwareRenderer
 {
-  int const xhdpi = 320;
+  // @TODO. It's a hard code of apple watch dpi. It should be gotten dynamicly.
+  int const iWatchDPI = 384;
   Framework & f = GetFramework();
   if (!f.IsSingleFrameRendererInited())
-    f.InitSingleFrameRenderer(graphics::EDensityXHDPI, xhdpi);
+    f.InitSingleFrameRenderer(graphics::EDensityXHDPI, iWatchDPI);
 }
 
 + (void)releaseSoftwareRenderer

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -363,7 +363,7 @@ void Framework::InitSingleFrameRenderer(graphics::EDensity density, int exactDen
   ASSERT(!IsSingleFrameRendererInited(), ());
   if (m_cpuDrawer == nullptr)
   {
-    CPUDrawer::Params params(GetGlyphCacheParams(density));
+    CPUDrawer::Params params(GetGlyphCacheParams(density, exactDensityDPI));
     params.m_visualScale = graphics::visualScaleExact(exactDensityDPI);
     params.m_density = density;
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -358,13 +358,13 @@ void Framework::DrawSingleFrame(m2::PointD const & center, int zoomModifier,
   m_cpuDrawer->EndFrame(image);
 }
 
-void Framework::InitSingleFrameRenderer(graphics::EDensity density)
+void Framework::InitSingleFrameRenderer(graphics::EDensity density, int exactDensityDPI)
 {
   ASSERT(!IsSingleFrameRendererInited(), ());
   if (m_cpuDrawer == nullptr)
   {
     CPUDrawer::Params params(GetGlyphCacheParams(density));
-    params.m_visualScale = graphics::visualScale(density);
+    params.m_visualScale = graphics::visualScaleExact(exactDensityDPI);
     params.m_density = density;
 
     m_cpuDrawer.reset(new CPUDrawer(params));
@@ -1582,6 +1582,7 @@ void Framework::InitGuiSubsystem()
   if (m_renderPolicy)
   {
     gui::Controller::RenderParams rp(m_renderPolicy->Density(),
+                                     m_renderPolicy->DensityExactDPI(),
                                      bind(&WindowHandle::invalidate,
                                           m_renderPolicy->GetWindowHandle().get()),
                                      m_renderPolicy->GetGlyphCache(),

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -189,7 +189,7 @@ public:
   };
 
   /// @param density - for Retina Display you must use EDensityXHDPI
-  void InitSingleFrameRenderer(graphics::EDensity density);
+  void InitSingleFrameRenderer(graphics::EDensity density, int exactDensityDPI);
   /// @param center - map center in ercator
   /// @param zoomModifier - result zoom calculate like "base zoom" + zoomModifier
   ///                       if we are have search result "base zoom" calculate that my position and search result

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -274,9 +274,16 @@ namespace qt
     rpParams.m_screenHeight = L2D(geometry.height());
 
     if (m_ratio >= 1.5 || QApplication::desktop()->physicalDpiX() >= 180)
+    {
       rpParams.m_density = graphics::EDensityXHDPI;
+      rpParams.m_exactDensityDPI = 320.;
+    }
     else
+    {
       rpParams.m_density = graphics::EDensityMDPI;
+      rpParams.m_exactDensityDPI = 160.;
+    }
+    rmParams.m_exactDensityDPI = rpParams.m_exactDensityDPI;
 
     rpParams.m_videoTimer = m_videoTimer.get();
     rpParams.m_useDefaultFB = true;

--- a/render/render_policy.cpp
+++ b/render/render_policy.cpp
@@ -342,7 +342,7 @@ RenderPolicy * CreateRenderPolicy(RenderPolicy::Params const & params)
 
 
 graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density,
-                                                 int exactDensity,
+                                                 int exactDensityDPI,
                                                  size_t cacheMaxSize)
 {
   return graphics::GlyphCache::Params(UNICODE_BLOCK_FILE,
@@ -350,7 +350,7 @@ graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density,
                                       BLACK_LIST_FILE,
                                       cacheMaxSize,
                                       density,
-                                      exactDensity,
+                                      exactDensityDPI,
                                       false);
 }
 

--- a/render/render_policy.cpp
+++ b/render/render_policy.cpp
@@ -40,7 +40,7 @@ RenderPolicy::RenderPolicy(Params const & p,
     m_doForceUpdate(false),
     m_density(p.m_density),
     m_exactDensityDPI(p.m_exactDensityDPI),
-    m_visualScale(graphics::visualScale(p.m_density)),
+    m_visualScale(graphics::visualScaleExact(p.m_exactDensityDPI)),
     m_skinName(p.m_skinName)
 {
   m_bgColors.resize(scales::UPPER_STYLE_SCALE+1);
@@ -341,13 +341,16 @@ RenderPolicy * CreateRenderPolicy(RenderPolicy::Params const & params)
 }
 
 
-graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density, size_t cacheMaxSize)
+graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density,
+                                                 int exactDensity,
+                                                 size_t cacheMaxSize)
 {
   return graphics::GlyphCache::Params(UNICODE_BLOCK_FILE,
                                       WHITE_LIST_FILE,
                                       BLACK_LIST_FILE,
                                       cacheMaxSize,
                                       density,
+                                      exactDensity,
                                       false);
 }
 

--- a/render/render_policy.cpp
+++ b/render/render_policy.cpp
@@ -39,6 +39,7 @@ RenderPolicy::RenderPolicy(Params const & p,
   : m_primaryRC(p.m_primaryRC),
     m_doForceUpdate(false),
     m_density(p.m_density),
+    m_exactDensityDPI(p.m_exactDensityDPI),
     m_visualScale(graphics::visualScale(p.m_density)),
     m_skinName(p.m_skinName)
 {
@@ -206,6 +207,11 @@ double RenderPolicy::VisualScale() const
 graphics::EDensity RenderPolicy::Density() const
 {
   return m_density;
+}
+
+int RenderPolicy::DensityExactDPI() const
+{
+  return m_exactDensityDPI;
 }
 
 string const & RenderPolicy::SkinName() const

--- a/render/render_policy.hpp
+++ b/render/render_policy.hpp
@@ -202,5 +202,5 @@ protected:
 RenderPolicy * CreateRenderPolicy(RenderPolicy::Params const & params);
 
 graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density,
-                                                 int exactDensity, size_t cacheMaxSize = 2 * 1024 * 1024);
+                                                 int exactDensityDPI, size_t cacheMaxSize = 2 * 1024 * 1024);
 graphics::ResourceManager::GlyphCacheParams GetResourceGlyphCacheParams(graphics::EDensity density, size_t cacheMaxSize = 2 * 1024 * 1024);

--- a/render/render_policy.hpp
+++ b/render/render_policy.hpp
@@ -201,5 +201,6 @@ protected:
 
 RenderPolicy * CreateRenderPolicy(RenderPolicy::Params const & params);
 
-graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density, size_t cacheMaxSize = 2 * 1024 * 1024);
+graphics::GlyphCache::Params GetGlyphCacheParams(graphics::EDensity density,
+                                                 int exactDensity, size_t cacheMaxSize = 2 * 1024 * 1024);
 graphics::ResourceManager::GlyphCacheParams GetResourceGlyphCacheParams(graphics::EDensity density, size_t cacheMaxSize = 2 * 1024 * 1024);

--- a/render/render_policy.hpp
+++ b/render/render_policy.hpp
@@ -73,6 +73,7 @@ protected:
   bool m_doForceUpdate;
   m2::AnyRectD m_invalidRect;
   graphics::EDensity m_density;
+  int m_exactDensityDPI;
   double m_visualScale;
   string m_skinName;
   anim::Controller * m_controller;
@@ -91,6 +92,7 @@ public:
     string m_skinName;
     size_t m_screenWidth;
     size_t m_screenHeight;
+    int m_exactDensityDPI;
   };
 
   /// constructor
@@ -148,6 +150,7 @@ public:
   double VisualScale() const;
   virtual size_t TileSize() const { return 256; }
   graphics::EDensity Density() const;
+  int DensityExactDPI() const;
   string const & SkinName() const;
 
   /// This function is used when we need to prevent race


### PR DESCRIPTION
Данный PR позволяет вычислять visualScale на базе более точных значений dpi, чем это было раньше. Что в свое очередь позволяет отображать тексты на карте и толщины линий почти одинаковыми в миллиметрах на экранах разного разрешения.

Замечания:
1. Ввиду большого размера и низкого разрешения iPad 2 для лучшей читаемости тестов для подобных девайсов используется специальная поправка для visualScale;
2. Для drape будет подготовлен отдельный PR;

https://trello.com/c/DRnhWD70/2045-dpi
