### PR TITLE
[types] Do not display wheelchair types in the PP

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -88,6 +88,7 @@ public:
       { "hwtag" },
       { "psurface" },
       { "internet_access" },
+      { "wheelchair" },
     };
 
     AddTypes(arr1);
@@ -99,6 +100,7 @@ public:
       { "amenity", "bench" },
       { "amenity", "shelter" },
       { "building", "address" },
+      { "building", "has_parts" },
       { "sponsored", "booking" },
     };
 


### PR DESCRIPTION
У нас сейчас на половине заведений в Европе выводится тип `wheelchair-no` или `-yes`. Мой косяк, забыл про список неважных типов. Здесь это правлю.