### PR TITLE
[generator] Fix New Zealand country names

### DIFF
--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -809,7 +809,11 @@
  "driving": "l",
  "languages": ["en", "mi"]
 },
-"New Zealand": {
+"New Zealand South": {
+ "driving": "l",
+ "languages": ["en", "mi"]
+},
+"New Zealand North": {
  "driving": "l",
  "languages": ["en", "mi"]
 },


### PR DESCRIPTION
MAPSME-3420

В Новой Зеландии движение определяется как правостороннее, потому что из-за моих кривых рук у нас нет Новой Зеландии. Есть Южная и Северная Н. З.