### PR TITLE
[qt] Implemented log-abort-level flag for Qt Desktop app.

### DIFF
--- a/base/logging.cpp
+++ b/base/logging.cpp
@@ -1,5 +1,5 @@
-#include "base/assert.hpp"
 #include "base/logging.hpp"
+#include "base/assert.hpp"
 #include "base/macros.hpp"
 #include "base/mutex.hpp"
 #include "base/thread.hpp"
@@ -8,94 +8,139 @@
 #include "std/target_os.hpp"
 //#include "std/windows.hpp"
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <mutex>
 #include <sstream>
+#include <vector>
 
 namespace my
 {
-  class LogHelper
-  {
-    int m_threadsCount;
-    std::map<threads::ThreadID, int> m_threadID;
-
-    int GetThreadID()
-    {
-      int & id = m_threadID[threads::GetCurrentThreadID()];
-      if (id == 0)
-        id = ++m_threadsCount;
-      return id;
-    }
-
-    my::Timer m_timer;
-
-    char const * m_names[5];
-    size_t m_lens[5];
-
-  public:
-    LogHelper() : m_threadsCount(0)
-    {
-      m_names[0] = "DEBUG"; m_lens[0] = 5;
-      m_names[1] = "INFO"; m_lens[1] = 4;
-      m_names[2] = "WARNING"; m_lens[2] = 7;
-      m_names[3] = "ERROR"; m_lens[3] = 5;
-      m_names[4] = "CRITICAL"; m_lens[4] = 8;
-    }
-
-    void WriteProlog(std::ostream & s, LogLevel level)
-    {
-      s << "LOG";
-
-      s << " TID(" << GetThreadID() << ")";
-      s << " " << m_names[level];
-
-      double const sec = m_timer.ElapsedSeconds();
-      s << " " << std::setfill(' ') << std::setw(static_cast<int>(16 - m_lens[level])) << sec << " ";
-    }
-  };
-
-  std::mutex g_logMutex;
-
-  void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string const & msg)
-  {
-    std::lock_guard<std::mutex> lock(g_logMutex);
-
-    static LogHelper logger;
-
-    std::ostringstream out;
-    logger.WriteProlog(out, level);
-
-    out << DebugPrint(srcPoint) << msg << std::endl;
-    std::cerr << out.str();
-
-    CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
-  }
-
-  void LogMessageTests(LogLevel level, SrcPoint const &, std::string const & msg)
-  {
-    std::lock_guard<std::mutex> lock(g_logMutex);
-
-    std::ostringstream out;
-    out << msg << std::endl;
-    std::cerr << out.str();
-
-    CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
-  }
-
-  LogMessageFn LogMessage = &LogMessageDefault;
-
-  LogMessageFn SetLogMessageFn(LogMessageFn fn)
-  {
-    std::swap(LogMessage, fn);
-    return fn;
-  }
-
-#ifdef DEBUG
-  TLogLevel g_LogLevel = {LDEBUG};
-  TLogLevel g_LogAbortLevel = {LERROR};
-#else
-  TLogLevel g_LogLevel = {LINFO};
-  TLogLevel g_LogAbortLevel = {LCRITICAL};
-#endif
+std::string ToString(LogLevel level)
+{
+  auto const & names = GetLogLevelNames();
+  CHECK_LESS(level, names.size(), ());
+  return names[level];
 }
