### PR TITLE
[Map downloader] Renaming TIndex, node id and so on to TCountryId.

### DIFF
--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -102,7 +102,7 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
 
         gui::CountryStatusHelper & helper = gui::DrapeGui::Instance().GetCountryStatusHelper();
         if ((*tiles.begin()).m_zoomLevel > scales::GetUpperWorldScale())
-          m_model.UpdateCountryIndex(helper.GetCountryIndex(), screen.ClipRect().Center());
+          m_model.UpdateCountryId(helper.GetCountryId(), screen.ClipRect().Center());
         else
           helper.Clear();
       }
@@ -197,7 +197,7 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
       else
       {
         gui::CountryInfo const & info = msg->GetCountryInfo();
-        if (msg->IsCurrentCountry() || helper.GetCountryIndex() == info.m_countryIndex)
+        if (msg->IsCurrentCountry() || helper.GetCountryId() == info.m_countryId)
         {
           helper.SetCountryInfo(info);
         }

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -23,10 +23,10 @@ void ConnectDownloadFn(gui::CountryStatusHelper::EButtonType buttonType, MapData
   gui::DrapeGui & guiSubsystem = gui::DrapeGui::Instance();
   guiSubsystem.ConnectOnButtonPressedHandler(buttonType, [downloadFn, &guiSubsystem]()
   {
-    storage::TIndex countryIndex = guiSubsystem.GetCountryStatusHelper().GetCountryIndex();
-    ASSERT(storage::IsIndexValid(countryIndex), (countryIndex));
+    storage::TCountryId countryId = guiSubsystem.GetCountryStatusHelper().GetCountryId();
+    ASSERT(storage::IsCountryIdValid(countryId), (countryId));
     if (downloadFn != nullptr)
-      downloadFn(countryIndex);
+      downloadFn(countryId);
   });
 }
 

--- a/drape_frontend/gui/country_status_helper.cpp
+++ b/drape_frontend/gui/country_status_helper.cpp
@@ -103,9 +103,9 @@ void CountryStatusHelper::Clear()
   SetState(COUNTRY_STATE_LOADED);
 }
 
-storage::TIndex CountryStatusHelper::GetCountryIndex() const
+storage::TCountryId CountryStatusHelper::GetCountryId() const
 {
-  return m_countryInfo.m_countryIndex;
+  return m_countryInfo.m_countryId;
 }
 
 void CountryStatusHelper::SetState(ECountryState state)

