### PR TITLE
Removing highway=pedestrian.

### DIFF
--- a/routing/car_model.cpp
+++ b/routing/car_model.cpp
@@ -19,7 +19,6 @@ double constexpr kSpeedSecondaryLinkKMpH = 50.0;
 double constexpr kSpeedTertiaryKMpH = 40.0;
 double constexpr kSpeedTertiaryLinkKMpH = 30.0;
 double constexpr kSpeedResidentialKMpH = 25.0;
-double constexpr kSpeedPedestrianKMpH = 25.0;
 double constexpr kSpeedUnclassifiedKMpH = 25.0;
 double constexpr kSpeedServiceKMpH = 15.0;
 double constexpr kSpeedLivingStreetKMpH = 10.0;
@@ -42,7 +41,6 @@ routing::VehicleModel::InitListT const s_carLimits = {
     {{"highway", "tertiary"}, kSpeedTertiaryKMpH},
     {{"highway", "tertiary_link"}, kSpeedTertiaryLinkKMpH},
     {{"highway", "residential"}, kSpeedResidentialKMpH},
-    {{"highway", "pedestrian"}, kSpeedPedestrianKMpH},
     {{"highway", "unclassified"}, kSpeedUnclassifiedKMpH},
     {{"highway", "service"}, kSpeedServiceKMpH},
     {{"highway", "living_street"}, kSpeedLivingStreetKMpH},

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -27,7 +27,7 @@ double constexpr kKMPH2MPS = 1000.0 / (60 * 60);
 
 inline double TimeBetweenSec(m2::PointD const & from, m2::PointD const & to, double speedMPS)
 {
-  ASSERT_GREATER(speedMPS, 0.0, ());
+  CHECK_GREATER(speedMPS, 0.0, ());
 
   double const distanceM = MercatorBounds::DistanceOnEarth(from, to);
   return distanceM / speedMPS;

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -51,16 +51,14 @@ namespace routing
 {
 // RoadGeometry ------------------------------------------------------------------------------------
 RoadGeometry::RoadGeometry(bool oneWay, double speed, Points const & points)
-  : m_points(points), m_speed(speed), m_isOneWay(oneWay)
+  : m_points(points), m_speed(speed), m_isOneWay(oneWay), m_valid(true)
 {
   ASSERT_GREATER(speed, 0.0, ());
 }
 
 void RoadGeometry::Load(IVehicleModel const & vehicleModel, FeatureType const & feature)
 {
-  if (!vehicleModel.IsRoad(feature))
-    return;
-
+  m_valid = vehicleModel.IsRoad(feature);
   m_isOneWay = vehicleModel.IsOneWay(feature);
   m_speed = vehicleModel.GetSpeed(feature);
 

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -58,8 +58,8 @@ RoadGeometry::RoadGeometry(bool oneWay, double speed, Points const & points)
 
 void RoadGeometry::Load(IVehicleModel const & vehicleModel, FeatureType const & feature)
 {
-  CHECK(vehicleModel.IsRoad(feature),
-        ("Feature", feature.GetID().m_index, "is not a road in the current vehicle model"));
+  if (!vehicleModel.IsRoad(feature))
+    return;
 
   m_isOneWay = vehicleModel.IsOneWay(feature);
   m_speed = vehicleModel.GetSpeed(feature);

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -35,10 +35,18 @@ public:
   }
 
   uint32_t GetPointsCount() const { return static_cast<uint32_t>(m_points.size()); }
+
+  // Note. It's possible that car_model was changed after the map was built.
+  // For example, the map from 12.2016 contained highway=pedestrian
+  // in car_model but this type of highways is removed as of 01.2017.
+  // In such cases RoadGeometry is not valid.
+  bool IsValid() const { return m_valid; }
+
 private:
   Points m_points;
   double m_speed = 0.0;
   bool m_isOneWay = false;
+  bool m_valid = false;
 };
 
 class GeometryLoader

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -49,10 +49,7 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
 {
   RoadGeometry const & road = m_geometry.GetRoad(rp.GetFeatureId());
 
-  // Note. It's possible that it's used a map which is built with car_model different from
-  // car_model in current sources. For example, the map from 12.2016 contained highway==pedestrian
-  // in car_model but now this type of highways is removed. In such cases |road| has no points.
-  if (road.GetPointsCount() == 0)
+  if (!road.IsValid())
     return;
 
   bool const bidirectional = !road.IsOneWay();

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -48,6 +48,13 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
                                      vector<SegmentEdge> & edges)
 {
   RoadGeometry const & road = m_geometry.GetRoad(rp.GetFeatureId());
+
+  // Note. It's possible that it's used a map which is built with car_model different from
+  // car_model in current sources. For example, the map from 12.2016 contained highway==pedestrian
+  // in car_model but now this type of highways is removed. In such cases |road| has no points.
+  if (road.GetPointsCount() == 0)
+    return;
+
   bool const bidirectional = !road.IsOneWay();
 
   if ((isOutgoing || bidirectional) && rp.GetPointId() + 1 < road.GetPointsCount())


### PR DESCRIPTION
1. Удалено highway=pedestrian из car_model;
2. Изменен код, чтоб работать в ситуациях, когда mwm в mwm и в исходниках(car_model) содержится разный набор highway.

@Zverik @dobriy-eeh @ygorshenin @mpimenov PTAL