### PR TITLE
[routing] Uturns support.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/RoutingInfo.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingInfo.java
@@ -47,7 +47,8 @@ public class RoutingInfo
     TURN_SHARP_LEFT(R.drawable.ic_sharp_right_light, R.drawable.ic_sharp_right_then),
     TURN_SLIGHT_LEFT(R.drawable.ic_slight_right_light, R.drawable.ic_slight_right_then),
 
-    U_TURN(R.drawable.ic_uturn_light, R.drawable.ic_uturn_then),
+    U_TURN_LEFT(R.drawable.ic_uturn_light, R.drawable.ic_uturn_then),
+    U_TURN_RIGHT(R.drawable.ic_uturn_light, R.drawable.ic_uturn_then),
     TAKE_THE_EXIT(R.drawable.ic_finish_point_light, 0),
 
     ENTER_ROUND_ABOUT(R.drawable.ic_round_light, R.drawable.ic_round_then),

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.mm
@@ -89,7 +89,8 @@ UIImage * image(routing::turns::TurnDirection t, bool isNextTurn)
     case TurnDirection::TurnSharpLeft:
       imageName = @"sharp_left";
       break;
-    case TurnDirection::UTurn:
+    case TurnDirection::UTurnLeft:
+    case TurnDirection::UTurnRight:
       imageName = @"uturn";
       break;
     case TurnDirection::ReachedYourDestination:

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -399,11 +399,15 @@ OsrmRouter::ResultCode OsrmRouter::MakeTurnAnnotation(
       bool isStartNode = (segmentIndex == 0);
       bool isEndNode = (segmentIndex == numSegments - 1);
       if (isStartNode || isEndNode)
+      {
         loadedSegments.emplace_back(*mapping, *m_pIndex, pathSegments[segmentIndex],
                                     routingResult.sourceEdge, routingResult.targetEdge, isStartNode,
                                     isEndNode);
+      }
       else
+      {
         loadedSegments.emplace_back(*mapping, *m_pIndex, pathSegments[segmentIndex]);
+      }
     }
 
     // Annotate turns.

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -399,10 +399,11 @@ OsrmRouter::ResultCode OsrmRouter::MakeTurnAnnotation(
       bool isStartNode = (segmentIndex == 0);
       bool isEndNode = (segmentIndex == numSegments - 1);
       if (isStartNode || isEndNode)
-        loadedSegments.emplace_back(*mapping, *m_pIndex, pathSegments[segmentIndex], routingResult.sourceEdge, routingResult.targetEdge, isStartNode, isEndNode);
+        loadedSegments.emplace_back(*mapping, *m_pIndex, pathSegments[segmentIndex],
+                                    routingResult.sourceEdge, routingResult.targetEdge, isStartNode,
+                                    isEndNode);
       else
         loadedSegments.emplace_back(*mapping, *m_pIndex, pathSegments[segmentIndex]);
-
     }
 
     // Annotate turns.
@@ -411,7 +412,7 @@ OsrmRouter::ResultCode OsrmRouter::MakeTurnAnnotation(
       auto const & loadedSegment = loadedSegments[segmentIndex];
 
       // ETA information.
-      double const nodeTimeSeconds = double(loadedSegment.m_weight) * kOSRMWeightToSecondsMultiplier;
+      double const nodeTimeSeconds = loadedSegment.m_weight * kOSRMWeightToSecondsMultiplier;
 
       // Turns information.
       if (segmentIndex > 0 && !points.empty())

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -120,6 +120,7 @@ namespace
         {11.327927635052676, 48.166256203616726}, 2870710.);
   }
 
+
   UNIT_TEST(RussiaMoscowFranceParisCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
@@ -245,6 +246,6 @@ namespace
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
 
-    integration::TestRouteTime(route, 900.);
+    integration::TestRouteTime(route, 909.);
   }
 }  // namespace

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -120,7 +120,6 @@ namespace
         {11.327927635052676, 48.166256203616726}, 2870710.);
   }
 
