### PR TITLE
[routing] Applying restrictions on index graph

### DIFF
--- a/generator/generator_tests/restriction_collector_test.cpp
+++ b/generator/generator_tests/restriction_collector_test.cpp
@@ -5,7 +5,7 @@
 #include "generator/osm_id.hpp"
 #include "generator/restriction_collector.hpp"
 
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 #include "platform/platform_tests_support/scoped_dir.hpp"
 #include "platform/platform_tests_support/scoped_file.hpp"

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 #include "std/functional.hpp"
 #include "std/limits.hpp"

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -4,7 +4,7 @@
 #include "generator/osm_id.hpp"
 #include "generator/restriction_collector.hpp"
 
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 #include "base/logging.hpp"
 

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -118,7 +118,7 @@ bool BuildRoutingIndex(string const & filename, string const & country)
     auto const sectionSize = writer.Pos() - startPos;
 
     LOG(LINFO, ("Routing section created:", sectionSize, "bytes,", graph.GetNumRoads(), "roads,",
-                graph.GetNumJoints(), "joints,", graph.GetNumPoints(), "points"));
+                graph.GetNumJoints(), "joints,", graph.GetNumStaticPoints(), "points"));
     return true;
   }
   catch (RootException const & e)

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -68,6 +68,8 @@ set(
   pedestrian_model.hpp
   restriction_loader.cpp
   restriction_loader.hpp
+  restrictions_serialization.cpp
+  restrictions_serialization.hpp
   road_graph.cpp
   road_graph.hpp
   road_graph_router.cpp
@@ -89,8 +91,6 @@ set(
   routing_mapping.cpp
   routing_mapping.hpp
   routing_result_graph.hpp
-  routing_serialization.cpp
-  routing_serialization.hpp
   routing_session.cpp
   routing_session.hpp
   routing_settings.hpp

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -6,6 +6,7 @@
 
 #include "base/assert.hpp"
 
+#include "std/sstream.hpp"
 #include "std/string.hpp"
 
 using namespace routing;
@@ -94,5 +95,15 @@ unique_ptr<GeometryLoader> GeometryLoader::Create(Index const & index, MwmSet::M
   CHECK(mwmId.IsAlive(), ());
   return make_unique<GeometryLoaderImpl>(index, mwmId, mwmId.GetInfo()->GetCountryName(),
                                          vehicleModel);
+}
+
+string DebugPrint(RoadGeometry const & roadGeometry)
+{
+  ostringstream oss;
+  oss << "RoadGeometry [ m_isOneWay: " << roadGeometry.m_isOneWay
+      << ", m_speed: " << roadGeometry.m_speed
+      << ", m_points: " << DebugPrint(roadGeometry.m_points) << " ]";
+
+  return oss.str();
 }
 }  // namespace routing

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -11,6 +11,7 @@
 
 #include "std/cstdint.hpp"
 #include "std/shared_ptr.hpp"
+#include "std/string.hpp"
 #include "std/unique_ptr.hpp"
 
 namespace routing
@@ -37,12 +38,21 @@ public:
   }
 
   uint32_t GetPointsCount() const { return m_points.size(); }
+  bool operator==(RoadGeometry const & roadGeometry) const
+  {
+    return m_isOneWay == roadGeometry.m_isOneWay && m_speed == roadGeometry.m_speed &&
+           m_points == roadGeometry.m_points;
+  }
 
 private:
+  friend string DebugPrint(RoadGeometry const & roadGeometry);
+
   Points m_points;
   double m_speed = 0.0;
   bool m_isOneWay = false;
 };
