### PR TITLE
[new downloader] Implementation new rules for calculating group mwm statuses.

### DIFF
--- a/android/src/com/mapswithme/maps/downloader/CountryItem.java
+++ b/android/src/com/mapswithme/maps/downloader/CountryItem.java
@@ -16,12 +16,14 @@ public final class CountryItem implements Comparable<CountryItem>
 
   // Must correspond to NodeStatus in storage_defines.hpp
   public static final int STATUS_UNKNOWN = 0;
-  public static final int STATUS_FAILED = 1;
-  public static final int STATUS_DONE = 2;
-  public static final int STATUS_DOWNLOADABLE = 3;
-  public static final int STATUS_PROGRESS = 4;
-  public static final int STATUS_ENQUEUED = 5;
-  public static final int STATUS_UPDATABLE = 6;
+
+  public static final int STATUS_PROGRESS = 1;       // Downloading a new mwm or updating an old one.
+  public static final int STATUS_ENQUEUED = 2;       // An mwm is waiting for downloading in the queue.
+  public static final int STATUS_FAILED = 3;         // An error happened while downloading
+  public static final int STATUS_UPDATABLE = 4;      // An update for a downloaded mwm is ready according to counties.txt.
+  public static final int STATUS_DONE = 5;           // Downloaded mwm(s) is up to date. No need to update it.
+  public static final int STATUS_DOWNLOADABLE = 6;   // An mwm can be downloaded but not downloaded yet.
+  public static final int STATUS_PARTLY = 7;         // Leafs of group node has a mix of NotDownloaded and OnDisk status.
 
   // Must correspond to NodeErrorCode in storage_defines.hpp
   public static final int ERROR_NONE = 0;

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -75,12 +75,12 @@ struct NodeAttrs
   /// Status of group and leaf node.
   /// For group nodes it's defined in the following way:
   /// If an mwm in a group has Downloading status the group has Downloading status
-  /// If not and if an mwm in the group has InQueue status the group has InQueue status
-  /// If not and if an mwm in the group has Error status the group has Error status
-  /// If not and if an mwm in the group has OnDiskOutOfDate the group has OnDiskOutOfDate status
-  /// If not and if all the mwms in the group have OnDisk status the group has OnDisk status
-  /// If not and if all the mwms in the group have NotDownloaded status the group has NotDownloaded status
-  /// If not (that means a part of mwms in the group has OnDisk and the other part has NotDownloaded status)
+  /// Otherwise if an mwm in the group has InQueue status the group has InQueue status
+  /// Otherwise if an mwm in the group has Error status the group has Error status
+  /// Otherwise if an mwm in the group has OnDiskOutOfDate the group has OnDiskOutOfDate status
+  /// Otherwise if all the mwms in the group have OnDisk status the group has OnDisk status
+  /// Otherwise if all the mwms in the group have NotDownloaded status the group has NotDownloaded status
+  /// Otherwise (that means a part of mwms in the group has OnDisk and the other part has NotDownloaded status)
   ///   the group has Mixed status
   NodeStatus m_status;
   /// Error code of leaf node. In case of group node |m_error| == NodeErrorCode::NoError.
@@ -503,7 +503,7 @@ private:
   Status CountryStatus(TCountryId const & countryId) const;
 
   /// Returns status for a node (group node or not)
-  StatusAndError NodeStatus(TCountryTreeNode const & node) const;
+  StatusAndError GetNodeStatus(TCountryTreeNode const & node) const;
 
   void NotifyStatusChanged(TCountryId const & countryId);
   void NotifyStatusChangedForHierarchy(TCountryId const & countryId);

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -72,7 +72,18 @@ struct NodeAttrs
   /// So m_downloadingProgress.first <= m_downloadingProgress.second.
   MapFilesDownloader::TProgress m_downloadingProgress;
 
+  /// Status of group and leaf node.
+  /// For group nodes it's defined in the following way:
+  /// If an mwm in a group has Downloading status the group has Downloading status
+  /// If not and if an mwm in the group has InQueue status the group has InQueue status
+  /// If not and if an mwm in the group has Error status the group has Error status
+  /// If not and if an mwm in the group has OnDiskOutOfDate the group has OnDiskOutOfDate status
+  /// If not and if all the mwms in the group have OnDisk status the group has OnDisk status
+  /// If not and if all the mwms in the group have NotDownloaded status the group has NotDownloaded status
+  /// If not (that means a part of mwms in the group has OnDisk and the other part has NotDownloaded status)
+  ///   the group has Mixed status
   NodeStatus m_status;
+  /// Error code of leaf node. In case of group node |m_error| == NodeErrorCode::NoError.
   NodeErrorCode m_error;
 
   /// Indicates if leaf mwm is currently downloaded and connected to storage.
