### PR TITLE
[tracking] Fix build on mac os

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -190,7 +190,7 @@ win32-g++ {
 
 macx-* {
   QMAKE_LFLAGS *= -dead_strip
-  LIBS *= "-framework Foundation"
+  LIBS *= "-framework Foundation" "-framework CFNetwork"
 
 #  macx-clang {
 #    QMAKE_CFLAGS_RELEASE -= -O3

--- a/tracking/tracking_tests/tracking_tests.pro
+++ b/tracking/tracking_tests/tracking_tests.pro
@@ -7,7 +7,7 @@ ROOT_DIR = ../..
 
 INCLUDEPATH *= $$ROOT_DIR/3party/jansson/src
 
-DEPENDENCIES = routing tracking platform_tests_support platform coding geometry base stats_client
+DEPENDENCIES = routing tracking platform_tests_support platform coding geometry base stats_client tomcrypt
 
 include($$ROOT_DIR/common.pri)
 


### PR DESCRIPTION
Теперь у нас сокеты в платформе, что потребовало подключить библиотеку `CFNetwork`. Ну и забыли одну зависимость в tracking.