### PR TITLE
[bicycle routing] "oneway" tag is taken into account while bicycle routing.

### DIFF
--- a/base/base_tests/stl_helpers_test.cpp
+++ b/base/base_tests/stl_helpers_test.cpp
@@ -77,41 +77,37 @@ UNIT_TEST(EqualsBy)
 
 UNIT_TEST(SortUnique)
 {
-  vector<int> v = {1, 2, 1, 4, 3, 5, 2, 7, 1};
-  my::SortUnique(v);
-  vector<int> const expected = {1, 2, 3, 4, 5, 7};
-  TEST_EQUAL(v, expected, ());
-}
+  {
+    vector<int> v = {1, 2, 1, 4, 3, 5, 2, 7, 1};
+    my::SortUnique(v);
+    vector<int> const expected = {1, 2, 3, 4, 5, 7};
+    TEST_EQUAL(v, expected, ());
+  }
+  {
+    using TValue = int;
+    using TPair = pair<TValue, int>;
+    vector<TPair> v =
+        {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
 
-UNIT_TEST(SortUniqueCompPredTest1)
-{
-  using TValue = int;
-  using TPair = pair<TValue, int>;
-  vector<TPair> v =
-      {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
+    my::SortUnique<TPair>(v, my::LessBy(&TPair::first), my::EqualsBy(&TPair::first));
 
-  my::SortUnique<TPair>(v, my::CompareBy(&TPair::first),
-                        [](TPair const & p1, TPair const & p2) { return p1.first == p2.first; });
+    vector<TValue> const expected = {1, 2, 3, 4, 5, 7};
+    TEST_EQUAL(v.size(), expected.size(), ());
+    for (int i = 0; i < v.size(); ++i)
+      TEST_EQUAL(v[i].first, expected[i], (i));
+  }
+  {
+    using TValue = double;
+    using TPair = pair<TValue, int>;
+    vector<TPair> v =
+        {{0.5, 11}, {1000.99, 234}, {0.5, 23}, {1234.56789, 54}, {1000.99, 34}};
 
-  vector<TValue> const expected = {1, 2, 3, 4, 5, 7};
-  TEST_EQUAL(v.size(), expected.size(), ());
-  for (int i = 0; i < v.size(); ++i)
-    TEST_EQUAL(v[i].first, expected[i], (i));
-}
+    my::SortUnique<TPair>(v, my::LessBy(&TPair::first), my::EqualsBy(&TPair::first));
 
-UNIT_TEST(SortUniqueCompPredTest2)
-{
-  using TValue = double;
-  using TPair = pair<TValue, int>;
-  vector<TPair> v =
-      {{0.5, 11}, {1000.99, 234}, {0.5, 23}, {1234.56789, 54}, {1000.99, 34}};
-
-  my::SortUnique<TPair>(v, my::CompareBy(&TPair::first),
-                        [](TPair const & p1, TPair const & p2) { return p1.first == p2.first; });
-
-  vector<TValue> const expected = {0.5, 1000.99, 1234.56789};
-  TEST_EQUAL(v.size(), expected.size(), ());
-  for (int i = 0; i < v.size(); ++i)
-    TEST_EQUAL(v[i].first, expected[i], (i));
+    vector<TValue> const expected = {0.5, 1000.99, 1234.56789};
+    TEST_EQUAL(v.size(), expected.size(), ());
+    for (int i = 0; i < v.size(); ++i)
+      TEST_EQUAL(v[i].first, expected[i], (i));
+  }
 }
 }  // namespace

--- a/base/base_tests/stl_helpers_test.cpp
+++ b/base/base_tests/stl_helpers_test.cpp
@@ -74,4 +74,31 @@ UNIT_TEST(EqualsBy)
       TEST_EQUAL(expected[i], actual[i].Get(), ());
   }
 }
+
+UNIT_TEST(SortUnique)
+{
+  vector<int> v = {1, 2, 1, 4, 3, 5, 2, 7, 1};
+  my::SortUnique(v);
+  vector<int> const expected = {1, 2, 3, 4, 5, 7};
+  TEST_EQUAL(v, expected, ());
+}
+
+UNIT_TEST(SortUniquePred)
+{
+  struct Foo
+  {
+    int i, j;
+  };
+
+  vector<Foo> v = {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
+  my::SortUnique<Foo>([](Foo const & f1, Foo const & f2) { return f1.i < f2.i; }, v);
+
+  TEST_EQUAL(v.size(), 6, ());
+  TEST_EQUAL(v[0].i, 1, ());
+  TEST_EQUAL(v[1].i, 2, ());
+  TEST_EQUAL(v[2].i, 3, ());
+  TEST_EQUAL(v[3].i, 4, ());
+  TEST_EQUAL(v[4].i, 5, ());
+  TEST_EQUAL(v[5].i, 7, ());
+}
 }  // namespace

--- a/base/base_tests/stl_helpers_test.cpp
+++ b/base/base_tests/stl_helpers_test.cpp
@@ -83,26 +83,35 @@ UNIT_TEST(SortUnique)
   TEST_EQUAL(v, expected, ());
 }
 
-UNIT_TEST(SortUniquePred)
+UNIT_TEST(SortUniqueCompPredTest1)
 {
-  struct Foo
-  {
-    int i, j;
-  };
+  using TValue = int;
+  using TPair = pair<TValue, int>;
+  vector<TPair> v =
+      {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
 
-  vector<Foo> v = {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
-  my::SortUnique<Foo>([](Foo const & f1, Foo const & f2)
-                      {
-                        return f1.i < f2.i;
-                      },
-                      v);
+  my::SortUnique<TPair>(v, my::CompareBy(&TPair::first),
+                        [](TPair const & p1, TPair const & p2) { return p1.first == p2.first; });
 
-  TEST_EQUAL(v.size(), 6, ());
-  TEST_EQUAL(v[0].i, 1, ());
-  TEST_EQUAL(v[1].i, 2, ());
-  TEST_EQUAL(v[2].i, 3, ());
-  TEST_EQUAL(v[3].i, 4, ());
-  TEST_EQUAL(v[4].i, 5, ());
-  TEST_EQUAL(v[5].i, 7, ());
+  vector<TValue> const expected = {1, 2, 3, 4, 5, 7};
+  TEST_EQUAL(v.size(), expected.size(), ());
+  for (int i = 0; i < v.size(); ++i)
+    TEST_EQUAL(v[i].first, expected[i], (i));
+}
+
+UNIT_TEST(SortUniqueCompPredTest2)
+{
+  using TValue = double;
+  using TPair = pair<TValue, int>;
+  vector<TPair> v =
+      {{0.5, 11}, {1000.99, 234}, {0.5, 23}, {1234.56789, 54}, {1000.99, 34}};
+
+  my::SortUnique<TPair>(v, my::CompareBy(&TPair::first),
+                        [](TPair const & p1, TPair const & p2) { return p1.first == p2.first; });
+
+  vector<TValue> const expected = {0.5, 1000.99, 1234.56789};
+  TEST_EQUAL(v.size(), expected.size(), ());
+  for (int i = 0; i < v.size(); ++i)
+    TEST_EQUAL(v[i].first, expected[i], (i));
 }
 }  // namespace

--- a/base/base_tests/stl_helpers_test.cpp
+++ b/base/base_tests/stl_helpers_test.cpp
@@ -91,7 +91,11 @@ UNIT_TEST(SortUniquePred)
   };
 
   vector<Foo> v = {{1, 22}, {2, 33}, {1, 23}, {4, 54}, {3, 34}, {5, 23}, {2, 23}, {7, 32}, {1, 12}};
