### PR TITLE
[search] Fixed slooow locality matching.

### DIFF
--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -193,12 +193,18 @@ Result PreResult2::GenerateFinalResult(storage::CountryInfoGetter const & infoGe
                                        set<uint32_t> const * pTypes, int8_t locale,
                                        ReverseGeocoder const * coder) const
 {
+  ReverseGeocoder::Address addr;
+  bool addrComputed = false;
+
   string name = m_str;
   if (coder && name.empty())
   {
     // Insert exact address (street and house number) instead of empty result name.
-    ReverseGeocoder::Address addr;
-    coder->GetNearbyAddress(GetCenter(), addr);
+    if (!addrComputed)
+    {
+      coder->GetNearbyAddress(GetCenter(), addr);
+      addrComputed = true;
+    }
     if (addr.GetDistance() == 0)
       name = FormatStreetAndHouse(addr);
   }
@@ -212,8 +218,11 @@ Result PreResult2::GenerateFinalResult(storage::CountryInfoGetter const & infoGe
     address = GetRegionName(infoGetter, type);
     if (ftypes::IsAddressObjectChecker::Instance()(m_types))
     {
-      ReverseGeocoder::Address addr;
-      coder->GetNearbyAddress(GetCenter(), addr);
+      if (!addrComputed)
+      {
+        coder->GetNearbyAddress(GetCenter(), addr);
+        addrComputed = true;
+      }
       address = FormatFullAddress(addr, address);
     }
   }

--- a/search/locality_finder.hpp
+++ b/search/locality_finder.hpp
@@ -1,73 +1,58 @@
 #pragma once
 
-#include "indexer/index.hpp"
+#include "indexer/mwm_set.hpp"
+#include "indexer/rank_table.hpp"
 
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 #include "geometry/tree4d.hpp"
 
 #include "std/set.hpp"
-
+#include "std/unique_ptr.hpp"
 
 class Index;
 
 namespace search
 {
-
 struct LocalityItem
 {
+  LocalityItem(string const & name, uint32_t population, uint32_t id);
+
   string m_name;
   uint32_t m_population;
-
-  typedef uint32_t ID;
-  ID m_id;
-
-  LocalityItem(uint32_t population, ID id, string const & name);
-
-  friend string DebugPrint(LocalityItem const & item);
+  uint32_t m_id;
 };
 
 class LocalityFinder
 {
+public:
   struct Cache
   {
-    m4::Tree<LocalityItem> m_tree;
-    set<LocalityItem::ID> m_loaded;
-    size_t m_usage;
-    m2::RectD m_rect;
-
-    Cache() : m_usage(0) {}
-
     void Clear();
     void GetLocality(m2::PointD const & pt, string & name);
+
+    m4::Tree<LocalityItem> m_tree;
+    set<uint32_t> m_loadedIds;
+    size_t m_usage = 0;
+    m2::RectD m_rect;
   };
 
-public:
-  LocalityFinder(Index const * pIndex);
+  LocalityFinder(Index const & index);
 
-  void SetLanguage(int8_t lang)
-  {
-    if (m_lang != lang)
-    {
-      ClearCache();
-      m_lang = lang;
-    }
-  }
-
+  void SetLanguage(int8_t lang);
   void GetLocality(m2::PointD const & pt, string & name);
   void ClearCache();
 
-protected:
-  void UpdateCache(Cache & cache, m2::PointD const & pt) const;
-
 private:
-  friend class DoLoader;
+  void UpdateCache(Cache & cache, m2::PointD const & pt);
 
-  Index const * m_pIndex;
+  Index const & m_index;
+  MwmSet::MwmId m_worldId;
+  unique_ptr<RankTable> m_ranks;
 
   Cache m_caches[10];
-
   int8_t m_lang;
 };
 
-} // namespace search
+string DebugPrint(LocalityItem const & item);
+}  // namespace search

--- a/search/mwm_context.hpp
+++ b/search/mwm_context.hpp
@@ -36,7 +36,7 @@ public:
   inline string const & GetName() const { return GetInfo()->GetCountryName(); }
   inline shared_ptr<MwmInfo> const & GetInfo() const { return GetId().GetInfo(); }
 
-  template <class TFn>
+  template <typename TFn>
   void ForEachIndex(covering::IntervalsT const & intervals, uint32_t scale, TFn && fn) const
   {
     ForEachIndexImpl(intervals, scale, [&](uint32_t index)
@@ -48,7 +48,16 @@ public:
                      });
   }
 
