### PR TITLE
[assessment-tool] Added view for non-found results.

### DIFF
--- a/search/search_quality/assessment_tool/main_model.hpp
+++ b/search/search_quality/assessment_tool/main_model.hpp
@@ -4,6 +4,7 @@
 #include "search/search_quality/assessment_tool/context.hpp"
 #include "search/search_quality/assessment_tool/edits.hpp"
 #include "search/search_quality/assessment_tool/model.hpp"
+#include "search/search_quality/assessment_tool/view.hpp"
 #include "search/search_quality/sample.hpp"
 
 #include "base/thread_checker.hpp"
@@ -32,6 +33,7 @@ public:
 
   void OnSampleSelected(int index) override;
   void OnResultSelected(int index) override;
+  void OnNonFoundResultSelected(int index) override;
   void OnShowViewportClicked() override;
   void OnShowPositionClicked() override;
   bool HasChanges() override;
@@ -39,9 +41,9 @@ public:
 private:
   static int constexpr kInvalidIndex = -1;
 
-  void OnUpdate(size_t index, Edits::Update const & update);
+  void OnUpdate(View::ResultType type, size_t sampleIndex, Edits::Update const & update);
 
-  void OnResults(uint64_t timestamp, size_t index, search::Results const & results,
+  void OnResults(uint64_t timestamp, size_t sampleIndex, search::Results const & results,
                  std::vector<search::Sample::Result::Relevance> const & relevances,
                  std::vector<size_t> const & goldenMatching,
                  std::vector<size_t> const & actualMatching);

--- a/search/search_quality/assessment_tool/main_view.cpp
+++ b/search/search_quality/assessment_tool/main_view.cpp
@@ -11,6 +11,8 @@
 
 #include "map/framework.hpp"
 
+#include "geometry/mercator.hpp"
+
 #include "base/assert.hpp"
 #include "base/string_utils.hpp"
 
@@ -58,19 +60,26 @@ void MainView::SetSamples(ContextList::SamplesSlice const & samples)
   m_sampleView->Clear();
 }
 
-void MainView::ShowSample(size_t index, search::Sample const & sample, bool hasEdits)
+void MainView::ShowSample(size_t sampleIndex, search::Sample const & sample, bool hasEdits)
 {
   MoveViewportToRect(sample.m_viewport);
 
   m_sampleView->SetContents(sample);
   m_sampleView->show();
 
-  OnSampleChanged(index, Edits::Update::AllRelevancesUpdate(), hasEdits);
+  OnResultChanged(sampleIndex, ResultType::Found, Edits::Update::AllRelevancesUpdate());
+  OnResultChanged(sampleIndex, ResultType::NonFound, Edits::Update::AllRelevancesUpdate());
+  OnSampleChanged(sampleIndex, hasEdits);
 }
 
-void MainView::ShowResults(search::Results::Iter begin, search::Results::Iter end)
+void MainView::ShowFoundResults(search::Results::Iter begin, search::Results::Iter end)
 {
-  m_sampleView->ShowResults(begin, end);
+  m_sampleView->ShowFoundResults(begin, end);
+}
+
+void MainView::ShowNonFoundResults(std::vector<search::Sample::Result> const & results)
+{
+  m_sampleView->ShowNonFoundResults(results);
 }
 
 void MainView::MoveViewportToResult(search::Result const & result)
@@ -78,18 +87,36 @@ void MainView::MoveViewportToResult(search::Result const & result)
   m_framework.ShowSearchResult(result, false /* animation */);
 }
 
+void MainView::MoveViewportToResult(search::Sample::Result const & result) {
+  int constexpr kViewportAroundResultSizeM = 100;
+  auto const rect =
+      MercatorBounds::RectByCenterXYAndSizeInMeters(result.m_pos, kViewportAroundResultSizeM);
+  MoveViewportToRect(rect);
+}
+
 void MainView::MoveViewportToRect(m2::RectD const & rect)
 {
   m_framework.ShowRect(rect, -1 /* maxScale */, false /* animation */);
 }
 
