### PR TITLE
Framework refactoring for correct Android events handling.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -349,7 +349,6 @@ bool Framework::ShowMapForURL(string const & url)
 
 void Framework::DeactivatePopup()
 {
-  m_work.ResetLastTapEvent();
   m_work.DeactivateUserMark();
 }
 

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -130,8 +130,7 @@ bool Framework::CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi
   m_work.CreateDrapeEngine(make_ref(m_contextFactory), move(p));
   m_work.EnterForeground();
 
-  // Load initial state of the map and execute drape tasks which set up custom state.
-  LoadState();
+  // Execute drape tasks which set up custom state.
   {
     lock_guard<mutex> lock(m_drapeQueueMutex);
     if (!m_drapeTasksQueue.empty())
@@ -143,7 +142,6 @@ bool Framework::CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi
 
 void Framework::DeleteDrapeEngine()
 {
-  SaveState();
   m_work.EnterBackground();
 
   m_work.DestroyDrapeEngine();
@@ -307,16 +305,6 @@ bool Framework::Search(search::SearchParams const & params)
 {
   m_searchQuery = params.m_query;
   return m_work.Search(params);
-}
-
-void Framework::LoadState()
-{
-  m_work.LoadState();
-}
-
-void Framework::SaveState()
-{
-  m_work.SaveState();
 }
 
 void Framework::AddLocalMaps()

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -144,6 +144,8 @@ bool Framework::CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi
 void Framework::DeleteDrapeEngine()
 {
   SaveState();
+  m_work.EnterBackground();
+
   m_work.DestroyDrapeEngine();
 }
 
@@ -160,7 +162,7 @@ void Framework::Resize(int w, int h)
 
 void Framework::DetachSurface()
 {
-  m_work.EnterBackground();
+  m_work.SetRenderingEnabled(false);
 
   ASSERT(m_contextFactory != nullptr, ());
   AndroidOGLContextFactory * factory = m_contextFactory->CastFactory<AndroidOGLContextFactory>();
@@ -173,7 +175,7 @@ void Framework::AttachSurface(JNIEnv * env, jobject jSurface)
   AndroidOGLContextFactory * factory = m_contextFactory->CastFactory<AndroidOGLContextFactory>();
   factory->SetSurface(env, jSurface);
 
-  m_work.EnterForeground();
+  m_work.SetRenderingEnabled(true);
 }
 
 void Framework::SetMapStyle(MapStyle mapStyle)

--- a/android/jni/com/mapswithme/maps/Framework.hpp
+++ b/android/jni/com/mapswithme/maps/Framework.hpp
@@ -112,9 +112,6 @@ namespace android
     string GetLastSearchQuery() { return m_searchQuery; }
     void ClearLastSearchQuery() { m_searchQuery.clear(); }
 
-    void LoadState();
-    void SaveState();
-
     void AddLocalMaps();
     void RemoveLocalMaps();
 

--- a/android/jni/com/mapswithme/maps/bookmarks/data/BookmarkManager.cpp
+++ b/android/jni/com/mapswithme/maps/bookmarks/data/BookmarkManager.cpp
@@ -22,7 +22,6 @@ Java_com_mapswithme_maps_bookmarks_data_BookmarkManager_nativeShowBookmarkOnMap(
   g_framework->PostDrapeTask([bnc]()
   {
     frm()->ShowBookmark(bnc);
-    frm()->SaveState();
   });
 }
 

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -59,7 +59,7 @@ DrapeEngine::DrapeEngine(Params && params)
                                     make_ref(m_textureManager), m_viewport,
                                     bind(&DrapeEngine::ModelViewChanged, this, _1),
                                     params.m_model.GetIsCountryLoadedFn(),
-                                    bind(&DrapeEngine::TapEvent, this, _1, _2, _3, _4),
+                                    bind(&DrapeEngine::TapEvent, this, _1),
                                     bind(&DrapeEngine::UserPositionChanged, this, _1),
                                     bind(&DrapeEngine::MyPositionModeChanged, this, _1),
                                     mode, make_ref(m_requestedTiles), params.m_allow3dBuildings);
@@ -235,12 +235,12 @@ void DrapeEngine::MyPositionModeChanged(location::EMyPositionMode mode)
   });
 }
 
