### PR TITLE
More details to close routing statistics.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -523,7 +523,7 @@ void Framework::OnMapDeregistered(platform::LocalCountryFile const & localFile)
   };
 
   // Call action on thread in which the framework was created
-  // For more information look at comment for Observer class in mwm_set.hpp 
+  // For more information look at comment for Observer class in mwm_set.hpp
   if (m_storage.GetThreadChecker().CalledOnOriginalThread())
     action();
   else
@@ -2235,12 +2235,7 @@ void Framework::CloseRouting()
 {
   if (m_routingSession.IsBuilt())
   {
-    auto const lastGoodPoint = MercatorBounds::ToLatLon(
-        m_routingSession.GetRoute().GetFollowedPolyline().GetCurrentIter().m_pt);
-    alohalytics::Stats::Instance().LogEvent(
-        "RouteTracking_RouteClosing",
-        {{"percent", strings::to_string(m_routingSession.GetCompletionPercent())}},
-        alohalytics::Location::FromLatLon(lastGoodPoint.lat, lastGoodPoint.lon));
+    m_routingSession.EmitCloseRoutingEvent();
   }
   m_routingSession.Reset();
   RemoveRoute(true /* deactivateFollowing */);

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -500,4 +500,23 @@ double RoutingSession::GetDistanceToCurrentCamM(SpeedCameraRestriction & camera,
   }
   return kInvalidSpeedCameraDistance;
 }
+
+void RoutingSession::EmitCloseRoutingEvent() const
+{
+  if (!m_route.IsValid())
+  {
+    ASSERT(false, ());
+    return;
+  }
+  auto const lastGoodPoint =
+      MercatorBounds::ToLatLon(m_route.GetFollowedPolyline().GetCurrentIter().m_pt);
+  alohalytics::Stats::Instance().LogEvent(
+      "RouteTracking_RouteClosing",
+      {{"percent", strings::to_string(GetCompletionPercent())},
+       {"distance", strings::to_string(m_passedDistanceOnRouteMeters +
+                                       m_route.GetCurrentDistanceToEndMeters())},
+       {"router", m_route.GetRouterId()},
+       {"rebuildCount", strings::to_string(m_routingRebuildCount)}},
+      alohalytics::Location::FromLatLon(lastGoodPoint.lat, lastGoodPoint.lon));
+}
 }  // namespace routing

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -123,6 +123,8 @@ public:
   void GenerateTurnNotifications(vector<string> & turnNotifications);
   double GetCompletionPercent() const;
 
+  void EmitCloseRoutingEvent() const;
+
 private:
   struct DoReadyCallback
   {


### PR DESCRIPTION
Добавил детали маршрута, который мы закрываем в сообщение статистики. Чтобы потом мучительно долго не собирать информацию о том какой же маршрут это был.