### PR TITLE
[search] Enable SearchQueryV2 by default.

### DIFF
--- a/search/search_query_factory.hpp
+++ b/search/search_query_factory.hpp
@@ -1,11 +1,7 @@
 #pragma once
 
-#include "search/search_query.hpp"
 #include "search/suggest.hpp"
-
-#if defined(USE_SEARCH_QUERY_V2)
 #include "search/v2/search_query_v2.hpp"
-#endif  // defined(USE_SEARCH_QUERY_V2)
 
 #include "std/unique_ptr.hpp"
 
@@ -25,11 +21,7 @@ public:
                                              vector<Suggest> const & suggests,
                                              storage::CountryInfoGetter const & infoGetter)
   {
-#if defined(USE_SEARCH_QUERY_V2)
     return make_unique<v2::SearchQueryV2>(index, categories, suggests, infoGetter);
-#else
-    return make_unique<Query>(index, categories, suggests, infoGetter);
-#endif  // defined(USE_SEARCH_QUERY_V2)
   }
 };
 }  // namespace search


### PR DESCRIPTION
Usage of USE_SEARCH_QUERY_V2 macro makes it hard to build new-search version for platforms. I think it would be nice to enable it by default, as it lives on a separate branch.
