### PR TITLE
[drape.Merge after release] merge batches on iOS and desktop

### DIFF
--- a/drape/drape_tests/glfunctions.cpp
+++ b/drape/drape_tests/glfunctions.cpp
@@ -251,7 +251,7 @@ void GLFunctions::glDisable(glConst mode) {}
 
 void GLFunctions::glUniformValueiv(int8_t location, int32_t * v, uint32_t size) {}
 
-void * GLFunctions::glMapBuffer(glConst target) { return 0; }
+void * GLFunctions::glMapBuffer(glConst, glConst) { return 0; }
 
 void GLFunctions::glUnmapBuffer(glConst target) {}
 

--- a/drape/glconstants.cpp
+++ b/drape/glconstants.cpp
@@ -33,6 +33,48 @@
   #define WRITE_ONLY_DEF 0x88B9
 #endif
 
+#if defined(GL_READ_ONLY)
+  #define READ_ONLY_DEF GL_READ_ONLY
+#else
+  #define READ_ONLY_DEF 0x88B8
+#endif
+
+#if defined(GL_MAP_READ_BIT_EXT)
+  #define READ_BIT_DEF GL_MAP_READ_BIT_EXT
+#else
+  #define READ_BIT_DEF 0x0001
+#endif
+
+#if defined(GL_MAP_WRITE_BIT_EXT)
+  #define WRITE_BIT_DEF GL_MAP_WRITE_BIT_EXT
+#else
+  #define WRITE_BIT_DEF 0x0002
+#endif
+
+#if defined(GL_MAP_INVALIDATE_RANGE_BIT_EXT)
+  #define INVALIDATE_RANGE_BIT_DEF GL_MAP_INVALIDATE_RANGE_BIT_EXT
+#else
+  #define INVALIDATE_RANGE_BIT_DEF 0x0004
+#endif
+
+#if defined(GL_MAP_INVALIDATE_BUFFER_BIT_EXT)
+  #define INVALIDATE_BUFFER_BIT_DEF GL_MAP_INVALIDATE_BUFFER_BIT_EXT
+#else
+  #define INVALIDATE_BUFFER_BIT_DEF 0x0008
+#endif
+
+#if defined(GL_MAP_FLUSH_EXPLICIT_BIT_EXT)
+  #define FLUSH_EXPLICIT_BIT_DEF GL_MAP_FLUSH_EXPLICIT_BIT_EXT
+#else
+  #define FLUSH_EXPLICIT_BIT_DEF 0x0010
+#endif
+
+#if defined(GL_MAP_UNSYNCHRONIZED_BIT_EXT)
+  #define UNSYNCHRONIZED_BIT_DEF GL_MAP_UNSYNCHRONIZED_BIT_EXT
+#else
+  #define UNSYNCHRONIZED_BIT_DEF 0x0020
+#endif
+
 namespace gl_const
 {
 
@@ -49,6 +91,14 @@ const glConst GLBufferSize          = GL_BUFFER_SIZE;
 const glConst GLBufferUsage         = GL_BUFFER_USAGE;
 
 const glConst GLWriteOnly           = WRITE_ONLY_DEF;
+const glConst GLReadOnly            = READ_ONLY_DEF;
+
+const glConst GLReadBufferBit       = READ_BIT_DEF;
+const glConst GLWriteBufferBit      = WRITE_BIT_DEF;
+const glConst GLInvalidateRange     = INVALIDATE_RANGE_BIT_DEF;
+const glConst GLInvalidateBuffer    = INVALIDATE_BUFFER_BIT_DEF;
+const glConst GLFlushExplicit       = FLUSH_EXPLICIT_BIT_DEF;
+const glConst GLUnsynchronized      = UNSYNCHRONIZED_BIT_DEF;
 
 const glConst GLStaticDraw          = GL_STATIC_DRAW;
 const glConst GLStreamDraw          = GL_STREAM_DRAW;

--- a/drape/glconstants.hpp
+++ b/drape/glconstants.hpp
@@ -23,6 +23,15 @@ extern const glConst GLBufferUsage;
 
 /// VBO Access
 extern const glConst GLWriteOnly;
+extern const glConst GLReadOnly;
+
+/// MapBufferRange
+extern const glConst GLWriteBufferBit;
+extern const glConst GLReadBufferBit;
+extern const glConst GLInvalidateRange;
+extern const glConst GLInvalidateBuffer;
+extern const glConst GLFlushExplicit;
+extern const glConst GLUnsynchronized;
 
 /// BufferUsage
 extern const glConst GLStaticDraw;

--- a/drape/glextensions_list.cpp
+++ b/drape/glextensions_list.cpp
@@ -86,17 +86,20 @@ GLExtensionsList::GLExtensionsList()
   m_impl->CheckExtension(TextureNPOT, "GL_OES_texture_npot");
   m_impl->CheckExtension(MapBuffer, "GL_OES_mapbuffer");
   m_impl->CheckExtension(UintIndices, "GL_OES_element_index_uint");
+  m_impl->CheckExtension(MapBufferRange, "GL_EXT_map_buffer_range");
 #elif defined(OMIM_OS_WINDOWS)
   m_impl->CheckExtension(TextureNPOT, "GL_ARB_texture_non_power_of_two");
   m_impl->SetExtension(VertexArrayObject, false);
   m_impl->SetExtension(RequiredInternalFormat, false);
   m_impl->SetExtension(MapBuffer, true);
+  m_impl->SetExtension(MapBufferRange, false);
   m_impl->SetExtension(UintIndices, true);
 #else
   m_impl->CheckExtension(VertexArrayObject, "GL_APPLE_vertex_array_object");
   m_impl->CheckExtension(TextureNPOT, "GL_ARB_texture_non_power_of_two");
   m_impl->SetExtension(RequiredInternalFormat, false);
   m_impl->SetExtension(MapBuffer, true);
+  m_impl->SetExtension(MapBufferRange, false);
   m_impl->SetExtension(UintIndices, true);
 #endif
 }

