### PR TITLE
Bicycle turn generation.

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -13,6 +13,7 @@ namespace
 class HighwayClasses
 {
   map<uint32_t, ftypes::HighwayClass> m_map;
+
 public:
   HighwayClasses()
   {
@@ -61,19 +62,19 @@ char const * HighwayClassToString(ftypes::HighwayClass const cls)
 {
   switch (cls)
   {
-    case ftypes::HighwayClass::Undefined: return "Undefined";
-    case ftypes::HighwayClass::Error: return "Error";
-    case ftypes::HighwayClass::Trunk: return "Trunk";
-    case ftypes::HighwayClass::Primary: return "Primary";
-    case ftypes::HighwayClass::Secondary: return "Secondary";
-    case ftypes::HighwayClass::Tertiary: return "Tertiary";
-    case ftypes::HighwayClass::LivingStreet: return "LivingStreet";
-    case ftypes::HighwayClass::Service: return "Service";
-    case ftypes::HighwayClass::Pedestrian: return "Pedestrian";
-    case ftypes::HighwayClass::Count: return "Count";
+  case ftypes::HighwayClass::Undefined: return "Undefined";
+  case ftypes::HighwayClass::Error: return "Error";
+  case ftypes::HighwayClass::Trunk: return "Trunk";
+  case ftypes::HighwayClass::Primary: return "Primary";
+  case ftypes::HighwayClass::Secondary: return "Secondary";
+  case ftypes::HighwayClass::Tertiary: return "Tertiary";
+  case ftypes::HighwayClass::LivingStreet: return "LivingStreet";
+  case ftypes::HighwayClass::Service: return "Service";
+  case ftypes::HighwayClass::Pedestrian: return "Pedestrian";
+  case ftypes::HighwayClass::Count: return "Count";
   }
 }
-} // namespace
+}  // namespace
 
 namespace ftypes
 {
@@ -482,4 +483,4 @@ bool IsTypeConformed(uint32_t type, StringIL const & path)
   }
   return true;
 }
-} // namespace ftypes
+}  // namespace ftypes

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -388,24 +388,27 @@ bool IsTypeConformed(uint32_t type, StringIL const & path)
   return true;
 }
 
+char const * HighwayClassToString(HighwayClass const & cls)
+{
+  switch (cls)
+  {
+    case HighwayClass::Undefined: return "Undefined";
+    case HighwayClass::Error: return "Error";
+    case HighwayClass::Trunk: return "Trunk";
+    case HighwayClass::Primary: return "Primary";
+    case HighwayClass::Secondary: return "Secondary";
+    case HighwayClass::Tertiary: return "Tertiary";
+    case HighwayClass::LivingStreet: return "LivingStreet";
+    case HighwayClass::Service: return "Service";
+    case HighwayClass::Pedestrian: return "Pedestrian";
+    case HighwayClass::Count: return "Count";
+  }
+}
+
 string DebugPrint(HighwayClass const cls)
 {
   stringstream out;
-  out << "[ ";
-  switch (cls)
-  {
-    case HighwayClass::Undefined: out << "Undefined"; break;
-    case HighwayClass::Error: out << "Error"; break;
-    case HighwayClass::Trunk: out << "Trunk"; break;
-    case HighwayClass::Primary: out << "Primary"; break;
-    case HighwayClass::Secondary: out << "Secondary"; break;
-    case HighwayClass::Tertiary: out << "Tertiary"; break;
-    case HighwayClass::LivingStreet: out << "LivingStreet"; break;
-    case HighwayClass::Service: out << "Service"; break;
-    case HighwayClass::Pedestrian: out << "Pedestrian"; break;
-    case HighwayClass::Count: out << "Count"; break;
-  }
-  out << " ]";
+  out << "[ " << HighwayClassToString(cls) << " ]";
   return out.str();
 }
 
@@ -439,13 +442,12 @@ HighwayClass GetHighwayClass(feature::TypesHolder const & types)
       {c.GetTypeByPath({"highway", "path"}), HighwayClass::Pedestrian},
   };
   uint8_t constexpr kTruncLevel = 2;
-  auto const highwayClassesEndIt = kHighwayClasses.cend();
 
   for (auto t : types)
   {
     ftype::TruncValue(t, kTruncLevel);
     auto const it = kHighwayClasses.find(t);
-    if (it != highwayClassesEndIt)
+    if (it != kHighwayClasses.cend())
       return it->second;
   }
 

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -8,8 +8,103 @@
 #include "std/sstream.hpp"
 #include "std/utility.hpp"
 
+namespace
+{
+class HighwayClasses
+{
+  map<uint32_t, ftypes::HighwayClass> m_map;
+public:
+  HighwayClasses()
+  {
+    auto const & c = classif();
+    m_map[c.GetTypeByPath({"highway", "motorway"})] = ftypes::HighwayClass::Trunk;
+    m_map[c.GetTypeByPath({"highway", "motorway_link"})] = ftypes::HighwayClass::Trunk;
+    m_map[c.GetTypeByPath({"highway", "trunk"})] = ftypes::HighwayClass::Trunk;
+    m_map[c.GetTypeByPath({"highway", "trunk_link"})] = ftypes::HighwayClass::Trunk;
+    m_map[c.GetTypeByPath({"route", "ferry"})] = ftypes::HighwayClass::Trunk;
+
+    m_map[c.GetTypeByPath({"highway", "primary"})] = ftypes::HighwayClass::Primary;
+    m_map[c.GetTypeByPath({"highway", "primary_link"})] = ftypes::HighwayClass::Primary;
+
+    m_map[c.GetTypeByPath({"highway", "secondary"})] = ftypes::HighwayClass::Secondary;
+    m_map[c.GetTypeByPath({"highway", "secondary_link"})] = ftypes::HighwayClass::Secondary;
+
+    m_map[c.GetTypeByPath({"highway", "tertiary"})] = ftypes::HighwayClass::Tertiary;
+    m_map[c.GetTypeByPath({"highway", "tertiary_link"})] = ftypes::HighwayClass::Tertiary;
+
+    m_map[c.GetTypeByPath({"highway", "unclassified"})] = ftypes::HighwayClass::LivingStreet;
+    m_map[c.GetTypeByPath({"highway", "residential"})] = ftypes::HighwayClass::LivingStreet;
+    m_map[c.GetTypeByPath({"highway", "living_street"})] = ftypes::HighwayClass::LivingStreet;
+    m_map[c.GetTypeByPath({"highway", "road"})] = ftypes::HighwayClass::LivingStreet;
+
+    m_map[c.GetTypeByPath({"highway", "service"})] = ftypes::HighwayClass::Service;
+    m_map[c.GetTypeByPath({"highway", "track"})] = ftypes::HighwayClass::Service;
+
+    m_map[c.GetTypeByPath({"highway", "pedestrian"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "footway"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "bridleway"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "steps"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "cycleway"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "path"})] = ftypes::HighwayClass::Pedestrian;
+  }
+
+  ftypes::HighwayClass Get(uint32_t t) const
+  {
+    auto const it = m_map.find(t);
+    if (it == m_map.cend())
+      return ftypes::HighwayClass::Error;
+    return it->second;
+  }
+};
+
+char const * HighwayClassToString(ftypes::HighwayClass const cls)
+{
+  switch (cls)
+  {
+    case ftypes::HighwayClass::Undefined: return "Undefined";
+    case ftypes::HighwayClass::Error: return "Error";
+    case ftypes::HighwayClass::Trunk: return "Trunk";
+    case ftypes::HighwayClass::Primary: return "Primary";
+    case ftypes::HighwayClass::Secondary: return "Secondary";
+    case ftypes::HighwayClass::Tertiary: return "Tertiary";
+    case ftypes::HighwayClass::LivingStreet: return "LivingStreet";
+    case ftypes::HighwayClass::Service: return "Service";
+    case ftypes::HighwayClass::Pedestrian: return "Pedestrian";
+    case ftypes::HighwayClass::Count: return "Count";
+  }
+}
+} // namespace
+
 namespace ftypes
 {
+string DebugPrint(HighwayClass const cls)
+{
+  stringstream out;
+  out << "[ " << HighwayClassToString(cls) << " ]";
+  return out.str();
+}
+
+HighwayClass GetHighwayClass(feature::TypesHolder const & types)
+{
+  uint8_t constexpr kTruncLevel = 2;
+  static HighwayClasses highwayClasses;
+
+  for (auto t : types)
+  {
+    ftype::TruncValue(t, kTruncLevel);
+    HighwayClass const hc = highwayClasses.Get(t);
+    if (hc != HighwayClass::Error)
+      return hc;
+  }
+
+  return HighwayClass::Error;
+}
+
+HighwayClass GetHighwayClass(FeatureType const & ft)
+{
+  return GetHighwayClass(feature::TypesHolder(ft));
+}
+
 uint32_t BaseChecker::PrepareToMatch(uint32_t type, uint8_t level)
 {
   ftype::TruncValue(type, level);
@@ -387,75 +482,4 @@ bool IsTypeConformed(uint32_t type, StringIL const & path)
   }
   return true;
 }
-
-char const * HighwayClassToString(HighwayClass const & cls)
-{
-  switch (cls)
-  {
-    case HighwayClass::Undefined: return "Undefined";
-    case HighwayClass::Error: return "Error";
-    case HighwayClass::Trunk: return "Trunk";
-    case HighwayClass::Primary: return "Primary";
-    case HighwayClass::Secondary: return "Secondary";
-    case HighwayClass::Tertiary: return "Tertiary";
-    case HighwayClass::LivingStreet: return "LivingStreet";
-    case HighwayClass::Service: return "Service";
-    case HighwayClass::Pedestrian: return "Pedestrian";
-    case HighwayClass::Count: return "Count";
-  }
-}
-
-string DebugPrint(HighwayClass const cls)
-{
-  stringstream out;
-  out << "[ " << HighwayClassToString(cls) << " ]";
-  return out.str();
-}
-
-HighwayClass GetHighwayClass(feature::TypesHolder const & types)
-{
-  Classificator const & c = classif();
-
-  static map<uint32_t, HighwayClass> const kHighwayClasses = {
-      {c.GetTypeByPath({"highway", "motorway"}), HighwayClass::Trunk},
-      {c.GetTypeByPath({"highway", "motorway_link"}), HighwayClass::Trunk},
-      {c.GetTypeByPath({"highway", "trunk"}), HighwayClass::Trunk},
-      {c.GetTypeByPath({"highway", "trunk_link"}), HighwayClass::Trunk},
-      {c.GetTypeByPath({"route", "ferry"}), HighwayClass::Trunk},
-      {c.GetTypeByPath({"highway", "primary"}), HighwayClass::Primary},
-      {c.GetTypeByPath({"highway", "primary_link"}), HighwayClass::Primary},
-      {c.GetTypeByPath({"highway", "secondary"}), HighwayClass::Secondary},
-      {c.GetTypeByPath({"highway", "secondary_link"}), HighwayClass::Secondary},
-      {c.GetTypeByPath({"highway", "tertiary"}), HighwayClass::Tertiary},
-      {c.GetTypeByPath({"highway", "tertiary_link"}), HighwayClass::Tertiary},
-      {c.GetTypeByPath({"highway", "unclassified"}), HighwayClass::LivingStreet},
-      {c.GetTypeByPath({"highway", "residential"}), HighwayClass::LivingStreet},
-      {c.GetTypeByPath({"highway", "living_street"}), HighwayClass::LivingStreet},
-      {c.GetTypeByPath({"highway", "road"}), HighwayClass::LivingStreet},
-      {c.GetTypeByPath({"highway", "service"}), HighwayClass::Service},
-      {c.GetTypeByPath({"highway", "track"}), HighwayClass::Service},
-      {c.GetTypeByPath({"highway", "pedestrian"}), HighwayClass::Pedestrian},
-      {c.GetTypeByPath({"highway", "footway"}), HighwayClass::Pedestrian},
-      {c.GetTypeByPath({"highway", "bridleway"}), HighwayClass::Pedestrian},
-      {c.GetTypeByPath({"highway", "steps"}), HighwayClass::Pedestrian},
-      {c.GetTypeByPath({"highway", "cycleway"}), HighwayClass::Pedestrian},
-      {c.GetTypeByPath({"highway", "path"}), HighwayClass::Pedestrian},
-  };
-  uint8_t constexpr kTruncLevel = 2;
-
-  for (auto t : types)
-  {
-    ftype::TruncValue(t, kTruncLevel);
-    auto const it = kHighwayClasses.find(t);
-    if (it != kHighwayClasses.cend())
-      return it->second;
-  }
-
-  return HighwayClass::Error;
-}
-
-HighwayClass GetHighwayClass(FeatureType const & ft)
-{
-  return GetHighwayClass(feature::TypesHolder(ft));
-}
-}
+} // namespace ftypes

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -4,6 +4,7 @@
 #include "indexer/feature_data.hpp"
 #include "indexer/classificator.hpp"
 
+#include "std/map.hpp"
 #include "std/sstream.hpp"
 #include "std/utility.hpp"
 
