### PR TITLE
[routing] Crash fix while turn generation cancellation

### DIFF
--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -298,7 +298,8 @@ void AsyncRouter::CalculateRoute()
 
   try
   {
-    LOG(LINFO, ("Calculating the route,", checkpoints, "startDirection", startDirection));
+    LOG(LINFO, ("Calculating the route. checkpoints:", checkpoints, "startDirection:",
+                startDirection, "router name:", router->GetName()));
 
     if (absentFetcher)
       absentFetcher->GenerateRequest(checkpoints);

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -157,27 +157,21 @@ bool BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
                                        Route::TStreets & streetNames,
                                        vector<Junction> & routeGeometry, vector<Segment> & segments)
 {
-  CHECK(!path.empty(), ());
+  size_t const pathSize = path.size();
+  // Note. According to Route::IsValid() method route of zero or one point is invalid.
+  if (pathSize < 1)
+    return false;
 
-  turns.clear();
-  streetNames.clear();
-  routeGeometry.clear();
   m_adjacentEdges.clear();
   m_pathSegments.clear();
-  segments.clear();
-
-  size_t const pathSize = path.size();
-
-  if (pathSize == 1)
-    return false;
 
   IRoadGraph::TEdgeVector routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LINFO, ("Couldn't reconstruct path."));
+    LOG(LWARNING, ("Couldn't reconstruct path."));
     return false;
   }
-  
+
   if (routeEdges.empty())
     return false;
 
@@ -191,6 +185,11 @@ bool BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
 
   RoutingResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
   RouterDelegate delegate;
+
+  turns.clear();
+  streetNames.clear();
+  routeGeometry.clear();
+  segments.clear();
 
   MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, streetNames, segments);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -157,18 +157,22 @@ bool BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
                                        Route::TStreets & streetNames,
                                        vector<Junction> & routeGeometry, vector<Segment> & segments)
 {
+  m_adjacentEdges.clear();
+  m_pathSegments.clear();
+  turns.clear();
+  streetNames.clear();
+  routeGeometry.clear();
+  segments.clear();
+  
   size_t const pathSize = path.size();
   // Note. According to Route::IsValid() method route of zero or one point is invalid.
   if (pathSize < 1)
     return false;
 
-  m_adjacentEdges.clear();
-  m_pathSegments.clear();
-
   IRoadGraph::TEdgeVector routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LWARNING, ("Couldn't reconstruct path."));
+    LOG(LWARNING, ("Can't reconstruct path."));
     return false;
   }
 
@@ -185,11 +189,6 @@ bool BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
 
   RoutingResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
   RouterDelegate delegate;
-
-  turns.clear();
-  streetNames.clear();
-  routeGeometry.clear();
-  segments.clear();
 
   MakeTurnAnnotation(resultGraph, delegate, routeGeometry, turns, streetNames, segments);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -167,31 +167,22 @@ bool BicycleDirectionsEngine::Generate(RoadGraphBase const & graph, vector<Junct
   segments.clear();
 
   size_t const pathSize = path.size();
-  auto emptyPathWorkaround = [&]()
-  {
-    turns.emplace_back(pathSize - 1, turns::TurnDirection::ReachedYourDestination);
-    // There's one ingoing edge to the finish.
-    this->m_adjacentEdges[UniNodeId(UniNodeId::Type::Mwm)] = AdjacentEdges(1);
-  };
 
   if (pathSize == 1)
-  {
-    emptyPathWorkaround();
     return false;
-  }
 
   IRoadGraph::TEdgeVector routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LDEBUG, ("Couldn't reconstruct path."));
-    emptyPathWorkaround();
+    LOG(LINFO, ("Couldn't reconstruct path."));
     return false;
   }
+  
   if (routeEdges.empty())