+
+string DebugPrint(RoadGeometry const & roadGeometry);
 
 class GeometryLoader
 {
@@ -63,11 +73,6 @@ public:
   explicit Geometry(unique_ptr<GeometryLoader> loader);
 
   RoadGeometry const & GetRoad(uint32_t featureId);
-
-  m2::PointD const & GetPoint(RoadPoint const & rp)
-  {
-    return GetRoad(rp.GetFeatureId()).GetPoint(rp.GetPointId());
-  }
 
 private:
   // Feature id to RoadGeometry map.

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -1,37 +1,544 @@
-#include "index_graph.hpp"
+#include "routing/index_graph.hpp"
+
+#include "routing/routing_exceptions.hpp"
 
 #include "base/assert.hpp"
 #include "base/exception.hpp"
+#include "base/stl_helpers.hpp"
 
 #include "std/limits.hpp"
 
 namespace routing
 {
+// DirectedEdge ----------------------------------------------------------------
+bool DirectedEdge::operator<(DirectedEdge const & rhs) const
+{
+  if (m_from != rhs.m_from)
+    return m_from < rhs.m_from;
+
+  if (m_to != rhs.m_to)
+    return m_to < rhs.m_to;
+
+  return m_featureId < rhs.m_featureId;
+}
+
+bool DirectedEdge::operator==(DirectedEdge const & rhs) const
+{
+  return m_from == rhs.m_from && m_to == rhs.m_to && m_featureId == rhs.m_featureId;
+}
+
+// RestrictionInfo -------------------------------------------------------------
+bool RestrictionInfo::operator<(RestrictionInfo const & rhs) const
+{
+  if (m_from != rhs.m_from)
+    return m_from < rhs.m_from;
+
+  if (m_center != rhs.m_center)
+    return m_center < rhs.m_center;
+
+  if (m_to != rhs.m_to)
+    return m_to < rhs.m_to;
+
+  if (m_fromFeatureId != rhs.m_fromFeatureId)
+    return m_fromFeatureId < rhs.m_fromFeatureId;
+
+  return m_toFeatureId < rhs.m_toFeatureId;
+}
+
+// IndexGraph ------------------------------------------------------------------
 IndexGraph::IndexGraph(unique_ptr<GeometryLoader> loader, shared_ptr<EdgeEstimator> estimator)
   : m_geometry(move(loader)), m_estimator(move(estimator))
 {
   ASSERT(m_estimator, ());
 }
 
-void IndexGraph::GetEdgeList(Joint::Id jointId, bool isOutgoing, vector<JointEdge> & edges)
+void IndexGraph::GetEdgeList(Joint::Id jointId, bool isOutgoing, bool graphWithoutRestrictions,
+                             vector<JointEdge> & edges)
 {
-  m_jointIndex.ForEachPoint(jointId, [this, &edges, isOutgoing](RoadPoint const & rp) {
-    GetNeighboringEdges(rp, isOutgoing, edges);
+  m_jointIndex.ForEachPoint(jointId, [&](RoadPoint const & rp) {
+    GetNeighboringEdges(rp, isOutgoing, graphWithoutRestrictions, edges);
   });
+}
+
+void IndexGraph::GetEdgeList(Joint::Id jointId, bool isOutgoing, bool graphWithoutRestrictions,
+                             vector<DirectedEdge> & edges)
+{
+  vector<JointEdge> jointEdges;
+  GetEdgeList(jointId, isOutgoing, graphWithoutRestrictions, jointEdges);
+
+  auto const fillEdges = [&](Joint::Id from, Joint::Id to) {
+    vector<pair<RoadPoint, RoadPoint>> result;
+    m_jointIndex.FindPointsWithCommonFeature(from, to, result);
+    for (auto const & p : result)
+      edges.emplace_back(from, to, p.first.GetFeatureId());
+  };
+
+  for (JointEdge const & e : jointEdges)
+  {
+    if (isOutgoing)
+      fillEdges(jointId, e.GetTarget());
+    else
+      fillEdges(e.GetTarget(), jointId);
+  }
+}
+
+m2::PointD const & IndexGraph::GetPoint(RoadPoint const & rp)
+{
+  RoadGeometry const & road = GetRoad(rp.GetFeatureId());
+  CHECK_LESS(rp.GetPointId(), road.GetPointsCount(), ());
+  return road.GetPoint(rp.GetPointId());
 }
 
 m2::PointD const & IndexGraph::GetPoint(Joint::Id jointId)
 {
-  return m_geometry.GetPoint(m_jointIndex.GetPoint(jointId));
+  return GetPoint(m_jointIndex.GetPoint(jointId));
 }
 
+double IndexGraph::GetSpeed(RoadPoint const & rp) { return GetRoad(rp.GetFeatureId()).GetSpeed(); }
 void IndexGraph::Build(uint32_t numJoints) { m_jointIndex.Build(m_roadIndex, numJoints); }
 
 void IndexGraph::Import(vector<Joint> const & joints)
 {
-  m_roadIndex.Import(joints);
   CHECK_LESS_OR_EQUAL(joints.size(), numeric_limits<uint32_t>::max(), ());
+  m_roadIndex.Import(joints);
   Build(static_cast<uint32_t>(joints.size()));
+}
+
+void IndexGraph::GetSingleFeaturePath(RoadPoint const & from, RoadPoint const & to,
+                                      vector<RoadPoint> & path)
+{
+  CHECK_EQUAL(from.GetFeatureId(), to.GetFeatureId(), ());
+
+  path.clear();
+  int const shift = to.GetPointId() > from.GetPointId() ? 1 : -1;
+  for (int i = from.GetPointId(); i != to.GetPointId(); i += shift)
+    path.emplace_back(from.GetFeatureId(), i);
+  path.push_back(to);
+}
+
+void IndexGraph::GetConnectionPaths(Joint::Id from, Joint::Id to,
+                                    vector<vector<RoadPoint>> & connectionPaths)
+{
+  CHECK_NOT_EQUAL(from, Joint::kInvalidId, ());
+  CHECK_NOT_EQUAL(to, Joint::kInvalidId, ());
+
+  connectionPaths.clear();
+  vector<pair<RoadPoint, RoadPoint>> connections;
+  m_jointIndex.FindPointsWithCommonFeature(from, to, connections);
+
+  connectionPaths.reserve(connections.size());
+  for (auto const & c : connections)
+  {
+    connectionPaths.emplace_back();
+    GetSingleFeaturePath(c.first /* from */, c.second /* to */, connectionPaths.back());
+  }
+}
+
+void IndexGraph::GetFeatureConnectionPath(Joint::Id from, Joint::Id to, uint32_t featureId,
+                                          vector<RoadPoint> & path)
+{
+  path.clear();
+  vector<pair<RoadPoint, RoadPoint>> connections;
+  m_jointIndex.FindPointsWithCommonFeature(from, to, connections);
+
+  for (auto const & c : connections)
+  {
+    CHECK_EQUAL(c.first.GetFeatureId(), c.second.GetFeatureId(), ());
+    if (c.first.GetFeatureId() == featureId)
+    {
+      GetSingleFeaturePath(c.first /* from */, c.second /* to */, path);
+      return;
+    }
+  }
+}
+
+void IndexGraph::GetOutgoingGeomEdges(vector<JointEdge> const & outgoingEdges, Joint::Id center,
+                                      vector<JointEdgeGeom> & outgoingGeomEdges)
+{
+  for (JointEdge const & e : outgoingEdges)
+  {
+    vector<vector<RoadPoint>> connectionPaths;
+    GetConnectionPaths(center, e.GetTarget(), connectionPaths);
+    if (connectionPaths.empty())
+    {
+      LOG(LERROR, ("Can't find common feature for joints", center, e.GetTarget()));
+      return;
+    }
+
+    for (auto const & path : connectionPaths)
+    {
+      CHECK(!path.empty(), ());
+      outgoingGeomEdges.emplace_back(e.GetTarget(), path);
+    }
+  }
+}
+
+void IndexGraph::CreateFakeFeatureGeometry(vector<RoadPoint> const & geometrySource, double speed,
+                                           RoadGeometry & geometry)
+{
+  RoadGeometry::Points points(geometrySource.size());
+  for (size_t i = 0; i < geometrySource.size(); ++i)
+    points[i] = GetPoint(geometrySource[i]);
+
+  geometry = RoadGeometry(true /* oneWay */, speed, points);
+}
+
+void IndexGraph::DisableAllEdges(Joint::Id from, Joint::Id to)
+{
+  vector<pair<RoadPoint, RoadPoint>> result;
+  m_jointIndex.FindPointsWithCommonFeature(from, to, result);
+  for (auto const & p : result)
+    DisableEdge(DirectedEdge(from, to, p.first.GetFeatureId()));
+}
+
+uint32_t IndexGraph::AddFakeLooseEndFeature(Joint::Id from,
+                                            vector<RoadPoint> const & geometrySource, double speed)
+{
+  CHECK_LESS(from, m_jointIndex.GetNumJoints(), ());
+  CHECK_GREATER(geometrySource.size(), 1, ());
+
+  // Getting fake feature geometry.
+  RoadGeometry geom;
+  CreateFakeFeatureGeometry(geometrySource, speed, geom);
+  m_fakeFeatureGeometry.insert(make_pair(m_nextFakeFeatureId, geom));
+
+  RoadPoint const fromFakeFtPoint(m_nextFakeFeatureId, 0 /* point id */);
+  m_roadIndex.AddJoint(fromFakeFtPoint, from);
+  m_jointIndex.AppendToJoint(from, fromFakeFtPoint);
+
+  return m_nextFakeFeatureId++;
+}
+
+uint32_t IndexGraph::AddFakeFeature(Joint::Id from, Joint::Id to,
+                                    vector<RoadPoint> const & geometrySource, double speed)
+{
+  CHECK_LESS(from, m_jointIndex.GetNumJoints(), ());
+  CHECK_LESS(to, m_jointIndex.GetNumJoints(), ());
+  CHECK_GREATER(geometrySource.size(), 1, ());
+
+  uint32_t fakeFeatureId = AddFakeLooseEndFeature(from, geometrySource, speed);
+  RoadPoint const toFakeFtPoint(fakeFeatureId, geometrySource.size() - 1 /* point id */);
+  m_roadIndex.AddJoint(toFakeFtPoint, to);
+  m_jointIndex.AppendToJoint(to, toFakeFtPoint);
+
+  return fakeFeatureId;
+}
+
+void IndexGraph::FindOneStepAsideRoadPoint(uint32_t featureId, vector<JointEdge> const & edges,
+                                           vector<Joint::Id> & oneStepAside) const
+{
+  oneStepAside.clear();
+  m_roadIndex.ForEachJoint(featureId, [&](uint32_t /* pointId */, Joint::Id jointId) {
+    for (JointEdge const & e : edges)
+    {
+      if (e.GetTarget() == jointId)
+        oneStepAside.push_back(jointId);
+    }
+  });
+}
+
+bool IndexGraph::GetIngoingAndOutgoingEdges(Joint::Id centerId, bool graphWithoutRestrictions,
+                                            vector<JointEdge> & ingoingEdges,
+                                            vector<JointEdge> & outgoingEdges)
+{
+  ingoingEdges.clear();
+  outgoingEdges.clear();
+  GetEdgeList(centerId, false /* isOutgoing */, graphWithoutRestrictions, ingoingEdges);
+  if (ingoingEdges.empty())
+    return false;
+
+  GetEdgeList(centerId, true /* isOutgoing */, graphWithoutRestrictions, outgoingEdges);
+  if (outgoingEdges.empty())
+    return false;
+  return true;
+}
+
+bool IndexGraph::ApplyRestrictionPrepareData(RestrictionPoint const & restrictionPoint,
+                                             RestrictionInfo & restrictionInfo)
+{
+  vector<JointEdge> ingoingEdges;
+  vector<JointEdge> outgoingEdges;
+
+  GetEdgeList(restrictionPoint.m_centerId, false /* isOutgoing */,
+              true /* graphWithoutRestrictions */, ingoingEdges);
+  vector<Joint::Id> fromOneStepAside;
+  FindOneStepAsideRoadPoint(restrictionPoint.m_from.GetFeatureId(), ingoingEdges, fromOneStepAside);
+  if (fromOneStepAside.empty())
+    return false;
+
+  GetEdgeList(restrictionPoint.m_centerId, true /* isOutgoing */,
+              true /* graphWithoutRestrictions */, outgoingEdges);
+  vector<Joint::Id> toOneStepAside;
+  FindOneStepAsideRoadPoint(restrictionPoint.m_to.GetFeatureId(), outgoingEdges, toOneStepAside);
+  if (toOneStepAside.empty())
+    return false;
+
+  restrictionInfo.m_center = restrictionPoint.m_centerId;
+  restrictionInfo.m_from = fromOneStepAside.back();
+  restrictionInfo.m_to = toOneStepAside.back();
+  restrictionInfo.m_fromFeatureId = restrictionPoint.m_from.GetFeatureId();
+  restrictionInfo.m_toFeatureId = restrictionPoint.m_to.GetFeatureId();
+  return true;
+}
+
+void IndexGraph::ApplyRestrictionNoRealFeatures(RestrictionPoint const & restrictionPoint)
+{
+  ApplyRestrictionRealFeatures(restrictionPoint, [&](RestrictionInfo const & restrictionInfo) {
+    ApplyRestrictionNo(restrictionInfo);
+  });
+}
+
+void IndexGraph::ApplyRestrictionNo(RestrictionInfo const & restrictionInfo)
+{
+  Joint::Id centerId = restrictionInfo.m_center;
+
+  DirectedEdge const from(restrictionInfo.m_from, centerId, restrictionInfo.m_fromFeatureId);
+  DirectedEdge const to(centerId, restrictionInfo.m_to, restrictionInfo.m_toFeatureId);
+  ASSERT_EQUAL(m_blockedEdges.count(from), 0, ());
+  ASSERT_EQUAL(m_blockedEdges.count(to), 0, ());
+
+  vector<JointEdge> ingoingEdges;
+  vector<JointEdge> outgoingEdges;
+  if (!GetIngoingAndOutgoingEdges(centerId, false /* graphWithoutRestrictions */, ingoingEdges,
+                                  outgoingEdges))
+  {
+    return;
+  }
+
+  // One ingoing edge case.
+  if (ingoingEdges.size() == 1)
+  {
+    DisableEdge(to);
+    return;
+  }
+
+  // One outgoing edge case.
+  if (outgoingEdges.size() == 1)
+  {
+    DisableEdge(from);
+    return;
+  }
+
+  // Prohibition of moving from one segment to another in case of any number of ingoing and outgoing
+  // edges.
+  // The idea is to transform the navigation graph for every non-degenerate case as it's shown
+  // below.
+  // At the picture below a restriction for prohibition moving from 4 to O to 3 is shown.
+  // So to implement it it's necessary to remove (disable) an edge 4-O and add features (edges)
+  // 4-N-1 and N-2.
+  //
+  // 1       2       3                     1       2       3
+  // *       *       *                     *       *       *
+  //  ↖     ^     ↗                       ^↖   ↗^     ↗
+  //    ↖   |   ↗                         |  ↖   |   ↗
+  //      ↖ | ↗                           |↗   ↖| ↗
+  //         *  O             ==>        N *       *  O
+  //      ↗ ^ ↖                           ^       ^ ↖
+  //    ↗   |   ↖                         |       |   ↖
+  //  ↗     |     ↖                       |       |     ↖
+  // *       *       *                     *       *       *
+  // 4       5       6                     4       5       6
+  //
+  // In case of this transformation the following edge mapping happens:
+  // 4-O -> 4-N
+  // O-1 -> O-1; N-1
+  // O-2 -> O-2; N-2
+
+  outgoingEdges.erase(
+      remove_if(outgoingEdges.begin(), outgoingEdges.end(),
+                [&](JointEdge const & e) {
+                  // Removing edge N->3 in example above.
+                  return e.GetTarget() == restrictionInfo.m_to
+                         // Preventing from adding in loop below
+                         // cycles |restrictionInfo.m_from|->|centerId|->|restrictionInfo.m_from|.
+                         // @TODO(bykoianko) e.GetTarget() == restrictionInfo.m_from should be
+                         // process correctly.
+                         // It's a common case of U-turn prohibition.
+                         || e.GetTarget() == restrictionInfo.m_from
+                         // Removing edges |centerId|->|centerId|.
+                         || e.GetTarget() == centerId;
+                }),
+      outgoingEdges.end());
+
+  my::SortUnique(outgoingEdges, my::LessBy(&JointEdge::GetTarget),
+                 my::EqualsBy(&JointEdge::GetTarget));
+  // Node. |centerId| could be connected with any outgoing joint with more than one edge (feature).
+  // In GetOutgoingGeomEdges() below is taken into account the case.
+  vector<JointEdgeGeom> outgoingGeomEdges;
+  GetOutgoingGeomEdges(outgoingEdges, centerId, outgoingGeomEdges);
+  if (outgoingGeomEdges.empty())
+    return;
+
+  vector<RoadPoint> ingoingPath;
+  GetFeatureConnectionPath(restrictionInfo.m_from, centerId, restrictionInfo.m_fromFeatureId,
+                           ingoingPath);
+  if (ingoingPath.empty())
+    return;
+
+  if (restrictionInfo.m_from == centerId)
+  {
+    // @TODO(bykoianko) In rare cases it's posible that outgoing edges staring from |centerId|
+    // contain as targets |centerId|. The same thing with ingoing edges.
+    // The most likely it's a consequence of adding
+    // restrictions with type no for some bidirectional roads. It's necessary to
+    // investigate this case, to undestand the reasons of appearing such edges clearly,
+    // prevent appearing of such edges and write unit tests on it.
+    return;
+  }
+
+  JointEdgeGeom ingoingEdge(restrictionInfo.m_from, ingoingPath);
+  CHECK(!ingoingEdge.GetPath().empty(), ());
+
+  Joint::Id newJoint = Joint::kInvalidId;
+  uint32_t ingoingFeatureId = 0;
+  uint32_t outgoingFeatureId = 0;
+  for (auto it = outgoingGeomEdges.cbegin(); it != outgoingGeomEdges.cend(); ++it)
+  {
+    CHECK(!ingoingEdge.GetPath().empty(), ());
+    // Adding features 4->N and N->1 in example above.
+    if (it == outgoingGeomEdges.cbegin())
+    {
+      ASSERT_NOT_EQUAL(centerId, it->GetTarget(), ());
+      // Ingoing edge.
+      ingoingFeatureId =
+          AddFakeLooseEndFeature(restrictionInfo.m_from, ingoingEdge.GetPath(),
+                                 GetRoad(restrictionInfo.m_fromFeatureId).GetSpeed());
+      newJoint =
+          InsertJoint({ingoingFeatureId, static_cast<uint32_t>(ingoingEdge.GetPath().size() - 1)});
+
+      // Edge mapping.
+      InsertToEdgeMapping(from, DirectedEdge(restrictionInfo.m_from, newJoint, ingoingFeatureId));
+    }
+
+    outgoingFeatureId =
+        AddFakeFeature(newJoint, it->GetTarget(), it->GetPath(), GetSpeed(it->GetPath().front()));
+    // Edge mapping.
+    DirectedEdge const toItEdge(centerId, it->GetTarget(), it->GetPath().front().GetFeatureId());
+    InsertToEdgeMapping(toItEdge, DirectedEdge(newJoint, it->GetTarget(), outgoingFeatureId));
+  }
+
+  DisableEdge(from);
+}
+
+void IndexGraph::ApplyRestrictionOnlyRealFeatures(RestrictionPoint const & restrictionPoint)
+{
+  ApplyRestrictionRealFeatures(restrictionPoint, [&](RestrictionInfo const & restrictionInfo) {
+    ApplyRestrictionOnly(restrictionInfo);
+  });
+}
+
+void IndexGraph::ApplyRestrictionOnly(RestrictionInfo const & restrictionInfo)
+{
+  Joint::Id centerId = restrictionInfo.m_center;
+
+  if (restrictionInfo.m_to == centerId || restrictionInfo.m_from == centerId)
+    return;
+
+  vector<JointEdge> ingoingEdges;
+  vector<JointEdge> outgoingEdges;
+  if (!GetIngoingAndOutgoingEdges(centerId, false /* graphWithoutRestrictions */, ingoingEdges,
+                                  outgoingEdges))
+    return;
+
+  // One outgoing edge case.
+  if (outgoingEdges.size() == 1)
+  {
+    return;
+  }
+
+  // One ingoing edge case.
+  if (ingoingEdges.size() == 1)
+  {
+    for (auto const & e : outgoingEdges)
+    {
+      if (e.GetTarget() != restrictionInfo.m_to)
+        DisableAllEdges(centerId, e.GetTarget());
+    }
+    return;
+  }
+
+  // It's possible to move only from one segment to another in case of any number of ingoing and
+  // outgoing edges.
+  // The idea is to tranform the navigation graph for every non-degenerate case as it's shown below.
+  // At the picture below a restriction for permission moving only from 6 to O to 3 is shown.
+  // So to implement it it's necessary to remove (disable) an edge 6-O and add feature (edge) 4-N-3.
+  // Adding N is important for a route recovery stage. (The geometry of O will be copied to N.)
+  //
+  // 1       2       3                     1       2       3
+  // *       *       *                     *       *       *
+  //  ↖     ^     ↗                        ↖     ^     ↗^
+  //    ↖   |   ↗                            ↖   |   ↗  |
+  //      ↖ | ↗                                ↖ | ↗    |
+  //         *  O             ==>                  *  O    * N
+  //      ↗ ^ ↖                                 ↗^       ^
+  //    ↗   |   ↖                             ↗  |       |
+  //  ↗     |     ↖                         ↗    |       |
+  // *       *       *                     *       *       *
+  // 4       5       6                     4       5       6
+  //
+  // In case of this transformation the following edge mapping happens:
+  // 6-O -> 6-N
+  // O-3 -> O-3; N-3
+
+  vector<RoadPoint> ingoingPath;
+  GetFeatureConnectionPath(restrictionInfo.m_from, centerId, restrictionInfo.m_fromFeatureId,
+                           ingoingPath);
+  if (ingoingPath.size() < 2 /* at least two points in path */)
+    return;
+
+  vector<RoadPoint> outgoingPath;
+  GetFeatureConnectionPath(centerId, restrictionInfo.m_to, restrictionInfo.m_toFeatureId,
+                           outgoingPath);
+  if (ingoingPath.size() < 2 /* at least two points in path */)
+    return;
+
+  uint32_t ingoingFeatureId = AddFakeLooseEndFeature(
+      restrictionInfo.m_from, ingoingPath, GetRoad(restrictionInfo.m_fromFeatureId).GetSpeed());
+  Joint::Id newJoint =
+      InsertJoint({ingoingFeatureId, static_cast<uint32_t>(ingoingPath.size() - 1)});
+  uint32_t outgoingFeatureId = AddFakeFeature(newJoint, restrictionInfo.m_to, outgoingPath,
+                                              GetRoad(restrictionInfo.m_toFeatureId).GetSpeed());
+
+  // Edge mapping.
+  DirectedEdge const from(restrictionInfo.m_from, centerId, restrictionInfo.m_fromFeatureId);
+  DirectedEdge const to(centerId, restrictionInfo.m_to, restrictionInfo.m_toFeatureId);
+  InsertToEdgeMapping(from, DirectedEdge(restrictionInfo.m_from, newJoint, ingoingFeatureId));
+  InsertToEdgeMapping(to, DirectedEdge(newJoint, restrictionInfo.m_to, outgoingFeatureId));
+
+  DisableEdge(from);
+}
+
+void IndexGraph::ApplyRestrictions(RestrictionVec const & restrictions)
+{
+  for (Restriction const & restriction : restrictions)
+  {
+    if (restriction.m_featureIds.size() != 2)
+    {
+      LOG(LERROR, ("Only two link restriction are supported. It's a",
+                   restriction.m_featureIds.size(), "-link restriction."));
+      continue;
+    }
+
+    RestrictionPoint restrictionPoint;
+    if (!m_roadIndex.GetRestrictionPoint(restriction.m_featureIds[0], restriction.m_featureIds[1],
+                                         restrictionPoint))
+    {
+      continue;  // Restriction doesn't contain adjacent features.
+    }
+
+    try
+    {
+      switch (restriction.m_type)
+      {
+      case Restriction::Type::No: ApplyRestrictionNoRealFeatures(restrictionPoint); continue;
+      case Restriction::Type::Only: ApplyRestrictionOnlyRealFeatures(restrictionPoint); continue;
+      }
+    }
+    catch (RootException const & e)
+    {
+      LOG(LERROR, ("Exception while applying restrictions. Message:", e.Msg()));
+    }
+  }
 }
 
 Joint::Id IndexGraph::InsertJoint(RoadPoint const & rp)
@@ -57,39 +564,119 @@ bool IndexGraph::JointLiesOnRoad(Joint::Id jointId, uint32_t featureId) const
 }
 
 void IndexGraph::GetNeighboringEdges(RoadPoint const & rp, bool isOutgoing,
-                                     vector<JointEdge> & edges)
+                                     bool graphWithoutRestrictions, vector<JointEdge> & edges)
 {
-  RoadGeometry const & road = m_geometry.GetRoad(rp.GetFeatureId());
+  RoadGeometry const & road = GetRoad(rp.GetFeatureId());
 
   bool const bidirectional = !road.IsOneWay();
   if (!isOutgoing || bidirectional)
-    GetNeighboringEdge(road, rp, false /* forward */, edges);
+    GetNeighboringEdge(road, rp, false /* forward */, isOutgoing, graphWithoutRestrictions, edges);
 
   if (isOutgoing || bidirectional)
-    GetNeighboringEdge(road, rp, true /* forward */, edges);
+    GetNeighboringEdge(road, rp, true /* forward */, isOutgoing, graphWithoutRestrictions, edges);
+}
+
+void IndexGraph::GetIntermediatePointEdges(RoadPoint const & rp, bool graphWithoutRestrictions,
+                                           vector<DirectedEdge> & edges)
+{
+  CHECK_EQUAL(m_roadIndex.GetJointId(rp), Joint::kInvalidId, ());
+
+  edges.clear();
+  vector<JointEdge> forwardEdges;
+  GetNeighboringEdges(rp, true /* isOutgoing */, graphWithoutRestrictions, forwardEdges);
+
+  CHECK_LESS_OR_EQUAL(forwardEdges.size(), 2,
+                      (rp, "is not a joint but it has 3 or more neighboring edges."));
+  if (forwardEdges.empty())
+    return;  // |rp| at a dead end.
+
+  // |fp| is an intermediate point of a one-way feature.
+  if (forwardEdges.size() == 1)
+  {
+    // It's a oneway feature. Looks for a former joint for |fp| on it.
+    vector<JointEdge> backwardEdges;
+    GetNeighboringEdges(rp, false /* isOutgoing */, graphWithoutRestrictions, backwardEdges);
+    if (backwardEdges.empty())
+      return;  // |rp| at the beginning of one way edge.
+    CHECK_EQUAL(backwardEdges.size(), 1, ());
+    edges.emplace_back(backwardEdges[0].GetTarget(), forwardEdges[0].GetTarget(),
+                       rp.GetFeatureId());
+    return;
+  }
+
+  // jointEdges.size() == 2. |fp| is an intermediate point of a two-way feature.
+  edges.emplace_back(forwardEdges[0].GetTarget(), forwardEdges[1].GetTarget(), rp.GetFeatureId());
+  edges.emplace_back(forwardEdges[1].GetTarget(), forwardEdges[0].GetTarget(), rp.GetFeatureId());
 }
 
 void IndexGraph::GetNeighboringEdge(RoadGeometry const & road, RoadPoint const & rp, bool forward,
+                                    bool outgoing, bool graphWithoutRestrictions,
                                     vector<JointEdge> & edges) const
 {
+  if (graphWithoutRestrictions && IsFakeFeature(rp.GetFeatureId()))
+    return;
+
   pair<Joint::Id, uint32_t> const & neighbor = m_roadIndex.FindNeighbor(rp, forward);
-  if (neighbor.first != Joint::kInvalidId)
+  if (neighbor.first == Joint::kInvalidId)
+    return;
+
+  if (!graphWithoutRestrictions)
   {
-    double const distance =
-        m_estimator->CalcEdgesWeight(rp.GetFeatureId(), road, rp.GetPointId(), neighbor.second);
-    edges.push_back({neighbor.first, distance});
+    Joint::Id const rpJointId = m_roadIndex.GetJointId(rp);
+    DirectedEdge const edge = outgoing ? DirectedEdge(rpJointId, neighbor.first, rp.GetFeatureId())
+                                       : DirectedEdge(neighbor.first, rpJointId, rp.GetFeatureId());
+    if (m_blockedEdges.find(edge) != m_blockedEdges.end())
+      return;
   }
+
+  double const distance =
+      m_estimator->CalcEdgesWeight(rp.GetFeatureId(), road, rp.GetPointId(), neighbor.second);
+  edges.emplace_back(neighbor.first, distance);
+}
+
+RoadGeometry const & IndexGraph::GetRoad(uint32_t featureId)
+{
+  auto const it = m_fakeFeatureGeometry.find(featureId);
+  if (it != m_fakeFeatureGeometry.cend())
+    return it->second;
+
+  return m_geometry.GetRoad(featureId);
 }
 
 void IndexGraph::GetDirectedEdge(uint32_t featureId, uint32_t pointFrom, uint32_t pointTo,
                                  Joint::Id target, bool forward, vector<JointEdge> & edges)
 {
-  RoadGeometry const & road = m_geometry.GetRoad(featureId);
+  RoadGeometry const & road = GetRoad(featureId);
 
   if (road.IsOneWay() && forward != (pointFrom < pointTo))
     return;
 
   double const distance = m_estimator->CalcEdgesWeight(featureId, road, pointFrom, pointTo);
   edges.emplace_back(target, distance);
+}
+
+void IndexGraph::InsertToEdgeMapping(DirectedEdge const & key, DirectedEdge const & value)
+{
+  // Note. While applying restrictions on the graph every restriction (except for degenerated cases)
+  // adds one node to the graph if it's the first restriction starting form the edge.
+  // The second restriction starting form the edge adds 2 more nodes to the graph.
+  // The third adds 4 more and so no. To be on the safe side it's worth checking
+  // the number of duplicated edges and if it's to big stop duplicating.
+  size_t constexpr kMaxEdgeNumber = 1024;
+  vector<DirectedEdge> & edges = m_edgeMapping[key];
+  if (edges.size() > kMaxEdgeNumber)
+  {
+    LOG(LERROR, ("A very big set of restrictions around edge:", key, "in source data."));
+    return;
+  }
+  edges.push_back(value);
+}
+
+string DebugPrint(DirectedEdge const & directedEdge)
+{
+  ostringstream out;
+  out << "DirectedEdge[" << directedEdge.GetFrom() << ", " << directedEdge.GetTo() << ", "
+      << directedEdge.GetFeatureId() << "]";
+  return out.str();
 }
 }  // namespace routing

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -4,16 +4,24 @@
 #include "routing/geometry.hpp"
 #include "routing/joint.hpp"
 #include "routing/joint_index.hpp"
+#include "routing/restrictions_serialization.hpp"
 #include "routing/road_index.hpp"
 #include "routing/road_point.hpp"
 
 #include "geometry/point2d.hpp"
 
 #include "std/cstdint.hpp"
+#include "std/functional.hpp"
+#include "std/set.hpp"
 #include "std/shared_ptr.hpp"
 #include "std/unique_ptr.hpp"
 #include "std/utility.hpp"
 #include "std/vector.hpp"
+
+namespace routing_test
+{
+struct RestrictionTest;
+}  // namespace routing_test
 
 namespace routing
 {
@@ -25,36 +33,127 @@ public:
   double GetWeight() const { return m_weight; }
 
 private:
-  // Target is vertex going to for outgoing edges, vertex going from for ingoing edges.
-  Joint::Id const m_target;
-  double const m_weight;
+  // Target is a vertex going to for outgoing edges, vertex going from for ingoing edges.
+  Joint::Id m_target;
+  double m_weight;
+};
+
+class JointEdgeGeom final
+{
+public:
+  JointEdgeGeom() = default;
+
+  JointEdgeGeom(Joint::Id target, vector<RoadPoint> const & path) : m_target(target), m_path(path)
+  {
+  }
+
+  Joint::Id GetTarget() const { return m_target; }
+  vector<RoadPoint> const & GetPath() const { return m_path; }
+private:
+  // Target is a vertex going to for outgoing edges, vertex going from for ingoing edges.
+  Joint::Id m_target = Joint::kInvalidId;
+  vector<RoadPoint> m_path;
+};
+
+class DirectedEdge final
+{
+public:
+  DirectedEdge() = default;
+  DirectedEdge(Joint::Id from, Joint::Id to, uint32_t featureId)
+    : m_from(from), m_to(to), m_featureId(featureId)
+  {
+  }
+
+  bool operator<(DirectedEdge const & rhs) const;
+  bool operator==(DirectedEdge const & rhs) const;
+
+  Joint::Id GetFrom() const { return m_from; }
+  Joint::Id GetTo() const { return m_to; }
+  uint32_t GetFeatureId() const { return m_featureId; }
+  static bool IsAdjacent(DirectedEdge const & ingoing, DirectedEdge const & outgoing)
+  {
+    return ingoing.GetTo() == outgoing.GetFrom();
+  }
+
+private:
+  Joint::Id const m_from = Joint::kInvalidId;
+  Joint::Id const m_to = Joint::kInvalidId;
+  // Note. It's important to store feature id because two |m_from| and |m_to| may be
+  // connected with several features.
+  uint32_t const m_featureId = 0;
+};
+
+string DebugPrint(DirectedEdge const & directedEdge);
+
+class RestrictionInfo final
+{
+public:
+  RestrictionInfo() = default;
+
+  RestrictionInfo(DirectedEdge const & ingoing, DirectedEdge const & outgoing)
+    : m_from(ingoing.GetFrom())
+    , m_center(ingoing.GetTo())
+    , m_to(outgoing.GetTo())
+    , m_fromFeatureId(ingoing.GetFeatureId())
+    , m_toFeatureId(outgoing.GetFeatureId())
+  {
+    CHECK(DirectedEdge::IsAdjacent(ingoing, outgoing), ());
+  }
+
+  bool operator<(RestrictionInfo const & rhs) const;
+  bool operator==(RestrictionInfo const & rhs) const { return !(*this < rhs || rhs < *this); }
+  bool operator!=(RestrictionInfo const & rhs) const { return !(*this == rhs); }
+  pair<DirectedEdge, DirectedEdge> Edges() const
+  {
+    return make_pair(DirectedEdge(m_from, m_center, m_fromFeatureId),
+                     DirectedEdge(m_center, m_to, m_toFeatureId));
+  }
+
+  Joint::Id m_from = Joint::kInvalidId;
+  Joint::Id m_center = Joint::kInvalidId;
+  Joint::Id m_to = Joint::kInvalidId;
+  uint32_t m_fromFeatureId = 0;
+  uint32_t m_toFeatureId = 0;
 };
 
 class IndexGraph final
 {
 public:
+  static uint32_t const kStartFakeFeatureIds = 1024 * 1024 * 1024;
+
   IndexGraph() = default;
   explicit IndexGraph(unique_ptr<GeometryLoader> loader, shared_ptr<EdgeEstimator> estimator);
 
   // Creates edge for points in same feature.
   void GetDirectedEdge(uint32_t featureId, uint32_t pointFrom, uint32_t pointTo, Joint::Id target,
                        bool forward, vector<JointEdge> & edges);
-  void GetNeighboringEdges(RoadPoint const & rp, bool isOutgoing, vector<JointEdge> & edges);
+  void GetNeighboringEdges(RoadPoint const & rp, bool isOutgoing, bool graphWithoutRestrictions,
+                           vector<JointEdge> & edges);
+  /// \brief Fills |edges| with edges going through |rp|. |rp| should not be a joint.
+  void GetIntermediatePointEdges(RoadPoint const & rp, bool graphWithoutRestrictions,
+                                 vector<DirectedEdge> & edges);
 
-  // Put outgoing (or ingoing) egdes for jointId to the 'edges' vector.
-  void GetEdgeList(Joint::Id jointId, bool isOutgoing, vector<JointEdge> & edges);
+  // Put outgoing (or ingoing) egdes for jointId to the |edges| vector.
+  void GetEdgeList(Joint::Id jointId, bool isOutgoing, bool graphWithoutRestrictions,
+                   vector<JointEdge> & edges);
+  void GetEdgeList(Joint::Id jointId, bool isOutgoing, bool graphWithoutRestrictions,
+                   vector<DirectedEdge> & edges);
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
   m2::PointD const & GetPoint(Joint::Id jointId);
 
-  Geometry & GetGeometry() { return m_geometry; }
   EdgeEstimator const & GetEstimator() const { return *m_estimator; }
   RoadJointIds const & GetRoad(uint32_t featureId) const { return m_roadIndex.GetRoad(featureId); }
 
   uint32_t GetNumRoads() const { return m_roadIndex.GetSize(); }
   uint32_t GetNumJoints() const { return m_jointIndex.GetNumJoints(); }
-  uint32_t GetNumPoints() const { return m_jointIndex.GetNumPoints(); }
-
+  uint32_t GetNumStaticPoints() const { return m_jointIndex.GetNumStaticPoints(); }
+  /// \brief Builds |m_jointIndex|.
+  /// \param numJoints number of joints.
+  /// \note This method should be called when |m_roadIndex| is ready.
   void Build(uint32_t numJoints);
+
+  uint32_t GetNextFakeFeatureId() const { return m_nextFakeFeatureId; }
+  m2::PointD const & GetPoint(RoadPoint const & rp);
   void Import(vector<Joint> const & joints);
   Joint::Id InsertJoint(RoadPoint const & rp);
   bool JointLiesOnRoad(Joint::Id jointId, uint32_t featureId) const;
@@ -76,13 +175,186 @@ public:
     m_jointIndex.ForEachPoint(jointId, forward<F>(f));
   }
 
+  /// \brief Add restrictions in |restrictions| to |m_ftPointIndex|.
+  void ApplyRestrictions(RestrictionVec const & restrictions);
+
+  /// \returns RoadGeometry by a real or fake featureId.
+  RoadGeometry const & GetRoad(uint32_t featureId);
+
+  static bool IsFakeFeature(uint32_t featureId) { return featureId >= kStartFakeFeatureIds; }
+  /// \brief Calls |f| for |directedEdge| if it's not blocked and recursively for every
+  /// non blocked edge in |m_edgeMapping|.
+  template <class F>
+  void ForEachNonBlockedEdgeMappingNode(DirectedEdge const & directedEdge, F && f) const
+  {
+    auto const it = m_edgeMapping.find(directedEdge);
+    if (it != m_edgeMapping.end())
+    {
+      for (DirectedEdge const & e : it->second)
+        ForEachNonBlockedEdgeMappingNode(e, f);
+    }
+
+    if (m_blockedEdges.count(directedEdge) == 0)
+      f(directedEdge);
+  }
+
+  template <class F>
+  void ForEachEdgeMappingNode(DirectedEdge const & directedEdge, F && f) const
+  {
+    auto const it = m_edgeMapping.find(directedEdge);
+    if (it != m_edgeMapping.end())
+    {
+      for (DirectedEdge const & e : it->second)
+        ForEachEdgeMappingNode(e, f);
+    }
+
+    f(directedEdge);
+  }
+
 private:
+  friend struct routing_test::RestrictionTest;
+
+  /// \brief Disables an edge between |from| and |to| along |featureId|.
+  /// \note Despite the fact that |from| and |to| could be connected with several edges
+  /// it's a rare case. In most cases |from| and |to| are connected with only one edge
+  /// if they are adjacent.
+  /// \note The method doesn't affect routing if |from| and |to| are not adjacent or
+  /// if one of them is equal to Joint::kInvalidId.
+  void DisableEdge(DirectedEdge const & edge) { m_blockedEdges.insert(edge); }
+  void DisableAllEdges(Joint::Id from, Joint::Id to);
+
+  /// \brief Adds a fake oneway feature with a loose end starting from joint |from|.
+  /// Geometry for the feature points is taken from |geometrySource|.
+  /// If |geometrySource| contains more than two points the feature is created
+  /// with intermediate (not joint) point(s).
+  /// \returns feature id which was added.
+  uint32_t AddFakeLooseEndFeature(Joint::Id from, vector<RoadPoint> const & geometrySource,
+                                  double speed);
+
+  /// \brief Connects joint |from| and |to| with a fake oneway feature. Geometry for the feature
+  /// points is taken from |geometrySource|. If |geometrySource| contains more than
+  /// two points the feature is created with intermediate (not joint) point(s).
+  /// \returns feature id which was added.
+  uint32_t AddFakeFeature(Joint::Id from, Joint::Id to, vector<RoadPoint> const & geometrySource,
+                          double speed);
+
+  void ApplyRestrictionNo(RestrictionInfo const & restrictionInfo);
+
+  void ApplyRestrictionOnly(RestrictionInfo const & restrictionInfo);
+
+  /// \brief Adds restriction to navigation graph which says that it's prohibited to go from
+  /// |restrictionPoint.m_from| to |restrictionPoint.m_to|.
+  /// \note |from| and |to| could be only begining or ending feature points and they has to belong
+  /// to the same junction with |jointId|. That means features |from| and |to| has to be adjacent.
+  /// \note This method could be called only after |m_roadIndex| have been loaded with the help of
+  /// Deserialize() or Import().
+  void ApplyRestrictionNoRealFeatures(RestrictionPoint const & restrictionPoint);
+
+  /// \brief Adds restriction to navigation graph which says that from feature
+  /// |restrictionPoint.m_from| it's permitted only
+  /// to go to feature |restrictionPoint.m_to|. All other ways starting form
+  /// |restrictionPoint.m_form| is prohibited.
+  /// \note All notes which are valid for ApplyRestrictionNoRealFeatures()
+  /// are valid for ApplyRestrictionOnlyRealFeatures().
+  void ApplyRestrictionOnlyRealFeatures(RestrictionPoint const & restrictionPoint);
+
+  /// \brief Fills |path| with points from point |from| to point |to|
+  /// \note |from| and |to| should belong to the same feature.
+  /// \note The order on points in items of |connectionPaths| is from |from| to |to|.
+  void GetSingleFeaturePath(RoadPoint const & from, RoadPoint const & to, vector<RoadPoint> & path);
+
+  /// \brief Fills |path| with a path from |from| to |to| of points of |featureId|.
+  void GetFeatureConnectionPath(Joint::Id from, Joint::Id to, uint32_t featureId,
+                                vector<RoadPoint> & path);
+
+  void GetOutgoingGeomEdges(vector<JointEdge> const & outgoingEdges, Joint::Id center,
+                            vector<JointEdgeGeom> & outgoingGeomEdges);
+
+  /// \brief Fills |connectionPaths| with all path from joint |from| to joint |to|.
+  /// If |from| and |to| don't belong to the same feature |connectionPaths| will
+  /// be empty.
+  /// If |from| and |to| belong to only one feature |connectionPaths| will have one item.
+  /// It's the most common case.
+  /// If |from| and |to| could be connected by several features |connectionPaths|
+  /// will have several items.
+  /// \note The order on points in items of |connectionPaths| is from |from| to |to|.
+  void GetConnectionPaths(Joint::Id from, Joint::Id to,
+                          vector<vector<RoadPoint>> & connectionPaths);
+
+  void CreateFakeFeatureGeometry(vector<RoadPoint> const & geometrySource, double speed,
+                                 RoadGeometry & geometry);
+
   void GetNeighboringEdge(RoadGeometry const & road, RoadPoint const & rp, bool forward,
+                          bool outgoing, bool graphWithoutRestrictions,
                           vector<JointEdge> & edges) const;
+
+  double GetSpeed(RoadPoint const & rp);
+
+  /// \brief Finds all joints of |featureId| which are equal to JointEdge::m_target
+  /// of |edges. Fills |oneStepAside| with found joints.
+  void FindOneStepAsideRoadPoint(uint32_t featureId, vector<JointEdge> const & edges,
+                                 vector<Joint::Id> & oneStepAside) const;
+
+  /// \returns false if it cannot get ingoing or outgoing edges and true otherwise.
+  bool GetIngoingAndOutgoingEdges(Joint::Id centerId, bool graphWithoutRestrictions,
+                                  vector<JointEdge> & ingoingEdges,
+                                  vector<JointEdge> & outgoingEdges);
+
+  bool ApplyRestrictionPrepareData(RestrictionPoint const & restrictionPoint,
+                                   RestrictionInfo & restrictionInfo);
+
+  void InsertToEdgeMapping(DirectedEdge const & key, DirectedEdge const & value);
+
+  /// \brief Calls |f| for |restrictionPoint| and for all restriction points formed by
+  /// all ingoing and outgoing edges which were generated from the ingoing edge
+  /// and the outgoing edge of |restrictionPoint|.
+  template<class F>
+  void ApplyRestrictionRealFeatures(RestrictionPoint const & restrictionPoint, F && f)
+  {
+    RestrictionInfo restrictionInfo;
+    if (!ApplyRestrictionPrepareData(restrictionPoint, restrictionInfo))
+      return;
+
+    // Note. It's necessary to collect edges ingoing to the restriction and
+    // outgoing from the restriction at first and then to apply |f|
+    // because |f| edits the graph and excecuting |f| affect the behavior of
+    // ForEachNonBlockedEdgeMappingNode().
+    auto const edges = restrictionInfo.Edges();
+    vector<DirectedEdge> ingoingRestEdges;
+    ForEachNonBlockedEdgeMappingNode(
+        edges.first, [&](DirectedEdge const & ingoing) { ingoingRestEdges.push_back(ingoing); });
+
+    vector<DirectedEdge> outgoingRestEdges;
+    ForEachNonBlockedEdgeMappingNode(
+        edges.second, [&](DirectedEdge const & outgoing) { outgoingRestEdges.push_back(outgoing); });
+
+    for (DirectedEdge const & ingoing : ingoingRestEdges)
+    {
+      for (DirectedEdge const & outgoing : outgoingRestEdges)
+      {
+        if (DirectedEdge::IsAdjacent(ingoing, outgoing))
+          f(RestrictionInfo(ingoing, outgoing));
+      }
+    }
+  }
 
   Geometry m_geometry;
   shared_ptr<EdgeEstimator> m_estimator;
   RoadIndex m_roadIndex;
   JointIndex m_jointIndex;
+
+  set<DirectedEdge> m_blockedEdges;
+  uint32_t m_nextFakeFeatureId = kStartFakeFeatureIds;
+  // Mapping from fake feature id to fake feature geometry.
+  map<uint32_t, RoadGeometry> m_fakeFeatureGeometry;
+  // Adding restrictions leads to disabling some edges and adding others.
+  // According to graph trasformation implemented in ApplyRestrictionNo() and
+  // ApplyRestrictionOnly() every |DirectedEdge| (a pair of joints) could:
+  // * disappears at all (in that case it's added to |m_blockedEdges|)
+  // * be transformed to another DirectedEdge. If so the mapping
+  //   is kept in |m_edgeMapping| and source edge is blocked (added to |m_blockedEdges|).
+  // * be copied. If so the mapping is kept in |m_edgeMapping| and the source edge is not blocked.
+  // See ApplyRestriction* method for a detailed comments about trasformation rules.
+  map<DirectedEdge, vector<DirectedEdge>> m_edgeMapping;
 };
 }  // namespace routing

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -6,27 +6,54 @@ namespace routing
 {
 IndexGraphStarter::IndexGraphStarter(IndexGraph & graph, RoadPoint const & startPoint,
                                      RoadPoint const & finishPoint)
-  : m_graph(graph)
-  , m_start(graph, startPoint, graph.GetNumJoints())
-  , m_finish(graph, finishPoint, graph.GetNumJoints() + 1)
+  : m_fakeNextFeatureId(graph.GetNextFakeFeatureId())
+  , m_graph(graph)
+  , m_start(startPoint, graph.GetNumJoints())
+  , m_finish(finishPoint, graph.GetNumJoints() + 1)
 {
+  CHECK(!IndexGraph::IsFakeFeature(startPoint.GetFeatureId()), ());
+  CHECK(!IndexGraph::IsFakeFeature(finishPoint.GetFeatureId()), ());
+
   m_start.SetupJointId(graph);
 
   if (startPoint == finishPoint)
     m_finish.m_jointId = m_start.m_jointId;
   else
     m_finish.SetupJointId(graph);
+
+  // After adding restrictions on IndexGraph some edges could be blocked some other could
+  // be copied. It's possible that start or finish could be matched on a new fake (or blocked)
+  // edge that may spoil route geometry or even worth prevent from building some routes.
+  // To overcome it some edge from start and to finish should be added below.
+  AddFakeZeroLengthEdges(m_start, EndPointType::Start);
+  AddFakeZeroLengthEdges(m_finish, EndPointType::Finish);
 }
 
 m2::PointD const & IndexGraphStarter::GetPoint(Joint::Id jointId)
 {
   if (jointId == m_start.m_fakeId)
-    return m_graph.GetGeometry().GetPoint(m_start.m_point);
+    return m_graph.GetPoint(m_start.m_point);
 
   if (jointId == m_finish.m_fakeId)
-    return m_graph.GetGeometry().GetPoint(m_finish.m_point);
+    return m_graph.GetPoint(m_finish.m_point);
 
   return m_graph.GetPoint(jointId);
+}
+
+m2::PointD const & IndexGraphStarter::GetPoint(RoadPoint const & rp)
+{
+  if (!IsFakeFeature(rp.GetFeatureId()))
+    return m_graph.GetPoint(rp);
+
+  for (DirectedEdge const & e : m_fakeZeroLengthEdges)
+  {
+    ASSERT_EQUAL(GetPoint(e.GetFrom()), GetPoint(e.GetTo()), ());
+    if (e.GetFeatureId() == rp.GetFeatureId())
+      return GetPoint(e.GetFrom());
+  }
+  CHECK(false,
+        (rp, "is a point of a fake feature but it's not contained in |m_fakeZeroLengthEdges|"));
+  return m_graph.GetPoint(rp);
 }
 
 void IndexGraphStarter::RedressRoute(vector<Joint::Id> const & route,
@@ -76,32 +103,71 @@ void IndexGraphStarter::RedressRoute(vector<Joint::Id> const & route,
   }
 }
 
+void IndexGraphStarter::AddZeroLengthOnewayFeature(Joint::Id from, Joint::Id to)
+{
+  if (from == to)
+    return;
+
+  m_jointsOfFakeEdges.insert(from);
+  m_jointsOfFakeEdges.insert(to);
+  m_fakeZeroLengthEdges.emplace_back(from, to, m_fakeNextFeatureId++);
+}
+
+void IndexGraphStarter::GetFakeEdgesList(Joint::Id jointId, bool isOutgoing,
+                                         vector<JointEdge> & edges)
+{
+  if (m_jointsOfFakeEdges.count(jointId) == 0)
+    return;
+
+  for (DirectedEdge const e : m_fakeZeroLengthEdges)
+  {
+    ASSERT_EQUAL(GetPoint(e.GetFrom()), GetPoint(e.GetTo()), ());
+    if (isOutgoing)
+    {
+      if (e.GetFrom() == jointId)
+        edges.emplace_back(e.GetTo(), 0 /* weight */);
+    }
+    else
+    {
+      if (e.GetTo() == jointId)
+        edges.emplace_back(e.GetFrom(), 0 /* weight */);
+    }
+  }
+}
+
 void IndexGraphStarter::GetEdgesList(Joint::Id jointId, bool isOutgoing, vector<JointEdge> & edges)
 {
   edges.clear();
 
+  // Note. Fake edges adding here may be ingoing or outgoing edges for start or finish.
+  // Or it may be "arrival edges". That mean |jointId| is not start of finish but
+  // a node which is connected with start of finish by an edge.
+  GetFakeEdgesList(jointId, isOutgoing, edges);
+
   if (jointId == m_start.m_fakeId)
   {
-    GetFakeEdges(m_start, m_finish, isOutgoing, edges);
+    GetStartFinishEdges(m_start, m_finish, isOutgoing, edges);
     return;
   }
 
   if (jointId == m_finish.m_fakeId)
   {
-    GetFakeEdges(m_finish, m_start, isOutgoing, edges);
+    GetStartFinishEdges(m_finish, m_start, isOutgoing, edges);
     return;
   }
 
-  m_graph.GetEdgeList(jointId, isOutgoing, edges);
+  m_graph.GetEdgeList(jointId, isOutgoing, false /* graphWithoutRestrictions */, edges);
   GetArrivalFakeEdges(jointId, m_start, isOutgoing, edges);
   GetArrivalFakeEdges(jointId, m_finish, isOutgoing, edges);
 }
 
-void IndexGraphStarter::GetFakeEdges(IndexGraphStarter::FakeJoint const & from,
-                                     IndexGraphStarter::FakeJoint const & to, bool isOutgoing,
-                                     vector<JointEdge> & edges)
+void IndexGraphStarter::GetStartFinishEdges(IndexGraphStarter::FakeJoint const & from,
+                                            IndexGraphStarter::FakeJoint const & to,
+                                            bool isOutgoing, vector<JointEdge> & edges)
 {
-  m_graph.GetNeighboringEdges(from.m_point, isOutgoing, edges);
+  ASSERT(!from.BelongsToGraph(), ());
+  m_graph.GetNeighboringEdges(from.m_point, isOutgoing, false /* graphWithoutRestrictions */,
+                              edges);
 
   if (!to.BelongsToGraph() && from.m_point.GetFeatureId() == to.m_point.GetFeatureId())
   {
@@ -121,7 +187,8 @@ void IndexGraphStarter::GetArrivalFakeEdges(Joint::Id jointId,
     return;
 
   vector<JointEdge> startEdges;
-  m_graph.GetNeighboringEdges(fakeJoint.m_point, !isOutgoing, startEdges);
+  m_graph.GetNeighboringEdges(fakeJoint.m_point, !isOutgoing, false /* graphWithoutRestrictions */,
+                              startEdges);
   for (JointEdge const & edge : startEdges)
   {
     if (edge.GetTarget() == jointId)
@@ -135,12 +202,30 @@ void IndexGraphStarter::FindPointsWithCommonFeature(Joint::Id jointId0, Joint::I
   bool found = false;
   double minWeight = -1.0;
 
+  auto const foundFn = [&](RoadPoint const & rp0, RoadPoint const & rp1) {
+    result0 = rp0;
+    result1 = rp1;
+    found = true;
+  };
+
+  // |m_graph| edges.
   ForEachPoint(jointId0, [&](RoadPoint const & rp0) {
     ForEachPoint(jointId1, [&](RoadPoint const & rp1) {
       if (rp0.GetFeatureId() != rp1.GetFeatureId())
         return;
 
-      RoadGeometry const & road = m_graph.GetGeometry().GetRoad(rp0.GetFeatureId());
+      if (IsFakeFeature(rp0.GetFeatureId()))
+      {
+        // Fake edge has alway two points. They are oneway and have zero wight.
+        if (rp0.GetPointId() == 0 && rp1.GetPointId() == 1)
+        {
+          foundFn(rp0, rp1);
+          minWeight = 0;
+        }
+        return;
+      }
+
+      RoadGeometry const & road = m_graph.GetRoad(rp0.GetFeatureId());
       if (road.IsOneWay() && rp0.GetPointId() > rp1.GetPointId())
         return;
 
@@ -150,7 +235,7 @@ void IndexGraphStarter::FindPointsWithCommonFeature(Joint::Id jointId0, Joint::I
         {
           // CalcEdgesWeight is very expensive.
           // So calculate it only if second common feature found.
-          RoadGeometry const & prevRoad = m_graph.GetGeometry().GetRoad(result0.GetFeatureId());
+          RoadGeometry const & prevRoad = m_graph.GetRoad(result0.GetFeatureId());
           minWeight = m_graph.GetEstimator().CalcEdgesWeight(
               rp0.GetFeatureId(), prevRoad, result0.GetPointId(), result1.GetPointId());
         }
@@ -166,9 +251,7 @@ void IndexGraphStarter::FindPointsWithCommonFeature(Joint::Id jointId0, Joint::I
       }
       else
       {
-        result0 = rp0;
-        result1 = rp1;
-        found = true;
+        foundFn(rp0, rp1);
       }
     });
   });
@@ -176,9 +259,46 @@ void IndexGraphStarter::FindPointsWithCommonFeature(Joint::Id jointId0, Joint::I
   CHECK(found, ("Can't find common feature for joints", jointId0, jointId1));
 }
 
+void IndexGraphStarter::AddFakeZeroLengthEdges(FakeJoint const & fj, EndPointType endPointType)
+{
+  CHECK(!IndexGraph::IsFakeFeature(fj.m_point.GetFeatureId()), ());
+
+  bool const isJoint = fj.BelongsToGraph();
+
+  vector<DirectedEdge> edges;
+  if (isJoint)
+  {
+    m_graph.GetEdgeList(fj.m_jointId, endPointType == EndPointType::Start /* is outgoing */,
+                        true /* graphWithoutRestrictions */, edges);
+  }
+  else
+  {
+    m_graph.GetIntermediatePointEdges(fj.m_point, true /* graphWithoutRestrictions */, edges);
+  }
+
+  for (DirectedEdge const & edge : edges)
+  {
+    m_graph.ForEachEdgeMappingNode(edge, [&](DirectedEdge const & e) {
+      if (edge == e)
+        return;
+
+      switch (endPointType)
+      {
+      case EndPointType::Start:
+        AddZeroLengthOnewayFeature(isJoint ? edge.GetFrom() : edge.GetTo(),
+                                   isJoint ? e.GetFrom() : e.GetTo());
+        return;
+      case EndPointType::Finish:
+        AddZeroLengthOnewayFeature(isJoint ? e.GetTo() : e.GetFrom(),
+                                   isJoint ? edge.GetTo() : edge.GetFrom());
+        return;
+      }
+    });
+  }
+}
+
 // IndexGraphStarter::FakeJoint --------------------------------------------------------------------
-IndexGraphStarter::FakeJoint::FakeJoint(IndexGraph const & graph, RoadPoint const & point,
-                                        Joint::Id fakeId)
+IndexGraphStarter::FakeJoint::FakeJoint(RoadPoint const & point, Joint::Id fakeId)
   : m_point(point), m_fakeId(fakeId), m_jointId(Joint::kInvalidId)
 {
 }

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -3,7 +3,14 @@
 #include "routing/index_graph.hpp"
 #include "routing/joint.hpp"
 
+#include "std/set.hpp"
 #include "std/utility.hpp"
+#include "std/vector.hpp"
+
+namespace routing_test
+{
+struct RestrictionTest;
+}  // namespace routing_test
 
 namespace routing
 {
@@ -20,6 +27,13 @@ public:
   using TVertexType = Joint::Id;
   using TEdgeType = JointEdge;
 
+  enum class EndPointType
+  {
+    Start,
+    Finish
+  };
+
+  /// \note |startPoint| and |finishPoint| should be points of real features.
   IndexGraphStarter(IndexGraph & graph, RoadPoint const & startPoint,
                     RoadPoint const & finishPoint);
 
@@ -28,6 +42,7 @@ public:
   Joint::Id GetFinishJoint() const { return m_finish.m_jointId; }
 
   m2::PointD const & GetPoint(Joint::Id jointId);
+  m2::PointD const & GetPoint(RoadPoint const & rp);
 
   void GetOutgoingEdgesList(Joint::Id jointId, vector<JointEdge> & edges)
   {
@@ -50,9 +65,11 @@ public:
   void RedressRoute(vector<Joint::Id> const & route, vector<RoadPoint> & roadPoints);
 
 private:
+  friend struct routing_test::RestrictionTest;
+
   struct FakeJoint final
   {
-    FakeJoint(IndexGraph const & graph, RoadPoint const & point, Joint::Id fakeId);
+    FakeJoint(RoadPoint const & point, Joint::Id fakeId);
 
     void SetupJointId(IndexGraph const & graph);
     bool BelongsToGraph() const { return m_jointId != m_fakeId; }
@@ -77,12 +94,32 @@ private:
       return;
     }
 
+    // |jointId| is not a fake start or a fake finish. So it's a real joint.
+    if (m_jointsOfFakeEdges.count(jointId) != 0)
+    {
+      for (DirectedEdge const & e : m_fakeZeroLengthEdges)
+      {
+        if (jointId == e.GetFrom())
+          f(RoadPoint(e.GetFeatureId(), 0 /* point id */));
+        if (jointId == e.GetTo())
+          f(RoadPoint(e.GetFeatureId(), 1 /* point id */));
+      }
+    }
+
     m_graph.ForEachPoint(jointId, forward<F>(f));
   }
 
+  bool IsFakeFeature(uint32_t featureId) const
+  {
+    return featureId >= m_graph.GetNextFakeFeatureId();
+  }
+
+  void AddZeroLengthOnewayFeature(Joint::Id from, Joint::Id to);
+  void GetFakeEdgesList(Joint::Id jointId, bool isOutgoing, vector<JointEdge> & edges);
+
   void GetEdgesList(Joint::Id jointId, bool isOutgoing, vector<JointEdge> & edges);
-  void GetFakeEdges(FakeJoint const & from, FakeJoint const & to, bool isOutgoing,
-                    vector<JointEdge> & edges);
+  void GetStartFinishEdges(FakeJoint const & from, FakeJoint const & to, bool isOutgoing,
+                           vector<JointEdge> & edges);
   void GetArrivalFakeEdges(Joint::Id jointId, FakeJoint const & fakeJoint, bool isOutgoing,
                            vector<JointEdge> & edges);
 
@@ -91,6 +128,14 @@ private:
   void FindPointsWithCommonFeature(Joint::Id jointId0, Joint::Id jointId1, RoadPoint & result0,
                                    RoadPoint & result1);
 
+  void AddFakeZeroLengthEdges(FakeJoint const & fp, EndPointType endPointType);
+
+  // Edges which added to IndexGraph in IndexGraphStarter. Size of |m_fakeZeroLengthEdges| should be
+  // relevantly small because some methods working with it have linear complexity.
+  vector<DirectedEdge> m_fakeZeroLengthEdges;
+  // |m_jointsOfFakeEdges| is set of all joint ids take part in |m_fakeZeroLengthEdges|.
+  set<Joint::Id> m_jointsOfFakeEdges;
+  uint32_t m_fakeNextFeatureId;
   IndexGraph & m_graph;
   FakeJoint m_start;
   FakeJoint m_finish;

--- a/routing/restriction_loader.cpp
+++ b/routing/restriction_loader.cpp
@@ -1,5 +1,5 @@
 #include "routing/restriction_loader.hpp"
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 namespace routing
 {

--- a/routing/restriction_loader.hpp
+++ b/routing/restriction_loader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 #include "indexer/index.hpp"
 

--- a/routing/restrictions_serialization.cpp
+++ b/routing/restrictions_serialization.cpp
@@ -1,4 +1,4 @@
-#include "routing/routing_serialization.hpp"
+#include "routing/restrictions_serialization.hpp"
 
 namespace
 {
@@ -13,8 +13,8 @@ uint32_t const Restriction::kInvalidFeatureId = numeric_limits<uint32_t>::max();
 
 bool Restriction::IsValid() const
 {
-  return !m_featureIds.empty() && find(begin(m_featureIds), end(m_featureIds), kInvalidFeatureId)
-      == end(m_featureIds);
+  return !m_featureIds.empty() &&
+         find(begin(m_featureIds), end(m_featureIds), kInvalidFeatureId) == end(m_featureIds);
 }
 
 bool Restriction::operator==(Restriction const & restriction) const
@@ -44,8 +44,8 @@ string DebugPrint(Restriction::Type const & type) { return ToString(type); }
 string DebugPrint(Restriction const & restriction)
 {
   ostringstream out;
-  out << "m_featureIds:[" << ::DebugPrint(restriction.m_featureIds)
-      << "] m_type:" << DebugPrint(restriction.m_type) << " ";
+  out << "Restriction [ m_featureIds: " << ::DebugPrint(restriction.m_featureIds)
+      << " m_type: " << DebugPrint(restriction.m_type) << " ]";
   return out.str();
 }
 }  // namespace routing

--- a/routing/road_index.cpp
+++ b/routing/road_index.cpp
@@ -1,9 +1,33 @@
 #include "routing/road_index.hpp"
 
+#include "routing/road_point.hpp"
 #include "routing/routing_exceptions.hpp"
+
+namespace
+{
+void MakeRestrictionPoint(uint32_t featureIdFrom, uint32_t pointIdFrom, uint32_t featureIdTo,
+                          uint32_t pointIdTo, routing::Joint::Id centerId,
+                          routing::RestrictionPoint & restrictionPoint)
+{
+  restrictionPoint.m_from = routing::RoadPoint(featureIdFrom, pointIdFrom);
+  restrictionPoint.m_to = routing::RoadPoint(featureIdTo, pointIdTo);
+  restrictionPoint.m_centerId = centerId;
+}
+}  // namespace
 
 namespace routing
 {
+bool RestrictionPoint::operator<(RestrictionPoint const & rhs) const
+{
+  if (m_from != rhs.m_from)
+    return m_from < rhs.m_from;
+
+  if (m_to != rhs.m_to)
+    return m_to < rhs.m_to;
+
+  return m_centerId < rhs.m_centerId;
+}
+
 void RoadIndex::Import(vector<Joint> const & joints)
 {
   for (Joint::Id jointId = 0; jointId < joints.size(); ++jointId)
@@ -18,6 +42,48 @@ void RoadIndex::Import(vector<Joint> const & joints)
   }
 }
 
+bool RoadIndex::GetRestrictionPoint(uint32_t featureIdFrom, uint32_t featureIdTo,
+                                    RestrictionPoint & restrictionPoint) const
+{
+  auto const fromIt = m_roads.find(featureIdFrom);
+  if (fromIt == m_roads.cend())
+    return false;  // No sense in restrictions to non-road features.
+
+  auto const toIt = m_roads.find(featureIdTo);
+  if (toIt == m_roads.cend())
+    return false;  // No sense in restrictions to non-road features.
+
+  RoadJointIds const & roadJointIdsFrom = fromIt->second;
+  RoadJointIds const & roadJointIdsTo = toIt->second;
+  if (roadJointIdsFrom.IsEmpty() || roadJointIdsTo.IsEmpty())
+    return false;  // No sense in restrictions on features without joints.
+
+  // Note 1. It's important to check other variant besides a restriction from last segment
+  // of featureIdFrom to first segment of featureIdTo since two way features can have
+  // reverse point order.
+  // Note 2. The code below assumes that feature of restrictions are connected with its ends.
+  // It's true for overwhelming majority for restrictions. If a restriction is defined with
+  // two feature which is not connected at all or which is connected but not with its ends
+  // the restriction is not used.
+  vector<size_t> from = {0, roadJointIdsFrom.GetSize() - 1};
+  vector<size_t> to = {0, roadJointIdsTo.GetSize() - 1};
+
+  for (size_t fromIdx : from)
+  {
+    for (size_t toIdx : to)
+    {
+      if (roadJointIdsFrom.GetJointId(fromIdx) == roadJointIdsTo.GetJointId(toIdx))
+      {
+        MakeRestrictionPoint(featureIdFrom, fromIdx, featureIdTo, toIdx,
+                             roadJointIdsFrom.GetJointId(fromIdx), restrictionPoint);
+        return true;
+      }
+    }
+  }
+
+  return false;  // |featureIdFrom| and |featureIdTo| are not adjacent.
+}
+
 pair<Joint::Id, uint32_t> RoadIndex::FindNeighbor(RoadPoint const & rp, bool forward) const
 {
   auto const it = m_roads.find(rp.GetFeatureId());
@@ -25,5 +91,14 @@ pair<Joint::Id, uint32_t> RoadIndex::FindNeighbor(RoadPoint const & rp, bool for
     MYTHROW(RoutingException, ("RoadIndex doesn't contains feature", rp.GetFeatureId()));
 
   return it->second.FindNeighbor(rp.GetPointId(), forward);
+}
+
+string DebugPrint(RestrictionPoint const & restrictionPoint)
+{
+  ostringstream out;
+  out << "restrictionPoint [ m_from: " << DebugPrint(restrictionPoint.m_from)
+      << " m_to: " << DebugPrint(restrictionPoint.m_to)
+      << " m_centerId: " << restrictionPoint.m_centerId << " ]";
+  return out.str();
 }
 }  // namespace routing

--- a/routing/road_point.hpp
+++ b/routing/road_point.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "std/cstdint.hpp"
+#include "std/limits.hpp"
 #include "std/sstream.hpp"
 #include "std/string.hpp"
 
@@ -17,30 +18,31 @@ public:
 
   RoadPoint(uint32_t featureId, uint32_t pointId) : m_featureId(featureId), m_pointId(pointId) {}
 
+  bool operator==(RoadPoint const & rhs) const
+  {
+    return m_featureId == rhs.m_featureId && m_pointId == rhs.m_pointId;
+  }
+
+  bool operator!=(RoadPoint const & rhs) const { return !(*this == rhs); }
+  bool operator<(RoadPoint const & rhs) const
+  {
+    if (m_featureId != rhs.m_featureId)
+      return m_featureId < rhs.m_featureId;
+    return m_pointId < rhs.m_pointId;
+  }
+
   uint32_t GetFeatureId() const { return m_featureId; }
-
   uint32_t GetPointId() const { return m_pointId; }
-
-  bool operator==(RoadPoint const & rp) const
-  {
-    return m_featureId == rp.m_featureId && m_pointId == rp.m_pointId;
-  }
-
-  bool operator!=(RoadPoint const & rp) const
-  {
-    return !(*this == rp);
-  }
 
 private:
   uint32_t m_featureId;
   uint32_t m_pointId;
 };
 
-inline string DebugPrint(RoadPoint const & rp)
+inline string DebugPrint(RoadPoint const & roadPoint)
 {
   ostringstream out;
-  out << "rp("
-      << "(" << rp.GetFeatureId() << ", " << rp.GetPointId() << ")";
+  out << "RoadPoint[" << roadPoint.GetFeatureId() << ", " << roadPoint.GetPointId() << "]";
   return out.str();
 }
 }  // namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -41,6 +41,7 @@ SOURCES += \
     pedestrian_directions.cpp \
     pedestrian_model.cpp \
     restriction_loader.cpp \
+    restrictions_serialization.cpp \
     road_graph.cpp \
     road_graph_router.cpp \
     road_index.cpp \
@@ -50,7 +51,6 @@ SOURCES += \
     routing_algorithm.cpp \
     routing_helpers.cpp \
     routing_mapping.cpp \
-    routing_serialization.cpp \
     routing_session.cpp \
     single_mwm_router.cpp \
     speed_camera.cpp \
@@ -94,6 +94,7 @@ HEADERS += \
     pedestrian_directions.hpp \
     pedestrian_model.hpp \
     restriction_loader.hpp \
+    restrictions_serialization.hpp \
     road_graph.hpp \
     road_graph_router.hpp \
     road_index.hpp \
@@ -106,7 +107,6 @@ HEADERS += \
     routing_helpers.hpp \
     routing_mapping.hpp \
     routing_result_graph.hpp \
-    routing_serialization.hpp \
     routing_session.hpp \
     routing_settings.hpp \
     single_mwm_router.hpp \

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -9,10 +9,14 @@ set(
   astar_router_test.cpp
   async_router_test.cpp
   cross_routing_tests.cpp
+  cumulative_restriction_test.cpp
   followed_polyline_test.cpp
+  index_graph_tools.cpp
+  index_graph_tools.hpp
   nearest_edge_finder_tests.cpp
   online_cross_fetcher_test.cpp
   osrm_router_test.cpp
+  restriction_test.cpp
   road_graph_builder.cpp
   road_graph_builder.hpp
   road_graph_nearest_edges_test.cpp

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -1,0 +1,265 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_tests/index_graph_tools.hpp"
+
+#include "routing/car_model.hpp"
+#include "routing/geometry.hpp"
+
+#include "traffic/traffic_cache.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "std/unique_ptr.hpp"
+#include "std/vector.hpp"
+
+namespace
+{
+using namespace routing;
+using namespace routing_test;
+
+//               Finish
+//  3               *
+//                  ^
+//                  F5
+//                  |
+// 2 *              *
+//    ↖          ↗   ↖
+//      F2      F3      F4
+//        ↖  ↗           ↖
+// 1        *               *
+//        ↗  ↖
+//      F0      F1
+//    ↗          ↖
+// 0 *              *
+//   0       1      2       3
+//                Start
+// Note. This graph contains of 6 one segment directed features.
+unique_ptr<IndexGraph> BuildXYGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(1 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(2 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {0.0, 2.0}}));
+  loader->AddRoad(3 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(4 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{3.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(5 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 2.0}, {2.0, 3.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{0 /* feature id */, 0 /* point id */}}), /* joint at point (0, 0) */
+      MakeJoint({{1, 0}}),                                 /* joint at point (2, 0) */
+      MakeJoint({{0, 1}, {1, 1}, {2, 0}, {3, 0}}),         /* joint at point (1, 1) */
+      MakeJoint({{2, 1}}),                                 /* joint at point (0, 2) */
+      MakeJoint({{3, 1}, {4, 1}, {5, 0}}),                 /* joint at point (2, 2) */
+      MakeJoint({{4, 0}}),                                 /* joint at point (3, 1) */
+      MakeJoint({{5, 1}}),                                 /* joint at point (2, 3) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+// Route through XY graph without any restrictions.
+UNIT_TEST(XYGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildXYGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(5, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
+  TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through XY graph with one restriciton (type only) from F1 to F3.
+UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
+{
+  Init(BuildXYGraph());
+
+  Joint::Id const restictionF1F3Id = GetJointId({1 /* feature id */, 1 /* point id */});
+  ApplyRestrictionOnlyRealFeatures(
+      RestrictionPoint({1 /* feature id */, 1 /* point id */}, {3, 0}, restictionF1F3Id));
+
+  SetStarter(RoadPoint(1, 0) /* start */, RoadPoint(5, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through XY graph with one restriciton (type only) from F3 to F5.
+UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
+{
+  Init(BuildXYGraph());
+
+  Joint::Id const restictionF3F5Id = GetJointId({3 /* feature id */, 1 /* point id */});
+  ApplyRestrictionOnlyRealFeatures(
+      RestrictionPoint({3 /* feature id */, 1 /* point id */}, {5, 0}, restictionF3F5Id));
+
+  SetStarter(RoadPoint(1, 0) /* start */, RoadPoint(5, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Cumulative case. Route through XY graph with two restricitons (type only) applying
+// in all possible orders.
+UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
+{
+  Init(BuildXYGraph());
+  RestrictionVec const restrictions = {
+      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}},
+      {Restriction::Type::Only, {1 /* feature from */, 3 /* feature to */}}};
+
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
+  TestRestrictionPermutations(restrictions, expectedGeom, RoadPoint(1, 0) /* start */,
+                              RoadPoint(5, 1) /* finish */, *this);
+}
+
+// Cumulative case. Route through XY graph with two restricitons (type only and type no) applying
+// in all possible orders.
+UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
+{
+  Init(BuildXYGraph());
+
+  RestrictionVec const restrictions = {
+      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}},
+      {Restriction::Type::No, {1 /* feature from */, 2 /* feature to */}}};
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
+  TestRestrictionPermutations(restrictions, expectedGeom, RoadPoint(1, 0) /* start */,
+                              RoadPoint(5, 1) /* finish */, *this);
+}
+
+// Cumulative case. Trying to build route through XY graph with two restricitons applying
+// according to the order. First from F3 to F5 (type only)
+// and then and from F1 to F3 (type no).
+UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
+{
+  Init(BuildXYGraph());
+
+  Joint::Id const restictionF3F5Id = GetJointId({3 /* feature id */, 1 /* point id */});
+  ApplyRestrictionOnlyRealFeatures(
+      RestrictionPoint({3 /* feature id */, 1 /* point id */}, {5, 0}, restictionF3F5Id));
+
+  Joint::Id const restictionF1F3Id = GetJointId({1 /* feature id */, 1 /* point id */});
+  ApplyRestrictionNoRealFeatures(
+      RestrictionPoint({1 /* feature id */, 1 /* point id */}, {3, 0}, restictionF1F3Id));
+
+  SetStarter(RoadPoint(1, 0) /* start */, RoadPoint(5, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::NoPath, expectedGeom);
+}
+
+//                        Finish
+//  3        *              *
+//             ↖          ↗
+//              F5     F6
+//                ↖   ↗
+// 2 *              *
+//    ↖          ↗   ↖
+//      F2      F3      F4
+//        ↖  ↗           ↖
+// 1        *               *
+//        ↗  ↖             ^
+//      F0      F1          F8
+//    ↗          ↖         |
+// 0 *              *--F7--->*
+//   0       1      2       3
+//                Start
+// Note. This graph contains of 9 one segment directed features.
+unique_ptr<IndexGraph> BuildXXGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(1 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(2 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {0.0, 2.0}}));
+  loader->AddRoad(3 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(4 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{3.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(5 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 2.0}, {1.0, 3.0}}));
+  loader->AddRoad(6 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 2.0}, {3.0, 3.0}}));
+  loader->AddRoad(7 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {3.0, 0.0}}));
+  loader->AddRoad(8 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{3.0, 0.0}, {3.0, 1.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{0 /* feature id */, 0 /* point id */}}), /* joint at point (0, 0) */
+      MakeJoint({{1, 0}, {7, 0}}),                         /* joint at point (2, 0) */
+      MakeJoint({{0, 1}, {1, 1}, {2, 0}, {3, 0}}),         /* joint at point (1, 1) */
+      MakeJoint({{2, 1}}),                                 /* joint at point (0, 2) */
+      MakeJoint({{3, 1}, {4, 1}, {5, 0}, {6, 0}}),         /* joint at point (2, 2) */
+      MakeJoint({{4, 0}, {8, 1}}),                         /* joint at point (3, 1) */
+      MakeJoint({{5, 1}}),                                 /* joint at point (1, 3) */
+      MakeJoint({{6, 1}}),                                 /* joint at point (3, 3) */
+      MakeJoint({{7, 1}, {8, 0}}),                         /* joint at point (3, 0) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+// Route through XY graph without any restrictions.
+UNIT_TEST(XXGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildXXGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {3, 3}};
+  TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Cumulative case. Route through XX graph with two restricitons (type only) applying
+// in all possible orders.
+UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
+{
+  Init(BuildXXGraph());
+  RestrictionVec const restrictions = {
+      {Restriction::Type::Only, {1 /* feature from */, 3 /* feature to */}},
+      {Restriction::Type::Only, {3 /* feature from */, 6 /* feature to */}}};
+
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {3, 3}};
+  TestRestrictionPermutations(restrictions, expectedGeom, RoadPoint(1, 0) /* start */,
+                              RoadPoint(6, 1) /* finish */, *this);
+}
+
+// Route through XX graph with one restriciton (type no) from F1 to F3.
+UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
+{
+  Init(BuildXXGraph());
+
+  Joint::Id const restictionF1F3Id = GetJointId({1 /* feature id */, 1 /* point id */});
+  ApplyRestrictionNoRealFeatures(
+      RestrictionPoint({1 /* feature id */, 1 /* point id */}, {3, 0}, restictionF1F3Id));
+
+  SetStarter(RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Cumulative case. Route through XX graph with four restricitons of different types applying
+// in all possible orders.
+UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6Only)
+{
+  Init(BuildXXGraph());
+  RestrictionVec const restrictions = {
+      {Restriction::Type::No, {1 /* feature from */, 3 /* feature to */}},
+      {Restriction::Type::Only, {7 /* feature from */, 8 /* feature to */}},
+      {Restriction::Type::Only, {8 /* feature from */, 4 /* feature to */}},
+      {Restriction::Type::Only, {4 /* feature from */, 6 /* feature to */}}};
+
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+  TestRestrictionPermutations(restrictions, expectedGeom, RoadPoint(1, 0) /* start */,
+                              RoadPoint(6, 1) /* finish */, *this);
+}
+}  // namespace

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_tests/index_graph_tools.hpp"
+
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/car_model.hpp"
 #include "routing/edge_estimator.hpp"
