### PR TITLE
Bicycle routing profile.

### DIFF
--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -1,5 +1,6 @@
 #include "generator/feature_builder.hpp"
 
+#include "routing/bicycle_model.hpp"
 #include "routing/car_model.hpp"
 #include "routing/pedestrian_model.hpp"
 
@@ -225,7 +226,9 @@ namespace
 bool FeatureBuilder1::IsRoad() const
 {
   static routing::PedestrianModel const pedModel;
-  return routing::CarModel::Instance().IsRoad(m_params.m_Types) || pedModel.IsRoad(m_params.m_Types);
+  static routing::BicycleModel const bicModel;
+  return routing::CarModel::Instance().IsRoad(m_params.m_Types) || pedModel.IsRoad(m_params.m_Types)
+      || bicModel.IsRoad(m_params.m_Types);
 }
 
 bool FeatureBuilder1::PreSerialize()

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2206,6 +2206,11 @@ void Framework::SetRouterImpl(RouterType type)
     router = CreatePedestrianAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter);
     m_routingSession.SetRoutingSettings(routing::GetPedestrianRoutingSettings());
   }
+  else if (type == RouterType::Bicycle)
+  {
+    router = CreateBicycleAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter);
+    m_routingSession.SetRoutingSettings(routing::GetBicycleRoutingSettings());
+  }
   else
   {
     auto localFileChecker = [this](string const & countryFile) -> bool

--- a/qt/search_panel.cpp
+++ b/qt/search_panel.cpp
@@ -175,21 +175,19 @@ bool SearchPanel::TryChangeMapStyleCmd(QString const & str)
 // TODO: This code only for demonstration purposes and will be removed soon
 bool SearchPanel::TryChangeRouterCmd(QString const & str)
 {
-  bool const isPedestrian = (str == "?pedestrian");
-  bool const isVehicle = isPedestrian ? false : (str == "?vehicle");
-  bool const isBicycle = isPedestrian || isVehicle ? false : (str == "?bicycle");
-
-  if (!isPedestrian && !isVehicle && !isBicycle)
+  routing::RouterType routerType;
+  if (str == "?pedestrian")
+    routerType = routing::RouterType::Pedestrian;
+  else if (str == "?vehicle")
+    routerType = routing::RouterType::Vehicle;
+  else if (str == "?bicycle")
+    routerType = routing::RouterType::Bicycle;
+  else
     return false;
 
   m_pEditor->setText("");
   parentWidget()->hide();
-
-  routing::RouterType const routerType = isPedestrian ? routing::RouterType::Pedestrian :
-                                                       isVehicle ? routing::RouterType::Vehicle :
-                                                                   routing::RouterType::Bicycle;
   m_pDrawWidget->SetRouter(routerType);
-
   return true;
 }
 

--- a/qt/search_panel.cpp
+++ b/qt/search_panel.cpp
@@ -177,14 +177,17 @@ bool SearchPanel::TryChangeRouterCmd(QString const & str)
 {
   bool const isPedestrian = (str == "?pedestrian");
   bool const isVehicle = isPedestrian ? false : (str == "?vehicle");
+  bool const isBicycle = isPedestrian || isVehicle ? false : (str == "?bicycle");
 
-  if (!isPedestrian && !isVehicle)
+  if (!isPedestrian && !isVehicle && !isBicycle)
     return false;
 
   m_pEditor->setText("");
   parentWidget()->hide();
 
-  routing::RouterType const routerType = isPedestrian ? routing::RouterType::Pedestrian : routing::RouterType::Vehicle;
+  routing::RouterType const routerType = isPedestrian ? routing::RouterType::Pedestrian :
+                                                       isVehicle ? routing::RouterType::Vehicle :
+                                                                   routing::RouterType::Bicycle;
   m_pDrawWidget->SetRouter(routerType);
 
   return true;

--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -49,7 +49,7 @@ double constexpr kSpeedFootwayKMpH = 7.0;
 double constexpr kSpeedPlatformKMpH = 3.0;
 
 // Default
-routing::VehicleModel::InitListT const s_bicycleLimits_Default =
+routing::VehicleModel::InitListT const g_bicycleLimitsDefault =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -72,7 +72,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Default =
 };
 
 // All options available.
-routing::VehicleModel::InitListT const s_bicycleLimits_All =
+routing::VehicleModel::InitListT const g_bicycleLimitsAll =
 {
   { {"highway", "trunk"},          kSpeedPedestrianKMpH },
   { {"highway", "trunk_link"},     kSpeedPedestrianKMpH },
@@ -98,7 +98,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_All =
 };
 
 // Australia
-routing::VehicleModel::InitListT const s_bicycleLimits_Australia =
+routing::VehicleModel::InitListT const g_bicycleLimitsAustralia =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -124,7 +124,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Australia =
 };
 
 // Austria
