### PR TITLE
[routing] Graph shortcut optimization for long routes.

### DIFF
--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace routing
@@ -89,6 +90,15 @@ public:
 
   void Clear();
 
+  template <typename Fn>
+  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
+  {
+    if (CrossMwmSectionExists(numMwmId))
+      m_crossMwmIndexGraph.ForEachTransition(numMwmId, isEnter, std::forward<Fn>(fn));
+    else
+      m_crossMwmOsrmGraph.ForEachTransition(numMwmId, isEnter, std::forward<Fn>(fn));
+  }
+
 private:
   struct ClosestSegment
   {
@@ -126,7 +136,7 @@ private:
   /// added to |twins| anyway. If there's no such segment in mwm it tries find the closet one and adds it
   /// to |minDistSegs|.
   void FindBestTwins(NumMwmId sMwmId, bool isOutgoing, FeatureType const & ft, m2::PointD const & point,
-                     map<NumMwmId, ClosestSegment> & minDistSegs, vector<Segment> & twins);
+                     std::map<NumMwmId, ClosestSegment> & minDistSegs, std::vector<Segment> & twins);
 
   /// \brief Fills |neighbors| with number mwm id of all loaded neighbors of |numMwmId| and
   /// sets |allNeighborsHaveCrossMwmSection| to true if all loaded neighbors have cross mwm section

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -135,8 +135,9 @@ private:
   /// \note If the method finds twin segment with a point which is very close to |point| the twin segment is
   /// added to |twins| anyway. If there's no such segment in mwm it tries find the closet one and adds it
   /// to |minDistSegs|.