--- a/drape/glextensions_list.hpp
+++ b/drape/glextensions_list.hpp
@@ -15,6 +15,7 @@ public:
     RequiredInternalFormat,
     MapBuffer,
     UintIndices,
+    MapBufferRange
   };
 
   static GLExtensionsList & Instance();

--- a/drape/glfunctions.cpp
+++ b/drape/glfunctions.cpp
@@ -57,6 +57,8 @@ typedef void (DP_APIENTRY *TglBufferDataFn)(GLenum target, GLsizeiptr size, GLvo
 typedef void (DP_APIENTRY *TglBufferSubDataFn)(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid const * data);
 typedef void * (DP_APIENTRY *TglMapBufferFn)(GLenum target, GLenum access);
 typedef GLboolean(DP_APIENTRY *TglUnmapBufferFn)(GLenum target);
+typedef void * (DP_APIENTRY *TglMapBufferRangeFn)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+typedef void (DP_APIENTRY *TglFlushMappedBufferRangeFn)(GLenum target, GLintptr offset, GLsizeiptr length);
 
 typedef GLuint(DP_APIENTRY *TglCreateShaderFn)(GLenum type);
 typedef void (DP_APIENTRY *TglShaderSourceFn)(GLuint shaderID, GLsizei count, GLchar const ** string, GLint const * length);
@@ -118,6 +120,8 @@ TglBufferDataFn glBufferDataFn = nullptr;
 TglBufferSubDataFn glBufferSubDataFn = nullptr;
 TglMapBufferFn glMapBufferFn = nullptr;
 TglUnmapBufferFn glUnmapBufferFn = nullptr;
+TglMapBufferRangeFn glMapBufferRangeFn = nullptr;
+TglFlushMappedBufferRangeFn glFlushMappedBufferRangeFn = nullptr;
 
 /// Shaders
 TglCreateShaderFn glCreateShaderFn = nullptr;
@@ -372,6 +376,8 @@ void GLFunctions::Init()
   glDeleteVertexArrayFn = &glDeleteVertexArraysOES;
   glMapBufferFn = &::glMapBufferOES;
   glUnmapBufferFn = &::glUnmapBufferOES;
+  glMapBufferRangeFn = &::glMapBufferRangeEXT;
+  glFlushMappedBufferRangeFn = &::glFlushMappedBufferRangeEXT;
 #elif defined(OMIM_OS_WINDOWS)
   if (dp::GLExtensionsList::Instance().IsSupported(dp::GLExtensionsList::VertexArrayObject))
   {
@@ -646,10 +652,10 @@ void GLFunctions::glBufferSubData(glConst target, uint32_t size, void const * da
   GLCHECK(glBufferSubDataFn(target, offset, size, data));
 }
 
-void * GLFunctions::glMapBuffer(glConst target)
+void * GLFunctions::glMapBuffer(glConst target, glConst access)
 {
   ASSERT(glMapBufferFn != nullptr, ());
-  void * result = glMapBufferFn(target, gl_const::GLWriteOnly);
+  void * result = glMapBufferFn(target, access);
   GLCHECKCALL();
   return result;
 }
@@ -659,6 +665,20 @@ void GLFunctions::glUnmapBuffer(glConst target)
   ASSERT(glUnmapBufferFn != nullptr, ());
   VERIFY(glUnmapBufferFn(target) == GL_TRUE, ());
   GLCHECKCALL();
+}
+
+void * GLFunctions::glMapBufferRange(glConst target, uint32_t offset, uint32_t length, glConst access)
+{
+  ASSERT(glMapBufferRangeFn != nullptr, ());
+  void * result = glMapBufferRangeFn(target, offset, length, access);
+  GLCHECKCALL();
+  return result;
+}
+
+void GLFunctions::glFlushMappedBufferRange(glConst target, uint32_t offset, uint32_t length)
+{
+  ASSERT(glFlushMappedBufferRangeFn != nullptr, ());
+  GLCHECK(glFlushMappedBufferRangeFn(target, offset, length));
 }
 
 uint32_t GLFunctions::glCreateShader(glConst type)

--- a/drape/glfunctions.hpp
+++ b/drape/glfunctions.hpp
@@ -61,8 +61,11 @@ public:
   static void glBufferData(glConst target, uint32_t size, void const * data, glConst usage);
   static void glBufferSubData(glConst target, uint32_t size, void const * data, uint32_t offset);
 
-  static void * glMapBuffer(glConst target);
+  static void * glMapBuffer(glConst target, glConst access = gl_const::GLWriteOnly);
   static void glUnmapBuffer(glConst target);
+
+  static void * glMapBufferRange(glConst target, uint32_t offset, uint32_t length, glConst access);
+  static void glFlushMappedBufferRange(glConst target, uint32_t offset, uint32_t length);
 
   /// Shaders support
   static uint32_t glCreateShader(glConst type);

--- a/drape/glstate.cpp
+++ b/drape/glstate.cpp
@@ -82,6 +82,8 @@ bool GLState::operator<(GLState const & other) const
     return m_blending < other.m_blending;
   if (m_gpuProgramIndex != other.m_gpuProgramIndex)
     return m_gpuProgramIndex < other.m_gpuProgramIndex;
+  if (m_depthFunction != other.m_depthFunction)
+    return m_depthFunction < other.m_depthFunction;
   if (m_colorTexture != other.m_colorTexture)
     return m_colorTexture < other.m_colorTexture;
 

--- a/drape/render_bucket.hpp
+++ b/drape/render_bucket.hpp
@@ -4,6 +4,11 @@
 
 class ScreenBase;
 
+namespace df
+{
+class BatchMergeHelper;
+}
+
 namespace dp
 {
 
@@ -13,6 +18,7 @@ class VertexArrayBuffer;
 
 class RenderBucket
 {
+  friend class df::BatchMergeHelper;
 public:
   RenderBucket(drape_ptr<VertexArrayBuffer> && buffer);
   ~RenderBucket();

--- a/drape/vertex_array_buffer.hpp
+++ b/drape/vertex_array_buffer.hpp
@@ -10,6 +10,11 @@
 
 #include "std/map.hpp"
 
+namespace df
+{
+class BatchMergeHelper;
+}
+
 namespace dp
 {
 
@@ -32,6 +37,7 @@ struct IndicesRange
 class VertexArrayBuffer
 {
   typedef map<BindingInfo, drape_ptr<DataBuffer> > TBuffersMap;
+  friend class df::BatchMergeHelper;
 public:
   VertexArrayBuffer(uint32_t indexBufferSize, uint32_t dataBufferSize);
   ~VertexArrayBuffer();

--- a/drape_frontend/batch_merge_helper.cpp
+++ b/drape_frontend/batch_merge_helper.cpp
@@ -1,0 +1,178 @@
+#include "batch_merge_helper.hpp"
+
+#include "drape/glextensions_list.hpp"
+#include "drape/render_bucket.hpp"
+#include "drape/vertex_array_buffer.hpp"
+
+namespace df
+{
+
+void ReadBufferData(void * dst, glConst target, uint32_t size)
+{
+#ifdef OMIM_OS_DESKTOP
+  void * bufferPointer = GLFunctions::glMapBuffer(target, gl_const::GLReadOnly);
+#else
+  void * bufferPointer = GLFunctions::glMapBufferRange(target, 0, size, gl_const::GLReadBufferBit);
+#endif
+
+  memcpy(dst, bufferPointer, size);
+}
+
+struct NotSupported32BitIndex{};
+struct Supported32BitIndex{};
+
+template<typename TSupported>
+void TransformIndeces(void * pointer, uint32_t count, uint32_t offset)
+{
+  ASSERT(false, ());
+}
+
+template<>
+void TransformIndeces<Supported32BitIndex>(void * pointer, uint32_t count, uint32_t offset)
+{
+  uint32_t * indexPtr = reinterpret_cast<uint32_t *>(pointer);
+  for (uint32_t i = 0; i < count; ++i)
+  {
+    *indexPtr += offset;
+    ++indexPtr;
+  }
+}
+
+template<>
+void TransformIndeces<NotSupported32BitIndex>(void * pointer, uint32_t count, uint32_t offset)
+{
+  uint16_t * indexPtr = reinterpret_cast<uint16_t *>(pointer);
+  uint16_t indexOffset = static_cast<uint16_t>(offset);
+  for (uint32_t i = 0; i < count; ++i)
+  {
+    *indexPtr += indexOffset;
+    ++indexPtr;
+  }
+}
+
+bool BatchMergeHelper::IsMergeSupported()
+{
+#if defined(OMIM_OS_DESKTOP)
+  return true;
+#else
+  static bool isSupported = dp::GLExtensionsList::Instance().IsSupported(dp::GLExtensionsList::MapBufferRange);
+  return isSupported;
+#endif
+}
+
+void BatchMergeHelper::MergeBatches(vector<drape_ptr<RenderGroup>> & batches,
+                                    vector<drape_ptr<RenderGroup>> & mergedBatches)
+{
+  ASSERT(!batches.empty(), ());
+  if (batches.size() < 2)
+  {
+    mergedBatches.emplace_back(move(batches.front()));
+    return;
+  }
+
+  uint32_t const kIndexBufferSize = 30000;
+  uint32_t const kVertexBufferSize = 20000;
+
+  using TBuffer = dp::VertexArrayBuffer;
+  using TBucket = dp::RenderBucket;
+
+  auto flushFn = [&](drape_ptr<TBucket> && bucket, ref_ptr<TBuffer> buffer)
+  {
+    if (buffer->GetIndexCount() == 0)
+      return;
+
+    ref_ptr<RenderGroup> oldGroup = make_ref(batches.front());
+    drape_ptr<RenderGroup> newGroup = make_unique_dp<RenderGroup>(oldGroup->GetState(), oldGroup->GetTileKey());
+    newGroup->m_shader = oldGroup->m_shader;
+    newGroup->m_uniforms = oldGroup->m_uniforms;
+    newGroup->m_generalUniforms = oldGroup->m_generalUniforms;
+    newGroup->AddBucket(move(bucket));
+
+    buffer->Preflush();
+    buffer->Build(newGroup->m_shader);
+    mergedBatches.push_back(move(newGroup));
+  };
+
+  auto allocateFn = [=](drape_ptr<TBucket> & bucket, ref_ptr<TBuffer> & buffer)
+  {
+    bucket = make_unique_dp<TBucket>(make_unique_dp<TBuffer>(kIndexBufferSize, kVertexBufferSize));
+    buffer = bucket->GetBuffer();
+  };
+
+  auto copyVertecesFn = [](TBuffer::TBuffersMap::value_type const & vboNode,
+                           vector<uint8_t> & rawDataBuffer,
+                           ref_ptr<TBuffer> newBuffer)
+  {
+    dp::BindingInfo const & binding = vboNode.first;
+    ref_ptr<dp::DataBufferBase> vbo = vboNode.second->GetBuffer();
+    uint32_t vertexCount = vbo->GetCurrentSize();
+    uint32_t bufferLength = vertexCount * vbo->GetElementSize();
+    if (rawDataBuffer.size() < bufferLength)
+      rawDataBuffer.resize(bufferLength);
+
+    vbo->Bind();
+    ReadBufferData(rawDataBuffer.data(), gl_const::GLArrayBuffer, bufferLength);
+    GLFunctions::glUnmapBuffer(gl_const::GLArrayBuffer);
+
+    newBuffer->UploadData(binding, rawDataBuffer.data(), vertexCount);
+  };
+
+  drape_ptr<TBucket> bucket;
+  ref_ptr<TBuffer> newBuffer;
+  allocateFn(bucket, newBuffer);
+
+  vector<uint8_t> rawDataBuffer;
+
+  for (drape_ptr<RenderGroup> const & group : batches)
+  {
+    for (drape_ptr<TBucket> const & b : group->m_renderBuckets)
+    {
+      ASSERT(b->m_overlay.empty(), ());
+      ref_ptr<TBuffer> buffer = b->GetBuffer();
+      uint32_t vertexCount = buffer->GetStartIndexValue();
+      uint32_t indexCount = buffer->GetIndexCount();
+
+      if (newBuffer->GetAvailableIndexCount() < vertexCount ||
+          newBuffer->GetAvailableVertexCount() < indexCount)
+      {
+        flushFn(move(bucket), newBuffer);
+        allocateFn(bucket, newBuffer);
+      }
+
+      uint32_t indexOffset = newBuffer->GetStartIndexValue();
+
+      for (dp::VertexArrayBuffer::TBuffersMap::value_type const & vboNode : buffer->m_staticBuffers)
+      {
+        copyVertecesFn(vboNode, rawDataBuffer, newBuffer);
+      }
+
+      for (dp::VertexArrayBuffer::TBuffersMap::value_type const & vboNode : buffer->m_dynamicBuffers)
+      {
+        copyVertecesFn(vboNode, rawDataBuffer, newBuffer);
+      }
+
+      uint32_t indexByteCount = indexCount * dp::IndexStorage::SizeOfIndex();
+      if (rawDataBuffer.size() < indexByteCount)
+        rawDataBuffer.resize(indexByteCount);
+
+      buffer->m_indexBuffer->GetBuffer()->Bind();
+      ReadBufferData(rawDataBuffer.data(), gl_const::GLElementArrayBuffer, indexByteCount);
+      GLFunctions::glUnmapBuffer(gl_const::GLElementArrayBuffer);
+
+      if (dp::IndexStorage::IsSupported32bit())
+        TransformIndeces<Supported32BitIndex>(rawDataBuffer.data(), indexCount, indexOffset);
+      else
+        TransformIndeces<NotSupported32BitIndex>(rawDataBuffer.data(), indexCount, indexOffset);
+
+      newBuffer->UploadIndexes(rawDataBuffer.data(), indexCount);
+    }
+  }
+
+  if (newBuffer->GetIndexCount() > 0)
+  {
+    flushFn(move(bucket), newBuffer);
+    allocateFn(bucket, newBuffer);
+  }
+}
+
+}

--- a/drape_frontend/batch_merge_helper.hpp
+++ b/drape_frontend/batch_merge_helper.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "drape/pointers.hpp"
+#include "drape_frontend/render_group.hpp"
+
+namespace dp
+{
+class VertexArrayBuffer;
+}
+
+namespace df
+{
+
+class BatchMergeHelper
+{
+public:
+  static bool IsMergeSupported();
+
+  static void MergeBatches(vector<drape_ptr<RenderGroup>> & batches,
+                           vector<drape_ptr<RenderGroup>> & mergedBatches);
+};
+
+}

--- a/drape_frontend/drape_frontend.pro
+++ b/drape_frontend/drape_frontend.pro
@@ -87,6 +87,7 @@ SOURCES += \
     watch/geometry_processors.cpp \
     watch/feature_processor.cpp \
     watch/default_font.cpp \
+    batch_merge_helper.cpp \
 
 HEADERS += \
     animation/base_interpolator.hpp \
@@ -179,3 +180,4 @@ HEADERS += \
     watch/brush_info.hpp \
     watch/geometry_processors.hpp \
     watch/feature_processor.hpp \
+    batch_merge_helper.hpp \

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -756,7 +756,7 @@ void FrontendRenderer::MergeBuckets()
     if (state.GetDepthLayer() == dp::GLState::GeometryLayer &&
         group->IsPendingOnDelete() == false)
     {
-      TGroup key = make_pair(state, group->GetTileKey());
+      TGroup const key = make_pair(state, group->GetTileKey());
       forMerge[key].push_back(move(m_renderGroups[i]));
     }
     else
@@ -766,7 +766,6 @@ void FrontendRenderer::MergeBuckets()
   for (TGroupMap::value_type & node : forMerge)
       BatchMergeHelper::MergeBatches(node.second, newGroups);
 
-  LOG(LINFO, ("Batches have been merged : ", m_renderGroups.size() - newGroups.size()));
   m_renderGroups = move(newGroups);
 }
 

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -4,6 +4,7 @@
 #include "drape_frontend/message_subclasses.hpp"
 #include "drape_frontend/visual_params.hpp"
 #include "drape_frontend/user_mark_shapes.hpp"
+#include "drape_frontend/batch_merge_helper.hpp"
 
 #include "drape/debug_rect_renderer.hpp"
 
@@ -723,6 +724,50 @@ void FrontendRenderer::RenderScene(ScreenBase const & modelView)
 #ifdef DRAW_INFO
   AfterDrawFrame();
 #endif
+
+  MergeBuckets();
+}
+
+void FrontendRenderer::MergeBuckets()
+{
+  if (BatchMergeHelper::IsMergeSupported() == false)
+    return;
+
+  ++m_mergeBucketsCounter;
+  if (m_mergeBucketsCounter < 60)
+    return;
+
+  if (m_renderGroups.empty())
+    return;
+
+  using TGroup = pair<dp::GLState, TileKey>;
+  using TGroupMap = map<TGroup, vector<drape_ptr<RenderGroup>>>;
+  TGroupMap forMerge;
+
+  vector<drape_ptr<RenderGroup>> newGroups;
+  newGroups.reserve(m_renderGroups.size());
+
+  m_mergeBucketsCounter = 0;
+  size_t groupsCount = m_renderGroups.size();
+  for (size_t i = 0; i < groupsCount; ++i)
+  {
+    ref_ptr<RenderGroup> group = make_ref(m_renderGroups[i]);
+    dp::GLState state = group->GetState();
+    if (state.GetDepthLayer() == dp::GLState::GeometryLayer &&
+        group->IsPendingOnDelete() == false)
+    {
+      TGroup key = make_pair(state, group->GetTileKey());
+      forMerge[key].push_back(move(m_renderGroups[i]));
+    }
+    else
+      newGroups.push_back(move(m_renderGroups[i]));
+  }
+
+  for (TGroupMap::value_type & node : forMerge)
+      BatchMergeHelper::MergeBatches(node.second, newGroups);
+
+  LOG(LINFO, ("Batches have been merged : ", m_renderGroups.size() - newGroups.size()));
+  m_renderGroups = move(newGroups);
 }
 
 void FrontendRenderer::RenderSingleGroup(ScreenBase const & modelView, ref_ptr<BaseRenderGroup> group)

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -133,6 +133,7 @@ protected:
 private:
   void OnResize(ScreenBase const & screen);
   void RenderScene(ScreenBase const & modelView);
+  void MergeBuckets();
   void RenderSingleGroup(ScreenBase const & modelView, ref_ptr<BaseRenderGroup> group);
   void RefreshProjection();
   void RefreshModelView(ScreenBase const & screen);
@@ -232,6 +233,7 @@ private:
   int m_currentZoomLevel = -1;
   ref_ptr<RequestedTiles> m_requestedTiles;
   uint64_t m_maxGeneration;
+  int m_mergeBucketsCounter = 0;
 };
 
 } // namespace df

--- a/drape_frontend/render_group.hpp
+++ b/drape_frontend/render_group.hpp
@@ -48,6 +48,7 @@ private:
 class RenderGroup : public BaseRenderGroup
 {
   typedef BaseRenderGroup TBase;
+  friend class BatchMergeHelper;
 public:
   RenderGroup(dp::GLState const & state, TileKey const & tileKey);
   ~RenderGroup();

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 		4579C89D1AD2F9E6001D6B90 /* drules_proto_dark.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4A00DBDE1AB704C400113624 /* drules_proto_dark.bin */; };
 		4579C89E1AD2F9E6001D6B90 /* drules_proto.bin in Resources */ = {isa = PBXBuildFile; fileRef = F7FDD822147F30CC005900FA /* drules_proto.bin */; };
 		4579C89F1AD2FA36001D6B90 /* packed_polygons.bin in Resources */ = {isa = PBXBuildFile; fileRef = FA85F632145DDDC20090E1A0 /* packed_polygons.bin */; };
-		4579C8A01AD2FAB1001D6B90 /* 00_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */; };
+		4579C8A01AD2FAB1001D6B90 /* 07_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 07_roboto_medium.ttf */; };
 		4579C8A11AD2FAB1001D6B90 /* 01_dejavusans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EEA615E5134C4968003A9827 /* 01_dejavusans.ttf */; };
 		4579C8A31AD2FAB1001D6B90 /* 03_jomolhari-id-a3d.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EEA615E7134C4968003A9827 /* 03_jomolhari-id-a3d.ttf */; };
 		4579C8A41AD2FAB1001D6B90 /* 04_padauk.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EEA615E8134C4968003A9827 /* 04_padauk.ttf */; };
