### PR TITLE
[build] Build routing consistency tests for gtool project

### DIFF
--- a/omim.pro
+++ b/omim.pro
@@ -35,7 +35,9 @@ SUBDIRS = 3party base coding geometry indexer routing
 
     routing_integration_tests.subdir = routing/routing_integration_tests
     routing_integration_tests.depends = $$SUBDIRS
-    SUBDIRS *= routing_integration_tests
+    routing_consistency_tests.subdir = routing/routing_consistency_tests
+    routing_consistency_tests.depends = $$SUBDIRS
+    SUBDIRS *= routing_integration_tests routing_consistency_tests
   }
 
   CONFIG(desktop) {


### PR DESCRIPTION
На серверах для сборки карт я собираю omim с ключом `CONFIG=gtool`. Там из-за недавнего улучшения тестов не хватает одного исполняемого файла. Этот PR добавляет его в сборку.