### PR TITLE
Fixed tests. AddressInfo does not have name and type now.

### DIFF
--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -397,11 +397,12 @@ namespace
     search::AddressInfo info;
     fm.GetAddressInfoForGlobalPoint(MercatorBounds::FromLatLon(lat, lon), info);
 
-    TEST_EQUAL(info.m_name, poi.m_name, ());
     TEST_EQUAL(info.m_street, poi.m_street, ());
     TEST_EQUAL(info.m_house, poi.m_house, ());
-    TEST_EQUAL(info.m_types.size(), 1, ());
-    TEST_EQUAL(info.GetBestType(), poi.m_type, ());
+    // TODO(AlexZ): AddressInfo should contain addresses only. Refactor.
+    //TEST_EQUAL(info.m_name, poi.m_name, ());
+    //TEST_EQUAL(info.m_types.size(), 1, ());
+    //TEST_EQUAL(info.GetBestType(), poi.m_type, ());
   }
 }
 


### PR DESCRIPTION
New geocoder (and editor branch too) does not use name and type fields of AddressInfo structure.
It will be refactored on the editor branch to contain only address-related fields.