### PR TITLE
Fixed GPS track rendering on Samsung Galaxy Nexus

### DIFF
--- a/drape/drape_tests/compile_shaders_test.cpp
+++ b/drape/drape_tests/compile_shaders_test.cpp
@@ -160,6 +160,17 @@ UNIT_TEST(CompileShaders_Test)
                 argsPrepareFn, successComparator, ss);
 
   TEST_EQUAL(errorLog.isEmpty(), true, ("PVR with defines : ", defines, "\n", errorLog));
+
+  defines = "#define SAMSUNG_GOOGLE_NEXUS\n";
+  errorLog.clear();
+  shaderType = "-v";
+  ForEachShader(defines, gpu::VertexEnum, compilerPath, [] (QProcess const &) {},
+                argsPrepareFn, successComparator, ss);
+  shaderType = "-f";
+  ForEachShader(defines, gpu::FragmentEnum, compilerPath,[] (QProcess const &) {},
+                argsPrepareFn, successComparator, ss);
+
+  TEST_EQUAL(errorLog.isEmpty(), true, ("PVR with defines : ", defines, "\n", errorLog));
 }
 
 #ifdef OMIM_OS_MAC
@@ -197,19 +208,14 @@ void TestMaliShaders(QString const & driver,
                               return output.indexOf("Compilation succeeded.") != -1;
                             };
 
+  string defines = "";
   QString const compilerPath = QString::fromStdString(glslCompilerPath);
-  ForEachShader("", gpu::VertexEnum, compilerPath, procPrepare, argForming, succesComparator, ss);
-  shaderType = "-f";
-  ForEachShader("", gpu::FragmentEnum, compilerPath, procPrepare, argForming, succesComparator, ss);
-
-  TEST(errorLog.isEmpty(), (shaderType,release, hardware, driver, errorLog));
-
-  errorLog.clear();
-  string defines = "#define ENABLE_VTF\n";
-  shaderType = "-v";
   ForEachShader(defines, gpu::VertexEnum, compilerPath, procPrepare, argForming, succesComparator, ss);
   shaderType = "-f";
   ForEachShader(defines, gpu::FragmentEnum, compilerPath, procPrepare, argForming, succesComparator, ss);
+  TEST(errorLog.isEmpty(), (shaderType, release, hardware, driver, defines, errorLog));
+
+  // MALI GPUs do not support ENABLE_VTF. Do not test it here.
 }
 
 UNIT_TEST(MALI_CompileShaders_Test)

--- a/drape/drape_tests/glfunctions.cpp
+++ b/drape/drape_tests/glfunctions.cpp
@@ -3,6 +3,8 @@
 
 #include "base/assert.hpp"
 
+#include "std/string.hpp"
+
 using namespace emul;
 
 #define MOCK_CALL(f) GLMockFunctions::Instance().f;
@@ -237,6 +239,11 @@ void GLFunctions::glTexParameter(glConst param, glConst value)
 int32_t GLFunctions::glGetInteger(glConst pname)
 {
   return MOCK_CALL(glGetInteger(pname));
+}
+
+string GLFunctions::glGetString(glConst pname)
+{
+  return MOCK_CALL(glGetString(pname));
 }
 
 void CheckGLError(my::SrcPoint const & /*srcPt*/) {}

--- a/drape/drape_tests/glmock_functions.hpp
+++ b/drape/drape_tests/glmock_functions.hpp
@@ -81,6 +81,7 @@ public:
   MOCK_METHOD2(glTexParameter, void(glConst, glConst));
 
   MOCK_METHOD1(glGetInteger, int32_t(glConst));
+  MOCK_METHOD1(glGetString, string(glConst));
 
 private:
   static GLMockFunctions * m_mock;

--- a/drape/glconstants.cpp
+++ b/drape/glconstants.cpp
@@ -38,6 +38,10 @@ namespace gl_const
 
 const glConst GLUnpackAlignment     = GL_UNPACK_ALIGNMENT;
 
+const glConst GLRenderer            = GL_RENDERER;
+const glConst GLVendor              = GL_VENDOR;
+const glConst GLVersion             = GL_VERSION;
+
 const glConst GLMaxFragmentTextures = GL_MAX_TEXTURE_IMAGE_UNITS;
 const glConst GLMaxVertexTextures   = GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS;
 const glConst GLMaxTextureSize      = GL_MAX_TEXTURE_SIZE;

