### PR TITLE
Tuned instant animation

### DIFF
--- a/drape_frontend/animation_utils.cpp
+++ b/drape_frontend/animation_utils.cpp
@@ -1,0 +1,18 @@
+#include "drape_frontend/animation_utils.hpp"
+#include "drape_frontend/animation_constants.hpp"
+#include "drape_frontend/visual_params.hpp"
+
+#include "indexer/scales.hpp"
+
+// Zoom level before which animation can not be instant.
+int const kInstantAnimationZoomLevel = 5;
+
+namespace df
+{
+
+bool IsAnimationAllowed(double duration, ScreenBase const & screen)
+{
+  return duration > 0.0 && (duration < kMaxAnimationTimeSec || df::GetDrawTileScale(screen) < kInstantAnimationZoomLevel);
+}
+
+} // namespace df

--- a/drape_frontend/animation_utils.hpp
+++ b/drape_frontend/animation_utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "geometry/screenbase.hpp"
+
+namespace df
+{
+
+bool IsAnimationAllowed(double duration, ScreenBase const & screen);
+
+} // namespace df

--- a/drape_frontend/drape_frontend.pro
+++ b/drape_frontend/drape_frontend.pro
@@ -29,6 +29,7 @@ SOURCES += \
     gui/ruler_helper.cpp \
     gui/shape.cpp \
     gui/skin.cpp \
+    animation_utils.cpp \
     apply_feature_functors.cpp \
     area_shape.cpp \
     arrow3d.cpp \
@@ -112,6 +113,7 @@ HEADERS += \
     gui/shape.hpp \
     gui/skin.hpp \
     animation_constants.hpp \
+    animation_utils.hpp \
     apply_feature_functors.hpp \
     area_shape.hpp \
     arrow3d.hpp \

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -1,9 +1,9 @@
-#include "my_position_controller.hpp"
-#include "animation_constants.hpp"
-#include "visual_params.hpp"
-#include "animation/base_interpolator.hpp"
-#include "animation/interpolations.hpp"
-#include "animation/model_view_animation.hpp"
+#include "drape_frontend/my_position_controller.hpp"
+#include "drape_frontend/animation_utils.hpp"
+#include "drape_frontend/visual_params.hpp"
+#include "drape_frontend/animation/base_interpolator.hpp"
+#include "drape_frontend/animation/interpolations.hpp"
+#include "drape_frontend/animation/model_view_animation.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -582,10 +582,9 @@ void MyPositionController::AnimationStarted(ref_ptr<BaseModelViewAnimation> anim
 
 void MyPositionController::CreateAnim(m2::PointD const & oldPos, double oldAzimut, ScreenBase const & screen)
 {
-  double moveDuration = ModelViewAnimation::GetMoveDuration(oldPos, m_position, screen);
-  double rotateDuration = ModelViewAnimation::GetRotateDuration(oldAzimut, m_drawDirection);
-  double maxDuration = max(moveDuration, rotateDuration);
-  if (maxDuration > 0.0 && maxDuration < kMaxAnimationTimeSec)
+  double const moveDuration = ModelViewAnimation::GetMoveDuration(oldPos, m_position, screen);
+  double const rotateDuration = ModelViewAnimation::GetRotateDuration(oldAzimut, m_drawDirection);
+  if (df::IsAnimationAllowed(max(moveDuration, rotateDuration), screen))
   {
     if (IsModeChangeViewport())
     {

--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -1,5 +1,6 @@
 #include "drape_frontend/user_event_stream.hpp"
 #include "drape_frontend/animation_constants.hpp"
+#include "drape_frontend/animation_utils.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "indexer/scales.hpp"
@@ -449,7 +450,7 @@ bool UserEventStream::SetRect(m2::AnyRectD const & rect, bool isAnim, TAnimation
     double scaleDuration = ModelViewAnimation::GetScaleDuration(startRect.GetLocalRect().SizeX(), rect.GetLocalRect().SizeX());
     if (scaleDuration > kMaxAnimationTimeSec)
       scaleDuration = kMaxAnimationTimeSec;
-    if (max(max(angleDuration, moveDuration), scaleDuration) <= kMaxAnimationTimeSec)
+    if (df::IsAnimationAllowed(max(max(angleDuration, moveDuration), scaleDuration), screen))
     {
       ASSERT(animCreator != nullptr, ());
       animCreator(startRect, rect, angleDuration, moveDuration, scaleDuration);
@@ -497,7 +498,7 @@ bool UserEventStream::SetFollowAndRotate(m2::PointD const & userPos, m2::PointD 
     double const angleDuration = ModelViewAnimation::GetRotateDuration(startRect.Angle().val(), -azimuth);
     double const moveDuration = ModelViewAnimation::GetMoveDuration(startRect.GlobalZero(), newCenter, screen);
     double const duration = max(angleDuration, moveDuration);
-    if (duration > 0.0 && duration < kMaxAnimationTimeSec)
+    if (df::IsAnimationAllowed(duration, screen))
     {
       m_animation.reset(new FollowAndRotateAnimation(startRect, targetLocalRect, userPos,
                                                      screen.GtoP(userPos), pixelPos, azimuth, duration));


### PR DESCRIPTION
Настроено поведение анимации таким образом, чтобы на низких зумах не было мгновенных анимаций. Это решает проблему MAPSME-481.