### PR TITLE
Backward wave in CrossMwmGraph

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -35,6 +35,8 @@ set(
   newtype.hpp
   normalize_unicode.cpp
   observer_list.hpp
+  random.cpp
+  random.hpp
   range_iterator.hpp
   ref_counted.hpp
   rolling_hash.hpp

--- a/base/base.pro
+++ b/base/base.pro
@@ -18,6 +18,7 @@ SOURCES += \
     logging.cpp \
     lower_case.cpp \
     normalize_unicode.cpp \
+    random.cpp \
     shared_buffer_manager.cpp \
     src_point.cpp \
     string_format.cpp \
@@ -59,6 +60,7 @@ HEADERS += \
     mutex.hpp \
     newtype.hpp \
     observer_list.hpp \
+    random.hpp \
     range_iterator.hpp \
     ref_counted.hpp \
     regexp.hpp \

--- a/base/random.cpp
+++ b/base/random.cpp
@@ -1,0 +1,22 @@
+#include "base/random.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+namespace my
+{
+std::vector<size_t> RandomSample(size_t n, size_t k, std::minstd_rand & rng)
+{
+  std::vector<size_t> result(std::min(k, n));
+  std::iota(result.begin(), result.end(), 0);
+
+  for (size_t i = k; i < n; ++i)
+  {
+    size_t const j = rng() % (i + 1);
+    if (j < k)
+      result[j] = i;
+  }
+
+  return result;
+}
+}  // my

--- a/base/random.cpp
+++ b/base/random.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <numeric>
 
-namespace my
+namespace base
 {
 std::vector<size_t> RandomSample(size_t n, size_t k, std::minstd_rand & rng)
 {
@@ -19,4 +19,4 @@ std::vector<size_t> RandomSample(size_t n, size_t k, std::minstd_rand & rng)
 
   return result;
 }
-}  // my
+}  // base

--- a/base/random.hpp
+++ b/base/random.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <random>
+#include <vector>
+
+namespace my
+{
+std::vector<size_t> RandomSample(size_t n, size_t k, std::minstd_rand & rng);
+}  // my

--- a/base/random.hpp
+++ b/base/random.hpp
@@ -3,7 +3,8 @@
 #include <random>
 #include <vector>
 
-namespace my
+namespace base
 {
+// Selects a fair random subset of size min(|n|, |k|) from [0, 1, 2, ..., n - 1].
 std::vector<size_t> RandomSample(size_t n, size_t k, std::minstd_rand & rng);
-}  // my
+}  // base

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -115,7 +115,6 @@ public:
   };
 
   explicit CrossMwmGraph(RoutingIndexManager & indexManager) : m_indexManager(indexManager) {}
