### PR TITLE
Fixed crash on style change

### DIFF
--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -428,8 +428,6 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
         blocker.Wait();
       }
 
-      classificator::Load();
-
       // Invalidate textures and wait for completion.
       {
         BaseBlockingMessage::Blocker blocker;

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -122,8 +122,7 @@ void ClassifObject::ConcatChildNames(string & s) const
 
 Classificator & classif(MapStyle mapStyle)
 {
-  int const index = static_cast<int>(mapStyle);
-  ASSERT_GREATER_OR_EQUAL(index, 0, ());
+  size_t const index = static_cast<size_t>(mapStyle);
   ASSERT_LESS(index, MapStyleCount, ());
   static Classificator c[MapStyleCount];
   return c[index];

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -1,5 +1,6 @@
 #include "indexer/classificator.hpp"
 #include "indexer/tree_structure.hpp"
+#include "indexer/map_style_reader.hpp"
 
 #include "base/macros.hpp"
 #include "base/logging.hpp"
@@ -119,10 +120,18 @@ void ClassifObject::ConcatChildNames(string & s) const
 // Classificator implementation
 /////////////////////////////////////////////////////////////////////////////////////////
 
+Classificator & classif(MapStyle mapStyle)
+{
+  int const index = static_cast<int>(mapStyle);
+  ASSERT_GREATER_OR_EQUAL(index, 0, ());
+  ASSERT_LESS(index, MapStyleCount, ());
+  static Classificator c[MapStyleCount];
+  return c[index];
+}
+
 Classificator & classif()
 {
-  static Classificator c;
-  return c;
+  return classif(GetStyleReader().GetCurrentStyle());
 }
 
 namespace ftype

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -1,6 +1,6 @@
 #include "indexer/classificator.hpp"
-#include "indexer/tree_structure.hpp"
 #include "indexer/map_style_reader.hpp"
+#include "indexer/tree_structure.hpp"
 
 #include "base/macros.hpp"
 #include "base/logging.hpp"

--- a/indexer/classificator.hpp
+++ b/indexer/classificator.hpp
@@ -1,16 +1,17 @@
 #pragma once
+
 #include "indexer/drawing_rule_def.hpp"
-#include "indexer/types_mapping.hpp"
-#include "indexer/scales.hpp"
 #include "indexer/feature_decl.hpp"
+#include "indexer/map_style.hpp"
+#include "indexer/scales.hpp"
+#include "indexer/types_mapping.hpp"
 
-#include "std/vector.hpp"
-#include "std/string.hpp"
-#include "std/iostream.hpp"
 #include "std/bitset.hpp"
-#include "std/noncopyable.hpp"
 #include "std/initializer_list.hpp"
-
+#include "std/iostream.hpp"
+#include "std/noncopyable.hpp"
+#include "std/string.hpp"
+#include "std/vector.hpp"
 
 class ClassifObject;
 
@@ -222,4 +223,5 @@ public:
   string GetReadableObjectName(uint32_t type) const;
 };
 
+Classificator & classif(MapStyle mapStyle);
 Classificator & classif();

--- a/indexer/classificator_loader.cpp
+++ b/indexer/classificator_loader.cpp
@@ -48,7 +48,7 @@ namespace classificator
 
     MapStyle const originMapStyle = GetStyleReader().GetCurrentStyle();
 
-    for (int i = 0; i < MapStyleCount; ++i)
+    for (size_t i = 0; i < MapStyleCount; ++i)
     {
       MapStyle const mapStyle = static_cast<MapStyle>(i);
       GetStyleReader().SetCurrentStyle(mapStyle);

--- a/indexer/classificator_loader.cpp
+++ b/indexer/classificator_loader.cpp
@@ -1,6 +1,7 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/classificator.hpp"
 #include "indexer/drawing_rules.hpp"
+#include "indexer/map_style_reader.hpp"
 
 #include "platform/platform.hpp"
 
@@ -45,10 +46,20 @@ namespace classificator
 
     Platform & p = GetPlatform();
 
-    ReadCommon(p.GetReader("classificator.txt"),            
-               p.GetReader("types.txt"));
+    MapStyle const originMapStyle = GetStyleReader().GetCurrentStyle();
 
-    drule::LoadRules();
+    for (int i = 0; i < MapStyleCount; ++i)
+    {
+      MapStyle const mapStyle = static_cast<MapStyle>(i);
+      GetStyleReader().SetCurrentStyle(mapStyle);
+
+      ReadCommon(p.GetReader("classificator.txt"),
+                 p.GetReader("types.txt"));
+
+      drule::LoadRules();
+    }
+
+    GetStyleReader().SetCurrentStyle(originMapStyle);
 
     LOG(LDEBUG, ("Reading of classificator finished"));
   }

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -185,10 +185,18 @@ void RulesHolder::ResizeCaches(size_t s)
   ForEachRule(bind(&BaseRule::CheckCacheSize, _4, s));
 }
 
+RulesHolder & rules(MapStyle mapStyle)
+{
+  int const index = static_cast<int>(mapStyle);
+  ASSERT_GREATER_OR_EQUAL(index, 0, ());
+  ASSERT_LESS(index, MapStyleCount, ());
+  static RulesHolder h[MapStyleCount];
+  return h[index];
+}
+
 RulesHolder & rules()
 {
-  static RulesHolder holder;
-  return holder;
+  return rules(GetStyleReader().GetCurrentStyle());
 }
 
 namespace

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -187,8 +187,7 @@ void RulesHolder::ResizeCaches(size_t s)
 
 RulesHolder & rules(MapStyle mapStyle)
 {
-  int const index = static_cast<int>(mapStyle);
-  ASSERT_GREATER_OR_EQUAL(index, 0, ());
+  size_t const index = static_cast<size_t>(mapStyle);
   ASSERT_LESS(index, MapStyleCount, ());
   static RulesHolder h[MapStyleCount];
   return h[index];

--- a/indexer/drawing_rules.hpp
+++ b/indexer/drawing_rules.hpp
@@ -2,6 +2,7 @@
 
 #include "indexer/drawing_rule_def.hpp"
 #include "indexer/drules_selector.hpp"
+#include "indexer/map_style.hpp"
 
 #include "base/base.hpp"
 #include "base/buffer_vector.hpp"
@@ -121,6 +122,7 @@ namespace drule
     void InitBackgroundColors(ContainerProto const & cp);
   };
 
+  RulesHolder & rules(MapStyle mapStyle);
   RulesHolder & rules();
 
   void LoadRules();


### PR DESCRIPTION
При изменении стиля происходит переинициализация classificator, который может использоваться в search. в этом случае возникает крэш.
