### PR TITLE
[search] Fixed greedy street matching.

### DIFF
--- a/base/buffer_vector.hpp
+++ b/base/buffer_vector.hpp
@@ -100,6 +100,12 @@ public:
     return *this;
   }
 
+  template <size_t M>
+  void append(buffer_vector<value_type, M> const & v)
+  {
+    append(v.begin(), v.end());
+  }
+
   template <typename IterT>
   void append(IterT beg, IterT end)
   {

--- a/indexer/feature_impl.cpp
+++ b/indexer/feature_impl.cpp
@@ -67,4 +67,8 @@ bool IsHouseNumber(string const & s)
   return (!s.empty() && IsDigit(s[0]));
 }
 
+bool IsHouseNumber(strings::UniString const & s)
+{
+  return (!s.empty() && IsDigit(s[0]));
+}
 }

--- a/indexer/feature_impl.hpp
+++ b/indexer/feature_impl.hpp
@@ -29,8 +29,10 @@ namespace feature
     return str;
   }
 
+  bool IsDigit(int c);
   bool IsNumber(strings::UniString const & s);
 
   bool IsHouseNumber(string const & s);
+  bool IsHouseNumber(strings::UniString const & s);
   bool IsHouseNumberDeepCheck(strings::UniString const & s);
 }

--- a/search/search_string_utils.cpp
+++ b/search/search_string_utils.cpp
@@ -1,7 +1,7 @@
 #include "search_string_utils.hpp"
 
+#include "std/set.hpp"
 #include "std/transform_iterator.hpp"
-#include "std/unordered_set.hpp"
 
 #include "base/macros.hpp"
 

--- a/search/search_tests/house_numbers_matcher_test.cpp
+++ b/search/search_tests/house_numbers_matcher_test.cpp
@@ -9,6 +9,22 @@
 using namespace strings;
 using namespace search::v2;
 
+namespace
+{
+void NormalizeHouseNumber(string const & s, vector<string> & ts)
+{
+  vector<strings::UniString> tokens;
+  search::v2::NormalizeHouseNumber(strings::MakeUniString(s), tokens);
+  for (auto const & token : tokens)
+    ts.push_back(strings::ToUtf8(token));
+}
+
+bool HouseNumbersMatch(string const & houseNumber, string const & query)
+{
+  return search::v2::HouseNumbersMatch(strings::MakeUniString(houseNumber),
+                                       strings::MakeUniString(query));
+}
+
 void CheckTokenizer(string const & utf8s, vector<string> const & expected)
 {
   UniString utf32s = MakeUniString(utf8s);
@@ -35,6 +51,7 @@ void CheckNormalizer(string const & utf8s, string const & expected)
   }
   TEST_EQUAL(actual, expected, ());
 }
