### PR TITLE
[ios] Fixed crash.

### DIFF
--- a/iphone/Maps/Classes/MapDownloader/MWMBaseMapDownloaderViewController.mm
+++ b/iphone/Maps/Classes/MapDownloader/MWMBaseMapDownloaderViewController.mm
@@ -636,13 +636,12 @@ using namespace storage;
 
 - (void)setDataSource:(MWMMapDownloaderDataSource *)dataSource
 {
-  self.tableView.dataSource = dataSource;
   self.forceFullReload = YES;
-}
 
-- (MWMMapDownloaderDataSource *)dataSource
-{
-  return static_cast<MWMMapDownloaderDataSource *>(self.tableView.dataSource);
+  // Order matters. _dataSource must be set last since self.tableView does not retain dataSource.
+  // In different order outdated datasource gets reclaimed between assignments.
+  self.tableView.dataSource = dataSource;
+  _dataSource = dataSource;
 }
 
 #pragma mark - Helpers


### PR DESCRIPTION
MWM<Base>MapDownloaderViewController retains its dataSources.
However its tableView does not retain its dataSource.
During switch of active dataSource, tableView was loosing its dataSource.
Table reload during dataSource switch led to crashes.