### PR TITLE
[routing] Cross mwm leaps

### DIFF
--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -44,7 +44,7 @@ public:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const override;
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const override;
   double GetUTurnPenalty() const override;
-  bool AllowLeap(NumMwmId mwmId) const override;
+  bool LeapIsAllowed(NumMwmId mwmId) const override;
 
 private:
   shared_ptr<TrafficStash> m_trafficStash;
@@ -102,7 +102,7 @@ double CarEdgeEstimator::GetUTurnPenalty() const
   return 2 * 60;  // seconds
 }
 
-bool CarEdgeEstimator::AllowLeap(NumMwmId mwmId) const { return !m_trafficStash->Has(mwmId); }
+bool CarEdgeEstimator::LeapIsAllowed(NumMwmId mwmId) const { return !m_trafficStash->Has(mwmId); }
 }  // namespace
 
 namespace routing

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -44,6 +44,7 @@ public:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const override;
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const override;
   double GetUTurnPenalty() const override;
+  bool AllowLeap(NumMwmId mwmId) const override;
 
 private:
   shared_ptr<TrafficStash> m_trafficStash;
@@ -100,6 +101,8 @@ double CarEdgeEstimator::GetUTurnPenalty() const
   // experiments.
   return 2 * 60;  // seconds
 }
+
+bool CarEdgeEstimator::AllowLeap(NumMwmId mwmId) const { return !m_trafficStash->Has(mwmId); }
 }  // namespace
 
 namespace routing

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -25,6 +25,7 @@ public:
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
+  virtual bool AllowLeap(NumMwmId mwmId) const = 0;
 
   static shared_ptr<EdgeEstimator> CreateForCar(shared_ptr<TrafficStash> trafficStash,
                                                 double maxSpeedKMpH);

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -25,7 +25,10 @@ public:
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
-  virtual bool AllowLeap(NumMwmId mwmId) const = 0;
+  // The leap is the shortcut edge from mwm border enter to exit.
+  // Router can't use leaps on some mwms: e.g. mwm with loaded traffic data.
+  // Check wherether leap is allowed on specified mwm or not.
+  virtual bool LeapIsAllowed(NumMwmId mwmId) const = 0;
 
   static shared_ptr<EdgeEstimator> CreateForCar(shared_ptr<TrafficStash> trafficStash,
                                                 double maxSpeedKMpH);

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -3,7 +3,6 @@
 #include "routing/edge_estimator.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/num_mwm_id.hpp"
-#include "routing/traffic_stash.hpp"
 #include "routing/vehicle_model.hpp"
 
 #include "indexer/index.hpp"
@@ -18,11 +17,11 @@ public:
   virtual ~IndexGraphLoader() = default;
 
   virtual IndexGraph & GetIndexGraph(NumMwmId mwmId) = 0;
+  virtual void Clear() = 0;
 
   static std::unique_ptr<IndexGraphLoader> Create(
       std::shared_ptr<NumMwmIds> numMwmIds,
       std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
-      std::shared_ptr<EdgeEstimator> estimator, std::shared_ptr<TrafficStash> trafficStash,
-      Index & index);
+      std::shared_ptr<EdgeEstimator> estimator, Index & index);
 };
 }  // namespace routing

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -65,7 +65,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
     return;
   }
 
-  m_graph.GetEdgeList(segment, isOutgoing, edges);
+  m_graph.GetEdgeList(segment, isOutgoing, IsLeap(segment.GetMwmId()), edges);
   GetNormalToFakeEdge(segment, m_start, kStartFakeSegment, isOutgoing, edges);
   GetNormalToFakeEdge(segment, m_finish, kFinishFakeSegment, isOutgoing, edges);
 }

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -91,7 +91,7 @@ public:
   bool IsLeap(NumMwmId mwmId) const
   {
     return mwmId != kFakeNumMwmId && mwmId != m_start.GetMwmId() && mwmId != m_finish.GetMwmId() &&
-           m_graph.GetEstimator().AllowLeap(mwmId);
+           m_graph.GetEstimator().LeapIsAllowed(mwmId);
   }
 
   static bool IsFakeSegment(Segment const & segment)

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -28,6 +28,14 @@ public:
     {
     }
 
