### PR TITLE
[generator] Fix typo in countries_meta.txt

### DIFF
--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -246,7 +246,7 @@
 },
 "Falkland Islands": {
  "driving": "l"
-}
+},
 "Fiji": {
  "driving": "l",
  "languages": ["en", "fj"]


### PR DESCRIPTION
Поспешил — generator tool насмешил.
Забыл проверить `countries_meta.txt` на валидность, пропустил запятую.