### PR TITLE
[generator] Fix a nasty bug in tag replacer

### DIFF
--- a/generator/tag_admixer.hpp
+++ b/generator/tag_admixer.hpp
@@ -172,9 +172,9 @@ public:
       if (it != m_entries.end())
       {
         auto const & v = it->second;
-        tag.key = v[2];
-        tag.value = v[3];
-        for (size_t i = 4; i < v.size(); i += 2)
+        tag.key = v[0];
+        tag.value = v[1];
+        for (size_t i = 2; i < v.size(); i += 2)
           p->AddTag(v[i], v[i + 1]);
       }
     }


### PR DESCRIPTION
Неделю назад в TagReplacer проникла ошибочка, из-за которой сборка планеты вылетает на шаге 4. Кто-то забыл, что первая пара ключ-значение уходит в индекс мэпки.