### PR TITLE
[generator]  Prevent merging different tags into one type

### DIFF
--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -305,13 +305,15 @@ namespace ftype
         current = path.back().get();
 
         // Next objects trying to find by value first.
-        ClassifObjectPtr pObj =
-            ForEachTagEx<ClassifObjectPtr>(p, skipRows, [&current](string const & k, string const & v)
-            {
-              if (!NeedMatchValue(k, v))
-                return ClassifObjectPtr();
-              return current->BinaryFind(v);
-            });
+        // Prevent merging different tags (e.g. shop=pet from shop=abandoned, was:shop=pet).
+       ClassifObjectPtr pObj =
+           path.size() == 1 ? ClassifObjectPtr()
+                            : ForEachTagEx<ClassifObjectPtr>(
+                                  p, skipRows, [&current](string const & k, string const & v) {
+                                    if (!NeedMatchValue(k, v))
+                                      return ClassifObjectPtr();
+                                    return current->BinaryFind(v);
+                                  });
 
         if (pObj)
         {


### PR DESCRIPTION
MAPSME-4288

Из highway=abandoned + abandoned:highway=path мы собирали highway-path. Здесь я устраняю такие случаи.

(вместо #6029)