### PR TITLE
[new downloader] Statuses. Downloading progress. GetNodeAttrs.

### DIFF
--- a/android/jni/com/mapswithme/maps/MapManager.cpp
+++ b/android/jni/com/mapswithme/maps/MapManager.cpp
@@ -146,7 +146,7 @@ static void UpdateItem(JNIEnv * env, jobject item, NodeAttrs const & attrs)
   env->SetBooleanField(item, countryItemFieldPresent, attrs.m_present);
 
   // Progress
-  env->SetIntField(item, countryItemFieldProgress,static_cast<jint>(attrs.m_downloadingMwmSize));
+  env->SetIntField(item, countryItemFieldProgress,static_cast<jint>(attrs.m_downloadingProgress.first));
 }
 
 static void PutItemsToList(JNIEnv * env, jobject const list,  vector<TCountryId> const & children, TCountryId const & parent, int category)

--- a/geometry/geometry_tests/tree_test.cpp
+++ b/geometry/geometry_tests/tree_test.cpp
@@ -8,7 +8,7 @@ namespace
   typedef m2::RectD R;
 
   struct traits_t { m2::RectD LimitRect(m2::RectD const & r) const { return r; }};
-  typedef m4::Tree<R, traits_t> TreeT;
+  typedef m4::Tree<R, traits_t> TTree;
 
   template <class T> bool RTrue(T const &, T const &) { return true; }
   template <class T> bool RFalse(T const &, T const &) { return false; }
@@ -16,7 +16,7 @@ namespace
 
 UNIT_TEST(Tree4D_Smoke)
 {
-  TreeT theTree;
+  TTree theTree;
 
   R arr[] = {
     R(0, 0, 1, 1),
@@ -52,7 +52,7 @@ UNIT_TEST(Tree4D_Smoke)
 
 UNIT_TEST(Tree4D_ReplaceAllInRect)
 {
-  TreeT theTree;
+  TTree theTree;
 
   R arr[] = {
     R(8, 13, 554, 32), R(555, 13, 700, 32),
@@ -91,7 +91,7 @@ namespace
 {
   void CheckInRect(R const * arr, size_t count, R const & searchR, size_t expected)
   {
-    TreeT theTree;
+    TTree theTree;
 
     for (size_t i = 0; i < count; ++i)
       theTree.Add(arr[i], arr[i]);

--- a/iphone/Maps/Classes/MapDownloader/Cells/MWMMapDownloaderTableViewCell.mm
+++ b/iphone/Maps/Classes/MapDownloader/Cells/MWMMapDownloaderTableViewCell.mm
@@ -73,7 +73,7 @@
       self.progressView.state = MWMCircularProgressStateNormal;
       break;
     case NodeStatus::Downloading:
-      self.progressView.progress = static_cast<CGFloat>(nodeAttrs.m_downloadingProgress) / 100.0;
+      self.progressView.progress = static_cast<CGFloat>(nodeAttrs.m_downloadingProgress.first) / 100.0;
       break;
     case NodeStatus::InQueue:
       self.progressView.state = MWMCircularProgressStateSpinner;
@@ -87,8 +87,6 @@
       break;
     case NodeStatus::OnDiskOutOfDate:
       self.progressView.state = MWMCircularProgressStateSelected;
-      break;
-    case NodeStatus::Mixed:
       break;
   }
 }
@@ -144,7 +142,6 @@
       [self.delegate cancelNode:m_countryId];
       break;
     case NodeStatus::OnDisk:
-    case NodeStatus::Mixed:
       break;
   }
 }

--- a/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
@@ -79,6 +79,7 @@ using namespace storage;
     self.progressView.state = MWMCircularProgressStateNormal;
     [self removeFromSuperview];
   };
+
   switch (nodeAttrs.m_status)
   {
     case NodeStatus::NotDownloaded:
@@ -98,7 +99,8 @@ using namespace storage;
       break;
     }
     case NodeStatus::Downloading:
-      [self showDownloading:static_cast<CGFloat>(nodeAttrs.m_downloadingProgress.first) / nodeAttrs.m_downloadingProgress.second];
+      if (nodeAttrs.m_downloadingProgress.second != 0)
+        [self showDownloading:static_cast<CGFloat>(nodeAttrs.m_downloadingProgress.first) / nodeAttrs.m_downloadingProgress.second];
       addSubview();
       break;
     case NodeStatus::InQueue:

--- a/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
@@ -98,7 +98,7 @@ using namespace storage;
       break;
     }
     case NodeStatus::Downloading:
-      [self showDownloading:static_cast<CGFloat>(nodeAttrs.m_downloadingProgress) / 100.0];
+      [self showDownloading:static_cast<CGFloat>(nodeAttrs.m_downloadingProgress.first) / nodeAttrs.m_downloadingProgress.second];
       addSubview();
       break;
     case NodeStatus::InQueue:
@@ -112,7 +112,6 @@ using namespace storage;
       break;
     case NodeStatus::OnDisk:
     case NodeStatus::OnDiskOutOfDate:
-    case NodeStatus::Mixed:
       removeSubview();
       break;
   }

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -186,9 +186,6 @@ namespace qt
       st.DeleteNode(countryId);
       break;
 
-    case NodeStatus::Mixed:
-      break;
-
     default:
       ASSERT(false, ("We shouldn't be here"));
       break;
@@ -271,11 +268,6 @@ namespace qt
     case NodeStatus::InQueue:
       statusString = tr("Marked for download");
       rowColor = COLOR_INQUEUE;
-      break;
-
-    case NodeStatus::Mixed:
-      statusString = tr("Mixed status");
-      rowColor = COLOR_MIXED;
       break;
 
     default:

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -427,7 +427,7 @@ namespace qt
   }
 
   void UpdateDialog::OnCountryDownloadProgress(TCountryId const & countryId,
-                                               pair<int64_t, int64_t> const & progress)
+                                               MapFilesDownloader::TProgress const & progress)
   {
     auto const items = GetTreeItemsByCountryId(countryId);
     for (auto const item : items)

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -234,7 +234,7 @@ namespace qt
     NodeAttrs attrs;
     st.GetNodeAttrs(countryId, attrs);
 
-    size.first = attrs.m_downloadingMwmSize;
+    size.first = attrs.m_downloadingProgress.first;
     size.second = attrs.m_mwmSize;
 
     switch (attrs.m_status)

--- a/qt/update_dialog.hpp
+++ b/qt/update_dialog.hpp
@@ -33,7 +33,7 @@ namespace qt
     //@{
     void OnCountryChanged(storage::TCountryId const & countryId);
     void OnCountryDownloadProgress(storage::TCountryId const & countryId,
-                                   pair<int64_t, int64_t> const & progress);
+                                   storage::MapFilesDownloader::TProgress const & progress);
     //@}
 
     void ShowModal();

