### PR TITLE
[routing] Preparing for segment generation at pedestrian mode.

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -1,9 +1,10 @@
 #include "routing/bicycle_directions.hpp"
-#include "routing/routing_helpers.hpp"
+
 #include "routing/num_mwm_id.hpp"
 #include "routing/road_point.hpp"
 #include "routing/router_delegate.hpp"
 #include "routing/routing_exceptions.hpp"
+#include "routing/routing_helpers.hpp"
 #include "routing/routing_result_graph.hpp"
 #include "routing/turns.hpp"
 #include "routing/turns_generator.hpp"
@@ -341,9 +342,7 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
       startSegId = inSegId;
 
     prevJunctions.push_back(prevJunction);
-    Segment segment;
-    EdgeToSegment(*m_numMwmIds, inEdge, segment);
-    prevSegments.push_back(segment);
+    prevSegments.push_back(ConvertEdgeToSegment(*m_numMwmIds, inEdge));
 
     if (!IsJoint(ingoingEdges, outgoingEdges, inEdge, routeEdges[i], isCurrJunctionFinish,
                  inFeatureId.IsValid()))

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -212,7 +212,7 @@ void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
                      segments);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());
   // In case of bicycle routing |m_pathSegments| may have an empty
-  // |LoadedPathSegment::m_trafficSegs| fields. In that case |segments| is empty
+  // |LoadedPathSegment::m_segments| fields. In that case |segments| is empty
   // so size of |segments| is not equal to size of |routeEdges|.
   if (!segments.empty())
     CHECK_EQUAL(segments.size(), routeEdges.size(), ());
@@ -367,15 +367,10 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
     pathSegment.m_path = std::move(prevJunctions);
     // @TODO(bykoianko) |pathSegment.m_weight| should be filled here.
 
-    // For LoadedPathSegment instances which contain fake feature id(s), |LoadedPathSegment::m_trafficSegs|
-    // should be empty because there's no traffic information for fake features.
-    // Traffic information is not supported for bicycle routes as well.
-    // Method BicycleDirectionsEngine::GetSegment() returns false for fake features and for bicycle routes.
-    // It leads to preventing pushing item to |prevSegments|. So if there's no enough items in |prevSegments|
-    // |pathSegment.m_trafficSegs| should be empty.
-    // Note. For the time being BicycleDirectionsEngine is used for turn generation for bicycle and car routes.
-    if (prevSegments.size() + 1 == prevJunctionSize)
-      pathSegment.m_trafficSegs = std::move(prevSegments);
+    // |prevSegments| contains segments which corresponds to road edges between joints. In case of a fake edge
+    // a fake segment is created.
+    CHECK_EQUAL(prevSegments.size() + 1, prevJunctionSize, ());
+    pathSegment.m_segments = std::move(prevSegments);
 
     auto const it = m_adjacentEdges.insert(make_pair(uniNodeId, std::move(adjacentEdges)));
     ASSERT(it.second, ());

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -47,8 +47,6 @@ private:
                                            IRoadGraph::TEdgeVector const & routeEdges,
                                            my::Cancellable const & cancellable);
 
-  Segment GetSegment(FeatureID const & featureId, uint32_t segId, bool forward) const;
-
   void GetEdges(RoadGraphBase const & graph, Junction const & currJunction,
                 bool isCurrJunctionFinish, IRoadGraph::TEdgeVector & outgoing,
                 IRoadGraph::TEdgeVector & ingoing);

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -31,7 +31,7 @@ struct LoadedPathSegment
   TEdgeWeight m_weight; /*!< Time in seconds to pass the segment. */
   UniNodeId m_nodeId;   /*!< May be either NodeID for OSRM route or
                              mwm id, feature id, segment id and direction for A*. */
-  vector<Segment> m_trafficSegs; /*!< Traffic segments for |m_path|. */
+  vector<Segment> m_segments; /*!< Traffic segments for |m_path|. */
   ftypes::HighwayClass m_highwayClass;
   bool m_onRoundabout;
   bool m_isLink;
@@ -44,7 +44,7 @@ struct LoadedPathSegment
     m_name.clear();
     m_weight = 0;
     m_nodeId.Clear();
-    m_trafficSegs.clear();
+    m_segments.clear();
     m_highwayClass = ftypes::HighwayClass::Undefined;
     m_onRoundabout = false;
     m_isLink = false;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -38,7 +38,7 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           my::Cancellable const & cancellable,
                                           Route::TTimes & times, Route::TTurns & turns,
                                           vector<Junction> & routeGeometry,
