### PR TITLE
[testing] Relaxed the filters in regular expressions.

### DIFF
--- a/testing/testingmain.cpp
+++ b/testing/testingmain.cpp
@@ -201,12 +201,12 @@ int main(int argc, char * argv[])
   {
     auto const & testName = testNames[iTest];
     if (g_testingOptions.m_filterRegExp &&
-        !regex_match(testName.begin(), testName.end(), filterRegExp))
+        !regex_search(testName.begin(), testName.end(), filterRegExp))
     {
       continue;
     }
     if (g_testingOptions.m_suppressRegExp &&
-        regex_match(testName.begin(), testName.end(), suppressRegExp))
+        regex_search(testName.begin(), testName.end(), suppressRegExp))
     {
       continue;
     }


### PR DESCRIPTION
This PR allows to write
```./search_tests --filter=Smoke```
instead of current
```./search_tests --filter='.*Smoke.*'```