--- a/storage/country.cpp
+++ b/storage/country.cpp
@@ -24,7 +24,6 @@ TMwmSubtreeAttrs LoadGroupSingleMwmsImpl(int depth, json_t * group, TCountryId c
   uint32_t mwmCounter = 0;
   size_t mwmSize = 0;
   size_t const groupListSize = json_array_size(group);
-  toDo.ReserveAtDepth(depth, groupListSize);
   for (size_t i = 0; i < groupListSize; ++i)
   {
     json_t * j = json_array_get(group, i);
@@ -77,7 +76,6 @@ void LoadGroupTwoComponentMwmsImpl(int depth, json_t * group, TCountryId const &
   // @TODO(bykoianko) After we stop supporting two component mwms (with routing files)
   // remove code below.
   size_t const groupListSize = json_array_size(group);
-  toDo.ReserveAtDepth(depth, groupListSize);
   for (size_t i = 0; i < groupListSize; ++i)
   {
     json_t * j = json_array_get(group, i);
@@ -175,8 +173,6 @@ public:
   }
 
   TMapping GetMapping() const { return m_idsMapping; }
-
-  void ReserveAtDepth(int level, size_t n) { m_cont.ReserveAtDepth(level, n); }
 };
 
 class DoStoreCountriesTwoComponentMwms
@@ -198,8 +194,6 @@ public:
     }
     m_cont.AddAtDepth(depth, country);
   }
-
-  void ReserveAtDepth(int level, size_t n) { m_cont.ReserveAtDepth(level, n); }
 };
 
 class DoStoreFile2InfoSingleMwms
@@ -226,7 +220,6 @@ public:
 
   void SetCountriesContainerAttrs(uint32_t, size_t) {}
   TMapping GetMapping() const { return m_idsMapping; }
-  void ReserveAtDepth(int, size_t) {}
 };
 
 class DoStoreFile2InfoTwoComponentMwms
@@ -247,7 +240,6 @@ public:
     CountryInfo info(id);
     m_file2info[id] = info;
   }
-  void ReserveAtDepth(int, size_t) {}
 };
 }  // namespace
 

--- a/storage/country.cpp
+++ b/storage/country.cpp
@@ -24,6 +24,7 @@ TMwmSubtreeAttrs LoadGroupSingleMwmsImpl(int depth, json_t * group, TCountryId c
   uint32_t mwmCounter = 0;
   size_t mwmSize = 0;
   size_t const groupListSize = json_array_size(group);
+  toDo.ReserveAtDepth(depth, groupListSize);
   for (size_t i = 0; i < groupListSize; ++i)
   {
     json_t * j = json_array_get(group, i);
@@ -173,6 +174,8 @@ public:
   }
 
   TMapping GetMapping() const { return m_idsMapping; }
+
+  void ReserveAtDepth(int level, size_t n) { m_cont.ReserveAtDepth(level, n); }
 };
 
 class DoStoreCountriesTwoComponentMwms
@@ -194,6 +197,8 @@ public:
     }
     m_cont.AddAtDepth(depth, country);
   }
+
+  void ReserveAtDepth(int level, size_t n) { m_cont.ReserveAtDepth(level, n); }
 };
 
 class DoStoreFile2InfoSingleMwms
@@ -220,6 +225,7 @@ public:
 
   void SetCountriesContainerAttrs(uint32_t, size_t) {}
   TMapping GetMapping() const { return m_idsMapping; }
+  void ReserveAtDepth(int, size_t) {}
 };
 
 class DoStoreFile2InfoTwoComponentMwms
@@ -240,6 +246,7 @@ public:
     CountryInfo info(id);
     m_file2info[id] = info;
   }
+  void ReserveAtDepth(int, size_t) {}
 };
 }  // namespace
 

