### PR TITLE
UTurn fix.

### DIFF
--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -154,6 +154,23 @@ UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::UTurnLeft);
 }
 
+UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetOsrmComponents(),
+      MercatorBounds::FromLatLon(55.66192, 37.62852), {0., 0.},
+      MercatorBounds::FromLatLon(55.66189, 37.63254));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2);
+  // Checking a turn in case going from a not-link to a link
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+}
+
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -936,6 +936,10 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
         return 0;
       }
 
+      // Avoid the UTurn on unnamed roads inside the rectangle based distinct.
+      if (checkedSegment.m_name.empty())
+        return 0;
+
       auto angle = ang::TwoVectorsAngle(m2::PointD::Zero(), p1, p2);
 
       if (!my::AlmostEqualAbs(angle, math::pi, kUTurnHeadingSensitivity))


### PR DESCRIPTION
https://trello.com/c/WG2mTxLB/2114-android
Фикс указания разворота в районах где есть много местных дорог с одинаковыми тегами, которые делят район на квадраты. Интеграционные тесты прилагаются.