### PR TITLE
[routing] Implementation of cross mwm methods (CrossMwmIndexGraph) for cross_mwm(non osrm) section.

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -115,6 +115,7 @@ set(
   speed_camera.cpp
   speed_camera.hpp
   traffic_stash.hpp
+  transition_points.hpp
   turn_candidate.hpp
   turns.cpp
   turns.hpp

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -23,8 +23,12 @@ set(
   cross_mwm_connector.hpp
   cross_mwm_connector_serialization.cpp
   cross_mwm_connector_serialization.hpp
+  cross_mwm_graph.cpp
+  cross_mwm_graph.hpp
   cross_mwm_index_graph.cpp
   cross_mwm_index_graph.hpp
+  cross_mwm_osrm_graph.cpp
+  cross_mwm_osrm_graph.hpp
   cross_mwm_road_graph.cpp
   cross_mwm_road_graph.hpp
   cross_mwm_router.cpp

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -57,7 +57,7 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
   // Note. If |isOutgoing| == true |segment| should be an exit transition segment
   // (|isEnter| == false) to a transition segment.
   // Otherwise |segment| should be an enter transition segment (|isEnter| == true)
-  // to be a trasition segment. If not, |segment| is not a transition segment.
+  // to be a transition segment. If not, |segment| is not a transition segment.
   // Please see documentation on CrossMwmGraph::IsTransition() method for details.
   bool const isEnter = (segment.IsForward() == transition.m_forwardIsEnter);
   return isEnter != isOutgoing;

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -55,7 +55,7 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
     return false;
 
   // Note. If |isOutgoing| == true |segment| should be an exit transition segment
-  // (|isEnter| == false) to a transition segment.
+  // (|isEnter| == false) to be a transition segment.
   // Otherwise |segment| should be an enter transition segment (|isEnter| == true)
   // to be a transition segment. If not, |segment| is not a transition segment.
   // Please see documentation on CrossMwmGraph::IsTransition() method for details.

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -54,6 +54,11 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
   if (transition.m_oneWay && !segment.IsForward())
     return false;
 
+  // Note. If |isOutgoing| == true |segment| should be an exit transition segment
+  // (|isEnter| == false) to a transition segment.
+  // Otherwise |segment| should be an enter transition segment (|isEnter| == true)
+  // to be a trasition segment. If not, |segment| is not a transition segment.
+  // Please see documentation on CrossMwmGraph::IsTransition() method for details.
   bool const isEnter = (segment.IsForward() == transition.m_forwardIsEnter);
   return isEnter != isOutgoing;
 }

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -54,7 +54,8 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
   if (transition.m_oneWay && !segment.IsForward())
     return false;
 
-  return (segment.IsForward() == transition.m_forwardIsEnter) == isOutgoing;
+  bool const isEnter = (segment.IsForward() == transition.m_forwardIsEnter);
+  return isEnter != isOutgoing;
 }
 
 m2::PointD const & CrossMwmConnector::GetPoint(Segment const & segment, bool front) const

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -188,7 +188,7 @@ public:
   }
 
   template <class Source>
