### PR TITLE
[generator] Add version parameter to planet generator

### DIFF
--- a/tools/python/hierarchy_to_countries.py
+++ b/tools/python/hierarchy_to_countries.py
@@ -48,6 +48,8 @@ parser.add_option('-c', '--old', help='old_vs_new.csv file')
 parser.add_option('-v', '--version', type='int', default=151231, help='Version')
 parser.add_option('-o', '--output', help='Output countries.txt file (default is stdout)')
 parser.add_option('-m', '--help', action='store_true', help='Display this help')
+parser.add_option('--flag', action='store_true', help='Add flags ("c") to countries')
+parser.add_option('--lang', action='store_true', help='Add languages ("lang") to countries')
 (options, args) = parser.parse_args()
 
 if options.help:
@@ -102,10 +104,10 @@ with open(options.hierarchy, 'r') as f:
       last = CountryDict({ "id": items[0], "d": depth })
       if items[0] in oldvs:
         last['old'] = oldvs[items[0]]
-      #if len(items) > 2 and len(items[2]) > 0::
-      #  last['c'] = items[2]
-      #if len(items) > 3 and len(items[3]) > 0:
-      #  last['lang'] = items[3].split(',')
+      if options.flag and len(items) > 2 and len(items[2]) > 0:
+        last['c'] = items[2]
+      if options.lang and len(items) > 3 and len(items[3]) > 0:
+        last['lang'] = items[3].split(',')
 
 # the last line is always a file
 del last['d']

--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -149,7 +149,7 @@ OSRM_FLAG="$INTDIR/osrm_done"
 SCRIPTS_PATH="$(dirname "$0")"
 ROUTING_SCRIPT="$SCRIPTS_PATH/generate_planet_routing.sh"
 TESTING_SCRIPT="$SCRIPTS_PATH/test_planet.sh"
-VERSION="${VERSION:-$(date +%y%m%d)}"
+VERSION_FORMAT="%y%m%d"
 LOG_PATH="${LOG_PATH:-$TARGET/logs}"
 mkdir -p "$LOG_PATH"
 PLANET_LOG="$LOG_PATH/generate_planet.log"
@@ -350,6 +350,18 @@ if [ "$MODE" == "features" ]; then
   "$GENERATOR_TOOL" --intermediate_data_path="$INTDIR/" --node_storage=$NODE_STORAGE --osm_file_type=o5m --osm_file_name="$PLANET" \
     --data_path="$TARGET" --user_resource_path="$DATA_PATH/" $PARAMS_SPLIT 2>> "$PLANET_LOG"
   MODE=mwm
+fi
+
+# Get version from the planet file
+if [ -z "${VERSION-}" ]; then
+  PLANET_VERSION="$("$OSMCTOOLS/osmconvert" --out-timestamp "$PLANET")"
+  if [[ $PLANET_VERSION == *nvalid* ]]; then
+    VERSION="$(date "+$VERSION_FORMAT")"
+  elif [ "$(uname -s)" == "Darwin" ]; then
+    VERSION="$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$PLANET_VERSION" "+$VERSION_FORMAT")"
+  else
+    VERSION="$(date -d "$(echo "$PLANET_VERSION" | sed -e 's/T/ /')" "+$VERSION_FORMAT")"
+  fi
 fi
 
 if [ "$MODE" == "mwm" ]; then


### PR DESCRIPTION
Основное, что PR добавляет, это указание номера версии в параметрах скрипта, делающего `countries.txt`. Это потребовало переработки системы указания параметров, что позволило сделать вызов в `generate_planet.sh` более наглядным.

Кроме того, теперь скрипту генерации планеты можно передать версию данных в ключе `VERSION` (едва ли кому пригодится), и скрипт создания countries не записывает пустые группы: если обрабатывали не все mwm, а какое-то подмножество, в итоговом countries.txt будет только оно.