### PR TITLE
 [old-map-downloader] Added cancel button and auto-downloading callback

### DIFF
--- a/drape_frontend/color_constants.cpp
+++ b/drape_frontend/color_constants.cpp
@@ -26,6 +26,8 @@ unordered_map<int, unordered_map<int, dp::Color>> kColorConstants =
       { TrackCarSpeed, dp::Color(21, 121, 244, 255) },
       { TrackPlaneSpeed, dp::Color(10, 196, 255, 255) },
       { TrackUnknownDistance, dp::Color(97, 97, 97, 255) },
+      { DownloadCancelButton, dp::Color(0, 0, 0, 112) },
+      { DownloadCancelButtonPressed, dp::Color(0, 0, 0, 184) },
     }
   },
   { MapStyleDark,
@@ -44,6 +46,8 @@ unordered_map<int, unordered_map<int, dp::Color>> kColorConstants =
       { TrackCarSpeed, dp::Color(255, 202, 40, 255) },
       { TrackPlaneSpeed, dp::Color(255, 245, 160, 255) },
       { TrackUnknownDistance, dp::Color(150, 150, 150, 255) },
+      { DownloadCancelButton, dp::Color(255, 255, 255, 178) },
+      { DownloadCancelButtonPressed, dp::Color(255, 255, 255, 77) },
     }
   },
 };

--- a/drape_frontend/color_constants.hpp
+++ b/drape_frontend/color_constants.hpp
@@ -22,7 +22,9 @@ enum ColorConstant
   TrackHumanSpeed,
   TrackCarSpeed,
   TrackPlaneSpeed,
-  TrackUnknownDistance
+  TrackUnknownDistance,
+  DownloadCancelButton,
+  DownloadCancelButtonPressed
 };
 
 dp::Color GetColorConstant(MapStyle style, ColorConstant constant);

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -45,6 +45,7 @@ DrapeEngine::DrapeEngine(Params && params)
 
   ConnectDownloadFn(gui::CountryStatusHelper::BUTTON_TYPE_MAP, params.m_model.GetDownloadMapHandler());
   ConnectDownloadFn(gui::CountryStatusHelper::BUTTON_TRY_AGAIN, params.m_model.GetDownloadRetryHandler());
+  ConnectDownloadFn(gui::CountryStatusHelper::BUTTON_CANCEL, params.m_model.GetDownloadCancelHandler());
 
   m_textureManager = make_unique_dp<dp::TextureManager>();
   m_threadCommutator = make_unique_dp<ThreadsCommutator>();

--- a/drape_frontend/gui/button.cpp
+++ b/drape_frontend/gui/button.cpp
@@ -70,9 +70,9 @@ uint32_t BuildCorner(vector<Button::ButtonVertex> & vertices,
 
 }
 
-ButtonHandle::ButtonHandle(dp::Anchor anchor, m2::PointF const & size,
+ButtonHandle::ButtonHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & size,
                            dp::Color const & color, dp::Color const & pressedColor)
-  : TBase(anchor, m2::PointF::Zero(), size)
+  : TBase(id, anchor, m2::PointF::Zero(), size)
   , m_isInPressedState(false)
   , m_color(color)
   , m_pressedColor(pressedColor)

--- a/drape_frontend/gui/button.hpp
+++ b/drape_frontend/gui/button.hpp
@@ -14,7 +14,7 @@ class ButtonHandle : public TappableHandle
   typedef TappableHandle TBase;
 
 public:
-  ButtonHandle(dp::Anchor anchor, m2::PointF const & size,
+  ButtonHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & size,
                dp::Color const & color, dp::Color const & pressedColor);
 
   void OnTapBegin() override;

--- a/drape_frontend/gui/compass.cpp
+++ b/drape_frontend/gui/compass.cpp
@@ -33,8 +33,9 @@ namespace
     double const VisibleEndAngle = my::DegToRad(355.0);
 
   public:
-    CompassHandle(m2::PointF const & pivot, m2::PointF const & size, Shape::TTapHandler const & tapHandler)
-      : TappableHandle(dp::Center, pivot, size)
+    CompassHandle(uint32_t id, m2::PointF const & pivot, m2::PointF const & size,
+                  Shape::TTapHandler const & tapHandler)
+      : TappableHandle(id, dp::Center, pivot, size)
       , m_tapHandler(tapHandler)
       , m_animation(false, 0.25)
     {
@@ -126,7 +127,9 @@ drape_ptr<ShapeRenderer> Compass::Draw(m2::PointF & compassSize, ref_ptr<dp::Tex
   provider.InitStream(0, info, make_ref(&vertexes));
 
   compassSize = region.GetPixelSize();
-  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CompassHandle>(m_position.m_pixelPivot, compassSize, tapHandler);
+  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CompassHandle>(EGuiHandle::GuiHandleCompass,
+                                                                      m_position.m_pixelPivot,
+                                                                      compassSize, tapHandler);
 
   drape_ptr<ShapeRenderer> renderer = make_unique_dp<ShapeRenderer>();
   dp::Batcher batcher(dp::Batcher::IndexPerQuad, dp::Batcher::VertexPerQuad);

--- a/drape_frontend/gui/copyright_label.cpp
+++ b/drape_frontend/gui/copyright_label.cpp
@@ -23,10 +23,10 @@ namespace
     using TBase = StaticLabelHandle;
 
   public:
-    CopyrightHandle(ref_ptr<dp::TextureManager> textureManager,
+    CopyrightHandle(uint32_t id, ref_ptr<dp::TextureManager> textureManager,
                     dp::Anchor anchor, m2::PointF const & pivot,
                     m2::PointF const & size, TAlphabet const & alphabet)
-      : TBase(textureManager, anchor, pivot, size, alphabet)
+      : TBase(id, textureManager, anchor, pivot, size, alphabet)
     {
       SetIsVisible(true);
     }
@@ -77,7 +77,8 @@ drape_ptr<ShapeRenderer> CopyrightLabel::Draw(m2::PointF & size, ref_ptr<dp::Tex
   size_t indexCount = dp::Batcher::IndexPerQuad * vertexCount / dp::Batcher::VertexPerQuad;
 
   size = m2::PointF(result.m_boundRect.SizeX(), result.m_boundRect.SizeY());
-  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CopyrightHandle>(tex, m_position.m_anchor,
+  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CopyrightHandle>(EGuiHandle::GuiHandleCopyright,
+                                                                        tex, m_position.m_anchor,
                                                                         m_position.m_pixelPivot, size,
                                                                         result.m_alphabet);
 

--- a/drape_frontend/gui/country_status_helper.cpp
+++ b/drape_frontend/gui/country_status_helper.cpp
@@ -56,6 +56,7 @@ void FormatMapSize(uint64_t sizeInBytes, string & units, size_t & sizeToDownload
 
 char const * DownloadMapButtonID = "country_status_download";
 char const * TryAgainButtonID = "try_again";
+char const * DownloadCancelButtonID = "country_download_cancel";
 char const * DownloadingLabelID = "country_status_downloading";
 char const * DownloadingFailedID = "country_status_download_failed";
 char const * InQueueID = "country_status_added_to_queue";
@@ -202,6 +203,8 @@ void CountryStatusHelper::FillControlsForLoading()
     strings::Trim(secondLabel , "\n ");
     m_controls.push_back(MakeLabel(secondLabel));
   }
+
+  m_controls.push_back(MakeButton(FormatCancel(), BUTTON_CANCEL));
 }
 
 void CountryStatusHelper::FillControlsForInQueue()
@@ -238,6 +241,12 @@ string CountryStatusHelper::FormatFailed()
 string CountryStatusHelper::FormatTryAgain()
 {
   return GetLocalizedString(TryAgainButtonID);
+}
+
+string CountryStatusHelper::FormatCancel()
+{
+  //TODO: Uncomment after adding localization for country_download_cancel
+  return "Cancel";//GetLocalizedString(DownloadCancelButtonID);
 }
 
 }  // namespace gui

--- a/drape_frontend/gui/country_status_helper.hpp
+++ b/drape_frontend/gui/country_status_helper.hpp
@@ -45,7 +45,8 @@ public:
   {
     BUTTON_TYPE_NOT_BUTTON,
     BUTTON_TYPE_MAP,
-    BUTTON_TRY_AGAIN
+    BUTTON_TRY_AGAIN,
+    BUTTON_CANCEL
   };
 
   struct Control
@@ -86,6 +87,7 @@ private:
   string FormatInQueueMap();
   string FormatFailed();
   string FormatTryAgain();
+  string FormatCancel();
 
   void SetState(ECountryState state);
 

--- a/drape_frontend/gui/gui_text.cpp
+++ b/drape_frontend/gui/gui_text.cpp
@@ -439,16 +439,16 @@ m2::PointF MutableLabel::GetAvarageSize() const
   return m2::PointF(w, h);
 }
 
-MutableLabelHandle::MutableLabelHandle(dp::Anchor anchor, m2::PointF const & pivot)
-  : TBase(anchor, pivot, m2::PointF::Zero())
+MutableLabelHandle::MutableLabelHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot)
+  : TBase(id, anchor, pivot, m2::PointF::Zero())
   , m_textView(make_unique_dp<MutableLabel>(anchor))
   , m_isContentDirty(true)
   , m_glyphsReady(false)
 {}
 
-MutableLabelHandle::MutableLabelHandle(dp::Anchor anchor, m2::PointF const & pivot,
+MutableLabelHandle::MutableLabelHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot,
                                        ref_ptr<dp::TextureManager> textures)
-  : TBase(anchor, pivot, m2::PointF::Zero())
+  : TBase(id, anchor, pivot, m2::PointF::Zero())
   , m_textView(make_unique_dp<MutableLabel>(anchor))
   , m_isContentDirty(true)
   , m_textureManager(textures)
@@ -570,11 +570,11 @@ m2::PointF MutableLabelDrawer::Draw(Params const & params, ref_ptr<dp::TextureMa
   return staticData.m_maxPixelSize;
 }
 
-StaticLabelHandle::StaticLabelHandle(ref_ptr<dp::TextureManager> textureManager,
+StaticLabelHandle::StaticLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textureManager,
                                      dp::Anchor anchor, m2::PointF const & pivot,
                                      m2::PointF const & size,
                                      TAlphabet const & alphabet)
-  : TBase(anchor, pivot, size)
+  : TBase(id, anchor, pivot, size)
   , m_alphabet(alphabet.begin(), alphabet.end())
   , m_textureManager(textureManager)
   , m_glyphsReady(false)

--- a/drape_frontend/gui/gui_text.hpp
+++ b/drape_frontend/gui/gui_text.hpp
@@ -145,9 +145,9 @@ class MutableLabelHandle : public Handle
   using TBase = Handle;
 
 public:
-  MutableLabelHandle(dp::Anchor anchor, m2::PointF const & pivot);
+  MutableLabelHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot);
 
