### PR TITLE
[routing] Cross mwm section compression

### DIFF
--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace routing
 {
-bool BuildRoutingIndex(string const & filename, string const & country);
-void BuildCrossMwmSection(string const & path, string const & mwmFile, string const & country);
+bool BuildRoutingIndex(std::string const & filename, std::string const & country);
+void BuildCrossMwmSection(std::string const & path, std::string const & mwmFile,
+                          std::string const & country);
 }  // namespace routing

--- a/geometry/region2d.hpp
+++ b/geometry/region2d.hpp
@@ -154,12 +154,12 @@ namespace m2
       std::swap(m_rect, rhs.m_rect);
     }
 
-    ContainerT Data() const { return m_points; }
+    ContainerT const & Data() const { return m_points; }
 
     template <class TEqualF>
-    inline bool IsIntersect(CoordT const & x11, CoordT const & y11, CoordT const & x12, CoordT const & y12,
+    static inline bool IsIntersect(CoordT const & x11, CoordT const & y11, CoordT const & x12, CoordT const & y12,
                             CoordT const & x21, CoordT const & y21, CoordT const & x22, CoordT const & y22,
-                            TEqualF equalF, PointT & pt) const
+                            TEqualF equalF, PointT & pt)
     {
       double const divider = ((y12 - y11) * (x22 - x21) - (x12 - x11) * (y22-y21));
       if (equalF.EqualZeroSquarePrecision(divider))
@@ -180,7 +180,7 @@ namespace m2
       return true;
     }
 
-    inline bool IsIntersect(PointT const & p1, PointT const & p2, PointT const & p3, PointT const & p4 , PointT & pt) const
+    static inline bool IsIntersect(PointT const & p1, PointT const & p2, PointT const & p3, PointT const & p4 , PointT & pt)
     {
       return IsIntersect(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y, typename TraitsT::EqualType(), pt);
     }

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
   bicycle_directions.hpp
   car_router.cpp
   car_router.hpp
+  coding.hpp
   cross_mwm_connector.cpp
   cross_mwm_connector.hpp
   cross_mwm_connector_serialization.cpp

