### PR TITLE
Editor fixes, also reduced mwm size by ~0.5%.

### DIFF
--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -107,38 +107,6 @@ UNIT_TEST(Metadata_ValidateAndFormat_operator)
   md.Drop(Metadata::FMD_OPERATOR);
 }
 
-UNIT_TEST(Metadata_ValidateAndFormat_ele)
-{
-  classificator::Load();
-  Classificator const & c = classif();
-  uint32_t const type_peak = c.GetTypeByPath({ "natural", "peak" });
-
-  FeatureParams params;
-  MetadataTagProcessor p(params);
-  Metadata & md = params.GetMetadata();
-
-  // Ignore tag 'operator' if feature have inappropriate type.
-  p("ele", "123");
-  TEST(md.Empty(), ());
-
-  params.SetType(type_peak);
-  p("ele", "0");
-  TEST(md.Empty(), ());
-
-  params.SetType(type_peak);
-  p("ele", "0,0000");
-  TEST(md.Empty(), ());
-
-  params.SetType(type_peak);
-  p("ele", "0.0");
-  TEST(md.Empty(), ());
-
-  params.SetType(type_peak);
-  p("ele", "123");
-  TEST_EQUAL(md.Get(Metadata::FMD_ELE), "123", ());
-  md.Drop(Metadata::FMD_ELE);
-}
-
 UNIT_TEST(Metadata_ValidateAndFormat_height)
 {
   FeatureParams params;
@@ -155,7 +123,7 @@ UNIT_TEST(Metadata_ValidateAndFormat_height)
   TEST(md.Empty(), ());
 
   p("height", "123");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "123.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "123", ());
   md.Drop(Metadata::FMD_HEIGHT);
 
   p("height", "123.2");
@@ -163,11 +131,11 @@ UNIT_TEST(Metadata_ValidateAndFormat_height)
   md.Drop(Metadata::FMD_HEIGHT);
 
   p("height", "2 m");
-  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "2.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "2", ());
   md.Drop(Metadata::FMD_HEIGHT);
 
   p("height", "3-6");
-  TEST(md.Empty(), ());
+  TEST_EQUAL(md.Get(Metadata::FMD_HEIGHT), "6", ());
 }
 
 UNIT_TEST(Metadata_ValidateAndFormat_building_levels)
@@ -186,7 +154,7 @@ UNIT_TEST(Metadata_ValidateAndFormat_building_levels)
   TEST(md.Empty(), ());
 
   p("building:levels", "1");
-  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1", ());
   md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("building:levels", "3.2");
@@ -194,18 +162,18 @@ UNIT_TEST(Metadata_ValidateAndFormat_building_levels)
   md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("building:levels", "1.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1", ());
   md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
 
   p("building:levels", "1.0");
   p("height", "4.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1", ());
   md.Drop(Metadata::FMD_BUILDING_LEVELS);
 
   p("height", "4.0");
-  p("building:levels", "1.0");
-  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1.0", ());
+  p("building:levels", "1");
+  TEST_EQUAL(md.Get(Metadata::FMD_BUILDING_LEVELS), "1", ());
   md.Drop(Metadata::FMD_BUILDING_LEVELS);
   md.Drop(Metadata::FMD_HEIGHT);
 

--- a/generator/generator_tests/osm2meta_test.cpp
+++ b/generator/generator_tests/osm2meta_test.cpp
@@ -14,3 +14,29 @@ UNIT_TEST(ValidateAndFormat_cuisine_test)
   TEST_EQUAL(tagProc.ValidateAndFormat_cuisine(" ; , "), "", ());
   TEST_EQUAL(tagProc.ValidateAndFormat_cuisine(" Korean bbq;barbeque;grill,bbq; "), "korean_bbq;barbecue;grill", ());
 }
