### PR TITLE
[generator] Tool for copying sections from one mwm to another

### DIFF
--- a/generator/move_cross_mwm/move_cross_mwm.cpp
+++ b/generator/move_cross_mwm/move_cross_mwm.cpp
@@ -1,0 +1,76 @@
+#include "generator/routing_helpers.hpp"
+
+#include "routing/cross_mwm_connector_serialization.hpp"
+
+#include "coding/file_container.hpp"
+
+#include "defines.hpp"
+
+#include "3party/gflags/src/gflags/gflags.h"
+
+DEFINE_string(old_mwm, "", "Path to the old mwm file.");
+DEFINE_string(new_mwm, "", "Path to the new mwm file.");
+DEFINE_string(osm2ft_path, "", "Path to an osm2ft file for the new mwm.");
+
+using namespace routing;
+
+int main(int argc, char ** argv)
+{
+  google::SetUsageMessage(
+      "Move a crossmwm section from one mwm to another, using an osm2ft file to renumber "
+      "features.");
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_old_mwm.empty() || FLAGS_new_mwm.empty())
+  {
+    google::ShowUsageWithFlagsRestrict("Move Cross MWM", "move_cross_mwm");
+    return -1;
+  }
+
+  string osmToFeatureFile =
+      !FLAGS_osm2ft_path.empty() ? FLAGS_osm2ft_path : FLAGS_new_mwm + OSM2FEATURE_FILE_EXTENSION;
+  map<osm::Id, uint32_t> osmIdToFeatureId;
+  if (!ParseOsmIdToFeatureIdMapping(osmToFeatureFile, osmIdToFeatureId))
+    return false;
+
+  FilesContainerR contOld(FLAGS_old_mwm);
+  FilesContainerR::TReader const reader =
+      FilesContainerR::TReader(contOld.GetReader(CROSS_MWM_FILE_TAG));
+  ReaderSource<FilesContainerR::TReader> src(reader);
+
+  FilesContainerW cont(FLAGS_new_mwm, FileWriter::OP_WRITE_EXISTING);
+  FileWriter writer = cont.GetWriter(CROSS_MWM_FILE_TAG);
+
+  // Read and copy the header.
+  CrossMwmConnectorSerializer::Header header;
+  header.Deserialize(src);
+  header.Serialize(writer);
+
+  uint8_t const bitsPerOsmId = header.GetBitsPerOsmId();
+  uint8_t const bitsPerMask = header.GetBitsPerMask();
+  auto const & codingParams = header.GetCodingParams();
+
+  // Renumber transitions.
+  auto const numTransitions = base::checked_cast<size_t>(header.GetNumTransitions());
+  for (size_t i = 0; i < numTransitions; ++i)
+  {
+    CrossMwmConnectorSerializer::Transition transition;
+    transition.Deserialize(codingParams, bitsPerOsmId, bitsPerMask, src);
+    auto const & osmIt = osmIdToFeatureId.find(osm::Id::Way(transition.GetOsmId()));
+    bool found = osmIt != osmIdToFeatureId.cend();
+    CHECK(found, ("Could not find feature Id for osm Id", transition.GetOsmId()));
+    if (found)
+      transition.ReplaceFeatureId(osmIt->second);
+    transition.Serialize(codingParams, bitsPerOsmId, bitsPerMask, writer);
+  }
+
+  // Copy all weights from source to target.
+  for (CrossMwmConnectorSerializer::Section const & section : header.GetSections())
+  {
+    vector<uint8_t> buffer(section.GetSize());
+    src.Read(buffer.data(), buffer.size());
+    writer.Write(buffer.data(), buffer.size());
+  }
+
+  return 0;
+}

--- a/generator/move_cross_mwm/move_cross_mwm.pro
+++ b/generator/move_cross_mwm/move_cross_mwm.pro
@@ -1,0 +1,23 @@
+# Moves cross_mwm section from older mwm to new one, cross-referencing features with osm2ft.
+
+TARGET = move_cross_mwm
+CONFIG += console warn_on
+CONFIG -= app_bundle
+TEMPLATE = app
+
+ROOT_DIR = ../..
+DEPENDENCIES = generator map routing traffic routing_common storage indexer \
+               coding geometry base minizip succinct protobuf gflags stats_client icu
+
+include($$ROOT_DIR/common.pri)
+
+INCLUDEPATH *= $$ROOT_DIR/3party/gflags/src
+
+QT *= core
+
+macx-* {
+    LIBS *= "-framework IOKit" "-framework SystemConfiguration"
+}
+
+SOURCES += \
+    move_cross_mwm.cpp \

--- a/omim.pro
+++ b/omim.pro
@@ -61,7 +61,9 @@ SUBDIRS = 3party base coding geometry editor indexer routing routing_common sear
     srtm_coverage_checker.depends = $$SUBDIRS routing
     feature_segments_checker.subdir = generator/feature_segments_checker
     feature_segments_checker.depends = $$SUBDIRS
-    SUBDIRS *= routing_integration_tests routing_consistency_tests srtm_coverage_checker feature_segments_checker
+    move_cross_mwm.subdir = generator/move_cross_mwm
+    move_cross_mwm.depends = $$SUBDIRS
+    SUBDIRS *= routing_integration_tests routing_consistency_tests srtm_coverage_checker feature_segments_checker move_cross_mwm
   }
 }
 

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -86,6 +86,7 @@ public:
     bool ForwardIsEnter() const { return m_forwardIsEnter; }
     VehicleMask GetRoadMask() const { return m_roadMask; }
     VehicleMask GetOneWayMask() const { return m_oneWayMask; }
+    void ReplaceFeatureId(uint32_t newFeatureId) { m_featureId = newFeatureId; }
 
   private:
     uint64_t m_osmId = 0;
@@ -254,6 +255,7 @@ private:
   static Weight constexpr kGranularity = 4;
   static_assert(kGranularity > 0, "kGranularity should be > 0");
 
+public:
   class Section final
   {
   public:
@@ -369,6 +371,7 @@ private:
     std::vector<Section> m_sections;
   };
 
+private:
   static uint32_t CalcBitsPerOsmId(std::vector<Transition> const & transitions);
 
   template <typename T>


### PR DESCRIPTION
Написал скрипт для переноса секции cross_mwm между файлами, собранными из одних и тех же данных. Посмотрите, вдруг пригодится в omim.

Особенное внимание файлу `cross_mwm_connector_serialization.hpp`, в котором я вынес пару классов в паблик.