### PR TITLE
[release-73] Routing issue fixes.

### DIFF
--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -97,6 +97,23 @@ void IndexGraph::SetRestrictions(RestrictionVec && restrictions)
 
 void IndexGraph::SetRoadAccess(RoadAccess && roadAccess) { m_roadAccess = move(roadAccess); }
 
+void IndexGraph::GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, true /* isOutgoing */, edges);
+}
+
+void IndexGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, false /* isOutgoing */, edges);
+}
+
+double IndexGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+{
+  return m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+}
+
 double IndexGraph::CalcSegmentWeight(Segment const & segment)
 {
   return m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId()));

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -23,6 +23,10 @@ namespace routing
 class IndexGraph final
 {
 public:
+  // AStarAlgorithm types aliases:
+  using TVertexType = Segment;
+  using TEdgeType = SegmentEdge;
+
   IndexGraph() = default;
   explicit IndexGraph(unique_ptr<GeometryLoader> loader, shared_ptr<EdgeEstimator> estimator);
 
@@ -44,6 +48,11 @@ public:
 
   void SetRestrictions(RestrictionVec && restrictions);
   void SetRoadAccess(RoadAccess && roadAccess);
+
+  // Interface for AStarAlgorithm:
+  void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  double HeuristicCostEstimate(Segment const & from, Segment const & to);
 
   void PushFromSerializer(Joint::Id jointId, RoadPoint const & rp)
   {
@@ -69,6 +78,10 @@ private:
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                           vector<SegmentEdge> & edges);
   double GetPenalties(Segment const & u, Segment const & v) const;
+  m2::PointD const & GetPoint(Segment const & segment, bool front)
+  {
+    return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
+  }
 
   Geometry m_geometry;
   shared_ptr<EdgeEstimator> m_estimator;

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -25,9 +25,9 @@ Segment constexpr IndexGraphStarter::kFinishFakeSegment;
 IndexGraphStarter::IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish, WorldGraph & graph)
   : m_graph(graph)
   , m_start(start.GetSegment(),
-            CalcProjectionToSegment(start.GetSegment(), start.GetPoint(), graph), start.GetSoft())
+            CalcProjectionToSegment(start.GetSegment(), start.GetPoint(), graph), start.IsSoft())
   , m_finish(finish.GetSegment(),
-             CalcProjectionToSegment(finish.GetSegment(), finish.GetPoint(), graph), finish.GetSoft())
+             CalcProjectionToSegment(finish.GetSegment(), finish.GetPoint(), graph), finish.IsSoft())
 {
 }
 
@@ -98,7 +98,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
 void IndexGraphStarter::GetFakeToNormalEdges(FakeVertex const & fakeVertex, bool isOutgoing,
                                              vector<SegmentEdge> & edges)
 {
-  if (!fakeVertex.GetSoft())
+  if (!fakeVertex.IsSoft())
   {
     GetFakeToNormalEdge(fakeVertex, fakeVertex.GetSegment().IsForward(), edges);
     return;

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -25,9 +25,9 @@ Segment constexpr IndexGraphStarter::kFinishFakeSegment;
 IndexGraphStarter::IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish, WorldGraph & graph)
   : m_graph(graph)
   , m_start(start.GetSegment(),
-            CalcProjectionToSegment(start.GetSegment(), start.GetPoint(), graph), start.IsSoft())
+            CalcProjectionToSegment(start.GetSegment(), start.GetPoint(), graph))
   , m_finish(finish.GetSegment(),
-             CalcProjectionToSegment(finish.GetSegment(), finish.GetPoint(), graph), finish.IsSoft())
+             CalcProjectionToSegment(finish.GetSegment(), finish.GetPoint(), graph))
 {
 }
 