-routing::VehicleModel::InitListT const s_bicycleLimits_Austria =
+routing::VehicleModel::InitListT const g_bicycleLimitsAustria =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -144,7 +144,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Austria =
 };
 
 // Belarus
-routing::VehicleModel::InitListT const s_bicycleLimits_Belarus =
+routing::VehicleModel::InitListT const g_bicycleLimitsBelarus =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -169,7 +169,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Belarus =
 };
 
 // Belgium
-routing::VehicleModel::InitListT const s_bicycleLimits_Belgium =
+routing::VehicleModel::InitListT const g_bicycleLimitsBelgium =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -191,7 +191,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Belgium =
 };
 
 // Brazil
-routing::VehicleModel::InitListT const s_bicycleLimits_Brazil =
+routing::VehicleModel::InitListT const g_bicycleLimitsBrazil =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -217,7 +217,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Brazil =
 };
 
 // Denmark
-routing::VehicleModel::InitListT const s_bicycleLimits_Denmark =
+routing::VehicleModel::InitListT const g_bicycleLimitsDenmark =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -238,7 +238,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Denmark =
 };
 
 // France
-routing::VehicleModel::InitListT const s_bicycleLimits_France =
+routing::VehicleModel::InitListT const g_bicycleLimitsFrance =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -260,7 +260,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_France =
 };
 
 // Finland
-routing::VehicleModel::InitListT const s_bicycleLimits_Finland =
+routing::VehicleModel::InitListT const g_bicycleLimitsFinland =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -284,7 +284,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Finland =
 };
 
 // Germany
-routing::VehicleModel::InitListT const s_bicycleLimits_Germany =
+routing::VehicleModel::InitListT const g_bicycleLimitsGermany =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -307,7 +307,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Germany =
 };
 
 // Hungary
-routing::VehicleModel::InitListT const s_bicycleLimits_Hungary =
+routing::VehicleModel::InitListT const g_bicycleLimitsHungary =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -328,7 +328,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Hungary =
 };
 
 // Netherlands
-routing::VehicleModel::InitListT const s_bicycleLimits_Netherlands =
+routing::VehicleModel::InitListT const g_bicycleLimitsNetherlands =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -349,7 +349,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Netherlands =
 };
 
 // Norway
-routing::VehicleModel::InitListT const s_bicycleLimits_Norway =
+routing::VehicleModel::InitListT const g_bicycleLimitsNorway =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -375,7 +375,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Norway =
 };
 
 // Poland
-routing::VehicleModel::InitListT const s_bicycleLimits_Poland =
+routing::VehicleModel::InitListT const g_bicycleLimitsPoland =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -396,7 +396,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Poland =
 };
 
 // Romania
-routing::VehicleModel::InitListT const s_bicycleLimits_Romania =
+routing::VehicleModel::InitListT const g_bicycleLimitsRomania =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -417,7 +417,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Romania =
 };
 
 // Russia
-routing::VehicleModel::InitListT const s_bicycleLimits_Russia =
+routing::VehicleModel::InitListT const g_bicycleLimitsRussia =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -440,7 +440,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Russia =
 };
 
 // Slovakia
-routing::VehicleModel::InitListT const s_bicycleLimits_Slovakia =
+routing::VehicleModel::InitListT const g_bicycleLimitsSlovakia =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -461,7 +461,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Slovakia =
 };
 
 // Switzerland
-routing::VehicleModel::InitListT const s_bicycleLimits_Switzerland =
+routing::VehicleModel::InitListT const g_bicycleLimitsSwitzerland =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -484,7 +484,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Switzerland =
 };
 
 // Turkey
-routing::VehicleModel::InitListT const s_bicycleLimits_Turkey =
+routing::VehicleModel::InitListT const g_bicycleLimitsTurkey =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -507,7 +507,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Turkey =
 };
 
 // Ukraine