-  MutableLabelHandle(dp::Anchor anchor, m2::PointF const & pivot,
+  MutableLabelHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot,
                      ref_ptr<dp::TextureManager> textures);
 
   void GetAttributeMutation(ref_ptr<dp::AttributeBufferMutator> mutator,
@@ -197,7 +197,7 @@ class StaticLabelHandle : public Handle
   using TBase = Handle;
 
 public:
-  StaticLabelHandle(ref_ptr<dp::TextureManager> textureManager,
+  StaticLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textureManager,
                     dp::Anchor anchor, m2::PointF const & pivot,
                     m2::PointF const & size,
                     TAlphabet const & alphabet);

--- a/drape_frontend/gui/layer_render.hpp
+++ b/drape_frontend/gui/layer_render.hpp
@@ -46,7 +46,7 @@ private:
   TRenderers m_renderers;
 
   ref_ptr<gui::Handle> m_activeOverlay;
-  EWidget m_activeOverlayWidget = EWidget::WIDGET_RULER;
+  FeatureID m_activeOverlayId;
 };
 
 class LayerCacher

--- a/drape_frontend/gui/ruler.cpp
+++ b/drape_frontend/gui/ruler.cpp
@@ -47,8 +47,8 @@ template<typename TBase>
 class BaseRulerHandle : public TBase
 {
 public:
-  BaseRulerHandle(dp::Anchor anchor, m2::PointF const & pivot, bool isAppearing)
-    : TBase(anchor, pivot)
+  BaseRulerHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, bool isAppearing)
+    : TBase(id, anchor, pivot)
     , m_isAppearing(isAppearing)
     , m_isVisibleAtEnd(true)
     , m_animation(false, 0.4)
