### PR TITLE
[altitude] Adding altitude section to mwm and using altitude for building pedestrian and bicycle routes.

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -25,6 +25,7 @@
 #define VERSION_FILE_TAG "version"
 #define METADATA_FILE_TAG "meta"
 #define METADATA_INDEX_FILE_TAG "metaidx"
+#define ALTITUDE_TAG "altitude"
 #define FEATURE_OFFSETS_FILE_TAG "offs"
 #define RANKS_FILE_TAG "ranks"
 #define REGION_INFO_FILE_TAG "rgninfo"

--- a/defines.hpp
+++ b/defines.hpp
@@ -25,7 +25,7 @@
 #define VERSION_FILE_TAG "version"
 #define METADATA_FILE_TAG "meta"
 #define METADATA_INDEX_FILE_TAG "metaidx"
-#define ALTITUDE_TAG "altitude"
+#define ALTITUDE_FILE_TAG "altitude"
 #define FEATURE_OFFSETS_FILE_TAG "offs"
 #define RANKS_FILE_TAG "ranks"
 #define REGION_INFO_FILE_TAG "rgninfo"

--- a/defines.hpp
+++ b/defines.hpp
@@ -25,7 +25,7 @@
 #define VERSION_FILE_TAG "version"
 #define METADATA_FILE_TAG "meta"
 #define METADATA_INDEX_FILE_TAG "metaidx"
-#define ALTITUDE_FILE_TAG "altitude"
+#define ALTITUDES_FILE_TAG "altitudes"
 #define FEATURE_OFFSETS_FILE_TAG "offs"
 #define RANKS_FILE_TAG "ranks"
 #define REGION_INFO_FILE_TAG "rgninfo"

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -67,14 +67,14 @@ private:
   generator::SrtmTileManager m_srtmManager;
   TFeatureAltitudeVec m_featureAltitudes;
 };
-} // namespace
+}  // namespace
 
 namespace routing
 {
 void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string const & countryName)
 {
   LOG(LINFO, ("srtmPath =", srtmPath, "baseDir =", baseDir, "countryName =", countryName));
-//  string const altPath = baseDir + countryName + "." + ALTITUDE_FILE_TAG;
+  //  string const altPath = baseDir + countryName + "." + ALTITUDE_FILE_TAG;
   string const mwmPath = baseDir + countryName + DATA_FILE_EXTENSION;
 
   // Writing section with altitude information.
@@ -95,4 +95,4 @@ void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string 
     LOG(LINFO, ("Altitude was written for", featureAltitudes.size(), "features."));
   }
 }
-} // namespace routing
+}  // namespace routing

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -46,6 +46,7 @@ class SrtmGetter : public AltitudeGetter
 {
 public:
   SrtmGetter(string const & srtmDir) : m_srtmManager(srtmDir) {}
+
   // AltitudeGetter overrides:
   feature::TAltitude GetAltitude(m2::PointD const & p) override
   {
@@ -113,7 +114,10 @@ public:
     {
       TAltitude const a = m_altitudeGetter.GetAltitude(f.GetPoint(i));
       if (a == kInvalidAltitude)
+      {
+        // One invalid point invalidates the whole feature.
         return;
+      }
 
       if (minFeatureAltitude == kInvalidAltitude)
         minFeatureAltitude = a;
@@ -133,6 +137,7 @@ public:
   }
 
   bool HasAltitudeInfo() const { return !m_featureAltitudes.empty(); }
+
   bool IsFeatureAltitudesSorted()
   {
     return is_sorted(m_featureAltitudes.begin(), m_featureAltitudes.end(),

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -220,7 +220,12 @@ void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter)
     w.Seek(startOffset);
     header.Serialize(w);
     w.Seek(endOffset);
-    LOG(LINFO, (ALTITUDES_FILE_TAG, "section is ready. The size is", endOffset - startOffset));
+    LOG(LINFO, (ALTITUDES_FILE_TAG, "section is ready. The size is", endOffset - startOffset,
+                "min altitude is", processor.GetMinAltitude()));
+    if (processor.HasAltitudeInfo())
+      LOG(LINFO, ("Min altitude is", processor.GetMinAltitude()));
+    else
+      LOG(LINFO, ("Min altitude isn't defined."));
   }
   catch (RootException const & e)
   {

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -3,6 +3,7 @@
 
 #include "routing/routing_helpers.hpp"
 
+#include "indexer/altitude_loader.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/feature_altitude.hpp"
 #include "indexer/feature_data.hpp"
@@ -10,6 +11,8 @@
 
 #include "coding/file_container.hpp"
 #include "coding/file_name_utils.hpp"
+#include "coding/read_write_utils.hpp"
+#include "coding/reader.hpp"
 #include "coding/varint.hpp"
 
 #include "coding/internal/file_data.hpp"
@@ -21,6 +24,10 @@
 
 #include "defines.hpp"
 
+#include "3party/succinct/elias_fano.hpp"
+#include "3party/succinct/mapper.hpp"
+#include "3party/succinct/rs_bit_vector.hpp"
+
 #include "std/algorithm.hpp"
 #include "std/type_traits.hpp"
 #include "std/utility.hpp"
@@ -30,29 +37,79 @@ using namespace feature;
 
 namespace
 {
+TAltitudeSectionVersion constexpr kAltitudeSectionVersion = 1;
+
 class Processor
 {
 public:
-  using TFeatureAltitude = pair<uint32_t, Altitudes>;
+  using TFeatureAltitude = pair<uint32_t, Altitude>;
   using TFeatureAltitudes = vector<TFeatureAltitude>;
 
-  Processor(string const & srtmPath) : m_srtmManager(srtmPath) {}
+  Processor(string const & srtmPath) : m_srtmManager(srtmPath), m_minAltitude(kInvalidAltitude) {}
 
   TFeatureAltitudes const & GetFeatureAltitudes() const { return m_featureAltitudes; }
 
+  vector<bool> const & GetAltitudeAvailability() const { return m_altitudeAvailability; }
+
+  TAltitude GetMinAltitude() const { return m_minAltitude; }
+
   void operator()(FeatureType const & f, uint32_t const & id)
   {
-    if (!routing::IsRoad(feature::TypesHolder(f)))
+    if (id != m_altitudeAvailability.size())
+    {
+      LOG(LERROR, ("There's a gap in feature id order."));
       return;
+    }
 
-    f.ParseGeometry(FeatureType::BEST_GEOMETRY);
-    size_t const pointsCount = f.GetPointsCount();
-    if (pointsCount == 0)
-      return;
+    bool hasAltitude = false;
+    do
+    {
+      if (!routing::IsRoad(feature::TypesHolder(f)))
+        break;
 
-    Altitudes alts(m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(0))),
-                   m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(pointsCount - 1))));
-    m_featureAltitudes.push_back(make_pair(id, alts));
+      f.ParseGeometry(FeatureType::BEST_GEOMETRY);
+      size_t const pointsCount = f.GetPointsCount();
+      if (pointsCount == 0)
+        break;
+
+      TAltitudes altitudes;
+      bool allPointsValidAltFlag = true;
+      TAltitude minFeatureAltitude = kInvalidAltitude;
+      for (size_t i = 0; i < pointsCount; ++i)
+      {
+        TAltitude const a = m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(i)));
+        if (a == kInvalidAltitude)
+        {
+          allPointsValidAltFlag = false;
+          break;
+        }
+
+        if (minFeatureAltitude == kInvalidAltitude)
+          minFeatureAltitude = a;
+        else
+          minFeatureAltitude = min(minFeatureAltitude, a);
+
+        altitudes.push_back(a);
+      }
+      if (!allPointsValidAltFlag)
+        break;
+
+      hasAltitude = true;
+      m_featureAltitudes.push_back(make_pair(id, Altitude(move(altitudes))));
+
+      if (m_minAltitude == kInvalidAltitude)
+        m_minAltitude = minFeatureAltitude;
+      else
+        m_minAltitude = min(minFeatureAltitude, m_minAltitude);
+    }
+    while(false);
+
+    m_altitudeAvailability.push_back(hasAltitude);
+  }
+
+  bool HasAltitudeInfo()
+  {
+    return !m_featureAltitudes.empty();
   }
 
   void SortFeatureAltitudes()
@@ -63,32 +120,128 @@ public:
 private:
   generator::SrtmTileManager m_srtmManager;
   TFeatureAltitudes m_featureAltitudes;
+  vector<bool> m_altitudeAvailability;
+  TAltitude m_minAltitude;
 };
+
+uint32_t GetFileSize(string const & filePath)
+{
+  uint64_t size;
+  if (!my::GetFileSize(filePath, size))
+  {
+    LOG(LWARNING, ("altitudeAvailability", filePath, "size = 0"));
+    return 0;
+  }
+
+  LOG(LINFO, ("altitudeAvailability ", filePath, "size =", size, "bytes"));
+  return size;
+}
+
+void MoveFileToAltitudeSection(string const & filePath, uint32_t fileSize, FileWriter & w)
+{
+  {
+    ReaderSource<FileReader> r = FileReader(filePath);
+    w.Write(&fileSize, sizeof(fileSize));
+    rw::ReadAndWrite(r, w);
+    LOG(LINFO, (filePath, "size is", fileSize));
+  }
+  FileWriter::DeleteFileX(filePath);
+}
+
+void SerializeHeader(TAltitudeSectionVersion version, TAltitude minAltitude,
+                     TAltitudeSectionOffset altitudeInfoOffset, FileWriter & w)
+{
+  w.Write(&version, sizeof(version));
+
+  w.Write(&minAltitude, sizeof(minAltitude));
+  LOG(LINFO, ("altitudeAvailability writing minAltitude =", minAltitude));
+
+  w.Write(&altitudeInfoOffset, sizeof(altitudeInfoOffset));
+  LOG(LINFO, ("altitudeAvailability writing altitudeInfoOffset =", altitudeInfoOffset));
+}
 }  // namespace
 
 namespace routing
 {
 void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string const & countryName)
 {
-  LOG(LINFO, ("srtmPath =", srtmPath, "baseDir =", baseDir, "countryName =", countryName));
-  string const mwmPath = my::JoinFoldersToPath(baseDir, countryName + DATA_FILE_EXTENSION);
-
-  // Writing section with altitude information.
+  try
   {
-    FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
-    FileWriter w = cont.GetWriter(ALTITUDE_FILE_TAG);
+    // Preparing altitude information.
+    LOG(LINFO, ("srtmPath =", srtmPath, "baseDir =", baseDir, "countryName =", countryName));
+    string const mwmPath = my::JoinFoldersToPath(baseDir, countryName + DATA_FILE_EXTENSION);
 
     Processor processor(srtmPath);
     feature::ForEachFromDat(mwmPath, processor);
     processor.SortFeatureAltitudes();
     Processor::TFeatureAltitudes const & featureAltitudes = processor.GetFeatureAltitudes();
 
-    for (auto const & a : featureAltitudes)
+    if (!processor.HasAltitudeInfo())
     {
-      Altitude altitude(a.first /* feature id */, a.second /* feature altitudes */);
-      altitude.Serialize(w);
+      LOG(LINFO, ("No altitude information for road features of mwm", countryName));
+      return;
+    }
+
+    // Writing compressed bit vector with features which have altitude information.
+    succinct::rs_bit_vector altitudeAvailability(processor.GetAltitudeAvailability());
+    string const altitudeAvailabilityPath = my::JoinFoldersToPath(baseDir, "altitude_availability.bitvector");
+    LOG(LINFO, ("altitudeAvailability succinct::mapper::size_of(altitudeAvailability) =", succinct::mapper::size_of(altitudeAvailability)));
+    succinct::mapper::freeze(altitudeAvailability, altitudeAvailabilityPath.c_str());
+
+    // Writing feature altitude information to a file and memorizing the offsets.
+    string const altitudeInfoPath = my::JoinFoldersToPath(baseDir, "altitude_info");
+    vector<uint32_t> offsets;
+    TAltitude const minAltitude = processor.GetMinAltitude();
+    offsets.reserve(featureAltitudes.size());
+    {
+      FileWriter altitudeInfoW(altitudeInfoPath);
+      for (auto const & a : featureAltitudes)
+      {
+        offsets.push_back(altitudeInfoW.Pos());
+        // Feature altitude serializing.
+        a.second.Serialize(minAltitude, altitudeInfoW);
+      }
     }
     LOG(LINFO, ("Altitude was written for", featureAltitudes.size(), "features."));
+
+    // Writing feature altitude offsets.
+    CHECK(is_sorted(offsets.begin(), offsets.end()), ());
+    CHECK(adjacent_find(offsets.begin(), offsets.end()) == offsets.end(), ());
+    LOG(LINFO, ("Max altitude info offset =", offsets.back(), "offsets.size() =", offsets.size()));
+    succinct::elias_fano::elias_fano_builder builder(offsets.back(), offsets.size());
+    for (uint32_t offset : offsets)
+      builder.push_back(offset);
+
+    succinct::elias_fano featureTable(&builder);
+    string const featuresTablePath = my::JoinFoldersToPath(baseDir, "altitude_offsets.elias_fano");
+    succinct::mapper::freeze(featureTable, featuresTablePath.c_str());
+
+    uint32_t const altitudeAvailabilitySize = GetFileSize(altitudeAvailabilityPath);
+    uint32_t const altitudeInfoSize = GetFileSize(altitudeInfoPath);
+    uint32_t const featuresTableSize = GetFileSize(featuresTablePath);
+
+    FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
+    FileWriter w = cont.GetWriter(ALTITUDE_FILE_TAG);
+
+    // Writing section with altitude information.
+    // Writing altitude section header.
+    TAltitudeSectionOffset const headerSize = sizeof(kAltitudeSectionVersion) +
+        sizeof(minAltitude) + sizeof(TAltitudeSectionOffset);
+    TAltitudeSectionOffset const featuresTableOffset = headerSize +
+        sizeof(altitudeAvailabilitySize) + altitudeAvailabilitySize;
+    TAltitudeSectionOffset const altitudeInfoOffset = featuresTableOffset +
+        sizeof(featuresTableSize) + featuresTableSize;
+    SerializeHeader(kAltitudeSectionVersion, processor.GetMinAltitude(),
+                    altitudeInfoOffset + sizeof(TAltitudeSectionOffset) /* for altitude info size */, w);
+
+    // Coping parts of altitude sections to mwm.
+    MoveFileToAltitudeSection(altitudeAvailabilityPath, altitudeAvailabilitySize, w);
+    MoveFileToAltitudeSection(featuresTablePath, featuresTableSize, w);
+    MoveFileToAltitudeSection(altitudeInfoPath, altitudeInfoSize, w);
+  }
+  catch (RootException const & e)
+  {
+    LOG(LERROR, ("An exception happend while creating", ALTITUDE_FILE_TAG, "section. ", e.what()));
   }
 }
 }  // namespace routing

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -1,0 +1,86 @@
+#include "generator/routing_generator.hpp"
+#include "generator/srtm_parser.hpp"
+
+#include "defines.hpp"
+
+#include "routing/routing_helpers.hpp"
+
+#include "indexer/feature.hpp"
+#include "indexer/feature_altitude.hpp"
+#include "indexer/feature_data.hpp"
+#include "indexer/feature_processor.hpp"
+
+#include "coding/file_container.hpp"
+#include "coding/varint.hpp"
+
+#include "coding/internal/file_data.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/string_utils.hpp"
+
+#include "std/map.hpp"
+#include "std/type_traits.hpp"
+
+using namespace feature;
+
+namespace
+{
+static_assert(is_same<TAltitude, generator::SrtmTile::THeight>::value, "");
+static_assert(kInvalidAltitude == generator::SrtmTile::kInvalidHeight, "");
+
+class Processor
+{
+public:
+  Processor(string const & srtmPath) : m_srtmManager(srtmPath) {}
+  map<uint32_t, Altitudes> const & GetFeatureAltitudes() const { return m_featureAltitudes; }
+
+  void operator()(FeatureType const & f, uint32_t const & id)
+  {
+    f.ParseTypes();
+    f.ParseHeader2();
+    if (!routing::IsRoad(feature::TypesHolder(f)))
+      return;
+
+    f.ParseGeometry(FeatureType::BEST_GEOMETRY);
+    size_t const pointsCount = f.GetPointsCount();
+    if (pointsCount == 0)
+      return;
+
+    Altitudes alts(m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(0))),
+                   m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(pointsCount - 1))));
+    m_featureAltitudes[id] = alts;
+  }
+
+private:
+  generator::SrtmTileManager m_srtmManager;
+  map<uint32_t, Altitudes> m_featureAltitudes;
+};
+} // namespace
+
+namespace routing
+{
+void BuildRoadFeatureAltitude(string const & srtmPath, string const & baseDir, string const & countryName)
+{
+  LOG(LINFO, ("srtmPath =", srtmPath, "baseDir =", baseDir, "countryName =", countryName));
+  string const altPath = baseDir + countryName + "." + ALTITUDE_TAG;
+  string const mwmPath = baseDir + countryName + DATA_FILE_EXTENSION;
+
+  // Writing section with altitude information.
+  {
+    FilesContainerW altCont(mwmPath, FileWriter::OP_WRITE_EXISTING);
+    FileWriter w = altCont.GetWriter(ALTITUDE_TAG);
+
+    Processor processor(srtmPath);
+    feature::ForEachFromDat(mwmPath, processor);
+    map<uint32_t, Altitudes> const & featureAltitudes = processor.GetFeatureAltitudes();
+
+    for (auto const & a : featureAltitudes)
+    {
+      Altitude altitude(a.first /* feature id */, a.second /* feature altitudes */);
+      altitude.Serialize(w);
+    }
+    LOG(LINFO, ("Altitude was written for", featureAltitudes.size(), "features."));
+  }
+}
+} // namespace routing

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -79,12 +79,14 @@ public:
   }
 
   TFeatureAltitudes const & GetFeatureAltitudes() const { return m_featureAltitudes; }
+
   succinct::bit_vector_builder & GetAltitudeAvailabilityBuilder()
   {
     return m_altitudeAvailabilityBuilder;
   }
 
   TAltitude GetMinAltitude() const { return m_minAltitude; }
+
   void operator()(FeatureType const & f, uint32_t const & id)
   {
     if (id != m_altitudeAvailabilityBuilder.size())

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -73,14 +73,14 @@ public:
         break;
 
       TAltitudes altitudes;
-      bool allPointsValidAltFlag = true;
+      bool valid = true;
       TAltitude minFeatureAltitude = kInvalidAltitude;
       for (size_t i = 0; i < pointsCount; ++i)
       {
         TAltitude const a = m_srtmManager.GetHeight(MercatorBounds::ToLatLon(f.GetPoint(i)));
         if (a == kInvalidAltitude)
         {
-          allPointsValidAltFlag = false;
+          valid = false;
           break;
         }
 
@@ -91,7 +91,7 @@ public:
 
         altitudes.push_back(a);
       }
-      if (!allPointsValidAltFlag)
+      if (!valid)
         break;
 
       hasAltitude = true;
@@ -107,7 +107,7 @@ public:
     m_altitudeAvailability.push_back(hasAltitude);
   }
 
-  bool HasAltitudeInfo()
+  bool HasAltitudeInfo() const
   {
     return !m_featureAltitudes.empty();
   }
@@ -129,11 +129,11 @@ uint32_t GetFileSize(string const & filePath)
   uint64_t size;
   if (!my::GetFileSize(filePath, size))
   {
-    LOG(LWARNING, ("altitudeAvailability", filePath, "size = 0"));
+    LOG(LERROR, (filePath, "size = 0"));
     return 0;
   }
 
-  LOG(LINFO, ("altitudeAvailability ", filePath, "size =", size, "bytes"));
+  LOG(LINFO, (filePath, "size =", size, "bytes"));
   return size;
 }
 
@@ -221,7 +221,7 @@ void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string 
     uint32_t const featuresTableSize = GetFileSize(featuresTablePath);
 
     FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
-    FileWriter w = cont.GetWriter(ALTITUDE_FILE_TAG);
+    FileWriter w = cont.GetWriter(ALTITUDES_FILE_TAG);
 
     // Writing section with altitude information.
     // Writing altitude section header.
@@ -241,7 +241,7 @@ void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string 
   }
   catch (RootException const & e)
   {
-    LOG(LERROR, ("An exception happend while creating", ALTITUDE_FILE_TAG, "section. ", e.what()));
+    LOG(LERROR, ("An exception happend while creating", ALTITUDES_FILE_TAG, "section. ", e.what()));
   }
 }
 }  // namespace routing

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -11,11 +11,11 @@
 
 #include "coding/file_container.hpp"
 #include "coding/file_name_utils.hpp"
+#include "coding/internal/file_data.hpp"
 #include "coding/read_write_utils.hpp"
 #include "coding/reader.hpp"
 #include "coding/succinct_mapper.hpp"
 #include "coding/varint.hpp"
-#include "coding/internal/file_data.hpp"
 
 #include "geometry/latlon.hpp"
 
@@ -46,7 +46,6 @@ class SrtmGetter : public AltitudeGetter
 {
 public:
   SrtmGetter(string const & srtmDir) : m_srtmManager(srtmDir) {}
-
   // AltitudeGetter overrides:
   feature::TAltitude GetAltitude(m2::PointD const & p) override
   {
@@ -80,14 +79,12 @@ public:
   }
 
   TFeatureAltitudes const & GetFeatureAltitudes() const { return m_featureAltitudes; }
-
   succinct::bit_vector_builder & GetAltitudeAvailabilityBuilder()
   {
     return m_altitudeAvailabilityBuilder;
   }
 
   TAltitude GetMinAltitude() const { return m_minAltitude; }
-
   void operator()(FeatureType const & f, uint32_t const & id)
   {
     if (id != m_altitudeAvailabilityBuilder.size())
@@ -97,10 +94,8 @@ public:
     }
 
     bool hasAltitude = false;
-    MY_SCOPE_GUARD(altitudeAvailabilityBuilding, [&] ()
-    {
-      m_altitudeAvailabilityBuilder.push_back(hasAltitude);
-    });
+    MY_SCOPE_GUARD(altitudeAvailabilityBuilding,
+                   [&]() { m_altitudeAvailabilityBuilder.push_back(hasAltitude); });
 
     if (!routing::IsRoad(feature::TypesHolder(f)))
       return;
@@ -135,11 +130,7 @@ public:
       m_minAltitude = min(minFeatureAltitude, m_minAltitude);
   }
 
-  bool HasAltitudeInfo() const
-  {
-    return !m_featureAltitudes.empty();
-  }
-
+  bool HasAltitudeInfo() const { return !m_featureAltitudes.empty(); }
   bool IsFeatureAltitudesSorted()
   {
     return is_sorted(m_featureAltitudes.begin(), m_featureAltitudes.end(),

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -74,7 +74,6 @@ namespace routing
 void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string const & countryName)
 {
   LOG(LINFO, ("srtmPath =", srtmPath, "baseDir =", baseDir, "countryName =", countryName));
-  //  string const altPath = baseDir + countryName + "." + ALTITUDE_FILE_TAG;
   string const mwmPath = baseDir + countryName + DATA_FILE_EXTENSION;
 
   // Writing section with altitude information.

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -4,5 +4,5 @@
 
 namespace routing
 {
-void BuildRoadFeatureAltitude(string const & srtmPath, string const & baseDir, string const & countryName);
+void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string const & countryName);
 } // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -8,7 +8,7 @@
 
 namespace routing
 {
-class IAltitudeGetter
+class AltitudeGetter
 {
 public:
   virtual feature::TAltitude GetAltitude(m2::PointD const & p) = 0;
@@ -22,8 +22,8 @@ public:
 /// 8                   altitude info offset  4
 /// 12                  end of section        4
 /// 16                  altitude availability feat. table offset - 16
-/// feat. table offset  feature table         alt. info offset - f. table offset
-/// alt. info offset    altitude info         alt. info offset - end of section
-void BuildRoadAltitudes(string const & mwmPath, IAltitudeGetter & altitudeGetter);
-void BuildRoadAltitudes(string const & mwmPath, string const & srtmPath);
+/// feat. table offset  feature table         alt. info offset - feat. table offset
+/// alt. info offset    altitude info         end of section - alt. info offset
+void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter);
+void BuildRoadAltitudes(string const & mwmPath, string const & srtmDir);
 }  // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "std/string.hpp"
+
+namespace routing
+{
+void BuildRoadFeatureAltitude(string const & srtmPath, string const & baseDir, string const & countryName);
+} // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
+#include "geometry/latlon.hpp"
+
+#include "indexer/feature_altitude.hpp"
+
 #include "std/string.hpp"
 
 namespace routing
 {
+class IAltitudeGetter
+{
+public:
+  virtual feature::TAltitude GetAltitude(ms::LatLon const & coord) = 0;
+};
+
+void BuildRoadAltitudes(IAltitudeGetter const & altitudeGetter, string const & baseDir,
+                        string const & countryName);
 void BuildRoadAltitudes(string const & srtmPath, string const & baseDir,
                         string const & countryName);
 }  // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "geometry/latlon.hpp"
+#include "geometry/point2d.hpp"
 
 #include "indexer/feature_altitude.hpp"
 
@@ -11,11 +11,11 @@ namespace routing
 class IAltitudeGetter
 {
 public:
-  virtual feature::TAltitude GetAltitude(ms::LatLon const & coord) = 0;
+  virtual feature::TAltitude GetAltitude(m2::PointD const & p) = 0;
 };
 
-void BuildRoadAltitudes(IAltitudeGetter const & altitudeGetter, string const & baseDir,
-                        string const & countryName);
+void BuildRoadAltitudes(string const & baseDir, string const & countryName,
+                        IAltitudeGetter & altitudeGetter);
 void BuildRoadAltitudes(string const & srtmPath, string const & baseDir,
                         string const & countryName);
 }  // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -4,5 +4,6 @@
 
 namespace routing
 {
-void BuildRoadAltitudes(string const & srtmPath, string const & baseDir, string const & countryName);
-} // namespace routing
+void BuildRoadAltitudes(string const & srtmPath, string const & baseDir,
+                        string const & countryName);
+}  // namespace routing

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -14,8 +14,16 @@ public:
   virtual feature::TAltitude GetAltitude(m2::PointD const & p) = 0;
 };
 
