### PR TITLE
[search] Fixed cancellation of outdated queries.

### DIFF
--- a/search/engine.cpp
+++ b/search/engine.cpp
@@ -284,6 +284,7 @@ void Engine::DoSearch(SearchParams const & params, m2::RectD const & viewport,
   bool const viewportSearch = params.GetMode() == Mode::Viewport;
 
   // Initialize query processor.
+  processor.Reset();
   processor.Init(viewportSearch);
   handle->Attach(processor);
   MY_SCOPE_GUARD(detach, [&handle]

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -70,7 +70,7 @@ class TokenSlice;
 // part is to find all paths through this layered graph and report all
 // features from the lowest layer, that are reachable from the
 // highest layer.
-class Geocoder : public my::Cancellable
+class Geocoder
 {
 public:
   struct Params : public QueryParams
@@ -146,9 +146,10 @@ public:
 #endif
   };
 
-  Geocoder(Index & index, storage::CountryInfoGetter const & infoGetter);
+  Geocoder(Index & index, storage::CountryInfoGetter const & infoGetter,
+           my::Cancellable const & cancellable);
 
-  ~Geocoder() override;
+  ~Geocoder();
 
   // Sets search query params.
   void SetParams(Params const & params);
@@ -215,7 +216,7 @@ private:
   // Throws CancelException if cancelled.
   inline void BailIfCancelled()
   {
-    ::search::BailIfCancelled(static_cast<my::Cancellable const &>(*this));
+    ::search::BailIfCancelled(m_cancellable);
   }
 
   // Tries to find all countries and states in a search query and then
@@ -311,6 +312,8 @@ private:
   Index & m_index;
 
   storage::CountryInfoGetter const & m_infoGetter;
+
+  my::Cancellable const & m_cancellable;
 
   // Geocoder params.
   Params m_params;

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -245,8 +245,6 @@ Processor::Processor(Index & index, CategoriesHolder const & categories,
 
 void Processor::Init(bool viewportSearch)
 {
-  Reset();
-
   m_tokens.clear();
   m_prefix.clear();
   m_preRanker.Clear();

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -95,14 +95,10 @@ ftypes::Type GetLocalityIndex(feature::TypesHolder const & types)
   case NONE:
   case COUNTRY:
   case STATE:
-  case CITY:
-    return type;
-  case TOWN:
-    return CITY;
-  case VILLAGE:
-    return NONE;
-  case LOCALITY_COUNT:
-    return type;
+  case CITY: return type;
+  case TOWN: return CITY;
+  case VILLAGE: return NONE;
+  case LOCALITY_COUNT: return type;
   }
 }
 
@@ -231,7 +227,7 @@ Processor::Processor(Index & index, CategoriesHolder const & categories,
   , m_viewportSearch(false)
   , m_keepHouseNumberInQuery(true)
   , m_preRanker(kPreResultsCount)
-  , m_geocoder(index, infoGetter)
+  , m_geocoder(index, infoGetter, static_cast<my::Cancellable const &>(*this))
   , m_reverseGeocoder(index)
 {
   // Initialize keywords scorer.
@@ -259,12 +255,7 @@ void Processor::Init(bool viewportSearch)
 
 void Processor::SetViewport(m2::RectD const & viewport, bool forceUpdate)
 {
-  Reset();
-
-  TMWMVector mwmsInfo;
-  m_index.GetMwmsInfo(mwmsInfo);
-
-  SetViewportByIndex(mwmsInfo, viewport, CURRENT_V, forceUpdate);
+  SetViewportByIndex(viewport, CURRENT_V, forceUpdate);
 }
 
 void Processor::SetPreferredLocale(string const & locale)
@@ -403,8 +394,7 @@ m2::RectD Processor::GetPivotRect() const
   return NormalizeViewport(viewport);
 }
 
-void Processor::SetViewportByIndex(TMWMVector const & mwmsInfo, m2::RectD const & viewport,
-                                   size_t idx, bool forceUpdate)
+void Processor::SetViewportByIndex(m2::RectD const & viewport, size_t idx, bool forceUpdate)
 {
   ASSERT(idx < COUNT_V, (idx));
 
@@ -1136,7 +1126,8 @@ void Processor::InitParams(QueryParams & params)
 
   // Add names of categories (and synonyms).
   Classificator const & c = classif();
-  auto addSyms = [&](size_t i, uint32_t t) {
+  auto addSyms = [&](size_t i, uint32_t t)
+  {
     QueryParams::TSynonymsVector & v = params.GetTokens(i);
 
     uint32_t const index = c.GetIndexForType(t);
@@ -1177,10 +1168,6 @@ void Processor::ClearCaches()
   m_locality.ClearCache();
   m_geocoder.ClearCaches();
 }
-
-void Processor::Reset() { m_geocoder.Reset(); }
-
-void Processor::Cancel() { m_geocoder.Cancel(); }
 
 void Processor::SuggestStrings(Results & res)
 {

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -117,10 +117,6 @@ public:
 
   void ClearCaches();
 
-  // my::Cancellable overrides:
-  void Reset() override;
-  void Cancel() override;
-
 protected:
   enum ViewportID
   {
@@ -151,8 +147,7 @@ protected:
   m2::PointD GetPivotPoint() const;
   m2::RectD GetPivotRect() const;
 
-  void SetViewportByIndex(TMWMVector const & mwmsInfo, m2::RectD const & viewport, size_t idx,
-                          bool forceUpdate);
+  void SetViewportByIndex(m2::RectD const & viewport, size_t idx, bool forceUpdate);
   void ClearCache(size_t ind);
 
   template <class T>


### PR DESCRIPTION
The problem is that SetViewport calls Reset(), which, in turn, resets the state of the cancellable. Therefore, all cancel signals that come after Processor::Init() but before Processor::SetViewport() are lost.