### PR TITLE
[gpstracks] Implemented gps track writer

### DIFF
--- a/map/gps_track_file.cpp
+++ b/map/gps_track_file.cpp
@@ -31,7 +31,7 @@ GpsTrackFile::GpsTrackFile(string const & filePath, size_t maxItemCount)
   , m_maxItemCount(max(maxItemCount, kMinItemCount) + 1)
   , m_lazyWriteHeaderCount(0)
 {
-  m_header.m_maxItemCount = m_maxItemCount;
+  m_header = Header(m_maxItemCount);
 
   m_stream = OpenBinaryFile(filePath);
   if (!m_stream)
@@ -50,8 +50,7 @@ GpsTrackFile::GpsTrackFile(string const & filePath, size_t maxItemCount)
     if (!m_stream)
       MYTHROW(CreateFileException, ("File:", filePath));
 
-    m_header = Header();
-    m_header.m_maxItemCount = m_maxItemCount;
+    m_header = Header(m_maxItemCount);
 
     WriteHeader(m_header);
   }
@@ -93,8 +92,7 @@ void GpsTrackFile::Close()
   if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
     MYTHROW(WriteFileException, ("File:", m_filePath));
 
-  m_header = Header();
-  m_header.m_maxItemCount = m_maxItemCount;
+  m_header = Header(m_maxItemCount);
 }
 
 void GpsTrackFile::Flush()
@@ -259,8 +257,7 @@ pair<size_t, size_t> GpsTrackFile::Clear()
   pair<size_t, size_t> const res = make_pair(m_header.m_lastId - GetCount(),
                                              m_header.m_lastId - 1);
 
-  m_header = Header();
-  m_header.m_maxItemCount = m_maxItemCount;
+  m_header = Header(m_maxItemCount);
 
   LazyWriteHeader();
 