--- a/storage/country.cpp
+++ b/storage/country.cpp
@@ -77,6 +77,7 @@ void LoadGroupTwoComponentMwmsImpl(int depth, json_t * group, TCountryId const &
   // @TODO(bykoianko) After we stop supporting two component mwms (with routing files)
   // remove code below.
   size_t const groupListSize = json_array_size(group);
+  toDo.ReserveAtDepth(depth, groupListSize);
   for (size_t i = 0; i < groupListSize; ++i)
   {
     json_t * j = json_array_get(group, i);

--- a/storage/country.hpp
+++ b/storage/country.hpp
@@ -2,7 +2,7 @@
 
 #include "storage/country_decl.hpp"
 #include "storage/index.hpp"
-#include "storage/simple_tree.hpp"
+#include "storage/country_tree.hpp"
 #include "storage/storage_defines.hpp"
 
 #include "platform/local_country_file.hpp"
@@ -74,7 +74,7 @@ public:
   TCountryId const & Name() const { return m_name; }
 };
 
-typedef SimpleTree<Country> TCountriesContainer;
+typedef CountryTree<Country> TCountriesContainer;
 
 /// @return version of country file or -1 if error was encountered
 int64_t LoadCountries(string const & jsonBuffer, TCountriesContainer & countries, TMapping * mapping = nullptr);

--- a/storage/country_tree.hpp
+++ b/storage/country_tree.hpp
@@ -7,19 +7,19 @@
 #include "std/vector.hpp"
 
 /// This class is developed for using in Storage. It's a implementation of a tree.
-/// It should be filled with AddAtDepth method. Before calling AddAtDepth for a node
-/// ReserveAtDepth should be called for the node. The tree can be filled only
-/// according to BFS order.
+/// It should be filled with AddAtDepth method.
+/// This class is used in Storage and filled based on countries.txt (countries_migrate.txt).
+/// While filling CountryTree nodes in countries.txt should be visited in DFS order.
 template <class T>
-class SimpleTree
+class CountryTree
 {
   T m_value;
 
   /// \brief m_children contains all first generation descendants of the node.
   /// Note. Once created the order of elements of |m_children| should not be changed.
   /// See implementation of AddAtDepth and Add methods for details.
-  vector<unique_ptr<SimpleTree<T>>> m_children;
-  SimpleTree<T> * m_parent;
+  vector<unique_ptr<CountryTree<T>>> m_children;
+  CountryTree<T> * m_parent;
 
   static bool IsEqual(T const & v1, T const & v2)
   {
@@ -27,7 +27,7 @@ class SimpleTree
   }
 
 public:
-  SimpleTree(T const & value = T(), SimpleTree<T> * parent = nullptr)
+  CountryTree(T const & value = T(), CountryTree<T> * parent = nullptr)
     : m_value(value), m_parent(parent)
   {
   }
@@ -36,25 +36,6 @@ public:
   T const & Value() const
   {
     return m_value;
-  }
-
-  /// \brief Reserves child size vector. This method should be called once for every node
-  /// just before filling children vector of the node to prevent m_children vector
-  /// relocation while filling.
-  /// \param level depth of node which children vector will be reserved.
-  /// \n number of vector elements will be reserved.
-  void ReserveAtDepth(int level, size_t n)
-  {
-    SimpleTree<T> * node = this;
-    while (level-- > 0 && !node->m_children.empty())
-      node = node->m_children.back().get();
-    ASSERT_EQUAL(level, -1, ());
-    return node->Reserve(n);
-  }
-
-  void Reserve(size_t n)
-  {
-    m_children.reserve(n);
   }
 
   /// @return reference is valid only up to the next tree structure modification
@@ -66,7 +47,7 @@ public:
   /// @return reference is valid only up to the next tree structure modification
   T & AddAtDepth(int level, T const & value)
   {
-    SimpleTree<T> * node = this;
+    CountryTree<T> * node = this;
     while (level-- > 0 && !node->m_children.empty())
       node = node->m_children.back().get();
     ASSERT_EQUAL(level, -1, ());
@@ -76,7 +57,7 @@ public:
   /// @return reference is valid only up to the next tree structure modification
   T & Add(T const & value)
   {
-    m_children.emplace_back(make_unique<SimpleTree<T>>(value, this));
+    m_children.emplace_back(make_unique<CountryTree<T>>(value, this));
     return m_children.back()->Value();
   }
 
@@ -86,7 +67,7 @@ public:
     m_children.clear();
   }
 
-  bool operator<(SimpleTree<T> const & other) const
+  bool operator<(CountryTree<T> const & other) const
   {
     return Value() < other.Value();
   }
@@ -97,7 +78,7 @@ public:
   /// @TODO(bykoianko) The complexity of the method is O(n). But the structure (tree) is built on the start of the program
   /// and then actively used on run time. This method (and class) should be redesigned to make the function work faster.
   /// A hash table is being planned to use.
-  void Find(T const & value, vector<SimpleTree<T> const *> & found) const
+  void Find(T const & value, vector<CountryTree<T> const *> & found) const
   {
     if (IsEqual(m_value, value))
       found.push_back(this);
@@ -105,14 +86,14 @@ public:
       child->Find(value, found);
   }
 
-  SimpleTree<T> const * const FindFirst(T const & value) const
+  CountryTree<T> const * const FindFirst(T const & value) const
   {
     if (IsEqual(m_value, value))
       return this;
 
     for (auto const & child : m_children)
     {
-      SimpleTree<T> const * const found = child->FindFirst(value);
+      CountryTree<T> const * const found = child->FindFirst(value);
       if (found != nullptr)
         return found;
     }
@@ -124,14 +105,14 @@ public:
   /// When new countries.txt with unique ids will be added FindLeaf will be removed
   /// and Find will be used intead.
   /// @TODO(bykoianko) Remove this method on countries.txt update.
-  SimpleTree<T> const * const FindFirstLeaf(T const & value) const
+  CountryTree<T> const * const FindFirstLeaf(T const & value) const
   {
     if (IsEqual(m_value, value) && m_children.empty())
       return this; // It's a leaf.
 
     for (auto const & child : m_children)
     {
-      SimpleTree<T> const * const found = child->FindFirstLeaf(value);
+      CountryTree<T> const * const found = child->FindFirstLeaf(value);
       if (found != nullptr)
         return found;
     }
@@ -140,13 +121,13 @@ public:
 
   bool HasParent() const { return m_parent != nullptr; }
 
-  SimpleTree<T> const & Parent() const
+  CountryTree<T> const & Parent() const
   {
     CHECK(HasParent(), ());
     return *m_parent;
   }
 
-  SimpleTree<T> const & Child(size_t index) const
+  CountryTree<T> const & Child(size_t index) const
   {
     ASSERT_LESS(index, m_children.size(), ());
     return *m_children[index];

--- a/storage/index.hpp
+++ b/storage/index.hpp
@@ -2,6 +2,7 @@
 
 #include "std/set.hpp"
 #include "std/string.hpp"
+#include "std/unordered_set.hpp"
 #include "std/vector.hpp"
 
 namespace storage
@@ -9,6 +10,7 @@ namespace storage
 using TCountryId = string;
 using TCountriesSet = set<TCountryId>;
 using TCountriesVec = vector<TCountryId>;
+using TCountriesUnorderedSet = unordered_set<TCountryId>;
 
 extern const storage::TCountryId kInvalidCountryId;
 

--- a/storage/index.hpp
+++ b/storage/index.hpp
@@ -10,7 +10,6 @@ namespace storage
 using TCountryId = string;
 using TCountriesSet = set<TCountryId>;
 using TCountriesVec = vector<TCountryId>;
-using TCountriesUnorderedSet = unordered_set<TCountryId>;
 
 extern const storage::TCountryId kInvalidCountryId;
 

--- a/storage/simple_tree.hpp
+++ b/storage/simple_tree.hpp
@@ -6,6 +6,10 @@
 #include "std/unique_ptr.hpp"
 #include "std/vector.hpp"
 
+/// This class is developed for using in Storage. It's a implementation of a tree.
+/// It should be filled with AddAtDepth method. Before calling AddAtDepth for a node
+/// ReserveAtDepth should be called for the node. The tree can be filled only
+/// according to BFS order.
 template <class T>
 class SimpleTree
 {
@@ -34,8 +38,11 @@ public:
     return m_value;
   }
 
-  /// \brief Reserves child size vector. This method should be called once before filling
-  /// children vector with correct |n| size to prevent m_children relocation while filling.
+  /// \brief Reserves child size vector. This method should be called once for every node
+  /// just before filling children vector of the node to prevent m_children vector
+  /// relocation while filling.
+  /// \param level depth of node which children vector will be reserved.
+  /// \n number of vector elements will be reserved.
   void ReserveAtDepth(int level, size_t n)
   {
     SimpleTree<T> * node = this;

--- a/storage/simple_tree.hpp
+++ b/storage/simple_tree.hpp
@@ -32,11 +32,14 @@ public:
     return m_value;
   }
 
+  /// \brief Reserves child size vector. This method should be called once before filling
+  /// children vector with correct |n| size to prevent m_children relocation while filling.
   void ReserveAtDepth(int level, size_t n)
   {
     SimpleTree<T> * node = this;
     while (level-- > 0 && !node->m_children.empty())
       node = &node->m_children.back();
+    ASSERT_EQUAL(level, -1, ());
     return node->Reserve(n);
   }
 
@@ -57,6 +60,7 @@ public:
     SimpleTree<T> * node = this;
     while (level-- > 0 && !node->m_children.empty())
       node = &node->m_children.back();
+    ASSERT_EQUAL(level, -1, ());
     return node->Add(value);
   }
 
@@ -197,20 +201,20 @@ public:
   }
 
   template <class TFunctor>
-  void ForEachParentExceptForTheRoot(TFunctor && f)
+  void ForEachAncestorExceptForTheRoot(TFunctor && f)
   {
     if (m_parent == nullptr || m_parent->m_parent == nullptr)
       return;
     f(*m_parent);
-    m_parent->ForEachParentExceptForTheRoot(f);
+    m_parent->ForEachAncestorExceptForTheRoot(f);
   }
 
   template <class TFunctor>
-  void ForEachParentExceptForTheRoot(TFunctor && f) const
+  void ForEachAncestorExceptForTheRoot(TFunctor && f) const
   {
     if (m_parent == nullptr || m_parent->m_parent == nullptr)
       return;
     f(*m_parent);
-    m_parent->ForEachParentExceptForTheRoot(f);
+    m_parent->ForEachAncestorExceptForTheRoot(f);
   }
 };

--- a/storage/simple_tree.hpp
+++ b/storage/simple_tree.hpp
@@ -32,6 +32,19 @@ public:
     return m_value;
   }
 
+  void ReserveAtDepth(int level, size_t n)
+  {
+    SimpleTree<T> * node = this;
+    while (level-- > 0 && !node->m_children.empty())
+      node = &node->m_children.back();
+    return node->Reserve(n);
+  }
+
+  void Reserve(size_t n)
+  {
+    m_children.reserve(n);
+  }
+
   /// @return reference is valid only up to the next tree structure modification
   T & Value()
   {
@@ -184,20 +197,20 @@ public:
   }
 
   template <class TFunctor>
-  void ForEachParent(TFunctor && f)
+  void ForEachParentExceptForTheRoot(TFunctor && f)
   {
-    if (m_parent == nullptr)
+    if (m_parent == nullptr || m_parent->m_parent == nullptr)
       return;
     f(*m_parent);
-    m_parent->ForEachParent(f);
+    m_parent->ForEachParentExceptForTheRoot(f);
   }
 
   template <class TFunctor>
-  void ForEachParent(TFunctor && f) const
+  void ForEachParentExceptForTheRoot(TFunctor && f) const
   {
-    if (m_parent == nullptr)
+    if (m_parent == nullptr || m_parent->m_parent == nullptr)
       return;
     f(*m_parent);
-    m_parent->ForEachParent(f);
+    m_parent->ForEachParentExceptForTheRoot(f);
   }
 };

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -245,7 +245,7 @@ public:
     TOnStatusChangedCallback m_onStatusChanged;
   };
 
