### PR TITLE
Fixed road numbers' priority calculation

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -650,7 +650,8 @@ void ApplyLineFeature::Finish()
     m2::Spline::iterator it = m_spline.CreateIterator();
     while (!it.BeginAgain())
     {
-      m_insertShape(make_unique_dp<TextShape>(it.m_pos, viewParams, false /* hasPOI */));
+      m_insertShape(make_unique_dp<TextShape>(it.m_pos, viewParams, false /* hasPOI */,
+                                              false /* affectedByZoomPriority */));
       it.Advance(splineStep);
     }
   }

--- a/drape_frontend/text_shape.hpp
+++ b/drape_frontend/text_shape.hpp
@@ -14,7 +14,8 @@ class StraightTextLayout;
 class TextShape : public MapShape
 {
 public:
-  TextShape(m2::PointF const & basePoint, TextViewParams const & params, bool hasPOI);
+  TextShape(m2::PointF const & basePoint, TextViewParams const & params,
+            bool hasPOI, bool affectedByZoomPriority = true);
 
   void Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> textures) const override;
   MapShapePriority GetPriority() const override { return MapShapePriority::TextAndPoiPriority; }
@@ -36,6 +37,7 @@ private:
   m2::PointF m_basePoint;
   TextViewParams m_params;
   bool m_hasPOI;
+  bool m_affectedByZoomPriority;
 };
 
 } // namespace df


### PR DESCRIPTION
Для номеров дорог на карте теперь не учитывается минимальный уровень зума при расчете приоритетов оверлеев. Решение аналогичное подписям на дорогах.