### PR TITLE
[generator] Multiple fixes, mostly for routing

### DIFF
--- a/tools/unix/find_generator_tool.sh
+++ b/tools/unix/find_generator_tool.sh
@@ -10,13 +10,17 @@ OMIM_PATH="${OMIM_PATH:-$(cd "$(dirname "$0")/../.."; pwd)}"
 
 if [ -z "${GENERATOR_TOOL-}" -o ! -x "${GENERATOR_TOOL-}" ]; then
   IT_PATHS_ARRAY=()
-  for i in ${BUILD_PATH-} $OMIM_PATH $OMIM_PATH/../*omim*elease* $OMIM_PATH/../*omim*ebug; do
+  for i in "${BUILD_PATH-}" "$OMIM_PATH" "$OMIM_PATH/.."/*omim*elease* "$OMIM_PATH/.."/*omim*ebug; do
     if [ -d "$i/out" ]; then
       IT_PATHS_ARRAY+=("$i/out/release/generator_tool" "$i/out/debug/generator_tool")
     fi
   done
 
-  for i in "${BUILD_PATH:+$BUILD_PATH/generator_tool}" ${IT_PATHS_ARRAY[@]}; do
+  if [ -d "$OMIM_PATH/../omim-xcode-build" ]; then
+    IT_PATHS_ARRAY+=("$OMIM_PATH/../omim-xcode-build/Release" "$OMIM_PATH/../omim-xcode-build/Debug")
+  fi
+
+  for i in "${BUILD_PATH:+$BUILD_PATH/generator_tool}" "${IT_PATHS_ARRAY[@]}"; do
     if [ -x "$i" ]; then
       GENERATOR_TOOL="$i"
       break

--- a/tools/unix/generate_planet_routing.sh
+++ b/tools/unix/generate_planet_routing.sh
@@ -3,6 +3,8 @@
 # Builds routing indices for given regions #
 ############################################
 
+set -e # Exit when any of commands fail
+set -o pipefail # Capture all errors in command chains
 set -u # Fail on undefined variables
 #set -x # Echo every script line
 
@@ -22,43 +24,41 @@ fail() {
 }
 
 OMIM_PATH="${OMIM_PATH:-$(cd "$(dirname "$0")/../.."; pwd)}"
-BORDERS_PATH="${BORDERS_PATH:-$OMIM_PATH/data/borders}"
-TARGET="${TARGET:-$OMIM_PATH/data}"
+DATA_PATH="${DATA_PATH:-$OMIM_PATH/data}"
+BORDERS_PATH="${BORDERS_PATH:-$DATA_PATH/borders}"
+TARGET="${TARGET:-$DATA_PATH}"
 [ ! -d "$TARGET" ] && fail "$TARGET should be a writable folder"
 INTDIR="${INTDIR:-$TARGET/intermediate_data}"
 mkdir -p "$INTDIR"
 NUM_PROCESSES=${NUM_PROCESSES:-8}
 KEEP_INTDIR=${KEEP_INTDIR-}
-OSRM_FLAG="${OSRM_FLAG:-$INTDIR/osrm_done}"
 LOG_PATH=${LOG_PATH:-.}
 echo "[$(date +%Y/%m/%d\ %H:%M:%S)] $0 $1"
 
 if [ "$1" == "pbf" ]; then
-  rm -f "$OSRM_FLAG"
   PLANET="${PLANET:-$HOME/planet/planet-latest.o5m}"
   OSMCTOOLS="${OSMCTOOLS:-$HOME/osmctools}"
   [ ! -d "$OSMCTOOLS" ] && OSMCTOOLS="$INTDIR"
   [ ! -x "$OSMCTOOLS/osmconvert" ] && cc -x c -lz -O3 "$OMIM_PATH/tools/osmctools/osmconvert.c" -o "$OSMCTOOLS/osmconvert"
 
   TMPBORDERS="$INTDIR/tmpborders"
+  [ -d "$TMPBORDERS" ] && rm -r "$TMPBORDERS"
   mkdir "$TMPBORDERS"
   if [ -z "${REGIONS-}" ]; then
     cp "$BORDERS_PATH"/*.poly "$TMPBORDERS"
   else
-    echo "$REGIONS" | xargs -I % cp "$BORDERS_PATH/%.poly" "$TMPBORDERS"
+    echo "$REGIONS" | xargs -I % cp "%" "$TMPBORDERS"
   fi
-  [ -z "$(ls "$TMPBORDERS"/*.poly)" ] && fail "No regions to create routing files for"
+  [ -z "$(ls "$TMPBORDERS" | grep '\.poly$')" ] && fail "No regions to create routing files for"
   export OSMCTOOLS
   export PLANET
   export INTDIR
   find "$TMPBORDERS" -maxdepth 1 -name '*.poly' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
     sh -c '"$OSMCTOOLS/osmconvert" "$PLANET" --hash-memory=2000 -B="%" --complex-ways --out-pbf -o="$INTDIR/$(basename "%" .poly).pbf"'
-  [ $? != 0 ] && fail "Failed to process all the regions"
   rm -r "$TMPBORDERS"
 
 elif [ "$1" == "prepare" ]; then
-  rm -f "$OSRM_FLAG"
-  [ -z "$(ls "$INTDIR"/*.pbf)" ] && fail "Please build PBF files first"
+  [ -z "$(ls "$INTDIR" | grep '\.pbf$')" ] && fail "Please build PBF files first"
   OSRM_PATH="${OSRM_PATH:-$OMIM_PATH/3party/osrm/osrm-backend}"
   OSRM_BUILD_PATH="${OSRM_BUILD_PATH:-$OMIM_PATH/../osrm-backend-release}"
   [ ! -x "$OSRM_BUILD_PATH/osrm-extract" ] && fail "Please compile OSRM binaries to $OSRM_BUILD_PATH"
@@ -81,9 +81,9 @@ elif [ "$1" == "prepare" ]; then
     RESTRICTIONS_FILE="$OSRM_FILE.restrictions"
     LOG="$LOG_PATH/$(basename "$PBF" .pbf).log"
     rm -f "$OSRM_FILE"
-    "$OSRM_BUILD_PATH/osrm-extract" --config "$EXTRACT_CFG" --profile "$PROFILE" "$PBF" >> "$LOG" 2>&1
-    "$OSRM_BUILD_PATH/osrm-prepare" --config "$PREPARE_CFG" --profile "$PROFILE" "$OSRM_FILE" -r "$RESTRICTIONS_FILE" >> "$LOG" 2>&1
-    "$OSRM_BUILD_PATH/osrm-mapsme" -i "$OSRM_FILE" >> "$LOG" 2>&1
+    "$OSRM_BUILD_PATH/osrm-extract" --config "$EXTRACT_CFG" --profile "$PROFILE" "$PBF" >> "$LOG" 2>&1 || true
+    "$OSRM_BUILD_PATH/osrm-prepare" --config "$PREPARE_CFG" --profile "$PROFILE" "$OSRM_FILE" -r "$RESTRICTIONS_FILE" >> "$LOG" 2>&1 || true
+    "$OSRM_BUILD_PATH/osrm-mapsme" -i "$OSRM_FILE" >> "$LOG" 2>&1 || true
     if [ -s "$OSRM_FILE" ]; then
       [ -z "$KEEP_INTDIR" ] && rm -f "$PBF"
       ONE_OSRM_READY=1
@@ -92,17 +92,20 @@ elif [ "$1" == "prepare" ]; then
     fi
   done
   [ -z "${ONE_OSRM_READY-}" ] && fail "No osrm files were prepared"
-  touch "$OSRM_FLAG"
 
 elif [ "$1" == "mwm" ]; then
-  [ ! -f "$OSRM_FLAG" ] && fail "Please build OSRM files first"
+  [ -z "$(ls "$INTDIR" | grep '\.osrm$')" ] && fail "Please build OSRM files first"
   source "$(dirname "$0")/find_generator_tool.sh"
 
-  if [ ! -d "$TARGET/borders" -o -z "$(ls "$TARGET/borders" | grep \.poly)" ]; then
+  if [ ! -d "$TARGET/borders" -o -z "$(ls "$TARGET/borders" | grep '\.poly$')" ]; then
     # copy polygons to a temporary directory
     POLY_DIR="$TARGET/borders"
     mkdir -p "$POLY_DIR"
-    cp "$BORDERS_PATH"/*.poly "$POLY_DIR/"
+    if [ -z "${REGIONS-}" ]; then
+      cp "$BORDERS_PATH"/*.poly "$POLY_DIR"
+    else
+      echo "$REGIONS" | xargs -I % cp "%" "$POLY_DIR"
+    fi
   fi
 
   # Xargs has 255 chars limit for exec string, so we use short variable names.
@@ -110,9 +113,11 @@ elif [ "$1" == "mwm" ]; then
   export K="--make_routing --make_cross_section"
   export TARGET
   export LOG_PATH
-  export DATA_PATH="$OMIM_PATH/data/"
+  export DATA_PATH
+  set +e
   find "$INTDIR" -maxdepth 1 -name '*.osrm' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
     sh -c 'O="%"; B="$(basename "$O" .osrm)"; "$G" $K --osrm_file_name="$O" --data_path="$TARGET" --user_resource_path="$DATA_PATH" --output="$B" 2>> "$LOG_PATH/$B.log"'
+  set -e
 
   if [ -n "${POLY_DIR-}" ]; then
     # delete temporary polygons
@@ -162,3 +167,4 @@ elif [ "$1" == "online" ]; then
 else
   fail "Incorrect parameter: $1"
 fi
+exit 0


### PR DESCRIPTION
Рефакторинг скрипта `generate_planet_routing.sh` и немного фиксов для удобства:

* Поиск generator_tool теперь знает про xcode.
* В скрипте роутинга включен режим `set -e`, просто для порядка.
* Обработка флага osrm_done выкорчевана из скрипта роутинга, осталась в `generate_planet`.
* Добавлен флаг osrm_done_pbf, чтобы не пересобирать pbf, если сломалась сборка osrm.
* Не работало указание `DATA_PATH`.
* Нормально определяем количество процессоров в маке.
* Ещё опечатался: сборка планеты требует не 250 МБ, а 250 ГБ.