### PR TITLE
fix tile text disappearing in DRAW_TILE_NET mode

### DIFF
--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -294,7 +294,7 @@ void RuleDrawer::operator()(FeatureType const & f)
                      strings::to_string(key.m_zoomLevel);
 
   tp.m_primaryTextFont = dp::FontDecl(dp::Color::Red(), 30);
-
+  tp.m_primaryOffset = {0.f, 0.f};
   drape_ptr<TextShape> textShape = make_unique_dp<TextShape>(r.Center(), tp, false, 0, false);
   textShape->DisableDisplacing();
   insertShape(move(textShape));


### PR DESCRIPTION
Point<float> not init any fields in default constructor,
so TextViewParams::m_primaryOffset can have any value
(depending on previous stack content), which leads to
captions disappearing in DRAW_TILE_NET debug mode.
