### PR TITLE
Rect covering in Index::ForEachInRect

### DIFF
--- a/drape/oglcontext.hpp
+++ b/drape/oglcontext.hpp
@@ -13,7 +13,7 @@ public:
   virtual void setDefaultFramebuffer() = 0;
   /// @ param w, h - pixel size of render target (logical size * visual scale)
   virtual void resize(int /*w*/, int /*h*/) {}
-  virtual void setRenderingEnabled(bool enabled) {}
+  virtual void setRenderingEnabled(bool /*enabled*/) {}
 };
 
 } // namespace dp

--- a/drape/texture.hpp
+++ b/drape/texture.hpp
@@ -51,7 +51,7 @@ public:
   virtual ref_ptr<ResourceInfo> FindResource(Key const & key, bool & newResource) = 0;
   virtual void UpdateState() {}
   virtual bool HasAsyncRoutines() const { return false; }
-  virtual bool HasEnoughSpace(uint32_t newKeysCount) const { return true; }
+  virtual bool HasEnoughSpace(uint32_t /*newKeysCount*/) const { return true; }
 
   using Params = HWTexture::Params;
 

--- a/drape/texture_manager.hpp
+++ b/drape/texture_manager.hpp
@@ -147,7 +147,7 @@ private:
 
   void MarkCharactersUsage(strings::UniString const & text, HybridGlyphGroup & group);
   /// it's a dummy method to support generic code
-  void MarkCharactersUsage(strings::UniString const & text, GlyphGroup & group) {}
+  void MarkCharactersUsage(strings::UniString const &, GlyphGroup &) {}
 
   template<typename TGlyphGroup>
   void FillResultBuffer(strings::UniString const & text, TGlyphGroup & group, TGlyphsBuffer & regions)

--- a/drape_frontend/gui/shape.hpp
+++ b/drape_frontend/gui/shape.hpp
@@ -22,7 +22,7 @@ public:
 
   bool Update(ScreenBase const & screen) override;
 
-  virtual bool IsTapped(m2::RectD const & touchArea) const { return false; }
+  virtual bool IsTapped(m2::RectD const & /*touchArea*/) const { return false; }
   virtual void OnTapBegin(){}
   virtual void OnTap(){}
   virtual void OnTapEnd(){}

--- a/drape_frontend/map_shape.hpp
+++ b/drape_frontend/map_shape.hpp
@@ -28,7 +28,7 @@ class MapShape
 {
 public:
   virtual ~MapShape(){}
-  virtual void Prepare(ref_ptr<dp::TextureManager> textures) const {}
+  virtual void Prepare(ref_ptr<dp::TextureManager> /*textures*/) const {}
   virtual void Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> textures) const = 0;
   virtual MapShapeType GetType() const { return MapShapeType::GeometryType; }
 

--- a/geometry/cellid.hpp
+++ b/geometry/cellid.hpp
@@ -12,8 +12,9 @@ namespace m2
 template <int kDepthLevels = 31> class CellId
 {
 public:
-  // TODO: Move CellId::DEPTH_LEVELS to private.
-  static int const DEPTH_LEVELS = kDepthLevels;
+  // Use enum to avoid linker errors.
+  // Can't realize why static const or constexpr is invalid here ...
+  enum { DEPTH_LEVELS = kDepthLevels };
   static uint8_t const MAX_CHILDREN = 4;
   static uint32_t const MAX_COORD = 1U << DEPTH_LEVELS;
 
@@ -213,6 +214,18 @@ public:
     }
   };
 
