### PR TITLE
[Downloader] Parametrization Storage with countries.txt file name and with downloading folder.

### DIFF
--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -83,9 +83,8 @@ public:
 private:
   friend string DebugPrint(LocalCountryFile const &);
   friend void UnitTest_LocalCountryFile_DirectoryLookup();
-  friend void FindAllLocalMapsAndCleanup(vector<LocalCountryFile> & localFiles,
-                                         int64_t latestVersion,
-                                         string const & dataDir);
+  friend void FindAllLocalMapsAndCleanup(int64_t latestVersion,
+                                         string const & dataDir, vector<LocalCountryFile> & localFiles);
 
   /// @note! If directory is empty, the file is stored in resources.
   /// In this case, the only valid params are m_countryFile and m_version.

--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -84,7 +84,8 @@ private:
   friend string DebugPrint(LocalCountryFile const &);
   friend void UnitTest_LocalCountryFile_DirectoryLookup();
   friend void FindAllLocalMapsAndCleanup(int64_t latestVersion,
-                                         vector<LocalCountryFile> & localFiles);
+                                         vector<LocalCountryFile> & localFiles,
+                                         string const & folder);
 
   /// @note! If directory is empty, the file is stored in resources.
   /// In this case, the only valid params are m_countryFile and m_version.

--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -83,9 +83,9 @@ public:
 private:
   friend string DebugPrint(LocalCountryFile const &);
   friend void UnitTest_LocalCountryFile_DirectoryLookup();
-  friend void FindAllLocalMapsAndCleanup(int64_t latestVersion,
-                                         vector<LocalCountryFile> & localFiles,
-                                         string const & folder);
+  friend void FindAllLocalMapsAndCleanup(vector<LocalCountryFile> & localFiles,
+                                         int64_t latestVersion,
+                                         string const & dataDir);
 
   /// @note! If directory is empty, the file is stored in resources.
   /// In this case, the only valid params are m_countryFile and m_version.

--- a/platform/local_country_file_utils.cpp
+++ b/platform/local_country_file_utils.cpp
@@ -207,13 +207,13 @@ void FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t ver
   }
 }
 
-void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles,
-                                string const & folder)
+void FindAllLocalMapsAndCleanup(vector<LocalCountryFile> & localFiles, int64_t latestVersion,
+                                string const & dataDir /* = string() */)
 {
   Platform & platform = GetPlatform();
 
-  string const dir = folder.empty() ? platform.WritableDir()
-                                    : my::JoinFoldersToPath(platform.WritableDir(), folder);
+  string const dir = dataDir.empty() ? platform.WritableDir()
+                                    : my::JoinFoldersToPath(platform.WritableDir(), dataDir);
   FindAllLocalMapsInDirectoryAndCleanup(dir, 0 /* version */, latestVersion, localFiles);
 
   Platform::TFilesWithType fwts;
@@ -275,7 +275,7 @@ void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> 
 void CleanupMapsDirectory(int64_t latestVersion)
 {
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(latestVersion, localFiles);
+  FindAllLocalMapsAndCleanup(localFiles, latestVersion);
 }
 
 bool ParseVersion(string const & s, int64_t & version)

--- a/platform/local_country_file_utils.hpp
+++ b/platform/local_country_file_utils.hpp
@@ -18,7 +18,8 @@ namespace migrate
 }
 
 // Removes all files downloader creates during downloading of a country.
-void DeleteDownloaderFilesForCountry(CountryFile const & countryFile, int64_t version);
+void DeleteDownloaderFilesForCountry(CountryFile const & countryFile,
+                                     int64_t version, string const & folder);
 
 // Finds all local map files in |directory|. Version of these files is
 // passed as an argument. Also, performs cleanup described in comment
@@ -42,7 +43,8 @@ void FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t ver
 //
 // Also, this method performs cleanup described in a comment for
 // CleanupMapsDirectory().
-void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles);
+void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles,
+                                string const & folder = string());
 
 // This method removes:
 // * partially downloaded non-latest maps (with version less than |latestVersion|)
@@ -60,9 +62,10 @@ bool ParseVersion(string const & s, int64_t & version);
 // When version is zero, uses writable directory, otherwise, creates
 // directory with name equal to decimal representation of version.
 shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(CountryFile const & countryFile,
-                                                         int64_t version);
+                                                         int64_t version, string const & folder);
 
-string GetFileDownloadPath(CountryFile const & countryFile, MapOptions file, int64_t version);
+string GetFileDownloadPath(CountryFile const & countryFile, MapOptions file,
+                           int64_t version, string const & folder);
 
 ModelReader * GetCountryReader(LocalCountryFile const & file, MapOptions options);
 

--- a/platform/local_country_file_utils.hpp
+++ b/platform/local_country_file_utils.hpp
@@ -18,8 +18,11 @@ namespace migrate
 }
 
 // Removes all files downloader creates during downloading of a country.
