### PR TITLE
[osm2ft] Write osm ids for all features, not just for roads

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -540,9 +540,11 @@ namespace feature
           fb.GetMetadata().Serialize(*w);
         }
 
-        uint64_t const osmID = fb.GetWayIDForRouting();
-        if (osmID != 0)
-          m_osm2ft.Add(make_pair(osmID, featureId));
+        if (!fb.GetOsmIds().empty())
+        {
+          osm::Id const osmId = fb.GetMostGenericOsmId();
+          m_osm2ft.Add(make_pair(osmId, featureId));
+        }
       };
       return featureId;
     }

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -3,6 +3,7 @@
 #include "testing/testing.hpp"
 
 #include "generator/gen_mwm_info.hpp"
+#include "generator/osm_id.hpp"
 
 #include "coding/file_writer.hpp"
 
@@ -16,7 +17,7 @@ void ReEncodeOsmIdsToFeatureIdsMapping(string const & mappingContent, string con
 {
   strings::SimpleTokenizer lineIter(mappingContent, "\n\r" /* line delimiters */);
 
-  gen::Accumulator<pair<uint64_t, uint32_t>> osmIdsToFeatureIds;
+  gen::Accumulator<pair<osm::Id, uint32_t>> osmIdsToFeatureIds;
   for (; lineIter; ++lineIter)
   {
     strings::SimpleTokenizer idIter(*lineIter, ", \t" /* id delimiters */);
@@ -29,7 +30,7 @@ void ReEncodeOsmIdsToFeatureIdsMapping(string const & mappingContent, string con
     uint32_t featureId = 0;
     TEST(idIter, ());
     TEST(strings::to_uint(*idIter, featureId), ("Cannot convert to uint:", *idIter));
-    osmIdsToFeatureIds.Add(make_pair(osmId, featureId));
+    osmIdsToFeatureIds.Add(make_pair(osm::Id::Way(osmId), featureId));
     ++idIter;
     TEST(!idIter, ());
   }

--- a/generator/osm_id.hpp
+++ b/generator/osm_id.hpp
@@ -28,8 +28,9 @@ public:
   /// For debug output
   string Type() const;
 
-  bool operator<(Id const & other) const { return m_encodedId < other.m_encodedId; }
-  bool operator==(Id const & other) const { return m_encodedId == other.m_encodedId; }
+  inline bool operator<(Id const & other) const { return m_encodedId < other.m_encodedId; }
+  inline bool operator==(Id const & other) const { return m_encodedId == other.m_encodedId; }
+  inline bool operator!=(Id const & other) const { return !(*this == other); }
   bool operator==(uint64_t other) const { return OsmId() == other; }
 };
 

--- a/generator/routing_generator.cpp
+++ b/generator/routing_generator.cpp
@@ -120,7 +120,7 @@ void FindCrossNodes(osrm::NodeDataVectorT const & nodeData, gen::OsmID2FeatureID
       auto const & startSeg = data.m_segments.front();
       auto const & endSeg = data.m_segments.back();
       // Check if we have geometry for our candidate.
-      if (osm2ft.GetFeatureID(startSeg.wayId) || osm2ft.GetFeatureID(endSeg.wayId))
+      if (osm2ft.GetRoadFeatureID(startSeg.wayId) || osm2ft.GetRoadFeatureID(endSeg.wayId))
       {
         // Check mwm borders crossing.
         for (m2::RegionD const & border: regionBorders)
@@ -177,7 +177,7 @@ void FindCrossNodes(osrm::NodeDataVectorT const & nodeData, gen::OsmID2FeatureID
           {
             FeatureType ft;
             Index::FeaturesLoaderGuard loader(index, mwmId);
-            if (loader.GetFeatureByIndex(osm2ft.GetFeatureID(startSeg.wayId), ft))
+            if (loader.GetFeatureByIndex(osm2ft.GetRoadFeatureID(startSeg.wayId), ft))
             {
               LOG(LINFO,
                   ("Double border intersection", wgsIntersection, "rank:", GetWarningRank(ft)));
@@ -313,7 +313,7 @@ void BuildRoutingIndex(string const & baseDir, string const & countryName, strin
       ++all;
 
       // now need to determine feature id and segments in it
-      uint32_t const fID = osm2ft.GetFeatureID(seg.wayId);
+      uint32_t const fID = osm2ft.GetRoadFeatureID(seg.wayId);
       if (fID == 0)
       {
         LOG(LWARNING, ("No feature id for way:", seg.wayId));

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -39,7 +39,10 @@ bool ParseOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
   }
 
   osmIdsToFeatureIds.ForEach([&](gen::OsmID2FeatureID::ValueT const & p) {
-    AddFeatureId(osmIdToFeatureId, p.second /* feature id */, p.first /* osm id */);
+    if (p.first.IsWay())
+    {
+      AddFeatureId(osmIdToFeatureId, p.second /* feature id */, p.first.OsmId() /* osm id */);
+    }
   });
 
   return true;

--- a/omim.pro
+++ b/omim.pro
@@ -199,7 +199,7 @@ SUBDIRS = 3party base coding geometry editor indexer routing routing_common sear
     SUBDIRS *= routing_integration_tests
 
     routing_consistency_tests.subdir = routing/routing_consistency_tests
-    routing_consistency_tests.depends = $$MapDepLibs routing
+    routing_consistency_tests.depends = $$MapDepLibs routing generator
     SUBDIRS *= routing_consistency_tests
 
     srtm_coverage_checker.subdir = generator/srtm_coverage_checker

--- a/tools/python/mwm/dump_mwm.py
+++ b/tools/python/mwm/dump_mwm.py
@@ -25,7 +25,6 @@ if cross:
     print('Outgoing points: {0}, incoming: {1}'.format(len(cross['out']), len(cross['in'])))
     print('Outgoing regions: {0}'.format(set(cross['neighbours'])))
 
-print('Sample features:')
 # Print some random features using reservoir sampling
 count = 5
 sample = []
@@ -34,5 +33,8 @@ for i, feature in enumerate(mwm.iter_features()):
         sample.append(feature)
     elif random.randint(0, i) < count:
         sample[random.randint(0, count-1)] = feature
+
+print('Feature count: {0}'.format(i))
+print('Sample features:')
 for feature in sample:
     print(json.dumps(feature, ensure_ascii=False))

--- a/tools/python/mwm/ft2osm.py
+++ b/tools/python/mwm/ft2osm.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import sys
+import mwm
+
+if len(sys.argv) < 3:
+    print('Finds an OSM object for a given feature id.')
+    print('Usage: {} <mwm.osm2ft> <ftid>'.format(sys.argv[0]))
+    sys.exit(1)
+
+with open(sys.argv[1], 'rb') as f:
+    ft2osm = mwm.read_osm2ft(f, True)
+
+code = 0
+for ftid in sys.argv[2:]:
+    ftid = int(ftid)
+    if ftid in ft2osm:
+        type_abbr = {'n': 'node', 'w': 'way', 'r': 'relation'}
+        print('https://www.openstreetmap.org/{}/{}'.format(type_abbr[ft2osm[ftid][0]], ft2osm[ftid][1]))
+    else:
+        print('Could not find osm id for feature {}'.format(ftid))
+        code = 2
+sys.exit(code)


### PR DESCRIPTION
Появилась задача искать osm id для произвольных объектов из mwm. Поэтому osm2ft боле не промежуточный файл, а важный элемент сгенерированных файлов, лол.