### PR TITLE
Float parsing workaround.

### DIFF
--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -12,6 +12,7 @@
 #include "base/object_tracker.hpp"
 
 #include "std/cstdio.hpp"
+#include "std/cstdlib.hpp"
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
@@ -62,6 +63,12 @@ namespace
 
 int main(int argc, char * argv[])
 {
+  // Our double parsing code (base/string_utils.hpp) needs dots as a floating point delimiters, not commas.
+  // TODO: Refactor our doubles parsing code to use locale-independent delimiters.
+  // For example, https://github.com/google/double-conversion can be used.
+  // See http://dbaron.org/log/20121222-locale for more details.
+  (void)::setenv("LC_NUMERIC", "C", 1);
+
   InitializeFinalize mainGuard;
   UNUSED_VALUE(mainGuard);
 

--- a/std/cstdio.hpp
+++ b/std/cstdio.hpp
@@ -4,6 +4,22 @@
 #undef new
 #endif
 
+// Correct snprintf support for MSVC. It was finaly implemented in MS Visual Studio 2015.
+// Original code: https://github.com/OlehKulykov/jansson/commit/8f2298bad8f77a22efe0dc9a95676fae6c203e36
+#if defined(_WIN32) || defined(WIN32)
+#  if defined(_MSC_VER)  /* MS compiller */
+#    if (_MSC_VER < 1900) && !defined(snprintf)  /* snprintf not defined yet & not introduced */
+#      define snprintf _snprintf
+#    endif
+#    if (_MSC_VER < 1500) && !defined(vsnprintf)  /* vsnprintf not defined yet & not introduced */
+#      define vsnprintf(b,c,f,a) _vsnprintf(b,c,f,a)
+#    endif
+#  else  /* Other Windows compiller, old definition */
+#    define snprintf _snprintf
+#    define vsnprintf _vsnprintf
+#  endif
+#endif
+
 #include <cstdio>
 
 #ifdef DEBUG_NEW

--- a/std/cstdlib.hpp
+++ b/std/cstdlib.hpp
@@ -1,10 +1,25 @@
 #pragma once
 
+#include "target_os.hpp"
+
 #ifdef new
 #undef new
 #endif
 
 #include <cstdlib>
+
+// setenv is absent in MSVC.
+#ifdef OMIM_OS_WINDOWS_NATIVE
+#include <cstdio> // Need it for snprintf.
+inline int setenv(char const * name, char const * value, int /*overwrite*/)
+{
+  char buffer[255];
+  int const err = ::snprintf(buffer, sizeof(buffer), "%s=%s", name, value);
+  if (err < 0 || err >= sizeof(buffer))
+    return -1;
+  return ::_putenv(buffer);
+}
+#endif
 
 #ifdef DEBUG_NEW
 #define new DEBUG_NEW


### PR DESCRIPTION
Fixes crashes on desktop project startup on some systems, if locale has comma delimiter for float numbers.