### PR TITLE
[routing] Prepare cross mwm index routing

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2489,15 +2489,13 @@ void Framework::SetRouterImpl(RouterType type)
       return m_model.GetIndex().GetMwmIdByCountryFile(CountryFile(countryFile)).IsAlive();
     };
 
-    //    @TODO(bykoianko, dobriy-eeh). Pass numMwmIds to router and CrossMwmIndexGraph.
-    //    shared_ptr<routing::NumMwmIds> numMwmIds = make_shared<routing::NumMwmIds>();
-    //    m_storage.ForEachCountryFile([&](platform::CountryFile const & file){
-    //      numMwmIds->RegisterFile(file);
-    //    });
+    auto numMwmIds = make_shared<routing::NumMwmIds>();
+    m_storage.ForEachCountryFile(
+        [&](platform::CountryFile const & file) { numMwmIds->RegisterFile(file); });
 
     router.reset(
         new CarRouter(m_model.GetIndex(), countryFileGetter,
-                      SingleMwmRouter::CreateCarRouter(m_model.GetIndex(), m_routingSession)));
+                      SingleMwmRouter::CreateCarRouter(countryFileGetter, numMwmIds, m_routingSession, m_model.GetIndex())));
     fetcher.reset(new OnlineAbsentCountriesFetcher(countryFileGetter, localFileChecker));
     m_routingSession.SetRoutingSettings(routing::GetCarRoutingSettings());
   }

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -40,6 +40,8 @@ set(
   geometry.hpp
   index_graph.cpp
   index_graph.hpp
+  index_graph_loader.cpp
+  index_graph_loader.hpp
   index_graph_serialization.cpp
   index_graph_serialization.hpp
   index_graph_starter.cpp
@@ -105,6 +107,7 @@ set(
   single_mwm_router.hpp
   speed_camera.cpp
   speed_camera.hpp
+  traffic_stash.hpp
   turn_candidate.hpp
   turns.cpp
   turns.hpp
@@ -119,6 +122,8 @@ set(
   vehicle_mask.hpp
   vehicle_model.cpp
   vehicle_model.hpp
+  world_graph.cpp
+  world_graph.hpp
 )
 
 add_library(${PROJECT_NAME} ${SRC})

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -4,8 +4,8 @@
 #include "routing/loaded_path_segment.hpp"
 #include "routing/turn_candidate.hpp"
 
-#include "std/map.hpp"
-#include "std/unique_ptr.hpp"
+#include <map>
+#include <memory>
 
 class Index;
 
@@ -22,15 +22,14 @@ public:
     size_t m_ingoingTurnsCount;
   };
 
-  using AdjacentEdgesMap = map<UniNodeId, AdjacentEdges>;
+  using AdjacentEdgesMap = std::map<UniNodeId, AdjacentEdges>;
 
-  BicycleDirectionsEngine(Index const & index);
+  BicycleDirectionsEngine(Index const & index, std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, vector<Junction> const & path, Route::TTimes & times,
-                Route::TTurns & turns, vector<Junction> & routeGeometry,
-                vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs,
-                my::Cancellable const & cancellable) override;
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+                my::Cancellable const & cancellable, Route::TTimes & times, Route::TTurns & turns,
+                vector<Junction> & routeGeometry, vector<Segment> & trafficSegs) override;
 
 private:
   Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
@@ -40,6 +39,7 @@ private:
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
   Index const & m_index;
