### PR TITLE
fix generate_mwm

### DIFF
--- a/docs/MAPS.md
+++ b/docs/MAPS.md
@@ -25,8 +25,6 @@ Specify `TARGET` variable for changing that (e.g. `TARGET=.`). The script runs `
 see `find_generator_tool.sh` script for an algorithm on how it finds it. All temporary files are created
 with `mktemp` and then removed.
 
-If you do not have osmconvert installed in ```$HOME/osmctools/osmconvert```, the script may compile it from source. In this case you need the following boost libraries: Thread, System, Program Options, Filesystem, Date Time, Atomic, Chrono, Serialization. On Ubuntu you may want to install them using ```apt-get install libboost-thread-dev libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-date-time-dev```
-
 The resulting file won't have any coastlines, though MAPS.ME will overlay zoomed-in map with a low-quality
 generalized coastline. To add a detailed coastline, you would need a `WorldCoasts.geom` file and
 a [border polygon](http://wiki.openstreetmap.org/wiki/Osmosis/Polygon_Filter_File_Format) for a source

--- a/docs/MAPS.md
+++ b/docs/MAPS.md
@@ -25,6 +25,8 @@ Specify `TARGET` variable for changing that (e.g. `TARGET=.`). The script runs `
 see `find_generator_tool.sh` script for an algorithm on how it finds it. All temporary files are created
 with `mktemp` and then removed.
 
+If you do not have osmconvert installed in ```$HOME/osmctools/osmconvert```, the script may compile it from source. In this case you need the following boost libraries: Thread, System, Program Options, Filesystem, Date Time, Atomic, Chrono, Serialization. On Ubuntu you may want to install them using ```apt-get install libboost-thread-dev libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-date-time-dev```
+
 The resulting file won't have any coastlines, though MAPS.ME will overlay zoomed-in map with a low-quality
 generalized coastline. To add a detailed coastline, you would need a `WorldCoasts.geom` file and
 a [border polygon](http://wiki.openstreetmap.org/wiki/Osmosis/Polygon_Filter_File_Format) for a source

--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -43,10 +43,11 @@ find_osmconvert() {
   OSMCONVERT="${OSMCONVERT:-$HOME/osmctools/osmconvert}"
   if [ ! -x "$OSMCONVERT" ]; then
     OSMCONVERT="$INTDIR/osmconvert"
+    echo "compiling osmconvert"
     if [ -e "$OMIM_PATH/tools/osmctools/osmconvert.c" ]; then
-      cc -x c -lz -O3 "$OMIM_PATH/tools/osmctools/osmconvert.c" -o "$OSMCONVERT"
+      cc -x c -O3 "$OMIM_PATH/tools/osmctools/osmconvert.c" -o "$OSMCONVERT" -lz
     else
-      curl -s https://raw.githubusercontent.com/mapsme/osmctools/master/osmconvert.c | cc -x c - -lz -O3 -o $OSMCONVERT
+      curl -s https://raw.githubusercontent.com/mapsme/osmctools/master/osmconvert.c | cc -x c - -O3 -o $OSMCONVERT -lz
     fi
   fi
 }
@@ -89,6 +90,7 @@ if [ -f "$COASTS" ]; then
   cp "$COASTS" "$INTDIR/WorldCoasts.geom"
   GENERATE_EVERYTHING="$GENERATE_EVERYTHING --emit_coasts=true --split_by_polygons=true"
 fi
+echo "src type: $SOURCE_TYPE"
 # Convert everything to o5m
 if [ "$SOURCE_TYPE" == "pbf" -o "$SOURCE_TYPE" == "bz2" -o "$SOURCE_TYPE" == "osm" ]; then
   find_osmconvert


### PR DESCRIPTION
It seems that ```generate_mwm.sh``` is unable to compile ```osmconvert``` with GNU C Compiler 4.8.4 on Ubuntu 14.04 if -lz is provided as an early argument. It fails with the error message ```undefined reference to `gzopen'```

~~Also I added boost-libraries to the docs. This is not ultimately neccessary as the build fails with appropriate messages if the libraries are unavailable and can be reverted if seen fit.~~