### PR TITLE
Turnaround direction fix.

### DIFF
--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -8,6 +8,30 @@
 using namespace routing;
 using namespace routing::turns;
 
+UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetOsrmComponents(),
+      MercatorBounds::FromLatLon(55.67251, 37.63604), {-0.004, -0.01},
+      MercatorBounds::FromLatLon(55.67293, 37.63507));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 3);
+
+  integration::GetNthTurn(route, 0)
+      .TestValid()
+      .TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 1)
+      .TestValid()
+      .TestDirection(TurnDirection::UTurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
+
+  integration::TestRouteLength(route, 561.);
+}
+
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -937,6 +937,10 @@ size_t CheckUTurnOnRoute(vector<LoadedPathSegment> const & segments, size_t curr
       if (checkedSegment.m_name.empty())
         return 0;
 
+      // Avoid returning to the same edge after uturn somewere else.
+      if (path[path.size() - 2] == checkedSegment.m_path[1])
+        return 0;
+
       m2::PointD const v1 = path[path.size() - 1] - path[path.size() - 2];
       m2::PointD const v2 = checkedSegment.m_path[1] - checkedSegment.m_path[0];
 


### PR DESCRIPTION
https://trello.com/c/ZAit79Gj/2202--
Фикс определения разворота через примыкающий проезд на себя.
Тест прилагается.