-
   void GetOutgoingEdgesList(BorderCross const & v, vector<CrossWeightedEdge> & adj) const
   {
     GetEdgesList(v, true /* isOutgoing */, adj);
@@ -130,12 +129,6 @@ public:
 
   IRouter::ResultCode SetStartNode(CrossNode const & startNode);
   IRouter::ResultCode SetFinalNode(CrossNode const & finalNode);
-
-  // Cashing wrapper for the ConstructBorderCrossByOutgoingImpl function.
-  vector<BorderCross> const & ConstructBorderCrossByOutgoingNode(OutgoingCrossNode const & startNode,
-                                                                 TRoutingMappingPtr const & currentMapping) const;
-  vector<BorderCross> const & ConstructBorderCrossByIngoingNode(IngoingCrossNode const & startNode,
-                                                                TRoutingMappingPtr const & currentMapping) const;
 
   vector<BorderCross> const & ConstructBorderCross(TRoutingMappingPtr const & currentMapping,
                                                    OutgoingCrossNode const & node) const;

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -102,8 +102,17 @@ private:
 class CrossMwmGraph
 {
 public:
+  using TCachingKey = pair<TWrittenNodeId, Index::MwmId>;
   using TVertexType = BorderCross;
   using TEdgeType = CrossWeightedEdge;
+
+  struct Hash
+  {
+    size_t operator()(TCachingKey const & p) const
+    {
+      return hash<TWrittenNodeId>()(p.first) ^ hash<string>()(p.second.GetInfo()->GetCountryName());
+    }
+  };
 
   explicit CrossMwmGraph(RoutingIndexManager & indexManager) : m_indexManager(indexManager) {}
 
@@ -149,17 +158,6 @@ private:
   map<CrossNode, vector<CrossWeightedEdge> > m_virtualEdges;
 
   mutable RoutingIndexManager m_indexManager;
-
-  // Caching stuff.
-  using TCachingKey = pair<TWrittenNodeId, Index::MwmId>;
-
-  struct Hash
-  {
-    size_t operator()(TCachingKey const & p) const
-    {
-      return hash<TWrittenNodeId>()(p.first) ^ hash<string>()(p.second.GetInfo()->GetCountryName());
-    }
-  };
 
   // @TODO(bykoianko) Consider removing key work mutable.
   mutable unordered_map<TCachingKey, vector<BorderCross>, Hash> m_cachedNextNodesByIngoing;

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -132,10 +132,15 @@ public:
   IRouter::ResultCode SetFinalNode(CrossNode const & finalNode);
 
   // Cashing wrapper for the ConstructBorderCrossByOutgoingImpl function.
-  vector<BorderCross> const & ConstructBorderCrossByOutgoing(OutgoingCrossNode const & startNode,
-                                                            TRoutingMappingPtr const & currentMapping) const;
-  vector<BorderCross> const & ConstructBorderCrossByIngoing(IngoingCrossNode const & startNode,
-                                                            TRoutingMappingPtr const & currentMapping) const;
+  vector<BorderCross> const & ConstructBorderCrossByOutgoingNode(OutgoingCrossNode const & startNode,
+                                                                 TRoutingMappingPtr const & currentMapping) const;
+  vector<BorderCross> const & ConstructBorderCrossByIngoingNode(IngoingCrossNode const & startNode,
+                                                                TRoutingMappingPtr const & currentMapping) const;
+
+  vector<BorderCross> const & ConstructBorderCross(TRoutingMappingPtr const & currentMapping,
+                                                   OutgoingCrossNode const & node) const;
+  vector<BorderCross> const & ConstructBorderCross(TRoutingMappingPtr const & currentMapping,
+                                                   IngoingCrossNode const & node) const;
 
 private:
   // Pure function to construct boder cross by outgoing cross node.
@@ -145,6 +150,7 @@ private:
   bool ConstructBorderCrossByIngoingImpl(IngoingCrossNode const & startNode,
                                          TRoutingMappingPtr const & currentMapping,
                                          vector<BorderCross> & crosses) const;
+
   /*!
    * Adds a virtual edge to the graph so that it is possible to represent
    * the final segment of the path that leads from the map's border

--- a/routing/cross_routing_context.cpp
+++ b/routing/cross_routing_context.cpp
@@ -106,7 +106,7 @@ const string & CrossRoutingContextReader::GetOutgoingMwmName(
 }
 
 TWrittenEdgeWeight CrossRoutingContextReader::GetAdjacencyCost(IngoingCrossNode const & ingoing,
-                                                              OutgoingCrossNode const & outgoing) const
+                                                               OutgoingCrossNode const & outgoing) const
 {
   if (ingoing.m_adjacencyIndex == kInvalidAdjacencyIndex ||
       outgoing.m_adjacencyIndex == kInvalidAdjacencyIndex)

--- a/routing/cross_routing_context.cpp
+++ b/routing/cross_routing_context.cpp
@@ -105,8 +105,8 @@ const string & CrossRoutingContextReader::GetOutgoingMwmName(
   return m_neighborMwmList[outgoingNode.m_outgoingIndex];
 }
 
-TWrittenEdgeWeight CrossRoutingContextReader::GetAdjacencyCost(IngoingCrossNode const & ingoing,
-                                                               OutgoingCrossNode const & outgoing) const
+TWrittenEdgeWeight CrossRoutingContextReader::GetAdjacencyCost(
+    IngoingCrossNode const & ingoing, OutgoingCrossNode const & outgoing) const
 {
   if (ingoing.m_adjacencyIndex == kInvalidAdjacencyIndex ||
       outgoing.m_adjacencyIndex == kInvalidAdjacencyIndex)

--- a/routing/cross_routing_context.hpp
+++ b/routing/cross_routing_context.hpp
@@ -91,7 +91,7 @@ class CrossRoutingContextReader
 public:
   void Load(Reader const & r);
 
-  const string & GetOutgoingMwmName(OutgoingCrossNode const & mwmIndex) const;
+  const string & GetOutgoingMwmName(OutgoingCrossNode const & outgoingNode) const;
 
   TWrittenEdgeWeight GetAdjacencyCost(IngoingCrossNode const & ingoing,
                                      OutgoingCrossNode const & outgoing) const;

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -266,7 +266,7 @@ void PreRanker::FilterForViewportSearch()
 
     if (m <= old)
     {
-      for (size_t i : my::RandomSample(old, m, m_rng))
+      for (size_t i : base::RandomSample(old, m, m_rng))
         results.push_back(m_results[bucket[i]]);
     }
     else
@@ -274,7 +274,7 @@ void PreRanker::FilterForViewportSearch()
       for (size_t i = 0; i < old; ++i)
         results.push_back(m_results[bucket[i]]);
 
-      for (size_t i : my::RandomSample(bucket.size() - old, m - old, m_rng))
+      for (size_t i : base::RandomSample(bucket.size() - old, m - old, m_rng))
         results.push_back(m_results[bucket[old + i]]);
     }
   }
@@ -286,7 +286,7 @@ void PreRanker::FilterForViewportSearch()
   else
   {
     m_results.clear();
-    for (size_t i : my::RandomSample(results.size(), BatchSize(), m_rng))
+    for (size_t i : base::RandomSample(results.size(), BatchSize(), m_rng))
       m_results.push_back(results[i]);
   }
 }

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -9,6 +9,7 @@
 #include "indexer/rank_table.hpp"
 #include "indexer/scales.hpp"
 
+#include "base/random.hpp"
 #include "base/stl_helpers.hpp"
 
 #include "std/iterator.hpp"
@@ -45,22 +46,6 @@ struct ComparePreResult1
     return linfo.InnermostTokenRange().Begin() < rinfo.InnermostTokenRange().Begin();
   }
 };
-
-// Selects a fair random subset of size min(|n|, |k|) from [0, 1, 2, ..., n - 1].
-vector<size_t> RandomSample(size_t n, size_t k, minstd_rand & rng)
-{
-  vector<size_t> result(std::min(k, n));
-  iota(result.begin(), result.end(), 0);
-
-  for (size_t i = k; i < n; ++i)
-  {
-    size_t const j = rng() % (i + 1);
-    if (j < k)
-      result[j] = i;
-  }
-
-  return result;
-}
 
 void SweepNearbyResults(double eps, vector<PreResult1> & results)
 {
@@ -281,7 +266,7 @@ void PreRanker::FilterForViewportSearch()
 
     if (m <= old)
     {
-      for (size_t i : RandomSample(old, m, m_rng))
+      for (size_t i : my::RandomSample(old, m, m_rng))
         results.push_back(m_results[bucket[i]]);
     }
     else
@@ -289,7 +274,7 @@ void PreRanker::FilterForViewportSearch()
       for (size_t i = 0; i < old; ++i)
         results.push_back(m_results[bucket[i]]);
 
-      for (size_t i : RandomSample(bucket.size() - old, m - old, m_rng))
+      for (size_t i : my::RandomSample(bucket.size() - old, m - old, m_rng))
         results.push_back(m_results[bucket[old + i]]);
     }
   }
@@ -301,7 +286,7 @@ void PreRanker::FilterForViewportSearch()
   else
   {
     m_results.clear();
-    for (size_t i : RandomSample(results.size(), BatchSize(), m_rng))
+    for (size_t i : my::RandomSample(results.size(), BatchSize(), m_rng))
       m_results.push_back(results[i]);
   }
 }

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		39FD27381CC65AD000AFF551 /* timegm_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD26E21CC65A0E00AFF551 /* timegm_test.cpp */; };
 		39FD27391CC65AD000AFF551 /* timer_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD26E31CC65A0E00AFF551 /* timer_test.cpp */; };
 		39FD273B1CC65B1000AFF551 /* libbase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675341771A3F57BF00A0A8C3 /* libbase.a */; };
