### PR TITLE
CrossMwmIndexGraph::GetTwins() osrm implementation.

### DIFF
--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -6,15 +6,18 @@
 
 #include <utility>
 
+using namespace platform;
+using namespace routing;
+
 namespace
 {
-void FillTransitionSegments(routing::OsrmFtSegMapping const & segMapping, routing::TWrittenNodeId nodeId,
-                            routing::NumMwmId mwmId, std::set<routing::Segment> & transitionSegments)
+bool GetTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
+                          NumMwmId numMwmId, Segment & segment)
 {
   auto const range = segMapping.GetSegmentsRange(nodeId);
   for (size_t segmentIndex = range.first; segmentIndex != range.second; ++segmentIndex)
   {
-    routing::OsrmMappingTypes::FtSeg seg;
+    OsrmMappingTypes::FtSeg seg;
     // The meaning of node id in osrm is an edge between two joints.
     // So, it's possible to consider the first valid segment from the range which returns by GetSegmentsRange().
     segMapping.GetSegmentByIndex(segmentIndex, seg);
@@ -22,11 +25,45 @@ void FillTransitionSegments(routing::OsrmFtSegMapping const & segMapping, routin
       continue;
 
     CHECK_NOT_EQUAL(seg.m_pointStart, seg.m_pointEnd, ());
-    transitionSegments.emplace(seg.m_fid, min(seg.m_pointStart, seg.m_pointEnd), mwmId, seg.IsForward());
-    return;
+    segment = Segment(seg.m_fid, min(seg.m_pointStart, seg.m_pointEnd), numMwmId, seg.IsForward());
+    return true;
   }
   LOG(LERROR, ("No valid segments in the range returned by OsrmFtSegMapping::GetSegmentsRange(", nodeId,
-               "). Num mwm id:", mwmId));
+               "). Num mwm id:", numMwmId));
+  return false;
+}
+
+void AddTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
+                          NumMwmId numMwmId, std::vector<Segment> & segments)
+{
+  Segment key;
+  if (!GetTransitionSegment(segMapping, nodeId, numMwmId, key))
+    return;
+  segments.push_back(move(key));
+}
+
+void FillTransitionSegments(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
+                            NumMwmId numMwmId, ms::LatLon const & latLon,
+                            std::map<Segment, ms::LatLon> & transitionSegments)
+{
+  Segment key;
+  if (!GetTransitionSegment(segMapping, nodeId, numMwmId, key))
+    return;
+
+  auto const p = transitionSegments.emplace(move(key), latLon);
+  if (p.second)
+    return;
+
+  // @TODO(bykoianko) It's necessary to investigate this case.
+  LOG(LWARNING, ("Trying to insert an inserted transition segment. The key:",
+                 *p.first, ". Inserted value", p.second, "Trying to insert value:", latLon));
+}
+
+std::map<Segment, ms::LatLon>::const_iterator FindSegment(std::map<Segment, ms::LatLon> const & segMap, Segment const & s)
+{
+  auto it = segMap.find(s);
+  CHECK(it != segMap.cend(), ());
+  return it;
 }
 }  // namespace
 
@@ -41,47 +78,109 @@ bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
   auto it = m_transitionCache.find(s.GetMwmId());
   if (it == m_transitionCache.cend())
   {
-    platform::CountryFile const & countryFile = m_numMwmIds->GetFile(s.GetMwmId());
-    TRoutingMappingPtr mappingPtr = m_indexManager.GetMappingByName(countryFile.GetName());
-    MappingGuard mappingPtrGuard(mappingPtr);
-
-    CHECK(mappingPtr, ("countryFile:", countryFile));
-    mappingPtr->LoadCrossContext();
-
-    TransitionSegments transitionSegments;
-    mappingPtr->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node)
-    {
-      FillTransitionSegments(mappingPtr->m_segMapping, node.m_nodeId, s.GetMwmId(),
-                             transitionSegments.m_outgoing);
-    });
-    mappingPtr->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node)
-    {
-      FillTransitionSegments(mappingPtr->m_segMapping, node.m_nodeId, s.GetMwmId(),
-                             transitionSegments.m_ingoing);
-    });
-    auto const p = m_transitionCache.emplace(s.GetMwmId(), transitionSegments);
-    it = p.first;
-    CHECK(p.second, ("Mwm num id:", s.GetMwmId(), "has been inserted before. countryFile:",
-                     countryFile));
+    FillWholeMwmTransitionSegments(s.GetMwmId());
+    it = m_transitionCache.find(s.GetMwmId());
   }