--- a/map/gps_track_file.cpp
+++ b/map/gps_track_file.cpp
@@ -1,0 +1,344 @@
+#include "map/gps_track_file.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+
+#include "std/algorithm.hpp"
+
+namespace
+{
+
+size_t constexpr kLinearSearchDistance = 10;
+size_t constexpr kMinItemCount = 1;
+size_t constexpr kLazyWriteHeaderMaxCount = 100;
+
+inline fstream CreateBinaryFile(string const & filePath)
+{
+  return fstream(filePath, ios::in|ios::out|ios::binary|ios::trunc);
+}
+
+inline fstream OpenBinaryFile(string const & filePath)
+{
+  return fstream(filePath, ios::in|ios::out|ios::binary);
+}
+
+} // namespace
+
+size_t const GpsTrackFile::kInvalidId = numeric_limits<size_t>::max();
+
+GpsTrackFile::GpsTrackFile(string const & filePath, size_t maxItemCount)
+  : m_filePath(filePath)
+  , m_maxItemCount(max(maxItemCount, kMinItemCount) + 1)
+  , m_lazyWriteHeaderCount(0)
+{
+  m_header.m_maxItemCount = m_maxItemCount;
+
+  m_stream = OpenBinaryFile(filePath);
+  if (!m_stream)
+  {
+    m_stream = CreateBinaryFile(filePath);
+    if (!m_stream)
+      MYTHROW(CreateFileException, ("File:", filePath));
+
+    WriteHeader(m_header);
+  }
+  else if (!ReadHeader(m_header) || m_header.m_maxItemCount != m_maxItemCount)
+  {
+    // Corrupted file, rewrite it
+
+    m_stream = CreateBinaryFile(filePath);
+    if (!m_stream)
+      MYTHROW(CreateFileException, ("File:", filePath));
+
+    m_header = Header();
+    m_header.m_maxItemCount = m_maxItemCount;
+
+    WriteHeader(m_header);
+  }
+}
+
+GpsTrackFile::~GpsTrackFile()
+{
+  ASSERT(!m_stream.is_open(), ("Don't forget to close file"));
+
+  if (m_stream.is_open())
+  {
+    try
+    {
+      Close();
+    }
+    catch (WriteFileException const & e)
+    {
+      LOG(LINFO, ("WriteHeader caused exception", e.Msg()));
+    }
+  }
+}
+
+bool GpsTrackFile::IsOpen() const
+{
+  return m_stream.is_open();
+}
+
+void GpsTrackFile::Close()
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  if (m_lazyWriteHeaderCount != 0)
+  {
+    m_lazyWriteHeaderCount = 0;
+    WriteHeader(m_header);
+  }
+
+  m_stream.close();
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(WriteFileException, ("File:", m_filePath));
+
+  m_header = Header();
+  m_header.m_maxItemCount = m_maxItemCount;
+}
+
+void GpsTrackFile::Flush()
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  if (m_lazyWriteHeaderCount != 0)
+  {
+    m_lazyWriteHeaderCount = 0;
+    WriteHeader(m_header);
+  }
+
+  m_stream.flush();
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(WriteFileException, ("File:", m_filePath));
+}
+
+size_t GpsTrackFile::Append(TItem const & item, size_t & poppedId)
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  if (item.m_timestamp < m_header.m_timestamp)
+  {
+    poppedId = kInvalidId; // nothing was popped
+    return kInvalidId; // nothing was added
+  }
+
+  size_t const newLast = (m_header.m_last + 1) % m_maxItemCount;
+  size_t const newFirst = (newLast == m_header.m_first) ? ((m_header.m_first + 1) % m_maxItemCount) : m_header.m_first;
+
+  WriteItem(m_header.m_last, item);
+
+  size_t const addedId = m_header.m_lastId;
+
+  if (m_header.m_first == newFirst)
+    poppedId = kInvalidId; // nothing was popped
+  else
+    poppedId = m_header.m_lastId - GetCount(); // the id of the first item
+
+  m_header.m_first = newFirst;
+  m_header.m_last = newLast;
+  m_header.m_timestamp = item.m_timestamp;
+  m_header.m_lastId += 1;
+
+  LazyWriteHeader();
+
+  return addedId;
+}
+
+void GpsTrackFile::ForEach(function<bool(TItem const & item, size_t id)> const & fn)
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  double prevTimestamp = 0;
+
+  size_t id = m_header.m_lastId - GetCount(); // the id of the first item
+
+  for (size_t i = m_header.m_first; i != m_header.m_last; i = (i + 1) % m_maxItemCount)
+  {
+    TItem item;
+    if (!ReadItem(i, item))
+      MYTHROW(CorruptedFileException, ("File:", m_filePath));
+
+    if (prevTimestamp > item.m_timestamp)
+      MYTHROW(CorruptedFileException, ("File:", m_filePath));
+
+    size_t itemId = id;
+    if (!fn(item, itemId))
+      break;
+
+    prevTimestamp = item.m_timestamp;
+    ++id;
+  }
+}
+
+pair<size_t, size_t> GpsTrackFile::DropEarlierThan(double timestamp)
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  if (IsEmpty())
+    return make_pair(kInvalidId, kInvalidId); // nothing was dropped
+
+  if (m_header.m_timestamp <= timestamp)
+    return Clear();
+
+  size_t const n = GetCount();
+
+  // Try linear search for short distance
+  // In common case elements will be removed from the tail by small pieces
+  size_t const linearSearchCount = min(kLinearSearchDistance, n);
+  for (size_t i = m_header.m_first, j = 0; i != m_header.m_last; i = (i + 1) % m_maxItemCount, ++j)
+  {
+    if (j >= linearSearchCount)
+      break;
+
+    TItem item;
+    if (!ReadItem(i, item))
+      MYTHROW(CorruptedFileException, ("File:", m_filePath));
+
+    if (item.m_timestamp >= timestamp)
+    {
+      // Dropped range is
+      pair<size_t, size_t> const res = make_pair(m_header.m_lastId - n,
+                                                 m_header.m_lastId - n + j - 1);
+
+      // Update header.first, if need
+      if (i != m_header.m_first)
+      {        
+        m_header.m_first = i;
+
+        LazyWriteHeader();
+      }
+
+      return res;
+    }
+  }
+
+  // By nature items are sorted by timestamp.
+  // Use lower_bound algorithm to find first element later than timestamp.
+  size_t len = n, first = m_header.m_first;
+  while (len > 0)
+  {
+    size_t const step = len / 2;
+    size_t const index = (first + step) % m_maxItemCount;
+
+    TItem item;
+    if (!ReadItem(index, item))
+      MYTHROW(CorruptedFileException, ("File:", m_filePath));
+
+    if (item.m_timestamp < timestamp)
+    {
+      first = (index + 1) % m_maxItemCount;
+      len -= step + 1;
+    }
+    else
+      len = step;
+  }
+
+  // Dropped range is
+  pair<size_t, size_t> const res = make_pair(m_header.m_lastId - n,
+                                             m_header.m_lastId - n + Distance(m_header.m_first, first) - 1);
+
+  // Update header.first, if need
+  if (first != m_header.m_first)
+  {
+    m_header.m_first = first;
+
+    LazyWriteHeader();
+  }
+
+  return res;
+}
+
+pair<size_t, size_t> GpsTrackFile::Clear()
+{
+  ASSERT(m_stream.is_open(), ("File is not open"));
+
+  if (IsEmpty())
+     return make_pair(kInvalidId, kInvalidId); // nothing was dropped
+
+  // Dropped range is
+  pair<size_t, size_t> const res = make_pair(m_header.m_lastId - GetCount(),
+                                             m_header.m_lastId - 1);
+
+  m_header = Header();
+  m_header.m_maxItemCount = m_maxItemCount;
+
+  LazyWriteHeader();
+
+  return res;
+}
+
+size_t GpsTrackFile::GetMaxCount() const
+{
+  return m_maxItemCount;
+}
+
+size_t GpsTrackFile::GetCount() const
+{
+  return Distance(m_header.m_first, m_header.m_last);
+}
+
+bool GpsTrackFile::IsEmpty() const
+{
+  return m_header.m_first == m_header.m_last;
+}
+
+double GpsTrackFile::GetTimestamp() const
+{
+  return m_header.m_timestamp;
+}
+
+void GpsTrackFile::LazyWriteHeader()
+{
+  ++m_lazyWriteHeaderCount;
+  if (m_lazyWriteHeaderCount < kLazyWriteHeaderMaxCount)
+    return;
+
+  m_lazyWriteHeaderCount = 0;
+  WriteHeader(m_header);
+}
+
+bool GpsTrackFile::ReadHeader(Header & header)
+{
+  m_stream.seekg(0, ios::beg);
+  m_stream.read(reinterpret_cast<char *>(&header), sizeof(header));
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(ReadFileException, ("File:", m_filePath));
+  return ((m_stream.rdstate() & ios::eofbit) == 0);
+}
+
+void GpsTrackFile::WriteHeader(Header const & header)
+{
+  m_stream.seekp(0, ios::beg);
+  m_stream.write(reinterpret_cast<char const *>(&header), sizeof(header));
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(WriteFileException, ("File:", m_filePath));
+}
+
+bool GpsTrackFile::ReadItem(size_t index, TItem & item)
+{
+  size_t const offset = ItemOffset(index);
+  m_stream.seekg(offset, ios::beg);
+  m_stream.read(reinterpret_cast<char *>(&item), sizeof(item));
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(ReadFileException, ("File:", m_filePath));
+  return ((m_stream.rdstate() & ios::eofbit) == 0);
+}
+
+void GpsTrackFile::WriteItem(size_t index, TItem const & item)
+{
+  size_t const offset = ItemOffset(index);
+  m_stream.seekp(offset, ios::beg);
+  m_stream.write(reinterpret_cast<char const *>(&item), sizeof(item));
+  if (0 != (m_stream.rdstate() & (ios::failbit | ios::badbit)))
+    MYTHROW(WriteFileException, ("File:", m_filePath));
+}
+
+size_t GpsTrackFile::ItemOffset(size_t index)
+{
+  return sizeof(Header) + index * sizeof(TItem);
+}
+
+size_t GpsTrackFile::Distance(size_t first, size_t last) const
+{
+  return (first <= last) ? (last - first) : (last + m_maxItemCount - first);
+}

