### PR TITLE
[routing] GetNearestStation implementation.

### DIFF
--- a/routing/routing_tests/subway_test.cpp
+++ b/routing/routing_tests/subway_test.cpp
@@ -3,10 +3,12 @@
 #include "generator/generator_tests_support/test_feature.hpp"
 #include "generator/generator_tests_support/test_mwm_builder.hpp"
 
+#include "routing/subway_graph.hpp"
 #include "routing/subway_model.hpp"
 
 #include "indexer/classificator_loader.hpp"
 #include "indexer/data_header.hpp"
+#include "indexer/index.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -30,6 +32,7 @@ namespace
 using namespace generator::tests_support;
 using namespace platform;
 using namespace routing;
+using namespace std;
 
 // Directory name for creating test mwm and temporary files.
 std::string const kTestDir = "subway_test";
@@ -74,6 +77,16 @@ UNIT_TEST(SubwayGraphTest)
       {std::vector<m2::PointD>({{0.0, 0.001}, {0.001, 0.001}, {0.002, 0.001}}), SubwayType::Line, "555557"},
   };
   BuildMwm(ways, country);
+
+  Index index;
+  index.Register(country);
+
+  SubwayModelFactory factory;
+  shared_ptr<NumMwmIds> numMwmIds = make_shared<NumMwmIds>();
+  numMwmIds->RegisterFile(country.GetCountryFile());
+
+  SubwayGraph graph(factory.GetVehicleModel(), numMwmIds, index);
+  graph.GetNearestStation({0.0, 0.0});
   // @TODO It's necessary to test using SubwayGraph methods hears.
 }
 }  // namespace

--- a/routing/routing_tests/subway_test.cpp
+++ b/routing/routing_tests/subway_test.cpp
@@ -81,11 +81,11 @@ UNIT_TEST(SubwayGraphTest)
   Index index;
   index.Register(country);
 
-  SubwayModelFactory factory;
+  shared_ptr<SubwayModelFactory> factory = make_shared<SubwayModelFactory>();
   shared_ptr<NumMwmIds> numMwmIds = make_shared<NumMwmIds>();
   numMwmIds->RegisterFile(country.GetCountryFile());
 
-  SubwayGraph graph(factory.GetVehicleModel(), numMwmIds, index);
+  SubwayGraph graph(factory, numMwmIds, index);
   graph.GetNearestStation({0.0, 0.0});
   // @TODO It's necessary to test using SubwayGraph methods hears.
 }

--- a/routing/subway_graph.cpp
+++ b/routing/subway_graph.cpp
@@ -1,6 +1,18 @@
 #include "routing/subway_graph.hpp"
 
+#include "indexer/ftypes_matcher.hpp"
+#include "indexer/scales.hpp"
+
+#include "geometry/mercator.hpp"
+
 #include "base/macros.hpp"
+
+#include <limits>
+
+namespace
+{
+double constexpr kLineSearchRadiusMeters = 100.0;
+}  // namespace
 
 namespace routing
 {
@@ -21,7 +33,42 @@ double SubwayGraph::HeuristicCostEstimate(TVertexType const & from, TVertexType 
 
 SubwayVertex SubwayGraph::GetNearestStation(m2::PointD const & point) const
 {
-  NOTIMPLEMENTED();
-  return SubwayVertex();
+  SubwayVertex closestVertex;
+  double closestVertexDist = std::numeric_limits<double>::max();
+
+  auto const f = [&](FeatureType & ft)
+  {
+    if (!m_model->IsRoad(ft))
+      return;
+
+    if (!ftypes::IsSubwayLineChecker::Instance()(ft))
+      return;
+
+    double const speedKMPH = m_model->GetSpeed(ft);
+    if (speedKMPH <= 0.0)
+      return;
+
+    // @TODO It's necessary to cache the parsed geometry.
+    ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
+    size_t const pointsCount = ft.GetPointsCount();
+    for (size_t i = 0; i < pointsCount; ++i)
+    {
+      double const dist = MercatorBounds::DistanceOnEarth(point, ft.GetPoint(i));
+      if (dist < closestVertexDist)
+      {
+        closestVertexDist = dist;
+        closestVertex = SubwayVertex(
+            m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile()),
+            ft.GetID().m_index, static_cast<uint32_t >(i), SubwayType::Line);
+      }
+    }
+  };
+
+  m_index.ForEachInRect(
+    f, MercatorBounds::RectByCenterXYAndSizeInMeters(point, kLineSearchRadiusMeters),
+    scales::GetUpperScale());
+
+  ASSERT_NOT_EQUAL(closestVertexDist, std::numeric_limits<double>::max(), ());
+  return closestVertex;
 }
 }  // namespace routing

