### PR TITLE
[routing] fix reconstruct route while cross mwm leaps

### DIFF
--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -1,5 +1,7 @@
 #include "routing/directions_engine.hpp"
 
+#include "geometry/mercator.hpp"
+
 #include "base/assert.hpp"
 
 namespace
@@ -78,7 +80,12 @@ bool IDirectionsEngine::ReconstructPath(RoadGraphBase const & graph, vector<Junc
     }
 
     if (!found)
+    {
+      LOG(LERROR, ("Can't find next edge, curr:", MercatorBounds::ToLatLon(curr.GetPoint()),
+                   ", next:", MercatorBounds::ToLatLon(next.GetPoint()), ", edges size:",
+                   currEdges.size(), ", i:", i));
       return false;
+    }
 
     curr = next;
   }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -82,7 +82,7 @@ IRouter::ResultCode IndexRouter::CalculateRouteForSingleMwm(
 }
 
 IRouter::ResultCode IndexRouter::CalculateRoute(string const & startCountry,
-                                                string const & finishCountry, bool blockMwmBorders,
+                                                string const & finishCountry, bool forSingleMwm,
                                                 m2::PointD const & startPoint,
                                                 m2::PointD const & startDirection,
                                                 m2::PointD const & finalPoint,
@@ -90,8 +90,8 @@ IRouter::ResultCode IndexRouter::CalculateRoute(string const & startCountry,
 {
   try
   {
-    return DoCalculateRoute(startCountry, finishCountry, blockMwmBorders, startPoint,
-                            startDirection, finalPoint, delegate, route);
+    return DoCalculateRoute(startCountry, finishCountry, forSingleMwm, startPoint, startDirection,
+                            finalPoint, delegate, route);
   }
   catch (RootException const & e)
   {
@@ -101,10 +101,12 @@ IRouter::ResultCode IndexRouter::CalculateRoute(string const & startCountry,
   }
 }
 
-IRouter::ResultCode IndexRouter::DoCalculateRoute(
-    string const & startCountry, string const & finishCountry, bool blockMwmBorders,
-    m2::PointD const & startPoint, m2::PointD const & /* startDirection */,
-    m2::PointD const & finalPoint, RouterDelegate const & delegate, Route & route)
+IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
+                                                  string const & finishCountry, bool forSingleMwm,
+                                                  m2::PointD const & startPoint,
+                                                  m2::PointD const & /* startDirection */,
+                                                  m2::PointD const & finalPoint,
+                                                  RouterDelegate const & delegate, Route & route)
 {
   auto const startFile = platform::CountryFile(startCountry);
   auto const finishFile = platform::CountryFile(finishCountry);
@@ -129,9 +131,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(
       make_unique<CrossMwmIndexGraph>(m_numMwmIds, m_indexManager),
       IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
       m_estimator);
-
-  if (blockMwmBorders)
-    graph.CloseBorders();
+  graph.SetMode(forSingleMwm ? WorldGraph::Mode::SingleMwm : WorldGraph::Mode::WorldWithLeaps);
 
   IndexGraphStarter starter(start, finish, graph);
 
@@ -170,7 +170,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(
 
     CHECK_GREATER_OR_EQUAL(segments.size(), routingResult.path.size(), ());
 
-    if (!RedressRoute(segments, delegate, starter, route))
+    if (!RedressRoute(segments, delegate, forSingleMwm, starter, route))
       return IRouter::InternalError;
     if (delegate.IsCancelled())
       return IRouter::Cancelled;
@@ -223,7 +223,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
   output.reserve(input.size());
 
   WorldGraph & worldGraph = starter.GetGraph();
-  worldGraph.CloseBorders();
+  worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
 
   for (size_t i = 0; i < input.size(); ++i)
   {
@@ -270,7 +270,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 }
 
 bool IndexRouter::RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
-                               IndexGraphStarter & starter, Route & route) const
+                               bool forSingleMwm, IndexGraphStarter & starter, Route & route) const
 {
   vector<Junction> junctions;
   size_t const numPoints = IndexGraphStarter::GetRouteNumPoints(segments);
@@ -283,7 +283,8 @@ bool IndexRouter::RedressRoute(vector<Segment> const & segments, RouterDelegate 
   }
 
   IndexRoadGraph roadGraph(m_numMwmIds, starter, segments, junctions, m_index);
-  starter.GetGraph().OpenBorders();
+  if (!forSingleMwm)
+    starter.GetGraph().SetMode(WorldGraph::Mode::WorldWithoutLeaps);
 
   CHECK(m_directionsEngine, ());
   ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, junctions, route);

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -53,12 +53,12 @@ public:
 
 private:
   IRouter::ResultCode CalculateRoute(string const & startCountry, string const & finishCountry,
-                                     bool blockMwmBorders, m2::PointD const & startPoint,
+                                     bool forSingleMwm, m2::PointD const & startPoint,
                                      m2::PointD const & startDirection,
                                      m2::PointD const & finalPoint, RouterDelegate const & delegate,
                                      Route & route);
   IRouter::ResultCode DoCalculateRoute(string const & startCountry, string const & finishCountry,
-                                       bool blockMwmBorders, m2::PointD const & startPoint,
+                                       bool forSingleMwm, m2::PointD const & startPoint,
                                        m2::PointD const & startDirection,
                                        m2::PointD const & finalPoint,
                                        RouterDelegate const & delegate, Route & route);
@@ -69,7 +69,7 @@ private:
   IRouter::ResultCode ProcessLeaps(vector<Segment> const & input, RouterDelegate const & delegate,
                                    IndexGraphStarter & starter, vector<Segment> & output);
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
-                    IndexGraphStarter & starter, Route & route) const;
+                    bool forSingleMwm, IndexGraphStarter & starter, Route & route) const;
 
   string const m_name;
   Index & m_index;

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -15,8 +15,9 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
 void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                              vector<SegmentEdge> & edges)
 {
-  if (m_crossMwmGraph && m_bordersAreOpened && isLeap)
+  if (isLeap && m_mode == Mode::WorldWithLeaps)
   {
+    CHECK(m_crossMwmGraph, ());
     if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
       GetTwins(segment, isOutgoing, edges);
     else
@@ -27,8 +28,12 @@ void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLe
   IndexGraph & indexGraph = GetIndexGraph(segment.GetMwmId());
   indexGraph.GetEdgeList(segment, isOutgoing, edges);
 
-  if (m_crossMwmGraph && m_bordersAreOpened && m_crossMwmGraph->IsTransition(segment, isOutgoing))
-    GetTwins(segment, isOutgoing, edges);
+  if (m_mode != Mode::SingleMwm)
+  {
+    CHECK(m_crossMwmGraph, ());
+    if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
+      GetTwins(segment, isOutgoing, edges);
+  }
 }
 
 m2::PointD const & WorldGraph::GetPoint(Segment const & segment, bool front)

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -16,6 +16,13 @@ namespace routing
 class WorldGraph final
 {
 public:
+  enum class Mode
+  {
+    SingleMwm,
+    WorldWithLeaps,
+    WorldWithoutLeaps,
+  };
+
   WorldGraph(std::unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
              std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
 
@@ -28,12 +35,9 @@ public:
   m2::PointD const & GetPoint(Segment const & segment, bool front);
   RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
 
-  // Disable edges between mwms.
-  void CloseBorders() { m_bordersAreOpened = false; }
-  // Enable edges between mwms.
-  void OpenBorders() { m_bordersAreOpened = true; }
   // Clear memory used by loaded index graphs.
   void ClearIndexGraphs() { m_loader->Clear(); }
+  void SetMode(Mode mode) { m_mode = mode; }
 
 private:  
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
@@ -42,6 +46,6 @@ private:
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::vector<Segment> m_twins;
-  bool m_bordersAreOpened = true;
+  Mode m_mode = Mode::SingleMwm;
 };
 }  // namespace routing


### PR DESCRIPTION
При запуске меж-mwm-ного роутинга с прыжками ломался ReconstructRoute.

Проблема была в том, что граф при ReconstructRoute работал в режиме прыжков, а путь был уже полный, и не находились внутренние ребра mwm, через которую перепрыгнули.

Фикс этой поломки.