### PR TITLE
A side_road tag support for the OSRM car profile.

### DIFF
--- a/3party/osrm/osrm-backend/profile.lua
+++ b/3party/osrm/osrm-backend/profile.lua
@@ -141,6 +141,7 @@ local min = math.min
 local max = math.max
 
 local speed_reduction = 0.8
+local side_road_speed_multiplier = 0.8
 
 --modes
 local mode_normal = 1
@@ -325,6 +326,14 @@ function way_function (way, result)
 
   if -1 == result.forward_speed and -1 == result.backward_speed then
     return
+  end
+
+  -- reduce speed on special side roads
+  local sideway = way:get_value_by_key("side_road")
+  if "yes" == sideway or
+  "rotary" == sideway then
+    result.forward_speed = result.forward_speed * side_road_speed_multiplier
+    result.backward_speed = result.backward_speed * side_road_speed_multiplier
   end
 
   -- reduce speed on bad surfaces

--- a/3party/osrm/osrm-backend/profiles/car.lua
+++ b/3party/osrm/osrm-backend/profiles/car.lua
@@ -141,6 +141,7 @@ local min = math.min
 local max = math.max
 
 local speed_reduction = 0.8
+local side_road_speed_multiplier = 0.8
 
 --modes
 local mode_normal = 1
@@ -310,8 +311,8 @@ function way_function (way, result)
       end
     else
       -- Set the avg speed on ways that are marked accessible
-      -- OMIM does not support non highway classes
-      --if access_tag_whitelist[access] and "yes" ~= access then
+      -- OMIM does not support not highway classes
+      -- if access_tag_whitelist[access] and "yes" ~= access then
       --  result.forward_speed = speed_profile["default"]
       --  result.backward_speed = speed_profile["default"]
       --end
@@ -325,6 +326,14 @@ function way_function (way, result)
 
   if -1 == result.forward_speed and -1 == result.backward_speed then
     return
+  end
+
+  -- reduce speed on special side roads
+  local sideway = way:get_value_by_key("side_road")
+  if "yes" == sideway or
+  "rotary" == sideway then
+    result.forward_speed = result.forward_speed * side_road_speed_multiplier
+    result.backward_speed = result.backward_speed * side_road_speed_multiplier
   end
 
   -- reduce speed on bad surfaces

--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -32,6 +32,20 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
   integration::TestRouteLength(route, 561.);
 }
 
+UNIT_TEST(StPetersburgSideRoadPenaltyTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetOsrmComponents(),
+      MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
+      MercatorBounds::FromLatLon(59.84268, 30.27589));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 0);
+}
+
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(


### PR DESCRIPTION
https://trello.com/c/XB4C9EfX/2144--
Добавляет замедление при учёте боковых проездов в OSRM профиле для машин. 