--- a/drape/glconstants.hpp
+++ b/drape/glconstants.hpp
@@ -8,6 +8,10 @@ namespace gl_const
 {
 extern const glConst GLUnpackAlignment;
 
+extern const glConst GLRenderer;
+extern const glConst GLVendor;
+extern const glConst GLVersion;
+
 /// Hardware specific params
 extern const glConst GLMaxFragmentTextures;
 extern const glConst GLMaxVertexTextures;

--- a/drape/glfunctions.cpp
+++ b/drape/glfunctions.cpp
@@ -453,7 +453,7 @@ void GLFunctions::AttachCache(thread::id const & threadId)
 
 bool GLFunctions::glHasExtension(string const & name)
 {
-  char const * extensions = reinterpret_cast<char const * >(glGetString(GL_EXTENSIONS));
+  char const * extensions = reinterpret_cast<char const * >(::glGetString(GL_EXTENSIONS));
   GLCHECKCALL();
   if (extensions == nullptr)
     return false;
@@ -527,6 +527,16 @@ int32_t GLFunctions::glGetInteger(glConst pname)
   GLint value;
   GLCHECK(::glGetIntegerv(pname, &value));
   return (int32_t)value;
+}
+
+string GLFunctions::glGetString(glConst pname)
+{
+  char const * str = reinterpret_cast<char const * >(::glGetString(pname));
+  GLCHECKCALL();
+  if (str == nullptr)
+    return "";
+
+  return string(str);
 }
 
 int32_t GLFunctions::glGetBufferParameter(glConst target, glConst name)

--- a/drape/glfunctions.hpp
+++ b/drape/glfunctions.hpp
@@ -37,6 +37,8 @@ public:
   /// name = { gl_const::GLBufferSize, gl_const::GLBufferUsage }
   static int32_t glGetBufferParameter(glConst target, glConst name);
 
+  static string glGetString(glConst pname);
+
   static void glEnable(glConst mode);
   static void glDisable(glConst mode);
   static void glClearDepthValue(double depth);

--- a/drape/glstate.cpp
+++ b/drape/glstate.cpp
@@ -113,9 +113,9 @@ void ApplyUniforms(UniformValuesStorage const & uniforms, ref_ptr<GpuProgram> pr
 void ApplyTextures(GLState state, ref_ptr<GpuProgram> program)
 {
   ref_ptr<Texture> tex = state.GetColorTexture();
-  if (tex != nullptr)
+  int8_t colorTexLoc = -1;
+  if (tex != nullptr && (colorTexLoc = program->GetUniformLocation("u_colorTex")) >= 0)
   {
-    int8_t const colorTexLoc = program->GetUniformLocation("u_colorTex");
     GLFunctions::glActiveTexture(gl_const::GLTexture0);
     tex->Bind();
     GLFunctions::glUniformValuei(colorTexLoc, 0);
@@ -136,9 +136,9 @@ void ApplyTextures(GLState state, ref_ptr<GpuProgram> program)
   }
 
   tex = state.GetMaskTexture();
-  if (tex != nullptr)
+  int8_t maskTexLoc = -1;
+  if (tex != nullptr && (maskTexLoc = program->GetUniformLocation("u_maskTex")) >= 0)
   {
-    int8_t const maskTexLoc = program->GetUniformLocation("u_maskTex");
     GLFunctions::glActiveTexture(gl_const::GLTexture0 + 1);
     tex->Bind();
     GLFunctions::glUniformValuei(maskTexLoc, 1);

--- a/drape/gpu_program_manager.cpp
+++ b/drape/gpu_program_manager.cpp
@@ -42,15 +42,27 @@ GpuProgramManager::~GpuProgramManager()
 
 void GpuProgramManager::Init()
 {
+  string const renderer = GLFunctions::glGetString(gl_const::GLRenderer);
+  string const version = GLFunctions::glGetString(gl_const::GLVersion);
+  LOG(LINFO, ("Renderer =", renderer, "Version =", version));
+
   // This feature is not supported on some Android devices (especially on Android 4.x version).
   // Since we can't predict on which devices it'll work fine, we have to turn off for all devices.
 #if !defined(OMIM_OS_ANDROID)
   if (GLFunctions::glGetInteger(gl_const::GLMaxVertexTextures) > 0)
   {
     LOG(LINFO, ("VTF enabled"));
-    globalDefines = "#define ENABLE_VTF\n"; // VTF == Vetrex Texture Fetch
+    m_globalDefines.append("#define ENABLE_VTF\n"); // VTF == Vetrex Texture Fetch
   }
 #endif
+
+  bool const isSamsungGoogleNexus = (renderer == "PowerVR SGX 540" &&
+                                     version.find("GOOGLENEXUS.ED945322") != string::npos);
+  if (isSamsungGoogleNexus)
+  {
+    LOG(LINFO, ("Samsung Google Nexus detected."));
+    m_globalDefines.append("#define SAMSUNG_GOOGLE_NEXUS\n");
+  }
 }
 
 ref_ptr<GpuProgram> GpuProgramManager::GetProgram(int index)
@@ -79,7 +91,7 @@ ref_ptr<Shader> GpuProgramManager::GetShader(int index, string const & source, S
   shader_map_t::iterator it = m_shaders.find(index);
   if (it == m_shaders.end())
   {
-    drape_ptr<Shader> shader = make_unique_dp<Shader>(source, globalDefines, t);
+    drape_ptr<Shader> shader = make_unique_dp<Shader>(source, m_globalDefines, t);
     ref_ptr<Shader> result = make_ref(shader);
     m_shaders.emplace(index, move(shader));
     return result;

--- a/drape/gpu_program_manager.hpp
+++ b/drape/gpu_program_manager.hpp
@@ -27,7 +27,7 @@ private:
   typedef map<int, drape_ptr<Shader> > shader_map_t;
   program_map_t m_programs;
   shader_map_t m_shaders;
-  string globalDefines;
+  string m_globalDefines;
 };
 
 } // namespace dp

--- a/drape/shaders/route_fragment_shader.fsh
+++ b/drape/shaders/route_fragment_shader.fsh
@@ -1,12 +1,26 @@
 varying vec3 v_length;
 
+#ifdef SAMSUNG_GOOGLE_NEXUS
+uniform sampler2D u_colorTex;
+#endif
+
 uniform vec4 u_color;
 
 void main(void)
 {
+#ifdef SAMSUNG_GOOGLE_NEXUS
+  // Because of a bug in OpenGL driver on Samsung Google Nexus this workaround is here.
+  const float kFakeColorScalar = 0.0;
+  lowp vec4 fakeColor = texture2D(u_colorTex, vec2(0.0, 0.0)) * kFakeColorScalar;
+#endif
+
   vec4 color = u_color;
   if (v_length.x < v_length.z)
     color.a = 0.0;
 
+#ifdef SAMSUNG_GOOGLE_NEXUS
+  gl_FragColor = color + fakeColor;
+#else
   gl_FragColor = color;
+#endif
 }

--- a/drape/texture_manager.cpp
+++ b/drape/texture_manager.cpp
@@ -474,6 +474,11 @@ bool TextureManager::AreGlyphsReady(strings::UniString const & str) const
   return m_glyphManager->AreGlyphsReady(str);
 }
 
+ref_ptr<Texture> TextureManager::GetSymbolsTexture() const
+{
+  return make_ref(m_symbolTexture);
+}
+
 constexpr size_t TextureManager::GetInvalidGlyphGroup()
 {
   return kInvalidGlyphGroup;

--- a/drape/texture_manager.hpp
+++ b/drape/texture_manager.hpp
@@ -101,6 +101,8 @@ public:
   /// This method must be called only on Frontend renderer's thread.
   bool AreGlyphsReady(strings::UniString const & str) const;
 
+  ref_ptr<Texture> GetSymbolsTexture() const;
+
 private:
   struct GlyphGroup
   {

--- a/drape_frontend/route_shape.cpp
+++ b/drape_frontend/route_shape.cpp
@@ -328,6 +328,7 @@ void RouteShape::Draw(ref_ptr<dp::TextureManager> textures, RouteData & routeDat
                     geometry, joinsGeometry, bounds, routeData.m_length);
 
     dp::GLState state = dp::GLState(gpu::ROUTE_PROGRAM, dp::GLState::GeometryLayer);
+    state.SetColorTexture(textures->GetSymbolsTexture());
     BatchGeometry(state, geometry, joinsGeometry, routeData.m_route);
   }
 


### PR DESCRIPTION
Черрипик одноименного коммита с ветки gps-tracks-3 (3Д-навигация теперь релизится раньше, а этот коммит нужен еще и для ветки drape-3d-view).

Оригинальный PR - https://github.com/mapsme/omim/pull/985