### PR TITLE
Prohibition of uturn on intermediate feature points

### DIFF
--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -70,6 +70,16 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
 void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                                     vector<SegmentEdge> & edges)
 {
+  RoadPoint const rp(from.GetPointId(isOutgoing), from.GetFeatureId());
+  if (from.GetFeatureId() == to.GetFeatureId() && from.GetSegmentIdx() == to.GetSegmentIdx()
+      && from.IsForward() != to.IsForward()
+      && m_roadIndex.GetJointId(rp) == Joint::kInvalidId
+      && rp.GetPointId() != 0
+      && rp.GetPointId() + 1 != m_geometry.GetRoad(from.GetFeatureId()).GetPointsCount())
+  {
+    return;
+  }
+
   double const weight = CalcSegmentWeight(isOutgoing ? to : from);
   edges.emplace_back(to, weight);
 }

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -70,7 +70,7 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
 void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                                     vector<SegmentEdge> & edges)
 {
-  RoadPoint const rp(from.GetPointId(isOutgoing), from.GetFeatureId());
+  RoadPoint const rp = from.GetRoadPoint(isOutgoing);
   if (from.GetFeatureId() == to.GetFeatureId() && from.GetSegmentIdx() == to.GetSegmentIdx()
       && from.IsForward() != to.IsForward()
       && m_roadIndex.GetJointId(rp) == Joint::kInvalidId


### PR DESCRIPTION
Допущение разворота только на точках пересечения с другими фичами и на (висящих) концах фич.

Данное изменение уменьшает время прокладки маршрута (A* на IndexGraph) на 25%-30%.

Детали. Я провел ряд тестов тестов на десктоп (release). Два маршрута. С данным изменением и без. По 3 измерения для каждого маршрута. Вот результаты:
```
Без данного PR:

Сокол - Кузьминки
findEndsS: 0.00782377 loadingGraphS: 0.110006 findingRouteS: 0.669541 reconstructingPathS: 1.30794
findEndsS: 0.00169901 loadingGraphS: 0.106325 findingRouteS: 0.668534 reconstructingPathS: 1.28947
findEndsS: 0.00154356 loadingGraphS: 0.0969779 findingRouteS: 0.662691 reconstructingPathS: 1.28333

Деловой центр - Черкизовская
findEndsS: 0.00131356 loadingGraphS: 0.0981052 findingRouteS: 0.696425 reconstructingPathS: 1.68831
findEndsS: 0.00125683 loadingGraphS: 0.101363 findingRouteS: 0.708295 reconstructingPathS: 1.70792
findEndsS: 0.00127969 loadingGraphS: 0.0960616 findingRouteS: 0.704679 reconstructingPathS: 1.70109

С данным PR

Сокол - Кузьминки
findEndsS: 0.00256711 loadingGraphS: 0.0996326 findingRouteS: 0.469578 reconstructingPathS: 1.08299
findEndsS: 0.00157339 loadingGraphS: 0.101553 findingRouteS: 0.476285 reconstructingPathS: 1.09259
findEndsS: 0.00157462 loadingGraphS: 0.101267 findingRouteS: 0.469528 reconstructingPathS: 1.08468

Деловой центр - Черкизовская
findEndsS: 0.00147884 loadingGraphS: 0.0994047 findingRouteS: 0.500819 reconstructingPathS: 1.50685
findEndsS: 0.00127439 loadingGraphS: 0.100223 findingRouteS: 0.507307 reconstructingPathS: 1.50799
findEndsS: 0.00130624 loadingGraphS: 0.0973816 findingRouteS: 0.500718 reconstructingPathS: 1.49574
```

В свете PR @dobriy-eeh (в котором время на ReconstructPath уменьшается до нуля) следует обратить внимание на findingRouteS. Видно, что оно уменьшается, например, с 0.668 до 0.473. Т.е. время прокладки маршрута уменьшается почти на треть.