+  CHECK(it != m_transitionCache.cend(),
+        ("Mwm ", s.GetMwmId(), "has not been downloaded. s:", s, ". isOutgoing", isOutgoing));
 
   if (isOutgoing)
     return it->second.m_outgoing.count(s) != 0;
   return it->second.m_ingoing.count(s) != 0;
 }
 
-void CrossMwmIndexGraph::GetTwins(Segment const & /* s */, std::vector<Segment> & /* twins */) const
+void CrossMwmIndexGraph::GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins)
+{
+  CHECK(IsTransition(s, isOutgoing), ("IsTransition(", s, ",", isOutgoing, ") returns false."));
+  // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
+  // and if so to use it. If not, osrm cross mwm sections should be used.
+  auto const segMwmMapping = GetRoutingMapping(s.GetMwmId());
+  CHECK(segMwmMapping, ("Mwm ", s.GetMwmId(), "has not been downloaded. s:", s, ". isOutgoing", isOutgoing));
+
+  twins.clear();
+  vector<string> const & neighboringMwm = segMwmMapping->m_crossContext.GetNeighboringMwmList();
+
+  for (string const & name : neighboringMwm)
+    FillWholeMwmTransitionSegments(m_numMwmIds->GetId(CountryFile(name)));
+
+  auto it = m_transitionCache.find(s.GetMwmId());
+  CHECK(it != m_transitionCache.cend(), ());
+
+  std::map<Segment, ms::LatLon>::const_iterator segIt = isOutgoing ? FindSegment(it->second.m_outgoing, s)
+                                                                   : FindSegment(it->second.m_ingoing, s);
+  ms::LatLon const & latLog = segIt->second;
+  for (string const & name : neighboringMwm)
+  {
+    NumMwmId const numMwmId = m_numMwmIds->GetId(CountryFile(name));
+    TRoutingMappingPtr mappingPtr = GetRoutingMapping(numMwmId);
+    if (mappingPtr == nullptr)
+      continue; // mwm was not loaded.
+
+    if (isOutgoing)
+    {
+      mappingPtr->m_crossContext.ForEachIngoingNodeNearPoint(latLog, [&](IngoingCrossNode const & node){
+        AddTransitionSegment(mappingPtr->m_segMapping, node.m_nodeId, numMwmId, twins);
+      });
+    }
+    else
+    {
+      mappingPtr->m_crossContext.ForEachOutgoingNodeNearPoint(latLog, [&](OutgoingCrossNode const & node){
+        AddTransitionSegment(mappingPtr->m_segMapping, node.m_nodeId, numMwmId, twins);
+      });
+    }
+  }
+
+  my::SortUnique(twins);
+}
+
+void CrossMwmIndexGraph::GetEdgeList(Segment const & /* s */,
+                                     bool /* isOutgoing */, std::vector<SegmentEdge> & /* edges */) const
 {
   // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
   // and if so to use it. If not, osrm cross mwm sections should be used.
   NOTIMPLEMENTED();
 }
 