-  {
-    emptyPathWorkaround();
     return false;
-  }
+
+  if (cancellable.IsCancelled())
+    return false;
 
   FillPathSegmentsAndAdjacentEdgesMap(graph, path, routeEdges, cancellable);
 

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -28,7 +28,7 @@ public:
   BicycleDirectionsEngine(Index const & index, std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+  bool Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                 my::Cancellable const & cancellable, Route::TTurns & turns,
                 Route::TStreets & streetNames, vector<Junction> & routeGeometry,
                 vector<Segment> & segments) override;

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -23,8 +23,8 @@ public:
   // vector<RouteSegment> instead of corresponding arguments.
   /// \brief Generates all args which are passed by reference.
   /// \param path is points of the route. It should not be empty.
-  /// \note If |routeGeometry| is empty after a call fo the method it shows an error.
-  virtual void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+  /// \returns true if fields passed by reference are filled correctly and falsed otherwise.
+  virtual bool Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                         my::Cancellable const & cancellable, Route::TTurns & turns,
                         Route::TStreets & streetNames, vector<Junction> & routeGeometry,
                         vector<Segment> & segments) = 0;

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -21,6 +21,9 @@ public:
   // @TODO(bykoianko) When fields |m_turns|, |m_times|, |m_streets| and |m_traffic|
   // are removed from class Route the method Generate() should fill
   // vector<RouteSegment> instead of corresponding arguments.
+  /// \brief Generates all args which are passed by reference.
+  /// \param path is points of the route. It should not be empty.
+  /// \note If |routeGeometry| is empty after a call fo the method it shows an error.
   virtual void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                         my::Cancellable const & cancellable, Route::TTurns & turns,
                         Route::TStreets & streetNames, vector<Junction> & routeGeometry,

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -23,7 +23,7 @@ public:
   // vector<RouteSegment> instead of corresponding arguments.
   /// \brief Generates all args which are passed by reference.
   /// \param path is points of the route. It should not be empty.