-void DeleteDownloaderFilesForCountry(CountryFile const & countryFile,
-                                     int64_t version, string const & folder);
+// Note. The the maps are deleted from writable dir/|dataDir|/|version| directory.
+// If |dataDir| is empty (or is not set) the function deletes maps from writable dir.
+void DeleteDownloaderFilesForCountry(int64_t version, CountryFile const & countryFile);
+void DeleteDownloaderFilesForCountry(int64_t version, string const & dataDir,
+                                     CountryFile const & countryFile);
 
 // Finds all local map files in |directory|. Version of these files is
 // passed as an argument. Also, performs cleanup described in comment
@@ -43,8 +46,11 @@ void FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t ver
 //
 // Also, this method performs cleanup described in a comment for
 // CleanupMapsDirectory().
-void FindAllLocalMapsAndCleanup(vector<LocalCountryFile> & localFiles, int64_t latestVersion,
-                                string const & dataDir = string());
+// Note. The the maps are looked for writable dir/|dataDir|/|version| directory.
+// If |dataDir| is empty (or is not set) the function looks for maps in writable dir.
+void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles);
+void FindAllLocalMapsAndCleanup(int64_t latestVersion, string const & dataDir,
+                                vector<LocalCountryFile> & localFiles);
 
 // This method removes:
 // * partially downloaded non-latest maps (with version less than |latestVersion|)
@@ -61,11 +67,17 @@ bool ParseVersion(string const & s, int64_t & version);
 
 // When version is zero, uses writable directory, otherwise, creates
 // directory with name equal to decimal representation of version.
-shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(CountryFile const & countryFile,
-                                                         int64_t version, string const & folder);
+// Note. The function assumes the maps are located in writable dir/|dataDir|/|version| directory.
+// If |dataDir| is empty (or is not set) the function assumes that maps are in writable dir.
+shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, CountryFile const & countryFile);
+shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, string const & dataDir,
+                                                         CountryFile const & countryFile);
 
-string GetFileDownloadPath(CountryFile const & countryFile, MapOptions file,
-                           int64_t version, string const & folder);
+// Note. The function assumes the maps are located in writable dir/|dataDir|/|version| directory.
+// If |dataDir| is empty (or is not set) the function assumes that maps are in writable dir.
+string GetFileDownloadPath(int64_t version, CountryFile const & countryFile, MapOptions file);
+string GetFileDownloadPath(int64_t version, string const & dataDir,
+                           CountryFile const & countryFile, MapOptions file);
 
 ModelReader * GetCountryReader(LocalCountryFile const & file, MapOptions options);
 

--- a/platform/local_country_file_utils.hpp
+++ b/platform/local_country_file_utils.hpp
@@ -43,8 +43,8 @@ void FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t ver
 //
 // Also, this method performs cleanup described in a comment for
 // CleanupMapsDirectory().
-void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles,
-                                string const & folder = string());
+void FindAllLocalMapsAndCleanup(vector<LocalCountryFile> & localFiles, int64_t latestVersion,
+                                string const & dataDir = string());
 
 // This method removes:
 // * partially downloaded non-latest maps (with version less than |latestVersion|)

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -342,7 +342,7 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
   CountryFile italyFile("Italy");
   LocalCountryFile expectedItalyFile(platform.WritableDir(), italyFile, 0 /* version */);
   shared_ptr<LocalCountryFile> italyLocalFile =
-      PreparePlaceForCountryFiles(italyFile, 0 /* version */);
+      PreparePlaceForCountryFiles(italyFile, 0 /* version */, string() /* folder */);
   TEST(italyLocalFile.get(), ());
   TEST_EQUAL(expectedItalyFile, *italyLocalFile, ());
 
@@ -351,14 +351,14 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
   CountryFile germanyFile("Germany");
   LocalCountryFile expectedGermanyFile(directoryForV1.GetFullPath(), germanyFile, 1 /* version */);
   shared_ptr<LocalCountryFile> germanyLocalFile =
-      PreparePlaceForCountryFiles(germanyFile, 1 /* version */);
+      PreparePlaceForCountryFiles(germanyFile, 1 /* version */, string() /* folder */);
   TEST(germanyLocalFile.get(), ());
   TEST_EQUAL(expectedGermanyFile, *germanyLocalFile, ());
 
   CountryFile franceFile("France");
   LocalCountryFile expectedFranceFile(directoryForV1.GetFullPath(), franceFile, 1 /* version */);
   shared_ptr<LocalCountryFile> franceLocalFile =
-      PreparePlaceForCountryFiles(franceFile, 1 /* version */);
+      PreparePlaceForCountryFiles(franceFile, 1 /* version */, string() /* folder */);
   TEST(franceLocalFile.get(), ());
   TEST_EQUAL(expectedFranceFile, *franceLocalFile, ());
 }

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -198,7 +198,7 @@ UNIT_TEST(LocalCountryFile_CleanupMapFiles)
 
   // Check FindAllLocalMaps()
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(localFiles, 4 /* latestVersion */);
+  FindAllLocalMapsAndCleanup(4 /* latestVersion */, localFiles);
   TEST(!Contains(localFiles, japanLocalFile), (japanLocalFile, localFiles));
   TEST(!Contains(localFiles, brazilLocalFile), (brazilLocalFile, localFiles));
   TEST(Contains(localFiles, irelandLocalFile), (irelandLocalFile, localFiles));
