### PR TITLE
A script for filtering out untranslated strings.

### DIFF
--- a/tools/python/clean_strings_txt.py
+++ b/tools/python/clean_strings_txt.py
@@ -67,7 +67,6 @@ def grep_ios_candidates():
 
     strs = strings_from_grepped(ret, IOS_CANDIDATES_RE)
     return strs
-    # return parenthesize(strings_from_grepped(ret, IOS_CANDIDATES_RE))
 
 
 def android_grep_wrapper(grep, regex):
@@ -236,23 +235,6 @@ def do_candidates(args):
         print(candidate, sources)
 
 
-    # all_candidates = set(grep_ios_candidates())
-    # strings_txt_keys = set(StringsTxt().translations.keys())
-    # candidates_in_txt = all_candidates & strings_txt_keys
-    # properly_used = grep_ios()
-    #
-    # improperly_used_candidates = candidates_in_txt - properly_used
-    #
-    # for s in improperly_used_candidates:
-    #     print(s)
-
-
-    # for a in all_candidates:
-    #     print(a)
-    #
-    # pass
-
-
 def do_ios_suspects(args):
     grep = "grep -re 'L(' ../../iphone/*"
     suspects = exec_shell(grep, "")
@@ -262,21 +244,10 @@ def do_ios_suspects(args):
         print(s)
 
 
-
-
 if __name__ == "__main__":
-
-
-
     logging.basicConfig(level=logging.DEBUG)
     args = get_args()
     args.langs = set(args.langs) if args.langs is not None else None
-
-    # do_ios_suspects(args)
-    do_candidates(args)
-    exit(4)
-
-
 
     if args.missing:
         do_missing(args)

