### PR TITLE
[editor] Fix xml tag test

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -34,9 +34,9 @@ bool OsmFeatureHasTags(pugi::xml_node const & osmFt)
   return osmFt.child("tag");
 }
 
-vector<string> const static kMainTags = {"amenity", "shop",      "tourism", "historic",
-                                         "craft",   "emergency", "barrier", "highway",
-                                         "office",  "entrance",  "building"};
+vector<string> const static kMainTags = {"amenity",   "shop",    "tourism", "historic", "craft",
+                                         "emergency", "barrier", "highway", "office",   "leisure",
+                                         "waterway",  "natural", "place",   "entrance", "building"};
 
 string GetTypeForFeature(XMLFeature const & node)
 {
@@ -101,8 +101,7 @@ namespace osm
 {
 ChangesetWrapper::ChangesetWrapper(TKeySecret const & keySecret,
                                    ServerApi06::TKeyValueTags const & comments) noexcept
-    : m_changesetComments(comments),
-      m_api(OsmOAuth::ServerAuth(keySecret))
+  : m_changesetComments(comments), m_api(OsmOAuth::ServerAuth(keySecret))
 {
 }
 
@@ -123,7 +122,8 @@ ChangesetWrapper::~ChangesetWrapper()
   }
 }
 
-void ChangesetWrapper::LoadXmlFromOSM(ms::LatLon const & ll, pugi::xml_document & doc, double radiusInMeters)
+void ChangesetWrapper::LoadXmlFromOSM(ms::LatLon const & ll, pugi::xml_document & doc,
+                                      double radiusInMeters)
 {
   auto const response = m_api.GetXmlFeaturesAtLatLon(ll.lat, ll.lon, radiusInMeters);
   if (response.first != OsmOAuth::HTTP::OK)
@@ -135,7 +135,8 @@ void ChangesetWrapper::LoadXmlFromOSM(ms::LatLon const & ll, pugi::xml_document 
         ("Can't parse OSM server response for GetXmlFeaturesAtLatLon request", response.second));
 }
 
-void ChangesetWrapper::LoadXmlFromOSM(ms::LatLon const & min, ms::LatLon const & max, pugi::xml_document & doc)
+void ChangesetWrapper::LoadXmlFromOSM(ms::LatLon const & min, ms::LatLon const & max,
+                                      pugi::xml_document & doc)
 {
   auto const response = m_api.GetXmlFeaturesInRect(min.lat, min.lon, max.lat, max.lon);
   if (response.first != OsmOAuth::HTTP::OK)

--- a/editor/editor_tests/xml_feature_test.cpp
+++ b/editor/editor_tests/xml_feature_test.cpp
@@ -129,6 +129,32 @@ UNIT_TEST(XMLFeature_ToOSMString)
   TEST_EQUAL(expectedString, feature.ToOSMString(), ());
 }
 
+UNIT_TEST(XMLFeature_HasTags)
+{
+  auto const taggedNode = R"(
+<node lat="55.7978998" lon="37.474528" timestamp="2015-11-27T21:13:32Z">
+  <tag k="name" v="OSM" />
+  <tag k="amenity" v="atm" />
+</node>
+)";
+  XMLFeature taggedFeature(taggedNode);
+  TEST(taggedFeature.HasAnyTags(), ());
+  TEST(taggedFeature.HasTag("amenity"), ());
+  TEST(taggedFeature.HasKey("amenity"), ());
+  TEST(!taggedFeature.HasTag("name:en"), ());
+  TEST(taggedFeature.HasKey("lon"), ());
+  TEST(!taggedFeature.HasTag("lon"), ());
+  TEST_EQUAL(taggedFeature.GetTagValue("name"), "OSM", ());
+  TEST_EQUAL(taggedFeature.GetTagValue("nope"), "", ());
+
+  constexpr char const * emptyWay = R"(
+<way timestamp="2015-11-27T21:13:32Z"/>
+)";
+  XMLFeature emptyFeature(emptyWay);
+  TEST(!emptyFeature.HasAnyTags(), ());
+  TEST(emptyFeature.HasAttribute("timestamp"), ());
+}
+
 UNIT_TEST(XMLFeature_IsArea)
 {
   constexpr char const * validAreaXml = R"(

--- a/editor/xml_feature.cpp
+++ b/editor/xml_feature.cpp
@@ -325,7 +325,7 @@ void XMLFeature::SetUploadError(string const & error)
 
 bool XMLFeature::HasAnyTags() const
 {
-  return m_document.child("tag");
+  return GetRootNode().child("tag");
 }
 
 bool XMLFeature::HasTag(string const & key) const


### PR DESCRIPTION
С помощью Сергея разобрался, почему проверка `.HasAnyTags()` не работала. Написал тесты соответствующих методов и попутно добавил пару тегов в проверку к комментариям ченджсетов.