### PR TITLE
[generator] Support names with spaces in generate_mwm.sh

### DIFF
--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -102,9 +102,8 @@ if [ "$SOURCE_TYPE" == "pbf" -o "$SOURCE_TYPE" == "bz2" -o "$SOURCE_TYPE" == "os
   SOURCE_TYPE=o5m
 fi
 if [ "$SOURCE_TYPE" == "o5m" ]; then
-  INTDIR_FLAG="$INTDIR_FLAG --osm_file_type=o5m --osm_file_name=$SOURCE_FILE"
-  $GENERATOR_TOOL $INTDIR_FLAG --preprocess=true || fail "Preprocessing failed"
-  $GENERATOR_TOOL $INTDIR_FLAG --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME"
+  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --preprocess=true || fail "Preprocessing failed"
+  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME"
 else
   fail "Unsupported source type: $SOURCE_TYPE"
 fi


### PR DESCRIPTION
Давно висела на мне эта задача, нашёл пять минут сделать. Generate_mwm.sh не поддерживал файлы с пробелами в названиях.