### PR TITLE
[routing] iOS no memory routing fix.

### DIFF
--- a/routing/osrm_data_facade.hpp
+++ b/routing/osrm_data_facade.hpp
@@ -272,6 +272,10 @@ public:
   {
     Clear();
 
+    // Load huge data first.
+    m_handleFanoMatrix.Assign(container.Map(ROUTING_MATRIX_FILE_TAG));
+    ASSERT(m_handleFanoMatrix.IsValid(), ());
+
     m_handleEdgeData.Assign(container.Map(ROUTING_EDGEDATA_FILE_TAG));
     ASSERT(m_handleEdgeData.IsValid(), ());
 
@@ -281,11 +285,7 @@ public:
     m_handleShortcuts.Assign(container.Map(ROUTING_SHORTCUTS_FILE_TAG));
     ASSERT(m_handleShortcuts.IsValid(), ());
 
-    m_handleFanoMatrix.Assign(container.Map(ROUTING_MATRIX_FILE_TAG));
-    ASSERT(m_handleFanoMatrix.IsValid(), ());
-
     LoadRawData(m_handleEdgeData.GetData<char>(), m_handleEdgeId.GetData<char>(), m_handleShortcuts.GetData<char>(), m_handleFanoMatrix.GetData<char>());
-
   }
 
   void Clear()

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -222,7 +222,6 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
                                                   RouterDelegate const & delegate, Route & route)
 {
   my::HighResTimer timer(true);
-  m_indexManager.Clear();  // TODO (Dragunov) make proper index manager cleaning
 
   TRoutingMappingPtr startMapping = m_indexManager.GetMappingByPoint(startPoint);
   TRoutingMappingPtr targetMapping = m_indexManager.GetMappingByPoint(finalPoint);
@@ -285,6 +284,9 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
 
   // 4. Find route.
   RawRoutingResult routingResult;
+
+  // Manually load facade to avoid unmaping files we routing on.
+  startMapping->LoadFacade();
 
   // 4.1 Single mwm case
   if (startMapping->GetMwmId() == targetMapping->GetMwmId())


### PR DESCRIPTION
PR не выгружает роутинг индексы текущей карты, чтобы роутингу на 7ой iOS хватало памяти при перестроении маршрута.