-  unique_ptr<Index::FeaturesLoaderGuard> m_loader;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
+  std::unique_ptr<Index::FeaturesLoaderGuard> m_loader;
 };
 }  // namespace routing

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -208,7 +208,7 @@ IRouter::ResultCode FindSingleOsrmRoute(FeatureGraphNode const & source,
   Route::TTurns turns;
   Route::TTimes times;
   Route::TStreets streets;
-  vector<traffic::TrafficInfo::RoadSegmentId> trafficSegs;
+  vector<Segment> trafficSegs;
 
   LOG(LINFO, ("OSRM route from", MercatorBounds::ToLatLon(source.segmentPoint), "to",
               MercatorBounds::ToLatLon(target.segmentPoint)));
@@ -599,7 +599,8 @@ IRouter::ResultCode CarRouter::FindSingleRouteDispatcher(FeatureGraphNode const 
     }
     LOG(LINFO, (m_router->GetName(), "route from", MercatorBounds::ToLatLon(source.segmentPoint),
                 "to", MercatorBounds::ToLatLon(target.segmentPoint)));
-    result = m_router->CalculateRoute(source.mwmId, source.segmentPoint,
+    m_router->SetCountry(source.mwmId.GetInfo()->GetCountryName());
+    result = m_router->CalculateRoute(source.segmentPoint,
                                       m2::PointD(0, 0) /* direction */, target.segmentPoint,
                                       delegate, mwmRoute);
   }

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -3,6 +3,7 @@
 #include "routing/road_graph.hpp"
 #include "routing/road_point.hpp"
 #include "routing/route.hpp"
+#include "routing/segment.hpp"
 
 #include "traffic/traffic_info.hpp"
 
@@ -18,10 +19,9 @@ public:
   virtual ~IDirectionsEngine() = default;
 
   virtual void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
-                        Route::TTimes & times, Route::TTurns & turns,
-                        vector<Junction> & routeGeometry,
-                        vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs,
-                        my::Cancellable const & cancellable) = 0;
+                        my::Cancellable const & cancellable, Route::TTimes & times,
+                        Route::TTurns & turns, vector<Junction> & routeGeometry,
+                        vector<Segment> & trafficSegs) = 0;
 
 protected:
   /// \brief constructs route based on |graph| and |path|. Fills |routeEdges| with the route.

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "routing/geometry.hpp"
+#include "routing/num_mwm_id.hpp"
 #include "routing/segment.hpp"
+#include "routing/traffic_stash.hpp"
 #include "routing/vehicle_model.hpp"
 
 #include "traffic/traffic_cache.hpp"
@@ -20,27 +22,11 @@ class EdgeEstimator
 public:
   virtual ~EdgeEstimator() = default;
 
-  virtual void Start(MwmSet::MwmId const & mwmId) = 0;
-  virtual void Finish() = 0;
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
 
-  static shared_ptr<EdgeEstimator> CreateForCar(IVehicleModel const & vehicleModel,
-                                                traffic::TrafficCache const & trafficCache);
-};
-
-class EstimatorGuard final
-{
-public:
-  EstimatorGuard(MwmSet::MwmId const & mwmId, EdgeEstimator & estimator) : m_estimator(estimator)
-  {
-    m_estimator.Start(mwmId);
-  }
-
-  ~EstimatorGuard() { m_estimator.Finish(); }
-
-private:
-  EdgeEstimator & m_estimator;
+  static shared_ptr<EdgeEstimator> CreateForCar(shared_ptr<TrafficStash> trafficStash,
+                                                double maxSpeedKMpH);
 };
 }  // namespace routing

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -112,14 +112,16 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
 
   if ((isOutgoing || bidirectional) && rp.GetPointId() + 1 < road.GetPointsCount())
   {
-    GetNeighboringEdge(from, Segment(rp.GetFeatureId(), rp.GetPointId(), isOutgoing), isOutgoing,
-                       edges);
+    GetNeighboringEdge(from,
+                       Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId(), isOutgoing),
+                       isOutgoing, edges);
   }
 
   if ((!isOutgoing || bidirectional) && rp.GetPointId() > 0)
   {
-    GetNeighboringEdge(from, Segment(rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing),
-                       isOutgoing, edges);
+    GetNeighboringEdge(
+        from, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing),
+        isOutgoing, edges);
   }
 }
 
@@ -145,7 +147,7 @@ void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bo
 double IndexGraph::GetPenalties(Segment const & u, Segment const & v) const
 {
   if (IsUTurn(u, v))
-    return GetEstimator().GetUTurnPenalty();
+    return m_estimator->GetUTurnPenalty();
 
   return 0.0;
 }

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -31,7 +31,6 @@ public:
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
 
   Geometry & GetGeometry() { return m_geometry; }
