### PR TITLE
[routing] Fix double junction route

### DIFF
--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -29,13 +29,13 @@ public:
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;
   Junction GetJunction(Segment const & segment, bool front) const;
-  const Segment & GetSegment(Junction const & junction, bool isOutgoing) const;
+  vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
 
   MwmSet::MwmId const & m_mwmId;
   Index const & m_index;
   double const m_maxSpeedKMPH;
   IndexGraphStarter & m_starter;
-  map<Junction, Segment> m_beginToSegment;
-  map<Junction, Segment> m_endToSegment;
+  map<Junction, vector<Segment>> m_beginToSegment;
+  map<Junction, vector<Segment>> m_endToSegment;
 };
 }  // namespace routing

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -71,8 +71,8 @@ public:
 
 private:
   // Target is vertex going to for outgoing edges, vertex going from for ingoing edges.
-  Segment const m_target;
-  double const m_weight;
+  Segment m_target;
+  double m_weight;
 };
 
 inline string DebugPrint(Segment const & segment)


### PR DESCRIPTION
Ошибка найдена в https://jira.mail.ru/browse/MAPSME-3632

Суть в следующем: иногда маршрут петляет и проходит через один и тот же junction в разных направлениях. Класс IndexRoadGraph не учитывал такой случай и возвращал не все ребра, из-за чего маршрут не прокладывался.

PTAL