+
+UNIT_TEST(ValidateAndFormat_ele)
+{
+  FeatureParams params;
+  MetadataTagProcessorImpl tagProc(params);
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele(""), "", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("not a number"), "", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("0"), "0", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("0.0"), "0", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("0.0000000"), "0", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("22.5"), "22.5", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("-100.3"), "-100.3", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("99.0000000"), "99", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("8900.000023"), "8900", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("-300.9999"), "-301", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("-300.9"), "-300.9", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("15 m"), "15", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("15.9 m"), "15.9", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("15.9m"), "15.9", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("3000 ft"), "914.4", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("3000ft"), "914.4", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("100 feet"), "30.48", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("100feet"), "30.48", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("11'"), "3.35", ());
+  TEST_EQUAL(tagProc.ValidateAndFormat_ele("11'4\""), "3.45", ());
+}

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -1,5 +1,7 @@
 #include "generator/osm2meta.hpp"
 
+#include "platform/measurement_utils.hpp"
+
 #include "coding/url_encode.hpp"
 
 #include "base/logging.hpp"
@@ -109,13 +111,7 @@ string MetadataTagProcessorImpl::ValidateAndFormat_opening_hours(string const & 
 
 string MetadataTagProcessorImpl::ValidateAndFormat_ele(string const & v) const
 {
-  auto const & isPeak = ftypes::IsPeakChecker::Instance();
-  if (!isPeak(m_params.m_Types))
-    return string();
-  double val = 0;
-  if(!strings::to_double(v, val) || val == 0)
-    return string();
-  return v;
+  return MeasurementUtils::OSMDistanceToMetersString(v);
 }
 
 string MetadataTagProcessorImpl::ValidateAndFormat_turn_lanes(string const & v) const
@@ -159,23 +155,15 @@ string MetadataTagProcessorImpl::ValidateAndFormat_internet(string v) const
 
 string MetadataTagProcessorImpl::ValidateAndFormat_height(string const & v) const
 {
-  double val = 0;
-  string corrected(v, 0, v.find(" "));
-  if(!strings::to_double(corrected, val) || val == 0)
-    return string();
-  ostringstream ss;
-  ss << fixed << setprecision(1) << val;
-  return ss.str();
+  return MeasurementUtils::OSMDistanceToMetersString(v, false /*supportZeroAndNegativeValues*/, 1);
 }
 
 string MetadataTagProcessorImpl::ValidateAndFormat_building_levels(string const & v) const
 {
-  double val = 0;
-  if(!strings::to_double(v, val) || val == 0)
-    return string();
-  ostringstream ss;
-  ss << fixed << setprecision(1) << val;
-  return ss.str();
+  double d;
+  if (!strings::to_double(v, d) || d == 0)
+    return {};
+  return strings::to_string_dac(d, 1);
 }
 
 string MetadataTagProcessorImpl::ValidateAndFormat_denomination(string const & v) const

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -3,9 +3,12 @@
 
 #include "geometry/mercator.hpp"
 
-#include "base/string_utils.hpp"
+#include "base/macros.hpp"
 #include "base/math.hpp"
+#include "base/stl_add.hpp"
+#include "base/string_utils.hpp"
 
+#include "std/cstring.hpp"
 #include "std/iomanip.hpp"
 #include "std/sstream.hpp"
 
@@ -187,6 +190,99 @@ string FormatSpeed(double metersPerSecond)
     break;
   }
   return res;
