### PR TITLE
[FOR ANDROID BUGFIX RELEASE] An approximate (but reliable) way getting dpi.

### DIFF
--- a/android/src/com/nvidia/devtech/NvEventQueueFragment.java
+++ b/android/src/com/nvidia/devtech/NvEventQueueFragment.java
@@ -77,10 +77,10 @@ public abstract class NvEventQueueFragment extends BaseMwmFragment implements Vi
   {
     super.onCreate(savedInstanceState);
     
-    final DisplayMetrics dm = getActivity().getResources().getDisplayMetrics();
-    final float exactDensityDpi = (dm.xdpi + dm.ydpi) / 2;
-    mDisplayDensity = (int)exactDensityDpi;
-    
+    final DisplayMetrics metrics = new DisplayMetrics();
+    getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+    mDisplayDensity = metrics.densityDpi;
+
     mIsNativeLaunched = true;
     onCreateNative();
     if (getActivity().isChangingConfigurations())


### PR DESCRIPTION
На двух девайсах
High screen Boost 2 SE
Xiaomi Red Rice 1s
способ точного получения dpi возвращал не корректные значения. Вернем приближенный способ получения dpi, который был в прежних версиях.

Отдельно хочу отметить, что на девайсах со сверх высоким dpi названия на карте должны остаться читаемыми.

https://trello.com/c/pIbsel7z/2131-android