### PR TITLE
Improve Swedish translation

### DIFF
--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -377,7 +377,7 @@
 	<!-- Text in menu -->
 	<string name="subscribe_to_news">Prenumerera på våra nyheter</string>
 	<!-- Text in menu -->
-	<string name="rate_the_app">Get appen ett betyg</string>
+	<string name="rate_the_app">Ge appen ett betyg</string>
 	<!-- Text in menu -->
 	<string name="help">Hjälp</string>
 	<!-- Text in menu -->
@@ -394,6 +394,8 @@
 	<string name="email_error_body">E-mailklienten har inte konfigurerats. Konfigurera den eller använd ett annat sätt att kontakta oss på %s</string>
 	<!-- Alert title -->
 	<string name="email_error_title">Fel när mailet skulle skickas</string>
+	<!-- Settings item title -->
+	<string name="pref_calibration_title">Kompasskalibrering</string>
 	<!-- Update map suggestion -->
 	<string name="routing_map_outdated">Uppdatera kartan för att skapa en rutt.</string>
 	<!-- Update maps suggestion -->

--- a/iphone/Maps/sv.lproj/Localizable.strings
+++ b/iphone/Maps/sv.lproj/Localizable.strings
@@ -626,7 +626,7 @@
 "subscribe_to_news" = "Prenumerera på våra nyheter";
 
 /* Text in menu */
-"rate_the_app" = "Get appen ett betyg";
+"rate_the_app" = "Ge appen ett betyg";
 
 /* Rate in Google Play (Android only) */
 "rate_gp" = "Rate on Google Play";
@@ -665,7 +665,7 @@
 "email_error_title" = "Fel när mailet skulle skickas";
 
 /* Settings item title */
-"pref_calibration_title" = "Compass calibration";
+"pref_calibration_title" = "Kompasskalibrering";
 
 /* Search Suggestion */
 "wifi" = "WiFi";

--- a/strings.txt
+++ b/strings.txt
@@ -6460,7 +6460,7 @@
     ar = تقييم التطبيق
     da = Bedøm appen
     tr = Uygulamayı değerlendir
-    sv = Get appen ett betyg
+    sv = Ge appen ett betyg
     he = דרגו את האפליקציה
     id = Beri nilai aplikasi
     vi = Cho điểm ứng dụng
@@ -6778,6 +6778,7 @@
     ro = Calibrare busolă
     nb = Kompasskalibrering
     fi = Kompassin kalibrointi
+    sv = Kompasskalibrering
 
   [wifi]
     tags = ios,android,tizen


### PR DESCRIPTION
Change: Get --> Ge
"Get" means goat in Swedish. Ge means "give", which is correct.

Also add translation for Compass calibration.