@@ -110,8 +110,8 @@ class RulerHandle : public BaseRulerHandle<Handle>
   using TBase = BaseRulerHandle<Handle>;
 
 public:
-  RulerHandle(dp::Anchor anchor, m2::PointF const & pivot, bool appearing)
-    : TBase(anchor, pivot, appearing)
+  RulerHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, bool appearing)
+    : TBase(id, anchor, pivot, appearing)
   {}
 
 private:
@@ -133,9 +133,9 @@ class RulerTextHandle : public BaseRulerHandle<MutableLabelHandle>
   using TBase = BaseRulerHandle<MutableLabelHandle>;
 
 public:
-  RulerTextHandle(dp::Anchor anchor, m2::PointF const & pivot, bool isAppearing,
-                  ref_ptr<dp::TextureManager> textures)
-    : TBase(anchor, pivot, isAppearing)
+  RulerTextHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot,
+                  bool isAppearing, ref_ptr<dp::TextureManager> textures)
+    : TBase(id, anchor, pivot, isAppearing)
     , m_firstUpdate(true)
   {
     SetTextureManager(textures);
@@ -224,7 +224,8 @@ void Ruler::DrawRuler(m2::PointF & size, ShapeControl & control, ref_ptr<dp::Tex
     dp::Batcher batcher(dp::Batcher::IndexPerQuad, dp::Batcher::VertexPerQuad);
     dp::SessionGuard guard(batcher, bind(&ShapeControl::AddShape, &control, _1, _2));
     batcher.InsertTriangleStrip(state, make_ref(&provider),
-                                make_unique_dp<RulerHandle>(m_position.m_anchor, m_position.m_pixelPivot, isAppearing));
+                                make_unique_dp<RulerHandle>(EGuiHandle::GuiHandleRuler, m_position.m_anchor,
+                                                            m_position.m_pixelPivot, isAppearing));
   }
 }
 
