### PR TITLE
[routing] Fix updating of mixed maps

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -64,6 +64,7 @@
 
 #include "platform/local_country_file_utils.hpp"
 #include "platform/measurement_utils.hpp"
+#include "platform/mwm_traits.hpp"
 #include "platform/mwm_version.hpp"
 #include "platform/network_policy.hpp"
 #include "platform/platform.hpp"
@@ -2675,9 +2676,13 @@ void Framework::SetRouterImpl(RouterType type)
   }
   else
   {
-    auto localFileChecker = [this](string const & countryFile) -> bool
-    {
-      return m_model.GetIndex().GetMwmIdByCountryFile(CountryFile(countryFile)).IsAlive();
+    auto localFileChecker = [this](string const & countryFile) -> bool {
+      MwmSet::MwmId const mwmId =
+          m_model.GetIndex().GetMwmIdByCountryFile(CountryFile(countryFile));
+      if (!mwmId.IsAlive())
+        return false;
+
+      return version::MwmTraits(mwmId.GetInfo()->m_version).HasRoutingIndex();
     };
 
     auto numMwmIds = make_shared<routing::NumMwmIds>();


### PR DESCRIPTION
WTR:
1. Подложить Russia_Moscow.mw версии 161105 (до того, как появилась секция с index graph). Mwm с подмосковьем должны отсутствовать.
2. Проложить маршрут из Москвы в подмосковье.

Наблюдаемое поведение: maps.me предложит скачать подмосковье. После скачки получится несовместимое сочетание из Москвы старой версии и нового подмосковья, на котором роутинг работать не будет.
Ожидаемое поведение: maps.me должна предложить скачать подмосковье и Москву.

https://jira.mail.ru/browse/MAPSME-3905