-void BuildRoadAltitudes(string const & baseDir, string const & countryName,
-                        IAltitudeGetter & altitudeGetter);
-void BuildRoadAltitudes(string const & srtmPath, string const & baseDir,
-                        string const & countryName);
+/// \brief Adds altitude section to mwm. It has the following format:
+/// File offset (bytes) Field name            Field size (bytes)
+/// 0                   version               2
+/// 2                   min altitude          2
+/// 4                   feature table offset  4
+/// 8                   altitude info offset  4
+/// 12                  end of section        4
+/// 16                  altitude availability feat. table offset - 16
+/// feat. table offset  feature table         alt. info offset - f. table offset
+/// alt. info offset    altitude info         alt. info offset - end of section
+void BuildRoadAltitudes(string const & mwmPath, IAltitudeGetter & altitudeGetter);
+void BuildRoadAltitudes(string const & mwmPath, string const & srtmPath);
 }  // namespace routing

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/bicycle_model.hpp"
 #include "routing/car_model.hpp"
+#include "routing/routing_helpers.hpp"
 #include "routing/pedestrian_model.hpp"
 
 #include "indexer/feature_impl.hpp"
@@ -230,10 +231,7 @@ namespace
 
 bool FeatureBuilder1::IsRoad() const
 {
-  static routing::PedestrianModel const pedModel;
-  static routing::BicycleModel const bicModel;
-  return routing::CarModel::Instance().HasRoadType(m_params.m_Types) ||
-         pedModel.HasRoadType(m_params.m_Types) || bicModel.HasRoadType(m_params.m_Types);
+  return routing::IsRoad(m_params.m_Types);
 }
 
 bool FeatureBuilder1::PreSerialize()

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -2,8 +2,8 @@
 
 #include "routing/bicycle_model.hpp"
 #include "routing/car_model.hpp"
-#include "routing/routing_helpers.hpp"
 #include "routing/pedestrian_model.hpp"
+#include "routing/routing_helpers.hpp"
 
 #include "indexer/feature_impl.hpp"
 #include "indexer/feature_visibility.hpp"

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -181,7 +181,7 @@ public:
       m_uniqueRoadPoints.insert(RoughPoint(f.GetPoint(i)));
 
     // Preparing feature altitude and length.
-    TAltitudeVec pointAltitudes(numPoints);
+    TAltitudes pointAltitudes(numPoints);
     vector<double> pointDists(numPoints);
     double distFromStartMeters = 0;
     for (uint32_t i = 0; i < numPoints; ++i)

--- a/generator/generator.pro
+++ b/generator/generator.pro
@@ -15,6 +15,7 @@ INCLUDEPATH *= $$ROOT_DIR/3party/gflags/src \
 QT *= core
 
 SOURCES += \
+    altitude_generator.cpp \
     booking_dataset.cpp \
     booking_scoring.cpp \
     borders_generator.cpp \
@@ -41,6 +42,7 @@ SOURCES += \
     unpack_mwm.cpp \
 
 HEADERS += \
+    altitude_generator.hpp \
     booking_dataset.hpp \
     booking_scoring.hpp \
     borders_generator.hpp \

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -1,0 +1,232 @@
+#include "testing/testing.hpp"
+
+#include "generator/altitude_generator.hpp"
+
+#include "generator/generator_tests_support/test_feature.hpp"
+#include "generator/generator_tests_support/test_mwm_builder.hpp"
+
+#include "routing/road_graph.hpp"
+#include "routing/routing_helpers.hpp"
+
+#include "indexer/altitude_loader.hpp"
+#include "indexer/classificator_loader.hpp"
+#include "indexer/index.hpp"
+#include "indexer/feature_processor.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "coding/file_name_utils.hpp"
+
+#include "platform/country_file.hpp"
+#include "platform/platform.hpp"
+
+#include "platform/platform_tests_support/writable_dir_changer.hpp"
+
+#include "base/logging.hpp"
+#include "base/scope_guard.hpp"
+
+#include "std/string.hpp"
+
+using namespace feature;
+using namespace generator;
+using namespace platform;
+using namespace routing;
+using namespace tests_support;
+
+namespace
+{
+// These tests generate mwms with altitude sections and then check if altitudes
+// in the mwms are correct. The mwms are inited with different sets of features defined below.
+// There are several restrictions for these features:
+// * all of them are linear
+// * all coords of these features should be integer (it's necessary for easy implementation of MockAltitudeGetter)
+// * if accoding to one feature a point has some altitude, the point of another feature
+//   with the same coords has to have the same altitude
+// @TODO(bykoianko) Add ability to add to the tests not road features without altitude information.
+
+// Directory name for creating test mwm and temporary files.
+string const kTestDir = "altitude_generation_test";
+// Temporary mwm name for testing.
+string const kTestMwm = "test";
+
+struct Rounded3DPoint
+{
+  Rounded3DPoint(int32_t x, int32_t y, TAltitude a) : point2D(x, y), altitude(a) {}
+
+  m2::PointI point2D;
+  TAltitude altitude;
+};
+
+using TRounded3DGeom = vector<Rounded3DPoint>;
+
+TRounded3DGeom const kRoad1 = {{0, -1, -1}, {0, 0, 0}, {0, 1, 1}};
+TRounded3DGeom const kRoad2 = {{0, 1, 1}, {5, 1, 1}, {10, 1, 1}};
+TRounded3DGeom const kRoad3 = {{10, 1, 1}, {15, 6, 100}, {20, 11, 110}};
+TRounded3DGeom const kRoad4 = {{-10, 1, -1}, {-20, 6, -100}, {-20, -11, -110}};
+
+class MockAltitudeGetter : public IAltitudeGetter
+{
+public:
+  using TMockAltitudes = map<m2::PointI, TAltitude>;
+
+  MockAltitudeGetter(TMockAltitudes && altitudes) : m_altitudes(altitudes) {}
+
+  // IAltitudeGetter overrides:
+  TAltitude GetAltitude(m2::PointD const & p) override
+  {
+    m2::PointI const rounded(static_cast<int32_t>(round(p.x)), static_cast<int32_t>(round(p.y)));
+    auto const it = m_altitudes.find(rounded);
+    if (it == m_altitudes.end())
+      return kInvalidAltitude;
+
+    return it->second;
+  }
+
+private:
+  TMockAltitudes const & m_altitudes;
+};
+
+template<class T>
+vector<T> ConvertTo2DGeom(TRounded3DGeom const & geom3D)
+{
+  vector<T> dv;
+  dv.clear();
+  for (Rounded3DPoint const & p : geom3D)
+    dv.push_back(T(p.point2D));
+  return dv;
+}
+
+TAltitudes ConvertToAltitudes(TRounded3DGeom const & geom3D)
+{
+  TAltitudes altitudes;
+  altitudes.clear();
+  for (Rounded3DPoint const & p : geom3D)
+    altitudes.push_back(p.altitude);
+  return altitudes;
+}
+
+void FillAltitudes(vector<TRounded3DGeom> const & roadFeatures,
+                   MockAltitudeGetter::TMockAltitudes & altitudes)
+{
+  for (TRounded3DGeom const & geom3D : roadFeatures)
+  {
+    vector<m2::PointI> const featureGeom = ConvertTo2DGeom<m2::PointI>(geom3D);
+    TAltitudes const featureAlt = ConvertToAltitudes(geom3D);
+    CHECK_EQUAL(featureGeom.size(), featureAlt.size(), ());
+    for (size_t i = 0; i < featureGeom.size(); ++i)
+    {
+      auto it = altitudes.find(featureGeom[i]);
+      if (it != altitudes.end())
+      {
+        CHECK_EQUAL(it->second, featureAlt[i], ("Point", it->first, "is set with two different altitudes."));
+        continue;
+      }
+      altitudes[featureGeom[i]] = featureAlt[i];
+    }
+  }
+}
+
+void BuildMwmWithoutAltitude(vector<TRounded3DGeom> const & roadFeatures, LocalCountryFile & country)
+{
+  TestMwmBuilder builder(country, feature::DataHeader::country);
+
+  for (TRounded3DGeom const & geom3D : roadFeatures)
+    builder.Add(TestStreet(ConvertTo2DGeom<m2::PointD>(geom3D), string(), string()));
+}
+
+void ReadAndTestAltitudeInfo(MwmValue const * mwmValue, string const & mwmPath, MockAltitudeGetter & altitudeGetter)
+{
+  AltitudeLoader const loader(mwmValue);
+
+  auto processor = [&altitudeGetter, &loader](FeatureType const & f, uint32_t const & id)
+  {
+    f.ParseGeometry(FeatureType::BEST_GEOMETRY);
+    size_t const pointsCount = f.GetPointsCount();
+    TAltitudes const altitudes = loader.GetAltitude(id, pointsCount);
+
+    if (!routing::IsRoad(feature::TypesHolder(f)))
+    {
+      TEST(altitudes.empty(), ());
+      return;
+    }
+
+    TEST_EQUAL(altitudes.size(), pointsCount, ());
+
+    for (size_t i = 0; i < pointsCount; ++i)
+      TEST_EQUAL(altitudeGetter.GetAltitude(f.GetPoint(i)), altitudes[i], ("A wrong altitude"));
+  };
+  feature::ForEachFromDat(mwmPath, processor);
+}
+
+void TestAltitudeSection(vector<TRounded3DGeom> const & roadFeatures)
+{
+  classificator::Load();
+  Platform & platform = GetPlatform();
+  string const testDirFullPath = my::JoinFoldersToPath(platform.WritableDir(), kTestDir);
+
+  MY_SCOPE_GUARD(removeTmpDir, [&] ()
+  {
+    GetPlatform().RmDirRecursively(testDirFullPath);
+  });
+
+  // Building mwm without altitude section.
+  platform.MkDir(testDirFullPath);
+  LocalCountryFile country(testDirFullPath, CountryFile(kTestMwm), 1);
+  BuildMwmWithoutAltitude(roadFeatures, country);
+
+  // Creating MockAltitudeGetter.
+  MockAltitudeGetter::TMockAltitudes altitudes;
+  FillAltitudes(roadFeatures, altitudes);
+  MockAltitudeGetter altitudeGetter(move(altitudes));
+
+  // Adding altitude section to mwm.
+  BuildRoadAltitudes(testDirFullPath, kTestMwm, altitudeGetter);
+
+  // Reading from mwm and testing altitue information.
+  Index index;
+  pair<MwmSet::MwmId, MwmSet::RegResult> regResult = index.RegisterMap(country);
+  TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());
+
+  MwmSet::MwmHandle mwmHandle = index.GetMwmHandleById(regResult.first);
+  CHECK(mwmHandle.IsAlive(), ());
+
+  string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
+  ReadAndTestAltitudeInfo(mwmHandle.GetValue<MwmValue>(), mwmPath, altitudeGetter);
+}
+} // namespace
+
+UNIT_TEST(ZeroFeatures_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {};
+  TestAltitudeSection(roadFeatures);
+}
+
+UNIT_TEST(OneRoad_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {kRoad1};
+  TestAltitudeSection(roadFeatures);
+}
+
+UNIT_TEST(TwoConnectedRoads_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {kRoad1, kRoad2};
+  TestAltitudeSection(roadFeatures);
+}
+
+UNIT_TEST(TwoDisconnectedRoads_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {kRoad1, kRoad3};
+  TestAltitudeSection(roadFeatures);
+}
+
+UNIT_TEST(ThreeRoads_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {kRoad1, kRoad2, kRoad3};
+  TestAltitudeSection(roadFeatures);
+}
+
+UNIT_TEST(FourRoads_AltitudeGenerationTest)
+{
+  vector<TRounded3DGeom> const roadFeatures = {kRoad1, kRoad2, kRoad3, kRoad4};
+  TestAltitudeSection(roadFeatures);
+}

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -9,8 +9,8 @@
 
 #include "indexer/altitude_loader.hpp"
 #include "indexer/classificator_loader.hpp"
-#include "indexer/index.hpp"
 #include "indexer/feature_processor.hpp"
+#include "indexer/index.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -38,7 +38,8 @@ namespace
 // in the mwms are correct. The mwms are initialized with different sets of features.
 // There are several restrictions for these features:
 // * all of them are linear
-// * all coords of these features should be integer (it's necessary for easy implementation of MockAltitudeGetter)
+// * all coords of these features should be integer (it's necessary for easy implementation of
+// MockAltitudeGetter)
 // * if accoding to one feature a point has some altitude, the point of another feature
 //   with the same coords has to have the same altitude
 // @TODO(bykoianko) Add ability to add to the tests not road features without altitude information.
@@ -51,7 +52,6 @@ string const kTestMwm = "test";
 struct Point3D
 {
   Point3D(int32_t x, int32_t y, TAltitude a) : m_point(x, y), m_altitude(a) {}
-
   m2::PointI m_point;
   TAltitude m_altitude;
 };
@@ -69,7 +69,6 @@ public:
   using TMockAltitudes = map<m2::PointI, TAltitude>;
 
   MockAltitudeGetter(TMockAltitudes && altitudes) : m_altitudes(altitudes) {}
-
   // AltitudeGetter overrides:
   TAltitude GetAltitude(m2::PointD const & p) override
   {
@@ -103,7 +102,8 @@ void FillAltitudes(vector<TPoint3DList> const & roads,
       auto it = altitudes.find(geom3D[i].m_point);
       if (it != altitudes.end())
       {
-        CHECK_EQUAL(it->second, geom3D[i].m_altitude, ("Point", it->first, "is set with two different altitudes."));
+        CHECK_EQUAL(it->second, geom3D[i].m_altitude,
+                    ("Point", it->first, "is set with two different altitudes."));
         continue;
       }
       altitudes[geom3D[i].m_point] = geom3D[i].m_altitude;
@@ -119,12 +119,12 @@ void BuildMwmWithoutAltitudes(vector<TPoint3DList> const & roads, LocalCountryFi
     builder.Add(generator::tests_support::TestStreet(ExtractPoints(geom3D), string(), string()));
 }
 
-void TestAltitudes(MwmValue const & mwmValue, string const & mwmPath, MockAltitudeGetter & altitudeGetter)
+void TestAltitudes(MwmValue const & mwmValue, string const & mwmPath,
+                   MockAltitudeGetter & altitudeGetter)
 {
   AltitudeLoader loader(mwmValue);
 
-  auto processor = [&altitudeGetter, &loader](FeatureType const & f, uint32_t const & id)
-  {
+  auto processor = [&altitudeGetter, &loader](FeatureType const & f, uint32_t const & id) {
     f.ParseGeometry(FeatureType::BEST_GEOMETRY);
     size_t const pointsCount = f.GetPointsCount();
     TAltitudes const altitudes = loader.GetAltitudes(id, pointsCount);
@@ -210,4 +210,4 @@ UNIT_TEST(AltitudeGenerationTest_FourRoads)
   vector<TPoint3DList> const roads = {kRoad1, kRoad2, kRoad3, kRoad4};
   TestAltitudesBuilding(roads);
 }
-} // namespace
+}  // namespace

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -180,7 +180,8 @@ void TestAltitudeSection(vector<TRounded3DGeom> const & roadFeatures)
   MockAltitudeGetter altitudeGetter(move(altitudes));
 
   // Adding altitude section to mwm.
-  BuildRoadAltitudes(testDirFullPath, kTestMwm, altitudeGetter);
+  string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
+  BuildRoadAltitudes(mwmPath, altitudeGetter);
 
   // Reading from mwm and testing altitue information.
   Index index;
@@ -190,7 +191,6 @@ void TestAltitudeSection(vector<TRounded3DGeom> const & roadFeatures)
   MwmSet::MwmHandle mwmHandle = index.GetMwmHandleById(regResult.first);
   CHECK(mwmHandle.IsAlive(), ());
 
-  string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
   ReadAndTestAltitudeInfo(*mwmHandle.GetValue<MwmValue>(), mwmPath, altitudeGetter);
 }
 } // namespace

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -52,6 +52,7 @@ string const kTestMwm = "test";
 struct Point3D
 {
   Point3D(int32_t x, int32_t y, TAltitude a) : m_point(x, y), m_altitude(a) {}
+
   m2::PointI m_point;
   TAltitude m_altitude;
 };

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -134,7 +134,7 @@ void BuildMwmWithoutAltitude(vector<TRounded3DGeom> const & roadFeatures, LocalC
     builder.Add(TestStreet(ConvertTo2DGeom<m2::PointD>(geom3D), string(), string()));
 }
 
