### PR TITLE
[booking] Save all translations we've got

### DIFF
--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -733,13 +733,13 @@ UNIT_TEST(NormalizeDigits_UniString)
 UNIT_TEST(CSV)
 {
   vector<string> target;
-  TEST(strings::ParseCSVRow(",Test\\,проверка,0,", target), ());
+  strings::ParseCSVRow(",Test\\,проверка,0,", ',', target);
   vector<string> expected({"", "Test\\", "проверка", "0", ""});
   TEST_EQUAL(target, expected, ());
-  TEST(strings::ParseCSVRow("and there  was none", target, ' ', 5), ());
+  strings::ParseCSVRow("and there  was none", ' ', target);
   vector<string> expected2({"and", "there", "", "was", "none"});
   TEST_EQUAL(target, expected2, ());
-  TEST(!strings::ParseCSVRow("", target), ());
+  strings::ParseCSVRow("", 'q', target);
   vector<string> expected3;
   TEST_EQUAL(target, expected3, ());
 }

--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -733,13 +733,16 @@ UNIT_TEST(NormalizeDigits_UniString)
 UNIT_TEST(Split)
 {
   vector<string> target;
-  strings::Split(";Test\\;проверка;0;", ';', target);
+  TEST(strings::ParseCSVRow(",Test\\,проверка,0,", target), ());
   vector<string> expected({"", "Test\\", "проверка", "0", ""});
   TEST_EQUAL(target, expected, ());
-  strings::Split("and there  was none", ' ', target);
-  vector<string> expected2({"and", "there", "", "was", "none"});
+  TEST(strings::ParseCSVRow("and there  \"was  none\"", target, ' '), ());
+  vector<string> expected2({"and", "there", "", "was  none"});
   TEST_EQUAL(target, expected2, ());
-  strings::Split("", '!', target);
+  TEST(!strings::ParseCSVRow("", target), ());
   vector<string> expected3;
   TEST_EQUAL(target, expected3, ());
+  TEST(!strings::ParseCSVRow("\"this, a line.\"", target, ',', 2), (target));
+  vector<string> expected4({"this, a line."});
+  TEST_EQUAL(target, expected4, ());
 }

--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -729,3 +729,17 @@ UNIT_TEST(NormalizeDigits_UniString)
   TEST_EQUAL(nd("a０１9２ "), "a0192 ", ());
   TEST_EQUAL(nd("３４５６７８９"), "3456789", ());
 }
+
+UNIT_TEST(Split)
+{
+  vector<string> target;
+  strings::Split(";Test\\;проверка;0;", ';', target);
+  vector<string> expected({"", "Test\\", "проверка", "0", ""});
+  TEST_EQUAL(target, expected, ());
+  strings::Split("and there  was none", ' ', target);
+  vector<string> expected2({"and", "there", "", "was", "none"});
+  TEST_EQUAL(target, expected2, ());
+  strings::Split("", '!', target);
+  vector<string> expected3;
+  TEST_EQUAL(target, expected3, ());
+}

--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -730,19 +730,16 @@ UNIT_TEST(NormalizeDigits_UniString)
   TEST_EQUAL(nd("３４５６７８９"), "3456789", ());
 }
 
-UNIT_TEST(Split)
+UNIT_TEST(CSV)
 {
   vector<string> target;
   TEST(strings::ParseCSVRow(",Test\\,проверка,0,", target), ());
   vector<string> expected({"", "Test\\", "проверка", "0", ""});
   TEST_EQUAL(target, expected, ());
-  TEST(strings::ParseCSVRow("and there  \"was  none\"", target, ' '), ());
-  vector<string> expected2({"and", "there", "", "was  none"});
+  TEST(strings::ParseCSVRow("and there  was none", target, ' ', 5), ());
+  vector<string> expected2({"and", "there", "", "was", "none"});
   TEST_EQUAL(target, expected2, ());
   TEST(!strings::ParseCSVRow("", target), ());
   vector<string> expected3;
   TEST_EQUAL(target, expected3, ());
-  TEST(!strings::ParseCSVRow("\"this, a line.\"", target, ',', 2), (target));
-  vector<string> expected4({"this, a line."});
-  TEST_EQUAL(target, expected4, ());
 }

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -328,4 +328,17 @@ bool AlmostEqual(string const & str1, string const & str2, size_t mismatchedCoun
   return false;
 }
 
