### PR TITLE
fix generate_mwmoc

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -82,7 +82,8 @@ To build and run OSRM binaries:
 
     sudo apt-get install libtbb2 libluabind0.9.1 liblua50 libstxxl1
     sudo apt-get install libtbb-dev libluabind-dev libstxxl-dev libosmpbf-dev libprotobuf-dev
-    sudo apt-get install libboost-thread-dev libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-date-time-dev
+    sudo apt-get install libboost-thread-dev libboost-system-dev libboost-program-options-dev
+    sudo apt-get install libboost-filesystem-dev libboost-date-time-dev
     tools/unix/build_omim.sh -o
 
 ### Windows

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -82,6 +82,7 @@ To build and run OSRM binaries:
 
     sudo apt-get install libtbb2 libluabind0.9.1 liblua50 libstxxl1
     sudo apt-get install libtbb-dev libluabind-dev libstxxl-dev libosmpbf-dev libprotobuf-dev
+    sudo apt-get install libboost-thread-dev libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-date-time-dev
     tools/unix/build_omim.sh -o
 
 ### Windows


### PR DESCRIPTION
I added libraries to the docs required on a fresh Ubuntu 14.4 in order to compile out-of-the-box.
( Sorry for the inconvenience of the previous pull-request, it should be the correct position in the docs now I hope! )