-  /// \brief Returns root country id of the county tree.
+  /// \brief Returns root country id of the country tree.
   TCountryId const GetRootId() const;
 
   /// \param childrenId is filled with children node ids by a parent. For example GetChildren(GetRootId())
@@ -325,7 +325,7 @@ public:
   template <class ToDo>
   void ForEachInSubtree(TCountryId const & root, ToDo && toDo) const;
   template <class ToDo>
-  void ForEachParentExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const;
+  void ForEachAncestorExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const;
 
   /// \brief Subscribe on change status callback.
   /// \returns a unique index of added status callback structure.
@@ -508,15 +508,15 @@ private:
   /// Will be removed in future after refactoring.
   TCountriesVec FindAllIndexesByFile(TCountryId const & name) const;
 
-  /// Calculates progress of downloading for non-expandable nodes in county tree.
+  /// Calculates progress of downloading for non-expandable nodes in country tree.
   /// |descendants| All descendants of the parent node.
-  /// |downlaodingMwm| Downloading leaf node country id if any. If not, downlaodingMwm == kInvalidCountryId.
-  /// if downlaodingMwm != kInvalidCountryId |downloadingMwmProgress| is a progress of downloading
+  /// |downloadingMwm| Downloading leaf node country id if any. If not, downloadingMwm == kInvalidCountryId.
+  /// If downloadingMwm != kInvalidCountryId |downloadingMwmProgress| is a progress of downloading
   /// the leaf node in bytes. |downloadingMwmProgress.first| == number of downloaded bytes.
   /// |downloadingMwmProgress.second| == number of bytes in downloading files.
   /// |hashQueue| hash table made from |m_queue|.
   pair<int64_t, int64_t> CalculateProgress(TCountriesVec const & descendants,
-                                           TCountryId const & downlaodingMwm,
+                                           TCountryId const & downloadingMwm,
                                            pair<int64_t, int64_t> const & downloadingMwmProgress,
                                            TCountriesUnorderedSet const & hashQueue) const;
 };