@@ -30,25 +32,22 @@ using namespace routing_test;
 void TestRoute(IndexGraph & graph, RoadPoint const & start, RoadPoint const & finish,
                size_t expectedLength, vector<RoadPoint> const * expectedRoute = nullptr)
 {
-  LOG(LINFO, ("Test route", start.GetFeatureId(), ",", start.GetPointId(), "=>",
-              finish.GetFeatureId(), ",", finish.GetPointId()));
-
+  vector<RoadPoint> route;
   IndexGraphStarter starter(graph, start, finish);
-  vector<RoadPoint> roadPoints;
-  auto const resultCode = CalculateRoute(starter, roadPoints);
-  TEST_EQUAL(resultCode, AStarAlgorithm<IndexGraphStarter>::Result::OK, ());
+  auto const resultCode = CalculateRoute(starter, route);
 
-  TEST_EQUAL(roadPoints.size(), expectedLength, ());
+  TEST_EQUAL(resultCode, AStarAlgorithm<IndexGraphStarter>::Result::OK, ());
+  TEST_EQUAL(route.size(), expectedLength, ());
 
   if (expectedRoute)
-    TEST_EQUAL(roadPoints, *expectedRoute, ());
+    TEST_EQUAL(route, *expectedRoute, ());
 }
 
 void TestEdges(IndexGraph & graph, Joint::Id jointId, vector<Joint::Id> const & expectedTargets,
                bool forward)
 {
   vector<JointEdge> edges;
-  graph.GetEdgeList(jointId, forward, edges);
+  graph.GetEdgeList(jointId, forward, false /* graphWithoutRestrictions */, edges);
 
   vector<Joint::Id> targets;
   for (JointEdge const & edge : edges)
@@ -203,6 +202,7 @@ UNIT_TEST(FindPathManhattan)
       street.emplace_back(static_cast<double>(i), static_cast<double>(j));
       avenue.emplace_back(static_cast<double>(j), static_cast<double>(i));
     }
