### PR TITLE
Routing following info fix.

### DIFF
--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -98,6 +98,7 @@ namespace location
   public:
     FollowingInfo()
         : m_turn(routing::turns::TurnDirection::NoTurn),
+          m_nextTurn(routing::turns::TurnDirection::NoTurn),
           m_exitNum(0),
           m_time(0),
           m_completionPercent(0),

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -241,10 +241,17 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   threads::MutexGuard guard(m_routeSessionMutex);
   UNUSED_VALUE(guard);
 
-  if (!m_route.IsValid() || !IsNavigable())
+  if (!m_route.IsValid())
   {
     // nothing should be displayed on the screen about turns if these lines are executed
     info = FollowingInfo();
+    return;
+  }
+
+  if (!IsNavigable())
+  {
+    info = FollowingInfo();
+    formatDistFn(m_route.GetTotalDistanceMeters(), info.m_distToTarget, info.m_targetUnitsSuffix);
     return;
   }
 


### PR DESCRIPTION
Фикс не инициализированных полей для FollowingInfo. Иногда это приводит к крешу на андройде.