### PR TITLE
[search] Fix flickering search results

### DIFF
--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -253,6 +253,9 @@ UNIT_TEST(to_string)
 
   TEST_EQUAL(strings::to_string(123456789123456789ULL), "123456789123456789", ());
   TEST_EQUAL(strings::to_string(-987654321987654321LL), "-987654321987654321", ());
+
+  uint64_t const n = numeric_limits<uint64_t>::max();
+  TEST_EQUAL(strings::to_string(n), "18446744073709551615", ());
 }
 
 UNIT_TEST(to_string_dac)

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -223,6 +223,22 @@ template <typename T> string to_string(T t)
 
 namespace impl
 {
+template <typename T>
+int UpperBoundOnChars()
+{
+  // It's wrong to return just numeric_limits<T>::digits10 + [is
+  // signed] because digits10 for a type T is computed as:
+  //
+  // floor(log10(2 ^ (CHAR_BITS * sizeof(T)))) =
+  // floor(CHAR_BITS * sizeof(T) * log10(2))
+  //
+  // Therefore, due to rounding, we need to compensate possible
+  // error.
+  //
+  // NOTE: following code works only on two-complement systems!
+
+  return numeric_limits<T>::digits10 + is_signed<T>::value + 1;
+}
 
 template <typename T> char * to_string_digits(char * buf, T i)
 {
@@ -238,7 +254,7 @@ template <typename T> char * to_string_digits(char * buf, T i)
 template <typename T> string to_string_signed(T i)
 {
   bool const negative = i < 0;
-  int const sz = numeric_limits<T>::digits10 + 1;
+  int const sz = UpperBoundOnChars<T>();
   char buf[sz];
   char * end = buf + sz;
   char * beg = to_string_digits(end, negative ? -i : i);
@@ -252,7 +268,7 @@ template <typename T> string to_string_signed(T i)
 
 template <typename T> string to_string_unsigned(T i)
 {
-  int const sz = numeric_limits<T>::digits10;
+  int const sz = UpperBoundOnChars<T>();
   char buf[sz];
   char * end = buf + sz;
   char * beg = to_string_digits(end, i);

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -7,6 +7,7 @@
 #include "indexer/categories_holder.hpp"
 #include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
+#include "indexer/feature_algo.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 
@@ -81,12 +82,6 @@ bool PreResult1::LessPriority(PreResult1 const & r1, PreResult1 const & r2)
   return r1.m_info.m_rank > r2.m_info.m_rank;
 }
 
-// static
-bool PreResult1::LessPointsForViewport(PreResult1 const & r1, PreResult1 const & r2)
-{
-  return r1.m_id < r2.m_id;
-}
-
 PreResult2::PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD const & pivot,
                        string const & displayName, string const & fileName)
   : m_id(f.GetID()),
@@ -100,10 +95,9 @@ PreResult2::PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD c
 
   m_types.SortBySpec();
 
-  m2::PointD fCenter;
-  fCenter = f.GetLimitRect(FeatureType::WORST_GEOMETRY).Center();
+  auto const center = feature::GetCenter(f);
 
-  m_region.SetParams(fileName, fCenter);
+  m_region.SetParams(fileName, center);
   m_distance = PointDistance(GetCenter(), pivot);
 
   ProcessMetadata(f, m_metadata);
@@ -213,22 +207,6 @@ Result PreResult2::GenerateFinalResult(storage::CountryInfoGetter const & infoGe
     ASSERT_EQUAL(m_resultType, RESULT_LATLON, ());
     return Result(GetCenter(), m_str, address);
   }
-}
-
-// static
-bool PreResult2::LessRank(PreResult2 const & r1, PreResult2 const & r2)
-{
-  if (r1.m_info.m_rank != r2.m_info.m_rank)
-    return r1.m_info.m_rank > r2.m_info.m_rank;
-  return r1.m_distance < r2.m_distance;
-}
-
-// static
-bool PreResult2::LessDistance(PreResult2 const & r1, PreResult2 const & r2)
-{
-  if (r1.m_distance != r2.m_distance)
-    return r1.m_distance < r2.m_distance;
-  return r1.m_info.m_rank > r2.m_info.m_rank;
 }
 
 bool PreResult2::StrictEqualF::operator() (PreResult2 const & r) const

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -82,23 +82,22 @@ bool PreResult1::LessPriority(PreResult1 const & r1, PreResult1 const & r2)
   return r1.m_info.m_rank > r2.m_info.m_rank;
 }
 