-void DrapeEngine::TapEvent(m2::PointD const & pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature)
+void DrapeEngine::TapEvent(TapInfo const & tapInfo)
 {
   GetPlatform().RunOnGuiThread([=]()
   {
     if (m_tapListener)
-      m_tapListener(pxPoint, isLong, isMyPosition, feature);
+      m_tapListener(tapInfo);
   });
 }
 

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -131,7 +131,7 @@ private:
   void ModelViewChangedGuiThread(ScreenBase const & screen);
 
   void MyPositionModeChanged(location::EMyPositionMode mode);
-  void TapEvent(m2::PointD const & pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature);
+  void TapEvent(TapInfo const & tapInfo);
   void UserPositionChanged(m2::PointD const & position);
 
   void ResizeImpl(int w, int h);

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1172,7 +1172,7 @@ void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
     isMyPosition = selectRect.IsPointInside(pt);
   }
 
-  m_tapEventInfoFn(pt, isLongTap, isMyPosition, GetVisiblePOI(selectRect));
+  m_tapEventInfoFn({pt, isLongTap, isMyPosition, GetVisiblePOI(selectRect)});
 }
 
 void FrontendRenderer::OnForceTap(m2::PointD const & pt)

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -53,10 +53,9 @@ class TransparentLayer;
 struct TapInfo
 {
   m2::PointD const m_pixelPoint;
-  bool m_isLong;
-
-  bool m_isMyPositionTapped;
-  FeatureID m_featureTapped;
+  bool const m_isLong;
+  bool const m_isMyPositionTapped;
+  FeatureID const m_featureTapped;
 };
 
 class FrontendRenderer : public BaseRenderer
@@ -66,7 +65,7 @@ class FrontendRenderer : public BaseRenderer
 public:
   using TModelViewChanged = function<void (ScreenBase const & screen)>;
   using TIsCountryLoaded = TIsCountryLoaded;
-  using TTapEventInfoFn = function<void (m2::PointD const & pxPoint, bool isLong, bool isMyPosition, FeatureID const & id)>;
+  using TTapEventInfoFn = function<void (TapInfo const &)>;
   using TUserPositionChangedFn = function<void (m2::PointD const & pt)>;
 
   struct Params : BaseRenderer::Params

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -137,7 +137,6 @@ double getExactDPI(double contentScaleFactor)
   if (GetFramework().GetDrapeEngine() == nullptr)
   {
     [self createDrapeEngineWithWidth:w height:h];
-    GetFramework().LoadState();
     return;
   }
 

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -374,17 +374,13 @@ NSString * const kAuthorizationSegue = @"Map2AuthorizationSegue";
 
 - (void)onTerminate
 {
-  GetFramework().SaveState();
   [(EAGLView *)self.view deallocateNative];
 }
 
 - (void)onEnterBackground
 {
   // Save state and notify about entering background.
-
-  Framework & f = GetFramework();
-  f.SaveState();
-  f.EnterBackground();
+  GetFramework().EnterBackground();
 }
 
 - (void)setMapStyle:(MapStyle)mapStyle

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1047,7 +1047,10 @@ void Framework::MemoryWarning()
 
 void Framework::EnterBackground()
 {
-  const ms::LatLon ll = MercatorBounds::ToLatLon(GetViewportCenter());
+  if (m_drapeEngine)
+    m_drapeEngine->SetRenderingEnabled(false);
+
+  ms::LatLon const ll = MercatorBounds::ToLatLon(GetViewportCenter());
   alohalytics::Stats::Instance().LogEvent("Framework::EnterBackground", {{"zoom", strings::to_string(GetDrawScale())},
                                           {"foregroundSeconds", strings::to_string(
                                            static_cast<int>(my::Timer::LocalTime() - m_startForegroundTime))}},
@@ -1058,9 +1061,6 @@ void Framework::EnterBackground()
 #ifndef OMIM_OS_ANDROID
   ClearAllCaches();
 #endif
-
-  if (m_drapeEngine != nullptr)
-    m_drapeEngine->SetRenderingEnabled(false);
 }
 
 void Framework::EnterForeground()
@@ -1068,7 +1068,7 @@ void Framework::EnterForeground()
   m_startForegroundTime = my::Timer::LocalTime();
 
   // Drape can be not initialized here in case of the first launch
-  if (m_drapeEngine != nullptr)
+  if (m_drapeEngine)
     m_drapeEngine->SetRenderingEnabled(true);
 }
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1862,6 +1862,7 @@ void Framework::ActivateUserMark(UserMark const * mark, bool needAnim)
 
 void Framework::DeactivateUserMark()
 {
+  m_lastTapEvent.reset();
   CallDrapeFunction(bind(&df::DrapeEngine::DeselectObject, _1));
 }
 
