### PR TITLE
Skip compiling desktop app when making ios.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,4 +185,6 @@ add_subdirectory(partners_api)
 omim_add_test_subdirectory(qt_tstfrm)
 omim_add_test_subdirectory(3party/gmock)
 
-add_subdirectory(qt)
+if (NOT PLATFORM_IPHONE AND NOT PLATFORM_ANDROID)
+    add_subdirectory(qt)
+endif()


### PR DESCRIPTION
At least fixes the cmake build in Xcode, may also fix the build on the server.