### PR TITLE
Osrm rebuilding

### DIFF
--- a/tools/python/road_runner.py
+++ b/tools/python/road_runner.py
@@ -79,6 +79,16 @@ for p1, p2 in tasks:
         filtered.append((p1,p2))
 tasks = filtered
 
+if not len(tasks):
+    print("Towns not found. No job.")
+    exit(1)
+
+try:
+    get_way_ids(tasks[0][0], tasks[0][1], sys.argv[2])
+except:
+    print("Can't connect to remote server: {0}".format(sys.argv[2]))
+    exit(1)
+
 qtasks = Queue()
 capitals_list = set()
 towns_list = set()

--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -312,12 +312,9 @@ if [ "$MODE" == "roads" ]; then
     bash "$ROUTING_SCRIPT" server >> "$PLANET_LOG" 2>&1
   fi
 
-  if [ -z "${OSRM_URL-}" ]; then
-    log "OSRM_URL variable not set. World roads will not be calculated."
-  else
-    putmode "Step 2a: Generating road networks for the World map"
-    python "$ROADS_SCRIPT" "$INTDIR" "$OSRM_URL" >>"$LOG_PATH"/road_runner.log
-  fi
+  putmode "Step 2a: Generating road networks for the World map"
+  python "$ROADS_SCRIPT" "$INTDIR" "$OSRM_URL" >>"$LOG_PATH"/road_runner.log
+
   MODE=inter
 fi
 

--- a/tools/unix/generate_planet_routing.sh
+++ b/tools/unix/generate_planet_routing.sh
@@ -131,6 +131,7 @@ elif [ "$1" == "stop" ]; then
   LOG="$LOG_PATH/planet.log"
   echo "Stopping osrm server..." >> "$LOG"
   pkill osrm-routed || true
+
 elif [ "$1" == "online" ]; then
   PLANET="${PLANET:-$HOME/planet/planet-latest.o5m}"
   OSMCTOOLS="${OSMCTOOLS:-$HOME/osmctools}"
@@ -167,6 +168,7 @@ elif [ "$1" == "online" ]; then
   else
       echo "Failed to create $OSRM_FILE" >> "$LOG"
   fi
+
 elif [ "$1" == "server" ]; then
   OSRM_PATH="${OSRM_PATH:-$OMIM_PATH/3party/osrm/osrm-backend}"
   OSRM_BUILD_PATH="${OSRM_BUILD_PATH:-$OMIM_PATH/../osrm-backend-release}"

--- a/tools/unix/generate_planet_routing.sh
+++ b/tools/unix/generate_planet_routing.sh
@@ -54,7 +54,7 @@ if [ "$1" == "pbf" ]; then
   export PLANET
   export INTDIR
   find "$TMPBORDERS" -maxdepth 1 -name '*.poly' -print0 | xargs -0 -P $NUM_PROCESSES -I % \
-    sh -c '"$OSMCTOOLS/osmconvert" "$PLANET" --hash-memory=2000 -B="%" --complex-ways --out-pbf -o="$INTDIR/$(basename "%" .poly).pbf"'
+    sh -c '"$OSMCTOOLS/osmconvert" "$PLANET" --hash-memory=2000 -B="%" --complete-ways --out-pbf -o="$INTDIR/$(basename "%" .poly).pbf"'
   rm -r "$TMPBORDERS"
 
 elif [ "$1" == "prepare" ]; then
@@ -127,6 +127,10 @@ elif [ "$1" == "mwm" ]; then
     fi
   fi
 
+elif [ "$1" == "stop" ]; then
+  LOG="$LOG_PATH/planet.log"
+  echo "Stopping osrm server..." >> "$LOG"
+  pkill osrm-routed || true
 elif [ "$1" == "online" ]; then
   PLANET="${PLANET:-$HOME/planet/planet-latest.o5m}"
   OSMCTOOLS="${OSMCTOOLS:-$HOME/osmctools}"
@@ -178,10 +182,7 @@ elif [ "$1" == "server" ]; then
   LOG="$LOG_PATH/planet.log"
   if [ -s "$OSRM_FILE" ]; then
     echo "Starting: $OSRM_FILE" >> "$LOG"
-    pkill osrm-routed
-    echo "killed: $OSRM_FILE" >> "$LOG"
     "$OSRM_BUILD_PATH/osrm-routed" "$OSRM_FILE" --borders "$OMIM_PATH/data/" --port "$PORT" >> "$LOG" 2>&1 &
-    echo "started: $OSRM_FILE" >> "$LOG"
 
     echo "Waiting until OSRM server starts:" >> "$LOG"
     until $(curl --output /dev/null --silent --head --fail http://localhost:$PORT/mapsme); do

--- a/tools/unix/generate_planet_routing.sh
+++ b/tools/unix/generate_planet_routing.sh
@@ -14,6 +14,9 @@ if [ $# -lt 1 ]; then
   echo "  $0 pbf"
   echo "  $0 prepare"
   echo "  $0 mwm"
+  echo "  $0 online"
+  echo "  $0 serve"
+  echo "  $0 stop"
   echo ''
   exit 1
 fi
@@ -169,7 +172,7 @@ elif [ "$1" == "online" ]; then
       echo "Failed to create $OSRM_FILE" >> "$LOG"
   fi
 
-elif [ "$1" == "server" ]; then
+elif [ "$1" == "serve" ]; then
   OSRM_PATH="${OSRM_PATH:-$OMIM_PATH/3party/osrm/osrm-backend}"
   OSRM_BUILD_PATH="${OSRM_BUILD_PATH:-$OMIM_PATH/../osrm-backend-release}"
   [ ! -x "$OSRM_BUILD_PATH/osrm-extract" ] && fail "Please compile OSRM binaries to $OSRM_BUILD_PATH"
@@ -183,16 +186,16 @@ elif [ "$1" == "server" ]; then
   RESTRICTIONS_FILE="$OSRM_FILE.restrictions"
   LOG="$LOG_PATH/planet.log"
   if [ -s "$OSRM_FILE" ]; then
-    echo "Starting: $OSRM_FILE" >> "$LOG"
+    echo "Starting: $OSRM_FILE"
     "$OSRM_BUILD_PATH/osrm-routed" "$OSRM_FILE" --borders "$OMIM_PATH/data/" --port "$PORT" >> "$LOG" 2>&1 &
 
-    echo "Waiting until OSRM server starts:" >> "$LOG"
+    echo "Waiting until OSRM server starts:"
     until $(curl --output /dev/null --silent --head --fail http://localhost:$PORT/mapsme); do
       printf '.' >> "$LOG"
       sleep 5
     done
    else
-    echo "Can't find OSRM file: $OSRM_FILE" >> "$LOG"
+    echo "Can't find OSRM file: $OSRM_FILE"
  fi
 
 else


### PR DESCRIPTION
Скрипт подготовки данных и запуска локального OSRM сервера для рассчёта дорог на обзорных масштабах. Если скрипту generate_planet.sh не предоставить URL работающего OSRM'a он создаст свой. Данные будут собраны из текущей планеты, что гарантирует их свежесть.

@Zverik PTAL