--- a/routing/subway_graph.cpp
+++ b/routing/subway_graph.cpp
@@ -34,17 +34,17 @@ double SubwayGraph::HeuristicCostEstimate(TVertexType const & from, TVertexType 
 SubwayVertex SubwayGraph::GetNearestStation(m2::PointD const & point) const
 {
   SubwayVertex closestVertex;
-  double closestVertexDist = std::numeric_limits<double>::max();
+  double closestVertexDistMeters = std::numeric_limits<double>::max();
 
-  auto const f = [&](FeatureType & ft)
+  auto const f = [&](FeatureType const & ft)
   {
-    if (!m_model->IsRoad(ft))
+    if (!m_modelFactory->GetVehicleModel()->IsRoad(ft))
       return;
 
     if (!ftypes::IsSubwayLineChecker::Instance()(ft))
       return;
 
-    double const speedKMPH = m_model->GetSpeed(ft);
+    double const speedKMPH = m_modelFactory->GetVehicleModel()->GetSpeed(ft);
     if (speedKMPH <= 0.0)
       return;
 
@@ -53,10 +53,10 @@ SubwayVertex SubwayGraph::GetNearestStation(m2::PointD const & point) const
     size_t const pointsCount = ft.GetPointsCount();
     for (size_t i = 0; i < pointsCount; ++i)
     {
-      double const dist = MercatorBounds::DistanceOnEarth(point, ft.GetPoint(i));
-      if (dist < closestVertexDist)
+      double const distMeters = MercatorBounds::DistanceOnEarth(point, ft.GetPoint(i));
+      if (distMeters < closestVertexDistMeters)
       {
-        closestVertexDist = dist;
+        closestVertexDistMeters = distMeters;
         closestVertex = SubwayVertex(
             m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile()),
             ft.GetID().m_index, static_cast<uint32_t >(i), SubwayType::Line);
@@ -68,7 +68,7 @@ SubwayVertex SubwayGraph::GetNearestStation(m2::PointD const & point) const
     f, MercatorBounds::RectByCenterXYAndSizeInMeters(point, kLineSearchRadiusMeters),
     scales::GetUpperScale());
 
-  ASSERT_NOT_EQUAL(closestVertexDist, std::numeric_limits<double>::max(), ());
+  CHECK_NOT_EQUAL(closestVertexDistMeters, std::numeric_limits<double>::max(), ());
   return closestVertex;
 }
 }  // namespace routing

--- a/routing/subway_graph.hpp
+++ b/routing/subway_graph.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include "routing/num_mwm_id.hpp"
 #include "routing/subway_edge.hpp"
+
 #include "routing/subway_vertex.hpp"
 
+#include "routing_common/vehicle_model.hpp"
+
+#include "indexer/index.hpp"
 #include "indexer/feature.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace routing
@@ -16,11 +22,22 @@ public:
   using TVertexType = SubwayVertex;
   using TEdgeType = SubwayEdge;
 
+  SubwayGraph(std::shared_ptr<IVehicleModel> model, std::shared_ptr<NumMwmIds> numMwmIds,
+              Index const & index)
+    : m_model(model), m_numMwmIds(numMwmIds), m_index(index)
+  {
+  }
+
   // Interface for AStarAlgorithm:
   void GetOutgoingEdgesList(TVertexType const & vertex, vector<TEdgeType> & edges);
   void GetIngoingEdgesList(TVertexType const & vertex, vector<TEdgeType> & edges);
   double HeuristicCostEstimate(TVertexType const & from, TVertexType const & to);
 
   SubwayVertex GetNearestStation(m2::PointD const & point) const;
+
+private:
+  std::shared_ptr<IVehicleModel> m_model;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
+  Index const & m_index;
 };
 }  // namespace routing

