### PR TITLE
Fix up "CONFIG=gtool build_omim.sh -cro"

### DIFF
--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -118,7 +118,7 @@ build_conf_osrm()
       mkdir -p "$DIRNAME"
       cd "$DIRNAME"
       cmake "$OMIM_PATH"
-      make routing indexer geometry coding base jansson -j $PROCESSES
+      make routing routing_common indexer geometry coding base jansson -j $PROCESSES
     else
       "$QMAKE" "$OMIM_PATH/omim.pro" ${SPEC:+-spec $SPEC} "CONFIG+=$CONF osrm no-tests" ${CONFIG+"CONFIG*=$CONFIG"}
       make -j $PROCESSES


### PR DESCRIPTION
Without this patch, building barfs while trying to link OSRM because it
can't find librouting_common.a in the requested location.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>