### PR TITLE
[editor] Fix std::min call

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -275,7 +275,7 @@ string ChangesetWrapper::TypeCountToString(TTypeCount const & typeCount)
        });
 
   ostringstream ss;
-  auto const limit = min(3UL, items.size());
+  auto const limit = min(size_t(3), items.size());
   for (auto i = 0; i < limit; ++i)
   {
     if (i > 0)


### PR DESCRIPTION
Правлю no matching function for call to 'min'. Работа с типами в шаблонных функциях, скажем так, хромает.