### PR TITLE
[build] Disable opening_hours tests for gtool profile

### DIFF
--- a/3party/3party.pro
+++ b/3party/3party.pro
@@ -12,7 +12,8 @@ SUBDIRS = freetype fribidi minizip jansson tomcrypt protobuf osrm expat succinct
 # TODO(mgsrergio): Move opening hours out of 3party to the main project tree.
 # See https://trello.com/c/tWYSnXSS/22-opening-hours-3party-boost-test-framework.
 SUBDIRS *= opening_hours
-CONFIG(desktop):!CONFIG(no-tests):!CONFIG(gtool):!CONFIG(osrm) {
+# Disable tests for gtool profile, since it needs only routing tests.
+CONFIG(desktop):!CONFIG(no-tests):!CONFIG(gtool) {
   opening_hours_tests.subdir = opening_hours/opening_hours_tests
   opening_hours_tests.depends = opening_hours
   SUBDIRS *= opening_hours_tests

--- a/3party/3party.pro
+++ b/3party/3party.pro
@@ -12,7 +12,7 @@ SUBDIRS = freetype fribidi minizip jansson tomcrypt protobuf osrm expat succinct
 # TODO(mgsrergio): Move opening hours out of 3party to the main project tree.
 # See https://trello.com/c/tWYSnXSS/22-opening-hours-3party-boost-test-framework.
 SUBDIRS *= opening_hours
-CONFIG(desktop):!CONFIG(no-tests) {
+CONFIG(desktop):!CONFIG(no-tests):!CONFIG(gtool):!CONFIG(osrm) {
   opening_hours_tests.subdir = opening_hours/opening_hours_tests
   opening_hours_tests.depends = opening_hours
   SUBDIRS *= opening_hours_tests

--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -113,7 +113,7 @@ build_conf_osrm()
     export BOOST_INCLUDEDIR="$BOOST_PATH/include"
     cd "$DIRNAME"
     if [ -n "$DEVTOOLSET_PATH" ]; then
-      "$QMAKE" "$OMIM_PATH/omim.pro" -spec $OSPEC "CONFIG+=$CONF osrm" \
+      "$QMAKE" "$OMIM_PATH/omim.pro" -spec $OSPEC "CONFIG+=$CONF osrm no-tests" \
         "QMAKE_CXXFLAGS *=--gcc-toolchain=$DEVTOOLSET_PATH/root/usr" \
         "QMAKE_LFLAGS *=--gcc-toolchain=$DEVTOOLSET_PATH/root/usr"
     else


### PR DESCRIPTION
Мелкая правка сборки в профилях, которые вы всё равно не используете. Ускоряет сборку `gtool` минут на десять, отключая тесты opening_hours, и слегка ускоряет сборку osrm.