### PR TITLE
Bicycle routing by stairs in Russian and Ukraine.

### DIFF
--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -435,6 +435,7 @@ routing::VehicleModel::InitListT const g_bicycleLimitsRussia =
   { {"highway", "cycleway"},       kSpeedCyclewayKMpH },
   { {"highway", "residential"},    kSpeedResidentialKMpH },
   { {"highway", "living_street"},  kSpeedLivingStreetKMpH },
+  { {"highway", "steps"},          kSpeedStepsKMpH }, // *
   { {"highway", "pedestrian"},     kSpeedPedestrianKMpH },
   { {"highway", "footway"},        kSpeedPedestrianKMpH },
   { {"highway", "platform"},       kSpeedPlatformKMpH }, // *
@@ -524,6 +525,7 @@ routing::VehicleModel::InitListT const g_bicycleLimitsUkraine =
   { {"highway", "cycleway"},       kSpeedCyclewayKMpH },
   { {"highway", "residential"},    kSpeedResidentialKMpH },
   { {"highway", "living_street"},  kSpeedLivingStreetKMpH },
+  { {"highway", "steps"},          kSpeedStepsKMpH }, // *
   { {"highway", "pedestrian"},     kSpeedPedestrianKMpH },
   { {"highway", "footway"},        kSpeedFootwayKMpH },
   { {"highway", "platform"},       kSpeedPlatformKMpH }, // *

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -20,3 +20,10 @@ UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
       integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
       MercatorBounds::FromLatLon(55.67695, 37.56220), 7570.0);
 }
+
+UNIT_TEST(RussiaDomodedovoSteps)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.44020, 37.77409), {0., 0.},
+      MercatorBounds::FromLatLon(55.43972, 37.77254), 123.0);
+}


### PR DESCRIPTION
Данный PR разрешает движение велосипедистов по лестницам в России и Украине (в остальных странах и было разрешено), но делает лестницам большой вес. Т.е. мы стараемся не вести вело маршрут через лестницы. Ведем, только если объезд очень далек.

Пояснение. Согласно правилам России и Украины велосипедист может стать пешеходам (спешившись) и идти по лестницам. 

Выдержки из ПДД, указывающие на допустимость движения пешехода с велосипедом в руках по пешеходной лестнице.

Россия:
1.2. В Правилах используются следующие основные понятия и термины:
...
"Пешеход" - лицо, находящееся вне транспортного средства на дороге либо на пешеходной или велопешеходной дорожке и не производящее на них работу. К пешеходам приравниваются лица, передвигающиеся в инвалидных колясках без двигателя, ведущие велосипед, мопед, мотоцикл, везущие санки, тележку, детскую или инвалидную коляску, а также использующие для передвижения роликовые коньки, самокаты и иные аналогичные средства.

Украина:
4.2.Пешеходы, переносящие громоздкие предметы, или лица, передвигающиеся в инвалидных колясках без двигателя, ведущие мотоцикл, велосипед или мопед, везущие санки, тележки и т.п., если их движение по тротуарам, пешеходным или велосипедным дорожкам или обочинам создает препятствия для других участников движения, могут двигаться по краю проезжей части в один ряд.

@Zverik PTAL