### PR TITLE
Removed not needed dependencies for static libraries, which only slow down the build.

### DIFF
--- a/drape/drape.pro
+++ b/drape/drape.pro
@@ -2,8 +2,6 @@ TARGET = drape
 TEMPLATE = lib
 CONFIG += staticlib warn_on
 
-DEPENDENCIES = base
-
 ROOT_DIR = ..
 SHADER_COMPILE_ARGS = $$PWD/shaders shader_index.txt shader_def
 include($$ROOT_DIR/common.pri)

--- a/drape_frontend/drape_frontend.pro
+++ b/drape_frontend/drape_frontend.pro
@@ -2,7 +2,6 @@ TARGET = drape_frontend
 TEMPLATE = lib
 CONFIG += staticlib
 
-DEPENDENCIES = drape base
 ROOT_DIR = ..
 include($$ROOT_DIR/common.pri)
 

--- a/generator/generator_tests_support/generator_tests_support.pro
+++ b/generator/generator_tests_support/generator_tests_support.pro
@@ -3,8 +3,6 @@ TEMPLATE = lib
 CONFIG += staticlib warn_on
 
 ROOT_DIR = ../..
-DEPENDENCIES = generator map routing indexer platform geometry coding base \
-               expat tess2 protobuf tomcrypt osrm succinct
 
 include($$ROOT_DIR/common.pri)
 

--- a/stats/stats.pro
+++ b/stats/stats.pro
@@ -7,8 +7,6 @@ CONFIG += staticlib
 ROOT_DIR = ..
 include($$ROOT_DIR/common.pri)
 
-DEPENDENCIES =
-
 SOURCES += $$ROOT_DIR/3party/Alohalytics/src/cpp/alohalytics.cc \
 
 HEADERS += $$ROOT_DIR/3party/Alohalytics/src/alohalytics.h \


### PR DESCRIPTION
Static libs don't need our DEPENDENCIES macro. It should be used for binaries projects only.