### PR TITLE
[editor] Trim name

### DIFF
--- a/editor/xml_feature.cpp
+++ b/editor/xml_feature.cpp
@@ -105,7 +105,7 @@ bool XMLFeature::operator==(XMLFeature const & other) const
 vector<XMLFeature> XMLFeature::FromOSM(string const & osmXml)
 {
   pugi::xml_document doc;
-  if (doc.load_string(osmXml.c_str()).status != pugi::status_ok)
+  if (doc.load_string(osmXml.data()).status != pugi::status_ok)
     MYTHROW(editor::InvalidXML, ("Not valid XML:", osmXml));
 
   vector<XMLFeature> features;
@@ -349,14 +349,15 @@ string XMLFeature::GetTagValue(string const & key) const
   return tag.attribute("v").value();
 }
 
-void XMLFeature::SetTagValue(string const & key, string const & value)
+void XMLFeature::SetTagValue(string const & key, string value)
 {
+  strings::Trim(value);
   auto tag = FindTag(m_document, key);
   if (!tag)
   {
     tag = GetRootNode().append_child("tag");
-    tag.append_attribute("k").set_value(key.c_str());
-    tag.append_attribute("v").set_value(value.c_str());
+    tag.append_attribute("k").set_value(key.data());
+    tag.append_attribute("v").set_value(value.data());
   }
   else
   {

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -155,7 +155,7 @@ public:
   }
 
   string GetTagValue(string const & key) const;
-  void SetTagValue(string const & key, string const & value);
+  void SetTagValue(string const & key, string value);
 
   string GetAttribute(string const & key) const;
   void SetAttribute(string const & key, string const & value);

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -61,8 +61,9 @@ void EditableMapObject::SetEditableProperties(osm::EditableProperties const & pr
 
 void EditableMapObject::SetName(StringUtf8Multilang const & name) { m_name = name; }
 
-void EditableMapObject::SetName(string const & name, int8_t langCode)
+void EditableMapObject::SetName(string name, int8_t langCode)
 {
+  strings::Trim(name);
   if (!name.empty())
     m_name.AddString(langCode, name);
 }

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -74,7 +74,7 @@ public:
   void SetEditableProperties(osm::EditableProperties const & props);
   //  void SetFeatureID(FeatureID const & fid);
   void SetName(StringUtf8Multilang const & name);
-  void SetName(string const & name, int8_t langCode = StringUtf8Multilang::kDefaultCode);
+  void SetName(string name, int8_t langCode = StringUtf8Multilang::kDefaultCode);
   void SetMercator(m2::PointD const & center);
   void SetType(uint32_t featureType);
   void SetID(FeatureID const & fid);


### PR DESCRIPTION
Фиксим #2902, навеяло [этой жалобой](https://lists.openstreetmap.org/pipermail/talk/2016-June/076231.html). Пользователи жалуются, что люди случайно пробелы в название вводят.

В этом PR не только обрезаются пробелы у значений тегов, но и у названия прямо после ввода его в редакторе. Это наглядно, и у пользователя не висит некрасивость до следующего обновления.

Протестировал на android.