### PR TITLE
[search] Moved out common test code to search_tests_support.

### DIFF
--- a/omim.pro
+++ b/omim.pro
@@ -144,8 +144,12 @@ SUBDIRS = 3party base coding geometry indexer routing
     generator_tests_support.depends = $$MapDepLibs generator
     SUBDIRS *= generator_tests_support
 
+    search_tests_support.subdir = search/search_tests_support
+    search_tests_support.depends = $$MapDepLibs generator
+    SUBDIRS *= search_tests_support
+
     search_integration_tests.subdir = search/search_integration_tests
-    search_integration_tests.depends = $$MapDepLibs generator generator_tests_support
+    search_integration_tests.depends = $$MapDepLibs generator generator_tests_support search_tests_support
     SUBDIRS *= search_integration_tests
 
     generator_tests.subdir = generator/generator_tests

--- a/search/search_integration_tests/search_integration_tests.pro
+++ b/search/search_integration_tests/search_integration_tests.pro
@@ -6,7 +6,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = generator_tests_support generator routing search storage stats_client indexer \
+DEPENDENCIES = generator_tests_support generator routing search search_tests_support storage stats_client indexer \
                platform geometry coding base tess2 protobuf tomcrypt jansson
 
 DEPENDENCIES += opening_hours \
@@ -22,9 +22,5 @@ SOURCES += \
     ../../testing/testingmain.cpp \
     retrieval_test.cpp \
     smoke_test.cpp \
-    test_search_engine.cpp \
-    test_search_request.cpp \
 
 HEADERS += \
-    test_search_engine.hpp \
-    test_search_request.hpp \

--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -2,8 +2,8 @@
 
 #include "generator/generator_tests_support/test_mwm_builder.hpp"
 
-#include "search/search_integration_tests/test_search_engine.hpp"
-#include "search/search_integration_tests/test_search_request.hpp"
+#include "search/search_tests_support/test_search_engine.hpp"
+#include "search/search_tests_support/test_search_request.hpp"
 
 #include "indexer/classificator_loader.hpp"
 #include "indexer/scales.hpp"
@@ -13,6 +13,8 @@
 #include "platform/local_country_file.hpp"
 #include "platform/local_country_file_utils.hpp"
 #include "platform/platform.hpp"
+
+using namespace search::tests_support;
 
 namespace
 {
@@ -38,6 +40,8 @@ private:
 };
 }  // namespace
 
+namespace search
+{
 void TestFeaturesCount(TestSearchEngine const & engine, m2::RectD const & rect,
                        size_t expectedCount)
 {
@@ -131,3 +135,4 @@ UNIT_TEST(GenerateTestMwm_NotPrefixFreeNames)
     TEST_EQUAL(3, request.Results().size(), ());
   }
 }
+}  // namespace search

--- a/search/search_tests_support/search_tests_support.pro
+++ b/search/search_tests_support/search_tests_support.pro
@@ -1,0 +1,15 @@
+TARGET = search_tests_support
+TEMPLATE = lib
+CONFIG += staticlib warn_on
+
+ROOT_DIR = ../..
+
+include($$ROOT_DIR/common.pri)
+
+SOURCES += \
+    test_search_engine.cpp \
+    test_search_request.cpp \
+
+HEADERS += \
+    test_search_engine.hpp \
+    test_search_request.hpp \

--- a/search/search_tests_support/test_search_engine.cpp
+++ b/search/search_tests_support/test_search_engine.cpp
@@ -1,4 +1,4 @@
-#include "search/search_integration_tests/test_search_engine.hpp"
+#include "search/search_tests_support/test_search_engine.hpp"
 
 #include "indexer/categories_holder.hpp"
 #include "indexer/scales.hpp"
@@ -40,6 +40,10 @@ class TestSearchQueryFactory : public search::SearchQueryFactory
 };
 }  // namespace
 
+namespace search
+{
+namespace tests_support
+{
 TestSearchEngine::TestSearchEngine(string const & locale)
   : m_platform(GetPlatform())
   , m_infoGetter(m_platform.GetReader(PACKED_POLYGONS_FILE), m_platform.GetReader(COUNTRIES_FILE))
@@ -52,3 +56,5 @@ bool TestSearchEngine::Search(search::SearchParams const & params, m2::RectD con
 {
   return m_engine.Search(params, viewport);
 }
+}  // namespace tests_support
+}  // namespace search

--- a/search/search_tests_support/test_search_engine.hpp
+++ b/search/search_tests_support/test_search_engine.hpp
@@ -15,8 +15,9 @@ class Platform;
 namespace search
 {
 class SearchParams;
-}
 
+namespace tests_support
+{
 class TestSearchEngine : public Index
 {
 public:
@@ -29,3 +30,5 @@ private:
   storage::CountryInfoGetter m_infoGetter;
   search::Engine m_engine;
 };
+}  // namespace tests_support
+}  // namespace search

--- a/search/search_tests_support/test_search_request.cpp
+++ b/search/search_tests_support/test_search_request.cpp
@@ -1,10 +1,14 @@
-#include "search/search_integration_tests/test_search_request.hpp"
+#include "search/search_tests_support/test_search_request.hpp"
 
-#include "search/search_integration_tests/test_search_engine.hpp"
+#include "search/search_tests_support/test_search_engine.hpp"
 #include "search/params.hpp"
 
 #include "base/logging.hpp"
 
+namespace search
+{
+namespace tests_support
+{
 TestSearchRequest::TestSearchRequest(TestSearchEngine & engine, string const & query,
                                      string const & locale, m2::RectD const & viewport)
     : m_done(false)
@@ -49,3 +53,5 @@ void TestSearchRequest::Done(search::Results const & results)
     m_results.assign(results.Begin(), results.End());
   }
 }
+}  // namespace tests_support
+}  // namespace search

--- a/search/search_tests_support/test_search_request.hpp
+++ b/search/search_tests_support/test_search_request.hpp
@@ -9,6 +9,10 @@
 #include "std/string.hpp"
 #include "std/vector.hpp"
 
+namespace search
+{
+namespace tests_support
+{
 class TestSearchEngine;
 
 // This class wraps a search query to a search engine. Note that the
@@ -33,3 +37,5 @@ private:
   vector<search::Result> m_results;
   bool m_done;
 };
+}  // namespace tests_support
+}  // namespace search


### PR DESCRIPTION
Идея аналогична platform_tests_support.
Сейчас это нужно для тестирования поиска без запуска framework'а. Более аккуратно эта работа проведена на ветке new-search, поэтому в этом PR только самое необходимое.