### PR TITLE
[routing] fix ferry routes

### DIFF
--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -27,7 +27,8 @@ double constexpr kKMPH2MPS = 1000.0 / (60 * 60);
 
 inline double TimeBetweenSec(m2::PointD const & from, m2::PointD const & to, double speedMPS)
 {
-  CHECK_GREATER(speedMPS, 0.0, ());
+  CHECK_GREATER(speedMPS, 0.0,
+                ("from:", MercatorBounds::ToLatLon(from), "to:", MercatorBounds::ToLatLon(to)));
 
   double const distanceM = MercatorBounds::DistanceOnEarth(from, to);
   return distanceM / speedMPS;

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -66,6 +66,17 @@ void RoadGeometry::Load(IVehicleModel const & vehicleModel, FeatureType const & 
   m_points.reserve(feature.GetPointsCount());
   for (size_t i = 0; i < feature.GetPointsCount(); ++i)
     m_points.emplace_back(feature.GetPoint(i));
+
+  if (m_valid && m_speed <= 0.0)
+  {
+    auto const & id = feature.GetID();
+    CHECK(!m_points.empty(), ("mwm:", id.GetMwmName(), ", featureId:", id.m_index));
+    auto const begin = MercatorBounds::ToLatLon(m_points.front());
+    auto const end = MercatorBounds::ToLatLon(m_points.back());
+    LOG(LERROR, ("Invalid speed", m_speed, "mwm:", id.GetMwmName(), ", featureId:", id.m_index,
+                 ", begin:", begin, "end:", end));
+    m_valid = false;
+  }
 }
 
 // Geometry ----------------------------------------------------------------------------------------

--- a/routing/vehicle_model.cpp
+++ b/routing/vehicle_model.cpp
@@ -62,7 +62,7 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
     if (it != m_types.end())
       speed = min(speed, it->second);
 
-    auto const addRoadInfoIter = FindRoadType(type);
+    auto const addRoadInfoIter = FindRoadType(t);
     if (addRoadInfoIter != m_addRoadTypes.cend())
       speed = min(speed, addRoadInfoIter->m_speedKMpH);
   }


### PR DESCRIPTION
Исправление сломанных маршрутов, которые ломались при попытке проложиться через паром.

Примеры бага есть в https://jira.mail.ru/browse/MAPSME-3546 и https://jira.mail.ru/browse/MAPSME-3456

Суть бага была в том, что хотя паромная переправа верно определялась как дорога, через которую можно проехать, из-за неверно переданного параметра её скорость рассчитывалась как 0 и дальше роутинг ломался.

PLAL @bykoianko @syershov @Zverik 