+
     loader->AddRoad(i, false, 1.0 /* speed */, street);
     loader->AddRoad(i + kCitySize, false, 1.0 /* speed */, avenue);
   }
@@ -216,6 +216,7 @@ UNIT_TEST(FindPathManhattan)
     for (uint32_t j = 0; j < kCitySize; ++j)
       joints.emplace_back(MakeJoint({{i, j}, {j + kCitySize, i}}));
   }
+
   graph.Import(joints);
 
   for (uint32_t startY = 0; startY < kCitySize; ++startY)
@@ -332,7 +333,7 @@ UNIT_TEST(SerializeSimpleGraph)
 
     TEST_EQUAL(graph.GetNumRoads(), 3, ());
     TEST_EQUAL(graph.GetNumJoints(), 2, ());
-    TEST_EQUAL(graph.GetNumPoints(), 4, ());
+    TEST_EQUAL(graph.GetNumStaticPoints(), 4, ());
 
     TEST_EQUAL(graph.GetJointId({0, 0}), Joint::kInvalidId, ());
     TEST_EQUAL(graph.GetJointId({0, 1}), 1, ());
@@ -350,7 +351,7 @@ UNIT_TEST(SerializeSimpleGraph)
 
     TEST_EQUAL(graph.GetNumRoads(), 2, ());
     TEST_EQUAL(graph.GetNumJoints(), 1, ());
