### PR TITLE
[editor][android] Fix swapped lat-lon for notes

### DIFF
--- a/android/jni/com/mapswithme/maps/editor/Editor.cpp
+++ b/android/jni/com/mapswithme/maps/editor/Editor.cpp
@@ -352,7 +352,7 @@ Java_com_mapswithme_maps_editor_Editor_nativeGetMwmVersion(JNIEnv * env, jclass 
 JNIEXPORT void JNICALL
 Java_com_mapswithme_maps_editor_Editor_nativeCreateNote(JNIEnv * env, jclass clazz, jdouble lat, jdouble lon, jstring text)
 {
-  Editor::Instance().CreateNote(m2::PointD(lat, lon), jni::ToNativeString(env, text));
+  Editor::Instance().CreateNote(m2::PointD(lon, lat), jni::ToNativeString(env, text));
 }
 
 } // extern "C"


### PR DESCRIPTION
Москвичи с андроида добавляют заметки в Иран, потому что `x` — это `lon`, а не `lat`.

Зачем там вообще `PointD`, а не `LatLon`?