### PR TITLE
[routing] Interface for getting cross mwm information CrossMwmIndexGraph.

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   car_model.hpp
   car_router.cpp
   car_router.hpp
+  cross_mwm_index_graph.hpp
   cross_mwm_road_graph.cpp
   cross_mwm_road_graph.hpp
   cross_mwm_router.cpp

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "routing/segment.hpp"
+
+#include <vector>
+
+namespace routing
+{
+/// \brief This is an interface for cross mwm routing.
+// @TODO(bykoianko) This interface will have two implementations.
+// * For orsm cross mwm section.
+// * For A* cross mwm section
+class CrossMwmIndexGraph
+{
+public:
+  /// \brief Transition segment is a segment which is crossed by mwm border. That means
+  /// start and finsh of such segment have to lie in different mwms. If a segment is
+  /// crossed by mwm border but its start and finish lie in the same mwm it's not
+  /// a transition segment.
+  /// For most cases there is only one transition segment for a transition feature.
+  /// Transition segment at the picture below is marked as *===>*.
+  /// Transition feature is a feature which contains one or more transition segments.
+  /// Transition features at the picture below is marked as *===>*------>*.
+  /// Every transition feature is duplicated in two neibouring mwms.
+  /// The duplicate is called "twin" at the picture below.
+  /// For most cases a transition feature contains only one transition segment.
+  /// -------MWM0---------------MWM1----------------MWM2-------------
+  /// |                   |                 |                       |
+  /// | F0 in MWM0   *===>*------>*    *===>*------>*  F2 of MWM1   |
+  /// | Twin in MWM1 *===>*------>*    *===>*------>*  Twin in MWM2 |
+  /// |                   |                 |                       |
+  /// | F1 in MWM0      *===>*---->*      *===>*--->*  F3 of MWM1   |
+  /// | Twin in MWM1    *===>*---->*      *===>*--->*  Twin in MWM2 |
+  /// |                   |                 |                       |
+  /// ---------------------------------------------------------------
+  /// There are two kinds of transition segments:
+  /// * enter transition segments are enters to their mwms;
+  /// * exit transition segments are exits from their mwms;
+  /// \returns true if |s| is an exit (|isOutgoing| == true) or an enter (|isOutgoing| == false)
+  /// transition segment.
+  virtual bool IsTransition(Segment const & s, bool isOutgoing) const = 0;
+
+  /// \brief Fills |twins| with a duplicates of |s| transition segment in neibouring mwm.
+  /// For most cases there is only one twin for |s|.
+  /// If |s| an enter transition segment fills |twins| with an appropriate exit transition segments.
+  /// If |s| an exit transition segment fills |twins| with an appropriate enter transition segments.
+  /// \note GetTwin(...) shall be called only if IsTransition(s, ...) returns true.
+  virtual void GetTwin(Segment const & s, std::vector<Segment> & twins) const = 0;
+
+  /// \brief Fills |edges| with edges outgoing from |s| (ingoing to |s|).
+  /// If |isOutgoing| == true then |s| should be an enter transition segment.
+  /// In that case |edges| is filled with all edges starting from |s| and ending at all reachable
+  /// exit transition segments of the mwm of |s|.
+  /// If |isOutgoing| == false then |s| should be an exit transition segment.
+  /// In that case |edges| is filled with all edges starting from all reachable
+  /// enter transition segments of the mwm of |s| and ending at |s|.
+  /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|
+  /// if |isOutgoing| == true and from |SegmentEdge::m_target| to |s| otherwise.
+  virtual void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges) const = 0;
+};
+}  // routing

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -42,10 +42,10 @@ public:
   /// transition segment.
   virtual bool IsTransition(Segment const & s, bool isOutgoing) const = 0;
 
-  /// \brief Fills |twins| with a duplicates of |s| transition segment in neighbouring mwm.
+  /// \brief Fills |twins| with duplicates of |s| transition segment in neighbouring mwm.
   /// For most cases there is only one twin for |s|.
-  /// If |s| is an enter transition segment fills |twins| with an appropriate exit transition segments.
-  /// If |s| is an exit transition segment fills |twins| with an appropriate enter transition segments.
+  /// If |s| is an enter transition segment fills |twins| with appropriate exit transition segments.
+  /// If |s| is an exit transition segment fills |twins| with appropriate enter transition segments.
   /// \note GetTwin(...) shall be called only if IsTransition(s, ...) returns true.
   virtual void GetTwin(Segment const & s, std::vector<Segment> & twins) const = 0;
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -21,7 +21,7 @@ public:
   /// Transition segment at the picture below is marked as *===>*.
   /// Transition feature is a feature which contains one or more transition segments.
   /// Transition features at the picture below is marked as *===>*------>*.
-  /// Every transition feature is duplicated in two neibouring mwms.
+  /// Every transition feature is duplicated in two neighbouring mwms.
   /// The duplicate is called "twin" at the picture below.
   /// For most cases a transition feature contains only one transition segment.
   /// -------MWM0---------------MWM1----------------MWM2-------------
@@ -40,10 +40,10 @@ public:
   /// transition segment.
   virtual bool IsTransition(Segment const & s, bool isOutgoing) const = 0;
 
-  /// \brief Fills |twins| with a duplicates of |s| transition segment in neibouring mwm.
+  /// \brief Fills |twins| with a duplicates of |s| transition segment in neighbouring mwm.
   /// For most cases there is only one twin for |s|.
