### PR TITLE
CrossMwmIndexGraph::GetEdgeList(...) implementation.

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -2,6 +2,7 @@
 
 #include "base/assert.hpp"
 #include "base/cancellable.hpp"
+
 #include "std/algorithm.hpp"
 #include "std/functional.hpp"
 #include "std/iostream.hpp"

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -2,7 +2,6 @@
 
 #include "base/assert.hpp"
 #include "base/cancellable.hpp"
-
 #include "std/algorithm.hpp"
 #include "std/functional.hpp"
 #include "std/iostream.hpp"

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -401,7 +401,6 @@ CarRouter::ResultCode CarRouter::CalculateRoute(m2::PointD const & startPoint,
                                                 m2::PointD const & finalPoint,
                                                 RouterDelegate const & delegate, Route & route)
 {
-// TODO uncomment this to activate cross mwm index router.
   if (AllMwmsHaveRoutingIndex())
     return m_router->CalculateRoute(startPoint, startDirection, finalPoint, delegate, route);
 

--- a/routing/car_router.cpp
+++ b/routing/car_router.cpp
@@ -402,8 +402,8 @@ CarRouter::ResultCode CarRouter::CalculateRoute(m2::PointD const & startPoint,
                                                 RouterDelegate const & delegate, Route & route)
 {
 // TODO uncomment this to activate cross mwm index router.
-//  if (AllMwmsHaveRoutingIndex())
-//    return m_router->CalculateRoute(startPoint, startDirection, finalPoint, delegate, route);
+  if (AllMwmsHaveRoutingIndex())
+    return m_router->CalculateRoute(startPoint, startDirection, finalPoint, delegate, route);
 
   my::HighResTimer timer(true);
 

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -117,7 +117,7 @@ void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMap
 
   // OSRM and AStar have different car models, therefore AStar heuristic doesn't work for OSRM node
   // ids (edges).
-  // This factor makes index graph (used in AStar) edge weight smaller then node ids weight.
+  // This factor makes index graph (used in AStar) edge weight smaller than node ids weight.
   //
   // As a result large cross mwm routes with connectors works as Dijkstra, but short and medium routes
   // without connectors works as AStar.
@@ -138,6 +138,7 @@ CrossMwmIndexGraph::CrossMwmIndexGraph(shared_ptr<NumMwmIds> numMwmIds,
 }
 
 CrossMwmIndexGraph::~CrossMwmIndexGraph() {}
+
 bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
 {
   // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -1,4 +1,6 @@
 #include "routing/cross_mwm_index_graph.hpp"
+#include "routing/cross_mwm_road_graph.hpp"
+#include "routing/osrm_path_segment_factory.hpp"
 
 #include "base/macros.hpp"
 #include "base/stl_helpers.hpp"
@@ -12,8 +14,33 @@ using namespace std;
 
 namespace
 {
-bool GetTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
-                          NumMwmId numMwmId, Segment & segment)
+/// \returns FtSeg by |segment|.
+OsrmMappingTypes::FtSeg GetFtSeg(Segment const & segment)
+{
+  uint32_t const startPnt = segment.IsForward() ? segment.GetPointId(false /* front */)
+                                                : segment.GetPointId(true /* front */);
+  uint32_t const endPnt = segment.IsForward() ? segment.GetPointId(true /* front */)
+                                              : segment.GetPointId(false /* front */);
+  return OsrmMappingTypes::FtSeg(segment.GetFeatureId(), startPnt, endPnt);
+}
+
+/// \returns a pair of direct and reverse(backward) node id by |segment|.
+/// The first member of the pair is direct node id and the second is reverse node id.
+pair<TOsrmNodeId, TOsrmNodeId> GetDirectAndReverseNodeId(
+    OsrmFtSegMapping const & segMapping, Segment const & segment)
+{
+  OsrmFtSegMapping::TFtSegVec const ftSegs = {GetFtSeg(segment)};
+  OsrmFtSegMapping::OsrmNodesT nodeIds;
+  segMapping.GetOsrmNodes(ftSegs, nodeIds);
+  CHECK_LESS(nodeIds.size(), 2, ());
+  return nodeIds.empty() ? make_pair(INVALID_NODE_ID, INVALID_NODE_ID)
+                         : segment.IsForward() ? nodeIds.begin()->second
+                                               : std::make_pair(nodeIds.begin()->second.second,
+                                                                nodeIds.begin()->second.first);
+}
+
+bool GetFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId,
+                          TWrittenNodeId nodeId, Segment & segment)
 {
   auto const range = segMapping.GetSegmentsRange(nodeId);
   for (size_t segmentIndex = range.first; segmentIndex != range.second; ++segmentIndex)
@@ -22,6 +49,7 @@ bool GetTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId no
     // The meaning of node id in osrm is an edge between two joints.
     // So, it's possible to consider the first valid segment from the range which returns by GetSegmentsRange().
     segMapping.GetSegmentByIndex(segmentIndex, seg);
+
     if (!seg.IsValid())
       continue;
 
@@ -29,69 +57,96 @@ bool GetTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId no
     segment = Segment(numMwmId, seg.m_fid, min(seg.m_pointStart, seg.m_pointEnd), seg.IsForward());
     return true;
   }
-  LOG(LERROR, ("No valid segments in the range returned by OsrmFtSegMapping::GetSegmentsRange(", nodeId,
+  LOG(LDEBUG, ("No valid segments in the range returned by OsrmFtSegMapping::GetSegmentsRange(", nodeId,
                "). Num mwm id:", numMwmId));
   return false;
 }
 
-void AddTransitionSegment(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
-                          NumMwmId numMwmId, std::vector<Segment> & segments)
+void AddFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId,
+                          TWrittenNodeId nodeId, vector<Segment> & segments)
 {
   Segment key;
-  if (GetTransitionSegment(segMapping, nodeId, numMwmId, key))
+  if (GetFirstValidSegment(segMapping, numMwmId, nodeId, key))
     segments.push_back(key);
 }
 
 void FillTransitionSegments(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
                             NumMwmId numMwmId, ms::LatLon const & latLon,
-                            std::map<Segment, ms::LatLon> & transitionSegments)
+                            std::map<Segment, std::vector<ms::LatLon>> & transitionSegments)
 {
   Segment key;
-  if (!GetTransitionSegment(segMapping, nodeId, numMwmId, key))
+  if (!GetFirstValidSegment(segMapping, numMwmId, nodeId, key))
     return;
 
-  auto const p = transitionSegments.emplace(key, latLon);
-  if (p.second)
-    return;
-
-  // @TODO(bykoianko) It's necessary to investigate this case.
-  LOG(LWARNING, ("Trying to insert a transition segment that was previously inserted. The key:",
-                 *p.first, ", the value:", latLon));
+  transitionSegments[key].push_back(latLon);
 }
 
-ms::LatLon const & GetLatLon(std::map<Segment, ms::LatLon> const & segMap, Segment const & s)
+vector<ms::LatLon> const & GetLatLon(std::map<Segment, std::vector<ms::LatLon>> const & segMap,
+                                     Segment const & s)
 {
   auto it = segMap.find(s);
   CHECK(it != segMap.cend(), ());
   return it->second;
 }
+
+void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMapping,
+                    CrossWeightedEdge const & osrmEdge, bool isOutgoing, NumMwmId numMwmId,
+                    vector<SegmentEdge> & edges)
+{
+  BorderCross const & target = osrmEdge.GetTarget();
+  CrossNode const & crossNode = isOutgoing ? target.fromNode : target.toNode;
+
+  if (!crossNode.mwmId.IsAlive())
+    return;
+
+  NumMwmId const crossNodeMwmId = numMwmIds.GetId(crossNode.mwmId.GetInfo()->GetLocalFile().GetCountryFile());
+  CHECK_EQUAL(numMwmId, crossNodeMwmId, ());
+
+  Segment segment;
+  if (!GetFirstValidSegment(segMapping, crossNodeMwmId, crossNode.node, segment))
+    return;
+
+  // OSRM and AStar have different car models, therefore AStar heuristic doen't work for OSRM edges.
+  // This factor makes AStar heuristic much smaller then OSRM egdes.
+  //
+  // As a result large cross mwm routes mith leap works as Dijkstra, but short and medium routes without leaps works as AStar.
+  // Most of routes doen't use leaps, therefore it is important to keep AStar performance.
+  double constexpr kAstarHeuristicFactor = 100000;
+  edges.emplace_back(segment, osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier * kAstarHeuristicFactor);
+}
 }  // namespace
 
 namespace routing
 {
+CrossMwmIndexGraph::CrossMwmIndexGraph(shared_ptr<NumMwmIds> numMwmIds, RoutingIndexManager & indexManager)
+  : m_indexManager(indexManager), m_numMwmIds(numMwmIds)
+{
+  InitCrossMwmGraph();
+}
+
+CrossMwmIndexGraph::~CrossMwmIndexGraph() {}
+
 bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
 {
   // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
   // and if so to use it. If not, osrm cross mwm sections should be used.
 
   // Checking if a segment |s| is a transition segment by osrm cross mwm sections.
-  auto it = m_transitionCache.find(s.GetMwmId());
-  if (it == m_transitionCache.cend())
-  {
-    InsertWholeMwmTransitionSegments(s.GetMwmId());
-    it = m_transitionCache.find(s.GetMwmId());
-  }
-  CHECK(it != m_transitionCache.cend(),
-        ("Mwm ", s.GetMwmId(), "has not been downloaded. s:", s, ". isOutgoing", isOutgoing));
+  TransitionSegments const & t = GetSegmentMaps(s.GetMwmId());
 
   if (isOutgoing)
-    return it->second.m_outgoing.count(s) != 0;
-  return it->second.m_ingoing.count(s) != 0;
+    return t.m_outgoing.count(s) != 0;
+  return t.m_ingoing.count(s) != 0;
 }
 
-void CrossMwmIndexGraph::GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins)
+void CrossMwmIndexGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
 {
   CHECK(IsTransition(s, isOutgoing), ("The segment is not a transition segment."));
+  // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
+  // |twins| is not filled for such cases. For details please see a note in rossMwmIndexGraph::GetEdgeList().
+  if (IsTransition(s, !isOutgoing))
+    return;
+
   twins.clear();
   // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
   // and if so to use it. If not, osrm cross mwm sections should be used.
@@ -106,46 +161,90 @@ void CrossMwmIndexGraph::GetTwins(Segment const & s, bool isOutgoing, std::vecto
     auto it = m_transitionCache.find(s.GetMwmId());
     CHECK(it != m_transitionCache.cend(), ());
 
-    ms::LatLon const & latLon = isOutgoing ? GetLatLon(it->second.m_outgoing, s)
-                                           : GetLatLon(it->second.m_ingoing, s);
+    vector<ms::LatLon> const & latLons = isOutgoing ? GetLatLon(it->second.m_outgoing, s)
+                                                    : GetLatLon(it->second.m_ingoing, s);
     for (string const & name : neighboringMwm)
     {
-      auto const addTransitionSegments = [&](NumMwmId numMwmId, TRoutingMappingPtr const & mapping)
+      auto const addFirstValidSegment = [&](NumMwmId numMwmId, TRoutingMappingPtr const & mapping)
       {
-        if (isOutgoing)
+        for (ms::LatLon const & ll : latLons)
         {
-          mapping->m_crossContext.ForEachIngoingNodeNearPoint(latLon, [&](IngoingCrossNode const & node){
-            AddTransitionSegment(mapping->m_segMapping, node.m_nodeId, numMwmId, twins);
-          });
-        }
-        else
-        {
-          mapping->m_crossContext.ForEachOutgoingNodeNearPoint(latLon, [&](OutgoingCrossNode const & node){
-            AddTransitionSegment(mapping->m_segMapping, node.m_nodeId, numMwmId, twins);
-          });
+          if (isOutgoing)
+          {
+            mapping->m_crossContext.ForEachIngoingNodeNearPoint(ll, [&](IngoingCrossNode const & node){
+              AddFirstValidSegment(mapping->m_segMapping, numMwmId, node.m_nodeId, twins);
+            });
+          }
+          else
+          {
+            mapping->m_crossContext.ForEachOutgoingNodeNearPoint(ll, [&](OutgoingCrossNode const & node){
+              AddFirstValidSegment(mapping->m_segMapping, numMwmId, node.m_nodeId, twins);
+            });
+          }
         }
       };
 
-      if (!LoadWith(m_numMwmIds->GetId(CountryFile(name)), addTransitionSegments))
+      if (!LoadWith(m_numMwmIds->GetId(CountryFile(name)), addFirstValidSegment))
         continue;  // mwm was not loaded.
     }
   };
 
   LoadWith(s.GetMwmId(), getTwins);
   my::SortUnique(twins);
+
+  for (Segment const & t : twins)
+    CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
 }
 
