### PR TITLE
[build] Check for private.h in build_omim.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -62,7 +62,7 @@ if git clone --depth 1 "$PRIVATE_REPO" "$TMP_REPO_DIR"; then
   echo "Saved private repository url to $SAVED_PRIVATE_REPO_FILE"
   echo "$PRIVATE_REPO" > "$SAVED_PRIVATE_REPO_FILE"
   rm -rf "$TMP_REPO_DIR/.git" "$TMP_REPO_DIR/README.md"
-  cp -Rv "$TMP_REPO_DIR"/* .
+  cp -Rv "$TMP_REPO_DIR"/* "$BASE_PATH"
   rm -rf "$TMP_REPO_DIR"
   echo "Private files have been updated."
 fi

--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -u -e
+
 OPT_DEBUG=
 OPT_RELEASE=
 OPT_OSRM=
@@ -37,9 +39,12 @@ if [ -z "$OPT_DEBUG$OPT_RELEASE$OPT_OSRM" ]; then
   OPT_RELEASE=1
 fi
 
-set -x -u -e
-
 OMIM_PATH="$(cd "${OMIM_PATH:-$(dirname "$0")/../..}"; pwd)"
+if ! grep "DEFAULT_URLS_JSON" "$OMIM_PATH/private.h" >/dev/null 2>/dev/null; then
+  echo "Please run $OMIM_PATH/configure.sh"
+  exit 2
+fi
+
 BOOST_PATH="${BOOST_PATH:-/usr/local/boost_1.54.0}"
 DEVTOOLSET_PATH=/opt/rh/devtoolset-2
 if [ -d "$DEVTOOLSET_PATH" ]; then


### PR DESCRIPTION
Снова люди пытаются собрать проект, забыв про `configure.sh`. Поэтому я добавил проверку на наличие нужных файлов прямо в скрипт сборки.

Заодно поправил ошибку при запуске `configure.sh` не из каталога omim.