### PR TITLE
[routing] Little number of mwm without cross_mwm section fix.

### DIFF
--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -146,7 +146,9 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
   bool allNeighborsHaveCrossMwmSection = false;
   GetAllLoadedNeighbors(s.GetMwmId(), neighbors, allNeighborsHaveCrossMwmSection);
   MwmStatus const currentMwmStatus = GetMwmStatus(s.GetMwmId());
-  CHECK(currentMwmStatus != MwmStatus::NotLoaded, ("Current mwm is not loaded. Mwm:", m_numMwmIds->GetFile(s.GetMwmId())));
+  CHECK(currentMwmStatus != MwmStatus::NotLoaded,
+        ("Current mwm is not loaded. Mwm:", m_numMwmIds->GetFile(s.GetMwmId()), "currentMwmStatus:",
+         currentMwmStatus));
   if (allNeighborsHaveCrossMwmSection && currentMwmStatus == MwmStatus::CrossMwmSectionExists)
   {
     DeserializeTransitions(neighbors);

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -145,7 +145,9 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
   vector<NumMwmId> neighbors;
   bool allNeighborsHaveCrossMwmSection = false;
   GetAllLoadedNeighbors(s.GetMwmId(), neighbors, allNeighborsHaveCrossMwmSection);
-  if (allNeighborsHaveCrossMwmSection)
+  MwmStatus const currentMwmStatus = GetMwmStatus(s.GetMwmId());
+  CHECK(currentMwmStatus != MwmStatus::NotLoaded, ("Current mwm is not loaded. Mwm:", m_numMwmIds->GetFile(s.GetMwmId())));
+  if (allNeighborsHaveCrossMwmSection && currentMwmStatus == MwmStatus::CrossMwmSectionExists)
   {
     DeserializeTransitions(neighbors);
     m_crossMwmIndexGraph.GetTwinsByOsmId(s, isOutgoing, neighbors, twins);

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -5,6 +5,7 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/assert.hpp"
 #include "base/math.hpp"
 #include "base/stl_helpers.hpp"
 
@@ -146,9 +147,9 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
   bool allNeighborsHaveCrossMwmSection = false;
   GetAllLoadedNeighbors(s.GetMwmId(), neighbors, allNeighborsHaveCrossMwmSection);
   MwmStatus const currentMwmStatus = GetMwmStatus(s.GetMwmId());
-  CHECK(currentMwmStatus != MwmStatus::NotLoaded,
-        ("Current mwm is not loaded. Mwm:", m_numMwmIds->GetFile(s.GetMwmId()), "currentMwmStatus:",
-         currentMwmStatus));
+  CHECK_NOT_EQUAL(currentMwmStatus, MwmStatus::NotLoaded,
+                  ("Current mwm is not loaded. Mwm:", m_numMwmIds->GetFile(s.GetMwmId()),
+                   "currentMwmStatus:", currentMwmStatus));
   if (allNeighborsHaveCrossMwmSection && currentMwmStatus == MwmStatus::CrossMwmSectionExists)
   {
     DeserializeTransitions(neighbors);
@@ -260,5 +261,17 @@ void CrossMwmGraph::GetTwinCandidates(FeatureType const & ft, bool isOutgoing,
     if (IsTransition(segBackward, isOutgoing))
       twinCandidates.push_back(segBackward);
   }
+}
+
+string DebugPrint(CrossMwmGraph::MwmStatus status)
+{
+  switch (status)
+  {
+  case CrossMwmGraph::MwmStatus::NotLoaded: return "CrossMwmGraph::NotLoaded";
+  case CrossMwmGraph::MwmStatus::CrossMwmSectionExists:
+    return "CrossMwmGraph::CrossMwmSectionExists";
+  case CrossMwmGraph::MwmStatus::NoCrossMwmSection: return "CrossMwmGraph::NoCrossMwmSection";
+  }
+  return string("Unknown CrossMwmGraph::MwmStatus.");
 }
 }  // namespace routing

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace routing
@@ -23,6 +24,13 @@ namespace routing
 class CrossMwmGraph final
 {
 public:
+  enum class MwmStatus
+  {
+    NotLoaded,
+    CrossMwmSectionExists,
+    NoCrossMwmSection,
+  };
+
   CrossMwmGraph(std::shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
                 std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
                 CourntryRectFn const & countryRectFn, Index & index,
@@ -82,13 +90,6 @@ public:
   void Clear();
 
 private:
-  enum class MwmStatus
-  {
-    NotLoaded,
-    CrossMwmSectionExists,
-    NoCrossMwmSection,
-  };
-
   struct ClosestSegment
   {
     ClosestSegment();
@@ -144,4 +145,6 @@ private:
   CrossMwmIndexGraph m_crossMwmIndexGraph;
   CrossMwmOsrmGraph m_crossMwmOsrmGraph;
 };
+
+string DebugPrint(CrossMwmGraph::MwmStatus status);
 }  // routing


### PR DESCRIPTION
Данный PR исправляет ситуации, когда были попытки проложить маршрут по одной mwm без cross_mwm секции. И маршрут были достаточно длинные, что волна подходила к краю mwm.

Причина, на наличие секции cross_mwmw проверялись только соседи, но не проверялась текущая mwm.

@dobriy-eeh @mpimenov @ygorshenin PTAL