### PR TITLE
[drape] Free tile info immediately on cancel.

### DIFF
--- a/drape_frontend/read_mwm_task.hpp
+++ b/drape_frontend/read_mwm_task.hpp
@@ -9,6 +9,7 @@
 #endif
 
 #include "std/shared_ptr.hpp"
+#include "std/weak_ptr.hpp"
 
 namespace df
 {
@@ -24,10 +25,11 @@ public:
   void Init(shared_ptr<TileInfo> const & tileInfo);
   void Reset() override;
   bool IsCancelled() const override;
-  TileKey GetTileKey() const;
+  TileKey const & GetTileKey() const { return m_tileKey; }
 
 private:
-  shared_ptr<TileInfo> m_tileInfo;
+  weak_ptr<TileInfo> m_tileInfo;
+  TileKey m_tileKey;
   MemoryFeatureIndex & m_memIndex;
   MapDataProvider & m_model;
 


### PR DESCRIPTION
Использование weak_ptr внутри таски, чтобы не держать память под уже ненужный TileInfo.