-routing::VehicleModel::InitListT const s_bicycleLimits_Ukraine =
+routing::VehicleModel::InitListT const g_bicycleLimitsUkraine =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -529,7 +529,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_Ukraine =
 };
 
 // United Kingdom
-routing::VehicleModel::InitListT const s_bicycleLimits_UK =
+routing::VehicleModel::InitListT const g_bicycleLimitsUK =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -553,7 +553,7 @@ routing::VehicleModel::InitListT const s_bicycleLimits_UK =
 };
 
 // USA
-routing::VehicleModel::InitListT const s_bicycleLimits_USA =
+routing::VehicleModel::InitListT const g_bicycleLimitsUSA =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -584,7 +584,8 @@ namespace routing
 
 // If one of feature types will be disabled for bicycles, features of this type will be simplyfied
 // in generator. Look FeatureBuilder1::IsRoad() for more details.
-BicycleModel::BicycleModel() : VehicleModel(classif(), s_bicycleLimits_All)
+BicycleModel::BicycleModel()
+  : VehicleModel(classif(), g_bicycleLimitsAll)
 {
   Init();
 }
@@ -635,28 +636,28 @@ double BicycleModel::GetSpeed(FeatureType const & f) const
 
 BicycleModelFactory::BicycleModelFactory()
 {
-  m_models[string()] = make_shared<BicycleModel>(s_bicycleLimits_Default);
-  m_models["Australia"] = make_shared<BicycleModel>(s_bicycleLimits_Australia);
-  m_models["Austria"] = make_shared<BicycleModel>(s_bicycleLimits_Austria);
-  m_models["Belarus"] = make_shared<BicycleModel>(s_bicycleLimits_Belarus);
-  m_models["Belgium"] = make_shared<BicycleModel>(s_bicycleLimits_Belgium);
-  m_models["Brazil"] = make_shared<BicycleModel>(s_bicycleLimits_Brazil);
-  m_models["Denmark"] = make_shared<BicycleModel>(s_bicycleLimits_Denmark);
-  m_models["France"] = make_shared<BicycleModel>(s_bicycleLimits_France);
-  m_models["Finland"] = make_shared<BicycleModel>(s_bicycleLimits_Finland);
-  m_models["Germany"] = make_shared<BicycleModel>(s_bicycleLimits_Germany);
-  m_models["Hungary"] = make_shared<BicycleModel>(s_bicycleLimits_Hungary);
-  m_models["Netherlands"] = make_shared<BicycleModel>(s_bicycleLimits_Netherlands);
-  m_models["Norway"] = make_shared<BicycleModel>(s_bicycleLimits_Norway);
-  m_models["Poland"] = make_shared<BicycleModel>(s_bicycleLimits_Poland);
-  m_models["Romania"] = make_shared<BicycleModel>(s_bicycleLimits_Romania);
-  m_models["Russia"] = make_shared<BicycleModel>(s_bicycleLimits_Russia);
-  m_models["Slovakia"] = make_shared<BicycleModel>(s_bicycleLimits_Slovakia);
-  m_models["Switzerland"] = make_shared<BicycleModel>(s_bicycleLimits_Switzerland);
-  m_models["Turkey"] = make_shared<BicycleModel>(s_bicycleLimits_Turkey);
-  m_models["Ukraine"] = make_shared<BicycleModel>(s_bicycleLimits_Ukraine);
-  m_models["UK"] = make_shared<BicycleModel>(s_bicycleLimits_UK);
-  m_models["USA"] = make_shared<BicycleModel>(s_bicycleLimits_USA);
+  m_models[string()] = make_shared<BicycleModel>(g_bicycleLimitsDefault);
+  m_models["Australia"] = make_shared<BicycleModel>(g_bicycleLimitsAustralia);
+  m_models["Austria"] = make_shared<BicycleModel>(g_bicycleLimitsAustria);
+  m_models["Belarus"] = make_shared<BicycleModel>(g_bicycleLimitsBelarus);
+  m_models["Belgium"] = make_shared<BicycleModel>(g_bicycleLimitsBelgium);
+  m_models["Brazil"] = make_shared<BicycleModel>(g_bicycleLimitsBrazil);
+  m_models["Denmark"] = make_shared<BicycleModel>(g_bicycleLimitsDenmark);
+  m_models["France"] = make_shared<BicycleModel>(g_bicycleLimitsFrance);
+  m_models["Finland"] = make_shared<BicycleModel>(g_bicycleLimitsFinland);
+  m_models["Germany"] = make_shared<BicycleModel>(g_bicycleLimitsGermany);
+  m_models["Hungary"] = make_shared<BicycleModel>(g_bicycleLimitsHungary);
+  m_models["Netherlands"] = make_shared<BicycleModel>(g_bicycleLimitsNetherlands);
+  m_models["Norway"] = make_shared<BicycleModel>(g_bicycleLimitsNorway);
+  m_models["Poland"] = make_shared<BicycleModel>(g_bicycleLimitsPoland);
+  m_models["Romania"] = make_shared<BicycleModel>(g_bicycleLimitsRomania);
+  m_models["Russia"] = make_shared<BicycleModel>(g_bicycleLimitsRussia);
+  m_models["Slovakia"] = make_shared<BicycleModel>(g_bicycleLimitsSlovakia);
+  m_models["Switzerland"] = make_shared<BicycleModel>(g_bicycleLimitsSwitzerland);
+  m_models["Turkey"] = make_shared<BicycleModel>(g_bicycleLimitsTurkey);
+  m_models["Ukraine"] = make_shared<BicycleModel>(g_bicycleLimitsUkraine);
+  m_models["UK"] = make_shared<BicycleModel>(g_bicycleLimitsUK);
+  m_models["USA"] = make_shared<BicycleModel>(g_bicycleLimitsUSA);
 }
 
 shared_ptr<IVehicleModel> BicycleModelFactory::GetVehicleModel() const

