### PR TITLE
Luxembourg languages

### DIFF
--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -434,7 +434,7 @@
  "languages": ["lt"]
 },
 "Luxembourg": {
- "languages": ["fr"]
+ "languages": ["fr", "lb", "de", "en"]
 },
 "Macedonia": {
  "languages": ["mk"]

--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -434,7 +434,7 @@
  "languages": ["lt"]
 },
 "Luxembourg": {
- "languages": ["fr", "lb", "de", "en"]
+ "languages": ["fr"]
 },
 "Macedonia": {
  "languages": ["mk"]


### PR DESCRIPTION
Languages for Luxembourg, as requested in https://www.openstreetmap.org/user/Zverik/diary/39637

French, Luxembourgish and German are the country's official languages, ordered by frequency of usage in place names. Luxembourg is a pretty international place, and some places have English names, e.g. the European Court of Justice.