-PreResult2::PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD const & pivot,
-                       string const & displayName, string const & fileName)
-  : m_id(f.GetID()),
-    m_types(f),
-    m_str(displayName),
-    m_resultType(ftypes::IsBuildingChecker::Instance()(m_types) ? RESULT_BUILDING : RESULT_FEATURE),
-    m_geomType(f.GetFeatureType())
+PreResult2::PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD const & center,
+                       m2::PointD const & pivot, string const & displayName,
+                       string const & fileName)
+  : m_id(f.GetID())
+  , m_types(f)
+  , m_str(displayName)
+  , m_resultType(ftypes::IsBuildingChecker::Instance()(m_types) ? RESULT_BUILDING : RESULT_FEATURE)
+  , m_geomType(f.GetFeatureType())
 {
   ASSERT(m_id.IsValid(), ());
   ASSERT(!m_types.Empty(), ());
 
   m_types.SortBySpec();
 
-  auto const center = feature::GetCenter(f);
-
   m_region.SetParams(fileName, center);
-  m_distance = PointDistance(GetCenter(), pivot);
+  m_distance = PointDistance(center, pivot);
 
   ProcessMetadata(f, m_metadata);
 }

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -40,7 +40,6 @@ public:
 
   static bool LessRank(PreResult1 const & r1, PreResult1 const & r2);
   static bool LessPriority(PreResult1 const & r1, PreResult1 const & r2);
-  static bool LessPointsForViewport(PreResult1 const & r1, PreResult1 const & r2);
 
   inline FeatureID GetID() const { return m_id; }
   inline double GetPriority() const { return m_priority; }
@@ -86,9 +85,6 @@ public:
   Result GenerateFinalResult(storage::CountryInfoGetter const & infoGetter,
                              CategoriesHolder const * pCat, set<uint32_t> const * pTypes,
                              int8_t locale, ReverseGeocoder const & coder) const;
-
-  static bool LessRank(PreResult2 const & r1, PreResult2 const & r2);
-  static bool LessDistance(PreResult2 const & r1, PreResult2 const & r2);
 
   /// Filter equal features for different mwm's.
   class StrictEqualF

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -64,8 +64,8 @@ public:
   };
 
   /// For RESULT_FEATURE and RESULT_BUILDING.
-  PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD const & pivot,
-             string const & displayName, string const & fileName);
+  PreResult2(FeatureType const & f, PreResult1 const * p, m2::PointD const & center,
+             m2::PointD const & pivot, string const & displayName, string const & fileName);
 
   /// For RESULT_LATLON.
   PreResult2(double lat, double lon);

--- a/search/search_query.cpp
+++ b/search/search_query.cpp
@@ -51,6 +51,7 @@
 #include "std/function.hpp"
 #include "std/iterator.hpp"
 #include "std/limits.hpp"
+#include "std/random.hpp"
 
 #define LONG_OP(op)    \
   {                    \
@@ -162,6 +163,27 @@ void RemoveDuplicatingLinear(vector<IndexedValue> & indV)
                     }),
              indV.end());
 }
+
+m2::RectD NormalizeViewport(m2::RectD viewport)
+{
+  double constexpr kMinViewportRadiusM = 5.0 * 1000;
+  double constexpr kMaxViewportRadiusM = 50.0 * 1000;
+
+  m2::RectD minViewport =
+      MercatorBounds::RectByCenterXYAndSizeInMeters(viewport.Center(), kMinViewportRadiusM);
+  viewport.Add(minViewport);
+
+  m2::RectD maxViewport =
+      MercatorBounds::RectByCenterXYAndSizeInMeters(viewport.Center(), kMaxViewportRadiusM);
+  VERIFY(viewport.Intersect(maxViewport), ());
+  return viewport;
+}
+
+m2::RectD GetRectAroundPosition(m2::PointD const & position)
+{
+  double constexpr kMaxPositionRadiusM = 50.0 * 1000;
+  return MercatorBounds::RectByCenterXYAndSizeInMeters(position, kMaxPositionRadiusM);
+}
 }  // namespace
 
 // static