@@ -209,7 +209,7 @@
 		6741A9161BF340D1002C974C /* resources-xhdpi_dark in Resources */ = {isa = PBXBuildFile; fileRef = 4A7D89C31B2EBF3B00AC843E /* resources-xhdpi_dark */; };
 		6741A9171BF340D1002C974C /* resources-xhdpi in Resources */ = {isa = PBXBuildFile; fileRef = 97FC99DA19C1A2CD00C1CF98 /* resources-xhdpi */; };
 		6741A9181BF340D1002C974C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = FA99CB71147089B100689A9A /* Localizable.strings */; };
-		6741A9191BF340D1002C974C /* 00_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */; };
+		6741A9191BF340D1002C974C /* 07_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 07_roboto_medium.ttf */; };
 		6741A91A1BF340D1002C974C /* 01_dejavusans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EEA615E5134C4968003A9827 /* 01_dejavusans.ttf */; };
 		6741A91B1BF340D1002C974C /* 02_droidsans-fallback.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9DF04B231B71010E00DACAF1 /* 02_droidsans-fallback.ttf */; };
 		6741A91C1BF340D1002C974C /* 03_jomolhari-id-a3d.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EEA615E7134C4968003A9827 /* 03_jomolhari-id-a3d.ttf */; };
@@ -326,7 +326,7 @@
 		6741A99C1BF340DE002C974C /* resources-6plus in Resources */ = {isa = PBXBuildFile; fileRef = 45159BF81B0CA2D5009BFA85 /* resources-6plus */; };
 		6741A99D1BF340DE002C974C /* MWMPedestrianShareAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 347BAC681B733D540010FF78 /* MWMPedestrianShareAlert.xib */; };
 		6741A99E1BF340DE002C974C /* MWMNextTurnPanel.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6FF2E2A1B8C5C020063FD1F /* MWMNextTurnPanel.xib */; };
