### PR TITLE
[editor] Fix localized street names when editing

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2738,7 +2738,10 @@ WARN_UNUSED_RESULT bool LocalizeStreet(Index const & index, FeatureID const & fi
   if (!g.GetFeatureByIndex(fid.m_index, ft))
     return false;
 
-  ft.GetPreferredNames(result.m_defaultName, result.m_localizedName);
+  ft.GetName(StringUtf8Multilang::kDefaultCode, result.m_defaultName);
+  ft.GetReadableName(result.m_localizedName);
+  if (result.m_localizedName == result.m_defaultName)
+    result.m_localizedName.clear();
   return true;
 }
 


### PR DESCRIPTION
«Я сейчас на нескольких зданиях проставил этажность. На тех зданиях, у чьей улицы был name:en и name, без name:ru, addr:street заменился на англоязычный.»

https://editor-api.maps.me/?changeset=43911578

Кажется, я нашёл причину (больше не меняем языки primary и secondary). Проверил на устройстве. @milchakov 