### PR TITLE
fix implicit cast compilation for archlinux with clang++-3.8

### DIFF
--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -560,7 +560,7 @@ void PathTextLayout::CalculatePositions(vector<float> & offsets, float splineLen
   }
   else
   {
-    double const textCount = max(floor(pathLength / minPeriodSize), 1.0);
+    double const textCount = max(floor(pathLength / minPeriodSize), 1.0f);
     double const glbTextLen = splineLength / textCount;
     for (double offset = 0.5 * glbTextLen; offset < splineLength; offset += glbTextLen)
       offsets.push_back(offset);


### PR DESCRIPTION
Add explicit cast on number in max function under archlinux with clang++-3.8.
This implicit cast causes this compilation error :
```
/home/fred/mapotempo/code/maps.me/omim/drape_frontend/text_layout.cpp:563:30: error: no matching function for call to 'max'
   double const textCount = max(floor(pathLength / minPeriodSize), 1.0);
                            ^~~
/usr/bin/../include/c++/v1/algorithm:2635:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp'
     ('float' vs. 'double')
max(const _Tp& __a, const _Tp& __b)
```