-                                          vector<Segment> & segments)
+                                          vector<Segment> & /* segments */)
 {
   times.clear();
   turns.clear();

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -38,7 +38,7 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           my::Cancellable const & cancellable,
                                           Route::TTimes & times, Route::TTurns & turns,
                                           vector<Junction> & routeGeometry,
-                                          vector<Segment> & /* segments */)
+                                          vector<Segment> & segments)
 {
   times.clear();
   turns.clear();

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -13,7 +13,7 @@ public:
   // IDirectionsEngine override:
   void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                 my::Cancellable const & cancellable, Route::TTimes & times, Route::TTurns & turns,
-                vector<Junction> & routeGeometry, vector<Segment> & /* segments */) override;
+                vector<Junction> & routeGeometry, vector<Segment> & segments) override;
 
 private:
   void CalculateTurns(RoadGraphBase const & graph, vector<Edge> const & routeEdges,

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -86,16 +86,14 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   route.SetTraffic(move(traffic));
 }
 
-void EdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge, Segment & segment)
+Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge)
 {
   if (edge.IsFake())
-  {
-    segment = Segment();
-    return;
-  }
+    return Segment();
+
 
   NumMwmId const numMwmId =
       numMwmIds.GetId(edge.GetFeatureId().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
-  segment = Segment(numMwmId, edge.GetFeatureId().m_index, edge.GetSegId(), edge.IsForward());
+  return Segment(numMwmId, edge.GetFeatureId().m_index, edge.GetSegId(), edge.IsForward());
 }
 }  // namespace rouing

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -85,4 +85,17 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
 
   route.SetTraffic(move(traffic));
 }
+
+void EdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge, Segment & segment)
+{
+  if (edge.IsFake())
+  {
+    segment = Segment();
+    return;
+  }
+
+  NumMwmId const numMwmId =
+      numMwmIds.GetId(edge.GetFeatureId().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
+  segment = Segment(numMwmId, edge.GetFeatureId().m_index, edge.GetSegId(), edge.IsForward());
+}
 }  // namespace rouing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -34,6 +34,10 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       my::Cancellable const & cancellable, bool hasAltitude,
                       vector<Junction> & path, Route & route);
 
+/// \brief Converts |edge| to |segment|.
+/// \returns false if mwm of |edge| is not alive.
+void EdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge, Segment & segment);
+
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,
 /// if graph ends before this number is reached then junction is assumed as not connected to the

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -36,7 +36,7 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
 
 /// \brief Converts |edge| to |segment|.
 /// \returns false if mwm of |edge| is not alive.
-void EdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge, Segment & segment);
+Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -258,7 +258,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        vector<Junction> & junctions,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets,
-                                       vector<Segment> & trafficSegs)
+                                       vector<Segment> & segments)
 {
   double estimatedTime = 0;
 
@@ -273,7 +273,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
   // Annotate turns.
   size_t skipTurnSegments = 0;
   auto const & loadedSegments = result.GetSegments();
-  trafficSegs.reserve(loadedSegments.size());
+  segments.reserve(loadedSegments.size());
   for (auto loadedSegmentIt = loadedSegments.cbegin(); loadedSegmentIt != loadedSegments.cend();
        ++loadedSegmentIt)
   {
@@ -336,8 +336,8 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                           ? loadedSegmentIt->m_path.cbegin()
                                           : loadedSegmentIt->m_path.cbegin() + 1,
                      loadedSegmentIt->m_path.cend());
-    trafficSegs.insert(trafficSegs.end(), loadedSegmentIt->m_trafficSegs.cbegin(),
-                       loadedSegmentIt->m_trafficSegs.cend());
+    segments.insert(segments.end(), loadedSegmentIt->m_trafficSegs.cbegin(),
+                    loadedSegmentIt->m_trafficSegs.cend());
   }
 
   // Path found. Points will be replaced by start and end edges junctions.

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -336,8 +336,8 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                           ? loadedSegmentIt->m_path.cbegin()
                                           : loadedSegmentIt->m_path.cbegin() + 1,
                      loadedSegmentIt->m_path.cend());
-    segments.insert(segments.end(), loadedSegmentIt->m_trafficSegs.cbegin(),
-                    loadedSegmentIt->m_trafficSegs.cend());
+    segments.insert(segments.end(), loadedSegmentIt->m_segments.cbegin(),
+                    loadedSegmentIt->m_segments.cend());
   }
 
   // Path found. Points will be replaced by start and end edges junctions.

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -51,7 +51,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        vector<Junction> & points,
                                        Route::TTurns & turnsDir, Route::TTimes & times,
                                        Route::TStreets & streets,
-                                       vector<Segment> & trafficSegs);
+                                       vector<Segment> & segments);
 
 /*!
  * \brief The TurnInfo struct is a representation of a junction.


### PR DESCRIPTION
Продолжение рефакторинга класса Routing + доработки по ревью https://github.com/mapsme/omim/pull/6371

Тема PR - подготовка к генерации сегментов при пешеходном роутинге.

@dobriy-eeh @ygorshenin @rokuz PTAL
