### PR TITLE
[generator] Shorter error message for unmerged coastline

### DIFF
--- a/generator/coastlines_generator.cpp
+++ b/generator/coastlines_generator.cpp
@@ -109,7 +109,12 @@ namespace
         m_rMain.AddRegionToTree(fb);
       else
       {
-        LOG(LINFO, ("Not merged coastline", fb.GetOsmIdsString()));
+        osm::Id const firstWay = fb.GetFirstOsmId();
+        osm::Id const lastWay = fb.GetLastOsmId();
+        if (firstWay == lastWay)
+          LOG(LINFO, ("Not merged coastline, way", firstWay.OsmId(), "(", fb.GetPointsCount(), "points)"));
+        else
+          LOG(LINFO, ("Not merged coastline, ways", firstWay.OsmId(), "to", lastWay.OsmId(), "(", fb.GetPointsCount(), "points)"));
         ++m_notMergedCoastsCount;
         m_totalNotMergedCoastsPoints += fb.GetPointsCount();
       }

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -432,6 +432,12 @@ void FeatureBuilder1::SetOsmId(osm::Id id)
   m_osmIds.assign(1, id);
 }
 
+osm::Id FeatureBuilder1::GetFirstOsmId() const
+{
+  ASSERT(!m_osmIds.empty(), ());
+  return m_osmIds.front();
+}
+
 osm::Id FeatureBuilder1::GetLastOsmId() const
 {
   ASSERT(!m_osmIds.empty(), ());

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -155,6 +155,7 @@ public:
   //@{
   void AddOsmId(osm::Id id);
   void SetOsmId(osm::Id id);
+  osm::Id GetFirstOsmId() const;
   osm::Id GetLastOsmId() const;
   bool HasOsmId(osm::Id const & id) const;
   string GetOsmIdsString() const;


### PR DESCRIPTION
Меня задолбало, что при ошибке мёржа костлайнов присылается длиннющая бесполезная простыня. Этот PR заменяет сообщение на простое, с идентификаторами только крайних линий.