-  static void DeserializeWeights(VehicleType /* requiredVehicle */, CrossMwmConnector & connector,
+  static void DeserializeWeights(VehicleType /* vehicle */, CrossMwmConnector & connector,
                                  Source & src)
   {
     CHECK(connector.m_weightsLoadState == WeightsLoadState::ReadyToLoad, ());

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -188,7 +188,7 @@ public:
   }
 
   template <class Source>
-  static void DeserializeWeights(VehicleType requiredVehicle, CrossMwmConnector & connector,
+  static void DeserializeWeights(VehicleType /* requiredVehicle */, CrossMwmConnector & connector,
                                  Source & src)
   {
     CHECK(connector.m_weightsLoadState == WeightsLoadState::ReadyToLoad, ());

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -1,0 +1,214 @@
+#include "routing/cross_mwm_graph.hpp"
+
+#include "indexer/scales.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/stl_helpers.hpp"
+
+#include "defines.hpp"
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+double constexpr kTransitionEqualityDistM = 20.0;
+}  // namespace
+
+namespace routing
+{
+CrossMwmGraph::CrossMwmGraph(Index & index, shared_ptr<NumMwmIds> numMwmIds,
+                             shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                             RoutingIndexManager & indexManager)
+  : m_index(index)
+  , m_numMwmIds(numMwmIds)
+  , m_vehicleModelFactory(vehicleModelFactory)
+  , m_crossMwmIndexGraph(index, numMwmIds)
+  , m_crossMwmOsrmGraph(numMwmIds, indexManager)
+{
+}
+
+bool CrossMwmGraph::IsTransition(Segment const & s, bool isOutgoing)
+{
+  // Index graph based cross-mwm information.
+  if (CrossMwmSectionExists(s.GetMwmId()))
+    return m_crossMwmIndexGraph.IsTransition(s, isOutgoing);
+  else
+    return m_crossMwmOsrmGraph.IsTransition(s, isOutgoing);
+}
+
+void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
+{
+  CHECK(IsTransition(s, isOutgoing), ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
+  // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
+  // |twins| is not filled for such cases. For details please see a note in CrossMwmGraph::GetEdgeList().
+  if (IsTransition(s, !isOutgoing))
+    return;
+
+  twins.clear();
+
+  // Note. The code below looks for twins based on geometry index. This code works for
+  // any combination mwms with different cross mwm sections.
+  // It's possible to implement a faster version for two special cases:
+  // * all neighboring mwms have cross_mwm section
+  // * all neighboring mwms have osrm cross mwm sections
+  TransitionPoints const points = GetTransitionPoints(s, isOutgoing);
+  for (m2::PointD const & p : points)
+  {
+    double constexpr kInvalidDistance = numeric_limits<double>::max();
+    struct ClosestSegment
+    {
+      ClosestSegment() = default;
+      ClosestSegment(double minDistM, Segment const & minDistTwinSeg, bool exactMatchFound)
+        : m_minDistM(minDistM), m_minDistTwinSeg(minDistTwinSeg), m_exactMatchFound(exactMatchFound) {}
+
+      double m_minDistM = kInvalidDistance;
+      Segment m_minDistTwinSeg;
+      bool m_exactMatchFound = false;
+    };
+
+    // Node. The map below is necessary because twin segments could belong to several mwm.
+    // It happens when a segment crosses more than one feature.
+    map<NumMwmId, ClosestSegment> minDistSegs;
+    auto const findBestTwins = [&](FeatureType & ft){
+      if (ft.GetID().m_mwmId.GetInfo()->GetType() != MwmInfo::COUNTRY)
+        return;
+
+      if (!ft.GetID().IsValid())
+        return;
+
+      NumMwmId const numMwmId = m_numMwmIds->GetId(ft.GetID().m_mwmId.
+                                                   GetInfo()->GetLocalFile().GetCountryFile());
+      if (numMwmId == s.GetMwmId())
+        return;
+
+      ft.ParseHeader2();
+      if (!m_vehicleModelFactory->GetVehicleModelForCountry(ft.GetID().GetMwmName())->IsRoad(ft))
+        return;
+
+      ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
+      vector<Segment> twinCandidates;
+      GetTwinCandidates(ft, !isOutgoing, twinCandidates);
+      for (Segment const & tc : twinCandidates)
+      {
+        TransitionPoints const twinPoints = GetTransitionPoints(tc, !isOutgoing);
+        for (m2::PointD const & tp : twinPoints)
+        {
+          double const distM = MercatorBounds::DistanceOnEarth(p, tp);
+          if (distM == 0.0)
+          {
+            twins.push_back(tc);
+            minDistSegs[numMwmId].m_exactMatchFound = true;
+          }
+          if (!minDistSegs[numMwmId].m_exactMatchFound
+              && distM <= kTransitionEqualityDistM
+              && distM < minDistSegs[numMwmId].m_minDistM)
+          {
+            minDistSegs[numMwmId].m_minDistM = distM;
+            minDistSegs[numMwmId].m_minDistTwinSeg = tc;
+          }
+        }
+      }
+    };
+
+    m_index.ForEachInRect(findBestTwins,
+                          MercatorBounds::RectByCenterXYAndSizeInMeters(p, kTransitionEqualityDistM),
+                          scales::GetUpperScale());
+
+    for (auto const & kv : minDistSegs)
+    {
+      if (kv.second.m_exactMatchFound)
+        continue;
+      if (kv.second.m_minDistM == kInvalidDistance)
+        continue;
+      twins.push_back(kv.second.m_minDistTwinSeg);
+    }
+  }
+
+  my::SortUnique(twins);
+
+  for (Segment const & t : twins)
+    CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
+}
+
+void CrossMwmGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
+{
+  CHECK(IsTransition(s, !isOutgoing), ("The segment is not a transition segment. IsTransition(",
+                                       s, "," , !isOutgoing, ") returns false."));
+  edges.clear();
+
+  // Osrm based cross-mwm information.
+
+  // Note. According to cross-mwm OSRM sections there're node id which could be ingoing and outgoing
+  // at the same time. For example in Berlin mwm on Nordlicher Berliner Ring (A10) near crossing
+  // with A11
+  // there's such node id. It's an extremely rare case. There're probably several such node id
+  // for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time
+  // being.
+  // To prevent filling |edges| with twins instead of leap edges and vice versa in
+  // WorldGraph::GetEdgeList()
+  // CrossMwmGraph::GetEdgeList() does not fill |edges| if |s| is a transition segment which
+  // corresponces node id described above.
+  if (IsTransition(s, isOutgoing))
+    return;
+
+  // Index graph based cross-mwm information.
+  if (CrossMwmSectionExists(s.GetMwmId()))
+    m_crossMwmIndexGraph.GetEdgeList(s, isOutgoing, edges);
+  else
+    m_crossMwmOsrmGraph.GetEdgeList(s, isOutgoing, edges);
+}
+
+void CrossMwmGraph::Clear()
+{
+  m_crossMwmOsrmGraph.Clear();
+  m_crossMwmIndexGraph.Clear();
+}
+
+TransitionPoints CrossMwmGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)
+{
+  if (CrossMwmSectionExists(s.GetMwmId()))
+  {
+    CrossMwmConnector const & connector = m_crossMwmIndexGraph.GetCrossMwmConnectorWithTransitions(s.GetMwmId());
+    // In case of transition segments of index graph cross-mwm section the front point of segment
+    // is used as a point which corresponds to the segment.
+    return TransitionPoints({connector.GetPoint(s, true /* front */)});
+  }
+  return m_crossMwmOsrmGraph.GetTransitionPoints(s, isOutgoing);
+}
+
+bool CrossMwmGraph::CrossMwmSectionExists(NumMwmId numMwmId)
+{
+  if (m_crossMwmIndexGraph.HasCache(numMwmId))
+    return true;
+
+  MwmValue * value = m_index.GetMwmHandleByCountryFile(m_numMwmIds->GetFile(numMwmId)).GetValue<MwmValue>();
+  CHECK(value != nullptr, ("Country file:", m_numMwmIds->GetFile(numMwmId)));
+  return value->m_cont.IsExist(CROSS_MWM_FILE_TAG);
+}
+
+void CrossMwmGraph::GetTwinCandidates(FeatureType const & ft, bool isOutgoing, vector<Segment> & twinCandidates)
+{
+  NumMwmId const numMwmId = m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
+  bool const isOneWay = m_vehicleModelFactory->GetVehicleModelForCountry(ft.GetID().GetMwmName())->IsOneWay(ft);
+
+  for (uint32_t segIdx = 0; segIdx + 1 < ft.GetPointsCount(); ++segIdx)
+  {
+    Segment const segForward(numMwmId, ft.GetID().m_index, segIdx, true /* forward */);
+    if (IsTransition(segForward, isOutgoing))
+      twinCandidates.push_back(segForward);
+
+    if (isOneWay)
+      continue;
+
+    Segment const segBackward(numMwmId, ft.GetID().m_index, segIdx, false /* forward */);
+    if (IsTransition(segBackward, isOutgoing))
+      twinCandidates.push_back(segBackward);
+  }
+}
+}  // namespace routing

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -24,7 +24,9 @@ struct ClosestSegment
 {
   ClosestSegment() = default;
   ClosestSegment(double minDistM, Segment const & bestSeg, bool exactMatchFound)
-    : m_bestDistM(minDistM), m_bestSeg(bestSeg), m_exactMatchFound(exactMatchFound) {}
+    : m_bestDistM(minDistM), m_bestSeg(bestSeg), m_exactMatchFound(exactMatchFound)
+  {
+  }
 
   double m_bestDistM = kInvalidDistance;
   Segment m_bestSeg;
@@ -57,9 +59,11 @@ bool CrossMwmGraph::IsTransition(Segment const & s, bool isOutgoing)
 
 void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
 {
-  CHECK(IsTransition(s, isOutgoing), ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
+  CHECK(IsTransition(s, isOutgoing),
+        ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
   // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
-  // |twins| is not filled for such cases. For details please see a note in CrossMwmGraph::GetEdgeList().
+  // |twins| is not filled for such cases. For details please see a note in
+  // CrossMwmGraph::GetEdgeList().
   if (IsTransition(s, !isOutgoing))
     return;
 
@@ -76,15 +80,15 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
     // Node. The map below is necessary because twin segments could belong to several mwm.
     // It happens when a segment crosses more than one feature.
     map<NumMwmId, ClosestSegment> minDistSegs;
-    auto const findBestTwins = [&](FeatureType & ft){
+    auto const findBestTwins = [&](FeatureType & ft) {
       if (ft.GetID().m_mwmId.GetInfo()->GetType() != MwmInfo::COUNTRY)
         return;
 
       if (!ft.GetID().IsValid())
         return;
 
-      NumMwmId const numMwmId = m_numMwmIds->GetId(ft.GetID().m_mwmId.
-                                                   GetInfo()->GetLocalFile().GetCountryFile());
+      NumMwmId const numMwmId =
+          m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
       if (numMwmId == s.GetMwmId())
         return;
 
@@ -105,9 +109,8 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
             twins.push_back(tc);
             minDistSegs[numMwmId].m_exactMatchFound = true;
           }
-          if (!minDistSegs[numMwmId].m_exactMatchFound
-              && distM <= kTransitionEqualityDistM
-              && distM < minDistSegs[numMwmId].m_bestDistM)
+          if (!minDistSegs[numMwmId].m_exactMatchFound && distM <= kTransitionEqualityDistM &&
+              distM < minDistSegs[numMwmId].m_bestDistM)
           {
             minDistSegs[numMwmId].m_bestDistM = distM;
             minDistSegs[numMwmId].m_bestSeg = tc;
@@ -116,9 +119,9 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
       }
     };
 
-    m_index.ForEachInRect(findBestTwins,
-                          MercatorBounds::RectByCenterXYAndSizeInMeters(p, kTransitionEqualityDistM),
-                          scales::GetUpperScale());
+    m_index.ForEachInRect(
+        findBestTwins, MercatorBounds::RectByCenterXYAndSizeInMeters(p, kTransitionEqualityDistM),
+        scales::GetUpperScale());
 
     for (auto const & kv : minDistSegs)
     {
@@ -138,15 +141,17 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
 
 void CrossMwmGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
 {
-  CHECK(IsTransition(s, !isOutgoing), ("The segment is not a transition segment. IsTransition(",
-                                       s, "," , !isOutgoing, ") returns false."));
+  CHECK(IsTransition(s, !isOutgoing), ("The segment is not a transition segment. IsTransition(", s,
+                                       ",", !isOutgoing, ") returns false."));
   edges.clear();
 
   // Osrm based cross-mwm information.
 
-  // Note. According to cross-mwm OSRM sections there is a node id that could be ingoing and outgoing
+  // Note. According to cross-mwm OSRM sections there is a node id that could be ingoing and
+  // outgoing
   // at the same time. For example in Berlin mwm on Nordlicher Berliner Ring (A10) near crossing
-  // with A11 there's such node id. It's an extremely rare case. There're probably several such node id
+  // with A11 there's such node id. It's an extremely rare case. There're probably several such node
+  // id
   // for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time
   // being.
   // To prevent filling |edges| with twins instead of leap edges and vice versa in
@@ -188,10 +193,13 @@ bool CrossMwmGraph::CrossMwmSectionExists(NumMwmId numMwmId)
   return value->m_cont.IsExist(CROSS_MWM_FILE_TAG);
 }
 
-void CrossMwmGraph::GetTwinCandidates(FeatureType const & ft, bool isOutgoing, vector<Segment> & twinCandidates)
+void CrossMwmGraph::GetTwinCandidates(FeatureType const & ft, bool isOutgoing,
+                                      vector<Segment> & twinCandidates)
 {
-  NumMwmId const numMwmId = m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
-  bool const isOneWay = m_vehicleModelFactory->GetVehicleModelForCountry(ft.GetID().GetMwmName())->IsOneWay(ft);
+  NumMwmId const numMwmId =
+      m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
+  bool const isOneWay =
+      m_vehicleModelFactory->GetVehicleModelForCountry(ft.GetID().GetMwmName())->IsOneWay(ft);
 
   for (uint32_t segIdx = 0; segIdx + 1 < ft.GetPointsCount(); ++segIdx)
   {

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -23,7 +23,8 @@ class CrossMwmGraph final
 {
 public:
   CrossMwmGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds,
-                std::shared_ptr<VehicleModelFactory> vehicleModelFactory, RoutingIndexManager & indexManager);
+                std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                RoutingIndexManager & indexManager);
 
   /// \brief Transition segment is a segment which is crossed by mwm border. That means
   /// start and finsh of such segment have to lie in different mwms. If a segment is
@@ -58,8 +59,10 @@ public:
   /// the mehtod fills |twins| with appropriate enter transition segments.
   /// If |isOutgoing| == false |s| should be an enter transition segment and
   /// the method fills |twins| with appropriate exit transition segments.
-  /// \note GetTwins(s, isOutgoing, ...) shall be called only if IsTransition(s, isOutgoing) returns true.
-  /// \note GetTwins(s, isOutgoing, twins) fills |twins| only if mwm contained |twins| has been downloaded.
+  /// \note GetTwins(s, isOutgoing, ...) shall be called only if IsTransition(s, isOutgoing) returns
+  /// true.
+  /// \note GetTwins(s, isOutgoing, twins) fills |twins| only if mwm contained |twins| has been
+  /// downloaded.
   /// If not, |twins| could be emply after a GetTwins(...) call.
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins);
 
@@ -77,17 +80,20 @@ public:
   void Clear();
 
 private:
-  /// \returns points of |s|. |s| should be a transition segment of mwm with an OSRM cross-mwm sections or
+  /// \returns points of |s|. |s| should be a transition segment of mwm with an OSRM cross-mwm
+  /// sections or
   /// with an index graph cross-mwm section.
   /// \param s is a transition segment of type |isOutgoing|.
-  /// \note the result of the method is returned by value because the size of the vector is usually one
+  /// \note the result of the method is returned by value because the size of the vector is usually
+  /// one
   /// or very small in rare cases in OSRM.
   TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
 
   bool CrossMwmSectionExists(NumMwmId numMwmId);
 
   /// \brief Fills |twins| with transition segments of feature |ft| of type |isOutgoing|.
-  void GetTwinCandidates(FeatureType const & ft, bool isOutgoing, std::vector<Segment> & twinCandidates);
+  void GetTwinCandidates(FeatureType const & ft, bool isOutgoing,
+                         std::vector<Segment> & twinCandidates);
 
   Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#include "routing/cross_mwm_index_graph.hpp"
+#include "routing/cross_mwm_osrm_graph.hpp"
+#include "routing/num_mwm_id.hpp"
+
+#include "routing/segment.hpp"
+
+#include "routing_common/vehicle_model.hpp"
+
+#include "indexer/index.hpp"
+
+#include "base/math.hpp"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace routing
+{
+/// \brief Getting information for cross mwm routing.
+class CrossMwmGraph final
+{
+public:
+  CrossMwmGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds,
+                std::shared_ptr<VehicleModelFactory> vehicleModelFactory, RoutingIndexManager & indexManager);
+
+  /// \brief Transition segment is a segment which is crossed by mwm border. That means
+  /// start and finsh of such segment have to lie in different mwms. If a segment is
+  /// crossed by mwm border but its start and finish lie in the same mwm it's not
+  /// a transition segment.
+  /// For most cases there is only one transition segment for a transition feature.
+  /// Transition segment at the picture below is marked as *===>*.
+  /// Transition feature is a feature which contains one or more transition segments.
+  /// Transition features at the picture below is marked as *===>*------>*.
+  /// Every transition feature is duplicated in two neighbouring mwms.
+  /// The duplicate is called "twin" at the picture below.
+  /// For most cases a transition feature contains only one transition segment.
+  /// -------MWM0---------------MWM1----------------MWM2-------------
+  /// |                   |                 |                       |
+  /// | F0 in MWM0   *===>*------>*    *===>*------>*  F2 of MWM1   |
+  /// | Twin in MWM1 *===>*------>*    *===>*------>*  Twin in MWM2 |
+  /// |                   |                 |                       |
+  /// | F1 in MWM0      *===>*---->*      *===>*--->*  F3 of MWM1   |
+  /// | Twin in MWM1    *===>*---->*      *===>*--->*  Twin in MWM2 |
+  /// |                   |                 |                       |
+  /// ---------------------------------------------------------------
+  /// There are two kinds of transition segments:
+  /// * enter transition segments are enters to their mwms;
+  /// * exit transition segments are exits from their mwms;
+  /// \returns true if |s| is an exit (|isOutgoing| == true) or an enter (|isOutgoing| == false)
+  /// transition segment.
+  bool IsTransition(Segment const & s, bool isOutgoing);
+
+  /// \brief Fills |twins| with duplicates of |s| transition segment in neighbouring mwm.
+  /// For most cases there is only one twin for |s|.
+  /// If |isOutgoing| == true |s| should be an exit transition segment and
+  /// the mehtod fills |twins| with appropriate enter transition segments.
+  /// If |isOutgoing| == false |s| should be an enter transition segment and
+  /// the method fills |twins| with appropriate exit transition segments.
+  /// \note GetTwins(s, isOutgoing, ...) shall be called only if IsTransition(s, isOutgoing) returns true.
+  /// \note GetTwins(s, isOutgoing, twins) fills |twins| only if mwm contained |twins| has been downloaded.
+  /// If not, |twins| could be emply after a GetTwins(...) call.
+  void GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins);
+
+  /// \brief Fills |edges| with edges outgoing from |s| (ingoing to |s|).
+  /// If |isOutgoing| == true then |s| should be an enter transition segment.
+  /// In that case |edges| is filled with all edges starting from |s| and ending at all reachable
+  /// exit transition segments of the mwm of |s|.
+  /// If |isOutgoing| == false then |s| should be an exit transition segment.
+  /// In that case |edges| is filled with all edges starting from all reachable
+  /// enter transition segments of the mwm of |s| and ending at |s|.
+  /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|
+  /// if |isOutgoing| == true and from |SegmentEdge::m_target| to |s| otherwise.
+  void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+
+  void Clear();
+
+private:
+  /// \returns points of |s|. |s| should be a transition segment of mwm with an OSRM cross-mwm sections or
+  /// with an index graph cross-mwm section.
+  /// \param s is a transition segment of type |isOutgoing|.
+  /// \note the result of the method is returned by value because the size of the vector is usually one
+  /// or very small in rare cases in OSRM.
+  TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
+
+  bool CrossMwmSectionExists(NumMwmId numMwmId);
+
+  /// \brief Fills |twins| with transition segments of feature |ft| of type |isOutgoing|.
+  void GetTwinCandidates(FeatureType const & ft, bool isOutgoing, std::vector<Segment> & twinCandidates);
+
+  Index & m_index;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
+  std::shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
+  CrossMwmIndexGraph m_crossMwmIndexGraph;
+  CrossMwmOsrmGraph m_crossMwmOsrmGraph;
+};
+}  // routing

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "routing/cross_mwm_index_graph.hpp"
 #include "routing/cross_mwm_osrm_graph.hpp"
 #include "routing/num_mwm_id.hpp"

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -1,5 +1,5 @@
-#include "routing/cross_mwm_road_graph.hpp"
 #include "routing/cross_mwm_connector_serialization.hpp"
+#include "routing/cross_mwm_road_graph.hpp"
 
 using namespace std;
 
@@ -11,7 +11,8 @@ bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
   return c.IsTransition(s, isOutgoing);
 }
 
-void CrossMwmIndexGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
+void CrossMwmIndexGraph::GetEdgeList(Segment const & s, bool isOutgoing,
+                                     vector<SegmentEdge> & edges)
 {
   CrossMwmConnector const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
   c.GetEdgeList(s, isOutgoing, edges);
@@ -23,8 +24,9 @@ CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithTransition
   if (it != m_connectors.cend())
     return it->second;
 
-  return Deserialize(numMwmId,
-                     CrossMwmConnectorSerializer::DeserializeTransitions<ReaderSource<FilesContainerR::TReader>>);
+  return Deserialize(
+      numMwmId,
+      CrossMwmConnectorSerializer::DeserializeTransitions<ReaderSource<FilesContainerR::TReader>>);
 }
 
 CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(NumMwmId numMwmId)
@@ -33,8 +35,9 @@ CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(Nu
   if (c.WeightsWereLoaded())
     return c;
 
-  return Deserialize(numMwmId,
-                     CrossMwmConnectorSerializer::DeserializeWeights<ReaderSource<FilesContainerR::TReader>>);
+  return Deserialize(
+      numMwmId,
+      CrossMwmConnectorSerializer::DeserializeWeights<ReaderSource<FilesContainerR::TReader>>);
 }
 
 TransitionPoints CrossMwmIndexGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -26,7 +26,7 @@ CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithTransition
 
   return Deserialize(
       numMwmId,
-      CrossMwmConnectorSerializer::DeserializeTransitions<ReaderSource<FilesContainerR::TReader>>);
+      CrossMwmConnectorSerializer::DeserializeTransitions<ReaderSourceFile>);
 }
 
 CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(NumMwmId numMwmId)
@@ -37,7 +37,7 @@ CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(Nu
 
   return Deserialize(
       numMwmId,
-      CrossMwmConnectorSerializer::DeserializeWeights<ReaderSource<FilesContainerR::TReader>>);
+      CrossMwmConnectorSerializer::DeserializeWeights<ReaderSourceFile>);
 }
 
 TransitionPoints CrossMwmIndexGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -1,376 +1,39 @@
-#include "routing/cross_mwm_index_graph.hpp"
-
 #include "routing/cross_mwm_road_graph.hpp"
-#include "routing/osrm_path_segment_factory.hpp"
+#include "routing/cross_mwm_connector_serialization.hpp"
 
-#include "base/macros.hpp"
-#include "base/stl_helpers.hpp"
-
-#include <algorithm>
-#include <utility>
-
-using namespace platform;
-using namespace routing;
 using namespace std;
-
-namespace
-{
-struct NodeIds
-{
-  TOsrmNodeId m_directNodeId;
-  TOsrmNodeId m_reverseNodeId;
-};
-
-/// \returns FtSeg by |segment|.
-OsrmMappingTypes::FtSeg GetFtSeg(Segment const & segment)
-{
-  return OsrmMappingTypes::FtSeg(segment.GetFeatureId(), segment.GetMinPointId(),
-                                 segment.GetMaxPointId());
-}
-
-/// \returns a pair of direct and reverse(backward) node id by |segment|.
-/// The first member of the pair is direct node id and the second is reverse node id.
-NodeIds GetDirectAndReverseNodeId(OsrmFtSegMapping const & segMapping, Segment const & segment)
-{
-  OsrmFtSegMapping::TFtSegVec const ftSegs = {GetFtSeg(segment)};
-  OsrmFtSegMapping::OsrmNodesT osrmNodes;
-  segMapping.GetOsrmNodes(ftSegs, osrmNodes);
-  CHECK_LESS(osrmNodes.size(), 2, ());
-  if (osrmNodes.empty())
-    return {INVALID_NODE_ID, INVALID_NODE_ID};
-
-  NodeIds const forwardNodeIds = {osrmNodes.begin()->second.first,
-                                  osrmNodes.begin()->second.second};
-  NodeIds const backwardNodeIds = {osrmNodes.begin()->second.second,
-                                   osrmNodes.begin()->second.first};
-
-  return segment.IsForward() ? forwardNodeIds : backwardNodeIds;
-}
-
-bool GetFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId,
-                          TWrittenNodeId nodeId, Segment & segment)
-{
-  auto const range = segMapping.GetSegmentsRange(nodeId);
-  for (size_t segmentIndex = range.first; segmentIndex != range.second; ++segmentIndex)
-  {
-    OsrmMappingTypes::FtSeg seg;
-    // The meaning of node id in osrm is an edge between two joints.
-    // So, it's possible to consider the first valid segment from the range which returns by GetSegmentsRange().
-    segMapping.GetSegmentByIndex(segmentIndex, seg);
-
-    if (!seg.IsValid())
-      continue;
-
-    CHECK_NOT_EQUAL(seg.m_pointStart, seg.m_pointEnd, ());
-    segment = Segment(numMwmId, seg.m_fid, min(seg.m_pointStart, seg.m_pointEnd), seg.IsForward());
-    return true;
-  }
-  LOG(LDEBUG, ("No valid segments in the range returned by OsrmFtSegMapping::GetSegmentsRange(",
-               nodeId, "). Num mwm id:", numMwmId));
-  return false;
-}
-
-void AddFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId,
-                          TWrittenNodeId nodeId, vector<Segment> & segments)
-{
-  Segment key;
-  if (GetFirstValidSegment(segMapping, numMwmId, nodeId, key))
-    segments.push_back(key);
-}
-
-void FillTransitionSegments(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
-                            NumMwmId numMwmId, ms::LatLon const & latLon,
-                            map<Segment, vector<ms::LatLon>> & transitionSegments)
-{
-  Segment key;
-  if (!GetFirstValidSegment(segMapping, numMwmId, nodeId, key))
-    return;
-
-  transitionSegments[key].push_back(latLon);
-}
-
-vector<ms::LatLon> const & GetLatLon(map<Segment, vector<ms::LatLon>> const & segMap,
-                                     Segment const & s)
-{
-  auto it = segMap.find(s);
-  CHECK(it != segMap.cend(), ());
-  return it->second;
-}
-
-void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMapping,
-                    CrossWeightedEdge const & osrmEdge, bool isOutgoing, NumMwmId numMwmId,
-                    vector<SegmentEdge> & edges)
-{
-  BorderCross const & target = osrmEdge.GetTarget();
-  CrossNode const & crossNode = isOutgoing ? target.fromNode : target.toNode;
-
-  if (!crossNode.mwmId.IsAlive())
-    return;
-
-  NumMwmId const crossNodeMwmId =
-      numMwmIds.GetId(crossNode.mwmId.GetInfo()->GetLocalFile().GetCountryFile());
-  CHECK_EQUAL(numMwmId, crossNodeMwmId, ());
-
-  Segment segment;
-  if (!GetFirstValidSegment(segMapping, crossNodeMwmId, crossNode.node, segment))
-    return;
-
-  // OSRM and AStar have different car models, therefore AStar heuristic doesn't work for OSRM node
-  // ids (edges).
-  // This factor makes index graph (used in AStar) edge weight smaller than node ids weight.
-  //
-  // As a result large cross mwm routes with connectors works as Dijkstra, but short and medium routes
-  // without connectors works as AStar.
-  // Most of routes don't use leaps, therefore it is important to keep AStar performance.
-  double constexpr kAstarHeuristicFactor = 100000;
-  edges.emplace_back(segment,
-                     osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier * kAstarHeuristicFactor);
-}
-}  // namespace
 
 namespace routing
 {
-CrossMwmIndexGraph::CrossMwmIndexGraph(shared_ptr<NumMwmIds> numMwmIds,
-                                       RoutingIndexManager & indexManager)
-  : m_indexManager(indexManager), m_numMwmIds(numMwmIds)
-{
-  ResetCrossMwmGraph();
-}
-
-CrossMwmIndexGraph::~CrossMwmIndexGraph() {}
-
 bool CrossMwmIndexGraph::IsTransition(Segment const & s, bool isOutgoing)
 {
-  // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
-  // and if so to use it. If not, osrm cross mwm sections should be used.
-
-  // Checking if a segment |s| is a transition segment by osrm cross mwm sections.
-  TransitionSegments const & t = GetSegmentMaps(s.GetMwmId());
-
-  if (isOutgoing)
-    return t.m_outgoing.count(s) != 0;
-  return t.m_ingoing.count(s) != 0;
+  CrossMwmConnector const & c = GetCrossMwmConnectorWithTransitions(s.GetMwmId());
+  return c.IsTransition(s, isOutgoing);
 }
 
-void CrossMwmIndexGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
+void CrossMwmIndexGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
 {
-  CHECK(IsTransition(s, isOutgoing), ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
-  // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
-  // |twins| is not filled for such cases. For details please see a note in
-  // rossMwmIndexGraph::GetEdgeList().
-  if (IsTransition(s, !isOutgoing))
-    return;
-
-  twins.clear();
-  // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
-  // and if so to use it. If not, osrm cross mwm sections should be used.
-
-  auto const getTwins = [&](TRoutingMappingPtr const & segMapping) {
-    vector<string> const & neighboringMwm = segMapping->m_crossContext.GetNeighboringMwmList();
-
-    for (string const & name : neighboringMwm)
-      InsertWholeMwmTransitionSegments(m_numMwmIds->GetId(CountryFile(name)));
-
-    auto it = m_transitionCache.find(s.GetMwmId());
-    CHECK(it != m_transitionCache.cend(), ());
-
-    vector<ms::LatLon> const & latLons =
-        isOutgoing ? GetLatLon(it->second.m_outgoing, s) : GetLatLon(it->second.m_ingoing, s);
-    for (string const & name : neighboringMwm)
-    {
-      NumMwmId const numMwmId = m_numMwmIds->GetId(CountryFile(name));
-      auto const addFirstValidSegment = [&](TRoutingMappingPtr const & mapping) {
-        for (auto const & ll : latLons)
-        {
-          if (isOutgoing)
-          {
-            mapping->m_crossContext.ForEachIngoingNodeNearPoint(
-                ll, [&](IngoingCrossNode const & node) {
-                  AddFirstValidSegment(mapping->m_segMapping, numMwmId, node.m_nodeId, twins);
-                });
-          }
-          else
-          {
-            mapping->m_crossContext.ForEachOutgoingNodeNearPoint(
-                ll, [&](OutgoingCrossNode const & node) {
-                  AddFirstValidSegment(mapping->m_segMapping, numMwmId, node.m_nodeId, twins);
-                });
-          }
-        }
-      };
-
-      if (!LoadWith(numMwmId, addFirstValidSegment))
-        continue;  // mwm was not loaded.
-    }
-  };
-
-  LoadWith(s.GetMwmId(), getTwins);
-  my::SortUnique(twins);
-
-  for (Segment const & t : twins)
-    CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
+  CrossMwmConnector const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
+  c.GetEdgeList(s, isOutgoing, edges);
 }
 
-void CrossMwmIndexGraph::GetEdgeList(Segment const & s, bool isOutgoing,
-                                     vector<SegmentEdge> & edges)
+CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithTransitions(NumMwmId numMwmId)
 {
-  // @TODO(bykoianko) It's necessary to check if mwm of |s| contains an A* cross mwm section
-  // and if so to use it. If not, osrm cross mwm sections should be used.
+  auto const it = m_connectors.find(numMwmId);
+  if (it != m_connectors.cend())
+    return it->second;
 
-  CHECK(IsTransition(s, !isOutgoing), ("The segment is not a transition segment. IsTransition(",
-                                       s, ",", !isOutgoing, ") returns false."));
-
-  // Note. According to cross-mwm OSRM sections there're node id which could be ingoing and outgoing
-  // at the same time. For example in Berlin mwm on Nordlicher Berliner Ring (A10) near crossing
-  // with A11
-  // there's such node id. It's an extremely rare case. There're probably several such node id
-  // for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time
-  // being.
-  // To prevent filling |edges| with twins instead of leap edges and vice versa in
-  // WorldGraph::GetEdgeList()
-  // CrossMwmIndexGraph::GetEdgeList() does not fill |edges| if |s| is a transition segment which
-  // corresponces node id described above.
-  if (IsTransition(s, isOutgoing))
-    return;
-
-  edges.clear();
-  auto const fillEdgeList = [&](TRoutingMappingPtr const & mapping) {
-    vector<BorderCross> borderCrosses;
-    GetBorderCross(mapping, s, isOutgoing, borderCrosses);
-
-    for (BorderCross const & v : borderCrosses)
-    {
-      vector<CrossWeightedEdge> adj;
-      if (isOutgoing)
-        m_crossMwmGraph->GetOutgoingEdgesList(v, adj);
-      else
-        m_crossMwmGraph->GetIngoingEdgesList(v, adj);
-
-      for (CrossWeightedEdge const & edge : adj)
-        AddSegmentEdge(*m_numMwmIds, mapping->m_segMapping, edge, isOutgoing, s.GetMwmId(), edges);
-    }
-  };
-  LoadWith(s.GetMwmId(), fillEdgeList);
-
-  my::SortUnique(edges);
+  return Deserialize(numMwmId,
+                     CrossMwmConnectorSerializer::DeserializeTransitions<ReaderSource<FilesContainerR::TReader>>);
 }
 
-void CrossMwmIndexGraph::Clear()
+CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(NumMwmId numMwmId)
 {
-  ResetCrossMwmGraph();
-  m_transitionCache.clear();
-  m_mappingGuards.clear();
-}
+  CrossMwmConnector const & c = GetCrossMwmConnectorWithTransitions(numMwmId);
+  if (c.WeightsWereLoaded())
+    return c;
 
-void CrossMwmIndexGraph::ResetCrossMwmGraph()
-{
-  m_crossMwmGraph = make_unique<CrossMwmGraph>(m_indexManager);
-}
-
-void CrossMwmIndexGraph::InsertWholeMwmTransitionSegments(NumMwmId numMwmId)
-{
-  if (m_transitionCache.count(numMwmId) != 0)
-    return;
-
-  auto const fillAllTransitionSegments = [&](TRoutingMappingPtr const & mapping) {
-    TransitionSegments transitionSegments;
-    mapping->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node)
-    {
-      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
-                             node.m_point, transitionSegments.m_outgoing);
-    });
-    mapping->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node)
-    {
-      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
-                             node.m_point, transitionSegments.m_ingoing);
-    });
-    auto const p = m_transitionCache.emplace(numMwmId, move(transitionSegments));
-    UNUSED_VALUE(p);
-    ASSERT(p.second, ("Mwm num id:", numMwmId, "has been inserted before. Country file name:",
-                      mapping->GetCountryName()));
-  };
-
-  if (!LoadWith(numMwmId, fillAllTransitionSegments))
-    m_transitionCache.emplace(numMwmId, TransitionSegments());
-}
-
-void CrossMwmIndexGraph::GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s,
-                                        bool isOutgoing, vector<BorderCross> & borderCrosses)
-{
-  // ingoing edge
-  NodeIds const nodeIdsTo = GetDirectAndReverseNodeId(mapping->m_segMapping, s);
-
-  vector<ms::LatLon> const & transitionPoints =
-      isOutgoing ? GetIngoingTransitionPoints(s) : GetOutgoingTransitionPoints(s);
-  CHECK(!transitionPoints.empty(), ("Segment:", s, ", isOutgoing:", isOutgoing));
-
-  // If |isOutgoing| == true |nodes| is "to" cross nodes, otherwise |nodes| is "from" cross nodes.
-  vector<CrossNode> nodes;
-  for (ms::LatLon const & p : transitionPoints)
-    nodes.emplace_back(nodeIdsTo.m_directNodeId, nodeIdsTo.m_reverseNodeId, mapping->GetMwmId(), p);
-
-  // outgoing edge
-  vector<Segment> twins;
-  GetTwins(s, !isOutgoing, twins);
-  CHECK(!twins.empty(), ("Segment:", s, ", isOutgoing:", isOutgoing));
-  for (Segment const & twin : twins)
-  {
-    // If |isOutgoing| == true |otherSideMapping| is mapping outgoing (to) border cross.
-    // If |isOutgoing| == false |mapping| is mapping ingoing (from) border cross.
-    auto const fillBorderCrossOut = [&](TRoutingMappingPtr const & otherSideMapping) {
-      NodeIds const nodeIdsFrom = GetDirectAndReverseNodeId(otherSideMapping->m_segMapping, twin);
-      vector<ms::LatLon> const & otherSideTransitionPoints =
-          isOutgoing ? GetOutgoingTransitionPoints(twin) : GetIngoingTransitionPoints(twin);
-
-      CHECK(!otherSideTransitionPoints.empty(), ("Segment:", s, ", isOutgoing:", isOutgoing));
-      for (CrossNode const & node : nodes)
-      {
-        // If |isOutgoing| == true |otherSideNodes| is "from" cross nodes, otherwise
-        // |otherSideNodes| is "to" cross nodes.
-        BorderCross bc;
-        if (isOutgoing)
-          bc.toNode = node;
-        else
-          bc.fromNode = node;
-
-        for (ms::LatLon const & ll : otherSideTransitionPoints)
-        {
-          CrossNode & resultNode = isOutgoing ? bc.fromNode : bc.toNode;
-          resultNode = CrossNode(nodeIdsFrom.m_directNodeId, nodeIdsFrom.m_reverseNodeId,
-                                 otherSideMapping->GetMwmId(), ll);
-          borderCrosses.push_back(bc);
-        }
-      }
-    };
-    LoadWith(twin.GetMwmId(), fillBorderCrossOut);
-  }
-}
-
-CrossMwmIndexGraph::TransitionSegments const & CrossMwmIndexGraph::GetSegmentMaps(NumMwmId numMwmId)
-{
-  auto it = m_transitionCache.find(numMwmId);
-  if (it == m_transitionCache.cend())
-  {
-    InsertWholeMwmTransitionSegments(numMwmId);
-    it = m_transitionCache.find(numMwmId);
-  }
-  CHECK(it != m_transitionCache.cend(), ("Mwm ", numMwmId, "has not been downloaded."));
-  return it->second;
-}
-
-vector<ms::LatLon> const & CrossMwmIndexGraph::GetIngoingTransitionPoints(Segment const & s)
-{
-  auto const & ingoingSeg = GetSegmentMaps(s.GetMwmId()).m_ingoing;
-  auto const it = ingoingSeg.find(s);
-  CHECK(it != ingoingSeg.cend(), ("Segment:", s));
-  return it->second;
-}
-
-vector<ms::LatLon> const & CrossMwmIndexGraph::GetOutgoingTransitionPoints(Segment const & s)
-{
-  auto const & outgoingSeg = GetSegmentMaps(s.GetMwmId()).m_outgoing;
-  auto const it = outgoingSeg.find(s);
-  CHECK(it != outgoingSeg.cend(), ("Segment:", s));
-  return it->second;
+  return Deserialize(numMwmId,
+                     CrossMwmConnectorSerializer::DeserializeWeights<ReaderSource<FilesContainerR::TReader>>);
 }
 }  // namespace routing