@@ -1905,11 +1906,6 @@ void Framework::OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, F
   }
 
   ActivateUserMark(mark, true);
-}
-
-void Framework::ResetLastTapEvent()
-{
-  m_lastTapEvent.reset();
 }
 
 void Framework::InvalidateRendering()

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -726,7 +726,7 @@ void Framework::PrepareToShutdown()
   DestroyDrapeEngine();
 }
 
-void Framework::SaveState()
+void Framework::SaveViewport()
 {
   m2::AnyRectD rect;
   if (m_currentModelView.isPerspective())
@@ -742,7 +742,7 @@ void Framework::SaveState()
   Settings::Set("ScreenClipRect", rect);
 }
 
-void Framework::LoadState()
+void Framework::LoadViewport()
 {
   m2::AnyRectD rect;
   if (Settings::Get("ScreenClipRect", rect) && df::GetWorldRect().IsRectInside(rect.GetGlobalRect()))
@@ -1048,6 +1048,7 @@ void Framework::MemoryWarning()
 void Framework::EnterBackground()
 {
   SetRenderingEnabled(false);
+  SaveViewport();
 
   ms::LatLon const ll = MercatorBounds::ToLatLon(GetViewportCenter());
   alohalytics::Stats::Instance().LogEvent("Framework::EnterBackground", {{"zoom", strings::to_string(GetDrawScale())},
@@ -1467,6 +1468,8 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
 
   if (m_connectToGpsTrack)
     GpsTracker::Instance().Connect(bind(&Framework::OnUpdateGpsTrackPointsCallback, this, _1, _2));
+
+  LoadViewport();
 
   // In case of the engine reinitialization simulate the last tap to show selection mark.
   SimulateLastTapEventIfNeeded();

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1435,7 +1435,7 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
     if (GetDrawScale() <= scales::GetUpperWorldScale())
       m_autoDownloadingOn = true;
   });
-  m_drapeEngine->SetTapEventInfoListener(bind(&Framework::OnTapEvent, this, _1, _2, _3, _4));
+  m_drapeEngine->SetTapEventInfoListener(bind(&Framework::OnTapEvent, this, _1));
   m_drapeEngine->SetUserPositionListener(bind(&Framework::OnUserPositionChanged, this, _1));
   OnSize(params.m_surfaceWidth, params.m_surfaceHeight);
 
@@ -1443,15 +1443,6 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
   m_drapeEngine->InvalidateMyPosition();
 
   InvalidateUserMarks();
-
-  // In case of the engine reinitialization simulate the last tap to show selection mark.
-  if (m_lastTapEvent != nullptr)
-  {
-    UserMark const * mark = OnTapEventImpl(m_lastTapEvent->m_pxPoint, m_lastTapEvent->m_isLong,
-                                           m_lastTapEvent->m_isMyPosition, m_lastTapEvent->m_feature);
-    if (mark != nullptr)
-      ActivateUserMark(mark, true);
-  }
 
 #ifdef OMIM_OS_ANDROID
   // In case of the engine reinitialization recover compass and location data
@@ -1474,6 +1465,19 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
 
   if (m_connectToGpsTrack)
     GpsTracker::Instance().Connect(bind(&Framework::OnUpdateGpsTrackPointsCallback, this, _1, _2));
+
+  // In case of the engine reinitialization simulate the last tap to show selection mark.
+  SimulateLastTapEventIfNeeded();
+}
+
+void Framework::SimulateLastTapEventIfNeeded()
+{
+  if (m_lastTapEvent)
+  {
+    UserMark const * mark = OnTapEventImpl(*m_lastTapEvent);
+    if (mark)
+      ActivateUserMark(mark, true);
+  }
 }
 
 ref_ptr<df::DrapeEngine> Framework::GetDrapeEngine()
@@ -1886,20 +1890,15 @@ void Framework::InvalidateUserMarks()
   }
 }
 