--- a/tools/python/clean_strings_txt.py
+++ b/tools/python/clean_strings_txt.py
@@ -1,0 +1,224 @@
+from __future__ import print_function
+
+import logging
+import re
+import subprocess
+from argparse import ArgumentParser
+from collections import defaultdict
+from itertools import chain
+
+from find_untranslated_strings import StringsTxt
+
+
+MACRO_RE =  re.compile('L\(.*?@\"(.*?)\"\)')
+XML_RE = re.compile("value=\"(.*?)\"")
+ANDROID_JAVA_RE = re.compile("R\.string\.([\w_]*)")
+ANDROID_XML_RE = re.compile("@string/(.*?)\W")
+
+HARDCODED_CATEGORIES = [
+    "food", "hotel", "tourism", "wifi", "transport", "fuel", "parking", "shop",
+    "atm", "bank", "entertainment", "hospital", "pharmacy", "police", "toilet", "post"
+]
+
+HARDCODED_COLOURS = [
+    "red", "yellow", "blue", "green", "purple", "orange", "brown", "pink"
+]
+
+
+def exec_shell(test, flags):
+    spell = ["{0} {1}".format(test, flags)]
+
+    process = subprocess.Popen(
+        spell,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        shell=True
+    )
+
+    logging.info(" ".join(spell))
+    out, _ = process.communicate()
+    return filter(None, out.splitlines())
+
+
+def grep_ios():
+    logging.info("Grepping ios")
+    grep = "grep -r 'L(\|localizedText\|localizedPlaceholder' ../../iphone/*"
+    ret = exec_shell(grep, "")
+    return filter_ios_grep(ret)
+
+
+def grep_android():
+    logging.info("Grepping android")
+    grep = "grep -r 'R.string.' ../../android/src"
+    ret = android_grep_wrapper(grep, ANDROID_JAVA_RE)
+    grep = "grep -r '@string/' ../../android/res"
+    ret.update(android_grep_wrapper(grep, ANDROID_XML_RE))
+    grep = "grep -r '@string/' ../../android/AndroidManifest.xml"
+    ret.update(android_grep_wrapper(grep, ANDROID_XML_RE))
+
+    return parenthesize(ret)
+
+
+def android_grep_wrapper(grep, regex):
+    grepped = exec_shell(grep, "")
+    return strings_from_grepped(grepped, regex)
+
+
+def filter_ios_grep(strings):
+    with_no_blobs = filter(lambda s: not s.startswith("Binary file"), strings)
+    filtered = strings_from_grepped(with_no_blobs, MACRO_RE)
+    filtered = parenthesize(process_ternary_operators(filtered))
+    filtered.update(parenthesize(strings_from_grepped(with_no_blobs, XML_RE)))
+    filtered.update(parenthesize(HARDCODED_CATEGORIES))
+    filtered.update(parenthesize(HARDCODED_COLOURS))
+    return filtered
+
+
+def process_ternary_operators(filtered):
+    return chain(*map(lambda s: s.split('" : @"'), filtered))
+
+
+def strings_from_grepped(grepped, regexp):
+    return set(
+        chain(
+            *filter(
+                None, map(lambda s: regexp.findall(s), grepped)
+            )
+        )
+    )
+
+
+def parenthesize(strings):
+    return set(map(lambda s: "[{0}]".format(s), strings))
+
+
+def write_filtered_strings_txt(filtered, filepath, languages=None):
+    logging.info("Writing strings to file {0}".format(filepath))
+    strings_txt = StringsTxt()
+    strings_dict = {key : dict(strings_txt.translations[key]) for key in filtered}
+    strings_txt.translations = strings_dict
+    strings_txt.comments_and_tags = {}
+    strings_txt.write_formatted(filepath, languages=languages)
+
+
+def get_args():
+    parser = ArgumentParser(
+        description="A script for cleaning up the strings.txt file. It can cleanup the file inplace, that is all the unused strings will be removed from strings.txt, or it can produce two separate files for ios and android. We can also produce the compiled string resources specifically for each platform that do not contain strings for other platforms or comments.")
+
+    parser.add_argument(
+        "-s", "--single-file",
+        dest="single", default=False,
+        action="store_true",
+        help="Create single cleaned up file for both platform. All strings that are not used in the project will be thrown away."
+    )
+
+    parser.add_argument(
+        "-l", "--language",
+        dest="langs", default=None,
+        action="append",
+        help="The languages to be included into the resulting strings.txt file or files. If this param is empty, all languages from the current strings.txt file will be preserved."
+    )
+
+    parser.add_argument(
+        "-g", "--generate-localizations",
+        dest="generate", default=False,
+        action="store_true",
+        help="Generate localizations for the platforms."
+    )
+
+    parser.add_argument(
+        "-o", "--output",
+        dest="output", default="strings.txt",
+        help="The name for the resulting file. It will be saved to the project folder. Only relevant if the -s option is set."
+    )
+
+    parser.add_argument(
+        "-m", "--missing-strings",
+        dest="missing", default=False,
+        action="store_true",
+        help="Find the keys that are used in iOS, but are not translated in strings.txt and exit."
+    )
+
+
+    return parser.parse_args()
+
+
+def do_multiple(args):
+    write_filtered_strings_txt(grep_ios(), "../../ios_strings.txt", args.langs)
+    write_filtered_strings_txt(grep_android(), "../../android_strings.txt", args.langs)
+    if args.generate:
+        exec_shell(
+            "../unix/generate_localizations.sh", "android_strings.txt ios_strings.txt"
+        )
+
+
+def generate_auto_tags(ios, android):
+    new_tags = defaultdict(list)
+    for i in ios:
+        new_tags[i].append("ios")
+
+    for a in android:
+        new_tags[a].append("android")
+
+    for key in new_tags:
+        new_tags[key] = ", ".join(new_tags[key])
+
+    return new_tags
+
+
+def new_comments_and_tags(strings_txt, filtered, new_tags):
+    comments_and_tags = {key: strings_txt.comments_and_tags[key] for key in filtered}
+    for key in comments_and_tags:
+        comments_and_tags[key]["tags"] = new_tags[key]
+    return comments_and_tags
+
+
+def do_single(args):
+    ios = grep_ios()
+    android = grep_android()
+
+    new_tags = generate_auto_tags(ios, android)
+
+    filtered = ios
+    filtered.update(android)
+
+    strings_txt = StringsTxt()
+    strings_txt.translations = {key: dict(strings_txt.translations[key]) for key in filtered}
+
+    strings_txt.comments_and_tags = new_comments_and_tags(strings_txt, filtered, new_tags)
+
+    strings_txt.write_formatted(languages=args.langs, target_file="../../{0}".format(args.output))
+
+    if args.generate:
+        exec_shell(
+            "../unix/generate_localizations.sh", "{0} {0}".format(args.output)
+        )
+
+def do_missing(args):
+    ios = set(grep_ios())
+    strings_txt_keys = set(StringsTxt().translations.keys())
+    missing = ios - strings_txt_keys
+
+    if missing:
+        for m in missing:
+            logging.info(m)
+        exit(1)
+    else:
+        logging.info("Ok. No missing strings.")
+        exit(0)
+
+
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    args = get_args()
+    args.langs = set(args.langs) if args.langs is not None else None
+
+    if args.missing:
+        do_missing(args)
+
+    if not args.single:
+        do_multiple(args)
+        exit(0)
+
+    do_single(args)