@@ -244,7 +245,7 @@ void Ruler::DrawText(m2::PointF & size, ShapeControl & control, ref_ptr<dp::Text
   params.m_pivot = m_position.m_pixelPivot + m2::PointF(0.0, helper.GetVerticalTextOffset());
   params.m_handleCreator = [isAppearing, tex](dp::Anchor anchor, m2::PointF const & pivot)
   {
-    return make_unique_dp<RulerTextHandle>(anchor, pivot, isAppearing, tex);
+    return make_unique_dp<RulerTextHandle>(EGuiHandle::GuiHandleRulerLabel, anchor, pivot, isAppearing, tex);
   };
 
   m2::PointF textSize = MutableLabelDrawer::Draw(params, tex, bind(&ShapeControl::AddShape, &control, _1, _2));

--- a/drape_frontend/gui/shape.cpp
+++ b/drape_frontend/gui/shape.cpp
@@ -9,8 +9,9 @@
 
 namespace gui
 {
-Handle::Handle(dp::Anchor anchor, const m2::PointF & pivot, const m2::PointF & size)
-  : dp::OverlayHandle(FeatureID(), anchor, 0, false)
+
+Handle::Handle(uint32_t id, dp::Anchor anchor, const m2::PointF & pivot, const m2::PointF & size)
+  : dp::OverlayHandle(FeatureID(MwmSet::MwmId(), id), anchor, 0, false)
   , m_pivot(glsl::ToVec2(pivot)), m_size(size)
 {
 }
@@ -162,6 +163,18 @@ ref_ptr<Handle> ShapeRenderer::ProcessTapEvent(m2::RectD const & touchArea)
   ForEachShapeInfo([&resultHandle, &touchArea](ShapeControl::ShapeInfo & shapeInfo)
                    {
                      if (shapeInfo.m_handle->IsTapped(touchArea))
+                       resultHandle = make_ref(shapeInfo.m_handle);
+                   });
+
+  return resultHandle;
+}
+
+ref_ptr<Handle> ShapeRenderer::FindHandle(FeatureID const & id)
+{
+  ref_ptr<Handle> resultHandle = nullptr;
+  ForEachShapeInfo([&resultHandle, &id](ShapeControl::ShapeInfo & shapeInfo)
+                   {
+                     if (shapeInfo.m_handle->GetFeatureID() == id)
                        resultHandle = make_ref(shapeInfo.m_handle);
                    });
 

--- a/drape_frontend/gui/shape.hpp
+++ b/drape_frontend/gui/shape.hpp
@@ -16,7 +16,7 @@ namespace gui
 class Handle : public dp::OverlayHandle
 {
 public:
-  Handle(dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size = m2::PointF::Zero());
+  Handle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size = m2::PointF::Zero());
 
   dp::UniformValuesStorage const & GetUniforms() const { return m_uniforms; }
 
@@ -43,8 +43,8 @@ protected:
 class TappableHandle : public Handle
 {
 public:
-  TappableHandle(dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size)
-    : Handle(anchor, pivot, size)
+  TappableHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size)
+    : Handle(id, anchor, pivot, size)
   {}
 
   bool IsTapped(m2::RectD const & touchArea) const override;
@@ -92,6 +92,7 @@ public:
   void SetPivot(m2::PointF const & pivot);
 
   ref_ptr<Handle> ProcessTapEvent(m2::RectD const & touchArea);
+  ref_ptr<Handle> FindHandle(FeatureID const & id);
 
 private:
   friend void ArrangeShapes(ref_ptr<ShapeRenderer>,

--- a/drape_frontend/gui/skin.hpp
+++ b/drape_frontend/gui/skin.hpp
@@ -19,6 +19,23 @@ enum EWidget
   WIDGET_COUNTRY_STATUS = 0x8000
 };
 
+enum EGuiHandle
+{
+  GuiHandleScaleLabel,
+  GuiHandleCopyright,
+  GuiHandleCompass,
+  GuiHandleRuler,
+  GuiHandleRulerLabel,
+  GuiHandleCountryLabel,
+  GuiHandleCountryProgress,
+  GuiHandleDownloadButton,
+  GuiHandleDownloadButtonLabel,
+  GuiHandleRetryButton,
+  GuiHandleRetryButtonLabel,
+  GuiHandleCancelButton,
+  GuiHandleCancelButtonLabel
+};
+
 struct Position
 {
   Position() : m_pixelPivot(m2::PointF::Zero()), m_anchor(dp::Center) {}

--- a/drape_frontend/map_data_provider.cpp
+++ b/drape_frontend/map_data_provider.cpp
@@ -9,13 +9,15 @@ MapDataProvider::MapDataProvider(TReadIDsFn const & idsReader,
                                  TIsCountryLoadedFn const & isCountryLoadedFn,
                                  TIsCountryLoadedByNameFn const & isCountryLoadedByNameFn,
                                  TDownloadFn const & downloadMapHandler,
-                                 TDownloadFn const & downloadRetryHandler)
+                                 TDownloadFn const & downloadRetryHandler,
+                                 TDownloadFn const & downloadCancelHandler)
   : m_featureReader(featureReader)
   , m_idsReader(idsReader)
   , m_countryIndexUpdater(countryIndexUpdater)
   , m_isCountryLoadedFn(isCountryLoadedFn)
   , m_downloadMapHandler(downloadMapHandler)
   , m_downloadRetryHandler(downloadRetryHandler)
+  , m_downloadCancelHandler(downloadCancelHandler)
   , m_isCountryLoadedByNameFn(isCountryLoadedByNameFn)
 {
 }
@@ -48,6 +50,11 @@ MapDataProvider::TDownloadFn const & MapDataProvider::GetDownloadMapHandler() co
 MapDataProvider::TDownloadFn const & MapDataProvider::GetDownloadRetryHandler() const
 {
   return m_downloadRetryHandler;
+}
+
+MapDataProvider::TDownloadFn const & MapDataProvider::GetDownloadCancelHandler() const
+{
+  return m_downloadCancelHandler;
 }
 
 }

--- a/drape_frontend/map_data_provider.hpp
+++ b/drape_frontend/map_data_provider.hpp
@@ -28,7 +28,8 @@ public:
                   TIsCountryLoadedFn const & isCountryLoadedFn,
                   TIsCountryLoadedByNameFn const & isCountryLoadedByNameFn,
                   TDownloadFn const & downloadMapHandler,
-                  TDownloadFn const & downloadRetryHandler);
+                  TDownloadFn const & downloadRetryHandler,
+                  TDownloadFn const & downloadCancelHandler);
 
   void ReadFeaturesID(TReadCallback<FeatureID> const & fn, m2::RectD const & r, int scale) const;
   void ReadFeatures(TReadCallback<FeatureType> const & fn, vector<FeatureID> const & ids) const;