-void CrossMwmIndexGraph::GetEdgeList(Segment const & /* s */,
-                                         bool /* isOutgoing */, std::vector<SegmentEdge> & /* edges */) const
+TRoutingMappingPtr CrossMwmIndexGraph::GetRoutingMapping(NumMwmId numMwmId)
 {
-  // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
-  // and if so to use it. If not, osrm cross mwm sections should be used.
-  NOTIMPLEMENTED();
+  CountryFile const & countryFile = m_numMwmIds->GetFile(numMwmId);
+  TRoutingMappingPtr mappingPtr = m_indexManager.GetMappingByName(countryFile.GetName());
+  CHECK(mappingPtr, ("countryFile:", countryFile));
+  MappingGuard mappingPtrGuard(mappingPtr);
+
+  if (!mappingPtr->IsValid())
+    return nullptr; // mwm was not loaded.
+  mappingPtr->LoadCrossContext();
+  return mappingPtr;
+}
+
+void CrossMwmIndexGraph::Clear()
+{
+  m_transitionCache.clear();
+}
+
+void CrossMwmIndexGraph::FillWholeMwmTransitionSegments(NumMwmId numMwmId)
+{
+  if (m_transitionCache.count(numMwmId) != 0)
+    return;
+
+  TRoutingMappingPtr mappingPtr = GetRoutingMapping(numMwmId);
+  if (mappingPtr == nullptr)
+    return;
+
+  TransitionSegments transitionSegments;
+  mappingPtr->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node)
+  {
+    FillTransitionSegments(mappingPtr->m_segMapping, node.m_nodeId, numMwmId,
+                           node.m_point, transitionSegments.m_outgoing);
+  });
+  mappingPtr->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node)
+  {
+    FillTransitionSegments(mappingPtr->m_segMapping, node.m_nodeId, numMwmId,
+                           node.m_point, transitionSegments.m_ingoing);
+  });
+  auto const p = m_transitionCache.emplace(numMwmId, move(transitionSegments));
+  CHECK(p.second, ("Mwm num id:", numMwmId, "has been inserted before. Country file name:",
+                   mappingPtr->GetCountryName()));
 }
 }  // namespace routing

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -93,13 +93,13 @@ private:
     platform::CountryFile const & countryFile = m_numMwmIds->GetFile(numMwmId);
     TRoutingMappingPtr mapping = m_indexManager.GetMappingByName(countryFile.GetName());
     CHECK(mapping, ("No routing mapping file for countryFile:", countryFile));
-    MappingGuard mappingGuard(mapping);
 
     if (!mapping->IsValid())
       return false; // mwm was not loaded.
 
+    MappingGuard mappingGuard(mapping);
     mapping->LoadCrossContext();
-    fn(mapping);
+    fn(numMwmId, mapping);
     return true;
   }
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -81,8 +81,14 @@ private:
     std::map<Segment, ms::LatLon> m_outgoing;
   };
 
-  void FillWholeMwmTransitionSegments(NumMwmId numMwmId);
-  TRoutingMappingPtr GetRoutingMapping(NumMwmId numMwmId);
+  /// \brief Inserts all ingoing and outgoing transition segments of mwm with |numMwmId|
+  /// to |m_transitionCache|.
+  void InsertWholeMwmTransitionSegments(NumMwmId numMwmId);
+
+  /// \returns routing mapping and guard for memory for succent stuctures in RoutingMapping::m_segMapping.
+  /// \note The result of GetRoutingMapping() call should be kept in a local value to prevent
+  /// an immediate unmaping some data after a GetRoutingMapping() call.
+  std::pair<TRoutingMappingPtr, std::unique_ptr<MappingGuard>> GetRoutingMapping(NumMwmId numMwmId);
 
   RoutingIndexManager & m_indexManager;
   std::shared_ptr<NumMwmIds> m_numMwmIds;

--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -6,7 +6,6 @@
 namespace
 {
 inline bool IsValidEdgeWeight(EdgeWeight const & w) { return w != INVALID_EDGE_WEIGHT; }
-double constexpr kMwmCrossingNodeEqualityRadiusDegrees = 0.001;
 }
 
 namespace routing
