### PR TITLE
[old map downloader] Fixing assert in Storage tests.

### DIFF
--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -1,4 +1,5 @@
 #include "platform/local_country_file.hpp"
+#include "platform/mwm_version.hpp"
 #include "platform/platform.hpp"
 
 #include "coding/internal/file_data.hpp"
@@ -45,7 +46,10 @@ void LocalCountryFile::SyncWithDisk()
 
 void LocalCountryFile::DeleteFromDisk(MapOptions files) const
 {
-  for (MapOptions file : {MapOptions::Map, MapOptions::CarRouting})
+  vector<MapOptions> const mapOptions =
+      version::IsSingleMwm(GetVersion()) ? vector<MapOptions>({MapOptions::Map})
+                                         : vector<MapOptions>({MapOptions::Map, MapOptions::CarRouting});
+  for (MapOptions file : mapOptions)
   {
     if (OnDisk(file) && HasOptions(files, file))
     {
@@ -58,7 +62,7 @@ void LocalCountryFile::DeleteFromDisk(MapOptions files) const
 string LocalCountryFile::GetPath(MapOptions file) const
 {
   // todo(@m): Refactor with MwmTraits after merge new-search branch.
-  bool singleFile = GetVersion() > 151215;
+  bool const singleFile = version::IsSingleMwm(GetVersion());
   string const & countryFilePath = singleFile ? m_countryFile.GetNameWithExt(MapOptions::Map)
                                               : m_countryFile.GetNameWithExt(file);
   return my::JoinFoldersToPath(m_directory, countryFilePath);


### PR DESCRIPTION
Предотвращение повторного удаления *.mwm файла при однокомпонентных (мелких) mwm.
Что убрало ASSERT при запуске Storage tests.

https://trello.com/c/qQxQrDBl/2322-mwm-2-mwm

@syershov PTAL