@@ -492,7 +503,7 @@ private:
   Status CountryStatus(TCountryId const & countryId) const;
 
   /// Returns status for a node (group node or not)
-  Status NodeStatus(TCountryTreeNode const & node) const;
+  StatusAndError NodeStatus(TCountryTreeNode const & node) const;
 
   void NotifyStatusChanged(TCountryId const & countryId);
   void NotifyStatusChangedForHierarchy(TCountryId const & countryId);

--- a/storage/storage_defines.cpp
+++ b/storage/storage_defines.cpp
@@ -47,8 +47,8 @@ string DebugPrint(NodeStatus status)
     return string("InQueue");
   case NodeStatus::OnDiskOutOfDate:
     return string("OnDiskOutOfDate");
-  case NodeStatus::Mixed:
-    return string("Mixed");
+  case NodeStatus::Partly:
+    return string("Partly");
   }
 }
 

--- a/storage/storage_defines.cpp
+++ b/storage/storage_defines.cpp
@@ -47,6 +47,8 @@ string DebugPrint(NodeStatus status)
     return string("InQueue");
   case NodeStatus::OnDiskOutOfDate:
     return string("OnDiskOutOfDate");
+  case NodeStatus::Mixed:
+    return string("Mixed");
   }
 }
 

--- a/storage/storage_defines.hpp
+++ b/storage/storage_defines.hpp
@@ -24,15 +24,18 @@ namespace storage
   };
   string DebugPrint(Status status);
 
+  /// \note The order of enum items is important. It is used in Storage::NodeStatus method.
+  /// If it's necessary to add more statuses it's better to add to the end.
   enum class NodeStatus
   {
     Undefined,
-    Error,            /**< An error happened while downloading */
-    OnDisk,           /**< Downloaded mwm(s) is up to date. No need to update it. */
-    NotDownloaded,    /**< Mwm can be download but not downloaded yet. */
     Downloading,      /**< Downloading a new mwm or updating an old one. */
     InQueue,          /**< A mwm is waiting for downloading in the queue. */
+    Error,            /**< An error happened while downloading */
     OnDiskOutOfDate,  /**< An update for a downloaded mwm is ready according to counties.txt. */
+    OnDisk,           /**< Downloaded mwm(s) is up to date. No need to update it. */
+    NotDownloaded,    /**< Mwm can be download but not downloaded yet. */
+    Mixed,            /**< Leafs of group node has a mix of NotDownloaded and OnDisk status. */
   };
   string DebugPrint(NodeStatus status);
 

--- a/storage/storage_defines.hpp
+++ b/storage/storage_defines.hpp
@@ -30,12 +30,12 @@ namespace storage
   {
     Undefined,
     Downloading,      /**< Downloading a new mwm or updating an old one. */
-    InQueue,          /**< A mwm is waiting for downloading in the queue. */
+    InQueue,          /**< An mwm is waiting for downloading in the queue. */
     Error,            /**< An error happened while downloading */
     OnDiskOutOfDate,  /**< An update for a downloaded mwm is ready according to counties.txt. */
     OnDisk,           /**< Downloaded mwm(s) is up to date. No need to update it. */
-    NotDownloaded,    /**< Mwm can be download but not downloaded yet. */
-    Mixed,            /**< Leafs of group node has a mix of NotDownloaded and OnDisk status. */
+    NotDownloaded,    /**< An mwm can be downloaded but not downloaded yet. */
+    Partly,           /**< Leafs of group node has a mix of NotDownloaded and OnDisk status. */
   };
   string DebugPrint(NodeStatus status);
 


### PR DESCRIPTION
Реализация новой логики получения статусов для групповых mwm-ок.
Поведение должно быть такое:
Реализовать объединение статусов групповых элементов согласно следующему ТЗ:
Groups of mwms inherit their statuses according the following rules:
If an mwm in a group has Downloading status the group has Downloading status
If not and if an mwm in the group has InQueue status the group has InQueue status
If not and if an mwm in the group has Error status the group has Error status
If not and if an mwm in the group has OnDiskOutOfDate the group has OnDiskOutOfDate status
If not and if all the mwms in the group have OnDisk status the group has OnDisk status
If not and if all the mwms in the group have NotDownloaded status the group has NotDownloaded status
If not (that means a part of mwms in the group has OnDisk and the other part has NotDownloaded status) the group has Mixed status


Пока прошу не мержить. Завтра поправлю интеграционные storage тесты, чтоб простестировать, как получилось и проверю странное поведение, о котором рассказывал @trashkalmar 

@trashkalmar @ygorshenin @syershov @igrechuhin Посмотрите по возможности.

https://jira.mail.ru/browse/MAPSME-200