-void MainView::OnSampleChanged(size_t index, Edits::Update const & update, bool hasEdits)
+void MainView::OnResultChanged(size_t sampleIndex, ResultType type, Edits::Update const & update)
 {
-  m_samplesView->OnUpdate(index);
-  if (!m_samplesView->IsSelected(index))
+  m_samplesView->OnUpdate(sampleIndex);
+
+  if (!m_samplesView->IsSelected(sampleIndex))
+    return;
+  switch (type)
+  {
+  case ResultType::Found: m_sampleView->GetFoundResultsView().Update(update); break;
+  case ResultType::NonFound: m_sampleView->GetNonFoundResultsView().Update(update); break;
+  }
+}
+
+void MainView::OnSampleChanged(size_t sampleIndex, bool hasEdits)
+{
+  if (!m_samplesView->IsSelected(sampleIndex))
     return;
   SetSampleDockTitle(hasEdits);
-  m_sampleView->Update(update);
 }
 
 void MainView::OnSamplesChanged(bool hasEdits)
@@ -99,10 +126,11 @@ void MainView::OnSamplesChanged(bool hasEdits)
   m_saveAs->setEnabled(hasEdits);
 }
 
-void MainView::EnableSampleEditing(size_t index, Edits & edits)
+void MainView::EnableSampleEditing(size_t sampleIndex, Edits & foundResultsEdits,
+                                   Edits & nonFoundResultsEdits)
 {
-  CHECK(m_samplesView->IsSelected(index), ());
-  m_sampleView->EnableEditing(edits);
+  CHECK(m_samplesView->IsSelected(sampleIndex), ());
+  m_sampleView->EnableEditing(foundResultsEdits, nonFoundResultsEdits);
 }
 
 void MainView::ShowError(std::string const & msg)
@@ -144,6 +172,14 @@ void MainView::OnResultSelected(QItemSelection const & current)
   auto const indexes = current.indexes();
   for (auto const & index : indexes)
     m_model->OnResultSelected(index.row());
+}
+
+void MainView::OnNonFoundResultSelected(QItemSelection const & current)
+{
+  CHECK(m_model, ());
+  auto const indexes = current.indexes();
+  for (auto const & index : indexes)
+    m_model->OnNonFoundResultSelected(index.row());
 }
 
 void MainView::InitMenuBar()
@@ -242,8 +278,15 @@ void MainView::InitDocks()
           [this]() { m_model->OnShowPositionClicked(); });
 
   {
-    auto * model = m_sampleView->GetResultsView().selectionModel();
-    connect(model, &QItemSelectionModel::selectionChanged, this, &MainView::OnResultSelected);
+    auto const & view = m_sampleView->GetFoundResultsView();
+    connect(&view, &ResultsView::OnResultSelected,
+            [&](int index) { m_model->OnResultSelected(index); });
+  }
+
+  {
+    auto const & view = m_sampleView->GetNonFoundResultsView();
+    connect(&view, &ResultsView::OnResultSelected,
+            [&](int index) { m_model->OnNonFoundResultSelected(index); });
   }
 
   m_sampleDock = CreateDock(*m_sampleView);

--- a/search/search_quality/assessment_tool/main_view.cpp
+++ b/search/search_quality/assessment_tool/main_view.cpp
@@ -87,7 +87,8 @@ void MainView::MoveViewportToResult(search::Result const & result)
   m_framework.ShowSearchResult(result, false /* animation */);
 }
 
