### PR TITLE
[routing] Fix index_graph_test.cpp::RestrictionTest_LoopGraph

### DIFF
--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -508,8 +508,13 @@ UNIT_CLASS_TEST(RestrictionTest, LoopGraph)
              routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 2, 0 /* seg id */,
                                                     m2::PointD(0.00005, 0.0004)) /* finish */);
 
-  double constexpr kExpectedRouteTimeSec = 3.92527;
-  TestRouteTime(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, kExpectedRouteTimeSec);
+  vector<Segment> const expectedRoute = {{kTestNumMwmId, 1, 0, true},  {kTestNumMwmId, 0, 0, true},
+                                         {kTestNumMwmId, 0, 1, true},  {kTestNumMwmId, 0, 8, false},
+                                         {kTestNumMwmId, 0, 7, false}, {kTestNumMwmId, 0, 6, false},
+                                         {kTestNumMwmId, 2, 0, true}};
+
+  TestRoute(m_starter->GetStartVertex(), m_starter->GetFinishVertex(), 7, &expectedRoute,
+            m_starter->GetGraph());
 }
 
 UNIT_TEST(IndexGraph_OnlyTopology_1)

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -278,7 +278,8 @@ shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & tr
 
 shared_ptr<EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash)
 {
-  return EdgeEstimator::CreateForCar(trafficStash, 90.0 /* maxSpeedKMpH */);
+  return EdgeEstimator::CreateForCar(trafficStash,
+                                     CarModelFactory().GetVehicleModel()->GetMaxSpeed());
 }
 
 AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & starter,
@@ -335,19 +336,6 @@ void TestRouteGeometry(IndexGraphStarter & starter,
 
   pushPoint(starter.GetPoint(routeSegs.back(), false /* front */));
   TEST_EQUAL(geom, expectedRouteGeom, ());
-}
-
-void TestRouteTime(IndexGraphStarter & starter,
-                   AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
-                   double expectedTime)
-{
-  vector<Segment> routeSegs;
-  double timeSec = 0.0;
-  auto const resultCode = CalculateRoute(starter, routeSegs, timeSec);
-
-  TEST_EQUAL(resultCode, expectedRouteResult, ());
-  double const kEpsilon = 1e-5;
-  TEST(my::AlmostEqualAbs(timeSec, expectedTime, kEpsilon), ());
 }
 
 void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -196,10 +196,6 @@ void TestRouteGeometry(
     routing::AStarAlgorithm<routing::IndexGraphStarter>::Result expectedRouteResult,
     vector<m2::PointD> const & expectedRouteGeom);
 
-void TestRouteTime(IndexGraphStarter & starter,
-                   AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
-                   double expectedTime);
-
 /// \brief Applies |restrictions| to graph in |restrictionTest| and
 /// tests the resulting route.
 /// \note restrictionTest should have a valid |restrictionTest.m_graph|.


### PR DESCRIPTION
После того как поменяли скорости в car model, сломался один из тестов.

Починил.