### PR TITLE
[generator] Fix build on linux, deduplicating names

### DIFF
--- a/generator/metalines_builder.cpp
+++ b/generator/metalines_builder.cpp
@@ -41,7 +41,7 @@ public:
     m_end = way.Nodes().back();
   }
 
-  Ways const & Ways() const { return m_ways; }
+  Ways const & GetWays() const { return m_ways; }
 
   void Reverse()
   {
@@ -128,9 +128,9 @@ public:
     std::vector<Ways> result;
     for (LineString const & line : m_parts)
     {
-      if (line.Ways().size() > 1)
+      if (line.GetWays().size() > 1)
       {
-        result.push_back(line.Ways());
+        result.push_back(line.GetWays());
       }
     }
     return result;


### PR DESCRIPTION
Рома передал:

/home/rootuser/workspace/GitHubWatchdog/BUILD_MODE/debug/label/Linux/omim/generator/metalines_builder.cpp: At global scope:
/home/rootuser/workspace/GitHubWatchdog/BUILD_MODE/debug/label/Linux/omim/generator/metalines_builder.cpp:44:46: error: declaration of ‘const Ways& {anonymous}::LineString::Ways() const’ [-fpermissive]
   Ways const & Ways() const { return m_ways; }
                                              ^
/home/rootuser/workspace/GitHubWatchdog/BUILD_MODE/debug/label/Linux/omim/generator/metalines_builder.cpp:22:34: error: changes meaning of ‘Ways’ from ‘using Ways = class std::vector<int>’ [-fpermissive]
 using Ways = std::vector<int32_t>;
