### PR TITLE
[routing] reconstruct route refactoring, also fix endpoints and times

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -42,6 +42,8 @@ set(
   index_graph_serialization.hpp
   index_graph_starter.cpp
   index_graph_starter.hpp
+  index_road_graph.cpp
+  index_road_graph.hpp
   joint.cpp
   joint.hpp
   joint_index.cpp

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -83,7 +83,7 @@ namespace routing
 {
 BicycleDirectionsEngine::BicycleDirectionsEngine(Index const & index) : m_index(index) {}
 
-void BicycleDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction> const & path,
+void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                                        Route::TTimes & times, Route::TTurns & turns,
                                        vector<Junction> & routeGeometry,
                                        vector<TrafficInfo::RoadSegmentId> & trafficSegs,

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -27,7 +27,7 @@ public:
   BicycleDirectionsEngine(Index const & index);
 
   // IDirectionsEngine override:
-  void Generate(IRoadGraph const & graph, vector<Junction> const & path, Route::TTimes & times,
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path, Route::TTimes & times,
                 Route::TTurns & turns, vector<Junction> & routeGeometry,
                 vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs,
                 my::Cancellable const & cancellable) override;

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -9,7 +9,7 @@ double constexpr KMPH2MPS = 1000.0 / (60 * 60);
 
 namespace routing
 {
-void IDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
+void IDirectionsEngine::CalculateTimes(RoadGraphBase const & graph, vector<Junction> const & path,
                                        Route::TTimes & times) const
 {
   times.clear();
@@ -44,7 +44,7 @@ void IDirectionsEngine::CalculateTimes(IRoadGraph const & graph, vector<Junction
   }
 }
 
-bool IDirectionsEngine::ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
+bool IDirectionsEngine::ReconstructPath(RoadGraphBase const & graph, vector<Junction> const & path,
                                         vector<Edge> & routeEdges,
                                         my::Cancellable const & cancellable) const
 {

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -17,7 +17,7 @@ class IDirectionsEngine
 public:
   virtual ~IDirectionsEngine() = default;
 
-  virtual void Generate(IRoadGraph const & graph, vector<Junction> const & path,
+  virtual void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                         Route::TTimes & times, Route::TTurns & turns,
                         vector<Junction> & routeGeometry,
                         vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs,
@@ -27,10 +27,10 @@ protected:
   /// \brief constructs route based on |graph| and |path|. Fills |routeEdges| with the route.
   /// \returns false in case of any errors while reconstruction, if reconstruction process
   /// was cancelled and in case of extremely short paths of 0 or 1 point. Returns true otherwise.
-  bool ReconstructPath(IRoadGraph const & graph, vector<Junction> const & path,
+  bool ReconstructPath(RoadGraphBase const & graph, vector<Junction> const & path,
                        vector<Edge> & routeEdges, my::Cancellable const & cancellable) const;
 
-  void CalculateTimes(IRoadGraph const & graph, vector<Junction> const & path,
+  void CalculateTimes(RoadGraphBase const & graph, vector<Junction> const & path,
                       Route::TTimes & times) const;
 };
 }  // namespace routing

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -16,39 +16,35 @@ IndexGraphStarter::IndexGraphStarter(IndexGraph & graph, FakeVertex const & star
 
 m2::PointD const & IndexGraphStarter::GetPoint(Segment const & segment, bool front)
 {
-  if (segment == kStartFakeSegment)
+  if (segment == kStartFakeSegment || (!front && m_start.Fits(segment)))
     return m_start.GetPoint();
 
-  if (segment == kFinishFakeSegment)
+  if (segment == kFinishFakeSegment || (front && m_finish.Fits(segment)))
     return m_finish.GetPoint();
 
   return m_graph.GetGeometry().GetPoint(segment.GetRoadPoint(front));
 }
 
 // static
-size_t IndexGraphStarter::GetRouteNumPoints(vector<Segment> const & route)
+size_t IndexGraphStarter::GetRouteNumPoints(vector<Segment> const & segments)
 {
-  // if route contains start and finish fakes only, it doesn't have segment points.
-  // TODO: add start and finish when RecounstructRoute will be reworked.
-  if (route.size() <= 2)
-    return 0;
+  // Valid route contains at least 3 segments:
+  // start fake, finish fake and at least one normal nearest segment.
+  CHECK_GREATER_OR_EQUAL(segments.size(), 3, ());
 
   // -2 for fake start and finish.
   // +1 for front point of first segment.
-  return route.size() - 1;
+  return segments.size() - 1;
 }
 
-m2::PointD const & IndexGraphStarter::GetRoutePoint(vector<Segment> const & route,
+m2::PointD const & IndexGraphStarter::GetRoutePoint(vector<Segment> const & segments,
                                                     size_t pointIndex)
 {
   if (pointIndex == 0)
-  {
-    CHECK_GREATER(route.size(), 1, ());
-    return GetPoint(route[1], false /* front */);
-  }
+    return m_start.GetPoint();
 
-  CHECK_LESS(pointIndex, route.size(), ());
-  return GetPoint(route[pointIndex], true /* front */);
+  CHECK_LESS(pointIndex, segments.size(), ());
+  return GetPoint(segments[pointIndex], true /* front */);
 }
 
 void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -46,10 +46,12 @@ public:
   IndexGraph & GetGraph() const { return m_graph; }
   Segment const & GetStart() const { return kStartFakeSegment; }
   Segment const & GetFinish() const { return kFinishFakeSegment; }
-  m2::PointD const & GetPoint(Segment const & segment, bool isOutgoing);
+  m2::PointD const & GetPoint(Segment const & segment, bool front);
 
   static size_t GetRouteNumPoints(vector<Segment> const & route);
   m2::PointD const & GetRoutePoint(vector<Segment> const & route, size_t pointIndex);
+
+  void GetEdgesList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
 
   void GetOutgoingEdgesList(TVertexType const & segment, vector<TEdgeType> & edges)
   {
@@ -67,13 +69,16 @@ public:
                                                 GetPoint(to, true /* front */));
   }
 
-private:
-  static Segment constexpr kStartFakeSegment =
-      Segment(numeric_limits<uint32_t>::max(), numeric_limits<uint32_t>::max(), false);
-  static Segment constexpr kFinishFakeSegment =
-      Segment(numeric_limits<uint32_t>::max(), numeric_limits<uint32_t>::max(), true);
+  static bool IsFakeSegment(Segment const & segment) { return segment.GetFeatureId() == kFakeFeatureId; }
 
-  void GetEdgesList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
+private:
+  static uint32_t constexpr kFakeFeatureId = numeric_limits<uint32_t>::max();
+  static uint32_t constexpr kFakeSegmentIdx = numeric_limits<uint32_t>::max();
+  static Segment constexpr kStartFakeSegment =
+      Segment(kFakeFeatureId, kFakeSegmentIdx, false);
+  static Segment constexpr kFinishFakeSegment =
+      Segment(kFakeFeatureId, kFakeSegmentIdx, true);
+
   void GetFakeToNormalEdges(FakeVertex const & fakeVertex, vector<SegmentEdge> & edges);
   void GetFakeToNormalEdge(FakeVertex const & fakeVertex, bool forward,
                            vector<SegmentEdge> & edges);

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -1,0 +1,95 @@
+#include "routing/index_road_graph.hpp"
+
+namespace routing
+{
+IndexRoadGraph::IndexRoadGraph(MwmSet::MwmId const & mwmId, Index const & index,
+                               double maxSpeedKMPH, IndexGraphStarter & starter,
+                               vector<Segment> const & segments, vector<Junction> const & junctions)
+  : m_mwmId(mwmId), m_index(index), m_maxSpeedKMPH(maxSpeedKMPH), m_starter(starter)
+{
+  CHECK_EQUAL(segments.size(), junctions.size() + 1, ());
+
+  for (size_t i = 0; i < junctions.size(); ++i)
+  {
+    Junction const & junction = junctions[i];
+    m_endToSegment[junction] = segments[i];
+    m_beginToSegment[junction] = segments[i + 1];
+  }
+}
+
+void IndexRoadGraph::GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const
+{
+  GetEdges(junction, true, edges);
+}
+
+void IndexRoadGraph::GetIngoingEdges(Junction const & junction, TEdgeVector & edges) const
+{
+  GetEdges(junction, false, edges);
+}
+
+double IndexRoadGraph::GetMaxSpeedKMPH() const
+{
+  return m_maxSpeedKMPH;
+}
+
+void IndexRoadGraph::GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const
+{
+  if (edge.IsFake())
+  {
+    types = feature::TypesHolder(feature::GEOM_LINE);
+    return;
+  }
+
+  FeatureID const featureId = edge.GetFeatureId();
+  FeatureType ft;
+  Index::FeaturesLoaderGuard loader(m_index, featureId.m_mwmId);
+  if (!loader.GetFeatureByIndex(featureId.m_index, ft))
+  {
+    LOG(LERROR, ("Can't load types for feature", featureId));
+    return;
+  }
+
+  ASSERT_EQUAL(ft.GetFeatureType(), feature::GEOM_LINE, ());
+  types = feature::TypesHolder(ft);
+}
+
+void IndexRoadGraph::GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const
+{
+  // TODO: implement method to support PedestrianDirection::LiftGate, PedestrianDirection::Gate
+  types = feature::TypesHolder();
+}
+
+void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const
+{
+  edges.clear();
+
+  vector<SegmentEdge> segmentEdges;
+  m_starter.GetEdgesList(GetSegment(junction, isOutgoing), isOutgoing, segmentEdges);
+
+  for (SegmentEdge const & segmentEdge : segmentEdges)
+  {
+    Segment const & segment = segmentEdge.GetTarget();
+    if (IndexGraphStarter::IsFakeSegment(segment))
+      continue;
+
+    edges.emplace_back(FeatureID(m_mwmId, segment.GetFeatureId()), segment.IsForward(),
+                       segment.GetSegmentIdx(), GetJunction(segment, false /* front */),
+                       GetJunction(segment, true /* front */));
+  }
+}
+
+Junction IndexRoadGraph::GetJunction(Segment const & segment, bool front) const
+{
+  // TODO: Use real altitudes for pedestrian and bicycle routing.
+  return Junction(m_starter.GetPoint(segment, front), feature::kDefaultAltitudeMeters);
+}
+
+const Segment & IndexRoadGraph::GetSegment(Junction const & junction, bool isOutgoing) const
+{
+  auto const & junctionToSegment = isOutgoing ? m_endToSegment : m_beginToSegment;
+
+  auto it = junctionToSegment.find(junction);
+  CHECK(it != junctionToSegment.cend(), ("junctionToSegment doesn't contains", junction, ", isOutgoing =" + isOutgoing));
+  return it->second;
+}
+}  // namespace routing

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "routing/index_graph_starter.hpp"
+#include "routing/road_graph.hpp"
+#include "routing/segment.hpp"
+
+#include "indexer/index.hpp"
+
+#include "std/map.hpp"
+#include "std/vector.hpp"
+
+namespace routing
+{
+class IndexRoadGraph : public RoadGraphBase
+{
+public:
+  IndexRoadGraph(MwmSet::MwmId const & mwmId, Index const & index, double maxSpeedKMPH,
+                 IndexGraphStarter & starter, vector<Segment> const & segments,
+                 vector<Junction> const & junctions);
+
+  // IRoadGraphBase overrides:
+  virtual void GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const override;
+  virtual void GetIngoingEdges(Junction const & junction, TEdgeVector & edges) const override;
+  virtual double GetMaxSpeedKMPH() const override;
+  virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const override;
+  virtual void GetJunctionTypes(Junction const & junction,
+                                feature::TypesHolder & types) const override;
+
+private:
+  void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;
+  Junction GetJunction(Segment const & segment, bool front) const;
+  const Segment & GetSegment(Junction const & junction, bool isOutgoing) const;
+
+  MwmSet::MwmId const & m_mwmId;
+  Index const & m_index;
+  double const m_maxSpeedKMPH;
+  IndexGraphStarter & m_starter;
+  map<Junction, Segment> m_beginToSegment;
+  map<Junction, Segment> m_endToSegment;
+};
+}  // namespace routing

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -32,7 +32,7 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine()
 {
 }
 
-void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junction> const & path,
+void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                                           Route::TTimes & times, Route::TTurns & turns,
                                           vector<Junction> & routeGeometry,
                                           vector<traffic::TrafficInfo::RoadSegmentId> & /* trafficSegs */,
@@ -60,7 +60,7 @@ void PedestrianDirectionsEngine::Generate(IRoadGraph const & graph, vector<Junct
   routeGeometry = path;
 }
 
-void PedestrianDirectionsEngine::CalculateTurns(IRoadGraph const & graph,
+void PedestrianDirectionsEngine::CalculateTurns(RoadGraphBase const & graph,
                                                 vector<Edge> const & routeEdges,
                                                 Route::TTurns & turns,
                                                 my::Cancellable const & cancellable) const

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -11,13 +11,13 @@ public:
   PedestrianDirectionsEngine();
 
   // IDirectionsEngine override:
-  void Generate(IRoadGraph const & graph, vector<Junction> const & path, Route::TTimes & times,
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path, Route::TTimes & times,
                 Route::TTurns & turns, vector<Junction> & routeGeometry,
                 vector<traffic::TrafficInfo::RoadSegmentId> & /* trafficSegs */,
                 my::Cancellable const & cancellable) override;
 
 private:
-  void CalculateTurns(IRoadGraph const & graph, vector<Edge> const & routeEdges,
+  void CalculateTurns(RoadGraphBase const & graph, vector<Edge> const & routeEdges,
                       Route::TTurns & turnsDir,
                       my::Cancellable const & cancellable) const;
 

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -92,11 +92,31 @@ private:
   Junction m_endJunction;
 };
 
-class IRoadGraph
+class RoadGraphBase
+{
+public:
+  typedef vector<Edge> TEdgeVector;
+
+  /// Finds all nearest outgoing edges, that route to the junction.
+  virtual void GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const = 0;
+
+  /// Finds all nearest ingoing edges, that route to the junction.
+  virtual void GetIngoingEdges(Junction const & junction, TEdgeVector & edges) const = 0;
+
+  /// Returns max speed in KM/H
+  virtual double GetMaxSpeedKMPH() const = 0;
+
+  /// @return Types for the specified edge
+  virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const = 0;
+
+  /// @return Types for specified junction
+  virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
+};
+
+class IRoadGraph : public RoadGraphBase
 {
 public:
   typedef vector<Junction> TJunctionVector;
-  typedef vector<Edge> TEdgeVector;
 
   enum class Mode
   {
@@ -200,11 +220,9 @@ public:
 
   virtual ~IRoadGraph() = default;
 
-  /// Finds all nearest outgoing edges, that route to the junction.
-  void GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const;
+  virtual void GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const override;
 
-  /// Finds all nearest ingoing edges, that route to the junction.
-  void GetIngoingEdges(Junction const & junction, TEdgeVector & edges) const;
+  virtual void GetIngoingEdges(Junction const & junction, TEdgeVector & edges) const override;
 
   /// Removes all fake turns and vertices from the graph.
   void ResetFakes();
@@ -222,9 +240,6 @@ public:
   /// Returns speed in KM/H for a road corresponding to edge.
   double GetSpeedKMPH(Edge const & edge) const;
 
-  /// Returns max speed in KM/H
-  virtual double GetMaxSpeedKMPH() const = 0;
-
   /// Calls edgesLoader on each feature which is close to cross.
   virtual void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                             ICrossEdgesLoader & edgesLoader) const = 0;
@@ -239,10 +254,7 @@ public:
   virtual void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const = 0;
 
   /// @return Types for the specified edge
-  void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const;
-
-  /// @return Types for specified junction
-  virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
+  virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const override;
 
   virtual IRoadGraph::Mode GetMode() const = 0;
 

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -29,6 +29,7 @@ SOURCES += \
     index_graph.cpp \
     index_graph_serialization.cpp \
     index_graph_starter.cpp \
+    index_road_graph.cpp \
     joint.cpp \
     joint_index.cpp \
     nearest_edge_finder.cpp \
@@ -80,6 +81,7 @@ HEADERS += \
     index_graph.hpp \
     index_graph_serialization.hpp \
     index_graph_starter.hpp \
+    index_road_graph.hpp \
     joint.hpp \
     joint_index.hpp \
     loaded_path_segment.hpp \

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -7,7 +7,7 @@ namespace routing
 {
 using namespace traffic;
 
-void ReconstructRoute(IDirectionsEngine & engine, IRoadGraph const & graph,
+void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       shared_ptr<TrafficInfo::Coloring> const & trafficColoring,
                       my::Cancellable const & cancellable, vector<Junction> & path, Route & route)
 {

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -25,7 +25,7 @@ bool IsRoad(TTypes const & types)
          BicycleModel::AllLimitsInstance().HasRoadType(types);
 }
 
-void ReconstructRoute(IDirectionsEngine & engine, IRoadGraph const & graph,
+void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       shared_ptr<traffic::TrafficInfo::Coloring> const & trafficColoring,
                       my::Cancellable const & cancellable, vector<Junction> & path, Route & route);
 }  // namespace rouing

--- a/routing/single_mwm_router.hpp
+++ b/routing/single_mwm_router.hpp
@@ -46,9 +46,9 @@ private:
   bool FindClosestEdge(MwmSet::MwmId const & mwmId, m2::PointD const & point,
                        Edge & closestEdge) const;
   bool LoadIndex(MwmSet::MwmId const & mwmId, string const & country, IndexGraph & graph);
-  bool BuildRoute(MwmSet::MwmId const & mwmId, vector<Segment> const & segments,
-                  RouterDelegate const & delegate, IndexGraphStarter & starter,
-                  Route & route) const;
+  bool RedressRoute(MwmSet::MwmId const & mwmId, IVehicleModel const & vehicleModel,
+                    vector<Segment> const & segments, RouterDelegate const & delegate,
+                    IndexGraphStarter & starter, Route & route) const;
 
   string const m_name;
   Index const & m_index;

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0C0DF9261DE898CF0055A22F /* single_mwm_router.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */; };
 		0C0DF92A1DE898FF0055A22F /* routing_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */; };
 		0C470E701E0D4EB1005B824D /* segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C470E6F1E0D4EB1005B824D /* segment.hpp */; };
+		0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BC9CF1E28FD4E0071BFDD /* index_road_graph.cpp */; };
+		0C5BC9D21E28FD4E0071BFDD /* index_road_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5BC9D01E28FD4E0071BFDD /* index_road_graph.hpp */; };
 		0C5FEC541DDE191E0017688C /* edge_estimator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC521DDE191E0017688C /* edge_estimator.cpp */; };
 		0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5FEC531DDE191E0017688C /* edge_estimator.hpp */; };
 		0C5FEC5E1DDE192A0017688C /* geometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC561DDE192A0017688C /* geometry.cpp */; };