-void ReadAndTestAltitudeInfo(MwmValue const * mwmValue, string const & mwmPath, MockAltitudeGetter & altitudeGetter)
+void ReadAndTestAltitudeInfo(MwmValue const & mwmValue, string const & mwmPath, MockAltitudeGetter & altitudeGetter)
 {
   AltitudeLoader const loader(mwmValue);
 
@@ -142,7 +142,7 @@ void ReadAndTestAltitudeInfo(MwmValue const * mwmValue, string const & mwmPath, 
   {
     f.ParseGeometry(FeatureType::BEST_GEOMETRY);
     size_t const pointsCount = f.GetPointsCount();
-    TAltitudes const altitudes = loader.GetAltitude(id, pointsCount);
+    TAltitudes const altitudes = loader.GetAltitudes(id, pointsCount);
 
     if (!routing::IsRoad(feature::TypesHolder(f)))
     {
@@ -191,7 +191,7 @@ void TestAltitudeSection(vector<TRounded3DGeom> const & roadFeatures)
   CHECK(mwmHandle.IsAlive(), ());
 
   string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
-  ReadAndTestAltitudeInfo(mwmHandle.GetValue<MwmValue>(), mwmPath, altitudeGetter);
+  ReadAndTestAltitudeInfo(*mwmHandle.GetValue<MwmValue>(), mwmPath, altitudeGetter);
 }
 } // namespace
 

--- a/generator/generator_tests/generator_tests.pro
+++ b/generator/generator_tests/generator_tests.pro
@@ -4,7 +4,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = generator drape_frontend routing search storage indexer drape map platform editor geometry \
+DEPENDENCIES = generator_tests_support generator drape_frontend routing search storage indexer drape map platform editor geometry \
                coding base freetype expat fribidi tomcrypt jansson protobuf osrm stats_client \
                minizip succinct pugixml tess2 gflags oauthcpp
 
@@ -19,6 +19,7 @@ HEADERS += \
 
 SOURCES += \
     ../../testing/testingmain.cpp \
+    altitude_test.cpp \
     check_mwms.cpp \
     coasts_test.cpp \
     feature_builder_test.cpp \

--- a/generator/generator_tests/generator_tests.pro
+++ b/generator/generator_tests/generator_tests.pro
@@ -4,7 +4,8 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = generator_tests_support generator drape_frontend routing search storage indexer drape map platform editor geometry \
+DEPENDENCIES = generator_tests_support platform_tests_support generator drape_frontend routing search storage \
+               indexer drape map platform editor geometry \
                coding base freetype expat fribidi tomcrypt jansson protobuf osrm stats_client \
                minizip succinct pugixml tess2 gflags oauthcpp
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -1,3 +1,4 @@
+#include "generator/altitude_generator.hpp"
 #include "generator/borders_generator.hpp"
 #include "generator/borders_loader.hpp"
 #include "generator/check_model.hpp"
@@ -63,13 +64,14 @@ DEFINE_bool(fail_on_coasts, false, "Stop and exit with '255' code if some coastl
 DEFINE_bool(generate_addresses_file, false, "Generate .addr file (for '--output' option) with full addresses list.");
 DEFINE_string(osrm_file_name, "", "Input osrm file to generate routing info");
 DEFINE_bool(make_routing, false, "Make routing info based on osrm file");
-DEFINE_bool(make_cross_section, false, "Make corss section in routing file for cross mwm routing");
+DEFINE_bool(make_cross_section, false, "Make cross section in routing file for cross mwm routing");
 DEFINE_string(osm_file_name, "", "Input osm area file");
 DEFINE_string(osm_file_type, "xml", "Input osm area file type [xml, o5m]");
 DEFINE_string(user_resource_path, "", "User defined resource path for classificator.txt and etc.");
 DEFINE_string(booking_data, "", "Path to booking data in .tsv format");
 DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses");
 DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now");
+DEFINE_string(srtm_path, "", "Path to srtm directory. If it's set generates section with altitude information about road features.");
 
 int main(int argc, char ** argv)
 {
@@ -244,6 +246,9 @@ int main(int argc, char ** argv)
 
   if (FLAGS_dump_feature_names != "")
     feature::DumpFeatureNames(datFile, FLAGS_dump_feature_names);
+
+  if (!FLAGS_srtm_path.empty())
+    routing::BuildRoadFeatureAltitude(FLAGS_srtm_path, path, FLAGS_output);
 
   if (FLAGS_unpack_mwm)
     UnpackMwm(datFile);

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -71,7 +71,9 @@ DEFINE_string(user_resource_path, "", "User defined resource path for classifica
 DEFINE_string(booking_data, "", "Path to booking data in .tsv format");
 DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses");
 DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now");
-DEFINE_string(srtm_path, "", "Path to srtm directory. If When set generates section with altitude information about roads.");
+DEFINE_string(
+    srtm_path, "",
+    "Path to srtm directory. If When set generates section with altitude information about roads.");
 
 int main(int argc, char ** argv)
 {

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -36,21 +36,25 @@ DEFINE_bool(generate_classif, false, "Generate classificator.");
 
 DEFINE_bool(preprocess, false, "1st pass - create nodes/ways/relations data.");
 DEFINE_bool(make_coasts, false, "Create intermediate file with coasts data.");
-DEFINE_bool(emit_coasts, false, "Push coasts features from intermediate file to out files/countries.");
+DEFINE_bool(emit_coasts, false,
+            "Push coasts features from intermediate file to out files/countries.");
 
 DEFINE_bool(generate_features, false, "2nd pass - generate intermediate features.");
-DEFINE_bool(generate_geometry, false, "3rd pass - split and simplify geometry and triangles for features.");
+DEFINE_bool(generate_geometry, false,
+            "3rd pass - split and simplify geometry and triangles for features.");
 DEFINE_bool(generate_index, false, "4rd pass - generate index.");
 DEFINE_bool(generate_search_index, false, "5th pass - generate search index.");
 DEFINE_bool(calc_statistics, false, "Calculate feature statistics for specified mwm bucket files.");
 DEFINE_bool(type_statistics, false, "Calculate statistics by type for specified mwm bucket files.");
 DEFINE_bool(preload_cache, false, "Preload all ways and relations cache.");
-DEFINE_string(node_storage, "map", "Type of storage for intermediate points representation. Available: raw, map, mem.");
+DEFINE_string(node_storage, "map",
+              "Type of storage for intermediate points representation. Available: raw, map, mem.");
 DEFINE_string(data_path, "", "Working directory, 'path_to_exe/../../data' if empty.");
 DEFINE_string(output, "", "File name for process (without 'mwm' ext).");
 DEFINE_string(intermediate_data_path, "", "Path to stored nodes, ways, relations.");
 DEFINE_bool(generate_world, false, "Generate separate world file.");
-DEFINE_bool(split_by_polygons, false, "Use countries borders to split planet by regions and countries.");
+DEFINE_bool(split_by_polygons, false,
+            "Use countries borders to split planet by regions and countries.");
 DEFINE_bool(dump_types, false, "Prints all types combinations and their total count.");
 DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes.");
 DEFINE_bool(dump_search_tokens, false, "Print statistics on search tokens.");
@@ -70,10 +74,11 @@ DEFINE_string(osm_file_type, "xml", "Input osm area file type [xml, o5m].");
 DEFINE_string(user_resource_path, "", "User defined resource path for classificator.txt and etc.");
 DEFINE_string(booking_data, "", "Path to booking data in .tsv format.");
 DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses.");
-DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now.");
-DEFINE_string(
-    srtm_path, "",
-    "Path to srtm directory. If it is set, generates section with altitude information about roads.");
+DEFINE_uint64(planet_version, my::SecondsSinceEpoch(),
+              "Version as seconds since epoch, by default - now.");
+DEFINE_string(srtm_path, "",
+              "Path to srtm directory. If it is set, generates section with altitude information "
+              "about roads.");
 
 int main(int argc, char ** argv)
 {

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -250,7 +250,10 @@ int main(int argc, char ** argv)
     feature::DumpFeatureNames(datFile, FLAGS_dump_feature_names);
 
   if (!FLAGS_srtm_path.empty())
-    routing::BuildRoadAltitudes(FLAGS_srtm_path, path, FLAGS_output);
+  {
+    string const mwmPath = my::JoinFoldersToPath(path, FLAGS_output + DATA_FILE_EXTENSION);
+    routing::BuildRoadAltitudes(FLAGS_srtm_path, mwmPath);
+  }
 
   if (FLAGS_unpack_mwm)
     UnpackMwm(datFile);

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -71,7 +71,7 @@ DEFINE_string(user_resource_path, "", "User defined resource path for classifica
 DEFINE_string(booking_data, "", "Path to booking data in .tsv format");
 DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses");
 DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now");
-DEFINE_string(srtm_path, "", "Path to srtm directory. If it's set generates section with altitude information about road features.");
+DEFINE_string(srtm_path, "", "Path to srtm directory. If When set generates section with altitude information about roads.");
 
 int main(int argc, char ** argv)
 {
@@ -248,7 +248,7 @@ int main(int argc, char ** argv)
     feature::DumpFeatureNames(datFile, FLAGS_dump_feature_names);
 
   if (!FLAGS_srtm_path.empty())
-    routing::BuildRoadFeatureAltitude(FLAGS_srtm_path, path, FLAGS_output);
+    routing::BuildRoadAltitudes(FLAGS_srtm_path, path, FLAGS_output);
 
   if (FLAGS_unpack_mwm)
     UnpackMwm(datFile);

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -34,25 +34,25 @@
 
 DEFINE_bool(generate_classif, false, "Generate classificator.");
 
-DEFINE_bool(preprocess, false, "1st pass - create nodes/ways/relations data");
-DEFINE_bool(make_coasts, false, "create intermediate file with coasts data");
-DEFINE_bool(emit_coasts, false, "push coasts features from intermediate file to out files/countries");
+DEFINE_bool(preprocess, false, "1st pass - create nodes/ways/relations data.");
+DEFINE_bool(make_coasts, false, "Create intermediate file with coasts data.");
+DEFINE_bool(emit_coasts, false, "Push coasts features from intermediate file to out files/countries.");
 
-DEFINE_bool(generate_features, false, "2nd pass - generate intermediate features");
-DEFINE_bool(generate_geometry, false, "3rd pass - split and simplify geometry and triangles for features");
-DEFINE_bool(generate_index, false, "4rd pass - generate index");
-DEFINE_bool(generate_search_index, false, "5th pass - generate search index");
-DEFINE_bool(calc_statistics, false, "Calculate feature statistics for specified mwm bucket files");
-DEFINE_bool(type_statistics, false, "Calculate statistics by type for specified mwm bucket files");
-DEFINE_bool(preload_cache, false, "Preload all ways and relations cache");
-DEFINE_string(node_storage, "map", "Type of storage for intermediate points representation. Available: raw, map, mem");
+DEFINE_bool(generate_features, false, "2nd pass - generate intermediate features.");
+DEFINE_bool(generate_geometry, false, "3rd pass - split and simplify geometry and triangles for features.");
+DEFINE_bool(generate_index, false, "4rd pass - generate index.");
+DEFINE_bool(generate_search_index, false, "5th pass - generate search index.");
+DEFINE_bool(calc_statistics, false, "Calculate feature statistics for specified mwm bucket files.");
+DEFINE_bool(type_statistics, false, "Calculate statistics by type for specified mwm bucket files.");
+DEFINE_bool(preload_cache, false, "Preload all ways and relations cache.");
+DEFINE_string(node_storage, "map", "Type of storage for intermediate points representation. Available: raw, map, mem.");
 DEFINE_string(data_path, "", "Working directory, 'path_to_exe/../../data' if empty.");
 DEFINE_string(output, "", "File name for process (without 'mwm' ext).");
 DEFINE_string(intermediate_data_path, "", "Path to stored nodes, ways, relations.");
-DEFINE_bool(generate_world, false, "Generate separate world file");
-DEFINE_bool(split_by_polygons, false, "Use countries borders to split planet by regions and countries");
-DEFINE_bool(dump_types, false, "Prints all types combinations and their total count");
-DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes");
+DEFINE_bool(generate_world, false, "Generate separate world file.");
+DEFINE_bool(split_by_polygons, false, "Use countries borders to split planet by regions and countries.");
+DEFINE_bool(dump_types, false, "Prints all types combinations and their total count.");
+DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes.");
 DEFINE_bool(dump_search_tokens, false, "Print statistics on search tokens.");
 DEFINE_string(dump_feature_names, "", "Print all feature names by 2-letter locale.");
 DEFINE_bool(unpack_mwm, false, "Unpack each section of mwm into a separate file with name filePath.sectionName.");
@@ -62,18 +62,18 @@ DEFINE_bool(check_mwm, false, "Check map file to be correct.");
 DEFINE_string(delete_section, "", "Delete specified section (defines.hpp) from container.");
 DEFINE_bool(fail_on_coasts, false, "Stop and exit with '255' code if some coastlines are not merged.");
 DEFINE_bool(generate_addresses_file, false, "Generate .addr file (for '--output' option) with full addresses list.");
-DEFINE_string(osrm_file_name, "", "Input osrm file to generate routing info");
-DEFINE_bool(make_routing, false, "Make routing info based on osrm file");
-DEFINE_bool(make_cross_section, false, "Make cross section in routing file for cross mwm routing");
-DEFINE_string(osm_file_name, "", "Input osm area file");
-DEFINE_string(osm_file_type, "xml", "Input osm area file type [xml, o5m]");
+DEFINE_string(osrm_file_name, "", "Input osrm file to generate routing info.");
+DEFINE_bool(make_routing, false, "Make routing info based on osrm file.");
+DEFINE_bool(make_cross_section, false, "Make cross section in routing file for cross mwm routing.");
+DEFINE_string(osm_file_name, "", "Input osm area file.");
+DEFINE_string(osm_file_type, "xml", "Input osm area file type [xml, o5m].");
 DEFINE_string(user_resource_path, "", "User defined resource path for classificator.txt and etc.");
-DEFINE_string(booking_data, "", "Path to booking data in .tsv format");
-DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses");
-DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now");
+DEFINE_string(booking_data, "", "Path to booking data in .tsv format.");
+DEFINE_string(booking_reference_path, "", "Path to mwm dataset for match booking addresses.");
+DEFINE_uint64(planet_version, my::SecondsSinceEpoch(), "Version as seconds since epoch, by default - now.");
 DEFINE_string(
     srtm_path, "",
-    "Path to srtm directory. If When set generates section with altitude information about roads.");
+    "Path to srtm directory. If it is set, generates section with altitude information about roads.");
 
 int main(int argc, char ** argv)
 {

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -212,9 +212,12 @@ int main(int argc, char ** argv)
       if (!search::RankTableBuilder::CreateIfNotExists(datFile))
         LOG(LCRITICAL, ("Error generating rank table."));
     }
+
+    if (!FLAGS_srtm_path.empty())
+      routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
   }
 
-  string const datFile = path + FLAGS_output + DATA_FILE_EXTENSION;
+  string const datFile = my::JoinFoldersToPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
   if (FLAGS_calc_statistics)
   {
@@ -248,12 +251,6 @@ int main(int argc, char ** argv)
 
   if (FLAGS_dump_feature_names != "")
     feature::DumpFeatureNames(datFile, FLAGS_dump_feature_names);
-
-  if (!FLAGS_srtm_path.empty())
-  {
-    string const mwmPath = my::JoinFoldersToPath(path, FLAGS_output + DATA_FILE_EXTENSION);
-    routing::BuildRoadAltitudes(FLAGS_srtm_path, mwmPath);
-  }
 
   if (FLAGS_unpack_mwm)
     UnpackMwm(datFile);

--- a/generator/routing_generator.cpp
+++ b/generator/routing_generator.cpp
@@ -15,12 +15,13 @@
 #include "indexer/feature.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/index.hpp"
-#include "geometry/mercator.hpp"
 
 #include "geometry/distance_on_sphere.hpp"
+#include "geometry/mercator.hpp"
 
 #include "coding/file_container.hpp"
 #include "coding/read_write_utils.hpp"
+
 #include "coding/internal/file_data.hpp"
 
 #include "base/logging.hpp"

--- a/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
+++ b/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
@@ -4,6 +4,8 @@
 
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
+#include "indexer/feature_altitude.hpp"
+
 #include "coding/file_name_utils.hpp"
 
 #include "platform/country_file.hpp"
@@ -98,7 +100,7 @@ int main(int argc, char * argv[])
         for (auto const & point : path)
         {
           auto const height = manager.GetHeight(MercatorBounds::ToLatLon(point));
-          if (height != generator::SrtmTile::kInvalidHeight)
+          if (height != feature::kInvalidAltitude)
             good++;
         }
       }

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -145,7 +145,6 @@ void SrtmTile::Invalidate()
 
 // SrtmTileManager ---------------------------------------------------------------------------------
 SrtmTileManager::SrtmTileManager(string const & dir) : m_dir(dir) {}
-
 feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 {
   string const base = SrtmTile::GetBase(coord);

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -84,10 +84,10 @@ void SrtmTile::Init(string const & dir, ms::LatLon const & coord)
   m_valid = true;
 }
 
-SrtmTile::THeight SrtmTile::GetHeight(ms::LatLon const & coord)
+feature::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
 {
   if (!IsValid())
-    return kInvalidHeight;
+    return feature::kInvalidAltitude;
 
   double ln = coord.lon - static_cast<int>(coord.lon);
   if (ln < 0)
@@ -103,7 +103,7 @@ SrtmTile::THeight SrtmTile::GetHeight(ms::LatLon const & coord)
   size_t const ix = row * (kArcSecondsInDegree + 1) + col;
 
   if (ix >= Size())
-    return kInvalidHeight;
+    return feature::kInvalidAltitude;
   return ReverseByteOrder(Data()[ix]);
 }
 
@@ -146,7 +146,7 @@ void SrtmTile::Invalidate()
 // SrtmTileManager ---------------------------------------------------------------------------------
 SrtmTileManager::SrtmTileManager(string const & dir) : m_dir(dir) {}
 
-SrtmTile::THeight SrtmTileManager::GetHeight(ms::LatLon const & coord)
+feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 {
   string const base = SrtmTile::GetBase(coord);
   auto it = m_tiles.find(base);

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -22,7 +22,7 @@ public:
 
   inline bool IsValid() const { return m_valid; }
 
-  // Returns height in meters at |coord|, or kInvalidAltitude if is not initialized.
+  // Returns height in meters at |coord| or kInvalidAltitude.
   feature::TAltitude GetHeight(ms::LatLon const & coord);
 
   static string GetBase(ms::LatLon coord);

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -2,6 +2,8 @@
 
 #include "geometry/latlon.hpp"
 
+#include "indexer/feature_altitude.hpp"
+
 #include "base/macros.hpp"
 
 #include "std/cstdint.hpp"
@@ -13,10 +15,6 @@ namespace generator
 class SrtmTile
 {
 public:
-  using THeight = int16_t;
-
-  static THeight constexpr kInvalidHeight = -32768;
-
   SrtmTile();
   SrtmTile(SrtmTile && rhs);
 
@@ -24,15 +22,15 @@ public:
 
   inline bool IsValid() const { return m_valid; }
 
-  // Returns height in meters at |coord|, or kInvalidHeight if is not initialized.
-  THeight GetHeight(ms::LatLon const & coord);
+  // Returns height in meters at |coord|, or kInvalidAltitude if is not initialized.
+  feature::TAltitude GetHeight(ms::LatLon const & coord);
 
   static string GetBase(ms::LatLon coord);
 
 private:
-  inline THeight const * Data() const { return reinterpret_cast<THeight const *>(m_data.data()); };
+  inline feature::TAltitude const * Data() const { return reinterpret_cast<feature::TAltitude const *>(m_data.data()); };
 
-  inline size_t Size() const { return m_data.size() / sizeof(THeight); }
+  inline size_t Size() const { return m_data.size() / sizeof(feature::TAltitude); }
 
   void Invalidate();
 
@@ -47,7 +45,7 @@ class SrtmTileManager
 public:
   SrtmTileManager(string const & dir);
 
-  SrtmTile::THeight GetHeight(ms::LatLon const & coord);
+  feature::TAltitude GetHeight(ms::LatLon const & coord);
 
 private:
   string m_dir;

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -21,7 +21,6 @@ public:
   void Init(string const & dir, ms::LatLon const & coord);
 
   inline bool IsValid() const { return m_valid; }
-
   // Returns height in meters at |coord| or kInvalidAltitude.
   feature::TAltitude GetHeight(ms::LatLon const & coord);
 
@@ -34,7 +33,6 @@ private:
   };
 
   inline size_t Size() const { return m_data.size() / sizeof(feature::TAltitude); }
-
   void Invalidate();
 
   string m_data;

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -28,7 +28,10 @@ public:
   static string GetBase(ms::LatLon coord);
 
 private:
-  inline feature::TAltitude const * Data() const { return reinterpret_cast<feature::TAltitude const *>(m_data.data()); };
+  inline feature::TAltitude const * Data() const
+  {
+    return reinterpret_cast<feature::TAltitude const *>(m_data.data());
+  };
 
   inline size_t Size() const { return m_data.size() / sizeof(feature::TAltitude); }
 

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -9,6 +9,8 @@
 
 #include "defines.hpp"
 
+#include "std/algorithm.hpp"
+
 #include "3party/succinct/mapper.hpp"
 
 namespace
@@ -59,7 +61,7 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
   if (!HasAltitudes())
   {
     // The version of mwm is less than version::Format::v8 or there's no altitude section in mwm.
-    return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, kDefautlAltitudeMeters))).first->second;
+    return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, kDefaultAltitudeMeters))).first->second;
   }
 
   auto const it = m_cache.find(featureId);
@@ -87,9 +89,9 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
     src.Skip(altitudeInfoOffsetInSection);
     altitudes.Deserialize(m_header.m_minAltitude, pointCount, src);
 
-    bool const isResultValid = none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
-                                       [](TAltitude a) { return a == kInvalidAltitude; });
-    if (!isResultValid)
+    bool const allValid = none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
+                                  [](TAltitude a) { return a == kInvalidAltitude; });
+    if (!allValid)
     {
       ASSERT(false, (altitudes.m_altitudes));
       return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, m_header.m_minAltitude))).first->second;

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -1,0 +1,49 @@
+#include "indexer/altitude_loader.hpp"
+
+#include "base/logging.hpp"
+#include "base/stl_helpers.hpp"
+
+#include "defines.hpp"
+
+namespace feature
+{
+AltitudeLoader::AltitudeLoader(MwmValue const * mwmValue)
+{
+  if (!mwmValue || mwmValue->GetHeader().GetFormat() < version::Format::v8 )
+    return;
+
+  try
+  {
+    m_idx = make_unique<DDVector<TAltitudeIndexEntry, FilesContainerR::TReader>>
+        (mwmValue->m_cont.GetReader(ALTITUDE_FILE_TAG));
+  }
+  catch (Reader::OpenException const &)
+  {
+    LOG(LINFO, ("MWM does not contain", ALTITUDE_FILE_TAG, "section."));
+  }
+}
+
+Altitudes AltitudeLoader::GetAltitudes(uint32_t featureId) const
+{
+  if (!m_idx || m_idx->size() == 0)
+    return Altitudes();
+
+  auto it = lower_bound(m_idx->begin(), m_idx->end(),
+                        TAltitudeIndexEntry{static_cast<uint32_t>(featureId), 0, 0},
+                        my::LessBy(&TAltitudeIndexEntry::featureId));
+
+  if (it == m_idx->end())
+    return Altitudes();
+
+  if (featureId != it->featureId)
+  {
+    ASSERT(false, ());
+    return Altitudes();
+  }
+
+  if (it->beginAlt == kInvalidAltitude || it->endAlt == kInvalidAltitude)
+    return Altitudes();
+
+  return Altitudes(it->beginAlt, it->endAlt);
+}
+} // namespace feature

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -60,6 +60,11 @@ AltitudeLoader::AltitudeLoader(MwmValue const * mwmValue)
   }
 }
 
+bool AltitudeLoader::IsAvailable() const
+{
+  return m_header.minAltitude != kInvalidAltitude && m_header.altitudeInfoOffset != 0;
+}
+
 TAltitudes AltitudeLoader::GetAltitude(uint32_t featureId, size_t pointCount) const
 {
   if (m_header.altitudeInfoOffset == 0)

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -87,16 +87,15 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
     src.Skip(altitudeInfoOffsetInSection);
     altitudes.Deserialize(m_header.m_minAltitude, pointCount, src);
 
-    TAltitudes pntAlt = altitudes.GetAltitudes();
-    bool const isResultValid = none_of(pntAlt.begin(), pntAlt.end(),
+    bool const isResultValid = none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
                                        [](TAltitude a) { return a == kInvalidAltitude; });
     if (!isResultValid)
     {
-      ASSERT(false, (pntAlt));
+      ASSERT(false, (altitudes.m_altitudes));
       return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, m_header.m_minAltitude))).first->second;
     }
 
-    return m_cache.insert(make_pair(featureId, move(pntAlt))).first->second;
+    return m_cache.insert(make_pair(featureId, move(altitudes.m_altitudes))).first->second;
   }
   catch (Reader::OpenException const & e)
   {

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -87,10 +87,11 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
     Altitudes altitudes;
     ReaderSource<FilesContainerR::TReader> src(*m_reader);
     src.Skip(altitudeInfoOffsetInSection);
-    altitudes.Deserialize(m_header.m_minAltitude, pointCount, src);
+    bool const isDeserialized = altitudes.Deserialize(m_header.m_minAltitude, pointCount, src);
 
-    bool const allValid = none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
-                                  [](TAltitude a) { return a == kInvalidAltitude; });
+    bool const allValid = isDeserialized
+        && none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
+                   [](TAltitude a) { return a == kInvalidAltitude; });
     if (!allValid)
     {
       ASSERT(false, (altitudes.m_altitudes));

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -13,9 +13,9 @@
 
 namespace
 {
-template<class TCont>
-void LoadAndMap(size_t dataSize, ReaderSource<FilesContainerR::TReader> & src,
-                TCont & cont, unique_ptr<CopiedMemoryRegion> & region)
+template <class TCont>
+void LoadAndMap(size_t dataSize, ReaderSource<FilesContainerR::TReader> & src, TCont & cont,
+                unique_ptr<CopiedMemoryRegion> & region)
 {
   vector<uint8_t> data(dataSize);
   src.Read(data.data(), data.size());
@@ -23,13 +23,13 @@ void LoadAndMap(size_t dataSize, ReaderSource<FilesContainerR::TReader> & src,
   coding::MapVisitor visitor(region->ImmutableData());
   cont.map(visitor);
 }
-} // namespace
+}  // namespace
 
 namespace feature
 {
 AltitudeLoader::AltitudeLoader(MwmValue const & mwmValue)
 {
-  if (mwmValue.GetHeader().GetFormat() < version::Format::v8 )
+  if (mwmValue.GetHeader().GetFormat() < version::Format::v8)
     return;
 
   if (!mwmValue.m_cont.IsExist(ALTITUDES_FILE_TAG))
@@ -52,11 +52,7 @@ AltitudeLoader::AltitudeLoader(MwmValue const & mwmValue)
   }
 }
 
-bool AltitudeLoader::HasAltitudes() const
-{
-  return m_header.m_minAltitude != kInvalidAltitude;
-}
-
+bool AltitudeLoader::HasAltitudes() const { return m_header.m_minAltitude != kInvalidAltitude; }
 TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t pointCount)
 {
   if (!HasAltitudes())
@@ -98,4 +94,4 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
     return m_cache.insert(make_pair(featureId, m_dummy)).first->second;
   }
 }
-} // namespace feature
+}  // namespace feature

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -30,7 +30,7 @@ void ReadBuffer(ReaderSource<FilesContainerR::TReader> & rs, vector<char> & buf)
 namespace feature
 {
 AltitudeLoader::AltitudeLoader(MwmValue const * mwmValue)
-  : reader(mwmValue->m_cont.GetReader(ALTITUDE_FILE_TAG)), m_altitudeInfoOffset(0), m_minAltitude(kInvalidAltitude)
+  : reader(mwmValue->m_cont.GetReader(ALTITUDES_FILE_TAG)), m_altitudeInfoOffset(0), m_minAltitude(kInvalidAltitude)
 {
   if (!mwmValue || mwmValue->GetHeader().GetFormat() < version::Format::v8 )
     return;
@@ -54,7 +54,7 @@ AltitudeLoader::AltitudeLoader(MwmValue const * mwmValue)
   {
     m_altitudeInfoOffset = 0;
     m_minAltitude = kInvalidAltitude;
-    LOG(LINFO, ("MWM does not contain", ALTITUDE_FILE_TAG, "section.", e.Msg()));
+    LOG(LINFO, ("MWM does not contain", ALTITUDES_FILE_TAG, "section.", e.Msg()));
   }
 }
 

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -1,49 +1,110 @@
 #include "indexer/altitude_loader.hpp"
 
+#include "coding/reader.hpp"
+
 #include "base/logging.hpp"
 #include "base/stl_helpers.hpp"
+#include "base/thread.hpp"
 
 #include "defines.hpp"
+
+#include "3party/succinct/mapper.hpp"
+
+namespace
+{
+void ReadBuffer(ReaderSource<FilesContainerR::TReader> & rs, vector<char> & buf)
+{
+  uint32_t bufSz = 0;
+  rs.Read(&bufSz, sizeof(bufSz));
+  if (bufSz > rs.Size() + rs.Pos())
+  {
+    ASSERT(false, ());
+    return;
+  }
+  buf.clear();
+  buf.resize(bufSz);
+  rs.Read(buf.data(), bufSz);
+}
+} // namespace
 
 namespace feature
 {
 AltitudeLoader::AltitudeLoader(MwmValue const * mwmValue)
+  : reader(mwmValue->m_cont.GetReader(ALTITUDE_FILE_TAG)), m_altitudeInfoOffset(0), m_minAltitude(kInvalidAltitude)
 {
   if (!mwmValue || mwmValue->GetHeader().GetFormat() < version::Format::v8 )
     return;
 
   try
   {
-    m_idx = make_unique<DDVector<TAltitudeIndexEntry, FilesContainerR::TReader>>
-        (mwmValue->m_cont.GetReader(ALTITUDE_FILE_TAG));
+    ReaderSource<FilesContainerR::TReader> rs(reader);
+    DeserializeHeader(rs);
+
+    // Reading rs_bit_vector with altitude availability information.
+    ReadBuffer(rs, m_altitudeAvailabilitBuf);
+    m_altitudeAvailability = make_unique<succinct::rs_bit_vector>();
+    succinct::mapper::map(*m_altitudeAvailability, m_altitudeAvailabilitBuf.data());
+
+    // Reading table with altitude ofsets for features.
+    ReadBuffer(rs, m_featureTableBuf);
+    m_featureTable = make_unique<succinct::elias_fano>();
+    succinct::mapper::map(*m_featureTable, m_featureTableBuf.data());
   }
-  catch (Reader::OpenException const &)
+  catch (Reader::OpenException const & e)
   {
-    LOG(LINFO, ("MWM does not contain", ALTITUDE_FILE_TAG, "section."));
+    m_altitudeInfoOffset = 0;
+    m_minAltitude = kInvalidAltitude;
+    LOG(LINFO, ("MWM does not contain", ALTITUDE_FILE_TAG, "section.", e.Msg()));
   }
 }
 
-Altitudes AltitudeLoader::GetAltitudes(uint32_t featureId) const
+void AltitudeLoader::DeserializeHeader(ReaderSource<FilesContainerR::TReader> & rs)
 {
-  if (!m_idx || m_idx->size() == 0)
-    return Altitudes();
+  TAltitudeSectionVersion version;
+  rs.Read(&version, sizeof(version));
+  LOG(LINFO, ("Reading version =", version));
+  rs.Read(&m_minAltitude, sizeof(m_minAltitude));
+  LOG(LINFO, ("Reading m_minAltitude =", m_minAltitude));
+  rs.Read(&m_altitudeInfoOffset, sizeof(m_altitudeInfoOffset));
+  LOG(LINFO, ("Reading m_altitudeInfoOffset =", m_altitudeInfoOffset));
+}
 
-  auto it = lower_bound(m_idx->begin(), m_idx->end(),
-                        TAltitudeIndexEntry{static_cast<uint32_t>(featureId), 0, 0},
-                        my::LessBy(&TAltitudeIndexEntry::featureId));
-
-  if (it == m_idx->end())
-    return Altitudes();
-
-  if (featureId != it->featureId)
+TAltitudes AltitudeLoader::GetAltitude(uint32_t featureId, size_t pointCount) const
+{
+  if (m_altitudeInfoOffset == 0)
   {
-    ASSERT(false, ());
-    return Altitudes();
+    // The version of mwm is less then version::Format::v8 or there's no altitude section in mwm.
+    return TAltitudes();
   }
 
-  if (it->beginAlt == kInvalidAltitude || it->endAlt == kInvalidAltitude)
-    return Altitudes();
+  if (!(*m_altitudeAvailability)[featureId])
+  {
+    LOG(LINFO, ("Feature featureId =", featureId, "does not contain any altitude information."));
+    return TAltitudes();
+  }
 
-  return Altitudes(it->beginAlt, it->endAlt);
+  uint64_t const r = m_altitudeAvailability->rank(featureId);
+  CHECK_LESS(r, m_altitudeAvailability->size(), (featureId));
+  uint64_t const offset = m_featureTable->select(r);
+  CHECK_LESS(offset, m_featureTable->size(), (featureId));
+
+  uint64_t const m_altitudeInfoOffsetInSection = m_altitudeInfoOffset + offset;
+  CHECK_LESS(m_altitudeInfoOffsetInSection, reader.Size(), ());
+
+  try
+  {
+    Altitude a;
+    ReaderSource<FilesContainerR::TReader> rs(reader);
+    rs.Skip(m_altitudeInfoOffsetInSection);
+    a.Deserialize(m_minAltitude, pointCount, rs);
+
+    // @TODO(bykoianko) Considers using move semantic for returned value here.
+    return a.GetAltitudes();
+  }
+  catch (Reader::OpenException const & e)
+  {
+    LOG(LERROR, ("Error while getting mwm data", e.Msg()));
+    return TAltitudes();
+  }
 }
 } // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "indexer/feature_altitude.hpp"
+#include "indexer/index.hpp"
+
+#include "coding/dd_vector.hpp"
+
+namespace feature
+{
+class AltitudeLoader
+{
+public:
+  AltitudeLoader(MwmValue const * mwmValue);
+  Altitudes GetAltitudes(uint32_t featureId) const;
+
+private:
+  struct TAltitudeIndexEntry
+  {
+    uint32_t featureId;
+    feature::TAltitude beginAlt;
+    feature::TAltitude endAlt;
+  };
+
+  unique_ptr<DDVector<TAltitudeIndexEntry, FilesContainerR::TReader>> m_idx;
+};
+} // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -9,9 +9,6 @@
 
 namespace feature
 {
-using TAltitudeSectionVersion = uint16_t;
-using TAltitudeSectionOffset = uint32_t;
-
 class AltitudeLoader
 {
 public:
@@ -20,14 +17,11 @@ public:
   TAltitudes GetAltitude(uint32_t featureId, size_t pointCount) const;
 
 private:
-  void DeserializeHeader(ReaderSource<FilesContainerR::TReader> & rs);
-
   vector<char> m_altitudeAvailabilitBuf;
   vector<char> m_featureTableBuf;
   unique_ptr<succinct::rs_bit_vector> m_altitudeAvailability;
   unique_ptr<succinct::elias_fano> m_featureTable;
   unique_ptr<FilesContainerR::TReader> m_reader;
-  TAltitudeSectionOffset m_altitudeInfoOffset;
-  TAltitude m_minAltitude;
+  AltitudeHeader m_header;
 };
 } // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -16,10 +16,13 @@ class AltitudeLoader
 public:
   explicit AltitudeLoader(MwmValue const & mwmValue);
 
+  /// \returns altitude of feature with |featureId|. All items of the returned vertor are valid
+  /// or the returned vertor is empty.
   TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
-  bool HasAltitudes() const;
 
 private:
+  bool HasAltitudes() const;
+
   unique_ptr<CopiedMemoryRegion> m_altitudeAvailabilityRegion;
   unique_ptr<CopiedMemoryRegion> m_featureTableRegion;
 
@@ -28,7 +31,6 @@ private:
 
   unique_ptr<FilesContainerR::TReader> m_reader;
   map<uint32_t, TAltitudes> m_cache;
-  TAltitudes const m_dummy;
   AltitudeHeader m_header;
 };
 }  // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -2,24 +2,32 @@
 #include "indexer/feature_altitude.hpp"
 #include "indexer/index.hpp"
 