+    FakeVertex(Segment const & segment, m2::PointD const & point)
+      : m_featureId(segment.GetFeatureId())
+      , m_segmentIdx(segment.GetSegmentIdx())
+      , m_mwmId(segment.GetMwmId())
+      , m_point(point)
+    {
+    }
+
     NumMwmId GetMwmId() const { return m_mwmId; }
     uint32_t GetFeatureId() const { return m_featureId; }
     uint32_t GetSegmentIdx() const { return m_segmentIdx; }
@@ -48,6 +56,7 @@ public:
 
   IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish, WorldGraph & graph);
 
+  WorldGraph & GetGraph() { return m_graph; }
   Segment const & GetStart() const { return kStartFakeSegment; }
   Segment const & GetFinish() const { return kFinishFakeSegment; }
   m2::PointD const & GetPoint(Segment const & segment, bool front);
@@ -77,6 +86,12 @@ public:
   {
     return m_graph.GetEstimator().CalcSegmentWeight(
         segment, m_graph.GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()));
+  }
+
+  bool IsLeap(NumMwmId mwmId) const
+  {
+    return mwmId != kFakeNumMwmId && mwmId != m_start.GetMwmId() && mwmId != m_finish.GetMwmId() &&
+           m_graph.GetEstimator().AllowLeap(mwmId);
   }
 
   static bool IsFakeSegment(Segment const & segment)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -663,6 +663,12 @@ shared_ptr<TrafficInfo::Coloring> RoutingSession::GetTrafficInfo(MwmSet::MwmId c
   return TrafficCache::GetTrafficInfo(mwmId);
 }
 
+void RoutingSession::CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
+{
+  threads::MutexGuard guard(m_routingSessionMutex);
+  TrafficCache::CopyTraffic(trafficColoring);
+}
+
 string DebugPrint(RoutingSession::State state)
 {
   switch (state)

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -162,6 +162,7 @@ public:
 
   // TrafficCache overrides:
   shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(MwmSet::MwmId const & mwmId) const override;
+  void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const override;
 
 private:
   struct DoReadyCallback

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -61,7 +61,7 @@ unique_ptr<WorldGraph> BuildXYGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -216,7 +216,7 @@ unique_ptr<WorldGraph> BuildXXGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -116,7 +116,7 @@ UNIT_TEST(EdgesTest)
                   RoadGeometry::Points({{3.0, -1.0}, {3.0, 0.0}, {3.0, 1.0}}));
 
   traffic::TrafficCache const trafficCache;
-  IndexGraph graph(move(loader), CreateEstimator(make_shared<TrafficStash>(trafficCache)));
+  IndexGraph graph(move(loader), CreateEstimator(trafficCache));
 
   vector<Joint> joints;
   joints.emplace_back(MakeJoint({{0, 1}, {3, 1}}));  // J0
@@ -175,7 +175,7 @@ UNIT_TEST(FindPathCross)
       RoadGeometry::Points({{0.0, -2.0}, {0.0, -1.0}, {0.0, 0.0}, {0.0, 1.0}, {0.0, 2.0}}));
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   unique_ptr<WorldGraph> worldGraph =
       BuildWorldGraph(move(loader), estimator, {MakeJoint({{0, 2}, {1, 2}})});
 
@@ -240,7 +240,7 @@ UNIT_TEST(FindPathManhattan)
   }
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
 
   vector<Joint> joints;
   for (uint32_t i = 0; i < kCitySize; ++i)
@@ -324,7 +324,7 @@ UNIT_TEST(RoadSpeed)
       RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}, {6.0, 0.0}}));
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
 
   vector<Joint> joints;
   joints.emplace_back(MakeJoint({{0, 0}, {1, 1}}));  // J0
