### PR TITLE
[planet] Update region_meta for Ukraine and Kyoto region

### DIFF
--- a/data/countries.txt
+++ b/data/countries.txt
@@ -1,2420 +1,2420 @@
 {
- "id": "Countries", 
- "v": 170609, 
+ "id": "Countries",
+ "v": 170609,
  "g": [
   {
-   "id": "Abkhazia", 
-   "s": 4478795, 
+   "id": "Abkhazia",
+   "s": 4478795,
    "affiliations": [
-    "\u0410\u0431\u0445\u0430\u0437\u0438\u044f - \u0410\u04a7\u0441\u043d\u044b", 
-    "\u10d0\u10e4\u10ee\u10d0\u10d6\u10d4\u10d7\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0 - \u0410\u04a7\u0441\u043d\u044b \u0410\u0432\u0442\u043e\u043d\u043e\u043c\u0442\u04d9 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", 
+    "\u0410\u0431\u0445\u0430\u0437\u0438\u044f - \u0410\u04a7\u0441\u043d\u044b",
+    "\u10d0\u10e4\u10ee\u10d0\u10d6\u10d4\u10d7\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0 - \u0410\u04a7\u0441\u043d\u044b \u0410\u0432\u0442\u043e\u043d\u043e\u043c\u0442\u04d9 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
     "\u10e1\u10d0\u10e5\u10d0\u10e0\u10d7\u10d5\u10d4\u10da\u10dd"
-   ], 
+   ],
    "old": [
     "Georgia"
    ]
-  }, 
+  },
   {
-   "id": "Afghanistan", 
-   "s": 18021107, 
+   "id": "Afghanistan",
+   "s": 18021107,
    "affiliations": [
-    "Badakhshan", 
-    "Badghis", 
-    "Balkh", 
-    "Baghlan", 
-    "Bamyan", 
-    "Daykundi", 
-    "Farah", 
-    "Faryab", 
-    "Ghazni", 
-    "Helmand", 
-    "Herat", 
-    "Jowzjan", 
-    "Kabul", 
-    "Kandahar", 
-    "Logar", 
-    "Kapisa", 
-    "Khost", 
-    "Kunar", 
-    "Kunduz", 
-    "Laghman", 
-    "Nimruz", 
-    "Nuristan", 
-    "Nangarhar", 
-    "Or\u016bzg\u0101n", 
-    "Paktia", 
-    "Paktika", 
-    "Panjshir", 
-    "Parwan", 
-    "Samangan", 
-    "Sar-e Pol", 
-    "Takhar", 
-    "Wardak", 
-    "Zabul", 
-    "\u0648\u0644\u0627\u06cc\u062a \u063a\u0648\u0631", 
+    "Badakhshan",
+    "Badghis",
+    "Balkh",
+    "Baghlan",
+    "Bamyan",
+    "Daykundi",
+    "Farah",
+    "Faryab",
+    "Ghazni",
+    "Helmand",
+    "Herat",
+    "Jowzjan",
+    "Kabul",
+    "Kandahar",
+    "Logar",
+    "Kapisa",
+    "Khost",
+    "Kunar",
+    "Kunduz",
+    "Laghman",
+    "Nimruz",
+    "Nuristan",
+    "Nangarhar",
+    "Or\u016bzg\u0101n",
+    "Paktia",
+    "Paktika",
+    "Panjshir",
+    "Parwan",
+    "Samangan",
+    "Sar-e Pol",
+    "Takhar",
+    "Wardak",
+    "Zabul",
+    "\u0648\u0644\u0627\u06cc\u062a \u063a\u0648\u0631",
     "\u0627\u0641\u063a\u0627\u0646\u0633\u062a\u0627\u0646"
-   ], 
+   ],
    "old": [
     "Afghanistan"
    ]
-  }, 
+  },
   {
-   "id": "Albania", 
-   "s": 15316181, 
+   "id": "Albania",
+   "s": 15316181,
    "affiliations": [
     "Shqip\u00ebria"
-   ], 
+   ],
    "old": [
     "Albania"
    ]
-  }, 
+  },
   {
-   "id": "Algeria", 
+   "id": "Algeria",
    "g": [
     {
-     "id": "Algeria_Central", 
-     "s": 14855040, 
+     "id": "Algeria_Central",
+     "s": 14855040,
      "affiliations": [
-      "Adrar \u2d30\u2d37\u2d54\u2d30\u2d54 \u0623\u062f\u0631\u0627\u0631", 
-      "Illizi \u2d49\u2d4d\u2d4d\u2d49\u2d63\u2d49 \u0625\u0644\u0640\u064a\u0640\u0632\u064a", 
-      "Alg\u00e9rie \u2d4d\u2d63\u2d63\u2d30\u2d62\u2d3b\u2d54 \u0627\u0644\u062c\u0632\u0627\u0626\u0631", 
-      "Batna - \u0628\u0627\u062a\u0646\u0629", 
-      "Biskra - \u0628\u0633\u0643\u0631\u0629", 
-      "B\u00e9char \u2d31\u2d5b\u2d30\u2d54 \u0628\u0634\u0627\u0631", 
-      "Djelfa - \u0627\u0644\u062c\u0644\u0641\u0629", 
-      "El Bayadh - \u0627\u0644\u0628\u064a\u0636", 
-      "El Oued \u2d4d\u2d61\u2d30\u2d37 \u0627\u0644\u0648\u0627\u062f\u064a", 
-      "Gharda\u00efa \u2d5c\u2d30\u2d56\u2d54\u2d37\u2d30\u2d62\u2d5c \u063a\u0631\u062f\u0627\u064a\u0629", 
-      "Khenchela - \u062e\u0646\u0634\u0644\u0629", 
-      "Laghouat - \u0627\u0644\u0623\u063a\u0648\u0627\u0637", 
-      "M'Sila - \u0627\u0644\u0645\u0633\u064a\u0644\u0629", 
-      "Na\u00e2ma - \u0627\u0644\u0646\u0639\u0627\u0645\u0629", 
-      "Ouargla - \u0648\u0631\u0642\u0644\u0629", 
-      "Tamanrasset \u2d5c\u2d30\u2d4e\u2d30\u2d4f\u2d56\u2d30\u2d59\u2d3b\u2d5c \u062a\u0645\u0646\u0631\u0627\u0633\u062a", 
-      "Tindouf \u2d5c\u2d49\u2d4f\u2d37\u2d53\u2d3c \u062a\u0646\u062f\u0648\u0641", 
+      "Adrar \u2d30\u2d37\u2d54\u2d30\u2d54 \u0623\u062f\u0631\u0627\u0631",
+      "Illizi \u2d49\u2d4d\u2d4d\u2d49\u2d63\u2d49 \u0625\u0644\u0640\u064a\u0640\u0632\u064a",
+      "Alg\u00e9rie \u2d4d\u2d63\u2d63\u2d30\u2d62\u2d3b\u2d54 \u0627\u0644\u062c\u0632\u0627\u0626\u0631",
+      "Batna - \u0628\u0627\u062a\u0646\u0629",
+      "Biskra - \u0628\u0633\u0643\u0631\u0629",
+      "B\u00e9char \u2d31\u2d5b\u2d30\u2d54 \u0628\u0634\u0627\u0631",
+      "Djelfa - \u0627\u0644\u062c\u0644\u0641\u0629",
+      "El Bayadh - \u0627\u0644\u0628\u064a\u0636",
+      "El Oued \u2d4d\u2d61\u2d30\u2d37 \u0627\u0644\u0648\u0627\u062f\u064a",
+      "Gharda\u00efa \u2d5c\u2d30\u2d56\u2d54\u2d37\u2d30\u2d62\u2d5c \u063a\u0631\u062f\u0627\u064a\u0629",
+      "Khenchela - \u062e\u0646\u0634\u0644\u0629",
+      "Laghouat - \u0627\u0644\u0623\u063a\u0648\u0627\u0637",
+      "M'Sila - \u0627\u0644\u0645\u0633\u064a\u0644\u0629",
+      "Na\u00e2ma - \u0627\u0644\u0646\u0639\u0627\u0645\u0629",
+      "Ouargla - \u0648\u0631\u0642\u0644\u0629",
+      "Tamanrasset \u2d5c\u2d30\u2d4e\u2d30\u2d4f\u2d56\u2d30\u2d59\u2d3b\u2d5c \u062a\u0645\u0646\u0631\u0627\u0633\u062a",
+      "Tindouf \u2d5c\u2d49\u2d4f\u2d37\u2d53\u2d3c \u062a\u0646\u062f\u0648\u0641",
       "T\u00e9bessa - \u062a\u0628\u0633\u0629"
-     ], 
+     ],
      "old": [
       "Algeria"
      ]
-    }, 
+    },
     {
-     "id": "Algeria_Coast", 
-     "s": 44142837, 
+     "id": "Algeria_Coast",
+     "s": 44142837,
      "affiliations": [
-      "Alger - \u0627\u0644\u062c\u0632\u0627\u0626\u0631", 
-      "Alg\u00e9rie \u2d4d\u2d63\u2d63\u2d30\u2d62\u2d3b\u2d54 \u0627\u0644\u062c\u0632\u0627\u0626\u0631", 
-      "Annaba - \u0639\u0646\u0627\u0628\u0629\u200e", 
-      "A\u00efn Defla - \u0639\u064a\u0646 \u0627\u0644\u062f\u0641\u0644\u0649", 
-      "A\u00efn T\u00e9mouchent - \u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a", 
-      "Blida - \u0627\u0644\u0628\u0644\u064a\u062f\u0629", 
-      "Bordj Bou Arreridj\u200e - \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c\u200e", 
-      "Bouira - \u0627\u0644\u0628\u0648\u064a\u0631\u0629", 
-      "Boumerd\u00e8s - \u0628\u0648\u0645\u0631\u062f\u0627\u0633", 
-      "B\u00e9ja\u00efa", 
-      "Mascara - \u0645\u0639\u0633\u0643\u0631", 
-      "Chlef - \u0627\u0644\u0634\u0644\u0641\u200e", 
-      "Constantine - \u0642\u0633\u0646\u0637\u064a\u0646\u0629", 
-      "Jijel - \u062c\u064a\u062c\u0644", 
-      "El Tarf - \u0627\u0644\u0640\u0640\u0637\u0627\u0631\u0641", 
-      "Guelma - \u06a4\u0627\u0644\u0645\u0629", 
-      "Mila - \u0645\u064a\u0644\u0629", 
-      "Mostaganem - \u0645\u0633\u062a\u063a\u0627\u0646\u0645", 
-      "M\u00e9d\u00e9a - \u0627\u0644\u0645\u062f\u064a\u0629", 
-      "Oran - \u0648\u0647\u0631\u0627\u0646", 
-      "Oum El Bouaghi - \u0623\u0645 \u0627\u0644\u0640\u0628\u0640\u0648\u0627\u0642\u064a", 
-      "Relizane - \u063a\u0644\u064a\u0632\u0627\u0646", 
-      "Sa\u00efda - \u0633\u0639\u064a\u062f\u0629", 
-      "Sidi Bel Abb\u00e8s - \u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633", 
-      "Skikda - \u0633\u0643\u064a\u0643\u062f\u0629", 
-      "Souk Ahras - \u0633\u0648\u0642 \u0623\u0647\u0631\u0627\u0633", 
-      "S\u00e9tif - \u0633\u0637\u064a\u0641\u200e", 
-      "Tiaret - \u062a\u064a\u0627\u0631\u062a", 
-      "Tipaza - \u062a\u064a\u0628\u0627\u0632\u0629", 
-      "Tissemsilt - \u062a\u0633\u0645\u0633\u064a\u0644\u062a", 
-      "Tizi Ouzou - \u2d5c\u2d49\u2d63\u2d49 \u2d53\u2d63\u2d63\u2d53 - \u062a\u064a\u0632\u064a \u0648\u0632\u0648", 
+      "Alger - \u0627\u0644\u062c\u0632\u0627\u0626\u0631",
+      "Alg\u00e9rie \u2d4d\u2d63\u2d63\u2d30\u2d62\u2d3b\u2d54 \u0627\u0644\u062c\u0632\u0627\u0626\u0631",
+      "Annaba - \u0639\u0646\u0627\u0628\u0629\u200e",
+      "A\u00efn Defla - \u0639\u064a\u0646 \u0627\u0644\u062f\u0641\u0644\u0649",
+      "A\u00efn T\u00e9mouchent - \u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a",
+      "Blida - \u0627\u0644\u0628\u0644\u064a\u062f\u0629",
+      "Bordj Bou Arreridj\u200e - \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c\u200e",
+      "Bouira - \u0627\u0644\u0628\u0648\u064a\u0631\u0629",
+      "Boumerd\u00e8s - \u0628\u0648\u0645\u0631\u062f\u0627\u0633",
+      "B\u00e9ja\u00efa",
+      "Mascara - \u0645\u0639\u0633\u0643\u0631",
+      "Chlef - \u0627\u0644\u0634\u0644\u0641\u200e",
+      "Constantine - \u0642\u0633\u0646\u0637\u064a\u0646\u0629",
+      "Jijel - \u062c\u064a\u062c\u0644",
+      "El Tarf - \u0627\u0644\u0640\u0640\u0637\u0627\u0631\u0641",
+      "Guelma - \u06a4\u0627\u0644\u0645\u0629",
+      "Mila - \u0645\u064a\u0644\u0629",
+      "Mostaganem - \u0645\u0633\u062a\u063a\u0627\u0646\u0645",
+      "M\u00e9d\u00e9a - \u0627\u0644\u0645\u062f\u064a\u0629",
+      "Oran - \u0648\u0647\u0631\u0627\u0646",
+      "Oum El Bouaghi - \u0623\u0645 \u0627\u0644\u0640\u0628\u0640\u0648\u0627\u0642\u064a",
+      "Relizane - \u063a\u0644\u064a\u0632\u0627\u0646",
+      "Sa\u00efda - \u0633\u0639\u064a\u062f\u0629",
+      "Sidi Bel Abb\u00e8s - \u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633",
+      "Skikda - \u0633\u0643\u064a\u0643\u062f\u0629",
+      "Souk Ahras - \u0633\u0648\u0642 \u0623\u0647\u0631\u0627\u0633",
+      "S\u00e9tif - \u0633\u0637\u064a\u0641\u200e",
+      "Tiaret - \u062a\u064a\u0627\u0631\u062a",
+      "Tipaza - \u062a\u064a\u0628\u0627\u0632\u0629",
+      "Tissemsilt - \u062a\u0633\u0645\u0633\u064a\u0644\u062a",
+      "Tizi Ouzou - \u2d5c\u2d49\u2d63\u2d49 \u2d53\u2d63\u2d63\u2d53 - \u062a\u064a\u0632\u064a \u0648\u0632\u0648",
       "Tlemcen - \u062a\u0644\u0645\u0633\u0627\u0646"
-     ], 
+     ],
      "old": [
       "Algeria"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Andorra", 
-   "s": 1034076, 
+   "id": "Andorra",
+   "s": 1034076,
    "affiliations": [
     "Andorra"
-   ], 
+   ],
    "old": [
     "Andorra"
    ]
-  }, 
+  },
   {
-   "id": "Angola", 
-   "s": 11371639, 
+   "id": "Angola",
+   "s": 11371639,
    "affiliations": [
-    "Angola", 
-    "Bengo", 
-    "Benguela", 
-    "Bi\u00e9", 
-    "Cabinda", 
-    "Cuando Cubango", 
-    "Cuanza Norte", 
-    "Cuanza Sul", 
-    "Cunene", 
-    "U\u00edge", 
-    "Huambo", 
-    "Hu\u00edla", 
-    "Luanda", 
-    "Lunda Norte", 
-    "Lunda Sul", 
-    "Malanje", 
-    "Moxico", 
-    "Namibe", 
+    "Angola",
+    "Bengo",
+    "Benguela",
+    "Bi\u00e9",
+    "Cabinda",
+    "Cuando Cubango",
+    "Cuanza Norte",
+    "Cuanza Sul",
+    "Cunene",
+    "U\u00edge",
+    "Huambo",
+    "Hu\u00edla",
+    "Luanda",
+    "Lunda Norte",
+    "Lunda Sul",
+    "Malanje",
+    "Moxico",
+    "Namibe",
     "Zaire"
-   ], 
+   ],
    "old": [
     "Angola"
    ]
-  }, 
+  },
   {
-   "id": "Anguilla", 
-   "s": 421126, 
+   "id": "Anguilla",
+   "s": 421126,
    "affiliations": [
     "Anguilla"
-   ], 
+   ],
    "old": [
     "Anguilla"
    ]
-  }, 
+  },
   {
-   "id": "Antigua and Barbuda", 
-   "s": 780173, 
+   "id": "Antigua and Barbuda",
+   "s": 780173,
    "affiliations": [
-    "Antigua and Barbuda", 
+    "Antigua and Barbuda",
     "Montserrat"
-   ], 
+   ],
    "old": [
     "Antigua and Barbuda"
    ]
-  }, 
+  },
   {
-   "id": "Barbados", 
-   "s": 1286572, 
+   "id": "Barbados",
+   "s": 1286572,
    "affiliations": [
     "Barbados"
-   ], 
+   ],
    "old": [
     "Barbados"
    ]
-  }, 
+  },
   {
-   "id": "British Virgin Islands", 
-   "s": 394673, 
+   "id": "British Virgin Islands",
+   "s": 394673,
    "affiliations": [
     "British Virgin Islands"
-   ], 
+   ],
    "old": [
     "British Virgin Islands"
    ]
-  }, 
+  },
   {
-   "id": "Caribisch Nederland", 
-   "s": 4218988, 
+   "id": "Caribisch Nederland",
+   "s": 4218988,
    "affiliations": [
-    "Caribisch Nederland", 
-    "Nederland", 
+    "Caribisch Nederland",
+    "Nederland",
     "Venezuela"
-   ], 
+   ],
    "old": [
-    "Netherlands Antilles", 
-    "Aruba", 
+    "Netherlands Antilles",
+    "Aruba",
     "Curacao"
    ]
-  }, 
+  },
   {
-   "id": "Dominica", 
-   "s": 1599890, 
+   "id": "Dominica",
+   "s": 1599890,
    "affiliations": [
-    "Dominica", 
-    "Saint Andrew Parish", 
-    "Saint David Parish", 
-    "Saint Luke Parish", 
-    "Saint Mark Parish", 
-    "Saint Patrick Parish", 
-    "Saint Paul Parish", 
-    "Saint George Parish", 
-    "Saint John Parish", 
-    "Saint Joseph Parish", 
+    "Dominica",
+    "Saint Andrew Parish",
+    "Saint David Parish",
+    "Saint Luke Parish",
+    "Saint Mark Parish",
+    "Saint Patrick Parish",
+    "Saint Paul Parish",
+    "Saint George Parish",
+    "Saint John Parish",
+    "Saint Joseph Parish",
     "Saint Peter Parish"
-   ], 
+   ],
    "old": [
     "Dominica"
    ]
-  }, 
+  },
   {
-   "id": "Grenada", 
-   "s": 962148, 
+   "id": "Grenada",
+   "s": 962148,
    "affiliations": [
     "Grenada"
-   ], 
+   ],
    "old": [
     "Grenada"
    ]
-  }, 
+  },
   {
-   "id": "Guadeloupe", 
-   "s": 11545619, 
+   "id": "Guadeloupe",
+   "s": 11545619,
    "affiliations": [
-    "France", 
-    "Guadeloupe", 
+    "France",
+    "Guadeloupe",
     "Montserrat"
-   ], 
+   ],
    "old": [
     "Guadeloupe"
    ]
-  }, 
+  },
   {
-   "id": "Martinique", 
-   "s": 9826867, 
+   "id": "Martinique",
+   "s": 9826867,
    "affiliations": [
-    "France", 
-    "Martinique", 
+    "France",
+    "Martinique",
     "Saint Lucia"
-   ], 
+   ],
    "old": [
     "Martinique"
    ]
-  }, 
+  },
   {
-   "id": "Montserrat", 
-   "s": 196099, 
+   "id": "Montserrat",
+   "s": 196099,
    "affiliations": [
     "Montserrat"
-   ], 
+   ],
    "old": [
     "Montserrat"
    ]
-  }, 
+  },
   {
-   "id": "Saint Barthelemy", 
-   "s": 262833, 
+   "id": "Saint Barthelemy",
+   "s": 262833,
    "affiliations": [
     "France"
-   ], 
+   ],
    "old": [
     "Saint Barthelemy"
    ]
-  }, 
+  },
   {
-   "id": "Saint Kitts and Nevis", 
-   "s": 392261, 
+   "id": "Saint Kitts and Nevis",
+   "s": 392261,
    "affiliations": [
     "Saint Kitts and Nevis"
-   ], 
+   ],
    "old": [
     "Saint Kitts and Nevis"
    ]
-  }, 
+  },
   {
-   "id": "Saint Lucia", 
-   "s": 1358942, 
+   "id": "Saint Lucia",
+   "s": 1358942,
    "affiliations": [
-    "Saint Lucia", 
+    "Saint Lucia",
     "Saint Vincent and the Grenadines"
-   ], 
+   ],
    "old": [
     "Saint Lucia"
    ]
-  }, 
+  },
   {
-   "id": "Saint Martin", 
-   "s": 1326687, 
+   "id": "Saint Martin",
+   "s": 1326687,
    "affiliations": [
-    "Anguilla", 
-    "France", 
+    "Anguilla",
+    "France",
     "Nederland"
-   ], 
+   ],
    "old": [
     "Saint Martin"
    ]
-  }, 
+  },
   {
-   "id": "Saint Vincent and the Grenadines", 
-   "s": 656141, 
+   "id": "Saint Vincent and the Grenadines",
+   "s": 656141,
    "affiliations": [
     "Saint Vincent and the Grenadines"
-   ], 
+   ],
    "old": [
     "Saint Vincent and the Grenadines"
    ]
-  }, 
+  },
   {
-   "id": "Trinidad and Tobago", 
-   "s": 8780611, 
+   "id": "Trinidad and Tobago",
+   "s": 8780611,
    "affiliations": [
     "Trinidad and Tobago"
-   ], 
+   ],
    "old": [
     "Trinidad and Tobago"
    ]
-  }, 
+  },
   {
-   "id": "United States Virgin Islands", 
-   "s": 1004480, 
+   "id": "United States Virgin Islands",
+   "s": 1004480,
    "affiliations": [
-    "British Virgin Islands", 
-    "Puerto Rico", 
-    "PR", 
-    "United States Virgin Islands", 
-    "VI", 
+    "British Virgin Islands",
+    "Puerto Rico",
+    "PR",
+    "United States Virgin Islands",
+    "VI",
     "United States of America"
-   ], 
+   ],
    "old": [
     "United States Virgin Islands"
    ]
-  }, 
+  },
   {
-   "id": "Argentina", 
+   "id": "Argentina",
    "g": [
     {
-     "id": "Campo de Hielo Sur", 
-     "s": 943609, 
+     "id": "Campo de Hielo Sur",
+     "s": 943609,
      "affiliations": [
       "Acuerdo de Campos de Hielo"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Buenos Aires_Buenos Aires", 
-     "s": 22700420, 
+     "id": "Argentina_Buenos Aires_Buenos Aires",
+     "s": 22700420,
      "affiliations": [
-      "Argentina", 
-      "Ciudad Aut\u00f3noma de Buenos Aires", 
+      "Argentina",
+      "Ciudad Aut\u00f3noma de Buenos Aires",
       "Buenos Aires"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Buenos Aires_North", 
-     "s": 8748327, 
+     "id": "Argentina_Buenos Aires_North",
+     "s": 8748327,
      "affiliations": [
-      "Argentina", 
+      "Argentina",
       "Buenos Aires"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Buenos Aires_South", 
-     "s": 9828110, 
+     "id": "Argentina_Buenos Aires_South",
+     "s": 9828110,
      "affiliations": [
-      "Argentina", 
+      "Argentina",
       "Buenos Aires"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Patagonia", 
-     "s": 27636690, 
+     "id": "Argentina_Patagonia",
+     "s": 27636690,
      "affiliations": [
-      "Argentina", 
-      "Chubut", 
-      "R\u00edo Negro", 
-      "Neuqu\u00e9n", 
-      "Santa Cruz", 
+      "Argentina",
+      "Chubut",
+      "R\u00edo Negro",
+      "Neuqu\u00e9n",
+      "Santa Cruz",
       "Tierra del Fuego"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Cuyo", 
-     "s": 10895273, 
+     "id": "Argentina_Cuyo",
+     "s": 10895273,
      "affiliations": [
-      "Argentina", 
-      "La Rioja", 
-      "Mendoza", 
-      "San Juan", 
+      "Argentina",
+      "La Rioja",
+      "Mendoza",
+      "San Juan",
       "San Luis"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Mesopotamia", 
-     "s": 24376755, 
+     "id": "Argentina_Mesopotamia",
+     "s": 24376755,
      "affiliations": [
-      "Argentina", 
-      "Corrientes", 
-      "Entre R\u00edos", 
-      "Isla San Mart\u00edn", 
-      "Isla Apip\u00e9 Chica", 
-      "Isla Entre R\u00edos", 
-      "Isla Los Patos", 
-      "Isla Progreso", 
-      "Isla Rivadavia", 
-      "Islas Apip\u00e9", 
-      "Itap\u00faa", 
+      "Argentina",
+      "Corrientes",
+      "Entre R\u00edos",
+      "Isla San Mart\u00edn",
+      "Isla Apip\u00e9 Chica",
+      "Isla Entre R\u00edos",
+      "Isla Los Patos",
+      "Isla Progreso",
+      "Isla Rivadavia",
+      "Islas Apip\u00e9",
+      "Itap\u00faa",
       "Misiones"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Northwest", 
-     "s": 19795745, 
+     "id": "Argentina_Northwest",
+     "s": 19795745,
      "affiliations": [
-      "Chaco", 
-      "Argentina", 
-      "Catamarca", 
-      "Formosa", 
-      "Jujuy", 
-      "Salta", 
-      "Santiago del Estero", 
+      "Chaco",
+      "Argentina",
+      "Catamarca",
+      "Formosa",
+      "Jujuy",
+      "Salta",
+      "Santiago del Estero",
       "Tucum\u00e1n"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Pampas", 
-     "s": 14155662, 
+     "id": "Argentina_Pampas",
+     "s": 14155662,
      "affiliations": [
-      "Argentina", 
-      "C\u00f3rdoba", 
+      "Argentina",
+      "C\u00f3rdoba",
       "La Pampa"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
-    }, 
+    },
     {
-     "id": "Argentina_Santa Fe", 
-     "s": 11241626, 
+     "id": "Argentina_Santa Fe",
+     "s": 11241626,
      "affiliations": [
-      "Argentina", 
+      "Argentina",
       "Santa Fe"
-     ], 
+     ],
      "old": [
       "Argentina"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Armenia", 
-   "s": 13291677, 
+   "id": "Armenia",
+   "s": 13291677,
    "affiliations": [
-    "Border Azerbaijan - Armenia (Enclave AZE)", 
-    "Qazax rayonu", 
-    "\u053c\u0578\u057c\u056b", 
-    "\u0535\u0580\u0587\u0561\u0576", 
-    "\u0547\u056b\u0580\u0561\u056f", 
-    "\u054e\u0561\u0575\u0578\u0581 \u0541\u0578\u0580", 
-    "\u053f\u0578\u057f\u0561\u0575\u0584", 
-    "\u054f\u0561\u057e\u0578\u0582\u0577", 
-    "\u0531\u0580\u0561\u0580\u0561\u057f", 
-    "\u0531\u0580\u0574\u0561\u057e\u056b\u0580", 
-    "\u054d\u0575\u0578\u0582\u0576\u056b\u0584", 
-    "\u0540\u0561\u0575\u0561\u057d\u057f\u0561\u0576", 
-    "\u0531\u0580\u0561\u0563\u0561\u056e\u0578\u057f\u0576\u056b \u0574\u0561\u0580\u0566", 
+    "Border Azerbaijan - Armenia (Enclave AZE)",
+    "Qazax rayonu",
+    "\u053c\u0578\u057c\u056b",
+    "\u0535\u0580\u0587\u0561\u0576",
+    "\u0547\u056b\u0580\u0561\u056f",
+    "\u054e\u0561\u0575\u0578\u0581 \u0541\u0578\u0580",
+    "\u053f\u0578\u057f\u0561\u0575\u0584",
+    "\u054f\u0561\u057e\u0578\u0582\u0577",
+    "\u0531\u0580\u0561\u0580\u0561\u057f",
+    "\u0531\u0580\u0574\u0561\u057e\u056b\u0580",
+    "\u054d\u0575\u0578\u0582\u0576\u056b\u0584",
+    "\u0540\u0561\u0575\u0561\u057d\u057f\u0561\u0576",
+    "\u0531\u0580\u0561\u0563\u0561\u056e\u0578\u057f\u0576\u056b \u0574\u0561\u0580\u0566",
     "\u0533\u0565\u0572\u0561\u0580\u0584\u0578\u0582\u0576\u056b\u0584"
-   ], 
+   ],
    "old": [
     "Armenia"
    ]
-  }, 
+  },
   {
-   "id": "Austria", 
+   "id": "Austria",
    "g": [
     {
-     "id": "Austria_Burgenland", 
-     "s": 14760110, 
+     "id": "Austria_Burgenland",
+     "s": 14760110,
      "affiliations": [
-      "Burgenland", 
+      "Burgenland",
       "\u00d6sterreich"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Carinthia", 
-     "s": 32749399, 
+     "id": "Austria_Carinthia",
+     "s": 32749399,
      "affiliations": [
-      "K\u00e4rnten", 
+      "K\u00e4rnten",
       "\u00d6sterreich"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Lower Austria_Wien", 
-     "s": 56823950, 
+     "id": "Austria_Lower Austria_Wien",
+     "s": 56823950,
      "affiliations": [
-      "\u00d6sterreich", 
-      "Nieder\u00f6sterreich", 
+      "\u00d6sterreich",
+      "Nieder\u00f6sterreich",
       "Wien"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Styria_Graz", 
-     "s": 48348006, 
+     "id": "Austria_Styria_Graz",
+     "s": 48348006,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Steiermark"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Styria_Leoben", 
-     "s": 29480181, 
+     "id": "Austria_Styria_Leoben",
+     "s": 29480181,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Steiermark"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Upper Austria_Linz", 
-     "s": 31728233, 
+     "id": "Austria_Upper Austria_Linz",
+     "s": 31728233,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Ober\u00f6sterreich"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Upper Austria_Wels", 
-     "s": 39407641, 
+     "id": "Austria_Upper Austria_Wels",
+     "s": 39407641,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Ober\u00f6sterreich"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Lower Austria_West", 
-     "s": 43247478, 
+     "id": "Austria_Lower Austria_West",
+     "s": 43247478,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Nieder\u00f6sterreich"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Tyrol", 
-     "s": 48920116, 
+     "id": "Austria_Tyrol",
+     "s": 48920116,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Tirol"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Salzburg", 
-     "s": 30544232, 
+     "id": "Austria_Salzburg",
+     "s": 30544232,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Salzburg"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
-    }, 
+    },
     {
-     "id": "Austria_Vorarlberg", 
-     "s": 17093744, 
+     "id": "Austria_Vorarlberg",
+     "s": 17093744,
      "affiliations": [
-      "\u00d6sterreich", 
+      "\u00d6sterreich",
       "Vorarlberg"
-     ], 
+     ],
      "old": [
       "Austria"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Australia", 
+   "id": "Australia",
    "g": [
     {
-     "id": "Willis Island", 
-     "s": 93369, 
+     "id": "Willis Island",
+     "s": 93369,
      "affiliations": [
-      "Australia", 
-      "Coral Sea Islands Territory", 
+      "Australia",
+      "Coral Sea Islands Territory",
       "Willis Island"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Melbourne", 
-     "s": 35886295, 
+     "id": "Australia_Melbourne",
+     "s": 35886295,
      "affiliations": [
-      "Australia", 
+      "Australia",
       "Victoria"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_New South Wales", 
-     "s": 26079625, 
+     "id": "Australia_New South Wales",
+     "s": 26079625,
      "affiliations": [
-      "Australia", 
-      "Coral Sea Islands Territory", 
-      "New South Wales", 
+      "Australia",
+      "Coral Sea Islands Territory",
+      "New South Wales",
       "Norfolk Island"
-     ], 
+     ],
      "old": [
-      "Australia", 
+      "Australia",
       "Norfolk Island"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Northern Territory", 
-     "s": 7937315, 
+     "id": "Australia_Northern Territory",
+     "s": 7937315,
      "affiliations": [
-      "Australia", 
+      "Australia",
       "Northern Territory"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Queensland", 
-     "s": 21117821, 
+     "id": "Australia_Queensland",
+     "s": 21117821,
      "affiliations": [
-      "Australia", 
-      "Coral Sea Islands Territory", 
+      "Australia",
+      "Coral Sea Islands Territory",
       "Queensland"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_South Australia", 
-     "s": 24965940, 
+     "id": "Australia_South Australia",
+     "s": 24965940,
      "affiliations": [
-      "Australia", 
+      "Australia",
       "South Australia"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Tasmania", 
-     "s": 20604379, 
+     "id": "Australia_Tasmania",
+     "s": 20604379,
      "affiliations": [
-      "Australia", 
+      "Australia",
       "Tasmania"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Victoria", 
-     "s": 28282601, 
+     "id": "Australia_Victoria",
+     "s": 28282601,
      "affiliations": [
-      "Australia", 
+      "Australia",
       "Victoria"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Western Australia", 
-     "s": 36724084, 
+     "id": "Australia_Western Australia",
+     "s": 36724084,
      "affiliations": [
-      "Ashmore and Cartier Islands", 
-      "Christmas Island", 
-      "Australia", 
-      "Cocos (Keeling) Islands", 
+      "Ashmore and Cartier Islands",
+      "Christmas Island",
+      "Australia",
+      "Cocos (Keeling) Islands",
       "Western Australia"
-     ], 
+     ],
      "old": [
-      "Cocos Islands", 
-      "Australia", 
+      "Cocos Islands",
+      "Australia",
       "Christmas Island"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Brisbane", 
-     "s": 28691438, 
+     "id": "Australia_Brisbane",
+     "s": 28691438,
      "affiliations": [
-      "Australia", 
-      "Coral Sea Islands Territory", 
-      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de Bellone (eaux territoriales)", 
+      "Australia",
+      "Coral Sea Islands Territory",
+      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de Bellone (eaux territoriales)",
       "Queensland"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
-    }, 
+    },
     {
-     "id": "Australia_Sydney", 
-     "s": 44226473, 
+     "id": "Australia_Sydney",
+     "s": 44226473,
      "affiliations": [
-      "Australia", 
-      "Australian Capital Territory", 
-      "Jervis Bay Territory", 
+      "Australia",
+      "Australian Capital Territory",
+      "Jervis Bay Territory",
       "New South Wales"
-     ], 
+     ],
      "old": [
       "Australia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Azerbaijan Region", 
+   "id": "Azerbaijan Region",
    "g": [
     {
-     "id": "Nagorno-Karabakh", 
-     "s": 2144860, 
+     "id": "Nagorno-Karabakh",
+     "s": 2144860,
      "affiliations": [
-      "Az\u0259rbaycan", 
-      "\u0544\u0561\u0580\u057f\u0561\u056f\u0565\u0580\u057f\u056b \u0577\u0580\u057b\u0561\u0576 (Martakert Province)", 
-      "\u0547\u0578\u0582\u0577\u056b\u056b \u0577\u0580\u057b\u0561\u0576 (Shushi District)", 
-      "\u0531\u057d\u056f\u0565\u0580\u0561\u0576\u056b \u0574\u0561\u0580\u0566 (Askeran Province)", 
-      "\u0540\u0561\u0564\u0580\u0578\u0582\u0569\u056b \u0577\u0580\u057b\u0561\u0576 (Hadrut Province)", 
-      "\u0554\u0561\u0577\u0561\u0569\u0561\u0572\u056b \u0577\u0580\u057b\u0561\u0576 (Kashatagh District)", 
-      "\u0547\u0561\u0570\u0578\u0582\u0574\u0575\u0561\u0576 \u0577\u0580\u057b\u0561\u0576", 
-      "\u0544\u0561\u0580\u057f\u0578\u0582\u0576\u0578\u0582 \u0577\u0580\u057b\u0561\u0576 (Martuni Province)", 
+      "Az\u0259rbaycan",
+      "\u0544\u0561\u0580\u057f\u0561\u056f\u0565\u0580\u057f\u056b \u0577\u0580\u057b\u0561\u0576 (Martakert Province)",
+      "\u0547\u0578\u0582\u0577\u056b\u056b \u0577\u0580\u057b\u0561\u0576 (Shushi District)",
+      "\u0531\u057d\u056f\u0565\u0580\u0561\u0576\u056b \u0574\u0561\u0580\u0566 (Askeran Province)",
+      "\u0540\u0561\u0564\u0580\u0578\u0582\u0569\u056b \u0577\u0580\u057b\u0561\u0576 (Hadrut Province)",
+      "\u0554\u0561\u0577\u0561\u0569\u0561\u0572\u056b \u0577\u0580\u057b\u0561\u0576 (Kashatagh District)",
+      "\u0547\u0561\u0570\u0578\u0582\u0574\u0575\u0561\u0576 \u0577\u0580\u057b\u0561\u0576",
+      "\u0544\u0561\u0580\u057f\u0578\u0582\u0576\u0578\u0582 \u0577\u0580\u057b\u0561\u0576 (Martuni Province)",
       "\u054d\u057f\u0565\u0583\u0561\u0576\u0561\u056f\u0565\u0580\u057f (Stepanakert - Khankendi)"
-     ], 
+     ],
      "old": [
       "Azerbaijan"
      ]
-    }, 
+    },
     {
-     "id": "Azerbaijan", 
-     "s": 13477245, 
+     "id": "Azerbaijan",
+     "s": 13477245,
      "affiliations": [
-      "Ab\u015feron rayonu", 
-      "A\u011fcab\u0259di rayonu", 
-      "A\u011fdam rayonu", 
-      "Astara rayonu", 
-      "Az\u0259rbaycan", 
-      "A\u011fda\u015f rayonu", 
-      "A\u011fstafa rayonu", 
-      "A\u011fsu rayonu", 
-      "Bak\u0131 \u0130nzibati \u018frazisi", 
-      "Balak\u0259n rayonu", 
-      "Bab\u0259k rayonu", 
-      "Beyl\u0259qan rayonu", 
-      "Bil\u0259suvar rayonu", 
-      "B\u0259rd\u0259 rayonu", 
-      "Da\u015fk\u0259s\u0259n rayonu", 
-      "Culfa rayonu", 
-      "C\u0259lilabad rayonu", 
-      "T\u0259rt\u0259r rayonu", 
-      "G\u00f6yg\u00f6l rayonu", 
-      "G\u00f6y\u00e7ay rayonu", 
-      "F\u00fczuli rayonu", 
-      "Goranboy rayonu", 
-      "Zaqatala rayonu", 
-      "G\u0259d\u0259b\u0259y rayonu", 
-      "G\u0259nc\u0259 \u0130nzibati \u018frazisi", 
-      "Hac\u0131qabul rayonu", 
-      "K\u0259ng\u0259rli rayonu", 
-      "K\u00fcrd\u0259mir rayonu", 
-      "Lerik rayonu", 
-      "L\u0259nk\u0259ran rayonu", 
-      "L\u0259nk\u0259ran \u0130nzibati \u018frazisi", 
-      "Neft\u00e7ala rayonu", 
-      "Masall\u0131 rayonu", 
-      "Ming\u0259\u00e7evir \u0130nzibati \u018frazisi", 
-      "Naftalan \u0130nzibati \u018frazisi", 
-      "Nax\u00e7\u0131van", 
-      "Nax\u00e7\u0131van \u0130nzibati \u018frazisi", 
-      "Ordubad rayonu", 
-      "O\u011fuz rayonu", 
-      "Qax rayonu", 
-      "Qazax rayonu", 
-      "Qobustan rayonu", 
-      "Quba rayonu", 
-      "Qusar rayonu", 
-      "Q\u0259b\u0259l\u0259 rayonu", 
-      "Saatl\u0131 rayonu", 
-      "Sabirabad rayonu", 
-      "Salyan rayonu", 
-      "Samux rayonu", 
-      "Siy\u0259z\u0259n rayonu", 
-      "Sumqay\u0131t \u0130nzibati \u018frazisi", 
-      "S\u0259d\u0259r\u0259k rayonu", 
-      "Tovuz rayonu", 
-      "Ucar rayonu", 
-      "X\u0131z\u0131 rayonu", 
-      "Yevlax rayonu", 
-      "Xa\u00e7maz rayonu", 
-      "Xocav\u0259nd rayonu", 
-      "Yevlax \u0130nzibati \u018frazisi", 
-      "Yard\u0131ml\u0131 rayonu", 
-      "Z\u0259rdab rayonu", 
-      "\u015eabran rayonu", 
-      "\u015eahbuz rayonu", 
-      "\u015eamax\u0131 rayonu", 
-      "\u015eirvan \u0130nzibati \u018frazisi", 
-      "\u0130mi\u015fli rayonu", 
-      "\u0130smay\u0131ll\u0131 rayonu", 
-      "\u015e\u0259ki rayonu", 
-      "\u015e\u0259ki \u0130nzibati \u018frazisi", 
-      "\u015e\u0259mkir rayonu", 
+      "Ab\u015feron rayonu",
+      "A\u011fcab\u0259di rayonu",
+      "A\u011fdam rayonu",
+      "Astara rayonu",
+      "Az\u0259rbaycan",
+      "A\u011fda\u015f rayonu",
+      "A\u011fstafa rayonu",
+      "A\u011fsu rayonu",
+      "Bak\u0131 \u0130nzibati \u018frazisi",
+      "Balak\u0259n rayonu",
+      "Bab\u0259k rayonu",
+      "Beyl\u0259qan rayonu",
+      "Bil\u0259suvar rayonu",
+      "B\u0259rd\u0259 rayonu",
+      "Da\u015fk\u0259s\u0259n rayonu",
+      "Culfa rayonu",
+      "C\u0259lilabad rayonu",
+      "T\u0259rt\u0259r rayonu",
+      "G\u00f6yg\u00f6l rayonu",
+      "G\u00f6y\u00e7ay rayonu",
+      "F\u00fczuli rayonu",
+      "Goranboy rayonu",
+      "Zaqatala rayonu",
+      "G\u0259d\u0259b\u0259y rayonu",
+      "G\u0259nc\u0259 \u0130nzibati \u018frazisi",
+      "Hac\u0131qabul rayonu",
+      "K\u0259ng\u0259rli rayonu",
+      "K\u00fcrd\u0259mir rayonu",
+      "Lerik rayonu",
+      "L\u0259nk\u0259ran rayonu",
+      "L\u0259nk\u0259ran \u0130nzibati \u018frazisi",
+      "Neft\u00e7ala rayonu",
+      "Masall\u0131 rayonu",
+      "Ming\u0259\u00e7evir \u0130nzibati \u018frazisi",
+      "Naftalan \u0130nzibati \u018frazisi",
+      "Nax\u00e7\u0131van",
+      "Nax\u00e7\u0131van \u0130nzibati \u018frazisi",
+      "Ordubad rayonu",
+      "O\u011fuz rayonu",
+      "Qax rayonu",
+      "Qazax rayonu",
+      "Qobustan rayonu",
+      "Quba rayonu",
+      "Qusar rayonu",
+      "Q\u0259b\u0259l\u0259 rayonu",
+      "Saatl\u0131 rayonu",
+      "Sabirabad rayonu",
+      "Salyan rayonu",
+      "Samux rayonu",
+      "Siy\u0259z\u0259n rayonu",
+      "Sumqay\u0131t \u0130nzibati \u018frazisi",
+      "S\u0259d\u0259r\u0259k rayonu",
+      "Tovuz rayonu",
+      "Ucar rayonu",
+      "X\u0131z\u0131 rayonu",
+      "Yevlax rayonu",
+      "Xa\u00e7maz rayonu",
+      "Xocav\u0259nd rayonu",
+      "Yevlax \u0130nzibati \u018frazisi",
+      "Yard\u0131ml\u0131 rayonu",
+      "Z\u0259rdab rayonu",
+      "\u015eabran rayonu",
+      "\u015eahbuz rayonu",
+      "\u015eamax\u0131 rayonu",
+      "\u015eirvan \u0130nzibati \u018frazisi",
+      "\u0130mi\u015fli rayonu",
+      "\u0130smay\u0131ll\u0131 rayonu",
+      "\u015e\u0259ki rayonu",
+      "\u015e\u0259ki \u0130nzibati \u018frazisi",
+      "\u015e\u0259mkir rayonu",
       "\u015e\u0259rur rayonu"
-     ], 
+     ],
      "old": [
       "Azerbaijan"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Bahrain", 
-   "s": 3101263, 
+   "id": "Bahrain",
+   "s": 3101263,
    "affiliations": [
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u062d\u0631\u0642", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0639\u0627\u0635\u0645\u0629", 
-    "\u200f\u0627\u0644\u0628\u062d\u0631\u064a\u0646\u200e", 
-    "\u0627\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0648\u0633\u0637\u0649", 
-    "\u0627\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629", 
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u062d\u0631\u0642",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0639\u0627\u0635\u0645\u0629",
+    "\u200f\u0627\u0644\u0628\u062d\u0631\u064a\u0646\u200e",
+    "\u0627\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0648\u0633\u0637\u0649",
+    "\u0627\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629",
     "\u0627\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
-   ], 
+   ],
    "old": [
     "Bahrain"
    ]
-  }, 
+  },
   {
-   "id": "Bangladesh", 
-   "s": 24515169, 
+   "id": "Bangladesh",
+   "s": 24515169,
    "affiliations": [
-    "Border India - Bangladesh", 
-    "\u09b0\u09be\u099c\u09b6\u09be\u09b9\u09c0 \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u09a2\u09be\u0995\u09be \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u0996\u09c1\u09b2\u09a8\u09be \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u09b0\u0982\u09aa\u09c1\u09b0 \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u09b8\u09bf\u09b2\u09c7\u099f \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u09ac\u09b0\u09bf\u09b6\u09be\u09b2 \u09ac\u09bf\u09ad\u09be\u0997", 
-    "\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6", 
+    "Border India - Bangladesh",
+    "\u09b0\u09be\u099c\u09b6\u09be\u09b9\u09c0 \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u09a2\u09be\u0995\u09be \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u0996\u09c1\u09b2\u09a8\u09be \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u09b0\u0982\u09aa\u09c1\u09b0 \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u09b8\u09bf\u09b2\u09c7\u099f \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u09ac\u09b0\u09bf\u09b6\u09be\u09b2 \u09ac\u09bf\u09ad\u09be\u0997",
+    "\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6",
     "\u099a\u099f\u09cd\u099f\u0997\u09cd\u09b0\u09be\u09ae \u09ac\u09bf\u09ad\u09be\u0997"
-   ], 
+   ],
    "old": [
     "Bangladesh"
    ]
-  }, 
+  },
   {
-   "id": "Belarus", 
+   "id": "Belarus",
    "g": [
     {
-     "id": "Belarus_Vitebsk Region", 
-     "s": 32715137, 
+     "id": "Belarus_Vitebsk Region",
+     "s": 32715137,
      "affiliations": [
-      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c", 
+      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c",
       "\u0412\u0438\u0442\u0435\u0431\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
-    }, 
+    },
     {
-     "id": "Belarus_Hrodna Region", 
-     "s": 19718533, 
+     "id": "Belarus_Hrodna Region",
+     "s": 19718533,
      "affiliations": [
-      "\u0413\u0440\u043e\u0434\u043d\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0413\u0440\u043e\u0434\u043d\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c"
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
-    }, 
+    },
     {
-     "id": "Belarus_Brest Region", 
-     "s": 15641612, 
+     "id": "Belarus_Brest Region",
+     "s": 15641612,
      "affiliations": [
-      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c", 
+      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c",
       "\u0411\u0440\u0435\u0441\u0442\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
-    }, 
+    },
     {
-     "id": "Belarus_Homiel Region", 
-     "s": 21601352, 
+     "id": "Belarus_Homiel Region",
+     "s": 21601352,
      "affiliations": [
-      "\u0413\u043e\u043c\u0435\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0413\u043e\u043c\u0435\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c"
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
-    }, 
+    },
     {
-     "id": "Belarus_Maglieu Region", 
-     "s": 17463797, 
+     "id": "Belarus_Maglieu Region",
+     "s": 17463797,
      "affiliations": [
-      "\u041c\u043e\u0433\u0438\u043b\u0451\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u041c\u043e\u0433\u0438\u043b\u0451\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c"
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
-    }, 
+    },
     {
-     "id": "Belarus_Minsk Region", 
-     "s": 39299678, 
+     "id": "Belarus_Minsk Region",
+     "s": 39299678,
      "affiliations": [
-      "\u0413\u043e\u043b\u044c\u0444-\u043a\u043b\u0443\u0431", 
-      "\u041c\u0438\u043d\u0441\u043a", 
-      "\u041c\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c", 
-      "\u041a\u043e\u043b\u043e\u0434\u0438\u0449\u0438", 
+      "\u0413\u043e\u043b\u044c\u0444-\u043a\u043b\u0443\u0431",
+      "\u041c\u0438\u043d\u0441\u043a",
+      "\u041c\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c",
+      "\u041a\u043e\u043b\u043e\u0434\u0438\u0449\u0438",
       "\u041d\u0430\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u044b\u0439 \u0430\u044d\u0440\u043e\u043f\u043e\u0440\u0442 \"\u041c\u0438\u043d\u0441\u043a\""
-     ], 
+     ],
      "old": [
       "Belarus"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Belgium", 
+   "id": "Belgium",
    "g": [
     {
-     "id": "Belgium_West Flanders", 
-     "s": 26646630, 
+     "id": "Belgium_West Flanders",
+     "s": 26646630,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Vlaanderen"
-     ], 
+     ],
      "old": [
-      "Belgium", 
+      "Belgium",
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Antwerp", 
-     "s": 41044867, 
+     "id": "Belgium_Antwerp",
+     "s": 41044867,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
-      "Nederland - Belgique / Belgi\u00eb / Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
+      "Nederland - Belgique / Belgi\u00eb / Belgien",
       "Vlaanderen"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_East Flanders", 
-     "s": 28177917, 
+     "id": "Belgium_East Flanders",
+     "s": 28177917,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Vlaanderen"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Hainaut", 
-     "s": 18653289, 
+     "id": "Belgium_Hainaut",
+     "s": 18653289,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Wallonie"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Walloon Brabant", 
-     "s": 6495335, 
+     "id": "Belgium_Walloon Brabant",
+     "s": 6495335,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Wallonie"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Namur", 
-     "s": 10011011, 
+     "id": "Belgium_Namur",
+     "s": 10011011,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Wallonie"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Limburg", 
-     "s": 23943757, 
+     "id": "Belgium_Limburg",
+     "s": 23943757,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Vlaanderen"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Luxembourg", 
-     "s": 11856106, 
+     "id": "Belgium_Luxembourg",
+     "s": 11856106,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Wallonie"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Flemish Brabant", 
-     "s": 41924658, 
+     "id": "Belgium_Flemish Brabant",
+     "s": 41924658,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
-      "R\u00e9gion de Bruxelles-Capitale - Brussels Hoofdstedelijk Gewest", 
+      "Belgi\u00eb - Belgique - Belgien",
+      "R\u00e9gion de Bruxelles-Capitale - Brussels Hoofdstedelijk Gewest",
       "Vlaanderen"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
-    }, 
+    },
     {
-     "id": "Belgium_Liege", 
-     "s": 26323071, 
+     "id": "Belgium_Liege",
+     "s": 26323071,
      "affiliations": [
-      "Belgi\u00eb - Belgique - Belgien", 
+      "Belgi\u00eb - Belgique - Belgien",
       "Wallonie"
-     ], 
+     ],
      "old": [
       "Belgium"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Belize", 
-   "s": 3289590, 
+   "id": "Belize",
+   "s": 3289590,
    "affiliations": [
-    "Belize District", 
-    "Belize", 
-    "Cayo", 
-    "Cort\u00e9s", 
-    "Corozal", 
-    "Honduras", 
-    "Orange Walk", 
-    "Stann Creek", 
+    "Belize District",
+    "Belize",
+    "Cayo",
+    "Cort\u00e9s",
+    "Corozal",
+    "Honduras",
+    "Orange Walk",
+    "Stann Creek",
     "Toledo"
-   ], 
+   ],
    "old": [
     "Belize"
    ]
-  }, 
+  },
   {
-   "id": "Benin", 
-   "s": 14807933, 
+   "id": "Benin",
+   "s": 14807933,
    "affiliations": [
-    "Alibori", 
-    "Atakora", 
-    "Atlantique", 
-    "Borgou", 
-    "B\u00e9nin", 
-    "Collines", 
-    "Donga", 
-    "Littoral", 
-    "Kouffo", 
-    "Mono", 
-    "Ou\u00e9m\u00e9", 
-    "Plateau", 
+    "Alibori",
+    "Atakora",
+    "Atlantique",
+    "Borgou",
+    "B\u00e9nin",
+    "Collines",
+    "Donga",
+    "Littoral",
+    "Kouffo",
+    "Mono",
+    "Ou\u00e9m\u00e9",
+    "Plateau",
     "Zou"
-   ], 
+   ],
    "old": [
     "Benin"
    ]
-  }, 
+  },
   {
-   "id": "Bermuda", 
-   "s": 659767, 
+   "id": "Bermuda",
+   "s": 659767,
    "affiliations": [
     "Bermuda"
-   ], 
+   ],
    "old": [
     "Bermuda"
    ]
-  }, 
+  },
   {
-   "id": "Bhutan", 
-   "s": 3816589, 
+   "id": "Bhutan",
+   "s": 3816589,
    "affiliations": [
-    "\u0f60\u0f56\u0fb2\u0f74\u0f42\u0f61\u0f74\u0f63\u0f0b", 
-    "\u0f58\u0f42\u0f62\u0f0b\u0f66\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f62\u0fa9\u0f72\u0f0b\u0f62\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f67\u0f71\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f51\u0f62\u0f0b\u0f51\u0f40\u0f62\u0f0b\u0f53\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f63\u0fb7\u0f74\u0f53\u0f0b\u0f62\u0fa9\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f42\u0f66\u0f62\u0f0b\u0f66\u0fa4\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f56\u0f66\u0f58\u0f0b\u0f62\u0fa9\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f58\u0f7c\u0f44\u0f0b\u0f66\u0f92\u0f62\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f66\u0fa4\u0f74\u0f0b\u0f53\u0f0b\u0f41\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f42\u0f5e\u0f63\u0f58\u0f0b\u0f66\u0f92\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f54\u0f51\u0fa8\u0f0b\u0f51\u0f42\u0f60\u0f0b\u0f5a\u0f63\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f46\u0f74\u0f0b\u0f41\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f66\u0fa4\u0f0b\u0f62\u0f7c\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f50\u0f72\u0f58\u0f0b\u0f55\u0f74\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f56\u0f74\u0f58\u0f0b\u0f50\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f40\u0fb2\u0f7c\u0f44\u0f0b\u0f42\u0f66\u0f62\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f56\u0f40\u0fb2\u0f0b\u0f64\u0f72\u0f66\u0f0b\u0f66\u0f92\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f56\u0f40\u0fb2\u0f0b\u0f64\u0f72\u0f66\u0f0b\u0f42\u0fb1\u0f44\u0f0b\u0f59\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
-    "\u0f51\u0f56\u0f44\u0f0b\u0f60\u0f51\u0f74\u0f66\u0f0b\u0f55\u0f7c\u0f0b\u0f56\u0fb2\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b", 
+    "\u0f60\u0f56\u0fb2\u0f74\u0f42\u0f61\u0f74\u0f63\u0f0b",
+    "\u0f58\u0f42\u0f62\u0f0b\u0f66\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f62\u0fa9\u0f72\u0f0b\u0f62\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f67\u0f71\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f51\u0f62\u0f0b\u0f51\u0f40\u0f62\u0f0b\u0f53\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f63\u0fb7\u0f74\u0f53\u0f0b\u0f62\u0fa9\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f42\u0f66\u0f62\u0f0b\u0f66\u0fa4\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f56\u0f66\u0f58\u0f0b\u0f62\u0fa9\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f58\u0f7c\u0f44\u0f0b\u0f66\u0f92\u0f62\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f66\u0fa4\u0f74\u0f0b\u0f53\u0f0b\u0f41\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f42\u0f5e\u0f63\u0f58\u0f0b\u0f66\u0f92\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f54\u0f51\u0fa8\u0f0b\u0f51\u0f42\u0f60\u0f0b\u0f5a\u0f63\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f46\u0f74\u0f0b\u0f41\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f66\u0fa4\u0f0b\u0f62\u0f7c\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f50\u0f72\u0f58\u0f0b\u0f55\u0f74\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f56\u0f74\u0f58\u0f0b\u0f50\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f40\u0fb2\u0f7c\u0f44\u0f0b\u0f42\u0f66\u0f62\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f56\u0f40\u0fb2\u0f0b\u0f64\u0f72\u0f66\u0f0b\u0f66\u0f92\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f56\u0f40\u0fb2\u0f0b\u0f64\u0f72\u0f66\u0f0b\u0f42\u0fb1\u0f44\u0f0b\u0f59\u0f7a\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
+    "\u0f51\u0f56\u0f44\u0f0b\u0f60\u0f51\u0f74\u0f66\u0f0b\u0f55\u0f7c\u0f0b\u0f56\u0fb2\u0f44\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b",
     "\u0f56\u0f66\u0f58\u0f0b\u0f42\u0fb2\u0f74\u0f56\u0f0b\u0f63\u0f97\u0f7c\u0f44\u0f66\u0f0b\u0f58\u0f41\u0f62\u0f0b\u0f62\u0fab\u0f7c\u0f44\u0f0b\u0f41\u0f42\u0f0b"
-   ], 
+   ],
    "old": [
     "Bhutan"
    ]
-  }, 
+  },
   {
-   "id": "Bolivia", 
+   "id": "Bolivia",
    "g": [
     {
-     "id": "Bolivia_North", 
-     "s": 28127277, 
+     "id": "Bolivia_North",
+     "s": 28127277,
      "affiliations": [
-      "Bolivia", 
-      "Beni", 
-      "La Paz", 
-      "Pando", 
+      "Bolivia",
+      "Beni",
+      "La Paz",
+      "Pando",
       "Santa Cruz"
-     ], 
+     ],
      "old": [
       "Bolivia"
      ]
-    }, 
+    },
     {
-     "id": "Bolivia_South", 
-     "s": 26673972, 
+     "id": "Bolivia_South",
+     "s": 26673972,
      "affiliations": [
-      "Bolivia", 
-      "Chuquisaca", 
-      "Cochabamba", 
-      "Oruro", 
-      "Potos\u00ed", 
+      "Bolivia",
+      "Chuquisaca",
+      "Cochabamba",
+      "Oruro",
+      "Potos\u00ed",
       "Tarija"
-     ], 
+     ],
      "old": [
       "Bolivia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Bosnia and Herzegovina", 
+   "id": "Bosnia and Herzegovina",
    "g": [
     {
-     "id": "Bosnia and Herzegovina_Entity Federation of Bosnia and Herzegovina", 
-     "s": 36179158, 
+     "id": "Bosnia and Herzegovina_Entity Federation of Bosnia and Herzegovina",
+     "s": 36179158,
      "affiliations": [
-      "Bosna i Hercegovina", 
+      "Bosna i Hercegovina",
       "Federacija Bosne i Hercegovine"
-     ], 
+     ],
      "old": [
       "Bosnia and Herzegovina"
      ]
-    }, 
+    },
     {
-     "id": "Bosnia and Herzegovina_Brcko district of Bosnia and Herzegowina", 
-     "s": 776850, 
+     "id": "Bosnia and Herzegovina_Brcko district of Bosnia and Herzegowina",
+     "s": 776850,
      "affiliations": [
-      "Br\u010dko distrikt Bosne i Hercegovine", 
-      "Bosna i Hercegovina", 
+      "Br\u010dko distrikt Bosne i Hercegovine",
+      "Bosna i Hercegovina",
       "Republika Srpska"
-     ], 
+     ],
      "old": [
       "Bosnia and Herzegovina"
      ]
-    }, 
+    },
     {
-     "id": "Bosnia and Herzegovina_Republic of Srpska", 
-     "s": 33084893, 
+     "id": "Bosnia and Herzegovina_Republic of Srpska",
+     "s": 33084893,
      "affiliations": [
-      "Bosna i Hercegovina", 
+      "Bosna i Hercegovina",
       "Republika Srpska"
-     ], 
+     ],
      "old": [
       "Bosnia and Herzegovina"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Botswana", 
-   "s": 27095566, 
+   "id": "Botswana",
+   "s": 27095566,
    "affiliations": [
-    "Botswana", 
-    "Central District", 
-    "Ghanzi District", 
-    "Kgalagadi District", 
-    "Kgatleng District", 
-    "Kweneng District", 
-    "North-East District", 
-    "North-West District", 
-    "South-East District", 
+    "Botswana",
+    "Central District",
+    "Ghanzi District",
+    "Kgalagadi District",
+    "Kgatleng District",
+    "Kweneng District",
+    "North-East District",
+    "North-West District",
+    "South-East District",
     "Southern District"
-   ], 
+   ],
    "old": [
     "Botswana"
    ]
-  }, 
+  },
   {
-   "id": "Brazil", 
+   "id": "Brazil",
    "g": [
     {
-     "id": "Brazil_Bahia", 
-     "s": 21630327, 
+     "id": "Brazil_Bahia",
+     "s": 21630327,
      "affiliations": [
-      "Bahia", 
+      "Bahia",
       "Brasil"
-     ], 
+     ],
      "old": [
       "Brazil_Northeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Goias_North", 
-     "s": 7757955, 
+     "id": "Brazil_Goias_North",
+     "s": 7757955,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Goi\u00e1s"
-     ], 
+     ],
      "old": [
       "Brazil_Central-West"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Goias_Brasilia", 
-     "s": 16241858, 
+     "id": "Brazil_Goias_Brasilia",
+     "s": 16241858,
      "affiliations": [
-      "Brasil", 
-      "Distrito Federal", 
+      "Brasil",
+      "Distrito Federal",
       "Goi\u00e1s"
-     ], 
+     ],
      "old": [
       "Brazil_Central-West"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Mato Grosso Do Sul", 
-     "s": 7853079, 
+     "id": "Brazil_Mato Grosso Do Sul",
+     "s": 7853079,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Mato Grosso do Sul"
-     ], 
+     ],
      "old": [
       "Brazil_Central-West"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Mato Grosso", 
-     "s": 13563057, 
+     "id": "Brazil_Mato Grosso",
+     "s": 13563057,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Mato Grosso"
-     ], 
+     ],
      "old": [
       "Brazil_Central-West"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_North Region_East", 
-     "s": 22609715, 
+     "id": "Brazil_North Region_East",
+     "s": 22609715,
      "affiliations": [
-      "Amap\u00e1", 
-      "Brasil", 
-      "Par\u00e1", 
+      "Amap\u00e1",
+      "Brasil",
+      "Par\u00e1",
       "Tocantins"
-     ], 
+     ],
      "old": [
       "Brazil_North"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_North Region_West", 
-     "s": 20345477, 
+     "id": "Brazil_North Region_West",
+     "s": 20345477,
      "affiliations": [
-      "Acre", 
-      "Amazonas", 
-      "Brasil", 
-      "Rond\u00f4nia", 
+      "Acre",
+      "Amazonas",
+      "Brasil",
+      "Rond\u00f4nia",
       "Roraima"
-     ], 
+     ],
      "old": [
       "Brazil_North"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Northeast Region_East", 
-     "s": 19128103, 
+     "id": "Brazil_Northeast Region_East",
+     "s": 19128103,
      "affiliations": [
-      "Alagoas", 
-      "Brasil", 
-      "Pernambuco", 
+      "Alagoas",
+      "Brasil",
+      "Pernambuco",
       "Sergipe"
-     ], 
+     ],
      "old": [
       "Brazil_Northeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Northeast Region_West", 
-     "s": 24408088, 
+     "id": "Brazil_Northeast Region_West",
+     "s": 24408088,
      "affiliations": [
-      "Brasil", 
-      "Cear\u00e1", 
-      "Maranh\u00e3o", 
-      "Pernambuco", 
+      "Brasil",
+      "Cear\u00e1",
+      "Maranh\u00e3o",
+      "Pernambuco",
       "Piau\u00ed"
-     ], 
+     ],
      "old": [
       "Brazil_Northeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Paraiba", 
-     "s": 8321714, 
+     "id": "Brazil_Paraiba",
+     "s": 8321714,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Para\u00edba"
-     ], 
+     ],
      "old": [
       "Brazil_Northeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Parana_East", 
-     "s": 15150711, 
+     "id": "Brazil_Parana_East",
+     "s": 15150711,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Paran\u00e1"
-     ], 
+     ],
      "old": [
       "Brazil_South"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Parana_West", 
-     "s": 23079692, 
+     "id": "Brazil_Parana_West",
+     "s": 23079692,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Paran\u00e1"
-     ], 
+     ],
      "old": [
       "Brazil_South"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Rio Grande do Norte", 
-     "s": 5092523, 
+     "id": "Brazil_Rio Grande do Norte",
+     "s": 5092523,
      "affiliations": [
-      "Brasil", 
-      "Pernambuco", 
+      "Brasil",
+      "Pernambuco",
       "Rio Grande do Norte"
-     ], 
+     ],
      "old": [
       "Brazil_Northeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Santa Catarina", 
-     "s": 33471321, 
+     "id": "Brazil_Santa Catarina",
+     "s": 33471321,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Santa Catarina"
-     ], 
+     ],
      "old": [
       "Brazil_South"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_South Region_East", 
-     "s": 35267826, 
+     "id": "Brazil_South Region_East",
+     "s": 35267826,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Rio Grande do Sul"
-     ], 
+     ],
      "old": [
       "Brazil_South"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_South Region_West", 
-     "s": 24064818, 
+     "id": "Brazil_South Region_West",
+     "s": 24064818,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Rio Grande do Sul"
-     ], 
+     ],
      "old": [
       "Brazil_South"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Espirito Santo", 
-     "s": 15881228, 
+     "id": "Brazil_Southeast Region_Espirito Santo",
+     "s": 15881228,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Esp\u00edrito Santo"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Minas Gerais_Contagem", 
-     "s": 30772042, 
+     "id": "Brazil_Southeast Region_Minas Gerais_Contagem",
+     "s": 30772042,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Minas Gerais"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Minas Gerais_North", 
-     "s": 24939578, 
+     "id": "Brazil_Southeast Region_Minas Gerais_North",
+     "s": 24939578,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Minas Gerais"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Rio de Janeiro", 
-     "s": 27221917, 
+     "id": "Brazil_Southeast Region_Rio de Janeiro",
+     "s": 27221917,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "Rio de Janeiro"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Sao Paulo_Campinas", 
-     "s": 23447340, 
+     "id": "Brazil_Southeast Region_Sao Paulo_Campinas",
+     "s": 23447340,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "S\u00e3o Paulo"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Sao Paulo_City", 
-     "s": 44375566, 
+     "id": "Brazil_Southeast Region_Sao Paulo_City",
+     "s": 44375566,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "S\u00e3o Paulo"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
-    }, 
+    },
     {
-     "id": "Brazil_Southeast Region_Sao Paulo_West", 
-     "s": 19647517, 
+     "id": "Brazil_Southeast Region_Sao Paulo_West",
+     "s": 19647517,
      "affiliations": [
-      "Brasil", 
+      "Brasil",
       "S\u00e3o Paulo"
-     ], 
+     ],
      "old": [
       "Brazil_Southeast"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Brunei", 
-   "s": 1845887, 
+   "id": "Brunei",
+   "s": 1845887,
    "affiliations": [
     "Brunei Darussalam"
-   ], 
+   ],
    "old": [
     "Brunei"
    ]
-  }, 
+  },
   {
-   "id": "Bulgaria", 
+   "id": "Bulgaria",
    "g": [
     {
-     "id": "Bulgaria_East", 
-     "s": 27094625, 
+     "id": "Bulgaria_East",
+     "s": 27094625,
      "affiliations": [
       "\u0411\u044a\u043b\u0433\u0430\u0440\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Bulgaria"
      ]
-    }, 
+    },
     {
-     "id": "Bulgaria_West", 
-     "s": 44267867, 
+     "id": "Bulgaria_West",
+     "s": 44267867,
      "affiliations": [
       "\u0411\u044a\u043b\u0433\u0430\u0440\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Bulgaria"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Burkina Faso", 
-   "s": 20243393, 
+   "id": "Burkina Faso",
+   "s": 20243393,
    "affiliations": [
-    "Boucle du Mouhoun", 
-    "Burkina Faso", 
-    "Cascades", 
-    "Centre", 
-    "Centre-Est", 
-    "Centre-Nord", 
-    "Centre-Ouest", 
-    "Centre-Sud", 
-    "Est", 
-    "Hauts-Bassins", 
-    "Nord", 
-    "Plateau-Central", 
-    "Sahel", 
+    "Boucle du Mouhoun",
+    "Burkina Faso",
+    "Cascades",
+    "Centre",
+    "Centre-Est",
+    "Centre-Nord",
+    "Centre-Ouest",
+    "Centre-Sud",
+    "Est",
+    "Hauts-Bassins",
+    "Nord",
+    "Plateau-Central",
+    "Sahel",
     "Sud-Ouest"
-   ], 
+   ],
    "old": [
     "Burkina Faso"
    ]
-  }, 
+  },
   {
-   "id": "Burundi", 
-   "s": 7243048, 
+   "id": "Burundi",
+   "s": 7243048,
    "affiliations": [
-    "Cibitoke", 
-    "Bubanza", 
-    "Bururi", 
-    "Bujumbura Mairie", 
-    "Bujumbura Rural", 
-    "Burundi", 
-    "Cankuzo", 
-    "Gitega", 
-    "Karuzi", 
-    "Kayanza", 
-    "Kirundo", 
-    "Makamba", 
-    "Ngozi", 
-    "Muramvya", 
-    "Muyinga", 
-    "Mwaro", 
-    "Rutana", 
+    "Cibitoke",
+    "Bubanza",
+    "Bururi",
+    "Bujumbura Mairie",
+    "Bujumbura Rural",
+    "Burundi",
+    "Cankuzo",
+    "Gitega",
+    "Karuzi",
+    "Kayanza",
+    "Kirundo",
+    "Makamba",
+    "Ngozi",
+    "Muramvya",
+    "Muyinga",
+    "Mwaro",
+    "Rutana",
     "Ruyigi"
-   ], 
+   ],
    "old": [
     "Burundi"
    ]
-  }, 
+  },
   {
-   "id": "Cambodia", 
-   "s": 9875625, 
+   "id": "Cambodia",
+   "s": 9875625,
    "affiliations": [
-    "Bantey Meanchey", 
-    "Battambang", 
-    "Kampong Cham", 
-    "Kampong Chhnang", 
-    "Kampong Speu", 
-    "Kampong Thom", 
-    "Kampot", 
-    "Kandal", 
-    "Koh Kong", 
-    "Kratie", 
-    "Kep", 
-    "Mondulkiri", 
-    "Oddar Meanchey", 
-    "Pailin", 
-    "Prey Veng", 
-    "Phnom Penh", 
-    "Preah Sihanouk", 
-    "Preah Vihear", 
-    "Pursat", 
-    "Ratanakiri", 
-    "Siem Reap", 
-    "Stung Treng", 
-    "Svay Rieng", 
-    "Takeo", 
-    "Tbong Khmum", 
+    "Bantey Meanchey",
+    "Battambang",
+    "Kampong Cham",
+    "Kampong Chhnang",
+    "Kampong Speu",
+    "Kampong Thom",
+    "Kampot",
+    "Kandal",
+    "Koh Kong",
+    "Kratie",
+    "Kep",
+    "Mondulkiri",
+    "Oddar Meanchey",
+    "Pailin",
+    "Prey Veng",
+    "Phnom Penh",
+    "Preah Sihanouk",
+    "Preah Vihear",
+    "Pursat",
+    "Ratanakiri",
+    "Siem Reap",
+    "Stung Treng",
+    "Svay Rieng",
+    "Takeo",
+    "Tbong Khmum",
     "\u1796\u17d2\u179a\u17c7\u179a\u17b6\u1787\u17b6\u178e\u17b6\u1785\u1780\u17d2\u179a\u1780\u1798\u17d2\u1796\u17bb\u1787\u17b6 (Cambodia)"
-   ], 
+   ],
    "old": [
     "Cambodia"
    ]
-  }, 
+  },
   {
-   "id": "Cameroon", 
+   "id": "Cameroon",
    "g": [
     {
-     "id": "Cameroon_Central", 
-     "s": 53617870, 
+     "id": "Cameroon_Central",
+     "s": 53617870,
      "affiliations": [
-      "Adamaoua", 
-      "Cameroun", 
-      "Centre", 
-      "Est", 
-      "Extr\u00eame-Nord", 
-      "Nord", 
+      "Adamaoua",
+      "Cameroun",
+      "Centre",
+      "Est",
+      "Extr\u00eame-Nord",
+      "Nord",
       "Sud"
-     ], 
+     ],
      "old": [
       "Cameroon"
      ]
-    }, 
+    },
     {
-     "id": "Cameroon_West", 
-     "s": 36955437, 
+     "id": "Cameroon_West",
+     "s": 36955437,
      "affiliations": [
-      "Cameroun", 
-      "Littoral", 
-      "Nord-Ouest", 
-      "Ouest", 
+      "Cameroun",
+      "Littoral",
+      "Nord-Ouest",
+      "Ouest",
       "Sud-Ouest"
-     ], 
+     ],
      "old": [
       "Cameroon"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Canada", 
+   "id": "Canada",
    "g": [
     {
-     "id": "Canada_Alberta", 
+     "id": "Canada_Alberta",
      "g": [
       {
-       "id": "Canada_Alberta_Edmonton", 
-       "s": 57268016, 
+       "id": "Canada_Alberta_Edmonton",
+       "s": 57268016,
        "affiliations": [
-        "Alberta", 
+        "Alberta",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_Alberta"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Alberta_North", 
-       "s": 25563376, 
+       "id": "Canada_Alberta_North",
+       "s": 25563376,
        "affiliations": [
-        "Alberta", 
+        "Alberta",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_Alberta"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Alberta_South", 
-       "s": 24089931, 
+       "id": "Canada_Alberta_South",
+       "s": 24089931,
        "affiliations": [
-        "Alberta", 
+        "Alberta",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_Alberta"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_British Columbia", 
+     "id": "Canada_British Columbia",
      "g": [
       {
-       "id": "Canada_British Columbia_Central", 
-       "s": 46190032, 
+       "id": "Canada_British Columbia_Central",
+       "s": 46190032,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_Far_North", 
-       "s": 26239096, 
+       "id": "Canada_British Columbia_Far_North",
+       "s": 26239096,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_Islands", 
-       "s": 36955644, 
+       "id": "Canada_British Columbia_Islands",
+       "s": 36955644,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_North", 
-       "s": 40992842, 
+       "id": "Canada_British Columbia_North",
+       "s": 40992842,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_Northeast", 
-       "s": 45861245, 
+       "id": "Canada_British Columbia_Northeast",
+       "s": 45861245,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_Southeast", 
-       "s": 47962115, 
+       "id": "Canada_British Columbia_Southeast",
+       "s": 47962115,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_British Columbia_Vancouver", 
-       "s": 40654169, 
+       "id": "Canada_British Columbia_Vancouver",
+       "s": 40654169,
        "affiliations": [
-        "British Columbia", 
+        "British Columbia",
         "Canada"
-       ], 
+       ],
        "old": [
         "Canada_British Columbia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Labrador", 
+     "id": "Canada_Labrador",
      "g": [
       {
-       "id": "Canada_Labrador_North", 
-       "s": 47654063, 
+       "id": "Canada_Labrador_North",
+       "s": 47654063,
        "affiliations": [
-        "Canada", 
-        "Newfoundland and Labrador", 
+        "Canada",
+        "Newfoundland and Labrador",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Labrador_South", 
-       "s": 36488371, 
+       "id": "Canada_Labrador_South",
+       "s": 36488371,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Newfoundland and Labrador"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Labrador_West", 
-       "s": 49139014, 
+       "id": "Canada_Labrador_West",
+       "s": 49139014,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Newfoundland and Labrador"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Manitoba", 
+     "id": "Canada_Manitoba",
      "g": [
       {
-       "id": "Canada_Manitoba_Northeast", 
-       "s": 35098862, 
+       "id": "Canada_Manitoba_Northeast",
+       "s": 35098862,
        "affiliations": [
-        "Canada", 
-        "Manitoba", 
+        "Canada",
+        "Manitoba",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
-        "Canada_Manitoba", 
+        "Canada_Manitoba",
         "Canada_Nunavut"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Manitoba_Northwest", 
-       "s": 39237732, 
+       "id": "Canada_Manitoba_Northwest",
+       "s": 39237732,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Manitoba"
-       ], 
+       ],
        "old": [
         "Canada_Manitoba"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Manitoba_South", 
-       "s": 38735343, 
+       "id": "Canada_Manitoba_South",
+       "s": 38735343,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Manitoba"
-       ], 
+       ],
        "old": [
         "Canada_Manitoba"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Manitoba_Winnipeg", 
-       "s": 31973190, 
+       "id": "Canada_Manitoba_Winnipeg",
+       "s": 31973190,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Manitoba"
-       ], 
+       ],
        "old": [
         "Canada_Manitoba"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_New Brunswick", 
-     "s": 45745462, 
+     "id": "Canada_New Brunswick",
+     "s": 45745462,
      "affiliations": [
-      "Canada", 
-      "Devon Indian Reserve NO. 30", 
-      "New Brunswick", 
+      "Canada",
+      "Devon Indian Reserve NO. 30",
+      "New Brunswick",
       "Oromocto Indian Reserve NO. 26"
-     ], 
+     ],
      "old": [
       "Canada_New Brunswick"
      ]
-    }, 
+    },
     {
-     "id": "Canada_Newfoundland", 
+     "id": "Canada_Newfoundland",
      "g": [
       {
-       "id": "Canada_Newfoundland_East", 
-       "s": 18889637, 
+       "id": "Canada_Newfoundland_East",
+       "s": 18889637,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Newfoundland and Labrador"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Newfoundland_North", 
-       "s": 26910036, 
+       "id": "Canada_Newfoundland_North",
+       "s": 26910036,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Newfoundland and Labrador"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Newfoundland_South", 
-       "s": 18010561, 
+       "id": "Canada_Newfoundland_South",
+       "s": 18010561,
        "affiliations": [
-        "Canada", 
-        "France", 
-        "Newfoundland and Labrador", 
+        "Canada",
+        "France",
+        "Newfoundland and Labrador",
         "\u00cele Verte"
-       ], 
+       ],
        "old": [
-        "Saint Pierre and Miquelon", 
+        "Saint Pierre and Miquelon",
         "Canada_Newfoundland and Labrador"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Newfoundland_West", 
-       "s": 21018918, 
+       "id": "Canada_Newfoundland_West",
+       "s": 21018918,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Newfoundland and Labrador"
-       ], 
+       ],
        "old": [
         "Canada_Newfoundland and Labrador"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Northwest Territories", 
+     "id": "Canada_Northwest Territories",
      "g": [
       {
-       "id": "Canada_Northwest Territories_East", 
-       "s": 16791801, 
+       "id": "Canada_Northwest Territories_East",
+       "s": 16791801,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Northwest Territories"
-       ], 
+       ],
        "old": [
         "Canada_Northwest Territories"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Northwest Territories_North", 
-       "s": 29183746, 
+       "id": "Canada_Northwest Territories_North",
+       "s": 29183746,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Northwest Territories"
-       ], 
+       ],
        "old": [
         "Canada_Northwest Territories"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Northwest Territories_Yellowknife", 
-       "s": 42393325, 
+       "id": "Canada_Northwest Territories_Yellowknife",
+       "s": 42393325,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Northwest Territories"
-       ], 
+       ],
        "old": [
         "Canada_Northwest Territories"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Nova Scotia", 
+     "id": "Canada_Nova Scotia",
      "g": [
       {
-       "id": "Canada_Nova Scotia_Halifax", 
-       "s": 46183278, 
+       "id": "Canada_Nova Scotia_Halifax",
+       "s": 46183278,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Nova Scotia"
-       ], 
+       ],
        "old": [
         "Canada_Nova Scotia"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Nova Scotia_Sydney", 
-       "s": 18866987, 
+       "id": "Canada_Nova Scotia_Sydney",
+       "s": 18866987,
        "affiliations": [
-        "Canada", 
-        "Nova Scotia", 
+        "Canada",
+        "Nova Scotia",
         "Prince Edward Island"
-       ], 
+       ],
        "old": [
         "Canada_Nova Scotia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Nunavut", 
+     "id": "Canada_Nunavut",
      "g": [
       {
-       "id": "Canada_Nunavut_North", 
-       "s": 35032243, 
+       "id": "Canada_Nunavut_North",
+       "s": 35032243,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
         "Canada_Nunavut"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Nunavut_South", 
-       "s": 75552520, 
+       "id": "Canada_Nunavut_South",
+       "s": 75552520,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
         "Canada_Nunavut"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Ontario", 
+     "id": "Canada_Ontario",
      "g": [
       {
-       "id": "Canada_Ontario_Bame", 
-       "s": 44507634, 
+       "id": "Canada_Ontario_Bame",
+       "s": 44507634,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Kingston", 
-       "s": 65772497, 
+       "id": "Canada_Ontario_Kingston",
+       "s": 65772497,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_London", 
-       "s": 40889881, 
+       "id": "Canada_Ontario_London",
+       "s": 40889881,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_Central", 
-       "s": 32294474, 
+       "id": "Canada_Ontario_Northeastern_Central",
+       "s": 32294474,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_North", 
-       "s": 36752144, 
+       "id": "Canada_Ontario_Northeastern_North",
+       "s": 36752144,
        "affiliations": [
-        "Canada", 
-        "Ontario", 
+        "Canada",
+        "Ontario",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
-        "Canada_Nunavut", 
+        "Canada_Nunavut",
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_S", 
-       "s": 35548020, 
+       "id": "Canada_Ontario_Northeastern_S",
+       "s": 35548020,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_SE", 
-       "s": 19942310, 
+       "id": "Canada_Ontario_Northeastern_SE",
+       "s": 19942310,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_SW", 
-       "s": 39700749, 
+       "id": "Canada_Ontario_Northeastern_SW",
+       "s": 39700749,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northeastern_Wawa", 
-       "s": 30753686, 
+       "id": "Canada_Ontario_Northeastern_Wawa",
+       "s": 30753686,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northern", 
-       "s": 41392630, 
+       "id": "Canada_Ontario_Northern",
+       "s": 41392630,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Northwestern", 
-       "s": 80487847, 
+       "id": "Canada_Ontario_Northwestern",
+       "s": 80487847,
        "affiliations": [
-        "Canada", 
-        "NU", 
-        "Ontario", 
+        "Canada",
+        "NU",
+        "Ontario",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
-        "Canada_Nunavut", 
+        "Canada_Nunavut",
         "Canada_Ontario"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Ontario_Toronto", 
-       "s": 53368492, 
+       "id": "Canada_Ontario_Toronto",
+       "s": 53368492,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Ontario"
-       ], 
+       ],
        "old": [
         "Canada_Ontario"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Prince Edward Island", 
-     "s": 6986649, 
+     "id": "Canada_Prince Edward Island",
+     "s": 6986649,
      "affiliations": [
-      "Canada", 
+      "Canada",
       "Prince Edward Island"
-     ], 
+     ],
      "old": [
       "Canada_Prince Edward Island"
      ]
-    }, 
+    },
     {
-     "id": "Canada_Quebec", 
+     "id": "Canada_Quebec",
      "g": [
       {
-       "id": "Canada_Quebec_Quebec", 
-       "s": 43467845, 
+       "id": "Canada_Quebec_Quebec",
+       "s": 43467845,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_Far North", 
-       "s": 46303373, 
+       "id": "Canada_Quebek_Far North",
+       "s": 46303373,
        "affiliations": [
-        "Canada", 
-        "NU", 
-        "Qu\u00e9bec", 
+        "Canada",
+        "NU",
+        "Qu\u00e9bec",
         "\u14c4\u14c7\u1557\u1466 Nunavut"
-       ], 
+       ],
        "old": [
-        "Canada_Quebec", 
+        "Canada_Quebec",
         "Canada_Nunavut"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_Montreal", 
-       "s": 29751766, 
+       "id": "Canada_Quebek_Montreal",
+       "s": 29751766,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_Lachute", 
-       "s": 38625382, 
+       "id": "Canada_Quebek_Lachute",
+       "s": 38625382,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_North", 
-       "s": 52685654, 
+       "id": "Canada_Quebek_North",
+       "s": 52685654,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_Southeast_Rimouski", 
-       "s": 19383568, 
+       "id": "Canada_Quebek_Southeast_Rimouski",
+       "s": 19383568,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_Southeast_Saguenay", 
-       "s": 37936565, 
+       "id": "Canada_Quebek_Southeast_Saguenay",
+       "s": 37936565,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_West_Chibougamau", 
-       "s": 49149257, 
+       "id": "Canada_Quebek_West_Chibougamau",
+       "s": 49149257,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Quebek_West_Rouyn-Noranda", 
-       "s": 32780428, 
+       "id": "Canada_Quebek_West_Rouyn-Noranda",
+       "s": 32780428,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Qu\u00e9bec"
-       ], 
+       ],
        "old": [
         "Canada_Quebec"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Saskatchewan", 
+     "id": "Canada_Saskatchewan",
      "g": [
       {
-       "id": "Canada_Saskatchewan_North", 
-       "s": 32893689, 
+       "id": "Canada_Saskatchewan_North",
+       "s": 32893689,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Saskatchewan"
-       ], 
+       ],
        "old": [
         "Canada_Saskatchewan"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Saskatchewan_Saskatoon", 
-       "s": 21505890, 
+       "id": "Canada_Saskatchewan_Saskatoon",
+       "s": 21505890,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Saskatchewan"
-       ], 
+       ],
        "old": [
         "Canada_Saskatchewan"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Saskatchewan_Regina", 
-       "s": 33561204, 
+       "id": "Canada_Saskatchewan_Regina",
+       "s": 33561204,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Saskatchewan"
-       ], 
+       ],
        "old": [
         "Canada_Saskatchewan"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Canada_Yukon", 
+     "id": "Canada_Yukon",
      "g": [
       {
-       "id": "Canada_Yukon_North", 
-       "s": 29040249, 
+       "id": "Canada_Yukon_North",
+       "s": 29040249,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Yukon"
-       ], 
+       ],
        "old": [
         "Canada_Yukon"
        ]
-      }, 
+      },
       {
-       "id": "Canada_Yukon_Whitehorse", 
-       "s": 35375502, 
+       "id": "Canada_Yukon_Whitehorse",
+       "s": 35375502,
        "affiliations": [
-        "Canada", 
+        "Canada",
         "Yukon"
-       ], 
+       ],
        "old": [
         "Canada_Yukon"
        ]
@@ -2422,4587 +2422,4587 @@
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Cape Verde", 
-   "s": 3396560, 
+   "id": "Cape Verde",
+   "s": 3396560,
    "affiliations": [
     "Cabo Verde"
-   ], 
+   ],
    "old": [
     "Cape Verde"
    ]
-  }, 
+  },
   {
-   "id": "Cayman Islands", 
-   "s": 925316, 
+   "id": "Cayman Islands",
+   "s": 925316,
    "affiliations": [
     "Cayman Islands"
-   ], 
+   ],
    "old": [
     "Cayman Islands"
    ]
-  }, 
+  },
   {
-   "id": "Central African Republic", 
-   "s": 17383766, 
+   "id": "Central African Republic",
+   "s": 17383766,
    "affiliations": [
-    "Bamingui-Bangoran", 
-    "Basse-Kotto", 
-    "Haut-Mbomou", 
-    "Haute-Kotto", 
-    "Lobaye", 
-    "K\u00e9mo", 
-    "K\u00f6d\u00f6r\u00f6s\u00ease t\u00ee B\u00eaafr\u00eeka - R\u00e9publique Centrafricaine", 
-    "Mamb\u00e9r\u00e9-Kad\u00e9\u00ef", 
-    "Mbomou", 
-    "Nana-Gr\u00e9bizi", 
-    "Nana-Mamb\u00e9r\u00e9", 
-    "Ombella M'Poko", 
-    "Ouaka", 
-    "Ouham", 
-    "Ouham-Pend\u00e9", 
-    "Sangha-Mba\u00e9r\u00e9", 
+    "Bamingui-Bangoran",
+    "Basse-Kotto",
+    "Haut-Mbomou",
+    "Haute-Kotto",
+    "Lobaye",
+    "K\u00e9mo",
+    "K\u00f6d\u00f6r\u00f6s\u00ease t\u00ee B\u00eaafr\u00eeka - R\u00e9publique Centrafricaine",
+    "Mamb\u00e9r\u00e9-Kad\u00e9\u00ef",
+    "Mbomou",
+    "Nana-Gr\u00e9bizi",
+    "Nana-Mamb\u00e9r\u00e9",
+    "Ombella M'Poko",
+    "Ouaka",
+    "Ouham",
+    "Ouham-Pend\u00e9",
+    "Sangha-Mba\u00e9r\u00e9",
     "Vakaga"
-   ], 
+   ],
    "old": [
     "Central African Republic"
    ]
-  }, 
+  },
   {
-   "id": "Chad", 
-   "s": 14894180, 
+   "id": "Chad",
+   "s": 14894180,
    "affiliations": [
-    "Bahr el Gazel", 
-    "Batha", 
-    "Borkou Region", 
-    "Chari-Baguirmi", 
-    "Ennedi Region", 
-    "Gu\u00e9ra", 
-    "Hadjer-Lamis", 
-    "Kanem", 
-    "Logone Occidental", 
-    "Logone Oriental", 
-    "Lac", 
-    "Mandoul", 
-    "Mayo-Kebbi Est", 
-    "Mayo-Kebbi Ouest", 
-    "N'Djamena", 
-    "Moyen-Chari", 
-    "Ouadda\u00ef", 
-    "Salamat", 
-    "Sila", 
-    "Tandjil\u00e9", 
-    "Tchad - \u062a\u0634\u0627\u062f", 
-    "Tibesti Region", 
+    "Bahr el Gazel",
+    "Batha",
+    "Borkou Region",
+    "Chari-Baguirmi",
+    "Ennedi Region",
+    "Gu\u00e9ra",
+    "Hadjer-Lamis",
+    "Kanem",
+    "Logone Occidental",
+    "Logone Oriental",
+    "Lac",
+    "Mandoul",
+    "Mayo-Kebbi Est",
+    "Mayo-Kebbi Ouest",
+    "N'Djamena",
+    "Moyen-Chari",
+    "Ouadda\u00ef",
+    "Salamat",
+    "Sila",
+    "Tandjil\u00e9",
+    "Tchad - \u062a\u0634\u0627\u062f",
+    "Tibesti Region",
     "Wadi Fira Region"
-   ], 
+   ],
    "old": [
     "Chad"
    ]
-  }, 
+  },
   {
-   "id": "Colombia", 
+   "id": "Colombia",
    "g": [
     {
-     "id": "Colombia_North", 
-     "s": 34611167, 
+     "id": "Colombia_North",
+     "s": 34611167,
      "affiliations": [
-      "Bol\u00edvar", 
-      "Antioquia", 
-      "Cesar", 
-      "Archipi\u00e9lago de San Andr\u00e9s, Providencia y Santa Catalina", 
-      "Atl\u00e1ntico", 
-      "Colombia", 
-      "C\u00f3rdoba", 
-      "Isla Grande, Col\u00f4mbia", 
-      "La Guajira", 
-      "Magdalena", 
-      "Norte de Santander", 
-      "Santander", 
+      "Bol\u00edvar",
+      "Antioquia",
+      "Cesar",
+      "Archipi\u00e9lago de San Andr\u00e9s, Providencia y Santa Catalina",
+      "Atl\u00e1ntico",
+      "Colombia",
+      "C\u00f3rdoba",
+      "Isla Grande, Col\u00f4mbia",
+      "La Guajira",
+      "Magdalena",
+      "Norte de Santander",
+      "Santander",
       "Sucre"
-     ], 
+     ],
      "old": [
       "Colombia"
      ]
-    }, 
+    },
     {
-     "id": "Colombia_West", 
-     "s": 36196902, 
+     "id": "Colombia_West",
+     "s": 36196902,
      "affiliations": [
-      "Cauca", 
-      "Bogot\u00e1", 
-      "Caldas", 
-      "Boyac\u00e1", 
-      "Choc\u00f3", 
-      "Colombia", 
-      "Cundinamarca", 
-      "Huila", 
-      "Nari\u00f1o", 
-      "Quind\u00edo", 
-      "Risaralda", 
-      "Tolima", 
+      "Cauca",
+      "Bogot\u00e1",
+      "Caldas",
+      "Boyac\u00e1",
+      "Choc\u00f3",
+      "Colombia",
+      "Cundinamarca",
+      "Huila",
+      "Nari\u00f1o",
+      "Quind\u00edo",
+      "Risaralda",
+      "Tolima",
       "Valle del Cauca"
-     ], 
+     ],
      "old": [
-      "Colombia", 
+      "Colombia",
       "Malpelo Island"
      ]
-    }, 
+    },
     {
-     "id": "Colombia_East", 
-     "s": 13008957, 
+     "id": "Colombia_East",
+     "s": 13008957,
      "affiliations": [
-      "Amazonas", 
-      "Arauca", 
-      "Caquet\u00e1", 
-      "Casanare", 
-      "Colombia", 
-      "Guain\u00eda", 
-      "Guaviare", 
-      "Putumayo", 
-      "Meta", 
-      "Vaup\u00e9s", 
+      "Amazonas",
+      "Arauca",
+      "Caquet\u00e1",
+      "Casanare",
+      "Colombia",
+      "Guain\u00eda",
+      "Guaviare",
+      "Putumayo",
+      "Meta",
+      "Vaup\u00e9s",
       "Vichada"
-     ], 
+     ],
      "old": [
       "Colombia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Comoros", 
-   "s": 1294765, 
+   "id": "Comoros",
+   "s": 1294765,
    "affiliations": [
-    "Komori", 
-    "Ngazidja", 
-    "Mwali", 
+    "Komori",
+    "Ngazidja",
+    "Mwali",
     "Nzwani / \u0623\u0646\u062c\u0648\u0627\u0646"
-   ], 
+   ],
    "old": [
     "Comoros"
    ]
-  }, 
+  },
   {
-   "id": "Congo-Brazzaville", 
-   "s": 4684223, 
+   "id": "Congo-Brazzaville",
+   "s": 4684223,
    "affiliations": [
-    "Bouenza", 
-    "Brazzaville", 
-    "Cuvette", 
-    "Cuvette-Ouest", 
-    "Kouilou", 
-    "Likouala", 
-    "L\u00e9koumou", 
-    "Niari", 
-    "R\u00e9publique du Congo", 
-    "Plateaux", 
-    "Pointe-Noire", 
-    "Pool", 
+    "Bouenza",
+    "Brazzaville",
+    "Cuvette",
+    "Cuvette-Ouest",
+    "Kouilou",
+    "Likouala",
+    "L\u00e9koumou",
+    "Niari",
+    "R\u00e9publique du Congo",
+    "Plateaux",
+    "Pointe-Noire",
+    "Pool",
     "Sangha"
-   ], 
+   ],
    "old": [
     "Congo-Brazzaville"
    ]
-  }, 
+  },
   {
-   "id": "Congo-Kinshasa", 
+   "id": "Congo-Kinshasa",
    "g": [
     {
-     "id": "Congo-Kinshasa_West", 
-     "s": 48767626, 
+     "id": "Congo-Kinshasa_West",
+     "s": 48767626,
      "affiliations": [
-      "Bas-Uele", 
-      "Haut-Katanga", 
-      "Haut-Lomami", 
-      "Haut-Uele", 
-      "Ituri", 
-      "Kinshasa", 
-      "Kongo-Central", 
-      "Kasa\u00ef", 
-      "Kasa\u00ef Central", 
-      "Kasa\u00ef Oriental", 
-      "Lomami", 
-      "Lualaba", 
-      "Kwango", 
-      "Kwilu", 
-      "Mai-Ndombe", 
-      "Maniema", 
-      "Mongala", 
-      "R\u00e9publique d\u00e9mocratique du Congo", 
-      "Nord-Ubangi", 
-      "Sankuru", 
-      "Sud-Ubangi", 
-      "Tanganyika", 
-      "Tshopo", 
-      "Tshuapa", 
+      "Bas-Uele",
+      "Haut-Katanga",
+      "Haut-Lomami",
+      "Haut-Uele",
+      "Ituri",
+      "Kinshasa",
+      "Kongo-Central",
+      "Kasa\u00ef",
+      "Kasa\u00ef Central",
+      "Kasa\u00ef Oriental",
+      "Lomami",
+      "Lualaba",
+      "Kwango",
+      "Kwilu",
+      "Mai-Ndombe",
+      "Maniema",
+      "Mongala",
+      "R\u00e9publique d\u00e9mocratique du Congo",
+      "Nord-Ubangi",
+      "Sankuru",
+      "Sud-Ubangi",
+      "Tanganyika",
+      "Tshopo",
+      "Tshuapa",
       "\u00c9quateur"
-     ], 
+     ],
      "old": [
       "Congo-Kinshasa"
      ]
-    }, 
+    },
     {
-     "id": "Congo-Kinshasa_Kivu", 
-     "s": 21378629, 
+     "id": "Congo-Kinshasa_Kivu",
+     "s": 21378629,
      "affiliations": [
-      "R\u00e9publique d\u00e9mocratique du Congo", 
-      "Nord-Kivu", 
+      "R\u00e9publique d\u00e9mocratique du Congo",
+      "Nord-Kivu",
       "Sud-Kivu"
-     ], 
+     ],
      "old": [
       "Congo-Kinshasa"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Cook Islands", 
-   "s": 528970, 
+   "id": "Cook Islands",
+   "s": 528970,
    "affiliations": [
     "Cook Islands"
-   ], 
+   ],
    "old": [
     "Cook Islands"
    ]
-  }, 
+  },
   {
-   "id": "Costa Rica", 
-   "s": 13417265, 
+   "id": "Costa Rica",
+   "s": 13417265,
    "affiliations": [
-    "Alajuela", 
-    "Cartago", 
-    "Costa Rica", 
-    "Guanacaste", 
-    "Heredia", 
-    "Lim\u00f3n", 
-    "Puntarenas", 
+    "Alajuela",
+    "Cartago",
+    "Costa Rica",
+    "Guanacaste",
+    "Heredia",
+    "Lim\u00f3n",
+    "Puntarenas",
     "San Jos\u00e9"
-   ], 
+   ],
    "old": [
-    "Cocos Island", 
-    "Costa Rica", 
+    "Cocos Island",
+    "Costa Rica",
     "Clipperton Island"
    ]
-  }, 
+  },
   {
-   "id": "Croatia", 
+   "id": "Croatia",
    "g": [
     {
-     "id": "Croatia_Central", 
-     "s": 32932100, 
+     "id": "Croatia_Central",
+     "s": 32932100,
      "affiliations": [
       "Hrvatska"
-     ], 
+     ],
      "old": [
       "Croatia"
      ]
-    }, 
+    },
     {
-     "id": "Croatia_West", 
-     "s": 52625970, 
+     "id": "Croatia_West",
+     "s": 52625970,
      "affiliations": [
-      "Hrvatska", 
+      "Hrvatska",
       "Italia"
-     ], 
+     ],
      "old": [
       "Croatia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Cuba", 
-   "s": 24185752, 
+   "id": "Cuba",
+   "s": 24185752,
    "affiliations": [
-    "Artemisa", 
-    "Ciego de \u00c1vila", 
-    "Cienfuegos", 
-    "Camag\u00fcey", 
-    "Matanzas", 
-    "Cuba", 
-    "Granma", 
-    "Guant\u00e1namo", 
-    "Holgu\u00edn", 
-    "Las Tunas", 
-    "Mayabeque", 
-    "Pinar del R\u00edo", 
-    "Sancti Spiritus", 
-    "Santiago de Cuba", 
+    "Artemisa",
+    "Ciego de \u00c1vila",
+    "Cienfuegos",
+    "Camag\u00fcey",
+    "Matanzas",
+    "Cuba",
+    "Granma",
+    "Guant\u00e1namo",
+    "Holgu\u00edn",
+    "Las Tunas",
+    "Mayabeque",
+    "Pinar del R\u00edo",
+    "Sancti Spiritus",
+    "Santiago de Cuba",
     "Villa Clara"
-   ], 
+   ],
    "old": [
     "Cuba"
    ]
-  }, 
+  },
   {
-   "id": "Cyprus", 
-   "s": 9487557, 
+   "id": "Cyprus",
+   "s": 9487557,
    "affiliations": [
-    "British Sovereign Base Areas", 
+    "British Sovereign Base Areas",
     "\u039a\u03cd\u03c0\u03c1\u03bf\u03c2 - K\u0131br\u0131s"
-   ], 
+   ],
    "old": [
     "Cyprus"
    ]
-  }, 
+  },
   {
-   "id": "Czech Republic", 
+   "id": "Czech Republic",
    "g": [
     {
-     "id": "Czech_Praha", 
-     "s": 23060073, 
+     "id": "Czech_Praha",
+     "s": 23060073,
      "affiliations": [
-      "Praha", 
+      "Praha",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Severovychod_Pardubicky kraj", 
-     "s": 30235145, 
+     "id": "Czech_Severovychod_Pardubicky kraj",
+     "s": 30235145,
      "affiliations": [
-      "Severov\u00fdchod", 
+      "Severov\u00fdchod",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Karlovasky kraj", 
-     "s": 15713818, 
+     "id": "Czech_Karlovasky kraj",
+     "s": 15713818,
      "affiliations": [
-      "Severoz\u00e1pad", 
+      "Severoz\u00e1pad",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Ustecky kraj", 
-     "s": 37565317, 
+     "id": "Czech_Ustecky kraj",
+     "s": 37565317,
      "affiliations": [
-      "Severoz\u00e1pad", 
+      "Severoz\u00e1pad",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Jihozapad_Plzensky kraj", 
-     "s": 39472761, 
+     "id": "Czech_Jihozapad_Plzensky kraj",
+     "s": 39472761,
      "affiliations": [
-      "Jihoz\u00e1pad", 
+      "Jihoz\u00e1pad",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Severovychod_Kralovehradecky kraj", 
-     "s": 33882607, 
+     "id": "Czech_Severovychod_Kralovehradecky kraj",
+     "s": 33882607,
      "affiliations": [
-      "Severov\u00fdchod", 
+      "Severov\u00fdchod",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Olomoucky kraj", 
-     "s": 32536319, 
+     "id": "Czech_Olomoucky kraj",
+     "s": 32536319,
      "affiliations": [
-      "St\u0159edn\u00ed Morava", 
+      "St\u0159edn\u00ed Morava",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Zlinsky Kraj", 
-     "s": 29713498, 
+     "id": "Czech_Zlinsky Kraj",
+     "s": 29713498,
      "affiliations": [
-      "St\u0159edn\u00ed Morava", 
+      "St\u0159edn\u00ed Morava",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Stredni Cechy_East", 
-     "s": 47297274, 
+     "id": "Czech_Stredni Cechy_East",
+     "s": 47297274,
      "affiliations": [
-      "St\u0159edn\u00ed \u010cechy", 
+      "St\u0159edn\u00ed \u010cechy",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Jihozapad_Jihocesky kraj", 
-     "s": 55721123, 
+     "id": "Czech_Jihozapad_Jihocesky kraj",
+     "s": 55721123,
      "affiliations": [
-      "Jihoz\u00e1pad", 
+      "Jihoz\u00e1pad",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Jihovychod_Kraj Vysocina", 
-     "s": 43446638, 
+     "id": "Czech_Jihovychod_Kraj Vysocina",
+     "s": 43446638,
      "affiliations": [
-      "Jihov\u00fdchod", 
+      "Jihov\u00fdchod",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Severovychod_Liberecky kraj", 
-     "s": 26419281, 
+     "id": "Czech_Severovychod_Liberecky kraj",
+     "s": 26419281,
      "affiliations": [
-      "Severov\u00fdchod", 
+      "Severov\u00fdchod",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Stredni Cechy_West", 
-     "s": 36990857, 
+     "id": "Czech_Stredni Cechy_West",
+     "s": 36990857,
      "affiliations": [
-      "St\u0159edn\u00ed \u010cechy", 
+      "St\u0159edn\u00ed \u010cechy",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Moravskoslezsko", 
-     "s": 45998492, 
+     "id": "Czech_Moravskoslezsko",
+     "s": 45998492,
      "affiliations": [
-      "Moravskoslezsko", 
+      "Moravskoslezsko",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
-    }, 
+    },
     {
-     "id": "Czech_Jihovychod_Jihomoravsky kraj", 
-     "s": 53225609, 
+     "id": "Czech_Jihovychod_Jihomoravsky kraj",
+     "s": 53225609,
      "affiliations": [
-      "Jihov\u00fdchod", 
+      "Jihov\u00fdchod",
       "\u010cesko"
-     ], 
+     ],
      "old": [
       "Czech Republic"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Cote dIvoire", 
-   "s": 15373355, 
+   "id": "Cote dIvoire",
+   "s": 15373355,
    "affiliations": [
-    "Abidjan", 
-    "Bas-Sassandra", 
-    "Como\u00e9", 
-    "C\u00f4te d\u2019Ivoire", 
-    "Dengu\u00e9l\u00e9", 
-    "Haut-Sassandra", 
-    "Zanzan", 
-    "G\u00f4h-Djiboua", 
-    "Lacs", 
-    "Lagunes", 
-    "Montagnes", 
-    "Savanes", 
-    "Vall\u00e9e du Bandama", 
-    "Woroba", 
+    "Abidjan",
+    "Bas-Sassandra",
+    "Como\u00e9",
+    "C\u00f4te d\u2019Ivoire",
+    "Dengu\u00e9l\u00e9",
+    "Haut-Sassandra",
+    "Zanzan",
+    "G\u00f4h-Djiboua",
+    "Lacs",
+    "Lagunes",
+    "Montagnes",
+    "Savanes",
+    "Vall\u00e9e du Bandama",
+    "Woroba",
     "Yamoussoukro"
-   ], 
+   ],
    "old": [
     "Ivory Coast"
    ]
-  }, 
+  },
   {
-   "id": "Denmark", 
+   "id": "Denmark",
    "g": [
     {
-     "id": "Denmark_North Denmark Region", 
-     "s": 32266500, 
+     "id": "Denmark_North Denmark Region",
+     "s": 32266500,
      "affiliations": [
-      "Danmark", 
+      "Danmark",
       "Region Nordjylland"
-     ], 
+     ],
      "old": [
       "Denmark"
      ]
-    }, 
+    },
     {
-     "id": "Denmark_Central Denmark Region", 
-     "s": 55622433, 
+     "id": "Denmark_Central Denmark Region",
+     "s": 55622433,
      "affiliations": [
-      "Danmark", 
+      "Danmark",
       "Region Midtjylland"
-     ], 
+     ],
      "old": [
       "Denmark"
      ]
-    }, 
+    },
     {
-     "id": "Denmark_Capital Region of Denmark", 
-     "s": 41804015, 
+     "id": "Denmark_Capital Region of Denmark",
+     "s": 41804015,
      "affiliations": [
-      "Danmark", 
-      "Region Hovedstaden", 
+      "Danmark",
+      "Region Hovedstaden",
       "Territorial waters of Bornholm"
-     ], 
+     ],
      "old": [
       "Denmark"
      ]
-    }, 
+    },
     {
-     "id": "Denmark_Region Zealand", 
-     "s": 36442800, 
+     "id": "Denmark_Region Zealand",
+     "s": 36442800,
      "affiliations": [
-      "Danmark", 
+      "Danmark",
       "Region Sj\u00e6lland"
-     ], 
+     ],
      "old": [
       "Denmark"
      ]
-    }, 
+    },
     {
-     "id": "Denmark_Region of Southern Denmark", 
-     "s": 63687171, 
+     "id": "Denmark_Region of Southern Denmark",
+     "s": 63687171,
      "affiliations": [
-      "Danmark", 
+      "Danmark",
       "Region Syddanmark"
-     ], 
+     ],
      "old": [
       "Denmark"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Djibouti", 
-   "s": 1017286, 
+   "id": "Djibouti",
+   "s": 1017286,
    "affiliations": [
-    "Ali Sabieh", 
-    "Arta", 
-    "Dikhil", 
-    "Djibouti", 
-    "Djibouti", 
-    "Obock", 
+    "Ali Sabieh",
+    "Arta",
+    "Dikhil",
+    "Djibouti",
+    "Djibouti",
+    "Obock",
     "Tadjourah"
-   ], 
+   ],
    "old": [
     "Djibouti"
    ]
-  }, 
+  },
   {
-   "id": "Dominican Republic", 
-   "s": 11640531, 
+   "id": "Dominican Republic",
+   "s": 11640531,
    "affiliations": [
-    "Azua", 
-    "Baoruco", 
-    "Barahona", 
-    "Duarte", 
-    "Dajab\u00f3n", 
-    "Distrito Nacional", 
-    "El Seibo", 
-    "El\u00edas Pi\u00f1a", 
-    "Espaillat", 
-    "Hato Mayor", 
-    "Hermanas Mirabal", 
-    "Independencia", 
-    "La Romana", 
-    "La Altagracia", 
-    "La Vega", 
-    "Mar\u00eda Trinidad S\u00e1nchez", 
-    "Monse\u00f1or Nouel", 
-    "Monte Cristi", 
-    "Monte Plata", 
-    "Peravia", 
-    "Pedernales", 
-    "Puerto Plata", 
-    "Rep\u00fablica Dominicana", 
-    "Saman\u00e1", 
-    "San Crist\u00f3bal", 
-    "San Jos\u00e9 de Ocoa", 
-    "San Juan", 
-    "San Pedro de Macor\u00eds", 
-    "Santiago", 
-    "Santiago Rodr\u00edguez", 
-    "Santo Domingo", 
-    "S\u00e1nchez Ram\u00edrez", 
+    "Azua",
+    "Baoruco",
+    "Barahona",
+    "Duarte",
+    "Dajab\u00f3n",
+    "Distrito Nacional",
+    "El Seibo",
+    "El\u00edas Pi\u00f1a",
+    "Espaillat",
+    "Hato Mayor",
+    "Hermanas Mirabal",
+    "Independencia",
+    "La Romana",
+    "La Altagracia",
+    "La Vega",
+    "Mar\u00eda Trinidad S\u00e1nchez",
+    "Monse\u00f1or Nouel",
+    "Monte Cristi",
+    "Monte Plata",
+    "Peravia",
+    "Pedernales",
+    "Puerto Plata",
+    "Rep\u00fablica Dominicana",
+    "Saman\u00e1",
+    "San Crist\u00f3bal",
+    "San Jos\u00e9 de Ocoa",
+    "San Juan",
+    "San Pedro de Macor\u00eds",
+    "Santiago",
+    "Santiago Rodr\u00edguez",
+    "Santo Domingo",
+    "S\u00e1nchez Ram\u00edrez",
     "Valverde"
-   ], 
+   ],
    "old": [
     "Dominican Republic"
    ]
-  }, 
+  },
   {
-   "id": "East Timor", 
-   "s": 3040449, 
+   "id": "East Timor",
+   "s": 3040449,
    "affiliations": [
-    "Aileu", 
-    "Ainaro", 
-    "Baucau", 
-    "Bobonaro", 
-    "Cova Lima", 
-    "Dili", 
-    "Ermera", 
-    "Indonesia", 
-    "Laut\u00e9m", 
-    "Liqui\u00e7\u00e1", 
-    "Manatuto", 
-    "Manufahi", 
-    "Nusa Tenggara Timur", 
-    "Oecusse", 
-    "Tim\u00f3r Loro Sa'e", 
+    "Aileu",
+    "Ainaro",
+    "Baucau",
+    "Bobonaro",
+    "Cova Lima",
+    "Dili",
+    "Ermera",
+    "Indonesia",
+    "Laut\u00e9m",
+    "Liqui\u00e7\u00e1",
+    "Manatuto",
+    "Manufahi",
+    "Nusa Tenggara Timur",
+    "Oecusse",
+    "Tim\u00f3r Loro Sa'e",
     "Viqueque"
-   ], 
+   ],
    "old": [
-    "Indonesia", 
+    "Indonesia",
     "East Timor"
    ]
-  }, 
+  },
   {
-   "id": "Chile", 
+   "id": "Chile",
    "g": [
     {
-     "id": "Campo de Hielo Sur", 
-     "s": 943609, 
+     "id": "Campo de Hielo Sur",
+     "s": 943609,
      "affiliations": [
       "Acuerdo de Campos de Hielo"
      ]
-    }, 
+    },
     {
-     "id": "Chile_Central", 
-     "s": 37055145, 
+     "id": "Chile_Central",
+     "s": 37055145,
      "affiliations": [
-      "Chile", 
-      "Islote Gaviota", 
-      "Islote Lobos", 
-      "Regi\u00f3n Metropolitana de Santiago", 
-      "Roca Fraile", 
-      "V Regi\u00f3n de Valpara\u00edso", 
-      "VI Regi\u00f3n del Libertador General Bernardo O'Higgins", 
+      "Chile",
+      "Islote Gaviota",
+      "Islote Lobos",
+      "Regi\u00f3n Metropolitana de Santiago",
+      "Roca Fraile",
+      "V Regi\u00f3n de Valpara\u00edso",
+      "VI Regi\u00f3n del Libertador General Bernardo O'Higgins",
       "VII Regi\u00f3n del Maule"
-     ], 
+     ],
      "old": [
       "Chile"
      ]
-    }, 
+    },
     {
-     "id": "Chile_North", 
-     "s": 12690979, 
+     "id": "Chile_North",
+     "s": 12690979,
      "affiliations": [
-      "Chile", 
-      "I Regi\u00f3n de Tarapac\u00e1", 
-      "II Regi\u00f3n de Antofagasta", 
-      "III Regi\u00f3n de Atacama", 
-      "IV Regi\u00f3n de Coquimbo", 
-      "V Regi\u00f3n de Valpara\u00edso", 
+      "Chile",
+      "I Regi\u00f3n de Tarapac\u00e1",
+      "II Regi\u00f3n de Antofagasta",
+      "III Regi\u00f3n de Atacama",
+      "IV Regi\u00f3n de Coquimbo",
+      "V Regi\u00f3n de Valpara\u00edso",
       "XV Regi\u00f3n de Arica y Parinacota"
-     ], 
+     ],
      "old": [
       "Chile"
      ]
-    }, 
+    },
     {
-     "id": "Chile_South", 
-     "s": 59042399, 
+     "id": "Chile_South",
+     "s": 59042399,
      "affiliations": [
-      "Chile", 
-      "IX Regi\u00f3n de la Araucan\u00eda", 
-      "VIII Regi\u00f3n del Biob\u00edo", 
-      "X Regi\u00f3n de Los Lagos", 
-      "XI Regi\u00f3n Ays\u00e9n del General Carlos Ib\u00e1\u00f1ez del Campo", 
-      "XII Regi\u00f3n de Magallanes y de la Ant\u00e1rtica Chilena", 
+      "Chile",
+      "IX Regi\u00f3n de la Araucan\u00eda",
+      "VIII Regi\u00f3n del Biob\u00edo",
+      "X Regi\u00f3n de Los Lagos",
+      "XI Regi\u00f3n Ays\u00e9n del General Carlos Ib\u00e1\u00f1ez del Campo",
+      "XII Regi\u00f3n de Magallanes y de la Ant\u00e1rtica Chilena",
       "XIV Regi\u00f3n de Los R\u00edos"
-     ], 
+     ],
      "old": [
       "Chile"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Ecuador", 
+   "id": "Ecuador",
    "g": [
     {
-     "id": "Ecuador_East", 
-     "s": 21256978, 
+     "id": "Ecuador_East",
+     "s": 21256978,
      "affiliations": [
-      "Azuay", 
-      "Carchi", 
-      "Ca\u00f1ar", 
-      "Chimborazo", 
-      "Cotopaxi", 
-      "Ecuador", 
-      "Imbabura", 
-      "Loja", 
-      "Morona Santiago", 
-      "Napo", 
-      "Orellana", 
-      "Pichincha", 
-      "Pastaza", 
-      "Sucumb\u00edos", 
-      "Tungurahua", 
+      "Azuay",
+      "Carchi",
+      "Ca\u00f1ar",
+      "Chimborazo",
+      "Cotopaxi",
+      "Ecuador",
+      "Imbabura",
+      "Loja",
+      "Morona Santiago",
+      "Napo",
+      "Orellana",
+      "Pichincha",
+      "Pastaza",
+      "Sucumb\u00edos",
+      "Tungurahua",
       "Zamora Chinchipe"
-     ], 
+     ],
      "old": [
       "Ecuador"
      ]
-    }, 
+    },
     {
-     "id": "Ecuador_West", 
-     "s": 27756761, 
+     "id": "Ecuador_West",
+     "s": 27756761,
      "affiliations": [
-      "Bol\u00edvar", 
-      "Azuay", 
-      "Ca\u00f1ar", 
-      "Chimborazo", 
-      "Cotopaxi", 
-      "Ecuador", 
-      "El Oro", 
-      "Esmeraldas", 
-      "Gal\u00e1pagos", 
-      "Guayas", 
-      "Imbabura", 
-      "Loja", 
-      "Los R\u00edos", 
-      "Manab\u00ed", 
-      "Pichincha", 
-      "Santa Elena", 
+      "Bol\u00edvar",
+      "Azuay",
+      "Ca\u00f1ar",
+      "Chimborazo",
+      "Cotopaxi",
+      "Ecuador",
+      "El Oro",
+      "Esmeraldas",
+      "Gal\u00e1pagos",
+      "Guayas",
+      "Imbabura",
+      "Loja",
+      "Los R\u00edos",
+      "Manab\u00ed",
+      "Pichincha",
+      "Santa Elena",
       "Santo Domingo de los Ts\u00e1chilas"
-     ], 
+     ],
      "old": [
-      "Galapagos Islands", 
+      "Galapagos Islands",
       "Ecuador"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Egypt", 
-   "s": 42314744, 
+   "id": "Egypt",
+   "s": 42314744,
    "affiliations": [
-    "\u062f\u0645\u064a\u0627\u0637\u200e\u200e", 
-    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0646\u0649 \u0633\u0648\u064a\u0641", 
-    "\u0627\u0644\u0625\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629", 
-    "\u0645\u0635\u0631", 
-    "\u0643\u0641\u0631 \u0627\u0644\u0634\u064a\u062e", 
-    "\u062c\u0646\u0648\u0628 \u0633\u064a\u0646\u0627\u0621", 
-    "\u0634\u0645\u0627\u0644 \u0633\u064a\u0646\u0627\u0621", 
-    "\u0623\u0633\u064a\u0648\u0637", 
-    "\u0645\u0637\u0631\u0648\u062d", 
-    "\u0627\u0644\u0628\u062d\u0631 \u0627\u0644\u0623\u062d\u0645\u0645\u0631", 
-    "\u0633\u0648\u0647\u0627\u062c\u200e", 
-    "\u0627\u0644\u0623\u0642\u0635\u0631 / Luxor", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0642\u0646\u0627", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0623\u0633\u0648\u0627\u0646", 
-    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0648\u0631\u0633\u0639\u064a\u062f", 
-    "\u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u062c\u062f\u064a\u062f", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0641\u064a\u0648\u0645", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u064a\u0632\u0629\u200e", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u0646\u0648\u0641\u064a\u0629", 
-    "\u0627\u0644\u0642\u0627\u0647\u0631\u0629", 
-    "\u0627\u0644\u063a\u0631\u0628\u064a\u0629", 
-    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u063a\u0631\u0628\u064a", 
-    "\u0627\u0644\u062f\u0642\u0647\u0644\u064a\u0629", 
-    "\u0627\u0644\u0634\u0631\u0642\u064a\u0629\u200e\u200e", 
-    "\u0627\u0644\u0642\u0644\u064a\u0648\u0628\u064a\u0629", 
-    "\u200f\u0627\u0644\u0628\u062d\u064a\u0631\u0629\u200e", 
+    "\u062f\u0645\u064a\u0627\u0637\u200e\u200e",
+    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0646\u0649 \u0633\u0648\u064a\u0641",
+    "\u0627\u0644\u0625\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629",
+    "\u0645\u0635\u0631",
+    "\u0643\u0641\u0631 \u0627\u0644\u0634\u064a\u062e",
+    "\u062c\u0646\u0648\u0628 \u0633\u064a\u0646\u0627\u0621",
+    "\u0634\u0645\u0627\u0644 \u0633\u064a\u0646\u0627\u0621",
+    "\u0623\u0633\u064a\u0648\u0637",
+    "\u0645\u0637\u0631\u0648\u062d",
+    "\u0627\u0644\u0628\u062d\u0631 \u0627\u0644\u0623\u062d\u0645\u0645\u0631",
+    "\u0633\u0648\u0647\u0627\u062c\u200e",
+    "\u0627\u0644\u0623\u0642\u0635\u0631 / Luxor",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0642\u0646\u0627",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0623\u0633\u0648\u0627\u0646",
+    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0648\u0631\u0633\u0639\u064a\u062f",
+    "\u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u062c\u062f\u064a\u062f",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0641\u064a\u0648\u0645",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u064a\u0632\u0629\u200e",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u0646\u0648\u0641\u064a\u0629",
+    "\u0627\u0644\u0642\u0627\u0647\u0631\u0629",
+    "\u0627\u0644\u063a\u0631\u0628\u064a\u0629",
+    "\u200f\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u063a\u0631\u0628\u064a",
+    "\u0627\u0644\u062f\u0642\u0647\u0644\u064a\u0629",
+    "\u0627\u0644\u0634\u0631\u0642\u064a\u0629\u200e\u200e",
+    "\u0627\u0644\u0642\u0644\u064a\u0648\u0628\u064a\u0629",
+    "\u200f\u0627\u0644\u0628\u062d\u064a\u0631\u0629\u200e",
     "\u0627\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629"
-   ], 
+   ],
    "old": [
     "Egypt"
    ]
-  }, 
+  },
   {
-   "id": "El Salvador", 
-   "s": 8342512, 
+   "id": "El Salvador",
+   "s": 8342512,
    "affiliations": [
-    "Departamento de Cuscatl\u00e1n", 
-    "Departamento de La Libertad", 
-    "Departamento de Ahuachap\u00e1n", 
-    "Departamento de Caba\u00f1as", 
-    "Departamento de La Paz", 
-    "Departamento de La Uni\u00f3n", 
-    "Departamento de Moraz\u00e1n", 
-    "Departamento de San Miguel", 
-    "Departamento de San Salvador", 
-    "Departamento de San Vicente", 
-    "Departamento de Santa Ana", 
-    "Departamento de Sonsonate", 
-    "Departamento de Usulut\u00e1n", 
-    "Departemento de Chalatenango", 
+    "Departamento de Cuscatl\u00e1n",
+    "Departamento de La Libertad",
+    "Departamento de Ahuachap\u00e1n",
+    "Departamento de Caba\u00f1as",
+    "Departamento de La Paz",
+    "Departamento de La Uni\u00f3n",
+    "Departamento de Moraz\u00e1n",
+    "Departamento de San Miguel",
+    "Departamento de San Salvador",
+    "Departamento de San Vicente",
+    "Departamento de Santa Ana",
+    "Departamento de Sonsonate",
+    "Departamento de Usulut\u00e1n",
+    "Departemento de Chalatenango",
     "El Salvador"
-   ], 
+   ],
    "old": [
     "El Salvador"
    ]
-  }, 
+  },
   {
-   "id": "Equatorial Guinea", 
-   "s": 1186861, 
+   "id": "Equatorial Guinea",
+   "s": 1186861,
    "affiliations": [
-    "Centro Sur", 
-    "Annob\u00f3n", 
-    "Bioko Norte", 
-    "Bioko Sur", 
-    "Guinea Ecuatorial", 
-    "Ki\u00e9-Ntem", 
-    "Litoral", 
+    "Centro Sur",
+    "Annob\u00f3n",
+    "Bioko Norte",
+    "Bioko Sur",
+    "Guinea Ecuatorial",
+    "Ki\u00e9-Ntem",
+    "Litoral",
     "Wele-Nzas"
-   ], 
+   ],
    "old": [
     "Equatorial Guinea"
    ]
-  }, 
+  },
   {
-   "id": "Eritrea", 
-   "s": 2438815, 
+   "id": "Eritrea",
+   "s": 2438815,
    "affiliations": [
-    "Debub", 
-    "Debubawi Kayih Bahri", 
-    "Eritrea", 
-    "Maekel", 
-    "Semienawi Kayih Bahri", 
-    "\u12de\u1263 \u12d3\u1295\u1230\u1263", 
+    "Debub",
+    "Debubawi Kayih Bahri",
+    "Eritrea",
+    "Maekel",
+    "Semienawi Kayih Bahri",
+    "\u12de\u1263 \u12d3\u1295\u1230\u1263",
     "\u130b\u123d-\u1263\u122d\u12ab"
-   ], 
+   ],
    "old": [
     "Eritrea"
    ]
-  }, 
+  },
   {
-   "id": "Estonia", 
+   "id": "Estonia",
    "g": [
     {
-     "id": "Estonia_West", 
-     "s": 30472042, 
+     "id": "Estonia_West",
+     "s": 30472042,
      "affiliations": [
       "Eesti"
-     ], 
+     ],
      "old": [
       "Estonia"
      ]
-    }, 
+    },
     {
-     "id": "Estonia_East", 
-     "s": 35256650, 
+     "id": "Estonia_East",
+     "s": 35256650,
      "affiliations": [
       "Eesti"
-     ], 
+     ],
      "old": [
       "Estonia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Ethiopia", 
-   "s": 25370923, 
+   "id": "Ethiopia",
+   "s": 25370923,
    "affiliations": [
-    "Addis Abeba", 
-    "Afar", 
-    "Amhara", 
-    "Dir\u0113 Dawa", 
-    "B\u012bnshangul-Gumuz Kilil", 
-    "Harari", 
-    "Gambela", 
-    "Oromia", 
-    "Oromia - Benishangul-Gumuz", 
-    "Oromia - Harari", 
-    "Southern Nations", 
-    "Somali", 
-    "Tigray", 
+    "Addis Abeba",
+    "Afar",
+    "Amhara",
+    "Dir\u0113 Dawa",
+    "B\u012bnshangul-Gumuz Kilil",
+    "Harari",
+    "Gambela",
+    "Oromia",
+    "Oromia - Benishangul-Gumuz",
+    "Oromia - Harari",
+    "Southern Nations",
+    "Somali",
+    "Tigray",
     "\u12a2\u1275\u12ee\u1335\u12eb Ethiopia"
-   ], 
+   ],
    "old": [
     "Ethiopia"
    ]
-  }, 
+  },
   {
-   "id": "Faroe Islands", 
-   "s": 1900625, 
+   "id": "Faroe Islands",
+   "s": 1900625,
    "affiliations": [
-    "Eysturoyar s\u00fdsla", 
-    "F\u00f8royar", 
-    "Nor\u00f0oyar s\u00fdsla", 
-    "Sandoyar s\u00fdsla", 
-    "Streymoyar s\u00fdsla", 
-    "Su\u00f0uroyar s\u00fdsla", 
-    "Territorial waters of Faroe Islands", 
+    "Eysturoyar s\u00fdsla",
+    "F\u00f8royar",
+    "Nor\u00f0oyar s\u00fdsla",
+    "Sandoyar s\u00fdsla",
+    "Streymoyar s\u00fdsla",
+    "Su\u00f0uroyar s\u00fdsla",
+    "Territorial waters of Faroe Islands",
     "V\u00e1ga s\u00fdsla"
-   ], 
+   ],
    "old": [
     "Faroe Islands"
    ]
-  }, 
+  },
   {
-   "id": "Federated States of Micronesia", 
-   "s": 1117686, 
+   "id": "Federated States of Micronesia",
+   "s": 1117686,
    "affiliations": [
-    "Chuuk", 
-    "Federated States of Micronesia", 
-    "FM", 
-    "Kosrae", 
-    "Pohnpei", 
+    "Chuuk",
+    "Federated States of Micronesia",
+    "FM",
+    "Kosrae",
+    "Pohnpei",
     "Yap"
-   ], 
+   ],
    "old": [
     "Micronesia"
    ]
-  }, 
+  },
   {
-   "id": "Fiji", 
-   "s": 5792471, 
+   "id": "Fiji",
+   "s": 5792471,
    "affiliations": [
-    "Central", 
-    "Eastern", 
-    "Northern", 
+    "Central",
+    "Eastern",
+    "Northern",
     "Viti"
-   ], 
+   ],
    "old": [
     "Fiji"
    ]
-  }, 
+  },
   {
-   "id": "Finland", 
+   "id": "Finland",
    "g": [
     {
-     "id": "Finland_Western Finland_Jyvaskyla", 
-     "s": 20456601, 
+     "id": "Finland_Western Finland_Jyvaskyla",
+     "s": 20456601,
      "affiliations": [
-      "L\u00e4nsi-Suomi", 
+      "L\u00e4nsi-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Western Finland_Tampere", 
-     "s": 38257561, 
+     "id": "Finland_Western Finland_Tampere",
+     "s": 38257561,
      "affiliations": [
-      "L\u00e4nsi-Suomi", 
+      "L\u00e4nsi-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Northern Finland", 
-     "s": 40482661, 
+     "id": "Finland_Northern Finland",
+     "s": 40482661,
      "affiliations": [
-      "Pohjois-Suomi", 
+      "Pohjois-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Eastern Finland_North", 
-     "s": 24347574, 
+     "id": "Finland_Eastern Finland_North",
+     "s": 24347574,
      "affiliations": [
-      "It\u00e4-Suomi", 
+      "It\u00e4-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Eastern Finland_South", 
-     "s": 30677340, 
+     "id": "Finland_Eastern Finland_South",
+     "s": 30677340,
      "affiliations": [
-      "It\u00e4-Suomi", 
+      "It\u00e4-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Southern Finland_West", 
-     "s": 23039751, 
+     "id": "Finland_Southern Finland_West",
+     "s": 23039751,
      "affiliations": [
-      "Etel\u00e4-Suomi", 
-      "Suomi", 
+      "Etel\u00e4-Suomi",
+      "Suomi",
       "\u00c5land"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Southern Finland_Helsinki", 
-     "s": 54488458, 
+     "id": "Finland_Southern Finland_Helsinki",
+     "s": 54488458,
      "affiliations": [
-      "Etel\u00e4-Suomi", 
+      "Etel\u00e4-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
-    }, 
+    },
     {
-     "id": "Finland_Southern Finland_Lappeenranta", 
-     "s": 37213499, 
+     "id": "Finland_Southern Finland_Lappeenranta",
+     "s": 37213499,
      "affiliations": [
-      "Etel\u00e4-Suomi", 
+      "Etel\u00e4-Suomi",
       "Suomi"
-     ], 
+     ],
      "old": [
       "Finland"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "France", 
+   "id": "France",
    "g": [
     {
-     "id": "France_Alsace", 
+     "id": "France_Alsace",
      "g": [
       {
-       "id": "France_Alsace_Bas-Rhin", 
-       "s": 40867880, 
+       "id": "France_Alsace_Bas-Rhin",
+       "s": 40867880,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Alsace"
        ]
-      }, 
+      },
       {
-       "id": "France_Alsace_Haut-Rhin", 
-       "s": 30589677, 
+       "id": "France_Alsace_Haut-Rhin",
+       "s": 30589677,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Alsace"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Aquitaine", 
+     "id": "France_Aquitaine",
      "g": [
       {
-       "id": "France_Aquitaine_Dordogne", 
-       "s": 26520302, 
+       "id": "France_Aquitaine_Dordogne",
+       "s": 26520302,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Aquitaine"
        ]
-      }, 
+      },
       {
-       "id": "France_Aquitaine_Gironde", 
-       "s": 51564770, 
+       "id": "France_Aquitaine_Gironde",
+       "s": 51564770,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Aquitaine"
        ]
-      }, 
+      },
       {
-       "id": "France_Aquitaine_Landes", 
-       "s": 23634304, 
+       "id": "France_Aquitaine_Landes",
+       "s": 23634304,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Aquitaine"
        ]
-      }, 
+      },
       {
-       "id": "France_Aquitaine_Lot-et-Garonne", 
-       "s": 19523587, 
+       "id": "France_Aquitaine_Lot-et-Garonne",
+       "s": 19523587,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Aquitaine"
        ]
-      }, 
+      },
       {
-       "id": "France_Aquitaine_Pyrenees-Atlantiques", 
-       "s": 31841244, 
+       "id": "France_Aquitaine_Pyrenees-Atlantiques",
+       "s": 31841244,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Aquitaine"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Auvergne", 
+     "id": "France_Auvergne",
      "g": [
       {
-       "id": "France_Auvergne_Allier", 
-       "s": 21612514, 
+       "id": "France_Auvergne_Allier",
+       "s": 21612514,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Auvergne"
        ]
-      }, 
+      },
       {
-       "id": "France_Auvergne_Cantal", 
-       "s": 12427384, 
+       "id": "France_Auvergne_Cantal",
+       "s": 12427384,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Auvergne"
        ]
-      }, 
+      },
       {
-       "id": "France_Auvergne_Haute-Loire", 
-       "s": 15901276, 
+       "id": "France_Auvergne_Haute-Loire",
+       "s": 15901276,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Auvergne"
        ]
-      }, 
+      },
       {
-       "id": "France_Auvergne_Puy-de-Dome", 
-       "s": 33097291, 
+       "id": "France_Auvergne_Puy-de-Dome",
+       "s": 33097291,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Auvergne"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Brittany", 
+     "id": "France_Brittany",
      "g": [
       {
-       "id": "France_Brittany_Cotes-dArmor", 
-       "s": 34696738, 
+       "id": "France_Brittany_Cotes-dArmor",
+       "s": 34696738,
        "affiliations": [
-        "Bretagne", 
-        "France", 
-        "Guernsey", 
+        "Bretagne",
+        "France",
+        "Guernsey",
         "Jersey"
-       ], 
+       ],
        "old": [
         "France_Bretagne"
        ]
-      }, 
+      },
       {
-       "id": "France_Brittany_Finistere", 
-       "s": 49706179, 
+       "id": "France_Brittany_Finistere",
+       "s": 49706179,
        "affiliations": [
-        "Bretagne", 
+        "Bretagne",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bretagne"
        ]
-      }, 
+      },
       {
-       "id": "France_Brittany_Ille-et-Vilaine", 
-       "s": 43744578, 
+       "id": "France_Brittany_Ille-et-Vilaine",
+       "s": 43744578,
        "affiliations": [
-        "Bretagne", 
-        "France", 
+        "Bretagne",
+        "France",
         "Jersey"
-       ], 
+       ],
        "old": [
         "France_Bretagne"
        ]
-      }, 
+      },
       {
-       "id": "France_Brittany_Morbihan", 
-       "s": 35985172, 
+       "id": "France_Brittany_Morbihan",
+       "s": 35985172,
        "affiliations": [
-        "Bretagne", 
+        "Bretagne",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bretagne"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Burgundy", 
+     "id": "France_Burgundy",
      "g": [
       {
-       "id": "France_Burgundy_Cote-dOr", 
-       "s": 24337334, 
+       "id": "France_Burgundy_Cote-dOr",
+       "s": 24337334,
        "affiliations": [
-        "Bourgogne-Franche-Comt\u00e9", 
+        "Bourgogne-Franche-Comt\u00e9",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bourgogne"
        ]
-      }, 
+      },
       {
-       "id": "France_Burgundy_Nievre", 
-       "s": 14155875, 
+       "id": "France_Burgundy_Nievre",
+       "s": 14155875,
        "affiliations": [
-        "Bourgogne-Franche-Comt\u00e9", 
+        "Bourgogne-Franche-Comt\u00e9",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bourgogne"
        ]
-      }, 
+      },
       {
-       "id": "France_Burgundy_Saone-et-Loire", 
-       "s": 40516787, 
+       "id": "France_Burgundy_Saone-et-Loire",
+       "s": 40516787,
        "affiliations": [
-        "Bourgogne-Franche-Comt\u00e9", 
+        "Bourgogne-Franche-Comt\u00e9",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bourgogne"
        ]
-      }, 
+      },
       {
-       "id": "France_Burgundy_Yonne", 
-       "s": 21760478, 
+       "id": "France_Burgundy_Yonne",
+       "s": 21760478,
        "affiliations": [
-        "Bourgogne-Franche-Comt\u00e9", 
+        "Bourgogne-Franche-Comt\u00e9",
         "France"
-       ], 
+       ],
        "old": [
         "France_Bourgogne"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Centre-Val de Loire", 
+     "id": "France_Centre-Val de Loire",
      "g": [
       {
-       "id": "France_Centre-Val de Loire_Cher", 
-       "s": 16386284, 
+       "id": "France_Centre-Val de Loire_Cher",
+       "s": 16386284,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
-      }, 
+      },
       {
-       "id": "France_Centre-Val de Loire_Eure-et-Loir", 
-       "s": 16512400, 
+       "id": "France_Centre-Val de Loire_Eure-et-Loir",
+       "s": 16512400,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
-      }, 
+      },
       {
-       "id": "France_Centre-Val de Loire_Indre", 
-       "s": 18944502, 
+       "id": "France_Centre-Val de Loire_Indre",
+       "s": 18944502,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
-      }, 
+      },
       {
-       "id": "France_Centre-Val de Loire_Indre-et-Loire", 
-       "s": 27236261, 
+       "id": "France_Centre-Val de Loire_Indre-et-Loire",
+       "s": 27236261,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
-      }, 
+      },
       {
-       "id": "France_Centre-Val de Loire_Loir-et-Cher", 
-       "s": 17199353, 
+       "id": "France_Centre-Val de Loire_Loir-et-Cher",
+       "s": 17199353,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
-      }, 
+      },
       {
-       "id": "France_Centre-Val de Loire_Loiret", 
-       "s": 25326224, 
+       "id": "France_Centre-Val de Loire_Loiret",
+       "s": 25326224,
        "affiliations": [
-        "Centre-Val de Loire", 
+        "Centre-Val de Loire",
         "France"
-       ], 
+       ],
        "old": [
         "France_Centre"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Champagne-Ardenne", 
-     "s": 48333842, 
+     "id": "France_Champagne-Ardenne",
+     "s": 48333842,
      "affiliations": [
-      "Alsace-Champagne-Ardenne-Lorraine", 
+      "Alsace-Champagne-Ardenne-Lorraine",
       "France"
-     ], 
+     ],
      "old": [
       "France_Champagne-Ardenne"
      ]
-    }, 
+    },
     {
-     "id": "France_Corsica", 
-     "s": 11060379, 
+     "id": "France_Corsica",
+     "s": 11060379,
      "affiliations": [
-      "Corse - Mer M\u00e9diterran\u00e9e", 
-      "Corse", 
-      "France", 
-      "Italia", 
+      "Corse - Mer M\u00e9diterran\u00e9e",
+      "Corse",
+      "France",
+      "Italia",
       "Monaco"
-     ], 
+     ],
      "old": [
       "France_Corsica"
      ]
-    }, 
+    },
     {
-     "id": "France_Free County_North", 
-     "s": 32585841, 
+     "id": "France_Free County_North",
+     "s": 32585841,
      "affiliations": [
-      "Bourgogne-Franche-Comt\u00e9", 
+      "Bourgogne-Franche-Comt\u00e9",
       "France"
-     ], 
+     ],
      "old": [
       "France_Franche-Comte"
      ]
-    }, 
+    },
     {
-     "id": "France_Free County_South", 
-     "s": 23493385, 
+     "id": "France_Free County_South",
+     "s": 23493385,
      "affiliations": [
-      "Bourgogne-Franche-Comt\u00e9", 
+      "Bourgogne-Franche-Comt\u00e9",
       "France"
-     ], 
+     ],
      "old": [
       "France_Franche-Comte"
      ]
-    }, 
+    },
     {
-     "id": "France_French Guiana", 
-     "s": 6569137, 
+     "id": "France_French Guiana",
+     "s": 6569137,
      "affiliations": [
-      "France", 
+      "France",
       "Guyane"
-     ], 
+     ],
      "old": [
       "French Guiana"
      ]
-    }, 
+    },
     {
-     "id": "France_Ile-de-France", 
+     "id": "France_Ile-de-France",
      "g": [
       {
-       "id": "France_Ile-de-France_Essonne", 
-       "s": 25553199, 
+       "id": "France_Ile-de-France_Essonne",
+       "s": 25553199,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Hauts-de-Seine", 
-       "s": 12257868, 
+       "id": "France_Ile-de-France_Hauts-de-Seine",
+       "s": 12257868,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Paris", 
-       "s": 15313369, 
+       "id": "France_Ile-de-France_Paris",
+       "s": 15313369,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Seine-Saint-Denis", 
-       "s": 13903999, 
+       "id": "France_Ile-de-France_Seine-Saint-Denis",
+       "s": 13903999,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Seine-et-Marne", 
-       "s": 34012810, 
+       "id": "France_Ile-de-France_Seine-et-Marne",
+       "s": 34012810,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Val-dOise", 
-       "s": 18300939, 
+       "id": "France_Ile-de-France_Val-dOise",
+       "s": 18300939,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Val-de-Marne", 
-       "s": 13362240, 
+       "id": "France_Ile-de-France_Val-de-Marne",
+       "s": 13362240,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
-      }, 
+      },
       {
-       "id": "France_Ile-de-France_Yvelines", 
-       "s": 24709358, 
+       "id": "France_Ile-de-France_Yvelines",
+       "s": 24709358,
        "affiliations": [
-        "France", 
+        "France",
         "\u00cele-de-France"
-       ], 
+       ],
        "old": [
         "France_Paris & Ile-de-France"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Languedoc-Roussillon", 
+     "id": "France_Languedoc-Roussillon",
      "g": [
       {
-       "id": "France_Languedoc-Roussillon_Aude", 
-       "s": 24536144, 
+       "id": "France_Languedoc-Roussillon_Aude",
+       "s": 24536144,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Languedoc-Roussillon"
        ]
-      }, 
+      },
       {
-       "id": "France_Languedoc-Roussillon_Gard", 
-       "s": 27523817, 
+       "id": "France_Languedoc-Roussillon_Gard",
+       "s": 27523817,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Languedoc-Roussillon"
        ]
-      }, 
+      },
       {
-       "id": "France_Languedoc-Roussillon_Herault", 
-       "s": 41663983, 
+       "id": "France_Languedoc-Roussillon_Herault",
+       "s": 41663983,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Languedoc-Roussillon"
        ]
-      }, 
+      },
       {
-       "id": "France_Languedoc-Roussillon_Lozere", 
-       "s": 10563033, 
+       "id": "France_Languedoc-Roussillon_Lozere",
+       "s": 10563033,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Languedoc-Roussillon"
        ]
-      }, 
+      },
       {
-       "id": "France_Languedoc-Roussillon_Pyrenees-Orientales", 
-       "s": 22415202, 
+       "id": "France_Languedoc-Roussillon_Pyrenees-Orientales",
+       "s": 22415202,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Languedoc-Roussillon"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Limousin", 
-     "s": 46443718, 
+     "id": "France_Limousin",
+     "s": 46443718,
      "affiliations": [
-      "Aquitaine-Limousin-Poitou-Charentes", 
+      "Aquitaine-Limousin-Poitou-Charentes",
       "France"
-     ], 
+     ],
      "old": [
       "France_Limousin"
      ]
-    }, 
+    },
     {
-     "id": "France_Lorraine", 
+     "id": "France_Lorraine",
      "g": [
       {
-       "id": "France_Lorraine_Meurthe-et-Moselle", 
-       "s": 23526732, 
+       "id": "France_Lorraine_Meurthe-et-Moselle",
+       "s": 23526732,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Lorraine"
        ]
-      }, 
+      },
       {
-       "id": "France_Lorraine_Meuse", 
-       "s": 10851400, 
+       "id": "France_Lorraine_Meuse",
+       "s": 10851400,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Lorraine"
        ]
-      }, 
+      },
       {
-       "id": "France_Lorraine_Moselle", 
-       "s": 34422544, 
+       "id": "France_Lorraine_Moselle",
+       "s": 34422544,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Lorraine"
        ]
-      }, 
+      },
       {
-       "id": "France_Lorraine_Vosges", 
-       "s": 22896505, 
+       "id": "France_Lorraine_Vosges",
+       "s": 22896505,
        "affiliations": [
-        "Alsace-Champagne-Ardenne-Lorraine", 
+        "Alsace-Champagne-Ardenne-Lorraine",
         "France"
-       ], 
+       ],
        "old": [
         "France_Lorraine"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Lower Normandy", 
+     "id": "France_Lower Normandy",
      "g": [
       {
-       "id": "France_Lower Normandy_Calvados", 
-       "s": 25330124, 
+       "id": "France_Lower Normandy_Calvados",
+       "s": 25330124,
        "affiliations": [
-        "France", 
+        "France",
         "Normandie"
-       ], 
+       ],
        "old": [
         "France_Basse-Normandie"
        ]
-      }, 
+      },
       {
-       "id": "France_Lower Normandy_Manche", 
-       "s": 25328752, 
+       "id": "France_Lower Normandy_Manche",
+       "s": 25328752,
        "affiliations": [
-        "France", 
-        "Jersey", 
+        "France",
+        "Jersey",
         "Normandie"
-       ], 
+       ],
        "old": [
         "France_Basse-Normandie"
        ]
-      }, 
+      },
       {
-       "id": "France_Lower Normandy_Orne", 
-       "s": 18561703, 
+       "id": "France_Lower Normandy_Orne",
+       "s": 18561703,
        "affiliations": [
-        "France", 
+        "France",
         "Normandie"
-       ], 
+       ],
        "old": [
         "France_Basse-Normandie"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Midi-Pyrenees", 
+     "id": "France_Midi-Pyrenees",
      "g": [
       {
-       "id": "France_Midi-Pyrenees_Ariege", 
-       "s": 11464500, 
+       "id": "France_Midi-Pyrenees_Ariege",
+       "s": 11464500,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Aveyron", 
-       "s": 28142932, 
+       "id": "France_Midi-Pyrenees_Aveyron",
+       "s": 28142932,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Gers", 
-       "s": 17600386, 
+       "id": "France_Midi-Pyrenees_Gers",
+       "s": 17600386,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Haute-Garonne", 
-       "s": 43672595, 
+       "id": "France_Midi-Pyrenees_Haute-Garonne",
+       "s": 43672595,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Hautes-Pyrenees", 
-       "s": 29752102, 
+       "id": "France_Midi-Pyrenees_Hautes-Pyrenees",
+       "s": 29752102,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Lot", 
-       "s": 14089974, 
+       "id": "France_Midi-Pyrenees_Lot",
+       "s": 14089974,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Tarn", 
-       "s": 21161687, 
+       "id": "France_Midi-Pyrenees_Tarn",
+       "s": 21161687,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
-      }, 
+      },
       {
-       "id": "France_Midi-Pyrenees_Tarn-et-Garonne", 
-       "s": 13348726, 
+       "id": "France_Midi-Pyrenees_Tarn-et-Garonne",
+       "s": 13348726,
        "affiliations": [
-        "France", 
+        "France",
         "Languedoc-Roussillon-Midi-Pyr\u00e9n\u00e9es"
-       ], 
+       ],
        "old": [
         "France_Midi-Pyrenees"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_New Caledonia", 
-     "s": 6107161, 
+     "id": "France_New Caledonia",
+     "s": 6107161,
      "affiliations": [
-      "France", 
-      "France, Nouvelle-Cal\u00e9donie, Grande Terre et r\u00e9cifs d'Entrecasteaux (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, R\u00e9cif de P\u00e9trie (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs Bampton et Chesterfield (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de Bellone (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de l'Astrolabe (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, \u00cele Hunter (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, \u00cele Matthew (eaux territoriales)", 
-      "France, Nouvelle-Cal\u00e9donie, \u00cele de Walpole (eaux territoriales)", 
+      "France",
+      "France, Nouvelle-Cal\u00e9donie, Grande Terre et r\u00e9cifs d'Entrecasteaux (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, R\u00e9cif de P\u00e9trie (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs Bampton et Chesterfield (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de Bellone (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, R\u00e9cifs de l'Astrolabe (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, \u00cele Hunter (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, \u00cele Matthew (eaux territoriales)",
+      "France, Nouvelle-Cal\u00e9donie, \u00cele de Walpole (eaux territoriales)",
       "France, Nouvelle-Cal\u00e9donie, \u00celes Loyaut\u00e9 (eaux territoriales)"
-     ], 
+     ],
      "old": [
       "New Caledonia"
      ]
-    }, 
+    },
     {
-     "id": "France_Nord-Pas-de-Calais", 
+     "id": "France_Nord-Pas-de-Calais",
      "g": [
       {
-       "id": "France_Nord-Pas-de-Calais_Nord", 
-       "s": 30986918, 
+       "id": "France_Nord-Pas-de-Calais_Nord",
+       "s": 30986918,
        "affiliations": [
-        "France", 
+        "France",
         "Nord-Pas-de-Calais-Picardie"
-       ], 
+       ],
        "old": [
         "France_Nord-Pas-de-Calais"
        ]
-      }, 
+      },
       {
-       "id": "France_Nord-Pas-de-Calais_Lille", 
-       "s": 35367325, 
+       "id": "France_Nord-Pas-de-Calais_Lille",
+       "s": 35367325,
        "affiliations": [
-        "France", 
+        "France",
         "Nord-Pas-de-Calais-Picardie"
-       ], 
+       ],
        "old": [
         "France_Nord-Pas-de-Calais"
        ]
-      }, 
+      },
       {
-       "id": "France_Nord-Pas-de-Calais_Pas-de-Calais", 
-       "s": 47878851, 
+       "id": "France_Nord-Pas-de-Calais_Pas-de-Calais",
+       "s": 47878851,
        "affiliations": [
-        "England", 
-        "France", 
-        "Nord-Pas-de-Calais-Picardie", 
+        "England",
+        "France",
+        "Nord-Pas-de-Calais-Picardie",
         "United Kingdom"
-       ], 
+       ],
        "old": [
         "France_Nord-Pas-de-Calais"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Pays de la Loire", 
+     "id": "France_Pays de la Loire",
      "g": [
       {
-       "id": "France_Pays de la Loire_Loire-Atlantique_Nantes", 
-       "s": 37805657, 
+       "id": "France_Pays de la Loire_Loire-Atlantique_Nantes",
+       "s": 37805657,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
-      }, 
+      },
       {
-       "id": "France_Pays de la Loire_Loire-Atlantique_Saint-Nazaire", 
-       "s": 20084598, 
+       "id": "France_Pays de la Loire_Loire-Atlantique_Saint-Nazaire",
+       "s": 20084598,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
-      }, 
+      },
       {
-       "id": "France_Pays de la Loire_Maine-et-Loire", 
-       "s": 35642019, 
+       "id": "France_Pays de la Loire_Maine-et-Loire",
+       "s": 35642019,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
-      }, 
+      },
       {
-       "id": "France_Pays de la Loire_Mayenne", 
-       "s": 19199950, 
+       "id": "France_Pays de la Loire_Mayenne",
+       "s": 19199950,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
-      }, 
+      },
       {
-       "id": "France_Pays de la Loire_Sarthe", 
-       "s": 32011080, 
+       "id": "France_Pays de la Loire_Sarthe",
+       "s": 32011080,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
-      }, 
+      },
       {
-       "id": "France_Pays de la Loire_Vendee", 
-       "s": 45826847, 
+       "id": "France_Pays de la Loire_Vendee",
+       "s": 45826847,
        "affiliations": [
-        "France", 
+        "France",
         "Pays de la Loire"
-       ], 
+       ],
        "old": [
         "France_Pays de la Loire"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Picardy", 
+     "id": "France_Picardy",
      "g": [
       {
-       "id": "France_Picardy_Aisne", 
-       "s": 25348628, 
+       "id": "France_Picardy_Aisne",
+       "s": 25348628,
        "affiliations": [
-        "France", 
+        "France",
         "Nord-Pas-de-Calais-Picardie"
-       ], 
+       ],
        "old": [
         "France_Picardie"
        ]
-      }, 
+      },
       {
-       "id": "France_Picardy_Oise", 
-       "s": 29002934, 
+       "id": "France_Picardy_Oise",
+       "s": 29002934,
        "affiliations": [
-        "France", 
+        "France",
         "Nord-Pas-de-Calais-Picardie"
-       ], 
+       ],
        "old": [
         "France_Picardie"
        ]
-      }, 
+      },
       {
-       "id": "France_Picardy_Somme", 
-       "s": 27487389, 
+       "id": "France_Picardy_Somme",
+       "s": 27487389,
        "affiliations": [
-        "France", 
+        "France",
         "Nord-Pas-de-Calais-Picardie"
-       ], 
+       ],
        "old": [
         "France_Picardie"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Poitou-Charentes", 
+     "id": "France_Poitou-Charentes",
      "g": [
       {
-       "id": "France_Poitou-Charentes_Charente", 
-       "s": 21839071, 
+       "id": "France_Poitou-Charentes_Charente",
+       "s": 21839071,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Poitou-Charentes"
        ]
-      }, 
+      },
       {
-       "id": "France_Poitou-Charentes_Charente-Maritime", 
-       "s": 40937113, 
+       "id": "France_Poitou-Charentes_Charente-Maritime",
+       "s": 40937113,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Poitou-Charentes"
        ]
-      }, 
+      },
       {
-       "id": "France_Poitou-Charentes_Deux-Sevres", 
-       "s": 29808316, 
+       "id": "France_Poitou-Charentes_Deux-Sevres",
+       "s": 29808316,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Poitou-Charentes"
        ]
-      }, 
+      },
       {
-       "id": "France_Poitou-Charentes_Vienne", 
-       "s": 27262529, 
+       "id": "France_Poitou-Charentes_Vienne",
+       "s": 27262529,
        "affiliations": [
-        "Aquitaine-Limousin-Poitou-Charentes", 
+        "Aquitaine-Limousin-Poitou-Charentes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Poitou-Charentes"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Provence-Alpes-Cote dAzur", 
+     "id": "France_Provence-Alpes-Cote dAzur",
      "g": [
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Alpes-de-Haute-Provence", 
-       "s": 14400152, 
+       "id": "France_Provence-Alpes-Cote dAzur_Alpes-de-Haute-Provence",
+       "s": 14400152,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Provence-Alpes-Cote d'Azur"
        ]
-      }, 
+      },
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Bouches-du-Rhone", 
-       "s": 46131613, 
+       "id": "France_Provence-Alpes-Cote dAzur_Bouches-du-Rhone",
+       "s": 46131613,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Provence-Alpes-Cote d'Azur"
        ]
-      }, 
+      },
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Hautes-Alpes", 
-       "s": 12068032, 
+       "id": "France_Provence-Alpes-Cote dAzur_Hautes-Alpes",
+       "s": 12068032,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Provence-Alpes-Cote d'Azur"
        ]
-      }, 
+      },
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Maritime Alps", 
-       "s": 26089702, 
+       "id": "France_Provence-Alpes-Cote dAzur_Maritime Alps",
+       "s": 26089702,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
-        "France_Provence-Alpes-Cote d'Azur", 
+        "France_Provence-Alpes-Cote d'Azur",
         "Monaco"
        ]
-      }, 
+      },
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Var", 
-       "s": 35355044, 
+       "id": "France_Provence-Alpes-Cote dAzur_Var",
+       "s": 35355044,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Provence-Alpes-Cote d'Azur"
        ]
-      }, 
+      },
       {
-       "id": "France_Provence-Alpes-Cote dAzur_Vaucluse", 
-       "s": 25401063, 
+       "id": "France_Provence-Alpes-Cote dAzur_Vaucluse",
+       "s": 25401063,
        "affiliations": [
-        "France", 
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Provence-Alpes-Cote d'Azur"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Rhone-Alpes", 
+     "id": "France_Rhone-Alpes",
      "g": [
       {
-       "id": "France_Rhone-Alpes_Ain", 
-       "s": 32915584, 
+       "id": "France_Rhone-Alpes_Ain",
+       "s": 32915584,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Ardeche", 
-       "s": 21660150, 
+       "id": "France_Rhone-Alpes_Ardeche",
+       "s": 21660150,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Drome", 
-       "s": 27116537, 
+       "id": "France_Rhone-Alpes_Drome",
+       "s": 27116537,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
-        "France", 
+        "Auvergne-Rh\u00f4ne-Alpes",
+        "France",
         "Provence-Alpes-C\u00f4te d'Azur"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Haute-Savoie", 
-       "s": 28991879, 
+       "id": "France_Rhone-Alpes_Haute-Savoie",
+       "s": 28991879,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Isere", 
-       "s": 41118624, 
+       "id": "France_Rhone-Alpes_Isere",
+       "s": 41118624,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Loire", 
-       "s": 25573670, 
+       "id": "France_Rhone-Alpes_Loire",
+       "s": 25573670,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Rhone", 
-       "s": 38202700, 
+       "id": "France_Rhone-Alpes_Rhone",
+       "s": 38202700,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
-      }, 
+      },
       {
-       "id": "France_Rhone-Alpes_Savoie", 
-       "s": 21140484, 
+       "id": "France_Rhone-Alpes_Savoie",
+       "s": 21140484,
        "affiliations": [
-        "Auvergne-Rh\u00f4ne-Alpes", 
+        "Auvergne-Rh\u00f4ne-Alpes",
         "France"
-       ], 
+       ],
        "old": [
         "France_Rhone-Alpes"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "France_Southern Islands", 
-     "s": 22763411, 
+     "id": "France_Southern Islands",
+     "s": 22763411,
      "affiliations": [
-      "France", 
-      "France, Mayotte (eaux territoriales)", 
-      "France, La R\u00e9union (eaux territoriales)", 
-      "France, Terres australes et antarctiques fran\u00e7aises, Saint-Paul-et-Amsterdam (eaux territoriales)", 
-      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes Crozet (eaux territoriales)", 
-      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes Kerguelen (eaux territoriales)", 
-      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes \u00c9parses, \u00cele Tromelin (eaux territoriales)", 
-      "Heard Island and McDonald Islands", 
-      "La R\u00e9union", 
+      "France",
+      "France, Mayotte (eaux territoriales)",
+      "France, La R\u00e9union (eaux territoriales)",
+      "France, Terres australes et antarctiques fran\u00e7aises, Saint-Paul-et-Amsterdam (eaux territoriales)",
+      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes Crozet (eaux territoriales)",
+      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes Kerguelen (eaux territoriales)",
+      "France, Terres australes et antarctiques fran\u00e7aises, \u00celes \u00c9parses, \u00cele Tromelin (eaux territoriales)",
+      "Heard Island and McDonald Islands",
+      "La R\u00e9union",
       "Mayotte"
-     ], 
+     ],
      "old": [
-      "Reunion", 
-      "French Southern Territories", 
-      "Heard Island and McDonald Islands", 
+      "Reunion",
+      "French Southern Territories",
+      "Heard Island and McDonald Islands",
       "Mayotte"
      ]
-    }, 
+    },
     {
-     "id": "France_Upper Normandy", 
-     "s": 48118311, 
+     "id": "France_Upper Normandy",
+     "s": 48118311,
      "affiliations": [
-      "France", 
+      "France",
       "Normandie"
-     ], 
+     ],
      "old": [
       "France_Haute-Normandie"
      ]
-    }, 
+    },
     {
-     "id": "French Polynesia", 
-     "s": 2550588, 
+     "id": "French Polynesia",
+     "s": 2550588,
      "affiliations": [
-      "France", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Gambier (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Marquises (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Sous-le-Vent (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, Archipel des Tuamotu (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Australes (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes du D\u00e9sappointement (eaux territoriales)", 
-      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes du Vent (eaux territoriales)", 
+      "France",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Gambier (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Marquises (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Sous-le-Vent (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, Archipel des Tuamotu (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes Australes (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes du D\u00e9sappointement (eaux territoriales)",
+      "France, Polyn\u00e9sie fran\u00e7aise, \u00celes du Vent (eaux territoriales)",
       "Polyn\u00e9sie fran\u00e7aise, \u00celes du Vent (eaux territoriales)"
-     ], 
+     ],
      "old": [
       "French Polynesia"
      ]
-    }, 
+    },
     {
-     "id": "Wallis and Futuna", 
-     "s": 330662, 
+     "id": "Wallis and Futuna",
+     "s": 330662,
      "affiliations": [
-      "France", 
+      "France",
       "France, Wallis-et-Futuna (eaux territoriales)"
-     ], 
+     ],
      "old": [
       "Wallis and Futuna"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Gabon", 
-   "s": 5281578, 
+   "id": "Gabon",
+   "s": 5281578,
    "affiliations": [
-    "Estuaire", 
-    "Gabon", 
-    "Haut-Ogoou\u00e9", 
-    "Ngouni\u00e9", 
-    "Moyen-Ogoou\u00e9", 
-    "Ogoou\u00e9-Maritime", 
-    "Nyanga", 
-    "Ogoou\u00e9-Ivindo", 
-    "Ogoou\u00e9-Lolo", 
+    "Estuaire",
+    "Gabon",
+    "Haut-Ogoou\u00e9",
+    "Ngouni\u00e9",
+    "Moyen-Ogoou\u00e9",
+    "Ogoou\u00e9-Maritime",
+    "Nyanga",
+    "Ogoou\u00e9-Ivindo",
+    "Ogoou\u00e9-Lolo",
     "Woleu-Ntem"
-   ], 
+   ],
    "old": [
     "Gabon"
    ]
-  }, 
+  },
   {
-   "id": "Georgia Region", 
+   "id": "Georgia Region",
    "g": [
     {
-     "id": "Georgia", 
-     "s": 28113945, 
+     "id": "Georgia",
+     "s": 28113945,
      "affiliations": [
-      "\u10d7\u10d1\u10d8\u10da\u10d8\u10e1\u10d8", 
-      "\u10d8\u10db\u10d4\u10e0\u10d4\u10d7\u10d8", 
-      "\u10e1\u10d0\u10db\u10d4\u10d2\u10e0\u10d4\u10da\u10dd-\u10d6\u10d4\u10db\u10dd \u10e1\u10d5\u10d0\u10dc\u10d4\u10d7\u10d8", 
-      "\u10e8\u10d8\u10d3\u10d0 \u10e5\u10d0\u10e0\u10d7\u10da\u10d8", 
-      "\u10e0\u10d0\u10ed\u10d0-\u10da\u10d4\u10e9\u10ee\u10e3\u10db\u10d8 \u10d3\u10d0 \u10e5\u10d5\u10d4\u10db\u10dd \u10e1\u10d5\u10d0\u10dc\u10d4\u10d7\u10d8", 
-      "\u10d2\u10e3\u10e0\u10d8\u10d0", 
-      "\u10e5\u10d5\u10d4\u10db\u10dd \u10e5\u10d0\u10e0\u10d7\u10da\u10d8", 
-      "\u10d9\u10d0\u10ee\u10d4\u10d7\u10d8", 
-      "\u10db\u10ea\u10ee\u10d4\u10d7\u10d0-\u10db\u10d7\u10d8\u10d0\u10dc\u10d4\u10d7\u10d8", 
-      "\u10e1\u10d0\u10db\u10ea\u10ee\u10d4-\u10ef\u10d0\u10d5\u10d0\u10ee\u10d4\u10d7\u10d8", 
-      "\u10d0\u10ed\u10d0\u10e0\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0", 
+      "\u10d7\u10d1\u10d8\u10da\u10d8\u10e1\u10d8",
+      "\u10d8\u10db\u10d4\u10e0\u10d4\u10d7\u10d8",
+      "\u10e1\u10d0\u10db\u10d4\u10d2\u10e0\u10d4\u10da\u10dd-\u10d6\u10d4\u10db\u10dd \u10e1\u10d5\u10d0\u10dc\u10d4\u10d7\u10d8",
+      "\u10e8\u10d8\u10d3\u10d0 \u10e5\u10d0\u10e0\u10d7\u10da\u10d8",
+      "\u10e0\u10d0\u10ed\u10d0-\u10da\u10d4\u10e9\u10ee\u10e3\u10db\u10d8 \u10d3\u10d0 \u10e5\u10d5\u10d4\u10db\u10dd \u10e1\u10d5\u10d0\u10dc\u10d4\u10d7\u10d8",
+      "\u10d2\u10e3\u10e0\u10d8\u10d0",
+      "\u10e5\u10d5\u10d4\u10db\u10dd \u10e5\u10d0\u10e0\u10d7\u10da\u10d8",
+      "\u10d9\u10d0\u10ee\u10d4\u10d7\u10d8",
+      "\u10db\u10ea\u10ee\u10d4\u10d7\u10d0-\u10db\u10d7\u10d8\u10d0\u10dc\u10d4\u10d7\u10d8",
+      "\u10e1\u10d0\u10db\u10ea\u10ee\u10d4-\u10ef\u10d0\u10d5\u10d0\u10ee\u10d4\u10d7\u10d8",
+      "\u10d0\u10ed\u10d0\u10e0\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0",
       "\u10e1\u10d0\u10e5\u10d0\u10e0\u10d7\u10d5\u10d4\u10da\u10dd"
-     ], 
+     ],
      "old": [
       "Georgia"
      ]
-    }, 
+    },
     {
-     "id": "Abkhazia", 
-     "s": 4478795, 
+     "id": "Abkhazia",
+     "s": 4478795,
      "affiliations": [
-      "\u0410\u0431\u0445\u0430\u0437\u0438\u044f - \u0410\u04a7\u0441\u043d\u044b", 
-      "\u10d0\u10e4\u10ee\u10d0\u10d6\u10d4\u10d7\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0 - \u0410\u04a7\u0441\u043d\u044b \u0410\u0432\u0442\u043e\u043d\u043e\u043c\u0442\u04d9 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", 
+      "\u0410\u0431\u0445\u0430\u0437\u0438\u044f - \u0410\u04a7\u0441\u043d\u044b",
+      "\u10d0\u10e4\u10ee\u10d0\u10d6\u10d4\u10d7\u10d8\u10e1 \u10d0\u10d5\u10e2\u10dd\u10dc\u10dd\u10db\u10d8\u10e3\u10e0\u10d8 \u10e0\u10d4\u10e1\u10de\u10e3\u10d1\u10da\u10d8\u10d9\u10d0 - \u0410\u04a7\u0441\u043d\u044b \u0410\u0432\u0442\u043e\u043d\u043e\u043c\u0442\u04d9 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
       "\u10e1\u10d0\u10e5\u10d0\u10e0\u10d7\u10d5\u10d4\u10da\u10dd"
-     ], 
+     ],
      "old": [
       "Georgia"
      ]
-    }, 
+    },
     {
-     "id": "South Ossetia", 
-     "s": 1326282, 
+     "id": "South Ossetia",
+     "s": 1326282,
      "affiliations": [
-      "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d", 
-      "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d - \u042e\u0436\u043d\u0430\u044f \u041e\u0441\u0435\u0442\u0438\u044f", 
+      "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d",
+      "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d - \u042e\u0436\u043d\u0430\u044f \u041e\u0441\u0435\u0442\u0438\u044f",
       "\u10e1\u10d0\u10e5\u10d0\u10e0\u10d7\u10d5\u10d4\u10da\u10dd"
-     ], 
+     ],
      "old": [
       "Georgia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Germany", 
+   "id": "Germany",
    "g": [
     {
-     "id": "Germany_Baden-Wurttemberg", 
+     "id": "Germany_Baden-Wurttemberg",
      "g": [
       {
-       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Freiburg", 
-       "s": 82407786, 
+       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Freiburg",
+       "s": 82407786,
        "affiliations": [
-        "Baden-W\u00fcrttemberg", 
-        "Deutschland", 
-        "Schaffhausen", 
+        "Baden-W\u00fcrttemberg",
+        "Deutschland",
+        "Schaffhausen",
         "Z\u00fcrich"
-       ], 
+       ],
        "old": [
         "Germany_Baden-Wurttemberg"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Karlsruhe", 
-       "s": 85471760, 
+       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Karlsruhe",
+       "s": 85471760,
        "affiliations": [
-        "Baden-W\u00fcrttemberg", 
+        "Baden-W\u00fcrttemberg",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Baden-Wurttemberg"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Stuttgart_Heilbronn", 
-       "s": 31088044, 
+       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Stuttgart_Heilbronn",
+       "s": 31088044,
        "affiliations": [
-        "Baden-W\u00fcrttemberg", 
+        "Baden-W\u00fcrttemberg",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Baden-Wurttemberg"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Stuttgart_Stuttgart", 
-       "s": 81015101, 
+       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Stuttgart_Stuttgart",
+       "s": 81015101,
        "affiliations": [
-        "Baden-W\u00fcrttemberg", 
+        "Baden-W\u00fcrttemberg",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Baden-Wurttemberg"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Tubingen", 
-       "s": 59182418, 
+       "id": "Germany_Baden-Wurttemberg_Regierungsbezirk Tubingen",
+       "s": 59182418,
        "affiliations": [
-        "Baden-W\u00fcrttemberg", 
+        "Baden-W\u00fcrttemberg",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Baden-Wurttemberg"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Germany_Berlin", 
-     "s": 44652665, 
+     "id": "Germany_Berlin",
+     "s": 44652665,
      "affiliations": [
-      "Berlin", 
+      "Berlin",
       "Deutschland"
-     ], 
+     ],
      "old": [
       "Germany_Berlin & Brandenburg"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Brandenburg_North", 
-     "s": 43043765, 
+     "id": "Germany_Brandenburg_North",
+     "s": 43043765,
      "affiliations": [
-      "Brandenburg", 
+      "Brandenburg",
       "Deutschland"
-     ], 
+     ],
      "old": [
       "Germany_Berlin & Brandenburg"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Brandenburg_South", 
-     "s": 43115602, 
+     "id": "Germany_Brandenburg_South",
+     "s": 43115602,
      "affiliations": [
-      "Brandenburg", 
+      "Brandenburg",
       "Deutschland"
-     ], 
+     ],
      "old": [
       "Germany_Berlin & Brandenburg"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Free State of Bavaria", 
+     "id": "Germany_Free State of Bavaria",
      "g": [
       {
-       "id": "Germany_Free State of Bavaria_Lower Bavaria", 
-       "s": 43556470, 
+       "id": "Germany_Free State of Bavaria_Lower Bavaria",
+       "s": 43556470,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Lower Franconia", 
-       "s": 44640863, 
+       "id": "Germany_Free State of Bavaria_Lower Franconia",
+       "s": 44640863,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Middle Franconia", 
-       "s": 48736126, 
+       "id": "Germany_Free State of Bavaria_Middle Franconia",
+       "s": 48736126,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Swabia", 
-       "s": 66011863, 
+       "id": "Germany_Free State of Bavaria_Swabia",
+       "s": 66011863,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Bavaria_East", 
-       "s": 41346271, 
+       "id": "Germany_Free State of Bavaria_Upper Bavaria_East",
+       "s": 41346271,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Bavaria_Ingolstadt", 
-       "s": 22462884, 
+       "id": "Germany_Free State of Bavaria_Upper Bavaria_Ingolstadt",
+       "s": 22462884,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Bavaria_Munchen", 
-       "s": 41011885, 
+       "id": "Germany_Free State of Bavaria_Upper Bavaria_Munchen",
+       "s": 41011885,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Bavaria_South", 
-       "s": 18506234, 
+       "id": "Germany_Free State of Bavaria_Upper Bavaria_South",
+       "s": 18506234,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Franconia", 
-       "s": 43569389, 
+       "id": "Germany_Free State of Bavaria_Upper Franconia",
+       "s": 43569389,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Free State of Bavaria_Upper Palatinate", 
-       "s": 42327843, 
+       "id": "Germany_Free State of Bavaria_Upper Palatinate",
+       "s": 42327843,
        "affiliations": [
-        "Bayern", 
+        "Bayern",
         "Deutschland"
-       ], 
+       ],
        "old": [
         "Germany_Bavaria"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Germany_Hamburg_main", 
-     "s": 24179219, 
+     "id": "Germany_Hamburg_main",
+     "s": 24179219,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Hamburg"
-     ], 
+     ],
      "old": [
       "Germany_Hamburg"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Hesse", 
+     "id": "Germany_Hesse",
      "g": [
       {
-       "id": "Germany_Hesse_Regierungsbezirk Darmstadt", 
-       "s": 84634265, 
+       "id": "Germany_Hesse_Regierungsbezirk Darmstadt",
+       "s": 84634265,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Hessen"
-       ], 
+       ],
        "old": [
         "Germany_Hesse"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Hesse_Regierungsbezirk Giessen", 
-       "s": 35128453, 
+       "id": "Germany_Hesse_Regierungsbezirk Giessen",
+       "s": 35128453,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Hessen"
-       ], 
+       ],
        "old": [
         "Germany_Hesse"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Hesse_Regierungsbezirk Kassel", 
-       "s": 49922922, 
+       "id": "Germany_Hesse_Regierungsbezirk Kassel",
+       "s": 49922922,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Hessen"
-       ], 
+       ],
        "old": [
         "Germany_Hesse"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Germany_Lower Saxony", 
+     "id": "Germany_Lower Saxony",
      "g": [
       {
-       "id": "Germany_Lower Saxony_Bremen_Bremen", 
-       "s": 43991795, 
+       "id": "Germany_Lower Saxony_Bremen_Bremen",
+       "s": 43991795,
        "affiliations": [
-        "Bremen", 
-        "Deutschland", 
-        "Hamburg", 
+        "Bremen",
+        "Deutschland",
+        "Hamburg",
         "Niedersachsen"
-       ], 
+       ],
        "old": [
-        "Germany_Bremen & Lower Saxony", 
+        "Germany_Bremen & Lower Saxony",
         "Germany_Hamburg"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Lower Saxony_Bremen_Munster", 
-       "s": 46408182, 
+       "id": "Germany_Lower Saxony_Bremen_Munster",
+       "s": 46408182,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Niedersachsen"
-       ], 
+       ],
        "old": [
         "Germany_Bremen & Lower Saxony"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Lower Saxony_Hannover", 
-       "s": 40879428, 
+       "id": "Germany_Lower Saxony_Hannover",
+       "s": 40879428,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Niedersachsen"
-       ], 
+       ],
        "old": [
         "Germany_Bremen & Lower Saxony"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Lower Saxony_Braunschweig", 
-       "s": 49347820, 
+       "id": "Germany_Lower Saxony_Braunschweig",
+       "s": 49347820,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Niedersachsen"
-       ], 
+       ],
        "old": [
         "Germany_Bremen & Lower Saxony"
        ]
-      }, 
+      },
       {
-       "id": "Germany_Lower Saxony_Oldenburg", 
-       "s": 64821410, 
+       "id": "Germany_Lower Saxony_Oldenburg",
+       "s": 64821410,
        "affiliations": [
-        "Bremen", 
-        "Deutschland", 
+        "Bremen",
+        "Deutschland",
         "Niedersachsen"
-       ], 
+       ],
        "old": [
         "Germany_Bremen & Lower Saxony"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Germany_Mecklenburg-Vorpommern", 
-     "s": 65393221, 
+     "id": "Germany_Mecklenburg-Vorpommern",
+     "s": 65393221,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Mecklenburg-Vorpommern"
-     ], 
+     ],
      "old": [
       "Germany_Mecklenburg-Vorpommern"
      ]
-    }, 
+    },
     {
-     "id": "Germany_North Rhine-Westphalia", 
+     "id": "Germany_North Rhine-Westphalia",
      "g": [
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Arnsberg_Arnsberg", 
-       "s": 44346208, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Arnsberg_Arnsberg",
+       "s": 44346208,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Arnsberg_Dortmund", 
-       "s": 67597488, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Arnsberg_Dortmund",
+       "s": 67597488,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Detmold", 
-       "s": 74593274, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Detmold",
+       "s": 74593274,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Dusseldorf", 
-       "s": 59280700, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Dusseldorf",
+       "s": 59280700,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Mulheim", 
-       "s": 51659804, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Mulheim",
+       "s": 51659804,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Wesel", 
-       "s": 16726357, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Dusseldorf_Wesel",
+       "s": 16726357,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Aachen", 
-       "s": 58879634, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Aachen",
+       "s": 58879634,
        "affiliations": [
-        "Deutschland", 
-        "Deutschland - Belgique / Belgi\u00eb / Belgien", 
+        "Deutschland",
+        "Deutschland - Belgique / Belgi\u00eb / Belgien",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Koln", 
-       "s": 73537693, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Koln",
+       "s": 73537693,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Munster_Munster", 
-       "s": 38640105, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Munster_Munster",
+       "s": 38640105,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
-      }, 
+      },
       {
-       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Munster_Recklinghausen", 
-       "s": 46026847, 
+       "id": "Germany_North Rhine-Westphalia_Regierungsbezirk Munster_Recklinghausen",
+       "s": 46026847,
        "affiliations": [
-        "Deutschland", 
+        "Deutschland",
         "Nordrhein-Westfalen"
-       ], 
+       ],
        "old": [
         "Germany_North Rhine-Westphalia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Germany_Rhineland-Palatinate_Koblenz", 
-     "s": 59370643, 
+     "id": "Germany_Rhineland-Palatinate_Koblenz",
+     "s": 59370643,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Rheinland-Pfalz"
-     ], 
+     ],
      "old": [
       "Germany_Rhineland-Palatinate"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Rhineland-Palatinate_South", 
-     "s": 55169652, 
+     "id": "Germany_Rhineland-Palatinate_South",
+     "s": 55169652,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Rheinland-Pfalz"
-     ], 
+     ],
      "old": [
       "Germany_Rhineland-Palatinate"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Saarland", 
-     "s": 25535371, 
+     "id": "Germany_Saarland",
+     "s": 25535371,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Saarland"
-     ], 
+     ],
      "old": [
       "Germany_Saarland"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Saxony-Anhalt_Magdeburg", 
-     "s": 36680438, 
+     "id": "Germany_Saxony-Anhalt_Magdeburg",
+     "s": 36680438,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Sachsen-Anhalt"
-     ], 
+     ],
      "old": [
       "Germany_Saxony-Anhalt"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Saxony-Anhalt_Halle", 
-     "s": 34464056, 
+     "id": "Germany_Saxony-Anhalt_Halle",
+     "s": 34464056,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Sachsen-Anhalt"
-     ], 
+     ],
      "old": [
       "Germany_Saxony-Anhalt"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Saxony_Dresden", 
-     "s": 46869297, 
+     "id": "Germany_Saxony_Dresden",
+     "s": 46869297,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Sachsen"
-     ], 
+     ],
      "old": [
       "Germany_Saxony"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Saxony_Leipzig", 
-     "s": 77810234, 
+     "id": "Germany_Saxony_Leipzig",
+     "s": 77810234,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Sachsen"
-     ], 
+     ],
      "old": [
       "Germany_Saxony"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Schleswig-Holstein_Kiel", 
-     "s": 41700850, 
+     "id": "Germany_Schleswig-Holstein_Kiel",
+     "s": 41700850,
      "affiliations": [
-      "Danmark", 
-      "Deutschland", 
+      "Danmark",
+      "Deutschland",
       "Schleswig-Holstein"
-     ], 
+     ],
      "old": [
       "Germany_Schleswig-Holstein"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Schleswig-Holstein_Flensburg", 
-     "s": 40313023, 
+     "id": "Germany_Schleswig-Holstein_Flensburg",
+     "s": 40313023,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Schleswig-Holstein"
-     ], 
+     ],
      "old": [
       "Germany_Schleswig-Holstein"
      ]
-    }, 
+    },
     {
-     "id": "Germany_Thuringia", 
-     "s": 73088839, 
+     "id": "Germany_Thuringia",
+     "s": 73088839,
      "affiliations": [
-      "Deutschland", 
+      "Deutschland",
       "Th\u00fcringen"
-     ], 
+     ],
      "old": [
       "Germany_Thuringia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Ghana", 
-   "s": 10831234, 
+   "id": "Ghana",
+   "s": 10831234,
    "affiliations": [
-    "Ashanti Region", 
-    "Brong-Ahafo Region", 
-    "Central Region", 
-    "Eastern Region", 
-    "Ghana", 
-    "Greater Accra Region", 
-    "Northern Region", 
-    "Upper East Region", 
-    "Upper West Region", 
-    "Volta Region", 
+    "Ashanti Region",
+    "Brong-Ahafo Region",
+    "Central Region",
+    "Eastern Region",
+    "Ghana",
+    "Greater Accra Region",
+    "Northern Region",
+    "Upper East Region",
+    "Upper West Region",
+    "Volta Region",
     "Western Region"
-   ], 
+   ],
    "old": [
     "Ghana"
    ]
-  }, 
+  },
   {
-   "id": "Gibraltar", 
-   "s": 287642, 
+   "id": "Gibraltar",
+   "s": 287642,
    "affiliations": [
-    "Espa\u00f1a", 
+    "Espa\u00f1a",
     "Gibraltar"
-   ], 
+   ],
    "old": [
-    "Spain", 
+    "Spain",
     "Gibraltar"
    ]
-  }, 
+  },
   {
-   "id": "Greece", 
+   "id": "Greece",
    "g": [
     {
-     "id": "Greece_Decentralized Administration of Crete", 
-     "s": 8632879, 
+     "id": "Greece_Decentralized Administration of Crete",
+     "s": 8632879,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
-      "Territorial waters of Greece - Gavdos and Gavdopoula", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
+      "Territorial waters of Greece - Gavdos and Gavdopoula",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u039a\u03c1\u03ae\u03c4\u03b7\u03c2"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of West Greece", 
-     "s": 21313732, 
+     "id": "Greece_Decentralized Administration of West Greece",
+     "s": 21313732,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
-      "Territorial waters of Greece - Strofades", 
-      "Shqip\u00ebria", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
+      "Territorial waters of Greece - Strofades",
+      "Shqip\u00ebria",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u03a0\u03b5\u03bb\u03bf\u03c0\u03bf\u03bd\u03bd\u03ae\u03c3\u03bf\u03c5, \u0394\u03c5\u03c4\u03b9\u03ba\u03ae\u03c2 \u0395\u03bb\u03bb\u03ac\u03b4\u03b1\u03c2 \u03ba\u03b1\u03b9 \u0399\u03bf\u03bd\u03af\u03bf\u03c5"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of Aegean", 
-     "s": 16459842, 
+     "id": "Greece_Decentralized Administration of Aegean",
+     "s": 16459842,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0391\u03b9\u03b3\u03b1\u03af\u03bf\u03c5"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of Epirus - Western Macedonia", 
-     "s": 12010923, 
+     "id": "Greece_Decentralized Administration of Epirus - Western Macedonia",
+     "s": 12010923,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0397\u03c0\u03b5\u03af\u03c1\u03bf\u03c5 - \u0394\u03c5\u03c4\u03b9\u03ba\u03ae\u03c2 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of Macedonia and Thrace", 
-     "s": 21846225, 
+     "id": "Greece_Decentralized Administration of Macedonia and Thrace",
+     "s": 21846225,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2 - \u0398\u03c1\u03ac\u03ba\u03b7\u03c2"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of Thessaly - Central Greece", 
-     "s": 24772773, 
+     "id": "Greece_Decentralized Administration of Thessaly - Central Greece",
+     "s": 24772773,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
-      "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0391\u03c4\u03c4\u03b9\u03ba\u03ae\u03c2", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
+      "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0391\u03c4\u03c4\u03b9\u03ba\u03ae\u03c2",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0398\u03b5\u03c3\u03c3\u03b1\u03bb\u03af\u03b1\u03c2 - \u03a3\u03c4\u03b5\u03c1\u03b5\u03ac\u03c2 \u0395\u03bb\u03bb\u03ac\u03b4\u03b1\u03c2"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
-    }, 
+    },
     {
-     "id": "Greece_Decentralized Administration of Attica", 
-     "s": 19471851, 
+     "id": "Greece_Decentralized Administration of Attica",
+     "s": 19471851,
      "affiliations": [
-      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1", 
+      "\u0395\u03bb\u03bb\u03ac\u03b4\u03b1",
       "\u0391\u03c0\u03bf\u03ba\u03b5\u03bd\u03c4\u03c1\u03c9\u03bc\u03ad\u03bd\u03b7 \u0394\u03b9\u03bf\u03af\u03ba\u03b7\u03c3\u03b7 \u0391\u03c4\u03c4\u03b9\u03ba\u03ae\u03c2"
-     ], 
+     ],
      "old": [
       "Greece"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Greenland", 
-   "s": 23554691, 
+   "id": "Greenland",
+   "s": 23554691,
    "affiliations": [
     "Kalaallit Nunaat"
-   ], 
+   ],
    "old": [
     "Greenland"
    ]
-  }, 
+  },
   {
-   "id": "Guatemala", 
-   "s": 24709997, 
+   "id": "Guatemala",
+   "s": 24709997,
    "affiliations": [
-    "Alta Verapaz", 
-    "Baja Verapaz", 
-    "Chimaltenango", 
-    "Chiquimula", 
-    "El Progreso", 
-    "Escuintla", 
-    "Guatemala", 
-    "Guatemala", 
-    "Huehuetenango", 
-    "Izabal", 
-    "Jalapa", 
-    "Jutiapa", 
-    "Pet\u00e9n", 
-    "Quetzaltenango", 
-    "Quich\u00e9", 
-    "Retalhuleu", 
-    "Sacatep\u00e9quez", 
-    "San Marcos", 
-    "Santa Rosa", 
-    "Solol\u00e1", 
-    "Suchitep\u00e9quez", 
-    "Totonicap\u00e1n", 
+    "Alta Verapaz",
+    "Baja Verapaz",
+    "Chimaltenango",
+    "Chiquimula",
+    "El Progreso",
+    "Escuintla",
+    "Guatemala",
+    "Guatemala",
+    "Huehuetenango",
+    "Izabal",
+    "Jalapa",
+    "Jutiapa",
+    "Pet\u00e9n",
+    "Quetzaltenango",
+    "Quich\u00e9",
+    "Retalhuleu",
+    "Sacatep\u00e9quez",
+    "San Marcos",
+    "Santa Rosa",
+    "Solol\u00e1",
+    "Suchitep\u00e9quez",
+    "Totonicap\u00e1n",
     "Zacapa"
-   ], 
+   ],
    "old": [
     "Guatemala"
    ]
-  }, 
+  },
   {
-   "id": "Guernsey", 
-   "s": 736737, 
+   "id": "Guernsey",
+   "s": 736737,
    "affiliations": [
-    "Alderney", 
-    "Brecqhou", 
-    "Burhou", 
-    "Caquorobert Islet", 
-    "Crevichon", 
-    "Jethou", 
-    "Fauconniere", 
-    "Fondu", 
-    "Guernsey", 
-    "Guernsey", 
-    "Herm", 
-    "Hermetier Island", 
-    "L'Etac de Sark", 
-    "Le Plat Houmet", 
-    "Les Casquets", 
-    "Lihou Island", 
-    "Mouliere", 
-    "Raz Island", 
-    "Ortac", 
-    "Putrainez Islet", 
-    "Renonquet", 
-    "Selle Rocque", 
+    "Alderney",
+    "Brecqhou",
+    "Burhou",
+    "Caquorobert Islet",
+    "Crevichon",
+    "Jethou",
+    "Fauconniere",
+    "Fondu",
+    "Guernsey",
+    "Guernsey",
+    "Herm",
+    "Hermetier Island",
+    "L'Etac de Sark",
+    "Le Plat Houmet",
+    "Les Casquets",
+    "Lihou Island",
+    "Mouliere",
+    "Raz Island",
+    "Ortac",
+    "Putrainez Islet",
+    "Renonquet",
+    "Selle Rocque",
     "Sark"
-   ], 
+   ],
    "old": [
-    "UK_England", 
+    "UK_England",
     "Guernsey"
    ]
-  }, 
+  },
   {
-   "id": "Guinea", 
-   "s": 33000435, 
+   "id": "Guinea",
+   "s": 33000435,
    "affiliations": [
-    "Conakry", 
-    "Faranah", 
-    "Guin\u00e9e", 
-    "Kankan", 
-    "R\u00e9gion de Bok\u00e9", 
-    "R\u00e9gion de Kindia", 
-    "R\u00e9gion de Lab\u00e9", 
-    "R\u00e9gion de Mamou", 
+    "Conakry",
+    "Faranah",
+    "Guin\u00e9e",
+    "Kankan",
+    "R\u00e9gion de Bok\u00e9",
+    "R\u00e9gion de Kindia",
+    "R\u00e9gion de Lab\u00e9",
+    "R\u00e9gion de Mamou",
     "R\u00e9gion de Nz\u00e9r\u00e9kor\u00e9"
-   ], 
+   ],
    "old": [
     "Guinea"
    ]
-  }, 
+  },
   {
-   "id": "Guinea-Bissau", 
-   "s": 4112312, 
+   "id": "Guinea-Bissau",
+   "s": 4112312,
    "affiliations": [
-    "Guin\u00e9-Bissau", 
-    "Regi\u00e3o de Bafat\u00e1", 
-    "Regi\u00e3o de Biombo", 
-    "Regi\u00e3o de Bolama", 
-    "Regi\u00e3o de Cacheu", 
-    "Regi\u00e3o de Gabu", 
-    "Regi\u00e3o de Oio", 
-    "Regi\u00e3o de Quinara", 
+    "Guin\u00e9-Bissau",
+    "Regi\u00e3o de Bafat\u00e1",
+    "Regi\u00e3o de Biombo",
+    "Regi\u00e3o de Bolama",
+    "Regi\u00e3o de Cacheu",
+    "Regi\u00e3o de Gabu",
+    "Regi\u00e3o de Oio",
+    "Regi\u00e3o de Quinara",
     "Regi\u00e3o de Tombali"
-   ], 
+   ],
    "old": [
     "Guinea-Bissau"
    ]
-  }, 
+  },
   {
-   "id": "Guyana", 
-   "s": 3440218, 
+   "id": "Guyana",
+   "s": 3440218,
    "affiliations": [
     "Guyana"
-   ], 
+   ],
    "old": [
     "Guyana"
    ]
-  }, 
+  },
   {
-   "id": "Haiti", 
-   "s": 32116266, 
+   "id": "Haiti",
+   "s": 32116266,
    "affiliations": [
-    "Ayiti", 
-    "D\u00e9partement de l'Artibonite", 
-    "D\u00e9partement de l'Ouest", 
-    "D\u00e9partement de la Grande-Anse", 
-    "D\u00e9partement des Nippes", 
-    "D\u00e9partement du Centre", 
-    "D\u00e9partement du Nord", 
-    "D\u00e9partement du Nord-Est", 
-    "D\u00e9partement du Nord-Ouest", 
-    "D\u00e9partement du Sud", 
+    "Ayiti",
+    "D\u00e9partement de l'Artibonite",
+    "D\u00e9partement de l'Ouest",
+    "D\u00e9partement de la Grande-Anse",
+    "D\u00e9partement des Nippes",
+    "D\u00e9partement du Centre",
+    "D\u00e9partement du Nord",
+    "D\u00e9partement du Nord-Est",
+    "D\u00e9partement du Nord-Ouest",
+    "D\u00e9partement du Sud",
     "D\u00e9partement du Sud-Est"
-   ], 
+   ],
    "old": [
     "Haiti"
    ]
-  }, 
+  },
   {
-   "id": "Honduras", 
-   "s": 14760179, 
+   "id": "Honduras",
+   "s": 14760179,
    "affiliations": [
-    "Atl\u00e1ntida", 
-    "Chinandega", 
-    "Choluteca", 
-    "Col\u00f3n", 
-    "Comayagua", 
-    "Cort\u00e9s", 
-    "Cop\u00e1n", 
-    "El Para\u00edso", 
-    "Francisco Moraz\u00e1n", 
-    "Gracias a Dios", 
-    "Honduras", 
-    "Intibuc\u00e1", 
-    "Islas de la Bah\u00eda", 
-    "La Paz", 
-    "Lempira", 
-    "Olancho", 
-    "Ocotepeque", 
-    "Santa B\u00e1rbara", 
-    "Valle", 
+    "Atl\u00e1ntida",
+    "Chinandega",
+    "Choluteca",
+    "Col\u00f3n",
+    "Comayagua",
+    "Cort\u00e9s",
+    "Cop\u00e1n",
+    "El Para\u00edso",
+    "Francisco Moraz\u00e1n",
+    "Gracias a Dios",
+    "Honduras",
+    "Intibuc\u00e1",
+    "Islas de la Bah\u00eda",
+    "La Paz",
+    "Lempira",
+    "Olancho",
+    "Ocotepeque",
+    "Santa B\u00e1rbara",
+    "Valle",
     "Yoro"
-   ], 
+   ],
    "old": [
     "Honduras"
    ]
-  }, 
+  },
   {
-   "id": "Hungary", 
+   "id": "Hungary",
    "g": [
     {
-     "id": "Hungary_Northern Great Plain", 
-     "s": 42241641, 
+     "id": "Hungary_Northern Great Plain",
+     "s": 42241641,
      "affiliations": [
-      "Alf\u00f6ld \u00e9s \u00c9szak", 
+      "Alf\u00f6ld \u00e9s \u00c9szak",
       "Magyarorsz\u00e1g"
-     ], 
+     ],
      "old": [
       "Hungary"
      ]
-    }, 
+    },
     {
-     "id": "Hungary_Transdanubia", 
-     "s": 52141816, 
+     "id": "Hungary_Transdanubia",
+     "s": 52141816,
      "affiliations": [
-      "Dun\u00e1nt\u00fal", 
+      "Dun\u00e1nt\u00fal",
       "Magyarorsz\u00e1g"
-     ], 
+     ],
      "old": [
       "Hungary"
      ]
-    }, 
+    },
     {
-     "id": "Hungary_Kozep-Magyarorszag", 
-     "s": 28445809, 
+     "id": "Hungary_Kozep-Magyarorszag",
+     "s": 28445809,
      "affiliations": [
-      "K\u00f6z\u00e9p-Magyarorsz\u00e1g", 
+      "K\u00f6z\u00e9p-Magyarorsz\u00e1g",
       "Magyarorsz\u00e1g"
-     ], 
+     ],
      "old": [
       "Hungary"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Iceland", 
-   "s": 19324740, 
+   "id": "Iceland",
+   "s": 19324740,
    "affiliations": [
     "\u00cdsland"
-   ], 
+   ],
    "old": [
     "Iceland"
    ]
-  }, 
+  },
   {
-   "id": "India", 
+   "id": "India",
    "g": [
     {
-     "id": "India_Andaman and Nicobar Islands", 
-     "s": 1304800, 
+     "id": "India_Andaman and Nicobar Islands",
+     "s": 1304800,
      "affiliations": [
-      "Andaman and Nicobar Islands", 
+      "Andaman and Nicobar Islands",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Lakshadweep", 
-     "s": 281763, 
+     "id": "India_Lakshadweep",
+     "s": 281763,
      "affiliations": [
-      "India", 
+      "India",
       "Lakshadweep"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Andhra Pradesh", 
-     "s": 17921690, 
+     "id": "India_Andhra Pradesh",
+     "s": 17921690,
      "affiliations": [
-      "Andhra Pradesh", 
-      "India", 
+      "Andhra Pradesh",
+      "India",
       "Puducherry"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Gujarat", 
-     "s": 15664755, 
+     "id": "India_Gujarat",
+     "s": 15664755,
      "affiliations": [
-      "Gujarat", 
-      "India", 
-      "Union Territory of Dadra & Nagar Haveli", 
+      "Gujarat",
+      "India",
+      "Union Territory of Dadra & Nagar Haveli",
       "Union Territory of Damman & Diu"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Kerala", 
-     "s": 11645189, 
+     "id": "India_Kerala",
+     "s": 11645189,
      "affiliations": [
-      "India", 
+      "India",
       "Kerala"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Madhya Pradesh", 
-     "s": 17882436, 
+     "id": "India_Madhya Pradesh",
+     "s": 17882436,
      "affiliations": [
-      "India", 
+      "India",
       "Madhya Pradesh"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Rajasthan", 
-     "s": 19289787, 
+     "id": "India_Rajasthan",
+     "s": 19289787,
      "affiliations": [
-      "India", 
+      "India",
       "Rajasthan"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Tamil Nadu", 
-     "s": 28802428, 
+     "id": "India_Tamil Nadu",
+     "s": 28802428,
      "affiliations": [
-      "Cuddalore-Puducherry Administrative Boundary", 
-      "India", 
-      "Kaduvanur (Puducherry)", 
-      "Manamedu (Puducherry)", 
-      "Nettapakkam (Puducherry)", 
-      "Puducherry", 
-      "Sorapattu", 
+      "Cuddalore-Puducherry Administrative Boundary",
+      "India",
+      "Kaduvanur (Puducherry)",
+      "Manamedu (Puducherry)",
+      "Nettapakkam (Puducherry)",
+      "Puducherry",
+      "Sorapattu",
       "Tamil Nadu"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Haryana", 
-     "s": 16504952, 
+     "id": "India_Haryana",
+     "s": 16504952,
      "affiliations": [
-      "Haryana", 
+      "Haryana",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Goa", 
-     "s": 2289842, 
+     "id": "India_Goa",
+     "s": 2289842,
      "affiliations": [
-      "Goa", 
+      "Goa",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Karnataka_North", 
-     "s": 16374244, 
+     "id": "India_Karnataka_North",
+     "s": 16374244,
      "affiliations": [
-      "India", 
+      "India",
       "Karnataka"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Karnataka_South", 
-     "s": 30902061, 
+     "id": "India_Karnataka_South",
+     "s": 30902061,
      "affiliations": [
-      "India", 
+      "India",
       "Karnataka"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Maharashtra", 
-     "s": 45791376, 
+     "id": "India_Maharashtra",
+     "s": 45791376,
      "affiliations": [
-      "Ankisha", 
-      "Ganjiramannapeta", 
-      "India", 
-      "Kambalpeta", 
-      "Karnataka - Maharashtra border", 
-      "Maharashtra", 
+      "Ankisha",
+      "Ganjiramannapeta",
+      "India",
+      "Kambalpeta",
+      "Karnataka - Maharashtra border",
+      "Maharashtra",
       "Rangadhampetha"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Telangana", 
-     "s": 32905194, 
+     "id": "India_Telangana",
+     "s": 32905194,
      "affiliations": [
-      "India", 
+      "India",
       "Telangana"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Delhi", 
-     "s": 9757400, 
+     "id": "India_Delhi",
+     "s": 9757400,
      "affiliations": [
-      "Delhi", 
+      "Delhi",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Uttar Pradesh", 
-     "s": 20253515, 
+     "id": "India_Uttar Pradesh",
+     "s": 20253515,
      "affiliations": [
-      "Uttar Pradesh", 
+      "Uttar Pradesh",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Odisha", 
-     "s": 7289300, 
+     "id": "India_Odisha",
+     "s": 7289300,
      "affiliations": [
-      "India", 
+      "India",
       "Odisha"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Chhattisgarh", 
-     "s": 5726603, 
+     "id": "India_Chhattisgarh",
+     "s": 5726603,
      "affiliations": [
-      "Chhattisgarh", 
+      "Chhattisgarh",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Jharkhand", 
-     "s": 3948509, 
+     "id": "India_Jharkhand",
+     "s": 3948509,
      "affiliations": [
-      "Jharkhand", 
+      "Jharkhand",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Bihar", 
-     "s": 6274870, 
+     "id": "India_Bihar",
+     "s": 6274870,
      "affiliations": [
-      "Bihar", 
+      "Bihar",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Tripura", 
-     "s": 565687, 
+     "id": "India_Tripura",
+     "s": 565687,
      "affiliations": [
-      "India", 
+      "India",
       "Tripura"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_West Bengal", 
-     "s": 23320627, 
+     "id": "India_West Bengal",
+     "s": 23320627,
      "affiliations": [
-      "Border India - Bangladesh", 
-      "Dist. Judges Court", 
-      "India", 
+      "Border India - Bangladesh",
+      "Dist. Judges Court",
+      "India",
       "West Bengal"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Sikkim", 
-     "s": 903656, 
+     "id": "India_Sikkim",
+     "s": 903656,
      "affiliations": [
-      "India", 
+      "India",
       "Sikkim"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Uttarakhand", 
-     "s": 6500762, 
+     "id": "India_Uttarakhand",
+     "s": 6500762,
      "affiliations": [
-      "Uttarakhand", 
+      "Uttarakhand",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Mizoram", 
-     "s": 684557, 
+     "id": "India_Mizoram",
+     "s": 684557,
      "affiliations": [
-      "India", 
+      "India",
       "Mizoram"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Meghalaya", 
-     "s": 935041, 
+     "id": "India_Meghalaya",
+     "s": 935041,
      "affiliations": [
-      "India", 
+      "India",
       "Meghalaya"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Manipur", 
-     "s": 695135, 
+     "id": "India_Manipur",
+     "s": 695135,
      "affiliations": [
-      "India", 
+      "India",
       "Manipur"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Nagaland", 
-     "s": 578119, 
+     "id": "India_Nagaland",
+     "s": 578119,
      "affiliations": [
-      "India", 
+      "India",
       "Nagaland"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Assam", 
-     "s": 3147214, 
+     "id": "India_Assam",
+     "s": 3147214,
      "affiliations": [
-      "Assam", 
+      "Assam",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Arunachal Pradesh", 
-     "s": 2039651, 
+     "id": "India_Arunachal Pradesh",
+     "s": 2039651,
      "affiliations": [
-      "Arunachal Pradesh", 
+      "Arunachal Pradesh",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Himachal Pradesh", 
-     "s": 4097497, 
+     "id": "India_Himachal Pradesh",
+     "s": 4097497,
      "affiliations": [
-      "Himachal Pradesh", 
+      "Himachal Pradesh",
       "India"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Jammu and Kashmir", 
-     "s": 5352508, 
+     "id": "India_Jammu and Kashmir",
+     "s": 5352508,
      "affiliations": [
-      "India", 
+      "India",
       "Jammu and Kashmir"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Chandigarh", 
-     "s": 584138, 
+     "id": "India_Chandigarh",
+     "s": 584138,
      "affiliations": [
-      "India", 
+      "India",
       "Union Territory of Chand\u012bgarh"
-     ], 
+     ],
      "old": [
       "India"
      ]
-    }, 
+    },
     {
-     "id": "India_Punjab", 
-     "s": 6833929, 
+     "id": "India_Punjab",
+     "s": 6833929,
      "affiliations": [
-      "India", 
+      "India",
       "Punjab"
-     ], 
+     ],
      "old": [
       "India"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Indonesia", 
+   "id": "Indonesia",
    "g": [
     {
-     "id": "Indonesia_Central", 
-     "s": 54263108, 
+     "id": "Indonesia_Central",
+     "s": 54263108,
      "affiliations": [
-      "Gorontalo", 
-      "Indonesia", 
-      "Kalimantan Barat", 
-      "Kalimantan Selatan", 
-      "Kalimantan Tengah", 
-      "Kalimantan Timur", 
-      "Kalimantan Utara", 
-      "Sulawesi Tenggara", 
-      "Sulawesi Barat", 
-      "Sulawesi Selatan", 
-      "Sulawesi Tengah", 
+      "Gorontalo",
+      "Indonesia",
+      "Kalimantan Barat",
+      "Kalimantan Selatan",
+      "Kalimantan Tengah",
+      "Kalimantan Timur",
+      "Kalimantan Utara",
+      "Sulawesi Tenggara",
+      "Sulawesi Barat",
+      "Sulawesi Selatan",
+      "Sulawesi Tengah",
       "Sulawesi Utara"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_West", 
-     "s": 34459240, 
+     "id": "Indonesia_West",
+     "s": 34459240,
      "affiliations": [
-      "Aceh", 
-      "Banten", 
-      "Bengkulu", 
-      "Indonesia", 
-      "Jambi", 
-      "Lampung", 
-      "Kepulauan Bangka Belitung", 
-      "Kepulauan Riau", 
-      "Riau", 
-      "Singapura", 
-      "Sumatera Barat", 
-      "Sumatera Selatan", 
+      "Aceh",
+      "Banten",
+      "Bengkulu",
+      "Indonesia",
+      "Jambi",
+      "Lampung",
+      "Kepulauan Bangka Belitung",
+      "Kepulauan Riau",
+      "Riau",
+      "Singapura",
+      "Sumatera Barat",
+      "Sumatera Selatan",
       "Sumatera Utara"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_Jawa Tengah", 
-     "s": 28062345, 
+     "id": "Indonesia_Jawa Tengah",
+     "s": 28062345,
      "affiliations": [
-      "Daerah Istimewa Yogyakarta", 
-      "Indonesia", 
+      "Daerah Istimewa Yogyakarta",
+      "Indonesia",
       "Jawa Tengah"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_Jawa Barat", 
-     "s": 47957559, 
+     "id": "Indonesia_Jawa Barat",
+     "s": 47957559,
      "affiliations": [
-      "Banten", 
-      "Daerah Khusus Ibukota Jakarta", 
-      "Indonesia", 
+      "Banten",
+      "Daerah Khusus Ibukota Jakarta",
+      "Indonesia",
       "Jawa Barat"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_Nusa Tenggara", 
-     "s": 37754741, 
+     "id": "Indonesia_Nusa Tenggara",
+     "s": 37754741,
      "affiliations": [
-      "Bali", 
-      "Batas Dusun Muntigunung Induk", 
-      "Batas Dusun Muntigunung Tengah", 
-      "Indonesia", 
-      "Nusa Tenggara Barat", 
+      "Bali",
+      "Batas Dusun Muntigunung Induk",
+      "Batas Dusun Muntigunung Tengah",
+      "Indonesia",
+      "Nusa Tenggara Barat",
       "Nusa Tenggara Timur"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_Jawa Timur", 
-     "s": 45754610, 
+     "id": "Indonesia_Jawa Timur",
+     "s": 45754610,
      "affiliations": [
-      "Indonesia", 
+      "Indonesia",
       "Jawa Timur"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
-    }, 
+    },
     {
-     "id": "Indonesia_East", 
-     "s": 12263851, 
+     "id": "Indonesia_East",
+     "s": 12263851,
      "affiliations": [
-      "Indonesia", 
-      "Maluku", 
-      "Maluku Utara", 
-      "Papua Barat", 
+      "Indonesia",
+      "Maluku",
+      "Maluku Utara",
+      "Papua Barat",
       "Papua"
-     ], 
+     ],
      "old": [
       "Indonesia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Iran", 
+   "id": "Iran",
    "g": [
     {
-     "id": "Iran_East", 
-     "s": 14376517, 
+     "id": "Iran_East",
+     "s": 14376517,
      "affiliations": [
-      "\u06cc\u0632\u062f\u200e", 
-      "\u06a9\u0631\u0645\u0627\u0646", 
-      "\u0633\u06cc\u0633\u062a\u0627\u0646 \u0648 \u0628\u0644\u0648\u0686\u0633\u062a\u0627\u0646\u200e", 
-      "\u062e\u0631\u0627\u0633\u0627\u0646 \u0631\u0636\u0648\u06cc\u200e", 
-      "\u062e\u0631\u0627\u0633\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc\u200e", 
-      "\u062e\u0631\u0627\u0633\u0627\u0646 \u0634\u0645\u0627\u0644\u06cc\u200e", 
+      "\u06cc\u0632\u062f\u200e",
+      "\u06a9\u0631\u0645\u0627\u0646",
+      "\u0633\u06cc\u0633\u062a\u0627\u0646 \u0648 \u0628\u0644\u0648\u0686\u0633\u062a\u0627\u0646\u200e",
+      "\u062e\u0631\u0627\u0633\u0627\u0646 \u0631\u0636\u0648\u06cc\u200e",
+      "\u062e\u0631\u0627\u0633\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc\u200e",
+      "\u062e\u0631\u0627\u0633\u0627\u0646 \u0634\u0645\u0627\u0644\u06cc\u200e",
       "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc\u200f\u0627\u064a\u0631\u0627\u0646\u200e"
-     ], 
+     ],
      "old": [
       "Iran"
      ]
-    }, 
+    },
     {
-     "id": "Iran_South", 
-     "s": 31771829, 
+     "id": "Iran_South",
+     "s": 31771829,
      "affiliations": [
-      "\u0644\u0631\u0633\u062a\u0627\u0646\u200e", 
-      "\u0641\u0627\u0631\u0633\u200e", 
-      "\u0645\u0631\u06a9\u0632\u06cc", 
-      "\u0627\u0635\u0641\u0647\u0627\u0646", 
-      "\u0627\u06cc\u0644\u0627\u0645\u200e", 
-      "\u0628\u0648\u0634\u0647\u0631\u200e", 
-      "\u0647\u0645\u062f\u0627\u0646\u200e", 
-      "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc\u200f\u0627\u064a\u0631\u0627\u0646\u200e", 
-      "\u062e\u0648\u0632\u0633\u062a\u0627\u0646\u200e", 
-      "\u06a9\u0631\u062f\u0633\u062a\u0627\u0646\u200e", 
-      "\u06a9\u0647\u06af\u06cc\u0644\u0648\u06cc\u0647 \u0648 \u0628\u0648\u06cc\u0631 \u0627\u062d\u0645\u062f", 
-      "\u0686\u0647\u0627\u0631\u0645\u062d\u0627\u0644 \u0648 \u0628\u062e\u062a\u06cc\u0627\u0631\u06cc\u200e", 
-      "\u06a9\u0631\u0645\u0627\u0646\u0634\u0627\u0647\u200e", 
+      "\u0644\u0631\u0633\u062a\u0627\u0646\u200e",
+      "\u0641\u0627\u0631\u0633\u200e",
+      "\u0645\u0631\u06a9\u0632\u06cc",
+      "\u0627\u0635\u0641\u0647\u0627\u0646",
+      "\u0627\u06cc\u0644\u0627\u0645\u200e",
+      "\u0628\u0648\u0634\u0647\u0631\u200e",
+      "\u0647\u0645\u062f\u0627\u0646\u200e",
+      "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc\u200f\u0627\u064a\u0631\u0627\u0646\u200e",
+      "\u062e\u0648\u0632\u0633\u062a\u0627\u0646\u200e",
+      "\u06a9\u0631\u062f\u0633\u062a\u0627\u0646\u200e",
+      "\u06a9\u0647\u06af\u06cc\u0644\u0648\u06cc\u0647 \u0648 \u0628\u0648\u06cc\u0631 \u0627\u062d\u0645\u062f",
+      "\u0686\u0647\u0627\u0631\u0645\u062d\u0627\u0644 \u0648 \u0628\u062e\u062a\u06cc\u0627\u0631\u06cc\u200e",
+      "\u06a9\u0631\u0645\u0627\u0646\u0634\u0627\u0647\u200e",
       "\u200f\u0647\u0631\u0645\u0632\u06af\u0627\u0646\u200e"
-     ], 
+     ],
      "old": [
       "Iran"
      ]
-    }, 
+    },
     {
-     "id": "Iran_North", 
-     "s": 33529224, 
+     "id": "Iran_North",
+     "s": 33529224,
      "affiliations": [
-      "\u0642\u0645\u200e", 
-      "\u0627\u0644\u0628\u0631\u0632", 
-      "\u062a\u0647\u0631\u0627\u0646", 
-      "\u0632\u0646\u062c\u0627\u0646\u200e", 
-      "\u0633\u0645\u0646\u0627\u0646\u200e", 
-      "\u0642\u0632\u0648\u06cc\u0646\u200e", 
-      "\u06af\u0644\u0633\u062a\u0627\u0646", 
-      "\u06af\u064a\u0644\u0627\u0646\u200e", 
-      "\u0627\u0631\u062f\u0628\u06cc\u0644\u200e", 
-      "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc\u200f\u0627\u064a\u0631\u0627\u0646\u200e", 
-      "\u06a9\u0631\u062f\u0633\u062a\u0627\u0646\u200e", 
-      "\u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646 \u063a\u0631\u0628\u06cc\u200e", 
-      "\u0645\u0627\u0632\u0646\u062f\u0631\u0627\u0646\u200e", 
-      "\u06a9\u0631\u0645\u0627\u0646\u0634\u0627\u0647\u200e", 
+      "\u0642\u0645\u200e",
+      "\u0627\u0644\u0628\u0631\u0632",
+      "\u062a\u0647\u0631\u0627\u0646",
+      "\u0632\u0646\u062c\u0627\u0646\u200e",
+      "\u0633\u0645\u0646\u0627\u0646\u200e",
+      "\u0642\u0632\u0648\u06cc\u0646\u200e",
+      "\u06af\u0644\u0633\u062a\u0627\u0646",
+      "\u06af\u064a\u0644\u0627\u0646\u200e",
+      "\u0627\u0631\u062f\u0628\u06cc\u0644\u200e",
+      "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc\u200f\u0627\u064a\u0631\u0627\u0646\u200e",
+      "\u06a9\u0631\u062f\u0633\u062a\u0627\u0646\u200e",
+      "\u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646 \u063a\u0631\u0628\u06cc\u200e",
+      "\u0645\u0627\u0632\u0646\u062f\u0631\u0627\u0646\u200e",
+      "\u06a9\u0631\u0645\u0627\u0646\u0634\u0627\u0647\u200e",
       "\u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646 \u0634\u0631\u0642\u06cc"
-     ], 
+     ],
      "old": [
       "Iran"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Iraq", 
+   "id": "Iraq",
    "g": [
     {
-     "id": "Iraq_North", 
-     "s": 21321629, 
+     "id": "Iraq_North",
+     "s": 21321629,
      "affiliations": [
-      "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0627\u0642", 
-      "garaki handren", 
-      "\u062f\u0647\u0648\u0643", 
-      "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646", 
-      "\u0623\u0631\u0628\u064a\u0644", 
-      "\u062d\u0644\u0628\u062c\u0629", 
-      "\u062f\u064a\u0627\u0644\u0649", 
-      "\u0643\u0631\u0643\u0648\u0643", 
-      "\u0646\u06cc\u0646\u0648\u0649", 
-      "\u0627\u0644\u0623\u0646\u0628\u0627\u0631", 
+      "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0627\u0642",
+      "garaki handren",
+      "\u062f\u0647\u0648\u0643",
+      "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646",
+      "\u0623\u0631\u0628\u064a\u0644",
+      "\u062d\u0644\u0628\u062c\u0629",
+      "\u062f\u064a\u0627\u0644\u0649",
+      "\u0643\u0631\u0643\u0648\u0643",
+      "\u0646\u06cc\u0646\u0648\u0649",
+      "\u0627\u0644\u0623\u0646\u0628\u0627\u0631",
       "\u0627\u0644\u0633\u0644\u064a\u0645\u0627\u0646\u064a\u0629"
-     ], 
+     ],
      "old": [
       "Iraq"
      ]
-    }, 
+    },
     {
-     "id": "Iraq_South", 
-     "s": 18647733, 
+     "id": "Iraq_South",
+     "s": 18647733,
      "affiliations": [
-      "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0627\u0642", 
-      "\u0630\u064a \u0642\u0627\u0631", 
-      "\u0628\u0627\u0628\u0644", 
-      "\u0648\u0627\u0633\u0637", 
-      "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646", 
-      "\u0627\u0644\u0646\u062c\u0641", 
-      "\u062f\u064a\u0627\u0644\u0649", 
-      "\u0645\u064a\u0633\u0627\u0646", 
-      "\u0627\u0644\u0645\u062b\u0646\u0649", 
-      "\u0627\u0644\u0628\u0635\u0631\u0629", 
-      "\u0643\u0631\u0628\u0644\u0627\u0621", 
-      "\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u063a\u062f\u0627\u062f", 
-      "\u0627\u0644\u0623\u0646\u0628\u0627\u0631", 
+      "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0627\u0642",
+      "\u0630\u064a \u0642\u0627\u0631",
+      "\u0628\u0627\u0628\u0644",
+      "\u0648\u0627\u0633\u0637",
+      "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646",
+      "\u0627\u0644\u0646\u062c\u0641",
+      "\u062f\u064a\u0627\u0644\u0649",
+      "\u0645\u064a\u0633\u0627\u0646",
+      "\u0627\u0644\u0645\u062b\u0646\u0649",
+      "\u0627\u0644\u0628\u0635\u0631\u0629",
+      "\u0643\u0631\u0628\u0644\u0627\u0621",
+      "\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u063a\u062f\u0627\u062f",
+      "\u0627\u0644\u0623\u0646\u0628\u0627\u0631",
       "\u0627\u0644\u0642\u0627\u062f\u0633\u064a\u0629"
-     ], 
+     ],
      "old": [
       "Iraq"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Isle of Man", 
-   "s": 1830769, 
+   "id": "Isle of Man",
+   "s": 1830769,
    "affiliations": [
-    "Isle of Man", 
-    "Scotland", 
+    "Isle of Man",
+    "Scotland",
     "United Kingdom"
-   ], 
+   ],
    "old": [
     "Isle of Man"
    ]
-  }, 
+  },
   {
-   "id": "Israel Region", 
+   "id": "Israel Region",
    "g": [
     {
-     "id": "Jerusalem", 
-     "s": 3693857, 
+     "id": "Jerusalem",
+     "s": 3693857,
      "affiliations": [
-      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd", 
+      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd",
       "\u05de\u05d3\u05d9\u05e0\u05ea \u05d9\u05e9\u05e8\u05d0\u05dc"
-     ], 
+     ],
      "old": [
-      "Israel", 
+      "Israel",
       "Palestine"
      ]
-    }, 
+    },
     {
-     "id": "Israel", 
-     "s": 37406679, 
+     "id": "Israel",
+     "s": 37406679,
      "affiliations": [
-      "\u05de\u05d7\u05d5\u05d6 \u05d7\u05d9\u05e4\u05d4", 
-      "\u05de\u05d7\u05d5\u05d6 \u05ea\u05dc \u05d0\u05d1\u05d9\u05d1", 
-      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05d3\u05e8\u05d5\u05dd", 
-      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05de\u05e8\u05db\u05d6", 
-      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05e6\u05e4\u05d5\u05df", 
-      "\u0642\u0636\u0627\u0621 \u062d\u0627\u0635\u0628\u064a\u0627", 
-      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd", 
+      "\u05de\u05d7\u05d5\u05d6 \u05d7\u05d9\u05e4\u05d4",
+      "\u05de\u05d7\u05d5\u05d6 \u05ea\u05dc \u05d0\u05d1\u05d9\u05d1",
+      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05d3\u05e8\u05d5\u05dd",
+      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05de\u05e8\u05db\u05d6",
+      "\u05de\u05d7\u05d5\u05d6 \u05d4\u05e6\u05e4\u05d5\u05df",
+      "\u0642\u0636\u0627\u0621 \u062d\u0627\u0635\u0628\u064a\u0627",
+      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd",
       "\u05de\u05d3\u05d9\u05e0\u05ea \u05d9\u05e9\u05e8\u05d0\u05dc"
-     ], 
+     ],
      "old": [
       "Israel"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Italy", 
+   "id": "Italy",
    "g": [
     {
-     "id": "Italy_Abruzzo", 
-     "s": 12436716, 
+     "id": "Italy_Abruzzo",
+     "s": 12436716,
      "affiliations": [
-      "Abruzzo", 
+      "Abruzzo",
       "Italia"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Aosta Valley", 
-     "s": 8756961, 
+     "id": "Italy_Aosta Valley",
+     "s": 8756961,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Valle d'Aosta/Vall\u00e9e d'Aoste"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Apulia", 
-     "s": 74624294, 
+     "id": "Italy_Apulia",
+     "s": 74624294,
      "affiliations": [
-      "Isola della Chianca", 
-      "Isola della Malva", 
-      "Isola Sant'Andrea", 
-      "Isola dei Conigli", 
-      "Isola del Campo", 
-      "Italia", 
+      "Isola della Chianca",
+      "Isola della Malva",
+      "Isola Sant'Andrea",
+      "Isola dei Conigli",
+      "Isola del Campo",
+      "Italia",
       "Puglia"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Basilicata", 
-     "s": 9316120, 
+     "id": "Italy_Basilicata",
+     "s": 9316120,
      "affiliations": [
-      "Basilicata", 
+      "Basilicata",
       "Italia"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Calabria", 
-     "s": 20116383, 
+     "id": "Italy_Calabria",
+     "s": 20116383,
      "affiliations": [
-      "Calabria", 
-      "Isola di Cirella", 
-      "Isola di Dino", 
+      "Calabria",
+      "Isola di Cirella",
+      "Isola di Dino",
       "Italia"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Campania", 
-     "s": 24476284, 
+     "id": "Italy_Campania",
+     "s": 24476284,
      "affiliations": [
-      "Campania", 
-      "Isola Licosa", 
-      "Il Gallo Lungo", 
-      "Isola di Vivara", 
-      "Italia", 
-      "La Rotonda", 
-      "La Castelluccia", 
+      "Campania",
+      "Isola Licosa",
+      "Il Gallo Lungo",
+      "Isola di Vivara",
+      "Italia",
+      "La Rotonda",
+      "La Castelluccia",
       "Scoglio Rovigliano"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Emilia", 
+     "id": "Italy_Emilia",
      "g": [
       {
-       "id": "Italy_Emilia-Romagna_Bologna", 
-       "s": 24537814, 
+       "id": "Italy_Emilia-Romagna_Bologna",
+       "s": 24537814,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Ferrara", 
-       "s": 11609857, 
+       "id": "Italy_Emilia-Romagna_Ferrara",
+       "s": 11609857,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Forli-Cesena", 
-       "s": 11205354, 
+       "id": "Italy_Emilia-Romagna_Forli-Cesena",
+       "s": 11205354,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Modena", 
-       "s": 22694717, 
+       "id": "Italy_Emilia-Romagna_Modena",
+       "s": 22694717,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Parma", 
-       "s": 15432630, 
+       "id": "Italy_Emilia-Romagna_Parma",
+       "s": 15432630,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Piacenza", 
-       "s": 9810338, 
+       "id": "Italy_Emilia-Romagna_Piacenza",
+       "s": 9810338,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Ravenna", 
-       "s": 10550506, 
+       "id": "Italy_Emilia-Romagna_Ravenna",
+       "s": 10550506,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Reggio Emilia", 
-       "s": 13481361, 
+       "id": "Italy_Emilia-Romagna_Reggio Emilia",
+       "s": 13481361,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Emilia-Romagna_Rimini", 
-       "s": 8158120, 
+       "id": "Italy_Emilia-Romagna_Rimini",
+       "s": 8158120,
        "affiliations": [
-        "Emilia-Romagna", 
+        "Emilia-Romagna",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Italy_Friuli", 
+     "id": "Italy_Friuli",
      "g": [
       {
-       "id": "Italy_Friuli-Venezia Giulia_Gorizia", 
-       "s": 6688476, 
+       "id": "Italy_Friuli-Venezia Giulia_Gorizia",
+       "s": 6688476,
        "affiliations": [
-        "Friuli Venezia Giulia", 
+        "Friuli Venezia Giulia",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Friuli-Venezia Giulia_Pordenone", 
-       "s": 17053160, 
+       "id": "Italy_Friuli-Venezia Giulia_Pordenone",
+       "s": 17053160,
        "affiliations": [
-        "Friuli Venezia Giulia", 
+        "Friuli Venezia Giulia",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Friuli-Venezia Giulia_Trieste", 
-       "s": 6200005, 
+       "id": "Italy_Friuli-Venezia Giulia_Trieste",
+       "s": 6200005,
        "affiliations": [
-        "Friuli Venezia Giulia", 
+        "Friuli Venezia Giulia",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Friuli-Venezia Giulia_Udine", 
-       "s": 37324620, 
+       "id": "Italy_Friuli-Venezia Giulia_Udine",
+       "s": 37324620,
        "affiliations": [
-        "Friuli Venezia Giulia", 
+        "Friuli Venezia Giulia",
         "Italia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Italy_Lazio", 
-     "s": 43679904, 
+     "id": "Italy_Lazio",
+     "s": 43679904,
      "affiliations": [
-      "Civitatis Vatican\u00e6", 
-      "Gavi", 
-      "Zannone", 
-      "Italia", 
-      "Lazio", 
-      "Palmarola", 
+      "Civitatis Vatican\u00e6",
+      "Gavi",
+      "Zannone",
+      "Italia",
+      "Lazio",
+      "Palmarola",
       "Ventotene"
-     ], 
+     ],
      "old": [
-      "Italy", 
+      "Italy",
       "Vatican"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Liguria", 
-     "s": 40194795, 
+     "id": "Italy_Liguria",
+     "s": 40194795,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Liguria"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Lombardy", 
+     "id": "Italy_Lombardy",
      "g": [
       {
-       "id": "Italy_Lombardy_Bergamo", 
-       "s": 12751753, 
+       "id": "Italy_Lombardy_Bergamo",
+       "s": 12751753,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Brescia", 
-       "s": 19284167, 
+       "id": "Italy_Lombardy_Brescia",
+       "s": 19284167,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Como", 
-       "s": 9503378, 
+       "id": "Italy_Lombardy_Como",
+       "s": 9503378,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Cremona", 
-       "s": 4070774, 
+       "id": "Italy_Lombardy_Cremona",
+       "s": 4070774,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Lecco", 
-       "s": 7098328, 
+       "id": "Italy_Lombardy_Lecco",
+       "s": 7098328,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Lodi", 
-       "s": 3162707, 
+       "id": "Italy_Lombardy_Lodi",
+       "s": 3162707,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Mantua", 
-       "s": 5017029, 
+       "id": "Italy_Lombardy_Mantua",
+       "s": 5017029,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Milan", 
-       "s": 22088166, 
+       "id": "Italy_Lombardy_Milan",
+       "s": 22088166,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Monza and Brianza", 
-       "s": 7298053, 
+       "id": "Italy_Lombardy_Monza and Brianza",
+       "s": 7298053,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Pavia", 
-       "s": 20266752, 
+       "id": "Italy_Lombardy_Pavia",
+       "s": 20266752,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Sondrio", 
-       "s": 7383271, 
+       "id": "Italy_Lombardy_Sondrio",
+       "s": 7383271,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Lombardy_Varese", 
-       "s": 11429214, 
+       "id": "Italy_Lombardy_Varese",
+       "s": 11429214,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Lombardia"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Italy_Marche", 
-     "s": 19279355, 
+     "id": "Italy_Marche",
+     "s": 19279355,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Marche"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Molise", 
-     "s": 6394009, 
+     "id": "Italy_Molise",
+     "s": 6394009,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Molise"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Piemont", 
+     "id": "Italy_Piemont",
      "g": [
       {
-       "id": "Italy_Piemont_Alessandria", 
-       "s": 10265349, 
+       "id": "Italy_Piemont_Alessandria",
+       "s": 10265349,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Asti", 
-       "s": 3754436, 
+       "id": "Italy_Piemont_Asti",
+       "s": 3754436,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Biella", 
-       "s": 3797439, 
+       "id": "Italy_Piemont_Biella",
+       "s": 3797439,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Cuneo", 
-       "s": 23252354, 
+       "id": "Italy_Piemont_Cuneo",
+       "s": 23252354,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Novara", 
-       "s": 6729707, 
+       "id": "Italy_Piemont_Novara",
+       "s": 6729707,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Torino", 
-       "s": 25776332, 
+       "id": "Italy_Piemont_Torino",
+       "s": 25776332,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Verbano-Cusio-Ossola", 
-       "s": 5721953, 
+       "id": "Italy_Piemont_Verbano-Cusio-Ossola",
+       "s": 5721953,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Piemont_Vercelli", 
-       "s": 6288348, 
+       "id": "Italy_Piemont_Vercelli",
+       "s": 6288348,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Piemonte"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Italy_Sardinia", 
-     "s": 60211575, 
+     "id": "Italy_Sardinia",
+     "s": 60211575,
      "affiliations": [
-      "Isola Tuaredda", 
-      "Isola de Sa tonnara", 
-      "Isola del Toro", 
-      "Isola di Campionna", 
-      "Isola Rossa", 
-      "Isola Sa mesa longa", 
-      "Isola San Macario", 
-      "Isola dei Ratti", 
-      "Italia", 
-      "Scoglio Pan di Zucchero", 
-      "Sardigna/Sardegna", 
+      "Isola Tuaredda",
+      "Isola de Sa tonnara",
+      "Isola del Toro",
+      "Isola di Campionna",
+      "Isola Rossa",
+      "Isola Sa mesa longa",
+      "Isola San Macario",
+      "Isola dei Ratti",
+      "Italia",
+      "Scoglio Pan di Zucchero",
+      "Sardigna/Sardegna",
       "Scoglio Il Catalano"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Sicily", 
-     "s": 51753145, 
+     "id": "Italy_Sicily",
+     "s": 51753145,
      "affiliations": [
-      "Isola dei Cani", 
-      "Isola delle Correnti", 
-      "Isola Formica", 
-      "Isola Lachea", 
-      "Isola Marettimo", 
-      "Isola Piccola", 
-      "Isola delle Femmine", 
-      "Faraglione Grande", 
-      "Faraglione Mezzano", 
-      "Faraglione Piccolo", 
-      "Faraglione di Tracino", 
-      "Galeotta", 
-      "Isola di Capo Passero", 
-      "Il Faraglione", 
-      "Isolotto di Ognina", 
-      "Isola Colombaia", 
-      "Isola San Pantaleo", 
-      "Isola Santa Maria", 
-      "Isola dei Conigli", 
-      "Isola dei Porri", 
-      "Isolotto Bottaro", 
-      "Isolotto Lisca Bianca", 
-      "Italia", 
-      "Lampione", 
-      "Preveto", 
-      "Pietra Quaglietto", 
-      "Territorial waters of Italy - Ustica", 
-      "Testa di Monaco", 
-      "Rocca San Nicola", 
-      "Scoglio Scibiliana", 
-      "Scoglio Spinazzola", 
-      "Scoglio a Pizzo", 
-      "Scoglio del Sacramento", 
-      "Scoglio di Maraone", 
-      "Scola", 
-      "Scoglio Faraglione", 
-      "Scoglio Grande", 
-      "Scoglio Palumbo", 
+      "Isola dei Cani",
+      "Isola delle Correnti",
+      "Isola Formica",
+      "Isola Lachea",
+      "Isola Marettimo",
+      "Isola Piccola",
+      "Isola delle Femmine",
+      "Faraglione Grande",
+      "Faraglione Mezzano",
+      "Faraglione Piccolo",
+      "Faraglione di Tracino",
+      "Galeotta",
+      "Isola di Capo Passero",
+      "Il Faraglione",
+      "Isolotto di Ognina",
+      "Isola Colombaia",
+      "Isola San Pantaleo",
+      "Isola Santa Maria",
+      "Isola dei Conigli",
+      "Isola dei Porri",
+      "Isolotto Bottaro",
+      "Isolotto Lisca Bianca",
+      "Italia",
+      "Lampione",
+      "Preveto",
+      "Pietra Quaglietto",
+      "Territorial waters of Italy - Ustica",
+      "Testa di Monaco",
+      "Rocca San Nicola",
+      "Scoglio Scibiliana",
+      "Scoglio Spinazzola",
+      "Scoglio a Pizzo",
+      "Scoglio del Sacramento",
+      "Scoglio di Maraone",
+      "Scola",
+      "Scoglio Faraglione",
+      "Scoglio Grande",
+      "Scoglio Palumbo",
       "Sicilia"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Trentino-Alto Adige Sudtirol", 
-     "s": 55190706, 
+     "id": "Italy_Trentino-Alto Adige Sudtirol",
+     "s": 55190706,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Trentino-Alto Adige/S\u00fcdtirol"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Tuscany_Grosseto", 
-     "s": 20386525, 
+     "id": "Italy_Tuscany_Grosseto",
+     "s": 20386525,
      "affiliations": [
-      "Formica Piccola", 
-      "Formica Grande", 
-      "Formica III", 
-      "Giannutri", 
-      "Isolotto dello Sparviero", 
-      "Italia", 
-      "Le Scole", 
+      "Formica Piccola",
+      "Formica Grande",
+      "Formica III",
+      "Giannutri",
+      "Isolotto dello Sparviero",
+      "Italia",
+      "Le Scole",
       "Toscana"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Tuscany_Massa e Carrara", 
-     "s": 46140781, 
+     "id": "Italy_Tuscany_Massa e Carrara",
+     "s": 46140781,
      "affiliations": [
-      "Cerboli", 
-      "Isola della Peraiola", 
-      "Gorgona", 
-      "Il Frate", 
-      "Isole Gemini", 
-      "Italia", 
-      "Palmaiola", 
-      "Scoglio d'Africa", 
+      "Cerboli",
+      "Isola della Peraiola",
+      "Gorgona",
+      "Il Frate",
+      "Isole Gemini",
+      "Italia",
+      "Palmaiola",
+      "Scoglio d'Africa",
       "Toscana"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Umbria", 
-     "s": 17534488, 
+     "id": "Italy_Umbria",
+     "s": 17534488,
      "affiliations": [
-      "Italia", 
+      "Italia",
       "Umbria"
-     ], 
+     ],
      "old": [
       "Italy"
      ]
-    }, 
+    },
     {
-     "id": "Italy_Veneto", 
+     "id": "Italy_Veneto",
      "g": [
       {
-       "id": "Italy_Veneto_Belluno", 
-       "s": 11838513, 
+       "id": "Italy_Veneto_Belluno",
+       "s": 11838513,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Padova", 
-       "s": 21863787, 
+       "id": "Italy_Veneto_Padova",
+       "s": 21863787,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Rovigo", 
-       "s": 8026470, 
+       "id": "Italy_Veneto_Rovigo",
+       "s": 8026470,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Treviso", 
-       "s": 29242340, 
+       "id": "Italy_Veneto_Treviso",
+       "s": 29242340,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Venezia", 
-       "s": 18168662, 
+       "id": "Italy_Veneto_Venezia",
+       "s": 18168662,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Verona", 
-       "s": 25737353, 
+       "id": "Italy_Veneto_Verona",
+       "s": 25737353,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
-      }, 
+      },
       {
-       "id": "Italy_Veneto_Vicenza", 
-       "s": 25275809, 
+       "id": "Italy_Veneto_Vicenza",
+       "s": 25275809,
        "affiliations": [
-        "Italia", 
+        "Italia",
         "Veneto"
-       ], 
+       ],
        "old": [
         "Italy"
        ]
@@ -7010,620 +7010,620 @@
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Jamaica", 
-   "s": 5606160, 
+   "id": "Jamaica",
+   "s": 5606160,
    "affiliations": [
     "Jamaica"
-   ], 
+   ],
    "old": [
     "Jamaica"
    ]
-  }, 
+  },
   {
-   "id": "Japan", 
+   "id": "Japan",
    "g": [
     {
-     "id": "Japan_Chubu Region", 
+     "id": "Japan_Chubu Region",
      "g": [
       {
-       "id": "Japan_Chubu Region_Aichi_Nagoya", 
-       "s": 23895434, 
+       "id": "Japan_Chubu Region_Aichi_Nagoya",
+       "s": 23895434,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u4e09\u91cd\u770c", 
+        "\u65e5\u672c",
+        "\u4e09\u91cd\u770c",
         "\u611b\u77e5\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Aichi_Toyohashi", 
-       "s": 11384927, 
+       "id": "Japan_Chubu Region_Aichi_Toyohashi",
+       "s": 11384927,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u611b\u77e5\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Fukui", 
-       "s": 8683887, 
+       "id": "Japan_Chubu Region_Fukui",
+       "s": 8683887,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u798f\u4e95\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Gifu", 
-       "s": 16947351, 
+       "id": "Japan_Chubu Region_Gifu",
+       "s": 16947351,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5c90\u961c\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Ishikawa", 
-       "s": 8733187, 
+       "id": "Japan_Chubu Region_Ishikawa",
+       "s": 8733187,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u77f3\u5ddd\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Nagano", 
-       "s": 23184467, 
+       "id": "Japan_Chubu Region_Nagano",
+       "s": 23184467,
        "affiliations": [
-        "\u9577\u91ce\u770c", 
+        "\u9577\u91ce\u770c",
         "\u65e5\u672c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Niigata", 
-       "s": 22799257, 
+       "id": "Japan_Chubu Region_Niigata",
+       "s": 22799257,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u65b0\u6f5f\u770c", 
+        "\u65e5\u672c",
+        "\u65b0\u6f5f\u770c",
         "\u77f3\u5ddd\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Shizuoka", 
-       "s": 36527608, 
+       "id": "Japan_Chubu Region_Shizuoka",
+       "s": 36527608,
        "affiliations": [
-        "\u9759\u5ca1\u770c", 
+        "\u9759\u5ca1\u770c",
         "\u65e5\u672c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Toyama", 
-       "s": 7532563, 
+       "id": "Japan_Chubu Region_Toyama",
+       "s": 7532563,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u5bcc\u5c71\u770c", 
+        "\u65e5\u672c",
+        "\u5bcc\u5c71\u770c",
         "\u77f3\u5ddd\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chubu Region_Yamanashi", 
-       "s": 11355941, 
+       "id": "Japan_Chubu Region_Yamanashi",
+       "s": 11355941,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5c71\u68a8\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chubu"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Japan_Chugoku Region", 
+     "id": "Japan_Chugoku Region",
      "g": [
       {
-       "id": "Japan_Chugoku Region_Hiroshima", 
-       "s": 25484813, 
+       "id": "Japan_Chugoku Region_Hiroshima",
+       "s": 25484813,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5e83\u5cf6\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chugoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chugoku Region_Okayama", 
-       "s": 15789630, 
+       "id": "Japan_Chugoku Region_Okayama",
+       "s": 15789630,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5ca1\u5c71\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chugoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chugoku Region_Shimane", 
-       "s": 12497805, 
+       "id": "Japan_Chugoku Region_Shimane",
+       "s": 12497805,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5cf6\u6839\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chugoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chugoku Region_Tottori", 
-       "s": 13328685, 
+       "id": "Japan_Chugoku Region_Tottori",
+       "s": 13328685,
        "affiliations": [
-        "\u9ce5\u53d6\u770c", 
+        "\u9ce5\u53d6\u770c",
         "\u65e5\u672c"
-       ], 
+       ],
        "old": [
         "Japan_Chugoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Chugoku Region_Yamaguchi", 
-       "s": 13593564, 
+       "id": "Japan_Chugoku Region_Yamaguchi",
+       "s": 13593564,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5c71\u53e3\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Chugoku"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Japan_Hokkaido Region", 
+     "id": "Japan_Hokkaido Region",
      "g": [
       {
-       "id": "Japan_Hokkaido Region_East", 
-       "s": 16151009, 
+       "id": "Japan_Hokkaido Region_East",
+       "s": 16151009,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5317\u6d77\u9053"
-       ], 
+       ],
        "old": [
         "Japan_Hokkaido"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Hokkaido Region_North", 
-       "s": 27796796, 
+       "id": "Japan_Hokkaido Region_North",
+       "s": 27796796,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5317\u6d77\u9053"
-       ], 
+       ],
        "old": [
         "Japan_Hokkaido"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Hokkaido Region_West", 
-       "s": 13464550, 
+       "id": "Japan_Hokkaido Region_West",
+       "s": 13464550,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5317\u6d77\u9053"
-       ], 
+       ],
        "old": [
         "Japan_Hokkaido"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Hokkaido Region_Sapporo", 
-       "s": 32045345, 
+       "id": "Japan_Hokkaido Region_Sapporo",
+       "s": 32045345,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5317\u6d77\u9053"
-       ], 
+       ],
        "old": [
         "Japan_Hokkaido"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Japan_Kanto", 
+     "id": "Japan_Kanto",
      "g": [
       {
-       "id": "Japan_Kanto_Chiba", 
-       "s": 24211827, 
+       "id": "Japan_Kanto_Chiba",
+       "s": 24211827,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u5343\u8449\u770c", 
-        "\u6771\u4eac\u90fd", 
+        "\u65e5\u672c",
+        "\u5343\u8449\u770c",
+        "\u6771\u4eac\u90fd",
         "\u795e\u5948\u5ddd\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Gunma", 
-       "s": 15154684, 
+       "id": "Japan_Kanto_Gunma",
+       "s": 15154684,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u7fa4\u99ac\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Ibaraki", 
-       "s": 16640263, 
+       "id": "Japan_Kanto_Ibaraki",
+       "s": 16640263,
        "affiliations": [
-        "\u8328\u57ce\u770c", 
-        "\u65e5\u672c", 
-        "\u5343\u8449\u770c", 
+        "\u8328\u57ce\u770c",
+        "\u65e5\u672c",
+        "\u5343\u8449\u770c",
         "\u798f\u5cf6\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Kanagawa", 
-       "s": 32580232, 
+       "id": "Japan_Kanto_Kanagawa",
+       "s": 32580232,
        "affiliations": [
-        "\u9759\u5ca1\u770c", 
-        "\u65e5\u672c", 
-        "\u5343\u8449\u770c", 
-        "\u6771\u4eac\u90fd", 
+        "\u9759\u5ca1\u770c",
+        "\u65e5\u672c",
+        "\u5343\u8449\u770c",
+        "\u6771\u4eac\u90fd",
         "\u795e\u5948\u5ddd\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Saitama", 
-       "s": 20409040, 
+       "id": "Japan_Kanto_Saitama",
+       "s": 20409040,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u57fc\u7389\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Tochigi", 
-       "s": 14775011, 
+       "id": "Japan_Kanto_Tochigi",
+       "s": 14775011,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u6803\u6728\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Kanto_Tokyo", 
-       "s": 37084583, 
+       "id": "Japan_Kanto_Tokyo",
+       "s": 37084583,
        "affiliations": [
-        "\u9759\u5ca1\u770c", 
-        "\u65e5\u672c", 
+        "\u9759\u5ca1\u770c",
+        "\u65e5\u672c",
         "\u6771\u4eac\u90fd"
-       ], 
+       ],
        "old": [
         "Japan_Kanto"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Japan_Kinki Region", 
+     "id": "Japan_Kinki Region",
      "g": [
       {
-       "id": "Japan_Kinki Region_Mie", 
-       "s": 14149459, 
+       "id": "Japan_Shikoku Region_Kyoto",
+       "s": 25436561,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u4e09\u91cd\u770c", 
-        "\u611b\u77e5\u770c"
-       ], 
-       "old": [
-        "Japan_Kinki"
-       ]
-      }, 
-      {
-       "id": "Japan_Kinki Region_Nara", 
-       "s": 9702735, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u5948\u826f\u770c", 
-        "\u548c\u6b4c\u5c71\u770c"
-       ], 
-       "old": [
-        "Japan_Kinki"
-       ]
-      }, 
-      {
-       "id": "Japan_Kinki Region_Osaka_Osaka", 
-       "s": 28090782, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u5175\u5eab\u770c", 
-        "\u5927\u962a\u5e9c"
-       ], 
-       "old": [
-        "Japan_Kinki"
-       ]
-      }, 
-      {
-       "id": "Japan_Kinki Region_Osaka_West", 
-       "s": 21245824, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u5175\u5eab\u770c"
-       ], 
-       "old": [
-        "Japan_Kinki"
-       ]
-      }, 
-      {
-       "id": "Japan_Kinki Region_Wakayama", 
-       "s": 8069941, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u548c\u6b4c\u5c71\u770c"
-       ], 
-       "old": [
-        "Japan_Kinki"
-       ]
-      }
-     ]
-    }, 
-    {
-     "id": "Japan_Kyushu Region", 
-     "g": [
-      {
-       "id": "Japan_Kyushu Region_Fukuoka", 
-       "s": 16631239, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u798f\u5ca1\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Kagoshima", 
-       "s": 18217036, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u9e7f\u5150\u5cf6\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Kumamoto", 
-       "s": 21703135, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u718a\u672c\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Miyazaki", 
-       "s": 10791956, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u5bae\u5d0e\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Nagasaki", 
-       "s": 11474596, 
-       "affiliations": [
-        "\u9577\u5d0e\u770c", 
-        "\u65e5\u672c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Oita", 
-       "s": 13375882, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u5927\u5206\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Okinawa", 
-       "s": 7204142, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u6c96\u7e04\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }, 
-      {
-       "id": "Japan_Kyushu Region_Saga", 
-       "s": 7616005, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u4f50\u8cc0\u770c"
-       ], 
-       "old": [
-        "Japan_Kyushu"
-       ]
-      }
-     ]
-    }, 
-    {
-     "id": "Japan_Shikoku Region", 
-     "g": [
-      {
-       "id": "Japan_Shikoku Region_Ehime", 
-       "s": 14623426, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u611b\u5a9b\u770c"
-       ], 
-       "old": [
-        "Japan_Shikoku"
-       ]
-      }, 
-      {
-       "id": "Japan_Shikoku Region_Kagawa", 
-       "s": 5761060, 
-       "affiliations": [
-        "\u9999\u5ddd\u770c", 
-        "\u65e5\u672c"
-       ], 
-       "old": [
-        "Japan_Shikoku"
-       ]
-      }, 
-      {
-       "id": "Japan_Shikoku Region_Kochi", 
-       "s": 10666060, 
-       "affiliations": [
-        "\u9ad8\u77e5\u770c", 
-        "\u65e5\u672c"
-       ], 
-       "old": [
-        "Japan_Shikoku"
-       ]
-      }, 
-      {
-       "id": "Japan_Shikoku Region_Kyoto", 
-       "s": 25436561, 
-       "affiliations": [
-        "\u65e5\u672c", 
-        "\u4eac\u90fd\u5e9c", 
+        "\u65e5\u672c",
+        "\u4eac\u90fd\u5e9c",
         "\u6ecb\u8cc0\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Kinki"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Shikoku Region_Tokushima", 
-       "s": 10115517, 
+       "id": "Japan_Kinki Region_Mie",
+       "s": 14149459,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
+        "\u4e09\u91cd\u770c",
+        "\u611b\u77e5\u770c"
+       ],
+       "old": [
+        "Japan_Kinki"
+       ]
+      },
+      {
+       "id": "Japan_Kinki Region_Nara",
+       "s": 9702735,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u5948\u826f\u770c",
+        "\u548c\u6b4c\u5c71\u770c"
+       ],
+       "old": [
+        "Japan_Kinki"
+       ]
+      },
+      {
+       "id": "Japan_Kinki Region_Osaka_Osaka",
+       "s": 28090782,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u5175\u5eab\u770c",
+        "\u5927\u962a\u5e9c"
+       ],
+       "old": [
+        "Japan_Kinki"
+       ]
+      },
+      {
+       "id": "Japan_Kinki Region_Osaka_West",
+       "s": 21245824,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u5175\u5eab\u770c"
+       ],
+       "old": [
+        "Japan_Kinki"
+       ]
+      },
+      {
+       "id": "Japan_Kinki Region_Wakayama",
+       "s": 8069941,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u548c\u6b4c\u5c71\u770c"
+       ],
+       "old": [
+        "Japan_Kinki"
+       ]
+      }
+     ]
+    },
+    {
+     "id": "Japan_Kyushu Region",
+     "g": [
+      {
+       "id": "Japan_Kyushu Region_Fukuoka",
+       "s": 16631239,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u798f\u5ca1\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Kagoshima",
+       "s": 18217036,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u9e7f\u5150\u5cf6\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Kumamoto",
+       "s": 21703135,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u718a\u672c\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Miyazaki",
+       "s": 10791956,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u5bae\u5d0e\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Nagasaki",
+       "s": 11474596,
+       "affiliations": [
+        "\u9577\u5d0e\u770c",
+        "\u65e5\u672c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Oita",
+       "s": 13375882,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u5927\u5206\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Okinawa",
+       "s": 7204142,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u6c96\u7e04\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      },
+      {
+       "id": "Japan_Kyushu Region_Saga",
+       "s": 7616005,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u4f50\u8cc0\u770c"
+       ],
+       "old": [
+        "Japan_Kyushu"
+       ]
+      }
+     ]
+    },
+    {
+     "id": "Japan_Shikoku Region",
+     "g": [
+      {
+       "id": "Japan_Shikoku Region_Ehime",
+       "s": 14623426,
+       "affiliations": [
+        "\u65e5\u672c",
+        "\u611b\u5a9b\u770c"
+       ],
+       "old": [
+        "Japan_Shikoku"
+       ]
+      },
+      {
+       "id": "Japan_Shikoku Region_Kagawa",
+       "s": 5761060,
+       "affiliations": [
+        "\u9999\u5ddd\u770c",
+        "\u65e5\u672c"
+       ],
+       "old": [
+        "Japan_Shikoku"
+       ]
+      },
+      {
+       "id": "Japan_Shikoku Region_Kochi",
+       "s": 10666060,
+       "affiliations": [
+        "\u9ad8\u77e5\u770c",
+        "\u65e5\u672c"
+       ],
+       "old": [
+        "Japan_Shikoku"
+       ]
+      },
+      {
+       "id": "Japan_Shikoku Region_Tokushima",
+       "s": 10115517,
+       "affiliations": [
+        "\u65e5\u672c",
         "\u5fb3\u5cf6\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Shikoku"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Japan_Tohoku", 
+     "id": "Japan_Tohoku",
      "g": [
       {
-       "id": "Japan_Tohoku_Akita", 
-       "s": 15570409, 
+       "id": "Japan_Tohoku_Akita",
+       "s": 15570409,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u79cb\u7530\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Tohoku_Aomori", 
-       "s": 12751171, 
+       "id": "Japan_Tohoku_Aomori",
+       "s": 12751171,
        "affiliations": [
-        "\u9752\u68ee\u770c", 
+        "\u9752\u68ee\u770c",
         "\u65e5\u672c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Tohoku_Fukushima", 
-       "s": 31649723, 
+       "id": "Japan_Tohoku_Fukushima",
+       "s": 31649723,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u798f\u5cf6\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Tohoku_Iwate", 
-       "s": 19878036, 
+       "id": "Japan_Tohoku_Iwate",
+       "s": 19878036,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5ca9\u624b\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Tohoku_Miyagi", 
-       "s": 15589685, 
+       "id": "Japan_Tohoku_Miyagi",
+       "s": 15589685,
        "affiliations": [
-        "\u65e5\u672c", 
-        "\u5bae\u57ce\u770c", 
+        "\u65e5\u672c",
+        "\u5bae\u57ce\u770c",
         "\u798f\u5cf6\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
-      }, 
+      },
       {
-       "id": "Japan_Tohoku_Yamagata", 
-       "s": 11714725, 
+       "id": "Japan_Tohoku_Yamagata",
+       "s": 11714725,
        "affiliations": [
-        "\u65e5\u672c", 
+        "\u65e5\u672c",
         "\u5c71\u5f62\u770c"
-       ], 
+       ],
        "old": [
         "Japan_Tohoku"
        ]
@@ -7631,8554 +7631,8554 @@
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Jersey", 
-   "s": 1100323, 
+   "id": "Jersey",
+   "s": 1100323,
    "affiliations": [
-    "France", 
-    "Guernsey", 
-    "Jersey", 
-    "Jersey", 
-    "Janvrin's Tomb", 
-    "King's Rock", 
-    "L'Ile Percee", 
-    "La Motte", 
-    "Queen's Rock", 
+    "France",
+    "Guernsey",
+    "Jersey",
+    "Jersey",
+    "Janvrin's Tomb",
+    "King's Rock",
+    "L'Ile Percee",
+    "La Motte",
+    "Queen's Rock",
     "The Islet"
-   ], 
+   ],
    "old": [
     "Jersey"
    ]
-  }, 
+  },
   {
-   "id": "Jordan", 
-   "s": 8488953, 
+   "id": "Jordan",
+   "s": 8488953,
    "affiliations": [
-    "Ajloun", 
-    "Amman", 
-    "Aqaba", 
-    "Balqa", 
-    "Irbid", 
-    "Jarash", 
-    "Karak", 
-    "Ma'an", 
-    "Madaba", 
-    "Mafraq", 
-    "Tafilah", 
-    "Zarqa", 
+    "Ajloun",
+    "Amman",
+    "Aqaba",
+    "Balqa",
+    "Irbid",
+    "Jarash",
+    "Karak",
+    "Ma'an",
+    "Madaba",
+    "Mafraq",
+    "Tafilah",
+    "Zarqa",
     "\u0627\u0644\u0623\u0631\u062f\u0646"
-   ], 
+   ],
    "old": [
     "Jordan"
    ]
-  }, 
+  },
   {
-   "id": "Kazakhstan", 
+   "id": "Kazakhstan",
    "g": [
     {
-     "id": "Kazakhstan_North", 
-     "s": 31656495, 
+     "id": "Kazakhstan_North",
+     "s": 31656495,
      "affiliations": [
-      "\u0410\u0441\u0442\u0430\u043d\u0430", 
-      "\u0421\u0435\u0432\u0435\u0440\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u049a\u0430\u0437\u0430\u049b\u0441\u0442\u0430\u043d", 
-      "\u0410\u043a\u043c\u043e\u043b\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u041a\u043e\u0441\u0442\u0430\u043d\u0430\u0439\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u041f\u0430\u0432\u043b\u043e\u0434\u0430\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0410\u0441\u0442\u0430\u043d\u0430",
+      "\u0421\u0435\u0432\u0435\u0440\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u049a\u0430\u0437\u0430\u049b\u0441\u0442\u0430\u043d",
+      "\u0410\u043a\u043c\u043e\u043b\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u041a\u043e\u0441\u0442\u0430\u043d\u0430\u0439\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u041f\u0430\u0432\u043b\u043e\u0434\u0430\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u041a\u0430\u0440\u0430\u0433\u0430\u043d\u0434\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Kazakhstan"
      ]
-    }, 
+    },
     {
-     "id": "Kazakhstan_South", 
-     "s": 37610529, 
+     "id": "Kazakhstan_South",
+     "s": 37610529,
      "affiliations": [
-      "\u0410\u043b\u043c\u0430\u0442\u044b", 
-      "\u0410\u0442\u044b\u0440\u0430\u0443\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0416\u0430\u043c\u0431\u044b\u043b\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u042e\u0436\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0417\u0430\u043f\u0430\u0434\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u049a\u0430\u0437\u0430\u049b\u0441\u0442\u0430\u043d", 
-      "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0410\u043a\u0442\u044e\u0431\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0410\u043b\u043c\u0430\u0442\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u041c\u0430\u043d\u0433\u0438\u0441\u0442\u0430\u0443\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0410\u043b\u043c\u0430\u0442\u044b",
+      "\u0410\u0442\u044b\u0440\u0430\u0443\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0416\u0430\u043c\u0431\u044b\u043b\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u042e\u0436\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0417\u0430\u043f\u0430\u0434\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u049a\u0430\u0437\u0430\u049b\u0441\u0442\u0430\u043d",
+      "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u043e-\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0410\u043a\u0442\u044e\u0431\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0410\u043b\u043c\u0430\u0442\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u041c\u0430\u043d\u0433\u0438\u0441\u0442\u0430\u0443\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u041a\u044b\u0437\u044b\u043b\u043e\u0440\u0434\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Kazakhstan"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Kenya", 
-   "s": 33200861, 
+   "id": "Kenya",
+   "s": 33200861,
    "affiliations": [
-    "Baringo", 
-    "Bungoma", 
-    "Busia", 
-    "Bomet", 
-    "Elegeyo-Marakwet", 
-    "Embu", 
-    "Garissa", 
-    "Homa Bay", 
-    "Isiolo", 
-    "Kajiado", 
-    "Kakamega", 
-    "Lamu", 
-    "Kenya", 
-    "Kericho", 
-    "Kiambu", 
-    "Kilifi", 
-    "Kirinyaga", 
-    "Kisii", 
-    "Kisumu", 
-    "Kitui", 
-    "Kwale", 
-    "Laikipia", 
-    "Machakos", 
-    "Makueni", 
-    "Mandera", 
-    "Marsabit", 
-    "Meru", 
-    "Migori", 
-    "Mombasa", 
-    "Murang`a", 
-    "Nairobi", 
-    "Nakuru", 
-    "Nandi", 
-    "Narok", 
-    "Nyamira", 
-    "Nyandarua", 
-    "Nyeri", 
-    "Tharaka-Nithi", 
-    "Samburu", 
-    "Siaya", 
-    "Taita Taveta", 
-    "Tana River", 
-    "Trans Nzoia", 
-    "Turkana", 
-    "Uasin Gishu", 
-    "Vihiga", 
-    "Wajir", 
+    "Baringo",
+    "Bungoma",
+    "Busia",
+    "Bomet",
+    "Elegeyo-Marakwet",
+    "Embu",
+    "Garissa",
+    "Homa Bay",
+    "Isiolo",
+    "Kajiado",
+    "Kakamega",
+    "Lamu",
+    "Kenya",
+    "Kericho",
+    "Kiambu",
+    "Kilifi",
+    "Kirinyaga",
+    "Kisii",
+    "Kisumu",
+    "Kitui",
+    "Kwale",
+    "Laikipia",
+    "Machakos",
+    "Makueni",
+    "Mandera",
+    "Marsabit",
+    "Meru",
+    "Migori",
+    "Mombasa",
+    "Murang`a",
+    "Nairobi",
+    "Nakuru",
+    "Nandi",
+    "Narok",
+    "Nyamira",
+    "Nyandarua",
+    "Nyeri",
+    "Tharaka-Nithi",
+    "Samburu",
+    "Siaya",
+    "Taita Taveta",
+    "Tana River",
+    "Trans Nzoia",
+    "Turkana",
+    "Uasin Gishu",
+    "Vihiga",
+    "Wajir",
     "West Pokot"
-   ], 
+   ],
    "old": [
     "Kenya"
    ]
-  }, 
+  },
   {
-   "id": "Kingdom of Lesotho", 
-   "s": 65610223, 
+   "id": "Kingdom of Lesotho",
+   "s": 65610223,
    "affiliations": [
     "Lesotho"
-   ], 
+   ],
    "old": [
     "South Africa"
    ]
-  }, 
+  },
   {
-   "id": "Kiribati", 
-   "s": 1020501, 
+   "id": "Kiribati",
+   "s": 1020501,
    "affiliations": [
     "Kiribati"
-   ], 
+   ],
    "old": [
     "Kiribati"
    ]
-  }, 
+  },
   {
-   "id": "Kuwait", 
-   "s": 8397146, 
+   "id": "Kuwait",
+   "s": 8397146,
    "affiliations": [
-    "\u062d\u0648\u0644\u064a", 
-    "\u0645\u0628\u0627\u0631\u0643 \u0627\u0644\u0643\u0628\u064a\u0631\u200e", 
-    "\u0627\u0644\u0627\u062d\u0645\u062f\u064a", 
-    "\u0627\u0644\u062c\u0647\u0631\u0627\u0621", 
-    "\u0627\u0644\u0639\u0627\u0635\u0645\u0629", 
-    "\u0627\u0644\u0641\u0631\u0648\u0627\u0646\u064a\u0629", 
+    "\u062d\u0648\u0644\u064a",
+    "\u0645\u0628\u0627\u0631\u0643 \u0627\u0644\u0643\u0628\u064a\u0631\u200e",
+    "\u0627\u0644\u0627\u062d\u0645\u062f\u064a",
+    "\u0627\u0644\u062c\u0647\u0631\u0627\u0621",
+    "\u0627\u0644\u0639\u0627\u0635\u0645\u0629",
+    "\u0627\u0644\u0641\u0631\u0648\u0627\u0646\u064a\u0629",
     "\u200f\u0627\u0644\u0643\u0648\u064a\u062a\u200e"
-   ], 
+   ],
    "old": [
     "Kuwait"
    ]
-  }, 
+  },
   {
-   "id": "Kyrgyzstan", 
-   "s": 19782835, 
+   "id": "Kyrgyzstan",
+   "s": 19782835,
    "affiliations": [
-    "\u041d\u0430\u0440\u044b\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "\u0422\u0430\u043b\u0430\u0441\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "Chong-Kara", 
-    "Farg'ona Viloyati", 
-    "\u0418\u0441\u0441\u044b\u043a-\u041a\u0443\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "\u0411\u0430\u0442\u043a\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "Jangy-ayyl", 
-    "\u0411\u0438\u0448\u043a\u0435\u043a", 
-    "\u041e\u0448\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "\u0414\u0436\u0430\u043b\u0430\u043b-\u0410\u0431\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-    "\u0427\u0443\u0439\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+    "\u041d\u0430\u0440\u044b\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "\u0422\u0430\u043b\u0430\u0441\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "Chong-Kara",
+    "Farg'ona Viloyati",
+    "\u0418\u0441\u0441\u044b\u043a-\u041a\u0443\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "\u0411\u0430\u0442\u043a\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "Jangy-ayyl",
+    "\u0411\u0438\u0448\u043a\u0435\u043a",
+    "\u041e\u0448\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "\u0414\u0436\u0430\u043b\u0430\u043b-\u0410\u0431\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+    "\u0427\u0443\u0439\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
     "\u041a\u044b\u0440\u0433\u044b\u0437\u0441\u0442\u0430\u043d"
-   ], 
+   ],
    "old": [
     "Kyrgyzstan"
    ]
-  }, 
+  },
   {
-   "id": "Laos", 
-   "s": 10612590, 
+   "id": "Laos",
+   "s": 10612590,
    "affiliations": [
-    "\u0e84\u0ecd\u0eb2\u0ea1\u0ec8\u0ea7\u0e99", 
-    "\u0e88\u0eb3\u0e9b\u0eb2\u0eaa\u0eb1\u0e81", 
-    "\u0e8a\u0ebd\u0e87\u0e82\u0ea7\u0eb2\u0e87", 
-    "\u0e9a\u0ecd\u0ec8\u0ec1\u0e81\u0ec9\u0ea7", 
-    "\u0eaa\u0eb2\u0ea5\u0eb0\u0ea7\u0eb1\u0e99", 
-    "\u0ead\u0eb1\u0e94\u0e95\u0eb0\u0e9b\u0eb7", 
-    "\u0ead\u0eb8\u0e94\u0ebb\u0ea1\u0ec4\u0e8a", 
-    "\u0eab\u0ebb\u0ea7\u0e9e\u0eb1\u0e99", 
-    "\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99", 
-    "\u0e9a\u0ecd\u0ea5\u0eb4\u0e84\u0eb3\u0ec4\u0e8a", 
-    "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0ea5\u0eb2\u0ea7", 
-    "\u0e9c\u0ebb\u0ec9\u0e87\u0eaa\u0eb2\u0ea5\u0eb5", 
-    "\u0ec4\u0e8a\u0e8d\u0eb0\u0e9a\u0eb9\u0ea5\u0eb5", 
-    "\u0ec4\u0e8a\u0eaa\u0ebb\u0ea1\u0e9a\u0eb9\u0e99", 
-    "\u0eab\u0ea5\u0ea7\u0e87\u0e9e\u0eb0\u0e9a\u0eb2\u0e87", 
-    "\u0eab\u0ea5\u0ea7\u0e87\u0e99\u0ecd\u0ec9\u0eb2\u0e97\u0eb2", 
-    "\u0eaa\u0eb0\u0eab\u0ea7\u0eb1\u0e99\u0e99\u0eb0\u0ec0\u0e82\u0e94", 
+    "\u0e84\u0ecd\u0eb2\u0ea1\u0ec8\u0ea7\u0e99",
+    "\u0e88\u0eb3\u0e9b\u0eb2\u0eaa\u0eb1\u0e81",
+    "\u0e8a\u0ebd\u0e87\u0e82\u0ea7\u0eb2\u0e87",
+    "\u0e9a\u0ecd\u0ec8\u0ec1\u0e81\u0ec9\u0ea7",
+    "\u0eaa\u0eb2\u0ea5\u0eb0\u0ea7\u0eb1\u0e99",
+    "\u0ead\u0eb1\u0e94\u0e95\u0eb0\u0e9b\u0eb7",
+    "\u0ead\u0eb8\u0e94\u0ebb\u0ea1\u0ec4\u0e8a",
+    "\u0eab\u0ebb\u0ea7\u0e9e\u0eb1\u0e99",
+    "\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99",
+    "\u0e9a\u0ecd\u0ea5\u0eb4\u0e84\u0eb3\u0ec4\u0e8a",
+    "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0ea5\u0eb2\u0ea7",
+    "\u0e9c\u0ebb\u0ec9\u0e87\u0eaa\u0eb2\u0ea5\u0eb5",
+    "\u0ec4\u0e8a\u0e8d\u0eb0\u0e9a\u0eb9\u0ea5\u0eb5",
+    "\u0ec4\u0e8a\u0eaa\u0ebb\u0ea1\u0e9a\u0eb9\u0e99",
+    "\u0eab\u0ea5\u0ea7\u0e87\u0e9e\u0eb0\u0e9a\u0eb2\u0e87",
+    "\u0eab\u0ea5\u0ea7\u0e87\u0e99\u0ecd\u0ec9\u0eb2\u0e97\u0eb2",
+    "\u0eaa\u0eb0\u0eab\u0ea7\u0eb1\u0e99\u0e99\u0eb0\u0ec0\u0e82\u0e94",
     "\u0e99\u0eb0\u0e84\u0ead\u0e99\u0eab\u0ebc\u0ea7\u0e87\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99"
-   ], 
+   ],
    "old": [
     "Laos"
    ]
-  }, 
+  },
   {
-   "id": "Latvia", 
-   "s": 49907753, 
+   "id": "Latvia",
+   "s": 49907753,
    "affiliations": [
-    "Latgale", 
-    "Latvija", 
-    "Kurzeme", 
-    "Vidzeme", 
+    "Latgale",
+    "Latvija",
+    "Kurzeme",
+    "Vidzeme",
     "Zemgale"
-   ], 
+   ],
    "old": [
     "Latvia"
    ]
-  }, 
+  },
   {
-   "id": "Lebanon", 
-   "s": 6105334, 
+   "id": "Lebanon",
+   "s": 6105334,
    "affiliations": [
-    "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0644\u0628\u0646\u0627\u0646\u064a\u0629", 
-    "\u0642\u0636\u0627\u0621 \u0632\u063a\u0631\u062a\u0627", 
-    "\u0642\u0636\u0627\u0621 \u062c\u0632\u064a\u0646", 
-    "\u0642\u0636\u0627\u0621 \u0635\u0648\u0631", 
-    "\u0642\u0636\u0627\u0621 \u0628\u0646\u062a \u062c\u0628\u064a\u0644", 
-    "\u0642\u0636\u0627\u0621 \u062c\u0628\u064a\u0644", 
-    "\u0642\u0636\u0627\u0621 \u0632\u062d\u0644\u0629", 
-    "\u0642\u0636\u0627\u0621 \u0635\u064a\u062f\u0627", 
-    "\u0642\u0636\u0627\u0621 \u0639\u0643\u0627\u0631", 
-    "\u0642\u0636\u0627\u0621 \u0628\u0634\u0631\u0651\u064a", 
-    "\u0642\u0636\u0627\u0621 \u0645\u0631\u062c\u0639\u064a\u0648\u0646", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0634\u0648\u0641", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0645\u062a\u0646", 
-    "\u0642\u0636\u0627\u0621 \u0628\u0639\u0628\u062f\u0627", 
-    "\u0642\u0636\u0627\u0621 \u0628\u0639\u0644\u0628\u0643", 
-    "\u0642\u0636\u0627\u0621 \u0631\u0627\u0634\u064a\u0627", 
-    "\u0642\u0636\u0627\u0621 \u0639\u0627\u0644\u064a\u0647", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0643\u0648\u0631\u0629", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0647\u0631\u0645\u0644", 
-    "\u0642\u0636\u0627\u0621 \u062d\u0627\u0635\u0628\u064a\u0627", 
-    "\u0642\u0636\u0627\u0621 \u0637\u0631\u0627\u0628\u0644\u0633", 
-    "\u0642\u0636\u0627\u0621 \u0643\u0633\u0631\u0648\u0627\u0646", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0645\u0646\u064a\u0629 \u0636\u0646\u064a\u0651\u0629", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0628\u0642\u0627\u0639 \u0627\u0644\u063a\u0631\u0628\u064a", 
-    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0628\u062a\u0631\u0648\u0646", 
+    "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0644\u0628\u0646\u0627\u0646\u064a\u0629",
+    "\u0642\u0636\u0627\u0621 \u0632\u063a\u0631\u062a\u0627",
+    "\u0642\u0636\u0627\u0621 \u062c\u0632\u064a\u0646",
+    "\u0642\u0636\u0627\u0621 \u0635\u0648\u0631",
+    "\u0642\u0636\u0627\u0621 \u0628\u0646\u062a \u062c\u0628\u064a\u0644",
+    "\u0642\u0636\u0627\u0621 \u062c\u0628\u064a\u0644",
+    "\u0642\u0636\u0627\u0621 \u0632\u062d\u0644\u0629",
+    "\u0642\u0636\u0627\u0621 \u0635\u064a\u062f\u0627",
+    "\u0642\u0636\u0627\u0621 \u0639\u0643\u0627\u0631",
+    "\u0642\u0636\u0627\u0621 \u0628\u0634\u0631\u0651\u064a",
+    "\u0642\u0636\u0627\u0621 \u0645\u0631\u062c\u0639\u064a\u0648\u0646",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0634\u0648\u0641",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0645\u062a\u0646",
+    "\u0642\u0636\u0627\u0621 \u0628\u0639\u0628\u062f\u0627",
+    "\u0642\u0636\u0627\u0621 \u0628\u0639\u0644\u0628\u0643",
+    "\u0642\u0636\u0627\u0621 \u0631\u0627\u0634\u064a\u0627",
+    "\u0642\u0636\u0627\u0621 \u0639\u0627\u0644\u064a\u0647",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0643\u0648\u0631\u0629",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0647\u0631\u0645\u0644",
+    "\u0642\u0636\u0627\u0621 \u062d\u0627\u0635\u0628\u064a\u0627",
+    "\u0642\u0636\u0627\u0621 \u0637\u0631\u0627\u0628\u0644\u0633",
+    "\u0642\u0636\u0627\u0621 \u0643\u0633\u0631\u0648\u0627\u0646",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0645\u0646\u064a\u0629 \u0636\u0646\u064a\u0651\u0629",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0628\u0642\u0627\u0639 \u0627\u0644\u063a\u0631\u0628\u064a",
+    "\u0642\u0636\u0627\u0621 \u0627\u0644\u0628\u062a\u0631\u0648\u0646",
     "\u0642\u0636\u0627\u0621 \u0627\u0644\u0646\u0628\u0637\u064a\u0629"
-   ], 
+   ],
    "old": [
     "Lebanon"
    ]
-  }, 
+  },
   {
-   "id": "Liberia", 
-   "s": 16495219, 
+   "id": "Liberia",
+   "s": 16495219,
    "affiliations": [
-    "Bomi County", 
-    "Bong County", 
-    "Montserrado County", 
-    "Gbarpolu County", 
-    "Grand Bassa County", 
-    "Grand Cape Mount County", 
-    "Grand Gedeh County", 
-    "Grand Kru County", 
-    "Lofa County", 
-    "Liberia", 
-    "Margibi County", 
-    "Maryland County", 
-    "Nimba County", 
-    "River Cess County", 
-    "River Gee County", 
+    "Bomi County",
+    "Bong County",
+    "Montserrado County",
+    "Gbarpolu County",
+    "Grand Bassa County",
+    "Grand Cape Mount County",
+    "Grand Gedeh County",
+    "Grand Kru County",
+    "Lofa County",
+    "Liberia",
+    "Margibi County",
+    "Maryland County",
+    "Nimba County",
+    "River Cess County",
+    "River Gee County",
     "Sinoe County"
-   ], 
+   ],
    "old": [
     "Liberia"
    ]
-  }, 
+  },
   {
-   "id": "Libya", 
-   "s": 9904428, 
+   "id": "Libya",
+   "s": 9904428,
    "affiliations": [
-    "Libya \u2d4d\u2d49\u2d31\u2d62\u2d30 \u0644\u064a\u0628\u064a\u0627", 
-    "\u0633\u0631\u062a", 
-    "\u063a\u0627\u062a", 
-    "\u062f\u0631\u0646\u0629", 
-    "\u0633\u0628\u0647\u0627", 
-    "\u0645\u0631\u0632\u0642", 
-    "\u0648\u0627\u062f\u064a \u0627\u0644\u0634\u0627\u0637\u0626", 
-    "\u0648\u0627\u062f\u064a \u0627\u0644\u062d\u064a\u0627\u0629", 
-    "\u0627\u0644\u0645\u0631\u062c", 
-    "\u0646\u0627\u0644\u0648\u062a", 
-    "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0623\u062e\u0636\u0631", 
-    "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u063a\u0631\u0628\u064a", 
-    "\u0627\u0644\u062c\u0641\u0631\u0629", 
-    "\u0627\u0644\u0643\u0641\u0631\u0629", 
-    "\u0627\u0644\u0645\u0631\u0642\u0628", 
-    "\u0628\u0646\u063a\u0627\u0632\u064a", 
-    "\u0637\u0631\u0627\u0628\u0644\u0633", 
-    "\u0645\u0635\u0631\u0627\u062a\u0629", 
-    "\u0627\u0644\u0646\u0642\u0627\u0637 \u0627\u0644\u062e\u0645\u0633", 
-    "\u0627\u0644\u0628\u0637\u0646\u0627\u0646", 
-    "\u0627\u0644\u062c\u0641\u0627\u0631\u0629", 
-    "\u0627\u0644\u0648\u0627\u062d\u0627\u062a", 
+    "Libya \u2d4d\u2d49\u2d31\u2d62\u2d30 \u0644\u064a\u0628\u064a\u0627",
+    "\u0633\u0631\u062a",
+    "\u063a\u0627\u062a",
+    "\u062f\u0631\u0646\u0629",
+    "\u0633\u0628\u0647\u0627",
+    "\u0645\u0631\u0632\u0642",
+    "\u0648\u0627\u062f\u064a \u0627\u0644\u0634\u0627\u0637\u0626",
+    "\u0648\u0627\u062f\u064a \u0627\u0644\u062d\u064a\u0627\u0629",
+    "\u0627\u0644\u0645\u0631\u062c",
+    "\u0646\u0627\u0644\u0648\u062a",
+    "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0623\u062e\u0636\u0631",
+    "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u063a\u0631\u0628\u064a",
+    "\u0627\u0644\u062c\u0641\u0631\u0629",
+    "\u0627\u0644\u0643\u0641\u0631\u0629",
+    "\u0627\u0644\u0645\u0631\u0642\u0628",
+    "\u0628\u0646\u063a\u0627\u0632\u064a",
+    "\u0637\u0631\u0627\u0628\u0644\u0633",
+    "\u0645\u0635\u0631\u0627\u062a\u0629",
+    "\u0627\u0644\u0646\u0642\u0627\u0637 \u0627\u0644\u062e\u0645\u0633",
+    "\u0627\u0644\u0628\u0637\u0646\u0627\u0646",
+    "\u0627\u0644\u062c\u0641\u0627\u0631\u0629",
+    "\u0627\u0644\u0648\u0627\u062d\u0627\u062a",
     "\u0627\u0644\u0632\u0627\u0648\u064a\u0629"
-   ], 
+   ],
    "old": [
     "Libya"
    ]
-  }, 
+  },
   {
-   "id": "Liechtenstein", 
-   "s": 1391804, 
+   "id": "Liechtenstein",
+   "s": 1391804,
    "affiliations": [
     "Liechtenstein"
-   ], 
+   ],
    "old": [
     "Liechtenstein"
    ]
-  }, 
+  },
   {
-   "id": "Lithuania", 
+   "id": "Lithuania",
    "g": [
     {
-     "id": "Lithuania_East", 
-     "s": 41326367, 
+     "id": "Lithuania_East",
+     "s": 41326367,
      "affiliations": [
-      "Alytaus apskritis", 
-      "Kauno apskritis", 
-      "Lietuva", 
-      "Utenos apskritis", 
+      "Alytaus apskritis",
+      "Kauno apskritis",
+      "Lietuva",
+      "Utenos apskritis",
       "Vilniaus apskritis"
-     ], 
+     ],
      "old": [
       "Lithuania"
      ]
-    }, 
+    },
     {
-     "id": "Lithuania_West", 
-     "s": 41598221, 
+     "id": "Lithuania_West",
+     "s": 41598221,
      "affiliations": [
-      "Klaip\u0117dos apskritis", 
-      "Lietuva", 
-      "Marijampol\u0117s apskritis", 
-      "Panev\u0117\u017eio apskritis", 
-      "Tel\u0161i\u0173 apskritis", 
-      "Taurag\u0117s apskritis", 
+      "Klaip\u0117dos apskritis",
+      "Lietuva",
+      "Marijampol\u0117s apskritis",
+      "Panev\u0117\u017eio apskritis",
+      "Tel\u0161i\u0173 apskritis",
+      "Taurag\u0117s apskritis",
       "\u0160iauli\u0173 apskritis"
-     ], 
+     ],
      "old": [
       "Lithuania"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Luxembourg", 
-   "s": 14876804, 
+   "id": "Luxembourg",
+   "s": 14876804,
    "affiliations": [
     "L\u00ebtzebuerg"
-   ], 
+   ],
    "old": [
     "Luxembourg"
    ]
-  }, 
+  },
   {
-   "id": "Macedonia", 
-   "s": 14468598, 
+   "id": "Macedonia",
+   "s": 14468598,
    "affiliations": [
-    "\u0418\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u041f\u043e\u043b\u043e\u0448\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u0421\u043a\u043e\u043f\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u0412\u0430\u0440\u0434\u0430\u0440\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430", 
-    "\u0408\u0443\u0433\u043e\u0437\u0430\u043f\u0430\u0434\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u0408\u0443\u0433\u043e\u0438\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d", 
-    "\u041f\u0435\u043b\u0430\u0433\u043e\u043d\u0438\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d", 
+    "\u0418\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u041f\u043e\u043b\u043e\u0448\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u0421\u043a\u043e\u043f\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u0412\u0430\u0440\u0434\u0430\u0440\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
+    "\u0408\u0443\u0433\u043e\u0437\u0430\u043f\u0430\u0434\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u0408\u0443\u0433\u043e\u0438\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d",
+    "\u041f\u0435\u043b\u0430\u0433\u043e\u043d\u0438\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d",
     "\u0421\u0435\u0432\u0435\u0440\u043e\u0438\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d"
-   ], 
+   ],
    "old": [
     "Macedonia"
    ]
-  }, 
+  },
   {
-   "id": "Madagascar", 
-   "s": 35004074, 
+   "id": "Madagascar",
+   "s": 35004074,
    "affiliations": [
-    "Madagasikara", 
-    "Region de Anosy", 
-    "R\u00e9gion de Diana", 
-    "R\u00e9gion de Sava", 
+    "Madagasikara",
+    "Region de Anosy",
+    "R\u00e9gion de Diana",
+    "R\u00e9gion de Sava",
     "Pr\u00e9fecture de police de Nosy Be"
-   ], 
+   ],
    "old": [
     "Madagascar"
    ]
-  }, 
+  },
   {
-   "id": "Malawi", 
-   "s": 41121805, 
+   "id": "Malawi",
+   "s": 41121805,
    "affiliations": [
-    "Border Malawi - Mozambique", 
-    "Central", 
-    "Malawi", 
-    "Niassa", 
-    "Mo\u00e7ambique", 
-    "Northern", 
+    "Border Malawi - Mozambique",
+    "Central",
+    "Malawi",
+    "Niassa",
+    "Mo\u00e7ambique",
+    "Northern",
     "Southern"
-   ], 
+   ],
    "old": [
     "Malawi"
    ]
-  }, 
+  },
   {
-   "id": "Malaysia", 
-   "s": 41563772, 
+   "id": "Malaysia",
+   "s": 41563772,
    "affiliations": [
-    "Terengganu / \u062a\u0631\u06a0\u06ac\u0627\u0646\u0648", 
-    "Johor", 
-    "Kedah / \u0642\u062f\u062d", 
-    "Kelantan / \u06a9\u0644\u0646\u062a\u0646 \u062f\u0627\u0631 \u0627\u0644\u0646\u0639\u064a\u0645", 
-    "Kuala Lumpur", 
-    "Labuan", 
-    "Putrajaya", 
-    "Malaysia", 
-    "Negeri Sembilan", 
-    "Melaka", 
-    "Perak / \u06a8\u064a\u0631\u0642", 
-    "Perlis", 
-    "Pahang", 
-    "Pulau Bidong", 
-    "Pulau Burung", 
-    "Pulau Rusukan Besar", 
-    "Pulau Rusukan Kecil", 
-    "Pulau Susu Dara Kecil", 
-    "Pulau Tenggol", 
-    "Pulau Tikus", 
-    "Pulau Aman", 
-    "Pulau Betong", 
-    "Pulau Daat", 
-    "Pulau Gedung", 
-    "Pulau Gemia", 
-    "Pulau Jerejak", 
-    "Pulau Kapas", 
-    "Pulau Kendi", 
-    "Pulau Kuraman", 
-    "Pulau Papan", 
-    "Pulau Pinang", 
-    "Pulau Rhu", 
-    "Pulau Rimau", 
-    "Sabah", 
-    "Selangor", 
-    "Sarawak", 
+    "Terengganu / \u062a\u0631\u06a0\u06ac\u0627\u0646\u0648",
+    "Johor",
+    "Kedah / \u0642\u062f\u062d",
+    "Kelantan / \u06a9\u0644\u0646\u062a\u0646 \u062f\u0627\u0631 \u0627\u0644\u0646\u0639\u064a\u0645",
+    "Kuala Lumpur",
+    "Labuan",
+    "Putrajaya",
+    "Malaysia",
+    "Negeri Sembilan",
+    "Melaka",
+    "Perak / \u06a8\u064a\u0631\u0642",
+    "Perlis",
+    "Pahang",
+    "Pulau Bidong",
+    "Pulau Burung",
+    "Pulau Rusukan Besar",
+    "Pulau Rusukan Kecil",
+    "Pulau Susu Dara Kecil",
+    "Pulau Tenggol",
+    "Pulau Tikus",
+    "Pulau Aman",
+    "Pulau Betong",
+    "Pulau Daat",
+    "Pulau Gedung",
+    "Pulau Gemia",
+    "Pulau Jerejak",
+    "Pulau Kapas",
+    "Pulau Kendi",
+    "Pulau Kuraman",
+    "Pulau Papan",
+    "Pulau Pinang",
+    "Pulau Rhu",
+    "Pulau Rimau",
+    "Sabah",
+    "Selangor",
+    "Sarawak",
     "Singapura"
-   ], 
+   ],
    "old": [
     "Malaysia"
    ]
-  }, 
+  },
   {
-   "id": "Maldives", 
-   "s": 1393434, 
+   "id": "Maldives",
+   "s": 1393434,
    "affiliations": [
-    "Mathi-Dhekunu Province", 
-    "Mathi-Uthuru Province", 
-    "Dhekunu Province", 
-    "Uthuru Province", 
-    "Gnaviyani", 
-    "Mal\u00e9", 
-    "Medhu Province", 
-    "Medhu-Dhekunu Province", 
-    "Medhu-Uthuru Province", 
+    "Mathi-Dhekunu Province",
+    "Mathi-Uthuru Province",
+    "Dhekunu Province",
+    "Uthuru Province",
+    "Gnaviyani",
+    "Mal\u00e9",
+    "Medhu Province",
+    "Medhu-Dhekunu Province",
+    "Medhu-Uthuru Province",
     "\u078b\u07a8\u0788\u07ac\u0780\u07a8\u0783\u07a7\u0787\u07b0\u0796\u07ad\u078e\u07ac \u0796\u07aa\u0789\u07aa\u0780\u07ab\u0783\u07a8\u0787\u07b0\u0794\u07a7"
-   ], 
+   ],
    "old": [
     "Maldives"
    ]
-  }, 
+  },
   {
-   "id": "Mali", 
-   "s": 32424831, 
+   "id": "Mali",
+   "s": 32424831,
    "affiliations": [
-    "District de Bamako", 
-    "Gao", 
-    "Koulikoro", 
-    "Kayes", 
-    "Kidal", 
-    "Mali", 
-    "Mopti", 
-    "Sikasso", 
-    "S\u00e9gou", 
+    "District de Bamako",
+    "Gao",
+    "Koulikoro",
+    "Kayes",
+    "Kidal",
+    "Mali",
+    "Mopti",
+    "Sikasso",
+    "S\u00e9gou",
     "Tombouctou"
-   ], 
+   ],
    "old": [
     "Mali"
    ]
-  }, 
+  },
   {
-   "id": "Malta", 
-   "s": 3071006, 
+   "id": "Malta",
+   "s": 3071006,
    "affiliations": [
-    "Comino", 
-    "Cominotto", 
-    "Ghawdex", 
-    "Gozo", 
-    "Islet in the Comino", 
-    "Kemmuna", 
-    "Malta", 
+    "Comino",
+    "Cominotto",
+    "Ghawdex",
+    "Gozo",
+    "Islet in the Comino",
+    "Kemmuna",
+    "Malta",
     "Malta"
-   ], 
+   ],
    "old": [
     "Malta"
    ]
-  }, 
+  },
   {
-   "id": "Marshall Islands", 
-   "s": 748594, 
+   "id": "Marshall Islands",
+   "s": 748594,
    "affiliations": [
-    "Aolep\u0101n Aor\u014dkin M\u0327aje\u013c", 
+    "Aolep\u0101n Aor\u014dkin M\u0327aje\u013c",
     "MH"
-   ], 
+   ],
    "old": [
     "Marshall Islands"
    ]
-  }, 
+  },
   {
-   "id": "Mauritania", 
-   "s": 5690721, 
+   "id": "Mauritania",
+   "s": 5690721,
    "affiliations": [
-    "\u0646\u0648\u0627\u0643\u0634\u0648\u0637", 
-    "Mauritanie \u0645\u0648\u0631\u064a\u062a\u0627\u0646\u064a\u0627", 
-    "\u062a\u064a\u0631\u0633 \u0632\u0645\u0648\u0631", 
-    "\u0623\u062f\u0631\u0627\u0631", 
-    "\u0648\u0644\u0627\u064a\u0629 \u062a\u0643\u0627\u0646\u062a", 
-    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062d\u0648\u0636 \u0627\u0644\u063a\u0631\u0628\u064a", 
-    "\u0627\u0644\u062d\u0648\u0636 \u0627\u0644\u0634\u0631\u0642\u064a", 
-    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0631\u0627\u0643\u0646\u0629", 
-    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062a\u0631\u0627\u0631\u0632\u0629", 
-    "\u062f\u0627\u062e\u0644\u0629 \u0646\u0648\u0627\u0630\u064a\u0628\u0648", 
-    "\u0643\u0648\u0631\u0643\u0648\u0644", 
-    "\u0625\u064a\u0646\u0634\u064a\u0631\u064a", 
+    "\u0646\u0648\u0627\u0643\u0634\u0648\u0637",
+    "Mauritanie \u0645\u0648\u0631\u064a\u062a\u0627\u0646\u064a\u0627",
+    "\u062a\u064a\u0631\u0633 \u0632\u0645\u0648\u0631",
+    "\u0623\u062f\u0631\u0627\u0631",
+    "\u0648\u0644\u0627\u064a\u0629 \u062a\u0643\u0627\u0646\u062a",
+    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062d\u0648\u0636 \u0627\u0644\u063a\u0631\u0628\u064a",
+    "\u0627\u0644\u062d\u0648\u0636 \u0627\u0644\u0634\u0631\u0642\u064a",
+    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0631\u0627\u0643\u0646\u0629",
+    "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062a\u0631\u0627\u0631\u0632\u0629",
+    "\u062f\u0627\u062e\u0644\u0629 \u0646\u0648\u0627\u0630\u064a\u0628\u0648",
+    "\u0643\u0648\u0631\u0643\u0648\u0644",
+    "\u0625\u064a\u0646\u0634\u064a\u0631\u064a",
     "\u063a\u064a\u062f\u064a\u0645\u0627\u063a\u0627"
-   ], 
+   ],
    "old": [
     "Mauritania"
    ]
-  }, 
+  },
   {
-   "id": "Mauritius", 
-   "s": 3265361, 
+   "id": "Mauritius",
+   "s": 3265361,
    "affiliations": [
-    "Black River", 
-    "Mauritius", 
-    "Flacq", 
-    "Grand Port", 
-    "\u00cele Gombrani", 
-    "\u00cele Hermitage", 
-    "\u00cele Paille en Queue", 
-    "\u00cele Plate", 
-    "Moka", 
-    "\u00cele au Chat ou Pierrot", 
-    "\u00cele aux Cocos", 
-    "\u00cele aux Diamants", 
-    "\u00cele aux Fous", 
-    "\u00cele aux Pintades", 
-    "\u00cele aux Sables", 
-    "Pamplemousses", 
-    "Plaines Wilhems", 
-    "Port Louis", 
-    "Rivi\u00e8re du Rempart", 
-    "Rodrigues", 
-    "Savanne", 
-    "\u00cele Catherine", 
-    "\u00cele Crabe", 
-    "\u00cele Destin\u00e9e", 
-    "\u00cele Deux Fr\u00e8res", 
+    "Black River",
+    "Mauritius",
+    "Flacq",
+    "Grand Port",
+    "\u00cele Gombrani",
+    "\u00cele Hermitage",
+    "\u00cele Paille en Queue",
+    "\u00cele Plate",
+    "Moka",
+    "\u00cele au Chat ou Pierrot",
+    "\u00cele aux Cocos",
+    "\u00cele aux Diamants",
+    "\u00cele aux Fous",
+    "\u00cele aux Pintades",
+    "\u00cele aux Sables",
+    "Pamplemousses",
+    "Plaines Wilhems",
+    "Port Louis",
+    "Rivi\u00e8re du Rempart",
+    "Rodrigues",
+    "Savanne",
+    "\u00cele Catherine",
+    "\u00cele Crabe",
+    "\u00cele Destin\u00e9e",
+    "\u00cele Deux Fr\u00e8res",
     "\u00cele Fr\u00e9gate"
-   ], 
+   ],
    "old": [
     "Mauritius"
    ]
-  }, 
+  },
   {
-   "id": "Mexico", 
+   "id": "Mexico",
    "g": [
     {
-     "id": "Mexico_California", 
-     "s": 8420760, 
+     "id": "Mexico_California",
+     "s": 8420760,
      "affiliations": [
-      "Baja California", 
-      "Baja California Sur", 
-      "Colima", 
+      "Baja California",
+      "Baja California Sur",
+      "Colima",
       "Estados Unidos Mexicanos"
-     ], 
+     ],
      "old": [
-      "Mexico", 
-      "Guadalupe Island", 
-      "Socorro Island", 
+      "Mexico",
+      "Guadalupe Island",
+      "Socorro Island",
       "Clarion Island"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_Central_East", 
-     "s": 14975709, 
+     "id": "Mexico_Central_East",
+     "s": 14975709,
      "affiliations": [
-      "Coahuila de Zaragoza", 
-      "Estados Unidos Mexicanos", 
-      "Nuevo Le\u00f3n", 
-      "San Luis Potos\u00ed", 
+      "Coahuila de Zaragoza",
+      "Estados Unidos Mexicanos",
+      "Nuevo Le\u00f3n",
+      "San Luis Potos\u00ed",
       "Tamaulipas"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_Central_West", 
-     "s": 25578985, 
+     "id": "Mexico_Central_West",
+     "s": 25578985,
      "affiliations": [
-      "Aguascalientes", 
-      "Colima", 
-      "Durango", 
-      "Estados Unidos Mexicanos", 
-      "Jalisco", 
-      "Nayarit", 
-      "Sinaloa", 
+      "Aguascalientes",
+      "Colima",
+      "Durango",
+      "Estados Unidos Mexicanos",
+      "Jalisco",
+      "Nayarit",
+      "Sinaloa",
       "Zacatecas"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_East", 
-     "s": 17295053, 
+     "id": "Mexico_East",
+     "s": 17295053,
      "affiliations": [
-      "Campeche", 
-      "Chiapas", 
-      "Estados Unidos Mexicanos", 
-      "Oaxaca", 
-      "Orange Walk", 
-      "Quintana Roo", 
-      "Tabasco", 
-      "Veracruz de Ignacio de la Llave", 
+      "Campeche",
+      "Chiapas",
+      "Estados Unidos Mexicanos",
+      "Oaxaca",
+      "Orange Walk",
+      "Quintana Roo",
+      "Tabasco",
+      "Veracruz de Ignacio de la Llave",
       "Yucat\u00e1n"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_Mexico", 
-     "s": 31532303, 
+     "id": "Mexico_Mexico",
+     "s": 31532303,
      "affiliations": [
-      "Distrito Federal", 
-      "Estados Unidos Mexicanos", 
-      "Hidalgo", 
-      "Morelos", 
-      "M\u00e9xico", 
-      "Puebla", 
-      "Tlaxcala", 
+      "Distrito Federal",
+      "Estados Unidos Mexicanos",
+      "Hidalgo",
+      "Morelos",
+      "M\u00e9xico",
+      "Puebla",
+      "Tlaxcala",
       "Veracruz de Ignacio de la Llave"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_Chihuahua", 
-     "s": 11329648, 
+     "id": "Mexico_Chihuahua",
+     "s": 11329648,
      "affiliations": [
-      "Chihuahua", 
-      "Coahuila de Zaragoza", 
-      "Durango", 
-      "Estados Unidos Mexicanos", 
-      "Nuevo Le\u00f3n", 
+      "Chihuahua",
+      "Coahuila de Zaragoza",
+      "Durango",
+      "Estados Unidos Mexicanos",
+      "Nuevo Le\u00f3n",
       "Sinaloa"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_Sonora", 
-     "s": 10151570, 
+     "id": "Mexico_Sonora",
+     "s": 10151570,
      "affiliations": [
-      "Chihuahua", 
-      "Durango", 
-      "Estados Unidos Mexicanos", 
-      "Sinaloa", 
+      "Chihuahua",
+      "Durango",
+      "Estados Unidos Mexicanos",
+      "Sinaloa",
       "Sonora"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
-    }, 
+    },
     {
-     "id": "Mexico_South", 
-     "s": 28000097, 
+     "id": "Mexico_South",
+     "s": 28000097,
      "affiliations": [
-      "Estados Unidos Mexicanos", 
-      "Guerrero", 
-      "Guanajuato", 
-      "Michoac\u00e1n de Ocampo", 
-      "Oaxaca", 
-      "Quer\u00e9taro", 
+      "Estados Unidos Mexicanos",
+      "Guerrero",
+      "Guanajuato",
+      "Michoac\u00e1n de Ocampo",
+      "Oaxaca",
+      "Quer\u00e9taro",
       "Veracruz de Ignacio de la Llave"
-     ], 
+     ],
      "old": [
       "Mexico"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Moldova", 
-   "s": 23337589, 
+   "id": "Moldova",
+   "s": 23337589,
    "affiliations": [
-    "G\u0103g\u0103uzia - Gagauz Yeri - \u0413\u0430\u0433\u0430\u0443\u0437\u0438\u044f", 
-    "Moldova", 
+    "G\u0103g\u0103uzia - Gagauz Yeri - \u0413\u0430\u0433\u0430\u0443\u0437\u0438\u044f",
+    "Moldova",
     "\u041f\u0440\u0438\u0434\u043d\u0435\u0441\u0442\u0440\u043e\u0432\u044c\u0435"
-   ], 
+   ],
    "old": [
     "Moldova"
    ]
-  }, 
+  },
   {
-   "id": "Monaco", 
-   "s": 228669, 
+   "id": "Monaco",
+   "s": 228669,
    "affiliations": [
-    "France", 
+    "France",
     "Monaco"
-   ], 
+   ],
    "old": [
     "Monaco"
    ]
-  }, 
+  },
   {
-   "id": "Mongolia", 
-   "s": 15307633, 
+   "id": "Mongolia",
+   "s": 15307633,
    "affiliations": [
-    "Border Darkhan-Uul - Selenge", 
-    "\u0423\u0432\u0441 \u0430\u0439\u043c\u0430\u0433", 
-    "Border T\u00f6v - Ulan Bator", 
-    "Border Ulan Bator - T\u00f6v", 
-    "\u0423\u043b\u0430\u0430\u043d\u0431\u0430\u0430\u0442\u0430\u0440", 
-    "\u0422\u04e9\u0432", 
-    "\u0425\u043e\u0432\u0434", 
-    "\u0411\u0430\u044f\u043d-\u04e8\u043b\u0433\u0438\u0439", 
-    "\u0413\u043e\u0432\u044c-\u0410\u043b\u0442\u0430\u0439", 
-    "\u041e\u0440\u0445\u043e\u043d \u0430\u0439\u043c\u0430\u0433", 
-    "\u0411\u0443\u043b\u0433\u0430\u043d", 
-    "\u0414\u043e\u0440\u043d\u043e\u0434", 
-    "\u0417\u0430\u0432\u0445\u0430\u043d", 
-    "\u0425\u044d\u043d\u0442\u0438\u0439", 
-    "\u041c\u043e\u043d\u0433\u043e\u043b \u0443\u043b\u0441", 
-    "\u0414\u0430\u0440\u0445\u0430\u043d-\u0423\u0443\u043b", 
-    "\u0421\u044d\u043b\u044d\u043d\u0433\u044d", 
-    "\u0425\u04e9\u0432\u0441\u0433\u04e9\u043b", 
-    "\u0410\u0440\u0445\u0430\u043d\u0433\u0430\u0439", 
-    "\u0414\u0443\u043d\u0434\u0433\u043e\u0432\u044c", 
-    "\u04e8\u043c\u043d\u04e9\u0433\u043e\u0432\u044c", 
-    "\u0414\u043e\u0440\u043d\u043e\u0433\u043e\u0432\u044c", 
-    "\u0421\u04af\u0445\u0431\u0430\u0430\u0442\u0430\u0440", 
-    "\u0411\u0430\u044f\u043d\u0445\u043e\u043d\u0433\u043e\u0440", 
-    "\u0413\u043e\u0432\u044c\u0441\u04af\u043c\u0431\u044d\u0440", 
+    "Border Darkhan-Uul - Selenge",
+    "\u0423\u0432\u0441 \u0430\u0439\u043c\u0430\u0433",
+    "Border T\u00f6v - Ulan Bator",
+    "Border Ulan Bator - T\u00f6v",
+    "\u0423\u043b\u0430\u0430\u043d\u0431\u0430\u0430\u0442\u0430\u0440",
+    "\u0422\u04e9\u0432",
+    "\u0425\u043e\u0432\u0434",
+    "\u0411\u0430\u044f\u043d-\u04e8\u043b\u0433\u0438\u0439",
+    "\u0413\u043e\u0432\u044c-\u0410\u043b\u0442\u0430\u0439",
+    "\u041e\u0440\u0445\u043e\u043d \u0430\u0439\u043c\u0430\u0433",
+    "\u0411\u0443\u043b\u0433\u0430\u043d",
+    "\u0414\u043e\u0440\u043d\u043e\u0434",
+    "\u0417\u0430\u0432\u0445\u0430\u043d",
+    "\u0425\u044d\u043d\u0442\u0438\u0439",
+    "\u041c\u043e\u043d\u0433\u043e\u043b \u0443\u043b\u0441",
+    "\u0414\u0430\u0440\u0445\u0430\u043d-\u0423\u0443\u043b",
+    "\u0421\u044d\u043b\u044d\u043d\u0433\u044d",
+    "\u0425\u04e9\u0432\u0441\u0433\u04e9\u043b",
+    "\u0410\u0440\u0445\u0430\u043d\u0433\u0430\u0439",
+    "\u0414\u0443\u043d\u0434\u0433\u043e\u0432\u044c",
+    "\u04e8\u043c\u043d\u04e9\u0433\u043e\u0432\u044c",
+    "\u0414\u043e\u0440\u043d\u043e\u0433\u043e\u0432\u044c",
+    "\u0421\u04af\u0445\u0431\u0430\u0430\u0442\u0430\u0440",
+    "\u0411\u0430\u044f\u043d\u0445\u043e\u043d\u0433\u043e\u0440",
+    "\u0413\u043e\u0432\u044c\u0441\u04af\u043c\u0431\u044d\u0440",
     "\u04e8\u0432\u04e9\u0440\u0445\u0430\u043d\u0433\u0430\u0439"
-   ], 
+   ],
    "old": [
     "Mongolia"
    ]
-  }, 
+  },
   {
-   "id": "Montenegro", 
-   "s": 16446474, 
+   "id": "Montenegro",
+   "s": 16446474,
    "affiliations": [
     "Crna Gora"
-   ], 
+   ],
    "old": [
     "Montenegro"
    ]
-  }, 
+  },
   {
-   "id": "Morocco", 
+   "id": "Morocco",
    "g": [
     {
-     "id": "Morocco_Western Sahara", 
-     "s": 5278338, 
+     "id": "Morocco_Western Sahara",
+     "s": 5278338,
      "affiliations": [
-      "Dakhla-Oued Ed-Dahab \u2d37\u2d30\u2d45\u2d4d\u2d30-\u2d61\u2d30\u2d37 \u2d37\u2d30\u2d40\u2d30\u2d31 \u0627\u0644\u062f\u0627\u062e\u0644\u0629-\u0648\u0627\u062f\u064a \u0627\u0644\u0630\u0647\u0628", 
-      "Guelmim-Oued Noun \u2d33\u2d4d\u2d4e\u2d49\u2d4e-\u2d61\u2d30\u2d37 \u2d4f\u2d53\u2d4f \u06af\u0644\u0645\u064a\u0645 - \u0648\u0627\u062f \u0646\u0648\u0646", 
-      "La\u00e2youne-Sakia El Hamra \u2d4d\u2d44\u2d62\u2d53\u2d4f-\u2d59\u2d30\u2d47\u2d62\u2d30 \u2d4d\u2d43\u2d30\u2d4e\u2d54\u2d30 \u0627\u0644\u0639\u064a\u0648\u0646-\u0627\u0644\u0633\u0627\u0642\u064a\u0629 \u0627\u0644\u062d\u0645\u0631\u0627\u0621", 
-      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
+      "Dakhla-Oued Ed-Dahab \u2d37\u2d30\u2d45\u2d4d\u2d30-\u2d61\u2d30\u2d37 \u2d37\u2d30\u2d40\u2d30\u2d31 \u0627\u0644\u062f\u0627\u062e\u0644\u0629-\u0648\u0627\u062f\u064a \u0627\u0644\u0630\u0647\u0628",
+      "Guelmim-Oued Noun \u2d33\u2d4d\u2d4e\u2d49\u2d4e-\u2d61\u2d30\u2d37 \u2d4f\u2d53\u2d4f \u06af\u0644\u0645\u064a\u0645 - \u0648\u0627\u062f \u0646\u0648\u0646",
+      "La\u00e2youne-Sakia El Hamra \u2d4d\u2d44\u2d62\u2d53\u2d4f-\u2d59\u2d30\u2d47\u2d62\u2d30 \u2d4d\u2d43\u2d30\u2d4e\u2d54\u2d30 \u0627\u0644\u0639\u064a\u0648\u0646-\u0627\u0644\u0633\u0627\u0642\u064a\u0629 \u0627\u0644\u062d\u0645\u0631\u0627\u0621",
+      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
       "Souss-Massa \u2d59\u2d53\u2d59\u2d59-\u2d4e\u2d30\u2d59\u2d59\u2d30 \u0633\u0648\u0633-\u0645\u0627\u0633\u0629"
-     ], 
+     ],
      "old": [
-      "Morocco", 
+      "Morocco",
       "Sahrawi"
      ]
-    }, 
+    },
     {
-     "id": "Morocco_Southern", 
-     "s": 26812550, 
+     "id": "Morocco_Southern",
+     "s": 26812550,
      "affiliations": [
-      "B\u00e9ni Mellal-Kh\u00e9nifra \u2d30\u2d62\u2d5c \u2d4e\u2d4d\u2d4d\u2d30\u2d4d-\u2d45\u2d4f\u2d49\u2d3c\u2d55\u2d30 \u0628\u0646\u064a \u0645\u0644\u0627\u0644-\u062e\u0646\u064a\u0641\u0631\u0629", 
-      "Dr\u00e2a-Tafilalet \u2d37\u2d30\u2d54\u2d44\u2d30-\u2d5c\u2d30\u2d3c\u2d49\u2d4d\u2d30\u2d4d\u2d5c \u062f\u0631\u0639\u0629-\u062a\u0627\u0641\u064a\u0644\u0627\u0644\u062a", 
-      "F\u00e8s-Mekn\u00e8s \u2d3c\u2d30\u2d59-\u2d4e\u2d3d\u2d4f\u2d30\u2d59 \u0641\u0627\u0633-\u0645\u0643\u0646\u0627\u0633", 
-      "Guelmim-Oued Noun \u2d33\u2d4d\u2d4e\u2d49\u2d4e-\u2d61\u2d30\u2d37 \u2d4f\u2d53\u2d4f \u06af\u0644\u0645\u064a\u0645 - \u0648\u0627\u062f \u0646\u0648\u0646", 
-      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
-      "Oriental \u2d5c\u2d30\u2d4f\u2d33\u2d4e\u2d53\u2d39\u2d5c \u0627\u0644\u0634\u0631\u0642\u064a\u0629", 
+      "B\u00e9ni Mellal-Kh\u00e9nifra \u2d30\u2d62\u2d5c \u2d4e\u2d4d\u2d4d\u2d30\u2d4d-\u2d45\u2d4f\u2d49\u2d3c\u2d55\u2d30 \u0628\u0646\u064a \u0645\u0644\u0627\u0644-\u062e\u0646\u064a\u0641\u0631\u0629",
+      "Dr\u00e2a-Tafilalet \u2d37\u2d30\u2d54\u2d44\u2d30-\u2d5c\u2d30\u2d3c\u2d49\u2d4d\u2d30\u2d4d\u2d5c \u062f\u0631\u0639\u0629-\u062a\u0627\u0641\u064a\u0644\u0627\u0644\u062a",
+      "F\u00e8s-Mekn\u00e8s \u2d3c\u2d30\u2d59-\u2d4e\u2d3d\u2d4f\u2d30\u2d59 \u0641\u0627\u0633-\u0645\u0643\u0646\u0627\u0633",
+      "Guelmim-Oued Noun \u2d33\u2d4d\u2d4e\u2d49\u2d4e-\u2d61\u2d30\u2d37 \u2d4f\u2d53\u2d4f \u06af\u0644\u0645\u064a\u0645 - \u0648\u0627\u062f \u0646\u0648\u0646",
+      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
+      "Oriental \u2d5c\u2d30\u2d4f\u2d33\u2d4e\u2d53\u2d39\u2d5c \u0627\u0644\u0634\u0631\u0642\u064a\u0629",
       "Souss-Massa \u2d59\u2d53\u2d59\u2d59-\u2d4e\u2d30\u2d59\u2d59\u2d30 \u0633\u0648\u0633-\u0645\u0627\u0633\u0629"
-     ], 
+     ],
      "old": [
       "Morocco"
      ]
-    }, 
+    },
     {
-     "id": "Morocco_Doukkala-Abda", 
-     "s": 16532597, 
+     "id": "Morocco_Doukkala-Abda",
+     "s": 16532597,
      "affiliations": [
-      "B\u00e9ni Mellal-Kh\u00e9nifra \u2d30\u2d62\u2d5c \u2d4e\u2d4d\u2d4d\u2d30\u2d4d-\u2d45\u2d4f\u2d49\u2d3c\u2d55\u2d30 \u0628\u0646\u064a \u0645\u0644\u0627\u0644-\u062e\u0646\u064a\u0641\u0631\u0629", 
-      "Casablanca-Settat \u2d5c\u2d49\u2d33\u2d4e\u2d49 \u2d5c\u2d53\u2d4e\u2d4d\u2d49\u2d4d\u2d5c-\u2d59\u2d5f\u2d5f\u2d30\u2d5c \u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621-\u0633\u0637\u0627\u062a", 
-      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
+      "B\u00e9ni Mellal-Kh\u00e9nifra \u2d30\u2d62\u2d5c \u2d4e\u2d4d\u2d4d\u2d30\u2d4d-\u2d45\u2d4f\u2d49\u2d3c\u2d55\u2d30 \u0628\u0646\u064a \u0645\u0644\u0627\u0644-\u062e\u0646\u064a\u0641\u0631\u0629",
+      "Casablanca-Settat \u2d5c\u2d49\u2d33\u2d4e\u2d49 \u2d5c\u2d53\u2d4e\u2d4d\u2d49\u2d4d\u2d5c-\u2d59\u2d5f\u2d5f\u2d30\u2d5c \u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621-\u0633\u0637\u0627\u062a",
+      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
       "Marrakech-Safi \u2d4e\u2d55\u2d55\u2d30\u2d3d\u2d5b-\u2d30\u2d59\u2d3c\u2d49 \u0645\u0631\u0627\u0643\u0634-\u0623\u0633\u0641\u064a"
-     ], 
+     ],
      "old": [
       "Morocco"
      ]
-    }, 
+    },
     {
-     "id": "Morocco_Rabat-Sale-Zemmour-Zaer", 
-     "s": 13136553, 
+     "id": "Morocco_Rabat-Sale-Zemmour-Zaer",
+     "s": 13136553,
      "affiliations": [
-      "F\u00e8s-Mekn\u00e8s \u2d3c\u2d30\u2d59-\u2d4e\u2d3d\u2d4f\u2d30\u2d59 \u0641\u0627\u0633-\u0645\u0643\u0646\u0627\u0633", 
-      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
-      "Oriental \u2d5c\u2d30\u2d4f\u2d33\u2d4e\u2d53\u2d39\u2d5c \u0627\u0644\u0634\u0631\u0642\u064a\u0629", 
-      "Rabat-Sal\u00e9-K\u00e9nitra \u2d3b\u2d54\u2d54\u2d31\u2d30\u2d5f-\u2d59\u2d4d\u2d30-\u2d47\u2d4f\u2d49\u2d5f\u2d54\u2d30 \u0627\u0644\u0631\u0628\u0627\u0637-\u0633\u0644\u0627-\u0627\u0644\u0642\u0646\u064a\u0637\u0631\u0629", 
+      "F\u00e8s-Mekn\u00e8s \u2d3c\u2d30\u2d59-\u2d4e\u2d3d\u2d4f\u2d30\u2d59 \u0641\u0627\u0633-\u0645\u0643\u0646\u0627\u0633",
+      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
+      "Oriental \u2d5c\u2d30\u2d4f\u2d33\u2d4e\u2d53\u2d39\u2d5c \u0627\u0644\u0634\u0631\u0642\u064a\u0629",
+      "Rabat-Sal\u00e9-K\u00e9nitra \u2d3b\u2d54\u2d54\u2d31\u2d30\u2d5f-\u2d59\u2d4d\u2d30-\u2d47\u2d4f\u2d49\u2d5f\u2d54\u2d30 \u0627\u0644\u0631\u0628\u0627\u0637-\u0633\u0644\u0627-\u0627\u0644\u0642\u0646\u064a\u0637\u0631\u0629",
       "Tanger-T\u00e9touan-Al Hoceima \u2d5f\u2d30\u2d4f\u2d4a-\u2d5f\u2d49\u2d5c\u2d30\u2d61\u2d49\u2d4f-\u2d4d\u2d43\u2d53\u2d59\u2d49\u2d4e\u2d30 \u0637\u0646\u062c\u0629-\u062a\u0637\u0648\u0627\u0646-\u0627\u0644\u062d\u0633\u064a\u0645\u0629"
-     ], 
+     ],
      "old": [
       "Morocco"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Mozambique", 
-   "s": 80298235, 
+   "id": "Mozambique",
+   "s": 80298235,
    "affiliations": [
-    "Cabo Delgado", 
-    "Gaza", 
-    "Inhambane", 
-    "Manica", 
-    "Maputo", 
-    "Niassa", 
-    "Mo\u00e7ambique", 
-    "Nampula", 
-    "Tete", 
-    "Sofala", 
+    "Cabo Delgado",
+    "Gaza",
+    "Inhambane",
+    "Manica",
+    "Maputo",
+    "Niassa",
+    "Mo\u00e7ambique",
+    "Nampula",
+    "Tete",
+    "Sofala",
     "Zamb\u00e9zia"
-   ], 
+   ],
    "old": [
     "Mozambique"
    ]
-  }, 
+  },
   {
-   "id": "Myanmar", 
-   "s": 34313060, 
+   "id": "Myanmar",
+   "s": 34313060,
    "affiliations": [
-    "Ayeyarwady", 
-    "Bago Region", 
-    "Chin", 
-    "Kachin", 
-    "Kayah", 
-    "Kayin", 
-    "Magway", 
-    "Mandalay", 
-    "Mon", 
-    "Naypyitaw", 
-    "Rakhine", 
-    "Shan State", 
-    "Tanintharyi", 
-    "Yangon", 
-    "\u1005\u1005\u103a\u1000\u102d\u102f\u1004\u103a\u1038\u1010\u102d\u102f\u1004\u103a\u1038 (Sagaing)", 
+    "Ayeyarwady",
+    "Bago Region",
+    "Chin",
+    "Kachin",
+    "Kayah",
+    "Kayin",
+    "Magway",
+    "Mandalay",
+    "Mon",
+    "Naypyitaw",
+    "Rakhine",
+    "Shan State",
+    "Tanintharyi",
+    "Yangon",
+    "\u1005\u1005\u103a\u1000\u102d\u102f\u1004\u103a\u1038\u1010\u102d\u102f\u1004\u103a\u1038 (Sagaing)",
     "\u1015\u103c\u100a\u103a\u1011\u1031\u102c\u1004\u103a\u1005\u102f\u1019\u103c\u1014\u103a\u1019\u102c\u1014\u102d\u102f\u1004\u103a\u1004\u1036\u1010\u1031\u102c\u103a\u200c"
-   ], 
+   ],
    "old": [
     "Burma"
    ]
-  }, 
+  },
   {
-   "id": "Namibia", 
-   "s": 13528527, 
+   "id": "Namibia",
+   "s": 13528527,
    "affiliations": [
-    "Arandis", 
-    "Aranos7", 
-    "Erongo Region", 
-    "Hardap Region", 
-    "Katima Mulilo", 
-    "Kavango-East Region", 
-    "Kavango-West Region", 
-    "Khomas Region", 
-    "Kunene Region", 
-    "Namibia", 
-    "Ohangwena Region", 
-    "Okahao", 
-    "Omaheke Region", 
-    "Omusati Region", 
-    "Oranjemund", 
-    "Oshana Region", 
-    "Oshikoto Region", 
-    "Otavi", 
-    "Otjozondjupa Region", 
-    "Outapi", 
-    "Rehoboth", 
-    "Zambezi Region", 
+    "Arandis",
+    "Aranos7",
+    "Erongo Region",
+    "Hardap Region",
+    "Katima Mulilo",
+    "Kavango-East Region",
+    "Kavango-West Region",
+    "Khomas Region",
+    "Kunene Region",
+    "Namibia",
+    "Ohangwena Region",
+    "Okahao",
+    "Omaheke Region",
+    "Omusati Region",
+    "Oranjemund",
+    "Oshana Region",
+    "Oshikoto Region",
+    "Otavi",
+    "Otjozondjupa Region",
+    "Outapi",
+    "Rehoboth",
+    "Zambezi Region",
     "\u01c1Karas Region"
-   ], 
+   ],
    "old": [
     "Namibia"
    ]
-  }, 
+  },
   {
-   "id": "Nauru", 
-   "s": 277781, 
+   "id": "Nauru",
+   "s": 277781,
    "affiliations": [
     "Naoero"
-   ], 
+   ],
    "old": [
     "Nauru"
    ]
-  }, 
+  },
   {
-   "id": "Nepal", 
+   "id": "Nepal",
    "g": [
     {
-     "id": "Nepal_West", 
-     "s": 52981963, 
+     "id": "Nepal_West",
+     "s": 52981963,
      "affiliations": [
-      "\u092e\u0927\u094d\u092f-\u092a\u0936\u094d\u091a\u093f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930", 
-      "\u0928\u0947\u092a\u093e\u0932", 
-      "\u0938\u0941\u0926\u0941\u0930 \u092a\u0936\u094d\u091a\u093f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930", 
+      "\u092e\u0927\u094d\u092f-\u092a\u0936\u094d\u091a\u093f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930",
+      "\u0928\u0947\u092a\u093e\u0932",
+      "\u0938\u0941\u0926\u0941\u0930 \u092a\u0936\u094d\u091a\u093f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930",
       "\u092a\u0936\u094d\u091a\u093f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930"
-     ], 
+     ],
      "old": [
       "Nepal"
      ]
-    }, 
+    },
     {
-     "id": "Nepal_Kathmandu", 
-     "s": 26358911, 
+     "id": "Nepal_Kathmandu",
+     "s": 26358911,
      "affiliations": [
-      "\u092e\u0927\u094d\u092f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930", 
+      "\u092e\u0927\u094d\u092f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930",
       "\u0928\u0947\u092a\u093e\u0932"
-     ], 
+     ],
      "old": [
       "Nepal"
      ]
-    }, 
+    },
     {
-     "id": "Nepal_Madhyamanchal", 
-     "s": 23033062, 
+     "id": "Nepal_Madhyamanchal",
+     "s": 23033062,
      "affiliations": [
-      "\u092e\u0927\u094d\u092f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930", 
+      "\u092e\u0927\u094d\u092f\u092e\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930",
       "\u0928\u0947\u092a\u093e\u0932"
-     ], 
+     ],
      "old": [
       "Nepal"
      ]
-    }, 
+    },
     {
-     "id": "Nepal_Purwanchal", 
-     "s": 13028563, 
+     "id": "Nepal_Purwanchal",
+     "s": 13028563,
      "affiliations": [
-      "\u092a\u0941\u0930\u094d\u0935\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930", 
+      "\u092a\u0941\u0930\u094d\u0935\u093e\u091e\u094d\u091a\u0932 \u0935\u093f\u0915\u093e\u0938 \u0915\u094d\u0937\u0947\u0924\u094d\u0930",
       "\u0928\u0947\u092a\u093e\u0932"
-     ], 
+     ],
      "old": [
       "Nepal"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Nicaragua", 
-   "s": 12362246, 
+   "id": "Nicaragua",
+   "s": 12362246,
    "affiliations": [
-    "Boaco", 
-    "Carazo", 
-    "Matagalpa", 
-    "Chinandega", 
-    "Chontales", 
-    "Jinotega", 
-    "Estel\u00ed", 
-    "Gracias a Dios", 
-    "Granada", 
-    "Le\u00f3n", 
-    "Madriz", 
-    "Managua", 
-    "Masaya", 
-    "Nicaragua", 
-    "R\u00edo San Juan", 
-    "Nueva Segovia", 
-    "Regi\u00f3n Aut\u00f3noma de la Costa Caribe Norte", 
-    "Regi\u00f3n Aut\u00f3noma de la Costa Caribe Sur", 
+    "Boaco",
+    "Carazo",
+    "Matagalpa",
+    "Chinandega",
+    "Chontales",
+    "Jinotega",
+    "Estel\u00ed",
+    "Gracias a Dios",
+    "Granada",
+    "Le\u00f3n",
+    "Madriz",
+    "Managua",
+    "Masaya",
+    "Nicaragua",
+    "R\u00edo San Juan",
+    "Nueva Segovia",
+    "Regi\u00f3n Aut\u00f3noma de la Costa Caribe Norte",
+    "Regi\u00f3n Aut\u00f3noma de la Costa Caribe Sur",
     "Rivas"
-   ], 
+   ],
    "old": [
     "Nicaragua"
    ]
-  }, 
+  },
   {
-   "id": "Niger", 
-   "s": 13234475, 
+   "id": "Niger",
+   "s": 13234475,
    "affiliations": [
-    "Agadez", 
-    "Dosso", 
-    "Diffa", 
-    "Maradi", 
-    "Niamey", 
-    "Niger", 
-    "Tahoua", 
-    "Tillab\u00e9ri", 
+    "Agadez",
+    "Dosso",
+    "Diffa",
+    "Maradi",
+    "Niamey",
+    "Niger",
+    "Tahoua",
+    "Tillab\u00e9ri",
     "Zinder"
-   ], 
+   ],
    "old": [
     "Niger"
    ]
-  }, 
+  },
   {
-   "id": "Nigeria", 
+   "id": "Nigeria",
    "g": [
     {
-     "id": "Nigeria_South", 
-     "s": 34650798, 
+     "id": "Nigeria_South",
+     "s": 34650798,
      "affiliations": [
-      "Abia", 
-      "Adamawa", 
-      "Akwa Ibom", 
-      "Anambra", 
-      "Bayelsa", 
-      "Benue", 
-      "Cross River", 
-      "Delta", 
-      "Ebonyi", 
-      "Edo", 
-      "Ekiti", 
-      "Enugu", 
-      "Federal Capital Territory", 
-      "Imo", 
-      "Kaduna", 
-      "Kogi", 
-      "Kebbi", 
-      "Kwara", 
-      "Lagos", 
-      "Nasarawa", 
-      "Niger", 
-      "Nigeria", 
-      "Ogun", 
-      "Ondo", 
-      "Osun", 
-      "Oyo", 
-      "Plateau", 
-      "Rivers", 
+      "Abia",
+      "Adamawa",
+      "Akwa Ibom",
+      "Anambra",
+      "Bayelsa",
+      "Benue",
+      "Cross River",
+      "Delta",
+      "Ebonyi",
+      "Edo",
+      "Ekiti",
+      "Enugu",
+      "Federal Capital Territory",
+      "Imo",
+      "Kaduna",
+      "Kogi",
+      "Kebbi",
+      "Kwara",
+      "Lagos",
+      "Nasarawa",
+      "Niger",
+      "Nigeria",
+      "Ogun",
+      "Ondo",
+      "Osun",
+      "Oyo",
+      "Plateau",
+      "Rivers",
       "Taraba"
-     ], 
+     ],
      "old": [
       "Nigeria"
      ]
-    }, 
+    },
     {
-     "id": "Nigeria_North", 
-     "s": 26746196, 
+     "id": "Nigeria_North",
+     "s": 26746196,
      "affiliations": [
-      "Bauchi", 
-      "Borno", 
-      "Jigawa", 
-      "Gombe", 
-      "Kano", 
-      "Katsina", 
-      "Kebbi", 
-      "Niger", 
-      "Nigeria", 
-      "Sokoto", 
-      "Yobe", 
+      "Bauchi",
+      "Borno",
+      "Jigawa",
+      "Gombe",
+      "Kano",
+      "Katsina",
+      "Kebbi",
+      "Niger",
+      "Nigeria",
+      "Sokoto",
+      "Yobe",
       "Zamfara"
-     ], 
+     ],
      "old": [
       "Nigeria"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Niue", 
-   "s": 195421, 
+   "id": "Niue",
+   "s": 195421,
    "affiliations": [
     "Niu\u0113"
-   ], 
+   ],
    "old": [
     "Niue"
    ]
-  }, 
+  },
   {
-   "id": "North Korea", 
-   "s": 14819753, 
+   "id": "North Korea",
+   "s": 14819753,
    "affiliations": [
-    "\uac15\uc6d0\ub3c4", 
-    "\ub7c9\uac15\ub3c4", 
-    "\uc790\uac15\ub3c4", 
-    "\uae08\uac15\uc0b0\uad00\uad11\uc9c0\uad6c", 
-    "\ud3c9\uc548\ub0a8\ub3c4", 
-    "\ud3c9\uc548\ubd81\ub3c4", 
-    "\ud568\uacbd\ub0a8\ub3c4", 
-    "\ud568\uacbd\ubd81\ub3c4", 
-    "\ud669\ud574\ub0a8\ub3c4", 
-    "\ud669\ud574\ubd81\ub3c4", 
-    "\ud3c9\uc591\uc9c1\ud560\uc2dc", 
+    "\uac15\uc6d0\ub3c4",
+    "\ub7c9\uac15\ub3c4",
+    "\uc790\uac15\ub3c4",
+    "\uae08\uac15\uc0b0\uad00\uad11\uc9c0\uad6c",
+    "\ud3c9\uc548\ub0a8\ub3c4",
+    "\ud3c9\uc548\ubd81\ub3c4",
+    "\ud568\uacbd\ub0a8\ub3c4",
+    "\ud568\uacbd\ubd81\ub3c4",
+    "\ud669\ud574\ub0a8\ub3c4",
+    "\ud669\ud574\ubd81\ub3c4",
+    "\ud3c9\uc591\uc9c1\ud560\uc2dc",
     "\uc870\uc120\ubbfc\uc8fc\uc8fc\uc758\uc778\ubbfc\uacf5\ud654\uad6d"
-   ], 
+   ],
    "old": [
     "North Korea"
    ]
-  }, 
+  },
   {
-   "id": "Norway", 
+   "id": "Norway",
    "g": [
     {
-     "id": "Norway_Northern", 
-     "s": 63863224, 
+     "id": "Norway_Northern",
+     "s": 63863224,
      "affiliations": [
-      "Finnmark", 
-      "Norge", 
+      "Finnmark",
+      "Norge",
       "Troms"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Hordaland", 
-     "s": 44718620, 
+     "id": "Norway_Hordaland",
+     "s": 44718620,
      "affiliations": [
-      "Hordaland", 
+      "Hordaland",
       "Norge"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Nordland", 
-     "s": 28268025, 
+     "id": "Norway_Nordland",
+     "s": 28268025,
      "affiliations": [
-      "Nordland", 
-      "Norge", 
+      "Nordland",
+      "Norge",
       "Troms"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Svalbard", 
-     "s": 1375925, 
+     "id": "Norway_Svalbard",
+     "s": 1375925,
      "affiliations": [
-      "Norge", 
+      "Norge",
       "Svalbard"
-     ], 
+     ],
      "old": [
       "Svalbard and Jan Mayen"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Oppland", 
-     "s": 36249947, 
+     "id": "Norway_Oppland",
+     "s": 36249947,
      "affiliations": [
-      "Norge", 
+      "Norge",
       "Oppland"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Rogaland", 
-     "s": 21837757, 
+     "id": "Norway_Rogaland",
+     "s": 21837757,
      "affiliations": [
-      "Norge", 
+      "Norge",
       "Rogaland"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Hedmark", 
-     "s": 38761224, 
+     "id": "Norway_Hedmark",
+     "s": 38761224,
      "affiliations": [
-      "Hedmark", 
+      "Hedmark",
       "Norge"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Jan Mayen", 
-     "s": 202797, 
+     "id": "Norway_Jan Mayen",
+     "s": 202797,
      "affiliations": [
-      "Jan Mayen", 
+      "Jan Mayen",
       "Norge"
      ]
-    }, 
+    },
     {
-     "id": "Norway_North Trondelag", 
-     "s": 47674552, 
+     "id": "Norway_North Trondelag",
+     "s": 47674552,
      "affiliations": [
-      "Nord-Tr\u00f8ndelag", 
-      "Norge", 
+      "Nord-Tr\u00f8ndelag",
+      "Norge",
       "S\u00f8r-Tr\u00f8ndelag"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_South Trondelag", 
-     "s": 52422859, 
+     "id": "Norway_South Trondelag",
+     "s": 52422859,
      "affiliations": [
-      "Norge", 
+      "Norge",
       "S\u00f8r-Tr\u00f8ndelag"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Southern", 
-     "s": 63347777, 
+     "id": "Norway_Southern",
+     "s": 63347777,
      "affiliations": [
-      "Aust-Agder", 
-      "\u00d8stfold", 
-      "Norge", 
-      "Telemark", 
-      "Vest-Agder", 
+      "Aust-Agder",
+      "\u00d8stfold",
+      "Norge",
+      "Telemark",
+      "Vest-Agder",
       "Vestfold"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Western", 
-     "s": 58270708, 
+     "id": "Norway_Western",
+     "s": 58270708,
      "affiliations": [
-      "M\u00f8re og Romsdal", 
-      "Norge", 
+      "M\u00f8re og Romsdal",
+      "Norge",
       "Sogn og Fjordane"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Central", 
-     "s": 56320160, 
+     "id": "Norway_Central",
+     "s": 56320160,
      "affiliations": [
-      "Akershus", 
-      "Buskerud", 
-      "Norge", 
+      "Akershus",
+      "Buskerud",
+      "Norge",
       "Oslo"
-     ], 
+     ],
      "old": [
       "Norway"
      ]
-    }, 
+    },
     {
-     "id": "Norway_Bouvet Island", 
-     "s": 20447, 
+     "id": "Norway_Bouvet Island",
+     "s": 20447,
      "affiliations": [
-      "Bouvet\u00f8ya", 
+      "Bouvet\u00f8ya",
       "Norge"
-     ], 
+     ],
      "old": [
       "Bouvet Island"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Oman", 
-   "s": 9653452, 
+   "id": "Oman",
+   "s": 9653452,
    "affiliations": [
-    "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0638\u0627\u0647\u0631\u0629", 
-    "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062f\u0627\u062e\u0644\u064a\u0629", 
-    "\u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0629", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0638\u0641\u0627\u0631", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0642\u0637", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u062c\u0646\u0648\u0628 \u0627\u0644\u0628\u0627\u0637\u0646\u0629", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0634\u0645\u0627\u0644 \u0627\u0644\u0628\u0627\u0637\u0646\u0629", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0648\u0633\u0637\u0649", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0646\u062f\u0645", 
-    "\u200f\u0633\u0644\u0637\u0646\u0629 \u0639\u0645\u0627\u0646\u200e", 
+    "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0638\u0627\u0647\u0631\u0629",
+    "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062f\u0627\u062e\u0644\u064a\u0629",
+    "\u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0629",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0638\u0641\u0627\u0631",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0642\u0637",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u062c\u0646\u0648\u0628 \u0627\u0644\u0628\u0627\u0637\u0646\u0629",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0634\u0645\u0627\u0644 \u0627\u0644\u0628\u0627\u0637\u0646\u0629",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0648\u0633\u0637\u0649",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0646\u062f\u0645",
+    "\u200f\u0633\u0644\u0637\u0646\u0629 \u0639\u0645\u0627\u0646\u200e",
     "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0628\u0631\u064a\u0645\u064a"
-   ], 
+   ],
    "old": [
     "Oman"
    ]
-  }, 
+  },
   {
-   "id": "Pakistan", 
-   "s": 31222496, 
+   "id": "Pakistan",
+   "s": 31222496,
    "affiliations": [
-    "\u0633\u0646\u068c", 
-    "\u0622\u0632\u0627\u062f \u062c\u0645\u0648\u06ba \u0648 \u06a9\u0634\u0645\u06cc\u0631", 
-    "\u06af\u0644\u06af\u062a \u0628\u0644\u062a\u0633\u062a\u0627\u0646", 
-    "\u062e\u06cc\u0628\u0631 \u067e\u062e\u062a\u0648\u0646\u062e\u0648\u0627", 
-    "\u067e\u0646\u062c\u0627\u0628", 
-    "\u0648\u0641\u0627\u0642\u06cc \u0642\u0628\u0627\u0626\u0644\u06cc \u0639\u0644\u0627\u0642\u06c1 \u062c\u0627\u062a", 
-    "\u0648\u0641\u0627\u0642\u06cc \u062f\u0627\u0631\u0627\u0644\u062d\u06a9\u0648\u0645\u062a", 
-    "\u0628\u0644\u0648\u0686\u0633\u062a\u0627\u0646 / Balochistan", 
+    "\u0633\u0646\u068c",
+    "\u0622\u0632\u0627\u062f \u062c\u0645\u0648\u06ba \u0648 \u06a9\u0634\u0645\u06cc\u0631",
+    "\u06af\u0644\u06af\u062a \u0628\u0644\u062a\u0633\u062a\u0627\u0646",
+    "\u062e\u06cc\u0628\u0631 \u067e\u062e\u062a\u0648\u0646\u062e\u0648\u0627",
+    "\u067e\u0646\u062c\u0627\u0628",
+    "\u0648\u0641\u0627\u0642\u06cc \u0642\u0628\u0627\u0626\u0644\u06cc \u0639\u0644\u0627\u0642\u06c1 \u062c\u0627\u062a",
+    "\u0648\u0641\u0627\u0642\u06cc \u062f\u0627\u0631\u0627\u0644\u062d\u06a9\u0648\u0645\u062a",
+    "\u0628\u0644\u0648\u0686\u0633\u062a\u0627\u0646 / Balochistan",
     "\u200f\u067e\u0627\u06a9\u0633\u062a\u0627\u0646\u200e"
-   ], 
+   ],
    "old": [
     "Pakistan"
    ]
-  }, 
+  },
   {
-   "id": "Palau", 
-   "s": 421397, 
+   "id": "Palau",
+   "s": 421397,
    "affiliations": [
-    "Belau", 
+    "Belau",
     "PW"
-   ], 
+   ],
    "old": [
     "Palau"
    ]
-  }, 
+  },
   {
-   "id": "Panama", 
-   "s": 8999374, 
+   "id": "Panama",
+   "s": 8999374,
    "affiliations": [
-    "Bocas del Toro", 
-    "Chiriqu\u00ed", 
-    "Cocl\u00e9", 
-    "Col\u00f3n", 
-    "Dari\u00e9n", 
-    "Ember\u00e1-Wounaan", 
-    "Guna Yala", 
-    "Herrera", 
-    "Isla Bastimentos", 
-    "Isla Loma Partida", 
-    "Los Santos", 
-    "Kuna de Madugand\u00ed", 
-    "Kuna de Wargand\u00ed", 
-    "Ng\u00e4be-Bugl\u00e9", 
-    "Panam\u00e1 Oeste", 
-    "Panam\u00e1", 
-    "Panam\u00e1", 
+    "Bocas del Toro",
+    "Chiriqu\u00ed",
+    "Cocl\u00e9",
+    "Col\u00f3n",
+    "Dari\u00e9n",
+    "Ember\u00e1-Wounaan",
+    "Guna Yala",
+    "Herrera",
+    "Isla Bastimentos",
+    "Isla Loma Partida",
+    "Los Santos",
+    "Kuna de Madugand\u00ed",
+    "Kuna de Wargand\u00ed",
+    "Ng\u00e4be-Bugl\u00e9",
+    "Panam\u00e1 Oeste",
+    "Panam\u00e1",
+    "Panam\u00e1",
     "Veraguas"
-   ], 
+   ],
    "old": [
     "Panama"
    ]
-  }, 
+  },
   {
-   "id": "Papua New Guinea", 
-   "s": 6496447, 
+   "id": "Papua New Guinea",
+   "s": 6496447,
    "affiliations": [
-    "Border Central-NCD", 
-    "Bougainville", 
-    "Manus", 
-    "Central", 
-    "East New Britain", 
-    "East Sepik", 
-    "Eastern Highlands", 
-    "Enga", 
-    "Gulf", 
-    "Hela", 
-    "Jiwaka", 
-    "Madang", 
-    "New Ireland", 
-    "Milne Bay", 
-    "Morobe", 
-    "National Capital District", 
-    "Oro", 
-    "Papua Niugini", 
-    "Sandaun", 
-    "Simbu", 
-    "Southern Highlands", 
-    "West New Britain", 
-    "Western", 
+    "Border Central-NCD",
+    "Bougainville",
+    "Manus",
+    "Central",
+    "East New Britain",
+    "East Sepik",
+    "Eastern Highlands",
+    "Enga",
+    "Gulf",
+    "Hela",
+    "Jiwaka",
+    "Madang",
+    "New Ireland",
+    "Milne Bay",
+    "Morobe",
+    "National Capital District",
+    "Oro",
+    "Papua Niugini",
+    "Sandaun",
+    "Simbu",
+    "Southern Highlands",
+    "West New Britain",
+    "Western",
     "Western Highlands"
-   ], 
+   ],
    "old": [
     "Papua New Guinea"
    ]
-  }, 
+  },
   {
-   "id": "Paraguay", 
-   "s": 19303613, 
+   "id": "Paraguay",
+   "s": 19303613,
    "affiliations": [
-    "Alto Paraguay", 
-    "Alto Paran\u00e1", 
-    "Amambay", 
-    "Caaguaz\u00fa", 
-    "Caazap\u00e1", 
-    "Boquer\u00f3n", 
-    "Borde Cordillera - Caaguaz\u00fa", 
-    "Canindey\u00fa", 
-    "Central", 
-    "Distrito Capital de Paraguay", 
-    "Concepci\u00f3n", 
-    "Cordillera", 
-    "Guair\u00e1", 
-    "Isla Dorado", 
-    "Itap\u00faa", 
-    "Misiones", 
-    "\u00d1eembuc\u00fa", 
-    "Paraguar\u00ed", 
-    "Paraguay", 
-    "Presidente Hayes", 
+    "Alto Paraguay",
+    "Alto Paran\u00e1",
+    "Amambay",
+    "Caaguaz\u00fa",
+    "Caazap\u00e1",
+    "Boquer\u00f3n",
+    "Borde Cordillera - Caaguaz\u00fa",
+    "Canindey\u00fa",
+    "Central",
+    "Distrito Capital de Paraguay",
+    "Concepci\u00f3n",
+    "Cordillera",
+    "Guair\u00e1",
+    "Isla Dorado",
+    "Itap\u00faa",
+    "Misiones",
+    "\u00d1eembuc\u00fa",
+    "Paraguar\u00ed",
+    "Paraguay",
+    "Presidente Hayes",
     "San Pedro"
-   ], 
+   ],
    "old": [
     "Paraguay"
    ]
-  }, 
+  },
   {
-   "id": "People's Republic of China", 
+   "id": "People's Republic of China",
    "g": [
     {
-     "id": "China_Anhui", 
-     "s": 10872225, 
+     "id": "China_Anhui",
+     "s": 10872225,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u5b89\u5fbd\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Chongqing", 
-     "s": 6381239, 
+     "id": "China_Chongqing",
+     "s": 6381239,
      "affiliations": [
-      "\u91cd\u5e86\u5e02", 
+      "\u91cd\u5e86\u5e02",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Fujian", 
-     "s": 9461283, 
+     "id": "China_Fujian",
+     "s": 9461283,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u798f\u5efa\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Gansu", 
-     "s": 13068751, 
+     "id": "China_Gansu",
+     "s": 13068751,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u7518\u8083\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Guangdong", 
-     "s": 49728979, 
+     "id": "China_Guangdong",
+     "s": 49728979,
      "affiliations": [
-      "\u4e2d\u56fd", 
-      "\u5e7f\u4e1c\u7701", 
+      "\u4e2d\u56fd",
+      "\u5e7f\u4e1c\u7701",
       "\u6d77\u5357\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Guangxi", 
-     "s": 9138896, 
+     "id": "China_Guangxi",
+     "s": 9138896,
      "affiliations": [
-      "\u5e7f\u897f\u58ee\u65cf\u81ea\u6cbb\u533a", 
+      "\u5e7f\u897f\u58ee\u65cf\u81ea\u6cbb\u533a",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Guizhou", 
-     "s": 6260278, 
+     "id": "China_Guizhou",
+     "s": 6260278,
      "affiliations": [
-      "\u8d35\u5dde\u7701", 
+      "\u8d35\u5dde\u7701",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Hebei", 
-     "s": 21704308, 
+     "id": "China_Hebei",
+     "s": 21704308,
      "affiliations": [
-      "\u4e2d\u56fd", 
-      "\u5317\u4eac\u5e02", 
-      "\u5929\u6d25\u5e02", 
+      "\u4e2d\u56fd",
+      "\u5317\u4eac\u5e02",
+      "\u5929\u6d25\u5e02",
       "\u6cb3\u5317\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Heilongjiang", 
-     "s": 7318237, 
+     "id": "China_Heilongjiang",
+     "s": 7318237,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u9ed1\u9f99\u6c5f\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Henan", 
-     "s": 7968601, 
+     "id": "China_Henan",
+     "s": 7968601,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u6cb3\u5357\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Hubei", 
-     "s": 9116870, 
+     "id": "China_Hubei",
+     "s": 9116870,
      "affiliations": [
-      "Border Henan - Hubei", 
-      "\u4e2d\u56fd", 
+      "Border Henan - Hubei",
+      "\u4e2d\u56fd",
       "\u6e56\u5317\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Hunan", 
-     "s": 9702592, 
+     "id": "China_Hunan",
+     "s": 9702592,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u6e56\u5357\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Inner Mongolia", 
-     "s": 10645818, 
+     "id": "China_Inner Mongolia",
+     "s": 10645818,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u5185\u8499\u53e4\u81ea\u6cbb\u533a / Inner Mongolia"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Jiangsu", 
-     "s": 24856391, 
+     "id": "China_Jiangsu",
+     "s": 24856391,
      "affiliations": [
-      "\u4e2d\u56fd", 
-      "\u6c5f\u82cf\u7701", 
+      "\u4e2d\u56fd",
+      "\u6c5f\u82cf\u7701",
       "\u79e6\u5c71\u5c9b"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Jiangxi", 
-     "s": 9474101, 
+     "id": "China_Jiangxi",
+     "s": 9474101,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u6c5f\u897f\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Jilin", 
-     "s": 7327174, 
+     "id": "China_Jilin",
+     "s": 7327174,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u5409\u6797\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Liaoning", 
-     "s": 9042298, 
+     "id": "China_Liaoning",
+     "s": 9042298,
      "affiliations": [
-      "\u8fbd\u5b81\u7701", 
+      "\u8fbd\u5b81\u7701",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Ningxia Hui", 
-     "s": 2545410, 
+     "id": "China_Ningxia Hui",
+     "s": 2545410,
      "affiliations": [
-      "\u5b81\u590f\u56de\u65cf\u81ea\u6cbb\u533a", 
+      "\u5b81\u590f\u56de\u65cf\u81ea\u6cbb\u533a",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Qinghai", 
-     "s": 6974356, 
+     "id": "China_Qinghai",
+     "s": 6974356,
      "affiliations": [
-      "\u9752\u6d77\u7701", 
+      "\u9752\u6d77\u7701",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Shaanxi", 
-     "s": 9847381, 
+     "id": "China_Shaanxi",
+     "s": 9847381,
      "affiliations": [
-      "\u9655\u897f\u7701", 
+      "\u9655\u897f\u7701",
       "\u4e2d\u56fd"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Shandong", 
-     "s": 14690573, 
+     "id": "China_Shandong",
+     "s": 14690573,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u5c71\u4e1c\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Shanghai", 
-     "s": 9136697, 
+     "id": "China_Shanghai",
+     "s": 9136697,
      "affiliations": [
-      "\u4e2d\u56fd", 
-      "\u4e0a\u6d77\u5e02", 
+      "\u4e2d\u56fd",
+      "\u4e0a\u6d77\u5e02",
       "\u6d59\u6c5f\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Shanxi", 
-     "s": 5688572, 
+     "id": "China_Shanxi",
+     "s": 5688572,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u5c71\u897f\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Sichuan", 
-     "s": 23116122, 
+     "id": "China_Sichuan",
+     "s": 23116122,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u56db\u5ddd\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Tibet Autonomous Region", 
-     "s": 13809029, 
+     "id": "China_Tibet Autonomous Region",
+     "s": 13809029,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u897f\u85cf\u81ea\u6cbb\u533a (\u0f56\u0f7c\u0f51\u0f0b\u0f62\u0f44\u0f0b\u0f66\u0f90\u0fb1\u0f7c\u0f44\u0f0b\u0f63\u0f97\u0f7c\u0f44\u0f66\u0f0b)"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Xinjiang", 
-     "s": 13739686, 
+     "id": "China_Xinjiang",
+     "s": 13739686,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u65b0\u7586\u7ef4\u543e\u5c14\u81ea\u6cbb\u533a"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Yunnan", 
-     "s": 16536762, 
+     "id": "China_Yunnan",
+     "s": 16536762,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u4e91\u5357\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
-    }, 
+    },
     {
-     "id": "China_Zhejiang", 
-     "s": 17180313, 
+     "id": "China_Zhejiang",
+     "s": 17180313,
      "affiliations": [
-      "\u4e2d\u56fd", 
+      "\u4e2d\u56fd",
       "\u6d59\u6c5f\u7701"
-     ], 
+     ],
      "old": [
       "China"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Taiwan", 
+   "id": "Taiwan",
    "g": [
     {
-     "id": "Taiwan_North", 
-     "s": 29978186, 
+     "id": "Taiwan_North",
+     "s": 29978186,
      "affiliations": [
-      "\u4e2d\u56fd", 
-      "\u65b0\u5317\u5e02", 
-      "\u6843\u5712\u5e02", 
-      "\u798f\u5efa\u7701", 
-      "\u81fa\u4e2d\u5e02", 
-      "\u81fa\u5317\u5e02", 
+      "\u4e2d\u56fd",
+      "\u65b0\u5317\u5e02",
+      "\u6843\u5712\u5e02",
+      "\u798f\u5efa\u7701",
+      "\u81fa\u4e2d\u5e02",
+      "\u81fa\u5317\u5e02",
       "\u4e2d\u83ef\u6c11\u570b"
-     ], 
+     ],
      "old": [
-      "Taiwan", 
+      "Taiwan",
       "China"
      ]
-    }, 
+    },
     {
-     "id": "Taiwan_South", 
-     "s": 24355121, 
+     "id": "Taiwan_South",
+     "s": 24355121,
      "affiliations": [
-      "\u9ad8\u96c4\u5e02", 
-      "\u53f0\u5357\u5e02", 
-      "\u81fa\u4e2d\u5e02", 
+      "\u9ad8\u96c4\u5e02",
+      "\u53f0\u5357\u5e02",
+      "\u81fa\u4e2d\u5e02",
       "\u4e2d\u83ef\u6c11\u570b"
-     ], 
+     ],
      "old": [
       "Taiwan"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Peru", 
+   "id": "Peru",
    "g": [
     {
-     "id": "Peru_North", 
-     "s": 21463560, 
+     "id": "Peru_North",
+     "s": 21463560,
      "affiliations": [
-      "Amazonas", 
-      "Ancash", 
-      "Cajamarca", 
-      "Hu\u00e1nuco", 
-      "Loreto", 
-      "La Libertad", 
-      "Lambayeque", 
-      "Per\u00fa", 
-      "Piura", 
-      "Pasco", 
-      "San Mart\u00edn", 
-      "Tumbes", 
+      "Amazonas",
+      "Ancash",
+      "Cajamarca",
+      "Hu\u00e1nuco",
+      "Loreto",
+      "La Libertad",
+      "Lambayeque",
+      "Per\u00fa",
+      "Piura",
+      "Pasco",
+      "San Mart\u00edn",
+      "Tumbes",
       "Ucayali"
-     ], 
+     ],
      "old": [
       "Peru"
      ]
-    }, 
+    },
     {
-     "id": "Peru_Lima", 
-     "s": 18667529, 
+     "id": "Peru_Lima",
+     "s": 18667529,
      "affiliations": [
-      "Callao", 
-      "Huancavelica", 
-      "Ica", 
-      "Jun\u00edn", 
-      "Lima", 
+      "Callao",
+      "Huancavelica",
+      "Ica",
+      "Jun\u00edn",
+      "Lima",
       "Per\u00fa"
-     ], 
+     ],
      "old": [
       "Peru"
      ]
-    }, 
+    },
     {
-     "id": "Peru_South", 
-     "s": 20232954, 
+     "id": "Peru_South",
+     "s": 20232954,
      "affiliations": [
-      "Apur\u00edmac", 
-      "Arequipa", 
-      "Ayacucho", 
-      "Cusco", 
-      "Madre de Dios", 
-      "Moquegua", 
-      "Per\u00fa", 
-      "Puno", 
+      "Apur\u00edmac",
+      "Arequipa",
+      "Ayacucho",
+      "Cusco",
+      "Madre de Dios",
+      "Moquegua",
+      "Per\u00fa",
+      "Puno",
       "Tacna"
-     ], 
+     ],
      "old": [
       "Peru"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Philippines", 
+   "id": "Philippines",
    "g": [
     {
-     "id": "Philippines_Mindanao", 
-     "s": 28448822, 
+     "id": "Philippines_Mindanao",
+     "s": 28448822,
      "affiliations": [
-      "Agusan Del Sur", 
-      "Agusan del Norte", 
-      "Iligan City", 
-      "Basilan", 
-      "Dinagat Islands", 
-      "Bukidnon", 
-      "Camiguin", 
-      "Compostela Valley", 
-      "Cotabato", 
-      "Davao City", 
-      "Davao Del Norte", 
-      "Davao Occidental", 
-      "Davao Oriental", 
-      "Davao del Sur", 
-      "Lanao Del Norte", 
-      "Lanao Del Sur", 
-      "Maguindanao", 
-      "Misamis Occidental", 
-      "Misamis Oriental", 
-      "Philippines", 
-      "Saguing", 
-      "Sarangani", 
-      "Siquijor", 
-      "South Cotabato", 
-      "Sultan Kudarat", 
-      "Sulu", 
-      "Surigao Del Norte", 
-      "Surigao del Sur", 
-      "Tawi Tawi", 
-      "Zamboanga Sibugay", 
-      "Zamboanga del Norte", 
+      "Agusan Del Sur",
+      "Agusan del Norte",
+      "Iligan City",
+      "Basilan",
+      "Dinagat Islands",
+      "Bukidnon",
+      "Camiguin",
+      "Compostela Valley",
+      "Cotabato",
+      "Davao City",
+      "Davao Del Norte",
+      "Davao Occidental",
+      "Davao Oriental",
+      "Davao del Sur",
+      "Lanao Del Norte",
+      "Lanao Del Sur",
+      "Maguindanao",
+      "Misamis Occidental",
+      "Misamis Oriental",
+      "Philippines",
+      "Saguing",
+      "Sarangani",
+      "Siquijor",
+      "South Cotabato",
+      "Sultan Kudarat",
+      "Sulu",
+      "Surigao Del Norte",
+      "Surigao del Sur",
+      "Tawi Tawi",
+      "Zamboanga Sibugay",
+      "Zamboanga del Norte",
       "Zamboanga del Sur"
-     ], 
+     ],
      "old": [
       "Philippines"
      ]
-    }, 
+    },
     {
-     "id": "Philippines_Visayas", 
-     "s": 45279648, 
+     "id": "Philippines_Visayas",
+     "s": 45279648,
      "affiliations": [
-      "Aklan", 
-      "Bohol", 
-      "Antique", 
-      "Biliran", 
-      "Dinagat Islands", 
-      "Camiguin", 
-      "Capiz", 
-      "Cebu", 
-      "Eastern Samar", 
-      "Guimaras", 
-      "Iloilo", 
-      "Leyte", 
-      "Masbate", 
-      "Negros Occidental", 
-      "Negros Oriental", 
-      "Northern Samar", 
-      "Palawan", 
-      "Philippines", 
-      "Samar", 
-      "Siquijor", 
-      "Southern Leyte", 
+      "Aklan",
+      "Bohol",
+      "Antique",
+      "Biliran",
+      "Dinagat Islands",
+      "Camiguin",
+      "Capiz",
+      "Cebu",
+      "Eastern Samar",
+      "Guimaras",
+      "Iloilo",
+      "Leyte",
+      "Masbate",
+      "Negros Occidental",
+      "Negros Oriental",
+      "Northern Samar",
+      "Palawan",
+      "Philippines",
+      "Samar",
+      "Siquijor",
+      "Southern Leyte",
       "Sorsogon"
-     ], 
+     ],
      "old": [
       "Philippines"
      ]
-    }, 
+    },
     {
-     "id": "Philippines_Luzon_South", 
-     "s": 7053744, 
+     "id": "Philippines_Luzon_South",
+     "s": 7053744,
      "affiliations": [
-      "Antique", 
-      "Ban Than (Zhongzhou) Reef", 
-      "Batangas", 
-      "Biliran", 
-      "Marinduque", 
-      "Masbate", 
-      "Occidental Mindoro", 
-      "Oriental Mindoro", 
-      "Palawan", 
-      "Philippines", 
-      "Quezon", 
-      "Romblon", 
-      "Sorsogon", 
+      "Antique",
+      "Ban Than (Zhongzhou) Reef",
+      "Batangas",
+      "Biliran",
+      "Marinduque",
+      "Masbate",
+      "Occidental Mindoro",
+      "Oriental Mindoro",
+      "Palawan",
+      "Philippines",
+      "Quezon",
+      "Romblon",
+      "Sorsogon",
       "\u592a\u5e73\u5cf6"
-     ], 
+     ],
      "old": [
       "Philippines"
      ]
-    }, 
+    },
     {
-     "id": "Philippines_Luzon_Manila", 
-     "s": 78575411, 
+     "id": "Philippines_Luzon_Manila",
+     "s": 78575411,
      "affiliations": [
-      "Catanduanes", 
-      "Cavite", 
-      "Albay", 
-      "Batangas", 
-      "Camarines Norte", 
-      "Camarines Sur", 
-      "Laguna", 
-      "Marinduque", 
-      "Masbate", 
-      "Philippines", 
-      "Quezon", 
-      "Rizal", 
+      "Catanduanes",
+      "Cavite",
+      "Albay",
+      "Batangas",
+      "Camarines Norte",
+      "Camarines Sur",
+      "Laguna",
+      "Marinduque",
+      "Masbate",
+      "Philippines",
+      "Quezon",
+      "Rizal",
       "Sorsogon"
-     ], 
+     ],
      "old": [
       "Philippines"
      ]
-    }, 
+    },
     {
-     "id": "Philippines_Luzon_North", 
-     "s": 47509279, 
+     "id": "Philippines_Luzon_North",
+     "s": 47509279,
      "affiliations": [
-      "Abra", 
-      "Cavite", 
-      "Apayao", 
-      "Aurora", 
-      "Bataan", 
-      "Batanes", 
-      "Batangas", 
-      "Benguet", 
-      "Bulacan", 
-      "Cagayan", 
-      "Ifugao", 
-      "Ilocos Norte", 
-      "Ilocos Sur", 
-      "Isabela", 
-      "Kalinga", 
-      "La Union", 
-      "Mountain Province", 
-      "Nueva Ecija", 
-      "Nueva Vizcaya", 
-      "Occidental Mindoro", 
-      "Pangasinan", 
-      "Pampanga", 
-      "Philippines", 
-      "Quirino", 
-      "Tarlac", 
-      "Zambales", 
+      "Abra",
+      "Cavite",
+      "Apayao",
+      "Aurora",
+      "Bataan",
+      "Batanes",
+      "Batangas",
+      "Benguet",
+      "Bulacan",
+      "Cagayan",
+      "Ifugao",
+      "Ilocos Norte",
+      "Ilocos Sur",
+      "Isabela",
+      "Kalinga",
+      "La Union",
+      "Mountain Province",
+      "Nueva Ecija",
+      "Nueva Vizcaya",
+      "Occidental Mindoro",
+      "Pangasinan",
+      "Pampanga",
+      "Philippines",
+      "Quirino",
+      "Tarlac",
+      "Zambales",
       "\u6d77\u5357\u7701"
-     ], 
+     ],
      "old": [
       "Philippines"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Pitcairn Islands", 
-   "s": 58610, 
+   "id": "Pitcairn Islands",
+   "s": 58610,
    "affiliations": [
     "Pitcairn Islands"
-   ], 
+   ],
    "old": [
     "Pitcairn Islands"
    ]
-  }, 
+  },
   {
-   "id": "Poland", 
+   "id": "Poland",
    "g": [
     {
-     "id": "Poland_West Pomeranian Voivodeship", 
-     "s": 50295251, 
+     "id": "Poland_West Pomeranian Voivodeship",
+     "s": 50295251,
      "affiliations": [
-      "Polska", 
-      "Territorial waters of Bornholm", 
+      "Polska",
+      "Territorial waters of Bornholm",
       "wojew\u00f3dztwo zachodniopomorskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Pomeranian Voivodeship", 
-     "s": 51713506, 
+     "id": "Poland_Pomeranian Voivodeship",
+     "s": 51713506,
      "affiliations": [
-      "Polska", 
-      "Territorial waters of Bornholm", 
+      "Polska",
+      "Territorial waters of Bornholm",
       "wojew\u00f3dztwo pomorskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Podlaskie Voivodeship", 
-     "s": 36966759, 
+     "id": "Poland_Podlaskie Voivodeship",
+     "s": 36966759,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo podlaskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Masovian Voivodeship", 
-     "s": 109659414, 
+     "id": "Poland_Masovian Voivodeship",
+     "s": 109659414,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo mazowieckie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Lubusz Voivodeship", 
-     "s": 31325787, 
+     "id": "Poland_Lubusz Voivodeship",
+     "s": 31325787,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo lubuskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Lublin Voivodeship", 
-     "s": 66134096, 
+     "id": "Poland_Lublin Voivodeship",
+     "s": 66134096,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo lubelskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Lower Silesian Voivodeship", 
-     "s": 82369343, 
+     "id": "Poland_Lower Silesian Voivodeship",
+     "s": 82369343,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo dolno\u015bl\u0105skie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Warmian-Masurian Voivodeship", 
-     "s": 40059966, 
+     "id": "Poland_Warmian-Masurian Voivodeship",
+     "s": 40059966,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo warmi\u0144sko-mazurskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Lodz Voivodeship", 
-     "s": 60623431, 
+     "id": "Poland_Lodz Voivodeship",
+     "s": 60623431,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo \u0142\u00f3dzkie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Subcarpathian Voivodeship", 
-     "s": 73044364, 
+     "id": "Poland_Subcarpathian Voivodeship",
+     "s": 73044364,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo podkarpackie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Lesser Poland Voivodeship", 
-     "s": 86710139, 
+     "id": "Poland_Lesser Poland Voivodeship",
+     "s": 86710139,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo ma\u0142opolskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Silesian Voivodeship", 
-     "s": 94637486, 
+     "id": "Poland_Silesian Voivodeship",
+     "s": 94637486,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo \u015bl\u0105skie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Kuyavian-Pomeranian Voivodeship", 
-     "s": 44072650, 
+     "id": "Poland_Kuyavian-Pomeranian Voivodeship",
+     "s": 44072650,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo kujawsko-pomorskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Greater Poland Voivodeship", 
-     "s": 73572373, 
+     "id": "Poland_Greater Poland Voivodeship",
+     "s": 73572373,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo wielkopolskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Opole Voivodeship", 
-     "s": 31098083, 
+     "id": "Poland_Opole Voivodeship",
+     "s": 31098083,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo opolskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
-    }, 
+    },
     {
-     "id": "Poland_Swietokrzyskie Voivodeship", 
-     "s": 43068170, 
+     "id": "Poland_Swietokrzyskie Voivodeship",
+     "s": 43068170,
      "affiliations": [
-      "Polska", 
+      "Polska",
       "wojew\u00f3dztwo \u015bwi\u0119tokrzyskie"
-     ], 
+     ],
      "old": [
       "Poland"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Portugal", 
+   "id": "Portugal",
    "g": [
     {
-     "id": "Portugal_Porto", 
-     "s": 37222052, 
+     "id": "Portugal_Porto",
+     "s": 37222052,
      "affiliations": [
-      "Centro", 
-      "Norte", 
+      "Centro",
+      "Norte",
       "Portugal"
-     ], 
+     ],
      "old": [
       "Portugal"
      ]
-    }, 
+    },
     {
-     "id": "Portugal_South", 
-     "s": 43021157, 
+     "id": "Portugal_South",
+     "s": 43021157,
      "affiliations": [
-      "Centro", 
-      "Alentejo", 
-      "Algarve", 
-      "Lisboa", 
+      "Centro",
+      "Alentejo",
+      "Algarve",
+      "Lisboa",
       "Portugal"
-     ], 
+     ],
      "old": [
       "Portugal"
      ]
-    }, 
+    },
     {
-     "id": "Portugal_Islands", 
-     "s": 8896659, 
+     "id": "Portugal_Islands",
+     "s": 8896659,
      "affiliations": [
-      "Ilh\u00e9u dos Rosais", 
-      "Ilh\u00e9us dos Rosais", 
-      "Illh\u00e9u da Vila", 
-      "Arquip\u00e9lago da Madeira", 
-      "A\u00e7ores", 
-      "Deserta Grande", 
-      "Fradinhos", 
-      "Ilh\u00e9u Alagado", 
-      "Ilh\u00e9u Ch\u00e3o", 
-      "Ilh\u00e9u Maria Vaz", 
-      "Ilha do Bugio", 
-      "Ilh\u00e9u Mole", 
-      "Ilh\u00e9u da Cevada", 
-      "Ilh\u00e9u da Mina", 
-      "Ilh\u00e9u de S\u00e3o Louren\u00e7o", 
-      "Ilh\u00e9u da Praia", 
-      "Ilh\u00e9u da Ribeira da Janela", 
-      "Ilh\u00e9u da Rocha do Navio", 
-      "Ilh\u00e9u da Vila", 
-      "Ilh\u00e9u das Cabras", 
-      "Ilh\u00e9u das Cenouras", 
-      "Ilh\u00e9u das Lago\u00ednhas", 
-      "Ilh\u00e9u de Baixo", 
-      "Ilh\u00e9u de Baixo ou da Cal", 
-      "Ilh\u00e9u do Campan\u00e1rio", 
-      "Ilh\u00e9u de Cima", 
-      "Ilh\u00e9u do Norte", 
-      "Ilh\u00e9u do Topo", 
-      "Ilh\u00e9u de Ferro", 
-      "Ilh\u00e9u do Farol", 
-      "Ilh\u00e9u do Monchique", 
-      "Portugal", 
+      "Ilh\u00e9u dos Rosais",
+      "Ilh\u00e9us dos Rosais",
+      "Illh\u00e9u da Vila",
+      "Arquip\u00e9lago da Madeira",
+      "A\u00e7ores",
+      "Deserta Grande",
+      "Fradinhos",
+      "Ilh\u00e9u Alagado",
+      "Ilh\u00e9u Ch\u00e3o",
+      "Ilh\u00e9u Maria Vaz",
+      "Ilha do Bugio",
+      "Ilh\u00e9u Mole",
+      "Ilh\u00e9u da Cevada",
+      "Ilh\u00e9u da Mina",
+      "Ilh\u00e9u de S\u00e3o Louren\u00e7o",
+      "Ilh\u00e9u da Praia",
+      "Ilh\u00e9u da Ribeira da Janela",
+      "Ilh\u00e9u da Rocha do Navio",
+      "Ilh\u00e9u da Vila",
+      "Ilh\u00e9u das Cabras",
+      "Ilh\u00e9u das Cenouras",
+      "Ilh\u00e9u das Lago\u00ednhas",
+      "Ilh\u00e9u de Baixo",
+      "Ilh\u00e9u de Baixo ou da Cal",
+      "Ilh\u00e9u do Campan\u00e1rio",
+      "Ilh\u00e9u de Cima",
+      "Ilh\u00e9u do Norte",
+      "Ilh\u00e9u do Topo",
+      "Ilh\u00e9u de Ferro",
+      "Ilh\u00e9u do Farol",
+      "Ilh\u00e9u do Monchique",
+      "Portugal",
       "Portugal (\u00e1guas territoriais)"
-     ], 
+     ],
      "old": [
       "Portugal"
      ]
-    }, 
+    },
     {
-     "id": "Portugal_Viseu", 
-     "s": 32459724, 
+     "id": "Portugal_Viseu",
+     "s": 32459724,
      "affiliations": [
-      "Centro", 
-      "Norte", 
+      "Centro",
+      "Norte",
       "Portugal"
-     ], 
+     ],
      "old": [
       "Portugal"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Qatar", 
-   "s": 5087120, 
+   "id": "Qatar",
+   "s": 5087120,
    "affiliations": [
-    "Ad Dawhah", 
-    "Al Ghuwariyah", 
-    "Al Jumaliyah", 
-    "Al Khawr", 
-    "Al Wakrah", 
-    "Ar Rayyan", 
-    "Ash Shamal", 
-    "Jariyan Al Batnah", 
-    "Umm Salal", 
+    "Ad Dawhah",
+    "Al Ghuwariyah",
+    "Al Jumaliyah",
+    "Al Khawr",
+    "Al Wakrah",
+    "Ar Rayyan",
+    "Ash Shamal",
+    "Jariyan Al Batnah",
+    "Umm Salal",
     "\u200f\u0642\u0637\u0631\u200e"
-   ], 
+   ],
    "old": [
-    "Qatar", 
+    "Qatar",
     "United Arab Emirates"
    ]
-  }, 
+  },
   {
-   "id": "Republic of Kosovo", 
-   "s": 8712024, 
+   "id": "Republic of Kosovo",
+   "s": 8712024,
    "affiliations": [
     "Republika e Kosov\u00ebs"
-   ], 
+   ],
    "old": [
     "Kosovo"
    ]
-  }, 
+  },
   {
-   "id": "Romania", 
+   "id": "Romania",
    "g": [
     {
-     "id": "Romania_South_East", 
-     "s": 17269897, 
+     "id": "Romania_South_East",
+     "s": 17269897,
      "affiliations": [
-      "Br\u0103ila", 
-      "Buz\u0103u", 
-      "Constan\u021ba", 
-      "Gala\u021bi", 
-      "Rom\u00e2nia", 
-      "Tulcea", 
+      "Br\u0103ila",
+      "Buz\u0103u",
+      "Constan\u021ba",
+      "Gala\u021bi",
+      "Rom\u00e2nia",
+      "Tulcea",
       "Vrancea"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_Centre", 
-     "s": 37482760, 
+     "id": "Romania_Centre",
+     "s": 37482760,
      "affiliations": [
-      "Alba", 
-      "Bra\u0219ov", 
-      "Covasna", 
-      "Harghita", 
-      "Mure\u0219", 
-      "Rom\u00e2nia", 
+      "Alba",
+      "Bra\u0219ov",
+      "Covasna",
+      "Harghita",
+      "Mure\u0219",
+      "Rom\u00e2nia",
       "Sibiu"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_West", 
-     "s": 25262956, 
+     "id": "Romania_West",
+     "s": 25262956,
      "affiliations": [
-      "Arad", 
-      "Cara\u0219 Severin", 
-      "Hunedoara", 
-      "Rom\u00e2nia", 
+      "Arad",
+      "Cara\u0219 Severin",
+      "Hunedoara",
+      "Rom\u00e2nia",
       "Timi\u0219"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_North_West", 
-     "s": 35356469, 
+     "id": "Romania_North_West",
+     "s": 35356469,
      "affiliations": [
-      "Bihor", 
-      "Bistri\u021ba-N\u0103s\u0103ud", 
-      "Cluj", 
-      "Maramure\u0219", 
-      "Rom\u00e2nia", 
-      "Satu Mare", 
+      "Bihor",
+      "Bistri\u021ba-N\u0103s\u0103ud",
+      "Cluj",
+      "Maramure\u0219",
+      "Rom\u00e2nia",
+      "Satu Mare",
       "S\u0103laj"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_South_West", 
-     "s": 18779942, 
+     "id": "Romania_South_West",
+     "s": 18779942,
      "affiliations": [
-      "Dolj", 
-      "Gorj", 
-      "Mehedin\u021bi", 
-      "Olt", 
-      "Rom\u00e2nia", 
+      "Dolj",
+      "Gorj",
+      "Mehedin\u021bi",
+      "Olt",
+      "Rom\u00e2nia",
       "V\u00e2lcea"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_North_East", 
-     "s": 26564838, 
+     "id": "Romania_North_East",
+     "s": 26564838,
      "affiliations": [
-      "Bac\u0103u", 
-      "Boto\u0219ani", 
-      "Ia\u0219i", 
-      "Neam\u021b", 
-      "Rom\u00e2nia", 
-      "Suceava", 
+      "Bac\u0103u",
+      "Boto\u0219ani",
+      "Ia\u0219i",
+      "Neam\u021b",
+      "Rom\u00e2nia",
+      "Suceava",
       "Vaslui"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
-    }, 
+    },
     {
-     "id": "Romania_South", 
-     "s": 29399720, 
+     "id": "Romania_South",
+     "s": 29399720,
      "affiliations": [
-      "Arge\u0219", 
-      "Bucure\u0219ti", 
-      "D\u00e2mbovi\u021ba", 
-      "C\u0103l\u0103ra\u0219i", 
-      "Giurgiu", 
-      "Ilfov", 
-      "Ialomi\u021ba", 
-      "Municipiul Bucure\u0219ti", 
-      "Prahova", 
-      "Rom\u00e2nia", 
+      "Arge\u0219",
+      "Bucure\u0219ti",
+      "D\u00e2mbovi\u021ba",
+      "C\u0103l\u0103ra\u0219i",
+      "Giurgiu",
+      "Ilfov",
+      "Ialomi\u021ba",
+      "Municipiul Bucure\u0219ti",
+      "Prahova",
+      "Rom\u00e2nia",
       "Teleorman"
-     ], 
+     ],
      "old": [
       "Romania"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Russian Federation", 
+   "id": "Russian Federation",
    "g": [
     {
-     "id": "Crimea", 
-     "s": 22508611, 
+     "id": "Crimea",
+     "s": 22508611,
      "affiliations": [
-      "\u0410\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041a\u0440\u0438\u043c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
-      "\u0421\u0435\u0432\u0430\u0441\u0442\u043e\u043f\u043e\u043b\u044c", 
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0410\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041a\u0440\u0438\u043c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
+      "\u0421\u0435\u0432\u0430\u0441\u0442\u043e\u043f\u043e\u043b\u044c",
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0440\u044b\u043c"
-     ], 
+     ],
      "old": [
       "Crimea"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Altai Krai", 
-     "s": 26924539, 
+     "id": "Russia_Altai Krai",
+     "s": 26924539,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0410\u043b\u0442\u0430\u0439\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Altai Republic", 
-     "s": 8073670, 
+     "id": "Russia_Altai Republic",
+     "s": 8073670,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u043b\u0442\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Amur Oblast", 
-     "s": 6390494, 
+     "id": "Russia_Amur Oblast",
+     "s": 6390494,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0410\u043c\u0443\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Arkhangelsk Oblast_Central", 
-     "s": 50594959, 
+     "id": "Russia_Arkhangelsk Oblast_Central",
+     "s": 50594959,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0410\u0440\u0445\u0430\u043d\u0433\u0435\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Arkhangelsk Oblast_North", 
-     "s": 21457655, 
+     "id": "Russia_Arkhangelsk Oblast_North",
+     "s": 21457655,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
-      "\u0417\u0435\u043c\u043b\u044f \u0424\u0440\u0430\u043d\u0446\u0430-\u0418\u043e\u0441\u0438\u0444\u0430", 
-      "\u041d\u0435\u043d\u0435\u0446\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
+      "\u0417\u0435\u043c\u043b\u044f \u0424\u0440\u0430\u043d\u0446\u0430-\u0418\u043e\u0441\u0438\u0444\u0430",
+      "\u041d\u0435\u043d\u0435\u0446\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433",
       "\u0410\u0440\u0445\u0430\u043d\u0433\u0435\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Astrakhan Oblast", 
-     "s": 6944825, 
+     "id": "Russia_Astrakhan Oblast",
+     "s": 6944825,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0410\u0441\u0442\u0440\u0430\u0445\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Bashkortostan", 
-     "s": 29794741, 
+     "id": "Russia_Bashkortostan",
+     "s": 29794741,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0411\u0430\u0448\u043a\u043e\u0440\u0442\u043e\u0441\u0442\u0430\u043d"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Belgorod Oblast", 
-     "s": 17979187, 
+     "id": "Russia_Belgorod Oblast",
+     "s": 17979187,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0411\u0435\u043b\u0433\u043e\u0440\u043e\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Bryansk Oblast", 
-     "s": 12402826, 
+     "id": "Russia_Bryansk Oblast",
+     "s": 12402826,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0411\u0440\u044f\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Buryatia", 
-     "s": 9264700, 
+     "id": "Russia_Buryatia",
+     "s": 9264700,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0411\u0443\u0440\u044f\u0442\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Chechen Republic", 
-     "s": 4029914, 
+     "id": "Russia_Chechen Republic",
+     "s": 4029914,
      "affiliations": [
-      "\u0427\u0435\u0447\u0435\u043d\u0441\u043a\u0430\u044f \u0440\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0427\u0435\u0447\u0435\u043d\u0441\u043a\u0430\u044f \u0440\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Chelyabinsk Oblast", 
-     "s": 36911416, 
+     "id": "Russia_Chelyabinsk Oblast",
+     "s": 36911416,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Chukotka Autonomous Okrug", 
-     "s": 8067944, 
+     "id": "Russia_Chukotka Autonomous Okrug",
+     "s": 8067944,
      "affiliations": [
-      "\u0427\u0443\u043a\u043e\u0442\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0427\u0443\u043a\u043e\u0442\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Chuvashia", 
-     "s": 9172680, 
+     "id": "Russia_Chuvashia",
+     "s": 9172680,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0427\u0443\u0432\u0430\u0448\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Ingushetia", 
-     "s": 1043997, 
+     "id": "Russia_Ingushetia",
+     "s": 1043997,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0418\u043d\u0433\u0443\u0448\u0435\u0442\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Irkutsk Oblast", 
-     "s": 24844115, 
+     "id": "Russia_Irkutsk Oblast",
+     "s": 24844115,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0418\u0440\u043a\u0443\u0442\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Ivanovo Oblast", 
-     "s": 11686419, 
+     "id": "Russia_Ivanovo Oblast",
+     "s": 11686419,
      "affiliations": [
-      "\u0418\u0432\u0430\u043d\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0418\u0432\u0430\u043d\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Jewish Autonomous Oblast", 
-     "s": 4097702, 
+     "id": "Russia_Jewish Autonomous Oblast",
+     "s": 4097702,
      "affiliations": [
-      "\u0415\u0432\u0440\u0435\u0439\u0441\u043a\u0430\u044f \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0415\u0432\u0440\u0435\u0439\u0441\u043a\u0430\u044f \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kabardino-Balkaria", 
-     "s": 3958990, 
+     "id": "Russia_Kabardino-Balkaria",
+     "s": 3958990,
      "affiliations": [
-      "\u041a\u0430\u0431\u0430\u0440\u0434\u0438\u043d\u043e-\u0411\u0430\u043b\u043a\u0430\u0440\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041a\u0430\u0431\u0430\u0440\u0434\u0438\u043d\u043e-\u0411\u0430\u043b\u043a\u0430\u0440\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kaliningrad Oblast", 
-     "s": 7863433, 
+     "id": "Russia_Kaliningrad Oblast",
+     "s": 7863433,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0430\u043b\u0438\u043d\u0438\u043d\u0433\u0440\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kaluga Oblast", 
-     "s": 19745670, 
+     "id": "Russia_Kaluga Oblast",
+     "s": 19745670,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0430\u043b\u0443\u0436\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kamchatka Krai", 
-     "s": 12006947, 
+     "id": "Russia_Kamchatka Krai",
+     "s": 12006947,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0430\u043c\u0447\u0430\u0442\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Karachay-Cherkessia", 
-     "s": 10559016, 
+     "id": "Russia_Karachay-Cherkessia",
+     "s": 10559016,
      "affiliations": [
-      "\u041a\u0430\u0440\u0430\u0447\u0430\u0435\u0432\u043e-\u0427\u0435\u0440\u043a\u0435\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041a\u0430\u0440\u0430\u0447\u0430\u0435\u0432\u043e-\u0427\u0435\u0440\u043a\u0435\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kemerov Oblast", 
-     "s": 15161950, 
+     "id": "Russia_Kemerov Oblast",
+     "s": 15161950,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0435\u043c\u0435\u0440\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Khabarovsk Krai", 
-     "s": 40726466, 
+     "id": "Russia_Khabarovsk Krai",
+     "s": 40726466,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0425\u0430\u0431\u0430\u0440\u043e\u0432\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Khakassia", 
-     "s": 4716907, 
+     "id": "Russia_Khakassia",
+     "s": 4716907,
      "affiliations": [
-      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0425\u0430\u043a\u0430\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0425\u0430\u043a\u0430\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kirov Oblast", 
-     "s": 53246254, 
+     "id": "Russia_Kirov Oblast",
+     "s": 53246254,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0438\u0440\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Komi Republic", 
-     "s": 21657605, 
+     "id": "Russia_Komi Republic",
+     "s": 21657605,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043c\u0438"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kostroma Oblast", 
-     "s": 10722977, 
+     "id": "Russia_Kostroma Oblast",
+     "s": 10722977,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u043e\u0441\u0442\u0440\u043e\u043c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Krasnodar Krai", 
-     "s": 44600594, 
+     "id": "Russia_Krasnodar Krai",
+     "s": 44600594,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0440\u0430\u0441\u043d\u043e\u0434\u0430\u0440\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Krasnodar Krai_Adygeya", 
-     "s": 37429844, 
+     "id": "Russia_Krasnodar Krai_Adygeya",
+     "s": 37429844,
      "affiliations": [
-      "\u0410\u0434\u044b\u0433\u0435\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0410\u0434\u044b\u0433\u0435\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0440\u0430\u0441\u043d\u043e\u0434\u0430\u0440\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Krasnoyarsk Krai_North", 
-     "s": 26104896, 
+     "id": "Russia_Krasnoyarsk Krai_North",
+     "s": 26104896,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Krasnoyarsk Krai_South", 
-     "s": 29098088, 
+     "id": "Russia_Krasnoyarsk Krai_South",
+     "s": 29098088,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kurgan Oblast", 
-     "s": 8840146, 
+     "id": "Russia_Kurgan Oblast",
+     "s": 8840146,
      "affiliations": [
-      "\u041a\u0443\u0440\u0433\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041a\u0443\u0440\u0433\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Kursk Oblast", 
-     "s": 30587880, 
+     "id": "Russia_Kursk Oblast",
+     "s": 30587880,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041a\u0443\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Leningradskaya Oblast_Karelsky", 
-     "s": 23773208, 
+     "id": "Russia_Leningradskaya Oblast_Karelsky",
+     "s": 23773208,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041b\u0435\u043d\u0438\u043d\u0433\u0440\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Leningradskaya Oblast_Southeast", 
-     "s": 42175040, 
+     "id": "Russia_Leningradskaya Oblast_Southeast",
+     "s": 42175040,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041b\u0435\u043d\u0438\u043d\u0433\u0440\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Lipetsk Oblast", 
-     "s": 19669068, 
+     "id": "Russia_Lipetsk Oblast",
+     "s": 19669068,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041b\u0438\u043f\u0435\u0446\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Magadan Oblast", 
-     "s": 3781247, 
+     "id": "Russia_Magadan Oblast",
+     "s": 3781247,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041c\u0430\u0433\u0430\u0434\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Mari El", 
-     "s": 14736422, 
+     "id": "Russia_Mari El",
+     "s": 14736422,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041c\u0430\u0440\u0438\u0439 \u042d\u043b"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Moscow Oblast_East", 
-     "s": 50263182, 
+     "id": "Russia_Moscow Oblast_East",
+     "s": 50263182,
      "affiliations": [
-      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Moscow Oblast_West", 
-     "s": 26141044, 
+     "id": "Russia_Moscow Oblast_West",
+     "s": 26141044,
      "affiliations": [
-      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041c\u043e\u0441\u043a\u0432\u0430"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Moscow", 
-     "s": 35618981, 
+     "id": "Russia_Moscow",
+     "s": 35618981,
      "affiliations": [
-      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041c\u043e\u0441\u043a\u0432\u0430"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Murmansk Oblast", 
-     "s": 33440135, 
+     "id": "Russia_Murmansk Oblast",
+     "s": 33440135,
      "affiliations": [
-      "\u041c\u0443\u0440\u043c\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041c\u0443\u0440\u043c\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Nenets Autonomous Okrug", 
-     "s": 14284327, 
+     "id": "Russia_Nenets Autonomous Okrug",
+     "s": 14284327,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041d\u0435\u043d\u0435\u0446\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Nizhny Novgorod Oblast", 
-     "s": 35237447, 
+     "id": "Russia_Nizhny Novgorod Oblast",
+     "s": 35237447,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041d\u0438\u0436\u0435\u0433\u043e\u0440\u043e\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_North Ossetia-Alania", 
-     "s": 3204523, 
+     "id": "Russia_North Ossetia-Alania",
+     "s": 3204523,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041e\u0441\u0435\u0442\u0438\u044f - \u0410\u043b\u0430\u043d\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Novgorod Oblast", 
-     "s": 13756939, 
+     "id": "Russia_Novgorod Oblast",
+     "s": 13756939,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041d\u043e\u0432\u0433\u043e\u0440\u043e\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Novosibirsk Oblast", 
-     "s": 39021235, 
+     "id": "Russia_Novosibirsk Oblast",
+     "s": 39021235,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Omsk Oblast", 
-     "s": 28707981, 
+     "id": "Russia_Omsk Oblast",
+     "s": 28707981,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041e\u043c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Orenburg Oblast", 
-     "s": 20312286, 
+     "id": "Russia_Orenburg Oblast",
+     "s": 20312286,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041e\u0440\u0435\u043d\u0431\u0443\u0440\u0433\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Oryol Oblast", 
-     "s": 5155344, 
+     "id": "Russia_Oryol Oblast",
+     "s": 5155344,
      "affiliations": [
-      "\u041e\u0440\u043b\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041e\u0440\u043b\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Penza Oblast", 
-     "s": 14016012, 
+     "id": "Russia_Penza Oblast",
+     "s": 14016012,
      "affiliations": [
-      "\u041f\u0435\u043d\u0437\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041f\u0435\u043d\u0437\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Perm Krai_North", 
-     "s": 21856282, 
+     "id": "Russia_Perm Krai_North",
+     "s": 21856282,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041f\u0435\u0440\u043c\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Perm Krai_South", 
-     "s": 31507583, 
+     "id": "Russia_Perm Krai_South",
+     "s": 31507583,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041f\u0435\u0440\u043c\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Primorsky Krai", 
-     "s": 26141686, 
+     "id": "Russia_Primorsky Krai",
+     "s": 26141686,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041f\u0440\u0438\u043c\u043e\u0440\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Pskov Oblast", 
-     "s": 24944443, 
+     "id": "Russia_Pskov Oblast",
+     "s": 24944443,
      "affiliations": [
-      "\u041f\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u041f\u0441\u043a\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Republic of Dagestan", 
-     "s": 8078470, 
+     "id": "Russia_Republic of Dagestan",
+     "s": 8078470,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0414\u0430\u0433\u0435\u0441\u0442\u0430\u043d"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Republic of Kalmykia", 
-     "s": 3346719, 
+     "id": "Russia_Republic of Kalmykia",
+     "s": 3346719,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
-      "\u041a\u0430\u043b\u043c\u044b\u043a\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
+      "\u041a\u0430\u043b\u043c\u044b\u043a\u0438\u044f",
       "\u0410\u0441\u0442\u0440\u0430\u0445\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Republic of Karelia_North", 
-     "s": 36034273, 
+     "id": "Russia_Republic of Karelia_North",
+     "s": 36034273,
      "affiliations": [
-      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0440\u0435\u043b\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0440\u0435\u043b\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Republic of Karelia_South", 
-     "s": 28098416, 
+     "id": "Russia_Republic of Karelia_South",
+     "s": 28098416,
      "affiliations": [
-      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0440\u0435\u043b\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0440\u0435\u043b\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Republic of Mordovia", 
-     "s": 11522334, 
+     "id": "Russia_Republic of Mordovia",
+     "s": 11522334,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041c\u043e\u0440\u0434\u043e\u0432\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Rostov Oblast", 
-     "s": 29683237, 
+     "id": "Russia_Rostov Oblast",
+     "s": 29683237,
      "affiliations": [
-      "\u0420\u043e\u0441\u0442\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0420\u043e\u0441\u0442\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Ryazan Oblast", 
-     "s": 16691766, 
+     "id": "Russia_Ryazan Oblast",
+     "s": 16691766,
      "affiliations": [
-      "\u0420\u044f\u0437\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0420\u044f\u0437\u0430\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Saint Petersburg", 
-     "s": 26631588, 
+     "id": "Russia_Saint Petersburg",
+     "s": 26631588,
      "affiliations": [
-      "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u041b\u0435\u043d\u0438\u043d\u0433\u0440\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Sakha Republic", 
-     "s": 54054971, 
+     "id": "Russia_Sakha Republic",
+     "s": 54054971,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0430\u0445\u0430 (\u042f\u043a\u0443\u0442\u0438\u044f)"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Sakhalin Oblast", 
-     "s": 25262054, 
+     "id": "Russia_Sakhalin Oblast",
+     "s": 25262054,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0430\u0445\u0430\u043b\u0438\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Far Eastern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Samara Oblast", 
-     "s": 22998604, 
+     "id": "Russia_Samara Oblast",
+     "s": 22998604,
      "affiliations": [
-      "\u0421\u0430\u043c\u0430\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0421\u0430\u043c\u0430\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Saratov Oblast", 
-     "s": 17665777, 
+     "id": "Russia_Saratov Oblast",
+     "s": 17665777,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0430\u0440\u0430\u0442\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Smolensk Oblast", 
-     "s": 14773707, 
+     "id": "Russia_Smolensk Oblast",
+     "s": 14773707,
      "affiliations": [
-      "\u0421\u043c\u043e\u043b\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0421\u043c\u043e\u043b\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Stavropol Krai", 
-     "s": 18484881, 
+     "id": "Russia_Stavropol Krai",
+     "s": 18484881,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0442\u0430\u0432\u0440\u043e\u043f\u043e\u043b\u044c\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_North Caucasian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Sverdlovsk Oblast_Ekaterinburg", 
-     "s": 29798021, 
+     "id": "Russia_Sverdlovsk Oblast_Ekaterinburg",
+     "s": 29798021,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0432\u0435\u0440\u0434\u043b\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Sverdlovsk Oblast_North", 
-     "s": 25694563, 
+     "id": "Russia_Sverdlovsk Oblast_North",
+     "s": 25694563,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0421\u0432\u0435\u0440\u0434\u043b\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tambov Oblast", 
-     "s": 9266354, 
+     "id": "Russia_Tambov Oblast",
+     "s": 9266354,
      "affiliations": [
-      "\u0422\u0430\u043c\u0431\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0422\u0430\u043c\u0431\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tatarstan", 
-     "s": 29950617, 
+     "id": "Russia_Tatarstan",
+     "s": 29950617,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0422\u0430\u0442\u0430\u0440\u0441\u0442\u0430\u043d"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tomsk Oblast", 
-     "s": 14489646, 
+     "id": "Russia_Tomsk Oblast",
+     "s": 14489646,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0422\u043e\u043c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tula Oblast", 
-     "s": 14642531, 
+     "id": "Russia_Tula Oblast",
+     "s": 14642531,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0422\u0443\u043b\u044c\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tuva", 
-     "s": 2423399, 
+     "id": "Russia_Tuva",
+     "s": 2423399,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0422\u044b\u0432\u0430"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tver Oblast", 
-     "s": 31135744, 
+     "id": "Russia_Tver Oblast",
+     "s": 31135744,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0422\u0432\u0435\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Tyumen Oblast", 
-     "s": 16355077, 
+     "id": "Russia_Tyumen Oblast",
+     "s": 16355077,
      "affiliations": [
-      "\u0422\u044e\u043c\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0422\u044e\u043c\u0435\u043d\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Udmurt Republic", 
-     "s": 19994207, 
+     "id": "Russia_Udmurt Republic",
+     "s": 19994207,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0423\u0434\u043c\u0443\u0440\u0442\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Ulyanovsk Oblast", 
-     "s": 14070170, 
+     "id": "Russia_Ulyanovsk Oblast",
+     "s": 14070170,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0423\u043b\u044c\u044f\u043d\u043e\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Volga"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Vladimir Oblast", 
-     "s": 33032841, 
+     "id": "Russia_Vladimir Oblast",
+     "s": 33032841,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0412\u043b\u0430\u0434\u0438\u043c\u0438\u0440\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Volgograd Oblast", 
-     "s": 25123514, 
+     "id": "Russia_Volgograd Oblast",
+     "s": 25123514,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Southern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Vologda Oblast", 
-     "s": 25089929, 
+     "id": "Russia_Vologda Oblast",
+     "s": 25089929,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0412\u043e\u043b\u043e\u0433\u043e\u0434\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Northwestern"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Voronezh Oblast", 
-     "s": 28976863, 
+     "id": "Russia_Voronezh Oblast",
+     "s": 28976863,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0412\u043e\u0440\u043e\u043d\u0435\u0436\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Yamalo-Nenets Autonomous Okrug", 
-     "s": 17673909, 
+     "id": "Russia_Yamalo-Nenets Autonomous Okrug",
+     "s": 17673909,
      "affiliations": [
-      "\u042f\u043c\u0430\u043b\u043e-\u041d\u0435\u043d\u0435\u0446\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u042f\u043c\u0430\u043b\u043e-\u041d\u0435\u043d\u0435\u0446\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Yaroslavl Oblast", 
-     "s": 24962181, 
+     "id": "Russia_Yaroslavl Oblast",
+     "s": 24962181,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u042f\u0440\u043e\u0441\u043b\u0430\u0432\u0441\u043a\u0430\u044f \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Russia_Central"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Yugra_Khanty", 
-     "s": 33834405, 
+     "id": "Russia_Yugra_Khanty",
+     "s": 33834405,
      "affiliations": [
-      "\u0425\u0430\u043d\u0442\u044b-\u041c\u0430\u043d\u0441\u0438\u0439\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433 - \u042e\u0433\u0440\u0430", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0425\u0430\u043d\u0442\u044b-\u041c\u0430\u043d\u0441\u0438\u0439\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433 - \u042e\u0433\u0440\u0430",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Yugra_Surgut", 
-     "s": 28274514, 
+     "id": "Russia_Yugra_Surgut",
+     "s": 28274514,
      "affiliations": [
-      "\u0425\u0430\u043d\u0442\u044b-\u041c\u0430\u043d\u0441\u0438\u0439\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433 - \u042e\u0433\u0440\u0430", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
+      "\u0425\u0430\u043d\u0442\u044b-\u041c\u0430\u043d\u0441\u0438\u0439\u0441\u043a\u0438\u0439 \u0430\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433 - \u042e\u0433\u0440\u0430",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
       "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f"
-     ], 
+     ],
      "old": [
       "Russia_Urals"
      ]
-    }, 
+    },
     {
-     "id": "Russia_Zabaykalsky Krai", 
-     "s": 16017970, 
+     "id": "Russia_Zabaykalsky Krai",
+     "s": 16017970,
      "affiliations": [
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
       "\u0417\u0430\u0431\u0430\u0439\u043a\u0430\u043b\u044c\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
-     ], 
+     ],
      "old": [
       "Russia_Siberian"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Rwanda", 
-   "s": 5022679, 
+   "id": "Rwanda",
+   "s": 5022679,
    "affiliations": [
-    "Amajvepfo", 
-    "Iburasirasuba", 
-    "Iburengerazuba", 
-    "Majyaruguru", 
-    "Rwanda", 
+    "Amajvepfo",
+    "Iburasirasuba",
+    "Iburengerazuba",
+    "Majyaruguru",
+    "Rwanda",
     "Umujyi wa Kigali"
-   ], 
+   ],
    "old": [
     "Rwanda"
    ]
-  }, 
+  },
   {
-   "id": "Sahrawi Arab Democratic Republic", 
-   "s": 329431, 
+   "id": "Sahrawi Arab Democratic Republic",
+   "s": 329431,
    "affiliations": [
-    "Dakhla-Oued Ed-Dahab \u2d37\u2d30\u2d45\u2d4d\u2d30-\u2d61\u2d30\u2d37 \u2d37\u2d30\u2d40\u2d30\u2d31 \u0627\u0644\u062f\u0627\u062e\u0644\u0629-\u0648\u0627\u062f\u064a \u0627\u0644\u0630\u0647\u0628", 
-    "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
+    "Dakhla-Oued Ed-Dahab \u2d37\u2d30\u2d45\u2d4d\u2d30-\u2d61\u2d30\u2d37 \u2d37\u2d30\u2d40\u2d30\u2d31 \u0627\u0644\u062f\u0627\u062e\u0644\u0629-\u0648\u0627\u062f\u064a \u0627\u0644\u0630\u0647\u0628",
+    "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
     "RASD"
-   ], 
+   ],
    "old": [
     "Sahrawi"
    ]
-  }, 
+  },
   {
-   "id": "Saint Helena Ascension and Tristan da Cunha", 
-   "s": 266324, 
+   "id": "Saint Helena Ascension and Tristan da Cunha",
+   "s": 266324,
    "affiliations": [
-    "Gough Island", 
-    "Inaccessible Island", 
-    "Nightingale Island", 
-    "Saint Helena, Ascension and Tristan da Cunha", 
+    "Gough Island",
+    "Inaccessible Island",
+    "Nightingale Island",
+    "Saint Helena, Ascension and Tristan da Cunha",
     "Tristan da Cunha"
-   ], 
+   ],
    "old": [
     "Saint Helena, Ascension and Tristan da Cunha"
    ]
-  }, 
+  },
   {
-   "id": "Samoa", 
-   "s": 2245172, 
+   "id": "Samoa",
+   "s": 2245172,
    "affiliations": [
-    "American Samoa", 
-    "AS", 
-    "S\u0101moa", 
+    "American Samoa",
+    "AS",
+    "S\u0101moa",
     "United States of America"
-   ], 
+   ],
    "old": [
-    "Samoa", 
+    "Samoa",
     "American Samoa"
    ]
-  }, 
+  },
   {
-   "id": "San Marino", 
-   "s": 284367, 
+   "id": "San Marino",
+   "s": 284367,
    "affiliations": [
-    "Italia", 
+    "Italia",
     "San Marino"
-   ], 
+   ],
    "old": [
-    "Italy", 
+    "Italy",
     "San Marino"
    ]
-  }, 
+  },
   {
-   "id": "Saudi Arabia", 
+   "id": "Saudi Arabia",
    "g": [
     {
-     "id": "Saudi Arabia_South", 
-     "s": 15595761, 
+     "id": "Saudi Arabia_South",
+     "s": 15595761,
      "affiliations": [
-      "\u0639\u0633\u064a\u0631", 
-      "\u062c\u0627\u0632\u0627\u0646", 
-      "\u0646\u062c\u0631\u0627\u0646", 
-      "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0631\u064a\u0627\u0636", 
-      "\u0627\u0644\u0634\u0631\u0642\u064a\u0629", 
+      "\u0639\u0633\u064a\u0631",
+      "\u062c\u0627\u0632\u0627\u0646",
+      "\u0646\u062c\u0631\u0627\u0646",
+      "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0631\u064a\u0627\u0636",
+      "\u0627\u0644\u0634\u0631\u0642\u064a\u0629",
       "\u200f\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629\u200e"
-     ], 
+     ],
      "old": [
       "Saudi Arabia"
      ]
-    }, 
+    },
     {
-     "id": "Saudi Arabia_North", 
-     "s": 15513440, 
+     "id": "Saudi Arabia_North",
+     "s": 15513440,
      "affiliations": [
-      "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629", 
-      "\u062a\u0628\u0648\u0643", 
-      "\u062d\u0627\u0626\u0644", 
-      "\u0627\u0644\u062c\u0648\u0641", 
-      "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0635\u064a\u0645", 
-      "\u0627\u0644\u0628\u0627\u062d\u0629", 
-      "\u0627\u0644\u062d\u062f\u0648\u062f \u0627\u0644\u0634\u0645\u0627\u0644\u064a", 
-      "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629", 
+      "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629",
+      "\u062a\u0628\u0648\u0643",
+      "\u062d\u0627\u0626\u0644",
+      "\u0627\u0644\u062c\u0648\u0641",
+      "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0635\u064a\u0645",
+      "\u0627\u0644\u0628\u0627\u062d\u0629",
+      "\u0627\u0644\u062d\u062f\u0648\u062f \u0627\u0644\u0634\u0645\u0627\u0644\u064a",
+      "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629",
       "\u200f\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629\u200e"
-     ], 
+     ],
      "old": [
       "Saudi Arabia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Senegal", 
-   "s": 23132097, 
+   "id": "Senegal",
+   "s": 23132097,
    "affiliations": [
-    "Basse", 
-    "Janjanbureh", 
-    "Mansakonko", 
-    "Regi\u00e3o de Cacheu", 
+    "Basse",
+    "Janjanbureh",
+    "Mansakonko",
+    "Regi\u00e3o de Cacheu",
     "Senegal"
-   ], 
+   ],
    "old": [
     "Senegal"
    ]
-  }, 
+  },
   {
-   "id": "Serbia", 
-   "s": 50352929, 
+   "id": "Serbia",
+   "s": 50352929,
    "affiliations": [
-    "\u0421\u0440\u0431\u0438\u0458\u0430", 
-    "\u0412\u043e\u0458\u0432\u043e\u0434\u0438\u043d\u0430", 
+    "\u0421\u0440\u0431\u0438\u0458\u0430",
+    "\u0412\u043e\u0458\u0432\u043e\u0434\u0438\u043d\u0430",
     "\u0426\u0435\u043d\u0442\u0440\u0430\u043b\u043d\u0430 \u0421\u0440\u0431\u0438\u0458\u0430"
-   ], 
+   ],
    "old": [
     "Serbia"
    ]
-  }, 
+  },
   {
-   "id": "Seychelles", 
-   "s": 701824, 
+   "id": "Seychelles",
+   "s": 701824,
    "affiliations": [
     "Sesel"
-   ], 
+   ],
    "old": [
     "Seychelles"
    ]
-  }, 
+  },
   {
-   "id": "Sierra Leone", 
-   "s": 24476655, 
+   "id": "Sierra Leone",
+   "s": 24476655,
    "affiliations": [
-    "Eastern Province", 
-    "Northern Province", 
-    "Sierra Leone", 
-    "Southern Province", 
+    "Eastern Province",
+    "Northern Province",
+    "Sierra Leone",
+    "Southern Province",
     "Western Area"
-   ], 
+   ],
    "old": [
     "Sierra Leone"
    ]
-  }, 
+  },
   {
-   "id": "Singapore", 
-   "s": 9578468, 
+   "id": "Singapore",
+   "s": 9578468,
    "affiliations": [
-    "Johor", 
-    "Malaysia", 
+    "Johor",
+    "Malaysia",
     "Singapura"
-   ], 
+   ],
    "old": [
     "Singapore"
    ]
-  }, 
+  },
   {
-   "id": "Slovakia", 
+   "id": "Slovakia",
    "g": [
     {
-     "id": "Slovakia_Region of Presov", 
-     "s": 20726177, 
+     "id": "Slovakia_Region of Presov",
+     "s": 20726177,
      "affiliations": [
-      "Pre\u0161ovsk\u00fd kraj", 
+      "Pre\u0161ovsk\u00fd kraj",
       "Slovensko"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Kosice", 
-     "s": 18889306, 
+     "id": "Slovakia_Region of Kosice",
+     "s": 18889306,
      "affiliations": [
-      "Ko\u0161ick\u00fd kraj", 
+      "Ko\u0161ick\u00fd kraj",
       "Slovensko"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Banska Bystrica", 
-     "s": 23108508, 
+     "id": "Slovakia_Region of Banska Bystrica",
+     "s": 23108508,
      "affiliations": [
-      "Banskobystrick\u00fd kraj", 
+      "Banskobystrick\u00fd kraj",
       "Slovensko"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Trnava", 
-     "s": 12702616, 
+     "id": "Slovakia_Region of Trnava",
+     "s": 12702616,
      "affiliations": [
-      "Slovensko", 
+      "Slovensko",
       "Trnavsk\u00fd kraj"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Trencin", 
-     "s": 16353488, 
+     "id": "Slovakia_Region of Trencin",
+     "s": 16353488,
      "affiliations": [
-      "Slovensko", 
+      "Slovensko",
       "Tren\u010diansky kraj"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Nitra", 
-     "s": 15638875, 
+     "id": "Slovakia_Region of Nitra",
+     "s": 15638875,
      "affiliations": [
-      "Nitriansky kraj", 
+      "Nitriansky kraj",
       "Slovensko"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Bratislava", 
-     "s": 12166780, 
+     "id": "Slovakia_Region of Bratislava",
+     "s": 12166780,
      "affiliations": [
-      "Bratislavsk\u00fd kraj", 
+      "Bratislavsk\u00fd kraj",
       "Slovensko"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
-    }, 
+    },
     {
-     "id": "Slovakia_Region of Zilina", 
-     "s": 21534009, 
+     "id": "Slovakia_Region of Zilina",
+     "s": 21534009,
      "affiliations": [
-      "Slovensko", 
+      "Slovensko",
       "\u017dilinsk\u00fd kraj"
-     ], 
+     ],
      "old": [
       "Slovakia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Slovenia", 
+   "id": "Slovenia",
    "g": [
     {
-     "id": "Slovenia_East", 
-     "s": 75270662, 
+     "id": "Slovenia_East",
+     "s": 75270662,
      "affiliations": [
-      "Border SI-HR", 
+      "Border SI-HR",
       "Slovenija"
-     ], 
+     ],
      "old": [
       "Slovenia"
      ]
-    }, 
+    },
     {
-     "id": "Slovenia_West", 
-     "s": 75798507, 
+     "id": "Slovenia_West",
+     "s": 75798507,
      "affiliations": [
       "Slovenija"
-     ], 
+     ],
      "old": [
       "Slovenia"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Solomon Islands", 
-   "s": 1525773, 
+   "id": "Solomon Islands",
+   "s": 1525773,
    "affiliations": [
-    "Capital Territory", 
-    "Central Province", 
-    "Choiseul Province", 
-    "Guadalcanal Province", 
-    "Isabel Province", 
-    "Makira-Ulawa Province", 
-    "Malaita Province", 
-    "Rennell and Bellona Province", 
-    "Solomon Islands", 
-    "Temotu Province", 
+    "Capital Territory",
+    "Central Province",
+    "Choiseul Province",
+    "Guadalcanal Province",
+    "Isabel Province",
+    "Makira-Ulawa Province",
+    "Malaita Province",
+    "Rennell and Bellona Province",
+    "Solomon Islands",
+    "Temotu Province",
     "Western Province"
-   ], 
+   ],
    "old": [
     "Solomon Islands"
    ]
-  }, 
+  },
   {
-   "id": "Somalia", 
-   "s": 11640013, 
+   "id": "Somalia",
+   "s": 11640013,
    "affiliations": [
-    "Awdal", 
-    "Bakool", 
-    "Banadir", 
-    "Bari", 
-    "Bay", 
-    "Galgaduud", 
-    "Gedo", 
-    "Hiiraan", 
-    "Jubbada Dhexe", 
-    "Jubbada Hoose", 
-    "Nugaal", 
-    "Mudug", 
-    "Shabeellaha Hoose", 
-    "Sanaag", 
-    "Shabeellaha Dhexe", 
-    "Sool", 
-    "Soomaaliya", 
-    "Togdheer", 
+    "Awdal",
+    "Bakool",
+    "Banadir",
+    "Bari",
+    "Bay",
+    "Galgaduud",
+    "Gedo",
+    "Hiiraan",
+    "Jubbada Dhexe",
+    "Jubbada Hoose",
+    "Nugaal",
+    "Mudug",
+    "Shabeellaha Hoose",
+    "Sanaag",
+    "Shabeellaha Dhexe",
+    "Sool",
+    "Soomaaliya",
+    "Togdheer",
     "Woqooyi Galbeed"
-   ], 
+   ],
    "old": [
     "Somalia"
    ]
-  }, 
+  },
   {
-   "id": "South Africa", 
+   "id": "South Africa",
    "g": [
     {
-     "id": "South Africa_Western Cape", 
-     "s": 18898251, 
+     "id": "South Africa_Western Cape",
+     "s": 18898251,
      "affiliations": [
-      "Prince Edward Islands", 
-      "South Africa", 
+      "Prince Edward Islands",
+      "South Africa",
       "Western Cape"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Gauteng", 
-     "s": 10916669, 
+     "id": "South Africa_Gauteng",
+     "s": 10916669,
      "affiliations": [
-      "Gauteng", 
+      "Gauteng",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_North West", 
-     "s": 5487698, 
+     "id": "South Africa_North West",
+     "s": 5487698,
      "affiliations": [
-      "North West", 
+      "North West",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Free State", 
-     "s": 5825689, 
+     "id": "South Africa_Free State",
+     "s": 5825689,
      "affiliations": [
-      "Free State", 
+      "Free State",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Eastern Cape", 
-     "s": 10153901, 
+     "id": "South Africa_Eastern Cape",
+     "s": 10153901,
      "affiliations": [
-      "Eastern Cape", 
+      "Eastern Cape",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Northern Cape", 
-     "s": 6658596, 
+     "id": "South Africa_Northern Cape",
+     "s": 6658596,
      "affiliations": [
-      "Northern Cape", 
+      "Northern Cape",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Mpumalanga", 
-     "s": 6114663, 
+     "id": "South Africa_Mpumalanga",
+     "s": 6114663,
      "affiliations": [
-      "Mpumalanga", 
+      "Mpumalanga",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_Limpopo", 
-     "s": 4964463, 
+     "id": "South Africa_Limpopo",
+     "s": 4964463,
      "affiliations": [
-      "Limpopo", 
+      "Limpopo",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
-    }, 
+    },
     {
-     "id": "South Africa_KwaZulu-Natal", 
-     "s": 15940764, 
+     "id": "South Africa_KwaZulu-Natal",
+     "s": 15940764,
      "affiliations": [
-      "KwaZulu-Natal", 
+      "KwaZulu-Natal",
       "South Africa"
-     ], 
+     ],
      "old": [
       "South Africa"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "South Georgia and the South Sandwich Islands", 
-   "s": 331921, 
+   "id": "South Georgia and the South Sandwich Islands",
+   "s": 331921,
    "affiliations": [
-    "Freezland Rock", 
+    "Freezland Rock",
     "South Georgia and South Sandwich Islands"
-   ], 
+   ],
    "old": [
     "South Georgia and the South Sandwich Islands"
    ]
-  }, 
+  },
   {
-   "id": "South Ossetia", 
-   "s": 1326282, 
+   "id": "South Ossetia",
+   "s": 1326282,
    "affiliations": [
-    "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d", 
-    "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d - \u042e\u0436\u043d\u0430\u044f \u041e\u0441\u0435\u0442\u0438\u044f", 
+    "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d",
+    "\u0425\u0443\u0441\u0441\u0430\u0440 \u0418\u0440\u044b\u0441\u0442\u043e\u043d - \u042e\u0436\u043d\u0430\u044f \u041e\u0441\u0435\u0442\u0438\u044f",
     "\u10e1\u10d0\u10e5\u10d0\u10e0\u10d7\u10d5\u10d4\u10da\u10dd"
-   ], 
+   ],
    "old": [
     "Georgia"
    ]
-  }, 
+  },
   {
-   "id": "South Sudan", 
-   "s": 35177205, 
+   "id": "South Sudan",
+   "s": 35177205,
    "affiliations": [
-    "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan", 
-    "Central Equatoria", 
-    "Eastern Equatoria", 
-    "Lakes", 
-    "Jonglei", 
-    "Northern Bahr el Ghazal State", 
-    "South Sudan", 
-    "Unity State", 
-    "Upper Nile State", 
-    "Western Bahr el Ghazal State", 
-    "Western Equatoria", 
+    "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan",
+    "Central Equatoria",
+    "Eastern Equatoria",
+    "Lakes",
+    "Jonglei",
+    "Northern Bahr el Ghazal State",
+    "South Sudan",
+    "Unity State",
+    "Upper Nile State",
+    "Western Bahr el Ghazal State",
+    "Western Equatoria",
     "\u0648\u0627\u0631\u0627\u0628"
-   ], 
+   ],
    "old": [
     "South Sudan"
    ]
-  }, 
+  },
   {
-   "id": "Spain", 
+   "id": "Spain",
    "g": [
     {
-     "id": "Spain_Andalusia_Granada", 
-     "s": 28503714, 
+     "id": "Spain_Andalusia_Granada",
+     "s": 28503714,
      "affiliations": [
-      "Andaluc\u00eda", 
-      "Espa\u00f1a (mare territorial)", 
+      "Andaluc\u00eda",
+      "Espa\u00f1a (mare territorial)",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Andalusia_Sevilla", 
-     "s": 36937487, 
+     "id": "Spain_Andalusia_Sevilla",
+     "s": 36937487,
      "affiliations": [
-      "Andaluc\u00eda", 
+      "Andaluc\u00eda",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Aragon", 
-     "s": 34199734, 
+     "id": "Spain_Aragon",
+     "s": 34199734,
      "affiliations": [
-      "Arag\u00f3n", 
+      "Arag\u00f3n",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Balearic Islands", 
-     "s": 16643219, 
+     "id": "Spain_Balearic Islands",
+     "s": 16643219,
      "affiliations": [
-      "Illes Balears", 
+      "Illes Balears",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Basque Country", 
-     "s": 30278672, 
+     "id": "Spain_Basque Country",
+     "s": 30278672,
      "affiliations": [
-      "Castilla y Le\u00f3n", 
-      "Espa\u00f1a", 
+      "Castilla y Le\u00f3n",
+      "Espa\u00f1a",
       "Euskadi"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Canary Islands", 
-     "s": 28841643, 
+     "id": "Spain_Canary Islands",
+     "s": 28841643,
      "affiliations": [
-      "Canarias", 
+      "Canarias",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Cantabria", 
-     "s": 12896549, 
+     "id": "Spain_Cantabria",
+     "s": 12896549,
      "affiliations": [
-      "Cantabria", 
+      "Cantabria",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Castile and Leon_West", 
-     "s": 40083073, 
+     "id": "Spain_Castile and Leon_West",
+     "s": 40083073,
      "affiliations": [
-      "Castilla y Le\u00f3n", 
+      "Castilla y Le\u00f3n",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Castile and Leon_East", 
-     "s": 31678673, 
+     "id": "Spain_Castile and Leon_East",
+     "s": 31678673,
      "affiliations": [
-      "Castilla y Le\u00f3n", 
+      "Castilla y Le\u00f3n",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Castile-La Mancha", 
-     "s": 42298743, 
+     "id": "Spain_Castile-La Mancha",
+     "s": 42298743,
      "affiliations": [
-      "Castilla-La Mancha", 
+      "Castilla-La Mancha",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Catalonia_Provincia de Barcelona", 
-     "s": 38063981, 
+     "id": "Spain_Catalonia_Provincia de Barcelona",
+     "s": 38063981,
      "affiliations": [
-      "Catalunya", 
+      "Catalunya",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Catalonia_Provincia de Girona", 
-     "s": 19339794, 
+     "id": "Spain_Catalonia_Provincia de Girona",
+     "s": 19339794,
      "affiliations": [
-      "Catalunya", 
+      "Catalunya",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Catalonia_Provincia de Lleida", 
-     "s": 21260117, 
+     "id": "Spain_Catalonia_Provincia de Lleida",
+     "s": 21260117,
      "affiliations": [
-      "Catalunya", 
+      "Catalunya",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Catalonia_Provincia de Tarragona", 
-     "s": 12635194, 
+     "id": "Spain_Catalonia_Provincia de Tarragona",
+     "s": 12635194,
      "affiliations": [
-      "Catalunya", 
+      "Catalunya",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Ceuta", 
-     "s": 237252, 
+     "id": "Spain_Ceuta",
+     "s": 237252,
      "affiliations": [
-      "Ceuta", 
-      "Espa\u00f1a", 
+      "Ceuta",
+      "Espa\u00f1a",
       "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Community of Madrid", 
-     "s": 37393922, 
+     "id": "Spain_Community of Madrid",
+     "s": 37393922,
      "affiliations": [
-      "Comunidad de Madrid", 
+      "Comunidad de Madrid",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Comunidad Foral de Navarra", 
-     "s": 12826825, 
+     "id": "Spain_Comunidad Foral de Navarra",
+     "s": 12826825,
      "affiliations": [
-      "Comunidad Foral de Navarra", 
+      "Comunidad Foral de Navarra",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Extremadura", 
-     "s": 17175087, 
+     "id": "Spain_Extremadura",
+     "s": 17175087,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "Extremadura"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Galicia_North", 
-     "s": 28354400, 
+     "id": "Spain_Galicia_North",
+     "s": 28354400,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "Galicia"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Galicia_South", 
-     "s": 20058488, 
+     "id": "Spain_Galicia_South",
+     "s": 20058488,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "Galicia"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_La Rioja", 
-     "s": 4633957, 
+     "id": "Spain_La Rioja",
+     "s": 4633957,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "La Rioja"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Melilla", 
-     "s": 484848, 
+     "id": "Spain_Melilla",
+     "s": 484848,
      "affiliations": [
-      "Espa\u00f1a", 
-      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628", 
+      "Espa\u00f1a",
+      "Maroc \u2d4d\u2d4e\u2d56\u2d54\u2d49\u2d31 \u0627\u0644\u0645\u063a\u0631\u0628",
       "Melilla"
-     ], 
+     ],
      "old": [
-      "Morocco", 
+      "Morocco",
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Principado de Asturias", 
-     "s": 16939387, 
+     "id": "Spain_Principado de Asturias",
+     "s": 16939387,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "Principado de Asturias"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Region de Murcia", 
-     "s": 11823947, 
+     "id": "Spain_Region de Murcia",
+     "s": 11823947,
      "affiliations": [
-      "Espa\u00f1a", 
+      "Espa\u00f1a",
       "Regi\u00f3n de Murcia"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
-    }, 
+    },
     {
-     "id": "Spain_Valencian Community", 
-     "s": 44247722, 
+     "id": "Spain_Valencian Community",
+     "s": 44247722,
      "affiliations": [
-      "Comunitat Valenciana", 
+      "Comunitat Valenciana",
       "Espa\u00f1a"
-     ], 
+     ],
      "old": [
       "Spain"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Palestine Region", 
+   "id": "Palestine Region",
    "g": [
     {
-     "id": "Jerusalem", 
-     "s": 3693857, 
+     "id": "Jerusalem",
+     "s": 3693857,
      "affiliations": [
-      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd", 
+      "\u05de\u05d7\u05d5\u05d6 \u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd",
       "\u05de\u05d3\u05d9\u05e0\u05ea \u05d9\u05e9\u05e8\u05d0\u05dc"
-     ], 
+     ],
      "old": [
-      "Israel", 
+      "Israel",
       "Palestine"
      ]
-    }, 
+    },
     {
-     "id": "Palestine", 
-     "s": 13935868, 
+     "id": "Palestine",
+     "s": 13935868,
      "affiliations": [
-      "Area A", 
-      "Area B", 
+      "Area A",
+      "Area B",
       "Area C"
-     ], 
+     ],
      "old": [
       "Palestine"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Sri Lanka", 
-   "s": 43106400, 
+   "id": "Sri Lanka",
+   "s": 43106400,
    "affiliations": [
-    "Central Province", 
-    "Eastern Province", 
-    "Uva Province", 
-    "North Central", 
-    "North Western Province", 
-    "Northern Province", 
-    "Sabaragamuwa Province", 
-    "Southern Province", 
-    "Western Province", 
+    "Central Province",
+    "Eastern Province",
+    "Uva Province",
+    "North Central",
+    "North Western Province",
+    "Northern Province",
+    "Sabaragamuwa Province",
+    "Southern Province",
+    "Western Province",
     "\u0dc1\u0dca\u200d\u0dbb\u0dd3 \u0dbd\u0d82\u0d9a\u0dcf"
-   ], 
+   ],
    "old": [
     "Sri Lanka"
    ]
-  }, 
+  },
   {
-   "id": "Sudan", 
+   "id": "Sudan",
    "g": [
     {
-     "id": "Sudan_East", 
-     "s": 4542889, 
+     "id": "Sudan_East",
+     "s": 4542889,
      "affiliations": [
-      "Al Ba\u1e29r al A\u1e29mar", 
-      "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan", 
-      "al-Jazeera", 
-      "al-Khartum", 
-      "Kassala", 
-      "Nahr an-Nil", 
-      "Sannar", 
-      "al-Qadarif", 
-      "an-Nil al-Abyad", 
-      "an-Nil al-Azraq", 
+      "Al Ba\u1e29r al A\u1e29mar",
+      "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan",
+      "al-Jazeera",
+      "al-Khartum",
+      "Kassala",
+      "Nahr an-Nil",
+      "Sannar",
+      "al-Qadarif",
+      "an-Nil al-Abyad",
+      "an-Nil al-Azraq",
       "ash-Shamaliyah"
-     ], 
+     ],
      "old": [
       "Sudan"
      ]
-    }, 
+    },
     {
-     "id": "Sudan_West", 
-     "s": 13214266, 
+     "id": "Sudan_West",
+     "s": 13214266,
      "affiliations": [
-      "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan", 
-      "Gharb Darfur", 
-      "al-Jazeera", 
-      "al-Khartum", 
-      "Janub Kurdufan", 
-      "Jonub Darfur", 
-      "Nahr an-Nil", 
-      "Shamal Darfur", 
-      "Shamal Kurdufan", 
-      "Sannar", 
-      "Sharq Darfur", 
-      "South Sudan", 
-      "Wasat Darfur", 
-      "an-Nil al-Abyad", 
-      "ash-Shamaliyah", 
+      "\u0627\u0644\u0633\u0648\u062f\u0627\u0646 - Sudan",
+      "Gharb Darfur",
+      "al-Jazeera",
+      "al-Khartum",
+      "Janub Kurdufan",
+      "Jonub Darfur",
+      "Nahr an-Nil",
+      "Shamal Darfur",
+      "Shamal Kurdufan",
+      "Sannar",
+      "Sharq Darfur",
+      "South Sudan",
+      "Wasat Darfur",
+      "an-Nil al-Abyad",
+      "ash-Shamaliyah",
       "\u0648\u0627\u0631\u0627\u0628"
-     ], 
+     ],
      "old": [
       "Sudan"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Suriname", 
-   "s": 4065194, 
+   "id": "Suriname",
+   "s": 4065194,
    "affiliations": [
-    "Brokopondo", 
-    "Commewijne", 
-    "Coronie", 
-    "Marowijne", 
-    "Nickerie", 
-    "Para", 
-    "Paramaribo", 
-    "Saramacca", 
-    "Sipaliwini", 
-    "Suriname", 
+    "Brokopondo",
+    "Commewijne",
+    "Coronie",
+    "Marowijne",
+    "Nickerie",
+    "Para",
+    "Paramaribo",
+    "Saramacca",
+    "Sipaliwini",
+    "Suriname",
     "Wanica"
-   ], 
+   ],
    "old": [
     "Suriname"
    ]
-  }, 
+  },
   {
-   "id": "Swaziland", 
-   "s": 16526033, 
+   "id": "Swaziland",
+   "s": 16526033,
    "affiliations": [
-    "Sifundza seHhohho", 
-    "Sifundza seLubombo", 
-    "Sifundza seManzini", 
-    "Sifundza seShiselweni", 
+    "Sifundza seHhohho",
+    "Sifundza seLubombo",
+    "Sifundza seManzini",
+    "Sifundza seShiselweni",
     "Swatini"
-   ], 
+   ],
    "old": [
     "Swaziland"
    ]
-  }, 
+  },
   {
-   "id": "Sweden", 
+   "id": "Sweden",
    "g": [
     {
-     "id": "Sweden_Malardalen", 
-     "s": 25719727, 
+     "id": "Sweden_Malardalen",
+     "s": 25719727,
      "affiliations": [
-      "S\u00f6dermanlands l\u00e4n", 
-      "Sverige", 
-      "Uppsala l\u00e4n", 
+      "S\u00f6dermanlands l\u00e4n",
+      "Sverige",
+      "Uppsala l\u00e4n",
       "V\u00e4stmanlands l\u00e4n"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Stockholm", 
-     "s": 37445884, 
+     "id": "Sweden_Stockholm",
+     "s": 37445884,
      "affiliations": [
-      "Stockholms l\u00e4n", 
+      "Stockholms l\u00e4n",
       "Sverige"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Ostra Gotaland", 
-     "s": 46791064, 
+     "id": "Sweden_Ostra Gotaland",
+     "s": 46791064,
      "affiliations": [
-      "Gotlands l\u00e4n", 
-      "J\u00f6nk\u00f6pings l\u00e4n", 
-      "Kalmar l\u00e4n", 
-      "Kronobergs l\u00e4n", 
-      "\u00d6sterg\u00f6tlands l\u00e4n", 
-      "Stockholms l\u00e4n", 
-      "Sverige", 
+      "Gotlands l\u00e4n",
+      "J\u00f6nk\u00f6pings l\u00e4n",
+      "Kalmar l\u00e4n",
+      "Kronobergs l\u00e4n",
+      "\u00d6sterg\u00f6tlands l\u00e4n",
+      "Stockholms l\u00e4n",
+      "Sverige",
       "Territorial waters of Gotland"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Norra Sverige", 
-     "s": 30555239, 
+     "id": "Sweden_Norra Sverige",
+     "s": 30555239,
      "affiliations": [
-      "Norrbottens l\u00e4n", 
-      "Sverige", 
+      "Norrbottens l\u00e4n",
+      "Sverige",
       "V\u00e4sterbottens l\u00e4n"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Mellannorrland", 
-     "s": 22733406, 
+     "id": "Sweden_Mellannorrland",
+     "s": 22733406,
      "affiliations": [
-      "J\u00e4mtlands l\u00e4n", 
-      "Sverige", 
+      "J\u00e4mtlands l\u00e4n",
+      "Sverige",
       "V\u00e4sternorrlands l\u00e4n"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Bergslagen", 
-     "s": 50800720, 
+     "id": "Sweden_Bergslagen",
+     "s": 50800720,
      "affiliations": [
-      "Dalarnas l\u00e4n", 
-      "G\u00e4vleborgs l\u00e4n", 
-      "\u00d6rebro l\u00e4n", 
-      "Sverige", 
+      "Dalarnas l\u00e4n",
+      "G\u00e4vleborgs l\u00e4n",
+      "\u00d6rebro l\u00e4n",
+      "Sverige",
       "V\u00e4rmlands l\u00e4n"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Vastra Gotaland", 
-     "s": 56262076, 
+     "id": "Sweden_Vastra Gotaland",
+     "s": 56262076,
      "affiliations": [
-      "Danmark", 
-      "Hallands l\u00e4n", 
-      "Sverige", 
+      "Danmark",
+      "Hallands l\u00e4n",
+      "Sverige",
       "V\u00e4stra G\u00f6talands l\u00e4n"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
-    }, 
+    },
     {
-     "id": "Sweden_Sodra Gotaland", 
-     "s": 35147512, 
+     "id": "Sweden_Sodra Gotaland",
+     "s": 35147512,
      "affiliations": [
-      "Blekinge l\u00e4n", 
-      "Danmark", 
-      "Sk\u00e5ne l\u00e4n", 
-      "Sverige", 
+      "Blekinge l\u00e4n",
+      "Danmark",
+      "Sk\u00e5ne l\u00e4n",
+      "Sverige",
       "Territorial waters of Bornholm"
-     ], 
+     ],
      "old": [
       "Sweden"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Switzerland", 
+   "id": "Switzerland",
    "g": [
     {
-     "id": "Switzerland_Eastern", 
-     "s": 38177393, 
+     "id": "Switzerland_Eastern",
+     "s": 38177393,
      "affiliations": [
-      "Appenzell Ausserrhoden", 
-      "Appenzell Innerrhoden", 
-      "Glarus", 
-      "Graub\u00fcnden - Grigioni - Grischun", 
-      "Sankt Gallen", 
-      "Schaffhausen", 
-      "Schweiz, Suisse, Svizzera, Svizra", 
+      "Appenzell Ausserrhoden",
+      "Appenzell Innerrhoden",
+      "Glarus",
+      "Graub\u00fcnden - Grigioni - Grischun",
+      "Sankt Gallen",
+      "Schaffhausen",
+      "Schweiz, Suisse, Svizzera, Svizra",
       "Thurgau"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Central", 
-     "s": 18807231, 
+     "id": "Switzerland_Central",
+     "s": 18807231,
      "affiliations": [
-      "Luzern", 
-      "Nidwalden", 
-      "Obwalden", 
-      "Schweiz, Suisse, Svizzera, Svizra", 
-      "Schwyz", 
-      "Uri", 
+      "Luzern",
+      "Nidwalden",
+      "Obwalden",
+      "Schweiz, Suisse, Svizzera, Svizra",
+      "Schwyz",
+      "Uri",
       "Zug"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Espace Mittelland_Bern", 
-     "s": 39112129, 
+     "id": "Switzerland_Espace Mittelland_Bern",
+     "s": 39112129,
      "affiliations": [
-      "Basel-Landschaft", 
-      "Bern - Berne", 
-      "Fribourg - Freiburg", 
-      "Jura", 
-      "Neuch\u00e2tel", 
-      "Schweiz, Suisse, Svizzera, Svizra", 
-      "Solothurn", 
+      "Basel-Landschaft",
+      "Bern - Berne",
+      "Fribourg - Freiburg",
+      "Jura",
+      "Neuch\u00e2tel",
+      "Schweiz, Suisse, Svizzera, Svizra",
+      "Solothurn",
       "Vaud"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Espace Mittelland_East", 
-     "s": 19294065, 
+     "id": "Switzerland_Espace Mittelland_East",
+     "s": 19294065,
      "affiliations": [
-      "Bern - Berne", 
+      "Bern - Berne",
       "Schweiz, Suisse, Svizzera, Svizra"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Ticino", 
-     "s": 8818804, 
+     "id": "Switzerland_Ticino",
+     "s": 8818804,
      "affiliations": [
-      "Schweiz, Suisse, Svizzera, Svizra", 
+      "Schweiz, Suisse, Svizzera, Svizra",
       "Ticino"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Northwestern", 
-     "s": 26453774, 
+     "id": "Switzerland_Northwestern",
+     "s": 26453774,
      "affiliations": [
-      "Aargau", 
-      "Basel-Landschaft", 
-      "Basel-Stadt", 
+      "Aargau",
+      "Basel-Landschaft",
+      "Basel-Stadt",
       "Schweiz, Suisse, Svizzera, Svizra"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Lake Geneva region", 
-     "s": 44478805, 
+     "id": "Switzerland_Lake Geneva region",
+     "s": 44478805,
      "affiliations": [
-      "Fribourg - Freiburg", 
-      "Gen\u00e8ve", 
-      "Schweiz, Suisse, Svizzera, Svizra", 
-      "Vaud", 
+      "Fribourg - Freiburg",
+      "Gen\u00e8ve",
+      "Schweiz, Suisse, Svizzera, Svizra",
+      "Vaud",
       "Valais - Wallis"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
-    }, 
+    },
     {
-     "id": "Switzerland_Zurich", 
-     "s": 27224846, 
+     "id": "Switzerland_Zurich",
+     "s": 27224846,
      "affiliations": [
-      "Schweiz, Suisse, Svizzera, Svizra", 
+      "Schweiz, Suisse, Svizzera, Svizra",
       "Z\u00fcrich"
-     ], 
+     ],
      "old": [
       "Switzerland"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Syria", 
-   "s": 23784370, 
+   "id": "Syria",
+   "s": 23784370,
    "affiliations": [
-    "Al-Hasakah", 
-    "Aleppo", 
-    "Ar-Raqqah", 
-    "As-Suwayda", 
-    "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0648\u0631\u064a\u0629", 
-    "\u0631\u064a\u0641 \u062f\u0645\u0634\u0642", 
-    "Daraa", 
-    "Deir ez-Zor", 
-    "Hama", 
-    "Idlib", 
-    "Latakia", 
-    "Quneitra", 
-    "Tartus", 
-    "UNDOF", 
+    "Al-Hasakah",
+    "Aleppo",
+    "Ar-Raqqah",
+    "As-Suwayda",
+    "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0648\u0631\u064a\u0629",
+    "\u0631\u064a\u0641 \u062f\u0645\u0634\u0642",
+    "Daraa",
+    "Deir ez-Zor",
+    "Hama",
+    "Idlib",
+    "Latakia",
+    "Quneitra",
+    "Tartus",
+    "UNDOF",
     "\u062d\u0645\u0635"
-   ], 
+   ],
    "old": [
     "Syria"
    ]
-  }, 
+  },
   {
-   "id": "Sao Tome and Principe", 
-   "s": 432738, 
+   "id": "Sao Tome and Principe",
+   "s": 432738,
    "affiliations": [
-    "Pr\u00edncipe Province", 
-    "S\u00e3o Tom\u00e9 Province", 
+    "Pr\u00edncipe Province",
+    "S\u00e3o Tom\u00e9 Province",
     "S\u00e3o Tom\u00e9 e Pr\u00edncipe"
-   ], 
+   ],
    "old": [
     "Sao Tome and Principe"
    ]
-  }, 
+  },
   {
-   "id": "Tajikistan", 
-   "s": 11996398, 
+   "id": "Tajikistan",
+   "s": 11996398,
    "affiliations": [
-    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0421\u0443\u0493\u0434", 
-    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0425\u0430\u0442\u043b\u043e\u043d", 
-    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041c\u0443\u0445\u0442\u043e\u0440\u0438 \u041a\u04ef\u04b3\u0438\u0441\u0442\u043e\u043d\u0438 \u0411\u0430\u0434\u0430\u0445\u0448\u043e\u043d", 
-    "\u041d\u043e\u04b3\u0438\u044f\u04b3\u043e\u0438 \u0442\u043e\u0431\u0435\u0438 \u04b7\u0443\u043c\u04b3\u0443\u0440\u04e3", 
+    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0421\u0443\u0493\u0434",
+    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0425\u0430\u0442\u043b\u043e\u043d",
+    "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041c\u0443\u0445\u0442\u043e\u0440\u0438 \u041a\u04ef\u04b3\u0438\u0441\u0442\u043e\u043d\u0438 \u0411\u0430\u0434\u0430\u0445\u0448\u043e\u043d",
+    "\u041d\u043e\u04b3\u0438\u044f\u04b3\u043e\u0438 \u0442\u043e\u0431\u0435\u0438 \u04b7\u0443\u043c\u04b3\u0443\u0440\u04e3",
     "\u0422\u043e\u04b7\u0438\u043a\u0438\u0441\u0442\u043e\u043d"
-   ], 
+   ],
    "old": [
     "Tajikistan"
    ]
-  }, 
+  },
   {
-   "id": "Tanzania", 
-   "s": 96809372, 
+   "id": "Tanzania",
+   "s": 96809372,
    "affiliations": [
-    "Arusha", 
-    "Dar es Salaam", 
-    "Dodoma", 
-    "Iringa", 
-    "Kagera", 
-    "Kilimanjaro", 
-    "Kaskazini Pemba", 
-    "Kusini Pemba", 
-    "Katavi", 
-    "Kigoma", 
-    "Lindi", 
-    "Pwani", 
-    "Manyara", 
-    "Mara", 
-    "Mbeya", 
-    "Morogoro", 
-    "Mtwara", 
-    "Njombe", 
-    "Rukwa", 
-    "Ruvuma", 
-    "Singida", 
-    "Tanzania", 
-    "Tanga", 
-    "Unguja Kaskazini", 
-    "Unguja Kusini", 
+    "Arusha",
+    "Dar es Salaam",
+    "Dodoma",
+    "Iringa",
+    "Kagera",
+    "Kilimanjaro",
+    "Kaskazini Pemba",
+    "Kusini Pemba",
+    "Katavi",
+    "Kigoma",
+    "Lindi",
+    "Pwani",
+    "Manyara",
+    "Mara",
+    "Mbeya",
+    "Morogoro",
+    "Mtwara",
+    "Njombe",
+    "Rukwa",
+    "Ruvuma",
+    "Singida",
+    "Tanzania",
+    "Tanga",
+    "Unguja Kaskazini",
+    "Unguja Kusini",
     "Unguja Mjini Magharibi"
-   ], 
+   ],
    "old": [
     "Tanzania"
    ]
-  }, 
+  },
   {
-   "id": "Thailand", 
+   "id": "Thailand",
    "g": [
     {
-     "id": "Thailand_North", 
-     "s": 21044110, 
+     "id": "Thailand_North",
+     "s": 21044110,
      "affiliations": [
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e30\u0e40\u0e22\u0e32", 
-      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e32\u0e01", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e25\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e48\u0e32\u0e19", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e41\u0e1e\u0e23\u0e48", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e33\u0e1b\u0e32\u0e07", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e33\u0e1e\u0e39\u0e19", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e15\u0e23\u0e14\u0e34\u0e15\u0e16\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e42\u0e02\u0e17\u0e31\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e29\u0e13\u0e38\u0e42\u0e25\u0e01", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e0a\u0e35\u0e22\u0e07\u0e23\u0e32\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e0a\u0e35\u0e22\u0e07\u0e43\u0e2b\u0e21\u0e48", 
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e30\u0e40\u0e22\u0e32",
+      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e32\u0e01",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e25\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e48\u0e32\u0e19",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e41\u0e1e\u0e23\u0e48",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e33\u0e1b\u0e32\u0e07",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e33\u0e1e\u0e39\u0e19",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e15\u0e23\u0e14\u0e34\u0e15\u0e16\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e42\u0e02\u0e17\u0e31\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e29\u0e13\u0e38\u0e42\u0e25\u0e01",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e0a\u0e35\u0e22\u0e07\u0e23\u0e32\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e0a\u0e35\u0e22\u0e07\u0e43\u0e2b\u0e21\u0e48",
       "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e41\u0e21\u0e48\u0e2e\u0e48\u0e2d\u0e07\u0e2a\u0e2d\u0e19"
-     ], 
+     ],
      "old": [
       "Thailand"
      ]
-    }, 
+    },
     {
-     "id": "Thailand_Central", 
-     "s": 29426481, 
+     "id": "Thailand_Central",
+     "s": 29426481,
      "affiliations": [
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e48\u0e32\u0e07\u0e17\u0e2d\u0e07", 
-      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e32\u0e01", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e25\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e32\u0e0d\u0e08\u0e19\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e32\u0e2c\u0e2a\u0e34\u0e19\u0e18\u0e38\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e33\u0e41\u0e1e\u0e07\u0e40\u0e1e\u0e0a\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e2a\u0e27\u0e23\u0e23\u0e04\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1a\u0e38\u0e23\u0e35\u0e23\u0e31\u0e21\u0e22\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e21\u0e2b\u0e32\u0e2a\u0e32\u0e23\u0e04\u0e32\u0e21", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e22\u0e42\u0e2a\u0e18\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2b\u0e19\u0e2d\u0e07\u0e1a\u0e31\u0e27\u0e25\u0e33\u0e20\u0e39", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e1a\u0e25\u0e23\u0e32\u0e0a\u0e18\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e34\u0e07\u0e2b\u0e4c\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e1e\u0e0a\u0e23\u0e1a\u0e39\u0e23\u0e13\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e31\u0e22\u0e19\u0e32\u0e17", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e1e\u0e19\u0e21", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1a\u0e36\u0e07\u0e01\u0e32\u0e2c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e23\u0e32\u0e0a\u0e2a\u0e35\u0e21\u0e32", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e08\u0e34\u0e15\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e1e\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e01\u0e25\u0e19\u0e04\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e02\u0e2d\u0e19\u0e41\u0e01\u0e48\u0e19", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e31\u0e22\u0e20\u0e39\u0e21\u0e34", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e23\u0e30\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e42\u0e02\u0e17\u0e31\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2b\u0e19\u0e2d\u0e07\u0e04\u0e32\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e29\u0e13\u0e38\u0e42\u0e25\u0e01", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e21\u0e38\u0e01\u0e14\u0e32\u0e2b\u0e32\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e49\u0e2d\u0e22\u0e40\u0e2d\u0e47\u0e14", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e28\u0e23\u0e35\u0e2a\u0e30\u0e40\u0e01\u0e29", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e23\u0e34\u0e19\u0e17\u0e23\u0e4c", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e14\u0e23\u0e18\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e17\u0e31\u0e22\u0e18\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e1e\u0e23\u0e23\u0e13\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e33\u0e19\u0e32\u0e08\u0e40\u0e08\u0e23\u0e34\u0e0d", 
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e48\u0e32\u0e07\u0e17\u0e2d\u0e07",
+      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e32\u0e01",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e25\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e32\u0e0d\u0e08\u0e19\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e32\u0e2c\u0e2a\u0e34\u0e19\u0e18\u0e38\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e33\u0e41\u0e1e\u0e07\u0e40\u0e1e\u0e0a\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e2a\u0e27\u0e23\u0e23\u0e04\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1a\u0e38\u0e23\u0e35\u0e23\u0e31\u0e21\u0e22\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e21\u0e2b\u0e32\u0e2a\u0e32\u0e23\u0e04\u0e32\u0e21",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e22\u0e42\u0e2a\u0e18\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2b\u0e19\u0e2d\u0e07\u0e1a\u0e31\u0e27\u0e25\u0e33\u0e20\u0e39",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e1a\u0e25\u0e23\u0e32\u0e0a\u0e18\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e34\u0e07\u0e2b\u0e4c\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e1e\u0e0a\u0e23\u0e1a\u0e39\u0e23\u0e13\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e31\u0e22\u0e19\u0e32\u0e17",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e1e\u0e19\u0e21",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1a\u0e36\u0e07\u0e01\u0e32\u0e2c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e23\u0e32\u0e0a\u0e2a\u0e35\u0e21\u0e32",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e08\u0e34\u0e15\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e25\u0e1e\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e01\u0e25\u0e19\u0e04\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e02\u0e2d\u0e19\u0e41\u0e01\u0e48\u0e19",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e31\u0e22\u0e20\u0e39\u0e21\u0e34",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e23\u0e30\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e42\u0e02\u0e17\u0e31\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2b\u0e19\u0e2d\u0e07\u0e04\u0e32\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e34\u0e29\u0e13\u0e38\u0e42\u0e25\u0e01",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e21\u0e38\u0e01\u0e14\u0e32\u0e2b\u0e32\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e49\u0e2d\u0e22\u0e40\u0e2d\u0e47\u0e14",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e28\u0e23\u0e35\u0e2a\u0e30\u0e40\u0e01\u0e29",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e23\u0e34\u0e19\u0e17\u0e23\u0e4c",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e14\u0e23\u0e18\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e38\u0e17\u0e31\u0e22\u0e18\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e1e\u0e23\u0e23\u0e13\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e33\u0e19\u0e32\u0e08\u0e40\u0e08\u0e23\u0e34\u0e0d",
       "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e23\u0e30\u0e19\u0e04\u0e23\u0e28\u0e23\u0e35\u0e2d\u0e22\u0e38\u0e18\u0e22\u0e32"
-     ], 
+     ],
      "old": [
       "Thailand"
      ]
-    }, 
+    },
     {
-     "id": "Thailand_South", 
-     "s": 37372029, 
+     "id": "Thailand_South",
+     "s": 37372029,
      "affiliations": [
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e38\u0e21\u0e1e\u0e23", 
-      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e2a\u0e32\u0e04\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e23\u0e31\u0e07", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e23\u0e32\u0e14", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e22\u0e30\u0e25\u0e32", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e15\u0e39\u0e25", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e31\u0e07\u0e07\u0e32", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e30\u0e19\u0e2d\u0e07", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e1b\u0e23\u0e32\u0e01\u0e32\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e30\u0e22\u0e2d\u0e07", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e07\u0e02\u0e25\u0e32", 
-      "\u0e01\u0e23\u0e38\u0e07\u0e40\u0e17\u0e1e\u0e21\u0e2b\u0e32\u0e19\u0e04\u0e23", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e2a\u0e07\u0e04\u0e23\u0e32\u0e21", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e23\u0e32\u0e29\u0e0e\u0e23\u0e4c\u0e18\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e23\u0e30\u0e1a\u0e35\u0e48", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e25\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e1b\u0e10\u0e21", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e09\u0e30\u0e40\u0e0a\u0e34\u0e07\u0e40\u0e17\u0e23\u0e32", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e31\u0e17\u0e25\u0e38\u0e07", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e20\u0e39\u0e40\u0e01\u0e47\u0e15", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e19\u0e32\u0e22\u0e01", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e19\u0e17\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e31\u0e15\u0e15\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e32\u0e0a\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e23\u0e30\u0e41\u0e01\u0e49\u0e27", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e08\u0e31\u0e19\u0e17\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e23\u0e32\u0e18\u0e34\u0e27\u0e32\u0e2a", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e17\u0e38\u0e21\u0e18\u0e32\u0e19\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e1e\u0e0a\u0e23\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e23\u0e32\u0e08\u0e35\u0e19\u0e1a\u0e38\u0e23\u0e35", 
-      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e28\u0e23\u0e35\u0e18\u0e23\u0e23\u0e21\u0e23\u0e32\u0e0a", 
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e38\u0e21\u0e1e\u0e23",
+      "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e44\u0e17\u0e22",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e2a\u0e32\u0e04\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e23\u0e31\u0e07",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e15\u0e23\u0e32\u0e14",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e22\u0e30\u0e25\u0e32",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e15\u0e39\u0e25",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e31\u0e07\u0e07\u0e32",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e30\u0e19\u0e2d\u0e07",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e1b\u0e23\u0e32\u0e01\u0e32\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e30\u0e22\u0e2d\u0e07",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e07\u0e02\u0e25\u0e32",
+      "\u0e01\u0e23\u0e38\u0e07\u0e40\u0e17\u0e1e\u0e21\u0e2b\u0e32\u0e19\u0e04\u0e23",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e21\u0e38\u0e17\u0e23\u0e2a\u0e07\u0e04\u0e23\u0e32\u0e21",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e38\u0e23\u0e32\u0e29\u0e0e\u0e23\u0e4c\u0e18\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e23\u0e30\u0e1a\u0e35\u0e48",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0a\u0e25\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e1b\u0e10\u0e21",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e09\u0e30\u0e40\u0e0a\u0e34\u0e07\u0e40\u0e17\u0e23\u0e32",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1e\u0e31\u0e17\u0e25\u0e38\u0e07",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e20\u0e39\u0e40\u0e01\u0e47\u0e15",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e19\u0e32\u0e22\u0e01",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e19\u0e17\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e31\u0e15\u0e15\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e23\u0e32\u0e0a\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2a\u0e23\u0e30\u0e41\u0e01\u0e49\u0e27",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e08\u0e31\u0e19\u0e17\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e23\u0e32\u0e18\u0e34\u0e27\u0e32\u0e2a",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e17\u0e38\u0e21\u0e18\u0e32\u0e19\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e40\u0e1e\u0e0a\u0e23\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e23\u0e32\u0e08\u0e35\u0e19\u0e1a\u0e38\u0e23\u0e35",
+      "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e28\u0e23\u0e35\u0e18\u0e23\u0e23\u0e21\u0e23\u0e32\u0e0a",
       "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e1b\u0e23\u0e30\u0e08\u0e27\u0e1a\u0e04\u0e35\u0e23\u0e35\u0e02\u0e31\u0e19\u0e18\u0e4c"
-     ], 
+     ],
      "old": [
       "Thailand"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "The Bahamas", 
-   "s": 5194718, 
+   "id": "The Bahamas",
+   "s": 5194718,
    "affiliations": [
-    "Ciego de \u00c1vila", 
+    "Ciego de \u00c1vila",
     "The Bahamas"
-   ], 
+   ],
    "old": [
     "Bahamas"
    ]
-  }, 
+  },
   {
-   "id": "The Gambia", 
-   "s": 3491168, 
+   "id": "The Gambia",
+   "s": 3491168,
    "affiliations": [
-    "Brikama", 
-    "Banjul", 
-    "Basse", 
-    "Gambia", 
-    "Janjanbureh", 
-    "Kanifing", 
-    "Kerewan", 
-    "Kuntaur", 
-    "Mansakonko", 
+    "Brikama",
+    "Banjul",
+    "Basse",
+    "Gambia",
+    "Janjanbureh",
+    "Kanifing",
+    "Kerewan",
+    "Kuntaur",
+    "Mansakonko",
     "Senegal"
-   ], 
+   ],
    "old": [
     "Gambia"
    ]
-  }, 
+  },
   {
-   "id": "Netherlands", 
+   "id": "Netherlands",
    "g": [
     {
-     "id": "Netherlands_Drenthe", 
-     "s": 37412439, 
+     "id": "Netherlands_Drenthe",
+     "s": 37412439,
      "affiliations": [
-      "Drenthe", 
+      "Drenthe",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Flevoland", 
-     "s": 22269356, 
+     "id": "Netherlands_Flevoland",
+     "s": 22269356,
      "affiliations": [
-      "Flevoland", 
+      "Flevoland",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Friesland", 
-     "s": 51358534, 
+     "id": "Netherlands_Friesland",
+     "s": 51358534,
      "affiliations": [
-      "Friesland", 
+      "Friesland",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Gelderland_Nijmegen", 
-     "s": 37451217, 
+     "id": "Netherlands_Gelderland_Nijmegen",
+     "s": 37451217,
      "affiliations": [
-      "Gelderland", 
+      "Gelderland",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Gelderland_North", 
-     "s": 60030794, 
+     "id": "Netherlands_Gelderland_North",
+     "s": 60030794,
      "affiliations": [
-      "Gelderland", 
+      "Gelderland",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Gelderland_Zutphen", 
-     "s": 25741626, 
+     "id": "Netherlands_Gelderland_Zutphen",
+     "s": 25741626,
      "affiliations": [
-      "Gelderland", 
+      "Gelderland",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Groningen", 
-     "s": 37388355, 
+     "id": "Netherlands_Groningen",
+     "s": 37388355,
      "affiliations": [
-      "Deutschland", 
-      "Groningen", 
-      "Nederland", 
+      "Deutschland",
+      "Groningen",
+      "Nederland",
       "Niedersachsen"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Limburg", 
-     "s": 66863675, 
+     "id": "Netherlands_Limburg",
+     "s": 66863675,
      "affiliations": [
-      "Limburg", 
+      "Limburg",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Brabant_Eindhoven", 
-     "s": 57904112, 
+     "id": "Netherlands_North Brabant_Eindhoven",
+     "s": 57904112,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Brabant"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Brabant_Roosendaal", 
-     "s": 19993072, 
+     "id": "Netherlands_North Brabant_Roosendaal",
+     "s": 19993072,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Brabant"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Brabant_Tiburg", 
-     "s": 44006631, 
+     "id": "Netherlands_North Brabant_Tiburg",
+     "s": 44006631,
      "affiliations": [
-      "Nederland", 
-      "Nederland - Belgique / Belgi\u00eb / Belgien", 
+      "Nederland",
+      "Nederland - Belgique / Belgi\u00eb / Belgien",
       "Noord-Brabant"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Brabant_Uden", 
-     "s": 20313313, 
+     "id": "Netherlands_North Brabant_Uden",
+     "s": 20313313,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Brabant"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Holland_Alkmaar", 
-     "s": 34331854, 
+     "id": "Netherlands_North Holland_Alkmaar",
+     "s": 34331854,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Holland_Amsterdam", 
-     "s": 75112816, 
+     "id": "Netherlands_North Holland_Amsterdam",
+     "s": 75112816,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_North Holland_Zaandam", 
-     "s": 26358408, 
+     "id": "Netherlands_North Holland_Zaandam",
+     "s": 26358408,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Noord-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Overijssel_Enschede", 
-     "s": 39343491, 
+     "id": "Netherlands_Overijssel_Enschede",
+     "s": 39343491,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Overijssel"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Overijssel_Zwolle", 
-     "s": 34594187, 
+     "id": "Netherlands_Overijssel_Zwolle",
+     "s": 34594187,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Overijssel"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_South Holland_Brielle", 
-     "s": 18740279, 
+     "id": "Netherlands_South Holland_Brielle",
+     "s": 18740279,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Zuid-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_South Holland_Den Haag", 
-     "s": 59043223, 
+     "id": "Netherlands_South Holland_Den Haag",
+     "s": 59043223,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Zuid-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_South Holland_Leiden", 
-     "s": 24845506, 
+     "id": "Netherlands_South Holland_Leiden",
+     "s": 24845506,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Zuid-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_South Holland_Rotterdam", 
-     "s": 61669226, 
+     "id": "Netherlands_South Holland_Rotterdam",
+     "s": 61669226,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Zuid-Holland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Utrecht_Amersfoort", 
-     "s": 28646226, 
+     "id": "Netherlands_Utrecht_Amersfoort",
+     "s": 28646226,
      "affiliations": [
-      "Utrecht", 
+      "Utrecht",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Utrecht_Utrecht", 
-     "s": 33846783, 
+     "id": "Netherlands_Utrecht_Utrecht",
+     "s": 33846783,
      "affiliations": [
-      "Utrecht", 
+      "Utrecht",
       "Nederland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
-    }, 
+    },
     {
-     "id": "Netherlands_Zeeland", 
-     "s": 30527980, 
+     "id": "Netherlands_Zeeland",
+     "s": 30527980,
      "affiliations": [
-      "Nederland", 
+      "Nederland",
       "Zeeland"
-     ], 
+     ],
      "old": [
       "Netherlands"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Togo", 
-   "s": 18511393, 
+   "id": "Togo",
+   "s": 18511393,
    "affiliations": [
-    "R\u00e9gion Centrale", 
-    "R\u00e9gion Maritime", 
-    "R\u00e9gion de la Kara", 
-    "R\u00e9gion des Plateaux", 
-    "R\u00e9gion des Savanes", 
+    "R\u00e9gion Centrale",
+    "R\u00e9gion Maritime",
+    "R\u00e9gion de la Kara",
+    "R\u00e9gion des Plateaux",
+    "R\u00e9gion des Savanes",
     "Togo"
-   ], 
+   ],
    "old": [
     "Togo"
    ]
-  }, 
+  },
   {
-   "id": "Tonga", 
-   "s": 2514075, 
+   "id": "Tonga",
+   "s": 2514075,
    "affiliations": [
-    "Ha\u02bbapai", 
-    "Ongo Niua", 
-    "Tonga", 
-    "Vahe Hihifo", 
-    "Vahe Kolofo'ou", 
-    "Vahe Kolomotu'a", 
-    "Vahe Lapaha", 
-    "Vahe Nukunuku", 
-    "Vahe Tatakamotonga", 
-    "Vahe Vaini", 
+    "Ha\u02bbapai",
+    "Ongo Niua",
+    "Tonga",
+    "Vahe Hihifo",
+    "Vahe Kolofo'ou",
+    "Vahe Kolomotu'a",
+    "Vahe Lapaha",
+    "Vahe Nukunuku",
+    "Vahe Tatakamotonga",
+    "Vahe Vaini",
     "Vava\u02bbu"
-   ], 
+   ],
    "old": [
     "Tonga"
    ]
-  }, 
+  },
   {
-   "id": "Tunisia", 
-   "s": 20993743, 
+   "id": "Tunisia",
+   "s": 20993743,
    "affiliations": [
-    "Tunisie \u2d5c\u2d53\u2d4f\u2d59 \u062a\u0648\u0646\u0633", 
-    "\u0628\u0627\u062c\u0629", 
-    "\u062a\u0648\u0632\u0631", 
-    "\u062a\u0648\u0646\u0633", 
-    "\u0633\u0648\u0633\u0629", 
-    "\u0639\u0631\u0648\u0633", 
-    "\u0642\u0627\u0628\u0633", 
-    "\u0642\u0628\u0644\u064a", 
-    "\u0642\u0641\u0635\u0629", 
-    "\u0646\u0627\u0628\u0644", 
-    "\u0633\u064a\u062f\u064a \u0628\u0648\u0632\u064a\u062f", 
-    "\u0628\u0646\u0632\u0631\u062a", 
-    "\u0627\u0644\u0643\u0627\u0641", 
-    "\u0632\u063a\u0648\u0627\u0646", 
-    "\u0635\u0641\u0627\u0642\u0633", 
-    "\u0645\u062f\u0646\u064a\u0646", 
-    "\u0645\u0646\u0648\u0628\u0629", 
-    "\u0623\u0631\u064a\u0627\u0646\u0629", 
-    "\u062a\u0637\u0627\u0648\u064a\u0646", 
-    "\u062c\u0646\u062f\u0648\u0628\u0629", 
-    "\u0633\u0644\u064a\u0627\u0646\u0629", 
-    "\u0627\u0644\u0642\u0635\u0631\u064a\u0646", 
-    "\u0627\u0644\u0645\u0647\u062f\u064a\u0629", 
-    "\u0627\u0644\u0642\u064a\u0631\u0648\u0627\u0646", 
+    "Tunisie \u2d5c\u2d53\u2d4f\u2d59 \u062a\u0648\u0646\u0633",
+    "\u0628\u0627\u062c\u0629",
+    "\u062a\u0648\u0632\u0631",
+    "\u062a\u0648\u0646\u0633",
+    "\u0633\u0648\u0633\u0629",
+    "\u0639\u0631\u0648\u0633",
+    "\u0642\u0627\u0628\u0633",
+    "\u0642\u0628\u0644\u064a",
+    "\u0642\u0641\u0635\u0629",
+    "\u0646\u0627\u0628\u0644",
+    "\u0633\u064a\u062f\u064a \u0628\u0648\u0632\u064a\u062f",
+    "\u0628\u0646\u0632\u0631\u062a",
+    "\u0627\u0644\u0643\u0627\u0641",
+    "\u0632\u063a\u0648\u0627\u0646",
+    "\u0635\u0641\u0627\u0642\u0633",
+    "\u0645\u062f\u0646\u064a\u0646",
+    "\u0645\u0646\u0648\u0628\u0629",
+    "\u0623\u0631\u064a\u0627\u0646\u0629",
+    "\u062a\u0637\u0627\u0648\u064a\u0646",
+    "\u062c\u0646\u062f\u0648\u0628\u0629",
+    "\u0633\u0644\u064a\u0627\u0646\u0629",
+    "\u0627\u0644\u0642\u0635\u0631\u064a\u0646",
+    "\u0627\u0644\u0645\u0647\u062f\u064a\u0629",
+    "\u0627\u0644\u0642\u064a\u0631\u0648\u0627\u0646",
     "\u0627\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
-   ], 
+   ],
    "old": [
     "Tunisia"
    ]
-  }, 
+  },
   {
-   "id": "Turkey", 
+   "id": "Turkey",
    "g": [
     {
-     "id": "Turkey_Mediterranean Region", 
-     "s": 20523090, 
+     "id": "Turkey_Mediterranean Region",
+     "s": 20523090,
      "affiliations": [
-      "Adana", 
-      "Antalya", 
-      "Burdur", 
-      "Hatay", 
-      "Isparta", 
-      "Kahramanmara\u015f", 
-      "Mersin \u0130li", 
-      "Osmaniye", 
+      "Adana",
+      "Antalya",
+      "Burdur",
+      "Hatay",
+      "Isparta",
+      "Kahramanmara\u015f",
+      "Mersin \u0130li",
+      "Osmaniye",
       "T\u00fcrkiye"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Southeastern Anatolia Region", 
-     "s": 11655207, 
+     "id": "Turkey_Southeastern Anatolia Region",
+     "s": 11655207,
      "affiliations": [
-      "Ad\u0131yaman", 
-      "Batman", 
-      "Bitlis", 
-      "Diyarbak\u0131r", 
-      "Gaziantep", 
-      "Kilis", 
-      "Mardin", 
-      "Siirt", 
-      "T\u00fcrkiye", 
-      "\u015eanl\u0131urfa", 
+      "Ad\u0131yaman",
+      "Batman",
+      "Bitlis",
+      "Diyarbak\u0131r",
+      "Gaziantep",
+      "Kilis",
+      "Mardin",
+      "Siirt",
+      "T\u00fcrkiye",
+      "\u015eanl\u0131urfa",
       "\u015e\u0131rnak"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Marmara Region_Istanbul", 
-     "s": 18467681, 
+     "id": "Turkey_Marmara Region_Istanbul",
+     "s": 18467681,
      "affiliations": [
-      "Edirne", 
-      "Kocaeli", 
-      "K\u0131rklareli", 
-      "Tekirda\u011f", 
-      "T\u00fcrkiye", 
-      "Yalova", 
-      "\u00c7anakkale", 
+      "Edirne",
+      "Kocaeli",
+      "K\u0131rklareli",
+      "Tekirda\u011f",
+      "T\u00fcrkiye",
+      "Yalova",
+      "\u00c7anakkale",
       "\u0130stanbul"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Marmara Region_Bursa", 
-     "s": 15276357, 
+     "id": "Turkey_Marmara Region_Bursa",
+     "s": 15276357,
      "affiliations": [
-      "Bal\u0131kesir", 
-      "Bilecik", 
-      "Bursa", 
-      "Edirne", 
-      "Kocaeli", 
-      "Sakarya", 
-      "Tekirda\u011f", 
-      "T\u00fcrkiye", 
-      "Yalova", 
-      "\u00c7anakkale", 
+      "Bal\u0131kesir",
+      "Bilecik",
+      "Bursa",
+      "Edirne",
+      "Kocaeli",
+      "Sakarya",
+      "Tekirda\u011f",
+      "T\u00fcrkiye",
+      "Yalova",
+      "\u00c7anakkale",
       "\u0130stanbul"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Eastern Anatolia Region", 
-     "s": 17691167, 
+     "id": "Turkey_Eastern Anatolia Region",
+     "s": 17691167,
      "affiliations": [
-      "Ardahan", 
-      "A\u011fr\u0131", 
-      "Bing\u00f6l \u0130li", 
-      "Bitlis", 
-      "Elaz\u0131\u011f", 
-      "Erzincan", 
-      "Erzurum", 
-      "Hakkari", 
-      "I\u011fd\u0131r", 
-      "Kars", 
-      "Malatya", 
-      "Mu\u015f", 
-      "Van", 
-      "Tunceli", 
+      "Ardahan",
+      "A\u011fr\u0131",
+      "Bing\u00f6l \u0130li",
+      "Bitlis",
+      "Elaz\u0131\u011f",
+      "Erzincan",
+      "Erzurum",
+      "Hakkari",
+      "I\u011fd\u0131r",
+      "Kars",
+      "Malatya",
+      "Mu\u015f",
+      "Van",
+      "Tunceli",
       "T\u00fcrkiye"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Black Sea Region", 
-     "s": 27411274, 
+     "id": "Turkey_Black Sea Region",
+     "s": 27411274,
      "affiliations": [
-      "Amasya", 
-      "Bolu", 
-      "Artvin", 
-      "Bart\u0131n", 
-      "Bayburt", 
-      "D\u00fczce", 
-      "Giresun", 
-      "G\u00fcm\u00fc\u015fhane", 
-      "Karab\u00fck", 
-      "Kastamonu", 
-      "Ordu", 
-      "Rize", 
-      "Samsun", 
-      "Sinop", 
-      "Tokat", 
-      "Trabzon", 
-      "T\u00fcrkiye", 
-      "Zonguldak", 
+      "Amasya",
+      "Bolu",
+      "Artvin",
+      "Bart\u0131n",
+      "Bayburt",
+      "D\u00fczce",
+      "Giresun",
+      "G\u00fcm\u00fc\u015fhane",
+      "Karab\u00fck",
+      "Kastamonu",
+      "Ordu",
+      "Rize",
+      "Samsun",
+      "Sinop",
+      "Tokat",
+      "Trabzon",
+      "T\u00fcrkiye",
+      "Zonguldak",
       "\u00c7orum"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Central Anatolia Region_Ankara", 
-     "s": 20035341, 
+     "id": "Turkey_Central Anatolia Region_Ankara",
+     "s": 20035341,
      "affiliations": [
-      "Aksaray", 
-      "Ankara", 
-      "Eski\u015fehir", 
-      "Konya", 
-      "Karaman", 
-      "K\u0131r\u015fehir", 
-      "K\u0131r\u0131kkale", 
-      "T\u00fcrkiye", 
+      "Aksaray",
+      "Ankara",
+      "Eski\u015fehir",
+      "Konya",
+      "Karaman",
+      "K\u0131r\u015fehir",
+      "K\u0131r\u0131kkale",
+      "T\u00fcrkiye",
       "\u00c7ank\u0131r\u0131"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Central Anatolia Region_Kayseri", 
-     "s": 10382197, 
+     "id": "Turkey_Central Anatolia Region_Kayseri",
+     "s": 10382197,
      "affiliations": [
-      "Kayseri", 
-      "K\u0131r\u015fehir", 
-      "Nev\u015fehir", 
-      "Ni\u011fde", 
-      "Sivas", 
-      "T\u00fcrkiye", 
+      "Kayseri",
+      "K\u0131r\u015fehir",
+      "Nev\u015fehir",
+      "Ni\u011fde",
+      "Sivas",
+      "T\u00fcrkiye",
       "Yozgat"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
-    }, 
+    },
     {
-     "id": "Turkey_Aegean Region", 
-     "s": 20615159, 
+     "id": "Turkey_Aegean Region",
+     "s": 20615159,
      "affiliations": [
-      "Afyonkarahisar", 
-      "Ayd\u0131n", 
-      "Denizli", 
-      "K\u00fctahya", 
-      "Manisa", 
-      "Mu\u011fla", 
-      "T\u00fcrkiye", 
-      "U\u015fak", 
+      "Afyonkarahisar",
+      "Ayd\u0131n",
+      "Denizli",
+      "K\u00fctahya",
+      "Manisa",
+      "Mu\u011fla",
+      "T\u00fcrkiye",
+      "U\u015fak",
       "\u0130zmir"
-     ], 
+     ],
      "old": [
       "Turkey"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Turkmenistan", 
-   "s": 6138155, 
+   "id": "Turkmenistan",
+   "s": 6138155,
    "affiliations": [
-    "Ahal", 
-    "Balkan", 
-    "Da\u015foguz", 
-    "Lebap", 
-    "Mary", 
+    "Ahal",
+    "Balkan",
+    "Da\u015foguz",
+    "Lebap",
+    "Mary",
     "T\u00fcrkmenistan"
-   ], 
+   ],
    "old": [
     "Turkmenistan"
    ]
-  }, 
+  },
   {
-   "id": "Turks and Caicos Islands", 
-   "s": 458861, 
+   "id": "Turks and Caicos Islands",
+   "s": 458861,
    "affiliations": [
-    "Rep\u00fablica Dominicana", 
-    "The Bahamas", 
+    "Rep\u00fablica Dominicana",
+    "The Bahamas",
     "Turks and Caicos Islands"
-   ], 
+   ],
    "old": [
     "Turks and Caicos Islands"
    ]
-  }, 
+  },
   {
-   "id": "Tuvalu", 
-   "s": 264587, 
+   "id": "Tuvalu",
+   "s": 264587,
    "affiliations": [
     "Tuvalu"
-   ], 
+   ],
    "old": [
     "Tuvalu"
    ]
-  }, 
+  },
   {
-   "id": "Uganda", 
-   "s": 30236612, 
+   "id": "Uganda",
+   "s": 30236612,
    "affiliations": [
-    "Abim", 
-    "Agago", 
-    "Alebtong", 
-    "Apac", 
-    "Busia", 
-    "Butambala", 
-    "Central Region", 
-    "Dokolo", 
-    "Eastern Region", 
-    "Gulu", 
-    "Isingiro", 
-    "Kaabong", 
-    "Kabarole", 
-    "Kamuli", 
-    "Kanungu District", 
-    "Kapchorwa", 
-    "Kole", 
-    "Katakwi", 
-    "Kayunga", 
-    "Kibaale", 
-    "Kiruhura", 
-    "Lira", 
-    "Mayuge", 
-    "Nwoya", 
-    "Mitooma", 
-    "Mpigi", 
-    "Nakapiripirit", 
-    "Nakaseke", 
-    "Northern Region", 
-    "Ntungamo", 
-    "Oyam", 
-    "Pader", 
-    "Rakai", 
-    "Rubirizi", 
-    "Sembabule", 
-    "Serere", 
-    "Soroti", 
-    "Tororo", 
-    "Uganda", 
+    "Abim",
+    "Agago",
+    "Alebtong",
+    "Apac",
+    "Busia",
+    "Butambala",
+    "Central Region",
+    "Dokolo",
+    "Eastern Region",
+    "Gulu",
+    "Isingiro",
+    "Kaabong",
+    "Kabarole",
+    "Kamuli",
+    "Kanungu District",
+    "Kapchorwa",
+    "Kole",
+    "Katakwi",
+    "Kayunga",
+    "Kibaale",
+    "Kiruhura",
+    "Lira",
+    "Mayuge",
+    "Nwoya",
+    "Mitooma",
+    "Mpigi",
+    "Nakapiripirit",
+    "Nakaseke",
+    "Northern Region",
+    "Ntungamo",
+    "Oyam",
+    "Pader",
+    "Rakai",
+    "Rubirizi",
+    "Sembabule",
+    "Serere",
+    "Soroti",
+    "Tororo",
+    "Uganda",
     "Western Region"
-   ], 
+   ],
    "old": [
     "Uganda"
    ]
-  }, 
+  },
   {
-   "id": "Ukraine", 
+   "id": "Ukraine",
    "g": [
     {
-     "id": "Ukraine_Cherkasy Oblast", 
-     "s": 11551112, 
+     "id": "Ukraine_Cherkasy Oblast",
+     "s": 11551115,
      "affiliations": [
-      "\u0427\u0435\u0440\u043a\u0430\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0427\u0435\u0440\u043a\u0430\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Chernihiv Oblast", 
-     "s": 12846885, 
+     "id": "Ukraine_Chernihiv Oblast",
+     "s": 12846884,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0427\u0435\u0440\u043d\u0456\u0433\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Chernivtsi Oblast", 
-     "s": 12416149, 
+     "id": "Ukraine_Chernivtsi Oblast",
+     "s": 12416155,
      "affiliations": [
-      "\u0427\u0435\u0440\u043d\u0456\u0432\u0435\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0427\u0435\u0440\u043d\u0456\u0432\u0435\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Dnipropetrovsk Oblast", 
-     "s": 27796987, 
+     "id": "Ukraine_Dnipropetrovsk Oblast",
+     "s": 27796988,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0414\u043d\u0456\u043f\u0440\u043e\u043f\u0435\u0442\u0440\u043e\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Donetsk Oblast", 
-     "s": 29346144, 
+     "id": "Ukraine_Donetsk Oblast",
+     "s": 29346148,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0414\u043e\u043d\u0435\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Ivano-Frankivsk Oblast", 
-     "s": 14901566, 
+     "id": "Ukraine_Ivano-Frankivsk Oblast",
+     "s": 14901571,
      "affiliations": [
-      "\u0406\u0432\u0430\u043d\u043e-\u0424\u0440\u0430\u043d\u043a\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0406\u0432\u0430\u043d\u043e-\u0424\u0440\u0430\u043d\u043a\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Kharkiv Oblast", 
-     "s": 22648338, 
+     "id": "Ukraine_Kharkiv Oblast",
+     "s": 22648339,
      "affiliations": [
-      "\u0425\u0430\u0440\u043a\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0425\u0430\u0440\u043a\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Kherson Oblast", 
-     "s": 7867777, 
+     "id": "Ukraine_Kherson Oblast",
+     "s": 7867777,
      "affiliations": [
-      "\u0425\u0435\u0440\u0441\u043e\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0425\u0435\u0440\u0441\u043e\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Khmelnytskyi Oblast", 
-     "s": 10525815, 
+     "id": "Ukraine_Khmelnytskyi Oblast",
+     "s": 10525818,
      "affiliations": [
-      "\u0425\u043c\u0435\u043b\u044c\u043d\u0438\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0425\u043c\u0435\u043b\u044c\u043d\u0438\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Kirovohrad Oblast", 
-     "s": 11220028, 
+     "id": "Ukraine_Kirovohrad Oblast",
+     "s": 11220034,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u041a\u0456\u0440\u043e\u0432\u043e\u0433\u0440\u0430\u0434\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Kyiv Oblast", 
-     "s": 30809423, 
+     "id": "Ukraine_Kyiv Oblast",
+     "s": 30809429,
      "affiliations": [
-      "\u041a\u0438\u0457\u0432", 
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u041a\u0438\u0457\u0432",
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u041a\u0438\u0457\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Luhansk Oblast", 
-     "s": 25413086, 
+     "id": "Ukraine_Luhansk Oblast",
+     "s": 25413091,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u041b\u0443\u0433\u0430\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Lviv Oblast", 
-     "s": 23291905, 
+     "id": "Ukraine_Lviv Oblast",
+     "s": 23291908,
      "affiliations": [
-      "\u041b\u044c\u0432\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u041b\u044c\u0432\u0456\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Mykolaiv Oblast", 
-     "s": 10060530, 
+     "id": "Ukraine_Mykolaiv Oblast",
+     "s": 10060531,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Odessa Oblast", 
-     "s": 17303604, 
+     "id": "Ukraine_Odessa Oblast",
+     "s": 17303604,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u041e\u0434\u0435\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Poltava Oblast", 
-     "s": 12779047, 
+     "id": "Ukraine_Poltava Oblast",
+     "s": 12779052,
      "affiliations": [
-      "\u041f\u043e\u043b\u0442\u0430\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u041f\u043e\u043b\u0442\u0430\u0432\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Rivne Oblast", 
-     "s": 7306080, 
+     "id": "Ukraine_Rivne Oblast",
+     "s": 7306082,
      "affiliations": [
-      "\u0420\u0456\u0432\u043d\u0435\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0420\u0456\u0432\u043d\u0435\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Sumy Oblast", 
-     "s": 14652044, 
+     "id": "Ukraine_Sumy Oblast",
+     "s": 14652043,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0421\u0443\u043c\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Ternopil Oblast", 
-     "s": 13908892, 
+     "id": "Ukraine_Ternopil Oblast",
+     "s": 13908891,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0422\u0435\u0440\u043d\u043e\u043f\u0456\u043b\u044c\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Vinnytsia Oblast", 
-     "s": 12353753, 
+     "id": "Ukraine_Vinnytsia Oblast",
+     "s": 12353754,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0412\u0456\u043d\u043d\u0438\u0446\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Volyn Oblast", 
-     "s": 10339386, 
+     "id": "Ukraine_Volyn Oblast",
+     "s": 10339386,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0412\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Zakarpattia Oblast", 
-     "s": 13359804, 
+     "id": "Ukraine_Zakarpattia Oblast",
+     "s": 13359803,
      "affiliations": [
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0417\u0430\u043a\u0430\u0440\u043f\u0430\u0442\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Zaporizhia Oblast", 
-     "s": 9789880, 
+     "id": "Ukraine_Zaporizhia Oblast",
+     "s": 9789882,
      "affiliations": [
-      "\u0417\u0430\u043f\u043e\u0440\u0456\u0437\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0417\u0430\u043f\u043e\u0440\u0456\u0437\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Ukraine_Zhytomyr Oblast", 
-     "s": 8055390, 
+     "id": "Ukraine_Zhytomyr Oblast",
+     "s": 8055394,
      "affiliations": [
-      "\u0416\u0438\u0442\u043e\u043c\u0438\u0440\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c", 
+      "\u0416\u0438\u0442\u043e\u043c\u0438\u0440\u0441\u044c\u043a\u0430 \u043e\u0431\u043b\u0430\u0441\u0442\u044c",
       "\u0423\u043a\u0440\u0430\u0457\u043d\u0430"
-     ], 
+     ],
      "old": [
       "Ukraine"
      ]
-    }, 
+    },
     {
-     "id": "Crimea", 
-     "s": 22508611, 
+     "id": "Crimea",
+     "s": 22508611,
      "affiliations": [
-      "\u0410\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041a\u0440\u0438\u043c", 
-      "\u0420\u043e\u0441\u0441\u0438\u044f", 
-      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", 
-      "\u0421\u0435\u0432\u0430\u0441\u0442\u043e\u043f\u043e\u043b\u044c", 
-      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430", 
+      "\u0410\u0432\u0442\u043e\u043d\u043e\u043c\u043d\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041a\u0440\u0438\u043c",
+      "\u0420\u043e\u0441\u0441\u0438\u044f",
+      "\u0420\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0430\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f",
+      "\u0421\u0435\u0432\u0430\u0441\u0442\u043e\u043f\u043e\u043b\u044c",
+      "\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
       "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0440\u044b\u043c"
-     ], 
+     ],
      "old": [
       "Crimea"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "United Arab Emirates", 
-   "s": 18666533, 
+   "id": "United Arab Emirates",
+   "s": 18666533,
    "affiliations": [
-    "\u0623\u0628\u0648 \u0638\u0628\u064a", 
-    "\u200f\u0623\u0645 \u0627\u0644\u0642\u064a\u0648\u064a\u0646\u200e", 
-    "\u062f\u0628\u064a\u200e", 
-    "\u200f\u0631\u0623\u0633 \u0627\u0644\u062e\u064a\u0645\u0629\u200e", 
-    "\u0639\u062c\u0645\u0627\u0646", 
-    "\u0641\u062c\u064a\u0631\u0629", 
-    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0646\u062f\u0645", 
-    "\u0627\u0644\u0634\u0627\u0631\u0642\u0629", 
+    "\u0623\u0628\u0648 \u0638\u0628\u064a",
+    "\u200f\u0623\u0645 \u0627\u0644\u0642\u064a\u0648\u064a\u0646\u200e",
+    "\u062f\u0628\u064a\u200e",
+    "\u200f\u0631\u0623\u0633 \u0627\u0644\u062e\u064a\u0645\u0629\u200e",
+    "\u0639\u062c\u0645\u0627\u0646",
+    "\u0641\u062c\u064a\u0631\u0629",
+    "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0633\u0646\u062f\u0645",
+    "\u0627\u0644\u0634\u0627\u0631\u0642\u0629",
     "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a \u0627\u0644\u0639\u0631\u0628\u064a\u0651\u0629 \u0627\u0644\u0645\u062a\u0651\u062d\u062f\u0629"
-   ], 
+   ],
    "old": [
     "United Arab Emirates"
    ]
-  }, 
+  },
   {
-   "id": "Falkland Islands", 
-   "s": 2188751, 
+   "id": "Falkland Islands",
+   "s": 2188751,
    "affiliations": [
     "Falkland Islands"
-   ], 
+   ],
    "old": [
     "Falkland Islands"
    ]
-  }, 
+  },
   {
-   "id": "United Kingdom", 
+   "id": "United Kingdom",
    "g": [
     {
-     "id": "British Indian Ocean Territory", 
-     "s": 105112, 
+     "id": "British Indian Ocean Territory",
+     "s": 105112,
      "affiliations": [
       "British Indian Ocean Territory"
-     ], 
+     ],
      "old": [
       "British Indian Ocean Territory"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_East Midlands", 
-     "s": 60062161, 
+     "id": "UK_England_East Midlands",
+     "s": 60062161,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_East of England_Essex", 
-     "s": 35775733, 
+     "id": "UK_England_East of England_Essex",
+     "s": 35775733,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_East of England_Norfolk", 
-     "s": 45082695, 
+     "id": "UK_England_East of England_Norfolk",
+     "s": 45082695,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_Greater London", 
-     "s": 37673517, 
+     "id": "UK_England_Greater London",
+     "s": 37673517,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_North East England", 
-     "s": 26786260, 
+     "id": "UK_England_North East England",
+     "s": 26786260,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_North West England_Manchester", 
-     "s": 43317588, 
+     "id": "UK_England_North West England_Manchester",
+     "s": 43317588,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_North West England_Lancaster", 
-     "s": 16956309, 
+     "id": "UK_England_North West England_Lancaster",
+     "s": 16956309,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_South East_Brighton", 
-     "s": 41870117, 
+     "id": "UK_England_South East_Brighton",
+     "s": 41870117,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_South East_Oxford", 
-     "s": 47428970, 
+     "id": "UK_England_South East_Oxford",
+     "s": 47428970,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_South West England_Bristol", 
-     "s": 49153649, 
+     "id": "UK_England_South West England_Bristol",
+     "s": 49153649,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_South West England_Cornwall", 
-     "s": 26333324, 
+     "id": "UK_England_South West England_Cornwall",
+     "s": 26333324,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_West Midlands", 
-     "s": 70784989, 
+     "id": "UK_England_West Midlands",
+     "s": 70784989,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_England_Yorkshire and the Humber", 
-     "s": 65918509, 
+     "id": "UK_England_Yorkshire and the Humber",
+     "s": 65918509,
      "affiliations": [
-      "England", 
+      "England",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_England"
      ]
-    }, 
+    },
     {
-     "id": "UK_Northern Ireland", 
-     "s": 13880584, 
+     "id": "UK_Northern Ireland",
+     "s": 13880584,
      "affiliations": [
-      "Northern Ireland", 
-      "Scotland", 
+      "Northern Ireland",
+      "Scotland",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_Northern Ireland"
      ]
-    }, 
+    },
     {
-     "id": "UK_Scotland_North", 
-     "s": 54659502, 
+     "id": "UK_Scotland_North",
+     "s": 54659502,
      "affiliations": [
-      "Scotland", 
+      "Scotland",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_Scotland"
      ]
-    }, 
+    },
     {
-     "id": "UK_Scotland_South", 
-     "s": 50386482, 
+     "id": "UK_Scotland_South",
+     "s": 50386482,
      "affiliations": [
-      "Isle of Man", 
-      "Scotland", 
+      "Isle of Man",
+      "Scotland",
       "United Kingdom"
-     ], 
+     ],
      "old": [
       "UK_Scotland"
      ]
-    }, 
+    },
     {
-     "id": "UK_Wales", 
-     "s": 46549720, 
+     "id": "UK_Wales",
+     "s": 46549720,
      "affiliations": [
-      "United Kingdom", 
+      "United Kingdom",
       "Wales"
-     ], 
+     ],
      "old": [
       "UK_Wales"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Ireland", 
+   "id": "Ireland",
    "g": [
     {
-     "id": "Ireland_Connacht", 
-     "s": 18920022, 
+     "id": "Ireland_Connacht",
+     "s": 18920022,
      "affiliations": [
       "Ireland"
-     ], 
+     ],
      "old": [
       "Ireland"
      ]
-    }, 
+    },
     {
-     "id": "Ireland_Leinster", 
-     "s": 32109906, 
+     "id": "Ireland_Leinster",
+     "s": 32109906,
      "affiliations": [
       "Ireland"
-     ], 
+     ],
      "old": [
       "Ireland"
      ]
-    }, 
+    },
     {
-     "id": "Ireland_Munster", 
-     "s": 22149570, 
+     "id": "Ireland_Munster",
+     "s": 22149570,
      "affiliations": [
       "Ireland"
-     ], 
+     ],
      "old": [
       "Ireland"
      ]
-    }, 
+    },
     {
-     "id": "Ireland_Northern Counties", 
-     "s": 7234885, 
+     "id": "Ireland_Northern Counties",
+     "s": 7234885,
      "affiliations": [
       "Ireland"
-     ], 
+     ],
      "old": [
       "Ireland"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "United States of America", 
+   "id": "United States of America",
    "g": [
     {
-     "id": "Alabama", 
+     "id": "Alabama",
      "g": [
       {
-       "id": "US_Alabama_Birmingham", 
-       "s": 23711397, 
+       "id": "US_Alabama_Birmingham",
+       "s": 23711397,
        "affiliations": [
-        "Alabama", 
-        "AL", 
+        "Alabama",
+        "AL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Alabama"
        ]
-      }, 
+      },
       {
-       "id": "US_Alabama_Montgomery", 
-       "s": 28515740, 
+       "id": "US_Alabama_Montgomery",
+       "s": 28515740,
        "affiliations": [
-        "Alabama", 
-        "AL", 
+        "Alabama",
+        "AL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Alabama"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Alaska", 
-     "s": 43150148, 
+     "id": "US_Alaska",
+     "s": 43150148,
      "affiliations": [
-      "Alaska", 
-      "AK", 
+      "Alaska",
+      "AK",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Alaska"
      ]
-    }, 
+    },
     {
-     "id": "Arizona", 
+     "id": "Arizona",
      "g": [
       {
-       "id": "US_Arizona_Flagstaff", 
-       "s": 27401098, 
+       "id": "US_Arizona_Flagstaff",
+       "s": 27401098,
        "affiliations": [
-        "Arizona", 
-        "AZ", 
+        "Arizona",
+        "AZ",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Arizona"
        ]
-      }, 
+      },
       {
-       "id": "US_Arizona_Phoenix", 
-       "s": 33719986, 
+       "id": "US_Arizona_Phoenix",
+       "s": 33719986,
        "affiliations": [
-        "Arizona", 
-        "AZ", 
+        "Arizona",
+        "AZ",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Arizona"
        ]
-      }, 
+      },
       {
-       "id": "US_Arizona_Tucson", 
-       "s": 15542755, 
+       "id": "US_Arizona_Tucson",
+       "s": 15542755,
        "affiliations": [
-        "Arizona", 
-        "AZ", 
+        "Arizona",
+        "AZ",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Arizona"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Arkansas", 
+     "id": "US_Arkansas",
      "g": [
       {
-       "id": "US_Arkansas_North", 
-       "s": 29265586, 
+       "id": "US_Arkansas_North",
+       "s": 29265586,
        "affiliations": [
-        "Arkansas", 
-        "AR", 
+        "Arkansas",
+        "AR",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Arkansas"
        ]
-      }, 
+      },
       {
-       "id": "US_Arkansas_South", 
-       "s": 14173238, 
+       "id": "US_Arkansas_South",
+       "s": 14173238,
        "affiliations": [
-        "Arkansas", 
-        "AR", 
+        "Arkansas",
+        "AR",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Arkansas"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "California", 
+     "id": "California",
      "g": [
       {
-       "id": "US_California_Chico", 
-       "s": 29215258, 
+       "id": "US_California_Chico",
+       "s": 29215258,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Bakersfield_Bakersfield", 
-       "s": 29635742, 
+       "id": "US_California_Bakersfield_Bakersfield",
+       "s": 29635742,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Bakersfield_Lancaster", 
-       "s": 23983638, 
+       "id": "US_California_Bakersfield_Lancaster",
+       "s": 23983638,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_LA", 
-       "s": 162638356, 
+       "id": "US_California_LA",
+       "s": 162638356,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_LA North", 
-       "s": 49563457, 
+       "id": "US_California_LA North",
+       "s": 49563457,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Redding", 
-       "s": 36875952, 
+       "id": "US_California_Redding",
+       "s": 36875952,
        "affiliations": [
-        "California", 
-        "CA", 
-        "Hoopa Valley Tribe", 
+        "California",
+        "CA",
+        "Hoopa Valley Tribe",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Sacramento_Sacramento", 
-       "s": 18993075, 
+       "id": "US_California_Sacramento_Sacramento",
+       "s": 18993075,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Sacramento_Fresno", 
-       "s": 23883970, 
+       "id": "US_California_Sacramento_Fresno",
+       "s": 23883970,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Sacramento_Stockton", 
-       "s": 28774639, 
+       "id": "US_California_Sacramento_Stockton",
+       "s": 28774639,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_San Diego", 
-       "s": 48903554, 
+       "id": "US_California_San Diego",
+       "s": 48903554,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Santa_Clara_Santa Cruz", 
-       "s": 15146766, 
+       "id": "US_California_Santa_Clara_Santa Cruz",
+       "s": 15146766,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
-      }, 
+      },
       {
-       "id": "US_California_Santa_Clara_Palo Alto", 
-       "s": 69332279, 
+       "id": "US_California_Santa_Clara_Palo Alto",
+       "s": 69332279,
        "affiliations": [
-        "California", 
-        "CA", 
+        "California",
+        "CA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_California"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Colorado", 
+     "id": "Colorado",
      "g": [
       {
-       "id": "US_Colorado_Aspen", 
-       "s": 37954825, 
+       "id": "US_Colorado_Aspen",
+       "s": 37954825,
        "affiliations": [
-        "Colorado", 
-        "CO", 
+        "Colorado",
+        "CO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Colorado"
        ]
-      }, 
+      },
       {
-       "id": "US_Colorado_Denver", 
-       "s": 44295817, 
+       "id": "US_Colorado_Denver",
+       "s": 44295817,
        "affiliations": [
-        "Colorado", 
-        "CO", 
+        "Colorado",
+        "CO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Colorado"
        ]
-      }, 
+      },
       {
-       "id": "US_Colorado_South", 
-       "s": 31138052, 
+       "id": "US_Colorado_South",
+       "s": 31138052,
        "affiliations": [
-        "Colorado", 
-        "CO", 
+        "Colorado",
+        "CO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Colorado"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Connecticut", 
-     "s": 19341729, 
+     "id": "US_Connecticut",
+     "s": 19341729,
      "affiliations": [
-      "Connecticut", 
-      "CT", 
+      "Connecticut",
+      "CT",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Connecticut"
      ]
-    }, 
+    },
     {
-     "id": "US_Delaware", 
-     "s": 6562761, 
+     "id": "US_Delaware",
+     "s": 6562761,
      "affiliations": [
-      "Delaware", 
-      "DE", 
+      "Delaware",
+      "DE",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Delaware"
      ]
-    }, 
+    },
     {
-     "id": "Florida", 
+     "id": "Florida",
      "g": [
       {
-       "id": "US_Florida_Jacksonville", 
-       "s": 24020210, 
+       "id": "US_Florida_Jacksonville",
+       "s": 24020210,
        "affiliations": [
-        "Florida", 
-        "FL", 
+        "Florida",
+        "FL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Florida"
        ]
-      }, 
+      },
       {
-       "id": "US_Florida_Miami", 
-       "s": 38469117, 
+       "id": "US_Florida_Miami",
+       "s": 38469117,
        "affiliations": [
-        "Florida", 
-        "FL", 
+        "Florida",
+        "FL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Florida"
        ]
-      }, 
+      },
       {
-       "id": "US_Florida_Orlando", 
-       "s": 16764218, 
+       "id": "US_Florida_Orlando",
+       "s": 16764218,
        "affiliations": [
-        "Florida", 
-        "FL", 
+        "Florida",
+        "FL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Florida"
        ]
-      }, 
+      },
       {
-       "id": "US_Florida_Tampa", 
-       "s": 27335289, 
+       "id": "US_Florida_Tampa",
+       "s": 27335289,
        "affiliations": [
-        "Florida", 
-        "FL", 
+        "Florida",
+        "FL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Florida"
        ]
-      }, 
+      },
       {
-       "id": "US_Florida_Gainesville", 
-       "s": 19404464, 
+       "id": "US_Florida_Gainesville",
+       "s": 19404464,
        "affiliations": [
-        "Florida", 
-        "FL", 
+        "Florida",
+        "FL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Florida"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Georgia", 
+     "id": "US_Georgia",
      "g": [
       {
-       "id": "US_Georgia_Atlanta", 
-       "s": 45921438, 
+       "id": "US_Georgia_Atlanta",
+       "s": 45921438,
        "affiliations": [
-        "Georgia", 
-        "GA", 
+        "Georgia",
+        "GA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Georgia"
        ]
-      }, 
+      },
       {
-       "id": "US_Georgia_Macon", 
-       "s": 31823399, 
+       "id": "US_Georgia_Macon",
+       "s": 31823399,
        "affiliations": [
-        "Georgia", 
-        "GA", 
+        "Georgia",
+        "GA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Georgia"
        ]
-      }, 
+      },
       {
-       "id": "US_Georgia_North", 
-       "s": 21135527, 
+       "id": "US_Georgia_North",
+       "s": 21135527,
        "affiliations": [
-        "Georgia", 
-        "GA", 
+        "Georgia",
+        "GA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Georgia"
        ]
-      }, 
+      },
       {
-       "id": "US_Georgia_South", 
-       "s": 25190238, 
+       "id": "US_Georgia_South",
+       "s": 25190238,
        "affiliations": [
-        "Georgia", 
-        "GA", 
+        "Georgia",
+        "GA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Georgia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Guam", 
-     "s": 1703860, 
+     "id": "US_Guam",
+     "s": 1703860,
      "affiliations": [
-      "Guam", 
-      "GU", 
-      "Northern Mariana Islands", 
-      "MP", 
+      "Guam",
+      "GU",
+      "Northern Mariana Islands",
+      "MP",
       "United States of America"
-     ], 
+     ],
      "old": [
-      "Northern Mariana Islands", 
+      "Northern Mariana Islands",
       "Guam"
      ]
-    }, 
+    },
     {
-     "id": "US_Hawaii", 
-     "s": 7960834, 
+     "id": "US_Hawaii",
+     "s": 7960834,
      "affiliations": [
-      "Hawaii", 
-      "HI", 
+      "Hawaii",
+      "HI",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Hawaii"
      ]
-    }, 
+    },
     {
-     "id": "US_Idaho", 
+     "id": "US_Idaho",
      "g": [
       {
-       "id": "US_Idaho_North", 
-       "s": 18887590, 
+       "id": "US_Idaho_North",
+       "s": 18887590,
        "affiliations": [
-        "Idaho", 
-        "ID", 
+        "Idaho",
+        "ID",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Idaho"
        ]
-      }, 
+      },
       {
-       "id": "US_Idaho_South", 
-       "s": 20195656, 
+       "id": "US_Idaho_South",
+       "s": 20195656,
        "affiliations": [
-        "Idaho", 
-        "ID", 
+        "Idaho",
+        "ID",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Idaho"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Illinois", 
+     "id": "Illinois",
      "g": [
       {
-       "id": "US_Illinois_South", 
-       "s": 17353213, 
+       "id": "US_Illinois_South",
+       "s": 17353213,
        "affiliations": [
-        "Illinois", 
-        "IL", 
+        "Illinois",
+        "IL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Illinois"
        ]
-      }, 
+      },
       {
-       "id": "US_Illinois_Chickago", 
-       "s": 47936347, 
+       "id": "US_Illinois_Chickago",
+       "s": 47936347,
        "affiliations": [
-        "Illinois", 
-        "IL", 
+        "Illinois",
+        "IL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Illinois"
        ]
-      }, 
+      },
       {
-       "id": "US_Illinois_Elgin", 
-       "s": 13840337, 
+       "id": "US_Illinois_Elgin",
+       "s": 13840337,
        "affiliations": [
-        "Illinois", 
-        "IL", 
+        "Illinois",
+        "IL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Illinois"
        ]
-      }, 
+      },
       {
-       "id": "US_Illinois_Rockford", 
-       "s": 10661359, 
+       "id": "US_Illinois_Rockford",
+       "s": 10661359,
        "affiliations": [
-        "Illinois", 
-        "IL", 
+        "Illinois",
+        "IL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Illinois"
        ]
-      }, 
+      },
       {
-       "id": "US_Illinois_Springfield", 
-       "s": 27973723, 
+       "id": "US_Illinois_Springfield",
+       "s": 27973723,
        "affiliations": [
-        "Illinois", 
-        "IL", 
+        "Illinois",
+        "IL",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Illinois"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Indiana", 
+     "id": "Indiana",
      "g": [
       {
-       "id": "US_Indiana_North", 
-       "s": 19079201, 
+       "id": "US_Indiana_North",
+       "s": 19079201,
        "affiliations": [
-        "Indiana", 
-        "IN", 
+        "Indiana",
+        "IN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Indiana"
        ]
-      }, 
+      },
       {
-       "id": "US_Indiana_Evansville", 
-       "s": 12858411, 
+       "id": "US_Indiana_Evansville",
+       "s": 12858411,
        "affiliations": [
-        "Indiana", 
-        "IN", 
+        "Indiana",
+        "IN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Indiana"
        ]
-      }, 
+      },
       {
-       "id": "US_Indiana_Indianapolis", 
-       "s": 18285587, 
+       "id": "US_Indiana_Indianapolis",
+       "s": 18285587,
        "affiliations": [
-        "Indiana", 
-        "IN", 
+        "Indiana",
+        "IN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Indiana"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Iowa", 
+     "id": "Iowa",
      "g": [
       {
-       "id": "US_Iowa_Des Moines", 
-       "s": 21724923, 
+       "id": "US_Iowa_Des Moines",
+       "s": 21724923,
        "affiliations": [
-        "Iowa", 
-        "IA", 
+        "Iowa",
+        "IA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Iowa"
        ]
-      }, 
+      },
       {
-       "id": "US_Iowa_Waterloo", 
-       "s": 18160533, 
+       "id": "US_Iowa_Waterloo",
+       "s": 18160533,
        "affiliations": [
-        "Iowa", 
-        "IA", 
+        "Iowa",
+        "IA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Iowa"
        ]
-      }, 
+      },
       {
-       "id": "US_Iowa_West", 
-       "s": 20161551, 
+       "id": "US_Iowa_West",
+       "s": 20161551,
        "affiliations": [
-        "Iowa", 
-        "IA", 
+        "Iowa",
+        "IA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Iowa"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Kansas", 
+     "id": "Kansas",
      "g": [
       {
-       "id": "US_Kansas_East", 
-       "s": 20291516, 
+       "id": "US_Kansas_East",
+       "s": 20291516,
        "affiliations": [
-        "Kansas", 
-        "KS", 
+        "Kansas",
+        "KS",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kansas"
        ]
-      }, 
+      },
       {
-       "id": "US_Kansas_West", 
-       "s": 9580490, 
+       "id": "US_Kansas_West",
+       "s": 9580490,
        "affiliations": [
-        "Kansas", 
-        "KS", 
+        "Kansas",
+        "KS",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kansas"
        ]
-      }, 
+      },
       {
-       "id": "US_Kansas_Wichita", 
-       "s": 13710122, 
+       "id": "US_Kansas_Wichita",
+       "s": 13710122,
        "affiliations": [
-        "Kansas", 
-        "KS", 
+        "Kansas",
+        "KS",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kansas"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Kentucky", 
+     "id": "Kentucky",
      "g": [
       {
-       "id": "US_Kentucky_East", 
-       "s": 30517329, 
+       "id": "US_Kentucky_East",
+       "s": 30517329,
        "affiliations": [
-        "Kentucky", 
-        "KY", 
+        "Kentucky",
+        "KY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kentucky"
        ]
-      }, 
+      },
       {
-       "id": "US_Kentucky_West", 
-       "s": 16977659, 
+       "id": "US_Kentucky_West",
+       "s": 16977659,
        "affiliations": [
-        "Kentucky", 
-        "KY", 
+        "Kentucky",
+        "KY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kentucky"
        ]
-      }, 
+      },
       {
-       "id": "US_Kentucky_Louisville", 
-       "s": 31367306, 
+       "id": "US_Kentucky_Louisville",
+       "s": 31367306,
        "affiliations": [
-        "Kentucky", 
-        "KY", 
+        "Kentucky",
+        "KY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Kentucky"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Louisiana", 
+     "id": "Louisiana",
      "g": [
       {
-       "id": "US_Louisiana_Central", 
-       "s": 28702377, 
+       "id": "US_Louisiana_Central",
+       "s": 28702377,
        "affiliations": [
-        "Louisiana", 
-        "LA", 
+        "Louisiana",
+        "LA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Louisiana"
        ]
-      }, 
+      },
       {
-       "id": "US_Louisiana_New Orleans", 
-       "s": 42251541, 
+       "id": "US_Louisiana_New Orleans",
+       "s": 42251541,
        "affiliations": [
-        "Louisiana", 
-        "LA", 
+        "Louisiana",
+        "LA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Louisiana"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Maine", 
-     "s": 31110419, 
+     "id": "US_Maine",
+     "s": 31110419,
      "affiliations": [
-      "Maine", 
-      "ME", 
+      "Maine",
+      "ME",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Maine"
      ]
-    }, 
+    },
     {
-     "id": "Maryland", 
+     "id": "Maryland",
      "g": [
       {
-       "id": "US_Maryland_Baltimore", 
-       "s": 65568407, 
+       "id": "US_Maryland_Baltimore",
+       "s": 65568407,
        "affiliations": [
-        "Maryland", 
-        "MD", 
+        "Maryland",
+        "MD",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Maryland"
        ]
-      }, 
+      },
       {
-       "id": "US_Maryland_and_DC", 
-       "s": 31599248, 
+       "id": "US_Maryland_and_DC",
+       "s": 31599248,
        "affiliations": [
-        "District of Columbia", 
-        "DC", 
-        "Maryland", 
-        "MD", 
+        "District of Columbia",
+        "DC",
+        "Maryland",
+        "MD",
         "United States of America"
-       ], 
+       ],
        "old": [
-        "USA_Maryland", 
+        "USA_Maryland",
         "USA_District of Columbia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Massachusetts", 
+     "id": "Massachusetts",
      "g": [
       {
-       "id": "US_Massachusetts_Boston", 
-       "s": 52168629, 
+       "id": "US_Massachusetts_Boston",
+       "s": 52168629,
        "affiliations": [
-        "Massachusetts", 
-        "MA", 
+        "Massachusetts",
+        "MA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Massachusetts"
        ]
-      }, 
+      },
       {
-       "id": "US_Massachusetts_Central", 
-       "s": 24717357, 
+       "id": "US_Massachusetts_Central",
+       "s": 24717357,
        "affiliations": [
-        "Massachusetts", 
-        "MA", 
+        "Massachusetts",
+        "MA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Massachusetts"
        ]
-      }, 
+      },
       {
-       "id": "US_Massachusetts_Plymouth", 
-       "s": 26913788, 
+       "id": "US_Massachusetts_Plymouth",
+       "s": 26913788,
        "affiliations": [
-        "Massachusetts", 
-        "MA", 
+        "Massachusetts",
+        "MA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Massachusetts"
        ]
-      }, 
+      },
       {
-       "id": "US_Massachusetts_Southeastern", 
-       "s": 13242461, 
+       "id": "US_Massachusetts_Southeastern",
+       "s": 13242461,
        "affiliations": [
-        "Massachusetts", 
-        "MA", 
+        "Massachusetts",
+        "MA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Massachusetts"
        ]
-      }, 
+      },
       {
-       "id": "US_Massachusetts_West", 
-       "s": 21399340, 
+       "id": "US_Massachusetts_West",
+       "s": 21399340,
        "affiliations": [
-        "Massachusetts", 
-        "MA", 
+        "Massachusetts",
+        "MA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Massachusetts"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Michigan", 
+     "id": "Michigan",
      "g": [
       {
-       "id": "US_Michigan_Detroit", 
-       "s": 23798615, 
+       "id": "US_Michigan_Detroit",
+       "s": 23798615,
        "affiliations": [
-        "Michigan", 
-        "MI", 
+        "Michigan",
+        "MI",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Michigan"
        ]
-      }, 
+      },
       {
-       "id": "US_Michigan_North", 
-       "s": 29588346, 
+       "id": "US_Michigan_North",
+       "s": 29588346,
        "affiliations": [
-        "Michigan", 
-        "MI", 
+        "Michigan",
+        "MI",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Michigan"
        ]
-      }, 
+      },
       {
-       "id": "US_Michigan_Grand Rapids", 
-       "s": 19822819, 
+       "id": "US_Michigan_Grand Rapids",
+       "s": 19822819,
        "affiliations": [
-        "Little Traverse Bay Band of Odawas Reservation", 
-        "Little Traverse Bay Bands Of Odawa Reservation", 
-        "Grand Traverse Reservation", 
-        "Little Traverse Bay Bands of Odawas Reservation", 
-        "Little Traverse Bay Band of Odawa Reservation", 
-        "Little Traverse Bay Band of Odawas", 
-        "Michigan", 
-        "MI", 
+        "Little Traverse Bay Band of Odawas Reservation",
+        "Little Traverse Bay Bands Of Odawa Reservation",
+        "Grand Traverse Reservation",
+        "Little Traverse Bay Bands of Odawas Reservation",
+        "Little Traverse Bay Band of Odawa Reservation",
+        "Little Traverse Bay Band of Odawas",
+        "Michigan",
+        "MI",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Michigan"
        ]
-      }, 
+      },
       {
-       "id": "US_Michigan_Lansing", 
-       "s": 21682041, 
+       "id": "US_Michigan_Lansing",
+       "s": 21682041,
        "affiliations": [
-        "Little Traverse Bay Band of Odawas Reservation", 
-        "Little Traverse Bay Bands of Odawas Reservation", 
-        "Michigan", 
-        "MI", 
+        "Little Traverse Bay Band of Odawas Reservation",
+        "Little Traverse Bay Bands of Odawas Reservation",
+        "Michigan",
+        "MI",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Michigan"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Minnesota", 
+     "id": "Minnesota",
      "g": [
       {
-       "id": "US_Minnesota_Rochester", 
-       "s": 26030554, 
+       "id": "US_Minnesota_Rochester",
+       "s": 26030554,
        "affiliations": [
-        "Minnesota", 
-        "MN", 
+        "Minnesota",
+        "MN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Minnesota"
        ]
-      }, 
+      },
       {
-       "id": "US_Minnesota_Minneapolis", 
-       "s": 23043517, 
+       "id": "US_Minnesota_Minneapolis",
+       "s": 23043517,
        "affiliations": [
-        "Minnesota", 
-        "MN", 
+        "Minnesota",
+        "MN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Minnesota"
        ]
-      }, 
+      },
       {
-       "id": "US_Minnesota_North", 
-       "s": 37051111, 
+       "id": "US_Minnesota_North",
+       "s": 37051111,
        "affiliations": [
-        "Minnesota", 
-        "MN", 
+        "Minnesota",
+        "MN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Minnesota"
        ]
-      }, 
+      },
       {
-       "id": "US_Minnesota_Saint Cloud", 
-       "s": 22811289, 
+       "id": "US_Minnesota_Saint Cloud",
+       "s": 22811289,
        "affiliations": [
-        "Minnesota", 
-        "MN", 
+        "Minnesota",
+        "MN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Minnesota"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Mississippi", 
+     "id": "US_Mississippi",
      "g": [
       {
-       "id": "US_Mississippi_Gulfport", 
-       "s": 17618098, 
+       "id": "US_Mississippi_Gulfport",
+       "s": 17618098,
        "affiliations": [
-        "Mississippi", 
-        "MS", 
+        "Mississippi",
+        "MS",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Mississippi"
        ]
-      }, 
+      },
       {
-       "id": "US_Mississippi_North", 
-       "s": 26431855, 
+       "id": "US_Mississippi_North",
+       "s": 26431855,
        "affiliations": [
-        "Mississippi", 
-        "MS", 
+        "Mississippi",
+        "MS",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Mississippi"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Missouri", 
+     "id": "Missouri",
      "g": [
       {
-       "id": "US_Missouri_East", 
-       "s": 8261859, 
+       "id": "US_Missouri_East",
+       "s": 8261859,
        "affiliations": [
-        "Missouri", 
-        "MO", 
+        "Missouri",
+        "MO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Missouri"
        ]
-      }, 
+      },
       {
-       "id": "US_Missouri_Springfield", 
-       "s": 18981379, 
+       "id": "US_Missouri_Springfield",
+       "s": 18981379,
        "affiliations": [
-        "Missouri", 
-        "MO", 
+        "Missouri",
+        "MO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Missouri"
        ]
-      }, 
+      },
       {
-       "id": "US_Missouri_Kansas", 
-       "s": 17515727, 
+       "id": "US_Missouri_Kansas",
+       "s": 17515727,
        "affiliations": [
-        "Missouri", 
-        "MO", 
+        "Missouri",
+        "MO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Missouri"
        ]
-      }, 
+      },
       {
-       "id": "US_Missouri_St Louis", 
-       "s": 21042279, 
+       "id": "US_Missouri_St Louis",
+       "s": 21042279,
        "affiliations": [
-        "Missouri", 
-        "MO", 
+        "Missouri",
+        "MO",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Missouri"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Montana", 
+     "id": "US_Montana",
      "g": [
       {
-       "id": "US_Montana_East", 
-       "s": 23349514, 
+       "id": "US_Montana_East",
+       "s": 23349514,
        "affiliations": [
-        "Montana", 
-        "MT", 
+        "Montana",
+        "MT",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Montana"
        ]
-      }, 
+      },
       {
-       "id": "US_Montana_West", 
-       "s": 23113600, 
+       "id": "US_Montana_West",
+       "s": 23113600,
        "affiliations": [
-        "Montana", 
-        "MT", 
+        "Montana",
+        "MT",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Montana"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Nebraska", 
+     "id": "US_Nebraska",
      "g": [
       {
-       "id": "US_Nebraska_East", 
-       "s": 18004990, 
+       "id": "US_Nebraska_East",
+       "s": 18004990,
        "affiliations": [
-        "Nebraska", 
-        "NE", 
+        "Nebraska",
+        "NE",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Nebraska"
        ]
-      }, 
+      },
       {
-       "id": "US_Nebraska_West", 
-       "s": 22065740, 
+       "id": "US_Nebraska_West",
+       "s": 22065740,
        "affiliations": [
-        "Nebraska", 
-        "NE", 
+        "Nebraska",
+        "NE",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Nebraska"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Nevada", 
-     "s": 28497441, 
+     "id": "US_Nevada",
+     "s": 28497441,
      "affiliations": [
-      "Nevada", 
-      "NV", 
+      "Nevada",
+      "NV",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Nevada"
      ]
-    }, 
+    },
     {
-     "id": "US_New Hampshire", 
-     "s": 25389919, 
+     "id": "US_New Hampshire",
+     "s": 25389919,
      "affiliations": [
-      "New Hampshire", 
-      "NH", 
+      "New Hampshire",
+      "NH",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_New Hampshire"
      ]
-    }, 
+    },
     {
-     "id": "New Jersey", 
+     "id": "New Jersey",
      "g": [
       {
-       "id": "US_New Jersey_North", 
-       "s": 24437562, 
+       "id": "US_New Jersey_North",
+       "s": 24437562,
        "affiliations": [
-        "New Jersey", 
-        "NJ", 
+        "New Jersey",
+        "NJ",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New Jersey"
        ]
-      }, 
+      },
       {
-       "id": "US_New Jersey_South", 
-       "s": 32016484, 
+       "id": "US_New Jersey_South",
+       "s": 32016484,
        "affiliations": [
-        "New Jersey", 
-        "NJ", 
+        "New Jersey",
+        "NJ",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New Jersey"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_New Mexico", 
+     "id": "US_New Mexico",
      "g": [
       {
-       "id": "US_New Mexico_Albuquerque", 
-       "s": 22899195, 
+       "id": "US_New Mexico_Albuquerque",
+       "s": 22899195,
        "affiliations": [
-        "New Mexico", 
-        "NM", 
+        "New Mexico",
+        "NM",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New Mexico"
        ]
-      }, 
+      },
       {
-       "id": "US_New Mexico_Roswell", 
-       "s": 22664755, 
+       "id": "US_New Mexico_Roswell",
+       "s": 22664755,
        "affiliations": [
-        "New Mexico", 
-        "NM", 
+        "New Mexico",
+        "NM",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New Mexico"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "New York", 
+     "id": "New York",
      "g": [
       {
-       "id": "US_New York_East", 
-       "s": 50389038, 
+       "id": "US_New York_East",
+       "s": 50389038,
        "affiliations": [
-        "Gardiners Island", 
-        "New York", 
-        "NY", 
+        "Gardiners Island",
+        "New York",
+        "NY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New York"
        ]
-      }, 
+      },
       {
-       "id": "US_New York_New York", 
-       "s": 70789647, 
+       "id": "US_New York_New York",
+       "s": 70789647,
        "affiliations": [
-        "Ellis Island (historical)", 
-        "Liberty Island", 
-        "New York", 
-        "NY", 
+        "Ellis Island (historical)",
+        "Liberty Island",
+        "New York",
+        "NY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New York"
        ]
-      }, 
+      },
       {
-       "id": "US_New York_North", 
-       "s": 27335707, 
+       "id": "US_New York_North",
+       "s": 27335707,
        "affiliations": [
-        "New York", 
-        "NY", 
+        "New York",
+        "NY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New York"
        ]
-      }, 
+      },
       {
-       "id": "US_New York_West", 
-       "s": 35497542, 
+       "id": "US_New York_West",
+       "s": 35497542,
        "affiliations": [
-        "New York", 
-        "NY", 
+        "New York",
+        "NY",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_New York"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "North Carolina", 
+     "id": "North Carolina",
      "g": [
       {
-       "id": "US_North Carolina_Wilson", 
-       "s": 23114418, 
+       "id": "US_North Carolina_Wilson",
+       "s": 23114418,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_North Carolina_Asheville", 
-       "s": 21022190, 
+       "id": "US_North Carolina_Asheville",
+       "s": 21022190,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_North Carolina_Charlotte", 
-       "s": 27138429, 
+       "id": "US_North Carolina_Charlotte",
+       "s": 27138429,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_North Carolina_Greensboro", 
-       "s": 22322673, 
+       "id": "US_North Carolina_Greensboro",
+       "s": 22322673,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_North Carolina_Raleigh", 
-       "s": 29806264, 
+       "id": "US_North Carolina_Raleigh",
+       "s": 29806264,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_North Carolina_Wilmington", 
-       "s": 20330192, 
+       "id": "US_North Carolina_Wilmington",
+       "s": 20330192,
        "affiliations": [
-        "North Carolina", 
-        "NC", 
+        "North Carolina",
+        "NC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Carolina"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "North Dakota", 
+     "id": "North Dakota",
      "g": [
       {
-       "id": "US_North Dakota_Bismarck", 
-       "s": 14305384, 
+       "id": "US_North Dakota_Bismarck",
+       "s": 14305384,
        "affiliations": [
-        "North Dakota", 
-        "ND", 
+        "North Dakota",
+        "ND",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Dakota"
        ]
-      }, 
+      },
       {
-       "id": "US_North Dakota_East", 
-       "s": 26007151, 
+       "id": "US_North Dakota_East",
+       "s": 26007151,
        "affiliations": [
-        "North Dakota", 
-        "ND", 
+        "North Dakota",
+        "ND",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Dakota"
        ]
-      }, 
+      },
       {
-       "id": "US_North Dakota_Minot", 
-       "s": 13551075, 
+       "id": "US_North Dakota_Minot",
+       "s": 13551075,
        "affiliations": [
-        "North Dakota", 
-        "ND", 
+        "North Dakota",
+        "ND",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_North Dakota"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Ohio", 
+     "id": "Ohio",
      "g": [
       {
-       "id": "US_Ohio_Cleveland", 
-       "s": 23256729, 
+       "id": "US_Ohio_Cleveland",
+       "s": 23256729,
        "affiliations": [
-        "Ohio", 
-        "OH", 
+        "Ohio",
+        "OH",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Ohio"
        ]
-      }, 
+      },
       {
-       "id": "US_Ohio_Cincinnati", 
-       "s": 21074035, 
+       "id": "US_Ohio_Cincinnati",
+       "s": 21074035,
        "affiliations": [
-        "Ohio", 
-        "OH", 
+        "Ohio",
+        "OH",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Ohio"
        ]
-      }, 
+      },
       {
-       "id": "US_Ohio_Columbus", 
-       "s": 16696124, 
+       "id": "US_Ohio_Columbus",
+       "s": 16696124,
        "affiliations": [
-        "Ohio", 
-        "OH", 
+        "Ohio",
+        "OH",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Ohio"
        ]
-      }, 
+      },
       {
-       "id": "US_Ohio_Toledo", 
-       "s": 13015482, 
+       "id": "US_Ohio_Toledo",
+       "s": 13015482,
        "affiliations": [
-        "Ohio", 
-        "OH", 
+        "Ohio",
+        "OH",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Ohio"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Oklahoma", 
+     "id": "Oklahoma",
      "g": [
       {
-       "id": "US_Oklahoma_East", 
-       "s": 14104200, 
+       "id": "US_Oklahoma_East",
+       "s": 14104200,
        "affiliations": [
-        "Oklahoma", 
-        "OK", 
+        "Oklahoma",
+        "OK",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oklahoma"
        ]
-      }, 
+      },
       {
-       "id": "US_Oklahoma_West", 
-       "s": 14594021, 
+       "id": "US_Oklahoma_West",
+       "s": 14594021,
        "affiliations": [
-        "Oklahoma", 
-        "OK", 
+        "Oklahoma",
+        "OK",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oklahoma"
        ]
-      }, 
+      },
       {
-       "id": "US_Oklahoma_Tulsa", 
-       "s": 24031994, 
+       "id": "US_Oklahoma_Tulsa",
+       "s": 24031994,
        "affiliations": [
-        "Oklahoma", 
-        "OK", 
+        "Oklahoma",
+        "OK",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oklahoma"
        ]
-      }, 
+      },
       {
-       "id": "US_Oklahoma_Oklahoma", 
-       "s": 19601671, 
+       "id": "US_Oklahoma_Oklahoma",
+       "s": 19601671,
        "affiliations": [
-        "Oklahoma", 
-        "OK", 
+        "Oklahoma",
+        "OK",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oklahoma"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Oregon", 
+     "id": "Oregon",
      "g": [
       {
-       "id": "US_Oregon_Eugene", 
-       "s": 21800045, 
+       "id": "US_Oregon_Eugene",
+       "s": 21800045,
        "affiliations": [
-        "Oregon", 
-        "OR", 
+        "Oregon",
+        "OR",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oregon"
        ]
-      }, 
+      },
       {
-       "id": "US_Oregon_Portland", 
-       "s": 64828442, 
+       "id": "US_Oregon_Portland",
+       "s": 64828442,
        "affiliations": [
-        "Oregon", 
-        "OR", 
+        "Oregon",
+        "OR",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oregon"
        ]
-      }, 
+      },
       {
-       "id": "US_Oregon_West", 
-       "s": 24472837, 
+       "id": "US_Oregon_West",
+       "s": 24472837,
        "affiliations": [
-        "Oregon", 
-        "OR", 
+        "Oregon",
+        "OR",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Oregon"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Pennsylvania", 
+     "id": "Pennsylvania",
      "g": [
       {
-       "id": "US_Pennsylvania_Central", 
-       "s": 30278955, 
+       "id": "US_Pennsylvania_Central",
+       "s": 30278955,
        "affiliations": [
-        "Pennsylvania", 
-        "PA", 
+        "Pennsylvania",
+        "PA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Pennsylvania"
        ]
-      }, 
+      },
       {
-       "id": "US_Pennsylvania_Pittsburgh", 
-       "s": 23525702, 
+       "id": "US_Pennsylvania_Pittsburgh",
+       "s": 23525702,
        "affiliations": [
-        "Pennsylvania", 
-        "PA", 
+        "Pennsylvania",
+        "PA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Pennsylvania"
        ]
-      }, 
+      },
       {
-       "id": "US_Pennsylvania_Reading", 
-       "s": 22043915, 
+       "id": "US_Pennsylvania_Reading",
+       "s": 22043915,
        "affiliations": [
-        "Pennsylvania", 
-        "PA", 
+        "Pennsylvania",
+        "PA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Pennsylvania"
        ]
-      }, 
+      },
       {
-       "id": "US_Pennsylvania_Scranton", 
-       "s": 26051079, 
+       "id": "US_Pennsylvania_Scranton",
+       "s": 26051079,
        "affiliations": [
-        "Pennsylvania", 
-        "PA", 
+        "Pennsylvania",
+        "PA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Pennsylvania"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Puerto Rico", 
-     "s": 22535030, 
+     "id": "US_Puerto Rico",
+     "s": 22535030,
      "affiliations": [
-      "Puerto Rico", 
-      "PR", 
-      "Rep\u00fablica Dominicana", 
+      "Puerto Rico",
+      "PR",
+      "Rep\u00fablica Dominicana",
       "United States of America"
-     ], 
+     ],
      "old": [
       "Puerto Rico"
      ]
-    }, 
+    },
     {
-     "id": "US_Rhode Island", 
-     "s": 6200199, 
+     "id": "US_Rhode Island",
+     "s": 6200199,
      "affiliations": [
-      "Patience Island", 
-      "Rhode Island", 
-      "RI", 
+      "Patience Island",
+      "Rhode Island",
+      "RI",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_Rhode Island"
      ]
-    }, 
+    },
     {
-     "id": "South Carolina", 
+     "id": "South Carolina",
      "g": [
       {
-       "id": "US_South Carolina_Charleston", 
-       "s": 18291968, 
+       "id": "US_South Carolina_Charleston",
+       "s": 18291968,
        "affiliations": [
-        "South Carolina", 
-        "SC", 
+        "South Carolina",
+        "SC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_South Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_South Carolina_Columbia", 
-       "s": 25835974, 
+       "id": "US_South Carolina_Columbia",
+       "s": 25835974,
        "affiliations": [
-        "South Carolina", 
-        "SC", 
+        "South Carolina",
+        "SC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_South Carolina"
        ]
-      }, 
+      },
       {
-       "id": "US_South Carolina_Florence", 
-       "s": 20575540, 
+       "id": "US_South Carolina_Florence",
+       "s": 20575540,
        "affiliations": [
-        "South Carolina", 
-        "SC", 
+        "South Carolina",
+        "SC",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_South Carolina"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_South Dakota", 
-     "s": 22167582, 
+     "id": "US_South Dakota",
+     "s": 22167582,
      "affiliations": [
-      "South Dakota", 
-      "SD", 
+      "South Dakota",
+      "SD",
       "United States of America"
-     ], 
+     ],
      "old": [
       "USA_South Dakota"
      ]
-    }, 
+    },
     {
-     "id": "Tennessee", 
+     "id": "Tennessee",
      "g": [
       {
-       "id": "US_Tennessee_East", 
-       "s": 34833060, 
+       "id": "US_Tennessee_East",
+       "s": 34833060,
        "affiliations": [
-        "Tennessee", 
-        "TN", 
+        "Tennessee",
+        "TN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Tennessee"
        ]
-      }, 
+      },
       {
-       "id": "US_Tennessee_West", 
-       "s": 22091449, 
+       "id": "US_Tennessee_West",
+       "s": 22091449,
        "affiliations": [
-        "Tennessee", 
-        "TN", 
+        "Tennessee",
+        "TN",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Tennessee"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Texas", 
+     "id": "Texas",
      "g": [
       {
-       "id": "US_Texas_Austin", 
-       "s": 44934989, 
+       "id": "US_Texas_Austin",
+       "s": 44934989,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Victoria", 
-       "s": 10312690, 
+       "id": "US_Texas_Victoria",
+       "s": 10312690,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Dallas", 
-       "s": 42194696, 
+       "id": "US_Texas_Dallas",
+       "s": 42194696,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Houston", 
-       "s": 29727831, 
+       "id": "US_Texas_Houston",
+       "s": 29727831,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Amarillo", 
-       "s": 10648583, 
+       "id": "US_Texas_Amarillo",
+       "s": 10648583,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Lubbock", 
-       "s": 11715553, 
+       "id": "US_Texas_Lubbock",
+       "s": 11715553,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_San Antonio", 
-       "s": 19091094, 
+       "id": "US_Texas_San Antonio",
+       "s": 19091094,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Southwest", 
-       "s": 15786669, 
+       "id": "US_Texas_Southwest",
+       "s": 15786669,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Tyler", 
-       "s": 20175942, 
+       "id": "US_Texas_Tyler",
+       "s": 20175942,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_Wako", 
-       "s": 16552691, 
+       "id": "US_Texas_Wako",
+       "s": 16552691,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
-      }, 
+      },
       {
-       "id": "US_Texas_West", 
-       "s": 19171257, 
+       "id": "US_Texas_West",
+       "s": 19171257,
        "affiliations": [
-        "Texas", 
-        "TX", 
+        "Texas",
+        "TX",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Texas"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_United States Minor Outlying Islands", 
-     "s": 496928, 
+     "id": "US_United States Minor Outlying Islands",
+     "s": 496928,
      "affiliations": [
-      "Navassa Island", 
+      "Navassa Island",
       "United States Minor Outlying Islands"
      ]
-    }, 
+    },
     {
-     "id": "US_Utah", 
+     "id": "US_Utah",
      "g": [
       {
-       "id": "US_Utah_South", 
-       "s": 17080821, 
+       "id": "US_Utah_South",
+       "s": 17080821,
        "affiliations": [
-        "United States of America", 
-        "Utah", 
+        "United States of America",
+        "Utah",
         "UT"
-       ], 
+       ],
        "old": [
         "USA_Utah"
        ]
-      }, 
+      },
       {
-       "id": "US_Utah_North", 
-       "s": 24013222, 
+       "id": "US_Utah_North",
+       "s": 24013222,
        "affiliations": [
-        "United States of America", 
-        "Utah", 
+        "United States of America",
+        "Utah",
         "UT"
-       ], 
+       ],
        "old": [
         "USA_Utah"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Vermont", 
-     "s": 13593631, 
+     "id": "US_Vermont",
+     "s": 13593631,
      "affiliations": [
-      "United States of America", 
-      "Vermont", 
+      "United States of America",
+      "Vermont",
       "VT"
-     ], 
+     ],
      "old": [
       "USA_Vermont"
      ]
-    }, 
+    },
     {
-     "id": "Virginia", 
+     "id": "Virginia",
      "g": [
       {
-       "id": "US_Virginia_Roanoke", 
-       "s": 28360857, 
+       "id": "US_Virginia_Roanoke",
+       "s": 28360857,
        "affiliations": [
-        "Virginia", 
-        "VA", 
+        "Virginia",
+        "VA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Virginia"
        ]
-      }, 
+      },
       {
-       "id": "US_Virginia_Norfolk", 
-       "s": 54694518, 
+       "id": "US_Virginia_Norfolk",
+       "s": 54694518,
        "affiliations": [
-        "Virginia", 
-        "VA", 
+        "Virginia",
+        "VA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Virginia"
        ]
-      }, 
+      },
       {
-       "id": "US_Virginia_Lynchburg", 
-       "s": 35413236, 
+       "id": "US_Virginia_Lynchburg",
+       "s": 35413236,
        "affiliations": [
-        "Virginia", 
-        "VA", 
+        "Virginia",
+        "VA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Virginia"
        ]
-      }, 
+      },
       {
-       "id": "US_Virginia_Richmond", 
-       "s": 16184461, 
+       "id": "US_Virginia_Richmond",
+       "s": 16184461,
        "affiliations": [
-        "Virginia", 
-        "VA", 
+        "Virginia",
+        "VA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Virginia"
        ]
-      }, 
+      },
       {
-       "id": "US_Virginia_Alexandria", 
-       "s": 25248374, 
+       "id": "US_Virginia_Alexandria",
+       "s": 25248374,
        "affiliations": [
-        "Virginia", 
-        "VA", 
+        "Virginia",
+        "VA",
         "United States of America"
-       ], 
+       ],
        "old": [
         "USA_Virginia"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "Washington", 
+     "id": "Washington",
      "g": [
       {
-       "id": "US_Washington_Coast", 
-       "s": 36285329, 
+       "id": "US_Washington_Coast",
+       "s": 36285329,
        "affiliations": [
-        "Puyallup Tribe", 
-        "Puyallup Tribe Reservation", 
-        "United States of America", 
-        "Washington", 
+        "Puyallup Tribe",
+        "Puyallup Tribe Reservation",
+        "United States of America",
+        "Washington",
         "WA"
-       ], 
+       ],
        "old": [
         "USA_Washington"
        ]
-      }, 
+      },
       {
-       "id": "US_Washington_Seattle", 
-       "s": 36892896, 
+       "id": "US_Washington_Seattle",
+       "s": 36892896,
        "affiliations": [
-        "United States of America", 
-        "Washington", 
+        "United States of America",
+        "Washington",
         "WA"
-       ], 
+       ],
        "old": [
         "USA_Washington"
        ]
-      }, 
+      },
       {
-       "id": "US_Washington_Yakima", 
-       "s": 24083072, 
+       "id": "US_Washington_Yakima",
+       "s": 24083072,
        "affiliations": [
-        "United States of America", 
-        "Washington", 
+        "United States of America",
+        "Washington",
         "WA"
-       ], 
+       ],
        "old": [
         "USA_Washington"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_West Virginia", 
-     "s": 23713468, 
+     "id": "US_West Virginia",
+     "s": 23713468,
      "affiliations": [
-      "United States of America", 
-      "West Virginia", 
+      "United States of America",
+      "West Virginia",
       "WV"
-     ], 
+     ],
      "old": [
       "USA_West Virginia"
      ]
-    }, 
+    },
     {
-     "id": "Wisconsin", 
+     "id": "Wisconsin",
      "g": [
       {
-       "id": "US_Wisconsin_Milwaukee", 
-       "s": 21277394, 
+       "id": "US_Wisconsin_Milwaukee",
+       "s": 21277394,
        "affiliations": [
-        "United States of America", 
-        "Wisconsin", 
+        "United States of America",
+        "Wisconsin",
         "WI"
-       ], 
+       ],
        "old": [
         "USA_Wisconsin"
        ]
-      }, 
+      },
       {
-       "id": "US_Wisconsin_North", 
-       "s": 22250727, 
+       "id": "US_Wisconsin_North",
+       "s": 22250727,
        "affiliations": [
-        "United States of America", 
-        "Wisconsin", 
+        "United States of America",
+        "Wisconsin",
         "WI"
-       ], 
+       ],
        "old": [
         "USA_Wisconsin"
        ]
-      }, 
+      },
       {
-       "id": "US_Wisconsin_Madison", 
-       "s": 19847396, 
+       "id": "US_Wisconsin_Madison",
+       "s": 19847396,
        "affiliations": [
-        "United States of America", 
-        "Wisconsin", 
+        "United States of America",
+        "Wisconsin",
         "WI"
-       ], 
+       ],
        "old": [
         "USA_Wisconsin"
        ]
-      }, 
+      },
       {
-       "id": "US_Wisconsin_Eau Claire", 
-       "s": 19545965, 
+       "id": "US_Wisconsin_Eau Claire",
+       "s": 19545965,
        "affiliations": [
-        "United States of America", 
-        "Wisconsin", 
+        "United States of America",
+        "Wisconsin",
         "WI"
-       ], 
+       ],
        "old": [
         "USA_Wisconsin"
        ]
       }
      ]
-    }, 
+    },
     {
-     "id": "US_Wyoming", 
-     "s": 30089504, 
+     "id": "US_Wyoming",
+     "s": 30089504,
      "affiliations": [
-      "United States of America", 
-      "Wyoming", 
+      "United States of America",
+      "Wyoming",
       "WY"
-     ], 
+     ],
      "old": [
       "USA_Wyoming"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Uruguay", 
-   "s": 19643657, 
+   "id": "Uruguay",
+   "s": 19643657,
    "affiliations": [
-    "Cerro Largo", 
-    "Artigas", 
-    "Canelones", 
-    "Colonia", 
-    "Durazno", 
-    "Flores", 
-    "Florida", 
-    "FL", 
-    "Lavalleja", 
-    "Maldonado", 
-    "Montevideo", 
-    "R\u00edo Negro", 
-    "Paysand\u00fa", 
-    "Rivera", 
-    "Rocha", 
-    "Salto", 
-    "San Jos\u00e9", 
-    "Soriano", 
-    "Tacuaremb\u00f3", 
-    "Treinta y Tres", 
+    "Cerro Largo",
+    "Artigas",
+    "Canelones",
+    "Colonia",
+    "Durazno",
+    "Flores",
+    "Florida",
+    "FL",
+    "Lavalleja",
+    "Maldonado",
+    "Montevideo",
+    "R\u00edo Negro",
+    "Paysand\u00fa",
+    "Rivera",
+    "Rocha",
+    "Salto",
+    "San Jos\u00e9",
+    "Soriano",
+    "Tacuaremb\u00f3",
+    "Treinta y Tres",
     "Uruguay"
-   ], 
+   ],
    "old": [
     "Uruguay"
    ]
-  }, 
+  },
   {
-   "id": "Uzbekistan", 
-   "s": 28280431, 
+   "id": "Uzbekistan",
+   "s": 28280431,
    "affiliations": [
-    "Andijon Viloyati", 
-    "Border Kyrgyzstan - Uzbekistan", 
-    "Buxoro Viloyati", 
-    "Farg'ona Viloyati", 
-    "Jizzax Viloyati", 
-    "Qaraqalpaqstan Respublikasi", 
-    "Namangan Viloyati", 
-    "Navoiy Viloyati", 
-    "O\u02bbzbekiston", 
-    "Qashqadaryo Viloyati", 
-    "Toshkent Viloyati", 
-    "Samarqand Viloyati", 
-    "Sirdaryo Viloyati", 
-    "Surxondaryo Viloyati", 
-    "Toshkent", 
+    "Andijon Viloyati",
+    "Border Kyrgyzstan - Uzbekistan",
+    "Buxoro Viloyati",
+    "Farg'ona Viloyati",
+    "Jizzax Viloyati",
+    "Qaraqalpaqstan Respublikasi",
+    "Namangan Viloyati",
+    "Navoiy Viloyati",
+    "O\u02bbzbekiston",
+    "Qashqadaryo Viloyati",
+    "Toshkent Viloyati",
+    "Samarqand Viloyati",
+    "Sirdaryo Viloyati",
+    "Surxondaryo Viloyati",
+    "Toshkent",
     "Xorazm Viloyati"
-   ], 
+   ],
    "old": [
     "Uzbekistan"
    ]
-  }, 
+  },
   {
-   "id": "Vanuatu", 
-   "s": 3576521, 
+   "id": "Vanuatu",
+   "s": 3576521,
    "affiliations": [
-    "Malampa", 
-    "Penama", 
-    "Sanma", 
-    "Shefa", 
-    "Tafea", 
-    "Vanuatu", 
+    "Malampa",
+    "Penama",
+    "Sanma",
+    "Shefa",
+    "Tafea",
+    "Vanuatu",
     "Torba"
-   ], 
+   ],
    "old": [
     "Vanuatu"
    ]
-  }, 
+  },
   {
-   "id": "Venezuela", 
+   "id": "Venezuela",
    "g": [
     {
-     "id": "Venezuela_North", 
-     "s": 15697501, 
+     "id": "Venezuela_North",
+     "s": 15697501,
      "affiliations": [
-      "Barinas", 
-      "Carabobo", 
-      "Cojedes", 
-      "Distrito Capital", 
-      "Dependencias Federales", 
-      "Estado Anzo\u00e1tegui", 
-      "Estado Aragua", 
-      "Estado Delta Amacuro", 
-      "Estado Gu\u00e1rico", 
-      "Estado Miranda", 
-      "Estado Monagas", 
-      "Estado Sucre", 
-      "Estado Vargas", 
-      "Falc\u00f3n", 
-      "Isla de Patos", 
-      "Lara", 
-      "Nueva Esparta", 
-      "Portuguesa", 
-      "Trujillo", 
-      "Venezuela", 
-      "Venezuela (territorial waters)", 
-      "Yaracuy", 
+      "Barinas",
+      "Carabobo",
+      "Cojedes",
+      "Distrito Capital",
+      "Dependencias Federales",
+      "Estado Anzo\u00e1tegui",
+      "Estado Aragua",
+      "Estado Delta Amacuro",
+      "Estado Gu\u00e1rico",
+      "Estado Miranda",
+      "Estado Monagas",
+      "Estado Sucre",
+      "Estado Vargas",
+      "Falc\u00f3n",
+      "Isla de Patos",
+      "Lara",
+      "Nueva Esparta",
+      "Portuguesa",
+      "Trujillo",
+      "Venezuela",
+      "Venezuela (territorial waters)",
+      "Yaracuy",
       "Zulia"
-     ], 
+     ],
      "old": [
       "Venezuela"
      ]
-    }, 
+    },
     {
-     "id": "Venezuela_South", 
-     "s": 14160447, 
+     "id": "Venezuela_South",
+     "s": 14160447,
      "affiliations": [
-      "Amazonas", 
-      "Apure", 
-      "Barinas", 
-      "Estado Bol\u00edvar", 
-      "Estado Delta Amacuro", 
-      "Estado Gu\u00e1rico", 
-      "M\u00e9rida", 
-      "Portuguesa", 
-      "Trujillo", 
-      "T\u00e1chira", 
-      "Venezuela", 
+      "Amazonas",
+      "Apure",
+      "Barinas",
+      "Estado Bol\u00edvar",
+      "Estado Delta Amacuro",
+      "Estado Gu\u00e1rico",
+      "M\u00e9rida",
+      "Portuguesa",
+      "Trujillo",
+      "T\u00e1chira",
+      "Venezuela",
       "Zulia"
-     ], 
+     ],
      "old": [
       "Venezuela"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "Vietnam", 
-   "s": 40277141, 
+   "id": "Vietnam",
+   "s": 40277141,
    "affiliations": [
-    "T\u1ec9nh H\u00e0 Nam", 
-    "T\u1ec9nh H\u00e0 T\u0129nh", 
-    "T\u1ec9nh H\u00f2a B\u00ecnh", 
-    "T\u1ec9nh H\u1ea3i D\u01b0\u01a1ng", 
-    "T\u1ec9nh H\u01b0ng Y\u00ean", 
-    "T\u1ec9nh H\u1eadu Giang", 
-    "T\u1ec9nh Kh\u00e1nh H\u00f2a", 
-    "T\u1ec9nh Kon Tum", 
-    "T\u1ec9nh Lai Ch\u00e2u", 
-    "T\u1ec9nh Long An", 
-    "T\u1ec9nh L\u00e0o Cai", 
-    "T\u1ec9nh L\u00e2m \u0110\u1ed3ng", 
-    "T\u1ec9nh L\u1ea1ng S\u01a1n", 
-    "T\u1ec9nh Nam \u0110\u1ecbnh", 
-    "T\u1ec9nh Ngh\u1ec7 An", 
-    "T\u1ec9nh Ninh B\u00ecnh", 
-    "T\u1ec9nh Ninh Thu\u1eadn", 
-    "T\u1ec9nh Ph\u00fa Th\u1ecd", 
-    "T\u1ec9nh Ph\u00fa Y\u00ean", 
-    "T\u1ec9nh Qu\u1ea3ng B\u00ecnh", 
-    "T\u1ec9nh Qu\u1ea3ng Nam", 
-    "T\u1ec9nh Qu\u1ea3ng Ng\u00e3i", 
-    "T\u1ec9nh Qu\u1ea3ng Tr\u1ecb", 
-    "T\u1ec9nh S\u01a1n La", 
-    "T\u1ec9nh Thanh H\u00f3a", 
-    "T\u1ec9nh Th\u00e1i B\u00ecnh", 
-    "T\u1ec9nh Th\u00e1i Nguy\u00ean", 
-    "T\u1ec9nh Th\u1eeba Thi\u00ean - Hu\u1ebf", 
-    "T\u1ec9nh Ti\u1ec1n Giang", 
-    "T\u1ec9nh Tr\u00e0 Vinh", 
-    "T\u1ec9nh Tuy\u00ean Quang", 
-    "T\u1ec9nh T\u00e2y Ninh", 
-    "T\u1ec9nh V\u0129nh Long", 
-    "T\u1ec9nh V\u0129nh Ph\u00fac", 
-    "T\u1ec9nh Y\u00ean B\u00e1i", 
-    "T\u1ec9nh \u0110i\u1ec7n Bi\u00ean", 
-    "T\u1ec9nh \u0110\u1eafk L\u1eafk", 
-    "T\u1ec9nh \u0110\u1eafk N\u00f4ng", 
-    "T\u1ec9nh \u0110\u1ed3ng Nai", 
-    "T\u1ec9nh \u0110\u1ed3ng Th\u00e1p", 
-    "B\u1ea1c Li\u00eau", 
-    "Cao B\u1eb1ng", 
-    "C\u00e0 Mau", 
-    "Ki\u00ean Giang", 
-    "Provinz T\u1ec9nh Qu\u1ea3ng Ninh", 
-    "S\u00f3c Tr\u0103ng", 
-    "Th\u00e0nh ph\u1ed1 C\u1ea7n Th\u01a1", 
-    "Th\u00e0nh ph\u1ed1 H\u00e0 N\u1ed9i", 
-    "Th\u00e0nh ph\u1ed1 H\u1ed3 Ch\u00ed Minh", 
-    "Th\u00e0nh ph\u1ed1 H\u1ea3i Ph\u00f2ng", 
-    "Th\u00e0nh ph\u1ed1 \u0110\u00e0 N\u1eb5ng", 
-    "T\u1ec9nh An Giang", 
-    "T\u1ec9nh B\u00e0 R\u1ecba \u2013 V\u0169ng T\u00e0u", 
-    "T\u1ec9nh B\u00ecnh D\u01b0\u01a1ng", 
-    "T\u1ec9nh B\u00ecnh Ph\u01b0\u1edbc", 
-    "T\u1ec9nh B\u00ecnh Thu\u1eadn", 
-    "T\u1ec9nh B\u00ecnh \u0110\u1ecbnh", 
-    "T\u1ec9nh B\u1eafc Giang", 
-    "T\u1ec9nh B\u1eafc K\u1ea1n", 
-    "T\u1ec9nh B\u1eafc Ninh", 
-    "T\u1ec9nh B\u1ebfn Tre", 
-    "T\u1ec9nh Gia Lai", 
-    "T\u1ec9nh H\u00e0 Giang", 
+    "T\u1ec9nh H\u00e0 Nam",
+    "T\u1ec9nh H\u00e0 T\u0129nh",
+    "T\u1ec9nh H\u00f2a B\u00ecnh",
+    "T\u1ec9nh H\u1ea3i D\u01b0\u01a1ng",
+    "T\u1ec9nh H\u01b0ng Y\u00ean",
+    "T\u1ec9nh H\u1eadu Giang",
+    "T\u1ec9nh Kh\u00e1nh H\u00f2a",
+    "T\u1ec9nh Kon Tum",
+    "T\u1ec9nh Lai Ch\u00e2u",
+    "T\u1ec9nh Long An",
+    "T\u1ec9nh L\u00e0o Cai",
+    "T\u1ec9nh L\u00e2m \u0110\u1ed3ng",
+    "T\u1ec9nh L\u1ea1ng S\u01a1n",
+    "T\u1ec9nh Nam \u0110\u1ecbnh",
+    "T\u1ec9nh Ngh\u1ec7 An",
+    "T\u1ec9nh Ninh B\u00ecnh",
+    "T\u1ec9nh Ninh Thu\u1eadn",
+    "T\u1ec9nh Ph\u00fa Th\u1ecd",
+    "T\u1ec9nh Ph\u00fa Y\u00ean",
+    "T\u1ec9nh Qu\u1ea3ng B\u00ecnh",
+    "T\u1ec9nh Qu\u1ea3ng Nam",
+    "T\u1ec9nh Qu\u1ea3ng Ng\u00e3i",
+    "T\u1ec9nh Qu\u1ea3ng Tr\u1ecb",
+    "T\u1ec9nh S\u01a1n La",
+    "T\u1ec9nh Thanh H\u00f3a",
+    "T\u1ec9nh Th\u00e1i B\u00ecnh",
+    "T\u1ec9nh Th\u00e1i Nguy\u00ean",
+    "T\u1ec9nh Th\u1eeba Thi\u00ean - Hu\u1ebf",
+    "T\u1ec9nh Ti\u1ec1n Giang",
+    "T\u1ec9nh Tr\u00e0 Vinh",
+    "T\u1ec9nh Tuy\u00ean Quang",
+    "T\u1ec9nh T\u00e2y Ninh",
+    "T\u1ec9nh V\u0129nh Long",
+    "T\u1ec9nh V\u0129nh Ph\u00fac",
+    "T\u1ec9nh Y\u00ean B\u00e1i",
+    "T\u1ec9nh \u0110i\u1ec7n Bi\u00ean",
+    "T\u1ec9nh \u0110\u1eafk L\u1eafk",
+    "T\u1ec9nh \u0110\u1eafk N\u00f4ng",
+    "T\u1ec9nh \u0110\u1ed3ng Nai",
+    "T\u1ec9nh \u0110\u1ed3ng Th\u00e1p",
+    "B\u1ea1c Li\u00eau",
+    "Cao B\u1eb1ng",
+    "C\u00e0 Mau",
+    "Ki\u00ean Giang",
+    "Provinz T\u1ec9nh Qu\u1ea3ng Ninh",
+    "S\u00f3c Tr\u0103ng",
+    "Th\u00e0nh ph\u1ed1 C\u1ea7n Th\u01a1",
+    "Th\u00e0nh ph\u1ed1 H\u00e0 N\u1ed9i",
+    "Th\u00e0nh ph\u1ed1 H\u1ed3 Ch\u00ed Minh",
+    "Th\u00e0nh ph\u1ed1 H\u1ea3i Ph\u00f2ng",
+    "Th\u00e0nh ph\u1ed1 \u0110\u00e0 N\u1eb5ng",
+    "T\u1ec9nh An Giang",
+    "T\u1ec9nh B\u00e0 R\u1ecba \u2013 V\u0169ng T\u00e0u",
+    "T\u1ec9nh B\u00ecnh D\u01b0\u01a1ng",
+    "T\u1ec9nh B\u00ecnh Ph\u01b0\u1edbc",
+    "T\u1ec9nh B\u00ecnh Thu\u1eadn",
+    "T\u1ec9nh B\u00ecnh \u0110\u1ecbnh",
+    "T\u1ec9nh B\u1eafc Giang",
+    "T\u1ec9nh B\u1eafc K\u1ea1n",
+    "T\u1ec9nh B\u1eafc Ninh",
+    "T\u1ec9nh B\u1ebfn Tre",
+    "T\u1ec9nh Gia Lai",
+    "T\u1ec9nh H\u00e0 Giang",
     "Vi\u1ec7t Nam"
-   ], 
+   ],
    "old": [
     "Vietnam"
    ]
-  }, 
+  },
   {
-   "id": "Yemen", 
-   "s": 15941092, 
+   "id": "Yemen",
+   "s": 15941092,
    "affiliations": [
-    "Abyan", 
-    "Ad Dali'", 
-    "Al Bay\u1e11\u0101\u2019", 
-    "Al Mahrah", 
-    "Al Jawf", 
-    "Al Ma\u1e29w\u012bt", 
-    "Al \u1e28udaydah", 
-    "Dhamar", 
-    "Ibb", 
-    "La\u1e29ij", 
-    "Ma'rib", 
-    "Raymah", 
-    "\u2018Adan", 
-    "Sa'dah", 
-    "San\u02bfa\u02be", 
-    "Shawah", 
-    "Socotra", 
-    "Ta\u2018izz", 
-    "\u2018Amr\u0101n", 
-    "\u1e28ajjah", 
-    "\u1e28a\u1e11ramawt", 
+    "Abyan",
+    "Ad Dali'",
+    "Al Bay\u1e11\u0101\u2019",
+    "Al Mahrah",
+    "Al Jawf",
+    "Al Ma\u1e29w\u012bt",
+    "Al \u1e28udaydah",
+    "Dhamar",
+    "Ibb",
+    "La\u1e29ij",
+    "Ma'rib",
+    "Raymah",
+    "\u2018Adan",
+    "Sa'dah",
+    "San\u02bfa\u02be",
+    "Shawah",
+    "Socotra",
+    "Ta\u2018izz",
+    "\u2018Amr\u0101n",
+    "\u1e28ajjah",
+    "\u1e28a\u1e11ramawt",
     "\u0627\u0644\u064a\u0645\u0646"
-   ], 
+   ],
    "old": [
     "Yemen"
    ]
-  }, 
+  },
   {
-   "id": "Zambia", 
-   "s": 34712476, 
+   "id": "Zambia",
+   "s": 34712476,
    "affiliations": [
-    "Central Province", 
-    "Copperbelt Province", 
-    "Eastern Province", 
-    "Luapula Province", 
-    "Lusaka Province", 
-    "Muchinga", 
-    "North-Western Province", 
-    "Northern Province", 
-    "Southern Province", 
-    "Western Province", 
+    "Central Province",
+    "Copperbelt Province",
+    "Eastern Province",
+    "Luapula Province",
+    "Lusaka Province",
+    "Muchinga",
+    "North-Western Province",
+    "Northern Province",
+    "Southern Province",
+    "Western Province",
     "Zambia"
-   ], 
+   ],
    "old": [
     "Zambia"
    ]
-  }, 
+  },
   {
-   "id": "Zimbabwe", 
-   "s": 83397221, 
+   "id": "Zimbabwe",
+   "s": 83397221,
    "affiliations": [
-    "Bulawayo Province", 
-    "Mashonaland Central", 
-    "Mashonaland East", 
-    "Mashonaland West", 
-    "Masvingo Province", 
-    "Matabeleland North", 
-    "Matabeleland South", 
-    "Harare Province", 
-    "Manicaland", 
-    "Midlands Province", 
+    "Bulawayo Province",
+    "Mashonaland Central",
+    "Mashonaland East",
+    "Mashonaland West",
+    "Masvingo Province",
+    "Matabeleland North",
+    "Matabeleland South",
+    "Harare Province",
+    "Manicaland",
+    "Midlands Province",
     "Zimbabwe"
-   ], 
+   ],
    "old": [
     "Zimbabwe"
    ]
-  }, 
+  },
   {
-   "id": "Antarctica", 
-   "s": 15344374, 
+   "id": "Antarctica",
+   "s": 15344374,
    "affiliations": [
     "South Georgia and South Sandwich Islands"
    ]
-  }, 
+  },
   {
-   "id": "New Zealand", 
+   "id": "New Zealand",
    "g": [
     {
-     "id": "Tokelau", 
-     "s": 81989, 
+     "id": "Tokelau",
+     "s": 81989,
      "affiliations": [
       "Tokelau"
-     ], 
+     ],
      "old": [
       "Tokelau"
      ]
-    }, 
+    },
     {
-     "id": "New Zealand North_Auckland", 
-     "s": 50501799, 
+     "id": "New Zealand North_Auckland",
+     "s": 50501799,
      "affiliations": [
-      "Auckland", 
-      "Bay of Plenty", 
-      "New Zealand/Aotearoa", 
-      "Northland", 
+      "Auckland",
+      "Bay of Plenty",
+      "New Zealand/Aotearoa",
+      "Northland",
       "Waikato"
-     ], 
+     ],
      "old": [
       "New Zealand"
      ]
-    }, 
+    },
     {
-     "id": "New Zealand North_Wellington", 
-     "s": 40384236, 
+     "id": "New Zealand North_Wellington",
+     "s": 40384236,
      "affiliations": [
-      "Gisborne", 
-      "Hawke's Bay", 
-      "Manawatu-Wanganui", 
-      "New Zealand/Aotearoa", 
-      "Taranaki", 
+      "Gisborne",
+      "Hawke's Bay",
+      "Manawatu-Wanganui",
+      "New Zealand/Aotearoa",
+      "Taranaki",
       "Wellington"
-     ], 
+     ],
      "old": [
       "New Zealand"
      ]
-    }, 
+    },
     {
-     "id": "New Zealand South_Canterbury", 
-     "s": 39642480, 
+     "id": "New Zealand South_Canterbury",
+     "s": 39642480,
      "affiliations": [
-      "Canterbury", 
-      "Chatham Islands", 
-      "Marlborough", 
-      "New Zealand/Aotearoa", 
-      "Nelson", 
-      "Tasman", 
+      "Canterbury",
+      "Chatham Islands",
+      "Marlborough",
+      "New Zealand/Aotearoa",
+      "Nelson",
+      "Tasman",
       "West Coast"
-     ], 
+     ],
      "old": [
       "New Zealand"
      ]
-    }, 
+    },
     {
-     "id": "New Zealand South_Southland", 
-     "s": 29462439, 
+     "id": "New Zealand South_Southland",
+     "s": 29462439,
      "affiliations": [
-      "New Zealand/Aotearoa", 
-      "Otago", 
-      "Southland", 
+      "New Zealand/Aotearoa",
+      "Otago",
+      "Southland",
       "West Coast"
-     ], 
+     ],
      "old": [
       "New Zealand"
      ]
     }
    ]
-  }, 
+  },
   {
-   "id": "South Korea", 
+   "id": "South Korea",
    "g": [
     {
-     "id": "South Korea_North", 
-     "s": 53754096, 
+     "id": "South Korea_North",
+     "s": 53754096,
      "affiliations": [
-      "\uac15\uc6d0\ub3c4", 
-      "\uacbd\uae30\ub3c4", 
-      "\ub300\uc804", 
-      "\uc11c\uc6b8", 
-      "\uc138\uc885", 
-      "\uc778\ucc9c", 
-      "\uacbd\uc0c1\ubd81\ub3c4", 
-      "\ub300\ud55c\ubbfc\uad6d", 
-      "\ucda9\uccad\ub0a8\ub3c4", 
+      "\uac15\uc6d0\ub3c4",
+      "\uacbd\uae30\ub3c4",
+      "\ub300\uc804",
+      "\uc11c\uc6b8",
+      "\uc138\uc885",
+      "\uc778\ucc9c",
+      "\uacbd\uc0c1\ubd81\ub3c4",
+      "\ub300\ud55c\ubbfc\uad6d",
+      "\ucda9\uccad\ub0a8\ub3c4",
       "\ucda9\uccad\ubd81\ub3c4"
-     ], 
+     ],
      "old": [
       "South Korea"
      ]
-    }, 
+    },
     {
-     "id": "South Korea_South", 
-     "s": 45874405, 
+     "id": "South Korea_South",
+     "s": 45874405,
      "affiliations": [
-      "\uc81c\uc8fc\ub3c4", 
-      "Gyeongnam-Busan Border", 
-      "\uad11\uc8fc", 
-      "\ub300\uad6c", 
-      "\ubd80\uc0b0", 
-      "\uc6b8\uc0b0", 
-      "\uacbd\uc0c1\ub0a8\ub3c4", 
-      "\uacbd\uc0c1\ubd81\ub3c4", 
-      "\ub300\ud55c\ubbfc\uad6d", 
-      "\uc804\ub77c\ub0a8\ub3c4", 
+      "\uc81c\uc8fc\ub3c4",
+      "Gyeongnam-Busan Border",
+      "\uad11\uc8fc",
+      "\ub300\uad6c",
+      "\ubd80\uc0b0",
+      "\uc6b8\uc0b0",
+      "\uacbd\uc0c1\ub0a8\ub3c4",
+      "\uacbd\uc0c1\ubd81\ub3c4",
+      "\ub300\ud55c\ubbfc\uad6d",
+      "\uc804\ub77c\ub0a8\ub3c4",
       "\uc804\ub77c\ubd81\ub3c4"
-     ], 
+     ],
      "old": [
       "South Korea"
      ]


### PR DESCRIPTION
Перезаписал секцию метаданных о регионе в украинских mwm, чтобы убрать из них русский язык как официальный. Теперь при включенной русской локали на телефоне в Украине будут выводиться украинские названия. Раньше не выводились, да.

Заодно по просьбе из #6104 перенёс Киото в соседний регион. Пул-реквест на соответствующее изменение файла иерархии сделаю завтра.

Дифф такой конский, потому что в реквесте #6263 забыл убрать пробелы с концов строк.