### PR TITLE
[drape] Fixed overlay priority comparison for text path shapes

### DIFF
--- a/drape/overlay_handle.hpp
+++ b/drape/overlay_handle.hpp
@@ -26,6 +26,12 @@ enum OverlayRank
   OverlayRanksCount
 };
 
+uint64_t constexpr kPriorityMaskZoomLevel = 0xFF0000000000FFFF;
+uint64_t constexpr kPriorityMaskManual    = 0x00FFFFFFFF00FFFF;
+uint64_t constexpr kPriorityMaskRank      = 0x0000000000FFFFFF;
+uint64_t constexpr kPriorityMaskAll = kPriorityMaskZoomLevel |
+                                      kPriorityMaskManual |
+                                      kPriorityMaskRank;
 class OverlayHandle
 {
 public:
@@ -58,6 +64,8 @@ public:
 
   FeatureID const & GetFeatureID() const;
   uint64_t const & GetPriority() const;
+
+  virtual uint64_t GetPriorityMask() const { return kPriorityMaskAll; }
 
   virtual bool IsBound() const { return false; }
 

--- a/drape/overlay_tree.cpp
+++ b/drape/overlay_tree.cpp
@@ -24,8 +24,9 @@ public:
 
   bool IsGreater(ref_ptr<OverlayHandle> const & l, ref_ptr<OverlayHandle> const & r) const
   {
-    uint64_t const priorityLeft = l->GetPriority();
-    uint64_t const priorityRight = r->GetPriority();
+    uint64_t const mask = l->GetPriorityMask() & r->GetPriorityMask();
+    uint64_t const priorityLeft = l->GetPriority() & mask;
+    uint64_t const priorityRight = r->GetPriority() & mask;
     if (priorityLeft > priorityRight)
       return true;
 

--- a/drape_frontend/path_text_shape.cpp
+++ b/drape_frontend/path_text_shape.cpp
@@ -84,6 +84,11 @@ public:
     TextHandle::GetAttributeMutation(mutator, screen);
   }
 
+  uint64_t GetPriorityMask() const override
+  {
+    return dp::kPriorityMaskManual | dp::kPriorityMaskRank;
+  }
+
 private:
   m2::SharedSpline m_spline;
   m2::Spline::iterator m_centerPointIter;


### PR DESCRIPTION
- Добавлены маски для сравнения оверлеев;
- Текста на дорогах теперь сравниваются без учета минимального уровня зума.