### PR TITLE
[iOS] Fixed recovering from background in landscape mode

### DIFF
--- a/iphone/Maps/Classes/EAGLView.h
+++ b/iphone/Maps/Classes/EAGLView.h
@@ -24,6 +24,8 @@ namespace dp
 
 @property (nonatomic, readonly) BOOL drapeEngineCreated;
 
+@property (nonatomic, readonly) m2::PointU pixelSize;
+
 - (void)deallocateNative;
 - (CGPoint)viewPoint2GlobalPoint:(CGPoint)pt;
 - (CGPoint)globalPoint2ViewPoint:(CGPoint)pt;

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -117,6 +117,14 @@ double getExactDPI(double contentScaleFactor)
   });
 }
 
+- (m2::PointU)pixelSize
+{
+  CGSize const s = self.bounds.size;
+  uint32_t const w = static_cast<uint32_t>(s.width * self.contentScaleFactor);
+  uint32_t const h = static_cast<uint32_t>(s.height * self.contentScaleFactor);
+  return m2::PointU(w, h);
+}
+
 - (void)onSize:(int)width withHeight:(int)height
 {
   int w = width * self.contentScaleFactor;

--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -677,7 +677,7 @@ using namespace osm_auth_ios;
   // because of new OpenGL driver powered by Metal.
   if ([AppInfo sharedInfo].isMetalDriver)
   {
-    m2::PointU size = GetFramework().GetViewportPixelSize();
+    m2::PointU const size = ((EAGLView *)self.mapViewController.view).pixelSize;
     GetFramework().OnRecoverGLContext(static_cast<int>(size.x), static_cast<int>(size.y));
   }
   [MWMLocationManager applicationDidBecomeActive];

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1051,12 +1051,6 @@ m2::PointD Framework::GetPixelCenter() const
                                             : m_currentModelView.PixelRect().Center();
 }
 
-m2::PointU Framework::GetViewportPixelSize() const
-{
-  auto & rect = m_currentModelView.PixelRect();
-  return m2::PointU(static_cast<uint32_t>(rect.SizeX()), static_cast<uint32_t>(rect.SizeY()));
-}
-
 m2::PointD Framework::GetVisiblePixelCenter() const
 {
   return m_visibleViewport.Center();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -563,7 +563,6 @@ public:
 
   m2::PointD GetPixelCenter() const;
   m2::PointD GetVisiblePixelCenter() const;
-  m2::PointU GetViewportPixelSize() const;
 
   m2::PointD const & GetViewportCenter() const;
   void SetViewportCenter(m2::PointD const & pt);


### PR DESCRIPTION
Если восстанавливать приложение из фона в лэндскейпном режиме (при условии, что свернуто приложение было в портретном), размер вьюпорта вычислялся неправильно. Единственное достоверное место, откуда можно получить текущий размер, это вьюшка.