### PR TITLE
[search] Fixed numero signs in search queries and names.

### DIFF
--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -236,6 +236,12 @@ bool IsASCIIString(std::string const & str)
 }
 
 bool IsASCIIDigit(UniChar c) { return c >= '0' && c <= '9'; }
+
+bool IsASCIISpace(UniChar c)
+{
+  return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
+}
+
 bool IsASCIILatin(UniChar c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); }
 
 bool StartsWith(UniString const & s, UniString const & p)

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -88,6 +88,7 @@ UniString MakeUniString(std::string const & utf8s);
 std::string ToUtf8(UniString const & s);
 bool IsASCIIString(std::string const & str);
 bool IsASCIIDigit(UniChar c);
+bool IsASCIISpace(UniChar c);
 bool IsASCIILatin(UniChar c);
 
 inline std::string DebugPrint(UniString const & s) { return ToUtf8(s); }

--- a/indexer/indexer_tests/search_string_utils_test.cpp
+++ b/indexer/indexer_tests/search_string_utils_test.cpp
@@ -4,9 +4,13 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/vector.hpp"
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace search;
+using namespace std;
 using namespace strings;
 
 namespace
@@ -41,6 +45,11 @@ bool TestStreetSynonym(char const * s)
 bool TestStreetPrefixMatch(char const * s)
 {
   return IsStreetSynonymPrefix(MakeUniString(s));
+}
+
+string NormalizeAndSimplifyStringUtf8(string const & s)
+{
+  return strings::ToUtf8(NormalizeAndSimplifyString(s));
 }
 } // namespace
 
@@ -170,4 +179,13 @@ UNIT_TEST(StreetTokensFilter)
 
     TEST_EQUAL(expected, actual, ());
   }
+}
+
+UNIT_TEST(NormalizeAndSimplifyString_Numero)
+{
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона №51"), "зона  51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона № 51"), "зона   51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area #51"), "area  51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area # "), "area   ", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area #One"), "area #one", ());
 }

--- a/indexer/postcodes_matcher.cpp
+++ b/indexer/postcodes_matcher.cpp
@@ -8,6 +8,7 @@
 #include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
+#include "std/algorithm.hpp"
 #include "std/transform_iterator.hpp"
 #include "std/unique_ptr.hpp"
 #include "std/utility.hpp"

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -5,8 +5,6 @@
 #include "base/macros.hpp"
 #include "base/mem_trie.hpp"
 
-#include <cctype>
-
 using namespace std;
 using namespace strings;
 
@@ -29,10 +27,10 @@ void RemoveNumeroSigns(UniString & s)
     }
 
     size_t j = i + 1;
-    while (j < n && isspace(s[j]))
+    while (j < n && IsASCIISpace(s[j]))
       ++j;
 
-    if (j == n || isdigit(s[j]))
+    if (j == n || IsASCIIDigit(s[j]))
       s[i] = ' ';
 
     i = j;
@@ -68,9 +66,9 @@ UniString NormalizeAndSimplifyString(string const & s)
       break;
     // Some Danish-specific hacks.
     case 0x00d8:  // Ø
-    case 0x00f8:
+    case 0x00f8:  // ø
       c = 'o';
-      break;      // ø
+      break;
     case 0x0152:  // Œ
     case 0x0153:  // œ
       c = 'o';

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -1,55 +1,61 @@
 #pragma once
+
+#include "indexer/search_delimiters.hpp"
+
 #include "base/stl_add.hpp"
 #include "base/string_utils.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/functional.hpp"
-#include "std/string.hpp"
-#include "std/utility.hpp"
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
 
 namespace search
 {
 
 // This function should be used for all search strings normalization.
 // It does some magic text transformation which greatly helps us to improve our search.
-strings::UniString NormalizeAndSimplifyString(string const & s);
+strings::UniString NormalizeAndSimplifyString(std::string const & s);
 
-template <class DelimsT, typename F>
-void SplitUniString(strings::UniString const & uniS, F f, DelimsT const & delims)
+template <class Delims, typename Fn>
+void SplitUniString(strings::UniString const & uniS, Fn f, Delims const & delims)
 {
-  for (strings::TokenizeIterator<DelimsT> iter(uniS, delims); iter; ++iter)
+  for (strings::TokenizeIterator<Delims> iter(uniS, delims); iter; ++iter)
     f(iter.GetUniString());
 }
 
-template <typename TCont, typename TDelims>
-void NormalizeAndTokenizeString(string const & s, TCont & tokens, TDelims const & delims)
+template <typename Tokens, typename Delims>
+void NormalizeAndTokenizeString(std::string const & s, Tokens & tokens, Delims const & delims)
 {
   SplitUniString(NormalizeAndSimplifyString(s), MakeBackInsertFunctor(tokens), delims);
 }
 
+template <typename Tokens>
+void NormalizeAndTokenizeString(std::string const & s, Tokens & tokens)
+{
+  SplitUniString(NormalizeAndSimplifyString(s), MakeBackInsertFunctor(tokens),
+                 search::Delimiters());
+}
+
 strings::UniString FeatureTypeToString(uint32_t type);
 
-template <class ContainerT, class DelimsT>
+template <class Tokens, class Delims>
 bool TokenizeStringAndCheckIfLastTokenIsPrefix(strings::UniString const & s,
-                                               ContainerT & tokens,
-                                               DelimsT const & delimiter)
+                                               Tokens & tokens,
+                                               Delims const & delims)
 {
-  SplitUniString(s, MakeBackInsertFunctor(tokens), delimiter);
-  return !s.empty() && !delimiter(s.back());
+  SplitUniString(s, MakeBackInsertFunctor(tokens), delims);
+  return !s.empty() && !delims(s.back());
 }
 