-		6741A99F1BF340DE002C974C /* 00_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */; };
+		6741A99F1BF340DE002C974C /* 07_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 07_roboto_medium.ttf */; };
 		6741A9A11BF340DE002C974C /* MWMSearchDownloadView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 344825961B8DCEC400757B1B /* MWMSearchDownloadView.mm */; };
 		6741A9A21BF340DE002C974C /* CommunityVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 978D4A241996B0EC00D72CA7 /* CommunityVC.mm */; };
 		6741A9A31BF340DE002C974C /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.mm */; };
@@ -612,6 +612,7 @@
 		A32B6D4D1A14980500E54A65 /* iosOGLContextFactory.mm in Sources */ = {isa = PBXBuildFile; fileRef = A32B6D4B1A14980500E54A65 /* iosOGLContextFactory.mm */; };
 		A367C93B1B17334800E2B6E7 /* resources-default in Resources */ = {isa = PBXBuildFile; fileRef = A367C93A1B17334800E2B6E7 /* resources-default */; };
 		A3CC2CD41A1C723900B832E1 /* LocationPredictor.mm in Sources */ = {isa = PBXBuildFile; fileRef = A3CC2CD21A1C723900B832E1 /* LocationPredictor.mm */; };
+		A3EA686C1C25D82F005E8916 /* 07_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A3EA686B1C25D82F005E8916 /* 07_roboto_medium.ttf */; };
 		B00510FB1A11015900A61AA4 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 972CDCC51887F1B7006641CA /* CFNetwork.framework */; };
 		B00511021A1101E000A61AA4 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97C98655186C734000AF7E9E /* AVFoundation.framework */; };
 		B00511041A1101F600A61AA4 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B00511031A1101F600A61AA4 /* CoreData.framework */; };