@@ -360,7 +360,7 @@ UNIT_TEST(OneSegmentWay)
                   RoadGeometry::Points({{0.0, 0.0}, {3.0, 0.0}}));
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(move(loader), estimator, vector<Joint>());
 
   IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 0, 0, m2::PointD(1, 0));
@@ -485,7 +485,7 @@ unique_ptr<WorldGraph> BuildLoopGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -32,6 +32,8 @@ IndexGraph & TestIndexGraphLoader::GetIndexGraph(NumMwmId mwmId)
   return *it->second;
 }
 
+void TestIndexGraphLoader::Clear() { m_graphs.clear(); }
+
 void TestIndexGraphLoader::AddGraph(NumMwmId mwmId, unique_ptr<IndexGraph> graph)
 {
   auto it = m_graphs.find(mwmId);
@@ -57,6 +59,13 @@ Joint MakeJoint(vector<RoadPoint> const & points)
     joint.AddPoint(point);
 
   return joint;
+}
+
+shared_ptr<EdgeEstimator> CreateEstimator(traffic::TrafficCache const & trafficCache)
+{
+  auto numMwmIds = make_shared<NumMwmIds>();
+  auto stash = make_shared<TrafficStash>(trafficCache, numMwmIds);
+  return CreateEstimator(stash);
 }
 
 shared_ptr<EdgeEstimator> CreateEstimator(shared_ptr<TrafficStash> trafficStash)

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -68,6 +68,7 @@ class TestIndexGraphLoader final : public IndexGraphLoader
 public:
   // IndexGraphLoader overrides:
   IndexGraph & GetIndexGraph(NumMwmId mwmId) override;
+  virtual void Clear() override;
 
   void AddGraph(NumMwmId mwmId, unique_ptr<IndexGraph> graph);
 
@@ -81,6 +82,7 @@ unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> loader,
 
 routing::Joint MakeJoint(vector<routing::RoadPoint> const & points);
 
+shared_ptr<routing::EdgeEstimator> CreateEstimator(traffic::TrafficCache const & trafficCache);
 shared_ptr<routing::EdgeEstimator> CreateEstimator(shared_ptr<TrafficStash> trafficStash);
 
 routing::AStarAlgorithm<routing::IndexGraphStarter>::Result CalculateRoute(

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -60,7 +60,7 @@ unique_ptr<WorldGraph> BuildCrossGraph()
       MakeJoint({{2, 1}, {3, 0}}), MakeJoint({{4, 1}, {5, 0}}), MakeJoint({{6, 1}, {7, 0}})};
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -138,7 +138,7 @@ unique_ptr<WorldGraph> BuildTriangularGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -260,7 +260,7 @@ unique_ptr<WorldGraph> BuildTwowayCornerGraph()
       MakeJoint({{3, 0}}),                 /* joint at point (3, 0) */
   };
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -369,7 +369,7 @@ unique_ptr<WorldGraph> BuildTwoSquaresGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -485,7 +485,7 @@ unique_ptr<WorldGraph> BuildFlagGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -586,7 +586,7 @@ unique_ptr<WorldGraph> BuildPosterGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -669,7 +669,7 @@ unique_ptr<WorldGraph> BuildTwoWayGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -720,7 +720,7 @@ unique_ptr<WorldGraph> BuildSquaresGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -774,7 +774,7 @@ unique_ptr<WorldGraph> BuildLineGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
@@ -827,7 +827,7 @@ unique_ptr<WorldGraph> BuildFGraph()
   };
 
   traffic::TrafficCache const trafficCache;
-  shared_ptr<EdgeEstimator> estimator = CreateEstimator(make_shared<TrafficStash>(trafficCache));
+  shared_ptr<EdgeEstimator> estimator = CreateEstimator(trafficCache);
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -64,7 +64,7 @@ public:
 private:
   uint32_t m_featureId = 0;
   uint32_t m_segmentIdx = 0;
