### PR TITLE
String to timestamp and timestamp to string

### DIFF
--- a/base/base.pro
+++ b/base/base.pro
@@ -30,6 +30,7 @@ SOURCES += \
     thread_checker.cpp \
     thread_pool.cpp \
     threaded_container.cpp \
+    timegm.cpp \
     timer.cpp \
 
 HEADERS += \
@@ -80,5 +81,6 @@ HEADERS += \
     threaded_container.hpp \
     threaded_list.hpp \
     threaded_priority_queue.hpp \
+    timegm.hpp \
     timer.hpp \
     worker_thread.hpp \

--- a/base/base_tests/base_tests.pro
+++ b/base/base_tests/base_tests.pro
@@ -37,6 +37,7 @@ SOURCES += \
   thread_pool_tests.cpp \
   threaded_list_test.cpp \
   threads_test.cpp \
+  timegm_test.cpp \
   timer_test.cpp \
   worker_thread_test.cpp \
 

--- a/base/base_tests/timegm_test.cpp
+++ b/base/base_tests/timegm_test.cpp
@@ -1,0 +1,27 @@
+#include "testing/testing.hpp"
+
+#include "std/ctime.hpp"
+
+#include "base/timegm.hpp"
+
+UNIT_TEST(TimegmTest)
+{
+  std::tm tm1{};
+  std::tm tm2{};
+
+  TEST(strptime("2016-05-17 07:10", "%Y-%m-%d %H:%M", &tm1), ());
+  TEST(strptime("2016-05-17 07:10", "%Y-%m-%d %H:%M", &tm2), ());
+  TEST_EQUAL(timegm(&tm1), base::TimeGM(tm2), ());
+
+  TEST(strptime("2016-03-12 11:10", "%Y-%m-%d %H:%M", &tm1), ());
+  TEST(strptime("2016-03-12 11:10", "%Y-%m-%d %H:%M", &tm2), ());
+  TEST_EQUAL(timegm(&tm1), base::TimeGM(tm2), ());
+
+  TEST(strptime("1970-01-01 00:00", "%Y-%m-%d %H:%M", &tm1), ());
+  TEST(strptime("1970-01-01 00:00", "%Y-%m-%d %H:%M", &tm2), ());
+  TEST_EQUAL(timegm(&tm1), base::TimeGM(tm2), ());
+
+  TEST(strptime("2012-12-02 21:08:34", "%Y-%m-%d %H:%M:%S", &tm1), ());
+  TEST(strptime("2012-12-02 21:08:34", "%Y-%m-%d %H:%M:%S", &tm2), ());
+  TEST_EQUAL(timegm(&tm1), base::TimeGM(tm2), ());
+}

--- a/base/base_tests/timer_test.cpp
+++ b/base/base_tests/timer_test.cpp
@@ -29,6 +29,7 @@ UNIT_TEST(Timer_TimestampConversion)
 
   TEST_EQUAL(TimestampToString(0), "1970-01-01T00:00:00Z", ());
   TEST_EQUAL(TimestampToString(1354482514), "2012-12-02T21:08:34Z", ());
+
   TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00Z"), 0, ());
   TEST_EQUAL(StringToTimestamp("2012-12-02T21:08:34Z"), 1354482514, ());
   TEST_EQUAL(StringToTimestamp("2012-12-03T00:38:34+03:30"), 1354482514, ());

--- a/base/timegm.cpp
+++ b/base/timegm.cpp
@@ -1,0 +1,57 @@
+#include "timegm.hpp"
+
+// There are issues with this implementation due to absence
+// of time_t fromat specification. There are no guarantees
+// of its internal structure so we cannot rely on + or -.
+
+// It could be possible to substitute time_t with boost::ptime
+// in contexts where we need some arithmetical and logical operations
+// on time and we don't have to use precisely time_t.
+
+namespace
+{
+// Number of days elapsed since Jan 01 up to each month
+// (except for February in leap years).
+int const g_monoff[] = {
+  0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+};
+
+bool IsLeapYear(int year)
+{
+  return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+int LeapDaysCount(int y1, int y2)
+{
+  --y1;
+  --y2;
+  return (y2/4 - y1/4) - (y2/100 - y1/100) + (y2/400 - y1/400);
+}
+} // namespace
+
+namespace base
+{
+// Inspired by python's calendar.py
+time_t TimeGM(std::tm const & tm)
+{
+  int year;
+  time_t days;
+  time_t hours;
+  time_t minutes;
+  time_t seconds;
+
+  year = 1900 + tm.tm_year;
+  days = 365 * (year - 1970) + LeapDaysCount(1970, year);
+  days += g_monoff[tm.tm_mon];
+
+  if (tm.tm_mon > 1 && IsLeapYear(year))
+    ++days;
+  days += tm.tm_mday - 1;
+
+  hours = days * 24 + tm.tm_hour;
+  minutes = hours * 60 + tm.tm_min;
+  seconds = minutes * 60 + tm.tm_sec;
+
+  return seconds;
+}
+} // namespace base

--- a/base/timegm.hpp
+++ b/base/timegm.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "std/ctime.hpp"
+
+// For some reasons android doesn't have timegm function. The following
+// work around is provided.
+namespace base
+{
+time_t TimeGM(std::tm const & tm);
+}


### PR DESCRIPTION
timegm() is not a standard function and may be missed on some platforms.
This request provides custom realization.
