### PR TITLE
Improved tiles loading on 17-19 zoom levels

### DIFF
--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -147,6 +147,7 @@ private:
   void ResolveTileKeys(ScreenBase const & screen, TTilesCollection & tiles);
   void ResolveTileKeys(m2::RectD const & rect, TTilesCollection & tiles);
   int GetCurrentZoomLevel() const;
+  int GetCurrentZoomLevelForData() const;
   void ResolveZoomLevel(ScreenBase const & screen);
 
   void OnTap(m2::PointD const & pt, bool isLong) override;
@@ -197,7 +198,7 @@ private:
   using TRenderGroupRemovePredicate = function<bool(drape_ptr<RenderGroup> const &)>;
   void RemoveRenderGroups(TRenderGroupRemovePredicate const & predicate);
 
-  void CheckTileGenerations(TileKey const & tileKey);
+  bool CheckTileGenerations(TileKey const & tileKey);
 
   void OnCompassTapped();
 
@@ -230,6 +231,7 @@ private:
   unique_ptr<TileTree> m_tileTree;
   int m_currentZoomLevel = -1;
   ref_ptr<RequestedTiles> m_requestedTiles;
+  uint64_t m_maxGeneration;
 };
 
 } // namespace df

--- a/drape_frontend/read_manager.cpp
+++ b/drape_frontend/read_manager.cpp
@@ -171,8 +171,8 @@ size_t ReadManager::ReadCount()
 
 bool ReadManager::MustDropAllTiles(ScreenBase const & screen) const
 {
-  int const oldScale = df::GetTileScaleBase(m_currentViewport);
-  int const newScale = df::GetTileScaleBase(screen);
+  int const oldScale = df::GetDrawTileScale(m_currentViewport);
+  int const newScale = df::GetDrawTileScale(screen);
   return (oldScale != newScale) || !m_currentViewport.GlobalRect().IsIntersect(screen.GlobalRect());
 }
 

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -50,9 +50,11 @@ RuleDrawer::RuleDrawer(TDrawerCallback const & fn,
   m_globalRect = m_context->GetTileKey().GetGlobalRect();
 
   int32_t tileSize = df::VisualParams::Instance().GetTileSize();
-  m_geometryConvertor.OnSize(0, 0, tileSize, tileSize);
-  m_geometryConvertor.SetFromRect(m2::AnyRectD(m_globalRect));
-  m_currentScaleGtoP = 1.0f / m_geometryConvertor.GetScale();
+  m2::RectD const r = m_context->GetTileKey().GetGlobalRect(true /* considerStyleZoom */);
+  ScreenBase geometryConvertor;
+  geometryConvertor.OnSize(0, 0, tileSize, tileSize);
+  geometryConvertor.SetFromRect(m2::AnyRectD(r));
+  m_currentScaleGtoP = 1.0f / geometryConvertor.GetScale();
 
   for (size_t i = 0; i < m_mapShapes.size(); i++)
     m_mapShapes[i].reserve(kMinFlushSizes[i] + 1);

--- a/drape_frontend/rule_drawer.hpp
+++ b/drape_frontend/rule_drawer.hpp
@@ -43,7 +43,6 @@ private:
 
   ref_ptr<EngineContext> m_context;
   m2::RectD m_globalRect;
-  ScreenBase m_geometryConvertor;
   double m_currentScaleGtoP;
 
   array<TMapShapes, df::PrioritiesCount> m_mapShapes;

--- a/drape_frontend/tile_info.cpp
+++ b/drape_frontend/tile_info.cpp
@@ -99,10 +99,8 @@ void TileInfo::ProcessID(FeatureID const & id)
 void TileInfo::InitStylist(FeatureType const & f, Stylist & s)
 {
   CheckCanceled();
-  df::InitStylist(f, m_context->GetTileKey().m_zoomLevel, s);
+  df::InitStylist(f, m_context->GetTileKey().m_styleZoomLevel, s);
 }
-
-//====================================================//
 
 bool TileInfo::DoNeedReadIndex() const
 {
@@ -117,9 +115,8 @@ void TileInfo::CheckCanceled() const
 
 int TileInfo::GetZoomLevel() const
 {
-  int const upperScale = scales::GetUpperScale();
-  int const zoomLevel = m_context->GetTileKey().m_zoomLevel;
-  return (zoomLevel <= upperScale ? zoomLevel : upperScale);
+  ASSERT_LESS_OR_EQUAL(m_context->GetTileKey().m_zoomLevel, scales::GetUpperScale(), ());
+  return m_context->GetTileKey().m_zoomLevel;
 }
 
 } // namespace df

--- a/drape_frontend/tile_key.cpp
+++ b/drape_frontend/tile_key.cpp
@@ -6,16 +6,23 @@ namespace df
 {
 
 TileKey::TileKey()
-  : m_x(-1), m_y(-1), m_zoomLevel(-1), m_generation(0)
+  : m_x(-1), m_y(-1),
+    m_zoomLevel(-1),
+    m_styleZoomLevel(-1),
+    m_generation(0)
 {}
 
 TileKey::TileKey(int x, int y, int zoomLevel)
-  : m_x(x), m_y(y), m_zoomLevel(zoomLevel), m_generation(0)
+  : m_x(x), m_y(y),
+    m_zoomLevel(zoomLevel),
+    m_styleZoomLevel(zoomLevel),
+    m_generation(0)
 {}
 
 TileKey::TileKey(TileKey const & key, uint64_t generation)
   : m_x(key.m_x), m_y(key.m_y),
     m_zoomLevel(key.m_zoomLevel),
+    m_styleZoomLevel(key.m_styleZoomLevel),
     m_generation(generation)
 {}
 
@@ -37,9 +44,9 @@ bool TileKey::operator ==(TileKey const & other) const
          m_zoomLevel == other.m_zoomLevel;
 }
 
-m2::RectD TileKey::GetGlobalRect() const
+m2::RectD TileKey::GetGlobalRect(bool considerStyleZoom) const
 {
-  double const worldSizeDevisor = 1 << m_zoomLevel;
+  double const worldSizeDevisor = 1 << (considerStyleZoom ? m_styleZoomLevel : m_zoomLevel);
   // Mercator SizeX and SizeY is equal
   double const rectSize = (MercatorBounds::maxX - MercatorBounds::minX) / worldSizeDevisor;
 
@@ -53,7 +60,8 @@ string DebugPrint(TileKey const & key)
 {
   ostringstream out;
   out << "[x = " << key.m_x << ", y = " << key.m_y << ", zoomLevel = "
-      << key.m_zoomLevel << ", gen = " << key.m_generation << "]";
+      << key.m_zoomLevel << ", styleZoomLevel = " << key.m_styleZoomLevel
+      << ", gen = " << key.m_generation << "]";
   return out.str();
 }
 

--- a/drape_frontend/tile_key.hpp
+++ b/drape_frontend/tile_key.hpp
@@ -26,11 +26,12 @@ struct TileKey
   bool operator < (TileKey const & other) const;
   bool operator == (TileKey const & other) const;
 
-  m2::RectD GetGlobalRect() const;
+  m2::RectD GetGlobalRect(bool considerStyleZoom = false) const;
 
   int m_x;
   int m_y;
   int m_zoomLevel;
+  int m_styleZoomLevel;
   uint64_t m_generation;
 };
 


### PR DESCRIPTION
На 18 и 19 зумах ранее создавались логические тайлы, размеры которых были меньше, чем позволяла система вычитки (там максимум - 17ый зум). Это приводило к тому, что в тайл объединялись большие области карты вне фактического размера тайла, что, в свою очередь, приводило к избыточным перевычиткам. Это проявлялось в том числе как мигание больших областей карты при драге.
Сейчас на 18 и 19 зумах используются тайлы такого же размера, как и на 17 уровне зума. При этом при смене уровней зума происходит обновление геометрии в полном соответсвии со стилями.
Необходимо протестировать на разных девайсах перед мержем!