@@ -309,7 +309,7 @@ UNIT_TEST(LocalCountryFile_AllLocalFilesLookup)
   ScopedFile testItalyMapFile(testDir, italyFile, MapOptions::Map, "Italy-map");
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(localFiles, 10101 /* latestVersion */);
+  FindAllLocalMapsAndCleanup(10101 /* latestVersion */, localFiles);
   multiset<LocalCountryFile> localFilesSet(localFiles.begin(), localFiles.end());
 
   bool worldFound = false;
@@ -342,7 +342,7 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
   CountryFile italyFile("Italy");
   LocalCountryFile expectedItalyFile(platform.WritableDir(), italyFile, 0 /* version */);
   shared_ptr<LocalCountryFile> italyLocalFile =
-      PreparePlaceForCountryFiles(italyFile, 0 /* version */, string() /* folder */);
+      PreparePlaceForCountryFiles(0 /* version */, italyFile);
   TEST(italyLocalFile.get(), ());
   TEST_EQUAL(expectedItalyFile, *italyLocalFile, ());
 
@@ -351,14 +351,14 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
   CountryFile germanyFile("Germany");
   LocalCountryFile expectedGermanyFile(directoryForV1.GetFullPath(), germanyFile, 1 /* version */);
   shared_ptr<LocalCountryFile> germanyLocalFile =
-      PreparePlaceForCountryFiles(germanyFile, 1 /* version */, string() /* folder */);
+      PreparePlaceForCountryFiles(1 /* version */, germanyFile);
   TEST(germanyLocalFile.get(), ());
   TEST_EQUAL(expectedGermanyFile, *germanyLocalFile, ());
 
   CountryFile franceFile("France");
   LocalCountryFile expectedFranceFile(directoryForV1.GetFullPath(), franceFile, 1 /* version */);
   shared_ptr<LocalCountryFile> franceLocalFile =
-      PreparePlaceForCountryFiles(franceFile, 1 /* version */, string() /* folder */);
+      PreparePlaceForCountryFiles(1 /* version */, franceFile);
   TEST(franceLocalFile.get(), ());
   TEST_EQUAL(expectedFranceFile, *franceLocalFile, ());
 }

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -198,7 +198,7 @@ UNIT_TEST(LocalCountryFile_CleanupMapFiles)
 
   // Check FindAllLocalMaps()
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(4 /* latestVersion */, localFiles);
+  FindAllLocalMapsAndCleanup(localFiles, 4 /* latestVersion */);
   TEST(!Contains(localFiles, japanLocalFile), (japanLocalFile, localFiles));
   TEST(!Contains(localFiles, brazilLocalFile), (brazilLocalFile, localFiles));
   TEST(Contains(localFiles, irelandLocalFile), (irelandLocalFile, localFiles));
@@ -309,7 +309,7 @@ UNIT_TEST(LocalCountryFile_AllLocalFilesLookup)
   ScopedFile testItalyMapFile(testDir, italyFile, MapOptions::Map, "Italy-map");
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(10101 /* latestVersion */, localFiles);
+  FindAllLocalMapsAndCleanup(localFiles, 10101 /* latestVersion */);
   multiset<LocalCountryFile> localFilesSet(localFiles.begin(), localFiles.end());
 
   bool worldFound = false;

--- a/routing/routing_integration_tests/cross_section_tests.cpp
+++ b/routing/routing_integration_tests/cross_section_tests.cpp
@@ -20,7 +20,7 @@ UNIT_TEST(CheckCrossSections)
 {
   static double constexpr kPointEquality = 0.01;
   vector<platform::LocalCountryFile> localFiles;
-  platform::FindAllLocalMapsAndCleanup(localFiles, numeric_limits<int64_t>::max() /* latestVersion */);
+  platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */, localFiles);
 
   size_t ingoingErrors = 0;
   size_t outgoingErrors = 0;

--- a/routing/routing_integration_tests/cross_section_tests.cpp
+++ b/routing/routing_integration_tests/cross_section_tests.cpp
@@ -20,8 +20,7 @@ UNIT_TEST(CheckCrossSections)
 {
   static double constexpr kPointEquality = 0.01;
   vector<platform::LocalCountryFile> localFiles;
-  platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
-                                       localFiles);
+  platform::FindAllLocalMapsAndCleanup(localFiles, numeric_limits<int64_t>::max() /* latestVersion */);
 
   size_t ingoingErrors = 0;
   size_t outgoingErrors = 0;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -135,8 +135,8 @@ namespace integration
       pl.SetResourceDir(options.m_resourcePath);
 
     vector<LocalCountryFile> localFiles;
-    platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
-                                         localFiles);
+    platform::FindAllLocalMapsAndCleanup(localFiles,
+                                         numeric_limits<int64_t>::max() /* latestVersion */);
     for (auto & file : localFiles)
       file.SyncWithDisk();
     ASSERT(!localFiles.empty(), ());

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -135,8 +135,8 @@ namespace integration
       pl.SetResourceDir(options.m_resourcePath);
 
     vector<LocalCountryFile> localFiles;