--- a/drape_frontend/gui/country_status_helper.hpp
+++ b/drape_frontend/gui/country_status_helper.hpp
@@ -15,7 +15,7 @@ namespace gui
 
 struct CountryInfo
 {
-  storage::TIndex m_countryIndex = storage::kInvalidIndex;
+  storage::TCountryId m_countryId = storage::kInvalidCountryId;
   storage::TStatus m_countryStatus = storage::TStatus::EUnknown;
   string m_currentCountryName;
   size_t m_mapSize = 0;
@@ -62,7 +62,7 @@ public:
   void SetCountryInfo(CountryInfo const & countryInfo);
   void Clear();
 
-  storage::TIndex GetCountryIndex() const;
+  storage::TCountryId GetCountryId() const;
   ECountryState GetState() const;
   /// CountryStatusHandle work on FrontendRenderer and call this function to check "is visible"
   /// or state has already changed.

--- a/drape_frontend/map_data_provider.cpp
+++ b/drape_frontend/map_data_provider.cpp
@@ -5,7 +5,7 @@ namespace df
 
 MapDataProvider::MapDataProvider(TReadIDsFn const & idsReader,
                                  TReadFeaturesFn const & featureReader,
-                                 TUpdateCountryIndexFn const & countryIndexUpdater,
+                                 TUpdateCountryIdFn const & countryIndexUpdater,
                                  TIsCountryLoadedFn const & isCountryLoadedFn,
                                  TIsCountryLoadedByNameFn const & isCountryLoadedByNameFn,
                                  TDownloadFn const & downloadMapHandler,
@@ -13,7 +13,7 @@ MapDataProvider::MapDataProvider(TReadIDsFn const & idsReader,
                                  TDownloadFn const & downloadRetryHandler)
   : m_featureReader(featureReader)
   , m_idsReader(idsReader)
-  , m_countryIndexUpdater(countryIndexUpdater)
+  , m_countryIdUpdater(countryIndexUpdater)
   , m_isCountryLoadedFn(isCountryLoadedFn)
   , m_downloadMapHandler(downloadMapHandler)
   , m_downloadMapRoutingHandler(downloadMapRoutingHandler)
@@ -32,9 +32,9 @@ void MapDataProvider::ReadFeatures(TReadCallback<FeatureType> const & fn, vector
   m_featureReader(fn, ids);
 }
 
-void MapDataProvider::UpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt)
+void MapDataProvider::UpdateCountryId(storage::TCountryId const & currentCountryId, m2::PointF const & pt)
 {
-  m_countryIndexUpdater(currentIndex, pt);
+  m_countryIdUpdater(currentCountryId, pt);
 }
 
 MapDataProvider::TIsCountryLoadedFn const & MapDataProvider::GetIsCountryLoadedFn() const

--- a/drape_frontend/map_data_provider.hpp
+++ b/drape_frontend/map_data_provider.hpp
@@ -17,14 +17,14 @@ public:
   template <typename T> using TReadCallback = function<void (T const &)>;
   using TReadFeaturesFn = function<void (TReadCallback<FeatureType> const & , vector<FeatureID> const &)>;
   using TReadIDsFn = function<void (TReadCallback<FeatureID> const & , m2::RectD const &, int)>;
-  using TUpdateCountryIndexFn = function<void (storage::TIndex const & , m2::PointF const &)>;
+  using TUpdateCountryIdFn = function<void (storage::TCountryId const & , m2::PointF const &)>;
   using TIsCountryLoadedFn = function<bool (m2::PointD const &)>;
   using TIsCountryLoadedByNameFn = function<bool (string const &)>;
-  using TDownloadFn = function<void (storage::TIndex const &)>;
+  using TDownloadFn = function<void (storage::TCountryId const &)>;
 
   MapDataProvider(TReadIDsFn const & idsReader,
                   TReadFeaturesFn const & featureReader,
-                  TUpdateCountryIndexFn const & countryIndexUpdater,
+                  TUpdateCountryIdFn const & countryIndexUpdater,
                   TIsCountryLoadedFn const & isCountryLoadedFn,
                   TIsCountryLoadedByNameFn const & isCountryLoadedByNameFn,
                   TDownloadFn const & downloadMapHandler,
@@ -34,7 +34,7 @@ public:
   void ReadFeaturesID(TReadCallback<FeatureID> const & fn, m2::RectD const & r, int scale) const;
   void ReadFeatures(TReadCallback<FeatureType> const & fn, vector<FeatureID> const & ids) const;
 
-  void UpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt);
+  void UpdateCountryId(storage::TCountryId const & currentCountryId, m2::PointF const & pt);
   TIsCountryLoadedFn const & GetIsCountryLoadedFn() const;
 
   TDownloadFn const & GetDownloadMapHandler() const;
@@ -44,7 +44,7 @@ public:
 private:
   TReadFeaturesFn m_featureReader;
   TReadIDsFn m_idsReader;
-  TUpdateCountryIndexFn m_countryIndexUpdater;
+  TUpdateCountryIdFn m_countryIdUpdater;
   TIsCountryLoadedFn m_isCountryLoadedFn;
   TDownloadFn m_downloadMapHandler;
   TDownloadFn m_downloadMapRoutingHandler;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -343,34 +343,34 @@ bool Framework::IsWatchFrameRendererInited() const
   return m_cpuDrawer != nullptr;
 }
 
-void Framework::DownloadCountry(TIndex const & index, MapOptions opt)
+void Framework::DownloadCountry(TCountryId const & countryId, MapOptions opt)
 {
-  m_storage.DownloadCountry(index, opt);
+  m_storage.DownloadCountry(countryId, opt);
 }
 
-TStatus Framework::GetCountryStatus(TIndex const & index) const
+TStatus Framework::GetCountryStatus(TCountryId const & countryId) const
 {
-  return m_storage.CountryStatusEx(index);
+  return m_storage.CountryStatusEx(countryId);
 }
 
-string Framework::GetCountryName(TIndex const & index) const
+string Framework::GetCountryName(TCountryId const & countryId) const
 {
   string group, name;
-  m_storage.GetGroupAndCountry(index, group, name);
+  m_storage.GetGroupAndCountry(countryId, group, name);
   return (!group.empty() ? group + ", " + name : name);
 }
 
