### PR TITLE
[editor] Disable creation of kiosks

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -589,7 +589,7 @@
         <include group="poi" />
         <include field="internet" />
       </type>
-      <type id="shop-kiosk" group="shop">
+      <type id="shop-kiosk" group="shop" can_add="no">
         <include group="poi" />
         <include field="operator" />
         <include field="internet" />


### PR DESCRIPTION
Нам пишут:

>https://www.openstreetmap.org/changeset/38034497#map=19/55.76393/37.56298 

> Судя по всему, для "проездных билетов" и "Прессы" вместо соответствующих тегов ставится shop=kiosk, что очень прискорбно (по факту именно shop=kiosk, т.е. киосков в которых продают сразу все - и газеты, и лотерейные билеты, и напитки, и лицензии на рыбалку, в России крайне мало). Лучше сделать отдельные пресеты на билетный магазин/киоск, на магазин прессы.

> С уважением,
> literan

По-моему, нужно отключить тип киосков. Не так много стран, где этот тип имеет смысл.

![](https://www.sbb.ch/content/sbbshop/en/mehr-bahnhof-schaffhausen/k_kiosk1/_jcr_content/shop/image.spooler.completeimage.553.jpg/1450428131102/schafh_Shop_k_kiosk_Unterfu%C2%A6%C3%AAhrung_BB_0658.jpg)