### PR TITLE
[metadata] Split height and building:levels

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/data/Metadata.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/Metadata.java
@@ -30,6 +30,10 @@ public class Metadata implements Parcelable
     FMD_WIKIPEDIA(16),
     FMD_MAXSPEED(17),
     FMD_FLATS(18);
+    FMD_HEIGHT(19),
+    FMD_MIN_HEIGHT(20),
+    FMD_DENOMINATION(21);
+    FMD_BUILDING_LEVELS(22);
 
     private int mMetaType;
 

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -148,19 +148,23 @@ void RuleDrawer::operator()(FeatureType const & f)
     {
       f.ParseMetadata();
       feature::Metadata const & md = f.GetMetadata();
-      string value = md.Get(feature::Metadata::FMD_HEIGHT);
 
-      double const kDefaultHeightInMeters = 3.0;
+      constexpr double kDefaultHeightInMeters = 3.0;
+      constexpr double kMetersPerLevel = 3.0;
       double heightInMeters = kDefaultHeightInMeters;
+
+      string value = md.Get(feature::Metadata::FMD_HEIGHT);
       if (!value.empty())
+      {
         strings::to_double(value, heightInMeters);
+      }
       else
       {
         value = md.Get(feature::Metadata::FMD_BUILDING_LEVELS);
         if (!value.empty())
         {
-          strings::to_double(value, heightInMeters);
-          heightInMeters *= 3.0;
+          if (strings::to_double(value, heightInMeters))
+            heightInMeters *= kMetersPerLevel;
         }
       }
 

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -154,6 +154,15 @@ void RuleDrawer::operator()(FeatureType const & f)
       double heightInMeters = kDefaultHeightInMeters;
       if (!value.empty())
         strings::to_double(value, heightInMeters);
+      else
+      {
+        value = md.Get(feature::Metadata::FMD_BUILDING_LEVELS);
+        if (!value.empty())
+        {
+          strings::to_double(value, heightInMeters);
+          heightInMeters *= 3.0;
+        }
+      }
 
       value = md.Get(feature::Metadata::FMD_MIN_HEIGHT);
       double minHeigthInMeters = 0.0;

--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -186,26 +186,27 @@ UNIT_TEST(Metadata_ValidateAndFormat_building_levels)
   TEST(md.Empty(), ());
 
   p("building:levels", "1");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "3.0", ());
-  md.Drop(Metadata::FMD_HEIGHT);
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("building:levels", "3.2");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "9.6", ());
-  md.Drop(Metadata::FMD_HEIGHT);
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "3.2", ());
+  md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("building:levels", "1.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "3.0", ());
-  md.Drop(Metadata::FMD_HEIGHT);
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
 
   p("building:levels", "1.0");
   p("height", "4.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "4.0", ());
-  md.Drop(Metadata::FMD_HEIGHT);
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("height", "4.0");
   p("building:levels", "1.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "4.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  md.Drop(Metadata::FMD_BUILDING_LEVELS);
   md.Drop(Metadata::FMD_HEIGHT);
 
   p("building:levels", "Level 1");

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -112,12 +112,11 @@ string MetadataTagProcessorImpl::ValidateAndFormat_height(string const & v) cons
 
 string MetadataTagProcessorImpl::ValidateAndFormat_building_levels(string const & v) const
 {
-  double constexpr kMetersPerLevel = 3;
   double val = 0;
   if(!strings::to_double(v, val) || val == 0)
     return string();
   ostringstream ss;
-  ss << fixed << setprecision(1) << (val * kMetersPerLevel);
+  ss << fixed << setprecision(1) << val;
   return ss.str();
 }
 

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -156,14 +156,9 @@ public:
     }
     else if (k == "building:levels")
     {
-      // Ignoring if FMD_HEIGHT already set
-      if (md.Get(Metadata::FMD_HEIGHT).empty())
-      {
-        // Converting this attribute into height
-        string const & value = ValidateAndFormat_building_levels(v);
-        if (!value.empty())
-          md.Set(Metadata::FMD_HEIGHT, value);
-      }
+      string const & value = ValidateAndFormat_building_levels(v);
+      if (!value.empty())
+        md.Set(Metadata::FMD_BUILDING_LEVELS, value);
     }
     else if (k == "min_height")
     {

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -109,6 +109,7 @@ public:
     FMD_HEIGHT = 19,
     FMD_MIN_HEIGHT = 20,
     FMD_DENOMINATION = 21,
+    FMD_BUILDING_LEVELS = 22,
     FMD_COUNT
   };
 


### PR DESCRIPTION
Разделил сохранение в метаданные height и building:levels. Поправил рендерер, чтобы читал оба значения.