@@ -542,10 +542,10 @@ void Storage::ForEachInSubtree(TCountryId const & root, ToDo && toDo) const
 /// for each parent (including indirect/great parents) except for the main root of the tree.
 /// |descendantsCountryId| is a vector of country id of descendats of |parentId|.
 /// Note. In case of disputable territories several nodes with the same name may be
-/// present in the country tree. In that case ForEachParentExceptForTheRoot calls
+/// present in the country tree. In that case ForEachAncestorExceptForTheRoot calls
 /// |toDo| for parents of each branch in the country tree.
 template <class ToDo>
-void Storage::ForEachParentExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const
+void Storage::ForEachAncestorExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const
 {
   vector<SimpleTree<Country> const *> nodes;
   m_countries.Find(Country(childId), nodes);
@@ -559,7 +559,7 @@ void Storage::ForEachParentExceptForTheRoot(TCountryId const & childId, ToDo && 
   // may be more than one. It means |childId| is present in the country tree more than once.
   for (auto const & node : nodes)
   {
-    node->ForEachParentExceptForTheRoot([&toDo](TCountriesContainer const & countryContainer)
+    node->ForEachAncestorExceptForTheRoot([&toDo](TCountriesContainer const & countryContainer)
     {
       TCountriesVec descendantsCountryId;
       countryContainer.ForEachDescendant([&descendantsCountryId](TCountriesContainer const & countryContainer)

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -516,6 +516,13 @@ void Storage::ForEachInSubtree(TCountryId const & root, ToDo && toDo) const
   });
 }
 
+/// Calls functor |toDo| with sigrature
+/// void(const TCountryId const & parentId, TCountriesVec const & descendantCountryId)
+/// for each parent (including indirect/great parents) except for the main root of the tree.
+/// |descendantsCountryId| is a vector of country id of descendats of |parentId|.
+/// Note. In case of disputable territories several nodes with the same name may be
+/// present in the country tree. In that case ForEachParentExceptForTheRoot calls
+/// |toDo| for parents of each branch in the country tree.
 template <class ToDo>
 void Storage::ForEachParentExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const
 {
@@ -527,16 +534,18 @@ void Storage::ForEachParentExceptForTheRoot(TCountryId const & childId, ToDo && 
     return;
   }
 
+  // In most cases nodes.size() == 1. In case of disputable territories nodes.size()
+  // may be more than one. It means |childId| is present in the country tree more than once.
   for (auto const & node : nodes)
   {
     node->ForEachParentExceptForTheRoot([&toDo](TCountriesContainer const & countryContainer)
     {
-      TCountriesVec descendantCountryId;
-      countryContainer.ForEachDescendant([&descendantCountryId](TCountriesContainer const & countryContainer)
+      TCountriesVec descendantsCountryId;
+      countryContainer.ForEachDescendant([&descendantsCountryId](TCountriesContainer const & countryContainer)
       {
-        descendantCountryId.push_back(countryContainer.Value().Name());
+        descendantsCountryId.push_back(countryContainer.Value().Name());
       });
-      toDo(countryContainer.Value().Name(), descendantCountryId);
+      toDo(countryContainer.Value().Name(), descendantsCountryId);
     });
   }
 }

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -297,10 +297,6 @@ public:
   /// \return false in case of error and true otherwise.
   bool RetryDownloadNode(TCountryId const & countryId) { return true; }
 
-  /// \brief Shows a node (expandable or not) on the map.
-  /// \return false in case of error and true otherwise.
-  bool ShowNode(TCountryId const & countryId) { return true; }
-
   /// \brief Get information for mwm update button.
   /// \return true if updateInfo is filled correctly and false otherwise.
   bool GetUpdateInfo(TCountryId const & countryId, UpdateInfo & updateInfo) const { return true; }

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -110,6 +110,12 @@ private:
   /// can call all the methods from a single thread using
   /// RunOnUIThread.  If not, at least use a syncronization object.
   TQueue m_queue;
+  /// Set of mwm files which have been downloaded recently.
+  /// When a mwm file is downloaded it's moved from |m_queue| to |m_justDownloaded|.
+  /// When a new mwm file is added to |m_queue| |m_justDownloaded| is cleared.
+  /// Note. This set is necessary for implementation of downloading progress of
+  /// expandable mwm.
+  TCountriesUnorderedSet m_justDownloaded;
 
   /// stores countries whose download has failed recently
   TCountriesSet m_failedCountries;
@@ -172,7 +178,8 @@ private:
                          string const & dataDir, TMapping * mapping = nullptr);
 
   void ReportProgress(TCountryId const & countryId, pair<int64_t, int64_t> const & p);
-  void ReportProgressForHierarchy(TCountryId const & countryId, pair<int64_t, int64_t> const & p);
+  void ReportProgressForHierarchy(TCountryId const & countryId,
+                                  pair<int64_t, int64_t> const & leafProgress);
 
   /// Called on the main thread by MapFilesDownloader when list of
   /// suitable servers is received.

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -32,7 +32,7 @@ struct CountryIdAndName
 struct NodeAttrs
 {
   NodeAttrs() : m_mwmCounter(0), m_localMwmCounter(0), m_mwmSize(0), m_localMwmSize(0),
-    m_downloadingMwmSize(0), m_downloadingProgress(make_pair(0, 0)),
+    m_downloadingProgress(make_pair(0, 0)),
     m_status(NodeStatus::Undefined), m_error(NodeErrorCode::NoError), m_present(false) {}
 
   /// If the node is expandable (a big country) |m_mwmCounter| is number of mwm files (leaves)
@@ -52,12 +52,6 @@ struct NodeAttrs
   /// Otherwise |m_localNodeSize| is the sum of all mwm file sizes which belong to the group and
   /// have been downloaded.
   size_t m_localMwmSize;
-
-  /// If downloading or updating an mwm is in progress apart from a local mwm
-  /// which is currently used there's a partly downloading mwm of the same region.
-  /// |m_downloadingMwmSize| is size of partly downloaded mwm if downloading is in progress.
-  /// And |m_downloadingMwmSize| == 0 otherwise.
-  size_t m_downloadingMwmSize;
 
   /// The name of the node in a local language. That means the language dependent on
   /// a device locale.
@@ -116,7 +110,7 @@ private:
   /// When a mwm file is downloaded it's moved from |m_queue| to |m_justDownloaded|.
   /// When a new mwm file is added to |m_queue| |m_justDownloaded| is cleared.
   /// Note. This set is necessary for implementation of downloading progress of
-  /// expandable mwm.
+  /// mwm group.
   TCountriesUnorderedSet m_justDownloaded;
 
   /// stores countries whose download has failed recently
@@ -508,17 +502,17 @@ private:
   /// Will be removed in future after refactoring.
   TCountriesVec FindAllIndexesByFile(TCountryId const & name) const;
 
-  /// Calculates progress of downloading for non-expandable nodes in country tree.
+  /// Calculates progress of downloading for expandable nodes in country tree.
   /// |descendants| All descendants of the parent node.
   /// |downloadingMwm| Downloading leaf node country id if any. If not, downloadingMwm == kInvalidCountryId.
   /// If downloadingMwm != kInvalidCountryId |downloadingMwmProgress| is a progress of downloading
   /// the leaf node in bytes. |downloadingMwmProgress.first| == number of downloaded bytes.
   /// |downloadingMwmProgress.second| == number of bytes in downloading files.
-  /// |hashQueue| hash table made from |m_queue|.
+  /// |mwmsInQueue| hash table made from |m_queue|.
   pair<int64_t, int64_t> CalculateProgress(TCountriesVec const & descendants,
                                            TCountryId const & downloadingMwm,
                                            pair<int64_t, int64_t> const & downloadingMwmProgress,
-                                           TCountriesUnorderedSet const & hashQueue) const;
+                                           TCountriesUnorderedSet const & mwmsInQueue) const;
 };
 
 template <class ToDo>

--- a/storage/storage.pro
+++ b/storage/storage.pro
@@ -16,11 +16,11 @@ HEADERS += \
   country_info_getter.hpp \
   country_name_getter.hpp \
   country_polygon.hpp \
+  country_tree.hpp \
   http_map_files_downloader.hpp \
   index.hpp \
   map_files_downloader.hpp \
   queued_country.hpp \
-  simple_tree.hpp \
   storage.hpp \
   storage_defines.hpp \
   storage_helpers.hpp \

--- a/storage/storage_defines.cpp
+++ b/storage/storage_defines.cpp
@@ -26,8 +26,6 @@ string DebugPrint(Status status)
     return string("OnDiskOutOfDate");
   case Status::EOutOfMemFailed:
     return string("OutOfMemFailed");
-  case Status::EMixed:
-    return string("EMixed");
   }
 }
 
@@ -49,8 +47,6 @@ string DebugPrint(NodeStatus status)
     return string("InQueue");
   case NodeStatus::OnDiskOutOfDate:
     return string("OnDiskOutOfDate");
-  case NodeStatus::Mixed:
-    return string("Mixed");
   }
 }
 
