### PR TITLE
[opentable] Ignore opentable and other sponsored types in PP

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -89,6 +89,7 @@ public:
       { "psurface" },
       { "internet_access" },
       { "wheelchair" },
+      { "sponsored" },
     };
 
     AddTypes(arr1);
@@ -101,7 +102,6 @@ public:
       { "amenity", "shelter" },
       { "building", "address" },
       { "building", "has_parts" },
-      { "sponsored", "booking" },
     };
 
     AddTypes(arr2);


### PR DESCRIPTION
MAPSME-2862

Раньше игнорировали только букинг, теперь не отображаем в РР любые типы из ветки `sponsored`.