### PR TITLE
[Release-63] Getting rid of returning zero speed while pedestrian and bicycle routing. Fixing routing along ferry.

### DIFF
--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -607,11 +607,11 @@ void BicycleModel::Init()
   m_noBicycleType = classif().GetTypeByPath({"hwtag", "nobicycle"});
   m_bidirBicycleType = classif().GetTypeByPath({"hwtag", "bidir_bicycle"});
 
-  initializer_list<char const *> arr[] = {
-      hwtagYesBicycle, {"route", "ferry"}, {"man_made", "pier"},
+  vector<AdditionalRoadTags> additionalTags = {
+      { hwtagYesBicycle, m_maxSpeedKMpH }, {{"route", "ferry"}, m_maxSpeedKMpH}, {{"man_made", "pier"}, 7.0 },
   };
 
-  SetAdditionalRoadTypes(classif(), arr, ARRAY_SIZE(arr));
+  SetAdditionalRoadTypes(classif(), additionalTags);
 }
 
 IVehicleModel::RoadAvailability BicycleModel::GetRoadAvailability(feature::TypesHolder const & types) const

--- a/routing/bicycle_model.cpp
+++ b/routing/bicycle_model.cpp
@@ -47,6 +47,7 @@ double constexpr kSpeedStepsKMpH = 1.0;
 double constexpr kSpeedPedestrianKMpH = 5.0;
 double constexpr kSpeedFootwayKMpH = 7.0;
 double constexpr kSpeedPlatformKMpH = 3.0;
+double constexpr kSpeedPierKMpH = 7.0;
 
 // Default
 routing::VehicleModel::InitListT const g_bicycleLimitsDefault =
@@ -607,8 +608,10 @@ void BicycleModel::Init()
   m_noBicycleType = classif().GetTypeByPath({"hwtag", "nobicycle"});
   m_bidirBicycleType = classif().GetTypeByPath({"hwtag", "bidir_bicycle"});
 
