### PR TITLE
[generator] addr:street should be exactly equal to street name

### DIFF
--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -192,6 +192,9 @@ StreetsSynonymsHolder g_streets;
 
 UniString GetStreetNameAsKey(string const & name)
 {
+  if (name.empty())
+    return UniString();
+
   UniString res;
   SimpleTokenizer iter(name, kStreetTokensSeparator);
   while (iter)
@@ -199,11 +202,9 @@ UniString GetStreetNameAsKey(string const & name)
     UniString const s = NormalizeAndSimplifyString(*iter);
     ++iter;
 
-    if (!g_streets.FullMatch(s))
-      res.append(s);
+    res.append(s);
   }
 
-  // In case when street name has only synonym tokens, but we should return valid key.
   return (res.empty() ? NormalizeAndSimplifyString(name) : res);
 }
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-1580

Оказалось, мы ищем улицу для дома по нечёткому сравнению названий. То есть, «улица Челюскинцев» и «переулок Челюскинцев» — одно и то же для алгоритма сравнения, т.к. префиксы отбрасываем. Это неправильно, т.к. значение `addr:street` дома должно с точностью до буквы повторять значение `name` улицы.

<s>Этот пул-реквест заменяет нечёткое сравнение точным, удаляя последнее использование `search::GetStreetNameAsKey` и ` search::ReverseGeocoder::GetMatchedStreetIndex`. Другое осталось в `search/house_detector.hpp`, но им никто не пользуется.</s>

Просто убрал выкидывание статусных частей.