### PR TITLE
[base] fix signed/unsigned checked_cast

### DIFF
--- a/base/checked_cast.hpp
+++ b/base/checked_cast.hpp
@@ -2,19 +2,31 @@
 
 #include "base/assert.hpp"
 
+#include <type_traits>
+
 namespace base
 {
 template <typename ReturnType, typename ParameterType>
 ReturnType checked_cast(ParameterType v)
 {
-  CHECK_EQUAL(static_cast<ParameterType>(static_cast<ReturnType>(v)), v, ());
-  return static_cast<ReturnType>(v);
+  static_assert(std::is_integral<ParameterType>::value, "ParameterType should be integral");
+  static_assert(std::is_integral<ReturnType>::value, "ReturnType should be integral");
+
+  ReturnType const result = static_cast<ReturnType>(v);
+  CHECK_EQUAL(static_cast<ParameterType>(result), v, ());
+  CHECK((result > 0) == (v > 0), ("checked_cast failed, value =", v, ", result =", result));
+  return result;
 }
 
 template <typename ReturnType, typename ParameterType>
 ReturnType asserted_cast(ParameterType v)
 {
-  ASSERT_EQUAL(static_cast<ParameterType>(static_cast<ReturnType>(v)), v, ());
-  return static_cast<ReturnType>(v);
+  static_assert(std::is_integral<ParameterType>::value, "ParameterType should be integral");
+  static_assert(std::is_integral<ReturnType>::value, "ReturnType should be integral");
+
+  ReturnType const result = static_cast<ReturnType>(v);
+  ASSERT_EQUAL(static_cast<ParameterType>(result), v, ());
+  ASSERT((result > 0) == (v > 0), ("asserted_cast failed, value =", v, ", result =", result));
+  return result;
 }
 }  // namespace base


### PR DESCRIPTION
Добавил дополнительную проверку в checked_cast/asserted_cast для преобразования signed/unsigned типов.

Пример, где она необходима: checked_cast<uint8_t>( int8_t(-2) )

PTAL @syershov 