### PR TITLE
Correction of subtracted distance for weight calculation in osrm_helpers.

### DIFF
--- a/routing/osrm_helpers.cpp
+++ b/routing/osrm_helpers.cpp
@@ -120,7 +120,7 @@ void Point2PhantomNode::CalculateWeight(OsrmMappingTypes::FtSeg const & seg,
       auto const splittedSegment = OsrmMappingTypes::SplitSegment(segment, seg);
       distanceM += CalculateDistance(ft, splittedSegment.m_pointStart, splittedSegment.m_pointEnd);
       // node.m_seg always forward ordered (m_pointStart < m_pointEnd)
-      distanceM -= MercatorBounds::DistanceOnEarth(ft.GetPoint(seg.m_pointEnd), segPt);
+      distanceM -= MercatorBounds::DistanceOnEarth(ft.GetPoint(splittedSegment.m_pointEnd), segPt);
 
       foundSeg = true;
     }


### PR DESCRIPTION
The subtracted distance is wrong.
If segment is ordered it's transparent because `splittedSegment.m_pointEnd` and `seg.m_pointEnd` are same but if segment is reverse the wrong part of last segment is subtracted.