--- a/map/gps_track_file.hpp
+++ b/map/gps_track_file.hpp
@@ -92,8 +92,11 @@ private:
     size_t m_last; // index of last item, items are in range [first,last)
     size_t m_lastId; // identifier of the last item
 
-    Header()
-      : m_maxItemCount(0), m_timestamp(0), m_first(0), m_last(0), m_lastId(0)
+    explicit Header(size_t maxItemCount = 0)
+      : m_maxItemCount(maxItemCount)
+      , m_timestamp(0)
+      , m_first(0), m_last(0)
+      , m_lastId(0)
     {}
   };
 

--- a/map/gps_track_file.hpp
+++ b/map/gps_track_file.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "platform/location.hpp"
+
+#include "base/exception.hpp"
+
+#include "std/fstream.hpp"
+#include "std/function.hpp"
+#include "std/limits.hpp"
+#include "std/string.hpp"
+
+class GpsTrackFile final
+{
+public:
+  DECLARE_EXCEPTION(CreateFileException, RootException);
+  DECLARE_EXCEPTION(WriteFileException, RootException);
+  DECLARE_EXCEPTION(ReadFileException, RootException);
+  DECLARE_EXCEPTION(CorruptedFileException, RootException);
+
+  /// Invalid identifier for point
+  static size_t const kInvalidId; // = numeric_limits<size_t>::max();
+
+  using TItem = location::GpsTrackInfo;
+
+  /// @note Opens file with track data or constructs new
+  /// @param filePath - path to the file on disk
+  /// @param maxItemCount - max number of items in recycling file
+  /// @exceptions CreateFileException if unable to create file, ReadFileException if read fails
+  /// or WriteFileException if write fails.
+  GpsTrackFile(string const & filePath, size_t maxItemCount);
+
+  ~GpsTrackFile();
+
+  /// Returns true if file is open, otherwise returns false
+  bool IsOpen() const;
+
+  /// Flushes all changes and closes file
+  /// @exceptions WriteFileException if write fails.
+  void Close();
+
+  /// Flushes all changes in file
+  /// @exceptions WriteFileException if write fails.
+  void Flush();
+
+  /// Appends new point in the file
+  /// @param item - gps track point.
+  /// @param poppedId - identifier of popped point due to recycling, kInvalidId if there is no popped point.
+  /// @returns identifier of point, kInvalidId if point was not added.
+  /// @note Timestamp must be not less than GetTimestamp(), otherwise function returns false.
+  /// @note File is circular, when GetMaxItemCount() limit is reached, old point is popped out from file.
+  /// @exceptions WriteFileException if write fails.
+  size_t Append(TItem const & item, size_t & poppedId);
+
+  /// Remove all points from the file
+  /// @returns range of identifiers of removed points, or pair(kInvalidId,kInvalidId) if nothing was removed.
+  /// @exceptions WriteFileException if write fails.
+  pair<size_t, size_t> Clear();
+
+  /// Returns max number of points in recycling file
+  size_t GetMaxCount() const;
+
+  /// Returns number of items in the file, this values is <= GetMaxItemCount()
+  size_t GetCount() const;
+
+  /// Returns true if file does not contain points
+  bool IsEmpty() const;
+
+  /// Returns upper bound timestamp, or zero if there is no points
+  double GetTimestamp() const;
+
+  /// Enumerates all points from the file in timestamp ascending order
+  /// @param fn - callable object which receives points. If fn returns false then enumeration is stopped.
+  /// @exceptions CorruptedFileException if file is corrupted or ReadFileException if read fails
+  void ForEach(function<bool(TItem const & item, size_t id)> const & fn);
+
+  /// Drops points earlier than specified date
+  /// @param timestamp - timestamp of lower bound, number of seconds since 1.1.1970.
+  /// @returns range of identifiers of removed points, or pair(kInvalidId,kInvalidId) if nothing was removed.
+  /// @exceptions CorruptedFileException if file is corrupted, ReadFileException if read fails
+  /// or WriteFileException if write fails.
+  pair<size_t, size_t> DropEarlierThan(double timestamp);
+
+private:
+  /// Header, stored in beginning of file
+  /// @note Due to recycling, indexes of items are reused, but idendifiers are unique
+  /// until Clear or create new file
+  struct Header
+  {
+    size_t m_maxItemCount; // max number of items in recycling file
+    double m_timestamp; // upper bound timestamp
+    size_t m_first; // index of first item
+    size_t m_last; // index of last item, items are in range [first,last)
+    size_t m_lastId; // identifier of the last item
+
+    Header()
+      : m_maxItemCount(0), m_timestamp(0), m_first(0), m_last(0), m_lastId(0)
+    {}
+  };
+
+  void LazyWriteHeader();
+
+  bool ReadHeader(Header & header);
+  void WriteHeader(Header const & header);
+
+  bool ReadItem(size_t index, TItem & item);
+  void WriteItem(size_t index, TItem const & item);
+
+  static size_t ItemOffset(size_t index);
+
+  size_t Distance(size_t first, size_t last) const;
+
+  string const m_filePath;
+  size_t const m_maxItemCount;
+
+  Header m_header;
+  uint32_t m_lazyWriteHeaderCount; // request count for write header
+
+  fstream m_stream; // buffered file stream
+};

