### PR TITLE
[new downloader] Added thread checkers in Storage

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -254,8 +254,8 @@ bool Framework::PreMigrate(ms::LatLon const & position,
   if (currentCountryId == kInvalidCountryId)
     return false;
 
-  Storage().m_prefetchStorage->Subscribe(change, progress);
-  Storage().m_prefetchStorage->DownloadNode(currentCountryId);
+  Storage().GetPrefetchStorage()->Subscribe(change, progress);
+  Storage().GetPrefetchStorage()->DownloadNode(currentCountryId);
   return true;
 }
 

--- a/qt/search_panel.cpp
+++ b/qt/search_panel.cpp
@@ -219,7 +219,7 @@ bool SearchPanel::TryMigrate(QString const & str)
   
   auto stateChanged = [&](storage::TCountryId const & id)
   {
-    storage::Status const nextStatus = m_pDrawWidget->GetFramework().Storage().m_prefetchStorage->CountryStatusEx(id);
+    storage::Status const nextStatus = m_pDrawWidget->GetFramework().Storage().GetPrefetchStorage()->CountryStatusEx(id);
     LOG_SHORT(LINFO, (id, "status :", nextStatus));
     if (nextStatus == storage::Status::EOnDisk)
     {

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -175,6 +175,8 @@ void Storage::Migrate(TCountriesVec const & existedCountries)
 
 void Storage::Clear()
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   m_downloader->Reset();
   m_queue.clear();
   m_failedCountries.clear();
@@ -365,6 +367,8 @@ void Storage::CountryStatusEx(TCountryId const & countryId, Status & status, Map
 
 void Storage::SaveDownloadQueue()
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   stringstream ss;
   for (auto const & item : m_queue)
     ss << (ss.str().empty() ? "" : ";") << item.GetCountryId();
@@ -387,6 +391,8 @@ void Storage::RestoreDownloadQueue()
 
 void Storage::DownloadCountry(TCountryId const & countryId, MapOptions opt)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   if (opt == MapOptions::Nothing)
     return;
 
@@ -463,12 +469,16 @@ void Storage::DeleteCustomCountryVersion(LocalCountryFile const & localFile)
 
 void Storage::NotifyStatusChanged(TCountryId const & countryId)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   for (CountryObservers const & observer : m_observers)
     observer.m_changeCountryFn(countryId);
 }
 
 void Storage::DownloadNextCountryFromQueue()
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   if (m_queue.empty())
     return;
 
@@ -523,10 +533,17 @@ bool Storage::DeleteFromDownloader(TCountryId const & countryId)
   return true;
 }
 
-bool Storage::IsDownloadInProgress() const { return !m_queue.empty(); }
+bool Storage::IsDownloadInProgress() const
+{
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
+  return !m_queue.empty();
+}
 
 TCountryId Storage::GetCurrentDownloadingCountryId() const
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   return IsDownloadInProgress() ? m_queue.front().GetCountryId() : storage::TCountryId();
 }
 
@@ -554,6 +571,8 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile,
 
 int Storage::Subscribe(TChangeCountryFunction const & change, TProgressFunction const & progress)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   CountryObservers obs;
 
   obs.m_changeCountryFn = change;
@@ -567,6 +586,8 @@ int Storage::Subscribe(TChangeCountryFunction const & change, TProgressFunction 
 
 void Storage::Unsubscribe(int slotId)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   for (auto i = m_observers.begin(); i != m_observers.end(); ++i)
   {
     if (i->m_slotId == slotId)
@@ -580,6 +601,8 @@ void Storage::Unsubscribe(int slotId)
 void Storage::OnMapFileDownloadFinished(bool success,
                                         MapFilesDownloader::TProgress const & progress)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   if (m_queue.empty())
     return;
 
@@ -603,12 +626,16 @@ void Storage::OnMapFileDownloadFinished(bool success,
 
 void Storage::ReportProgress(TCountryId const & countryId, pair<int64_t, int64_t> const & p)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   for (CountryObservers const & o : m_observers)
     o.m_progressFn(countryId, p);
 }
 
 void Storage::OnServerListDownloaded(vector<string> const & urls)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   // Queue can be empty because countries were deleted from queue.
   if (m_queue.empty())
     return;
@@ -632,6 +659,8 @@ void Storage::OnServerListDownloaded(vector<string> const & urls)
 
 void Storage::OnMapFileDownloadProgress(MapFilesDownloader::TProgress const & progress)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   // Queue can be empty because countries were deleted from queue.
   if (m_queue.empty())
     return;
@@ -797,12 +826,16 @@ MapOptions Storage::NormalizeDeleteFileSet(MapOptions options) const
 
 QueuedCountry * Storage::FindCountryInQueue(TCountryId const & countryId)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   auto it = find(m_queue.begin(), m_queue.end(), countryId);
   return it == m_queue.end() ? nullptr : &*it;
 }
 
 QueuedCountry const * Storage::FindCountryInQueue(TCountryId const & countryId) const
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   auto it = find(m_queue.begin(), m_queue.end(), countryId);
   return it == m_queue.end() ? nullptr : &*it;
 }