+}
+
+bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)
+{
+  char * stop;
+  char const * s = osmRawValue.c_str();
+  outMeters = strtod(s, &stop);
+
+  // Not a number, was not parsed at all.
+  if (s == stop)
+    return false;
+
+  if (!isfinite(outMeters))
+    return false;
+
+  switch (*stop)
+  {
+  // Default units - meters.
+  case 0: return true;
+
+  // Feet and probably inches.
+  case '\'':
+    {
+      outMeters = FeetToMeters(outMeters);
+      s = stop + 1;
+      double const inches = strtod(s, &stop);
+      if (s != stop && *stop == '"' && isfinite(inches))
+        outMeters += InchesToMeters(inches);
+      return true;
+    }
+    break;
+
+  // Inches.
+  case '\"': outMeters = InchesToMeters(outMeters); return true;
+
+  // It's probably a range. Use maximum value (if possible) for a range.
+  case '-':
+    {
+      s = stop + 1;
+      double const newValue = strtod(s, &stop);
+      if (s != stop && isfinite(newValue))
+        outMeters = newValue;
+    }
+    break;
+
+  // It's probably a list. Use maximum value (if possible) for a list.
+  case ';':
+    do
+    {
+      s = stop + 1;
+      double const newValue = strtod(s, &stop);
+      if (s == stop)
+        break;
+      if (isfinite(newValue))
+        outMeters = newValue;
+    } while (*stop && *stop == ';');
+    break;
+  }
+
+  while (*stop && isspace(*stop))
+    ++stop;
+
+  // Default units - meters.
+  if (*stop == 0)
+    return true;
+
+  if (strstr(stop, "nmi") == stop)
+    outMeters = NauticalMilesToMeters(outMeters);
+  else if (strstr(stop, "mi") == stop)
+    outMeters = MilesToMeters(outMeters);
+  else if (strstr(stop, "ft") == stop)
+    outMeters = FeetToMeters(outMeters);
+  else if (strstr(stop, "feet") == stop)
+    outMeters = FeetToMeters(outMeters);
+  else if (strstr(stop, "km") == stop)
+    outMeters = outMeters * 1000;
+
+  // Count all other cases as meters.
+  return true;
+}
+
+string OSMDistanceToMetersString(string const & osmRawValue,
+                                 bool supportZeroAndNegativeValues,
+                                 int digitsAfterComma)
+{
+  double meters;
+  if (OSMDistanceToMeters(osmRawValue, meters))
+  {
+    if (!supportZeroAndNegativeValues && meters <= 0)
+      return {};
+    return strings::to_string_dac(meters, digitsAfterComma);
+  }
+  return {};
 }
 
 } // namespace MeasurementUtils

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -235,18 +235,8 @@ bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)
     }
     break;
 
-  // It's probably a list. Use maximum value (if possible) for a list.
-  case ';':
-    do
-    {
-      s = stop + 1;
-      double const newValue = strtod(s, &stop);
-      if (s == stop)
-        break;
-      if (isfinite(newValue))
-        outMeters = newValue;
-    } while (*stop && *stop == ';');
-    break;
+  // It's probably a list. We don't support them.
+  case ';': return false;
   }
 
   while (*stop && isspace(*stop))

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -12,6 +12,8 @@ inline double MilesToMeters(double mi) { return mi * 1609.344; }
 inline double MetersToFeet(double m) { return m * 3.2808399; }
 inline double FeetToMeters(double ft) {  return ft * 0.3048; }
 inline double FeetToMiles(double ft) { return ft * 5280; }
+inline double InchesToMeters(double in) { return in / 39.370; }
+inline double NauticalMilesToMeters(double nmi) { return nmi * 1852; }
 
 /// Takes into an account user settings [metric, imperial]
 /// @param[in] m meters
@@ -36,5 +38,14 @@ string FormatLatLon(double lat, double lon, int dac = 6);
 void FormatLatLon(double lat, double lon, string & latText, string & lonText, int dac = 6);
 string FormatMercator(m2::PointD const & mercator, int dac = 6);
 void FormatMercator(m2::PointD const & mercator, string & lat, string & lon, int dac = 6);
+
+/// Converts OSM distance (height, ele etc.) to meters.
+/// @returns false if fails.
+bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters);
+/// Converts OSM distance (height, ele etc.) to meters string.
+/// @returns empty string on failure.
+string OSMDistanceToMetersString(string const & osmRawValue,
+                                 bool supportZeroAndNegativeValues = true,
+                                 int digitsAfterComma = 2);
 
 }

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -101,3 +101,58 @@ UNIT_TEST(FormatSpeed)
   TEST_EQUAL(FormatSpeed(10), "36km/h", ());
   TEST_EQUAL(FormatSpeed(1), "3.6km/h", ());
 }