-#include "coding/dd_vector.hpp"
+#include "3party/succinct/rs_bit_vector.hpp"
+
+#include "std/unique_ptr.hpp"
+#include "std/vector.hpp"
 
 namespace feature
 {
+using TAltitudeSectionVersion = uint16_t;
+using TAltitudeSectionOffset = uint32_t;
+
 class AltitudeLoader
 {
 public:
   AltitudeLoader(MwmValue const * mwmValue);
-  Altitudes GetAltitudes(uint32_t featureId) const;
+
+  TAltitudes GetAltitude(uint32_t featureId, size_t pointCount) const;
 
 private:
-  struct TAltitudeIndexEntry
-  {
-    uint32_t featureId;
-    feature::TAltitude beginAlt;
-    feature::TAltitude endAlt;
-  };
+  void DeserializeHeader(ReaderSource<FilesContainerR::TReader> & rs);
 
-  unique_ptr<DDVector<TAltitudeIndexEntry, FilesContainerR::TReader>> m_idx;
+  vector<char> m_altitudeAvailabilitBuf;
+  vector<char> m_featureTableBuf;
+  unique_ptr<succinct::rs_bit_vector> m_altitudeAvailability;
+  unique_ptr<succinct::elias_fano> m_featureTable;
+  FilesContainerR::TReader reader;
+  TAltitudeSectionOffset m_altitudeInfoOffset;
+  TAltitude m_minAltitude;
 };
 } // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -16,8 +16,8 @@ class AltitudeLoader
 public:
   explicit AltitudeLoader(MwmValue const & mwmValue);
 
-  TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount) const;
-  bool IsAvailable() const;
+  TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
+  bool HasAltitudes() const;
 
 private:
   unique_ptr<CopiedMemoryRegion> m_altitudeAvailabilityRegion;
@@ -27,7 +27,7 @@ private:
   succinct::elias_fano m_featureTable;
 
   unique_ptr<FilesContainerR::TReader> m_reader;
-  mutable map<uint32_t, TAltitudes> m_cache;
+  map<uint32_t, TAltitudes> m_cache;
   TAltitudes const m_dummy;
   AltitudeHeader m_header;
 };

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -15,7 +15,7 @@ using TAltitudeSectionOffset = uint32_t;
 class AltitudeLoader
 {
 public:
-  AltitudeLoader(MwmValue const * mwmValue);
+  explicit AltitudeLoader(MwmValue const * mwmValue);
 
   TAltitudes GetAltitude(uint32_t featureId, size_t pointCount) const;
 

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -2,6 +2,8 @@
 #include "indexer/feature_altitude.hpp"
 #include "indexer/index.hpp"
 
+#include "coding/memory_region.hpp"
+
 #include "std/unique_ptr.hpp"
 #include "std/vector.hpp"
 
@@ -18,10 +20,12 @@ public:
   bool IsAvailable() const;
 
 private:
-  vector<char> m_altitudeAvailabilitBuf;
-  vector<char> m_featureTableBuf;
+  unique_ptr<CopiedMemoryRegion> m_altitudeAvailabilityRegion;
+  unique_ptr<CopiedMemoryRegion> m_featureTableRegion;
+
   succinct::rs_bit_vector m_altitudeAvailability;
   succinct::elias_fano m_featureTable;
+
   unique_ptr<FilesContainerR::TReader> m_reader;
   mutable map<uint32_t, TAltitudes> m_cache;
   TAltitudes const m_dummy;

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -15,6 +15,7 @@ public:
   explicit AltitudeLoader(MwmValue const * mwmValue);
 
   TAltitudes GetAltitude(uint32_t featureId, size_t pointCount) const;
+  bool IsAvailable() const;
 
 private:
   vector<char> m_altitudeAvailabilitBuf;

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -2,27 +2,29 @@
 #include "indexer/feature_altitude.hpp"
 #include "indexer/index.hpp"
 
-#include "3party/succinct/rs_bit_vector.hpp"
-
 #include "std/unique_ptr.hpp"
 #include "std/vector.hpp"
+
+#include "3party/succinct/rs_bit_vector.hpp"
 
 namespace feature
 {
 class AltitudeLoader
 {
 public:
-  explicit AltitudeLoader(MwmValue const * mwmValue);
+  explicit AltitudeLoader(MwmValue const & mwmValue);
 
-  TAltitudes GetAltitude(uint32_t featureId, size_t pointCount) const;
+  TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount) const;
   bool IsAvailable() const;
 
 private:
   vector<char> m_altitudeAvailabilitBuf;
   vector<char> m_featureTableBuf;
-  unique_ptr<succinct::rs_bit_vector> m_altitudeAvailability;
-  unique_ptr<succinct::elias_fano> m_featureTable;
+  succinct::rs_bit_vector m_altitudeAvailability;
+  succinct::elias_fano m_featureTable;
   unique_ptr<FilesContainerR::TReader> m_reader;
+  mutable map<uint32_t, TAltitudes> m_cache;
+  TAltitudes const m_dummy;
   AltitudeHeader m_header;
 };
 } // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -16,8 +16,8 @@ class AltitudeLoader
 public:
   explicit AltitudeLoader(MwmValue const & mwmValue);
 
-  /// \returns altitude of feature with |featureId|. All items of the returned vertor are valid
-  /// or the returned vertor is empty.
+  /// \returns altitude of feature with |featureId|. All items of the returned vector are valid
+  /// or the returned vector is empty.
   TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
 
 private:

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -31,4 +31,4 @@ private:
   TAltitudes const m_dummy;
   AltitudeHeader m_header;
 };
-} // namespace feature
+}  // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -26,7 +26,7 @@ private:
   vector<char> m_featureTableBuf;
   unique_ptr<succinct::rs_bit_vector> m_altitudeAvailability;
   unique_ptr<succinct::elias_fano> m_featureTable;
-  FilesContainerR::TReader reader;
+  unique_ptr<FilesContainerR::TReader> m_reader;
   TAltitudeSectionOffset m_altitudeInfoOffset;
   TAltitude m_minAltitude;
 };

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -302,7 +302,8 @@ void FeatureType::Deserialize(feature::LoaderBase * pLoader, TBuffer buffer)
 
   m_pLoader->InitFeature(this);
 
-  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = m_altitudeParsed = false;
+  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = m_altitudeParsed =
+      false;
 
   m_innerStats.MakeZero();
 }

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -302,7 +302,7 @@ void FeatureType::Deserialize(feature::LoaderBase * pLoader, TBuffer buffer)
 
   m_pLoader->InitFeature(this);
 
-  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = false;
+  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = m_altitudeParsed = false;
 
   m_innerStats.MakeZero();
 }
@@ -373,6 +373,15 @@ void FeatureType::ParseMetadata() const
   m_pLoader->ParseMetadata();
 
   m_metadataParsed = true;
+}
+
+void FeatureType::ParseAltitude() const
+{
+  if (m_altitudeParsed)
+    return;
+
+  m_pLoader->ParseAltitude();
+  m_altitudeParsed = true;
 }
 
 StringUtf8Multilang const & FeatureType::GetNames() const

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -302,8 +302,7 @@ void FeatureType::Deserialize(feature::LoaderBase * pLoader, TBuffer buffer)
 
   m_pLoader->InitFeature(this);
 
-  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = m_altitudeParsed =
-      false;
+  m_header2Parsed = m_pointsParsed = m_trianglesParsed = m_metadataParsed = false;
 
   m_innerStats.MakeZero();
 }
@@ -374,15 +373,6 @@ void FeatureType::ParseMetadata() const
   m_pLoader->ParseMetadata();
 
   m_metadataParsed = true;
-}
-
-void FeatureType::ParseAltitude() const
-{
-  if (m_altitudeParsed)
-    return;
-
-  m_pLoader->ParseAltitude();
-  m_altitudeParsed = true;
 }
 
 StringUtf8Multilang const & FeatureType::GetNames() const

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -362,10 +362,6 @@ private:
   mutable points_t m_points, m_triangles;
   mutable feature::Metadata m_metadata;
 
-  // @TODO |m_altitudes| should be exchanged with vector<TAltitude>.
-  // If the vector is empty no altitude information is available for this feature.
-  feature::Altitudes m_altitudes;
-
   mutable bool m_header2Parsed = false;
   mutable bool m_pointsParsed = false;
   mutable bool m_trianglesParsed = false;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -371,7 +371,7 @@ private:
 
   // @TODO |m_altitudes| should be exchanged with vector<TAltitude>.
   // If the vector is empty no altitude information is available for this feature.
-  mutable feature::Altitudes m_altitudes;
+  feature::Altitudes m_altitudes;
 
   mutable bool m_header2Parsed = false;
   mutable bool m_pointsParsed = false;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "indexer/cell_id.hpp"
+#include "indexer/feature_altitude.hpp"
 #include "indexer/feature_data.hpp"
 
 #include "geometry/point2d.hpp"
@@ -201,6 +202,7 @@ public:
   uint32_t ParseTriangles(int scale) const;
 
   void ParseMetadata() const;
+  void ParseAltitude() const;
   //@}
 
   /// @name Geometry.
@@ -241,6 +243,12 @@ public:
     ASSERT_LESS(i, m_points.size(), ());
     ASSERT(m_pointsParsed, ());
     return m_points[i];
+  }
+
+  inline feature::Altitudes const & GetAltitudes() const
+  {
+    ASSERT(m_altitudeParsed, ());
+    return m_altitudes;
   }
 
   template <typename TFunctor>
@@ -361,10 +369,15 @@ private:
   mutable points_t m_points, m_triangles;
   mutable feature::Metadata m_metadata;
 
+  // @TODO |m_altitudes| should be exchanged with vector<TAltitude>.
+  // If the vector is empty no altitude information is available for this feature.
+  mutable feature::Altitudes m_altitudes;
+
   mutable bool m_header2Parsed = false;
   mutable bool m_pointsParsed = false;
   mutable bool m_trianglesParsed = false;
   mutable bool m_metadataParsed = false;
+  mutable bool m_altitudeParsed = false;
 
   mutable inner_geom_stat_t m_innerStats;
 

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -202,7 +202,6 @@ public:
   uint32_t ParseTriangles(int scale) const;
 
   void ParseMetadata() const;
-  void ParseAltitude() const;
   //@}
 
   /// @name Geometry.
@@ -243,12 +242,6 @@ public:
     ASSERT_LESS(i, m_points.size(), ());
     ASSERT(m_pointsParsed, ());
     return m_points[i];
-  }
-
-  inline feature::Altitudes const & GetAltitudes() const
-  {
-    ASSERT(m_altitudeParsed, ());
-    return m_altitudes;
   }
 
   template <typename TFunctor>
@@ -377,7 +370,6 @@ private:
   mutable bool m_pointsParsed = false;
   mutable bool m_trianglesParsed = false;
   mutable bool m_metadataParsed = false;
-  mutable bool m_altitudeParsed = false;
 
   mutable inner_geom_stat_t m_innerStats;
 

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -16,8 +16,8 @@ struct Altitudes
   Altitudes() = default;
   Altitudes(TAltitude b, TAltitude e) : begin(b), end(e) {}
 
-  TAltitude begin = 0;
-  TAltitude end = 0;
+  TAltitude begin = kInvalidAltitude;
+  TAltitude end = kInvalidAltitude;
 };
 
 class Altitude

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -2,13 +2,14 @@
 
 #include "coding/varint.hpp"
 
+#include "std/limits.hpp"
 #include "std/vector.hpp"
 
 namespace feature
 {
 using TAltitude = int16_t;
 using TAltitudeVec = vector<feature::TAltitude>;
-static TAltitude constexpr kInvalidAltitude = -32768;
+static TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::lowest();
 
 struct Altitudes
 {

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -11,13 +11,14 @@ namespace feature
 {
 using TAltitude = int16_t;
 using TAltitudes = vector<feature::TAltitude>;
-using TAltitudeSectionVersion = uint16_t;
 using TAltitudeSectionOffset = uint32_t;
 
 TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
 
 struct AltitudeHeader
 {
+  using TAltitudeSectionVersion = uint16_t;
+
   AltitudeHeader()
   {
     Reset();
@@ -109,10 +110,10 @@ public:
 
 private:
   /// \note |m_altitudes| is a vector of feature point altitudes. There's two posibilities:
-  /// * |m_altitudes| is empty. It means no altitude information defines.
-  /// * size of |m_altitudes| is equal to feature point number. In that case every item of
-  /// |m_altitudes| defines altitude in meters for every feature point. If altitude is not defined
-  ///  for some feature point corresponding vector items are equel to |kInvalidAltitude|
+  /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
+  /// * size of |m_pointAlt| is equal to the number of this feature's points.
+  /// In this case the i'th element of |m_pointAlt| corresponds to the altitude of the
+  /// i'th point of the feature and is set to kInvalidAltitude when there is no information about the point.
   TAltitudes m_altitudes;
 };
 }  // namespace feature

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -15,7 +15,7 @@ using TAltitude = int16_t;
 using TAltitudes = vector<feature::TAltitude>;
 
 TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
-feature::TAltitude constexpr kDefautlAltitudeMeters = 0;
+feature::TAltitude constexpr kDefaultAltitudeMeters = 0;
 
 struct AltitudeHeader
 {
@@ -55,7 +55,7 @@ struct AltitudeHeader
   void Reset()
   {
     m_version = 0;
-    m_minAltitude = kDefautlAltitudeMeters;
+    m_minAltitude = kDefaultAltitudeMeters;
     m_featureTableOffset = 0;
     m_altitudesOffset = 0;
     m_endOffset = 0;

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -8,8 +8,8 @@
 namespace feature
 {
 using TAltitude = int16_t;
-using TAltitudeVec = vector<feature::TAltitude>;
-static TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::lowest();
+using TAltitudes = vector<feature::TAltitude>;
+TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
 
 struct Altitudes
 {

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -15,6 +15,7 @@ using TAltitude = int16_t;
 using TAltitudes = vector<feature::TAltitude>;
 
 TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
+feature::TAltitude constexpr kDefautlAltitudeMeters = 0;
 
 struct AltitudeHeader
 {
@@ -50,10 +51,11 @@ struct AltitudeHeader
   size_t GetFeatureTableSize() const { return m_altitudesOffset - m_featureTableOffset; }
 
   size_t GetAltitudeInfo() const { return m_endOffset - m_altitudesOffset; }
+
   void Reset()
   {
     m_version = 0;
-    m_minAltitude = kInvalidAltitude;
+    m_minAltitude = kDefautlAltitudeMeters;
     m_featureTableOffset = 0;
     m_altitudesOffset = 0;
     m_endOffset = 0;
@@ -117,10 +119,8 @@ public:
 private:
   /// \note |m_altitudes| is a vector of feature point altitudes. There's two possibilities:
   /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
-  /// * size of |m_pointAlt| is equal to the number of this feature's points.
-  /// In this case the i'th element of |m_pointAlt| corresponds to the altitude of the
-  /// i'th point of the feature and is set to kInvalidAltitude when there is no information about
-  /// the point.
+  /// * size of |m_pointAlt| is equal to the number of this feature's points. If so
+  ///   all items of |m_altitudes| have valid value.
   TAltitudes m_altitudes;
 };
 }  // namespace feature

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -1,6 +1,7 @@
 #pragma once
-
 #include "coding/varint.hpp"
+
+#include "base/logging.hpp"
 
 #include "std/limits.hpp"
 #include "std/vector.hpp"
@@ -9,7 +10,55 @@ namespace feature
 {
 using TAltitude = int16_t;
 using TAltitudes = vector<feature::TAltitude>;
+using TAltitudeSectionVersion = uint16_t;
+using TAltitudeSectionOffset = uint32_t;
+
 TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
+
+struct AltitudeHeader
+{
+  AltitudeHeader()
+  {
+    Reset();
+  }
+
+  AltitudeHeader(TAltitudeSectionVersion v, TAltitude min, TAltitudeSectionOffset offset)
+    : version(v), minAltitude(min), altitudeInfoOffset(offset)
+  {
+  }
+
+  template <class TSink>
+  void Serialize(TSink & sink) const
+  {
+    sink.Write(&version, sizeof(version));
+    sink.Write(&minAltitude, sizeof(minAltitude));
+    sink.Write(&altitudeInfoOffset, sizeof(altitudeInfoOffset));
+  }
+
+  template <class TSource>
+  void Deserialize(TSource & src)
+  {
+    src.Read(&version, sizeof(version));
+    src.Read(&minAltitude, sizeof(minAltitude));
+    src.Read(&altitudeInfoOffset, sizeof(altitudeInfoOffset));
+  }
+
+  static size_t GetHeaderSize()
+  {
+    return sizeof(version) + sizeof(minAltitude) + sizeof(altitudeInfoOffset);
+  }
+
+  void Reset()
+  {
+    version = 1;
+    minAltitude = kInvalidAltitude;
+    altitudeInfoOffset = 0;
+  }
+
+  TAltitudeSectionVersion version;
+  TAltitude minAltitude;
+  TAltitudeSectionOffset altitudeInfoOffset;
+};
 
 class Altitude
 {

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -115,8 +115,6 @@ public:
     }
   }
 
-  TAltitudes GetAltitudes() const { return m_altitudes; }
-private:
   /// \note |m_altitudes| is a vector of feature point altitudes. There's two possibilities:
   /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
   /// * size of |m_pointAlt| is equal to the number of this feature's points. If so

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -20,11 +20,7 @@ struct AltitudeHeader
 {
   using TAltitudeSectionVersion = uint16_t;
 
-  AltitudeHeader()
-  {
-    Reset();
-  }
-
+  AltitudeHeader() { Reset(); }
   template <class TSink>
   void Serialize(TSink & sink) const
   {
@@ -46,10 +42,12 @@ struct AltitudeHeader
   }
 
   // Methods below return sizes of parts of altitude section in bytes.
-  size_t GetAltitudeAvailabilitySize() const { return m_featureTableOffset - sizeof(AltitudeHeader); }
+  size_t GetAltitudeAvailabilitySize() const
+  {
+    return m_featureTableOffset - sizeof(AltitudeHeader);
+  }
   size_t GetFeatureTableSize() const { return m_altitudesOffset - m_featureTableOffset; }
   size_t GetAltitudeInfo() const { return m_endOffset - m_altitudesOffset; }
-
   void Reset()
   {
     m_version = 0;
@@ -73,7 +71,6 @@ class Altitudes
 public:
   Altitudes() = default;
   explicit Altitudes(TAltitudes const & altitudes) : m_altitudes(altitudes) {}
-
   template <class TSink>
   void Serialize(TAltitude minAltitude, TSink & sink) const
   {
@@ -81,7 +78,8 @@ public:
 
     WriteVarInt(sink, static_cast<int32_t>(m_altitudes[0]) - static_cast<int32_t>(minAltitude));
     for (size_t i = 1; i < m_altitudes.size(); ++i)
-      WriteVarInt(sink, static_cast<int32_t>(m_altitudes[i]) - static_cast<int32_t>(m_altitudes[i - 1]));
+      WriteVarInt(sink,
+                  static_cast<int32_t>(m_altitudes[i]) - static_cast<int32_t>(m_altitudes[i - 1]));
   }
 
   template <class TSource>
@@ -109,17 +107,14 @@ public:
     }
   }
 
-  TAltitudes GetAltitudes() const
-  {
-    return m_altitudes;
-  }
-
+  TAltitudes GetAltitudes() const { return m_altitudes; }
 private:
   /// \note |m_altitudes| is a vector of feature point altitudes. There's two possibilities:
   /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
   /// * size of |m_pointAlt| is equal to the number of this feature's points.
   /// In this case the i'th element of |m_pointAlt| corresponds to the altitude of the
-  /// i'th point of the feature and is set to kInvalidAltitude when there is no information about the point.
+  /// i'th point of the feature and is set to kInvalidAltitude when there is no information about
+  /// the point.
   TAltitudes m_altitudes;
 };
 }  // namespace feature

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -46,7 +46,9 @@ struct AltitudeHeader
   {
     return m_featureTableOffset - sizeof(AltitudeHeader);
   }
+
   size_t GetFeatureTableSize() const { return m_altitudesOffset - m_featureTableOffset; }
+
   size_t GetAltitudeInfo() const { return m_endOffset - m_altitudesOffset; }
   void Reset()
   {
@@ -70,7 +72,9 @@ class Altitudes
 {
 public:
   Altitudes() = default;
+
   explicit Altitudes(TAltitudes const & altitudes) : m_altitudes(altitudes) {}
+
   template <class TSink>
   void Serialize(TAltitude minAltitude, TSink & sink) const
   {
@@ -78,8 +82,10 @@ public:
 
     WriteVarInt(sink, static_cast<int32_t>(m_altitudes[0]) - static_cast<int32_t>(minAltitude));
     for (size_t i = 1; i < m_altitudes.size(); ++i)
+    {
       WriteVarInt(sink,
                   static_cast<int32_t>(m_altitudes[i]) - static_cast<int32_t>(m_altitudes[i - 1]));
+    }
   }
 
   template <class TSource>

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -22,6 +22,7 @@ struct AltitudeHeader
   using TAltitudeSectionVersion = uint16_t;
 
   AltitudeHeader() { Reset(); }
+
   template <class TSink>
   void Serialize(TSink & sink) const
   {
@@ -91,13 +92,13 @@ public:
   }
 
   template <class TSource>
-  void Deserialize(TAltitude minAltitude, size_t pointCount, TSource & src)
+  bool Deserialize(TAltitude minAltitude, size_t pointCount, TSource & src)
   {
     m_altitudes.clear();
     if (pointCount == 0)
     {
       ASSERT(false, ());
-      return;
+      return false;
     }
 
     m_altitudes.resize(pointCount);
@@ -109,10 +110,11 @@ public:
       {
         ASSERT(false, ());
         m_altitudes.clear();
-        return;
+        return false;
       }
       prevAltitude = m_altitudes[i];
     }
+    return true;
   }
 
   /// \note |m_altitudes| is a vector of feature point altitudes. There's two possibilities:

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "coding/varint.hpp"
+
+#include "std/vector.hpp"
+
+namespace feature
+{
+using TAltitude = int16_t;
+using TAltitudeVec = vector<feature::TAltitude>;
+static TAltitude constexpr kInvalidAltitude = -32768;
+
+struct Altitudes
+{
+  Altitudes() = default;
+  Altitudes(TAltitude b, TAltitude e) : begin(b), end(e) {}
+
+  TAltitude begin = 0;
+  TAltitude end = 0;
+};
+
+class Altitude
+{
+public:
+  Altitude() = default;
+  Altitude(uint32_t featureId, Altitudes const & altitudes) : m_featureId(featureId), m_altitudes(altitudes) {}
+
+  template <class TSink>
+  void Serialize(TSink & sink) const
+  {
+    sink.Write(&m_featureId, sizeof(uint32_t));
+    sink.Write(&m_altitudes.begin, sizeof(TAltitude));
+    sink.Write(&m_altitudes.end, sizeof(TAltitude));
+  }
+
+  /// @TODO template <class TSource> void Deserialize(TSource & src) should be implement here.
+  /// But now for test purposes deserialization is done with DDVector construction.
+
+  uint32_t GetFeatureId() const { return m_featureId; }
+  Altitudes const & GetAltitudes() const { return m_altitudes; }
+
+private:
+  /// @TODO Note. Feature id is located here because there's no index for altitudes.
+  /// There's only pairs sorted by feature id. Before merging to master some index has to be implemented.
+  /// Don't forget to remove |m_featureId|.
+  uint32_t m_featureId = 0;
+  Altitudes m_altitudes;
+};
+} // namespace feature

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -24,7 +24,10 @@ class Altitude
 {
 public:
   Altitude() = default;
-  Altitude(uint32_t featureId, Altitudes const & altitudes) : m_featureId(featureId), m_altitudes(altitudes) {}
+  Altitude(uint32_t featureId, Altitudes const & altitudes)
+    : m_featureId(featureId), m_altitudes(altitudes)
+  {
+  }
 
   template <class TSink>
   void Serialize(TSink & sink) const
@@ -42,9 +45,10 @@ public:
 
 private:
   /// @TODO Note. Feature id is located here because there's no index for altitudes.
-  /// There's only pairs sorted by feature id. Before merging to master some index has to be implemented.
+  /// There's only pairs sorted by feature id. Before merging to master some index has to be
+  /// implemented.
   /// Don't forget to remove |m_featureId|.
   uint32_t m_featureId = 0;
   Altitudes m_altitudes;
 };
-} // namespace feature
+}  // namespace feature

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -15,7 +15,7 @@ class Altitude
 {
 public:
   Altitude() = default;
-  Altitude(TAltitudes const & altitudes) : m_pointAlt(altitudes) {}
+  explicit Altitude(TAltitudes const & altitudes) : m_pointAlt(altitudes) {}
 
   template <class TSink>
   void Serialize(TAltitude minAltitude, TSink & sink) const

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include "coding/reader.hpp"
 #include "coding/varint.hpp"
+#include "coding/write_to_sink.hpp"
 
 #include "base/assert.hpp"
 
@@ -11,7 +13,6 @@ namespace feature
 {
 using TAltitude = int16_t;
 using TAltitudes = vector<feature::TAltitude>;
-using TAltitudeSectionOffset = uint32_t;
 
 TAltitude constexpr kInvalidAltitude = numeric_limits<TAltitude>::min();
 
@@ -27,58 +28,58 @@ struct AltitudeHeader
   template <class TSink>
   void Serialize(TSink & sink) const
   {
-    sink.Write(&version, sizeof(version));
-    sink.Write(&minAltitude, sizeof(minAltitude));
-    sink.Write(&featureTableOffset, sizeof(featureTableOffset));
-    sink.Write(&altitudeInfoOffset, sizeof(altitudeInfoOffset));
-    sink.Write(&endOffset, sizeof(endOffset));
+    WriteToSink(sink, m_version);
+    WriteToSink(sink, m_minAltitude);
+    WriteToSink(sink, m_featureTableOffset);
+    WriteToSink(sink, m_altitudesOffset);
+    WriteToSink(sink, m_endOffset);
   }
 
   template <class TSource>
   void Deserialize(TSource & src)
   {
-    src.Read(&version, sizeof(version));
-    src.Read(&minAltitude, sizeof(minAltitude));
-    src.Read(&featureTableOffset, sizeof(featureTableOffset));
-    src.Read(&altitudeInfoOffset, sizeof(altitudeInfoOffset));
-    src.Read(&endOffset, sizeof(endOffset));
+    m_version = ReadPrimitiveFromSource<TAltitudeSectionVersion>(src);
+    m_minAltitude = ReadPrimitiveFromSource<TAltitude>(src);
+    m_featureTableOffset = ReadPrimitiveFromSource<uint32_t>(src);
+    m_altitudesOffset = ReadPrimitiveFromSource<uint32_t>(src);
+    m_endOffset = ReadPrimitiveFromSource<uint32_t>(src);
   }
 
   // Methods below return sizes of parts of altitude section in bytes.
-  static size_t GetHeaderSize() { return sizeof(AltitudeHeader); }
-
-  size_t GetAltitudeAvailabilitySize() const { return featureTableOffset - GetHeaderSize(); }
-  size_t GetFeatureTableSize() const { return altitudeInfoOffset - featureTableOffset; }
-  size_t GetAltitudeInfo() const { return endOffset - altitudeInfoOffset; }
+  size_t GetAltitudeAvailabilitySize() const { return m_featureTableOffset - sizeof(AltitudeHeader); }
+  size_t GetFeatureTableSize() const { return m_altitudesOffset - m_featureTableOffset; }
+  size_t GetAltitudeInfo() const { return m_endOffset - m_altitudesOffset; }
 
   void Reset()
   {
-    version = 1;
-    minAltitude = kInvalidAltitude;
-    featureTableOffset = 0;
-    altitudeInfoOffset = 0;
-    endOffset = 0;
+    m_version = 0;
+    m_minAltitude = kInvalidAltitude;
+    m_featureTableOffset = 0;
+    m_altitudesOffset = 0;
+    m_endOffset = 0;
   }
 
-  TAltitudeSectionVersion version;
-  TAltitude minAltitude;
-  TAltitudeSectionOffset featureTableOffset;
-  TAltitudeSectionOffset altitudeInfoOffset;
-  TAltitudeSectionOffset endOffset;
+  TAltitudeSectionVersion m_version;
+  TAltitude m_minAltitude;
+  uint32_t m_featureTableOffset;
+  uint32_t m_altitudesOffset;
+  uint32_t m_endOffset;
 };
 
-class Altitude
+static_assert(sizeof(AltitudeHeader) == 16, "Wrong header size of altitude section.");
+
+class Altitudes
 {
 public:
-  Altitude() = default;
-  explicit Altitude(TAltitudes const & altitudes) : m_altitudes(altitudes) {}
+  Altitudes() = default;
+  explicit Altitudes(TAltitudes const & altitudes) : m_altitudes(altitudes) {}
 
   template <class TSink>
   void Serialize(TAltitude minAltitude, TSink & sink) const
   {
     CHECK(!m_altitudes.empty(), ());
 
-    WriteVarInt(sink, static_cast<int32_t>(m_altitudes[0] - static_cast<int32_t>(minAltitude)));
+    WriteVarInt(sink, static_cast<int32_t>(m_altitudes[0]) - static_cast<int32_t>(minAltitude));
     for (size_t i = 1; i < m_altitudes.size(); ++i)
       WriteVarInt(sink, static_cast<int32_t>(m_altitudes[i]) - static_cast<int32_t>(m_altitudes[i - 1]));
   }
@@ -94,17 +95,17 @@ public:
     }
 
     m_altitudes.resize(pointCount);
-    TAltitude prevPntAltitude = minAltitude;
+    TAltitude prevAltitude = minAltitude;
     for (size_t i = 0; i < pointCount; ++i)
     {
-      m_altitudes[i] = static_cast<TAltitude>(ReadVarInt<int32_t>(src) + prevPntAltitude);
+      m_altitudes[i] = static_cast<TAltitude>(ReadVarInt<int32_t>(src) + prevAltitude);
       if (m_altitudes[i] < minAltitude)
       {
         ASSERT(false, ());
         m_altitudes.clear();
         return;
       }
-      prevPntAltitude = m_altitudes[i];
+      prevAltitude = m_altitudes[i];
     }
   }
 
@@ -114,7 +115,7 @@ public:
   }
 
 private:
-  /// \note |m_altitudes| is a vector of feature point altitudes. There's two posibilities:
+  /// \note |m_altitudes| is a vector of feature point altitudes. There's two possibilities:
   /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
   /// * size of |m_pointAlt| is equal to the number of this feature's points.
   /// In this case the i'th element of |m_pointAlt| corresponds to the altitude of the

--- a/indexer/feature_loader.cpp
+++ b/indexer/feature_loader.cpp
@@ -292,47 +292,6 @@ void LoaderCurrent::ParseMetadata()
   }
 }
 
-void LoaderCurrent::ParseAltitude()
-{
-  // @TODO Index and should be used here before merging to master.
-
-  if (m_Info.GetMWMFormat() < version::Format::v8)
-    return;
-
-  struct TAltitudeIndexEntry
-  {
-    uint32_t featureId;
-    feature::TAltitude beginAlt;
-    feature::TAltitude endAlt;
-  };
-
-  try
-  {
-    DDVector<TAltitudeIndexEntry, FilesContainerR::TReader> idx(m_Info.GetAltitudeReader());
-    auto it = lower_bound(idx.begin(), idx.end(),
-                          TAltitudeIndexEntry{static_cast<uint32_t>(m_pF->m_id.m_index), 0, 0},
-                          [](TAltitudeIndexEntry const & v1, TAltitudeIndexEntry const & v2)
-    {
-      return v1.featureId < v2.featureId;
-    });
-    if (it == idx.end())
-      return;
-
-    if (m_pF->m_id.m_index != it->featureId)
-      return;
-
-    if (it->beginAlt == kInvalidAltitude || it->endAlt == kInvalidAltitude)
-      return;
-
-    m_pF->m_altitudes.begin = it->beginAlt;
-    m_pF->m_altitudes.end = it->endAlt;
-  }
-  catch (Reader::OpenException const &)
-  {
-    // Now ignore exception because not all mwm have needed sections.
-  }
-}
-
 int LoaderCurrent::GetScaleIndex(int scale) const
 {
   int const count = m_Info.GetScalesCount();

--- a/indexer/feature_loader.cpp
+++ b/indexer/feature_loader.cpp
@@ -292,6 +292,48 @@ void LoaderCurrent::ParseMetadata()
   }
 }
 
