### PR TITLE
[routing integration tests] Warning fix.

### DIFF
--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -132,8 +132,8 @@ namespace integration
   public:
     OsrmRouterComponents(vector<LocalCountryFile> const & localFiles)
       : IRouterComponents(localFiles)
-      , m_indexRouter(move(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter,
-                                           m_trafficCache, localFiles)))
+      , m_indexRouter(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter, m_trafficCache,
+                                      localFiles))
     {
     }
 


### PR DESCRIPTION
/Users/vladimirbykoyanko/src_github/omim/routing/routing_integration_tests/routing_test_tools.cpp:135:23: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
      , m_indexRouter(move(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter,
                      ^
/Users/vladimirbykoyanko/src_github/omim/routing/routing_integration_tests/routing_test_tools.cpp:135:23: note: remove std::move call here
      , m_indexRouter(move(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter,

@dobriy-eeh @ygorshenin PTAL