+
+bool FromString(std::string const & s, LogLevel & level)
+{
+  auto const & names = GetLogLevelNames();
+  auto it = std::find(names.begin(), names.end(), s);
+  if (it == names.end())
+    return false;
+  level = static_cast<LogLevel>(std::distance(names.begin(), it));
+  return true;
+}
+
+std::vector<std::string> const & GetLogLevelNames()
+{
+  static std::vector<std::string> const kNames = {
+      {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}};
+  return kNames;
+}
+
+class LogHelper
+{
+  int m_threadsCount;
+  std::map<threads::ThreadID, int> m_threadID;
+
+  int GetThreadID()
+  {
+    int & id = m_threadID[threads::GetCurrentThreadID()];
+    if (id == 0)
+      id = ++m_threadsCount;
+    return id;
+  }
+
+  my::Timer m_timer;
+
+  char const * m_names[5];
+  size_t m_lens[5];
+
+public:
+  LogHelper() : m_threadsCount(0)
+  {
+    m_names[0] = "DEBUG";
+    m_lens[0] = 5;
+    m_names[1] = "INFO";
+    m_lens[1] = 4;
+    m_names[2] = "WARNING";
+    m_lens[2] = 7;
+    m_names[3] = "ERROR";
+    m_lens[3] = 5;
+    m_names[4] = "CRITICAL";
+    m_lens[4] = 8;
+  }
+
+  void WriteProlog(std::ostream & s, LogLevel level)
+  {
+    s << "LOG";
+
+    s << " TID(" << GetThreadID() << ")";
+    s << " " << m_names[level];
+
+    double const sec = m_timer.ElapsedSeconds();
+    s << " " << std::setfill(' ') << std::setw(static_cast<int>(16 - m_lens[level])) << sec << " ";
+  }
+};
+
+std::mutex g_logMutex;
+
+void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string const & msg)
+{
+  std::lock_guard<std::mutex> lock(g_logMutex);
+
+  static LogHelper logger;
+
+  std::ostringstream out;
+  logger.WriteProlog(out, level);
+
+  out << DebugPrint(srcPoint) << msg << std::endl;
+  std::cerr << out.str();
+
+  CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
+}
+
+void LogMessageTests(LogLevel level, SrcPoint const &, std::string const & msg)
+{
+  std::lock_guard<std::mutex> lock(g_logMutex);
+
+  std::ostringstream out;
+  out << msg << std::endl;
+  std::cerr << out.str();
+
+  CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
+}
+
+LogMessageFn LogMessage = &LogMessageDefault;
+
+LogMessageFn SetLogMessageFn(LogMessageFn fn)
+{
+  std::swap(LogMessage, fn);
+  return fn;
+}
+
+LogLevel GetDefaultLogLevel()
+{
+#if defined(DEBUG)
+  return LDEBUG;
+#else
+  return LINFO;
+#endif  // defined(DEBUG)
+}
+
+LogLevel GetDefaultLogAbortLevel()
+{
+#if defined(DEBUG)
+  return LERROR;
+#else
+  return LCRITICAL;
+#endif  // defined(DEBUG)
+}
+
+TLogLevel g_LogLevel = {GetDefaultLogLevel()};
+TLogLevel g_LogAbortLevel = {GetDefaultLogAbortLevel()};
+}  // namespace my

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -14,6 +14,7 @@ execute_process(
 
 include_directories(
   ${OMIM_ROOT}/3party/glm
+  ${OMIM_ROOT}/3party/gflags/src
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
@@ -74,6 +75,7 @@ omim_link_libraries(
   base
   freetype
   expat
+  gflags
   icu
   jansson
   protobuf

--- a/qt/qt.pro
+++ b/qt/qt.pro
@@ -3,12 +3,14 @@ ROOT_DIR = ..
 
 DEPENDENCIES = qt_common map drape_frontend openlr routing search storage tracking traffic routing_common \
                indexer drape partners_api local_ads platform editor geometry \
-               coding base freetype expat jansson protobuf osrm stats_client \
+               coding base freetype expat gflags jansson protobuf osrm stats_client \
                minizip succinct pugixml oauthcpp stb_image sdf_image icu
 
 DEPENDENCIES += opening_hours \
 
 include($$ROOT_DIR/common.pri)
+
+INCLUDEPATH *= $$ROOT_DIR/3party/gflags/src
 
 TARGET = MAPS.ME
 TEMPLATE = app


### PR DESCRIPTION
Sometimes debug build of desktop app crashes because of LERROR messages from HttpThread (as it tries to download local_ads). This flags makes it possible to modify severity of abort messages.