### PR TITLE
[generator] Add bench and shelter to replaced tags

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -1,4 +1,6 @@
 atm=yes : amenity=atm
+bench=yes : amenity=bench
+shelter=yes : amenity=shelter
 restaurant=yes : amenity=restaurant
 hotel=yes : tourism=hotel
 building=entrance : entrance=yes

--- a/defines.hpp
+++ b/defines.hpp
@@ -69,4 +69,4 @@
 
 #define GPS_TRACK_FILENAME "gps_track.dat"
 
-#define PEPLACED_TAGS_FILE "replaced_tags.txt"
+#define REPLACED_TAGS_FILE "replaced_tags.txt"

--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -510,7 +510,7 @@ bool GenerateFeaturesImpl(feature::GenerateInfo & info)
 
     TagAdmixer tagAdmixer(info.GetIntermediateFileName("ways", ".csv"),
                           info.GetIntermediateFileName("towns", ".csv"));
-    TagReplacer tagReplacer(GetPlatform().ResourcesDir() + PEPLACED_TAGS_FILE);
+    TagReplacer tagReplacer(GetPlatform().ResourcesDir() + REPLACED_TAGS_FILE);
 
     // Here we can add new tags to element!!!
     auto const fn = [&](OsmElement * e)

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -92,6 +92,8 @@ public:
     // 2-arity
     char const * arr2[][2] = {
       { "amenity", "atm" },
+      { "amenity", "bench" },
+      { "amenity", "shelter" },
       { "building", "address" },
     };
 


### PR DESCRIPTION
Фоллоу-ап к #2698: поправил опечатку и добавил определение тегов для скамейки и крыши (полезно для остановок транспорта).