### PR TITLE
Clear editable map object before editing

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2835,6 +2835,7 @@ bool Framework::GetEditableMapObject(FeatureID const & fid, osm::EditableMapObje
 
   GetPlatform().SendMarketingEvent("EditorEdit_start", {});
 
+  emo = {};
   emo.SetFromFeatureType(ft);
   emo.SetHouseNumber(ft.GetHouseNumber());
   auto const & editor = osm::Editor::Instance();


### PR DESCRIPTION
В андройде не отключался продвинутый режим редактирования имен, т.к. в ядре не очищался EditableMapObject перед редактированием, а в андройде используется один глобальный EditableMapObject, который, как оказалось, тоже не очищается.
https://jira.mail.ru/browse/MAPSME-2506
https://jira.mail.ru/browse/MAPSME-2507
