### PR TITLE
[android] Added checking of empty price string to fix crash while tap…

### DIFF
--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -180,7 +180,9 @@ string Info::GetApproximatePricing() const
     return string();
 
   int pricing;
-  strings::to_int(GetMetadata().Get(feature::Metadata::FMD_PRICE_RATE), pricing);
+  if (!strings::to_int(GetMetadata().Get(feature::Metadata::FMD_PRICE_RATE), pricing))
+    return string();
+
   string result;
   for (auto i = 0; i < pricing; i++)
     result.append(kPricingSymbol);


### PR DESCRIPTION
… on opentable object on some devices (x86 Acer, arm Boost)

https://jira.mail.ru/browse/MAPSME-4426

Так как не было проверки на успешность конвертации строки в int, на некоторых андроид девайсах , пустая строка превращалась в очень большое число и мы зависали в цикле, так как это число используется как предел в цикле. Также, по-хорошему надо все места поправить, в котором используется этот метод без проверки результат.

@VladiMihaylenko @mpimenov @milchakov @goblinr  PTAL