### PR TITLE
[routing] Change astar epsilon CHECK to ASSERT

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -354,7 +354,7 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::FindPathBidirect
       double const pW = cur->ConsistentHeuristic(stateW.vertex);
       double const reducedLen = len + pW - pV;
 
-      CHECK_GREATER_OR_EQUAL(
+      ASSERT_GREATER_OR_EQUAL(
           reducedLen, -kEpsilon,
           ("Invariant violation, vertex V:", stateV.vertex, "vertex W:", stateW.vertex,
            "edge weight:", len, "heuristic V:", pV, "heuristic W:", pW));


### PR DESCRIPTION
В AStar проверка инварианта эвристики сделана ненадежно: поскольку операции делаются в double и могут быть погрешности, то инвариант сравнивается с числом -1e-6, взятым, по большому счету, с потолка.

Иногда на больших расстояниях эта проверка нарушается из-за того что накопленная погрешность превышает -1e-6.
По хорошему надо сделать проверку инварианта как то более надежно (например, перевести веса на целые числа), а пока в таких случаях следует все равно прокладывать маршрут и не крашить приложение.