### PR TITLE
Fixed misprint: .cpp -> .hpp

### DIFF
--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -59,8 +59,8 @@ HEADERS += \
     drawing_rule_def.hpp \
     drawing_rules.hpp \
     drules_include.hpp \
-    drules_selector.cpp \
-    drules_selector_parser.cpp \
+    drules_selector.hpp \
+    drules_selector_parser.hpp \
     feature.hpp \
     feature_algo.hpp \
     feature_covering.hpp \


### PR DESCRIPTION
Cherry-pick. See https://github.com/mapsme/omim/pull/1873.
