### PR TITLE
[new downloader] CountryTree refactoring. Processing affiliations field in countries.txt

### DIFF
--- a/3party/jansson/jansson.pro
+++ b/3party/jansson/jansson.pro
@@ -19,6 +19,7 @@ SOURCES += \
     src/error.c \
     src/strconv.c \
     jansson_handle.cpp \
+    myjansson.cpp \
 
 HEADERS += \
     myjansson.hpp \

--- a/3party/jansson/myjansson.cpp
+++ b/3party/jansson/myjansson.cpp
@@ -37,4 +37,46 @@ void FromJSONObject(json_t * root, string const & field, double & result)
     MYTHROW(my::Json::Exception, ("The field", field, "must contain a json number."));
   result = json_number_value(val);
 }
+
+void FromJSONObject(json_t * root, string const & field, json_int_t & result)
+{
+  if (!json_is_object(root))
+    MYTHROW(my::Json::Exception, ("Bad json object when parsing", field));
+  json_t * val = json_object_get(root, field.c_str());
+  if (!val)
+    MYTHROW(my::Json::Exception, ("Obligatory field", field, "is absent."));
+  if (!json_is_number(val))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json number."));
+  result = json_integer_value(val);
+}
+
+void FromJSONObjectOptionalField(json_t * root, string const & field, string & result)
+{
+  if (!json_is_object(root))
+    MYTHROW(my::Json::Exception, ("Bad json object when parsing", field));
+  json_t * val = json_object_get(root, field.c_str());
+  if (!val)
+  {
+    result = string("");
+    return;
+  }
+  if (!json_is_string(val))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json string."));
+  result = string(json_string_value(val));
+}
+
+void FromJSONObjectOptionalField(json_t * root, string const & field, json_int_t & result)
+{
+  if (!json_is_object(root))
+    MYTHROW(my::Json::Exception, ("Bad json object when parsing", field));
+  json_t * val = json_object_get(root, field.c_str());
+  if (!val)
+  {
+    result = 0;
+    return;
+  }
+  if (!json_is_number(val))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json number."));
+  result = json_integer_value(val);
+}
 }  // namespace my

