### PR TITLE
[search] Fixed tests.

### DIFF
--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -13,7 +13,7 @@
 namespace platform
 {
 LocalCountryFile::LocalCountryFile()
-    : m_version(0), m_files(MapOptions::Nothing), m_mapSize(0), m_routingSize()
+    : m_version(0), m_files(MapOptions::Nothing), m_mapSize(0), m_routingSize(0)
 {
 }
 

--- a/search/search_integration_tests/retrieval_test.cpp
+++ b/search/search_integration_tests/retrieval_test.cpp
@@ -155,7 +155,7 @@ UNIT_TEST(Retrieval_Smoke)
         builder.Add(TestPOI(m2::PointD(x, y), "Whiskey bar", "en"));
     }
   }
-  TEST_EQUAL(MapOptions::Map, file.GetFiles(), ());
+  TEST_EQUAL(MapOptions::MapWithCarRouting, file.GetFiles(), ());
 
   Index index;
   auto p = index.RegisterMap(file);

--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -62,7 +62,6 @@ UNIT_TEST(GenerateTestMwm_Smoke)
   classificator::Load();
   ScopedMapFile scopedFile("BuzzTown");
   platform::LocalCountryFile & file = scopedFile.GetFile();
-
   {
     TestMwmBuilder builder(file, feature::DataHeader::country);
     builder.Add(TestPOI(m2::PointD(0, 0), "Wine shop", "en"));
@@ -70,7 +69,7 @@ UNIT_TEST(GenerateTestMwm_Smoke)
     builder.Add(TestPOI(m2::PointD(0, 1), "Brandy shop", "en"));
     builder.Add(TestPOI(m2::PointD(1, 1), "Russian vodka shop", "en"));
   }
-  TEST_EQUAL(MapOptions::Map, file.GetFiles(), ());
+  TEST_EQUAL(MapOptions::MapWithCarRouting, file.GetFiles(), ());
 
   TestSearchEngine engine("en" /* locale */);
   auto ret = engine.RegisterMap(file);
@@ -110,7 +109,7 @@ UNIT_TEST(GenerateTestMwm_NotPrefixFreeNames)
     builder.Add(TestPOI(m2::PointD(2, 0), "aaa", "en"));
     builder.Add(TestPOI(m2::PointD(2, 1), "aaa", "en"));
   }
-  TEST_EQUAL(MapOptions::Map, file.GetFiles(), ());
+  TEST_EQUAL(MapOptions::MapWithCarRouting, file.GetFiles(), ());
 
   TestSearchEngine engine("en" /* locale */);
   auto ret = engine.RegisterMap(file);

--- a/search/search_quality_tests/search_quality_tests.cpp
+++ b/search/search_quality_tests/search_quality_tests.cpp
@@ -113,8 +113,16 @@ void PrintTopResults(string const & query, vector<search::Result> const & result
 
 uint64_t ReadVersionFromHeader(platform::LocalCountryFile const & mwm)
 {
-  if (mwm.GetCountryName() == WORLD_FILE_NAME || mwm.GetCountryName() == WORLD_COASTS_FILE_NAME)
-    return mwm.GetVersion();
+  vector<string> specialFiles = {
+    WORLD_FILE_NAME,
+    WORLD_COASTS_FILE_NAME,
+    WORLD_COASTS_MIGRATE_FILE_NAME
+  };
+  for (auto const & name : specialFiles)
+  {
+    if (mwm.GetCountryName() == name)
+      return mwm.GetVersion();
+  }
 
   ModelReaderPtr reader = FilesContainerR(mwm.GetPath(MapOptions::Map)).GetReader(VERSION_FILE_TAG);
   ReaderSrc src(reader.GetPtr());


### PR DESCRIPTION
Migration to small MWMs conicided with removing separate
routing files (thus incorporating routing into regular map files).
This CL fixes the corresponding behaviour of search integration tests.

Also, fixed quality tests to account for a new World file.