### PR TITLE
[ios] Fixed assert for unsupported cell types in Place Page.

### DIFF
--- a/iphone/Maps/Classes/MWMPlacePageEntity.mm
+++ b/iphone/Maps/Classes/MWMPlacePageEntity.mm
@@ -108,12 +108,6 @@ void initFieldsMap()
       case Metadata::FMD_INTERNET:
         [self setMetaField:gMetaFieldsMap[type] value:L(@"WiFi_available").UTF8String];
         break;
-      case Metadata::FMD_ELE:
-        [self setMetaField:gMetaFieldsMap[type] value:"▲" + m_info.GetElevationFormatted()];
-        break;
-      case Metadata::FMD_STARS:
-        [self setMetaField:gMetaFieldsMap[type] value:m_info.FormatStars()];
-        break;
       default:
         break;
     }


### PR DESCRIPTION
Ассерт падал в дебаге на объектах со звездочками или горах. Например, отель adagio в Москве.