@@ -38,6 +39,7 @@ public:
 
   TDownloadFn const & GetDownloadMapHandler() const;
   TDownloadFn const & GetDownloadRetryHandler() const;
+  TDownloadFn const & GetDownloadCancelHandler() const;
 
 private:
   TReadFeaturesFn m_featureReader;
@@ -46,6 +48,7 @@ private:
   TIsCountryLoadedFn m_isCountryLoadedFn;
   TDownloadFn m_downloadMapHandler;
   TDownloadFn m_downloadRetryHandler;
+  TDownloadFn m_downloadCancelHandler;
 
 public:
   TIsCountryLoadedByNameFn m_isCountryLoadedByNameFn;

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -587,6 +587,19 @@ NSString * const kAuthorizationSegue = @"Map2AuthorizationSegue";
       }];
     }
   });
+  
+  f.SetDownloadCancelListener([self, &f](storage::TIndex const & idx)
+  {
+    ActiveMapsLayout & layout = f.GetCountryTree().GetActiveMapLayout();
+    layout.CancelDownloading(idx);
+  });
+  
+  f.SetAutoDownloadListener([self, &f](storage::TIndex const & idx)
+  {
+    //TODO: check wifi, migration, settings, whatever and download or not download
+    ActiveMapsLayout & layout = f.GetCountryTree().GetActiveMapLayout();
+    layout.DownloadMap(idx, MapOptions::Map);
+  });
 
   f.SetRouteBuildingListener([self, &f](routing::IRouter::ResultCode code, vector<storage::TIndex> const & absentCountries, vector<storage::TIndex> const & absentRoutes)
   {

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -910,6 +910,16 @@ void Framework::SetDownloadCountryListener(TDownloadCountryListener const & list
   m_downloadCountryListener = listener;
 }
 
+void Framework::SetDownloadCancelListener(TDownloadCancelListener const & listener)
+{
+  m_downloadCancelListener = listener;
+}
+
+void Framework::SetAutoDownloadListener(TAutoDownloadListener const & listener)
+{
+  m_autoDownloadListener = listener;
+}
+
 void Framework::OnDownloadMapCallback(storage::TIndex const & countryIndex)
 {
   if (m_downloadCountryListener != nullptr)
@@ -918,20 +928,23 @@ void Framework::OnDownloadMapCallback(storage::TIndex const & countryIndex)
     m_activeMaps->DownloadMap(countryIndex, MapOptions::Map);
 }
 
-void Framework::OnDownloadMapRoutingCallback(storage::TIndex const & countryIndex)
-{
-  if (m_downloadCountryListener != nullptr)
-    m_downloadCountryListener(countryIndex, static_cast<int>(MapOptions::MapWithCarRouting));
-  else
-    m_activeMaps->DownloadMap(countryIndex, MapOptions::MapWithCarRouting);
-}
-
 void Framework::OnDownloadRetryCallback(storage::TIndex const & countryIndex)
 {
   if (m_downloadCountryListener != nullptr)
     m_downloadCountryListener(countryIndex, -1);
   else
     m_activeMaps->RetryDownloading(countryIndex);
+}
+
+void Framework::OnDownloadCancelCallback(storage::TIndex const & countryIndex)
+{
+  // Any cancel leads to disable auto-downloading.
+  m_autoDownloadingOn = false;
+
+  if (m_downloadCancelListener != nullptr)
+    m_downloadCancelListener(countryIndex);
+  else
+    m_activeMaps->CancelDownloading(countryIndex);
 }
 
 void Framework::OnUpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt)
@@ -944,7 +957,16 @@ void Framework::OnUpdateCountryIndex(storage::TIndex const & currentIndex, m2::P
   }
 
   if (currentIndex != newCountryIndex)
+  {
+    // Enable auto-downloading after return from the world map.
+    if (!currentIndex.IsValid())
+      m_autoDownloadingOn = true;
+
+    if (m_autoDownloadingOn && m_autoDownloadListener != nullptr)
+      m_autoDownloadListener(newCountryIndex);
+
     UpdateCountryInfo(newCountryIndex, true /* isCurrentCountry */);
+  }
 }
 
 void Framework::UpdateCountryInfo(storage::TIndex const & countryIndex, bool isCurrentCountry)