@@ -91,8 +87,6 @@ StatusAndError ParseStatus(Status innerStatus)
     return StatusAndError(NodeStatus::OnDiskOutOfDate, NodeErrorCode::NoError);
   case Status::EOutOfMemFailed:
     return StatusAndError(NodeStatus::Error, NodeErrorCode::OutOfMemFailed);
-  case Status::EMixed:
-    return StatusAndError(NodeStatus::Mixed, NodeErrorCode::NoError);
   }
 }
 

--- a/storage/storage_defines.hpp
+++ b/storage/storage_defines.hpp
@@ -21,7 +21,6 @@ namespace storage
     EUnknown,         /**< Downloading failed because of unknown error. */
     EOnDiskOutOfDate, /**< An update for a downloaded mwm is ready according to counties.txt. */
     EOutOfMemFailed,  /**< Downloading failed because it's not enough memory */
-    EMixed,           /**< Descendants of a group node have different statuses. */
   };
   string DebugPrint(Status status);
 
@@ -34,7 +33,6 @@ namespace storage
     Downloading,      /**< Downloading a new mwm or updating an old one. */
     InQueue,          /**< A mwm is waiting for downloading in the queue. */
     OnDiskOutOfDate,  /**< An update for a downloaded mwm is ready according to counties.txt. */
-    Mixed,            /**< Descendants of a group node have different statuses. */
   };
   string DebugPrint(NodeStatus status);
 

--- a/storage/storage_tests/simple_tree_test.cpp
+++ b/storage/storage_tests/simple_tree_test.cpp
@@ -56,8 +56,8 @@ UNIT_TEST(SimpleTree_Smoke)
   TEST_EQUAL(c2.count, 8, ());
 
   Calculator<TreeT> c3;
-  tree.Child(4).Child(0).ForEachParent(c3);
-  TEST_EQUAL(c3.count, 2, ());
+  tree.Child(4).Child(0).ForEachParentExceptForTheRoot(c3);
+  TEST_EQUAL(c3.count, 1, ());
 
   tree.Clear();
   Calculator<TreeT> c4;

--- a/storage/storage_tests/simple_tree_test.cpp
+++ b/storage/storage_tests/simple_tree_test.cpp
@@ -56,7 +56,7 @@ UNIT_TEST(SimpleTree_Smoke)
   TEST_EQUAL(c2.count, 8, ());
 
   Calculator<TreeT> c3;
-  tree.Child(4).Child(0).ForEachParentExceptForTheRoot(c3);
+  tree.Child(4).Child(0).ForEachAncestorExceptForTheRoot(c3);
   TEST_EQUAL(c3.count, 1, ());
 
   tree.Clear();

--- a/storage/storage_tests/simple_tree_test.cpp
+++ b/storage/storage_tests/simple_tree_test.cpp
@@ -5,7 +5,6 @@
 
 namespace
 {
-
 template <class TNode>
 struct Calculator
 {
@@ -16,8 +15,7 @@ struct Calculator
     ++count;
   }
 };
