### PR TITLE
[metalines] Do not read metalines for the entire world

### DIFF
--- a/drape_frontend/read_metaline_task.cpp
+++ b/drape_frontend/read_metaline_task.cpp
@@ -104,6 +104,8 @@ void ReadMetalineTask::Do()
 {
   if (!m_mwmId.IsAlive())
     return;
+  if (m_mwmId.GetInfo()->GetType() != MwmInfo::MwmTypeT::COUNTRY)
+    return;
 
   auto metalines = ReadMetalinesFromFile(m_mwmId);
   for (auto const & metaline : metalines)


### PR DESCRIPTION
У мира нет osm2ft, поэтому металинии фейлились, и генератор выпадал с `LCRITICAL`.