@@ -395,26 +396,32 @@ string DebugPrint(HighwayClass const cls)
   {
     case HighwayClass::Undefined:
       out << "Undefined";
+      break;
     case HighwayClass::Error:
       out << "Error";
+      break;
     case HighwayClass::Trunk:
       out << "Trunk";
+      break;
     case HighwayClass::Primary:
       out << "Primary";
+      break;
     case HighwayClass::Secondary:
       out << "Secondary";
+      break;
     case HighwayClass::Tertiary:
       out << "Tertiary";
+      break;
     case HighwayClass::LivingStreet:
       out << "LivingStreet";
+      break;
     case HighwayClass::Service:
       out << "Service";
-    case HighwayClass::Pedestrian:
-      out << "Pedestrian";
+      break;
+    case HighwayClass::Pedestrian: out << "Pedestrian"; break;
     case HighwayClass::Count:
       out << "Count";
-    default:
-      out << "Unknown value of HighwayClass: " << static_cast<int>(cls);
+      break;
   }
   out << " ]";
   return out.str();
@@ -423,41 +430,41 @@ string DebugPrint(HighwayClass const cls)
 HighwayClass GetHighwayClass(feature::TypesHolder const & types)
 {
   Classificator const & c = classif();
-  static pair<HighwayClass, uint32_t> const kHighwayClasses[] = {
-      {HighwayClass::Trunk, c.GetTypeByPath({"highway", "motorway"})},
-      {HighwayClass::Trunk, c.GetTypeByPath({"highway", "motorway_link"})},
-      {HighwayClass::Trunk, c.GetTypeByPath({"highway", "trunk"})},
-      {HighwayClass::Trunk, c.GetTypeByPath({"highway", "trunk_link"})},
-      {HighwayClass::Trunk, c.GetTypeByPath({"route", "ferry"})},
-      {HighwayClass::Primary, c.GetTypeByPath({"highway", "primary"})},
-      {HighwayClass::Primary, c.GetTypeByPath({"highway", "primary_link"})},
-      {HighwayClass::Secondary, c.GetTypeByPath({"highway", "secondary"})},
-      {HighwayClass::Secondary, c.GetTypeByPath({"highway", "secondary_link"})},
-      {HighwayClass::Tertiary, c.GetTypeByPath({"highway", "tertiary"})},
-      {HighwayClass::Tertiary, c.GetTypeByPath({"highway", "tertiary_link"})},
-      {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "unclassified"})},
-      {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "residential"})},
-      {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "living_street"})},
-      {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "road"})},
-      {HighwayClass::Service, c.GetTypeByPath({"highway", "service"})},
-      {HighwayClass::Service, c.GetTypeByPath({"highway", "track"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "pedestrian"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "footway"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "bridleway"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "steps"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "cycleway"})},
-      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "path"})},
+
+  static map<uint32_t, HighwayClass> const kHighwayClasses = {
+      {c.GetTypeByPath({"highway", "motorway"}), HighwayClass::Trunk},
+      {c.GetTypeByPath({"highway", "motorway_link"}), HighwayClass::Trunk},
+      {c.GetTypeByPath({"highway", "trunk"}), HighwayClass::Trunk},
+      {c.GetTypeByPath({"highway", "trunk_link"}), HighwayClass::Trunk},
+      {c.GetTypeByPath({"route", "ferry"}), HighwayClass::Trunk},
+      {c.GetTypeByPath({"highway", "primary"}), HighwayClass::Primary},
+      {c.GetTypeByPath({"highway", "primary_link"}), HighwayClass::Primary},
+      {c.GetTypeByPath({"highway", "secondary"}), HighwayClass::Secondary},
+      {c.GetTypeByPath({"highway", "secondary_link"}), HighwayClass::Secondary},
+      {c.GetTypeByPath({"highway", "tertiary"}), HighwayClass::Tertiary},
+      {c.GetTypeByPath({"highway", "tertiary_link"}), HighwayClass::Tertiary},
+      {c.GetTypeByPath({"highway", "unclassified"}), HighwayClass::LivingStreet},
+      {c.GetTypeByPath({"highway", "residential"}), HighwayClass::LivingStreet},
+      {c.GetTypeByPath({"highway", "living_street"}), HighwayClass::LivingStreet},
+      {c.GetTypeByPath({"highway", "road"}), HighwayClass::LivingStreet},
+      {c.GetTypeByPath({"highway", "service"}), HighwayClass::Service},
+      {c.GetTypeByPath({"highway", "track"}), HighwayClass::Service},
+      {c.GetTypeByPath({"highway", "pedestrian"}), HighwayClass::Pedestrian},
+      {c.GetTypeByPath({"highway", "footway"}), HighwayClass::Pedestrian},
+      {c.GetTypeByPath({"highway", "bridleway"}), HighwayClass::Pedestrian},
+      {c.GetTypeByPath({"highway", "steps"}), HighwayClass::Pedestrian},
+      {c.GetTypeByPath({"highway", "cycleway"}), HighwayClass::Pedestrian},
+      {c.GetTypeByPath({"highway", "path"}), HighwayClass::Pedestrian},
   };
-  uint8_t const kTruncLevel = 2;
+  uint8_t constexpr kTruncLevel = 2;
+  auto const highwayClassesEndIt = kHighwayClasses.cend();
 
   for (auto t : types)
   {
     ftype::TruncValue(t, kTruncLevel);
-    for (auto const & cls : kHighwayClasses)
-    {
-      if (cls.second == t)
-        return cls.first;
-    }
+    auto const it = kHighwayClasses.find(t);
+    if (it != highwayClassesEndIt)
+      return it->second;
   }
 
   return HighwayClass::Error;

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -394,34 +394,16 @@ string DebugPrint(HighwayClass const cls)
   out << "[ ";
   switch (cls)
   {
-    case HighwayClass::Undefined:
-      out << "Undefined";
-      break;
-    case HighwayClass::Error:
-      out << "Error";
-      break;
-    case HighwayClass::Trunk:
-      out << "Trunk";
-      break;
-    case HighwayClass::Primary:
-      out << "Primary";
-      break;
-    case HighwayClass::Secondary:
-      out << "Secondary";
-      break;
-    case HighwayClass::Tertiary:
-      out << "Tertiary";
-      break;
-    case HighwayClass::LivingStreet:
-      out << "LivingStreet";
-      break;
-    case HighwayClass::Service:
-      out << "Service";
-      break;
+    case HighwayClass::Undefined: out << "Undefined"; break;
+    case HighwayClass::Error: out << "Error"; break;
+    case HighwayClass::Trunk: out << "Trunk"; break;
+    case HighwayClass::Primary: out << "Primary"; break;
+    case HighwayClass::Secondary: out << "Secondary"; break;
+    case HighwayClass::Tertiary: out << "Tertiary"; break;
+    case HighwayClass::LivingStreet: out << "LivingStreet"; break;
+    case HighwayClass::Service: out << "Service"; break;
     case HighwayClass::Pedestrian: out << "Pedestrian"; break;
-    case HighwayClass::Count:
-      out << "Count";
-      break;
+    case HighwayClass::Count: out << "Count"; break;
   }
   out << " ]";
   return out.str();

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -73,6 +73,8 @@ char const * HighwayClassToString(ftypes::HighwayClass const cls)
   case ftypes::HighwayClass::Pedestrian: return "Pedestrian";
   case ftypes::HighwayClass::Count: return "Count";
   }
+  ASSERT(false, ());
+  return "";
 }
 }  // namespace
 
@@ -99,11 +101,6 @@ HighwayClass GetHighwayClass(feature::TypesHolder const & types)
   }
 
   return HighwayClass::Error;
-}
-
-HighwayClass GetHighwayClass(FeatureType const & ft)
-{
-  return GetHighwayClass(feature::TypesHolder(ft));
 }
 
 uint32_t BaseChecker::PrepareToMatch(uint32_t type, uint8_t level)

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -409,6 +409,8 @@ string DebugPrint(HighwayClass const cls)
       out << "LivingStreet";
     case HighwayClass::Service:
       out << "Service";
+    case HighwayClass::Pedestrian:
+      out << "Pedestrian";
     case HighwayClass::Count:
       out << "Count";
     default:
@@ -436,8 +438,16 @@ HighwayClass GetHighwayClass(feature::TypesHolder const & types)
       {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "unclassified"})},
       {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "residential"})},
       {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "living_street"})},
+      {HighwayClass::LivingStreet, c.GetTypeByPath({"highway", "road"})},
       {HighwayClass::Service, c.GetTypeByPath({"highway", "service"})},
-      {HighwayClass::Service, c.GetTypeByPath({"highway", "track"})}};
+      {HighwayClass::Service, c.GetTypeByPath({"highway", "track"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "pedestrian"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "footway"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "bridleway"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "steps"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "cycleway"})},
+      {HighwayClass::Pedestrian, c.GetTypeByPath({"highway", "path"})},
+  };
   uint8_t const kTruncLevel = 2;
 
   for (auto t : types)

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -206,7 +206,7 @@ enum class HighwayClass
   LivingStreet,
   Service,
   Pedestrian,
-  Count           // This value is used for internals only.
+  Count  // This value is used for internals only.
 };
 
 string DebugPrint(HighwayClass const cls);

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -205,6 +205,7 @@ enum class HighwayClass
   Tertiary,
   LivingStreet,
   Service,
+  Pedestrian,
   Count           // This value is used for internals only.
 };
 

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -212,6 +212,4 @@ enum class HighwayClass
 string DebugPrint(HighwayClass const cls);
 
 HighwayClass GetHighwayClass(feature::TypesHolder const & types);
-HighwayClass GetHighwayClass(FeatureType const & ft);
-
 }  // namespace ftypes

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -15,12 +15,12 @@ namespace
 using namespace routing;
 using namespace routing::turns;
 
-class RoutingResultGraph : public IRoutingResult
+class RoutingResult : public IRoutingResult
 {
 public:
-  RoutingResultGraph(IRoadGraph::TEdgeVector const & routeEdges,
-                     TAdjacentEdgesMap const & adjacentEdges,
-                     TUnpackedPathSegments const & pathSegments)
+  RoutingResult(IRoadGraph::TEdgeVector const & routeEdges,
+                BicycleDirectionsEngine::TAdjacentEdgesMap const & adjacentEdges,
+                TUnpackedPathSegments const & pathSegments)
     : m_routeEdges(routeEdges)
     , m_adjacentEdges(adjacentEdges)
     , m_pathSegments(pathSegments)
@@ -70,7 +70,7 @@ public:
 
 private:
   IRoadGraph::TEdgeVector const & m_routeEdges;
-  TAdjacentEdgesMap const & m_adjacentEdges;
+  BicycleDirectionsEngine::TAdjacentEdgesMap const & m_adjacentEdges;
   TUnpackedPathSegments const & m_pathSegments;
   double m_routeLength;
 };
@@ -151,14 +151,16 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
 
     LoadedPathSegment pathSegment;
     if (inFeatureId.IsValid())
+    {
       LoadPathGeometry(inFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()},
                        pathSegment);
+    }
 
     m_adjacentEdges.insert(make_pair(inFeatureId.m_index, move(adjacentEdges)));
     m_pathSegments.push_back(move(pathSegment));
   }
 
-  RoutingResultGraph resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
+  RoutingResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
   RouterDelegate delegate;
   Route::TTimes turnAnnotationTimes;
   Route::TStreets streetNames;

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -1,4 +1,5 @@
 #include "routing/bicycle_directions.hpp"
+#include "routing/car_model.hpp"
 #include "routing/router_delegate.hpp"
 #include "routing/routing_result_graph.hpp"
 #include "routing/turns_generator.hpp"
@@ -6,11 +7,72 @@
 #include "geometry/point2d.hpp"
 
 #include "indexer/index.hpp"
