### PR TITLE
Fixing bicycle integration test after allowing bicycle routing on highway=footway in Russia.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -18,5 +18,5 @@ UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
-      MercatorBounds::FromLatLon(55.67695, 37.56220), 6938.0);
+      MercatorBounds::FromLatLon(55.67695, 37.56220), 7570.0);
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -17,13 +17,9 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 3);
-
+  integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
-
-  integration::TestRouteLength(route, 2350.0);
+  integration::TestRouteLength(route, 1054.0);
 }
 
 UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
@@ -54,7 +50,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 
   integration::TestTurnCount(route, 1);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::GoStraight);
 }
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)


### PR DESCRIPTION
Починка интеграционных тестов на велосипедную навигацию после ряда изменений:
- запрет для движения против хода на велосипеде для oneway дорог;
- разрешение ездить по пешеходным дорогам велосипедистам;
- выключение коррекции угла по исходящим дорогам для велосипедных маршрутов.

https://jira.mail.ru/browse/MAPSME-1376