### PR TITLE
[generator]Loading classificator before altitude generation.

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -139,7 +139,7 @@ int main(int argc, char ** argv)
   if (FLAGS_make_coasts || FLAGS_generate_features || FLAGS_generate_geometry ||
       FLAGS_generate_index || FLAGS_generate_search_index || FLAGS_calc_statistics ||
       FLAGS_type_statistics || FLAGS_dump_types || FLAGS_dump_prefixes ||
-      FLAGS_dump_feature_names != "" || FLAGS_check_mwm)
+      FLAGS_dump_feature_names != "" || FLAGS_check_mwm || FLAGS_srtm_path != "")
   {
     classificator::Load();
     classif().SortClassificator();


### PR DESCRIPTION
Он необходим, поскольку во время генерации секции с рельефом мы вызываем метод routing::IsRoad(feature::TypesHolder(f).

@ygorshenin or @mpimenov PTAL