@@ -98,12 +98,6 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
 void IndexGraphStarter::GetFakeToNormalEdges(FakeVertex const & fakeVertex, bool isOutgoing,
                                              vector<SegmentEdge> & edges)
 {
-  if (!fakeVertex.IsSoft())
-  {
-    GetFakeToNormalEdge(fakeVertex, fakeVertex.GetSegment().IsForward(), edges);
-    return;
-  }
-
   GetFakeToNormalEdge(fakeVertex, true /* forward */, edges);
 
   if (!m_graph.GetRoadGeometry(fakeVertex.GetMwmId(), fakeVertex.GetFeatureId()).IsOneWay())

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -37,7 +37,7 @@ public:
     uint32_t GetFeatureId() const { return m_segment.GetFeatureId(); }
     m2::PointD const & GetPoint() const { return m_point; }
     Segment const & GetSegment() const { return m_segment; }
-    bool GetSoft() const { return m_soft; }
+    bool IsSoft() const { return m_soft; }
 
     Segment GetSegmentWithDirection(bool forward) const
     {

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -47,11 +47,12 @@ public:
 
     bool Fits(Segment const & segment) const
     {
-      bool const softFits = segment.GetMwmId() == m_segment.GetMwmId() &&
-                            segment.GetFeatureId() == m_segment.GetFeatureId() &&
-                            segment.GetSegmentIdx() == m_segment.GetSegmentIdx();
-      return m_soft ? softFits : softFits && m_segment.IsForward() == segment.IsForward();
+      if (!m_soft)
+        return segment == m_segment;
 
+      return segment.GetMwmId() == m_segment.GetMwmId() &&
+             segment.GetFeatureId() == m_segment.GetFeatureId() &&
+             segment.GetSegmentIdx() == m_segment.GetSegmentIdx();
     }
 
     uint32_t GetSegmentIdxForTesting() const { return m_segment.GetSegmentIdx(); }
@@ -59,6 +60,11 @@ public:
   private:
     Segment m_segment;
     m2::PointD const m_point;
+    // If |m_soft| == true it means that |m_segment| should be used as a two way segment. So it's
+    // possible to go along |m_segment| in any direction. In that case the instanse of FakeVertex
+    // could be considered as a soft FakeVertex.
+    // If |m_soft| == true it means it's possible to go along |m_segment| only in direction according
+    // to its |m_forward| parameter.
     bool const m_soft;
   };
 
@@ -77,6 +83,7 @@ public:
   FakeVertex const & GetStartVertex() const { return m_start; }
   FakeVertex const & GetFinishVertex() const { return m_finish; }
   m2::PointD const & GetPoint(Segment const & segment, bool front);
+  bool FitsStart(Segment const & s) const { return m_start.Fits(s); }
   bool FitsFinish(Segment const & s) const { return m_finish.Fits(s); }
 
   static size_t GetRouteNumPoints(vector<Segment> const & route);

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -17,19 +17,19 @@ class IndexGraphStarter final
 {
 public:
   // AStarAlgorithm types aliases:
-  using TVertexType = WorldGraph::Vertex;
-  using TEdgeType = WorldGraph::Edge;
+  using TVertexType = IndexGraph::TVertexType;
+  using TEdgeType = IndexGraph::TEdgeType;
 
   class FakeVertex final
   {
   public:
     FakeVertex(NumMwmId mwmId, uint32_t featureId, uint32_t segmentIdx, m2::PointD const & point)
-      : m_segment(mwmId, featureId, segmentIdx, true /* forward */), m_point(point), m_soft(true)
+      : m_segment(mwmId, featureId, segmentIdx, true /* forward */), m_point(point)
     {
     }
 
-    FakeVertex(Segment const & segment, m2::PointD const & point, bool soft)
-      : m_segment(segment), m_point(point), m_soft(soft)
+    FakeVertex(Segment const & segment, m2::PointD const & point)
+      : m_segment(segment), m_point(point)
     {
     }
 
@@ -37,7 +37,6 @@ public:
     uint32_t GetFeatureId() const { return m_segment.GetFeatureId(); }
     m2::PointD const & GetPoint() const { return m_point; }
     Segment const & GetSegment() const { return m_segment; }
-    bool IsSoft() const { return m_soft; }
 
     Segment GetSegmentWithDirection(bool forward) const
     {
@@ -47,9 +46,6 @@ public:
 
     bool Fits(Segment const & segment) const
     {
-      if (!m_soft)
-        return segment == m_segment;
-
       return segment.GetMwmId() == m_segment.GetMwmId() &&
              segment.GetFeatureId() == m_segment.GetFeatureId() &&
              segment.GetSegmentIdx() == m_segment.GetSegmentIdx();
@@ -60,12 +56,6 @@ public:
   private:
     Segment m_segment;
     m2::PointD const m_point;
-    // If |m_soft| == true it means that |m_segment| should be used as a two way segment. So it's
-    // possible to go along |m_segment| in any direction. In that case the instanse of FakeVertex
-    // could be considered as a soft FakeVertex.
-    // If |m_soft| == true it means it's possible to go along |m_segment| only in direction according
-    // to its |m_forward| parameter.
-    bool const m_soft;
   };
 
   static uint32_t constexpr kFakeFeatureId = numeric_limits<uint32_t>::max();

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -97,10 +97,16 @@ void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeV
   }
 }
 
+m2::PointD IndexRoadGraph::GetJunctionPoint(Segment const & segment, bool front) const
+{
+  return front && m_starter.FitsFinish(segment) ? m_starter.GetFinishVertex().GetPoint()
+                                                : m_starter.GetPoint(segment, front);
+}
+
 Junction IndexRoadGraph::GetJunction(Segment const & segment, bool front) const
 {
   // TODO: Use real altitudes for pedestrian and bicycle routing.
-  return Junction(m_starter.GetPoint(segment, front), feature::kDefaultAltitudeMeters);
+  return Junction(GetJunctionPoint(segment, front), feature::kDefaultAltitudeMeters);
 }
 
 vector<Segment> const & IndexRoadGraph::GetSegments(Junction const & junction,

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -99,8 +99,13 @@ void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeV
 
 m2::PointD IndexRoadGraph::GetJunctionPoint(Segment const & segment, bool front) const
 {
-  return front && m_starter.FitsFinish(segment) ? m_starter.GetFinishVertex().GetPoint()
-                                                : m_starter.GetPoint(segment, front);
+  if (!front && m_starter.FitsStart(segment))
+    return m_starter.GetStartVertex().GetPoint();
+
+  if (front && m_starter.FitsFinish(segment))
+    return m_starter.GetFinishVertex().GetPoint();
+
+  return m_starter.GetPoint(segment, front);
 }
 
 Junction IndexRoadGraph::GetJunction(Segment const & segment, bool front) const

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -29,6 +29,7 @@ public:
 
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;
+  m2::PointD GetJunctionPoint(Segment const & segment, bool front) const;
   Junction GetJunction(Segment const & segment, bool front) const;
   vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1,6 +1,5 @@
 #include "routing/index_router.hpp"
 
-#include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_progress.hpp"
 #include "routing/bicycle_directions.hpp"
 #include "routing/index_graph.hpp"
@@ -191,11 +190,11 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
   IndexGraphStarter::FakeVertex const start(
       Segment(m_numMwmIds->GetId(startFile), startEdge.GetFeatureId().m_index, startEdge.GetSegId(),
               true /* forward */),
-      startPoint, true /* soft */);
+      startPoint);
   IndexGraphStarter::FakeVertex const finish(
       Segment(m_numMwmIds->GetId(finishFile), finishEdge.GetFeatureId().m_index,
               finishEdge.GetSegId(), true /* forward */),
-      finalPoint, true /* soft */);
+      finalPoint);
 
   WorldGraph::Mode mode = WorldGraph::Mode::SingleMwm;
   if (forSingleMwm)
@@ -226,31 +225,25 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
     ++drawPointsStep;
   };
 