-m2::RectD Framework::GetCountryBounds(TIndex const & index) const
+m2::RectD Framework::GetCountryBounds(TCountryId const & countryId) const
 {
-  CountryFile const & file = m_storage.GetCountryFile(index);
+  CountryFile const & file = m_storage.GetCountryFile(countryId);
   return GetCountryBounds(file.GetName());
 }
 
-void Framework::ShowCountry(TIndex const & index)
+void Framework::ShowCountry(TCountryId const & countryId)
 {
   StopLocationFollow();
 
-  ShowRect(GetCountryBounds(index));
+  ShowRect(GetCountryBounds(countryId));
 }
 
 void Framework::UpdateLatestCountryFile(LocalCountryFile const & localFile)
@@ -762,28 +762,28 @@ void Framework::ClearAllCaches()
   m_searchEngine->ClearAllCaches();
 }
 
-void Framework::OnUpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt)
+void Framework::OnUpdateCountryId(storage::TCountryId const & currentCountryId, m2::PointF const & pt)
 {
-  storage::TIndex const newCountryIndex =
-      m_storage.FindIndexByFile(m_infoGetter->GetRegionFile(m2::PointD(pt)));
-  if (newCountryIndex.empty())
+  storage::TCountryId const newCountryId =
+      m_storage.FindCountryIdByFile(m_infoGetter->GetRegionFile(m2::PointD(pt)));
+  if (newCountryId.empty())
   {
     m_drapeEngine->SetInvalidCountryInfo();
     return;
   }
 
-  if (currentIndex != newCountryIndex)
-    UpdateCountryInfo(newCountryIndex, true /* isCurrentCountry */);
+  if (currentCountryId != newCountryId)
+    UpdateCountryInfo(newCountryId, true /* isCurrentCountry */);
 }
 
