### PR TITLE
[routing] numeric mwm id

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -10,6 +10,7 @@
 #include "private.h"
 
 #include "routing/car_router.hpp"
+#include "routing/num_mwm_id.hpp"
 #include "routing/online_absent_fetcher.hpp"
 #include "routing/road_graph_router.hpp"
 #include "routing/route.hpp"
@@ -2488,6 +2489,12 @@ void Framework::SetRouterImpl(RouterType type)
     {
       return m_model.GetIndex().GetMwmIdByCountryFile(CountryFile(countryFile)).IsAlive();
     };
+
+    //    @TODO(bykoianko, dobriy-eeh). Pass numMwmIds to router and CrossMwmIndexGraph.
+    //    shared_ptr<routing::NumMwmIds> numMwmIds = make_shared<routing::NumMwmIds>();
+    //    m_storage.ForEachCountryFile([&](platform::CountryFile const & file){
+    //      numMwmIds->RegisterFile(file);
+    //    });
 
     router.reset(
         new CarRouter(m_model.GetIndex(), countryFileGetter,

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
   loaded_path_segment.hpp
   nearest_edge_finder.cpp
   nearest_edge_finder.hpp
+  num_mwm_id.hpp
   online_absent_fetcher.cpp
   online_absent_fetcher.hpp
   online_cross_fetcher.cpp

--- a/routing/num_mwm_id.hpp
+++ b/routing/num_mwm_id.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "platform/country_file.hpp"
+
+#include "base/assert.hpp"
+#include "base/checked_cast.hpp"
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace routing
+{
+using NumMwmId = std::uint16_t;
+
+class NumMwmIds final
+{
+public:
+  void RegisterFile(platform::CountryFile const & file)
+  {
+    if (ContainsFile(file))
+      return;
+
+    NumMwmId const id = base::asserted_cast<NumMwmId>(m_idToFile.size());
+    m_idToFile.push_back(file);
+    m_fileToId[file] = id;
+  }
+
+  bool ContainsFile(platform::CountryFile const & file) const
+  {
+    return m_fileToId.find(file) != m_fileToId.cend();
+  }
+
+  platform::CountryFile const & GetFile(NumMwmId mwmId) const
+  {
+    size_t const index = base::asserted_cast<size_t>(mwmId);
+    CHECK_LESS(index, m_idToFile.size(), ());
+    return m_idToFile[index];
+  }
+
+  NumMwmId GetId(platform::CountryFile const & file) const
+  {
+    auto const it = m_fileToId.find(file);
+    CHECK(it != m_fileToId.cend(), ("Can't find mwm id for", file));
+    return it->second;
+  }
+
+private:
+  std::vector<platform::CountryFile> m_idToFile;
+  std::map<platform::CountryFile, NumMwmId> m_fileToId;
+};
+}  //  namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -87,6 +87,7 @@ HEADERS += \
     joint_index.hpp \
     loaded_path_segment.hpp \
     nearest_edge_finder.hpp \
+    num_mwm_id.hpp \
     online_absent_fetcher.hpp \
     online_cross_fetcher.hpp \
     osrm2feature_map.hpp \

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/num_mwm_id.hpp"
 #include "routing/road_point.hpp"
 
 #include "std/cstdint.hpp"
@@ -26,6 +27,7 @@ public:
   {
   }
 
+  NumMwmId GetMwmId() const { return m_mwmId; }
   uint32_t GetFeatureId() const { return m_featureId; }
   uint32_t GetSegmentIdx() const { return m_segmentIdx; }
   bool IsForward() const { return m_forward; }
@@ -45,22 +47,25 @@ public:
     if (m_segmentIdx != seg.m_segmentIdx)
       return m_segmentIdx < seg.m_segmentIdx;
 
+    if (m_mwmId != seg.m_mwmId)
+      return m_mwmId < seg.m_mwmId;
+
     return m_forward < seg.m_forward;
   }
 
   bool operator==(Segment const & seg) const
   {
     return m_featureId == seg.m_featureId && m_segmentIdx == seg.m_segmentIdx &&
-           m_forward == seg.m_forward;
+           m_mwmId == seg.m_mwmId && m_forward == seg.m_forward;
   }
 
   bool operator!=(Segment const & seg) const { return !(*this == seg); }
 
 private:
-  // @TODO(bykoianko, dobriy-eeh). It's necessary to add a member for mwm identification
-  // as a field. It'll be used during implementation of CrossMwmIndexGraph interface.
   uint32_t m_featureId = 0;
   uint32_t m_segmentIdx = 0;
+  // @TODO(bykoianko, dobriy-eeh). It's a placeholder. Init m_mwmId in a proper way.
+  NumMwmId m_mwmId = 0;
   bool m_forward = true;
 };
 
@@ -80,8 +85,8 @@ private:
 inline string DebugPrint(Segment const & segment)
 {
   ostringstream out;
-  out << "Segment(" << segment.GetFeatureId() << ", " << segment.GetSegmentIdx() << ", "
-      << segment.IsForward() << ")";
+  out << "Segment(" << segment.GetMwmId() << ", " << segment.GetFeatureId() << ", "
+      << segment.GetSegmentIdx() << ", " << segment.IsForward() << ")";
   return out.str();
 }
 }  // namespace routing

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -424,6 +424,8 @@ public:
   void ForEachInSubtree(TCountryId const & root, ToDo && toDo) const;
   template <class ToDo>
   void ForEachAncestorExceptForTheRoot(TCountryId const & childId, ToDo && toDo) const;
+  template <class ToDo>
+  void ForEachCountryFile(ToDo && toDo) const;
 
   /// \brief Sets callback which will be called in case of a click on download map button on the map.
   void SetCallbackForClickOnDownloadMap(TDownloadFn & downloadFn);
