### PR TITLE
[tests] Fix user stats and building level validation tests

### DIFF
--- a/editor/editor_tests/user_stats_test.cpp
+++ b/editor/editor_tests/user_stats_test.cpp
@@ -9,7 +9,8 @@ namespace editor
 namespace
 {
 auto constexpr kEditorTestDir = "editor-tests";
-auto constexpr kUserName = "Vladimir BI";
+// This user has made only 9 changes and then renamed himself, so there will be no further edits from him.
+auto constexpr kUserName = "Nikita Bokiy";
 
 UNIT_TEST(UserStatsLoader_Smoke)
 {
@@ -21,7 +22,6 @@ UNIT_TEST(UserStatsLoader_Smoke)
   }
 
   {
-    // This user made only two changes and the possibility of further changes is very low.
     UserStatsLoader statsLoader;
 
     statsLoader.Update(kUserName);
@@ -32,8 +32,8 @@ UNIT_TEST(UserStatsLoader_Smoke)
     TEST(userStats.GetRank(rank), ());
     TEST(userStats.GetChangesCount(changesCount), ());
 
-    TEST_GREATER_OR_EQUAL(rank, 5800, ());
-    TEST_EQUAL(changesCount, 2, ());
+    TEST_GREATER_OR_EQUAL(rank, 2100, ());
+    TEST_EQUAL(changesCount, 9, ());
   }
 
   // This test checks if user stats info was stored in setting.
@@ -49,8 +49,8 @@ UNIT_TEST(UserStatsLoader_Smoke)
     TEST(userStats.GetRank(rank), ());
     TEST(userStats.GetChangesCount(changesCount), ());
 
-    TEST_GREATER_OR_EQUAL(rank, 5800, ());
-    TEST_EQUAL(changesCount, 2, ());
+    TEST_GREATER_OR_EQUAL(rank, 2100, ());
+    TEST_EQUAL(changesCount, 9, ());
   }
 }
 }  // namespace

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -197,9 +197,11 @@ bool EditableMapObject::ValidateBuildingLevels(string const & buildingLevels)
 {
   if (buildingLevels.size() > 18 /* max number of digits in uint_64 */)
     return false;
+  if (buildingLevels.empty())
+    return true;
 
   uint64_t levels;
-  return strings::to_uint64(buildingLevels, levels) && levels <= kMaximumLevelsEditableByUsers;
+  return strings::to_uint64(buildingLevels, levels) && levels > 0 && levels <= kMaximumLevelsEditableByUsers;
 }
 
 // static

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -28,6 +28,7 @@ UNIT_TEST(EditableMapObject_ValidateBuildingLevels)
   TEST(EditableMapObject::ValidateBuildingLevels("7"), ());
   TEST(EditableMapObject::ValidateBuildingLevels("17"), ());
   TEST(EditableMapObject::ValidateBuildingLevels("25"), ());
+  TEST(!EditableMapObject::ValidateBuildingLevels("0"), ());
   TEST(!EditableMapObject::ValidateBuildingLevels("26"), ());
   TEST(!EditableMapObject::ValidateBuildingLevels("ab"), ());
   TEST(!EditableMapObject::ValidateBuildingLevels(


### PR DESCRIPTION
Заодно запретил вводить «0» в высоту здания. Ибо нефиг.