### PR TITLE
Fix Japanese and Chinese translations of book button

### DIFF
--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -858,7 +858,7 @@
 	<string name="minute">分</string>
 	<string name="placepage_place_description">説明</string>
 	<string name="placepage_more_button">さらに詳しく</string>
-	<string name="bookingcom_book_button">書籍</string>
+	<string name="bookingcom_book_button">予約</string>
 	<string name="placepage_call_button">コール</string>
 	<string name="placepage_edit_bookmark_button">ブックマークを編集</string>
 	<string name="placepage_bookmark_name_hint">ブックマーク名</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -879,7 +879,7 @@
 	<string name="minute">分鐘</string>
 	<string name="placepage_place_description">說明</string>
 	<string name="placepage_more_button">更多</string>
-	<string name="bookingcom_book_button">圖書</string>
+	<string name="bookingcom_book_button">預約</string>
 	<string name="placepage_call_button">呼叫</string>
 	<string name="placepage_edit_bookmark_button">編輯書籤</string>
 	<string name="placepage_bookmark_name_hint">書籤名稱</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -865,7 +865,7 @@
 	<string name="minute">分鐘</string>
 	<string name="placepage_place_description">说明</string>
 	<string name="placepage_more_button">更多</string>
-	<string name="bookingcom_book_button">图书</string>
+	<string name="bookingcom_book_button">预約</string>
 	<string name="placepage_call_button">呼叫</string>
 	<string name="placepage_edit_bookmark_button">编辑书签</string>
 	<string name="placepage_bookmark_name_hint">书签名称</string>

--- a/iphone/Maps/ja.lproj/Localizable.strings
+++ b/iphone/Maps/ja.lproj/Localizable.strings
@@ -1496,7 +1496,7 @@
 
 "placepage_more_button" = "さらに詳しく";
 
-"bookingcom_book_button" = "書籍";
+"bookingcom_book_button" = "予約";
 
 "placepage_call_button" = "コール";
 

--- a/iphone/Maps/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/zh-Hans.lproj/Localizable.strings
@@ -1496,7 +1496,7 @@
 
 "placepage_more_button" = "更多";
 
-"bookingcom_book_button" = "图书";
+"bookingcom_book_button" = "预約";
 
 "placepage_call_button" = "呼叫";
 

--- a/iphone/Maps/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/zh-Hant.lproj/Localizable.strings
@@ -1496,7 +1496,7 @@
 
 "placepage_more_button" = "更多";
 
-"bookingcom_book_button" = "圖書";
+"bookingcom_book_button" = "預約";
 
 "placepage_call_button" = "呼叫";
 

--- a/strings.txt
+++ b/strings.txt
@@ -17935,7 +17935,7 @@
     hu = Foglalás
     id = Pesan
     it = Prenota
-    ja = 書籍
+    ja = 予約
     ko = 예약
     nb = Bestill
     pl = Zarezerwuj
@@ -17947,8 +17947,8 @@
     tr = Rezervasyon
     uk = Забронювати
     vi = Đặt trước
-    zh-Hans = 图书
-    zh-Hant = 圖書
+    zh-Hans = 预約
+    zh-Hant = 預約
     sk = Rezervovať
 
   [placepage_call_button]


### PR DESCRIPTION
Hi,

The Japanese and Chinese translations of the "book" button for booking.com are incorrect.

The original translations are nouns (📕) , not verbs.

I have fixed them in this pull request.

Please take a look. Thanks! 😄 

p.s. I have already signed the CLA.
