### PR TITLE
[Release only] Block cross mwm routing in case of single mwm route cannot be found.

### DIFF
--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -290,10 +290,13 @@ IRouter::ResultCode CarRouter::FindRouteMSMT(TFeatureGraphNodeVec const & source
       case Cancelled:
       case InconsistentMWMandRoute:
       case RouteFileNotExist:
-      case PointsInDifferentMWM:
       case NeedMoreMaps:
       case InternalError:
       case FileTooOld:
+        return code;
+
+      case PointsInDifferentMWM:
+        LOG(LERROR, ("FindSingleRouteDispatcher returns PointsInDifferentMWM in FindRouteMSMT(...)."));
         return code;
 
       case NoCurrentPosition:
@@ -476,8 +479,11 @@ CarRouter::ResultCode CarRouter::CalculateRoute(m2::PointD const & startPoint,
     LOG(LINFO, ("Single mwm routing case"));
     IRouter::ResultCode const code =
         FindRouteMSMT(startTask, m_cachedTargets, delegate, startMapping, route);
-    if (code != IRouter::ResultCode::NoError && code != IRouter::ResultCode::RouteNotFound)
+    if (code != IRouter::ResultCode::NoError && code != IRouter::ResultCode::RouteNotFound
+        && code != IRouter::ResultCode::PointsInDifferentMWM)
+    {
       return code;
+    }
 
     m_indexManager.ForEachMapping([](pair<string, TRoutingMappingPtr> const & indexPair) {
       indexPair.second->FreeCrossContext();

--- a/routing/car_router.hpp
+++ b/routing/car_router.hpp
@@ -105,8 +105,8 @@ private:
      * \param rawRoutingResult: routing result store
      * \return true when path exists, false otherwise.
      */
-  bool FindRouteMSMT(TFeatureGraphNodeVec const & source, TFeatureGraphNodeVec const & target,
-                     RouterDelegate const & delegate, TRoutingMappingPtr & mapping, Route & route);
+  IRouter::ResultCode FindRouteMSMT(TFeatureGraphNodeVec const & source, TFeatureGraphNodeVec const & target,
+                                    RouterDelegate const & delegate, TRoutingMappingPtr & mapping, Route & route);
 
   Index & m_index;
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-3632

Проблема в следующем. Если старт и финиш лежат внутри одной mwm и внутри mwm-й маршрут не может быть проложен, то мы пытаемся проложить крос mwm-й маршрут и если он прокладывается, то используем его.

На техническом уровне. Ввиду того, что в качестве результата прокладки маршрута выдаются односегментные дуги (и каждая вторая дуга имеет длину 0) ReconstructPath стал чаще возвращать, что не может реконструировать маршрут. Чаще всего проблема возникает в BicycleDirectionsEngine::Generate(...), которая вызывается из ReconstructPath. Правильным решением видится:
- сделать, чтоб BicycleDirectionsEngine::Generate(...) не создавала линию маршрута. Не правильно, что генератор тернов создает геометрию маршрута;
- сделать, чтоб в ReconstructPath (BicycleDirectionsEngine::Generate(...)) поступали наборы сегментов (между joints);

PR делает хот фикс к следующей проблеме.

В качестве hotfix данный PR делает следующее. Если старт и финиш лежат внутри одной mwm и внутри mwm-й маршрут не может быть проложен, то мы сообщаем клиенту, что маршрут не может быть проложен вообще. В этом случае мы не пытаемся проложить меж mwm-й маршрут.

@dobriy-eeh @ygorshenin @mpimenov PTAL