### PR TITLE
[editor] Avoid empty changeset comments on partial upload

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -18,6 +18,8 @@ using editor::XMLFeature;
 
 namespace
 {
+constexpr char const * kInitialChangesetComment = "Edits via MAPS.ME app, a partial upload";
+
 m2::RectD GetBoundingRect(vector<m2::PointD> const & geometry)
 {
   m2::RectD rect;
@@ -34,9 +36,9 @@ bool OsmFeatureHasTags(pugi::xml_node const & osmFt)
   return osmFt.child("tag");
 }
 
-vector<string> const static kMainTags = {"amenity", "shop",      "tourism", "historic",
-                                         "craft",   "emergency", "barrier", "highway",
-                                         "office",  "entrance",  "building"};
+vector<string> const static kMainTags = {
+    "amenity", "shop",    "tourism",  "historic", "craft", "emergency", "barrier",  "highway",
+    "office",  "leisure", "waterway", "natural",  "place", "entrance",  "building", "name"};
 
 string GetTypeForFeature(XMLFeature const & node)
 {
@@ -101,6 +103,7 @@ ChangesetWrapper::ChangesetWrapper(TKeySecret const & keySecret,
     : m_changesetComments(comments),
       m_api(OsmOAuth::ServerAuth(keySecret))
 {
+  m_changesetComments["comment"] = kInitialChangesetComment;
 }
 
 ChangesetWrapper::~ChangesetWrapper()


### PR DESCRIPTION
Теперь если связь оборвалась, комментарий всё равно будет непустой, хотя и не особо осмысленный.

Также добавил пару тегов для создания комментария: даже если главный тег не будет найден, воспользуемся названием.