### PR TITLE
[boost] Use system boost in stl_iterator

### DIFF
--- a/base/stl_iterator.hpp
+++ b/base/stl_iterator.hpp
@@ -5,7 +5,7 @@
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
-#include "3party/boost/boost/iterator/iterator_facade.hpp"
+#include <boost/iterator/iterator_facade.hpp>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop


### PR DESCRIPTION
У нас сейчас osrm-backend не собирается под centos с gcc, потому что в нашей копии boost какая-то фигня.