-  NumMwmId m_mwmId = 0;
+  NumMwmId m_mwmId = kFakeNumMwmId;
   bool m_forward = false;
 };
 

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -64,9 +64,8 @@ public:
 private:
   uint32_t m_featureId = 0;
   uint32_t m_segmentIdx = 0;
-  // @TODO(bykoianko, dobriy-eeh). It's a placeholder. Init m_mwmId in a proper way.
   NumMwmId m_mwmId = 0;
-  bool m_forward = true;
+  bool m_forward = false;
 };
 
 class SegmentEdge final

--- a/routing/single_mwm_router.cpp
+++ b/routing/single_mwm_router.cpp
@@ -107,10 +107,10 @@ IRouter::ResultCode SingleMwmRouter::DoCalculateRoute(m2::PointD const & startPo
                                              finishEdge.GetSegId(), finalPoint);
 
   TrafficStash::Guard guard(*m_trafficStash);
-  WorldGraph graph(make_unique<CrossMwmIndexGraph>(m_numMwmIds, m_indexManager),
-                   IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator,
-                                            m_trafficStash, m_index),
-                   m_estimator);
+  WorldGraph graph(
+      make_unique<CrossMwmIndexGraph>(m_numMwmIds, m_indexManager),
+      IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
+      m_estimator);
 
   // TODO remove to activate CrossMwmGraph.
   graph.BlockMwmBorders();
@@ -203,40 +203,50 @@ IRouter::ResultCode SingleMwmRouter::ProcessLeaps(vector<Segment> const & input,
                                                   IndexGraphStarter & starter,
                                                   vector<Segment> & output)
 {
-  starter.GetGraph().BlockMwmBorders();
+  output.reserve(input.size());
+
+  WorldGraph & worldGraph = starter.GetGraph();
+  worldGraph.BlockMwmBorders();
 
   for (size_t i = 0; i < input.size(); ++i)
   {
     Segment const & current = input[i];
-    if (starter.IsLeap(current.GetMwmId()))
+    if (!starter.IsLeap(current.GetMwmId()))
     {
-      ++i;
-      CHECK_LESS(i, input.size(), ());
-      Segment const & next = input[i];
-      CHECK_EQUAL(current.GetMwmId(), next.GetMwmId(), ("i:", i));
+      output.push_back(current);
+      continue;
+    }
 
-      IndexGraphStarter::FakeVertex const start(current,
-                                                starter.GetPoint(current, true /* front */));
-      IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */));
+    ++i;
+    CHECK_LESS(i, input.size(), ());
+    Segment const & next = input[i];
+    CHECK_EQUAL(current.GetMwmId(), next.GetMwmId(),
+                ("Different mwm ids for leap enter and exit, i:", i));
 
-      IndexGraphStarter leapStarter(start, finish, starter.GetGraph());
+    IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */));
+    IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */));
+    IndexGraphStarter leapStarter(start, finish, starter.GetGraph());
 
-      AStarAlgorithm<IndexGraphStarter> algorithm;
-      RoutingResult<Segment> routingResult;
-      auto const resultCode =
-          algorithm.FindPathBidirectional(leapStarter, leapStarter.GetStart(),
-                                          leapStarter.GetFinish(), routingResult, delegate, {});
+    // Clear previous loaded graphs.
+    // Dont spend too much memory at one time.
+    worldGraph.ClearIndexGraphs();
 
