### PR TITLE
Obb for worldcoasts_migrate.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -371,9 +371,9 @@ task obbPush(dependsOn: ['obbGenerate', 'obbPushMain', 'obbPushPatch']) {
     commandLine android.getAdbExe(), 'shell', 'rm', "${obbPath}*.obb"
   }
   tasks.create(type: Exec, name: 'obbPushMain', dependsOn: 'obbRemoveOnDevice') {
-    commandLine android.getAdbExe(), 'push', propObbWorldsOutput, "${obbPath}fonts.obb"
+    commandLine android.getAdbExe(), 'push', propObbFontsOutput, "${obbPath}fonts.obb"
   }
   tasks.create(type: Exec, name: 'obbPushPatch', dependsOn: 'obbRemoveOnDevice') {
-    commandLine android.getAdbExe(), 'push', propObbFontsOutput, "${obbPath}worlds.obb"
+    commandLine android.getAdbExe(), 'push', propObbWorldsOutput, "${obbPath}worlds.obb"
   }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,6 +16,8 @@ propObbFonts  ../data/01_dejavusans.ttf \
               ../data/05_khmeros.ttf \
               ../data/06_code2000.ttf \
               ../data/07_roboto_medium.ttf
-propObbWorlds ../data/World.mwm ../data/WorldCoasts.mwm
+propObbWorlds ../data/World.mwm \
+              ../data/WorldCoasts.mwm \
+              ../data/WorldCoasts_migrate.mwm
 propObbWorldsOutput build/worlds.obb
 propObbFontsOutput build/fonts.obb

--- a/data/external_resources.txt
+++ b/data/external_resources.txt
@@ -1,4 +1,5 @@
-WorldCoasts.mwm 4572627
+WorldCoasts.mwm 4584314
+WorldCoasts_migrate.mwm 4572627
 World.mwm 27639985
 01_dejavusans.ttf 633604
 02_droidsans-fallback.ttf 4033420
@@ -6,3 +7,4 @@ World.mwm 27639985
 04_padauk.ttf 248076
 05_khmeros.ttf 265552
 06_code2000.ttf 3155104
+07_roboto_medium.ttf 162588


### PR DESCRIPTION
Пока не понял, почему размеры World[Coasts].mwm отличались от реально лежащих в папке data/*, поменял на актуальные размеры.
Так же вернул 07_roboto_medium в список внешних ресурсов.