### PR TITLE
Editor core v3.

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -25,7 +25,7 @@ define add_prebuild_static_lib
   include $(PREBUILT_STATIC_LIBRARY)
 endef
 
-prebuild_static_libs := osrm protobuf tomcrypt jansson minizip fribidi freetype expat base coding geometry platform indexer storage search routing drape drape_frontend map stats_client succinct opening_hours
+prebuild_static_libs := osrm protobuf tomcrypt jansson minizip fribidi freetype expat base coding geometry platform indexer storage search routing drape drape_frontend map stats_client succinct opening_hours pugixml
 
 $(foreach item,$(prebuild_static_libs),$(eval $(call add_prebuild_static_lib,$(item))))
 
@@ -40,7 +40,7 @@ LOCAL_CPP_FEATURES += exceptions rtti
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../
 
 LOCAL_MODULE := mapswithme
-LOCAL_STATIC_LIBRARIES := map drape_frontend routing search storage indexer drape platform geometry coding base expat freetype fribidi minizip jansson tomcrypt protobuf osrm stats_client succinct opening_hours
+LOCAL_STATIC_LIBRARIES := map drape_frontend routing search storage indexer drape platform geometry coding base expat freetype fribidi minizip jansson tomcrypt protobuf osrm stats_client succinct opening_hours pugixml
 LOCAL_CFLAGS := -ffunction-sections -fdata-sections -Wno-extern-c-compat
 
 ifneq ($(NDK_DEBUG),1)