@@ -205,6 +227,22 @@ void Query::SetLanguage(int id, int8_t lang)
 int8_t Query::GetLanguage(int id) const
 {
   return m_keywordsScorer.GetLanguage(GetLangIndex(id));
+}
+
+m2::PointD Query::GetPivotPoint() const
+{
+  m2::RectD const & viewport = m_viewport[CURRENT_V];
+  if (viewport.IsPointInside(GetPosition()))
+    return GetPosition();
+  return viewport.Center();
+}
+
+m2::RectD Query::GetPivotRect() const
+{
+  m2::RectD const & viewport = m_viewport[CURRENT_V];
+  if (viewport.IsPointInside(GetPosition()))
+    return GetRectAroundPosition(GetPosition());
+  return NormalizeViewport(viewport);
 }
 
 void Query::SetViewport(m2::RectD const & viewport, bool forceUpdate)
@@ -549,9 +587,10 @@ class PreResult2Maker
                        search::v2::RankingInfo & info)
   {
     auto const & preInfo = res.GetInfo();
-    m2::PointD pivot = m_params.m_pivot.Center();
 
-    info.m_distanceToPivot = feature::GetMinDistanceMeters(ft, pivot);
+    auto const & pivot = m_params.m_pivotCenter;
+
+    info.m_distanceToPivot = MercatorBounds::DistanceOnEarth(feature::GetCenter(ft), pivot);
     info.m_rank = preInfo.m_rank;
     info.m_searchType = preInfo.m_searchType;
 
@@ -600,8 +639,7 @@ public:
     string name, country;
     LoadFeature(res1.GetID(), ft, name, country);
 
-    Query::ViewportID const viewportID = static_cast<Query::ViewportID>(res1.GetViewportID());
-    auto res2 = make_unique<impl::PreResult2>(ft, &res1, m_query.GetPosition(viewportID), name, country);
+    auto res2 = make_unique<impl::PreResult2>(ft, &res1, m_query.GetPosition(), name, country);
     search::v2::RankingInfo info;
     InitRankingInfo(ft, res1, info);
     res2->SetRankingInfo(move(info));
@@ -668,9 +706,17 @@ void Query::MakePreResult2(v2::Geocoder::Params const & params, vector<T> & cont
     for (; e != m_results.end() && e->GetPriority() == lastPriority; ++e)
       ;
 
-    // TODO (@y, @m, @vng): this method is deprecated, need to rewrite
-    // it.
-    random_shuffle(b, e);
+    // The main reason of shuffling here is to select a random subset
+    // from the low-priority results. We're using a linear congruental
+    // method with default seed because it is fast, simple and doesn't
+    // need an external entropy source.
+    //
+    // TODO (@y, @m, @vng): consider to take some kind of hash from
+    // features and then select a subset with smallest values of this
+    // hash.  In this case this subset of results will be persistent
+    // to small changes in the original set.
+    minstd_rand engine;
+    shuffle(b, e, engine);
   }
   theSet.insert(m_results.begin(), m_results.begin() + min(m_results.size(), kPreResultsCount));
 
@@ -1640,17 +1686,6 @@ m2::RectD const & Query::GetViewport(ViewportID vID /*= DEFAULT_V*/) const
 
   ASSERT(m_viewport[CURRENT_V].IsValid(), ());
   return m_viewport[CURRENT_V];
-}
-
-m2::PointD Query::GetPosition(ViewportID vID /*= DEFAULT_V*/) const
-{
-  switch (vID)
-  {
-  case LOCALITY_V:      // center of the founded locality
-    return m_viewport[vID].Center();
-  default:
-    return m_pivot;
-  }
 }
 
 string DebugPrint(Query::ViewportID viewportId)

--- a/search/search_query.cpp
+++ b/search/search_query.cpp
@@ -566,13 +566,16 @@ class PreResult2Maker
   unique_ptr<Index::FeaturesLoaderGuard> m_pFV;
 
   // For the best performance, incoming id's should be sorted by id.first (mwm file id).
-  void LoadFeature(FeatureID const & id, FeatureType & f, string & name, string & country)
+  void LoadFeature(FeatureID const & id, FeatureType & f, m2::PointD & center, string & name,
+                   string & country)
   {
     if (m_pFV.get() == 0 || m_pFV->GetId() != id.m_mwmId)
       m_pFV.reset(new Index::FeaturesLoaderGuard(m_query.m_index, id.m_mwmId));
 
     m_pFV->GetFeatureByIndex(id.m_index, f);
     f.SetID(id);
+
+    center = feature::GetCenter(f);
 
     m_query.GetBestMatchName(f, name);
 
@@ -583,14 +586,14 @@ class PreResult2Maker
       country = m_pFV->GetCountryFileName();
   }
 