+#include "indexer/scales.hpp"
 
 namespace
 {
 using namespace routing;
 using namespace routing::turns;
+
+/*!
+ * \brief The Point2Geometry class is responsable for looking for all adjacent to junctionPoint
+ * road network edges. Including the current edge.
+ */
+class Point2Geometry
+{
+  m2::PointD const m_junctionPoint, m_ingoingPoint;
+  TGeomTurnCandidate & m_candidates; /*!< All road feature angles crosses |m_junctionPoint| point. */
+
+public:
+  Point2Geometry(m2::PointD const & junctionPoint, m2::PointD const & ingoingPoint,
+                 TGeomTurnCandidate & candidates)
+      : m_junctionPoint(junctionPoint), m_ingoingPoint(ingoingPoint), m_candidates(candidates)
+  {
+  }
+
+  void operator()(FeatureType const & ft)
+  {
+    if (!CarModel::Instance().IsRoad(ft))
+      return;
+    ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
+    size_t const count = ft.GetPointsCount();
+    ASSERT_GREATER(count, 1, ());
+
+    for (size_t i = 0; i < count; ++i)
+    {
+      if (MercatorBounds::DistanceOnEarth(m_junctionPoint, ft.GetPoint(i)) <
+          kFeaturesNearTurnMeters)
+      {
+        if (i > 0)
+          m_candidates.push_back(my::RadToDeg(
+              PiMinusTwoVectorsAngle(m_junctionPoint, m_ingoingPoint, ft.GetPoint(i - 1))));
+        if (i < count - 1)
+          m_candidates.push_back(my::RadToDeg(
+              PiMinusTwoVectorsAngle(m_junctionPoint, m_ingoingPoint, ft.GetPoint(i + 1))));
+        return;
+      }
+    }
+  }
+
+  DISALLOW_COPY_AND_MOVE(Point2Geometry);
+};
+
+/*!
+ * \brief GetTurnGeometry looks for all the road network edges near ingoingPoint.
+ * GetTurnGeometry fills candidates with angles of all the incoming and outgoint segments.
+ * \warning GetTurnGeometry should be used carefully because it's a time-consuming function.
+ * \warning In multilevel crossroads there is an insignificant possibility that candidates
+ * is filled with redundant segments of roads of different levels.
+ */
+void GetTurnGeometry(m2::PointD const & junctionPoint, m2::PointD const & ingoingPoint,
+                     TGeomTurnCandidate & candidates, Index::MwmId const & mwmId,
+                     Index const & index)
+{
+  Point2Geometry getter(junctionPoint, ingoingPoint, candidates);
+  index.ForEachInRectForMWM(
+      getter, MercatorBounds::RectByCenterXYAndSizeInMeters(junctionPoint, kFeaturesNearTurnMeters),
+      scales::GetUpperScale(), mwmId);
+}
 
 class AStarRoutingResultGraph : public IRoutingResultGraph
 {
@@ -33,11 +95,11 @@ public:
     // TODO(bykoianko) Calculate correctly ingoingCount. For the time being
     // any juction with one outgoing way would not be considered as a turn.
     ingoingCount = 0;
-    // Find all roads near junctionPoint.
+    // Find all roads near junctionPoint using GetTurnGeometry()
     //
   }
 
-  virtual double GetShortestPathLength() const override { return m_routeLength; }
+  virtual double GetPathLength() const override { return m_routeLength; }
 
   virtual m2::PointD const & GetStartPoint() const override
   {

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -111,13 +111,12 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
   IRoadGraph::TEdgeVector routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LDEBUG, ("Couldn't reconstruct path"));
+    LOG(LDEBUG, ("Couldn't reconstruct path."));
     emptyPathWorkaround();
     return;
   }
   if (routeEdges.empty())
   {
-    ASSERT(false, ());
     emptyPathWorkaround();
     return;
   }
@@ -137,7 +136,7 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
     adjacentEdges.m_outgoingTurns.isCandidatesAngleValid = false;
     adjacentEdges.m_outgoingTurns.candidates.reserve(outgoingEdges.size());
     ASSERT_EQUAL(routeEdges.size(), pathSize - 1, ());
-    FeatureID const inEdgeFeatureId = routeEdges[i - 1].GetFeatureId();
+    FeatureID const inFeatureId = routeEdges[i - 1].GetFeatureId();
 
     for (auto const & edge : outgoingEdges)
     {
@@ -150,10 +149,10 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
     }
 
     LoadedPathSegment pathSegment;
-    if (inEdgeFeatureId.IsValid())
-      LoadPathGeometry(inEdgeFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()}, pathSegment);
+    if (inFeatureId.IsValid())
+      LoadPathGeometry(inFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()}, pathSegment);
 
-    m_adjacentEdges.insert(make_pair(inEdgeFeatureId.m_index, move(adjacentEdges)));
+    m_adjacentEdges.insert(make_pair(inFeatureId.m_index, move(adjacentEdges)));
     m_pathSegments.push_back(move(pathSegment));
   }
 
@@ -175,10 +174,10 @@ ftypes::HighwayClass BicycleDirectionsEngine::GetHighwayClass(FeatureID const & 
 {
   FeatureType ft;
   GetLoader(featureId.m_mwmId).GetFeatureByIndex(featureId.m_index, ft);
-  auto const highWayClass = ftypes::GetHighwayClass(ft);
-  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Error, ());
-  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Undefined, ());
-  return highWayClass;
+  auto const highwayClass = ftypes::GetHighwayClass(ft);
+  ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Error, ());
+  ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Undefined, ());
+  return highwayClass;
 }
 
 void BicycleDirectionsEngine::LoadPathGeometry(FeatureID const & featureId, vector<m2::PointD> const & path,

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -84,14 +84,15 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
                                        vector<m2::PointD> & routeGeometry,
                                        my::Cancellable const & cancellable)
 {
-  size_t const pathSize = path.size();
-  CHECK_NOT_EQUAL(pathSize, 0, ());
-
   times.clear();
   turns.clear();
   routeGeometry.clear();
   m_adjacentEdges.clear();
   m_pathSegments.clear();
+
+  size_t const pathSize = path.size();
+  if (pathSize == 0)
+    return;
 
   auto emptyPathWorkaround = [&]()
   {
@@ -99,9 +100,8 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
     this->m_adjacentEdges[0] = AdjacentEdges(1);  // There's one ingoing edge to the finish.
   };
 
-  if (pathSize <= 1)
+  if (pathSize == 1)
   {
-    ASSERT(false, (pathSize));
     emptyPathWorkaround();
     return;
   }

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -1,0 +1,107 @@
+#include "routing/bicycle_directions.hpp"
+#include "routing/router_delegate.hpp"
+#include "routing/routing_result_graph.hpp"
+#include "routing/turns_generator.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "indexer/index.hpp"
+
+namespace
+{
+using namespace routing;
+using namespace routing::turns;
+
+class AStarRoutingResultGraph : public IRoutingResultGraph
+{
+public:
+  virtual vector<LoadedPathSegment> const & GetSegments() const override
+  {
+    return vector<LoadedPathSegment>();
+  }
+
+  virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
+                                m2::PointD const & junctionPoint,
+                                size_t & ingoingCount,
+                                TTurnCandidates & outgoingTurns) const override
+  {
+    if (node >= m_routeEdges.size())
+    {
+      ASSERT(false, ());
+      return;
+    }
+    // TODO(bykoianko) Calculate correctly ingoingCount. For the time being
+    // any juction with one outgoing way would not be considered as a turn.
+    ingoingCount = 0;
+    // Find all roads near junctionPoint.
+    //
+  }
+
+  virtual double GetShortestPathLength() const override { return m_routeLength; }
+
+  virtual m2::PointD const & GetStartPoint() const override
+  {
+    CHECK(!m_routeEdges.empty(), ());
+    return m_routeEdges.front().GetStartJunction().GetPoint();
+  }
+
+  virtual m2::PointD const & GetEndPoint() const override
+  {
+    CHECK(!m_routeEdges.empty(), ());
+    return m_routeEdges.back().GetEndJunction().GetPoint();
+  }
+
+  AStarRoutingResultGraph(/*Index const & index,*/ vector<Edge> const & routeEdges)
+    : // m_index(index),
+      m_routeEdges(routeEdges), m_routeLength(0)
+  {
+    // Calculate length of routeEdges |m_routeLength|
+  }
+
+  ~AStarRoutingResultGraph() {}
+
+private:
+//   Index const & m_index;
+   vector<Edge> const & m_routeEdges;
+   double m_routeLength;
+};
+}  // namespace
+
+namespace routing
+{
+BicycleDirectionsEngine::BicycleDirectionsEngine()
+{
+}
+
+void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction> const & path,
+                                       Route::TTimes & times,
+                                       Route::TTurns & turnsDir,
+                                       my::Cancellable const & cancellable)
+{
+  CHECK_GREATER(path.size(), 1, ());
+
+  CalculateTimes(graph, path, times);
+
+  vector<Edge> routeEdges;
+  if (!ReconstructPath(graph, path, routeEdges, cancellable))
+  {
+    LOG(LDEBUG, ("Couldn't reconstruct path"));
+    // use only "arrival" direction
+    turnsDir.emplace_back(path.size() - 1, turns::TurnDirection::ReachedYourDestination);
+    return;
+  }
+  if (routeEdges.empty())
+  {
+    ASSERT(false, ());
+    turnsDir.emplace_back(path.size() - 1, turns::TurnDirection::ReachedYourDestination);
+    return;
+  }
+
+  AStarRoutingResultGraph resultGraph(routeEdges);
+  RouterDelegate delegate;
+  vector<m2::PointD> routePoints;
+  Route::TTimes turnAnnotationTimes;
+  Route::TStreets streetNames;
+  MakeTurnAnnotation(resultGraph, delegate, routePoints, turnsDir, turnAnnotationTimes, streetNames);
+}
+}  // namespace routing

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -43,7 +43,7 @@ public:
     ingoingCount = 0;
     outgoingTurns.candidates.clear();
 
-    auto adjacentEdges = m_adjacentEdges.find(node);
+    auto const adjacentEdges = m_adjacentEdges.find(node);
     if (adjacentEdges == m_adjacentEdges.cend())
     {
       ASSERT(false, ());
@@ -74,49 +74,6 @@ private:
   TUnpackedPathSegments const & m_pathSegments;
   double m_routeLength;
 };
-
-ftypes::HighwayClass GetHighwayClass(FeatureID const & featureId, Index const & index)
-{
-  ftypes::HighwayClass highWayClass = ftypes::HighwayClass::Undefined;
-  MwmSet::MwmId const & mwmId = featureId.m_mwmId;
-  uint32_t const featureIndex = featureId.m_index;
-
-  FeatureType ft;
-  Index::FeaturesLoaderGuard loader(index, mwmId);
-  loader.GetFeatureByIndex(featureIndex, ft);
-  highWayClass = ftypes::GetHighwayClass(ft);
-  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Error, ());
-  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Undefined, ());
-  return highWayClass;
-}
-
-void LoadPathGeometry(FeatureID const & featureId, Index const & index,
-                      vector<m2::PointD> const & path, LoadedPathSegment & pathSegment)
-{
-  pathSegment.Clear();
-
-  MwmSet::MwmId const & mwmId = featureId.m_mwmId;
-  if (!featureId.IsValid())
-  {
-    ASSERT(false, ());
-    return;
-  }
-
-  FeatureType ft;
-  Index::FeaturesLoaderGuard loader(index, mwmId);
-  loader.GetFeatureByIndex(featureId.m_index, ft);
-  pathSegment.m_highwayClass =  ftypes::GetHighwayClass(ft);
-  ASSERT_NOT_EQUAL(pathSegment.m_highwayClass, ftypes::HighwayClass::Error, ());
-  ASSERT_NOT_EQUAL(pathSegment.m_highwayClass, ftypes::HighwayClass::Undefined, ());
-  pathSegment.m_isLink = ftypes::IsLinkChecker::Instance()(ft);
-
-  ft.GetName(FeatureType::DEFAULT_LANG, pathSegment.m_name);
-
-  pathSegment.m_nodeId = featureId.m_index;
-  pathSegment.m_onRoundabout = ftypes::IsRoundAboutChecker::Instance()(ft);
-  pathSegment.m_path = path;
-  // @TODO(bykoianko) It's better to fill pathSegment.m_weight.
-}
 }  // namespace
 
 namespace routing
@@ -190,15 +147,12 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
       if (!outFeatureId.IsValid())
         continue;
       adjacentEdges.m_outgoingTurns.candidates.emplace_back(0. /* angle */, outFeatureId.m_index,
-                                                            GetHighwayClass(outFeatureId, m_index));
+                                                            GetHighwayClass(outFeatureId));
     }
 
     LoadedPathSegment pathSegment;
     if (inEdgeFeatureId.IsValid())
-    {
-      LoadPathGeometry(inEdgeFeatureId, m_index,
-                       {prevJunction.GetPoint(), currJunction.GetPoint()}, pathSegment);
-    }
+      LoadPathGeometry(inEdgeFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()}, pathSegment);
 
     m_adjacentEdges.insert(make_pair(inEdgeFeatureId.m_index, move(adjacentEdges)));
     m_pathSegments.push_back(move(pathSegment));
@@ -209,5 +163,54 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
   Route::TTimes turnAnnotationTimes;
   Route::TStreets streetNames;
   MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, turnAnnotationTimes, streetNames);
