### PR TITLE
Fixed hotel bookmark color appearance after app restart

### DIFF
--- a/map/api_mark_point.cpp
+++ b/map/api_mark_point.cpp
@@ -5,9 +5,9 @@
 namespace style
 {
 
-char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",  "placemark-purple",
-                                   "placemark-yellow", "placemark-pink",  "placemark-brown",
-                                   "placemark-green",  "placemark-orange"};
+char const * kSupportedColors[] = {"placemark-red",    "placemark-blue",    "placemark-purple",
+                                   "placemark-yellow", "placemark-pink",    "placemark-brown",
+                                   "placemark-green",  "placemark-orange",  "placemark-hotel"};
 
 string GetSupportedStyle(string const & s, string const & context, string const & fallback)
 {


### PR DESCRIPTION
Fixed issue, when bookmark with "hotel" color become red after app restart

100% reproducing on iOS, should reproduce on Android too:
1. Create bookmark.
2. Set bookmark color "hotel".
3. Save it.
4. Restart app.

Expected result: Created bookmark has "hotel" color
Actual result: It has red color
