### PR TITLE
[editor] Capitalize names

### DIFF
--- a/android/res/layout/item_localized_name.xml
+++ b/android/res/layout/item_localized_name.xml
@@ -17,6 +17,7 @@
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       android:hint="@string/editor_edit_place_name_hint"
+      android:inputType="textCapSentences"
       android:singleLine="true"/>
 
   </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
При создании нового объекта заставляем вводить его название с заглавной буквы, а не со строчной. В iOS умолчание уже такое, а вот в андроиде было со строчной, приходилось каждый раз шифт нажимать.

Проверил на устройстве.