+}
+
+void BicycleDirectionsEngine::UpdateFeatureLoaderGuardIfNeeded(Index const & index, MwmSet::MwmId const & mwmId)
+{
+  if (!m_featuresLoaderGuard || mwmId != m_mwmIdFeaturesLoaderGuard)
+    m_featuresLoaderGuard.reset(new Index::FeaturesLoaderGuard(index, mwmId));
+}
+
+ftypes::HighwayClass BicycleDirectionsEngine::GetHighwayClass(FeatureID const & featureId)
+{
+  ftypes::HighwayClass highWayClass = ftypes::HighwayClass::Undefined;
+  MwmSet::MwmId const & mwmId = featureId.m_mwmId;
+  uint32_t const featureIndex = featureId.m_index;
+
+  FeatureType ft;
+  UpdateFeatureLoaderGuardIfNeeded(m_index, mwmId);
+  m_featuresLoaderGuard->GetFeatureByIndex(featureIndex, ft);
+  highWayClass = ftypes::GetHighwayClass(ft);
+  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Error, ());
+  ASSERT_NOT_EQUAL(highWayClass, ftypes::HighwayClass::Undefined, ());
+  return highWayClass;
+}
+
+void BicycleDirectionsEngine::LoadPathGeometry(FeatureID const & featureId, vector<m2::PointD> const & path,
+                                               LoadedPathSegment & pathSegment)
+{
+  pathSegment.Clear();
+
+  MwmSet::MwmId const & mwmId = featureId.m_mwmId;
+  if (!featureId.IsValid())
+  {
+    ASSERT(false, ());
+    return;
+  }
+
+  FeatureType ft;
+  UpdateFeatureLoaderGuardIfNeeded(m_index, mwmId);
+  m_featuresLoaderGuard->GetFeatureByIndex(featureId.m_index, ft);
+  pathSegment.m_highwayClass =  ftypes::GetHighwayClass(ft);
+  ASSERT_NOT_EQUAL(pathSegment.m_highwayClass, ftypes::HighwayClass::Error, ());
+  ASSERT_NOT_EQUAL(pathSegment.m_highwayClass, ftypes::HighwayClass::Undefined, ());
+  pathSegment.m_isLink = ftypes::IsLinkChecker::Instance()(ft);
+
+  ft.GetName(FeatureType::DEFAULT_LANG, pathSegment.m_name);
+
+  pathSegment.m_nodeId = featureId.m_index;
+  pathSegment.m_onRoundabout = ftypes::IsRoundAboutChecker::Instance()(ft);
+  pathSegment.m_path = path;
+  // @TODO(bykoianko) It's better to fill pathSegment.m_weight.
 }
 }  // namespace routing

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -18,7 +18,8 @@ using namespace routing::turns;
 class RoutingResultGraph : public IRoutingResult
 {
 public:
-  RoutingResultGraph(IRoadGraph::TEdgeVector const & routeEdges, TAdjacentEdgesMap const & adjacentEdges,
+  RoutingResultGraph(IRoadGraph::TEdgeVector const & routeEdges,
+                     TAdjacentEdgesMap const & adjacentEdges,
                      TUnpackedPathSegments const & pathSegments)
     : m_routeEdges(routeEdges)
     , m_adjacentEdges(adjacentEdges)
@@ -150,7 +151,8 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
 
     LoadedPathSegment pathSegment;
     if (inFeatureId.IsValid())
-      LoadPathGeometry(inFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()}, pathSegment);
+      LoadPathGeometry(inFeatureId, {prevJunction.GetPoint(), currJunction.GetPoint()},
+                       pathSegment);
 
     m_adjacentEdges.insert(make_pair(inFeatureId.m_index, move(adjacentEdges)));
     m_pathSegments.push_back(move(pathSegment));
@@ -180,7 +182,8 @@ ftypes::HighwayClass BicycleDirectionsEngine::GetHighwayClass(FeatureID const & 
   return highwayClass;
 }
 
-void BicycleDirectionsEngine::LoadPathGeometry(FeatureID const & featureId, vector<m2::PointD> const & path,
+void BicycleDirectionsEngine::LoadPathGeometry(FeatureID const & featureId,
+                                               vector<m2::PointD> const & path,
                                                LoadedPathSegment & pathSegment)
 {
   pathSegment.Clear();

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -39,7 +39,7 @@ private:
 
   TAdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
-  unique_ptr<Index::FeaturesLoaderGuard> m_loader;
   Index const & m_index;
+  unique_ptr<Index::FeaturesLoaderGuard> m_loader;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -14,7 +14,7 @@ struct AdjacentEdges
 {
   AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
 
-  turns::TTurnCandidates m_outgoingTurns;
+  turns::TurnCandidates m_outgoingTurns;
   size_t m_ingoingTurnsCount;
 };
 

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -19,7 +19,7 @@ struct AdjacentEdges
   size_t m_ingoingTurnsCount;
 };
 
-using AdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
+using TAdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
 
 class BicycleDirectionsEngine : public IDirectionsEngine
 {
@@ -32,15 +32,14 @@ public:
                 my::Cancellable const & cancellable) override;
 
 private:
-  void UpdateFeatureLoaderGuardIfNeeded(Index const & index, MwmSet::MwmId const & mwmId);
+  Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
   ftypes::HighwayClass GetHighwayClass(FeatureID const & featureId);
   void LoadPathGeometry(FeatureID const & featureId, vector<m2::PointD> const & path,
                         LoadedPathSegment & pathSegment);
 
-  AdjacentEdgesMap m_adjacentEdges;
+  TAdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
-  unique_ptr<Index::FeaturesLoaderGuard> m_featuresLoaderGuard;
-  MwmSet::MwmId m_mwmIdFeaturesLoaderGuard;
+  unique_ptr<Index::FeaturesLoaderGuard> m_loader;
   Index const & m_index;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "routing/directions_engine.hpp"
+
+namespace routing
+{
+
+class BicycleDirectionsEngine : public IDirectionsEngine
+{
+public:
+  BicycleDirectionsEngine();
+
+  // IDirectionsEngine override:
+  void Generate(IRoadGraph const & graph, vector<Junction> const & path,
+                Route::TTimes & times,
+                Route::TTurns & turnsDir,
+                my::Cancellable const & cancellable) override;
+};
+}  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -5,6 +5,7 @@
 #include "routing/turn_candidate.hpp"
 
 #include "std/map.hpp"
+#include "std/unique_ptr.hpp"
 
 class Index;
 
@@ -12,7 +13,7 @@ namespace routing
 {
 struct AdjacentEdges
 {
-  AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
+  explicit AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
 
   turns::TurnCandidates m_outgoingTurns;
   size_t m_ingoingTurnsCount;
@@ -31,8 +32,15 @@ public:
                 my::Cancellable const & cancellable) override;
 
 private:
+  void UpdateFeatureLoaderGuardIfNeeded(Index const & index, MwmSet::MwmId const & mwmId);
+  ftypes::HighwayClass GetHighwayClass(FeatureID const & featureId);
+  void LoadPathGeometry(FeatureID const & featureId, vector<m2::PointD> const & path,
+                        LoadedPathSegment & pathSegment);
+
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
+  unique_ptr<Index::FeaturesLoaderGuard> m_featuresLoaderGuard;
+  MwmSet::MwmId m_mwmIdFeaturesLoaderGuard;
   Index const & m_index;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -6,6 +6,8 @@
 
 #include "std/map.hpp"
 
+class Index;
+
 namespace routing
 {
 struct AdjacentEdges
@@ -19,15 +21,17 @@ using AdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
 class BicycleDirectionsEngine : public IDirectionsEngine
 {
 public:
-  BicycleDirectionsEngine();
+  BicycleDirectionsEngine(Index const & index);
 
   // IDirectionsEngine override:
   void Generate(IRoadGraph const & graph, vector<Junction> const & path,
                 Route::TTimes & times,
                 Route::TTurns & turnsDir,
+                vector<m2::PointD> & routeGeometry,
                 my::Cancellable const & cancellable) override;
 private:
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
+  Index const & m_index;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/directions_engine.hpp"
+#include "loaded_path_segment.hpp"
 #include "routing/turn_candidate.hpp"
 
 #include "std/map.hpp"
@@ -13,6 +14,8 @@ struct AdjacentEdges
   size_t ingoingTurnCount;
 };
 
+using AdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
+
 class BicycleDirectionsEngine : public IDirectionsEngine
 {
 public:
@@ -24,6 +27,7 @@ public:
                 Route::TTurns & turnsDir,
                 my::Cancellable const & cancellable) override;
 private:
-  map<TNodeId, AdjacentEdges> m_adjacentEdges;
+  AdjacentEdgesMap m_adjacentEdges;
+  TUnpackedPathSegments m_pathSegments;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -11,19 +11,19 @@ class Index;
 
 namespace routing
 {
-struct AdjacentEdges
-{
-  explicit AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
-
-  turns::TurnCandidates m_outgoingTurns;
-  size_t m_ingoingTurnsCount;
-};
-
-using TAdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
-
 class BicycleDirectionsEngine : public IDirectionsEngine
 {
 public:
+  struct AdjacentEdges
+  {
+    explicit AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
+
+    turns::TurnCandidates m_outgoingTurns;
+    size_t m_ingoingTurnsCount;
+  };
+
+  using TAdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
+
   BicycleDirectionsEngine(Index const & index);
 
   // IDirectionsEngine override:

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "routing/directions_engine.hpp"
-#include "loaded_path_segment.hpp"
+#include "routing/loaded_path_segment.hpp"
 #include "routing/turn_candidate.hpp"
 
 #include "std/map.hpp"
@@ -12,8 +12,10 @@ namespace routing
 {
 struct AdjacentEdges
 {
-  turns::TTurnCandidates outgoingTurns;
-  size_t ingoingTurnCount;
+  AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
+
+  turns::TTurnCandidates m_outgoingTurns;
+  size_t m_ingoingTurnsCount;
 };
 
 using AdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
@@ -24,11 +26,10 @@ public:
   BicycleDirectionsEngine(Index const & index);
 
   // IDirectionsEngine override:
-  void Generate(IRoadGraph const & graph, vector<Junction> const & path,
-                Route::TTimes & times,
-                Route::TTurns & turnsDir,
-                vector<m2::PointD> & routeGeometry,
+  void Generate(IRoadGraph const & graph, vector<Junction> const & path, Route::TTimes & times,
+                Route::TTurns & turns, vector<m2::PointD> & routeGeometry,
                 my::Cancellable const & cancellable) override;
+
 private:
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -1,9 +1,17 @@
 #pragma once
 
 #include "routing/directions_engine.hpp"
+#include "routing/turn_candidate.hpp"
+
+#include "std/map.hpp"
 
 namespace routing
 {
+struct AdjacentEdges
+{
+  turns::TTurnCandidates outgoingTurns;
+  size_t ingoingTurnCount;
+};
 
 class BicycleDirectionsEngine : public IDirectionsEngine
 {
@@ -15,5 +23,7 @@ public:
                 Route::TTimes & times,
                 Route::TTurns & turnsDir,
                 my::Cancellable const & cancellable) override;
+private:
+  map<TNodeId, AdjacentEdges> m_adjacentEdges;
 };
 }  // namespace routing

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -37,6 +37,13 @@ bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junctio
                                         vector<Edge> & routeEdges,
                                         my::Cancellable const & cancellable) const
 {
+  routeEdges.clear();
+  if (path.size() <= 1)
+  {
+    ASSERT(false, (path.size()));
+    return false;
+  }
+
   routeEdges.reserve(path.size() - 1);
 
   Junction curr = path[0];
@@ -52,7 +59,7 @@ bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junctio
     graph.GetOutgoingEdges(curr, currEdges);
 
     bool found = false;
-    for (Edge const & e : currEdges)
+    for (auto const & e : currEdges)
     {
       if (e.GetEndJunction() == next)
       {
@@ -68,7 +75,7 @@ bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junctio
     curr = next;
   }
 
-  ASSERT_EQUAL(routeEdges.size()+1, path.size(), ());
+  ASSERT_EQUAL(routeEdges.size() + 1, path.size(), ());
 
   return true;
 }

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -1,0 +1,75 @@
+#include "routing/directions_engine.hpp"
+
+#include "base/assert.hpp"
+
+namespace
+{
+double constexpr KMPH2MPS = 1000.0 / (60 * 60);
+}  // namespace
+
+namespace routing
+{
+void IDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
+                                       Route::TTimes & times) const
+{
+  double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
+
+  times.reserve(path.size());
+
+  double trackTimeSec = 0.0;
+  times.emplace_back(0, trackTimeSec);
+
+  m2::PointD prev = path[0].GetPoint();
+  for (size_t i = 1; i < path.size(); ++i)
+  {
+    m2::PointD const & curr = path[i].GetPoint();
+
+    double const lengthM = MercatorBounds::DistanceOnEarth(prev, curr);
+    trackTimeSec += lengthM / speedMPS;
+
+    times.emplace_back(i, trackTimeSec);
+
+    prev = curr;
+  }
+}
+
+bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
+                                        vector<Edge> & routeEdges,
+                                        my::Cancellable const & cancellable) const
+{
+  routeEdges.reserve(path.size() - 1);
+
+  Junction curr = path[0];
+  vector<Edge> currEdges;
+  for (size_t i = 1; i < path.size(); ++i)
+  {
+    if (cancellable.IsCancelled())
+      return false;
+
+    Junction const & next = path[i];
+
+    currEdges.clear();
+    graph.GetOutgoingEdges(curr, currEdges);
+
+    bool found = false;
+    for (Edge const & e : currEdges)
+    {
+      if (e.GetEndJunction() == next)
+      {
+        routeEdges.emplace_back(e);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found)
+      return false;
+
+    curr = next;
+  }
+
+  ASSERT_EQUAL(routeEdges.size()+1, path.size(), ());
+
+  return true;
+}
+}  // namespace routing

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -16,6 +16,13 @@ void IDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction
   if (path.size() <= 1)
     return;
 
+  // graph.GetMaxSpeedKMPH() below is used on purpose.
+  // The idea is while pedestian (bicycle) routing ways for pedestrians (cyclists) are prefered.
+  // At the same time routing along big roads is still possible but if there's
+  // a pedestrian (bicycle) alternative it's prefered. To implement it a small speed
+  // is set in pedestrian_model (bicycle_model) for big roads. On the other hand
+  // the most likely a pedestrian (a cyclist) will go along big roads with average
+  // speed (graph.GetMaxSpeedKMPH()).
   double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
 
   times.reserve(path.size());

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -12,6 +12,10 @@ namespace routing
 void IDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
                                        Route::TTimes & times) const
 {
+  times.clear();
+  if (path.size() <= 1)
+    return;
+
   double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
 
   times.reserve(path.size());
@@ -39,10 +43,7 @@ bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junctio
 {
   routeEdges.clear();
   if (path.size() <= 1)
-  {
-    ASSERT(false, (path.size()));
     return false;
-  }
 
   routeEdges.reserve(path.size() - 1);
 

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -5,6 +5,8 @@
 
 #include "base/cancellable.hpp"
 
+#include "std/vector.hpp"
+
 namespace routing
 {
 
@@ -16,6 +18,7 @@ public:
   virtual void Generate(IRoadGraph const & graph, vector<Junction> const & path,
                         Route::TTimes & times,
                         Route::TTurns & turnsDir,
+                        vector<m2::PointD> & routeGeometry,
                         my::Cancellable const & cancellable) = 0;
 protected:
   bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -16,14 +16,13 @@ public:
   virtual ~IDirectionsEngine() = default;
 
   virtual void Generate(IRoadGraph const & graph, vector<Junction> const & path,
-                        Route::TTimes & times,
-                        Route::TTurns & turnsDir,
+                        Route::TTimes & times, Route::TTurns & turns,
                         vector<m2::PointD> & routeGeometry,
                         my::Cancellable const & cancellable) = 0;
+
 protected:
   bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
-                       vector<Edge> & routeEdges,
-                       my::Cancellable const & cancellable) const;
+                       vector<Edge> & routeEdges, my::Cancellable const & cancellable) const;
 
   void CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
                       Route::TTimes & times) const;

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -17,6 +17,13 @@ public:
                         Route::TTimes & times,
                         Route::TTurns & turnsDir,
                         my::Cancellable const & cancellable) = 0;
+protected:
+  bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
+                       vector<Edge> & routeEdges,
+                       my::Cancellable const & cancellable) const;
+
+  void CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
+                      Route::TTimes & times) const;
 };
 
 }  // namespace routing

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -21,6 +21,9 @@ public:
                         my::Cancellable const & cancellable) = 0;
 
 protected:
+  /// \brief constructs route based on |graph| and |path|. Fills |routeEdges| with the route.
+  /// \returns false in case of any errors while reconstruction, if reconstruction process
+  /// was cancelled and in case of extremely short paths of 0 or 1 point. Returns true otherwise.
   bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
                        vector<Edge> & routeEdges, my::Cancellable const & cancellable) const;
 

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -28,7 +28,7 @@ struct LoadedPathSegment
   vector<m2::PointD> m_path;
   vector<turns::SingleLaneInfo> m_lanes;
   string m_name;
-  TEdgeWeight m_weight;
+  TEdgeWeight m_weight; /*!< Time in seconds to pass the segment. */
   TNodeId m_nodeId;
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -29,7 +29,7 @@ struct LoadedPathSegment
   vector<turns::SingleLaneInfo> m_lanes;
   string m_name;
   TEdgeWeight m_weight; /*!< Time in seconds to pass the segment. */
-  TNodeId m_nodeId;
+  TNodeId m_nodeId;     /*!< May be NodeId for OSRM router or FeatureId::index for graph router. */
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;
   bool m_isLink;

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -52,11 +52,6 @@ double constexpr kMwmLoadedProgress = 10.0f;
 double constexpr kPointsFoundProgress = 15.0f;
 double constexpr kCrossPathFoundProgress = 50.0f;
 double constexpr kPathFoundProgress = 70.0f;
-
-double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2)
-{
-  return math::pi - ang::TwoVectorsAngle(p, p1, p2);
-}
 } //  namespace
 
 using RawRouteData = InternalRouteResult;
@@ -145,7 +140,7 @@ public:
                   turns::kFeaturesNearTurnMeters, ());
 
       double const a =
-          my::RadToDeg(PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
+          my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
       outgoingTurns.emplace_back(a, targetNode, ftypes::GetHighwayClass(ft));
     }
 

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -60,12 +60,10 @@ class OSRMRoutingResult : public turns::IRoutingResult
 {
 public:
   // turns::IRoutingResult overrides:
-  TUnpackedPathSegments const & GetSegments() const override
-  {
-    return m_loadedSegments;
-  }
-  void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint, m2::PointD const & junctionPoint,
-                        size_t & ingoingCount, turns::TurnCandidates & outgoingTurns) const override
+  TUnpackedPathSegments const & GetSegments() const override { return m_loadedSegments; }
+  void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
+                        m2::PointD const & junctionPoint, size_t & ingoingCount,
+                        turns::TurnCandidates & outgoingTurns) const override
   {
     double const kReadCrossEpsilon = 1.0E-4;
 
@@ -145,22 +143,16 @@ public:
 
     sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(),
          [](turns::TurnCandidate const & t1, turns::TurnCandidate const & t2)
-         {
-           return t1.angle < t2.angle;
-         });
+    {
+      return t1.angle < t2.angle;
+    });
   }
 
   double GetPathLength() const override { return m_rawResult.shortestPathLength; }
 
-  m2::PointD const & GetStartPoint() const override
-  {
-    return m_rawResult.sourceEdge.segmentPoint;
-  }
+  m2::PointD const & GetStartPoint() const override { return m_rawResult.sourceEdge.segmentPoint; }
 
-  m2::PointD const & GetEndPoint() const override
-  {
-    return m_rawResult.targetEdge.segmentPoint;
-  }
+  m2::PointD const & GetEndPoint() const override { return m_rawResult.targetEdge.segmentPoint; }
 
   OSRMRoutingResult(Index const & index, RoutingMapping & mapping, RawRoutingResult & result)
     : m_rawResult(result), m_index(index), m_routingMapping(mapping)

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -56,10 +56,10 @@ double constexpr kPathFoundProgress = 70.0f;
 
 using RawRouteData = InternalRouteResult;
 
-class OSRMRoutingResultGraph : public turns::IRoutingResultGraph
+class OSRMRoutingResult : public turns::IRoutingResult
 {
 public:
-  // turns::IRoutingResultGraph overrides:
+  // turns::IRoutingResult overrides:
   virtual TUnpackedPathSegments const & GetSegments() const override
   {
     return m_loadedSegments;
@@ -161,7 +161,7 @@ public:
     return m_rawResult.targetEdge.segmentPoint;
   }
 
-  OSRMRoutingResultGraph(Index const & index, RoutingMapping & mapping, RawRoutingResult & result)
+  OSRMRoutingResult(Index const & index, RoutingMapping & mapping, RawRoutingResult & result)
     : m_rawResult(result), m_index(index), m_routingMapping(mapping)
   {
     for (auto const & pathSegments : m_rawResult.unpackedPathSegments)
@@ -187,7 +187,6 @@ public:
     }
   }
 
-  ~OSRMRoutingResultGraph() {}
 private:
   TUnpackedPathSegments m_loadedSegments;
   RawRoutingResult m_rawResult;
@@ -330,7 +329,7 @@ OsrmRouter::ResultCode OsrmRouter::MakeRouteFromCrossesPath(TCheckedPath const &
     Route::TTimes mwmTimes;
     Route::TStreets mwmStreets;
     vector<m2::PointD> mwmPoints;
-    OSRMRoutingResultGraph resultGraph(*m_pIndex, *mwmMapping, routingResult);
+    OSRMRoutingResult resultGraph(*m_pIndex, *mwmMapping, routingResult);
     if (MakeTurnAnnotation(resultGraph, delegate, mwmPoints, mwmTurnsDir, mwmTimes, mwmStreets) != NoError)
     {
       LOG(LWARNING, ("Can't load road path data from disk for", mwmMapping->GetCountryName()));
@@ -500,7 +499,7 @@ OsrmRouter::ResultCode OsrmRouter::CalculateRoute(m2::PointD const & startPoint,
     Route::TStreets streets;
     vector<m2::PointD> points;
 
-    OSRMRoutingResultGraph resultGraph(*m_pIndex, *startMapping, routingResult);
+    OSRMRoutingResult resultGraph(*m_pIndex, *startMapping, routingResult);
     if (MakeTurnAnnotation(resultGraph, delegate, points, turnsDir, times, streets) != NoError)
     {
       LOG(LWARNING, ("Can't load road path data from disk!"));

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -75,7 +75,6 @@ public:
                                 turns::TTurnCandidates & outgoingTurns) const override
   {
     double const kReadCrossEpsilon = 1.0E-4;
-    double const kFeaturesNearTurnMeters = 3.0;
 
     // Geting nodes by geometry.
     vector<NodeID> geomNodes;
@@ -143,7 +142,7 @@ public:
       m2::PointD const outgoingPoint = ft.GetPoint(
           seg.m_pointStart < seg.m_pointEnd ? seg.m_pointStart + 1 : seg.m_pointStart - 1);
       ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, ft.GetPoint(seg.m_pointStart)),
-                  kFeaturesNearTurnMeters, ());
+                  turns::kFeaturesNearTurnMeters, ());
 
       double const a =
           my::RadToDeg(PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
@@ -157,7 +156,7 @@ public:
          });
   }
 
-  virtual double GetShortestPathLength() const override { return m_rawResult.shortestPathLength; }
+  virtual double GetPathLength() const override { return m_rawResult.shortestPathLength; }
   virtual m2::PointD const & GetStartPoint() const override
   {
     return m_rawResult.sourceEdge.segmentPoint;

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -61,6 +61,7 @@ class OSRMRoutingResult : public turns::IRoutingResult
 public:
   // turns::IRoutingResult overrides:
   TUnpackedPathSegments const & GetSegments() const override { return m_loadedSegments; }
+
   void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                         m2::PointD const & junctionPoint, size_t & ingoingCount,
                         turns::TurnCandidates & outgoingTurns) const override

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -60,14 +60,12 @@ class OSRMRoutingResult : public turns::IRoutingResult
 {
 public:
   // turns::IRoutingResult overrides:
-  virtual TUnpackedPathSegments const & GetSegments() const override
+  TUnpackedPathSegments const & GetSegments() const override
   {
     return m_loadedSegments;
   }
-  virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
-                                m2::PointD const & junctionPoint,
-                                size_t & ingoingCount,
-                                turns::TurnCandidates & outgoingTurns) const override
+  void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint, m2::PointD const & junctionPoint,
+                        size_t & ingoingCount, turns::TurnCandidates & outgoingTurns) const override
   {
     double const kReadCrossEpsilon = 1.0E-4;
 
@@ -152,12 +150,14 @@ public:
          });
   }
 
-  virtual double GetPathLength() const override { return m_rawResult.shortestPathLength; }
-  virtual m2::PointD const & GetStartPoint() const override
+  double GetPathLength() const override { return m_rawResult.shortestPathLength; }
+
+  m2::PointD const & GetStartPoint() const override
   {
     return m_rawResult.sourceEdge.segmentPoint;
   }
-  virtual m2::PointD const & GetEndPoint() const override
+
+  m2::PointD const & GetEndPoint() const override
   {
     return m_rawResult.targetEdge.segmentPoint;
   }

--- a/routing/osrm_router.cpp
+++ b/routing/osrm_router.cpp
@@ -67,7 +67,7 @@ public:
   virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
-                                turns::TTurnCandidates & outgoingTurns) const override
+                                turns::TurnCandidates & outgoingTurns) const override
   {
     double const kReadCrossEpsilon = 1.0E-4;
 
@@ -139,12 +139,13 @@ public:
       ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, ft.GetPoint(seg.m_pointStart)),
                   turns::kFeaturesNearTurnMeters, ());
 
+      outgoingTurns.isCandidatesAngleValid = true;
       double const a =
           my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
-      outgoingTurns.emplace_back(a, targetNode, ftypes::GetHighwayClass(ft));
+      outgoingTurns.candidates.emplace_back(a, targetNode, ftypes::GetHighwayClass(ft));
     }
 
