### PR TITLE
Taxi engine crash fix

### DIFF
--- a/partners_api/taxi_base.cpp
+++ b/partners_api/taxi_base.cpp
@@ -5,7 +5,10 @@ namespace taxi
 bool ApiItem::AreAllCountriesDisabled(storage::TCountriesVec const & countryIds,
                                       std::string const & city) const
 {
-  if (m_disabledCountries.IsEmpty() || countryIds.empty())
+  if (countryIds.empty())
+    return true;
+
+  if (m_disabledCountries.IsEmpty())
     return false;
 
   bool isCountryDisabled = true;
@@ -18,7 +21,10 @@ bool ApiItem::AreAllCountriesDisabled(storage::TCountriesVec const & countryIds,
 bool ApiItem::IsAnyCountryEnabled(storage::TCountriesVec const & countryIds,
                                   std::string const & city) const
 {
-  if (m_enabledCountries.IsEmpty() || countryIds.empty())
+  if (countryIds.empty())
+    return false;
+
+  if (m_enabledCountries.IsEmpty())
     return true;
 
   for (auto const & countryId : countryIds)

--- a/partners_api/taxi_engine.cpp
+++ b/partners_api/taxi_engine.cpp
@@ -3,6 +3,8 @@
 #include "partners_api/uber_api.hpp"
 #include "partners_api/yandex_api.hpp"
 
+#include "geometry/latlon.hpp"
+
 #include "base/macros.hpp"
 #include "base/stl_add.hpp"
 

--- a/partners_api/uber_api.hpp
+++ b/partners_api/uber_api.hpp
@@ -58,6 +58,7 @@ public:
   void Reset(uint64_t const requestId);
   void SetTimes(uint64_t const requestId, string const & times);
   void SetPrices(uint64_t const requestId, string const & prices);
+  void SetError(uint64_t const requestId, taxi::ErrorCode code);
   void MakeProducts(uint64_t const requestId, ProductsCallback const & successFn,
                     ErrorProviderCallback const & errorFn);
 
@@ -65,6 +66,7 @@ private:
   uint64_t m_requestId = 0;
   unique_ptr<string> m_times;
   unique_ptr<string> m_prices;
+  unique_ptr<taxi::ErrorCode> m_error;
   mutex m_mutex;
 };
 


### PR DESCRIPTION
 Пофиксил креш, который возникал в случае, когда сетевые запросы к уберу были неудачными. Убер для каждого неудачного внутреннего запроса вызывал коллбэк с ошибкой, из-за этого, в TaxiEngine, счетчик, который декрементится на каждый ответ от таксишных апи, уходил в значение меньше нуля и срабатывал CHECK.

Еще пофиксил потенциальную проблему с определением доступности сервисов такси - пустой список стран считался всегда доступным. Сделал чтоб наоборот считался недоступным.