-void MainView::MoveViewportToResult(search::Sample::Result const & result) {
+void MainView::MoveViewportToResult(search::Sample::Result const & result)
+{
   int constexpr kViewportAroundResultSizeM = 100;
   auto const rect =
       MercatorBounds::RectByCenterXYAndSizeInMeters(result.m_pos, kViewportAroundResultSizeM);
@@ -280,13 +281,13 @@ void MainView::InitDocks()
   {
     auto const & view = m_sampleView->GetFoundResultsView();
     connect(&view, &ResultsView::OnResultSelected,
-            [&](int index) { m_model->OnResultSelected(index); });
+            [this](int index) { m_model->OnResultSelected(index); });
   }
 
   {
     auto const & view = m_sampleView->GetNonFoundResultsView();
     connect(&view, &ResultsView::OnResultSelected,
-            [&](int index) { m_model->OnNonFoundResultSelected(index); });
+            [this](int index) { m_model->OnNonFoundResultSelected(index); });
   }
 
   m_sampleDock = CreateDock(*m_sampleView);

--- a/search/search_quality/assessment_tool/main_view.hpp
+++ b/search/search_quality/assessment_tool/main_view.hpp
@@ -28,14 +28,18 @@ public:
 
   // View overrides:
   void SetSamples(ContextList::SamplesSlice const & samples) override;
-  void ShowSample(size_t index, search::Sample const & sample, bool hasEdits) override;
-  void ShowResults(search::Results::Iter begin, search::Results::Iter end) override;
+  void ShowSample(size_t sampleIndex, search::Sample const & sample, bool hasEdits) override;
+  void ShowFoundResults(search::Results::Iter begin, search::Results::Iter end) override;
+  void ShowNonFoundResults(std::vector<search::Sample::Result> const & results) override;
 
   void MoveViewportToResult(search::Result const & result) override;
+  void MoveViewportToResult(search::Sample::Result const & result) override;
   void MoveViewportToRect(m2::RectD const & rect) override;
 
-  void OnSampleChanged(size_t index, Edits::Update const & update, bool hasEdits) override;
-  void EnableSampleEditing(size_t index, Edits & edits) override;
+  void OnResultChanged(size_t sampleIndex, ResultType type, Edits::Update const & update) override;
+  void EnableSampleEditing(size_t sampleIndex, Edits & foundResultsEdits,
+                           Edits & nonFoundResultsEdits) override;
+  void OnSampleChanged(size_t sampleIndex, bool hasEdits) override;
   void OnSamplesChanged(bool hasEdits) override;
 
   void ShowError(std::string const & msg) override;
@@ -49,6 +53,7 @@ protected:
 private slots:
   void OnSampleSelected(QItemSelection const & current);
   void OnResultSelected(QItemSelection const & current);
+  void OnNonFoundResultSelected(QItemSelection const & current);
 
 private:
   enum class SaveResult

--- a/search/search_quality/assessment_tool/model.hpp
+++ b/search/search_quality/assessment_tool/model.hpp
@@ -17,6 +17,7 @@ public:
 
   virtual void OnSampleSelected(int index) = 0;
   virtual void OnResultSelected(int index) = 0;
+  virtual void OnNonFoundResultSelected(int index) = 0;
   virtual void OnShowViewportClicked() = 0;
   virtual void OnShowPositionClicked() = 0;
   virtual bool HasChanges() = 0;

--- a/search/search_quality/assessment_tool/result_view.cpp
+++ b/search/search_quality/assessment_tool/result_view.cpp
@@ -5,13 +5,15 @@
 
 #include "base/stl_add.hpp"
 
-#include <string>
 #include <utility>
+#include <vector>
 
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QRadioButton>
 #include <QtWidgets/QVBoxLayout>
+
+using namespace std;
 
 namespace
 {
@@ -23,7 +25,7 @@ QLabel * CreateLabel(QWidget & parent)
   return label;
 }
 