-  template <class TFn>
+  template <typename TFn>
+  void ForEachIndex(m2::RectD const & rect, TFn && fn) const
+  {
+    uint32_t const scale = m_value.GetHeader().GetLastScale();
+    covering::IntervalsT intervals;
+    CoverRect(rect, scale, intervals);
+    ForEachIndex(intervals, scale, forward<TFn>(fn));
+  }
+
+  template <typename TFn>
   void ForEachFeature(m2::RectD const & rect, TFn && fn) const
   {
     uint32_t const scale = m_value.GetHeader().GetLastScale();

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -188,9 +188,7 @@ void Processor::SetPreferredLocale(string const & locale)
   // Default initialization.
   // If you want to reset input language, call SetInputLocale before search.
   SetInputLocale(locale);
-#ifdef FIND_LOCALITY_TEST
   m_ranker.SetLocalityFinderLanguage(code);
-#endif  // FIND_LOCALITY_TEST
 }
 
 void Processor::SetInputLocale(string const & locale)

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -276,9 +276,7 @@ Ranker::Ranker(Index const & index, storage::CountryInfoGetter const & infoGette
                my::Cancellable const & cancellable)
   : m_reverseGeocoder(index)
   , m_cancellable(cancellable)
-#ifdef FIND_LOCALITY_TEST
-  , m_locality(&index)
-#endif  // FIND_LOCALITY_TEST
+  , m_locality(index)
   , m_index(index)
   , m_infoGetter(infoGetter)
   , m_categories(categories)
@@ -332,14 +330,12 @@ Result Ranker::MakeResult(PreResult2 const & r) const
   Result res = r.GenerateFinalResult(m_infoGetter, &m_categories, &m_params.m_preferredTypes,
                                      m_params.m_currentLocaleCode, &m_reverseGeocoder);
   MakeResultHighlight(res);
-#ifdef FIND_LOCALITY_TEST
   if (ftypes::IsLocalityChecker::Instance().GetType(r.GetTypes()) == ftypes::NONE)
   {
     string city;
     m_locality.GetLocality(res.GetFeatureCenter(), city);
     res.AppendCity(city);
   }
-#endif  // FIND_LOCALITY_TEST
 
   res.SetRankingInfo(r.GetRankingInfo());
   return res;
@@ -533,8 +529,6 @@ void Ranker::FlushViewportResults(Geocoder::Params const & geocoderParams)
 
 void Ranker::ClearCaches()
 {
-#ifdef FIND_LOCALITY_TEST
   m_locality.ClearCache();
-#endif  // FIND_LOCALITY_TEST
 }
 }  // namespace search

--- a/search/ranker.hpp
+++ b/search/ranker.hpp
@@ -4,6 +4,7 @@
 #include "search/geocoder.hpp"
 #include "search/intermediate_result.hpp"
 #include "search/keyword_lang_matcher.hpp"
+#include "search/locality_finder.hpp"
 #include "search/mode.hpp"
 #include "search/params.hpp"
 #include "search/result.hpp"
@@ -22,12 +23,6 @@
 #include "std/string.hpp"
 #include "std/utility.hpp"
 #include "std/vector.hpp"
-
-#define FIND_LOCALITY_TEST
-
-#ifdef FIND_LOCALITY_TEST
-#include "search/locality_finder.hpp"
-#endif  // FIND_LOCALITY_TEST
 
 class CategoriesHolder;
 class Index;
@@ -102,9 +97,7 @@ public:
   void SetPreResults1(vector<PreResult1> && preResults1) { m_preResults1 = move(preResults1); }
   void ClearCaches();
 
-#ifdef FIND_LOCALITY_TEST
   inline void SetLocalityFinderLanguage(int8_t code) { m_locality.SetLanguage(code); }
-#endif  // FIND_LOCALITY_TEST
 
   inline void SetLanguage(pair<int, int> const & ind, int8_t lang)
   {
@@ -137,9 +130,7 @@ private:
   my::Cancellable const & m_cancellable;
   KeywordLangMatcher m_keywordsScorer;
 
-#ifdef FIND_LOCALITY_TEST
   mutable LocalityFinder m_locality;
-#endif  // FIND_LOCALITY_TEST
 
   Index const & m_index;
   storage::CountryInfoGetter const & m_infoGetter;

--- a/search/search_tests/locality_finder_test.cpp
+++ b/search/search_tests/locality_finder_test.cpp
@@ -23,7 +23,7 @@ class LocalityFinderTest
   m2::RectD m_worldRect;
 
 public:
-  LocalityFinderTest() : m_finder(&m_index)
+  LocalityFinderTest() : m_finder(m_index)
   {
     classificator::Load();
     m_worldFile = platform::LocalCountryFile::MakeForTesting("World");

--- a/std/algorithm.hpp
+++ b/std/algorithm.hpp
@@ -24,6 +24,7 @@ using std::lower_bound;
 using std::max;
 using std::max_element;
 using std::min;
+using std::min_element;
 using std::next_permutation;
 using std::nth_element;
 using std::partial_sort;


### PR DESCRIPTION
Locality matching code haven't supported a lot of mwms, and iterated
over the whole mwms set on each search result (sic!).  Moreover, for
locality selection it directly read all features in the rect instead of
RankTable usage.

This CL significantly speeds up search results generation stage, when
there're a lot of maps and a lot of search results.