### PR TITLE
[routing] Flag for disabling cross mwm progress logs

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -72,10 +72,10 @@ DEFINE_string(osrm_file_name, "", "Input osrm file to generate routing info.");
 DEFINE_bool(make_routing, false, "Make routing info based on osrm file.");
 DEFINE_bool(make_cross_section, false, "Make cross section in routing file for cross mwm routing (for OSRM routing).");
 DEFINE_bool(make_routing_index, false, "Make sections with the routing information.");
-DEFINE_bool(make_cross_mwm, false, "Make section for cross mwm routing (for dynamic indexed routing).");
-DEFINE_uint64(
-    cross_mwm_progress_peroid, 10,
-    "The smaller the period, the more often progress logs are printed. Set 0 to disable logs.");
+DEFINE_bool(make_cross_mwm, false,
+            "Make section for cross mwm routing (for dynamic indexed routing).");
+DEFINE_bool(disable_cross_mwm_progress, false,
+            "Disable log of cross mwm section building progress.");
 DEFINE_string(srtm_path, "",
               "Path to srtm directory. If set, generates a section with altitude information "
               "about roads.");
@@ -269,7 +269,7 @@ int main(int argc, char ** argv)
     if (FLAGS_make_cross_mwm)
     {
       if (!routing::BuildCrossMwmSection(path, datFile, country, osmToFeatureFilename,
-                                         FLAGS_cross_mwm_progress_peroid))
+                                         FLAGS_disable_cross_mwm_progress))
         LOG(LCRITICAL, ("Error generating cross mwm section."));
     }
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -73,6 +73,9 @@ DEFINE_bool(make_routing, false, "Make routing info based on osrm file.");
 DEFINE_bool(make_cross_section, false, "Make cross section in routing file for cross mwm routing (for OSRM routing).");
 DEFINE_bool(make_routing_index, false, "Make sections with the routing information.");
 DEFINE_bool(make_cross_mwm, false, "Make section for cross mwm routing (for dynamic indexed routing).");
+DEFINE_uint64(
+    cross_mwm_progress_peroid, 10,
+    "The smaller the period, the more often progress logs are printed. Set 0 to disable logs.");
 DEFINE_string(srtm_path, "",
               "Path to srtm directory. If set, generates a section with altitude information "
               "about roads.");
@@ -265,7 +268,8 @@ int main(int argc, char ** argv)
 
     if (FLAGS_make_cross_mwm)
     {
-      if (!routing::BuildCrossMwmSection(path, datFile, country, osmToFeatureFilename))
+      if (!routing::BuildCrossMwmSection(path, datFile, country, osmToFeatureFilename,
+                                         FLAGS_cross_mwm_progress_peroid))
         LOG(LCRITICAL, ("Error generating cross mwm section."));
     }
 

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -276,7 +276,7 @@ void CalcCrossMwmTransitions(string const & path, string const & mwmFile, string
 }
 
 void FillWeights(string const & path, string const & mwmFile, string const & country,
-                 uint64_t crossMwmProgressPeroid, CrossMwmConnector & connector)
+                 bool disableCrossMwmProgress, CrossMwmConnector & connector)
 {
   my::Timer timer;
 
@@ -295,7 +295,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   size_t notFoundCount = 0;
   for (size_t i = 0; i < numEnters; ++i)
   {
-    if (crossMwmProgressPeroid != 0 && (i % crossMwmProgressPeroid == 0) && (i != 0))
+    if (!disableCrossMwmProgress && (i % 10 == 0) && (i != 0))
       LOG(LINFO, ("Building leaps:", i, "/", numEnters, "waves passed"));
 
     Segment const & enter = connector.GetEnter(i);
@@ -378,7 +378,7 @@ bool BuildRoutingIndex(string const & filename, string const & country)
 }
 
 bool BuildCrossMwmSection(string const & path, string const & mwmFile, string const & country,
-                          string const & osmToFeatureFile, uint64_t crossMwmProgressPeroid)
+                          string const & osmToFeatureFile, bool disableCrossMwmProgress)
 {
   LOG(LINFO, ("Building cross mwm section for", country));
 
@@ -399,7 +399,7 @@ bool BuildCrossMwmSection(string const & path, string const & mwmFile, string co
                 connector.GetExits().size()));
   }
 
