### PR TITLE
[banners] Use tutu strings for raileurope banners

### DIFF
--- a/data/banners.txt
+++ b/data/banners.txt
@@ -47,3 +47,4 @@ end = 2017-01-15
 [raileurope]
 end = 2017-01-15
 url = http://www.anrdoezrs.net/links/8196243/type/dlg/fragment/%2Fptp_request/https://mobile.raileurope.com/app/index.html
+messages = banner_tutu


### PR DESCRIPTION
Сказав вслух, что для RailEurope можно использовать те же строчки, что для Tutu, забыл закрепить это в конфигурационном файле.