### PR TITLE
case-sensitive search on linux-systems

### DIFF
--- a/map/style_tests/classificator_tests.cpp
+++ b/map/style_tests/classificator_tests.cpp
@@ -6,7 +6,7 @@
 #include "indexer/feature_data.hpp"
 #include "indexer/map_style_reader.hpp"
 
-#include "Platform/platform.hpp"
+#include "platform/platform.hpp"
 
 #include "base/logging.hpp"
 


### PR DESCRIPTION
It seems the compilation fails due to case-sensitivity under Linux.