-void CrossMwmIndexGraph::GetEdgeList(Segment const & /* s */,
-                                     bool /* isOutgoing */, std::vector<SegmentEdge> & /* edges */) const
+void CrossMwmIndexGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
 {
   // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
   // and if so to use it. If not, osrm cross mwm sections should be used.
-  NOTIMPLEMENTED();
+
+  CHECK(IsTransition(s, !isOutgoing), ());
+
+  // Note. According to cross-mwm OSRM sections there're node id which could be ingoing and outgoing
+  // at the same time. For example in Berlin mwm on Nordlicher Berliner Ring (A10) near crossing with A11
+  // there's such node id. It's an extremely rare case. There're probably several such node id
+  // for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time being.
+  // To prevent filling |edges| with twins instead of leap edges and vice versa in WorldGraph::GetEdgeList()
+  // CrossMwmIndexGraph::GetEdgeList() does not fill |edges| if |s| is a transition segment which
+  // corresponces node id described above.
+  if (IsTransition(s, isOutgoing))
+    return;
+
+  edges.clear();
+  auto const  fillEdgeList = [&](NumMwmId /* numMwmId */, TRoutingMappingPtr const & mapping){
+    vector<BorderCross> borderCrosses;
+    GetBorderCross(mapping, s, isOutgoing, borderCrosses);
+
+    for (BorderCross const v : borderCrosses)
+    {
+      vector<CrossWeightedEdge> adj;
+      if (isOutgoing)
+        m_crossMwmGraph->GetOutgoingEdgesList(v, adj);
+      else
+        m_crossMwmGraph->GetIngoingEdgesList(v, adj);
+
+      for (CrossWeightedEdge const & a : adj)
+        AddSegmentEdge(*m_numMwmIds, mapping->m_segMapping, a, isOutgoing, s.GetMwmId(), edges);
+    }
+  };
+  LoadWith(s.GetMwmId(), fillEdgeList);
+
+  my::SortUnique(edges);
 }
 
 void CrossMwmIndexGraph::Clear()
 {
+  InitCrossMwmGraph();
   m_transitionCache.clear();
+  m_mappingGuards.clear();
+}
+
+void CrossMwmIndexGraph::InitCrossMwmGraph()
+{
+  m_crossMwmGraph = make_unique<CrossMwmGraph>(m_indexManager);
 }
 
 void CrossMwmIndexGraph::InsertWholeMwmTransitionSegments(NumMwmId numMwmId)
