### PR TITLE
[search] Relax the condition of matching a locality to a country.

### DIFF
--- a/search/v2/geocoder.cpp
+++ b/search/v2/geocoder.cpp
@@ -771,15 +771,9 @@ void Geocoder::FillLocalitiesTable()
         country.m_center = ft.GetCenter();
 
         GetEnglishName(ft, country.m_enName);
-
-        m_infoGetter.GetMatchedRegions(country.m_enName, country.m_ids);
-        if (!country.m_ids.empty())
-        {
-          LOG(LDEBUG, ("Country =", country.m_enName));
-          ++numCountries;
-          m_regions[REGION_TYPE_COUNTRY][make_pair(l.m_startToken, l.m_endToken)].push_back(
-              country);
-        }
+        LOG(LDEBUG, ("Country =", country.m_enName));
+        ++numCountries;
+        m_regions[REGION_TYPE_COUNTRY][{l.m_startToken, l.m_endToken}].push_back(country);
       }
       break;
     default:

--- a/search/v2/locality_scorer.cpp
+++ b/search/v2/locality_scorer.cpp
@@ -8,7 +8,7 @@ namespace v2
 {
 namespace
 {
-const size_t kDefaultReadLimit = 50;
+const size_t kDefaultReadLimit = 100;
 
 bool IsAlmostFullMatch(NameScore score)
 {


### PR DESCRIPTION
It is enough that search model reports a feature to be a country
and there is no need for additional checks. Besides, the infoGetter
check looks broken: "Kingdom of Lesotho" does not have "Lesotho" as
a prefix.

This change cannot be applied to the current implementation of
states checker, however, so the prefix check is infoGetter is not
removed in this CL.