### PR TITLE
Do not shown house number if name exists

### DIFF
--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -214,8 +214,6 @@ void CaptionDescription::FormatCaptions(FeatureType const & f,
     {
       if (m_mainText.empty() || m_houseNumber.find(m_mainText) != string::npos)
         m_houseNumber.swap(m_mainText);
-      else
-        m_mainText += (" (" + m_houseNumber + ")");
     }
   }
 }


### PR DESCRIPTION
PR fixes France capital caption. Now it is shown as 'Paris (19)' because capital POI has a house number.  Fix is: construct main text as "name (houseNumber)" only for buildings.