@@ -173,5 +272,83 @@ void CrossMwmIndexGraph::InsertWholeMwmTransitionSegments(NumMwmId numMwmId)
 
   if (!LoadWith(numMwmId, fillAllTransitionSegments))
     m_transitionCache.emplace(numMwmId, TransitionSegments());
+}
+
+void CrossMwmIndexGraph::GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s, bool isOutgoing,
+                                        vector<BorderCross> & borderCrosses)
+{
+  // ingoing edge
+  pair<TOsrmNodeId, TOsrmNodeId> const directReverseTo = GetDirectAndReverseNodeId(mapping->m_segMapping, s);
+
+  vector<ms::LatLon> const & transitionPnt = isOutgoing ? GetIngoingTransitionPnt(s)
+                                                        : GetOutgoingTransitionPnt(s);
+  CHECK(!transitionPnt.empty(), ());
+
+  // If |isOutgoing| == true |nodes| is "to" cross nodes, otherwise |nodes| is "from" cross nodes.
+  vector<CrossNode> nodes;
+  for (ms::LatLon const & p : transitionPnt)
+    nodes.emplace_back(directReverseTo.first, directReverseTo.second, mapping->GetMwmId(), p);
+
+  // outgoing edge
+  vector<Segment> twins;
+  GetTwins(s, !isOutgoing, twins);
+  CHECK(!twins.empty(), ());
+  for (Segment const & twin : twins)
+  {
+    // If |isOutgoing| == true |otherSideMapping| is mapping outgoing (to) border cross.
+    // If |isOutgoing| == false |mapping| is mapping ingoing (from) border cross.
+    auto const fillBorderCrossOut = [&](NumMwmId /* otherSideNumMwmId */, TRoutingMappingPtr const & otherSideMapping){
+      pair<TOsrmNodeId, TOsrmNodeId> directReverseFrom = GetDirectAndReverseNodeId(otherSideMapping->m_segMapping, twin);
+      vector<ms::LatLon> const & otherSideTransitionPnt = isOutgoing ? GetOutgoingTransitionPnt(twin)
+                                                                     : GetIngoingTransitionPnt(twin);
+
+      CHECK(!otherSideTransitionPnt.empty(), ());
+      for (CrossNode const & node : nodes)
+      {
+        // If |isOutgoing| == true |otherSideNodes| is "from" cross nodes, otherwise |otherSideNodes| is "to" cross nodes.
+        BorderCross bc;
+        if (isOutgoing)
+          bc.toNode = node;
+        else
+          bc.fromNode = node;
+
+        for (ms::LatLon const & ll : otherSideTransitionPnt)
+        {
+          CrossNode & resultNode = isOutgoing ? bc.fromNode : bc.toNode;
+          resultNode = CrossNode(directReverseFrom.first, directReverseFrom.second, otherSideMapping->GetMwmId(), ll);
+          borderCrosses.push_back(bc);
+        }
+      }
+    };
+    LoadWith(twin.GetMwmId(), fillBorderCrossOut);
+  }
+}
+
+CrossMwmIndexGraph::TransitionSegments const & CrossMwmIndexGraph::GetSegmentMaps(NumMwmId numMwmId)
+{
+  auto it = m_transitionCache.find(numMwmId);
+  if (it == m_transitionCache.cend())
+  {
+    InsertWholeMwmTransitionSegments(numMwmId);
+    it = m_transitionCache.find(numMwmId);
+  }
+  CHECK(it != m_transitionCache.cend(), ("Mwm ", numMwmId, "has not been downloaded."));
+  return it->second;
+}
+
+vector<ms::LatLon> const & CrossMwmIndexGraph::GetIngoingTransitionPnt(Segment const & s)
+{
+  auto const & ingoingSeg = GetSegmentMaps(s.GetMwmId()).m_ingoing;
+  auto const it = ingoingSeg.find(s);
+  CHECK(it != ingoingSeg.cend(), ());
+  return it->second;
+}
+
+vector<ms::LatLon> const & CrossMwmIndexGraph::GetOutgoingTransitionPnt(Segment const & s)
+{
+  auto const & outgoingSeg = GetSegmentMaps(s.GetMwmId()).m_outgoing;
+  auto const it = outgoingSeg.find(s);
+  CHECK(it != outgoingSeg.cend(), ());
+  return it->second;
 }
 }  // namespace routing

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -84,7 +84,7 @@ private:
     std::map<Segment, std::vector<ms::LatLon>> m_outgoing;
   };
 
