### PR TITLE
Street names

### DIFF
--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -183,8 +183,7 @@ OsrmRouter::ResultCode OsrmRouter::MakeRouteFromCrossesPath(TCheckedPath const &
       points.pop_back();
       turnsDir.pop_back();
       times.pop_back();
-      if (streets.back().first >= points.size())
-        streets.pop_back();
+      // Streets might not point to the last point of the path.
     }
 
     // Get annotated route.
@@ -478,7 +477,7 @@ OsrmRouter::ResultCode OsrmRouter::MakeTurnAnnotation(
 
       // Street names. I put empty names too, to avoid freezing old street name while riding on
       // unnamed street.
-      streets.emplace_back(max(points.size(), (size_t)1) - 1, loadedSegment.m_name);
+      streets.emplace_back(max(points.size(), static_cast<size_t>(1)) - 1, loadedSegment.m_name);
 
       // Turns information.
       if (segmentIndex > 0 && !points.empty() && skipTurnSegments == 0)

--- a/routing/osrm_router.hpp
+++ b/routing/osrm_router.hpp
@@ -85,9 +85,9 @@ protected:
    * \return routing operation result code.
    */
   ResultCode MakeTurnAnnotation(RawRoutingResult const & routingResult,
-                                TRoutingMappingPtr const & mapping,
-                                RouterDelegate const & delegate, vector<m2::PointD> & points,
-                                Route::TTurns & turnsDir, Route::TTimes & times, Route::TStreets & streets);
+                                TRoutingMappingPtr const & mapping, RouterDelegate const & delegate,
+                                vector<m2::PointD> & points, Route::TTurns & turnsDir,
+                                Route::TTimes & times, Route::TStreets & streets);
 
 private:
   /*!

--- a/routing/osrm_router.hpp
+++ b/routing/osrm_router.hpp
@@ -81,12 +81,13 @@ protected:
    * \param points Storage for unpacked points of the path.
    * \param turnsDir output turns annotation storage.
    * \param times output times annotation storage.
+   * \param streets output street names along the path.
    * \return routing operation result code.
    */
   ResultCode MakeTurnAnnotation(RawRoutingResult const & routingResult,
                                 TRoutingMappingPtr const & mapping,
                                 RouterDelegate const & delegate, vector<m2::PointD> & points,
-                                Route::TTurns & turnsDir, Route::TTimes & times);
+                                Route::TTurns & turnsDir, Route::TTimes & times, Route::TStreets & streets);
 
 private:
   /*!

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -251,12 +251,14 @@ void RoadGraphRouter::ReconstructRoute(vector<Junction> && path, Route & route,
 
   Route::TTimes times;
   Route::TTurns turnsDir;
+  Route::TStreets streetNames;
   if (m_directionsEngine)
     m_directionsEngine->Generate(*m_roadGraph, path, times, turnsDir, cancellable);
 
   route.SetGeometry(geometry.begin(), geometry.end());
   route.SetSectionTimes(times);
   route.SetTurnInstructions(turnsDir);
+  route.SetStreetNames(streetNames);
 }
 
 unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn const & countryFileFn)

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -169,7 +169,7 @@ void Route::GetStreetNameAfterIdx(uint32_t idx, string & name) const
   for (;it != m_streets.cend(); ++it)
     if (!it->second.empty())
     {
-      if (m_poly.GetDistanceM(polyIter, m_poly.GetIterToIndex(it->first)) < kSteetNameLinkMeters)
+      if (m_poly.GetDistanceM(polyIter, m_poly.GetIterToIndex(max(it->first, static_cast<uint32_t>(polyIter.m_ind)))) < kSteetNameLinkMeters)
         name = it->second;
       return;
     }
@@ -187,14 +187,14 @@ Route::TStreets::const_iterator Route::GetCurrentStreetNameIterAfter(FollowedPol
   TStreets::const_iterator prevIter = curIter;
   curIter++;
 
-  while (curIter->first<=iter.m_ind)
+  while (curIter->first < iter.m_ind)
   {
     ++prevIter;
     ++curIter;
     if (curIter==m_streets.cend())
       return curIter;
   }
-  return prevIter;
+  return curIter->first == iter.m_ind ? curIter : prevIter;
 }
 
 bool Route::GetCurrentTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -156,7 +156,8 @@ void Route::GetCurrentStreetName(string & name) const
   auto it = GetCurrentStreetNameIterAfter(m_poly.GetCurrentIter());
   if (it == m_streets.cend())
     name.clear();
-  name = it->second;
+  else
+    name = it->second;
 }
 
 void Route::GetStreetNameAfterIdx(uint32_t idx, string & name) const
@@ -191,7 +192,7 @@ Route::TStreets::const_iterator Route::GetCurrentStreetNameIterAfter(FollowedPol
   {
     ++prevIter;
     ++curIter;
-    if (curIter==m_streets.cend())
+    if (curIter == m_streets.cend())
       return curIter;
   }
   return curIter->first == iter.m_ind ? curIter : prevIter;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -23,9 +23,11 @@ namespace routing
 class Route
 {
 public:
-  typedef vector<turns::TurnItem> TTurns;
-  typedef pair<uint32_t, double> TTimeItem;
-  typedef vector<TTimeItem> TTimes;
+  using TTurns = vector<turns::TurnItem>;
+  using TTimeItem = pair<uint32_t, double>;
+  using TTimes = vector<TTimeItem>;
+  using TStreetItem = pair<uint32_t, string>;
+  using TStreets = vector<TStreetItem>;
 
   explicit Route(string const & router)
     : m_router(router), m_routingSettings(GetCarRoutingSettings()) {}
@@ -55,6 +57,11 @@ public:
   inline void SetSectionTimes(TTimes & v)
   {
     swap(m_times, v);
+  }
+
+  inline void SetStreetNames(TStreets & v)
+  {
+    swap(m_streets, v);
   }
 
   uint32_t GetTotalTimeSec() const;
@@ -130,6 +137,7 @@ private:
 
   TTurns m_turns;
   TTimes m_times;
+  TStreets m_streets;
 
   mutable double m_currentTime;
 };

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -86,6 +86,12 @@ public:
   /// \param turn is information about the nearest turn.
   bool GetCurrentTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
 
+  /// \brief Returns a name of a street where the user rides at this moment.
+  void GetCurrentStreetName(string &) const;
+
+  /// \brief Returns a name of a street next to idx point of the path. Function avoids short unnamed links.
+  void GetStreetNameAfterIdx(uint32_t idx, string &) const;
+
   /// @return true if GetNextTurn() returns a valid result in parameters, false otherwise.
   /// \param distanceToTurnMeters is a distance from current position to the second turn.
   /// \param turn is information about the second turn.
@@ -122,6 +128,7 @@ private:
   void Update();
   double GetPolySegAngle(size_t ind) const;
   TTurns::const_iterator GetCurrentTurn() const;
+  TStreets::const_iterator GetCurrentStreetNameIterAfter(FollowedPolyline::Iter iter) const;
 
 private:
   friend string DebugPrint(Route const & r);

--- a/routing/routing_integration_tests/osrm_street_names_test.cpp
+++ b/routing/routing_integration_tests/osrm_street_names_test.cpp
@@ -6,7 +6,6 @@
 
 #include "platform/location.hpp"
 
-
 using namespace routing;
 using namespace routing::turns;
 
@@ -23,8 +22,7 @@ void MoveRoute(Route & route, ms::LatLon const & coords)
 UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetOsrmComponents(),
-      MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
+      integration::GetOsrmComponents(), MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
       MercatorBounds::FromLatLon(55.73198, 37.63945));
 
   Route & route = *routeResult.first;
@@ -38,7 +36,6 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
 
   integration::TestCurrentStreetName(route, "Подольское шоссе");
   integration::TestNextStreetName(route, "Валовая улица");
-
 
   MoveRoute(route, ms::LatLon(55.72059, 37.62766));
 

--- a/routing/routing_integration_tests/osrm_street_names_test.cpp
+++ b/routing/routing_integration_tests/osrm_street_names_test.cpp
@@ -1,0 +1,59 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "routing/route.hpp"
+
+#include "platform/location.hpp"
+
+
+using namespace routing;
+using namespace routing::turns;
+
+void MoveRoute(Route & route, ms::LatLon const & coords)
+{
+  location::GpsInfo info;
+  info.m_horizontalAccuracy = 0.01;
+  info.m_verticalAccuracy = 0.01;
+  info.m_longitude = coords.lon;
+  info.m_latitude = coords.lat;
+  route.MoveIterator(info);
+}
+
+UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetOsrmComponents(),
+      MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
+      MercatorBounds::FromLatLon(55.73198, 37.63945));
+
+  Route & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestCurrentStreetName(route, "Большая Тульская улица");
+  integration::TestNextStreetName(route, "Подольское шоссе");
+
+  MoveRoute(route, ms::LatLon(55.71398, 37.62443));
+
+  integration::TestCurrentStreetName(route, "Подольское шоссе");
+  integration::TestNextStreetName(route, "Валовая улица");
+
+
+  MoveRoute(route, ms::LatLon(55.72059, 37.62766));
+
+  integration::TestCurrentStreetName(route, "Павловская улица");
+  integration::TestNextStreetName(route, "Валовая улица");
+
+  MoveRoute(route, ms::LatLon(55.72469, 37.62624));
+
+  integration::TestCurrentStreetName(route, "Большая Серпуховская улица");
+  integration::TestNextStreetName(route, "Валовая улица");
+
+  MoveRoute(route, ms::LatLon(55.73034, 37.63099));
+
+  integration::TestCurrentStreetName(route, "Валовая улица");
+  integration::TestNextStreetName(route, "");
+
+  integration::TestRouteLength(route, 3390.);
+}

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -30,6 +30,7 @@ SOURCES += \
   osrm_turn_test.cpp \
   pedestrian_route_test.cpp \
   routing_test_tools.cpp \
+  osrm_street_names_test.cpp \
 
 HEADERS += \
   routing_test_tools.hpp \

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -27,10 +27,10 @@ SOURCES += \
   cross_section_tests.cpp \
   online_cross_tests.cpp \
   osrm_route_test.cpp \
+  osrm_street_names_test.cpp \
   osrm_turn_test.cpp \
   pedestrian_route_test.cpp \
   routing_test_tools.cpp \
-  osrm_street_names_test.cpp \
 
 HEADERS += \
   routing_test_tools.hpp \

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -188,6 +188,23 @@ namespace integration
     TEST_EQUAL(route.GetTurns().size() - 1, expectedTurnCount, ());
   }
 
+  void TestCurrentStreetName(routing::Route const & route, string const & expectedStreetName)
+  {
+    string streetName;
+    route.GetCurrentStreetName(streetName);
+    TEST_EQUAL(streetName, expectedStreetName, ());
+  }
+
+  void TestNextStreetName(routing::Route const & route, string const & expectedStreetName)
+  {
+    string streetName;
+    double distance;
+    turns::TurnItem turn;
+    TEST(route.GetCurrentTurn(distance, turn), ());
+    route.GetStreetNameAfterIdx(turn.m_index, streetName);
+    TEST_EQUAL(streetName, expectedStreetName, ());
+  }
+
   void TestRouteLength(Route const & route, double expectedRouteMeters,
                        double relativeError)
   {

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -144,4 +144,8 @@ unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetter();
   /// Extracting appropriate TestTurn if any. If not TestTurn::isValid() returns false.
   /// inaccuracy is set in meters.
   TestTurn GetNthTurn(Route const & route, uint32_t turnNumber);
+
+  void TestCurrentStreetName(routing::Route const & route, string const & expectedStreetName);
+
+  void TestNextStreetName(routing::Route const & route, string const & expectedStreetName);
 }

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -288,8 +288,8 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
 
   info.m_exitNum = turn.m_exitNum;
   info.m_time = max(kMinimumETASec, m_route.GetCurrentTimeToEndSec());
-  info.m_sourceName = turn.m_sourceName;
-  info.m_targetName = turn.m_targetName;
+  m_route.GetCurrentStreetName(info.m_sourceName);
+  m_route.GetStreetNameAfterIdx(turn.m_index, info.m_targetName);
   info.m_completionPercent = GetCompletionPercent();
   // Lane information.
   if (distanceToTurnMeters < kShowLanesDistInMeters)

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -18,6 +18,7 @@ static vector<m2::PointD> const kTestGeometry({{0, 0}, {0,1}, {1,1}, {1,2}, {1,3
 static vector<turns::TurnItem> const kTestTurns({turns::TurnItem(1, turns::TurnDirection::TurnLeft),
                                turns::TurnItem(2, turns::TurnDirection::TurnRight),
                                turns::TurnItem(4, turns::TurnDirection::ReachedYourDestination)});
+static Route::TStreets const kTestNames({{0,"Street1"}, {1, "Street2"}, {4, "Street3"}});
 
 location::GpsInfo GetGps(double x, double y)
 {
@@ -156,4 +157,34 @@ UNIT_TEST(NextTurnsTest)
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
   }
+}
+
+UNIT_TEST(RouteNameTest)
+{
+  Route route("TestRouter");
+
+  route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
+  vector<turns::TurnItem> turns(kTestTurns);
+  route.SetTurnInstructions(turns);
+  Route::TStreets names(kTestNames);
+  route.SetStreetNames(names);
+
+  string name;
+  route.GetCurrentStreetName(name);
+  TEST_EQUAL(name, "Street1", ());
+
+  route.GetStreetNameAfterIdx(0, name);
+  TEST_EQUAL(name, "Street1", ());
+
+  route.GetStreetNameAfterIdx(1, name);
+  TEST_EQUAL(name, "Street2", ());
+
+  route.GetStreetNameAfterIdx(2, name);
+  TEST_EQUAL(name, "Street2", ());
+
+  route.GetStreetNameAfterIdx(3, name);
+  TEST_EQUAL(name, "Street2", ());
+
+  route.GetStreetNameAfterIdx(4, name);
+  TEST_EQUAL(name, "Street3", ());
 }

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -18,7 +18,7 @@ static vector<m2::PointD> const kTestGeometry({{0, 0}, {0,1}, {1,1}, {1,2}, {1,3
 static vector<turns::TurnItem> const kTestTurns({turns::TurnItem(1, turns::TurnDirection::TurnLeft),
                                turns::TurnItem(2, turns::TurnDirection::TurnRight),
                                turns::TurnItem(4, turns::TurnDirection::ReachedYourDestination)});
-static Route::TStreets const kTestNames({{0,"Street1"}, {1, "Street2"}, {4, "Street3"}});
+static Route::TStreets const kTestNames({{0, "Street1"}, {1, "Street2"}, {4, "Street3"}});
 
 location::GpsInfo GetGps(double x, double y)
 {


### PR DESCRIPTION
MAPSME-451
Храним названия улиц в отдельном хранилище внутри класса маршрута. Название улицы берётся из поля name.
Эти названия показываются в интерфейсе пользователя при ведении по маршруту. 
Интеграционный тест прилагается.