### PR TITLE
[routing] Removing duplication of routing ETA calculation.

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -182,12 +182,6 @@ void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
     return;
   }
 
-  // @TODO(bykoianko) This method should be removed. Generally speaking it's wrong to calculate ETA
-  // based on max speed as it's done in CalculateTimes(). We'll get a better result and better code
-  // if to used ETA calculated in MakeTurnAnnotation(). To do that it's necessary to fill
-  // LoadedPathSegment::m_weight in FillPathSegmentsAndAdjacentEdgesMap().
-  CalculateTimes(graph, path, times);
-
   IRoadGraph::TEdgeVector routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -153,11 +153,10 @@ BicycleDirectionsEngine::BicycleDirectionsEngine(Index const & index, shared_ptr
 }
 
 void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junction> const & path,
-                                       my::Cancellable const & cancellable, Route::TTimes & times,
-                                       Route::TTurns & turns, Route::TStreets & streetNames,
+                                       my::Cancellable const & cancellable, Route::TTurns & turns,
+                                       Route::TStreets & streetNames,
                                        vector<Junction> & routeGeometry, vector<Segment> & segments)
 {
-  times.clear();
   turns.clear();
   streetNames.clear();
   routeGeometry.clear();
@@ -202,10 +201,8 @@ void BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
 
   RoutingResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
   RouterDelegate delegate;
-  Route::TTimes dummyTimes;
 
-  MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, dummyTimes, streetNames,
-                     segments);
+  MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, streetNames, segments);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());
   // In case of bicycle routing |m_pathSegments| may have an empty
   // |LoadedPathSegment::m_segments| fields. In that case |segments| is empty

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -28,10 +28,10 @@ public:
   BicycleDirectionsEngine(Index const & index, std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, std::vector<Junction> const & path,
-                my::Cancellable const & cancellable, Route::TTimes & times, Route::TTurns & turns,
-                Route::TStreets & streetNames, std::vector<Junction> & routeGeometry,
-                std::vector<Segment> & segments) override;
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+                my::Cancellable const & cancellable, Route::TTurns & turns,
+                Route::TStreets & streetNames, vector<Junction> & routeGeometry,
+                vector<Segment> & segments) override;
 
 private:
   Index::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -4,48 +4,8 @@
 
 #include "base/assert.hpp"
 
-namespace
-{
-double constexpr KMPH2MPS = 1000.0 / (60 * 60);
-}  // namespace
-
 namespace routing
 {
-void IDirectionsEngine::CalculateTimes(RoadGraphBase const & graph, vector<Junction> const & path,
-                                       Route::TTimes & times) const
-{
-  times.clear();
-  if (path.size() < 1)
-    return;
-
-  // graph.GetMaxSpeedKMPH() below is used on purpose.
-  // The idea is while pedestrian (bicycle) routing ways for pedestrians (cyclists) are preferred.
-  // At the same time routing along big roads is still possible but if there's
-  // a pedestrian (bicycle) alternative it's prefered. To implement it a small speed
-  // is set in pedestrian_model (bicycle_model) for big roads. On the other hand
-  // the most likely a pedestrian (a cyclist) will go along big roads with average
-  // speed (graph.GetMaxSpeedKMPH()).
-  double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
-
-  times.reserve(path.size());
-
-  double trackTimeSec = 0.0;
-  times.emplace_back(0, trackTimeSec);
-
-  m2::PointD prev = path[0].GetPoint();
-  for (size_t i = 1; i < path.size(); ++i)
-  {
-    m2::PointD const & curr = path[i].GetPoint();
-
-    double const lengthM = MercatorBounds::DistanceOnEarth(prev, curr);
-    trackTimeSec += lengthM / speedMPS;
-
-    times.emplace_back(i, trackTimeSec);
-
-    prev = curr;
-  }
-}
-
 bool IDirectionsEngine::ReconstructPath(RoadGraphBase const & graph, vector<Junction> const & path,
                                         vector<Edge> & routeEdges,
                                         my::Cancellable const & cancellable) const

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -29,8 +29,5 @@ protected:
   /// was cancelled and in case of extremely short paths of 0 or 1 point. Returns true otherwise.
   bool ReconstructPath(RoadGraphBase const & graph, std::vector<Junction> const & path,
                        std::vector<Edge> & routeEdges, my::Cancellable const & cancellable) const;
-
-  void CalculateTimes(RoadGraphBase const & graph, std::vector<Junction> const & path,
-                      Route::TTimes & times) const;
 };
 }  // namespace routing

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -18,10 +18,10 @@ class IDirectionsEngine
 public:
   virtual ~IDirectionsEngine() = default;
 
