### PR TITLE
[android] Added hanlding of errors while getting a currency code

### DIFF
--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -12,6 +12,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.NavUtils;
 import android.support.v7.app.AlertDialog;
@@ -35,6 +36,8 @@ import com.mapswithme.util.statistics.AlohaHelper;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.util.Currency;
+import java.util.Locale;
 import java.util.Map;
 
 public class Utils
@@ -318,6 +321,33 @@ public class Utils
     {
       LOGGER.e(TAG, "Failed to call phone", e);
       AlohaHelper.logException(e);
+    }
+  }
+
+  @Nullable
+  public static String getCurrencyCode()
+  {
+    Locale[] locales = { Locale.getDefault(), Locale.US };
+    for (Locale locale : locales)
+    {
+      Currency currency = getCurrencyForLocale(locale);
+      if (currency != null)
+        return currency.getCurrencyCode();
+    }
+    return null;
+  }
+
+  @Nullable
+  public static Currency getCurrencyForLocale(@NonNull Locale locale)
+  {
+    try
+    {
+      return Currency.getInstance(locale);
+    }
+    catch (Throwable e)
+    {
+      LOGGER.e(TAG, "Failed to obtain a currency for locale: " + locale, e);
+      return null;
     }
   }
 


### PR DESCRIPTION
@goblinr @milchakov PTAL

В Fabric есть подобные крэши:

```
Fatal Exception: java.lang.IllegalArgumentException: Unsupported ISO 3166 country: my_ZG
       at java.util.Currency.getInstance(Currency.java:84)
       at com.mapswithme.maps.widget.placepage.PlacePageView.setMapObject(PlacePageView.java:887)
       at com.mapswithme.maps.MwmActivity.onMapObjectActivated(MwmActivity.java:1161)
       at com.mapswithme.maps.search.SearchEngine.nativeShowResult(SearchEngine.java)
       at com.mapswithme.maps.search.SearchEngine.showResult(SearchEngine.java:148)
       at com.mapswithme.maps.search.SearchFragment.showSingleResultOnMap(SearchFragment.java:480)
       at com.mapswithme.maps.search.SearchAdapter$ResultViewHolder.processClick(SearchAdapter.java:222)
       at com.mapswithme.maps.search.SearchAdapter$BaseResultViewHolder$1.onClick(SearchAdapter.java:72)
       at android.view.View.performClick(View.java:5210)
       at android.view.View$PerformClick.run(View.java:20976)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:145)
       at android.app.ActivityThread.main(ActivityThread.java:6220)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1399)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1194)
```
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/588855c80aeb16625b7fa4f7/sessions/58C1369900E6000113F6B31679A6CC07_5e5f25cb0af146db9415e374fe9eac45_0_v1?

В этом реквесте я добавил безопасное получение currency code. Если он не может быть получен для дефолтной локали, то делаем попытку получить currency code для Locale.US. Если и для Locale.US не можем получить, то не запрашиваем цену вовсе.