-  void FindBestTwins(NumMwmId sMwmId, bool isOutgoing, FeatureType const & ft, m2::PointD const & point,
-                     std::map<NumMwmId, ClosestSegment> & minDistSegs, std::vector<Segment> & twins);
+  void FindBestTwins(NumMwmId sMwmId, bool isOutgoing, FeatureType const & ft,
+                     m2::PointD const & point, std::map<NumMwmId, ClosestSegment> & minDistSegs,
+                     std::vector<Segment> & twins);
 
   /// \brief Fills |neighbors| with number mwm id of all loaded neighbors of |numMwmId| and
   /// sets |allNeighborsHaveCrossMwmSection| to true if all loaded neighbors have cross mwm section

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -48,7 +48,8 @@ public:
   {
     if (isEnter)
     {
-      std::vector<Segment> const & enters = GetCrossMwmConnectorWithTransitions(numMwmId).GetEnters();
+      std::vector<Segment> const & enters =
+          GetCrossMwmConnectorWithTransitions(numMwmId).GetEnters();
       for (Segment const & enter : enters)
         fn(enter);
     }

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -43,6 +43,23 @@ public:
   bool InCache(NumMwmId numMwmId) const { return m_connectors.count(numMwmId) != 0; }
   CrossMwmConnector const & GetCrossMwmConnectorWithTransitions(NumMwmId numMwmId);
 
+  template <typename Fn>
+  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
+  {
+    if (isEnter)
+    {
+      std::vector<Segment> const & enters = GetCrossMwmConnectorWithTransitions(numMwmId).GetEnters();
+      for (Segment const & enter : enters)
+        fn(enter);
+    }
+    else
+    {
+      std::vector<Segment> const & exits = GetCrossMwmConnectorWithTransitions(numMwmId).GetExits();
+      for (Segment const & exit : exits)
+        fn(exit);
+    }
+  }
+
 private:
   CrossMwmConnector const & GetCrossMwmConnectorWithWeights(NumMwmId numMwmId);
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -48,9 +48,9 @@ public:
   {
     if (isEnter)
     {
-      std::vector<Segment> const & enters =
+      auto const & enters =
           GetCrossMwmConnectorWithTransitions(numMwmId).GetEnters();
-      for (Segment const & enter : enters)
+      for (auto const & enter : enters)
         fn(enter);
     }
     else

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -46,19 +46,9 @@ public:
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
   {
-    if (isEnter)
-    {
-      auto const & enters =
-          GetCrossMwmConnectorWithTransitions(numMwmId).GetEnters();
-      for (auto const & enter : enters)
-        fn(enter);
-    }
-    else
-    {
-      std::vector<Segment> const & exits = GetCrossMwmConnectorWithTransitions(numMwmId).GetExits();
-      for (Segment const & exit : exits)
-        fn(exit);
-    }
+    auto const & connectors = GetCrossMwmConnectorWithTransitions(numMwmId);
+    for (Segment const & t : (isEnter ? connectors.GetEnters() : connectors.GetExits()))
+      fn(t);
   }
 
 private:

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -34,16 +34,9 @@ public:
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
   {
-    if (isEnter)
-    {
-      for (auto const & kv : GetSegmentMaps(numMwmId).m_ingoing)
-        fn(kv.first);
-    }
-    else
-    {
-      for (auto const & kv : GetSegmentMaps(numMwmId).m_outgoing)
-        fn(kv.first);
-    }
+    auto const & ts = GetSegmentMaps(numMwmId);
+    for (auto const & kv : isEnter ? ts.m_ingoing : ts.m_outgoing)
+      fn(kv.first);
   }
 
 private:

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -31,6 +31,21 @@ public:
   void Clear();
   TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
 
+  template <typename Fn>
+  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
+  {
+    if (isEnter)
+    {
+      for (auto const & kv : GetSegmentMaps(numMwmId).m_ingoing)
+        fn(kv.first);
+    }
+    else
+    {
+      for (auto const & kv : GetSegmentMaps(numMwmId).m_outgoing)
+        fn(kv.first);
+    }
+  }
+
 private:
   struct TransitionSegments
   {

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -46,6 +46,7 @@ public:
   // EdgeEstimator overrides:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const override;
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const override;
+  double CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const override;
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
 
@@ -98,6 +99,14 @@ double CarEdgeEstimator::CalcSegmentWeight(Segment const & segment, RoadGeometry
 double CarEdgeEstimator::CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const
 {
   return TimeBetweenSec(from, to, m_maxSpeedMPS);
+}
+
+double CarEdgeEstimator::CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const
+{
+  // Let us assume for the time being that
+  // leap edges will be added with a half of max speed.
+  // @TODO(bykoianko) It's necessary to gather statistics to calculate better factor(s) instead of one below.
+  return TimeBetweenSec(from, to, m_maxSpeedMPS / 2.0);
 }
 
 double CarEdgeEstimator::GetUTurnPenalty() const

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -105,7 +105,8 @@ double CarEdgeEstimator::CalcLeapEdgeTime(m2::PointD const & from, m2::PointD co
 {
   // Let us assume for the time being that
   // leap edges will be added with a half of max speed.
-  // @TODO(bykoianko) It's necessary to gather statistics to calculate better factor(s) instead of one below.
+  // @TODO(bykoianko) It's necessary to gather statistics to calculate better factor(s) instead of
+  // one below.
   return TimeBetweenSec(from, to, m_maxSpeedMPS / 2.0);
 }
 

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -46,7 +46,7 @@ public:
   // EdgeEstimator overrides:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const override;
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const override;
-  double CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const override;
+  double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
 
@@ -101,7 +101,7 @@ double CarEdgeEstimator::CalcHeuristic(m2::PointD const & from, m2::PointD const
   return TimeBetweenSec(from, to, m_maxSpeedMPS);
 }
 
-double CarEdgeEstimator::CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const
+double CarEdgeEstimator::CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const
 {
   // Let us assume for the time being that
   // leap edges will be added with a half of max speed.

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -28,9 +28,8 @@ public:
   // edge |from|-|to|.
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
   // (|from|, |to|) in road graph.
-  // Note 2. The result of the method should be less or equal to CalcHeuristic(|form|, |to|).
-  // Note 3. It's assumed here that GetEstimator().CalcLeapWeight(p1, p2) ==
-  // GetEstimator().CalcLeapWeight(p2, p1).
+  // Note 2. The result of the method should be less or equal to CalcHeuristic(|from|, |to|).
+  // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
   virtual double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
   // The leap is the shortcut edge from mwm border enter to exit.

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -24,11 +24,13 @@ public:
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
-  // Returns time in seconds is taken for going from point |from| to point |to| along a leap (fake)
+  // Returns time in seconds it takes to go from point |from| to point |to| along a leap (fake)
   // edge |from|-|to|.
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
-  // (|form|, |to|) in road graph.
+  // (|from|, |to|) in road graph.
   // Note 2. The result of the method should be less or equal to CalcHeuristic(|form|, |to|).
+  // Note 3. It's assumed here that GetEstimator().CalcLeapWeight(p1, p2) ==
+  // GetEstimator().CalcLeapWeight(p2, p1).
   virtual double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
   // The leap is the shortcut edge from mwm border enter to exit.

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -24,6 +24,10 @@ public:
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
+  // Returns time in seconds is taken for going from point |from| to point |to| along a leap (fake) edge |from|-|to|.
+  // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge (|form|, |to|) in road graph.
+  // Note 2. The result of the method should be less or equal to CalcHeuristic(|form|, |to|).
+  virtual double CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
   // The leap is the shortcut edge from mwm border enter to exit.
   // Router can't use leaps on some mwms: e.g. mwm with loaded traffic data.

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -24,8 +24,10 @@ public:
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const = 0;
-  // Returns time in seconds is taken for going from point |from| to point |to| along a leap (fake) edge |from|-|to|.
-  // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge (|form|, |to|) in road graph.
+  // Returns time in seconds is taken for going from point |from| to point |to| along a leap (fake)
+  // edge |from|-|to|.
+  // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
+  // (|form|, |to|) in road graph.
   // Note 2. The result of the method should be less or equal to CalcHeuristic(|form|, |to|).
   virtual double CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -29,7 +29,7 @@ public:
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
   // (|form|, |to|) in road graph.
   // Note 2. The result of the method should be less or equal to CalcHeuristic(|form|, |to|).
-  virtual double CalcLeapEdgeTime(m2::PointD const & from, m2::PointD const & to) const = 0;
+  virtual double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual double GetUTurnPenalty() const = 0;
   // The leap is the shortcut edge from mwm border enter to exit.
   // Router can't use leaps on some mwms: e.g. mwm with loaded traffic data.

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -124,9 +124,9 @@ void IndexGraphStarter::ConnectLeapToTransitions(FakeVertex const & fakeVertex, 
   m2::PointD const & segmentPoint = fakeVertex.GetPoint();
 
   // Note. If |isOutgoing| == true it's necessary to add edges which connect the start with all
-  // exits of its mwm.
-  // So |isEnter| below should be set to false. If |isOutgoing| == false all enters of the
-  // finish mwm should be connected with the finish point. So |isEnter| below should be set to true.
+  // exits of its mwm. So |isEnter| below should be set to false.
+  // If |isOutgoing| == false all enters of the finish mwm should be connected with the finish point.
+  // So |isEnter| below should be set to true.
   m_graph.ForEachTransition(
       fakeVertex.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
         edges.emplace_back(transition, m_graph.GetEstimator().CalcLeapWeight(

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -69,8 +69,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
   GetNormalToFakeEdge(segment, m_finish, kFinishFakeSegment, isOutgoing, edges);
 }
 
-void IndexGraphStarter::GetFakeToNormalEdges(FakeVertex const & fakeVertex,
-                                             bool isOutgoing,
+void IndexGraphStarter::GetFakeToNormalEdges(FakeVertex const & fakeVertex, bool isOutgoing,
                                              vector<SegmentEdge> & edges)
 {
   if (m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
@@ -100,18 +99,22 @@ void IndexGraphStarter::GetNormalToFakeEdge(Segment const & segment, FakeVertex 
                                             vector<SegmentEdge> & edges)
 {
   m2::PointD const & pointFrom = GetPoint(segment, isOutgoing);
-  if (segment.GetMwmId() == fakeVertex.GetMwmId() && m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
+  if (segment.GetMwmId() == fakeVertex.GetMwmId() &&
+      m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
   {
-    // It's assumed here that GetEstimator().CalcLeapEdgeTime(p1, p2) == GetEstimator().CalcLeapEdgeTime(p2, p1).
+    // It's assumed here that GetEstimator().CalcLeapEdgeTime(p1, p2) ==
+    // GetEstimator().CalcLeapEdgeTime(p2, p1).
     if (m_graph.IsTransition(segment, isOutgoing))
-      edges.emplace_back(fakeSegment, m_graph.GetEstimator().CalcLeapEdgeTime(pointFrom, fakeVertex.GetPoint()));
+      edges.emplace_back(fakeSegment,
+                         m_graph.GetEstimator().CalcLeapEdgeTime(pointFrom, fakeVertex.GetPoint()));
     return;
   }
 
   if (!fakeVertex.Fits(segment))
     return;
 
-  edges.emplace_back(fakeSegment, m_graph.GetEstimator().CalcLeapEdgeTime(pointFrom, fakeVertex.GetPoint()));
+  edges.emplace_back(fakeSegment,
+                     m_graph.GetEstimator().CalcLeapEdgeTime(pointFrom, fakeVertex.GetPoint()));
 }
 
 void IndexGraphStarter::ConnectLeapToTransitions(FakeVertex const & fakeVertex, bool isOutgoing,
@@ -129,7 +132,7 @@ void IndexGraphStarter::ConnectLeapToTransitions(FakeVertex const & fakeVertex, 
         // It's assumed here that GetEstimator().CalcLeapEdgeTime(p1, p2) ==
         // GetEstimator().CalcLeapEdgeTime(p2, p1).
         edges.emplace_back(transition, m_graph.GetEstimator().CalcLeapEdgeTime(
-          segmentPoint, GetPoint(transition, isOutgoing)));
+                                           segmentPoint, GetPoint(transition, isOutgoing)));
       });
 }
 

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -102,8 +102,6 @@ void IndexGraphStarter::GetNormalToFakeEdge(Segment const & segment, FakeVertex 
   if (segment.GetMwmId() == fakeVertex.GetMwmId() &&
       m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
   {
-    // It's assumed here that GetEstimator().CalcLeapWeight(p1, p2) ==
-    // GetEstimator().CalcLeapWeight(p2, p1).
     if (m_graph.IsTransition(segment, isOutgoing))
     {
       edges.emplace_back(fakeSegment,
@@ -131,8 +129,6 @@ void IndexGraphStarter::ConnectLeapToTransitions(FakeVertex const & fakeVertex, 
   // finish mwm should be connected with the finish point. So |isEnter| below should be set to true.
   m_graph.ForEachTransition(
       fakeVertex.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
-        // It's assumed here that GetEstimator().CalcLeapWeight(p1, p2) ==
-        // GetEstimator().CalcLeapWeight(p2, p1).
         edges.emplace_back(transition, m_graph.GetEstimator().CalcLeapWeight(
           segmentPoint, GetPoint(transition, isOutgoing)));
       });

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -111,10 +111,10 @@ private:
   void GetNormalToFakeEdge(Segment const & segment, FakeVertex const & fakeVertex,
                            Segment const & fakeSegment, bool isOutgoing,
                            vector<SegmentEdge> & edges);
-  /// \brief If |toExits| == true fills |edges| with SegmentEdge(s) which connects
-  /// |segment| with all exits of mwm.
-  /// \brief If |toExits| == false fills |edges| with SegmentEdge(s) which connects
-  /// all enters to mwm with |segment|.
+  /// \brief If |isOutgoing| == true fills |edges| with SegmentEdge(s) which connects
+  /// |fakeVertex| with all exits of mwm.
+  /// \brief If |isOutgoing| == false fills |edges| with SegmentEdge(s) which connects
+  /// all enters to mwm with |fakeVertex|.
   void ConnectLeapToTransitions(FakeVertex const & fakeVertex, bool isOutgoing,
                                 vector<SegmentEdge> & edges);
 

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -49,11 +49,20 @@ public:
     m2::PointD const m_point;
   };
 
+  static uint32_t constexpr kFakeFeatureId = numeric_limits<uint32_t>::max();
+  static uint32_t constexpr kFakeSegmentIdx = numeric_limits<uint32_t>::max();
+  static Segment constexpr kStartFakeSegment =
+    Segment(kFakeNumMwmId, kFakeFeatureId, kFakeSegmentIdx, false);
+  static Segment constexpr kFinishFakeSegment =
+    Segment(kFakeNumMwmId, kFakeFeatureId, kFakeSegmentIdx, true);
+
   IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish, WorldGraph & graph);
 
   WorldGraph & GetGraph() { return m_graph; }
   Segment const & GetStart() const { return kStartFakeSegment; }
   Segment const & GetFinish() const { return kFinishFakeSegment; }
+  FakeVertex const & GetStartVertex() const { return m_start; }
+  FakeVertex const & GetFinishVertex() const { return m_finish; }
   m2::PointD const & GetPoint(Segment const & segment, bool front);
 
   static size_t GetRouteNumPoints(vector<Segment> const & route);
@@ -94,16 +103,7 @@ public:
     return segment.GetFeatureId() == kFakeFeatureId;
   }
 
-  Segment const & ConvertSegment(Segment const & segment);
-
 private:
-  static uint32_t constexpr kFakeFeatureId = numeric_limits<uint32_t>::max();
-  static uint32_t constexpr kFakeSegmentIdx = numeric_limits<uint32_t>::max();
-  static Segment constexpr kStartFakeSegment =
-      Segment(kFakeNumMwmId, kFakeFeatureId, kFakeSegmentIdx, false);
-  static Segment constexpr kFinishFakeSegment =
-      Segment(kFakeNumMwmId, kFakeFeatureId, kFakeSegmentIdx, true);
-
   void GetFakeToNormalEdges(FakeVertex const & fakeVertex, bool isOutgoing,
                             vector<SegmentEdge> & edges);
   void GetFakeToNormalEdge(FakeVertex const & fakeVertex, bool forward,

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -138,7 +138,13 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
                                  m_index, m_indexManager),
       IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
       m_estimator);
-  graph.SetMode(forSingleMwm ? WorldGraph::Mode::SingleMwm : WorldGraph::Mode::WorldWithLeaps);
+
+  auto const getRoutingMode = [&](){
+    return AreMwmsNear(start.GetMwmId(), finish.GetMwmId()) ? WorldGraph::Mode::LeapsIfPossible
+                                                            : WorldGraph::Mode::LeapsOnly;
+  };
+  graph.SetMode(forSingleMwm ? WorldGraph::Mode::SingleMwm : getRoutingMode());
+  LOG(LINFO, ("Routing in mode:", graph.GetMode()));
 
   IndexGraphStarter starter(start, finish, graph);
 
@@ -230,27 +236,30 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
   output.reserve(input.size());
 
   WorldGraph & worldGraph = starter.GetGraph();
+  WorldGraph::Mode const worldRouteMode = worldGraph.GetMode();
   worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
 
   for (size_t i = 0; i < input.size(); ++i)
   {
     Segment const & current = input[i];
-    if (!starter.IsLeap(current.GetMwmId()))
+    if (worldRouteMode == WorldGraph::Mode::LeapsIfPossible && !starter.IsLeap(current.GetMwmId()))
     {
       output.push_back(current);
       continue;
     }
 
+    Segment const & convertedCurrent = starter.ConvertSegment(input[i]);
     ++i;
     CHECK_LESS(i, input.size(), ());
-    Segment const & next = input[i];
-
+    Segment const & convertedNext = starter.ConvertSegment(input[i]);
     CHECK_EQUAL(
-        current.GetMwmId(), next.GetMwmId(),
+        convertedCurrent.GetMwmId(), convertedNext.GetMwmId(),
         ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
 
-    IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */));
-    IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */));
+    IndexGraphStarter::FakeVertex const start(convertedCurrent,
+                                              starter.GetPoint(convertedCurrent, true /* front */));
+    IndexGraphStarter::FakeVertex const finish(convertedNext,
+                                               starter.GetPoint(convertedNext, true /* front */));
     IndexGraphStarter leapStarter(start, finish, starter.GetGraph());
 
     // Clear previous loaded graphs.
@@ -293,7 +302,7 @@ bool IndexRouter::RedressRoute(vector<Segment> const & segments, RouterDelegate 
 
   IndexRoadGraph roadGraph(m_numMwmIds, starter, segments, junctions, m_index);
   if (!forSingleMwm)
-    starter.GetGraph().SetMode(WorldGraph::Mode::WorldWithoutLeaps);
+    starter.GetGraph().SetMode(WorldGraph::Mode::NoLeaps);
 
   CHECK(m_directionsEngine, ());
   ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, junctions, route);
@@ -317,6 +326,17 @@ bool IndexRouter::RedressRoute(vector<Segment> const & segments, RouterDelegate 
   route.SetSectionTimes(move(times));
 
   return true;
+}
+
+bool IndexRouter::AreMwmsNear(NumMwmId startId, NumMwmId finishId) const
+{
+  m2::RectD const startMwmRect = m_countryRectFn(m_numMwmIds->GetFile(startId).GetName());
+  bool areMwmsNear = false;
+  m_numMwmTree->ForEachInRect(startMwmRect, [&](NumMwmId id) {
+    if (id == finishId)
+      areMwmsNear = true;
+  });
+  return areMwmsNear;
 }
 
 // static

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -139,7 +139,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
       IndexGraphLoader::Create(m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
       m_estimator);
 
-  auto const getRoutingMode = [&](){
+  auto const getRoutingMode = [&]() {
     return AreMwmsNear(start.GetMwmId(), finish.GetMwmId()) ? WorldGraph::Mode::LeapsIfPossible
                                                             : WorldGraph::Mode::LeapsOnly;
   };

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -77,6 +77,8 @@ private:
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
                     bool forSingleMwm, IndexGraphStarter & starter, Route & route) const;
 
+  bool AreMwmsNear(NumMwmId startId, NumMwmId finishId) const;
+
   string const m_name;
   Index & m_index;
   TCountryFileFn const m_countryFileFn;

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -462,20 +462,20 @@ UNIT_TEST(SerializeSimpleGraph)
 //           F2
 //           |
 //           |
-// 0.0003    *---------*
+// 0.0003   6*---------*5
 //           |         |
 //           |         |
 //           |         |
 //           |         |
 //           |         |
-// 0.0002    *         *
+// 0.0002   7*         *4
 //           |         |
 //           |         |
-// 0.00015   *    F0   *
+// 0.00015  8*    F0   *3
 //            \       /
-//              \   /
-// 0.0001         *---F0-*----*
-//                            ^
+//              \   /    1    0
+// 0.0001        9*---F0-*----*
+//                2           ^
 //                            |
 //                            F1
 //                            |
@@ -524,7 +524,7 @@ UNIT_CLASS_TEST(RestrictionTest, LoopGraph)
              routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 2, 0 /* seg id */,
                                                     m2::PointD(0.00005, 0.0004)) /* finish */);
 
-  double constexpr kExpectedRouteTimeSec = 3.48;
+  double constexpr kExpectedRouteTimeSec = 3.92527;
   TestRouteTime(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, kExpectedRouteTimeSec);
 }
 

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -68,6 +68,12 @@ double WeightedEdgeEstimator::CalcHeuristic(m2::PointD const & /* from */,
   return 0.0;
 }
 
+double WeightedEdgeEstimator::CalcLeapEdgeTime(m2::PointD const & /* from */,
+                                               m2::PointD const & /* to */) const
+{
+  return 0.0;
+}
+
 double WeightedEdgeEstimator::GetUTurnPenalty() const { return 0.0; }
 
 bool WeightedEdgeEstimator::LeapIsAllowed(NumMwmId /* mwmId */) const { return false; }

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -68,8 +68,8 @@ double WeightedEdgeEstimator::CalcHeuristic(m2::PointD const & /* from */,
   return 0.0;
 }
 
-double WeightedEdgeEstimator::CalcLeapEdgeTime(m2::PointD const & /* from */,
-                                               m2::PointD const & /* to */) const
+double WeightedEdgeEstimator::CalcLeapWeight(m2::PointD const & /* from */,
+                                             m2::PointD const & /* to */) const
 {
   return 0.0;
 }

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -101,6 +101,7 @@ public:
   // EdgeEstimator overrides:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
   double CalcHeuristic(m2::PointD const & /* from */, m2::PointD const & /* to */) const override;
+  double CalcLeapEdgeTime(m2::PointD const & /* from */, m2::PointD const & /* to */) const override;
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId /* mwmId */) const override;
 

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -101,8 +101,8 @@ public:
   // EdgeEstimator overrides:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
   double CalcHeuristic(m2::PointD const & /* from */, m2::PointD const & /* to */) const override;
-  double CalcLeapEdgeTime(m2::PointD const & /* from */,
-                          m2::PointD const & /* to */) const override;
+  double CalcLeapWeight(m2::PointD const & /* from */,
+                        m2::PointD const & /* to */) const override;
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId /* mwmId */) const override;
 

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -101,7 +101,8 @@ public:
   // EdgeEstimator overrides:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
   double CalcHeuristic(m2::PointD const & /* from */, m2::PointD const & /* to */) const override;
-  double CalcLeapEdgeTime(m2::PointD const & /* from */, m2::PointD const & /* to */) const override;
+  double CalcLeapEdgeTime(m2::PointD const & /* from */,
+                          m2::PointD const & /* to */) const override;
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId /* mwmId */) const override;
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -12,7 +12,8 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph, unique_ptr<Index
   CHECK(m_estimator, ());
 }
 
-void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, std::vector<SegmentEdge> & edges)
+void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+                             std::vector<SegmentEdge> & edges)
 {
   if (m_mode != Mode::NoLeaps && (isLeap || m_mode == Mode::LeapsOnly))
   {
@@ -63,10 +64,10 @@ string DebugPrint(WorldGraph::Mode mode)
 {
   switch (mode)
   {
-    case WorldGraph::Mode::SingleMwm: return "SingleMwm";
-    case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
-    case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
-    case WorldGraph::Mode::NoLeaps: return "NoLeaps";
+  case WorldGraph::Mode::SingleMwm: return "SingleMwm";
+  case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
+  case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
+  case WorldGraph::Mode::NoLeaps: return "NoLeaps";
   }
   return "Unknown mode";
 }

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -12,10 +12,9 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph, unique_ptr<Index
   CHECK(m_estimator, ());
 }
 
-void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
-                             vector<SegmentEdge> & edges)
+void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, std::vector<SegmentEdge> & edges)
 {
-  if (isLeap && m_mode == Mode::WorldWithLeaps)
+  if (m_mode != Mode::NoLeaps && (isLeap || m_mode == Mode::LeapsOnly))
   {
     CHECK(m_crossMwmGraph, ());
     if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
@@ -58,5 +57,17 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
     double const weight = m_estimator->CalcHeuristic(from, to);
     edges.emplace_back(twin, weight);
   }
+}
+
+string DebugPrint(WorldGraph::Mode mode)
+{
+  switch (mode)
+  {
+    case WorldGraph::Mode::SingleMwm: return "SingleMwm";
+    case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
+    case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
+    case WorldGraph::Mode::NoLeaps: return "NoLeaps";
+  }
+  return "Unknown mode";
 }
 }  // namespace routing

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -69,6 +69,7 @@ string DebugPrint(WorldGraph::Mode mode)
   case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
   case WorldGraph::Mode::NoLeaps: return "NoLeaps";
   }
