### PR TITLE
[release-70] [routing] Tune start and finish points

### DIFF
--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -228,7 +228,7 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
     ASSERT_EQUAL(result.path.back(), finalPos, ());
     ASSERT_GREATER(result.distance, 0., ());
     ReconstructRoute(m_directionsEngine.get(), *m_roadGraph, nullptr /* trafficColoring */,
-                     delegate, result.path, route);
+                     delegate, startPoint, finalPoint, result.path, route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -9,7 +9,8 @@ using namespace traffic;
 
 void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
                       shared_ptr<TrafficInfo::Coloring> const & trafficColoring,
-                      my::Cancellable const & cancellable, vector<Junction> & path, Route & route)
+                      my::Cancellable const & cancellable, m2::PointD const & start,
+                      m2::PointD const & finish, vector<Junction> & path, Route & route)
 {
   if (path.empty())
   {
@@ -38,6 +39,9 @@ void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
 
   vector<m2::PointD> routeGeometry;
   JunctionsToPoints(junctions, routeGeometry);
+  CHECK(!routeGeometry.empty(), ());
+  routeGeometry.front() = start;
+  routeGeometry.back() = finish;
   feature::TAltitudes altitudes;
   JunctionsToAltitudes(junctions, altitudes);
 
@@ -76,4 +80,4 @@ void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
 
   route.SetTraffic(move(traffic));
 }
-}  // namespace rouing
+}  // namespace routing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -27,5 +27,6 @@ bool IsRoad(TTypes const & types)
 
 void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
                       shared_ptr<traffic::TrafficInfo::Coloring> const & trafficColoring,
-                      my::Cancellable const & cancellable, vector<Junction> & path, Route & route);
+                      my::Cancellable const & cancellable, m2::PointD const & start,
+                      m2::PointD const & finish, vector<Junction> & path, Route & route);
 }  // namespace rouing

--- a/routing/single_mwm_router.hpp
+++ b/routing/single_mwm_router.hpp
@@ -47,8 +47,8 @@ private:
                        Edge & closestEdge) const;
   bool LoadIndex(MwmSet::MwmId const & mwmId, string const & country, IndexGraph & graph);
   bool BuildRoute(MwmSet::MwmId const & mwmId, vector<Joint::Id> const & joints,
-                  RouterDelegate const & delegate, IndexGraphStarter & starter,
-                  Route & route) const;
+                  RouterDelegate const & delegate, m2::PointD const & start,
+                  m2::PointD const & finish, IndexGraphStarter & starter, Route & route) const;
 
   string const m_name;
   Index const & m_index;


### PR DESCRIPTION
Раньше начало и конец маршрута могли быть только на концах сегментов.
Это приводило к сдвигу начала и конца относительно выбранных пользователем точек.
Поступали на это жалобы.

Этот PR корректирует начало и конец маршрута.