-  AStarAlgorithm<IndexGraphStarter> algorithm;
-
   RoutingResult<Segment> routingResult;
-  auto const resultCode = algorithm.FindPathBidirectional(
-      starter, starter.GetStart(), starter.GetFinish(), routingResult, delegate, onVisitJunction);
+  IRouter::ResultCode const result = FindPath(starter.GetStart(), starter.GetFinish(), delegate,
+                                              starter, onVisitJunction, routingResult);
+  if (result != IRouter::NoError)
+    return result;
 
-  switch (resultCode)
-  {
-  case AStarAlgorithm<IndexGraphStarter>::Result::NoPath: return IRouter::RouteNotFound;
-  case AStarAlgorithm<IndexGraphStarter>::Result::Cancelled: return IRouter::Cancelled;
-  case AStarAlgorithm<IndexGraphStarter>::Result::OK:
-    vector<Segment> segments;
-    IRouter::ResultCode const leapsResult =
-        ProcessLeaps(routingResult.path, delegate, starter, segments);
-    if (leapsResult != IRouter::NoError)
-      return leapsResult;
+  vector<Segment> segments;
+  IRouter::ResultCode const leapsResult =
+      ProcessLeaps(routingResult.path, delegate, starter, segments);
+  if (leapsResult != IRouter::NoError)
+    return leapsResult;
 
-    CHECK_GREATER_OR_EQUAL(segments.size(), routingResult.path.size(), ());
+  CHECK_GREATER_OR_EQUAL(segments.size(), routingResult.path.size(), ());
 
-    if (!RedressRoute(segments, delegate, forSingleMwm, starter, route))
-      return IRouter::InternalError;
-    if (delegate.IsCancelled())
-      return IRouter::Cancelled;
-    return IRouter::NoError;
-  }
+  if (!RedressRoute(segments, delegate, forSingleMwm, starter, route))
+    return IRouter::InternalError;
+  if (delegate.IsCancelled())
+    return IRouter::Cancelled;
+  return IRouter::NoError;
 }
 
 bool IndexRouter::FindClosestEdge(platform::CountryFile const & file, m2::PointD const & point,
@@ -302,6 +295,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 
   WorldGraph & worldGraph = starter.GetGraph();
   WorldGraph::Mode const worldRouteMode = worldGraph.GetMode();
+  worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
 
   for (size_t i = 0; i < input.size(); ++i)
   {
@@ -314,58 +308,39 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       continue;
     }
 
+    // Clear previous loaded graphs to not spend too much memory at one time.
+    worldGraph.ClearIndexGraphs();
+
+    ++i;
+    CHECK_LESS(i, input.size(), ());
+    Segment const & next = input[i];
+
+    CHECK(!IndexGraphStarter::IsFakeSegment(current), ());
+    CHECK(!IndexGraphStarter::IsFakeSegment(next), ());
+    CHECK_EQUAL(
+      current.GetMwmId(), next.GetMwmId(),
+      ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
+
+    IRouter::ResultCode result = IRouter::InternalError;
+    RoutingResult<Segment> routingResult;
     // In case of leaps from the start to its mwm transition and from finish mwm transition
     // Route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
     if ((current.GetMwmId() == starter.GetStartVertex().GetMwmId()
         || current.GetMwmId() == starter.GetFinishVertex().GetMwmId())
         && worldRouteMode == WorldGraph::Mode::LeapsOnly)
     {
-      worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
+      // World graph route.
+      result = FindPath(current, next, delegate, worldGraph, {} /* onVisitedVertexCallback */, routingResult);
     }
     else
     {
-      worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
+      // Single mwm route.
+      IndexGraph & indexGraph = worldGraph.GetIndexGraph(current.GetMwmId());
+      result = FindPath(current, next, delegate, indexGraph, {} /* onVisitedVertexCallback */, routingResult);
     }
-
-    ++i;
-    CHECK_LESS(i, input.size(), ());
-    Segment const & next = input[i];
-
-    CHECK_NOT_EQUAL(current, IndexGraphStarter::kFinishFakeSegment, ());
-    CHECK_NOT_EQUAL(next, IndexGraphStarter::kStartFakeSegment, ());
-    if (current != IndexGraphStarter::kStartFakeSegment &&
-        next != IndexGraphStarter::kFinishFakeSegment)
-    {
-      CHECK_EQUAL(
-          current.GetMwmId(), next.GetMwmId(),
-          ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
-    }
-
-    IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */), false /* soft */);
-    IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */), false /* soft */);
-
-    IndexGraphStarter leapStarter(start, finish, starter.GetGraph());
-
-    // Clear previous loaded graphs.
-    // Dont spend too much memory at one time.
-    worldGraph.ClearIndexGraphs();
-
-    AStarAlgorithm<IndexGraphStarter> algorithm;
-    RoutingResult<Segment> routingResult;
-    auto const resultCode = algorithm.FindPathBidirectional(
-        leapStarter, leapStarter.GetStart(), leapStarter.GetFinish(), routingResult, delegate, {});
-
-    switch (resultCode)
-    {
-    case AStarAlgorithm<IndexGraphStarter>::Result::NoPath: return IRouter::RouteNotFound;
-    case AStarAlgorithm<IndexGraphStarter>::Result::Cancelled: return IRouter::Cancelled;
-    case AStarAlgorithm<IndexGraphStarter>::Result::OK:
-      for (Segment const & segment : routingResult.path)
-      {
-        if (!IndexGraphStarter::IsFakeSegment(segment))
-          output.push_back(segment);
-      }
-    }
+    if (result != IRouter::NoError)
+      return result;
+    output.insert(output.end(), routingResult.path.cbegin(), routingResult.path.cend());
   }
 
   return IRouter::NoError;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -302,7 +302,6 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 
   WorldGraph & worldGraph = starter.GetGraph();
   WorldGraph::Mode const worldRouteMode = worldGraph.GetMode();
