### PR TITLE
[search] Removed wrong and faulty cache.

### DIFF
--- a/search/v2/features_layer_matcher.cpp
+++ b/search/v2/features_layer_matcher.cpp
@@ -1,6 +1,7 @@
 #include "search/v2/features_layer_matcher.hpp"
 
 #include "search/reverse_geocoder.hpp"
+#include "search/v2/house_to_street_table.hpp"
 
 #include "indexer/scales.hpp"
 
@@ -32,8 +33,6 @@ void FeaturesLayerMatcher::SetContext(MwmContext * context)
     return;
 
   m_context = context;
-  m_houseToStreetTable = HouseToStreetTable::Load(m_context->m_value);
-  ASSERT(m_houseToStreetTable, ());
   m_loader.SetContext(context);
 }
 
@@ -121,10 +120,10 @@ uint32_t FeaturesLayerMatcher::GetMatchingStreetImpl(uint32_t houseId, FeatureTy
     if (ret != streets.end())
       result = ret->m_id.m_index;
   }
-  else
+  else if (m_context->m_houseToStreetTable)
   {
     uint32_t index;
-    if (m_houseToStreetTable->Get(houseId, index) && index < streets.size())
+    if (m_context->m_houseToStreetTable->Get(houseId, index) && index < streets.size())
       result = streets[index].m_id.m_index;
   }
 

--- a/search/v2/features_layer_matcher.hpp
+++ b/search/v2/features_layer_matcher.hpp
@@ -4,7 +4,6 @@
 #include "search/reverse_geocoder.hpp"
 #include "search/v2/features_layer.hpp"
 #include "search/v2/house_numbers_matcher.hpp"
-#include "search/v2/house_to_street_table.hpp"
 #include "search/v2/mwm_context.hpp"
 #include "search/v2/search_model.hpp"
 #include "search/v2/street_vicinity_loader.hpp"
@@ -355,8 +354,6 @@ private:
   // supports only one street for a building, whereas buildings can be
   // located on multiple streets.
   Cache<uint32_t, uint32_t> m_matchingStreetsCache;
-
-  unique_ptr<HouseToStreetTable> m_houseToStreetTable;
 
   StreetVicinityLoader m_loader;
   my::Cancellable const & m_cancellable;

--- a/search/v2/mwm_context.cpp
+++ b/search/v2/mwm_context.cpp
@@ -18,7 +18,9 @@ MwmContext::MwmContext(MwmSet::MwmHandle handle)
   , m_value(*m_handle.GetValue<MwmValue>())
   , m_vector(m_value.m_cont, m_value.GetHeader(), m_value.m_table)
   , m_index(m_value.m_cont.GetReader(INDEX_FILE_TAG), m_value.m_factory)
+  , m_houseToStreetTable(HouseToStreetTable::Load(m_value))
 {
+  ASSERT(m_houseToStreetTable, ());
 }
 
 bool MwmContext::GetFeature(uint32_t index, FeatureType & ft) const

--- a/search/v2/mwm_context.hpp
+++ b/search/v2/mwm_context.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
+#include "search/v2/house_to_street_table.hpp"
+
 #include "indexer/features_vector.hpp"
 #include "indexer/index.hpp"
 #include "indexer/scale_index.hpp"
 
 #include "base/macros.hpp"
+
+#include "std/unique_ptr.hpp"
 
 class MwmValue;
 
@@ -25,6 +29,7 @@ struct MwmContext
   MwmValue & m_value;
   FeaturesVector m_vector;
   ScaleIndex<ModelReaderPtr> m_index;
+  unique_ptr<HouseToStreetTable> m_houseToStreetTable;
 
   inline MwmSet::MwmId const & GetId() const { return m_handle.GetId(); }
   inline string const & GetName() const { return GetInfo()->GetCountryName(); }


### PR DESCRIPTION
All features layer matchers are kept in Geocoder cache, and it's ok since we do not want to re-read street s or buildings vicinities, but it's wrong to keep m_houseToStreetTable in features layer matcher, because:
* HouseToStreetTable contains Reader, therefore, Geocoder actually had been kept Readers to all mwms, even when idle
* there is no reason to keep HouseToStreetTable between search sessions, because it's impossible to use FeaturesLayerMatcher without MwmHandle, and MwmHandle is impossible without MwmValue, and MwmValue contains a Reader.
* we already have a cache of MwmValues in MwmSet, so some kind of caching already exists

@mpimenov PTAL