@@ -690,5 +692,14 @@ void Storage::ForEachAncestorExceptForTheRoot(vector<TCountryTreeNode const *> c
           toDo(ancestorId, container);
         });
   }
+}
+
+template <class ToDo>
+void Storage::ForEachCountryFile(ToDo && toDo) const
+{
+  m_countries.GetRoot().ForEachInSubtree([&](TCountryTree::Node const & node) {
+    if (node.ChildrenCount() == 0)
+      toDo(node.Value().GetFile());
+  });
 }
 }  // storage

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0C0DF9261DE898CF0055A22F /* single_mwm_router.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */; };
 		0C0DF92A1DE898FF0055A22F /* routing_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */; };
 		0C470E701E0D4EB1005B824D /* segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C470E6F1E0D4EB1005B824D /* segment.hpp */; };
+		0C5992E21E433BE600203653 /* num_mwm_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5992E11E433BE600203653 /* num_mwm_id.hpp */; };
 		0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BC9CF1E28FD4E0071BFDD /* index_road_graph.cpp */; };
 		0C5BC9D21E28FD4E0071BFDD /* index_road_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5BC9D01E28FD4E0071BFDD /* index_road_graph.hpp */; };
 		0C5FEC541DDE191E0017688C /* edge_estimator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC521DDE191E0017688C /* edge_estimator.cpp */; };
@@ -34,8 +35,6 @@
 		0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5FEC681DDE193F0017688C /* road_point.hpp */; };
 		0C5FEC6D1DDE19A40017688C /* index_graph_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC6C1DDE19A40017688C /* index_graph_test.cpp */; };
 		0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C8705041E0182F200BCAF71 /* route_point.hpp */; };
-		3462520D1E3238CE00D1D75C /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3462520B1E3238CE00D1D75C /* restrictions_serialization.cpp */; };
-		3462520E1E3238CE00D1D75C /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3462520C1E3238CE00D1D75C /* restrictions_serialization.hpp */; };
 		3462FDAD1DC1E5BF00906FD7 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */; };
 		349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */; };
 		349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */; };
@@ -268,6 +267,7 @@
 		0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_mwm_router.hpp; sourceTree = "<group>"; };
 		0C0DF9281DE898FF0055A22F /* routing_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers.cpp; sourceTree = "<group>"; };
 		0C470E6F1E0D4EB1005B824D /* segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = segment.hpp; sourceTree = "<group>"; };
+		0C5992E11E433BE600203653 /* num_mwm_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = num_mwm_id.hpp; sourceTree = "<group>"; };
 		0C5BC9CF1E28FD4E0071BFDD /* index_road_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_road_graph.cpp; sourceTree = "<group>"; };
 		0C5BC9D01E28FD4E0071BFDD /* index_road_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_road_graph.hpp; sourceTree = "<group>"; };
 		0C5FEC521DDE191E0017688C /* edge_estimator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edge_estimator.cpp; sourceTree = "<group>"; };
@@ -285,8 +285,6 @@
 		0C5FEC681DDE193F0017688C /* road_point.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_point.hpp; sourceTree = "<group>"; };
 		0C5FEC6C1DDE19A40017688C /* index_graph_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_test.cpp; sourceTree = "<group>"; };
 		0C8705041E0182F200BCAF71 /* route_point.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_point.hpp; sourceTree = "<group>"; };
-		3462520B1E3238CE00D1D75C /* restrictions_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restrictions_serialization.cpp; sourceTree = "<group>"; };
-		3462520C1E3238CE00D1D75C /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
 		3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-build/xcode/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restrictions_serialization.cpp; sourceTree = "<group>"; };
 		349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
@@ -729,11 +727,6 @@
 				56099E321CC9247E00A7772A /* directions_engine.cpp */,
 				670EE56E1B664796001E8064 /* directions_engine.hpp */,
 				56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */,
-				67C79BA31E2CEE3100C40034 /* routing_serialization.cpp */,
-				67C79BA41E2CEE3100C40034 /* routing_serialization.hpp */,
-				67C79B9F1E2CEE1400C40034 /* restriction_loader.cpp */,
-				67C79BA01E2CEE1400C40034 /* restriction_loader.hpp */,
-				0C470E6F1E0D4EB1005B824D /* segment.hpp */,
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
 				674F9BBC1B0A580E00704FFA /* features_road_graph.cpp */,
@@ -755,6 +748,7 @@
 				56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */,
 				670D049C1B0B4A970013A7AC /* nearest_edge_finder.cpp */,
 				670D049D1B0B4A970013A7AC /* nearest_edge_finder.hpp */,
+				0C5992E11E433BE600203653 /* num_mwm_id.hpp */,
 				A120B34A1B4A7C0A002F3808 /* online_absent_fetcher.cpp */,
 				A120B34B1B4A7C0A002F3808 /* online_absent_fetcher.hpp */,
 				674F9BC01B0A580E00704FFA /* online_cross_fetcher.cpp */,
@@ -859,6 +853,7 @@
 				0C5FEC5F1DDE192A0017688C /* geometry.hpp in Headers */,
 				674A28B21B1605D2001A525C /* osrm_engine.hpp in Headers */,
 				67AB92E71B7B3E6E00AB5194 /* turns_tts_text.hpp in Headers */,
+				0C5992E21E433BE600203653 /* num_mwm_id.hpp in Headers */,
 				56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */,
 				A120B3481B4A7BE5002F3808 /* cross_mwm_router.hpp in Headers */,
 				674F9BD31B0A580E00704FFA /* road_graph_router.hpp in Headers */,


### PR DESCRIPTION
Добавил целочисленный идентификатор mwm.

Он нужен для эффективной идентификации сегментов дорог на всем земном шаре.
Это будет использоваться в cross mwm роутинге.