### PR TITLE
Adding MappingGuard to CrossMwmIndexGraph::IsTransition().

### DIFF
--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -43,6 +43,8 @@ bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
   {
     platform::CountryFile const & countryFile = m_numMwmIds->GetFile(s.GetMwmId());
     TRoutingMappingPtr mappingPtr = m_indexManager.GetMappingByName(countryFile.GetName());
+    MappingGuard mappingPtrGuard(mappingPtr);
+
     CHECK(mappingPtr, ("countryFile:", countryFile));
     mappingPtr->LoadCrossContext();
 


### PR DESCRIPTION
Поправил баг с тем, что OsrmFtSegMapping::m_handle был пуст при вызове CrossMwmIndexGraph::IsTransition()

@dobriy-eeh @ygorshenin @mpimenov PTAL