### PR TITLE
Fixed drape qmake dependencies.

### DIFF
--- a/drape/drape.pro
+++ b/drape/drape.pro
@@ -2,8 +2,6 @@ TARGET = drape
 TEMPLATE = lib
 CONFIG += staticlib warn_on
 
-DEPENDENCIES = base
-
 ROOT_DIR = ..
 SHADER_COMPILE_ARGS = $$PWD/shaders shader_index.txt shader_def
 include($$ROOT_DIR/common.pri)

--- a/drape_frontend/drape_frontend.pro
+++ b/drape_frontend/drape_frontend.pro
@@ -2,7 +2,6 @@ TARGET = drape_frontend
 TEMPLATE = lib
 CONFIG += staticlib
 
-DEPENDENCIES = drape base
 ROOT_DIR = ..
 include($$ROOT_DIR/common.pri)
 


### PR DESCRIPTION
It should fix build errors on Drape.
Technically, libraries do not depend on each other and can be built in parallel. Dependencies are needed only when libraries are linked to any executable.