### PR TITLE
[ios] Fixed location manager subscription restore.

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -360,6 +360,8 @@ BOOL gIsFirstMyPositionMode = YES;
     return;
   // Notify about entering foreground (should be called on the first launch too).
   GetFramework().EnterForeground();
+  if (![Alohalytics isFirstSession])
+    [[MapsAppDelegate theApp].locationManager start:self];
 }
 
 - (void)onGetFocus:(BOOL)isOnFocus


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-1607

Restore location manager subscription on enter foreground.
Skip first session since we must ask user for permission on first launch.