### PR TITLE
[search] Added hashtags.

### DIFF
--- a/indexer/search_delimiters.cpp
+++ b/indexer/search_delimiters.cpp
@@ -19,40 +19,40 @@ bool Delimiters::operator()(strings::UniChar c) const
   switch (c)
   {
   case 0x2116:  // NUMERO SIGN
-                //  case 0x00B0:  // DEGREE SIGN
+  //  case 0x00B0:  // DEGREE SIGN
   case 0x2013:  // EN DASH
   case 0x2019:  // RIGHT SINGLE QUOTATION MARK
   case 0x00AB:  // LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
   case 0x00BB:  // RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
   case 0x3000:  // IDEOGRAPHIC SPACE
   case 0x30FB:  // KATAKANA MIDDLE DOT
-                //  case 0x00B4:  // ACUTE ACCENT
+  //  case 0x00B4:  // ACUTE ACCENT
   case 0x200E:  // LEFT-TO-RIGHT MARK
   case 0xFF08:  // FULLWIDTH LEFT PARENTHESIS
-                //  case 0x00A0:  // NO-BREAK SPACE
+  //  case 0x00A0:  // NO-BREAK SPACE
   case 0xFF09:  // FULLWIDTH RIGHT PARENTHESIS
   case 0x2018:  // LEFT SINGLE QUOTATION MARK
-                //  case 0x007E:  // TILDE
+  //  case 0x007E:  // TILDE
   case 0x2014:  // EM DASH
-                //  case 0x007C:  // VERTICAL LINE
+  //  case 0x007C:  // VERTICAL LINE
   case 0x0F0B:  // TIBETAN MARK INTERSYLLABIC TSHEG
   case 0x201C:  // LEFT DOUBLE QUOTATION MARK
   case 0x201E:  // DOUBLE LOW-9 QUOTATION MARK
-                //  case 0x00AE:  // REGISTERED SIGN
+  //  case 0x00AE:  // REGISTERED SIGN
   case 0xFFFD:  // REPLACEMENT CHARACTER
   case 0x200C:  // ZERO WIDTH NON-JOINER
   case 0x201D:  // RIGHT DOUBLE QUOTATION MARK
   case 0x3001:  // IDEOGRAPHIC COMMA
   case 0x300C:  // LEFT CORNER BRACKET
   case 0x300D:  // RIGHT CORNER BRACKET
-                //  case 0x00B7:  // MIDDLE DOT
+  //  case 0x00B7:  // MIDDLE DOT
   case 0x061F:  // ARABIC QUESTION MARK
   case 0x2192:  // RIGHTWARDS ARROW
   case 0x2212:  // MINUS SIGN
-                //  case 0x0091:  // <control>
-                //  case 0x007D:  // RIGHT CURLY BRACKET
-                //  case 0x007B:  // LEFT CURLY BRACKET
-                //  case 0x00A9:  // COPYRIGHT SIGN
+  //  case 0x0091:  // <control>
+  //  case 0x007D:  // RIGHT CURLY BRACKET
+  //  case 0x007B:  // LEFT CURLY BRACKET
+  //  case 0x00A9:  // COPYRIGHT SIGN
   case 0x200D:  // ZERO WIDTH JOINER
   case 0x200B:  // ZERO WIDTH SPACE
     return true;

--- a/indexer/search_delimiters.cpp
+++ b/indexer/search_delimiters.cpp
@@ -1,8 +1,8 @@
-#include "search_delimiters.hpp"
+#include "indexer/search_delimiters.hpp"
 
 namespace search
 {
-
+// Delimiters --------------------------------------------------------------------------------------
 bool Delimiters::operator()(strings::UniChar c) const
 {
   // ascii ranges first
@@ -19,40 +19,40 @@ bool Delimiters::operator()(strings::UniChar c) const
   switch (c)
   {
   case 0x2116:  // NUMERO SIGN
-//  case 0x00B0:  // DEGREE SIGN
+                //  case 0x00B0:  // DEGREE SIGN
   case 0x2013:  // EN DASH
   case 0x2019:  // RIGHT SINGLE QUOTATION MARK
   case 0x00AB:  // LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
   case 0x00BB:  // RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
   case 0x3000:  // IDEOGRAPHIC SPACE
   case 0x30FB:  // KATAKANA MIDDLE DOT
-//  case 0x00B4:  // ACUTE ACCENT
+                //  case 0x00B4:  // ACUTE ACCENT
   case 0x200E:  // LEFT-TO-RIGHT MARK
   case 0xFF08:  // FULLWIDTH LEFT PARENTHESIS
-//  case 0x00A0:  // NO-BREAK SPACE
+                //  case 0x00A0:  // NO-BREAK SPACE
   case 0xFF09:  // FULLWIDTH RIGHT PARENTHESIS
   case 0x2018:  // LEFT SINGLE QUOTATION MARK
-//  case 0x007E:  // TILDE
+                //  case 0x007E:  // TILDE
   case 0x2014:  // EM DASH
-//  case 0x007C:  // VERTICAL LINE
+                //  case 0x007C:  // VERTICAL LINE
   case 0x0F0B:  // TIBETAN MARK INTERSYLLABIC TSHEG
   case 0x201C:  // LEFT DOUBLE QUOTATION MARK
   case 0x201E:  // DOUBLE LOW-9 QUOTATION MARK
-//  case 0x00AE:  // REGISTERED SIGN
+                //  case 0x00AE:  // REGISTERED SIGN
   case 0xFFFD:  // REPLACEMENT CHARACTER
   case 0x200C:  // ZERO WIDTH NON-JOINER
   case 0x201D:  // RIGHT DOUBLE QUOTATION MARK
   case 0x3001:  // IDEOGRAPHIC COMMA
   case 0x300C:  // LEFT CORNER BRACKET
   case 0x300D:  // RIGHT CORNER BRACKET
-//  case 0x00B7:  // MIDDLE DOT
+                //  case 0x00B7:  // MIDDLE DOT
   case 0x061F:  // ARABIC QUESTION MARK
   case 0x2192:  // RIGHTWARDS ARROW
   case 0x2212:  // MINUS SIGN
-//  case 0x0091:  // <control>
-//  case 0x007D:  // RIGHT CURLY BRACKET
-//  case 0x007B:  // LEFT CURLY BRACKET
-//  case 0x00A9:  // COPYRIGHT SIGN
+                //  case 0x0091:  // <control>
+                //  case 0x007D:  // RIGHT CURLY BRACKET
+                //  case 0x007B:  // LEFT CURLY BRACKET
+                //  case 0x00A9:  // COPYRIGHT SIGN
   case 0x200D:  // ZERO WIDTH JOINER
   case 0x200B:  // ZERO WIDTH SPACE
     return true;
@@ -60,4 +60,16 @@ bool Delimiters::operator()(strings::UniChar c) const
   return false;
 }
 
+// DelimitersWithExceptions ------------------------------------------------------------------------
+DelimitersWithExceptions::DelimitersWithExceptions(vector<strings::UniChar> const & exceptions)
+  : m_exceptions(exceptions)
+{
 }
+
+bool DelimitersWithExceptions::operator()(strings::UniChar c) const
+{
+  if (find(m_exceptions.begin(), m_exceptions.end(), c) != m_exceptions.end())
+    return false;
+  return m_delimiters(c);
+}
+}  // namespace search

--- a/indexer/search_delimiters.hpp
+++ b/indexer/search_delimiters.hpp
@@ -4,9 +4,21 @@
 
 namespace search
 {
-  class Delimiters
-  {
-  public:
-    bool operator()(strings::UniChar c) const;
-  };
-}
+class Delimiters
+{
+public:
+  bool operator()(strings::UniChar c) const;
+};
+
+class DelimitersWithExceptions
+{
+public:
+  DelimitersWithExceptions(vector<strings::UniChar> const & exceptions);
+
+  bool operator()(strings::UniChar c) const;
+
+private:
+  vector<strings::UniChar> m_exceptions;
+  Delimiters m_delimiters;
+};
+}  // namespace search

--- a/search/search_integration_tests/search_query_v2_test.cpp
+++ b/search/search_integration_tests/search_query_v2_test.cpp
@@ -290,8 +290,6 @@ UNIT_CLASS_TEST(SearchQueryV2Test, TestRankingInfo)
       "Golden Gate Bridge", "en");
 
   TestPOI goldenGateBridge(m2::PointD(0, 0), "Golden Gate Bridge", "en");
