### PR TITLE
[Android] EAT display in navigation mode change when switching between landscape/portrait.

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -124,6 +124,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private PlacePageView mPlacePage;
 
   private RoutingPlanInplaceController mRoutingPlanInplaceController;
+  @Nullable
   private NavigationController mNavigationController;
 
   private MainMenu mMainMenu;
@@ -768,6 +769,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
         fragment.saveAltitudeChartState(outState);
     }
 
+    if (mNavigationController != null)
+      mNavigationController.onSaveState(outState);
+
     RoutingController.get().onSaveState();
     super.onSaveInstanceState(outState);
   }
@@ -782,6 +786,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (!mIsFragmentContainer && RoutingController.get().isPlanning())
       mRoutingPlanInplaceController.restoreState(savedInstanceState);
+
+    if (mNavigationController != null)
+      mNavigationController.onRestoreState(savedInstanceState);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.View;
@@ -31,6 +33,8 @@ import com.mapswithme.util.statistics.Statistics;
 
 public class NavigationController
 {
+  private static final String STATE_SHOW_TIME_LEFT = "ShowTimeLeft";
+
   private final View mFrame;
   private final View mBottomFrame;
   private final NavMenu mNavMenu;
@@ -281,4 +285,15 @@ public class NavigationController
   {
     return mNavMenu;
   }
+
+  public void onSaveState(@NonNull Bundle outState)
+  {
+    outState.putBoolean(STATE_SHOW_TIME_LEFT, mShowTimeLeft);
+  }
+
+  public void onRestoreState(@NonNull Bundle savedInstanceState)
+  {
+    mShowTimeLeft = savedInstanceState.getBoolean(STATE_SHOW_TIME_LEFT);
+  }
+
 }


### PR DESCRIPTION
When i change the EAT information to display the arrival hour and i switch the ui into landscape/portait mode, the EAT information go back to display the remaining time.

Example : 
![device-2016-09-23-164426](https://cloud.githubusercontent.com/assets/16467651/18790233/4b0426cc-81ae-11e6-93ce-e9c77a93ce0d.png)

[Only under Android]