-void SetText(QLabel & label, std::string const & text) {
+void SetText(QLabel & label, string const & text) {
   if (text.empty())
   {
     label.hide();
@@ -33,14 +35,32 @@ void SetText(QLabel & label, std::string const & text) {
   label.setText(ToQString(text));
   label.show();
 }
+
+string GetResultType(search::Sample::Result const & result)
+{
+  return strings::JoinStrings(result.m_types, ", ");
+}
 }  // namespace
 
-ResultView::ResultView(search::Result const & result, QWidget & parent) : QWidget(&parent)
+ResultView::ResultView(string const & name, string const & type, string const & address,
+                       QWidget & parent)
+  : QWidget(&parent)
 {
   Init();
-  SetContents(result);
+  SetContents(name, type, address);
   setEnabled(false);
   setObjectName("result");
+}
+
+ResultView::ResultView(search::Result const & result, QWidget & parent)
+  : ResultView(result.GetString(), result.GetFeatureType(), result.GetAddress(), parent)
+{
+}
+
+ResultView::ResultView(search::Sample::Result const & result, QWidget & parent)
+  : ResultView(strings::ToUtf8(result.m_name), GetResultType(result), string() /* address */,
+               parent)
+{
 }
 
 void ResultView::EnableEditing(Edits::RelevanceEditor && editor)
@@ -75,8 +95,8 @@ void ResultView::Init()
   layout->setSizeConstraint(QLayout::SetMinimumSize);
   setLayout(layout);
 
-  m_string = CreateLabel(*this /* parent */);
-  layout->addWidget(m_string);
+  m_name = CreateLabel(*this /* parent */);
+  layout->addWidget(m_name);
 
   m_type = CreateLabel(*this /* parent */);
   m_type->setStyleSheet("QLabel { font-size : 8pt }");
@@ -99,11 +119,11 @@ void ResultView::Init()
   }
 }
 
-void ResultView::SetContents(search::Result const & result)
+void ResultView::SetContents(string const & name, string const & type, string const & address)
 {
-  SetText(*m_string, result.GetString());
-  SetText(*m_type, result.GetFeatureType());
-  SetText(*m_address, result.GetAddress());
+  SetText(*m_name, name);
+  SetText(*m_type, type);
+  SetText(*m_address, address);
 
   m_irrelevant->setChecked(false);
   m_relevant->setChecked(false);

--- a/search/search_quality/assessment_tool/result_view.hpp
+++ b/search/search_quality/assessment_tool/result_view.hpp
@@ -4,6 +4,7 @@
 #include "search/search_quality/sample.hpp"
 
 #include <memory>
+#include <string>
 
 #include <QtWidgets/QWidget>
 
@@ -21,19 +22,24 @@ public:
   using Relevance = search::Sample::Result::Relevance;
 
   ResultView(search::Result const & result, QWidget & parent);
+  ResultView(search::Sample::Result const & result, QWidget & parent);
 
   void EnableEditing(Edits::RelevanceEditor && editor);
 
   void Update();
 
 private:
+  ResultView(std::string const & name, std::string const & type, std::string const & address,
+             QWidget & parent);
+
   void Init();
-  void SetContents(search::Result const & result);
+  void SetContents(std::string const & name, std::string const & type,
+                   std::string const & address);
 
   QRadioButton * CreateRatioButton(string const & label, QLayout & layout);
   void OnRelevanceChanged();
 
-  QLabel * m_string = nullptr;
+  QLabel * m_name = nullptr;
   QLabel * m_type = nullptr;
   QLabel * m_address = nullptr;
 

--- a/search/search_quality/assessment_tool/results_view.hpp
+++ b/search/search_quality/assessment_tool/results_view.hpp
@@ -17,10 +17,13 @@ class Result;
 
 class ResultsView : public QListWidget
 {
+  Q_OBJECT
+
 public:
   explicit ResultsView(QWidget & parent);
 
   void Add(search::Result const & result);
+  void Add(search::Sample::Result const & result);
 
   ResultView & Get(size_t i);
   ResultView const & Get(size_t i) const;
@@ -30,6 +33,12 @@ public:
 
   void Clear();
 
+signals:
+  void OnResultSelected(int index);
+
 private:
+  template <typename Result>
+  void AddImpl(Result const & result);
+
   std::vector<ResultView *> m_results;
 };

--- a/search/search_quality/assessment_tool/sample_view.hpp
+++ b/search/search_quality/assessment_tool/sample_view.hpp
@@ -21,25 +21,27 @@ public:
   explicit SampleView(QWidget * parent);
 
   void SetContents(search::Sample const & sample);
-  void ShowResults(search::Results::Iter begin, search::Results::Iter end);
+  void ShowFoundResults(search::Results::Iter begin, search::Results::Iter end);
+  void ShowNonFoundResults(std::vector<search::Sample::Result> const & results);
 
-  void EnableEditing(Edits & edits);
+  void EnableEditing(Edits & resultsEdits, Edits & nonFoundResultsEdits);
 
-  void Update(Edits::Update const & update);
   void Clear();
 
-  ResultsView & GetResultsView() { return *m_results; }
+  ResultsView & GetFoundResultsView() { return *m_foundResults; }
+  ResultsView & GetNonFoundResultsView() { return *m_nonFoundResults; }
 
 signals:
   void OnShowViewportClicked();
   void OnShowPositionClicked();
 
 private:
+  void EnableEditing(ResultsView & results, Edits & edits);
+
   QLineEdit * m_query = nullptr;
   LanguagesList * m_langs = nullptr;
   QPushButton * m_showViewport = nullptr;
   QPushButton * m_showPosition = nullptr;
-  ResultsView * m_results = nullptr;
-
-  Edits * m_edits = nullptr;
+  ResultsView * m_foundResults = nullptr;
+  ResultsView * m_nonFoundResults = nullptr;
 };