-void Framework::OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & fid)
+void Framework::OnTapEvent(df::TapInfo const & tapInfo)
 {
   // Back up last tap event to recover selection in case of Drape reinitialization.
-  if (!m_lastTapEvent)
-    m_lastTapEvent = make_unique<TapEventData>();
-  m_lastTapEvent->m_pxPoint = pxPoint;
-  m_lastTapEvent->m_isLong = isLong;
-  m_lastTapEvent->m_isMyPosition = isMyPosition;
-  m_lastTapEvent->m_feature = fid;
+  m_lastTapEvent.reset(new df::TapInfo(tapInfo));
 
-  UserMark const * mark = OnTapEventImpl(pxPoint, isLong, isMyPosition, fid);
+  UserMark const * mark = OnTapEventImpl(tapInfo);
 
   {
-    alohalytics::TStringMap details {{"isLongPress", isLong ? "1" : "0"}};
+    alohalytics::TStringMap details {{"isLongPress", tapInfo.m_isLong ? "1" : "0"}};
     if (mark)
       mark->FillLogEvent(details);
     alohalytics::Stats::Instance().LogEvent("$GetUserMark", details);
@@ -1914,11 +1913,11 @@ void Framework::InvalidateRendering()
     m_drapeEngine->Invalidate();
 }
 
-UserMark const * Framework::OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & fid)
+UserMark const * Framework::OnTapEventImpl(const df::TapInfo & tapInfo)
 {
-  m2::PointD const pxPoint2d = m_currentModelView.P3dtoP(pxPoint);
+  m2::PointD const pxPoint2d = m_currentModelView.P3dtoP(tapInfo.m_pixelPoint);
 
-  if (isMyPosition)
+  if (tapInfo.m_isMyPositionTapped)
     return UserMarkContainer::UserMarkForMyPostion();
 
   df::VisualParams const & vp = df::VisualParams::Instance();
@@ -1939,6 +1938,7 @@ UserMark const * Framework::OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool
           return (type == UserMarkType::BOOKMARK_MARK ? bmSearchRect : rect);
         });
 
+  FeatureID const & fid = tapInfo.m_featureTapped;
   if (mark != nullptr)
   {
     // TODO(AlexZ): Refactor out together with UserMarks.
@@ -1962,7 +1962,7 @@ UserMark const * Framework::OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool
     mercatorPivot = feature::GetCenter(*feature);
     needMark = true;
   }