@@ -752,7 +753,6 @@
 		FAAEA7D1161BD26600CCD661 /* synonyms.txt in Resources */ = {isa = PBXBuildFile; fileRef = FAAEA7D0161BD26600CCD661 /* synonyms.txt */; };
 		FAAEA7D5161D8D3100CCD661 /* BookmarksRootVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAAEA7D3161D8D3100CCD661 /* BookmarksRootVC.mm */; };
 		FAAFD697139D9BE2000AE70C /* categories.txt in Resources */ = {isa = PBXBuildFile; fileRef = FAAFD696139D9BE2000AE70C /* categories.txt */; };
-		FAF30A95173AB23900818BF6 /* 00_roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */; };
 		FAF457E715597D4600DCCC49 /* Framework.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAF457E615597D4600DCCC49 /* Framework.cpp */; };
 		FAFCB63613366E78001A5C59 /* WebViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAFCB63513366E78001A5C59 /* WebViewController.mm */; };
 		FAFF422A1347F101009BBB14 /* World.mwm in Resources */ = {isa = PBXBuildFile; fileRef = FAFF42291347F101009BBB14 /* World.mwm */; };
@@ -1160,6 +1160,7 @@
 		A367C93A1B17334800E2B6E7 /* resources-default */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "resources-default"; path = "../../data/resources-default"; sourceTree = "<group>"; };
 		A3CC2CD21A1C723900B832E1 /* LocationPredictor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LocationPredictor.mm; sourceTree = "<group>"; };
 		A3CC2CD31A1C723900B832E1 /* LocationPredictor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocationPredictor.h; sourceTree = "<group>"; };
+		A3EA686B1C25D82F005E8916 /* 07_roboto_medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = 07_roboto_medium.ttf; path = ../../data/07_roboto_medium.ttf; sourceTree = "<group>"; };
 		B00511031A1101F600A61AA4 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		B00511051A1101FC00A61AA4 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		B08AA8D81A26299A00810B1C /* TimeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TimeUtils.h; path = Categories/TimeUtils.h; sourceTree = "<group>"; };
@@ -1386,7 +1387,7 @@
 		FAB09895148E2F1500892860 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FAB0FC6019251E85003B396F /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FAB9D5D91992B981003F6A52 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = 00_roboto_medium.ttf; path = ../../data/00_roboto_medium.ttf; sourceTree = "<group>"; };
+		FAF30A94173AB23900818BF6 /* 07_roboto_medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = 07_roboto_medium.ttf; path = ../../data/07_roboto_medium.ttf; sourceTree = "<group>"; };
 		FAF457E415597BC100DCCC49 /* Framework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Framework.h; sourceTree = "<group>"; };
 		FAF457E615597D4600DCCC49 /* Framework.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Framework.cpp; sourceTree = "<group>"; };
 		FAF8E2EC1752E0F100D41090 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1630,6 +1631,7 @@
 		29B97314FDCFA39411CA2CEA /* Maps */ = {
 			isa = PBXGroup;
 			children = (
+				A3EA686B1C25D82F005E8916 /* 07_roboto_medium.ttf */,
 				6741AA5F1BF34185002C974C /* defaults.xcconfig */,
 				CB252D6816FF82C8001E41E9 /* Statistics */,
 				FA36B8011540388B004560CC /* Bookmarks */,
@@ -2753,7 +2755,7 @@
 				FA64D9A813F975AD00350ECF /* types.txt */,
 				452FCA3A1B6A3DF7007019AB /* colors.txt */,
 				451950391B7A3E070085DA05 /* patterns.txt */,
-				FAF30A94173AB23900818BF6 /* 00_roboto_medium.ttf */,
+				FAF30A94173AB23900818BF6 /* 07_roboto_medium.ttf */,
 				EEA615E5134C4968003A9827 /* 01_dejavusans.ttf */,
 				9DF04B231B71010E00DACAF1 /* 02_droidsans-fallback.ttf */,
 				EEA615E7134C4968003A9827 /* 03_jomolhari-id-a3d.ttf */,
@@ -3051,6 +3053,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A3EA686C1C25D82F005E8916 /* 07_roboto_medium.ttf in Resources */,
 				4519503A1B7A3E070085DA05 /* patterns.txt in Resources */,
 				5605022F1B6211E100169CAD /* sound-strings in Resources */,
 				452FCA3B1B6A3DF7007019AB /* colors.txt in Resources */,
@@ -3152,7 +3155,6 @@
 				45159BF91B0CA2D5009BFA85 /* resources-6plus in Resources */,
 				347BAC691B733D540010FF78 /* MWMPedestrianShareAlert.xib in Resources */,
 				F6FF2E2B1B8C5C020063FD1F /* MWMNextTurnPanel.xib in Resources */,
-				FAF30A95173AB23900818BF6 /* 00_roboto_medium.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3175,7 +3177,7 @@
 				6741A9161BF340D1002C974C /* resources-xhdpi_dark in Resources */,
 				6741A9171BF340D1002C974C /* resources-xhdpi in Resources */,
 				6741A9181BF340D1002C974C /* Localizable.strings in Resources */,
-				6741A9191BF340D1002C974C /* 00_roboto_medium.ttf in Resources */,
+				6741A9191BF340D1002C974C /* 07_roboto_medium.ttf in Resources */,
 				6741A91A1BF340D1002C974C /* 01_dejavusans.ttf in Resources */,
 				6741A91B1BF340D1002C974C /* 02_droidsans-fallback.ttf in Resources */,
 				6741A91C1BF340D1002C974C /* 03_jomolhari-id-a3d.ttf in Resources */,
@@ -3307,7 +3309,7 @@
 				6741A99C1BF340DE002C974C /* resources-6plus in Resources */,
 				6741A99D1BF340DE002C974C /* MWMPedestrianShareAlert.xib in Resources */,
 				6741A99E1BF340DE002C974C /* MWMNextTurnPanel.xib in Resources */,
-				6741A99F1BF340DE002C974C /* 00_roboto_medium.ttf in Resources */,
+				6741A99F1BF340DE002C974C /* 07_roboto_medium.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3322,7 +3324,7 @@
 				F6C7B7131BA840A4004233F4 /* resources-xhdpi_dark in Resources */,
 				343F26311AEFDF3E00388A6D /* resources-xhdpi in Resources */,
 				6C47C8BF1AD6C47E000C52C1 /* Localizable.strings in Resources */,
-				4579C8A01AD2FAB1001D6B90 /* 00_roboto_medium.ttf in Resources */,
+				4579C8A01AD2FAB1001D6B90 /* 07_roboto_medium.ttf in Resources */,
 				4579C8A11AD2FAB1001D6B90 /* 01_dejavusans.ttf in Resources */,
 				9DF04B241B71010E00DACAF1 /* 02_droidsans-fallback.ttf in Resources */,
 				4579C8A31AD2FAB1001D6B90 /* 03_jomolhari-id-a3d.ttf in Resources */,


### PR DESCRIPTION
Что это и зачем надо:
У drape есть одна болезнь - фрагментация данных по разным батчам. Это значит геометрия которая может быть отрисована за один drawCall рисуется за много.
Как это происходит:
1) На некотором тайле слишком много однотипной информации и она не влазит в наш стандартный батч 5к на 5к (индексов надо бы поставить 7к), поэтому мы разбиваем геометрию на несколько батчей что бы быстрее показать пользователю картинку.
2) Пользователь активно драгает карты не меняя масштаба. Это приводит к переодическим дочиткам геометрии, которая кладется в отдельный батч, в результате чего  со временем фпс падает, что хорошо заметно на густых областях.

Решение простое: раз в 60 кадров собираем геометрию которую можно смержить (одинаковый GLState, не является оверлэем, не помечена на удаление и относиться к одному тайлу) и мержим их. Поскольку GLES 2.0 не позволяет читать данные VBO, мы пользуемся расширением glMapBufferRange которое позволяет. Данное расширение поддерживается на всех версиях iOS начиная с толи 4-ой, толи с 5-ой. С андроидами более грустно. Там данное расширение поддерживается всего парой устройств (что надо еще проверить). Кроме того я не уверен в том что на андроидах это расширение будет иметь такое же добуквенное имя, так что хорошо бы провести исследование и включить для тех устройств что поддерживают.

Для десктоп систем используется glMapBuffer (которая в GLES 2.0 работает только на запись), поскольку на я не нашел в хидерах MacOS сигнатуру функции glMapBufferRange.