+void LoaderCurrent::ParseAltitude()
+{
+  // @TODO Index and should be used here before merging to master.
+
+  if (m_Info.GetMWMFormat() < version::Format::v8)
+    return;
+
+  struct TAltitudeIndexEntry
+  {
+    uint32_t featureId;
+    feature::TAltitude beginAlt;
+    feature::TAltitude endAlt;
+  };
+
+  try
+  {
+    DDVector<TAltitudeIndexEntry, FilesContainerR::TReader> idx(m_Info.GetAltitudeReader());
+    auto it = lower_bound(
+        idx.begin(), idx.end(),
+        TAltitudeIndexEntry{static_cast<uint32_t>(m_pF->m_id.m_index), 0, 0},
+        [](TAltitudeIndexEntry const & v1, TAltitudeIndexEntry const & v2)
+        {
+          return v1.featureId < v2.featureId;
+        });
+    if (it == idx.end())
+      return;
+
+    if (m_pF->m_id.m_index != it->featureId)
+      return;
+
+    if (it->beginAlt == kInvalidAltitude || it->endAlt == kInvalidAltitude)
+      return;
+
+    m_pF->m_altitudes.begin = it->beginAlt;
+    m_pF->m_altitudes.end = it->endAlt;
+  }
+  catch (Reader::OpenException const &)
+  {
+    // Now ignore exception because not all mwm have needed sections.
+  }
+}
+
 int LoaderCurrent::GetScaleIndex(int scale) const
 {
   int const count = m_Info.GetScalesCount();

--- a/indexer/feature_loader.cpp
+++ b/indexer/feature_loader.cpp
@@ -309,13 +309,12 @@ void LoaderCurrent::ParseAltitude()
   try
   {
     DDVector<TAltitudeIndexEntry, FilesContainerR::TReader> idx(m_Info.GetAltitudeReader());
-    auto it = lower_bound(
-        idx.begin(), idx.end(),
-        TAltitudeIndexEntry{static_cast<uint32_t>(m_pF->m_id.m_index), 0, 0},
-        [](TAltitudeIndexEntry const & v1, TAltitudeIndexEntry const & v2)
-        {
-          return v1.featureId < v2.featureId;
-        });
+    auto it = lower_bound(idx.begin(), idx.end(),
+                          TAltitudeIndexEntry{static_cast<uint32_t>(m_pF->m_id.m_index), 0, 0},
+                          [](TAltitudeIndexEntry const & v1, TAltitudeIndexEntry const & v2)
+    {
+      return v1.featureId < v2.featureId;
+    });
     if (it == idx.end())
       return;
 

--- a/indexer/feature_loader.hpp
+++ b/indexer/feature_loader.hpp
@@ -21,13 +21,14 @@ namespace feature
   public:
     LoaderCurrent(SharedLoadInfo const & info) : BaseT(info) {}
 
-    virtual uint8_t GetHeader();
-
-    virtual void ParseTypes();
-    virtual void ParseCommon();
-    virtual void ParseHeader2();
-    virtual uint32_t ParseGeometry(int scale);
-    virtual uint32_t ParseTriangles(int scale);
-    virtual void ParseMetadata();
+    /// LoaderBase overrides:
+    virtual uint8_t GetHeader() override;
+    void ParseTypes() override;
+    void ParseCommon() override;
+    void ParseHeader2() override;
+    uint32_t ParseGeometry(int scale) override;
+    uint32_t ParseTriangles(int scale) override;
+    void ParseMetadata() override;
+    void ParseAltitude() override;
   };
 }

--- a/indexer/feature_loader.hpp
+++ b/indexer/feature_loader.hpp
@@ -29,6 +29,5 @@ namespace feature
     uint32_t ParseGeometry(int scale) override;
     uint32_t ParseTriangles(int scale) override;
     void ParseMetadata() override;
-    void ParseAltitude() override;
   };
 }

--- a/indexer/feature_loader.hpp
+++ b/indexer/feature_loader.hpp
@@ -20,7 +20,6 @@ namespace feature
 
   public:
     LoaderCurrent(SharedLoadInfo const & info) : BaseT(info) {}
-
     /// LoaderBase overrides:
     virtual uint8_t GetHeader() override;
     void ParseTypes() override;

--- a/indexer/feature_loader_base.cpp
+++ b/indexer/feature_loader_base.cpp
@@ -46,7 +46,7 @@ SharedLoadInfo::TReader SharedLoadInfo::GetMetadataIndexReader() const
 
 SharedLoadInfo::TReader SharedLoadInfo::GetAltitudeReader() const
 {
-  return m_cont.GetReader(ALTITUDE_TAG);
+  return m_cont.GetReader(ALTITUDE_FILE_TAG);
 }
 
 SharedLoadInfo::TReader SharedLoadInfo::GetGeometryReader(int ind) const

--- a/indexer/feature_loader_base.cpp
+++ b/indexer/feature_loader_base.cpp
@@ -44,6 +44,11 @@ SharedLoadInfo::TReader SharedLoadInfo::GetMetadataIndexReader() const
   return m_cont.GetReader(METADATA_INDEX_FILE_TAG);
 }
 
+SharedLoadInfo::TReader SharedLoadInfo::GetAltitudeReader() const
+{
+  return m_cont.GetReader(ALTITUDE_TAG);
+}
+
 SharedLoadInfo::TReader SharedLoadInfo::GetGeometryReader(int ind) const
 {
   return m_cont.GetReader(GetTagForIndex(GEOMETRY_FILE_TAG, ind));

--- a/indexer/feature_loader_base.cpp
+++ b/indexer/feature_loader_base.cpp
@@ -46,7 +46,7 @@ SharedLoadInfo::TReader SharedLoadInfo::GetMetadataIndexReader() const
 
 SharedLoadInfo::TReader SharedLoadInfo::GetAltitudeReader() const
 {
-  return m_cont.GetReader(ALTITUDE_FILE_TAG);
+  return m_cont.GetReader(ALTITUDES_FILE_TAG);
 }
 
 SharedLoadInfo::TReader SharedLoadInfo::GetGeometryReader(int ind) const

--- a/indexer/feature_loader_base.hpp
+++ b/indexer/feature_loader_base.hpp
@@ -79,7 +79,6 @@ namespace feature
     virtual uint32_t ParseGeometry(int scale) = 0;
     virtual uint32_t ParseTriangles(int scale) = 0;
     virtual void ParseMetadata() = 0;
-    virtual void ParseAltitude() = 0;
 
     inline uint32_t GetTypesSize() const { return m_CommonOffset - m_TypesOffset; }
 

--- a/indexer/feature_loader_base.hpp
+++ b/indexer/feature_loader_base.hpp
@@ -32,6 +32,7 @@ namespace feature
     TReader GetDataReader() const;
     TReader GetMetadataReader() const;
     TReader GetMetadataIndexReader() const;
+    TReader GetAltitudeReader() const;
     TReader GetGeometryReader(int ind) const;
     TReader GetTrianglesReader(int ind) const;
 
@@ -78,6 +79,7 @@ namespace feature
     virtual uint32_t ParseGeometry(int scale) = 0;
     virtual uint32_t ParseTriangles(int scale) = 0;
     virtual void ParseMetadata() = 0;
+    virtual void ParseAltitude() = 0;
 
     inline uint32_t GetTypesSize() const { return m_CommonOffset - m_TypesOffset; }
 

--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -81,6 +81,7 @@ HEADERS += \
     edits_migration.hpp \
     feature.hpp \
     feature_algo.hpp \
+    feature_altitude.hpp \
     feature_covering.hpp \
     feature_data.hpp \
     feature_decl.hpp \

--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -10,6 +10,7 @@ ROOT_DIR = ..
 include($$ROOT_DIR/common.pri)
 
 SOURCES += \
+    altitude_loader.cpp \
     categories_holder.cpp \
     categories_holder_loader.cpp \
     categories_index.cpp \
@@ -61,6 +62,7 @@ SOURCES += \
     types_mapping.cpp \
 
 HEADERS += \
+    altitude_loader.hpp \
     categories_holder.hpp \
     categories_index.hpp \
     cell_coverer.hpp \

--- a/indexer/old/feature_loader_101.hpp
+++ b/indexer/old/feature_loader_101.hpp
@@ -29,15 +29,15 @@ namespace old_101 { namespace feature
   public:
     LoaderImpl(::feature::SharedLoadInfo const & info) : BaseT(info) {}
 
-    virtual uint8_t GetHeader();
-
-    virtual void ParseTypes();
-    virtual void ParseCommon();
-    virtual void ParseHeader2();
-    virtual uint32_t ParseGeometry(int scale);
-    virtual uint32_t ParseTriangles(int scale);
-    virtual void ParseMetadata() {} /// not supported in this version
-
+    /// LoaderBase overrides:
+    uint8_t GetHeader() override;
+    void ParseTypes() override;
+    void ParseCommon() override;
+    void ParseHeader2() override;
+    uint32_t ParseGeometry(int scale) override;
+    uint32_t ParseTriangles(int scale) override;
+    void ParseMetadata() override {} /// not supported in this version
+    void ParseAltitude() override {} /// not supported in this version
   };
 }
 }

--- a/indexer/old/feature_loader_101.hpp
+++ b/indexer/old/feature_loader_101.hpp
@@ -28,7 +28,6 @@ namespace old_101 { namespace feature
 
   public:
     LoaderImpl(::feature::SharedLoadInfo const & info) : BaseT(info) {}
-
     /// LoaderBase overrides:
     uint8_t GetHeader() override;
     void ParseTypes() override;

--- a/indexer/old/feature_loader_101.hpp
+++ b/indexer/old/feature_loader_101.hpp
@@ -36,8 +36,8 @@ namespace old_101 { namespace feature
     void ParseHeader2() override;
     uint32_t ParseGeometry(int scale) override;
     uint32_t ParseTriangles(int scale) override;
-    void ParseMetadata() override {} /// not supported in this version
-    void ParseAltitude() override {} /// not supported in this version
+    void ParseMetadata() override {}  /// not supported in this version
+    void ParseAltitude() override {}  /// not supported in this version
   };
 }
 }

--- a/indexer/old/feature_loader_101.hpp
+++ b/indexer/old/feature_loader_101.hpp
@@ -37,7 +37,6 @@ namespace old_101 { namespace feature
     uint32_t ParseGeometry(int scale) override;
     uint32_t ParseTriangles(int scale) override;
     void ParseMetadata() override {}  /// not supported in this version
-    void ParseAltitude() override {}  /// not supported in this version
   };
 }
 }

--- a/pedestrian_routing_tests/pedestrian_routing_tests.cpp
+++ b/pedestrian_routing_tests/pedestrian_routing_tests.cpp
@@ -4,10 +4,12 @@
 #include "indexer/classificator_loader.hpp"
 
 #include "routing/features_road_graph.hpp"
-#include "routing/road_graph_router.hpp"
-#include "routing/route.hpp"
 #include "routing/pedestrian_directions.hpp"
 #include "routing/pedestrian_model.hpp"
+#include "routing/pedestrian_model.hpp"
+#include "routing/road_graph.hpp"
+#include "routing/road_graph_router.hpp"
+#include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
 
 #include "storage/country_info_getter.hpp"
@@ -124,7 +126,8 @@ m2::PointD GetPointOnEdge(routing::Edge & e, double posAlong)
   return e.GetStartJunction().GetPoint() + d * posAlong;
 }
 
-void GetNearestPedestrianEdges(Index & index, m2::PointD const & pt, vector<pair<routing::Edge, m2::PointD>> & edges)
+void GetNearestPedestrianEdges(Index & index, m2::PointD const & pt,
+                               vector<pair<routing::Edge, routing::Junction>> & edges)
 {
   unique_ptr<routing::IVehicleModelFactory> vehicleModelFactory(new SimplifiedPedestrianModelFactory());
   routing::FeaturesRoadGraph roadGraph(index, routing::IRoadGraph::Mode::IgnoreOnewayTag,
@@ -189,11 +192,11 @@ void TestTwoPointsOnFeature(m2::PointD const & startPos, m2::PointD const & fina
     TEST(id.IsAlive(), ());
   }
 
-  vector<pair<routing::Edge, m2::PointD>> startEdges;
+  vector<pair<routing::Edge, routing::Junction>> startEdges;
   GetNearestPedestrianEdges(index, startPos, startEdges);
   TEST(!startEdges.empty(), ());
 
-  vector<pair<routing::Edge, m2::PointD>> finalEdges;
+  vector<pair<routing::Edge, routing::Junction>> finalEdges;
   GetNearestPedestrianEdges(index, finalPos, finalEdges);
   TEST(!finalEdges.empty(), ());
 

--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -638,6 +638,13 @@ bool BicycleModel::IsOneWay(FeatureType const & f) const
   return VehicleModel::IsOneWay(f);
 }
 
+// static
+BicycleModel const & BicycleModel::DefaultInstance()
+{
+  static BicycleModel const instance;
+  return instance;
+}
+
 BicycleModelFactory::BicycleModelFactory()
 {
   m_models[string()] = make_shared<BicycleModel>(g_bicycleLimitsDefault);

--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -639,7 +639,7 @@ bool BicycleModel::IsOneWay(FeatureType const & f) const
 }
 
 // static
-BicycleModel const & BicycleModel::DefaultInstance()
+BicycleModel const & BicycleModel::AllLimitsInstance()
 {
   static BicycleModel const instance;
   return instance;

--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -686,7 +686,7 @@ shared_ptr<IVehicleModel> BicycleModelFactory::GetVehicleModelForCountry(string 
     LOG(LDEBUG, ("Bicycle model was found:", country));
     return itr->second;
   }
-  LOG(LDEBUG, ("Bicycle model wasn't found, default model is used instead:", country));
+  LOG(LDEBUG, ("Bicycle model wasn't found, default bicycle model is used instead:", country));
   return BicycleModelFactory::GetVehicleModel();
 }
 }  // routing

--- a/routing/bicycle_model.hpp
+++ b/routing/bicycle_model.hpp
@@ -17,6 +17,8 @@ public:
   /// VehicleModel overrides:
   bool IsOneWay(FeatureType const & f) const override;
 
+  static BicycleModel const & DefaultInstance();
+
 protected:
   RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;
 
@@ -45,5 +47,4 @@ public:
 private:
   unordered_map<string, shared_ptr<IVehicleModel>> m_models;
 };
-
 }  // namespace routing

--- a/routing/bicycle_model.hpp
+++ b/routing/bicycle_model.hpp
@@ -17,7 +17,7 @@ public:
   /// VehicleModel overrides:
   bool IsOneWay(FeatureType const & f) const override;
 
-  static BicycleModel const & DefaultInstance();
+  static BicycleModel const & AllLimitsInstance();
 
 protected:
   RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -275,25 +275,23 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   size_t const pointsCount = ft.GetPointsCount();
 
   feature::TAltitudes altitudes;
-  if (value.HasAltitudeLoader())
+  if (value.m_altitudeLoader)
   {
     altitudes = value.m_altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount());
-    if (altitudes.size() != pointsCount)
-    {
-      ASSERT(false, ("altitudes.size() is different from ft.GetPointsCount()"));
-      altitudes.clear();
-    }
+  }
+  else
+  {
+    ASSERT(false, ());
+    altitudes = feature::TAltitudes(ft.GetPointsCount(), feature::kDefautlAltitudeMeters);
   }
 
-  ri.m_junctions.clear();
+  CHECK_EQUAL(altitudes.size(), pointsCount,
+              ("altitudeLoader->GetAltitudes(", featureId.m_index, "...) returns wrong alititudes:",
+               altitudes));
+
   ri.m_junctions.resize(pointsCount);
   for (size_t i = 0; i < pointsCount; ++i)
