### PR TITLE
Routing follow state

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1450,7 +1450,7 @@ bool Framework::ShowMapForURL(string const & url)
 
     return true;
   }
-  
+
   return false;
 }
 
@@ -1863,6 +1863,9 @@ void Framework::BuildRoute(m2::PointD const & start, m2::PointD const & finish, 
 void Framework::FollowRoute()
 {
   ASSERT(m_drapeEngine != nullptr, ());
+
+  if (!m_routingSession.EnableFollowMode())
+    return;
 
   int const scale = (m_currentRouterType == RouterType::Pedestrian) ? scales::GetPedestrianNavigationScale()
                                                                     : scales::GetNavigationScale();

--- a/routing/osrm2feature_map.cpp
+++ b/routing/osrm2feature_map.cpp
@@ -118,8 +118,7 @@ bool IsInside(FtSeg const & bigSeg, FtSeg const & smallSeg)
   auto segmentLeft = min(bigSeg.m_pointStart, bigSeg.m_pointEnd);
   auto segmentRight = max(bigSeg.m_pointStart, bigSeg.m_pointEnd);
 
-  return (smallSeg.m_pointStart != segmentLeft || smallSeg.m_pointEnd != segmentRight) &&
-         (segmentLeft <= smallSeg.m_pointStart && segmentRight >= smallSeg.m_pointEnd);
+  return (segmentLeft <= smallSeg.m_pointStart && segmentRight >= smallSeg.m_pointEnd);
 }
 
 FtSeg SplitSegment(FtSeg const & segment, FtSeg const & splitter)

--- a/routing/osrm2feature_map.hpp
+++ b/routing/osrm2feature_map.hpp
@@ -88,8 +88,8 @@ namespace OsrmMappingTypes
   };
 #pragma pack (pop)
 
-/// Checks if a smallSeg is inside a bigSeg and at least one point of a smallSeg differs from
-/// point of a bigSeg. Note that the smallSeg must be an ordered segment with 1 point length.
+/// Checks if a smallSeg is inside a bigSeg. Note that the smallSeg must be an ordered segment
+/// with 1 point length.
 bool IsInside(FtSeg const & bigSeg, FtSeg const & smallSeg);
 
 /// Splits segment by splitter segment and takes part of it.

--- a/routing/osrm_helpers.cpp
+++ b/routing/osrm_helpers.cpp
@@ -128,6 +128,7 @@ void Point2PhantomNode::CalculateWeight(OsrmMappingTypes::FtSeg const & seg,
     }
   }
 
+  ASSERT(foundSeg, ("Intersection not found!"));
   ASSERT_GREATER(fullDistanceM, 0, ("No valid segments on the edge."));
   double const ratio = (fullDistanceM == 0) ? 0 : distanceM / fullDistanceM;
   ASSERT_LESS_OR_EQUAL(ratio, 1., ());

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -173,7 +173,8 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & 
     }
     else
     {
-      m_state = OnRoute;
+      if (m_state != RouteFollowing)
+        m_state = OnRoute;
 
       // Warning signals checks
       if (m_routingSettings.m_speedCameraWarning && !m_speedWarningSignal)
@@ -368,6 +369,16 @@ bool RoutingSession::DisableFollowMode()
   if (m_state == RouteNotStarted || m_state == OnRoute)
   {
     m_state = RouteNoFollowing;
+    return true;
+  }
+  return false;
+}
+
+bool RoutingSession::EnableFollowMode()
+{
+  if (m_state == RouteNotStarted || m_state == OnRoute)
+  {
+    m_state = RouteFollowing;
     return true;
   }
   return false;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -45,7 +45,8 @@ public:
     OnRoute,           // user follows the route
     RouteNeedRebuild,  // user left the route
     RouteFinished,     // destination point is reached but the session isn't closed
-    RouteNoFollowing   // route is built but following mode has been disabled
+    RouteNoFollowing,  // route is built but following mode has been disabled
+    RouteFollowing     // user driwes on road. Similar to OnRoute. Indicates that user pushed the start button.
   };
 
   /*
@@ -57,6 +58,8 @@ public:
    * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
    * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position.
    * OnRoute -> RouteFinished             // user reached the end of route
+   * OnRoute -> RouteFollowing            // user pushed the start button
+   * RouteFollowing -> RouteFinished      // user reached the end of route
    * RouteNeedRebuild -> RouteNotReady    // start rebuild route
    * RouteFinished -> RouteNotReady       // start new route
    */
@@ -83,10 +86,11 @@ public:
 
   m2::PointD GetEndPoint() const { return m_endPoint; }
   bool IsActive() const { return (m_state != RoutingNotActive); }
-  bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished); }
+  bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished || m_state == RouteFollowing); }
   bool IsBuilt() const { return (IsNavigable() || m_state == RouteNeedRebuild || m_state == RouteFinished); }
   bool IsBuilding() const { return (m_state == RouteBuilding); }
-  bool IsOnRoute() const { return (m_state == OnRoute); }
+  bool IsOnRoute() const { return (m_state == OnRoute || m_state == RouteFollowing); }
+  bool IsFollowing() const { return (m_state == RouteFollowing); }
   void Reset();
 
   Route const & GetRoute() const { return m_route; }
@@ -106,6 +110,10 @@ public:
   /// If a route is rebuilt you must call DisableFollowMode again.
   /// Returns true if following was disabled, false if a route is not ready for the following yet.
   bool DisableFollowMode();
+
+  /// Now indicates only that user pushed start button. Route follows by default.
+  /// Returns true if following was enabled, false if a route is not ready for the following yet.
+  bool EnableFollowMode();
 
   void SetRoutingSettings(RoutingSettings const & routingSettings);
 


### PR DESCRIPTION
https://trello.com/c/MZ1O0SaH/265-3d-view-3d
Дополнительный состояние роутинг сессии, которое определяет состояние программы после нажатия кнопки "Старт" на маршруте. Нужно для правильного включения 3d режима.