### PR TITLE
Display addresses parsed from KML file.

### DIFF
--- a/android/jni/com/mapswithme/maps/bookmarks/data/Bookmark.cpp
+++ b/android/jni/com/mapswithme/maps/bookmarks/data/Bookmark.cpp
@@ -3,6 +3,7 @@
 #include "../../../core/jni_helper.hpp"
 
 
+
 namespace
 {
 ::Framework * frm() { return g_framework->NativeFramework(); }
@@ -23,6 +24,13 @@ Java_com_mapswithme_maps_bookmarks_data_Bookmark_nativeGetName(
      JNIEnv * env, jobject thiz, jint cat, jlong bmk)
 {
   return jni::ToJavaString(env, getBookmark(cat, bmk)->GetName());
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_mapswithme_maps_bookmarks_data_Bookmark_nativeGetBookmarkAddress(
+     JNIEnv * env, jobject thiz, jint cat, jlong bmk)
+{
+  return jni::ToJavaString(env, getBookmark(cat, bmk)->GetBookmarkAddress());
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/src/com/mapswithme/maps/bookmarks/data/Bookmark.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/Bookmark.java
@@ -58,7 +58,12 @@ public class Bookmark extends MapObject
   @Override
   public String getAddress()
   {
-    return nativeGetAddress(mCategoryId, mBookmarkId);
+    String res = nativeGetBookmarkAddress(mCategoryId, mBookmarkId);
+    if(res == null || res.isEmpty())
+    {
+      res = nativeGetAddress(mCategoryId, mBookmarkId);
+    }
+    return res;
   }
 
   @Override
@@ -152,6 +157,8 @@ public class Bookmark extends MapObject
   {
     return getGe0Url(addName).replaceFirst(Constants.Url.GE0_PREFIX, Constants.Url.HTTP_GE0_PREFIX);
   }
+
+  private native String nativeGetBookmarkAddress(@IntRange(from = 0) int categoryId, @IntRange(from = 0) long bookmarkId);
 
   private native String nativeGetBookmarkDescription(@IntRange(from = 0) int categoryId, @IntRange(from = 0) long bookmarkId);
 

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -95,6 +95,16 @@ m2::RectD Bookmark::GetViewport() const
   return m2::RectD(GetPivot(), GetPivot());
 }
 
+string const & Bookmark::GetBookmarkAddress() const
+{
+  return m_data.GetAddress();
+}
+
+void Bookmark::SetBookmarkAddress(string const & address)
+{
+  m_data.SetAddress(address);
+}
+
 string const & Bookmark::GetDescription() const
 {
   return m_data.GetDescription();
@@ -231,6 +241,7 @@ namespace
     string m_type;
     string m_description;
     time_t m_timeStamp;
+    string m_address;
 
     m2::PointD m_org;
     double m_scale;
@@ -243,6 +254,7 @@ namespace
       m_type.clear();
       m_scale = -1.0;
       m_timeStamp = my::INVALID_TIME_STAMP;
+      m_address.clear();
 
       m_trackColor = kDefaultTrackColor;
       m_styleId.clear();
@@ -404,7 +416,7 @@ namespace
           if (GEOMETRY_TYPE_POINT == m_geometryType)
           {
             Bookmark * bm = static_cast<Bookmark *>(m_controller.CreateUserMark(m_org));
-            bm->SetData(BookmarkData(m_name, m_type, m_description, m_scale, m_timeStamp));
+            bm->SetData(BookmarkData(m_name, m_type, m_address, m_description, m_scale, m_timeStamp));
             bm->RunCreationAnim();
           }
           else if (GEOMETRY_TYPE_LINE == m_geometryType)
@@ -472,6 +484,8 @@ namespace
           }
           else if (currTag == "description")
             m_description = value;
+          else if (currTag == "address")
+            m_address = value;
         }
         else if (prevTag == "LineStyle" && currTag == "color")
         {
@@ -707,6 +721,13 @@ void BookmarkCategory::SaveToKML(ostream & s)
     s << "    <name>";
     SaveStringWithCDATA(s, bm->GetName());
     s << "</name>\n";
+
+    if (!bm->GetBookmarkAddress().empty())
+    {
+      s << "    <address>";
+      SaveStringWithCDATA(s, bm->GetBookmarkAddress());
+      s << "</address>\n";
+    }
 
     if (!bm->GetDescription().empty())
     {

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -31,7 +31,7 @@ public:
   {
   }
 
-  BookmarkData(string const & name, string const & type,
+  BookmarkData(string const & name, string const & type, string const & address = "",
                      string const & description = "", double scale = -1.0,
                      time_t timeStamp = my::INVALID_TIME_STAMP)
     : m_name(name)
@@ -39,11 +39,15 @@ public:
     , m_type(type)
     , m_scale(scale)
     , m_timeStamp(timeStamp)
+    , m_address(address)
   {
   }
 
   string const & GetName() const { return m_name; }
   void SetName(const string & name) { m_name = name; }
+
+  string const & GetAddress() const { return m_address;}
+  void SetAddress(const string & address) { m_address = address;}
 
   string const & GetDescription() const { return m_description; }
   void SetDescription(const string & description) { m_description = description; }
@@ -63,6 +67,7 @@ private:
   string m_type;  ///< Now it stores bookmark color (category style).
   double m_scale; ///< Viewport scale. -1.0 - is a default value (no scale set).
   time_t m_timeStamp;
+  string m_address;
 };
 
 class Bookmark : public UserMark
@@ -89,6 +94,9 @@ public:
   string const & GetType() const;
   void SetType(string const & type);
   m2::RectD GetViewport() const;
+
+  string const & GetBookmarkAddress() const;
+  void SetBookmarkAddress(string const & address);
 
   string const & GetDescription() const;
   void SetDescription(string const & description);


### PR DESCRIPTION
Adding JNI implementation to access at bookmark address rather than OSM address.
Changing the  behavior of the "override" method "getAddress" in the class "Bookmark".
When bookmark address is defined, it is displayed in priority otherwise the OSM address's is displayed (old behavior).
