### PR TITLE
[routing] Route calculation on world graph in case of start and finish leaps.

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -313,6 +313,13 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       continue;
     }
 
+    // In case of leaps from the start to its mwm transition and from finish mwm transition
+    // Route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
+    if ((i == 0 || i + 2 == input.size()) && worldRouteMode == WorldGraph::Mode::LeapsOnly)
+      worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
+    else
+      worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
+
     ++i;
     CHECK_LESS(i, input.size(), ());
     Segment const & next = input[i];

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -302,7 +302,6 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 
   WorldGraph & worldGraph = starter.GetGraph();
   WorldGraph::Mode const worldRouteMode = worldGraph.GetMode();
-  worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
 
   for (size_t i = 0; i < input.size(); ++i)
   {


### PR DESCRIPTION
В случае прокладки маршрута с эвристикой с достроением дуг от старта ко всем выходам из mwm и от всех входов к финишу используется прокладка маршрута по мировому графу.

@dobriy-eeh @ygorshenin @mpimenov PTAL