--- a/search/search_quality/assessment_tool/view.hpp
+++ b/search/search_quality/assessment_tool/view.hpp
@@ -3,6 +3,7 @@
 #include "search/result.hpp"
 #include "search/search_quality/assessment_tool/context.hpp"
 #include "search/search_quality/assessment_tool/edits.hpp"
+#include "search/search_quality/sample.hpp"
 
 #include "geometry/rect2d.hpp"
 
@@ -16,19 +17,30 @@ class Model;
 class View
 {
 public:
+  enum class ResultType
+  {
+    Found,
+    NonFound
+  };
+
   virtual ~View() = default;
 
   void SetModel(Model & model) { m_model = &model; }
 
   virtual void SetSamples(ContextList::SamplesSlice const & samples) = 0;
   virtual void ShowSample(size_t index, search::Sample const & sample, bool hasEdits) = 0;
-  virtual void ShowResults(search::Results::Iter begin, search::Results::Iter end) = 0;
+  virtual void ShowFoundResults(search::Results::Iter begin, search::Results::Iter end) = 0;
+  virtual void ShowNonFoundResults(std::vector<search::Sample::Result> const & results) = 0;
 
   virtual void MoveViewportToResult(search::Result const & result) = 0;
+  virtual void MoveViewportToResult(search::Sample::Result const & result) = 0;
   virtual void MoveViewportToRect(m2::RectD const & rect) = 0;
 
-  virtual void OnSampleChanged(size_t index, Edits::Update const & update, bool hasEdits) = 0;
-  virtual void EnableSampleEditing(size_t index, Edits & edits) = 0;
+  virtual void OnResultChanged(size_t sampleIndex, ResultType type,
+                               Edits::Update const & update) = 0;
+  virtual void EnableSampleEditing(size_t index, Edits & foundResultsEdits,
+                                   Edits & nonFoundResultsEdits) = 0;
+  virtual void OnSampleChanged(size_t sampleIndex, bool hasEdits) = 0;
   virtual void OnSamplesChanged(bool hasEdits) = 0;
 
   virtual void ShowError(std::string const & msg) = 0;


### PR DESCRIPTION
Added a simple list view for results that are present in the search samples json, but weren't retrieved by the search engine. Relevances of these results may be modified by the user and these modifications will be saved.

@milchakov @bykoianko PTAL