+  ASSERT(false, ("Unknown mode:", static_cast<size_t>(mode)));
   return "Unknown mode";
 }
 }  // namespace routing

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -28,7 +28,8 @@ public:
   WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph, std::unique_ptr<IndexGraphLoader> loader,
              std::shared_ptr<EdgeEstimator> estimator);
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, std::vector<SegmentEdge> & edges);
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+                   std::vector<SegmentEdge> & edges);
 
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
   EdgeEstimator const & GetEstimator() const { return *m_estimator; }
@@ -40,14 +41,16 @@ public:
   void ClearIndexGraphs() { m_loader->Clear(); }
   void SetMode(Mode mode) { m_mode = mode; }
   Mode GetMode() const { return m_mode; }
-
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
   {
     m_crossMwmGraph->ForEachTransition(numMwmId, isEnter, std::forward<Fn>(fn));
   }
 
-  bool IsTransition(Segment const & s, bool isOutgoing) { return m_crossMwmGraph->IsTransition(s, isOutgoing);}
+  bool IsTransition(Segment const & s, bool isOutgoing)
+  {
+    return m_crossMwmGraph->IsTransition(s, isOutgoing);
+  }
 
 private:  
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -19,10 +19,14 @@ class WorldGraph final
 public:
   enum class Mode
   {
-    SingleMwm,
-    LeapsOnly,
-    LeapsIfPossible,
-    NoLeaps,
+    SingleMwm,  // Mode for building a route within single mwm.
+    LeapsOnly,  // Mode for building a cross mwm route contains of only leaps. In case of start and
+                // finish they (start and finish) will be connected with all transition segments of
+                // their mwm with leap (fake) edges.
+    LeapsIfPossible,  // Mode for build cross mwm and single mwm routes. In case of cross mwm route
+                      // if they are neighboring mwms the route will be made without leaps.
+                      // If not the route is made with leaps for intermediate mwms.
+    NoLeaps,  // Mode for building route and getting outgoing/ingoing edges without leaps anyway.
   };
 
   WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph, std::unique_ptr<IndexGraphLoader> loader,

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -26,7 +26,7 @@ public:
     LeapsIfPossible,  // Mode for building cross mwm and single mwm routes. In case of cross mwm route
                       // if they are neighboring mwms the route will be made without leaps.
                       // If not the route is made with leaps for intermediate mwms.