--- a/routing/coding.hpp
+++ b/routing/coding.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "routing/routing_exceptions.hpp"
+
+#include "coding/bit_streams.hpp"
+#include "coding/elias_coder.hpp"
+
+#include "base/assert.hpp"
+#include "base/bits.hpp"
+#include "base/checked_cast.hpp"
+#include "base/macros.hpp"
+
+#include <limits>
+#include <type_traits>
+
+namespace routing
+{
+template <typename T, typename Source>
+T ReadDelta(BitReader<Source> & reader)
+{
+  static_assert(std::is_unsigned<T>::value, "T should be an unsigned type");
+  uint64_t const decoded = coding::DeltaCoder::Decode(reader);
+  if (decoded > std::numeric_limits<T>::max())
+  {
+    MYTHROW(CorruptedDataException,
+            ("Decoded value", decoded, "out of limit", std::numeric_limits<T>::max()));
+  }
+
+  return static_cast<T>(decoded);
+}
+
+template <typename T, typename Sink>
+void WriteDelta(BitWriter<Sink> & writer, T value)
+{
+  static_assert(std::is_unsigned<T>::value, "T should be an unsigned type");
+  ASSERT_GREATER(value, 0, ());
+
+  bool const success = coding::DeltaCoder::Encode(writer, static_cast<uint64_t>(value));
+  ASSERT(success, ());
+  UNUSED_VALUE(success);
+}
+
+template <typename T, typename Source>
+T ReadGamma(BitReader<Source> & reader)
+{
+  static_assert(std::is_unsigned<T>::value, "T should be an unsigned type");
+  uint64_t const decoded = coding::GammaCoder::Decode(reader);
+  if (decoded > std::numeric_limits<T>::max())
+  {
+    MYTHROW(CorruptedDataException,
+            ("Decoded value", decoded, "out of limit", std::numeric_limits<T>::max()));
+  }
+
+  return static_cast<T>(decoded);
+}
+
+template <typename T, typename Sink>
+void WriteGamma(BitWriter<Sink> & writer, T value)
+{
+  static_assert(std::is_unsigned<T>::value, "T should be an unsigned type");
+  ASSERT_GREATER(value, 0, ());
+
+  bool const success = coding::GammaCoder::Encode(writer, static_cast<uint64_t>(value));
+  ASSERT(success, ());
+  UNUSED_VALUE(success);
+}
+
+// C++ standart says:
+// if the value can't be represented in the destination unsigned type,
+// the result is implementation-defined.
+//
+// ModularCast makes unambiguous conversion from unsigned value to signed.
+// The resulting value is the least signed integer congruent to the source integer
+// (modulo 2^n where n is the number of bits used to represent the unsigned type)
+template <typename Unsigned, typename Signed = typename std::make_signed<Unsigned>::type>
+Signed ModularCast(Unsigned value)
+{
+  static_assert(std::is_unsigned<Unsigned>::value, "T should be an unsigned type");
+
+  if (value <= static_cast<Unsigned>(std::numeric_limits<Signed>::max()))
+    return static_cast<Signed>(value);
+
+  auto constexpr minSignedT = std::numeric_limits<Signed>::min();
+  return static_cast<Signed>(value - static_cast<Unsigned>(minSignedT)) + minSignedT;
+}
+
+// Encodes current as delta compared with prev.
+template <typename T, typename UnsignedT = typename std::make_unsigned<T>::type>
+UnsignedT EncodeZigZagDelta(T prev, T current)
+{
+  static_assert(std::is_integral<T>::value, "T should be an integral type");
+  using SignedT = typename std::make_signed<T>::type;
+
+  auto const unsignedPrev = static_cast<UnsignedT>(prev);
+  auto const unsignedCurrent = static_cast<UnsignedT>(current);
+  auto originalDelta = ModularCast(static_cast<UnsignedT>(unsignedCurrent - unsignedPrev));
+  static_assert(std::is_same<decltype(originalDelta), SignedT>::value,
+                "It's expected that ModuleCast returns SignedT");
+
+  auto encodedDelta = bits::ZigZagEncode(originalDelta);
+  static_assert(std::is_same<decltype(encodedDelta), UnsignedT>::value,
+                "It's expected that bits::ZigZagEncode returns UnsignedT");
+  return encodedDelta;
+}
+
+// Reverse function for EncodeZigZagDelta.
+template <typename T, typename UnsignedT = typename std::make_unsigned<T>::type>
+T DecodeZigZagDelta(T prev, UnsignedT delta)
+{
+  static_assert(std::is_integral<T>::value, "T should be an integral type");
+  using SignedT = typename std::make_signed<T>::type;
+
+  auto decoded = bits::ZigZagDecode(delta);
+  static_assert(std::is_same<decltype(decoded), SignedT>::value,
+                "It's expected that bits::ZigZagDecode returns SignedT");
+  return prev + static_cast<T>(decoded);
+}
+}  // namespace routing

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -147,6 +147,7 @@ private:
   std::unordered_map<Key, Transition, HashKey> m_transitions;
   WeightsLoadState m_weightsLoadState = WeightsLoadState::Unknown;
   uint64_t m_weightsOffset = 0;
+  Weight m_accuracy = 0;
   std::vector<Weight> m_weights;
 };
 }  // namespace routing

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -147,7 +147,7 @@ private:
   std::unordered_map<Key, Transition, HashKey> m_transitions;
   WeightsLoadState m_weightsLoadState = WeightsLoadState::Unknown;
   uint64_t m_weightsOffset = 0;
-  Weight m_accuracy = 0;
+  Weight m_granularity = 0;
   std::vector<Weight> m_weights;
 };
 }  // namespace routing

--- a/routing/cross_mwm_connector_serialization.cpp
+++ b/routing/cross_mwm_connector_serialization.cpp
@@ -35,8 +35,8 @@ void CrossMwmConnectorSerializer::WriteWeights(vector<Weight> const & weights,
     }
 
     writer.Write(kRouteBit, 1);
-    auto const storedWeight = (weight + kAccuracy - 1) / kAccuracy;
-    WriteDelta(writer, EncodePositivesDelta(prevWeight, storedWeight));
+    auto const storedWeight = (weight + kGranularity - 1) / kGranularity;
+    WriteDelta(writer, EncodeZigZagDelta(prevWeight, storedWeight) + 1);
     prevWeight = storedWeight;
   }
 }

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -71,6 +71,7 @@ HEADERS += \
     base/followed_polyline.hpp \
     bicycle_directions.hpp \
     car_router.hpp \