-      switch (resultCode)
+    AStarAlgorithm<IndexGraphStarter> algorithm;
+    RoutingResult<Segment> routingResult;
+    auto const resultCode = algorithm.FindPathBidirectional(
+        leapStarter, leapStarter.GetStart(), leapStarter.GetFinish(), routingResult, delegate, {});
+
+    switch (resultCode)
+    {
+    case AStarAlgorithm<IndexGraphStarter>::Result::NoPath: return IRouter::RouteNotFound;
+    case AStarAlgorithm<IndexGraphStarter>::Result::Cancelled: return IRouter::Cancelled;
+    case AStarAlgorithm<IndexGraphStarter>::Result::OK:
+      for (Segment const & segment : routingResult.path)
       {
-      case AStarAlgorithm<IndexGraphStarter>::Result::NoPath: return IRouter::RouteNotFound;
-      case AStarAlgorithm<IndexGraphStarter>::Result::Cancelled: return IRouter::Cancelled;
-      case AStarAlgorithm<IndexGraphStarter>::Result::OK:
-        output.insert(output.end(), routingResult.path.begin(), routingResult.path.end());
+        if (!IndexGraphStarter::IsFakeSegment(segment))
+          output.push_back(segment);
       }
     }
-    else
-      output.push_back(current);
   }
 
   return IRouter::NoError;
@@ -300,7 +310,7 @@ unique_ptr<SingleMwmRouter> SingleMwmRouter::CreateCarRouter(
     maxSpeed = max(maxSpeed, mwmMaxSpeed);
   });
 
-  auto trafficStash = make_shared<TrafficStash>(trafficCache);
+  auto trafficStash = make_shared<TrafficStash>(trafficCache, numMwmIds);
 
   auto estimator = EdgeEstimator::CreateForCar(trafficStash, maxSpeed);
   auto router = make_unique<SingleMwmRouter>("astar-bidirectional-car", countryFileFn, numMwmIds,

--- a/routing/single_mwm_router.hpp
+++ b/routing/single_mwm_router.hpp
@@ -52,6 +52,8 @@ private:
                                        RouterDelegate const & delegate, Route & route);
   bool FindClosestEdge(platform::CountryFile const & file, m2::PointD const & point,
                        Edge & closestEdge) const;
+  IRouter::ResultCode ProcessLeaps(vector<Segment> const & input, RouterDelegate const & delegate,
+                                   IndexGraphStarter & starter, vector<Segment> & output);
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
                     IndexGraphStarter & starter, Route & route) const;
 

--- a/routing/single_mwm_router.hpp
+++ b/routing/single_mwm_router.hpp
@@ -52,6 +52,8 @@ private:
                                        RouterDelegate const & delegate, Route & route);
   bool FindClosestEdge(platform::CountryFile const & file, m2::PointD const & point,
                        Edge & closestEdge) const;
+  // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
+  // ProcessLeaps replaces each leap with calculated route through mwm.
   IRouter::ResultCode ProcessLeaps(vector<Segment> const & input, RouterDelegate const & delegate,
                                    IndexGraphStarter & starter, vector<Segment> & output);
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,

--- a/routing/traffic_stash.hpp
+++ b/routing/traffic_stash.hpp
@@ -36,6 +36,11 @@ public:
     return it->second.get();
   }
 
+  bool Has(NumMwmId numMwmId) const
+  {
+    return m_mwmToTraffic.find(numMwmId) != m_mwmToTraffic.cend();
+  }
+
   void Load(MwmSet::MwmId const & mwmId, NumMwmId numMwmId)
   {
     auto traffic = m_source.GetTrafficInfo(mwmId);

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -12,10 +12,10 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
   CHECK(m_estimator, ());
 }
 
-void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool leap,
+void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                              vector<SegmentEdge> & edges)
 {
-  if (m_crossMwmGraph && leap)
+  if (m_crossMwmGraph && isLeap)
   {
     if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
       GetTwins(segment, isOutgoing, edges);

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -12,25 +12,35 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
   CHECK(m_estimator, ());
 }
 
-void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
+void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool leap,
+                             vector<SegmentEdge> & edges)
 {
+  if (m_crossMwmGraph && leap)
+  {
+    if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
+      GetTwins(segment, isOutgoing, edges);
+    else
+      m_crossMwmGraph->GetEdgeList(segment, isOutgoing, edges);
+    return;
+  }
+
   IndexGraph & indexGraph = GetIndexGraph(segment.GetMwmId());
   indexGraph.GetEdgeList(segment, isOutgoing, edges);
 
-  // TODO remove this return to activate m_crossMwmGraph.
-  return;
-
-  if (!m_crossMwmGraph || !m_crossMwmGraph->IsTransition(segment, isOutgoing))
-    return;
-
-  m_twins.clear();
-  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
-  for (Segment const & twin : m_twins)
-    edges.emplace_back(twin, 0.0 /* weight */);
+  if (m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
+    GetTwins(segment, isOutgoing, edges);
 }
 
 RoadGeometry const & WorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
   return GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+}