-  worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
 
   for (size_t i = 0; i < input.size(); ++i)
   {
@@ -313,6 +312,19 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     {
       output.push_back(current);
       continue;
+    }
+
+    // In case of leaps from the start to its mwm transition and from finish mwm transition
+    // Route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
+    if ((current.GetMwmId() == starter.GetStartVertex().GetMwmId()
+        || current.GetMwmId() == starter.GetFinishVertex().GetMwmId())
+        && worldRouteMode == WorldGraph::Mode::LeapsOnly)
+    {
+      worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
+    }
+    else
+    {
+      worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
     }
 
     ++i;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1,5 +1,6 @@
 #include "routing/index_router.hpp"
 
+#include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_progress.hpp"
 #include "routing/bicycle_directions.hpp"
 #include "routing/index_graph.hpp"
@@ -34,6 +35,24 @@ namespace
 size_t constexpr kMaxRoadCandidates = 6;
 float constexpr kProgressInterval = 2;
 uint32_t constexpr kDrawPointsPeriod = 10;
+
+template <typename Graph>
+IRouter::ResultCode FindPath(
+  typename Graph::TVertexType const & start, typename Graph::TVertexType const & finish,
+  RouterDelegate const & delegate, Graph & graph,
+  typename AStarAlgorithm<Graph>::TOnVisitedVertexCallback const & onVisitedVertexCallback,
+  RoutingResult<typename Graph::TVertexType> & routingResult)
+{
+  AStarAlgorithm<Graph> algorithm;
+  auto const resultCode = algorithm.FindPathBidirectional(graph, start, finish, routingResult,
+                                                          delegate, onVisitedVertexCallback);
+  switch (resultCode)
+  {
+    case AStarAlgorithm<Graph>::Result::NoPath: return IRouter::RouteNotFound;
+    case AStarAlgorithm<Graph>::Result::Cancelled: return IRouter::Cancelled;
+    case AStarAlgorithm<Graph>::Result::OK: return IRouter::NoError;
+  }
+}
 
 bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph)
 {
@@ -233,7 +252,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
 
   vector<Segment> segments;
   IRouter::ResultCode const leapsResult =
-      ProcessLeaps(routingResult.path, delegate, starter, segments);
+      ProcessLeaps(routingResult.path, delegate, mode, starter, segments);
   if (leapsResult != IRouter::NoError)
     return leapsResult;
 
@@ -289,20 +308,21 @@ bool IndexRouter::FindClosestEdge(platform::CountryFile const & file, m2::PointD
 
 IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
                                               RouterDelegate const & delegate,
-                                              IndexGraphStarter & starter, vector<Segment> & output)
+                                              WorldGraph::Mode prevMode,
+                                              IndexGraphStarter & starter,
+                                              vector<Segment> & output)
 {
   output.reserve(input.size());
 
   WorldGraph & worldGraph = starter.GetGraph();
-  WorldGraph::Mode const worldRouteMode = worldGraph.GetMode();
   worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
 
   for (size_t i = 0; i < input.size(); ++i)
   {
     Segment const & current = input[i];
 
-    if ((worldRouteMode == WorldGraph::Mode::LeapsOnly && IndexGraphStarter::IsFakeSegment(current))
-      || (worldRouteMode != WorldGraph::Mode::LeapsOnly && !starter.IsLeap(current.GetMwmId())))
+    if ((prevMode == WorldGraph::Mode::LeapsOnly && IndexGraphStarter::IsFakeSegment(current))
+      || (prevMode != WorldGraph::Mode::LeapsOnly && !starter.IsLeap(current.GetMwmId())))
     {
       output.push_back(current);
       continue;
@@ -324,10 +344,10 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     IRouter::ResultCode result = IRouter::InternalError;
     RoutingResult<Segment> routingResult;
     // In case of leaps from the start to its mwm transition and from finish mwm transition
-    // Route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
+    // route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
     if ((current.GetMwmId() == starter.GetStartVertex().GetMwmId()
         || current.GetMwmId() == starter.GetFinishVertex().GetMwmId())
-        && worldRouteMode == WorldGraph::Mode::LeapsOnly)
+        && prevMode == WorldGraph::Mode::LeapsOnly)
     {
       // World graph route.
       result = FindPath(current, next, delegate, worldGraph, {} /* onVisitedVertexCallback */, routingResult);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -191,11 +191,11 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(string const & startCountry,
   IndexGraphStarter::FakeVertex const start(
       Segment(m_numMwmIds->GetId(startFile), startEdge.GetFeatureId().m_index, startEdge.GetSegId(),
               true /* forward */),
-      startPoint);
+      startPoint, true /* soft */);
   IndexGraphStarter::FakeVertex const finish(
       Segment(m_numMwmIds->GetId(finishFile), finishEdge.GetFeatureId().m_index,
               finishEdge.GetSegId(), true /* forward */),
-      finalPoint);
+      finalPoint, true /* soft */);
 
   WorldGraph::Mode mode = WorldGraph::Mode::SingleMwm;
   if (forSingleMwm)
@@ -307,7 +307,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
   for (size_t i = 0; i < input.size(); ++i)
   {
     Segment const & current = input[i];
-    if (worldRouteMode == WorldGraph::Mode::LeapsIfPossible && !starter.IsLeap(current.GetMwmId()))
+
+    if ((worldRouteMode == WorldGraph::Mode::LeapsOnly && IndexGraphStarter::IsFakeSegment(current))
+      || (worldRouteMode != WorldGraph::Mode::LeapsOnly && !starter.IsLeap(current.GetMwmId())))
     {
       output.push_back(current);
       continue;
@@ -327,14 +329,8 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
           ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
     }
 
-    IndexGraphStarter::FakeVertex const start =
-        (current == IndexGraphStarter::kStartFakeSegment)
-            ? starter.GetStartVertex()
-            : IndexGraphStarter::FakeVertex(current, starter.GetPoint(current, true /* front */));
-    IndexGraphStarter::FakeVertex const finish =
-        (next == IndexGraphStarter::kFinishFakeSegment)
-            ? starter.GetFinishVertex()
-            : IndexGraphStarter::FakeVertex(next, starter.GetPoint(next, true /* front */));
+    IndexGraphStarter::FakeVertex const start(current, starter.GetPoint(current, true /* front */), false /* soft */);
+    IndexGraphStarter::FakeVertex const finish(next, starter.GetPoint(next, true /* front */), false /* soft */);
 
     IndexGraphStarter leapStarter(start, finish, starter.GetGraph());
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "routing/base/astar_algorithm.hpp"
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
@@ -78,28 +77,13 @@ private:
                        bool isOutgoing, WorldGraph & worldGraph, Edge & closestEdge) const;
   // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
   // ProcessLeaps replaces each leap with calculated route through mwm.
-  IRouter::ResultCode ProcessLeaps(vector<Segment> const & input, RouterDelegate const & delegate,
-                                   IndexGraphStarter & starter, vector<Segment> & output);
+  IRouter::ResultCode ProcessLeaps(vector<Segment> const & input,
+                                   RouterDelegate const & delegate,
+                                   WorldGraph::Mode prevMode,
+                                   IndexGraphStarter & starter,
+                                   vector<Segment> & output);
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
                     bool forSingleMwm, IndexGraphStarter & starter, Route & route) const;
-
-  template <typename Graph>
-  IRouter::ResultCode FindPath(
-      typename Graph::TVertexType const & start, typename Graph::TVertexType const & finish,
-      RouterDelegate const & delegate, Graph & graph,
-      typename AStarAlgorithm<Graph>::TOnVisitedVertexCallback const & onVisitedVertexCallback,
-      RoutingResult<typename Graph::TVertexType> & routingResult)
-  {
-    AStarAlgorithm<Graph> algorithm;
-    auto const resultCode = algorithm.FindPathBidirectional(graph, start, finish, routingResult,
-                                                            delegate, onVisitedVertexCallback);
-    switch (resultCode)
-    {
-    case AStarAlgorithm<Graph>::Result::NoPath: return IRouter::RouteNotFound;
-    case AStarAlgorithm<Graph>::Result::Cancelled: return IRouter::Cancelled;
-    case AStarAlgorithm<Graph>::Result::OK: return IRouter::NoError;
-    }
-  }
 
   bool AreMwmsNear(NumMwmId startId, NumMwmId finishId) const;
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/base/astar_algorithm.hpp"
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
@@ -81,6 +82,24 @@ private:
                                    IndexGraphStarter & starter, vector<Segment> & output);
   bool RedressRoute(vector<Segment> const & segments, RouterDelegate const & delegate,
                     bool forSingleMwm, IndexGraphStarter & starter, Route & route) const;
