### PR TITLE
[android] Added checking before starting LocationHelper through 'Cont…

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1848,7 +1848,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
           @Override
           public void onClick(DialogInterface dialog, int which)
           {
-            LocationHelper.INSTANCE.start();
+            if (!LocationHelper.INSTANCE.isActive())
+              LocationHelper.INSTANCE.start();
           }
         }).show();
   }

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -241,11 +241,12 @@ public enum LocationHelper
   }
 
   /**
-   * @see LocationState#isTurnedOn()
+   * Indicates about whether a location provider is polling location updates right now or not.
+   * @see BaseLocationProvider#isActive()
    */
-  public boolean isTurnedOn()
+  public boolean isActive()
   {
-    return LocationState.isTurnedOn();
+    return mLocationProvider != null && mLocationProvider.isActive();
   }
 
   void notifyCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy)


### PR DESCRIPTION
…inue' button in 'Not found Location' dialog

@milchakov @goblinr PTAL

Фикс вот этого крэша:

```
Fatal Exception: java.lang.AssertionError: Location provider 'com.mapswithme.maps.location.AndroidNativeProvider@4222a210' must be stopped first
       at com.mapswithme.maps.location.LocationHelper.start(LocationHelper.java:438)
       at com.mapswithme.maps.MwmActivity$22.onClick(MwmActivity.java:1851)
       at android.support.v7.app.AlertController$ButtonHandler.handleMessage(AlertController.java:157)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:176)
       at android.app.ActivityThread.main(ActivityThread.java:5365)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:511)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1102)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:869)
       at dalvik.system.NativeStart.main(NativeStart.java)
```