-    sort(outgoingTurns.begin(), outgoingTurns.end(),
+    sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(),
          [](turns::TurnCandidate const & t1, turns::TurnCandidate const & t2)
          {
            return t1.angle < t2.angle;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -57,7 +57,7 @@ void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junct
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LDEBUG, ("Couldn't reconstruct path"));
+    LOG(LDEBUG, ("Couldn't reconstruct path."));
     // use only "arrival" direction
     turns.emplace_back(path.size() - 1, turns::PedestrianDirection::ReachedYourDestination);
     return;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -1,4 +1,5 @@
 #include "routing/pedestrian_directions.hpp"
+#include "routing/road_graph.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
@@ -19,6 +20,14 @@ bool HasType(uint32_t type, feature::TypesHolder const & types)
   }
   return false;
 }
+
+void Convert(vector<routing::Junction> const & path, vector<m2::PointD> & geometry)
+{
+  geometry.clear();
+  geometry.reserve(path.size());
+  for (auto const & pos : path)
+    geometry.emplace_back(pos.GetPoint());
+}
 }  // namespace
 
 namespace routing
@@ -34,6 +43,7 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine()
 void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction> const & path,
                                           Route::TTimes & times,
                                           Route::TTurns & turnsDir,
+                                          vector<m2::PointD> & routeGeometry,
                                           my::Cancellable const & cancellable)
 {
   CHECK_GREATER(path.size(), 1, ());
@@ -50,6 +60,7 @@ void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junct
   }
 
   CalculateTurns(graph, routeEdges, turnsDir, cancellable);
+  Convert(path, routeGeometry);
 }
 
 void PedestrianDirectionsEngine::CalculateTurns(IRoadGraph const & graph, vector<Edge> const & routeEdges,

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -45,7 +45,12 @@ void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junct
                                           vector<m2::PointD> & routeGeometry,
                                           my::Cancellable const & cancellable)
 {
-  CHECK_GREATER(path.size(), 1, ());
+  times.clear();
+  turns.clear();
+  routeGeometry.clear();
+
+  if (path.size() <= 1)
+    return;
 
   CalculateTimes(graph, path, times);
 

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -1,18 +1,14 @@
 #include "routing/pedestrian_directions.hpp"
-#include "routing/turns_generator.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/ftypes_matcher.hpp"
-#include "indexer/index.hpp"
 
 #include "base/assert.hpp"
 #include "base/logging.hpp"
 
 namespace
 {
-double constexpr KMPH2MPS = 1000.0 / (60 * 60);
-
 bool HasType(uint32_t type, feature::TypesHolder const & types)
 {
   for (uint32_t t : types)
@@ -56,70 +52,6 @@ void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junct
   CalculateTurns(graph, routeEdges, turnsDir, cancellable);
 }
 
-bool PedestrianDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
-                                                 vector<Edge> & routeEdges,
-                                                 my::Cancellable const & cancellable) const
-{
-  routeEdges.reserve(path.size() - 1);
-
-  Junction curr = path[0];
-  vector<Edge> currEdges;
-  for (size_t i = 1; i < path.size(); ++i)
-  {
-    if (cancellable.IsCancelled())
-      return false;
-
-    Junction const & next = path[i];
-
-    currEdges.clear();
-    graph.GetOutgoingEdges(curr, currEdges);
-
-    bool found = false;
-    for (Edge const & e : currEdges)
-    {
-      if (e.GetEndJunction() == next)
-      {
-        routeEdges.emplace_back(e);
-        found = true;
-        break;
-      }
-    }
-
-    if (!found)
-      return false;
-
-    curr = next;
-  }
-
-  ASSERT_EQUAL(routeEdges.size()+1, path.size(), ());
-
-  return true;
-}
-
-void PedestrianDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
-                                                Route::TTimes & times) const
-{
-  double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
-
-  times.reserve(path.size());
-
-  double trackTimeSec = 0.0;
-  times.emplace_back(0, trackTimeSec);
-
-  m2::PointD prev = path[0].GetPoint();
-  for (size_t i = 1; i < path.size(); ++i)
-  {
-    m2::PointD const & curr = path[i].GetPoint();
-
-    double const lengthM = MercatorBounds::DistanceOnEarth(prev, curr);
-    trackTimeSec += lengthM / speedMPS;
-
-    times.emplace_back(i, trackTimeSec);
-
-    prev = curr;
-  }
-}
-
 void PedestrianDirectionsEngine::CalculateTurns(IRoadGraph const & graph, vector<Edge> const & routeEdges,
                                                 Route::TTurns & turnsDir,
                                                 my::Cancellable const & cancellable) const
@@ -156,5 +88,4 @@ void PedestrianDirectionsEngine::CalculateTurns(IRoadGraph const & graph, vector
   // (index of last junction is the same as number of edges)
   turnsDir.emplace_back(routeEdges.size(), turns::PedestrianDirection::ReachedYourDestination);
 }
-
 }  // namespace routing

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -23,9 +23,9 @@ bool HasType(uint32_t type, feature::TypesHolder const & types)
 
 void Convert(vector<routing::Junction> const & path, vector<m2::PointD> & geometry)
 {
-  size_t const pathSz = path.size();
-  geometry.resize(pathSz);
-  for (size_t i = 0; i < pathSz; ++i)
+  size_t const pathSize = path.size();
+  geometry.resize(pathSize);
+  for (size_t i = 0; i < pathSize; ++i)
     geometry[i] = path[i].GetPoint();
 }
 }  // namespace

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -14,6 +14,7 @@ public:
   void Generate(IRoadGraph const & graph, vector<Junction> const & path,
                 Route::TTimes & times,
                 Route::TTurns & turnsDir,
+                vector<m2::PointD> & routeGeometry,
                 my::Cancellable const & cancellable) override;
 
 private:

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -17,13 +17,6 @@ public:
                 my::Cancellable const & cancellable) override;
 
 private:
-  bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
-                       vector<Edge> & routeEdges,
-                       my::Cancellable const & cancellable) const;
-
-  void CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
-                      Route::TTimes & times) const;
-
   void CalculateTurns(IRoadGraph const & graph, vector<Edge> const & routeEdges,
                       Route::TTurns & turnsDir,
                       my::Cancellable const & cancellable) const;

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -11,10 +11,8 @@ public:
   PedestrianDirectionsEngine();
 
   // IDirectionsEngine override:
-  void Generate(IRoadGraph const & graph, vector<Junction> const & path,
-                Route::TTimes & times,
-                Route::TTurns & turnsDir,
-                vector<m2::PointD> & routeGeometry,
+  void Generate(IRoadGraph const & graph, vector<Junction> const & path, Route::TTimes & times,
+                Route::TTurns & turns, vector<m2::PointD> & routeGeometry,
                 my::Cancellable const & cancellable) override;
 
 private:

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -259,7 +259,8 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter("astar-pedestrian", index, countryFileFn,
-                                                 move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
+                                                 move(vehicleModelFactory), move(algorithm),
+                                                 move(directionsEngine)));
   return router;
 }
 
@@ -268,8 +269,9 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index, countryFileFn,
-                                                 move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index,
+                                                 countryFileFn, move(vehicleModelFactory),
+                                                 move(algorithm), move(directionsEngine)));
   return router;
 }
 

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -165,7 +165,6 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
                                                     m2::PointD const & finalPoint,
                                                     RouterDelegate const & delegate, Route & route)
 {
-
   if (!CheckMapExistence(startPoint, route) || !CheckMapExistence(finalPoint, route))
     return RouteFileNotExist;
 
@@ -259,7 +258,8 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-pedestrian", index, countryFileFn, move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter("astar-pedestrian", index, countryFileFn,
+                                                 move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
 
@@ -268,7 +268,8 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index, countryFileFn, move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index, countryFileFn,
+                                                 move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
 

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -1,3 +1,4 @@
+#include "routing/bicycle_directions.hpp"
 #include "routing/bicycle_model.hpp"
 #include "routing/features_road_graph.hpp"
 #include "routing/nearest_edge_finder.hpp"
@@ -47,14 +48,6 @@ IRouter::ResultCode Convert(IRoutingAlgorithm::Result value)
   }
   ASSERT(false, ("Unexpected IRoutingAlgorithm::Result value:", value));
   return IRouter::ResultCode::RouteNotFound;
-}
-
-void Convert(vector<Junction> const & path, vector<m2::PointD> & geometry)
-{
-  geometry.clear();
-  geometry.reserve(path.size());
-  for (auto const & pos : path)
-    geometry.emplace_back(pos.GetPoint());
 }
 
 // Check if the found edges lays on mwm with pedestrian routing support.
@@ -237,6 +230,7 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
 void RoadGraphRouter::ReconstructRoute(vector<Junction> && path, Route & route,
                                        my::Cancellable const & cancellable) const
 {
+  LOG(LINFO, ("RoadGraphRouter::ReconstructRoute path.size()", path.size()));
   CHECK(!path.empty(), ("Can't reconstruct route from an empty list of positions."));
 
   // By some reason there're two adjacent positions on a road with
@@ -247,15 +241,13 @@ void RoadGraphRouter::ReconstructRoute(vector<Junction> && path, Route & route,
   if (path.size() == 1)
     path.emplace_back(path.back());
 
-  vector<m2::PointD> geometry;
-  Convert(path, geometry);
-
   Route::TTimes times;
   Route::TTurns turnsDir;
+  vector<m2::PointD> geometry;
   // @TODO(bykoianko) streetNames is not filled in Generate(). It should be done.
   Route::TStreets streetNames;
   if (m_directionsEngine)
-    m_directionsEngine->Generate(*m_roadGraph, path, times, turnsDir, cancellable);
+    m_directionsEngine->Generate(*m_roadGraph, path, times, turnsDir, geometry, cancellable);
 
   route.SetGeometry(geometry.begin(), geometry.end());
   route.SetSectionTimes(times);
@@ -285,10 +277,9 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountr
 {
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
-  unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
+  unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index));
   unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-bicycle", index, countryFileFn, move(vehicleModelFactory),
                                                  move(algorithm), move(directionsEngine)));
   return router;
 }
-
 }  // namespace routing

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -252,6 +252,7 @@ void RoadGraphRouter::ReconstructRoute(vector<Junction> && path, Route & route,
 
   Route::TTimes times;
   Route::TTurns turnsDir;
+  // @TODO(bykoianko) streetNames is not filled in Generate(). It should be done.
   Route::TStreets streetNames;
   if (m_directionsEngine)
     m_directionsEngine->Generate(*m_roadGraph, path, times, turnsDir, cancellable);

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -230,7 +230,6 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
 void RoadGraphRouter::ReconstructRoute(vector<Junction> && path, Route & route,
                                        my::Cancellable const & cancellable) const
 {
-  LOG(LINFO, ("RoadGraphRouter::ReconstructRoute path.size()", path.size()));
   CHECK(!path.empty(), ("Can't reconstruct route from an empty list of positions."));
 
   // By some reason there're two adjacent positions on a road with

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -50,18 +50,25 @@ void Route::AddAbsentCountry(string const & name)
 
 double Route::GetTotalDistanceMeters() const
 {
+  if (!m_poly.IsValid())
+    return 0.0;
   return m_poly.GetTotalDistanceM();
 }
 
 double Route::GetCurrentDistanceFromBeginMeters() const
 {
+  if (!m_poly.IsValid())
+    return 0.0;
   return m_poly.GetDistanceFromBeginM();
 }
 
 void Route::GetTurnsDistances(vector<double> & distances) const
 {
-  double mercatorDistance = 0;
   distances.clear();
+  if (!m_poly.IsValid())
+    return;
+
+  double mercatorDistance = 0.0;
   auto const & polyline = m_poly.GetPolyline();
   for (auto currentTurn = m_turns.begin(); currentTurn != m_turns.end(); ++currentTurn)
   {
@@ -84,6 +91,8 @@ void Route::GetTurnsDistances(vector<double> & distances) const
 
 double Route::GetCurrentDistanceToEndMeters() const
 {
+  if (!m_poly.IsValid())
+    return 0.0;
   return m_poly.GetDistanceToEndM();
 }
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -45,7 +45,10 @@ public:
 
   template <class TIter> void SetGeometry(TIter beg, TIter end)
   {
-    FollowedPolyline(beg, end).Swap(m_poly);
+    if (beg == end)
+      FollowedPolyline().Swap(m_poly);
+    else
+      FollowedPolyline(beg, end).Swap(m_poly);
     Update();
   }
 

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -15,6 +15,7 @@ INCLUDEPATH += $$ROOT_DIR/3party/jansson/src \
 SOURCES += \
     async_router.cpp \
     base/followed_polyline.cpp \
+    bicycle_directions.cpp \
     bicycle_model.cpp \
     car_model.cpp \
     cross_mwm_road_graph.cpp \
@@ -52,6 +53,7 @@ HEADERS += \
     async_router.hpp \
     base/astar_algorithm.hpp \
     base/followed_polyline.hpp \
+    bicycle_directions.hpp \
     bicycle_model.hpp \
     car_model.hpp \
     cross_mwm_road_graph.hpp \

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -48,6 +48,7 @@ SOURCES += \
     turns_sound_settings.cpp \
     turns_tts_text.cpp \
     vehicle_model.cpp \
+    turn_helpers.cpp
 
 HEADERS += \
     async_router.hpp \
@@ -91,3 +92,4 @@ HEADERS += \
     turns_sound_settings.hpp \
     turns_tts_text.hpp \
     vehicle_model.hpp \
+    turn_helpers.hpp

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -20,6 +20,7 @@ SOURCES += \
     cross_mwm_road_graph.cpp \
     cross_mwm_router.cpp \
     cross_routing_context.cpp \
+    directions_engine.cpp \
     features_road_graph.cpp \
     nearest_edge_finder.cpp \
     online_absent_fetcher.cpp \
@@ -51,7 +52,7 @@ HEADERS += \
     async_router.hpp \
     base/astar_algorithm.hpp \
     base/followed_polyline.hpp \
-    bicycle_model.cpp \
+    bicycle_model.hpp \
     car_model.hpp \
     cross_mwm_road_graph.hpp \
     cross_mwm_router.hpp \

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -48,7 +48,6 @@ SOURCES += \
     turns_sound_settings.cpp \
     turns_tts_text.cpp \
     vehicle_model.cpp \
-    turn_helpers.cpp
 
 HEADERS += \
     async_router.hpp \
@@ -92,4 +91,3 @@ HEADERS += \
     turns_sound_settings.hpp \
     turns_tts_text.hpp \
     vehicle_model.hpp \
-    turn_helpers.hpp

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -1,0 +1,16 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "geometry/mercator.hpp"
+
+using namespace routing;
+using namespace routing::turns;
+
+UNIT_TEST(RussiaMoscowSevTushinoParkPreferingBicycleWay)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetBicycleComponents(),
+      MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
+      MercatorBounds::FromLatLon(55.87203, 37.44274), 460.);
+}

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -10,7 +10,6 @@ using namespace routing::turns;
 UNIT_TEST(RussiaMoscowSevTushinoParkPreferingBicycleWay)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(),
-      MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
       MercatorBounds::FromLatLon(55.87203, 37.44274), 460.);
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -54,3 +54,16 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnSlightRight);
 }
