### PR TITLE
[zlib] Refine #if for zlib destructor

### DIFF
--- a/coding/zlib.cpp
+++ b/coding/zlib.cpp
@@ -59,7 +59,8 @@ ZLib::DeflateProcessor::DeflateProcessor(void const * data, size_t size, ZLib::L
 
 ZLib::DeflateProcessor::~DeflateProcessor() noexcept
 {
-#if !defined(OMIM_OS_ANDROID)
+#if !defined(OMIM_OS_ANDROID) && ZLIB_VERNUM >= 0x1253
+  // deflatePending() was added in zlib 1.2.5.1 and refined in 1.2.5.3
   unsigned bytes = 0;
   int bits = 0;
   auto const ret = deflatePending(&m_stream, &bytes, &bits);


### PR DESCRIPTION
На линуксе не собирался проект, нашёл причину: старый zlib. Юра сказал, что этот кусок кода не обязательный, поэтому просто уточнил `#if`.