### PR TITLE
Added styles overrides

### DIFF
--- a/indexer/map_style_reader.cpp
+++ b/indexer/map_style_reader.cpp
@@ -6,15 +6,17 @@
 
 #include "platform/platform.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 namespace
 {
 
-const char * const kSuffixDark = "_dark";
-const char * const kSuffixClear = "_clear";
-const char * const kSuffixVehicleDark = "_vehicle_dark";
-const char * const kSuffixVehicleClear = "_vehicle_clear";
+std::string const kSuffixDark = "_dark";
+std::string const kSuffixClear = "_clear";
+std::string const kSuffixVehicleDark = "_vehicle_dark";
+std::string const kSuffixVehicleClear = "_vehicle_clear";
+
+std::string const kStylesOverrideDir = "styles";
 
 string GetStyleRulesSuffix(MapStyle mapStyle)
 {
@@ -79,14 +81,25 @@ MapStyle StyleReader::GetCurrentStyle()
 
 ReaderPtr<Reader> StyleReader::GetDrawingRulesReader()
 {
-  string const rulesFile = string("drules_proto") + GetStyleRulesSuffix(GetCurrentStyle()) + ".bin";
+  string rulesFile = string("drules_proto") + GetStyleRulesSuffix(GetCurrentStyle()) + ".bin";
+
+  auto overriddenRulesFile = my::JoinFoldersToPath({GetPlatform().WritableDir(), kStylesOverrideDir}, rulesFile);
+  if (GetPlatform().IsFileExistsByFullPath(overriddenRulesFile))
+    rulesFile = overriddenRulesFile;
+
   return GetPlatform().GetReader(rulesFile);
 }
 
 ReaderPtr<Reader> StyleReader::GetResourceReader(string const & file, string const & density)
 {
   string const resourceDir = string("resources-") + density + GetStyleResourcesSuffix(GetCurrentStyle());
-  return GetPlatform().GetReader(my::JoinFoldersToPath(resourceDir, file));
+  string resFile = my::JoinFoldersToPath(resourceDir, file);
+
+  auto overriddenResFile = my::JoinFoldersToPath({GetPlatform().WritableDir(), kStylesOverrideDir}, resFile);
+  if (GetPlatform().IsFileExistsByFullPath(overriddenResFile))
+    resFile = overriddenResFile;
+
+  return GetPlatform().GetReader(resFile);
 }
 
 StyleReader & GetStyleReader()

--- a/tools/python/generate_styles_override.py
+++ b/tools/python/generate_styles_override.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import shutil
+
+
+def copy_style_file(style_path, drules_suffix, target_path):
+    if not os.path.exists(style_path):
+        print('Path {0} is not found'.format(style_path))
+        return
+
+    drules_proto_path = os.path.join(style_path, 'drules_proto.bin')
+    if not os.path.exists(drules_proto_path):
+        print('Path {0} is not found'.format(drules_proto_path))
+        return
+    shutil.copyfile(drules_proto_path, os.path.join(target_path, 'drules_proto' + drules_suffix + '.bin'))
+
+    for density in ['6plus', 'hdpi', 'mdpi', 'xhdpi', 'xxhdpi']:
+        res_path = os.path.join(style_path, 'resources-' + density)
+        if os.path.exists(res_path):
+            shutil.copytree(res_path, os.path.join(target_path, 'resources-' + density + drules_suffix))
+
+
+if len(sys.argv) < 2:
+    print('Usage: {0} <path_to_omim/data/styles> [<target_path>]'.format(sys.argv[0]))
+    sys.exit() 
+
+path_to_styles = sys.argv[1]
+if not os.path.isdir(path_to_styles):
+    print('Invalid path to styles folder')
+    sys.exit()
+
+output_name = os.path.join('' if len(sys.argv) < 3 else sys.argv[2], 'styles')
+if os.path.exists(output_name):
+    shutil.rmtree(output_name)
+os.makedirs(output_name)
+
+paths = ['clear/style-clear', 'clear/style-night', 'vehicle/style-clear', 'vehicle/style-night']
+suffixes = ['_clear', '_dark', '_vehicle_clear', '_vehicle_dark']
+
+for i in range(0, len(paths)):
+    copy_style_file(os.path.join(path_to_styles, paths[i], 'out'), suffixes[i], output_name)


### PR DESCRIPTION
- Добавлена возможность перезаписывать файлы стилей путем помещения их в специальную папку в директорию для записи. Это позволит дизайнерам тестировать новые стили на телефоне.
- Скрипт для генерации папки, которую нужно подкладывать в директорию для записи. Скрипт генерирует папку по данным, которые выдает дизайнер-тул.