-  TestPOI goldenGateAtm(m2::PointD(1, 1), "", "en");
-  goldenGateAtm.SetTypes({{"amenity", "atm"}});
 
   TestPOI waterfall(m2::PointD(0.5, 0.5), "", "en");
   waterfall.SetTypes({{"waterway", "waterfall"}});
@@ -315,7 +313,6 @@ UNIT_CLASS_TEST(SearchQueryV2Test, TestRankingInfo)
                                    {
                                      builder.Add(cafe1);
                                      builder.Add(cafe2);
-                                     builder.Add(goldenGateAtm);
                                      builder.Add(goldenGateBridge);
                                      builder.Add(goldenGateStreet);
                                      builder.Add(lermontov);
@@ -364,12 +361,6 @@ UNIT_CLASS_TEST(SearchQueryV2Test, TestRankingInfo)
   {
     TRules rules{ExactMatch(wonderlandId, waterfall)};
     TEST(ResultsMatch("waterfall", rules), ());
-  }
-
-  SetViewport(m2::RectD(m2::PointD(0.999, 0.999), m2::PointD(1.001, 1.001)));
-  {
-    TRules rules = {ExactMatch(wonderlandId, goldenGateAtm)};
-    TEST(ResultsMatch("atm", rules), ());
   }
 }
 
