### PR TITLE
[shields] Deduplicate US State Highways shields

### DIFF
--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -79,6 +79,13 @@ public:
 
   RoadShieldType FindNetworkShield(std::string network) const
   {
+    // Special processing for US state highways, to not duplicate the table.
+    if (network.size() == 5 && strings::StartsWith(network, "US:"))
+    {
+      if (std::find(kStatesCode.begin(), kStatesCode.end(), network.substr(3)) != kStatesCode.end())
+        return RoadShieldType::Generic_White;
+    }
+
     // Minimum length for the network tag is 4 (US:I).
     if (network.size() > 4)
     {


### PR DESCRIPTION
Когда в теге `ref` дороги и в тегах `network` и `ref` на отношении трассы, которое содержит эту дорогу, одинаковые шилды, они схлопываются в один. Очевидно. Но иногда для семантически одинаковых значений генерируются разные виды шилдов.

Этот PR правит ситуацию в Штатах, когда `ref=US:CA 91` не равнялся значениям с отношения `network=US:CA` + `ref=91`. Теперь там и там будут одинаковые белые шилды.