### PR TITLE
Integration tests constant fixes.

### DIFF
--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -11,8 +11,8 @@ namespace
   UNIT_TEST(StrangeCaseInAfrica)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(19.207890000000002573, 30.506630000000001246), {0., 0.},
-        MercatorBounds::FromLatLon(19.172889999999998878, 30.473150000000000404), 7250.);
+        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
+        MercatorBounds::FromLatLon(19.17289, 30.47315), 9186.);
   }
 
   UNIT_TEST(MoscowShortRoadUnpacking)

--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -156,7 +156,7 @@ UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
   integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
 
-  integration::TestRouteLength(route, 214.);
+  integration::TestRouteLength(route, 217.);
 }
 
 UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)


### PR DESCRIPTION
пара фиксов, чтобы интеграционные тесты не фейлили. Оба случая посмотрел глазами. В африке запретили поворот (мост вместо плоского перекрёстка) и маршрут стал длиннее. На планетной поравили геометрию. Хватило 2х метров чтобы обрушить тест.