### PR TITLE
[generator] Do not copy int_name from relations

### DIFF
--- a/generator/osm_translator.hpp
+++ b/generator/osm_translator.hpp
@@ -188,7 +188,7 @@ protected:
         TBase::AddCustomTag({"addr:street", p.second});
 
       // Important! Skip all "name" tags.
-      if (strings::StartsWith(p.first, "name"))
+      if (strings::StartsWith(p.first, "name") || p.first == "int_name")
         continue;
 
       if (!isBoundary && p.first == "boundary")


### PR DESCRIPTION
MAPSME-2900

Просачивались названия улиц в названия домов в некоторых городах.