### PR TITLE
[shields] Remove duplicate shields of default style

### DIFF
--- a/generator/osm_translator.hpp
+++ b/generator/osm_translator.hpp
@@ -168,7 +168,8 @@ protected:
         if (!ref.empty())
         {
           std::string const & network = e.GetTagValue("network");
-          if (!network.empty() && network.find('/') == std::string::npos)
+          // Not processing networks with more than 15 chars (see road_shields_parser.cpp).
+          if (!network.empty() && network.find('/') == std::string::npos && network.size() < 15)
             ref = network + '/' + ref;
           std::string const & refBase = m_current->GetTag("ref");
           if (!refBase.empty())

--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -108,6 +108,7 @@ public:
   std::set<RoadShield> GetRoadShields() const
   {
     std::set<RoadShield> result;
+    std::set<RoadShield> defaultShields;
     std::vector<std::string> shieldsRawTests = strings::Tokenize(m_baseRoadNumber, ";");
     for (std::string const & rawText : shieldsRawTests)
     {
@@ -123,8 +124,17 @@ public:
         shield.m_type = FindNetworkShield(rawText.substr(0, slashPos));
       }
       if (!shield.m_name.empty() && shield.m_type != RoadShieldType::Hidden)
+      {
+        if (shield.m_type != RoadShieldType::Default)
+        {
+          // Schedule deletion of a shield with the same text and default style, if present.
+          defaultShields.insert({RoadShieldType::Default, shield.m_name, shield.m_additionalText});
+        }
         result.insert(std::move(shield));
+      }
     }
+    for (RoadShield const & shield : defaultShields)
+      result.erase(shield);
     return result;
   }
 


### PR DESCRIPTION
Игорь тут тестировал стиль на Болгарии, и мне резанули глаз дублирующиеся шилды разных цветов. Проблема была в том, что сначала мы из `ref` брали номер и в отсутствие правил для Болгарии красили номер в цвет по умолчанию. А затем получали номер из отношения, где правило уже было, и поэтому мы красили его в синий. Что получается, можете посмотреть на релизной сборке в Болгарии.

Здесь я удаляю шилд с цветом по умолчанию, если из отношения пришёл он же, но раскрашенный. Фикс надеюсь впихнуть в багфикс после релиза. Пока не мёржите.

Осталась проблема с Латвией, которую нужно решить либо правкой кода, либо правкой Латвии. [Жду ответа](https://lists.openstreetmap.org/pipermail/talk-lv/2017-July/005989.html) от латышских мапперов.