@@ -159,7 +158,7 @@ bool CrossMwmGraph::ConstructBorderCrossImpl(OutgoingCrossNode const & startNode
   nextMapping->LoadCrossContext();
   nextMapping->m_crossContext.ForEachIngoingNodeNearPoint(startNode.m_point, [&](IngoingCrossNode const & node)
     {
-    if (node.m_point.EqualDxDy(startNode.m_point, kMwmCrossingNodeEqualityRadiusDegrees))
+    if (node.m_point.EqualDxDy(startNode.m_point, kMwmCrossingNodeEqualityMeters * MercatorBounds::degreeInMetres))
     {
       auto const toCross = CrossNode(node.m_nodeId, nextMapping->GetMwmId(), node.m_point);
       if (toCross.IsValid())

--- a/routing/cross_routing_context.cpp
+++ b/routing/cross_routing_context.cpp
@@ -116,6 +116,15 @@ TWrittenEdgeWeight CrossRoutingContextReader::GetAdjacencyCost(IngoingCrossNode 
   return cost_index < m_adjacencyMatrix.size() ? m_adjacencyMatrix[cost_index] : kInvalidContextEdgeWeight;
 }
 
+m2::RectD CrossRoutingContextReader::GetMwmCrossingNodeEqualityRect(ms::LatLon const & point) const
+{
+  double constexpr kMwmCrossingNodeEqualityDegrees = kMwmCrossingNodeEqualityMeters * MercatorBounds::degreeInMetres;
+  return m2::RectD(point.lat - kMwmCrossingNodeEqualityDegrees,
+                   point.lon - kMwmCrossingNodeEqualityDegrees,
+                   point.lat + kMwmCrossingNodeEqualityDegrees,
+                   point.lon + kMwmCrossingNodeEqualityDegrees);
+}
+
 void CrossRoutingContextWriter::Save(Writer & w) const
 {
   uint32_t size = static_cast<uint32_t>(m_ingoingNodes.size());

--- a/routing/cross_routing_context.cpp
+++ b/routing/cross_routing_context.cpp
@@ -1,21 +1,10 @@
 #include "routing/cross_routing_context.hpp"
 
-#include "geometry/mercator.hpp"
 #include "indexer/point_to_int64.hpp"
 
 namespace
 {
 uint32_t constexpr kCoordBits = POINT_COORD_BITS;
-
-double constexpr kMwmCrossingNodeEqualityRadiusDegrees = 0.001;
-
-m2::RectD GetMwmCrossingNodeEqualityRect(ms::LatLon const & point)
-{
-  return m2::RectD(point.lat - kMwmCrossingNodeEqualityRadiusDegrees,
-                   point.lon - kMwmCrossingNodeEqualityRadiusDegrees,
-                   point.lat + kMwmCrossingNodeEqualityRadiusDegrees,
-                   point.lon + kMwmCrossingNodeEqualityRadiusDegrees);
-}
 }  // namespace
 
 namespace routing
@@ -105,27 +94,6 @@ void CrossRoutingContextReader::Load(Reader const & r)
     m_neighborMwmList.push_back(string(&buffer[0], size));
     pos += size;
   }
-}
-
-bool CrossRoutingContextReader::ForEachIngoingNodeNearPoint(ms::LatLon const & point, function<void(IngoingCrossNode const & node)> && fn) const
-{
-  bool found = false;
-  m_ingoingIndex.ForEachInRect(GetMwmCrossingNodeEqualityRect(point), [&found, &fn](IngoingCrossNode const & node) {
-                                 fn(node);
-                                 found = true;
-                               });
-  return found;
-}
-
-bool CrossRoutingContextReader::ForEachOutgoingNodeNearPoint(ms::LatLon const & point,
-                                                             function<void(OutgoingCrossNode const & node)> && fn) const
-{
-  bool found = false;
-  m_outgoingIndex.ForEachInRect(GetMwmCrossingNodeEqualityRect(point), [&found, &fn](OutgoingCrossNode const & node) {
-                                  fn(node);
-                                  found = true;
-                                });
-  return found;
 }
 
 const string & CrossRoutingContextReader::GetOutgoingMwmName(

--- a/routing/cross_routing_context.hpp
+++ b/routing/cross_routing_context.hpp
@@ -98,12 +98,13 @@ public:
 
   vector<string> const & GetNeighboringMwmList() const { return m_neighborMwmList; }
 
+  m2::RectD GetMwmCrossingNodeEqualityRect(ms::LatLon const & point) const;
+
   template <class Fn>
   bool ForEachIngoingNodeNearPoint(ms::LatLon const & point, Fn && fn) const
   {
     bool found = false;
-    m_ingoingIndex.ForEachInRect(MercatorBounds::RectByCenterLatLonAndSizeInMeters(
-                                   point.lat, point.lon, kMwmCrossingNodeEqualityMeters),
+    m_ingoingIndex.ForEachInRect(GetMwmCrossingNodeEqualityRect(point),
                                  [&found, &fn](IngoingCrossNode const & node) {
                                    fn(node);
                                    found = true;
@@ -115,8 +116,7 @@ public:
   bool ForEachOutgoingNodeNearPoint(ms::LatLon const & point, Fn && fn) const
   {
     bool found = false;
-    m_outgoingIndex.ForEachInRect(MercatorBounds::RectByCenterLatLonAndSizeInMeters(
-                                    point.lat, point.lon, kMwmCrossingNodeEqualityMeters),
+    m_outgoingIndex.ForEachInRect(GetMwmCrossingNodeEqualityRect(point),
                                   [&found, &fn](OutgoingCrossNode const & node) {
                                     fn(node);
                                     found = true;

--- a/routing/cross_routing_context.hpp
+++ b/routing/cross_routing_context.hpp
@@ -70,6 +70,8 @@ struct OutgoingCrossNode
   void Save(Writer & w) const;
 
   size_t Load(Reader const & r, size_t pos, size_t adjacencyIndex);
+
+  m2::RectD const GetLimitRect() const { return m2::RectD(m_point.lat, m_point.lon, m_point.lat, m_point.lon); }
 };
 
 using IngoingEdgeIteratorT = vector<IngoingCrossNode>::const_iterator;
@@ -82,6 +84,7 @@ class CrossRoutingContextReader
   vector<string> m_neighborMwmList;
   vector<TWrittenEdgeWeight> m_adjacencyMatrix;
   m4::Tree<IngoingCrossNode> m_ingoingIndex;
+  m4::Tree<OutgoingCrossNode> m_outgoingIndex;
 
 public:
   void Load(Reader const & r);
@@ -89,9 +92,12 @@ public:
   const string & GetOutgoingMwmName(OutgoingCrossNode const & mwmIndex) const;
 
   bool ForEachIngoingNodeNearPoint(ms::LatLon const & point, function<void(IngoingCrossNode const & node)> && fn) const;
+  bool ForEachOutgoingNodeNearPoint(ms::LatLon const & point, function<void(OutgoingCrossNode const & node)> && fn) const;
 
   TWrittenEdgeWeight GetAdjacencyCost(IngoingCrossNode const & ingoing,
                                      OutgoingCrossNode const & outgoing) const;
+
+  vector<string> const & GetNeighboringMwmList() const { return m_neighborMwmList; }
 
   template <class TFunctor>
   void ForEachIngoingNode(TFunctor f) const

--- a/routing/routing_tests/cross_routing_tests.cpp
+++ b/routing/routing_tests/cross_routing_tests.cpp
@@ -154,5 +154,15 @@ UNIT_TEST(TestFindingByPoint)
   TEST_EQUAL(node.size(), 2, ());
   TEST_EQUAL(node[0].m_nodeId, 5, ());
   TEST_EQUAL(node[1].m_nodeId, 6, ());
+
+  vector<OutgoingCrossNode> outgoingNode;
+  auto fnOutgoing = [&outgoingNode](OutgoingCrossNode const & nd) {outgoingNode.push_back(nd);};
+  TEST(newContext.ForEachOutgoingNodeNearPoint(ms::LatLon::Zero(), fnOutgoing), ());
+  TEST_EQUAL(outgoingNode.size(), 1, ());
+  TEST_EQUAL(outgoingNode[0].m_nodeId, 4, ());
+
+  outgoingNode.clear();
+  TEST(!newContext.ForEachOutgoingNodeNearPoint(p3, fnOutgoing), ());
+  TEST(outgoingNode.empty(), ());
 }
 }  // namespace


### PR DESCRIPTION
OSRM вариант реализации метода по получению близницов. 

Идея  по получению близницов проста (CrossMwmIndexGraph::GetTwins()):
1. из CrossRoutingContextReader получаем список mwm соседий для данной mwm;
2. загружаем в кеш переходные сегменты для соседних mwm;
3. по координате (о очень большим прямоугольником со стороной в 2 * 0.001 градус, как в OSRM) ищем близнецов в соседних mwm. Зачем такой большой "квадрат" поиска пока не знаю, но такой был в OSRM, потому и оставил.

@dobriy-eeh @ygorshenin @mpimenov PTAL