--- a/coding/multilang_utf8_string.cpp
+++ b/coding/multilang_utf8_string.cpp
@@ -17,7 +17,7 @@ static char const * gLangs[] = {
 
 int8_t StringUtf8Multilang::GetLangIndex(string const & lang)
 {
-  static_assert(ARRAY_SIZE(gLangs) == MAX_SUPPORTED_LANGUAGES, "");
+  static_assert(ARRAY_SIZE(gLangs) == MAX_SUPPORTED_LANGUAGES, "With current encoding we are limited to 64 languages max.");
 
   for (size_t i = 0; i < ARRAY_SIZE(gLangs); ++i)
     if (lang == gLangs[i])

--- a/coding/multilang_utf8_string.hpp
+++ b/coding/multilang_utf8_string.hpp
@@ -60,7 +60,7 @@ public:
   }
 
   template <class T>
-  void ForEachRef(T & functor) const
+  void ForEachRef(T && functor) const
   {
     size_t i = 0;
     size_t const sz = m_s.size();

--- a/coding/multilang_utf8_string.hpp
+++ b/coding/multilang_utf8_string.hpp
@@ -35,8 +35,12 @@ class StringUtf8Multilang
   size_t GetNextIndex(size_t i) const;
 
 public:
-  static int8_t const UNSUPPORTED_LANGUAGE_CODE = -1;
-  static int8_t const DEFAULT_CODE = 0;
+  static int8_t constexpr UNSUPPORTED_LANGUAGE_CODE = -1;
+  static int8_t constexpr DEFAULT_CODE = 0;
+  /// How many languages we support on indexing stage. See full list in cpp file.
+  /// TODO(AlexZ): Review and replace invalid languages by valid ones.
+  static int8_t constexpr MAX_SUPPORTED_LANGUAGES = 64;
+
 
   /// @return UNSUPPORTED_LANGUAGE_CODE if language is not recognized
   static int8_t GetLangIndex(string const & lang);

--- a/defines.hpp
+++ b/defines.hpp
@@ -58,8 +58,3 @@
 #define PACKED_POLYGONS_INFO_TAG "info"
 
 #define EXTERNAL_RESOURCES_FILE "external_resources.txt"
-
-/// How many langs we're supporting on indexing stage
-#define MAX_SUPPORTED_LANGUAGES 64
-
-

--- a/generator/generator_tool/generator_tool.pro
+++ b/generator/generator_tool/generator_tool.pro
@@ -3,7 +3,7 @@
 ROOT_DIR = ../..
 DEPENDENCIES = generator routing storage indexer platform geometry coding base \
                osrm gflags expat tess2 jansson protobuf tomcrypt \
-               succinct stats_client
+               succinct stats_client pugixml
 
 include($$ROOT_DIR/common.pri)
 

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -149,6 +149,28 @@ void FeatureType::ParseMetadata() const
   m_bMetadataParsed = true;
 }
 
+void FeatureType::SetNames(StringUtf8Multilang const & newNames)
+{
+  m_params.name.Clear();
+  // Validate passed string to clean up empty names (if any).
+  newNames.ForEachRef([this](int8_t langCode, string const & name) -> bool
+  {
+    if (!name.empty())
+      m_params.name.AddString(langCode, name);
+    return true;
+  });
+
+  if (m_params.name.IsEmpty())
+    SetHeader(~feature::HEADER_HAS_NAME & Header());
+  else
+    SetHeader(feature::HEADER_HAS_NAME | Header());
+}
+
+void FeatureType::SetMetadata(feature::Metadata const & newMetadata)
+{
+  m_bMetadataParsed = true;
+  m_metadata = newMetadata;
+}
 
 namespace
 {

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -156,6 +156,12 @@ public:
   inline void SetID(FeatureID const & id) { m_id = id; }
   inline FeatureID GetID() const { return m_id; }
 
+  /// @name Editor functions.
+  //@{
+  void SetNames(StringUtf8Multilang const & newNames);
+  void SetMetadata(feature::Metadata const & newMetadata);
+  //@}
+
   /// @name Parse functions. Do simple dispatching to m_pLoader.
   //@{
   void ParseHeader2() const;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -21,7 +21,6 @@ namespace old_101 { namespace feature
   class LoaderImpl;
 }}
 
-
 /// Base feature class for storing common data (without geometry).
 class FeatureBase
 {

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -79,7 +79,7 @@ public:
   */
 
   template <class T>
-  inline bool ForEachNameRef(T & functor) const
+  inline bool ForEachNameRef(T && functor) const
   {
     if (!HasName())
       return false;

--- a/indexer/index.cpp
+++ b/indexer/index.cpp
@@ -115,6 +115,11 @@ bool Index::FeaturesLoaderGuard::IsWorld() const
 
 void Index::FeaturesLoaderGuard::GetFeatureByIndex(uint32_t index, FeatureType & ft) const
 {
-  m_vector.GetByIndex(index, ft);
-  ft.SetID(FeatureID(m_handle.GetId(), index));
+  FeatureID const fid(m_handle.GetId(), index);
+  ASSERT(!m_editor.IsFeatureDeleted(fid), ("Deleted feature was cached. Please review your code."));
+  if (!m_editor.Instance().GetEditedFeature(fid, ft))
+  {
+    m_vector.GetByIndex(index, ft);
+    ft.SetID(fid);
+  }
 }

--- a/indexer/index.hpp
+++ b/indexer/index.hpp
@@ -214,13 +214,6 @@ public:
   }
 
   template <typename F>
-  void ForEachInRect_TileDrawing(F & f, m2::RectD const & rect, uint32_t scale) const
-  {
-    ReadMWMFunctor<F> implFunctor(f);
-    ForEachInIntervals(implFunctor, covering::LowLevelsOnly, rect, scale);
-  }
-
-  template <typename F>
   void ForEachFeatureIDInRect(F & f, m2::RectD const & rect, uint32_t scale) const
   {
     ReadFeatureIndexFunctor<F> implFunctor(f);

--- a/indexer/index.hpp
+++ b/indexer/index.hpp
@@ -114,19 +114,20 @@ private:
         uint32_t const lastScale = header.GetLastScale();
 
         // In case of WorldCoasts we should pass correct scale in ForEachInIntervalAndScale.
-        if (scale > lastScale) scale = lastScale;
+        if (scale > lastScale)
+          scale = lastScale;
 
         // Use last coding scale for covering (see index_builder.cpp).
         covering::IntervalsT const & interval = cov.Get(lastScale);
 
-        // prepare features reading
-        FeaturesVector fv(pValue->m_cont, header, pValue->m_table);
+        // Prepare features reading.
+        FeaturesVector const fv(pValue->m_cont, header, pValue->m_table);
         ScaleIndex<ModelReaderPtr> index(pValue->m_cont.GetReader(INDEX_FILE_TAG),
                                          pValue->m_factory);
 
         // iterate through intervals
         CheckUniqueIndexes checkUnique(header.GetFormat() >= version::v5);
-        MwmId const mwmID = handle.GetId();
+        MwmId const & mwmID = handle.GetId();
 
         for (auto const & i : interval)
         {
@@ -179,16 +180,16 @@ private:
         int const lastScale = header.GetLastScale();
 
         // In case of WorldCoasts we should pass correct scale in ForEachInIntervalAndScale.
-        if (scale > lastScale) scale = lastScale;
+        if (scale > lastScale)
+          scale = lastScale;
 
         // Use last coding scale for covering (see index_builder.cpp).
         covering::IntervalsT const & interval = cov.Get(lastScale);
-        ScaleIndex<ModelReaderPtr> index(pValue->m_cont.GetReader(INDEX_FILE_TAG),
-                                         pValue->m_factory);
+        ScaleIndex<ModelReaderPtr> const index(pValue->m_cont.GetReader(INDEX_FILE_TAG), pValue->m_factory);
 
-        // iterate through intervals
+        // Iterate through intervals.
         CheckUniqueIndexes checkUnique(header.GetFormat() >= version::v5);
-        MwmId const mwmID = handle.GetId();
+        MwmId const & mwmID = handle.GetId();
 
         for (auto const & i : interval)
         {
@@ -275,7 +276,7 @@ public:
   public:
     FeaturesLoaderGuard(Index const & parent, MwmId id);
 
-    inline MwmSet::MwmId GetId() const { return m_handle.GetId(); }
+    inline MwmSet::MwmId const & GetId() const { return m_handle.GetId(); }
     string GetCountryFileName() const;
     bool IsWorld() const;
     void GetFeatureByIndex(uint32_t index, FeatureType & ft) const;
@@ -287,7 +288,7 @@ public:
   };
 
   template <typename F>
-  void ForEachInRectForMWM(F & f, m2::RectD const & rect, uint32_t scale, MwmId const id) const
+  void ForEachInRectForMWM(F & f, m2::RectD const & rect, uint32_t scale, MwmId const & id) const
   {
     MwmHandle const handle = GetMwmHandleById(id);
     if (handle.IsAlive())
@@ -318,7 +319,7 @@ private:
       if (info->m_minScale <= scale && scale <= info->m_maxScale &&
           rect.IsIntersect(info->m_limitRect))
       {
-        MwmId id(info);
+        MwmId const id(info);
         switch (info->GetType())
         {
           case MwmInfo::COUNTRY:

--- a/indexer/index.hpp
+++ b/indexer/index.hpp
@@ -5,6 +5,7 @@
 #include "indexer/features_offsets_table.hpp"
 #include "indexer/features_vector.hpp"
 #include "indexer/mwm_set.hpp"
+#include "indexer/osm_editor.hpp"
 #include "indexer/scale_index.hpp"
 #include "indexer/unique_index.hpp"
 
@@ -92,8 +93,15 @@ private:
   template <typename F> class ReadMWMFunctor
   {
     F & m_f;
+    osm::Editor & m_editor = osm::Editor::Instance();
   public:
     ReadMWMFunctor(F & f) : m_f(f) {}
+
+    /// Used by Editor to inject new features.
+    void operator()(FeatureType & feature)
+    {
+      m_f(feature);
+    }
 
     void operator()(MwmHandle const & handle, covering::CoveringGetter & cov, uint32_t scale) const
     {
@@ -122,18 +130,26 @@ private:
 
         for (auto const & i : interval)
         {
-          index.ForEachInIntervalAndScale([&] (uint32_t index)
-          {
-            if (checkUnique(index))
-            {
-              FeatureType feature;
-
-              fv.GetByIndex(index, feature);
-              feature.SetID(FeatureID(mwmID, index));
-
-              m_f(feature);
-            }
-          }, i.first, i.second, scale);
+          index.ForEachInIntervalAndScale(
+              [&](uint32_t index)
+              {
+                FeatureID const fid(mwmID, index);
+                if (m_editor.IsFeatureDeleted(fid))
+                  return;
+                FeatureType feature;
+                if (m_editor.GetEditedFeature(fid, feature))
+                {
+                  m_f(feature);
+                  return;
+                }
+                if (checkUnique(index))
+                {
+                  fv.GetByIndex(index, feature);
+                  feature.SetID(fid);
+                  m_f(feature);
+                }
+              },
+              i.first, i.second, scale);
         }
       }
     }
@@ -142,8 +158,15 @@ private:
   template <typename F> class ReadFeatureIndexFunctor
   {
     F & m_f;
+    osm::Editor & m_editor = osm::Editor::Instance();
   public:
     ReadFeatureIndexFunctor(F & f) : m_f(f) {}
+
+    /// Used by Editor to inject new features.
+    void operator()(FeatureID const & fid) const
+    {
+      m_f(fid);
+    }
 
     void operator()(MwmHandle const & handle, covering::CoveringGetter & cov, uint32_t scale) const
     {
@@ -171,8 +194,9 @@ private:
         {
           index.ForEachInIntervalAndScale([&] (uint32_t index)
           {
-            if (checkUnique(index))
-              m_f(FeatureID(mwmID, index));
+            FeatureID const fid(mwmID, index);
+            if (!m_editor.IsFeatureDeleted(fid) && checkUnique(index))
+              m_f(fid);
           }, i.first, i.second, scale);
         }
       }
@@ -215,6 +239,7 @@ public:
   {
     auto fidIter = features.begin();
     auto const endIter = features.end();
+    auto & editor = osm::Editor::Instance();
     while (fidIter != endIter)
     {
       MwmId const & id = fidIter->m_mwmId;
@@ -225,9 +250,13 @@ public:
         FeaturesVector const featureReader(pValue->m_cont, pValue->GetHeader(), pValue->m_table);
         do
         {
+          ASSERT(!editor.IsFeatureDeleted(*fidIter), ("Deleted feature was cached. Please review your code."));
           FeatureType featureType;
-          featureReader.GetByIndex(fidIter->m_index, featureType);
-          featureType.SetID(*fidIter);
+          if (!editor.GetEditedFeature(*fidIter, featureType))
+          {
+            featureReader.GetByIndex(fidIter->m_index, featureType);
+            featureType.SetID(*fidIter);
+          }
           f(featureType);
         }
         while (++fidIter != endIter && id == fidIter->m_mwmId);
@@ -254,6 +283,7 @@ public:
   private:
     MwmHandle m_handle;
     FeaturesVector m_vector;
+    osm::Editor & m_editor = osm::Editor::Instance();
   };
 
   template <typename F>
@@ -281,6 +311,8 @@ private:
 
     MwmId worldID[2];
 
+    osm::Editor & editor = osm::Editor::Instance();
+
     for (shared_ptr<MwmInfo> const & info : mwms)
     {
       if (info->m_minScale <= scale && scale <= info->m_maxScale &&
@@ -293,6 +325,9 @@ private:
           {
             MwmHandle const handle = GetMwmHandleById(id);
             f(handle, cov, scale);
+            // Check created features container.
+            // Need to do it on a per-mwm basis, because Drape relies on features in a sorted order.
+            editor.ForEachFeatureInMwmRectAndScale(id, f, rect, scale);
           }
           break;
 
@@ -311,12 +346,18 @@ private:
     {
       MwmHandle const handle = GetMwmHandleById(worldID[0]);
       f(handle, cov, scale);
+      // Check edited/created features container.
+      // Need to do it on a per-mwm basis, because Drape relies on features in a sorted order.
+      editor.ForEachFeatureInMwmRectAndScale(worldID[0], f, rect, scale);
     }
 
     if (worldID[1].IsAlive())
     {
       MwmHandle const handle = GetMwmHandleById(worldID[1]);
       f(handle, cov, scale);
+      // Check edited/created features container.
+      // Need to do it on a per-mwm basis, because Drape relies on features in a sorted order.
+      editor.ForEachFeatureInMwmRectAndScale(worldID[1], f, rect, scale);
     }
   }
 

--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -42,6 +42,7 @@ SOURCES += \
     map_style_reader.cpp \
     mwm_set.cpp \
     old/feature_loader_101.cpp \
+    osm_editor.cpp \
     point_to_int64.cpp \
     scales.cpp \
     search_delimiters.cpp \
@@ -90,6 +91,7 @@ HEADERS += \
     mwm_set.hpp \
     old/feature_loader_101.hpp \
     old/interval_index_101.hpp \
+    osm_editor.hpp \
     point_to_int64.hpp \
     scale_index.hpp \
     scale_index_builder.hpp \

--- a/indexer/indexer_tests/indexer_tests.pro
+++ b/indexer/indexer_tests/indexer_tests.pro
@@ -4,7 +4,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = indexer platform geometry coding base protobuf tomcrypt
+DEPENDENCIES = indexer platform geometry coding base protobuf tomcrypt pugixml
 DEPENDENCIES += opening_hours
 
 include($$ROOT_DIR/common.pri)

--- a/indexer/osm_editor.cpp
+++ b/indexer/osm_editor.cpp
@@ -1,0 +1,150 @@
+#include "indexer/classificator.hpp"
+#include "indexer/feature_decl.hpp"
+#include "indexer/index.hpp"
+#include "indexer/osm_editor.hpp"
+
+#include "platform/platform.hpp"
+
+#include "base/logging.hpp"
+
+#include "std/map.hpp"
+#include "std/set.hpp"
+
+#include "3party/pugixml/src/pugixml.hpp"
+
+using namespace pugi;
+using feature::EGeomType;
+using feature::Metadata;
+
+static char constexpr const * kEditorXMLFileName = "edits.xml";
+
+namespace osm
+{
+
+// TODO(AlexZ): Normalize osm multivalue strings for correct merging
+// (e.g. insert/remove spaces after ';' delimeter);
+
+namespace
+{
+string GetEditorFilePath() { return GetPlatform().WritablePathForFile(kEditorXMLFileName); }
+} // namespace
+
+Editor::Editor()
+{
+  // Load all previous edits from persistent storage.
+  Load(GetEditorFilePath());
+}
+
+Editor & Editor::Instance()
+{
+  static Editor instance;
+  return instance;
+}
+
+void Editor::Load(string const & fullFilePath)
+{
+  xml_document xml;
+  xml_parse_result res = xml.load_file(fullFilePath.c_str());
+  // Note: status_file_not_found is ok if user has never made any edits.
+  if (res != status_ok && res != status_file_not_found)
+  {
+    LOG(LERROR, ("Can't load XML Edits from disk:", fullFilePath));
+  }
+  // TODO(mgsergio): Implement XML deserialization into m_[deleted|edited|created]Features.
+}
+
+void Editor::Save(string const & /*fullFilePath*/) const
+{
+  // Do not save empty xml file if no any edits were made.
+  if (m_deletedFeatures.empty() && m_editedFeatures.empty() && m_createdFeatures.empty())
+    return;
+  // TODO(mgsergio): Implement XML serialization from m_[deleted|edited|created]Features.
+}
+
+bool Editor::IsFeatureDeleted(FeatureID const & fid) const
+{
+  // Most popular case optimization.
+  if (m_deletedFeatures.empty())
+    return false;
+
+  return m_deletedFeatures.find(fid) != m_deletedFeatures.end();
+}
+
+void Editor::DeleteFeature(FeatureType const & feature)
+{
+  m_deletedFeatures.insert(feature.GetID());
+  // TODO(AlexZ): Synchronize Save call/make it on a separate thread.
+  Save(GetEditorFilePath());
+
+  if (m_invalidateFn)
+    m_invalidateFn();
+}
+
+//namespace
+//{
+//FeatureID GenerateNewFeatureId(FeatureID const & oldFeatureId)
+//{
+//  // TODO(AlexZ): Stable & unique features ID generation.
+//  static uint32_t newOffset = 0x0effffff;
+//  return FeatureID(oldFeatureId.m_mwmId, newOffset++);
+//}
+//}  // namespace
+
+void Editor::EditFeature(FeatureType & editedFeature)
+{
+  m_editedFeatures[editedFeature.GetID()] = editedFeature;
+  // TODO(AlexZ): Synchronize Save call/make it on a separate thread.
+  Save(GetEditorFilePath());
+
+  if (m_invalidateFn)
+    m_invalidateFn();
+}
+
+bool Editor::IsFeatureEdited(FeatureID const & fid) const
+{
+  return m_editedFeatures.find(fid) != m_editedFeatures.end();
+}
+
+void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
+                                             function<void(FeatureID const &)> const & f,
+                                             m2::RectD const & /*rect*/,
+                                             uint32_t /*scale*/)
+{
+  // TODO(AlexZ): Check that features are in the rect and are visible at this scale.
+  for (auto & feature : m_createdFeatures)
+  {
+    if (feature.first.m_mwmId == id)
+      f(feature.first);
+  }
+}
+
+void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
+                                             function<void(FeatureType &)> const & f,
+                                             m2::RectD const & /*rect*/,
+                                             uint32_t /*scale*/)
+{
+  // TODO(AlexZ): Check that features are in the rect and are visible at this scale.
+  for (auto & feature : m_createdFeatures)
+  {
+    if (feature.first.m_mwmId == id)
+      f(feature.second);
+  }
+}
+
+bool Editor::GetEditedFeature(FeatureID const & fid, FeatureType & outFeature) const
+{
+  auto found = m_editedFeatures.find(fid);
+  if (found == m_editedFeatures.end())
+    return false;
+  outFeature = found->second;
+  return true;
+}
+
+vector<Metadata::EType> Editor::EditableMetadataForType(uint32_t type) const
+{
+  // TODO(mgsergio): Load editable fields into memory from XML and query them here.
+  // Enable opening hours for the first release.
+  return {Metadata::FMD_OPEN_HOURS};
+}
+
+}  // namespace osm

--- a/indexer/osm_editor.hpp
+++ b/indexer/osm_editor.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "geometry/rect2d.hpp"
+
+#include "indexer/feature_meta.hpp"
+#include "indexer/mwm_set.hpp"
+
+#include "std/function.hpp"
+#include "std/map.hpp"
+#include "std/set.hpp"
+#include "std/string.hpp"
+
+struct FeatureID;
+class FeatureType;
+class Index;
+
+namespace osm
+{
+
+class Editor final
+{
+  Editor();
+
+public:
+  using TInvalidateFn = function<void()>;
+
+  static Editor & Instance();
+
+  void SetInvalidateFn(TInvalidateFn && fn) { m_invalidateFn = move(fn); }
+
+  void Load(string const & fullFilePath);
+  // TODO(AlexZ): Synchronize Save call/make it on a separate thread.
+  void Save(string const & fullFilePath) const;
+
+  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
+                                       function<void(FeatureID const &)> const & f,
+                                       m2::RectD const & rect,
+                                       uint32_t scale);
+  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
+                                       function<void(FeatureType &)> const & f,
+                                       m2::RectD const & rect,
+                                       uint32_t scale);
+
+  /// True if feature was deleted by user.
+  bool IsFeatureDeleted(FeatureID const & fid) const;
+
+  /// Marks feature as "deleted" from MwM file.
+  void DeleteFeature(FeatureType const & feature);
+
+  /// True if feature was edited by user.
+  bool IsFeatureEdited(FeatureID const & fid) const;
+  /// @returns false if feature wasn't edited.
+  /// @param outFeature is valid only if true was returned.
+  bool GetEditedFeature(FeatureID const & fid, FeatureType & outFeature) const;
+
+  /// Original feature with same FeatureID as newFeature is replaced by newFeature.
+  void EditFeature(FeatureType & editedFeature);
+
+  vector<feature::Metadata::EType> EditableMetadataForType(uint32_t type) const;
+
+private:
+  // TODO(AlexZ): Synchronize multithread access to these structures.
+  set<FeatureID> m_deletedFeatures;
+  map<FeatureID, FeatureType> m_editedFeatures;
+  map<FeatureID, FeatureType> m_createdFeatures;
+
+  /// Invalidate map viewport after edits.
+  TInvalidateFn m_invalidateFn;
+};  // class Editor
+
+}  // namespace osm

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -4810,6 +4810,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = "maps.me dbg";
 				SDKROOT = iphoneos;
@@ -4930,6 +4931,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = "maps.me dbg";
 				SDKROOT = iphoneos;
@@ -5052,6 +5054,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = "maps.me beta";
 				SDKROOT = iphoneos;
@@ -5175,6 +5178,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = maps.me;
 				SDKROOT = iphoneos;
@@ -5297,6 +5301,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = "maps.me rel";
 				SDKROOT = iphoneos;
@@ -5417,6 +5422,7 @@
 					"-lsuccinct",
 					"-ObjC",
 					"-lopening_hours",
+					"-lpugixml",
 				);
 				PRODUCT_NAME = "maps.me rel";
 				SDKROOT = iphoneos;

--- a/map/benchmark_tool/benchmark_tool.pro
+++ b/map/benchmark_tool/benchmark_tool.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../..
 
-DEPENDENCIES = map indexer platform geometry coding base gflags protobuf tomcrypt
+DEPENDENCIES = map indexer platform geometry coding base gflags protobuf tomcrypt pugixml
 
 include($$ROOT_DIR/common.pri)
 

--- a/map/feature_vec_model.hpp
+++ b/map/feature_vec_model.hpp
@@ -75,12 +75,6 @@ class FeaturesFetcher : public Index::Observer
     }
 
     template <class ToDo>
-    void ForEachFeature_TileDrawing(m2::RectD const & rect, ToDo & toDo, int scale) const
-    {
-      m_multiIndex.ForEachInRect_TileDrawing(toDo, rect, scale);
-    }
-
-    template <class ToDo>
     void ForEachFeatureID(m2::RectD const & rect, ToDo & toDo, int scale) const
     {
       m_multiIndex.ForEachFeatureIDInRect(toDo, rect, scale);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -27,6 +27,7 @@
 #include "indexer/drawing_rules.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/map_style_reader.hpp"
+#include "indexer/osm_editor.hpp"
 #include "indexer/scales.hpp"
 
 /// @todo Probably it's better to join this functionality.
@@ -268,6 +269,8 @@ Framework::Framework()
   LOG(LDEBUG, ("Routing engine initialized"));
 
   LOG(LINFO, ("System languages:", languages::GetPreferred()));
+
+  osm::Editor::Instance().SetInvalidateFn([this](){ InvalidateRect(GetCurrentViewport()); });
 }
 
 Framework::~Framework()

--- a/map/map_tests/map_tests.pro
+++ b/map/map_tests/map_tests.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../..
 DEPENDENCIES = map drape_frontend routing search storage drape indexer platform geometry coding base \
-               freetype fribidi expat protobuf tomcrypt jansson osrm stats_client minizip succinct
+               freetype fribidi expat protobuf tomcrypt jansson osrm stats_client minizip succinct pugixml
 
 DEPENDENCIES *= opening_hours
 

--- a/map/mwm_tests/multithread_mwm_test.cpp
+++ b/map/mwm_tests/multithread_mwm_test.cpp
@@ -46,7 +46,7 @@ namespace
         m2::RectD const r = GetRandomRect();
         m_scale = scales::GetScaleLevel(r);
 
-        m_src.ForEachFeature_TileDrawing(r, *this, m_scale);
+        m_src.ForEachFeature(r, *this, m_scale);
       }
     }
 

--- a/map/mwm_tests/mwm_tests.pro
+++ b/map/mwm_tests/mwm_tests.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../..
 DEPENDENCIES = map search storage indexer platform geometry coding base \
-               freetype fribidi expat protobuf tomcrypt jansson
+               freetype fribidi expat protobuf tomcrypt jansson pugixml
 
 include($$ROOT_DIR/common.pri)
 

--- a/mapshot/mapshot.pro
+++ b/mapshot/mapshot.pro
@@ -2,7 +2,7 @@
 
 ROOT_DIR = ..
 DEPENDENCIES = map drape_frontend routing search storage indexer drape platform geometry coding base \
-               freetype expat fribidi tomcrypt gflags jansson protobuf osrm stats_client minizip succinct
+               freetype expat fribidi tomcrypt gflags jansson protobuf osrm stats_client minizip succinct pugixml
 
 include($$ROOT_DIR/common.pri)
 

--- a/pedestrian_routing_tests/pedestrian_routing_tests.pro
+++ b/pedestrian_routing_tests/pedestrian_routing_tests.pro
@@ -5,7 +5,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../
 DEPENDENCIES = map routing search storage indexer platform geometry coding base \
-               osrm jansson protobuf tomcrypt succinct
+               osrm jansson protobuf tomcrypt succinct pugixml
 
 macx-*: LIBS *= "-framework IOKit"
 

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -18,9 +18,10 @@
 #include <QtGui/QOpenGLFunctions>
 #include <QtGui/QVector2D>
 
-#include <QtWidgets/QMenu>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QMenu>
 
 #include <QtCore/QLocale>
 #include <QtCore/QDateTime>
@@ -472,31 +473,21 @@ void DrawWidget::ShowPOIEditor(m2::PointD const & pt)
     return;
 
   // Show Edit POI dialog.
-  EditorDialog(this, feature).exec();
-/*
+  auto & editor = osm::Editor::Instance();
+  EditorDialog dlg(this, feature);
   int const result = dlg.exec();
   if (result == QDialog::Accepted)
   {
-    // TODO(AlexZ): Uncomment and finish the code below.
     // Save edited data.
-    string const editedName = lineEditName->text().toStdString();
-    if (editedName != info.m_name)
-      m_framework->EditFeatureName(feature.GetID(), editedName);
-    // TODO: Compare with
-    // 1) osm::EditFeatureName(feature, editedName);
-    // 2) feature.EditName(editedName);
-    // 3) m_framework->EditFeature(feature.EditName(editedName));
-
-    // Save edited metadata (if any).
-    size_t index = 0;
-    for (auto const field : editableMetadataFields)
-      metadata.Set(field, metaFieldEditors[index]->text().toStdString());
+    feature.SetNames(dlg.GetEditedNames());
+    // Save edited metadata.
+    feature.SetMetadata(dlg.GetEditedMetadata());
+    editor.EditFeature(feature);
   }
   else if (result == QDialogButtonBox::DestructiveRole)
   {
-    m_framework->DeleteFeature(feature.GetID());
+    editor.DeleteFeature(feature);
   }
-*/
 }
 
 void DrawWidget::ShowInfoPopup(QMouseEvent * e, m2::PointD const & pt)

--- a/qt/editor_dialog.cpp
+++ b/qt/editor_dialog.cpp
@@ -4,7 +4,7 @@
 
 #include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
-#include "indexer/feature_meta.hpp"
+#include "indexer/osm_editor.hpp"
 
 #include "std/set.hpp"
 #include "std/vector.hpp"
@@ -34,43 +34,55 @@ EditorDialog::EditorDialog(QWidget * parent, FeatureType const & feature) : QDia
   typesRow->addWidget(new QLabel("Types:"));
   typesRow->addWidget(new QLabel(QString::fromStdString(strTypes)));
   vLayout->addLayout(typesRow);
-  // Second row: Name label and text input.
-  QHBoxLayout * nameRow = new QHBoxLayout();
-  nameRow->addWidget(new QLabel("Name:"));
-  // TODO(AlexZ): Print names in all available languages.
-  string defaultName, intName;
-  feature.GetPreferredNames(defaultName, intName);
-  QLineEdit * lineEditName = new QLineEdit(QString::fromStdString(defaultName));
-  nameRow->addWidget(lineEditName);
-  vLayout->addLayout(nameRow);
 
-  // More rows: All  metadata rows.
+  // Rows block: Name(s) label(s) and text input.
+  char const * defaultLangStr = StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::DEFAULT_CODE);
+  // Default name editor is always displayed, even if feature name is empty.
+  QHBoxLayout * defaultNameRow = new QHBoxLayout();
+  defaultNameRow->addWidget(new QLabel(QString("Name:")));
+  QLineEdit * defaultNamelineEdit = new QLineEdit();
+  defaultNamelineEdit->setObjectName(defaultLangStr);
+  defaultNameRow->addWidget(defaultNamelineEdit);
+  vLayout->addLayout(defaultNameRow);
+
+  feature.ForEachNameRef([&vLayout, &defaultNamelineEdit](int8_t langCode, string const & name) -> bool
+  {
+    if (langCode == StringUtf8Multilang::DEFAULT_CODE)
+      defaultNamelineEdit->setText(QString::fromStdString(name));
+    else
+    {
+      QHBoxLayout * nameRow = new QHBoxLayout();
+      char const * langStr = StringUtf8Multilang::GetLangByCode(langCode);
+      nameRow->addWidget(new QLabel(QString("Name:") + langStr));
+      QLineEdit * lineEditName = new QLineEdit(QString::fromStdString(name));
+      lineEditName->setObjectName(langStr);
+      nameRow->addWidget(lineEditName);
+      vLayout->addLayout(nameRow);
+    }
+    return true; // true is needed to enumerate all languages.
+  });
+
+  // All  metadata rows.
   QVBoxLayout * metaRows = new QVBoxLayout();
