### PR TITLE
[new downloader] Implementation and using Storage::IsCoutryIdCountryTreeLeaf instead of IsCountryIdInCountryTree.

### DIFF
--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -416,7 +416,7 @@ public:
 
   TCountryId FindCountryIdByFile(string const & name) const;
 
-  bool IsCoutryIdInCountryTree(TCountryId const & countryId) const;
+  bool IsCoutryIdCountryTreeLeaf(TCountryId const & countryId) const;
 
   TLocalAndRemoteSize CountrySizeInBytes(TCountryId const & countryId, MapOptions opt) const;
   platform::CountryFile const & GetCountryFile(TCountryId const & countryId) const;

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -229,7 +229,7 @@ public:
     m_slot = m_storage.Subscribe(
         bind(&CountryDownloaderChecker::OnCountryStatusChanged, this, _1),
         bind(&CountryDownloaderChecker::OnCountryDownloadingProgress, this, _1, _2));
-    TEST(storage.IsCoutryIdInCountryTree(countryId), (m_countryFile));
+    TEST(storage.IsCoutryIdCountryTreeLeaf(countryId), (m_countryFile));
     TEST(!m_transitionList.empty(), (m_countryFile));
   }
 


### PR DESCRIPTION
Баг фиск. Падение при наличии пользовательской карты, имя которой совпадает в узловой нодой.
https://jira.mail.ru/browse/MAPSME-278