### PR TITLE
[bicycle routing] Moving some data stuctures from turn_generator unit to separate files.

### DIFF
--- a/routing/loaded_path_segment.cpp
+++ b/routing/loaded_path_segment.cpp
@@ -1,0 +1,179 @@
+#include "routing/loaded_path_segment.hpp"
+#include "routing/routing_mapping.hpp"
+
+#include "indexer/feature.hpp"
+#include "indexer/ftypes_matcher.hpp"
+
+#include "3party/Alohalytics/src/alohalytics.h"
+
+#include "base/buffer_vector.hpp"
+
+namespace routing
+{
+namespace turns
+{
+// Osrm multiples seconds to 10, so we need to divide it back.
+double constexpr kOSRMWeightToSecondsMultiplier = 1. / 10.;
+
+LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                                     RawPathData const & osrmPathSegment)
+  : m_highwayClass(ftypes::HighwayClass::Undefined)
+  , m_onRoundabout(false)
+  , m_isLink(false)
+  , m_weight(osrmPathSegment.segmentWeight * kOSRMWeightToSecondsMultiplier)
+  , m_nodeId(osrmPathSegment.node)
+{
+  buffer_vector<TSeg, 8> buffer;
+  mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
+  if (buffer.empty())
+  {
+    LOG(LERROR, ("Can't unpack geometry for map:", mapping.GetCountryName(), " node: ",
+                 osrmPathSegment.node));
+    alohalytics::Stats::Instance().LogEvent(
+        "RouteTracking_UnpackingError",
+        {{"node", strings::to_string(osrmPathSegment.node)},
+         {"map", mapping.GetCountryName()},
+         {"version", strings::to_string(mapping.GetMwmId().GetInfo()->GetVersion())}});
+    return;
+  }
+  LoadPathGeometry(buffer, 0, buffer.size(), index, mapping, FeatureGraphNode(), FeatureGraphNode(),
+                   false /* isStartNode */, false /*isEndNode*/);
+}
+
+void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startIndex,
+                                         size_t endIndex, Index const & index, RoutingMapping & mapping,
+                                         FeatureGraphNode const & startGraphNode,
+                                         FeatureGraphNode const & endGraphNode, bool isStartNode,
+                                         bool isEndNode)
+{
+  ASSERT_LESS(startIndex, endIndex, ());
+  ASSERT_LESS_OR_EQUAL(endIndex, buffer.size(), ());
+  ASSERT(!buffer.empty(), ());
+  for (size_t k = startIndex; k < endIndex; ++k)
+  {
+    auto const & segment = buffer[k];
+    if (!segment.IsValid())
+    {
+      m_path.clear();
+      return;
+    }
+    // Load data from drive.
+    FeatureType ft;
+    Index::FeaturesLoaderGuard loader(index, mapping.GetMwmId());
+    loader.GetFeatureByIndex(segment.m_fid, ft);
+    ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
+
+    // Get points in proper direction.
+    auto startIdx = segment.m_pointStart;
+    auto endIdx = segment.m_pointEnd;
+    if (isStartNode && k == startIndex && startGraphNode.segment.IsValid())
+      startIdx = (segment.m_pointEnd > segment.m_pointStart) ? startGraphNode.segment.m_pointStart
+                                                             : startGraphNode.segment.m_pointEnd;
+    if (isEndNode && k == endIndex - 1 && endGraphNode.segment.IsValid())
+      endIdx = (segment.m_pointEnd > segment.m_pointStart) ? endGraphNode.segment.m_pointEnd
+                                                           : endGraphNode.segment.m_pointStart;
+    if (startIdx < endIdx)
+    {
+      for (auto idx = startIdx; idx <= endIdx; ++idx)
+        m_path.push_back(ft.GetPoint(idx));
+    }
+    else
+    {
+      // I use big signed type because endIdx can be 0.
+      for (int64_t idx = startIdx; idx >= static_cast<int64_t>(endIdx); --idx)
+        m_path.push_back(ft.GetPoint(idx));
+    }
+
+    // Load lanes if it is a last segment before junction.
+    if (buffer.back() == segment)
+    {
+      using feature::Metadata;
+      Metadata const & md = ft.GetMetadata();
+
+      auto directionType = Metadata::FMD_TURN_LANES;
+
+      if (!ftypes::IsOneWayChecker::Instance()(ft))
+      {
+        directionType = (startIdx < endIdx) ? Metadata::FMD_TURN_LANES_FORWARD
+                                            : Metadata::FMD_TURN_LANES_BACKWARD;
+      }
+      ParseLanes(md.Get(directionType), m_lanes);
+    }
+    // Calculate node flags.
+    m_onRoundabout |= ftypes::IsRoundAboutChecker::Instance()(ft);
+    m_isLink |= ftypes::IsLinkChecker::Instance()(ft);
+    m_highwayClass = ftypes::GetHighwayClass(ft);
+    string name;
+    ft.GetName(FeatureType::DEFAULT_LANG, name);
+    if (!name.empty())
+      m_name = name;
+  }
+}
+
+LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                                     RawPathData const & osrmPathSegment,
+                                     FeatureGraphNode const & startGraphNode,
+                                     FeatureGraphNode const & endGraphNode, bool isStartNode,
+                                     bool isEndNode)
+  : m_highwayClass(ftypes::HighwayClass::Undefined)
+  , m_onRoundabout(false)
+  , m_isLink(false)
+  , m_weight(0)
+  , m_nodeId(osrmPathSegment.node)
+{
+  ASSERT(isStartNode || isEndNode, ("This function process only corner cases."));
+  if (!startGraphNode.segment.IsValid() || !endGraphNode.segment.IsValid())
+    return;
+  buffer_vector<TSeg, 8> buffer;
+  mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
+
+  auto findIntersectingSeg = [&buffer](TSeg const & seg) -> size_t
+  {
+    ASSERT(seg.IsValid(), ());
+    auto const it = find_if(buffer.begin(), buffer.end(), [&seg](OsrmMappingTypes::FtSeg const & s)
+                            {
+                              return s.IsIntersect(seg);
+                            });
+
+    ASSERT(it != buffer.end(), ());
+    return distance(buffer.begin(), it);
+  };
+
+  // Calculate estimated time for a start and a end node cases.
+  if (isStartNode && isEndNode)
+  {
+    double const forwardWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
+                                     ? startGraphNode.node.forward_weight
+                                     : startGraphNode.node.reverse_weight;
+    double const backwardWeight = (osrmPathSegment.node == endGraphNode.node.forward_node_id)
+                                      ? endGraphNode.node.forward_weight
+                                      : endGraphNode.node.reverse_weight;
+    double const wholeWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
+                                   ? startGraphNode.node.forward_offset
+                                   : startGraphNode.node.reverse_offset;
+    // Sum because weights in forward/backward_weight fields are negative. Look osrm_helpers for
+    // more info.
+    m_weight = wholeWeight + forwardWeight + backwardWeight;
+  }
+  else
+  {
+    PhantomNode const * node = nullptr;
+    if (isStartNode)
+      node = &startGraphNode.node;
+    if (isEndNode)
+      node = &endGraphNode.node;
+    if (node)
+    {
+      m_weight = (osrmPathSegment.node == node->forward_weight)
+                  ? node->GetForwardWeightPlusOffset() : node->GetReverseWeightPlusOffset();
+    }
+  }
+
+  size_t startIndex = isStartNode ? findIntersectingSeg(startGraphNode.segment) : 0;
+  size_t endIndex = isEndNode ? findIntersectingSeg(endGraphNode.segment) + 1 : buffer.size();
+  LoadPathGeometry(buffer, startIndex, endIndex, index, mapping, startGraphNode, endGraphNode, isStartNode,
+                   isEndNode);
+  m_weight *= kOSRMWeightToSecondsMultiplier;
+}
+}  // namespace routing
+}  // namespace turns

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "routing/osrm_helpers.hpp"
+#include "routing/turns.hpp"
+#include "routing/turn_candidate.hpp"
+
+#include "indexer/ftypes_matcher.hpp"
+
+#include "base/buffer_vector.hpp"
+
+#include "std/vector.hpp"
+
+class Index;
+
+namespace routing
+{
+struct RoutingMapping;
+struct RawPathData;
+struct FeatureGraphNode;
+
+namespace turns
+{
+using TSeg = OsrmMappingTypes::FtSeg;
+
+/*!
+ * \brief The LoadedPathSegment struct is a representation of a single node path.
+ * It unpacks and stores information about path and road type flags.
+ * Postprocessing must read information from the structure and does not initiate disk readings.
+ */
+struct LoadedPathSegment
+{
+  vector<m2::PointD> m_path;
+  ftypes::HighwayClass m_highwayClass;
+  bool m_onRoundabout;
+  bool m_isLink;
+  TUniversalEdgeWeight m_weight;
+  string m_name;
+  TUniversalNodeId m_nodeId;
+  vector<SingleLaneInfo> m_lanes;
+
+  // General constructor.
+  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                    RawPathData const & osrmPathSegment);
+  // Special constructor for side nodes. Splits OSRM node by information from the FeatureGraphNode.
+  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
+                    RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode,
+                    FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
+
+private:
+  // Load information about road, that described as the sequence of FtSegs and start/end indexes in
+  // in it. For the side case, it has information about start/end graph nodes.
+  void LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startIndex,
+                        size_t endIndex, Index const & index, RoutingMapping & mapping,
+                        FeatureGraphNode const & startGraphNode,
+                        FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
+};
+}  // namespace routing
+}  // namespace turns

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -33,9 +33,9 @@ struct LoadedPathSegment
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;
   bool m_isLink;
