### PR TITLE
Traffic cache for routing memory optimization.

### DIFF
--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -593,7 +593,7 @@ void RoutingSession::OnTrafficInfoAdded(TrafficInfo && info)
   ASSERT_EQUAL(kSpeedGroupThresholdPercentage[static_cast<size_t>(SpeedGroup::Unknown)], 100, ());
 
   // The code below is memory optimization. Edges with traffic SpeedGroup::G5 and
-  // SpeedGroup::Unknown are 95% of all edges but they are not used in routing now.
+  // SpeedGroup::Unknown constitute a large part of all edges but they are not used in routing now.
   // So we don't need to keep the information in TrafficCache.
   TrafficInfo::Coloring const & fullColoring = info.GetColoring();
   TrafficInfo::Coloring coloring;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -589,9 +589,23 @@ void RoutingSession::OnTrafficInfoClear()
 
 void RoutingSession::OnTrafficInfoAdded(TrafficInfo && info)
 {
+  ASSERT_EQUAL(kSpeedGroupThresholdPercentage[static_cast<size_t>(SpeedGroup::G5)], 100, ());
+  ASSERT_EQUAL(kSpeedGroupThresholdPercentage[static_cast<size_t>(SpeedGroup::Unknown)], 100, ());
+
+  // The code below is memory optimization. Edges with traffic SpeedGroup::G5 and
+  // SpeedGroup::Unknown are 95% of all edges but they are not used in routing now.
+  // So we don't need to keep the information in TrafficCache.
+  TrafficInfo::Coloring const & fullColoring = info.GetColoring();
+  TrafficInfo::Coloring coloring;
+  for (auto const & kv : fullColoring)
+  {
+    if (kv.second != SpeedGroup::G5 && kv.second != SpeedGroup::Unknown)
+      coloring.insert(kv);
+  }
+
   threads::MutexGuard guard(m_routingSessionMutex);
   UNUSED_VALUE(guard);
-  Set(move(info));
+  Set(info.GetMwmId(), move(coloring));
 }
 
 void RoutingSession::OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId)
@@ -601,7 +615,7 @@ void RoutingSession::OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId)
   Remove(mwmId);
 }
 
-shared_ptr<traffic::TrafficInfo> RoutingSession::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
+shared_ptr<TrafficInfo::Coloring> RoutingSession::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
 {
   threads::MutexGuard guard(m_routingSessionMutex);
   UNUSED_VALUE(guard);

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -160,7 +160,7 @@ public:
   void OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId) override;
 
   // TrafficCache overrides:
-  shared_ptr<traffic::TrafficInfo> GetTrafficInfo(MwmSet::MwmId const & mwmId) const override;
+  shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(MwmSet::MwmId const & mwmId) const override;
 
 private:
   struct DoReadyCallback

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -92,7 +92,11 @@ public:
   class TrafficCacheTest : public TrafficCache
   {
   public:
-    void SetTrafficInfo(traffic::TrafficInfo && info) { Set(move(info)); }
+    void SetTrafficInfo(TrafficInfo && info)
+    {
+      TrafficInfo::Coloring coloring = info.GetColoring();
+      Set(info.GetMwmId(), move(coloring));
+    }
   };
 
   ApplyingTrafficTest() { classificator::Load(); }

--- a/traffic/traffic_cache.cpp
+++ b/traffic/traffic_cache.cpp
@@ -2,22 +2,21 @@
 
 namespace traffic
 {
-void TrafficCache::Set(TrafficInfo && info)
+void TrafficCache::Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && coloring)
 {
-  MwmSet::MwmId const mwmId = info.GetMwmId();
-  m_trafficInfo[mwmId] = make_shared<TrafficInfo>(move(info));
+  m_trafficColoring[mwmId] = make_shared<TrafficInfo::Coloring>(move(coloring));
 }
 
-void TrafficCache::Remove(MwmSet::MwmId const & mwmId) { m_trafficInfo.erase(mwmId); }
+void TrafficCache::Remove(MwmSet::MwmId const & mwmId) { m_trafficColoring.erase(mwmId); }
 
-shared_ptr<TrafficInfo> TrafficCache::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
+shared_ptr<TrafficInfo::Coloring> TrafficCache::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
 {
-  auto it = m_trafficInfo.find(mwmId);
+  auto it = m_trafficColoring.find(mwmId);
 
-  if (it == m_trafficInfo.cend())
-    return shared_ptr<TrafficInfo>();
+  if (it == m_trafficColoring.cend())
+    return shared_ptr<TrafficInfo::Coloring>();
   return it->second;
 }
 
-void TrafficCache::Clear() { m_trafficInfo.clear(); }
+void TrafficCache::Clear() { m_trafficColoring.clear(); }
 }  // namespace traffic

--- a/traffic/traffic_cache.hpp
+++ b/traffic/traffic_cache.hpp
@@ -11,17 +11,17 @@ namespace traffic
 class TrafficCache
 {
 public:
-  TrafficCache() : m_trafficInfo() {}
+  TrafficCache() : m_trafficColoring() {}
   virtual ~TrafficCache() = default;
 
-  virtual shared_ptr<traffic::TrafficInfo> GetTrafficInfo(MwmSet::MwmId const & mwmId) const;
+  virtual shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(MwmSet::MwmId const & mwmId) const;
 
 protected:
-  void Set(traffic::TrafficInfo && info);
+  void Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && mwmIdAndColoring);
   void Remove(MwmSet::MwmId const & mwmId);
   void Clear();
 
 private:
-  map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo>> m_trafficInfo;
+  map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> m_trafficColoring;
 };
 }  // namespace traffic


### PR DESCRIPTION
@rokuz @mpimenov @ygorshenin прошу оперативно посмотреть.

Оптимизация пробочного кеша для роутинга. 95% трафик информации сейчас составляют зеленые дуги и дуги трафик на которых не известен. В тоже время в роутинге они сейчас не используются. Так не будем их хранить в кеше. Кроме того, сейчас после закачки в TrafficInfo появилось поле vector<RoadSegmentId> m_keys. Оно тоже может быть большим и для роутнига не нужно.

Для Москвы в TrafficInfo передается 945438 дуг. Если из них выкинуть SpeedGroup::G5 и SpeedGroup::Unknown то останется 58518 дуг.