### PR TITLE
[osrm] Fix osrm maps.me plugin build after renaming country.name

### DIFF
--- a/3party/osrm/osrm-backend/plugins/MapsMePlugin.hpp
+++ b/3party/osrm/osrm-backend/plugins/MapsMePlugin.hpp
@@ -272,7 +272,7 @@ public:
             osrm::json::Array pointArray;
             pointArray.values.push_back(mwm.second.x);
             pointArray.values.push_back(mwm.second.y);
-            pointArray.values.push_back(m_countries[mwm.first].m_name);
+            pointArray.values.push_back(m_countries[mwm.first].m_countryId);
             json_array.values.push_back(pointArray);
         }
         reply.values["used_mwms"] = json_array;


### PR DESCRIPTION
После 34791b0168be4da436517deeae385c2928d954fb перестал собираться osrm.