### PR TITLE
fix build with clang/libcxx on linux

### DIFF
--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -561,7 +561,7 @@ void PathTextLayout::CalculatePositions(vector<float> & offsets, float splineLen
   }
   else
   {
-    double const textCount = max(floor(pathLength / minPeriodSize), 1.0);
+    double const textCount = max(floor(static_cast<double>(pathLength / minPeriodSize)), 1.0);
     double const glbTextLen = splineLength / textCount;
     for (double offset = 0.5 * glbTextLen; offset < splineLength; offset += glbTextLen)
       offsets.push_back(offset);


### PR DESCRIPTION
This closes #3807 issue. Because of clang/libcxx 3.8 have overload of
`floor` function in math.h for `float` and `double` we got compilation
error, but obvious fix:
1.0 -> 1.0f
not works, because of at least on Android we have no `floor(float)`
overload. So to fix build force usage of floor(double) which exists on every platform.