+}  // namespace
 
 UNIT_TEST(HouseNumberTokenizer_Smoke)
 {

--- a/search/v2/cbv_ptr.cpp
+++ b/search/v2/cbv_ptr.cpp
@@ -6,6 +6,10 @@ namespace search
 {
 namespace v2
 {
+CBVPtr::CBVPtr(coding::CompressedBitVector const * p, bool isOwner)
+{
+  Set(p, isOwner);
+}
 
 void CBVPtr::Release()
 {

--- a/search/v2/cbv_ptr.hpp
+++ b/search/v2/cbv_ptr.hpp
@@ -25,6 +25,7 @@ class CBVPtr
 
 public:
   CBVPtr() = default;
+  CBVPtr(coding::CompressedBitVector const * p, bool isOwner);
   ~CBVPtr() { Release(); }
 
   inline void SetFull()
@@ -36,6 +37,8 @@ public:
   void Set(coding::CompressedBitVector const * p, bool isOwner = false);
 
   inline coding::CompressedBitVector const * Get() const { return m_ptr; }
+
+  coding::CompressedBitVector const & operator*() const { return *m_ptr; }
 
   bool IsEmpty() const;
 

--- a/search/v2/features_layer.cpp
+++ b/search/v2/features_layer.cpp
@@ -25,7 +25,7 @@ string DebugPrint(FeaturesLayer const & layer)
   ostringstream os;
   os << "FeaturesLayer [ size of m_sortedFeatures: "
      << (layer.m_sortedFeatures ? layer.m_sortedFeatures->size() : 0)
-     << ", m_subQuery: " << layer.m_subQuery << ", m_startToken: " << layer.m_startToken
+     << ", m_subQuery: " << DebugPrint(layer.m_subQuery) << ", m_startToken: " << layer.m_startToken
      << ", m_endToken: " << layer.m_endToken << ", m_type: " << DebugPrint(layer.m_type) << " ]";
   return os.str();
 }

--- a/search/v2/features_layer.hpp
+++ b/search/v2/features_layer.hpp
@@ -2,6 +2,8 @@
 
 #include "search/v2/search_model.hpp"
 
+#include "base/string_utils.hpp"
+
 #include "std/vector.hpp"
 
 namespace search
@@ -20,7 +22,7 @@ struct FeaturesLayer
   // Non-owning ptr to a sorted vector of features.
   vector<uint32_t> const * m_sortedFeatures;
 
-  string m_subQuery;
+  strings::UniString m_subQuery;
 
   size_t m_startToken;
   size_t m_endToken;

--- a/search/v2/features_layer_matcher.hpp
+++ b/search/v2/features_layer_matcher.hpp
@@ -24,6 +24,7 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 #include "base/stl_helpers.hpp"
+#include "base/string_utils.hpp"
 
 #include "std/algorithm.hpp"
 #include "std/bind.hpp"
@@ -151,7 +152,7 @@ private:
     // |buildings| doesn't contain buildings matching by house number,
     // so following code reads buildings in POIs vicinities and checks
     // house numbers.
-    vector<string> queryTokens;
+    vector<strings::UniString> queryTokens;
     NormalizeHouseNumber(parent.m_subQuery, queryTokens);
     if (queryTokens.empty())
       return;
@@ -168,7 +169,7 @@ private:
       {
         if (building.m_id.m_mwmId != m_context->m_id || building.m_distanceMeters > kBuildingRadiusMeters)
           continue;
-        if (HouseNumbersMatch(building.m_name, queryTokens))
+        if (HouseNumbersMatch(strings::MakeUniString(building.m_name), queryTokens))
           fn(pois[i], building.m_id.m_index);
       }
     }
@@ -240,7 +241,7 @@ private:
       return;
     }
 
-    vector<string> queryTokens;
+    vector<strings::UniString> queryTokens;
     NormalizeHouseNumber(child.m_subQuery, queryTokens);
 
     auto const & checker = ftypes::IsBuildingChecker::Instance();
@@ -272,7 +273,7 @@ private:
       if (!child.m_hasDelayedFeatures)
         return false;
 
-      string const houseNumber = feature.GetHouseNumber();
+      strings::UniString const houseNumber(strings::MakeUniString(feature.GetHouseNumber()));
       if (!feature::IsHouseNumber(houseNumber))
         return false;
       return HouseNumbersMatch(houseNumber, queryTokens);

--- a/search/v2/features_layer_path_finder.cpp
+++ b/search/v2/features_layer_path_finder.cpp
@@ -45,9 +45,9 @@ uint64_t CalcBottomUpPassCost(vector<FeaturesLayer const *> const & layers)
   return CalcPassCost(layers.begin(), layers.end());
 }
 
-bool LooksLikeHouseNumber(string const & query)
+bool LooksLikeHouseNumber(strings::UniString const & query)
 {
-  vector<string> tokens;
+  vector<strings::UniString> tokens;
   NormalizeHouseNumber(query, tokens);
   return !tokens.empty() && feature::IsHouseNumber(tokens.front());
 }

--- a/search/v2/geocoder.hpp
+++ b/search/v2/geocoder.hpp
@@ -186,6 +186,9 @@ private:
   // then performs geocoding in street vicinities.
   void GreedilyMatchStreets();
 