-  my::SortUnique<Foo>([](Foo const & f1, Foo const & f2) { return f1.i < f2.i; }, v);
+  my::SortUnique<Foo>([](Foo const & f1, Foo const & f2)
+                      {
+                        return f1.i < f2.i;
+                      },
+                      v);
 
   TEST_EQUAL(v.size(), 6, ());
   TEST_EQUAL(v[0].i, 1, ());

--- a/base/base_tests/stl_helpers_test.cpp
+++ b/base/base_tests/stl_helpers_test.cpp
@@ -78,10 +78,10 @@ UNIT_TEST(EqualsBy)
 UNIT_TEST(SortUnique)
 {
   {
-    vector<int> v = {1, 2, 1, 4, 3, 5, 2, 7, 1};
-    my::SortUnique(v);
+    vector<int> actual = {1, 2, 1, 4, 3, 5, 2, 7, 1};
+    my::SortUnique(actual);
     vector<int> const expected = {1, 2, 3, 4, 5, 7};
-    TEST_EQUAL(v, expected, ());
+    TEST_EQUAL(actual, expected, ());
   }
   {
     using TValue = int;

--- a/base/stl_helpers.hpp
+++ b/base/stl_helpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "std/algorithm.hpp"
+#include "std/functional.hpp"
 #include "std/vector.hpp"
 
 namespace my
@@ -83,6 +84,21 @@ void SortUnique(vector<T> & v)
 {
   sort(v.begin(), v.end());
   v.erase(unique(v.begin(), v.end()), v.end());
+}
+
+// Sorts and removes duplicate entries from |v| according to |comp|.
+// Note. If several entries are equivalent according to |comp| an arbitrary entry of them
+// is left in |v| after a call of this method.
+// Note. |comp| should implement operator<. It means the expression
+// !comp(t1, t2) && !comp(t2, t1) should return true iff t1 is equivalent to t2.
+// It's necessary for std::unique.
+template <typename T>
+void SortUnique(function<bool(T const &, T const &)> const & comp, vector<T> & v)
+{
+  sort(v.begin(), v.end(), comp);
+  function<bool(T const &, T const &)> const pred =
+      [&comp](T const &t1, T const &t2) { return !comp(t1, t2) && !comp(t2, t1); };
+  v.erase(unique(v.begin(), v.end(), pred), v.end());
 }
 
 template <typename T, class TFn>

--- a/base/stl_helpers.hpp
+++ b/base/stl_helpers.hpp
@@ -96,8 +96,10 @@ template <typename T>
 void SortUnique(function<bool(T const &, T const &)> const & comp, vector<T> & v)
 {
   sort(v.begin(), v.end(), comp);
-  function<bool(T const &, T const &)> const pred =
-      [&comp](T const &t1, T const &t2) { return !comp(t1, t2) && !comp(t2, t1); };
+  function<bool(T const &, T const &)> const pred = [&comp](T const & t1, T const & t2)
+  {
+    return !comp(t1, t2) && !comp(t2, t1);
+  };
   v.erase(unique(v.begin(), v.end(), pred), v.end());
 }
 

--- a/base/stl_helpers.hpp
+++ b/base/stl_helpers.hpp
@@ -2,7 +2,9 @@
 
 #include "std/algorithm.hpp"
 #include "std/functional.hpp"
+#include "std/utility.hpp"
 #include "std/vector.hpp"
+
 
 namespace my
 {
@@ -89,11 +91,11 @@ void SortUnique(vector<T> & v)
 // Sorts according to |comp| and removes duplicate entries according to |pred| from |v|.
 // Note. If several entries are equal according to |pred| an arbitrary entry of them
 // is left in |v| after a call of this function.
-template <typename T, typename TComp, typename TPred>
-void SortUnique(vector<T> & v, TComp && comp, TPred && pred)
+template <typename T, typename TLess, typename TEquals>
+void SortUnique(vector<T> & v, TLess && less, TEquals && equals)
 {
-  sort(v.begin(), v.end(), comp);
-  v.erase(unique(v.begin(), v.end(), pred), v.end());
+  sort(v.begin(), v.end(), forward<TLess>(less));
+  v.erase(unique(v.begin(), v.end(), forward<TEquals>(equals)), v.end());
 }
 
 template <typename T, class TFn>

--- a/base/stl_helpers.hpp
+++ b/base/stl_helpers.hpp
@@ -86,20 +86,13 @@ void SortUnique(vector<T> & v)
   v.erase(unique(v.begin(), v.end()), v.end());
 }
 
-// Sorts and removes duplicate entries from |v| according to |comp|.
-// Note. If several entries are equivalent according to |comp| an arbitrary entry of them
-// is left in |v| after a call of this method.
-// Note. |comp| should implement operator<. It means the expression
-// !comp(t1, t2) && !comp(t2, t1) should return true iff t1 is equivalent to t2.
-// It's necessary for std::unique.
-template <typename T>
-void SortUnique(function<bool(T const &, T const &)> const & comp, vector<T> & v)
+// Sorts according to |comp| and removes duplicate entries according to |pred| from |v|.
+// Note. If several entries are equal according to |pred| an arbitrary entry of them
+// is left in |v| after a call of this function.
+template <typename T, typename TComp, typename TPred>
+void SortUnique(vector<T> & v, TComp && comp, TPred && pred)
 {
   sort(v.begin(), v.end(), comp);
-  function<bool(T const &, T const &)> const pred = [&comp](T const & t1, T const & t2)
-  {
-    return !comp(t1, t2) && !comp(t2, t1);
-  };
   v.erase(unique(v.begin(), v.end(), pred), v.end());
 }
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1035,7 +1035,7 @@ void Framework::StartInteractiveSearch(search::SearchParams const & params)
 
   m_lastInteractiveSearchParams = params;
   m_lastInteractiveSearchParams.SetForceSearch(false);
-  m_lastInteractiveSearchParams.SetMode(Mode::Viewport);
+  m_lastInteractiveSearchParams.SetMode(search::Mode::Viewport);
   m_lastInteractiveSearchParams.SetSuggestsEnabled(false);
   m_lastInteractiveSearchParams.m_onResults = [this](Results const & results)
   {

--- a/pedestrian_routing_tests/pedestrian_routing_tests.cpp
+++ b/pedestrian_routing_tests/pedestrian_routing_tests.cpp
@@ -94,7 +94,9 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarTestRouter(Index & index, stor
   auto UKGetter = [&](m2::PointD const & pt) { return cig.GetRegionCountryId(pt); };
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarRoutingAlgorithm());
-  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-pedestrian", index, UKGetter, move(vehicleModelFactory), move(algorithm), nullptr));
+  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-pedestrian", index, UKGetter,
+                                                                   true /* onewayAsBidirectional */,
+                                                                   move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
 
@@ -103,7 +105,9 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarBidirectionalTestRouter(Index 
   auto UKGetter = [&](m2::PointD const & pt) { return cig.GetRegionCountryId(pt); };
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarBidirectionalRoutingAlgorithm());
-  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-bidirectional-pedestrian", index, UKGetter, move(vehicleModelFactory), move(algorithm), nullptr));
+  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-bidirectional-pedestrian", index, UKGetter,
+                                                                   true /* onewayAsBidirectional */,
+                                                                   move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
 
@@ -120,7 +124,7 @@ m2::PointD GetPointOnEdge(routing::Edge & e, double posAlong)
 void GetNearestPedestrianEdges(Index & index, m2::PointD const & pt, vector<pair<routing::Edge, m2::PointD>> & edges)
 {
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
-  routing::FeaturesRoadGraph roadGraph(index, move(vehicleModelFactory));
+  routing::FeaturesRoadGraph roadGraph(index, true /* onewayAsBidirectional */, move(vehicleModelFactory));
 
   roadGraph.FindClosestEdges(pt, 1 /*count*/, edges);
 }

--- a/pedestrian_routing_tests/pedestrian_routing_tests.cpp
+++ b/pedestrian_routing_tests/pedestrian_routing_tests.cpp
@@ -95,7 +95,7 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarTestRouter(Index & index, stor
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarRoutingAlgorithm());
   unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter(
-      "test-astar-pedestrian", index, UKGetter, true /* onewayAsBidirectional */,
+      "test-astar-pedestrian", index, UKGetter, routing::IRoadGraph::Mode::IgnoreOnewayTag,
       move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
@@ -106,7 +106,7 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarBidirectionalTestRouter(Index 
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarBidirectionalRoutingAlgorithm());
   unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter(
-      "test-astar-bidirectional-pedestrian", index, UKGetter, true /* onewayAsBidirectional */,
+      "test-astar-bidirectional-pedestrian", index, UKGetter, routing::IRoadGraph::Mode::IgnoreOnewayTag,
       move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
@@ -124,7 +124,7 @@ m2::PointD GetPointOnEdge(routing::Edge & e, double posAlong)
 void GetNearestPedestrianEdges(Index & index, m2::PointD const & pt, vector<pair<routing::Edge, m2::PointD>> & edges)
 {
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
-  routing::FeaturesRoadGraph roadGraph(index, true /* onewayAsBidirectional */,
+  routing::FeaturesRoadGraph roadGraph(index, routing::IRoadGraph::Mode::IgnoreOnewayTag,
                                        move(vehicleModelFactory));
 
   roadGraph.FindClosestEdges(pt, 1 /*count*/, edges);

--- a/pedestrian_routing_tests/pedestrian_routing_tests.cpp
+++ b/pedestrian_routing_tests/pedestrian_routing_tests.cpp
@@ -94,9 +94,9 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarTestRouter(Index & index, stor
   auto UKGetter = [&](m2::PointD const & pt) { return cig.GetRegionCountryId(pt); };
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarRoutingAlgorithm());
-  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-pedestrian", index, UKGetter,
-                                                                   true /* onewayAsBidirectional */,
-                                                                   move(vehicleModelFactory), move(algorithm), nullptr));
+  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter(
+      "test-astar-pedestrian", index, UKGetter, true /* onewayAsBidirectional */,
+      move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
 
@@ -105,9 +105,9 @@ unique_ptr<routing::IRouter> CreatePedestrianAStarBidirectionalTestRouter(Index 
   auto UKGetter = [&](m2::PointD const & pt) { return cig.GetRegionCountryId(pt); };
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   unique_ptr<routing::IRoutingAlgorithm> algorithm(new routing::AStarBidirectionalRoutingAlgorithm());
-  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter("test-astar-bidirectional-pedestrian", index, UKGetter,
-                                                                   true /* onewayAsBidirectional */,
-                                                                   move(vehicleModelFactory), move(algorithm), nullptr));
+  unique_ptr<routing::IRouter> router(new routing::RoadGraphRouter(
+      "test-astar-bidirectional-pedestrian", index, UKGetter, true /* onewayAsBidirectional */,
+      move(vehicleModelFactory), move(algorithm), nullptr));
   return router;
 }
 
@@ -124,7 +124,8 @@ m2::PointD GetPointOnEdge(routing::Edge & e, double posAlong)
 void GetNearestPedestrianEdges(Index & index, m2::PointD const & pt, vector<pair<routing::Edge, m2::PointD>> & edges)
 {
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
-  routing::FeaturesRoadGraph roadGraph(index, true /* onewayAsBidirectional */, move(vehicleModelFactory));
+  routing::FeaturesRoadGraph roadGraph(index, true /* onewayAsBidirectional */,
+                                       move(vehicleModelFactory));
 
   roadGraph.FindClosestEdges(pt, 1 /*count*/, edges);
 }

--- a/routing/bicycle_model.hpp
+++ b/routing/bicycle_model.hpp
@@ -17,7 +17,6 @@ public:
   /// @name Overrides from VehicleModel.
   //@{
   double GetSpeed(FeatureType const & f) const override;
-  bool IsOneWay(FeatureType const &) const override { return false; }
   //@}
 
 private:

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -36,12 +36,6 @@ string GetFeatureCountryName(FeatureID const featureId)
     return countryName;
   return countryName.substr(0, pos);
 }
-
-inline bool PointsAlmostEqualAbs(const m2::PointD & pt1, const m2::PointD & pt2)
-{
-  double constexpr kEpsilon = 1e-6;
-  return my::AlmostEqualAbs(pt1.x, pt2.x, kEpsilon) && my::AlmostEqualAbs(pt1.y, pt2.y, kEpsilon);
-}
 }  // namespace
 
 

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -101,10 +101,10 @@ void FeaturesRoadGraph::RoadInfoCache::Clear()
   m_cache.clear();
 }
 
-FeaturesRoadGraph::FeaturesRoadGraph(Index const & index, bool onewayAsBidirectional,
+FeaturesRoadGraph::FeaturesRoadGraph(Index const & index, IRoadGraph::Mode mode,
                                      unique_ptr<IVehicleModelFactory> && vehicleModelFactory)
   : m_index(index)
-  , m_onewayAsBidirectional(onewayAsBidirectional)
+  , m_mode(mode)
   , m_vehicleModel(move(vehicleModelFactory))
 {
 }
@@ -230,9 +230,9 @@ void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::Typ
   m_index.ForEachInRect(f, rect, GetStreetReadScale());
 }
 
-bool FeaturesRoadGraph::ConsiderOnewayFeaturesAsBidirectional() const
+IRoadGraph::Mode FeaturesRoadGraph::ConsiderOnewayFeaturesAsBidirectional() const
 {
-  return m_onewayAsBidirectional;
+  return m_mode;
 };
 
 void FeaturesRoadGraph::ClearState()

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -103,8 +103,9 @@ void FeaturesRoadGraph::RoadInfoCache::Clear()
 
 FeaturesRoadGraph::FeaturesRoadGraph(Index const & index, bool onewayAsBidirectional,
                                      unique_ptr<IVehicleModelFactory> && vehicleModelFactory)
-    : m_index(index), m_onewayAsBidirectional(onewayAsBidirectional),
-      m_vehicleModel(move(vehicleModelFactory))
+  : m_index(index)
+  , m_onewayAsBidirectional(onewayAsBidirectional)
+  , m_vehicleModel(move(vehicleModelFactory))
 {
 }
 
@@ -113,9 +114,8 @@ uint32_t FeaturesRoadGraph::GetStreetReadScale() { return scales::GetUpperScale(
 class CrossFeaturesLoader
 {
 public:
-  CrossFeaturesLoader(FeaturesRoadGraph const & graph,
-                      IRoadGraph::ICrossEdgesLoader & edgesLoader)
-      : m_graph(graph), m_edgesLoader(edgesLoader)
+  CrossFeaturesLoader(FeaturesRoadGraph const & graph, IRoadGraph::ICrossEdgesLoader & edgesLoader)
+    : m_graph(graph), m_edgesLoader(edgesLoader)
   {}
 
   void operator()(FeatureType & ft)

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -212,7 +212,7 @@ void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::Typ
     if (ft.GetFeatureType() != feature::GEOM_POINT)
       return;
 
-    if (!PointsAlmostEqualAbs(ft.GetCenter(), cross))
+    if (!my::AlmostEqualAbs(ft.GetCenter(), cross, routing::kPointsEqualEpsilon))
       return;
 
     feature::TypesHolder typesHolder(ft);
@@ -224,7 +224,7 @@ void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::Typ
   m_index.ForEachInRect(f, rect, GetStreetReadScale());
 }
 
-IRoadGraph::Mode FeaturesRoadGraph::ConsiderOnewayFeaturesAsBidirectional() const
+IRoadGraph::Mode FeaturesRoadGraph::GetMode() const
 {
   return m_mode;
 };

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -101,9 +101,9 @@ void FeaturesRoadGraph::RoadInfoCache::Clear()
   m_cache.clear();
 }
 
-
-FeaturesRoadGraph::FeaturesRoadGraph(Index & index, unique_ptr<IVehicleModelFactory> && vehicleModelFactory)
-    : m_index(index),
+FeaturesRoadGraph::FeaturesRoadGraph(Index const & index, bool onewayAsBidirectional,
+                                     unique_ptr<IVehicleModelFactory> && vehicleModelFactory)
+    : m_index(index), m_onewayAsBidirectional(onewayAsBidirectional),
       m_vehicleModel(move(vehicleModelFactory))
 {
 }
@@ -114,7 +114,7 @@ class CrossFeaturesLoader
 {
 public:
   CrossFeaturesLoader(FeaturesRoadGraph const & graph,
-                      IRoadGraph::CrossEdgesLoader & edgesLoader)
+                      IRoadGraph::ICrossEdgesLoader & edgesLoader)
       : m_graph(graph), m_edgesLoader(edgesLoader)
   {}
 
@@ -136,7 +136,7 @@ public:
 
 private:
   FeaturesRoadGraph const & m_graph;
-  IRoadGraph::CrossEdgesLoader & m_edgesLoader;
+  IRoadGraph::ICrossEdgesLoader & m_edgesLoader;
 };
 
 IRoadGraph::RoadInfo FeaturesRoadGraph::GetRoadInfo(FeatureID const & featureId) const
@@ -159,7 +159,7 @@ double FeaturesRoadGraph::GetMaxSpeedKMPH() const
 }
 
 void FeaturesRoadGraph::ForEachFeatureClosestToCross(m2::PointD const & cross,
-                                                     CrossEdgesLoader & edgesLoader) const
+                                                     ICrossEdgesLoader & edgesLoader) const
 {
   CrossFeaturesLoader featuresLoader(*this, edgesLoader);
   m2::RectD const rect = MercatorBounds::RectByCenterXYAndSizeInMeters(cross, kMwmRoadCrossingRadiusMeters);
@@ -229,6 +229,11 @@ void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::Typ
   m2::RectD const rect = MercatorBounds::RectByCenterXYAndSizeInMeters(cross, kMwmRoadCrossingRadiusMeters);
   m_index.ForEachInRect(f, rect, GetStreetReadScale());
 }
