### PR TITLE
Fix for some integration tests:

### DIFF
--- a/tools/integration_tests_runner.py
+++ b/tools/integration_tests_runner.py
@@ -20,7 +20,7 @@ from run_desktop_tests import tests_on_disk
 __author__ = 't.danshin'
 
 
-TEMPFOLDER_TESTS = ["search_integration_tests"]
+TEMPFOLDER_TESTS = ["search_integration_tests", "storage_integration_tests"]
 
 
 class IntegrationRunner:

--- a/tools/run_desktop_tests.py
+++ b/tools/run_desktop_tests.py
@@ -157,6 +157,7 @@ class TestRunner:
                                    format(tests_path=self.workspace_path, test_file=test_file_with_keys, logfile=self.logfile),
                                    shell=True,
                                    stdout=subprocess.PIPE)
+            logging.info("Pid: {0}".format(process.pid))
 
             process.wait()
 


### PR DESCRIPTION
* Added storage integration tests to those that require temporary forlders for running normally;
* Added logging the process id for the shells running our tests (needed when a test hangs);