### PR TITLE
[android] Changed core logs tag

### DIFF
--- a/android/src/com/mapswithme/util/log/LoggerFactory.java
+++ b/android/src/com/mapswithme/util/log/LoggerFactory.java
@@ -43,7 +43,7 @@ public class LoggerFactory
   @NonNull
   @GuardedBy("this")
   private final EnumMap<Type, BaseLogger> mLoggers = new EnumMap<>(Type.class);
-  private final static String CORE_TAG = "Core";
+  private final static String CORE_TAG = "MapsmeCore";
   @Nullable
   @GuardedBy("this")
   private ExecutorService mFileLoggerExecutor;


### PR DESCRIPTION
Changed the logs tag from "Core" to "MapsmeCore" for messages coming from C++/JNI code to simplify the reading and filtering logs. Updated the wiki page https://github.com/mapsme/omim/wiki/%5BAndroid%5D-How-to-get-log-output 

@ygorshenin @milchakov PTAL