+
+bool FeaturesRoadGraph::ConsiderOnewayFeaturesAsBidirectional() const
+{
+  return m_onewayAsBidirectional;
+};
 
 void FeaturesRoadGraph::ClearState()
 {

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -71,7 +71,7 @@ public:
                         vector<pair<Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
-  IRoadGraph::Mode ConsiderOnewayFeaturesAsBidirectional() const override;
+  IRoadGraph::Mode GetMode() const override;
   void ClearState() override;
 
 private:

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -56,7 +56,8 @@ private:
   };
 
 public:
-  FeaturesRoadGraph(Index & index, unique_ptr<IVehicleModelFactory> && vehicleModelFactory);
+  FeaturesRoadGraph(Index const & index, bool onewayAsBidirectional,
+                    unique_ptr<IVehicleModelFactory> && vehicleModelFactory);
 
   static uint32_t GetStreetReadScale();
 
@@ -65,11 +66,12 @@ public:
   double GetSpeedKMPH(FeatureID const & featureId) const override;
   double GetMaxSpeedKMPH() const override;
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
-                                    CrossEdgesLoader & edgesLoader) const override;
+                                    ICrossEdgesLoader & edgesLoader) const override;
   void FindClosestEdges(m2::PointD const & point, uint32_t count,
                         vector<pair<Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
+  bool ConsiderOnewayFeaturesAsBidirectional() const override;
   void ClearState() override;
 
 private:
@@ -89,7 +91,8 @@ private:
 
   void LockFeatureMwm(FeatureID const & featureId) const;
 
-  Index & m_index;
+  Index const & m_index;
+  bool const m_onewayAsBidirectional;
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable map<MwmSet::MwmId, MwmSet::MwmHandle> m_mwmLocks;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -56,7 +56,7 @@ private:
   };
 
 public:
-  FeaturesRoadGraph(Index const & index, bool onewayAsBidirectional,
+  FeaturesRoadGraph(Index const & index, IRoadGraph::Mode mode,
                     unique_ptr<IVehicleModelFactory> && vehicleModelFactory);
 
   static uint32_t GetStreetReadScale();
@@ -71,7 +71,7 @@ public:
                         vector<pair<Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
-  bool ConsiderOnewayFeaturesAsBidirectional() const override;
+  IRoadGraph::Mode ConsiderOnewayFeaturesAsBidirectional() const override;
   void ClearState() override;
 
 private:
@@ -92,7 +92,7 @@ private:
   void LockFeatureMwm(FeatureID const & featureId) const;
 
   Index const & m_index;
-  bool const m_onewayAsBidirectional;
+  IRoadGraph::Mode const m_mode;
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable map<MwmSet::MwmId, MwmSet::MwmHandle> m_mwmLocks;

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -179,7 +179,7 @@ void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId,
     if (!PointsAlmostEqualAbs(m_cross, p))
       continue;
 
-    if (i > 0 && (roadInfo.m_bidirectional || m_onewayAsBidirectional))
+    if (i > 0 && (roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag))
     {
       //               p
       // o------------>o
@@ -218,7 +218,7 @@ void IRoadGraph::CrossIngoingLoader::LoadEdge(FeatureID const & featureId,
       m_edges.emplace_back(featureId, true /* forward */, i - 1, roadInfo.m_points[i - 1], p);
     }
 
-    if (i < numPoints - 1 && (roadInfo.m_bidirectional || m_onewayAsBidirectional))
+    if (i < numPoints - 1 && (roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag))
     {
       // p
       // o------------>o

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -64,11 +64,7 @@ vector<Edge>::const_iterator FindEdgeContainingPoint(vector<Edge> const & edges,
 /// \brief Reverses |edges| starting from index |beginIdx| and upto the end of |v|.
 void ReverseEdges(size_t beginIdx, IRoadGraph::TEdgeVector & edges)
 {
-  if (beginIdx > edges.size())
-  {
-    ASSERT(false, ());
-    return;
-  }
+  ASSERT_LESS_OR_EQUAL(beginIdx, edges.size(), ("Index too large."));
 
   for (size_t i = beginIdx; i < edges.size(); ++i)
     edges[i] = edges[i].GetReverseEdge();
@@ -167,8 +163,8 @@ IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH, initializer
 {}
 
 // IRoadGraph::CrossOutgoingLoader ---------------------------------------------
-void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId,
-                                               RoadInfo const & roadInfo)
+void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId,
+                                                RoadInfo const & roadInfo)
 {
   size_t const numPoints = roadInfo.m_points.size();
 
@@ -198,8 +194,8 @@ void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId,
 }
 
 // IRoadGraph::CrossIngoingLoader ----------------------------------------------
-void IRoadGraph::CrossIngoingLoader::LoadEdge(FeatureID const & featureId,
-                                              RoadInfo const & roadInfo)
+void IRoadGraph::CrossIngoingLoader::LoadEdges(FeatureID const & featureId,
+                                               RoadInfo const & roadInfo)
 {
   size_t const numPoints = roadInfo.m_points.size();
 

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -158,33 +158,20 @@ IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH, initializer
 // IRoadGraph::CrossOutgoingLoader ---------------------------------------------
 void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
-  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t i, m2::PointD const & p)
+  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, m2::PointD const & endPoint,  bool forward)
   {
-    ASSERT_LESS(i, roadInfo.m_points.size() - 1, ());
-    m_edges.emplace_back(featureId, true /* forward */, i, p, roadInfo.m_points[i + 1]);
-  },
-  [&featureId, &roadInfo, this](size_t i, m2::PointD const & p)
-  {
-    ASSERT_LESS(i, roadInfo.m_points.size(), ());
-    if (roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
-      m_edges.emplace_back(featureId, false /* forward */, i - 1, p, roadInfo.m_points[i - 1]);
+    if (forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
+      m_edges.emplace_back(featureId, forward, segId, m_cross, endPoint);
   });
 }
 
 // IRoadGraph::CrossIngoingLoader ----------------------------------------------
 void IRoadGraph::CrossIngoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
-  ForEachEdge(roadInfo,
-  [&featureId, &roadInfo, this](size_t i, m2::PointD const & p)
+  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, m2::PointD const & endPoint, bool forward)
   {
-    ASSERT_LESS(i, roadInfo.m_points.size() - 1, ());
-    if (roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
-      m_edges.emplace_back(featureId, false /* forward */, i, roadInfo.m_points[i + 1], p);
-  },
-  [&featureId, &roadInfo, this](size_t i, m2::PointD const & p)
-  {
-    ASSERT_LESS(i, roadInfo.m_points.size() , ());
-    m_edges.emplace_back(featureId, true /* forward */, i - 1, roadInfo.m_points[i - 1], p);
+    if (!forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
+      m_edges.emplace_back(featureId, !forward, segId, endPoint, m_cross);
   });
 }
 

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -167,7 +167,8 @@ IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH, initializer
 {}
 
 // IRoadGraph::CrossOutgoingLoader ---------------------------------------------
-void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo)
+void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId,
+                                               RoadInfo const & roadInfo)
 {
   size_t const numPoints = roadInfo.m_points.size();
 
@@ -197,7 +198,8 @@ void IRoadGraph::CrossOutgoingLoader::LoadEdge(FeatureID const & featureId, Road
 }
 
 // IRoadGraph::CrossIngoingLoader ----------------------------------------------
-void IRoadGraph::CrossIngoingLoader::LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo)
+void IRoadGraph::CrossIngoingLoader::LoadEdge(FeatureID const & featureId,
+                                              RoadInfo const & roadInfo)
 {
   size_t const numPoints = roadInfo.m_points.size();
 

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -116,11 +116,11 @@ public:
 
     void operator()(FeatureID const & featureId, RoadInfo const & roadInfo)
     {
-      LoadEdge(featureId, roadInfo);
+      LoadEdges(featureId, roadInfo);
     }
 
   private:
-    virtual void LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo) = 0;
+    virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) = 0;
 
   protected:
     m2::PointD const m_cross;