+  struct GreaterLevelOrder
+  {
+    bool operator() (CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
+    {
+      if (id1.m_Level != id2.m_Level)
+        return id1.m_Level > id2.m_Level;
+      if (id1.m_Bits != id2.m_Bits)
+        return id1.m_Bits > id2.m_Bits;
+      return false;
+    }
+  };
+
   struct LessPreOrder
   {
     bool operator() (CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
@@ -295,7 +308,7 @@ private:
 
   CellId(uint64_t bits, int level) : m_Bits(bits), m_Level(level)
   {
-    ASSERT_LESS(level, static_cast<uint32_t>(DEPTH_LEVELS), (bits, level));
+    ASSERT_LESS(level, DEPTH_LEVELS, (bits, level));
     ASSERT_LESS(bits, 1ULL << m_Level * 2, (bits, m_Level));
     ASSERT(IsValid(), (m_Bits, m_Level));
   }

--- a/geometry/cellid.hpp
+++ b/geometry/cellid.hpp
@@ -1,47 +1,31 @@
 #pragma once
 #include "base/assert.hpp"
 #include "base/base.hpp"
-#include "std/string.hpp"
 #include "std/sstream.hpp"
+#include "std/string.hpp"
 #include "std/utility.hpp"
-
 
 namespace m2
 {
-
-template <int kDepthLevels = 31> class CellId
+template <int kDepthLevels = 31>
+class CellId
 {
 public:
   // Use enum to avoid linker errors.
   // Can't realize why static const or constexpr is invalid here ...
-  enum { DEPTH_LEVELS = kDepthLevels };
+  enum
+  {
+    DEPTH_LEVELS = kDepthLevels
+  };
   static uint8_t const MAX_CHILDREN = 4;
   static uint32_t const MAX_COORD = 1U << DEPTH_LEVELS;
 
-  CellId() : m_Bits(0), m_Level(0)
-  {
-    ASSERT(IsValid(), ());
-  }
+  CellId() : m_Bits(0), m_Level(0) { ASSERT(IsValid(), ()); }
+  explicit CellId(string const & s) { *this = FromString(s); }
 
-  explicit CellId(string const & s)
-  {
-    *this = FromString(s);
-  }
-
-  static CellId Root()
-  {
-    return CellId(0, 0);
-  }
-
-  static CellId FromBitsAndLevel(uint64_t bits, int level)
-  {
-    return CellId(bits, level);
-  }
-
-  inline static size_t TotalCellsOnLevel(size_t level)
-  {
-    return 1 << (2 * level);
-  }
+  static CellId Root() { return CellId(0, 0); }
+  static CellId FromBitsAndLevel(uint64_t bits, int level) { return CellId(bits, level); }
+  static size_t TotalCellsOnLevel(size_t level) { return 1 << (2 * level); }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Simple getters
@@ -91,18 +75,14 @@ public:
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Operators
 
-  bool operator == (CellId const & cellId) const
+  bool operator==(CellId const & cellId) const
   {
     ASSERT(IsValid(), (m_Bits, m_Level));
     ASSERT(cellId.IsValid(), (cellId.m_Bits, cellId.m_Level));
     return m_Bits == cellId.m_Bits && m_Level == cellId.m_Level;
   }
 
-  bool operator != (CellId const & cellId) const
-  {
-    return !(*this == cellId);
-  }
-
+  bool operator!=(CellId const & cellId) const { return !(*this == cellId); }
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Conversion to/from string
 
@@ -204,7 +184,7 @@ public:
 
   struct LessLevelOrder
   {
-    bool operator() (CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
+    bool operator()(CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
     {
       if (id1.m_Level != id2.m_Level)
         return id1.m_Level < id2.m_Level;
@@ -216,7 +196,7 @@ public:
 
   struct GreaterLevelOrder
   {
-    bool operator() (CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
+    bool operator()(CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
     {
       if (id1.m_Level != id2.m_Level)
         return id1.m_Level > id2.m_Level;
@@ -228,7 +208,7 @@ public:
 
   struct LessPreOrder
   {
-    bool operator() (CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
+    bool operator()(CellId<DEPTH_LEVELS> const & id1, CellId<DEPTH_LEVELS> const & id2) const
     {
       int64_t const n1 = id1.ToInt64LevelZOrder(DEPTH_LEVELS);
       int64_t const n2 = id2.ToInt64LevelZOrder(DEPTH_LEVELS);
@@ -241,17 +221,9 @@ public:
   // Numbering
 
   // Default ToInt64().
-  int64_t ToInt64(int depth) const
-  {
-    return ToInt64LevelZOrder(depth);
-  }
-
+  int64_t ToInt64(int depth) const { return ToInt64LevelZOrder(depth); }
   // Default FromInt64().
-  static CellId FromInt64(int64_t v, int depth)
-  {
-    return FromInt64LevelZOrder(v, depth);
-  }
-
+  static CellId FromInt64(int64_t v, int depth) { return FromInt64LevelZOrder(v, depth); }
   // Level order, numbering by Z-curve.
   int64_t ToInt64LevelZOrder(int depth) const
   {
@@ -297,9 +269,8 @@ public:
     return CellId(bits, level);
   }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
 private:
-
   static uint64_t TreeSizeForDepth(int depth)
   {
     ASSERT(0 < depth && depth <= DEPTH_LEVELS, (depth));
@@ -326,11 +297,11 @@ private:
   int m_Level;
 };
 
-template <int DEPTH_LEVELS> string DebugPrint(CellId<DEPTH_LEVELS> const & id)
+template <int DEPTH_LEVELS>
+string DebugPrint(CellId<DEPTH_LEVELS> const & id)
 {
   ostringstream out;
   out << "CellId<" << DEPTH_LEVELS << ">(\"" << id.ToString().c_str() << "\")";
   return out.str();
 }
-
 }

--- a/indexer/cell_coverer.hpp
+++ b/indexer/cell_coverer.hpp
@@ -2,54 +2,58 @@
 
 #include "indexer/cell_id.hpp"
 
+#include "base/buffer_vector.hpp"
+
 #include "std/queue.hpp"
 #include "std/vector.hpp"
 
 // TODO: Move neccessary functions to geometry/covering_utils.hpp and delete this file.
 
+constexpr int SPLIT_RECT_CELLS_COUNT = 512;
+
 template <typename BoundsT, typename CellIdT>
-inline void SplitRectCell(CellIdT id,
-                          double minX, double minY,
-                          double maxX, double maxY,
-                          vector<CellIdT> & result)
+inline int SplitRectCell(CellIdT const & id, m2::RectD const & rect,
+                         array<pair<CellIdT, m2::RectD>, 4> & result)
 {
+  int index = 0;
   for (int8_t i = 0; i < 4; ++i)
   {
-    CellIdT child = id.Child(i);
+    CellIdT const child = id.Child(i);
     double minCellX, minCellY, maxCellX, maxCellY;
     CellIdConverter<BoundsT, CellIdT>::GetCellBounds(child, minCellX, minCellY, maxCellX, maxCellY);
-    if (!((maxX < minCellX) || (minX > maxCellX) || (maxY < minCellY) || (minY > maxCellY)))
-      result.push_back(child);
+
+    m2::RectD const childRect(minCellX, minCellY, maxCellX, maxCellY);
+    if (rect.IsIntersect(childRect))
+      result[index++] = {child, childRect};
   }
+  return index;
 }
 
 template <typename BoundsT, typename CellIdT>
-inline void CoverRect(double minX, double minY,
-                      double maxX, double maxY,
-                      size_t cells_count, int maxDepth,
-                      vector<CellIdT> & cells)
+inline void CoverRect(m2::RectD rect, size_t cellsCount, int maxDepth,
+                      vector<CellIdT> & result)
 {
-  if (minX < BoundsT::minX) minX = BoundsT::minX;
-  if (minY < BoundsT::minY) minY = BoundsT::minY;
-  if (maxX > BoundsT::maxX) maxX = BoundsT::maxX;
-  if (maxY > BoundsT::maxY) maxY = BoundsT::maxY;
+  ASSERT(result.empty(), ());
+  {
+    // Fit rect to converter bounds.
+    if (!rect.Intersect({ BoundsT::minX, BoundsT::minY, BoundsT::maxX, BoundsT::maxY }))
+      return;
+    ASSERT(rect.IsValid(), ());
+  }
 
-  if (minX >= maxX || minY >= maxY)
-    return;
+  CellIdT const commonCell = CellIdConverter<BoundsT, CellIdT>::Cover2PointsWithCell(
+        rect.minX(), rect.minY(), rect.maxX(), rect.maxY());
 
-  CellIdT commonCell =
-      CellIdConverter<BoundsT, CellIdT>::Cover2PointsWithCell(minX, minY, maxX, maxY);
-
-  vector<CellIdT> result;
-
-  queue<CellIdT> cellQueue;
+  priority_queue<CellIdT,
+                 buffer_vector<CellIdT, SPLIT_RECT_CELLS_COUNT>,
+                 typename CellIdT::GreaterLevelOrder> cellQueue;
   cellQueue.push(commonCell);
 
   maxDepth -= 1;
 
-  while (!cellQueue.empty() && cellQueue.size() + result.size() < cells_count)
+  while (!cellQueue.empty() && cellQueue.size() + result.size() < cellsCount)
   {
-    CellIdT id = cellQueue.front();
+    CellIdT id = cellQueue.top();
     cellQueue.pop();
 
     while (id.Level() > maxDepth)
@@ -61,44 +65,37 @@ inline void CoverRect(double minX, double minY,
       break;
     }
 
-    vector<CellIdT> children;
-    SplitRectCell<BoundsT>(id, minX, minY, maxX, maxY, children);
+    array<pair<CellIdT, m2::RectD>, 4> arr;
+    int const count = SplitRectCell<BoundsT>(id, rect, arr);
 
-    // Children shouldn't be empty, but if it is, ignore this cellid in release.
-    ASSERT(!children.empty(), (id, minX, minY, maxX, maxY));
-    if (children.empty())
+    if (cellQueue.size() + result.size() + count <= cellsCount)
     {
-      result.push_back(id);
-      continue;
-    }
-
-    if (cellQueue.size() + result.size() + children.size() <= cells_count)
-    {
-      for (size_t i = 0; i < children.size(); ++i)
-        cellQueue.push(children[i]);
+      for (int i = 0; i < count; ++i)
+      {
+        if (rect.IsRectInside(arr[i].second))
+          result.push_back(arr[i].first);
+        else
+          cellQueue.push(arr[i].first);
+      }
     }
     else
+    {
       result.push_back(id);
+    }
   }
 
   for (; !cellQueue.empty(); cellQueue.pop())
-    result.push_back(cellQueue.front());
-
-  for (size_t i = 0; i < result.size(); ++i)
   {
-    CellIdT id = result[i];
+    CellIdT id = cellQueue.top();
     while (id.Level() < maxDepth)
     {
-      vector<CellIdT> children;
-      SplitRectCell<BoundsT>(id, minX, minY, maxX, maxY, children);
-      if (children.size() == 1)
-        id = children[0];
+      array<pair<CellIdT, m2::RectD>, 4> arr;
+      int const count = SplitRectCell<BoundsT>(id, rect, arr);
+      if (count == 1)
+        id = arr[0].first;
       else
         break;
     }
-    result[i] = id;
+    result.push_back(id);
   }
-
-  ASSERT_LESS_OR_EQUAL(result.size(), cells_count, (minX, minY, maxX, maxY));
-  cells.insert(cells.end(), result.begin(), result.end());
 }

--- a/indexer/feature_covering.cpp
+++ b/indexer/feature_covering.cpp
@@ -192,11 +192,10 @@ void AppendLowerLevels(RectId id, int cellDepth, IntervalsT & intervals)
 void CoverViewportAndAppendLowerLevels(m2::RectD const & r, int cellDepth, IntervalsT & res)
 {
   vector<RectId> ids;
-  CoverRect<MercatorBounds, RectId>(r.minX(), r.minY(), r.maxX(), r.maxY(), 8, cellDepth, ids);
+  ids.reserve(SPLIT_RECT_CELLS_COUNT);
+  CoverRect<MercatorBounds, RectId>(r, SPLIT_RECT_CELLS_COUNT, cellDepth, ids);
 
   IntervalsT intervals;
-  intervals.reserve(ids.size() * 4);
-
   for (size_t i = 0; i < ids.size(); ++i)
     AppendLowerLevels(ids[i], cellDepth, intervals);
 

--- a/indexer/indexer_tests/cell_coverer_test.cpp
+++ b/indexer/indexer_tests/cell_coverer_test.cpp
@@ -18,7 +18,7 @@ UNIT_TEST(CellIdToStringRecode)
 UNIT_TEST(GoldenCoverRect)
 {
   vector<CellIdT> cells;
-  CoverRect<OrthoBounds>(27.43, 53.83, 27.70, 53.96, 4, RectId::DEPTH_LEVELS, cells);
+  CoverRect<OrthoBounds>({27.43, 53.83, 27.70, 53.96}, 4, RectId::DEPTH_LEVELS, cells);
 
   TEST_EQUAL(cells.size(), 4, ());
 
@@ -33,7 +33,7 @@ UNIT_TEST(ArtificialCoverRect)
   typedef Bounds<0, 0, 16, 16> TestBounds;
 
   vector<CellIdT> cells;
-  CoverRect<TestBounds>(5, 5, 11, 11, 4, RectId::DEPTH_LEVELS, cells);
+  CoverRect<TestBounds>({5, 5, 11, 11}, 4, RectId::DEPTH_LEVELS, cells);
 
   TEST_EQUAL(cells.size(), 4, ());
 

--- a/indexer/mwm_set.hpp
+++ b/indexer/mwm_set.hpp
@@ -235,15 +235,16 @@ public:
 
     // Called when a map is registered for a first time and can be
     // used.
-    virtual void OnMapRegistered(platform::LocalCountryFile const & localFile) {}
+    virtual void OnMapRegistered(platform::LocalCountryFile const & /*localFile*/) {}
 
     // Called when a map is updated to a newer version. Feel free to
     // treat it as combined OnMapRegistered(newFile) +
     // OnMapRegistered(oldFile).
-    virtual void OnMapUpdated(platform::LocalCountryFile const & newFile, platform::LocalCountryFile const & oldFile) {}
+    virtual void OnMapUpdated(platform::LocalCountryFile const & /*newFile*/,
+                              platform::LocalCountryFile const & /*oldFile*/) {}
 
     // Called when a map is deregistered and can no longer be used.
-    virtual void OnMapDeregistered(platform::LocalCountryFile const & localFile) {}
+    virtual void OnMapDeregistered(platform::LocalCountryFile const & /*localFile*/) {}
   };
 
   /// Registers a new map.

--- a/routing/osrm_data_facade.hpp
+++ b/routing/osrm_data_facade.hpp
@@ -101,7 +101,7 @@ public:
     return res;
   }
 
-  EdgeDataT & GetEdgeData(const EdgeID e) const override
+  EdgeDataT & GetEdgeData(const EdgeID) const override
   {
     static EdgeDataT res;
     ASSERT(false, ("Maps me routing facade does not supports this edge unpacking method"));
@@ -109,7 +109,7 @@ public:
   }
 
   //! TODO: Make proper travelmode getter when we add it to routing file
-  TravelMode GetTravelModeForEdgeID(const unsigned id) const override
+  TravelMode GetTravelModeForEdgeID(const unsigned) const override
   {
       return TRAVEL_MODE_DEFAULT;
   }
@@ -149,44 +149,44 @@ public:
     return smallest_edge;
   }
 
-  EdgeID FindEdgeInEitherDirection(const NodeID from, const NodeID to) const override
+  EdgeID FindEdgeInEitherDirection(const NodeID, const NodeID) const override
   {
     return (EdgeID)0;
   }
 
-  EdgeID FindEdgeIndicateIfReverse(const NodeID from, const NodeID to, bool &result) const override
+  EdgeID FindEdgeIndicateIfReverse(const NodeID, const NodeID, bool &) const override
   {
     return (EdgeID)0;
   }
 
   // node and edge information access
-  FixedPointCoordinate GetCoordinateOfNode(const unsigned id) const override
+  FixedPointCoordinate GetCoordinateOfNode(const unsigned) const override
   {
     return FixedPointCoordinate();
   }
 
-  bool EdgeIsCompressed(const unsigned id) const override
+  bool EdgeIsCompressed(const unsigned) const override
   {
     return false;
   }
 
-  unsigned GetGeometryIndexForEdgeID(const unsigned id) const override
+  unsigned GetGeometryIndexForEdgeID(const unsigned) const override
   {
     return false;
   }
 
-  void GetUncompressedGeometry(const unsigned id, std::vector<unsigned> &result_nodes) const override
+  void GetUncompressedGeometry(const unsigned, std::vector<unsigned> &) const override
   {
   }
 
-  TurnInstruction GetTurnInstructionForEdgeID(const unsigned id) const override
+  TurnInstruction GetTurnInstructionForEdgeID(const unsigned) const override
   {
     return TurnInstruction::NoTurn;
   }
 
-  bool LocateClosestEndPointForCoordinate(const FixedPointCoordinate &input_coordinate,
-                                          FixedPointCoordinate &result,
-                                          const unsigned zoom_level = 18) override
+  bool LocateClosestEndPointForCoordinate(const FixedPointCoordinate &,
+                                          FixedPointCoordinate &,
+                                          const unsigned = 18) override
   {
     return false;
   }
@@ -206,25 +206,25 @@ public:
     return false;
   }*/
 
-  bool IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate & input_coordinate,
-                                               std::vector<PhantomNode> & resulting_phantom_node_vector,
-                                               const unsigned number_of_results) override
+  bool IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &,
+                                               std::vector<PhantomNode> &,
+                                               const unsigned) override
   {
     return false;
   }
 
-  bool IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate & input_coordinate,
-                                               PhantomNode & resulting_phantom_node) override
+  bool IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &,
+                                               PhantomNode &) override
   {
     return false;
   }
 
   bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
-           const FixedPointCoordinate & input_coordinate,
-           std::vector<std::pair<PhantomNode, double>> & resulting_phantom_node_vector,
-           const double max_distance,
-           const unsigned min_number_of_phantom_nodes,
-           const unsigned max_number_of_phantom_nodes) override
+           const FixedPointCoordinate &,
+           std::vector<std::pair<PhantomNode, double>> &,
+           const double,
+           const unsigned,
+           const unsigned) override
   {
     return false;
   }
@@ -234,7 +234,7 @@ public:
     return 0;
   }
 
-  unsigned GetNameIndexFromEdgeID(const unsigned id) const override
+  unsigned GetNameIndexFromEdgeID(const unsigned) const override
   {
     return -1;
   }
@@ -243,8 +243,10 @@ public:
   //{
   //}
 
-  std::string get_name_for_id(const unsigned name_id) const override
-  {return "";}
+  std::string get_name_for_id(const unsigned) const override
+  {
+    return std::string();
+  }
 
   std::string GetTimestamp() const override
   {


### PR DESCRIPTION
В двух словах. Раньше в функции ForEachInRect для произвольного ректа мы покрывали его всего 8 ячейками геометрического индекса. Как следствие - в функтор могло приходить много фич, которые не лежат в ректе. Я переписал функцию CoverRect. Теперь вместо 8 используем константу 512 и функция дробит именно крупные ячейки сначала.

Я делал тесты для другого проекта и это показывает хороший прирост в производительности, когда мы в функторе просто вычитываем фичу. Т е лучше провести чуть чуть больше времени на разбитии входного ректа, чем потом вычитывать лишние фичи.

Для убедительности, стресс тест на константу 8 vs 512 при желании сделаете сами.