### PR TITLE
Display unit number only if <= 100 in the navigation maneuver panel.

### DIFF
--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -44,7 +44,10 @@ bool FormatDistanceImpl(double m, string & res,
     res = ToStringPrecision(v, v >= 10.0 ? 0 : 1) + high;
   }
   else
-    res = ToStringPrecision(lowV, 0) + low;
+  {
+    // To display unit number only if <= 100.
+    res = ToStringPrecision(lowV <= 100.0 ? lowV : round(lowV / 10) * 10, 0) + low;
+  }
 
   return true;
 }


### PR DESCRIPTION
The unit numbers is moving too fast between 100 and 1000.
It was useless information, this commit rounded to nearest ten between 100 and 1000 and the units numbers are only display under 100.