### PR TITLE
[routing] Turn generation fix. Removing segments duplicates.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2671,14 +2671,20 @@ void Framework::SetRouterImpl(RouterType type)
     return m_infoGetter->GetRegionCountryId(p);
   };
 
+  auto numMwmIds = make_shared<routing::NumMwmIds>();
+  m_storage.ForEachCountryFile(
+    [&](platform::CountryFile const & file) { numMwmIds->RegisterFile(file); });
+
   if (type == RouterType::Pedestrian)
   {
-    router = CreatePedestrianAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter);
+    router =
+      CreatePedestrianAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter, numMwmIds);
     m_routingSession.SetRoutingSettings(routing::GetPedestrianRoutingSettings());
   }
   else if (type == RouterType::Bicycle)
   {
-    router = CreateBicycleAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter);
+    router =
+      CreateBicycleAStarBidirectionalRouter(m_model.GetIndex(), countryFileGetter, numMwmIds);
     m_routingSession.SetRoutingSettings(routing::GetBicycleRoutingSettings());
   }
   else
@@ -2691,10 +2697,6 @@ void Framework::SetRouterImpl(RouterType type)
 
       return version::MwmTraits(mwmId.GetInfo()->m_version).HasRoutingIndex();
     };
-
-    auto numMwmIds = make_shared<routing::NumMwmIds>();
-    m_storage.ForEachCountryFile(
-        [&](platform::CountryFile const & file) { numMwmIds->RegisterFile(file); });
 
     auto const getMwmRectByName = [this](string const & countryId) -> m2::RectD {
       return m_infoGetter->GetLimitRectForLeaf(countryId);

--- a/map/mwm_tree.hpp
+++ b/map/mwm_tree.hpp
@@ -3,6 +3,7 @@
 #include "routing/num_mwm_id.hpp"
 
 #include "storage/country_info_getter.hpp"
+#include "storage/storage.hpp"
 
 #include "geometry/tree4d.hpp"
 

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -212,6 +212,9 @@ void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
   MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, dummyTimes, streetNames,
                      trafficSegs);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());
+  // In case of bicycle routing |m_pathSegments| may have an empty
+  // |LoadedPathSegment::m_trafficSegs| fields. In that case |trafficSegs| is empty
+  // so size of |trafficSegs| is not equal to size of |routeEdges|.
   if (!trafficSegs.empty())
     CHECK_EQUAL(trafficSegs.size(), routeEdges.size(), ());
 }
@@ -252,6 +255,7 @@ void BicycleDirectionsEngine::GetUniNodeIdAndAdjacentEdges(IRoadGraph::TEdgeVect
   outgoingTurns.isCandidatesAngleValid = true;
   outgoingTurns.candidates.reserve(outgoingEdges.size());
   uniNodeId = UniNodeId(inEdge.GetFeatureId(), startSegId, endSegId, inEdge.IsForward());
+  CHECK(uniNodeId.IsCorrect(), ());
   m2::PointD const & ingoingPoint = inEdge.GetStartJunction().GetPoint();
   m2::PointD const & junctionPoint = inEdge.GetEndJunction().GetPoint();
 
@@ -364,7 +368,7 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
 
     AdjacentEdges adjacentEdges(ingoingEdges.size());
     UniNodeId uniNodeId(UniNodeId::Type::Mwm);
-    GetUniNodeIdAndAdjacentEdges(outgoingEdges, inEdge, startSegId, inSegId + 1, uniNodeId,
+    GetUniNodeIdAndAdjacentEdges(outgoingEdges, inEdge, startSegId, inSegId, uniNodeId,
                                  adjacentEdges.m_outgoingTurns);
 
     size_t const prevJunctionSize = prevJunctions.size();

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -44,17 +44,9 @@ private:
                                            vector<Junction> const & path,
                                            IRoadGraph::TEdgeVector const & routeEdges,
                                            my::Cancellable const & cancellable);
-  /// \brief This method should be called for an internal junction of the route with corresponding
-  /// |ingoingEdges|, |outgoingEdges|, |ingoingRouteEdge| and |outgoingRouteEdge|.
-  /// \returns false if the junction is an internal point of feature segment and can be considered as
-  /// a part of LoadedPathSegment and returns true if the junction should be considered as a beginning
-  /// of a new LoadedPathSegment.
-  bool IsJoint(IRoadGraph::TEdgeVector const & ingoingEdges,
-               IRoadGraph::TEdgeVector const & outgoingEdges, Edge const & ingoingRouteEdge,
-               Edge const & outgoingRouteEdge);
 
-  bool GetSegment(FeatureID const & featureId, uint32_t segId, bool isFeatureForward,
-                  Segment & segment);
+  bool GetSegment(FeatureID const & featureId, uint32_t segId, bool forward,
+                  Segment & segment) const;
 
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -24,7 +24,9 @@ public:
 
   using AdjacentEdgesMap = std::map<UniNodeId, AdjacentEdges>;
 
-  BicycleDirectionsEngine(Index const & index, std::shared_ptr<NumMwmIds> numMwmIds);
+  BicycleDirectionsEngine(Index const & index,
+                          std::shared_ptr<NumMwmIds> numMwmIds,
+                          bool generateTrafficSegs);
 
   // IDirectionsEngine override:
   void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
@@ -39,7 +41,7 @@ private:
                                     uint32_t startSegId,
                                     uint32_t endSegId,
                                     UniNodeId & uniNodeId,
-                                    BicycleDirectionsEngine::AdjacentEdges & adjacentEdges);
+                                    turns::TurnCandidates & outgoingTurns);
   /// \brief The method gathers sequence of segments according to IsJoint() method
   /// and fills |m_adjacentEdges| and |m_pathSegments|.
   void FillPathSegmentsAndAdjacentEdgesMap(RoadGraphBase const & graph,
@@ -47,13 +49,19 @@ private:
                                            IRoadGraph::TEdgeVector const & routeEdges,
                                            my::Cancellable const & cancellable);
 
