### PR TITLE
Std migration generator

### DIFF
--- a/base/stl_add.hpp
+++ b/base/stl_add.hpp
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <functional>
+#include <initializer_list>
 #include <iterator>
 #include <memory>
 
 namespace my
 {
+typedef std::initializer_list<char const *> StringIL;
+
 /// @todo(y): replace this hand-written helper function by
 /// std::make_unique when it will be available in C++14
 template <typename T, typename... Args>

--- a/base/stl_add.hpp
+++ b/base/stl_add.hpp
@@ -8,7 +8,7 @@
 
 namespace my
 {
-typedef std::initializer_list<char const *> StringIL;
+using StringIL = std::initializer_list<char const *>;
 
 /// @todo(y): replace this hand-written helper function by
 /// std::make_unique when it will be available in C++14

--- a/coding/internal/xmlparser.hpp
+++ b/coding/internal/xmlparser.hpp
@@ -66,7 +66,7 @@ public:
     if (m_restrictDepth != size_t(-1))
       m_restrictDepth = static_cast<size_t>(-1);
     else
-      m_dispatcher.Pop(string(pszName));
+      m_dispatcher.Pop(std::string(pszName));
   }
 
   void OnCharacterData(XML_Char const * pszData, int nLength)
@@ -89,7 +89,7 @@ private:
   size_t m_restrictDepth;
   DispatcherT & m_dispatcher;
 
-  string m_charData;
+  std::string m_charData;
   bool m_enableCharHandler;
 
   void CheckCharData()

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -142,7 +142,7 @@ public:
   bool IsFeatureAltitudesSorted()
   {
     return std::is_sorted(m_featureAltitudes.begin(), m_featureAltitudes.end(),
-                     my::LessBy(&Processor::FeatureAltitude::m_featureId));
+                          my::LessBy(&Processor::FeatureAltitude::m_featureId));
   }
 
 private:

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -28,10 +28,10 @@
 
 #include "defines.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/type_traits.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "3party/succinct/elias_fano.hpp"
 #include "3party/succinct/mapper.hpp"
@@ -46,7 +46,7 @@ using namespace routing;
 class SrtmGetter : public AltitudeGetter
 {
 public:
-  SrtmGetter(string const & srtmDir) : m_srtmManager(srtmDir) {}
+  SrtmGetter(std::string const & srtmDir) : m_srtmManager(srtmDir) {}
 
   // AltitudeGetter overrides:
   feature::TAltitude GetAltitude(m2::PointD const & p) override
@@ -73,7 +73,7 @@ public:
     Altitudes m_altitudes;
   };
 
-  using TFeatureAltitudes = vector<FeatureAltitude>;
+  using TFeatureAltitudes = std::vector<FeatureAltitude>;
 
   Processor(AltitudeGetter & altitudeGetter)
     : m_altitudeGetter(altitudeGetter), m_minAltitude(kInvalidAltitude)
@@ -123,25 +123,25 @@ public:
       if (minFeatureAltitude == kInvalidAltitude)
         minFeatureAltitude = a;
       else
-        minFeatureAltitude = min(minFeatureAltitude, a);
+        minFeatureAltitude = std::min(minFeatureAltitude, a);
 
       altitudes.push_back(a);
     }
 
     hasAltitude = true;
-    m_featureAltitudes.emplace_back(id, Altitudes(move(altitudes)));
+    m_featureAltitudes.emplace_back(id, Altitudes(std::move(altitudes)));
 
     if (m_minAltitude == kInvalidAltitude)
       m_minAltitude = minFeatureAltitude;
     else
-      m_minAltitude = min(minFeatureAltitude, m_minAltitude);
+      m_minAltitude = std::min(minFeatureAltitude, m_minAltitude);
   }
 
   bool HasAltitudeInfo() const { return !m_featureAltitudes.empty(); }
 
   bool IsFeatureAltitudesSorted()
   {
-    return is_sorted(m_featureAltitudes.begin(), m_featureAltitudes.end(),
+    return std::is_sorted(m_featureAltitudes.begin(), m_featureAltitudes.end(),
                      my::LessBy(&Processor::FeatureAltitude::m_featureId));
   }
 
@@ -155,7 +155,7 @@ private:
 
 namespace routing
 {
-void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter)
+void BuildRoadAltitudes(std::string const & mwmPath, AltitudeGetter & altitudeGetter)
 {
   try
   {
@@ -187,11 +187,11 @@ void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter)
     }
     header.m_featureTableOffset = base::checked_cast<uint32_t>(w.Pos() - startOffset);
 
-    vector<uint32_t> offsets;
-    vector<uint8_t> deltas;
+    std::vector<uint32_t> offsets;
+    std::vector<uint8_t> deltas;
     {
       // Altitude info serialization to memory.
-      MemWriter<vector<uint8_t>> writer(deltas);
+      MemWriter<std::vector<uint8_t>> writer(deltas);
       Processor::TFeatureAltitudes const & featureAltitudes = processor.GetFeatureAltitudes();
       for (auto const & a : featureAltitudes)
       {
@@ -201,7 +201,7 @@ void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter)
     }
     {
       // Altitude offsets serialization.
-      CHECK(is_sorted(offsets.begin(), offsets.end()), ());
+      CHECK(std::is_sorted(offsets.begin(), offsets.end()), ());
       CHECK(adjacent_find(offsets.begin(), offsets.end()) == offsets.end(), ());
 
       succinct::elias_fano::elias_fano_builder builder(offsets.back(), offsets.size());
@@ -234,7 +234,7 @@ void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter)
   }
 }
 
