### PR TITLE
[search][build] Fixed build deps for search quality tools.

### DIFF
--- a/omim.pro
+++ b/omim.pro
@@ -71,6 +71,10 @@ SUBDIRS = 3party base coding geometry editor indexer routing search
   }
   
   CONFIG(desktop) {
+    # Desktop-only support library, used in tests and search quality tools.
+    search_tests_support.subdir = search/search_tests_support
+    SUBDIRS *= search_tests_support
+
     search_quality.subdir = search/search_quality
     search_quality.depends = $$SUBDIRS
 
@@ -87,9 +91,6 @@ SUBDIRS = 3party base coding geometry editor indexer routing search
     # Additional desktop-only, tests-only libraries.
     platform_tests_support.subdir = platform/platform_tests_support
     SUBDIRS *= platform_tests_support
-
-    search_tests_support.subdir = search/search_tests_support
-    SUBDIRS *= search_tests_support
 
     # Tests binaries.
     base_tests.subdir = base/base_tests


### PR DESCRIPTION
search quality tools depends on search_tests_support, so it must be declared first in SUBDIRS.