### PR TITLE
[android] Fixed the order of class fields while marshaling/unmarshali…

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/data/Bookmark.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/Bookmark.java
@@ -58,9 +58,9 @@ public class Bookmark extends MapObject
     dest.writeString(mObjectTitle);
   }
 
-  protected Bookmark(Parcel source)
+  protected Bookmark(@MapObjectType int type, Parcel source)
   {
-    super(source);
+    super(type, source);
     mCategoryId = source.readInt();
     mBookmarkId = source.readInt();
     mIcon = getIconInternal();

--- a/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
@@ -89,13 +89,13 @@ public class MapObject implements Parcelable
       mBanners = new ArrayList<>(Arrays.asList(banners));
   }
 
-  protected MapObject(Parcel source)
+  protected MapObject(@MapObjectType int type, Parcel source)
   {
     //noinspection ResourceType
     this(source.readString(), // MwmName
          source.readLong(),   // MwmVersion
          source.readInt(),    // FeatureId
-         source.readInt(),    // MapObjectType
+         type, // MapObjectType
          source.readString(), // Title
          source.readString(), // SecondaryTitle
          source.readString(), // Subtitle
@@ -268,9 +268,9 @@ public class MapObject implements Parcelable
   {
     @MapObjectType int type = source.readInt();
     if (type == BOOKMARK)
-      return new Bookmark(source);
+      return new Bookmark(type, source);
 
-    return new MapObject(source);
+    return new MapObject(type, source);
   }
 
   @Override
@@ -282,11 +282,12 @@ public class MapObject implements Parcelable
   @Override
   public void writeToParcel(Parcel dest, int flags)
   {
+    // A map object type must be written first, since it's used in readParcel method to distinguish
+    // what type of object should be read from the parcel.
+    dest.writeInt(mMapObjectType);
     dest.writeString(mMwmName);
     dest.writeLong(mMwmVersion);
     dest.writeInt(mFeatureIndex);
-    dest.writeInt(mMapObjectType); // write map object type twice - first int is used to distinguish created object (MapObject or Bookmark)
-    dest.writeInt(mMapObjectType);
     dest.writeString(mTitle);
     dest.writeString(mSecondaryTitle);
     dest.writeString(mSubtitle);


### PR DESCRIPTION
…ng the map object (bookmark)
https://jira.mail.ru/browse/MAPSME-4489

1. После добавления полей mwmName, mwmVersion, mFeatureIndex в класс MapObject сбился необходимый порядок записи/чтения поля mType. Согласно исторически сложившемуся костыль-дизайну это поле должно писаться первым в Parcel, так как оно затем первым читается чтобы понять что это за тип объекта. Воспроизвел синтетически в коде, получил крэш, который у нас есть с версии 7.3.1 https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/59174d25be077a4dccaf45b4?time=last-seven-days
Также скорее всего из-за этого появились другие крэши в этом же классе:
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5916c276be077a4dccaa6a92?time=last-seven-days
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5916c276be077a4dccaa6a92?time=last-seven-days

2. Было очень мутное место с double записью поля mMapObjectType в методе writeToParcel. Я двойную запись убрал и стал передавать прочитанный один раз type в конструктор напрямую.