+void Split(string const & s, char delimiter, vector<string> & target)
+{
+  target.clear();
+
+  // Special case: if the string is empty, return an empty array instead of {""}.
+  if (s.empty())
+    return;
+
+  using It = TokenizeIterator<SimpleDelimiter, string::const_iterator, true>;
+  for (It it(s, SimpleDelimiter(delimiter)); it; ++it)
+    target.push_back(*it);
+}
+
 }  // namespace strings

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -328,7 +328,7 @@ bool AlmostEqual(string const & str1, string const & str2, size_t mismatchedCoun
   return false;
 }
 
-bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter, size_t const columns)
+void ParseCSVRow(string const & s, char const delimiter, vector<string> & target)
 {
   target.clear();
   using It = TokenizeIterator<SimpleDelimiter, string::const_iterator, true>;
@@ -341,12 +341,7 @@ bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter
 
   // Special case: if the string is empty, return an empty array instead of {""}.
   if (target.size() == 1 && target[0].empty())
-  {
     target.clear();
-    return false;
-  }
-
-  return columns <= 0 || target.size() == columns;
 }
 
 }  // namespace strings

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -332,47 +332,11 @@ bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter
 {
   target.clear();
   using It = TokenizeIterator<SimpleDelimiter, string::const_iterator, true>;
-  bool insideQuotes = false;
-  ostringstream quoted;
   for (It it(s, SimpleDelimiter(delimiter)); it; ++it)
   {
     string column = *it;
-    if (insideQuotes)
-    {
-      if (!column.empty() && column.back() == '"')
-      {
-        // Found the tail quote: remove it and add |quoted| to the vector.
-        insideQuotes = false;
-        column.pop_back();
-        quoted << delimiter << column;
-        target.push_back(quoted.str());
-        quoted.clear();
-      }
-      else
-        quoted << delimiter << column;
-    }
-    else if (!column.empty() && column.front() == '"')
-    {
-      // Found the front quote: if there is the last one also, remove both and append column,
-      // otherwise push the column into a |quoted| buffer.
-      column.erase(0, 1);
-      if (column.back() == '"')
-      {
-        column.pop_back();
-        strings::Trim(column);
-        target.push_back(column);
-      }
-      else
-      {
-        quoted << column;
-        insideQuotes = true;
-      }
-    }
-    else
-    {
-      strings::Trim(column);
-      target.push_back(column);
-    }
+    strings::Trim(column);
+    target.push_back(move(column));
   }
 
   // Special case: if the string is empty, return an empty array instead of {""}.

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -306,6 +306,9 @@ void Tokenize(string const & str, char const * delims, TFunctor && f)
   }
 }
 
+/// Splits a string by the delimiter, keeps empty parts, on an empty string returns an empty vector.
+void Split(string const & s, char delimiter, vector<string> & target);
+
 /// @return code of last symbol in string or 0 if s is empty
 UniChar LastUniChar(string const & s);
 

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -308,8 +308,7 @@ void Tokenize(string const & str, char const * delims, TFunctor && f)
 
 /// Splits a string by the delimiter, keeps empty parts, on an empty string returns an empty vector.
 /// Does not support quoted columns, newlines in columns and escaped quotes.
-/// @return false if the line is empty or number of columns differs from |columns|.
-bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter = ',', size_t const columns = 0);
+void ParseCSVRow(string const & s, char const delimiter, vector<string> & target);
 
 /// @return code of last symbol in string or 0 if s is empty
 UniChar LastUniChar(string const & s);

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -307,7 +307,7 @@ void Tokenize(string const & str, char const * delims, TFunctor && f)
 }
 
 /// Splits a string by the delimiter, keeps empty parts, on an empty string returns an empty vector.