--- a/routing/bicycle_model.hpp
+++ b/routing/bicycle_model.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "std/shared_ptr.hpp"
+#include "std/unordered_map.hpp"
+
+#include "vehicle_model.hpp"
+
+namespace routing
+{
+
+class BicycleModel : public VehicleModel
+{
+public:
+  BicycleModel();
+  BicycleModel(VehicleModel::InitListT const & speedLimits);
+
+  /// @name Overrides from VehicleModel.
+  //@{
+  double GetSpeed(FeatureType const & f) const override;
+  bool IsOneWay(FeatureType const &) const override { return false; }
+  //@}
+
+private:
+  void Init();
+
+  /// @return true if road is prohibited for bicycle,
+  /// but if function returns false, real prohibition is unknown.
+  bool IsNoBicycle(feature::TypesHolder const & types) const;
+
+  /// @return true if road is allowed for bicycle,
+  /// but if function returns false, real allowance is unknown.
+  bool IsYesBicycle(feature::TypesHolder const & types) const;
+
+  uint32_t m_noBicycleType;
+  uint32_t m_yesBicycleType;
+};
+
+class BicycleModelFactory : public IVehicleModelFactory
+{
+public:
+  BicycleModelFactory();
+
+  /// @name Overrides from IVehicleModelFactory.
+  //@{
+  shared_ptr<IVehicleModel> GetVehicleModel() const override;
+  shared_ptr<IVehicleModel> GetVehicleModelForCountry(string const & country) const override;
+  //@}
+
+private:
+  unordered_map<string, shared_ptr<IVehicleModel>> m_models;
+};
+
+}  // namespace routing

--- a/routing/bicycle_model.hpp
+++ b/routing/bicycle_model.hpp
@@ -31,8 +31,8 @@ private:
   /// but if function returns false, real allowance is unknown.
   bool IsYesBicycle(feature::TypesHolder const & types) const;
 
-  uint32_t m_noBicycleType;
-  uint32_t m_yesBicycleType;
+  uint32_t m_noBicycleType = 0;
+  uint32_t m_yesBicycleType = 0;
 };
 
 class BicycleModelFactory : public IVehicleModelFactory

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -49,7 +49,7 @@ double constexpr kSpeedFootwayKMpH = 5.0;
 double constexpr kSpeedPlatformKMpH = 5.0;
 
 // Default
-routing::VehicleModel::InitListT const s_pedestrianLimits_Default =
+routing::VehicleModel::InitListT const g_pedestrianLimitsDefault =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -73,7 +73,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Default =
 };
 
 // All options available.
-routing::VehicleModel::InitListT const s_pedestrianLimits_All =
+routing::VehicleModel::InitListT const g_pedestrianLimitsAll =
 {
   { {"highway", "trunk"},          kSpeedPedestrianKMpH },
   { {"highway", "trunk_link"},     kSpeedPedestrianKMpH },
@@ -99,7 +99,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_All =
 };
 
 // Australia