-  EdgeEstimator const & GetEstimator() const { return *m_estimator; }
   bool IsRoad(uint32_t featureId) const { return m_roadIndex.IsRoad(featureId); }
   RoadJointIds const & GetRoad(uint32_t featureId) const { return m_roadIndex.GetRoad(featureId); }
 

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -1,0 +1,107 @@
+#include "routing/index_graph_loader.hpp"
+
+#include "routing/index_graph_serialization.hpp"
+#include "routing/restriction_loader.hpp"
+#include "routing/routing_exceptions.hpp"
+
+#include "coding/file_container.hpp"
+
+#include "base/assert.hpp"
+#include "base/timer.hpp"
+
+namespace
+{
+using namespace routing;
+using namespace std;
+
+class IndexGraphLoaderImpl final : public IndexGraphLoader
+{
+public:
+  IndexGraphLoaderImpl(shared_ptr<NumMwmIds> numMwmIds,
+                       shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                       shared_ptr<EdgeEstimator> estimator, shared_ptr<TrafficStash> trafficStash,
+                       Index & index);
+
+  // IndexGraphLoader overrides:
+  virtual IndexGraph & GetIndexGraph(NumMwmId numMwmId) override;
+
+private:
+  IndexGraph & Load(NumMwmId mwmId);
+
+  Index & m_index;
+  shared_ptr<NumMwmIds> m_numMwmIds;
+  shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
+  shared_ptr<EdgeEstimator> m_estimator;
+  shared_ptr<TrafficStash> m_trafficStash;
+  unordered_map<NumMwmId, unique_ptr<IndexGraph>> m_graphs;
+};
+
+IndexGraphLoaderImpl::IndexGraphLoaderImpl(shared_ptr<NumMwmIds> numMwmIds,
+                                           shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                                           shared_ptr<EdgeEstimator> estimator,
+                                           shared_ptr<TrafficStash> trafficStash, Index & index)
+  : m_index(index)
+  , m_numMwmIds(numMwmIds)
+  , m_vehicleModelFactory(vehicleModelFactory)
+  , m_estimator(estimator)
+  , m_trafficStash(trafficStash)
+{
+  CHECK(m_numMwmIds, ());
+  CHECK(m_vehicleModelFactory, ());
+  CHECK(m_estimator, ());
+  CHECK(m_trafficStash, ());
+}
+
+IndexGraph & IndexGraphLoaderImpl::GetIndexGraph(NumMwmId numMwmId)
+{
+  auto it = m_graphs.find(numMwmId);
+  if (it != m_graphs.end())
+    return *it->second;
+
+  return Load(numMwmId);
+}
+
+IndexGraph & IndexGraphLoaderImpl::Load(NumMwmId numMwmId)
+{
+  platform::CountryFile const & file = m_numMwmIds->GetFile(numMwmId);
+  MwmSet::MwmHandle handle = m_index.GetMwmHandleByCountryFile(file);
+  if (!handle.IsAlive())
+    MYTHROW(RoutingException, ("Can't get mwm handle for", file));
+
+  shared_ptr<IVehicleModel> vehicleModel =
+      m_vehicleModelFactory->GetVehicleModelForCountry(file.GetName());
+
+  auto const mwmId = MwmSet::MwmId(handle.GetInfo());
+  auto graphPtr =
+      make_unique<IndexGraph>(GeometryLoader::Create(m_index, mwmId, vehicleModel), m_estimator);
+  auto & graph = *graphPtr;
+  m_trafficStash->Load(mwmId, numMwmId);
+
+  MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
+
+  my::Timer timer;
+  FilesContainerR::TReader reader(mwmValue.m_cont.GetReader(ROUTING_FILE_TAG));
+  ReaderSource<FilesContainerR::TReader> src(reader);
+  IndexGraphSerializer::Deserialize(graph, src, kCarMask);
+  RestrictionLoader restrictionLoader(mwmValue, graph);
+  if (restrictionLoader.HasRestrictions())
+    graph.SetRestrictions(restrictionLoader.StealRestrictions());
+
+  m_graphs[numMwmId] = move(graphPtr);
+  LOG(LINFO, (ROUTING_FILE_TAG, "section for", file.GetName(), "loaded in", timer.ElapsedSeconds(),
+              "seconds"));
+  return graph;
+}
+}  // namespace
+
+namespace routing
+{
+// static
+unique_ptr<IndexGraphLoader> IndexGraphLoader::Create(
+    shared_ptr<NumMwmIds> numMwmIds, shared_ptr<VehicleModelFactory> vehicleModelFactory,
+    shared_ptr<EdgeEstimator> estimator, shared_ptr<TrafficStash> trafficStash, Index & index)
+{
+  return make_unique<IndexGraphLoaderImpl>(numMwmIds, vehicleModelFactory, estimator, trafficStash,
+                                           index);
+}
+}  // namespace routing

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "routing/edge_estimator.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/num_mwm_id.hpp"
+#include "routing/traffic_stash.hpp"
+#include "routing/vehicle_model.hpp"
+
+#include "indexer/index.hpp"
+
+#include <memory>
+
+namespace routing
+{
+class IndexGraphLoader
+{
+public:
+  virtual ~IndexGraphLoader() = default;
+
+  virtual IndexGraph & GetIndexGraph(NumMwmId mwmId) = 0;
+
+  static std::unique_ptr<IndexGraphLoader> Create(
+      std::shared_ptr<NumMwmIds> numMwmIds,
+      std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
+      std::shared_ptr<EdgeEstimator> estimator, std::shared_ptr<TrafficStash> trafficStash,
+      Index & index);
+};
+}  // namespace routing

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/index_graph_starter.hpp"
+#include "routing/num_mwm_id.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/segment.hpp"
 