+
+  template <typename Graph>
+  IRouter::ResultCode FindPath(
+      typename Graph::TVertexType const & start, typename Graph::TVertexType const & finish,
+      RouterDelegate const & delegate, Graph & graph,
+      typename AStarAlgorithm<Graph>::TOnVisitedVertexCallback const & onVisitedVertexCallback,
+      RoutingResult<typename Graph::TVertexType> & routingResult)
+  {
+    AStarAlgorithm<Graph> algorithm;
+    auto const resultCode = algorithm.FindPathBidirectional(graph, start, finish, routingResult,
+                                                            delegate, onVisitedVertexCallback);
+    switch (resultCode)
+    {
+    case AStarAlgorithm<Graph>::Result::NoPath: return IRouter::RouteNotFound;
+    case AStarAlgorithm<Graph>::Result::Cancelled: return IRouter::Cancelled;
+    case AStarAlgorithm<Graph>::Result::OK: return IRouter::NoError;
+    }
+  }
 
   bool AreMwmsNear(NumMwmId startId, NumMwmId finishId) const;
 

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -137,6 +137,13 @@ namespace
         {39.836562407458047, 65.774372510437971}, 239426.);
   }
 
+  UNIT_TEST(RussiaMoscowBelarusMinsk)
+  {
+    integration::CalculateRouteAndTestRouteLength(integration::GetOsrmComponents(),
+                                                  MercatorBounds::FromLatLon(55.750650, 37.617673), {0., 0.},
+                                                  MercatorBounds::FromLatLon(53.902114, 27.562020), 712649.0);
+  }
+
   // TODO OSRM offers a possible turn to a pedestrian road in this test. It's fixing right now.
   UNIT_TEST(UKRugbyStIvesRouteTest)
   {

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -91,9 +91,14 @@ namespace integration
       return infoGetter.GetLimitRectForLeaf(countryId);
     };
 
