### PR TITLE
[bicycle routing] Using highway=footway for bicycle routing in Russia.

### DIFF
--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -436,6 +436,7 @@ routing::VehicleModel::InitListT const g_bicycleLimitsRussia =
   { {"highway", "residential"},    kSpeedResidentialKMpH },
   { {"highway", "living_street"},  kSpeedLivingStreetKMpH },
   { {"highway", "pedestrian"},     kSpeedPedestrianKMpH },
+  { {"highway", "footway"},        kSpeedPedestrianKMpH },
   { {"highway", "platform"},       kSpeedPlatformKMpH }, // *
 };
 


### PR DESCRIPTION
Более внимательное изучение 
http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions#Russia
показало, что для России допустимо прокладывать велосипедные маршруты по дороге с highway=footway.

https://jira.mail.ru/browse/MAPSME-1311

@Zverik @yunikkk PTAL