### PR TITLE
[editor] Do not overwrite OSM type when feature is modified (not created by user).

### DIFF
--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -48,6 +48,8 @@ public:
   XMLFeature(pugi::xml_document const & xml);
   XMLFeature(pugi::xml_node const & xml);
   XMLFeature(XMLFeature const & feature);
+  // TODO: It should make "deep" compare instead of converting to strings.
+  // Strings comparison does not work if tags order is different but tags are equal.
   bool operator==(XMLFeature const & other) const;
   /// @returns nodes and ways from osmXml. Vector can be empty.
   static vector<XMLFeature> FromOSM(string const & osmXml);

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -170,7 +170,10 @@ public:
   /// Replaces all FeatureType's components.
   void ReplaceBy(osm::EditableMapObject const & ef);
 
-  editor::XMLFeature ToXML() const;
+  /// @param serializeType if false, types are not serialized.
+  /// Useful for applying modifications to existing OSM features, to avoid ussues when someone
+  /// has changed a type in OSM, but our users uploaded invalid outdated type after modifying feature.
+  editor::XMLFeature ToXML(bool serializeType) const;
   /// Creates new feature, including geometry and types.
   /// @Note: only nodes (points) are supported at the moment.
   bool FromXML(editor::XMLFeature const & xml);

--- a/indexer/indexer_tests/feature_xml_test.cpp
+++ b/indexer/indexer_tests/feature_xml_test.cpp
@@ -3,10 +3,6 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/feature.hpp"
 
-#include "base/string_utils.hpp"
-
-#include "std/sstream.hpp"
-/*
 namespace
 {
 struct TestSetUp
@@ -15,77 +11,33 @@ struct TestSetUp
 };
 
 TestSetUp g_testSetUp;
-
-// Sort tags and compare as strings.
-void CompareFeatureXML(string const & d1, string const & d2)
-{
-  pugi::xml_document xml1, xml2;
-  xml1.load(d1.data());
-  xml2.load(d2.data());
-
-  xml1.child("node").remove_attribute("timestamp");
-  xml2.child("node").remove_attribute("timestamp");
-
-  stringstream ss1, ss2;
-  xml1.save(ss1);
-  xml2.save(ss2);
-
-  vector<string> v1(strings::SimpleTokenizer(ss1.str(), "\n"), strings::SimpleTokenizer());
-  vector<string> v2(strings::SimpleTokenizer(ss2.str(), "\n"), strings::SimpleTokenizer());
-
-  TEST(v1.size() >= 3, ());
-  TEST(v2.size() >= 3, ());
-
-  // Sort all except <xml ...>,  <node ...> and </node>
-  sort(begin(v1) + 2, end(v1) - 1);
-  sort(begin(v2) + 2, end(v2) - 1);
-
-  // Format back to string to have a nice readable error message.
-  auto s1 = strings::JoinStrings(v1, "\n");
-  auto s2 = strings::JoinStrings(v2, "\n");
-
-  TEST_EQUAL(s1, s2, ());
-}
 }  // namespace
 
- TODO(mgsergio): Unkomment when creation is required.
- UNIT_TEST(FeatureType_FromXMLAndBackToXML)
- {
-   auto const xml = R"(<?xml version="1.0"?>
- <node
-   lat="55.7978998"
-   lon="37.474528"
-   timestamp="2015-11-27T21:13:32Z">
-   <tag
-     k="name"
-     v="Gorki Park" />
-   <tag
-     k="name:en"
-     v="Gorki Park" />
-   <tag
-     k="name:ru"
-     v="Парк Горького" />
-   <tag
-     k="addr:housenumber"
-     v="10" />
-   <tag
-     k="opening_hours"
-     v="Mo-Fr 08:15-17:30" />
-   <tag
-     k="amenity"
-     v="atm" />
-   <tag
-     k="mapswithme:geom_type"
-     v="GEOM_POINT" />
- </node>
- )";
 
-   auto const feature = FeatureType::FromXML(xml);
-   auto const xmlFeature = feature.ToXML();
+UNIT_TEST(FeatureType_FromXMLAndBackToXML)
+{
+  string const xmlNoTypeStr = R"(<?xml version="1.0"?>
+<node lat="55.7978998" lon="37.474528" timestamp="2015-11-27T21:13:32Z">
+  <tag k="name" v="Gorki Park" />
+  <tag k="name:en" v="Gorki Park" />
+  <tag k="name:ru" v="Парк Горького" />
+  <tag k="addr:housenumber" v="10" />
+</node>
+)";
 
-   stringstream sstr;
-   xmlFeature.Save(sstr);
+  char const kTimestamp[] = "2015-11-27T21:13:32Z";
 
-   CompareFeatureXML(xml, sstr.str());
- }
-*/
+  editor::XMLFeature xmlNoType(xmlNoTypeStr);
+  editor::XMLFeature xmlWithType = xmlNoType;
+  xmlWithType.SetTagValue("amenity", "atm");
+
+  FeatureType ft;
+  ft.FromXML(xmlWithType);
+  auto fromFtWithType = ft.ToXML(true);
+  fromFtWithType.SetAttribute("timestamp", kTimestamp);
+  TEST_EQUAL(fromFtWithType, xmlWithType, ());
+
+  auto fromFtWithoutType = ft.ToXML(false);
+  fromFtWithoutType.SetAttribute("timestamp", kTimestamp);
+  TEST_EQUAL(fromFtWithoutType, xmlNoType, ());
+}


### PR DESCRIPTION
https://trello.com/c/lQs9wLzq/130--
@Zverik нужно проверить этот код, попробовав отредактировать одну и ту же фичу в maps.me и в осме, и убедиться, что maps.me не перетирает тип.