@@ -14,9 +15,9 @@ namespace routing
 class IndexRoadGraph : public RoadGraphBase
 {
 public:
-  IndexRoadGraph(MwmSet::MwmId const & mwmId, Index const & index, double maxSpeedKMPH,
-                 IndexGraphStarter & starter, vector<Segment> const & segments,
-                 vector<Junction> const & junctions);
+  IndexRoadGraph(shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarter & starter,
+                 vector<Segment> const & segments, vector<Junction> const & junctions,
+                 Index & index);
 
   // IRoadGraphBase overrides:
   virtual void GetOutgoingEdges(Junction const & junction, TEdgeVector & edges) const override;
@@ -31,9 +32,8 @@ private:
   Junction GetJunction(Segment const & segment, bool front) const;
   vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
 
-  MwmSet::MwmId const & m_mwmId;
-  Index const & m_index;
-  double const m_maxSpeedKMPH;
+  Index & m_index;
+  shared_ptr<NumMwmIds> m_numMwmIds;
   IndexGraphStarter & m_starter;
   map<Junction, vector<Segment>> m_beginToSegment;
   map<Junction, vector<Segment>> m_endToSegment;

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -5,6 +5,7 @@
 #include "routing/road_point.hpp"
 #include "routing/turns.hpp"
 #include "routing/turn_candidate.hpp"
+#include "routing/segment.hpp"
 
 #include "traffic/traffic_info.hpp"
 
@@ -35,7 +36,7 @@ struct LoadedPathSegment
   TEdgeWeight m_weight; /*!< Time in seconds to pass the segment. */
   UniNodeId m_nodeId;   /*!< May be either NodeID for OSRM route or
                              mwm id, feature id, segment id and direction for A*. */
-  vector<traffic::TrafficInfo::RoadSegmentId> m_trafficSegs; /*!< Traffic segments for |m_path|. */
+  vector<Segment> m_trafficSegs; /*!< Traffic segments for |m_path|. */
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;
   bool m_isLink;

--- a/routing/num_mwm_id.hpp
+++ b/routing/num_mwm_id.hpp
@@ -6,12 +6,14 @@
 #include "base/checked_cast.hpp"
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <vector>
 
 namespace routing
 {
 using NumMwmId = std::uint16_t;
+NumMwmId constexpr kFakeNumMwmId = std::numeric_limits<NumMwmId>::max();
 
 class NumMwmIds final
 {
@@ -43,6 +45,13 @@ public:
     auto const it = m_fileToId.find(file);
     CHECK(it != m_fileToId.cend(), ("Can't find mwm id for", file));
     return it->second;
+  }
+
+  template <typename F>
+  void ForEachId(F && f) const
+  {
+    for (NumMwmId id = 0; id < base::asserted_cast<NumMwmId>(m_idToFile.size()); ++id)
+      f(id);
   }
 
 private:

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -32,11 +32,12 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine()
 {
 }
 
-void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
+                                          vector<Junction> const & path,
+                                          my::Cancellable const & cancellable,
                                           Route::TTimes & times, Route::TTurns & turns,
                                           vector<Junction> & routeGeometry,
-                                          vector<traffic::TrafficInfo::RoadSegmentId> & /* trafficSegs */,
-                                          my::Cancellable const & cancellable)
+                                          vector<Segment> & /* trafficSegs */)
 {
   times.clear();
   turns.clear();

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -11,15 +11,13 @@ public:
   PedestrianDirectionsEngine();
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, vector<Junction> const & path, Route::TTimes & times,
-                Route::TTurns & turns, vector<Junction> & routeGeometry,
-                vector<traffic::TrafficInfo::RoadSegmentId> & /* trafficSegs */,
-                my::Cancellable const & cancellable) override;
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+                my::Cancellable const & cancellable, Route::TTimes & times, Route::TTurns & turns,
+                vector<Junction> & routeGeometry, vector<Segment> & /* trafficSegs */) override;
 
 private:
   void CalculateTurns(RoadGraphBase const & graph, vector<Edge> const & routeEdges,
-                      Route::TTurns & turnsDir,
-                      my::Cancellable const & cancellable) const;
+                      Route::TTurns & turnsDir, my::Cancellable const & cancellable) const;
 
   uint32_t const m_typeSteps;
   uint32_t const m_typeLiftGate;

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -277,7 +277,7 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountr
 {
   unique_ptr<VehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
-  unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index));
+  unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index, nullptr));
   unique_ptr<IRouter> router(new RoadGraphRouter(
       "astar-bidirectional-bicycle", index, countryFileFn, IRoadGraph::Mode::ObeyOnewayTag,
       move(vehicleModelFactory), move(algorithm), move(directionsEngine)));

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -28,6 +28,7 @@ SOURCES += \
     features_road_graph.cpp \
     geometry.cpp \
     index_graph.cpp \
