### PR TITLE
[DNM][editor] building matching fix

### DIFF
--- a/android/src/com/mapswithme/maps/settings/MiscPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/MiscPrefsFragment.java
@@ -1,0 +1,147 @@
+package com.mapswithme.maps.settings;
+
+import android.os.Bundle;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.preference.TwoStatePreference;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.mapswithme.maps.BuildConfig;
+import com.mapswithme.maps.MwmApplication;
+import com.mapswithme.maps.R;
+import com.mapswithme.maps.location.LocationHelper;
+import com.mapswithme.maps.search.SearchFragment;
+import com.mapswithme.util.Config;
+import com.mapswithme.util.log.LoggerFactory;
+import com.mapswithme.util.NetworkPolicy;
+import com.mapswithme.util.concurrency.UiThread;
+import com.mapswithme.util.statistics.MytargetHelper;
+import com.mapswithme.util.statistics.Statistics;
+
+public class MiscPrefsFragment extends BaseXmlSettingsFragment
+{
+  @Override
+  protected int getXmlResources()
+  {
+    return R.xml.prefs_misc;
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+
+    Preference pref = findPreference(getString(R.string.pref_send_statistics));
+    ((TwoStatePreference)pref).setChecked(Config.isStatisticsEnabled());
+    pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+    {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue)
+      {
+        Statistics.INSTANCE.setStatEnabled((Boolean) newValue);
+        return true;
+      }
+    });
+
+    pref = findPreference(getString(R.string.pref_play_services));
+
+    if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(MwmApplication.get()) != ConnectionResult.SUCCESS)
+      getPreferenceScreen().removePreference(pref);
+    else
+    {
+      ((TwoStatePreference) pref).setChecked(Config.useGoogleServices());
+      pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+      {
+        @Override
+        public boolean onPreferenceChange(Preference preference, Object newValue)
+        {
+          boolean oldVal = Config.useGoogleServices();
+          boolean newVal = ((Boolean) newValue).booleanValue();
+          if (oldVal != newVal)
+          {
+            Config.setUseGoogleService(newVal);
+            LocationHelper.INSTANCE.restart();
+          }
+          return true;
+        }
+      });
+    }
+
+    if (!MytargetHelper.isShowcaseSwitchedOnServer())
+      getPreferenceScreen().removePreference(findPreference(getString(R.string.pref_showcase_switched_on)));
+
+    pref = findPreference(getString(R.string.pref_enable_logging));
+    if (!MwmApplication.prefs().getBoolean(SearchFragment.PREFS_SHOW_ENABLE_LOGGING_SETTING,
+                                           BuildConfig.BUILD_TYPE.equals("beta")))
+    {
+      getPreferenceScreen().removePreference(pref);
+    }
+    else
+    {
+      final boolean isLoggingEnabled = LoggerFactory.INSTANCE.isFileLoggingEnabled();
+      ((TwoStatePreference) pref).setChecked(isLoggingEnabled);
+      pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+      {
+        @Override
+        public boolean onPreferenceChange(Preference preference, Object newValue)
+        {
+          boolean oldVal = isLoggingEnabled;
+          boolean newVal = (Boolean) newValue;
+          if (oldVal != newVal)
+          {
+            LoggerFactory.INSTANCE.setFileLoggingEnabled(newVal);
+          }
+          return true;
+        }
+      });
+    }
+
+    int curValue = Config.getUseMobileDataSettings();
+    final ListPreference mobilePref = (ListPreference)findPreference(
+        getString(R.string.pref_use_mobile_data));
+    if (curValue != NetworkPolicy.NOT_TODAY && curValue != NetworkPolicy.TODAY
+        && curValue != NetworkPolicy.NONE)
+    {
+      mobilePref.setValue(String.valueOf(curValue));
+      mobilePref.setSummary(mobilePref.getEntry());
+    }
+    else
+    {
+      mobilePref.setSummary(getString(R.string.mobile_data_description));
+    }
+    mobilePref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+    {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue)
+      {
+        String valueStr = (String)newValue;
+        switch (Integer.parseInt(valueStr))
+        {
+          case NetworkPolicy.ASK:
+            Config.setUseMobileDataSettings(NetworkPolicy.ASK);
+            break;
+          case NetworkPolicy.ALWAYS:
+            Config.setUseMobileDataSettings(NetworkPolicy.ALWAYS);
+            break;
+          case NetworkPolicy.NEVER:
+            Config.setUseMobileDataSettings(NetworkPolicy.NEVER);
+            break;
+          default:
+            throw new AssertionError("Wrong NetworkPolicy type!");
+        }
+
+        UiThread.runLater(new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            mobilePref.setSummary(mobilePref.getEntry());
+          }
+        });
+
+        return true;
+      }
+    });
+  }
+}

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1557,6 +1557,8 @@ public class PlacePageView extends RelativeLayout
           if (localAdInfo == null)
             throw new AssertionError("A local ad must be non-null if button is shown!");
 
