### PR TITLE
Nomem routing fix.

### DIFF
--- a/coding/file_container.cpp
+++ b/coding/file_container.cpp
@@ -4,6 +4,7 @@
 #include "coding/internal/file_data.hpp"
 
 #ifndef OMIM_OS_WINDOWS
+  #include <errno.h>
   #include <unistd.h>
   #include <sys/mman.h>
   #include <sys/stat.h>
@@ -169,7 +170,7 @@ MappedFile::Handle MappedFile::Map(uint64_t offset, uint64_t size, string const 
 #else
   void * pMap = mmap(0, length, PROT_READ, MAP_SHARED, m_fd, alignedOffset);
   if (pMap == MAP_FAILED)
-    MYTHROW(Reader::OpenException, ("Can't map section:", tag, "with [offset, size]:", offset, size, "errno:", errno));
+    MYTHROW(Reader::OpenException, ("Can't map section:", tag, "with [offset, size]:", offset, size, "errno:", strerror(errno)));
 #endif
 
   char const * data = reinterpret_cast<char const *>(pMap);

--- a/coding/file_container.cpp
+++ b/coding/file_container.cpp
@@ -169,7 +169,7 @@ MappedFile::Handle MappedFile::Map(uint64_t offset, uint64_t size, string const 
 #else
   void * pMap = mmap(0, length, PROT_READ, MAP_SHARED, m_fd, alignedOffset);
   if (pMap == MAP_FAILED)
-    MYTHROW(Reader::OpenException, ("Can't map section:", tag, "with [offset, size]:", offset, size));
+    MYTHROW(Reader::OpenException, ("Can't map section:", tag, "with [offset, size]:", offset, size, "errno:", errno));
 #endif
 
   char const * data = reinterpret_cast<char const *>(pMap);

--- a/coding/file_container.cpp
+++ b/coding/file_container.cpp
@@ -5,6 +5,7 @@
 
 #ifndef OMIM_OS_WINDOWS
   #include <errno.h>
+  #include <stdio.h>
   #include <unistd.h>
   #include <sys/mman.h>
   #include <sys/stat.h>

--- a/routing/osrm_data_facade.hpp
+++ b/routing/osrm_data_facade.hpp
@@ -272,7 +272,7 @@ public:
   {
     Clear();
 
-    // Load huge data first.
+    // Map huge data first, as we hope it will reduce fragmentation of the program address space.
     m_handleFanoMatrix.Assign(container.Map(ROUTING_MATRIX_FILE_TAG));
     ASSERT(m_handleFanoMatrix.IsValid(), ());
 

--- a/routing/osrm_data_facade.hpp
+++ b/routing/osrm_data_facade.hpp
@@ -272,6 +272,10 @@ public:
   {
     Clear();
 
+    // Load huge data first.
+    m_handleFanoMatrix.Assign(container.Map(ROUTING_MATRIX_FILE_TAG));
+    ASSERT(m_handleFanoMatrix.IsValid(), ());
+
     m_handleEdgeData.Assign(container.Map(ROUTING_EDGEDATA_FILE_TAG));
     ASSERT(m_handleEdgeData.IsValid(), ());
 
@@ -281,11 +285,7 @@ public:
     m_handleShortcuts.Assign(container.Map(ROUTING_SHORTCUTS_FILE_TAG));
     ASSERT(m_handleShortcuts.IsValid(), ());
 
-    m_handleFanoMatrix.Assign(container.Map(ROUTING_MATRIX_FILE_TAG));
-    ASSERT(m_handleFanoMatrix.IsValid(), ());
-
     LoadRawData(m_handleEdgeData.GetData<char>(), m_handleEdgeId.GetData<char>(), m_handleShortcuts.GetData<char>(), m_handleFanoMatrix.GetData<char>());
-
   }
 
   void Clear()

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -222,7 +222,6 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
                                                   RouterDelegate const & delegate, Route & route)
 {
   my::HighResTimer timer(true);
-  m_indexManager.Clear();  // TODO (Dragunov) make proper index manager cleaning
 
   TRoutingMappingPtr startMapping = m_indexManager.GetMappingByPoint(startPoint);
   TRoutingMappingPtr targetMapping = m_indexManager.GetMappingByPoint(finalPoint);
@@ -285,6 +284,9 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
 
   // 4. Find route.
   RawRoutingResult routingResult;
+
+  // Manually load facade to avoid unmaping files we routing on.
+  startMapping->LoadFacade();
 
   // 4.1 Single mwm case
   if (startMapping->GetMwmId() == targetMapping->GetMwmId())


### PR DESCRIPTION
https://github.com/mapsme/omim/issues/654
We will not unmap the routing facade for the current map while routing is active. iOS7 often returns NOMEM error when we are trying to map the fano matrix section. 