### PR TITLE
[coding] Fixed bug with PredictPointInTriangle.

### DIFF
--- a/indexer/geometry_coding.cpp
+++ b/indexer/geometry_coding.cpp
@@ -9,30 +9,30 @@
 
 namespace
 {
-  inline m2::PointU ClampPoint(m2::PointU const & maxPoint, m2::Point<double> const & point)
+  inline m2::PointU ClampPoint(m2::PointD const & maxPoint, m2::PointD const & point)
   {
     typedef m2::PointU::value_type uvalue_t;
     //return m2::PointU(my::clamp(static_cast<uvalue_t>(point.x), static_cast<uvalue_t>(0), maxPoint.x),
     //                  my::clamp(static_cast<uvalue_t>(point.y), static_cast<uvalue_t>(0), maxPoint.y));
 
-    return m2::PointU(static_cast<uvalue_t>(my::clamp(point.x, 0.0, static_cast<double>(maxPoint.x))),
-                      static_cast<uvalue_t>(my::clamp(point.y, 0.0, static_cast<double>(maxPoint.y))));
+    return m2::PointU(static_cast<uvalue_t>(my::clamp(point.x, 0.0, maxPoint.x)),
+                      static_cast<uvalue_t>(my::clamp(point.y, 0.0, maxPoint.y)));
   }
 }
 
-m2::PointU PredictPointInPolyline(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2)
+m2::PointU PredictPointInPolyline(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2)
 {
   // return ClampPoint(maxPoint, m2::PointI64(p1) + m2::PointI64(p1) - m2::PointI64(p2));
   // return ClampPoint(maxPoint, m2::PointI64(p1) + (m2::PointI64(p1) - m2::PointI64(p2)) / 2);
-  return ClampPoint(maxPoint, m2::PointD(p1) + (m2::PointD(p1) - m2::PointD(p2)) / 2.0);
+  return ClampPoint(maxPoint, p1 + (p1 - p2) / 2.0);
 }
 
-m2::PointU PredictPointInPolyline(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2,
-                                  m2::PointU const & p3)
+m2::PointU PredictPointInPolyline(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2,
+                                  m2::PointD const & p3)
 {
   CHECK_NOT_EQUAL(p2, p3, ());
 
@@ -52,13 +52,13 @@ m2::PointU PredictPointInPolyline(m2::PointU const & maxPoint,
   complex<double> const c0 = (c01 + c02) * complex<double>(0.5, 0.0);
   */
 
-  return ClampPoint(maxPoint, m2::PointD(c0.real(), c0.imag()));
+  return ClampPoint(maxPoint, {c0.real(), c0.imag()});
 }
 
-m2::PointU PredictPointInTriangle(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2,
-                                  m2::PointU const & p3)
+m2::PointU PredictPointInTriangle(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2,
+                                  m2::PointD const & p3)
 {
   // parallelogram prediction
   return ClampPoint(maxPoint, p1 + p2 - p3);

--- a/indexer/geometry_coding.hpp
+++ b/indexer/geometry_coding.hpp
@@ -26,22 +26,22 @@ inline m2::PointU DecodeDelta(uint64_t delta, m2::PointU const & prediction)
 
 
 /// Predict next point for polyline with given previous points (p1, p2).
-m2::PointU PredictPointInPolyline(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2);
+m2::PointU PredictPointInPolyline(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2);
 
 /// Predict next point for polyline with given previous points (p1, p2, p3).
-m2::PointU PredictPointInPolyline(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2,
-                                  m2::PointU const & p3);
+m2::PointU PredictPointInPolyline(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2,
+                                  m2::PointD const & p3);
 
 /// Predict point for neighbour triangle with given
 /// previous triangle (p1, p2, p3) and common edge (p1, p2).
-m2::PointU PredictPointInTriangle(m2::PointU const & maxPoint,
-                                  m2::PointU const & p1,
-                                  m2::PointU const & p2,
-                                  m2::PointU const & p3);
+m2::PointU PredictPointInTriangle(m2::PointD const & maxPoint,
+                                  m2::PointD const & p1,
+                                  m2::PointD const & p2,
+                                  m2::PointD const & p3);
 
 /// Geometry Coding-Decoding functions.
 namespace geo_coding


### PR DESCRIPTION
Застарелый баг. Изменения касаются функции PredictPointInTriangle. В констексте PointU (unsigned) p1+p2-p3 могла выдавать неожиданный результат. Здесь логичнее гонять PointD.
- Баг не критический, но мы можем получать непомерно большой размер кодированного треугольника в районе границы mwm
- Если его примете, то при работе со старыми mwm маловероятно могут возникнуть артефакты отрисовки на границах mwm (очень маловероятно).

На ваше усмотрение ... Но я бы его взял и затестил. Все таки логика должна быть в коде :)