### PR TITLE
[release] Bugfix in turn generation system.

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -39,7 +39,6 @@ public:
 
   // turns::IRoutingResult overrides:
   TUnpackedPathSegments const & GetSegments() const override { return m_pathSegments; }
-
   void GetPossibleTurns(UniNodeId const & node, m2::PointD const & /* ingoingPoint */,
                         m2::PointD const & /* junctionPoint */, size_t & ingoingCount,
                         TurnCandidates & outgoingTurns) const override
@@ -166,7 +165,8 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
       auto const highwayClass = ftypes::GetHighwayClass(ft);
       ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Error, ());
       ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Undefined, ());
-      adjacentEdges.m_outgoingTurns.candidates.emplace_back(0.0 /* angle */, uniNodeId, highwayClass);
+      adjacentEdges.m_outgoingTurns.candidates.emplace_back(0.0 /* angle */, uniNodeId,
+                                                            highwayClass);
     }
 
     LoadedPathSegment pathSegment(UniNodeId::Type::Mwm);
@@ -175,12 +175,9 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
     // prevJunction == path[i - 1] and currJunction == path[i].
     if (inFeatureId.IsValid())
       LoadPathGeometry(uniNodeId, {prevJunction, currJunction}, pathSegment);
-    pathSegment.m_trafficSegs = {
-      {inFeatureId.m_index,
-       static_cast<uint16_t>(inSegId),
-       inIsForward ? TrafficInfo::RoadSegmentId::kForwardDirection
-                   : TrafficInfo::RoadSegmentId::kReverseDirection
-      }};
+    pathSegment.m_trafficSegs = {{inFeatureId.m_index, static_cast<uint16_t>(inSegId),
+                                  inIsForward ? TrafficInfo::RoadSegmentId::kForwardDirection
+                                              : TrafficInfo::RoadSegmentId::kReverseDirection}};
 
     auto const it = m_adjacentEdges.insert(make_pair(uniNodeId, move(adjacentEdges)));
     ASSERT(it.second, ());
@@ -227,7 +224,8 @@ void BicycleDirectionsEngine::LoadPathGeometry(UniNodeId const & uniNodeId,
   }
 
   FeatureType ft;
-  if (!GetLoader(uniNodeId.GetFeature().m_mwmId).GetFeatureByIndex(uniNodeId.GetFeature().m_index, ft))
+  if (!GetLoader(uniNodeId.GetFeature().m_mwmId)
+           .GetFeatureByIndex(uniNodeId.GetFeature().m_index, ft))
   {
     // The feature can't be read, therefore path geometry can't be
     // loaded.

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -105,7 +105,7 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
   {
     turns.emplace_back(pathSize - 1, turns::TurnDirection::ReachedYourDestination);
     // There's one ingoing edge to the finish.
-    this->m_adjacentEdges[UniNodeId()] = AdjacentEdges(1);
+    this->m_adjacentEdges[UniNodeId(UniNodeId::Type::Mwm)] = AdjacentEdges(1);
   };
 
   if (pathSize == 1)
@@ -130,7 +130,7 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
   }
 
   // Filling |m_adjacentEdges|.
-  m_adjacentEdges.insert(make_pair(UniNodeId(), AdjacentEdges(0)));
+  m_adjacentEdges.insert(make_pair(UniNodeId(UniNodeId::Type::Mwm), AdjacentEdges(0)));
   for (size_t i = 1; i < pathSize; ++i)
   {
     if (cancellable.IsCancelled())
@@ -169,7 +169,7 @@ void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction
       adjacentEdges.m_outgoingTurns.candidates.emplace_back(0.0 /* angle */, uniNodeId, highwayClass);
     }
 
-    LoadedPathSegment pathSegment;
+    LoadedPathSegment pathSegment(UniNodeId::Type::Mwm);
     // @TODO(bykoianko) This place should be fixed. Putting |prevJunction| and |currJunction|
     // for every route edge leads that all route points are duplicated. It's because
     // prevJunction == path[i - 1] and currJunction == path[i].

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -22,7 +22,7 @@ public:
     size_t m_ingoingTurnsCount;
   };
 
