### PR TITLE
[editor] Forbid editing old maps

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -859,8 +859,10 @@ void Framework::FillInfoFromFeatureType(FeatureType const & ft, place_page::Info
   if (m_bannerSet.HasBannerForFeature(ft))
     info.m_banner = m_bannerSet.GetBannerForFeature(ft);
 
+  auto const mwmInfo = ft.GetID().m_mwmId.GetInfo();
+  bool const isMapVersionEditable = mwmInfo && mwmInfo->m_version.IsEditableMap();
   info.m_canEditOrAdd = featureStatus != osm::Editor::FeatureStatus::Obsolete && CanEditMap() &&
-                        !info.IsNotEditableSponsored();
+                        !info.IsNotEditableSponsored() && isMapVersionEditable;
 
   info.m_localizedWifiString = m_stringsBundle.GetString("wifi");
   info.m_localizedRatingString = m_stringsBundle.GetString("place_page_booking_rating");

--- a/platform/mwm_version.cpp
+++ b/platform/mwm_version.cpp
@@ -19,6 +19,12 @@ namespace version
 {
 namespace
 {
+// Editing maps older than approximately two months old is disabled, since the data
+// is most likely already fixed on OSM. Not limited to the latest one or two versions,
+// because a user can forget to update maps after a new app version has been installed
+// automatically in the background.
+uint64_t constexpr kMaxSecondsTillNoEdits = 3600 * 24 * 31 * 2;
+
 uint64_t VersionToSecondsSinceEpoch(uint64_t version)
 {
   auto constexpr partsCount = 3;
@@ -72,6 +78,11 @@ uint32_t MwmVersion::GetVersion() const
 {
   auto const tm = my::GmTime(my::SecondsSinceEpochToTimeT(m_secondsSinceEpoch));
   return my::GenerateYYMMDD(tm.tm_year, tm.tm_mon, tm.tm_mday);
+}
+
+bool MwmVersion::IsEditableMap() const
+{
+  return m_secondsSinceEpoch + kMaxSecondsTillNoEdits > my::SecondsSinceEpoch();
 }
 
 string DebugPrint(Format f)

--- a/platform/mwm_version.hpp
+++ b/platform/mwm_version.hpp
@@ -36,6 +36,7 @@ public:
 
   void SetFormat(Format format) { m_format = format; }
   void SetSecondsSinceEpoch(uint64_t secondsSinceEpoch) { m_secondsSinceEpoch = secondsSinceEpoch; }
+  bool IsEditableMap() const;
 
 private:
   /// Data layout format in mwm file.


### PR DESCRIPTION
Мы сейчас позволяем редактировать карты, скачанные в марте прошлого года. Не очень хорошо. Этот PR немного сократит набор карт, позволяющих редактирование. По мотивам #5132.