### PR TITLE
[release-72] [tracking] Add traffic info to tracking reporter

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -216,7 +216,7 @@ void Framework::OnLocationUpdate(GpsInfo const & info)
   CallDrapeFunction(bind(&df::DrapeEngine::SetGpsInfo, _1, rInfo,
                          m_routingSession.IsNavigable(), routeMatchingInfo));
   if (IsTrackingReporterEnabled())
-    m_trackingReporter.AddLocation(info);
+    m_trackingReporter.AddLocation(info, m_routingSession.MatchTraffic(routeMatchingInfo));
 }
 
 void Framework::OnCompassUpdate(CompassInfo const & info)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -447,9 +447,12 @@ traffic::SpeedGroup RoutingSession::MatchTraffic(
   if (!routeMatchingInfo.IsMatched())
     return SpeedGroup::Unknown;
 
-  threads::MutexGuard guard(m_routingSessionMutex);
   size_t const index = routeMatchingInfo.GetIndexInRoute();
+  threads::MutexGuard guard(m_routingSessionMutex);
   vector<traffic::SpeedGroup> const & traffic = m_route->GetTraffic();
+
+  if (traffic.empty())
+    return SpeedGroup::Unknown;
 
   if (index >= traffic.size())
   {

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -441,6 +441,25 @@ void RoutingSession::MatchLocationToRoute(location::GpsInfo & location,
   m_route->MatchLocationToRoute(location, routeMatchingInfo);
 }
 
+traffic::SpeedGroup RoutingSession::MatchTraffic(
+    location::RouteMatchingInfo const & routeMatchingInfo) const
+{
+  if (!routeMatchingInfo.IsMatched())
+    return SpeedGroup::Unknown;
+
+  threads::MutexGuard guard(m_routingSessionMutex);
+  size_t const index = routeMatchingInfo.GetIndexInRoute();
+  vector<traffic::SpeedGroup> const & traffic = m_route->GetTraffic();
+
+  if (index >= traffic.size())
+  {
+    LOG(LERROR, ("Invalid index", index, "in RouteMatchingInfo, traffic.size():", traffic.size()));
+    return SpeedGroup::Unknown;
+  }
+
+  return traffic[index];
+}
+
 bool RoutingSession::DisableFollowMode()
 {
   LOG(LINFO, ("Routing disables a following mode. State: ", m_state.load()));

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -126,6 +126,8 @@ public:
 
   void MatchLocationToRoute(location::GpsInfo & location,
                             location::RouteMatchingInfo & routeMatchingInfo) const;
+  // Get traffic speed for the current route position.
+  // Returns SpeedGroup::Unknown if any trouble happens: position doesn't match with route or something else.
   traffic::SpeedGroup MatchTraffic(location::RouteMatchingInfo const & routeMatchingInfo) const;
 
   void SetUserCurrentPosition(m2::PointD const & position);

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -6,6 +6,7 @@
 #include "routing/turns.hpp"
 #include "routing/turns_notification_manager.hpp"
 
+#include "traffic/speed_groups.hpp"
 #include "traffic/traffic_cache.hpp"
 #include "traffic/traffic_info.hpp"
 
@@ -125,6 +126,7 @@ public:
 
   void MatchLocationToRoute(location::GpsInfo & location,
                             location::RouteMatchingInfo & routeMatchingInfo) const;
+  traffic::SpeedGroup MatchTraffic(location::RouteMatchingInfo const & routeMatchingInfo) const;
 
   void SetUserCurrentPosition(m2::PointD const & position);
   m2::PointD const & GetUserCurrentPosition() const;

--- a/tracking/reporter.cpp
+++ b/tracking/reporter.cpp
@@ -43,7 +43,7 @@ Reporter::~Reporter()
   m_thread.join();
 }
 
-void Reporter::AddLocation(location::GpsInfo const & info)
+void Reporter::AddLocation(location::GpsInfo const & info, traffic::SpeedGroup /* speedGroup */)
 {
   lock_guard<mutex> lg(m_mutex);
 

--- a/tracking/reporter.hpp
+++ b/tracking/reporter.hpp
@@ -2,6 +2,8 @@
 
 #include "tracking/connection.hpp"
 
+#include "traffic/speed_groups.hpp"
+
 #include "base/thread.hpp"
 
 #include "std/atomic.hpp"
@@ -37,7 +39,7 @@ public:
            milliseconds pushDelay);
   ~Reporter();
 
-  void AddLocation(location::GpsInfo const & info);
+  void AddLocation(location::GpsInfo const & info, traffic::SpeedGroup speedGroup);
 
   void SetAllowSendingPoints(bool allow) { m_allowSendingPoints = allow; }
 

--- a/tracking/tracking_tests/reporter_test.cpp
+++ b/tracking/tracking_tests/reporter_test.cpp
@@ -27,7 +27,7 @@ void TransferLocation(Reporter & reporter, TestSocket & testSocket, double times
   gpsInfo.m_latitude = latidute;
   gpsInfo.m_longitude = longtitude;
   gpsInfo.m_horizontalAccuracy = 1.0;
-  reporter.AddLocation(gpsInfo);
+  reporter.AddLocation(gpsInfo, traffic::SpeedGroup::Unknown);
 
   using Packet = tracking::Protocol::PacketType;
   vector<uint8_t> buffer;


### PR DESCRIPTION
Протянул информацию о трафике из роутинга в tracking::Reporter

Дубликат https://github.com/mapsme/omim/pull/5526, только тот по ошибке был сделан в мастер, а этот в release-72

Откатывать https://github.com/mapsme/omim/pull/5526 не надо, его все равно потом бы пришлось переносить в master.