-routing::VehicleModel::InitListT const s_pedestrianLimits_Australia =
+routing::VehicleModel::InitListT const g_pedestrianLimitsAustralia =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -125,7 +125,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Australia =
 };
 
 // Austria
-routing::VehicleModel::InitListT const s_pedestrianLimits_Austria =
+routing::VehicleModel::InitListT const g_pedestrianLimitsAustria =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -148,7 +148,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Austria =
 };
 
 // Belarus
-routing::VehicleModel::InitListT const s_pedestrianLimits_Belarus =
+routing::VehicleModel::InitListT const g_pedestrianLimitsBelarus =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -173,7 +173,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Belarus =
 };
 
 // Belgium
-routing::VehicleModel::InitListT const s_pedestrianLimits_Belgium =
+routing::VehicleModel::InitListT const g_pedestrianLimitsBelgium =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -197,7 +197,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Belgium =
 };
 
 // Brazil
-routing::VehicleModel::InitListT const s_pedestrianLimits_Brazil =
+routing::VehicleModel::InitListT const g_pedestrianLimitsBrazil =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -223,7 +223,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Brazil =
 };
 
 // Denmark
-routing::VehicleModel::InitListT const s_pedestrianLimits_Denmark =
+routing::VehicleModel::InitListT const g_pedestrianLimitsDenmark =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -246,7 +246,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Denmark =
 };
 
 // France
-routing::VehicleModel::InitListT const s_pedestrianLimits_France =
+routing::VehicleModel::InitListT const g_pedestrianLimitsFrance =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -268,7 +268,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_France =
 };
 
 // Finland
-routing::VehicleModel::InitListT const s_pedestrianLimits_Finland =
+routing::VehicleModel::InitListT const g_pedestrianLimitsFinland =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -293,7 +293,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Finland =
 };
 
 // Germany
-routing::VehicleModel::InitListT const s_pedestrianLimits_Germany =
+routing::VehicleModel::InitListT const g_pedestrianLimitsGermany =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -317,7 +317,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Germany =
 };
 
 // Hungary
-routing::VehicleModel::InitListT const s_pedestrianLimits_Hungary =
+routing::VehicleModel::InitListT const g_pedestrianLimitsHungary =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -339,7 +339,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Hungary =
 };
 
 // Netherlands
-routing::VehicleModel::InitListT const s_pedestrianLimits_Netherlands =
+routing::VehicleModel::InitListT const g_pedestrianLimitsNetherlands =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -362,7 +362,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Netherlands =
 };
 
 // Norway
-routing::VehicleModel::InitListT const s_pedestrianLimits_Norway =
+routing::VehicleModel::InitListT const g_pedestrianLimitsNorway =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -388,7 +388,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Norway =
 };
 
 // Poland
-routing::VehicleModel::InitListT const s_pedestrianLimits_Poland =
+routing::VehicleModel::InitListT const g_pedestrianLimitsPoland =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -410,7 +410,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Poland =
 };
 
 // Romania
-routing::VehicleModel::InitListT const s_pedestrianLimits_Romania =
+routing::VehicleModel::InitListT const g_pedestrianLimitsRomania =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -432,7 +432,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Romania =
 };
 
 // Russia
-routing::VehicleModel::InitListT const s_pedestrianLimits_Russia =
+routing::VehicleModel::InitListT const g_pedestrianLimitsRussia =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -457,7 +457,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Russia =
 };
 
 // Slovakia
-routing::VehicleModel::InitListT const s_pedestrianLimits_Slovakia =
+routing::VehicleModel::InitListT const g_pedestrianLimitsSlovakia =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -479,7 +479,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Slovakia =
 };
 
 // Switzerland
-routing::VehicleModel::InitListT const s_pedestrianLimits_Switzerland =
+routing::VehicleModel::InitListT const g_pedestrianLimitsSwitzerland =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -501,7 +501,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Switzerland =
 };
 
 // Turkey
-routing::VehicleModel::InitListT const s_pedestrianLimits_Turkey =
+routing::VehicleModel::InitListT const g_pedestrianLimitsTurkey =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -527,7 +527,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Turkey =
 };
 
 // Ukraine