-  using TAdjacentEdgesMap = map<TNodeId, AdjacentEdges>;
+  using AdjacentEdgesMap = map<UniNodeId, AdjacentEdges>;
 
   BicycleDirectionsEngine(Index const & index);
 
@@ -34,10 +34,10 @@ public:
 
 private:
   Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
-  void LoadPathGeometry(FeatureID const & featureId, vector<Junction> const & path,
+  void LoadPathGeometry(UniNodeId const & uniNodeId, vector<Junction> const & path,
                         LoadedPathSegment & pathSegment);
 
-  TAdjacentEdgesMap m_adjacentEdges;
+  AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
   Index const & m_index;
   unique_ptr<Index::FeaturesLoaderGuard> m_loader;

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -87,9 +87,9 @@ public:
     // Filtering virtual edges.
     vector<NodeID> adjacentNodes;
     ingoingCount = 0;
-    for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(node.GetIndex()))
+    for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(node.GetNodeId()))
     {
-      QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, node.GetIndex());
+      QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, node.GetNodeId());
       if (data.shortcut)
         continue;
       if (data.forward)
@@ -105,11 +105,11 @@ public:
 
     for (NodeID const adjacentNode : geomNodes)
     {
-      if (adjacentNode == node.GetIndex())
+      if (adjacentNode == node.GetNodeId())
         continue;
       for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(adjacentNode))
       {
-        if (m_routingMapping.m_dataFacade.GetTarget(e) != node.GetIndex())
+        if (m_routingMapping.m_dataFacade.GetTarget(e) != node.GetNodeId())
           continue;
         QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, adjacentNode);
         if (data.shortcut)
@@ -172,7 +172,7 @@ public:
     for (auto const & pathSegments : m_rawResult.unpackedPathSegments)
     {
       auto numSegments = pathSegments.size();
-      m_loadedSegments.resize(numSegments);
+      m_loadedSegments.resize(numSegments, LoadedPathSegment(UniNodeId::Type::Osrm));
       for (size_t segmentIndex = 0; segmentIndex < numSegments; ++segmentIndex)
       {
         bool isStartNode = (segmentIndex == 0);

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -66,7 +66,7 @@ class OSRMRoutingResult : public turns::IRoutingResult
 public:
   // turns::IRoutingResult overrides:
   TUnpackedPathSegments const & GetSegments() const override { return m_loadedSegments; }
-  void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
+  void GetPossibleTurns(UniNodeId const & node, m2::PointD const & ingoingPoint,
                         m2::PointD const & junctionPoint, size_t & ingoingCount,
                         turns::TurnCandidates & outgoingTurns) const override
   {
@@ -87,9 +87,9 @@ public:
     // Filtering virtual edges.
     vector<NodeID> adjacentNodes;
     ingoingCount = 0;
-    for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(node))
+    for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(node.GetIndex()))
     {
-      QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, node);
+      QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, node.GetIndex());
       if (data.shortcut)
         continue;
       if (data.forward)
@@ -105,11 +105,11 @@ public:
 
     for (NodeID const adjacentNode : geomNodes)
     {
-      if (adjacentNode == node)
+      if (adjacentNode == node.GetIndex())
         continue;
       for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(adjacentNode))
       {
-        if (m_routingMapping.m_dataFacade.GetTarget(e) != node)
+        if (m_routingMapping.m_dataFacade.GetTarget(e) != node.GetIndex())
           continue;
         QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, adjacentNode);
         if (data.shortcut)
@@ -145,7 +145,8 @@ public:
       outgoingTurns.isCandidatesAngleValid = true;
       double const a =
           my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
