### PR TITLE
[tracking] change gps reporter push period from 10 sec to 20 sec

### DIFF
--- a/tracking/reporter.cpp
+++ b/tracking/reporter.cpp
@@ -21,7 +21,7 @@ namespace tracking
 const char Reporter::kEnableTrackingKey[] = "StatisticsEnabled";
 
 // static
-milliseconds const Reporter::kPushDelayMs = milliseconds(10000);
+milliseconds const Reporter::kPushDelayMs = milliseconds(20000);
 
 Reporter::Reporter(unique_ptr<platform::Socket> socket, string const & host, uint16_t port,
                    milliseconds pushDelay)


### PR DESCRIPTION
Увеличил период с 10 до 20 секунд, через который gps координаты отправляются на сервер.