-/// Supports quoted columns, does not support newlines in columns and escaped quotes.
+/// Does not support quoted columns, newlines in columns and escaped quotes.
 /// @return false if the line is empty or number of columns differs from |columns|.
 bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter = ',', size_t const columns = 0);
 

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -307,7 +307,9 @@ void Tokenize(string const & str, char const * delims, TFunctor && f)
 }
 
 /// Splits a string by the delimiter, keeps empty parts, on an empty string returns an empty vector.
-void Split(string const & s, char delimiter, vector<string> & target);
+/// Supports quoted columns, does not support newlines in columns and escaped quotes.
+/// @return false if the line is empty or number of columns differs from |columns|.
+bool ParseCSVRow(string const & s, vector<string> & target, char const delimiter = ',', size_t const columns = 0);
 
 /// @return code of last symbol in string or 0 if s is empty
 UniChar LastUniChar(string const & s);

--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -30,10 +30,8 @@ bool CheckForValues(string const & value)
 
 BookingDataset::Hotel::Hotel(string const & src)
 {
-  vector<string> rec(FieldsCount());
-  strings::SimpleTokenizer token(src, "\t");
-  for (size_t i = 0; token && i < rec.size(); ++i, ++token)
-    rec[i] = *token;
+  vector<string> rec;
+  CHECK(strings::ParseCSVRow(src, rec, '\t', FieldsCount()), ("Error parsing hotels.tsv line:", src));
 
   strings::to_uint(rec[Index(Fields::Id)], id);
   strings::to_double(rec[Index(Fields::Latitude)], lat);
@@ -176,7 +174,7 @@ void BookingDataset::BuildFeatures(function<void(OsmElement *)> const & fn) cons
     if (!hotel.translations.empty())
     {
       vector<string> parts;
-      strings::Split(hotel.translations, '|', parts);
+      strings::ParseCSVRow(hotel.translations, parts, '|');
       for (auto i = 0; i < parts.size(); i += 3)
       {
         e.AddTag("name:" + parts[i], parts[i + 1]);

--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -31,7 +31,8 @@ bool CheckForValues(string const & value)
 BookingDataset::Hotel::Hotel(string const & src)
 {
   vector<string> rec;
-  CHECK(strings::ParseCSVRow(src, rec, '\t', FieldsCount()), ("Error parsing hotels.tsv line:", src));
+  strings::ParseCSVRow(src, '\t', rec);
+  CHECK(rec.size() == FieldsCount(), ("Error parsing hotels.tsv line:", src));
 
   strings::to_uint(rec[Index(Fields::Id)], id);
   strings::to_double(rec[Index(Fields::Latitude)], lat);
@@ -174,7 +175,8 @@ void BookingDataset::BuildFeatures(function<void(OsmElement *)> const & fn) cons
     if (!hotel.translations.empty())
     {
       vector<string> parts;
-      strings::ParseCSVRow(hotel.translations, parts, '|');
+      strings::ParseCSVRow(hotel.translations, '|', parts);
+      CHECK(parts.size() % 3 == 0, ());
       for (auto i = 0; i < parts.size(); i += 3)
       {
         e.AddTag("name:" + parts[i], parts[i + 1]);

--- a/generator/booking_dataset.hpp
+++ b/generator/booking_dataset.hpp
@@ -36,9 +36,7 @@ public:
       RatingUsers = 8,
       DescUrl = 9,
       Type = 10,
-      Language = 11,
-      NameLoc = 12,
-      AddressLoc = 13,
+      Translations = 11,
 
       Counter
     };
@@ -54,9 +52,7 @@ public:
     double ratingUser = 0.0;
     string descUrl;
     uint32_t type = 0;
-    string langCode;
-    string nameLoc;
-    string addressLoc;
+    string translations;
 
     static constexpr size_t Index(Fields field) { return static_cast<size_t>(field); }
     static constexpr size_t FieldsCount() { return static_cast<size_t>(Fields::Counter); }


### PR DESCRIPTION
Вместо трёх полей в `hotels.tsv` добавляют только одно, в котором переводы склеены символом `|`. И в генераторе, соответственно, его разбираю. Попутно добавил метод `strings::Split()`.