-routing::VehicleModel::InitListT const s_pedestrianLimits_Ukraine =
+routing::VehicleModel::InitListT const g_pedestrianLimitsUkraine =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
@@ -549,7 +549,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_Ukraine =
 };
 
 // United Kingdom
-routing::VehicleModel::InitListT const s_pedestrianLimits_UK =
+routing::VehicleModel::InitListT const g_pedestrianLimitsUK =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -575,7 +575,7 @@ routing::VehicleModel::InitListT const s_pedestrianLimits_UK =
 };
 
 // USA
-routing::VehicleModel::InitListT const s_pedestrianLimits_USA =
+routing::VehicleModel::InitListT const g_pedestrianLimitsUSA =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -607,7 +607,8 @@ namespace routing
 
 // If one of feature types will be disabled for pedestrian, features of this type will be simplyfied
 // in generator. Look FeatureBuilder1::IsRoad() for more details.
-PedestrianModel::PedestrianModel() : VehicleModel(classif(), s_pedestrianLimits_All)
+PedestrianModel::PedestrianModel()
+  : VehicleModel(classif(), g_pedestrianLimitsAll)
 {
   Init();
 }
@@ -657,28 +658,28 @@ double PedestrianModel::GetSpeed(FeatureType const & f) const
 
 PedestrianModelFactory::PedestrianModelFactory()
 {
-  m_models[string()] = make_shared<PedestrianModel>(s_pedestrianLimits_Default);
-  m_models["Australia"] = make_shared<PedestrianModel>(s_pedestrianLimits_Australia);
-  m_models["Austria"] = make_shared<PedestrianModel>(s_pedestrianLimits_Austria);
-  m_models["Belarus"] = make_shared<PedestrianModel>(s_pedestrianLimits_Belarus);
-  m_models["Belgium"] = make_shared<PedestrianModel>(s_pedestrianLimits_Belgium);
-  m_models["Brazil"] = make_shared<PedestrianModel>(s_pedestrianLimits_Brazil);
-  m_models["Denmark"] = make_shared<PedestrianModel>(s_pedestrianLimits_Denmark);
-  m_models["France"] = make_shared<PedestrianModel>(s_pedestrianLimits_France);
-  m_models["Finland"] = make_shared<PedestrianModel>(s_pedestrianLimits_Finland);
-  m_models["Germany"] = make_shared<PedestrianModel>(s_pedestrianLimits_Germany);
-  m_models["Hungary"] = make_shared<PedestrianModel>(s_pedestrianLimits_Hungary);
-  m_models["Netherlands"] = make_shared<PedestrianModel>(s_pedestrianLimits_Netherlands);
-  m_models["Norway"] = make_shared<PedestrianModel>(s_pedestrianLimits_Norway);
-  m_models["Poland"] = make_shared<PedestrianModel>(s_pedestrianLimits_Poland);
-  m_models["Romania"] = make_shared<PedestrianModel>(s_pedestrianLimits_Romania);
-  m_models["Russia"] = make_shared<PedestrianModel>(s_pedestrianLimits_Russia);
-  m_models["Slovakia"] = make_shared<PedestrianModel>(s_pedestrianLimits_Slovakia);
-  m_models["Switzerland"] = make_shared<PedestrianModel>(s_pedestrianLimits_Switzerland);
-  m_models["Turkey"] = make_shared<PedestrianModel>(s_pedestrianLimits_Turkey);
-  m_models["Ukraine"] = make_shared<PedestrianModel>(s_pedestrianLimits_Ukraine);
-  m_models["UK"] = make_shared<PedestrianModel>(s_pedestrianLimits_UK);
-  m_models["USA"] = make_shared<PedestrianModel>(s_pedestrianLimits_USA);
+  m_models[string()] = make_shared<PedestrianModel>(g_pedestrianLimitsDefault);
+  m_models["Australia"] = make_shared<PedestrianModel>(g_pedestrianLimitsAustralia);
+  m_models["Austria"] = make_shared<PedestrianModel>(g_pedestrianLimitsAustria);
+  m_models["Belarus"] = make_shared<PedestrianModel>(g_pedestrianLimitsBelarus);
+  m_models["Belgium"] = make_shared<PedestrianModel>(g_pedestrianLimitsBelgium);
+  m_models["Brazil"] = make_shared<PedestrianModel>(g_pedestrianLimitsBrazil);
+  m_models["Denmark"] = make_shared<PedestrianModel>(g_pedestrianLimitsDenmark);
+  m_models["France"] = make_shared<PedestrianModel>(g_pedestrianLimitsFrance);
+  m_models["Finland"] = make_shared<PedestrianModel>(g_pedestrianLimitsFinland);
+  m_models["Germany"] = make_shared<PedestrianModel>(g_pedestrianLimitsGermany);
+  m_models["Hungary"] = make_shared<PedestrianModel>(g_pedestrianLimitsHungary);
+  m_models["Netherlands"] = make_shared<PedestrianModel>(g_pedestrianLimitsNetherlands);
+  m_models["Norway"] = make_shared<PedestrianModel>(g_pedestrianLimitsNorway);
+  m_models["Poland"] = make_shared<PedestrianModel>(g_pedestrianLimitsPoland);
+  m_models["Romania"] = make_shared<PedestrianModel>(g_pedestrianLimitsRomania);
+  m_models["Russia"] = make_shared<PedestrianModel>(g_pedestrianLimitsRussia);
+  m_models["Slovakia"] = make_shared<PedestrianModel>(g_pedestrianLimitsSlovakia);
+  m_models["Switzerland"] = make_shared<PedestrianModel>(g_pedestrianLimitsSwitzerland);
+  m_models["Turkey"] = make_shared<PedestrianModel>(g_pedestrianLimitsTurkey);
+  m_models["Ukraine"] = make_shared<PedestrianModel>(g_pedestrianLimitsUkraine);
+  m_models["UK"] = make_shared<PedestrianModel>(g_pedestrianLimitsUK);
+  m_models["USA"] = make_shared<PedestrianModel>(g_pedestrianLimitsUSA);
 }
 
 shared_ptr<IVehicleModel> PedestrianModelFactory::GetVehicleModel() const