-    shared_ptr<NumMwmIds> numMwmIds = make_shared<NumMwmIds>();
-    for (LocalCountryFile const & f : localFiles)
-      numMwmIds->RegisterFile(f.GetCountryFile());
+    auto numMwmIds = make_shared<NumMwmIds>();
+    for (auto const & f : localFiles)
+    {
+      auto const & countryFile = f.GetCountryFile();
+      auto const mwmId = index.GetMwmIdByCountryFile(countryFile);
+      if (mwmId.GetInfo()->GetType() == MwmInfo::COUNTRY && countryFile.GetName() != "minsk-pass")
+        numMwmIds->RegisterFile(countryFile);
+    }
 
     auto carRouter = make_unique<CarRouter>(
         index, countryFileGetter,

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -375,7 +375,7 @@ UNIT_TEST(OneSegmentWay)
   IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 0, 0, m2::PointD(1, 0));
   IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 0, 0, m2::PointD(2, 0));
 
-  // According to picture above it seems that direction of route segment should be true but it's false
+  // According to picture below it seems that direction of route segment should be true but it's false
   // according to current code. The reason is the start and the finish of the route are projected to
   // the same segment. In IndexGraphStarter::GetEdgesList() two fake edges are added. One of them
   // from start to end of the segment. The other one is from beginning of the segment to the finish.

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -375,7 +375,28 @@ UNIT_TEST(OneSegmentWay)
   IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 0, 0, m2::PointD(1, 0));
   IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 0, 0, m2::PointD(2, 0));
 