-void Framework::UpdateCountryInfo(storage::TIndex const & countryIndex, bool isCurrentCountry)
+void Framework::UpdateCountryInfo(storage::TCountryId const & countryId, bool isCurrentCountry)
 {
   if (!m_drapeEngine)
     return;
 
   int64_t const currentVersion = m_storage.GetCurrentDataVersion();
 
-  string const countryFile = m_storage.CountryByIndex(countryIndex).GetFile().GetName();
+  string const countryFile = m_storage.CountryByCountryId(countryId).GetFile().GetName();
   CHECK(!countryFile.empty(), ());
 
   // Note. MapOptions::Map is used below to be sure fileName has mwm extension
@@ -798,14 +798,14 @@ void Framework::UpdateCountryInfo(storage::TIndex const & countryIndex, bool isC
 
   gui::CountryInfo countryInfo;
 
-  countryInfo.m_countryIndex = countryIndex;
+  countryInfo.m_countryId = countryId;
   // @TODO(bykoianko) Locolize country name should be used here.
-  countryInfo.m_currentCountryName = countryIndex;
+  countryInfo.m_currentCountryName = countryId;
   // @TODO(bykoianko) Valid values for countryInfo fields should be got with new Storage
   // interface when it's ready. Now temporary values are used.
   countryInfo.m_mapSize = 0;
   countryInfo.m_routingSize = 0;
-  countryInfo.m_countryStatus = m_storage.CountryStatusEx(countryIndex);
+  countryInfo.m_countryStatus = m_storage.CountryStatusEx(countryId);
   if (countryInfo.m_countryStatus == storage::TStatus::EDownloading)
   {
     countryInfo.m_downloadProgress = 50 /* Just to show that downloading is in progress */;
@@ -1135,7 +1135,7 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
 {
   using TReadIDsFn = df::MapDataProvider::TReadIDsFn;
   using TReadFeaturesFn = df::MapDataProvider::TReadFeaturesFn;
-  using TUpdateCountryIndexFn = df::MapDataProvider::TUpdateCountryIndexFn;
+  using TUpdateCountryIndexFn = df::MapDataProvider::TUpdateCountryIdFn;
   using TIsCountryLoadedFn = df::MapDataProvider::TIsCountryLoadedFn;
   using TDownloadFn = df::MapDataProvider::TDownloadFn;
 
@@ -1149,27 +1149,27 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
     m_model.ReadFeatures(fn, ids);
   };
 
-  TUpdateCountryIndexFn updateCountryIndex = [this](storage::TIndex const & currentIndex, m2::PointF const & pt)
+  TUpdateCountryIndexFn updateCountryIndex = [this](storage::TCountryId const & currentCountryId, m2::PointF const & pt)
   {
-    GetPlatform().RunOnGuiThread(bind(&Framework::OnUpdateCountryIndex, this, currentIndex, pt));
+    GetPlatform().RunOnGuiThread(bind(&Framework::OnUpdateCountryId, this, currentCountryId, pt));
   };
 
   TIsCountryLoadedFn isCountryLoadedFn = bind(&Framework::IsCountryLoaded, this, _1);
   auto isCountryLoadedByNameFn = bind(&Framework::IsCountryLoadedByName, this, _1);
 
-  TDownloadFn downloadMapFn = [this](storage::TIndex const &)
+  TDownloadFn downloadMapFn = [this](storage::TCountryId const &)
   {
     // @TODO(bykoianko) This method should be removed when map downloader is finished.
     ASSERT(false, ());
   };
 
-  TDownloadFn downloadMapWithoutRoutingFn = [this](storage::TIndex const &)
+  TDownloadFn downloadMapWithoutRoutingFn = [this](storage::TCountryId const &)
   {
     // @TODO(bykoianko) This method should be removed when map downloader is finished.
     ASSERT(false, ());
   };
 
-  TDownloadFn downloadRetryFn = [this](storage::TIndex const &)
+  TDownloadFn downloadRetryFn = [this](storage::TCountryId const &)
   {
     // @TODO(bykoianko) This method should be removed when map downloader is finished.
     ASSERT(false, ());
@@ -1724,7 +1724,7 @@ void Framework::BuildRoute(m2::PointD const & finish, uint32_t timeoutSec)
   m2::PointD start;
   if (!m_drapeEngine->GetMyPosition(start))
   {
-    CallRouteBuilded(IRouter::NoCurrentPosition, vector<storage::TIndex>(), vector<storage::TIndex>());
+    CallRouteBuilded(IRouter::NoCurrentPosition, vector<storage::TCountryId>(), vector<storage::TCountryId>());
     return;
   }
 
@@ -1744,8 +1744,8 @@ void Framework::BuildRoute(m2::PointD const & start, m2::PointD const & finish, 
 
   auto readyCallback = [this] (Route const & route, IRouter::ResultCode code)
   {
-    vector<storage::TIndex> absentCountries;
-    vector<storage::TIndex> absentRoutingIndexes;
+    vector<storage::TCountryId> absentCountries;
+    vector<storage::TCountryId> absentRoutingIndexes;
     if (code == IRouter::NoError)
     {
       double const kRouteScaleMultiplier = 1.5;
@@ -1759,11 +1759,11 @@ void Framework::BuildRoute(m2::PointD const & start, m2::PointD const & finish, 
     {
       for (string const & name : route.GetAbsentCountries())
       {
-        storage::TIndex fileIndex = m_storage.FindIndexByFile(name);
-        if (m_storage.GetLatestLocalFile(fileIndex))
-          absentRoutingIndexes.push_back(fileIndex);
+        storage::TCountryId fileCountryId = m_storage.FindCountryIdByFile(name);
+        if (m_storage.GetLatestLocalFile(fileCountryId))
+          absentRoutingIndexes.push_back(fileCountryId);
         else
-          absentCountries.push_back(fileIndex);
+          absentCountries.push_back(fileCountryId);
       }
 
       if (code != IRouter::NeedMoreMaps)
@@ -1909,7 +1909,8 @@ void Framework::MatchLocationToRoute(location::GpsInfo & location, location::Rou
   m_routingSession.MatchLocationToRoute(location, routeMatchingInfo);
 }
 
-void Framework::CallRouteBuilded(IRouter::ResultCode code, vector<storage::TIndex> const & absentCountries, vector<storage::TIndex> const & absentRoutingFiles)
+void Framework::CallRouteBuilded(IRouter::ResultCode code, vector<storage::TCountryId> const & absentCountries,
+                                 vector<storage::TCountryId> const & absentRoutingFiles)
 {
   if (code == IRouter::Cancelled)
     return;

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -92,7 +92,7 @@ class Framework
 
 protected:
   using TDrapeFunction = function<void (df::DrapeEngine *)>;
-  using TDownloadCountryListener = function<void(storage::TIndex const &, int)>;
+  using TDownloadCountryListener = function<void(storage::TCountryId const &, int)>;
 
   StringsBundle m_stringsBundle;
 
@@ -171,18 +171,18 @@ public:
   /// @name This functions is used by Downloader UI.
   //@{
   /// options - flags that signal about parts of map that must be downloaded
-  void DownloadCountry(storage::TIndex const & index, MapOptions opt);
+  void DownloadCountry(storage::TCountryId const & countryId, MapOptions opt);
 
   void SetDownloadCountryListener(TDownloadCountryListener const & listener);
 
-  storage::TStatus GetCountryStatus(storage::TIndex const & index) const;
-  string GetCountryName(storage::TIndex const & index) const;
+  storage::TStatus GetCountryStatus(storage::TCountryId const & countryId) const;
+  string GetCountryName(storage::TCountryId const & countryId) const;
 
   /// Get country rect from borders (not from mwm file).
   /// @param[in] file Pass country file name without extension as an id.
-  m2::RectD GetCountryBounds(storage::TIndex const & index) const;
+  m2::RectD GetCountryBounds(storage::TCountryId const & countryId) const;
 
-  void ShowCountry(storage::TIndex const & index);
+  void ShowCountry(storage::TCountryId const & countryId);
 
   /// Checks, whether the country which contains the specified point is loaded.
   bool IsCountryLoaded(m2::PointD const & pt) const;
@@ -313,8 +313,8 @@ private:
 
   void FillSearchResultsMarks(search::Results const & results);
 
-  void OnUpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt);
-  void UpdateCountryInfo(storage::TIndex const & countryIndex, bool isCurrentCountry);
+  void OnUpdateCountryId(storage::TCountryId const & currentCountryId, m2::PointF const & pt);
+  void UpdateCountryInfo(storage::TCountryId const & countryCountryId, bool isCurrentCountry);
 
 public:
   using TSearchRequest = search::QuerySaver::TSearchRequest;
@@ -464,8 +464,8 @@ public:
 
 public:
   using TRouteBuildingCallback = function<void(routing::IRouter::ResultCode, 
-                                               vector<storage::TIndex> const &,
-                                               vector<storage::TIndex> const &)>;
+                                               vector<storage::TCountryId> const &,
+                                               vector<storage::TCountryId> const &)>;
   using TRouteProgressCallback = function<void(float)>;
 
   /// @name Routing mode
@@ -531,8 +531,8 @@ private:
   void InsertRoute(routing::Route const & route);
   void CheckLocationForRouting(location::GpsInfo const & info);
   void CallRouteBuilded(routing::IRouter::ResultCode code,
-                        vector<storage::TIndex> const & absentCountries,
-                        vector<storage::TIndex> const & absentRoutingFiles);
+                        vector<storage::TCountryId> const & absentCountries,
+                        vector<storage::TCountryId> const & absentRoutingFiles);
   void MatchLocationToRoute(location::GpsInfo & info, location::RouteMatchingInfo & routeMatchingInfo) const;
   string GetRoutingErrorMessage(routing::IRouter::ResultCode code);
 

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -84,8 +84,8 @@ DrawWidget::DrawWidget(QWidget * parent)
   });
 
   m_framework->SetRouteBuildingListener([](routing::IRouter::ResultCode,
-                                           vector<storage::TIndex> const &,
-                                           vector<storage::TIndex> const &)
+                                           vector<storage::TCountryId> const &,
+                                           vector<storage::TCountryId> const &)
   {
   });
 

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -130,11 +130,11 @@ namespace qt
     return NULL;
   }
 
-  /// @return can be null if index is invalid
-  QTreeWidgetItem * GetTreeItemByIndex(QTreeWidget & tree, TIndex const & index)
+  /// @return can be null if countryId is invalid
+  QTreeWidgetItem * GetTreeItemByIndex(QTreeWidget & tree, TCountryId const & countryId)
   {
     QTreeWidgetItem * item = 0;
-    // @TODO(bykoianko) With the help of MatchedItem find item in tree by index.
+    // @TODO(bykoianko) With the help of MatchedItem find item in tree by countryId.
     return item;
   }
 
@@ -150,9 +150,9 @@ namespace qt
       item.setTextColor(column, color);
   }
 
-  void UpdateDialog::UpdateRowWithCountryInfo(TIndex const & index)
+  void UpdateDialog::UpdateRowWithCountryInfo(TCountryId const & countryId)
   {
-    QTreeWidgetItem * item = GetTreeItemByIndex(*m_tree, index);
+    QTreeWidgetItem * item = GetTreeItemByIndex(*m_tree, countryId);
     if (item)
     {
       QColor rowColor;
@@ -162,13 +162,13 @@ namespace qt
       MapOptions const options = MapOptions::MapWithCarRouting;
 
       Storage const & st = GetStorage();
-      switch (m_framework.GetCountryStatus(index))
+      switch (m_framework.GetCountryStatus(countryId))
       {
       case TStatus::ENotDownloaded:
-        if (st.CountriesCount(index) == 0)
+        if (st.CountriesCount(countryId) == 0)
         {
-          size = st.CountrySizeInBytes(index, options);
-          ASSERT(size.second > 0, (index));
+          size = st.CountrySizeInBytes(countryId, options);
+          ASSERT(size.second > 0, (countryId));
           statusString = tr("Click to download");
         }
         rowColor = COLOR_NOTDOWNLOADED;
@@ -177,19 +177,19 @@ namespace qt
       case TStatus::EOnDisk:
         statusString = tr("Installed (click to delete)");
         rowColor = COLOR_ONDISK;
-        size = st.CountrySizeInBytes(index, options);
+        size = st.CountrySizeInBytes(countryId, options);
         break;
 
       case TStatus::EOnDiskOutOfDate:
         statusString = tr("Out of date (click to update or delete)");
         rowColor = COLOR_OUTOFDATE;
-        size = st.CountrySizeInBytes(index, options);
+        size = st.CountrySizeInBytes(countryId, options);
         break;
 
       case TStatus::EDownloadFailed:
         statusString = tr("Download has failed");
         rowColor = COLOR_DOWNLOADFAILED;
-        size = st.CountrySizeInBytes(index, options);
+        size = st.CountrySizeInBytes(countryId, options);
         break;
 
       case TStatus::EDownloading:
@@ -200,7 +200,7 @@ namespace qt
       case TStatus::EInQueue:
         statusString = tr("Marked for download");
         rowColor = COLOR_INQUEUE;
-        size = st.CountrySizeInBytes(index, options);
+        size = st.CountrySizeInBytes(countryId, options);
         break;
 
       default:
@@ -237,9 +237,9 @@ namespace qt
     }
   }
 
-  QTreeWidgetItem * UpdateDialog::CreateTreeItem(TIndex const & index, int value, QTreeWidgetItem * parent)
+  QTreeWidgetItem * UpdateDialog::CreateTreeItem(TCountryId const & countryId, int value, QTreeWidgetItem * parent)
   {
-    QString const text = QString::fromUtf8(GetStorage().CountryName(index).c_str());
+    QString const text = QString::fromUtf8(GetStorage().CountryName(countryId).c_str());
     QTreeWidgetItem * item = new QTreeWidgetItem(parent, QStringList(text));
     item->setData(KColumnIndexCountry, Qt::UserRole, QVariant(value));
 
@@ -248,9 +248,9 @@ namespace qt
     return item;
   }
 
-  int UpdateDialog::GetChildsCount(TIndex const & index) const
+  int UpdateDialog::GetChildsCount(TCountryId const & countryId) const
   {
-    return static_cast<int>(GetStorage().CountriesCount(index));
+    return static_cast<int>(GetStorage().CountriesCount(countryId));
   }
 
   void UpdateDialog::FillTree()
@@ -271,15 +271,15 @@ namespace qt
 #endif
   }
 
-  void UpdateDialog::OnCountryChanged(TIndex const & index)
+  void UpdateDialog::OnCountryChanged(TCountryId const & countryId)
   {
-    UpdateRowWithCountryInfo(index);
+    UpdateRowWithCountryInfo(countryId);
   }
 
-  void UpdateDialog::OnCountryDownloadProgress(TIndex const & index,
+  void UpdateDialog::OnCountryDownloadProgress(TCountryId const & countryId,
                                                pair<int64_t, int64_t> const & progress)
   {
-    QTreeWidgetItem * item = GetTreeItemByIndex(*m_tree, index);
+    QTreeWidgetItem * item = GetTreeItemByIndex(*m_tree, countryId);
     if (item)
       item->setText(KColumnIndexSize, QString("%1%").arg(progress.first * 100 / progress.second));
   }

--- a/qt/update_dialog.hpp
+++ b/qt/update_dialog.hpp
@@ -27,8 +27,8 @@ namespace qt
 
     /// @name Called from downloader to notify GUI
     //@{
-    void OnCountryChanged(storage::TIndex const & index);
-    void OnCountryDownloadProgress(storage::TIndex const & index,
+    void OnCountryChanged(storage::TCountryId const & countryId);
+    void OnCountryDownloadProgress(storage::TCountryId const & countryId,
                                    pair<int64_t, int64_t> const & progress);
     //@}
 
@@ -40,10 +40,10 @@ namespace qt
 
   private:
     void FillTree();
-    void UpdateRowWithCountryInfo(storage::TIndex const & index);
+    void UpdateRowWithCountryInfo(storage::TCountryId const & countryId);
 
-    QTreeWidgetItem * CreateTreeItem(storage::TIndex const & index, int value, QTreeWidgetItem * parent);
-    int GetChildsCount(storage::TIndex const & index) const;
+    QTreeWidgetItem * CreateTreeItem(storage::TCountryId const & countryId, int value, QTreeWidgetItem * parent);
+    int GetChildsCount(storage::TCountryId const & countryId) const;
 
   private:
     inline storage::Storage & GetStorage() const { return m_framework.Storage(); }

--- a/storage/country.hpp
+++ b/storage/country.hpp
@@ -30,13 +30,13 @@ class Country
 {
   friend class update::SizeUpdater;
   /// Name in the country node tree
-  TIndex m_name;
+  TCountryId m_name;
   /// stores squares with world pieces which are part of the country
   buffer_vector<platform::CountryFile, 1> m_files;
 
 public:
   Country() = default;
-  Country(TIndex const & name) : m_name(name) {}
+  Country(TCountryId const & name) : m_name(name) {}
 
   bool operator<(Country const & other) const { return Name() < other.Name(); }
 
@@ -52,7 +52,7 @@ public:
     return m_files.front();
   }
 
-  TIndex const & Name() const { return m_name; }
+  TCountryId const & Name() const { return m_name; }
 };
 
 typedef SimpleTree<Country> CountriesContainerT;

--- a/storage/index.cpp
+++ b/storage/index.cpp
@@ -4,10 +4,10 @@
 
 namespace storage
 {
-storage::TIndex const kInvalidIndex;
+storage::TCountryId const kInvalidCountryId;
 
-bool IsIndexValid(TIndex const & index)
+bool IsCountryIdValid(TCountryId const & countryId)
 {
-  return index != kInvalidIndex;
+  return countryId != kInvalidCountryId;
 }
 } //  namespace storage

--- a/storage/index.hpp
+++ b/storage/index.hpp
@@ -3,10 +3,10 @@
 
 namespace storage
 {
-using TIndex = string;
+using TCountryId = string;
 
-extern const storage::TIndex kInvalidIndex;
+extern const storage::TCountryId kInvalidCountryId;
 
-// @TODO(bykoianko) Check in counrtry tree if the index valid.
-bool IsIndexValid(TIndex const & index);
+// @TODO(bykoianko) Check in counrtry tree if the countryId valid.
+bool IsCountryIdValid(TCountryId const & countryId);
 } //  namespace storage

--- a/storage/queued_country.cpp
+++ b/storage/queued_country.cpp
@@ -4,11 +4,11 @@
 
 namespace storage
 {
-QueuedCountry::QueuedCountry(TIndex const & index, MapOptions opt)
-    : m_index(index), m_init(opt), m_left(opt), m_current(MapOptions::Nothing)
+QueuedCountry::QueuedCountry(TCountryId const & countryId, MapOptions opt)
+    : m_countryId(countryId), m_init(opt), m_left(opt), m_current(MapOptions::Nothing)
 {
   // @TODO(bykoianko) Probably it's nessecary to check if InIndexInCountryTree here.
-  ASSERT(IsIndexValid(GetIndex()), ("Only valid countries may be downloaded."));
+  ASSERT(IsCountryIdValid(GetCountryId()), ("Only valid countries may be downloaded."));
   ASSERT(m_left != MapOptions::Nothing, ("Empty file set was requested for downloading."));
   SwitchToNextFile();
 }

--- a/storage/queued_country.hpp
+++ b/storage/queued_country.hpp
@@ -9,21 +9,21 @@ namespace storage
 class QueuedCountry
 {
 public:
-  QueuedCountry(TIndex const & index, MapOptions opt);
+  QueuedCountry(TCountryId const & m_countryId, MapOptions opt);
 
   void AddOptions(MapOptions opt);
   void RemoveOptions(MapOptions opt);
   bool SwitchToNextFile();
 
-  inline TIndex const & GetIndex() const { return m_index; }
+  inline TCountryId const & GetCountryId() const { return m_countryId; }
   inline MapOptions GetInitOptions() const { return m_init; }
   inline MapOptions GetCurrentFile() const { return m_current; }
   inline MapOptions GetDownloadedFiles() const { return UnsetOptions(m_init, m_left); }
 
-  inline bool operator==(TIndex const & index) const { return m_index == index; }
+  inline bool operator==(TCountryId const & countryId) const { return m_countryId == countryId; }
 
 private:
-  TIndex m_index;
+  TCountryId m_countryId;
   MapOptions m_init;
   MapOptions m_left;
   MapOptions m_current;

--- a/storage/storage_tests/queued_country_tests.cpp
+++ b/storage/storage_tests/queued_country_tests.cpp
@@ -8,10 +8,10 @@ namespace storage
 UNIT_TEST(QueuedCountry_AddOptions)
 {
   Storage storage;
-  TIndex const index = storage.FindIndexByFile("USA_Georgia");
-  QueuedCountry country(index, MapOptions::CarRouting);
+  TCountryId const countryId = storage.FindCountryIdByFile("USA_Georgia");
+  QueuedCountry country(countryId, MapOptions::CarRouting);
 
-  TEST_EQUAL(index, country.GetIndex(), ());
+  TEST_EQUAL(countryId, country.GetCountryId(), ());
   TEST_EQUAL(MapOptions::CarRouting, country.GetInitOptions(), ());
   TEST_EQUAL(MapOptions::CarRouting, country.GetCurrentFile(), ());
 
@@ -31,10 +31,10 @@ UNIT_TEST(QueuedCountry_AddOptions)
 UNIT_TEST(QueuedCountry_RemoveOptions)
 {
   Storage storage;
-  TIndex const index = storage.FindIndexByFile("USA_Georgia");
+  TCountryId const countryId = storage.FindCountryIdByFile("USA_Georgia");
 
   {
-    QueuedCountry country(index, MapOptions::MapWithCarRouting);
+    QueuedCountry country(countryId, MapOptions::MapWithCarRouting);
     TEST_EQUAL(MapOptions::MapWithCarRouting, country.GetInitOptions(), ());
     TEST_EQUAL(MapOptions::Map, country.GetCurrentFile(), ());
     TEST_EQUAL(MapOptions::Nothing, country.GetDownloadedFiles(), ());
@@ -51,7 +51,7 @@ UNIT_TEST(QueuedCountry_RemoveOptions)
   }
 
   {
-    QueuedCountry country(index, MapOptions::MapWithCarRouting);
+    QueuedCountry country(countryId, MapOptions::MapWithCarRouting);
     TEST_EQUAL(MapOptions::MapWithCarRouting, country.GetInitOptions(), ());
     TEST_EQUAL(MapOptions::Map, country.GetCurrentFile(), ());
     TEST_EQUAL(MapOptions::Nothing, country.GetDownloadedFiles(), ());
@@ -68,7 +68,7 @@ UNIT_TEST(QueuedCountry_RemoveOptions)
   }
 
   {
-    QueuedCountry country(index, MapOptions::MapWithCarRouting);
+    QueuedCountry country(countryId, MapOptions::MapWithCarRouting);
     TEST_EQUAL(MapOptions::MapWithCarRouting, country.GetInitOptions(), ());
     TEST_EQUAL(MapOptions::Map, country.GetCurrentFile(), ());
     TEST_EQUAL(MapOptions::Nothing, country.GetDownloadedFiles(), ());
@@ -93,8 +93,8 @@ UNIT_TEST(QueuedCountry_RemoveOptions)
 UNIT_TEST(QueuedCountry_Bits)
 {
   Storage storage;
-  TIndex const index = storage.FindIndexByFile("USA_Georgia");
-  QueuedCountry country(index, MapOptions::MapWithCarRouting);
+  TCountryId const countryId = storage.FindCountryIdByFile("USA_Georgia");
+  QueuedCountry country(countryId, MapOptions::MapWithCarRouting);
   TEST_EQUAL(MapOptions::Nothing, country.GetDownloadedFiles(), ());
 
   TEST(country.SwitchToNextFile(), ());


### PR DESCRIPTION
Для идентификации mwm (или группы) мы используем строчный id. 
За ним закреплено имя TIndex. Кроме того вместе с новым интерфейсом прибыло имя node id.
Я переименовал все эти имена в CountryId. Для сохранения консистентности переименованы соответствующие локальные переменные и данные члены класса.

Это сделано, т.к. TIndex - очень общее имя, определено по разному в разных подсистемах и не совсем точно передает смысл, на мой взгляд.

https://trello.com/c/ikSl5kF2/2234-tindex-nodeid