### PR TITLE
[routing] Invert index graph

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -95,6 +95,7 @@ set(
   routing_session.cpp
   routing_session.hpp
   routing_settings.hpp
+  segment.hpp
   single_mwm_router.cpp
   single_mwm_router.hpp
   speed_camera.cpp

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/geometry.hpp"
+#include "routing/segment.hpp"
 #include "routing/vehicle_model.hpp"
 
 #include "traffic/traffic_cache.hpp"
@@ -21,10 +22,8 @@ public:
 
   virtual void Start(MwmSet::MwmId const & mwmId) = 0;
   virtual void Finish() = 0;
-  virtual double CalcEdgesWeight(uint32_t featureId, RoadGeometry const & road, uint32_t pointFrom,
-                                 uint32_t pointTo) const = 0;
+  virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
-
 
   static shared_ptr<EdgeEstimator> CreateForCar(IVehicleModel const & vehicleModel,
                                                 traffic::TrafficCache const & trafficCache);

--- a/routing/joint_index.cpp
+++ b/routing/joint_index.cpp
@@ -4,23 +4,8 @@
 
 namespace routing
 {
-Joint::Id JointIndex::InsertJoint(RoadPoint const & rp)
-{
-  Joint::Id const jointId = GetNumJoints();
-  m_points.emplace_back(rp);
-  m_offsets.emplace_back(m_points.size());
-  return jointId;
-}
-
-void JointIndex::AppendToJoint(Joint::Id jointId, RoadPoint const & rp)
-{
-  m_dynamicJoints[jointId].AddPoint(rp);
-}
-
 void JointIndex::Build(RoadIndex const & roadIndex, uint32_t numJoints)
 {
-  m_dynamicJoints.clear();
-
   // + 1 is protection for 'End' method from out of bounds.
   // Call End(numJoints-1) requires more size, so add one more item.
   // Therefore m_offsets.size() == numJoints + 1,

--- a/routing/joint_index.hpp
+++ b/routing/joint_index.hpp
@@ -32,19 +32,9 @@ public:
   {
     for (uint32_t i = Begin(jointId); i < End(jointId); ++i)
       f(m_points[i]);
-
-    auto const & it = m_dynamicJoints.find(jointId);
-    if (it != m_dynamicJoints.end())
-    {
-      Joint const & joint = it->second;
-      for (size_t i = 0; i < joint.GetSize(); ++i)
-        f(joint.GetEntry(i));
-    }
   }
 
   void Build(RoadIndex const & roadIndex, uint32_t numJoints);
-  Joint::Id InsertJoint(RoadPoint const & rp);
-  void AppendToJoint(Joint::Id jointId, RoadPoint const & rp);
 
 private:
   // Begin index for jointId entries.
@@ -64,6 +54,5 @@ private:
 
   vector<uint32_t> m_offsets;
   vector<RoadPoint> m_points;
-  unordered_map<Joint::Id, Joint> m_dynamicJoints;
 };
 }  // namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -110,6 +110,7 @@ HEADERS += \
     routing_serialization.hpp \
     routing_session.hpp \
     routing_settings.hpp \
+    segment.hpp \
     single_mwm_router.hpp \
     speed_camera.hpp \
     turn_candidate.hpp \

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -44,9 +44,14 @@ using namespace traffic;
 //      F0      F1          F8
 //    ↗          ↖         |
 // 0 *              *--F7--->*
+//                  ^
+//                  F9
+//                  |
+//-1                *
 //   0       1      2       3
 //                Start
-// Note. This graph contains of 9 one segment directed features.
+//
+// Note. This graph consists of 10 one segment directed features.
 unique_ptr<IndexGraph> BuildXXGraph(shared_ptr<EdgeEstimator> estimator)
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
@@ -68,10 +73,12 @@ unique_ptr<IndexGraph> BuildXXGraph(shared_ptr<EdgeEstimator> estimator)
                   RoadGeometry::Points({{2.0, 0.0}, {3.0, 0.0}}));
   loader->AddRoad(8 /* featureId */, true /* oneWay */, 1.0 /* speed */,
                   RoadGeometry::Points({{3.0, 0.0}, {3.0, 1.0}}));