@@ -465,6 +456,32 @@ UNIT_CLASS_TEST(SearchQueryV2Test, TestPostcodes)
       TRules rules{ExactMatch(countryId, building1)};
       TEST(ResultsMatch(query, rules), (query));
     }
+  }
+}
+
+UNIT_CLASS_TEST(SearchQueryV2Test, TestCategories)
+{
+  string const countryName = "Wonderland";
+
+  TestCity sanFrancisco(m2::PointD(0, 0), "San Francisco", "en", 100 /* rank */);
+
+  TestPOI atm(m2::PointD(0, 0), "", "en");
+  atm.SetTypes({{"amenity", "atm"}});
+
+  BuildWorld([&](TestMwmBuilder & builder)
+             {
+               builder.Add(sanFrancisco);
+             });
+  auto wonderlandId = BuildCountry(countryName, [&](TestMwmBuilder & builder)
+                                   {
+                                     builder.Add(atm);
+                                   });
+
+  SetViewport(m2::RectD(m2::PointD(-0.5, -0.5), m2::PointD(0.5, 0.5)));
+  {
+    TRules rules = {ExactMatch(wonderlandId, atm)};
+    TEST(ResultsMatch("atm", rules), ());
+    TEST(ResultsMatch("#atm", rules), ());
   }
 }
 }  // namespace

--- a/search/search_query.cpp
+++ b/search/search_query.cpp
@@ -206,6 +206,15 @@ void UpdateNameScore(vector<strings::UniString> const & tokens, TSlice const & s
     bestCoverage = coverage;
   }
 }
+
+inline bool IsHashed(strings::UniString const & s) { return !s.empty() && s[0] == '#'; }
+
+inline strings::UniString RemoveHash(strings::UniString const & s)
+{
+  if (IsHashed(s))
+    return strings::UniString(s.begin() + 1, s.end());
+  return s;
+}
 }  // namespace
 
 // static
@@ -417,25 +426,24 @@ void Query::ForEachCategoryTypes(ToDo toDo) const
 {
   int8_t arrLocales[3];
   int const localesCount = GetCategoryLocales(arrLocales);
-
   size_t const tokensCount = m_tokens.size();
+
   for (size_t i = 0; i < tokensCount; ++i)
   {
-    for (int j = 0; j < localesCount; ++j)
-      m_categories.ForEachTypeByName(arrLocales[j], m_tokens[i], bind<void>(ref(toDo), i, _1));
+    auto token = RemoveHash(m_tokens[i]);
 
-    ProcessEmojiIfNeeded(m_tokens[i], i, toDo);
+    for (int j = 0; j < localesCount; ++j)
+      m_categories.ForEachTypeByName(arrLocales[j], token, bind<void>(ref(toDo), i, _1));
+    ProcessEmojiIfNeeded(token, i, toDo);
   }
 
   if (!m_prefix.empty())
   {
-    for (int j = 0; j < localesCount; ++j)
-    {
-      m_categories.ForEachTypeByName(arrLocales[j], m_prefix,
-                                     bind<void>(ref(toDo), tokensCount, _1));
-    }
+    auto prefix = RemoveHash(m_prefix);
 
-    ProcessEmojiIfNeeded(m_prefix, tokensCount, toDo);
+    for (int j = 0; j < localesCount; ++j)
+      m_categories.ForEachTypeByName(arrLocales[j], prefix, bind<void>(ref(toDo), tokensCount, _1));
+    ProcessEmojiIfNeeded(prefix, tokensCount, toDo);
   }
 }
 
@@ -461,9 +469,42 @@ void Query::SetQuery(string const & query)
   ASSERT(m_tokens.empty(), ());
   ASSERT(m_prefix.empty(), ());
 
