### PR TITLE
[editor] Remove atm fields

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -135,14 +135,15 @@
         <include field="ele" />
         <include field="operator" />
       </type>
-      <type id="amenity-atm" group="banking">
+      <type id="amenity-atm" group="banking" priority="low">
         <include field="opening_hours" />
         <include field="operator" />
       </type>
       <type id="amenity-bank" group="banking">
         <include group="poi" />
         <include field="operator" />
-        <include field="atm" />
+        <!-- Uncomment this and other atm fields when the code supports it. -->
+        <!--include field="atm" /-->
       </type>
       <type id="amenity-bar" group="food">
         <include group="poi" />
@@ -157,7 +158,7 @@
       <type id="amenity-bureau_de_change" group="banking">
         <include group="poi" />
         <include field="operator" />
-        <include field="atm" />
+        <!--include field="atm" /-->
       </type>
       <type id="amenity-bus_station">
         <include group="poi" />

--- a/editor/editor_config.cpp
+++ b/editor/editor_config.cpp
@@ -61,6 +61,7 @@ bool TypeDescriptionFromXml(pugi::xml_node const & root, pugi::xml_node const & 
       return;
     }
 
+    // TODO(mgsergio): Add support for non-metadata fields like atm, wheelchair, toilet etc.
     auto const it = kNamesToFMD.find(fieldName);
     ASSERT(it != end(kNamesToFMD), ("Wrong field:", fieldName));
     outDesc.m_editableFields.push_back(it->second);


### PR DESCRIPTION
Добавление поля `atm` в банки и обмен валют сломало матчинг типов. Закомментировал поле и добавил TODO.