-
   UNIT_TEST(RussiaMoscowFranceParisCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(

--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -23,7 +23,7 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestOneOfDirections({TurnDirection::TurnSlightLeft, TurnDirection::TurnLeft});
+      .TestDirection(TurnDirection::UTurnLeft);
   integration::GetNthTurn(route, 1)
       .TestValid()
       .TestDirection(TurnDirection::TurnRight);
@@ -136,6 +136,22 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+}
+
+UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetOsrmComponents(),
+      MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
+      MercatorBounds::FromLatLon(55.80955, 37.78056));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1);
+  // Checking a turn in case going from a not-link to a link
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::UTurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
@@ -345,8 +361,8 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::TestTurnCount(route, 1);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::UTurnLeft);
 }
 
 // Test case: checking that no unnecessary turn on a serpentine road.

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -216,7 +216,7 @@ namespace integration
     double const delta = expectedRouteMeters * relativeError;
     double const routeMeters = route.GetTotalDistanceMeters();
     TEST(my::AlmostEqualAbs(routeMeters, expectedRouteMeters, delta),
-        ("Route time test failed. Expected:", expectedRouteMeters, "have:", routeMeters, "delta:", delta));
+        ("Route length test failed. Expected:", expectedRouteMeters, "have:", routeMeters, "delta:", delta));
   }
 
   void TestRouteTime(Route const & route, double expectedRouteSeconds, double relativeError)

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -176,7 +176,8 @@ UNIT_TEST(TestIsLaneWayConformedTurnDirection)
   TEST(IsLaneWayConformedTurnDirection(LaneWay::Right, TurnDirection::TurnRight), ());
   TEST(IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, TurnDirection::TurnSlightLeft), ());
   TEST(IsLaneWayConformedTurnDirection(LaneWay::SharpRight, TurnDirection::TurnSharpRight), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::UTurn), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::UTurnLeft), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::UTurnRight), ());
   TEST(IsLaneWayConformedTurnDirection(LaneWay::Through, TurnDirection::GoStraight), ());
 
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::Left, TurnDirection::TurnSlightLeft), ());
@@ -193,12 +194,15 @@ UNIT_TEST(TestIsLaneWayConformedTurnDirectionApproximately)
   TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Left, TurnDirection::TurnSlightLeft), ());
   TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, TurnDirection::TurnSharpRight), ());
   TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, TurnDirection::TurnRight), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, TurnDirection::UTurn), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, TurnDirection::UTurnLeft), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, TurnDirection::UTurnRight), ());
   TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightLeft, TurnDirection::GoStraight), ());
   TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightRight, TurnDirection::GoStraight), ());
 
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, TurnDirection::UTurn), ());
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, TurnDirection::UTurn), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, TurnDirection::UTurnLeft), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, TurnDirection::UTurnRight), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, TurnDirection::UTurnLeft), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, TurnDirection::UTurnRight), ());
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::Through, TurnDirection::ReachedYourDestination), ());
   TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::Through, TurnDirection::TurnRight), ());
   TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightRight,

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -20,70 +20,70 @@ UNIT_TEST(GetDistanceTextIdMetersTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
-  TEST_EQUAL(GetDistanceTextId(notifiation1), "in_500_meters", ());
-  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, ::Settings::Metric);
-  TEST_EQUAL(GetDistanceTextId(notifiation2), "then", ());
-  Notification const notifiation3(200, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
-  TEST_EQUAL(GetDistanceTextId(notifiation3), "in_200_meters", ());
-  Notification const notifiation4(2000, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
-  TEST_EQUAL(GetDistanceTextId(notifiation4), "in_2_kilometers", ());
+  Notification const notification1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
+  TEST_EQUAL(GetDistanceTextId(notification1), "in_500_meters", ());
+  Notification const notification2(500, 0, true, TurnDirection::TurnRight, ::Settings::Metric);
+  TEST_EQUAL(GetDistanceTextId(notification2), "then", ());
+  Notification const notification3(200, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
+  TEST_EQUAL(GetDistanceTextId(notification3), "in_200_meters", ());
+  Notification const notification4(2000, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
+  TEST_EQUAL(GetDistanceTextId(notification4), "in_2_kilometers", ());
 }
 
 UNIT_TEST(GetDistanceTextIdFeetTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
-  TEST_EQUAL(GetDistanceTextId(notifiation1), "in_500_feet", ());
-  Notification const notifiation2(500, 0, true, TurnDirection::TurnRight, ::Settings::Foot);
-  TEST_EQUAL(GetDistanceTextId(notifiation2), "then", ());
-  Notification const notifiation3(800, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
-  TEST_EQUAL(GetDistanceTextId(notifiation3), "in_800_feet", ());
-  Notification const notifiation4(5000, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
-  TEST_EQUAL(GetDistanceTextId(notifiation4), "in_5000_feet", ());
+  Notification const notification1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
+  TEST_EQUAL(GetDistanceTextId(notification1), "in_500_feet", ());
+  Notification const notification2(500, 0, true, TurnDirection::TurnRight, ::Settings::Foot);
+  TEST_EQUAL(GetDistanceTextId(notification2), "then", ());
+  Notification const notification3(800, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
+  TEST_EQUAL(GetDistanceTextId(notification3), "in_800_feet", ());
+  Notification const notification4(5000, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
+  TEST_EQUAL(GetDistanceTextId(notification4), "in_5000_feet", ());
 }
 
 UNIT_TEST(GetRoundaboutTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::LeaveRoundAbout, ::Settings::Foot);
-  TEST_EQUAL(GetRoundaboutTextId(notifiation1), "leave_the_roundabout", ());
-  Notification const notifiation2(0, 3, true, TurnDirection::LeaveRoundAbout, ::Settings::Foot);
-  TEST_EQUAL(GetRoundaboutTextId(notifiation2), "take_the_3_exit", ());
-  Notification const notifiation3(0, 7, true, TurnDirection::LeaveRoundAbout, ::Settings::Metric);
-  TEST_EQUAL(GetRoundaboutTextId(notifiation3), "take_the_7_exit", ());
-  Notification const notifiation4(0, 15, true, TurnDirection::LeaveRoundAbout, ::Settings::Metric);
-  TEST_EQUAL(GetRoundaboutTextId(notifiation4), "leave_the_roundabout", ());
+  Notification const notification1(500, 0, false, TurnDirection::LeaveRoundAbout, ::Settings::Foot);
+  TEST_EQUAL(GetRoundaboutTextId(notification1), "leave_the_roundabout", ());
+  Notification const notification2(0, 3, true, TurnDirection::LeaveRoundAbout, ::Settings::Foot);
+  TEST_EQUAL(GetRoundaboutTextId(notification2), "take_the_3_exit", ());
+  Notification const notification3(0, 7, true, TurnDirection::LeaveRoundAbout, ::Settings::Metric);
+  TEST_EQUAL(GetRoundaboutTextId(notification3), "take_the_7_exit", ());
+  Notification const notification4(0, 15, true, TurnDirection::LeaveRoundAbout, ::Settings::Metric);
+  TEST_EQUAL(GetRoundaboutTextId(notification4), "leave_the_roundabout", ());
 }
 
 UNIT_TEST(GetYouArriveTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Foot);
-  TEST_EQUAL(GetYouArriveTextId(notifiation1), "destination", ());
-  Notification const notifiation2(0, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
-  TEST_EQUAL(GetYouArriveTextId(notifiation2), "you_have_reached_the_destination", ());
-  Notification const notifiation3(0, 0, true, TurnDirection::ReachedYourDestination, ::Settings::Metric);
-  TEST_EQUAL(GetYouArriveTextId(notifiation3), "destination", ());
+  Notification const notification1(500, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Foot);
+  TEST_EQUAL(GetYouArriveTextId(notification1), "destination", ());
+  Notification const notification2(0, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
+  TEST_EQUAL(GetYouArriveTextId(notification2), "you_have_reached_the_destination", ());
+  Notification const notification3(0, 0, true, TurnDirection::ReachedYourDestination, ::Settings::Metric);
+  TEST_EQUAL(GetYouArriveTextId(notification3), "destination", ());
 }
 
 UNIT_TEST(GetDirectionTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
-  TEST_EQUAL(GetDirectionTextId(notifiation1), "make_a_right_turn", ());
-  Notification const notifiation2(1000, 0, false, TurnDirection::GoStraight, ::Settings::Metric);
-  TEST_EQUAL(GetDirectionTextId(notifiation2), "go_straight", ());
-  Notification const notifiation3(700, 0, false, TurnDirection::UTurnLeft, ::Settings::Metric);
-  TEST_EQUAL(GetDirectionTextId(notifiation3), "make_a_u_turn", ());
-  Notification const notifiation4(200, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
-  TEST_EQUAL(GetDirectionTextId(notifiation4), "destination", ());
-  Notification const notifiation5(0, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
-  TEST_EQUAL(GetDirectionTextId(notifiation5), "you_have_reached_the_destination", ());
+  Notification const notification1(500, 0, false, TurnDirection::TurnRight, ::Settings::Foot);
+  TEST_EQUAL(GetDirectionTextId(notification1), "make_a_right_turn", ());
+  Notification const notification2(1000, 0, false, TurnDirection::GoStraight, ::Settings::Metric);
+  TEST_EQUAL(GetDirectionTextId(notification2), "go_straight", ());
+  Notification const notification3(700, 0, false, TurnDirection::UTurnLeft, ::Settings::Metric);
+  TEST_EQUAL(GetDirectionTextId(notification3), "make_a_u_turn", ());
+  Notification const notification4(200, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
+  TEST_EQUAL(GetDirectionTextId(notification4), "destination", ());
+  Notification const notification5(0, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
+  TEST_EQUAL(GetDirectionTextId(notification5), "you_have_reached_the_destination", ());
 }
 
 UNIT_TEST(GetTtsTextTest)
@@ -113,23 +113,23 @@ UNIT_TEST(GetTtsTextTest)
   GetTtsText getTtsText;
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
   //    TurnDirection turnDir, Settings::Units lengthUnits)
-  Notification const notifiation1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
-  Notification const notifiation2(300, 0, false, TurnDirection::TurnLeft, ::Settings::Metric);
-  Notification const notifiation3(0, 0, false, TurnDirection::ReachedYourDestination,
+  Notification const notification1(500, 0, false, TurnDirection::TurnRight, ::Settings::Metric);
+  Notification const notification2(300, 0, false, TurnDirection::TurnLeft, ::Settings::Metric);
+  Notification const notification3(0, 0, false, TurnDirection::ReachedYourDestination,
                                   ::Settings::Metric);
-  Notification const notifiation4(0, 0, true, TurnDirection::TurnLeft, ::Settings::Metric);
+  Notification const notification4(0, 0, true, TurnDirection::TurnLeft, ::Settings::Metric);
 
   getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  TEST_EQUAL(getTtsText(notifiation1), "In 500 meters. Make a right turn.", ());
-  TEST_EQUAL(getTtsText(notifiation2), "In 300 meters. Make a left turn.", ());
-  TEST_EQUAL(getTtsText(notifiation3), "You have reached the destination.", ());
-  TEST_EQUAL(getTtsText(notifiation4), "Then. Make a left turn.", ());
+  TEST_EQUAL(getTtsText(notification1), "In 500 meters. Make a right turn.", ());
+  TEST_EQUAL(getTtsText(notification2), "In 300 meters. Make a left turn.", ());
+  TEST_EQUAL(getTtsText(notification3), "You have reached the destination.", ());
+  TEST_EQUAL(getTtsText(notification4), "Then. Make a left turn.", ());
 
   getTtsText.ForTestingSetLocaleWithJson(rusShortJson, "ru");
-  TEST_EQUAL(getTtsText(notifiation1), "Через 500 метров. Поворот направо.", ());
-  TEST_EQUAL(getTtsText(notifiation2), "Через 300 метров. Поворот налево.", ());
-  TEST_EQUAL(getTtsText(notifiation3), "Вы достигли конца маршрута.", ());
-  TEST_EQUAL(getTtsText(notifiation4), "Затем. Поворот налево.", ());
+  TEST_EQUAL(getTtsText(notification1), "Через 500 метров. Поворот направо.", ());
+  TEST_EQUAL(getTtsText(notification2), "Через 300 метров. Поворот налево.", ());
+  TEST_EQUAL(getTtsText(notification3), "Вы достигли конца маршрута.", ());
+  TEST_EQUAL(getTtsText(notification4), "Затем. Поворот налево.", ());
 }
 
 UNIT_TEST(GetAllSoundedDistMetersTest)

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -78,7 +78,7 @@ UNIT_TEST(GetDirectionTextIdTest)
   TEST_EQUAL(GetDirectionTextId(notifiation1), "make_a_right_turn", ());
   Notification const notifiation2(1000, 0, false, TurnDirection::GoStraight, ::Settings::Metric);
   TEST_EQUAL(GetDirectionTextId(notifiation2), "go_straight", ());
-  Notification const notifiation3(700, 0, false, TurnDirection::UTurn, ::Settings::Metric);
+  Notification const notifiation3(700, 0, false, TurnDirection::UTurnLeft, ::Settings::Metric);
   TEST_EQUAL(GetDirectionTextId(notifiation3), "make_a_u_turn", ());
   Notification const notifiation4(200, 0, false, TurnDirection::ReachedYourDestination, ::Settings::Metric);
   TEST_EQUAL(GetDirectionTextId(notifiation4), "destination", ());

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -35,7 +35,8 @@ array<pair<TurnDirection, char const *>, static_cast<size_t>(TurnDirection::Coun
      {TurnDirection::TurnLeft, "TurnLeft"},
      {TurnDirection::TurnSharpLeft, "TurnSharpLeft"},
      {TurnDirection::TurnSlightLeft, "TurnSlightLeft"},
-     {TurnDirection::UTurn, "UTurn"},
+     {TurnDirection::UTurnLeft, "UTurnLeft"},
+     {TurnDirection::UTurnRight, "UTurnRight"},
      {TurnDirection::TakeTheExit, "TakeTheExit"},
      {TurnDirection::EnterRoundAbout, "EnterRoundAbout"},
      {TurnDirection::LeaveRoundAbout, "LeaveRoundAbout"},
@@ -138,7 +139,8 @@ bool IsLaneWayConformedTurnDirection(LaneWay l, TurnDirection t)
       return l == LaneWay::SharpLeft;
     case TurnDirection::TurnSlightLeft:
       return l == LaneWay::SlightLeft;
-    case TurnDirection::UTurn:
+    case TurnDirection::UTurnLeft:
+    case TurnDirection::UTurnRight:
       return l == LaneWay::Reverse;
   }
 }
@@ -163,7 +165,8 @@ bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, TurnDirection t)
       return l == LaneWay::SharpLeft || l == LaneWay::Left;
     case TurnDirection::TurnSlightLeft:
       return l == LaneWay::SlightLeft || l == LaneWay::Through || l == LaneWay::Left;
-    case TurnDirection::UTurn:
+    case TurnDirection::UTurnLeft:
+    case TurnDirection::UTurnRight:
       return l == LaneWay::Reverse;
   }
 }

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -36,7 +36,8 @@ enum class TurnDirection
   TurnSharpLeft,
   TurnSlightLeft,
 
-  UTurn,
+  UTurnLeft,
+  UTurnRight,
 
   TakeTheExit,
 

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -919,16 +919,27 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
       auto const & path = masterSegment.m_path;
       m2::PointD p1 = path[path.size() - 1] - path[path.size() - 2];
       m2::PointD p2 = checkedSegment.m_path[1] - checkedSegment.m_path[0];
+
+      // Same segment UTurn case.
+      if (i == 0)
+      {
+        // TODO Fix direction calculation.
+        // Warning! We can not determine UTurn direction in single edge case. So we use UTurnLeft.
+        // We deside to add driving rules (left-right sided driving) to mwm header.
+        if (p1 == p2)
+        {
+          turn.m_turn = TurnDirection::UTurnLeft;
+          return 1;
+        }
+        // Wide UTurn must have link in it's middle.
+        return 0;
+      }
+
       auto angle = ang::TwoVectorsAngle(m2::PointD::Zero(), p1, p2);
 
       if (!my::AlmostEqualAbs(angle, math::pi, kUTurnHeadingSensitivity))
         return 0;
 
-      if (i == 0)
-      {
-        turn.m_turn = TurnDirection::UTurnLeft;
-        return 0;
-      }
       // Determine turn direction.
       m2::PointD const junctionPoint = masterSegment.m_path.back();
       m2::PointD const ingoingPoint = GetPointForTurn(masterSegment.m_path, junctionPoint,

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -133,7 +133,8 @@ ftypes::HighwayClass GetOutgoingHighwayClass(NodeID outgoingNode,
  * - and the turn is GoStraight or TurnSlight*.
  */
 bool KeepTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possibleTurns,
-                            TurnInfo const & turnInfo, Index const & index, RoutingMapping & mapping)
+                            TurnInfo const & turnInfo, Index const & index,
+                            RoutingMapping & mapping)
 {
   if (!IsGoStraightOrSlightTurn(turn))
     return true;  // The road significantly changes its direction here. So this turn shall be kept.
@@ -147,8 +148,7 @@ bool KeepTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possible
   {
     if (t.node == turnInfo.m_outgoing.m_nodeId)
       continue;
-    ftypes::HighwayClass const highwayClass =
-        GetOutgoingHighwayClass(t.node, mapping, index);
+    ftypes::HighwayClass const highwayClass = GetOutgoingHighwayClass(t.node, mapping, index);
     if (static_cast<int>(highwayClass) > static_cast<int>(maxClassForPossibleTurns))
       maxClassForPossibleTurns = highwayClass;
   }
@@ -309,7 +309,8 @@ TurnDirection FindDirectionByAngle(vector<pair<double, TurnDirection>> const & l
  * \param maxPointsCount returned poit could't be more than maxPointsCount poins away from junctionPoint
  * \param minDistMeters returned point should be minDistMeters away from junctionPoint if ft is long and consists of short segments
  * \param GetPointIndex is a function for getting points by index.
- * It defines a direction of following along a feature. So it differs for ingoing and outgoing cases.
+ * It defines a direction of following along a feature. So it differs for ingoing and outgoing
+ * cases.
  * It has following parameters:
  * - start is an index of the start point of a feature segment. For example, path.back().
  * - end is an index of the end point of a feature segment. For example, path.front().
@@ -319,11 +320,10 @@ TurnDirection FindDirectionByAngle(vector<pair<double, TurnDirection>> const & l
  * shift belongs to a  range [0, abs(end - start)].
  * \return an ingoing or outgoing point for a turn calculation.
  */
-m2::PointD GetPointForTurn(vector<m2::PointD> const & path,
-                           m2::PointD const & junctionPoint,
-                           size_t const maxPointsCount,
-                           double const minDistMeters,
-                           size_t (*GetPointIndex)(const size_t start, const size_t end, const size_t shift))
+m2::PointD GetPointForTurn(vector<m2::PointD> const & path, m2::PointD const & junctionPoint,
+                           size_t const maxPointsCount, double const minDistMeters,
+                           size_t (*GetPointIndex)(const size_t start, const size_t end,
+                                                   const size_t shift))
 {
   double curDistanceMeters = 0.;
   m2::PointD point = junctionPoint;
@@ -338,7 +338,8 @@ m2::PointD GetPointForTurn(vector<m2::PointD> const & path,
     nextPoint = path[GetPointIndex(0, numSegPoints, i)];
 
     // TODO The code below is a stub for compatability with older versions with this function.
-    // Remove it, fix tests cases when it works (integration test RussiaMoscowTTKKashirskoeShosseOutTurnTest)
+    // Remove it, fix tests cases when it works (integration test
+    // RussiaMoscowTTKKashirskoeShosseOutTurnTest)
     // and remove point duplication when we get geometry from feature segments.
     if (point == nextPoint)
       return nextPoint;
@@ -444,14 +445,25 @@ namespace turns
 {
 using TSeg = OsrmMappingTypes::FtSeg;
 
-LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index, RawPathData const & osrmPathSegment) : m_highwayClass(ftypes::HighwayClass::Undefined), m_onRoundabout(false), m_isLink(false), m_weight(osrmPathSegment.segmentWeight), m_nodeId(osrmPathSegment.node)
+LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                                     RawPathData const & osrmPathSegment)
+  : m_highwayClass(ftypes::HighwayClass::Undefined)
+  , m_onRoundabout(false)
+  , m_isLink(false)
+  , m_weight(osrmPathSegment.segmentWeight)
+  , m_nodeId(osrmPathSegment.node)
 {
   buffer_vector<TSeg, 8> buffer;
   mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
-  LoadPathGeometry(buffer, 0, buffer.size(), index, mapping, FeatureGraphNode(), FeatureGraphNode(), false /* isStartNode */, false /*isEndNode*/);
+  LoadPathGeometry(buffer, 0, buffer.size(), index, mapping, FeatureGraphNode(), FeatureGraphNode(),
+                   false /* isStartNode */, false /*isEndNode*/);
 }
 
-void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startK, size_t endK, Index const & index, RoutingMapping & mapping, FeatureGraphNode const & startGraphNode, FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode)
+void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startK,
+                                         size_t endK, Index const & index, RoutingMapping & mapping,
+                                         FeatureGraphNode const & startGraphNode,
+                                         FeatureGraphNode const & endGraphNode, bool isStartNode,
+                                         bool isEndNode)
 {
   for (size_t k = startK; k < endK; ++k)
   {
@@ -471,9 +483,11 @@ void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, 
     auto startIdx = segment.m_pointStart;
     auto endIdx = segment.m_pointEnd;
     if (isStartNode && k == startK && startGraphNode.segment.IsValid())
-      startIdx = (segment.m_pointEnd > segment.m_pointStart) ? startGraphNode.segment.m_pointStart : startGraphNode.segment.m_pointEnd;
+      startIdx = (segment.m_pointEnd > segment.m_pointStart) ? startGraphNode.segment.m_pointStart
+                                                             : startGraphNode.segment.m_pointEnd;
     if (isEndNode && k == endK - 1 && endGraphNode.segment.IsValid())
-      endIdx = (segment.m_pointEnd > segment.m_pointStart) ? endGraphNode.segment.m_pointEnd : endGraphNode.segment.m_pointStart;
+      endIdx = (segment.m_pointEnd > segment.m_pointStart) ? endGraphNode.segment.m_pointEnd
+                                                           : endGraphNode.segment.m_pointStart;
     if (startIdx < endIdx)
     {
       for (auto idx = startIdx; idx <= endIdx; ++idx)
@@ -497,7 +511,8 @@ void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, 
 
       if (!ftypes::IsOneWayChecker::Instance()(ft))
       {
-        directionType = (startIdx < endIdx) ? Metadata::FMD_TURN_LANES_FORWARD : Metadata::FMD_TURN_LANES_BACKWARD;
+        directionType = (startIdx < endIdx) ? Metadata::FMD_TURN_LANES_FORWARD
+                                            : Metadata::FMD_TURN_LANES_BACKWARD;
       }
       ParseLanes(md.Get(directionType), m_lanes);
     }
@@ -512,49 +527,68 @@ void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, 
   }
 }
 
-LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index, RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode, FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode) : m_highwayClass(ftypes::HighwayClass::Undefined), m_onRoundabout(false), m_isLink(false), m_weight(0), m_nodeId(osrmPathSegment.node)
+LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                                     RawPathData const & osrmPathSegment,
+                                     FeatureGraphNode const & startGraphNode,
+                                     FeatureGraphNode const & endGraphNode, bool isStartNode,
+                                     bool isEndNode)
+  : m_highwayClass(ftypes::HighwayClass::Undefined)
+  , m_onRoundabout(false)
+  , m_isLink(false)
+  , m_weight(0)
+  , m_nodeId(osrmPathSegment.node)
 {
   if (!startGraphNode.segment.IsValid() || !endGraphNode.segment.IsValid())
     return;
   buffer_vector<TSeg, 8> buffer;
   mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
 
-  auto FindIntersectingSeg = [&buffer] (TSeg const & seg) -> size_t
+  auto FindIntersectingSeg = [&buffer](TSeg const & seg) -> size_t
   {
     ASSERT(seg.IsValid(), ());
-    auto const it = find_if(buffer.begin(), buffer.end(), [&seg] (OsrmMappingTypes::FtSeg const & s)
-    {
-      return s.IsIntersect(seg);
-    });
+    auto const it = find_if(buffer.begin(), buffer.end(), [&seg](OsrmMappingTypes::FtSeg const & s)
+                            {
+                              return s.IsIntersect(seg);
+                            });
 
     ASSERT(it != buffer.end(), ());
     return distance(buffer.begin(), it);
   };
 
   // Calculate estimated time for a start and a end node cases.
-  // Multiplier -1 because a whole node weight is already in esimated time, and we need to substruct time
-  // form a node start to a user point.
   if (isStartNode)
   {
-    m_weight = (osrmPathSegment.node == startGraphNode.node.forward_node_id) ? startGraphNode.node.GetForwardWeightPlusOffset() : startGraphNode.node.GetReverseWeightPlusOffset();
+    m_weight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
+                   ? startGraphNode.node.GetForwardWeightPlusOffset()
+                   : startGraphNode.node.GetReverseWeightPlusOffset();
   }
   if (isEndNode)
   {
-    m_weight = (osrmPathSegment.node == endGraphNode.node.forward_node_id) ? endGraphNode.node.GetForwardWeightPlusOffset() : endGraphNode.node.GetReverseWeightPlusOffset();
+    m_weight = (osrmPathSegment.node == endGraphNode.node.forward_node_id)
+                   ? endGraphNode.node.GetForwardWeightPlusOffset()
+                   : endGraphNode.node.GetReverseWeightPlusOffset();
   }
 
- if (isStartNode && isEndNode)
+  if (isStartNode && isEndNode)
   {
-    double const forwardWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id) ? startGraphNode.node.forward_weight : startGraphNode.node.reverse_weight;
-    double const backwardWeight = (osrmPathSegment.node == endGraphNode.node.forward_node_id) ? endGraphNode.node.forward_weight : endGraphNode.node.reverse_weight;
-    double const wholeWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id) ? startGraphNode.node.forward_offset : startGraphNode.node.reverse_offset;
-    // Sum because weights in forward/backward_weight fields are negative. Look osrm_helpers for more info.
+    double const forwardWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
+                                     ? startGraphNode.node.forward_weight
+                                     : startGraphNode.node.reverse_weight;
+    double const backwardWeight = (osrmPathSegment.node == endGraphNode.node.forward_node_id)
+                                      ? endGraphNode.node.forward_weight
+                                      : endGraphNode.node.reverse_weight;
+    double const wholeWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
+                                   ? startGraphNode.node.forward_offset
+                                   : startGraphNode.node.reverse_offset;
+    // Sum because weights in forward/backward_weight fields are negative. Look osrm_helpers for
+    // more info.
     m_weight = wholeWeight + forwardWeight + backwardWeight;
   }
 
   size_t startK = isStartNode ? FindIntersectingSeg(startGraphNode.segment) : 0;
   size_t endK = isEndNode ? FindIntersectingSeg(endGraphNode.segment) + 1 : buffer.size();
-  LoadPathGeometry(buffer, startK, endK, index, mapping, startGraphNode, endGraphNode, isStartNode, isEndNode);
+  LoadPathGeometry(buffer, startK, endK, index, mapping, startGraphNode, endGraphNode, isStartNode,
+                   isEndNode);
 }
 
 bool TurnInfo::IsSegmentsValid() const
@@ -765,7 +799,8 @@ TurnDirection IntermediateDirection(const double angle)
   return FindDirectionByAngle(kLowerBounds, angle);
 }
 
-void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & turnInfo, TurnItem & turn)
+void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & turnInfo,
+                      TurnItem & turn)
 {
   if (!turnInfo.IsSegmentsValid())
     return;
@@ -819,7 +854,7 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & 
       turn.m_turn = intermediateDirection;
   }
 
-  bool const keepTurnByHighwayClass = KeepTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
+  bool const keepTurnByHighwayClass =  KeepTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
   if (turnInfo.m_ingoing.m_onRoundabout || turnInfo.m_outgoing.m_onRoundabout)
   {
     turn.m_turn = GetRoundaboutDirection(turnInfo.m_ingoing.m_onRoundabout,
@@ -834,10 +869,9 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & 
     return;
   }
 
-  auto const notSoCloseToTheTurnPoint = GetPointForTurn(turnInfo.m_ingoing.m_path, junctionPoint,
-                                                        kNotSoCloseMaxPointsCount,
-                                                        kNotSoCloseMinDistMeters,
-                                                        GetIngoingPointIndex);
+  auto const notSoCloseToTheTurnPoint =
+      GetPointForTurn(turnInfo.m_ingoing.m_path, junctionPoint, kNotSoCloseMaxPointsCount,
+                      kNotSoCloseMinDistMeters, GetIngoingPointIndex);
 
   if (!KeepTurnByIngoingEdges(junctionPoint, notSoCloseToTheTurnPoint, outgoingPoint, hasMultiTurns,
                               mapping, index))

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -890,7 +890,7 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & 
 
 size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t currentSegment, TurnItem & turn)
 {
-  size_t constexpr kUTurnLookAhead = 5;
+  size_t constexpr kUTurnLookAhead = 3;
   double const kUTurnHeadingSensitivity = math::pi / 10.0;
 
   ASSERT_GREATER(segments.size(), 1, ());
@@ -929,6 +929,10 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
         else
           turn.m_turn = TurnDirection::UTurnRight;
         return ++i;
+      }
+      else
+      {
+        return 0;
       }
     }
   }

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -543,7 +543,7 @@ LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & ind
   , m_weight(0)
   , m_nodeId(osrmPathSegment.node)
 {
-  ASSERT(isStartNode || isEndNode, ("This function process only side cases."));
+  ASSERT(isStartNode || isEndNode, ("This function process only corner cases."));
   if (!startGraphNode.segment.IsValid() || !endGraphNode.segment.IsValid())
     return;
   buffer_vector<TSeg, 8> buffer;
@@ -581,13 +581,13 @@ LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & ind
   {
     PhantomNode const * node = nullptr;
     if (isStartNode)
-        node = &startGraphNode.node;
-    else if (isEndNode)
-        node = &endGraphNode.node;
+      node = &startGraphNode.node;
+    if (isEndNode)
+      node = &endGraphNode.node;
     if (node)
     {
-        m_weight = (osrmPathSegment.node == node->forward_weight)
-                     ? node->GetForwardWeightPlusOffset() : node->GetReverseWeightPlusOffset();
+      m_weight = (osrmPathSegment.node == node->forward_weight)
+                  ? node->GetForwardWeightPlusOffset() : node->GetReverseWeightPlusOffset();
     }
   }
 
@@ -909,7 +909,7 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
   // Roundabout is not the UTurn.
   if (masterSegment.m_onRoundabout)
     return 0;
-  for (size_t i = 0; i < min(kUTurnLookAhead, segments.size() - currentSegment); ++i)
+  for (size_t i = 0; i < kUTurnLookAhead && i + currentSegment < segments.size(); ++i)
   {
     auto const & checkedSegment = segments[currentSegment + i];
     if (checkedSegment.m_name == masterSegment.m_name &&
@@ -925,7 +925,7 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
       {
         // TODO Fix direction calculation.
         // Warning! We can not determine UTurn direction in single edge case. So we use UTurnLeft.
-        // We deside to add driving rules (left-right sided driving) to mwm header.
+        // We decided to add driving rules (left-right sided driving) to mwm header.
         if (p1 == p2)
         {
           turn.m_turn = TurnDirection::UTurnLeft;

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -143,5 +143,11 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
 void GetTurnDirection(Index const & index, RoutingMapping & mapping, turns::TurnInfo & turnInfo,
                       TurnItem & turn);
 
+/*!
+ * \brief Finds UTurn started from current segment and returns how many segments it lasts.
+ * Returns 0 otherwise.
+ */
+size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t currentSegment, TurnItem & turn);
+
 }  // namespace routing
 }  // namespace turns

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -45,15 +45,20 @@ struct LoadedPathSegment
   vector<SingleLaneInfo> m_lanes;
 
   // General constructor.
-  LoadedPathSegment(RoutingMapping & mapping, Index const & index, RawPathData const & osrmPathSegment);
+  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                    RawPathData const & osrmPathSegment);
   // Spesial constructor for side nodes. Splits OSRM node by information from the FeatureGraphNode.
-  LoadedPathSegment(RoutingMapping & mapping, Index const & index, RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode, FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
+  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                    RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode,
+                    FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
   LoadedPathSegment() = delete;
 
 private:
-  void LoadPathGeometry(buffer_vector<OsrmMappingTypes::FtSeg, 8> const & buffer, size_t startK, size_t endK, Index const & index, RoutingMapping & mapping, FeatureGraphNode const & startGraphNode, FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
+  void LoadPathGeometry(buffer_vector<OsrmMappingTypes::FtSeg, 8> const & buffer, size_t startK,
+                        size_t endK, Index const & index, RoutingMapping & mapping,
+                        FeatureGraphNode const & startGraphNode,
+                        FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
 };
-
 
 /*!
  * \brief The TurnInfo struct is a representation of a junction.
@@ -64,7 +69,10 @@ struct TurnInfo
   LoadedPathSegment const & m_ingoing;
   LoadedPathSegment const & m_outgoing;
 
-  TurnInfo(LoadedPathSegment const & ingoingSegment, LoadedPathSegment const & outgoingSegment) : m_ingoing(ingoingSegment), m_outgoing(outgoingSegment) {}
+  TurnInfo(LoadedPathSegment const & ingoingSegment, LoadedPathSegment const & outgoingSegment)
+    : m_ingoing(ingoingSegment), m_outgoing(outgoingSegment)
+  {
+  }
 
   bool IsSegmentsValid() const;
 };
@@ -132,7 +140,8 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
  * \param turnInfo is used for cashing some information while turn calculation.
  * \param turn is used for keeping the result of turn calculation.
  */
-void GetTurnDirection(Index const & index, RoutingMapping & mapping, turns::TurnInfo & turnInfo, TurnItem & turn);
+void GetTurnDirection(Index const & index, RoutingMapping & mapping, turns::TurnInfo & turnInfo,
+                      TurnItem & turn);
 
 }  // namespace routing
 }  // namespace turns

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -148,6 +148,5 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, turns::Turn
  * Returns 0 otherwise.
  */
 size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t currentSegment, TurnItem & turn);