+		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
+		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
+		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
 		670E39441C46C76900E9C0A6 /* sunrise_sunset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 670E39421C46C76900E9C0A6 /* sunrise_sunset.cpp */; };
 		670E39451C46C76900E9C0A6 /* sunrise_sunset.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 670E39431C46C76900E9C0A6 /* sunrise_sunset.hpp */; };
 		671182F01C807C0A00CB8177 /* gmtime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671182EE1C807C0A00CB8177 /* gmtime.cpp */; };
@@ -157,6 +160,9 @@
 		39FD273D1CC65B1000AFF551 /* libplatform.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libplatform.a; path = "../../../omim-xcode-build/Debug/libplatform.a"; sourceTree = "<group>"; };
 		39FD27401CC65B2800AFF551 /* libindexer.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libindexer.a; path = "../../../omim-xcode-build/Debug/libindexer.a"; sourceTree = "<group>"; };
 		39FD27421CC65B4800AFF551 /* libcoding.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoding.a; path = "../../../omim-xcode-build/Debug/libcoding.a"; sourceTree = "<group>"; };
+		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
+		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
+		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
 		670E39421C46C76900E9C0A6 /* sunrise_sunset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sunrise_sunset.cpp; sourceTree = "<group>"; };
 		670E39431C46C76900E9C0A6 /* sunrise_sunset.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = sunrise_sunset.hpp; sourceTree = "<group>"; };
 		671182EE1C807C0A00CB8177 /* gmtime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gmtime.cpp; sourceTree = "<group>"; };
@@ -311,6 +317,9 @@
 		675341791A3F57BF00A0A8C3 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				56B1A0711E69DE4D00395022 /* random.cpp */,
