### PR TITLE
[bookmarks] Words → Sentences capitalization

### DIFF
--- a/android/res/layout/edit_bookmark_common.xml
+++ b/android/res/layout/edit_bookmark_common.xml
@@ -22,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/name"
-        android:inputType="textCapWords"
+        android:inputType="textCapSentences"
         android:singleLine="true"/>
 
     </com.mapswithme.maps.widget.CustomTextInputLayout>

--- a/iphone/Maps/Bookmarks/BookmarksRootVC.mm
+++ b/iphone/Maps/Bookmarks/BookmarksRootVC.mm
@@ -214,7 +214,7 @@
     f.font = [cell.textLabel.font fontWithSize:[cell.textLabel.font pointSize]];
     f.tag = TEXTFIELD_TAG;
     f.delegate = self;
-    f.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    f.autocapitalizationType = UITextAutocapitalizationTypeSentences;
     cell.textLabel.hidden = YES;
     cell.detailTextLabel.hidden = YES;
     cell.accessoryType = UITableViewCellAccessoryNone;


### PR DESCRIPTION
В рамках федеральной программы «Хватит это терпеть!» заменил пословную капитализацию закладок на попредложенческую. То есть, с заглавной буквы теперь будет только Первое слово в названии, а не Все Слова В Закладке Блин.

(Протестировал на андроиде, айфона нет)