### PR TITLE
Fixed OpenGL context creation on Android

### DIFF
--- a/android/jni/com/mapswithme/opengl/android_gl_utils.cpp
+++ b/android/jni/com/mapswithme/opengl/android_gl_utils.cpp
@@ -11,13 +11,13 @@ ConfigComparator::ConfigComparator(EGLDisplay display)
 {
 }
 
-int ConfigComparator::operator()(EGLConfig const & l, EGLConfig const & r) const
+bool ConfigComparator::operator()(EGLConfig const & l, EGLConfig const & r) const
 {
   int const weight = configWeight(l) - configWeight(r);
   if (weight == 0)
-    return configAlphaSize(l) - configAlphaSize(r);
+    return configAlphaSize(l) < configAlphaSize(r);
 
-  return weight;
+  return weight < 0;
 }
 
 int ConfigComparator::configWeight(EGLConfig const & config) const

--- a/android/jni/com/mapswithme/opengl/android_gl_utils.hpp
+++ b/android/jni/com/mapswithme/opengl/android_gl_utils.hpp
@@ -13,7 +13,7 @@ class ConfigComparator
 public:
   ConfigComparator(EGLDisplay display);
 
-  int operator()(EGLConfig const & l, EGLConfig const & r) const;
+  bool operator()(EGLConfig const & l, EGLConfig const & r) const;
   int configWeight(EGLConfig const & config) const;
   int configAlphaSize(EGLConfig const & config) const;
 

--- a/android/jni/com/mapswithme/opengl/androidoglcontextfactory.cpp
+++ b/android/jni/com/mapswithme/opengl/androidoglcontextfactory.cpp
@@ -19,6 +19,7 @@ static EGLint * getConfigAttributesListRGB8()
     EGL_RED_SIZE, 8,
     EGL_GREEN_SIZE, 8,
     EGL_BLUE_SIZE, 8,
+    EGL_ALPHA_SIZE, 0,
     EGL_STENCIL_SIZE, 0,
     EGL_DEPTH_SIZE, 16,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,


### PR DESCRIPTION
Исправлен выбор параметров контекста. Должно помочь с бедой с альфаканалом, которую видели на Samsung S4 mini.