@@ -137,7 +137,7 @@ public:
     }
 
     // ICrossEdgesLoader overrides:
-    virtual void LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo) override;
+    virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) override;
   };
 
   class CrossIngoingLoader : public ICrossEdgesLoader
@@ -148,7 +148,7 @@ public:
     {
     }
     // ICrossEdgesLoader overrides:
-    virtual void LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo) override;
+    virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) override;
   };
 
   virtual ~IRoadGraph() = default;

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -103,7 +103,9 @@ public:
   {
   public:
     ICrossEdgesLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-        : m_cross(cross), m_onewayAsBidirectional(onewayAsBidirectional), m_edges(edges) {}
+      : m_cross(cross), m_onewayAsBidirectional(onewayAsBidirectional), m_edges(edges)
+    {
+    }
     virtual ~ICrossEdgesLoader() = default;
 
     void operator()(FeatureID const & featureId, RoadInfo const & roadInfo)
@@ -124,7 +126,9 @@ public:
   {
   public:
     CrossOutgoingLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges) {}
+      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges)
+    {
+    }
 
     // ICrossEdgesLoader overrides:
     virtual void LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo) override;
@@ -134,7 +138,9 @@ public:
   {
   public:
     CrossIngoingLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges) {}
+      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges)
+    {
+    }
     // ICrossEdgesLoader overrides:
     virtual void LoadEdge(FeatureID const & featureId, RoadInfo const & roadInfo) override;
   };

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -125,27 +125,27 @@ public:
     virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) = 0;
 
   protected:
