### PR TITLE
Fixed roads shield parsing in US

### DIFF
--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -87,7 +87,7 @@ public:
     }
 
     // Minimum length for the network tag is 4 (US:I).
-    if (network.size() > 4)
+    if (network.size() >= 4)
     {
       strings::AsciiToLower(network);
 
@@ -111,11 +111,17 @@ public:
     std::vector<std::string> shieldsRawTests = strings::Tokenize(m_baseRoadNumber, ";");
     for (std::string const & rawText : shieldsRawTests)
     {
+      RoadShield shield;
       auto slashPos = rawText.find('/');
-      RoadShield shield = slashPos == std::string::npos
-                              ? ParseRoadShield(rawText)
-                              : RoadShield{FindNetworkShield(rawText.substr(0, slashPos)),
-                                           rawText.substr(slashPos + 1)};
+      if (slashPos == std::string::npos)
+      {
+        shield = ParseRoadShield(rawText);
+      }
+      else
+      {
+        shield = ParseRoadShield(rawText.substr(slashPos + 1));
+        shield.m_type = FindNetworkShield(rawText.substr(0, slashPos));
+      }
       if (!shield.m_name.empty() && shield.m_type != RoadShieldType::Hidden)
         result.insert(std::move(shield));
     }


### PR DESCRIPTION
1. Исправлен баг, когда US:I не обрабатывалась в FindNetworkShield, так как было строгое неравенство;
2. Исправлен баг, когда, например, строка "I 710;US:I/I 710" генерировала интерстейт с текстом I 710, а не просто 710, что приводило к дублированию роад-шилда.