### PR TITLE
[android] Mapsme 4114 fb banners cache

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   compile('com.crashlytics.sdk.android:crashlytics-ndk:1.1.2@aar') { transitive = true }
   // 3-party
   compile 'com.facebook.android:facebook-android-sdk:4.8.0'
-  compile('com.facebook.android:audience-network-sdk:4.8.0') {
+  compile('com.facebook.android:audience-network-sdk:4.20.0') {
     exclude group: 'com.google.android.gms'
   }
   compile 'com.google.code.gson:gson:2.6.1'
@@ -65,6 +65,7 @@ dependencies {
   compile 'com.github.bumptech.glide:glide:3.7.0'
   // Java concurrency annotations
   compile 'net.jcip:jcip-annotations:1.0'
+  compile 'com.android.support:multidex:1.0.1'
 }
 
 def getDate() {
@@ -110,6 +111,7 @@ android {
     manifestPlaceholders += ['PW_APPID': pwProps['pwAppId']]
     buildConfigField 'String', 'PW_APPID', /"${pwProps['pwAppId']}"/
     manifestPlaceholders += ['PW_PROJECT_ID': pwProps['pwProjectId']]
+    multiDexEnabled true
   }
 
   sourceSets.main {

--- a/android/res/layout/place_page_banner.xml
+++ b/android/res/layout/place_page_banner.xml
@@ -26,7 +26,7 @@
     android:textColor="?warmGray"
     android:background="?adsActionBackground"
     android:foreground="?clickableBackground"
-    android:visibility="visible"
+    android:visibility="gone"
     tools:text="Заказать"
     tools:visibility="visible"/>
 
@@ -65,6 +65,7 @@
         android:textSize="@dimen/text_size_banner"
         android:textColor="?adsText"
         android:gravity="center"
+        android:visibility="gone"
         android:background="?adsBackground"
         android:text="@string/advertisement"/>
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -998,6 +998,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mNavigationController.onResume();
     if (mNavAnimationController != null)
       mNavAnimationController.onResume();
+    mPlacePage.onActivityResume();
   }
 
   @Override
@@ -1040,6 +1041,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     TtsPlayer.INSTANCE.stop();
     LikesManager.INSTANCE.cancelDialogs();
     mOnmapDownloader.onPause();
+    mPlacePage.onActivityPause();
     super.onPause();
   }
 

--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -1,6 +1,7 @@
 package com.mapswithme.maps;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Environment;
@@ -9,6 +10,7 @@ import android.os.Message;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
+import android.support.multidex.MultiDex;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -126,6 +128,13 @@ public class MwmApplication extends Application
   public static boolean isCrashlyticsEnabled()
   {
     return !BuildConfig.FABRIC_API_KEY.startsWith("0000");
+  }
+
+  @Override
+  protected void attachBaseContext(Context base)
+  {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/android/src/com/mapswithme/maps/ads/AdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/AdTracker.java
@@ -1,0 +1,9 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+
+interface AdTracker
+{
+  void start(@NonNull String bannerId);
+  void stop(@NonNull String bannerId);
+}

--- a/android/src/com/mapswithme/maps/ads/AdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/AdTracker.java
@@ -2,8 +2,10 @@ package com.mapswithme.maps.ads;
 
 import android.support.annotation.NonNull;
 
-interface AdTracker
+public interface AdTracker
 {
-  void start(@NonNull String bannerId);
-  void stop(@NonNull String bannerId);
+  void onViewShown(@NonNull String bannerId);
+  void onViewHidden(@NonNull String bannerId);
+  void onContentObtained(@NonNull String bannerId);
+  boolean isImpressionGood(@NonNull String bannerId);
 }

--- a/android/src/com/mapswithme/maps/ads/AdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/AdTracker.java
@@ -2,7 +2,7 @@ package com.mapswithme.maps.ads;
 
 import android.support.annotation.NonNull;
 
-public interface AdTracker
+interface AdTracker
 {
   void onViewShown(@NonNull String bannerId);
   void onViewHidden(@NonNull String bannerId);

--- a/android/src/com/mapswithme/maps/ads/AdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/AdTracker.java
@@ -2,7 +2,12 @@ package com.mapswithme.maps.ads;
 
 import android.support.annotation.NonNull;
 
-interface AdTracker
+/**
+ * Represents a interface to track an ad visibility on the screen.
+ * As result, object of this class can conclude whether a tracked ad has a good impression indicator,
+ * i.e. has been shown enough time for user, or not.
+ */
+public interface AdTracker
 {
   void onViewShown(@NonNull String bannerId);
   void onViewHidden(@NonNull String bannerId);

--- a/android/src/com/mapswithme/maps/ads/BaseNativeAdLoader.java
+++ b/android/src/com/mapswithme/maps/ads/BaseNativeAdLoader.java
@@ -1,0 +1,21 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.Nullable;
+
+abstract class BaseNativeAdLoader implements NativeAdLoader
+{
+  @Nullable
+  private NativeAdListener mAdListener;
+
+  @Override
+  public void setAdListener(@Nullable NativeAdListener adListener)
+  {
+    mAdListener = adListener;
+  }
+
+  @Nullable
+  NativeAdListener getAdListener()
+  {
+    return mAdListener;
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
@@ -125,6 +125,10 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
           LOGGER.d(TAG, "it's a last time for this ad");
           return;
         }
+
+        if (mTimestamp == 0)
+          throw new AssertionError("A timestamp mustn't be 0 when ad is hidden!");
+
         mShowTime += SystemClock.elapsedRealtime() - mTimestamp;
         LOGGER.d(TAG, "A show time = " + mShowTime);
         mTimestamp = 0;

--- a/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
@@ -13,18 +13,18 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
 {
   private final static Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
   private final static String TAG = DefaultAdTracker.class.getSimpleName();
-  private final static int IMPRESSION_TIME_MS = 2000;
-  private final Map<String, TrackInfo> mTracks = new HashMap<>();
+  private final static int IMPRESSION_TIME_MS = 2500;
+  private final static Map<String, TrackInfo> TRACKS = new HashMap<>();
 
   @Override
   public void onViewShown(@NonNull String bannerId)
   {
     LOGGER.d(TAG, "onViewShown bannerId = " + bannerId);
-    TrackInfo info = mTracks.get(bannerId);
+    TrackInfo info = TRACKS.get(bannerId);
     if (info == null)
     {
       info = new TrackInfo();
-      mTracks.put(bannerId, info);
+      TRACKS.put(bannerId, info);
     }
     info.setVisible(true);
   }
@@ -33,18 +33,16 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
   public void onViewHidden(@NonNull String bannerId)
   {
     LOGGER.d(TAG, "onViewHidden bannerId = " + bannerId);
-    TrackInfo info = mTracks.get(bannerId);
-    if (info == null)
-      throw new AssertionError("A track info cannot be null because this method " +
-                               "is called only after onViewShown!");
-    info.setVisible(false);
+    TrackInfo info = TRACKS.get(bannerId);
+    if (info != null)
+      info.setVisible(false);
   }
 
   @Override
   public void onContentObtained(@NonNull String bannerId)
   {
     LOGGER.d(TAG, "onContentObtained bannerId = " + bannerId);
-    TrackInfo info = mTracks.get(bannerId);
+    TrackInfo info = TRACKS.get(bannerId);
     if (info == null)
       throw new AssertionError("A track info must be put in a cache before a content is obtained");
 
@@ -54,23 +52,23 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
   @Override
   public boolean isImpressionGood(@NonNull String bannerId)
   {
-    TrackInfo info = mTracks.get(bannerId);
+    TrackInfo info = TRACKS.get(bannerId);
     return info != null && info.getShowTime() > IMPRESSION_TIME_MS;
   }
 
   @Override
   public void onRemoved(@NonNull String bannerId)
   {
-    mTracks.remove(bannerId);
+    TRACKS.remove(bannerId);
   }
 
   @Override
   public void onPut(@NonNull String bannerId)
   {
-    TrackInfo info = mTracks.get(bannerId);
+    TrackInfo info = TRACKS.get(bannerId);
     if (info == null)
     {
-      mTracks.put(bannerId, new TrackInfo());
+      TRACKS.put(bannerId, new TrackInfo());
       return;
     }
 
@@ -128,6 +126,7 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
           return;
         }
         mShowTime += SystemClock.elapsedRealtime() - mTimestamp;
+        LOGGER.d(TAG, "A show time = " + mShowTime);
         mTimestamp = 0;
       }
     }

--- a/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
@@ -1,0 +1,125 @@
+package com.mapswithme.maps.ads;
+
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
+
+import com.mapswithme.util.log.Logger;
+import com.mapswithme.util.log.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
+{
+  private final static Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
+  private final static String TAG = DefaultAdTracker.class.getSimpleName();
+  private final static int GOOD_IMPRESSION_TIME_MS = 2000;
+  private final Map<String, TrackInfo> mTracks = new HashMap<>();
+
+  @Override
+  public void onViewShown(@NonNull String bannerId)
+  {
+    LOGGER.d(TAG, "onViewShown bannerId = " + bannerId);
+    TrackInfo info = mTracks.get(bannerId);
+    if (info != null)
+      info.setVisible(true);
+  }
+
+  @Override
+  public void onViewHidden(@NonNull String bannerId)
+  {
+    LOGGER.d(TAG, "onViewHidden bannerId = " + bannerId);
+    TrackInfo info = mTracks.get(bannerId);
+    if (info != null)
+      info.setVisible(false);
+  }
+
+  @Override
+  public void onContentObtained(@NonNull String bannerId)
+  {
+    LOGGER.d(TAG, "onContentObtained bannerId = " + bannerId);
+    TrackInfo info = mTracks.get(bannerId);
+    if (info == null)
+      throw new AssertionError("A track info must be put in a cache before a content is obtained");
+
+    info.fill();
+  }
+
+  @Override
+  public boolean isImpressionGood(@NonNull String bannerId)
+  {
+    TrackInfo info = mTracks.get(bannerId);
+    return info != null && info.getShowTime() > GOOD_IMPRESSION_TIME_MS;
+  }
+
+  @Override
+  public void onRemoved(@NonNull String id)
+  {
+    LOGGER.d(TAG, "onRemoved id = " + id);
+    mTracks.remove(id);
+  }
+
+  @Override
+  public void onPut(@NonNull String id)
+  {
+    LOGGER.d(TAG, "onPut id = " + id);
+    mTracks.put(id, new TrackInfo());
+  }
+
+  private static class TrackInfo
+  {
+    private long mTimestamp;
+    /**
+     * Accumulates amount of time that ad is already shown.
+     */
+    private long mShowTime;
+    /**
+     * Indicates whether the ad view is visible or not.
+     */
+    private boolean mVisible;
+    /**
+     * Indicates whether the ad content is obtained or not.
+     */
+    private boolean mFilled;
+
+    public void setVisible(boolean visible)
+    {
+      // No need tracking if the ad is not filled with a content
+      if (!mFilled)
+        return;
+
+      // If ad becomes visible, and it's filled with a content the timestamp must be stored.
+      if (visible && !mVisible)
+      {
+        mTimestamp = SystemClock.elapsedRealtime();
+      }
+      // If ad is hidden the show time must be accumulated.
+      else if (!visible && mVisible)
+      {
+        mShowTime += SystemClock.elapsedRealtime() - mTimestamp;
+        mTimestamp = 0;
+      }
+      mVisible = visible;
+    }
+
+    public void fill()
+    {
+      // If the visible ad is filled with the content the timestamp must be stored
+      if (mVisible)
+      {
+        mTimestamp = SystemClock.elapsedRealtime();
+      }
+      mFilled = true;
+    }
+
+    private boolean isRealShow()
+    {
+      return mFilled && mVisible;
+    }
+
+    long getShowTime()
+    {
+      return mShowTime;
+    }
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
+++ b/android/src/com/mapswithme/maps/ads/DefaultAdTracker.java
@@ -59,18 +59,18 @@ public class DefaultAdTracker implements AdTracker, OnAdCacheModifiedListener
   }
 
   @Override
-  public void onRemoved(@NonNull String id)
+  public void onRemoved(@NonNull String bannerId)
   {
-    mTracks.remove(id);
+    mTracks.remove(bannerId);
   }
 
   @Override
-  public void onPut(@NonNull String id)
+  public void onPut(@NonNull String bannerId)
   {
-    TrackInfo info = mTracks.get(id);
+    TrackInfo info = mTracks.get(bannerId);
     if (info == null)
     {
-      mTracks.put(id, new TrackInfo());
+      mTracks.put(bannerId, new TrackInfo());
       return;
     }
 

--- a/android/src/com/mapswithme/maps/ads/FacebookAdError.java
+++ b/android/src/com/mapswithme/maps/ads/FacebookAdError.java
@@ -1,0 +1,30 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.ads.AdError;
+
+class FacebookAdError implements NativeAdError
+{
+  @NonNull
+  private final AdError mError;
+
+  FacebookAdError(@NonNull AdError error)
+  {
+    mError = error;
+  }
+
+  @Nullable
+  @Override
+  public String getMessage()
+  {
+    return mError.getErrorMessage();
+  }
+
+  @Override
+  public int getCode()
+  {
+    return mError.getErrorCode();
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
+++ b/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
@@ -1,0 +1,185 @@
+package com.mapswithme.maps.ads;
+
+import android.content.Context;
+import android.os.SystemClock;
+import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
+
+import com.facebook.ads.Ad;
+import com.facebook.ads.AdError;
+import com.facebook.ads.AdListener;
+import com.facebook.ads.NativeAd;
+import com.mapswithme.util.log.Logger;
+import com.mapswithme.util.log.LoggerFactory;
+import net.jcip.annotations.NotThreadSafe;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@NotThreadSafe
+public class FacebookAdsLoader
+{
+  private static final Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
+  private static final String TAG = FacebookAdsLoader.class.getSimpleName();
+  private static final long EXPIRATION_TIME_MS = 60 * 60 * 1000;
+  private static final Map<String, FacebookAd> CACHE = new HashMap<>();
+  private static final Set<String> PENDING_REQUESTS = new HashSet<>();
+
+  /**
+   * Loads an ad for a specified placement id. If there is a cached ad, and it's not expired,
+   * that ad will be returned immediately. Otherwise, this method returns null, and a listener will
+   * be notified when a requested ad is loaded.
+   *
+   * @param context An activity context.
+   * @param placementId A placement id that ad will be loaded for.
+   * @param listener A listener to be notified when an ad is loaded.
+   * @return A cached banner if it presents, otherwise <code>null</code>
+   */
+  @Nullable
+  @UiThread
+  public NativeAd load(@NonNull Context context, @NonNull String placementId,
+                       @NonNull FacebookAdsListener listener)
+  {
+    LOGGER.d(TAG, "Load a facebook ad for a placement id '" + placementId + "'");
+    if (!PENDING_REQUESTS.contains(placementId))
+    {
+      NativeAd ad = new NativeAd(context, placementId);
+      ad.setAdListener(listener);
+      ad.loadAd(EnumSet.of(NativeAd.MediaCacheFlag.ICON));
+      LOGGER.d(TAG, "Loading is started");
+      PENDING_REQUESTS.add(placementId);
+    } else
+    {
+      LOGGER.d(TAG, "The ad request for placement id '" + placementId + "' hasn't been completed yet.");
+    }
+
+    FacebookAd cachedAd = CACHE.get(placementId);
+
+    if (cachedAd == null)
+    {
+      LOGGER.d(TAG, "There is no an ad in a cache for a placement id '" + placementId + "'");
+      return null;
+    }
+
+    long cacheTime = SystemClock.elapsedRealtime() - cachedAd.getLoadedTime();
+    if (cacheTime >= EXPIRATION_TIME_MS)
+    {
+      LOGGER.d(TAG, "A facebook ad is expired for a placement id '" + placementId + "'. " +
+                    "An expiration time is " + (cacheTime - EXPIRATION_TIME_MS) + " ms");
+      CACHE.remove(placementId);
+      return null;
+    }
+
+    return cachedAd.getAd();
+  }
+
+  /**
+   * Indicates whether the ad is loading right now or not.
+   *
+   * @param placementId A placement id that an ad is loading for.
+   * @return true if an ad is loading, otherwise - false.
+   */
+  public static boolean isAdLoadingForId(@NonNull String placementId)
+  {
+    return PENDING_REQUESTS.contains(placementId);
+  }
+
+  /**
+   * Retrieves the cached ad for the specified placement id.
+   *
+   * @return A cached ad or <code>null</code> if it doesn't exist.
+   */
+  @Nullable
+  public static NativeAd getAdByIdFromCache(@NonNull String placementId)
+  {
+    FacebookAd ad = CACHE.get(placementId);
+    return ad != null ? ad.getAd() : null;
+  }
+
+  /**
+   * Indicates whether there is a cached ad for the specified placement id or not.
+   *
+   * @return <code>true</code> if there is a cached ad, otherwise - <code>false</code>
+   */
+  public static boolean isCacheEmptyForId(@NonNull String placementId)
+  {
+    return getAdByIdFromCache(placementId) == null;
+  }
+
+  public abstract static class FacebookAdsListener implements AdListener
+  {
+    @Override
+    public final void onAdLoaded(Ad ad)
+    {
+      LOGGER.d(TAG, "An ad for id '" + ad.getPlacementId() + "' is loaded");
+      PENDING_REQUESTS.remove(ad.getPlacementId());
+
+      boolean isCacheWasEmpty = isCacheEmptyForId(ad.getPlacementId());
+
+      LOGGER.d(TAG, "Put a facebook ad to cache for a placement id '" + ad.getPlacementId());
+      CACHE.put(ad.getPlacementId(), new FacebookAd((NativeAd)ad, SystemClock.elapsedRealtime()));
+
+      if (isCacheWasEmpty)
+        onFacebookAdLoaded((NativeAd) ad);
+    }
+
+    @Override
+    @CallSuper
+    public final void onError(Ad ad, AdError adError)
+    {
+      LOGGER.w(TAG, "A error '" + adError + "' is occurred while loading an ad for placement id " +
+                    "'" + ad.getPlacementId() + "'");
+      PENDING_REQUESTS.remove(ad.getPlacementId());
+      onError(ad, adError, isCacheEmptyForId(ad.getPlacementId()));
+    }
+
+    /**
+     * Called <b>only if</b> there is no a cached ad for a corresponding placement id
+     * contained within a downloaded ad object, i.e. {@link NativeAd#getPlacementId()}.
+     * In other words, this callback will never be called until there is a cached ad for
+     * a requested placement id.
+     *
+     * @param ad A downloaded ad.
+     */
+    @UiThread
+    protected abstract void onFacebookAdLoaded(@NonNull NativeAd ad);
+
+    /**
+     * Notifies about a error occurred while loading the ad.
+     *
+     * @param isCacheEmpty Will be true if there is a cached ad for the same placement id,
+     *                     otherwise - false
+     */
+    @UiThread
+    protected abstract void onError(@NonNull Ad ad, @NonNull AdError adError, boolean isCacheEmpty);
+  }
+
+  private static class FacebookAd
+  {
+    @NonNull
+    private NativeAd mAd;
+    private final long mLoadedTime;
+
+    FacebookAd(@NonNull NativeAd ad, long timestamp)
+    {
+      mLoadedTime = timestamp;
+      mAd = ad;
+    }
+
+    long getLoadedTime()
+    {
+      return mLoadedTime;
+    }
+
+    @NonNull
+    NativeAd getAd()
+    {
+      return mAd;
+    }
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
+++ b/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
@@ -47,7 +47,7 @@ public class FacebookAdsLoader implements AdListener
    * @param tracker An ad tracker
    */
   @UiThread
-  public void load(@NonNull Context context, @NonNull String placementId, @NonNull AdTracker tracker)
+  public void load(@NonNull Context context, @NonNull String placementId, @Nullable AdTracker tracker)
   {
     LOGGER.d(TAG, "Load a facebook ad for a placement id '" + placementId + "'");
 
@@ -60,7 +60,7 @@ public class FacebookAdsLoader implements AdListener
       return;
     }
 
-    if (tracker.isImpressionGood(placementId)
+    if (tracker != null && tracker.isImpressionGood(placementId)
         && SystemClock.elapsedRealtime() - cachedAd.getLoadedTime() >= REQUEST_INTERVAL_MS)
     {
       LOGGER.d(TAG, "A new ad will be loaded because the previous one has a good impression");
@@ -204,7 +204,7 @@ public class FacebookAdsLoader implements AdListener
   private static class FacebookAd
   {
     @NonNull
-    private NativeAd mAd;
+    private final NativeAd mAd;
     private final long mLoadedTime;
 
     FacebookAd(@NonNull NativeAd ad, long timestamp)

--- a/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
+++ b/android/src/com/mapswithme/maps/ads/FacebookAdsLoader.java
@@ -41,8 +41,8 @@ class FacebookAdsLoader extends BaseNativeAdLoader implements AdListener
   }
 
   /**
-   * Loads an ad for a specified banner id. If there is a cached ad, and it's not expired,
-   * the caller will be notified immediately through {@link NativeAdListener#onAdLoaded(MwmNativeAd)}.
+   * Loads an ad for a specified banner id. If there is a cached ad, the caller will be notified
+   * immediately through {@link NativeAdListener#onAdLoaded(MwmNativeAd)}.
    * Otherwise, the caller will be notified once an ad is loaded through the mentioned method.
    *
    * <br><br><b>Important note: </b> if there is a cached ad for the requested banner id, and that ad
@@ -55,7 +55,7 @@ class FacebookAdsLoader extends BaseNativeAdLoader implements AdListener
   {
     LOGGER.d(TAG, "Load a facebook ad for a banner id '" + bannerId + "'");
 
-    FacebookNativeAd cachedAd = CACHE.get(bannerId);
+    FacebookNativeAd cachedAd = getAdByIdFromCache(bannerId);
 
     if (cachedAd == null)
     {
@@ -100,8 +100,8 @@ class FacebookAdsLoader extends BaseNativeAdLoader implements AdListener
   @Override
   public void onError(Ad ad, AdError adError)
   {
-    LOGGER.w(TAG, "A error '" + adError + "' is occurred while loading an ad for banner id " +
-                  "'" + ad.getPlacementId() + "'");
+    LOGGER.w(TAG, "A error '" + adError.getErrorMessage() + "' is occurred while loading " +
+                  "an ad for banner id '" + ad.getPlacementId() + "'");
     PENDING_REQUESTS.remove(ad.getPlacementId());
     if (getAdListener() != null)
       getAdListener().onError(new FacebookNativeAd((NativeAd)ad), new FacebookAdError(adError));

--- a/android/src/com/mapswithme/maps/ads/FacebookNativeAd.java
+++ b/android/src/com/mapswithme/maps/ads/FacebookNativeAd.java
@@ -1,0 +1,79 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.facebook.ads.NativeAd;
+import com.mapswithme.maps.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class FacebookNativeAd implements MwmNativeAd
+{
+  @NonNull
+  private final NativeAd mAd;
+  private final long mLoadedTime;
+
+  FacebookNativeAd(@NonNull NativeAd ad, long timestamp)
+  {
+    mLoadedTime = timestamp;
+    mAd = ad;
+  }
+
+  FacebookNativeAd(@NonNull NativeAd ad)
+  {
+    mLoadedTime = 0;
+    mAd = ad;
+  }
+
+  long getLoadedTime()
+  {
+    return mLoadedTime;
+  }
+
+  @NonNull
+  @Override
+  public String getTitle()
+  {
+    return mAd.getAdTitle();
+  }
+
+  @NonNull
+  @Override
+  public String getDescription()
+  {
+    return mAd.getAdBody();
+  }
+
+  @NonNull
+  @Override
+  public String getAction()
+  {
+    return mAd.getAdCallToAction();
+  }
+
+  @Override
+  public void loadIcon(@NonNull View view)
+  {
+    NativeAd.downloadAndDisplayImage(mAd.getAdIcon(), (ImageView) view);
+  }
+
+  @Override
+  public void registerView(@NonNull View bannerView)
+  {
+    List<View> clickableViews = new ArrayList<>();
+    clickableViews.add(bannerView.findViewById(R.id.tv__banner_title));
+    clickableViews.add(bannerView.findViewById(R.id.tv__action_small));
+    clickableViews.add(bannerView.findViewById(R.id.tv__action_large));
+    mAd.registerViewForInteraction(bannerView, clickableViews);
+  }
+
+  @NonNull
+  @Override
+  public String getProvider()
+  {
+    return "FB";
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/Factory.java
+++ b/android/src/com/mapswithme/maps/ads/Factory.java
@@ -1,0 +1,14 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class Factory
+{
+  @NonNull
+  public static NativeAdLoader createFacebookAdLoader(@Nullable OnAdCacheModifiedListener cacheListener,
+                                        @Nullable AdTracker tracker)
+  {
+    return new FacebookAdsLoader(cacheListener, tracker);
+  }
+}

--- a/android/src/com/mapswithme/maps/ads/MwmNativeAd.java
+++ b/android/src/com/mapswithme/maps/ads/MwmNativeAd.java
@@ -1,0 +1,38 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+/**
+ * Represents a native ad object which can be obtained from any providers such as Facebook,
+ * MyTarget, etc.
+ */
+public interface MwmNativeAd
+{
+  @NonNull
+  String getTitle();
+
+  @NonNull
+  String getDescription();
+
+  @NonNull
+  String getAction();
+
+  /**
+   *
+   * @param view A view which the loaded icon should be placed into.
+   */
+  void loadIcon(@NonNull View view);
+
+  /**
+   * Registers the specified banner view in third-party sdk to track the native ad internally.
+   * @param bannerView A view which holds all native ad information.
+   */
+  void registerView(@NonNull View bannerView);
+
+  /**
+   * Returns a provider name for this ad.
+   */
+  @NonNull
+  String getProvider();
+}

--- a/android/src/com/mapswithme/maps/ads/NativeAdError.java
+++ b/android/src/com/mapswithme/maps/ads/NativeAdError.java
@@ -1,0 +1,11 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.Nullable;
+
+public interface NativeAdError
+{
+  @Nullable
+  String getMessage();
+
+  int getCode();
+}

--- a/android/src/com/mapswithme/maps/ads/NativeAdListener.java
+++ b/android/src/com/mapswithme/maps/ads/NativeAdListener.java
@@ -1,0 +1,20 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+
+public interface NativeAdListener
+{
+  @UiThread
+  void onAdLoaded(@NonNull MwmNativeAd ad);
+
+  /**
+   * Notifies about a error occurred while loading the ad.
+   *
+   */
+  @UiThread
+  void onError(@NonNull MwmNativeAd ad, @NonNull NativeAdError error);
+
+  @UiThread
+  void onClick(@NonNull MwmNativeAd ad);
+}

--- a/android/src/com/mapswithme/maps/ads/NativeAdLoader.java
+++ b/android/src/com/mapswithme/maps/ads/NativeAdLoader.java
@@ -1,0 +1,31 @@
+package com.mapswithme.maps.ads;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public interface NativeAdLoader
+{
+  /**
+   * Loads an ad for the specified banner id. A caller will be notified about loading through
+   * {@link NativeAdListener} interface.
+   *
+   * @param context An activity context.
+   * @param bannerId A banner id that ad will be loaded for.
+   */
+  void loadAd(@NonNull Context context, @NonNull String bannerId);
+
+  /**
+   * Caller should set this listener to be informed about status of an ad loading.
+   *
+   * @see NativeAdListener
+   */
+  void setAdListener(@Nullable NativeAdListener adListener);
+
+  /**
+   * Indicated whether the ad for the specified banner is loading right now or not.
+   * @param bannerId A specified banner id.
+   * @return <code>true</code> if loading is in a progress, otherwise - <code>false</code>.
+   */
+  boolean isAdLoading(@NonNull String bannerId);
+}

--- a/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
+++ b/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
@@ -4,6 +4,6 @@ import android.support.annotation.NonNull;
 
 interface OnAdCacheModifiedListener
 {
-  void onRemove(@NonNull String id);
+  void onRemoved(@NonNull String id);
   void onPut(@NonNull String id);
 }

--- a/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
+++ b/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
@@ -4,6 +4,6 @@ import android.support.annotation.NonNull;
 
 interface OnAdCacheModifiedListener
 {
-  void onRemoved(@NonNull String id);
-  void onPut(@NonNull String id);
+  void onRemoved(@NonNull String bannerId);
+  void onPut(@NonNull String bannerId);
 }

--- a/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
+++ b/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
@@ -1,0 +1,9 @@
+package com.mapswithme.maps.ads;
+
+import android.support.annotation.NonNull;
+
+interface OnAdCacheModifiedListener
+{
+  void onRemove(@NonNull String id);
+  void onPut(@NonNull String id);
+}

--- a/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
+++ b/android/src/com/mapswithme/maps/ads/OnAdCacheModifiedListener.java
@@ -2,6 +2,9 @@ package com.mapswithme.maps.ads;
 
 import android.support.annotation.NonNull;
 
+/**
+ * A common listener to make all interested observers be able to watch for ads cache modifications.
+ */
 interface OnAdCacheModifiedListener
 {
   void onRemoved(@NonNull String bannerId);

--- a/android/src/com/mapswithme/maps/bookmarks/data/Banner.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/Banner.java
@@ -61,4 +61,21 @@ public final class Banner implements Parcelable
            "mId='" + mId + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Banner banner = (Banner) o;
+
+    return mId != null ? mId.equals(banner.mId) : banner.mId == null;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return mId != null ? mId.hashCode() : 0;
+  }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
@@ -295,11 +295,11 @@ final class BannerController
       if (mBanner == null || TextUtils.isEmpty(mBanner.getId()))
         return;
 
-      boolean isCacheEmpty = mCurrentAd != null;
-      setErrorStatus(isCacheEmpty);
+      boolean isNotCached = mCurrentAd == null;
+      setErrorStatus(isNotCached);
       updateVisibility();
 
-      if (mListener != null && isCacheEmpty)
+      if (mListener != null && isNotCached)
         mListener.onSizeChanged();
 
       Statistics.INSTANCE.trackNativeAdError(mBanner.getId(), ad, error, mOpened ? 1 : 0);

--- a/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
@@ -254,7 +254,7 @@ final class BannerController implements AdListener
     updateVisibility();
 
     BannerData newData = new BannerData(mNativeAd);
-    LOGGER.d(TAG, "A new banner was loaded");
+    LOGGER.d(TAG, "A new banner was loaded with placement id '" + ad.getPlacementId() + "'");
 
     // In general, if there is a cached banner, we have to show it instead of a just-downloaded banner.
     // Thus, we try to eliminate a number of situations when user sees a blank banner view until

--- a/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BannerController.java
@@ -90,7 +90,6 @@ final class BannerController
     mActionSmall = (TextView) bannerView.findViewById(R.id.tv__action_small);
     mActionLarge = (TextView) bannerView.findViewById(R.id.tv__action_large);
     mAds = bannerView.findViewById(R.id.tv__ads);
-    //TODO: pass as constructor arguments
     mAdsLoader = new FacebookAdsLoader();
     mAdsLoader.setAdsListener(new NativeAdsListener());
     mAdTracker = new DefaultAdTracker();
@@ -156,12 +155,11 @@ final class BannerController
 
   void open()
   {
-    if (!isBannerVisible() || mBanner == null || mOpened)
+    if (!isBannerVisible() || mBanner == null || TextUtils.isEmpty(mBanner.getId()) || mOpened)
       return;
 
     mOpened = true;
     setFrameHeight(WRAP_CONTENT);
-    //FIXME NPE
     NativeAd data = mAdsLoader.getAdByIdFromCache(mBanner.getId());
     if (data != null)
       loadIcon(data.getAdIcon());

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -281,6 +281,19 @@ public class PlacePageView extends RelativeLayout
     return UiUtils.isViewTouched(event, mHotelGallery);
   }
 
+  public void onActivityResume()
+  {
+    if (mBannerController != null)
+      mBannerController.onChangedVisibility(true);
+
+  }
+
+  public void onActivityPause()
+  {
+    if (mBannerController != null)
+      mBannerController.onChangedVisibility(false);
+  }
+
   private void initViews()
   {
     LayoutInflater.from(getContext()).inflate(R.layout.place_page, this);
@@ -1431,7 +1444,7 @@ public class PlacePageView extends RelativeLayout
 
   public void setOnVisibilityChangedListener(BasePlacePageAnimationController.OnVisibilityChangedListener listener)
   {
-    mAnimationController.setOnVisibilityChangedListener(listener);
+    mAnimationController.setOnVisibilityChangedListener(new PlacePageVisibilityProxy(listener, mBannerController));
   }
 
   public void setOnAnimationListener(@Nullable BasePlacePageAnimationController.OnAnimationListener listener)

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -285,7 +285,6 @@ public class PlacePageView extends RelativeLayout
   {
     if (mBannerController != null)
       mBannerController.onChangedVisibility(true);
-
   }
 
   public void onActivityPause()

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -43,6 +43,9 @@ import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.MwmActivity;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.R;
+import com.mapswithme.maps.ads.DefaultAdTracker;
+import com.mapswithme.maps.ads.Factory;
+import com.mapswithme.maps.ads.NativeAdLoader;
 import com.mapswithme.maps.api.ParsedMwmRequest;
 import com.mapswithme.maps.bookmarks.data.Bookmark;
 import com.mapswithme.maps.bookmarks.data.BookmarkManager;
@@ -379,7 +382,11 @@ public class PlacePageView extends RelativeLayout
 
     View bannerView = findViewById(R.id.banner);
     if (bannerView != null)
-      mBannerController = new BannerController(bannerView, this);
+    {
+      DefaultAdTracker tracker = new DefaultAdTracker();
+      NativeAdLoader loader = Factory.createFacebookAdLoader(tracker, tracker);
+      mBannerController = new BannerController(bannerView, this, loader, tracker);
+    }
 
     mButtons = new PlacePageButtons(this, ppButtons, new PlacePageButtons.ItemListener()
     {

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageVisibilityProxy.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageVisibilityProxy.java
@@ -1,0 +1,35 @@
+package com.mapswithme.maps.widget.placepage;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+
+public class PlacePageVisibilityProxy implements BasePlacePageAnimationController.OnVisibilityChangedListener
+{
+  @NonNull
+  private final BasePlacePageAnimationController.OnVisibilityChangedListener mListener;
+  @Nullable
+  private final BannerController mBannerController;
+
+  public PlacePageVisibilityProxy(@NonNull BasePlacePageAnimationController.OnVisibilityChangedListener listener,
+                                  @Nullable BannerController bannerController)
+  {
+    mListener = listener;
+    mBannerController = bannerController;
+  }
+
+  @Override
+  public void onPreviewVisibilityChanged(boolean isVisible)
+  {
+    if (mBannerController != null)
+      mBannerController.onChangedVisibility(isVisible);
+    mListener.onPreviewVisibilityChanged(isVisible);
+
+  }
+
+  @Override
+  public void onPlacePageVisibilityChanged(boolean isVisible)
+  {
+    mListener.onPlacePageVisibilityChanged(isVisible);
+  }
+}

--- a/android/src/com/mapswithme/util/statistics/Statistics.java
+++ b/android/src/com/mapswithme/util/statistics/Statistics.java
@@ -8,6 +8,7 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.facebook.ads.AdError;
@@ -16,6 +17,8 @@ import com.flurry.android.FlurryAgent;
 import com.mapswithme.maps.BuildConfig;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.PrivateVariables;
+import com.mapswithme.maps.ads.MwmNativeAd;
+import com.mapswithme.maps.ads.NativeAdError;
 import com.mapswithme.maps.api.ParsedMwmRequest;
 import com.mapswithme.maps.bookmarks.data.Banner;
 import com.mapswithme.maps.bookmarks.data.MapObject;
@@ -525,15 +528,16 @@ public enum Statistics
                                     .add(BANNER_STATE, String.valueOf(state)));
   }
 
-  public void trackFacebookBannerError(@Nullable Banner banner, @Nullable AdError error, int state)
+  public void trackNativeAdError(@NonNull String bannerId, @NonNull MwmNativeAd ad,
+                                 @Nullable NativeAdError error, int state)
   {
-    boolean isAdBlank = error != null && error.getErrorCode() == AdError.NO_FILL_ERROR_CODE;
+    boolean isAdBlank = error != null && error.getCode() == AdError.NO_FILL_ERROR_CODE;
     String eventName = isAdBlank ? PP_BANNER_BLANK : PP_BANNER_ERROR;
     Statistics.ParameterBuilder builder = Statistics.params();
-    builder.add(BANNER, banner != null ? banner.getId() : "N/A")
-           .add(ERROR_CODE, error != null ? String.valueOf(error.getErrorCode()) : "N/A")
-           .add(ERROR_MESSAGE, error != null ? error.getErrorMessage() : "N/A")
-           .add(PROVIDER, "FB")
+    builder.add(BANNER, !TextUtils.isEmpty(bannerId) ? bannerId : "N/A")
+           .add(ERROR_CODE, error != null ? String.valueOf(error.getCode()) : "N/A")
+           .add(ERROR_MESSAGE, error != null ? error.getMessage() : "N/A")
+           .add(PROVIDER, ad.getProvider())
            .add(BANNER_STATE, String.valueOf(state));
     trackEvent(eventName, builder.get());
   }


### PR DESCRIPTION
@goblinr @mpimenov PTAL

## **Caching**
We always show cached banner for a placement_id if we have one. Otherwise we do 2.
Every time a banner is needed (pp opens, search opens and so on), despite of what we're showing in the banner slot, we will:
Check if this banner has been showed at least N (2) seconds on the screen (cumulatively) and there's at least M (30) seconds interval between the first time it was requested and the current moment.
If the previous check was successful, app must make a request to the FB API and try to get a new banner. If that request was a success app sets a new cached banner for a specified placement_id.

## **Requests**
If there's any pending request for the same placement_id app must not start a new one.