### PR TITLE
[tests] Fix generator test after hwtag-yescar type was added

### DIFF
--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -608,7 +608,7 @@ UNIT_TEST(OsmType_Ferry)
   FeatureParams params;
   ftype::GetNameAndType(&e, params);
 
-  TEST_EQUAL(params.m_Types.size(), 2, (params));
+  TEST_EQUAL(params.m_Types.size(), 3, (params));
 
   uint32_t type = GetType({"highway", "primary", "bridge"});
   TEST(params.IsTypeExist(type), ());
@@ -621,6 +621,9 @@ UNIT_TEST(OsmType_Ferry)
   type = GetType({"route", "ferry"});
   TEST(!params.IsTypeExist(type), ());
   TEST(!carModel.IsRoadType(type), ());
+
+  type = GetType({"hwtag", "yescar"});
+  TEST(params.IsTypeExist(type), ());
 }
 
 UNIT_TEST(OsmType_Boundary)


### PR DESCRIPTION
Добавили новый тип, и его отловил `osm_type_test`. Чиню его.