### PR TITLE
[routing] Add osm ids to cross mwm section

### DIFF
--- a/generator/generator_tests/restriction_collector_test.cpp
+++ b/generator/generator_tests/restriction_collector_test.cpp
@@ -33,16 +33,16 @@ UNIT_TEST(RestrictionTest_ValidCase)
   RestrictionCollector restrictionCollector("" /* restrictionPath */,
                                             "" /* osmIdsToFeatureIdsPath */);
   // Adding feature ids.
-  restrictionCollector.AddFeatureId(30 /* featureId */, 3 /* osmId */);
-  restrictionCollector.AddFeatureId(10 /* featureId */, 1 /* osmId */);
-  restrictionCollector.AddFeatureId(50 /* featureId */, 5 /* osmId */);
-  restrictionCollector.AddFeatureId(70 /* featureId */, 7 /* osmId */);
-  restrictionCollector.AddFeatureId(20 /* featureId */, 2 /* osmId */);
+  restrictionCollector.AddFeatureId(30 /* featureId */, osm::Id::Way(3));
+  restrictionCollector.AddFeatureId(10 /* featureId */, osm::Id::Way(1));
+  restrictionCollector.AddFeatureId(50 /* featureId */, osm::Id::Way(5));
+  restrictionCollector.AddFeatureId(70 /* featureId */, osm::Id::Way(7));
+  restrictionCollector.AddFeatureId(20 /* featureId */, osm::Id::Way(2));
 
   // Adding restrictions.
-  TEST(restrictionCollector.AddRestriction(Restriction::Type::No, {1, 2} /* osmIds */), ());
-  TEST(restrictionCollector.AddRestriction(Restriction::Type::No, {2, 3} /* osmIds */), ());
-  TEST(restrictionCollector.AddRestriction(Restriction::Type::Only, {5, 7} /* osmIds */), ());
+  TEST(restrictionCollector.AddRestriction(Restriction::Type::No, {osm::Id::Way(1), osm::Id::Way(2)}), ());
+  TEST(restrictionCollector.AddRestriction(Restriction::Type::No, {osm::Id::Way(2), osm::Id::Way(3)}), ());
+  TEST(restrictionCollector.AddRestriction(Restriction::Type::Only, {osm::Id::Way(5), osm::Id::Way(7)}), ());
   my::SortUnique(restrictionCollector.m_restrictions);
 
   // Checking the result.