--- a/routing/pedestrian_model.hpp
+++ b/routing/pedestrian_model.hpp
@@ -31,8 +31,8 @@ private:
   /// but if function returns False, real allowance is unknown.
   bool IsYesFoot(feature::TypesHolder const & types) const;
 
-  uint32_t m_noFootType;
-  uint32_t m_yesFootType;
+  uint32_t m_noFootType = 0;
+  uint32_t m_yesFootType = 0;
 };
 
 class PedestrianModelFactory : public IVehicleModelFactory

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -1,3 +1,4 @@
+#include "routing/bicycle_model.hpp"
 #include "routing/features_road_graph.hpp"
 #include "routing/nearest_edge_finder.hpp"
 #include "routing/pedestrian_directions.hpp"
@@ -276,6 +277,16 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index, countryFileFn, move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
+  return router;
+}
+
+unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn)
+{
+  unique_ptr<IVehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
+  unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
+  unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
+  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-bicycle", index, countryFileFn, move(vehicleModelFactory),
+                                                 move(algorithm), move(directionsEngine)));
   return router;
 }
 

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -54,6 +54,6 @@ private:
 };
 
 unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn const & countryFileFn);
-
 unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn);
+unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn);
 }  // namespace routing

--- a/routing/router.cpp
+++ b/routing/router.cpp
@@ -9,6 +9,7 @@ string ToString(RouterType type)
   {
     case RouterType::Vehicle: return "Vehicle";
     case RouterType::Pedestrian: return "Pedestrian";
+    case RouterType::Bicycle: return "Bicycle";
   }
   ASSERT(false, ());
   return "Error";

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -19,8 +19,9 @@ class Route;
 /// Routing engine type.
 enum class RouterType
 {
-  Vehicle = 0, /// For OSRM vehicle routing
-  Pedestrian   /// For A star pedestrian routing
+  Vehicle = 0,  /// For OSRM vehicle routing
+  Pedestrian,   /// For A star pedestrian routing
+  Bicycle,      /// For A star bicycle routing
 };
 
 string ToString(RouterType type);

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -83,4 +83,3 @@ HEADERS += \
     turns_sound_settings.hpp \
     turns_tts_text.hpp \
     vehicle_model.hpp \
-    bicycle_model.hpp

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -15,6 +15,7 @@ INCLUDEPATH += $$ROOT_DIR/3party/jansson/src \
 SOURCES += \
     async_router.cpp \
     base/followed_polyline.cpp \
