### PR TITLE
Use THREAD_CHECKER under Android

### DIFF
--- a/base/thread_checker.hpp
+++ b/base/thread_checker.hpp
@@ -23,9 +23,7 @@ private:
   DISALLOW_COPY_AND_MOVE(ThreadChecker);
 };
 
-// ThreadChecker checker is not valid on Android.
-// UI thread (NV thread) can change it's handle value during app lifecycle.
-#if defined(DEBUG) && !defined(OMIM_OS_ANDROID)
+#if defined(DEBUG)
   #define DECLARE_THREAD_CHECKER(threadCheckerName) ThreadChecker threadCheckerName
   #define ASSERT_THREAD_CHECKER(threadCheckerName, msg) ASSERT(threadCheckerName.CalledOnOriginalThread(), msg)
 #else


### PR DESCRIPTION
С архитектурой DRAPE очереди NV больше нет, мы можем использовать ThreadChecker.