-  vector<AdditionalRoadTags> additionalTags = {
-      { hwtagYesBicycle, m_maxSpeedKMpH }, {{"route", "ferry"}, m_maxSpeedKMpH}, {{"man_made", "pier"}, 7.0 },
+  vector<AdditionalRoadTags> const additionalTags = {
+      {hwtagYesBicycle, m_maxSpeedKMpH},
+      {{"route", "ferry"}, m_maxSpeedKMpH},
+      {{"man_made", "pier"}, kSpeedPierKMpH},
   };
 
   SetAdditionalRoadTypes(classif(), additionalTags);

--- a/routing/car_model.cpp
+++ b/routing/car_model.cpp
@@ -8,26 +8,47 @@
 
 namespace
 {
+double constexpr kSpeedMotorwayKMpH = 90.0;
+double constexpr kSpeedMotorwayLinkKMpH = 75.0;
+double constexpr kSpeedTrunkKMpH = 85.0;
+double constexpr kSpeedTrunkLinkKMpH = 70.0;
+double constexpr kSpeedPrimaryKMpH = 65.0;
+double constexpr kSpeedPrimaryLinkKMpH = 60.0;
+double constexpr kSpeedSecondaryKMpH = 55.0;
+double constexpr kSpeedSecondaryLinkKMpH = 50.0;
+double constexpr kSpeedTertiaryKMpH = 40.0;
+double constexpr kSpeedTertiaryLinkKMpH = 30.0;
+double constexpr kSpeedResidentialKMpH = 25.0;
+double constexpr kSpeedPedestrianKMpH = 25.0;
+double constexpr kSpeedUnclassifiedKMpH = 25.0;
+double constexpr kSpeedServiceKMpH = 15.0;
+double constexpr kSpeedLivingStreetKMpH = 10.0;
+double constexpr kSpeedRoadKMpH = 10.0;
+double constexpr kSpeedTrackKMpH = 5.0;
+double constexpr kSpeedFerryMotorcarKMpH = 15.0;
+double constexpr kSpeedFerryMotorcarVehicleKMpH = 15.0;
+double constexpr kSpeedRailMotorcarVehicleKMpH = 25.0;
+double constexpr kSpeedShuttleTrainKMpH = 25.0;
 
 routing::VehicleModel::InitListT const s_carLimits =
 {
-  { {"highway", "motorway"},       90 },
-  { {"highway", "trunk"},          85 },
-  { {"highway", "motorway_link"},  75 },
-  { {"highway", "trunk_link"},     70 },
-  { {"highway", "primary"},        65 },
-  { {"highway", "primary_link"},   60 },
-  { {"highway", "secondary"},      55 },
-  { {"highway", "secondary_link"}, 50 },
-  { {"highway", "tertiary"},       40 },
-  { {"highway", "tertiary_link"},  30 },
-  { {"highway", "residential"},    25 },
-  { {"highway", "pedestrian"},     25 },
-  { {"highway", "unclassified"},   25 },
-  { {"highway", "service"},        15 },
-  { {"highway", "living_street"},  10 },
-  { {"highway", "road"},           10 },
-  { {"highway", "track"},          5  },
+  { {"highway", "motorway"},       kSpeedMotorwayKMpH },
+  { {"highway", "trunk"},          kSpeedTrunkKMpH },
+  { {"highway", "motorway_link"},  kSpeedMotorwayLinkKMpH },
+  { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
+  { {"highway", "primary"},        kSpeedPrimaryKMpH },
+  { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
+  { {"highway", "secondary"},      kSpeedSecondaryKMpH },
+  { {"highway", "secondary_link"}, kSpeedSecondaryLinkKMpH },
+  { {"highway", "tertiary"},       kSpeedTertiaryKMpH },
+  { {"highway", "tertiary_link"},  kSpeedTertiaryLinkKMpH },
+  { {"highway", "residential"},    kSpeedResidentialKMpH },
+  { {"highway", "pedestrian"},     kSpeedPedestrianKMpH },
+  { {"highway", "unclassified"},   kSpeedUnclassifiedKMpH },
+  { {"highway", "service"},        kSpeedServiceKMpH },
+  { {"highway", "living_street"},  kSpeedLivingStreetKMpH },
+  { {"highway", "road"},           kSpeedRoadKMpH },
+  { {"highway", "track"},          kSpeedTrackKMpH  },
   /// @todo: Add to classificator
   //{ {"highway", "shuttle_train"},  10 },
   //{ {"highway", "ferry"},          5  },
@@ -44,12 +65,11 @@ namespace routing
 CarModel::CarModel()
   : VehicleModel(classif(), s_carLimits)
 {
-  vector<AdditionalRoadTags> additionalTags =
-  {
-    {{ "route", "ferry", "motorcar" }, 15.0 },
-    {{ "route", "ferry", "motor_vehicle" }, 15.0 },
-    {{ "railway", "rail", "motor_vehicle" }, 40.0 },
-    {{ "route", "shuttle_train"}, 40.0 },
+  vector<AdditionalRoadTags> const additionalTags = {
+      {{"route", "ferry", "motorcar"}, kSpeedFerryMotorcarKMpH},
+      {{"route", "ferry", "motor_vehicle"}, kSpeedFerryMotorcarVehicleKMpH},
+      {{"railway", "rail", "motor_vehicle"}, kSpeedRailMotorcarVehicleKMpH},
+      {{"route", "shuttle_train"}, kSpeedShuttleTrainKMpH},
   };
 
   SetAdditionalRoadTypes(classif(), additionalTags);

--- a/routing/car_model.cpp
+++ b/routing/car_model.cpp
@@ -4,6 +4,8 @@
 
 #include "indexer/classificator.hpp"
 
+#include "std/vector.hpp"
+
 namespace
 {
 
@@ -42,15 +44,15 @@ namespace routing
 CarModel::CarModel()
   : VehicleModel(classif(), s_carLimits)
 {
-  initializer_list<char const *> arr[] =
+  vector<AdditionalRoadTags> additionalTags =
   {
-    { "route", "ferry", "motorcar" },
-    { "route", "ferry", "motor_vehicle" },
-    { "railway", "rail", "motor_vehicle" },
-    { "route", "shuttle_train"},
+    {{ "route", "ferry", "motorcar" }, 15.0 },
+    {{ "route", "ferry", "motor_vehicle" }, 15.0 },
+    {{ "railway", "rail", "motor_vehicle" }, 40.0 },
+    {{ "route", "shuttle_train"}, 40.0 },
   };
 
-  SetAdditionalRoadTypes(classif(), arr, ARRAY_SIZE(arr));
+  SetAdditionalRoadTypes(classif(), additionalTags);
 }
 
 // static

--- a/routing/car_model.cpp
+++ b/routing/car_model.cpp
@@ -30,31 +30,30 @@ double constexpr kSpeedFerryMotorcarVehicleKMpH = 15.0;
 double constexpr kSpeedRailMotorcarVehicleKMpH = 25.0;
 double constexpr kSpeedShuttleTrainKMpH = 25.0;
 
-routing::VehicleModel::InitListT const s_carLimits =
-{
-  { {"highway", "motorway"},       kSpeedMotorwayKMpH },
-  { {"highway", "trunk"},          kSpeedTrunkKMpH },
-  { {"highway", "motorway_link"},  kSpeedMotorwayLinkKMpH },
-  { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH },
-  { {"highway", "primary"},        kSpeedPrimaryKMpH },
-  { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH },
-  { {"highway", "secondary"},      kSpeedSecondaryKMpH },
-  { {"highway", "secondary_link"}, kSpeedSecondaryLinkKMpH },
-  { {"highway", "tertiary"},       kSpeedTertiaryKMpH },
-  { {"highway", "tertiary_link"},  kSpeedTertiaryLinkKMpH },
-  { {"highway", "residential"},    kSpeedResidentialKMpH },
-  { {"highway", "pedestrian"},     kSpeedPedestrianKMpH },
-  { {"highway", "unclassified"},   kSpeedUnclassifiedKMpH },
-  { {"highway", "service"},        kSpeedServiceKMpH },
-  { {"highway", "living_street"},  kSpeedLivingStreetKMpH },
-  { {"highway", "road"},           kSpeedRoadKMpH },
-  { {"highway", "track"},          kSpeedTrackKMpH  },
-  /// @todo: Add to classificator
-  //{ {"highway", "shuttle_train"},  10 },
-  //{ {"highway", "ferry"},          5  },
-  //{ {"highway", "default"},        10 },
-  /// @todo: Check type
-  //{ {"highway", "construction"},   40 },
+routing::VehicleModel::InitListT const s_carLimits = {
+    {{"highway", "motorway"}, kSpeedMotorwayKMpH},
+    {{"highway", "trunk"}, kSpeedTrunkKMpH},
+    {{"highway", "motorway_link"}, kSpeedMotorwayLinkKMpH},
+    {{"highway", "trunk_link"}, kSpeedTrunkLinkKMpH},
+    {{"highway", "primary"}, kSpeedPrimaryKMpH},
+    {{"highway", "primary_link"}, kSpeedPrimaryLinkKMpH},
+    {{"highway", "secondary"}, kSpeedSecondaryKMpH},
+    {{"highway", "secondary_link"}, kSpeedSecondaryLinkKMpH},
+    {{"highway", "tertiary"}, kSpeedTertiaryKMpH},
+    {{"highway", "tertiary_link"}, kSpeedTertiaryLinkKMpH},
+    {{"highway", "residential"}, kSpeedResidentialKMpH},
+    {{"highway", "pedestrian"}, kSpeedPedestrianKMpH},
+    {{"highway", "unclassified"}, kSpeedUnclassifiedKMpH},
+    {{"highway", "service"}, kSpeedServiceKMpH},
+    {{"highway", "living_street"}, kSpeedLivingStreetKMpH},
+    {{"highway", "road"}, kSpeedRoadKMpH},
+    {{"highway", "track"}, kSpeedTrackKMpH},
+    /// @todo: Add to classificator
+    //{ {"highway", "shuttle_train"},  10 },
+    //{ {"highway", "ferry"},          5  },
+    //{ {"highway", "default"},        10 },
+    /// @todo: Check type
+    //{ {"highway", "construction"},   40 },
 };
 
 }  // namespace

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -626,11 +626,11 @@ void PedestrianModel::Init()
   m_noFootType = classif().GetTypeByPath({ "hwtag", "nofoot" });
   m_yesFootType = classif().GetTypeByPath(hwtagYesFoot);
 
-  initializer_list<char const *> arr[] = {
-      hwtagYesFoot, {"route", "ferry"}, {"man_made", "pier"},
+  vector<AdditionalRoadTags> additionalTags = {
+      { hwtagYesFoot, m_maxSpeedKMpH }, {{"route", "ferry"}, m_maxSpeedKMpH }, {{"man_made", "pier"}, 4.0 },
   };
 
-  SetAdditionalRoadTypes(classif(), arr, ARRAY_SIZE(arr));
+  SetAdditionalRoadTypes(classif(), additionalTags);
 }
 
 IVehicleModel::RoadAvailability PedestrianModel::GetRoadAvailability(feature::TypesHolder const & types) const

--- a/routing/pedestrian_model.cpp
+++ b/routing/pedestrian_model.cpp
@@ -47,6 +47,7 @@ double constexpr kSpeedStepsKMpH = 4.9;
 double constexpr kSpeedPedestrianKMpH = 5.0;
 double constexpr kSpeedFootwayKMpH = 5.0;
 double constexpr kSpeedPlatformKMpH = 5.0;
+double constexpr kSpeedPierKMpH = 4.0;
 
 // Default
 routing::VehicleModel::InitListT const g_pedestrianLimitsDefault =
@@ -626,8 +627,10 @@ void PedestrianModel::Init()
   m_noFootType = classif().GetTypeByPath({ "hwtag", "nofoot" });
   m_yesFootType = classif().GetTypeByPath(hwtagYesFoot);
 
-  vector<AdditionalRoadTags> additionalTags = {
-      { hwtagYesFoot, m_maxSpeedKMpH }, {{"route", "ferry"}, m_maxSpeedKMpH }, {{"man_made", "pier"}, 4.0 },
+  vector<AdditionalRoadTags> const additionalTags = {
+      {hwtagYesFoot, m_maxSpeedKMpH},
+      {{"route", "ferry"}, m_maxSpeedKMpH},
+      {{"man_made", "pier"}, kSpeedPierKMpH},
   };
 
   SetAdditionalRoadTypes(classif(), additionalTags);

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -70,3 +70,10 @@ UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
       integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
 }
+
+UNIT_TEST(RussiaKerchStraitFerryRoute)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
+      MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
+}

--- a/routing/routing_tests/vehicle_model_test.cpp
+++ b/routing/routing_tests/vehicle_model_test.cpp
@@ -74,7 +74,6 @@ UNIT_TEST(VehicleModel_Speed)
   CheckSpeed({GetType("highway", "secondary", "bridge")}, 80.0);
   CheckSpeed({GetType("highway", "secondary", "tunnel")}, 80.0);
   CheckSpeed({GetType("highway", "secondary")}, 80.0);
-  CheckSpeed({GetType("highway")}, 0.0);
 
   CheckSpeed({GetType("highway", "trunk")}, 150.0);
   CheckSpeed({GetType("highway", "primary")}, 120.0);
@@ -90,7 +89,6 @@ UNIT_TEST(VehicleModel_Speed_MultiTypes)
   CheckSpeed({typeTunnel, typeSecondary}, 80.0);
   CheckSpeed({typeTunnel, typeHighway}, 80.0);
   CheckSpeed({typeHighway, typeTunnel}, 80.0);
-  CheckSpeed({typeHighway, typeHighway}, 0.0);
 }
 
 UNIT_TEST(VehicleModel_OneWay)
@@ -103,7 +101,6 @@ UNIT_TEST(VehicleModel_OneWay)
   CheckSpeed({typeOneway, typeBridge}, 80.0);
   CheckOneWay({typeOneway, typeBridge}, true);
 
-  CheckSpeed({typeOneway}, 0.0);
   CheckOneWay({typeOneway}, true);
 }
 

--- a/routing/vehicle_model.cpp
+++ b/routing/vehicle_model.cpp
@@ -7,14 +7,14 @@
 #include "base/macros.hpp"
 
 #include "std/algorithm.hpp"
-#include "std/limits.hpp"
 #include "std/initializer_list.hpp"
+#include "std/limits.hpp"
 
 namespace routing
 {
-
-VehicleModel::AdditionalRoadTypes::AdditionalRoadTypes(Classificator const & c, AdditionalRoadTags const & tag)
-  : m_type(c.GetTypeByPath(tag.m_hwtag)), m_speedKmPerH(tag.m_speedKmPerH)
+VehicleModel::AdditionalRoadType::AdditionalRoadType(Classificator const & c,
+                                                       AdditionalRoadTags const & tag)
+  : m_type(c.GetTypeByPath(tag.m_hwtag)), m_speedKMpH(tag.m_speedKMpH)
 {
 }
 
@@ -35,7 +35,7 @@ void VehicleModel::SetAdditionalRoadTypes(Classificator const & c,
   for (auto const & tag : additionalTags)
   {
     m_addRoadTypes.emplace_back(c, tag);
-    m_maxSpeedKMpH = max(m_maxSpeedKMpH, tag.m_speedKmPerH);
+    m_maxSpeedKMpH = max(m_maxSpeedKMpH, tag.m_speedKMpH);
   }
 }
 
@@ -49,8 +49,7 @@ double VehicleModel::GetSpeed(FeatureType const & f) const
   if (restriction != RoadAvailability::NotAvailable && HasRoadType(types))
     return GetMinTypeSpeed(types);
 
-  LOG(LERROR, ("Wrong routing types:", types));
-  return 0.5 /* Small speed to prevent routing along this edge. */;
+  return 0.0 /* Speed */;
 }
 
 double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
@@ -64,14 +63,13 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
       speed = min(speed, it->second);
 
     auto const addRoadInfoIter = GetRoadTypeIter(type);
-    if (addRoadInfoIter!= m_addRoadTypes.end())
-      speed = min(speed, addRoadInfoIter->m_speedKmPerH);
+    if (addRoadInfoIter != m_addRoadTypes.end())
+      speed = min(speed, addRoadInfoIter->m_speedKMpH);
   }
   if (speed <= m_maxSpeedKMpH)
     return speed;
 
-  LOG(LERROR, ("Wrong routing types:", types));
-  return 0.5 /* Small speed to prevent routing along this edge. */;
+  return 0.0 /* Speed */;
 }
 
 bool VehicleModel::IsOneWay(FeatureType const & f) const
@@ -107,10 +105,11 @@ IVehicleModel::RoadAvailability VehicleModel::GetRoadAvailability(feature::Types
   return RoadAvailability::Unknown;
 }
 
-vector<VehicleModel::AdditionalRoadTypes>::const_iterator VehicleModel::GetRoadTypeIter(uint32_t type) const
+vector<VehicleModel::AdditionalRoadType>::const_iterator VehicleModel::GetRoadTypeIter(
+    uint32_t type) const
 {
   return find_if(m_addRoadTypes.begin(), m_addRoadTypes.end(),
-                 [&type](AdditionalRoadTypes const & t){ return t.m_type == type;});
+                 [&type](AdditionalRoadType const & t) { return t.m_type == type; });
 }
 
 string DebugPrint(IVehicleModel::RoadAvailability const l)

--- a/routing/vehicle_model.cpp
+++ b/routing/vehicle_model.cpp
@@ -62,8 +62,8 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
     if (it != m_types.end())
       speed = min(speed, it->second);
 
-    auto const addRoadInfoIter = GetRoadTypeIter(type);
-    if (addRoadInfoIter != m_addRoadTypes.end())
+    auto const addRoadInfoIter = FindRoadType(type);
+    if (addRoadInfoIter != m_addRoadTypes.cend())
       speed = min(speed, addRoadInfoIter->m_speedKMpH);
   }
   if (speed <= m_maxSpeedKMpH)
@@ -96,7 +96,7 @@ bool VehicleModel::IsRoad(FeatureType const & f) const
 
 bool VehicleModel::IsRoadType(uint32_t type) const
 {
-  return GetRoadTypeIter(type) != m_addRoadTypes.end() ||
+  return FindRoadType(type) != m_addRoadTypes.cend() ||
          m_types.find(ftypes::BaseChecker::PrepareToMatch(type, 2)) != m_types.end();
 }
 
@@ -105,10 +105,10 @@ IVehicleModel::RoadAvailability VehicleModel::GetRoadAvailability(feature::Types
   return RoadAvailability::Unknown;
 }
 
-vector<VehicleModel::AdditionalRoadType>::const_iterator VehicleModel::GetRoadTypeIter(
+vector<VehicleModel::AdditionalRoadType>::const_iterator VehicleModel::FindRoadType(
     uint32_t type) const
 {
-  return find_if(m_addRoadTypes.begin(), m_addRoadTypes.end(),
+  return find_if(m_addRoadTypes.begin(), m_addRoadTypes.cend(),
                  [&type](AdditionalRoadType const & t) { return t.m_type == type; });
 }
 

--- a/routing/vehicle_model.cpp
+++ b/routing/vehicle_model.cpp
@@ -13,7 +13,7 @@
 namespace routing
 {
 VehicleModel::AdditionalRoadType::AdditionalRoadType(Classificator const & c,
-                                                       AdditionalRoadTags const & tag)
+                                                     AdditionalRoadTags const & tag)
   : m_type(c.GetTypeByPath(tag.m_hwtag)), m_speedKMpH(tag.m_speedKMpH)
 {
 }

--- a/routing/vehicle_model.hpp
+++ b/routing/vehicle_model.hpp
@@ -1,9 +1,8 @@
 #pragma once
-#include "base/buffer_vector.hpp"
-
 #include "std/cstdint.hpp"
 #include "std/initializer_list.hpp"
 #include "std/shared_ptr.hpp"
+#include "std/string.hpp"
 #include "std/unordered_map.hpp"
 #include "std/utility.hpp"
 #include "std/vector.hpp"
@@ -90,12 +89,18 @@ public:
   }
 
 protected:
+  struct AdditionalRoadTags
+  {
+    initializer_list<char const *> m_hwtag;
+    double m_speedKmPerH;
+  };
+
   /// @returns a special restriction which is set to the feature.
   virtual RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const;
 
   /// Used in derived class constructors only. Not for public use.
   void SetAdditionalRoadTypes(Classificator const & c,
-                              initializer_list<char const *> const * arr, size_t sz);
+                              vector<AdditionalRoadTags> const & additionalTags);
 
   /// \returns true if |types| is a oneway feature.
   /// \note According to OSM, tag "oneway" could have value "-1". That means it's a oneway feature
@@ -109,9 +114,21 @@ protected:
   double m_maxSpeedKMpH;
 
 private:
+  struct AdditionalRoadTypes
+  {
+    AdditionalRoadTypes(Classificator const & c, AdditionalRoadTags const & tag);
+
+    bool operator==(AdditionalRoadTypes const & rhs) const { return m_type == rhs.m_type; }
+
+    uint32_t const m_type;
+    double const m_speedKmPerH;
+  };
+
+  vector<AdditionalRoadTypes>::const_iterator GetRoadTypeIter(uint32_t type) const;
+
   unordered_map<uint32_t, double> m_types;
 
-  buffer_vector<uint32_t, 4> m_addRoadTypes;
+  vector<AdditionalRoadTypes> m_addRoadTypes;
   uint32_t m_onewayType;
 };
 