--- a/routing/cross_mwm_index_graph.cpp
+++ b/routing/cross_mwm_index_graph.cpp
@@ -36,4 +36,12 @@ CrossMwmConnector const & CrossMwmIndexGraph::GetCrossMwmConnectorWithWeights(Nu
   return Deserialize(numMwmId,
                      CrossMwmConnectorSerializer::DeserializeWeights<ReaderSource<FilesContainerR::TReader>>);
 }
+
+TransitionPoints CrossMwmIndexGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)
+{
+  CrossMwmConnector const & connector = GetCrossMwmConnectorWithTransitions(s.GetMwmId());
+  // In case of transition segments of index graph cross-mwm section the front point of segment
+  // is used as a point which corresponds to the segment.
+  return TransitionPoints({connector.GetPoint(s, true /* front */)});
+}
 }  // namespace routing

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -1,14 +1,15 @@
 #pragma once
-
+#include "routing/cross_mwm_connector.hpp"
 #include "routing/num_mwm_id.hpp"
-#include "routing/routing_mapping.hpp"
 #include "routing/segment.hpp"
+#include "routing/vehicle_mask.hpp"
 
-#include "geometry/latlon.hpp"
+#include "routing_common/vehicle_model.hpp"
 
-#include "platform/country_file.hpp"
+#include "coding/file_container.hpp"
+#include "coding/reader.hpp"
 