-void BuildRoadAltitudes(string const & mwmPath, string const & srtmDir)
+void BuildRoadAltitudes(std::string const & mwmPath, std::string const & srtmDir)
 {
   LOG(LINFO, ("mwmPath =", mwmPath, "srtmDir =", srtmDir));
   SrtmGetter srtmGetter(srtmDir);

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -4,7 +4,7 @@
 
 #include "indexer/feature_altitude.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 namespace routing
 {
@@ -24,6 +24,6 @@ public:
 /// 16                  altitude availability feat. table offset - 16
 /// feat. table offset  feature table         alt. info offset - feat. table offset
 /// alt. info offset    altitude info         end of section - alt. info offset
-void BuildRoadAltitudes(string const & mwmPath, AltitudeGetter & altitudeGetter);
-void BuildRoadAltitudes(string const & mwmPath, string const & srtmDir);
+void BuildRoadAltitudes(std::string const & mwmPath, AltitudeGetter & altitudeGetter);
+void BuildRoadAltitudes(std::string const & mwmPath, std::string const & srtmDir);
 }  // namespace routing

--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -8,16 +8,16 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/iomanip.hpp"
+#include <iomanip>
 
 #include "boost/algorithm/string/replace.hpp"
 
 namespace generator
 {
 // BookingHotel ------------------------------------------------------------------------------------
-BookingHotel::BookingHotel(string const & src)
+BookingHotel::BookingHotel(std::string const & src)
 {
-  vector<string> rec;
+  vector<std::string> rec;
   strings::ParseCSVRow(src, '\t', rec);
   CHECK_EQUAL(rec.size(), FieldsCount(), ("Error parsing hotels.tsv line:",
                                           boost::replace_all_copy(src, "\t", "\\t")));
@@ -44,7 +44,7 @@ BookingHotel::BookingHotel(string const & src)
 
 ostream & operator<<(ostream & s, BookingHotel const & h)
 {
-  s << fixed << setprecision(7);
+  s << std::fixed << std::setprecision(7);
   s << "Id: " << h.m_id << "\t Name: " << h.m_name << "\t Address: " << h.m_address
     << "\t lat: " << h.m_latLon.lat << " lon: " << h.m_latLon.lon;
   return s;
@@ -117,7 +117,7 @@ void BookingDataset::BuildObject(Object const & hotel,
   if (!hotel.m_translations.empty())
   {
     // TODO(mgsergio): Move parsing to the hotel costruction stage.
-    vector<string> parts;
+    vector<std::string> parts;
     strings::ParseCSVRow(hotel.m_translations, '|', parts);
     CHECK_EQUAL(parts.size() % 3, 0, ("Invalid translation string:", hotel.m_translations));
     for (size_t i = 0; i < parts.size(); i += 3)

--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -17,7 +17,7 @@ namespace generator
 // BookingHotel ------------------------------------------------------------------------------------
 BookingHotel::BookingHotel(std::string const & src)
 {
-  vector<std::string> rec;
+  std::vector<std::string> rec;
   strings::ParseCSVRow(src, '\t', rec);
   CHECK_EQUAL(rec.size(), FieldsCount(), ("Error parsing hotels.tsv line:",
                                           boost::replace_all_copy(src, "\t", "\\t")));
@@ -62,7 +62,7 @@ bool BookingDataset::NecessaryMatchingConditionHolds(FeatureBuilder1 const & fb)
 
 template <>
 void BookingDataset::PreprocessMatchedOsmObject(ObjectId, FeatureBuilder1 & fb,
-                                                function<void(FeatureBuilder1 &)> const fn) const
+                                                std::function<void(FeatureBuilder1 &)> const fn) const
 {
   // Turn a hotel into a simple building.
   if (fb.GetGeomType() == feature::GEOM_AREA)
@@ -89,7 +89,7 @@ void BookingDataset::PreprocessMatchedOsmObject(ObjectId, FeatureBuilder1 & fb,
 
 template <>
 void BookingDataset::BuildObject(Object const & hotel,
-                                 function<void(FeatureBuilder1 &)> const & fn) const
+                                 std::function<void(FeatureBuilder1 &)> const & fn) const
 {
   FeatureBuilder1 fb;
   FeatureParams params;
@@ -117,7 +117,7 @@ void BookingDataset::BuildObject(Object const & hotel,
   if (!hotel.m_translations.empty())
   {
     // TODO(mgsergio): Move parsing to the hotel costruction stage.
-    vector<std::string> parts;
+    std::vector<std::string> parts;
     strings::ParseCSVRow(hotel.m_translations, '|', parts);
     CHECK_EQUAL(parts.size() % 3, 0, ("Invalid translation string:", hotel.m_translations));
     for (size_t i = 0; i < parts.size(); i += 3)

--- a/generator/booking_dataset.hpp
+++ b/generator/booking_dataset.hpp
@@ -6,8 +6,8 @@
 
 #include "base/newtype.hpp"
 
-#include "std/limits.hpp"
-#include "std/string.hpp"
+#include <limits>
+#include <string>
 
 namespace generator
 {
@@ -35,10 +35,10 @@ struct BookingHotel
 
   static constexpr ObjectId InvalidObjectId()
   {
-    return ObjectId(numeric_limits<typename ObjectId::RepType>::max());
+    return ObjectId(std::numeric_limits<typename ObjectId::RepType>::max());
   }
 
-  explicit BookingHotel(string const & src);
+  explicit BookingHotel(std::string const & src);
 
   static constexpr size_t FieldIndex(Fields field) { return static_cast<size_t>(field); }
   static constexpr size_t FieldsCount() { return static_cast<size_t>(Fields::Counter); }
@@ -47,18 +47,18 @@ struct BookingHotel
 
   ObjectId m_id{InvalidObjectId()};
   ms::LatLon m_latLon = ms::LatLon::Zero();
-  string m_name;
-  string m_street;
-  string m_houseNumber;
+  std::string m_name;
+  std::string m_street;
+  std::string m_houseNumber;
 
-  string m_address;
+  std::string m_address;
   uint32_t m_stars = 0;
   uint32_t m_priceCategory = 0;
   double m_ratingBooking = 0.0;
   double m_ratingUser = 0.0;
-  string m_descUrl;
+  std::string m_descUrl;
   uint32_t m_type = 0;
-  string m_translations;
+  std::string m_translations;
 };
 
 ostream & operator<<(ostream & s, BookingHotel const & h);

--- a/generator/booking_quality_check/booking_addr_match.cpp
+++ b/generator/booking_quality_check/booking_addr_match.cpp
@@ -92,12 +92,12 @@ int main(int argc, char * argv[])
       ++matchedNum;
       std::cout << "[" << i << "/" << bookingDataset.Size() << "] Hotel: " << hotel.address
            << " AddLoc: " << hotel.translations << " --> " << hotel.street << " "
-           << hotel.houseNumber << endl;
+           << hotel.houseNumber << std::endl;
     }
   }
 
   std::cout << "Num of hotels: " << bookingDataset.Size() << " matched: " << matchedNum
-       << " Empty addresses: " << emptyAddr << endl;
+       << " Empty addresses: " << emptyAddr << std::endl;
 
   return 0;
 }

--- a/generator/booking_quality_check/booking_addr_match.cpp
+++ b/generator/booking_quality_check/booking_addr_match.cpp
@@ -28,10 +28,10 @@
 #include "platform/local_country_file_utils.hpp"
 #include "platform/platform.hpp"
 
-#include "std/fstream.hpp"
-#include "std/iostream.hpp"
-#include "std/numeric.hpp"
-#include "std/shared_ptr.hpp"
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
 
 #include "3party/gflags/src/gflags/gflags.h"
 
@@ -55,7 +55,7 @@ int main(int argc, char * argv[])
 
   Platform & platform = GetPlatform();
 
-  string countriesFile = COUNTRIES_FILE;
+  std::string countriesFile = COUNTRIES_FILE;
   if (!FLAGS_user_resource_path.empty())
   {
     platform.SetResourceDir(FLAGS_user_resource_path);
@@ -90,13 +90,13 @@ int main(int argc, char * argv[])
     if (hotel.HasAddresParts())
     {
       ++matchedNum;
-      cout << "[" << i << "/" << bookingDataset.Size() << "] Hotel: " << hotel.address
+      std::cout << "[" << i << "/" << bookingDataset.Size() << "] Hotel: " << hotel.address
            << " AddLoc: " << hotel.translations << " --> " << hotel.street << " "
            << hotel.houseNumber << endl;
     }
   }
 
-  cout << "Num of hotels: " << bookingDataset.Size() << " matched: " << matchedNum
+  std::cout << "Num of hotels: " << bookingDataset.Size() << " matched: " << matchedNum
        << " Empty addresses: " << emptyAddr << endl;
 
   return 0;

--- a/generator/booking_quality_check/booking_quality_check.cpp
+++ b/generator/booking_quality_check/booking_quality_check.cpp
@@ -10,21 +10,24 @@
 
 #include "coding/file_name_utils.hpp"
 
+#include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/cstdlib.hpp"
-#include "std/cstring.hpp"
-#include "std/fstream.hpp"
-#include "std/iostream.hpp"
-#include "std/numeric.hpp"
-#include "std/random.hpp"
-#include "std/unique_ptr.hpp"
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <random>
 
 #include "3party/gflags/src/gflags/gflags.h"
 
 #include "boost/range/adaptor/map.hpp"
 #include "boost/range/algorithm/copy.hpp"
 
+
+using namespace std;
 
 DEFINE_string(osm, "", "Input .o5m file");
 DEFINE_string(booking, "", "Path to booking data in .tsv format");
@@ -358,7 +361,7 @@ void RunImpl(feature::GenerateInfo & info)
   map<osm::Id, FeatureBuilder1> features;
   GenerateFeatures(info, [&dataset, &features](feature::GenerateInfo const & /* info */)
   {
-    return make_unique<Emitter<Dataset>>(dataset, features);
+    return my::make_unique<Emitter<Dataset>>(dataset, features);
   });
 
   if (FLAGS_generate)

--- a/generator/borders_generator.cpp
+++ b/generator/borders_generator.cpp
@@ -4,6 +4,7 @@
 
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/generator/borders_generator.cpp
+++ b/generator/borders_generator.cpp
@@ -4,25 +4,25 @@
 
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
-#include "std/fstream.hpp"
-#include "std/iostream.hpp"
-#include "std/sstream.hpp"
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
 namespace osm
 {
-  bool ReadPolygon(istream & stream, m2::RegionD & region, string const & filename)
+  bool ReadPolygon(std::istream & stream, m2::RegionD & region, std::string const & filename)
   {
-    string line, name;
+    std::string line, name;
     double lon, lat;
 
     // read ring id, fail if it's empty
-    getline(stream, name);
+    std::getline(stream, name);
     if (name.empty() || name == "END")
       return false;
 
     while (stream.good())
     {
-      getline(stream, line);
+      std::getline(stream, line);
       strings::Trim(line);
 
       if (line.empty())
@@ -31,7 +31,7 @@ namespace osm
       if (line == "END")
         break;
 
-      istringstream iss(line);
+      std::istringstream iss(line);
       iss >> lon >> lat;
       CHECK(!iss.fail(), ("Incorrect data in", filename));
 
@@ -42,11 +42,11 @@ namespace osm
     return name[0] != '!';
   }
 
-  bool LoadBorders(string const & borderFile, vector<m2::RegionD> & outBorders)
+  bool LoadBorders(std::string const & borderFile, std::vector<m2::RegionD> & outBorders)
   {
-    ifstream stream(borderFile);
-    string line;
-    if (!getline(stream, line).good()) // skip title
+    std::ifstream stream(borderFile);
+    std::string line;
+    if (!std::getline(stream, line).good()) // skip title
     {
       LOG(LERROR, ("Polygon file is empty:", borderFile));
       return false;

--- a/generator/borders_generator.hpp
+++ b/generator/borders_generator.hpp
@@ -3,11 +3,11 @@
 #include "geometry/region2d.hpp"
 #include "geometry/point2d.hpp"
 
-#include "std/vector.hpp"
-#include "std/string.hpp"
+#include <string>
+#include <vector>
 
 namespace osm
 {
   /// @return false if borderFile can't be opened
-  bool LoadBorders(string const & borderFile, vector<m2::RegionD> & outBorders);
+  bool LoadBorders(std::string const & borderFile, std::vector<m2::RegionD> & outBorders);
 }

--- a/generator/borders_loader.hpp
+++ b/generator/borders_loader.hpp
@@ -3,7 +3,7 @@
 #include "geometry/region2d.hpp"
 #include "geometry/tree4d.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 #define BORDERS_DIR "borders/"
 #define BORDERS_EXTENSION ".poly"
@@ -15,7 +15,7 @@ namespace borders
 
   struct CountryPolygons
   {
-    CountryPolygons(string const & name = "") : m_name(name), m_index(-1) {}
+    CountryPolygons(std::string const & name = "") : m_name(name), m_index(-1) {}
 
     bool IsEmpty() const { return m_regions.IsEmpty(); }
     void Clear()
@@ -26,14 +26,14 @@ namespace borders
     }
 
     RegionsContainerT m_regions;
-    string m_name;
+    std::string m_name;
     mutable int m_index;
   };
 
   typedef m4::Tree<CountryPolygons> CountriesContainerT;
 
-  bool LoadCountriesList(string const & baseDir, CountriesContainerT & countries);
+  bool LoadCountriesList(std::string const & baseDir, CountriesContainerT & countries);
 
-  void GeneratePackedBorders(string const & baseDir);
-  void UnpackBorders(string const & baseDir, string const & targetDir);
+  void GeneratePackedBorders(std::string const & baseDir);
+  void UnpackBorders(std::string const & baseDir, std::string const & targetDir);
 }

--- a/generator/centers_table_builder.cpp
+++ b/generator/centers_table_builder.cpp
@@ -17,7 +17,7 @@
 
 namespace indexer
 {
-bool BuildCentersTableFromDataFile(string const & filename, bool forceRebuild)
+bool BuildCentersTableFromDataFile(std::string const & filename, bool forceRebuild)
 {
   try
   {

--- a/generator/centers_table_builder.hpp
+++ b/generator/centers_table_builder.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 class FilesContainerR;
 class Writer;
@@ -9,5 +9,5 @@ namespace indexer
 {
 // Builds the latest version of the centers table section and writes
 // it to the mwm file.
-bool BuildCentersTableFromDataFile(string const & filename, bool forceRebuild = false);
+bool BuildCentersTableFromDataFile(std::string const & filename, bool forceRebuild = false);
 }  // namespace indexer

--- a/generator/check_model.cpp
+++ b/generator/check_model.cpp
@@ -13,7 +13,7 @@ using namespace feature;
 
 namespace check_model
 {
-  void ReadFeatures(string const & fName)
+  void ReadFeatures(std::string const & fName)
   {
     Classificator const & c = classif();
 

--- a/generator/check_model.hpp
+++ b/generator/check_model.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include "std/string.hpp"
+#include <string>
 
 namespace check_model
 {
-  void ReadFeatures(string const & fName);
+  void ReadFeatures(std::string const & fName);
 }

--- a/generator/coastlines_generator.cpp
+++ b/generator/coastlines_generator.cpp
@@ -8,11 +8,12 @@
 #include "base/string_utils.hpp"
 #include "base/logging.hpp"
 
-#include "std/bind.hpp"
-#include "std/condition_variable.hpp"
-#include "std/function.hpp"
-#include "std/thread.hpp"
-#include "std/utility.hpp"
+#include <condition_variable>
+#include <functional>
+#include <thread>
+#include <utility>
+
+using namespace std;
 
 typedef m2::RegionI RegionT;
 typedef m2::PointI PointT;
@@ -272,7 +273,7 @@ public:
     // Do 'and' with all regions and accumulate the result, including bound region.
     // In 'odd' parts we will have an ocean.
     DoDifference doDiff(rectR);
-    m_index.ForEachInRect(GetLimitRect(rectR), bind<void>(ref(doDiff), _1));
+    m_index.ForEachInRect(GetLimitRect(rectR), bind<void>(ref(doDiff), placeholders::_1));
 
     // Check if too many points for feature.
     if (cell.Level() < kHighLevel && doDiff.GetPointsCount() >= kMaxPoints)

--- a/generator/dumper.cpp
+++ b/generator/dumper.cpp
@@ -13,12 +13,13 @@
 
 #include "base/logging.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/bind.hpp"
-#include "std/functional.hpp"
-#include "std/iostream.hpp"
-#include "std/map.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <vector>
+
+using namespace std;
 
 namespace
 {

--- a/generator/dumper.hpp
+++ b/generator/dumper.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace feature
 {
-  void DumpTypes(string const & fPath);
-  void DumpPrefixes(string const & fPath);
+  void DumpTypes(std::string const & fPath);
+  void DumpPrefixes(std::string const & fPath);
 
   // Writes top maxTokensToShow tokens sorted by their
   // frequency, i.e. by the number of features in
   // an mwm that contain the token in their name.
-  void DumpSearchTokens(string const & fPath, size_t maxTokensToShow);
+  void DumpSearchTokens(std::string const & fPath, size_t maxTokensToShow);
 
   // Writes the names of all features in the locale provided by lang
   // (e.g. "en", "ru", "sv"). If the locale is not recognized, writes all names
   // preceded by their locales.
-  void DumpFeatureNames(string const & fPath, string const & lang);
+  void DumpFeatureNames(std::string const & fPath, std::string const & lang);
 }

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -19,8 +19,8 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/cstring.hpp"
-#include "std/algorithm.hpp"
+#include <algorithm>
+#include <cstring>
 
 using namespace feature;
 
@@ -79,14 +79,14 @@ void FeatureBuilder1::SetRank(uint8_t rank)
   m_params.rank = rank;
 }
 
-void FeatureBuilder1::AddHouseNumber(string const & houseNumber)
+void FeatureBuilder1::AddHouseNumber(std::string const & houseNumber)
 {
   m_params.AddHouseNumber(houseNumber);
 }
 
-void FeatureBuilder1::AddStreet(string const & streetName) { m_params.AddStreet(streetName); }
+void FeatureBuilder1::AddStreet(std::string const & streetName) { m_params.AddStreet(streetName); }
 
-void FeatureBuilder1::AddPostcode(string const & postcode)
+void FeatureBuilder1::AddPostcode(std::string const & postcode)
 {
   m_params.GetMetadata().Set(Metadata::FMD_POSTCODE, postcode);
 }
@@ -106,7 +106,7 @@ void FeatureBuilder1::SetLinear(bool reverseGeometry)
   {
     auto & cont = m_polygons.front();
     ASSERT(!cont.empty(), ());
-    reverse(cont.begin(), cont.end());
+    std::reverse(cont.begin(), cont.end());
   }
 }
 
@@ -169,7 +169,7 @@ bool FeatureBuilder1::RemoveInvalidTypes()
                                         m_params.IsEmptyNames());
 }
 
-bool FeatureBuilder1::FormatFullAddress(string & res) const
+bool FeatureBuilder1::FormatFullAddress(std::string & res) const
 {
   return m_params.FormatFullAddress(m_limitRect.Center(), res);
 }
@@ -491,7 +491,7 @@ bool FeatureBuilder1::HasOsmId(osm::Id const & id) const
   return false;
 }
 
-string FeatureBuilder1::GetOsmIdsString() const
+std::string FeatureBuilder1::GetOsmIdsString() const
 {
   if (m_osmIds.empty())
     return "(NOT AN OSM FEATURE)";
@@ -510,14 +510,14 @@ int FeatureBuilder1::GetMinFeatureDrawScale() const
   return (minScale == -1 ? 1000 : minScale);
 }
 
-bool FeatureBuilder1::AddName(string const & lang, string const & name)
+bool FeatureBuilder1::AddName(std::string const & lang, std::string const & name)
 {
   return m_params.AddName(lang, name);
 }
 
-string FeatureBuilder1::GetName(int8_t lang) const
+std::string FeatureBuilder1::GetName(int8_t lang) const
 {
-  string s;
+  std::string s;
   VERIFY(m_params.name.GetString(lang, s) != s.empty(), ());
   return s;
 }
@@ -530,7 +530,7 @@ size_t FeatureBuilder1::GetPointsCount() const
   return counter;
 }
 
-string DebugPrint(FeatureBuilder1 const & f)
+std::string DebugPrint(FeatureBuilder1 const & f)
 {
   ostringstream out;
 
@@ -569,7 +569,7 @@ uint64_t FeatureBuilder1::GetWayIDForRouting() const
   return 0;
 }
 
-string DebugPrint(FeatureBuilder2 const & f)
+std::string DebugPrint(FeatureBuilder2 const & f)
 {
   return DebugPrint(static_cast<FeatureBuilder1 const &>(f));
 }
@@ -654,7 +654,7 @@ void FeatureBuilder2::Serialize(SupportingData & data, serial::CodingParams cons
       serial::SavePoint(sink, GetOuterGeometry()[0], params);
 
       // offsets was pushed from high scale index to low
-      reverse(data.m_ptsOffset.begin(), data.m_ptsOffset.end());
+      std::reverse(data.m_ptsOffset.begin(), data.m_ptsOffset.end());
       serial::WriteVarUintArray(data.m_ptsOffset, sink);
     }
   }
@@ -665,7 +665,7 @@ void FeatureBuilder2::Serialize(SupportingData & data, serial::CodingParams cons
     else
     {
       // offsets was pushed from high scale index to low
-      reverse(data.m_trgOffset.begin(), data.m_trgOffset.end());
+      std::reverse(data.m_trgOffset.begin(), data.m_trgOffset.end());
       serial::WriteVarUintArray(data.m_trgOffset, sink);
     }
   }

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -7,8 +7,8 @@
 #include "coding/file_reader.hpp"
 #include "coding/read_write_utils.hpp"
 
-#include "std/bind.hpp"
-#include "std/list.hpp"
+#include <functional>
+#include <list>
 
 
 namespace serial { class CodingParams; }
@@ -17,11 +17,11 @@ namespace serial { class CodingParams; }
 class FeatureBuilder1
 {
   /// For debugging
-  friend string DebugPrint(FeatureBuilder1 const & f);
+  friend std::string DebugPrint(FeatureBuilder1 const & f);
 
 public:
   using TPointSeq = vector<m2::PointD>;
-  using TGeometry = list<TPointSeq>;
+  using TGeometry = std::list<TPointSeq>;
 
   using TBuffer = vector<char>;
 
@@ -34,11 +34,11 @@ public:
 
   void SetRank(uint8_t rank);
 
-  void AddHouseNumber(string const & houseNumber);
+  void AddHouseNumber(std::string const & houseNumber);
 
-  void AddStreet(string const & streetName);
+  void AddStreet(std::string const & streetName);
 
-  void AddPostcode(string const & postcode);
+  void AddPostcode(std::string const & postcode);
 
   /// Add point to geometry.
   void AddPoint(m2::PointD const & p);
@@ -100,7 +100,7 @@ public:
   //@{
   inline m2::RectD GetLimitRect() const { return m_limitRect; }
 
-  bool FormatFullAddress(string & res) const;
+  bool FormatFullAddress(std::string & res) const;
 
   /// Get common parameters of feature.
   FeatureBase GetFeatureBase() const;
@@ -171,7 +171,7 @@ public:
   /// area's one if there is no relation, and relation id otherwise.
   osm::Id GetMostGenericOsmId() const;
   bool HasOsmId(osm::Id const & id) const;
-  string GetOsmIdsString() const;
+  std::string GetOsmIdsString() const;
   vector<osm::Id> const & GetOsmIds() const { return m_osmIds; }
   //@}
 
@@ -183,8 +183,8 @@ public:
   void SetCoastCell(int64_t iCell) { m_coastCell = iCell; }
   inline bool IsCoastCell() const { return (m_coastCell != -1); }
 
-  bool AddName(string const & lang, string const & name);
-  string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
+  bool AddName(std::string const & lang, std::string const & name);
+  std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
 
   uint8_t GetRank() const { return m_params.rank; }
 
@@ -227,7 +227,7 @@ class FeatureBuilder2 : public FeatureBuilder1
   static void SerializeOffsets(uint32_t mask, TOffsets const & offsets, TBuffer & buffer);
 
   /// For debugging
-  friend string DebugPrint(FeatureBuilder2 const & f);
+  friend std::string DebugPrint(FeatureBuilder2 const & f);
 
 public:
   struct SupportingData
@@ -274,7 +274,7 @@ namespace feature
 
   /// Process features in .dat file.
   template <class ToDo>
-  void ForEachFromDatRawFormat(string const & fName, ToDo && toDo)
+  void ForEachFromDatRawFormat(std::string const & fName, ToDo && toDo)
   {
     FileReader reader(fName);
     ReaderSource<FileReader> src(reader);

--- a/generator/feature_generator.cpp
+++ b/generator/feature_generator.cpp
@@ -14,9 +14,9 @@
 #include "base/logging.hpp"
 #include "base/stl_add.hpp"
 
-#include "std/bind.hpp"
+#include <functional>
 #include "std/target_os.hpp"
-#include "std/unordered_map.hpp"
+#include <unordered_map>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // FeaturesCollector implementation
@@ -24,7 +24,7 @@
 namespace feature
 {
 
-FeaturesCollector::FeaturesCollector(string const & fName)
+FeaturesCollector::FeaturesCollector(std::string const & fName)
   : m_datFile(fName)
 {
   CHECK_EQUAL(GetFileSize(m_datFile), 0, ());
@@ -90,7 +90,7 @@ void FeaturesCollector::Write(char const * src, size_t size)
   } while (size > 0);
 }
 
-uint32_t FeaturesCollector::WriteFeatureBase(vector<char> const & bytes, FeatureBuilder1 const & fb)
+uint32_t FeaturesCollector::WriteFeatureBase(std::vector<char> const & bytes, FeatureBuilder1 const & fb)
 {
   size_t const sz = bytes.size();
   CHECK(sz != 0, ("Empty feature not allowed here!"));
@@ -112,8 +112,8 @@ uint32_t FeaturesCollector::operator()(FeatureBuilder1 const & fb)
   return featureId;
 }
 
-FeaturesAndRawGeometryCollector::FeaturesAndRawGeometryCollector(string const & featuresFileName,
-                                                                 string const & rawGeometryFileName)
+FeaturesAndRawGeometryCollector::FeaturesAndRawGeometryCollector(std::string const & featuresFileName,
+                                                                 std::string const & rawGeometryFileName)
   : FeaturesCollector(featuresFileName), m_rawGeometryFileStream(rawGeometryFileName)
 {
   CHECK_EQUAL(GetFileSize(m_rawGeometryFileStream), 0, ());

--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -4,9 +4,9 @@
 
 #include "coding/file_writer.hpp"
 
-#include "std/limits.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <limits>
+#include <string>
+#include <vector>
 
 class FeatureBuilder1;
 
@@ -20,7 +20,7 @@ class FeaturesCollector
   uint32_t m_featureID = 0;
 
 protected:
-  static uint32_t constexpr kInvalidFeatureId = numeric_limits<uint32_t>::max();
+  static uint32_t constexpr kInvalidFeatureId = std::numeric_limits<uint32_t>::max();
 
   FileWriter m_datFile;
   m2::RectD m_bounds;
@@ -33,15 +33,15 @@ protected:
   static uint32_t GetFileSize(FileWriter const & f);
 
   /// @return feature offset in the file, which is used as an ID later
-  uint32_t WriteFeatureBase(vector<char> const & bytes, FeatureBuilder1 const & fb);
+  uint32_t WriteFeatureBase(std::vector<char> const & bytes, FeatureBuilder1 const & fb);
 
   void Flush();
 
 public:
-  FeaturesCollector(string const & fName);
+  FeaturesCollector(std::string const & fName);
   virtual ~FeaturesCollector();
 
-  string const & GetFilePath() const { return m_datFile.GetName(); }
+  std::string const & GetFilePath() const { return m_datFile.GetName(); }
   /// \brief Serializes |f|.
   /// \returns feature id of serialized feature if |f| is serialized after the call
   /// and |kInvalidFeatureId| if not.
@@ -56,8 +56,8 @@ class FeaturesAndRawGeometryCollector : public FeaturesCollector
   size_t m_rawGeometryCounter = 0;
 
 public:
-  FeaturesAndRawGeometryCollector(string const & featuresFileName,
-                                  string const & rawGeometryFileName);
+  FeaturesAndRawGeometryCollector(std::string const & featuresFileName,
+                                  std::string const & rawGeometryFileName);
   ~FeaturesAndRawGeometryCollector();
 
   uint32_t operator()(FeatureBuilder1 const & f) override;

--- a/generator/feature_merger.cpp
+++ b/generator/feature_merger.cpp
@@ -143,7 +143,7 @@ void FeatureMergeProcessor::operator() (MergedFeatureBuilder1 * p)
     ///@ todo Do it only for small round features!
     p->SetRound();
 
-    p->ForEachMiddlePoints(bind(&FeatureMergeProcessor::Insert, this, _1, p));
+    p->ForEachMiddlePoints(std::bind(&FeatureMergeProcessor::Insert, this, std::placeholders::_1, p));
   }
 }
 
@@ -175,7 +175,7 @@ void FeatureMergeProcessor::Remove(MergedFeatureBuilder1 const * p)
   {
     ASSERT ( p->IsRound(), () );
 
-    p->ForEachMiddlePoints(bind(&FeatureMergeProcessor::Remove1, this, _1, p));
+    p->ForEachMiddlePoints(std::bind(&FeatureMergeProcessor::Remove1, this, std::placeholders::_1, p));
   }
 }
 
@@ -275,7 +275,7 @@ void FeatureMergeProcessor::DoMerge(FeatureEmitterIFace & emitter)
 
 uint32_t FeatureTypesProcessor::GetType(char const * arr[], size_t n)
 {
-  uint32_t const type = classif().GetTypeByPath(vector<string>(arr, arr + n));
+  uint32_t const type = classif().GetTypeByPath(std::vector<std::string>(arr, arr + n));
   CHECK_NOT_EQUAL(type, ftype::GetEmptyValue(), ());
   return type;
 }

--- a/generator/feature_merger.hpp
+++ b/generator/feature_merger.hpp
@@ -2,10 +2,9 @@
 #include "generator/feature_emitter_iface.hpp"
 #include "generator/feature_builder.hpp"
 
-#include "std/map.hpp"
-#include "std/set.hpp"
-#include "std/vector.hpp"
-
+#include <map>
+#include <set>
+#include <vector>
 
 /// Feature builder class that used while feature type processing and merging.
 class MergedFeatureBuilder1 : public FeatureBuilder1
@@ -61,8 +60,8 @@ class FeatureMergeProcessor
 
   MergedFeatureBuilder1 m_last;
 
-  typedef vector<MergedFeatureBuilder1 *> vector_t;
-  typedef map<key_t, vector_t> map_t;
+  typedef std::vector<MergedFeatureBuilder1 *> vector_t;
+  typedef std::map<key_t, vector_t> map_t;
   map_t m_map;
 
   void Insert(m2::PointD const & pt, MergedFeatureBuilder1 * p);
@@ -89,8 +88,8 @@ public:
 /// Feature types corrector.
 class FeatureTypesProcessor
 {
-  set<uint32_t> m_dontNormalize;
-  map<uint32_t, uint32_t> m_mapping;
+  std::set<uint32_t> m_dontNormalize;
+  std::map<uint32_t, uint32_t> m_mapping;
 
   static uint32_t GetType(char const * arr[], size_t n);
 

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -19,15 +19,17 @@
 #include "base/logging.hpp"
 #include "base/math.hpp"
 
-#include "std/cmath.hpp"
-#include "std/fstream.hpp"
-#include "std/iostream.hpp"
-#include "std/map.hpp"
-#include "std/numeric.hpp"
-#include "std/set.hpp"
-#include "std/string.hpp"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <set>
+#include <string>
 
 #include "3party/gflags/src/gflags/gflags.h"
+
+using namespace std;
 
 DEFINE_string(srtm_dir_path, "", "Path to directory with SRTM files");
 DEFINE_string(mwm_file_path, "", "Path to an mwm file.");

--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -95,7 +95,7 @@ namespace feature
     class TmpFile : public FileWriter
     {
     public:
-      explicit TmpFile(string const & filePath) : FileWriter(filePath) {}
+      explicit TmpFile(std::string const & filePath) : FileWriter(filePath) {}
       ~TmpFile()
       {
         DeleteFileX(GetName());
@@ -118,14 +118,14 @@ namespace feature
     gen::OsmID2FeatureID m_osm2ft;
 
   public:
-    FeaturesCollector2(string const & fName, DataHeader const & header,
+    FeaturesCollector2(std::string const & fName, DataHeader const & header,
                        RegionData const & regionData, uint32_t versionDate)
       : FeaturesCollector(fName + DATA_FILE_TAG), m_writer(fName),
         m_header(header), m_regionData(regionData), m_versionDate(versionDate)
     {
       for (size_t i = 0; i < m_header.GetScalesCount(); ++i)
       {
-        string const postfix = strings::to_string(i);
+        std::string const postfix = strings::to_string(i);
         m_geoFile.push_back(make_unique<TmpFile>(fName + GEOMETRY_FILE_TAG + postfix));
         m_trgFile.push_back(make_unique<TmpFile>(fName + TRIANGLE_FILE_TAG + postfix));
       }
@@ -162,8 +162,8 @@ namespace feature
       m_writer.Write(m_datFile.GetName(), DATA_FILE_TAG);
 
       // File Writer finalization function with appending to the main mwm file.
-      auto const finalizeFn = [this](unique_ptr<TmpFile> w, string const & tag,
-                                     string const & postfix = string())
+      auto const finalizeFn = [this](unique_ptr<TmpFile> w, std::string const & tag,
+                                     std::string const & postfix = std::string())
       {
         w->Flush();
         m_writer.Write(w->GetName(), tag + postfix);
@@ -171,7 +171,7 @@ namespace feature
 
       for (size_t i = 0; i < m_header.GetScalesCount(); ++i)
       {
-        string const postfix = strings::to_string(i);
+        std::string const postfix = strings::to_string(i);
         finalizeFn(move(m_geoFile[i]), GEOMETRY_FILE_TAG, postfix);
         finalizeFn(move(m_trgFile[i]), TRIANGLE_FILE_TAG, postfix);
       }
@@ -250,7 +250,7 @@ namespace feature
         tesselator::PointsInfo points;
         m2::PointU (* D2U)(m2::PointD const &, uint32_t) = &PointD2PointU;
         info.GetPointsInfo(saver.GetBasePoint(), saver.GetMaxPoint(),
-                           bind(D2U, _1, cp.GetCoordBits()), points);
+                           std::bind(D2U, std::placeholders::_1, cp.GetCoordBits()), points);
 
         // triangles processing (should be optimal)
         info.ProcessPortions(points, saver, true);
@@ -556,10 +556,10 @@ namespace feature
     return static_cast<FeatureBuilder2 &>(fb);
   }
 
-  bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & name, int mapType)
+  bool GenerateFinalFeatures(feature::GenerateInfo const & info, std::string const & name, int mapType)
   {
-    string const srcFilePath = info.GetTmpFileName(name);
-    string const datFilePath = info.GetTargetFileName(name);
+    std::string const srcFilePath = info.GetTmpFileName(name);
+    std::string const datFilePath = info.GetTargetFileName(name);
 
     // stores cellIds for middle points
     CalculateMidPoints midPoints;

--- a/generator/feature_sorter.hpp
+++ b/generator/feature_sorter.hpp
@@ -7,7 +7,7 @@
 
 #include "indexer/scales.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 
 namespace feature
@@ -15,7 +15,7 @@ namespace feature
   /// Final generation of data from input feature-dat-file.
   /// @param path - path to folder with countries;
   /// @param name - name of generated country;
-  bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & name, int mapType);
+  bool GenerateFinalFeatures(feature::GenerateInfo const & info, std::string const & name, int mapType);
 
   template <class PointT>
   inline bool are_points_equal(PointT const & p1, PointT const & p2)
@@ -50,7 +50,7 @@ namespace feature
           fabs(p.y - m_rect.minY()) <= m_eps || fabs(p.y - m_rect.maxY()) <= m_eps)
       {
         // points near rect should be in a result simplified vector
-        return numeric_limits<double>::max();
+        return std::numeric_limits<double>::max();
       }
 
       return m2::DistanceToLineSquare<m2::PointD>::operator()(p);

--- a/generator/gen_mwm_info.hpp
+++ b/generator/gen_mwm_info.hpp
@@ -6,16 +6,16 @@
 
 #include "base/assert.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <utility>
+#include <vector>
 
 namespace gen
 {
 template <class T> class Accumulator
 {
 protected:
-  vector<T> m_data;
+  std::vector<T> m_data;
 
 public:
   typedef T ValueT;
@@ -33,7 +33,7 @@ public:
   }
 };
 
-class OsmID2FeatureID : public Accumulator<pair<osm::Id, uint32_t /* feature id */>>
+class OsmID2FeatureID : public Accumulator<std::pair<osm::Id, uint32_t /* feature id */>>
 {
   typedef Accumulator<ValueT> BaseT;
 
@@ -47,7 +47,7 @@ class OsmID2FeatureID : public Accumulator<pair<osm::Id, uint32_t /* feature id 
 public:
   template <class TSink> void Flush(TSink & sink)
   {
-    sort(m_data.begin(), m_data.end());
+    std::sort(m_data.begin(), m_data.end());
     BaseT::Flush(sink);
   }
 
@@ -55,7 +55,7 @@ public:
   uint32_t GetRoadFeatureID(uint64_t wayId) const
   {
     osm::Id id = osm::Id::Way(wayId);
-    auto const it = lower_bound(m_data.begin(), m_data.end(), id, LessID());
+    auto const it = std::lower_bound(m_data.begin(), m_data.end(), id, LessID());
     if (it != m_data.end() && it->first == id)
       return it->second;
     return 0;

--- a/generator/generate_info.hpp
+++ b/generator/generate_info.hpp
@@ -6,8 +6,8 @@
 
 #include "coding/file_name_utils.hpp"
 
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <string>
+#include <vector>
 
 namespace feature
 {
@@ -27,27 +27,27 @@ struct GenerateInfo
   };
 
   // Directory for .mwm.tmp files.
-  string m_tmpDir;
+  std::string m_tmpDir;
   // Directory for result .mwm files.
-  string m_targetDir;
+  std::string m_targetDir;
   // Directory for all intermediate files.
-  string m_intermediateDir;
+  std::string m_intermediateDir;
 
   // Current generated file name if --output option is defined.
-  string m_fileName;
+  std::string m_fileName;
 
   NodeStorageType m_nodeStorageType;
   OsmSourceType m_osmFileType;
-  string m_osmFileName;
+  std::string m_osmFileName;
 
-  string m_bookingDatafileName;
-  string m_bookingReferenceDir;
-  string m_opentableDatafileName;
-  string m_opentableReferenceDir;
+  std::string m_bookingDatafileName;
+  std::string m_bookingReferenceDir;
+  std::string m_opentableDatafileName;
+  std::string m_opentableReferenceDir;
 
   uint32_t m_versionDate = 0;
 
-  vector<string> m_bucketNames;
+  std::vector<std::string> m_bucketNames;
 
   bool m_createWorld = false;
   bool m_splitByPolygons = false;
@@ -60,7 +60,7 @@ struct GenerateInfo
 
   GenerateInfo() = default;
 
-  void SetOsmFileType(string const & type)
+  void SetOsmFileType(std::string const & type)
   {
     if (type == "xml")
       m_osmFileType = OsmSourceType::XML;
@@ -70,7 +70,7 @@ struct GenerateInfo
       LOG(LCRITICAL, ("Unknown source type:", type));
   }
 
-  void SetNodeStorageType(string const & type)
+  void SetNodeStorageType(std::string const & type)
   {
     if (type == "raw")
       m_nodeStorageType = NodeStorageType::File;
@@ -82,24 +82,24 @@ struct GenerateInfo
       LOG(LCRITICAL, ("Incorrect node_storage type:", type));
   }
 
-  string GetTmpFileName(string const & fileName, char const * ext = DATA_FILE_EXTENSION_TMP) const
+  std::string GetTmpFileName(std::string const & fileName, char const * ext = DATA_FILE_EXTENSION_TMP) const
   {
     return my::JoinFoldersToPath(m_tmpDir, fileName + ext);
   }
 
-  string GetTargetFileName(string const & fileName, char const * ext = DATA_FILE_EXTENSION) const
+  std::string GetTargetFileName(std::string const & fileName, char const * ext = DATA_FILE_EXTENSION) const
   {
     return my::JoinFoldersToPath(m_targetDir, fileName + ext);
   }
 
-  string GetIntermediateFileName(string const & fileName, char const * ext = DATA_FILE_EXTENSION) const
+  std::string GetIntermediateFileName(std::string const & fileName, char const * ext = DATA_FILE_EXTENSION) const
   {
     return my::JoinFoldersToPath(m_intermediateDir, fileName + ext);
   }
 
-  string GetAddressesFileName() const
+  std::string GetAddressesFileName() const
   {
-    return ((m_genAddresses && !m_fileName.empty()) ? GetTargetFileName(m_fileName, ADDR_FILE_EXTENSION) : string());
+    return ((m_genAddresses && !m_fileName.empty()) ? GetTargetFileName(m_fileName, ADDR_FILE_EXTENSION) : std::string());
   }
 };
 }  // namespace feature

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -25,7 +25,7 @@
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 using namespace feature;
 using namespace generator;
@@ -45,9 +45,9 @@ namespace
 // @TODO(bykoianko) Add ability to add to the tests not road features without altitude information.
 
 // Directory name for creating test mwm and temporary files.
-string const kTestDir = "altitude_generation_test";
+std::string const kTestDir = "altitude_generation_test";
 // Temporary mwm name for testing.
-string const kTestMwm = "test";
+std::string const kTestMwm = "test";
 
 struct Point3D
 {
@@ -125,10 +125,10 @@ void BuildMwmWithoutAltitudes(vector<TPoint3DList> const & roads, LocalCountryFi
   generator::tests_support::TestMwmBuilder builder(country, feature::DataHeader::country);
 
   for (TPoint3DList const & geom3D : roads)
-    builder.Add(generator::tests_support::TestStreet(ExtractPoints(geom3D), string(), string()));
+    builder.Add(generator::tests_support::TestStreet(ExtractPoints(geom3D), std::string(), std::string()));
 }
 
-void TestAltitudes(MwmValue const & mwmValue, string const & mwmPath,
+void TestAltitudes(MwmValue const & mwmValue, std::string const & mwmPath,
                    bool hasAltitudeExpected, AltitudeGetter & expectedAltitudes)
 {
   AltitudeLoader loader(mwmValue);
@@ -163,7 +163,7 @@ void TestAltitudesBuilding(vector<TPoint3DList> const & roads, bool hasAltitudeE
 {
   classificator::Load();
   Platform & platform = GetPlatform();
-  string const testDirFullPath = my::JoinFoldersToPath(platform.WritableDir(), kTestDir);
+  std::string const testDirFullPath = my::JoinFoldersToPath(platform.WritableDir(), kTestDir);
 
   // Building mwm without altitude section.
   LocalCountryFile country(testDirFullPath, CountryFile(kTestMwm), 1);
@@ -172,7 +172,7 @@ void TestAltitudesBuilding(vector<TPoint3DList> const & roads, bool hasAltitudeE
   BuildMwmWithoutAltitudes(roads, country);
 
   // Adding altitude section to mwm.
-  string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
+  std::string const mwmPath = my::JoinFoldersToPath(testDirFullPath, kTestMwm + DATA_FILE_EXTENSION);
   BuildRoadAltitudes(mwmPath, altitudeGetter);
 
   // Reading from mwm and testing altitude information.

--- a/generator/generator_tests/coasts_test.cpp
+++ b/generator/generator_tests/coasts_test.cpp
@@ -12,6 +12,7 @@
 
 #include "base/logging.hpp"
 
+using namespace std;
 
 namespace
 {

--- a/generator/generator_tests/osm_o5m_source_test.cpp
+++ b/generator/generator_tests/osm_o5m_source_test.cpp
@@ -2,13 +2,15 @@
 
 #include "generator/osm_o5m_source.hpp"
 
-#include "std/iterator.hpp"
-#include "std/set.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <iterator>
+#include <set>
+#include <utility>
+#include <vector>
 
 #include "source_data.hpp"
 
+
+using namespace std;
 
 UNIT_TEST(OSM_O5M_Source_Node_read_test)
 {

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -42,11 +42,11 @@ UNIT_TEST(OsmType_SkipDummy)
 
 namespace
 {
-  void DumpTypes(vector<uint32_t> const & v)
+  void DumpTypes(std::vector<uint32_t> const & v)
   {
     Classificator const & c = classif();
     for (size_t i = 0; i < v.size(); ++i)
-      std::cout << c.GetFullObjectName(v[i]) << endl;
+      std::cout << c.GetFullObjectName(v[i]) << std::endl;
   }
 
   void DumpParsedTypes(char const * arr[][2], size_t count)
@@ -60,7 +60,8 @@ namespace
     DumpTypes(params.m_Types);
   }
 
-  void TestSurfaceTypes(std::string const & surface, std::string const & smoothness, std::string const & grade, char const * value)
+  void TestSurfaceTypes(std::string const & surface, std::string const & smoothness,
+                        std::string const & grade, char const * value)
   {
     OsmElement e;
     e.AddTag("highway", "unclassified");

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -14,7 +14,7 @@
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
 
-#include "std/iostream.hpp"
+#include <iostream>
 
 using namespace tests;
 
@@ -46,7 +46,7 @@ namespace
   {
     Classificator const & c = classif();
     for (size_t i = 0; i < v.size(); ++i)
-      cout << c.GetFullObjectName(v[i]) << endl;
+      std::cout << c.GetFullObjectName(v[i]) << endl;
   }
 
   void DumpParsedTypes(char const * arr[][2], size_t count)
@@ -60,7 +60,7 @@ namespace
     DumpTypes(params.m_Types);
   }
 
-  void TestSurfaceTypes(string const & surface, string const & smoothness, string const & grade, char const * value)
+  void TestSurfaceTypes(std::string const & surface, std::string const & smoothness, std::string const & grade, char const * value)
   {
     OsmElement e;
     e.AddTag("highway", "unclassified");
@@ -73,10 +73,10 @@ namespace
 
     TEST_EQUAL(params.m_Types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"highway", "unclassified"})), ());
-    string psurface;
+    std::string psurface;
     for (auto type : params.m_Types)
     {
-      string const rtype = classif().GetReadableObjectName(type);
+      std::string const rtype = classif().GetReadableObjectName(type);
       if (rtype.substr(0, 9) == "psurface-")
         psurface = rtype.substr(9);
     }
@@ -141,7 +141,7 @@ UNIT_TEST(OsmType_Combined)
   TEST(params.IsTypeExist(GetType(arr[3])), ());
   TEST(params.IsTypeExist(GetType({"building"})), ());
 
-  string s;
+  std::string s;
   params.name.GetString(0, s);
   TEST_EQUAL(s, arr[5][1], ());
 
@@ -195,7 +195,7 @@ UNIT_TEST(OsmType_PlaceState)
   TEST_EQUAL(params.m_Types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "state", "USA"})), ());
 
-  string s;
+  std::string s;
   TEST(params.name.GetString(0, s), ());
   TEST_EQUAL(s, "California", ());
   TEST_GREATER(params.rank, 1, ());
@@ -667,7 +667,7 @@ UNIT_TEST(OsmType_Dibrugarh)
 
   TEST_EQUAL(params.m_Types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), (params));
-  string name;
+  std::string name;
   TEST(params.name.GetString(StringUtf8Multilang::kDefaultCode, name), (params));
   TEST_EQUAL(name, "Dibrugarh", (params));
 }

--- a/generator/generator_tests/restriction_collector_test.cpp
+++ b/generator/generator_tests/restriction_collector_test.cpp
@@ -16,9 +16,9 @@
 
 #include "base/stl_helpers.hpp"
 
-#include "std/string.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace generator;
 using namespace platform;
@@ -26,7 +26,7 @@ using namespace platform::tests_support;
 
 namespace routing
 {
-string const kRestrictionTestDir = "test-restrictions";
+std::string const kRestrictionTestDir = "test-restrictions";
 
 UNIT_TEST(RestrictionTest_ValidCase)
 {
@@ -67,9 +67,9 @@ UNIT_TEST(RestrictionTest_InvalidCase)
 
 UNIT_TEST(RestrictionTest_ParseRestrictions)
 {
-  string const kRestrictionName = "restrictions_in_osm_ids.csv";
-  string const kRestrictionPath = my::JoinFoldersToPath(kRestrictionTestDir, kRestrictionName);
-  string const kRestrictionContent = R"(No, 1, 1,
+  std::string const kRestrictionName = "restrictions_in_osm_ids.csv";
+  std::string const kRestrictionPath = my::JoinFoldersToPath(kRestrictionTestDir, kRestrictionName);
+  std::string const kRestrictionContent = R"(No, 1, 1,
                                         Only, 0, 2,
                                         Only, 2, 3,
                                         No, 38028428, 38028428
@@ -92,22 +92,22 @@ UNIT_TEST(RestrictionTest_RestrictionCollectorWholeClassTest)
 {
   ScopedDir scopedDir(kRestrictionTestDir);
 
-  string const kRestrictionName = "restrictions_in_osm_ids.csv";
-  string const kRestrictionPath = my::JoinFoldersToPath(kRestrictionTestDir, kRestrictionName);
-  string const kRestrictionContent = R"(No, 10, 10,
+  std::string const kRestrictionName = "restrictions_in_osm_ids.csv";
+  std::string const kRestrictionPath = my::JoinFoldersToPath(kRestrictionTestDir, kRestrictionName);
+  std::string const kRestrictionContent = R"(No, 10, 10,
                                         Only, 10, 20,
                                         Only, 30, 40,)";
   ScopedFile restrictionScopedFile(kRestrictionPath, kRestrictionContent);
 
-  string const kOsmIdsToFeatureIdsName = "osm_ids_to_feature_ids" OSM2FEATURE_FILE_EXTENSION;
-  string const osmIdsToFeatureIdsPath =
+  std::string const kOsmIdsToFeatureIdsName = "osm_ids_to_feature_ids" OSM2FEATURE_FILE_EXTENSION;
+  std::string const osmIdsToFeatureIdsPath =
       my::JoinFoldersToPath(kRestrictionTestDir, kOsmIdsToFeatureIdsName);
-  string const kOsmIdsToFeatureIdsContent = R"(10, 1,
+  std::string const kOsmIdsToFeatureIdsContent = R"(10, 1,
                                                20, 2,
                                                30, 3,
                                                40, 4)";
   Platform const & platform = Platform();
-  string const osmIdsToFeatureIdsFullPath =
+  std::string const osmIdsToFeatureIdsFullPath =
       my::JoinFoldersToPath(platform.WritableDir(), osmIdsToFeatureIdsPath);
   ReEncodeOsmIdsToFeatureIdsMapping(kOsmIdsToFeatureIdsContent, osmIdsToFeatureIdsFullPath);
   ScopedFile mappingScopedFile(osmIdsToFeatureIdsPath);

--- a/generator/generator_tests/restriction_test.cpp
+++ b/generator/generator_tests/restriction_test.cpp
@@ -19,7 +19,9 @@
 
 #include "base/logging.hpp"
 
-#include "std/string.hpp"
+#include <string>
+
+using namespace std;
 
 using namespace feature;
 using namespace generator;

--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+using namespace std;
+
 using namespace feature;
 using namespace generator::tests_support;
 using namespace generator;

--- a/generator/generator_tests/source_to_element_test.cpp
+++ b/generator/generator_tests/source_to_element_test.cpp
@@ -4,16 +4,16 @@
 #include "generator/osm_source.hpp"
 #include "generator/osm_element.hpp"
 
-#include "std/iterator.hpp"
+#include <iterator>
 
 #include "source_data.hpp"
 
 UNIT_TEST(Source_To_Element_create_from_xml_test)
 {
-  istringstream ss(way_xml_data);
+  std::istringstream ss(way_xml_data);
   SourceReader reader(ss);
 
-  vector<OsmElement> elements;
+  std::vector<OsmElement> elements;
   ProcessOsmElementsFromXML(reader, [&elements](OsmElement * e)
   {
     elements.push_back(*e);
@@ -24,36 +24,36 @@ UNIT_TEST(Source_To_Element_create_from_xml_test)
 
 UNIT_TEST(Source_To_Element_create_from_o5m_test)
 {
-  string src(begin(relation_o5m_data), end(relation_o5m_data));
-  istringstream ss(src);
+  std::string src(std::begin(relation_o5m_data), std::end(relation_o5m_data));
+  std::istringstream ss(src);
   SourceReader reader(ss);
 
-  vector<OsmElement> elements;
+  std::vector<OsmElement> elements;
   ProcessOsmElementsFromO5M(reader, [&elements](OsmElement * e)
   {
     elements.push_back(*e);
   });
   TEST_EQUAL(elements.size(), 11, (elements));
 
-  cout << DebugPrint(elements);
+  std::cout << DebugPrint(elements);
 }
 
 UNIT_TEST(Source_To_Element_check_equivalence)
 {
-  istringstream ss1(relation_xml_data);
+  std::istringstream ss1(relation_xml_data);
   SourceReader readerXML(ss1);
 
-  vector<OsmElement> elementsXML;
+  std::vector<OsmElement> elementsXML;
   ProcessOsmElementsFromXML(readerXML, [&elementsXML](OsmElement * e)
   {
     elementsXML.push_back(*e);
   });
 
-  string src(begin(relation_o5m_data), end(relation_o5m_data));
-  istringstream ss2(src);
+  std::string src(std::begin(relation_o5m_data), std::end(relation_o5m_data));
+  std::istringstream ss2(src);
   SourceReader readerO5M(ss2);
 
-  vector<OsmElement> elementsO5M;
+  std::vector<OsmElement> elementsO5M;
   ProcessOsmElementsFromO5M(readerO5M, [&elementsO5M](OsmElement * e)
   {
     elementsO5M.push_back(*e);

--- a/generator/generator_tests/srtm_parser_test.cpp
+++ b/generator/generator_tests/srtm_parser_test.cpp
@@ -6,7 +6,7 @@ using namespace generator;
 
 namespace
 {
-inline string GetBase(ms::LatLon const & coord) { return SrtmTile::GetBase(coord); }
+inline std::string GetBase(ms::LatLon const & coord) { return SrtmTile::GetBase(coord); }
 
 UNIT_TEST(FilenameTests)
 {

--- a/generator/generator_tests/tag_admixer_test.cpp
+++ b/generator/generator_tests/tag_admixer_test.cpp
@@ -2,30 +2,30 @@
 
 #include "generator/tag_admixer.hpp"
 
-#include "std/map.hpp"
-#include "std/set.hpp"
-#include "std/sstream.hpp"
+#include <map>
+#include <set>
+#include <sstream>
 
 UNIT_TEST(WaysParserTests)
 {
-  map<uint64_t, string> ways;
+  std::map<uint64_t, std::string> ways;
   WaysParserHelper parser(ways);
-  istringstream stream("140247102;world_level\n86398306;another_level\n294584441;world_level");
+  std::istringstream stream("140247102;world_level\n86398306;another_level\n294584441;world_level");
   parser.ParseStream(stream);
   TEST(ways.find(140247102) != ways.end(), ());
-  TEST_EQUAL(ways[140247102], string("world_level"), ());
+  TEST_EQUAL(ways[140247102], std::string("world_level"), ());
   TEST(ways.find(86398306) != ways.end(), ());
-  TEST_EQUAL(ways[86398306], string("another_level"), ());
+  TEST_EQUAL(ways[86398306], std::string("another_level"), ());
   TEST(ways.find(294584441) != ways.end(), ());
-  TEST_EQUAL(ways[294584441], string("world_level"), ());
+  TEST_EQUAL(ways[294584441], std::string("world_level"), ());
   TEST(ways.find(140247101) == ways.end(), ());
 }
 
 UNIT_TEST(CapitalsParserTests)
 {
-  set<uint64_t> capitals;
+  std::set<uint64_t> capitals;
   CapitalsParserHelper parser(capitals);
-  istringstream stream("-21.1343401;-175.201808;1082208696;t\n-16.6934156;-179.87995;242715809;f\n19.0534159;169.919199;448768937;t");
+  std::istringstream stream("-21.1343401;-175.201808;1082208696;t\n-16.6934156;-179.87995;242715809;f\n19.0534159;169.919199;448768937;t");
   parser.ParseStream(stream);
   TEST(capitals.find(1082208696) != capitals.end(), ());
   TEST(capitals.find(242715809) != capitals.end(), ());

--- a/generator/generator_tests/tesselator_test.cpp
+++ b/generator/generator_tests/tesselator_test.cpp
@@ -4,6 +4,7 @@
 
 #include "base/logging.hpp"
 
+using namespace std;
 
 namespace
 {

--- a/generator/generator_tests/triangles_tree_coding_test.cpp
+++ b/generator/generator_tests/triangles_tree_coding_test.cpp
@@ -64,12 +64,12 @@ namespace
     tesselator::PointsInfo points;
     m2::PointU (* D2U)(m2::PointD const &, uint32_t) = &PointD2PointU;
     info.GetPointsInfo(saver.GetBasePoint(), saver.GetMaxPoint(),
-                       bind(D2U, _1, cp.GetCoordBits()), points);
+                       std::bind(D2U, std::placeholders::_1, cp.GetCoordBits()), points);
 
     info.ProcessPortions(points, saver);
 
-    vector<char> buffer;
-    MemWriter<vector<char> > writer(buffer);
+    std::vector<char> buffer;
+    MemWriter<std::vector<char> > writer(buffer);
     saver.Save(writer);
 
     TEST ( !buffer.empty(), () );

--- a/generator/generator_tests/types_helper.hpp
+++ b/generator/generator_tests/types_helper.hpp
@@ -5,8 +5,10 @@
 #include "indexer/classificator.hpp"
 #include "indexer/feature_data.hpp"
 
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include "base/stl_add.hpp"
+
+#include <string>
+#include <vector>
 
 
 namespace tests
@@ -18,7 +20,7 @@ inline void AddTypes(FeatureParams & params, char const * (&arr)[N][M])
   Classificator const & c = classif();
 
   for (size_t i = 0; i < N; ++i)
-    params.AddType(c.GetTypeByPath(vector<string>(arr[i], arr[i] + M)));
+    params.AddType(c.GetTypeByPath(std::vector<std::string>(arr[i], arr[i] + M)));
 }
 
 inline void FillXmlElement(char const * arr[][2], size_t count, OsmElement * p)
@@ -30,11 +32,11 @@ inline void FillXmlElement(char const * arr[][2], size_t count, OsmElement * p)
 template <size_t N>
 inline uint32_t GetType(char const * (&arr)[N])
 {
-  vector<string> path(arr, arr + N);
+  std::vector<std::string> path(arr, arr + N);
   return classif().GetTypeByPath(path);
 }
 
-inline uint32_t GetType(StringIL const & lst)
+inline uint32_t GetType(my::StringIL const & lst)
 {
   return classif().GetTypeByPath(lst);
 }

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -9,15 +9,15 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/utility.hpp"
+#include <utility>
 
 namespace generator
 {
-void ReEncodeOsmIdsToFeatureIdsMapping(string const & mappingContent, string const & outputFilePath)
+void ReEncodeOsmIdsToFeatureIdsMapping(std::string const & mappingContent, std::string const & outputFilePath)
 {
   strings::SimpleTokenizer lineIter(mappingContent, "\n\r" /* line delimiters */);
 
-  gen::Accumulator<pair<osm::Id, uint32_t>> osmIdsToFeatureIds;
+  gen::Accumulator<std::pair<osm::Id, uint32_t>> osmIdsToFeatureIds;
   for (; lineIter; ++lineIter)
   {
     strings::SimpleTokenizer idIter(*lineIter, ", \t" /* id delimiters */);
@@ -30,7 +30,7 @@ void ReEncodeOsmIdsToFeatureIdsMapping(string const & mappingContent, string con
     uint32_t featureId = 0;
     TEST(idIter, ());
     TEST(strings::to_uint(*idIter, featureId), ("Cannot convert to uint:", *idIter));
-    osmIdsToFeatureIds.Add(make_pair(osm::Id::Way(osmId), featureId));
+    osmIdsToFeatureIds.Add(std::make_pair(osm::Id::Way(osmId), featureId));
     ++idIter;
     TEST(!idIter, ());
   }

--- a/generator/generator_tests_support/routing_helpers.hpp
+++ b/generator/generator_tests_support/routing_helpers.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace generator
 {
@@ -12,6 +12,6 @@ namespace generator
 /// 30, 3,
 /// 40, 4
 /// \param outputFilePath full path to an output file where the mapping is saved.
-void ReEncodeOsmIdsToFeatureIdsMapping(string const & mappingContent,
-                                       string const & outputFilePath);
+void ReEncodeOsmIdsToFeatureIdsMapping(std::string const & mappingContent,
+                                       std::string const & outputFilePath);
 }  // namespace generator

--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -17,8 +17,10 @@
 #include "base/assert.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/atomic.hpp"
-#include "std/sstream.hpp"
+#include <atomic>
+#include <sstream>
+
+using namespace std;
 
 namespace generator
 {

--- a/generator/generator_tests_support/test_feature.hpp
+++ b/generator/generator_tests_support/test_feature.hpp
@@ -5,9 +5,9 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/string.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <string>
+#include <utility>
+#include <vector>
 
 class FeatureBuilder1;
 class FeatureType;
@@ -27,43 +27,43 @@ public:
   virtual ~TestFeature() = default;
 
   bool Matches(FeatureType const & feature) const;
-  inline void SetPostcode(string const & postcode) { m_postcode = postcode; }
+  inline void SetPostcode(std::string const & postcode) { m_postcode = postcode; }
   inline uint64_t GetId() const { return m_id; }
-  inline string const & GetName() const { return m_name; }
+  inline std::string const & GetName() const { return m_name; }
 
   virtual void Serialize(FeatureBuilder1 & fb) const;
-  virtual string ToString() const = 0;
+  virtual std::string ToString() const = 0;
 
 protected:
-  TestFeature(string const & name, string const & lang);
-  TestFeature(m2::PointD const & center, string const & name, string const & lang);
+  TestFeature(std::string const & name, std::string const & lang);
+  TestFeature(m2::PointD const & center, std::string const & name, std::string const & lang);
 
   uint64_t const m_id;
   m2::PointD const m_center;
   bool const m_hasCenter;
-  string const m_name;
-  string const m_lang;
-  string m_postcode;
+  std::string const m_name;
+  std::string const m_lang;
+  std::string m_postcode;
 };
 
 class TestCountry : public TestFeature
 {
 public:
-  TestCountry(m2::PointD const & center, string const & name, string const & lang);
+  TestCountry(m2::PointD const & center, std::string const & name, std::string const & lang);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 };
 
 class TestCity : public TestFeature
 {
 public:
-  TestCity(m2::PointD const & center, string const & name, string const & lang, uint8_t rank);
+  TestCity(m2::PointD const & center, std::string const & name, std::string const & lang, uint8_t rank);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
   uint8_t const m_rank;
@@ -72,11 +72,11 @@ private:
 class TestVillage : public TestFeature
 {
 public:
-  TestVillage(m2::PointD const & center, string const & name, string const & lang, uint8_t rank);
+  TestVillage(m2::PointD const & center, std::string const & name, std::string const & lang, uint8_t rank);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
   uint8_t const m_rank;
@@ -85,84 +85,84 @@ private:
 class TestStreet : public TestFeature
 {
 public:
-  TestStreet(vector<m2::PointD> const & points, string const & name, string const & lang);
+  TestStreet(std::vector<m2::PointD> const & points, std::string const & name, std::string const & lang);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
-  vector<m2::PointD> m_points;
+  std::vector<m2::PointD> m_points;
 };
 
 class TestPOI : public TestFeature
 {
 public:
-  TestPOI(m2::PointD const & center, string const & name, string const & lang);
+  TestPOI(m2::PointD const & center, std::string const & name, std::string const & lang);
 
-  static pair<TestPOI, FeatureID> AddWithEditor(osm::Editor & editor, MwmSet::MwmId const & mwmId,
-                                                string const & enName, m2::PointD const & pt);
+  static std::pair<TestPOI, FeatureID> AddWithEditor(osm::Editor & editor, MwmSet::MwmId const & mwmId,
+                                                std::string const & enName, m2::PointD const & pt);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
-  inline void SetHouseNumber(string const & houseNumber) { m_houseNumber = houseNumber; }
+  inline void SetHouseNumber(std::string const & houseNumber) { m_houseNumber = houseNumber; }
   inline void SetStreet(TestStreet const & street) { m_streetName = street.GetName(); }
-  inline void SetTypes(vector<vector<string>> const & types) { m_types = types; }
+  inline void SetTypes(std::vector<std::vector<std::string>> const & types) { m_types = types; }
 
 private:
-  string m_houseNumber;
-  string m_streetName;
-  vector<vector<string>> m_types;
+  std::string m_houseNumber;
+  std::string m_streetName;
+  std::vector<std::vector<std::string>> m_types;
 };
 
 class TestBuilding : public TestFeature
 {
 public:
-  TestBuilding(m2::PointD const & center, string const & name, string const & houseNumber,
-               string const & lang);
-  TestBuilding(m2::PointD const & center, string const & name, string const & houseNumber,
-               TestStreet const & street, string const & lang);
-  TestBuilding(vector<m2::PointD> const & boundary, string const & name, string const & houseNumber,
-               TestStreet const & street, string const & lang);
+  TestBuilding(m2::PointD const & center, std::string const & name, std::string const & houseNumber,
+               std::string const & lang);
+  TestBuilding(m2::PointD const & center, std::string const & name, std::string const & houseNumber,
+               TestStreet const & street, std::string const & lang);
+  TestBuilding(std::vector<m2::PointD> const & boundary, std::string const & name, std::string const & houseNumber,
+               TestStreet const & street, std::string const & lang);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
-  vector<m2::PointD> const m_boundary;
-  string const m_houseNumber;
-  string const m_streetName;
+  std::vector<m2::PointD> const m_boundary;
+  std::string const m_houseNumber;
+  std::string const m_streetName;
 };
 
 class TestPark : public TestFeature
 {
 public:
-  TestPark(vector<m2::PointD> const & boundary, string const & name, string const & lang);
+  TestPark(std::vector<m2::PointD> const & boundary, std::string const & name, std::string const & lang);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
-  vector<m2::PointD> m_boundary;
+  std::vector<m2::PointD> m_boundary;
 };
 
 class TestRoad : public TestFeature
 {
 public:
-  TestRoad(vector<m2::PointD> const & points, string const & name, string const & lang);
+  TestRoad(std::vector<m2::PointD> const & points, std::string const & name, std::string const & lang);
 
   // TestFeature overrides:
   void Serialize(FeatureBuilder1 & fb) const override;
-  string ToString() const override;
+  std::string ToString() const override;
 
 private:
-  vector<m2::PointD> m_points;
+  std::vector<m2::PointD> m_points;
 };
 
-string DebugPrint(TestFeature const & feature);
+std::string DebugPrint(TestFeature const & feature);
 }  // namespace tests_support
 }  // namespace generator

--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -28,7 +28,7 @@ TestMwmBuilder::TestMwmBuilder(platform::LocalCountryFile & file, feature::DataH
     : m_file(file),
       m_type(type),
       m_collector(
-          make_unique<feature::FeaturesCollector>(m_file.GetPath(MapOptions::Map) + EXTENSION_TMP))
+          my::make_unique<feature::FeaturesCollector>(m_file.GetPath(MapOptions::Map) + EXTENSION_TMP))
 {
 }
 
@@ -67,7 +67,7 @@ bool TestMwmBuilder::Add(FeatureBuilder1 & fb)
 
 void TestMwmBuilder::Finish()
 {
-  string const tmpFilePath = m_collector->GetFilePath();
+  std::string const tmpFilePath = m_collector->GetFilePath();
 
   CHECK(m_collector, ("Finish() already was called."));
   m_collector.reset();
@@ -80,7 +80,7 @@ void TestMwmBuilder::Finish()
 
   CHECK(my::DeleteFileX(tmpFilePath), ());
 
-  string const path = m_file.GetPath(MapOptions::Map);
+  std::string const path = m_file.GetPath(MapOptions::Map);
   (void)my::DeleteFileX(path + OSM2FEATURE_FILE_EXTENSION);
 
   CHECK(feature::BuildOffsetsTable(path), ("Can't build feature offsets table."));

--- a/generator/generator_tests_support/test_mwm_builder.hpp
+++ b/generator/generator_tests_support/test_mwm_builder.hpp
@@ -2,7 +2,7 @@
 
 #include "indexer/data_header.hpp"
 
-#include "std/unique_ptr.hpp"
+#include <memory>
 
 namespace feature
 {
@@ -35,7 +35,7 @@ public:
 private:
   platform::LocalCountryFile & m_file;
   feature::DataHeader::MapType m_type;
-  unique_ptr<feature::FeaturesCollector> m_collector;
+  std::unique_ptr<feature::FeaturesCollector> m_collector;
 };
 }  // namespace tests_support
 }  // namespace generator

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -117,7 +117,7 @@ int main(int argc, char ** argv)
   if (!FLAGS_user_resource_path.empty())
     pl.SetResourceDir(FLAGS_user_resource_path);
 
-  string const path =
+  std::string const path =
       FLAGS_data_path.empty() ? pl.WritableDir() : my::AddSlashIfNeeded(FLAGS_data_path);
 
   feature::GenerateInfo genInfo;
@@ -128,7 +128,7 @@ int main(int argc, char ** argv)
   /// @todo Probably, it's better to add separate option for .mwm.tmp files.
   if (!FLAGS_intermediate_data_path.empty())
   {
-    string const tmpPath = genInfo.m_intermediateDir + "tmp" + my::GetNativeSeparator();
+    std::string const tmpPath = genInfo.m_intermediateDir + "tmp" + my::GetNativeSeparator();
     if (pl.MkDir(tmpPath) != Platform::ERR_UNKNOWN)
       genInfo.m_tmpDir = tmpPath;
   }
@@ -203,8 +203,8 @@ int main(int argc, char ** argv)
   size_t const count = genInfo.m_bucketNames.size();
   for (size_t i = 0; i < count; ++i)
   {
-    string const & country = genInfo.m_bucketNames[i];
-    string const datFile = my::JoinFoldersToPath(path, country + DATA_FILE_EXTENSION);
+    std::string const & country = genInfo.m_bucketNames[i];
+    std::string const datFile = my::JoinFoldersToPath(path, country + DATA_FILE_EXTENSION);
 
     if (FLAGS_generate_geometry)
     {
@@ -252,13 +252,13 @@ int main(int argc, char ** argv)
     if (!FLAGS_srtm_path.empty())
       routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
 
-    string const osmToFeatureFilename = genInfo.GetTargetFileName(country) + OSM2FEATURE_FILE_EXTENSION;
+    std::string const osmToFeatureFilename = genInfo.GetTargetFileName(country) + OSM2FEATURE_FILE_EXTENSION;
 
     if (FLAGS_make_routing_index)
     {
-      string const restrictionsFilename =
+      std::string const restrictionsFilename =
           genInfo.GetIntermediateFileName(RESTRICTIONS_FILENAME, "" /* extension */);
-      string const roadAccessFilename =
+      std::string const roadAccessFilename =
           genInfo.GetIntermediateFileName(ROAD_ACCESS_FILENAME, "" /* extension */);
 
       routing::BuildRoadRestrictions(datFile, restrictionsFilename, osmToFeatureFilename);
@@ -280,7 +280,7 @@ int main(int argc, char ** argv)
     }
   }
 
-  string const datFile = my::JoinFoldersToPath(path, FLAGS_output + DATA_FILE_EXTENSION);
+  std::string const datFile = my::JoinFoldersToPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
   if (FLAGS_calc_statistics)
   {

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -12,12 +12,11 @@
 #include <algorithm>
 #include <deque>
 #include <exception>
+#include <fstream>
 #include <limits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <fstream>
 
 #include "defines.hpp"
 
@@ -192,7 +191,7 @@ public:
     uint64_t pos = 0;
     if (!m_offsets.GetValueByKey(id, pos))
     {
-      LOG_SHORT(LWARNING, ("Can't std::find offset in file", m_offsets.GetFileName(), "by id", id));
+      LOG_SHORT(LWARNING, ("Can't find offset in file", m_offsets.GetFileName(), "by id", id));
       return false;
     }
 

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -9,15 +9,15 @@
 
 #include "base/logging.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/deque.hpp"
-#include "std/exception.hpp"
-#include "std/limits.hpp"
-#include "std/unordered_map.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <deque>
+#include <exception>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "std/fstream.hpp"
+#include <fstream>
 
 #include "defines.hpp"
 
@@ -35,8 +35,8 @@ class IndexFile
 {
   using TKey = uint64_t;
   static_assert(is_integral<TKey>::value, "TKey is not integral type");
-  using TElement = pair<TKey, TValue>;
-  using TContainer = vector<TElement>;
+  using TElement = std::pair<TKey, TValue>;
+  using TContainer = std::vector<TElement>;
 
   TContainer m_elements;
   TFile m_file;
@@ -55,14 +55,14 @@ class IndexFile
 
   static size_t CheckedCast(uint64_t v)
   {
-    ASSERT_LESS(v, numeric_limits<size_t>::max(), ("Value too long for memory address : ", v));
+    ASSERT_LESS(v, std::numeric_limits<size_t>::max(), ("Value too long for memory address : ", v));
     return static_cast<size_t>(v);
   }
 
 public:
-  explicit IndexFile(string const & name) : m_file(name.c_str()) {}
+  explicit IndexFile(std::string const & name) : m_file(name.c_str()) {}
 
-  string GetFileName() const { return m_file.GetName(); }
+  std::string GetFileName() const { return m_file.GetName(); }
 
   void WriteAll()
   {
@@ -87,14 +87,14 @@ public:
     {
       m_elements.resize(CheckedCast(fileSize / sizeof(TElement)));
     }
-    catch (exception const &)  // bad_alloc
+    catch (std::exception const &)  // bad_alloc
     {
       LOG(LCRITICAL, ("Insufficient memory for required offset map"));
     }
 
     m_file.Read(0, &m_elements[0], CheckedCast(fileSize));
 
-    sort(m_elements.begin(), m_elements.end(), ElementComparator());
+    std::sort(m_elements.begin(), m_elements.end(), ElementComparator());
 
     LOG_SHORT(LINFO, ("Offsets reading is finished"));
   }
@@ -104,12 +104,12 @@ public:
     if (m_elements.size() > kFlushCount)
       WriteAll();
 
-    m_elements.push_back(make_pair(k, v));
+    m_elements.push_back(std::make_pair(k, v));
   }
 
   bool GetValueByKey(TKey key, TValue & value) const
   {
-    auto it = lower_bound(m_elements.begin(), m_elements.end(), key, ElementComparator());
+    auto it = std::lower_bound(m_elements.begin(), m_elements.end(), key, ElementComparator());
     if ((it != m_elements.end()) && ((*it).first == key))
     {
       value = (*it).second;
@@ -121,7 +121,7 @@ public:
   template <class ToDo>
   void ForEachByKey(TKey k, ToDo && toDo) const
   {
-    auto range = equal_range(m_elements.begin(), m_elements.end(), k, ElementComparator());
+    auto range = std::equal_range(m_elements.begin(), m_elements.end(), k, ElementComparator());
     for (; range.first != range.second; ++range.first)
     {
       if (toDo((*range.first).second))
@@ -140,15 +140,15 @@ public:
   using TOffsetFile = typename conditional<TMode == EMode::Write, FileWriter, FileReader>::type;
 
 protected:
-  using TBuffer = vector<uint8_t>;
+  using TBuffer = std::vector<uint8_t>;
   TStorage m_storage;
   detail::IndexFile<TOffsetFile, uint64_t> m_offsets;
-  string m_name;
+  std::string m_name;
   TBuffer m_data;
   bool m_preload = false;
 
 public:
-  OSMElementCache(string const & name, bool preload = false)
+  OSMElementCache(std::string const & name, bool preload = false)
   : m_storage(name)
   , m_offsets(name + OFFSET_EXT)
   , m_name(name)
@@ -180,7 +180,7 @@ public:
     value.Write(w);
 
     // write buffer
-    ASSERT_LESS(m_data.size(), numeric_limits<uint32_t>::max(), ());
+    ASSERT_LESS(m_data.size(), std::numeric_limits<uint32_t>::max(), ());
     uint32_t sz = static_cast<uint32_t>(m_data.size());
     m_storage.Write(&sz, sizeof(sz));
     m_storage.Write(m_data.data(), sz * sizeof(TBuffer::value_type));
@@ -192,7 +192,7 @@ public:
     uint64_t pos = 0;
     if (!m_offsets.GetValueByKey(id, pos))
     {
-      LOG_SHORT(LWARNING, ("Can't find offset in file", m_offsets.GetFileName(), "by id", id));
+      LOG_SHORT(LWARNING, ("Can't std::find offset in file", m_offsets.GetFileName(), "by id", id));
       return false;
     }
 
@@ -258,7 +258,7 @@ class RawFilePointStorage : public PointStorage
   constexpr static double const kValueOrder = 1E+7;
 
 public:
-  explicit RawFilePointStorage(string const & name) : m_file(name) {}
+  explicit RawFilePointStorage(std::string const & name) : m_file(name) {}
 
   template <EMode T = TMode>
   typename enable_if<T == EMode::Write, void>::type AddPoint(uint64_t id, double lat, double lng)
@@ -304,10 +304,10 @@ class RawMemPointStorage : public PointStorage
 
   constexpr static double const kValueOrder = 1E+7;
 
-  vector<LatLon> m_data;
+  std::vector<LatLon> m_data;
 
 public:
-  explicit RawMemPointStorage(string const & name) : m_file(name), m_data(static_cast<size_t>(1) << 33)
+  explicit RawMemPointStorage(std::string const & name) : m_file(name), m_data(static_cast<size_t>(1) << 33)
   {
     InitStorage<TMode>();
   }
@@ -369,12 +369,12 @@ template <EMode TMode>
 class MapFilePointStorage : public PointStorage
 {
   typename conditional<TMode == EMode::Write, FileWriter, FileReader>::type m_file;
-  unordered_map<uint64_t, pair<int32_t, int32_t>> m_map;
+  std::unordered_map<uint64_t, std::pair<int32_t, int32_t>> m_map;
 
   constexpr static double const kValueOrder = 1E+7;
 
 public:
-  explicit MapFilePointStorage(string const & name) : m_file(name + ".short") { InitStorage<TMode>(); }
+  explicit MapFilePointStorage(std::string const & name) : m_file(name + ".short") { InitStorage<TMode>(); }
 
   template <EMode T>
   typename enable_if<T == EMode::Write, void>::type InitStorage() {}
@@ -392,7 +392,7 @@ public:
       LatLonPos ll;
       m_file.Read(pos, &ll, sizeof(ll));
 
-      m_map.emplace(make_pair(ll.pos, make_pair(ll.lat, ll.lon)));
+      m_map.emplace(std::make_pair(ll.pos, std::make_pair(ll.lat, ll.lon)));
 
       pos += sizeof(ll);
     }

--- a/generator/intermediate_elements.hpp
+++ b/generator/intermediate_elements.hpp
@@ -7,18 +7,18 @@
 #include "coding/varint.hpp"
 #include "coding/writer.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/bind.hpp"
-#include "std/limits.hpp"
-#include "std/map.hpp"
-#include "std/string.hpp"
-#include "std/sstream.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 struct WayElement
 {
-  vector<uint64_t> nodes;
+  std::vector<uint64_t> nodes;
   uint64_t m_wayOsmId;
 
   explicit WayElement(uint64_t osmId) : m_wayOsmId(osmId) {}
@@ -37,7 +37,7 @@ struct WayElement
   template <class ToDo>
   void ForEachPoint(ToDo & toDo) const
   {
-    for_each(nodes.begin(), nodes.end(), ref(toDo));
+    std::for_each(nodes.begin(), nodes.end(), std::ref(toDo));
   }
 
   template <class ToDo>
@@ -45,9 +45,9 @@ struct WayElement
   {
     ASSERT(!nodes.empty(), ());
     if (start == nodes.front())
-      for_each(nodes.begin(), nodes.end(), ref(toDo));
+      std::for_each(nodes.begin(), nodes.end(), std::ref(toDo));
     else
-      for_each(nodes.rbegin(), nodes.rend(), ref(toDo));
+      std::for_each(nodes.rbegin(), nodes.rend(), std::ref(toDo));
   }
 
   template <class TWriter>
@@ -69,16 +69,16 @@ struct WayElement
       e = ReadVarUint<uint64_t>(r);
   }
 
-  string ToString() const
+  std::string ToString() const
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << nodes.size() << " " << m_wayOsmId;
     return ss.str();
   }
 
-  string Dump() const
+  std::string Dump() const
   {
-    stringstream ss;
+    std::stringstream ss;
     for (auto const & e : nodes)
       ss << e << ";";
     return ss.str();
@@ -88,23 +88,23 @@ struct WayElement
 class RelationElement
 {
 public:
-  using TMembers = vector<pair<uint64_t, string>>;
+  using TMembers = std::vector<std::pair<uint64_t, std::string>>;
 
   TMembers nodes;
   TMembers ways;
-  map<string, string> tags;
+  std::map<std::string, std::string> tags;
 
   bool IsValid() const { return !(nodes.empty() && ways.empty()); }
 
-  string GetTagValue(string const & key) const
+  std::string GetTagValue(std::string const & key) const
   {
     auto it = tags.find(key);
-    return ((it != tags.end()) ? it->second : string());
+    return ((it != tags.end()) ? it->second : std::string());
   }
 
-  string GetType() const { return GetTagValue("type"); }
-  bool FindWay(uint64_t id, string & role) const { return FindRoleImpl(ways, id, role); }
-  bool FindNode(uint64_t id, string & role) const { return FindRoleImpl(nodes, id, role); }
+  std::string GetType() const { return GetTagValue("type"); }
+  bool FindWay(uint64_t id, std::string & role) const { return FindRoleImpl(ways, id, role); }
+  bool FindNode(uint64_t id, std::string & role) const { return FindRoleImpl(nodes, id, role); }
 
   template <class ToDo>
   void ForEachWay(ToDo & toDo) const
@@ -113,20 +113,20 @@ public:
       toDo(ways[i].first, ways[i].second);
   }
 
-  string GetNodeRole(uint64_t const id) const
+  std::string GetNodeRole(uint64_t const id) const
   {
     for (size_t i = 0; i < nodes.size(); ++i)
       if (nodes[i].first == id)
         return nodes[i].second;
-    return string();
+    return std::string();
   }
 
-  string GetWayRole(uint64_t const id) const
+  std::string GetWayRole(uint64_t const id) const
   {
     for (size_t i = 0; i < ways.size(); ++i)
       if (ways[i].first == id)
         return ways[i].second;
-    return string();
+    return std::string();
   }
 
   void Swap(RelationElement & rhs)
@@ -139,10 +139,10 @@ public:
   template <class TWriter>
   void Write(TWriter & writer) const
   {
-    auto StringWriter = [&writer, this](string const & str)
+    auto StringWriter = [&writer, this](std::string const & str)
     {
-      CHECK_LESS(str.size(), numeric_limits<uint16_t>::max(),
-                 ("Can't store string greater then 65535 bytes", Dump()));
+      CHECK_LESS(str.size(), std::numeric_limits<uint16_t>::max(),
+                 ("Can't store std::string greater then 65535 bytes", Dump()));
       uint16_t sz = static_cast<uint16_t>(str.size());
       writer.Write(&sz, sizeof(sz));
       writer.Write(str.data(), sz);
@@ -180,7 +180,7 @@ public:
   {
     ReaderSource<TReader> r(reader);
 
-    auto StringReader = [&r](string & str)
+    auto StringReader = [&r](std::string & str)
     {
       uint16_t sz = 0;
       r.Read(&sz, sizeof(sz));
@@ -209,7 +209,7 @@ public:
     uint64_t count = ReadVarUint<uint64_t>(r);
     for (uint64_t i = 0; i < count; ++i)
     {
-      pair<string, string> kv;
+      std::pair<std::string, std::string> kv;
       // decode key
       StringReader(kv.first);
       // decode value
@@ -218,16 +218,16 @@ public:
     }
   }
 
-  string ToString() const
+  std::string ToString() const
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << nodes.size() << " " << ways.size() << " " << tags.size();
     return ss.str();
   }
 
-  string Dump() const
+  std::string Dump() const
   {
-    stringstream ss;
+    std::stringstream ss;
     for (auto const & e : nodes)
       ss << "n{" << e.first << "," << e.second << "};";
     for (auto const & e : ways)
@@ -238,7 +238,7 @@ public:
   }
 
 protected:
-  bool FindRoleImpl(TMembers const & container, uint64_t id, string & role) const
+  bool FindRoleImpl(TMembers const & container, uint64_t id, std::string & role) const
   {
     for (auto const & e : container)
     {

--- a/generator/kml_parser.cpp
+++ b/generator/kml_parser.cpp
@@ -32,10 +32,10 @@ namespace kml
 
   class KmlParser
   {
-    vector<string> m_tags;
+    vector<std::string> m_tags;
     /// buffer for text with points
-    string m_data;
-    string m_name;
+    std::string m_data;
+    std::string m_name;
 
     PolygonsContainerT & m_country;
     int m_level;
@@ -43,10 +43,10 @@ namespace kml
   public:
     KmlParser(PolygonsContainerT & country, int level);
 
-    bool Push(string const & element);
-    void Pop(string const & element);
-    void AddAttr(string const &, string const &) {}
-    void CharData(string const & data);
+    bool Push(std::string const & element);
+    void Pop(std::string const & element);
+    void AddAttr(std::string const &, std::string const &) {}
+    void CharData(std::string const & data);
   };
 
   KmlParser::KmlParser(PolygonsContainerT & country, int level)
@@ -54,7 +54,7 @@ namespace kml
   {
   }
 
-  bool KmlParser::Push(string const & element)
+  bool KmlParser::Push(std::string const & element)
   {
     m_tags.push_back(element);
 
@@ -71,16 +71,16 @@ namespace kml
     {
     }
 
-    void operator()(string const & latLon)
+    void operator()(std::string const & latLon)
     {
       size_t const firstCommaPos = latLon.find(',');
-      CHECK(firstCommaPos != string::npos, ("invalid latlon", latLon));
-      string const lonStr = latLon.substr(0, firstCommaPos);
+      CHECK(firstCommaPos != std::string::npos, ("invalid latlon", latLon));
+      std::string const lonStr = latLon.substr(0, firstCommaPos);
       double lon;
       CHECK(utils::to_double(lonStr, lon), ("invalid lon", lonStr));
       size_t const secondCommaPos = latLon.find(',', firstCommaPos + 1);
-      string latStr;
-      if (secondCommaPos == string::npos)
+      std::string latStr;
+      if (secondCommaPos == std::string::npos)
         latStr = latLon.substr(firstCommaPos + 1);
       else
         latStr = latLon.substr(firstCommaPos + 1, secondCommaPos - firstCommaPos - 1);
@@ -117,7 +117,7 @@ namespace kml
         m_Triangles.push_back(triangles[i]);
     }
   };
-  void KmlParser::Pop(string const & element)
+  void KmlParser::Pop(std::string const & element)
   {
     if (element == "Placemark")
     {
@@ -198,7 +198,7 @@ namespace kml
     m_tags.pop_back();
   }
 
-  void KmlParser::CharData(string const & data)
+  void KmlParser::CharData(std::string const & data)
   {
     size_t const size = m_tags.size();
 
@@ -214,7 +214,7 @@ namespace kml
     }
   }
 
-  bool LoadPolygons(string const & kmlFile, PolygonsContainerT & country, int level)
+  bool LoadPolygons(std::string const & kmlFile, PolygonsContainerT & country, int level)
   {
     KmlParser parser(country, level);
     try

--- a/generator/kml_parser.hpp
+++ b/generator/kml_parser.hpp
@@ -6,5 +6,5 @@ class PolygonsContainerT;
 
 namespace kml
 {
-  bool LoadPolygons(string const & kmlFile, PolygonsContainerT & country, int level);
+  bool LoadPolygons(std::string const & kmlFile, PolygonsContainerT & country, int level);
 }

--- a/generator/opentable_dataset.cpp
+++ b/generator/opentable_dataset.cpp
@@ -8,16 +8,16 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/iomanip.hpp"
+#include <iomanip>
 
 #include "boost/algorithm/string/replace.hpp"
 
 namespace generator
 {
 // OpentableRestaurant ------------------------------------------------------------------------------
-OpentableRestaurant::OpentableRestaurant(string const & src)
+OpentableRestaurant::OpentableRestaurant(std::string const & src)
 {
-  vector<string> rec;
+  vector<std::string> rec;
   strings::ParseCSVRow(src, '\t', rec);
   CHECK_EQUAL(rec.size(), FieldsCount(), ("Error parsing restaurants.tsv line:",
                                           boost::replace_all_copy(src, "\t", "\\t")));
@@ -33,7 +33,7 @@ OpentableRestaurant::OpentableRestaurant(string const & src)
 
 ostream & operator<<(ostream & s, OpentableRestaurant const & h)
 {
-  s << fixed << setprecision(7);
+  s << std::fixed << std::setprecision(7);
   return s << "Id: " << h.m_id << "\t Name: " << h.m_name << "\t Address: " << h.m_address
            << "\t lat: " << h.m_latLon.lat << " lon: " << h.m_latLon.lon;
 }

--- a/generator/opentable_dataset.hpp
+++ b/generator/opentable_dataset.hpp
@@ -6,8 +6,8 @@
 
 #include "base/newtype.hpp"
 
-#include "std/limits.hpp"
-#include "std/string.hpp"
+#include <limits>
+#include <string>
 
 namespace generator
 {
@@ -32,10 +32,10 @@ struct OpentableRestaurant
 
   static constexpr ObjectId InvalidObjectId()
   {
-    return ObjectId(numeric_limits<typename ObjectId::RepType>::max());
+    return ObjectId(std::numeric_limits<typename ObjectId::RepType>::max());
   }
 
-  explicit OpentableRestaurant(string const & src);
+  explicit OpentableRestaurant(std::string const & src);
 
   static constexpr size_t FieldIndex(Fields field) { return static_cast<size_t>(field); }
   static constexpr size_t FieldsCount() { return static_cast<size_t>(Fields::Counter); }
@@ -44,12 +44,12 @@ struct OpentableRestaurant
 
   ObjectId m_id{InvalidObjectId()};
   ms::LatLon m_latLon = ms::LatLon::Zero();
-  string m_name;
-  string m_street;
-  string m_houseNumber;
+  std::string m_name;
+  std::string m_street;
+  std::string m_houseNumber;
 
-  string m_address;
-  string m_descUrl;
+  std::string m_address;
+  std::string m_descUrl;
   // string m_translations;
 };
 

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -7,11 +7,13 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/cctype.hpp"
-#include "std/cmath.hpp"
-#include "std/cstdlib.hpp"
-#include "std/unordered_set.hpp"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <unordered_set>
+
+using namespace std;
 
 namespace
 {
@@ -29,7 +31,7 @@ void RemoveDuplicatesAndKeepOrder(vector<T> & vec)
     seen.insert(value);
     return false;
   };
-  vec.erase(std::remove_if(vec.begin(), vec.end(), predicate), vec.end());
+  vec.erase(remove_if(vec.begin(), vec.end(), predicate), vec.end());
 }
 
 // Also filters out duplicates.

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -4,7 +4,7 @@
 #include "indexer/classificator.hpp"
 #include "indexer/ftypes_matcher.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 struct MetadataTagProcessorImpl
 {
@@ -13,28 +13,28 @@ struct MetadataTagProcessorImpl
   {
   }
 
-  string ValidateAndFormat_maxspeed(string const & v) const;
-  string ValidateAndFormat_stars(string const & v) const;
-  string ValidateAndFormat_cuisine(string v) const;
-  string ValidateAndFormat_operator(string const & v) const;
-  string ValidateAndFormat_url(string const & v) const;
-  string ValidateAndFormat_phone(string const & v) const;
-  string ValidateAndFormat_opening_hours(string const & v) const;
-  string ValidateAndFormat_ele(string const & v) const;
-  string ValidateAndFormat_turn_lanes(string const & v) const;
-  string ValidateAndFormat_turn_lanes_forward(string const & v) const;
-  string ValidateAndFormat_turn_lanes_backward(string const & v) const;
-  string ValidateAndFormat_email(string const & v) const;
-  string ValidateAndFormat_postcode(string const & v) const;
-  string ValidateAndFormat_flats(string const & v) const;
-  string ValidateAndFormat_internet(string v) const;
-  string ValidateAndFormat_height(string const & v) const;
-  string ValidateAndFormat_building_levels(string v) const;
-  string ValidateAndFormat_denomination(string const & v) const;
-  string ValidateAndFormat_wikipedia(string v) const;
-  string ValidateAndFormat_price_rate(string const & v) const;
-  string ValidateAndFormat_sponsored_id(string const & v) const;
-  string ValidateAndFormat_rating(string const & v) const;
+  std::string ValidateAndFormat_maxspeed(std::string const & v) const;
+  std::string ValidateAndFormat_stars(std::string const & v) const;
+  std::string ValidateAndFormat_cuisine(std::string v) const;
+  std::string ValidateAndFormat_operator(std::string const & v) const;
+  std::string ValidateAndFormat_url(std::string const & v) const;
+  std::string ValidateAndFormat_phone(std::string const & v) const;
+  std::string ValidateAndFormat_opening_hours(std::string const & v) const;
+  std::string ValidateAndFormat_ele(std::string const & v) const;
+  std::string ValidateAndFormat_turn_lanes(std::string const & v) const;
+  std::string ValidateAndFormat_turn_lanes_forward(std::string const & v) const;
+  std::string ValidateAndFormat_turn_lanes_backward(std::string const & v) const;
+  std::string ValidateAndFormat_email(std::string const & v) const;
+  std::string ValidateAndFormat_postcode(std::string const & v) const;
+  std::string ValidateAndFormat_flats(std::string const & v) const;
+  std::string ValidateAndFormat_internet(std::string v) const;
+  std::string ValidateAndFormat_height(std::string const & v) const;
+  std::string ValidateAndFormat_building_levels(std::string v) const;
+  std::string ValidateAndFormat_denomination(std::string const & v) const;
+  std::string ValidateAndFormat_wikipedia(std::string v) const;
+  std::string ValidateAndFormat_price_rate(std::string const & v) const;
+  std::string ValidateAndFormat_sponsored_id(std::string const & v) const;
+  std::string ValidateAndFormat_rating(std::string const & v) const;
 
 protected:
   FeatureParams & m_params;
@@ -48,7 +48,7 @@ public:
   /// Since it is used as a functor wich stops iteration in ftype::ForEachTag
   /// and the is no need for interrupting it always returns false.
   /// TODO(mgsergio): Move to cpp after merge with https://github.com/mapsme/omim/pull/1314
-  bool operator() (string const & k, string const & v)
+  bool operator() (std::string const & k, std::string const & v)
   {
     if (v.empty())
       return false;
@@ -69,7 +69,7 @@ public:
       return false;
     }
 
-    string valid;
+    std::string valid;
     switch (mdType)
     {
     case Metadata::FMD_CUISINE: valid = ValidateAndFormat_cuisine(v); break;

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -9,14 +9,16 @@
 #include "geometry/mercator.hpp"
 
 #include "base/assert.hpp"
+#include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/bind.hpp"
-#include "std/cstdint.hpp"
-#include "std/function.hpp"
-#include "std/initializer_list.hpp"
-#include "std/set.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <set>
+#include <vector>
+
+using namespace std;
 
 namespace ftype
 {
@@ -227,7 +229,7 @@ namespace ftype
     {
       Classificator const & c = classif();
 
-      StringIL arr[] =
+      my::StringIL arr[] =
       {
         {"entrance"}, {"highway"},
         {"building", "address"}, {"hwtag", "oneway"}, {"hwtag", "private"},
@@ -431,13 +433,13 @@ namespace ftype
     if (!isHighway || (surface.empty() && smoothness.empty()))
       return string();
 
-    static StringIL pavedSurfaces = {"paved", "asphalt", "cobblestone", "cobblestone:flattened",
-                                     "sett", "concrete", "concrete:lanes", "concrete:plates",
-                                     "paving_stones", "metal", "wood"};
-    static StringIL badSurfaces = {"cobblestone", "sett", "metal", "wood", "grass", "gravel",
-                                   "mud", "sand", "snow", "woodchips"};
-    static StringIL badSmoothness = {"bad", "very_bad", "horrible", "very_horrible", "impassable",
-                                     "robust_wheels", "high_clearance", "off_road_wheels", "rough"};
+    static my::StringIL pavedSurfaces = {"paved", "asphalt", "cobblestone", "cobblestone:flattened",
+                                         "sett", "concrete", "concrete:lanes", "concrete:plates",
+                                         "paving_stones", "metal", "wood"};
+    static my::StringIL badSurfaces = {"cobblestone", "sett", "metal", "wood", "grass", "gravel",
+                                       "mud", "sand", "snow", "woodchips"};
+    static my::StringIL badSmoothness = {"bad", "very_bad", "horrible", "very_horrible", "impassable",
+                                         "robust_wheels", "high_clearance", "off_road_wheels", "rough"};
 
     bool isPaved = false;
     bool isGood = true;

--- a/generator/osm_element.cpp
+++ b/generator/osm_element.cpp
@@ -3,11 +3,11 @@
 #include "base/string_utils.hpp"
 #include "coding/parse_xml.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/cstdio.hpp"
-#include "std/sstream.hpp"
+#include <algorithm>
+#include <cstdio>
+#include <sstream>
 
-string DebugPrint(OsmElement::EntityType e)
+std::string DebugPrint(OsmElement::EntityType e)
 {
   switch (e)
   {
@@ -31,7 +31,7 @@ string DebugPrint(OsmElement::EntityType e)
 }
 
 
-void OsmElement::AddTag(string const & k, string const & v)
+void OsmElement::AddTag(std::string const & k, std::string const & v)
 {
   // Seems like source osm data has empty values. They are useless for us.
   if (k.empty() || v.empty())
@@ -64,19 +64,19 @@ void OsmElement::AddTag(string const & k, string const & v)
   SKIP_KEY("official_name");
 #undef SKIP_KEY
 
-  string value = v;
+  std::string value = v;
   strings::Trim(value);
   m_tags.emplace_back(k, value);
 }
 
-string OsmElement::ToString(string const & shift) const
+std::string OsmElement::ToString(std::string const & shift) const
 {
-  stringstream ss;
+  std::stringstream ss;
   ss << (shift.empty() ? "\n" : shift);
   switch (type)
   {
     case EntityType::Node:
-      ss << "Node: " << id << " (" << fixed << setw(7) << lat << ", " << lon << ")"
+      ss << "Node: " << id << " (" << std::fixed << std::setw(7) << lat << ", " << lon << ")"
          << " tags: " << m_tags.size();
       break;
     case EntityType::Nd:
@@ -86,7 +86,7 @@ string OsmElement::ToString(string const & shift) const
       ss << "Way: " << id << " nds: " << m_nds.size() << " tags: " << m_tags.size();
       if (!m_nds.empty())
       {
-        string shift2 = shift;
+        std::string shift2 = shift;
         shift2 += shift2.empty() ? "\n  " : "  ";
         for (auto const & e : m_nds)
           ss << shift2 << e;
@@ -96,7 +96,7 @@ string OsmElement::ToString(string const & shift) const
       ss << "Relation: " << id << " members: " << m_members.size() << " tags: " << m_tags.size();
       if (!m_members.empty())
       {
-        string shift2 = shift;
+        std::string shift2 = shift;
         shift2 += shift2.empty() ? "\n  " : "  ";
         for (auto const & e : m_members)
           ss << shift2 << e.ref << " " << DebugPrint(e.type) << " " << e.role;
@@ -113,7 +113,7 @@ string OsmElement::ToString(string const & shift) const
   }
   if (!m_tags.empty())
   {
-    string shift2 = shift;
+    std::string shift2 = shift;
     shift2 += shift2.empty() ? "\n  " : "  ";
     for (auto const & e : m_tags)
       ss << shift2 << e.key << " = " << e.value;
@@ -121,9 +121,9 @@ string OsmElement::ToString(string const & shift) const
   return ss.str();
 }
 
-string OsmElement::GetTag(string const & key) const
+std::string OsmElement::GetTag(std::string const & key) const
 {
-  auto const it = find_if(begin(m_tags), end(m_tags), [&key](Tag const & tag)
+  auto const it = std::find_if(begin(m_tags), end(m_tags), [&key](Tag const & tag)
   {
     return tag.key == key;
   });
@@ -134,14 +134,14 @@ string OsmElement::GetTag(string const & key) const
   return it->value;
 }
 
-string DebugPrint(OsmElement const & e)
+std::string DebugPrint(OsmElement const & e)
 {
   return e.ToString();
 }
 
-string DebugPrint(OsmElement::Tag const & tag)
+std::string DebugPrint(OsmElement::Tag const & tag)
 {
-  stringstream ss;
+  std::stringstream ss;
   ss << tag.key << '=' << tag.value;
   return ss.str();
 }

--- a/generator/osm_element.hpp
+++ b/generator/osm_element.hpp
@@ -3,13 +3,13 @@
 #include "base/math.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/exception.hpp"
-#include "std/function.hpp"
-#include "std/iomanip.hpp"
-#include "std/iostream.hpp"
-#include "std/map.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 struct OsmElement
 {
@@ -29,10 +29,10 @@ struct OsmElement
   {
     uint64_t ref = 0;
     EntityType type = EntityType::Unknown;
-    string role;
+    std::string role;
 
     Member() = default;
-    Member(uint64_t ref, EntityType type, string const & role)
+    Member(uint64_t ref, EntityType type, std::string const & role)
     : ref(ref), type(type), role(role)
     {}
 
@@ -44,11 +44,11 @@ struct OsmElement
 
   struct Tag
   {
-    string key;
-    string value;
+    std::string key;
+    std::string value;
 
     Tag() = default;
-    Tag(string const & k, string const & v) : key(k), value(v) {}
+    Tag(std::string const & k, std::string const & v) : key(k), value(v) {}
 
     bool operator == (Tag const & e) const
     {
@@ -67,14 +67,14 @@ struct OsmElement
   double lon = 0;
   double lat = 0;
   uint64_t ref = 0;
-  string k;
-  string v;
+  std::string k;
+  std::string v;
   EntityType memberType = EntityType::Unknown;
-  string role;
+  std::string role;
 
-  vector<uint64_t> m_nds;
-  vector<Member> m_members;
-  vector<Tag> m_tags;
+  std::vector<uint64_t> m_nds;
+  std::vector<Member> m_members;
+  std::vector<Tag> m_tags;
 
   void Clear()
   {
@@ -93,13 +93,13 @@ struct OsmElement
     m_tags.clear();
   }
 
-  string ToString(string const & shift = string()) const;
+  std::string ToString(std::string const & shift = std::string()) const;
 
-  inline vector<uint64_t> const & Nodes() const { return m_nds; }
-  inline vector<Member> const & Members() const { return m_members; }
-  inline vector<Tag> const & Tags() const { return m_tags; }
+  inline std::vector<uint64_t> const & Nodes() const { return m_nds; }
+  inline std::vector<Member> const & Members() const { return m_members; }
+  inline std::vector<Tag> const & Tags() const { return m_tags; }
 
-  static EntityType StringToEntityType(string const & t)
+  static EntityType StringToEntityType(std::string const & t)
   {
     if (t == "way")
       return EntityType::Way;
@@ -130,13 +130,13 @@ struct OsmElement
   }
 
   void AddNd(uint64_t ref) { m_nds.emplace_back(ref); }
-  void AddMember(uint64_t ref, EntityType type, string const & role)
+  void AddMember(uint64_t ref, EntityType type, std::string const & role)
   {
     m_members.emplace_back(ref, type, role);
   }
 
-  void AddTag(string const & k, string const & v);
-  template <class TFn> void UpdateTag(string const & k, TFn && fn)
+  void AddTag(std::string const & k, std::string const & v);
+  template <class TFn> void UpdateTag(std::string const & k, TFn && fn)
   {
     for (auto & tag : m_tags)
     {
@@ -147,15 +147,15 @@ struct OsmElement
       }
     }
 
-    string v;
+    std::string v;
     fn(v);
     if (!v.empty())
       AddTag(k, v);
   }
 
-  string GetTag(string const & key) const;
+  std::string GetTag(std::string const & key) const;
 };
 
-string DebugPrint(OsmElement const & e);
-string DebugPrint(OsmElement::EntityType e);
-string DebugPrint(OsmElement::Tag const & tag);
+std::string DebugPrint(OsmElement const & e);
+std::string DebugPrint(OsmElement::EntityType e);
+std::string DebugPrint(OsmElement::Tag const & tag);

--- a/generator/osm_id.cpp
+++ b/generator/osm_id.cpp
@@ -2,7 +2,7 @@
 
 #include "base/assert.hpp"
 
-#include "std/sstream.hpp"
+#include <sstream>
 
 
 namespace osm
@@ -53,7 +53,7 @@ bool Id::IsRelation() const
   return ((m_encodedId & RELATION) == RELATION);
 }
 
-string Id::Type() const
+std::string Id::Type() const
 {
   if ((m_encodedId & RELATION) == RELATION)
     return "relation";
@@ -65,9 +65,9 @@ string Id::Type() const
     return "ERROR: Not initialized Osm ID";
 }
 
-string DebugPrint(osm::Id const & id)
+std::string DebugPrint(osm::Id const & id)
 {
-  ostringstream stream;
+  std::ostringstream stream;
   stream << id.Type() << " " << id.OsmId();
   return stream.str();
 }

--- a/generator/osm_id.hpp
+++ b/generator/osm_id.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "std/cstdint.hpp"
-#include "std/string.hpp"
+#include <cstdint>
+#include <string>
 
 
 namespace osm
@@ -26,7 +26,7 @@ public:
   bool IsRelation() const;
 
   /// For debug output
-  string Type() const;
+  std::string Type() const;
 
   inline bool operator<(Id const & other) const { return m_encodedId < other.m_encodedId; }
   inline bool operator==(Id const & other) const { return m_encodedId == other.m_encodedId; }
@@ -34,5 +34,5 @@ public:
   bool operator==(uint64_t other) const { return OsmId() == other; }
 };
 
-string DebugPrint(osm::Id const & id);
+std::string DebugPrint(osm::Id const & id);
 } // namespace osm

--- a/generator/osm_o5m_source.hpp
+++ b/generator/osm_o5m_source.hpp
@@ -1,25 +1,25 @@
 // See O5M Format definition at http://wiki.openstreetmap.org/wiki/O5m
 #pragma once
 
-#include "std/algorithm.hpp"
-#include "std/cstring.hpp"
-#include "std/exception.hpp"
-#include "std/function.hpp"
-#include "std/iomanip.hpp"
-#include "std/iostream.hpp"
-#include "std/iterator.hpp"
-#include "std/sstream.hpp"
-#include "std/type_traits.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <type_traits>
+#include <vector>
 
-using TReadFunc = function<size_t(uint8_t *, size_t)>;
+using TReadFunc = std::function<size_t(uint8_t *, size_t)>;
 
 namespace
 {
 
 class StreamBuffer
 {
-  using TBuffer = vector<uint8_t>;
+  using TBuffer = std::vector<uint8_t>;
 
   TReadFunc m_reader;
   TBuffer m_buffer;
@@ -59,7 +59,7 @@ public:
 
   void Skip(size_t size = 1)
   {
-    size_t const bytesLeft = distance(m_position, m_buffer.cend());
+    size_t const bytesLeft = std::distance(m_position, m_buffer.cend());
     if (size >= bytesLeft)
     {
       size -= bytesLeft;
@@ -72,10 +72,10 @@ public:
 
   void Read(TBuffer::value_type * dest, size_t size)
   {
-    size_t const bytesLeft = distance(m_position, m_buffer.cend());
+    size_t const bytesLeft = std::distance(m_position, m_buffer.cend());
     if (size >= bytesLeft)
     {
-      size_t const index = distance(m_buffer.cbegin(), m_position);
+      size_t const index = std::distance(m_buffer.cbegin(), m_position);
       memmove(dest, &m_buffer[index], bytesLeft);
       size -= bytesLeft;
       dest += bytesLeft;
@@ -86,7 +86,7 @@ public:
         Refill();
       }
     }
-    size_t const index = distance(m_buffer.cbegin(), m_position);
+    size_t const index = std::distance(m_buffer.cbegin(), m_position);
     memmove(dest, &m_buffer[index], size);
     m_position += size;
   }
@@ -98,7 +98,7 @@ private:
       m_buffer.resize(m_maxBufferSize);
 
     size_t const readBytes = m_reader(m_buffer.data(), m_buffer.size());
-    CHECK_NOT_EQUAL(readBytes, 0, ("Unexpected end input stream."));
+    CHECK_NOT_EQUAL(readBytes, 0, ("Unexpected std::end input stream."));
 
     if (readBytes != m_buffer.size())
       m_buffer.resize(readBytes);
@@ -128,7 +128,7 @@ public:
     Reset = 0xff
   };
 
-  friend ostream & operator << (ostream & s, EntityType const & type)
+  friend std::ostream & operator << (std::ostream & s, EntityType const & type)
   {
     switch (type)
     {
@@ -143,7 +143,7 @@ public:
       case EntityType::Jump:      s << "O5M_CMD_JUMP";
       case EntityType::Reset:     s << "O5M_CMD_RESET";
       default:
-        return s << "Unknown command: " << hex << static_cast<typename underlying_type<EntityType>::type>(type);
+        return s << "Unknown command: " << std::hex << static_cast<typename std::underlying_type<EntityType>::type>(type);
     }
     return s;
   }
@@ -177,8 +177,8 @@ protected:
     char const * role = nullptr;
   };
 
-  vector<StringTableRecord> m_stringTable;
-  vector<char> m_stringBuffer;
+  std::vector<StringTableRecord> m_stringTable;
+  std::vector<char> m_stringBuffer;
   size_t m_stringCurrentIndex;
   StreamBuffer m_buffer;
   size_t m_remainder;
@@ -197,7 +197,7 @@ public:
   template <typename TValue>
   class SubElements
   {
-    using TSubElementGetter = function<O5MSource *(TValue *)>;
+    using TSubElementGetter = std::function<O5MSource *(TValue *)>;
 
     O5MSource * m_reader;
     TSubElementGetter m_func;
@@ -584,7 +584,7 @@ public:
   {
     if (EntityType::Reset != EntityType(m_buffer.Get()))
     {
-      throw runtime_error("Incorrect o5m start");
+      throw std::runtime_error("Incorrect o5m start");
     }
     CheckHeader();
     InitStringTable();
@@ -595,7 +595,7 @@ public:
     size_t const len = 4;
     if (EntityType::Header == EntityType(m_buffer.Get()) && ReadVarUInt() == len)
     {
-      string sign(len, ' ');
+      std::string sign(len, ' ');
       m_buffer.Read(reinterpret_cast<uint8_t *>(&sign[0]), len);
       if (sign == "o5m2" || sign == "o5c2")
         return true;
@@ -603,7 +603,7 @@ public:
     return false;
   }
 
-  friend ostream & operator<<(ostream & s, O5MSource::Entity const & em)
+  friend std::ostream & operator<<(std::ostream & s, O5MSource::Entity const & em)
   {
     s << EntityType(em.type) << " ID: " << em.id;
     if (em.version)
@@ -617,7 +617,7 @@ public:
     }
     if (em.type == EntityType::Node)
     {
-      s << endl << " lon: " << em.lon << " lat: " << em.lat;
+      s << std::endl << " lon: " << em.lon << " lat: " << em.lat;
     }
     return s;
   }

--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -29,6 +29,8 @@
 
 #include "defines.hpp"
 
+using namespace std;
+
 SourceReader::SourceReader()
 : m_file(unique_ptr<istream, Deleter>(&cin, Deleter(false)))
 {
@@ -336,7 +338,7 @@ public:
           new feature::FeaturesCollector(info.GetTmpFileName(WORLD_COASTS_FILE_NAME)));
 
     if (info.m_splitByPolygons || !info.m_fileName.empty())
-      m_countries = make_unique<TCountriesGenerator>(info);
+      m_countries = my::make_unique<TCountriesGenerator>(info);
 
     if (info.m_createWorld)
       m_world.reset(new TWorldGenerator(info));
@@ -527,7 +529,7 @@ private:
 unique_ptr<EmitterBase> MakeMainFeatureEmitter(feature::GenerateInfo const & info)
 {
   LOG(LINFO, ("Processing booking data from", info.m_bookingDatafileName, "done."));
-  return make_unique<MainFeaturesEmitter>(info);
+  return my::make_unique<MainFeaturesEmitter>(info);
 }
 
 template <typename TElement, typename TCache>

--- a/generator/osm_source.hpp
+++ b/generator/osm_source.hpp
@@ -3,12 +3,12 @@
 #include "generator/generate_info.hpp"
 #include "generator/osm_element.hpp"
 
-#include "std/function.hpp"
-#include "std/iostream.hpp"
-#include "std/string.hpp"
-#include "std/sstream.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 class SourceReader
 {
@@ -16,19 +16,19 @@ class SourceReader
   {
     bool m_needDelete;
     Deleter(bool needDelete = true) : m_needDelete(needDelete) {}
-    void operator()(istream * s) const
+    void operator()(std::istream * s) const
     {
       if (m_needDelete)
         delete s;
     }
   };
 
-  unique_ptr<istream, Deleter> m_file;
+  std::unique_ptr<std::istream, Deleter> m_file;
 
 public:
   SourceReader();
-  explicit SourceReader(string const & filename);
-  explicit SourceReader(istringstream & stream);
+  explicit SourceReader(std::string const & filename);
+  explicit SourceReader(std::istringstream & stream);
 
   uint64_t Read(char * buffer, uint64_t bufferSize);
 };
@@ -48,16 +48,16 @@ public:
   virtual bool Finish() { return true; }
   /// Sets buckets (mwm names).
   // TODO(syershov): Make this topic clear.
-  virtual void GetNames(vector<string> & names) const = 0;
+  virtual void GetNames(std::vector<std::string> & names) const = 0;
 };
 
-unique_ptr<EmitterBase> MakeMainFeatureEmitter(feature::GenerateInfo const & info);
+std::unique_ptr<EmitterBase> MakeMainFeatureEmitter(feature::GenerateInfo const & info);
 
-using EmitterFactory = function<unique_ptr<EmitterBase>(feature::GenerateInfo const &)>;
+using EmitterFactory = std::function<std::unique_ptr<EmitterBase>(feature::GenerateInfo const &)>;
 
 bool GenerateFeatures(feature::GenerateInfo & info,
                       EmitterFactory factory = MakeMainFeatureEmitter);
 bool GenerateIntermediateData(feature::GenerateInfo & info);
 
-void ProcessOsmElementsFromO5M(SourceReader & stream, function<void(OsmElement *)> processor);
-void ProcessOsmElementsFromXML(SourceReader & stream, function<void(OsmElement *)> processor);
+void ProcessOsmElementsFromO5M(SourceReader & stream, std::function<void(OsmElement *)> processor);
+void ProcessOsmElementsFromXML(SourceReader & stream, std::function<void(OsmElement *)> processor);

--- a/generator/osm_translator.hpp
+++ b/generator/osm_translator.hpp
@@ -19,10 +19,10 @@
 #include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/list.hpp"
-#include "std/type_traits.hpp"
-#include "std/unordered_set.hpp"
-#include "std/vector.hpp"
+#include <list>
+#include <type_traits>
+#include <unordered_set>
+#include <vector>
 
 namespace
 {
@@ -55,13 +55,13 @@ public:
   }
 
 protected:
-  static bool IsSkipRelation(string const & type)
+  static bool IsSkipRelation(std::string const & type)
   {
     /// @todo Skip special relation types.
     return (type == "multipolygon" || type == "bridge");
   }
 
-  bool IsKeyTagExists(string const & key) const
+  bool IsKeyTagExists(std::string const & key) const
   {
     for (auto const & p : m_current->m_tags)
       if (p.key == key)
@@ -69,7 +69,7 @@ protected:
     return false;
   }
 
-  void AddCustomTag(pair<string, string> const & p)
+  void AddCustomTag(pair<std::string, std::string> const & p)
   {
     m_current->AddTag(p.first, p.second);
   }
@@ -95,7 +95,7 @@ public:
 protected:
   void Process(RelationElement const & e) override
   {
-    string const & type = e.GetType();
+    std::string const & type = e.GetType();
     if (TBase::IsSkipRelation(type))
       return;
 
@@ -137,11 +137,11 @@ public:
 
 private:
   using TBase = RelationTagsBase;
-  using TNameKeys = unordered_set<string>;
+  using TNameKeys = std::unordered_set<std::string>;
 
   bool IsAcceptBoundary(RelationElement const & e) const
   {
-    string role;
+    std::string role;
     CHECK(e.FindWay(TBase::m_featureID, role), (TBase::m_featureID));
 
     // Do not accumulate boundary types (boundary=administrative) for inner polygons.
@@ -154,7 +154,7 @@ protected:
   {
     /// @todo Review route relations in future.
     /// Actually, now they give a lot of dummy tags.
-    string const & type = e.GetType();
+    std::string const & type = e.GetType();
     if (TBase::IsSkipRelation(type))
       return;
 
@@ -163,13 +163,13 @@ protected:
       if (e.GetTagValue("route") == "road")
       {
         // Append "network/ref" to the feature ref tag.
-        string ref = e.GetTagValue("ref");
+        std::string ref = e.GetTagValue("ref");
         if (!ref.empty())
         {
-          string const & network = e.GetTagValue("network");
-          if (!network.empty() && network.find('/') == string::npos)
+          std::string const & network = e.GetTagValue("network");
+          if (!network.empty() && network.find('/') == std::string::npos)
             ref = network + '/' + ref;
-          string const & refBase = m_current->GetTag("ref");
+          std::string const & refBase = m_current->GetTag("ref");
           if (!refBase.empty())
             ref = refBase + ';' + ref;
           TBase::AddCustomTag({"ref", std::move(ref)});
@@ -250,7 +250,7 @@ class OsmToFeatureTranslator
     FeatureBuilder1::TGeometry & GetHoles()
     {
       ASSERT(m_holes.empty(), ("Can call only once"));
-      m_merger.ForEachArea(false, [this](FeatureBuilder1::TPointSeq & v, vector<uint64_t> const &)
+      m_merger.ForEachArea(false, [this](FeatureBuilder1::TPointSeq & v, std::vector<uint64_t> const &)
       {
         m_holes.push_back(FeatureBuilder1::TPointSeq());
         m_holes.back().swap(v);
@@ -273,7 +273,7 @@ class OsmToFeatureTranslator
     {
       if (e.GetType() != "multipolygon")
         return false;
-      string role;
+      std::string role;
       if (e.FindWay(m_id, role) && (role == "outer"))
       {
         e.ForEachWay(*this);
@@ -284,7 +284,7 @@ class OsmToFeatureTranslator
     }
 
     /// 2. "ways in relation" process function
-    void operator() (uint64_t id, string const & role)
+    void operator() (uint64_t id, std::string const & role)
     {
       if (id != m_id && role == "inner")
         m_holes(id);
@@ -321,7 +321,7 @@ class OsmToFeatureTranslator
     ft.SetParams(params);
     if (ft.PreSerialize())
     {
-      string addr;
+      std::string addr;
       if (m_addrWriter && ftypes::IsBuildingChecker::Instance()(params.m_Types) &&
           ft.FormatFullAddress(addr))
       {
@@ -503,7 +503,7 @@ public:
         }
 
         auto const & holesGeometry = holes.GetHoles();
-        outer.ForEachArea(true, [&] (FeatureBuilder1::TPointSeq const & pts, vector<uint64_t> const & ids)
+        outer.ForEachArea(true, [&] (FeatureBuilder1::TPointSeq const & pts, std::vector<uint64_t> const & ids)
         {
           FeatureBuilder1 ft;
 
@@ -542,8 +542,8 @@ public:
 
 public:
   OsmToFeatureTranslator(TEmitter & emitter, TCache & holder, uint32_t coastType,
-                         string const & addrFilePath = {}, string const & restrictionsFilePath = {},
-                         string const & roadAccessFilePath = {})
+                         std::string const & addrFilePath = {}, std::string const & restrictionsFilePath = {},
+                         std::string const & roadAccessFilePath = {})
     : m_emitter(emitter)
     , m_holder(holder)
     , m_coastType(coastType)

--- a/generator/osm_xml_source.hpp
+++ b/generator/osm_xml_source.hpp
@@ -16,9 +16,9 @@ class XMLSource
 public:
   XMLSource(TEmmiterFn fn) : m_EmmiterFn(fn) {}
 
-  void CharData(string const &) {}
+  void CharData(std::string const &) {}
 
-  void AddAttr(string const & key, string const & value)
+  void AddAttr(std::string const & key, std::string const & value)
   {
     if (!m_current)
       return;
@@ -41,7 +41,7 @@ public:
       m_current->role = value;
   }
 
-  bool Push(string const & tagName)
+  bool Push(std::string const & tagName)
   {
     ASSERT_GREATER_OR_EQUAL(tagName.size(), 2, ());
 
@@ -64,7 +64,7 @@ public:
     return true;
   }
 
-  void Pop(string const & v)
+  void Pop(std::string const & v)
   {
     switch (--m_depth)
     {

--- a/generator/polygonizer.hpp
+++ b/generator/polygonizer.hpp
@@ -16,7 +16,7 @@
 #include "base/buffer_vector.hpp"
 #include "base/macros.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 #ifndef PARALLEL_POLYGONIZER
 #define PARALLEL_POLYGONIZER 1
@@ -38,7 +38,7 @@ namespace feature
     feature::GenerateInfo const & m_info;
 
     vector<FeatureOutT*> m_Buckets;
-    vector<string> m_Names;
+    vector<std::string> m_Names;
     borders::CountriesContainerT m_countries;
 
 #if PARALLEL_POLYGONIZER
@@ -86,7 +86,8 @@ namespace feature
 
       bool operator()(m2::PointD const & pt)
       {
-        m_regions.ForEachInRect(m2::RectD(pt, pt), bind<void>(ref(*this), _1, cref(pt)));
+        m_regions.ForEachInRect(m2::RectD(pt, pt),
+                                std::bind<void>(std::ref(*this), std::placeholders::_1, std::cref(pt)));
         return !m_belongs;
       }
 
@@ -133,7 +134,7 @@ namespace feature
       }
     }
 
-    string m_currentNames;
+    std::string m_currentNames;
 
     void Start()
     {
@@ -168,7 +169,7 @@ namespace feature
       bucket(fb);
     }
 
-    vector<string> const & Names() const
+    vector<std::string> const & Names() const
     {
       return m_Names;
     }

--- a/generator/region_meta.cpp
+++ b/generator/region_meta.cpp
@@ -8,7 +8,7 @@
 
 namespace
 {
-int8_t ParseHolidayReference(string const & ref)
+int8_t ParseHolidayReference(std::string const & ref)
 {
   if (ref == "easter")
     return feature::RegionData::PHReference::PH_EASTER;
@@ -24,12 +24,12 @@ int8_t ParseHolidayReference(string const & ref)
 
 namespace feature
 {
-bool ReadRegionDataImpl(string const & countryName, RegionData & data)
+bool ReadRegionDataImpl(std::string const & countryName, RegionData & data)
 {
   try
   {
     auto reader = GetPlatform().GetReader(COUNTRIES_META_FILE);
-    string buffer;
+    std::string buffer;
     reader->ReadAsString(buffer);
     my::Json root(buffer.data());
 
@@ -38,17 +38,17 @@ bool ReadRegionDataImpl(string const & countryName, RegionData & data)
     if (!jsonData)
       return false;
 
-    vector<string> languages;
+    vector<std::string> languages;
     FromJSONObjectOptionalField(jsonData, "languages", languages);
     if (!languages.empty())
       data.SetLanguages(languages);
 
-    string driving;
+    std::string driving;
     FromJSONObjectOptionalField(jsonData, "driving", driving);
     if (driving == "l" || driving == "r")
       data.Set(RegionData::Type::RD_DRIVING, driving);
 
-    string timezone;
+    std::string timezone;
     FromJSONObjectOptionalField(jsonData, "timezone", timezone);
     if (!timezone.empty())
       data.Set(RegionData::Type::RD_TIMEZONE, timezone);
@@ -74,12 +74,12 @@ bool ReadRegionDataImpl(string const & countryName, RegionData & data)
       }
       else if (json_is_string(reference))
       {
-        refId = ParseHolidayReference(string(json_string_value(reference)));
+        refId = ParseHolidayReference(std::string(json_string_value(reference)));
       }
       else
       {
         MYTHROW(my::Json::Exception,
-                ("Holiday month reference should be either a string or a number in", countryName));
+                ("Holiday month reference should be either a std::string or a number in", countryName));
       }
 
       if (refId <= 0)
@@ -104,7 +104,7 @@ bool ReadRegionDataImpl(string const & countryName, RegionData & data)
   return false;
 }
 
-bool ReadRegionData(string const & countryName, RegionData & data)
+bool ReadRegionData(std::string const & countryName, RegionData & data)
 {
   // When there is a match for a complete countryName, simply relay the call.
   if (ReadRegionDataImpl(countryName, data))
@@ -112,11 +112,11 @@ bool ReadRegionData(string const & countryName, RegionData & data)
 
   // If not, cut parts of a country name from the tail. E.g. "Russia_Moscow" -> "Russia".
   auto p = countryName.find_last_of('_');
-  while (p != string::npos)
+  while (p != std::string::npos)
   {
     if (ReadRegionDataImpl(countryName.substr(0, p), data))
       return true;
-    p = p > 0 ? countryName.find_last_of('_', p - 1) : string::npos;
+    p = p > 0 ? countryName.find_last_of('_', p - 1) : std::string::npos;
   }
   return false;
 }

--- a/generator/region_meta.hpp
+++ b/generator/region_meta.hpp
@@ -6,5 +6,5 @@
 
 namespace feature
 {
-bool ReadRegionData(string const & countryName, RegionData & data);
+bool ReadRegionData(std::string const & countryName, RegionData & data);
 }  // namespace feature

--- a/generator/restaurants_info/restaurants_info.cpp
+++ b/generator/restaurants_info/restaurants_info.cpp
@@ -9,13 +9,14 @@
 #include "geometry/mercator.hpp"
 
 #include "base/logging.hpp"
+#include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/fstream.hpp"
-#include "std/sstream.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <vector>
 
 #include "gflags/gflags.h"
 
@@ -27,7 +28,7 @@ namespace
 class Emitter : public EmitterBase
 {
 public:
-  Emitter(vector<FeatureBuilder1> & features)
+  Emitter(std::vector<FeatureBuilder1> & features)
     : m_features(features)
   {
     LOG_SHORT(LINFO, ("OSM data:", FLAGS_osm));
@@ -51,7 +52,7 @@ public:
     m_features.emplace_back(fb);
   }
 
-  void GetNames(vector<string> & names) const override
+  void GetNames(std::vector<std::string> & names) const override
   {
     // We do not need to create any data file. See generator_tool.cpp and osm_source.cpp.
     names.clear();
@@ -67,7 +68,7 @@ public:
   }
 
 private:
-  vector<FeatureBuilder1> & m_features;
+  std::vector<FeatureBuilder1> & m_features;
 
   struct Stats
   {
@@ -94,15 +95,15 @@ feature::GenerateInfo GetGenerateInfo()
   return info;
 }
 
-void DumpRestaurants(vector<FeatureBuilder1> const & features, ostream & out)
+void DumpRestaurants(std::vector<FeatureBuilder1> const & features, ostream & out)
 {
   for (auto const & f : features)
   {
     auto const multilangName = f.GetParams().name;
 
-    string defaultName;
-    vector<string> translations;
-    multilangName.ForEach([&translations, &defaultName](uint8_t const langCode, string const & name)
+    std::string defaultName;
+    std::vector<std::string> translations;
+    multilangName.ForEach([&translations, &defaultName](uint8_t const langCode, std::string const & name)
     {
       if (langCode == StringUtf8Multilang::kDefaultCode)
       {
@@ -140,14 +141,14 @@ int main(int argc, char * argv[])
   auto info = GetGenerateInfo();
   GenerateIntermediateData(info);
 
-  vector<FeatureBuilder1> features;
+  std::vector<FeatureBuilder1> features;
   GenerateFeatures(info, [&features](feature::GenerateInfo const & /* info */)
   {
-    return make_unique<Emitter>(features);
+    return my::make_unique<Emitter>(features);
   });
 
   {
-    ofstream ost(FLAGS_out);
+    std::ofstream ost(FLAGS_out);
     CHECK(ost.is_open(), ("Can't open file", FLAGS_out, strerror(errno)));
     DumpRestaurants(features, ost);
   }

--- a/generator/restaurants_info/restaurants_info.cpp
+++ b/generator/restaurants_info/restaurants_info.cpp
@@ -95,7 +95,7 @@ feature::GenerateInfo GetGenerateInfo()
   return info;
 }
 
-void DumpRestaurants(std::vector<FeatureBuilder1> const & features, ostream & out)
+void DumpRestaurants(std::vector<FeatureBuilder1> const & features, std::ostream & out)
 {
   for (auto const & f : features)
   {

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -8,8 +8,8 @@
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/fstream.hpp"
+#include <algorithm>
+#include <fstream>
 
 namespace
 {
@@ -17,7 +17,7 @@ char const kNo[] = "No";
 char const kOnly[] = "Only";
 char const kDelim[] = ", \t\r\n";
 
-bool ParseLineOfWayIds(strings::SimpleTokenizer & iter, vector<osm::Id> & numbers)
+bool ParseLineOfWayIds(strings::SimpleTokenizer & iter, std::vector<osm::Id> & numbers)
 {
   uint64_t number = 0;
   for (; iter; ++iter)
@@ -32,8 +32,8 @@ bool ParseLineOfWayIds(strings::SimpleTokenizer & iter, vector<osm::Id> & number
 
 namespace routing
 {
-RestrictionCollector::RestrictionCollector(string const & restrictionPath,
-                                           string const & osmIdsToFeatureIdPath)
+RestrictionCollector::RestrictionCollector(std::string const & restrictionPath,
+                                           std::string const & osmIdsToFeatureIdPath)
 {
   MY_SCOPE_GUARD(clean, [this](){
     m_osmIdToFeatureId.clear();
@@ -63,18 +63,18 @@ RestrictionCollector::RestrictionCollector(string const & restrictionPath,
 
 bool RestrictionCollector::IsValid() const
 {
-  return find_if(begin(m_restrictions), end(m_restrictions),
+  return std::find_if(begin(m_restrictions), end(m_restrictions),
                  [](Restriction const & r) { return !r.IsValid(); }) == end(m_restrictions);
 }
 
-bool RestrictionCollector::ParseRestrictions(string const & path)
+bool RestrictionCollector::ParseRestrictions(std::string const & path)
 {
-  ifstream stream(path);
+  std::ifstream stream(path);
   if (stream.fail())
     return false;
 
-  string line;
-  while (getline(stream, line))
+  std::string line;
+  while (std::getline(stream, line))
   {
     strings::SimpleTokenizer iter(line, kDelim);
     if (!iter)  // the line is empty
@@ -88,7 +88,7 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
     }
 
     ++iter;
-    vector<osm::Id> osmIds;
+    std::vector<osm::Id> osmIds;
     if (!ParseLineOfWayIds(iter, osmIds))
     {
       LOG(LWARNING, ("Cannot parse osm ids from", path));
@@ -100,9 +100,9 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
   return true;
 }
 
-bool RestrictionCollector::AddRestriction(Restriction::Type type, vector<osm::Id> const & osmIds)
+bool RestrictionCollector::AddRestriction(Restriction::Type type, std::vector<osm::Id> const & osmIds)
 {
-  vector<uint32_t> featureIds(osmIds.size());
+  std::vector<uint32_t> featureIds(osmIds.size());
   for (size_t i = 0; i < osmIds.size(); ++i)
   {
     auto const result = m_osmIdToFeatureId.find(osmIds[i]);
@@ -126,7 +126,7 @@ void RestrictionCollector::AddFeatureId(uint32_t featureId, osm::Id osmId)
   ::routing::AddFeatureId(osmId, featureId, m_osmIdToFeatureId);
 }
 
-bool FromString(string str, Restriction::Type & type)
+bool FromString(std::string str, Restriction::Type & type)
 {
   if (str == kNo)
   {

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -4,12 +4,12 @@
 
 #include "routing/restrictions_serialization.hpp"
 
-#include "std/functional.hpp"
-#include "std/limits.hpp"
-#include "std/map.hpp"
-#include "std/string.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <functional>
+#include <limits>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace routing
 {
@@ -21,7 +21,7 @@ public:
   RestrictionCollector() = default;
   /// \param restrictionPath full path to file with road restrictions in osm id terms.
   /// \param osmIdsToFeatureIdsPath full path to file with mapping from osm ids to feature ids.
-  RestrictionCollector(string const & restrictionPath, string const & osmIdsToFeatureIdsPath);
+  RestrictionCollector(std::string const & restrictionPath, std::string const & osmIdsToFeatureIdsPath);
 
   bool HasRestrictions() const { return !m_restrictions.empty(); }
 
@@ -45,7 +45,7 @@ private:
   /// No, 157616940, 157616940,
   /// No, 157616940, 157617107,
   /// \param path path to the text file with restrictions.
-  bool ParseRestrictions(string const & path);
+  bool ParseRestrictions(std::string const & path);
 
   /// \brief Adds feature id and corresponding |osmId| to |m_osmIdToFeatureId|.
   void AddFeatureId(uint32_t featureId, osm::Id osmId);
@@ -56,11 +56,11 @@ private:
   /// \note This method should be called to add a restriction when feature ids of the restriction
   /// are unknown. The feature ids should be set later with a call of |SetFeatureId(...)| method.
   /// \returns true if restriction is add and false otherwise.
-  bool AddRestriction(Restriction::Type type, vector<osm::Id> const & osmIds);
+  bool AddRestriction(Restriction::Type type, std::vector<osm::Id> const & osmIds);
 
   RestrictionVec m_restrictions;
-  map<osm::Id, uint32_t> m_osmIdToFeatureId;
+  std::map<osm::Id, uint32_t> m_osmIdToFeatureId;
 };
 
-bool FromString(string str, Restriction::Type & type);
+bool FromString(std::string str, Restriction::Type & type);
 }  // namespace routing

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -32,7 +32,8 @@ bool BuildRoadRestrictions(std::string const & mwmPath, std::string const & rest
 
   auto const firstOnlyIt =
       std::lower_bound(restrictions.cbegin(), restrictions.cend(),
-                  Restriction(Restriction::Type::Only, {} /* links */), my::LessBy(&Restriction::m_type));
+                       Restriction(Restriction::Type::Only, {} /* links */),
+                       my::LessBy(&Restriction::m_type));
 
   RestrictionHeader header;
   header.m_noRestrictionCount = base::checked_cast<uint32_t>(std::distance(restrictions.cbegin(), firstOnlyIt));

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -11,12 +11,12 @@
 
 #include "defines.hpp"
 
-#include "std/algorithm.hpp"
+#include <algorithm>
 
 namespace routing
 {
-bool BuildRoadRestrictions(string const & mwmPath, string const & restrictionPath,
-                           string const & osmIdsTofeatureIdsPath)
+bool BuildRoadRestrictions(std::string const & mwmPath, std::string const & restrictionPath,
+                           std::string const & osmIdsTofeatureIdsPath)
 {
   LOG(LINFO, ("BuildRoadRestrictions(", mwmPath, ", ", restrictionPath, ", ",
               osmIdsTofeatureIdsPath, ");"));
@@ -31,11 +31,11 @@ bool BuildRoadRestrictions(string const & mwmPath, string const & restrictionPat
   RestrictionVec const & restrictions = restrictionCollector.GetRestrictions();
 
   auto const firstOnlyIt =
-      lower_bound(restrictions.cbegin(), restrictions.cend(),
+      std::lower_bound(restrictions.cbegin(), restrictions.cend(),
                   Restriction(Restriction::Type::Only, {} /* links */), my::LessBy(&Restriction::m_type));
 
   RestrictionHeader header;
-  header.m_noRestrictionCount = base::checked_cast<uint32_t>(distance(restrictions.cbegin(), firstOnlyIt));
+  header.m_noRestrictionCount = base::checked_cast<uint32_t>(std::distance(restrictions.cbegin(), firstOnlyIt));
   header.m_onlyRestrictionCount = base::checked_cast<uint32_t>(restrictions.size() - header.m_noRestrictionCount);
 
   LOG(LINFO, ("Header info. There are", header.m_noRestrictionCount, "restrictions of type No and",

--- a/generator/restriction_generator.hpp
+++ b/generator/restriction_generator.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace routing
 {
@@ -29,6 +29,6 @@ namespace routing
 /// \param osmIdsToFeatureIdsPath a binary file with mapping form osm ids to feature ids.
 /// One osm id is mapped to one feature id. The file should be saved with the help of
 /// OsmID2FeatureID class or using a similar way.
-bool BuildRoadRestrictions(string const & mwmPath, string const & restrictionPath,
-                           string const & osmIdsToFeatureIdsPath);
+bool BuildRoadRestrictions(std::string const & mwmPath, std::string const & restrictionPath,
+                           std::string const & osmIdsToFeatureIdsPath);
 }  // namespace routing

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -8,17 +8,17 @@
 
 #include "base/logging.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/fstream.hpp"
-#include "std/string.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {
 using namespace routing;
 
-vector<pair<string, Restriction::Type>> const kRestrictionTypes =
+vector<std::pair<std::string, Restriction::Type>> const kRestrictionTypes =
   {{"no_right_turn", Restriction::Type::No},  {"no_left_turn", Restriction::Type::No},
    {"no_u_turn", Restriction::Type::No}, {"no_straight_on", Restriction::Type::No},
    {"no_entry", Restriction::Type::No}, {"no_exit", Restriction::Type::No},
@@ -27,10 +27,10 @@ vector<pair<string, Restriction::Type>> const kRestrictionTypes =
 
 /// \brief Converts restriction type form string to RestrictionCollector::Type.
 /// \returns true if conversion was successful and false otherwise.
-bool TagToType(string const & tag, Restriction::Type & type)
+bool TagToType(std::string const & tag, Restriction::Type & type)
 {
-  auto const it = find_if(kRestrictionTypes.cbegin(), kRestrictionTypes.cend(),
-                          [&tag](pair<string, Restriction::Type> const & v) {
+  auto const it = std::find_if(kRestrictionTypes.cbegin(), kRestrictionTypes.cend(),
+                          [&tag](std::pair<std::string, Restriction::Type> const & v) {
     return v.first == tag;
   });
   if (it == kRestrictionTypes.cend())
@@ -43,7 +43,7 @@ bool TagToType(string const & tag, Restriction::Type & type)
 
 namespace routing
 {
-void RestrictionWriter::Open(string const & fullPath)
+void RestrictionWriter::Open(std::string const & fullPath)
 {
   LOG(LINFO, ("Saving road restrictions in osm id terms to", fullPath));
   m_stream.open(fullPath, std::ofstream::out);
@@ -67,10 +67,10 @@ void RestrictionWriter::Write(RelationElement const & relationElement)
     return;  // Unsupported restriction. For example line-line-line.
 
   // Extracting osm ids of lines and points of the restriction.
-  auto const findTag = [&relationElement](vector<pair<uint64_t, string>> const & members,
-                                          string const & tag) {
-    auto const it = find_if(members.cbegin(), members.cend(),
-                            [&tag](pair<uint64_t, string> const & p) { return p.second == tag; });
+  auto const findTag = [&relationElement](std::vector<std::pair<uint64_t, std::string>> const & members,
+                                          std::string const & tag) {
+    auto const it = std::find_if(members.cbegin(), members.cend(),
+                            [&tag](std::pair<uint64_t, std::string> const & p) { return p.second == tag; });
     return it;
   };
 

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -18,7 +18,7 @@ namespace
 {
 using namespace routing;
 
-vector<std::pair<std::string, Restriction::Type>> const kRestrictionTypes =
+std::vector<std::pair<std::string, Restriction::Type>> const kRestrictionTypes =
   {{"no_right_turn", Restriction::Type::No},  {"no_left_turn", Restriction::Type::No},
    {"no_u_turn", Restriction::Type::No}, {"no_straight_on", Restriction::Type::No},
    {"no_entry", Restriction::Type::No}, {"no_exit", Restriction::Type::No},

--- a/generator/restriction_writer.hpp
+++ b/generator/restriction_writer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "std/fstream.hpp"
-#include "std/string.hpp"
+#include <fstream>
+#include <string>
 
 class RelationElement;
 
@@ -10,7 +10,7 @@ namespace routing
 class RestrictionWriter
 {
 public:
-  void Open(string const & fullPath);
+  void Open(std::string const & fullPath);
 
   /// \brief Writes |relationElement| to |m_stream| if |relationElement| is a supported restriction.
   /// See restriction_generator.hpp for the description of the format.
@@ -22,6 +22,6 @@ public:
 private:
   bool IsOpened() const;
 
-  ofstream m_stream;
+  std::ofstream m_stream;
 };
 }  // namespace routing

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -17,7 +17,7 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/initializer_list.hpp"
+#include <initializer_list>
 
 #include "defines.hpp"
 

--- a/generator/routing_generator.cpp
+++ b/generator/routing_generator.cpp
@@ -56,7 +56,7 @@ uint8_t GetWarningRank(FeatureType const & ft)
   return 3;
 }
 
-bool LoadIndexes(string const & mwmFile, string const & osrmFile, osrm::NodeDataVectorT & nodeData, gen::OsmID2FeatureID & osm2ft)
+bool LoadIndexes(std::string const & mwmFile, std::string const & osrmFile, osrm::NodeDataVectorT & nodeData, gen::OsmID2FeatureID & osm2ft)
 {
   if (!osrm::LoadNodeDataFromFile(osrmFile + ".nodeData", nodeData))
   {
@@ -96,7 +96,7 @@ bool CheckBBoxCrossingBorder(m2::RegionD const & border, osrm::NodeData const & 
 }
 
 void FindCrossNodes(osrm::NodeDataVectorT const & nodeData, gen::OsmID2FeatureID const & osm2ft,
-                    borders::CountriesContainerT const & countries, string const & countryName,
+                    borders::CountriesContainerT const & countries, std::string const & countryName,
                     Index const & index, MwmSet::MwmId mwmId,
                     routing::CrossRoutingContextWriter & crossContext)
 {
@@ -154,7 +154,7 @@ void FindCrossNodes(osrm::NodeDataVectorT const & nodeData, gen::OsmID2FeatureID
               crossContext.AddIngoingNode(nodeId, wgsIntersection);
             else if (outStart && !outEnd)
             {
-              string mwmName;
+              std::string mwmName;
               m2::PointD const & mercatorPoint = MercatorBounds::FromLatLon(endSeg.lat2, endSeg.lon2);
               countries.ForEachInRect(m2::RectD(mercatorPoint, mercatorPoint), [&](borders::CountryPolygons const & c)
               {
@@ -189,7 +189,7 @@ void FindCrossNodes(osrm::NodeDataVectorT const & nodeData, gen::OsmID2FeatureID
   }
 }
 
-void CalculateCrossAdjacency(string const & mwmRoutingPath, routing::CrossRoutingContextWriter & crossContext)
+void CalculateCrossAdjacency(std::string const & mwmRoutingPath, routing::CrossRoutingContextWriter & crossContext)
 {
   OsrmDataFacade<QueryEdge::EdgeData> facade;
   FilesMappingContainer routingCont(mwmRoutingPath);
@@ -223,7 +223,7 @@ void CalculateCrossAdjacency(string const & mwmRoutingPath, routing::CrossRoutin
   LOG(LINFO, ("Calculation of weight map between outgoing nodes DONE"));
 }
 
-void WriteCrossSection(routing::CrossRoutingContextWriter const & crossContext, string const & mwmRoutingPath)
+void WriteCrossSection(routing::CrossRoutingContextWriter const & crossContext, std::string const & mwmRoutingPath)
 {
   LOG(LINFO, ("Collect all data into one file..."));
 
@@ -235,8 +235,8 @@ void WriteCrossSection(routing::CrossRoutingContextWriter const & crossContext, 
   LOG(LINFO, ("Have written routing info, bytes written:", w.Pos() - start_size, "bytes"));
 }
 
-void BuildCrossRoutingIndex(string const & baseDir, string const & countryName,
-                            string const & osrmFile)
+void BuildCrossRoutingIndex(std::string const & baseDir, std::string const & countryName,
+                            std::string const & osrmFile)
 {
   LOG(LINFO, ("Cross mwm routing section builder"));
   classificator::Load();
@@ -267,12 +267,12 @@ void BuildCrossRoutingIndex(string const & baseDir, string const & countryName,
   routing::CrossRoutingContextWriter crossContext;
   FindCrossNodes(nodeData, osm2ft, countries, countryName, index, p.first, crossContext);
 
-  string const mwmPath = localFile.GetPath(MapOptions::Map);
+  std::string const mwmPath = localFile.GetPath(MapOptions::Map);
   CalculateCrossAdjacency(mwmPath, crossContext);
   WriteCrossSection(crossContext, mwmPath);
 }
 
-void BuildRoutingIndex(string const & baseDir, string const & countryName, string const & osrmFile)
+void BuildRoutingIndex(std::string const & baseDir, std::string const & countryName, std::string const & osrmFile)
 {
   classificator::Load();
 
@@ -451,8 +451,8 @@ void BuildRoutingIndex(string const & baseDir, string const & countryName, strin
 
   LOG(LINFO, ("Collect all data into one file..."));
 
-  string const mwmPath = localFile.GetPath(MapOptions::Map);
-  string const mwmWithoutRoutingPath = mwmPath + NOROUTING_FILE_EXTENSION;
+  std::string const mwmPath = localFile.GetPath(MapOptions::Map);
+  std::string const mwmWithoutRoutingPath = mwmPath + NOROUTING_FILE_EXTENSION;
 
   // Backup mwm file without routing.
   CHECK(my::CopyFileX(mwmPath, mwmWithoutRoutingPath), ("Can't copy", mwmPath, "to", mwmWithoutRoutingPath));
@@ -461,9 +461,9 @@ void BuildRoutingIndex(string const & baseDir, string const & countryName, strin
 
   mapping.Save(routingCont);
 
-  auto appendFile = [&] (string const & tag)
+  auto appendFile = [&] (std::string const & tag)
   {
-    string const fileName = osrmFile + "." + tag;
+    std::string const fileName = osrmFile + "." + tag;
     LOG(LINFO, ("Append file", fileName, "with tag", tag));
     routingCont.Write(fileName, tag);
   };

--- a/generator/routing_generator.hpp
+++ b/generator/routing_generator.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace routing
 {
 /// @param[in]  baseDir   Full path to .mwm files directory.
 /// @param[in]  countryName   Country name same with .mwm and .border file name.
 /// @param[in]  osrmFile  Full path to .osrm file (all prepared osrm files should be there).
-void BuildRoutingIndex(string const & baseDir, string const & countryName, string const & osrmFile);
+void BuildRoutingIndex(std::string const & baseDir, std::string const & countryName, std::string const & osrmFile);
 
 /// @param[in]  baseDir      Full path to .mwm files directory.
 /// @param[in]  countryName   Country name same with .mwm and .border file name.
 /// @param[in]  osrmFile  Full path to .osrm file (all prepared osrm files should be there).
 /// perform if it's emplty.
-void BuildCrossRoutingIndex(string const & baseDir, string const & countryName,
-                            string const & osrmFile);
+void BuildCrossRoutingIndex(std::string const & baseDir, std::string const & countryName,
+                            std::string const & osrmFile);
 }

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -13,7 +13,7 @@ using std::string;
 namespace
 {
 template <class ToDo>
-bool ForEachRoadFromFile(string const & filename, ToDo && toDo)
+bool ForEachRoadFromFile(std::string const & filename, ToDo && toDo)
 {
   gen::OsmID2FeatureID osmIdsToFeatureIds;
   try
@@ -46,7 +46,7 @@ void AddFeatureId(osm::Id osmId, uint32_t featureId, map<osm::Id, uint32_t> &osm
   osmIdToFeatureId.insert(make_pair(osmId, featureId));
 }
 
-bool ParseOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
+bool ParseOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
                                   map<osm::Id, uint32_t> & osmIdToFeatureId)
 {
   return ForEachRoadFromFile(osmIdsToFeatureIdPath, [&](uint32_t featureId, osm::Id osmId) {
@@ -54,7 +54,7 @@ bool ParseOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
   });
 }
 
-bool ParseFeatureIdToOsmIdMapping(string const & osmIdsToFeatureIdPath,
+bool ParseFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
                                   map<uint32_t, osm::Id> & featureIdToOsmId)
 {
   featureIdToOsmId.clear();

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -13,7 +13,7 @@ using std::string;
 namespace
 {
 template <class ToDo>
-bool ForEachRoadFromFile(std::string const & filename, ToDo && toDo)
+bool ForEachRoadFromFile(string const & filename, ToDo && toDo)
 {
   gen::OsmID2FeatureID osmIdsToFeatureIds;
   try
@@ -46,7 +46,7 @@ void AddFeatureId(osm::Id osmId, uint32_t featureId, map<osm::Id, uint32_t> &osm
   osmIdToFeatureId.insert(make_pair(osmId, featureId));
 }
 
-bool ParseOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
+bool ParseOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
                                   map<osm::Id, uint32_t> & osmIdToFeatureId)
 {
   return ForEachRoadFromFile(osmIdsToFeatureIdPath, [&](uint32_t featureId, osm::Id osmId) {
@@ -54,7 +54,7 @@ bool ParseOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
   });
 }
 
-bool ParseFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
+bool ParseFeatureIdToOsmIdMapping(string const & osmIdsToFeatureIdPath,
                                   map<uint32_t, osm::Id> & featureIdToOsmId)
 {
   featureIdToOsmId.clear();

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -18,7 +18,7 @@ struct TagsProcessor
 // Adds feature id and corresponding |osmId| to |osmIdToFeatureId|.
 // Note. In general, one |featureId| may correspond to several osm ids.
 // But for a road feature |featureId| corresponds to exactly one osm id.
-void AddFeatureId(osm::Id osmId, uint32_t featureId, map<osm::Id, uint32_t> &osmIdToFeatureId);
+void AddFeatureId(osm::Id osmId, uint32_t featureId, std::map<osm::Id, uint32_t> & osmIdToFeatureId);
 
 // Parses comma separated text file with line in following format:
 // <feature id>, <osm id 1 corresponding feature id>, <osm id 2 corresponding feature id>, and so

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -35,12 +35,14 @@
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/fstream.hpp"
-#include "std/initializer_list.hpp"
-#include "std/limits.hpp"
-#include "std/unordered_map.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <fstream>
+#include <initializer_list>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+using namespace std;
 
 #define SYNONYMS_FILE "synonyms.txt"
 
@@ -61,7 +63,7 @@ public:
 
     while (stream.good())
     {
-      std::getline(stream, line);
+      getline(stream, line);
       if (line.empty())
         continue;
 

--- a/generator/search_index_builder.hpp
+++ b/generator/search_index_builder.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 class FilesContainerR;
 class Writer;
@@ -11,7 +11,7 @@ namespace indexer
 // An attempt to rewrite the search index of an old mwm may result in a future crash
 // when using search because this function does not update mwm's version. This results
 // in version mismatch when trying to read the index.
-bool BuildSearchIndexFromDataFile(string const & filename, bool forceRebuild = false);
+bool BuildSearchIndexFromDataFile(std::string const & filename, bool forceRebuild = false);
 
 void BuildSearchIndex(FilesContainerR & container, Writer & indexWriter);
 }  // namespace indexer

--- a/generator/sponsored_dataset.hpp
+++ b/generator/sponsored_dataset.hpp
@@ -33,14 +33,16 @@ public:
   static double constexpr kDistanceLimitInMeters = 150;
   static size_t constexpr kMaxSelectedElements = 3;
 
-  explicit SponsoredDataset(std::string const & dataPath, std::string const & addressReferencePath = std::string());
-  explicit SponsoredDataset(istream & dataSource, std::string const & addressReferencePath = std::string());
+  explicit SponsoredDataset(std::string const & dataPath,
+                            std::string const & addressReferencePath = std::string());
+  explicit SponsoredDataset(std::istream & dataSource,
+                            std::string const & addressReferencePath = std::string());
 
   size_t Size() const { return m_objects.size(); }
 
   Object const & GetObjectById(ObjectId id) const;
   Object & GetObjectById(ObjectId id);
-  vector<ObjectId> GetNearestObjects(ms::LatLon const & latLon, size_t limit,
+  std::vector<ObjectId> GetNearestObjects(ms::LatLon const & latLon, size_t limit,
                                      double maxDistance = 0.0) const;
 
   /// @return true if |fb| satisfies some necessary conditions to match one or serveral
@@ -64,7 +66,7 @@ protected:
 
   private:
     Index m_index;
-    unique_ptr<search::ReverseGeocoder> m_coder;
+    std::unique_ptr<search::ReverseGeocoder> m_coder;
   };
 
   // TODO(mgsergio): Get rid of Box since boost::rtree supports point as value type.
@@ -72,7 +74,7 @@ protected:
   // instead of boost::geometry::cs::cartesian.
   using Point = boost::geometry::model::point<float, 2, boost::geometry::cs::cartesian>;
   using Box = boost::geometry::model::box<Point>;
-  using Value = pair<Box, ObjectId>;
+  using Value = std::pair<Box, ObjectId>;
 
   // Create the rtree using default constructor.
   boost::geometry::index::rtree<Value, boost::geometry::index::quadratic<16>> m_rtree;
@@ -80,7 +82,7 @@ protected:
   void BuildObject(Object const & object,
                    std::function<void(FeatureBuilder1 &)> const & fn) const;
 
-  void LoadData(istream & src, std::string const & addressReferencePath);
+  void LoadData(std::istream & src, std::string const & addressReferencePath);
 
   /// @return an id of a matched object or kInvalidObjectId on failure.
   ObjectId FindMatchingObjectIdImpl(FeatureBuilder1 const & fb) const;

--- a/generator/sponsored_dataset.hpp
+++ b/generator/sponsored_dataset.hpp
@@ -10,9 +10,9 @@
 
 #include "base/newtype.hpp"
 
-#include "std/function.hpp"
-#include "std/map.hpp"
-#include "std/string.hpp"
+#include <functional>
+#include <map>
+#include <string>
 
 #include "boost/geometry.hpp"
 #include "boost/geometry/geometries/point.hpp"
@@ -33,8 +33,8 @@ public:
   static double constexpr kDistanceLimitInMeters = 150;
   static size_t constexpr kMaxSelectedElements = 3;
 
-  explicit SponsoredDataset(string const & dataPath, string const & addressReferencePath = string());
-  explicit SponsoredDataset(istream & dataSource, string const & addressReferencePath = string());
+  explicit SponsoredDataset(std::string const & dataPath, std::string const & addressReferencePath = std::string());
+  explicit SponsoredDataset(istream & dataSource, std::string const & addressReferencePath = std::string());
 
   size_t Size() const { return m_objects.size(); }
 
@@ -51,9 +51,9 @@ public:
   // Applies changes to a given osm object (for example, remove hotel type)
   // and passes the result to |fn|.
   void PreprocessMatchedOsmObject(ObjectId matchedObjId, FeatureBuilder1 & fb,
-                                  function<void(FeatureBuilder1 &)> const fn) const;
+                                  std::function<void(FeatureBuilder1 &)> const fn) const;
   // Creates objects and adds them to the map (MWM) via |fn|.
-  void BuildOsmObjects(function<void(FeatureBuilder1 &)> const & fn) const;
+  void BuildOsmObjects(std::function<void(FeatureBuilder1 &)> const & fn) const;
 
 protected:
   class AddressMatcher
@@ -78,14 +78,14 @@ protected:
   boost::geometry::index::rtree<Value, boost::geometry::index::quadratic<16>> m_rtree;
 
   void BuildObject(Object const & object,
-                   function<void(FeatureBuilder1 &)> const & fn) const;
+                   std::function<void(FeatureBuilder1 &)> const & fn) const;
 
-  void LoadData(istream & src, string const & addressReferencePath);
+  void LoadData(istream & src, std::string const & addressReferencePath);
 
   /// @return an id of a matched object or kInvalidObjectId on failure.
   ObjectId FindMatchingObjectIdImpl(FeatureBuilder1 const & fb) const;
 
-  map<ObjectId, Object> m_objects;
+  std::map<ObjectId, Object> m_objects;
 };
 }  // namespace generator
 

--- a/generator/sponsored_dataset_inl.hpp
+++ b/generator/sponsored_dataset_inl.hpp
@@ -5,8 +5,8 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/fstream.hpp"
-#include "std/iostream.hpp"
+#include <fstream>
+#include <iostream>
 
 namespace generator
 {
@@ -48,12 +48,12 @@ void SponsoredDataset<SponsoredObject>::AddressMatcher::operator()(Object & obje
 
 // SponsoredDataset --------------------------------------------------------------------------------
 template <typename SponsoredObject>
-SponsoredDataset<SponsoredObject>::SponsoredDataset(string const & dataPath, string const & addressReferencePath)
+SponsoredDataset<SponsoredObject>::SponsoredDataset(std::string const & dataPath, std::string const & addressReferencePath)
 {
   if (dataPath.empty())
     return;
 
-  ifstream dataSource(dataPath);
+  std::ifstream dataSource(dataPath);
   if (!dataSource.is_open())
   {
     LOG(LERROR, ("Error while opening", dataPath, ":", strerror(errno)));
@@ -64,7 +64,7 @@ SponsoredDataset<SponsoredObject>::SponsoredDataset(string const & dataPath, str
 }
 
 template <typename SponsoredObject>
-SponsoredDataset<SponsoredObject>::SponsoredDataset(istream & dataSource, string const & addressReferencePath)
+SponsoredDataset<SponsoredObject>::SponsoredDataset(std::istream & dataSource, std::string const & addressReferencePath)
 {
   LoadData(dataSource, addressReferencePath);
 }
@@ -126,12 +126,12 @@ SponsoredDataset<SponsoredObject>::GetNearestObjects(ms::LatLon const & latLon, 
 }
 
 template <typename SponsoredObject>
-void SponsoredDataset<SponsoredObject>::LoadData(istream & src, string const & addressReferencePath)
+void SponsoredDataset<SponsoredObject>::LoadData(std::istream & src, std::string const & addressReferencePath)
 {
   m_objects.clear();
   m_rtree.clear();
 
-  for (string line; getline(src, line);)
+  for (std::string line; std::getline(src, line);)
   {
     Object hotel(line);
     m_objects.emplace(hotel.m_id, hotel);
@@ -142,7 +142,7 @@ void SponsoredDataset<SponsoredObject>::LoadData(istream & src, string const & a
   {
     LOG(LINFO, ("Reference addresses for sponsored objects", addressReferencePath));
     Platform & platform = GetPlatform();
-    string const backupPath = platform.WritableDir();
+    std::string const backupPath = platform.WritableDir();
 
     // MWMs can be loaded only from a writebledir or from a resourcedir,
     // changig resourcedir can lead to probles with classificator, so

--- a/generator/sponsored_scoring.cpp
+++ b/generator/sponsored_scoring.cpp
@@ -5,22 +5,22 @@
 
 #include "geometry/distance_on_sphere.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <vector>
 
 namespace
 {
-using WeightedBagOfWords = vector<pair<strings::UniString, double>>;
+using WeightedBagOfWords = std::vector<std::pair<strings::UniString, double>>;
 
-vector<strings::UniString> StringToWords(string const & str)
+std::vector<strings::UniString> StringToWords(std::string const & str)
 {
-  vector<strings::UniString> result;
+  std::vector<strings::UniString> result;
   search::NormalizeAndTokenizeString(str, result, search::Delimiters{});
-  sort(begin(result), end(result));
+  std::sort(std::begin(result), std::end(result));
   return result;
 }
 
-WeightedBagOfWords MakeWeightedBagOfWords(vector<strings::UniString> const & words)
+WeightedBagOfWords MakeWeightedBagOfWords(std::vector<strings::UniString> const & words)
 {
   // TODO(mgsergio): Calculate tf-idsf score for every word.
   auto constexpr kTfIdfScorePlaceholder = 1;
@@ -92,7 +92,7 @@ double GetLinearNormDistanceScore(double distance, double const maxDistance)
   return 1.0 - distance / maxDistance;
 }
 
-double GetNameSimilarityScore(string const & booking_name, string const & osm_name)
+double GetNameSimilarityScore(std::string const & booking_name, std::string const & osm_name)
 {
   auto const aws = MakeWeightedBagOfWords(StringToWords(booking_name));
   auto const bws = MakeWeightedBagOfWords(StringToWords(osm_name));

--- a/generator/sponsored_scoring.hpp
+++ b/generator/sponsored_scoring.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 class FeatureBuilder1;
 
@@ -9,7 +9,7 @@ namespace generator
 namespace impl
 {
 double GetLinearNormDistanceScore(double distance, double maxDistance);
-double GetNameSimilarityScore(string const & booking_name, string const & osm_name);
+double GetNameSimilarityScore(std::string const & booking_name, std::string const & osm_name);
 }  // namespace impl
 
 namespace sponsored_scoring

--- a/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
+++ b/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
@@ -13,7 +13,7 @@
 
 #include "base/logging.hpp"
 
-#include "std/algorithm.hpp"
+#include <algorithm>
 
 #include "3party/gflags/src/gflags/gflags.h"
 
@@ -93,7 +93,7 @@ int main(int argc, char * argv[])
         // Get points in proper direction.
         auto const startIdx = segment.m_pointStart;
         auto const endIdx = segment.m_pointEnd;
-        for (auto idx = min(startIdx, endIdx); idx <= max(startIdx, endIdx); ++idx)
+        for (auto idx = std::min(startIdx, endIdx); idx <= std::max(startIdx, endIdx); ++idx)
           path.push_back(ft.GetPoint(idx));
 
         all += path.size();

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -5,8 +5,8 @@
 
 #include "base/logging.hpp"
 
-#include "std/iomanip.hpp"
-#include "std/sstream.hpp"
+#include <iomanip>
+#include <sstream>
 
 namespace generator
 {
@@ -17,7 +17,7 @@ size_t constexpr kSrtmTileSize = (kArcSecondsInDegree + 1) * (kArcSecondsInDegre
 
 struct UnzipMemDelegate : public ZipFileReader::Delegate
 {
-  UnzipMemDelegate(string & buffer) : m_buffer(buffer), m_completed(false) {}
+  UnzipMemDelegate(std::string & buffer) : m_buffer(buffer), m_completed(false) {}
 
   // ZipFileReader::Delegate overrides:
   void OnBlockUnzipped(size_t size, char const * data) override { m_buffer.append(data, size); }
@@ -30,7 +30,7 @@ struct UnzipMemDelegate : public ZipFileReader::Delegate
 
   void OnCompleted() override { m_completed = true; }
 
-  string & m_buffer;
+  std::string & m_buffer;
   bool m_completed;
 };
 }  // namespace
@@ -46,13 +46,13 @@ SrtmTile::SrtmTile(SrtmTile && rhs) : m_data(move(rhs.m_data)), m_valid(rhs.m_va
   rhs.Invalidate();
 }
 
-void SrtmTile::Init(string const & dir, ms::LatLon const & coord)
+void SrtmTile::Init(std::string const & dir, ms::LatLon const & coord)
 {
   Invalidate();
 
-  string const base = GetBase(coord);
-  string const cont = dir + base + ".SRTMGL1.hgt.zip";
-  string file = base + ".hgt";
+  std::string const base = GetBase(coord);
+  std::string const cont = dir + base + ".SRTMGL1.hgt.zip";
+  std::string file = base + ".hgt";
 
   UnzipMemDelegate delegate(m_data);
   try
@@ -107,9 +107,9 @@ feature::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
   return ReverseByteOrder(Data()[ix]);
 }
 
-string SrtmTile::GetBase(ms::LatLon coord)
+std::string SrtmTile::GetBase(ms::LatLon coord)
 {
-  ostringstream ss;
+  std::ostringstream ss;
   if (coord.lat < 0)
   {
     ss << "S";
@@ -120,7 +120,7 @@ string SrtmTile::GetBase(ms::LatLon coord)
   {
     ss << "N";
   }
-  ss << setw(2) << setfill('0') << static_cast<int>(coord.lat);
+  ss << std::setw(2) << std::setfill('0') << static_cast<int>(coord.lat);
 
   if (coord.lon < 0)
   {
@@ -132,7 +132,7 @@ string SrtmTile::GetBase(ms::LatLon coord)
   {
     ss << "E";
   }
-  ss << setw(3) << static_cast<int>(coord.lon);
+  ss << std::setw(3) << static_cast<int>(coord.lon);
   return ss.str();
 }
 
@@ -144,10 +144,10 @@ void SrtmTile::Invalidate()
 }
 
 // SrtmTileManager ---------------------------------------------------------------------------------
-SrtmTileManager::SrtmTileManager(string const & dir) : m_dir(dir) {}
+SrtmTileManager::SrtmTileManager(std::string const & dir) : m_dir(dir) {}
 feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 {
-  string const base = SrtmTile::GetBase(coord);
+  std::string const base = SrtmTile::GetBase(coord);
   auto it = m_tiles.find(base);
   if (it == m_tiles.end())
   {
@@ -163,7 +163,7 @@ feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 
     // It's OK to store even invalid tiles and return invalid height
     // for them later.
-    it = m_tiles.emplace(base, move(tile)).first;
+    it = m_tiles.emplace(base, std::move(tile)).first;
   }
 
   return it->second.GetHeight(coord);

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -6,9 +6,9 @@
 
 #include "base/macros.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/string.hpp"
-#include "std/unordered_map.hpp"
+#include <cstdint>
+#include <string>
+#include <unordered_map>
 
 namespace generator
 {
@@ -18,13 +18,13 @@ public:
   SrtmTile();
   SrtmTile(SrtmTile && rhs);
 
-  void Init(string const & dir, ms::LatLon const & coord);
+  void Init(std::string const & dir, ms::LatLon const & coord);
 
   inline bool IsValid() const { return m_valid; }
   // Returns height in meters at |coord| or kInvalidAltitude.
   feature::TAltitude GetHeight(ms::LatLon const & coord);
 
-  static string GetBase(ms::LatLon coord);
+  static std::string GetBase(ms::LatLon coord);
 
 private:
   inline feature::TAltitude const * Data() const
@@ -35,7 +35,7 @@ private:
   inline size_t Size() const { return m_data.size() / sizeof(feature::TAltitude); }
   void Invalidate();
 
-  string m_data;
+  std::string m_data;
   bool m_valid;
 
   DISALLOW_COPY(SrtmTile);
@@ -44,13 +44,13 @@ private:
 class SrtmTileManager
 {
 public:
-  SrtmTileManager(string const & dir);
+  SrtmTileManager(std::string const & dir);
 
   feature::TAltitude GetHeight(ms::LatLon const & coord);
 
 private:
-  string m_dir;
-  unordered_map<string, SrtmTile> m_tiles;
+  std::string m_dir;
+  std::unordered_map<std::string, SrtmTile> m_tiles;
 
   DISALLOW_COPY(SrtmTileManager);
 };

--- a/generator/statistics.cpp
+++ b/generator/statistics.cpp
@@ -10,22 +10,22 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/iomanip.hpp"
-#include "std/iostream.hpp"
+#include <iomanip>
+#include <iostream>
 
 
 using namespace feature;
 
 namespace stats
 {
-  void FileContainerStatistic(string const & fPath)
+  void FileContainerStatistic(std::string const & fPath)
   {
     try
     {
       FilesContainerR cont(fPath);
       cont.ForEachTag([&cont] (FilesContainerR::Tag const & tag)
       {
-        cout << setw(10) << tag << " : " << cont.GetReader(tag).Size() << endl;
+        std::cout << std::setw(10) << tag << " : " << cont.GetReader(tag).Size() << endl;
       });
     }
     catch (Reader::Exception const & ex)
@@ -106,23 +106,23 @@ namespace stats
     }
   };
 
-  void CalcStatistic(string const & fPath, MapInfo & info)
+  void CalcStatistic(std::string const & fPath, MapInfo & info)
   {
     AccumulateStatistic doProcess(info);
     feature::ForEachFromDat(fPath, doProcess);
   }
 
-  void PrintInfo(string const & prefix, GeneralInfo const & info, bool measurements)
+  void PrintInfo(std::string const & prefix, GeneralInfo const & info, bool measurements)
   {
-    cout << prefix << ": size = " << info.m_size << "; count = " << info.m_count;
+    std::cout << prefix << ": size = " << info.m_size << "; count = " << info.m_count;
     if (measurements)
     {
-      cout << "; length = " << uint64_t(info.m_length) << " m; area = " << uint64_t(info.m_area) << " m²";
+      std::cout << "; length = " << uint64_t(info.m_length) << " m; area = " << uint64_t(info.m_area) << " m²";
     }
-    cout << endl;
+    std::cout << endl;
   }
 
-  string GetKey(EGeomType type)
+  std::string GetKey(EGeomType type)
   {
     switch (type)
     {
@@ -132,17 +132,17 @@ namespace stats
     }
   }
 
-  string GetKey(CountType t)
+  std::string GetKey(CountType t)
   {
     return strings::to_string(t.m_val);
   }
 
-  string GetKey(ClassifType t)
+  std::string GetKey(ClassifType t)
   {
     return classif().GetFullObjectName(t.m_val);
   }
 
-  string GetKey(AreaType t)
+  std::string GetKey(AreaType t)
   {
     return strings::to_string(arrAreas[t.m_val]);
   }
@@ -150,7 +150,7 @@ namespace stats
   template <class TSortCr, class TSet>
   void PrintTop(char const * prefix, TSet const & theSet)
   {
-    cout << prefix << endl;
+    std::cout << prefix << endl;
 
     vector<pair<typename TSet::key_type, typename TSet::mapped_type>> vec(theSet.begin(), theSet.end());
 
@@ -159,7 +159,7 @@ namespace stats
     size_t const count = min(static_cast<size_t>(10), vec.size());
     for (size_t i = 0; i < count; ++i)
     {
-      cout << i << ". ";
+      std::cout << i << ". ";
       PrintInfo(GetKey(vec[i].first), vec[i].second, false);
     }
   }

--- a/generator/statistics.hpp
+++ b/generator/statistics.hpp
@@ -2,7 +2,7 @@
 
 #include "indexer/feature.hpp"
 
-#include "std/map.hpp"
+#include <map>
 
 
 namespace stats
@@ -40,17 +40,17 @@ namespace stats
 
   struct MapInfo
   {
-    map<feature::EGeomType, GeneralInfo> m_byGeomType;
-    map<ClassifType, GeneralInfo> m_byClassifType;
-    map<CountType, GeneralInfo> m_byPointsCount, m_byTrgCount;
-    map<AreaType, GeneralInfo> m_byAreaSize;
+    std::map<feature::EGeomType, GeneralInfo> m_byGeomType;
+    std::map<ClassifType, GeneralInfo> m_byClassifType;
+    std::map<CountType, GeneralInfo> m_byPointsCount, m_byTrgCount;
+    std::map<AreaType, GeneralInfo> m_byAreaSize;
 
     GeneralInfo m_inner[3];
   };
 
-  void FileContainerStatistic(string const & fPath);
+  void FileContainerStatistic(std::string const & fPath);
 
-  void CalcStatistic(string const & fPath, MapInfo & info);
+  void CalcStatistic(std::string const & fPath, MapInfo & info);
   void PrintStatistic(MapInfo & info);
   void PrintTypeStatistic(MapInfo & info);
 }

--- a/generator/tag_admixer.hpp
+++ b/generator/tag_admixer.hpp
@@ -6,26 +6,26 @@
 #include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/fstream.hpp"
-#include "std/map.hpp"
-#include "std/set.hpp"
-#include "std/string.hpp"
-#include "std/utility.hpp"
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
 
 
 class WaysParserHelper
 {
 public:
-  WaysParserHelper(map<uint64_t, string> & ways) : m_ways(ways) {}
+  WaysParserHelper(std::map<uint64_t, std::string> & ways) : m_ways(ways) {}
 
   void ParseStream(istream & input)
   {
-    string oneLine;
-    while (getline(input, oneLine, '\n'))
+    std::string oneLine;
+    while (std::getline(input, oneLine, '\n'))
     {
       // String format: <<id;tag>>.
       auto pos = oneLine.find(';');
-      if (pos != string::npos)
+      if (pos != std::string::npos)
       {
         uint64_t wayId;
         CHECK(strings::to_uint64(oneLine.substr(0, pos), wayId),());
@@ -35,32 +35,32 @@ public:
   }
 
 private:
-  map<uint64_t, string> & m_ways;
+  std::map<uint64_t, std::string> & m_ways;
 };
 
 class CapitalsParserHelper
 {
 public:
-  CapitalsParserHelper(set<uint64_t> & capitals) : m_capitals(capitals) {}
+  CapitalsParserHelper(std::set<uint64_t> & capitals) : m_capitals(capitals) {}
 
   void ParseStream(istream & input)
   {
-    string oneLine;
-    while (getline(input, oneLine, '\n'))
+    std::string oneLine;
+    while (std::getline(input, oneLine, '\n'))
     {
       // String format: <<lat;lon;id;is_capital>>.
       // First ';'.
       auto pos = oneLine.find(";");
-      if (pos != string::npos)
+      if (pos != std::string::npos)
       {
         // Second ';'.
         pos = oneLine.find(";", pos + 1);
-        if (pos != string::npos)
+        if (pos != std::string::npos)
         {
           uint64_t nodeId;
           // Third ';'.
           auto endPos = oneLine.find(";", pos + 1);
-          if (endPos != string::npos)
+          if (endPos != std::string::npos)
           {
             if (strings::to_uint64(oneLine.substr(pos + 1, endPos - pos - 1), nodeId))
               m_capitals.insert(nodeId);
@@ -71,21 +71,21 @@ public:
   }
 
 private:
-  set<uint64_t> & m_capitals;
+  std::set<uint64_t> & m_capitals;
 };
 
 class TagAdmixer
 {
 public:
-  TagAdmixer(string const & waysFile, string const & capitalsFile) : m_ferryTag("route", "ferry")
+  TagAdmixer(std::string const & waysFile, std::string const & capitalsFile) : m_ferryTag("route", "ferry")
   {
     try
     {
-      ifstream reader(waysFile);
+      std::ifstream reader(waysFile);
       WaysParserHelper parser(m_ways);
       parser.ParseStream(reader);
     }
-    catch (ifstream::failure const &)
+    catch (std::ifstream::failure const &)
     {
       LOG(LWARNING, ("Can't read the world level ways file! Generating world without roads. Path:", waysFile));
       return;
@@ -93,11 +93,11 @@ public:
 
     try
     {
-      ifstream reader(capitalsFile);
+      std::ifstream reader(capitalsFile);
       CapitalsParserHelper parser(m_capitals);
       parser.ParseStream(reader);
     }
-    catch (ifstream::failure const &)
+    catch (std::ifstream::failure const &)
     {
       LOG(LWARNING, ("Can't read the world level capitals file! Generating world without towns admixing. Path:", capitalsFile));
       return;
@@ -117,7 +117,7 @@ public:
       // Our goal here - to make some capitals visible in World map.
       // The simplest way is to upgrade population to 45000,
       // according to our visibility rules in mapcss files.
-      e->UpdateTag("population", [] (string & v)
+      e->UpdateTag("population", [] (std::string & v)
       {
         uint64_t n;
         if (!strings::to_uint64(v, n) || n < 45000)
@@ -127,22 +127,22 @@ public:
   }
 
 private:
-  map<uint64_t, string> m_ways;
-  set<uint64_t> m_capitals;
+  std::map<uint64_t, std::string> m_ways;
+  std::set<uint64_t> m_capitals;
   OsmElement::Tag const m_ferryTag;
 };
 
 class TagReplacer
 {
-  map<OsmElement::Tag, vector<string>> m_entries;
+  std::map<OsmElement::Tag, std::vector<std::string>> m_entries;
 public:
-  TagReplacer(string const & filePath)
+  TagReplacer(std::string const & filePath)
   {
-    ifstream stream(filePath);
+    std::ifstream stream(filePath);
 
     OsmElement::Tag tag;
-    vector<string> values;
-    string line;
+    std::vector<std::string> values;
+    std::string line;
     while (std::getline(stream, line))
     {
       if (line.empty())
@@ -185,15 +185,15 @@ public:
 
 class OsmTagMixer
 {
-  map<pair<OsmElement::EntityType, uint64_t>, vector<OsmElement::Tag>> m_elements;
+  std::map<std::pair<OsmElement::EntityType, uint64_t>, std::vector<OsmElement::Tag>> m_elements;
 
 public:
-  OsmTagMixer(string const & filePath)
+  OsmTagMixer(std::string const & filePath)
   {
-    ifstream stream(filePath);
-    vector<string> values;
-    vector<OsmElement::Tag> tags;
-    string line;
+    std::ifstream stream(filePath);
+    std::vector<std::string> values;
+    std::vector<OsmElement::Tag> tags;
+    std::string line;
     while (std::getline(stream, line))
     {
       if (line.empty() || line.front() == '#')
@@ -211,13 +211,13 @@ public:
       for (size_t i = 2; i < values.size(); ++i)
       {
         auto p = values[i].find('=');
-        if (p != string::npos)
+        if (p != std::string::npos)
           tags.push_back(OsmElement::Tag(values[i].substr(0, p), values[i].substr(p + 1)));
       }
 
       if (!tags.empty())
       {
-        pair<OsmElement::EntityType, uint64_t> elementPair = {entityType, id};
+        std::pair<OsmElement::EntityType, uint64_t> elementPair = {entityType, id};
         m_elements[elementPair].swap(tags);
       }
     }
@@ -225,7 +225,7 @@ public:
 
   void operator()(OsmElement * p)
   {
-    pair<OsmElement::EntityType, uint64_t> elementId = {p->type, p->id};
+    std::pair<OsmElement::EntityType, uint64_t> elementId = {p->type, p->id};
     auto elements = m_elements.find(elementId);
     if (elements != m_elements.end())
     {

--- a/generator/tesselator.cpp
+++ b/generator/tesselator.cpp
@@ -9,9 +9,9 @@
 #include "base/assert.hpp"
 #include "base/logging.hpp"
 
-#include "std/limits.hpp"
-#include "std/queue.hpp"
-#include "std/unique_ptr.hpp"
+#include <limits>
+#include <memory>
+#include <queue>
 
 #include "3party/libtess2/Include/tesselator.h"
 
@@ -24,7 +24,7 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   int constexpr kVerticesInPolygon = 3;
 
   auto const deleter = [](TESStesselator * tess) {tessDeleteTess(tess);};
-  unique_ptr<TESStesselator, decltype(deleter)> tess(tessNewTess(nullptr), deleter);
+  std::unique_ptr<TESStesselator, decltype(deleter)> tess(tessNewTess(nullptr), deleter);
 
   for (auto const & contour : polys)
   {
@@ -65,7 +65,7 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   void TrianglesInfo::ListInfo::AddNeighbour(int p1, int p2, int trg)
   {
     // find or insert element for key
-    pair<TNeighbours::iterator, bool> ret = m_neighbors.insert(make_pair(make_pair(p1, p2), trg));
+    std::pair<TNeighbours::iterator, bool> ret = m_neighbors.insert(std::make_pair(std::make_pair(p1, p2), trg));
 
     // triangles should not duplicate
     CHECK ( ret.second, ("Duplicating triangles for indices : ", p1, p2) );
@@ -83,8 +83,8 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
 
   template <class IterT> size_t GetBufferSize(IterT b, IterT e)
   {
-    vector<char> buffer;
-    MemWriter<vector<char> > writer(buffer);
+    std::vector<char> buffer;
+    MemWriter<std::vector<char> > writer(buffer);
     while (b != e) WriteVarUint(writer, *b++);
     return buffer.size();
   }
@@ -94,12 +94,12 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   TrianglesInfo::ListInfo::FindStartTriangle(PointsInfo const & points) const
   {
     TIterator ret = m_neighbors.end();
-    size_t cr = numeric_limits<size_t>::max();
+    size_t cr = std::numeric_limits<size_t>::max();
 
     for (TIterator i = m_neighbors.begin(); i != m_neighbors.end(); ++i)
     {
       if (!m_visited[i->second] &&
-          m_neighbors.find(make_pair(i->first.second, i->first.first)) == m_neighbors.end())
+          m_neighbors.find(std::make_pair(i->first.second, i->first.first)) == m_neighbors.end())
       {
         uint64_t deltas[3];
         deltas[0] = EncodeDelta(points.m_points[i->first.first], points.m_base);
@@ -121,19 +121,19 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   }
 
   /// Return indexes of common edges of [to, from] triangles.
-  pair<int, int> CommonEdge(Triangle const & to, Triangle const & from)
+  std::pair<int, int> CommonEdge(Triangle const & to, Triangle const & from)
   {
     for (int i = 0; i < 3; ++i)
     {
       for (int j = 0; j < 3; ++j)
       {
         if (to.m_p[i] == from.m_p[my::NextModN(j, 3)] && to.m_p[my::NextModN(i, 3)] == from.m_p[j])
-          return make_pair(i, j);
+          return std::make_pair(i, j);
       }
     }
 
     ASSERT ( false, ("?WTF? Triangles not neighbors!") );
-    return make_pair(-1, -1);
+    return std::make_pair(-1, -1);
   }
 
   /// Get neighbors of 'trg' triangle, which was achieved from 'from' triangle.
@@ -147,10 +147,10 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
     int j = my::NextModN(i, 3);
 
     int ind = 0;
-    TIterator it = m_neighbors.find(make_pair(trg.m_p[j], trg.m_p[i]));
+    TIterator it = m_neighbors.find(std::make_pair(trg.m_p[j], trg.m_p[i]));
     nb[ind++] = (it != m_neighbors.end()) ? it->second : empty_key;
 
-    it = m_neighbors.find(make_pair(trg.m_p[my::NextModN(j, 3)], trg.m_p[j]));
+    it = m_neighbors.find(std::make_pair(trg.m_p[my::NextModN(j, 3)], trg.m_p[j]));
     nb[ind++] = (it != m_neighbors.end()) ? it->second : empty_key;
   }
 
@@ -158,7 +158,7 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   uint64_t TrianglesInfo::ListInfo::CalcDelta(
       PointsInfo const & points, Triangle const & from, Triangle const & to) const
   {
-    pair<int, int> const p = CommonEdge(to, from);
+    std::pair<int, int> const p = CommonEdge(to, from);
 
     m2::PointU const prediction =
         PredictPointInTriangle(points.m_max,
@@ -174,13 +174,13 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
 
   template <class TPopOrder>
   void TrianglesInfo::ListInfo::MakeTrianglesChainImpl(
-      PointsInfo const & points, TIterator start, vector<Edge> & chain) const
+      PointsInfo const & points, TIterator start, std::vector<Edge> & chain) const
   {
     chain.clear();
 
     Triangle const fictive(start->first.second, start->first.first, -1);
 
-    priority_queue<Edge, vector<Edge>, TPopOrder> q;
+    std::priority_queue<Edge, std::vector<Edge>, TPopOrder> q;
     q.push(Edge(-1, start->second, 0, -1));
 
     while (!q.empty())
@@ -229,7 +229,7 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
   };
 
   void TrianglesInfo::ListInfo::MakeTrianglesChain(
-    PointsInfo const & points, TIterator start, vector<Edge> & chain, bool /*goodOrder*/) const
+    PointsInfo const & points, TIterator start, std::vector<Edge> & chain, bool /*goodOrder*/) const
   {
     //if (goodOrder)
       MakeTrianglesChainImpl<edge_greater_delta>(points, start, chain);
@@ -244,7 +244,7 @@ int TesselateInterior(PolygonsT const & polys, TrianglesInfo & info)
 
   void TrianglesInfo::GetPointsInfo(m2::PointU const & baseP,
                                     m2::PointU const & maxP,
-                                    function<m2::PointU (m2::PointD)> const & convert,
+                                    std::function<m2::PointU (m2::PointD)> const & convert,
                                     PointsInfo & info) const
   {
     info.m_base = baseP;

--- a/generator/tesselator.hpp
+++ b/generator/tesselator.hpp
@@ -3,18 +3,18 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/function.hpp"
-#include "std/iterator.hpp"
-#include "std/list.hpp"
-#include "std/vector.hpp"
-#include "std/unordered_map.hpp"
-#include "std/utility.hpp"
+#include <functional>
+#include <iterator>
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 
 namespace tesselator
 {
-  typedef vector<m2::PointD> PointsT;
-  typedef list<PointsT> PolygonsT;
+  typedef std::vector<m2::PointD> PointsT;
+  typedef std::list<PointsT> PolygonsT;
 
   struct Triangle
   {
@@ -33,7 +33,7 @@ namespace tesselator
         m_p[i] = p[i];
     }
 
-    int GetPoint3(pair<int, int> const & p) const
+    int GetPoint3(std::pair<int, int> const & p) const
     {
       for (int i = 0; i < 3; ++i)
         if (m_p[i] != p.first && m_p[i] != p.second)
@@ -48,7 +48,7 @@ namespace tesselator
   struct PointsInfo
   {
     typedef m2::PointU PointT;
-    vector<PointT> m_points;
+    std::vector<PointT> m_points;
     PointT m_base, m_max;
   };
 
@@ -60,20 +60,20 @@ namespace tesselator
     {
       static int empty_key;
 
-      vector<Triangle> m_triangles;
+      std::vector<Triangle> m_triangles;
 
-      mutable vector<bool> m_visited;
+      mutable std::vector<bool> m_visited;
 
       // directed edge -> triangle
       template <typename T1, typename T2> struct HashPair
       {
-        size_t operator()(pair<T1, T2> const & p) const
+        size_t operator()(std::pair<T1, T2> const & p) const
         {
           return my::Hash(p.first, p.second);
         }
       };
 
-      using TNeighbours = unordered_map<pair<int, int>, int, HashPair<int, int>>;
+      using TNeighbours = std::unordered_map<std::pair<int, int>, int, HashPair<int, int>>;
       TNeighbours m_neighbors;
 
       void AddNeighbour(int p1, int p2, int trg);
@@ -101,7 +101,7 @@ namespace tesselator
 
       bool HasUnvisited() const
       {
-        vector<bool> test;
+        std::vector<bool> test;
         test.assign(m_triangles.size(), true);
         return (m_visited != test);
       }
@@ -110,15 +110,15 @@ namespace tesselator
 
     private:
       template <class TPopOrder>
-      void MakeTrianglesChainImpl(PointsInfo const & points, TIterator start, vector<Edge> & chain) const;
+      void MakeTrianglesChainImpl(PointsInfo const & points, TIterator start, std::vector<Edge> & chain) const;
     public:
-      void MakeTrianglesChain(PointsInfo const & points, TIterator start, vector<Edge> & chain, bool goodOrder) const;
+      void MakeTrianglesChain(PointsInfo const & points, TIterator start, std::vector<Edge> & chain, bool goodOrder) const;
 
       size_t GetCount() const { return m_triangles.size(); }
       Triangle GetTriangle(size_t i) const { return m_triangles[i]; }
     };
 
-    list<ListInfo> m_triangles;
+    std::list<ListInfo> m_triangles;
 
 //    int m_isCCW;  // 0 - uninitialized; -1 - false; 1 - true
 
@@ -141,7 +141,7 @@ namespace tesselator
 
     template <class ToDo> void ForEachTriangle(ToDo toDo) const
     {
-      for (list<ListInfo>::const_iterator i = m_triangles.begin(); i != m_triangles.end(); ++i)
+      for (std::list<ListInfo>::const_iterator i = m_triangles.begin(); i != m_triangles.end(); ++i)
       {
         size_t const count = i->GetCount();
         for (size_t j = 0; j < count; ++j)
@@ -154,15 +154,15 @@ namespace tesselator
 
     // Convert points from double to uint.
     void GetPointsInfo(m2::PointU const & baseP, m2::PointU const & maxP,
-                       function<m2::PointU (m2::PointD)> const & convert, PointsInfo & info) const;
+                       std::function<m2::PointU (m2::PointD)> const & convert, PointsInfo & info) const;
 
     /// Triangles chains processing function.
     template <class EmitterT>
     void ProcessPortions(PointsInfo const & points, EmitterT & emitter, bool goodOrder = true) const
     {
       // process portions and push out result chains
-      vector<Edge> chain;
-      for (list<ListInfo>::const_iterator i = m_triangles.begin(); i != m_triangles.end(); ++i)
+      std::vector<Edge> chain;
+      for (std::list<ListInfo>::const_iterator i = m_triangles.begin(); i != m_triangles.end(); ++i)
       {
         i->Start();
 

--- a/generator/towns_dumper.cpp
+++ b/generator/towns_dumper.cpp
@@ -5,9 +5,9 @@
 
 #include "base/logging.hpp"
 
-#include "std/fstream.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <fstream>
+#include <string>
+#include <vector>
 
 namespace
 {
@@ -19,7 +19,7 @@ void TownsDumper::FilterTowns()
 {
   LOG(LINFO, ("Preprocessing started. Have", m_records.size(), "towns."));
   m4::Tree<Town> resultTree;
-  vector<Town> towns;
+  std::vector<Town> towns;
   towns.reserve(m_records.size());
   for (auto const & town : m_records)
   {
@@ -57,15 +57,15 @@ void TownsDumper::FilterTowns()
   LOG(LINFO, ("Preprocessing finished. Have", m_records.size(), "towns."));
 }
 
-void TownsDumper::Dump(string const & filePath)
+void TownsDumper::Dump(std::string const & filePath)
 {
   FilterTowns();
   ASSERT(!filePath.empty(), ());
-  ofstream stream(filePath);
+  std::ofstream stream(filePath);
   stream.precision(9);
   for (auto const & record : m_records)
   {
-    string const isCapital = record.capital ? "t" : "f";
+    std::string const isCapital = record.capital ? "t" : "f";
     stream << record.point.lat << ";" << record.point.lon << ";" << record.id << ";" << isCapital <<  std::endl;
   }
 }

--- a/generator/towns_dumper.hpp
+++ b/generator/towns_dumper.hpp
@@ -6,9 +6,9 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/limits.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <limits>
+#include <string>
+#include <vector>
 
 class TownsDumper
 {
@@ -23,10 +23,10 @@ public:
     uint64_t population = 1;
     bool town = false;
     bool capital = false;
-    int admin_level = numeric_limits<int>::max();
+    int admin_level = std::numeric_limits<int>::max();
     for (auto const & tag : em.Tags())
     {
-      string key(tag.key), value(tag.value);
+      std::string key(tag.key), value(tag.value);
       if (key == "population")
       {
         if (!strings::to_uint64(value, population))
@@ -55,7 +55,7 @@ public:
       m_records.emplace_back(em.lat, em.lon, em.id, capital, population);
   }
 
-  void Dump(string const & filePath);
+  void Dump(std::string const & filePath);
 
 private:
   void FilterTowns();
@@ -79,5 +79,5 @@ private:
     }
   };
 
-  vector<Town> m_records;
+  std::vector<Town> m_records;
 };

--- a/generator/traffic_generator.cpp
+++ b/generator/traffic_generator.cpp
@@ -15,18 +15,18 @@
 #include "coding/file_container.hpp"
 #include "coding/file_writer.hpp"
 
-#include "std/vector.hpp"
+#include <vector>
 
 namespace traffic
 {
-bool GenerateTrafficKeysFromDataFile(string const & mwmPath)
+bool GenerateTrafficKeysFromDataFile(std::string const & mwmPath)
 {
   try
   {
-    vector<TrafficInfo::RoadSegmentId> keys;
+    std::vector<TrafficInfo::RoadSegmentId> keys;
     TrafficInfo::ExtractTrafficKeys(mwmPath, keys);
 
-    vector<uint8_t> buf;
+    std::vector<uint8_t> buf;
     TrafficInfo::SerializeTrafficKeys(keys, buf);
 
     FilesContainerW writeContainer(mwmPath, FileWriter::OP_WRITE_EXISTING);

--- a/generator/traffic_generator.hpp
+++ b/generator/traffic_generator.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "std/string.hpp"
+#include <string>
 
 namespace traffic
 {
-bool GenerateTrafficKeysFromDataFile(string const & mwmPath);
+bool GenerateTrafficKeysFromDataFile(std::string const & mwmPath);
 }  // namespace traffic

--- a/generator/unpack_mwm.cpp
+++ b/generator/unpack_mwm.cpp
@@ -7,17 +7,17 @@
 #include "base/logging.hpp"
 #include "base/stl_add.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <vector>
 
 
-void UnpackMwm(string const & filePath)
+void UnpackMwm(std::string const & filePath)
 {
   LOG(LINFO, ("Unpacking mwm sections..."));
 
   FilesContainerR container(filePath);
-  vector<string> tags;
-  container.ForEachTag(MakeBackInsertFunctor<vector<string> >(tags));
+  std::vector<std::string> tags;
+  container.ForEachTag(MakeBackInsertFunctor<std::vector<std::string> >(tags));
 
   for (size_t i = 0; i < tags.size(); ++i)
   {
@@ -32,7 +32,7 @@ void UnpackMwm(string const & filePath)
   LOG(LINFO, ("Unpacking done."));
 }
 
-void DeleteSection(string const & filePath, string const & tag)
+void DeleteSection(std::string const & filePath, std::string const & tag)
 {
   FilesContainerW(filePath, FileWriter::OP_WRITE_EXISTING).DeleteSection(tag);
 }

--- a/generator/unpack_mwm.hpp
+++ b/generator/unpack_mwm.hpp
@@ -2,10 +2,10 @@
 
 #include "base/base.hpp"
 
-#include "std/string.hpp"
+#include <string>
 
 
 // Unpack each section of mwm into a separate file with name filePath.sectionName
-void UnpackMwm(string const & filePath);
+void UnpackMwm(std::string const & filePath);
 
-void DeleteSection(string const & filePath, string const & tag);
+void DeleteSection(std::string const & filePath, std::string const & tag);

--- a/generator/ways_merger.hpp
+++ b/generator/ways_merger.hpp
@@ -3,15 +3,15 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/map.hpp"
-#include "std/vector.hpp"
-#include "std/shared_ptr.hpp"
+#include <map>
+#include <memory>
+#include <vector>
 
 template <class THolder>
 class AreaWayMerger
 {
-  using TPointSeq = vector<m2::PointD>;
-  using TWayMap = multimap<uint64_t, shared_ptr<WayElement>>;
+  using TPointSeq = std::vector<m2::PointD>;
+  using TWayMap = std::multimap<uint64_t, std::shared_ptr<WayElement>>;
   using TWayMapIterator = TWayMap::iterator;
 
   THolder & m_holder;
@@ -22,7 +22,7 @@ public:
 
   void AddWay(uint64_t id)
   {
-    shared_ptr<WayElement> e(new WayElement(id));
+    std::shared_ptr<WayElement> e(new WayElement(id));
     if (m_holder.GetWay(id, *e) && e->IsValid())
     {
       m_map.insert(make_pair(e->nodes.front(), e));
@@ -39,13 +39,13 @@ public:
       TWayMapIterator i = m_map.begin();
       uint64_t id = i->first;
 
-      vector<uint64_t> ids;
+      std::vector<uint64_t> ids;
       TPointSeq points;
 
       do
       {
         // process way points
-        shared_ptr<WayElement> e = i->second;
+        std::shared_ptr<WayElement> e = i->second;
         if (collectID)
           ids.push_back(e->m_wayOsmId);
 

--- a/generator/world_map_generator.hpp
+++ b/generator/world_map_generator.hpp
@@ -44,7 +44,7 @@ public:
                 "borders skipped:", m_skippedBorders, "selected polygons:", m_selectedPolygons));
   }
 
-  void LoadWaterGeometry(string const & rawGeometryFileName)
+  void LoadWaterGeometry(std::string const & rawGeometryFileName)
   {
     LOG_SHORT(LINFO, ("Loading water geometry:", rawGeometryFileName));
     FileReader reader(rawGeometryFileName);


### PR DESCRIPTION
Для cpp файлов добавил `using namespace std;` в случаях:
- количество строк в файле меньше 50 и при этом количество` std::` больше 10
- количество строк в файле  больше или равно 50 и при этом количество `std::` больше 20

тесты генератора прогнал, все ок