### PR TITLE
[generator] Switch housename and housenumber if needed

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -258,6 +258,21 @@ bool FeatureParams::AddHouseName(string const & s)
   if (house.IsEmpty() && AddHouseNumber(s))
     return true;
 
+  // If we got a clear number, replace the house number with it.
+  // Example: housename=16th Street, housenumber=34
+  if (strings::is_number(s))
+  {
+    string housename(house.Get());
+    if (AddHouseNumber(s))
+    {
+      // Duplicating code to avoid changing the method header.
+      string dummy;
+      if (!name.GetString(StringUtf8Multilang::kDefaultCode, dummy))
+        name.AddString(StringUtf8Multilang::kDefaultCode, housename);
+      return true;
+    }
+  }
+
   // Add as a default name if we don't have it yet.
   string dummy;
   if (!name.GetString(StringUtf8Multilang::kDefaultCode, dummy))


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-1247

Если сначала приходит `housename=улица с 41слом`, то она забивает номер дома. Теперь смотрим, если настоящий номер дома пришёл вторым, меняем их местами. Проверка очень простая, но и название улицы с числом пихают в `addr:housename` нечасто.