### PR TITLE
[build] Use system-provided boost instead of 3party in cmake.

### DIFF
--- a/3party/opening_hours/CMakeLists.txt
+++ b/3party/opening_hours/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.2)
 
 project(opening_hours C CXX)
 
+add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
+
 include_directories(src ../../)
 
 add_compile_options(

--- a/3party/opening_hours/opening_hours.pro
+++ b/3party/opening_hours/opening_hours.pro
@@ -13,6 +13,8 @@ ROOT_DIR = ../..
 
 include($$ROOT_DIR/common.pri)
 
+DEFINES *= BOOST_SPIRIT_USE_PHOENIX_V3
+
 HEADERS += opening_hours.hpp \
            opening_hours_parsers.hpp \
            parse_opening_hours.hpp \

--- a/3party/opening_hours/opening_hours_parsers.hpp
+++ b/3party/opening_hours/opening_hours_parsers.hpp
@@ -112,4 +112,3 @@ public:
 
 } // namespace parsing
 } // namespace osmoh
-#undef BOOST_SPIRIT_USE_PHOENIX_V3

--- a/3party/opening_hours/parse_months.cpp
+++ b/3party/opening_hours/parse_months.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 

--- a/3party/opening_hours/parse_opening_hours.cpp
+++ b/3party/opening_hours/parse_opening_hours.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>

--- a/3party/opening_hours/parse_timespans.cpp
+++ b/3party/opening_hours/parse_timespans.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 

--- a/3party/opening_hours/parse_weekdays.cpp
+++ b/3party/opening_hours/parse_weekdays.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 

--- a/3party/opening_hours/parse_weeks.cpp
+++ b/3party/opening_hours/parse_weeks.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 
 namespace osmoh

--- a/3party/opening_hours/parse_years.cpp
+++ b/3party/opening_hours/parse_years.cpp
@@ -1,7 +1,6 @@
 #include "parse_opening_hours.hpp"
 #include "opening_hours_parsers.hpp"
 
-#define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/phoenix_bind.hpp>
 
 namespace osmoh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,20 @@ endif()
 
 find_package(Threads)
 
+set(Boost_USE_MULTITHREADED ON)
+add_definitions(-DBOOST_BIND_NO_PLACEHOLDERS)
+
+if (PLATFORM_MAC)
+  set(Boost_USE_STATIC_LIBS ON)
+  set(Boost_USE_STATIC_RUNTIME ON)
+endif()
+
+if (PYBINDINGS)
+  find_package(Boost 1.54 REQUIRED COMPONENTS python)
+else()
+  find_package(Boost 1.54)
+endif()
+
 if (NOT PLATFORM_IPHONE AND NOT PLATFORM_ANDROID)
   find_package(Qt5Core REQUIRED)
   find_package(Qt5Network REQUIRED)
@@ -103,7 +117,7 @@ include_directories(
   ${CMAKE_HOME_DIRECTORY}
   ${Qt5Core_INCLUDE_DIRS}
   ${Qt5Network_INCLUDE_DIRS}
-  ${CMAKE_HOME_DIRECTORY}/3party/boost
+  ${Boost_INCLUDE_DIRS}
 )
 
 # Functions for using in subdirectories

--- a/coding/simple_dense_coding.cpp
+++ b/coding/simple_dense_coding.cpp
@@ -5,7 +5,7 @@
 #include "std/algorithm.hpp"
 #include "std/limits.hpp"
 
-#include "3party/boost/boost/range/adaptor/transformed.hpp"
+#include <boost/range/adaptor/transformed.hpp>
 
 namespace coding
 {

--- a/pyhelpers/vector_list_conversion.hpp
+++ b/pyhelpers/vector_list_conversion.hpp
@@ -3,6 +3,7 @@
 #include "std/vector.hpp"
 
 #include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
 
 namespace
 {

--- a/tracking/pytracking/CMakeLists.txt
+++ b/tracking/pytracking/CMakeLists.txt
@@ -6,19 +6,8 @@ set(
   SRC
   bindings.cpp
 )
-add_compile_options(
-    "-Wno-unused-local-typedef"
-)
-
-set(Boost_USE_MULTITHREADED ON)
-
-if (PLATFORM_MAC)
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_STATIC_RUNTIME ON)
-endif()
 
 find_package(PythonLibs 2.7 REQUIRED)
-find_package(Boost 1.54 REQUIRED COMPONENTS python)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE ${SRC})

--- a/traffic/pytraffic/CMakeLists.txt
+++ b/traffic/pytraffic/CMakeLists.txt
@@ -7,21 +7,7 @@ set(
   bindings.cpp
 )
 
-# Suppress boost-python warnings
-add_compile_options(
-  "-Wno-unused-local-typedef"
-)
-
-set(Boost_USE_MULTITHREADED ON)
-
-# For macOS we can use static linking, on Linux we can't.
-if (PLATFORM_MAC)
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_STATIC_RUNTIME ON)
-endif()
-
 find_package(PythonLibs 2.7 REQUIRED)
-find_package(Boost 1.54 REQUIRED COMPONENTS python)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE ${SRC})


### PR DESCRIPTION
@milchakov @syershov PTAL