### PR TITLE
[classificator] Restore old classificator loading algorythm

### DIFF
--- a/indexer/classificator_loader.cpp
+++ b/indexer/classificator_loader.cpp
@@ -45,16 +45,24 @@ namespace classificator
     LOG(LDEBUG, ("Reading of classificator started"));
 
     Platform & p = GetPlatform();
-    StyleReader & reader = GetStyleReader();
 
-    for (auto style : { MapStyleLight, MapStyleDark, MapStyleClear })
+    MapStyle const originMapStyle = GetStyleReader().GetCurrentStyle();
+
+    for (size_t i = 0; i < MapStyleCount; ++i)
     {
-      reader.SetCurrentStyle(style);
+      MapStyle const mapStyle = static_cast<MapStyle>(i);
+      // Read the merged style only if it was requested.
+      if (mapStyle != MapStyleMerged || originMapStyle == MapStyleMerged)
+      {
+        GetStyleReader().SetCurrentStyle(mapStyle);
+        ReadCommon(p.GetReader("classificator.txt"),
+                   p.GetReader("types.txt"));
 
-      ReadCommon(p.GetReader("classificator.txt"), p.GetReader("types.txt"));
-
-      drule::LoadRules();
+        drule::LoadRules();
+      }
     }
+
+    GetStyleReader().SetCurrentStyle(originMapStyle);
 
     LOG(LDEBUG, ("Reading of classificator finished"));
   }


### PR DESCRIPTION
Чуть больше месяца назад Витя [сломал]https://github.com/mapsme/omim/commit/9d52efd6538cc3be684329888a9490c3428f653e#diff-e53ab62079f4a6c127313cb75e92c806[ кэширование стилей и классификаторов, оставив загрузку только стиля по умолчанию. Через неделю он [вернул](https://github.com/mapsme/omim/pull/2854/files#diff-e53ab62079f4a6c127313cb75e92c806) старый код, но при этом забыл про две фичи: 
* восстановление стиля перед запуском функции (вероятно, у нас сейчас сломано сохранение последнего стиля в приложении);
* обработку смёрженного стиля для генератора (поэтому по факту мы использовали стиль clear для последних данных).

Этот пул-реквест восстанавливает файл, как он был до витиного вмешательства.