### PR TITLE
Correct danish for amenity=shelter

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -3166,7 +3166,7 @@ hu:Menedék
 th:ที่อยู่อาศัย
 zh-Hans:2庇护所
 ar:مأوى
-da:Hjem|ly|tilflugtssted
+da:Shelter|læskur|hytte
 tr:Barınak
 sv:Logi
 vi:Chổ nương thân


### PR DESCRIPTION
Danish translation of amenity=shelter was misleading. It was translated to "home" which lead to quite a few amenity=shelter's spuriously located on top of houses and other weird places. This has puzzled me for quite some time now...