### PR TITLE
[new downloader] Calculating for statuses for group mwm.

### DIFF
--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1225,7 +1225,7 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   storage.GetNodeAttrs("Algeria", nodeAttrs);
   TEST_EQUAL(nodeAttrs.m_mwmCounter, 2, ());
   TEST_EQUAL(nodeAttrs.m_mwmSize, 90878678, ());
-  TEST_EQUAL(nodeAttrs.m_status, NodeStatus::OnDisk, ()); // It's a status of expandable node.
+  TEST_EQUAL(nodeAttrs.m_status, NodeStatus::NotDownloaded, ()); // It's a status of expandable node.
   TEST_EQUAL(nodeAttrs.m_error, NodeErrorCode::NoError, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo.size(), 1, ());
   TEST_EQUAL(nodeAttrs.m_parentInfo[0].m_id, "Countries", ());


### PR DESCRIPTION
Привел статусы загрузки для групповых mwm:

This section contains list of previously downloaded maps with their current statuses: (listed according to priority in case of group mwms) in any kind of download process, update available or some errors exist, up-to-date with no fragments to download and up-to-date with some fragments to download. Groups of mwms inherit their statuses.

@igrechuhin @syershov  PTAL

https://jira.mail.ru/browse/MAPSME-22