### PR TITLE
Added the --user_resource_path to the script.

### DIFF
--- a/tools/integration_tests_runner.py
+++ b/tools/integration_tests_runner.py
@@ -32,6 +32,7 @@ class IntegrationRunner:
 
         self.file_lock = Lock()
         self.tests = Queue()
+        self.resource_path_postfix = " \"--user_resource_path={}\"".format(self.user_resource_path) if self.user_resource_path else ""
 
 
     def run_tests(self):
@@ -77,6 +78,9 @@ class IntegrationRunner:
             tmpdir = tempfile.mkdtemp()
             keys = '{old_key} "--user_resource_path={tmpdir}"'.format(old_key=keys, tmpdir=tmpdir)
             logging.debug("Temp dir: {tmpdir}".format(tmpdir=tmpdir))
+        else:
+            keys = "{old_key}{resource_path}".format(old_key=keys, resource_path=self.resource_path_postfix)
+            logging.debug("Setting user_resource_path to {resource_path}".format(resource_path=self.resource_path_postfix))
 
         out, err, result = self.get_tests_from_exec_file(test_file, keys)
 
@@ -113,6 +117,7 @@ class IntegrationRunner:
         parser.add_option("-o", "--output", dest="output", default="testlog.log", help="resulting log file. Default testlog.log")
         parser.add_option("-f", "--folder", dest="folder", default="omim-build-release/out/release", help="specify the folder where the tests reside (absolute path or relative to the location of this script)")
         parser.add_option("-i", "--include", dest="runlist", action="append", default=[], help="Include test into execution, comma separated list with no spaces or individual tests, or both. E.g.: -i one -i two -i three,four,five")
+        parser.add_option("-r", "--user_resource_path", dest="user_resource_path", default="", help="Path to user resources, such as MWMs")
 
         (options, args) = parser.parse_args()
 
@@ -127,6 +132,7 @@ class IntegrationRunner:
 
         self.runlist = filter(lambda x: x in tests_on_disk(self.workspace_path), interim_runlist)
         self.output = options.output
+        self.user_resource_path = options.user_resource_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now we can skip copying the mwm files to the omim/data folder, which saves a lot of space an time.