-  // TODO(mgsergio): Load editable fields from metadata.
-  vector<Metadata::EType> editableMetadataFields;
-  // TODO(AlexZ): Temporary enable only existing meta information fields.
-  // Final editor should have all editable fields enabled.
-  editableMetadataFields = feature.GetMetadata().GetPresentTypes();
-/*
+  // TODO(mgsergio): Load editable fields from metadata. Features can have several types, so we merge all editable fields here.
+  set<Metadata::EType> editableMetadataFields;
   // Merge editable fields for all feature's types.
   feature.ForEachType([&editableMetadataFields](uint32_t type)
   {
-    auto const editableFields = osm::Editor::EditableMetadataForType(type);
+    auto const editableFields = osm::Editor::Instance().EditableMetadataForType(type);
     editableMetadataFields.insert(editableFields.begin(), editableFields.end());
   });
-*/
-  // Equals to editableMetadataFields, used to retrieve text entered by user.
-  vector<QLineEdit *> metaFieldEditors;
-  for (auto const field : editableMetadataFields)
+  for (Metadata::EType const field : editableMetadataFields)
   {
+    QString const fieldName = QString::fromStdString(DebugPrint(field));
     QHBoxLayout * fieldRow = new QHBoxLayout();
-    fieldRow->addWidget(new QLabel(QString::fromStdString(DebugPrint(field) + ":")));
+    fieldRow->addWidget(new QLabel(fieldName + ":"));
     QLineEdit * lineEdit = new QLineEdit(QString::fromStdString(feature.GetMetadata().Get(field)));
+    // Mark line editor to query it's text value when editing is finished.
+    lineEdit->setObjectName(fieldName);
     fieldRow->addWidget(lineEdit);
-    metaFieldEditors.push_back(lineEdit);
     metaRows->addLayout(fieldRow);
   }
