### PR TITLE
Routing no map error code fix.

### DIFF
--- a/routing/routing_mapping.hpp
+++ b/routing/routing_mapping.hpp
@@ -25,7 +25,7 @@ struct RoutingMapping
 
   /// Default constructor to create invalid instance for existing client code.
   /// @postcondition IsValid() == false.
-  RoutingMapping() : m_pIndex(nullptr) {}
+  RoutingMapping() : m_pIndex(nullptr), m_error(IRouter::ResultCode::RouteFileNotExist) {}
   /// @param countryFile Country file name without extension.
   RoutingMapping(string const & countryFile, MwmSet & index);
   ~RoutingMapping();


### PR DESCRIPTION
Фикс некорректного кода ошибки в ситуации, когда по точке не получилось определить карту.