### PR TITLE
Exchanging size_t to uint64_t for mwm and group mwm size in bytes.

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
@@ -27,7 +27,7 @@
   if (self)
   {
     NSMutableArray * titles = [@[] mutableCopy];
-    size_t totalRoutingSize = 0;
+    storage::TMwmSize totalRoutingSize = 0;
     auto & s = GetFramework().Storage();
     for (auto const & countryId : countriesVec)
     {

--- a/iphone/Maps/Classes/MapDownloader/MWMBaseMapDownloaderViewController.mm
+++ b/iphone/Maps/Classes/MapDownloader/MWMBaseMapDownloaderViewController.mm
@@ -325,7 +325,7 @@ using namespace storage;
     s.GetQueuedChildren(parentCountryId, queuedChildren);
     if (!queuedChildren.empty())
     {
-      size_t queuedSize = 0;
+      storage::TMwmSize queuedSize = 0;
       for (TCountryId const & countryId : queuedChildren)
       {
         NodeAttrs nodeAttrs;

--- a/iphone/Maps/Classes/Storage/MWMStorage.mm
+++ b/iphone/Maps/Classes/Storage/MWMStorage.mm
@@ -69,7 +69,7 @@
     {
       storage::NodeAttrs attrs;
       GetFramework().Storage().GetNodeAttrs(countryId, attrs);
-      size_t const warningSizeForWWAN = 50 * MB;
+      storage::TMwmSize const warningSizeForWWAN = 50 * MB;
       if (attrs.m_mwmSize > warningSizeForWWAN)
         [alertController presentNoWiFiAlertWithName:@(attrs.m_nodeLocalName.c_str()) okBlock:action];
       else

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -290,9 +290,10 @@ void Framework::Migrate(bool keepDownloaded)
 Framework::Framework()
   : m_storage(platform::migrate::NeedMigrate() ? COUNTRIES_OBSOLETE_FILE : COUNTRIES_FILE)
   , m_bmManager(*this)
+  , m_isRenderingEnabled(true)
   , m_fixedSearchResults(0)
   , m_lastReportedCountry(kInvalidCountryId)
-  , m_isRenderingEnabled(true)
+
 {
   // Restore map style before classificator loading
   int mapStyle = MapStyleLight;

--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -70,17 +70,15 @@ string LocalCountryFile::GetPath(MapOptions file) const
   return my::JoinFoldersToPath(m_directory, GetFileName(m_countryFile.GetName(), file, GetVersion()));
 }
 
-uint32_t LocalCountryFile::GetSize(MapOptions filesMask) const
+uint64_t LocalCountryFile::GetSize(MapOptions filesMask) const
 {
-  uint64_t size64 = 0;
+  uint64_t size = 0;
   if (HasOptions(filesMask, MapOptions::Map))
-    size64 += m_mapSize;
+    size += m_mapSize;
   if (!version::IsSingleMwm(GetVersion()) && HasOptions(filesMask, MapOptions::CarRouting))
-    size64 += m_routingSize;
+    size += m_routingSize;
 
-  uint32_t const size32 = static_cast<uint32_t>(size64);
-  ASSERT_EQUAL(size32, size64, ());
-  return size32;
+  return size;
 }
 
 bool LocalCountryFile::operator<(LocalCountryFile const & rhs) const

--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -51,7 +51,7 @@ public:
 
   // Returns size of a file. Return value may be zero until
   // SyncWithDisk() is called.
-  uint32_t GetSize(MapOptions filesMask) const;
+  uint64_t GetSize(MapOptions filesMask) const;
 
   // Returns a mask of all known country files. Return value may be
   // empty until SyncWithDisk() is called.

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -129,7 +129,7 @@ void DrawWidget::UpdateCountryStatus(storage::TCountryId const & countryId)
 
     auto status = m_framework->Storage().CountryStatusEx(countryId);
 
-    uint64_t sizeInBytes = 0;
+    storage::TMwmSize sizeInBytes = 0;
     if (!countryId.empty())
     {
       storage::NodeAttrs nodeAttrs;

--- a/storage/country.cpp
+++ b/storage/country.cpp
@@ -17,7 +17,7 @@ namespace storage
 // Mwm subtree attributes. They can be calculated based on information contained in countries.txt.
 // The first in the pair is number of mwms in a subtree. The second is sum of sizes of
 // all mwms in a subtree.
-using TMwmSubtreeAttrs = pair<uint32_t, size_t>;
+using TMwmSubtreeAttrs = pair<TMwmCounter, TMwmSize>;
 
 namespace
 {
@@ -25,7 +25,7 @@ class StoreSingleMwmInterface
 {
 public:
   virtual ~StoreSingleMwmInterface() = default;
-  virtual Country * InsertToCountryTree(TCountryId const & id, uint32_t mapSize, size_t depth,
+  virtual Country * InsertToCountryTree(TCountryId const & id, TMwmSize mapSize, size_t depth,
                                         TCountryId const & parent) = 0;
   virtual void InsertOldMwmMapping(TCountryId const & newId, TCountryId const & oldId) = 0;
   virtual void InsertAffiliation(TCountryId const & countryId, string const & affilation) = 0;
@@ -50,7 +50,7 @@ public:
   }
 
   // StoreSingleMwmInterface overrides:
-  Country * InsertToCountryTree(TCountryId const & id, uint32_t mapSize, size_t depth,
+  Country * InsertToCountryTree(TCountryId const & id, TMwmSize mapSize, size_t depth,
                                 TCountryId const & parent) override
   {
     Country country(id, parent);
@@ -88,7 +88,7 @@ public:
   StoreFile2InfoSingleMwms(map<string, CountryInfo> & file2info) : m_file2info(file2info) {}
 
   // StoreSingleMwmInterface overrides:
-  Country * InsertToCountryTree(TCountryId const & id, uint32_t /* mapSize */, size_t /* depth */,
+  Country * InsertToCountryTree(TCountryId const & id, TMwmSize /* mapSize */, size_t /* depth */,
                                 TCountryId const & /* parent */) override
   {
     CountryInfo info(id);
@@ -135,8 +135,8 @@ TMwmSubtreeAttrs LoadGroupSingleMwmsImpl(size_t depth, json_t * node, TCountryId
   // We expect that mwm and routing files should be less than 2GB.
   Country * addedNode = store.InsertToCountryTree(id, nodeSize, depth, parent);
 
-  uint32_t mwmCounter = 0;
-  size_t mwmSize = 0;
+  TMwmCounter mwmCounter = 0;
+  TMwmSize mwmSize = 0;
   vector<json_t *> children;
   my::FromJSONObjectOptionalField(node, "g", children);
   if (children.empty())
@@ -181,7 +181,7 @@ class StoreTwoComponentMwmInterface
 {
 public:
   virtual ~StoreTwoComponentMwmInterface() = default;
-  virtual Country * Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */, size_t depth,
+  virtual Country * Insert(string const & id, TMwmSize mapSize, TMwmSize /* routingSize */, size_t depth,
                            TCountryId const & parent) = 0;
 };
 
@@ -197,7 +197,7 @@ public:
   }
 
   // StoreTwoComponentMwmInterface overrides:
-  virtual Country * Insert(string const & id, uint32_t mapSize, uint32_t routingSize, size_t depth,
+  virtual Country * Insert(string const & id, TMwmSize mapSize, TMwmSize routingSize, size_t depth,
                            TCountryId const & parent) override
   {
     Country country(id, parent);
@@ -220,7 +220,7 @@ public:
   StoreFile2InfoTwoComponentMwms(map<string, CountryInfo> & file2info) : m_file2info(file2info) {}
 
   // StoreTwoComponentMwmInterface overrides:
-  virtual Country * Insert(string const & id, uint32_t mapSize, uint32_t /* routingSize */, size_t /* depth */,
+  virtual Country * Insert(string const & id, TMwmSize mapSize, TMwmSize /* routingSize */, size_t /* depth */,
                            TCountryId const & /* parent */) override
   {
     if (mapSize == 0)
@@ -250,11 +250,11 @@ TMwmSubtreeAttrs LoadGroupTwoComponentMwmsImpl(size_t depth, json_t * node, TCou
   ASSERT_LESS_OR_EQUAL(0, mwmSize, ());
   ASSERT_LESS_OR_EQUAL(0, routingSize, ());
 
-  Country * addedNode = store.Insert(file, static_cast<uint32_t>(mwmSize), static_cast<uint32_t>(routingSize),
+  Country * addedNode = store.Insert(file, static_cast<TMwmSize>(mwmSize), static_cast<TMwmSize>(routingSize),
                                      depth, parent);
 
-  uint32_t countryCounter = 0;
-  size_t countrySize = 0;
+  TMwmCounter countryCounter = 0;
+  TMwmSize countrySize = 0;
   vector<json_t *> children;
   my::FromJSONObjectOptionalField(node, "g", children);
   if (children.empty())

--- a/storage/country.hpp
+++ b/storage/country.hpp
@@ -50,10 +50,10 @@ class Country
   platform::CountryFile m_file;
   /// The number of descendant mwm files of |m_name|. Only files (leaves in tree) are counted.
   /// If |m_name| is a mwm file name |m_childrenNumber| == 1.
-  uint32_t m_subtreeMwmNumber;
+  TMwmCounter m_subtreeMwmNumber;
   /// Size of descendant mwm files of |m_name|.
   /// If |m_name| is a mwm file name |m_subtreeMwmSizeBytes| is equal to size of the mwm.
-  size_t m_subtreeMwmSizeBytes;
+  TMwmSize m_subtreeMwmSizeBytes;
 
 public:
   Country() = default;
@@ -61,13 +61,13 @@ public:
     : m_name(name), m_parent(parent) {}
 
   void SetFile(platform::CountryFile const & file) { m_file = file; }
-  void SetSubtreeAttrs(uint32_t subtreeMwmNumber, size_t subtreeMwmSizeBytes)
+  void SetSubtreeAttrs(TMwmCounter subtreeMwmNumber, TMwmSize subtreeMwmSizeBytes)
   {
     m_subtreeMwmNumber = subtreeMwmNumber;
     m_subtreeMwmSizeBytes = subtreeMwmSizeBytes;
   }
-  uint32_t GetSubtreeMwmCounter() const { return m_subtreeMwmNumber; }
-  size_t GetSubtreeMwmSizeBytes() const { return m_subtreeMwmSizeBytes; }
+  TMwmCounter GetSubtreeMwmCounter() const { return m_subtreeMwmNumber; }
+  TMwmSize GetSubtreeMwmSizeBytes() const { return m_subtreeMwmSizeBytes; }
   TCountryId GetParent() const { return m_parent; }
 
   /// This function valid for current logic - one file for one country (region).

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -1316,7 +1316,7 @@ void Storage::GetNodeAttrs(TCountryId const & countryId, NodeAttrs & nodeAttrs) 
   if (nodeAttrs.m_status == NodeStatus::OnDisk)
   {
     // Group or leaf node is on disk and up to date.
-    size_t const subTreeSizeBytes = node->Value().GetSubtreeMwmSizeBytes();
+    TMwmSize const subTreeSizeBytes = node->Value().GetSubtreeMwmSizeBytes();
     nodeAttrs.m_downloadingProgress.first = subTreeSizeBytes;
     nodeAttrs.m_downloadingProgress.second = subTreeSizeBytes;
   }

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -293,8 +293,8 @@ public:
   {
     UpdateInfo() : m_numberOfMwmFilesToUpdate(0), m_totalUpdateSizeInBytes(0) {}
 
-    uint32_t m_numberOfMwmFilesToUpdate;
-    uint64_t m_totalUpdateSizeInBytes;
+    TMwmCounter m_numberOfMwmFilesToUpdate;
+    TMwmSize m_totalUpdateSizeInBytes;
   };
 
   struct StatusCallback

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -3,6 +3,7 @@
 #include "storage/country.hpp"
 #include "storage/country_name_getter.hpp"
 #include "storage/country_tree.hpp"
+#include "storage/storage_defines.hpp"
 #include "storage/index.hpp"
 #include "storage/map_files_downloader.hpp"
 #include "storage/queued_country.hpp"
@@ -45,31 +46,31 @@ struct NodeAttrs
   /// If the node is expandable (a big country) |m_mwmCounter| is number of mwm files (leaves)
   /// belonging to the node. If the node isn't expandable |m_mwmCounter| == 1.
   /// Note. For every expandable node |m_mwmCounter| >= 2.
-  uint32_t m_mwmCounter;
+  TMwmCounter m_mwmCounter;
 
   /// Number of mwms belonging to the node which have been downloaded.
-  uint32_t m_localMwmCounter;
+  TMwmCounter m_localMwmCounter;
 
   /// Number of leaves of the node which have been downloaded
   /// plus which is in progress of downloading (zero or one)
   /// plus which are staying in queue.
-  uint32_t m_downloadingMwmCounter;
+  TMwmCounter m_downloadingMwmCounter;
 
   /// If it's not an expandable node, |m_mwmSize| is size of one mwm according to countries.txt.
   /// Otherwise |m_mwmSize| is the sum of all mwm file sizes which belong to the group
   /// according to countries.txt.
-  size_t m_mwmSize;
+  TMwmSize m_mwmSize;
 
   /// If it's not an expandable node, |m_localMwmSize| is size of one downloaded mwm.
   /// Otherwise |m_localNodeSize| is the sum of all mwm file sizes which belong to the group and
   /// have been downloaded.
-  size_t m_localMwmSize;
+  TMwmSize m_localMwmSize;
 
   /// Size of leaves of the node which have been downloaded
   /// plus which is in progress of downloading (zero or one)
   /// plus which are staying in queue.
   /// \note The size of leaves is the size is written in countries.txt.
-  size_t m_downloadingMwmSize;
+  TMwmSize m_downloadingMwmSize;
 
   /// The name of the node in a local language. That means the language dependent on
   /// a device locale.
@@ -88,7 +89,7 @@ struct NodeAttrs
   /// Locale language is a language set by Storage::SetLocale().
   /// \note Most number of nodes have only first level parent. But in case of a disputed territories
   /// an mwm could have two or even more parents. See Country description for details.
-   vector<CountryIdAndName> m_topmostParentInfo;
+  vector<CountryIdAndName> m_topmostParentInfo;
 
   /// Progress of downloading for the node expandable or not. It reflects downloading progress in case of
   /// downloading and updating mwm.
@@ -292,8 +293,8 @@ public:
   {
     UpdateInfo() : m_numberOfMwmFilesToUpdate(0), m_totalUpdateSizeInBytes(0) {}
 
-    size_t m_numberOfMwmFilesToUpdate;
-    size_t m_totalUpdateSizeInBytes;
+    uint32_t m_numberOfMwmFilesToUpdate;
+    uint64_t m_totalUpdateSizeInBytes;
   };
 
   struct StatusCallback

--- a/storage/storage_defines.hpp
+++ b/storage/storage_defines.hpp
@@ -63,7 +63,9 @@ namespace storage
   };
   string DebugPrint(StatusAndError statusAndError);
 
-  using TLocalAndRemoteSize = pair<uint64_t, uint64_t>;
+  using TMwmCounter = uint32_t;
+  using TMwmSize = uint64_t;
+  using TLocalAndRemoteSize = pair<TMwmSize, TMwmSize>;
 
   StatusAndError ParseStatus(Status innerStatus);
 }  // namespace storage

--- a/storage/storage_integration_tests/storage_group_download_tests.cpp
+++ b/storage/storage_integration_tests/storage_group_download_tests.cpp
@@ -105,7 +105,7 @@ void DownloadGroup(Storage & storage, bool oneByOne)
   TEST(downloaded.empty(), ());
 
   // Check status for the all children nodes is set to ENotDownloaded.
-  size_t totalGroupSize = 0;
+  TMwmSize totalGroupSize = 0;
   for (auto const & countryId : children)
   {
     TEST_EQUAL(Status::ENotDownloaded, storage.CountryStatusEx(countryId), ());

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -467,7 +467,7 @@ void OnCountryDownloaded(TCountryId const & countryId, TLocalFilePtr const local
   LOG(LINFO, ("OnCountryDownloaded:", *localFile));
 }
 
-TLocalFilePtr CreateDummyMapFile(CountryFile const & countryFile, int64_t version, size_t size)
+TLocalFilePtr CreateDummyMapFile(CountryFile const & countryFile, int64_t version, uint64_t size)
 {
   TLocalFilePtr localFile = PreparePlaceForCountryFiles(version, string() /* dataDir */, countryFile);
   TEST(localFile.get(), ("Can't prepare place for", countryFile, "(version", version, ")"));


### PR DESCRIPTION
1. Замена типа с size_t на uint64_t для размера стран в байтах. size_t переполнялось для США на 32 битных девайсах;
2. Поменял порядок в списке инициализации Framework, чтоб не было warning;

https://jira.mail.ru/browse/MAPSME-140

@syershov, @igrechuhin, @rokuz PTAL