### PR TITLE
[DNM] Prototype of correct calculation fake edges taking into account road direction.

### DIFF
--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -237,7 +237,7 @@ void IRoadGraph::ResetFakes()
   m_ingoingEdges.clear();
 }
 
-void IRoadGraph::AddFakeEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinity)
+void IRoadGraph::AddFakeOutgoingEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinity)
 {
   for (auto const & v : vicinity)
   {
@@ -269,7 +269,7 @@ void IRoadGraph::AddFakeEdges(Junction const & junction, vector<pair<Edge, m2::P
       Edge edgeToSplit = closestEdge;
 
       vector<Edge> splittingToFakeEdges;
-      if (HasBeenSplitToFakes(closestEdge, splittingToFakeEdges))
+      if (HasBeenSplitToOutgoingFakes(closestEdge, splittingToFakeEdges))
       {
         // Edge AB has already been split by some point Q and this point P
         // should split AB one more time
@@ -344,7 +344,7 @@ void IRoadGraph::AddFakeEdges(Junction const & junction, vector<pair<Edge, m2::P
     my::SortUnique(m.second);
 }
 
-bool IRoadGraph::HasBeenSplitToFakes(Edge const & edge, vector<Edge> & fakeEdges) const
+bool IRoadGraph::HasBeenSplitToOutgoingFakes(Edge const & edge, vector<Edge> & fakeEdges) const
 {
   vector<Edge> tmp;
 
@@ -381,8 +381,6 @@ bool IRoadGraph::HasBeenSplitToFakes(Edge const & edge, vector<Edge> & fakeEdges
   return true;
 }
 
-//=================
-
 void IRoadGraph::AddFakeIngoingEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinity)
 {
   for (auto const & v : vicinity)
@@ -401,11 +399,11 @@ void IRoadGraph::AddFakeIngoingEdges(Junction const & junction, vector<pair<Edge
       // Here AB is a feature, M is a junction, which is projected to A (where P is projection),
       // P is the closest junction of the feature to the junction M.
 
-      // Add outgoing edges for M.
+      // Add ingoing edges for M.
       TEdgeVector & edgesM = m_ingoingEdges[p]; //*
       edgesM.push_back(Edge::MakeFake(junction, p)); //* delete this section
 
-      // Add outgoing edges for P.
+      // Add ingoing edges for P.
       TEdgeVector & edgesP = m_ingoingEdges[junction]; //*
       GetRegularIngoingEdges(junction, edgesP); //*
       edgesP.push_back(Edge::MakeFake(p, junction)); //*
@@ -462,13 +460,13 @@ void IRoadGraph::AddFakeIngoingEdges(Junction const & junction, vector<pair<Edge
       Edge const bp(ab.GetFeatureId(), false /* forward */, ab.GetSegId(), ab.GetEndJunction(), p); //*
       Edge const mp = Edge::MakeFake(junction, p); //*
 
-      // Add outgoing edges to point P.
+      // Add ingoing edges to point P.
       TEdgeVector & edgesP = m_ingoingEdges[p]; //*
       edgesP.push_back(ap);
       edgesP.push_back(bp);
       edgesP.push_back(mp);
 
-      // Add outgoing edges for point M.
+      // Add ingoing edges for point M.
       m_ingoingEdges[junction].push_back(mp.GetReverseEdge()); //*
 
       // Replace AB edge with AP edge.

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -195,7 +195,7 @@ public:
 
   /// Adds fake edges from fake position rp to real vicinity
   /// positions.
-  void AddFakeEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinities);
+  void AddFakeOutgoingEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinities);
   void AddFakeIngoingEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinity);
 
   /// Returns RoadInfo for a road corresponding to featureId.
@@ -245,7 +245,7 @@ private:
   void GetFakeIngoingEdges(Junction const & junction, TEdgeVector & edges) const;
 
   /// Determines if the edge has been split by fake edges and if yes returns these fake edges.
-  bool HasBeenSplitToFakes(Edge const & edge, vector<Edge> & fakeEdges) const;
+  bool HasBeenSplitToOutgoingFakes(Edge const & edge, vector<Edge> & fakeEdges) const;
   bool HasBeenSplitToIngoingFakes(Edge const & edge, vector<Edge> & fakeEdges) const;
 
   // Map of outgoing edges for junction

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -196,6 +196,7 @@ public:
   /// Adds fake edges from fake position rp to real vicinity
   /// positions.
   void AddFakeEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinities);
+  void AddFakeIngoingEdges(Junction const & junction, vector<pair<Edge, m2::PointD>> const & vicinity);
 
   /// Returns RoadInfo for a road corresponding to featureId.
   virtual RoadInfo GetRoadInfo(FeatureID const & featureId) const = 0;
@@ -245,8 +246,10 @@ private:
 
   /// Determines if the edge has been split by fake edges and if yes returns these fake edges.
   bool HasBeenSplitToFakes(Edge const & edge, vector<Edge> & fakeEdges) const;
+  bool HasBeenSplitToIngoingFakes(Edge const & edge, vector<Edge> & fakeEdges) const;
 
   // Map of outgoing edges for junction
   map<Junction, TEdgeVector> m_outgoingEdges;
+  map<Junction, TEdgeVector> m_ingoingEdges;
 };
 }  // namespace routing

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -191,7 +191,7 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
 
   m_roadGraph->ResetFakes();
   m_roadGraph->AddFakeEdges(startPos, startVicinity);
-  m_roadGraph->AddFakeEdges(finalPos, finalVicinity);
+  m_roadGraph->AddFakeIngoingEdges(finalPos, finalVicinity);
 
   RoutingResult<Junction> result;
   IRoutingAlgorithm::Result const resultCode =

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -190,7 +190,7 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
   Junction const finalPos(finalPoint);
 
   m_roadGraph->ResetFakes();
-  m_roadGraph->AddFakeEdges(startPos, startVicinity);
+  m_roadGraph->AddFakeOutgoingEdges(startPos, startVicinity);
   m_roadGraph->AddFakeIngoingEdges(finalPos, finalVicinity);
 
   RoutingResult<Junction> result;

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -41,3 +41,10 @@ UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
       integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
 }
+
+UNIT_TEST(RussiaMoscowNearJewMuseum)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.77484, 37.54545), {0., 0.},
+      MercatorBounds::FromLatLon(55.79370, 37.56051), 4123.8);
+}


### PR DESCRIPTION
В велосипедном роутинге мы стали учитывать направление на односторонних дорогах. В такой ситуации некорректно получить исходящие файковые дуги ревером входящих. Данный баг воспроизводился например вот здесь: https://jira.mail.ru/browse/MAPSME-1554

Это прототип исправления бага. Он все корректно исправляет, но код содержит большой копи пейст. (Методы: AddFakeIngoingEdges и HasBeenSplitToIngoingFakes). Если от него избавляться и без того сложный код вычисления дополнительных дуг получит еще большее усложнение. С другой стороны, оставлять копи пейст, так же не желательно. Если есть идеи - пишите. 

Пока лучшее, что я вижу, это избавиться от копипейста ценой сильного усложнения.

@ygorshenin @mpimenov PTAL

Данный PR должен исправить баги:
https://jira.mail.ru/browse/MAPSME-1554
https://jira.mail.ru/browse/MAPSME-1498
https://jira.mail.ru/browse/MAPSME-1510
(Нужно написать интеграционный тест на каждый)

Тикет по PR: https://jira.mail.ru/browse/MAPSME-1619
