### PR TITLE
[android] Attempted to fixed crash in download adapter

### DIFF
--- a/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
+++ b/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
@@ -16,7 +16,6 @@ import android.support.v7.widget.RecyclerView;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.StyleSpan;
-import android.util.Log;
 import android.util.SparseArray;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -24,7 +23,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.crashlytics.android.Crashlytics;
 import com.mapswithme.maps.MwmActivity;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.R;
@@ -628,35 +626,11 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       }
       else
       {
-        // TODO: remove this debug 'if' if the crash is gone in next (6.5.3) release
-        // - https://www.fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/58249a350aeb16625bb4d0a7,
-        // otherwise the logged information should help to pinpoint the 'IndexOutOfBounds' bug.
-        if (position >= mItems.size())
-          logIndexOutOfBoundsErrorInfoToCrashlytics(position);
-
+        if (position > mNearMeCount)
+          position -= getAdsCount();
         CountryItem ci = mItems.get(position);
         mTitle.setText(mHeaders.get(ci.headerId));
       }
-    }
-  }
-
-  private void logIndexOutOfBoundsErrorInfoToCrashlytics(int position)
-  {
-    String tag = DownloaderAdapter.class.getSimpleName();
-    int itemSize = mItems.size();
-    Crashlytics.log(Log.ERROR, tag, "Index " + position + " is out of bounds, mItem.size = "
-                                    + itemSize + ", current thread = " + Thread.currentThread() +
-                                    " mNearMeCount = " + mNearMeCount + ", ads count = " + mAds.size()
-                                    + ", showAds = " + mShowAds + ", mAdsLoaded = " + mAdsLoaded
-                                    + ", mAdsLoading = " + mAdsLoading +
-                                    " mSearchResultsMode = " + mSearchResultsMode
-                                    + ", mSearchQuery = " + mSearchQuery +
-                                    " mHeaders.size = " + mHeaders.size()
-                                    + " mHeaders = " + mHeaders);
-    if (itemSize > 0)
-    {
-      CountryItem lastCi = mItems.get(--itemSize);
-      Crashlytics.log(Log.INFO, tag, "last county item in position = " + itemSize + " = " + lastCi);
     }
   }
 


### PR DESCRIPTION
@goblinr @milchakov PTAL

```
Fatal Exception: java.lang.IndexOutOfBoundsException: Invalid index 225, size is 225
       at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:255)
       at java.util.ArrayList.get(ArrayList.java:308)
       at com.mapswithme.maps.downloader.DownloaderAdapter$HeaderViewHolder.bind(DownloaderAdapter.java:637)
       at com.mapswithme.maps.downloader.DownloaderAdapter.onBindHeaderViewHolder(DownloaderAdapter.java:873)
       at com.mapswithme.maps.downloader.DownloaderAdapter.onBindHeaderViewHolder(DownloaderAdapter.java:52)
       at com.timehop.stickyheadersrecyclerview.caching.HeaderViewCache.getHeader(HeaderViewCache.java:35)
       at com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration.getHeaderView(StickyRecyclerHeadersDecoration.java:148)
       at com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration.getItemOffsets(StickyRecyclerHeadersDecoration.java:70)
       at android.support.v7.widget.RecyclerView.getItemDecorInsetsForChild(RecyclerView.java:3623)
       at android.support.v7.widget.RecyclerView$LayoutManager.measureChildWithMargins(RecyclerView.java:6687)
       at android.support.v7.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1390)
       at android.support.v7.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1327)
       at android.support.v7.widget.LinearLayoutManager.scrollBy(LinearLayoutManager.java:1155)
       at android.support.v7.widget.LinearLayoutManager.scrollVerticallyBy(LinearLayoutManager.java:1012)
       at android.support.v7.widget.RecyclerView$ViewFlinger.run(RecyclerView.java:3777)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:803)
       at android.view.Choreographer.doCallbacks(Choreographer.java:603)
       at android.view.Choreographer.doFrame(Choreographer.java:572)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:789)
       at android.os.Handler.handleCallback(Handler.java:733)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:157)
       at android.app.ActivityThread.main(ActivityThread.java:5350)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:515)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1265)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1081)
       at dalvik.system.NativeStart.main(NativeStart.java)
```
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/583fada40aeb16625b790070?time=last-ninety-days

Сделал фикс, опираясь только на логи.  Во всех крэшах, есть загруженная реклама (ads count), которая кажется не учитывалась и вылетал arrayindexoutofbounds.

`E/DownloaderAdapter Index 225 is out of bounds, mItem.size = 225, current thread = Thread[main,5,main] mNearMeCount = 1, ads count = 1, showAds = true, mAdsLoaded = true, mAdsLoading = false mSearchResultsMode = false, mSearchQuery = null mHeaders.size = 29 mHeaders = {0=Yakınlarımda, 85=A, 86=B, 87=C, 88=D, 89=E, 90=F, 91=G, 92=H, 93=I, 94=J, 95=K, 96=L, 97=M, 98=N, 99=O, 100=P, 102=R, 103=S, 104=T, 105=U, 106=V, 109=Y, 110=Z, 219=Ç, 234=Ö, 240=Ü, 324=İ, 370=Ş}`