-#include "base/math.hpp"
+#include "indexer/index.hpp"
 
 #include <map>
 #include <memory>
@@ -16,123 +17,44 @@
 
 namespace routing
 {
-struct BorderCross;
-class CrossMwmGraph;
-
-/// \brief Getting information for cross mwm routing.
 class CrossMwmIndexGraph final
 {
 public:
-  CrossMwmIndexGraph(std::shared_ptr<NumMwmIds> numMwmIds, RoutingIndexManager & indexManager);
-  ~CrossMwmIndexGraph();
+  CrossMwmIndexGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds)
+    : m_index(index), m_numMwmIds(numMwmIds) {}
 
-  /// \brief Transition segment is a segment which is crossed by mwm border. That means
-  /// start and finsh of such segment have to lie in different mwms. If a segment is
-  /// crossed by mwm border but its start and finish lie in the same mwm it's not
-  /// a transition segment.
-  /// For most cases there is only one transition segment for a transition feature.
-  /// Transition segment at the picture below is marked as *===>*.
-  /// Transition feature is a feature which contains one or more transition segments.
-  /// Transition features at the picture below is marked as *===>*------>*.
-  /// Every transition feature is duplicated in two neighbouring mwms.
-  /// The duplicate is called "twin" at the picture below.
-  /// For most cases a transition feature contains only one transition segment.
-  /// -------MWM0---------------MWM1----------------MWM2-------------
-  /// |                   |                 |                       |
-  /// | F0 in MWM0   *===>*------>*    *===>*------>*  F2 of MWM1   |
-  /// | Twin in MWM1 *===>*------>*    *===>*------>*  Twin in MWM2 |
-  /// |                   |                 |                       |
-  /// | F1 in MWM0      *===>*---->*      *===>*--->*  F3 of MWM1   |
-  /// | Twin in MWM1    *===>*---->*      *===>*--->*  Twin in MWM2 |
-  /// |                   |                 |                       |
-  /// ---------------------------------------------------------------
-  /// There are two kinds of transition segments:
-  /// * enter transition segments are enters to their mwms;
-  /// * exit transition segments are exits from their mwms;
-  /// \returns true if |s| is an exit (|isOutgoing| == true) or an enter (|isOutgoing| == false)
-  /// transition segment.
   bool IsTransition(Segment const & s, bool isOutgoing);
-
-  /// \brief Fills |twins| with duplicates of |s| transition segment in neighbouring mwm.
-  /// For most cases there is only one twin for |s|.
-  /// If |isOutgoing| == true |s| should be an exit transition segment and
-  /// the mehtod fills |twins| with appropriate enter transition segments.
-  /// If |isOutgoing| == false |s| should be an enter transition segment and
-  /// the method fills |twins| with appropriate exit transition segments.
-  /// \note GetTwins(s, isOutgoing, ...) shall be called only if IsTransition(s, isOutgoing) returns true.
-  /// \note GetTwins(s, isOutgoing, twins) fills |twins| only if mwm contained |twins| has been downloaded.
-  /// If not, |twins| could be emply after a GetTwins(...) call.
-  void GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins);
-
-  /// \brief Fills |edges| with edges outgoing from |s| (ingoing to |s|).
-  /// If |isOutgoing| == true then |s| should be an enter transition segment.
-  /// In that case |edges| is filled with all edges starting from |s| and ending at all reachable
-  /// exit transition segments of the mwm of |s|.
-  /// If |isOutgoing| == false then |s| should be an exit transition segment.
-  /// In that case |edges| is filled with all edges starting from all reachable
-  /// enter transition segments of the mwm of |s| and ending at |s|.
-  /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|
-  /// if |isOutgoing| == true and from |SegmentEdge::m_target| to |s| otherwise.
   void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  void Clear() { m_connectors.clear(); }
 
-  void Clear();
+  CrossMwmConnector const & GetCrossMwmConnectorWithTransitions(NumMwmId numMwmId);
+  bool HasCache(NumMwmId numMwmId) const { return m_connectors.count(numMwmId) != 0; }
 
 private:
-  struct TransitionSegments
+  CrossMwmConnector const & GetCrossMwmConnectorWithWeights(NumMwmId numMwmId);
+
+  template <typename Fn>
+  CrossMwmConnector const & Deserialize(NumMwmId numMwmId, Fn && fn)
   {
-    std::map<Segment, std::vector<ms::LatLon>> m_ingoing;
-    std::map<Segment, std::vector<ms::LatLon>> m_outgoing;
-  };
+    MwmValue * value = m_index.GetMwmHandleByCountryFile(m_numMwmIds->GetFile(numMwmId)).GetValue<MwmValue>();
+    CHECK(value != nullptr, ("Country file:", m_numMwmIds->GetFile(numMwmId)));
 