+    index_graph_loader.cpp \
     index_graph_serialization.cpp \
     index_graph_starter.cpp \
     index_road_graph.cpp \
@@ -62,6 +63,7 @@ SOURCES += \
     turns_sound_settings.cpp \
     turns_tts_text.cpp \
     vehicle_model.cpp \
+    world_graph.cpp \
 
 
 HEADERS += \
@@ -81,6 +83,7 @@ HEADERS += \
     features_road_graph.hpp \
     geometry.hpp \
     index_graph.hpp \
+    index_graph_loader.hpp \
     index_graph_serialization.hpp \
     index_graph_starter.hpp \
     index_road_graph.hpp \
@@ -118,6 +121,7 @@ HEADERS += \
     segment.hpp \
     single_mwm_router.hpp \
     speed_camera.hpp \
+    traffic_stash.hpp \
     turn_candidate.hpp \
     turns.hpp \
     turns_generator.hpp \
@@ -126,3 +130,4 @@ HEADERS += \
     turns_tts_text.hpp \
     vehicle_mask.hpp \
     vehicle_model.hpp \
+    world_graph.hpp \

--- a/routing/routing_benchmarks/bicycle_routing_tests.cpp
+++ b/routing/routing_benchmarks/bicycle_routing_tests.cpp
@@ -26,7 +26,8 @@ protected:
   // RoutingTest overrides:
   unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine() override
   {
-    unique_ptr<routing::IDirectionsEngine> engine(new routing::BicycleDirectionsEngine(m_index));
+    unique_ptr<routing::IDirectionsEngine> engine(
+        new routing::BicycleDirectionsEngine(m_index, nullptr /* numMwmIds */));
     return engine;
   }
 

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -6,6 +6,7 @@
 #include "routing/pedestrian_model.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route.hpp"
+#include "routing/traffic_stash.hpp"
 
 #include "traffic/traffic_info.hpp"
 
@@ -26,6 +27,6 @@ bool IsRoad(TTypes const & types)
 }
 
 void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
-                      shared_ptr<traffic::TrafficInfo::Coloring> const & trafficColoring,
+                      shared_ptr<TrafficStash> const & trafficStash,
                       my::Cancellable const & cancellable, vector<Junction> & path, Route & route);
 }  // namespace rouing

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -86,7 +86,7 @@ namespace integration
     };
 
     auto carRouter = make_unique<CarRouter>(index, countryFileGetter,
-                                            SingleMwmRouter::CreateCarRouter(index, trafficCache));
+                                            SingleMwmRouter::CreateCarRouter(countryFileGetter, nullptr, trafficCache, index));
     return carRouter;
   }
 

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -2,7 +2,9 @@
 
 #include "routing/edge_estimator.hpp"
 #include "routing/index_graph.hpp"
+#include "routing/index_graph_loader.hpp"
 #include "routing/index_graph_starter.hpp"
+#include "routing/num_mwm_id.hpp"
 #include "routing/restrictions_serialization.hpp"
 #include "routing/road_point.hpp"
 #include "routing/segment.hpp"
@@ -25,22 +27,26 @@ namespace routing_test
 {
 using namespace routing;
 
+// The value doesn't matter, it doesn't associated with any real mwm id.
+// It just a noticeable value to detect the source of such id while debuggging unit tests.
+NumMwmId constexpr kTestNumMwmId = 777;
+
 struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }
-  void Init(unique_ptr<IndexGraph> graph) { m_graph = move(graph); }
+  void Init(unique_ptr<WorldGraph> graph) { m_graph = move(graph); }
   void SetStarter(IndexGraphStarter::FakeVertex const & start,
                   IndexGraphStarter::FakeVertex const & finish)
   {
-    m_starter = make_unique<IndexGraphStarter>(*m_graph, start, finish);
+    m_starter = make_unique<IndexGraphStarter>(start, finish, *m_graph);
   }
 
   void SetRestrictions(RestrictionVec && restrictions)
   {
-    m_graph->SetRestrictions(move(restrictions));
+    m_graph->GetIndexGraph(kTestNumMwmId).SetRestrictions(move(restrictions));
   }
 