-    template <typename THeadFn, typename TTailFn>
-    void ForEachEdge(RoadInfo const & roadInfo, THeadFn && headFn, TTailFn && tailFn)
+    template <typename TFn>
+    void ForEachEdge(RoadInfo const & roadInfo, TFn && fn)
     {
       for (size_t i = 0; i < roadInfo.m_points.size(); ++i)
       {
-        m2::PointD const & p = roadInfo.m_points[i];
-
-        if (!my::AlmostEqualAbs(m_cross, p, kPointsEqualEpsilon))
+        if (!my::AlmostEqualAbs(m_cross, roadInfo.m_points[i], kPointsEqualEpsilon))
           continue;
 
-        if (i > 0)
-        {
-          //               p
-          // o------------>o
-          tailFn(i, p);
-        }
         if (i < roadInfo.m_points.size() - 1)
         {
-          // p
-          // o------------>o
-          headFn(i, p);
+          // Head of the edge.
+          // m_cross
+          //     o------------>o
+          fn(i, roadInfo.m_points[i + 1], true /* forward */);
+        }
+        if (i > 0)
+        {
+          // Tail of the edge.
+          //                m_cross
+          //     o------------>o
+          fn(i - 1, roadInfo.m_points[i - 1],  false /* backward */);
         }
       }
     }

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -83,6 +83,12 @@ public:
   typedef vector<Junction> TJunctionVector;
   typedef vector<Edge> TEdgeVector;
 
+  enum class Mode
+  {
+    ObeyOnewayTag,
+    IgnoreOnewayTag,
+  };
+
   /// This struct contains the part of a feature's metadata that is
   /// relevant for routing.
   struct RoadInfo
@@ -102,8 +108,8 @@ public:
   class ICrossEdgesLoader
   {
   public:
-    ICrossEdgesLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-      : m_cross(cross), m_onewayAsBidirectional(onewayAsBidirectional), m_edges(edges)
+    ICrossEdgesLoader(m2::PointD const & cross, IRoadGraph::Mode mode, TEdgeVector & edges)
+      : m_cross(cross), m_mode(mode), m_edges(edges)
     {
     }
     virtual ~ICrossEdgesLoader() = default;
@@ -118,15 +124,15 @@ public:
 
   protected:
     m2::PointD const m_cross;
-    bool const m_onewayAsBidirectional;
+    IRoadGraph::Mode const m_mode;
     TEdgeVector & m_edges;
   };
 
   class CrossOutgoingLoader : public ICrossEdgesLoader
   {
   public:
-    CrossOutgoingLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges)
+    CrossOutgoingLoader(m2::PointD const & cross, IRoadGraph::Mode mode, TEdgeVector & edges)
+      : ICrossEdgesLoader(cross, mode, edges)
     {
     }
 
@@ -137,8 +143,8 @@ public:
   class CrossIngoingLoader : public ICrossEdgesLoader
   {
   public:
-    CrossIngoingLoader(m2::PointD const & cross, bool onewayAsBidirectional, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, onewayAsBidirectional, edges)
+    CrossIngoingLoader(m2::PointD const & cross, IRoadGraph::Mode mode, TEdgeVector & edges)
+      : ICrossEdgesLoader(cross, mode, edges)
     {
     }
     // ICrossEdgesLoader overrides:
@@ -191,7 +197,7 @@ public:
   /// @return Types for specified junction
   virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
 
-  virtual bool ConsiderOnewayFeaturesAsBidirectional() const = 0;
+  virtual IRoadGraph::Mode ConsiderOnewayFeaturesAsBidirectional() const = 0;
 
   /// Clear all temporary buffers.
   virtual void ClearState() {}

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -77,6 +77,12 @@ private:
   Junction m_endJunction;
 };
 
+inline bool PointsAlmostEqualAbs(const m2::PointD & pt1, const m2::PointD & pt2)
+{
+  double constexpr kEpsilon = 1e-6;
+  return my::AlmostEqualAbs(pt1.x, pt2.x, kEpsilon) && my::AlmostEqualAbs(pt1.y, pt2.y, kEpsilon);
+}
+
 class IRoadGraph
 {
 public:
@@ -123,6 +129,21 @@ public:
     virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) = 0;
 
   protected:
+    template <typename THeadFn, typename TTailFn>
+    void ForEachEdge(RoadInfo const & roadInfo, THeadFn && headFn, TTailFn && tailFn)
+    {
+      for (size_t i = 0; i < roadInfo.m_points.size(); ++i)
+      {
+        m2::PointD const & p = roadInfo.m_points[i];
+
+        if (!PointsAlmostEqualAbs(m_cross, p))
+          continue;
+
+        tailFn(i, p);
+        headFn(i, p);
+      }
+    }
+
     m2::PointD const m_cross;
     IRoadGraph::Mode const m_mode;
     TEdgeVector & m_edges;
@@ -136,6 +157,7 @@ public:
     {
     }
 
+  private:
     // ICrossEdgesLoader overrides:
     virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) override;
   };
@@ -147,6 +169,8 @@ public:
       : ICrossEdgesLoader(cross, mode, edges)
     {
     }
