### PR TITLE
Cross mwm routing fix. Final map twise case.

### DIFF
--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -177,7 +177,11 @@ void CrossMwmGraph::GetOutgoingEdgesList(BorderCross const & v,
   if (it != m_virtualEdges.end())
   {
     adj.insert(adj.end(), it->second.begin(), it->second.end());
-    return;
+    // For last map we need to load virtual shortcuts and real cross roads. It takes to account case
+    // when we have a path from the mwmw border to the point inside the map throuh another map.
+    // See Ust-Katav test for more.
+    if (!it->second.front().GetTarget().toNode.isVirtual)
+      return;
   }
 
   // Loading cross routing section.

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -62,6 +62,14 @@ namespace
         MercatorBounds::FromLatLon(37.33498, -122.03575), 1438.);
   }
 
+  // Path in the last map through the other map.
+  UNIT_TEST(RussiaUfaToUstKatavTest)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(54.7304, 55.9554), {0., 0.},
+        MercatorBounds::FromLatLon(54.9228, 58.1469), 164667.);
+  }
+
   // ASSERT on pedestrian edges
   UNIT_TEST(RussiaAssertHighwayClassOnPedestrianRouteInOSRM)
   {


### PR DESCRIPTION
MAPSME-604
Фикс случая, когда кратчайший маршрут пересекает последнюю карту несколько раз.
@bykoianko PTAL