+
+UNIT_TEST(OSMDistanceToMetersString)
+{
+  TEST_EQUAL(OSMDistanceToMetersString(""), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("INF"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("NAN"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("not a number"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("10й"), "10", ());
+  TEST_EQUAL(OSMDistanceToMetersString("0"), "0", ());
+  TEST_EQUAL(OSMDistanceToMetersString("0.0"), "0", ());
+  TEST_EQUAL(OSMDistanceToMetersString("0.0000000"), "0", ());
+  TEST_EQUAL(OSMDistanceToMetersString("22.5"), "22.5", ());
+  TEST_EQUAL(OSMDistanceToMetersString("+21.5"), "21.5", ());
+  TEST_EQUAL(OSMDistanceToMetersString("1e+2"), "100", ());
+  TEST_EQUAL(OSMDistanceToMetersString("5 метров"), "5", ());
+  TEST_EQUAL(OSMDistanceToMetersString(" 4.4 "), "4.4", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8-15"), "15", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8-15 ft"), "4.57", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8-й километр"), "8", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10"), "10", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 meters"), "10", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 km"), "10000", ());
+  TEST_EQUAL(OSMDistanceToMetersString("10;20!111"), "20", ());
+  TEST_EQUAL(OSMDistanceToMetersString("10;20\""), "20", ());
+  TEST_EQUAL(OSMDistanceToMetersString("-100.3"), "-100.3", ());
+  TEST_EQUAL(OSMDistanceToMetersString("99.0000000"), "99", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8900.000023"), "8900", ());
+  TEST_EQUAL(OSMDistanceToMetersString("-300.9999"), "-301", ());
+  TEST_EQUAL(OSMDistanceToMetersString("-300.9"), "-300.9", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15 m"), "15", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15.9 m"), "15.9", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15.9m"), "15.9", ());
+  TEST_EQUAL(OSMDistanceToMetersString("3000 ft"), "914.4", ());
+  TEST_EQUAL(OSMDistanceToMetersString("3000ft"), "914.4", ());
+  TEST_EQUAL(OSMDistanceToMetersString("100 feet"), "30.48", ());
+  TEST_EQUAL(OSMDistanceToMetersString("100feet"), "30.48", ());
+  TEST_EQUAL(OSMDistanceToMetersString("3 nmi"), "5556", ());
+  TEST_EQUAL(OSMDistanceToMetersString("3 mi"), "4828.03", ());
+  TEST_EQUAL(OSMDistanceToMetersString("3.3 km"), "3300", ());
+  TEST_EQUAL(OSMDistanceToMetersString("105'"), "32", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11'"), "3.35", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11 3\""), "11", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11 3'"), "11", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11\"'"), "0.28", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11'\""), "3.35", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11'4\""), "3.45", ());
+  TEST_EQUAL(OSMDistanceToMetersString("11\""), "0.28", ());
+  TEST_EQUAL(OSMDistanceToMetersString("100 \""), "100", ());
+
+  TEST_EQUAL(OSMDistanceToMetersString("0", false), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("-15", false), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15.12345", false, 1), "15.1", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15.123", false, 4), "15.123", ());
+  TEST_EQUAL(OSMDistanceToMetersString("15.654321", true, 1), "15.7", ());
+}

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -120,11 +120,12 @@ UNIT_TEST(OSMDistanceToMetersString)
   TEST_EQUAL(OSMDistanceToMetersString("8-15"), "15", ());
   TEST_EQUAL(OSMDistanceToMetersString("8-15 ft"), "4.57", ());
   TEST_EQUAL(OSMDistanceToMetersString("8-й километр"), "8", ());
-  TEST_EQUAL(OSMDistanceToMetersString("8;9;10"), "10", ());
-  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 meters"), "10", ());
-  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 km"), "10000", ());
-  TEST_EQUAL(OSMDistanceToMetersString("10;20!111"), "20", ());
-  TEST_EQUAL(OSMDistanceToMetersString("10;20\""), "20", ());
+  // Do not support lists for distance values.
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 meters"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("8;9;10 km"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("10;20!111"), "", ());
+  TEST_EQUAL(OSMDistanceToMetersString("10;20\""), "", ());
   TEST_EQUAL(OSMDistanceToMetersString("-100.3"), "-100.3", ());
   TEST_EQUAL(OSMDistanceToMetersString("99.0000000"), "99", ());
   TEST_EQUAL(OSMDistanceToMetersString("8900.000023"), "8900", ());


### PR DESCRIPTION
Do not store insignificant zeroes after dot in metadata.
It also fixes https://trello.com/c/vZ1NxG4U/60-building-levels-1-1-0