### PR TITLE
[new downloader] Fixing routing tests. Compatibility local_country_files with two components mwms.

### DIFF
--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -39,7 +39,11 @@ void LocalCountryFile::SyncWithDisk()
     m_files = SetOptions(m_files, MapOptions::Map);
 
   if (version::IsSingleMwm(GetVersion()))
+  {
+    if (m_files == MapOptions::Map)
+      m_files = SetOptions(m_files, MapOptions::CarRouting);
     return;
+  }
 
   string const routingPath = GetPath(MapOptions::CarRouting);
   if (platform.GetFileSizeByFullPath(routingPath, m_routingSize))

--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -33,11 +33,13 @@ void LocalCountryFile::SyncWithDisk()
   m_files = MapOptions::Nothing;
   m_mapSize = 0;
   m_routingSize = 0;
-
   Platform & platform = GetPlatform();
 
   if (platform.GetFileSizeByFullPath(GetPath(MapOptions::Map), m_mapSize))
     m_files = SetOptions(m_files, MapOptions::Map);
+
+  if (version::IsSingleMwm(GetVersion()))
+    return;
 
   string const routingPath = GetPath(MapOptions::CarRouting);
   if (platform.GetFileSizeByFullPath(routingPath, m_routingSize))
@@ -69,8 +71,9 @@ uint32_t LocalCountryFile::GetSize(MapOptions filesMask) const
   uint64_t size64 = 0;
   if (HasOptions(filesMask, MapOptions::Map))
     size64 += m_mapSize;
-  if (HasOptions(filesMask, MapOptions::CarRouting))
+  if (!version::IsSingleMwm(GetVersion()) && HasOptions(filesMask, MapOptions::CarRouting))
     size64 += m_routingSize;
+
   uint32_t const size32 = static_cast<uint32_t>(size64);
   ASSERT_EQUAL(size32, size64, ());
   return size32;

--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -35,6 +35,10 @@ public:
 
   // Syncs internal state like availability of map and routing files,
   // their sizes etc. with disk.
+  // In case of one component (single) mwm this method assumed the every mwm has a routing section.
+  // Generality speaking it's not always true. To know it for sure it's necessary to read a mwm in
+  // this method but it's not implemented by performance reasons. This check is done on
+  // building routes stage.
   void SyncWithDisk();
 
   // Removes specified files from disk if they're known for LocalCountryFile, i.e.

--- a/routing/routing_mapping.cpp
+++ b/routing/routing_mapping.cpp
@@ -27,8 +27,9 @@ namespace
  */
 bool CheckMwmConsistency(LocalCountryFile const & localFile)
 {
-  if (localFile.GetPath(MapOptions::CarRouting) == localFile.GetPath(MapOptions::Map))
+  if (version::IsSingleMwm(localFile.GetVersion()))
     return true;
+
   ModelReaderPtr r1 = FilesContainerR(localFile.GetPath(MapOptions::CarRouting))
       .GetReader(VERSION_FILE_TAG);
   ReaderSrc src1(r1.GetPtr());
@@ -62,14 +63,6 @@ RoutingMapping::RoutingMapping(string const & countryFile, MwmSet & index)
     return;
 
   LocalCountryFile const & localFile = m_handle.GetInfo()->GetLocalFile();
-
-  if (version::IsSingleMwm(localFile.GetVersion()))
-  {
-    m_container.Open(localFile.GetPath(MapOptions::Map));
-    m_mwmId = m_handle.GetId();
-    m_error = IRouter::ResultCode::NoError;
-    return;
-  }
 
   if (!HasOptions(localFile.GetFiles(), MapOptions::MapWithCarRouting))
   {

--- a/routing/routing_mapping.cpp
+++ b/routing/routing_mapping.cpp
@@ -62,6 +62,15 @@ RoutingMapping::RoutingMapping(string const & countryFile, MwmSet & index)
     return;
 
   LocalCountryFile const & localFile = m_handle.GetInfo()->GetLocalFile();
+
+  if (version::IsSingleMwm(localFile.GetVersion()))
+  {
+    m_container.Open(localFile.GetPath(MapOptions::Map));
+    m_mwmId = m_handle.GetId();
+    m_error = IRouter::ResultCode::NoError;
+    return;
+  }
+
   if (!HasOptions(localFile.GetFiles(), MapOptions::MapWithCarRouting))
   {
     m_error = IRouter::ResultCode::RouteFileNotExist;

--- a/routing/routing_tests/routing_mapping_test.cpp
+++ b/routing/routing_tests/routing_mapping_test.cpp
@@ -36,7 +36,7 @@ public:
         m_localFile(GetPlatform().WritableDir(), m_countryFile, 0 /* version */)
   {
     m_localFile.SyncWithDisk();
-    TEST(m_localFile.OnDisk(MapOptions::MapWithCarRouting), ());
+    TEST(m_localFile.OnDisk(MapOptions::Map), ());
     GenerateNecessarySections(m_localFile);
 
     m_result = m_testSet.Register(m_localFile);


### PR DESCRIPTION
Перенос изменений из map-downloader в new-downloader.
Поправил тесты на роутинг.

https://trello.com/c/E8Oy10Ka/2442-routing

@gardster @syershov @kshalnev PTAL