-      outgoingTurns.candidates.emplace_back(a, targetNode, ftypes::GetHighwayClass(ft));
+      outgoingTurns.candidates.emplace_back(a, UniNodeId(targetNode),
+                                            ftypes::GetHighwayClass(ft));
     }
 
     sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(),

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -89,7 +89,8 @@ public:
     ingoingCount = 0;
     for (EdgeID const e : m_routingMapping.m_dataFacade.GetAdjacentEdgeRange(node.GetNodeId()))
     {
-      QueryEdge::EdgeData const data = m_routingMapping.m_dataFacade.GetEdgeData(e, node.GetNodeId());
+      QueryEdge::EdgeData const data =
+          m_routingMapping.m_dataFacade.GetEdgeData(e, node.GetNodeId());
       if (data.shortcut)
         continue;
       if (data.forward)
@@ -145,8 +146,7 @@ public:
       outgoingTurns.isCandidatesAngleValid = true;
       double const a =
           my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
-      outgoingTurns.candidates.emplace_back(a, UniNodeId(targetNode),
-                                            ftypes::GetHighwayClass(ft));
+      outgoingTurns.candidates.emplace_back(a, UniNodeId(targetNode), ftypes::GetHighwayClass(ft));
     }
 
     sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(),

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -40,11 +40,7 @@ struct LoadedPathSegment
   bool m_onRoundabout;
   bool m_isLink;
 