-  void InitCrossMwmGraph();
+  void ResetCrossMwmGraph();
 
   /// \brief Inserts all ingoing and outgoing transition segments of mwm with |numMwmId|
   /// to |m_transitionCache|.
@@ -96,12 +96,12 @@ private:
   /// \note |s| and |isOutgoing| params have the same restrictions which described in
   /// GetEdgeList() method.
   void GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s, bool isOutgoing,
-                      vector<BorderCross> & borderCrosses);
+                      std::vector<BorderCross> & borderCrosses);
 
   TransitionSegments const & GetSegmentMaps(NumMwmId numMwmId);
 
-  vector<ms::LatLon> const & GetIngoingTransitionPnt(Segment const & s);
-  vector<ms::LatLon> const & GetOutgoingTransitionPnt(Segment const & s);
+  std::vector<ms::LatLon> const & GetIngoingTransitionPoints(Segment const & s);
+  std::vector<ms::LatLon> const & GetOutgoingTransitionPoints(Segment const & s);
 
   template <class Fn>
   bool LoadWith(NumMwmId numMwmId, Fn && fn)
@@ -120,13 +120,13 @@ private:
       mapping->LoadCrossContext();
     }
 
-    fn(numMwmId, mapping);
+    fn(mapping);
     return true;
   }
 
   RoutingIndexManager & m_indexManager;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
