### PR TITLE
Fixed traffic for left-handed mwms

### DIFF
--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -84,8 +84,6 @@ void ExtractTrafficGeometry(FeatureType const & f, df::RoadClass const & roadCla
 
       auto const sid = traffic::TrafficInfo::RoadSegmentId(f.GetID().m_index, segIndex, directions[dirIndex]);
       bool isReversed = (directions[dirIndex] == traffic::TrafficInfo::RoadSegmentId::kReverseDirection);
-      if (isLeftHandTraffic)
-        isReversed = !isReversed;
 
       auto const segment = polyline.ExtractSegment(segIndex, isReversed);
       ASSERT_EQUAL(segment.size(), 2, ());


### PR DESCRIPTION
Для левосторонних локаций мы не должны инвертировать порядок следования точек, т.к. этот порядок уже учитывается при расчете входящих и исходящих ребер при матчинге