+    bicycle_model.cpp \
     car_model.cpp \
     cross_mwm_road_graph.cpp \
     cross_mwm_router.cpp \
@@ -49,6 +50,7 @@ HEADERS += \
     async_router.hpp \
     base/astar_algorithm.hpp \
     base/followed_polyline.hpp \
+    bicycle_model.cpp \
     car_model.hpp \
     cross_mwm_road_graph.hpp \
     cross_mwm_router.hpp \
@@ -81,3 +83,4 @@ HEADERS += \
     turns_sound_settings.hpp \
     turns_tts_text.hpp \
     vehicle_model.hpp \
+    bicycle_model.hpp

--- a/routing/routing_settings.hpp
+++ b/routing/routing_settings.hpp
@@ -50,4 +50,11 @@ inline RoutingSettings GetCarRoutingSettings()
                            50. /* m_matchingThresholdM */, false /* m_keepPedestrianInfo */,
                            true /* m_showTurnAfterNext */, true /* m_speedCameraWarning*/});
 }
+
+inline RoutingSettings GetBicycleRoutingSettings()
+{
+  return RoutingSettings({ false /* m_matchRoute */, false /* m_soundDirection */,
+                           20. /* m_matchingThresholdM */, true /* m_keepPedestrianInfo */,
+                           false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/});
+}
 }  // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		563B91C51CC4F1DC00222BC1 /* bicycle_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */; };
+		563B91C61CC4F1DC00222BC1 /* bicycle_model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */; };
 		670B84C01A9381D900CE4492 /* cross_routing_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */; };
 		670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 670B84BF1A9381D900CE4492 /* cross_routing_context.hpp */; };
 		670C62131AC5A15700C38A8C /* routing_mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 670C62111AC5A15700C38A8C /* routing_mapping.cpp */; };
@@ -176,6 +178,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_model.cpp; sourceTree = "<group>"; };
+		563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_model.hpp; sourceTree = "<group>"; };
 		670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_routing_context.cpp; sourceTree = "<group>"; };
 		670B84BF1A9381D900CE4492 /* cross_routing_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_routing_context.hpp; sourceTree = "<group>"; };
 		670C62111AC5A15700C38A8C /* routing_mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_mapping.cpp; sourceTree = "<group>"; };
@@ -533,6 +537,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */,
+				563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */,
 				A17B42961BCFBD0E00A1EAE4 /* osrm_helpers.cpp */,
 				A17B42971BCFBD0E00A1EAE4 /* osrm_helpers.hpp */,
 				6741AA9A1BF35331002C974C /* turns_notification_manager.cpp */,
@@ -660,6 +666,7 @@
 				A120B3511B4A7C0A002F3808 /* routing_algorithm.hpp in Headers */,
 				675344211A3F644F00A0A8C3 /* vehicle_model.hpp in Headers */,
 				670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */,
+				563B91C61CC4F1DC00222BC1 /* bicycle_model.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -841,6 +848,7 @@
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,
 				675344171A3F644F00A0A8C3 /* osrm_router.cpp in Sources */,
 				A17B42981BCFBD0E00A1EAE4 /* osrm_helpers.cpp in Sources */,
+				563B91C51CC4F1DC00222BC1 /* bicycle_model.cpp in Sources */,
 				674F9BD21B0A580E00704FFA /* road_graph_router.cpp in Sources */,
 				A1876BC61BB19C4300C9C743 /* speed_camera.cpp in Sources */,
 				671F58BD1B874EC80032311E /* followed_polyline.cpp in Sources */,


### PR DESCRIPTION
Сделан и задействован новый profile для прокладки вело маршрута двусторонним A* (Так же как, сейчас прокладывается пешеходный). Чтоб его активировать нужно в qt приложении ввести ?bicycle.

Строчек много, но суть очень проста.
1. Добавлен routing/bicycle_model.hpp/cpp, в котором для разных стран задан вело профайл (BicycleModel/BicycleModelFactory) на основании: http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions;

2. Вело профайл учтен в генераторе;

3. Сделано, чтоб при вводе в qt приложении ?bicycle прокладка маршрута осуществлялась по вело профайлу.

Тесты я планирую добавить позже.

@gardster обязательно посмотри.
@mpimenov @ygorshenin @syershov посмотрите по возможности.

https://jira.mail.ru/browse/MAPSME-797