### PR TITLE
Fix german night strings

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -322,9 +322,9 @@
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nachtmodus</string>
 	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">An</string>
+	<string name="pref_map_style_default">Aus</string>
 	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Aus</string>
+	<string name="pref_map_style_night">An</string>
 	<!-- «Map style» entry value -->
 	<string name="pref_map_style_auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->

--- a/iphone/Maps/de.lproj/Localizable.strings
+++ b/iphone/Maps/de.lproj/Localizable.strings
@@ -499,10 +499,10 @@
 "pref_map_style_title" = "Nachtmodus";
 
 /* «Map style» entry value */
-"pref_map_style_default" = "An";
+"pref_map_style_default" = "Aus";
 
 /* «Map style» entry value */
-"pref_map_style_night" = "Aus";
+"pref_map_style_night" = "An";
 
 /* «Map style» entry value */
 "pref_map_style_auto" = "Auto";

--- a/strings.txt
+++ b/strings.txt
@@ -5325,7 +5325,7 @@
     uk = Вимкнуто
     vi = Tắt
     hu = Ki
-    de = An
+    de = Aus
     fi = Pois päältä
     cs = Vypnuto
     it = Sì
@@ -5356,7 +5356,7 @@
     uk = Увімкнуто
     vi = Bật
     hu = Be
-    de = Aus
+    de = An
     fi = Päällä
     cs = Zapnuto
     it = No


### PR DESCRIPTION
В немецком строчки Вкл и Выкл были перепутаны. Исправил.