-  unique_ptr<IndexGraph> m_graph;
+  unique_ptr<WorldGraph> m_graph;
   unique_ptr<IndexGraphStarter> m_starter;
 };
 
@@ -57,9 +63,25 @@ private:
   unordered_map<uint32_t, routing::RoadGeometry> m_roads;
 };
 
+class TestIndexGraphLoader final : public IndexGraphLoader
+{
+public:
+  // IndexGraphLoader overrides:
+  IndexGraph & GetIndexGraph(NumMwmId mwmId) override;
+
+  void AddGraph(NumMwmId mwmId, unique_ptr<IndexGraph> graph);
+
+private:
+  unordered_map<NumMwmId, unique_ptr<IndexGraph>> m_graphs;
+};
+
+unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> loader,
+                                       shared_ptr<EdgeEstimator> estimator,
+                                       vector<Joint> const & joints);
+
 routing::Joint MakeJoint(vector<routing::RoadPoint> const & points);
 
-shared_ptr<routing::EdgeEstimator> CreateEstimator(traffic::TrafficCache const & trafficCache);
+shared_ptr<routing::EdgeEstimator> CreateEstimator(shared_ptr<TrafficStash> trafficStash);
 
 routing::AStarAlgorithm<routing::IndexGraphStarter>::Result CalculateRoute(
     routing::IndexGraphStarter & starter, vector<routing::Segment> & roadPoints, double & timeSec);

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -22,11 +22,6 @@ class Segment final
 public:
   Segment() = default;
 
-  constexpr Segment(uint32_t featureId, uint32_t segmentIdx, bool forward)
-    : m_featureId(featureId), m_segmentIdx(segmentIdx), m_forward(forward)
-  {
-  }
-
   constexpr Segment(NumMwmId mwmId, uint32_t featureId, uint32_t segmentIdx, bool forward)
     : m_featureId(featureId), m_segmentIdx(segmentIdx), m_mwmId(mwmId), m_forward(forward)
   {

--- a/routing/traffic_stash.hpp
+++ b/routing/traffic_stash.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "routing/num_mwm_id.hpp"
+
+#include "traffic/traffic_cache.hpp"
+#include "traffic/traffic_info.hpp"
+
+#include "indexer/mwm_set.hpp"
+
+#include <unordered_map>
+
+namespace routing
+{
+class TrafficStash final
+{
+public:
+  class Guard final
+  {
+  public:
+    Guard(TrafficStash & stash) : m_stash(stash) {}
+
+    ~Guard() { m_stash.Clear(); }
+
+  private:
+    TrafficStash & m_stash;
+  };
+
+  TrafficStash(traffic::TrafficCache const & source) : m_source(source) {}
+
+  traffic::TrafficInfo::Coloring const * Get(NumMwmId numMwmId) const
+  {
+    auto it = m_mwmToTraffic.find(numMwmId);
+    if (it == m_mwmToTraffic.cend())
+      return nullptr;
+
+    return it->second.get();
+  }
+
+  void Load(MwmSet::MwmId const & mwmId, NumMwmId numMwmId)
+  {
+    auto traffic = m_source.GetTrafficInfo(mwmId);
+    if (traffic)
+      m_mwmToTraffic[numMwmId] = traffic;
+  }
+
+private:
+  void Clear() { m_mwmToTraffic.clear(); }
+
+  traffic::TrafficCache const & m_source;
+  std::unordered_map<NumMwmId, shared_ptr<traffic::TrafficInfo::Coloring>> m_mwmToTraffic;
+};
+}  // namespace routing

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -258,7 +258,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        vector<Junction> & junctions,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets,
-                                       vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs)
+                                       vector<Segment> & trafficSegs)
 {
   double estimatedTime = 0;
 

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -8,6 +8,7 @@
 #include "routing/router.hpp"
 #include "routing/turns.hpp"
 #include "routing/turn_candidate.hpp"
+#include "routing/segment.hpp"
 
 #include "traffic/traffic_info.hpp"
 
@@ -50,7 +51,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        vector<Junction> & points,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets,
-                                       vector<traffic::TrafficInfo::RoadSegmentId> & trafficSegs);
+                                       vector<Segment> & trafficSegs);
 
 /*!
  * \brief The TurnInfo struct is a representation of a junction.

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -1,0 +1,36 @@
+#include "routing/world_graph.hpp"
+
+namespace routing
+{
+using namespace std;
+
+WorldGraph::WorldGraph(unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
+                       unique_ptr<IndexGraphLoader> loader, shared_ptr<EdgeEstimator> estimator)
+  : m_crossMwmGraph(move(crossMwmGraph)), m_loader(move(loader)), m_estimator(estimator)
+{
+  CHECK(m_loader, ());
+  CHECK(m_estimator, ());
+}
+
+void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
+{
+  IndexGraph & indexGraph = GetIndexGraph(segment.GetMwmId());
+  indexGraph.GetEdgeList(segment, isOutgoing, edges);
+
+  // TODO remove this return to activate m_crossMwmGraph.
+  return;
+
+  if (!m_crossMwmGraph || !m_crossMwmGraph->IsTransition(segment, isOutgoing))
+    return;
+
+  m_twins.clear();
+  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
+  for (Segment const & twin : m_twins)
+    edges.emplace_back(twin, 0.0 /* weight */);
+}
+
+RoadGeometry const & WorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
+{
+  return GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+}
+}  // namespace routing

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "routing/cross_mwm_index_graph.hpp"
+#include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/index_graph_loader.hpp"
+#include "routing/segment.hpp"
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace routing
+{
+class WorldGraph final
+{
+public:
+  WorldGraph(std::unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
+             std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
+
+  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
+
+  IndexGraph & GetIndexGraph(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
+  EdgeEstimator const & GetEstimator() const { return *m_estimator; }
+
+  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
+
+private:
+  std::unique_ptr<CrossMwmIndexGraph> m_crossMwmGraph;
+  std::unique_ptr<IndexGraphLoader> m_loader;
+  std::shared_ptr<EdgeEstimator> m_estimator;
+  std::vector<Segment> m_twins;
+};
+}  // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C08AA331DF83223004195DD /* index_graph_serialization.hpp */; };
 		0C08AA371DF8324D004195DD /* vehicle_mask.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C08AA361DF8324D004195DD /* vehicle_mask.hpp */; };
 		0C08AA391DF8329B004195DD /* routing_exceptions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C08AA381DF8329B004195DD /* routing_exceptions.hpp */; };
