### PR TITLE
[DO NOT MERGE] Replace Republic of China with Taiwan in translations (release)

### DIFF
--- a/data/countries-strings/cs.json/localize.json
+++ b/data/countries-strings/cs.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Ticino",
 "Switzerland_Zurich":"Metropolitní oblast Curych",
 "Syria":"Sýrie",
-"Taiwan":"Čínská republika",
+"Taiwan":"Tchaj-wan",
 "Tajikistan":"Tádžikistán",
 "Tanzania":"Tanzanie",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/da.json/localize.json
+++ b/data/countries-strings/da.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Ticino",
 "Switzerland_Zurich":"Zürich byområde",
 "Syria":"Syrien",
-"Taiwan":"Republikken Kina",
+"Taiwan":"Taiwan",
 "Tajikistan":"Tadsjikistan",
 "Tanzania":"Tanzania",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/de.json/localize.json
+++ b/data/countries-strings/de.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Kanton Tessin",
 "Switzerland_Zurich":"Metropolregion Zürich",
 "Syria":"Syrien",
-"Taiwan":"Republik China (Taiwan)",
+"Taiwan":"Taiwan",
 "Tajikistan":"Tadschikistan",
 "Tanzania":"Tansania",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/es.json/localize.json
+++ b/data/countries-strings/es.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Tesino",
 "Switzerland_Zurich":"Área metropolitana de Zurich",
 "Syria":"Siria",
-"Taiwan":"República de China",
+"Taiwan":"Taiwán",
 "Tajikistan":"Tayikistán",
 "Tanzania":"Tanzania",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/pl.json/localize.json
+++ b/data/countries-strings/pl.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Ticino",
 "Switzerland_Zurich":"Aglomeracja Zurych",
 "Syria":"Syria",
-"Taiwan":"Republika Chińska",
+"Taiwan":"Tajwan",
 "Tajikistan":"Tadżykistan",
 "Tanzania":"Tanzania",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/pt.json/localize.json
+++ b/data/countries-strings/pt.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Ticino",
 "Switzerland_Zurich":"Área Metropolitana de Zurique",
 "Syria":"Síria",
-"Taiwan":"República da China",
+"Taiwan":"Taiwan",
 "Tajikistan":"Tajiquistão",
 "Tanzania":"Tanzânia",
 "Tennessee":"Tennessee",

--- a/data/countries-strings/ru.json/localize.json
+++ b/data/countries-strings/ru.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Тичино",
 "Switzerland_Zurich":"Цюрих",
 "Syria":"Сирия",
-"Taiwan":"Китайская Республика",
+"Taiwan":"Тайвань",
 "Tajikistan":"Таджикистан",
 "Tanzania":"Танзания",
 "Tennessee":"Теннесси",

--- a/data/countries-strings/uk.json/localize.json
+++ b/data/countries-strings/uk.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Тічино",
 "Switzerland_Zurich":"Агломерація Цюрих",
 "Syria":"Сирія",
-"Taiwan":"Республіка Китай",
+"Taiwan":"Тайвань",
 "Tajikistan":"Таджикистан",
 "Tanzania":"Танзанія",
 "Tennessee":"Теннессі",

--- a/data/countries-strings/vi.json/localize.json
+++ b/data/countries-strings/vi.json/localize.json
@@ -974,7 +974,7 @@
 "Switzerland_Ticino":"Ticino",
 "Switzerland_Zurich":"Vùng đô thị Zürich",
 "Syria":"Syria",
-"Taiwan":"Trung Hoa Dân Quốc",
+"Taiwan":"Đài Loan",
 "Tajikistan":"Tajikistan",
 "Tanzania":"Tanzania",
 "Tennessee":"Tennessee",

--- a/localization/countries_names/countries_names.txt
+++ b/localization/countries_names/countries_names.txt
@@ -29250,19 +29250,19 @@ he = סוריה
 
 [Taiwan]
 en = Taiwan
-ru = Китайская Республика
+ru = Тайвань
 fr = Taïwan
-da = Republikken Kina
+da = Taiwan
 id = Republik Tiongkok
 ko = 중화민국
 sv = Taiwan
 tr = Çin Cumhuriyeti
-uk = Республіка Китай
-vi = Trung Hoa Dân Quốc
+uk = Тайвань
+vi = Đài Loan
 hu = Kínai Köztársaság
-de = Republik China (Taiwan)
+de = Taiwan
 fi = Taiwan
-cs = Čínská republika
+cs = Tchaj-wan
 it = Taiwan
 nb = Republikken Kina
 zh-Hant = 中華民國
@@ -29272,10 +29272,10 @@ ja = 中華民国
 ro = Taiwan
 ar = تايوان
 sk = Taiwan
-es = República de China
-pl = Republika Chińska
+es = Taiwán
+pl = Tajwan
 nl = Taiwan
-pt = República da China
+pt = Taiwan
 he = הרפובליקה הסינית
 
 [Tajikistan]


### PR DESCRIPTION
Тайвань — это, конечно, Китайская Республика, но никто не ищет его по этому названию.