### PR TITLE
[routing] Crashfix. Processing errors while turn generation.

### DIFF
--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -227,7 +227,8 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
     ASSERT_EQUAL(result.path.front(), startPos, ());
     ASSERT_EQUAL(result.path.back(), finalPos, ());
     ASSERT_GREATER(result.distance, 0., ());
-    ReconstructRoute(m_directionsEngine.get(), *m_roadGraph, nullptr /* trafficColoring */,
+    CHECK(m_directionsEngine, ());
+    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr /* trafficColoring */,
                      delegate, startPoint, finalPoint, result.path, route);
   }
 

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -7,7 +7,7 @@ namespace routing
 {
 using namespace traffic;
 
-void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
+void ReconstructRoute(IDirectionsEngine & engine, IRoadGraph const & graph,
                       shared_ptr<TrafficInfo::Coloring> const & trafficColoring,
                       my::Cancellable const & cancellable, m2::PointD const & start,
                       m2::PointD const & finish, vector<Junction> & path, Route & route)
@@ -30,8 +30,7 @@ void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
   // @TODO(bykoianko) streetNames is not filled in Generate(). It should be done.
   Route::TStreets streetNames;
   vector<TrafficInfo::RoadSegmentId> trafficSegs;
-  if (engine)
-    engine->Generate(graph, path, times, turnsDir, junctions, trafficSegs, cancellable);
+  engine.Generate(graph, path, times, turnsDir, junctions, trafficSegs, cancellable);
 
   if (cancellable.IsCancelled())
     return;

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -33,6 +33,16 @@ void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
   if (engine)
     engine->Generate(graph, path, times, turnsDir, junctions, trafficSegs, cancellable);
 
+  if (cancellable.IsCancelled())
+    return;
+
+  // In case of any errors in IDirectionsEngine::Generate() |junctions| is empty.
+  if (junctions.empty())
+  {
+    LOG(LERROR, ("Internal error happened while turn generation."));
+    return;
+  }
+
   // @TODO(bykoianko) If the start and the finish of a route lies on the same road segment
   // engine->Generate() fills with empty vectors |times|, |turnsDir|, |junctions| and |trafficSegs|.
   // It's not correct and should be fixed. It's necessary to work corrrectly with such routes.

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -25,7 +25,7 @@ bool IsRoad(TTypes const & types)
          BicycleModel::AllLimitsInstance().HasRoadType(types);
 }
 
-void ReconstructRoute(IDirectionsEngine * engine, IRoadGraph const & graph,
+void ReconstructRoute(IDirectionsEngine & engine, IRoadGraph const & graph,
                       shared_ptr<traffic::TrafficInfo::Coloring> const & trafficColoring,
                       my::Cancellable const & cancellable, m2::PointD const & start,
                       m2::PointD const & finish, vector<Junction> & path, Route & route);

--- a/routing/single_mwm_router.cpp
+++ b/routing/single_mwm_router.cpp
@@ -264,7 +264,8 @@ bool SingleMwmRouter::BuildRoute(MwmSet::MwmId const & mwmId, vector<Joint::Id> 
   shared_ptr<traffic::TrafficInfo::Coloring> trafficColoring = m_trafficCache.GetTrafficInfo(mwmId);
 
   auto const numJunctions = junctions.size();
-  ReconstructRoute(m_directionsEngine.get(), m_roadGraph, trafficColoring, delegate, start, finish,
+  CHECK(m_directionsEngine, ());
+  ReconstructRoute(*m_directionsEngine, m_roadGraph, trafficColoring, delegate, start, finish,
                    junctions, route);
 
   if (junctions.size() != numJunctions)


### PR DESCRIPTION
Обработка ошибок возникающих в IDirectionsEngine::Generate().

https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5858f58b0aeb16625b352b6d

@dobriy-eeh @ygorshenin @mpimenov PTAL