-  bool GetSegment(FeatureID const & featureId, uint32_t segId, bool forward,
-                  Segment & segment) const;
+  Segment GetSegment(FeatureID const & featureId, uint32_t segId, bool forward) const;
+
+  void GetEdges(RoadGraphBase const & graph, Junction const & currJunction,
+                bool isCurrJunctionFinish, IRoadGraph::TEdgeVector & outgoing,
+                IRoadGraph::TEdgeVector & ingoing);
 
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;
   Index const & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   std::unique_ptr<Index::FeaturesLoaderGuard> m_loader;
+  // If |m_generateTrafficSegs| is set to true |LoadedPathSegment::m_trafficSeg| is filled
+  // and not otherwise.
+  bool const m_generateTrafficSegs;
 };
 }  // namespace routing

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -33,8 +33,28 @@ public:
 
 private:
   Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
-  void LoadPathGeometry(UniNodeId const & uniNodeId, vector<Junction> const & path,
-                        LoadedPathSegment & pathSegment);
+  void LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment);
+  void GetUniNodeIdAndAdjacentEdges(IRoadGraph::TEdgeVector const & outgoingEdges,
+                                    FeatureID const & inFeatureId, uint32_t startSegId,
+                                    uint32_t endSegId, bool inIsForward, UniNodeId & uniNodeId,
+                                    BicycleDirectionsEngine::AdjacentEdges & adjacentEdges);
+  /// \brief The method gathers sequence of segments according to IsJoint() method
+  /// and fills |m_adjacentEdges| and |m_pathSegments|.
+  void FillPathSegmentsAndAdjacentEdgesMap(RoadGraphBase const & graph,
+                                           vector<Junction> const & path,
+                                           IRoadGraph::TEdgeVector const & routeEdges,
+                                           my::Cancellable const & cancellable);
+  /// \brief This method should be called for an internal junction of the route with corresponding
+  /// |ingoingEdges|, |outgoingEdges|, |ingoingRouteEdge| and |outgoingRouteEdge|.
+  /// \returns false if the junction is an internal point of feature segment and can be considered as
+  /// a part of LoadedPathSegment and returns true if the junction should be considered as a beginning
+  /// of a new LoadedPathSegment.
+  bool IsJoint(IRoadGraph::TEdgeVector const & ingoingEdges,
+               IRoadGraph::TEdgeVector const & outgoingEdges, Edge const & ingoingRouteEdge,
+               Edge const & outgoingRouteEdge);
+
+  bool GetSegment(FeatureID const & featureId, uint32_t segId, bool isFeatureForward,
+                  Segment & segment);
 
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -35,8 +35,10 @@ private:
   Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
   void LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment);
   void GetUniNodeIdAndAdjacentEdges(IRoadGraph::TEdgeVector const & outgoingEdges,
-                                    FeatureID const & inFeatureId, uint32_t startSegId,
-                                    uint32_t endSegId, bool inIsForward, UniNodeId & uniNodeId,
+                                    Edge const & inEdge,
+                                    uint32_t startSegId,
+                                    uint32_t endSegId,
+                                    UniNodeId & uniNodeId,
                                     BicycleDirectionsEngine::AdjacentEdges & adjacentEdges);
   /// \brief The method gathers sequence of segments according to IsJoint() method
   /// and fills |m_adjacentEdges| and |m_pathSegments|.

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -19,7 +19,7 @@ void IDirectionsEngine::CalculateTimes(RoadGraphBase const & graph, vector<Junct
     return;
 
   // graph.GetMaxSpeedKMPH() below is used on purpose.
-  // The idea is while pedestian (bicycle) routing ways for pedestrians (cyclists) are prefered.
+  // The idea is while pedestrian (bicycle) routing ways for pedestrians (cyclists) are preferred.
   // At the same time routing along big roads is still possible but if there's
   // a pedestrian (bicycle) alternative it's prefered. To implement it a small speed
   // is set in pedestrian_model (bicycle_model) for big roads. On the other hand

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -70,35 +70,6 @@ bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph
   return !CheckGraphConnectivity(segment, kDeadEndTestLimit, worldGraph,
                                  getVertexByEdgeFn, getOutgoingEdgesFn);
 }
