### PR TITLE
Release 65 hot fix

### DIFF
--- a/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
+++ b/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
@@ -1010,7 +1010,6 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
     {
       mHeadersDecoration.invalidateHeaders();
       notifyItemRangeInserted(mNearMeCount, mAds.size());
-      handleBannersShow(mAds);
       return;
     }
 


### PR DESCRIPTION
Фикс крэша https://www.fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/583ef7150aeb16625b73c609 с 1% сборки.

Фикс заключается в том, что мы не должны вызывать метод handleBannersShow когда показываем баннеры из нашего кэша, так как myTarget сдк в этот момент может не проинициализирован корректно