### PR TITLE
[search] Removed one aggressive house number check and replaced another.

### DIFF
--- a/search/features_layer_matcher.hpp
+++ b/search/features_layer_matcher.hpp
@@ -255,12 +255,6 @@ private:
       if (m_postcodes && !m_postcodes->GetBit(id))
         return false;
 
-      // HouseNumbersMatch() calls are expensive, so following code
-      // tries to reduce the number of calls. The most important
-      // optimization: as first tokens from the house-number part of
-      // the query and feature's house numbers must be numbers, their
-      // first symbols must be the same.
-
       if (!loaded)
       {
         GetByIndex(id, feature);
@@ -271,8 +265,6 @@ private:
         return false;
 
       strings::UniString const houseNumber(strings::MakeUniString(feature.GetHouseNumber()));
-      if (!feature::IsHouseNumber(houseNumber))
-        return false;
       return house_numbers::HouseNumbersMatch(houseNumber, queryParse);
     };
 

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1095,7 +1095,7 @@ void Geocoder::GreedilyMatchStreets()
       if (IsStreetSynonymPrefix(token))
         continue;
 
-      if (feature::IsHouseNumber(token))
+      if (house_numbers::LooksLikeHouseNumber(token, true /* isPrefix */))
       {
         CreateStreetsLayerAndMatchLowerLayers(startToken, curToken, allFeatures);
         lastStopToken = curToken;

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1095,7 +1095,8 @@ void Geocoder::GreedilyMatchStreets()
       if (IsStreetSynonymPrefix(token))
         continue;
 
-      if (house_numbers::LooksLikeHouseNumber(token, true /* isPrefix */))
+      bool const isPrefix = curToken >= m_params.m_tokens.size();
+      if (house_numbers::LooksLikeHouseNumber(token, isPrefix))
       {
         CreateStreetsLayerAndMatchLowerLayers(startToken, curToken, allFeatures);
         lastStopToken = curToken;

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -366,6 +366,54 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo)
   }
 }
 
+UNIT_CLASS_TEST(ProcessorTest, TestHouseNumbers)
+{
+  string const countryName = "HouseNumberLand";
+
+  TestCity greenCity(m2::PointD(0, 0), "Зеленоград", "ru", 100 /* rank */);
+
+  TestStreet street(
+      vector<m2::PointD>{m2::PointD(0.0, -10.0), m2::PointD(0, 0), m2::PointD(5.0, 5.0)},
+      "Генерала Генералова", "ru");
+
+  TestBuilding building0(m2::PointD(2.0, 2.0), "", "100", "en");
+  TestBuilding building1(m2::PointD(3.0, 3.0), "", "к200", "ru");
+  TestBuilding building2(m2::PointD(4.0, 4.0), "", "300 строение 400", "ru");
+
+  BuildWorld([&](TestMwmBuilder & builder) { builder.Add(greenCity); });
+  auto countryId = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
+    builder.Add(street);
+    builder.Add(building0);
+    builder.Add(building1);
+    builder.Add(building2);
+  });
+
+  {
+    TRules rules{ExactMatch(countryId, building0)};
+    TEST(ResultsMatch("Зеленоград генералова к100", "ru", rules), ());
+  }
+  {
+    TRules rules{ExactMatch(countryId, building1)};
+    TEST(ResultsMatch("Зеленоград генералова к200", "ru", rules), ());
+  }
+  {
+    TRules rules{ExactMatch(countryId, building1)};
+    TEST(ResultsMatch("Зеленоград к200 генералова", "ru", rules), ());
+  }
+  {
+    TRules rules{ExactMatch(countryId, building2)};
+    TEST(ResultsMatch("Зеленоград 300 строение 400 генералова", "ru", rules), ());
+  }
+  {
+    TRules rules{};
+    TEST(ResultsMatch("Зеленоград генералова строе 300", "ru", rules), ());
+  }
+  {
+    TRules rules{ExactMatch(countryId, building2)};
+    TEST(ResultsMatch("Зеленоград генералова 300 строе", "ru", rules), ());
+  }
+}
+
 UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
 {
   string const countryName = "Russia";

--- a/search/search_tests/house_numbers_matcher_test.cpp
+++ b/search/search_tests/house_numbers_matcher_test.cpp
@@ -157,6 +157,10 @@ UNIT_TEST(LooksLikeHouseNumber_Smoke)
 
   TEST(LooksLikeHouseNumber("39 строе", true /* isPrefix */), ());
   TEST(!LooksLikeHouseNumber("39 строе", false /* isPrefix */), ());
+  TEST(LooksLikeHouseNumber("39", true /* isPrefix */), ());
+  TEST(LooksLikeHouseNumber("39", false /* isPrefix */), ());
+  TEST(LooksLikeHouseNumber("строе", true /* isPrefix */), ());
+  TEST(!LooksLikeHouseNumber("строе", false /* isPrefix */), ());
 
   TEST(LooksLikeHouseNumber("дом ", true /* isPrefix */), ());
   TEST(LooksLikeHouseNumber("дом ", false /* isPrefix */), ());


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-1471

This CL slows down the worst case searches.
Below are the results of several runs on queries.txt.

Before:
Maximum response time: 6.546s
Average response time: 0.493s (std. dev. 1.035s)
Maximum response time: 6.713s
Average response time: 0.506s (std. dev. 1.061s)
Maximum response time: 6.548s
Average response time: 0.494s (std. dev. 1.034s)

After:
Maximum response time: 7.735s
Average response time: 0.573s (std. dev. 1.222s)
Maximum response time: 6.528s
Average response time: 0.497s (std. dev. 1.032s)
Maximum response time: 6.877s
Average response time: 0.514s (std. dev. 1.084s)