-  else if (isLong)
+  else if (tapInfo.m_isLong)
   {
     mercatorPivot = m_currentModelView.PtoG(pxPoint2d);
     // TODO(AlexZ): Should we change mercatorPivot to found feature's center?

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1047,8 +1047,7 @@ void Framework::MemoryWarning()
 
 void Framework::EnterBackground()
 {
-  if (m_drapeEngine)
-    m_drapeEngine->SetRenderingEnabled(false);
+  SetRenderingEnabled(false);
 
   ms::LatLon const ll = MercatorBounds::ToLatLon(GetViewportCenter());
   alohalytics::Stats::Instance().LogEvent("Framework::EnterBackground", {{"zoom", strings::to_string(GetDrawScale())},
@@ -1068,8 +1067,11 @@ void Framework::EnterForeground()
   m_startForegroundTime = my::Timer::LocalTime();
 
   // Drape can be not initialized here in case of the first launch
-  if (m_drapeEngine)
-    m_drapeEngine->SetRenderingEnabled(true);
+  // TODO(AlexZ): Why it can't be initialized here? Is it because we call EnterForeground in Android for every
+  // time when activity is created? If yes, then this code should be refactored:
+  // EnterForeground and EnterBackground should be called only when user opens the app and
+  // when user completely leaves the app (and is not just switching between app's activities).
+  SetRenderingEnabled(true);
 }
 
 bool Framework::GetCurrentPosition(double & lat, double & lon) const
@@ -1489,6 +1491,12 @@ void Framework::DestroyDrapeEngine()
 {
   GpsTracker::Instance().Disconnect();
   m_drapeEngine.reset();
+}
+
+void Framework::SetRenderingEnabled(bool enable)
+{
+  if (m_drapeEngine)
+    m_drapeEngine->SetRenderingEnabled(enable);
 }
 
 void Framework::ConnectToGpsTracker()

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1889,6 +1889,13 @@ bool Framework::HasActiveUserMark()
   return m_drapeEngine->GetSelectedObject() != df::SelectionShape::OBJECT_EMPTY;
 }
 
+UserMark const * Framework::GetActiveUserMark() const
+{
+  if (m_lastTapEvent)
+    return OnTapEventImpl(*m_lastTapEvent);
+  return nullptr;
+}
+
 void Framework::InvalidateUserMarks()
 {
   m_bmManager.InitBookmarks();
@@ -1924,7 +1931,7 @@ void Framework::InvalidateRendering()
     m_drapeEngine->Invalidate();
 }
 
-UserMark const * Framework::OnTapEventImpl(const df::TapInfo & tapInfo)
+UserMark const * Framework::OnTapEventImpl(const df::TapInfo & tapInfo) const
 {
   m2::PointD const pxPoint2d = m_currentModelView.P3dtoP(tapInfo.m_pixelPoint);
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -329,7 +329,13 @@ public:
   void DestroyDrapeEngine();
   /// Called when graphics engine should be temporarily paused and then resumed.
   void SetRenderingEnabled(bool enable);
+private:
+  /// Depends on initialized Drape engine.
+  void SaveViewport();
+  /// Depends on initialized Drape engine.
+  void LoadViewport();
 
+public:
   void ConnectToGpsTracker();
   void DisconnectFromGpsTracker();
 
@@ -422,9 +428,6 @@ public:
   inline m2::PointD PtoG(m2::PointD const & p) const { return m_currentModelView.PtoG(p); }
   inline m2::PointD GtoP(m2::PointD const & p) const { return m_currentModelView.GtoP(p); }
   inline m2::PointD GtoP3d(m2::PointD const & p) const { return m_currentModelView.PtoP3d(m_currentModelView.GtoP(p)); }
-
-  void SaveState();
-  void LoadState();
 
   /// Show all model by it's world rect.
   void ShowAll();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -274,6 +274,10 @@ public:
   bool HasActiveUserMark();
   void InvalidateUserMarks();
   PoiMarkPoint * GetAddressMark(m2::PointD const & globalPoint) const;
+  // TODO(AlexZ): Temporary workaround to get last active UserMark on Android.
+  // Refactor it out together with UserMarks.
+  /// @returns nullptr if there is no selection on the map.
+  UserMark const * GetActiveUserMark() const;
 
   using TActivateCallbackFn = function<void (unique_ptr<UserMarkCopy> mark)>;
   void SetUserMarkActivationListener(TActivateCallbackFn const & fn) { m_activateUserMarkFn = fn; }
@@ -292,8 +296,7 @@ private:
 #endif
 
   void OnTapEvent(df::TapInfo const & tapInfo);
-  UserMark const * OnTapEventImpl(df::TapInfo const & tapInfo);
-  //@}
+  UserMark const * OnTapEventImpl(df::TapInfo const & tapInfo) const;
 
   TActivateCallbackFn m_activateUserMarkFn;
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -327,6 +327,8 @@ public:
   void CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory, DrapeCreationParams && params);
   ref_ptr<df::DrapeEngine> GetDrapeEngine();
   void DestroyDrapeEngine();
+  /// Called when graphics engine should be temporarily paused and then resumed.
+  void SetRenderingEnabled(bool enable);
 
   void ConnectToGpsTracker();
   void DisconnectFromGpsTracker();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -283,21 +283,16 @@ public:
   void InvalidateRendering();
 
 private:
-  struct TapEventData
-  {
-    m2::PointD m_pxPoint;
-    bool m_isLong;
-    bool m_isMyPosition;
-    FeatureID m_feature;
-  };
-  unique_ptr<TapEventData> m_lastTapEvent;
+  /// UI callback is called when tap event is "restored" after Drape engine restart.
+  void SimulateLastTapEventIfNeeded();
+  unique_ptr<df::TapInfo> m_lastTapEvent;
 #ifdef OMIM_OS_ANDROID
   unique_ptr<location::CompassInfo> m_lastCompassInfo;
   unique_ptr<location::GpsInfo> m_lastGPSInfo;
 #endif
 
-  void OnTapEvent(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature);
-  UserMark const * OnTapEventImpl(m2::PointD pxPoint, bool isLong, bool isMyPosition, FeatureID const & feature);
+  void OnTapEvent(df::TapInfo const & tapInfo);
+  UserMark const * OnTapEventImpl(df::TapInfo const & tapInfo);
   //@}
 
   TActivateCallbackFn m_activateUserMarkFn;

--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -28,6 +28,7 @@ bool IsSpecialDirName(string const & dirName)
 // BEFORE MERGE TO MASTER. THESE CHANGES ARE FOR TESTING PURPOSES
 // ONLY.
 #define METASERVER_URL ""
+#define RESOURCES_METASERVER_URL ""
 #define DEFAULT_URLS_JSON "[\"http://new-search.mapswithme.com/\"]"
 
 // static

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -105,6 +105,7 @@ DrawWidget::DrawWidget(QWidget * parent)
 
 DrawWidget::~DrawWidget()
 {
+  m_framework->EnterBackground();
   m_framework.reset();
 }
 
@@ -124,17 +125,6 @@ void DrawWidget::PrepareShutdown()
 void DrawWidget::UpdateAfterSettingsChanged()
 {
   m_framework->EnterForeground();
-}
-
-void DrawWidget::LoadState()
-{
-  m_framework->LoadState();
-  m_framework->LoadBookmarks();
-}
-
-void DrawWidget::SaveState()
-{
-  m_framework->SaveState();
 }
 
 void DrawWidget::ScalePlus()
@@ -210,7 +200,9 @@ void DrawWidget::initializeGL()
 
   emit BeforeEngineCreation();
   CreateEngine();
-  LoadState();
+
+  m_framework->LoadBookmarks();
+  m_framework->EnterForeground();
 }
 
 void DrawWidget::paintGL()

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -54,9 +54,6 @@ namespace qt
 
     void OnLocationUpdate(location::GpsInfo const & info);
 
-    void SaveState();
-    void LoadState();
-
     void UpdateAfterSettingsChanged();
 
     void PrepareShutdown();

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -119,7 +119,8 @@ MainWindow::MainWindow() : m_locationService(CreateDesktopLocationService(*this)
   }
 #endif
 
-  LoadState();
+  // Always show on full screen.
+  showMaximized();
 
 #ifndef NO_DOWNLOADER
   // Show intro dialog if necessary
@@ -176,27 +177,6 @@ bool MainWindow::winEvent(MSG * msg, long * result)
   return false;
 }
 #endif
