### PR TITLE
Downloader online fixes

### DIFF
--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -8,8 +8,13 @@ namespace
 UNIT_TEST(OnlineCrossFetcherSmokeTest)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
-  TestOnlineFetcher({61.76, 34.45}, {45.07, 38.94},
-                    {"Russia_Central", "Russia_Southern", "Russia_Northwestern"}, routerComponents);
+  TestOnlineFetcher(
+      {61.76, 34.45}, {45.07, 38.94},
+      {"Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
+       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
+       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Southern",
+       "Russia_Southern", "Russia_Northwestern", "Russia_Northwestern"},
+      routerComponents);
 }
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)

--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -11,10 +11,8 @@ UNIT_TEST(OnlineCrossFetcherSmokeTest)
   TestOnlineFetcher(
       {61.76, 34.45}, {45.07, 38.94},
       {"Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
-       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
-       "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Southern",
-       "Russia_Southern", "Russia_Northwestern", "Russia_Northwestern"},
-      routerComponents);
+       "Russia_Central", "Russia_Southern", "Russia_Southern", "Russia_Northwestern",
+       "Russia_Northwestern", "Russia_Northwestern"}, routerComponents);
 }
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)

--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -8,45 +8,63 @@ namespace
 UNIT_TEST(OnlineCrossFetcherSmokeTest)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
-  TestOnlineFetcher(
-      {61.76, 34.45}, {45.07, 38.94},
-      {"Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central", "Russia_Central",
-       "Russia_Central", "Russia_Southern", "Russia_Southern", "Russia_Northwestern",
-       "Russia_Northwestern", "Russia_Northwestern"}, routerComponents);
+  TestOnlineFetcher({61.76, 34.45}, {45.07, 38.94},
+                    {"Russia_Republic of Karelia", "Russia_Leningradskaya Oblast_Southeast",
+                     "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast",
+                     "Russia_Moscow", "Russia_Tula Oblast", "Russia_Lipetsk Oblast",
+                     "Russia_Voronezh Oblast", "Russia_Rostov Oblast", "Russia_Krasnodar Krai"},
+                    routerComponents);
 }
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
   TestOnlineCrosses({61.76, 34.45}, {45.07, 38.94},
-                    {"Russia_Central", "Russia_Southern", "Russia_Northwestern"}, routerComponents);
+                    {"Russia_Republic of Karelia", "Russia_Leningradskaya Oblast_Southeast",
+                     "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast",
+                     "Russia_Moscow", "Russia_Tula Oblast", "Russia_Lipetsk Oblast",
+                     "Russia_Voronezh Oblast", "Russia_Rostov Oblast", "Russia_Krasnodar Krai"},
+                    routerComponents);
 }
 
 UNIT_TEST(OnlineEuropeTestNurnbergToMoscow)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
-  TestOnlineCrosses({49.45, 11.082}, {55.74, 37.56},
-                    {"Russia_Central", "Belarus", "Poland", "Germany_Bavaria", "Germany_Saxony"}, routerComponents);
+  TestOnlineCrosses(
+      {49.45, 11.082}, {55.74, 37.56},
+      {"Germany_Free State of Bavaria_Middle Franconia",
+       "Germany_Free State of Bavaria_Upper Franconia", "Germany_Saxony_Leipzig",
+       "Germany_Saxony_Dresden", "Poland_Lower Silesian Voivodeship",
+       "Poland_Greater Poland Voivodeship", "Poland_Lodz Voivodeship",
+       "Poland_Masovian Voivodeship", "Poland_Lublin Voivodeship", "Belarus_Brest Region",
+       "Belarus_Hrodna Region", "Belarus_Minsk Region", "Belarus_Vitebsk Region",
+       "Russia_Smolensk Oblast", "Russia_Moscow Oblast", "Russia_Moscow"},
+      routerComponents);
 }
 
 UNIT_TEST(OnlineAmericanTestOttawaToWashington)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
   TestOnlineCrosses({45.38, -75.69}, {38.91, -77.031},
-                    {"Canada_Ontario", "USA_New York", "USA_Pennsylvania", "USA_Maryland", "USA_District of Columbia"}, routerComponents);
+                    {"Canada_Ontario_Kingston", "US_New York_North", "US_New York_West",
+                     "US_Pennsylvania_Scranton", "US_Pennsylvania_Central", "US_Maryland_Baltimore",
+                     "US_Maryland_and_DC"},
+                    routerComponents);
 }
 
 UNIT_TEST(OnlineAsiaPhuketToPnompen)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
