### PR TITLE
Online routing fixes

### DIFF
--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -231,7 +231,10 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
     ResultCode const code = startMapping->GetError();
     if (code != NoError)
     {
-      route.AddAbsentCountry(startMapping->GetCountryName());
+      string const name = startMapping->GetCountryName();
+      if (name.empty())
+        return IRouter::ResultCode::StartPointNotFound;
+      route.AddAbsentCountry(name);
       return code;
     }
     return IRouter::StartPointNotFound;
@@ -241,7 +244,10 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
     ResultCode const code = targetMapping->GetError();
     if (code != NoError)
     {
-      route.AddAbsentCountry(targetMapping->GetCountryName());
+      string const name = targetMapping->GetCountryName();
+      if (name.empty())
+        return IRouter::EndPointNotFound;
+      route.AddAbsentCountry(name);
       return code;
     }
     return IRouter::EndPointNotFound;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -42,6 +42,11 @@ void Route::Swap(Route & rhs)
   m_absentCountries.swap(rhs.m_absentCountries);
 }
 
+void Route::AddAbsentCountry(string const & name)
+{
+  if (!name.empty()) m_absentCountries.insert(name);
+}
+
 double Route::GetTotalDistanceMeters() const
 {
   return m_poly.GetTotalDistanceM();

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -99,7 +99,7 @@ public:
   bool IsCurrentOnEnd() const;
 
   /// Add country name if we have no country filename to make route
-  void AddAbsentCountry(string const & name) { m_absentCountries.insert(name); }
+  void AddAbsentCountry(string const & name) { if (!name.empty()) m_absentCountries.insert(name); }
 
   /// Get absent file list of a routing files for shortest path finding
   set<string> const & GetAbsentCountries() const { return m_absentCountries; }

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -99,7 +99,7 @@ public:
   bool IsCurrentOnEnd() const;
 
   /// Add country name if we have no country filename to make route
-  void AddAbsentCountry(string const & name) { if (!name.empty()) m_absentCountries.insert(name); }
+  void AddAbsentCountry(string const & name);
 
   /// Get absent file list of a routing files for shortest path finding
   set<string> const & GetAbsentCountries() const { return m_absentCountries; }

--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -8,8 +8,13 @@ namespace
 UNIT_TEST(OnlineCrossFetcherSmokeTest)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
-  TestOnlineFetcher({61.76, 34.45}, {45.07, 38.94},
-                    {"Russia_Central", "Russia_Southern", "Russia_Northwestern"}, routerComponents);
+  TestOnlineFetcher(
+      {61.76, 34.45}, {45.07, 38.94},
+      {"Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
+       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
+       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Southern",
+       "Russia_Southern", "Russia_Northwestern", "Russia_Northwestern"},
+      routerComponents);
 }
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -301,13 +301,21 @@ namespace integration
     routing::OnlineCrossFetcher fetcher(OSRM_ONLINE_SERVER_URL, startPoint, finalPoint);
     fetcher.Do();
     vector<m2::PointD> const & points = fetcher.GetMwmPoints();
-    TEST_EQUAL(points.size(), expected.size(), ());
+    set<string> foundMwms;
+
+    // Start/stop mwm workaround. Remove after borders migration.
+    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
+        MercatorBounds::FromLatLon(startPoint)));
+    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
+        MercatorBounds::FromLatLon(finalPoint)));
+
     for (m2::PointD const & point : points)
     {
       string const mwmName = routerComponents.GetCountryInfoGetter().GetRegionFile(point);
       TEST(find(expected.begin(), expected.end(), mwmName) != expected.end(),
            ("Can't find ", mwmName));
+      foundMwms.insert(mwmName);
     }
-    TestOnlineFetcher(startPoint, finalPoint, expected, routerComponents);
+    TEST_EQUAL(expected.size(), foundMwms.size(), ());
   }
 }


### PR DESCRIPTION
https://trello.com/c/wmKPRzvU/2254-online-routing
фиксит нахождение страны без названия (и вылет по ассерту в дебаге), если строить маршрут в центр моря.
+ Фиксит работу интеграционных тестов с новым онлайн сервером.