+  void CreateStreetsLayerAndMatchLowerLayers(
+      size_t startToken, size_t endToken, unique_ptr<coding::CompressedBitVector> const & features);
+
   // Tries to find all paths in a search tree, where each edge is
   // marked with some substring of the query tokens. These paths are
   // called "layer sequence" and current path is stored in |m_layers|.

--- a/search/v2/house_numbers_matcher.cpp
+++ b/search/v2/house_numbers_matcher.cpp
@@ -153,23 +153,19 @@ void HouseNumberTokenizer::Tokenize(UniString const & s, vector<Token> & ts)
   }
 }
 
-void NormalizeHouseNumber(string const & s, vector<string> & ts)
+void NormalizeHouseNumber(strings::UniString const & s, vector<strings::UniString> & ts)
 {
   vector<HouseNumberTokenizer::Token> tokens;
-  HouseNumberTokenizer::Tokenize(MakeLowerCase(MakeUniString(s)), tokens);
-
-  vector<UniString> mergedTokens;
-  MergeTokens(tokens, mergedTokens);
-
-  transform(mergedTokens.begin(), mergedTokens.end(), back_inserter(ts), &ToUtf8);
+  HouseNumberTokenizer::Tokenize(MakeLowerCase(s), tokens);
+  MergeTokens(tokens, ts);
 }
 
-bool HouseNumbersMatch(string const & houseNumber, string const & query)
+bool HouseNumbersMatch(strings::UniString const & houseNumber, strings::UniString const & query)
 {
   if (houseNumber == query)
     return true;
 
-  vector<string> queryTokens;
+  vector<strings::UniString> queryTokens;
   NormalizeHouseNumber(query, queryTokens);
 
   if (!queryTokens.empty())
@@ -178,14 +174,14 @@ bool HouseNumbersMatch(string const & houseNumber, string const & query)
   return HouseNumbersMatch(houseNumber, queryTokens);
 }
 
-bool HouseNumbersMatch(string const & houseNumber, vector<string> const & queryTokens)
+bool HouseNumbersMatch(strings::UniString const & houseNumber, vector<strings::UniString> const & queryTokens)
 {
   if (houseNumber.empty() || queryTokens.empty())
     return false;
   if (queryTokens[0][0] != houseNumber[0])
     return false;
 
-  vector<string> houseNumberTokens;
+  vector<strings::UniString> houseNumberTokens;
   NormalizeHouseNumber(houseNumber, houseNumberTokens);
 
   if (houseNumberTokens.empty())

--- a/search/v2/house_numbers_matcher.hpp
+++ b/search/v2/house_numbers_matcher.hpp
@@ -38,12 +38,13 @@ public:
 };
 
 // Splits house number by tokens, removes blanks and separators.
-void NormalizeHouseNumber(string const & s, vector<string> & ts);
+void NormalizeHouseNumber(strings::UniString const & s, vector<strings::UniString> & ts);
 
 // Returns true when |query| matches to |houseNumber|.
-bool HouseNumbersMatch(string const & houseNumber, string const & query);
+bool HouseNumbersMatch(strings::UniString const & houseNumber, strings::UniString const & query);
 
 // Returns true when |queryTokens| match to |houseNumber|.
-bool HouseNumbersMatch(string const & houseNumber, vector<string> const & queryTokens);
+bool HouseNumbersMatch(strings::UniString const & houseNumber,
+                       vector<strings::UniString> const & queryTokens);
 }  // namespace v2
 }  // namespace search


### PR DESCRIPTION
During greedy street matching we need to spawn sub-calls to MatchPOIsAndBuildings() each time we met a token that looks like a start of a house number. For example, on a query "тверь советская 1" тверь will be matched to a city, but as there exists "1-я советская улица", current implementation will consume both tokens, whereas the user's intent is to find house No1 on the sovetskaya street in Tver.