### PR TITLE
Fix build

### DIFF
--- a/search/nearby_points_sweeper.hpp
+++ b/search/nearby_points_sweeper.hpp
@@ -3,6 +3,7 @@
 #include "base/assert.hpp"
 
 #include "std/algorithm.hpp"
+#include "std/cmath.hpp"
 #include "std/cstdint.hpp"
 #include "std/limits.hpp"
 #include "std/set.hpp"


### PR DESCRIPTION
Without this modification, the build barfs on using fabs()
on Linux 4.10, glibc 2.25, clang 4.0

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>