### PR TITLE
[countries] Move Falkland Island to the top level (release)

### DIFF
--- a/data/countries.txt
+++ b/data/countries.txt
@@ -13434,6 +13434,16 @@
    ]
   },
   {
+   "id": "Falkland Islands",
+   "s": 1412665,
+   "affiliations": [
+    "Falkland Islands"
+   ],
+   "old": [
+    "Falkland Islands"
+   ]
+  },
+  {
    "id": "United Kingdom",
    "g": [
     {
@@ -13444,16 +13454,6 @@
      ],
      "old": [
       "British Indian Ocean Territory"
-     ]
-    },
-    {
-     "id": "Falkland Islands",
-     "s": 1412665,
-     "affiliations": [
-      "Falkland Islands"
-     ],
-     "old": [
-      "Falkland Islands"
      ]
     },
     {

--- a/data/hierarchy.txt
+++ b/data/hierarchy.txt
@@ -1063,9 +1063,9 @@ Ukraine;Q212;ua;uk
  Ukraine_Zhytomyr Oblast;Q40637
  Crimea;Q7835
 United Arab Emirates;Q878;ae;ar
+Falkland Islands;Q9648
 United Kingdom;Q145;gb;en
  British Indian Ocean Territory;Q43448
- Falkland Islands;Q9648
  UK_England_East Midlands;Q47994
  UK_England_East of England_Essex;Q48006-Q23240
  UK_England_East of England_Norfolk;Q48006-Q23109


### PR DESCRIPTION
По ходу, не все согласны, что Фолкленды должны быть в UK.