### PR TITLE
[platform] Fix language detection on some linux systems

### DIFF
--- a/platform/preferred_languages.cpp
+++ b/platform/preferred_languages.cpp
@@ -103,7 +103,7 @@ void GetSystemPreferred(vector<string> & languages)
 #elif defined(OMIM_OS_LINUX)
   // check environment variables
   char const * p = getenv("LANGUAGE");
-  if (p) // LANGUAGE can contain several values divided by ':'
+  if (p && strlen(p)) // LANGUAGE can contain several values divided by ':'
   {
     string const str(p);
     strings::SimpleTokenizer iter(str, ":");


### PR DESCRIPTION
На некоторых системах переменная окружения `LANGUAGE` может быть установлена, но равна пустой строке. В этом случае тоже нужно проверять дальше по списку.