@@ -254,6 +256,8 @@
 		0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_mwm_router.hpp; sourceTree = "<group>"; };
 		0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers.cpp; sourceTree = "<group>"; };
 		0C470E6F1E0D4EB1005B824D /* segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = segment.hpp; sourceTree = "<group>"; };
+		0C5BC9CF1E28FD4E0071BFDD /* index_road_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_road_graph.cpp; sourceTree = "<group>"; };
+		0C5BC9D01E28FD4E0071BFDD /* index_road_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_road_graph.hpp; sourceTree = "<group>"; };
 		0C5FEC521DDE191E0017688C /* edge_estimator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edge_estimator.cpp; sourceTree = "<group>"; };
 		0C5FEC531DDE191E0017688C /* edge_estimator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = edge_estimator.hpp; sourceTree = "<group>"; };
 		0C5FEC561DDE192A0017688C /* geometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = geometry.cpp; sourceTree = "<group>"; };
@@ -688,6 +692,8 @@
 				0C08AA331DF83223004195DD /* index_graph_serialization.hpp */,
 				0C0DF91F1DE898B70055A22F /* index_graph_starter.cpp */,
 				0C0DF9201DE898B70055A22F /* index_graph_starter.hpp */,
+				0C5BC9CF1E28FD4E0071BFDD /* index_road_graph.cpp */,
+				0C5BC9D01E28FD4E0071BFDD /* index_road_graph.hpp */,
 				0C5FEC5C1DDE192A0017688C /* joint.cpp */,
 				0C5FEC5D1DDE192A0017688C /* joint.hpp */,
 				56099E2D1CC8FBDA00A7772A /* osrm_path_segment_factory.hpp */,
