### PR TITLE
Add padding on the bounding box when focus on a track.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -815,8 +815,13 @@ void Framework::ShowBookmark(BookmarkAndCategory const & bnc)
 
 void Framework::ShowTrack(Track const & track)
 {
+  double const kPaddingScale = 1.2;
+
   StopLocationFollow();
-  ShowRect(track.GetLimitRect());
+  auto rect = track.GetLimitRect();
+  rect.Scale(kPaddingScale);
+
+  ShowRect(rect);
 }
 
 void Framework::ClearBookmarks()


### PR DESCRIPTION
Add padding on the bounding box generated when "ShowTrack" framework function is called.
![device-2016-08-31-1](https://cloud.githubusercontent.com/assets/16467651/18125656/b1702562-6f77-11e6-883a-ab48d9772d5f.png)
![device-2016-08-31-2](https://cloud.githubusercontent.com/assets/16467651/18125660/b3c4755c-6f77-11e6-8ff5-0294c47d02e8.png)