-
-template <class ContainerT, class DelimsT>
-bool TokenizeStringAndCheckIfLastTokenIsPrefix(string const & s,
-                                               ContainerT & tokens,
-                                               DelimsT const & delimiter)
+template <class Tokens, class Delims>
+bool TokenizeStringAndCheckIfLastTokenIsPrefix(std::string const & s, Tokens & tokens,
+                                               Delims const & delims)
 {
-  return TokenizeStringAndCheckIfLastTokenIsPrefix(NormalizeAndSimplifyString(s),
-                                                   tokens,
-                                                   delimiter);
+  return TokenizeStringAndCheckIfLastTokenIsPrefix(NormalizeAndSimplifyString(s), tokens, delims);
 }
 
-strings::UniString GetStreetNameAsKey(string const & name);
+strings::UniString GetStreetNameAsKey(std::string const & name);
 
 // *NOTE* The argument string must be normalized and simplified.
 bool IsStreetSynonym(strings::UniString const & s);
@@ -57,7 +63,7 @@ bool IsStreetSynonymPrefix(strings::UniString const & s);
 
 /// Normalizes both str and substr, and then returns true if substr is found in str.
 /// Used in native platform code for search in localized strings (cuisines, categories, strings etc.).
-bool ContainsNormalized(string const & str, string const & substr);
+bool ContainsNormalized(std::string const & str, std::string const & substr);
 
 // This class can be used as a filter for street tokens.  As there can
 // be street synonyms in the street name, single street synonym is
@@ -68,11 +74,10 @@ bool ContainsNormalized(string const & str, string const & substr);
 class StreetTokensFilter
 {
 public:
-  using TCallback = function<void(strings::UniString const & token, size_t tag)>;
+  using Callback = std::function<void(strings::UniString const & token, size_t tag)>;
 
   template <typename TC>
-  StreetTokensFilter(TC && callback)
-    : m_callback(forward<TC>(callback))
+  StreetTokensFilter(TC && callback) : m_callback(std::forward<TC>(callback))
   {
   }
 
@@ -84,7 +89,7 @@ public:
   void Put(strings::UniString const & token, bool isPrefix, size_t tag);
 
 private:
-  using TCell = pair<strings::UniString, size_t>;
+  using Cell = std::pair<strings::UniString, size_t>;
 
   inline void EmitToken(strings::UniString const & token, size_t tag) { m_callback(token, tag); }
 
@@ -92,6 +97,7 @@ private:
   size_t m_delayedTag = 0;
   size_t m_numSynonyms = 0;
 
-  TCallback m_callback;
+  Callback m_callback;
 };
+
 }  // namespace search

--- a/indexer/string_set.hpp
+++ b/indexer/string_set.hpp
@@ -5,6 +5,7 @@
 
 #include "std/cstdint.hpp"
 #include "std/unique_ptr.hpp"
+#include "std/utility.hpp"
 
 namespace search
 {

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -847,5 +847,24 @@ UNIT_CLASS_TEST(ProcessorTest, StopWords)
     TEST_EQUAL(info.m_nameScore, NAME_SCORE_FULL_MATCH, ());
   }
 }
+
+UNIT_CLASS_TEST(ProcessorTest, Numerals)
+{
+  TestCountry country(m2::PointD(0, 0), "Беларусь", "ru");
+  TestPOI school(m2::PointD(0, 0), "СШ №61", "ru");
+  school.SetTypes({{"amenity", "school"}});
+
+  auto id = BuildCountry(country.GetName(), [&](TestMwmBuilder & builder) { builder.Add(school); });
+
+  SetViewport(m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0)));
+  {
+    TRules rules{ExactMatch(id, school)};
+    TEST(ResultsMatch("Школа 61", "ru", rules), ());
+    TEST(ResultsMatch("Школа # 61", "ru", rules), ());
+    TEST(ResultsMatch("school #61", "ru", rules), ());
+    TEST(ResultsMatch("сш №61", "ru", rules), ());
+    TEST(ResultsMatch("школа", "ru", rules), ());
+  }
+}
 }  // namespace
 }  // namespace search


### PR DESCRIPTION
'#' and '№' before digits are considered as spaces now.