### PR TITLE
Restored qmake call for all Android and iOS builds to fix build errors when switching branches in git.

### DIFF
--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -50,10 +50,10 @@ BuildQt() {
 
     mkdir -p "$SHADOW_DIR"
     cd "$SHADOW_DIR"
-    if [ ! -f "$SHADOW_DIR/Makefile" ]; then
-      echo "Launching qmake..."
-      "$QMAKE" CONFIG-=sdk "$QMAKE_PARAMS" -spec "$(StripCygwinPrefix $MKSPEC)" "$(StripCygwinPrefix $MY_PATH)/../../omim.pro"
-    fi
+    echo "Launching qmake..."
+    # This call is needed to correctly rebuild c++ sources after switching between branches with added or removed source files.
+    # Otherwise we get build errors.
+    "$QMAKE" -r CONFIG-=sdk "$QMAKE_PARAMS" -spec "$(StripCygwinPrefix $MKSPEC)" "$(StripCygwinPrefix $MY_PATH)/../../omim.pro"
 #    make clean > /dev/null || true
     make -j $(GetCPUCores)
   )


### PR DESCRIPTION
Typical error appears when some new source files were added on a one branch and are missing on another one. Another possible fix would be to create an unique build folder for each branch to avoid their sharing, but it's a bigger overhead.

We had correct implementation for years but it was changed around a year ago to make builds faster.

I prefer to have slower but stable builds than faster but unstable.