### PR TITLE
[Routing] crashfix in case of routes passing through loop edges.

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -202,7 +202,6 @@ void IndexGraphStarter::RedressRoute(vector<Joint::Id> const & route,
     RoadGeometry const roadGeometry = IsFakeFeature(featureId) ? GetFakeRoadGeometry(featureId)
                                                                : m_graph.GetRoad(featureId);
 
-    CHECK_NOT_EQUAL(pointFrom, pointTo, ("featureId =", featureId));
     uint32_t const step = pointFrom < pointTo ? 1 : -1;
 
     for (uint32_t prevPointId = pointFrom; prevPointId != pointTo; prevPointId += step)


### PR DESCRIPTION
Исправление креш фикс при прокладке маршрута до ул. Мосфильмовская д. 15:
http://www.openstreetmap.org/way/45423745#map=19/55.71633/37.52047

https://jira.mail.ru/browse/MAPSME-3323

https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5858f58b0aeb16625b352b6d/sessions/585907EE039A00015B1E17E80345A767_d8f1cb777c2d4f15ac22bba69e239e9a_0_v1

@dobriy-eeh @ygorshenin @mpimenov PTAL