### PR TITLE
[editor] Added default language for Panama

### DIFF
--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -546,6 +546,9 @@
 "Taiwan": {
  "languages": ["zh"]
 },
+"Panama": {
+ "languages": ["es"]
+},
 "Peru": {
  "languages": ["es"]
 },


### PR DESCRIPTION
MAPSME-4088

В Панаме государственный язык — испанский. Мы этого не знали.