-  void ResetCrossMwmGraph();
-
-  /// \brief Inserts all ingoing and outgoing transition segments of mwm with |numMwmId|
-  /// to |m_transitionCache|.
-  void InsertWholeMwmTransitionSegments(NumMwmId numMwmId);
-
-  /// \brief Fills |borderCrosses| of mwm with |mapping| according to |s|.
-  /// \param mapping if |isOutgoing| == true |mapping| is mapping ingoing (from) border cross.
-  /// If |isOutgoing| == false |mapping| is mapping outgoing (to) border cross.
-  /// \note |s| and |isOutgoing| params have the same restrictions which described in
-  /// GetEdgeList() method.
-  void GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s, bool isOutgoing,
-                      std::vector<BorderCross> & borderCrosses);
-
-  TransitionSegments const & GetSegmentMaps(NumMwmId numMwmId);
-
-  std::vector<ms::LatLon> const & GetIngoingTransitionPoints(Segment const & s);
-  std::vector<ms::LatLon> const & GetOutgoingTransitionPoints(Segment const & s);
-
-  template <class Fn>
-  bool LoadWith(NumMwmId numMwmId, Fn && fn)
-  {
-    platform::CountryFile const & countryFile = m_numMwmIds->GetFile(numMwmId);
-    TRoutingMappingPtr mapping = m_indexManager.GetMappingByName(countryFile.GetName());
-    CHECK(mapping, ("No routing mapping file for countryFile:", countryFile));
-
-    if (!mapping->IsValid())
-      return false; // mwm was not loaded.
-
-    auto const it = m_mappingGuards.find(numMwmId);
-    if (it == m_mappingGuards.cend())
-    {
-      m_mappingGuards[numMwmId] = make_unique<MappingGuard>(mapping);
-      mapping->LoadCrossContext();
-    }
-
-    fn(mapping);
-    return true;
+    auto const reader = make_unique<FilesContainerR::TReader>(value->m_cont.GetReader(CROSS_MWM_FILE_TAG));
+    ReaderSource<FilesContainerR::TReader> src(*reader);
+    auto const p = m_connectors.emplace(numMwmId, CrossMwmConnector(numMwmId));
+    fn(VehicleType::Car, p.first->second, src);
+    return p.first->second;
   }
 
-  RoutingIndexManager & m_indexManager;
+  Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
-  /// \note According to the constructor CrossMwmGraph is initialized with RoutingIndexManager &.
-  /// But then it is copied by value to CrossMwmGraph::RoutingIndexManager m_indexManager.
-  /// It means that there're two copies of RoutingIndexManager in CrossMwmIndexGraph.
-  std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
 
-  std::map<NumMwmId, TransitionSegments> m_transitionCache;
-
-  std::map<NumMwmId, std::unique_ptr<MappingGuard>> m_mappingGuards;
+  /// \note |m_connectors| contains cache with transition segments and leap edges.
+  /// Each mwm in |m_connectors| may be in two conditions:
+  /// * with loaded transition segments (after a call to CrossMwmConnectorSerializer::DeserializeTransitions())
+  /// * with loaded transition segments and with loaded weights
+  ///   (after a call to CrossMwmConnectorSerializer::DeserializeTransitions()
+  ///   and CrossMwmConnectorSerializer::DeserializeWeights())
+  std::map<NumMwmId, CrossMwmConnector> m_connectors;
 };
-}  // routing
+}  // namespace routing

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -23,15 +23,15 @@ class CrossMwmIndexGraph final
 {
 public:
   CrossMwmIndexGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds)
-    : m_index(index), m_numMwmIds(numMwmIds) {}
+    : m_index(index), m_numMwmIds(numMwmIds)
+  {
+  }
 
   bool IsTransition(Segment const & s, bool isOutgoing);
   void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
   void Clear() { m_connectors.clear(); }
-
   TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
   bool HasCache(NumMwmId numMwmId) const { return m_connectors.count(numMwmId) != 0; }
-
 private:
   CrossMwmConnector const & GetCrossMwmConnectorWithTransitions(NumMwmId numMwmId);
   CrossMwmConnector const & GetCrossMwmConnectorWithWeights(NumMwmId numMwmId);
@@ -44,7 +44,8 @@ private:
     MwmValue * value = handle.GetValue<MwmValue>();
     CHECK(value != nullptr, ("Country file:", m_numMwmIds->GetFile(numMwmId)));
 
-    auto const reader = make_unique<FilesContainerR::TReader>(value->m_cont.GetReader(CROSS_MWM_FILE_TAG));
+    auto const reader =
+        make_unique<FilesContainerR::TReader>(value->m_cont.GetReader(CROSS_MWM_FILE_TAG));
     ReaderSource<FilesContainerR::TReader> src(*reader);
     auto const p = m_connectors.emplace(numMwmId, CrossMwmConnector(numMwmId));
     fn(VehicleType::Car, p.first->second, src);
@@ -56,7 +57,8 @@ private:
 
   /// \note |m_connectors| contains cache with transition segments and leap edges.
   /// Each mwm in |m_connectors| may be in two conditions:
-  /// * with loaded transition segments (after a call to CrossMwmConnectorSerializer::DeserializeTransitions())
+  /// * with loaded transition segments (after a call to
+  /// CrossMwmConnectorSerializer::DeserializeTransitions())
   /// * with loaded transition segments and with loaded weights
   ///   (after a call to CrossMwmConnectorSerializer::DeserializeTransitions()
   ///   and CrossMwmConnectorSerializer::DeserializeWeights())

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -1,0 +1,253 @@
+#include "routing/cross_mwm_osrm_graph.hpp"
+#include "routing/cross_mwm_road_graph.hpp"
+#include "routing/osrm_path_segment_factory.hpp"
+
+#include "base/stl_helpers.hpp"
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+struct NodeIds
+{
+  TOsrmNodeId m_directNodeId;
+  TOsrmNodeId m_reverseNodeId;
+};
+
+OsrmMappingTypes::FtSeg GetFtSeg(Segment const & segment)
+{
+  return OsrmMappingTypes::FtSeg(segment.GetFeatureId(), segment.GetMinPointId(),
+                                 segment.GetMaxPointId());
+}
+
+/// \returns a pair of direct and reverse(backward) node id by |segment|.
+/// The first member of the pair is direct node id and the second is reverse node id.
+NodeIds GetDirectAndReverseNodeId(OsrmFtSegMapping const & segMapping, Segment const & segment)
+{
+  OsrmFtSegMapping::TFtSegVec const ftSegs = {GetFtSeg(segment)};
+  OsrmFtSegMapping::OsrmNodesT osrmNodes;
+  segMapping.GetOsrmNodes(ftSegs, osrmNodes);
+  CHECK_LESS(osrmNodes.size(), 2, ());
+  if (osrmNodes.empty())
+    return {INVALID_NODE_ID, INVALID_NODE_ID};
+
+  NodeIds const forwardNodeIds = {osrmNodes.begin()->second.first,
+                                  osrmNodes.begin()->second.second};
+  NodeIds const backwardNodeIds = {osrmNodes.begin()->second.second,
+                                   osrmNodes.begin()->second.first};
+
+  return segment.IsForward() ? forwardNodeIds : backwardNodeIds;
+}
+
+bool GetFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId,
+                          TWrittenNodeId nodeId, Segment & segment)
+{
+  auto const range = segMapping.GetSegmentsRange(nodeId);
+  for (size_t segmentIndex = range.first; segmentIndex != range.second; ++segmentIndex)
+  {
+    OsrmMappingTypes::FtSeg seg;
+    // The meaning of node id in osrm is an edge between two joints.
+    // So, it's possible to consider the first valid segment from the range which returns by GetSegmentsRange().
+    segMapping.GetSegmentByIndex(segmentIndex, seg);
+
+    if (!seg.IsValid())
+      continue;
+
+    CHECK_NOT_EQUAL(seg.m_pointStart, seg.m_pointEnd, ());
+    segment = Segment(numMwmId, seg.m_fid, min(seg.m_pointStart, seg.m_pointEnd), seg.IsForward());
+    return true;
+  }
+  LOG(LDEBUG, ("No valid segments in the range returned by OsrmFtSegMapping::GetSegmentsRange(",
+               nodeId, "). Num mwm id:", numMwmId));
+  return false;
+}
+
+void FillTransitionSegments(OsrmFtSegMapping const & segMapping, TWrittenNodeId nodeId,
+                            NumMwmId numMwmId, ms::LatLon const & latLon,
+                            map<Segment, vector<ms::LatLon>> & transitionSegments)
+{
+  Segment key;
+  if (!GetFirstValidSegment(segMapping, numMwmId, nodeId, key))
+    return;
+
+  transitionSegments[key].push_back(latLon);
+}
+
+void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMapping,
+                    CrossWeightedEdge const & osrmEdge, bool isOutgoing, NumMwmId numMwmId,
+                    vector<SegmentEdge> & edges)
+{
+  BorderCross const & target = osrmEdge.GetTarget();
+  CrossNode const & crossNode = isOutgoing ? target.fromNode : target.toNode;
+
+  if (!crossNode.mwmId.IsAlive())
+    return;
+
+  NumMwmId const crossNodeMwmId =
+      numMwmIds.GetId(crossNode.mwmId.GetInfo()->GetLocalFile().GetCountryFile());
+  CHECK_EQUAL(numMwmId, crossNodeMwmId, ());
+
+  Segment segment;
+  if (!GetFirstValidSegment(segMapping, crossNodeMwmId, crossNode.node, segment))
+    return;
+
+  // OSRM and AStar have different car models, therefore AStar heuristic doesn't work for OSRM node
+  // ids (edges).
+  // This factor makes index graph (used in AStar) edge weight smaller than node ids weight.
+  //
+  // As a result large cross mwm routes with connectors works as Dijkstra, but short and medium routes
+  // without connectors works as AStar.
+  // Most of routes don't use leaps, therefore it is important to keep AStar performance.
+  double constexpr kAstarHeuristicFactor = 100000;
+  edges.emplace_back(segment,
+                     osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier * kAstarHeuristicFactor);
+}
+}  // namespace
+
+namespace routing
+{
+CrossMwmOsrmGraph::CrossMwmOsrmGraph(shared_ptr<NumMwmIds> numMwmIds, RoutingIndexManager & indexManager)
+  : m_numMwmIds(numMwmIds), m_indexManager(indexManager)
+{
+  Clear();
+}
+
+CrossMwmOsrmGraph::~CrossMwmOsrmGraph() {}
+
+bool CrossMwmOsrmGraph::IsTransition(Segment const & s, bool isOutgoing)
+{
+  TransitionSegments const & t = GetSegmentMaps(s.GetMwmId());
+
+  if (isOutgoing)
+    return t.m_outgoing.count(s) != 0;
+  return t.m_ingoing.count(s) != 0;
+}
+
+void CrossMwmOsrmGraph::GetEdgeList(Segment const & s, bool isOutgoing,
+                                    vector<SegmentEdge> & edges)
+{
+  auto const fillEdgeList = [&](TRoutingMappingPtr const & mapping) {
+    vector<BorderCross> borderCrosses;
+    GetBorderCross(mapping, s, isOutgoing, borderCrosses);
+
+    for (BorderCross const & v : borderCrosses)
+    {
+      vector<CrossWeightedEdge> adj;
+      if (isOutgoing)
+        m_crossMwmGraph->GetOutgoingEdgesList(v, adj);
+      else
+        m_crossMwmGraph->GetIngoingEdgesList(v, adj);
+
+      for (CrossWeightedEdge const & edge : adj)
+        AddSegmentEdge(*m_numMwmIds, mapping->m_segMapping, edge, isOutgoing, s.GetMwmId(), edges);
+    }
+  };
+  LoadWith(s.GetMwmId(), fillEdgeList);
+
+  my::SortUnique(edges);
+}
+
+void CrossMwmOsrmGraph::Clear()
+{
+  m_crossMwmGraph = make_unique<CrossMwmRoadGraph>(m_indexManager);
+  m_transitionCache.clear();
+  m_mappingGuards.clear();
+}
+
+TransitionPoints CrossMwmOsrmGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)
+{
+  vector<ms::LatLon> const & latLons = isOutgoing ? GetOutgoingTransitionPoints(s)
+                                                  : GetIngoingTransitionPoints(s);
+  TransitionPoints points;
+  points.reserve(latLons.size());
+  for (auto const & latLon : latLons)
+    points.push_back(MercatorBounds::FromLatLon(latLon));
+  return points;
+}
+
+CrossMwmOsrmGraph::TransitionSegments const & CrossMwmOsrmGraph::LoadSegmentMaps(NumMwmId numMwmId)
+{
+  //map<NumMwmId, TransitionSegments>::iterator
+  auto it = m_transitionCache.find(numMwmId);
+  if (it != m_transitionCache.cend())
+    return it->second;
+
+  auto const fillAllTransitionSegments = [&](TRoutingMappingPtr const & mapping) {
+    TransitionSegments transitionSegments;
+    mapping->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node)
+    {
+      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
+                             node.m_point, transitionSegments.m_outgoing);
+    });
+    mapping->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node)
+    {
+      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
+                             node.m_point, transitionSegments.m_ingoing);
+    });
+    auto const p = m_transitionCache.emplace(numMwmId, move(transitionSegments));
+    UNUSED_VALUE(p);
+    ASSERT(p.second, ("Mwm num id:", numMwmId, "has been inserted before. Country file name:",
+                      mapping->GetCountryName()));
+    it = p.first;
+  };
+
+  if (!LoadWith(numMwmId, fillAllTransitionSegments))
+    it = m_transitionCache.emplace(numMwmId, TransitionSegments()).first;
+  return it->second;
+}
+
+void CrossMwmOsrmGraph::GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s,
+                                       bool isOutgoing, vector<BorderCross> & borderCrosses)
+{
+  // ingoing edge
+  NodeIds const nodeIdsTo = GetDirectAndReverseNodeId(mapping->m_segMapping, s);
+
+  vector<ms::LatLon> const & transitionPoints =
+      isOutgoing ? GetIngoingTransitionPoints(s) : GetOutgoingTransitionPoints(s);
+  CHECK(!transitionPoints.empty(), ("Segment:", s, ", isOutgoing:", isOutgoing));
+
+  // If |isOutgoing| == true |nodes| is "to" cross nodes, otherwise |nodes| is "from" cross nodes.
+  vector<CrossNode> nodes;
+  for (ms::LatLon const & p : transitionPoints)
+    nodes.emplace_back(nodeIdsTo.m_directNodeId, nodeIdsTo.m_reverseNodeId, mapping->GetMwmId(), p);
+
+  for (CrossNode const & node : nodes)
+  {
+    // If |isOutgoing| == true |otherSideNodes| is "from" cross nodes, otherwise
+    // |otherSideNodes| is "to" cross nodes.
+    BorderCross bc;
+    if (isOutgoing)
+      bc.toNode = node;
+    else
+      bc.fromNode = node;
+    borderCrosses.push_back(bc);
+  }
+}
+
+CrossMwmOsrmGraph::TransitionSegments const & CrossMwmOsrmGraph::GetSegmentMaps(NumMwmId numMwmId)
+{
+  auto it = m_transitionCache.find(numMwmId);
+  if (it == m_transitionCache.cend())
+    return LoadSegmentMaps(numMwmId);
+
+  CHECK(it != m_transitionCache.cend(), ("Mwm ", numMwmId, "has not been downloaded."));
+  return it->second;
+}
+
+vector<ms::LatLon> const & CrossMwmOsrmGraph::GetIngoingTransitionPoints(Segment const & s)
+{
+  auto const & ingoingSeg = GetSegmentMaps(s.GetMwmId()).m_ingoing;
+  auto const it = ingoingSeg.find(s);
+  CHECK(it != ingoingSeg.cend(), ("Segment:", s));
+  return it->second;
+}
+
+vector<ms::LatLon> const & CrossMwmOsrmGraph::GetOutgoingTransitionPoints(Segment const & s)
+{
+  auto const & outgoingSeg = GetSegmentMaps(s.GetMwmId()).m_outgoing;
+  auto const it = outgoingSeg.find(s);
+  CHECK(it != outgoingSeg.cend(), ("Segment:", s));
+  return it->second;
+}
+}  // namespace routing

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -48,7 +48,8 @@ bool GetFirstValidSegment(OsrmFtSegMapping const & segMapping, NumMwmId numMwmId
   {
     OsrmMappingTypes::FtSeg seg;
     // The meaning of node id in osrm is an edge between two joints.
-    // So, it's possible to consider the first valid segment from the range which returns by GetSegmentsRange().
+    // So, it's possible to consider the first valid segment from the range which returns by
+    // GetSegmentsRange().
     segMapping.GetSegmentByIndex(segmentIndex, seg);
 
     if (!seg.IsValid())
@@ -96,7 +97,8 @@ void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMap
   // ids (edges).
   // This factor makes index graph (used in AStar) edge weight smaller than node ids weight.
   //
-  // As a result large cross mwm routes with connectors works as Dijkstra, but short and medium routes
+  // As a result large cross mwm routes with connectors works as Dijkstra, but short and medium
+  // routes
   // without connectors works as AStar.
   // Most of routes don't use leaps, therefore it is important to keep AStar performance.
   double constexpr kAstarHeuristicFactor = 100000;
@@ -107,14 +109,14 @@ void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMap
 
 namespace routing
 {
-CrossMwmOsrmGraph::CrossMwmOsrmGraph(shared_ptr<NumMwmIds> numMwmIds, RoutingIndexManager & indexManager)
+CrossMwmOsrmGraph::CrossMwmOsrmGraph(shared_ptr<NumMwmIds> numMwmIds,
+                                     RoutingIndexManager & indexManager)
   : m_numMwmIds(numMwmIds), m_indexManager(indexManager)
 {
   Clear();
 }
 
 CrossMwmOsrmGraph::~CrossMwmOsrmGraph() {}
-
 bool CrossMwmOsrmGraph::IsTransition(Segment const & s, bool isOutgoing)
 {
   TransitionSegments const & t = GetSegmentMaps(s.GetMwmId());
@@ -124,8 +126,7 @@ bool CrossMwmOsrmGraph::IsTransition(Segment const & s, bool isOutgoing)
   return t.m_ingoing.count(s) != 0;
 }
 
-void CrossMwmOsrmGraph::GetEdgeList(Segment const & s, bool isOutgoing,
-                                    vector<SegmentEdge> & edges)
+void CrossMwmOsrmGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
 {
   auto const fillEdgeList = [&](TRoutingMappingPtr const & mapping) {
     vector<BorderCross> borderCrosses;
@@ -159,8 +160,8 @@ void CrossMwmOsrmGraph::Clear()
 
 TransitionPoints CrossMwmOsrmGraph::GetTransitionPoints(Segment const & s, bool isOutgoing)
 {
-  vector<ms::LatLon> const & latLons = isOutgoing ? GetOutgoingTransitionPoints(s)
-                                                  : GetIngoingTransitionPoints(s);
+  vector<ms::LatLon> const & latLons =
+      isOutgoing ? GetOutgoingTransitionPoints(s) : GetIngoingTransitionPoints(s);
   TransitionPoints points;
   points.reserve(latLons.size());
   for (auto const & latLon : latLons)
@@ -170,22 +171,19 @@ TransitionPoints CrossMwmOsrmGraph::GetTransitionPoints(Segment const & s, bool 
 
 CrossMwmOsrmGraph::TransitionSegments const & CrossMwmOsrmGraph::LoadSegmentMaps(NumMwmId numMwmId)
 {
-  //map<NumMwmId, TransitionSegments>::iterator
   auto it = m_transitionCache.find(numMwmId);
   if (it != m_transitionCache.cend())
     return it->second;
 
   auto const fillAllTransitionSegments = [&](TRoutingMappingPtr const & mapping) {
     TransitionSegments transitionSegments;
-    mapping->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node)
-    {
-      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
-                             node.m_point, transitionSegments.m_outgoing);
+    mapping->m_crossContext.ForEachOutgoingNode([&](OutgoingCrossNode const & node) {
+      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId, node.m_point,
+                             transitionSegments.m_outgoing);
     });
-    mapping->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node)
-    {
-      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId,
-                             node.m_point, transitionSegments.m_ingoing);
+    mapping->m_crossContext.ForEachIngoingNode([&](IngoingCrossNode const & node) {
+      FillTransitionSegments(mapping->m_segMapping, node.m_nodeId, numMwmId, node.m_point,
+                             transitionSegments.m_ingoing);
     });
     auto const p = m_transitionCache.emplace(numMwmId, move(transitionSegments));
     UNUSED_VALUE(p);

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -133,11 +133,9 @@ void CrossMwmOsrmGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<S
   // outgoing
   // at the same time. For example in Berlin mwm on Nordlicher Berliner Ring (A10) near crossing
   // with A11 there's such node id. It's an extremely rare case. There're probably several such node
-  // id
-  // for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time
-  // being.
-  // To prevent filling |edges| with twins instead of leap edges and vice versa in
-  // WorldGraph::GetEdgeList()
+  // id for the whole Europe. Such cases are not processed in WorldGraph::GetEdgeList() for the time
+  // being. To prevent filling |edges| with twins instead of leap edges and vice versa in
+  // WorldGraph::GetEdgeList().
   // CrossMwmGraph::GetEdgeList() does not fill |edges| if |s| is a transition segment which
   // corresponces node id described above.
   if (IsTransition(s, isOutgoing))

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -143,7 +143,9 @@ void CrossMwmOsrmGraph::GetEdgeList(Segment const & s, bool isOutgoing,
         AddSegmentEdge(*m_numMwmIds, mapping->m_segMapping, edge, isOutgoing, s.GetMwmId(), edges);
     }
   };
-  LoadWith(s.GetMwmId(), fillEdgeList);
+  bool const isLoaded = LoadWith(s.GetMwmId(), fillEdgeList);
+  UNUSED_VALUE(isLoaded);
+  CHECK(isLoaded, ("Mmw", m_numMwmIds->GetFile(s.GetMwmId()), "was not loaded."));
 
   my::SortUnique(edges);
 }

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -1,13 +1,13 @@
 #pragma once
+
 #include "routing/num_mwm_id.hpp"
 #include "routing/routing_mapping.hpp"
 #include "routing/segment.hpp"
+#include "routing/transition_points.hpp"
 
 #include "geometry/latlon.hpp"
 
 #include "platform/country_file.hpp"
-
-#include "base/buffer_vector.hpp"
 
 #include <map>
 #include <memory>

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -56,14 +56,12 @@ private:
   std::vector<ms::LatLon> const & GetOutgoingTransitionPoints(Segment const & s);
 
   template <typename Fn>
-  bool LoadWith(NumMwmId numMwmId, Fn && fn)
+  void LoadWith(NumMwmId numMwmId, Fn && fn)
   {
     platform::CountryFile const & countryFile = m_numMwmIds->GetFile(numMwmId);
     TRoutingMappingPtr mapping = m_indexManager.GetMappingByName(countryFile.GetName());
     CHECK(mapping, ("No routing mapping file for countryFile:", countryFile));
-
-    if (!mapping->IsValid())
-      return false;  // mwm was not loaded.
+    CHECK(mapping->IsValid(), ("Mwm:", countryFile, "was not loaded."));
 
     auto const it = m_mappingGuards.find(numMwmId);
     if (it == m_mappingGuards.cend())
@@ -73,7 +71,6 @@ private:
     }
 
     fn(mapping);
-    return true;
   }
 
   std::shared_ptr<NumMwmIds> m_numMwmIds;

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -63,7 +63,7 @@ private:
     CHECK(mapping, ("No routing mapping file for countryFile:", countryFile));
 
     if (!mapping->IsValid())
-      return false; // mwm was not loaded.
+      return false;  // mwm was not loaded.
 
     auto const it = m_mappingGuards.find(numMwmId);
     if (it == m_mappingGuards.cend())
@@ -80,7 +80,8 @@ private:
 
   // OSRM based cross-mwm information.
   RoutingIndexManager & m_indexManager;
-  /// \note According to the constructor CrossMwmRoadGraph is initialized with RoutingIndexManager &.
+  /// \note According to the constructor CrossMwmRoadGraph is initialized with RoutingIndexManager
+  /// &.
   /// But then it is copied by value to CrossMwmRoadGraph::RoutingIndexManager m_indexManager.
   /// It means that there're two copies of RoutingIndexManager in CrossMwmGraph.
   std::unique_ptr<CrossMwmRoadGraph> m_crossMwmGraph;

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -1,0 +1,91 @@
+#pragma once
+#include "routing/num_mwm_id.hpp"
+#include "routing/routing_mapping.hpp"
+#include "routing/segment.hpp"
+
+#include "geometry/latlon.hpp"
+
+#include "platform/country_file.hpp"
+
+#include "base/buffer_vector.hpp"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace routing
+{
+struct BorderCross;
+class CrossMwmRoadGraph;
+
+using TransitionPoints = buffer_vector<m2::PointD, 1>;
+
+class CrossMwmOsrmGraph final
+{
+public:
+  CrossMwmOsrmGraph(std::shared_ptr<NumMwmIds> numMwmIds, RoutingIndexManager & indexManager);
+  ~CrossMwmOsrmGraph();
+
+  bool IsTransition(Segment const & s, bool isOutgoing);
+  void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  void Clear();
+  TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
+
+private:
+  struct TransitionSegments
+  {
+    std::map<Segment, std::vector<ms::LatLon>> m_ingoing;
+    std::map<Segment, std::vector<ms::LatLon>> m_outgoing;
+  };
+
+  /// \brief Inserts all ingoing and outgoing transition segments of mwm with |numMwmId|
+  /// to |m_transitionCache|. It works for OSRM section.
+  /// \returns Reference to TransitionSegments corresponded to |numMwmId|.
+  TransitionSegments const & LoadSegmentMaps(NumMwmId numMwmId);
+
+  /// \brief Fills |borderCrosses| of mwm with |mapping| according to |s|.
+  /// \param mapping if |isOutgoing| == true |mapping| is mapping ingoing (from) border cross.
+  /// If |isOutgoing| == false |mapping| is mapping outgoing (to) border cross.
+  /// \note |s| and |isOutgoing| params have the same restrictions which described in
+  /// GetEdgeList() method.
+  void GetBorderCross(TRoutingMappingPtr const & mapping, Segment const & s, bool isOutgoing,
+                      std::vector<BorderCross> & borderCrosses);
+
+  TransitionSegments const & GetSegmentMaps(NumMwmId numMwmId);
+  std::vector<ms::LatLon> const & GetIngoingTransitionPoints(Segment const & s);
+  std::vector<ms::LatLon> const & GetOutgoingTransitionPoints(Segment const & s);
+
+  template <typename Fn>
+  bool LoadWith(NumMwmId numMwmId, Fn && fn)
+  {
+    platform::CountryFile const & countryFile = m_numMwmIds->GetFile(numMwmId);
+    TRoutingMappingPtr mapping = m_indexManager.GetMappingByName(countryFile.GetName());
+    CHECK(mapping, ("No routing mapping file for countryFile:", countryFile));
+
+    if (!mapping->IsValid())
+      return false; // mwm was not loaded.
+
+    auto const it = m_mappingGuards.find(numMwmId);
+    if (it == m_mappingGuards.cend())
+    {
+      m_mappingGuards[numMwmId] = make_unique<MappingGuard>(mapping);
+      mapping->LoadCrossContext();
+    }
+
+    fn(mapping);
+    return true;
+  }
+
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
+
+  // OSRM based cross-mwm information.
+  RoutingIndexManager & m_indexManager;
+  /// \note According to the constructor CrossMwmRoadGraph is initialized with RoutingIndexManager &.
+  /// But then it is copied by value to CrossMwmRoadGraph::RoutingIndexManager m_indexManager.
+  /// It means that there're two copies of RoutingIndexManager in CrossMwmGraph.
+  std::unique_ptr<CrossMwmRoadGraph> m_crossMwmGraph;
+
+  std::map<NumMwmId, TransitionSegments> m_transitionCache;
+  std::map<NumMwmId, std::unique_ptr<MappingGuard>> m_mappingGuards;
+};
+}  // namespace routing

--- a/routing/cross_mwm_road_graph.cpp
+++ b/routing/cross_mwm_road_graph.cpp
@@ -124,8 +124,8 @@ bool FindCrossNode(CrossRoutingContextReader const & currentContext, CrossNode c
 template <class Fn>
 vector<BorderCross> const & ConstructBorderCrossImpl(
     TWrittenNodeId nodeId, TRoutingMappingPtr const & currentMapping,
-    unordered_map<CrossMwmRoadGraph::TCachingKey, vector<BorderCross>, CrossMwmRoadGraph::Hash> const &
-        cachedNextNodes,
+    unordered_map<CrossMwmRoadGraph::TCachingKey, vector<BorderCross>,
+                  CrossMwmRoadGraph::Hash> const & cachedNextNodes,
     Fn && borderCrossConstructor)
 {
   auto const key = make_pair(nodeId, currentMapping->GetMwmId());
@@ -260,9 +260,9 @@ IRouter::ResultCode CrossMwmRoadGraph::SetFinalNode(CrossNode const & finalNode)
   return IRouter::NoError;
 }
 
-bool CrossMwmRoadGraph::ConstructBorderCrossByOutgoingImpl(OutgoingCrossNode const & startNode,
-                                                           TRoutingMappingPtr const & currentMapping,
-                                                           vector<BorderCross> & crosses) const
+bool CrossMwmRoadGraph::ConstructBorderCrossByOutgoingImpl(
+    OutgoingCrossNode const & startNode, TRoutingMappingPtr const & currentMapping,
+    vector<BorderCross> & crosses) const
 {
   auto const fromCross = CrossNode(startNode.m_nodeId, currentMapping->GetMwmId(), startNode.m_point);
   string const & nextMwm = currentMapping->m_crossContext.GetOutgoingMwmName(startNode);

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -36,7 +36,7 @@ struct CrossNode final
   {
   }
 
-  CrossNode() : node(INVALID_NODE_ID), reverseNode(INVALID_NODE_ID), point(ms::LatLon::Zero()) {}
+  CrossNode() : node(INVALID_NODE_ID), reverseNode(INVALID_NODE_ID), point(ms::LatLon::Zero()), isVirtual(false) {}
 
   inline bool IsValid() const { return node != INVALID_NODE_ID; }
 
@@ -86,7 +86,7 @@ inline string DebugPrint(BorderCross const & t)
   return out.str();
 }
 
-/// A class which represents an cross mwm weighted edge used by CrossMwmGraph.
+/// A class which represents an cross mwm weighted edge used by CrossMwmRoadGraph.
 class CrossWeightedEdge final
 {
 public:
@@ -115,7 +115,7 @@ private:
 };
 
 /// A graph used for cross mwm routing in an astar algorithms.
-class CrossMwmGraph final
+class CrossMwmRoadGraph final
 {
 public:
   using TCachingKey = pair<TWrittenNodeId, Index::MwmId>;
@@ -130,7 +130,7 @@ public:
     }
   };
 
-  explicit CrossMwmGraph(RoutingIndexManager & indexManager) : m_indexManager(indexManager) {}
+  explicit CrossMwmRoadGraph(RoutingIndexManager & indexManager) : m_indexManager(indexManager) {}
   void GetOutgoingEdgesList(BorderCross const & v, vector<CrossWeightedEdge> & adj) const
   {
     GetEdgesList(v, true /* isOutgoing */, adj);
@@ -184,7 +184,7 @@ private:
 //--------------------------------------------------------------------------------------------------
 
 /*!
- * \brief Convertor from CrossMwmGraph to cross mwm route task.
+ * \brief Convertor from CrossMwmRoadGraph to cross mwm route task.
  * \warning It's assumed that the first and the last BorderCrosses are always virtual and represents
  * routing inside mwm.
  */

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -36,7 +36,13 @@ struct CrossNode final
   {
   }
 
-  CrossNode() : node(INVALID_NODE_ID), reverseNode(INVALID_NODE_ID), point(ms::LatLon::Zero()), isVirtual(false) {}
+  CrossNode()
+    : node(INVALID_NODE_ID)
+    , reverseNode(INVALID_NODE_ID)
+    , point(ms::LatLon::Zero())
+    , isVirtual(false)
+  {
+  }
 
   inline bool IsValid() const { return node != INVALID_NODE_ID; }
 

--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -12,10 +12,10 @@ namespace
 {
 /// Function to run AStar Algorithm from the base.
 IRouter::ResultCode CalculateRoute(BorderCross const & startPos, BorderCross const & finalPos,
-                                   CrossMwmGraph & roadGraph, RouterDelegate const & delegate,
+                                   CrossMwmRoadGraph & roadGraph, RouterDelegate const & delegate,
                                    RoutingResult<BorderCross> & route)
 {
-  using TAlgorithm = AStarAlgorithm<CrossMwmGraph>;
+  using TAlgorithm = AStarAlgorithm<CrossMwmRoadGraph>;
 
   TAlgorithm::TOnVisitedVertexCallback onVisitedVertex =
       [&delegate](BorderCross const & cross, BorderCross const & /* target */)
@@ -48,7 +48,7 @@ IRouter::ResultCode CalculateCrossMwmPath(TRoutingNodes const & startGraphNodes,
                                           double & cost,
                                           RouterDelegate const & delegate, TCheckedPath & route)
 {
-  CrossMwmGraph roadGraph(indexManager);
+  CrossMwmRoadGraph roadGraph(indexManager);
   FeatureGraphNode startGraphNode, finalGraphNode;
   CrossNode startNode, finalNode;
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -129,7 +129,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
 
   TrafficStash::Guard guard(*m_trafficStash);
   WorldGraph graph(
-      make_unique<CrossMwmIndexGraph>(m_numMwmIds, m_indexManager),
+      make_unique<CrossMwmGraph>(m_index, m_numMwmIds, m_vehicleModelFactory, m_indexManager),
       IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
       m_estimator);
   graph.SetMode(forSingleMwm ? WorldGraph::Mode::SingleMwm : WorldGraph::Mode::WorldWithLeaps);

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "routing/cross_mwm_index_graph.hpp"
+#include "routing/cross_mwm_graph.hpp"
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/features_road_graph.hpp"

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -19,7 +19,9 @@ SOURCES += \
     car_router.cpp \
     cross_mwm_connector.cpp \
     cross_mwm_connector_serialization.cpp \
+    cross_mwm_graph.cpp \
     cross_mwm_index_graph.cpp \
+    cross_mwm_osrm_graph.cpp \
     cross_mwm_road_graph.cpp \
     cross_mwm_router.cpp \
     cross_routing_context.cpp \
@@ -74,7 +76,9 @@ HEADERS += \
     coding.hpp \
     cross_mwm_connector.hpp \
     cross_mwm_connector_serialization.hpp \
+    cross_mwm_graph.hpp \
     cross_mwm_index_graph.hpp \
+    cross_mwm_osrm_graph.hpp \
     cross_mwm_road_graph.hpp \
     cross_mwm_router.hpp \
     cross_routing_context.hpp \

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -127,6 +127,7 @@ HEADERS += \
     segment.hpp \
     speed_camera.hpp \
     traffic_stash.hpp \
+    transition_points.hpp \
     turn_candidate.hpp \
     turns.hpp \
     turns_generator.hpp \

--- a/routing/routing_integration_tests/cross_section_tests.cpp
+++ b/routing/routing_integration_tests/cross_section_tests.cpp
@@ -169,7 +169,7 @@ UNIT_TEST(CrossMwmGraphTest)
   };
 
   RoutingIndexManager manager(countryFileGetter, index);
-  CrossMwmGraph crossMwmGraph(manager);
+  CrossMwmRoadGraph crossMwmGraph(manager);
 
   auto const seed = std::chrono::system_clock::now().time_since_epoch().count();
   LOG(LINFO, ("Seed for RandomSample:", seed));

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -15,14 +15,14 @@ void TestConnectorConsistency(CrossMwmConnector const & connector)
 {
   for (Segment const & enter : connector.GetEnters())
   {
-    TEST(connector.IsTransition(enter, true /* isOutgoing */), ("enter:", enter));
-    TEST(!connector.IsTransition(enter, false /* isOutgoing */), ("enter:", enter));
+    TEST(connector.IsTransition(enter, false /* isOutgoing */), ("enter:", enter));
+    TEST(!connector.IsTransition(enter, true /* isOutgoing */), ("enter:", enter));
   }
 
   for (Segment const & exit : connector.GetExits())
   {
-    TEST(!connector.IsTransition(exit, true /* isOutgoing */), ("exit:", exit));
-    TEST(connector.IsTransition(exit, false /* isOutgoing */), ("exit:", exit));
+    TEST(!connector.IsTransition(exit, false /* isOutgoing */), ("exit:", exit));
+    TEST(connector.IsTransition(exit, true /* isOutgoing */), ("exit:", exit));
   }
 }
 
@@ -48,11 +48,11 @@ UNIT_TEST(OneWayEnter)
   TestConnectorConsistency(connector);
   TEST_EQUAL(connector.GetEnters().size(), 1, ());
   TEST_EQUAL(connector.GetExits().size(), 0, ());
-  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                              true /* isOutgoing */),
-       ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                               false /* isOutgoing */),
+                               true /* isOutgoing */),
+       ());
+  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
+                              false /* isOutgoing */),
        ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
                                true /* isOutgoing */),