+
+void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
+{
+  m_twins.clear();
+  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
+  for (Segment const & twin : m_twins)
+    edges.emplace_back(twin, 0.0 /* weight */);
 }
 }  // namespace routing

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -19,14 +19,19 @@ public:
   WorldGraph(std::unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
              std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool leap,
+                   std::vector<SegmentEdge> & edges);
 
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
   EdgeEstimator const & GetEstimator() const { return *m_estimator; }
 
   RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
 
-private:
+  void BlockMwmBorders() { m_crossMwmGraph = nullptr; }
+
+private:  
+  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+
   std::unique_ptr<CrossMwmIndexGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -19,7 +19,7 @@ public:
   WorldGraph(std::unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
              std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool leap,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                    std::vector<SegmentEdge> & edges);
 
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
@@ -27,7 +27,11 @@ public:
 
   RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
 
+  // Disable edges between mwms.
+  // Unblocking is not implemented due to YAGNI principle.
   void BlockMwmBorders() { m_crossMwmGraph = nullptr; }
+  // Clear memory used by loaded index graphs.
+  void ClearIndexGraphs() { m_loader->Clear(); }
 
 private:  
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);

--- a/traffic/traffic_cache.cpp
+++ b/traffic/traffic_cache.cpp
@@ -2,6 +2,8 @@
 
 namespace traffic
 {
+using namespace std;
+
 void TrafficCache::Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && coloring)
 {
   m_trafficColoring[mwmId] = make_shared<TrafficInfo::Coloring>(move(coloring));
@@ -16,6 +18,12 @@ shared_ptr<TrafficInfo::Coloring> TrafficCache::GetTrafficInfo(MwmSet::MwmId con
   if (it == m_trafficColoring.cend())
     return shared_ptr<TrafficInfo::Coloring>();
   return it->second;
+}
+
+void TrafficCache::CopyTraffic(
+    map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
+{
+  trafficColoring = m_trafficColoring;
 }
 
 void TrafficCache::Clear() { m_trafficColoring.clear(); }

--- a/traffic/traffic_cache.hpp
+++ b/traffic/traffic_cache.hpp
@@ -3,8 +3,8 @@
 
 #include "indexer/mwm_set.hpp"
 
-#include "std/map.hpp"
-#include "std/shared_ptr.hpp"
+#include <map>
+#include <memory>
 
 namespace traffic
 {
@@ -14,7 +14,11 @@ public:
   TrafficCache() : m_trafficColoring() {}
   virtual ~TrafficCache() = default;
 
-  virtual shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(MwmSet::MwmId const & mwmId) const;
+  virtual shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(
+      MwmSet::MwmId const & mwmId) const;
+  virtual void CopyTraffic(
+      std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring)
+      const;
 
 protected:
   void Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && mwmIdAndColoring);
@@ -22,6 +26,6 @@ protected:
   void Clear();
 
 private:
-  map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> m_trafficColoring;
+  std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> m_trafficColoring;
 };
 }  // namespace traffic


### PR DESCRIPTION
Cross mwm роутинг с помощью прыжков: ребер основанных на предрассчитанных маршрутах между входами и выходами внутри mwm.

Основано на использование функции CrossMwmGraph::GetEdgesList()

Подготовительный pull request, то есть функционал не подключен и не влияет на работу приложения.