### PR TITLE
Added tile-based model-view

### DIFF
--- a/drape/batcher.cpp
+++ b/drape/batcher.cpp
@@ -262,7 +262,7 @@ Batcher * BatcherFactory::GetNew() const
   return new Batcher(kIndexBufferSize, kVertexBufferSize);
 }
 
-SessionGuard::SessionGuard(Batcher & batcher, const Batcher::TFlushFn & flusher)
+SessionGuard::SessionGuard(Batcher & batcher, Batcher::TFlushFn const & flusher)
   : m_batcher(batcher)
 {
   m_batcher.StartSession(flusher);

--- a/drape/glsl_types.hpp
+++ b/drape/glsl_types.hpp
@@ -56,6 +56,11 @@ inline vec2 ToVec2(m2::PointD const & pt)
   return glsl::vec2(pt.x, pt.y);
 }
 
+inline m2::PointD FromVec2(glsl::vec2 const & pt)
+{
+  return m2::PointD(pt.x, pt.y);
+}
+
 inline vec4 ToVec4(dp::Color const & color)
 {
   return glsl::vec4(double(color.GetRed()) / 255,

--- a/drape/shaders/arrow3d_shadow_vertex_shader.vsh
+++ b/drape/shaders/arrow3d_shadow_vertex_shader.vsh
@@ -1,12 +1,12 @@
 attribute vec4 a_pos;
 
-uniform mat4 m_transform;
+uniform mat4 u_transform;
 
 varying float v_intensity;
 
 void main()
 {
-  vec4 position = m_transform * vec4(a_pos.x, a_pos.y, 0.0, 1.0);
+  vec4 position = u_transform * vec4(a_pos.x, a_pos.y, 0.0, 1.0);
   v_intensity = a_pos.w;
   gl_Position = position;
 }

--- a/drape/shaders/arrow3d_vertex_shader.vsh
+++ b/drape/shaders/arrow3d_vertex_shader.vsh
@@ -1,7 +1,7 @@
 attribute vec4 a_pos;
 attribute vec3 a_normal;
 
-uniform mat4 m_transform;
+uniform mat4 u_transform;
 
 varying vec2 v_intensity;
 
@@ -9,7 +9,7 @@ const vec3 lightDir = vec3(0.316, 0.0, 0.948);
 
 void main()
 {
-  vec4 position = m_transform * vec4(a_pos.xyz, 1.0);
+  vec4 position = u_transform * vec4(a_pos.xyz, 1.0);
   v_intensity = vec2(max(0.0, -dot(lightDir, a_normal)), a_pos.w);
   gl_Position = position;
 }

--- a/drape/shaders/circle_shader.vsh
+++ b/drape/shaders/circle_shader.vsh
@@ -16,8 +16,8 @@ varying vec2 v_colorTexCoords;
 
 void main(void)
 {
-  lowp vec4 p = vec4(a_position, 1) * modelView;
-  highp vec4 pos = vec4(a_normal.xy, 0, 0) + p;
+  vec4 p = vec4(a_position, 1) * modelView;
+  vec4 pos = vec4(a_normal.xy, 0, 0) + p;
   pos = pos * projection;
 
   float w = pos.w;

--- a/drape/shaders/dashed_vertex_shader.vsh
+++ b/drape/shaders/dashed_vertex_shader.vsh
@@ -11,6 +11,8 @@ varying vec2 v_colorTexCoord;
 varying vec2 v_maskTexCoord;
 varying vec2 v_halfLength;
 
+const float kShapeCoordScalar = 1000.0;
+
 void main(void)
 {
   vec2 normal = a_normal.xy;
@@ -23,7 +25,7 @@ void main(void)
     transformedAxisPos = transformedAxisPos + normalize(shiftPos - transformedAxisPos) * halfWidth;
   }
 
-  float uOffset = min(length(vec4(1, 0, 0, 0) * modelView) * a_maskTexCoord.x, 1.0);
+  float uOffset = min(length(vec4(kShapeCoordScalar, 0, 0, 0) * modelView) * a_maskTexCoord.x, 1.0);
   v_colorTexCoord = a_colorTexCoord;
   v_maskTexCoord = vec2(a_maskTexCoord.y + uOffset * a_maskTexCoord.z, a_maskTexCoord.w);
   v_halfLength = vec2(sign(a_normal.z) * halfWidth, abs(a_normal.z));

--- a/drape/shaders/masked_texturing_vertex_shader.vsh
+++ b/drape/shaders/masked_texturing_vertex_shader.vsh
@@ -12,10 +12,8 @@ varying vec2 v_maskTexCoords;
 
 void main(void)
 {
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = vec4(a_position.xyz, 1) * modelView;
-  highp vec4 shiftedPos = vec4(a_normal, 0, 0) + pos;
+  vec4 pos = vec4(a_position.xyz, 1) * modelView;
+  vec4 shiftedPos = vec4(a_normal, 0, 0) + pos;
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;
   shiftedPos.xyw = (pivotTransform * vec4(shiftedPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/my_position_shader.vsh
+++ b/drape/shaders/my_position_shader.vsh
@@ -21,9 +21,9 @@ void main(void)
   rotation[2] = vec4(0.0, 0.0, 1.0, 0.0);
   rotation[3] = vec4(0.0, 0.0, 0.0, 1.0);
 
-  lowp vec4 pos = vec4(u_position, 1.0) * modelView;
-  highp vec4 normal = vec4(a_normal, 0, 0);
-  highp vec4 shiftedPos = normal * rotation + pos;
+  vec4 pos = vec4(u_position, 1.0) * modelView;
+  vec4 normal = vec4(a_normal, 0, 0);
+  vec4 shiftedPos = normal * rotation + pos;
 
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;

--- a/drape/shaders/path_symbol_vertex_shader.vsh
+++ b/drape/shaders/path_symbol_vertex_shader.vsh
@@ -10,9 +10,9 @@ varying vec2 v_colorTexCoords;
 
 void main(void)
 {
-  lowp vec4 pos = vec4(a_position.xyz, 1) * modelView;
-  highp vec4 norm = vec4(a_normal, 0, 0) * modelView;
-  highp vec4 shiftedPos = norm + pos;
+  vec4 pos = vec4(a_position.xyz, 1) * modelView;
+  vec4 norm = vec4(a_normal, 0, 0) * modelView;
+  vec4 shiftedPos = norm + pos;
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;
   shiftedPos.xyw = (pivotTransform * vec4(shiftedPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/text_outlined_gui_vertex_shader.vsh
+++ b/drape/shaders/text_outlined_gui_vertex_shader.vsh
@@ -27,10 +27,8 @@ void main()
   float notOutline = One - isOutline;
   float depthShift = BaseDepthShift * isOutline;
   
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = (vec4(a_position.xyz, 1.0) + vec4(Zero, Zero, depthShift, Zero)) * modelView;
-  highp vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
+  vec4 pos = (vec4(a_position.xyz, 1.0) + vec4(Zero, Zero, depthShift, Zero)) * modelView;
+  vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
   gl_Position = shiftedPos * projection;
   vec2 colorTexCoord = a_colorTexCoord * notOutline + a_outlineColorTexCoord * isOutline;
 #ifdef ENABLE_VTF

--- a/drape/shaders/text_outlined_vertex_shader.vsh
+++ b/drape/shaders/text_outlined_vertex_shader.vsh
@@ -28,10 +28,8 @@ void main()
   float notOutline = One - isOutline;
   float depthShift = BaseDepthShift * isOutline;
 
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = (vec4(a_position.xyz, 1) + vec4(Zero, Zero, depthShift, Zero)) * modelView;
-  highp vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
+  vec4 pos = (vec4(a_position.xyz, 1) + vec4(Zero, Zero, depthShift, Zero)) * modelView;
+  vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;
   shiftedPos.xyw = (pivotTransform * vec4(shiftedPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/text_vertex_shader.vsh
+++ b/drape/shaders/text_vertex_shader.vsh
@@ -22,10 +22,8 @@ const float One = 1.0;
 
 void main()
 {
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = vec4(a_position.xyz, 1) * modelView;
-  highp vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
+  vec4 pos = vec4(a_position.xyz, 1) * modelView;
+  vec4 shiftedPos = vec4(a_normal, Zero, Zero) + pos;
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;
   shiftedPos.xyw = (pivotTransform * vec4(shiftedPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/texturing_vertex_shader.vsh
+++ b/drape/shaders/texturing_vertex_shader.vsh
@@ -10,10 +10,8 @@ varying vec2 v_colorTexCoords;
 
 void main(void)
 {
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = vec4(a_position.xyz, 1) * modelView;
-  highp vec4 shiftedPos = vec4(a_normal, 0, 0) + pos;
+  vec4 pos = vec4(a_position.xyz, 1) * modelView;
+  vec4 shiftedPos = vec4(a_normal, 0, 0) + pos;
   shiftedPos = shiftedPos * projection;
   float w = shiftedPos.w;
   shiftedPos.xyw = (pivotTransform * vec4(shiftedPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/trackpoint_vertex_shader.vsh
+++ b/drape/shaders/trackpoint_vertex_shader.vsh
@@ -17,11 +17,8 @@ varying vec4 v_color;
 void main(void)
 {
   vec3 radius = a_normal * a_position.z;
-
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 pos = vec4(a_position.xy, 0, 1) * modelView;
-  highp vec4 shiftedPos = vec4(radius.xy, 0, 0) + pos;
+  vec4 pos = vec4(a_position.xy, 0, 1) * modelView;
+  vec4 shiftedPos = vec4(radius.xy, 0, 0) + pos;
   vec4 finalPos = shiftedPos * projection;
   float w = finalPos.w;
   finalPos.xyw = (pivotTransform * vec4(finalPos.xy, 0.0, w)).xyw;

--- a/drape/shaders/user_mark.vsh
+++ b/drape/shaders/user_mark.vsh
@@ -16,10 +16,8 @@ void main(void)
   if (a_animate > 0.0)
     normal = u_interpolationT * normal;
 
-  // Here we intentionally decrease precision of 'pos' calculation
-  // to eliminate jittering effect in process of billboard reconstruction.
-  lowp vec4 p = vec4(a_position, 1) * modelView;
-  highp vec4 pos = vec4(normal, 0, 0) + p;
+  vec4 p = vec4(a_position, 1) * modelView;
+  vec4 pos = vec4(normal, 0, 0) + p;
   pos = pos * projection;
   float w = pos.w;
   pos.xyw = (pivotTransform * vec4(pos.xy, 0.0, w)).xyw;

--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -424,13 +424,13 @@ void ApplyPointFeature::Finish()
 
 ApplyAreaFeature::ApplyAreaFeature(m2::PointD const & tileCenter,
                                    TInsertShapeFn const & insertShape, FeatureID const & id,
-                                   m2::RectD tileRect, float minPosZ,
+                                   m2::RectD const & clipRect, float minPosZ,
                                    float posZ, int minVisibleScale, uint8_t rank,
                                    CaptionDescription const & captions)
   : TBase(tileCenter, insertShape, id, minVisibleScale, rank, captions, posZ)
   , m_minPosZ(minPosZ)
   , m_isBuilding(posZ > 0.0f)
-  , m_tileRect(tileRect)
+  , m_clipRect(clipRect)
 {}
 
 void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3)
@@ -459,9 +459,9 @@ void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, 
   };
 
   if (m2::CrossProduct(p2 - p1, p3 - p1) < 0)
-    m2::ClipTriangleByRect(m_tileRect, p1, p2, p3, clipFunctor);
+    m2::ClipTriangleByRect(m_clipRect, p1, p2, p3, clipFunctor);
   else
-    m2::ClipTriangleByRect(m_tileRect, p1, p3, p2, clipFunctor);
+    m2::ClipTriangleByRect(m_clipRect, p1, p3, p2, clipFunctor);
 }
 
 void ApplyAreaFeature::ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD const & p2,

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -99,7 +99,7 @@ class ApplyAreaFeature : public ApplyPointFeature
 public:
   ApplyAreaFeature(m2::PointD const & tileCenter,
                    TInsertShapeFn const & insertShape, FeatureID const & id,
-                   m2::RectD tileRect, float minPosZ,
+                   m2::RectD const & clipRect, float minPosZ,
                    float posZ, int minVisibleScale, uint8_t rank,
                    CaptionDescription const & captions);
 
@@ -125,7 +125,7 @@ private:
   vector<pair<TEdge, int>> m_edges;
   float const m_minPosZ;
   bool const m_isBuilding;
-  m2::RectD m_tileRect;
+  m2::RectD m_clipRect;
 };
 
 class ApplyLineFeature : public BaseApplyFeature

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -31,7 +31,8 @@ using TInsertShapeFn = function<void(drape_ptr<MapShape> && shape)>;
 class BaseApplyFeature
 {
 public:
-  BaseApplyFeature(TInsertShapeFn const & insertShape, FeatureID const & id,
+  BaseApplyFeature(m2::PointD const & tileCenter,
+                   TInsertShapeFn const & insertShape, FeatureID const & id,
                    int minVisibleScale, uint8_t rank, CaptionDescription const & captions);
 
   virtual ~BaseApplyFeature() {}
@@ -58,6 +59,8 @@ protected:
   int m_minVisibleScale;
   uint8_t m_rank;
   HotelData m_hotelData;
+
+  m2::PointD m_tileCenter;
 };
 
 class ApplyPointFeature : public BaseApplyFeature
@@ -65,7 +68,8 @@ class ApplyPointFeature : public BaseApplyFeature
   using TBase = BaseApplyFeature;
 
 public:
-  ApplyPointFeature(TInsertShapeFn const & insertShape, FeatureID const & id,
+  ApplyPointFeature(m2::PointD const & tileCenter,
+                    TInsertShapeFn const & insertShape, FeatureID const & id,
                     int minVisibleScale, uint8_t rank, CaptionDescription const & captions,
                     float posZ);
 
@@ -93,8 +97,11 @@ class ApplyAreaFeature : public ApplyPointFeature
   using TBase = ApplyPointFeature;
 
 public:
-  ApplyAreaFeature(TInsertShapeFn const & insertShape, FeatureID const & id, m2::RectD tileRect, float minPosZ,
-                   float posZ, int minVisibleScale, uint8_t rank, CaptionDescription const & captions);
+  ApplyAreaFeature(m2::PointD const & tileCenter,
+                   TInsertShapeFn const & insertShape, FeatureID const & id,
+                   m2::RectD tileRect, float minPosZ,
+                   float posZ, int minVisibleScale, uint8_t rank,
+                   CaptionDescription const & captions);
 
   using TBase::operator ();
 
@@ -112,7 +119,7 @@ private:
   bool FindEdge(TEdge const & edge);
   m2::PointD CalculateNormal(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3) const;
 
-  vector<m2::PointF> m_triangles;
+  vector<m2::PointD> m_triangles;
 
   unordered_map<int, m2::PointD> m_indices;
   vector<pair<TEdge, int>> m_edges;
@@ -126,9 +133,10 @@ class ApplyLineFeature : public BaseApplyFeature
   using TBase = BaseApplyFeature;
 
 public:
-  ApplyLineFeature(TInsertShapeFn const & insertShape, FeatureID const & id, m2::RectD tileRect,
-                   int minVisibleScale, uint8_t rank, CaptionDescription const & captions,
-                   double currentScaleGtoP, bool simplify, size_t pointsCount);
+  ApplyLineFeature(m2::PointD const & tileCenter, double currentScaleGtoP,
+                   TInsertShapeFn const & insertShape, FeatureID const & id,
+                   m2::RectD const & clipRect, int minVisibleScale, uint8_t rank,
+                   CaptionDescription const & captions, bool simplify, size_t pointsCount);
 
   void operator() (m2::PointD const & point);
   bool HasGeometry() const;
@@ -145,7 +153,7 @@ private:
   size_t m_initialPointsCount;
   double m_shieldDepth;
   ShieldRuleProto const * m_shieldRule;
-  m2::RectD m_tileRect;
+  m2::RectD m_clipRect;
 
 #ifdef CALC_FILTERED_POINTS
   int m_readedCount;

--- a/drape_frontend/area_shape.cpp
+++ b/drape_frontend/area_shape.cpp
@@ -36,8 +36,8 @@ void AreaShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> t
 
     for (auto const & edge : m_buildingEdges)
     {
-      glsl::vec2 const startPt = glsl::ToVec2(ConvertPt(edge.m_startVertex, m_params.m_tileCenter, kShapeCoordScalar));
-      glsl::vec2 const endPt = glsl::ToVec2(ConvertPt(edge.m_endVertex, m_params.m_tileCenter, kShapeCoordScalar));
+      glsl::vec2 const startPt = glsl::ToVec2(ConvertToLocal(edge.m_startVertex, m_params.m_tileCenter, kShapeCoordScalar));
+      glsl::vec2 const endPt = glsl::ToVec2(ConvertToLocal(edge.m_endVertex, m_params.m_tileCenter, kShapeCoordScalar));
 
       glsl::vec3 normal(glsl::ToVec2(edge.m_normal), 0.0f);
       vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(startPt, -m_params.m_minPosZ), normal, colorPoint));
@@ -52,7 +52,7 @@ void AreaShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> t
     glsl::vec3 normal(0.0f, 0.0f, -1.0f);
     for (auto const & vertex : m_vertexes)
     {
-      glsl::vec2 const pt = glsl::ToVec2(ConvertPt(vertex, m_params.m_tileCenter, kShapeCoordScalar));
+      glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(vertex, m_params.m_tileCenter, kShapeCoordScalar));
       vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(pt, -m_params.m_posZ), normal, colorPoint));
     }
 
@@ -70,7 +70,7 @@ void AreaShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> t
     vertexes.resize(m_vertexes.size());
     transform(m_vertexes.begin(), m_vertexes.end(), vertexes.begin(), [&colorPoint, this](m2::PointF const & vertex)
     {
-      return gpu::AreaVertex(glsl::vec3(glsl::ToVec2(ConvertPt(vertex, m_params.m_tileCenter, kShapeCoordScalar)),
+      return gpu::AreaVertex(glsl::vec3(glsl::ToVec2(ConvertToLocal(vertex, m_params.m_tileCenter, kShapeCoordScalar)),
                                         m_params.m_depth), colorPoint);
     });
 

--- a/drape_frontend/area_shape.hpp
+++ b/drape_frontend/area_shape.hpp
@@ -21,13 +21,13 @@ struct BuildingEdge
 class AreaShape : public MapShape
 {
 public:
-  AreaShape(vector<m2::PointF> && triangleList, vector<BuildingEdge> && buildingEdges,
+  AreaShape(vector<m2::PointD> && triangleList, vector<BuildingEdge> && buildingEdges,
             AreaViewParams const & params);
 
   void Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> textures) const override;
 
 private:
-  vector<m2::PointF> m_vertexes;
+  vector<m2::PointD> m_vertexes;
   vector<BuildingEdge> m_buildingEdges;
   AreaViewParams m_params;
 };

--- a/drape_frontend/arrow3d.cpp
+++ b/drape_frontend/arrow3d.cpp
@@ -118,7 +118,7 @@ void Arrow3d::SetPositionObsolete(bool obsolete)
   m_obsoletePosition = obsolete;
 }
 
-void Arrow3d::Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramManager> mng)
+void Arrow3d::Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp::GpuProgramManager> mng)
 {
   // Unbind current VAO, because glVertexAttributePointer and glEnableVertexAttribute can affect it.
   if (dp::GLExtensionsList::Instance().IsSupported(dp::GLExtensionsList::VertexArrayObject))
@@ -170,7 +170,7 @@ void Arrow3d::RenderArrow(ScreenBase const & screen, ref_ptr<dp::GpuProgram> pro
   
   dp::UniformValuesStorage uniforms;
   math::Matrix<float, 4, 4> const modelTransform = CalculateTransform(screen, dz);
-  uniforms.SetMatrix4x4Value("m_transform", modelTransform.m_data);
+  uniforms.SetMatrix4x4Value("u_transform", modelTransform.m_data);
   glsl::vec4 const c = glsl::ToVec4(color);
   uniforms.SetFloatValue("u_color", c.r, c.g, c.b, c.a);
   dp::ApplyState(m_state, program);

--- a/drape_frontend/arrow3d.hpp
+++ b/drape_frontend/arrow3d.hpp
@@ -30,7 +30,7 @@ public:
   void SetTexture(ref_ptr<dp::TextureManager> texMng);
   void SetPositionObsolete(bool obsolete);
 
-  void Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramManager> mng);
+  void Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp::GpuProgramManager> mng);
 
 private:
   void Build();

--- a/drape_frontend/circle_shape.cpp
+++ b/drape_frontend/circle_shape.cpp
@@ -25,7 +25,7 @@ void CircleShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager>
   dp::TextureManager::ColorRegion region;
   textures->GetColorRegion(m_params.m_color, region);
   glsl::vec2 const colorPoint(glsl::ToVec2(region.GetTexRect().Center()));
-  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
 
   buffer_vector<gpu::SolidTexturingVertex, 22> vertexes;
   vertexes.push_back(gpu::SolidTexturingVertex

--- a/drape_frontend/circle_shape.cpp
+++ b/drape_frontend/circle_shape.cpp
@@ -24,12 +24,13 @@ void CircleShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager>
 
   dp::TextureManager::ColorRegion region;
   textures->GetColorRegion(m_params.m_color, region);
-  glsl::vec2 colorPoint(glsl::ToVec2(region.GetTexRect().Center()));
+  glsl::vec2 const colorPoint(glsl::ToVec2(region.GetTexRect().Center()));
+  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
 
   buffer_vector<gpu::SolidTexturingVertex, 22> vertexes;
   vertexes.push_back(gpu::SolidTexturingVertex
   {
-    glsl::vec4(glsl::ToVec2(m_pt), m_params.m_depth, 0.0f),
+    glsl::vec4(pt, m_params.m_depth, 0.0f),
     glsl::vec2(0.0f, 0.0f),
     colorPoint
   });
@@ -41,7 +42,7 @@ void CircleShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager>
     m2::PointD rotatedNormal = m2::Rotate(startNormal, (i) * etalonSector);
     vertexes.push_back(gpu::SolidTexturingVertex
     {
-      glsl::vec4(glsl::ToVec2(m_pt), m_params.m_depth, 0.0f),
+      glsl::vec4(pt, m_params.m_depth, 0.0f),
       glsl::ToVec2(rotatedNormal),
       colorPoint
     });

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -143,24 +143,24 @@ void DrapeEngine::SetModelViewAnyRect(m2::AnyRectD const & rect, bool isAnim)
   AddUserEvent(make_unique_dp<SetAnyRectEvent>(rect, isAnim));
 }
 
-void DrapeEngine::ClearUserMarksLayer(df::TileKey const & tileKey)
+void DrapeEngine::ClearUserMarksLayer(size_t layerId)
 {
   m_threadCommutator->PostMessage(ThreadsCommutator::RenderThread,
-                                  make_unique_dp<ClearUserMarkLayerMessage>(tileKey),
+                                  make_unique_dp<ClearUserMarkLayerMessage>(layerId),
                                   MessagePriority::Normal);
 }
 
-void DrapeEngine::ChangeVisibilityUserMarksLayer(TileKey const & tileKey, bool isVisible)
+void DrapeEngine::ChangeVisibilityUserMarksLayer(size_t layerId, bool isVisible)
 {
   m_threadCommutator->PostMessage(ThreadsCommutator::RenderThread,
-                                  make_unique_dp<ChangeUserMarkLayerVisibilityMessage>(tileKey, isVisible),
+                                  make_unique_dp<ChangeUserMarkLayerVisibilityMessage>(layerId, isVisible),
                                   MessagePriority::Normal);
 }
 
-void DrapeEngine::UpdateUserMarksLayer(TileKey const & tileKey, UserMarksProvider * provider)
+void DrapeEngine::UpdateUserMarksLayer(size_t layerId, UserMarksProvider * provider)
 {
   m_threadCommutator->PostMessage(ThreadsCommutator::ResourceUploadThread,
-                                  make_unique_dp<UpdateUserMarkLayerMessage>(tileKey, provider),
+                                  make_unique_dp<UpdateUserMarkLayerMessage>(layerId, provider),
                                   MessagePriority::Normal);
 }
 

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -100,9 +100,9 @@ public:
   using TModelViewListenerFn = FrontendRenderer::TModelViewChanged;
   void SetModelViewListener(TModelViewListenerFn && fn);
 
-  void ClearUserMarksLayer(TileKey const & tileKey);
-  void ChangeVisibilityUserMarksLayer(TileKey const & tileKey, bool isVisible);
-  void UpdateUserMarksLayer(TileKey const & tileKey, UserMarksProvider * provider);
+  void ClearUserMarksLayer(size_t layerId);
+  void ChangeVisibilityUserMarksLayer(size_t layerId, bool isVisible);
+  void UpdateUserMarksLayer(size_t layerId, UserMarksProvider * provider);
 
   void SetRenderingEnabled(ref_ptr<dp::OGLContextFactory> contextFactory = nullptr);
   void SetRenderingDisabled(bool const destroyContext);

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -37,6 +37,7 @@
 #include "std/function.hpp"
 #include "std/map.hpp"
 #include "std/array.hpp"
+#include "std/unordered_set.hpp"
 
 namespace dp
 {
@@ -170,6 +171,7 @@ private:
   void Render2dLayer(ScreenBase const & modelView);
   void Render3dLayer(ScreenBase const & modelView);
   void RenderOverlayLayer(ScreenBase const & modelView);
+  void RenderUserMarksLayer(ScreenBase const & modelView);
   //////
   ScreenBase const & ProcessEvents(bool & modelViewChanged, bool & viewportChanged);
   void PrepareScene(ScreenBase const & modelView);
@@ -270,7 +272,7 @@ private:
 
   array<RenderLayer, RenderLayer::LayerCountID> m_layers;
   vector<drape_ptr<UserMarkRenderGroup>> m_userMarkRenderGroups;
-  set<TileKey> m_userMarkVisibility;
+  unordered_set<size_t> m_userMarkVisibility;
 
   drape_ptr<gui::LayerRenderer> m_guiRenderer;
   drape_ptr<MyPositionController> m_myPositionController;

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -161,7 +161,7 @@ private:
   void MergeBuckets();
   void RenderSingleGroup(ScreenBase const & modelView, ref_ptr<BaseRenderGroup> group);
   void RefreshProjection(ScreenBase const & screen);
-  void RefreshModelView(ScreenBase const & screen);
+  void RefreshZScale(ScreenBase const & screen);
   void RefreshPivotTransform(ScreenBase const & screen);
   void RefreshBgColor();
 

--- a/drape_frontend/gps_track_renderer.cpp
+++ b/drape_frontend/gps_track_renderer.cpp
@@ -235,7 +235,7 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
     if (m_points.size() == 1)
     {
       dp::Color const color = GetColorBySpeed(m_points.front().m_speedMPS);
-      m2::PointD const pt = MapShape::ConvertPt(m_points.front().m_point, m_pivot, kShapeCoordScalar);
+      m2::PointD const pt = MapShape::ConvertToLocal(m_points.front().m_point, m_pivot, kShapeCoordScalar);
       m_handlesCache[cacheIndex].first->SetPoint(0, pt, m_radius, color);
       m_handlesCache[cacheIndex].second++;
     }
@@ -253,7 +253,7 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
         if (screen.ClipRect().IsIntersect(pointRect))
         {
           dp::Color const color = CalculatePointColor(static_cast<size_t>(it.GetIndex()), pt, it.GetLength(), it.GetFullLength());
-          m2::PointD const convertedPt = MapShape::ConvertPt(pt, m_pivot, kShapeCoordScalar);
+          m2::PointD const convertedPt = MapShape::ConvertToLocal(pt, m_pivot, kShapeCoordScalar);
           m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, convertedPt, m_radius, color);
           m_handlesCache[cacheIndex].second++;
           if (m_handlesCache[cacheIndex].second >= m_handlesCache[cacheIndex].first->GetPointsCount())
@@ -272,7 +272,7 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
 #ifdef SHOW_RAW_POINTS
       for (size_t i = 0; i < m_points.size(); i++)
       {
-        m2::PointD const convertedPt = MapShape::ConvertPt(m_points[i].m_point, m_pivot, kShapeCoordScalar);
+        m2::PointD const convertedPt = MapShape::ConvertToLocal(m_points[i].m_point, m_pivot, kShapeCoordScalar);
         m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, convertedPt, m_radius * 1.2, dp::Color(0, 0, 255, 255));
         m_handlesCache[cacheIndex].second++;
         if (m_handlesCache[cacheIndex].second >= m_handlesCache[cacheIndex].first->GetPointsCount())

--- a/drape_frontend/gps_track_renderer.cpp
+++ b/drape_frontend/gps_track_renderer.cpp
@@ -1,5 +1,7 @@
 #include "drape_frontend/gps_track_renderer.hpp"
 #include "drape_frontend/color_constants.hpp"
+#include "drape_frontend/map_shape.hpp"
+#include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "drape/glsl_func.hpp"
@@ -227,11 +229,14 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
       m_handlesCache.push_back(make_pair(handle, 0));
     }
 
+    m_pivot = screen.GlobalRect().Center();
+
     size_t cacheIndex = 0;
     if (m_points.size() == 1)
     {
       dp::Color const color = GetColorBySpeed(m_points.front().m_speedMPS);
-      m_handlesCache[cacheIndex].first->SetPoint(0, m_points.front().m_point, m_radius, color);
+      m2::PointD const pt = MapShape::ConvertPt(m_points.front().m_point, m_pivot, kShapeCoordScalar);
+      m_handlesCache[cacheIndex].first->SetPoint(0, pt, m_radius, color);
       m_handlesCache[cacheIndex].second++;
     }
     else
@@ -248,7 +253,8 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
         if (screen.ClipRect().IsIntersect(pointRect))
         {
           dp::Color const color = CalculatePointColor(static_cast<size_t>(it.GetIndex()), pt, it.GetLength(), it.GetFullLength());
-          m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, pt, m_radius, color);
+          m2::PointD const convertedPt = MapShape::ConvertPt(pt, m_pivot, kShapeCoordScalar);
+          m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, convertedPt, m_radius, color);
           m_handlesCache[cacheIndex].second++;
           if (m_handlesCache[cacheIndex].second >= m_handlesCache[cacheIndex].first->GetPointsCount())
             cacheIndex++;
@@ -266,7 +272,8 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
 #ifdef SHOW_RAW_POINTS
       for (size_t i = 0; i < m_points.size(); i++)
       {
-        m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, m_points[i].m_point, m_radius * 1.2, dp::Color(0, 0, 255, 255));
+        m2::PointD const convertedPt = MapShape::ConvertPt(m_points[i].m_point, m_pivot, kShapeCoordScalar);
+        m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second, convertedPt, m_radius * 1.2, dp::Color(0, 0, 255, 255));
         m_handlesCache[cacheIndex].second++;
         if (m_handlesCache[cacheIndex].second >= m_handlesCache[cacheIndex].first->GetPointsCount())
           cacheIndex++;
@@ -292,6 +299,8 @@ void GpsTrackRenderer::RenderTrack(ScreenBase const & screen, int zoomLevel,
 
   // Render points.
   dp::UniformValuesStorage uniforms = commonUniforms;
+  math::Matrix<float, 4, 4> mv = screen.GetModelView(m_pivot, kShapeCoordScalar);
+  uniforms.SetMatrix4x4Value("modelView", mv.m_data);
   uniforms.SetFloatValue("u_opacity", 1.0f);
   ref_ptr<dp::GpuProgram> program = mng->GetProgram(gpu::TRACK_POINT_PROGRAM);
   program->Bind();

--- a/drape_frontend/gps_track_renderer.hpp
+++ b/drape_frontend/gps_track_renderer.hpp
@@ -51,6 +51,7 @@ private:
   bool m_waitForRenderData;
   vector<pair<GpsTrackHandle*, size_t>> m_handlesCache;
   float m_radius;
+  m2::PointD m_pivot;
 };
 
 } // namespace df

--- a/drape_frontend/line_shape.cpp
+++ b/drape_frontend/line_shape.cpp
@@ -73,13 +73,6 @@ public:
     m_joinGeom.reserve(joinsSize);
   }
 
-  void GetTexturingInfo(float const globalLength, int & steps, float & maskSize)
-  {
-    UNUSED_VALUE(globalLength);
-    UNUSED_VALUE(steps);
-    UNUSED_VALUE(maskSize);
-  }
-
   dp::BindingInfo const & GetBindingInfo() override
   {
     return TVertex::GetBindingInfo();
@@ -136,42 +129,6 @@ public:
   }
 
 protected:
-  vector<glsl::vec2> const & GenerateCap(LineSegment const & segment, EPointType type,
-                                         float sign, bool isStart)
-  {
-    m_normalBuffer.clear();
-    m_normalBuffer.reserve(24);
-
-    GenerateCapNormals(m_params.m_cap,
-                       segment.m_leftNormals[type],
-                       segment.m_rightNormals[type],
-                       sign * segment.m_tangent,
-                       GetHalfWidth(), isStart, m_normalBuffer);
-
-    return m_normalBuffer;
-  }
-
-  vector<glsl::vec2> const & GenerateJoin(LineSegment const & seg1, LineSegment const & seg2)
-  {
-    m_normalBuffer.clear();
-    m_normalBuffer.reserve(24);
-
-    glsl::vec2 n1 = seg1.m_hasLeftJoin[EndPoint] ? seg1.m_leftNormals[EndPoint] :
-                                                   seg1.m_rightNormals[EndPoint];
-
-    glsl::vec2 n2 = seg2.m_hasLeftJoin[StartPoint] ? seg2.m_leftNormals[StartPoint] :
-                                                     seg2.m_rightNormals[StartPoint];
-
-    float widthScalar = seg1.m_hasLeftJoin[EndPoint] ? seg1.m_rightWidthScalar[EndPoint].x :
-                                                       seg1.m_leftWidthScalar[EndPoint].x;
-
-    GenerateJoinNormals(m_params.m_join, n1, n2, GetHalfWidth(),
-                        seg1.m_hasLeftJoin[EndPoint], widthScalar, m_normalBuffer);
-
-    return m_normalBuffer;
-  }
-
-protected:
   using V = TVertex;
   using TGeometryBuffer = vector<V>;
 
@@ -200,8 +157,7 @@ class SolidLineBuilder : public BaseLineBuilder<gpu::LineVertex>
       : m_position(pos)
       , m_normal(normal)
       , m_color(color)
-    {
-    }
+    {}
 
     TPosition m_position;
     TNormal m_normal;
@@ -326,11 +282,10 @@ public:
     , m_baseGtoPScale(params.m_baseGtoP)
   {}
 
-  void GetTexturingInfo(float const globalLength, int & steps, float & maskSize)
+  int GetDashesCount(float const globalLength) const
   {
     float const pixelLen = globalLength * m_baseGtoPScale;
-    steps = static_cast<int>((pixelLen + m_texCoordGen.GetMaskLength() - 1) / m_texCoordGen.GetMaskLength());
-    maskSize = globalLength / steps;
+    return static_cast<int>((pixelLen + m_texCoordGen.GetMaskLength() - 1) / m_texCoordGen.GetMaskLength());
   }
 
   dp::GLState GetState() override
@@ -381,16 +336,16 @@ void LineShape::Construct<DashedLineBuilder>(DashedLineBuilder & builder) const
     if (path[i].EqualDxDy(path[i - 1], 1.0E-5))
       continue;
 
-    glsl::vec2 const p1 = glsl::vec2(path[i - 1].x, path[i - 1].y);
-    glsl::vec2 const p2 = glsl::vec2(path[i].x, path[i].y);
+    glsl::vec2 const p1 = glsl::ToVec2(ConvertPt(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p2 = glsl::ToVec2(ConvertPt(path[i], m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 tangent, leftNormal, rightNormal;
     CalculateTangentAndNormals(p1, p2, tangent, leftNormal, rightNormal);
 
     // calculate number of steps to cover line segment
-    float const initialGlobalLength = glsl::length(p2 - p1);
-    int steps = 1;
-    float maskSize = initialGlobalLength;
-    builder.GetTexturingInfo(initialGlobalLength, steps, maskSize);
+    float const initialGlobalLength = static_cast<float>((path[i] - path[i - 1]).Length());
+    int const steps = max(1, builder.GetDashesCount(initialGlobalLength));
+    float const maskSize = glsl::length(p2 - p1) / steps;
+    float const offsetSize = initialGlobalLength / steps;
 
     // generate vertices
     float currentSize = 0;
@@ -402,8 +357,8 @@ void LineShape::Construct<DashedLineBuilder>(DashedLineBuilder & builder) const
 
       builder.SubmitVertex(currentStartPivot, rightNormal, false /* isLeft */, 0.0);
       builder.SubmitVertex(currentStartPivot, leftNormal, true /* isLeft */, 0.0);
-      builder.SubmitVertex(newPivot, rightNormal, false /* isLeft */, maskSize);
-      builder.SubmitVertex(newPivot, leftNormal, true /* isLeft */, maskSize);
+      builder.SubmitVertex(newPivot, rightNormal, false /* isLeft */, offsetSize);
+      builder.SubmitVertex(newPivot, leftNormal, true /* isLeft */, offsetSize);
 
       currentStartPivot = newPivot;
     }
@@ -424,7 +379,7 @@ void LineShape::Construct<SolidLineBuilder>(SolidLineBuilder & builder) const
     generateJoins = false;
 
   // build geometry
-  glsl::vec2 firstPoint = glsl::vec2(path.front().x, path.front().y);
+  glsl::vec2 firstPoint = glsl::ToVec2(ConvertPt(path.front(), m_params.m_tileCenter, kShapeCoordScalar));
   glsl::vec2 lastPoint;
   bool hasConstructedSegments = false;
   for (size_t i = 1; i < path.size(); ++i)
@@ -432,8 +387,8 @@ void LineShape::Construct<SolidLineBuilder>(SolidLineBuilder & builder) const
     if (path[i].EqualDxDy(path[i - 1], 1.0E-5))
       continue;
 
-    glsl::vec2 const p1 = glsl::vec2(path[i - 1].x, path[i - 1].y);
-    glsl::vec2 const p2 = glsl::vec2(path[i].x, path[i].y);
+    glsl::vec2 const p1 = glsl::ToVec2(ConvertPt(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p2 = glsl::ToVec2(ConvertPt(path[i], m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 tangent, leftNormal, rightNormal;
     CalculateTangentAndNormals(p1, p2, tangent, leftNormal, rightNormal);
 

--- a/drape_frontend/line_shape.cpp
+++ b/drape_frontend/line_shape.cpp
@@ -336,8 +336,8 @@ void LineShape::Construct<DashedLineBuilder>(DashedLineBuilder & builder) const
     if (path[i].EqualDxDy(path[i - 1], 1.0E-5))
       continue;
 
-    glsl::vec2 const p1 = glsl::ToVec2(ConvertPt(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
-    glsl::vec2 const p2 = glsl::ToVec2(ConvertPt(path[i], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p1 = glsl::ToVec2(ConvertToLocal(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p2 = glsl::ToVec2(ConvertToLocal(path[i], m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 tangent, leftNormal, rightNormal;
     CalculateTangentAndNormals(p1, p2, tangent, leftNormal, rightNormal);
 
@@ -379,7 +379,7 @@ void LineShape::Construct<SolidLineBuilder>(SolidLineBuilder & builder) const
     generateJoins = false;
 
   // build geometry
-  glsl::vec2 firstPoint = glsl::ToVec2(ConvertPt(path.front(), m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec2 firstPoint = glsl::ToVec2(ConvertToLocal(path.front(), m_params.m_tileCenter, kShapeCoordScalar));
   glsl::vec2 lastPoint;
   bool hasConstructedSegments = false;
   for (size_t i = 1; i < path.size(); ++i)
@@ -387,8 +387,8 @@ void LineShape::Construct<SolidLineBuilder>(SolidLineBuilder & builder) const
     if (path[i].EqualDxDy(path[i - 1], 1.0E-5))
       continue;
 
-    glsl::vec2 const p1 = glsl::ToVec2(ConvertPt(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
-    glsl::vec2 const p2 = glsl::ToVec2(ConvertPt(path[i], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p1 = glsl::ToVec2(ConvertToLocal(path[i - 1], m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const p2 = glsl::ToVec2(ConvertToLocal(path[i], m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 tangent, leftNormal, rightNormal;
     CalculateTangentAndNormals(p1, p2, tangent, leftNormal, rightNormal);
 

--- a/drape_frontend/map_shape.hpp
+++ b/drape_frontend/map_shape.hpp
@@ -5,6 +5,8 @@
 
 #include "drape/pointers.hpp"
 
+#include "geometry/point2d.hpp"
+
 namespace dp
 {
   class Batcher;
@@ -32,6 +34,11 @@ public:
 
   void SetFeatureMinZoom(int minZoom) { m_minZoom = minZoom; }
   int GetFeatureMinZoom() const { return m_minZoom; }
+
+  static m2::PointD ConvertPt(m2::PointD const & basePt, m2::PointD const & tileCenter, double scalar)
+  {
+    return (basePt - tileCenter) * scalar;
+  }
 
 private:
   int m_minZoom = 0;

--- a/drape_frontend/map_shape.hpp
+++ b/drape_frontend/map_shape.hpp
@@ -35,7 +35,7 @@ public:
   void SetFeatureMinZoom(int minZoom) { m_minZoom = minZoom; }
   int GetFeatureMinZoom() const { return m_minZoom; }
 
-  static m2::PointD ConvertPt(m2::PointD const & basePt, m2::PointD const & tileCenter, double scalar)
+  static m2::PointD ConvertToLocal(m2::PointD const & basePt, m2::PointD const & tileCenter, double scalar)
   {
     return (basePt - tileCenter) * scalar;
   }

--- a/drape_frontend/message.hpp
+++ b/drape_frontend/message.hpp
@@ -23,6 +23,7 @@ public:
     ClearUserMarkLayer,
     ChangeUserMarkLayerVisibility,
     UpdateUserMarkLayer,
+    FlushUserMarks,
     GuiLayerRecached,
     GuiRecache,
     GuiLayerLayout,

--- a/drape_frontend/my_position.cpp
+++ b/drape_frontend/my_position.cpp
@@ -110,7 +110,7 @@ void MyPosition::RenderAccuracy(ScreenBase const & screen, int zoomLevel,
   math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
   uniforms.SetMatrix4x4Value("modelView", mv.m_data);
 
-  m2::PointD const pos = MapShape::ConvertPt(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+  m2::PointD const pos = MapShape::ConvertToLocal(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
   uniforms.SetFloatValue("u_position", pos.x, pos.y, 0.0f);
   uniforms.SetFloatValue("u_accuracy", pixelAccuracy);
   uniforms.SetFloatValue("u_opacity", 1.0f);
@@ -134,7 +134,7 @@ void MyPosition::RenderMyPosition(ScreenBase const & screen, int zoomLevel,
     math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
     uniforms.SetMatrix4x4Value("modelView", mv.m_data);
 
-    m2::PointD const pos = MapShape::ConvertPt(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+    m2::PointD const pos = MapShape::ConvertToLocal(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
     uniforms.SetFloatValue("u_position", pos.x, pos.y, dp::depth::MY_POSITION_MARK);
     uniforms.SetFloatValue("u_azimut", -(m_azimuth + screen.GetAngle()));
     uniforms.SetFloatValue("u_opacity", 1.0);

--- a/drape_frontend/my_position.hpp
+++ b/drape_frontend/my_position.hpp
@@ -28,11 +28,11 @@ public:
   void SetRoutingMode(bool routingMode);
   void SetPositionObsolete(bool obsolete);
 
-  void RenderAccuracy(ScreenBase const & screen,
+  void RenderAccuracy(ScreenBase const & screen, int zoomLevel,
                       ref_ptr<dp::GpuProgramManager> mng,
                       dp::UniformValuesStorage const & commonUniforms);
 
-  void RenderMyPosition(ScreenBase const & screen,
+  void RenderMyPosition(ScreenBase const & screen, int zoomLevel,
                         ref_ptr<dp::GpuProgramManager> mng,
                         dp::UniformValuesStorage const & commonUniforms);
 

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -500,7 +500,8 @@ bool MyPositionController::UpdateViewportWithAutoZoom()
   return false;
 }
 
-void MyPositionController::Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramManager> mng,
+void MyPositionController::Render(ScreenBase const & screen, int zoomLevel,
+                                  ref_ptr<dp::GpuProgramManager> mng,
                                   dp::UniformValuesStorage const & commonUniforms)
 {
   if (IsWaitingForLocation())
@@ -551,8 +552,8 @@ void MyPositionController::Render(ScreenBase const & screen, ref_ptr<dp::GpuProg
     m_shape->SetAccuracy(m_errorRadius);
     m_shape->SetRoutingMode(IsInRouting());
 
-    m_shape->RenderAccuracy(screen, mng, commonUniforms);
-    m_shape->RenderMyPosition(screen, mng, commonUniforms);
+    m_shape->RenderAccuracy(screen, zoomLevel, mng, commonUniforms);
+    m_shape->RenderMyPosition(screen, zoomLevel, mng, commonUniforms);
   }
 }
 

--- a/drape_frontend/my_position_controller.hpp
+++ b/drape_frontend/my_position_controller.hpp
@@ -90,7 +90,7 @@ public:
 
   void SetModeListener(location::TMyPositionModeChanged const & fn);
 
-  void Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramManager> mng,
+  void Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp::GpuProgramManager> mng,
               dp::UniformValuesStorage const & commonUniforms);
 
   bool IsRotationAvailable() const { return m_isDirectionAssigned; }

--- a/drape_frontend/path_symbol_shape.cpp
+++ b/drape_frontend/path_symbol_shape.cpp
@@ -40,7 +40,7 @@ void PathSymbolShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureMana
   glsl::vec2 dummy(0.0, 0.0);
   while (!splineIter.BeginAgain())
   {
-    glsl::vec2 pivot = glsl::ToVec2(splineIter.m_pos);
+    glsl::vec2 const pivot = glsl::ToVec2(ConvertPt(splineIter.m_pos, m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 n = halfH * glsl::normalize(glsl::vec2(-splineIter.m_dir.y, splineIter.m_dir.x));
     glsl::vec2 d = halfW * glsl::normalize(glsl::vec2(splineIter.m_dir.x, splineIter.m_dir.y));
     float nLength = glsl::length(n) * pToGScale;

--- a/drape_frontend/path_symbol_shape.cpp
+++ b/drape_frontend/path_symbol_shape.cpp
@@ -40,7 +40,7 @@ void PathSymbolShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureMana
   glsl::vec2 dummy(0.0, 0.0);
   while (!splineIter.BeginAgain())
   {
-    glsl::vec2 const pivot = glsl::ToVec2(ConvertPt(splineIter.m_pos, m_params.m_tileCenter, kShapeCoordScalar));
+    glsl::vec2 const pivot = glsl::ToVec2(ConvertToLocal(splineIter.m_pos, m_params.m_tileCenter, kShapeCoordScalar));
     glsl::vec2 n = halfH * glsl::normalize(glsl::vec2(-splineIter.m_dir.y, splineIter.m_dir.x));
     glsl::vec2 d = halfW * glsl::normalize(glsl::vec2(splineIter.m_dir.x, splineIter.m_dir.y));
     float nLength = glsl::length(n) * pToGScale;

--- a/drape_frontend/path_text_shape.cpp
+++ b/drape_frontend/path_text_shape.cpp
@@ -319,8 +319,8 @@ void PathTextShape::DrawPathTextOutlined(ref_ptr<dp::TextureManager> textures,
 
 void PathTextShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> textures) const
 {
-  unique_ptr<PathTextLayout> layout = make_unique<PathTextLayout>(strings::MakeUniString(m_params.m_text),
-                                                                  m_params.m_textFont.m_size, textures);
+  auto layout = make_unique<PathTextLayout>(m_params.m_tileCenter, strings::MakeUniString(m_params.m_text),
+                                            m_params.m_textFont.m_size, textures);
 
   uint32_t glyphCount = layout->GetGlyphCount();
   if (glyphCount == 0)

--- a/drape_frontend/poi_symbol_shape.cpp
+++ b/drape_frontend/poi_symbol_shape.cpp
@@ -108,7 +108,8 @@ void PoiSymbolShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManag
   dp::TextureManager::SymbolRegion region;
   textures->GetSymbolRegion(m_params.m_symbolName, region);
 
-  glsl::vec4 const position = glsl::vec4(glsl::ToVec2(m_pt), m_params.m_depth, -m_params.m_posZ);
+  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec4 const position = glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ);
   m2::PointU const pixelSize = region.GetPixelSize();
 
   drape_ptr<dp::OverlayHandle> handle = make_unique_dp<dp::SquareHandle>(m_params.m_id,

--- a/drape_frontend/poi_symbol_shape.cpp
+++ b/drape_frontend/poi_symbol_shape.cpp
@@ -108,7 +108,7 @@ void PoiSymbolShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManag
   dp::TextureManager::SymbolRegion region;
   textures->GetSymbolRegion(m_params.m_symbolName, region);
 
-  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(m_pt, m_params.m_tileCenter, kShapeCoordScalar));
   glsl::vec4 const position = glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ);
   m2::PointU const pixelSize = region.GetPixelSize();
 

--- a/drape_frontend/render_group.cpp
+++ b/drape_frontend/render_group.cpp
@@ -88,9 +88,15 @@ void RenderGroup::Render(ScreenBase const & screen)
   for(auto & renderBucket : m_renderBuckets)
     renderBucket->GetBuffer()->Build(shader);
 
-  auto const & params = df::VisualParams::Instance().GetGlyphVisualParams();
+  // Set tile-based model-view matrix.
+  {
+    math::Matrix<float, 4, 4> mv = GetTileKey().GetTileBasedModelView(screen);
+    m_uniforms.SetMatrix4x4Value("modelView", mv.m_data);
+  }
+
   int programIndex = m_state.GetProgramIndex();
   int program3dIndex = m_state.GetProgram3dIndex();
+  auto const & params = df::VisualParams::Instance().GetGlyphVisualParams();
   if (programIndex == gpu::TEXT_OUTLINED_PROGRAM ||
       program3dIndex == gpu::TEXT_OUTLINED_BILLBOARD_PROGRAM)
   {
@@ -215,6 +221,10 @@ void UserMarkRenderGroup::UpdateAnimation()
 void UserMarkRenderGroup::Render(ScreenBase const & screen)
 {
   BaseRenderGroup::Render(screen);
+
+  math::Matrix<float, 4, 4> mv = screen.GetModelView();
+  m_uniforms.SetMatrix4x4Value("modelView", mv.m_data);
+
   ref_ptr<dp::GpuProgram> shader = screen.isPerspective() ? m_shader3d : m_shader;
   dp::ApplyUniforms(m_uniforms, shader);
   if (m_renderBucket != nullptr)

--- a/drape_frontend/render_group.hpp
+++ b/drape_frontend/render_group.hpp
@@ -26,6 +26,8 @@ public:
     : m_state(state)
     , m_tileKey(tileKey) {}
 
+  virtual ~BaseRenderGroup() {}
+
   void SetRenderParams(ref_ptr<dp::GpuProgram> shader, ref_ptr<dp::GpuProgram> shader3d,
                        ref_ptr<dp::UniformValuesStorage> generalUniforms);
 
@@ -50,11 +52,11 @@ private:
 
 class RenderGroup : public BaseRenderGroup
 {
-  typedef BaseRenderGroup TBase;
+  using TBase = BaseRenderGroup;
   friend class BatchMergeHelper;
 public:
   RenderGroup(dp::GLState const & state, TileKey const & tileKey);
-  ~RenderGroup();
+  ~RenderGroup() override;
 
   void Update(ScreenBase const & modelView);
   void CollectOverlay(ref_ptr<dp::OverlayTree> tree);
@@ -91,20 +93,23 @@ public:
 
 class UserMarkRenderGroup : public BaseRenderGroup
 {
-  typedef BaseRenderGroup TBase;
+  using TBase = BaseRenderGroup;
 
 public:
-  UserMarkRenderGroup(dp::GLState const & state, TileKey const & tileKey,
+  UserMarkRenderGroup(size_t layerId, dp::GLState const & state, TileKey const & tileKey,
                       drape_ptr<dp::RenderBucket> && bucket);
-  ~UserMarkRenderGroup();
+  ~UserMarkRenderGroup() override;
 
   void UpdateAnimation() override;
   void Render(ScreenBase const & screen) override;
+
+  size_t GetLayerId() const;
 
 private:
   drape_ptr<dp::RenderBucket> m_renderBucket;
   unique_ptr<OpacityAnimation> m_animation;
   ValueMapping<float> m_mapping;
+  size_t m_layerId;
 };
 
 } // namespace df

--- a/drape_frontend/route_builder.cpp
+++ b/drape_frontend/route_builder.cpp
@@ -23,6 +23,7 @@ void RouteBuilder::Build(m2::PolylineD const & routePolyline, vector<double> con
   routeData->m_sourcePolyline = routePolyline;
   routeData->m_sourceTurns = turns;
   routeData->m_pattern = pattern;
+  routeData->m_pivot = routePolyline.GetLimitRect().Center();
   RouteShape::CacheRoute(textures, *routeData.get());
   m_routeCache.insert(make_pair(routeData->m_routeIndex, routePolyline));
 
@@ -63,6 +64,7 @@ void RouteBuilder::BuildArrows(int routeIndex, vector<ArrowBorders> const & bord
     return;
 
   drape_ptr<RouteArrowsData> routeArrowsData = make_unique_dp<RouteArrowsData>();
+  routeArrowsData->m_pivot = it->second.GetLimitRect().Center();
   RouteShape::CacheRouteArrows(textures, it->second, borders, *routeArrowsData.get());
 
   // Flush route arrows geometry.

--- a/drape_frontend/route_renderer.cpp
+++ b/drape_frontend/route_renderer.cpp
@@ -1,4 +1,5 @@
 #include "drape_frontend/route_renderer.hpp"
+#include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/message_subclasses.hpp"
 
 #include "drape/glsl_func.hpp"
@@ -238,6 +239,8 @@ void RouteRenderer::RenderRoute(ScreenBase const & screen, ref_ptr<dp::GpuProgra
 
     // Set up uniforms.
     dp::UniformValuesStorage uniforms = commonUniforms;
+    math::Matrix<float, 4, 4> mv = screen.GetModelView(m_routeData->m_pivot, kShapeCoordScalar);
+    uniforms.SetMatrix4x4Value("modelView", mv.m_data);
     glsl::vec4 const color = glsl::ToVec4(df::GetColorConstant(GetStyleReader().GetCurrentStyle(),
                                                                m_routeData->m_color));
     uniforms.SetFloatValue("u_color", color.r, color.g, color.b, m_currentAlpha);
@@ -269,6 +272,8 @@ void RouteRenderer::RenderRoute(ScreenBase const & screen, ref_ptr<dp::GpuProgra
 
     // set up shaders and apply common uniforms
     dp::UniformValuesStorage uniforms = commonUniforms;
+    math::Matrix<float, 4, 4> mv = screen.GetModelView(m_routeArrows->m_pivot, kShapeCoordScalar);
+    uniforms.SetMatrix4x4Value("modelView", mv.m_data);
     uniforms.SetFloatValue("u_arrowHalfWidth", m_currentHalfWidth * kArrowHeightFactor);
     uniforms.SetFloatValue("u_opacity", 1.0f);
 
@@ -305,8 +310,9 @@ void RouteRenderer::RenderRouteSign(drape_ptr<RouteSignData> const & sign, Scree
     return;
 
   dp::GLState const & state = sign->m_sign.m_state;
-
   dp::UniformValuesStorage uniforms = commonUniforms;
+  math::Matrix<float, 4, 4> mv = screen.GetModelView(sign->m_position, 1.0);
+  uniforms.SetMatrix4x4Value("modelView", mv.m_data);
   uniforms.SetFloatValue("u_opacity", 1.0f);
 
   ref_ptr<dp::GpuProgram> program = screen.isPerspective() ? mng->GetProgram(state.GetProgram3dIndex())

--- a/drape_frontend/route_shape.cpp
+++ b/drape_frontend/route_shape.cpp
@@ -1,5 +1,7 @@
 #include "drape_frontend/route_shape.hpp"
 #include "drape_frontend/line_shape_helper.hpp"
+#include "drape_frontend/shape_view_params.hpp"
+#include "drape_frontend/tile_utils.hpp"
 
 #include "drape/attribute_provider.hpp"
 #include "drape/batcher.hpp"
@@ -120,8 +122,9 @@ void GenerateArrowsTriangles(glsl::vec4 const & pivot, vector<glsl::vec2> const 
 
 } // namespace
 
-void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffer & geometry,
-                                 TGeometryBuffer & joinsGeometry, double & outputLength)
+void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, m2::PointD const & pivot,
+                                 TGeometryBuffer & geometry, TGeometryBuffer & joinsGeometry,
+                                 double & outputLength)
 {
   ASSERT(path.size() > 1, ());
 
@@ -139,8 +142,13 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffe
                  (i < segments.size() - 1) ? &segments[i + 1] : nullptr);
 
     // Generate main geometry.
-    glsl::vec3 const startPivot = glsl::vec3(segments[i].m_points[StartPoint], kDepth);
-    glsl::vec3 const endPivot = glsl::vec3(segments[i].m_points[EndPoint], kDepth);
+    m2::PointD const startPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[StartPoint]),
+                                                   pivot, kShapeCoordScalar);
+    m2::PointD const endPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[EndPoint]),
+                                                 pivot, kShapeCoordScalar);
+
+    glsl::vec3 const startPivot = glsl::vec3(glsl::ToVec2(startPt), kDepth);
+    glsl::vec3 const endPivot = glsl::vec3(glsl::ToVec2(endPt), kDepth);
 
     float const endLength = length + glsl::length(segments[i].m_points[EndPoint] - segments[i].m_points[StartPoint]);
 
@@ -177,10 +185,11 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffe
 
       vector<glsl::vec2> normals;
       normals.reserve(24);
-      GenerateJoinNormals(dp::RoundJoin, n1, n2, 1.0f, segments[i].m_hasLeftJoin[EndPoint], widthScalar, normals);
+      GenerateJoinNormals(dp::RoundJoin, n1, n2, 1.0f, segments[i].m_hasLeftJoin[EndPoint],
+                          widthScalar, normals);
 
-      GenerateJoinsTriangles(glsl::vec3(segments[i].m_points[EndPoint], kDepth), normals,
-                             glsl::vec2(endLength, 0), segments[i].m_hasLeftJoin[EndPoint], joinsGeometry);
+      GenerateJoinsTriangles(endPivot, normals, glsl::vec2(endLength, 0),
+                             segments[i].m_hasLeftJoin[EndPoint], joinsGeometry);
     }
 
     // Generate caps.
@@ -192,8 +201,7 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffe
                          segments[i].m_rightNormals[StartPoint], -segments[i].m_tangent,
                          1.0f, true /* isStart */, normals);
 
-      GenerateJoinsTriangles(glsl::vec3(segments[i].m_points[StartPoint], kDepth), normals,
-                             glsl::vec2(length, 0), true, joinsGeometry);
+      GenerateJoinsTriangles(startPivot, normals, glsl::vec2(length, 0), true, joinsGeometry);
     }
 
     if (i == segments.size() - 1)
@@ -204,8 +212,7 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffe
                          segments[i].m_rightNormals[EndPoint], segments[i].m_tangent,
                          1.0f, false /* isStart */, normals);
 
-      GenerateJoinsTriangles(glsl::vec3(segments[i].m_points[EndPoint], kDepth), normals,
-                             glsl::vec2(endLength, 0), true, joinsGeometry);
+      GenerateJoinsTriangles(endPivot, normals, glsl::vec2(endLength, 0), true, joinsGeometry);
     }
 
     length = endLength;
@@ -214,7 +221,8 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffe
   outputLength = length; 
 }
 
-void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF const & texRect, float depth,
+void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::PointD const & pivot,
+                                      m2::RectF const & texRect, float depth,
                                       TArrowGeometryBuffer & geometry, TArrowGeometryBuffer & joinsGeometry)
 {
   ASSERT(path.size() > 1, ());
@@ -240,8 +248,13 @@ void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF
                  (i < segments.size() - 1) ? &segments[i + 1] : nullptr);
 
     // Generate main geometry.
-    glsl::vec4 const startPivot = glsl::vec4(segments[i].m_points[StartPoint], depth, 1.0);
-    glsl::vec4 const endPivot = glsl::vec4(segments[i].m_points[EndPoint], depth, 1.0);
+    m2::PointD const startPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[StartPoint]),
+                                                   pivot, kShapeCoordScalar);
+    m2::PointD const endPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[EndPoint]),
+                                                 pivot, kShapeCoordScalar);
+
+    glsl::vec4 const startPivot = glsl::vec4(glsl::ToVec2(startPt), depth, 1.0);
+    glsl::vec4 const endPivot = glsl::vec4(glsl::ToVec2(endPt), depth, 1.0);
 
     float const endLength = length + glsl::length(segments[i].m_points[EndPoint] - segments[i].m_points[StartPoint]);
 
@@ -285,8 +298,7 @@ void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF
 
       ASSERT_EQUAL(normals.size(), uv.size(), ());
 
-      GenerateArrowsTriangles(glsl::vec4(segments[i].m_points[EndPoint], depth, 1.0),
-                              normals, tr, uv, true /* normalizedUV */, joinsGeometry);
+      GenerateArrowsTriangles(endPivot, normals, tr, uv, true /* normalizedUV */, joinsGeometry);
     }
 
     // Generate arrow head.
@@ -300,8 +312,7 @@ void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF
       };
       float const u = 1.0f - kArrowHeadSize;
       vector<glsl::vec2> uv = { glsl::vec2(u, 1.0f), glsl::vec2(u, 0.0f), glsl::vec2(1.0f, 0.5f) };
-      GenerateArrowsTriangles(glsl::vec4(segments[i].m_points[EndPoint], depth, 1.0),
-                              normals, texRect, uv, true /* normalizedUV */, joinsGeometry);
+      GenerateArrowsTriangles(endPivot, normals, texRect, uv, true /* normalizedUV */, joinsGeometry);
     }
 
     // Generate arrow tail.
@@ -325,8 +336,7 @@ void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF
         glsl::ToVec2(t.LeftTop())
       };
 
-      GenerateArrowsTriangles(glsl::vec4(segments[i].m_points[StartPoint], depth, 1.0),
-                              normals, texRect, uv, false /* normalizedUV */, joinsGeometry);
+      GenerateArrowsTriangles(startPivot, normals, texRect, uv, false /* normalizedUV */, joinsGeometry);
     }
 
     length = endLength;
@@ -341,8 +351,7 @@ void RouteShape::CacheRouteSign(ref_ptr<dp::TextureManager> mng, RouteSignData &
   m2::RectF const & texRect = symbol.GetTexRect();
   m2::PointF halfSize = m2::PointF(symbol.GetPixelSize()) * 0.5f;
 
-  glsl::vec2 const pos = glsl::ToVec2(routeSignData.m_position);
-  glsl::vec4 const pivot = glsl::vec4(pos.x, pos.y, 0.0f /* depth */, 0.0f /* pivot z */);
+  glsl::vec4 const pivot = glsl::vec4(0.0f /* x */, 0.0f /* y */, 0.0f /* depth */, 0.0f /* pivot z */);
   gpu::SolidTexturingVertex data[4]=
   {
     { pivot, glsl::vec2(-halfSize.x,  halfSize.y), glsl::ToVec2(texRect.LeftTop()) },
@@ -389,7 +398,7 @@ void RouteShape::CacheRouteArrows(ref_ptr<dp::TextureManager> mng, m2::PolylineD
   {
     vector<m2::PointD> points = CalculatePoints(polyline, b.m_startDistance, b.m_endDistance);
     ASSERT_LESS_OR_EQUAL(points.size(), polyline.GetSize(), ());
-    PrepareArrowGeometry(points, region.GetTexRect(), depth, geometry, joinsGeometry);
+    PrepareArrowGeometry(points, routeArrowsData.m_pivot, region.GetTexRect(), depth, geometry, joinsGeometry);
     depth += 1.0f;
   }
 
@@ -402,7 +411,7 @@ void RouteShape::CacheRoute(ref_ptr<dp::TextureManager> textures, RouteData & ro
 {
   TGeometryBuffer geometry;
   TGeometryBuffer joinsGeometry;
-  PrepareGeometry(routeData.m_sourcePolyline.GetPoints(),
+  PrepareGeometry(routeData.m_sourcePolyline.GetPoints(), routeData.m_pivot,
                   geometry, joinsGeometry, routeData.m_length);
 
   dp::GLState state = dp::GLState(gpu::ROUTE_PROGRAM, dp::GLState::GeometryLayer);

--- a/drape_frontend/route_shape.cpp
+++ b/drape_frontend/route_shape.cpp
@@ -142,10 +142,10 @@ void RouteShape::PrepareGeometry(vector<m2::PointD> const & path, m2::PointD con
                  (i < segments.size() - 1) ? &segments[i + 1] : nullptr);
 
     // Generate main geometry.
-    m2::PointD const startPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[StartPoint]),
-                                                   pivot, kShapeCoordScalar);
-    m2::PointD const endPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[EndPoint]),
-                                                 pivot, kShapeCoordScalar);
+    m2::PointD const startPt = MapShape::ConvertToLocal(glsl::FromVec2(segments[i].m_points[StartPoint]),
+                                                        pivot, kShapeCoordScalar);
+    m2::PointD const endPt = MapShape::ConvertToLocal(glsl::FromVec2(segments[i].m_points[EndPoint]),
+                                                      pivot, kShapeCoordScalar);
 
     glsl::vec3 const startPivot = glsl::vec3(glsl::ToVec2(startPt), kDepth);
     glsl::vec3 const endPivot = glsl::vec3(glsl::ToVec2(endPt), kDepth);
@@ -248,10 +248,10 @@ void RouteShape::PrepareArrowGeometry(vector<m2::PointD> const & path, m2::Point
                  (i < segments.size() - 1) ? &segments[i + 1] : nullptr);
 
     // Generate main geometry.
-    m2::PointD const startPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[StartPoint]),
-                                                   pivot, kShapeCoordScalar);
-    m2::PointD const endPt = MapShape::ConvertPt(glsl::FromVec2(segments[i].m_points[EndPoint]),
-                                                 pivot, kShapeCoordScalar);
+    m2::PointD const startPt = MapShape::ConvertToLocal(glsl::FromVec2(segments[i].m_points[StartPoint]),
+                                                        pivot, kShapeCoordScalar);
+    m2::PointD const endPt = MapShape::ConvertToLocal(glsl::FromVec2(segments[i].m_points[EndPoint]),
+                                                      pivot, kShapeCoordScalar);
 
     glsl::vec4 const startPivot = glsl::vec4(glsl::ToVec2(startPt), depth, 1.0);
     glsl::vec4 const endPivot = glsl::vec4(glsl::ToVec2(endPt), depth, 1.0);

--- a/drape_frontend/route_shape.hpp
+++ b/drape_frontend/route_shape.hpp
@@ -62,6 +62,7 @@ struct RouteData
   int m_routeIndex;
   m2::PolylineD m_sourcePolyline;
   vector<double> m_sourceTurns;
+  m2::PointD m_pivot;
   df::ColorConstant m_color;
   double m_length;
   RouteRenderProperty m_route;
@@ -79,6 +80,7 @@ struct RouteSignData
 struct RouteArrowsData
 {
   RouteRenderProperty m_arrows;
+  m2::PointD m_pivot;
 };
 
 class RouteShape
@@ -95,9 +97,11 @@ public:
                                vector<ArrowBorders> const & borders, RouteArrowsData & routeArrowsData);
 
 private:
-  static void PrepareGeometry(vector<m2::PointD> const & path, TGeometryBuffer & geometry,
-                              TGeometryBuffer & joinsGeometry, double & outputLength);
-  static void PrepareArrowGeometry(vector<m2::PointD> const & path, m2::RectF const & texRect, float depth,
+  static void PrepareGeometry(vector<m2::PointD> const & path, m2::PointD const & pivot,
+                              TGeometryBuffer & geometry, TGeometryBuffer & joinsGeometry,
+                              double & outputLength);
+  static void PrepareArrowGeometry(vector<m2::PointD> const & path, m2::PointD const & pivot,
+                                   m2::RectF const & texRect, float depth,
                                    TArrowGeometryBuffer & geometry, TArrowGeometryBuffer & joinsGeometry);
   static void BatchGeometry(dp::GLState const & state, ref_ptr<void> geometry, size_t geomSize,
                             ref_ptr<void> joinsGeometry, size_t joinsGeomSize,

--- a/drape_frontend/selection_shape.cpp
+++ b/drape_frontend/selection_shape.cpp
@@ -1,5 +1,8 @@
 #include "drape_frontend/selection_shape.hpp"
 #include "drape_frontend/color_constants.hpp"
+#include "drape_frontend/map_shape.hpp"
+#include "drape_frontend/shape_view_params.hpp"
+#include "drape_frontend/tile_utils.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "drape/attribute_provider.hpp"
@@ -125,7 +128,7 @@ void SelectionShape::Hide()
   m_selectedObject = OBJECT_EMPTY;
 }
 
-void SelectionShape::Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramManager> mng,
+void SelectionShape::Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp::GpuProgramManager> mng,
                             dp::UniformValuesStorage const & commonUniforms)
 {
   ShowHideAnimation::EState state = m_animation.GetState();
@@ -133,7 +136,12 @@ void SelectionShape::Render(ScreenBase const & screen, ref_ptr<dp::GpuProgramMan
       state == ShowHideAnimation::STATE_SHOW_DIRECTION)
   {
     dp::UniformValuesStorage uniforms = commonUniforms;
-    uniforms.SetFloatValue("u_position", m_position.x, m_position.y, -m_positionZ);
+    TileKey const key = GetTileKeyByPoint(m_position, ClipTileZoomByMaxDataZoom(zoomLevel));
+    math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
+    uniforms.SetMatrix4x4Value("modelView", mv.m_data);
+
+    m2::PointD const pos = MapShape::ConvertPt(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+    uniforms.SetFloatValue("u_position", pos.x, pos.y, -m_positionZ);
 
     float accuracy = m_mapping.GetValue(m_animation.GetT());
     if (screen.isPerspective())

--- a/drape_frontend/selection_shape.cpp
+++ b/drape_frontend/selection_shape.cpp
@@ -140,7 +140,7 @@ void SelectionShape::Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp
     math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
     uniforms.SetMatrix4x4Value("modelView", mv.m_data);
 
-    m2::PointD const pos = MapShape::ConvertPt(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+    m2::PointD const pos = MapShape::ConvertToLocal(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
     uniforms.SetFloatValue("u_position", pos.x, pos.y, -m_positionZ);
 
     float accuracy = m_mapping.GetValue(m_animation.GetT());

--- a/drape_frontend/selection_shape.hpp
+++ b/drape_frontend/selection_shape.hpp
@@ -35,8 +35,7 @@ public:
   void SetPosition(m2::PointD const & position) { m_position = position; }
   void Show(ESelectedObject obj, m2::PointD const & position, double positionZ, bool isAnimate);
   void Hide();
-  void Render(ScreenBase const & screen,
-              ref_ptr<dp::GpuProgramManager> mng,
+  void Render(ScreenBase const & screen, int zoomLevel, ref_ptr<dp::GpuProgramManager> mng,
               dp::UniformValuesStorage const & commonUniforms);
 
   ESelectedObject GetSelectedObject() const;

--- a/drape_frontend/shape_view_params.hpp
+++ b/drape_frontend/shape_view_params.hpp
@@ -12,11 +12,14 @@
 namespace df
 {
 
+double const kShapeCoordScalar = 1000;
+
 struct CommonViewParams
 {
   float m_depth = 0.0f;
   int m_minVisibleScale = 0;
   uint8_t m_rank = 0;
+  m2::PointD m_tileCenter;
 };
 
 struct PoiSymbolViewParams : CommonViewParams

--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -482,7 +482,7 @@ bool PathTextLayout::CacheDynamicGeometry(m2::Spline::iterator const & iter, flo
   glsl::vec2 pxPivot = glsl::ToVec2(iter.m_pos);
   buffer.resize(4 * m_metrics.size());
 
-  glsl::vec4 const pivot(glsl::ToVec2(MapShape::ConvertPt(globalPivot, m_tileCenter, kShapeCoordScalar)), depth, 0.0f);
+  glsl::vec4 const pivot(glsl::ToVec2(MapShape::ConvertToLocal(globalPivot, m_tileCenter, kShapeCoordScalar)), depth, 0.0f);
   for (size_t i = 0; i < m_metrics.size(); ++i)
   {
     GlyphRegion const & g = m_metrics[i];

--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -1,6 +1,5 @@
 #include "drape_frontend/text_layout.hpp"
-#include "drape_frontend/visual_params.hpp"
-
+#include "drape_frontend/map_shape.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "drape/fribidi.hpp"
@@ -436,8 +435,9 @@ void StraightTextLayout::Cache(glm::vec4 const & pivot, glm::vec2 const & pixelO
   }
 }
 
-PathTextLayout::PathTextLayout(strings::UniString const & text, float fontSize,
-                               ref_ptr<dp::TextureManager> textures)
+PathTextLayout::PathTextLayout(m2::PointD const & tileCenter, strings::UniString const & text,
+                               float fontSize, ref_ptr<dp::TextureManager> textures)
+  : m_tileCenter(tileCenter)
 {
   Init(fribidi::log2vis(text), fontSize, textures);
 }
@@ -481,6 +481,8 @@ bool PathTextLayout::CacheDynamicGeometry(m2::Spline::iterator const & iter, flo
 
   glsl::vec2 pxPivot = glsl::ToVec2(iter.m_pos);
   buffer.resize(4 * m_metrics.size());
+
+  glsl::vec4 const pivot(glsl::ToVec2(MapShape::ConvertPt(globalPivot, m_tileCenter, kShapeCoordScalar)), depth, 0.0f);
   for (size_t i = 0; i < m_metrics.size(); ++i)
   {
     GlyphRegion const & g = m_metrics[i];
@@ -501,7 +503,6 @@ bool PathTextLayout::CacheDynamicGeometry(m2::Spline::iterator const & iter, flo
 
     size_t baseIndex = 4 * i;
 
-    glsl::vec4 pivot(glsl::ToVec2(globalPivot), depth, 0.0f);
     buffer[baseIndex + 0] = gpu::TextDynamicVertex(pivot, formingVector + normal * bottomVector + tangent * xOffset);
     buffer[baseIndex + 1] = gpu::TextDynamicVertex(pivot, formingVector + normal * upVector + tangent * xOffset);
     buffer[baseIndex + 2] = gpu::TextDynamicVertex(pivot, formingVector + normal * bottomVector + tangent * (pxSize.x + xOffset));

--- a/drape_frontend/text_layout.hpp
+++ b/drape_frontend/text_layout.hpp
@@ -55,7 +55,7 @@ protected:
 
 class StraightTextLayout : public TextLayout
 {
-  typedef TextLayout TBase;
+  using TBase = TextLayout;
 public:
   StraightTextLayout(strings::UniString const & text,
                      float fontSize,
@@ -82,9 +82,9 @@ private:
 
 class PathTextLayout : public TextLayout
 {
-  typedef TextLayout TBase;
+  using TBase = TextLayout;
 public:
-  PathTextLayout(strings::UniString const & text,
+  PathTextLayout(m2::PointD const & tileCenter, strings::UniString const & text,
                  float fontSize, ref_ptr<dp::TextureManager> textures);
 
   void CacheStaticGeometry(dp::TextureManager::ColorRegion const & colorRegion,
@@ -107,6 +107,8 @@ public:
 
 private:
   static float CalculateTextLength(float textPixelLength);
+
+  m2::PointD m_tileCenter;
 };
 
 class SharedTextLayout

--- a/drape_frontend/text_shape.cpp
+++ b/drape_frontend/text_shape.cpp
@@ -197,7 +197,7 @@ void TextShape::DrawSubStringPlain(StraightTextLayout const & layout, dp::FontDe
   textures->GetColorRegion(font.m_color, color);
   textures->GetColorRegion(font.m_outlineColor, outline);
 
-  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
   layout.Cache(glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ),
                baseOffset, color, staticBuffer, dynamicBuffer);
 
@@ -245,7 +245,7 @@ void TextShape::DrawSubStringOutlined(StraightTextLayout const & layout, dp::Fon
   textures->GetColorRegion(font.m_color, color);
   textures->GetColorRegion(font.m_outlineColor, outline);
 
-  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
+  glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
   layout.Cache(glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ),
                baseOffset, color, outline, staticBuffer, dynamicBuffer);
 

--- a/drape_frontend/text_shape.cpp
+++ b/drape_frontend/text_shape.cpp
@@ -197,7 +197,8 @@ void TextShape::DrawSubStringPlain(StraightTextLayout const & layout, dp::FontDe
   textures->GetColorRegion(font.m_color, color);
   textures->GetColorRegion(font.m_outlineColor, outline);
 
-  layout.Cache(glsl::vec4(glsl::ToVec2(m_basePoint), m_params.m_depth, -m_params.m_posZ),
+  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
+  layout.Cache(glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ),
                baseOffset, color, staticBuffer, dynamicBuffer);
 
   dp::GLState state(gpu::TEXT_PROGRAM, dp::GLState::OverlayLayer);
@@ -244,7 +245,8 @@ void TextShape::DrawSubStringOutlined(StraightTextLayout const & layout, dp::Fon
   textures->GetColorRegion(font.m_color, color);
   textures->GetColorRegion(font.m_outlineColor, outline);
 
-  layout.Cache(glsl::vec4(glsl::ToVec2(m_basePoint), m_params.m_depth, -m_params.m_posZ),
+  glsl::vec2 const pt = glsl::ToVec2(ConvertPt(m_basePoint, m_params.m_tileCenter, kShapeCoordScalar));
+  layout.Cache(glsl::vec4(pt, m_params.m_depth, -m_params.m_posZ),
                baseOffset, color, outline, staticBuffer, dynamicBuffer);
 
   dp::GLState state(gpu::TEXT_OUTLINED_PROGRAM, dp::GLState::OverlayLayer);

--- a/drape_frontend/tile_key.cpp
+++ b/drape_frontend/tile_key.cpp
@@ -1,4 +1,6 @@
 #include "drape_frontend/tile_key.hpp"
+
+#include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/tile_utils.hpp"
 
 #include "indexer/scales.hpp"
@@ -78,6 +80,11 @@ m2::RectD TileKey::GetGlobalRect(bool clipByDataMaxZoom) const
   double const startY = m_y * rectSize;
 
   return m2::RectD (startX, startY, startX + rectSize, startY + rectSize);
+}
+
+math::Matrix<float, 4, 4> TileKey::GetTileBasedModelView(ScreenBase const & screen) const
+{
+  return screen.GetModelView(GetGlobalRect().Center(), kShapeCoordScalar);
 }
 
 string DebugPrint(TileKey const & key)

--- a/drape_frontend/tile_key.hpp
+++ b/drape_frontend/tile_key.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "geometry/rect2d.hpp"
+#include "geometry/screenbase.hpp"
+
+#include "base/matrix.hpp"
 
 namespace df
 {
@@ -23,6 +26,8 @@ struct TileKey
   bool EqualStrict(TileKey const & other) const;
 
   m2::RectD GetGlobalRect(bool clipByDataMaxZoom = true) const;
+
+  math::Matrix<float, 4, 4> GetTileBasedModelView(ScreenBase const & screen) const;
 
   int m_x;
   int m_y;

--- a/drape_frontend/tile_utils.cpp
+++ b/drape_frontend/tile_utils.cpp
@@ -46,4 +46,13 @@ int ClipTileZoomByMaxDataZoom(int zoom)
   return zoom <= upperScale ? zoom : upperScale;
 }
 
+TileKey GetTileKeyByPoint(m2::PointD const & pt, int zoom)
+{
+  ASSERT_GREATER(zoom, 0, ());
+  double const range = MercatorBounds::maxX - MercatorBounds::minX;
+  double const rectSize = range / (1 << (zoom - 1));
+  return TileKey(static_cast<int>(floor(pt.x / rectSize)),
+                 static_cast<int>(floor(pt.y / rectSize)), zoom);
+}
+
 } // namespace df

--- a/drape_frontend/tile_utils.hpp
+++ b/drape_frontend/tile_utils.hpp
@@ -28,4 +28,7 @@ bool IsNeighbours(TileKey const & tileKey1, TileKey const & tileKey2);
 /// This function performs clipping by maximum zoom label available for map data.
 int ClipTileZoomByMaxDataZoom(int zoom);
 
+/// This function returns tile key by point on specific zoom level.
+TileKey GetTileKeyByPoint(m2::PointD const & pt, int zoom);
+
 } // namespace df

--- a/drape_frontend/user_mark_shapes.hpp
+++ b/drape_frontend/user_mark_shapes.hpp
@@ -12,12 +12,22 @@
 
 namespace df
 {
-  TileKey GetSearchTileKey();
-  TileKey GetApiTileKey();
-  TileKey GetDebugTileKey();
-  TileKey GetBookmarkTileKey(size_t categoryIndex);
-  bool IsUserMarkLayer(TileKey const & tileKey);
 
-  void CacheUserMarks(UserMarksProvider const * provider, ref_ptr<dp::Batcher> batcher,
-                      ref_ptr<dp::TextureManager> textures);
+struct UserMarkShape
+{
+  dp::GLState m_state;
+  drape_ptr<dp::RenderBucket> m_bucket;
+  TileKey m_tileKey;
+
+  UserMarkShape(dp::GLState const & state, drape_ptr<dp::RenderBucket> && bucket,
+                TileKey const & tileKey)
+    : m_state(state), m_bucket(move(bucket)), m_tileKey(tileKey)
+  {}
+};
+
+using TUserMarkShapes = vector<UserMarkShape>;
+
+TUserMarkShapes CacheUserMarks(UserMarksProvider const * provider,
+                               ref_ptr<dp::TextureManager> textures);
+
 } // namespace df

--- a/drape_head/testing_engine.cpp
+++ b/drape_head/testing_engine.cpp
@@ -506,8 +506,8 @@ void TestingEngine::DrawImpl()
   }
 
   {
-    vector<m2::PointF> trg{ m2::PointD(110.0f, 30.0f), m2::PointD(112.0f, 30.0f), m2::PointD(112.0f, 28.0f),
-                            m2::PointD(110.0f, 30.0f), m2::PointD(112.0f, 28.0f), m2::PointD(110.0f, 28.0f) };
+    vector<m2::PointD> trg{ m2::PointD(110.0, 30.0), m2::PointD(112.0, 30.0), m2::PointD(112.0, 28.0),
+                            m2::PointD(110.0, 30.0), m2::PointD(112.0, 28.0), m2::PointD(110.0, 28.0) };
     vector<df::BuildingEdge> edges;
     AreaViewParams p;
     p.m_color = dp::Color::White();

--- a/geometry/screenbase.cpp
+++ b/geometry/screenbase.cpp
@@ -509,3 +509,24 @@ bool ScreenBase::IsReverseProjection3d(m2::PointD const & pt) const
   Vector3dT const perspectivePoint = normalizedPoint * m_Pto3d;
   return perspectivePoint(0, 3) < 0.0;
 }
+
+ScreenBase::Matrix3dT ScreenBase::GetModelView() const
+{
+  return ScreenBase::Matrix3dT { m_GtoP(0, 0), m_GtoP(1, 0), 0, m_GtoP(2, 0),
+                                 m_GtoP(0, 1), m_GtoP(1, 1), 0, m_GtoP(2, 1),
+                                 0, 0, 1, 0,
+                                 0, 0, 0, 1 };
+}
+
+ScreenBase::Matrix3dT ScreenBase::GetModelView(m2::PointD const & pivot, double scalar) const
+{
+  MatrixT const & m = m_GtoP;
+  double const s = 1.0 / scalar;
+  return ScreenBase::Matrix3dT
+  {
+    s * m(0, 0), s * m(1, 0), 0, m(2, 0) + pivot.x * m(0, 0) + pivot.y * m(1, 0),
+    s * m(0, 1), s * m(1, 1), 0, m(2, 1) + pivot.x * m(0, 1) + pivot.y * m(1, 1),
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  };
+}

--- a/geometry/screenbase.cpp
+++ b/geometry/screenbase.cpp
@@ -512,10 +512,13 @@ bool ScreenBase::IsReverseProjection3d(m2::PointD const & pt) const
 
 ScreenBase::Matrix3dT ScreenBase::GetModelView() const
 {
-  return ScreenBase::Matrix3dT { m_GtoP(0, 0), m_GtoP(1, 0), 0, m_GtoP(2, 0),
-                                 m_GtoP(0, 1), m_GtoP(1, 1), 0, m_GtoP(2, 1),
-                                 0, 0, 1, 0,
-                                 0, 0, 0, 1 };
+  return ScreenBase::Matrix3dT
+  {
+    m_GtoP(0, 0), m_GtoP(1, 0), 0, m_GtoP(2, 0),
+    m_GtoP(0, 1), m_GtoP(1, 1), 0, m_GtoP(2, 1),
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  };
 }
 
 ScreenBase::Matrix3dT ScreenBase::GetModelView(m2::PointD const & pivot, double scalar) const

--- a/geometry/screenbase.hpp
+++ b/geometry/screenbase.hpp
@@ -165,6 +165,9 @@ public:
   m2::RectD CalculatePixelRect(double scale) const;
   double CalculatePerspectiveAngle(double scale) const;
 
+  Matrix3dT GetModelView() const;
+  Matrix3dT GetModelView(m2::PointD const & pivot, double scalar) const;
+
   static double CalculateAutoPerspectiveAngle(double scale);
 
   /// Compute arbitrary pixel transformation, that translates the (oldPt1, oldPt2) -> (newPt1, newPt2)

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -136,7 +136,7 @@ public:
   };
 
   BookmarkCategory(string const & name, Framework & framework);
-  ~BookmarkCategory();
+  ~BookmarkCategory() override;
 
   size_t GetUserLineCount() const override;
   df::UserLineMark const * GetUserLineMark(size_t index) const override;

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -148,7 +148,7 @@ size_t BookmarkManager::LastEditedBMCategory()
   }
 
   if (m_categories.empty())
-    m_categories.push_back(new BookmarkCategory(m_framework.GetStringsBundle().GetString("my_places"), m_framework));
+    CreateBmCategory(m_framework.GetStringsBundle().GetString("my_places"));
 
   return 0;
 }


### PR DESCRIPTION
Теперь при рендеринге каждый тайл карты становится локальной системой координат для геометрии, принадлежащей этому тайлу. Это позволило убрать почти все хаки с точностью float. Работает для всего кроме usermarks, для них придется делать отдельное решение, так как они не привязываются к тайлам.