@@ -73,11 +73,11 @@ UNIT_TEST(OneWayExit)
   TestConnectorConsistency(connector);
   TEST_EQUAL(connector.GetEnters().size(), 0, ());
   TEST_EQUAL(connector.GetExits().size(), 1, ());
-  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                               true /* isOutgoing */),
-       ());
   TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                              false /* isOutgoing */),
+                              true /* isOutgoing */),
+       ());
+  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
+                               false /* isOutgoing */),
        ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
                                true /* isOutgoing */),
@@ -98,17 +98,17 @@ UNIT_TEST(TwoWayEnter)
   TestConnectorConsistency(connector);
   TEST_EQUAL(connector.GetEnters().size(), 1, ());
   TEST_EQUAL(connector.GetExits().size(), 1, ());
-  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                              true /* isOutgoing */),
-       ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                               false /* isOutgoing */),
-       ());
-  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
                                true /* isOutgoing */),
        ());
-  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                               false /* isOutgoing */),
+       ());
+  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+                              true /* isOutgoing */),
+       ());
+  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+                               false /* isOutgoing */),
        ());
 }
 
@@ -123,17 +123,17 @@ UNIT_TEST(TwoWayExit)
   TestConnectorConsistency(connector);
   TEST_EQUAL(connector.GetEnters().size(), 1, ());
   TEST_EQUAL(connector.GetExits().size(), 1, ());