-
 }  // namespace routing
 }  // namespace turns

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -51,7 +51,6 @@ struct LoadedPathSegment
   LoadedPathSegment(RoutingMapping & mapping, Index const & index,
                     RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode,
                     FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
-  LoadedPathSegment() = delete;
 
 private:
   // Load information about road, that described as the sequence of FtSegs and start/end indexes in

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -29,8 +29,8 @@ namespace turns
 using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
 
 /*!
- * \brief The LoadedPathSegment struct is a representation for a single osrm node path.
- * It unpacks all necessary information about path and stores it inside this structure.
+ * \brief The LoadedPathSegment struct is a representation of a single osrm node path.
+ * It unpacks and stores information about path and road type flags.
  * Postprocessing must read information from the structure and does not initiate disk readings.
  */
 struct LoadedPathSegment
@@ -47,22 +47,24 @@ struct LoadedPathSegment
   // General constructor.
   LoadedPathSegment(RoutingMapping & mapping, Index const & index,
                     RawPathData const & osrmPathSegment);
-  // Spesial constructor for side nodes. Splits OSRM node by information from the FeatureGraphNode.
+  // Special constructor for side nodes. Splits OSRM node by information from the FeatureGraphNode.
   LoadedPathSegment(RoutingMapping & mapping, Index const & index,
                     RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode,
                     FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
   LoadedPathSegment() = delete;
 
 private:
-  void LoadPathGeometry(buffer_vector<OsrmMappingTypes::FtSeg, 8> const & buffer, size_t startK,
-                        size_t endK, Index const & index, RoutingMapping & mapping,
+  // Load information about road, that described as the sequence of FtSegs and start/end indexes in
+  // in it. For the side case, it has information about start/end graph nodes.
+  void LoadPathGeometry(buffer_vector<OsrmMappingTypes::FtSeg, 8> const & buffer, size_t startIndex,
+                        size_t endIndex, Index const & index, RoutingMapping & mapping,
                         FeatureGraphNode const & startGraphNode,
                         FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
 };
 
 /*!
  * \brief The TurnInfo struct is a representation of a junction.
- * It has ingoing and outgoing edges and method to check if this edges are valid.
+ * It has ingoing and outgoing edges and method to check if these edges are valid.
  */
 struct TurnInfo
 {
@@ -144,8 +146,9 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, turns::Turn
                       TurnItem & turn);
 
 /*!
- * \brief Finds UTurn started from current segment and returns how many segments it lasts.
- * Returns 0 otherwise.
+ * \brief Finds an UTurn that starts from current segment and returns how many segments it lasts.
+ * Returns 0 if there is no UTurn.
+ * Warning! currentSegment must be greater than 0.
  */
 size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t currentSegment, TurnItem & turn);
 }  // namespace routing

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -147,7 +147,8 @@ string GetDirectionTextId(Notification const & notification)
       return "make_a_sharp_left_turn";
     case TurnDirection::TurnSlightLeft:
       return "make_a_slight_left_turn";
-    case TurnDirection::UTurn:
+    case TurnDirection::UTurnLeft:
+    case TurnDirection::UTurnRight:
       return "make_a_u_turn";
     case TurnDirection::EnterRoundAbout:
       return "enter_the_roundabout";

--- a/std/cmath.hpp
+++ b/std/cmath.hpp
@@ -13,10 +13,10 @@
 
 namespace math
 {
-  static const double pi = 3.14159265358979323846;
-  static const double pi2 = pi / 2.;
-  static const double pi4 = pi / 4.;
-  static const double twicePi = 2. * pi;
+  double constexpr pi = 3.14159265358979323846;
+  double constexpr pi2 = pi / 2.;
+  double constexpr pi4 = pi / 4.;
+  double constexpr twicePi = 2. * pi;
 
   template <class T> T sqr(T t) { return (t*t); }
 }


### PR DESCRIPTION
https://trello.com/c/FCT2moyo/2050--

Добавляет поддержку разворотов в легенду для роутинга. Для того чтобы добавить эту функциональность, пришлось провести рефакторинг процедур построения легенды маршрута.
PR добавляет 2 состояния разворота : UTurnLeft и UTurnRight (для стран с правосторонним движением).