-  // Split input query by tokens with possible last prefix.
+  // Following code splits input query by delimiters except hash tags
+  // first, and then splits result tokens by hash tags. The reason is
+  // to retrieve all tokens that starts with a single hash tag sign
+  // and leave them as is.
+
+  vector<strings::UniString> tokens;
+  {
+    search::DelimitersWithExceptions delims(vector<strings::UniChar>{'#'});
+    SplitUniString(NormalizeAndSimplifyString(query), MakeBackInsertFunctor(tokens), delims);
+  }
+
   search::Delimiters delims;
-  SplitUniString(NormalizeAndSimplifyString(query), MakeBackInsertFunctor(m_tokens), delims);
+  {
+    buffer_vector<strings::UniString, 32> subTokens;
+    for (auto const & token : tokens)
+    {
+      size_t numHashes = 0;
+      for (; numHashes < token.size() && token[numHashes] == '#'; ++numHashes)
+        ;
+
+      // Splits |tokens[i]| by hash signs, because all other
+      // delimiters are already removed.
+      subTokens.clear();
+      SplitUniString(token, MakeBackInsertFunctor(subTokens), delims);
+      if (subTokens.empty())
+        continue;
+
+      if (numHashes == 1)
+        m_tokens.push_back(strings::MakeUniString("#") + subTokens[0]);
+      else
+        m_tokens.emplace_back(move(subTokens[0]));
+
+      for (size_t i = 1; i < subTokens.size(); ++i)
+        m_tokens.push_back(move(subTokens[i]));
+    }
+  }
 
   // Assign prefix with last parsed token.
   if (!m_tokens.empty() && !delims(strings::LastUniChar(query)))
@@ -472,11 +513,11 @@ void Query::SetQuery(string const & query)
     m_tokens.pop_back();
   }
 
-  int const maxTokensCount = MAX_TOKENS-1;
+  int const maxTokensCount = MAX_TOKENS - 1;
   if (m_tokens.size() > maxTokensCount)
     m_tokens.resize(maxTokensCount);
 
-  // assign tokens and prefix to scorer
+  // Assign tokens and prefix to scorer.
   m_keywordsScorer.SetKeywords(m_tokens.data(), m_tokens.size(), m_prefix);
 
   // get preffered types to show in results
@@ -662,7 +703,9 @@ class PreResult2Maker
         return rank *= 1.7;
     }
     case v2::SearchModel::SEARCH_TYPE_COUNTRY: return rank /= 1.5;
-    default: return rank;
+
+    // For all other search types, rank should be zero for now.
+    default: return 0;
     }
   }
 
@@ -838,11 +881,15 @@ void Query::GetSuggestion(string const & name, string & suggest) const
   vector<bool> tokensMatched(tokens.size());
   bool prefixMatched = false;
   bool fullPrefixMatched = false;