+
+UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
+{
+  m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(route.GetTurns().size(), 0, ());
+  integration::TestRouteLength(route, 0.0);
+}

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -58,8 +58,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -1,0 +1,35 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "routing/route.hpp"
+
+
+using namespace routing;
+using namespace routing::turns;
+
+UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(),
+      MercatorBounds::FromLatLon(55.87445, 37.43711), {0.0, 0.0},
+      MercatorBounds::FromLatLon(55.8719, 37.4464));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 3);
+
+  integration::GetNthTurn(route, 0)
+      .TestValid()
+      .TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 1)
+      .TestValid()
+      .TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 2)
+      .TestValid()
+      .TestDirection(TurnDirection::TurnRight);
+
+  integration::TestRouteLength(route, 711.);
+}

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -4,16 +4,14 @@
 
 #include "routing/route.hpp"
 
-
 using namespace routing;
 using namespace routing::turns;
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(),
-      MercatorBounds::FromLatLon(55.87445, 37.43711), {0.0, 0.0},
-      MercatorBounds::FromLatLon(55.8719, 37.4464));
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87445, 37.43711),
+      {0.0, 0.0}, MercatorBounds::FromLatLon(55.8719, 37.4464));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -21,15 +19,9 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 
   integration::TestTurnCount(route, 3);
 
-  integration::GetNthTurn(route, 0)
-      .TestValid()
-      .TestDirection(TurnDirection::TurnRight);
-  integration::GetNthTurn(route, 1)
-      .TestValid()
-      .TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 2)
-      .TestValid()
-      .TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnRight);
 
   integration::TestRouteLength(route, 711.);
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -10,18 +10,47 @@ using namespace routing::turns;
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87445, 37.43711),
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87467, 37.43658),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.8719, 37.4464));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 3);
+  integration::TestTurnCount(route, 1);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+
+  integration::TestRouteLength(route, 752.);
+}
+
+UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.85630, 37.41004),
+      {0.0, 0.0}, MercatorBounds::FromLatLon(55.85717, 37.41052));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 2);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnRight);
+}
 
-  integration::TestRouteLength(route, 711.);
+UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.85159, 37.38903),
+      {0.0, 0.0}, MercatorBounds::FromLatLon(55.85157, 37.38813));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 1);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnSlightRight);
 }

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -515,3 +515,16 @@ UNIT_TEST(MoscowChistiePrudiSelectPointsInConnectedGraph)
       MercatorBounds::FromLatLon(55.76613, 37.63769), {0., 0.},
       MercatorBounds::FromLatLon(55.76593, 37.63893), 134.02);
 }
+
+UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
+{
+  m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetPedestrianComponents(), point, {0.0, 0.0}, point);
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0);
+  integration::TestRouteLength(route, 0.0);
+}

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -519,8 +519,8 @@ UNIT_TEST(MoscowChistiePrudiSelectPointsInConnectedGraph)
 UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(), point, {0.0, 0.0}, point);
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetPedestrianComponents(), point, {0.0, 0.0}, point);
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -24,6 +24,8 @@ QT *= core
 
 SOURCES += \
   ../../testing/testingmain.cpp \
+  bicycle_route_test.cpp \
+  bicycle_turn_test.cpp \
   cross_section_tests.cpp \
   online_cross_tests.cpp \
   osrm_route_test.cpp \

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -244,9 +244,7 @@ namespace integration
   void TestRouteLength(Route const & route, double expectedRouteMeters,
                        double relativeError)
   {
-    double delta = expectedRouteMeters * relativeError;
-    if (delta < kErrorMeters)
-      delta = kErrorMeters;
+    double const delta = max(expectedRouteMeters * relativeError, kErrorMeters);
     double const routeMeters = route.GetTotalDistanceMeters();
     TEST(my::AlmostEqualAbs(routeMeters, expectedRouteMeters, delta),
         ("Route length test failed. Expected:", expectedRouteMeters, "have:", routeMeters, "delta:", delta));
@@ -254,9 +252,7 @@ namespace integration
 
   void TestRouteTime(Route const & route, double expectedRouteSeconds, double relativeError)
   {
-    double delta = expectedRouteSeconds * relativeError;
-    if (delta < kErrorSeconds)
-      delta = kErrorSeconds;
+    double const delta = max(expectedRouteSeconds * relativeError, kErrorSeconds);
     double const routeSeconds = route.GetTotalTimeSec();
     TEST(my::AlmostEqualAbs(routeSeconds, expectedRouteSeconds, delta),
         ("Route time test failed. Expected:", expectedRouteSeconds, "have:", routeSeconds, "delta:", delta));

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -36,8 +36,8 @@ using TRouterFactory =
 
 namespace
 {
-double kErrorMeters = 1.0;
-double kErrorSeconds = 1.0;
+double constexpr kErrorMeters = 1.0;
+double constexpr kErrorSeconds = 1.0;
 void ChangeMaxNumberOfOpenFiles(size_t n)
 {
   struct rlimit rlp;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -86,6 +86,8 @@ namespace integration
                                         storage::CountryInfoGetter const & infoGetter,
                                         TRouterFactory const & routerFactory)
   {
+    // |infoGetter| should be a reference to an object which exists while the
+    // result of the function is used.
     auto countryFileGetter = [&infoGetter](m2::PointD const & pt)
     {
       return infoGetter.GetRegionCountryId(pt);

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -36,6 +36,8 @@ using TRouterFactory =
 
 namespace
 {
+  double kErrorMeters = 1.0;
+  double kErrorSeconds = 1.0;
   void ChangeMaxNumberOfOpenFiles(size_t n)
   {
     struct rlimit rlp;
@@ -242,7 +244,9 @@ namespace integration
   void TestRouteLength(Route const & route, double expectedRouteMeters,
                        double relativeError)
   {
-    double const delta = expectedRouteMeters * relativeError;
+    double delta = expectedRouteMeters * relativeError;
+    if (delta < kErrorMeters)
+      delta = kErrorMeters;
     double const routeMeters = route.GetTotalDistanceMeters();
     TEST(my::AlmostEqualAbs(routeMeters, expectedRouteMeters, delta),
         ("Route length test failed. Expected:", expectedRouteMeters, "have:", routeMeters, "delta:", delta));
@@ -250,7 +254,9 @@ namespace integration
 
   void TestRouteTime(Route const & route, double expectedRouteSeconds, double relativeError)
   {
-    double const delta = expectedRouteSeconds * relativeError;
+    double delta = expectedRouteSeconds * relativeError;
+    if (delta < kErrorSeconds)
+      delta = kErrorSeconds;
     double const routeSeconds = route.GetTotalTimeSec();
     TEST(my::AlmostEqualAbs(routeSeconds, expectedRouteSeconds, delta),
         ("Route time test failed. Expected:", expectedRouteSeconds, "have:", routeSeconds, "delta:", delta));

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -36,16 +36,16 @@ using TRouterFactory =
 
 namespace
 {
-  double kErrorMeters = 1.0;
-  double kErrorSeconds = 1.0;
-  void ChangeMaxNumberOfOpenFiles(size_t n)
-  {
-    struct rlimit rlp;
-    getrlimit(RLIMIT_NOFILE, &rlp);
-    rlp.rlim_cur = n;
-    setrlimit(RLIMIT_NOFILE, &rlp);
-  }
+double kErrorMeters = 1.0;
+double kErrorSeconds = 1.0;
+void ChangeMaxNumberOfOpenFiles(size_t n)
+{
+  struct rlimit rlp;
+  getrlimit(RLIMIT_NOFILE, &rlp);
+  rlp.rlim_cur = n;
+  setrlimit(RLIMIT_NOFILE, &rlp);
 }
+}  // namespace
 
 namespace integration
 {

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -78,13 +78,17 @@ unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetter();
   void TestOnlineFetcher(ms::LatLon const & startPoint, ms::LatLon const & finalPoint,
                          vector<string> const & expected, IRouterComponents & routerComponents);
 
-  /// Get OSRM router components
+  /// Gets OSRM router components
   IRouterComponents & GetOsrmComponents();
   shared_ptr<IRouterComponents> GetOsrmComponents(vector<platform::LocalCountryFile> const & localFiles);
 
-  /// Get pedestrian router components
+  /// Gets pedestrian router components
   IRouterComponents & GetPedestrianComponents();
   shared_ptr<IRouterComponents> GetPedestrianComponents(vector<platform::LocalCountryFile> const & localFiles);
+
+  /// Gets bicycle router components.
+  IRouterComponents & GetBicycleComponents();
+  shared_ptr<IRouterComponents> GetBicycleComponents(vector<platform::LocalCountryFile> const & localFiles);
 
   TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                               m2::PointD const & startPoint, m2::PointD const & startDirection,

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -88,7 +88,8 @@ unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetter();
 
   /// Gets bicycle router components.
   IRouterComponents & GetBicycleComponents();
-  shared_ptr<IRouterComponents> GetBicycleComponents(vector<platform::LocalCountryFile> const & localFiles);
+  shared_ptr<IRouterComponents> GetBicycleComponents(
+      vector<platform::LocalCountryFile> const & localFiles);
 
   TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                               m2::PointD const & startPoint, m2::PointD const & startDirection,

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -17,13 +17,21 @@ namespace turns
 class IRoutingResultGraph
 {
 public:
+  /// \returns information about all route segments.
   virtual TUnpackedPathSegments const & GetSegments() const = 0;
+  /// \brief for number of a |node|, point of the node (|junctionPoint|) and for a point
+  /// just before the node (|ingoingPoint|) it fills
+  /// * |ingoingCount| - number of incomming ways to |junctionPoint|. (|junctionPoint| >= 1)
+  /// * |outgoingTurns| - vector of ways to leave |junctionPoint|.
   virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
                                 TTurnCandidates & outgoingTurns) const = 0;
-  virtual double GetShortestPathLength() const = 0;
+  /// \returns route length.
+  virtual double GetPathLength() const = 0;
+  /// \returns route start point.
   virtual m2::PointD const & GetStartPoint() const = 0;
+  /// \returns route finish point.
   virtual m2::PointD const & GetEndPoint() const = 0;
 
   virtual ~IRoutingResultGraph() = default;

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -21,8 +21,7 @@ public:
   /// \brief For a |node|, |junctionPoint| and |ingoingPoint| (point before the |node|)
   /// this method computes number of ingoing ways to |junctionPoint| and fills |outgoingTurns|.
   virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
-                                m2::PointD const & junctionPoint,
-                                size_t & ingoingCount,
+                                m2::PointD const & junctionPoint, size_t & ingoingCount,
                                 TurnCandidates & outgoingTurns) const = 0;
   virtual double GetPathLength() const = 0;
   virtual m2::PointD const & GetStartPoint() const = 0;

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -9,32 +9,26 @@ namespace routing
 {
 namespace turns
 {
-
 /*!
- * \brief The IRoutingResultGraph interface for the routing result. Uncouple router from the
+ * \brief The IRoutingResult interface for the routing result. Uncouple router from the
  * annotation code that describes turns. See routers for detail implementations.
  */
-class IRoutingResultGraph
+class IRoutingResult
 {
 public:
   /// \returns information about all route segments.
   virtual TUnpackedPathSegments const & GetSegments() const = 0;
-  /// \brief for number of a |node|, point of the node (|junctionPoint|) and for a point
-  /// just before the node (|ingoingPoint|) it fills
-  /// * |ingoingCount| - number of incomming ways to |junctionPoint|. (|junctionPoint| >= 1)
-  /// * |outgoingTurns| - vector of ways to leave |junctionPoint|.
+  /// \brief For a |node|, |junctionPoint| and |ingoingPoint| (point before the |node|)
+  /// this method computes number of ingoing ways to |junctionPoint| and fills |outgoingTurns|.
   virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
                                 TTurnCandidates & outgoingTurns) const = 0;
-  /// \returns route length.
   virtual double GetPathLength() const = 0;
-  /// \returns route start point.
   virtual m2::PointD const & GetStartPoint() const = 0;
-  /// \returns route finish point.
   virtual m2::PointD const & GetEndPoint() const = 0;
 
-  virtual ~IRoutingResultGraph() = default;
+  virtual ~IRoutingResult() = default;
 };
 }  // namespace routing
 }  // namespace turns

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -23,7 +23,7 @@ public:
   virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint,
                                 size_t & ingoingCount,
-                                TTurnCandidates & outgoingTurns) const = 0;
+                                TurnCandidates & outgoingTurns) const = 0;
   virtual double GetPathLength() const = 0;
   virtual m2::PointD const & GetStartPoint() const = 0;
   virtual m2::PointD const & GetEndPoint() const = 0;

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -46,7 +46,7 @@ struct TurnCandidates
   vector<TurnCandidate> candidates;
   bool isCandidatesAngleValid;
 
-  TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}
+  explicit TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}
 };
 
 }  // namespace routing

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -41,6 +41,13 @@ struct TurnCandidate
   }
 };
 