-
-// ReconstructRoute duplicates polyline internal points.
-// Internal points are all polyline points except first and last.
-//
-// Need duplicate times also.
-void DuplicateRouteTimes(size_t const polySize, Route::TTimes &times)
-{
-  if (polySize - 2 != (times.size() - 2) * 2)
-  {
-    LOG(LERROR, ("Can't duplicate route times, polyline:", polySize, ", times:", times.size()));
-    return;
-  }
-
-  Route::TTimes duplicatedTimes;
-  duplicatedTimes.reserve(polySize);
-  size_t index = 0;
-  duplicatedTimes.emplace_back(index++, times.front().second);
-
-  for (size_t i = 1; i < times.size() - 1; ++i)
-  {
-    double const time = times[i].second;
-    duplicatedTimes.emplace_back(index++, time);
-    duplicatedTimes.emplace_back(index++, time);
-  }
-
-  duplicatedTimes.emplace_back(index++, times.back().second);
-  times = move(duplicatedTimes);
-  CHECK_EQUAL(times.size(), polySize, ());
-}
 }  // namespace
 
 namespace routing
@@ -404,7 +375,6 @@ bool IndexRouter::RedressRoute(vector<Segment> const & segments, RouterDelegate 
     time += starter.CalcSegmentWeight(segments[i]);
   }
 
-  DuplicateRouteTimes(route.GetPoly().GetSize(), times);
   route.SetSectionTimes(move(times));
   return true;
 }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -402,7 +402,7 @@ unique_ptr<IndexRouter> IndexRouter::CreateCarRouter(TCountryFileFn const & coun
   auto vehicleModelFactory = make_shared<CarModelFactory>();
   // @TODO Bicycle turn generation engine is used now. It's ok for the time being.
   // But later a special car turn generation engine should be implemented.
-  auto directionsEngine = make_unique<BicycleDirectionsEngine>(index, numMwmIds);
+  auto directionsEngine = make_unique<BicycleDirectionsEngine>(index, numMwmIds, true /* generateTrafficSegs */);
 
   double maxSpeed = 0.0;
   numMwmIds->ForEachId([&](NumMwmId id) {

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -54,6 +54,8 @@ struct LoadedPathSegment
     m_onRoundabout = false;
     m_isLink = false;
   }
+
+  bool IsValid() const { return !m_path.empty(); }
 };
 
 using TUnpackedPathSegments = vector<LoadedPathSegment>;

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -234,7 +234,9 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn co
   return router;
 }
 
-unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn)
+unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index,
+                                                             TCountryFileFn const & countryFileFn,
+                                                             shared_ptr<NumMwmIds> /* numMwmIds */)
 {
   unique_ptr<VehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
@@ -245,11 +247,14 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCou
   return router;
 }
 
-unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn)
+unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index,
+                                                          TCountryFileFn const & countryFileFn,
+                                                          shared_ptr<NumMwmIds> numMwmIds)
 {
   unique_ptr<VehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
-  unique_ptr<IDirectionsEngine> directionsEngine(new BicycleDirectionsEngine(index, nullptr));
+  unique_ptr<IDirectionsEngine> directionsEngine(
+      new BicycleDirectionsEngine(index, numMwmIds, false /* generateTrafficSegs */));
   unique_ptr<IRouter> router(new RoadGraphRouter(
       "astar-bidirectional-bicycle", index, countryFileFn, IRoadGraph::Mode::ObeyOnewayTag,
       move(vehicleModelFactory), move(algorithm), move(directionsEngine)));

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -10,6 +10,7 @@
 #include "indexer/mwm_set.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/tree4d.hpp"
 
 #include "std/function.hpp"
 #include "std/string.hpp"
@@ -51,6 +52,10 @@ private:
 };
 
 unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index, TCountryFileFn const & countryFileFn);
-unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn);
-unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index, TCountryFileFn const & countryFileFn);
+unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index,
+                                                             TCountryFileFn const & countryFileFn,
+                                                             shared_ptr<NumMwmIds> /* numMwmIds */);
+unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index,
+                                                          TCountryFileFn const & countryFileFn,
+                                                          shared_ptr<NumMwmIds> numMwmIds);
 }  // namespace routing

--- a/routing/routing_benchmarks/bicycle_routing_tests.cpp
+++ b/routing/routing_benchmarks/bicycle_routing_tests.cpp
@@ -25,10 +25,11 @@ public:
 
 protected:
   // RoutingTest overrides:
-  unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine() override
+  unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
+    shared_ptr<routing::NumMwmIds> numMwmIds) override
   {
-    unique_ptr<routing::IDirectionsEngine> engine(
-        new routing::BicycleDirectionsEngine(m_index, nullptr /* numMwmIds */));
+    unique_ptr<routing::IDirectionsEngine> engine(new routing::BicycleDirectionsEngine(
+        m_index, numMwmIds, false /* generateTrafficSegs */));
     return engine;
   }
 

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -70,6 +70,8 @@ RoutingTest::RoutingTest(routing::IRoadGraph::Mode mode, set<string> const & nee
   set<string> registeredMaps;
   for (auto const & localFile : localFiles)
   {
+    m_numMwmIds->RegisterFile(localFile.GetCountryFile());
+
     auto const & name = localFile.GetCountryName();
     if (neededMaps.count(name) == 0)
       continue;

--- a/routing/routing_benchmarks/helpers.hpp
+++ b/routing/routing_benchmarks/helpers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/num_mwm_id.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/router.hpp"
 #include "routing/road_graph_router.hpp"
@@ -30,7 +31,8 @@ public:
   void TestTwoPointsOnFeature(m2::PointD const & startPos, m2::PointD const & finalPos);
 
 protected:
-  virtual unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine() = 0;
+  virtual unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
+      shared_ptr<routing::NumMwmIds> numMwmIds) = 0;
   virtual unique_ptr<routing::VehicleModelFactory> CreateModelFactory() = 0;
 
   template <typename Algorithm>
@@ -40,7 +42,7 @@ protected:
     unique_ptr<routing::IRoutingAlgorithm> algorithm(new Algorithm());
     unique_ptr<routing::IRouter> router(
         new routing::RoadGraphRouter(name, m_index, getter, m_mode, CreateModelFactory(),
-                                     move(algorithm), CreateDirectionsEngine()));
+                                     move(algorithm), CreateDirectionsEngine(m_numMwmIds)));
     return router;
   }
 
@@ -49,6 +51,8 @@ protected:
 
   routing::IRoadGraph::Mode const m_mode;
   Index m_index;
+
+  shared_ptr<routing::NumMwmIds> m_numMwmIds;
   unique_ptr<storage::CountryInfoGetter> m_cig;
 };
 

--- a/routing/routing_benchmarks/pedestrian_routing_tests.cpp
+++ b/routing/routing_benchmarks/pedestrian_routing_tests.cpp
@@ -38,7 +38,8 @@ public:
 
 protected:
   // RoutingTest overrides:
-  unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine() override
+  unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
+    shared_ptr<routing::NumMwmIds> /* numMwmIds */) override
   {
     unique_ptr<routing::IDirectionsEngine> engine(new routing::PedestrianDirectionsEngine());
     return engine;

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -80,7 +80,6 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
       }
       traffic.push_back(segTraffic);
     }
-    CHECK(!traffic.empty(), ());
     CHECK_EQUAL(trafficSegs.size(), traffic.size(), ());
   }
 

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -63,7 +63,7 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   vector<traffic::SpeedGroup> traffic;
   if (trafficStash && !trafficSegs.empty())
   {
-    traffic.reserve(2 * trafficSegs.size());
+    traffic.reserve(trafficSegs.size());
     for (Segment const & seg : trafficSegs)
     {
       traffic::TrafficInfo::RoadSegmentId roadSegment(
@@ -78,22 +78,10 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
         if (it != trafficColoring->cend())
           segTraffic = it->second;
       }
-      // @TODO It's written to compensate an error. The problem is in case of any routing except for osrm
-      // all route points except for begining and ending are duplicated.
-      // See a TODO in BicycleDirectionsEngine::Generate() for details.
-      // At this moment the route looks like:
-      // 0----1    4----5
-      //      2----3    6---7
-      // This route consists of 4 edges and there're 4 items in trafficSegs.
-      // But it has 8 items in routeGeometry.
-      // So for segments 0-1 and 1-2 let's set trafficSegs[0]
-      // for segments 2-3 and 3-4 let's set trafficSegs[1]
-      // for segments 4-5 and 5-6 let's set trafficSegs[2]
-      // and for segment 6-7 let's set trafficSegs[3]
-      traffic.insert(traffic.end(), {segTraffic, segTraffic});
+      traffic.push_back(segTraffic);
     }
     CHECK(!traffic.empty(), ());
-    traffic.pop_back();
+    CHECK_EQUAL(trafficSegs.size(), traffic.size(), ());
   }
 
   route.SetTraffic(move(traffic));

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -28,7 +28,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId, TAltitude const alti
                                   TAltitude const altitudeUpperBoundMeters)
 {
   Index index;
-  platform::LocalCountryFile const country = platform::LocalCountryFile::MakeForTesting(countryId);
+  platform::LocalCountryFile const country = platform::LocalCountryFile::MakeForTesting(countryId, 170511);
   pair<MwmSet::MwmId, MwmSet::RegResult> const regResult = index.RegisterMap(country);
 
   TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -28,7 +28,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId, TAltitude const alti
                                   TAltitude const altitudeUpperBoundMeters)
 {
   Index index;
-  platform::LocalCountryFile const country = platform::LocalCountryFile::MakeForTesting(countryId, 170511);
+  platform::LocalCountryFile const country = platform::LocalCountryFile::MakeForTesting(countryId);
   pair<MwmSet::MwmId, MwmSet::RegResult> const regResult = index.RegisterMap(country);
 
   TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -52,7 +52,19 @@ static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
 namespace routing
 {
 // UniNodeId -------------------------------------------------------------------
-uint32_t UniNodeId::nextFakeId = 0;
+std::atomic<uint32_t> UniNodeId::m_nextFakeId(0);
+
+UniNodeId::UniNodeId(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId,
+                     bool forward)
+  : m_type(Type::Mwm)
+  , m_featureId(featureId)
+  , m_startSegId(startSegId)
+  , m_endSegId(endSegId)
+  , m_forward(forward)
+{
+  if (!m_featureId.IsValid())
+    m_nodeId = m_nextFakeId++;
+}
 
 bool UniNodeId::operator==(UniNodeId const & rhs) const
 {

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -52,6 +52,8 @@ static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
 namespace routing
 {
 // UniNodeId -------------------------------------------------------------------
+uint32_t UniNodeId::nextFakeId = 0;
+
 bool UniNodeId::operator==(UniNodeId const & rhs) const
 {
   if (m_type != rhs.m_type)
@@ -61,7 +63,8 @@ bool UniNodeId::operator==(UniNodeId const & rhs) const
   {
   case Type::Osrm: return m_nodeId == rhs.m_nodeId;
   case Type::Mwm:
-    return m_featureId == rhs.m_featureId && m_segId == rhs.m_segId && m_forward == rhs.m_forward;
+    return m_featureId == rhs.m_featureId && m_startSegId == rhs.m_startSegId &&
+           m_endSegId == rhs.m_endSegId && m_forward == rhs.m_forward && m_nodeId == rhs.m_nodeId;
   }
 }
 
@@ -77,17 +80,24 @@ bool UniNodeId::operator<(UniNodeId const & rhs) const
     if (m_featureId != rhs.m_featureId)
       return m_featureId < rhs.m_featureId;
 
-    if (m_segId != rhs.m_segId)
-      return m_segId < rhs.m_segId;
+    if (m_startSegId != rhs.m_startSegId)
+      return m_startSegId < rhs.m_startSegId;
 
-    return m_forward < rhs.m_forward;
+    if (m_endSegId != rhs.m_endSegId)
+      return m_endSegId < rhs.m_endSegId;
+
+    if (m_forward != rhs.m_forward)
+      return m_forward < rhs.m_forward;
+
+    return m_nodeId < rhs.m_nodeId;
   }
 }
 
 void UniNodeId::Clear()
 {
   m_featureId = FeatureID();
-  m_segId = 0;
+  m_startSegId = 0;
+  m_endSegId = 0;
   m_forward = true;
   m_nodeId = SPECIAL_NODEID;
 }
@@ -102,18 +112,6 @@ FeatureID const & UniNodeId::GetFeature() const
 {
   ASSERT_EQUAL(m_type, Type::Mwm, ());
   return m_featureId;
-}
-
-uint32_t UniNodeId::GetSegId() const
-{
-  ASSERT_EQUAL(m_type, Type::Mwm, ());
-  return m_segId;
-}
-
-bool UniNodeId::IsForward() const
-{
-  ASSERT_EQUAL(m_type, Type::Mwm, ());
-  return m_forward;
 }
 
 string DebugPrint(UniNodeId::Type type)

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -52,7 +52,7 @@ static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
 namespace routing
 {
 // UniNodeId -------------------------------------------------------------------
-std::atomic<uint32_t> UniNodeId::m_nextFakeId(0);
+std::atomic<NodeID> UniNodeId::m_nextFakeId(0);
 
 UniNodeId::UniNodeId(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId,
                      bool forward)
@@ -63,7 +63,10 @@ UniNodeId::UniNodeId(FeatureID const & featureId, uint32_t startSegId, uint32_t 
   , m_forward(forward)
 {
   if (!m_featureId.IsValid())
+  {
     m_nodeId = m_nextFakeId++;
+    CHECK_NOT_EQUAL(m_nodeId, SPECIAL_NODEID, ());
+  }
 }
 
 bool UniNodeId::operator==(UniNodeId const & rhs) const

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -129,6 +129,12 @@ FeatureID const & UniNodeId::GetFeature() const
   return m_featureId;
 }
 
+bool UniNodeId::IsCorrect() const
+{
+  return m_type == Type::Mwm &&
+         (m_forward && m_startSegId <= m_endSegId || !m_forward && m_endSegId <= m_startSegId);
+}
+
 string DebugPrint(UniNodeId::Type type)
 {
   switch (type)

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -39,7 +39,7 @@ struct UniNodeId
   FeatureID const & GetFeature() const;
 
 private:
-  static std::atomic<uint32_t> m_nextFakeId;
+  static std::atomic<NodeID> m_nextFakeId;
 
   Type m_type;
   FeatureID m_featureId;     // Not valid for OSRM.

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -9,6 +9,8 @@
 #include "std/string.hpp"
 #include "std/vector.hpp"
 
+#include <atomic>
+
 #include "3party/osrm/osrm-backend/typedefs.h"
 
 namespace routing
@@ -27,18 +29,9 @@ struct UniNodeId
     Mwm,  // It's a node for A* router so |m_nodeId| is not valid.
   };
 
-  UniNodeId(Type type) : m_type(type) {}
-  UniNodeId(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId, bool forward)
-    : m_type(Type::Mwm)
-    , m_featureId(featureId)
-    , m_startSegId(startSegId)
-    , m_endSegId(endSegId)
-    , m_forward(forward)
-  {
-    if (!m_featureId.IsValid())
-      m_nodeId = nextFakeId++;
-  }
-  UniNodeId(uint32_t nodeId) : m_type(Type::Osrm), m_nodeId(nodeId) {}
+  explicit UniNodeId(Type type) : m_type(type) {}
+  UniNodeId(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId, bool forward);
+  explicit UniNodeId(uint32_t nodeId) : m_type(Type::Osrm), m_nodeId(nodeId) {}
   bool operator==(UniNodeId const & rh) const;
   bool operator<(UniNodeId const & rh) const;
   void Clear();
@@ -46,7 +39,8 @@ struct UniNodeId
   FeatureID const & GetFeature() const;
 
 private:
-  static uint32_t nextFakeId;
+  static std::atomic<uint32_t> m_nextFakeId;
+
   Type m_type;
   FeatureID m_featureId;     // Not valid for OSRM.
   uint32_t m_startSegId = 0; // Not valid for OSRM. The first segment index of UniNodeId.

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -37,14 +37,18 @@ struct UniNodeId
   void Clear();
   uint32_t GetNodeId() const;
   FeatureID const & GetFeature() const;
+  // \returns true if the instance of UniNodeId is correct.
+  bool IsCorrect() const;
 
 private:
   static std::atomic<NodeID> m_nextFakeId;
 
   Type m_type;
   FeatureID m_featureId;     // Not valid for OSRM.
+  // Note. In mwm case if UniNodeId represents two directional feature |m_endSegId| is greater
+  // than |m_startSegId| if |m_forward| == true.
   uint32_t m_startSegId = 0; // Not valid for OSRM. The first segment index of UniNodeId.
-  uint32_t m_endSegId = 0;   // Not valid for OSRM. The segment index after last of UniNodeId.
+  uint32_t m_endSegId = 0;   // Not valid for OSRM. The last segment index UniNodeId.
   bool m_forward = true;     // Not valid for OSRM. Segment direction in |m_featureId|.
   // Node id for OSRM case. Fake feature id if UniNodeId is based on an invalid feature id valid for
   // mwm case. UniNodeId is based on an invalid feature id in case of fake edges near starts and

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -326,6 +326,13 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
 
     // Path geometry.
     CHECK_GREATER_OR_EQUAL(loadedSegmentIt->m_path.size(), 2, ());
+    // Note. Every LoadedPathSegment in TUnpackedPathSegments contains LoadedPathSegment::m_path
+    // of several Junctions. Last Junction in a LoadedPathSegment::m_path is equal to first junction
+    // in next LoadedPathSegment::m_path in vector TUnpackedPathSegments:
+    // *---*---*---*---*       *---*           *---*---*---*
+    //                 *---*---*   *---*---*---*
+    // To prevent having repetitions in |junctions| list it's necessary to take the first point only from the
+    // first item of |loadedSegments|. The beginning should be ignored for the rest |m_path|.
     junctions.insert(junctions.end(), loadedSegmentIt == loadedSegments.cbegin()
                                           ? loadedSegmentIt->m_path.cbegin()
                                           : loadedSegmentIt->m_path.cbegin() + 1,

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -278,6 +278,8 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
   for (auto loadedSegmentIt = loadedSegments.cbegin(); loadedSegmentIt != loadedSegments.cend();
        ++loadedSegmentIt)
   {
+    CHECK(loadedSegmentIt->IsValid(), ());
+
     // ETA information.
     double const nodeTimeSeconds = loadedSegmentIt->m_weight;
 
@@ -323,7 +325,11 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
       --skipTurnSegments;
 
     // Path geometry.
-    junctions.insert(junctions.end(), loadedSegmentIt->m_path.begin(), loadedSegmentIt->m_path.end());
+    CHECK_GREATER_OR_EQUAL(loadedSegmentIt->m_path.size(), 2, ());
+    junctions.insert(junctions.end(), loadedSegmentIt == loadedSegments.cbegin()
+                                          ? loadedSegmentIt->m_path.cbegin()
+                                          : loadedSegmentIt->m_path.cbegin() + 1,
+                     loadedSegmentIt->m_path.cend());
     trafficSegs.insert(trafficSegs.end(), loadedSegmentIt->m_trafficSegs.cbegin(),
                        loadedSegmentIt->m_trafficSegs.cend());
   }


### PR DESCRIPTION
1. Правильная генерация маневров при авто (index_graph) и вело роутинге;
2. Удаление дублирующихся точке в маршруте;
3. Исправление срабатывающего ASSERT на не уникальность uniNodeId. (Они были не уникальны при фейковых фичах);

@dobriy-eeh @ygorshenin @mpimenov PTAL