### PR TITLE
[generator] Demote log message about invalid wikipedia tag value

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -157,7 +157,7 @@ string MetadataTagProcessorImpl::ValidateAndFormat_wikipedia(string v) const
         return v.substr(slashIndex + 1, baseIndex - slashIndex - 1) + ":" + title;
       }
     }
-    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
+    LOG(LDEBUG, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Standard case: "lang:Article Name With Spaces".
@@ -165,13 +165,13 @@ string MetadataTagProcessorImpl::ValidateAndFormat_wikipedia(string v) const
   auto const colonIndex = v.find(':');
   if (colonIndex == string::npos || colonIndex < 2 || colonIndex + 2 > v.size())
   {
-    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
+    LOG(LDEBUG, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Check if it's not a random/invalid link.
   if (v.find("//") != string::npos || v.find(".org") != string::npos)
   {
-    LOG(LINFO, ("Invalid Wikipedia tag value:", v));
+    LOG(LDEBUG, ("Invalid Wikipedia tag value:", v));
     return string();
   }
   // Normalize to OSM standards.


### PR DESCRIPTION
Сообщения о неправильных значения тега `wikipedia` замусоривают лог, и ничего не дают тем, кто его читает. Не будем же мы бросаться исправлять в планете все криво записанные адреса вики. Алгоритм хорошо парсит правильные значения тега, большего и не нужно.