### PR TITLE
Reducing message priority if a tile of srtm is not found.

### DIFF
--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -158,7 +158,7 @@ feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
     }
     catch (RootException const & e)
     {
-      LOG(LWARNING, ("Can't init SRTM tile:", base, "reason:", e.Msg()));
+      LOG(LINFO, ("Can't init SRTM tile:", base, "reason:", e.Msg()));
     }
 
     // It's OK to store even invalid tiles and return invalid height


### PR DESCRIPTION
Выше 60-й параллели нет данных srtm. Это ожидаемо. Чтоб не загрязнять результирующий лог приоритет сообщения о том, что srtm tile не найден понижен с LWARNING до LINFO.