### PR TITLE
[new downloader] Checking availability of country id in country tree before adding it from the queue.

### DIFF
--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -438,7 +438,7 @@ void Storage::RestoreDownloadQueue()
   strings::SimpleTokenizer iter(queue, ";");
   while (iter)
   {
-    DownloadCountry(*iter, MapOptions::MapWithCarRouting);
+    DownloadNode(*iter);
     ++iter;
   }
 }


### PR DESCRIPTION
При раскатывании версии на 1% у 2 клиентов было падение программы при восстановлении сохраненной очереди. Данное падение, скорее всего не давало запустить программу. Согласно crashlytics у 2 пользователей не нашлось, country id, которой было сохранено в download queue в setting.ini. 

https://jira.mail.ru/browse/MAPSME-654

@syershov PTAL

Вот такие callstack-и были у пользователей:

libmapswithme.so  
logging.cpp line 49
jni::AndroidAssertMessage(my::SrcPoint const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
6
libmapswithme.so  
storage.cpp line 80
storage::Storage::CountryLeafByCountryId(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const
7
libmapswithme.so  
storage.cpp line 338
storage::Storage::DownloadNextCountryFromQueue()
8
libmapswithme.so  
storage.cpp line 462
storage::Storage::DownloadCountry(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MapOptions)
9
libmapswithme.so  
storage.cpp line 441
storage::Storage::RestoreDownloadQueue()
10
libmapswithme.so  
storage.cpp line 264
storage::Storage::RegisterAllLocalMaps()
11
libmapswithme.so  
framework.cpp line 547
Framework::RegisterAllMaps()
12
libmapswithme.so  
framework.cpp line 333
Framework::Framework()
13
libmapswithme.so  
Framework.cpp line 62
android::Framework::Framework()
14
libmapswithme.so  
MwmApplication.cpp line 20
Java_com_mapswithme_maps_MwmApplication_nativeInitFramework