-  {
-    if (altitudes.empty())
-      ri.m_junctions[i] = Junction(ft.GetPoint(i), feature::kInvalidAltitude);
-    else
-      ri.m_junctions[i] = Junction(ft.GetPoint(i), altitudes[i]);
-  }
+    ri.m_junctions[i] = Junction(ft.GetPoint(i), altitudes[i]);
 }
 
 IRoadGraph::RoadInfo const & FeaturesRoadGraph::GetCachedRoadInfo(FeatureID const & featureId) const

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -277,6 +277,11 @@ IRoadGraph::RoadInfo const & FeaturesRoadGraph::GetCachedRoadInfo(FeatureID cons
   ri.m_speedKMPH = GetSpeedKMPHFromFt(ft);
   ft.SwapPoints(ri.m_points);
 
+  ft.ParseAltitude();
+  // @TODO It's better to use swap here when altitudes is kept in a vector.
+  ri.m_altitudes = ft.GetAltitudes();
+  LOG(LINFO, ("ri.m_altitudes.begin =", ri.m_altitudes.begin, "ri.m_altitudes.end =", ri.m_altitudes.end));
+
   LockFeatureMwm(featureId);
 
   return ri;

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -263,11 +263,12 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
   ft.ParseAltitude();
   // @TODO It's a temprarery solution until a vector of feature altitudes is saved in mwm.
-  bool const isAltidudeValid =
-      ft.GetAltitudes().begin != feature::kInvalidAltitude && ft.GetAltitudes().end != feature::kInvalidAltitude;
+  bool const isAltidudeValid = ft.GetAltitudes().begin != feature::kInvalidAltitude &&
+                               ft.GetAltitudes().end != feature::kInvalidAltitude;
   feature::TAltitude pointAlt = ft.GetAltitudes().begin;
   size_t const pointsCount = ft.GetPointsCount();
-  feature::TAltitude const diffAlt = isAltidudeValid ? (ft.GetAltitudes().end - ft.GetAltitudes().begin) / pointsCount : 0;
+  feature::TAltitude const diffAlt =
+      isAltidudeValid ? (ft.GetAltitudes().end - ft.GetAltitudes().begin) / pointsCount : 0;
 
   ri.m_junctions.clear();
   ri.m_junctions.resize(pointsCount);

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -268,7 +268,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   ri.m_speedKMPH = speedKMPH;
 
   ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
-  feature::TAltitudes altitudes = value.altitudeLoader->GetAltitude(featureId.m_index, ft.GetPointsCount());
+  feature::TAltitudes altitudes = value.altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount());
 
   size_t const pointsCount = ft.GetPointsCount();
   if (altitudes.size() != pointsCount)

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -38,7 +38,7 @@ string GetFeatureCountryName(FeatureID const featureId)
 }
 }  // namespace
 
-FeaturesRoadGraph::Value::Value(MwmSet::MwmHandle && handle) : m_mwmHandle(move(handle))
+FeaturesRoadGraph::Value::Value(MwmSet::MwmHandle handle) : m_mwmHandle(move(handle))
 {
   if (!m_mwmHandle.IsAlive())
     return;
@@ -282,7 +282,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   else
   {
     ASSERT(false, ());
-    altitudes = feature::TAltitudes(ft.GetPointsCount(), feature::kDefautlAltitudeMeters);
+    altitudes = feature::TAltitudes(ft.GetPointsCount(), feature::kDefaultAltitudeMeters);
   }
 
   CHECK_EQUAL(altitudes.size(), pointsCount,

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -38,8 +38,7 @@ string GetFeatureCountryName(FeatureID const featureId)
 }
 }  // namespace
 
-FeaturesRoadGraph::Value::Value(MwmSet::MwmHandle && handle)
-  : m_mwmHandle(move(handle))
+FeaturesRoadGraph::Value::Value(MwmSet::MwmHandle && handle) : m_mwmHandle(move(handle))
 {
   if (!m_mwmHandle.IsAlive())
     return;
@@ -342,6 +341,7 @@ FeaturesRoadGraph::Value const & FeaturesRoadGraph::LockMwm(MwmSet::MwmId const 
   if (itr != m_mwmLocks.end())
     return itr->second;
 
-  return m_mwmLocks.insert(make_pair(move(mwmId), Value(m_index.GetMwmHandleById(mwmId)))).first->second;
+  return m_mwmLocks.insert(make_pair(move(mwmId), Value(m_index.GetMwmHandleById(mwmId))))
+      .first->second;
 }
 }  // namespace routing

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -86,8 +86,6 @@ private:
 
     bool IsAlive() const { return m_mwmHandle.IsAlive(); }
 
-    bool HasAltitudeLoader() const { return m_altitudeLoader && m_altitudeLoader->HasAltitudes(); }
-
     MwmSet::MwmHandle m_mwmHandle;
     unique_ptr<feature::AltitudeLoader> m_altitudeLoader;
   };

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -81,6 +81,11 @@ private:
 
   struct Value
   {
+    Value(MwmSet::MwmHandle && handle, MwmValue const * MwmValue)
+      : mwmHandle(move(handle)), altitudeLoader(MwmValue)
+    {
+    }
+
     MwmSet::MwmHandle mwmHandle;
     feature::AltitudeLoader altitudeLoader;
   };

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -81,8 +81,8 @@ private:
 
   struct Value
   {
-    Value(MwmSet::MwmHandle && handle, MwmValue const * MwmValue)
-      : mwmHandle(move(handle)), altitudeLoader(MwmValue)
+    Value(MwmSet::MwmHandle && handle, MwmValue const * mwmValue)
+      : mwmHandle(move(handle)), altitudeLoader(mwmValue)
     {
     }
 

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -82,7 +82,7 @@ private:
   struct Value
   {
     Value() = default;
-    Value(MwmSet::MwmHandle && handle)
+    explicit Value(MwmSet::MwmHandle && handle)
       : mwmHandle(move(handle))
     {
       if (!mwmHandle.IsAlive())
@@ -90,7 +90,7 @@ private:
         ASSERT(false, ());
         return;
       }
-      altitudeLoader = make_unique<feature::AltitudeLoader>(mwmHandle.GetValue<MwmValue>());
+      altitudeLoader = make_unique<feature::AltitudeLoader>(*mwmHandle.GetValue<MwmValue>());
     }
 
     bool IsAlive() const

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -2,6 +2,7 @@
 #include "routing/road_graph.hpp"
 #include "routing/vehicle_model.hpp"
 
+#include "indexer/altitude_loader.hpp"
 #include "indexer/feature_data.hpp"
 #include "indexer/mwm_set.hpp"
 
@@ -78,6 +79,12 @@ public:
 private:
   friend class CrossFeaturesLoader;
 
+  struct Value
+  {
+    MwmSet::MwmHandle mwmHandle;
+    feature::AltitudeLoader altitudeLoader;
+  };
+
   bool IsRoad(FeatureType const & ft) const;
   bool IsOneWay(FeatureType const & ft) const;
   double GetSpeedKMPHFromFt(FeatureType const & ft) const;
@@ -92,13 +99,13 @@ private:
   void ExtractRoadInfo(FeatureID const & featureId, FeatureType const & ft, double speedKMPH,
                        RoadInfo & ri) const;
 
-  void LockFeatureMwm(FeatureID const & featureId) const;
+  Value const & LockFeatureMwm(FeatureID const & featureId) const;
 
   Index const & m_index;
   IRoadGraph::Mode const m_mode;
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
-  mutable map<MwmSet::MwmId, MwmSet::MwmHandle> m_mwmLocks;
+  mutable map<MwmSet::MwmId, Value> m_mwmLocks;
 };
 
 }  // namespace routing

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -87,11 +87,10 @@ private:
   RoadInfo const & GetCachedRoadInfo(FeatureID const & featureId) const;
   // Searches a feature RoadInfo in the cache, and if does not find then takes passed feature and speed.
   // This version is used to prevent redundant feature loading when feature speed is known.
-  RoadInfo const & GetCachedRoadInfo(FeatureID const & featureId,
-                                     FeatureType const & ft,
+  RoadInfo const & GetCachedRoadInfo(FeatureID const & featureId, FeatureType const & ft,
                                      double speedKMPH) const;
-  void ExtractRoadInfo(FeatureID const & featureId, FeatureType const & ft,
-                       double speedKMPH, RoadInfo & ri) const;
+  void ExtractRoadInfo(FeatureID const & featureId, FeatureType const & ft, double speedKMPH,
+                       RoadInfo & ri) const;
 
   void LockFeatureMwm(FeatureID const & featureId) const;
 

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -81,13 +81,25 @@ private:
 
   struct Value
   {
-    Value(MwmSet::MwmHandle && handle, MwmValue const * mwmValue)
-      : mwmHandle(move(handle)), altitudeLoader(mwmValue)
+    Value() = default;
+    Value(MwmSet::MwmHandle && handle)
+      : mwmHandle(move(handle))
     {
+      if (!mwmHandle.IsAlive())
+      {
+        ASSERT(false, ());
+        return;
+      }
+      altitudeLoader = make_unique<feature::AltitudeLoader>(mwmHandle.GetValue<MwmValue>());
+    }
+
+    bool IsAlive() const
+    {
+      return mwmHandle.IsAlive() && altitudeLoader && altitudeLoader->IsAvailable();
     }
 
     MwmSet::MwmHandle mwmHandle;
-    feature::AltitudeLoader altitudeLoader;
+    unique_ptr<feature::AltitudeLoader> altitudeLoader;
   };
 
   bool IsRoad(FeatureType const & ft) const;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -69,7 +69,7 @@ public:
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgesLoader) const override;
   void FindClosestEdges(m2::PointD const & point, uint32_t count,
-                        vector<pair<Edge, m2::PointD>> & vicinities) const override;
+                        vector<pair<Edge, Junction>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
   IRoadGraph::Mode GetMode() const override;
@@ -88,8 +88,10 @@ private:
   // Searches a feature RoadInfo in the cache, and if does not find then takes passed feature and speed.
   // This version is used to prevent redundant feature loading when feature speed is known.
   RoadInfo const & GetCachedRoadInfo(FeatureID const & featureId,
-                                     FeatureType & ft,
+                                     FeatureType const & ft,
                                      double speedKMPH) const;
+  void ExtractRoadInfo(FeatureID const & featureId, FeatureType const & ft,
+                       double speedKMPH, RoadInfo & ri) const;
 
   void LockFeatureMwm(FeatureID const & featureId) const;
 

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -85,7 +85,9 @@ private:
     explicit Value(MwmSet::MwmHandle && handle);
 
     bool IsAlive() const { return m_mwmHandle.IsAlive(); }
+
     bool HasAltitudeLoader() const { return m_altitudeLoader && m_altitudeLoader->HasAltitudes(); }
+
     MwmSet::MwmHandle m_mwmHandle;
     unique_ptr<feature::AltitudeLoader> m_altitudeLoader;
   };

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -82,24 +82,20 @@ private:
   struct Value
   {
     Value() = default;
-    explicit Value(MwmSet::MwmHandle && handle)
-      : mwmHandle(move(handle))
-    {
-      if (!mwmHandle.IsAlive())
-      {
-        ASSERT(false, ());
-        return;
-      }
-      altitudeLoader = make_unique<feature::AltitudeLoader>(*mwmHandle.GetValue<MwmValue>());
-    }
+    explicit Value(MwmSet::MwmHandle && handle);
 
     bool IsAlive() const
     {
-      return mwmHandle.IsAlive() && altitudeLoader && altitudeLoader->IsAvailable();
+      return m_mwmHandle.IsAlive();
     }
 
-    MwmSet::MwmHandle mwmHandle;
-    unique_ptr<feature::AltitudeLoader> altitudeLoader;
+    bool HasAltitudeLoader() const
+    {
+      return m_altitudeLoader && m_altitudeLoader->HasAltitudes();
+    }
+
+    MwmSet::MwmHandle m_mwmHandle;
+    unique_ptr<feature::AltitudeLoader> m_altitudeLoader;
   };
 
   bool IsRoad(FeatureType const & ft) const;
@@ -116,7 +112,7 @@ private:
   void ExtractRoadInfo(FeatureID const & featureId, FeatureType const & ft, double speedKMPH,
                        RoadInfo & ri) const;
 
-  Value const & LockFeatureMwm(FeatureID const & featureId) const;
+  Value const & LockMwm(MwmSet::MwmId const & mwmId) const;
 
   Index const & m_index;
   IRoadGraph::Mode const m_mode;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -84,16 +84,8 @@ private:
     Value() = default;
     explicit Value(MwmSet::MwmHandle && handle);
 