--- a/3party/jansson/myjansson.cpp
+++ b/3party/jansson/myjansson.cpp
@@ -2,10 +2,7 @@
 
 namespace my
 {
-void FromJSON(json_t * root, string & result)
-{
-  result = string(json_string_value(root));
-}
+void FromJSON(json_t * root, string & result) { result = string(json_string_value(root)); }
 
 void FromJSONObject(json_t * root, string const & field, string & result)
 {

--- a/3party/jansson/myjansson.cpp
+++ b/3party/jansson/myjansson.cpp
@@ -1,0 +1,40 @@
+#include "3party/jansson/myjansson.hpp"
+
+namespace my
+{
+void FromJSON(json_t * root, string & result)
+{
+  result = string(json_string_value(root));
+}
+
+void FromJSONObject(json_t * root, string const & field, string & result)
+{
+  if (!json_is_object(root))
+    MYTHROW(my::Json::Exception, ("Bad json object when parsing", field));
+  json_t * val = json_object_get(root, field.c_str());
+  if (!val)
+    MYTHROW(my::Json::Exception, ("Obligatory field", field, "is absent."));
+  if (!json_is_string(val))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json string."));
+  result = string(json_string_value(val));
+}
+
+void FromJSONObject(json_t * root, string const & field, strings::UniString & result)
+{
+  string s;
+  FromJSONObject(root, field, s);
+  result = strings::MakeUniString(s);
+}
+
+void FromJSONObject(json_t * root, string const & field, double & result)
+{
+  if (!json_is_object(root))
+    MYTHROW(my::Json::Exception, ("Bad json object when parsing", field));
+  json_t * val = json_object_get(root, field.c_str());
+  if (!val)
+    MYTHROW(my::Json::Exception, ("Obligatory field", field, "is absent."));
+  if (!json_is_number(val))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json number."));
+  result = json_number_value(val);
+}
+}  // namespace my

--- a/3party/jansson/myjansson.cpp
+++ b/3party/jansson/myjansson.cpp
@@ -2,7 +2,12 @@
 
 namespace my
 {
-void FromJSON(json_t * root, string & result) { result = string(json_string_value(root)); }
+void FromJSON(json_t * root, string & result)
+{
+  if (!json_is_string(root))
+    MYTHROW(my::Json::Exception, ("The field must contain a json string."));
+  result = string(json_string_value(root));
+}
 
 void FromJSONObject(json_t * root, string const & field, string & result)
 {
@@ -54,7 +59,7 @@ void FromJSONObjectOptionalField(json_t * root, string const & field, string & r
   json_t * val = json_object_get(root, field.c_str());
   if (!val)
   {
-    result = string("");
+    result.clear();
     return;
   }
   if (!json_is_string(val))

--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -33,6 +33,7 @@ void FromJSON(json_t * root, string & result);
 void FromJSONObject(json_t * root, string const & field, string & result);
 void FromJSONObject(json_t * root, string const & field, strings::UniString & result);
 void FromJSONObject(json_t * root, string const & field, double & result);
+void FromJSONObject(json_t * root, string const & field, json_int_t & result);
 
 template <typename T>
 void FromJSONObject(json_t * root, string const & field, vector<T> & result)
@@ -47,4 +48,7 @@ void FromJSONObject(json_t * root, string const & field, vector<T> & result)
   for (size_t i = 0; i < sz; ++i)
     FromJSON(json_array_get(arr, i), result[i]);
 }
+
+void FromJSONObjectOptionalField(json_t * root, string const & field, string & result);
+void FromJSONObjectOptionalField(json_t * root, string const & field, json_int_t & result);
 }  // namespace my

--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -3,8 +3,11 @@
 #include "jansson_handle.hpp"
 
 #include "base/exception.hpp"
+#include "base/string_utils.hpp"
 
 #include <jansson.h>
+
+#include "std/vector.hpp"
 
 namespace my
 {
@@ -25,4 +28,23 @@ public:
 
   json_t * get() const { return m_handle.get(); }
 };
+
+void FromJSON(json_t * root, string & result);
+void FromJSONObject(json_t * root, string const & field, string & result);
+void FromJSONObject(json_t * root, string const & field, strings::UniString & result);
+void FromJSONObject(json_t * root, string const & field, double & result);
+
+template <typename T>
+void FromJSONObject(json_t * root, string const & field, vector<T> & result)
+{
+  json_t * arr = json_object_get(root, field.c_str());
+  if (!arr)
+    MYTHROW(my::Json::Exception, ("Obligatory field", field, "is absent."));
+  if (!json_is_array(arr))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json array."));
+  size_t sz = json_array_size(arr);
+  result.resize(sz);
+  for (size_t i = 0; i < sz; ++i)
+    FromJSON(json_array_get(arr, i), result[i]);
+}
 }  // namespace my

--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -30,6 +30,7 @@ public:
 };
 
 void FromJSON(json_t * root, string & result);
+void FromJSON(json_t * root, json_t *& value) { value = root; }
 void FromJSONObject(json_t * root, string const & field, string & result);
 void FromJSONObject(json_t * root, string const & field, strings::UniString & result);
 void FromJSONObject(json_t * root, string const & field, double & result);
@@ -51,4 +52,21 @@ void FromJSONObject(json_t * root, string const & field, vector<T> & result)
 
 void FromJSONObjectOptionalField(json_t * root, string const & field, string & result);
 void FromJSONObjectOptionalField(json_t * root, string const & field, json_int_t & result);
+
+template <typename T>
+void FromJSONObjectOptionalField(json_t * root, string const & field, vector<T> & result)
+{
+  json_t * arr = json_object_get(root, field.c_str());
+  if (!arr)
+  {
+    result.clear();
+    return;
+  }
+  if (!json_is_array(arr))
+    MYTHROW(my::Json::Exception, ("The field", field, "must contain a json array."));
+  size_t sz = json_array_size(arr);
+  result.resize(sz);
+  for (size_t i = 0; i < sz; ++i)
+    FromJSON(json_array_get(arr, i), result[i]);
+}
 }  // namespace my

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -285,10 +285,10 @@ void Framework::Migrate(bool keepDownloaded)
 
 Framework::Framework()
   : m_storage(platform::migrate::NeedMigrate() ? COUNTRIES_OBSOLETE_FILE : COUNTRIES_FILE)
+  , m_deferredCountryUpdate(milliseconds(300))
   , m_bmManager(*this)
   , m_fixedSearchResults(0)
   , m_lastReportedCountry(kInvalidCountryId)