-  ASSERT_EQUAL(editableMetadataFields.size(), metaFieldEditors.size(), ());
   vLayout->addLayout(metaRows);
 
   // Dialog buttons.
@@ -91,4 +103,31 @@ EditorDialog::EditorDialog(QWidget * parent, FeatureType const & feature) : QDia
 
   setLayout(vLayout);
   setWindowTitle("POI Editor");
+}
+
+StringUtf8Multilang EditorDialog::GetEditedNames() const
+{
+  StringUtf8Multilang names;
+  for (int8_t langCode = StringUtf8Multilang::DEFAULT_CODE; langCode < StringUtf8Multilang::MAX_SUPPORTED_LANGUAGES; ++langCode)
+  {
+    QLineEdit * le = findChild<QLineEdit *>(StringUtf8Multilang::GetLangByCode(langCode));
+    if (!le)
+      continue;
+    string const name = le->text().toStdString();
+    if (!name.empty())
+      names.AddString(langCode, name);
+  }
+  return names;
+}
+
+Metadata EditorDialog::GetEditedMetadata() const
+{
+  Metadata metadata;
+  for (int type = Metadata::FMD_CUISINE; type < Metadata::FMD_COUNT; ++type)
+  {
+    QLineEdit * editor = findChild<QLineEdit *>(QString::fromStdString(DebugPrint(static_cast<Metadata::EType>(type))));
+    if (editor)
+      metadata.Set(static_cast<Metadata::EType>(type), editor->text().toStdString());
+  }
+  return metadata;
 }