-
-}
+} // namespace
 
 UNIT_TEST(SimpleTree_Smoke)
 {
@@ -33,16 +31,21 @@ UNIT_TEST(SimpleTree_Smoke)
   tree.AddAtDepth(1, 10);  // 1 is parent
   tree.AddAtDepth(1, 30);  // 1 is parent
 
-  tree.Sort();
-  // test sorting
-  TEST_EQUAL(tree.Child(0).Value(), 1, ());
-  TEST_EQUAL(tree.Child(1).Value(), 2, ());
-  TEST_EQUAL(tree.Child(2).Value(), 3, ());
-  TEST_EQUAL(tree.Child(3).Value(), 4, ());
-  TEST_EQUAL(tree.Child(4).Value(), 5, ());
-  TEST_EQUAL(tree.Child(0).Child(0).Value(), 10, ());
-  TEST_EQUAL(tree.Child(0).Child(1).Value(), 20, ());
-  TEST_EQUAL(tree.Child(0).Child(2).Value(), 30, ());
+  // children test
+  TEST_EQUAL(tree.Child(0).Value(), 4, ());
+  TEST_EQUAL(tree.Child(1).Value(), 3, ());
+  TEST_EQUAL(tree.Child(2).Value(), 5, ());
+  TEST_EQUAL(tree.Child(3).Value(), 2, ());
+  TEST_EQUAL(tree.Child(4).Value(), 1, ());
+  TEST_EQUAL(tree.Child(4).Child(0).Value(), 20, ());
+  TEST_EQUAL(tree.Child(4).Child(1).Value(), 10, ());
+  TEST_EQUAL(tree.Child(4).Child(2).Value(), 30, ());
+
+  // parent test
+  TEST(!tree.HasParent(), ());
+  TEST(!tree.Child(0).Parent().HasParent(), ());
+  TEST_EQUAL(tree.Child(4).Child(0).Parent().Value(), 1, ());
+  TEST_EQUAL(tree.Child(4).Child(2).Parent().Value(), 1, ());
 
   Calculator<TreeT> c1;
   tree.ForEachChild(c1);
@@ -52,8 +55,12 @@ UNIT_TEST(SimpleTree_Smoke)
   tree.ForEachDescendant(c2);
   TEST_EQUAL(c2.count, 8, ());
 
-  tree.Clear();
   Calculator<TreeT> c3;
-  tree.ForEachDescendant(c3);
-  TEST_EQUAL(c3.count, 0, ("Tree should be empty"));
+  tree.Child(4).Child(0).ForEachParent(c3);
+  TEST_EQUAL(c3.count, 2, ());
+
+  tree.Clear();
+  Calculator<TreeT> c4;
+  tree.ForEachDescendant(c4);
+  TEST_EQUAL(c4.count, 0, ("Tree should be empty"));
 }

--- a/storage/storage_tests/simple_tree_test.cpp
+++ b/storage/storage_tests/simple_tree_test.cpp
@@ -1,7 +1,6 @@
 #include "testing/testing.hpp"
 
-#include "storage/simple_tree.hpp"
-
+#include "storage/country_tree.hpp"
 
 namespace
 {
@@ -17,10 +16,10 @@ struct Calculator
 };
 } // namespace
 
-UNIT_TEST(SimpleTree_Smoke)
+UNIT_TEST(CountryTree_Smoke)
 {
-  typedef SimpleTree<int> TreeT;
-  TreeT tree;
+  typedef CountryTree<int> TTree;
+  TTree tree;
 
   tree.Add(4);
   tree.Add(3);
@@ -47,20 +46,20 @@ UNIT_TEST(SimpleTree_Smoke)
   TEST_EQUAL(tree.Child(4).Child(0).Parent().Value(), 1, ());
   TEST_EQUAL(tree.Child(4).Child(2).Parent().Value(), 1, ());
 
-  Calculator<TreeT> c1;
+  Calculator<TTree> c1;
   tree.ForEachChild(c1);
   TEST_EQUAL(c1.count, 5, ());
 
-  Calculator<TreeT> c2;
+  Calculator<TTree> c2;
   tree.ForEachDescendant(c2);
   TEST_EQUAL(c2.count, 8, ());
 
-  Calculator<TreeT> c3;
+  Calculator<TTree> c3;
   tree.Child(4).Child(0).ForEachAncestorExceptForTheRoot(c3);
   TEST_EQUAL(c3.count, 1, ());
 
   tree.Clear();
-  Calculator<TreeT> c4;
+  Calculator<TTree> c4;
   tree.ForEachDescendant(c4);
   TEST_EQUAL(c4.count, 0, ("Tree should be empty"));
 }

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1227,6 +1227,9 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Algeria", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 2, ());
@@ -1235,6 +1238,9 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Algeria_Coast", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
@@ -1243,6 +1249,9 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Algeria", ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("South Korea_South", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
@@ -1251,16 +1260,22 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Disputable Territory", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
   TEST_EQUAL(nodeAttrs.m_mwmSize, 1234, ());
   TEST_EQUAL(nodeAttrs.m_status, NodeStatus::NotDownloaded, ());
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
-  vector<TCountryId> expectedParents = {"Country1", "Country2"};
+  vector<TCountryId> const expectedParents = {"Country1", "Country2"};
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 2, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Country1", ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[1].m_id, "Country2", ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 }
 
 UNIT_TEST(StorageTest_ParseStatus)

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1295,7 +1295,9 @@ UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
 {
   Storage storage(kSingleMwmCountriesTxt, make_unique<TestMapFilesDownloader>());
 
-  auto const forEach = [](TCountryId const & parentId, TCountriesVec const & descendants)
+  // Two parent case.
+  auto const forEachParentDisputableTerritory
+      = [](TCountryId const & parentId, TCountriesVec const & descendants)
   {
     if (parentId == "Country1")
     {
@@ -1311,7 +1313,22 @@ UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
     }
     TEST(false, ());
   };
-  storage.ForEachParentExceptForTheRoot("Disputable Territory", forEach);
+  storage.ForEachParentExceptForTheRoot("Disputable Territory", forEachParentDisputableTerritory);
+
+  // One parent case.
+  auto const forEachParentIndisputableTerritory
+      = [](TCountryId const & parentId, TCountriesVec const & descendants)
+  {
+    if (parentId == "Country1")
+    {
+      TCountriesVec const expectedDescendants = {"Disputable Territory", "Indisputable Territory Of Country1"};
+      TEST_EQUAL(descendants, expectedDescendants, ());
+      return;
+    }
+    TEST(false, ());
+  };
+  storage.ForEachParentExceptForTheRoot("Indisputable Territory Of Country1",
+                                        forEachParentIndisputableTerritory);
 }
 
 UNIT_TEST(StorageTest_CalcLimitRect)

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1234,7 +1234,7 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   storage.GetNodeAttrs("Algeria", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 2, ());
   TEST_EQUAL(nodeAttrs.m_mwmSize, 90878678, ());