--- a/map/map.pro
+++ b/map/map.pro
@@ -22,6 +22,7 @@ HEADERS += \
     ge0_parser.hpp \
     geourl_process.hpp \
     gps_track_container.hpp \
+    gps_track_file.hpp \
     mwm_url.hpp \
     storage_bridge.hpp \
     styled_point.hpp \
@@ -42,6 +43,7 @@ SOURCES += \
     ge0_parser.cpp \
     geourl_process.cpp \
     gps_track_container.cpp \
+    gps_track_file.cpp \
     mwm_url.cpp \
     storage_bridge.cpp \
     styled_point.cpp \

--- a/map/map_tests/gps_track_file_test.cpp
+++ b/map/map_tests/gps_track_file_test.cpp
@@ -1,0 +1,280 @@
+#include "testing/testing.hpp"
+
+#include "map/gps_track_file.hpp"
+
+#include "platform/platform.hpp"
+
+#include "coding/file_name_utils.hpp"
+
+#include "geometry/latlon.hpp"
+
+#include "std/chrono.hpp"
+
+namespace
+{
+
+location::GpsTrackInfo Make(double timestamp, ms::LatLon const & ll, double speed)
+{
+  location::GpsTrackInfo info;
+  info.m_timestamp = timestamp;
+  info.m_speed = speed;
+  info.m_latitude = ll.lat;
+  info.m_longitude = ll.lon;
+  return info;
+}
+
+} // namespace
+
+UNIT_TEST(GpsTrackFile_SimpleWriteRead)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+  size_t const fileMaxItemCount = 100000;
+
+  // Write GPS tracks.
+  // (write only half of max items to do not do recycling)
+  {
+    GpsTrackFile file(filePath, fileMaxItemCount);
+
+    file.Clear();
+
+    TEST_EQUAL(0, file.GetCount(), ());
+
+    for (size_t i = 0; i < fileMaxItemCount / 2; ++i)
+    {
+      size_t poppedId;
+      size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000, i + 2000), i + 3000), poppedId);
+      TEST_EQUAL(i, addedId, ());
+      TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+    }
+
+    TEST_EQUAL(fileMaxItemCount / 2, file.GetCount(), ());
+
+    file.Close();
+  }
+
+  // Read GPS tracks.
+  {
+    GpsTrackFile file(filePath, fileMaxItemCount);
+
+    TEST_EQUAL(fileMaxItemCount/2, file.GetCount(), ());
+
+    size_t i = 0;
+    file.ForEach([&i,timestamp](location::GpsTrackInfo const & info, size_t id)->bool
+    {
+      TEST_EQUAL(id, i, ());
+      TEST_EQUAL(info.m_timestamp, timestamp + i, ());
+      TEST_EQUAL(info.m_latitude, i + 1000, ());
+      TEST_EQUAL(info.m_longitude, i + 2000, ());
+      TEST_EQUAL(info.m_speed, i + 3000, ());
+      ++i;
+      return true;
+    });
+
+    TEST_EQUAL(i, fileMaxItemCount / 2, ());
+
+    auto res = file.Clear();
+    TEST_EQUAL(res.first, 0, ());
+    TEST_EQUAL(res.second, fileMaxItemCount / 2 - 1, ());
+
+    file.Close();
+  }
+}
+
+UNIT_TEST(GpsTrackFile_WriteReadWithPopping)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+  size_t const fileMaxItemCount = 100000;
+
+  // Write GPS tracks.
+  // 2 x fileMaxItemCount more items are written in cyclic file, first half will be popped
+  {
+    GpsTrackFile file(filePath, fileMaxItemCount);
+
+    file.Clear();
+
+    TEST_EQUAL(0, file.GetCount(), ());
+
+    for (size_t i = 0; i < 2 * fileMaxItemCount; ++i)
+    {
+      size_t poppedId;
+      size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000, i + 2000), i + 3000), poppedId);
+      TEST_EQUAL(i, addedId, ());
+      if (i >= fileMaxItemCount)
+      {
+        TEST_EQUAL(i - fileMaxItemCount, poppedId, ());
+      }
+      else
+      {
+        TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+      }
+    }
+
+    TEST_EQUAL(fileMaxItemCount, file.GetCount(), ());
+
+    file.Close();
+  }
+
+  // Read GPS tracks
+  // Only last fileMaxItemCount must be in cyclic buffer
+  {
+    GpsTrackFile file(filePath, fileMaxItemCount);
+
+    TEST_EQUAL(fileMaxItemCount, file.GetCount(), ());
+
+    size_t i = 0;
+    file.ForEach([&i,timestamp](location::GpsTrackInfo const & info, size_t id)->bool
+    {
+      TEST_EQUAL(id, i + fileMaxItemCount, ());
+      TEST_EQUAL(info.m_timestamp, timestamp + i + fileMaxItemCount, ());
+      TEST_EQUAL(info.m_latitude, i + 1000 + fileMaxItemCount, ());
+      TEST_EQUAL(info.m_longitude, i + 2000 + fileMaxItemCount, ());
+      TEST_EQUAL(info.m_speed, i + 3000 + fileMaxItemCount, ());
+      ++i;
+      return true;
+    });
+
+    TEST_EQUAL(i, fileMaxItemCount, ());
+
+    file.Close();
+  }
+}
+
+UNIT_TEST(GpsTrackFile_DropInTail)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+
+  GpsTrackFile file(filePath, 100);
+
+  file.Clear();
+
+  for (size_t i = 0; i < 50; ++i)
+  {
+    size_t poppedId;
+    size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000, i + 2000), i + 3000), poppedId);
+    TEST_EQUAL(i, addedId, ());
+    TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+  }
+
+  TEST_EQUAL(50, file.GetCount(), ());
+
+  auto res = file.DropEarlierThan(timestamp + 4.5); // drop points 0,1,2,3,4
+  TEST_EQUAL(res.first, 0, ());
+  TEST_EQUAL(res.second, 4, ());
+
+  TEST_EQUAL(45, file.GetCount(), ());
+
+  size_t i = 5; // new first
+  file.ForEach([&i,timestamp](location::GpsTrackInfo const & info, size_t id)->bool
+  {
+    TEST_EQUAL(info.m_timestamp, timestamp + i, ());
+    TEST_EQUAL(info.m_latitude, i + 1000, ());
+    TEST_EQUAL(info.m_longitude, i + 2000, ());
+    TEST_EQUAL(info.m_speed, i + 3000, ());
+    ++i;
+    return true;
+  });
+
+  res = file.Clear();
+  TEST_EQUAL(res.first, 5, ());
+  TEST_EQUAL(res.second, 49, ());
+
+  file.Close();
+}
+
+UNIT_TEST(GpsTrackFile_DropInMiddle)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+
+  GpsTrackFile file(filePath, 100);
+
+  file.Clear();
+
+  for (size_t i = 0; i < 50; ++i)
+  {
+    size_t poppedId;
+    size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000,i + 2000), i + 3000), poppedId);
+    TEST_EQUAL(i, addedId, ());
+    TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+  }
+
+  TEST_EQUAL(50, file.GetCount(), ());
+
+  auto res = file.DropEarlierThan(timestamp + 48.5); // drop all except last
+  TEST_EQUAL(res.first, 0, ());
+  TEST_EQUAL(res.second, 48, ());
+
+  TEST_EQUAL(1, file.GetCount(), ());
+
+  size_t i = 49; // new first
+  file.ForEach([&i,timestamp](location::GpsTrackInfo const & info, size_t id)->bool
+  {
+    TEST_EQUAL(info.m_timestamp, timestamp + i, ());
+    TEST_EQUAL(info.m_latitude, i + 1000, ());
+    TEST_EQUAL(info.m_longitude, i + 2000, ());
+    TEST_EQUAL(info.m_speed, i + 3000, ());
+    ++i;
+    return true;
+  });
+
+  file.Close();
+}
+
+UNIT_TEST(GpsTrackFile_DropAll)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+
+  GpsTrackFile file(filePath, 100);
+
+  file.Clear();
+
+  for (size_t i = 0; i < 50; ++i)
+  {
+    size_t poppedId;
+    size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000, i + 2000), i + 3000), poppedId);
+    TEST_EQUAL(i, addedId, ());
+    TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+  }
+
+  TEST_EQUAL(50, file.GetCount(), ());
+
+  auto res = file.DropEarlierThan(timestamp + 51); // drop all
+  TEST_EQUAL(res.first, 0, ());
+  TEST_EQUAL(res.second, 49, ());
+
+  TEST_EQUAL(0, file.GetCount(), ());
+
+  file.Close();
+}
+
+UNIT_TEST(GpsTrackFile_Clear)
+{
+  time_t const timestamp = system_clock::to_time_t(system_clock::now());
+  string const filePath = my::JoinFoldersToPath(GetPlatform().WritableDir(), "gpstrack.bin");
+
+  GpsTrackFile file(filePath, 100);
+
+  file.Clear();
+
+  for (size_t i = 0; i < 50; ++i)
+  {
+    size_t poppedId;
+    size_t addedId = file.Append(Make(timestamp + i, ms::LatLon(i + 1000, i + 2000), i + 3000), poppedId);
+    TEST_EQUAL(i, addedId, ());
+    TEST_EQUAL(GpsTrackFile::kInvalidId, poppedId, ());
+  }
+
+  TEST_EQUAL(50, file.GetCount(), ());
+
+  auto res = file.Clear();
+  TEST_EQUAL(res.first, 0, ());
+  TEST_EQUAL(res.second, 49, ());
+
+  TEST_EQUAL(0, file.GetCount(), ());
+
+  file.Close();
+}