+				56B1A0721E69DE4D00395022 /* random.hpp */,
+				56B1A0731E69DE4D00395022 /* small_set.hpp */,
 				675341851A3F57E400A0A8C3 /* array_adapters.hpp */,
 				675341861A3F57E400A0A8C3 /* assert.hpp */,
 				675341871A3F57E400A0A8C3 /* base.cpp */,
@@ -420,6 +429,7 @@
 				675341D11A3F57E400A0A8C3 /* cache.hpp in Headers */,
 				675341E31A3F57E400A0A8C3 /* math.hpp in Headers */,
 				3446C6731DDCA96300146687 /* levenshtein_dfa.hpp in Headers */,
+				56B1A0751E69DE4D00395022 /* random.hpp in Headers */,
 				675341E21A3F57E400A0A8C3 /* macros.hpp in Headers */,
 				672DD4C51E0425600078E13C /* observer_list.hpp in Headers */,
 				675341EF1A3F57E400A0A8C3 /* rolling_hash.hpp in Headers */,
@@ -452,6 +462,7 @@
 				675341FA1A3F57E400A0A8C3 /* src_point.hpp in Headers */,
 				674A7E2F1C0DB03D003D48E1 /* timegm.hpp in Headers */,
 				675341F71A3F57E400A0A8C3 /* shared_buffer_manager.hpp in Headers */,
+				56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */,
 				67B52B611AD3C84E00664C17 /* thread_checker.hpp in Headers */,
 				672DD4BE1E0425600078E13C /* cancellable.hpp in Headers */,
 				675341CB1A3F57E400A0A8C3 /* array_adapters.hpp in Headers */,
@@ -601,6 +612,7 @@
 				67E40EC81E4DC0D500A6D200 /* small_set_test.cpp in Sources */,
 				6753420E1A3F57E400A0A8C3 /* timer.cpp in Sources */,
 				675341F61A3F57E400A0A8C3 /* shared_buffer_manager.cpp in Sources */,
+				56B1A0741E69DE4D00395022 /* random.cpp in Sources */,
 				675341DA1A3F57E400A0A8C3 /* exception.cpp in Sources */,
 				675341F91A3F57E400A0A8C3 /* src_point.cpp in Sources */,
 				675342031A3F57E400A0A8C3 /* strings_bundle.cpp in Sources */,


### PR DESCRIPTION
1. Реализована обратная волна в классе CrossMwmGraph. Т.е. метод CrossMwmGraph::GetIngoingEdgesList() и методы необходимые для его реализации.

2. Написан тест (в routing_integration_test), который проходится по всем входам всех mwm всего мира. Для каждого входа ищет все доступные выходы в данной mwm. Для каждого найденного выхода - ищет все входы и проверяет, что среди них есть вход, с которого начали.

@dobriy-eeh @ygorshenin @mpimenov PTAL

Замечания:
- Тест, указанный в (2) занимает 3 часа и должен выполняться над картой мира. Я пока не решил, что с ним делать. Вероятно, оставлю в routing_integration_test и закомментирую. Если есть идеи - пишите.
- Несложно заметить, что в коде есть срытый copy paste. Он связан с тем, что в сигнатурах многих функций используется OutgoingCrossNode/IngoingCrossNode. Т.о. нам требуется два набора ф-ций. Если получится не очень сложно -  я попробую отрефакторить код, так чтоб у OutgoingCrossNode/IngoingCrossNode был общий базовый класс, который можно будет использовать в сигнатурах и убрать скрытый copypaste.