### PR TITLE
[indexer] Check for runtime selectors for static displacement

### DIFF
--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -68,17 +68,6 @@ bool IsMiddleTunnel(int const layer, double const depth)
   return layer != feature::LAYER_EMPTY && depth < 19000;
 }
 
-void FilterRulesByRuntimeSelector(FeatureType const & f, int zoomLevel, drule::KeysT & keys)
-{
-  keys.erase_if([&f, zoomLevel](drule::Key const & key)->bool
-  {
-    drule::BaseRule const * const rule = drule::rules().Find(key);
-    if (rule == nullptr)
-      return true;
-    return !rule->TestFeature(f, zoomLevel);
-  });
-}
-
 class Aggregator
 {
 public:
@@ -382,7 +371,7 @@ bool InitStylist(FeatureType const & f, int8_t deviceLang, int const zoomLevel, 
   drule::KeysT keys;
   pair<int, bool> const geomType = feature::GetDrawRule(types, zoomLevel, keys);
 
-  FilterRulesByRuntimeSelector(f, zoomLevel, keys);
+  feature::FilterRulesByRuntimeSelector(f, zoomLevel, keys);
 
   if (keys.empty())
     return false;
@@ -433,7 +422,7 @@ double GetFeaturePriority(FeatureType const & f, int const zoomLevel)
   drule::KeysT keys;
   pair<int, bool> const geomType = feature::GetDrawRule(f, zoomLevel, keys);
 
-  FilterRulesByRuntimeSelector(f, zoomLevel, keys);
+  feature::FilterRulesByRuntimeSelector(f, zoomLevel, keys);
 
   feature::EGeomType const mainGeomType = feature::EGeomType(geomType.first);
 

--- a/indexer/displacement_manager.hpp
+++ b/indexer/displacement_manager.hpp
@@ -185,6 +185,8 @@ private:
       // Calculate depth field
       drule::KeysT keys;
       feature::GetDrawRule(ft, zoomLevel, keys);
+      // While the function has "runtime" in its name, it merely filters by metadata-based rules.
+      feature::FilterRulesByRuntimeSelector(ft, zoomLevel, keys);
       drule::MakeUnique(keys);
       float depth = 0;
       for (size_t i = 0, count = keys.size(); i < count; ++i)

--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -1,6 +1,6 @@
 #include "indexer/feature_visibility.hpp"
 #include "indexer/classificator.hpp"
-#include "indexer/feature.hpp"
+#include "indexer/drawing_rules.hpp"
 #include "indexer/scales.hpp"
 
 #include "base/assert.hpp"
@@ -112,6 +112,17 @@ void GetDrawRule(vector<uint32_t> const & types, int level, int geoType,
 
   for (uint32_t t : types)
     (void)c.ProcessObjects(t, doRules);
+}
+
+void FilterRulesByRuntimeSelector(FeatureType const & f, int zoomLevel, drule::KeysT & keys)
+{
+  keys.erase_if([&f, zoomLevel](drule::Key const & key)->bool
+  {
+    drule::BaseRule const * const rule = drule::rules().Find(key);
+    if (rule == nullptr)
+      return true;
+    return !rule->TestFeature(f, zoomLevel);
+  });
 }
 
 namespace

--- a/indexer/feature_visibility.hpp
+++ b/indexer/feature_visibility.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "indexer/drawing_rule_def.hpp"
+#include "indexer/feature.hpp"
 #include "indexer/feature_decl.hpp"
 
 #include "base/base.hpp"
@@ -64,6 +65,7 @@ namespace feature
                               drule::KeysT & keys);
   void GetDrawRule(vector<uint32_t> const & types, int level, int geoType,
                    drule::KeysT & keys);
+  void FilterRulesByRuntimeSelector(FeatureType const & f, int zoomLevel, drule::KeysT & keys);
 
   /// Used to check whether user types belong to particular classificator set.
   class TypeSetChecker


### PR DESCRIPTION
MAPSME-4407

Гостиницы с рейтингом 8 должны вытеснять гостиницы с рейтингом 7, но не вытесняли. Оказалось, статическое вытеснение учитывало только тип объекта, но не дополнительные свойства. Теоретически это должно было ускорить индексацию.

Я добавил фильтрацию правил по селекторам на основе полной информации об объекте. Это замедлило сборку Москвы меньше, чем на два процента. Теперь гостиницы вытесняются в правильном порядке.

Основное изменение в коде — что `FilterRulesByRuntimeSelector` вынес из `drape_frontend` в `indexer`.