-    NoLeaps,  // Mode for building route and getting outgoing/ingoing edges without leaps anyway.
+    NoLeaps,  // Mode for building route and getting outgoing/ingoing edges without leaps at all.
   };
 
   WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph, std::unique_ptr<IndexGraphLoader> loader,

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -20,10 +20,10 @@ public:
   enum class Mode
   {
     SingleMwm,  // Mode for building a route within single mwm.
-    LeapsOnly,  // Mode for building a cross mwm route contains of only leaps. In case of start and
+    LeapsOnly,  // Mode for building a cross mwm route containing only leaps. In case of start and
                 // finish they (start and finish) will be connected with all transition segments of
                 // their mwm with leap (fake) edges.
-    LeapsIfPossible,  // Mode for build cross mwm and single mwm routes. In case of cross mwm route
+    LeapsIfPossible,  // Mode for building cross mwm and single mwm routes. In case of cross mwm route
                       // if they are neighboring mwms the route will be made without leaps.
                       // If not the route is made with leaps for intermediate mwms.
     NoLeaps,  // Mode for building route and getting outgoing/ingoing edges without leaps anyway.
@@ -45,6 +45,7 @@ public:
   void ClearIndexGraphs() { m_loader->Clear(); }
   void SetMode(Mode mode) { m_mode = mode; }
   Mode GetMode() const { return m_mode; }
+  
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
   {


### PR DESCRIPTION
Если mwm являются соседями или начало и конец лежат в одной mwm - то маршрут считается точно, но без оптимизаций. Под соседними понимается, что прямоугольник полностью содержащий стартовую mwm накрывает какую-то часть финишной mwm. Например, так считаются маршрут Москва-Москва, Москва-Область, Москва-Тверь.

Если mwm удалены друг от друга, то старт и финиш соединяются со всеми переходными точками mwm и затем считается кросс mwm-й маршрут. После чего считаются маршруты внутри mwm.

Данный PR дает значительное ускорение при прокладке длинных маршрутов (300 км и более), хотя может давать не точности в вычислениях. В то время как на коротких маршрута (мене 300 км) сохраняется точность и обеспечивается скорость.

Результаты измерений времени прокладки маршрута на iPhone 7:
Офис (м. Аэропорт) - дом (Тушино)
OSRM: 1.5 сек (0.5-2.5)
Release 7.2: 2 сек (0.9-3.0)
Данный PR (маршрут рассчитывается точно): 1.5 сек (0.6-2.5)

Москва-Тверь
OSRM: 1.5 сек (0.5-2.5)
Release 7.2:  4 сек (3-5)
Данный PR (маршрут рассчитывается точно): 6 сек (5-8)

Москва-Минск
OSRM 2 сек (0.6-2.5)
Release 7.2: 5.5 сек (4.5-6)
A* (по мировому графу, мастер до данного PR) - 23.8 сек (23.5-24.8)
Данный PR (используется эвристика): 7 сек (6-8)

@dobriy-eeh @ygorshenin @mpimenov PTAL