+
+  private:
     // ICrossEdgesLoader overrides:
     virtual void LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo) override;
   };

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -131,17 +131,17 @@ void FindClosestEdges(IRoadGraph const & graph, m2::PointD const & point,
 RoadGraphRouter::~RoadGraphRouter() {}
 
 RoadGraphRouter::RoadGraphRouter(string const & name, Index const & index,
-                                 TCountryFileFn const & countryFileFn,
-                                 bool onewayAsBidirectional,
+                                 TCountryFileFn const & countryFileFn, bool onewayAsBidirectional,
                                  unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                                  unique_ptr<IRoutingAlgorithm> && algorithm,
                                  unique_ptr<IDirectionsEngine> && directionsEngine)
-    : m_name(name)
-    , m_countryFileFn(countryFileFn)
-    , m_index(index)
-    , m_algorithm(move(algorithm))
-    , m_roadGraph(make_unique<FeaturesRoadGraph>(index, onewayAsBidirectional, move(vehicleModelFactory)))
-    , m_directionsEngine(move(directionsEngine))
+  : m_name(name)
+  , m_countryFileFn(countryFileFn)
+  , m_index(index)
+  , m_algorithm(move(algorithm))
+  , m_roadGraph(
+        make_unique<FeaturesRoadGraph>(index, onewayAsBidirectional, move(vehicleModelFactory)))
+  , m_directionsEngine(move(directionsEngine))
 {
 }
 
@@ -259,10 +259,9 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-pedestrian", index, countryFileFn,
-                                                 true /* onewayAsBidirectional */,
-                                                 move(vehicleModelFactory), move(algorithm),
-                                                 move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter(
+      "astar-pedestrian", index, countryFileFn, true /* onewayAsBidirectional */,
+      move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
 
@@ -271,10 +270,9 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index,
-                                                 countryFileFn, true /* onewayAsBidirectional */,
-                                                 move(vehicleModelFactory),
-                                                 move(algorithm), move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter(
+      "astar-bidirectional-pedestrian", index, countryFileFn, true /* onewayAsBidirectional */,
+      move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
 
@@ -283,9 +281,9 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountr
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index));
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-bicycle", index, countryFileFn,
-                                                 false /* onewayAsBidirectional */, move(vehicleModelFactory),
-                                                 move(algorithm), move(directionsEngine)));
+  unique_ptr<IRouter> router(new RoadGraphRouter(
+      "astar-bidirectional-bicycle", index, countryFileFn, false /* onewayAsBidirectional */,
+      move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
 }  // namespace routing

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -130,8 +130,9 @@ void FindClosestEdges(IRoadGraph const & graph, m2::PointD const & point,
 
 RoadGraphRouter::~RoadGraphRouter() {}
 
-RoadGraphRouter::RoadGraphRouter(string const & name, Index & index,
+RoadGraphRouter::RoadGraphRouter(string const & name, Index const & index,
                                  TCountryFileFn const & countryFileFn,
+                                 bool onewayAsBidirectional,
                                  unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                                  unique_ptr<IRoutingAlgorithm> && algorithm,
                                  unique_ptr<IDirectionsEngine> && directionsEngine)
@@ -139,7 +140,7 @@ RoadGraphRouter::RoadGraphRouter(string const & name, Index & index,
     , m_countryFileFn(countryFileFn)
     , m_index(index)
     , m_algorithm(move(algorithm))
-    , m_roadGraph(make_unique<FeaturesRoadGraph>(index, move(vehicleModelFactory)))
+    , m_roadGraph(make_unique<FeaturesRoadGraph>(index, onewayAsBidirectional, move(vehicleModelFactory)))
     , m_directionsEngine(move(directionsEngine))
 {
 }
@@ -259,6 +260,7 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter("astar-pedestrian", index, countryFileFn,
+                                                 true /* onewayAsBidirectional */,
                                                  move(vehicleModelFactory), move(algorithm),
                                                  move(directionsEngine)));
   return router;
@@ -270,7 +272,8 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-pedestrian", index,
-                                                 countryFileFn, move(vehicleModelFactory),
+                                                 countryFileFn, true /* onewayAsBidirectional */,
+                                                 move(vehicleModelFactory),
                                                  move(algorithm), move(directionsEngine)));
   return router;
 }
@@ -280,7 +283,8 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountr
   unique_ptr<IVehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index));
-  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-bicycle", index, countryFileFn, move(vehicleModelFactory),
+  unique_ptr<IRouter> router(new RoadGraphRouter("astar-bidirectional-bicycle", index, countryFileFn,
+                                                 false /* onewayAsBidirectional */, move(vehicleModelFactory),
                                                  move(algorithm), move(directionsEngine)));
   return router;
 }

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -131,7 +131,7 @@ void FindClosestEdges(IRoadGraph const & graph, m2::PointD const & point,
 RoadGraphRouter::~RoadGraphRouter() {}
 
 RoadGraphRouter::RoadGraphRouter(string const & name, Index const & index,
-                                 TCountryFileFn const & countryFileFn, bool onewayAsBidirectional,
+                                 TCountryFileFn const & countryFileFn, IRoadGraph::Mode mode,
                                  unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                                  unique_ptr<IRoutingAlgorithm> && algorithm,
                                  unique_ptr<IDirectionsEngine> && directionsEngine)
@@ -139,8 +139,7 @@ RoadGraphRouter::RoadGraphRouter(string const & name, Index const & index,
   , m_countryFileFn(countryFileFn)
   , m_index(index)
   , m_algorithm(move(algorithm))
-  , m_roadGraph(
-        make_unique<FeaturesRoadGraph>(index, onewayAsBidirectional, move(vehicleModelFactory)))
+  , m_roadGraph(make_unique<FeaturesRoadGraph>(index, mode, move(vehicleModelFactory)))
   , m_directionsEngine(move(directionsEngine))
 {
 }
@@ -260,7 +259,7 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter(
-      "astar-pedestrian", index, countryFileFn, true /* onewayAsBidirectional */,
+      "astar-pedestrian", index, countryFileFn, IRoadGraph::Mode::IgnoreOnewayTag,
       move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
@@ -271,7 +270,7 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new PedestrianDirectionsEngine());
   unique_ptr<IRouter> router(new RoadGraphRouter(
-      "astar-bidirectional-pedestrian", index, countryFileFn, true /* onewayAsBidirectional */,
+      "astar-bidirectional-pedestrian", index, countryFileFn, IRoadGraph::Mode::IgnoreOnewayTag,
       move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }
@@ -282,7 +281,7 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountr
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index));
   unique_ptr<IRouter> router(new RoadGraphRouter(
-      "astar-bidirectional-bicycle", index, countryFileFn, false /* onewayAsBidirectional */,
+      "astar-bidirectional-bicycle", index, countryFileFn, IRoadGraph::Mode::ObeyOnewayTag,
       move(vehicleModelFactory), move(algorithm), move(directionsEngine)));
   return router;
 }

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -23,8 +23,7 @@ namespace routing
 class RoadGraphRouter : public IRouter
 {
 public:
-  RoadGraphRouter(string const & name, Index const & index,
-                  TCountryFileFn const & countryFileFn,
+  RoadGraphRouter(string const & name, Index const & index, TCountryFileFn const & countryFileFn,
                   bool onewayAsBidirectional,
                   unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                   unique_ptr<IRoutingAlgorithm> && algorithm,

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -24,7 +24,7 @@ class RoadGraphRouter : public IRouter
 {
 public:
   RoadGraphRouter(string const & name, Index const & index, TCountryFileFn const & countryFileFn,
-                  bool onewayAsBidirectional,
+                  IRoadGraph::Mode mode,
                   unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                   unique_ptr<IRoutingAlgorithm> && algorithm,
                   unique_ptr<IDirectionsEngine> && directionsEngine);

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -23,8 +23,9 @@ namespace routing
 class RoadGraphRouter : public IRouter
 {
 public:
-  RoadGraphRouter(string const & name, Index & index,
+  RoadGraphRouter(string const & name, Index const & index,
                   TCountryFileFn const & countryFileFn,
+                  bool onewayAsBidirectional,
                   unique_ptr<IVehicleModelFactory> && vehicleModelFactory,
                   unique_ptr<IRoutingAlgorithm> && algorithm,
                   unique_ptr<IDirectionsEngine> && directionsEngine);
@@ -47,7 +48,7 @@ private:
 
   string const m_name;
   TCountryFileFn const m_countryFileFn;
-  Index & m_index;
+  Index const & m_index;
   unique_ptr<IRoutingAlgorithm> const m_algorithm;
   unique_ptr<IRoadGraph> const m_roadGraph;
   unique_ptr<IDirectionsEngine> const m_directionsEngine;

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -17,11 +17,13 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 3);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
 
-  integration::TestRouteLength(route, 752.);
+  integration::TestRouteLength(route, 2350.0);
 }
 
 UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
@@ -66,4 +68,43 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   TEST_EQUAL(route.GetTurns().size(), 0, ());
   integration::TestRouteLength(route, 0.0);
+}
+
+UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87012, 37.44028),
+      {0.0, 0.0}, MercatorBounds::FromLatLon(55.87153, 37.43928));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 4);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(TurnDirection::TurnLeft);
+
+  integration::TestRouteLength(route, 420.0);
+}
+
+UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87277, 37.44002),
+      {0.0, 0.0}, MercatorBounds::FromLatLon(55.87362, 37.43853));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+  TEST_EQUAL(result, IRouter::NoError, ());
+
+  integration::TestTurnCount(route, 3);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
+
+  integration::TestRouteLength(route, 768.0);
 }

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -110,7 +110,7 @@ void RoadGraphMockSource::GetJunctionTypes(Junction const & junction, feature::T
   UNUSED_VALUE(types);
 }
 
