### PR TITLE
Substitute steady_clock for system_clock in local ads

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -591,7 +591,7 @@ void Framework::LogLocalAdsEvent(local_ads::EventType type, double lat, double l
     return;
 
   local_ads::Event event(type, mwmInfo->GetVersion(), mwmInfo->GetCountryName(), featureID.m_index,
-                         m_work.GetDrawScale(), std::chrono::steady_clock::now(), lat, lon, accuracy);
+                         m_work.GetDrawScale(), local_ads::Clock::now(), lat, lon, accuracy);
   m_work.GetLocalAdsManager().GetStatistics().RegisterEvent(std::move(event));
 }
 }  // namespace android

--- a/drape_frontend/overlays_tracker.cpp
+++ b/drape_frontend/overlays_tracker.cpp
@@ -42,7 +42,7 @@ void OverlaysTracker::Track(FeatureID const & fid)
   {
     it->second.m_status = OverlayStatus::Visible;
     m_events.emplace_back(it->first, static_cast<uint8_t>(m_zoomLevel),
-                          std::chrono::steady_clock::now(), m_hasMyPosition,
+                          EventClock::now(), m_hasMyPosition,
                           m_myPosition, m_gpsAccuracy);
   }
 }
@@ -56,7 +56,7 @@ void OverlaysTracker::FinishTracking()
     if (p.second.m_status == OverlayStatus::Visible && !p.second.m_tracked)
     {
       p.second.m_status = OverlayStatus::InvisibleCandidate;
-      p.second.m_timestamp = std::chrono::steady_clock::now();
+      p.second.m_timestamp = EventClock::now();
     }
     else if (p.second.m_status == OverlayStatus::InvisibleCandidate)
     {
@@ -64,7 +64,7 @@ void OverlaysTracker::FinishTracking()
       static auto const kDelay = std::chrono::milliseconds(500);
       if (p.second.m_tracked)
         p.second.m_status = OverlayStatus::Visible;
-      else if (std::chrono::steady_clock::now() - p.second.m_timestamp > kDelay)
+      else if (EventClock::now() - p.second.m_timestamp > kDelay)
         p.second.m_status = OverlayStatus::Invisible;
     }
   }

--- a/drape_frontend/overlays_tracker.hpp
+++ b/drape_frontend/overlays_tracker.hpp
@@ -10,17 +10,20 @@
 
 namespace df
 {
+using EventClock = std::chrono::system_clock;
+using EventTimestamp = EventClock::time_point;
+
 struct OverlayShowEvent
 {
   FeatureID m_feature;
   uint8_t m_zoomLevel;
-  std::chrono::steady_clock::time_point m_timestamp;
+  EventTimestamp m_timestamp;
   bool m_hasMyPosition;
   m2::PointD m_myPosition;
   double m_gpsAccuracy;
   OverlayShowEvent(FeatureID const & feature, uint8_t zoomLevel,
-                   std::chrono::steady_clock::time_point const & timestamp,
-                   bool hasMyPosition, m2::PointD const & myPosition, double gpsAccuracy)
+                   EventTimestamp const & timestamp, bool hasMyPosition,
+                   m2::PointD const & myPosition, double gpsAccuracy)
     : m_feature(feature)
     , m_zoomLevel(zoomLevel)
     , m_timestamp(timestamp)
@@ -60,7 +63,7 @@ private:
 
   struct OverlayInfo
   {
-    std::chrono::steady_clock::time_point m_timestamp;
+    EventTimestamp m_timestamp;
     OverlayStatus m_status = OverlayStatus::Invisible;
     bool m_tracked = false;
   };
@@ -72,5 +75,4 @@ private:
   m2::PointD m_myPosition = m2::PointD::Zero();
   double m_gpsAccuracy = 0.0;
 };
-
 }  // namespace df