+    coding.hpp \
     cross_mwm_connector.hpp \
     cross_mwm_connector_serialization.hpp \
     cross_mwm_index_graph.hpp \

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(
   astar_progress_test.cpp
   astar_router_test.cpp
   async_router_test.cpp
+  coding_test.cpp
   cross_mwm_connector_test.cpp
   cross_routing_tests.cpp
   cumulative_restriction_test.cpp

--- a/routing/routing_tests/coding_test.cpp
+++ b/routing/routing_tests/coding_test.cpp
@@ -1,0 +1,93 @@
+#include "testing/testing.hpp"
+
+#include "routing/coding.hpp"
+
+#include <limits>
+#include <type_traits>
+
+using namespace routing;
+
+namespace
+{
+template <typename T, typename ToDo>
+void ForEachNumber(ToDo && toDo)
+{
+  for (T number = numeric_limits<T>::min();; ++number)
+  {
+    toDo(number);
+
+    if (number == numeric_limits<T>::max())
+      break;
+  }
+}
+
+template <typename T>
+void TestZigZag(T prev, T current)
+{
+  auto const delta = EncodeZigZagDelta(prev, current);
+  auto const decodedCurrent = DecodeZigZagDelta(prev, delta);
+  TEST_EQUAL(decodedCurrent, current, ("prev:", prev, "delta:", delta));
+}
+
+template <typename T>
+void TestZigZagUnsigned()
+{
+  static_assert(std::is_unsigned<T>::value, "T should be an unsigned type");
+
+  constexpr auto max = std::numeric_limits<T>::max();
+  constexpr T values[] = {0, 1, 7, max / 2, max - 1, max};
+  for (T prev : values)
+  {
+    for (T current : values)
+      TestZigZag(prev, current);
+  }
+}
+
+template <typename T>
+void TestZigZagSigned()
+{
+  static_assert(std::is_signed<T>::value, "T should be a signed type");
+
+  constexpr auto min = std::numeric_limits<T>::min();
+  constexpr auto max = std::numeric_limits<T>::max();
+  constexpr T values[] = {min, min + 1, min / 2, -7, -1, 0, 1, 7, max / 2, max - 1, max};
+  for (T prev : values)
+  {
+    for (T current : values)
+      TestZigZag(prev, current);
+  }
+}
+}  // namespace
+
+namespace routing_test
+{
+UNIT_TEST(ModuleCastTest)
+{
+  ForEachNumber<uint8_t>([](uint8_t number) {
+    auto signedNumber = ModularCast(number);
+    static_assert(std::is_same<decltype(signedNumber), int8_t>::value, "int8_t expected");
+    TEST_EQUAL(static_cast<uint8_t>(signedNumber), number, ("signedNumber:", signedNumber));
+  });
+}
+
+UNIT_TEST(ZigZagUint8)
+{
+  ForEachNumber<uint8_t>([](uint8_t prev) {
+    ForEachNumber<uint8_t>([&](uint8_t current) { TestZigZag(prev, current); });
+  });
+}
+
+UNIT_TEST(ZigZagInt8)
+{
+  ForEachNumber<int8_t>([](int8_t prev) {
+    ForEachNumber<int8_t>([&](int8_t current) { TestZigZag(prev, current); });
+  });
+}
+
+UNIT_TEST(ZigZagUint16) { TestZigZagUnsigned<uint16_t>(); }
+UNIT_TEST(ZigZagInt16) { TestZigZagSigned<int16_t>(); }
+UNIT_TEST(ZigZagUint32) { TestZigZagUnsigned<uint32_t>(); }
+UNIT_TEST(ZigZagInt32) { TestZigZagSigned<int32_t>(); }
+UNIT_TEST(ZigZagUint64) { TestZigZagUnsigned<uint64_t>(); }
+UNIT_TEST(ZigZagInt64) { TestZigZagSigned<int64_t>(); }
+}  // namespace routing_test

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -240,7 +240,7 @@ UNIT_TEST(Serialization)
 UNIT_TEST(WeightsSerialization)
 {
   size_t constexpr kNumTransitions = 3;
-  std::vector<double> const weights = {
+  vector<double> const weights = {
       4.0,  20.0, CrossMwmConnector::kNoRoute, 12.0, CrossMwmConnector::kNoRoute, 40.0, 48.0,
       24.0, 12.0};
   TEST_EQUAL(weights.size(), kNumTransitions * kNumTransitions, ());
@@ -301,7 +301,10 @@ UNIT_TEST(WeightsSerialization)
     {
       auto const weight = weights[weightIdx];
       if (weight != CrossMwmConnector::kNoRoute)
-        expectedEdges.emplace_back(Segment(mwmId, exitId, 1, false /* forward */), weight);
+      {
+        expectedEdges.emplace_back(Segment(mwmId, exitId, 1 /* segmentIdx */, false /* forward */),
+                                   weight);
+      }
       ++weightIdx;
     }
 

--- a/routing/routing_tests/routing_tests.pro
+++ b/routing/routing_tests/routing_tests.pro
@@ -26,6 +26,7 @@ SOURCES += \
   astar_progress_test.cpp \
   astar_router_test.cpp \
   async_router_test.cpp \
+  coding_test.cpp \
   cross_mwm_connector_test.cpp \
   cross_routing_tests.cpp \
   cumulative_restriction_test.cpp \

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -44,7 +44,9 @@
 		0C5FEC6A1DDE193F0017688C /* road_index.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5FEC671DDE193F0017688C /* road_index.hpp */; };
 		0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C5FEC681DDE193F0017688C /* road_point.hpp */; };
 		0C5FEC6D1DDE19A40017688C /* index_graph_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FEC6C1DDE19A40017688C /* index_graph_test.cpp */; };