-  /// \note According to the constructor CrossMwmGraph is inited with RoutingIndexManager &.
+  /// \note According to the constructor CrossMwmGraph is initialized with RoutingIndexManager &.
   /// But then it is copied by value to CrossMwmGraph::RoutingIndexManager m_indexManager.
   /// It means that there're two copies of RoutingIndexManager in CrossMwmIndexGraph.
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;

--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -109,16 +109,16 @@ template <class Node>
 bool FindCrossNode(CrossRoutingContextReader const & currentContext, CrossNode const & crossNode,
                    Node & node)
 {
-  double minDistance = std::numeric_limits<double>::max();
+  double constexpr kInvalidDistance = std::numeric_limits<double>::max();
+  double minDistance = kInvalidDistance;
   ClosestNodeFinder<Node> findingNode(crossNode, minDistance, node);
   CHECK(ForEachNodeNearPoint(currentContext, crossNode.point, findingNode), ());
-  if (minDistance == std::numeric_limits<double>::max())
+  if (minDistance == kInvalidDistance)
   {
     LOG(LWARNING, ("Cross node is not found. Point:", crossNode.point));
     return false;
   }
   return true;
-
 }
 
 template <class Fn>

--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -92,28 +92,33 @@ private:
 };
 
 bool ForEachNodeNearPoint(CrossRoutingContextReader const & currentContext,
-                          CrossNode const & crossNode,
+                          ms::LatLon const & point,
                           ClosestNodeFinder<IngoingCrossNode> const & findingNode)
 {
-  return currentContext.ForEachIngoingNodeNearPoint(crossNode.point, findingNode);
+  return currentContext.ForEachIngoingNodeNearPoint(point, findingNode);
 }
 
 bool ForEachNodeNearPoint(CrossRoutingContextReader const & currentContext,
-                          CrossNode const & crossNode,
+                          ms::LatLon const & point,
                           ClosestNodeFinder<OutgoingCrossNode> const & findingNode)
 {
-  return currentContext.ForEachOutgoingNodeNearPoint(crossNode.point, findingNode);
+  return currentContext.ForEachOutgoingNodeNearPoint(point, findingNode);
 }
 
 template <class Node>
