### PR TITLE
[routing] Fix integration tests 

### DIFF
--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -16,6 +16,13 @@ bool IDirectionsEngine::ReconstructPath(RoadGraphBase const & graph, vector<Junc
 
   routeEdges.reserve(path.size() - 1);
 
+  if (graph.IsRouteEdgesImplemented())
+  {
+    graph.GetRouteEdges(routeEdges);
+    ASSERT_EQUAL(routeEdges.size() + 1, path.size(), ());
+    return true;
+  }
+
   Junction curr = path[0];
   vector<Edge> currEdges;
   for (size_t i = 1; i < path.size(); ++i)

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -14,14 +14,14 @@ bool IDirectionsEngine::ReconstructPath(RoadGraphBase const & graph, vector<Junc
   if (path.size() <= 1)
     return false;
 
-  routeEdges.reserve(path.size() - 1);
-
   if (graph.IsRouteEdgesImplemented())
   {
     graph.GetRouteEdges(routeEdges);
     ASSERT_EQUAL(routeEdges.size() + 1, path.size(), ());
     return true;
   }
+
+  routeEdges.reserve(path.size() - 1);
 
   Junction curr = path[0];
   vector<Edge> currEdges;

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -74,6 +74,7 @@ bool IndexRoadGraph::IsRouteEdgesImplemented() const
 void IndexRoadGraph::GetRouteEdges(TEdgeVector & edges) const
 {
   edges.clear();
+  edges.reserve(m_segments.size());
 
   for (Segment const & segment : m_segments)
   {

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -26,16 +26,20 @@ public:
   virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const override;
   virtual void GetJunctionTypes(Junction const & junction,
                                 feature::TypesHolder & types) const override;
+  virtual bool IsRouteEdgesImplemented() const override;
+  virtual void GetRouteEdges(TEdgeVector & edges) const override;
+
 
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;
+  m2::PointD GetJunctionPoint(Segment const & segment, bool front) const;
   Junction GetJunction(Segment const & segment, bool front) const;
-  Junction GetJunction(m2::PointD const & point) const;
   vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
 
   Index & m_index;
   shared_ptr<NumMwmIds> m_numMwmIds;
   IndexGraphStarter & m_starter;
+  vector<Segment> m_segments;
   map<Junction, vector<Segment>> m_beginToSegment;
   map<Junction, vector<Segment>> m_endToSegment;
 };

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -272,4 +272,14 @@ IRoadGraph::RoadInfo MakeRoadInfoForTesting(bool bidirectional, double speedKMPH
 
   return ri;
 }
+// RoadGraphBase ------------------------------------------------------------------
+bool RoadGraphBase::IsRouteEdgesImplemented() const
+{
+  return false;
+}
+
+void RoadGraphBase::GetRouteEdges(TEdgeVector & routeEdges) const
+{
+  NOTIMPLEMENTED()
+}
 }  // namespace routing

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -118,6 +118,10 @@ public:
 
   /// @return Types for specified junction
   virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
+
+  virtual bool IsRouteEdgesImplemented() const;
+
+  virtual void GetRouteEdges(TEdgeVector & routeEdges) const;
 };
 
 class IRoadGraph : public RoadGraphBase


### PR DESCRIPTION
История:
В https://github.com/mapsme/omim/pull/6420 ломался ReconstructRoute при попытке собрать routeEdges косвенным способом (см. цикл в IDirectionsEngine::ReconstructPath)
Проблема в том, что Junction как узел графа неоднозначен, и при самопересечении маршрутов (а при промежуточных точках такое часто происходит) всё плохо.

Была сделана попытка починить. ReconstructRoute ломаться перестал.

Однако изменения привели к тому, что сломалось два интеграционных теста:
RestrictionTestNearMetroShodnenskaya
SwedenBarlangeRoundaboutTurnTest

В этом PR:
* Откатил неудачную попытку починить из https://github.com/mapsme/omim/pull/6420
* Починил ReconstructRoute другим способом: чтобы routeEdges заполнялись напрямую из сегментов.