### PR TITLE
[DNM][generator] Prepend version to external_resources.txt lines

### DIFF
--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -466,9 +466,9 @@ if [ "$MODE" == "resources" ]; then
     for file in "$TARGET"/World*.mwm "$TARGET"/*.ttf; do
       if [[ "$file" != *roboto_reg* ]]; then
         if [ "$UNAME" == "Darwin" ]; then
-          stat -f "%N %z" "$file" | sed 's#^.*/##' >> "$EXT_RES"
+          stat -f "$COUNTRIES_VERSION %N %z" "$file" | sed 's#^.*/##' >> "$EXT_RES"
         else
-          stat -c "%n %s" "$file" | sed 's#^.*/##' >> "$EXT_RES"
+          stat -c "$COUNTRIES_VERSION %n %s" "$file" | sed 's#^.*/##' >> "$EXT_RES"
         fi
       fi
     done


### PR DESCRIPTION
Перенос #2299 на мастер.

Все строки файла `external_resources.txt` будут в виде `160313 World.mwm 8923475`.
Мёржить только после того, как обработка этого формата будет в ядре, или хотя бы в пул-реквесте: https://jira.mail.ru/browse/MAPSME-367