### PR TITLE
Recovering location usage on GPS switch on.

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -389,6 +389,5 @@
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
       </intent-filter>
     </receiver>
-
   </application>
 </manifest>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -390,12 +390,5 @@
       </intent-filter>
     </receiver>
 
-    <receiver android:name="com.mapswithme.maps.location.GPSCheck" >
-      <intent-filter>
-        <action android:name="android.location.PROVIDERS_CHANGED" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
-    </receiver>
-
   </application>
 </manifest>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -34,6 +34,7 @@
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
+  <uses-permission android:name="android.permission.ACCESS_GPS"/>
 
   <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
   <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
@@ -389,5 +390,13 @@
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
       </intent-filter>
     </receiver>
+
+    <receiver android:name="com.mapswithme.maps.location.GPSCheck" >
+      <intent-filter>
+        <action android:name="android.location.PROVIDERS_CHANGED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </receiver>
+
   </application>
 </manifest>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -34,7 +34,6 @@
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.ACCESS_GPS"/>
 
   <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
   <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>

--- a/android/src/com/mapswithme/maps/location/GPSCheck.java
+++ b/android/src/com/mapswithme/maps/location/GPSCheck.java
@@ -1,0 +1,21 @@
+package com.mapswithme.maps.location;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.location.LocationManager;
+import android.util.Log;
+
+public class GPSCheck extends BroadcastReceiver
+{
+  @Override
+  public void onReceive(Context context, Intent intent) {
+
+    LocationManager locationManager = (LocationManager) context.getSystemService(context.LOCATION_SERVICE);
+
+    if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER))
+    {
+      LocationHelper.INSTANCE.addLocationListener();
+    }
+  }
+}

--- a/android/src/com/mapswithme/maps/location/GPSCheck.java
+++ b/android/src/com/mapswithme/maps/location/GPSCheck.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.location.LocationManager;
 import android.util.Log;
 
+import com.mapswithme.maps.MwmApplication;
+
 public class GPSCheck extends BroadcastReceiver
 {
   @Override
@@ -13,7 +15,9 @@ public class GPSCheck extends BroadcastReceiver
 
     LocationManager locationManager = (LocationManager) context.getSystemService(context.LOCATION_SERVICE);
 
-    if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER))
+    if ((locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+        || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER))
+        && MwmApplication.get().isFrameworkInitialized() && MwmApplication.backgroundTracker().isForeground())
     {
       LocationHelper.INSTANCE.addLocationListener();
     }

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -252,7 +252,7 @@ public enum LocationHelper
 
     calcParams();
     initProvider(false);
-    MwmApplication.get().backgroundTracker().addListener(mOnTransition);
+    MwmApplication.backgroundTracker().addListener(mOnTransition);
   }
 
   public void initProvider(boolean forceNative)

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -3,7 +3,9 @@ package com.mapswithme.maps.location;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.location.Location;
+import android.location.LocationManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
@@ -26,6 +28,8 @@ import com.mapswithme.util.Utils;
 import com.mapswithme.util.concurrency.UiThread;
 import com.mapswithme.util.log.DebugLogger;
 import com.mapswithme.util.log.Logger;
+
+import static com.mapswithme.maps.background.AppBackgroundTracker.*;
 
 public enum LocationHelper
 {
@@ -58,6 +62,25 @@ public enum LocationHelper
     void onCompassUpdated(@NonNull CompassData compass);
     boolean shouldNotifyLocationNotFound();
   }
+
+  private final GPSCheck mReceiver = new GPSCheck();
+
+  private final OnTransitionListener mOnTransition = new OnTransitionListener()
+  {
+    @Override
+    public void onTransit(boolean foreground)
+    {
+      if (foreground)
+      {
+        final IntentFilter filter = new IntentFilter();
+        filter.addAction(LocationManager.PROVIDERS_CHANGED_ACTION);
+        filter.addCategory(Intent.CATEGORY_DEFAULT);
+        MwmApplication.get().registerReceiver(mReceiver, filter);
+        return;
+      }
+      MwmApplication.get().unregisterReceiver(mReceiver);
+    }
+  };
 
   private final LocationListener mLocationListener = new LocationListener()
   {
@@ -150,7 +173,6 @@ public enum LocationHelper
   private boolean mHighAccuracy;
   private CompassData mCompassData;
 
-
   @SuppressWarnings("FieldCanBeLocal")
   private final LocationState.ModeChangeListener mModeChangeListener = new LocationState.ModeChangeListener()
   {
@@ -230,6 +252,7 @@ public enum LocationHelper
 
     calcParams();
     initProvider(false);
+    MwmApplication.get().backgroundTracker().addListener(mOnTransition);
   }
 
   public void initProvider(boolean forceNative)

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -649,6 +649,11 @@ public enum LocationHelper
       addListener(mLocationListener, true);
   }
 
+  public void addLocationListener()
+  {
+    addListener(mLocationListener, true);
+  }
+
   private void compareWithPreviousCallback()
   {
     if (mPrevUiCallback != null)


### PR DESCRIPTION
Если gps выключен и включается во время работы maps.me, то maps.me его сразу не подхватит, сколько не жди. Надо уводить приложение в backgroud и возвращать в foregroud, чтоб подхватило. 

Данный PR решает эту проблему. Идея проста: добавляем ресивер на включение GPS и если он включается переинициализируем систему.

Данный PR решает проблему, но что в текущей реализации мне не нравится:
- при включении GPS мы добавляем только native gps listener. Просто переиницилизировать (restart) не получается, поскольку ни один listener не добавлен в mListeners на момент вызова onReceive;
- у меня был native crash в Java_com_mapswithme_maps_LocationState_nativeSetListener+68, в момент еще одного вызова addListener(mLocationListener, true); Правдо, я не уверен, что он воспроизводится;

@trashkalmar @yunikkk Прошу покритиковать.

https://jira.mail.ru/browse/MAPSME-2074
https://jira.mail.ru/browse/MAPSME-2160