-  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                               true /* isOutgoing */),
-       ());
   TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
-                              false /* isOutgoing */),
-       ());
-  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
                               true /* isOutgoing */),
        ());
-  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                                false /* isOutgoing */),
+       ());
+  TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+                               true /* isOutgoing */),
+       ());
+  TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, false /* forward */),
+                              false /* isOutgoing */),
        ());
 }
 
@@ -176,22 +176,22 @@ UNIT_TEST(Serialization)
 
   TEST(!connector.IsTransition(Segment(mwmId, 0, 0, true), true /* isOutgoing */), ());
 
-  TEST(connector.IsTransition(Segment(mwmId, 10, 1, true /* forward */), true /* isOutgoing */),
+  TEST(!connector.IsTransition(Segment(mwmId, 10, 1, true /* forward */), true /* isOutgoing */),
        ());
-  TEST(!connector.IsTransition(Segment(mwmId, 10, 1, true /* forward */), false /* isOutgoing */),
+  TEST(connector.IsTransition(Segment(mwmId, 10, 1, true /* forward */), false /* isOutgoing */),
        ());
   TEST(!connector.IsTransition(Segment(mwmId, 10, 1, false /* forward */), true /* isOutgoing */),
        ());
   TEST(!connector.IsTransition(Segment(mwmId, 10, 1, false /* forward */), false /* isOutgoing */),
        ());
 
-  TEST(connector.IsTransition(Segment(mwmId, 20, 2, true /* forward */), true /* isOutgoing */),
+  TEST(!connector.IsTransition(Segment(mwmId, 20, 2, true /* forward */), true /* isOutgoing */),
        ());
-  TEST(!connector.IsTransition(Segment(mwmId, 20, 2, true /* forward */), false /* isOutgoing */),
+  TEST(connector.IsTransition(Segment(mwmId, 20, 2, true /* forward */), false /* isOutgoing */),
        ());
-  TEST(!connector.IsTransition(Segment(mwmId, 20, 2, false /* forward */), true /* isOutgoing */),
+  TEST(connector.IsTransition(Segment(mwmId, 20, 2, false /* forward */), true /* isOutgoing */),
        ());
-  TEST(connector.IsTransition(Segment(mwmId, 20, 2, false /* forward */), false /* isOutgoing */),
+  TEST(!connector.IsTransition(Segment(mwmId, 20, 2, false /* forward */), false /* isOutgoing */),
        ());
 
   TEST(!connector.IsTransition(Segment(mwmId, 30, 3, true /* forward */), true /* isOutgoing */),

--- a/routing/transition_points.hpp
+++ b/routing/transition_points.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "base/buffer_vector.hpp"
+
+namespace routing
+{
+using TransitionPoints = buffer_vector<m2::PointD, 1>;
+}  // namespace routing

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,7 +4,7 @@ namespace routing
 {
 using namespace std;
 
-WorldGraph::WorldGraph(unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
+WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
                        unique_ptr<IndexGraphLoader> loader, shared_ptr<EdgeEstimator> estimator)
   : m_crossMwmGraph(move(crossMwmGraph)), m_loader(move(loader)), m_estimator(estimator)
 {

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,8 +4,8 @@ namespace routing
 {
 using namespace std;
 
-WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
-                       unique_ptr<IndexGraphLoader> loader, shared_ptr<EdgeEstimator> estimator)
+WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph, unique_ptr<IndexGraphLoader> loader,
+                       shared_ptr<EdgeEstimator> estimator)
   : m_crossMwmGraph(move(crossMwmGraph)), m_loader(move(loader)), m_estimator(estimator)
 {
   CHECK(m_loader, ());

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "routing/cross_mwm_index_graph.hpp"
+#include "routing/cross_mwm_graph.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
@@ -23,7 +23,7 @@ public:
     WorldWithoutLeaps,
   };
 
-  WorldGraph(std::unique_ptr<CrossMwmIndexGraph> crossMwmGraph,
+  WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
              std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
 
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
@@ -42,7 +42,7 @@ public:
 private:  
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
-  std::unique_ptr<CrossMwmIndexGraph> m_crossMwmGraph;
+  std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::vector<Segment> m_twins;

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -23,8 +23,8 @@ public:
     WorldWithoutLeaps,
   };
 
-  WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
-             std::unique_ptr<IndexGraphLoader> loader, std::shared_ptr<EdgeEstimator> estimator);
+  WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph, std::unique_ptr<IndexGraphLoader> loader,
+             std::shared_ptr<EdgeEstimator> estimator);
 
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                    std::vector<SegmentEdge> & edges);

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -63,6 +63,11 @@
 		56555E591D897D28009D786D /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6742ACDE1C68A13F009CB89E /* testingmain.cpp */; };
 		56826BD01DB51C4E00807C62 /* car_router.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56826BCE1DB51C4E00807C62 /* car_router.cpp */; };
 		56826BD11DB51C4E00807C62 /* car_router.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56826BCF1DB51C4E00807C62 /* car_router.hpp */; };
+		56C439281E93BF8C00998E29 /* cross_mwm_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */; };
+		56C439291E93BF8C00998E29 /* cross_mwm_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */; };
+		56C4392A1E93BF8C00998E29 /* cross_mwm_osrm_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C439261E93BF8C00998E29 /* cross_mwm_osrm_graph.cpp */; };
+		56C4392B1E93BF8C00998E29 /* cross_mwm_osrm_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C439271E93BF8C00998E29 /* cross_mwm_osrm_graph.hpp */; };
+		56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C4392C1E93E5DF00998E29 /* transition_points.hpp */; };
 		56CA09E31E30E73B00D05C9A /* applying_traffic_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09DE1E30E73B00D05C9A /* applying_traffic_test.cpp */; };
 		56CA09E41E30E73B00D05C9A /* cumulative_restriction_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09DF1E30E73B00D05C9A /* cumulative_restriction_test.cpp */; };
 		56CA09E51E30E73B00D05C9A /* index_graph_tools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09E01E30E73B00D05C9A /* index_graph_tools.cpp */; };
@@ -315,6 +320,11 @@
 		56099E321CC9247E00A7772A /* directions_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = directions_engine.cpp; sourceTree = "<group>"; };
 		56826BCE1DB51C4E00807C62 /* car_router.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = car_router.cpp; sourceTree = "<group>"; };
 		56826BCF1DB51C4E00807C62 /* car_router.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = car_router.hpp; sourceTree = "<group>"; };
+		56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_mwm_graph.cpp; sourceTree = "<group>"; };
+		56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_graph.hpp; sourceTree = "<group>"; };
+		56C439261E93BF8C00998E29 /* cross_mwm_osrm_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_mwm_osrm_graph.cpp; sourceTree = "<group>"; };
+		56C439271E93BF8C00998E29 /* cross_mwm_osrm_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_osrm_graph.hpp; sourceTree = "<group>"; };
+		56C4392C1E93E5DF00998E29 /* transition_points.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_points.hpp; sourceTree = "<group>"; };
 		56CA09DE1E30E73B00D05C9A /* applying_traffic_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = applying_traffic_test.cpp; sourceTree = "<group>"; };
 		56CA09DF1E30E73B00D05C9A /* cumulative_restriction_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cumulative_restriction_test.cpp; sourceTree = "<group>"; };
 		56CA09E01E30E73B00D05C9A /* index_graph_tools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_tools.cpp; sourceTree = "<group>"; };
@@ -712,6 +722,11 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				56C4392C1E93E5DF00998E29 /* transition_points.hpp */,
+				56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */,
+				56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */,
+				56C439261E93BF8C00998E29 /* cross_mwm_osrm_graph.cpp */,
+				56C439271E93BF8C00998E29 /* cross_mwm_osrm_graph.hpp */,
 				56D637D51E4B12AA00B86D7B /* cross_mwm_index_graph.cpp */,
 				674F9BBA1B0A580E00704FFA /* async_router.cpp */,
 				674F9BBB1B0A580E00704FFA /* async_router.hpp */,
@@ -878,6 +893,7 @@
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
 				349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */,
 				A17B42991BCFBD0E00A1EAE4 /* osrm_helpers.hpp in Headers */,
+				56C4392B1E93BF8C00998E29 /* cross_mwm_osrm_graph.hpp in Headers */,
 				56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */,
 				67C7D42E1B4EB48F00FE41AA /* turns_sound_settings.hpp in Headers */,
 				56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */,
@@ -894,6 +910,7 @@
 				A1616E2E1B6B60B3003F078E /* astar_progress.hpp in Headers */,
 				0C090C821E4E274000D52AFD /* index_graph_loader.hpp in Headers */,
 				670EE5721B664796001E8064 /* directions_engine.hpp in Headers */,
+				56C439291E93BF8C00998E29 /* cross_mwm_graph.hpp in Headers */,
 				0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */,
 				A1876BC71BB19C4300C9C743 /* speed_camera.hpp in Headers */,
 				56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */,
@@ -910,6 +927,7 @@
 				A120B3511B4A7C0A002F3808 /* routing_algorithm.hpp in Headers */,
 				0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */,
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
+				56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */,
 				0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */,
 				670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */,
 				0C12ED241E5C822A0080D0F4 /* index_router.hpp in Headers */,
@@ -1129,6 +1147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
+				56C4392A1E93BF8C00998E29 /* cross_mwm_osrm_graph.cpp in Sources */,
 				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
 				0C5F5D201E798B0400307B98 /* cross_mwm_connector_serialization.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
@@ -1143,6 +1162,7 @@
 				56D637D61E4B12AA00B86D7B /* cross_mwm_index_graph.cpp in Sources */,
 				0C0DF9211DE898B70055A22F /* index_graph_starter.cpp in Sources */,
 				A120B3471B4A7BE5002F3808 /* cross_mwm_router.cpp in Sources */,
+				56C439281E93BF8C00998E29 /* cross_mwm_graph.cpp in Sources */,
 				670EE5731B664796001E8064 /* pedestrian_directions.cpp in Sources */,
 				6753441B1A3F644F00A0A8C3 /* route.cpp in Sources */,
 				674F9BCA1B0A580E00704FFA /* async_router.cpp in Sources */,


### PR DESCRIPTION
Реализация методов по получению меж mwm-ой информации на базе новой (не OSRM) секции (cross_mwm). Поддержка получения меж mwm-ой информации для смеси mwm с OSRM и без.

Ограничения:
- сейчас не корректно работает метод: CrossMwmIndexGraph::GetEdgeList() на новых mwm. Онa возвращает переходы через mwm, но маршрут потом не прокладывается. Вероятно, не удается получить близнецы к этим переходам. Вероятно, сами переходы не корректны. Буду разбираться.
- если карта состоит из смеси mwm, не все переходы через смешанную границу (не osrm - osrm) возвращаются корректно. Похожий баг был и ранее переходом через границы osrm-osrm. Данный баг я не планирую лечить, поскольку ресурсы ограничены. Важно, чтоб на новых mwm все отрабатывало корректно.

@dobriy-eeh @ygorshenin @mpimenov PTAL