-  void InitRankingInfo(FeatureType const & ft, impl::PreResult1 const & res,
-                       search::v2::RankingInfo & info)
+  void InitRankingInfo(FeatureType const & ft, m2::PointD const & center,
+                       impl::PreResult1 const & res, search::v2::RankingInfo & info)
   {
     auto const & preInfo = res.GetInfo();
 
-    auto const & pivot = m_params.m_pivotCenter;
+    auto const & pivot = m_params.m_accuratePivotCenter;
 
-    info.m_distanceToPivot = MercatorBounds::DistanceOnEarth(feature::GetCenter(ft), pivot);
+    info.m_distanceToPivot = MercatorBounds::DistanceOnEarth(center, pivot);
     info.m_rank = preInfo.m_rank;
     info.m_searchType = preInfo.m_searchType;
 
@@ -620,10 +623,34 @@ class PreResult2Maker
 
     if (info.m_searchType == v2::SearchModel::SEARCH_TYPE_BUILDING)
     {
-      string houseNumber = ft.GetHouseNumber();
+      string const houseNumber = ft.GetHouseNumber();
       auto score = GetNameScore(houseNumber, m_params, preInfo.m_startToken, preInfo.m_endToken);
       if (score > info.m_nameScore)
         info.m_nameScore = score;
+    }
+  }
+
+  uint8_t NormalizeRank(uint8_t rank, v2::SearchModel::SearchType type, m2::PointD const & center,
+                        string const & country)
+  {
+    switch (type)
+    {
+    case v2::SearchModel::SEARCH_TYPE_VILLAGE: return rank /= 1.5;
+    case v2::SearchModel::SEARCH_TYPE_CITY:
+    {
+      if (m_query.GetViewport(Query::CURRENT_V).IsPointInside(center))
+        return rank * 2;
+
+      storage::CountryInfo info;
+      if (country.empty())
+        m_query.m_infoGetter.GetRegionInfo(center, info);
+      else
+        m_query.m_infoGetter.GetRegionInfo(country, info);
+      if (info.IsNotEmpty() && info.m_name == m_query.GetPivotRegion())
+        return rank *= 1.7;
+    }
+    case v2::SearchModel::SEARCH_TYPE_COUNTRY: return rank /= 1.5;
+    default: return rank;
     }
   }
 
@@ -636,40 +663,19 @@ public:
   unique_ptr<impl::PreResult2> operator()(impl::PreResult1 const & res1)
   {
     FeatureType ft;
-    string name, country;
-    LoadFeature(res1.GetID(), ft, name, country);
+    m2::PointD center;
+    string name;
+    string country;
 
-    auto res2 = make_unique<impl::PreResult2>(ft, &res1, m_query.GetPosition(), name, country);
+    LoadFeature(res1.GetID(), ft, center, name, country);
+
+    auto res2 = make_unique<impl::PreResult2>(ft, &res1, center, m_query.GetPosition() /* pivot */,
+                                              name, country);
+
     search::v2::RankingInfo info;
-    InitRankingInfo(ft, res1, info);
+    InitRankingInfo(ft, center, res1, info);
+    info.m_rank = NormalizeRank(info.m_rank, info.m_searchType, center, country);
     res2->SetRankingInfo(move(info));
-
-    /// @todo: add exluding of states (without USA states), continents
-    using namespace ftypes;
-    Type const tp = IsLocalityChecker::Instance().GetType(res2->m_types);
-    switch (tp)
-    {
-      case COUNTRY:
-        res2->m_info.m_rank /= 1.5;
-        break;
-      case CITY:
-      case TOWN:
-        if (m_query.GetViewport(Query::CURRENT_V).IsPointInside(res2->GetCenter()))
-          res2->m_info.m_rank *= 2;
-        else
-        {
-          storage::CountryInfo ci;
-          res2->m_region.GetRegion(m_query.m_infoGetter, ci);
-          if (ci.IsNotEmpty() && ci.m_name == m_query.GetPivotRegion())
-            res2->m_info.m_rank *= 1.7;
-        }
-        break;
-      case VILLAGE:
-        res2->m_info.m_rank /= 1.5;
-        break;
-      default:
-        break;
-    }
 
     return res2;
   }
