### PR TITLE
New naming rules for map objects

### DIFF
--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -96,7 +96,7 @@ StringUtf8Multilang const & EditableMapObject::GetName() const { return m_name; 
 
 NamesDataSource EditableMapObject::GetNamesDataSource() const
 {
-  const auto mwmInfo = GetID().m_mwmId.GetInfo();
+  auto const mwmInfo = GetID().m_mwmId.GetInfo();
 
   if (!mwmInfo)
     return NamesDataSource();

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -4,6 +4,8 @@
 
 #include "base/base.hpp"
 
+struct FeatureID;
+class StringUtf8Multilang;
 
 namespace feature
 {
@@ -11,4 +13,8 @@ namespace feature
 
   /// Get viewport scale to show given feature. Used in search.
   int GetFeatureViewportScale(TypesHolder const & types);
+
+  void GetPreferredNames(FeatureID const & id, StringUtf8Multilang const & src, string & primary,
+                         string & secondary);
+  void GetReadableName(FeatureID const & id, StringUtf8Multilang const & src, string & out);
 }  // namespace feature

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -1,8 +1,7 @@
 #include "place_page_info.hpp"
 
+#include "indexer/feature_utils.hpp"
 #include "indexer/osm_editor.hpp"
-
-#include "platform/preferred_languages.hpp"
 
 namespace place_page
 {
@@ -48,16 +47,10 @@ string Info::GetTitle() const
   if (!m_customName.empty())
     return m_customName;
 
-  // Prefer names in native language over default ones.
-  int8_t const langCode = StringUtf8Multilang::GetLangIndex(languages::GetCurrentNorm());
-  if (langCode != StringUtf8Multilang::kUnsupportedLanguageCode)
-  {
-    string native;
-    if (m_name.GetString(langCode, native))
-      return native;
-  }
+  string name;
+  feature::GetReadableName(GetID(), m_name, name);
 
-  return GetDefaultName();
+  return name;
 }
 
 string Info::GetSubtitle() const


### PR DESCRIPTION
Новый приоритет выбора названий объектов
// Names using priority:
+  // - device language name;
+  // - international name;
+  // - english name;
+  // - default name;
+  // - country language name.

Слегка подправлен приоритет выбора имен для важных объектов
+  // Primary name using priority:
+  // - default name;
+  // - country language name.
+  // Secondary name using priority:
+  // - device language name;
+  // - international name;
+  // - english name.

@mpimenov 
@mgsergio 
@Zverik 