### PR TITLE
Crashfix. Recursive call of LocationHelper.notifyLocationUpdated().

### DIFF
--- a/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
+++ b/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
@@ -41,7 +41,7 @@ abstract class BaseLocationProvider implements LocationListener
     if (isLocationBetterThanLast(location))
     {
       LocationHelper.INSTANCE.resetMagneticField(location);
-      LocationHelper.INSTANCE.onLocationUpdated(location);
+      LocationHelper.INSTANCE.onLocationUpdated(location, true);
     }
   }
 

--- a/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
+++ b/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
@@ -41,7 +41,8 @@ abstract class BaseLocationProvider implements LocationListener
     if (isLocationBetterThanLast(location))
     {
       LocationHelper.INSTANCE.resetMagneticField(location);
-      LocationHelper.INSTANCE.onLocationUpdated(location, true);
+      LocationHelper.INSTANCE.onLocationUpdated(location);
+      LocationHelper.INSTANCE.notifyLocationUpdated();
     }
   }
 

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -237,12 +237,14 @@ public enum LocationHelper
       startInternal();
   }
 
-  public void onLocationUpdated(@NonNull Location location)
+  public void onLocationUpdated(@NonNull Location location, boolean notify)
   {
     mSavedLocation = location;
     mMyPosition = null;
     mSavedLocationTime = System.currentTimeMillis();
-    notifyLocationUpdated();
+
+    if (notify)
+      notifyLocationUpdated();
   }
 
   /**

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -237,14 +237,11 @@ public enum LocationHelper
       startInternal();
   }
 
-  public void onLocationUpdated(@NonNull Location location, boolean notify)
+  public void onLocationUpdated(@NonNull Location location)
   {
     mSavedLocation = location;
     mMyPosition = null;
     mSavedLocationTime = System.currentTimeMillis();
-
-    if (notify)
-      notifyLocationUpdated();
   }
 
   /**

--- a/android/src/com/mapswithme/maps/location/TrackRecorder.java
+++ b/android/src/com/mapswithme/maps/location/TrackRecorder.java
@@ -45,7 +45,7 @@ public final class TrackRecorder
     {
       log("onLocationUpdated()");
       setAwaitTimeout(LOCATION_TIMEOUT_MIN_MS);
-      LocationHelper.INSTANCE.onLocationUpdated(location, false);
+      LocationHelper.INSTANCE.onLocationUpdated(location);
       TrackRecorderWakeService.stop();
     }
 

--- a/android/src/com/mapswithme/maps/location/TrackRecorder.java
+++ b/android/src/com/mapswithme/maps/location/TrackRecorder.java
@@ -45,7 +45,7 @@ public final class TrackRecorder
     {
       log("onLocationUpdated()");
       setAwaitTimeout(LOCATION_TIMEOUT_MIN_MS);
-      LocationHelper.INSTANCE.onLocationUpdated(location);
+      LocationHelper.INSTANCE.onLocationUpdated(location, false);
       TrackRecorderWakeService.stop();
     }
 


### PR DESCRIPTION
Fix креша:

https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/57a214e3ffcdc04250009918/sessions/57ae512e03cd00011197516153fe0d22

Вот кол стек. Проблемы была в циклическом вызове LocationHelper.notifyLocationUpdated 

com.mapswithme.util.Listeners.iterator (Listeners.java:26)
com.mapswithme.maps.location.LocationHelper.notifyLocationUpdated (LocationHelper.java:296)
com.mapswithme.maps.location.LocationHelper.onLocationUpdated (LocationHelper.java:245)
com.mapswithme.maps.location.TrackRecorder$2.onLocationUpdated (TrackRecorder.java:48)
com.mapswithme.maps.location.LocationHelper.notifyLocationUpdated (LocationHelper.java:297)
com.mapswithme.maps.location.LocationHelper.onLocationUpdated (LocationHelper.java:245)
com.mapswithme.maps.location.BaseLocationProvider.onLocationChanged (BaseLocationProvider.java:44)
com.mapswithme.maps.location.GoogleFusedLocationProvider.requestLocationUpdates (GoogleFusedLocationProvider.java:154)
com.mapswithme.maps.location.GoogleFusedLocationProvider.access$100 (GoogleFusedLocationProvider.java:22)
com.mapswithme.maps.location.GoogleFusedLocationProvider$1.onResult (GoogleFusedLocationProvider.java:124)
com.mapswithme.maps.location.GoogleFusedLocationProvider$1.onResult (GoogleFusedLocationProvider.java:104)

Обязательно @trashkalmar и повозможности @yunikkk PTAL