### PR TITLE
Extract following flag from routing session state.

### DIFF
--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -46,6 +46,7 @@ RoutingSession::RoutingSession()
     : m_router(nullptr),
       m_route(string()),
       m_state(RoutingNotActive),
+      m_isFollowing(false),
       m_endPoint(m2::PointD::Zero()),
       m_lastWarnedSpeedCameraIndex(0),
       m_lastCheckedSpeedCameraIndex(0),
@@ -70,6 +71,7 @@ void RoutingSession::BuildRoute(m2::PointD const & startPoint, m2::PointD const 
   m_lastGoodPosition = startPoint;
   m_endPoint = endPoint;
   m_router->ClearState();
+  m_isFollowing = false;
   RebuildRoute(startPoint, readyCallback, progressCallback, timeoutSec);
 }
 
@@ -140,6 +142,7 @@ void RoutingSession::Reset()
   m_lastCheckedSpeedCameraIndex = 0;
   m_lastFoundCamera = SpeedCameraRestriction();
   m_speedWarningSignal = false;
+  m_isFollowing = false;
 }
 
 RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & info, Index const & index)
@@ -173,8 +176,7 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & 
     }
     else
     {
-      if (m_state != RouteFollowing)
-        m_state = OnRoute;
+      m_state = OnRoute;
 
       // Warning signals checks
       if (m_routingSettings.m_speedCameraWarning && !m_speedWarningSignal)
@@ -370,6 +372,7 @@ bool RoutingSession::DisableFollowMode()
   if (m_state == RouteNotStarted || m_state == OnRoute)
   {
     m_state = RouteNoFollowing;
+    m_isFollowing = false;
     return true;
   }
   return false;
@@ -378,11 +381,8 @@ bool RoutingSession::DisableFollowMode()
 bool RoutingSession::EnableFollowMode()
 {
   if (m_state == RouteNotStarted || m_state == OnRoute)
-  {
-    m_state = RouteFollowing;
-    return true;
-  }
-  return false;
+    m_isFollowing = true;
+  return m_isFollowing;
 }
 
 void RoutingSession::SetRoutingSettings(RoutingSettings const & routingSettings)

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -45,8 +45,7 @@ public:
     OnRoute,           // user follows the route
     RouteNeedRebuild,  // user left the route
     RouteFinished,     // destination point is reached but the session isn't closed
-    RouteNoFollowing,  // route is built but following mode has been disabled
-    RouteFollowing     // user driwes on road. Similar to OnRoute. Indicates that user pushed the start button.
+    RouteNoFollowing   // route is built but following mode has been disabled
   };
 
   /*
@@ -58,8 +57,6 @@ public:
    * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
    * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position.
    * OnRoute -> RouteFinished             // user reached the end of route
-   * OnRoute -> RouteFollowing            // user pushed the start button
-   * RouteFollowing -> RouteFinished      // user reached the end of route
    * RouteNeedRebuild -> RouteNotReady    // start rebuild route
    * RouteFinished -> RouteNotReady       // start new route
    */
@@ -86,11 +83,11 @@ public:
 
   m2::PointD GetEndPoint() const { return m_endPoint; }
   bool IsActive() const { return (m_state != RoutingNotActive); }
-  bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished || m_state == RouteFollowing); }
+  bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished); }
   bool IsBuilt() const { return (IsNavigable() || m_state == RouteNeedRebuild || m_state == RouteFinished); }
   bool IsBuilding() const { return (m_state == RouteBuilding); }
-  bool IsOnRoute() const { return (m_state == OnRoute || m_state == RouteFollowing); }
-  bool IsFollowing() const { return (m_state == RouteFollowing); }
+  bool IsOnRoute() const { return (m_state == OnRoute); }
+  bool IsFollowing() const { return m_isFollowing; }
   void Reset();
 
   Route const & GetRoute() const { return m_route; }
@@ -155,6 +152,7 @@ private:
   unique_ptr<AsyncRouter> m_router;
   Route m_route;
   atomic<State> m_state;
+  atomic<bool> m_isFollowing;
   m2::PointD m_endPoint;
   size_t m_lastWarnedSpeedCameraIndex;
   SpeedCameraRestriction m_lastFoundCamera;


### PR DESCRIPTION
https://trello.com/c/LHYf6H68/2285-3

Вынес флаг того, что кнопка start нажата в отдельную переменную. Теперь, если в процессе езды по маршруту его нужно перестроить, то мы не теряем информацию о следовании по маршруту. + тест на эту логику.