-  TEST_EQUAL(nodeAttrs.m_status, NodeStatus::NotDownloaded, ());
+  TEST_EQUAL(nodeAttrs.m_status, NodeStatus::OnDisk, ()); // It's a status of expandable node.
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1306,7 +1306,7 @@ UNIT_TEST(StorageTest_ForEachInSubtree)
   TEST_EQUAL(leafVec, expectedLeafVec, ());
 }
 
-UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
+UNIT_TEST(StorageTest_ForEachAncestorExceptForTheRoot)
 {
   Storage storage(kSingleMwmCountriesTxt, make_unique<TestMapFilesDownloader>());
 
@@ -1328,7 +1328,7 @@ UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
     }
     TEST(false, ());
   };
-  storage.ForEachParentExceptForTheRoot("Disputable Territory", forEachParentDisputableTerritory);
+  storage.ForEachAncestorExceptForTheRoot("Disputable Territory", forEachParentDisputableTerritory);
 
   // One parent case.
   auto const forEachParentIndisputableTerritory
@@ -1342,8 +1342,8 @@ UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
     }
     TEST(false, ());
   };
-  storage.ForEachParentExceptForTheRoot("Indisputable Territory Of Country1",
-                                        forEachParentIndisputableTerritory);
+  storage.ForEachAncestorExceptForTheRoot("Indisputable Territory Of Country1",
+                                          forEachParentIndisputableTerritory);
 }
 
 UNIT_TEST(StorageTest_CalcLimitRect)

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1307,8 +1307,14 @@ UNIT_TEST(StorageTest_ForEachAncestorExceptForTheRoot)
 
   // Two parent case.
   auto const forEachParentDisputableTerritory
-      = [](TCountryId const & parentId, TCountriesVec const & descendants)
+      = [](TCountryId const & parentId, TCountriesContainer const & parentNode)
   {
+    TCountriesVec descendants;
+    parentNode.ForEachDescendant([&descendants](TCountriesContainer const & container)
+    {
+      descendants.push_back(container.Value().Name());
+    });
+
     if (parentId == "Country1")
     {
       TCountriesVec const expectedDescendants = {"Disputable Territory", "Indisputable Territory Of Country1"};
@@ -1327,8 +1333,14 @@ UNIT_TEST(StorageTest_ForEachAncestorExceptForTheRoot)
 
   // One parent case.
   auto const forEachParentIndisputableTerritory
-      = [](TCountryId const & parentId, TCountriesVec const & descendants)
+      = [](TCountryId const & parentId, TCountriesContainer const & parentNode)
   {
+    TCountriesVec descendants;
+    parentNode.ForEachDescendant([&descendants](TCountriesContainer const & container)
+    {
+      descendants.push_back(container.Value().Name());
+    });
+
     if (parentId == "Country1")
     {
       TCountriesVec const expectedDescendants = {"Disputable Territory", "Indisputable Territory Of Country1"};

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1291,6 +1291,29 @@ UNIT_TEST(StorageTest_ForEachInSubtree)
   TEST_EQUAL(leafVec, expectedLeafVec, ());
 }
 
+UNIT_TEST(StorageTest_ForEachParentExceptForTheRoot)
+{
+  Storage storage(kSingleMwmCountriesTxt, make_unique<TestMapFilesDownloader>());
+
+  auto const forEach = [](TCountryId const & parentId, TCountriesVec const & descendants)
+  {
+    if (parentId == "Country1")
+    {
+      TCountriesVec const expectedDescendants = {"Disputable Territory", "Indisputable Territory Of Country1"};
+      TEST_EQUAL(descendants, expectedDescendants, ());
+      return;
+    }
+    if (parentId == "Country2")
+    {
+      TCountriesVec const expectedDescendants = {"Indisputable Territory Of Country2", "Disputable Territory"};
+      TEST_EQUAL(descendants, expectedDescendants, ());
+      return;
+    }
+    TEST(false, ());
+  };
+  storage.ForEachParentExceptForTheRoot("Disputable Territory", forEach);
+}
+
 UNIT_TEST(StorageTest_CalcLimitRect)
 {
   Storage storage(COUNTRIES_MIGRATE_FILE);

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1229,7 +1229,6 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
-  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Algeria", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 2, ());
@@ -1240,7 +1239,6 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
-  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Algeria_Coast", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
@@ -1251,7 +1249,6 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Algeria", ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
-  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("South Korea_South", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
@@ -1262,7 +1259,6 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
-  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 
   storage.GetNodeAttrs("Disputable Territory", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 1, ());
@@ -1275,7 +1271,6 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_parentInfo[1].m_id, "Country2", ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
-  TEST_EQUAL(nodeAttrs.m_downloadingMwmSize, 0, ());
 }
 
 UNIT_TEST(StorageTest_ParseStatus)


### PR DESCRIPTION
В этом PR реализован ряд вещей:
1. Вызываются колбеки прогресса загрузки для групповых и для обычных mwm;
2. Удален статус Mixed и вместо него для групповых узлов приходят статусы согласно ТЗ; (https://confluence.mail.ru/display/MAPSME/Maps+downloader+v3)
3. Метод GetNodeAttrs заполняет поля структуры, кроме недавно появившегося поля m_present;

PR рекомендую смотреть по коммитам. Комментарий к каждому коммиту поясняет, что сделано.

Тикеты:
https://jira.mail.ru/browse/MAPSME-76
https://jira.mail.ru/browse/MAPSME-75

Перенесен с https://github.com/mapsme/omim/pull/1941
Замечания учтены.