### PR TITLE
Using special profile for pedestrian routing in the USA.

### DIFF
--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -575,7 +575,7 @@ routing::VehicleModel::InitListT const g_pedestrianLimitsUK =
 };
 
 // USA
-routing::VehicleModel::InitListT const g_pedestrianLimitsUSA =
+routing::VehicleModel::InitListT const g_pedestrianLimitsUS =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
@@ -679,7 +679,7 @@ PedestrianModelFactory::PedestrianModelFactory()
   m_models["Turkey"] = make_shared<PedestrianModel>(g_pedestrianLimitsTurkey);
   m_models["Ukraine"] = make_shared<PedestrianModel>(g_pedestrianLimitsUkraine);
   m_models["UK"] = make_shared<PedestrianModel>(g_pedestrianLimitsUK);
-  m_models["US"] = make_shared<PedestrianModel>(g_pedestrianLimitsUSA);
+  m_models["US"] = make_shared<PedestrianModel>(g_pedestrianLimitsUS);
 }
 
 shared_ptr<IVehicleModel> PedestrianModelFactory::GetVehicleModel() const

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -679,7 +679,7 @@ PedestrianModelFactory::PedestrianModelFactory()
   m_models["Turkey"] = make_shared<PedestrianModel>(g_pedestrianLimitsTurkey);
   m_models["Ukraine"] = make_shared<PedestrianModel>(g_pedestrianLimitsUkraine);
   m_models["UK"] = make_shared<PedestrianModel>(g_pedestrianLimitsUK);
-  m_models["USA"] = make_shared<PedestrianModel>(g_pedestrianLimitsUSA);
+  m_models["US"] = make_shared<PedestrianModel>(g_pedestrianLimitsUSA);
 }
 
 shared_ptr<IVehicleModel> PedestrianModelFactory::GetVehicleModel() const


### PR DESCRIPTION
Я изучил ситуацию с профайлом для пешеходного роутинга для разных стран. По крупному, он ошибочно использовал только в США дефолтный профайл. Данный PR исправляет ошибку.
Но это быстрый фикс. Правильный фиск - это использовать для получения countryId страны Storage. (Для этого надо прокинуть колбек в routing.) Ввиду не хватки времени, я откладываю данное дело. В коде есть TODO на эту тему.

https://jira.mail.ru/browse/MAPSME-849

@gardster PTAL