### PR TITLE
[new downloader] Show on the map implementation.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -4,6 +4,10 @@
 #include "com/mapswithme/opengl/androidoglcontextfactory.hpp"
 #include "com/mapswithme/platform/Platform.hpp"
 
+#include "map/user_mark.hpp"
+
+#include "storage/storage_helpers.hpp"
+
 #include "drape_frontend/visual_params.hpp"
 #include "drape_frontend/user_event_stream.hpp"
 #include "drape/pointers.hpp"
@@ -209,17 +213,17 @@ Storage & Framework::Storage()
   return m_work.Storage();
 }
 
-void Framework::ShowCountry(TCountryId const & idx, bool zoomToDownloadButton)
+void Framework::ShowNode(TCountryId const & idx, bool zoomToDownloadButton)
 {
   if (zoomToDownloadButton)
   {
-    m2::RectD const rect = m_work.GetCountryBounds(idx);
+    m2::RectD const rect = CalcLimitRect(idx, m_work.Storage(), m_work.CountryInfoGetter());
     double const lon = MercatorBounds::XToLon(rect.Center().x);
     double const lat = MercatorBounds::YToLat(rect.Center().y);
     m_work.ShowRect(lat, lon, 10);
   }
   else
-    m_work.ShowCountry(idx);
+    m_work.ShowNode(idx);
 }
 
 void Framework::Touch(int action, Finger const & f1, Finger const & f2, uint8_t maskedPointer)
@@ -822,7 +826,7 @@ extern "C"
   JNIEXPORT void JNICALL
   Java_com_mapswithme_maps_Framework_nativeShowCountry(JNIEnv * env, jobject thiz, jstring countryId, jboolean zoomToDownloadButton)
   {
-    g_framework->ShowCountry(jni::ToNativeString(env, countryId), (bool) zoomToDownloadButton);
+    g_framework->ShowNode(jni::ToNativeString(env, countryId), (bool) zoomToDownloadButton);
   }
 
   JNIEXPORT void JNICALL

--- a/android/jni/com/mapswithme/maps/Framework.hpp
+++ b/android/jni/com/mapswithme/maps/Framework.hpp
@@ -57,7 +57,7 @@ namespace android
 
     storage::Storage & Storage();
 
-    void ShowCountry(storage::TCountryId const & countryId, bool zoomToDownloadButton);
+    void ShowNode(storage::TCountryId const & countryId, bool zoomToDownloadButton);
 
     void OnLocationError(int/* == location::TLocationStatus*/ newStatus);
     void OnLocationUpdated(location::GpsInfo const & info);

--- a/iphone/Maps/Classes/LocalNotificationManager.mm
+++ b/iphone/Maps/Classes/LocalNotificationManager.mm
@@ -68,9 +68,7 @@ using namespace storage;
     TCountryId const countryId = notificationCountryId.UTF8String;
     [MWMStorage downloadNode:countryId alertController:mapViewController.alertController onSuccess:^
     {
-      auto & f = GetFramework();
-      double const defaultZoom = 10;
-      f.ShowRect(CalcLimitRect(countryId, f.Storage(), f.CountryInfoGetter()));
+      GetFramework().ShowNode(countryId);
     }];
   }
 }

--- a/iphone/Maps/Classes/LocalNotificationManager.mm
+++ b/iphone/Maps/Classes/LocalNotificationManager.mm
@@ -70,7 +70,7 @@ using namespace storage;
     {
       auto & f = GetFramework();
       double const defaultZoom = 10;
-      f.ShowRect(f.GetCountryBounds(countryId), defaultZoom);
+      f.ShowRect(CalcLimitRect(countryId, f.Storage(), f.CountryInfoGetter()));
     }];
   }
 }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -18,6 +18,8 @@
 #include "search/search_engine.hpp"
 #include "search/search_query_factory.hpp"
 
+#include "storage/storage_helpers.hpp"
+
 #include "drape_frontend/color_constants.hpp"
 #include "drape_frontend/gps_track_point.hpp"
 #include "drape_frontend/visual_params.hpp"
@@ -455,17 +457,11 @@ bool Framework::IsWatchFrameRendererInited() const
   return m_cpuDrawer != nullptr;
 }
 
-m2::RectD Framework::GetCountryBounds(storage::TCountryId const & countryId) const
-{
-  CountryFile const & file = m_storage.GetCountryFile(countryId);
-  return GetCountryBounds(file.GetName());
-}
-
-void Framework::ShowCountry(storage::TCountryId const & index)
+void Framework::ShowNode(storage::TCountryId const & countryId)
 {
   StopLocationFollow();
 
-  ShowRect(GetCountryBounds(index));
+  ShowRect(CalcLimitRect(countryId, Storage(), CountryInfoGetter()));
 }
 
 void Framework::UpdateLatestCountryFile(LocalCountryFile const & localFile)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -64,8 +64,6 @@ class CountryInfoGetter;
 
 namespace routing { namespace turns{ class Settings; } }
 
-class StorageBridge;
-
 namespace df
 {
   namespace watch
@@ -187,11 +185,8 @@ public:
       platform::LocalCountryFile const & localFile);
   //@}
 
-  /// Get country rect from borders (not from mwm file).
-  /// @param[in] file Pass country file name without extension as an id.
-  m2::RectD GetCountryBounds(storage::TCountryId const & countryId) const;
-
-  void ShowCountry(storage::TCountryId const & index);
+  /// Shows group or leaf mwm on the map.
+  void ShowNode(storage::TCountryId const & countryId);
 
   /// Checks, whether the country which contains the specified point is loaded.
   bool IsCountryLoaded(m2::PointD const & pt) const;


### PR DESCRIPTION
Реализовал метод: Framework::ShowNode(), который позволяет показать произвольный (групповой или не групповой) узел дерева стран на карте.

Удалил методы: GetCountryBounds и ShowCountry и поправил, чтоб собиралось на iOS и на Android.

Проверил работоспособность метода Framework::ShowNode() на листовых нодах на iOS.

@trashkalmar @igrechuhin Саша, Илья, посмотрите п-та тикет и используйте метод, чтоб клик на п-те меню Show on map корректно отрабатывался.

https://jira.mail.ru/browse/MAPSME-178