+		0C090C811E4E274000D52AFD /* index_graph_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C090C7F1E4E274000D52AFD /* index_graph_loader.cpp */; };
+		0C090C821E4E274000D52AFD /* index_graph_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C090C801E4E274000D52AFD /* index_graph_loader.hpp */; };
+		0C090C841E4E275E00D52AFD /* traffic_stash.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C090C831E4E275E00D52AFD /* traffic_stash.hpp */; };
+		0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C090C851E4E276700D52AFD /* world_graph.cpp */; };
+		0C090C881E4E276700D52AFD /* world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C090C861E4E276700D52AFD /* world_graph.hpp */; };
 		0C0DF9211DE898B70055A22F /* index_graph_starter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF91F1DE898B70055A22F /* index_graph_starter.cpp */; };
 		0C0DF9221DE898B70055A22F /* index_graph_starter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C0DF9201DE898B70055A22F /* index_graph_starter.hpp */; };
 		0C0DF9251DE898CF0055A22F /* single_mwm_router.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF9231DE898CF0055A22F /* single_mwm_router.cpp */; };
@@ -262,6 +267,11 @@
 		0C08AA331DF83223004195DD /* index_graph_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_serialization.hpp; sourceTree = "<group>"; };
 		0C08AA361DF8324D004195DD /* vehicle_mask.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vehicle_mask.hpp; sourceTree = "<group>"; };
 		0C08AA381DF8329B004195DD /* routing_exceptions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_exceptions.hpp; sourceTree = "<group>"; };
+		0C090C7F1E4E274000D52AFD /* index_graph_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_loader.cpp; sourceTree = "<group>"; };
+		0C090C801E4E274000D52AFD /* index_graph_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_loader.hpp; sourceTree = "<group>"; };
+		0C090C831E4E275E00D52AFD /* traffic_stash.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = traffic_stash.hpp; sourceTree = "<group>"; };
+		0C090C851E4E276700D52AFD /* world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = world_graph.cpp; sourceTree = "<group>"; };
+		0C090C861E4E276700D52AFD /* world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = world_graph.hpp; sourceTree = "<group>"; };
 		0C0DF91F1DE898B70055A22F /* index_graph_starter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_starter.cpp; sourceTree = "<group>"; };
 		0C0DF9201DE898B70055A22F /* index_graph_starter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_starter.hpp; sourceTree = "<group>"; };
 		0C0DF9231DE898CF0055A22F /* single_mwm_router.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = single_mwm_router.cpp; sourceTree = "<group>"; };
@@ -736,6 +746,8 @@
 				674F9BBD1B0A580E00704FFA /* features_road_graph.hpp */,
 				0C5FEC561DDE192A0017688C /* geometry.cpp */,
 				0C5FEC571DDE192A0017688C /* geometry.hpp */,
