### PR TITLE
[editor] Reduced radius to match features for exactly 1 meter.

### DIFF
--- a/editor/changeset_wrapper.hpp
+++ b/editor/changeset_wrapper.hpp
@@ -53,8 +53,8 @@ public:
 private:
   /// Unfortunately, pugi can't return xml_documents from methods.
   /// Throws exceptions from above list.
-  void LoadXmlFromOSM(ms::LatLon const & ll, pugi::xml_document & doc);
-  void LoadXmlFromOSM(m2::RectD const & rect, pugi::xml_document & doc);
+  void LoadXmlFromOSM(ms::LatLon const & ll, pugi::xml_document & doc, double radiusInMeters = 1.0);
+  void LoadXmlFromOSM(ms::LatLon const & min, ms::LatLon const & max, pugi::xml_document & doc);
 
   ServerApi06::TKeyValueTags m_changesetComments;
   ServerApi06 m_api;

--- a/editor/editor_tests/server_api_test.cpp
+++ b/editor/editor_tests/server_api_test.cpp
@@ -47,7 +47,7 @@ ServerApi06 CreateAPI()
 void DeleteOSMNodeIfExists(ServerApi06 const & api, uint64_t changeSetId, ms::LatLon const & ll)
 {
   // Delete all test nodes left on the server (if any).
-  auto const response = api.GetXmlFeaturesAtLatLon(ll);
+  auto const response = api.GetXmlFeaturesAtLatLon(ll, 1.0);
   TEST_EQUAL(response.first, OsmOAuth::HTTP::OK, ());
   xml_document reply;
   reply.load_string(response.second.c_str());
@@ -72,6 +72,7 @@ UNIT_TEST(OSM_ServerAPI_ChangesetAndNode)
   uint64_t changeSetId = api.CreateChangeSet({{"created_by", "MAPS.ME Unit Test"},
                                               {"comment", "For test purposes only."}});
   auto const changesetCloser = [&]() { api.CloseChangeSet(changeSetId); };
+
   {
     MY_SCOPE_GUARD(guard, changesetCloser);
 
@@ -99,7 +100,7 @@ UNIT_TEST(OSM_ServerAPI_ChangesetAndNode)
     // It is done here via Scope Guard.
   }
 
-  auto const response = api.GetXmlFeaturesAtLatLon(kModifiedLocation);
+  auto const response = api.GetXmlFeaturesAtLatLon(kModifiedLocation, 1.0);
   TEST_EQUAL(response.first, OsmOAuth::HTTP::OK, ());
   auto const features = XMLFeature::FromOSM(response.second);
   TEST_EQUAL(1, features.size(), ());

--- a/editor/server_api.cpp
+++ b/editor/server_api.cpp
@@ -5,6 +5,7 @@
 #include "geometry/mercator.hpp"
 
 #include "base/logging.hpp"
+#include "base/math.hpp"
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
 
@@ -155,31 +156,33 @@ UserPreferences ServerApi06::GetUserPreferences() const
   return pref;
 }
 
-OsmOAuth::Response ServerApi06::GetXmlFeaturesInRect(m2::RectD const & latLonRect) const
+OsmOAuth::Response ServerApi06::GetXmlFeaturesInRect(double minLat, double minLon, double maxLat, double maxLon) const
 {
   using strings::to_string_dac;
 
   // Digits After Comma.
   static constexpr double kDAC = 7;
-  m2::PointD const lb = latLonRect.LeftBottom();
-  m2::PointD const rt = latLonRect.RightTop();
-  string const url = "/map?bbox=" + to_string_dac(lb.x, kDAC) + ',' + to_string_dac(lb.y, kDAC) + ',' +
-      to_string_dac(rt.x, kDAC) + ',' + to_string_dac(rt.y, kDAC);
+  string const url = "/map?bbox=" + to_string_dac(minLon, kDAC) + ',' + to_string_dac(minLat, kDAC) + ',' +
+      to_string_dac(maxLon, kDAC) + ',' + to_string_dac(maxLat, kDAC);
 
   return m_auth.DirectRequest(url);
 }
 
-OsmOAuth::Response ServerApi06::GetXmlFeaturesAtLatLon(double lat, double lon) const
+OsmOAuth::Response ServerApi06::GetXmlFeaturesAtLatLon(double lat, double lon, double radiusInMeters) const
 {
-  double const kInflateEpsilon = MercatorBounds::GetCellID2PointAbsEpsilon() / 2;
-  m2::RectD rect(lon, lat, lon, lat);
-  rect.Inflate(kInflateEpsilon, kInflateEpsilon);
-  return GetXmlFeaturesInRect(rect);
+  double const latDegreeOffset = radiusInMeters * MercatorBounds::degreeInMetres;
+  double const minLat = max(-90.0, lat - latDegreeOffset);
+  double const maxLat = min( 90.0, lat + latDegreeOffset);
+  double const cosL = max(cos(my::DegToRad(max(fabs(minLat), fabs(maxLat)))), 0.00001);
+  double const lonDegreeOffset = radiusInMeters * MercatorBounds::degreeInMetres / cosL;
+  double const minLon = max(-180.0, lon - lonDegreeOffset);
+  double const maxLon = min( 180.0, lon + lonDegreeOffset);
+  return GetXmlFeaturesInRect(minLat, minLon, maxLat, maxLon);
 }
 
-OsmOAuth::Response ServerApi06::GetXmlFeaturesAtLatLon(ms::LatLon const & ll) const
+OsmOAuth::Response ServerApi06::GetXmlFeaturesAtLatLon(ms::LatLon const & ll, double radiusInMeters) const
 {
-  return GetXmlFeaturesAtLatLon(ll.lat, ll.lon);
+  return GetXmlFeaturesAtLatLon(ll.lat, ll.lon, radiusInMeters);
 }
 
 } // namespace osm

--- a/editor/server_api.hpp
+++ b/editor/server_api.hpp
@@ -76,9 +76,9 @@ public:
   void CloseNote(uint64_t const id) const;
 
   /// @returns OSM xml string with features in the bounding box or empty string on error.
-  OsmOAuth::Response GetXmlFeaturesInRect(m2::RectD const & latLonRect) const;
-  OsmOAuth::Response GetXmlFeaturesAtLatLon(double lat, double lon) const;
-  OsmOAuth::Response GetXmlFeaturesAtLatLon(ms::LatLon const & ll) const;
+  OsmOAuth::Response GetXmlFeaturesInRect(double minLat, double minLon, double maxLat, double maxLon) const;
+  OsmOAuth::Response GetXmlFeaturesAtLatLon(double lat, double lon, double radiusInMeters = 1.0) const;
+  OsmOAuth::Response GetXmlFeaturesAtLatLon(ms::LatLon const & ll, double radiusInMeters = 1.0) const;
 
 private:
   OsmOAuth m_auth;


### PR DESCRIPTION
Fixes issues when newly created/edited features are incorrectly matched to existing nearby features in the OSM.