### PR TITLE
[editor] Remove extra fields for some types

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -136,7 +136,7 @@
         <include field="operator" />
       </type>
       <type id="amenity-atm" group="banking">
-        <include group="poi" />
+        <include field="opening_hours" />
         <include field="operator" />
       </type>
       <type id="amenity-bank" group="banking">
@@ -149,7 +149,8 @@
         <include field="internet" />
       </type>
       <type id="amenity-bicycle_rental">
-        <include group="poi" />
+        <include field="website" />
+        <include field="opening_hours" />
         <include field="operator" />
       </type>
       <type id="amenity-bureau_de_change" group="banking">
@@ -368,7 +369,7 @@
         <include group="poi" />
       </type>
       <type id="highway-bus_stop">
-        <include group="poi" />
+        <include field="name" />
         <include field="operator" />
       </type>
       <type id="historic-archaeological_site" group="historic" can_add="no">
@@ -380,15 +381,15 @@
         <include field="wikipedia" />
       </type>
       <type id="historic-memorial" group="historic">
-        <include group="poi" />
+        <include field="name" />
         <include field="wikipedia" />
       </type>
       <type id="historic-monument" group="historic">
-        <include group="poi" />
+        <include field="name" />
         <include field="wikipedia" />
       </type>
       <type id="historic-ruins" group="historic" can_add="no">
-        <include group="poi" />
+        <include field="name" />
         <include field="wikipedia" />
       </type>
       <type id="landuse-cemetery" can_add="no">
@@ -449,15 +450,15 @@
         <include field="wikipedia" />
       </type>
       <type id="place-hamlet" can_add="no">
-        <include group="poi" />
+        <include field="name" />
         <include field="wikipedia" />
       </type>
       <type id="place-village" can_add="no">
-        <include group="poi" />
+        <include field="name" />
         <include field="wikipedia" />
       </type>
       <type id="railway-halt" editable="no" can_add="no">
-        <include group="poi" />
+        <include field="name" />
       </type>
       <type id="railway-station" editable="no" can_add="no">
         <include group="poi" />
@@ -541,7 +542,7 @@
         <include field="operator" />
         <include field="internet" />
       </type>
-      <type id="shop-doityourself" group="shop">
+      <type id="shop-doityourself" group="shop" can_add="no">
         <include group="poi" />
         <include field="operator" />
         <include field="internet" />


### PR DESCRIPTION
Убрал создание `shop=doityourself`, потому что даже осмеры не знают, в чём отличие от `shop=hardware`. Заодно поубирал лишние поля, типа e-mail и address, с мелких POI, вроде остановок.