-  TUniversalEdgeWeight m_weight;
+  TEdgeWeight m_weight;
   string m_name;
-  TUniversalNodeId m_nodeId;
+  TNodeId m_nodeId;
   vector<SingleLaneInfo> m_lanes;
 
   // General constructor.

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -67,7 +67,7 @@ public:
   {
     return m_loadedSegments;
   }
-  virtual void GetPossibleTurns(TUniversalNodeId node, m2::PointD const & ingoingPoint,
+  virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
                                 turns::TTurnCandidates & outgoingTurns) const override

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -1,9 +1,10 @@
-#include "cross_mwm_router.hpp"
-#include "online_cross_fetcher.hpp"
-#include "osrm2feature_map.hpp"
-#include "osrm_helpers.hpp"
-#include "osrm_router.hpp"
-#include "turns_generator.hpp"
+#include "routing/cross_mwm_router.hpp"
+#include "routing/loaded_path_segment.hpp"
+#include "routing/online_cross_fetcher.hpp"
+#include "routing/osrm2feature_map.hpp"
+#include "routing/osrm_helpers.hpp"
+#include "routing/osrm_router.hpp"
+#include "routing/turns_generator.hpp"
 
 #include "platform/country_file.hpp"
 #include "platform/platform.hpp"
@@ -11,9 +12,9 @@
 #include "geometry/angles.hpp"
 #include "geometry/distance.hpp"
 #include "geometry/distance_on_sphere.hpp"