-  LoadedPathSegment(UniNodeId::Type type) : m_nodeId(type)
-  {
-    Clear();
-  }
-
+  LoadedPathSegment(UniNodeId::Type type) : m_nodeId(type) { Clear(); }
   void Clear()
   {
     m_path.clear();

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -40,7 +40,7 @@ struct LoadedPathSegment
   bool m_onRoundabout;
   bool m_isLink;
 
-  LoadedPathSegment()
+  LoadedPathSegment(UniNodeId::Type type) : m_nodeId(type)
   {
     Clear();
   }

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -33,7 +33,8 @@ struct LoadedPathSegment
   vector<turns::SingleLaneInfo> m_lanes;
   string m_name;
   TEdgeWeight m_weight; /*!< Time in seconds to pass the segment. */
-  TNodeId m_nodeId;     /*!< May be NodeId for OSRM router or FeatureId::index for graph router. */
+  UniNodeId m_nodeId;   /*!< May be either NodeID for OSRM route or
+                             mwm id, feature id, segment id and direction for A*. */
   vector<traffic::TrafficInfo::RoadSegmentId> m_trafficSegs; /*!< Traffic segments for |m_path|. */
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;
@@ -50,7 +51,7 @@ struct LoadedPathSegment
     m_lanes.clear();
     m_name.clear();
     m_weight = 0;
-    m_nodeId = 0;
+    m_nodeId.Clear();
     m_trafficSegs.clear();
     m_highwayClass = ftypes::HighwayClass::Undefined;
     m_onRoundabout = false;

--- a/routing/osrm_path_segment_factory.cpp
+++ b/routing/osrm_path_segment_factory.cpp
@@ -102,7 +102,7 @@ void OsrmPathSegmentFactory(RoutingMapping & mapping, Index const & index,
   buffer_vector<TSeg, 8> buffer;
   mapping.m_segMapping.ForEachFtSeg(osrmPathSegment.node, MakeBackInsertFunctor(buffer));
   loadedPathSegment.m_weight = osrmPathSegment.segmentWeight * kOSRMWeightToSecondsMultiplier;
-  loadedPathSegment.m_nodeId = osrmPathSegment.node;
+  loadedPathSegment.m_nodeId = UniNodeId(osrmPathSegment.node);
   if (buffer.empty())
   {
     LOG(LERROR, ("Can't unpack geometry for map:", mapping.GetCountryName(), " node: ",
@@ -125,7 +125,7 @@ void OsrmPathSegmentFactory(RoutingMapping & mapping, Index const & index, RawPa
   ASSERT(isStartNode || isEndNode, ("This function process only corner cases."));
   loadedPathSegment.Clear();
 
-  loadedPathSegment.m_nodeId = osrmPathSegment.node;
+  loadedPathSegment.m_nodeId = UniNodeId(osrmPathSegment.node);
   if (!startGraphNode.segment.IsValid() || !endGraphNode.segment.IsValid())
     return;
   buffer_vector<TSeg, 8> buffer;

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -21,7 +21,7 @@ public:
   virtual TUnpackedPathSegments const & GetSegments() const = 0;
   /// \brief For a |node|, |junctionPoint| and |ingoingPoint| (point before the |node|)
   /// this method computes number of ingoing ways to |junctionPoint| and fills |outgoingTurns|.
-  virtual void GetPossibleTurns(TNodeId node, m2::PointD const & ingoingPoint,
+  virtual void GetPossibleTurns(UniNodeId const & node, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint, size_t & ingoingCount,
                                 TurnCandidates & outgoingTurns) const = 0;
   virtual double GetPathLength() const = 0;

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -326,7 +326,7 @@ UNIT_TEST(TestCalculateMercatorDistanceAlongRoute)
 
 UNIT_TEST(TestCheckUTurnOnRoute)
 {
-  TUnpackedPathSegments pathSegments(4);
+  TUnpackedPathSegments pathSegments(4, LoadedPathSegment(UniNodeId::Type::Osrm));
   pathSegments[0].m_name = "A road";
   pathSegments[0].m_weight = 1;
   pathSegments[0].m_nodeId = UniNodeId(0 /* node id */);

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -329,22 +329,22 @@ UNIT_TEST(TestCheckUTurnOnRoute)
   TUnpackedPathSegments pathSegments(4);
   pathSegments[0].m_name = "A road";
   pathSegments[0].m_weight = 1;
-  pathSegments[0].m_nodeId = 0;
+  pathSegments[0].m_nodeId = UniNodeId(0 /* node id */);
   pathSegments[0].m_highwayClass = ftypes::HighwayClass::Trunk;
   pathSegments[0].m_onRoundabout = false;
   pathSegments[0].m_isLink = false;
   pathSegments[0].m_path = {{{0, 0}, 0}, {{0, 1}, 0}};
 
   pathSegments[1] = pathSegments[0];
-  pathSegments[1].m_nodeId = 1;
+  pathSegments[1].m_nodeId = UniNodeId(1 /* node id */);
   pathSegments[1].m_path = {{{0, 1}, 0}, {{0, 0}, 0}};
 
   pathSegments[2] = pathSegments[0];
-  pathSegments[2].m_nodeId = 2;
+  pathSegments[2].m_nodeId = UniNodeId(2 /* node id */);
   pathSegments[2].m_path = {{{0, 0}, 0}, {{0, 1}, 0}};
 
   pathSegments[3] = pathSegments[0];
-  pathSegments[3].m_nodeId = 3;
+  pathSegments[3].m_nodeId = UniNodeId(3 /* node id */);
   pathSegments[3].m_path.clear();
 
   // Zigzag test.

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -26,17 +26,19 @@ struct TurnCandidate
    */
   double angle;
   /*!
-   * node is a possible node (a possible way) from the juction.
-   * May be NodeId for OSRM router or FeatureId::index for graph router.
+   * |m_nodeId| is a possible node (a possible way) from the juction.
+   * |m_nodeId| contain either only unique NodeID for OSRM case or mwm id, feature id, segment id
+   * and direction in case of A*.
    */
-  TNodeId node;
+  UniNodeId m_nodeId;
   /*!
    * \brief highwayClass field for the road class caching. Because feature reading is a long
    * function.
    */
   ftypes::HighwayClass highwayClass;
 
-  TurnCandidate(double a, TNodeId n, ftypes::HighwayClass c) : angle(a), node(n), highwayClass(c)
+  TurnCandidate(double a, UniNodeId const & n, ftypes::HighwayClass c)
+    : angle(a), m_nodeId(n), highwayClass(c)
   {
   }
 };

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -51,9 +51,33 @@ static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
 
 namespace routing
 {
+// UniNodeId -------------------------------------------------------------------
+bool UniNodeId::operator==(UniNodeId const & rh) const
+{
+  return m_featureId == rh.m_featureId && m_segId == rh.m_segId && m_forward == rh.m_forward;
+}
+
+bool UniNodeId::operator<(UniNodeId const & rh) const
+{
+  if (m_featureId != rh.m_featureId)
+    return m_featureId < rh.m_featureId;
+
+  if (m_segId != rh.m_segId)
+    return m_segId < rh.m_segId;
+
+  return m_forward < rh.m_forward;
+}
+
+void UniNodeId::Clear()
+{
+  m_featureId = FeatureID();
+  m_segId = 0;
+  m_forward = true;
+}
+
 namespace turns
 {
-
+// SingleLaneInfo --------------------------------------------------------------
 bool SingleLaneInfo::operator==(SingleLaneInfo const & other) const
 {
   return m_lane == other.m_lane && m_isRecommended == other.m_isRecommended;

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -57,10 +57,11 @@ bool UniNodeId::operator==(UniNodeId const & rhs) const
   if (m_type != rhs.m_type)
     return false;
 
-  switch (m_type) {
+  switch (m_type)
+  {
   case Type::Osrm: return m_nodeId == rhs.m_nodeId;
-  case Type::Mwm: return m_featureId == rhs.m_featureId
-        && m_segId == rhs.m_segId && m_forward == rhs.m_forward;
+  case Type::Mwm:
+    return m_featureId == rhs.m_featureId && m_segId == rhs.m_segId && m_forward == rhs.m_forward;
   }
 }
 
@@ -69,7 +70,8 @@ bool UniNodeId::operator<(UniNodeId const & rhs) const
   if (m_type != rhs.m_type)
     return m_type < rhs.m_type;
 
-  switch (m_type) {
+  switch (m_type)
+  {
   case Type::Osrm: return m_nodeId < rhs.m_nodeId;
   case Type::Mwm:
     if (m_featureId != rhs.m_featureId)
@@ -116,7 +118,8 @@ bool UniNodeId::IsForward() const
 
 string DebugPrint(UniNodeId::Type type)
 {
-  switch (type) {
+  switch (type)
+  {
   case UniNodeId::Type::Osrm: return "Osrm";
   case UniNodeId::Type::Mwm: return "Mwm";
   }

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -52,20 +52,34 @@ static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
 namespace routing
 {
 // UniNodeId -------------------------------------------------------------------
-bool UniNodeId::operator==(UniNodeId const & rh) const
+bool UniNodeId::operator==(UniNodeId const & rhs) const
 {
-  return m_featureId == rh.m_featureId && m_segId == rh.m_segId && m_forward == rh.m_forward;
+  if (m_type != rhs.m_type)
+    return false;
+
+  switch (m_type) {
+  case Type::Osrm: return m_nodeId == rhs.m_nodeId;
+  case Type::Mwm: return m_featureId == rhs.m_featureId
+        && m_segId == rhs.m_segId && m_forward == rhs.m_forward;
+  }
 }
 
-bool UniNodeId::operator<(UniNodeId const & rh) const
+bool UniNodeId::operator<(UniNodeId const & rhs) const
 {
-  if (m_featureId != rh.m_featureId)
-    return m_featureId < rh.m_featureId;
+  if (m_type != rhs.m_type)
+    return m_type < rhs.m_type;
 
-  if (m_segId != rh.m_segId)
-    return m_segId < rh.m_segId;
+  switch (m_type) {
+  case Type::Osrm: return m_nodeId < rhs.m_nodeId;
+  case Type::Mwm:
+    if (m_featureId != rhs.m_featureId)
+      return m_featureId < rhs.m_featureId;
 
-  return m_forward < rh.m_forward;
+    if (m_segId != rhs.m_segId)
+      return m_segId < rhs.m_segId;
+
+    return m_forward < rhs.m_forward;
+  }
 }
 
 void UniNodeId::Clear()
@@ -73,6 +87,39 @@ void UniNodeId::Clear()
   m_featureId = FeatureID();
   m_segId = 0;
   m_forward = true;
+  m_nodeId = SPECIAL_NODEID;
+}
+
+uint32_t UniNodeId::GetNodeId() const
+{
+  ASSERT_EQUAL(m_type, Type::Osrm, ());
+  return m_nodeId;
+}
+
+FeatureID const & UniNodeId::GetFeature() const
+{
+  ASSERT_EQUAL(m_type, Type::Mwm, ());
+  return m_featureId;
+}
+
+uint32_t UniNodeId::GetSegId() const
+{
+  ASSERT_EQUAL(m_type, Type::Mwm, ());
+  return m_segId;
+}
+
+bool UniNodeId::IsForward() const
+{
+  ASSERT_EQUAL(m_type, Type::Mwm, ());
+  return m_forward;
+}
+
+string DebugPrint(UniNodeId::Type type)
+{
+  switch (type) {
+  case UniNodeId::Type::Osrm: return "Osrm";
+  case UniNodeId::Type::Mwm: return "Mwm";
+  }
 }
 
 namespace turns

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "indexer/feature_decl.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "3party/osrm/osrm-backend/typedefs.h"
@@ -13,6 +15,32 @@ namespace routing
 {
 using TNodeId = uint32_t;
 using TEdgeWeight = double;
+
+/// \brief Unique identification for a road edge between to junctions (joints).
+/// In case of OSRM it's NodeID and in case of RoadGraph (IndexGraph)
+/// it's mwm id, feature id, segment id and direction.
+struct UniNodeId
+{
+  UniNodeId() = default;
+  UniNodeId(FeatureID const & featureId, uint32_t segId, bool forward)
+    : m_featureId(featureId), m_segId(segId), m_forward(forward) {}
+  UniNodeId(uint32_t nodeId) : m_featureId(MwmSet::MwmId(), nodeId) {}
+
+  bool operator==(UniNodeId const & rh) const;
+  bool operator<(UniNodeId const & rh) const;
+  uint32_t GetIndex() const { return m_featureId.m_index; }
+  FeatureID const & GetFeature() const { return m_featureId; }
+  uint32_t GetSegId() const { return m_segId; }
+  bool IsForward() const { return m_forward; }
+  void Clear();
+
+private:
+  /// \note In case of OSRM unique id is kept in |m_featureId.m_index|.
+  /// So |m_featureId.m_mwmId|, |m_segId| and |m_forward| have default values.
+  FeatureID m_featureId; // |m_featureId.m_index| is NodeID for OSRM.
+  uint32_t m_segId = 0; // Not valid for OSRM.
+  bool m_forward = true; // Segment direction in |m_featureId|.
+};
 
 namespace turns
 {

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -16,31 +16,41 @@ namespace routing
 using TNodeId = uint32_t;
 using TEdgeWeight = double;
 
-/// \brief Unique identification for a road edge between to junctions (joints).
+/// \brief Unique identification for a road edge between two junctions (joints).
 /// In case of OSRM it's NodeID and in case of RoadGraph (IndexGraph)
 /// it's mwm id, feature id, segment id and direction.
 struct UniNodeId
 {
-  UniNodeId() = default;
+  enum class Type
+  {
+    Osrm,
+    Mwm,
+  };
+
+  UniNodeId(Type type) : m_type(type) {}
   UniNodeId(FeatureID const & featureId, uint32_t segId, bool forward)
-    : m_featureId(featureId), m_segId(segId), m_forward(forward) {}
-  UniNodeId(uint32_t nodeId) : m_featureId(MwmSet::MwmId(), nodeId) {}
+    : m_type(Type::Mwm), m_featureId(featureId), m_segId(segId), m_forward(forward) {}
+  UniNodeId(uint32_t nodeId) : m_type(Type::Osrm), m_nodeId(nodeId) {}
 
   bool operator==(UniNodeId const & rh) const;
   bool operator<(UniNodeId const & rh) const;
-  uint32_t GetIndex() const { return m_featureId.m_index; }
-  FeatureID const & GetFeature() const { return m_featureId; }
-  uint32_t GetSegId() const { return m_segId; }
-  bool IsForward() const { return m_forward; }
   void Clear();
+  uint32_t GetNodeId() const;
+  FeatureID const & GetFeature() const;
+  uint32_t GetSegId() const;
+  bool IsForward() const;
 
 private:
+  Type m_type;
   /// \note In case of OSRM unique id is kept in |m_featureId.m_index|.
   /// So |m_featureId.m_mwmId|, |m_segId| and |m_forward| have default values.
   FeatureID m_featureId; // |m_featureId.m_index| is NodeID for OSRM.
   uint32_t m_segId = 0; // Not valid for OSRM.
   bool m_forward = true; // Segment direction in |m_featureId|.
+  NodeID m_nodeId = SPECIAL_NODEID;
 };
+
+string DebugPrint(UniNodeId::Type type);
 
 namespace turns
 {

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -29,9 +29,10 @@ struct UniNodeId
 
   UniNodeId(Type type) : m_type(type) {}
   UniNodeId(FeatureID const & featureId, uint32_t segId, bool forward)
-    : m_type(Type::Mwm), m_featureId(featureId), m_segId(segId), m_forward(forward) {}
+    : m_type(Type::Mwm), m_featureId(featureId), m_segId(segId), m_forward(forward)
+  {
+  }
   UniNodeId(uint32_t nodeId) : m_type(Type::Osrm), m_nodeId(nodeId) {}
-
   bool operator==(UniNodeId const & rh) const;
   bool operator<(UniNodeId const & rh) const;
   void Clear();
@@ -44,9 +45,9 @@ private:
   Type m_type;
   /// \note In case of OSRM unique id is kept in |m_featureId.m_index|.
   /// So |m_featureId.m_mwmId|, |m_segId| and |m_forward| have default values.
-  FeatureID m_featureId; // |m_featureId.m_index| is NodeID for OSRM.
-  uint32_t m_segId = 0; // Not valid for OSRM.
-  bool m_forward = true; // Segment direction in |m_featureId|.
+  FeatureID m_featureId;  // |m_featureId.m_index| is NodeID for OSRM.
+  uint32_t m_segId = 0;   // Not valid for OSRM.
+  bool m_forward = true;  // Segment direction in |m_featureId|.
   NodeID m_nodeId = SPECIAL_NODEID;
 };
 

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -45,7 +45,7 @@ bool KeepTurnByHighwayClass(TurnDirection turn, TurnCandidates const & possibleT
   ftypes::HighwayClass maxClassForPossibleTurns = ftypes::HighwayClass::Error;
   for (auto const & t : possibleTurns.candidates)
   {
-    if (t.node == turnInfo.m_outgoing.m_nodeId)
+    if (t.m_nodeId == turnInfo.m_outgoing.m_nodeId)
       continue;
     ftypes::HighwayClass const highwayClass = t.highwayClass;
     if (static_cast<int>(highwayClass) > static_cast<int>(maxClassForPossibleTurns))
@@ -84,7 +84,7 @@ bool KeepRoundaboutTurnByHighwayClass(TurnDirection turn, TurnCandidates const &
 {
   for (auto const & t : possibleTurns.candidates)
   {
-    if (t.node == turnInfo.m_outgoing.m_nodeId)
+    if (t.m_nodeId == turnInfo.m_outgoing.m_nodeId)
       continue;
     if (static_cast<int>(t.highwayClass) != static_cast<int>(ftypes::HighwayClass::Service))
       return true;
@@ -615,9 +615,9 @@ void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnIt
   }
   else
   {
-    if (nodes.candidates.front().node == turnInfo.m_outgoing.m_nodeId)
+    if (nodes.candidates.front().m_nodeId == turnInfo.m_outgoing.m_nodeId)
       turn.m_turn = LeftmostDirection(turnAngle);
-    else if (nodes.candidates.back().node == turnInfo.m_outgoing.m_nodeId)
+    else if (nodes.candidates.back().m_nodeId == turnInfo.m_outgoing.m_nodeId)
       turn.m_turn = RightmostDirection(turnAngle);
     else
       turn.m_turn = intermediateDirection;


### PR DESCRIPTION
Система генерации тернов для A* отдавала много меньше поворотов, чем нужно.
Причина была в том, что мы идентифицировали соединения между joints при помощи feature id. А нужно было чем-то уникальным. Например, mwm id + feature id + seg id + направление.

По интеграционным routing тестам данное исправление несколько улучшает ситуацию. Не проходило 39 из 140. Сейчас 35 из 140.

https://jira.mail.ru/browse/MAPSME-3260

@ygorshenin @dobriy-eeh PTAL