-  vector<Segment> const expectedRoute({{kTestNumMwmId, 0, 0, true}});
+  // According to picture above it seems that direction of route segment should be true but it's false
+  // according to current code. The reason is the start and the finish of the route are projected to
+  // the same segment. In IndexGraphStarter::GetEdgesList() two fake edges are added. One of them
+  // from start to end of the segment. The other one is from beginning of the segment to the finish.
+  // So the route will be built in opposite direction of segment 0 of feature 0. See IndexGraphStarter
+  // for details.
+  //
+  //                    finish
+  //                      O
+  //                  ↗
+  //               ↗
+  //            ↗
+  //    R0    * - - - - - - - - *
+  //                         ↗
+  //                      ↗
+  //                   ↗
+  //                O
+  //              start
+  //
+  //    x:    0     1     2     3
+  vector<Segment> const expectedRoute({{kTestNumMwmId, 0 /* featureId */, 0 /* seg id */,
+                                        false /* forward */}});
   TestRoute(start, finish, 1 /* expectedLength */, &expectedRoute, *worldGraph);
 }
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -47,6 +47,23 @@ RoadGeometry const & WorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featur
   return GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
 }
 
+void WorldGraph::GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, true /* isOutgoing */, false /* isLeap */, edges);
+}
+
+void WorldGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, false /* isOutgoing */, false /* isLeap */, edges);
+}
+
+double WorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+{
+  return m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+}
+
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
 {
   m_twins.clear();

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -17,9 +17,13 @@ namespace routing
 class WorldGraph final
 {
 public:
+  // AStarAlgorithm types aliases:
+  using TVertexType = IndexGraph::TVertexType;
+  using TEdgeType = IndexGraph::TEdgeType;
+
   // CheckGraphConnectivity() types aliases:
-  using Vertex = Segment;
-  using Edge = SegmentEdge;
+  using Vertex = TVertexType;
+  using Edge = TEdgeType;
 
   enum class Mode
   {
@@ -49,7 +53,12 @@ public:
   void ClearIndexGraphs() { m_loader->Clear(); }
   void SetMode(Mode mode) { m_mode = mode; }
   Mode GetMode() const { return m_mode; }
-  
+
+  // Interface for AStarAlgorithm:
+  void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  double HeuristicCostEstimate(Segment const & from, Segment const & to);
+
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
   {
@@ -61,7 +70,7 @@ public:
     return m_crossMwmGraph->IsTransition(s, isOutgoing);
   }
 
-private:  
+private:
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;


### PR DESCRIPTION
Данный PR исправляет ряд тонких багов в системе маршрутизации. 

В первом коммите (Routing issue fixes...):
1. Исправлено нарушение инварианта эвристики A*, если старт указан около переходного сегмента. Это было связано с тем, что в этой ситуации для переходного сегмента выдавалась одна координата, а для его близнеца другая. Главное исправление в IndexGraphStarter::GetPoint();
2. Возможность разворота не на joint, а на road point после склеивания маршрута из кусочков при cross mwm routing. Ранее разворот на road point, которая не является joint был возможен, при наличии разворота сразу после переходной точки;
3. Корректность сегментов маршрута после склеивания из кусочков. Ранее корректность нарушалась при наличии разворота сразу после переходной точки;

Во втором коммите ([routing] Route calculation on world graph)...:
Прокладка маршрута от старта к выходу стартовой mwm и от входа финишной mwm к финишу по мировому графу.

@dobriy-eeh , @ygorshenin , @mpimenov PTAL

@dobriy-eeh добавь п-та интеграционный тест на маршрут Москва - Минск
