### PR TITLE
Fixed artefacts on fetching from symbols texture

### DIFF
--- a/drape/font_texture.cpp
+++ b/drape/font_texture.cpp
@@ -69,10 +69,16 @@ m2::RectF GlyphPacker::MapTextureCoords(const m2::RectU & pixelRect) const
 {
   float fWidth = static_cast<float>(m_size.x);
   float fHeight = static_cast<float>(m_size.y);
-  return m2::RectF(pixelRect.minX() / fWidth,
-                   pixelRect.minY() / fHeight,
-                   pixelRect.maxX() / fWidth,
-                   pixelRect.maxY() / fHeight);
+
+  // Half-pixel offset to eliminate arfefacts on fetching from texture.
+  float offset = 0.0;
+  if (pixelRect.SizeX() != 0 && pixelRect.SizeY() != 0)
+    offset = 0.5;
+
+  return m2::RectF((pixelRect.minX() + offset) / fWidth,
+                   (pixelRect.minY() + offset) / fHeight,
+                   (pixelRect.maxX() - offset) / fWidth,
+                   (pixelRect.maxY() - offset) / fHeight);
 }
 
 bool GlyphPacker::IsFull() const { return m_isFull; }

--- a/drape/font_texture.cpp
+++ b/drape/font_texture.cpp
@@ -71,9 +71,9 @@ m2::RectF GlyphPacker::MapTextureCoords(const m2::RectU & pixelRect) const
   float fHeight = static_cast<float>(m_size.y);
 
   // Half-pixel offset to eliminate arfefacts on fetching from texture.
-  float offset = 0.0;
+  float offset = 0.0f;
   if (pixelRect.SizeX() != 0 && pixelRect.SizeY() != 0)
-    offset = 0.5;
+    offset = 0.5f;
 
   return m2::RectF((pixelRect.minX() + offset) / fWidth,
                    (pixelRect.minY() + offset) / fHeight,

--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -44,7 +44,7 @@ void VisualParams::Init(double vs, uint32_t tileSize, vector<uint32_t> const & a
   if (vs <= 1.0)
     g_VizParams.m_glyphVisualParams = { 0.48f, 0.08f, 0.2f, 0.01f, 0.49f, 0.04f };
   else
-    g_VizParams.m_glyphVisualParams = { 0.5f, 0.05f, 0.2f, 0.01f, 0.49f, 0.04f };
+    g_VizParams.m_glyphVisualParams = { 0.5f, 0.06f, 0.2f, 0.01f, 0.49f, 0.04f };
 
   RISE_INITED;
 }


### PR DESCRIPTION
Исправлены артефакты при выборке из текстуры глифов, когда глиф при выборке захватывал часть другого глифа