-IRoadGraph::Mode RoadGraphMockSource::ConsiderOnewayFeaturesAsBidirectional() const
+IRoadGraph::Mode RoadGraphMockSource::GetMode() const
 {
   return IRoadGraph::Mode::IgnoreOnewayTag;
 }

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -110,7 +110,10 @@ void RoadGraphMockSource::GetJunctionTypes(Junction const & junction, feature::T
   UNUSED_VALUE(types);
 }
 
-bool RoadGraphMockSource::ConsiderOnewayFeaturesAsBidirectional() const { return true; }
+IRoadGraph::Mode RoadGraphMockSource::ConsiderOnewayFeaturesAsBidirectional() const
+{
+  return IRoadGraph::Mode::IgnoreOnewayTag;
+}
 
 FeatureID MakeTestFeatureID(uint32_t offset)
 {

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -84,7 +84,7 @@ double RoadGraphMockSource::GetMaxSpeedKMPH() const
 }
 
 void RoadGraphMockSource::ForEachFeatureClosestToCross(m2::PointD const & /* cross */,
-                                                       CrossEdgesLoader & edgesLoader) const
+                                                       ICrossEdgesLoader & edgesLoader) const
 {
   for (size_t roadId = 0; roadId < m_roads.size(); ++roadId)
     edgesLoader(MakeTestFeatureID(roadId), m_roads[roadId]);
@@ -109,6 +109,8 @@ void RoadGraphMockSource::GetJunctionTypes(Junction const & junction, feature::T
   UNUSED_VALUE(junction);
   UNUSED_VALUE(types);
 }
+
+bool RoadGraphMockSource::ConsiderOnewayFeaturesAsBidirectional() const { return true; }
 
 FeatureID MakeTestFeatureID(uint32_t offset)
 {

--- a/routing/routing_tests/road_graph_builder.hpp
+++ b/routing/routing_tests/road_graph_builder.hpp
@@ -22,7 +22,7 @@ public:
                         vector<pair<routing::Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(routing::Junction const & junction, feature::TypesHolder & types) const override;
-  routing::IRoadGraph::Mode ConsiderOnewayFeaturesAsBidirectional() const override;
+  routing::IRoadGraph::Mode GetMode() const override;
 
 private:
   vector<RoadInfo> m_roads;

--- a/routing/routing_tests/road_graph_builder.hpp
+++ b/routing/routing_tests/road_graph_builder.hpp
@@ -17,11 +17,12 @@ public:
   double GetSpeedKMPH(FeatureID const & featureId) const override;
   double GetMaxSpeedKMPH() const override;
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
-                                    CrossEdgesLoader & edgeLoader) const override;
+                                    ICrossEdgesLoader & edgeLoader) const override;
   void FindClosestEdges(m2::PointD const & point, uint32_t count,
                         vector<pair<routing::Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(routing::Junction const & junction, feature::TypesHolder & types) const override;
+  bool ConsiderOnewayFeaturesAsBidirectional() const override;
 
 private:
   vector<RoadInfo> m_roads;

--- a/routing/routing_tests/road_graph_builder.hpp
+++ b/routing/routing_tests/road_graph_builder.hpp
@@ -22,7 +22,7 @@ public:
                         vector<pair<routing::Edge, m2::PointD>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(routing::Junction const & junction, feature::TypesHolder & types) const override;
-  bool ConsiderOnewayFeaturesAsBidirectional() const override;
+  routing::IRoadGraph::Mode ConsiderOnewayFeaturesAsBidirectional() const override;
 
 private:
   vector<RoadInfo> m_roads;

--- a/routing/vehicle_model.hpp
+++ b/routing/vehicle_model.hpp
@@ -64,6 +64,7 @@ public:
   //@}
 
   double GetSpeed(feature::TypesHolder const & types) const;
+
   /// \returns true if |types| is a oneway feature.
   /// \note According to OSM tag "oneway" could have value "-1". That means it's a oneway feature
   /// with reversed geometry. In that case while map generation the geometry of such features

--- a/routing/vehicle_model.hpp
+++ b/routing/vehicle_model.hpp
@@ -64,6 +64,11 @@ public:
   //@}
 
   double GetSpeed(feature::TypesHolder const & types) const;
+  /// \returns true if |types| is a oneway feature.
+  /// \note According to OSM tag "oneway" could have value "-1". That means it's a oneway feature
+  /// with reversed geometry. In that case while map generation the geometry of such features
+  /// is reversed (the order of points is changed) so in vehicle model all oneway feature
+  /// could be considered as features with forward geometry.
   bool IsOneWay(feature::TypesHolder const & types) const;
 
   bool IsRoad(FeatureType const & f) const;


### PR DESCRIPTION
Учет односторонних дорог, как односторонних, для всех типов (highway=cycleway, highway=primary и т.д.) при велороутинге.

https://jira.mail.ru/browse/MAPSME-1274

@ygorshenin @mpimenov @Zverik PTAL