-    bool IsAlive() const
-    {
-      return m_mwmHandle.IsAlive();
-    }
-
-    bool HasAltitudeLoader() const
-    {
-      return m_altitudeLoader && m_altitudeLoader->HasAltitudes();
-    }
-
+    bool IsAlive() const { return m_mwmHandle.IsAlive(); }
+    bool HasAltitudeLoader() const { return m_altitudeLoader && m_altitudeLoader->HasAltitudes(); }
     MwmSet::MwmHandle m_mwmHandle;
     unique_ptr<feature::AltitudeLoader> m_altitudeLoader;
   };

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -82,7 +82,7 @@ private:
   struct Value
   {
     Value() = default;
-    explicit Value(MwmSet::MwmHandle && handle);
+    explicit Value(MwmSet::MwmHandle handle);
 
     bool IsAlive() const { return m_mwmHandle.IsAlive(); }
 

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -13,10 +13,7 @@ namespace routing
 
 NearestEdgeFinder::Candidate::Candidate()
     : m_dist(numeric_limits<double>::max()),
-      m_segId(0),
-      m_segStart(m2::PointD::Zero()),
-      m_segEnd(m2::PointD::Zero()),
-      m_point(m2::PointD::Zero())
+      m_segId(0)
 {
 }
 
@@ -29,13 +26,13 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
 {
   Candidate res;
 
-  size_t const count = roadInfo.m_points.size();
+  size_t const count = roadInfo.m_junctions.size();
   ASSERT_GREATER(count, 1, ());
   for (size_t i = 1; i < count; ++i)
   {
     /// @todo Probably, we need to get exact projection distance in meters.
     m2::ProjectionToSection<m2::PointD> segProj;
-    segProj.SetBounds(roadInfo.m_points[i - 1], roadInfo.m_points[i]);
+    segProj.SetBounds(roadInfo.m_junctions[i - 1].GetPoint(), roadInfo.m_junctions[i].GetPoint());
 
     m2::PointD const pt = segProj(m_point);
     double const d = m_point.SquareLength(pt);
@@ -44,9 +41,16 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       res.m_dist = d;
       res.m_fid = featureId;
       res.m_segId = static_cast<uint32_t>(i - 1);
-      res.m_segStart = roadInfo.m_points[i - 1];
-      res.m_segEnd = roadInfo.m_points[i];
-      res.m_point = pt;
+      res.m_segStart = roadInfo.m_junctions[i - 1];
+      res.m_segEnd = roadInfo.m_junctions[i];
+      // @TODO res.m_projPoint.GetAltitude() is an altitude of |pt|. |pt| is a projection of m_point
+      // to segment [res.m_segStart.GetPoint(), res.m_segEnd.GetPoint()].
+      // It's necessary to calculate exact value of res.m_projPoint.GetAltitude() by this information.
+      bool const isAltidudeValid = res.m_segStart.GetAltitude() != feature::kInvalidAltitude
+          && res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
+      feature::TAltitude const projPointAlt = isAltidudeValid ? static_cast<feature::TAltitude>((res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
+                                                              : feature::kInvalidAltitude;
+      res.m_projPoint = Junction(pt, projPointAlt);
     }
   }
 
@@ -54,7 +58,7 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
     m_candidates.push_back(res);
 }
 
-void NearestEdgeFinder::MakeResult(vector<pair<Edge, m2::PointD>> & res, size_t const maxCountFeatures)
+void NearestEdgeFinder::MakeResult(vector<pair<Edge, Junction>> & res, size_t const maxCountFeatures)
 {
   sort(m_candidates.begin(), m_candidates.end(), [](Candidate const & r1, Candidate const & r2)
   {
@@ -67,7 +71,8 @@ void NearestEdgeFinder::MakeResult(vector<pair<Edge, m2::PointD>> & res, size_t 
   size_t i = 0;
   for (Candidate const & candidate : m_candidates)
   {
-    res.emplace_back(Edge(candidate.m_fid, true /* forward */, candidate.m_segId, candidate.m_segStart, candidate.m_segEnd), candidate.m_point);
+    res.emplace_back(Edge(candidate.m_fid, true /* forward */, candidate.m_segId,
+                          candidate.m_segStart, candidate.m_segEnd), candidate.m_projPoint);
     ++i;
     if (i == maxCountFeatures)
       break;

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -41,12 +41,10 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       // to segment [res.m_segStart.GetPoint(), res.m_segEnd.GetPoint()].
       // It's necessary to calculate exact value of res.m_projPoint.GetAltitude() by this
       // information.
-      bool const isAltitude = res.m_segStart.GetAltitude() != feature::kInvalidAltitude &&
-                              res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
+      ASSERT_NOT_EQUAL(res.m_segStart.GetAltitude() , feature::kInvalidAltitude, ());
+      ASSERT_NOT_EQUAL(res.m_segEnd.GetAltitude(), feature::kInvalidAltitude, ());
       feature::TAltitude const projPointAlt =
-          isAltitude ? static_cast<feature::TAltitude>(
-                           (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
-                     : feature::kInvalidAltitude;
+           static_cast<feature::TAltitude>((res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2);
       res.m_projPoint = Junction(pt, projPointAlt);
     }
   }

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -41,12 +41,15 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       feature::TAltitude projPointAlt = feature::kDefaultAltitudeMeters;
       if (segLenM == 0.0)
       {
-        ASSERT(false, (featureId));
+        LOG(LWARNING, ("Length of segment", i, " of feature", featureId, "is zero."));
         projPointAlt = startAlt;
       }
-      double const distFromStartM = MercatorBounds::DistanceOnEarth(segStart.GetPoint(), pt);
-      ASSERT_LESS_OR_EQUAL(distFromStartM, segLenM, (featureId));
-      projPointAlt = startAlt + static_cast<feature::TAltitude>((endAlt - startAlt) * distFromStartM / segLenM);
+      else
+      {
+        double const distFromStartM = MercatorBounds::DistanceOnEarth(segStart.GetPoint(), pt);
+        ASSERT_LESS_OR_EQUAL(distFromStartM, segLenM, (featureId));
+        projPointAlt = startAlt + static_cast<feature::TAltitude>((endAlt - startAlt) * distFromStartM / segLenM);
+      }
 
       res.m_dist = d;
       res.m_fid = featureId;

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -42,12 +42,10 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       // to segment [res.m_segStart.GetPoint(), res.m_segEnd.GetPoint()].
       // It's necessary to calculate exact value of res.m_projPoint.GetAltitude() by this
       // information.
-      bool const isAltidudeValid = res.m_segStart.GetAltitude() != feature::kInvalidAltitude &&
-                                   res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
-      feature::TAltitude const projPointAlt =
-          isAltidudeValid ? static_cast<feature::TAltitude>(
-                                (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
-                          : feature::kInvalidAltitude;
+      bool const isAltitude = res.m_segStart.GetAltitude() != feature::kInvalidAltitude &&
+                              res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
+      feature::TAltitude const projPointAlt = isAltitude ? static_cast<feature::TAltitude>(
+          (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2) : feature::kInvalidAltitude;
       res.m_projPoint = Junction(pt, projPointAlt);
     }
   }

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -10,12 +10,7 @@
 
 namespace routing
 {
-
-NearestEdgeFinder::Candidate::Candidate()
-    : m_dist(numeric_limits<double>::max()),
-      m_segId(0)
-{
-}
+NearestEdgeFinder::Candidate::Candidate() : m_dist(numeric_limits<double>::max()), m_segId(0) {}
 
 NearestEdgeFinder::NearestEdgeFinder(m2::PointD const & point)
     : m_point(point)
@@ -45,11 +40,14 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       res.m_segEnd = roadInfo.m_junctions[i];
       // @TODO res.m_projPoint.GetAltitude() is an altitude of |pt|. |pt| is a projection of m_point
       // to segment [res.m_segStart.GetPoint(), res.m_segEnd.GetPoint()].
-      // It's necessary to calculate exact value of res.m_projPoint.GetAltitude() by this information.
-      bool const isAltidudeValid = res.m_segStart.GetAltitude() != feature::kInvalidAltitude
-          && res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
-      feature::TAltitude const projPointAlt = isAltidudeValid ? static_cast<feature::TAltitude>((res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
-                                                              : feature::kInvalidAltitude;
+      // It's necessary to calculate exact value of res.m_projPoint.GetAltitude() by this
+      // information.
+      bool const isAltidudeValid = res.m_segStart.GetAltitude() != feature::kInvalidAltitude &&
+                                   res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
+      feature::TAltitude const projPointAlt =
+          isAltidudeValid ? static_cast<feature::TAltitude>(
+                                (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
+                          : feature::kInvalidAltitude;
       res.m_projPoint = Junction(pt, projPointAlt);
     }
   }
@@ -58,7 +56,8 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
     m_candidates.push_back(res);
 }
 
-void NearestEdgeFinder::MakeResult(vector<pair<Edge, Junction>> & res, size_t const maxCountFeatures)
+void NearestEdgeFinder::MakeResult(vector<pair<Edge, Junction>> & res,
+                                   size_t const maxCountFeatures)
 {
   sort(m_candidates.begin(), m_candidates.end(), [](Candidate const & r1, Candidate const & r2)
   {
@@ -72,7 +71,8 @@ void NearestEdgeFinder::MakeResult(vector<pair<Edge, Junction>> & res, size_t co
   for (Candidate const & candidate : m_candidates)
   {
     res.emplace_back(Edge(candidate.m_fid, true /* forward */, candidate.m_segId,
-                          candidate.m_segStart, candidate.m_segEnd), candidate.m_projPoint);
+                          candidate.m_segStart, candidate.m_segEnd),
+                     candidate.m_projPoint);
     ++i;
     if (i == maxCountFeatures)
       break;

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -11,7 +11,6 @@
 namespace routing
 {
 NearestEdgeFinder::Candidate::Candidate() : m_dist(numeric_limits<double>::max()), m_segId(0) {}
-
 NearestEdgeFinder::NearestEdgeFinder(m2::PointD const & point)
     : m_point(point)
 {
@@ -44,8 +43,10 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       // information.
       bool const isAltitude = res.m_segStart.GetAltitude() != feature::kInvalidAltitude &&
                               res.m_segEnd.GetAltitude() != feature::kInvalidAltitude;
-      feature::TAltitude const projPointAlt = isAltitude ? static_cast<feature::TAltitude>(
-          (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2) : feature::kInvalidAltitude;
+      feature::TAltitude const projPointAlt =
+          isAltitude ? static_cast<feature::TAltitude>(
+                           (res.m_segStart.GetAltitude() + res.m_segEnd.GetAltitude()) / 2)
+                     : feature::kInvalidAltitude;
       res.m_projPoint = Junction(pt, projPointAlt);
     }
   }

--- a/routing/nearest_edge_finder.hpp
+++ b/routing/nearest_edge_finder.hpp
@@ -5,6 +5,7 @@
 
 #include "geometry/point2d.hpp"
 
+#include "indexer/feature_altitude.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/index.hpp"
 #include "indexer/mwm_set.hpp"
@@ -24,9 +25,9 @@ class NearestEdgeFinder
   {
     double m_dist;
     uint32_t m_segId;
-    m2::PointD m_segStart;
-    m2::PointD m_segEnd;
-    m2::PointD m_point;
+    Junction m_segStart;
+    Junction m_segEnd;
+    Junction m_projPoint;
     FeatureID m_fid;
 
     Candidate();
@@ -42,7 +43,7 @@ public:
 
   void AddInformationSource(FeatureID const & featureId, IRoadGraph::RoadInfo const & roadInfo);
 
-  void MakeResult(vector<pair<Edge, m2::PointD>> & res, size_t const maxCountFeatures);
+  void MakeResult(vector<pair<Edge, Junction>> & res, size_t const maxCountFeatures);
 };
 
 }  // namespace routing

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -642,6 +642,13 @@ IVehicleModel::RoadAvailability PedestrianModel::GetRoadAvailability(feature::Ty
   return RoadAvailability::Unknown;
 }
 
+// static
+PedestrianModel const & PedestrianModel::DefaultInstance()
+{
+  static PedestrianModel const instance;
+  return instance;
+}
+
 PedestrianModelFactory::PedestrianModelFactory()
 {
   m_models[string()] = make_shared<PedestrianModel>(g_pedestrianLimitsDefault);

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -643,7 +643,7 @@ IVehicleModel::RoadAvailability PedestrianModel::GetRoadAvailability(feature::Ty
 }
 
 // static
-PedestrianModel const & PedestrianModel::DefaultInstance()
+PedestrianModel const & PedestrianModel::AllLimitsInstance()
 {
   static PedestrianModel const instance;
   return instance;

--- a/routing/pedestrian_model.hpp
+++ b/routing/pedestrian_model.hpp
@@ -17,6 +17,8 @@ public:
   /// VehicleModel overrides:
   bool IsOneWay(FeatureType const &) const override { return false; }
 
+  static PedestrianModel const & DefaultInstance();
+
 protected:
   RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;
 

--- a/routing/pedestrian_model.hpp
+++ b/routing/pedestrian_model.hpp
@@ -17,7 +17,7 @@ public:
   /// VehicleModel overrides:
   bool IsOneWay(FeatureType const &) const override { return false; }
 
-  static PedestrianModel const & DefaultInstance();
+  static PedestrianModel const & AllLimitsInstance();
 
 protected:
   RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;

--- a/routing/pedestrian_model.hpp
+++ b/routing/pedestrian_model.hpp
@@ -16,7 +16,6 @@ public:
 
   /// VehicleModel overrides:
   bool IsOneWay(FeatureType const &) const override { return false; }
-
   static PedestrianModel const & AllLimitsInstance();
 
 protected:

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -66,7 +66,7 @@ void ReverseEdges(size_t beginIdx, IRoadGraph::TEdgeVector & edges)
 
 // Junction --------------------------------------------------------------------
 
-Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kDefautlAltitudeMeters) {}
+Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kDefaultAltitudeMeters) {}
 Junction::Junction(m2::PointD const & point, feature::TAltitude altitude)
   : m_point(point), m_altitude(altitude)
 {}

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -67,7 +67,6 @@ void ReverseEdges(size_t beginIdx, IRoadGraph::TEdgeVector & edges)
 // Junction --------------------------------------------------------------------
 
 Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kInvalidAltitude) {}
-
 Junction::Junction(m2::PointD const & point, feature::TAltitude altitude)
   : m_point(point), m_altitude(altitude)
 {}
@@ -142,7 +141,6 @@ string DebugPrint(Edge const & r)
 IRoadGraph::RoadInfo::RoadInfo()
   : m_speedKMPH(0.0), m_bidirectional(false)
 {}
-
 IRoadGraph::RoadInfo::RoadInfo(RoadInfo && ri)
   : m_junctions(move(ri.m_junctions))
   , m_speedKMPH(ri.m_speedKMPH)
@@ -158,8 +156,7 @@ IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH,
 void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
   ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction,
-                                                      bool forward)
-  {
+                                                      bool forward) {
     if (forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
       m_edges.emplace_back(featureId, forward, segId, m_cross, endJunction);
   });
@@ -169,8 +166,7 @@ void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId, Roa
 void IRoadGraph::CrossIngoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
   ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction,
-                                                      bool forward)
-  {
+                                                      bool forward) {
     if (!forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
       m_edges.emplace_back(featureId, !forward, segId, endJunction, m_cross);
   });
@@ -222,7 +218,6 @@ void IRoadGraph::ResetFakes()
 {
   m_outgoingEdges.clear();
 }
-
 void IRoadGraph::AddFakeEdges(Junction const & junction,
                               vector<pair<Edge, Junction>> const & vicinity)
 {

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -390,12 +390,10 @@ void IRoadGraph::GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) c
 IRoadGraph::RoadInfo MakeRoadInfoForTesting(bool bidirectional, double speedKMPH,
                                             initializer_list<m2::PointD> const & points)
 {
-  buffer_vector<Junction, 32> junctions;
-  for (auto const & p : points)
-    junctions.emplace_back(MakeJunctionForTesting(p));
-
   IRoadGraph::RoadInfo ri(bidirectional, speedKMPH, {});
-  ri.m_junctions.swap(junctions);
+  for (auto const & p : points)
+    ri.m_junctions.emplace_back(MakeJunctionForTesting(p));
+
   return ri;
 }
 }  // namespace routing

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -66,7 +66,7 @@ void ReverseEdges(size_t beginIdx, IRoadGraph::TEdgeVector & edges)
 
 // Junction --------------------------------------------------------------------
 
-Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kInvalidAltitude) {}
+Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kDefautlAltitudeMeters) {}
 Junction::Junction(m2::PointD const & point, feature::TAltitude altitude)
   : m_point(point), m_altitude(altitude)
 {}

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -66,9 +66,7 @@ void ReverseEdges(size_t beginIdx, IRoadGraph::TEdgeVector & edges)
 
 // Junction --------------------------------------------------------------------
 
-Junction::Junction()
-  : m_point(m2::PointD::Zero()), m_altitude(feature::kInvalidAltitude)
-{}
+Junction::Junction() : m_point(m2::PointD::Zero()), m_altitude(feature::kInvalidAltitude) {}
 
 Junction::Junction(m2::PointD const & point, feature::TAltitude altitude)
   : m_point(point), m_altitude(altitude)
@@ -146,19 +144,21 @@ IRoadGraph::RoadInfo::RoadInfo()
 {}
 
 IRoadGraph::RoadInfo::RoadInfo(RoadInfo && ri)
-    : m_junctions(move(ri.m_junctions)),
-      m_speedKMPH(ri.m_speedKMPH),
-      m_bidirectional(ri.m_bidirectional)
+  : m_junctions(move(ri.m_junctions))
+  , m_speedKMPH(ri.m_speedKMPH)
+  , m_bidirectional(ri.m_bidirectional)
 {}
 
-IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH, initializer_list<Junction> const & points)
-    : m_junctions(points), m_speedKMPH(speedKMPH), m_bidirectional(bidirectional)
+IRoadGraph::RoadInfo::RoadInfo(bool bidirectional, double speedKMPH,
+                               initializer_list<Junction> const & points)
+  : m_junctions(points), m_speedKMPH(speedKMPH), m_bidirectional(bidirectional)
 {}
 
 // IRoadGraph::CrossOutgoingLoader ---------------------------------------------
 void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
-  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction, bool forward)
+  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction,
+                                                      bool forward)
   {
     if (forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
       m_edges.emplace_back(featureId, forward, segId, m_cross, endJunction);
@@ -168,7 +168,8 @@ void IRoadGraph::CrossOutgoingLoader::LoadEdges(FeatureID const & featureId, Roa
 // IRoadGraph::CrossIngoingLoader ----------------------------------------------
 void IRoadGraph::CrossIngoingLoader::LoadEdges(FeatureID const & featureId, RoadInfo const & roadInfo)
 {
-  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction, bool forward)
+  ForEachEdge(roadInfo, [&featureId, &roadInfo, this](size_t segId, Junction const & endJunction,
+                                                      bool forward)
   {
     if (!forward || roadInfo.m_bidirectional || m_mode == IRoadGraph::Mode::IgnoreOnewayTag)
       m_edges.emplace_back(featureId, !forward, segId, endJunction, m_cross);
@@ -222,7 +223,8 @@ void IRoadGraph::ResetFakes()
   m_outgoingEdges.clear();
 }
 
-void IRoadGraph::AddFakeEdges(Junction const & junction, vector<pair<Edge, Junction>> const & vicinity)
+void IRoadGraph::AddFakeEdges(Junction const & junction,
+                              vector<pair<Edge, Junction>> const & vicinity)
 {
   for (auto const & v : vicinity)
   {

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -143,7 +143,8 @@ public:
     {
       for (size_t i = 0; i < roadInfo.m_junctions.size(); ++i)
       {
-        if (!my::AlmostEqualAbs(m_cross.GetPoint(), roadInfo.m_junctions[i].GetPoint(), kPointsEqualEpsilon))
+        if (!my::AlmostEqualAbs(m_cross.GetPoint(), roadInfo.m_junctions[i].GetPoint(),
+                                kPointsEqualEpsilon))
           continue;
 
         if (i < roadInfo.m_junctions.size() - 1)
@@ -172,7 +173,9 @@ public:
   {
   public:
     CrossOutgoingLoader(Junction const & cross, IRoadGraph::Mode mode, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, mode, edges) {}
+      : ICrossEdgesLoader(cross, mode, edges)
+    {
+    }
 
   private:
     // ICrossEdgesLoader overrides:
@@ -183,7 +186,9 @@ public:
   {
   public:
     CrossIngoingLoader(Junction const & cross, IRoadGraph::Mode mode, TEdgeVector & edges)
-      : ICrossEdgesLoader(cross, mode, edges) {}
+      : ICrossEdgesLoader(cross, mode, edges)
+    {
+    }
 
   private:
     // ICrossEdgesLoader overrides:

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -4,6 +4,7 @@
 
 #include "base/string_utils.hpp"
 
+#include "indexer/feature_altitude.hpp"
 #include "indexer/feature_data.hpp"
 
 #include "std/initializer_list.hpp"
@@ -106,6 +107,7 @@ public:
     RoadInfo & operator=(RoadInfo const &) = default;
 
     buffer_vector<m2::PointD, 32> m_points;
+    feature::Altitudes m_altitudes;
     double m_speedKMPH;
     bool m_bidirectional;
   };

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -29,6 +29,7 @@ public:
 
   inline m2::PointD const & GetPoint() const { return m_point; }
   inline feature::TAltitude GetAltitude() const { return m_altitude; }
+
 private:
   friend string DebugPrint(Junction const & r);
 
@@ -39,7 +40,7 @@ private:
 
 inline Junction MakeJunctionForTesting(m2::PointD const & point)
 {
-  return Junction(point, feature::kDefautlAltitudeMeters);
+  return Junction(point, feature::kDefaultAltitudeMeters);
 }
 
 inline bool AlmostEqualAbs(Junction const & lhs, Junction const & rhs)

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -39,7 +39,7 @@ private:
 
 inline Junction MakeJunctionForTesting(m2::PointD const & point)
 {
-  return Junction(point, feature::kInvalidAltitude);
+  return Junction(point, feature::kDefautlAltitudeMeters);
 }
 
 inline bool AlmostEqualAbs(Junction const & lhs, Junction const & rhs)

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -29,7 +29,6 @@ public:
 
   inline m2::PointD const & GetPoint() const { return m_point; }
   inline feature::TAltitude GetAltitude() const { return m_altitude; }
-
 private:
   friend string DebugPrint(Junction const & r);
 

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -49,6 +49,7 @@ SOURCES += \
     turns_tts_text.cpp \
     vehicle_model.cpp \
 
+
 HEADERS += \
     async_router.hpp \
     base/astar_algorithm.hpp \
@@ -79,6 +80,7 @@ HEADERS += \
     router.hpp \
     router_delegate.hpp \
     routing_algorithm.hpp \
+    routing_helpers.hpp \
     routing_mapping.hpp \
     routing_result_graph.hpp \
     routing_session.hpp \

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -19,7 +19,9 @@ double constexpr KMPH2MPS = 1000.0 / (60 * 60);
 inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double speedMPS)
 {
   ASSERT(speedMPS > 0.0, ());
-  return MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint()) / speedMPS;
+  double const distanceM = MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
+  double const altidudeDiffM = j2.GetAltitude() - j1.GetAltitude();
+  return sqrt(distanceM * distanceM + altidudeDiffM * altidudeDiffM) / speedMPS;
 }
 
 /// A class which represents an weighted edge used by RoadGraph.

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -20,7 +20,12 @@ inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double sp
 {
   ASSERT(speedMPS > 0.0, ());
   double const distanceM = MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
-  double const altidudeDiffM = j2.GetAltitude() - j1.GetAltitude();
+  feature::TAltitude const j1Altitude = j1.GetAltitude();
+  feature::TAltitude const j2Altitude = j2.GetAltitude();
+  if (j1Altitude == feature::kInvalidAltitude || j2Altitude == feature::kInvalidAltitude)
+    return distanceM / speedMPS;
+
+  feature::TAltitude const altidudeDiffM = j2Altitude - j1Altitude;
   return sqrt(distanceM * distanceM + altidudeDiffM * altidudeDiffM) / speedMPS;
 }
 

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -19,13 +19,11 @@ double constexpr KMPH2MPS = 1000.0 / (60 * 60);
 inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double speedMPS)
 {
   ASSERT(speedMPS > 0.0, ());
-  double const distanceM = MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
-  feature::TAltitude const j1Altitude = j1.GetAltitude();
-  feature::TAltitude const j2Altitude = j2.GetAltitude();
-  if (j1Altitude == feature::kInvalidAltitude || j2Altitude == feature::kInvalidAltitude)
-    return distanceM / speedMPS;
+  ASSERT_NOT_EQUAL(j1.GetAltitude(), feature::kInvalidAltitude, ());
+  ASSERT_NOT_EQUAL(j2.GetAltitude(), feature::kInvalidAltitude, ());
 
-  feature::TAltitude const altidudeDiffM = j2Altitude - j1Altitude;
+  double const distanceM = MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
+  feature::TAltitude const altidudeDiffM = j2.GetAltitude() - j1.GetAltitude();
   return sqrt(distanceM * distanceM + altidudeDiffM * altidudeDiffM) / speedMPS;
 }
 

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -23,8 +23,9 @@ inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double sp
   ASSERT_NOT_EQUAL(j2.GetAltitude(), feature::kInvalidAltitude, ());
 
   double const distanceM = MercatorBounds::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
-  feature::TAltitude const altidudeDiffM = j2.GetAltitude() - j1.GetAltitude();
-  return sqrt(distanceM * distanceM + altidudeDiffM * altidudeDiffM) / speedMPS;
+  double const altitudeDiffM =
+      static_cast<double>(j2.GetAltitude()) - static_cast<double>(j1.GetAltitude());
+  return sqrt(distanceM * distanceM + altitudeDiffM * altitudeDiffM) / speedMPS;
 }
 
 /// A class which represents an weighted edge used by RoadGraph.

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -10,8 +10,8 @@ namespace routing
 template <class TList>
 bool IsRoad(TList const & types)
 {
-  return CarModel::Instance().HasRoadType(types)
-         || PedestrianModel::DefaultInstance().HasRoadType(types)
-         || BicycleModel::DefaultInstance().HasRoadType(types);
+  return CarModel::Instance().HasRoadType(types) ||
+         PedestrianModel::DefaultInstance().HasRoadType(types) ||
+         BicycleModel::DefaultInstance().HasRoadType(types);
 }
-} // namespace rouing
+}  // namespace rouing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -7,8 +7,8 @@
 namespace routing
 {
 /// \returns true when there exists a routing mode where the feature with |types| can be used.
-template <class TList>
-bool IsRoad(TList const & types)
+template <class TTypes>
+bool IsRoad(TTypes const & types)
 {
   return CarModel::Instance().HasRoadType(types) ||
          PedestrianModel::DefaultInstance().HasRoadType(types) ||

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -6,7 +6,7 @@
 
 namespace routing
 {
-/// \returns true if a feature with |types| can be used for any kind of routing.
+/// \returns true when there exists a routing mode where the feature with |types| can be used.
 template <class TList>
 bool IsRoad(TList const & types)
 {

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -11,7 +11,7 @@ template <class TTypes>
 bool IsRoad(TTypes const & types)
 {
   return CarModel::Instance().HasRoadType(types) ||
-         PedestrianModel::DefaultInstance().HasRoadType(types) ||
-         BicycleModel::DefaultInstance().HasRoadType(types);
+         PedestrianModel::AllLimitsInstance().HasRoadType(types) ||
+         BicycleModel::AllLimitsInstance().HasRoadType(types);
 }
 }  // namespace rouing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "routing/bicycle_model.hpp"
+#include "routing/car_model.hpp"
+#include "routing/pedestrian_model.hpp"
+
+namespace routing
+{
+/// \returns true if a feature with |types| can be used for any kind of routing.
+template <class TList>
+bool IsRoad(TList const & types)
+{
+  return CarModel::Instance().HasRoadType(types)
+         || PedestrianModel::DefaultInstance().HasRoadType(types)
+         || BicycleModel::DefaultInstance().HasRoadType(types);
+}
+} // namespace rouing

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -59,6 +59,9 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
 
+  Route const & route = *routeResult.first;
+  UNUSED_VALUE(route);
+
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::IRouter::RouteNotFound, ());
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -59,9 +59,6 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
 
-  Route const & route = *routeResult.first;
-  UNUSED_VALUE(route);
-
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::IRouter::RouteNotFound, ());
 }

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -56,12 +56,10 @@ UNIT_TEST(AStarRouter_Graph2_Simple1)
   Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
   Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 55));
 
-  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(0, 0)),
-                                     MakeJunctionForTesting(m2::PointD(5, 10)),
-                                     MakeJunctionForTesting(m2::PointD(5, 40)),
-                                     MakeJunctionForTesting(m2::PointD(18, 55)),
-                                     MakeJunctionForTesting(m2::PointD(39, 55)),
-                                     MakeJunctionForTesting(m2::PointD(80, 55))};
+  vector<Junction> const expected = {
+      MakeJunctionForTesting(m2::PointD(0, 0)),   MakeJunctionForTesting(m2::PointD(5, 10)),
+      MakeJunctionForTesting(m2::PointD(5, 40)),  MakeJunctionForTesting(m2::PointD(18, 55)),
+      MakeJunctionForTesting(m2::PointD(39, 55)), MakeJunctionForTesting(m2::PointD(80, 55))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
@@ -71,13 +69,11 @@ UNIT_TEST(AStarRouter_Graph2_Simple2)
   Junction const startPos = MakeJunctionForTesting(m2::PointD(80, 55));
   Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 0));
 
-  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(80, 55)),
-                                     MakeJunctionForTesting(m2::PointD(39, 55)),
-                                     MakeJunctionForTesting(m2::PointD(37, 30)),
-                                     MakeJunctionForTesting(m2::PointD(70, 30)),
-                                     MakeJunctionForTesting(m2::PointD(70, 10)),
-                                     MakeJunctionForTesting(m2::PointD(70, 0)),
-                                     MakeJunctionForTesting(m2::PointD(80, 0))};
+  vector<Junction> const expected = {
+      MakeJunctionForTesting(m2::PointD(80, 55)), MakeJunctionForTesting(m2::PointD(39, 55)),
+      MakeJunctionForTesting(m2::PointD(37, 30)), MakeJunctionForTesting(m2::PointD(70, 30)),
+      MakeJunctionForTesting(m2::PointD(70, 10)), MakeJunctionForTesting(m2::PointD(70, 0)),
+      MakeJunctionForTesting(m2::PointD(80, 0))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
@@ -97,10 +93,9 @@ UNIT_TEST(AStarRouter_SimpleGraph_RouteIsFound)
   Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
   Junction const finalPos = MakeJunctionForTesting(m2::PointD(40, 100));
 
-  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(0, 0)),
-                                     MakeJunctionForTesting(m2::PointD(0, 30)),
-                                     MakeJunctionForTesting(m2::PointD(0, 60)),
-                                     MakeJunctionForTesting(m2::PointD(40, 100))};
+  vector<Junction> const expected = {
+      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 30)),
+      MakeJunctionForTesting(m2::PointD(0, 60)), MakeJunctionForTesting(m2::PointD(40, 100))};
 
   RouterDelegate delegate;
   RoutingResult<Junction> result;
@@ -120,30 +115,36 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   double const speedKMPH = graph.GetMaxSpeedKMPH();
 
   // Roads in the first connected component.
-  vector<IRoadGraph::RoadInfo> const roadInfo_1 =
-  {
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(10, 10)), MakeJunctionForTesting(m2::PointD(90, 10))}), // feature 0
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(90, 10)), MakeJunctionForTesting(m2::PointD(90, 90))}), // feature 1
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(90, 90)), MakeJunctionForTesting(m2::PointD(10, 90))}), // feature 2
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(10, 90)), MakeJunctionForTesting(m2::PointD(10, 10))}), // feature 3
+  vector<IRoadGraph::RoadInfo> const roadInfo_1 = {
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(10, 10)),
+                            MakeJunctionForTesting(m2::PointD(90, 10))}),  // feature 0
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(90, 10)),
+                            MakeJunctionForTesting(m2::PointD(90, 90))}),  // feature 1
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(90, 90)),
+                            MakeJunctionForTesting(m2::PointD(10, 90))}),  // feature 2
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(10, 90)),
+                            MakeJunctionForTesting(m2::PointD(10, 10))}),  // feature 3
   };
   vector<uint32_t> const featureId_1 = { 0, 1, 2, 3 }; // featureIDs in the first connected component
 
   // Roads in the second connected component.
-  vector<IRoadGraph::RoadInfo> const roadInfo_2 =
-  {
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(30, 30)), MakeJunctionForTesting(m2::PointD(70, 30))}), // feature 4
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(70, 30)), MakeJunctionForTesting(m2::PointD(70, 70))}), // feature 5
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(70, 70)), MakeJunctionForTesting(m2::PointD(30, 70))}), // feature 6
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
-        MakeJunctionForTesting(m2::PointD(30, 70)), MakeJunctionForTesting(m2::PointD(30, 30))}), // feature 7
+  vector<IRoadGraph::RoadInfo> const roadInfo_2 = {
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(30, 30)),
+                            MakeJunctionForTesting(m2::PointD(70, 30))}),  // feature 4
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(70, 30)),
+                            MakeJunctionForTesting(m2::PointD(70, 70))}),  // feature 5
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(70, 70)),
+                            MakeJunctionForTesting(m2::PointD(30, 70))}),  // feature 6
+      IRoadGraph::RoadInfo(true /* bidir */, speedKMPH,
+                           {MakeJunctionForTesting(m2::PointD(30, 70)),
+                            MakeJunctionForTesting(m2::PointD(30, 30))}),  // feature 7
   };
   vector<uint32_t> const featureId_2 = { 4, 5, 6, 7 }; // featureIDs in the second connected component
 
@@ -232,13 +233,14 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad1)
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
-                                            MakeJunctionForTesting(m2::PointD(2,3)),
-                                            MakeJunctionForTesting(m2::PointD(4,3)),
-                                            MakeJunctionForTesting(m2::PointD(6,3)),
-                                            MakeJunctionForTesting(m2::PointD(8,3)),
-                                            MakeJunctionForTesting(m2::PointD(10,3)),
-                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
+  TEST_EQUAL(
+      result.path,
+      vector<Junction>(
+          {MakeJunctionForTesting(m2::PointD(2, 2)), MakeJunctionForTesting(m2::PointD(2, 3)),
+           MakeJunctionForTesting(m2::PointD(4, 3)), MakeJunctionForTesting(m2::PointD(6, 3)),
+           MakeJunctionForTesting(m2::PointD(8, 3)), MakeJunctionForTesting(m2::PointD(10, 3)),
+           MakeJunctionForTesting(m2::PointD(10, 2))}),
+      ());
   TEST(my::AlmostEqualAbs(result.distance, 800451., 1.), ("Distance error:", result.distance));
 }
 
@@ -266,9 +268,10 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
-                                            MakeJunctionForTesting(m2::PointD(6,2)),
-                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
+  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
+                                            MakeJunctionForTesting(m2::PointD(6, 2)),
+                                            MakeJunctionForTesting(m2::PointD(10, 2))}),
+             ());
   TEST(my::AlmostEqualAbs(result.distance, 781458., 1.), ("Distance error:", result.distance));
 }
 
@@ -296,9 +299,10 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
-                                            MakeJunctionForTesting(m2::PointD(2,1)),
-                                            MakeJunctionForTesting(m2::PointD(10,1)),
-                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
+  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
+                                            MakeJunctionForTesting(m2::PointD(2, 1)),
+                                            MakeJunctionForTesting(m2::PointD(10, 1)),
+                                            MakeJunctionForTesting(m2::PointD(10, 2))}),
+             ());
   TEST(my::AlmostEqualAbs(result.distance, 814412., 1.), ("Distance error:", result.distance));
 }

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -7,8 +7,8 @@
 #include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
 
-#include "indexer/feature_altitude.hpp"
 #include "indexer/classificator_loader.hpp"
+#include "indexer/feature_altitude.hpp"
 
 #include "base/logging.hpp"
 #include "base/macros.hpp"

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -7,6 +7,7 @@
 #include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
 
+#include "indexer/feature_altitude.hpp"
 #include "indexer/classificator_loader.hpp"
 
 #include "base/logging.hpp"
@@ -39,36 +40,44 @@ void TestAStarRouterMock(Junction const & startPos, Junction const & finalPos,
 
 void AddRoad(RoadGraphMockSource & graph, double speedKMPH, initializer_list<m2::PointD> const & points)
 {
-  graph.AddRoad(IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, points));
+  graph.AddRoad(routing::MakeRoadInfoForTesting(true /* bidir */, speedKMPH, points));
 }
 
 void AddRoad(RoadGraphMockSource & graph, initializer_list<m2::PointD> const & points)
 {
   double const speedKMPH = graph.GetMaxSpeedKMPH();
-  graph.AddRoad(IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, points));
+  graph.AddRoad(routing::MakeRoadInfoForTesting(true /* bidir */, speedKMPH, points));
 }
 
 }  // namespace
 
 UNIT_TEST(AStarRouter_Graph2_Simple1)
 {
-  Junction const startPos = m2::PointD(0, 0);
-  Junction const finalPos = m2::PointD(80, 55);
+  Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
+  Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 55));
 
-  vector<Junction> const expected = {m2::PointD(0, 0),   m2::PointD(5, 10),  m2::PointD(5, 40),
-                                     m2::PointD(18, 55), m2::PointD(39, 55), m2::PointD(80, 55)};
+  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(0, 0)),
+                                     MakeJunctionForTesting(m2::PointD(5, 10)),
+                                     MakeJunctionForTesting(m2::PointD(5, 40)),
+                                     MakeJunctionForTesting(m2::PointD(18, 55)),
+                                     MakeJunctionForTesting(m2::PointD(39, 55)),
+                                     MakeJunctionForTesting(m2::PointD(80, 55))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
 
 UNIT_TEST(AStarRouter_Graph2_Simple2)
 {
-  Junction const startPos = m2::PointD(80, 55);
-  Junction const finalPos = m2::PointD(80, 0);
+  Junction const startPos = MakeJunctionForTesting(m2::PointD(80, 55));
+  Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 0));
 
-  vector<Junction> const expected = {m2::PointD(80, 55), m2::PointD(39, 55), m2::PointD(37, 30),
-                                     m2::PointD(70, 30), m2::PointD(70, 10), m2::PointD(70, 0),
-                                     m2::PointD(80, 0)};
+  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(80, 55)),
+                                     MakeJunctionForTesting(m2::PointD(39, 55)),
+                                     MakeJunctionForTesting(m2::PointD(37, 30)),
+                                     MakeJunctionForTesting(m2::PointD(70, 30)),
+                                     MakeJunctionForTesting(m2::PointD(70, 10)),
+                                     MakeJunctionForTesting(m2::PointD(70, 0)),
+                                     MakeJunctionForTesting(m2::PointD(80, 0))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
@@ -85,10 +94,13 @@ UNIT_TEST(AStarRouter_SimpleGraph_RouteIsFound)
   AddRoad(graph, {m2::PointD(0, 60), m2::PointD(0, 30)}); // feature 4
   AddRoad(graph, {m2::PointD(0, 30), m2::PointD(0, 0)}); // feature 5
 
-  Junction const startPos = m2::PointD(0, 0);
-  Junction const finalPos = m2::PointD(40, 100);
+  Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
+  Junction const finalPos = MakeJunctionForTesting(m2::PointD(40, 100));
 
-  vector<Junction> const expected = {m2::PointD(0, 0), m2::PointD(0, 30), m2::PointD(0, 60), m2::PointD(40, 100)};
+  vector<Junction> const expected = {MakeJunctionForTesting(m2::PointD(0, 0)),
+                                     MakeJunctionForTesting(m2::PointD(0, 30)),
+                                     MakeJunctionForTesting(m2::PointD(0, 60)),
+                                     MakeJunctionForTesting(m2::PointD(40, 100))};
 
   RouterDelegate delegate;
   RoutingResult<Junction> result;
