### PR TITLE
[new downloader] Adding downloading size and downloading counter.

### DIFF
--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -1273,11 +1273,21 @@ void Storage::GetNodeAttrs(TCountryId const & countryId, NodeAttrs & nodeAttrs) 
         CalculateProgress(downloadingMwm, subtree, downloadingMwmProgress, setQueue);
   }
 
-  // Local mwm information.
+  // Local mwm information and information about downloading mwms.
   nodeAttrs.m_localMwmCounter = 0;
   nodeAttrs.m_localMwmSize = 0;
+  nodeAttrs.m_downloadingMwmCounter = 0;
+  nodeAttrs.m_downloadingMwmSize = 0;
   node->ForEachInSubtree([this, &nodeAttrs](TCountryTreeNode const & d)
   {
+    // Downloading mwm information.
+    if (nodeAttrs.m_status != NodeStatus::NotDownloaded && d.ChildrenCount() == 0)
+    {
+      nodeAttrs.m_downloadingMwmCounter += 1;
+      nodeAttrs.m_downloadingMwmSize += d.Value().GetSubtreeMwmSizeBytes();
+    }
+
+    // Local mwm information.
     Storage::TLocalFilePtr const localFile =
         GetLatestLocalFile(d.Value().Name());
     if (localFile == nullptr)

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -32,7 +32,8 @@ struct CountryIdAndName
 /// It's applicable for expandable and not expandable node id.
 struct NodeAttrs
 {
-  NodeAttrs() : m_mwmCounter(0), m_localMwmCounter(0), m_mwmSize(0), m_localMwmSize(0),
+  NodeAttrs() : m_mwmCounter(0), m_localMwmCounter(0), m_downloadingMwmCounter(0),
+    m_mwmSize(0), m_localMwmSize(0), m_downloadingMwmSize(0),
     m_downloadingProgress(make_pair(0, 0)),
     m_status(NodeStatus::Undefined), m_error(NodeErrorCode::NoError), m_present(false) {}
 
@@ -44,7 +45,7 @@ struct NodeAttrs
   /// Number of mwms belonging to the node which have been downloaded.
   uint32_t m_localMwmCounter;
 
-  /// Number of leafs belonging which have been downloaded
+  /// Number of leaves of the node which have been downloaded
   /// plus which is in progress of downloading (zero or one)
   /// plus which are staying in queue.
   uint32_t m_downloadingMwmCounter;
@@ -59,10 +60,10 @@ struct NodeAttrs
   /// have been downloaded.
   size_t m_localMwmSize;
 
-  /// Size of leafs belonging which have been downloaded
+  /// Size of leaves of the node which have been downloaded
   /// plus which is in progress of downloading (zero or one)
   /// plus which are staying in queue.
-  /// \note It's which is written in countries.txt.
+  /// \note The size of leaves is the size is written in countries.txt.
   size_t m_downloadingMwmSize;
 
   /// The name of the node in a local language. That means the language dependent on

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -44,6 +44,11 @@ struct NodeAttrs
   /// Number of mwms belonging to the node which have been downloaded.
   uint32_t m_localMwmCounter;
 
+  /// Number of leafs belonging which have been downloaded
+  /// plus which is in progress of downloading (zero or one)
+  /// plus which are staying in queue.
+  uint32_t m_downloadingMwmCounter;
+
   /// If it's not an expandable node, |m_mwmSize| is size of one mwm according to countries.txt.
   /// Otherwise |m_mwmSize| is the sum of all mwm file sizes which belong to the group
   /// according to countries.txt.
@@ -53,6 +58,12 @@ struct NodeAttrs
   /// Otherwise |m_localNodeSize| is the sum of all mwm file sizes which belong to the group and
   /// have been downloaded.
   size_t m_localMwmSize;
+
+  /// Size of leafs belonging which have been downloaded
+  /// plus which is in progress of downloading (zero or one)
+  /// plus which are staying in queue.
+  /// \note It's which is written in countries.txt.
+  size_t m_downloadingMwmSize;
 
   /// The name of the node in a local language. That means the language dependent on
   /// a device locale.

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1272,6 +1272,8 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmCounter, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmCounter, 0, ());
+  TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
   TEST(!nodeAttrs.m_present, ());
 
   storage.GetNodeAttrs("Algeria", nodeAttrs);
@@ -1284,6 +1286,8 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmCounter, 0, ());
+  TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmCounter, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
   TEST(!nodeAttrs.m_present, ());
 
@@ -1298,6 +1302,8 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmCounter, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmCounter, 0, ());
+  TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
   TEST(!nodeAttrs.m_present, ());
 
   storage.GetNodeAttrs("South Korea_South", nodeAttrs);
@@ -1310,6 +1316,8 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmCounter, 0, ());
+  TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmCounter, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
   TEST(!nodeAttrs.m_present, ());
 
@@ -1325,6 +1333,8 @@ UNIT_TEST(StorageTest_GetNodeAttrsSingleMwm)
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.first, 0, ());
   TEST_EQUAL(nodeAttrs.m_downloadingProgress.second, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmCounter, 0, ());
+  TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
+  TEST_EQUAL(nodeAttrs.m_downloadingMwmCounter, 0, ());
   TEST_EQUAL(nodeAttrs.m_localMwmSize, 0, ());
   TEST(!nodeAttrs.m_present, ());
 }


### PR DESCRIPTION
В структуру NodeAttr добавил поля:
nodeAttrs.m_downloadingMwmCounter;
nodeAttrs.m_downloadingMwmSize;
В этих полях содержится информация о количестве и размере тех mwm которые:
- принадлежат поддереву с указаной в GetNodeAttrs вершиной;
- имеют любой статус отличный не загруженных (Т.е. находятся в секции downloaded);

При доработке UI по отображению кол-ва загруженных карт и их размеров необходимо использовать именно его.

Т.е. на пункте, соответствующем карте пишем:
Загружено карт: m_downloadingMwmCounter из m_mwmCounter
Размер того что загружено m_downloadingMwmSize из m_mwmSize

https://jira.mail.ru/browse/MAPSME-482
