### PR TITLE
[repo] Add .qmake.stash to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ server
 *.li
 
 *.autosave
+
+.qmake.stash


### PR DESCRIPTION
Надоели файлы `.qmake.stash`, раскиданные по разным каталогам.