-    platform::FindAllLocalMapsAndCleanup(localFiles,
-                                         numeric_limits<int64_t>::max() /* latestVersion */);
+    platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
+                                         localFiles);
     for (auto & file : localFiles)
       file.SyncWithDisk();
     ASSERT(!localFiles.empty(), ());

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -84,8 +84,7 @@ bool HasCountryId(vector<TCountryId> const & sortedCountryIds, TCountryId const 
 }
 
 Storage::Storage(string const & pathToCountriesFile /* = COUNTRIES_FILE */, string const & folder /* = string() */)
-  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_dataDir(folder),
-    m_pathToCountriesFile(pathToCountriesFile)
+  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_dataDir(folder)
 {
   if (!m_dataDir.empty())
   {
@@ -93,7 +92,7 @@ Storage::Storage(string const & pathToCountriesFile /* = COUNTRIES_FILE */, stri
     platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_dataDir));
   }
 
-  LoadCountriesFile(false /* forceReload */);
+  LoadCountriesFile(false /* forceReload */, pathToCountriesFile);
 }
 
 Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
@@ -475,7 +474,7 @@ TCountryId Storage::GetCurrentDownloadingCountryIndex() const
   return IsDownloadInProgress() ? m_queue.front().GetCountryId() : storage::TCountryId();
 }
 
-void Storage::LoadCountriesFile(bool forceReload)
+void Storage::LoadCountriesFile(bool forceReload, string const & pathToCountriesFile)
 {
   if (forceReload)
     m_countries.Clear();
@@ -483,10 +482,10 @@ void Storage::LoadCountriesFile(bool forceReload)
   if (m_countries.ChildrenCount() == 0)
   {
     string json;
-    ReaderPtr<Reader>(GetPlatform().GetReader(m_pathToCountriesFile)).ReadAsString(json);
+    ReaderPtr<Reader>(GetPlatform().GetReader(pathToCountriesFile)).ReadAsString(json);
     m_currentVersion = LoadCountries(json, m_countries);
     if (m_currentVersion < 0)
-      LOG(LERROR, ("Can't load countries file", m_pathToCountriesFile));
+      LOG(LERROR, ("Can't load countries file", pathToCountriesFile));
   }
 }
 

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -83,13 +83,14 @@ bool HasCountryId(vector<TCountryId> const & sortedCountryIds, TCountryId const 
   return binary_search(sortedCountryIds.begin(), sortedCountryIds.end(), countryId);
 }
 
-Storage::Storage(string const & countiesTxt /* = COUNTRIES_FILE */, string const & folder /* = string() */)
-  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_folder(folder), m_countiesTxt(countiesTxt)
+Storage::Storage(string const & pathToCountriesFile /* = COUNTRIES_FILE */, string const & folder /* = string() */)
+  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_dataDir(folder),
+    m_pathToCountriesFile(pathToCountriesFile)
 {
-  if (!m_folder.empty())
+  if (!m_dataDir.empty())
   {
     Platform & platform = GetPlatform();
-    platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_folder));
+    platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_dataDir));
   }
 
   LoadCountriesFile(false /* forceReload */);