+  loader->AddRoad(9 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, -1.0}, {2.0, 0.0}}));
 
   vector<Joint> const joints = {
       MakeJoint({{0 /* feature id */, 0 /* point id */}}), /* joint at point (0, 0) */
-      MakeJoint({{1, 0}, {7, 0}}),                         /* joint at point (2, 0) */
+      MakeJoint({{1, 0}, {7, 0}, {9, 1}}),                 /* joint at point (2, 0) */
       MakeJoint({{0, 1}, {1, 1}, {2, 0}, {3, 0}}),         /* joint at point (1, 1) */
       MakeJoint({{2, 1}}),                                 /* joint at point (0, 2) */
       MakeJoint({{3, 1}, {4, 1}, {5, 0}, {6, 0}}),         /* joint at point (2, 2) */
@@ -127,8 +134,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
   SetEstimator({} /* coloring */);
 
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
 
@@ -141,8 +150,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
   SetEstimator(move(coloring));
 
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -156,8 +167,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
   SetEstimator(move(coloring));
 
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -171,8 +184,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
   SetEstimator(move(coloring));
 
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -192,8 +207,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
   SetEstimator(move(coloring));
 
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -204,8 +221,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   // No trafic at all.
   SetEstimator({} /* coloring */);
   unique_ptr<IndexGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter starter(*graph, RoadPoint(1, 0) /* start */, RoadPoint(6, 1) /* finish */);
-  vector<m2::PointD> const noTrafficGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {3, 3}};
+  IndexGraphStarter::FakeVertex const start(9, 0, m2::PointD(2.0, -1.0));
+  IndexGraphStarter::FakeVertex const finish(6, 0, m2::PointD(3.0, 3.0));
+  IndexGraphStarter starter(*graph, start, finish);
+  vector<m2::PointD> const noTrafficGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   {
     EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
     TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, noTrafficGeom);
@@ -218,7 +237,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   UpdateTrafficInfo(move(coloringHeavyF3));
   {
     EstimatorGuard guard(MwmSet::MwmId(), *GetEstimator());
-    vector<m2::PointD> const heavyF3Geom = {{2 /* x */, 0 /* y */}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
+    vector<m2::PointD> const heavyF3Geom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
     TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, heavyF3Geom);
   }
 

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -4,6 +4,7 @@
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_starter.hpp"
 #include "routing/road_point.hpp"
+#include "routing/segment.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
 
@@ -37,7 +38,7 @@ routing::Joint MakeJoint(vector<routing::RoadPoint> const & points);
 shared_ptr<routing::EdgeEstimator> CreateEstimator(traffic::TrafficCache const & trafficCache);
 
 routing::AStarAlgorithm<routing::IndexGraphStarter>::Result CalculateRoute(
-    routing::IndexGraphStarter & graph, vector<routing::RoadPoint> & roadPoints);
+    routing::IndexGraphStarter & starter, vector<routing::Segment> & roadPoints);
 
 void TestRouteSegments(
     routing::IndexGraphStarter & starter,

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "routing/road_point.hpp"
+
+#include "std/cstdint.hpp"
+#include "std/sstream.hpp"
+#include "std/string.hpp"
+
+namespace routing
+{
+// This is directed road segment used as vertex in index graph.
+//
+// You can imagine the segment as a material arrow.
+// Head of each arrow is connected to fletchings of next arrows with invisible links:
+// these are the edges of the graph.
+//
+// Position of the segment is a position of the arrowhead: GetPointId(true).
+// This position is used in heuristic and edges weight calculations.
+class Segment final
+{
+public:
+  Segment() = default;
+
+  constexpr Segment(uint32_t featureId, uint32_t segmentIdx, bool forward)
+    : m_featureId(featureId), m_segmentIdx(segmentIdx), m_forward(forward)
+  {
+  }
+
+  uint32_t GetFeatureId() const { return m_featureId; }
+  uint32_t GetSegmentIdx() const { return m_segmentIdx; }
+  bool IsForward() const { return m_forward; }
+
+  uint32_t GetPointId(bool front) const
+  {
+    return m_forward == front ? m_segmentIdx + 1 : m_segmentIdx;
+  }
+
+  RoadPoint GetRoadPoint(bool front) const { return RoadPoint(m_featureId, GetPointId(front)); }
+
+  bool operator<(Segment const & seg) const
+  {
+    if (m_featureId != seg.m_featureId)
+      return m_featureId < seg.m_featureId;
+
+    if (m_segmentIdx != seg.m_segmentIdx)
+      return m_segmentIdx < seg.m_segmentIdx;
+
+    return m_forward < seg.m_forward;
+  }
+
+  bool operator==(Segment const & seg) const
+  {
+    return m_featureId == seg.m_featureId && m_segmentIdx == seg.m_segmentIdx &&
+           m_forward == seg.m_forward;
+  }
+
+  bool operator!=(Segment const & seg) const { return !(*this == seg); }
+
+private:
+  uint32_t m_featureId = 0;
+  uint32_t m_segmentIdx = 0;
+  bool m_forward = true;
+};
+
+class SegmentEdge final
+{
+public:
+  SegmentEdge(Segment const & target, double weight) : m_target(target), m_weight(weight) {}
+  Segment const & GetTarget() const { return m_target; }
+  double GetWeight() const { return m_weight; }
+
+private:
+  // Target is vertex going to for outgoing edges, vertex going from for ingoing edges.
+  Segment const m_target;
+  double const m_weight;
+};
+
+inline string DebugPrint(Segment const & segment)
+{
+  ostringstream out;
+  out << "Segment(" << segment.GetFeatureId() << ", " << segment.GetSegmentIdx() << ", "
+      << segment.IsForward() << ")";
+  return out.str();
+}
+}  // namespace routing

--- a/routing/single_mwm_router.hpp
+++ b/routing/single_mwm_router.hpp
@@ -46,7 +46,7 @@ private:
   bool FindClosestEdge(MwmSet::MwmId const & mwmId, m2::PointD const & point,
                        Edge & closestEdge) const;
   bool LoadIndex(MwmSet::MwmId const & mwmId, string const & country, IndexGraph & graph);
-  bool BuildRoute(MwmSet::MwmId const & mwmId, vector<Joint::Id> const & joints,
+  bool BuildRoute(MwmSet::MwmId const & mwmId, vector<Segment> const & segments,
                   RouterDelegate const & delegate, IndexGraphStarter & starter,
                   Route & route) const;
 

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0C0DF9251DE898CF0055A22F /* single_mwm_router.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF9231DE898CF0055A22F /* single_mwm_router.cpp */; };
 		0C0DF9261DE898CF0055A22F /* single_mwm_router.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */; };
 		0C0DF92A1DE898FF0055A22F /* routing_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */; };