+				0C090C7F1E4E274000D52AFD /* index_graph_loader.cpp */,
+				0C090C801E4E274000D52AFD /* index_graph_loader.hpp */,
 				0C08AA321DF83223004195DD /* index_graph_serialization.cpp */,
 				0C08AA331DF83223004195DD /* index_graph_serialization.hpp */,
 				0C0DF91F1DE898B70055A22F /* index_graph_starter.cpp */,
@@ -803,6 +815,7 @@
 				0C0DF9241DE898CF0055A22F /* single_mwm_router.hpp */,
 				A1876BC41BB19C4300C9C743 /* speed_camera.cpp */,
 				A1876BC51BB19C4300C9C743 /* speed_camera.hpp */,
+				0C090C831E4E275E00D52AFD /* traffic_stash.hpp */,
 				56099E271CC7C97D00A7772A /* turn_candidate.hpp */,
 				674F9BC61B0A580E00704FFA /* turns_generator.cpp */,
 				674F9BC71B0A580E00704FFA /* turns_generator.hpp */,
@@ -817,6 +830,8 @@
 				0C08AA361DF8324D004195DD /* vehicle_mask.hpp */,
 				675344121A3F644F00A0A8C3 /* vehicle_model.cpp */,
 				675344131A3F644F00A0A8C3 /* vehicle_model.hpp */,
+				0C090C851E4E276700D52AFD /* world_graph.cpp */,
+				0C090C861E4E276700D52AFD /* world_graph.hpp */,
 			);
 			name = routing;
 			path = ../../routing;
@@ -852,6 +867,7 @@
 				0C5BC9D21E28FD4E0071BFDD /* index_road_graph.hpp in Headers */,
 				674F9BD11B0A580E00704FFA /* online_cross_fetcher.hpp in Headers */,
 				0C470E701E0D4EB1005B824D /* segment.hpp in Headers */,
+				0C090C841E4E275E00D52AFD /* traffic_stash.hpp in Headers */,
 				A120B3531B4A7C1C002F3808 /* astar_algorithm.hpp in Headers */,
 				0C5FEC5F1DDE192A0017688C /* geometry.hpp in Headers */,
 				674A28B21B1605D2001A525C /* osrm_engine.hpp in Headers */,
@@ -887,11 +903,13 @@
 				0C08AA371DF8324D004195DD /* vehicle_mask.hpp in Headers */,
 				6753441D1A3F644F00A0A8C3 /* router.hpp in Headers */,
 				A1616E2E1B6B60B3003F078E /* astar_progress.hpp in Headers */,
+				0C090C821E4E274000D52AFD /* index_graph_loader.hpp in Headers */,
 				670EE5721B664796001E8064 /* directions_engine.hpp in Headers */,
 				0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */,
 				A1876BC71BB19C4300C9C743 /* speed_camera.hpp in Headers */,
 				56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */,
 				0C0DF9221DE898B70055A22F /* index_graph_starter.hpp in Headers */,
+				0C090C881E4E276700D52AFD /* world_graph.hpp in Headers */,
 				56099E2F1CC8FBDA00A7772A /* osrm_path_segment_factory.hpp in Headers */,
 				67C7D42A1B4EB48F00FE41AA /* car_model.hpp in Headers */,
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
@@ -1123,9 +1141,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
+				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
 				0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */,
 				56826BD01DB51C4E00807C62 /* car_router.cpp in Sources */,
+				0C090C811E4E274000D52AFD /* index_graph_loader.cpp in Sources */,
 				56099E2E1CC8FBDA00A7772A /* osrm_path_segment_factory.cpp in Sources */,
 				349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */,
 				675344201A3F644F00A0A8C3 /* vehicle_model.cpp in Sources */,


### PR DESCRIPTION
Подготовка к меж mwm-ному роутингу на базе новой секции.

Этот pull request не влияет на внешнее поведение приложения: меж mwm-ный роутиг как и прежде базируется на OSRM. Основной смысл изменений: введение общемирового графа WorldGraph и переход на использование Segment.GetMwmId().

Будут сделаны позже:
1. Поддержка старых карт, в которых отсутствует секция index graph.
2. Переключение меж-mwm-ного OSRM роутинга на новый функционал.