-    TEST_EQUAL(graph.GetNumPoints(), 2, ());
+    TEST_EQUAL(graph.GetNumStaticPoints(), 2, ());
 
     TEST_EQUAL(graph.GetJointId({0, 0}), Joint::kInvalidId, ());
     TEST_EQUAL(graph.GetJointId({0, 1}), Joint::kInvalidId, ());

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -12,7 +12,10 @@ void TestGeometryLoader::Load(uint32_t featureId, RoadGeometry & road) const
 {
   auto it = m_roads.find(featureId);
   if (it == m_roads.cend())
+  {
+    TEST(false, ("There's no road in |m_roads| for feature id:", featureId));
     return;
+  }
 
   road = it->second;
 }
@@ -44,11 +47,22 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
 {
   AStarAlgorithm<IndexGraphStarter> algorithm;
   RoutingResult<Joint::Id> routingResult;
+
   auto const resultCode = algorithm.FindPath(
       starter, starter.GetStartJoint(), starter.GetFinishJoint(), routingResult, {}, {});
 
   starter.RedressRoute(routingResult.path, roadPoints);
   return resultCode;
+}
+
+void TestRouteSegments(IndexGraphStarter & starter,
+                       AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
+                       vector<RoadPoint> const & expectedRoute)
+{
+  vector<RoadPoint> route;
+  auto const resultCode = CalculateRoute(starter, route);
+  TEST_EQUAL(resultCode, expectedRouteResult, ());
+  TEST_EQUAL(route, expectedRoute, ());
 }
 
 void TestRouteGeometry(IndexGraphStarter & starter,
@@ -57,14 +71,49 @@ void TestRouteGeometry(IndexGraphStarter & starter,
 {
   vector<RoadPoint> route;
   auto const resultCode = CalculateRoute(starter, route);
+
   TEST_EQUAL(resultCode, expectedRouteResult, ());
-  TEST_EQUAL(route.size(), expectedRouteGeom.size(), ());
+  vector<m2::PointD> geom;
   for (size_t i = 0; i < route.size(); ++i)
   {
-    // When PR with applying restricions is merged IndexGraph::GetRoad() should be used here instead.
-    RoadGeometry roadGeom = starter.GetGraph().GetGeometry().GetRoad(route[i].GetFeatureId());
-    CHECK_LESS(route[i].GetPointId(), roadGeom.GetPointsCount(), ());
-    TEST_EQUAL(expectedRouteGeom[i], roadGeom.GetPoint(route[i].GetPointId()), ());
+    m2::PointD const & pnt = starter.GetPoint(route[i]);
+    // Note. In case of A* router all internal points of route are duplicated.
+    // So it's necessary to exclude the duplicates.
+    if (geom.empty() || geom.back() != pnt)
+      geom.push_back(pnt);
   }
+  TEST_EQUAL(geom, expectedRouteGeom, ());
+}
+
+void TestRestrictionPermutations(RestrictionVec restrictions,
+                                 vector<m2::PointD> const & expectedRouteGeom,
+                                 RoadPoint const & start, RoadPoint const & finish,
+                                 RestrictionTest & restrictionTest)
+{
+  sort(restrictions.begin(), restrictions.end());
+  do
+  {
+    for (Restriction const & restriction : restrictions)
+    {
+      CHECK_EQUAL(restriction.m_featureIds.size(), 2, ());
+      RestrictionPoint restrictionPoint;
+      CHECK(restrictionTest.GetRestrictionPoint(restriction.m_featureIds[0],
+                                                restriction.m_featureIds[1], restrictionPoint),
+            ());
+
+      switch (restriction.m_type)
+      {
+      case Restriction::Type::No:
+        restrictionTest.ApplyRestrictionNoRealFeatures(restrictionPoint);
+        continue;
+      case Restriction::Type::Only:
+        restrictionTest.ApplyRestrictionOnlyRealFeatures(restrictionPoint);
+        continue;
+      }
+    }
+    restrictionTest.SetStarter(start, finish);
+    TestRouteGeometry(*restrictionTest.m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+                      expectedRouteGeom);
+  } while (next_permutation(restrictions.begin(), restrictions.end()));
 }
 }  // namespace routing_test

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -1,0 +1,795 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_tests/index_graph_tools.hpp"
+
+#include "routing/car_model.hpp"
+#include "routing/geometry.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "std/unique_ptr.hpp"
+#include "std/vector.hpp"
+
+namespace routing_test
+{
+using namespace routing;
+
+void TestRoutes(vector<RoadPoint> const & starts, vector<RoadPoint> const & finishes,
+                vector<vector<RoadPoint>> const & expectedRoutes, IndexGraph & graph)
+{
+  CHECK_EQUAL(starts.size(), expectedRoutes.size(), ());
+  CHECK_EQUAL(finishes.size(), expectedRoutes.size(), ());
+
+  for (size_t i = 0; i < expectedRoutes.size(); ++i)
+  {
+    IndexGraphStarter starter(graph, starts[i], finishes[i]);
+    TestRouteSegments(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedRoutes[i]);
+  }
+}
+
+void EdgeTest(Joint::Id vertex, size_t expectedIntgoingNum, size_t expectedOutgoingNum,
+              bool graphWithoutRestrictions, IndexGraph & graph)
+{
+  vector<IndexGraphStarter::TEdgeType> ingoing;
+  graph.GetEdgeList(vertex, false /* is outgoing */, graphWithoutRestrictions, ingoing);
+  TEST_EQUAL(ingoing.size(), expectedIntgoingNum, ());
+
+  vector<IndexGraphStarter::TEdgeType> outgoing;
+  graph.GetEdgeList(vertex, true /* is outgoing */, graphWithoutRestrictions, outgoing);
+  TEST_EQUAL(outgoing.size(), expectedOutgoingNum, ());
+}
+
+// Finish
+// 2 *
+//   ^ ↖
+//   |   F1
+//   |      ↖
+// 1 |        *
+//   F0         ↖
+//   |            F2
+//   |              ↖
+// 0 *<--F3---<--F3---* Start
+//   0        1       2
+// Note. F0, F1 and F2 are one segment features. F3 is a two segments feature.
+unique_ptr<IndexGraph> BuildTriangularGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 2.0}}));
+  loader->AddRoad(1 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {0.0, 2.0}}));
+  loader->AddRoad(2 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 2.0}, {1.0, 1.0}}));
+  loader->AddRoad(3 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{2, 0}, {3, 0}}), /* joint at point (2, 0) */
+      MakeJoint({{3, 2}, {0, 0}}), /* joint at point (0, 0) */
+      MakeJoint({{2, 1}, {1, 0}}), /* joint at point (1, 1) */
+      MakeJoint({{0, 1}, {1, 1}})  /* joint at point (0, 2) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+// Route through triangular graph without any restrictions.
+UNIT_TEST(TriangularGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildTriangularGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(2, 0) /* start */, RoadPoint(1, 1) /* finish */);
+  vector<RoadPoint> const expectedRoute = {{2 /* feature id */, 0 /* seg id */}, {2, 1}, {1, 1}};
+  TestRouteSegments(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedRoute);
+}
+
+// Route through triangular graph with feature 2 disabled.
+UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_DisableF2)
+{
+  Init(BuildTriangularGraph());
+
+  DisableEdge({2 /* feature id */, 0 /* point id */}, {2, 1}, 2 /* feature id */);
+  SetStarter(RoadPoint(2, 0) /* start */, RoadPoint(1, 1) /* finish */);
+  vector<RoadPoint> const expectedRouteOneEdgeRemoved = {
+      {3 /* feature id */, 0 /* seg id */}, {3, 1}, {3, 2}, {0, 1}};
+  TestRouteSegments(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+                    expectedRouteOneEdgeRemoved);
+}
+
+// Route through triangular graph with restriction type no from feature 2 to feature 1.
+UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF2F1)
+{
+  Init(BuildTriangularGraph());
+
+  ApplyRestrictionNoRealFeatures(
+      RestrictionPoint({2 /* feature id */, 1 /* seg id */}, {1, 0}, GetJointId({1, 0})));
+  SetStarter(RoadPoint(2, 0) /* start */, RoadPoint(1, 1) /* finish */);
+  vector<RoadPoint> const expectedRouteRestrictionF2F1No = {
+      {3 /* feature id */, 0 /* seg id */}, {3, 1}, {3, 2}, {0, 1}};
+  TestRouteSegments(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+                    expectedRouteRestrictionF2F1No);
+}
+
+// Finish
+// 2 *
+//   ^ ↖
+//   |   ↖
+//   |     ↖
+// 1 |       Fake adding one link feature
+//   F0        ↖
+//   |           ↖
+//   |             ↖
+// 0 *<--F1---<--F1--* Start
+//   0        1       2
+// Note. F1 is a two setments feature. The others are one setment ones.
+unique_ptr<IndexGraph> BuildCornerGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 2.0}}));
+  loader->AddRoad(1 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}));
+
+  vector<Joint> const joints = {MakeJoint({{1 /* feature id */, 2 /* point id */}, {0, 0}}),
+                                /* joint at point (0, 0) */};
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  graph->InsertJoint({1 /* feature id */, 0 /* point id */});  // Start joint.
+  graph->InsertJoint({0 /* feature id */, 1 /* point id */});  // Finish joint.
+  return graph;
+}
+
+// Route through corner graph without any restrictions.
+UNIT_TEST(CornerGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildCornerGraph();
+
+  // Route along F1 and F0.
+  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(0, 1) /* finish */);
+  vector<RoadPoint> const expectedRoute = {
+      {1 /* feature id */, 0 /* point id */}, {1, 1}, {1, 2}, {0, 1}};
+  TestRouteSegments(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedRoute);
+}
+
+// Generate geometry based on feature 1 of corner graph.
+UNIT_CLASS_TEST(RestrictionTest, CornerGraph_CreateFakeFeature1Geometry)
+{
+  Init(BuildCornerGraph());
+
+  vector<vector<RoadPoint>> oneEdgeConnectionPaths;
+  GetConnectionPaths({1 /* feature id */, 0 /* point id */}, {1, 2}, oneEdgeConnectionPaths);
+  TEST_EQUAL(oneEdgeConnectionPaths.size(), 1, ());
+
+  vector<RoadPoint> const expectedDirectOrder = {{1, 0}, {1, 1}, {1, 2}};
+  TEST_EQUAL(oneEdgeConnectionPaths[0], expectedDirectOrder, ());
+  RoadGeometry geometryDirect;
+  CreateFakeFeatureGeometry(oneEdgeConnectionPaths[0], 1.0 /* speed */, geometryDirect);
+  RoadGeometry expectedGeomentryDirect(true /* one way */, 1.0 /* speed */,
+                                       RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}));
+  TEST_EQUAL(geometryDirect, expectedGeomentryDirect, ());
+}
+
+// Generate geometry based on reversed feature 1 of corner graph.
+UNIT_CLASS_TEST(RestrictionTest, CornerGraph_CreateFakeReversedFeature1Geometry)
+{
+  Init(BuildCornerGraph());
+
+  vector<vector<RoadPoint>> oneEdgeConnectionPaths;
+  GetConnectionPaths({1 /* feature id */, 2 /* point id */}, {1, 0}, oneEdgeConnectionPaths);
+  TEST_EQUAL(oneEdgeConnectionPaths.size(), 1, ());
+
+  vector<RoadPoint> const expectedBackOrder = {{1, 2}, {1, 1}, {1, 0}};
+  TEST_EQUAL(oneEdgeConnectionPaths[0], expectedBackOrder, ());
+  RoadGeometry geometryBack;
+  CreateFakeFeatureGeometry(oneEdgeConnectionPaths[0], 1.0 /* speed */, geometryBack);
+  RoadGeometry expectedGeomentryBack(true /* one way */, 1.0 /* speed */,
+                                     RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}}));
+  TEST_EQUAL(geometryBack, expectedGeomentryBack, ());
+}
+
+// Route through corner graph with adding a fake edge.
+UNIT_CLASS_TEST(RestrictionTest, CornerGraph_AddFakeFeature)
+{
+  RoadPoint const kStart(1, 0);
+  RoadPoint const kFinish(0, 1);
+  Init(BuildCornerGraph());
+
+  AddFakeFeature(kStart, kFinish, {kStart, kFinish} /* geometrySource */, 1.0 /* speed */);
+
+  SetStarter(kStart, kFinish);
+  vector<RoadPoint> const expectedRouteByFakeFeature = {
+      {IndexGraph::kStartFakeFeatureIds, 0 /* seg id */},
+      {IndexGraph::kStartFakeFeatureIds, 1 /* seg id */}};
+  TestRouteSegments(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+                    expectedRouteByFakeFeature);
+}
+
+// Finish
+// 2 *
+//   | \
+//   F0  F2
+//   |     \
+// 1 *       *
+//   |         \
+//   F0         F2
+//   |             \
+// 0 *---F1--*--F1--*
+//   0       1       2
+//         Start
+// Note. All features are two setments and two-way.
+unique_ptr<IndexGraph> BuildTwowayCornerGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}, {0.0, 2.0}}));
+  loader->AddRoad(1 /* feature id */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(2 /* feature id */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 1.0}, {0.0, 2.0}}));
+
+  vector<Joint> const joints = {MakeJoint({{1 /* feature id */, 2 /* point id */}, {0, 0}})
+                                /* joint at point (0, 0) */,
+                                MakeJoint({{1, 0}, {2, 0}}), /* joint at point (2, 0) */
+                                MakeJoint({{2, 2}, {0, 2}}),
+                                /* joint at point (0, 2) */};
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_AdditionalZeroEdges)
+{
+  Init(BuildTwowayCornerGraph());
+
+  RestrictionVec const restrictions = {
+      {Restriction::Type::Only, {1 /* feature from */, 0 /* feature to */}}};
+  m_graph->ApplyRestrictions(restrictions);
+  SetStarter(RoadPoint(1, 1) /* start */, RoadPoint(2, 2) /* finish */);
+
+  vector<DirectedEdge> expected = {
+      {0 /* from joint id */, 3 /* to joint id */, IndexGraph::kStartFakeFeatureIds + 2}};
+  TEST_EQUAL(GetFakeZeroLengthEdges(), expected, ());
+}
+
+UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_GetEdgeList)
+{
+  Init(BuildTwowayCornerGraph());
+
+  vector<DirectedEdge> outgoing;
+  m_graph->GetEdgeList(GetJointId({1 /* feature id */, 0 /* point id */}), true /* isOutgoing */,
+                       false /* graphWithoutRestrictions */, outgoing);
+
+  vector<DirectedEdge> expectedOutgoing = {
+      {1 /* from joint */, 0 /* to joint */, 1 /* feature id */},
+      {1 /* from joint */, 2 /* to joint */, 2 /* feature id */}};
+  TEST_EQUAL(outgoing, expectedOutgoing, ());
+
+  vector<DirectedEdge> ingoing;
+  m_graph->GetEdgeList(GetJointId({1 /* feature id */, 0 /* point id */}), false /* isOutgoing */,
+                       false /* graphWithoutRestrictions */, ingoing);
+  vector<DirectedEdge> expectedIngoing = {
+      {0 /* from joint */, 1 /* to joint */, 1 /* feature id */},
+      {2 /* from joint */, 1 /* to joint */, 2 /* feature id */}};
+  TEST_EQUAL(ingoing, expectedIngoing, ());
+}
+
+// Finish 2   Finish 1  Finish 0
+// 2 *<---F5----*<---F6---*
+//   ^ ↖       ^ ↖       ^
+//   | Fake-1   | Fake-0  |
+//   |     ↖   F1    ↖   F2
+//   |       ↖ |       ↖ |
+// 1 F0         *          *
+//   |          ^  ↖      ^
+//   |         F1  Fake-2 F2
+//   |          |       ↖ |
+// 0 *<----F4---*<---F3----* Start
+//   0          1          2
+// Note. F1 and F2 are two segments features. The others are one segment ones.
+unique_ptr<IndexGraph> BuildTwoSquaresGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 2.0}}));
+  loader->AddRoad(1 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}}));
+  loader->AddRoad(2 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {2.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(3 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(4 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(5 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 2.0}, {0.0, 2.0}}));
+  loader->AddRoad(6 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 2.0}, {1.0, 2.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{4 /* featureId */, 1 /* pointId */}, {0, 0}}), /* joint at point (0, 0) */
+      MakeJoint({{0, 1}, {5, 1}}),                               /* joint at point (0, 2) */
+      MakeJoint({{4, 0}, {1, 0}, {3, 1}}),                       /* joint at point (1, 0) */
+      MakeJoint({{5, 0}, {1, 2}, {6, 1}}),                       /* joint at point (1, 2) */
+      MakeJoint({{3, 0}, {2, 0}}),                               /* joint at point (2, 0) */
+      MakeJoint({{2, 2}, {6, 0}}),                               /* joint at point (2, 2) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+// Route through two squares graph without any restrictions.
+UNIT_TEST(TwoSquaresGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildTwoSquaresGraph();
+
+  vector<RoadPoint> const starts = {{2 /* feature id */, 0 /* point id */}, {2, 0}, {2, 0}};
+  vector<RoadPoint> const finishes = {{6 /* feature id */, 0 /* point id */}, {6, 1}, {5, 1}};
+  vector<RoadPoint> const expectedRoute0 = {{2 /* feature id */, 0 /* point id */}, {2, 1}, {2, 2}};
+  vector<RoadPoint> const expectedRoute1 = {
+      {2 /* feature id */, 0 /* point id */}, {2, 1}, {2, 2}, {6, 1}};
+  vector<RoadPoint> const expectedRoute2 = {
+      {2 /* feature id */, 0 /* point id */}, {2, 1}, {2, 2}, {6, 1}, {5, 1}};
+
+  TestRoutes(starts, finishes, {expectedRoute0, expectedRoute1, expectedRoute2}, *graph);
+}
+
+// Route through two squares graph with adding a Fake-0 edge.
+UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_AddFakeFeatureZero)
+{
+  Init(BuildTwoSquaresGraph());
+  AddFakeFeature(m_graph->InsertJoint({2 /* feature id */, 1 /* point id */}),
+                 GetJointId({6 /* feature id */, 1 /* point id */}),
+                 {{2, 1}, {6, 1}} /* geometrySource */, 1.0 /* speed */);
+
+  vector<RoadPoint> const starts = {{2 /* feature id */, 0 /* point id */}, {2, 0}, {2, 0}};
+  vector<RoadPoint> const finishes = {{6 /* feature id */, 0 /* point id */}, {6, 1}, {5, 1}};
+  vector<RoadPoint> const expectedRoute0 = {{2 /* feature id */, 0 /* point id */}, {2, 1}, {2, 2}};
+  vector<RoadPoint> const expectedRoute1 = {
+      {2 /* feature id */, 0 /* point id */}, {2, 1}, {IndexGraph::kStartFakeFeatureIds, 1}};
+  vector<RoadPoint> const expectedRoute2 = {{2 /* feature id */, 0 /* point id */},
+                                            {2, 1},
+                                            {IndexGraph::kStartFakeFeatureIds, 1},
+                                            {5, 1}};
+
+  TestRoutes(starts, finishes, {expectedRoute0, expectedRoute1, expectedRoute2}, *m_graph);
+}
+
+// Route through two squares graph with adding a Fake-0, Fake-1 and Fake-2 edge.
+UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_AddFakeFeatureZeroOneTwo)
+{
+  Init(BuildTwoSquaresGraph());
+  // Adding features: Fake 0, Fake 1 and Fake 2.
+  AddFakeFeature(m_graph->InsertJoint({2 /* feature id */, 1 /* point id */}),
+                 GetJointId({6 /* feature id */, 1 /* point id */}),
+                 {{2, 1}, {6, 1}} /* geometrySource */, 1.0 /* speed */);
+  AddFakeFeature(m_graph->InsertJoint({1 /* feature id */, 1 /* point id */}),
+                 GetJointId({5 /* feature id */, 1 /* point id */}),
+                 {{1, 1}, {5, 1}} /* geometrySource */, 1.0 /* speed */);
+  AddFakeFeature({2 /* feature id */, 0 /* point id */}, {1 /* feature id */, 1 /* point id */},
+                 {{2, 0}, {1, 1}} /* geometrySource */, 1.0 /* speed */);
+
+  vector<RoadPoint> const starts = {{2 /* feature id */, 0 /* point id */}, {2, 0}, {2, 0}};
+  vector<RoadPoint> const finishes = {{6 /* feature id */, 0 /* point id */}, {6, 1}, {5, 1}};
+  vector<RoadPoint> const expectedRoute0 = {{2 /* feature id */, 0 /* point id */}, {2, 1}, {2, 2}};
+  vector<RoadPoint> const expectedRoute1 = {
+      {2 /* feature id */, 0 /* point id */}, {2, 1}, {IndexGraph::kStartFakeFeatureIds, 1}};
+  vector<RoadPoint> const expectedRoute2 = {{IndexGraph::kStartFakeFeatureIds + 2 /* Fake 2 */, 0},
+                                            {IndexGraph::kStartFakeFeatureIds + 2 /* Fake 2 */, 1},
+                                            {IndexGraph::kStartFakeFeatureIds + 1 /* Fake 1 */, 1}};
+  TestRoutes(starts, finishes, {expectedRoute0, expectedRoute1, expectedRoute2}, *m_graph);
+
+  // Disabling Fake-2 feature.
+  DisableEdge({IndexGraph::kStartFakeFeatureIds + 2 /* Fake 2 */, 0},
+              {IndexGraph::kStartFakeFeatureIds + 2 /* Fake 2 */, 1},
+              IndexGraph::kStartFakeFeatureIds + 2 /* Fake feature id */);
+  vector<RoadPoint> const expectedRoute2Disable2 = {{2 /* feature id */, 0 /* point id */},
+                                                    {2, 1},
+                                                    {IndexGraph::kStartFakeFeatureIds, 1},
+                                                    {5, 1}};
+  TestRoutes(starts, finishes, {expectedRoute0, expectedRoute1, expectedRoute2Disable2}, *m_graph);
+}
+
+//      Finish
+// 1 *-F4-*-F5-*
+//   |         |
+//   F2        F3
+//   |         |
+// 0 *---F1----*---F0---* Start
+//   0         1        2
+// Note 1. All features are two-way. (It's possible to move along any direction of the features.)
+// Note 2. Any feature contains of one segment.
+unique_ptr<IndexGraph> BuildFlagGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(1 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(2 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}}));
+  loader->AddRoad(3 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(4 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 1.0}, {0.5, 1.0}}));
+  loader->AddRoad(5 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.5, 1.0}, {1.0, 1.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{1 /* feature id */, 1 /* point id */}, {2, 0}}), /* joint at point (0, 0) */
+      MakeJoint({{2, 1}, {4, 0}}),                                 /* joint at point (0, 1) */
+      MakeJoint({{4, 1}, {5, 0}}),                                 /* joint at point (0.5, 1) */
+      MakeJoint({{1, 0}, {3, 0}, {0, 1}}),                         /* joint at point (1, 0) */
+      MakeJoint({{3, 1}, {5, 1}}),                                 /* joint at point (1, 1) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  // Note. It's necessary to insert start joint because the edge F0 is used
+  // for creating restrictions.
+  graph->InsertJoint({0 /* feature id */, 0 /* point id */});  // start
+  return graph;
+}
+
+// Route through flag graph without any restrictions.
+UNIT_TEST(FlagGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildFlagGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(0, 0) /* start */, RoadPoint(5, 0) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {0.5, 1}};
+  TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through flag graph with one restriciton (type no) from F0 to F3.
+UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F3No)
+{
+  Init(BuildFlagGraph());
+  Joint::Id const restictionCenterId = GetJointId({0, 1});
+
+  // Testing outgoing and ingoing edge number near restriction joint.
+  EdgeTest(restictionCenterId, 3 /* expectedIntgoingNum */, 3 /* expectedOutgoingNum */,
+           false /* graphWithoutRestrictions */, *m_graph);
+  ApplyRestrictionNoRealFeatures(RestrictionPoint({0 /* feature id */, 1 /* point id */},
+                                                  {3 /* feature id */, 0 /* point id */},
+                                                  restictionCenterId));
+  EdgeTest(restictionCenterId, 2 /* expectedIntgoingNum */, 3 /* expectedOutgoingNum */,
+           false /* graphWithoutRestrictions */, *m_graph);
+  EdgeTest(restictionCenterId, 3 /* expectedIntgoingNum */, 3 /* expectedOutgoingNum */,
+           true /* graphWithoutRestrictions */, *m_graph);
+
+  // Testing route building after adding the restriction.
+  SetStarter(RoadPoint(0, 0) /* start */, RoadPoint(5, 0) /* finish */);
+  vector<m2::PointD> const expectedGeom = {
+      {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through flag graph with one restriciton (type only) from F0 to F1.
+UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F1Only)
+{
+  Init(BuildFlagGraph());
+  Joint::Id const restictionCenterId = GetJointId({0, 1});
+  ApplyRestrictionOnlyRealFeatures(RestrictionPoint({0 /* feature id */, 1 /* point id */},
+                                                    {1 /* feature id */, 0 /* point id */},
+                                                    restictionCenterId));
+
+  SetStarter(RoadPoint(0, 0) /* start */, RoadPoint(5, 0) /* finish */);
+  vector<RoadPoint> const expectedRoute = {{IndexGraph::kStartFakeFeatureIds, 0 /* point id */},
+                                           {IndexGraph::kStartFakeFeatureIds, 1},
+                                           {IndexGraph::kStartFakeFeatureIds + 1, 1},
+                                           {2 /* feature id */, 1 /* point id */},
+                                           {4, 1}};
+  TestRouteSegments(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedRoute);
+}
+
+UNIT_CLASS_TEST(RestrictionTest, FlagGraph_FindPointsWithCommonFeatureTest)
+{
+  Init(BuildFlagGraph());
+  Joint::Id const restictionCenterId = GetJointId({0, 1});
+  ApplyRestrictionOnlyRealFeatures(RestrictionPoint({0 /* feature id */, 1 /* point id */},
+                                                    {1 /* feature id */, 0 /* point id */},
+                                                    restictionCenterId));
+
+  SetStarter(RoadPoint(0, 1) /* start */, RoadPoint(5, 0) /* finish */);
+
+  // Finds fake zero length feature of starter.
+  RoadPoint result0;
+  RoadPoint result1;
+  FindPointsWithCommonFeature(3 /* from joint id */, 6 /* to joint id */, result0, result1);
+  TEST_EQUAL(result0, RoadPoint(IndexGraph::kStartFakeFeatureIds + 2, 0 /* point id */), ());
+  TEST_EQUAL(result1, RoadPoint(IndexGraph::kStartFakeFeatureIds + 2, 1 /* point id */), ());
+}
+
+UNIT_CLASS_TEST(RestrictionTest, FlagGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6Only)
+{
+  Init(BuildFlagGraph());
+  RestrictionVec const restrictions = {
+      {Restriction::Type::No, {0 /* feature from */, 3 /* feature to */}},
+      {Restriction::Type::Only, {0 /* feature from */, 1 /* feature to */}},
+      {Restriction::Type::Only, {1 /* feature from */, 2 /* feature to */}}};
+
+  vector<m2::PointD> const expectedGeom = {
+      {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
+  TestRestrictionPermutations(restrictions, expectedGeom, RoadPoint(0, 0) /* start */,
+                              RoadPoint(5, 0) /* finish */, *this);
+}
+
+// 1 *-F4-*-F5-*---F6---* Finish
+//   |         |
+//   F2        F3
+//   |         |
+// 0 *---F1----*---F0---* Start
+//   0         1        2
+// Note 1. All features are two-way. (It's possible to move along any direction of the features.)
+// Note 2. Any feature contains of one segment.
+unique_ptr<IndexGraph> BuildPosterGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(1 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(2 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}}));
+  loader->AddRoad(3 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(4 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 1.0}, {0.5, 1.0}}));
+  loader->AddRoad(5 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.5, 1.0}, {1.0, 1.0}}));
+  loader->AddRoad(6 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 1.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{1 /* feature id */, 1 /* point id */}, {2, 0}}), /* joint at point (0, 0) */
+      MakeJoint({{2, 1}, {4, 0}}),                                 /* joint at point (0, 1) */
+      MakeJoint({{4, 1}, {5, 0}}),                                 /* joint at point (0.5, 1) */
+      MakeJoint({{1, 0}, {3, 0}, {0, 1}}),                         /* joint at point (1, 0) */
+      MakeJoint({{3, 1}, {5, 1}, {6, 0}}),                         /* joint at point (1, 1) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  // Note. It's necessary to insert start and finish joints because the edge F0 is used
+  // for creating restrictions.
+  graph->InsertJoint({0 /* feature id */, 0 /* point id */});  // start
+  graph->InsertJoint({6 /* feature id */, 1 /* point id */});  // finish
+
+  return graph;
+}
+
+// Route through poster graph without any restrictions.
+UNIT_TEST(PosterGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildPosterGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(0, 0) /* start */, RoadPoint(6, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {2, 1}};
+
+  TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through poster graph with restrictions F0-F3 (type no).
+UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F3No)
+{
+  Init(BuildPosterGraph());
+  Joint::Id const restictionCenterId = GetJointId({0, 1});
+
+  ApplyRestrictionNoRealFeatures(
+      RestrictionPoint({0 /* feature id */, 1 /* point id */}, {3, 0}, restictionCenterId));
+
+  SetStarter(RoadPoint(0, 0) /* start */, RoadPoint(6, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {
+      {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// Route through poster graph with restrictions F0-F1 (type only).
+UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F1Only)
+{
+  Init(BuildPosterGraph());
+  Joint::Id const restictionCenterId = GetJointId({0, 1});
+
+  ApplyRestrictionOnlyRealFeatures(
+      RestrictionPoint({0 /* feature id */, 1 /* point id */}, {1, 0}, restictionCenterId));
+
+  m_graph->ForEachNonBlockedEdgeMappingNode(
+      DirectedEdge(GetJointId({0 /* feature id */, 0 /* point id */}), GetJointId({0, 1}),
+                   0 /* feature id */),
+      [](DirectedEdge const & leaf) {
+        TEST_EQUAL(leaf, DirectedEdge(5 /* form joint id */, 7 /* to joint id */,
+                                      IndexGraph::kStartFakeFeatureIds),
+                   ());
+        return;
+      });
+
+  SetStarter(RoadPoint(0, 0) /* start */, RoadPoint(6, 1) /* finish */);
+  vector<m2::PointD> const expectedGeom = {
+      {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// 1               *--F1-->*
+//               ↗          ↘
+//            F1               F1
+//          ↗                   ↘
+// Start 0 *---F0--->-------F0----->* Finish
+//         0        1       2       3
+// Start
+// Note. F0 is a two setments feature. F1 is a three segment one.
+unique_ptr<IndexGraph> BuildTwoWayGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}, {3.0, 0}}));
+  loader->AddRoad(1 /* feature id */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 1.0}, {2.0, 1.0}, {3.0, 0.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{0 /* feature id */, 0 /* point id */}, {1, 0}}), /* joint at point (0, 0) */
+      MakeJoint({{0 /* feature id */, 2 /* point id */}, {1, 3}})};
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+UNIT_CLASS_TEST(RestrictionTest, TwoWay_GetSingleFeaturePath)
+{
+  Init(BuildTwoWayGraph());
+  vector<RoadPoint> singleFeaturePath;
+
+  // Full feature 0.
+  GetSingleFeaturePath({0 /* feature id */, 0 /* point id */}, {0, 2}, singleFeaturePath);
+  vector<RoadPoint> const expectedF0 = {{0 /* feature id */, 0 /* point id */}, {0, 1}, {0, 2}};
+  TEST_EQUAL(singleFeaturePath, expectedF0, ());
+
+  // Full feature 1.
+  GetSingleFeaturePath({1 /* feature id */, 0 /* point id */}, {1, 3}, singleFeaturePath);
+  vector<RoadPoint> const expectedF1 = {
+      {1 /* feature id */, 0 /* point id */}, {1, 1}, {1, 2}, {1, 3}};
+  TEST_EQUAL(singleFeaturePath, expectedF1, ());
+
+  // Full feature 1 in reversed order.
+  GetSingleFeaturePath({1 /* feature id */, 3 /* point id */}, {1, 0}, singleFeaturePath);
+  vector<RoadPoint> const expectedReversedF1 = {
+      {1 /* feature id */, 3 /* point id */}, {1, 2}, {1, 1}, {1, 0}};
+  TEST_EQUAL(singleFeaturePath, expectedReversedF1, ());
+
+  // Part of feature 0.
+  GetSingleFeaturePath({0 /* feature id */, 1 /* point id */}, {0, 2}, singleFeaturePath);
+  vector<RoadPoint> const expectedPartF0 = {{0 /* feature id */, 1 /* point id */}, {0, 2}};
+  TEST_EQUAL(singleFeaturePath, expectedPartF0, ());
+
+  // Part of feature 1 in reversed order.
+  GetSingleFeaturePath({1 /* feature id */, 2 /* point id */}, {1, 1}, singleFeaturePath);
+  vector<RoadPoint> const expectedPartF1 = {{1 /* feature id */, 2 /* point id */}, {1, 1}};
+  TEST_EQUAL(singleFeaturePath, expectedPartF1, ());
+
+  // Single point test.
+  GetSingleFeaturePath({0 /* feature id */, 0 /* point id */}, {0, 0}, singleFeaturePath);
+  vector<RoadPoint> const expectedSinglePoint = {{0 /* feature id */, 0 /* point id */}};
+  TEST_EQUAL(singleFeaturePath, expectedSinglePoint, ());
+}
+
+UNIT_CLASS_TEST(RestrictionTest, TwoWay_GetConnectionPaths)
+{
+  Init(BuildTwoWayGraph());
+
+  vector<vector<RoadPoint>> connectionPaths;
+  GetConnectionPaths({1 /* feature id */, 0 /* point id */}, {0, 2}, connectionPaths);
+  vector<vector<RoadPoint>> const expectedConnectionPaths = {
+      {{0, 0}, {0, 1}, {0, 2}},          // feature 0
+      {{1, 0}, {1, 1}, {1, 2}, {1, 3}},  // feature 1
+  };
+  sort(connectionPaths.begin(), connectionPaths.end());
+  TEST_EQUAL(connectionPaths, expectedConnectionPaths, ());
+}
+
+UNIT_CLASS_TEST(RestrictionTest, TwoWay_GetFeatureConnectionPath)
+{
+  Init(BuildTwoWayGraph());
+  vector<RoadPoint> featurePath;
+
+  // Full feature 0.
+  GetFeatureConnectionPath({1 /* feature id */, 0 /* point id */}, {1, 3}, 0 /* feature id */,
+                           featurePath);
+  vector<RoadPoint> const expectedF0Path = {{0, 0}, {0, 1}, {0, 2}};
+  TEST_EQUAL(featurePath, expectedF0Path, ());
+
+  // Full feature 1.
+  GetFeatureConnectionPath({1 /* feature id */, 0 /* point id */}, {1, 3}, 1 /* feature id */,
+                           featurePath);
+  vector<RoadPoint> const expectedF1Path = {{1, 0}, {1, 1}, {1, 2}, {1, 3}};
+  TEST_EQUAL(featurePath, expectedF1Path, ());
+
+  // Reversed full feature 0.
+  GetFeatureConnectionPath({1 /* feature id */, 3 /* point id */}, {1, 0}, 0 /* feature id */,
+                           featurePath);
+  vector<RoadPoint> const expectedReversedF0Path = {{0, 2}, {0, 1}, {0, 0}};
+  TEST_EQUAL(featurePath, expectedReversedF0Path, ());
+}
+
+// 1          *---F4----*
+//            |         |
+//           F2        F3
+//            |         |
+// 0 *<--F5---*<--F1----*<--F0---* Start
+// Finish
+//   0        1        2         3
+// Note 1. F0, F1 and F5 are one-way features. F3, F2 and F4 are two-way features.
+// Note 2. Any feature contains of one segment.
+unique_ptr<IndexGraph> BuildSquaresGraph()
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{3.0, 0.0}, {2.0, 0.0}}));
+  loader->AddRoad(1 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(2 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(3 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {2.0, 1.0}}));
+  loader->AddRoad(4 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 1.0}, {1.0, 1.0}}));
+  loader->AddRoad(5 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {0.0, 0.0}}));
+
+  vector<Joint> const joints = {
+      MakeJoint({{0 /* feature id */, 0 /* point id */}}), /* joint at point (3, 0) */
+      MakeJoint({{0, 1}, {3, 0}, {1, 0}}),                 /* joint at point (2, 0) */
+      MakeJoint({{3, 1}, {4, 0}}),                         /* joint at point (2, 1) */
+      MakeJoint({{2, 1}, {4, 1}}),                         /* joint at point (1, 1) */
+      MakeJoint({{1, 1}, {2, 0}, {5, 0}}),                 /* joint at point (1, 0) */
+      MakeJoint({{5, 1}})                                  /* joint at point (0, 0) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  unique_ptr<IndexGraph> graph =
+      make_unique<IndexGraph>(move(loader), CreateEstimator(trafficCache));
+  graph->Import(joints);
+  return graph;
+}
+
+UNIT_TEST(SquaresGraph)
+{
+  unique_ptr<IndexGraph> graph = BuildSquaresGraph();
+  IndexGraphStarter starter(*graph, RoadPoint(0, 0) /* start */, RoadPoint(5, 0) /* finish */);
+  vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}};
+  TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+
+// It's a test on correct working in case when because of adding restrictions
+// start and finish could be match on blocked, moved or copied edges.
+// See IndexGraphStarter constructor for a detailed description.
+UNIT_CLASS_TEST(RestrictionTest, SquaresGraph_RestrictionF0F1OnlyF1F5Only)
+{
+  Init(BuildSquaresGraph());
+
+  RestrictionVec const restrictions = {
+      {Restriction::Type::Only, {0 /* feature from */, 1 /* feature to */}},
+      {Restriction::Type::Only, {1 /* feature from */, 5 /* feature to */}}};
+  m_graph->ApplyRestrictions(restrictions);
+
+  SetStarter(RoadPoint(0, 0) /* start */, RoadPoint(5, 0) /* finish */);
+
+  vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}};
+  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+}
+}  // namespace routing_test