+#include "geometry/mercator.hpp"
 
 #include "indexer/ftypes_matcher.hpp"
-#include "geometry/mercator.hpp"
 #include "indexer/index.hpp"
 #include "indexer/scales.hpp"
 
@@ -66,7 +67,7 @@ public:
   {
     return m_loadedSegments;
   }
-  virtual void GetPossibleTurns(NodeID node, m2::PointD const & ingoingPoint,
+  virtual void GetPossibleTurns(TUniversalNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
                                 turns::TTurnCandidates & outgoingTurns) const override

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -21,6 +21,7 @@ SOURCES += \
     cross_mwm_router.cpp \
     cross_routing_context.cpp \
     features_road_graph.cpp \
+    loaded_path_segment.cpp \
     nearest_edge_finder.cpp \
     online_absent_fetcher.cpp \
     online_cross_fetcher.cpp \
@@ -57,6 +58,7 @@ HEADERS += \
     cross_routing_context.hpp \
     directions_engine.hpp \
     features_road_graph.hpp \
+    loaded_path_segment.hpp \
     nearest_edge_finder.hpp \
     online_absent_fetcher.hpp \
     online_cross_fetcher.hpp \
@@ -74,9 +76,11 @@ HEADERS += \
     router_delegate.hpp \
     routing_algorithm.hpp \
     routing_mapping.hpp \
+    routing_result_graph.hpp \
     routing_session.hpp \
     routing_settings.hpp \
     speed_camera.hpp \
+    turn_candidate.hpp \
     turns.hpp \
     turns_generator.hpp \
     turns_notification_manager.hpp \

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "routing/loaded_path_segment.hpp"
+#include "routing/turn_candidate.hpp"
+
+#include "std/vector.hpp"
+
+namespace routing
+{
+namespace turns
+{
+
+/*!
+ * \brief The IRoutingResultGraph interface for the routing result. Uncouple router from the
+ * annotation code that describes turns. See routers for detail implementations.
+ */
+class IRoutingResultGraph
+{
+public:
+  virtual vector<LoadedPathSegment> const & GetSegments() const = 0;
+  virtual void GetPossibleTurns(TUniversalNodeId node, m2::PointD const & ingoingPoint,
+                                m2::PointD const & junctionPoint,
+                                size_t & ingoingCount,
+                                TTurnCandidates & outgoingTurns) const = 0;
+  virtual double GetShortestPathLength() const = 0;
+  virtual m2::PointD const & GetStartPoint() const = 0;
+  virtual m2::PointD const & GetEndPoint() const = 0;
+
+  virtual ~IRoutingResultGraph() = default;
+};
+}  // namespace routing
+}  // namespace turns

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -18,7 +18,7 @@ class IRoutingResultGraph
 {
 public:
   virtual vector<LoadedPathSegment> const & GetSegments() const = 0;
-  virtual void GetPossibleTurns(TUniversalNodeId node, m2::PointD const & ingoingPoint,
+  virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
                                 TTurnCandidates & outgoingTurns) const = 0;

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -29,14 +29,14 @@ struct TurnCandidate
    * node is a possible node (a possible way) from the juction.
    * May be NodeId for OSRM router or FeatureId::index for graph router.
    */
-  TUniversalNodeId node;
+  TNodeId node;
   /*!
    * \brief highwayClass field for the road class caching. Because feature reading is a long
    * function.
    */
   ftypes::HighwayClass highwayClass;
 
-  TurnCandidate(double a, TUniversalNodeId n, ftypes::HighwayClass c) : angle(a), node(n), highwayClass(c)
+  TurnCandidate(double a, TNodeId n, ftypes::HighwayClass c) : angle(a), node(n), highwayClass(c)
   {
   }
 };

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "routing/turns.hpp"
+
+#include "std/vector.hpp"
+
+namespace ftypes
+{
+enum class HighwayClass;
+}
+
+namespace routing
+{
+namespace turns
+{
+/*!
+ * \brief The TurnCandidate struct contains information about possible ways from a junction.
+ */
+struct TurnCandidate
+{
+  /*!
+   * angle is an angle of the turn in degrees. It means angle is 180 minus
+   * an angle between the current edge and the edge of the candidate. A counterclockwise rotation.
+   * The current edge is an edge which belongs the route and located before the junction.
+   * angle belongs to the range [-180; 180];
+   */
+  double angle;
+  /*!
+   * node is a possible node (a possible way) from the juction.
+   * May be NodeId for OSRM router or FeatureId::index for graph router.
+   */
+  TUniversalNodeId node;
+  /*!
+   * \brief highwayClass field for the road class caching. Because feature reading is a long
+   * function.
+   */
+  ftypes::HighwayClass highwayClass;
+
+  TurnCandidate(double a, TUniversalNodeId n, ftypes::HighwayClass c) : angle(a), node(n), highwayClass(c)
+  {
+  }
+};
+
+using TTurnCandidates = vector<TurnCandidate>;
+}  // namespace routing
+}  // namespace turns

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -11,8 +11,8 @@
 
 namespace routing
 {
-using TUniversalNodeId = uint32_t;
-using TUniversalEdgeWeight = double;
+using TNodeId = uint32_t;
+using TEdgeWeight = double;
 
 namespace turns
 {

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -11,6 +11,9 @@
 
 namespace routing
 {
+using TUniversalNodeId = uint32_t;
+using TUniversalEdgeWeight = double;
+
 namespace turns
 {
 /// @todo(vbykoianko) It's a good idea to gather all the turns information into one entity.

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -1,8 +1,7 @@
-#include "turns_generator.hpp"
-
-#include "car_model.hpp"
-#include "osrm_helpers.hpp"
-#include "routing_mapping.hpp"
+#include "routing/car_model.hpp"
+#include "routing/osrm_helpers.hpp"
+#include "routing/routing_mapping.hpp"
+#include "routing/turns_generator.hpp"
 
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
@@ -11,13 +10,11 @@
 
 #include "base/macros.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
 #include "3party/osrm/osrm-backend/data_structures/internal_route_result.hpp"
 
 #include "std/cmath.hpp"
 #include "std/numeric.hpp"
 #include "std/string.hpp"
-
 
 using namespace routing;
 using namespace routing::turns;
@@ -29,9 +26,6 @@ size_t constexpr kMaxPointsCount = 5;
 double constexpr kMinDistMeters = 200.;
 size_t constexpr kNotSoCloseMaxPointsCount = 3;
 double constexpr kNotSoCloseMinDistMeters = 30.;
-
-// Osrm multiples seconds to 10, so we need to divide it back.
-double constexpr kOSRMWeightToSecondsMultiplier = 1. / 10.;
 
 typedef vector<double> TGeomTurnCandidate;
 
@@ -257,169 +251,6 @@ namespace routing
 {
 namespace turns
 {
-using TSeg = OsrmMappingTypes::FtSeg;
-
-LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
-                                     RawPathData const & osrmPathSegment)
-  : m_highwayClass(ftypes::HighwayClass::Undefined)
-  , m_onRoundabout(false)
-  , m_isLink(false)
-  , m_weight(osrmPathSegment.segmentWeight * kOSRMWeightToSecondsMultiplier)
-  , m_nodeId(osrmPathSegment.node)
-{
-  buffer_vector<TSeg, 8> buffer;
-  mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
-  if (buffer.empty())
-  {
-    LOG(LERROR, ("Can't unpack geometry for map:", mapping.GetCountryName(), " node: ",
-                 osrmPathSegment.node));
-    alohalytics::Stats::Instance().LogEvent(
-        "RouteTracking_UnpackingError",
-        {{"node", strings::to_string(osrmPathSegment.node)},
-         {"map", mapping.GetCountryName()},
-         {"version", strings::to_string(mapping.GetMwmId().GetInfo()->GetVersion())}});
-    return;
-  }
-  LoadPathGeometry(buffer, 0, buffer.size(), index, mapping, FeatureGraphNode(), FeatureGraphNode(),
-                   false /* isStartNode */, false /*isEndNode*/);
-}
-
-void LoadedPathSegment::LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startIndex,
-                                         size_t endIndex, Index const & index, RoutingMapping & mapping,
-                                         FeatureGraphNode const & startGraphNode,
-                                         FeatureGraphNode const & endGraphNode, bool isStartNode,
-                                         bool isEndNode)
-{
-  ASSERT_LESS(startIndex, endIndex, ());
-  ASSERT_LESS_OR_EQUAL(endIndex, buffer.size(), ());
-  ASSERT(!buffer.empty(), ());
-  for (size_t k = startIndex; k < endIndex; ++k)
-  {
-    auto const & segment = buffer[k];
-    if (!segment.IsValid())
-    {
-      m_path.clear();
-      return;
-    }
-    // Load data from drive.
-    FeatureType ft;
-    Index::FeaturesLoaderGuard loader(index, mapping.GetMwmId());
-    loader.GetFeatureByIndex(segment.m_fid, ft);
-    ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
-
-    // Get points in proper direction.
-    auto startIdx = segment.m_pointStart;
-    auto endIdx = segment.m_pointEnd;
-    if (isStartNode && k == startIndex && startGraphNode.segment.IsValid())
-      startIdx = (segment.m_pointEnd > segment.m_pointStart) ? startGraphNode.segment.m_pointStart
-                                                             : startGraphNode.segment.m_pointEnd;
-    if (isEndNode && k == endIndex - 1 && endGraphNode.segment.IsValid())
-      endIdx = (segment.m_pointEnd > segment.m_pointStart) ? endGraphNode.segment.m_pointEnd
-                                                           : endGraphNode.segment.m_pointStart;
-    if (startIdx < endIdx)
-    {
-      for (auto idx = startIdx; idx <= endIdx; ++idx)
-        m_path.push_back(ft.GetPoint(idx));
-    }
-    else
-    {
-      // I use big signed type because endIdx can be 0.
-      for (int64_t idx = startIdx; idx >= static_cast<int64_t>(endIdx); --idx)
-        m_path.push_back(ft.GetPoint(idx));
-    }
-
-    // Load lanes if it is a last segment before junction.
-    if (buffer.back() == segment)
-    {
-      using feature::Metadata;
-      Metadata const & md = ft.GetMetadata();
-
-      auto directionType = Metadata::FMD_TURN_LANES;
-
-      if (!ftypes::IsOneWayChecker::Instance()(ft))
-      {
-        directionType = (startIdx < endIdx) ? Metadata::FMD_TURN_LANES_FORWARD
-                                            : Metadata::FMD_TURN_LANES_BACKWARD;
-      }
-      ParseLanes(md.Get(directionType), m_lanes);
-    }
-    // Calculate node flags.
-    m_onRoundabout |= ftypes::IsRoundAboutChecker::Instance()(ft);
-    m_isLink |= ftypes::IsLinkChecker::Instance()(ft);
-    m_highwayClass = ftypes::GetHighwayClass(ft);
-    string name;
-    ft.GetName(FeatureType::DEFAULT_LANG, name);
-    if (!name.empty())
-      m_name = name;
-  }
-}
-
-LoadedPathSegment::LoadedPathSegment(RoutingMapping & mapping, Index const & index,
-                                     RawPathData const & osrmPathSegment,
-                                     FeatureGraphNode const & startGraphNode,
-                                     FeatureGraphNode const & endGraphNode, bool isStartNode,
-                                     bool isEndNode)
-  : m_highwayClass(ftypes::HighwayClass::Undefined)
-  , m_onRoundabout(false)
-  , m_isLink(false)
-  , m_weight(0)
-  , m_nodeId(osrmPathSegment.node)
-{
-  ASSERT(isStartNode || isEndNode, ("This function process only corner cases."));
-  if (!startGraphNode.segment.IsValid() || !endGraphNode.segment.IsValid())
-    return;
-  buffer_vector<TSeg, 8> buffer;
-  mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
-
-  auto findIntersectingSeg = [&buffer](TSeg const & seg) -> size_t
-  {
-    ASSERT(seg.IsValid(), ());
-    auto const it = find_if(buffer.begin(), buffer.end(), [&seg](OsrmMappingTypes::FtSeg const & s)
-                            {
-                              return s.IsIntersect(seg);
-                            });
-
-    ASSERT(it != buffer.end(), ());
-    return distance(buffer.begin(), it);
-  };
-
-  // Calculate estimated time for a start and a end node cases.
-  if (isStartNode && isEndNode)
-  {
-    double const forwardWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
-                                     ? startGraphNode.node.forward_weight
-                                     : startGraphNode.node.reverse_weight;
-    double const backwardWeight = (osrmPathSegment.node == endGraphNode.node.forward_node_id)
-                                      ? endGraphNode.node.forward_weight
-                                      : endGraphNode.node.reverse_weight;
-    double const wholeWeight = (osrmPathSegment.node == startGraphNode.node.forward_node_id)
-                                   ? startGraphNode.node.forward_offset
-                                   : startGraphNode.node.reverse_offset;
-    // Sum because weights in forward/backward_weight fields are negative. Look osrm_helpers for
-    // more info.
-    m_weight = wholeWeight + forwardWeight + backwardWeight;
-  }
-  else
-  {
-    PhantomNode const * node = nullptr;
-    if (isStartNode)
-      node = &startGraphNode.node;
-    if (isEndNode)
-      node = &endGraphNode.node;
-    if (node)
-    {
-      m_weight = (osrmPathSegment.node == node->forward_weight)
-                  ? node->GetForwardWeightPlusOffset() : node->GetReverseWeightPlusOffset();
-    }
-  }
-
-  size_t startIndex = isStartNode ? findIntersectingSeg(startGraphNode.segment) : 0;
-  size_t endIndex = isEndNode ? findIntersectingSeg(endGraphNode.segment) + 1 : buffer.size();
-  LoadPathGeometry(buffer, startIndex, endIndex, index, mapping, startGraphNode, endGraphNode, isStartNode,
-                   isEndNode);
-  m_weight *= kOSRMWeightToSecondsMultiplier;
-}
-
 bool TurnInfo::IsSegmentsValid() const
 {
   if (m_ingoing.m_path.empty() || m_outgoing.m_path.empty())

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -27,7 +27,7 @@ double constexpr kMinDistMeters = 200.;
 size_t constexpr kNotSoCloseMaxPointsCount = 3;
 double constexpr kNotSoCloseMinDistMeters = 30.;
 
-typedef vector<double> TGeomTurnCandidate;
+using TGeomTurnCandidate = vector<double>;
 
 double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2)
 {

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "routing/loaded_path_segment.hpp"
 #include "routing/osrm2feature_map.hpp"
 #include "routing/osrm_engine.hpp"
+#include "routing/routing_result_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/turns.hpp"
+#include "routing/turn_candidate.hpp"
 
 #include "std/function.hpp"
 #include "std/utility.hpp"
@@ -28,88 +31,6 @@ namespace turns
  * \brief Returns a segment index by STL-like range [s, e) of segments indices for the passed node.
  */
 using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
-
-/*!
- * \brief The LoadedPathSegment struct is a representation of a single osrm node path.
- * It unpacks and stores information about path and road type flags.
- * Postprocessing must read information from the structure and does not initiate disk readings.
- */
-struct LoadedPathSegment
-{
-  vector<m2::PointD> m_path;
-  ftypes::HighwayClass m_highwayClass;
-  bool m_onRoundabout;
-  bool m_isLink;
-  EdgeWeight m_weight;
-  string m_name;
-  NodeID m_nodeId;
-  vector<SingleLaneInfo> m_lanes;
-
-  // General constructor.
-  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
-                    RawPathData const & osrmPathSegment);
-  // Special constructor for side nodes. Splits OSRM node by information from the FeatureGraphNode.
-  LoadedPathSegment(RoutingMapping & mapping, Index const & index,
-                    RawPathData const & osrmPathSegment, FeatureGraphNode const & startGraphNode,
-                    FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
-
-private:
-  // Load information about road, that described as the sequence of FtSegs and start/end indexes in
-  // in it. For the side case, it has information about start/end graph nodes.
-  void LoadPathGeometry(buffer_vector<OsrmMappingTypes::FtSeg, 8> const & buffer, size_t startIndex,
-                        size_t endIndex, Index const & index, RoutingMapping & mapping,
-                        FeatureGraphNode const & startGraphNode,
-                        FeatureGraphNode const & endGraphNode, bool isStartNode, bool isEndNode);
-};
-
-/*!
- * \brief The TurnCandidate struct contains information about possible ways from a junction.
- */
-struct TurnCandidate
-{
-  /*!
-   * angle is an angle of the turn in degrees. It means angle is 180 minus
-   * an angle between the current edge and the edge of the candidate. A counterclockwise rotation.
-   * The current edge is an edge which belongs the route and located before the junction.
-   * angle belongs to the range [-180; 180];
-   */
-  double angle;
-  /*!
-   * node is a possible node (a possible way) from the juction.
-   * May be NodeId for OSRM router or FeatureId::index for graph router.
-   */
-  uint32_t node;
-  /*!
-   * \brief highwayClass field for the road class caching. Because feature reading is a long
-   * function.
-   */
-  ftypes::HighwayClass highwayClass;
-
-  TurnCandidate(double a, uint32_t n, ftypes::HighwayClass c) : angle(a), node(n), highwayClass(c)
-  {
-  }
-};
-
-using TTurnCandidates = vector<TurnCandidate>;
-
-/*!
- * \brief The IRoutingResultGraph interface for the routing result. Uncouple router from the
- * annotation code that describes turns. See routers for detail implementations.
- */
-class IRoutingResultGraph
-{
-public:
-  virtual vector<LoadedPathSegment> const & GetSegments() const = 0;
-  virtual void GetPossibleTurns(NodeID node, m2::PointD const & ingoingPoint,
-                                m2::PointD const & junctionPoint,
-                                size_t & ingoingCount,
-                                TTurnCandidates & outgoingTurns) const = 0;
-  virtual double GetShortestPathLength() const = 0;
-  virtual m2::PointD const & GetStartPoint() const = 0;
-  virtual m2::PointD const & GetEndPoint() const = 0;
-
-  virtual ~IRoutingResultGraph() {}
-};
 
 /*!
  * \brief Compute turn and time estimation structs for the abstract route result.


### PR DESCRIPTION
Главная цели этого PR - перенос ряда структур (IRoutingResultGraph, TurnCandidate, LoadedPathSegment) из модуля turn_generator в отдельные файлы. Это необходимо, чтоб потом их можно было использовать для велороутинга. За одно фалы turn_generator стали поменьше.

Кроме того, структура LoadedPathSegment в будущем будет заполняться не только при помощи osrm роутинга, но и при помощи вело роутинга (AStar). Чтоб это было удобнее добавлены типы: TUniversalNodeId и TUniversalEdgeWeight.

@gardster PTAL