@@ -1388,6 +1410,11 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
     GetPlatform().RunOnGuiThread(bind(&Framework::OnDownloadRetryCallback, this, countryIndex));
   };
 
+  TDownloadFn downloadCancelFn = [this](storage::TIndex const & countryIndex)
+  {
+    GetPlatform().RunOnGuiThread(bind(&Framework::OnDownloadCancelCallback, this, countryIndex));
+  };
+
   bool allow3d;
   bool allow3dBuildings;
   Load3dMode(allow3d, allow3dBuildings);
@@ -1397,7 +1424,7 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
                             df::Viewport(0, 0, params.m_surfaceWidth, params.m_surfaceHeight),
                             df::MapDataProvider(idReadFn, featureReadFn, updateCountryIndex,
                                                 isCountryLoadedFn, isCountryLoadedByNameFn,
-                                                downloadMapFn, downloadRetryFn),
+                                                downloadMapFn, downloadRetryFn, downloadCancelFn),
                             params.m_visualScale,
                             move(params.m_widgetsInitInfo),
                             make_pair(params.m_initialMyPositionState, params.m_hasMyPositionState),

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -98,6 +98,8 @@ class Framework
 protected:
   using TDrapeFunction = function<void (df::DrapeEngine *)>;
   using TDownloadCountryListener = function<void(storage::TIndex const &, int)>;
+  using TDownloadCancelListener = function<void(storage::TIndex const &)>;
+  using TAutoDownloadListener = function<void(storage::TIndex const &)>;
 
   StringsBundle m_stringsBundle;
 
@@ -124,6 +126,9 @@ protected:
   double m_startForegroundTime;
 
   TDownloadCountryListener m_downloadCountryListener;
+  TDownloadCancelListener m_downloadCancelListener;
+  TAutoDownloadListener m_autoDownloadListener;
+  bool m_autoDownloadingOn = true;
 
   storage::Storage m_storage;
   shared_ptr<storage::ActiveMapsLayout> m_activeMaps;
@@ -193,6 +198,8 @@ public:
   void DownloadCountry(storage::TIndex const & index, MapOptions opt);
 
   void SetDownloadCountryListener(TDownloadCountryListener const & listener);
+  void SetDownloadCancelListener(TDownloadCancelListener const & listener);
+  void SetAutoDownloadListener(TAutoDownloadListener const & listener);
 
   storage::TStatus GetCountryStatus(storage::TIndex const & index) const;
   string GetCountryName(storage::TIndex const & index) const;
@@ -353,8 +360,8 @@ private:
   void FillSearchResultsMarks(search::Results const & results);
 
   void OnDownloadMapCallback(storage::TIndex const & countryIndex);
-  void OnDownloadMapRoutingCallback(storage::TIndex const & countryIndex);
   void OnDownloadRetryCallback(storage::TIndex const & countryIndex);
+  void OnDownloadCancelCallback(storage::TIndex const & countryIndex);
 
   void OnUpdateCountryIndex(storage::TIndex const & currentIndex, m2::PointF const & pt);
   void UpdateCountryInfo(storage::TIndex const & countryIndex, bool isCurrentCountry);


### PR DESCRIPTION
Что есть в этом пулреквесте:
1) Добавлена кнопка "Отменить" скачивание;
2) Добавлен колбэк на отмену скачивания;
3) Добавлен колбэк на автоматическое скачивание карты.

Чего нет и не будет в этом пулреквесте (доверим это специалистам):
1) Реализации колбэков в платформенно-зависимом коде (для iOS, правда, добавлены заглушки для тестирования);
2) JNI оберток для добавленных колбэков;
3) Добавления строки локализации для кнопки "Отменить".

Особо хочу заострить внимание, что в реквесте код, который должен прожить ровно один релиз и потом будет выкинут. Поэтому прошу комментировать по-существу, без ревью-нацизма. 

Не мержить реквест! Этот реквест только для ревью. После слияния old-map-downloader, будет создан новый PR на new-search, который и будем мержить.