--- a/routing/routing_tests/routing_tests.pro
+++ b/routing/routing_tests/routing_tests.pro
@@ -27,12 +27,14 @@ SOURCES += \
   astar_router_test.cpp \
   async_router_test.cpp \
   cross_routing_tests.cpp \
+  cumulative_restriction_test.cpp \
   followed_polyline_test.cpp \
   index_graph_test.cpp \
   index_graph_tools.cpp \
   nearest_edge_finder_tests.cpp \
   online_cross_fetcher_test.cpp \
   osrm_router_test.cpp \
+  restriction_test.cpp \
   road_graph_builder.cpp \
   road_graph_nearest_edges_test.cpp \
   route_tests.cpp \

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -44,8 +44,12 @@
 		56555E561D897C90009D786D /* libalohalitics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACE61C68A23B009CB89E /* libalohalitics.a */; };
 		56555E581D897C9D009D786D /* liboauthcpp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACFA1C68A2D7009CB89E /* liboauthcpp.a */; };
 		56555E591D897D28009D786D /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6742ACDE1C68A13F009CB89E /* testingmain.cpp */; };
+		5678A6631E019DAA00D29BE6 /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5678A6611E019DAA00D29BE6 /* restrictions_serialization.cpp */; };
+		5678A6641E019DAA00D29BE6 /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5678A6621E019DAA00D29BE6 /* restrictions_serialization.hpp */; };
 		56826BD01DB51C4E00807C62 /* car_router.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56826BCE1DB51C4E00807C62 /* car_router.cpp */; };
 		56826BD11DB51C4E00807C62 /* car_router.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56826BCF1DB51C4E00807C62 /* car_router.hpp */; };
