### PR TITLE
Revert "[generator] Set maximum points per coastline feature to 1000."

### DIFF
--- a/generator/coastlines_generator.cpp
+++ b/generator/coastlines_generator.cpp
@@ -208,7 +208,7 @@ public:
 
   static int constexpr kStartLevel = 4;
   static int constexpr kHighLevel = 10;
-  static int constexpr kMaxPoints = 1000;
+  static int constexpr kMaxPoints = 20000;
 
 protected:
   struct Context


### PR DESCRIPTION
This reverts commit 71f0b98f306e198b5757e6f89f0dc886d9bbd2e3.