@@ -814,6 +847,8 @@ bool Storage::IsCountryInQueue(TCountryId const & countryId) const
 
 bool Storage::IsCountryFirstInQueue(TCountryId const & countryId) const
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   return !m_queue.empty() && m_queue.front().GetCountryId() == countryId;
 }
 
@@ -919,6 +954,8 @@ void Storage::DeleteCountryFiles(TCountryId const & countryId, MapOptions opt)
 
 bool Storage::DeleteCountryFilesFromDownloader(TCountryId const & countryId, MapOptions opt)
 {
+  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+
   QueuedCountry * queuedCountry = FindCountryInQueue(countryId);
   if (!queuedCountry)
     return false;

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -162,6 +162,8 @@ private:
 
   CountryNameGetter m_countryNameGetter;
 
+  unique_ptr<Storage> m_prefetchStorage;
+
   DECLARE_THREAD_CHECKER(m_threadChecker);
 
   void DownloadNextCountryFromQueue();
@@ -326,7 +328,7 @@ public:
   void UnsubscribeStatusCallback(size_t index) {}
 
   /// \brief Sets callback which will be called in case of a click on download map button on the map.
-  void SetCallbackForClickOnDownloadMap(TDownloadFn & downloadFn) { m_downloadMapOnTheMap = downloadFn; }
+  void SetCallbackForClickOnDownloadMap(TDownloadFn & downloadFn);
 
   /// \brief Calls |m_downloadMapOnTheMap| if one has been set.
   /// \param |countryId| is country id of a leaf. That means it's a file name.
@@ -342,12 +344,12 @@ public:
   /// Do we have downloaded countries
   bool HaveDownloadedCountries() const;
 
-  /// Prefetch MWMs before migrate
-  unique_ptr<Storage> m_prefetchStorage;
-  void PrefetchMigrateData();
-
   /// Delete local maps and aggregate their Id if needed
   void DeleteAllLocalMaps(TCountriesVec * existedCountries = nullptr);
+
+  /// Prefetch MWMs before migrate
+  Storage * GetPrefetchStorage();
+  void PrefetchMigrateData();
 
   /// Switch on new storage version, remove old mwm
   /// and add required mwm's into download queue.

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -9,6 +9,8 @@
 
 #include "platform/local_country_file.hpp"
 
+#include "base/thread_checker.hpp"
+
 #include "std/function.hpp"
 #include "std/list.hpp"
 #include "std/shared_ptr.hpp"
@@ -159,6 +161,8 @@ private:
   TDownloadFn m_downloadMapOnTheMap;
 
   CountryNameGetter m_countryNameGetter;
+
+  DECLARE_THREAD_CHECKER(m_threadChecker);
 
   void DownloadNextCountryFromQueue();
 

--- a/storage/storage_integration_tests/migrate_tests.cpp
+++ b/storage/storage_integration_tests/migrate_tests.cpp
@@ -51,9 +51,9 @@ UNIT_TEST(StorageMigrationTests)
 
   auto statePrefetchChanged = [&](TCountryId const & id)
   {
-    Status const nextStatus = f.Storage().m_prefetchStorage->CountryStatusEx(id);
+    Status const nextStatus = f.Storage().GetPrefetchStorage()->CountryStatusEx(id);
     LOG_SHORT(LINFO, (id, "status :", nextStatus));
-    if (!f.Storage().m_prefetchStorage->IsDownloadInProgress())
+    if (!f.Storage().GetPrefetchStorage()->IsDownloadInProgress())
     {
       LOG_SHORT(LINFO, ("All prefetched. Ready to migrate."));
       testing::StopEventLoop();
@@ -95,7 +95,7 @@ UNIT_TEST(StorageMigrationTests)
 
   TEST_EQUAL(s.GetDownloadedFilesCount(), kPrefetchCountries.size(), ());
   for (auto const & countryId : kPrefetchCountries)
-    TEST(s.m_prefetchStorage->IsNodeDownloaded(countryId), (countryId));
+    TEST(s.GetPrefetchStorage()->IsNodeDownloaded(countryId), (countryId));
 
   f.Migrate();
   // Wait for downloading complete.


### PR DESCRIPTION
Added thread checker to check:
- observers are used from the main thread
- downloading queue is used from the main thread