--- a/routing/subway_graph.hpp
+++ b/routing/subway_graph.hpp
@@ -11,6 +11,7 @@
 #include "indexer/feature.hpp"
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace routing
@@ -22,10 +23,12 @@ public:
   using TVertexType = SubwayVertex;
   using TEdgeType = SubwayEdge;
 
-  SubwayGraph(std::shared_ptr<IVehicleModel> model, std::shared_ptr<NumMwmIds> numMwmIds,
-              Index const & index)
-    : m_model(model), m_numMwmIds(numMwmIds), m_index(index)
+  SubwayGraph(std::shared_ptr<VehicleModelFactory> modelFactory,
+              std::shared_ptr<NumMwmIds> numMwmIds, Index const & index)
+    : m_modelFactory(std::move(modelFactory)), m_numMwmIds(std::move(numMwmIds)), m_index(index)
   {
+    CHECK(m_modelFactory, ());
+    CHECK(m_numMwmIds, ());
   }
 
   // Interface for AStarAlgorithm:
@@ -36,7 +39,7 @@ public:
   SubwayVertex GetNearestStation(m2::PointD const & point) const;
 
 private:
-  std::shared_ptr<IVehicleModel> m_model;
+  std::shared_ptr<VehicleModelFactory> m_modelFactory;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   Index const & m_index;
 };

--- a/routing/subway_router.cpp
+++ b/routing/subway_router.cpp
@@ -21,7 +21,9 @@ IRouter::ResultCode ConvertResult(typename AStarAlgorithm<SubwayGraph>::Result r
 namespace routing
 {
 SubwayRouter::SubwayRouter(std::shared_ptr<NumMwmIds> numMwmIds, Index & index)
-  : m_index(index), m_numMwmIds(std::move(numMwmIds))
+  : m_index(index)
+  , m_numMwmIds(std::move(numMwmIds))
+  , m_graph(m_modelFactory.GetVehicleModel(), m_numMwmIds, index)
 {
   CHECK(m_numMwmIds, ());
 }

--- a/routing/subway_router.cpp
+++ b/routing/subway_router.cpp
@@ -23,7 +23,8 @@ namespace routing
 SubwayRouter::SubwayRouter(std::shared_ptr<NumMwmIds> numMwmIds, Index & index)
   : m_index(index)
   , m_numMwmIds(std::move(numMwmIds))
-  , m_graph(m_modelFactory.GetVehicleModel(), m_numMwmIds, index)
+  , m_modelFactory(make_shared<SubwayModelFactory>())
+  , m_graph(m_modelFactory, m_numMwmIds, index)
 {
   CHECK(m_numMwmIds, ());
 }

--- a/routing/subway_router.hpp
+++ b/routing/subway_router.hpp
@@ -34,7 +34,7 @@ private:
 
   Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
-  SubwayModelFactory m_modelFactory;
+  std::shared_ptr<SubwayModelFactory> m_modelFactory;
   SubwayGraph m_graph;
 };
 }  // namespace routing


### PR DESCRIPTION
Это реализация GetNearestStation() по ней осталось:
1. сделать кэш, в котором для распаршенных фич хранить SubwayVertex-ы. Этот кэш будет переиспользован в  GetOutgoingEdgesList()
2. доработать тест SubwayGraphTest, чтоб проверять результаты GetNearestStation()
3. дописать еще несколько тестов на создание тестовых mwm-ок и последующий тест GetNearestStation()/GetOutgoingEdgesList() используя инфраструктуры теста SubwayGraphTest.

@dobriy-eeh PTAL