### PR TITLE
Roundabout exit number fix.

### DIFF
--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -87,9 +87,8 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-    integration::GetOsrmComponents(),
-    MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
-    MercatorBounds::FromLatLon(60.48462, 15.42120));
+      integration::GetOsrmComponents(), MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
+      MercatorBounds::FromLatLon(60.48462, 15.42120));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 

--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -84,6 +84,27 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
   integration::TestRouteLength(route, 387.);
 }
 
+UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+    integration::GetOsrmComponents(),
+    MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
+    MercatorBounds::FromLatLon(60.48462, 15.42120));
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2);
+
+  integration::GetNthTurn(route, 0)
+      .TestValid()
+      .TestDirection(TurnDirection::EnterRoundAbout)
+      .TestRoundAboutExitNum(2);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::LeaveRoundAbout);
+
+  integration::TestRouteLength(route, 255.);
+}
+
 UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
@@ -231,11 +252,11 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestDirection(TurnDirection::EnterRoundAbout)
-      .TestRoundAboutExitNum(4);
+      .TestRoundAboutExitNum(5);
   integration::GetNthTurn(route, 1)
       .TestValid()
       .TestDirection(TurnDirection::LeaveRoundAbout)
-      .TestRoundAboutExitNum(4);
+      .TestRoundAboutExitNum(5);
 }
 
 UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -182,8 +182,8 @@ bool KeepTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possible
  * \brief Returns false when other possible turns leads to service roads;
  */
 bool KeepRoundaboutTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possibleTurns,
-                            TurnInfo const & turnInfo, Index const & index,
-                            RoutingMapping & mapping)
+                                      TurnInfo const & turnInfo, Index const & index,
+                                      RoutingMapping & mapping)
 {
   for (auto const & t : possibleTurns)
   {
@@ -881,7 +881,7 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & 
 
   if (turnInfo.m_ingoing.m_onRoundabout || turnInfo.m_outgoing.m_onRoundabout)
   {
-  bool const keepTurnByHighwayClass = KeepRoundaboutTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
+    bool const keepTurnByHighwayClass = KeepRoundaboutTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
     turn.m_turn = GetRoundaboutDirection(turnInfo.m_ingoing.m_onRoundabout,
                                          turnInfo.m_outgoing.m_onRoundabout, hasMultiTurns,
                                          keepTurnByHighwayClass);

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -178,6 +178,24 @@ bool KeepTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possible
   return true;
 }
 
+/*!
+ * \brief Returns false when other possible turns leads to service roads;
+ */
+bool KeepRoundaboutTurnByHighwayClass(TurnDirection turn, TTurnCandidates const & possibleTurns,
+                            TurnInfo const & turnInfo, Index const & index,
+                            RoutingMapping & mapping)
+{
+  for (auto const & t : possibleTurns)
+  {
+    if (t.node == turnInfo.m_outgoing.m_nodeId)
+      continue;
+    ftypes::HighwayClass const highwayClass = GetOutgoingHighwayClass(t.node, mapping, index);
+    if (static_cast<int>(highwayClass) != static_cast<int>(ftypes::HighwayClass::Service))
+      return true;
+  }
+  return false;
+}
+
 bool DiscardTurnByIngoingAndOutgoingEdges(TurnDirection intermediateDirection,
                                           TurnInfo const & turnInfo, TurnItem const & turn)
 {
@@ -861,15 +879,16 @@ void GetTurnDirection(Index const & index, RoutingMapping & mapping, TurnInfo & 
       turn.m_turn = intermediateDirection;
   }
 
-  bool const keepTurnByHighwayClass =  KeepTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
   if (turnInfo.m_ingoing.m_onRoundabout || turnInfo.m_outgoing.m_onRoundabout)
   {
+  bool const keepTurnByHighwayClass = KeepRoundaboutTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
     turn.m_turn = GetRoundaboutDirection(turnInfo.m_ingoing.m_onRoundabout,
                                          turnInfo.m_outgoing.m_onRoundabout, hasMultiTurns,
                                          keepTurnByHighwayClass);
     return;
   }
 
+  bool const keepTurnByHighwayClass = KeepTurnByHighwayClass(turn.m_turn, nodes, turnInfo, index, mapping);
   if (!turn.m_keepAnyway && !keepTurnByHighwayClass)
   {
     turn.m_turn = TurnDirection::NoTurn;


### PR DESCRIPTION
https://trello.com/c/LFDaNJUR/2178-routing
Фикс рассчёта номера съезда. Теперь как съезд учитываются все дороги кроме highway=service.
Интеграционные тесты прилагаются.