-  TestOnlineCrosses({7.90, 98.23}, {11.56, 104.86},
-                    {"Thailand", "Cambodia"}, routerComponents);
+  TestOnlineCrosses({7.90, 98.23}, {11.56, 104.86}, {"Thailand_South", "Cambodia"},
+                    routerComponents);
 }
 
 UNIT_TEST(OnlineAustraliaCanberraToPerth)
 {
   integration::IRouterComponents & routerComponents  = integration::GetOsrmComponents();
   TestOnlineCrosses({-33.88, 151.13}, {-31.974, 115.88},
-                    {"Australia"}, routerComponents);
+                    {"Australia_New South Wales", "Australia_Victoria", "Australia_South Australia",
+                     "Australia_Western Australia"},
+                    routerComponents);
 }
 }  // namespace

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -303,12 +303,6 @@ namespace integration
     vector<m2::PointD> const & points = fetcher.GetMwmPoints();
     set<string> foundMwms;
 
-    // Start/stop mwm workaround. Remove after borders migration.
-    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
-        MercatorBounds::FromLatLon(startPoint)));
-    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
-        MercatorBounds::FromLatLon(finalPoint)));
-
     for (m2::PointD const & point : points)
     {
       string const mwmName = routerComponents.GetCountryInfoGetter().GetRegionFile(point);

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -301,13 +301,21 @@ namespace integration
     routing::OnlineCrossFetcher fetcher(OSRM_ONLINE_SERVER_URL, startPoint, finalPoint);
     fetcher.Do();
     vector<m2::PointD> const & points = fetcher.GetMwmPoints();
-    TEST_EQUAL(points.size(), expected.size(), ());
+    set<string> foundMwms;
+
+    // Start/stop mwm workaround. Remove after borders migration.
+    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
+        MercatorBounds::FromLatLon(startPoint)));
+    foundMwms.insert(routerComponents.GetCountryInfoGetter().GetRegionFile(
+        MercatorBounds::FromLatLon(finalPoint)));
+
     for (m2::PointD const & point : points)
     {
       string const mwmName = routerComponents.GetCountryInfoGetter().GetRegionFile(point);
       TEST(find(expected.begin(), expected.end(), mwmName) != expected.end(),
            ("Can't find ", mwmName));
+      foundMwms.insert(mwmName);
     }
-    TestOnlineFetcher(startPoint, finalPoint, expected, routerComponents);
+    TEST_EQUAL(expected.size(), foundMwms.size(), ());
   }
 }

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -66,7 +66,7 @@ namespace integration
   unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetter()
   {
     Platform const & platform = GetPlatform();
-    return make_unique<storage::CountryInfoGetter>(platform.GetReader(PACKED_POLYGONS_FILE),
+    return make_unique<storage::CountryInfoGetter>(platform.GetReader(PACKED_POLYGONS_MIGRATE_FILE),
                                                    platform.GetReader(COUNTRIES_FILE));
   }
 


### PR DESCRIPTION
Починил интеграционные тесты для маленьких mwm и нового packed_polygons.bin. Всё должно работать после обновления OSRM на наших серверах (а большая часть тестов начнёт работать и до обновления) и сразу с внутреннего сервера OSRM. Важный коммит последний. Первые 2 - это cherry-pick нужных изменений с мастера.