--- a/qt/editor_dialog.hpp
+++ b/qt/editor_dialog.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "indexer/feature_meta.hpp"
+
+#include "coding/multilang_utf8_string.hpp"
+
 #include "std/string.hpp"
 
 #include <QtWidgets/QDialog>
@@ -12,4 +16,6 @@ class EditorDialog : public QDialog
   Q_OBJECT
 public:
   EditorDialog(QWidget * parent, FeatureType const & feature);
+  StringUtf8Multilang GetEditedNames() const;
+  feature::Metadata GetEditedMetadata() const;
 };

--- a/qt/qt.pro
+++ b/qt/qt.pro
@@ -1,7 +1,7 @@
 # Main application in qt.
 ROOT_DIR = ..
 DEPENDENCIES = map drape_frontend routing search storage indexer drape platform geometry coding base \
-               freetype expat fribidi tomcrypt jansson protobuf osrm stats_client minizip succinct
+               freetype expat fribidi tomcrypt jansson protobuf osrm stats_client minizip succinct pugixml
 
 
 DEPENDENCIES += opening_hours \

--- a/routing/routing_consistency_tests/routing_consistency_tests.pro
+++ b/routing/routing_consistency_tests/routing_consistency_tests.pro
@@ -7,7 +7,8 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = map routing search storage indexer platform geometry coding base osrm jansson protobuf tomcrypt succinct stats_client generator gflags
+DEPENDENCIES = map routing search storage indexer platform geometry coding base osrm \
+               jansson protobuf tomcrypt succinct stats_client generator gflags pugixml
 
 include($$ROOT_DIR/common.pri)
 

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -11,7 +11,8 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = map routing search storage indexer platform geometry coding base osrm jansson protobuf tomcrypt succinct stats_client
+DEPENDENCIES = map routing search storage indexer platform geometry coding base \
+               osrm jansson protobuf tomcrypt succinct stats_client pugixml
 
 DEPENDENCIES += opening_hours
 