-void FindCrossNode(CrossRoutingContextReader const & currentContext, CrossNode const & crossNode,
+bool FindCrossNode(CrossRoutingContextReader const & currentContext, CrossNode const & crossNode,
                    Node & node)
 {
   double minDistance = std::numeric_limits<double>::max();
   ClosestNodeFinder<Node> findingNode(crossNode, minDistance, node);
-  CHECK(ForEachNodeNearPoint(currentContext, crossNode, findingNode), ());
-  CHECK_NOT_EQUAL(minDistance, std::numeric_limits<double>::max(),
-                  ("crossNode.point:", crossNode.point));
+  CHECK(ForEachNodeNearPoint(currentContext, crossNode.point, findingNode), ());
+  if (minDistance == std::numeric_limits<double>::max())
+  {
+    LOG(LWARNING, ("Cross node is not found. Point:", crossNode.point));
+    return false;
+  }
+  return true;
+
 }
 
 template <class Fn>
@@ -121,7 +126,7 @@ vector<BorderCross> const & ConstructBorderCrossImpl(
     TWrittenNodeId nodeId, TRoutingMappingPtr const & currentMapping,
     unordered_map<CrossMwmGraph::TCachingKey, vector<BorderCross>, CrossMwmGraph::Hash> const &
         cachedNextNodes,
-    Fn && borderCrossConstructor /*bool & result*/)
+    Fn && borderCrossConstructor)
 {
   auto const key = make_pair(nodeId, currentMapping->GetMwmId());
   auto const it = cachedNextNodes.find(key);
@@ -180,6 +185,7 @@ IRouter::ResultCode CrossMwmGraph::SetStartNode(CrossNode const & startNode)
     {
       vector<BorderCross> const & nextCrosses =
           ConstructBorderCross(startMapping, outgoingNodes[i]);
+
       for (auto const & nextCross : nextCrosses)
       {
         if (nextCross.toNode.IsValid())
@@ -380,14 +386,22 @@ void CrossMwmGraph::GetEdgesList(BorderCross const & v, bool isOutgoing,
   if (isOutgoing)
   {
     IngoingCrossNode ingoingNode;
-    FindCrossNode<IngoingCrossNode>(currentContext, v.toNode, ingoingNode);
+    if (!FindCrossNode<IngoingCrossNode>(currentContext, v.toNode, ingoingNode))
+      return;
+    if (!ingoingNode.IsValid())
+      return;
+
     currentContext.ForEachOutgoingNode(EdgesFiller<IngoingCrossNode, OutgoingCrossNode>(
         currentMapping, currentContext, ingoingNode, *this, adj));
   }
   else
   {
     OutgoingCrossNode outgoingNode;
-    FindCrossNode<OutgoingCrossNode>(currentContext, v.fromNode, outgoingNode);
+    if (!FindCrossNode<OutgoingCrossNode>(currentContext, v.fromNode, outgoingNode))
+      return;
+    if (!outgoingNode.IsValid())
+      return;
+
     currentContext.ForEachIngoingNode(EdgesFiller<OutgoingCrossNode, IngoingCrossNode>(
         currentMapping, currentContext, outgoingNode, *this, adj));
   }

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/car_router.hpp"
+#include "routing/cross_mwm_router.hpp"
 #include "routing/osrm_engine.hpp"
 #include "routing/router.hpp"
 
@@ -93,6 +94,16 @@ public:
   inline BorderCross const & GetTarget() const { return target; }
   inline double GetWeight() const { return weight; }
 
+  inline bool operator==(CrossWeightedEdge const & a) const
+  {
+    return target == a.target && weight == a.weight;
+  }
+
+  inline bool operator<(CrossWeightedEdge const & a) const
+  {
+    return target < a.target && weight < a.weight;
+  }
+
 private:
   BorderCross target;
   double weight;
@@ -115,6 +126,7 @@ public:
   };
 
   explicit CrossMwmGraph(RoutingIndexManager & indexManager) : m_indexManager(indexManager) {}
+
   void GetOutgoingEdgesList(BorderCross const & v, vector<CrossWeightedEdge> & adj) const
   {
     GetEdgesList(v, true /* isOutgoing */, adj);

--- a/routing/cross_routing_context.hpp
+++ b/routing/cross_routing_context.hpp
@@ -34,10 +34,13 @@ struct IngoingCrossNode
     , m_adjacencyIndex(kInvalidAdjacencyIndex)
   {
   }
+
   IngoingCrossNode(TWrittenNodeId nodeId, ms::LatLon const & point, size_t const adjacencyIndex)
     : m_point(point), m_nodeId(nodeId), m_adjacencyIndex(adjacencyIndex)
   {
   }
+
+  bool IsValid() const { return m_nodeId != kInvalidContextEdgeNodeId; }
 
   void Save(Writer & w) const;
 
@@ -60,6 +63,7 @@ struct OutgoingCrossNode
     , m_adjacencyIndex(kInvalidAdjacencyIndex)
   {
   }
+
   OutgoingCrossNode(TWrittenNodeId nodeId, size_t const index, ms::LatLon const & point,
                     size_t const adjacencyIndex)
     : m_point(point)
@@ -68,6 +72,8 @@ struct OutgoingCrossNode
     , m_adjacencyIndex(adjacencyIndex)
   {
   }
+
+  bool IsValid() const { return m_nodeId != kInvalidContextEdgeNodeId; }
 
   void Save(Writer & w) const;
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -239,8 +239,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     CHECK_LESS(i, input.size(), ());
     Segment const & next = input[i];
 
-    CHECK_EQUAL(current.GetMwmId(), next.GetMwmId(),
-                ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
+    CHECK_EQUAL(
+        current.GetMwmId(), next.GetMwmId(),
+        ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
 
     IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */));
     IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */));

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -238,8 +238,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     ++i;
     CHECK_LESS(i, input.size(), ());
     Segment const & next = input[i];
+
     CHECK_EQUAL(current.GetMwmId(), next.GetMwmId(),
-                ("Different mwm ids for leap enter and exit, i:", i));
+                ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
 
     IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */));
     IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */));