-  , m_deferredCountryUpdate(seconds(1))
 {
   // Restore map style before classificator loading
   int mapStyle = MapStyleLight;

--- a/storage/country.cpp
+++ b/storage/country.cpp
@@ -38,7 +38,9 @@ class StoreCountriesSingleMwms : public StoreSingleMwmInterface
 
 public:
   StoreCountriesSingleMwms(TCountryTree & countries, TMappingAffiliations & affiliations)
-    : m_countries(countries), m_affiliations(affiliations) {}
+    : m_countries(countries), m_affiliations(affiliations)
+  {
+  }
 
   Country * InsertToCountryTree(TCountryId const & id, uint32_t mapSize, int depth,
                                 TCountryId const & parent) override
@@ -72,8 +74,7 @@ class StoreFile2InfoSingleMwms : public StoreSingleMwmInterface
   map<string, CountryInfo> & m_file2info;
 
 public:
-  StoreFile2InfoSingleMwms(map<string, CountryInfo> & file2info)
-    : m_file2info(file2info) {}
+  StoreFile2InfoSingleMwms(map<string, CountryInfo> & file2info) : m_file2info(file2info) {}
 
   Country * InsertToCountryTree(TCountryId const & id, uint32_t /* mapSize */, int /* depth */,
                                 TCountryId const & /* parent */) override
@@ -83,8 +84,13 @@ public:
     return nullptr;
   }
 
-  void InsertOldMwmMapping(TCountryId const & /* newId */, TCountryId const & /* oldId */) override {}
-  void InsertAffiliation(TCountryId const & /* countryId */, string const & /* affilation */) override {}
+  void InsertOldMwmMapping(TCountryId const & /* newId */, TCountryId const & /* oldId */) override
+  {
+  }
+  void InsertAffiliation(TCountryId const & /* countryId */,
+                         string const & /* affilation */) override
+  {
+  }
   TMappingOldMwm GetMapping() const override
   {
     ASSERT(false, ());
@@ -146,7 +152,7 @@ TMwmSubtreeAttrs LoadGroupSingleMwmsImpl(int depth, json_t * node, TCountryId co
   }
   else
   {
-    mwmCounter = 1; // It's a leaf. Any leaf contains one mwm.
+    mwmCounter = 1;  // It's a leaf. Any leaf contains one mwm.
     mwmSize = nodeSize;
   }
 
@@ -176,8 +182,8 @@ namespace
 class StoreTwoComponentMwmInterface
 {
 public:
-  virtual void Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */,
-                      int depth, TCountryId const & parent) = 0;
+  virtual void Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */, int depth,
+                      TCountryId const & parent) = 0;
 };
 
 class StoreCountriesTwoComponentMwms : public StoreTwoComponentMwmInterface
@@ -185,11 +191,14 @@ class StoreCountriesTwoComponentMwms : public StoreTwoComponentMwmInterface
   TCountryTree & m_countries;
 
 public:
-  StoreCountriesTwoComponentMwms(TCountryTree & countries, TMappingAffiliations & /* affiliations */)
-    : m_countries(countries) {}
+  StoreCountriesTwoComponentMwms(TCountryTree & countries,
+                                 TMappingAffiliations & /* affiliations */)
+    : m_countries(countries)
+  {
+  }
 