+          Statistics.INSTANCE.trackPPOwnershipButtonClick(mMapObject);
+
           if (!TextUtils.isEmpty(localAdInfo.getUrl()))
           {
             Statistics.INSTANCE.trackPPOwnershipButtonClick(mMapObject);

--- a/editor/editor_tests/osm_feature_matcher_test.cpp
+++ b/editor/editor_tests/osm_feature_matcher_test.cpp
@@ -261,7 +261,6 @@ char const * const osmRawResponseRelation = R"SEP(
  </relation>
 </osm>
 )SEP";
-}  // namespace
 
 // Note: Geometry should not contain duplicates.
 
@@ -355,8 +354,6 @@ UNIT_TEST(GetBestOsmRealtion_Test)
   TEST_EQUAL(bestWay.attribute("id").value(), string("365808"), ());
 }
 
-namespace
-{
 char const * const osmResponseBuildingMiss = R"SEP(
 <osm version="0.6" generator="CGImap 0.4.0 (8662 thorn-01.openstreetmap.org)">
  <bounds minlat="51.5342700" minlon="-0.2047000" maxlat="51.5343200" maxlon="-0.2046300"/>
@@ -399,7 +396,6 @@ char const * const osmResponseBuildingMiss = R"SEP(
  </way>
 </osm>
 )SEP";
-}  // namespace
 
 UNIT_TEST(HouseBuildingMiss_test)
 {
@@ -415,3 +411,62 @@ UNIT_TEST(HouseBuildingMiss_test)
   auto const bestWay = osm::GetBestOsmWayOrRelation(osmResponse, geometry);
   TEST_EQUAL(bestWay.attribute("id").value(), string("345630019"), ());
 }
+
+string const kHouseWithSeveralEntrances = R"xxx("
+<osm version="0.6" generator="CGImap 0.6.0 (3589 thorn-03.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+  <node id="339283610" visible="true" version="6" changeset="33699414" timestamp="2015-08-31T09:53:02Z" user="Lazy Ranma" uid="914471" lat="55.8184397" lon="37.5700770"/>
+  <node id="339283612" visible="true" version="6" changeset="33699414" timestamp="2015-08-31T09:53:02Z" user="Lazy Ranma" uid="914471" lat="55.8184655" lon="37.5702599"/>
+  <node id="339283614" visible="true" version="6" changeset="33699414" timestamp="2015-08-31T09:53:02Z" user="Lazy Ranma" uid="914471" lat="55.8190524" lon="37.5698027"/>
+  <node id="339283615" visible="true" version="6" changeset="33699414" timestamp="2015-08-31T09:53:02Z" user="Lazy Ranma" uid="914471" lat="55.8190782" lon="37.5699856"/>
+  <node id="1131238558" visible="true" version="7" changeset="33699414" timestamp="2015-08-31T09:52:50Z" user="Lazy Ranma" uid="914471" lat="55.8188226" lon="37.5699055">
+    <tag k="entrance" v="yes"/>
+    <tag k="ref" v="2"/>
+  </node>
+  <node id="1131238581" visible="true" version="7" changeset="33699414" timestamp="2015-08-31T09:52:51Z" user="Lazy Ranma" uid="914471" lat="55.8185163" lon="37.5700427">
+    <tag k="entrance" v="yes"/>
+    <tag k="ref" v="4"/>
+  </node>
+  <node id="1131238623" visible="true" version="7" changeset="33699414" timestamp="2015-08-31T09:52:51Z" user="Lazy Ranma" uid="914471" lat="55.8189758" lon="37.5698370">
+    <tag k="entrance" v="yes"/>
+    <tag k="ref" v="1"/>
+  </node>
+  <node id="1131238704" visible="true" version="7" changeset="33699414" timestamp="2015-08-31T09:52:52Z" user="Lazy Ranma" uid="914471" lat="55.8186694" lon="37.5699741">
+    <tag k="entrance" v="yes"/>
+    <tag k="ref" v="3"/>
+  </node>
+  <way id="30680719" visible="true" version="10" changeset="25301783" timestamp="2014-09-08T07:52:43Z" user="Felis Pimeja" uid="260756">
+    <nd ref="339283614"/>
+    <nd ref="339283615"/>
+    <nd ref="339283612"/>
+    <nd ref="339283610"/>
+    <nd ref="1131238581"/>
+    <nd ref="1131238704"/>
+    <nd ref="1131238558"/>
+    <nd ref="1131238623"/>
+    <nd ref="339283614"/>
+    <tag k="addr:city" v="Москва"/>
+    <tag k="addr:country" v="RU"/>
+    <tag k="addr:housenumber" v="14 к1"/>
+    <tag k="addr:street" v="Ивановская улица"/>
+    <tag k="building" v="yes"/>
+  </way>
+</osm>
+)xxx";
+
+UNIT_TEST(HouseWithSeveralEntrances)
+{
+  pugi::xml_document osmResponse;
+  TEST(osmResponse.load_buffer(kHouseWithSeveralEntrances.c_str(),
+                               kHouseWithSeveralEntrances.size()), ());
+
+  vector<m2::PointD> const geometry = {
+    {37.569802534355233, 67.575570401367315},
+    {37.56998492456961, 67.57561599892091},
+    {37.570076119676798, 67.574481424499169},
+    {37.570258509891175, 67.574527022052763}
+  };
+
+  auto const bestWay = osm::GetBestOsmWayOrRelation(osmResponse, geometry);
+  TEST_EQUAL(bestWay.attribute("id").value(), string("30680719"), ());
+}
+}  // namespace