+		0C470E701E0D4EB1005B824D /* segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C470E6F1E0D4EB1005B824D /* segment.hpp */; };
 		0C5FEC541DDE191E0017688C /* edge_estimator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC521DDE191E0017688C /* edge_estimator.cpp */; };
 		0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5FEC531DDE191E0017688C /* edge_estimator.hpp */; };
 		0C5FEC5E1DDE192A0017688C /* geometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC561DDE192A0017688C /* geometry.cpp */; };
@@ -252,6 +253,7 @@
 		0C0DF9231DE898CF0055A22F /* single_mwm_router.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = single_mwm_router.cpp; sourceTree = "<group>"; };
 		0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_mwm_router.hpp; sourceTree = "<group>"; };
 		0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers.cpp; sourceTree = "<group>"; };
+		0C470E6F1E0D4EB1005B824D /* segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = segment.hpp; sourceTree = "<group>"; };
 		0C5FEC521DDE191E0017688C /* edge_estimator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edge_estimator.cpp; sourceTree = "<group>"; };
 		0C5FEC531DDE191E0017688C /* edge_estimator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = edge_estimator.hpp; sourceTree = "<group>"; };
 		0C5FEC561DDE192A0017688C /* geometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = geometry.cpp; sourceTree = "<group>"; };
@@ -671,6 +673,7 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				0C470E6F1E0D4EB1005B824D /* segment.hpp */,
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
 				56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */,
@@ -801,6 +804,7 @@
 				674F9BCB1B0A580E00704FFA /* async_router.hpp in Headers */,
 				0C08AA391DF8329B004195DD /* routing_exceptions.hpp in Headers */,
 				674F9BD11B0A580E00704FFA /* online_cross_fetcher.hpp in Headers */,
+				0C470E701E0D4EB1005B824D /* segment.hpp in Headers */,
 				A120B3531B4A7C1C002F3808 /* astar_algorithm.hpp in Headers */,
 				0C5FEC5F1DDE192A0017688C /* geometry.hpp in Headers */,
 				674A28B21B1605D2001A525C /* osrm_engine.hpp in Headers */,


### PR DESCRIPTION
Смена формата IndexGraph: теперь в нем вершинами являются не Joint::Id, а направленные сегменты дорог.

Что это дает:
1. Более привычное представление для проектного кода в целом.
2. Сильно упрощается реализация restrictions.
3. Избавимся от неоднозначности дуг между Joint'ами. Эти неоднозначности приводили к различным багам в некоторых ситуациях (гонки между дорогами, петли).
4. Устранены ненадежные функции FindPointsWithCommonFeature и RedressRoute.
5. Упрощается починка бага со сдвигом стартовой точки.

PTAL