### PR TITLE
MacDeployQtFix until we use Qt 5.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3party/Alohalytics"]
 	path = 3party/Alohalytics
 	url = git://github.com/mapsme/Alohalytics.git
+[submodule "tools/macdeployqtfix"]
+	path = tools/macdeployqtfix
+	url = git://github.com/aurelien-rainone/macdeployqtfix.git

--- a/tools/unix/build_designer.sh
+++ b/tools/unix/build_designer.sh
@@ -30,6 +30,8 @@ rm -rf "$RELEASE_PATH"
 # Prepare app package by copying Qt, Kothic, Skin Generator, Style tests
 for i in skin_generator style_tests generator_tool MAPS.ME.Designer; do
   "$(dirname "$QMAKE")/macdeployqt" "$RELEASE_PATH/$i.app"
+  [ -z "${QTPATH-}" ] && QTPATH="$(otool -L "$RELEASE_PATH/$i.app/Contents/Frameworks/QtGui.framework/QtGui" | grep QtCore | sed -e 's/^[[:space:]]*\(.*\)lib\/QtCore.framework.*$/\1/')"
+  python "$OMIM_PATH/tools/macdeployqtfix/macdeployqtfix.py" -q -nl "$RELEASE_PATH/$i.app/Contents/MacOS/$i" "$QTPATH"
 done
 
 MAC_RESOURCES="$RELEASE_PATH/MAPS.ME.Designer.app/Contents/Resources"


### PR DESCRIPTION
Используем https://github.com/aurelien-rainone/macdeployqtfix , чтобы собранные пакеты использовали правильные модули Qt.

(NB: пул-реквест в ветку designer tool)