@@ -133,7 +134,7 @@ void Storage::RegisterAllLocalMaps()
   m_localFilesForFakeCountries.clear();
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(GetCurrentDataVersion(), localFiles, m_folder);
+  FindAllLocalMapsAndCleanup(localFiles, GetCurrentDataVersion(), m_dataDir);
 
   auto compareByCountryAndVersion = [](LocalCountryFile const & lhs, LocalCountryFile const & rhs)
   {
@@ -422,7 +423,7 @@ void Storage::DownloadNextCountryFromQueue()
   // It's not even possible to prepare directory for files before
   // downloading.  Mark this country as failed and switch to next
   // country.
-  if (!PreparePlaceForCountryFiles(GetCountryFile(countryId), GetCurrentDataVersion(), m_folder))
+  if (!PreparePlaceForCountryFiles(GetCountryFile(countryId), GetCurrentDataVersion(), m_dataDir))
   {
     OnMapDownloadFinished(countryId, false /* success */, queuedCountry.GetInitOptions());
     NotifyStatusChanged(countryId);
@@ -482,10 +483,10 @@ void Storage::LoadCountriesFile(bool forceReload)
   if (m_countries.ChildrenCount() == 0)
   {
     string json;
-    ReaderPtr<Reader>(GetPlatform().GetReader(m_countiesTxt)).ReadAsString(json);
+    ReaderPtr<Reader>(GetPlatform().GetReader(m_pathToCountriesFile)).ReadAsString(json);
     m_currentVersion = LoadCountries(json, m_countries);
     if (m_currentVersion < 0)
-      LOG(LERROR, ("Can't load countries file", m_countiesTxt));
+      LOG(LERROR, ("Can't load countries file", m_pathToCountriesFile));
   }
 }
 
@@ -587,7 +588,7 @@ bool Storage::RegisterDownloadedFiles(TCountryId const & countryId, MapOptions f
   CountryFile const countryFile = GetCountryFile(countryId);
   TLocalFilePtr localFile = GetLocalFile(countryId, GetCurrentDataVersion());
   if (!localFile)
-    localFile = PreparePlaceForCountryFiles(countryFile, GetCurrentDataVersion(), m_folder);
+    localFile = PreparePlaceForCountryFiles(countryFile, GetCurrentDataVersion(), m_dataDir);
   if (!localFile)
   {
     LOG(LERROR, ("Local file data structure can't be prepared for downloaded file(", countryFile,
@@ -870,7 +871,7 @@ bool Storage::DeleteCountryFilesFromDownloader(TCountryId const & countryId, Map
       m_downloader->Reset();
 
     // Remove all files downloader had been created for a country.
-    DeleteDownloaderFilesForCountry(GetCountryFile(countryId), GetCurrentDataVersion(), m_folder);
+    DeleteDownloaderFilesForCountry(GetCountryFile(countryId), GetCurrentDataVersion(), m_dataDir);
   }
 
   queuedCountry->RemoveOptions(opt);
@@ -898,7 +899,7 @@ uint64_t Storage::GetDownloadSize(QueuedCountry const & queuedCountry) const
 
 string Storage::GetFileDownloadPath(TCountryId const & countryId, MapOptions file) const
 {
-  return platform::GetFileDownloadPath(GetCountryFile(countryId), file, GetCurrentDataVersion(), m_folder);
+  return platform::GetFileDownloadPath(GetCountryFile(countryId), file, GetCurrentDataVersion(), m_dataDir);
 }
 
 TCountryId const Storage::GetRootId() const

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -83,8 +83,15 @@ bool HasCountryId(vector<TCountryId> const & sortedCountryIds, TCountryId const 
   return binary_search(sortedCountryIds.begin(), sortedCountryIds.end(), countryId);
 }
 
-Storage::Storage() : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0)
+Storage::Storage(string const & countiesTxt /* = COUNTRIES_FILE */, string const & folder /* = string() */)
+  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_folder(folder), m_countiesTxt(countiesTxt)
 {
+  if (!m_folder.empty())
+  {
+    Platform & platform = GetPlatform();
+    platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_folder));
+  }
+
   LoadCountriesFile(false /* forceReload */);
 }
 
@@ -126,7 +133,7 @@ void Storage::RegisterAllLocalMaps()
   m_localFilesForFakeCountries.clear();
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(GetCurrentDataVersion(), localFiles);
+  FindAllLocalMapsAndCleanup(GetCurrentDataVersion(), localFiles, m_folder);
 
   auto compareByCountryAndVersion = [](LocalCountryFile const & lhs, LocalCountryFile const & rhs)
   {
@@ -415,7 +422,7 @@ void Storage::DownloadNextCountryFromQueue()
   // It's not even possible to prepare directory for files before
   // downloading.  Mark this country as failed and switch to next
   // country.
-  if (!PreparePlaceForCountryFiles(GetCountryFile(countryId), GetCurrentDataVersion()))
+  if (!PreparePlaceForCountryFiles(GetCountryFile(countryId), GetCurrentDataVersion(), m_folder))
   {
     OnMapDownloadFinished(countryId, false /* success */, queuedCountry.GetInitOptions());
     NotifyStatusChanged(countryId);
@@ -475,11 +482,10 @@ void Storage::LoadCountriesFile(bool forceReload)
   if (m_countries.ChildrenCount() == 0)
   {
     string json;
-    string name = migrate::NeedMigrate() ? COUNTRIES_FILE : COUNTRIES_MIGRATE_FILE;
-    ReaderPtr<Reader>(GetPlatform().GetReader(name)).ReadAsString(json);
+    ReaderPtr<Reader>(GetPlatform().GetReader(m_countiesTxt)).ReadAsString(json);
     m_currentVersion = LoadCountries(json, m_countries);
     if (m_currentVersion < 0)
-      LOG(LERROR, ("Can't load countries file", name));
+      LOG(LERROR, ("Can't load countries file", m_countiesTxt));
   }
 }
 
@@ -581,7 +587,7 @@ bool Storage::RegisterDownloadedFiles(TCountryId const & countryId, MapOptions f
   CountryFile const countryFile = GetCountryFile(countryId);
   TLocalFilePtr localFile = GetLocalFile(countryId, GetCurrentDataVersion());
   if (!localFile)
-    localFile = PreparePlaceForCountryFiles(countryFile, GetCurrentDataVersion());
+    localFile = PreparePlaceForCountryFiles(countryFile, GetCurrentDataVersion(), m_folder);
   if (!localFile)
   {
     LOG(LERROR, ("Local file data structure can't be prepared for downloaded file(", countryFile,
@@ -864,7 +870,7 @@ bool Storage::DeleteCountryFilesFromDownloader(TCountryId const & countryId, Map
       m_downloader->Reset();
 
     // Remove all files downloader had been created for a country.
-    DeleteDownloaderFilesForCountry(GetCountryFile(countryId), GetCurrentDataVersion());
+    DeleteDownloaderFilesForCountry(GetCountryFile(countryId), GetCurrentDataVersion(), m_folder);
   }
 
   queuedCountry->RemoveOptions(opt);
@@ -892,7 +898,7 @@ uint64_t Storage::GetDownloadSize(QueuedCountry const & queuedCountry) const
 
 string Storage::GetFileDownloadPath(TCountryId const & countryId, MapOptions file) const
 {
-  return platform::GetFileDownloadPath(GetCountryFile(countryId), file, GetCurrentDataVersion());
+  return platform::GetFileDownloadPath(GetCountryFile(countryId), file, GetCurrentDataVersion(), m_folder);
 }
 
 TCountryId const Storage::GetRootId() const

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -83,16 +83,12 @@ bool HasCountryId(vector<TCountryId> const & sortedCountryIds, TCountryId const 
   return binary_search(sortedCountryIds.begin(), sortedCountryIds.end(), countryId);
 }
 
-Storage::Storage(string const & pathToCountriesFile /* = COUNTRIES_FILE */, string const & folder /* = string() */)
-  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_dataDir(folder)
+Storage::Storage(string const & pathToCountriesFile /* = COUNTRIES_FILE */, string const & dataDir /* = string() */)
+  : m_downloader(new HttpMapFilesDownloader()), m_currentSlotId(0), m_dataDir(dataDir)
 {
-  if (!m_dataDir.empty())
-  {
-    Platform & platform = GetPlatform();
-    platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_dataDir));
-  }
 
-  LoadCountriesFile(false /* forceReload */, pathToCountriesFile);
+
+  LoadCountriesFile(false /* forceReload */, pathToCountriesFile, m_dataDir);
 }
 
 Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
@@ -133,7 +129,7 @@ void Storage::RegisterAllLocalMaps()
   m_localFilesForFakeCountries.clear();
 
   vector<LocalCountryFile> localFiles;
-  FindAllLocalMapsAndCleanup(localFiles, GetCurrentDataVersion(), m_dataDir);
+  FindAllLocalMapsAndCleanup(GetCurrentDataVersion(), m_dataDir, localFiles);
 
   auto compareByCountryAndVersion = [](LocalCountryFile const & lhs, LocalCountryFile const & rhs)
   {
@@ -422,7 +418,7 @@ void Storage::DownloadNextCountryFromQueue()
   // It's not even possible to prepare directory for files before
   // downloading.  Mark this country as failed and switch to next
   // country.
-  if (!PreparePlaceForCountryFiles(GetCountryFile(countryId), GetCurrentDataVersion(), m_dataDir))
+  if (!PreparePlaceForCountryFiles(GetCurrentDataVersion(), m_dataDir, GetCountryFile(countryId)))
   {
     OnMapDownloadFinished(countryId, false /* success */, queuedCountry.GetInitOptions());
     NotifyStatusChanged(countryId);
@@ -474,8 +470,17 @@ TCountryId Storage::GetCurrentDownloadingCountryIndex() const
   return IsDownloadInProgress() ? m_queue.front().GetCountryId() : storage::TCountryId();
 }
 
-void Storage::LoadCountriesFile(bool forceReload, string const & pathToCountriesFile)
+void Storage::LoadCountriesFile(bool forceReload, string const & pathToCountriesFile,
+                                string const & dataDir)
 {
+  m_dataDir = dataDir;
+
+  if (!m_dataDir.empty())
+  {
+    Platform & platform = GetPlatform();
+    platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_dataDir));
+  }
+
   if (forceReload)
     m_countries.Clear();
 
@@ -587,7 +592,7 @@ bool Storage::RegisterDownloadedFiles(TCountryId const & countryId, MapOptions f
   CountryFile const countryFile = GetCountryFile(countryId);
   TLocalFilePtr localFile = GetLocalFile(countryId, GetCurrentDataVersion());
   if (!localFile)
-    localFile = PreparePlaceForCountryFiles(countryFile, GetCurrentDataVersion(), m_dataDir);
+    localFile = PreparePlaceForCountryFiles(GetCurrentDataVersion(), m_dataDir, countryFile);
   if (!localFile)
   {
     LOG(LERROR, ("Local file data structure can't be prepared for downloaded file(", countryFile,
@@ -870,7 +875,7 @@ bool Storage::DeleteCountryFilesFromDownloader(TCountryId const & countryId, Map
       m_downloader->Reset();
 
     // Remove all files downloader had been created for a country.
-    DeleteDownloaderFilesForCountry(GetCountryFile(countryId), GetCurrentDataVersion(), m_dataDir);
+    DeleteDownloaderFilesForCountry(GetCurrentDataVersion(), m_dataDir, GetCountryFile(countryId));
   }
 
   queuedCountry->RemoveOptions(opt);
@@ -898,7 +903,7 @@ uint64_t Storage::GetDownloadSize(QueuedCountry const & queuedCountry) const
 
 string Storage::GetFileDownloadPath(TCountryId const & countryId, MapOptions file) const
 {
-  return platform::GetFileDownloadPath(GetCountryFile(countryId), file, GetCurrentDataVersion(), m_dataDir);
+  return platform::GetFileDownloadPath(GetCurrentDataVersion(), m_dataDir, GetCountryFile(countryId), file);
 }
 
 TCountryId const Storage::GetRootId() const

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -83,6 +83,13 @@ private:
   // country were successfully downloaded.
   TUpdate m_update;
 
+  // If |folder| is not empty Storage will create version directories and download maps into
+  // platform::WritableDir/|m_folder|/. Not empty |m_folder| can be used only for
+  // downloading maps to a special place but not for continue working with them from this place.
+  string const m_folder;
+  // |m_countiesTxt| is name of countries.txt file which is used by an instance of Storage.
+  string const m_countiesTxt;
+
   void DownloadNextCountryFromQueue();
 
   void LoadCountriesFile(bool forceReload);
@@ -108,7 +115,17 @@ private:
   void DownloadNextFile(QueuedCountry const & country);
 
 public:
-  Storage();
+  /// \brief Storage will create its directories in Writable Directory
+  /// (gotten with platform::WritableDir) by default.
+  /// \param countiesTxt is a name of countries.txt file.
+  /// \param folder If |folder| is not empty Storage will create its directory in WritableDir/|folder|.
+  /// \note if |folder| is not empty the instance of Storage can be used only for downloading map files
+  /// but not for continue working with them.
+  /// If |folder| is not empty the work flow is
+  /// * create a instance of Storage with a special countries.txt and |folder|
+  /// * download some maps to WritableDir/|folder|
+  /// * destroy the instance of Storage and move the downloaded maps to proper place
+  Storage(string const & countiesTxt = COUNTRIES_FILE, string const & folder = string());
   /// \brief This constructor should be used for testing only.
   Storage(string const & referenceCountriesTxtJsonForTesting,
           unique_ptr<MapFilesDownloader> mapDownloaderForTesting);

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -84,11 +84,11 @@ private:
   TUpdate m_update;
 
   // If |folder| is not empty Storage will create version directories and download maps into
-  // platform::WritableDir/|m_folder|/. Not empty |m_folder| can be used only for
+  // platform::WritableDir/|m_dataDir|/. Not empty |m_dataDir| can be used only for
   // downloading maps to a special place but not for continue working with them from this place.
-  string const m_folder;
-  // |m_countiesTxt| is name of countries.txt file which is used by an instance of Storage.
-  string const m_countiesTxt;
+  string const m_dataDir;
+  // |m_pathToCountriesFile| is name of countries.txt file which is used by an instance of Storage.
+  string const m_pathToCountriesFile;
 
   void DownloadNextCountryFromQueue();
 
@@ -117,7 +117,7 @@ private:
 public:
   /// \brief Storage will create its directories in Writable Directory
   /// (gotten with platform::WritableDir) by default.
-  /// \param countiesTxt is a name of countries.txt file.
+  /// \param pathToCountriesFile is a name of countries.txt file.
   /// \param folder If |folder| is not empty Storage will create its directory in WritableDir/|folder|.
   /// \note if |folder| is not empty the instance of Storage can be used only for downloading map files
   /// but not for continue working with them.
@@ -125,7 +125,7 @@ public:
   /// * create a instance of Storage with a special countries.txt and |folder|
   /// * download some maps to WritableDir/|folder|
   /// * destroy the instance of Storage and move the downloaded maps to proper place
-  Storage(string const & countiesTxt = COUNTRIES_FILE, string const & folder = string());
+  Storage(string const & pathToCountriesFile = COUNTRIES_FILE, string const & folder = string());
   /// \brief This constructor should be used for testing only.
   Storage(string const & referenceCountriesTxtJsonForTesting,
           unique_ptr<MapFilesDownloader> mapDownloaderForTesting);

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -87,12 +87,10 @@ private:
   // platform::WritableDir/|m_dataDir|/. Not empty |m_dataDir| can be used only for
   // downloading maps to a special place but not for continue working with them from this place.
   string const m_dataDir;
-  // |m_pathToCountriesFile| is name of countries.txt file which is used by an instance of Storage.
-  string const m_pathToCountriesFile;
 
   void DownloadNextCountryFromQueue();
 
-  void LoadCountriesFile(bool forceReload);
+  void LoadCountriesFile(bool forceReload, string const & pathToCountriesFile);
 
   void ReportProgress(TCountryId const & countryId, pair<int64_t, int64_t> const & p);
 

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -83,14 +83,15 @@ private:
   // country were successfully downloaded.
   TUpdate m_update;
 
-  // If |folder| is not empty Storage will create version directories and download maps into
+  // If |m_dataDir| is not empty Storage will create version directories and download maps in
   // platform::WritableDir/|m_dataDir|/. Not empty |m_dataDir| can be used only for
   // downloading maps to a special place but not for continue working with them from this place.
-  string const m_dataDir;
+  string m_dataDir;
 
   void DownloadNextCountryFromQueue();
 
-  void LoadCountriesFile(bool forceReload, string const & pathToCountriesFile);
+  void LoadCountriesFile(bool forceReload, string const & pathToCountriesFile,
+                         string const & dataDir);
 
   void ReportProgress(TCountryId const & countryId, pair<int64_t, int64_t> const & p);
 
@@ -116,14 +117,14 @@ public:
   /// \brief Storage will create its directories in Writable Directory
   /// (gotten with platform::WritableDir) by default.
   /// \param pathToCountriesFile is a name of countries.txt file.
-  /// \param folder If |folder| is not empty Storage will create its directory in WritableDir/|folder|.
-  /// \note if |folder| is not empty the instance of Storage can be used only for downloading map files
+  /// \param dataDir If |dataDir| is not empty Storage will create its directory in WritableDir/|dataDir|.
+  /// \note if |dataDir| is not empty the instance of Storage can be used only for downloading map files
   /// but not for continue working with them.
-  /// If |folder| is not empty the work flow is
-  /// * create a instance of Storage with a special countries.txt and |folder|
-  /// * download some maps to WritableDir/|folder|
+  /// If |dataDir| is not empty the work flow is
+  /// * create a instance of Storage with a special countries.txt and |dataDir|
+  /// * download some maps to WritableDir/|dataDir|
   /// * destroy the instance of Storage and move the downloaded maps to proper place
-  Storage(string const & pathToCountriesFile = COUNTRIES_FILE, string const & folder = string());
+  Storage(string const & pathToCountriesFile = COUNTRIES_FILE, string const & dataDir = string());
   /// \brief This constructor should be used for testing only.
   Storage(string const & referenceCountriesTxtJsonForTesting,
           unique_ptr<MapFilesDownloader> mapDownloaderForTesting);

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -858,7 +858,7 @@ UNIT_TEST(StorageTest_GetRootId)
 {
   Storage storage(string(R"({
                            "id": "Countries",
-                           "v": 161227,
+                           "v": )" + strings::to_string(version::FOR_TESTING_SINGLE_MWM1) + R"(,
                            "g": []
                          })"), make_unique<TestMapFilesDownloader>());
 
@@ -870,7 +870,7 @@ UNIT_TEST(StorageTest_GetChildren)
 {
   Storage storage(string(R"({
                         "id": "Countries",
-                        "v": 161227,
+                        "v": )" + strings::to_string(version::FOR_TESTING_SINGLE_MWM1) + R"(,
                         "g": [
                             {
                              "id": "Abkhazia",

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -309,7 +309,7 @@ void OnCountryDownloaded(LocalCountryFile const & localFile)
 
 TLocalFilePtr CreateDummyMapFile(CountryFile const & countryFile, int64_t version, size_t size)
 {
-  TLocalFilePtr localFile = PreparePlaceForCountryFiles(countryFile, version, "" /* folder */);
+  TLocalFilePtr localFile = PreparePlaceForCountryFiles(version, string() /* dataDir */, countryFile);
   TEST(localFile.get(), ("Can't prepare place for", countryFile, "(version", version, ")"));
   {
     string const zeroes(size, '\0');
@@ -779,10 +779,10 @@ UNIT_TEST(StorageTest_FailedDownloading)
 
   // To prevent interference from other tests and on other tests it's
   // better to remove temprorary downloader files.
-  DeleteDownloaderFilesForCountry(countryFile, storage.GetCurrentDataVersion(), string() /* folder */);
+  DeleteDownloaderFilesForCountry(storage.GetCurrentDataVersion(), countryFile);
   MY_SCOPE_GUARD(cleanup, [&]()
   {
-    DeleteDownloaderFilesForCountry(countryFile, storage.GetCurrentDataVersion(), string() /* folder */);
+    DeleteDownloaderFilesForCountry(storage.GetCurrentDataVersion(), countryFile);
   });
 
   {
@@ -793,7 +793,7 @@ UNIT_TEST(StorageTest_FailedDownloading)
 
   // File wasn't downloaded, but temprorary downloader files must exist.
   string const downloadPath =
-      GetFileDownloadPath(countryFile, MapOptions::Map, storage.GetCurrentDataVersion(), string() /* folder */);
+      GetFileDownloadPath(storage.GetCurrentDataVersion(), countryFile, MapOptions::Map);
   TEST(!Platform::IsFileExistsByFullPath(downloadPath), ());
   TEST(Platform::IsFileExistsByFullPath(downloadPath + DOWNLOADING_FILE_EXTENSION), ());
   TEST(Platform::IsFileExistsByFullPath(downloadPath + RESUME_FILE_EXTENSION), ());


### PR DESCRIPTION
Данный PR позволяет создавать несколько экземпляров Storage с разными countries.txt и скачивать карты при помощи них в разные директории.

Это нужно, поскольку до обновления, работая с большими mwm, нам необходимо перед началом обновления, скачать маленькую mwm около клиента.

@syershov @ygorshenin @vng @deathbaba посмотрите по возможности.

https://trello.com/c/KaGuXfOM/2255-storage-counries-txt