### PR TITLE
Fixed EGL context creation which led to artifacts on Meizu MX4

### DIFF
--- a/android/jni/com/mapswithme/opengl/android_gl_utils.cpp
+++ b/android/jni/com/mapswithme/opengl/android_gl_utils.cpp
@@ -13,7 +13,11 @@ ConfigComparator::ConfigComparator(EGLDisplay display)
 
 int ConfigComparator::operator()(EGLConfig const & l, EGLConfig const & r) const
 {
-  return configWeight(l) - configWeight(r);
+  int const weight = configWeight(l) - configWeight(r);
+  if (weight == 0)
+    return configAlphaSize(l) - configAlphaSize(r);
+
+  return weight;
 }
 
 int ConfigComparator::configWeight(EGLConfig const & config) const
@@ -32,6 +36,13 @@ int ConfigComparator::configWeight(EGLConfig const & config) const
     default:
       return 0;
   }
+}
+
+int ConfigComparator::configAlphaSize(EGLConfig const & config) const
+{
+  int val = 0;
+  eglGetConfigAttrib(m_display, config, EGL_ALPHA_SIZE, &val);
+  return val;
 }
 
 namespace

--- a/android/jni/com/mapswithme/opengl/android_gl_utils.hpp
+++ b/android/jni/com/mapswithme/opengl/android_gl_utils.hpp
@@ -15,6 +15,7 @@ public:
 
   int operator()(EGLConfig const & l, EGLConfig const & r) const;
   int configWeight(EGLConfig const & config) const;
+  int configAlphaSize(EGLConfig const & config) const;
 
 private:
   EGLDisplay m_display;


### PR DESCRIPTION
При создании EGL контекста выбирались параметры backbuffer'а с ненулевой альфой. Это приводило к аду при альфа-блендинге. Теперь в приоритете выбирается конфигурация backbuffer'а без альфы.

Надо проверить на других Андроидах, что все в порядке.