### PR TITLE
[FOR RELEASE] pushwoosh update to version 4.6.1. It'll remove unnecessary READ_PHONE_STATE permission.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   // 3-party
   compile 'com.facebook.android:facebook-android-sdk:4.8.0'
   compile 'com.google.code.gson:gson:2.6.1'
-  compile 'com.pushwoosh:pushwoosh:4.3.2'
+  compile 'com.pushwoosh:pushwoosh:4.6.1'
   compile fileTree(dir: '3rd_party', include: '*.jar')
   // BottomSheet
   compile project(":3rd_party:BottomSheet")

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,7 +3,7 @@ propMinSdkVersion=15
 # https://code.google.com/p/android/issues/detail?id=184567
 propTargetSdkVersion=22
 propBuildToolsVersion=22.0.1
-propVersionCode=622
+propVersionCode=625
 propVersionName=6.2.0
 propDebugNdkFlags=V=1 NDK_DEBUG=1 DEBUG=1
 propReleaseNdkFlags=V=1 NDK_DEBUG=0 PRODUCTION=1


### PR DESCRIPTION
У нас в сегодняшнем Andorid релизе появился запрос не нужного пермишен: READ_PHONE_STATE
Обновил pushwoosh, чтоб это вылечить. И поднял propVersionCode.

@yunikkk @trashkalmar PTAL