### PR TITLE
Android. RoutingController crash fix.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -116,7 +116,8 @@ public class RoutingController
             mCachedRoutingInfo = Framework.nativeGetRouteFollowingInfo();
             setBuildState(BuildState.BUILT);
             mLastBuildProgress = 100;
-            mContainer.onRouteBuilt(mLastRouterType);
+            if (mContainer != null)
+              mContainer.onRouteBuilt(mLastRouterType);
           }
 
           processRoutingEvent();


### PR DESCRIPTION
Исправил.
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/57e3270f0aeb16625b938043

Мы падали, если приходил какой-нибудь Routing Event когда приложение находилось в background.

@alexzatsepin  @trashkalmar @yunikkk PTAL