### PR TITLE
[tests] Correctly process empty strings in to_whatever

### DIFF
--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -238,6 +238,9 @@ UNIT_TEST(to_uint64)
   uint64_t i;
   string s;
 
+  s = "";
+  TEST(!strings::to_uint64(s, i), ());
+
   s = "0";
   TEST(strings::to_uint64(s, i), ());
   TEST_EQUAL(0, i, ());

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -46,7 +46,7 @@ namespace
 template <typename T, typename TResult>
 bool IntegerCheck(char const * start, char const * stop, T x, TResult & out)
 {
-  if (errno != EINVAL && *stop == 0)
+  if (errno != EINVAL && *stop == 0 && start != stop)
   {
     out = static_cast<TResult>(x);
     return static_cast<T>(out) == x;
@@ -80,7 +80,7 @@ bool to_uint64(char const * s, uint64_t & i)
 #else
   i = strtoull(s, &stop, 10);
 #endif
-  return *stop == 0;
+  return *stop == 0 && s != stop;
 }
 
 bool to_int64(char const * s, int64_t & i)
@@ -91,7 +91,7 @@ bool to_int64(char const * s, int64_t & i)
 #else
   i = strtoll(s, &stop, 10);
 #endif
-  return *stop == 0;
+  return *stop == 0 && s != stop;
 }
 
 bool to_double(char const * s, double & d)


### PR DESCRIPTION
Интересно, работали ли когда-нибудь проверки на пустые строки в `to_int` и им подобных? Поправил здесь.