-  FillWeights(path, mwmFile, country, crossMwmProgressPeroid,
+  FillWeights(path, mwmFile, country, disableCrossMwmProgress,
               connectors[static_cast<size_t>(VehicleType::Car)]);
 
   serial::CodingParams const codingParams = LoadCodingParams(mwmFile);

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -276,7 +276,7 @@ void CalcCrossMwmTransitions(string const & path, string const & mwmFile, string
 }
 
 void FillWeights(string const & path, string const & mwmFile, string const & country,
-                 CrossMwmConnector & connector)
+                 uint64_t crossMwmProgressPeroid, CrossMwmConnector & connector)
 {
   my::Timer timer;
 
@@ -295,7 +295,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   size_t notFoundCount = 0;
   for (size_t i = 0; i < numEnters; ++i)
   {
-    if ((i % 10 == 0) && (i != 0))
+    if (crossMwmProgressPeroid != 0 && (i % crossMwmProgressPeroid == 0) && (i != 0))
       LOG(LINFO, ("Building leaps:", i, "/", numEnters, "waves passed"));
 
     Segment const & enter = connector.GetEnter(i);
@@ -377,7 +377,8 @@ bool BuildRoutingIndex(string const & filename, string const & country)
   }
 }
 
-bool BuildCrossMwmSection(string const & path, string const & mwmFile, string const & country, string const & osmToFeatureFile)
+bool BuildCrossMwmSection(string const & path, string const & mwmFile, string const & country,
+                          string const & osmToFeatureFile, uint64_t crossMwmProgressPeroid)
 {
   LOG(LINFO, ("Building cross mwm section for", country));
 
@@ -398,7 +399,8 @@ bool BuildCrossMwmSection(string const & path, string const & mwmFile, string co
                 connector.GetExits().size()));
   }
 
-  FillWeights(path, mwmFile, country, connectors[static_cast<size_t>(VehicleType::Car)]);
+  FillWeights(path, mwmFile, country, crossMwmProgressPeroid,
+              connectors[static_cast<size_t>(VehicleType::Car)]);
 
   serial::CodingParams const codingParams = LoadCodingParams(mwmFile);
   FilesContainerW cont(mwmFile, FileWriter::OP_WRITE_EXISTING);

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace routing
 {
 bool BuildRoutingIndex(std::string const & filename, std::string const & country);
-bool BuildCrossMwmSection(std::string const & path, std::string const & mwmFile, std::string const & country, std::string const & osmToFeatureFile);
+bool BuildCrossMwmSection(std::string const & path, std::string const & mwmFile,
+                          std::string const & country, std::string const & osmToFeatureFile,
+                          uint64_t crossMwmProgressPeroid);
 }  // namespace routing

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -8,5 +8,5 @@ namespace routing
 bool BuildRoutingIndex(std::string const & filename, std::string const & country);
 bool BuildCrossMwmSection(std::string const & path, std::string const & mwmFile,
                           std::string const & country, std::string const & osmToFeatureFile,
-                          uint64_t crossMwmProgressPeroid);
+                          bool disableCrossMwmProgress);
 }  // namespace routing


### PR DESCRIPTION
Добавил флаг для управления логами сборки cross mwm секции.

По умолчанию прогресс печатается в виде:
Building leaps: 10 / 239 waves passed
Building leaps: 20 / 239 waves passed
Building leaps: 30 / 239 waves passed
...

Можно выставить cross_mwm_progress_peroid=0, чтобы отключить эти логи, которые не нужны при автоматической сборке карт на сервере.