### PR TITLE
[build] Fixes to linux build.

### DIFF
--- a/drape/drape_tests/drape_tests.pro
+++ b/drape/drape_tests/drape_tests.pro
@@ -4,7 +4,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 DEFINES += OGL_TEST_ENABLED GTEST_DONT_DEFINE_TEST COMPILER_TESTS
 
-DEPENDENCIES = qt_tstfrm platform coding base gmock freetype fribidi expat tomcrypt
+DEPENDENCIES = qt_tstfrm indexer platform coding geometry base gmock freetype fribidi expat tomcrypt
 ROOT_DIR = ../..
 SHADER_COMPILE_ARGS = $$PWD/../shaders shader_index.txt shader_def
 include($$ROOT_DIR/common.pri)

--- a/drape/drape_tests/glfunctions.cpp
+++ b/drape/drape_tests/glfunctions.cpp
@@ -249,6 +249,8 @@ void GLFunctions::glBlendFunc(glConst srcFactor, glConst dstFactor) {}
 
 void GLFunctions::glDisable(glConst mode) {}
 
+void GLFunctions::glDepthFunc(glConst depthFunc) {}
+
 void GLFunctions::glUniformValueiv(int8_t location, int32_t * v, uint32_t size) {}
 
 void * GLFunctions::glMapBuffer(glConst target) { return 0; }

--- a/drape_frontend/drape_frontend_tests/drape_frontend_tests.pro
+++ b/drape_frontend/drape_frontend_tests/drape_frontend_tests.pro
@@ -4,7 +4,7 @@ CONFIG += console warn_on
 CONFIG -= app_bundle
 TEMPLATE = app
 
-DEPENDENCIES = drape_frontend drape platform indexer geometry coding base expat
+DEPENDENCIES = drape_frontend drape platform indexer geometry coding base expat tomcrypt
 
 ROOT_DIR = ../..
 include($$ROOT_DIR/common.pri)

--- a/map/style_tests/style_tests.pro
+++ b/map/style_tests/style_tests.pro
@@ -6,7 +6,7 @@ TEMPLATE = app
 INCLUDEPATH += ../../3party/protobuf/src
 
 ROOT_DIR = ../..
-DEPENDENCIES = map indexer platform geometry coding base expat protobuf
+DEPENDENCIES = map indexer platform geometry coding base expat protobuf tomcrypt
 
 macx-*: LIBS *= "-framework IOKit"
 


### PR DESCRIPTION
This patch is needed mostly for sanitizer. We need these dependencies only because address sanitizer does not work with dead code elimination at link time (https://github.com/google/sanitizers/issues/260). This patch does not affect release build or build to mobile clients.