### PR TITLE
Working on better performance of pedestrian routing.

### DIFF
--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -32,7 +32,7 @@ namespace osm
 class EditableMapObject;
 }
 
-using TFeatureBuf = buffer_vector<m2::PointD, 8>;
+using TPointsBuf = buffer_vector<m2::PointD, 8>;
 
 /// Base feature class for storing common data (without geometry).
 class FeatureBase
@@ -345,7 +345,7 @@ public:
 
   void SwapGeometry(FeatureType & r);
 
-  inline void SwapPoints(TFeatureBuf & points) const
+  inline void SwapPoints(TPointsBuf & points) const
   {
     ASSERT(m_bPointsParsed, ());
     return m_points.swap(points);
@@ -354,7 +354,8 @@ public:
 private:
   void ParseGeometryAndTriangles(int scale) const;
 
-  mutable TFeatureBuf m_points, m_triangles;
+  mutable TPointsBuf m_points;
+  mutable TPointsBuf m_triangles;
   mutable feature::Metadata m_metadata;
 
   mutable bool m_bHeader2Parsed, m_bPointsParsed, m_bTrianglesParsed, m_bMetadataParsed;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -32,6 +32,8 @@ namespace osm
 class EditableMapObject;
 }
 
+using TFeatureBuf = buffer_vector<m2::PointD, 8>;
+
 /// Base feature class for storing common data (without geometry).
 class FeatureBase
 {
@@ -343,7 +345,7 @@ public:
 
   void SwapGeometry(FeatureType & r);
 
-  inline void SwapPoints(buffer_vector<m2::PointD, 8> & points) const
+  inline void SwapPoints(TFeatureBuf & points) const
   {
     ASSERT(m_bPointsParsed, ());
     return m_points.swap(points);
@@ -352,12 +354,7 @@ public:
 private:
   void ParseGeometryAndTriangles(int scale) const;
 
-  // For better result this value should be greater than 17
-  // (number of points in inner triangle-strips).
-  static const size_t static_buffer = 8;
-
-  typedef buffer_vector<m2::PointD, static_buffer> points_t;
-  mutable points_t m_points, m_triangles;
+  mutable TFeatureBuf m_points, m_triangles;
   mutable feature::Metadata m_metadata;
 
   mutable bool m_bHeader2Parsed, m_bPointsParsed, m_bTrianglesParsed, m_bMetadataParsed;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -343,7 +343,7 @@ public:
 
   void SwapGeometry(FeatureType & r);
 
-  inline void SwapPoints(buffer_vector<m2::PointD, 32> & points) const
+  inline void SwapPoints(buffer_vector<m2::PointD, 8> & points) const
   {
     ASSERT(m_bPointsParsed, ());
     return m_points.swap(points);
@@ -354,7 +354,7 @@ private:
 
   // For better result this value should be greater than 17
   // (number of points in inner triangle-strips).
-  static const size_t static_buffer = 32;
+  static const size_t static_buffer = 8;
 
   typedef buffer_vector<m2::PointD, static_buffer> points_t;
   mutable points_t m_points, m_triangles;

--- a/indexer/feature_loader.cpp
+++ b/indexer/feature_loader.cpp
@@ -162,7 +162,7 @@ void LoaderCurrent::ParseHeader2()
 
       char const * start = static_cast<char const *>(src.PtrC());
 
-      TFeatureBuf points;
+      TPointsBuf points;
       src = ArrayByteSource(serial::LoadInnerTriangles(start, trgCount, cp, points));
 
       m_pF->m_innerStats.m_strips = static_cast<uint32_t>(src.PtrC() - start);
@@ -209,7 +209,7 @@ uint32_t LoaderCurrent::ParseGeometry(int scale)
     {
       // filter inner geometry
 
-      TFeatureBuf points;
+      TPointsBuf points;
       points.reserve(count);
 
       int const scaleIndex = GetScaleIndex(scale);

--- a/indexer/feature_loader.cpp
+++ b/indexer/feature_loader.cpp
@@ -162,7 +162,7 @@ void LoaderCurrent::ParseHeader2()
 
       char const * start = static_cast<char const *>(src.PtrC());
 
-      FeatureType::points_t points;
+      TFeatureBuf points;
       src = ArrayByteSource(serial::LoadInnerTriangles(start, trgCount, cp, points));
 
       m_pF->m_innerStats.m_strips = static_cast<uint32_t>(src.PtrC() - start);
@@ -209,7 +209,7 @@ uint32_t LoaderCurrent::ParseGeometry(int scale)
     {
       // filter inner geometry
 
-      FeatureType::points_t points;
+      TFeatureBuf points;
       points.reserve(count);
 
       int const scaleIndex = GetScaleIndex(scale);

--- a/indexer/geometry_serialization.hpp
+++ b/indexer/geometry_serialization.hpp
@@ -38,7 +38,7 @@ namespace serial
   //@}
 
   typedef buffer_vector<uint64_t, 32> DeltasT;
-  typedef buffer_vector<m2::PointD, 32> OutPointsT;
+  typedef buffer_vector<m2::PointD, 8> OutPointsT;
 
   void Encode(EncodeFunT fn, vector<m2::PointD> const & points, CodingParams const & params,
               DeltasT & deltas);

--- a/indexer/geometry_serialization.hpp
+++ b/indexer/geometry_serialization.hpp
@@ -39,7 +39,7 @@ namespace serial
   //@}
 
   typedef buffer_vector<uint64_t, 32> DeltasT;
-  typedef TFeatureBuf OutPointsT;
+  typedef TPointsBuf OutPointsT;
 
   void Encode(EncodeFunT fn, vector<m2::PointD> const & points, CodingParams const & params,
               DeltasT & deltas);

--- a/indexer/geometry_serialization.hpp
+++ b/indexer/geometry_serialization.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "indexer/feature.hpp"
 #include "indexer/geometry_coding.hpp"
 #include "indexer/tesselator_decl.hpp"
 #include "indexer/point_to_int64.hpp"
@@ -38,7 +39,7 @@ namespace serial
   //@}
 
   typedef buffer_vector<uint64_t, 32> DeltasT;
-  typedef buffer_vector<m2::PointD, 8> OutPointsT;
+  typedef TFeatureBuf OutPointsT;
 
   void Encode(EncodeFunT fn, vector<m2::PointD> const & points, CodingParams const & params,
               DeltasT & deltas);

--- a/indexer/old/feature_loader_101.cpp
+++ b/indexer/old/feature_loader_101.cpp
@@ -326,7 +326,7 @@ void LoaderImpl::ParseHeader2()
 
       char const * start = src.PtrC();
 
-      FeatureType::points_t points;
+      TFeatureBuf points;
       src = ArrayByteSource(serial::LoadInnerTriangles(
                               start, trgCount, GetDefCodingParams(), points));
 
@@ -369,7 +369,7 @@ uint32_t LoaderImpl::ParseGeometry(int scale)
       // filter inner geometry
 
       size_t const count = m_pF->m_points.size();
-      FeatureType::points_t points;
+      TFeatureBuf points;
       points.reserve(count);
 
       int const scaleIndex = GetScaleIndex(scale);

--- a/indexer/old/feature_loader_101.cpp
+++ b/indexer/old/feature_loader_101.cpp
@@ -326,7 +326,7 @@ void LoaderImpl::ParseHeader2()
 
       char const * start = src.PtrC();
 
-      TFeatureBuf points;
+      TPointsBuf points;
       src = ArrayByteSource(serial::LoadInnerTriangles(
                               start, trgCount, GetDefCodingParams(), points));
 
@@ -369,7 +369,7 @@ uint32_t LoaderImpl::ParseGeometry(int scale)
       // filter inner geometry
 
       size_t const count = m_pF->m_points.size();
-      TFeatureBuf points;
+      TPointsBuf points;
       points.reserve(count);
 
       int const scaleIndex = GetScaleIndex(scale);

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -18,7 +18,7 @@ namespace routing
 
 namespace
 {
-uint32_t constexpr kPowOfTwoForFeatureCacheSize = 10; // cache contains 2 ^ kPowOfTwoForFeatureCacheSize elements
+uint32_t constexpr kPowOfTwoForFeatureCacheSize = 14; // cache contains 2 ^ kPowOfTwoForFeatureCacheSize elements
 
 double constexpr kMwmRoadCrossingRadiusMeters = 2.0;
 

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -100,7 +100,7 @@ public:
     RoadInfo(RoadInfo const &) = default;
     RoadInfo & operator=(RoadInfo const &) = default;
 
-    buffer_vector<m2::PointD, 32> m_points;
+    buffer_vector<m2::PointD, 8> m_points;
     double m_speedKMPH;
     bool m_bidirectional;
   };

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -4,6 +4,7 @@
 
 #include "base/string_utils.hpp"
 
+#include "indexer/feature.hpp"
 #include "indexer/feature_data.hpp"
 
 #include "std/initializer_list.hpp"
@@ -100,7 +101,7 @@ public:
     RoadInfo(RoadInfo const &) = default;
     RoadInfo & operator=(RoadInfo const &) = default;
 
-    buffer_vector<m2::PointD, 8> m_points;
+    TFeatureBuf m_points;
     double m_speedKMPH;
     bool m_bidirectional;
   };

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -101,7 +101,7 @@ public:
     RoadInfo(RoadInfo const &) = default;
     RoadInfo & operator=(RoadInfo const &) = default;
 
-    TFeatureBuf m_points;
+    TPointsBuf m_points;
     double m_speedKMPH;
     bool m_bidirectional;
   };


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-1502

Ускорение прокладки пешеходных и вело маршрутов простыми способами.

Идея данного изменения в следующем:
1.
Мы уменьшаем размер статического буфера RoadInfo::m_points: 
был sizeof(PointD) \* 32 = 512B
стал sizeof(PointD) \* 8 = 128B
На основании того факта, что размер фичи (для mwm с крупными городами) в среднем 4-5 сегментов.

2.
Увеличиваем размер кеша для каждой mwm, в которая задействована в пешеходном (вело) роутинге кол-во структур (Data), которые состоят из uint32_t и RoadInfo в 16 раз. 

Т.о. при прокладке пешего(вело) маршрута раньше выделялось на одну mwm:
2^10 \* (sizeof(uint32_t) + sizeof(RoadInfo)) = 
2^10 \* (sizeof(uint32_t) + sizeof(buffer_vector<m2::PointD, 32>) + sizeof(double) + sizeof(bool)) = 
2^10 \* (sizeof(uint32_t) + sizeof(PointD) \* 32 + sizeof(size_t) + sizeof(vector<PointD>) + sizeof(double) + sizeof(bool)) ~
2^10 \* (8 + 512 + 8 + 3*8 + 8 + 8) = 1024 \* 568 = 568K

Стало после изменений:
2^14 \* (sizeof(uint32_t) + sizeof(RoadInfo)) = 
2^14 \* (sizeof(uint32_t) + sizeof(buffer_vector<m2::PointD, 8>) + sizeof(double) + sizeof(bool)) = 
2^14 \* (sizeof(uint32_t) + sizeof(PointD) \* 8 + sizeof(size_t) + sizeof(vector<PointD>) + sizeof(double) + sizeof(bool)) ~
2^14 \* (8 + 128 + 8 + 3*8 + 8 + 8) = 2944K

Учитывая, что это используется обычно для одной mwm, думаю, расход допустим.

Тесты на деск топ и Android показали, что данный расход желателен. Мы получаем ощутимый выигрыш на длинных и средних маршрутах.

Тесты на Андроид. Релиз. Время прокладки ряда одинаковых пеших маршрутов
master:
3.7516, 15.242, 48.5277, 57.9181

master + данный PR:
3.15811, 14.2245, 44.0729, 53.7908

master + данный PR, но kPowOfTwoForFeatureCacheSize = 12
3.59588, 13.9481, 45.5906, 55.4822

master + данный PR, но kPowOfTwoForFeatureCacheSize = 10
3.83688, 14.5216, 49.3716, 56.5522

Картина показательна. Она повторяется на pedestrian_routing_tests на деск топ debug.

Все результаты исследований:
https://docs.google.com/spreadsheets/d/1991dXnNJ1TOJ6GUa0KCKfOgigPYTA5jJvTi0wMGXiEw/edit#gid=1698955389
https://docs.google.com/document/d/1bTzzraxv9ZFKBqHhSGbrZZ1pZ0xrnhFZsseReSaa3JY

@ygorshenin @mpimenov @kshalnev PTAL