@@ -58,10 +58,10 @@ UNIT_TEST(RestrictionTest_InvalidCase)
 {
   RestrictionCollector restrictionCollector("" /* restrictionPath */,
                                             "" /* osmIdsToFeatureIdsPath */);
-  restrictionCollector.AddFeatureId(0 /* featureId */, 0 /* osmId */);
-  restrictionCollector.AddFeatureId(20 /* featureId */, 2 /* osmId */);
+  restrictionCollector.AddFeatureId(0 /* featureId */, osm::Id::Way(0));
+  restrictionCollector.AddFeatureId(20 /* featureId */, osm::Id::Way(2));
 
-  TEST(!restrictionCollector.AddRestriction(Restriction::Type::No, {0, 1} /* osmIds */), ());
+  TEST(!restrictionCollector.AddRestriction(Restriction::Type::No, {osm::Id::Way(0), osm::Id::Way(1)}), ());
 
   TEST(!restrictionCollector.HasRestrictions(), ());
   TEST(restrictionCollector.IsValid(), ());

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -249,9 +249,10 @@ int main(int argc, char ** argv)
     if (!FLAGS_srtm_path.empty())
       routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
 
+    string const osmToFeatureFilename = genInfo.GetTargetFileName(country) + OSM2FEATURE_FILE_EXTENSION;
+
     if (FLAGS_make_routing_index)
     {
-      string const osmToFeatureFilename = genInfo.GetTargetFileName(country) + OSM2FEATURE_FILE_EXTENSION;
       string const restrictionsFilename =
           genInfo.GetIntermediateFileName(RESTRICTIONS_FILENAME, "" /* extension */);
       string const roadAccessFilename =
@@ -263,7 +264,10 @@ int main(int argc, char ** argv)
     }
 
     if (FLAGS_make_cross_mwm)
-      routing::BuildCrossMwmSection(path, datFile, country);
+    {
+      if (!routing::BuildCrossMwmSection(path, datFile, country, osmToFeatureFilename))
+        LOG(LCRITICAL, ("Error generating cross mwm section."));
+    }
 
     if (FLAGS_generate_traffic_keys)
     {

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -17,14 +17,14 @@ char const kNo[] = "No";
 char const kOnly[] = "Only";
 char const kDelim[] = ", \t\r\n";
 
-bool ParseLineOfNumbers(strings::SimpleTokenizer & iter, vector<uint64_t> & numbers)
+bool ParseLineOfWayIds(strings::SimpleTokenizer & iter, vector<osm::Id> & numbers)
 {
   uint64_t number = 0;
   for (; iter; ++iter)
   {
     if (!strings::to_uint64(*iter, number))
       return false;
-    numbers.push_back(number);
+    numbers.push_back(osm::Id::Way(number));
   }
   return true;
 }
@@ -88,8 +88,8 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
     }
 
     ++iter;
-    vector<uint64_t> osmIds;
-    if (!ParseLineOfNumbers(iter, osmIds))
+    vector<osm::Id> osmIds;
+    if (!ParseLineOfWayIds(iter, osmIds))
     {
       LOG(LWARNING, ("Cannot parse osm ids from", path));
       return false;
@@ -100,7 +100,7 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
   return true;
 }
 
-bool RestrictionCollector::AddRestriction(Restriction::Type type, vector<uint64_t> const & osmIds)
+bool RestrictionCollector::AddRestriction(Restriction::Type type, vector<osm::Id> const & osmIds)
 {
   vector<uint32_t> featureIds(osmIds.size());
   for (size_t i = 0; i < osmIds.size(); ++i)
@@ -121,9 +121,9 @@ bool RestrictionCollector::AddRestriction(Restriction::Type type, vector<uint64_
   return true;
 }
 
-void RestrictionCollector::AddFeatureId(uint32_t featureId, uint64_t osmId)
+void RestrictionCollector::AddFeatureId(uint32_t featureId, osm::Id osmId)
 {
-  ::routing::AddFeatureId(m_osmIdToFeatureId, featureId, osmId);
+  ::routing::AddFeatureId(osmId, featureId, m_osmIdToFeatureId);
 }
 
 bool FromString(string str, Restriction::Type & type)

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "generator/osm_id.hpp"
+
 #include "routing/restrictions_serialization.hpp"
 
 #include "std/functional.hpp"
@@ -45,7 +47,7 @@ private:
   bool ParseRestrictions(string const & path);
 
   /// \brief Adds feature id and corresponding |osmId| to |m_osmIdToFeatureId|.
-  void AddFeatureId(uint32_t featureId, uint64_t osmId);
+  void AddFeatureId(uint32_t featureId, osm::Id osmId);
 
   /// \brief Adds a restriction (vector of osm id).
   /// \param type is a type of restriction
@@ -53,10 +55,10 @@ private:
   /// \note This method should be called to add a restriction when feature ids of the restriction
   /// are unknown. The feature ids should be set later with a call of |SetFeatureId(...)| method.
   /// \returns true if restriction is add and false otherwise.
-  bool AddRestriction(Restriction::Type type, vector<uint64_t> const & osmIds);
+  bool AddRestriction(Restriction::Type type, vector<osm::Id> const & osmIds);
 
   RestrictionVec m_restrictions;
-  map<uint64_t, uint32_t> m_osmIdToFeatureId;
+  map<osm::Id, uint32_t> m_osmIdToFeatureId;
 };
 
 bool FromString(string str, Restriction::Type & type);

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -1,6 +1,7 @@
 #include "generator/road_access_generator.hpp"
 
 #include "generator/osm_element.hpp"
+#include "generator/osm_id.hpp"
 #include "generator/routing_helpers.hpp"
 
 #include "routing/road_access.hpp"
@@ -35,7 +36,7 @@ char constexpr kBarrierGate[] = "barrier=gate";
 char constexpr kDelim[] = " \t\r\n";
 
 bool ParseRoadAccess(string const & roadAccessPath,
-                     map<uint64_t, uint32_t> const & osmIdToFeatureId,
+                     map<osm::Id, uint32_t> const & osmIdToFeatureId,
                      routing::RoadAccess & roadAccess)
 {
   ifstream stream(roadAccessPath);
@@ -71,7 +72,7 @@ bool ParseRoadAccess(string const & roadAccessPath,
       return false;
     }
 
-    auto const it = osmIdToFeatureId.find(osmId);
+    auto const it = osmIdToFeatureId.find(osm::Id::Way(osmId));
     if (it == osmIdToFeatureId.cend())
     {
       LOG(LWARNING, ("Error when parsing road access: unknown osm id", osmId, "at line", lineNo));
@@ -133,7 +134,7 @@ bool RoadAccessWriter::IsOpened() const { return m_stream && m_stream.is_open();
 RoadAccessCollector::RoadAccessCollector(string const & roadAccessPath,
                                          string const & osmIdsToFeatureIdsPath)
 {
-  map<uint64_t, uint32_t> osmIdToFeatureId;
+  map<osm::Id, uint32_t> osmIdToFeatureId;
   if (!ParseOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureId))
   {
     LOG(LWARNING, ("An error happened while parsing feature id to osm ids mapping from file:",

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -28,4 +28,6 @@ void AddFeatureId(std::map<uint64_t, uint32_t> & osmIdToFeatureId, uint32_t feat
 // 138001, 5170228,
 bool ParseOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
                                   std::map<uint64_t, uint32_t> & osmIdToFeatureId);
+bool ParseFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
+                                  std::map<uint32_t, uint64_t> & featureIdToOsmId);
 }  // namespace routing

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "generator/osm_id.hpp"
 #include "generator/road_access_generator.hpp"
 #include "generator/restriction_writer.hpp"
 
@@ -17,7 +18,7 @@ struct TagsProcessor
 // Adds feature id and corresponding |osmId| to |osmIdToFeatureId|.
 // Note. In general, one |featureId| may correspond to several osm ids.
 // But for a road feature |featureId| corresponds to exactly one osm id.
-void AddFeatureId(std::map<uint64_t, uint32_t> & osmIdToFeatureId, uint32_t featureId, uint64_t osmId);
+void AddFeatureId(osm::Id osmId, uint32_t featureId, map<osm::Id, uint32_t> &osmIdToFeatureId);
 
 // Parses comma separated text file with line in following format:
 // <feature id>, <osm id 1 corresponding feature id>, <osm id 2 corresponding feature id>, and so
@@ -27,7 +28,7 @@ void AddFeatureId(std::map<uint64_t, uint32_t> & osmIdToFeatureId, uint32_t feat
 // 138000, 5170209, 5143342,
 // 138001, 5170228,
 bool ParseOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
-                                  std::map<uint64_t, uint32_t> & osmIdToFeatureId);
+                                  std::map<osm::Id, uint32_t> & osmIdToFeatureId);
 bool ParseFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
-                                  std::map<uint32_t, uint64_t> & featureIdToOsmId);
+                                  std::map<uint32_t, osm::Id> & featureIdToOsmId);
 }  // namespace routing

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -2,6 +2,7 @@
 
 #include "generator/borders_generator.hpp"
 #include "generator/borders_loader.hpp"
+#include "generator/osm_id.hpp"
 #include "generator/routing_helpers.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
@@ -209,7 +210,7 @@ double CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
 }
 
 void CalcCrossMwmTransitions(string const & path, string const & mwmFile, string const & country,
-                             map<uint32_t, uint64_t> const & featureIdToOsmId,
+                             map<uint32_t, osm::Id> const & featureIdToOsmId,
                              vector<CrossMwmConnectorSerializer::Transition> & transitions,
                              CrossMwmConnectorPerVehicleType & connectors)
 {
@@ -232,7 +233,7 @@ void CalcCrossMwmTransitions(string const & path, string const & mwmFile, string
 
     auto osmIt = featureIdToOsmId.find(featureId);
     CHECK(osmIt != featureIdToOsmId.end(), ("Can't find osm id for feature id", featureId));
-    uint64_t const osmId = osmIt->second;
+    uint64_t const osmId = osmIt->second.OsmId();
 
     bool prevPointIn = RegionsContain(borders, f.GetPoint(0));
 
@@ -380,7 +381,7 @@ bool BuildCrossMwmSection(string const & path, string const & mwmFile, string co
 {
   LOG(LINFO, ("Building cross mwm section for", country));
 
-  map<uint32_t, uint64_t> featureIdToOsmId;
+  map<uint32_t, osm::Id> featureIdToOsmId;
   if (!ParseFeatureIdToOsmIdMapping(osmToFeatureFile, featureIdToOsmId))
     return false;
 

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -5,6 +5,5 @@
 namespace routing
 {
 bool BuildRoutingIndex(std::string const & filename, std::string const & country);
-void BuildCrossMwmSection(std::string const & path, std::string const & mwmFile,
-                          std::string const & country);
+bool BuildCrossMwmSection(std::string const & path, std::string const & mwmFile, std::string const & country, std::string const & osmToFeatureFile);
 }  // namespace routing

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -1,5 +1,7 @@
 #include "routing/cross_mwm_connector.hpp"
 
+#include "geometry/mercator.hpp"
+
 namespace
 {
 uint32_t constexpr kFakeId = std::numeric_limits<uint32_t>::max();
@@ -10,11 +12,11 @@ namespace routing
 // static
 double constexpr CrossMwmConnector::kNoRoute;
 
-void CrossMwmConnector::AddTransition(uint32_t featureId, uint32_t segmentIdx, bool oneWay,
-                                      bool forwardIsEnter, m2::PointD const & backPoint,
-                                      m2::PointD const & frontPoint)
+void CrossMwmConnector::AddTransition(uint64_t osmId, uint32_t featureId, uint32_t segmentIdx,
+                                      bool oneWay, bool forwardIsEnter,
+                                      m2::PointD const & backPoint, m2::PointD const & frontPoint)
 {
-  Transition transition(kFakeId, kFakeId, oneWay, forwardIsEnter, backPoint, frontPoint);
+  Transition transition(kFakeId, kFakeId, osmId, oneWay, forwardIsEnter, backPoint, frontPoint);
 
   if (forwardIsEnter)
   {
@@ -55,6 +57,32 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
     return false;
 
   return (segment.IsForward() == transition.m_forwardIsEnter) == isOutgoing;
+}
+
+Segment const * CrossMwmConnector::GetTransition(uint64_t osmId, bool isEnter) const
+{
+  auto it = m_osmIdToKey.find(osmId);
+  if (it == m_osmIdToKey.cend())
+    return nullptr;
+
+  Key const & key = it->second;
+  auto it2 = m_transitions.find(key);
+  CHECK(it2 != m_transitions.cend(), ("Can't find transition by key, osmId:", osmId, ", feature:",
+                                      key.m_featureId, ", segment:", key.m_segmentIdx));
+
+  Transition const & transition = it2->second;
+  CHECK_EQUAL(transition.m_osmId, osmId,
+              ("feature:", key.m_featureId, ", segment:", key.m_segmentIdx, ", point:",
+               MercatorBounds::ToLatLon(transition.m_frontPoint)));
+  bool const isForward = transition.m_forwardIsEnter == isEnter;
+  if (transition.m_oneWay && !isForward)
+    return nullptr;
+
+  Segment const & segment =
+      isEnter ? GetEnter(transition.m_enterIdx) : GetExit(transition.m_exitIdx);
+  CHECK_EQUAL(segment.IsForward(), isForward, ("osmId:", osmId, ", segment:", segment, ", point:",
+                                               MercatorBounds::ToLatLon(transition.m_frontPoint)));
+  return &segment;
 }
 
 m2::PointD const & CrossMwmConnector::GetPoint(Segment const & segment, bool front) const

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -44,6 +44,7 @@ void CrossMwmConnector::AddTransition(uint64_t osmId, uint32_t featureId, uint32
   }
 
   m_transitions[Key(featureId, segmentIdx)] = transition;
+  m_osmIdToFeatureId.emplace(osmId, featureId);
 }
 
 bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) const
@@ -59,20 +60,22 @@ bool CrossMwmConnector::IsTransition(Segment const & segment, bool isOutgoing) c
   return (segment.IsForward() == transition.m_forwardIsEnter) == isOutgoing;
 }
 
-Segment const * CrossMwmConnector::GetTransition(uint64_t osmId, bool isEnter) const
+Segment const * CrossMwmConnector::GetTransition(uint64_t osmId, uint32_t segmentIdx,
+                                                 bool isEnter) const
 {
-  auto it = m_osmIdToKey.find(osmId);
-  if (it == m_osmIdToKey.cend())
+  auto fIt = m_osmIdToFeatureId.find(osmId);
+  if (fIt == m_osmIdToFeatureId.cend())
     return nullptr;
 
-  Key const & key = it->second;
-  auto it2 = m_transitions.find(key);
-  CHECK(it2 != m_transitions.cend(), ("Can't find transition by key, osmId:", osmId, ", feature:",
-                                      key.m_featureId, ", segment:", key.m_segmentIdx));
+  uint32_t const featureId = fIt->second;
 
-  Transition const & transition = it2->second;
+  auto tIt = m_transitions.find(Key(featureId, segmentIdx));
+  if (tIt == m_transitions.cend())
+    return nullptr;
+
+  Transition const & transition = tIt->second;
   CHECK_EQUAL(transition.m_osmId, osmId,
-              ("feature:", key.m_featureId, ", segment:", key.m_segmentIdx, ", point:",
+              ("feature:", featureId, ", segment:", segmentIdx, ", point:",
                MercatorBounds::ToLatLon(transition.m_frontPoint)));
   bool const isForward = transition.m_forwardIsEnter == isEnter;
   if (transition.m_oneWay && !isForward)

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -28,7 +28,7 @@ public:
   bool IsTransition(Segment const & segment, bool isOutgoing) const;
   uint64_t GetOsmId(Segment const & segment) const { return GetTransition(segment).m_osmId; }
   // returns nullptr if there is no transition for such osm id.
-  Segment const * GetTransition(uint64_t osmId, bool isOutgoing) const;
+  Segment const * GetTransition(uint64_t osmId, uint32_t segmentIdx, bool isOutgoing) const;
   m2::PointD const & GetPoint(Segment const & segment, bool front) const;
   void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) const;
@@ -151,7 +151,7 @@ private:
   std::vector<Segment> m_enters;
   std::vector<Segment> m_exits;
   std::unordered_map<Key, Transition, HashKey> m_transitions;
-  std::unordered_map<uint64_t, Key> m_osmIdToKey;
+  std::unordered_map<uint64_t, uint32_t> m_osmIdToFeatureId;
   WeightsLoadState m_weightsLoadState = WeightsLoadState::Unknown;
   uint64_t m_weightsOffset = 0;
   Weight m_granularity = 0;

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -21,10 +21,14 @@ public:
   CrossMwmConnector() : m_mwmId(kFakeNumMwmId) {}
   explicit CrossMwmConnector(NumMwmId mwmId) : m_mwmId(mwmId) {}
 
-  void AddTransition(uint32_t featureId, uint32_t segmentIdx, bool oneWay, bool forwardIsEnter,
-                     m2::PointD const & backPoint, m2::PointD const & frontPoint);
+  void AddTransition(uint64_t osmId, uint32_t featureId, uint32_t segmentIdx, bool oneWay,
+                     bool forwardIsEnter, m2::PointD const & backPoint,
+                     m2::PointD const & frontPoint);
 
   bool IsTransition(Segment const & segment, bool isOutgoing) const;
+  uint64_t GetOsmId(Segment const & segment) const { return GetTransition(segment).m_osmId; }
+  // returns nullptr if there is no transition for such osm id.
+  Segment const * GetTransition(uint64_t osmId, bool isOutgoing) const;
   m2::PointD const & GetPoint(Segment const & segment, bool front) const;
   void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) const;
@@ -101,10 +105,11 @@ private:
   {
     Transition() = default;
 
-    Transition(uint32_t enterIdx, uint32_t exitIdx, bool oneWay, bool forwardIsEnter,
-               m2::PointD const & backPoint, m2::PointD const & frontPoint)
+    Transition(uint32_t enterIdx, uint32_t exitIdx, uint64_t osmId, bool oneWay,
+               bool forwardIsEnter, m2::PointD const & backPoint, m2::PointD const & frontPoint)
       : m_enterIdx(enterIdx)
       , m_exitIdx(exitIdx)
+      , m_osmId(osmId)
       , m_backPoint(backPoint)
       , m_frontPoint(frontPoint)
       , m_oneWay(oneWay)
@@ -114,6 +119,7 @@ private:
 
     uint32_t m_enterIdx = 0;
     uint32_t m_exitIdx = 0;
+    uint64_t m_osmId = 0;
     // Endpoints of transition segment.
     // m_backPoint = points[segmentIdx]
     // m_frontPoint = points[segmentIdx + 1]
@@ -145,6 +151,7 @@ private:
   std::vector<Segment> m_enters;
   std::vector<Segment> m_exits;
   std::unordered_map<Key, Transition, HashKey> m_transitions;
+  std::unordered_map<uint64_t, Key> m_osmIdToKey;
   WeightsLoadState m_weightsLoadState = WeightsLoadState::Unknown;
   uint64_t m_weightsOffset = 0;
   Weight m_granularity = 0;

--- a/routing/cross_mwm_connector_serialization.cpp
+++ b/routing/cross_mwm_connector_serialization.cpp
@@ -1,5 +1,9 @@
 #include "routing/cross_mwm_connector_serialization.hpp"
 
+#include "base/bits.hpp"
+
+#include <algorithm>
+
 using namespace std;
 
 namespace routing
@@ -8,14 +12,25 @@ namespace routing
 uint32_t constexpr CrossMwmConnectorSerializer::kLastVersion;
 
 // static
+uint32_t CrossMwmConnectorSerializer::CalcBitsPerOsmId(std::vector<Transition> const & transitions)
+{
+  uint64_t maxOsmId = 0;
+  for (Transition const & transition : transitions)
+    maxOsmId = std::max(maxOsmId, transition.GetOsmId());
+
+  return bits::NumUsedBits(maxOsmId);
+}
+
+// static
 void CrossMwmConnectorSerializer::WriteTransitions(vector<Transition> const & transitions,
                                                    serial::CodingParams const & codingParams,
-                                                   uint8_t bitsPerMask, vector<uint8_t> & buffer)
+                                                   uint32_t bitsPerOsmId, uint8_t bitsPerMask,
+                                                   vector<uint8_t> & buffer)
 {
   MemWriter<vector<uint8_t>> memWriter(buffer);
 
   for (Transition const & transition : transitions)
-    transition.Serialize(codingParams, bitsPerMask, memWriter);
+    transition.Serialize(codingParams, bitsPerOsmId, bitsPerMask, memWriter);
 }
 
 // static

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -39,10 +39,11 @@ namespace routing_test
 {
 UNIT_TEST(OneWayEnter)
 {
+  uint64_t constexpr osmId = 1;
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   CrossMwmConnector connector(mwmId);
-  connector.AddTransition(featureId, segmentIdx, true /* oneWay */, true /* forwardIsEnter */,
+  connector.AddTransition(osmId, featureId, segmentIdx, true /* oneWay */, true /* forwardIsEnter */,
                           {} /* backPoint */, {} /* frontPoint */);
 
   TestConnectorConsistency(connector);
@@ -64,10 +65,11 @@ UNIT_TEST(OneWayEnter)
 
 UNIT_TEST(OneWayExit)
 {
+  uint64_t constexpr osmId = 1;
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   CrossMwmConnector connector(mwmId);
-  connector.AddTransition(featureId, segmentIdx, true /* oneWay */, false /* forwardIsEnter */,
+  connector.AddTransition(osmId, featureId, segmentIdx, true /* oneWay */, false /* forwardIsEnter */,
                           {} /* backPoint */, {} /* frontPoint */);
 
   TestConnectorConsistency(connector);
@@ -89,10 +91,11 @@ UNIT_TEST(OneWayExit)
 
 UNIT_TEST(TwoWayEnter)
 {
+  uint64_t constexpr osmId = 1;
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   CrossMwmConnector connector(mwmId);
-  connector.AddTransition(featureId, segmentIdx, false /* oneWay */, true /* forwardIsEnter */,
+  connector.AddTransition(osmId, featureId, segmentIdx, false /* oneWay */, true /* forwardIsEnter */,
                           {} /* backPoint */, {} /* frontPoint */);
 
   TestConnectorConsistency(connector);
@@ -114,10 +117,11 @@ UNIT_TEST(TwoWayEnter)
 
 UNIT_TEST(TwoWayExit)
 {
+  uint64_t constexpr osmId = 1;
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   CrossMwmConnector connector(mwmId);
-  connector.AddTransition(featureId, segmentIdx, false /* oneWay */, false /* forwardIsEnter */,
+  connector.AddTransition(osmId, featureId, segmentIdx, false /* oneWay */, false /* forwardIsEnter */,
                           {} /* backPoint */, {} /* frontPoint */);
 
   TestConnectorConsistency(connector);
@@ -144,10 +148,10 @@ UNIT_TEST(Serialization)
   vector<uint8_t> buffer;
   {
     vector<CrossMwmConnectorSerializer::Transition> transitions = {
-        /* featureId, segmentIdx, roadMask, oneWayMask, forwardIsEnter, backPoint, frontPoint */
-        {10, 1, kCarMask, kCarMask, true, m2::PointD(1.1, 1.2), m2::PointD(1.3, 1.4)},
-        {20, 2, kCarMask, 0, true, m2::PointD(2.1, 2.2), m2::PointD(2.3, 2.4)},
-        {30, 3, kPedestrianMask, kCarMask, true, m2::PointD(3.1, 3.2), m2::PointD(3.3, 3.4)}};
+        /* osmId featureId, segmentIdx, roadMask, oneWayMask, forwardIsEnter, backPoint, frontPoint */
+        {100, 10, 1, kCarMask, kCarMask, true, m2::PointD(1.1, 1.2), m2::PointD(1.3, 1.4)},
+        {200, 20, 2, kCarMask, 0, true, m2::PointD(2.1, 2.2), m2::PointD(2.3, 2.4)},
+        {300, 30, 3, kPedestrianMask, kCarMask, true, m2::PointD(3.1, 3.2), m2::PointD(3.3, 3.4)}};
 
     CrossMwmConnectorPerVehicleType connectors;
     CrossMwmConnector & carConnector = connectors[static_cast<size_t>(VehicleType::Car)];
@@ -250,7 +254,8 @@ UNIT_TEST(WeightsSerialization)
     vector<CrossMwmConnectorSerializer::Transition> transitions;
     for (uint32_t featureId = 0; featureId < kNumTransitions; ++featureId)
     {
-      transitions.emplace_back(featureId, 1 /* segmentIdx */, kCarMask, 0 /* oneWayMask */,
+      auto const osmId = static_cast<uint64_t>(featureId * 10);
+      transitions.emplace_back(osmId, featureId, 1 /* segmentIdx */, kCarMask, 0 /* oneWayMask */,
                                true /* forwardIsEnter */, m2::PointD::Zero(), m2::PointD::Zero());
     }
 


### PR DESCRIPTION
Добавил в cross mwm секцию osm id для транзитных дорог.

Osm id нужны для более надёжного и оптимального связывания между mwm.
Без них это приходится делать приблизительно, по геометрии.