### PR TITLE
[DO NOT MERGE] Set up minimal priority of house number mark

### DIFF
--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -12,6 +12,8 @@
 namespace df
 {
 
+string kHouseNumberSymbol = "·";
+
 namespace
 {
 
@@ -185,7 +187,7 @@ void CaptionDescription::Init(FeatureType const & f,
   {
     // Mark houses without names/numbers so user can select them by single tap.
     if (m_houseNumber.empty() && m_mainText.empty())
-      m_houseNumber = "·";
+      m_houseNumber = kHouseNumberSymbol;
   }
 
   SwapCaptions(zoomLevel);

--- a/drape_frontend/stylist.hpp
+++ b/drape_frontend/stylist.hpp
@@ -15,6 +15,8 @@ namespace drule { class BaseRule; }
 namespace df
 {
 
+extern string kHouseNumberSymbol;
+
 struct CaptionDescription
 {
   void Init(FeatureType const & f,

--- a/drape_frontend/text_shape.cpp
+++ b/drape_frontend/text_shape.cpp
@@ -1,6 +1,7 @@
 #include "drape_frontend/text_shape.hpp"
 #include "drape_frontend/text_handle.hpp"
 #include "drape_frontend/text_layout.hpp"
+#include "drape_frontend/stylist.hpp"
 
 #include "drape/utils/vertex_decl.hpp"
 #include "drape/shader_def.hpp"
@@ -230,6 +231,10 @@ void TextShape::DrawSubStringOutlined(StraightTextLayout const & layout, dp::Fon
 
 uint64_t TextShape::GetOverlayPriority() const
 {
+  // Set minimal priority of house number symbol.
+  if (m_params.m_primaryText == kHouseNumberSymbol)
+    return 0;
+
   // Overlay priority for text shapes considers the existance of secondary string and length of primary text.
   // - If the text has secondary string then it has more priority;
   // - The more text length, the more priority.


### PR DESCRIPTION
Для оверлеев номеров домов, которые обозначаются при помощи точки, понижаем приоритет до минимального, чтобы они не вытесняли более полезные объекты.