### PR TITLE
Fixed syntax error in meta viewport tag.

### DIFF
--- a/data/faq.html
+++ b/data/faq.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8"/>
-  <meta name='viewport' content='width=device-width; initial-scale=1.0; maximum-scale=1.0;'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
   <style type="text/css">
 
     /* All langs are invisible by default */


### PR DESCRIPTION
It caused errors like:
```
01-18 17:34:34.478 I/chromium( 3807): [INFO:CONSOLE(5)] "The value "device-width;" for key "width" is invalid, and has been ignored.", source: file:///android_asset/faq.html (5)
01-18 17:34:34.478 I/chromium( 3807): [INFO:CONSOLE(5)] "The value "1.0;" for key "initial-scale" was truncated to its numeric prefix.", source: file:///android_asset/faq.html (5)
01-18 17:34:34.478 I/chromium( 3807): [INFO:CONSOLE(5)] "The value "1.0;" for key "maximum-scale" was truncated to its numeric prefix.", source: file:///android_asset/faq.html (5)
01-18 17:34:34.478 I/chromium( 3807): [INFO:CONSOLE(5)] "Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.", source: file:///android_asset/faq.html (5)
```