@@ -707,9 +713,9 @@ void Query::MakePreResult2(v2::Geocoder::Params const & params, vector<T> & cont
       ;
 
     // The main reason of shuffling here is to select a random subset
-    // from the low-priority results. We're using a linear congruental
-    // method with default seed because it is fast, simple and doesn't
-    // need an external entropy source.
+    // from the low-priority results. We're using a linear
+    // congruential method with default seed because it is fast,
+    // simple and doesn't need an external entropy source.
     //
     // TODO (@y, @m, @vng): consider to take some kind of hash from
     // features and then select a subset with smallest values of this

--- a/search/search_query.hpp
+++ b/search/search_query.hpp
@@ -80,9 +80,12 @@ public:
   /// @param[in]  forceUpdate Pass true (default) to recache feature's ids even
   /// if viewport is a part of the old cached rect.
   void SetViewport(m2::RectD const & viewport, bool forceUpdate);
+
+  // TODO (@y): this function must be removed.
   void SetRankPivot(m2::PointD const & pivot);
   inline string const & GetPivotRegion() const { return m_region; }
   inline void SetPosition(m2::PointD const & position) { m_position = position; }
+  inline m2::PointD const & GetPosition() const { return m_position; }
 
   inline void SetMode(Mode mode) { m_mode = mode; }
   inline void SetSearchInWorld(bool b) { m_worldSearch = b; }
@@ -146,6 +149,9 @@ protected:
   using TMWMVector = vector<shared_ptr<MwmInfo>>;
   using TOffsetsVector = map<MwmSet::MwmId, vector<uint32_t>>;
   using TFHeader = feature::DataHeader;
+
+  m2::PointD GetPivotPoint() const;
+  m2::RectD GetPivotRect() const;
 
   void SetViewportByIndex(TMWMVector const & mwmsInfo, m2::RectD const & viewport, size_t idx,
                           bool forceUpdate);
@@ -223,8 +229,6 @@ protected:
   //@{
   /// @return Rect for viewport-distance calculation.
   m2::RectD const & GetViewport(ViewportID vID = DEFAULT_V) const;
-  /// @return Control point for distance-to calculation.
-  m2::PointD GetPosition(ViewportID vID = DEFAULT_V) const;
   //@}
 
   void SetLanguage(int id, int8_t lang);

--- a/search/v2/geocoder.cpp
+++ b/search/v2/geocoder.cpp
@@ -399,7 +399,10 @@ bool SameMwm(Geocoder::TResult const & lhs, Geocoder::TResult const & rhs)
 }  // namespace
 
 // Geocoder::Params --------------------------------------------------------------------------------
-Geocoder::Params::Params() : m_mode(Mode::Everywhere), m_pivotCenter(0, 0), m_maxNumResults(0) {}
+Geocoder::Params::Params()
+  : m_mode(Mode::Everywhere), m_accuratePivotCenter(0, 0), m_maxNumResults(0)
+{
+}
 
 // Geocoder::Geocoder ------------------------------------------------------------------------------
 Geocoder::Geocoder(Index & index, storage::CountryInfoGetter const & infoGetter)
