### PR TITLE
[generator] Process wifi=* tags and discard FMD_URL

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -164,6 +164,9 @@ string MetadataTagProcessorImpl::ValidateAndFormat_internet(string v) const
   strings::AsciiToLower(v);
   if (v == "wlan" || v == "wired" || v == "yes" || v == "no")
     return v;
+  // Process wifi=free tag.
+  if (v == "free")
+    return "wlan";
   return {};
 }
 

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -80,7 +80,7 @@ public:
     case Metadata::FMD_OPERATOR: valid = ValidateAndFormat_operator(v); break;
     case Metadata::FMD_URL:  // The same validator as for website.
     case Metadata::FMD_WEBSITE: valid = ValidateAndFormat_url(v); break;
-    case Metadata::FMD_INTERNET: ValidateAndFormat_internet(v); break;
+    case Metadata::FMD_INTERNET: valid = ValidateAndFormat_internet(v); break;
     case Metadata::FMD_ELE: valid = ValidateAndFormat_ele(v); break;
     case Metadata::FMD_TURN_LANES: valid = ValidateAndFormat_turn_lanes(v); break;
     case Metadata::FMD_TURN_LANES_FORWARD: valid = ValidateAndFormat_turn_lanes_forward(v); break;

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -219,7 +219,7 @@ namespace ftype
   public:
     enum EType { ENTRANCE, HIGHWAY, ADDRESS, ONEWAY, PRIVATE, LIT, NOFOOT, YESFOOT,
                  NOBICYCLE, YESBICYCLE, BICYCLE_BIDIR, SURFPGOOD, SURFPBAD, SURFUGOOD, SURFUBAD,
-                 HASPARTS, NOCAR, YESCAR,
+                 HASPARTS, NOCAR, YESCAR, WLAN,
                  RW_STATION, RW_STATION_SUBWAY, WHEELCHAIR_YES };
 
     CachedTypes()
@@ -236,7 +236,8 @@ namespace ftype
         {"hwtag", "nobicycle"}, {"hwtag", "yesbicycle"}, {"hwtag", "bidir_bicycle"},
         {"psurface", "paved_good"}, {"psurface", "paved_bad"},
         {"psurface", "unpaved_good"}, {"psurface", "unpaved_bad"},
-        {"building", "has_parts"}, {"hwtag", "nocar"}, {"hwtag", "yescar"}
+        {"building", "has_parts"}, {"hwtag", "nocar"}, {"hwtag", "yescar"},
+        {"internet_access", "wlan"}
       };
       for (auto const & e : arr)
         m_types.push_back(c.GetTypeByPath(e));
@@ -552,6 +553,7 @@ namespace ftype
     TagProcessor(p).ApplyRules
     ({
       { "wheelchair", "designated", [&params] { params.AddType(types.Get(CachedTypes::WHEELCHAIR_YES)); }},
+      { "wifi", "~", [&params] { params.AddType(types.Get(CachedTypes::WLAN)); }},
       { "building:part", "no", [&params] { params.AddType(types.Get(CachedTypes::HASPARTS)); }},
       { "building:parts", "~", [&params] { params.AddType(types.Get(CachedTypes::HASPARTS)); }},
     });

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -60,7 +60,7 @@ bool Metadata::TypeFromString(string const & k, Metadata::EType & outType)
     outType = Metadata::FMD_URL;
   else if (k == "website" || k == "contact:website")
     outType = Metadata::FMD_WEBSITE;
-  else if (k == "internet_access")
+  else if (k == "internet_access" || k == "wifi")
     outType = Metadata::FMD_INTERNET;
   else if (k == "ele")
     outType = Metadata::FMD_ELE;

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -57,7 +57,7 @@ bool Metadata::TypeFromString(string const & k, Metadata::EType & outType)
   else if (k == "operator")
     outType = Metadata::FMD_OPERATOR;
   else if (k == "url")  // TODO: Should we match url to website here?
-    outType = Metadata::FMD_URL;
+    outType = Metadata::FMD_WEBSITE;
   else if (k == "website" || k == "contact:website")
     outType = Metadata::FMD_WEBSITE;
   else if (k == "internet_access" || k == "wifi")


### PR DESCRIPTION
Fixes #1740. Тегов `wifi=*` десять тысяч, хорошо бы их поддержать.
При сохранении будут добавляться теги `internet_access=wlan`, но это даже хорошо.

Заодно убрал `FMD_URL`, это одно и то же, что `FMD_WEBSITE`.