-  virtual void Generate(RoadGraphBase const & graph, std::vector<Junction> const & path,
-                        my::Cancellable const & cancellable, Route::TTimes & times,
-                        Route::TTurns & turns, Route::TStreets & streetNames,
-                        std::vector<Junction> & routeGeometry, std::vector<Segment> & segments) = 0;
+  virtual void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+                        my::Cancellable const & cancellable, Route::TTurns & turns,
+                        Route::TStreets & streetNames, vector<Junction> & routeGeometry,
+                        vector<Segment> & segments) = 0;
 
 protected:
   /// \brief constructs route based on |graph| and |path|. Fills |routeEdges| with the route.

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -32,8 +32,8 @@ void IndexRoadGraph::GetIngoingEdges(Junction const & junction, TEdgeVector & ed
 double IndexRoadGraph::GetMaxSpeedKMPH() const
 {
   // Value doesn't matter.
-  // It used in IDirectionsEngine::CalculateTimes only.
-  // But SingleMwmRouter::RedressRoute overwrites time values.
+  // It is used in CalculateMaxSpeedTimes only.
+  // Then SingleMwmRouter::RedressRoute overwrites time values.
   //
   // TODO: remove this stub after transfering Bicycle and Pedestrian to index routing.
   return 0.0;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -42,12 +42,11 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine(shared_ptr<NumMwmIds> num
 void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Junction> const & path,
                                           my::Cancellable const & cancellable,
-                                          Route::TTimes & times, Route::TTurns & turns,
+                                          Route::TTimes & /* times */, Route::TTurns & turns,
                                           Route::TStreets & streetNames,
                                           vector<Junction> & routeGeometry,
                                           vector<Segment> & segments)
 {
-  times.clear();
   turns.clear();
   streetNames.clear();
   routeGeometry.clear();
@@ -55,8 +54,6 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
 
   if (path.size() <= 1)
     return;
-
-  CalculateTimes(graph, path, times);
 
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -42,8 +42,7 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine(shared_ptr<NumMwmIds> num
 void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Junction> const & path,
                                           my::Cancellable const & cancellable,
-                                          Route::TTimes & /* times */, Route::TTurns & turns,
-                                          Route::TStreets & streetNames,
+                                          Route::TTurns & turns, Route::TStreets & streetNames,
                                           vector<Junction> & routeGeometry,
                                           vector<Segment> & segments)
 {

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -14,10 +14,10 @@ public:
   PedestrianDirectionsEngine(std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, std::vector<Junction> const & path,
-                my::Cancellable const & cancellable, Route::TTimes & times, Route::TTurns & turns,
-                Route::TStreets & streetNames, std::vector<Junction> & routeGeometry,
-                std::vector<Segment> & segments) override;
+  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+                my::Cancellable const & cancellable, Route::TTurns & turns,
+                Route::TStreets & streetNames, vector<Junction> & routeGeometry,
+                vector<Segment> & segments) override;
 
 private:
   void CalculateTurns(RoadGraphBase const & graph, std::vector<Edge> const & routeEdges,

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -203,9 +203,12 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
     ASSERT_EQUAL(result.path.back(), finalPos, ());
     ASSERT_GREATER(result.distance, 0., ());
 
+    Route::TTimes times;
+    CalculateMaxSpeedTimes(*m_roadGraph, result.path, times);
+
     CHECK(m_directionsEngine, ());
-    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr, delegate, true /* hasAltitude */,
-                     result.path, route);
+    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr, delegate, true, result.path,
+                     std::move(times), route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -207,8 +207,8 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(m2::PointD const & startPoin
     CalculateMaxSpeedTimes(*m_roadGraph, result.path, times);
 
     CHECK(m_directionsEngine, ());
-    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr, delegate, true, result.path,
-                     std::move(times), route);
+    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr /* trafficStash */, delegate,
+                     true /* hasAltitude */, result.path, std::move(times), route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -30,7 +30,7 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   }
 
   CHECK_EQUAL(path.size(), times.size(), ());
-  
+
   Route::TTurns turnsDir;
   vector<Junction> junctions;
   Route::TStreets streetNames;
@@ -98,7 +98,7 @@ void CalculateMaxSpeedTimes(RoadGraphBase const & graph, vector<Junction> const 
                             Route::TTimes & times)
 {
   times.clear();
-  if (path.size() < 1)
+  if (path.empty())
     return;
 
   // graph.GetMaxSpeedKMPH() below is used on purpose.
@@ -109,23 +109,21 @@ void CalculateMaxSpeedTimes(RoadGraphBase const & graph, vector<Junction> const 
   // the most likely a pedestrian (a cyclist) will go along big roads with average
   // speed (graph.GetMaxSpeedKMPH()).
   double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
+  CHECK_GREATER(speedMPS, 0.0, ());
 
   times.reserve(path.size());
 
   double trackTimeSec = 0.0;
   times.emplace_back(0, trackTimeSec);
 
-  m2::PointD prev = path[0].GetPoint();
   for (size_t i = 1; i < path.size(); ++i)
   {
-    m2::PointD const & curr = path[i].GetPoint();
-
-    double const lengthM = MercatorBounds::DistanceOnEarth(prev, curr);
+    double const lengthM =
+        MercatorBounds::DistanceOnEarth(path[i - 1].GetPoint(), path[i].GetPoint());
     trackTimeSec += lengthM / speedMPS;
 
     times.emplace_back(i, trackTimeSec);
-
-    prev = curr;
   }
+  CHECK_EQUAL(times.size(), path.size(), ());
 }
 }  // namespace routing

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -30,14 +30,13 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   }
 
   CHECK_EQUAL(path.size(), times.size(), ());
-
-  Route::TTimes dummyTimes;
+  
   Route::TTurns turnsDir;
   vector<Junction> junctions;
   Route::TStreets streetNames;
   vector<Segment> segments;
-  // @TODO It's necessary to remove |dummyTimes| from Generate() and MakeTurnAnnotation() methods..
-  engine.Generate(graph, path, cancellable, dummyTimes, turnsDir, streetNames, junctions, segments);
+
+  engine.Generate(graph, path, cancellable, turnsDir, streetNames, junctions, segments);
   CHECK_EQUAL(segments.size() + 1, junctions.size(), ());
 
   if (cancellable.IsCancelled())

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -32,11 +32,15 @@ bool IsRoad(TTypes const & types)
 void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       shared_ptr<TrafficStash> const & trafficStash,
                       my::Cancellable const & cancellable, bool hasAltitude,
-                      vector<Junction> & path, Route & route);
+                      vector<Junction> const & path, Route::TTimes && times, Route & route);
 
 /// \brief Converts |edge| to |segment|.
 /// \returns false if mwm of |edge| is not alive.
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
+
+/// \brief Fills |times| according to max speed at |graph| and |path|.
+void CalculateMaxSpeedTimes(RoadGraphBase const & graph, vector<Junction> const & path,
+                            Route::TTimes & times);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -259,7 +259,7 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
                                        Route::TStreets & streets, vector<Segment> & segments)
 {
   LOG(LDEBUG, ("Shortest th length:", result.GetPathLength()));
-  
+
   if (delegate.IsCancelled())
     return IRouter::Cancelled;
   // Annotate turns.

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -41,16 +41,13 @@ using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
  * \param delegate Routing callbacks delegate.
  * \param points Storage for unpacked points of the path.
  * \param turnsDir output turns annotation storage.
- * \param times output times annotation storage.
  * \param streets output street names along the path.
  * \param traffic road traffic information.
  * \return routing operation result code.
  */
 IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
-                                       RouterDelegate const & delegate,
-                                       vector<Junction> & points,
-                                       Route::TTurns & turnsDir, Route::TTimes & times,
-                                       Route::TStreets & streets,
+                                       RouterDelegate const & delegate, vector<Junction> & points,
+                                       Route::TTurns & turnsDir, Route::TStreets & streets,
                                        vector<Segment> & segments);
 
 /*!


### PR DESCRIPTION
Идея этого PR в том, чтоб удалить дубли в вычислении ETA, так же сделать еще одну важную вещь.

Чтоб в одной точке (ReconstructRoute()) установить классу Route вектор с SegmentInfo к моменту вызова ReconstructRoute() (или в нем) нужно посчитать ETA в сегменты маршрута (в дальнюю точку сегментов). 

В случае IndexGraph ETA считается с учетом пробок при помощи EdgeEstimator. В случае велосипедного и пешего при помощи особой CalculateMaxSpeedTimes(). (См. коммент в ней. Там поясняется зачем нужно брать максимальную скорость у графа.)

В результате рефакторинга ETA считается перед вызовом ReconstructRoute() двумя разными способами для IndexGraph и RoadGraph. Все остальные "dummy" расчеты удалены.

Следующей шаг - создание вектора из SegmentInfo и установка его для Route в ReconstructRoute().

@dobriy-eeh @ygorshenin PTAL