### PR TITLE
Avoid heavy and unnecessary FeatureID copying.

### DIFF
--- a/drape_frontend/watch/cpu_drawer.hpp
+++ b/drape_frontend/watch/cpu_drawer.hpp
@@ -132,7 +132,7 @@ private:
 
   struct ComplexShape : BaseShape
   {
-    ComplexShape(FeatureID geomID, DrawRule const & rule, int generation, EShapeType type)
+    ComplexShape(FeatureID const & geomID, DrawRule const & rule, int generation, EShapeType type)
       : BaseShape(rule, generation, type)
       , m_geomID(geomID)
     {

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1444,7 +1444,7 @@ bool Framework::GetVisiblePOI(m2::PointD const & glbPoint, search::AddressInfo &
   return true;
 }
 
-m2::PointD Framework::GetVisiblePOI(FeatureID id, search::AddressInfo & info, feature::Metadata & metadata) const
+m2::PointD Framework::GetVisiblePOI(FeatureID const & id, search::AddressInfo & info, feature::Metadata & metadata) const
 {
   ASSERT(id.IsValid(), ());
   Index::FeaturesLoaderGuard guard(m_model.GetIndex(), id.m_mwmId);
@@ -1609,7 +1609,7 @@ void Framework::InvalidateUserMarks()
   }
 }
 
-void Framework::OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID feature)
+void Framework::OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature)
 {
   // Back up last tap event to recover selection in case of Drape reinitialization.
   if (!m_lastTapEvent)
@@ -1642,7 +1642,7 @@ void Framework::InvalidateRendering()
     m_drapeEngine->Invalidate();
 }
 
-UserMark const * Framework::OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID feature)
+UserMark const * Framework::OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature)
 {
   if (isMyPosition)
   {

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -276,8 +276,8 @@ private:
   };
   unique_ptr<TapEventData> m_lastTapEvent;
 
-  void OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID feature);
-  UserMark const * OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID feature);
+  void OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature);
+  UserMark const * OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature);
   //@}
 
   TActivateCallbackFn m_activateUserMarkFn;
@@ -447,7 +447,7 @@ private:
 
 public:
   bool GetVisiblePOI(m2::PointD const & glbPoint, search::AddressInfo & info, feature::Metadata & metadata) const;
-  m2::PointD GetVisiblePOI(FeatureID id, search::AddressInfo & info, feature::Metadata & metadata) const;
+  m2::PointD GetVisiblePOI(FeatureID const & id, search::AddressInfo & info, feature::Metadata & metadata) const;
   void FindClosestPOIMetadata(m2::PointD const & pt, feature::Metadata & metadata) const;
 
   void MemoryWarning();

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -87,7 +87,7 @@ Edge Edge::MakeFake(Junction const & startJunction, Junction const & endJunction
   return Edge(FeatureID(), true /* forward */, 0 /* segId */, startJunction, endJunction);
 }
 
-Edge::Edge(FeatureID featureId, bool forward, uint32_t segId, Junction const & startJunction, Junction const & endJunction)
+Edge::Edge(FeatureID const & featureId, bool forward, uint32_t segId, Junction const & startJunction, Junction const & endJunction)
   : m_featureId(featureId), m_forward(forward), m_segId(segId), m_startJunction(startJunction), m_endJunction(endJunction)
 {
   ASSERT_LESS(segId, numeric_limits<uint32_t>::max(), ());

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -40,7 +40,7 @@ class Edge
 public:
   static Edge MakeFake(Junction const & startJunction, Junction const & endJunction);
 
-  Edge(FeatureID featureId, bool forward, uint32_t segId, Junction const & startJunction, Junction const & endJunction);
+  Edge(FeatureID const & featureId, bool forward, uint32_t segId, Junction const & startJunction, Junction const & endJunction);
   Edge(Edge const &) = default;
   Edge & operator=(Edge const &) = default;
 


### PR DESCRIPTION
FeatureID has heavy shared_ptr copying. It's better and faster to pass it by const reference.