@@ -803,6 +809,7 @@
 				67AB92E51B7B3E6E00AB5194 /* routing_mapping.hpp in Headers */,
 				674F9BCB1B0A580E00704FFA /* async_router.hpp in Headers */,
 				0C08AA391DF8329B004195DD /* routing_exceptions.hpp in Headers */,
+				0C5BC9D21E28FD4E0071BFDD /* index_road_graph.hpp in Headers */,
 				674F9BD11B0A580E00704FFA /* online_cross_fetcher.hpp in Headers */,
 				0C470E701E0D4EB1005B824D /* segment.hpp in Headers */,
 				A120B3531B4A7C1C002F3808 /* astar_algorithm.hpp in Headers */,
@@ -1073,6 +1080,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
+				0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */,
 				56826BD01DB51C4E00807C62 /* car_router.cpp in Sources */,
 				56099E2E1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp in Sources */,
 				675344201A3F644F00A0A8C3 /* vehicle_model.cpp in Sources */,


### PR DESCRIPTION
Первый этап рефакторинга ReconstructRoute: она теперь берет ребра не из геометрического индекса, а из IndexGraph. Это ускоряет общее время поиска примерно в два раза.
На ноутбуке маршрут от метро Аэропорт до метро Царицыно прокладывался 4 секунды, после изменений прокладывается за 2 секунды.

Также в изменения входят:
1. Корректировка старта и финиша маршрута (чтобы находились не на концах сегмента, а там где укажет пользователь).
2. Корректировка времени прокладки маршрута, умножение на 1.8

PTAL