### PR TITLE
[routing] fix crash near zoo

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -10,10 +10,11 @@ m2::PointD CalcProjectionToSegment(Segment const & segment, m2::PointD const & p
                                    WorldGraph & graph)
 {
   m2::ProjectionToSection<m2::PointD> projection;
-  projection.SetBounds(graph.GetPoint(segment, false), graph.GetPoint(segment, true));
+  projection.SetBounds(graph.GetPoint(segment, false /* front */),
+                       graph.GetPoint(segment, true /* front */));
   return projection(point);
 }
-}
+}  // namespace
 
 namespace routing
 {

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -1,6 +1,19 @@
 #include "routing/index_graph_starter.hpp"
 
-#include "routing/routing_exceptions.hpp"
+#include "geometry/distance.hpp"
+
+namespace
+{
+using namespace routing;
+
+m2::PointD CalcProjectionToSegment(Segment const & segment, m2::PointD const & point,
+                                   WorldGraph & graph)
+{
+  m2::ProjectionToSection<m2::PointD> projection;
+  projection.SetBounds(graph.GetPoint(segment, false), graph.GetPoint(segment, true));
+  return projection(point);
+}
+}
 
 namespace routing
 {
@@ -10,7 +23,11 @@ Segment constexpr IndexGraphStarter::kFinishFakeSegment;
 
 IndexGraphStarter::IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish,
                                      WorldGraph & graph)
-  : m_graph(graph), m_start(start), m_finish(finish)
+  : m_graph(graph)
+  , m_start(start.GetSegment(),
+            CalcProjectionToSegment(start.GetSegment(), start.GetPoint(), graph))
+  , m_finish(finish.GetSegment(),
+             CalcProjectionToSegment(finish.GetSegment(), finish.GetPoint(), graph))
 {
 }
 

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -36,6 +36,7 @@ public:
     NumMwmId GetMwmId() const { return m_segment.GetMwmId(); }
     uint32_t GetFeatureId() const { return m_segment.GetFeatureId(); }
     m2::PointD const & GetPoint() const { return m_point; }
+    Segment const & GetSegment() const { return m_segment; }
 
     Segment GetSegmentWithDirection(bool forward) const
     {

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -211,7 +211,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
   IndexGraphStarter starter(start, finish, graph);
 
   AStarProgress progress(0, 100);
-  progress.Initialize(startPoint, finalPoint);
+  progress.Initialize(starter.GetStartVertex().GetPoint(), starter.GetFinishVertex().GetPoint());
 
   uint32_t drawPointsStep = 0;
   auto onVisitJunction = [&](Segment const & from, Segment const & to) {


### PR DESCRIPTION
Исправление бага https://jira.mail.ru/browse/MAPSME-4172

Нарушался инвариант в AStar.
Причина была в том, что IndexGraphStarter был рассчитан на то, что стартовая и финишная точка лежат на стартовом и финишном сегменте соответственно.

Раньше это обеспечивала инфраструктура, которая располагалась выше по callstack. Теперь это не так, нужно делать проекцию непостредственно в starter.