--- a/tools/python/clean_strings_txt.py
+++ b/tools/python/clean_strings_txt.py
@@ -14,7 +14,7 @@ MACRO_RE =  re.compile('L\(.*?@\"(.*?)\"\)')
 XML_RE = re.compile("value=\"(.*?)\"")
 ANDROID_JAVA_RE = re.compile("R\.string\.([\w_]*)")
 ANDROID_XML_RE = re.compile("@string/(.*?)\W")
-IOS_CANDIDATES_RE = re.compile("[^L\(]@\"([a-z0-9_]*?)\"")
+IOS_CANDIDATES_RE = re.compile("(.*?):[^L\(]@\"([a-z0-9_]*?)\"")
 
 
 HARDCODED_CATEGORIES = [
@@ -62,9 +62,12 @@ def grep_android():
 
 def grep_ios_candidates():
     logging.info("Grepping ios candidates")
-    grep = "grep -r '@\"' ../../iphone/*"
+    grep = "grep -nr '@\"' ../../iphone/*"
     ret = exec_shell(grep, "")
-    return parenthesize(strings_from_grepped(ret, IOS_CANDIDATES_RE))
+
+    strs = strings_from_grepped(ret, IOS_CANDIDATES_RE)
+    return strs
+    # return parenthesize(strings_from_grepped(ret, IOS_CANDIDATES_RE))
 
 
 def android_grep_wrapper(grep, regex):
@@ -225,15 +228,23 @@ def do_missing(args):
 
 
 def do_candidates(args):
-    all_candidates = set(grep_ios_candidates())
-    strings_txt_keys = set(StringsTxt().translations.keys())
-    candidates_in_txt = all_candidates & strings_txt_keys
-    properly_used = grep_ios()
+    all_candidates = defaultdict(list)
+    for source, candidate in grep_ios_candidates():
+        all_candidates[candidate].append(source)
 
-    improperly_used_candidates = candidates_in_txt - properly_used
+    for candidate, sources in all_candidates.iteritems():
+        print(candidate, sources)
 
-    for s in improperly_used_candidates:
-        print(s)
+
+    # all_candidates = set(grep_ios_candidates())
+    # strings_txt_keys = set(StringsTxt().translations.keys())
+    # candidates_in_txt = all_candidates & strings_txt_keys
+    # properly_used = grep_ios()
+    #
+    # improperly_used_candidates = candidates_in_txt - properly_used
+    #
+    # for s in improperly_used_candidates:
+    #     print(s)
 
 
     # for a in all_candidates:

--- a/tools/python/find_untranslated_strings.py
+++ b/tools/python/find_untranslated_strings.py
@@ -31,6 +31,8 @@ class StringsTxt:
         self.duplicates = {} # dict<lang, TransAndKey>
         self.keys_in_order = []
         self._read_file()
+
+    def process_file(self):
         self._populate_translations_by_langs()
         self._find_duplicates()
         self.most_duplicated = []
@@ -163,29 +165,40 @@ class StringsTxt:
             print("{0}:\n{1}\n".format(lang, "\n".join(missing_keys)))
 
 
-    def write_formatted(self):
+    def write_formatted(self, target_file=None, languages=None):
+        before_block = ""
+        if target_file is None:
+            target_file = self.strings_path
         non_itunes_langs = sorted(list(self.all_langs - set(ITUNES_LANGS)))
-        with open(self.strings_path, "w") as outfile:
+        with open(target_file, "w") as outfile:
             for key in self.keys_in_order:
+                if not key:
+                    continue
                 if key in self.translations:
                     tran = self.translations[key]
                 else:
-                    outfile.write("{0}\n\n".format(key))
+                    if key.startswith("[["):
+                        outfile.write("{0}{1}\n".format(before_block, key))
+                        before_block = "\n"
                     continue
 
-                outfile.write("  {0}\n".format(key))
+                outfile.write("{0}  {1}\n".format(before_block, key))
+                before_block = "\n"
+
                 if key in self.comments_and_tags:
                     for k, v in self.comments_and_tags[key].items():
                         outfile.write("    {0} = {1}\n".format(k, v))
-
-                self._write_translations_for_langs(ITUNES_LANGS, tran, outfile)
-                self._write_translations_for_langs(non_itunes_langs, tran, outfile)
-
-                outfile.write("\n")
+                self._write_translations_for_langs(ITUNES_LANGS, tran, outfile, only_langs=languages)
+                self._write_translations_for_langs(non_itunes_langs, tran, outfile, only_langs=languages)
 
 
-    def _write_translations_for_langs(self, langs, tran, outfile):
-        for lang in langs:
+    def _write_translations_for_langs(self, langs, tran, outfile, only_langs=None):
+        langs_to_write = set(langs)
+
+        if only_langs is not None:
+            langs_to_write = langs_to_write.intersection(set(only_langs))
+
+        for lang in langs_to_write:
             if lang in tran:
                 outfile.write("    {0} = {1}\n".format(lang, tran[lang]))
 
@@ -284,6 +297,7 @@ class StringsTxt:
 
 if __name__ == "__main__":
     strings = StringsTxt()
+    strings.process_file()
     strings.print_statistics()
     strings.print_duplicates()
     strings.print_most_duplicated()

--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -1,13 +1,29 @@
 #!/bin/bash
 set -e -u -x
 
+echo "
+******
+    You can specify the name of string files for android and ios, in which case the resources will be generated for individual platforms. Otherwise the default strings.txt will be used.
+
+    tools/unix/generate_localizations.sh android_strings.txt ios_strings.txt
+
+******"
+
 OMIM_PATH="$(dirname "$0")/../.."
 TWINE="$OMIM_PATH/tools/twine/twine"
 
+ANDROID_SOURCE_FILE=strings.txt
+IOS_SOURCE_FILE=strings.txt
+
+if [ $# == 2 ]; then
+    ANDROID_SOURCE_FILE=$1
+    IOS_SOURCE_FILE=$2
+fi
+
 # TODO: Add "--untagged --tags android" when tags are properly set.
 # TODO: Add validate-strings-file call to check for duplicates (and avoid Android build errors) when tags are properly set.
-$TWINE --format android generate-all-string-files "$OMIM_PATH/strings.txt" "$OMIM_PATH/android/res/"
-$TWINE --format apple generate-all-string-files "$OMIM_PATH/strings.txt" "$OMIM_PATH/iphone/Maps/"
+$TWINE --format android generate-all-string-files "$OMIM_PATH/$ANDROID_SOURCE_FILE" "$OMIM_PATH/android/res/"
+$TWINE --format apple generate-all-string-files "$OMIM_PATH/$IOS_SOURCE_FILE" "$OMIM_PATH/iphone/Maps/"
 $TWINE --format apple --file-name InfoPlist.strings generate-all-string-files "$OMIM_PATH/iphone/plist.txt" "$OMIM_PATH/iphone/Maps/"
 $TWINE --format jquery generate-all-string-files "$OMIM_PATH/data/cuisines.txt" "$OMIM_PATH/data/cuisine-strings/"
 $TWINE --format jquery generate-all-string-files "$OMIM_PATH/data/countries_names.txt" "$OMIM_PATH/data/countries-strings/"


### PR DESCRIPTION
A script for cleaning up strings.txt. It can:
* Remove unused strings from strings.txt (the ones that are not used in either of the projects)
* Write the resulting cleaned up file either to the same file or a different file, or individual files for specific platforms, removing the comments as well.
* Generate localisation resources from the resulting files.

This reduced the size of APK by 1 megabyte.