-  /// \returns true if fields passed by reference are filled correctly and falsed otherwise.
+  /// \returns true if fields passed by reference are filled correctly and false otherwise.
   virtual bool Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                         my::Cancellable const & cancellable, Route::TTurns & turns,
                         Route::TStreets & streetNames, vector<Junction> & routeGeometry,

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -48,8 +48,9 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
 {
   turns.clear();
   streetNames.clear();
-  routeGeometry.clear();
   segments.clear();
+
+  routeGeometry = path;
 
   if (path.size() <= 1)
     return;
@@ -58,6 +59,7 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
     LOG(LDEBUG, ("Couldn't reconstruct path."));
+    routeGeometry.clear();
     // use only "arrival" direction
     turns.emplace_back(path.size() - 1, turns::PedestrianDirection::ReachedYourDestination);
     return;
@@ -69,7 +71,7 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
   for (Edge const & e : routeEdges)
     segments.push_back(ConvertEdgeToSegment(*m_numMwmIds, e));
   
-  routeGeometry = path;
+  
 }
 
 void PedestrianDirectionsEngine::CalculateTurns(RoadGraphBase const & graph,

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -39,30 +39,28 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine(shared_ptr<NumMwmIds> num
 {
 }
 
-void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
+bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Junction> const & path,
                                           my::Cancellable const & cancellable,
                                           Route::TTurns & turns, Route::TStreets & streetNames,
                                           vector<Junction> & routeGeometry,
                                           vector<Segment> & segments)
 {
+  CHECK(!path.empty(), ());
+  
   turns.clear();
   streetNames.clear();
   segments.clear();
 
   routeGeometry = path;
 
-  if (path.size() <= 1)
-    return;
-
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
     LOG(LDEBUG, ("Couldn't reconstruct path."));
-    routeGeometry.clear();
     // use only "arrival" direction
     turns.emplace_back(path.size() - 1, turns::PedestrianDirection::ReachedYourDestination);
-    return;
+    return false;
   }
 
   CalculateTurns(graph, routeEdges, turns, cancellable);
@@ -71,7 +69,7 @@ void PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
   for (Edge const & e : routeEdges)
     segments.push_back(ConvertEdgeToSegment(*m_numMwmIds, e));
   
-  
+  return true;
 }
 
 void PedestrianDirectionsEngine::CalculateTurns(RoadGraphBase const & graph,

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -47,7 +47,7 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Segment> & segments)
 {
   CHECK(!path.empty(), ());
-  
+
   turns.clear();
   streetNames.clear();
   segments.clear();
@@ -57,9 +57,7 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LDEBUG, ("Couldn't reconstruct path."));
-    // use only "arrival" direction
-    turns.emplace_back(path.size() - 1, turns::PedestrianDirection::ReachedYourDestination);
+    LOG(LINFO, ("Couldn't reconstruct path."));
     return false;
   }
 

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -46,20 +46,19 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Junction> & routeGeometry,
                                           vector<Segment> & segments)
 {
+  turns.clear();
+  streetNames.clear();
+  segments.clear();
+  routeGeometry = path;
+
   // Note. According to Route::IsValid() method route of zero or one point is invalid.
   if (path.size() < 1)
     return false;
 
-  turns.clear();
-  streetNames.clear();
-  segments.clear();
-
-  routeGeometry = path;
-
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LWARNING, ("Couldn't reconstruct path."));
+    LOG(LWARNING, ("Can't reconstruct path."));
     return false;
   }
 

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -46,7 +46,9 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
                                           vector<Junction> & routeGeometry,
                                           vector<Segment> & segments)
 {
-  CHECK(!path.empty(), ());
+  // Note. According to Route::IsValid() method route of zero or one point is invalid.
+  if (path.size() < 1)
+    return false;
 
   turns.clear();
   streetNames.clear();
@@ -57,7 +59,7 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
   vector<Edge> routeEdges;
   if (!ReconstructPath(graph, path, routeEdges, cancellable))
   {
-    LOG(LINFO, ("Couldn't reconstruct path."));
+    LOG(LWARNING, ("Couldn't reconstruct path."));
     return false;
   }
 

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -14,7 +14,7 @@ public:
   PedestrianDirectionsEngine(std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  void Generate(RoadGraphBase const & graph, vector<Junction> const & path,
+  bool Generate(RoadGraphBase const & graph, vector<Junction> const & path,
                 my::Cancellable const & cancellable, Route::TTurns & turns,
                 Route::TStreets & streetNames, vector<Junction> & routeGeometry,
                 vector<Segment> & segments) override;

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -117,9 +117,6 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   vector<Segment> segments;
 
   engine.Generate(graph, path, cancellable, turnsDir, streetNames, junctions, segments);
-  CHECK_EQUAL(path.size(), junctions.size(), ());
-
-
   if (cancellable.IsCancelled())
     return;
 
@@ -129,6 +126,9 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
     LOG(LERROR, ("Internal error happened while turn generation."));
     return;
   }
+
+  CHECK_EQUAL(path.size(), junctions.size(),
+              ("Size of path:", path.size(), "size of junctions:", junctions.size()));
 
   vector<RouteSegment> segmentInfo;
   FillSegmentInfo(segments, junctions, turnsDir, streetNames, times, trafficStash, segmentInfo);

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -116,7 +116,9 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   Route::TStreets streetNames;
   vector<Segment> segments;
 
-  engine.Generate(graph, path, cancellable, turnsDir, streetNames, junctions, segments);
+  if (!engine.Generate(graph, path, cancellable, turnsDir, streetNames, junctions, segments))
+    return;
+
   if (cancellable.IsCancelled())
     return;
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-4914

Если во время генерации тернов нажать на отмену прокладки маршрута наше приложение падало. Причина была в том, что CHECK на корректность результатов генерации стоял перед проверкой, что генерация была отменена. Данный PR исправляет это.

Кроме того, данный PR добавляет в метод IDirectionsEngine::Generate() возвращаемый результат, который явно сообщает о том, сгенерированны ли терны.

Кроме того, выкинут некоторый теперь не нужный код (emptyPathWorkaround)

@rokuz @ygorshenin PTAL