--- a/routing/osrm2feature_map.hpp
+++ b/routing/osrm2feature_map.hpp
@@ -166,6 +166,10 @@ public:
   /// @name For unit test purpose only.
   //@{
   /// @return STL-like range [s, e) of segments indexies for passed node.
+  /// @note Methods GetSegmentsRange(...) and GetOsrmNodes(...) are not symmetric.
+  /// For example in Tverskay Oblast for node id 161179 two FtSet can be gotten
+  /// with GetSegmentsRange() / GetSegmentByIndex().
+  /// But having these segments it's impossible to get node id 161179 with the help of GetOsrmNodes(...).
   pair<size_t, size_t> GetSegmentsRange(TOsrmNodeId nodeId) const;
   /// @return Node id for segment's index.
   TOsrmNodeId GetNodeId(uint32_t segInd) const;

--- a/routing/osrm2feature_map.hpp
+++ b/routing/osrm2feature_map.hpp
@@ -169,7 +169,8 @@ public:
   /// @note Methods GetSegmentsRange(...) and GetOsrmNodes(...) are not symmetric.
   /// For example in Tverskay Oblast for node id 161179 two FtSet can be gotten
   /// with GetSegmentsRange() / GetSegmentByIndex().
-  /// But having these segments it's impossible to get node id 161179 with the help of GetOsrmNodes(...).
+  /// But having these segments it's impossible to get node id 161179 with the help of
+  /// GetOsrmNodes(...).
   pair<size_t, size_t> GetSegmentsRange(TOsrmNodeId nodeId) const;
   /// @return Node id for segment's index.
   TOsrmNodeId GetNodeId(uint32_t segInd) const;