@@ -110,20 +122,28 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Roads in the first connected component.
   vector<IRoadGraph::RoadInfo> const roadInfo_1 =
   {
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(10, 10), m2::PointD(90, 10)}), // feature 0
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(90, 10), m2::PointD(90, 90)}), // feature 1
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(90, 90), m2::PointD(10, 90)}), // feature 2
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(10, 90), m2::PointD(10, 10)}), // feature 3
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(10, 10)), MakeJunctionForTesting(m2::PointD(90, 10))}), // feature 0
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(90, 10)), MakeJunctionForTesting(m2::PointD(90, 90))}), // feature 1
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(90, 90)), MakeJunctionForTesting(m2::PointD(10, 90))}), // feature 2
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(10, 90)), MakeJunctionForTesting(m2::PointD(10, 10))}), // feature 3
   };
   vector<uint32_t> const featureId_1 = { 0, 1, 2, 3 }; // featureIDs in the first connected component
 
   // Roads in the second connected component.
   vector<IRoadGraph::RoadInfo> const roadInfo_2 =
   {
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(30, 30), m2::PointD(70, 30)}), // feature 4
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(70, 30), m2::PointD(70, 70)}), // feature 5
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(70, 70), m2::PointD(30, 70)}), // feature 6
-    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {m2::PointD(30, 70), m2::PointD(30, 30)}), // feature 7
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(30, 30)), MakeJunctionForTesting(m2::PointD(70, 30))}), // feature 4
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(70, 30)), MakeJunctionForTesting(m2::PointD(70, 70))}), // feature 5
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(70, 70)), MakeJunctionForTesting(m2::PointD(30, 70))}), // feature 6
+    IRoadGraph::RoadInfo(true /* bidir */, speedKMPH, {
+        MakeJunctionForTesting(m2::PointD(30, 70)), MakeJunctionForTesting(m2::PointD(30, 30))}), // feature 7
   };
   vector<uint32_t> const featureId_2 = { 4, 5, 6, 7 }; // featureIDs in the second connected component
 
@@ -141,11 +161,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is no any route between points in different connected components.
   for (size_t i = 0; i < roadInfo_1.size(); ++i)
   {
-    Junction const startPos(roadInfo_1[i].m_points[0]);
+    Junction const startPos = roadInfo_1[i].m_junctions[0];
     for (size_t j = 0; j < roadInfo_2.size(); ++j)
     {
       RouterDelegate delegate;
-      Junction const finalPos(roadInfo_2[j].m_points[0]);
+      Junction const finalPos = roadInfo_2[j].m_junctions[0];
       RoutingResult<Junction> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::NoPath,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
@@ -157,11 +177,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is route between points in the first connected component.
   for (size_t i = 0; i < roadInfo_1.size(); ++i)
   {
-    Junction const startPos(roadInfo_1[i].m_points[0]);
+    Junction const startPos = roadInfo_1[i].m_junctions[0];
     for (size_t j = i + 1; j < roadInfo_1.size(); ++j)
     {
       RouterDelegate delegate;
-      Junction const finalPos(roadInfo_1[j].m_points[0]);
+      Junction const finalPos = roadInfo_1[j].m_junctions[0];
       RoutingResult<Junction> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
@@ -173,11 +193,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is route between points in the second connected component.
   for (size_t i = 0; i < roadInfo_2.size(); ++i)
   {
-    Junction const startPos(roadInfo_2[i].m_points[0]);
+    Junction const startPos = roadInfo_2[i].m_junctions[0];
     for (size_t j = i + 1; j < roadInfo_2.size(); ++j)
     {
       RouterDelegate delegate;
-      Junction const finalPos(roadInfo_2[j].m_points[0]);
+      Junction const finalPos = roadInfo_2[j].m_junctions[0];
       RoutingResult<Junction> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
@@ -209,10 +229,16 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad1)
   RoutingResult<Junction> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
-             algorithm.CalculateRoute(graph, m2::PointD(2, 2), m2::PointD(10, 2), delegate, result),
+             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
+                                      MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({m2::PointD(2,2), m2::PointD(2,3), m2::PointD(4,3), m2::PointD(6,3),
-                                     m2::PointD(8,3), m2::PointD(10,3), m2::PointD(10,2)}), ());
+  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
+                                            MakeJunctionForTesting(m2::PointD(2,3)),
+                                            MakeJunctionForTesting(m2::PointD(4,3)),
+                                            MakeJunctionForTesting(m2::PointD(6,3)),
+                                            MakeJunctionForTesting(m2::PointD(8,3)),
+                                            MakeJunctionForTesting(m2::PointD(10,3)),
+                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
   TEST(my::AlmostEqualAbs(result.distance, 800451., 1.), ("Distance error:", result.distance));
 }
 
@@ -237,9 +263,12 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
   RoutingResult<Junction> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
-             algorithm.CalculateRoute(graph, m2::PointD(2, 2), m2::PointD(10, 2), delegate, result),
+             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
+                                      MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({m2::PointD(2,2), m2::PointD(6,2), m2::PointD(10,2)}), ());
+  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
+                                            MakeJunctionForTesting(m2::PointD(6,2)),
+                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
   TEST(my::AlmostEqualAbs(result.distance, 781458., 1.), ("Distance error:", result.distance));
 }
 
@@ -264,8 +293,12 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
   RoutingResult<Junction> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
-             algorithm.CalculateRoute(graph, m2::PointD(2, 2), m2::PointD(10, 2), delegate, result),
+             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
+                                      MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({m2::PointD(2,2), m2::PointD(2,1), m2::PointD(10,1), m2::PointD(10,2)}), ());
+  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2,2)),
+                                            MakeJunctionForTesting(m2::PointD(2,1)),
+                                            MakeJunctionForTesting(m2::PointD(10,1)),
+                                            MakeJunctionForTesting(m2::PointD(10,2))}), ());
   TEST(my::AlmostEqualAbs(result.distance, 814412., 1.), ("Distance error:", result.distance));
 }

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -8,7 +8,7 @@ using namespace routing;
 using namespace routing_test;
 
 void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
-                     vector<pair<Edge, Junction>> const & expected)
+                        vector<pair<Edge, Junction>> const & expected)
 {
   unique_ptr<RoadGraphMockSource> graph(new RoadGraphMockSource());
   InitRoadGraphMockSourceWithTest1(*graph);
@@ -29,36 +29,32 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
 
 UNIT_TEST(StarterPosAtBorder_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected =
-  {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0,
-        MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(5, 0))),
-        MakeJunctionForTesting(m2::PointD(0, 0)))
-  };
+  vector<pair<Edge, Junction>> const expected = {make_pair(
+      Edge(MakeTestFeatureID(0), true /* forward */, 0, MakeJunctionForTesting(m2::PointD(0, 0)),
+           MakeJunctionForTesting(m2::PointD(5, 0))),
+      MakeJunctionForTesting(m2::PointD(0, 0)))};
   TestNearestOnMock1(m2::PointD(0, 0), 1, expected);
 }
 
 UNIT_TEST(MiddleEdgeTest_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected =
-  {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0,
-        MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(5, 0))),
-        MakeJunctionForTesting(m2::PointD(3, 0)))
-  };
+  vector<pair<Edge, Junction>> const expected = {make_pair(
+      Edge(MakeTestFeatureID(0), true /* forward */, 0, MakeJunctionForTesting(m2::PointD(0, 0)),
+           MakeJunctionForTesting(m2::PointD(5, 0))),
+      MakeJunctionForTesting(m2::PointD(3, 0)))};
   TestNearestOnMock1(m2::PointD(3, 3), 1, expected);
 }
 
 UNIT_TEST(MiddleSegmentTest_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected =
-  {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 2,
-        MakeJunctionForTesting(m2::PointD(10, 0)), MakeJunctionForTesting(m2::PointD(15, 0))),
-        MakeJunctionForTesting(m2::PointD(12.5, 0))),
-    make_pair(Edge(MakeTestFeatureID(1), true /* forward */, 2,
-        MakeJunctionForTesting(m2::PointD(10, 0)), MakeJunctionForTesting(m2::PointD(10, 5))),
-        MakeJunctionForTesting(m2::PointD(10, 2.5)))
-  };
+  vector<pair<Edge, Junction>> const expected = {
+      make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 2,
+                     MakeJunctionForTesting(m2::PointD(10, 0)),
+                     MakeJunctionForTesting(m2::PointD(15, 0))),
+                MakeJunctionForTesting(m2::PointD(12.5, 0))),
+      make_pair(Edge(MakeTestFeatureID(1), true /* forward */, 2,
+                     MakeJunctionForTesting(m2::PointD(10, 0)),
+                     MakeJunctionForTesting(m2::PointD(10, 5))),
+                MakeJunctionForTesting(m2::PointD(10, 2.5)))};
   TestNearestOnMock1(m2::PointD(12.5, 2.5), 2, expected);
 }

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -8,7 +8,7 @@ using namespace routing;
 using namespace routing_test;
 
 void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
-                     vector<pair<Edge, m2::PointD>> const & expected)
+                     vector<pair<Edge, Junction>> const & expected)
 {
   unique_ptr<RoadGraphMockSource> graph(new RoadGraphMockSource());
   InitRoadGraphMockSourceWithTest1(*graph);
@@ -20,7 +20,7 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
     finder.AddInformationSource(featureId, graph->GetRoadInfo(featureId));
   }
 
-  vector<pair<Edge, m2::PointD>> result;
+  vector<pair<Edge, Junction>> result;
   TEST(finder.HasCandidates(), ());
   finder.MakeResult(result, candidatesCount);
 
@@ -29,28 +29,36 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
 
 UNIT_TEST(StarterPosAtBorder_Mock1Graph)
 {
-  vector<pair<Edge, m2::PointD>> const expected =
+  vector<pair<Edge, Junction>> const expected =
   {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0, m2::PointD(0, 0), m2::PointD(5, 0)), m2::PointD(0, 0))
+    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0,
+        MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(5, 0))),
+        MakeJunctionForTesting(m2::PointD(0, 0)))
   };
   TestNearestOnMock1(m2::PointD(0, 0), 1, expected);
 }
 
 UNIT_TEST(MiddleEdgeTest_Mock1Graph)
 {
-  vector<pair<Edge, m2::PointD>> const expected =
+  vector<pair<Edge, Junction>> const expected =
   {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0, m2::PointD(0, 0), m2::PointD(5, 0)), m2::PointD(3, 0))
+    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 0,
+        MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(5, 0))),
+        MakeJunctionForTesting(m2::PointD(3, 0)))
   };
   TestNearestOnMock1(m2::PointD(3, 3), 1, expected);
 }
 
 UNIT_TEST(MiddleSegmentTest_Mock1Graph)
 {
-  vector<pair<Edge, m2::PointD>> const expected =
+  vector<pair<Edge, Junction>> const expected =
   {
-    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 2, m2::PointD(10, 0), m2::PointD(15, 0)), m2::PointD(12.5, 0)),
-    make_pair(Edge(MakeTestFeatureID(1), true /* forward */, 2, m2::PointD(10, 0), m2::PointD(10, 5)), m2::PointD(10, 2.5))
+    make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 2,
+        MakeJunctionForTesting(m2::PointD(10, 0)), MakeJunctionForTesting(m2::PointD(15, 0))),
+        MakeJunctionForTesting(m2::PointD(12.5, 0))),
+    make_pair(Edge(MakeTestFeatureID(1), true /* forward */, 2,
+        MakeJunctionForTesting(m2::PointD(10, 0)), MakeJunctionForTesting(m2::PointD(10, 5))),
+        MakeJunctionForTesting(m2::PointD(10, 2.5)))
   };
   TestNearestOnMock1(m2::PointD(12.5, 2.5), 2, expected);
 }

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -1,5 +1,7 @@
 #include "road_graph_builder.hpp"
 
+#include "routing/road_graph.hpp"
+
 #include "indexer/mwm_set.hpp"
 
 #include "base/macros.hpp"
@@ -62,7 +64,7 @@ namespace routing_test
 
 void RoadGraphMockSource::AddRoad(RoadInfo && ri)
 {
-  CHECK_GREATER_OR_EQUAL(ri.m_points.size(), 2, ("Empty road"));
+  CHECK_GREATER_OR_EQUAL(ri.m_junctions.size(), 2, ("Empty road"));
   m_roads.push_back(move(ri));
 }
 
@@ -91,7 +93,7 @@ void RoadGraphMockSource::ForEachFeatureClosestToCross(m2::PointD const & /* cro
 }
 
 void RoadGraphMockSource::FindClosestEdges(m2::PointD const & point, uint32_t count,
-                                           vector<pair<Edge, m2::PointD>> & vicinities) const
+                                           vector<pair<Edge, Junction>> & vicinities) const
 {
   UNUSED_VALUE(point);
   UNUSED_VALUE(count);
@@ -128,34 +130,34 @@ void InitRoadGraphMockSourceWithTest1(RoadGraphMockSource & src)
   IRoadGraph::RoadInfo ri0;
   ri0.m_bidirectional = true;
   ri0.m_speedKMPH = speedKMPH;
-  ri0.m_points.push_back(m2::PointD(0, 0));
-  ri0.m_points.push_back(m2::PointD(5, 0));
-  ri0.m_points.push_back(m2::PointD(10, 0));
-  ri0.m_points.push_back(m2::PointD(15, 0));
-  ri0.m_points.push_back(m2::PointD(20, 0));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
 
   IRoadGraph::RoadInfo ri1;
   ri1.m_bidirectional = true;
   ri1.m_speedKMPH = speedKMPH;
-  ri1.m_points.push_back(m2::PointD(10, -10));
-  ri1.m_points.push_back(m2::PointD(10, -5));
-  ri1.m_points.push_back(m2::PointD(10, 0));
-  ri1.m_points.push_back(m2::PointD(10, 5));
-  ri1.m_points.push_back(m2::PointD(10, 10));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, -10)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, -5)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 5)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
 
   IRoadGraph::RoadInfo ri2;
   ri2.m_bidirectional = true;
   ri2.m_speedKMPH = speedKMPH;
-  ri2.m_points.push_back(m2::PointD(15, -5));
-  ri2.m_points.push_back(m2::PointD(15, 0));
+  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, -5)));
+  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 0)));
 
   IRoadGraph::RoadInfo ri3;
   ri3.m_bidirectional = true;
   ri3.m_speedKMPH = speedKMPH;
-  ri3.m_points.push_back(m2::PointD(20, 0));
-  ri3.m_points.push_back(m2::PointD(25, 5));
-  ri3.m_points.push_back(m2::PointD(15, 5));
-  ri3.m_points.push_back(m2::PointD(20, 0));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 5)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 5)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
 
   src.AddRoad(move(ri0));
   src.AddRoad(move(ri1));
@@ -170,72 +172,72 @@ void InitRoadGraphMockSourceWithTest2(RoadGraphMockSource & graph)
   IRoadGraph::RoadInfo ri0;
   ri0.m_bidirectional = true;
   ri0.m_speedKMPH = speedKMPH;
-  ri0.m_points.push_back(m2::PointD(0, 0));
-  ri0.m_points.push_back(m2::PointD(10, 0));
-  ri0.m_points.push_back(m2::PointD(25, 0));
-  ri0.m_points.push_back(m2::PointD(35, 0));
-  ri0.m_points.push_back(m2::PointD(70, 0));
-  ri0.m_points.push_back(m2::PointD(80, 0));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(35, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 0)));
+  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 0)));
 
   IRoadGraph::RoadInfo ri1;
   ri1.m_bidirectional = true;
   ri1.m_speedKMPH = speedKMPH;
-  ri1.m_points.push_back(m2::PointD(0, 0));
-  ri1.m_points.push_back(m2::PointD(5, 10));
-  ri1.m_points.push_back(m2::PointD(5, 40));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 10)));
+  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
 
   IRoadGraph::RoadInfo ri2;
   ri2.m_bidirectional = true;
   ri2.m_speedKMPH = speedKMPH;
-  ri2.m_points.push_back(m2::PointD(12, 25));
-  ri2.m_points.push_back(m2::PointD(10, 10));
-  ri2.m_points.push_back(m2::PointD(10, 0));
+  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(12, 25)));
+  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
+  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
 
   IRoadGraph::RoadInfo ri3;
   ri3.m_bidirectional = true;
   ri3.m_speedKMPH = speedKMPH;
-  ri3.m_points.push_back(m2::PointD(5, 10));
-  ri3.m_points.push_back(m2::PointD(10, 10));
-  ri3.m_points.push_back(m2::PointD(70, 10));
-  ri3.m_points.push_back(m2::PointD(80, 10));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 10)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 10)));
+  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 10)));
 
   IRoadGraph::RoadInfo ri4;
   ri4.m_bidirectional = true;
   ri4.m_speedKMPH = speedKMPH;
-  ri4.m_points.push_back(m2::PointD(25, 0));
-  ri4.m_points.push_back(m2::PointD(27, 25));
+  ri4.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 0)));
+  ri4.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(27, 25)));
 
   IRoadGraph::RoadInfo ri5;
   ri5.m_bidirectional = true;
   ri5.m_speedKMPH = speedKMPH;
-  ri5.m_points.push_back(m2::PointD(35, 0));
-  ri5.m_points.push_back(m2::PointD(37, 30));
-  ri5.m_points.push_back(m2::PointD(70, 30));
-  ri5.m_points.push_back(m2::PointD(80, 30));
+  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(35, 0)));
+  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(37, 30)));
+  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 30)));
+  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 30)));
 
   IRoadGraph::RoadInfo ri6;
   ri6.m_bidirectional = true;
   ri6.m_speedKMPH = speedKMPH;
-  ri6.m_points.push_back(m2::PointD(70, 0));
-  ri6.m_points.push_back(m2::PointD(70, 10));
-  ri6.m_points.push_back(m2::PointD(70, 30));
+  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 0)));
+  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 10)));
+  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 30)));
 
   IRoadGraph::RoadInfo ri7;
   ri7.m_bidirectional = true;
   ri7.m_speedKMPH = speedKMPH;
-  ri7.m_points.push_back(m2::PointD(39, 55));
-  ri7.m_points.push_back(m2::PointD(80, 55));
+  ri7.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(39, 55)));
+  ri7.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 55)));
 
   IRoadGraph::RoadInfo ri8;
   ri8.m_bidirectional = true;
   ri8.m_speedKMPH = speedKMPH;
-  ri8.m_points.push_back(m2::PointD(5, 40));
-  ri8.m_points.push_back(m2::PointD(18, 55));
-  ri8.m_points.push_back(m2::PointD(39, 55));
-  ri8.m_points.push_back(m2::PointD(37, 30));
-  ri8.m_points.push_back(m2::PointD(27, 25));
-  ri8.m_points.push_back(m2::PointD(12, 25));
-  ri8.m_points.push_back(m2::PointD(5, 40));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(18, 55)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(39, 55)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(37, 30)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(27, 25)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(12, 25)));
+  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
 
   graph.AddRoad(move(ri0));
   graph.AddRoad(move(ri1));

--- a/routing/routing_tests/road_graph_builder.hpp
+++ b/routing/routing_tests/road_graph_builder.hpp
@@ -19,7 +19,7 @@ public:
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgeLoader) const override;
   void FindClosestEdges(m2::PointD const & point, uint32_t count,
-                        vector<pair<routing::Edge, m2::PointD>> & vicinities) const override;
+                        vector<pair<routing::Edge, routing::Junction>> & vicinities) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(routing::Junction const & junction, feature::TypesHolder & types) const override;
   routing::IRoadGraph::Mode GetMode() const override;

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -30,20 +30,20 @@ UNIT_TEST(RoadGraph_NearestEdges)
   RoadGraphMockSource graph;
   {
     IRoadGraph::RoadInfo ri0;
-    ri0.m_points.emplace_back(-2, 0);
-    ri0.m_points.emplace_back(-1, 0);
-    ri0.m_points.emplace_back(0, 0);
-    ri0.m_points.emplace_back(1, 0);
-    ri0.m_points.emplace_back(2, 0);
+    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(-2, 0)));
+    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(-1, 0)));
+    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
+    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(1, 0)));
+    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(2, 0)));
     ri0.m_speedKMPH = 5;
     ri0.m_bidirectional = true;
 
     IRoadGraph::RoadInfo ri1;
-    ri1.m_points.emplace_back(0, -2);
-    ri1.m_points.emplace_back(0, -1);
-    ri1.m_points.emplace_back(0, 0);
-    ri1.m_points.emplace_back(0, 1);
-    ri1.m_points.emplace_back(0, 2);
+    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, -2)));
+    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, -1)));
+    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
+    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 1)));
+    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 2)));
     ri1.m_speedKMPH = 5;
     ri1.m_bidirectional = true;
 
@@ -52,25 +52,33 @@ UNIT_TEST(RoadGraph_NearestEdges)
   }
 
   // We are standing at x junction.
-  Junction const crossPos(m2::PointD(0, 0));
+  Junction const crossPos = MakeJunctionForTesting(m2::PointD(0, 0));
 
   // Expected outgoing edges.
   IRoadGraph::TEdgeVector expectedOutgoing =
   {
-    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */, m2::PointD(0, 0), m2::PointD(-1, 0)),
-    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */, m2::PointD(0, 0), m2::PointD(1, 0)),
-    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */, m2::PointD(0, 0), m2::PointD(0, -1)),
-    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */, m2::PointD(0, 0), m2::PointD(0, 1)),
+    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(-1, 0))),
+    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(1, 0))),
+    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, -1))),
+    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 1))),
   };
   sort(expectedOutgoing.begin(), expectedOutgoing.end());
 
   // Expected ingoing edges.
   IRoadGraph::TEdgeVector expectedIngoing =
   {
-    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */, m2::PointD(-1, 0), m2::PointD(0, 0)),
-    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */, m2::PointD(1, 0), m2::PointD(0, 0)),
-    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */, m2::PointD(0, -1), m2::PointD(0, 0)),
-    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */, m2::PointD(0, 1), m2::PointD(0, 0)),
+    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
+      MakeJunctionForTesting(m2::PointD(-1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
+    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
+      MakeJunctionForTesting(m2::PointD(1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
+    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, -1)), MakeJunctionForTesting(m2::PointD(0, 0))),
+    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
+      MakeJunctionForTesting(m2::PointD(0, 1)), MakeJunctionForTesting(m2::PointD(0, 0))),
   };
   sort(expectedIngoing.begin(), expectedIngoing.end());
 

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -55,30 +55,28 @@ UNIT_TEST(RoadGraph_NearestEdges)
   Junction const crossPos = MakeJunctionForTesting(m2::PointD(0, 0));
 
   // Expected outgoing edges.
-  IRoadGraph::TEdgeVector expectedOutgoing =
-  {
-    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(-1, 0))),
-    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(1, 0))),
-    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, -1))),
-    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 1))),
+  IRoadGraph::TEdgeVector expectedOutgoing = {
+      Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(-1, 0))),
+      Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(1, 0))),
+      Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, -1))),
+      Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 1))),
   };
   sort(expectedOutgoing.begin(), expectedOutgoing.end());
 
   // Expected ingoing edges.
-  IRoadGraph::TEdgeVector expectedIngoing =
-  {
-    Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
-      MakeJunctionForTesting(m2::PointD(-1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
-    Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
-      MakeJunctionForTesting(m2::PointD(1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
-    Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, -1)), MakeJunctionForTesting(m2::PointD(0, 0))),
-    Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
-      MakeJunctionForTesting(m2::PointD(0, 1)), MakeJunctionForTesting(m2::PointD(0, 0))),
+  IRoadGraph::TEdgeVector expectedIngoing = {
+      Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
+           MakeJunctionForTesting(m2::PointD(-1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
+           MakeJunctionForTesting(m2::PointD(1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, -1)), MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
+           MakeJunctionForTesting(m2::PointD(0, 1)), MakeJunctionForTesting(m2::PointD(0, 0))),
   };
   sort(expectedIngoing.begin(), expectedIngoing.end());
 

--- a/std/algorithm.hpp
+++ b/std/algorithm.hpp
@@ -26,6 +26,7 @@ using std::max_element;
 using std::min;
 using std::min_element;
 using std::next_permutation;
+using std::none_of;
 using std::nth_element;
 using std::partial_sort;
 using std::remove_if;

--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -103,7 +103,7 @@ if [ "$SOURCE_TYPE" == "pbf" -o "$SOURCE_TYPE" == "bz2" -o "$SOURCE_TYPE" == "os
 fi
 if [ "$SOURCE_TYPE" == "o5m" ]; then
   $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --preprocess=true || fail "Preprocessing failed"
-  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME" --srtm_path="./../../maps/srtm/2000.02.11/"
+  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME"
 else
   fail "Unsupported source type: $SOURCE_TYPE"
 fi

--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -103,7 +103,7 @@ if [ "$SOURCE_TYPE" == "pbf" -o "$SOURCE_TYPE" == "bz2" -o "$SOURCE_TYPE" == "os
 fi
 if [ "$SOURCE_TYPE" == "o5m" ]; then
   $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --preprocess=true || fail "Preprocessing failed"
-  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME"
+  $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME" --srtm_path="./../../maps/srtm/2000.02.11/"
 else
   fail "Unsupported source type: $SOURCE_TYPE"
 fi


### PR DESCRIPTION
Добавление секции с высотами точек фичь в mwm.

Данный PR: 
1.  добавляет секцию для хранения высоты в mwm;
В секции:
хедер (16 байт): версия (2 байта), минимальная высота(2 байта), смещения до индексов и данных с высотами(3 смещения * 4 байта);
индекс:
  rs_bit_vector (1 если фича имеет высоту и 0 если нет);
  elia_fano (смещения данными с высотами);
данные с высотами:
  набор WriteVarInt с дельтами;

2. тесты на создание и чтение этой секции;

3. используются данные с высотами при прокладке пешего и вело маршрутов. Считается длина в пространстве вместо длины на плоскости.

@ygorshenin @mpimenov @syershov @Zverik и те кому интересно PTAL