### PR TITLE
has_parts type checking (for more accurate rendering of 3d buildings).

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -516,18 +516,20 @@ void ApplyPointFeature::Finish(CustomSymbolsContextPtr const & customSymbolsCont
 }
 
 ApplyAreaFeature::ApplyAreaFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape, FeatureID const & id,
-                                   bool isBuilding, float minPosZ, float posZ, int minVisibleScale,
+                                   bool isBuilding, bool skipAreaGeometry, float minPosZ, float posZ, int minVisibleScale,
                                    uint8_t rank, CaptionDescription const & captions)
   : TBase(tileKey, insertShape, id, minVisibleScale, rank, captions, posZ)
   , m_minPosZ(minPosZ)
   , m_isBuilding(isBuilding)
+  , m_skipAreaGeometry(skipAreaGeometry)
 {}
 
 void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3)
 {
   if (m_isBuilding)
   {
-    ProcessBuildingPolygon(p1, p2, p3);
+    if (!m_skipAreaGeometry)
+      ProcessBuildingPolygon(p1, p2, p3);
     return;
   }
 

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -103,7 +103,7 @@ class ApplyAreaFeature : public ApplyPointFeature
 
 public:
   ApplyAreaFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape, FeatureID const & id,
-                   bool isBuilding, float minPosZ, float posZ, int minVisibleScale,
+                   bool isBuilding, bool skipAreaGeometry, float minPosZ, float posZ, int minVisibleScale,
                    uint8_t rank, CaptionDescription const & captions);
 
   using TBase::operator ();
@@ -129,6 +129,7 @@ private:
 
   float const m_minPosZ;
   bool const m_isBuilding;
+  bool const m_skipAreaGeometry;
 };
 
 class ApplyLineFeature : public BaseApplyFeature

--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -1,8 +1,8 @@
 #include "drape_frontend/stylist.hpp"
 
+#include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/feature_visibility.hpp"
-#include "indexer/ftypes_matcher.hpp"
 #include "indexer/drawing_rules.hpp"
 #include "indexer/drules_include.hpp"
 #include "indexer/scales.hpp"
@@ -181,6 +181,30 @@ const uint8_t PointStyleFlag = 1 << 3;
 
 } // namespace
 
+IsBuildingHasPartsChecker::IsBuildingHasPartsChecker()
+{
+  m_types.push_back(classif().GetTypeByPath({"building", "has_parts"}));
+}
+
+// static
+IsBuildingHasPartsChecker const & IsBuildingHasPartsChecker::Instance()
+{
+  static const IsBuildingHasPartsChecker inst;
+  return inst;
+}
+
+IsBuildingPartChecker::IsBuildingPartChecker() : BaseChecker(1 /* level */)
+{
+  m_types.push_back(classif().GetTypeByPath({"building:part"}));
+}
+
+// static
+IsBuildingPartChecker const & IsBuildingPartChecker::Instance()
+{
+  static IsBuildingPartChecker const inst;
+  return inst;
+}
+
 // ==================================== //
 
 void CaptionDescription::Init(FeatureType const & f,
@@ -331,7 +355,7 @@ bool InitStylist(FeatureType const & f, int const zoomLevel, bool buildings3d, S
 {
   feature::TypesHolder const types(f);
 
-  if (!buildings3d && ftypes::IsBuildingPartChecker::Instance()(types) &&
+  if (!buildings3d && IsBuildingPartChecker::Instance()(types) &&
       !ftypes::IsBuildingChecker::Instance()(types))
     return false;
 

--- a/drape_frontend/stylist.hpp
+++ b/drape_frontend/stylist.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "indexer/feature_data.hpp"
+#include "indexer/ftypes_matcher.hpp"
 #include "indexer/drawing_rule_def.hpp"
 
 #include "base/buffer_vector.hpp"
@@ -14,6 +15,20 @@ namespace drule { class BaseRule; }
 
 namespace df
 {
+
+class IsBuildingHasPartsChecker : public ftypes::BaseChecker
+{
+  IsBuildingHasPartsChecker();
+public:
+  static IsBuildingHasPartsChecker const & Instance();
+};
+
+class IsBuildingPartChecker : public ftypes::BaseChecker
+{
+  IsBuildingPartChecker();
+public:
+  static IsBuildingPartChecker const & Instance();
+};
 
 struct CaptionDescription
 {

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -326,17 +326,6 @@ IsBuildingChecker const & IsBuildingChecker::Instance()
   return inst;
 }
 
-IsBuildingPartChecker::IsBuildingPartChecker() : BaseChecker(1 /* level */)
-{
-  m_types.push_back(classif().GetTypeByPath({"building:part"}));
-}
-
-IsBuildingPartChecker const & IsBuildingPartChecker::Instance()
-{
-  static IsBuildingPartChecker const inst;
-  return inst;
-}
-
 IsBridgeChecker::IsBridgeChecker() : BaseChecker(3 /* level */) {}
 IsBridgeChecker const & IsBridgeChecker::Instance()
 {

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -128,13 +128,6 @@ public:
   uint32_t GetMainType() const { return m_types[0]; }
 };
 
-class IsBuildingPartChecker : public BaseChecker
-{
-  IsBuildingPartChecker();
-public:
-  static IsBuildingPartChecker const & Instance();
-};
-
 class IsBridgeChecker : public BaseChecker
 {
   virtual bool IsMatched(uint32_t type) const override;


### PR DESCRIPTION
Do not render building feature if it is not a building part but has building parts.