### PR TITLE
traffic manager map deregistered fix

### DIFF
--- a/indexer/mwm_set.hpp
+++ b/indexer/mwm_set.hpp
@@ -239,7 +239,7 @@ public:
 
     // Called when a map is updated to a newer version. Feel free to
     // treat it as combined OnMapRegistered(newFile) +
-    // OnMapRegistered(oldFile).
+    // OnMapDeregistered(oldFile).
     virtual void OnMapUpdated(platform::LocalCountryFile const & /*newFile*/,
                               platform::LocalCountryFile const & /*oldFile*/) {}
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -664,11 +664,9 @@ bool Framework::OnCountryFileDelete(storage::TCountryId const & countryId, stora
   bool deferredDelete = false;
   if (localFile)
   {
-    auto const mwmId = m_model.GetIndex().GetMwmIdByCountryFile(platform::CountryFile(countryId));
     rect = m_infoGetter->GetLimitRectForLeaf(countryId);
     m_model.DeregisterMap(platform::CountryFile(countryId));
     deferredDelete = true;
-    m_trafficManager.OnMwmDelete(mwmId);
     m_localAdsManager.OnDeleteCountry(countryId);
   }
   InvalidateRect(rect);
@@ -690,6 +688,9 @@ void Framework::OnMapDeregistered(platform::LocalCountryFile const & localFile)
     action();
   else
     GetPlatform().RunOnGuiThread(action);
+
+  auto const mwmId = m_model.GetIndex().GetMwmIdByCountryFile(localFile.GetCountryFile());
+  m_trafficManager.OnMwmDeregistered(mwmId);
 }
 
 bool Framework::HasUnsavedEdits(storage::TCountryId const & countryId)

--- a/map/traffic_manager.cpp
+++ b/map/traffic_manager.cpp
@@ -141,7 +141,7 @@ void TrafficManager::SetCurrentDataVersion(int64_t dataVersion)
   m_currentDataVersion = dataVersion;
 }
 
-void TrafficManager::OnMwmDelete(MwmSet::MwmId const & mwmId)
+void TrafficManager::OnMwmDeregistered(MwmSet::MwmId const & mwmId)
 {
   if (!IsEnabled())
     return;
@@ -237,8 +237,7 @@ void TrafficManager::ThreadRoutine()
   {
     for (auto const & mwm : mwms)
     {
-      auto const & mwmInfo = mwm.GetInfo();
-      if (!mwmInfo)
+      if (!mwm.IsAlive())
         continue;
 
       traffic::TrafficInfo info(mwm, m_currentDataVersion);

--- a/map/traffic_manager.hpp
+++ b/map/traffic_manager.hpp
@@ -79,7 +79,7 @@ public:
 
   void OnDestroyGLContext();
   void OnRecoverGLContext();
-  void OnMwmDelete(MwmSet::MwmId const & mwmId);
+  void OnMwmDeregistered(MwmSet::MwmId const & mwmId);
 
   void OnEnterForeground();
   void OnEnterBackground();


### PR DESCRIPTION
Пофиксил случай, когда мы обновляем карту, а в трафик менеджере не обновляется список валидных mwm