### PR TITLE
[platform] Do not add/register maps newer than App.

### DIFF
--- a/platform/local_country_file_utils.cpp
+++ b/platform/local_country_file_utils.cpp
@@ -198,7 +198,7 @@ void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> 
   {
     string const & subdir = fwt.first;
     int64_t version;
-    if (!ParseVersion(subdir, version))
+    if (!ParseVersion(subdir, version) || version > latestVersion)
       continue;
 
     string const fullPath = my::JoinFoldersToPath(dir, subdir);

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -159,7 +159,7 @@ UNIT_TEST(LocalCountryFile_CleanupMapFiles)
 
   // Check FindAllLocalMaps()
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(-1 /* latestVersion */, localFiles);
+  FindAllLocalMapsAndCleanup(4 /* latestVersion */, localFiles);
   TEST(!Contains(localFiles, japanLocalFile), (japanLocalFile, localFiles));
   TEST(!Contains(localFiles, brazilLocalFile), (brazilLocalFile, localFiles));
   TEST(Contains(localFiles, irelandLocalFile), (irelandLocalFile, localFiles));
@@ -270,7 +270,7 @@ UNIT_TEST(LocalCountryFile_AllLocalFilesLookup)
   ScopedFile testItalyMapFile(testDir, italyFile, MapOptions::Map, "Italy-map");
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(-1 /* latestVersion */, localFiles);
+  FindAllLocalMapsAndCleanup(10101 /* latestVersion */, localFiles);
   multiset<LocalCountryFile> localFilesSet(localFiles.begin(), localFiles.end());
 
   bool worldFound = false;

--- a/routing/routing_integration_tests/cross_section_tests.cpp
+++ b/routing/routing_integration_tests/cross_section_tests.cpp
@@ -10,6 +10,8 @@
 
 #include "base/logging.hpp"
 
+#include "std/limits.hpp"
+
 using namespace routing;
 
 namespace
@@ -18,7 +20,8 @@ UNIT_TEST(CheckCrossSections)
 {
   static double constexpr kPointEquality = 0.01;
   vector<platform::LocalCountryFile> localFiles;
-  platform::FindAllLocalMapsAndCleanup(-1 /* latestVersion */, localFiles);
+  platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
+                                       localFiles);
 
   size_t ingoingErrors = 0;
   size_t outgoingErrors = 0;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -24,6 +24,8 @@
 
 #include "geometry/distance_on_sphere.hpp"
 
+#include "std/limits.hpp"
+
 #include "private.h"
 
 #include <sys/resource.h>
@@ -159,7 +161,8 @@ namespace integration
       pl.SetResourceDir(options.m_resourcePath);
 
     vector<LocalCountryFile> localFiles;
-    platform::FindAllLocalMapsAndCleanup(-1, localFiles);
+    platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
+                                         localFiles);
     for (auto & file : localFiles)
       file.SyncWithDisk();
     ASSERT(!localFiles.empty(), ());


### PR DESCRIPTION
https://trello.com/c/ou4IMisg/2063-ui

This is wrong to try to add maps newer than the app, because:
* Newer maps can not be supported by the app, but all older maps already have been deleted.
* Even if they're supported by the app, it'll be suggested to user to update them, because app version is not equal to newer maps version. All these updates will be discarded after downloading.