--- a/editor/osm_feature_matcher.cpp
+++ b/editor/osm_feature_matcher.cpp
@@ -89,11 +89,10 @@ vector<m2::PointD> GetWaysOrRelationsGeometry(pugi::xml_document const & osmResp
   return GetRelationsGeometry(osmResponse, wayOrRelation);
 }
 
-/// @returns value form [-0.5, 0.5]. Negative values are used as penalty,
-/// positive as score.
-/// @param osmResponse - nodes, ways and relations from osm
-/// @param wayOrRelation - either way or relation to be compared agains ourGeometry
-/// @param outGeometry - geometry of a FeatureType (ourGeometry must be sort-uniqued)
+/// @returns value form [-1, 1]. Negative values are used as penalty, positive as score.
+/// @param osmResponse - nodes, ways and relations from osm;
+/// @param wayOrRelation - either way or relation to be compared agains ourGeometry;
+/// @param outGeometry - geometry of a FeatureType (ourGeometry must be sort-uniqued);
 double ScoreGeometry(pugi::xml_document const & osmResponse,
                      pugi::xml_node const & wayOrRelation, vector<m2::PointD> ourGeometry)
 {
@@ -128,9 +127,12 @@ double ScoreGeometry(pugi::xml_document const & osmResponse,
     }
   }
 
-  auto const wayScore = static_cast<double>(matched) / theirGeometry.size() - 0.5;
-  auto const geomScore = static_cast<double>(matched) / ourGeometry.size() - 0.5;
-  auto const result = wayScore <= 0 || geomScore <= 0
+  auto const wayScore = static_cast<double>(matched) / theirGeometry.size();
+  auto const geomScore = static_cast<double>(matched) / ourGeometry.size();
+  // Our geometry is less detailed and we expect the pair to be found for more than half of points.
+  // OSM geometry is more detailed and we expect the pair to be found for at least a quarter of
+  // the points.
+  auto const result = wayScore < 0.25 || geomScore <= 0.5
       ? -1
       : 2 / (1 / wayScore + 1 / geomScore);
 


### PR DESCRIPTION
Не мержить пока Саша не протестит на сборке из этой ветки.
https://jira.mail.ru/browse/MAPSME-4322
У зданий из примера есть подъезды, они отмечены точками в геометрии. Получается, что количество точек здания = точки контура + точки подъездов + возможно еще какие-то точки. У нас в приложении геометрия упрощается и точки с подъездами из геометрии удаляются. В итоге на зданиях из примера у нас находились пары только для половины точек осма, потому что в осмовских фичах 8 точек (4 контур и 4 подъезды), а у нас всего 4. Для наших точек совпадение полное (4 из 4). При поиске пар такие объекты сразу отбрасывались из-за маленького количества соответствий с осмовскими точками.
Подкрутил настройки мэтчинга, ослабил правила. Теперь сразу отбрасываются объекты у которых менее 25 процентов совпадений с точками осмовского объекта или половина и менее совпадений с точками из нашей геометрии. 