### PR TITLE
[editor] Do not send empty stats requests

### DIFF
--- a/editor/user_stats.cpp
+++ b/editor/user_stats.cpp
@@ -82,6 +82,9 @@ UserStatsLoader::UserStatsLoader()
 
 bool UserStatsLoader::Update(string const & userName)
 {
+  if (userName.empty())
+    return false;
+
   {
     lock_guard<mutex> g(m_mutex);
     m_userName = userName;


### PR DESCRIPTION
Посмотрел логи — а они полны `"GET /user?format=xml&name= HTTP/1.0" 404`. Давайте не будем слать бесполезные запросы на сервер. Лучше бы, конечно, вообще не вызывать статистику для пустого профиля, но для начала поставим защиту на самом низком уровне.