+		569831C91DE9930B00D6E247 /* restriction_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 569831C71DE9930B00D6E247 /* restriction_loader.cpp */; };
+		569831CA1DE9930B00D6E247 /* restriction_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 569831C81DE9930B00D6E247 /* restriction_loader.hpp */; };
 		56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */; };
 		56F0D7341D896A5300045886 /* libmap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BD35DE1C69F198003AA26F /* libmap.a */; };
 		56F0D7391D896A5300045886 /* libstorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BD35D41C69F155003AA26F /* libstorage.a */; };
@@ -278,8 +282,12 @@
 		56099E321CC9247E00A7772A /* directions_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = directions_engine.cpp; sourceTree = "<group>"; };
 		563B91C31CC4F1DC00222BC1 /* bicycle_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_model.cpp; sourceTree = "<group>"; };
 		563B91C41CC4F1DC00222BC1 /* bicycle_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_model.hpp; sourceTree = "<group>"; };
+		5678A6611E019DAA00D29BE6 /* restrictions_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restrictions_serialization.cpp; sourceTree = "<group>"; };
+		5678A6621E019DAA00D29BE6 /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
 		56826BCE1DB51C4E00807C62 /* car_router.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = car_router.cpp; sourceTree = "<group>"; };
 		56826BCF1DB51C4E00807C62 /* car_router.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = car_router.hpp; sourceTree = "<group>"; };
+		569831C71DE9930B00D6E247 /* restriction_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restriction_loader.cpp; sourceTree = "<group>"; };
+		569831C81DE9930B00D6E247 /* restriction_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restriction_loader.hpp; sourceTree = "<group>"; };
 		56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_helpers.hpp; sourceTree = "<group>"; };
 		56F0D75F1D896A5300045886 /* routing_benchmarks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = routing_benchmarks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_routing_context.cpp; sourceTree = "<group>"; };
@@ -669,6 +677,10 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				5678A6611E019DAA00D29BE6 /* restrictions_serialization.cpp */,
+				5678A6621E019DAA00D29BE6 /* restrictions_serialization.hpp */,
+				569831C71DE9930B00D6E247 /* restriction_loader.cpp */,
+				569831C81DE9930B00D6E247 /* restriction_loader.hpp */,
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
 				56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */,