-  /// If |s| an enter transition segment fills |twins| with an appropriate exit transition segments.
-  /// If |s| an exit transition segment fills |twins| with an appropriate enter transition segments.
+  /// If |s| is an enter transition segment fills |twins| with an appropriate exit transition segments.
+  /// If |s| is an exit transition segment fills |twins| with an appropriate enter transition segments.
   /// \note GetTwin(...) shall be called only if IsTransition(s, ...) returns true.
   virtual void GetTwin(Segment const & s, std::vector<Segment> & twins) const = 0;
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -13,6 +13,8 @@ namespace routing
 class CrossMwmIndexGraph
 {
 public:
+  virtual ~CrossMwmIndexGraph() = default;
+
   /// \brief Transition segment is a segment which is crossed by mwm border. That means
   /// start and finsh of such segment have to lie in different mwms. If a segment is
   /// crossed by mwm border but its start and finish lie in the same mwm it's not

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -71,6 +71,7 @@ HEADERS += \
     bicycle_model.hpp \
     car_model.hpp \
     car_router.hpp \
+    cross_mwm_index_graph.hpp \
     cross_mwm_road_graph.hpp \
     cross_mwm_router.hpp \
     cross_routing_context.hpp \

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -57,6 +57,8 @@ public:
   bool operator!=(Segment const & seg) const { return !(*this == seg); }
 
 private:
+  // @TODO(bykoianko, dobriy-eeh). It's necessary to add a member for mwm identification
+  // as a field. It'll be used during implementation of CrossMwmIndexGraph interface.
   uint32_t m_featureId = 0;
   uint32_t m_segmentIdx = 0;
   bool m_forward = true;

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		56CA09E61E30E73B00D05C9A /* index_graph_tools.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CA09E11E30E73B00D05C9A /* index_graph_tools.hpp */; };
 		56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09E21E30E73B00D05C9A /* restriction_test.cpp */; };
 		56CA09E91E30F19800D05C9A /* libtraffic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56CA09E81E30F19800D05C9A /* libtraffic.a */; };
+		56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */; };
 		56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */; };
 		56F0D7341D896A5300045886 /* libmap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BD35DE1C69F198003AA26F /* libmap.a */; };
 		56F0D7391D896A5300045886 /* libstorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BD35D41C69F155003AA26F /* libstorage.a */; };
@@ -305,6 +306,7 @@
 		56CA09E11E30E73B00D05C9A /* index_graph_tools.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_tools.hpp; sourceTree = "<group>"; };
 		56CA09E21E30E73B00D05C9A /* restriction_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restriction_test.cpp; sourceTree = "<group>"; };
 		56CA09E81E30F19800D05C9A /* libtraffic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtraffic.a; path = "/Users/vladimirbykoyanko/src_github_master/omim/xcode/traffic/../../../omim-build/xcode/Debug/libtraffic.a"; sourceTree = "<absolute>"; };
+		56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_index_graph.hpp; sourceTree = "<group>"; };
 		56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_helpers.hpp; sourceTree = "<group>"; };
 		56F0D75F1D896A5300045886 /* routing_benchmarks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = routing_benchmarks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		670B84BE1A9381D900CE4492 /* cross_routing_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_routing_context.cpp; sourceTree = "<group>"; };
@@ -722,6 +724,12 @@
 				670B84BF1A9381D900CE4492 /* cross_routing_context.hpp */,
 				56099E321CC9247E00A7772A /* directions_engine.cpp */,
 				670EE56E1B664796001E8064 /* directions_engine.hpp */,
+				56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */,
+				67C79BA31E2CEE3100C40034 /* routing_serialization.cpp */,
+				67C79BA41E2CEE3100C40034 /* routing_serialization.hpp */,
+				67C79B9F1E2CEE1400C40034 /* restriction_loader.cpp */,
+				67C79BA01E2CEE1400C40034 /* restriction_loader.hpp */,
+				0C470E6F1E0D4EB1005B824D /* segment.hpp */,
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
 				674F9BBC1B0A580E00704FFA /* features_road_graph.cpp */,
@@ -862,6 +870,7 @@
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
 				349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */,
 				A17B42991BCFBD0E00A1EAE4 /* osrm_helpers.hpp in Headers */,
+				56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */,
 				67C7D42E1B4EB48F00FE41AA /* turns_sound_settings.hpp in Headers */,
 				56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */,
 				670EE55E1B6001E7001E8064 /* routing_session.hpp in Headers */,


### PR DESCRIPTION
Реализация интерфейса для получения информации для меж mwm-го роутинга.

Для реализации mwm-го роутинга на базе разных версий карт требуется получать определенную информацию о меж mwm-х переходах. Данный интерфейс предназначен для этого. 

В плане данных возможны следующие варианты:

Карты ранее чем декабрь 2016 => используем полностью старый механизм меж mwm-го роутинга;

Карты декабрь 2016 - февраль 2017 => используем CrossMwmIndexGraph() интерфейс с информацией из osrm-ой меж mwm-ой секции.

Карты позже чем февраль 2017-го => используем CrossMwmIndexGraph() интерфейс с информаций из новой меж mwm-ой секции посчитанной на базе A* и не содержащей osrm информацию.

@dobriy-eeh @mpimenov @ygorshenin PTAL