-using TTurnCandidates = vector<TurnCandidate>;
+struct TurnCandidates
+{
+  vector<TurnCandidate> candidates;
+  bool isCandidatesAngleValid;
+
+  TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}
+};
+
 }  // namespace routing
 }  // namespace turns

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -280,9 +280,10 @@ string DebugPrint(SingleLaneInfo const & singleLaneInfo)
   return out.str();
 }
 
-double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2)
+double PiMinusTwoVectorsAngle(m2::PointD const & junctionPoint, m2::PointD const & ingoingPoint,
+                              m2::PointD const & outgoingPoint)
 {
-  return math::pi - ang::TwoVectorsAngle(p, p1, p2);
+  return math::pi - ang::TwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint);
 }
 }  // namespace turns
 }  // namespace routing

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -1,5 +1,7 @@
 #include "routing/turns.hpp"
 
+#include "geometry/angles.hpp"
+
 #include "base/internal/message.hpp"
 
 #include "std/array.hpp"
@@ -276,6 +278,11 @@ string DebugPrint(SingleLaneInfo const & singleLaneInfo)
   out << "SingleLaneInfo [ m_isRecommended == " << singleLaneInfo.m_isRecommended
       << ", m_lane == " << ::DebugPrint(singleLaneInfo.m_lane) << " ]" << endl;
   return out.str();
+}
+
+double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2)
+{
+  return math::pi - ang::TwoVectorsAngle(p, p1, p2);
 }
 }  // namespace turns
 }  // namespace routing

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -206,7 +206,7 @@ void SplitLanes(string const & lanesString, char delimiter, vector<string> & lan
 bool ParseSingleLane(string const & laneString, char delimiter, TSingleLane & lane);
 
 /*!
- * \returns pi minus an angle from vector [junctionPoint, ingoingPoint]
+ * \returns pi minus angle from vector [junctionPoint, ingoingPoint]
  * to vector [junctionPoint, outgoingPoint]. A counterclockwise rotation.
  * Angle is in range [-pi, pi].
 */

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -19,6 +19,8 @@ namespace turns
 /// @todo(vbykoianko) It's a good idea to gather all the turns information into one entity.
 /// For the time being several separate entities reflect the turn information. Like Route::TTurns
 
+using TGeomTurnCandidate = vector<double>;
+
 /*!
  * \warning The order of values below shall not be changed.
  * TurnRight(TurnLeft) must have a minimal value and
@@ -202,5 +204,6 @@ bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, TurnDirection t);
 bool ParseLanes(string lanesString, vector<SingleLaneInfo> & lanes);
 void SplitLanes(string const & lanesString, char delimiter, vector<string> & lanes);
 bool ParseSingleLane(string const & laneString, char delimiter, TSingleLane & lane);
+double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2);
 }  // namespace turns
 }  // namespace routing

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -19,8 +19,6 @@ namespace turns
 /// @todo(vbykoianko) It's a good idea to gather all the turns information into one entity.
 /// For the time being several separate entities reflect the turn information. Like Route::TTurns
 
-using TGeomTurnCandidate = vector<double>;
-
 double constexpr kFeaturesNearTurnMeters = 3.0;
 
 /*!
@@ -206,6 +204,13 @@ bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, TurnDirection t);
 bool ParseLanes(string lanesString, vector<SingleLaneInfo> & lanes);
 void SplitLanes(string const & lanesString, char delimiter, vector<string> & lanes);
 bool ParseSingleLane(string const & laneString, char delimiter, TSingleLane & lane);
-double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2);
+
+/*!
+ * \returns pi minus an angle from vector [junctionPoint, ingoingPoint]
+ * to vector [junctionPoint, outgoingPoint]. A counterclockwise rotation.
+ * Angle is in range [-pi, pi].
+*/
+double PiMinusTwoVectorsAngle(m2::PointD const & junctionPoint, m2::PointD const & ingoingPoint,
+                              m2::PointD const & outgoingPoint);
 }  // namespace turns
 }  // namespace routing

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -21,6 +21,8 @@ namespace turns
 
 using TGeomTurnCandidate = vector<double>;
 
+double constexpr kFeaturesNearTurnMeters = 3.0;
+
 /*!
  * \warning The order of values below shall not be changed.
  * TurnRight(TurnLeft) must have a minimal value and

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -27,13 +27,6 @@ double constexpr kMinDistMeters = 200.;
 size_t constexpr kNotSoCloseMaxPointsCount = 3;
 double constexpr kNotSoCloseMinDistMeters = 30.;
 
-using TGeomTurnCandidate = vector<double>;
-
-double PiMinusTwoVectorsAngle(m2::PointD const & p, m2::PointD const & p1, m2::PointD const & p2)
-{
-  return math::pi - ang::TwoVectorsAngle(p, p1, p2);
-}
-
 /*!
  * \brief Returns false when
  * - the route leads from one big road to another one;

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -21,7 +21,6 @@ using namespace routing::turns;
 
 namespace
 {
-double const kFeaturesNearTurnMeters = 3.0;
 size_t constexpr kMaxPointsCount = 5;
 double constexpr kMinDistMeters = 200.;
 size_t constexpr kNotSoCloseMaxPointsCount = 3;
@@ -261,7 +260,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResultGraph const & result
 {
   double estimatedTime = 0;
 
-  LOG(LDEBUG, ("Shortest th length:", result.GetShortestPathLength()));
+  LOG(LDEBUG, ("Shortest th length:", result.GetPathLength()));
 
 #ifdef DEBUG
   size_t lastIdx = 0;

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -253,7 +253,7 @@ bool TurnInfo::IsSegmentsValid() const
   return true;
 }
 
-IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResultGraph const & result,
+IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        RouterDelegate const & delegate, vector<m2::PointD> & points,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets)
@@ -561,7 +561,7 @@ TurnDirection IntermediateDirection(const double angle)
   return FindDirectionByAngle(kLowerBounds, angle);
 }
 
-void GetTurnDirection(IRoutingResultGraph const & result, TurnInfo & turnInfo, TurnItem & turn)
+void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnItem & turn)
 {
   if (!turnInfo.IsSegmentsValid())
     return;

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -42,7 +42,7 @@ using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
  * \param streets output street names along the path.
  * \return routing operation result code.
  */
-IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResultGraph const & result,
+IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        RouterDelegate const & delegate, vector<m2::PointD> & points,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets);
@@ -127,8 +127,7 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
  * \param turnInfo is used for cashing some information while turn calculation.
  * \param turn is used for keeping the result of turn calculation.
  */
-void GetTurnDirection(IRoutingResultGraph const & result, turns::TurnInfo & turnInfo,
-                      TurnItem & turn);
+void GetTurnDirection(IRoutingResult const & result, turns::TurnInfo & turnInfo, TurnItem & turn);
 
 /*!
  * \brief Finds an UTurn that starts from current segment and returns how many segments it lasts.

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
 		56099E2E1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56099E2C1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp */; };
 		56099E2F1CC8FBDA00A7772A /* osrm_path_segment_factory.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E2D1CC8FBDA00A7772A /* osrm_path_segment_factory.hpp */; };
+		56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56099E301CC9247E00A7772A /* bicycle_directions.cpp */; };
+		56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E311CC9247E00A7772A /* bicycle_directions.hpp */; };
+		56099E351CC9247E00A7772A /* directions_engine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56099E321CC9247E00A7772A /* directions_engine.cpp */; };
 		563B91C51CC4F1DC00222BC1 /* bicycle_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */; };
 		563B91C61CC4F1DC00222BC1 /* bicycle_model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */; };
 		670B84C01A9381D900CE4492 /* cross_routing_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */; };
@@ -188,6 +191,9 @@
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
 		56099E2C1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = osrm_path_segment_factory.cpp; path = ../../routing/osrm_path_segment_factory.cpp; sourceTree = "<group>"; };
 		56099E2D1CC8FBDA00A7772A /* osrm_path_segment_factory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = osrm_path_segment_factory.hpp; path = ../../routing/osrm_path_segment_factory.hpp; sourceTree = "<group>"; };
+		56099E301CC9247E00A7772A /* bicycle_directions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_directions.cpp; sourceTree = "<group>"; };
+		56099E311CC9247E00A7772A /* bicycle_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_directions.hpp; sourceTree = "<group>"; };
+		56099E321CC9247E00A7772A /* directions_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = directions_engine.cpp; sourceTree = "<group>"; };
 		563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_model.cpp; sourceTree = "<group>"; };
 		563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_model.hpp; sourceTree = "<group>"; };
 		670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_routing_context.cpp; sourceTree = "<group>"; };
@@ -549,6 +555,9 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				56099E301CC9247E00A7772A /* bicycle_directions.cpp */,
+				56099E311CC9247E00A7772A /* bicycle_directions.hpp */,
+				56099E321CC9247E00A7772A /* directions_engine.cpp */,
 				56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */,
 				56099E261CC7C97D00A7772A /* routing_result_graph.hpp */,
 				56099E271CC7C97D00A7772A /* turn_candidate.hpp */,
@@ -665,6 +674,7 @@
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
 				A17B42991BCFBD0E00A1EAE4 /* osrm_helpers.hpp in Headers */,
 				67C7D42E1B4EB48F00FE41AA /* turns_sound_settings.hpp in Headers */,
+				56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */,
 				670EE55E1B6001E7001E8064 /* routing_session.hpp in Headers */,
 				56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */,
 				670EE55F1B6001E7001E8064 /* routing_settings.hpp in Headers */,
@@ -856,6 +866,7 @@
 			files = (
 				56099E2E1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp in Sources */,
 				675344201A3F644F00A0A8C3 /* vehicle_model.cpp in Sources */,
+				56099E351CC9247E00A7772A /* directions_engine.cpp in Sources */,
 				A1616E2B1B6B60AB003F078E /* router_delegate.cpp in Sources */,
 				6741AA9C1BF35331002C974C /* turns_notification_manager.cpp in Sources */,
 				67C7D42B1B4EB48F00FE41AA /* pedestrian_model.cpp in Sources */,
@@ -875,6 +886,7 @@
 				670EE55D1B6001E7001E8064 /* routing_session.cpp in Sources */,
 				A120B3451B4A7BE5002F3808 /* cross_mwm_road_graph.cpp in Sources */,
 				67C7D4291B4EB48F00FE41AA /* car_model.cpp in Sources */,
+				56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */,
 				674A28B11B1605D2001A525C /* osrm_engine.cpp in Sources */,
 				674F9BD41B0A580E00704FFA /* road_graph.cpp in Sources */,
 				67AB92E61B7B3E6E00AB5194 /* turns_tts_text.cpp in Sources */,


### PR DESCRIPTION
Генерация тернов для велороутинга. 
PR реализует простую идею: использовать генератор тернов от car-routing-га для вело-роутинга. 
+ написана тестовая инфраструктура для тестов вело маршрутов и написано пару routing_integration_test: на прокладку вело маршрута и на маневры в вело маршруте. Их кол-во будет увеличиваться.

@ygorshenin @mpimenov  по возможности посмотрите.