--- a/iphone/Maps/UI/PlacePage/MWMPlacePageData.mm
+++ b/iphone/Maps/UI/PlacePage/MWMPlacePageData.mm
@@ -597,7 +597,7 @@ using namespace place_page;
   auto location = [MWMLocationManager lastLocation];
   auto event = local_ads::Event(type, mwmInfo->GetVersion(), mwmInfo->GetCountryName(),
                                 featureID.m_index, f.GetDrawScale(),
-                                std::chrono::steady_clock::now(), location.coordinate.latitude,
+                                local_ads::Clock::now(), location.coordinate.latitude,
                                 location.coordinate.longitude, location.horizontalAccuracy);
   f.GetLocalAdsManager().GetStatistics().RegisterEvent(std::move(event));
 }

--- a/local_ads/event.hpp
+++ b/local_ads/event.hpp
@@ -5,7 +5,8 @@
 
 namespace local_ads
 {
-using Timestamp = std::chrono::steady_clock::time_point;
+using Clock = std::chrono::system_clock;
+using Timestamp = Clock::time_point;
 
 enum class EventType
 {

--- a/local_ads/local_ads_tests/file_helpers_tests.cpp
+++ b/local_ads/local_ads_tests/file_helpers_tests.cpp
@@ -33,15 +33,15 @@ UNIT_TEST(LocalAdsHelpers_Read_Write_Timestamp)
 {
   platform::tests_support::ScopedFile testFile("la_tests.dat");
 
-  auto ts = chrono::steady_clock::now();
+  auto ts = local_ads::Clock::now();
   {
     FileWriter writer(testFile.GetFullPath());
     WriteTimestamp<chrono::hours>(writer, ts);
     WriteTimestamp<chrono::seconds>(writer, ts);
   }
 
-  chrono::steady_clock::time_point resultInHours;
-  chrono::steady_clock::time_point resultInSeconds;
+  local_ads::Timestamp resultInHours;
+  local_ads::Timestamp resultInSeconds;
   {
     FileReader reader(testFile.GetFullPath());
     ReaderSource<FileReader> src(reader);

--- a/local_ads/statistics.cpp
+++ b/local_ads/statistics.cpp
@@ -201,7 +201,7 @@ bool Statistics::RequestEvents(std::list<Event> & events, bool & needToSend)
 
   using namespace std::chrono;
   needToSend = m_isFirstSending || isTimeout ||
-    (steady_clock::now() > (m_lastSending + kSendingTimeout));
+    (std::chrono::steady_clock::now() > (m_lastSending + kSendingTimeout));
 
   events = std::move(m_events);
   m_events.clear();

--- a/local_ads/statistics.hpp
+++ b/local_ads/statistics.hpp
@@ -79,7 +79,7 @@ private:
     }
   };
   std::map<MetadataKey, Metadata> m_metadataCache;
-  Timestamp m_lastSending;
+  std::chrono::steady_clock::time_point m_lastSending;
   bool m_isFirstSending = true;
 
   std::string m_userId;

--- a/map/local_ads_manager.cpp
+++ b/map/local_ads_manager.cpp
@@ -68,11 +68,6 @@ std::string GetPath(std::string const & fileName)
   return my::JoinFoldersToPath(GetPlatform().WritableDir(), fileName);
 }
 
-std::chrono::steady_clock::time_point Now()
-{
-  return std::chrono::steady_clock::now();
-}
-
 std::string MakeCampaignDownloadingURL(MwmSet::MwmId const & mwmId)
 {
   if (kServerUrl.empty() || !mwmId.IsAlive())
@@ -97,7 +92,7 @@ df::CustomSymbols ParseCampaign(std::vector<uint8_t> const & rawData, MwmSet::Mw
   {
     std::string const iconName = campaign.GetIconName();
     auto const expiration = timestamp + std::chrono::hours(24 * campaign.m_daysBeforeExpired);
-    if (iconName.empty() || Now() > expiration)
+    if (iconName.empty() || local_ads::Clock::now() > expiration)
       continue;
     symbols.insert(std::make_pair(FeatureID(mwmId, campaign.m_featureId),
                                   df::CustomSymbol(iconName, campaign.m_priorityBit)));
@@ -269,8 +264,8 @@ void LocalAdsManager::UpdateViewport(ScreenBase const & screen)
       auto const failedDownloadsIt = m_failedDownloads.find(mwm);
       if (failedDownloadsIt != m_failedDownloads.cend() &&
           (failedDownloadsIt->second.m_attemptsCount >= kMaxDownloadingAttempts ||
-           Now() <= failedDownloadsIt->second.m_lastDownloading +
-                        failedDownloadsIt->second.m_currentTimeout))
+           std::chrono::steady_clock::now() <= failedDownloadsIt->second.m_lastDownloading +
+                                               failedDownloadsIt->second.m_currentTimeout))
       {
         continue;
       }
@@ -289,7 +284,7 @@ void LocalAdsManager::UpdateViewport(ScreenBase const & screen)
         auto const it = m_info.find(mwmName);
         bool needUpdateByTimeout = (connectionStatus == Platform::EConnectionType::CONNECTION_WIFI);
         if (!needUpdateByTimeout && it != m_info.end())
-          needUpdateByTimeout = Now() > (it->second.m_created + kWWanUpdateTimeout);
+          needUpdateByTimeout = local_ads::Clock::now() > (it->second.m_created + kWWanUpdateTimeout);
 
         if (needUpdateByTimeout || it == m_info.end())
           requestedCampaigns.push_back(mwmName);
@@ -333,8 +328,9 @@ bool LocalAdsManager::DownloadCampaign(MwmSet::MwmId const & mwmId, std::vector<
     auto const it = m_failedDownloads.find(mwmId);
     if (it == m_failedDownloads.cend())
     {
-      m_failedDownloads.insert(std::make_pair(
-          mwmId, BackoffStats(Now(), kFailedDownloadingTimeout, 1 /* m_attemptsCount */)));
+      m_failedDownloads.insert(std::make_pair(mwmId, BackoffStats(std::chrono::steady_clock::now(),
+                                                                  kFailedDownloadingTimeout,
+                                                                  1 /* m_attemptsCount */)));
     }
     else
     {
@@ -395,7 +391,7 @@ void LocalAdsManager::ThreadRoutine()
         {
           DeleteSymbolsFromRendering(mwm.first);
         }
-        info.m_created = Now();
+        info.m_created = local_ads::Clock::now();
 
         // Update run-time data.
         {

--- a/map/local_ads_manager.hpp
+++ b/map/local_ads_manager.hpp
@@ -110,14 +110,15 @@ private:
   struct BackoffStats
   {
     BackoffStats() = default;
-    BackoffStats(Timestamp lastDownloading, std::chrono::seconds currentTimeout,
+    BackoffStats(std::chrono::steady_clock::time_point lastDownloading,
+                 std::chrono::seconds currentTimeout,
                  uint8_t attemptsCount)
       : m_lastDownloading(lastDownloading)
       , m_currentTimeout(currentTimeout)
       , m_attemptsCount(attemptsCount)
     {}
 
-    Timestamp m_lastDownloading = {};
+    std::chrono::steady_clock::time_point m_lastDownloading = {};
     std::chrono::seconds m_currentTimeout = std::chrono::seconds(0);
     uint8_t m_attemptsCount = 0;
   };


### PR DESCRIPTION
steady_clock::now при вызове time_since_epoch не возвращает правильное число заданных единиц

int64_t const d = std::chrono::duration_cast<std::chrono::seconds>(std::steady_clock::now().time_since_epoch()).count();
Результат: 63259

int64_t const d = std::chrono::duration_cast<std::chrono::seconds>(std::system_clock::now().time_since_epoch()).count();
Результат: 1499425462

Замечание: графический движок и библиотека local_ads имеет собственные using для Timestamp и Clock, чтобы ни один не зависел от другого.