+
   for (size_t i = 0; i < tokens.size(); ++i)
   {
     auto const & token = tokens[i];
+
     if (find(m_tokens.begin(), m_tokens.end(), token) != m_tokens.end())
+    {
       tokensMatched[i] = true;
+    }
     else if (StartsWith(token, m_prefix))
     {
       prefixMatched = true;
@@ -1191,13 +1238,12 @@ void Query::InitParams(bool localitySearch, SearchQueryParams & params)
   // Add names of categories (and synonyms).
   if (!localitySearch)
   {
-    Classificator const & cl = classif();
+    Classificator const & c = classif();
     auto addSyms = [&](size_t i, uint32_t t)
     {
-      SearchQueryParams::TSynonymsVector & v =
-          (i < tokensCount ? params.m_tokens[i] : params.m_prefixTokens);
+      SearchQueryParams::TSynonymsVector & v = params.GetTokens(i);
 
-      uint32_t const index = cl.GetIndexForType(t);
+      uint32_t const index = c.GetIndexForType(t);
       v.push_back(FeatureTypeToString(index));
       params.m_isCategorySynonym[i] = true;
 
@@ -1215,6 +1261,14 @@ void Query::InitParams(bool localitySearch, SearchQueryParams & params)
     };
     ForEachCategoryTypes(addSyms);
   }
+
+  for (auto & tokens : params.m_tokens)
+  {
+    if (IsHashed(tokens[0]))
+      tokens.erase(tokens.begin());
+  }
+  if (!params.m_prefixTokens.empty() && IsHashed(params.m_prefixTokens[0]))
+    params.m_prefixTokens.erase(params.m_prefixTokens.begin());
 
   for (int i = 0; i < LANG_COUNT; ++i)
     params.m_langs.insert(GetLanguage(i));

--- a/search/search_query.cpp
+++ b/search/search_query.cpp
@@ -207,11 +207,11 @@ void UpdateNameScore(vector<strings::UniString> const & tokens, TSlice const & s
   }
 }
 
-inline bool IsHashed(strings::UniString const & s) { return !s.empty() && s[0] == '#'; }
+inline bool IsHashtagged(strings::UniString const & s) { return !s.empty() && s[0] == '#'; }
 
-inline strings::UniString RemoveHash(strings::UniString const & s)
+inline strings::UniString RemoveHashtag(strings::UniString const & s)
 {
-  if (IsHashed(s))
+  if (IsHashtagged(s))
     return strings::UniString(s.begin() + 1, s.end());
   return s;
 }
@@ -430,7 +430,7 @@ void Query::ForEachCategoryTypes(ToDo toDo) const
 
   for (size_t i = 0; i < tokensCount; ++i)
   {
-    auto token = RemoveHash(m_tokens[i]);
+    auto token = RemoveHashtag(m_tokens[i]);
 
     for (int j = 0; j < localesCount; ++j)
       m_categories.ForEachTypeByName(arrLocales[j], token, bind<void>(ref(toDo), i, _1));
@@ -439,7 +439,7 @@ void Query::ForEachCategoryTypes(ToDo toDo) const
 
   if (!m_prefix.empty())
   {
-    auto prefix = RemoveHash(m_prefix);
+    auto prefix = RemoveHashtag(m_prefix);
 
     for (int j = 0; j < localesCount; ++j)
       m_categories.ForEachTypeByName(arrLocales[j], prefix, bind<void>(ref(toDo), tokensCount, _1));
@@ -470,9 +470,9 @@ void Query::SetQuery(string const & query)
   ASSERT(m_prefix.empty(), ());
 
   // Following code splits input query by delimiters except hash tags
-  // first, and then splits result tokens by hash tags. The reason is
-  // to retrieve all tokens that starts with a single hash tag sign
-  // and leave them as is.
+  // first, and then splits result tokens by hashtags. The goal is to
+  // retrieve all tokens that start with a single hashtag and leave
+  // them as is.
 
   vector<strings::UniString> tokens;
   {
@@ -489,8 +489,8 @@ void Query::SetQuery(string const & query)
       for (; numHashes < token.size() && token[numHashes] == '#'; ++numHashes)
         ;
 
-      // Splits |tokens[i]| by hash signs, because all other
-      // delimiters are already removed.
+      // Splits |token| by hashtags, because all other delimiters are
+      // already removed.
       subTokens.clear();
       SplitUniString(token, MakeBackInsertFunctor(subTokens), delims);
       if (subTokens.empty())
@@ -1264,10 +1264,10 @@ void Query::InitParams(bool localitySearch, SearchQueryParams & params)
 
   for (auto & tokens : params.m_tokens)
   {
-    if (IsHashed(tokens[0]))
+    if (IsHashtagged(tokens[0]))
       tokens.erase(tokens.begin());
   }
-  if (!params.m_prefixTokens.empty() && IsHashed(params.m_prefixTokens[0]))
+  if (!params.m_prefixTokens.empty() && IsHashtagged(params.m_prefixTokens[0]))
     params.m_prefixTokens.erase(params.m_prefixTokens.begin());
 
   for (int i = 0; i < LANG_COUNT; ++i)

--- a/search/v2/geocoder.cpp
+++ b/search/v2/geocoder.cpp
@@ -590,8 +590,10 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> & infos, bool inViewport)
       if (viewportCBV)
       {
         for (size_t i = 0; i < m_numTokens; ++i)
+        {
           m_addressFeatures[i] =
               coding::CompressedBitVector::Intersect(*m_addressFeatures[i], *viewportCBV);
+        }
       }
 
       m_streets = LoadStreets(*m_context);
@@ -1417,7 +1419,6 @@ void Geocoder::FillMissingFieldsInResults()
       {
         auto const & id = ii->first;
         auto & info = ii->second;
-
         info.m_rank = rankTable->Get(id.m_index);
       }
     }


### PR DESCRIPTION
Added possibility to add hashtags before categorial tokens. In this case, these tokens will be used only as categorial filters, not as parts of name. This is an internal feature and should be used internally, mostly for debugging.