### PR TITLE
Routing crosses finding fix.

### DIFF
--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -6,6 +6,7 @@
 namespace
 {
 inline bool IsValidEdgeWeight(EdgeWeight const & w) { return w != INVALID_EDGE_WEIGHT; }
+double constexpr kMwmCrossingNodeEqualityRadiusDegrees = 0.001;
 }
 
 namespace routing
@@ -58,7 +59,7 @@ IRouter::ResultCode CrossMwmGraph::SetStartNode(CrossNode const & startNode)
       for (auto const & nextCross : nextCrosses)
       {
         if (nextCross.toNode.IsValid())
-        dummyEdges.emplace_back(nextCross, weights[i]);
+          dummyEdges.emplace_back(nextCross, weights[i]);
     }
   }
   }
@@ -158,7 +159,7 @@ bool CrossMwmGraph::ConstructBorderCrossImpl(OutgoingCrossNode const & startNode
   nextMapping->LoadCrossContext();
   nextMapping->m_crossContext.ForEachIngoingNodeNearPoint(startNode.m_point, [&](IngoingCrossNode const & node)
     {
-    if (node.m_point == startNode.m_point)
+    if (node.m_point.EqualDxDy(startNode.m_point, kMwmCrossingNodeEqualityRadiusDegrees))
     {
       auto const toCross = CrossNode(node.m_nodeId, nextMapping->GetMwmId(), node.m_point);
       if (toCross.IsValid())

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -121,6 +121,13 @@ namespace
                                                   {37.40993977728661, 67.644784047393685}, 14296.);
   }
 
+  UNIT_TEST(NederlandLeeuwardenToDenOeverTest)
+  {
+    integration::CalculateRouteAndTestRouteLength(integration::GetOsrmComponents(),
+                                                  MercatorBounds::FromLatLon(53.2076, 5.7082), {0., 0.},
+                                                  MercatorBounds::FromLatLon(52.9337, 5.0308), 59500.);
+  }
+
   UNIT_TEST(RussiaMoscowGerPanfilovtsev22SolodchaPravdiRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(


### PR DESCRIPTION
MAPSME-707

Иногда при упрощении точки пересечения границы попадают в соседние квадраты. Это надо учитывать при их сравнении.