--- a/routing/osrm_engine.hpp
+++ b/routing/osrm_engine.hpp
@@ -43,7 +43,7 @@ struct FeatureGraphNode
 struct RawPathData
 {
   NodeID node;
-  EdgeWeight segmentWeight;
+  EdgeWeight segmentWeight;  // Time in tenths of a second to pass |node|.
 
   RawPathData() : node(SPECIAL_NODEID), segmentWeight(INVALID_EDGE_WEIGHT) {}
 

--- a/routing/osrm_path_segment_factory.cpp
+++ b/routing/osrm_path_segment_factory.cpp
@@ -12,9 +12,6 @@
 
 namespace
 {
-// Osrm multiples seconds to 10, so we need to divide it back.
-double constexpr kOSRMWeightToSecondsMultiplier = 1. / 10.;
-
 using TSeg = routing::OsrmMappingTypes::FtSeg;
 
 void LoadPathGeometry(buffer_vector<TSeg, 8> const & buffer, size_t startIndex,

--- a/routing/osrm_path_segment_factory.hpp
+++ b/routing/osrm_path_segment_factory.hpp
@@ -9,7 +9,7 @@ struct RawPathData;
 struct RoutingMapping;
 
 // Osrm multiples seconds to 10, so we need to divide it back.
-double constexpr kOSRMWeightToSecondsMultiplier = 1. / 10.;
+double constexpr kOSRMWeightToSecondsMultiplier = 0.1;
 
 // General constructor.
 void OsrmPathSegmentFactory(RoutingMapping & mapping, Index const & index,

--- a/routing/osrm_path_segment_factory.hpp
+++ b/routing/osrm_path_segment_factory.hpp
@@ -8,6 +8,9 @@ struct FeatureGraphNode;
 struct RawPathData;
 struct RoutingMapping;
 
+// Osrm multiples seconds to 10, so we need to divide it back.
+double constexpr kOSRMWeightToSecondsMultiplier = 1. / 10.;
+
 // General constructor.
 void OsrmPathSegmentFactory(RoutingMapping & mapping, Index const & index,
                             RawPathData const & osrmPathSegment, LoadedPathSegment & loadedPathSegment);

--- a/routing/routing_integration_tests/cross_section_tests.cpp
+++ b/routing/routing_integration_tests/cross_section_tests.cpp
@@ -199,6 +199,7 @@ UNIT_TEST(CrossMwmGraphTest)
       ++ingoingCounter;
       vector<BorderCross> const & targets =
           crossMwmGraph.ConstructBorderCross(currentMapping, node);
+
       for (BorderCross const & t : targets)
       {
         vector<CrossWeightedEdge> outAdjs;

--- a/routing/routing_tests/cross_routing_tests.cpp
+++ b/routing/routing_tests/cross_routing_tests.cpp
@@ -165,4 +165,12 @@ UNIT_TEST(TestFindingByPoint)
   TEST(!newContext.ForEachOutgoingNodeNearPoint(p3, fnOutgoing), ());
   TEST(outgoingNode.empty(), ());
 }
+UNIT_TEST(TestCrossWeightedEdgeComparator)
+{
+  CrossNode const from(0, Index::MwmId(), ms::LatLon::Zero());
+  CrossWeightedEdge const lhs(BorderCross(from, {1, Index::MwmId(), ms::LatLon::Zero()}), 2.0);
+  CrossWeightedEdge const rhs(BorderCross(from, {2, Index::MwmId(), ms::LatLon::Zero()}), 1.0);
+
+  TEST(lhs < rhs || rhs < lhs || lhs == rhs, ());
+}
 }  // namespace

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -80,6 +80,13 @@ public:
     return m_target == edge.m_target && m_weight == edge.m_weight;
   }
 
+  bool operator< (SegmentEdge const & edge) const
+  {
+    if (m_target != edge.m_target)
+      return m_target < edge.m_target;
+    return m_weight < edge.m_weight;
+  }
+
 private:
   // Target is vertex going to for outgoing edges, vertex going from for ingoing edges.
   Segment m_target;

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -37,6 +37,9 @@ public:
     return m_forward == front ? m_segmentIdx + 1 : m_segmentIdx;
   }
 
+  uint32_t GetMinPointId() const { return m_segmentIdx; }
+  uint32_t GetMaxPointId() const { return m_segmentIdx + 1; }
+
   RoadPoint GetRoadPoint(bool front) const { return RoadPoint(m_featureId, GetPointId(front)); }
 
   bool operator<(Segment const & seg) const
@@ -80,7 +83,7 @@ public:
     return m_target == edge.m_target && m_weight == edge.m_weight;
   }
 
-  bool operator< (SegmentEdge const & edge) const
+  bool operator<(SegmentEdge const & edge) const
   {
     if (m_target != edge.m_target)
       return m_target < edge.m_target;


### PR DESCRIPTION
* реализация метода для получения списка прескоков в cross mwm-ом роутинге на базе OSRM;
* реализовано кеширование MappingGuard при кросс mwm-ом роутинге;
* включен WorldGraph;

Данный PR тестировался на маршрутах:
Москва - Лиссабон, Москва - Париж, Москва - Берлин, Москва - Минск

@dobriy-eeh @ygorshenin @mpimenov PTAL