@@ -806,6 +818,7 @@
 				A120B3481B4A7BE5002F3808 /* cross_mwm_router.hpp in Headers */,
 				674F9BD31B0A580E00704FFA /* road_graph_router.hpp in Headers */,
 				675344141A3F644F00A0A8C3 /* osrm_data_facade.hpp in Headers */,
+				569831CA1DE9930B00D6E247 /* restriction_loader.hpp in Headers */,
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
 				6753441A1A3F644F00A0A8C3 /* osrm2feature_map.hpp in Headers */,
@@ -838,6 +851,7 @@
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
 				670D049F1B0B4A970013A7AC /* nearest_edge_finder.hpp in Headers */,
 				A120B34F1B4A7C0A002F3808 /* online_absent_fetcher.hpp in Headers */,
+				5678A6641E019DAA00D29BE6 /* restrictions_serialization.hpp in Headers */,
 				674F9BD51B0A580E00704FFA /* road_graph.hpp in Headers */,
 				56826BD11DB51C4E00807C62 /* car_router.hpp in Headers */,
 				A120B3511B4A7C0A002F3808 /* routing_algorithm.hpp in Headers */,
@@ -1079,11 +1093,13 @@
 				6753441B1A3F644F00A0A8C3 /* route.cpp in Sources */,
 				674F9BCA1B0A580E00704FFA /* async_router.cpp in Sources */,
 				675344191A3F644F00A0A8C3 /* osrm2feature_map.cpp in Sources */,
+				569831C91DE9930B00D6E247 /* restriction_loader.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,
 				A17B42981BCFBD0E00A1EAE4 /* osrm_helpers.cpp in Sources */,
 				563B91C51CC4F1DC00222BC1 /* bicycle_model.cpp in Sources */,
 				674F9BD21B0A580E00704FFA /* road_graph_router.cpp in Sources */,
+				5678A6631E019DAA00D29BE6 /* restrictions_serialization.cpp in Sources */,
 				A1876BC61BB19C4300C9C743 /* speed_camera.cpp in Sources */,
 				0C5FEC691DDE193F0017688C /* road_index.cpp in Sources */,
 				671F58BD1B874EC80032311E /* followed_polyline.cpp in Sources */,


### PR DESCRIPTION
Данный PR реализовывает наложение restriction на index graph. В не тривильных случаях это одно из двух преобразований графа: 
Restriction type Only
```
  // It's possible to move only from one segment to another in case of any number of ingoing and
  // outgoing edges.
  // The idea is to tranform the navigation graph for every non-degenerate case as it's shown below.
  // At the picture below a restriction for permission moving only from 6 to O to 3 is shown.
  // So to implement it it's necessary to remove (disable) an edge 6-O and add feature (edge) 4-N-3.
  // Adding N is important for a route recovery stage. (The geometry of O will be copied to N.)
  //
  // 1       2       3                     1       2       3
  // *       *       *                     *       *       *
  //  ↖     ^     ↗                        ↖     ^     ↗^
  //    ↖   |   ↗                            ↖   |   ↗  |
  //      ↖ | ↗                                ↖ | ↗    |
  //         *  O             ==>                  *  O    * N
  //      ↗ ^ ↖                                 ↗^       ^
  //    ↗   |   ↖                             ↗  |       |
  //  ↗     |     ↖                         ↗    |       |
  // *       *       *                     *       *       *
  // 4       5       6                     4       5       6
  //
  // In case of this transformation the following edge mapping happens:
  // 6-O -> 6-N
  // O-3 -> O-3; N-3
```

Restriction type No
```
  // Prohibition of moving from one segment to another in case of any number of ingoing and outgoing
  // edges.
  // The idea is to transform the navigation graph for every non-degenerate case as it's shown below.
  // At the picture below a restriction for prohibition moving from 4 to O to 3 is shown.
  // So to implement it it's necessary to remove (disable) an edge 4-O and add features (edges)
  // 4-N-1 and N-2.
  //
  // 1       2       3                     1       2       3
  // *       *       *                     *       *       *
  //  ↖     ^     ↗                       ^↖   ↗^     ↗
  //    ↖   |   ↗                         |  ↖   |   ↗
  //      ↖ | ↗                           |↗   ↖| ↗
  //         *  O             ==>        N *       *  O
  //      ↗ ^ ↖                           ^       ^ ↖
  //    ↗   |   ↖                         |       |   ↖
  //  ↗     |     ↖                       |       |     ↖
  // *       *       *                     *       *       *
  // 4       5       6                     4       5       6
  //
  // In case of this transformation the following edge mapping happens:
  // 4-O -> 4-N
  // O-1 -> O-1; N-1
  // O-2 -> 0-2; N-2
```

В данном PR я планирую еще доделать наложение пересекающихся рестрикшинов (входная дуга одного совпадает с выходной дугой другого). И добавить тестов.

Но это сильно не повлияет на уже написанный код. Прошу всех заинтересованных коллег приступать к ревью.

@ygorshenin @mpimenov @dobriy-eeh PTAL
