### PR TITLE
Crash fix in CheckUTurnOnRoute

### DIFF
--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -281,4 +281,22 @@ namespace
     TEST_EQUAL(result, IRouter::NoError, ());
     TEST_LESS(route.GetTotalTimeSec(), numeric_limits<uint32_t>::max() / 2, ());
   }
+
+// There are road ids in osrm which don't have appropriate features ids in mwm.
+// When the route goes through such osrm id a code line with LOG(LERROR, ... is executed:
+// on route reconstruction stage. As a result some item of |segments| vector could have an empty |m_path|.
+// This test shows such case. It's commented because if to uncomment it debug version of
+// routing_integration_tests would crash.
+//  UNIT_TEST(RussiaSpbPloschadBekhterevaToKomendantskiyProspekt)
+//  {
+//    TRouteResult const routeResult = integration::CalculateRoute(
+//        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(59.90126, 30.39970), {0., 0.},
+//        MercatorBounds::FromLatLon(60.02499, 30.23889));
+
+//    Route const & route = *routeResult.first;
+//    IRouter::ResultCode const result = routeResult.second;
+//    TEST_EQUAL(result, IRouter::NoError, ());
+
+//    integration::TestRouteTime(route, 1364.0);
+//  }
 }  // namespace

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -283,11 +283,9 @@ namespace
   }
 
   // There are road ids in osrm which don't have appropriate features ids in mwm.
-  // When the route goes through such osrm id a code line with LOG(LERROR, ... is executed:
-  // on route reconstruction stage. As a result some item of |segments| vector could have an empty
-  // |m_path|.
-  // This test shows such case. It's commented because if to uncomment it debug version of
-  // routing_integration_tests would crash.
+  // When the route goes through such osrm id a code line with LOG(LERROR, ...) is executed
+  // on route reconstruction stage. As a result some items of |segments| vector could have an empty
+  // |m_path|. This test shows such case.
   //  UNIT_TEST(RussiaSpbPloschadBekhterevaToKomendantskiyProspekt)
   //  {
   //    TRouteResult const routeResult = integration::CalculateRoute(

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -282,21 +282,23 @@ namespace
     TEST_LESS(route.GetTotalTimeSec(), numeric_limits<uint32_t>::max() / 2, ());
   }
 
-// There are road ids in osrm which don't have appropriate features ids in mwm.
-// When the route goes through such osrm id a code line with LOG(LERROR, ... is executed:
-// on route reconstruction stage. As a result some item of |segments| vector could have an empty |m_path|.
-// This test shows such case. It's commented because if to uncomment it debug version of
-// routing_integration_tests would crash.
-//  UNIT_TEST(RussiaSpbPloschadBekhterevaToKomendantskiyProspekt)
-//  {
-//    TRouteResult const routeResult = integration::CalculateRoute(
-//        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(59.90126, 30.39970), {0., 0.},
-//        MercatorBounds::FromLatLon(60.02499, 30.23889));
+  // There are road ids in osrm which don't have appropriate features ids in mwm.
+  // When the route goes through such osrm id a code line with LOG(LERROR, ... is executed:
+  // on route reconstruction stage. As a result some item of |segments| vector could have an empty
+  // |m_path|.
+  // This test shows such case. It's commented because if to uncomment it debug version of
+  // routing_integration_tests would crash.
+  //  UNIT_TEST(RussiaSpbPloschadBekhterevaToKomendantskiyProspekt)
+  //  {
+  //    TRouteResult const routeResult = integration::CalculateRoute(
+  //        integration::GetOsrmComponents(), MercatorBounds::FromLatLon(59.90126, 30.39970), {0.,
+  //        0.},
+  //        MercatorBounds::FromLatLon(60.02499, 30.23889));
 
-//    Route const & route = *routeResult.first;
-//    IRouter::ResultCode const result = routeResult.second;
-//    TEST_EQUAL(result, IRouter::NoError, ());
+  //    Route const & route = *routeResult.first;
+  //    IRouter::ResultCode const result = routeResult.second;
+  //    TEST_EQUAL(result, IRouter::NoError, ());
 
-//    integration::TestRouteTime(route, 1364.0);
-//  }
+  //    integration::TestRouteTime(route, 1364.0);
+  //  }
 }  // namespace

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -668,6 +668,8 @@ size_t CheckUTurnOnRoute(TUnpackedPathSegments const & segments,
   auto const & masterSegment = segments[currentSegment - 1];
   if (masterSegment.m_path.size() < 2)
     return 0;
+  if (segments[currentSegment].m_path.empty())
+    return 0;
   // Roundabout is not the UTurn.
   if (masterSegment.m_onRoundabout)
     return 0;

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -668,14 +668,16 @@ size_t CheckUTurnOnRoute(TUnpackedPathSegments const & segments,
   auto const & masterSegment = segments[currentSegment - 1];
   if (masterSegment.m_path.size() < 2)
     return 0;
-  if (segments[currentSegment].m_path.empty())
-    return 0;
+
   // Roundabout is not the UTurn.
   if (masterSegment.m_onRoundabout)
     return 0;
   for (size_t i = 0; i < kUTurnLookAhead && i + currentSegment < segments.size(); ++i)
   {
     auto const & checkedSegment = segments[currentSegment + i];
+    if (checkedSegment.m_path.size() < 2)
+      return 0;
+
     if (checkedSegment.m_name == masterSegment.m_name &&
         checkedSegment.m_highwayClass == masterSegment.m_highwayClass &&
         checkedSegment.m_isLink == masterSegment.m_isLink && !checkedSegment.m_onRoundabout)

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -130,9 +130,10 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
 void GetTurnDirection(IRoutingResult const & result, turns::TurnInfo & turnInfo, TurnItem & turn);
 
 /*!
- * \brief Finds an UTurn that starts from current segment and returns how many segments it lasts.
- * Returns 0 if there is no UTurn.
- * Warning! currentSegment must be greater than 0.
+ * \brief Finds an U-turn that starts from master segment and returns how many segments it lasts.
+ * \returns an index in |segments| that has the opposite direction with master segment
+ * (|segments[currentSegment - 1]|) and 0 if there is no UTurn.
+ * \warning |currentSegment| must be greater than 0.
  */
 size_t CheckUTurnOnRoute(TUnpackedPathSegments const & segments,
                          size_t currentSegment, TurnItem & turn);


### PR DESCRIPTION
Крешфис при построении маршрута на карте Санкт-Петербурга. (В CheckUTurnOnRoute)
https://jira.mail.ru/browse/MAPSME-1716

@ygorshenin @mpimenov PTAL