### PR TITLE
[android] Added clearing the banners when search returns nothing

### DIFF
--- a/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
+++ b/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
@@ -740,7 +740,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
     loadAds();
   }
 
-  void setSearchResultsMode(Collection<CountryItem> results, String query)
+  void setSearchResultsMode(@NonNull Collection<CountryItem> results, String query)
   {
     mSearchResultsMode = true;
     mSearchQuery = query.toLowerCase();
@@ -748,6 +748,18 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
     mItems.clear();
     mItems.addAll(results);
     processData();
+    if (results.isEmpty())
+      clearAds();
+  }
+
+  private void clearAds()
+  {
+    if (mAds.isEmpty())
+      return;
+
+    mAds.clear();
+    mAdsLoaded = false;
+    notifyDataSetChanged();
   }
 
   void resetSearchResultsMode()
@@ -1009,7 +1021,6 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
             mAdsLoading = false;
             mAdsLoaded = true;
 
-            int oldSize = mAds.size();
             mAds.clear();
 
             if (banners != null)
@@ -1018,10 +1029,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
                   mAds.add(banner);
 
             mHeadersDecoration.invalidateHeaders();
-            if (oldSize == 0)
-              notifyItemRangeInserted(mNearMeCount, mAds.size());
-            else
-              notifyDataSetChanged();
+            notifyDataSetChanged();
           }
         }, mActivity);
       }


### PR DESCRIPTION
@mpimenov  @milchakov PTAL

- Added clearing the banners when search returns nothing (In downloader)
- Fixed the bug when banners are not showing at all

The initial task was - https://jira.mail.ru/browse/MAPSME-2954 