+		0C62BFE61E8ADC3100055A79 /* coding.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C62BFE51E8ADC3100055A79 /* coding.hpp */; };
 		0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0C8705041E0182F200BCAF71 /* route_point.hpp */; };
+		0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CF5E8A91E8EA7A1001ED497 /* coding_test.cpp */; };
 		3462FDAD1DC1E5BF00906FD7 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */; };
 		349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */; };
 		349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */; };
@@ -295,7 +297,9 @@
 		0C5FEC671DDE193F0017688C /* road_index.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_index.hpp; sourceTree = "<group>"; };
 		0C5FEC681DDE193F0017688C /* road_point.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_point.hpp; sourceTree = "<group>"; };
 		0C5FEC6C1DDE19A40017688C /* index_graph_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_test.cpp; sourceTree = "<group>"; };
+		0C62BFE51E8ADC3100055A79 /* coding.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = coding.hpp; sourceTree = "<group>"; };
 		0C8705041E0182F200BCAF71 /* route_point.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_point.hpp; sourceTree = "<group>"; };
+		0CF5E8A91E8EA7A1001ED497 /* coding_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coding_test.cpp; sourceTree = "<group>"; };
 		3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-build/xcode/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restrictions_serialization.cpp; sourceTree = "<group>"; };
 		349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
@@ -589,6 +593,7 @@
 				6742ACA71C68A0B1009CB89E /* astar_progress_test.cpp */,
 				6742ACA81C68A0B1009CB89E /* astar_router_test.cpp */,
 				6742ACA91C68A0B1009CB89E /* async_router_test.cpp */,
+				0CF5E8A91E8EA7A1001ED497 /* coding_test.cpp */,
 				0C5F5D241E798B3800307B98 /* cross_mwm_connector_test.cpp */,
 				6742ACAA1C68A0B1009CB89E /* cross_routing_tests.cpp */,
 				6742ACAB1C68A0B1009CB89E /* followed_polyline_test.cpp */,
@@ -715,6 +720,7 @@
 				56099E311CC9247E00A7772A /* bicycle_directions.hpp */,
 				56826BCE1DB51C4E00807C62 /* car_router.cpp */,
 				56826BCF1DB51C4E00807C62 /* car_router.hpp */,
+				0C62BFE51E8ADC3100055A79 /* coding.hpp */,
 				0C5F5D1E1E798B0400307B98 /* cross_mwm_connector.cpp */,
 				0C5F5D1F1E798B0400307B98 /* cross_mwm_connector.hpp */,
 				0C5F5D1C1E798B0400307B98 /* cross_mwm_connector_serialization.cpp */,
@@ -898,6 +904,7 @@
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
 				670D049F1B0B4A970013A7AC /* nearest_edge_finder.hpp in Headers */,
 				A120B34F1B4A7C0A002F3808 /* online_absent_fetcher.hpp in Headers */,
+				0C62BFE61E8ADC3100055A79 /* coding.hpp in Headers */,
 				674F9BD51B0A580E00704FFA /* road_graph.hpp in Headers */,
 				56826BD11DB51C4E00807C62 /* car_router.hpp in Headers */,
 				A120B3511B4A7C0A002F3808 /* routing_algorithm.hpp in Headers */,
@@ -1140,6 +1147,7 @@
 				6753441B1A3F644F00A0A8C3 /* route.cpp in Sources */,
 				674F9BCA1B0A580E00704FFA /* async_router.cpp in Sources */,
 				0C5F5D221E798B0400307B98 /* cross_mwm_connector.cpp in Sources */,
+				0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */,
 				675344191A3F644F00A0A8C3 /* osrm2feature_map.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,
 				0C5F5D251E798B3800307B98 /* cross_mwm_connector_test.cpp in Sources */,


### PR DESCRIPTION
Сжатие cross mwm секции.

Веса прыжковых дуг (leaps) хранятся с точностью до 4 секунд.
С этой точностью для Москвы секция занимает ~800 kb.

Каждое увеличение точности в два раза стоит 100 kb
То есть если хранить с точностью до 2 секунд будет занимать ~900 kb
Если до 1 секунды - то 1 mb

Алгоритм сжатия:
Сортируем переходы вдоль границы по часовой стрелке, далее пишем разницу delta кодером.