--- a/routing/routing_tests/routing_tests.pro
+++ b/routing/routing_tests/routing_tests.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../..
 DEPENDENCIES = routing indexer platform_tests_support platform geometry coding base \
-               osrm protobuf tomcrypt succinct jansson stats_client map
+               osrm protobuf tomcrypt succinct jansson stats_client map pugixml
 
 macx-*: LIBS *= "-framework IOKit" "-framework SystemConfiguration"
 

--- a/search/search_integration_tests/search_integration_tests.pro
+++ b/search/search_integration_tests/search_integration_tests.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 ROOT_DIR = ../..
 DEPENDENCIES = generator_tests_support generator routing search storage stats_client indexer \
-               platform geometry coding base tess2 protobuf tomcrypt jansson
+               platform geometry coding base tess2 protobuf tomcrypt jansson pugixml
 
 DEPENDENCIES += opening_hours \
 

--- a/search/search_tests/search_tests.pro
+++ b/search/search_tests/search_tests.pro
@@ -6,7 +6,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = search indexer platform geometry coding base protobuf tomcrypt
+DEPENDENCIES = search indexer platform geometry coding base protobuf tomcrypt pugixml
 
 include($$ROOT_DIR/common.pri)
 


### PR DESCRIPTION
Код ядра редактора с UI в QtCreator (можно кликать левой мышкой в POI и редактировать поля).
Особенности:
- В QT сейчас редактируются все name поля и одно поле метаинформации - opening hours.
- Там же можно удалять фичи.
- Пока нет создания фич, только заглушки.
- Фича с подредактированным именем не находится в поиске. Это TODO @vng и @ygorshenin в search_query.cpp
- Пока нет сериализации фич (TODO @mgsergio ) и отправки их на сервер.