@@ -1312,7 +1315,7 @@ void Geocoder::FillMissingFieldsInResults()
 
   if (m_results->size() > m_params.m_maxNumResults)
   {
-    m_pivotFeatures.SetPosition(m_params.m_pivotCenter, m_params.m_scale);
+    m_pivotFeatures.SetPosition(m_params.m_accuratePivotCenter, m_params.m_scale);
     for (auto & result : *m_results)
     {
       auto const & id = result.first;

--- a/search/v2/geocoder.cpp
+++ b/search/v2/geocoder.cpp
@@ -399,7 +399,7 @@ bool SameMwm(Geocoder::TResult const & lhs, Geocoder::TResult const & rhs)
 }  // namespace
 
 // Geocoder::Params --------------------------------------------------------------------------------
-Geocoder::Params::Params() : m_mode(Mode::Everywhere), m_maxNumResults(0) {}
+Geocoder::Params::Params() : m_mode(Mode::Everywhere), m_pivotCenter(0, 0), m_maxNumResults(0) {}
 
 // Geocoder::Geocoder ------------------------------------------------------------------------------
 Geocoder::Geocoder(Index & index, storage::CountryInfoGetter const & infoGetter)
@@ -1312,7 +1312,7 @@ void Geocoder::FillMissingFieldsInResults()
 
   if (m_results->size() > m_params.m_maxNumResults)
   {
-    m_pivotFeatures.SetPosition(m_params.m_pivot.Center(), m_params.m_scale);
+    m_pivotFeatures.SetPosition(m_params.m_pivotCenter, m_params.m_scale);
     for (auto & result : *m_results)
     {
       auto const & id = result.first;

--- a/search/v2/geocoder.hpp
+++ b/search/v2/geocoder.hpp
@@ -80,9 +80,12 @@ public:
     // We need to pass both pivot and pivot center because pivot is
     // usually a rectangle created by radius and center, and due to
     // precision loss, |m_pivot|.Center() may differ from
-    // |m_pivotCenter|.
+    // |m_accuratePivotCenter|. Therefore |m_pivot| should be used for
+    // fast filtering of features outside of the rectangle, while
+    // |m_accuratePivotCenter| should be used when it's needed to
+    // compute a distance from a feature to the pivot.
     m2::RectD m_pivot;
-    m2::PointD m_pivotCenter;
+    m2::PointD m_accuratePivotCenter;
     size_t m_maxNumResults;
   };
 

--- a/search/v2/geocoder.hpp
+++ b/search/v2/geocoder.hpp
@@ -76,7 +76,13 @@ public:
     Params();
 
     Mode m_mode;
+
+    // We need to pass both pivot and pivot center because pivot is
+    // usually a rectangle created by radius and center, and due to
+    // precision loss, |m_pivot|.Center() may differ from
+    // |m_pivotCenter|.
     m2::RectD m_pivot;
+    m2::PointD m_pivotCenter;
     size_t m_maxNumResults;
   };
 

--- a/search/v2/search_query_v2.cpp
+++ b/search/v2/search_query_v2.cpp
@@ -13,30 +13,6 @@ namespace search
 {
 namespace v2
 {
-namespace
-{
-m2::RectD NormalizeViewport(m2::RectD viewport)
-{
-  double constexpr kMinViewportRadiusM = 5.0 * 1000;
-  double constexpr kMaxViewportRadiusM = 50.0 * 1000;
-
-  m2::RectD minViewport =
-      MercatorBounds::RectByCenterXYAndSizeInMeters(viewport.Center(), kMinViewportRadiusM);
-  viewport.Add(minViewport);
-
-  m2::RectD maxViewport =
-      MercatorBounds::RectByCenterXYAndSizeInMeters(viewport.Center(), kMaxViewportRadiusM);
-  VERIFY(viewport.Intersect(maxViewport), ());
-  return viewport;
-}
-
-m2::RectD GetRectAroundPosition(m2::PointD const & position)
-{
-  double constexpr kMaxPositionRadiusM = 50.0 * 1000;
-  return MercatorBounds::RectByCenterXYAndSizeInMeters(position, kMaxPositionRadiusM);
-}
-}  // namespace
-
 SearchQueryV2::SearchQueryV2(Index & index, CategoriesHolder const & categories,
                              vector<Suggest> const & suggests,
                              storage::CountryInfoGetter const & infoGetter)
@@ -66,12 +42,8 @@ void SearchQueryV2::Search(Results & res, size_t resCount)
   InitParams(false /* localitySearch */, params);
   params.m_mode = m_mode;
 
-  m2::RectD const & viewport = m_viewport[CURRENT_V];
-  if (viewport.IsPointInside(m_position))
-    params.m_pivot = GetRectAroundPosition(m_position);
-  else
-    params.m_pivot = NormalizeViewport(viewport);
-
+  params.m_pivot = GetPivotRect();
+  params.m_pivotCenter = GetPivotPoint();
   params.m_maxNumResults = max(resCount, kPreResultsCount);
   m_geocoder.SetParams(params);
 

--- a/search/v2/search_query_v2.cpp
+++ b/search/v2/search_query_v2.cpp
@@ -43,7 +43,7 @@ void SearchQueryV2::Search(Results & res, size_t resCount)
   params.m_mode = m_mode;
 
   params.m_pivot = GetPivotRect();
-  params.m_pivotCenter = GetPivotPoint();
+  params.m_accuratePivotCenter = GetPivotPoint();
   params.m_maxNumResults = max(resCount, kPreResultsCount);
   m_geocoder.SetParams(params);
 

--- a/std/random.hpp
+++ b/std/random.hpp
@@ -7,6 +7,7 @@
 #include <random>
 
 using std::default_random_engine;
+using std::minstd_rand;
 using std::mt19937;
 using std::uniform_int_distribution;
 


### PR DESCRIPTION
 Because of precision errors when pivot rectange is calculated from a position, a significant error was in computations of distance from search results to the pivot rectangle center. This PR resolves this issue, and, as a side effect, resolves a problem with buggy integral to string conversion.

@vng @mpimenov PTAL