--- a/routing/vehicle_model.hpp
+++ b/routing/vehicle_model.hpp
@@ -123,7 +123,7 @@ private:
     double const m_speedKMpH;
   };
 
-  vector<AdditionalRoadType>::const_iterator GetRoadTypeIter(uint32_t type) const;
+  vector<AdditionalRoadType>::const_iterator FindRoadType(uint32_t type) const;
 
   unordered_map<uint32_t, double> m_types;
 

--- a/routing/vehicle_model.hpp
+++ b/routing/vehicle_model.hpp
@@ -92,7 +92,7 @@ protected:
   struct AdditionalRoadTags
   {
     initializer_list<char const *> m_hwtag;
-    double m_speedKmPerH;
+    double m_speedKMpH;
   };
 
   /// @returns a special restriction which is set to the feature.
@@ -114,21 +114,20 @@ protected:
   double m_maxSpeedKMpH;
 
 private:
-  struct AdditionalRoadTypes
+  struct AdditionalRoadType
   {
-    AdditionalRoadTypes(Classificator const & c, AdditionalRoadTags const & tag);
+    AdditionalRoadType(Classificator const & c, AdditionalRoadTags const & tag);
 
-    bool operator==(AdditionalRoadTypes const & rhs) const { return m_type == rhs.m_type; }
-
+    bool operator==(AdditionalRoadType const & rhs) const { return m_type == rhs.m_type; }
     uint32_t const m_type;
-    double const m_speedKmPerH;
+    double const m_speedKMpH;
   };
 
-  vector<AdditionalRoadTypes>::const_iterator GetRoadTypeIter(uint32_t type) const;
+  vector<AdditionalRoadType>::const_iterator GetRoadTypeIter(uint32_t type) const;
 
   unordered_map<uint32_t, double> m_types;
 
-  vector<AdditionalRoadTypes> m_addRoadTypes;
+  vector<AdditionalRoadType> m_addRoadTypes;
   uint32_t m_onewayType;
 };
 


### PR DESCRIPTION
Bugfix. Возвращаем не нулевую скорость для валидных дорог для пешеходного и вело роутинга. 
Данный PR закрывает следующие тикеты:
https://jira.mail.ru/browse/MAPSME-1829
https://jira.mail.ru/browse/MAPSME-1506
https://jira.mail.ru/browse/MAPSME-1620

@ygorshenin @mpimenov @Zverik PTAL