--- a/map/map_tests/map_tests.pro
+++ b/map/map_tests/map_tests.pro
@@ -32,6 +32,7 @@ SOURCES += \
   ge0_parser_tests.cpp  \
   geourl_test.cpp \
   gps_track_container_test.cpp \
+  gps_track_file_test.cpp \
   kmz_unarchive_test.cpp \
   mwm_url_tests.cpp \
 

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -69,6 +69,20 @@ namespace location
     double m_latitude;  //!< degrees
     double m_longitude; //!< degrees
     double m_speed;     //!< meters per second
+
+    GpsTrackInfo() = default;
+    GpsTrackInfo(GpsTrackInfo const &) = default;
+    GpsTrackInfo & operator=(GpsTrackInfo const &) = default;
+    GpsTrackInfo(GpsInfo const & info)
+      : m_timestamp(info.m_timestamp)
+      , m_latitude(info.m_latitude)
+      , m_longitude(info.m_longitude)
+      , m_speed(info.m_speed)
+    {}
+    GpsTrackInfo & operator=(GpsInfo const & info)
+    {
+      return operator=(GpsTrackInfo(info));
+    }
   };
 
   class CompassInfo

--- a/std/fstream.hpp
+++ b/std/fstream.hpp
@@ -7,6 +7,7 @@
 #include <fstream>
 using std::ofstream;
 using std::ifstream;
+using std::fstream;
 using std::ios;
 
 #ifdef DEBUG_NEW


### PR DESCRIPTION
Этот файл нужен для записи сырых данных gps треков при незапущенном приложении и записи в запущенном приложении с целью восстановления трека после падения приложения. 

В файл циклически записываются точки gps трека, при overflow выкидываются старые точки, сохраняются новые точки. каждая точка при добавлении получает уникальный идентификатор, при выкидывании старых точек (Clear, DropEarlierThan или Append) возвращаются их идентификаторы.

Файл бинарный и не требует разбора в отличие от gpx и nmea.
Файл может быть экспортирован/импортирован в/из gpx или nmea.

В отличие от https://github.com/mapsme/omim/pull/833, этот реквест содержит только реализацию файла.