### PR TITLE
[routing] fix one segment way

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -82,8 +82,7 @@ void IndexGraphStarter::GetFakeToNormalEdge(FakeVertex const & fakeVertex, bool 
                                             vector<SegmentEdge> & edges)
 {
   Segment const segment(fakeVertex.GetFeatureId(), fakeVertex.GetSegmentIdx(), forward);
-  RoadPoint const & roadPoint = segment.GetRoadPoint(true /* front */);
-  m2::PointD const & pointTo = m_graph.GetGeometry().GetPoint(roadPoint);
+  m2::PointD const & pointTo = GetPoint(segment, true /* front */);
   double const weight = m_graph.GetEstimator().CalcHeuristic(fakeVertex.GetPoint(), pointTo);
   edges.emplace_back(segment, weight);
 }

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -327,6 +327,32 @@ UNIT_TEST(RoadSpeed)
   TestRoute(graph, start, finish, 6, &expectedRoute);
 }
 
+// Roads                             y:
+//
+//    R0    * - - - - - - - - *      0
+//                ^     ^
+//             start   finish
+//
+//    x:    0     1     2     3
+//
+UNIT_TEST(OneSegmentWay)
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+
+  loader->AddRoad(0 /* featureId */, false, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {3.0, 0.0}}));
+
+  traffic::TrafficCache const trafficCache;
+  IndexGraph graph(move(loader), CreateEstimator(trafficCache));
+  graph.Import(vector<Joint>());
+
+  IndexGraphStarter::FakeVertex const start(0, 0, m2::PointD(1, 0));
+  IndexGraphStarter::FakeVertex const finish(0, 0, m2::PointD(2, 0));
+
+  vector<Segment> const expectedRoute({{0, 0, true}});
+  TestRoute(graph, start, finish, 1 /* expectedLength */, &expectedRoute);
+}
+
 //
 //  Road       R0 (ped)       R1 (car)       R2 (car)
 //           0----------1 * 0----------1 * 0----------1


### PR DESCRIPTION
В интеграционном тесте RussiaMoscowNagatinoUturnTurnTest было обнаружено срабатывание проверки инварианта в astar.

Ошибку удалось свести к более простому случаю, который описан в тесте OneSegmentWay (присутствует в этом PR) и починить.

PTAL @bykoianko @syershov 