-
-MainWindow::~MainWindow()
-{
-  SaveState();
-}
-
-void MainWindow::SaveState()
-{
-  pair<int, int> xAndY(x(), y());
-  pair<int, int> widthAndHeight(width(), height());
-  Settings::Set("MainWindowXY", xAndY);
-  Settings::Set("MainWindowSize", widthAndHeight);
-
-  m_pDrawWidget->SaveState();
-}
-
-void MainWindow::LoadState()
-{
-  // do always show on full screen
-  showMaximized();
-}
 
 void MainWindow::LocationStateModeChanged(location::EMyPositionMode mode)
 {

--- a/qt/mainwindow.hpp
+++ b/qt/mainwindow.hpp
@@ -34,15 +34,12 @@ namespace qt
 
   public:
     MainWindow();
-    virtual ~MainWindow();
 
     virtual void OnLocationError(location::TLocationError errorCode);
     virtual void OnLocationUpdated(location::GpsInfo const & info);
 
   protected:
     string GetIniFile();
-    void SaveState();
-    void LoadState();
 
     void LocationStateModeChanged(location::EMyPositionMode mode);
 


### PR DESCRIPTION
@yunikkk Please check out SimulateLastTapEventIfNeeded() method. It is already called now right after Drape engine is created (and it is always recreated when you start maps activity). You should automatically get correct callback with UserMark at CallOnUserMarkActivated

@vng @rokuz please take a look too.