-  void Insert(string const & id, uint32_t mapSize, uint32_t routingSize,
-              int depth, TCountryId const & parent) override
+  void Insert(string const & id, uint32_t mapSize, uint32_t routingSize, int depth,
+              TCountryId const & parent) override
   {
     Country country(id, parent);
     if (mapSize)
@@ -208,11 +217,10 @@ class StoreFile2InfoTwoComponentMwms : public StoreTwoComponentMwmInterface
   map<string, CountryInfo> & m_file2info;
 
 public:
-  StoreFile2InfoTwoComponentMwms(map<string, CountryInfo> & file2info)
-    : m_file2info(file2info) {}
+  StoreFile2InfoTwoComponentMwms(map<string, CountryInfo> & file2info) : m_file2info(file2info) {}
 
-  void Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */,
-              int /* depth */, TCountryId const & /* parent */) override
+  void Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */, int /* depth */,
+              TCountryId const & /* parent */) override
   {
     if (mapSize == 0)
       return;
@@ -240,7 +248,8 @@ void LoadGroupTwoComponentMwmsImpl(int depth, json_t * node, TCountryId const & 
   ASSERT_LESS_OR_EQUAL(0, mwmSize, ());
   ASSERT_LESS_OR_EQUAL(0, routingSize, ());
 
-  store.Insert(file, static_cast<uint32_t>(mwmSize), static_cast<uint32_t>(routingSize), depth, parent);
+  store.Insert(file, static_cast<uint32_t>(mwmSize), static_cast<uint32_t>(routingSize), depth,
+               parent);
 
   json_t * children = json_object_get(node, "g");
   if (children)

--- a/storage/country.hpp
+++ b/storage/country.hpp
@@ -23,7 +23,8 @@ class SizeUpdater;
 
 namespace storage
 {
-using TMapping = map<TCountryId, TCountriesSet>;
+using TMappingOldMwm = map<TCountryId, TCountriesSet>;
+using TMappingAffiliations = unordered_multimap<TCountryId, string>;
 
 /// This class keeps all the information about a country in country tree (TCountryTree).
 /// It is guaranteed that every node represent a unique region has a unique |m_name| in country
@@ -79,7 +80,7 @@ using TCountryTreeNode = TCountryTree::Node;
 
 /// @return version of country file or -1 if error was encountered
 int64_t LoadCountries(string const & jsonBuffer, TCountryTree & countries,
-                      TMapping * mapping = nullptr);
+                      TMappingAffiliations & affiliations, TMappingOldMwm * mapping = nullptr);
 
 void LoadCountryFile2CountryInfo(string const & jsonBuffer, map<string, CountryInfo> & id2info,
                                  bool & isSingleMwm);

--- a/storage/country.hpp
+++ b/storage/country.hpp
@@ -58,8 +58,6 @@ public:
   explicit Country(TCountryId const & name, TCountryId const & parent = kInvalidCountryId)
     : m_name(name), m_parent(parent) {}
 
-  bool operator<(Country const & other) const { return Name() < other.Name(); }
-  bool operator==(Country const & other) const { return Name() == other.Name(); }
   void SetFile(platform::CountryFile const & file) { m_file = file; }
   void SetSubtreeAttrs(uint32_t subtreeMwmNumber, size_t subtreeMwmSizeBytes)
   {

--- a/storage/country_tree.hpp
+++ b/storage/country_tree.hpp
@@ -175,6 +175,7 @@ public:
     {
       added = m_countryTree->AddAtDepth(level, value);
     }
+
     ASSERT(added, ());
     m_countryTreeHashTable.insert(make_pair(value.Name(), added));
     return added->Value();
@@ -192,11 +193,9 @@ public:
   /// \returns a poiter item in the tree if found and nullptr otherwise.
   void Find(TKey const & key, vector<Node const *> & found) const
   {
+    found.clear();
     if (IsEmpty())
-    {
-      found.clear(); // Nothing found.
       return;
-    }
 
     if (key == m_countryTree->Value().Name())
       found.push_back(m_countryTree.get());

--- a/storage/country_tree.hpp
+++ b/storage/country_tree.hpp
@@ -47,7 +47,16 @@ public:
     TValue const & Value() const { return m_value; }
     TValue & Value() { return m_value; }
 
-    Node * AddAtDepth(int level, TValue const & value)
+    /// \brief Adds a node to a tree with root == |this|.
+    /// \param level is depth where a node with |value| will be add. |level| == 0 means |this|.
+    /// When the method is called the node |this| exists. So it's wrong call it with |level| == 0.
+    /// If |level| == 1 the node with |value| will be added as a child of this.
+    /// If |level| == 2 the node with |value| will be added as a child of the last added child of the |this|.
+    /// And so on.
+    /// \param value is a value of node which will be added.
+    /// \note This method does not let to add a node to an arbitrary place in the tree.
+    /// It's posible to add children only from "right side".
+    Node * AddAtDepth(size_t level, TValue const & value)
     {
       Node * node = this;
       while (--level > 0 && !node->m_children.empty())
@@ -161,8 +170,7 @@ public:
     return *m_countryTree;
   }
 
-  /// @return reference is valid only up to the next tree structure modification
-  TValue & AddAtDepth(int level, TValue const & value)
+  TValue & AddAtDepth(size_t level, TValue const & value)
   {
     Node * added = nullptr;
     if (level == 0)

--- a/storage/country_tree.hpp
+++ b/storage/country_tree.hpp
@@ -168,7 +168,7 @@ public:
     if (level == 0)
     {
       ASSERT(IsEmpty(), ());
-      m_countryTree = make_unique<Node>(value, nullptr); // Creating the root node.
+      m_countryTree = make_unique<Node>(value, nullptr);  // Creating the root node.
       added = m_countryTree.get();
     }
     else

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -632,7 +632,7 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile,
     platform.MkDir(my::JoinFoldersToPath(platform.WritableDir(), m_dataDir));
   }
 
-  if (m_countries.ChildrenCount() == 0)
+  if (m_countries.IsEmpty())
   {
     string json;
     ReaderPtr<Reader>(GetPlatform().GetReader(pathToCountriesFile)).ReadAsString(json);

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -122,7 +122,7 @@ Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
   : m_downloader(move(mapDownloaderForTesting)), m_currentSlotId(0),
     m_downloadMapOnTheMap(nullptr)
 {
-  m_currentVersion = LoadCountries(referenceCountriesTxtJsonForTesting, m_countries);
+  m_currentVersion = LoadCountries(referenceCountriesTxtJsonForTesting, m_countries, m_affiliations);
   CHECK_LESS_OR_EQUAL(0, m_currentVersion, ("Can't load test countries file"));
 }
 
@@ -185,7 +185,7 @@ void Storage::Migrate(TCountriesVec const & existedCountries)
   Clear();
   m_countries.Clear();
 
-  TMapping mapping;
+  TMappingOldMwm mapping;
   LoadCountriesFile(COUNTRIES_FILE, m_dataDir, &mapping);
 
   vector<TCountryId> prefetchedMaps;
@@ -622,7 +622,7 @@ TCountryId Storage::GetCurrentDownloadingCountryId() const
 }
 
 void Storage::LoadCountriesFile(string const & pathToCountriesFile,
-                                string const & dataDir, TMapping * mapping /* = nullptr */)
+                                string const & dataDir, TMappingOldMwm * mapping /* = nullptr */)
 {
   m_dataDir = dataDir;
 
@@ -636,7 +636,7 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile,
   {
     string json;
     ReaderPtr<Reader>(GetPlatform().GetReader(pathToCountriesFile)).ReadAsString(json);
-    m_currentVersion = LoadCountries(json, m_countries, mapping);
+    m_currentVersion = LoadCountries(json, m_countries, m_affiliations, mapping);
     LOG_SHORT(LINFO, ("Loaded countries list for version:", m_currentVersion));
     if (m_currentVersion < 0)
       LOG(LERROR, ("Can't load countries file", pathToCountriesFile));

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -122,7 +122,8 @@ Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
   : m_downloader(move(mapDownloaderForTesting)), m_currentSlotId(0),
     m_downloadMapOnTheMap(nullptr)
 {
-  m_currentVersion = LoadCountries(referenceCountriesTxtJsonForTesting, m_countries, m_affiliations);
+  m_currentVersion =
+      LoadCountries(referenceCountriesTxtJsonForTesting, m_countries, m_affiliations);
   CHECK_LESS_OR_EQUAL(0, m_currentVersion, ("Can't load test countries file"));
 }
 
@@ -621,8 +622,8 @@ TCountryId Storage::GetCurrentDownloadingCountryId() const
   return IsDownloadInProgress() ? m_queue.front().GetCountryId() : storage::TCountryId();
 }
 
-void Storage::LoadCountriesFile(string const & pathToCountriesFile,
-                                string const & dataDir, TMappingOldMwm * mapping /* = nullptr */)
+void Storage::LoadCountriesFile(string const & pathToCountriesFile, string const & dataDir,
+                                TMappingOldMwm * mapping /* = nullptr */)
 {
   m_dataDir = dataDir;
 

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -342,7 +342,7 @@ public:
   /// \return true if updateInfo is filled correctly and false otherwise.
   bool GetUpdateInfo(TCountryId const & countryId, UpdateInfo & updateInfo) const;
 
-  TMappingAffiliations & GetAffiliations() { return m_affiliations; }
+  TMappingAffiliations const & GetAffiliations() const { return m_affiliations; }
 
   /// \brief Calls |toDo| for each node for subtree with |root|.
   /// For example ForEachInSubtree(GetRootId()) calls |toDo| for every node including

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -193,6 +193,7 @@ private:
 
   // |m_affiliations| is a mapping from countryId to the list of names of
   // geographical objects (such as countries) that encompass this countryId.
+  // Note. Affiliations is inherited from ancestors of the countryId in country tree.
   // |m_affiliations| is filled during Storage initialization or during migration process.
   // It is filled with data of countries.txt (field "affiliations").
   // Once filled |m_affiliations| is not changed.
@@ -583,10 +584,10 @@ void Storage::ForEachInSubtreeAndInQueue(TCountryId const & root, ToDo && toDo) 
 /// Calls functor |toDo| with signature
 /// void(const TCountryId const & parentId, TCountriesVec const & descendantCountryId)
 /// for each ancestor except for the main root of the tree.
-/// |descendantsCountryId| is a vector of country id of descendats of |parentId|.
 /// Note. In case of disputable territories several nodes with the same name may be
 /// present in the country tree. In that case ForEachAncestorExceptForTheRoot calls
-/// |toDo| for parents of each way to the root in the country tree.
+/// |toDo| for parents of each way to the root in the country tree. In case of diamond
+/// trees toDo is called for common part of ways to the root only once.
 template <class ToDo>
 void Storage::ForEachAncestorExceptForTheRoot(TCountryId const & countryId, ToDo && toDo) const
 {

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -203,8 +203,8 @@ private:
 
   void DownloadNextCountryFromQueue();
 
-  void LoadCountriesFile(string const & pathToCountriesFile,
-                         string const & dataDir, TMappingOldMwm * mapping = nullptr);
+  void LoadCountriesFile(string const & pathToCountriesFile, string const & dataDir,
+                         TMappingOldMwm * mapping = nullptr);
 
   void ReportProgress(TCountryId const & countryId, MapFilesDownloader::TProgress const & p);
   void ReportProgressForHierarchy(TCountryId const & countryId,

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -191,12 +191,20 @@ private:
 
   unique_ptr<Storage> m_prefetchStorage;
 
+  // |m_affiliations| is mapping countryIds (mwm file names) to geographical names
+  // which includes the mwm.
+  // |m_affiliations| is filled during Storage initialization or during migration process.
+  // It is filled with data of countries.txt (field "affiliations").
+  // Once filled |m_affiliations| is not changed.
+  // Node. |m_affiliations| is empty in case of countries_obsolete.txt.
+  TMappingAffiliations m_affiliations;
+
   DECLARE_THREAD_CHECKER(m_threadChecker);
 
   void DownloadNextCountryFromQueue();
 
   void LoadCountriesFile(string const & pathToCountriesFile,
-                         string const & dataDir, TMapping * mapping = nullptr);
+                         string const & dataDir, TMappingOldMwm * mapping = nullptr);
 
   void ReportProgress(TCountryId const & countryId, MapFilesDownloader::TProgress const & p);
   void ReportProgressForHierarchy(TCountryId const & countryId,
@@ -333,6 +341,8 @@ public:
   /// \brief Get information for mwm update button.
   /// \return true if updateInfo is filled correctly and false otherwise.
   bool GetUpdateInfo(TCountryId const & countryId, UpdateInfo & updateInfo) const;
+
+  TMappingAffiliations & GetAffiliations() { return m_affiliations; }
 
   /// \brief Calls |toDo| for each node for subtree with |root|.
   /// For example ForEachInSubtree(GetRootId()) calls |toDo| for every node including

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -191,12 +191,12 @@ private:
 
   unique_ptr<Storage> m_prefetchStorage;
 
-  // |m_affiliations| is mapping countryIds (mwm file names) to geographical names
-  // which includes the mwm.
+  // |m_affiliations| is a mapping from countryId to the list of names of
+  // geographical objects (such as countries) that encompass this countryId.
   // |m_affiliations| is filled during Storage initialization or during migration process.
   // It is filled with data of countries.txt (field "affiliations").
   // Once filled |m_affiliations| is not changed.
-  // Node. |m_affiliations| is empty in case of countries_obsolete.txt.
+  // Note. |m_affiliations| is empty in case of countries_obsolete.txt.
   TMappingAffiliations m_affiliations;
 
   DECLARE_THREAD_CHECKER(m_threadChecker);

--- a/storage/storage_tests/simple_tree_test.cpp
+++ b/storage/storage_tests/simple_tree_test.cpp
@@ -19,16 +19,16 @@ struct Calculator
 UNIT_TEST(CountryTree_Smoke)
 {
   typedef CountryTree<int, int>::Node TTree;
-  TTree tree;
+  TTree tree(0, nullptr);
 
-  tree.AddAtDepth(0, 4);
-  tree.AddAtDepth(0, 3);
-  tree.AddAtDepth(0, 5);
-  tree.AddAtDepth(0, 2);
-  tree.AddAtDepth(0, 1);
-  tree.AddAtDepth(1, 20);  // 1 is parent
-  tree.AddAtDepth(1, 10);  // 1 is parent
-  tree.AddAtDepth(1, 30);  // 1 is parent
+  tree.AddAtDepth(1, 4);
+  tree.AddAtDepth(1, 3);
+  tree.AddAtDepth(1, 5);
+  tree.AddAtDepth(1, 2);
+  tree.AddAtDepth(1, 1);
+  tree.AddAtDepth(2, 20);
+  tree.AddAtDepth(2, 10);
+  tree.AddAtDepth(2, 30);
 
   // children test
   TEST_EQUAL(tree.Child(0).Value(), 4, ());
@@ -57,9 +57,4 @@ UNIT_TEST(CountryTree_Smoke)
   Calculator<TTree> c3;
   tree.Child(4).Child(0).ForEachAncestorExceptForTheRoot(c3);
   TEST_EQUAL(c3.count, 1, ());
-
-  tree.Clear();
-  Calculator<TTree> c4;
-  tree.ForEachDescendant(c4);
-  TEST_EQUAL(c4.count, 0, ("Tree should be empty"));
 }

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -51,8 +51,7 @@ string const kMapTestDir = "map-tests";
 
 using TLocalFilePtr = shared_ptr<LocalCountryFile>;
 
-string const kSingleMwmCountriesTxt =
-    string(R"({
+string const kSingleMwmCountriesTxt = string(R"({
            "id": "Countries",
            "v": )" + strings::to_string(version::FOR_TESTING_SINGLE_MWM1) + R"(,
            "g": [
@@ -994,11 +993,11 @@ UNIT_TEST(StorageTest_GetAffiliations)
   string const abkhaziaId = "Abkhazia";
 
   TMappingAffiliations const expectedAffiliations = {{abkhaziaId.c_str(), "Georgia"},
-                                                    {abkhaziaId.c_str(), "Russia"},
-                                                    {abkhaziaId.c_str(), "Europe"}};
+                                                     {abkhaziaId.c_str(), "Russia"},
+                                                     {abkhaziaId.c_str(), "Europe"}};
   auto const rangeResultAffiliations = storage.GetAffiliations().equal_range(abkhaziaId);
   TMappingAffiliations const resultAffiliations(rangeResultAffiliations.first,
-                                               rangeResultAffiliations.second);
+                                                rangeResultAffiliations.second);
   TEST(expectedAffiliations == resultAffiliations, ());
 
   auto const rangeResultNoAffiliations = storage.GetAffiliations().equal_range("Algeria");

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -101,6 +101,10 @@ string const kSingleMwmCountriesTxt = string(R"({
                   "s": 1234,
                   "old": [
                    "Country1"
+                  ],
+                  "affiliations":
+                  [
+                   "Stepchild Land1", "Stepchild Land2"
                   ]
                  },
                  {
@@ -108,8 +112,16 @@ string const kSingleMwmCountriesTxt = string(R"({
                   "s": 1111,
                   "old": [
                    "Country1"
+                  ],
+                  "affiliations":
+                  [
+                   "Child Land1"
                   ]
                  }
+                ],
+                "affiliations":
+                [
+                 "Parent Land1"
                 ]
                },
                {
@@ -127,8 +139,16 @@ string const kSingleMwmCountriesTxt = string(R"({
                   "s": 1234,
                   "old": [
                    "Country2"
+                  ],
+                  "affiliations":
+                  [
+                   "Stepchild Land1", "Stepchild Land2"
                   ]
                  }
+                ],
+                "affiliations":
+                [
+                 "Parent Land2"
                 ]
                }
             ]})");
@@ -990,18 +1010,34 @@ UNIT_TEST(StorageTest_GetChildren)
 UNIT_TEST(StorageTest_GetAffiliations)
 {
   Storage storage(kSingleMwmCountriesTxt, make_unique<TestMapFilesDownloader>());
-  string const abkhaziaId = "Abkhazia";
 
-  TMappingAffiliations const expectedAffiliations = {{abkhaziaId.c_str(), "Georgia"},
-                                                     {abkhaziaId.c_str(), "Russia"},
-                                                     {abkhaziaId.c_str(), "Europe"}};
-  auto const rangeResultAffiliations = storage.GetAffiliations().equal_range(abkhaziaId);
-  TMappingAffiliations const resultAffiliations(rangeResultAffiliations.first,
-                                                rangeResultAffiliations.second);
-  TEST(expectedAffiliations == resultAffiliations, ());
+  string const abkhaziaId = "Abkhazia";
+  TMappingAffiliations const expectedAffiliations1 = {{abkhaziaId.c_str(), "Georgia"},
+                                                      {abkhaziaId.c_str(), "Russia"},
+                                                      {abkhaziaId.c_str(), "Europe"}};
+  auto const rangeResultAffiliations1 = storage.GetAffiliations().equal_range(abkhaziaId);
+  TMappingAffiliations const resultAffiliations1(rangeResultAffiliations1.first,
+                                                 rangeResultAffiliations1.second);
+  TEST(expectedAffiliations1 == resultAffiliations1, ());
 
   auto const rangeResultNoAffiliations = storage.GetAffiliations().equal_range("Algeria");
   TEST(rangeResultNoAffiliations.first == rangeResultNoAffiliations.second, ());
+
+  // Affiliation inheritance.
+  string const disputableId = "Disputable Territory";
+  auto const rangeResultAffiliations2 = storage.GetAffiliations().equal_range(disputableId);
+  TMappingAffiliations const resultAffiliations2(rangeResultAffiliations2.first,
+                                                 rangeResultAffiliations2.second);
+  TMappingAffiliations const expectedAffiliations2 = {{disputableId.c_str(), "Stepchild Land1"},
+                                                      {disputableId.c_str(), "Stepchild Land2"}};
+  TEST(expectedAffiliations2 == resultAffiliations2, ());
+
+  string const indisputableId = "Indisputable Territory Of Country1";
+  auto const rangeResultAffiliations3 = storage.GetAffiliations().equal_range(indisputableId);
+  TMappingAffiliations const resultAffiliations3(rangeResultAffiliations3.first,
+                                                 rangeResultAffiliations3.second);
+  TMappingAffiliations const expectedAffiliations3 = {{indisputableId.c_str(), "Child Land1"}};
+  TEST(expectedAffiliations3 == resultAffiliations3, ());
 }
 
 UNIT_TEST(StorageTest_HasCountryId)

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -61,6 +61,10 @@ string const kSingleMwmCountriesTxt =
                 "s": 4689718,
                 "old": [
                  "Georgia"
+                ],
+                "affiliations":
+                [
+                 "Georgia", "Russia", "Europe"
                 ]
                },
                {
@@ -982,6 +986,23 @@ UNIT_TEST(StorageTest_GetChildren)
   storage.GetChildren("Algeria", algeriaList);
   TEST_EQUAL(algeriaList.size(), 2, ());
   TEST_EQUAL(algeriaList.front(), "Algeria_Central", ());
+}
+
+UNIT_TEST(StorageTest_GetAffiliations)
+{
+  Storage storage(kSingleMwmCountriesTxt, make_unique<TestMapFilesDownloader>());
+  string const abkhaziaId = "Abkhazia";
+
+  TMappingAffiliations const expectedAffiliations = {{abkhaziaId.c_str(), "Georgia"},
+                                                    {abkhaziaId.c_str(), "Russia"},
+                                                    {abkhaziaId.c_str(), "Europe"}};
+  auto const rangeResultAffiliations = storage.GetAffiliations().equal_range(abkhaziaId);
+  TMappingAffiliations const resultAffiliations(rangeResultAffiliations.first,
+                                               rangeResultAffiliations.second);
+  TEST(expectedAffiliations == resultAffiliations, ());
+
+  auto const rangeResultNoAffiliations = storage.GetAffiliations().equal_range("Algeria");
+  TEST(rangeResultNoAffiliations.first == rangeResultNoAffiliations.second, ());
 }
 
 UNIT_TEST(StorageTest_HasCountryId)


### PR DESCRIPTION
1. Рефакториг класса CountryTree. Теперь корень дерева хранится так же, как и ноды (unique_ptr), что позволило удалить ряд "if-ов" при работе с деревом. (Витя и Юра, вы обращали внимание на эту особенность реализации в https://github.com/mapsme/omim/pull/2068 и других PR)

2. Я добавил обработку поля affiliations в countries.txt. Теперь при разборе countries.txt (новый вариант) заполнятся unordered_multimap<TCountryId, string>. Это происходит при инициализации приложения или в процессе миграции со старых mwm на новые. Во время работы программы по CountryId можно получить те строчки, что были записаны в поле affiliations в countries.txt. Предполагается вот такой формат countries.txt:
```
{
 "id": "Countries",
 "v": 160224,
 "g": [
  {
   "id": "Abkhazia",
   "s": 4651119,
   "old": [
    "Georgia"
   ],
   "affiliations": 
   [
    "Georgia", "Europe"
   ]
  },
  {
   "id": "Afghanistan",
   "s": 22288097,
   "old": [
    "Afghanistan"
   ],
   "affiliations":
   [
    "Georgia", 
    "Asia"
   ]
  },
  {
   "id": "Albania",
   "s": 14367480,
   "old": [
    "Albania"
   ]
  },
...
```
Т.е. у некоторых полей может появиться поле affiliations (принадлежность), в котором записан список строчек, описывающих, где находится данная mwm. В данном PR 

@vng @ygorshenin @mpimenov @Zverik Вам определенно стоит взглянуть.

https://jira.mail.ru/browse/MAPSME-193