### PR TITLE
[docs] No iOS nightly builds; building instructions for Fedora 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and Android debug packages.
 For detailed installation instructions and Android/iOS building process,
 see [INSTALL.md](https://github.com/mapsme/omim/tree/master/docs/INSTALL.md).
 
-Nightly builds for Android and iOS are published to [osmz.ru](http://osmz.ru/mwm/)
+Nightly builds for Android are published to [osmz.ru](http://osmz.ru/mwm/)
 and Dropbox: [release](http://maps.me/release), [debug](http://maps.me/debug).
 
 ## Building maps

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,6 +86,16 @@ To build and run OSRM binaries:
     sudo apt-get install libboost-filesystem-dev libboost-date-time-dev
     tools/unix/build_omim.sh -o
 
+### Fedora 23
+
+Install dependencies:
+
+    dnf install clang qt5-qtbase-devel boost-devel libstdc++-devel
+
+Then do a git clone, run `configure.sh` and compile with linux-clang spec:
+
+    SPEC=linux-clang tools/unix/build_omim.sh -r
+
 ### Windows
 
 We haven't compiled MAPS.ME on Windows in a long time, though it is possible. It is likely


### PR DESCRIPTION
Пользователи заметили, что еженочные сборки для iOS отключены. Также, добавил пару заметок про сборку проекта под Fedora Linux.