### PR TITLE
[routing] Route class refactoring. Segment based Route.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -41,7 +41,6 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static com.mapswithme.util.statistics.Statistics.EventName.ROUTING_BOOKMARKS_CLICK;
-import static com.mapswithme.util.statistics.Statistics.EventName.ROUTING_SEARCH_CLICK;
 
 public class NavigationController implements TrafficManager.TrafficCallback, View.OnClickListener
 {
@@ -204,15 +203,15 @@ public class NavigationController implements TrafficManager.TrafficCallback, Vie
                                                     R.dimen.text_size_nav_dimension,
                                                     info.distToTurn,
                                                     info.turnUnits));
-    info.vehicleTurnDirection.setTurnDrawable(mNextTurnImage);
-    if (RoutingInfo.VehicleTurnDirection.isRoundAbout(info.vehicleTurnDirection))
+    info.carDirection.setTurnDrawable(mNextTurnImage);
+    if (RoutingInfo.CarDirection.isRoundAbout(info.carDirection))
       UiUtils.setTextAndShow(mCircleExit, String.valueOf(info.exitNum));
     else
       UiUtils.hide(mCircleExit);
 
-    UiUtils.showIf(info.vehicleNextTurnDirection.containsNextTurn(), mNextNextTurnFrame);
-    if (info.vehicleNextTurnDirection.containsNextTurn())
-      info.vehicleNextTurnDirection.setNextTurnDrawable(mNextNextTurnImage);
+    UiUtils.showIf(info.nextCarDirection.containsNextTurn(), mNextNextTurnFrame);
+    if (info.nextCarDirection.containsNextTurn())
+      info.nextCarDirection.setNextTurnDrawable(mNextNextTurnImage);
   }
 
   private void updatePedestrian(RoutingInfo info)

--- a/android/src/com/mapswithme/maps/routing/RoutingInfo.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingInfo.java
@@ -23,8 +23,8 @@ public class RoutingInfo
   public final String nextStreet;
   public final double completionPercent;
   // For vehicle routing.
-  public final VehicleTurnDirection vehicleTurnDirection;
-  public final VehicleTurnDirection vehicleNextTurnDirection;
+  public final CarDirection carDirection;
+  public final CarDirection nextCarDirection;
   public final int exitNum;
   public final SingleLaneInfo[] lanes;
   // For pedestrian routing.
@@ -34,7 +34,7 @@ public class RoutingInfo
   /**
    * IMPORTANT : Order of enum values MUST BE the same as native CarDirection enum.
    */
-  public enum VehicleTurnDirection
+  public enum CarDirection
   {
     NO_TURN(R.drawable.ic_turn_straight, 0),
     GO_STRAIGHT(R.drawable.ic_turn_straight, 0),
@@ -61,7 +61,7 @@ public class RoutingInfo
     private final int mTurnRes;
     private final int mNextTurnRes;
 
-    VehicleTurnDirection(@DrawableRes int mainResId, @DrawableRes int nextResId)
+    CarDirection(@DrawableRes int mainResId, @DrawableRes int nextResId)
     {
       mTurnRes = mainResId;
       mNextTurnRes = nextResId;
@@ -83,7 +83,7 @@ public class RoutingInfo
       return mNextTurnRes != 0;
     }
 
-    public static boolean isRoundAbout(VehicleTurnDirection turn)
+    public static boolean isRoundAbout(CarDirection turn)
     {
       return turn == ENTER_ROUND_ABOUT || turn == LEAVE_ROUND_ABOUT || turn == STAY_ON_ROUND_ABOUT;
     }
@@ -138,8 +138,8 @@ public class RoutingInfo
     this.nextStreet = nextStreet;
     this.totalTimeInSeconds = totalTime;
     this.completionPercent = completionPercent;
-    this.vehicleTurnDirection = VehicleTurnDirection.values()[vehicleTurnOrdinal];
-    this.vehicleNextTurnDirection = VehicleTurnDirection.values()[vehicleNextTurnOrdinal];
+    this.carDirection = CarDirection.values()[vehicleTurnOrdinal];
+    this.nextCarDirection = CarDirection.values()[vehicleNextTurnOrdinal];
     this.lanes = lanes;
     this.exitNum = exitNum;
     this.pedestrianTurnDirection = PedestrianTurnDirection.values()[pedestrianTurnOrdinal];

--- a/android/src/com/mapswithme/maps/routing/RoutingInfo.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingInfo.java
@@ -32,7 +32,7 @@ public class RoutingInfo
   public final Location pedestrianNextDirection;
 
   /**
-   * IMPORTANT : Order of enum values MUST BE the same as native TurnDirection enum.
+   * IMPORTANT : Order of enum values MUST BE the same as native CarDirection enum.
    */
   public enum VehicleTurnDirection
   {

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -50,11 +50,11 @@ void FillTurnsDistancesForRendering(std::vector<routing::RouteSegment> const & s
   for (auto const & s : segments)
   {
     auto const & t = s.GetTurn();
-    CHECK_NOT_EQUAL(t.m_turn, TurnDirection::Count, ());
+    CHECK_NOT_EQUAL(t.m_turn, CarDirection::Count, ());
     // We do not render some of turn directions.
-    if (t.m_turn == TurnDirection::None || t.m_turn == TurnDirection::StartAtEndOfStreet ||
-        t.m_turn == TurnDirection::StayOnRoundAbout || t.m_turn == TurnDirection::TakeTheExit ||
-        t.m_turn == TurnDirection::ReachedYourDestination)
+    if (t.m_turn == CarDirection::None || t.m_turn == CarDirection::StartAtEndOfStreet ||
+        t.m_turn == CarDirection::StayOnRoundAbout || t.m_turn == CarDirection::TakeTheExit ||
+        t.m_turn == CarDirection::ReachedYourDestination)
     {
       continue;
     }

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -52,7 +52,7 @@ void FillTurnsDistancesForRendering(std::vector<routing::RouteSegment> const & s
     auto const & t = s.GetTurn();
     CHECK_NOT_EQUAL(t.m_turn, TurnDirection::Count, ());
     // We do not render some of turn directions.
-    if (t.m_turn == TurnDirection::NoTurn || t.m_turn == TurnDirection::StartAtEndOfStreet ||
+    if (t.m_turn == TurnDirection::None || t.m_turn == TurnDirection::StartAtEndOfStreet ||
         t.m_turn == TurnDirection::StayOnRoundAbout || t.m_turn == TurnDirection::TakeTheExit ||
         t.m_turn == TurnDirection::ReachedYourDestination)
     {

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -125,8 +125,8 @@ namespace location
   {
   public:
     FollowingInfo()
-        : m_turn(routing::turns::TurnDirection::NoTurn),
-          m_nextTurn(routing::turns::TurnDirection::NoTurn),
+        : m_turn(routing::turns::TurnDirection::None),
+          m_nextTurn(routing::turns::TurnDirection::None),
           m_exitNum(0),
           m_time(0),
           m_completionPercent(0),

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -125,8 +125,8 @@ namespace location
   {
   public:
     FollowingInfo()
-        : m_turn(routing::turns::TurnDirection::None),
-          m_nextTurn(routing::turns::TurnDirection::None),
+        : m_turn(routing::turns::CarDirection::None),
+          m_nextTurn(routing::turns::CarDirection::None),
           m_exitNum(0),
           m_time(0),
           m_completionPercent(0),
@@ -165,9 +165,9 @@ namespace location
     //@{
     string m_distToTurn;
     string m_turnUnitsSuffix;
-    routing::turns::TurnDirection m_turn;
+    routing::turns::CarDirection m_turn;
     /// Turn after m_turn. Returns NoTurn if there is no turns after.
-    routing::turns::TurnDirection m_nextTurn;
+    routing::turns::CarDirection m_nextTurn;
     uint32_t m_exitNum;
     //@}
     int m_time;

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -166,18 +166,20 @@ Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect) const
   return res;
 }
 
-double FollowedPolyline::GetMercatorDistanceFromBegin() const
+double FollowedPolyline::GetDistFromCurPointToRoutePointMerc() const
 {
-  double distance = 0.0;
-  if (m_current.IsValid())
-  {
-    for (size_t i = 1; i <= m_current.m_ind; i++)
-      distance += m_poly.GetPoint(i).Length(m_poly.GetPoint(i - 1));
+  if (!m_current.IsValid())
+    return 0.0;
 
-    distance += m_poly.GetPoint(m_current.m_ind).Length(m_current.m_pt);
-  }
+  return m_poly.GetPoint(m_current.m_ind).Length(m_current.m_pt);
+}
 
-  return distance;
+double FollowedPolyline::GetDistFromCurPointToRoutePointMeters() const
+{
+  if (!m_current.IsValid())
+    return 0.0;
+
+  return MercatorBounds::DistanceOnEarth(m_poly.GetPoint(m_current.m_ind), m_current.m_pt);
 }
 
 void FollowedPolyline::GetCurrentDirectionPoint(m2::PointD & pt, double toleranceM) const

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -41,7 +41,7 @@ double FollowedPolyline::GetDistanceM(Iter const & it1, Iter const & it2) const
           MercatorBounds::DistanceOnEarth(m_poly.GetPoint(it2.m_ind), it2.m_pt));
 }
 
-double FollowedPolyline::GetTotalDistanceM() const
+double FollowedPolyline::GetTotalDistanceMeters() const
 {
   if (!IsValid())
   {
@@ -51,7 +51,7 @@ double FollowedPolyline::GetTotalDistanceM() const
   return m_segDistance.back();
 }
 
-double FollowedPolyline::GetDistanceFromBeginM() const
+double FollowedPolyline::GetDistanceFromBeginMeters() const
 {
   if (!IsValid() || !m_current.IsValid())
   {
@@ -64,9 +64,9 @@ double FollowedPolyline::GetDistanceFromBeginM() const
          MercatorBounds::DistanceOnEarth(m_current.m_pt, m_poly.GetPoint(m_current.m_ind));
 }
 
-double FollowedPolyline::GetDistanceToEndM() const
+double FollowedPolyline::GetDistanceToEndMeters() const
 {
-  return GetTotalDistanceM() - GetDistanceFromBeginM();
+  return GetTotalDistanceMeters() - GetDistanceFromBeginMeters();
 }
 
 void FollowedPolyline::Swap(FollowedPolyline & rhs)

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -51,7 +51,7 @@ double FollowedPolyline::GetTotalDistanceMeters() const
   return m_segDistance.back();
 }
 
-double FollowedPolyline::GetDistanceFromBeginMeters() const
+double FollowedPolyline::GetDistanceFromStartMeters() const
 {
   if (!IsValid() || !m_current.IsValid())
   {
@@ -66,7 +66,7 @@ double FollowedPolyline::GetDistanceFromBeginMeters() const
 
 double FollowedPolyline::GetDistanceToEndMeters() const
 {
-  return GetTotalDistanceMeters() - GetDistanceFromBeginMeters();
+  return GetTotalDistanceMeters() - GetDistanceFromStartMeters();
 }
 
 void FollowedPolyline::Swap(FollowedPolyline & rhs)

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -26,12 +26,6 @@ public:
     Update();
   }
 
-  void PopBack()
-  {
-    m_poly.PopBack();
-    Update();
-  }
-
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
 
   m2::PolylineD const & GetPolyline() const { return m_poly; }
@@ -39,10 +33,11 @@ public:
   double GetTotalDistanceM() const;
   double GetDistanceFromBeginM() const;
   double GetDistanceToEndM() const;
-  double GetMercatorDistanceFromBegin() const;
+  double GetDistFromCurPointToRoutePointMerc() const;
+  double GetDistFromCurPointToRoutePointMeters() const;
 
   /*! \brief Return next navigation point for direction widgets.
-   *  Returns first geomety point from the polyline after your location if it is farther then
+   *  Returns first geometry point from the polyline after your location if it is farther then
    *  toleranceM.
    */
   void GetCurrentDirectionPoint(m2::PointD & pt, double toleranceM) const;

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -31,7 +31,7 @@ public:
   m2::PolylineD const & GetPolyline() const { return m_poly; }
   vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
   double GetTotalDistanceMeters() const;
-  double GetDistanceFromBeginMeters() const;
+  double GetDistanceFromStartMeters() const;
   double GetDistanceToEndMeters() const;
   double GetDistFromCurPointToRoutePointMerc() const;
   double GetDistFromCurPointToRoutePointMeters() const;

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -29,10 +29,10 @@ public:
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
 
   m2::PolylineD const & GetPolyline() const { return m_poly; }
-  vector<double> const & GetSegDistanceM() const { return m_segDistance; }
-  double GetTotalDistanceM() const;
-  double GetDistanceFromBeginM() const;
-  double GetDistanceToEndM() const;
+  vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
+  double GetTotalDistanceMeters() const;
+  double GetDistanceFromBeginMeters() const;
+  double GetDistanceToEndMeters() const;
   double GetDistFromCurPointToRoutePointMerc() const;
   double GetDistFromCurPointToRoutePointMeters() const;
 

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -258,8 +258,8 @@ void BicycleDirectionsEngine::GetUniNodeIdAndAdjacentEdges(IRoadGraph::TEdgeVect
 
     if (inEdge.GetFeatureId().m_mwmId == edge.GetFeatureId().m_mwmId)
     {
-//      ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, edge.GetStartJunction().GetPoint()),
-//                  turns::kFeaturesNearTurnMeters, ());
+      ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, edge.GetStartJunction().GetPoint()),
+                  turns::kFeaturesNearTurnMeters, ());
       m2::PointD const & outgoingPoint = edge.GetEndJunction().GetPoint();
       angle = my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
     }

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -258,8 +258,8 @@ void BicycleDirectionsEngine::GetUniNodeIdAndAdjacentEdges(IRoadGraph::TEdgeVect
 
     if (inEdge.GetFeatureId().m_mwmId == edge.GetFeatureId().m_mwmId)
     {
-      ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, edge.GetStartJunction().GetPoint()),
-                  turns::kFeaturesNearTurnMeters, ());
+//      ASSERT_LESS(MercatorBounds::DistanceOnEarth(junctionPoint, edge.GetStartJunction().GetPoint()),
+//                  turns::kFeaturesNearTurnMeters, ());
       m2::PointD const & outgoingPoint = edge.GetEndJunction().GetPoint();
       angle = my::RadToDeg(turns::PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
     }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -627,12 +627,12 @@ IRouter::ResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   // First and last segments are fakes: skip it.
   for (size_t i = 1; i < segments.size() - 1; ++i)
   {
-    times.emplace_back(static_cast<uint32_t>(i), time);
     time += starter.CalcSegmentWeight(segments[i]);
+    times.emplace_back(static_cast<uint32_t>(i), time);
   }
   
   CHECK(m_directionsEngine, ());
-  ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, false /* hasAltitude */, junctions,
+  ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, junctions,
                    std::move(times), route);
 
   if (!route.IsValid())

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -210,8 +210,8 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(Checkpoints const & checkpoi
     CHECK(m_directionsEngine, ());
     route.SetSubroteAttrs(vector<Route::SubrouteAttrs>(
         {Route::SubrouteAttrs(startPos, finalPos, 0, result.path.size() - 1)}));
-    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr /* trafficStash */, delegate,
-                     true /* hasAltitude */, result.path, std::move(times), route);
+    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr, delegate, result.path,
+                     std::move(times), route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -210,8 +210,8 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(Checkpoints const & checkpoi
     CHECK(m_directionsEngine, ());
     route.SetSubroteAttrs(vector<Route::SubrouteAttrs>(
         {Route::SubrouteAttrs(startPos, finalPos, 0, result.path.size() - 1)}));
-    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr, delegate, result.path,
-                     std::move(times), route);
+    ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr /* trafficStash */, delegate,
+                     result.path, std::move(times), route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -68,21 +68,21 @@ double Route::GetTotalDistanceMeters() const
 {
   if (!m_poly.IsValid())
     return 0.0;
-  return m_poly.GetTotalDistanceM();
+  return m_poly.GetTotalDistanceMeters();
 }
 
 double Route::GetCurrentDistanceFromBeginMeters() const
 {
   if (!m_poly.IsValid())
     return 0.0;
-  return m_poly.GetDistanceFromBeginM();
+  return m_poly.GetDistanceFromBeginMeters();
 }
 
 double Route::GetCurrentDistanceToEndMeters() const
 {
   if (!m_poly.IsValid())
     return 0.0;
-  return m_poly.GetDistanceToEndM();
+  return m_poly.GetDistanceToEndMeters();
 }
 
 double Route::GetMercatorDistanceFromBegin() const
@@ -322,7 +322,7 @@ bool Route::IsSubroutePassed(size_t subrouteIdx) const
   size_t const segmentIdx = GetSubrouteAttrs(subrouteIdx).GetEndSegmentIdx() - 1;
   CHECK_LESS(segmentIdx, m_routeSegments.size(), ());
   double const lengthMeters = m_routeSegments[segmentIdx].GetDistFromBeginningMeters();
-  double const passedDistanceMeters = m_poly.GetDistanceFromBeginM();
+  double const passedDistanceMeters = m_poly.GetDistanceFromBeginMeters();
   return lengthMeters - passedDistanceMeters < kOnEndToleranceM;
 }
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -34,10 +34,10 @@ double constexpr kSteetNameLinkMeters = 400.;
 
 bool IsNormalTurn(TurnItem const & turn)
 {
-  CHECK_NOT_EQUAL(turn.m_turn, TurnDirection::Count, ());
+  CHECK_NOT_EQUAL(turn.m_turn, CarDirection::Count, ());
   CHECK_NOT_EQUAL(turn.m_pedestrianTurn, PedestrianDirection::Count, ());
 
-  return turn.m_turn != turns::TurnDirection::None ||
+  return turn.m_turn != turns::CarDirection::None ||
          turn.m_pedestrianTurn != turns::PedestrianDirection::None;
 }
 }  //  namespace
@@ -183,7 +183,7 @@ void Route::GetClosestTurn(size_t segIdx, TurnItem & turn) const
       return;
     }
   }
-  CHECK(false, ("The last turn should be TurnDirection::ReachedYourDestination."));
+  CHECK(false, ("The last turn should be CarDirection::ReachedYourDestination."));
   return;
 }
 
@@ -206,7 +206,7 @@ bool Route::GetNextTurn(double & distanceToTurnMeters, TurnItem & nextTurn) cons
   // |curIdx| + 1 - 1 is an index of segment to start look for the closest turn.
   GetClosestTurn(curIdx, curTurn);
   CHECK_LESS(curIdx, curTurn.m_index, ());
-  if (curTurn.m_turn == TurnDirection::ReachedYourDestination)
+  if (curTurn.m_turn == CarDirection::ReachedYourDestination)
   {
     nextTurn = TurnItem();
     return false;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -37,7 +37,7 @@ bool IsNormalTurn(TurnItem const & turn)
   CHECK_NOT_EQUAL(turn.m_turn, TurnDirection::Count, ());
   CHECK_NOT_EQUAL(turn.m_pedestrianTurn, PedestrianDirection::Count, ());
 
-  return turn.m_turn != turns::TurnDirection::NoTurn ||
+  return turn.m_turn != turns::TurnDirection::None ||
          turn.m_pedestrianTurn != turns::PedestrianDirection::None;
 }
 }  //  namespace

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -111,10 +111,10 @@ double Route::GetCurrentTimeToEndSec() const
     return 0.0;
 
   CHECK_LESS(curIter.m_ind, m_routeSegments.size(), ());
-  double const etaToLastPassedPointS = GetETAToLastPassedPointS();
+  double const etaToLastPassedPointS = GetETAToLastPassedPointSec();
   double const curSegLenMeters = GetSegLenMeters(curIter.m_ind);
   double const totalTimeS = GetTotalTimeSec();
-  // Note. If a segment is short it does not make any sence to take into account time needed
+  // Note. If a segment is short it does not make any sense to take into account time needed
   // to path its part.
   if (my::AlmostEqualAbs(curSegLenMeters, 0.0, 1.0 /* meters */))
     return totalTimeS - etaToLastPassedPointS;
@@ -369,7 +369,7 @@ double Route::GetSegLenMeters(size_t segIdx) const
          (segIdx == 0 ? 0.0 : m_routeSegments[segIdx - 1].GetDistFromBeginningMeters());
 }
 
-double Route::GetETAToLastPassedPointS() const
+double Route::GetETAToLastPassedPointSec() const
 {
   CHECK(IsValid(), ());
   auto const & curIter = m_poly.GetCurrentIter();

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -170,7 +170,10 @@ public:
     for (auto const & s : m_routeSegments)
     {
       if (s.GetJunction().GetAltitude() == feature::kInvalidAltitude)
+      {
         m_haveAltitudes = false;
+        return;
+      }
     }
   }
 
@@ -285,7 +288,7 @@ private:
   /// \returns Length of the route segment with |segIdx| in meters.
   double GetSegLenMeters(size_t segIdx) const;
   /// \returns ETA to the last passed route point in seconds.
-  double GetETAToLastPassedPointS() const;
+  double GetETAToLastPassedPointSec() const;
 
   std::string m_router;
   RoutingSettings m_routingSettings;
@@ -295,8 +298,7 @@ private:
 
   std::set<std::string> m_absentCountries;
   std::vector<RouteSegment> m_routeSegments;
-  // |m_haveAltitudes| == true if all route points have altitude information.
-  // |m_haveAltitudes| == false if at least one of route points don't have altitude information.
+  // |m_haveAltitudes| is true if and only if all route points have altitude information.
   bool m_haveAltitudes = false;
 
   // Subroute

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -55,7 +55,7 @@ public:
   std::string const & GetStreet() const { return m_street; }
   double GetDistFromBeginningMeters() const { return m_distFromBeginningMeters; }
   double GetDistFromBeginningMerc() const { return m_distFromBeginningMerc; }
-  double GetTimeFromBeginningS() const { return m_timeFromBeginningS; }
+  double GetTimeFromBeginningSec() const { return m_timeFromBeginningS; }
   traffic::SpeedGroup GetTraffic() const { return m_traffic; }
 
 private:
@@ -284,7 +284,7 @@ private:
   size_t ConvertPointIdxToSegmentIdx(size_t pointIdx) const;
 
   /// \returns Estimated time to pass the route segment with |segIdx|.
-  double GetTimeToPassSegS(size_t segIdx) const;
+  double GetTimeToPassSegSec(size_t segIdx) const;
   /// \returns Length of the route segment with |segIdx| in meters.
   double GetSegLenMeters(size_t segIdx) const;
   /// \returns ETA to the last passed route point in seconds.

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -13,11 +13,8 @@
 
 #include "base/followed_polyline.hpp"
 
-#include "std/vector.hpp"
-#include "std/set.hpp"
-#include "std/string.hpp"
-
 #include <limits>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -82,11 +79,11 @@ private:
 class Route
 {
 public:
-  using TTurns = vector<turns::TurnItem>;
-  using TTimeItem = pair<uint32_t, double>;
-  using TTimes = vector<TTimeItem>;
-  using TStreetItem = pair<uint32_t, string>;
-  using TStreets = vector<TStreetItem>;
+  using TTurns = std::vector<turns::TurnItem>;
+  using TTimeItem = std::pair<uint32_t, double>;
+  using TTimes = std::vector<TTimeItem>;
+  using TStreetItem = std::pair<uint32_t, std::string>;
+  using TStreets = std::vector<TStreetItem>;
 
   class SubrouteAttrs final
   {
@@ -129,28 +126,30 @@ public:
   /// \brief For every subroute some attributes are kept the following stucture.
   struct SubrouteSettings final
   {
-    SubrouteSettings(RoutingSettings const & routingSettings, string const & router, SubrouteUid id)
+    SubrouteSettings(RoutingSettings const & routingSettings, std::string const & router,
+                     SubrouteUid id)
       : m_routingSettings(routingSettings), m_router(router), m_id(id)
     {
     }
 
     RoutingSettings const m_routingSettings;
-    string const m_router;
+    std::string const m_router;
     /// Some subsystems (for example drape) which is used Route class need to have an id of any subroute.
     /// This subsystems may set the id and then use it. The id is kept in |m_id|.
     SubrouteUid const m_id = kInvalidSubrouteId;
   };
 
-  explicit Route(string const & router)
+  explicit Route(std::string const & router)
     : m_router(router), m_routingSettings(GetCarRoutingSettings()) {}
 
   template <class TIter>
-  Route(string const & router, TIter beg, TIter end)
+  Route(std::string const & router, TIter beg, TIter end)
     : m_router(router), m_routingSettings(GetCarRoutingSettings()), m_poly(beg, end)
   {
   }
 
-  Route(string const & router, vector<m2::PointD> const & points, string const & name = string());
+  Route(std::string const & router, std::vector<m2::PointD> const & points,
+        std::string const & name = std::string());
 
   void Swap(Route & rhs);
 
@@ -187,13 +186,13 @@ public:
 
   FollowedPolyline const & GetFollowedPolyline() const { return m_poly; }
 
-  string const & GetRouterId() const { return m_router; }
+  std::string const & GetRouterId() const { return m_router; }
   m2::PolylineD const & GetPoly() const { return m_poly.GetPolyline(); }
   
   size_t GetCurrentSubrouteIdx() const { return m_currentSubrouteIdx; }
-  vector<SubrouteAttrs> const & GetSubroutes() const { return m_subrouteAttrs; }
+  std::vector<SubrouteAttrs> const & GetSubroutes() const { return m_subrouteAttrs; }
 
-  vector<double> const & GetSegDistanceMeters() const { return m_poly.GetSegDistanceM(); }
+  std::vector<double> const & GetSegDistanceMeters() const { return m_poly.GetSegDistanceM(); }
   bool IsValid() const { return (m_poly.GetPolyline().GetSize() > 1); }
 
   double GetTotalDistanceMeters() const;
@@ -207,17 +206,18 @@ public:
   void GetCurrentTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
 
   /// \brief Returns a name of a street where the user rides at this moment.
-  void GetCurrentStreetName(string & name) const;
+  void GetCurrentStreetName(std::string & name) const;
 
   /// \brief Returns a name of a street next to idx point of the path. Function avoids short unnamed links.
-  void GetStreetNameAfterIdx(uint32_t idx, string & name) const;
+  void GetStreetNameAfterIdx(uint32_t idx, std::string & name) const;
 
+  /// \brief Gets turn information after the turn next to the nearest one.
   /// \param distanceToTurnMeters is a distance from current position to the second turn.
-  /// \param turn is information about the second turn.
+  /// \param nextTurn is information about the second turn.
   /// \note All parameters are filled while a GetNextTurn function call.
-  bool GetNextTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
+  bool GetNextTurn(double & distanceToTurnMeters, turns::TurnItem & nextTurn) const;
   /// \brief Extract information about zero, one or two nearest turns depending on current position.
-  bool GetNextTurns(vector<turns::TurnItemDist> & turns) const;
+  bool GetNextTurns(std::vector<turns::TurnItemDist> & turns) const;
 
   void GetCurrentDirectionPoint(m2::PointD & pt) const;
 
@@ -227,10 +227,10 @@ public:
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 
   /// Add country name if we have no country filename to make route
-  void AddAbsentCountry(string const & name);
+  void AddAbsentCountry(std::string const & name);
 
   /// Get absent file list of a routing files for shortest path finding
-  set<string> const & GetAbsentCountries() const { return m_absentCountries; }
+  std::set<std::string> const & GetAbsentCountries() const { return m_absentCountries; }
 
   inline void SetRoutingSettings(RoutingSettings const & routingSettings)
   {
@@ -271,10 +271,10 @@ public:
   bool HaveAltitudes() const { return m_haveAltitudes; }
   traffic::SpeedGroup GetTraffic(size_t segmentIdx) const;
 
-  void GetTurnsForTesting(vector<turns::TurnItem> & turns) const;
+  void GetTurnsForTesting(std::vector<turns::TurnItem> & turns) const;
 
 private:
-  friend string DebugPrint(Route const & r);
+  friend std::string DebugPrint(Route const & r);
 
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurn(size_t segIdx, turns::TurnItem & turn) const;
@@ -287,13 +287,13 @@ private:
   /// \returns ETA to the last passed route point in seconds.
   double GetETAToLastPassedPointS() const;
 
-  string m_router;
+  std::string m_router;
   RoutingSettings m_routingSettings;
-  string m_name;
+  std::string m_name;
 
   FollowedPolyline m_poly;
 
-  set<string> m_absentCountries;
+  std::set<std::string> m_absentCountries;
   std::vector<RouteSegment> m_routeSegments;
   // |m_haveAltitudes| == true if all route points have altitude information.
   // |m_haveAltitudes| == false if at least one of route points don't have altitude information.

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -192,7 +192,7 @@ public:
   size_t GetCurrentSubrouteIdx() const { return m_currentSubrouteIdx; }
   std::vector<SubrouteAttrs> const & GetSubroutes() const { return m_subrouteAttrs; }
 
-  std::vector<double> const & GetSegDistanceMeters() const { return m_poly.GetSegDistanceM(); }
+  std::vector<double> const & GetSegDistanceMeters() const { return m_poly.GetSegDistanceMeters(); }
   bool IsValid() const { return (m_poly.GetPolyline().GetSize() > 1); }
 
   double GetTotalDistanceMeters() const;

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -100,8 +100,8 @@ void FillSegmentInfo(vector<Segment> const & segments, vector<Junction> const & 
 
 void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       shared_ptr<TrafficStash> const & trafficStash,
-                      my::Cancellable const & cancellable, bool hasAltitude,
-                      vector<Junction> const & path, Route::TTimes && times, Route & route)
+                      my::Cancellable const & cancellable, vector<Junction> const & path,
+                      Route::TTimes && times, Route & route)
 {
   if (path.empty())
   {
@@ -145,26 +145,6 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
   JunctionsToPoints(junctions, routeGeometry);
 
   route.SetGeometry(routeGeometry.begin(), routeGeometry.end());
-  route.SetSectionTimes(move(times));
-  route.SetTurnInstructions(move(turnsDir));
-  route.SetStreetNames(move(streetNames));
-  if (hasAltitude)
-  {
-    feature::TAltitudes altitudes;
-    JunctionsToAltitudes(junctions, altitudes);
-    route.SetAltitudes(move(altitudes));
-  }
-
-  vector<traffic::SpeedGroup> traffic;
-  if (trafficStash && !segments.empty())
-  {
-    traffic.reserve(segments.size());
-    for (Segment const & seg : segments)
-      traffic.push_back(trafficStash->GetSpeedGroup(seg));
-    CHECK_EQUAL(segments.size(), traffic.size(), ());
-  }
-
-  route.SetTraffic(move(traffic));
 }
 
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge)

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -36,8 +36,8 @@ void FillSegmentInfo(vector<Segment> const & segments, vector<Junction> const & 
 
 void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
                       shared_ptr<TrafficStash> const & trafficStash,
-                      my::Cancellable const & cancellable, bool hasAltitude,
-                      vector<Junction> const & path, Route::TTimes && times, Route & route);
+                      my::Cancellable const & cancellable, vector<Junction> const & path,
+                      Route::TTimes && times, Route & route);
 
 /// \brief Converts |edge| to |segment|.
 /// \returns false if mwm of |edge| is not alive.

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -13,10 +13,10 @@
 
 #include "base/cancellable.hpp"
 
-#include "std/queue.hpp"
-#include "std/set.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/vector.hpp"
+#include <memory>
+#include <queue>
+#include <set>
+#include <vector>
 
 namespace routing
 {
@@ -29,14 +29,14 @@ bool IsRoad(TTypes const & types)
          BicycleModel::AllLimitsInstance().HasRoadType(types);
 }
 
-void FillSegmentInfo(vector<Segment> const & segments, vector<Junction> const & junctions,
+void FillSegmentInfo(std::vector<Segment> const & segments, std::vector<Junction> const & junctions,
                      Route::TTurns const & turns, Route::TStreets const & streets,
-                     Route::TTimes const & times, shared_ptr<TrafficStash> const & trafficStash,
-                     vector<RouteSegment> & routeSegment);
+                     Route::TTimes const & times, std::shared_ptr<TrafficStash> const & trafficStash,
+                     std::vector<RouteSegment> & routeSegment);
 
 void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
-                      shared_ptr<TrafficStash> const & trafficStash,
-                      my::Cancellable const & cancellable, vector<Junction> const & path,
+                      std::shared_ptr<TrafficStash> const & trafficStash,
+                      my::Cancellable const & cancellable, std::vector<Junction> const & path,
                       Route::TTimes && times, Route & route);
 
 /// \brief Converts |edge| to |segment|.
@@ -44,7 +44,7 @@ void ReconstructRoute(IDirectionsEngine & engine, RoadGraphBase const & graph,
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
 
 /// \brief Fills |times| according to max speed at |graph| and |path|.
-void CalculateMaxSpeedTimes(RoadGraphBase const & graph, vector<Junction> const & path,
+void CalculateMaxSpeedTimes(RoadGraphBase const & graph, std::vector<Junction> const & path,
                             Route::TTimes & times);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
@@ -55,13 +55,13 @@ template <typename Graph, typename GetVertexByEdgeFn, typename GetOutgoingEdgesF
 bool CheckGraphConnectivity(typename Graph::Vertex const & start, size_t limit, Graph & graph,
                             GetVertexByEdgeFn && getVertexByEdgeFn, GetOutgoingEdgesFn && getOutgoingEdgesFn)
 {
-  queue<typename Graph::Vertex> q;
+  std::queue<typename Graph::Vertex> q;
   q.push(start);
 
-  set<typename Graph::Vertex> marked;
+  std::set<typename Graph::Vertex> marked;
   marked.insert(start);
 
-  vector<typename Graph::Edge> edges;
+  std::vector<typename Graph::Edge> edges;
   while (!q.empty() && marked.size() < limit)
   {
     auto const u = q.front();

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -4,6 +4,8 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/math.hpp"
+
 using namespace routing;
 using namespace routing::turns;
 
@@ -18,7 +20,7 @@ UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
-      MercatorBounds::FromLatLon(55.67695, 37.56220), 7570.0);
+      MercatorBounds::FromLatLon(55.67695, 37.56220), 5670.0);
 }
 
 UNIT_TEST(RussiaDomodedovoSteps)
@@ -54,7 +56,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
-  TEST_EQUAL(route.GetTotalTimeSec(), 356, ());
+  TEST(my::AlmostEqualAbs(route.GetTotalTimeSec(), 356.0, 1.0), ());
 }
 
 UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -18,7 +18,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   TEST_EQUAL(result, IRouter::NoError, ());
 
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::TestRouteLength(route, 1054.0);
 }
 
@@ -34,8 +34,8 @@ UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
 
   integration::TestTurnCount(route, 2);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
@@ -50,7 +50,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 
   integration::TestTurnCount(route, 1);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::GoStraight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
 }
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
@@ -75,10 +75,10 @@ UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
 
   integration::TestTurnCount(route, 4);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 420.0);
 }
@@ -95,9 +95,9 @@ UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
 
   integration::TestTurnCount(route, 3);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 768.0);
 }

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -302,7 +302,7 @@ namespace
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
-    TEST_LESS(route.GetTotalTimeSec(), numeric_limits<uint32_t>::max() / 2, ());
+    TEST_LESS(route.GetTotalTimeSec(), numeric_limits<double >::max() / 2.0, ());
   }
 
   // There are road ids in osrm which don't have appropriate features ids in mwm.

--- a/routing/routing_integration_tests/osrm_turn_test.cpp
+++ b/routing/routing_integration_tests/osrm_turn_test.cpp
@@ -23,11 +23,11 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestDirection(TurnDirection::TurnRight);
+      .TestDirection(CarDirection::TurnRight);
   integration::GetNthTurn(route, 1)
       .TestValid()
-      .TestDirection(TurnDirection::UTurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(TurnDirection::TurnLeft);
+      .TestDirection(CarDirection::UTurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 561.);
 }
@@ -61,14 +61,14 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestDirection(TurnDirection::TurnRight);
+      .TestDirection(CarDirection::TurnRight);
   integration::GetNthTurn(route, 1)
       .TestValid()
-      .TestDirection(TurnDirection::UTurnLeft);
+      .TestDirection(CarDirection::UTurnLeft);
   integration::GetNthTurn(route, 2)
       .TestValid()
-      .TestDirection(TurnDirection::TurnRight);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(TurnDirection::TurnLeft);
+      .TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 2033.);
 }
@@ -87,19 +87,19 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestPoint({37.38848, 67.63338}, 20.)
-      .TestDirection(TurnDirection::TurnSlightRight);
+      .TestDirection(CarDirection::TurnSlightRight);
   integration::GetNthTurn(route, 1)
       .TestValid()
       .TestPoint({37.38711, 67.63336}, 20.)
-      .TestDirection(TurnDirection::TurnLeft);
+      .TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 2)
       .TestValid()
       .TestPoint({37.38738, 67.63278}, 20.)
-      .TestDirection(TurnDirection::TurnLeft);
+      .TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 3)
       .TestValid()
       .TestPoint({37.39052, 67.63310}, 20.)
-      .TestDirection(TurnDirection::TurnRight);
+      .TestDirection(CarDirection::TurnRight);
 
   integration::TestRouteLength(route, 1637.);
 }
@@ -118,9 +118,9 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestDirection(TurnDirection::EnterRoundAbout)
+      .TestDirection(CarDirection::EnterRoundAbout)
       .TestRoundAboutExitNum(2);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::LeaveRoundAbout);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::LeaveRoundAbout);
 
   integration::TestRouteLength(route, 387.);
 }
@@ -138,9 +138,9 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestDirection(TurnDirection::EnterRoundAbout)
+      .TestDirection(CarDirection::EnterRoundAbout)
       .TestRoundAboutExitNum(2);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::LeaveRoundAbout);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::LeaveRoundAbout);
 
   integration::TestRouteLength(route, 255.);
 }
@@ -157,7 +157,7 @@ UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 217.);
 }
@@ -177,7 +177,7 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestPoint({37.68276, 67.14062})
-      .TestOneOfDirections({TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+      .TestOneOfDirections({CarDirection::TurnSlightRight, CarDirection::TurnRight});
 
   integration::TestRouteLength(route, 43233.7);
 }
@@ -196,7 +196,7 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
   integration::TestTurnCount(route, 1);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
 UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
@@ -212,7 +212,7 @@ UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
   // Checking a turn in case going from a not-link to a link
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::UTurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
@@ -228,8 +228,8 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 2);
   // Checking a turn in case going from a not-link to a link
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
@@ -244,7 +244,7 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
 
 UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
@@ -260,7 +260,7 @@ UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
 UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
@@ -291,11 +291,11 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
   integration::TestTurnCount(route, 2);
   integration::GetNthTurn(route, 0)
       .TestValid()
-      .TestDirection(TurnDirection::EnterRoundAbout)
+      .TestDirection(CarDirection::EnterRoundAbout)
       .TestRoundAboutExitNum(5);
   integration::GetNthTurn(route, 1)
       .TestValid()
-      .TestDirection(TurnDirection::LeaveRoundAbout)
+      .TestDirection(CarDirection::LeaveRoundAbout)
       .TestRoundAboutExitNum(5);
 }
 
@@ -312,7 +312,7 @@ UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
 // Test case: turning form one street to another one with the same name.
@@ -329,7 +329,7 @@ UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 // Test case: a route goes straight along a unnamed big link road when joined a small road.
@@ -360,7 +360,7 @@ UNIT_TEST(BelarusMKADShosseinai)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {TurnDirection::GoStraight, TurnDirection::TurnSlightRight});
+      {CarDirection::GoStraight, CarDirection::TurnSlightRight});
 }
 
 // Test case: a route goes straight along a unnamed big road when joined small road.
@@ -394,7 +394,7 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {TurnDirection::TurnSlightRight, TurnDirection::TurnRight});
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
 // Test case: a route goes in Moscow from Tverskaya street (towards city center)
@@ -410,7 +410,7 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
@@ -424,7 +424,7 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::TurnRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
 
 // Test case: a route goes in Moscow along Leningradskiy Prpt (towards city center)
@@ -440,7 +440,7 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(TurnDirection::UTurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
 
 // Test case: checking that no unnecessary turn on a serpentine road.

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -399,7 +399,8 @@ UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 3, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::Downstairs, ());
@@ -418,7 +419,8 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 3, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::Upstairs, ());
@@ -437,7 +439,8 @@ UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 3, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::Downstairs, ());
@@ -456,7 +459,8 @@ UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 2, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::LiftGate, ());
@@ -474,7 +478,8 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 2, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::Gate, ());
@@ -492,7 +497,8 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane19LiftGateAndGate)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  auto const & t = route.GetTurns();
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
   TEST_EQUAL(t.size(), 3, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::LiftGate, ());

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -324,14 +324,14 @@ namespace integration
     return *this;
   }
 
-  const TestTurn & TestTurn::TestDirection(routing::turns::TurnDirection expectedDirection) const
+  const TestTurn & TestTurn::TestDirection(routing::turns::CarDirection expectedDirection) const
   {
     TEST_EQUAL(m_direction, expectedDirection, ());
     return *this;
   }
 
   const TestTurn & TestTurn::TestOneOfDirections(
-      set<routing::turns::TurnDirection> const & expectedDirections) const
+      set<routing::turns::CarDirection> const & expectedDirections) const
   {
     TEST(expectedDirections.find(m_direction) != expectedDirections.cend(), ());
     return *this;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -253,7 +253,9 @@ namespace integration
   void TestTurnCount(routing::Route const & route, uint32_t expectedTurnCount)
   {
     // We use -1 for ignoring the "ReachedYourDestination" turn record.
-    TEST_EQUAL(route.GetTurns().size() - 1, expectedTurnCount, ());
+    vector<turns::TurnItem> turns;
+    route.GetTurnsForTesting(turns);
+    TEST_EQUAL(turns.size() - 1, expectedTurnCount, ());
   }
 
   void TestCurrentStreetName(routing::Route const & route, string const & expectedStreetName)
@@ -268,7 +270,7 @@ namespace integration
     string streetName;
     double distance;
     turns::TurnItem turn;
-    TEST(route.GetCurrentTurn(distance, turn), ());
+    route.GetCurrentTurn(distance, turn);
     route.GetStreetNameAfterIdx(turn.m_index, streetName);
     TEST_EQUAL(streetName, expectedStreetName, ());
   }
@@ -343,7 +345,8 @@ namespace integration
 
   TestTurn GetNthTurn(routing::Route const & route, uint32_t turnNumber)
   {
-    Route::TTurns const & turns = route.GetTurns();
+    vector<turns::TurnItem> turns;
+    route.GetTurnsForTesting(turns);
     if (turnNumber >= turns.size())
       return TestTurn();
 

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -117,7 +117,7 @@ class TestTurn
 
   TestTurn()
     : m_point({0.0, 0.0})
-    , m_direction(TurnDirection::NoTurn)
+    , m_direction(TurnDirection::None)
     , m_roundAboutExitNum(0)
     , m_isValid(false)
   {

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -111,18 +111,18 @@ class TestTurn
   friend TestTurn GetNthTurn(Route const & route, uint32_t turnNumber);
 
   m2::PointD const m_point;
-  TurnDirection const m_direction;
+  CarDirection const m_direction;
   uint32_t const m_roundAboutExitNum;
   bool const m_isValid;
 
   TestTurn()
     : m_point({0.0, 0.0})
-    , m_direction(TurnDirection::None)
+    , m_direction(CarDirection::None)
     , m_roundAboutExitNum(0)
     , m_isValid(false)
   {
   }
-  TestTurn(m2::PointD const & pnt, TurnDirection direction, uint32_t roundAboutExitNum)
+  TestTurn(m2::PointD const & pnt, CarDirection direction, uint32_t roundAboutExitNum)
     : m_point(pnt), m_direction(direction), m_roundAboutExitNum(roundAboutExitNum), m_isValid(true)
   {
   }
@@ -131,8 +131,8 @@ public:
   const TestTurn & TestValid() const;
   const TestTurn & TestNotValid() const;
   const TestTurn & TestPoint(m2::PointD const & expectedPoint, double inaccuracyMeters = 3.) const;
-  const TestTurn & TestDirection(TurnDirection expectedDirection) const;
-  const TestTurn & TestOneOfDirections(set<TurnDirection> const & expectedDirections) const;
+  const TestTurn & TestDirection(CarDirection expectedDirection) const;
+  const TestTurn & TestOneOfDirections(set<CarDirection> const & expectedDirections) const;
   const TestTurn & TestRoundAboutExitNum(uint32_t expectedRoundAboutExitNum) const;
 };
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -606,17 +606,11 @@ void RoutingSession::EmitCloseRoutingEvent() const
       alohalytics::Location::FromLatLon(lastGoodPoint.lat, lastGoodPoint.lon));
 }
 
-bool RoutingSession::HasRouteAltitudeImpl() const
-{
-  ASSERT(m_route, ());
-
-  return m_route->HaveAltitudes();
-}
-
 bool RoutingSession::HasRouteAltitude() const
 {
   threads::MutexGuard guard(m_routingSessionMutex);
-  return HasRouteAltitudeImpl();
+  ASSERT(m_route, ());
+  return m_route->HaveAltitudes();
 }
 
 bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDistanceM,
@@ -625,7 +619,7 @@ bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDis
   threads::MutexGuard guard(m_routingSessionMutex);
   ASSERT(m_route, ());
 
-  if (!m_route->IsValid() || !HasRouteAltitudeImpl())
+  if (!m_route->IsValid() || !m_route->HaveAltitudes())
     return false;
 
   routeSegDistanceM = m_route->GetSegDistanceMeters();

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -315,7 +315,7 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   if (m_routingSettings.m_showTurnAfterNext)
     info.m_nextTurn = m_turnNotificationsMgr.GetSecondTurnNotification();
   else
-    info.m_nextTurn = routing::turns::TurnDirection::None;
+    info.m_nextTurn = routing::turns::CarDirection::None;
 
   info.m_exitNum = turn.m_exitNum;
   info.m_time = static_cast<int>(max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -315,7 +315,7 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   if (m_routingSettings.m_showTurnAfterNext)
     info.m_nextTurn = m_turnNotificationsMgr.GetSecondTurnNotification();
   else
-    info.m_nextTurn = routing::turns::TurnDirection::NoTurn;
+    info.m_nextTurn = routing::turns::TurnDirection::None;
 
   info.m_exitNum = turn.m_exitNum;
   info.m_time = static_cast<int>(max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -197,7 +197,6 @@ private:
   void RemoveRouteImpl();
   void RebuildRouteOnTrafficUpdate();
 
-  bool HasRouteAltitudeImpl() const;
   double GetCompletionPercent() const;
   void PassCheckpoints();
 

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -111,8 +111,8 @@ UNIT_TEST(FollowedPolylineGetDistanceFromBeginM)
   FollowedPolyline polyline(testPolyline.Begin(), testPolyline.End());
   m2::PointD point(4, 0);
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters(point, 2));
-  double distance = polyline.GetDistanceFromBeginMeters();
-  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
+  double const distance = polyline.GetDistanceFromStartMeters();
+  double const masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
                                                           point);
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 }

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -68,7 +68,7 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
                                                           kTestDirectedPolyline.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
-  distance = polyline.GetTotalDistanceM();
+  distance = polyline.GetTotalDistanceMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 
   // Test partial length case.
@@ -77,7 +77,7 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.GetPoint(1),
                                                    kTestDirectedPolyline.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
-  distance = polyline.GetDistanceToEndM();
+  distance = polyline.GetDistanceToEndMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 
   // Test point in the middle case.
@@ -86,7 +86,7 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   masterDistance = MercatorBounds::DistanceOnEarth(m2::PointD(4, 0),
                                                    kTestDirectedPolyline.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
-  distance = polyline.GetDistanceToEndM();
+  distance = polyline.GetDistanceToEndMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 }
 
@@ -111,7 +111,7 @@ UNIT_TEST(FollowedPolylineGetDistanceFromBeginM)
   FollowedPolyline polyline(testPolyline.Begin(), testPolyline.End());
   m2::PointD point(4, 0);
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters(point, 2));
-  double distance = polyline.GetDistanceFromBeginM();
+  double distance = polyline.GetDistanceFromBeginMeters();
   double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
                                                           point);
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -30,10 +30,10 @@ static Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(
                                       Route::TTimeItem(4, 15)});
 
 static Route::TTurns const kTestTurns2(
-    {turns::TurnItem(0, turns::TurnDirection::NoTurn),
+    {turns::TurnItem(0, turns::TurnDirection::None),
      turns::TurnItem(1, turns::TurnDirection::TurnLeft),
      turns::TurnItem(2, turns::TurnDirection::TurnRight),
-     turns::TurnItem(3, turns::TurnDirection::NoTurn),
+     turns::TurnItem(3, turns::TurnDirection::None),
      turns::TurnItem(4, turns::TurnDirection::ReachedYourDestination)});
 static vector<string> const kTestNames2 = {"Street0", "Street1", "Street2", "", "Street3"};
 static vector<double> const kTestTimes2 = {0.0, 5.0, 6.0, 10.0, 15.0};

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -10,6 +10,7 @@
 
 #include "geometry/point2d.hpp"
 
+#include "std/set.hpp"
 #include "std/string.hpp"
 #include "std/vector.hpp"
 
@@ -22,19 +23,19 @@ static vector<m2::PointD> const kTestGeometry({{0, 0}, {0,1}, {1,1}, {1,2}, {1,3
 static vector<Segment> const kTestSegments(
     {{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}, {0, 0, 3, true}});
 static Route::TTurns const kTestTurns(
-    {turns::TurnItem(1, turns::TurnDirection::TurnLeft),
-     turns::TurnItem(2, turns::TurnDirection::TurnRight),
-     turns::TurnItem(4, turns::TurnDirection::ReachedYourDestination)});
+    {turns::TurnItem(1, turns::CarDirection::TurnLeft),
+     turns::TurnItem(2, turns::CarDirection::TurnRight),
+     turns::TurnItem(4, turns::CarDirection::ReachedYourDestination)});
 static Route::TStreets const kTestNames({{0, "Street1"}, {1, "Street2"}, {4, "Street3"}});
 static Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(3, 10),
                                       Route::TTimeItem(4, 15)});
 
 static Route::TTurns const kTestTurns2(
-    {turns::TurnItem(0, turns::TurnDirection::None),
-     turns::TurnItem(1, turns::TurnDirection::TurnLeft),
-     turns::TurnItem(2, turns::TurnDirection::TurnRight),
-     turns::TurnItem(3, turns::TurnDirection::None),
-     turns::TurnItem(4, turns::TurnDirection::ReachedYourDestination)});
+    {turns::TurnItem(0, turns::CarDirection::None),
+     turns::TurnItem(1, turns::CarDirection::TurnLeft),
+     turns::TurnItem(2, turns::CarDirection::TurnRight),
+     turns::TurnItem(3, turns::CarDirection::None),
+     turns::TurnItem(4, turns::CarDirection::ReachedYourDestination)});
 static vector<string> const kTestNames2 = {"Street0", "Street1", "Street2", "", "Street3"};
 static vector<double> const kTestTimes2 = {0.0, 5.0, 6.0, 10.0, 15.0};
 

--- a/routing/routing_tests/routing_helpers_tests.cpp
+++ b/routing/routing_tests/routing_helpers_tests.cpp
@@ -25,7 +25,7 @@ UNIT_TEST(FillSegmentInfoSmokeTest)
   vector<Junction> const junctions = {
       {m2::PointD(0.0 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
       {m2::PointD(0.1 /* x */, 0.0 /* y */), feature::kInvalidAltitude}};
-  Route::TTurns const & turnDirs = {{1 /* point index */, TurnDirection::ReachedYourDestination}};
+  Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::ReachedYourDestination}};
   Route::TStreets const streets = {};
   Route::TTimes const times = {{0 /* point index */, 0.0 /* time in seconds */}, {1, 1.0}};
 
@@ -33,7 +33,7 @@ UNIT_TEST(FillSegmentInfoSmokeTest)
   FillSegmentInfo(segments, junctions, turnDirs, streets, times, nullptr, segmentInfo);
 
   TEST_EQUAL(segmentInfo.size(), 1, ());
-  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, TurnDirection::ReachedYourDestination, ());
+  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
   TEST(segmentInfo[0].GetStreet().empty(), ());
 }
 
@@ -45,8 +45,8 @@ UNIT_TEST(FillSegmentInfoTest)
       {m2::PointD(0.0 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
       {m2::PointD(0.1 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
       {m2::PointD(0.2 /* x */, 0.0 /* y */), feature::kInvalidAltitude}};
-  Route::TTurns const & turnDirs = {{1 /* point index */, TurnDirection::TurnRight},
-                                    {2 /* point index */, TurnDirection::ReachedYourDestination}};
+  Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::TurnRight},
+                                    {2 /* point index */, CarDirection::ReachedYourDestination}};
   Route::TStreets const streets = {{0 /* point index */, "zero"}, {1, "first"}, {2, "second"}};
   Route::TTimes const times = {
       {0 /* point index */, 0.0 /* time in seconds */}, {1, 1.0}, {2, 2.0}};
@@ -55,11 +55,11 @@ UNIT_TEST(FillSegmentInfoTest)
   FillSegmentInfo(segments, junctions, turnDirs, streets, times, nullptr, segmentInfo);
 
   TEST_EQUAL(segmentInfo.size(), 2, ());
-  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, TurnDirection::TurnRight, ());
+  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, CarDirection::TurnRight, ());
   TEST_EQUAL(segmentInfo[0].GetStreet(), string("first"), ());
   TEST_EQUAL(segmentInfo[0].GetSegment(), segments[0], ());
 
-  TEST_EQUAL(segmentInfo[1].GetTurn().m_turn, TurnDirection::ReachedYourDestination, ());
+  TEST_EQUAL(segmentInfo[1].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
   TEST_EQUAL(segmentInfo[1].GetStreet(), string("second"), ());
   TEST_EQUAL(segmentInfo[1].GetSegment(), segments[1], ());
 }

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -44,7 +44,7 @@ public:
 static vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 2.}, {0., 3.}, {0., 4.}};
 static vector<Segment> const kTestSegments({{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}});
 static Route::TTurns const kTestTurns = {
-    turns::TurnItem(3, turns::TurnDirection::ReachedYourDestination)};
+    turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
 static Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(2, 10),
                                        Route::TTimeItem(3, 15)});
 

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -186,7 +186,7 @@ UNIT_TEST(TestIsLaneWayConformedTurnDirection)
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::Left, TurnDirection::TurnSlightLeft), ());
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::Right, TurnDirection::TurnSharpRight), ());
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, TurnDirection::GoStraight), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SharpRight, TurnDirection::NoTurn), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SharpRight, TurnDirection::None), ());
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::TurnLeft), ());
   TEST(!IsLaneWayConformedTurnDirection(LaneWay::None, TurnDirection::ReachedYourDestination), ());
 }
@@ -240,9 +240,9 @@ UNIT_TEST(TestGetRoundaboutDirection)
   // GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRoundabout,
   //     bool isMultiTurnJunction, bool keepTurnByHighwayClass)
   TEST_EQUAL(GetRoundaboutDirection(true, true, true, true), TurnDirection::StayOnRoundAbout, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, true, false), TurnDirection::NoTurn, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, false, true), TurnDirection::NoTurn, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, false, false), TurnDirection::NoTurn, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, true, false), TurnDirection::None, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, false, true), TurnDirection::None, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, false, false), TurnDirection::None, ());
   TEST_EQUAL(GetRoundaboutDirection(false, true, false, true), TurnDirection::EnterRoundAbout, ());
   TEST_EQUAL(GetRoundaboutDirection(true, false, false, false), TurnDirection::LeaveRoundAbout, ());
 }

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -130,17 +130,17 @@ UNIT_TEST(TestFixupTurns)
     {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
     {{ kSquareNearZero.maxX(), kSquareNearZero.minY() }, feature::kDefaultAltitudeMeters},
   };
-  // The constructor TurnItem(uint32_t idx, TurnDirection t, uint32_t exitNum = 0)
+  // The constructor TurnItem(uint32_t idx, CarDirection t, uint32_t exitNum = 0)
   // is used for initialization of vector<TurnItem> below.
-  Route::TTurns turnsDir1 = {{0, TurnDirection::EnterRoundAbout},
-                             {1, TurnDirection::StayOnRoundAbout},
-                             {2, TurnDirection::LeaveRoundAbout},
-                             {3, TurnDirection::ReachedYourDestination}};
+  Route::TTurns turnsDir1 = {{0, CarDirection::EnterRoundAbout},
+                             {1, CarDirection::StayOnRoundAbout},
+                             {2, CarDirection::LeaveRoundAbout},
+                             {3, CarDirection::ReachedYourDestination}};
 
   FixupTurns(pointsMerc1, turnsDir1);
-  Route::TTurns const expectedTurnDir1 = {{0, TurnDirection::EnterRoundAbout, 2},
-                                          {2, TurnDirection::LeaveRoundAbout, 2},
-                                          {3, TurnDirection::ReachedYourDestination}};
+  Route::TTurns const expectedTurnDir1 = {{0, CarDirection::EnterRoundAbout, 2},
+                                          {2, CarDirection::LeaveRoundAbout, 2},
+                                          {3, CarDirection::ReachedYourDestination}};
   TEST_EQUAL(turnsDir1, expectedTurnDir1, ());
 
   // Merging turns which are close to each other.
@@ -149,13 +149,13 @@ UNIT_TEST(TestFixupTurns)
     {{ kSquareCenterLonLat.x, kSquareCenterLonLat.y }, feature::kDefaultAltitudeMeters},
     {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
   };
-  Route::TTurns turnsDir2 = {{0, TurnDirection::GoStraight},
-                             {1, TurnDirection::TurnLeft},
-                             {2, TurnDirection::ReachedYourDestination}};
+  Route::TTurns turnsDir2 = {{0, CarDirection::GoStraight},
+                             {1, CarDirection::TurnLeft},
+                             {2, CarDirection::ReachedYourDestination}};
 
   FixupTurns(pointsMerc2, turnsDir2);
-  Route::TTurns const expectedTurnDir2 = {{1, TurnDirection::TurnLeft},
-                                          {2, TurnDirection::ReachedYourDestination}};
+  Route::TTurns const expectedTurnDir2 = {{1, CarDirection::TurnLeft},
+                                          {2, CarDirection::ReachedYourDestination}};
   TEST_EQUAL(turnsDir2, expectedTurnDir2, ());
 
   // No turn is removed.
@@ -164,59 +164,59 @@ UNIT_TEST(TestFixupTurns)
     {{ kSquareNearZero.minX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
     {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
   };
-  Route::TTurns turnsDir3 = {{1, TurnDirection::TurnRight},
-                             {2, TurnDirection::ReachedYourDestination}};
+  Route::TTurns turnsDir3 = {{1, CarDirection::TurnRight},
+                             {2, CarDirection::ReachedYourDestination}};
 
   FixupTurns(pointsMerc3, turnsDir3);
-  Route::TTurns const expectedTurnDir3 = {{1, TurnDirection::TurnRight},
-                                          {2, TurnDirection::ReachedYourDestination}};
+  Route::TTurns const expectedTurnDir3 = {{1, CarDirection::TurnRight},
+                                          {2, CarDirection::ReachedYourDestination}};
   TEST_EQUAL(turnsDir3, expectedTurnDir3, ());
 }
 
 UNIT_TEST(TestIsLaneWayConformedTurnDirection)
 {
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Left, TurnDirection::TurnLeft), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Right, TurnDirection::TurnRight), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, TurnDirection::TurnSlightLeft), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::SharpRight, TurnDirection::TurnSharpRight), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::UTurnLeft), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::UTurnRight), ());
-  TEST(IsLaneWayConformedTurnDirection(LaneWay::Through, TurnDirection::GoStraight), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Left, CarDirection::TurnLeft), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Right, CarDirection::TurnRight), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, CarDirection::TurnSlightLeft), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::SharpRight, CarDirection::TurnSharpRight), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, CarDirection::UTurnLeft), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Reverse, CarDirection::UTurnRight), ());
+  TEST(IsLaneWayConformedTurnDirection(LaneWay::Through, CarDirection::GoStraight), ());
 
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Left, TurnDirection::TurnSlightLeft), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Right, TurnDirection::TurnSharpRight), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, TurnDirection::GoStraight), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SharpRight, TurnDirection::None), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Reverse, TurnDirection::TurnLeft), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::None, TurnDirection::ReachedYourDestination), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Left, CarDirection::TurnSlightLeft), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Right, CarDirection::TurnSharpRight), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SlightLeft, CarDirection::GoStraight), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::SharpRight, CarDirection::None), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Reverse, CarDirection::TurnLeft), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::None, CarDirection::ReachedYourDestination), ());
 }
 
 UNIT_TEST(TestIsLaneWayConformedTurnDirectionApproximately)
 {
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Left, TurnDirection::TurnSharpLeft), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Left, TurnDirection::TurnSlightLeft), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, TurnDirection::TurnSharpRight), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, TurnDirection::TurnRight), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, TurnDirection::UTurnLeft), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, TurnDirection::UTurnRight), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightLeft, TurnDirection::GoStraight), ());
-  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightRight, TurnDirection::GoStraight), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Left, CarDirection::TurnSharpLeft), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Left, CarDirection::TurnSlightLeft), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, CarDirection::TurnSharpRight), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Right, CarDirection::TurnRight), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, CarDirection::UTurnLeft), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::Reverse, CarDirection::UTurnRight), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightLeft, CarDirection::GoStraight), ());
+  TEST(IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightRight, CarDirection::GoStraight), ());
 
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, TurnDirection::UTurnLeft), ());
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, TurnDirection::UTurnRight), ());
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, TurnDirection::UTurnLeft), ());
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, TurnDirection::UTurnRight), ());
-  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Through, TurnDirection::ReachedYourDestination), ());
-  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::Through, TurnDirection::TurnRight), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, CarDirection::UTurnLeft), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpLeft, CarDirection::UTurnRight), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, CarDirection::UTurnLeft), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SharpRight, CarDirection::UTurnRight), ());
+  TEST(!IsLaneWayConformedTurnDirection(LaneWay::Through, CarDirection::ReachedYourDestination), ());
+  TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::Through, CarDirection::TurnRight), ());
   TEST(!IsLaneWayConformedTurnDirectionApproximately(LaneWay::SlightRight,
-                                                     TurnDirection::TurnSharpLeft), ());
+                                                     CarDirection::TurnSharpLeft), ());
 }
 
 UNIT_TEST(TestAddingActiveLaneInformation)
 {
-  Route::TTurns turns = {{0, TurnDirection::GoStraight},
-                         {1, TurnDirection::TurnLeft},
-                         {2, TurnDirection::ReachedYourDestination}};
+  Route::TTurns turns = {{0, CarDirection::GoStraight},
+                         {1, CarDirection::TurnLeft},
+                         {2, CarDirection::ReachedYourDestination}};
   turns[0].m_lanes.push_back({LaneWay::Left, LaneWay::Through});
   turns[0].m_lanes.push_back({LaneWay::Right});
 
@@ -239,12 +239,12 @@ UNIT_TEST(TestGetRoundaboutDirection)
   // The signature of GetRoundaboutDirection function is
   // GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRoundabout,
   //     bool isMultiTurnJunction, bool keepTurnByHighwayClass)
-  TEST_EQUAL(GetRoundaboutDirection(true, true, true, true), TurnDirection::StayOnRoundAbout, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, true, false), TurnDirection::None, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, false, true), TurnDirection::None, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, true, false, false), TurnDirection::None, ());
-  TEST_EQUAL(GetRoundaboutDirection(false, true, false, true), TurnDirection::EnterRoundAbout, ());
-  TEST_EQUAL(GetRoundaboutDirection(true, false, false, false), TurnDirection::LeaveRoundAbout, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, true, true), CarDirection::StayOnRoundAbout, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, true, false), CarDirection::None, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, false, true), CarDirection::None, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, true, false, false), CarDirection::None, ());
+  TEST_EQUAL(GetRoundaboutDirection(false, true, false, true), CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(GetRoundaboutDirection(true, false, false, false), CarDirection::LeaveRoundAbout, ());
 }
 
 UNIT_TEST(TestCheckRoundaboutEntrance)
@@ -269,49 +269,49 @@ UNIT_TEST(TestCheckRoundaboutExit)
 
 UNIT_TEST(TestInvertDirection)
 {
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnSlightRight), TurnDirection::TurnSlightLeft, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnRight), TurnDirection::TurnLeft, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnSharpRight), TurnDirection::TurnSharpLeft, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnSlightLeft), TurnDirection::TurnSlightRight, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnSlightRight), TurnDirection::TurnSlightLeft, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnLeft), TurnDirection::TurnRight, ());
-  TEST_EQUAL(InvertDirection(TurnDirection::TurnSharpLeft), TurnDirection::TurnSharpRight, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnSlightRight), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnRight), CarDirection::TurnLeft, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnSharpRight), CarDirection::TurnSharpLeft, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnSlightLeft), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnSlightRight), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnLeft), CarDirection::TurnRight, ());
+  TEST_EQUAL(InvertDirection(CarDirection::TurnSharpLeft), CarDirection::TurnSharpRight, ());
 }
 
 UNIT_TEST(TestRightmostDirection)
 {
-  TEST_EQUAL(RightmostDirection(180.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(RightmostDirection(170.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(RightmostDirection(90.), TurnDirection::TurnRight, ());
-  TEST_EQUAL(RightmostDirection(45.), TurnDirection::TurnRight, ());
-  TEST_EQUAL(RightmostDirection(0.), TurnDirection::TurnSlightRight, ());
-  TEST_EQUAL(RightmostDirection(-20.), TurnDirection::GoStraight, ());
-  TEST_EQUAL(RightmostDirection(-90.), TurnDirection::TurnLeft, ());
-  TEST_EQUAL(RightmostDirection(-170.), TurnDirection::TurnSharpLeft, ());
+  TEST_EQUAL(RightmostDirection(180.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(RightmostDirection(170.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(RightmostDirection(90.), CarDirection::TurnRight, ());
+  TEST_EQUAL(RightmostDirection(45.), CarDirection::TurnRight, ());
+  TEST_EQUAL(RightmostDirection(0.), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(RightmostDirection(-20.), CarDirection::GoStraight, ());
+  TEST_EQUAL(RightmostDirection(-90.), CarDirection::TurnLeft, ());
+  TEST_EQUAL(RightmostDirection(-170.), CarDirection::TurnSharpLeft, ());
 }
 
 UNIT_TEST(TestLeftmostDirection)
 {
-  TEST_EQUAL(LeftmostDirection(180.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(LeftmostDirection(170.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(LeftmostDirection(90.), TurnDirection::TurnRight, ());
-  TEST_EQUAL(LeftmostDirection(45.), TurnDirection::TurnSlightRight, ());
-  TEST_EQUAL(LeftmostDirection(0.), TurnDirection::TurnSlightLeft, ());
-  TEST_EQUAL(LeftmostDirection(-20.), TurnDirection::TurnSlightLeft, ());
-  TEST_EQUAL(LeftmostDirection(-90.), TurnDirection::TurnLeft, ());
-  TEST_EQUAL(LeftmostDirection(-170.), TurnDirection::TurnSharpLeft, ());
+  TEST_EQUAL(LeftmostDirection(180.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(LeftmostDirection(170.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(LeftmostDirection(90.), CarDirection::TurnRight, ());
+  TEST_EQUAL(LeftmostDirection(45.), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(LeftmostDirection(0.), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(LeftmostDirection(-20.), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(LeftmostDirection(-90.), CarDirection::TurnLeft, ());
+  TEST_EQUAL(LeftmostDirection(-170.), CarDirection::TurnSharpLeft, ());
 }
 
 UNIT_TEST(TestIntermediateDirection)
 {
-  TEST_EQUAL(IntermediateDirection(180.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(IntermediateDirection(170.), TurnDirection::TurnSharpRight, ());
-  TEST_EQUAL(IntermediateDirection(90.), TurnDirection::TurnRight, ());
-  TEST_EQUAL(IntermediateDirection(45.), TurnDirection::TurnSlightRight, ());
-  TEST_EQUAL(IntermediateDirection(0.), TurnDirection::GoStraight, ());
-  TEST_EQUAL(IntermediateDirection(-20.), TurnDirection::TurnSlightLeft, ());
-  TEST_EQUAL(IntermediateDirection(-90.), TurnDirection::TurnLeft, ());
-  TEST_EQUAL(IntermediateDirection(-170.), TurnDirection::TurnSharpLeft, ());
+  TEST_EQUAL(IntermediateDirection(180.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(IntermediateDirection(170.), CarDirection::TurnSharpRight, ());
+  TEST_EQUAL(IntermediateDirection(90.), CarDirection::TurnRight, ());
+  TEST_EQUAL(IntermediateDirection(45.), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(IntermediateDirection(0.), CarDirection::GoStraight, ());
+  TEST_EQUAL(IntermediateDirection(-20.), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(IntermediateDirection(-90.), CarDirection::TurnLeft, ());
+  TEST_EQUAL(IntermediateDirection(-170.), CarDirection::TurnSharpLeft, ());
 }
 
 UNIT_TEST(TestCalculateMercatorDistanceAlongRoute)
@@ -351,10 +351,10 @@ UNIT_TEST(TestCheckUTurnOnRoute)
   // Zigzag test.
   TurnItem turn1;
   TEST_EQUAL(CheckUTurnOnRoute(pathSegments, 1, turn1), 1, ());
-  TEST_EQUAL(turn1.m_turn, TurnDirection::UTurnLeft, ());
+  TEST_EQUAL(turn1.m_turn, CarDirection::UTurnLeft, ());
   TurnItem turn2;
   TEST_EQUAL(CheckUTurnOnRoute(pathSegments, 2, turn2), 1, ());
-  TEST_EQUAL(turn2.m_turn, TurnDirection::UTurnLeft, ());
+  TEST_EQUAL(turn2.m_turn, CarDirection::UTurnLeft, ());
 
   // Empty path test.
   TurnItem turn3;

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -107,20 +107,20 @@ UNIT_TEST(TurnsSoundMetersTest)
   notificationManager.Reset();
   notificationManager.SetSpeedMetersPerSecond(30.);
 
-  vector<TurnItemDist> turns = {{{5 /* idx */, TurnDirection::TurnRight}, 1000.}};
+  vector<TurnItemDist> turns = {{{5 /* idx */, CarDirection::TurnRight}, 1000.}};
   vector<string> turnNotifications;
 
   // Starting nearing the turnItem.
   // 1000 meters till the turn. No sound notifications is required.
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 700 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 700.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 699 meters till the turn. It's time to pronounce the first voice notification.
   // Why? The current speed is 30 meters per seconds. According to correctSettingsMeters
@@ -132,13 +132,13 @@ UNIT_TEST(TurnsSoundMetersTest)
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification1 = {{"In 600 meters. Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification1, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 650 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 650.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   notificationManager.SetSpeedMetersPerSecond(32.);
 
@@ -146,38 +146,38 @@ UNIT_TEST(TurnsSoundMetersTest)
   turns.front().m_distMeters = 150.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 100 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 100.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 99 meters till the turn. It's time to pronounce the second voice notification.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification2 = {{"Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 99 meters till the turn again. No sound notifications is required.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 50 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 50.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 0 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 0.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   TEST(notificationManager.IsEnabled(), ());
 }
@@ -206,7 +206,7 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
   notificationManager.Reset();
   notificationManager.SetSpeedMetersPerSecond(35.);
 
-  vector<TurnItemDist> turns = {{{5 /* idx */, TurnDirection::TurnSharpRight}, 800.}};
+  vector<TurnItemDist> turns = {{{5 /* idx */, CarDirection::TurnSharpRight}, 800.}};
   vector<string> turnNotifications;
 
   // Starting nearing the first turn.
@@ -246,7 +246,7 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
 
-  vector<TurnItemDist> turns2 = {{{11 /* idx */, TurnDirection::EnterRoundAbout,
+  vector<TurnItemDist> turns2 = {{{11 /* idx */, CarDirection::EnterRoundAbout,
                                          2 /* exitNum */}, 60.}};
 
   // Starting nearing the second turn.
@@ -282,7 +282,7 @@ UNIT_TEST(TurnsSoundFeetTest)
   notificationManager.Reset();
   notificationManager.SetSpeedMetersPerSecond(30.);
 
-  vector<TurnItemDist> turns = {{{7 /* idx */, TurnDirection::EnterRoundAbout,
+  vector<TurnItemDist> turns = {{{7 /* idx */, CarDirection::EnterRoundAbout,
                                   3 /* exitNum */}, 1000.}};
   vector<string> turnNotifications;
 
@@ -371,56 +371,56 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
 
   // Starting nearing the first turn.
   // 800 meters till the first turn.
-  vector<TurnItemDist> const turns1 = {{{5 /* idx */, TurnDirection::TurnRight}, 800. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::EnterRoundAbout}, 1000. /* m_distMeters */}};
+  vector<TurnItemDist> const turns1 = {{{5 /* idx */, CarDirection::TurnRight}, 800. /* m_distMeters */},
+                                       {{10 /* idx */, CarDirection::EnterRoundAbout}, 1000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 620 meters till the first turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns2 = {{{5 /* idx */, TurnDirection::TurnRight}, 620. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::EnterRoundAbout}, 820. /* m_distMeters */}};
+  vector<TurnItemDist> const turns2 = {{{5 /* idx */, CarDirection::TurnRight}, 620. /* m_distMeters */},
+                                       {{10 /* idx */, CarDirection::EnterRoundAbout}, 820. /* m_distMeters */}};
   vector<string> const expectedNotification2 = {{"In 600 meters. Turn right."},
                                                 {"Then. Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns2, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
 
   // 300 meters till the first turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns3 = {{{5 /* idx */, TurnDirection::TurnRight}, 300. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::EnterRoundAbout}, 500. /* m_distMeters */}};
+  vector<TurnItemDist> const turns3 = {{{5 /* idx */, CarDirection::TurnRight}, 300. /* m_distMeters */},
+                                       {{10 /* idx */, CarDirection::EnterRoundAbout}, 500. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns3, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
 
   // 20 meters till the first turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns4 = {{{5 /* idx */, TurnDirection::TurnRight}, 20. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::EnterRoundAbout}, 220. /* m_distMeters */}};
+  vector<TurnItemDist> const turns4 = {{{5 /* idx */, CarDirection::TurnRight}, 20. /* m_distMeters */},
+                                       {{10 /* idx */, CarDirection::EnterRoundAbout}, 220. /* m_distMeters */}};
   vector<string> const expectedNotification4 = {{"Turn right."},
                                                 {"Then. Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns4, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification4, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
 
   // After the first turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns5 = {{{10 /* idx */, TurnDirection::EnterRoundAbout}, 180. /* m_distMeters */},
-                                       {{15 /* idx */, TurnDirection::ReachedYourDestination}, 1180. /* m_distMeters */}};
+  vector<TurnItemDist> const turns5 = {{{10 /* idx */, CarDirection::EnterRoundAbout}, 180. /* m_distMeters */},
+                                       {{15 /* idx */, CarDirection::ReachedYourDestination}, 1180. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // Just before the second turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns6 = {{{10 /* idx */, TurnDirection::EnterRoundAbout}, 10. /* m_distMeters */},
-                                       {{15 /* idx */, TurnDirection::ReachedYourDestination}, 1010. /* m_distMeters */}};
+  vector<TurnItemDist> const turns6 = {{{10 /* idx */, CarDirection::EnterRoundAbout}, 10. /* m_distMeters */},
+                                       {{15 /* idx */, CarDirection::ReachedYourDestination}, 1010. /* m_distMeters */}};
   vector<string> const expectedNotification6 = {{"Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 }
 
 UNIT_TEST(TurnsSoundRoundaboutTurnTest)
@@ -450,68 +450,68 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
 
   // Starting nearing the first turn.
   // 1000 meters till the first turn.
-  vector<TurnItemDist> const turns1 = {{{5 /* idx */, TurnDirection::EnterRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns1 = {{{5 /* idx */, CarDirection::EnterRoundAbout, 2 /* m_exitNum */},
                                         1000. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+                                       {{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         2000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 620 meters till the first turn.
-  vector<TurnItemDist> const turns2 = {{{5 /* idx */, TurnDirection::EnterRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns2 = {{{5 /* idx */, CarDirection::EnterRoundAbout, 2 /* m_exitNum */},
                                         620. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+                                       {{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         1620. /* m_distMeters */}};
   vector<string> const expectedNotification2 = {{"In 600 meters. Enter the roundabout."},
                                                 {"Then. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns2, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 3 meters till the first turn.
-  vector<TurnItemDist> const turns3 = {{{5 /* idx */, TurnDirection::EnterRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns3 = {{{5 /* idx */, CarDirection::EnterRoundAbout, 2 /* m_exitNum */},
                                         3. /* m_distMeters */},
-                                       {{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+                                       {{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         1003. /* m_distMeters */}};
   vector<string> const expectedNotification3 = {{"Enter the roundabout."},
                                                 {"Then. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns3, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification3, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 900 meters till the second turn.
-  vector<TurnItemDist> const turns4 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns4 = {{{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         900. /* m_distMeters */},
-                                       {{15 /* idx */, TurnDirection::EnterRoundAbout, 1 /* m_exitNum */},
+                                       {{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */},
                                         1900. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns4, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 300 meters till the second turn.
-  vector<TurnItemDist> const turns5 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns5 = {{{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         300. /* m_distMeters */},
-                                       {{15 /* idx */, TurnDirection::EnterRoundAbout, 1 /* m_exitNum */},
+                                       {{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */},
                                         1300. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 3 meters till the second turn.
-  vector<TurnItemDist> const turns6 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
+  vector<TurnItemDist> const turns6 = {{{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */},
                                         3. /* m_distMeters */},
-                                       {{15 /* idx */, TurnDirection::EnterRoundAbout, 1 /* m_exitNum */},
+                                       {{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */},
                                         1003. /* m_distMeters */}};
   vector<string> const expectedNotification6 = {{"Leave the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 5 meters till the third turn.
-  vector<TurnItemDist> const turns7 = {{{15 /* idx */, TurnDirection::EnterRoundAbout, 1 /* m_exitNum */},
+  vector<TurnItemDist> const turns7 = {{{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */},
                                         5. /* m_distMeters */},
-                                       {{20 /* idx */, TurnDirection::LeaveRoundAbout, 1 /* m_exitNum */},
+                                       {{20 /* idx */, CarDirection::LeaveRoundAbout, 1 /* m_exitNum */},
                                         1005. /* m_distMeters */}};
   vector<string> const expectedNotification7 = {{"Enter the roundabout."},
                                                 {"Then. Take the first exit."}};
@@ -519,28 +519,28 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
       turns7, turnNotifications);  // The first notification fast forwarding.
   notificationManager.GenerateTurnNotifications(turns7, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification7, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 900 meters till the 4th turn.
   notificationManager.Reset();
-  vector<TurnItemDist> const turns8 = {{{25 /* idx */, TurnDirection::EnterRoundAbout, 4 /* m_exitNum */},
+  vector<TurnItemDist> const turns8 = {{{25 /* idx */, CarDirection::EnterRoundAbout, 4 /* m_exitNum */},
                                         900. /* m_distMeters */},
-                                       {{30 /* idx */, TurnDirection::LeaveRoundAbout, 4 /* m_exitNum */},
+                                       {{30 /* idx */, CarDirection::LeaveRoundAbout, 4 /* m_exitNum */},
                                         1200. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns8, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
 
   // 620 meters till the 4th turn.
-  vector<TurnItemDist> const turns9 = {{{25 /* idx */, TurnDirection::EnterRoundAbout, 4 /* m_exitNum */},
+  vector<TurnItemDist> const turns9 = {{{25 /* idx */, CarDirection::EnterRoundAbout, 4 /* m_exitNum */},
                                         620. /* m_distMeters */},
-                                       {{30 /* idx */, TurnDirection::LeaveRoundAbout, 4 /* m_exitNum */},
+                                       {{30 /* idx */, CarDirection::LeaveRoundAbout, 4 /* m_exitNum */},
                                         920. /* m_distMeters */}};
   vector<string> const expectedNotification9 = {{"In 600 meters. Enter the roundabout."},
                                                 {"Then. Take the fourth exit."}};
   notificationManager.GenerateTurnNotifications(turns9, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification9, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::LeaveRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::LeaveRoundAbout, ());
 }
 
 UNIT_TEST(GetJsonBufferTest)

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -114,13 +114,13 @@ UNIT_TEST(TurnsSoundMetersTest)
   // 1000 meters till the turn. No sound notifications is required.
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 700 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 700.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 699 meters till the turn. It's time to pronounce the first voice notification.
   // Why? The current speed is 30 meters per seconds. According to correctSettingsMeters
@@ -132,13 +132,13 @@ UNIT_TEST(TurnsSoundMetersTest)
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification1 = {{"In 600 meters. Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification1, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 650 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 650.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   notificationManager.SetSpeedMetersPerSecond(32.);
 
@@ -146,38 +146,38 @@ UNIT_TEST(TurnsSoundMetersTest)
   turns.front().m_distMeters = 150.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 100 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 100.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 99 meters till the turn. It's time to pronounce the second voice notification.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification2 = {{"Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 99 meters till the turn again. No sound notifications is required.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 50 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 50.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 0 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 0.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   TEST(notificationManager.IsEnabled(), ());
 }
@@ -375,7 +375,7 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
                                        {{10 /* idx */, TurnDirection::EnterRoundAbout}, 1000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 620 meters till the first turn.
   turnNotifications.clear();
@@ -411,7 +411,7 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
                                        {{15 /* idx */, TurnDirection::ReachedYourDestination}, 1180. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // Just before the second turn.
   turnNotifications.clear();
@@ -420,7 +420,7 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
   vector<string> const expectedNotification6 = {{"Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 }
 
 UNIT_TEST(TurnsSoundRoundaboutTurnTest)
@@ -456,7 +456,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                         2000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 620 meters till the first turn.
   vector<TurnItemDist> const turns2 = {{{5 /* idx */, TurnDirection::EnterRoundAbout, 2 /* m_exitNum */},
@@ -467,7 +467,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                                 {"Then. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns2, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 3 meters till the first turn.
   vector<TurnItemDist> const turns3 = {{{5 /* idx */, TurnDirection::EnterRoundAbout, 2 /* m_exitNum */},
@@ -478,7 +478,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                                 {"Then. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns3, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification3, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 900 meters till the second turn.
   vector<TurnItemDist> const turns4 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
@@ -487,7 +487,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                         1900. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns4, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 300 meters till the second turn.
   vector<TurnItemDist> const turns5 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
@@ -496,7 +496,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                         1300. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 3 meters till the second turn.
   vector<TurnItemDist> const turns6 = {{{10 /* idx */, TurnDirection::LeaveRoundAbout, 2 /* m_exitNum */},
@@ -506,7 +506,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
   vector<string> const expectedNotification6 = {{"Leave the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 5 meters till the third turn.
   vector<TurnItemDist> const turns7 = {{{15 /* idx */, TurnDirection::EnterRoundAbout, 1 /* m_exitNum */},
@@ -519,7 +519,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
       turns7, turnNotifications);  // The first notification fast forwarding.
   notificationManager.GenerateTurnNotifications(turns7, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification7, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 900 meters till the 4th turn.
   notificationManager.Reset();
@@ -529,7 +529,7 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
                                         1200. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns8, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::NoTurn, ());
+  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), TurnDirection::None, ());
 
   // 620 meters till the 4th turn.
   vector<TurnItemDist> const turns9 = {{{25 /* idx */, TurnDirection::EnterRoundAbout, 4 /* m_exitNum */},

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -19,17 +19,17 @@ bool PairDistEquals(PairDist const & lhs, PairDist const & rhs)
 UNIT_TEST(GetDistanceTextIdMetersTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::TurnRight,
+  //    CarDirection turnDir, ::Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDistanceTextId(notification1), "in_500_meters", ());
-  Notification const notification2(500, 0, true, TurnDirection::TurnRight,
+  Notification const notification2(500, 0, true, CarDirection::TurnRight,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDistanceTextId(notification2), "then", ());
-  Notification const notification3(200, 0, false, TurnDirection::TurnRight,
+  Notification const notification3(200, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDistanceTextId(notification3), "in_200_meters", ());
-  Notification const notification4(2000, 0, false, TurnDirection::TurnRight,
+  Notification const notification4(2000, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDistanceTextId(notification4), "in_2_kilometers", ());
 }
@@ -37,17 +37,17 @@ UNIT_TEST(GetDistanceTextIdMetersTest)
 UNIT_TEST(GetDistanceTextIdFeetTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::TurnRight,
+  //    CarDirection turnDir, ::Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetDistanceTextId(notification1), "in_500_feet", ());
-  Notification const notification2(500, 0, true, TurnDirection::TurnRight,
+  Notification const notification2(500, 0, true, CarDirection::TurnRight,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetDistanceTextId(notification2), "then", ());
-  Notification const notification3(800, 0, false, TurnDirection::TurnRight,
+  Notification const notification3(800, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetDistanceTextId(notification3), "in_800_feet", ());
-  Notification const notification4(5000, 0, false, TurnDirection::TurnRight,
+  Notification const notification4(5000, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetDistanceTextId(notification4), "in_5000_feet", ());
 }
@@ -55,17 +55,17 @@ UNIT_TEST(GetDistanceTextIdFeetTest)
 UNIT_TEST(GetRoundaboutTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::LeaveRoundAbout,
+  //    CarDirection turnDir, ::Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::LeaveRoundAbout,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetRoundaboutTextId(notification1), "leave_the_roundabout", ());
-  Notification const notification2(0, 3, true, TurnDirection::LeaveRoundAbout,
+  Notification const notification2(0, 3, true, CarDirection::LeaveRoundAbout,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetRoundaboutTextId(notification2), "take_the_3_exit", ());
-  Notification const notification3(0, 7, true, TurnDirection::LeaveRoundAbout,
+  Notification const notification3(0, 7, true, CarDirection::LeaveRoundAbout,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetRoundaboutTextId(notification3), "take_the_7_exit", ());
-  Notification const notification4(0, 15, true, TurnDirection::LeaveRoundAbout,
+  Notification const notification4(0, 15, true, CarDirection::LeaveRoundAbout,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetRoundaboutTextId(notification4), "leave_the_roundabout", ());
 }
@@ -73,14 +73,14 @@ UNIT_TEST(GetRoundaboutTextIdTest)
 UNIT_TEST(GetYouArriveTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::ReachedYourDestination,
+  //    CarDirection turnDir, ::Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetYouArriveTextId(notification1), "destination", ());
-  Notification const notification2(0, 0, false, TurnDirection::ReachedYourDestination,
+  Notification const notification2(0, 0, false, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetYouArriveTextId(notification2), "you_have_reached_the_destination", ());
-  Notification const notification3(0, 0, true, TurnDirection::ReachedYourDestination,
+  Notification const notification3(0, 0, true, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetYouArriveTextId(notification3), "destination", ());
 }
@@ -88,20 +88,20 @@ UNIT_TEST(GetYouArriveTextIdTest)
 UNIT_TEST(GetDirectionTextIdTest)
 {
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, ::Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::TurnRight,
+  //    CarDirection turnDir, ::Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Imperial);
   TEST_EQUAL(GetDirectionTextId(notification1), "make_a_right_turn", ());
-  Notification const notification2(1000, 0, false, TurnDirection::GoStraight,
+  Notification const notification2(1000, 0, false, CarDirection::GoStraight,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDirectionTextId(notification2), "go_straight", ());
-  Notification const notification3(700, 0, false, TurnDirection::UTurnLeft,
+  Notification const notification3(700, 0, false, CarDirection::UTurnLeft,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDirectionTextId(notification3), "make_a_u_turn", ());
-  Notification const notification4(200, 0, false, TurnDirection::ReachedYourDestination,
+  Notification const notification4(200, 0, false, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDirectionTextId(notification4), "destination", ());
-  Notification const notification5(0, 0, false, TurnDirection::ReachedYourDestination,
+  Notification const notification5(0, 0, false, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Metric);
   TEST_EQUAL(GetDirectionTextId(notification5), "you_have_reached_the_destination", ());
 }
@@ -132,14 +132,14 @@ UNIT_TEST(GetTtsTextTest)
 
   GetTtsText getTtsText;
   // Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-  //    TurnDirection turnDir, Settings::Units lengthUnits)
-  Notification const notification1(500, 0, false, TurnDirection::TurnRight,
+  //    CarDirection turnDir, Settings::Units lengthUnits)
+  Notification const notification1(500, 0, false, CarDirection::TurnRight,
                                    measurement_utils::Units::Metric);
-  Notification const notification2(300, 0, false, TurnDirection::TurnLeft,
+  Notification const notification2(300, 0, false, CarDirection::TurnLeft,
                                    measurement_utils::Units::Metric);
-  Notification const notification3(0, 0, false, TurnDirection::ReachedYourDestination,
+  Notification const notification3(0, 0, false, CarDirection::ReachedYourDestination,
                                    measurement_utils::Units::Metric);
-  Notification const notification4(0, 0, true, TurnDirection::TurnLeft,
+  Notification const notification4(0, 0, true, CarDirection::TurnLeft,
                                    measurement_utils::Units::Metric);
 
   getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -28,24 +28,24 @@ array<pair<LaneWay, char const *>, static_cast<size_t>(LaneWay::Count)> const g_
 static_assert(g_laneWayNames.size() == static_cast<size_t>(LaneWay::Count),
               "Check the size of g_laneWayNames");
 
-array<pair<TurnDirection, char const *>, static_cast<size_t>(TurnDirection::Count)> const g_turnNames = {
-    {{TurnDirection::None, "None"},
-     {TurnDirection::GoStraight, "GoStraight"},
-     {TurnDirection::TurnRight, "TurnRight"},
-     {TurnDirection::TurnSharpRight, "TurnSharpRight"},
-     {TurnDirection::TurnSlightRight, "TurnSlightRight"},
-     {TurnDirection::TurnLeft, "TurnLeft"},
-     {TurnDirection::TurnSharpLeft, "TurnSharpLeft"},
-     {TurnDirection::TurnSlightLeft, "TurnSlightLeft"},
-     {TurnDirection::UTurnLeft, "UTurnLeft"},
-     {TurnDirection::UTurnRight, "UTurnRight"},
-     {TurnDirection::TakeTheExit, "TakeTheExit"},
-     {TurnDirection::EnterRoundAbout, "EnterRoundAbout"},
-     {TurnDirection::LeaveRoundAbout, "LeaveRoundAbout"},
-     {TurnDirection::StayOnRoundAbout, "StayOnRoundAbout"},
-     {TurnDirection::StartAtEndOfStreet, "StartAtEndOfStreet"},
-     {TurnDirection::ReachedYourDestination, "ReachedYourDestination"}}};
-static_assert(g_turnNames.size() == static_cast<size_t>(TurnDirection::Count),
+array<pair<CarDirection, char const *>, static_cast<size_t>(CarDirection::Count)> const g_turnNames = {
+    {{CarDirection::None, "None"},
+     {CarDirection::GoStraight, "GoStraight"},
+     {CarDirection::TurnRight, "TurnRight"},
+     {CarDirection::TurnSharpRight, "TurnSharpRight"},
+     {CarDirection::TurnSlightRight, "TurnSlightRight"},
+     {CarDirection::TurnLeft, "TurnLeft"},
+     {CarDirection::TurnSharpLeft, "TurnSharpLeft"},
+     {CarDirection::TurnSlightLeft, "TurnSlightLeft"},
+     {CarDirection::UTurnLeft, "UTurnLeft"},
+     {CarDirection::UTurnRight, "UTurnRight"},
+     {CarDirection::TakeTheExit, "TakeTheExit"},
+     {CarDirection::EnterRoundAbout, "EnterRoundAbout"},
+     {CarDirection::LeaveRoundAbout, "LeaveRoundAbout"},
+     {CarDirection::StayOnRoundAbout, "StayOnRoundAbout"},
+     {CarDirection::StartAtEndOfStreet, "StartAtEndOfStreet"},
+     {CarDirection::ReachedYourDestination, "ReachedYourDestination"}}};
+static_assert(g_turnNames.size() == static_cast<size_t>(CarDirection::Count),
               "Check the size of g_turnNames");
 }  // namespace
 
@@ -175,7 +175,7 @@ string DebugPrint(TurnItemDist const & turnItemDist)
   return out.str();
 }
 
-string const GetTurnString(TurnDirection turn)
+string const GetTurnString(CarDirection turn)
 {
   for (auto const & p : g_turnNames)
   {
@@ -184,84 +184,84 @@ string const GetTurnString(TurnDirection turn)
   }
 
   stringstream out;
-  out << "unknown TurnDirection (" << static_cast<int>(turn) << ")";
+  out << "unknown CarDirection (" << static_cast<int>(turn) << ")";
   return out.str();
 }
 
-bool IsLeftTurn(TurnDirection t)
+bool IsLeftTurn(CarDirection t)
 {
-  return (t >= TurnDirection::TurnLeft && t <= TurnDirection::TurnSlightLeft);
+  return (t >= CarDirection::TurnLeft && t <= CarDirection::TurnSlightLeft);
 }
 
-bool IsRightTurn(TurnDirection t)
+bool IsRightTurn(CarDirection t)
 {
-  return (t >= TurnDirection::TurnRight && t <= TurnDirection::TurnSlightRight);
+  return (t >= CarDirection::TurnRight && t <= CarDirection::TurnSlightRight);
 }
 
-bool IsLeftOrRightTurn(TurnDirection t)
+bool IsLeftOrRightTurn(CarDirection t)
 {
   return IsLeftTurn(t) || IsRightTurn(t);
 }
 
-bool IsStayOnRoad(TurnDirection t)
+bool IsStayOnRoad(CarDirection t)
 {
-  return (t == TurnDirection::GoStraight || t == TurnDirection::StayOnRoundAbout);
+  return (t == CarDirection::GoStraight || t == CarDirection::StayOnRoundAbout);
 }
 
-bool IsGoStraightOrSlightTurn(TurnDirection t)
+bool IsGoStraightOrSlightTurn(CarDirection t)
 {
-  return (t == TurnDirection::GoStraight || t == TurnDirection::TurnSlightLeft ||
-          t == TurnDirection::TurnSlightRight);
+  return (t == CarDirection::GoStraight || t == CarDirection::TurnSlightLeft ||
+          t == CarDirection::TurnSlightRight);
 }
 
-bool IsLaneWayConformedTurnDirection(LaneWay l, TurnDirection t)
+bool IsLaneWayConformedTurnDirection(LaneWay l, CarDirection t)
 {
   switch (t)
   {
     default:
       return false;
-    case TurnDirection::GoStraight:
+    case CarDirection::GoStraight:
       return l == LaneWay::Through;
-    case TurnDirection::TurnRight:
+    case CarDirection::TurnRight:
       return l == LaneWay::Right;
-    case TurnDirection::TurnSharpRight:
+    case CarDirection::TurnSharpRight:
       return l == LaneWay::SharpRight;
-    case TurnDirection::TurnSlightRight:
+    case CarDirection::TurnSlightRight:
       return l == LaneWay::SlightRight;
-    case TurnDirection::TurnLeft:
+    case CarDirection::TurnLeft:
       return l == LaneWay::Left;
-    case TurnDirection::TurnSharpLeft:
+    case CarDirection::TurnSharpLeft:
       return l == LaneWay::SharpLeft;
-    case TurnDirection::TurnSlightLeft:
+    case CarDirection::TurnSlightLeft:
       return l == LaneWay::SlightLeft;
-    case TurnDirection::UTurnLeft:
-    case TurnDirection::UTurnRight:
+    case CarDirection::UTurnLeft:
+    case CarDirection::UTurnRight:
       return l == LaneWay::Reverse;
   }
 }
 
-bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, TurnDirection t)
+bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, CarDirection t)
 {
   switch (t)
   {
     default:
       return false;
-    case TurnDirection::GoStraight:
+    case CarDirection::GoStraight:
       return l == LaneWay::Through || l == LaneWay::SlightRight || l == LaneWay::SlightLeft;
-    case TurnDirection::TurnRight:
+    case CarDirection::TurnRight:
       return l == LaneWay::Right || l == LaneWay::SharpRight || l == LaneWay::SlightRight;
-    case TurnDirection::TurnSharpRight:
+    case CarDirection::TurnSharpRight:
       return l == LaneWay::SharpRight || l == LaneWay::Right;
-    case TurnDirection::TurnSlightRight:
+    case CarDirection::TurnSlightRight:
       return l == LaneWay::SlightRight || l == LaneWay::Through || l == LaneWay::Right;
-    case TurnDirection::TurnLeft:
+    case CarDirection::TurnLeft:
       return l == LaneWay::Left || l == LaneWay::SlightLeft || l == LaneWay::SharpLeft;
-    case TurnDirection::TurnSharpLeft:
+    case CarDirection::TurnSharpLeft:
       return l == LaneWay::SharpLeft || l == LaneWay::Left;
-    case TurnDirection::TurnSlightLeft:
+    case CarDirection::TurnSlightLeft:
       return l == LaneWay::SlightLeft || l == LaneWay::Through || l == LaneWay::Left;
-    case TurnDirection::UTurnLeft:
-    case TurnDirection::UTurnRight:
+    case CarDirection::UTurnLeft:
+    case CarDirection::UTurnRight:
       return l == LaneWay::Reverse;
   }
 }
@@ -337,7 +337,7 @@ string DebugPrint(LaneWay const l)
   return it->second;
 }
 
-string DebugPrint(TurnDirection const turn)
+string DebugPrint(CarDirection const turn)
 {
   stringstream out;
   out << "[ " << GetTurnString(turn) << " ]";

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -29,7 +29,7 @@ static_assert(g_laneWayNames.size() == static_cast<size_t>(LaneWay::Count),
               "Check the size of g_laneWayNames");
 
 array<pair<TurnDirection, char const *>, static_cast<size_t>(TurnDirection::Count)> const g_turnNames = {
-    {{TurnDirection::NoTurn, "NoTurn"},
+    {{TurnDirection::None, "None"},
      {TurnDirection::GoStraight, "GoStraight"},
      {TurnDirection::TurnRight, "TurnRight"},
      {TurnDirection::TurnSharpRight, "TurnSharpRight"},

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -72,7 +72,7 @@ double constexpr kFeaturesNearTurnMeters = 3.0;
  * \warning The values of TurnDirection shall be synchronized with values of TurnDirection enum in
  * java.
  */
-enum class TurnDirection
+enum class CarDirection
 {
   None = 0,
   GoStraight,
@@ -99,7 +99,7 @@ enum class TurnDirection
   Count  /**< This value is used for internals only. */
 };
 
-string DebugPrint(TurnDirection const l);
+string DebugPrint(CarDirection const l);
 
 /*!
  * \warning The values of PedestrianDirectionType shall be synchronized with values in java
@@ -156,21 +156,21 @@ struct TurnItem
 {
   TurnItem()
       : m_index(numeric_limits<uint32_t>::max()),
-        m_turn(TurnDirection::None),
+        m_turn(CarDirection::None),
         m_exitNum(0),
         m_keepAnyway(false),
         m_pedestrianTurn(PedestrianDirection::None)
   {
   }
 
-  TurnItem(uint32_t idx, TurnDirection t, uint32_t exitNum = 0)
+  TurnItem(uint32_t idx, CarDirection t, uint32_t exitNum = 0)
       : m_index(idx), m_turn(t), m_exitNum(exitNum), m_keepAnyway(false)
       , m_pedestrianTurn(PedestrianDirection::None)
   {
   }
 
   TurnItem(uint32_t idx, PedestrianDirection p)
-      : m_index(idx), m_turn(TurnDirection::None), m_exitNum(0), m_keepAnyway(false)
+      : m_index(idx), m_turn(CarDirection::None), m_exitNum(0), m_keepAnyway(false)
       , m_pedestrianTurn(p)
   {
   }
@@ -184,7 +184,7 @@ struct TurnItem
   }
 
   uint32_t m_index;               /*!< Index of point on route polyline (number of segment + 1). */
-  TurnDirection m_turn;           /*!< The turn instruction of the TurnItem */
+  CarDirection m_turn;            /*!< The turn instruction of the TurnItem */
   vector<SingleLaneInfo> m_lanes; /*!< Lane information on the edge before the turn. */
   uint32_t m_exitNum;             /*!< Number of exit on roundabout. */
   string m_sourceName;            /*!< Name of the street which the ingoing edge belongs to */
@@ -211,13 +211,13 @@ struct TurnItemDist
 
 string DebugPrint(TurnItemDist const & turnItemDist);
 
-string const GetTurnString(TurnDirection turn);
+string const GetTurnString(CarDirection turn);
 
-bool IsLeftTurn(TurnDirection t);
-bool IsRightTurn(TurnDirection t);
-bool IsLeftOrRightTurn(TurnDirection t);
-bool IsStayOnRoad(TurnDirection t);
-bool IsGoStraightOrSlightTurn(TurnDirection t);
+bool IsLeftTurn(CarDirection t);
+bool IsRightTurn(CarDirection t);
+bool IsLeftOrRightTurn(CarDirection t);
+bool IsStayOnRoad(CarDirection t);
+bool IsGoStraightOrSlightTurn(CarDirection t);
 
 /*!
  * \param l A variant of going along a lane.
@@ -226,7 +226,7 @@ bool IsGoStraightOrSlightTurn(TurnDirection t);
  * when @l equals to LaneWay::Right and @t equals to TurnDirection::TurnRight.
  * Otherwise it returns false.
  */
-bool IsLaneWayConformedTurnDirection(LaneWay l, TurnDirection t);
+bool IsLaneWayConformedTurnDirection(LaneWay l, CarDirection t);
 
 /*!
  * \param l A variant of going along a lane.
@@ -235,7 +235,7 @@ bool IsLaneWayConformedTurnDirection(LaneWay l, TurnDirection t);
  * when @l equals to LaneWay::Right and @t equals to TurnDirection::TurnSlightRight.
  * Otherwise it returns false.
  */
-bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, TurnDirection t);
+bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, CarDirection t);
 
 /*!
  * \brief Parse lane information which comes from @lanesString

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -74,7 +74,7 @@ double constexpr kFeaturesNearTurnMeters = 3.0;
  */
 enum class TurnDirection
 {
-  NoTurn = 0,
+  None = 0,
   GoStraight,
 
   TurnRight,
@@ -156,7 +156,7 @@ struct TurnItem
 {
   TurnItem()
       : m_index(numeric_limits<uint32_t>::max()),
-        m_turn(TurnDirection::NoTurn),
+        m_turn(TurnDirection::None),
         m_exitNum(0),
         m_keepAnyway(false),
         m_pedestrianTurn(PedestrianDirection::None)
@@ -170,7 +170,7 @@ struct TurnItem
   }
 
   TurnItem(uint32_t idx, PedestrianDirection p)
-      : m_index(idx), m_turn(TurnDirection::NoTurn), m_exitNum(0), m_keepAnyway(false)
+      : m_index(idx), m_turn(TurnDirection::None), m_exitNum(0), m_keepAnyway(false)
       , m_pedestrianTurn(p)
   {
   }

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -165,7 +165,7 @@ TurnDirection FindDirectionByAngle(vector<pair<double, TurnDirection>> const & l
   }
 
   ASSERT(false, ("The angle is not covered by the table. angle = ", angle));
-  return TurnDirection::NoTurn;
+  return TurnDirection::None;
 }
 
 /*!
@@ -286,11 +286,11 @@ IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result,
 
       turns::TurnInfo turnInfo(loadedSegments[segmentIndex - 1], *loadedSegmentIt);
 
-      if (turnItem.m_turn == turns::TurnDirection::NoTurn)
+      if (turnItem.m_turn == turns::TurnDirection::None)
         turns::GetTurnDirection(result, turnInfo, turnItem);
 
       //  Lane information.
-      if (turnItem.m_turn != turns::TurnDirection::NoTurn)
+      if (turnItem.m_turn != turns::TurnDirection::None)
       {
         turnItem.m_lanes = turnInfo.m_ingoing.m_lanes;
         turnsDir.push_back(move(turnItem));
@@ -470,8 +470,8 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
   if (isIngoingEdgeRoundabout && isOutgoingEdgeRoundabout)
   {
     if (isMultiTurnJunction)
-      return keepTurnByHighwayClass ? TurnDirection::StayOnRoundAbout : TurnDirection::NoTurn;
-    return TurnDirection::NoTurn;
+      return keepTurnByHighwayClass ? TurnDirection::StayOnRoundAbout : TurnDirection::None;
+    return TurnDirection::None;
   }
 
   if (CheckRoundaboutEntrance(isIngoingEdgeRoundabout, isOutgoingEdgeRoundabout))
@@ -481,7 +481,7 @@ TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoi
     return TurnDirection::LeaveRoundAbout;
 
   ASSERT(false, ());
-  return TurnDirection::NoTurn;
+  return TurnDirection::None;
 }
 
 TurnDirection InvertDirection(TurnDirection dir)
@@ -563,7 +563,7 @@ void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnIt
   turn.m_keepAnyway = (!turnInfo.m_ingoing.m_isLink && turnInfo.m_outgoing.m_isLink);
   turn.m_sourceName = turnInfo.m_ingoing.m_name;
   turn.m_targetName = turnInfo.m_outgoing.m_name;
-  turn.m_turn = TurnDirection::NoTurn;
+  turn.m_turn = TurnDirection::None;
   // Early filtering based only on the information about ingoing and outgoing edges.
   if (DiscardTurnByIngoingAndOutgoingEdges(intermediateDirection, turnInfo, turn))
     return;
@@ -608,7 +608,7 @@ void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnIt
   bool const keepTurnByHighwayClass = KeepTurnByHighwayClass(turn.m_turn, nodes, turnInfo);
   if (!turn.m_keepAnyway && !keepTurnByHighwayClass)
   {
-    turn.m_turn = TurnDirection::NoTurn;
+    turn.m_turn = TurnDirection::None;
     return;
   }
 
@@ -619,14 +619,14 @@ void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnIt
   if (!KeepTurnByIngoingEdges(junctionPoint, notSoCloseToTheTurnPoint, outgoingPoint, hasMultiTurns,
                               nodes.candidates.size() + ingoingCount))
   {
-    turn.m_turn = TurnDirection::NoTurn;
+    turn.m_turn = TurnDirection::None;
     return;
   }
 
   if (turn.m_turn == TurnDirection::GoStraight)
   {
     if (!hasMultiTurns)
-      turn.m_turn = TurnDirection::NoTurn;
+      turn.m_turn = TurnDirection::None;
     return;
   }
 }

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -78,21 +78,21 @@ void SelectRecommendedLanes(Route::TTurns & turnsDir);
 void FixupTurns(vector<Junction> const & points, Route::TTurns & turnsDir);
 inline size_t GetFirstSegmentPointIndex(pair<size_t, size_t> const & p) { return p.first; }
 
-TurnDirection InvertDirection(TurnDirection dir);
+CarDirection InvertDirection(CarDirection dir);
 
 /*!
  * \param angle is an angle of a turn. It belongs to a range [-180, 180].
  * \return correct direction if the route follows along the rightmost possible way.
  */
-TurnDirection RightmostDirection(double angle);
-TurnDirection LeftmostDirection(double angle);
+CarDirection RightmostDirection(double angle);
+CarDirection LeftmostDirection(double angle);
 
 /*!
  * \param angle is an angle of a turn. It belongs to a range [-180, 180].
  * \return correct direction if the route follows not along one of two outermost ways
  * or if there is only one possible way.
  */
-TurnDirection IntermediateDirection(double angle);
+CarDirection IntermediateDirection(double angle);
 
 /*!
  * \return Returns true if the route enters a roundabout.
@@ -122,7 +122,7 @@ bool CheckRoundaboutExit(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRounda
  *   (b) and there is a way(s) besides outgoing edge to leave the junction (the roundabout)
  *       but it is (they are) relevantly small.
  */
-TurnDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRoundabout,
+CarDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRoundabout,
                                      bool isMultiTurnJunction, bool keepTurnByHighwayClass);
 
 /*!

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -186,7 +186,7 @@ void NotificationManager::Reset()
   m_nextTurnNotificationProgress = PronouncedNotification::Nothing;
   m_nextTurnIndex = 0;
   m_turnNotificationWithThen = false;
-  m_secondTurnNotification = TurnDirection::NoTurn;
+  m_secondTurnNotification = TurnDirection::None;
   m_secondTurnNotificationIndex = 0;
 }
 
@@ -202,7 +202,7 @@ TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnIte
   if (turns.size() < 2)
   {
     m_secondTurnNotificationIndex = 0;
-    return TurnDirection::NoTurn;
+    return TurnDirection::None;
   }
 
   TurnItemDist const & firstTurn = turns[0];
@@ -217,7 +217,7 @@ TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnIte
   ASSERT_LESS_OR_EQUAL(0., distBetweenTurnsMeters, ());
 
   if (distBetweenTurnsMeters > kMaxTurnDistM)
-    return TurnDirection::NoTurn;
+    return TurnDirection::None;
 
   uint32_t const startPronounceDistMeters =
       m_settings.ComputeTurnDistanceM(m_speedMetersPerSecond) +
@@ -227,7 +227,7 @@ TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnIte
     m_secondTurnNotificationIndex = firstTurn.m_turnItem.m_index;
     return secondTurn.m_turnItem.m_turn;  // It's time to inform about the turn after the next one.
   }
-  return TurnDirection::NoTurn;
+  return TurnDirection::None;
 }
 
 string DebugPrint(PronouncedNotification const notificationProgress)

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -19,8 +19,8 @@ double constexpr kMaxTurnDistM = 400.;
 bool IsClassicEntranceToRoundabout(routing::turns::TurnItemDist const & firstTurn,
                                    routing::turns::TurnItemDist const & secondTurn)
 {
-  return firstTurn.m_turnItem.m_turn == routing::turns::TurnDirection::EnterRoundAbout &&
-         secondTurn.m_turnItem.m_turn == routing::turns::TurnDirection::LeaveRoundAbout;
+  return firstTurn.m_turnItem.m_turn == routing::turns::CarDirection::EnterRoundAbout &&
+         secondTurn.m_turnItem.m_turn == routing::turns::CarDirection::LeaveRoundAbout;
 }
 }  // namespace
 
@@ -31,7 +31,7 @@ namespace turns
 namespace sound
 {
 string NotificationManager::GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum,
-                                             bool useThenInsteadOfDistance, TurnDirection turnDir,
+                                             bool useThenInsteadOfDistance, CarDirection turnDir,
                                              measurement_utils::Units lengthUnits) const
 {
   Notification const notification(distanceUnits, exitNum, useThenInsteadOfDistance, turnDir,
@@ -186,7 +186,7 @@ void NotificationManager::Reset()
   m_nextTurnNotificationProgress = PronouncedNotification::Nothing;
   m_nextTurnIndex = 0;
   m_turnNotificationWithThen = false;
-  m_secondTurnNotification = TurnDirection::None;
+  m_secondTurnNotification = CarDirection::None;
   m_secondTurnNotificationIndex = 0;
 }
 
@@ -197,12 +197,12 @@ void NotificationManager::FastForwardFirstTurnNotification()
     m_nextTurnNotificationProgress = PronouncedNotification::First;
 }
 
-TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnItemDist> const & turns)
+CarDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnItemDist> const & turns)
 {
   if (turns.size() < 2)
   {
     m_secondTurnNotificationIndex = 0;
-    return TurnDirection::None;
+    return CarDirection::None;
   }
 
   TurnItemDist const & firstTurn = turns[0];
@@ -217,7 +217,7 @@ TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnIte
   ASSERT_LESS_OR_EQUAL(0., distBetweenTurnsMeters, ());
 
   if (distBetweenTurnsMeters > kMaxTurnDistM)
-    return TurnDirection::None;
+    return CarDirection::None;
 
   uint32_t const startPronounceDistMeters =
       m_settings.ComputeTurnDistanceM(m_speedMetersPerSecond) +
@@ -227,7 +227,7 @@ TurnDirection NotificationManager::GenerateSecondTurnNotification(vector<TurnIte
     m_secondTurnNotificationIndex = firstTurn.m_turnItem.m_index;
     return secondTurn.m_turnItem.m_turn;  // It's time to inform about the turn after the next one.
   }
-  return TurnDirection::None;
+  return CarDirection::None;
 }
 
 string DebugPrint(PronouncedNotification const notificationProgress)

--- a/routing/turns_notification_manager.hpp
+++ b/routing/turns_notification_manager.hpp
@@ -51,7 +51,7 @@ class NotificationManager
     , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
     , m_turnNotificationWithThen(false)
     , m_nextTurnIndex(0)
-    , m_secondTurnNotification(TurnDirection::None)
+    , m_secondTurnNotification(CarDirection::None)
   {
   }
 
@@ -90,7 +90,7 @@ class NotificationManager
   /// m_secondTurnNotification is a direction of the turn after the closest one
   /// if an end user shall be informed about it. If not, m_secondTurnNotification ==
   /// TurnDirection::NoTurn
-  TurnDirection m_secondTurnNotification;
+  CarDirection m_secondTurnNotification;
   /// m_secondTurnNotificationIndex is an index of the closest turn on the route polyline
   /// where m_secondTurnNotification was set to true last time for a turn.
   /// If the closest turn is changed m_secondTurnNotification is set to 0.
@@ -101,7 +101,7 @@ class NotificationManager
   uint32_t m_secondTurnNotificationIndex;
 
   string GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-                          TurnDirection turnDir, measurement_utils::Units lengthUnits) const;
+                          CarDirection turnDir, measurement_utils::Units lengthUnits) const;
   /// Generates turn sound notification for the nearest to the current position turn.
   string GenerateFirstTurnSound(TurnItem const & turn, double distanceToTurnMeters);
   /// Changes the state of the class to emulate that first turn notification is pronouned
@@ -114,7 +114,7 @@ class NotificationManager
   /// for a turn once it will return the same value until the turn is changed.
   /// \note This method works independent from m_enabled value.
   /// So it works when the class enable and disable.
-  TurnDirection GenerateSecondTurnNotification(vector<TurnItemDist> const & turns);
+  CarDirection GenerateSecondTurnNotification(vector<TurnItemDist> const & turns);
 
 public:
   NotificationManager()
@@ -125,7 +125,7 @@ public:
     , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
     , m_turnNotificationWithThen(false)
     , m_nextTurnIndex(0)
-    , m_secondTurnNotification(TurnDirection::None)
+    , m_secondTurnNotification(CarDirection::None)
   {
   }
 
@@ -168,7 +168,7 @@ public:
   /// for a turn once it continues returning the same value until the turn is changed.
   /// \note This method works independent from m_enabled value.
   /// So it works when the class enable and disable.
-  TurnDirection GetSecondTurnNotification() const { return m_secondTurnNotification; }
+  CarDirection GetSecondTurnNotification() const { return m_secondTurnNotification; }
 };
 }  // namespace sound
 }  // namespace turns

--- a/routing/turns_notification_manager.hpp
+++ b/routing/turns_notification_manager.hpp
@@ -51,7 +51,7 @@ class NotificationManager
     , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
     , m_turnNotificationWithThen(false)
     , m_nextTurnIndex(0)
-    , m_secondTurnNotification(TurnDirection::NoTurn)
+    , m_secondTurnNotification(TurnDirection::None)
   {
   }
 
@@ -125,7 +125,7 @@ public:
     , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
     , m_turnNotificationWithThen(false)
     , m_nextTurnIndex(0)
-    , m_secondTurnNotification(TurnDirection::NoTurn)
+    , m_secondTurnNotification(TurnDirection::None)
   {
   }
 

--- a/routing/turns_sound_settings.hpp
+++ b/routing/turns_sound_settings.hpp
@@ -134,11 +134,11 @@ struct Notification
   /// if m_useThenInsteadOfDistance == true the m_distanceUnits is ignored.
   /// The word "Then" shall be pronounced intead of the distance.
   bool m_useThenInsteadOfDistance;
-  TurnDirection m_turnDir;
+  CarDirection m_turnDir;
   measurement_utils::Units m_lengthUnits;
 
   Notification(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-               TurnDirection turnDir, measurement_utils::Units lengthUnits)
+               CarDirection turnDir, measurement_utils::Units lengthUnits)
     : m_distanceUnits(distanceUnits)
     , m_exitNum(exitNum)
     , m_useThenInsteadOfDistance(useThenInsteadOfDistance)

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -49,7 +49,7 @@ string GetTtsText::operator()(Notification const & notification) const
 {
   if (notification.m_distanceUnits == 0 && !notification.m_useThenInsteadOfDistance)
     return GetTextById(GetDirectionTextId(notification));
-  if (notification.m_useThenInsteadOfDistance && notification.m_turnDir == TurnDirection::None)
+  if (notification.m_useThenInsteadOfDistance && notification.m_turnDir == CarDirection::None)
     return string();
 
   string const dirStr = GetTextById(GetDirectionTextId(notification));
@@ -102,7 +102,7 @@ string GetDistanceTextId(Notification const & notification)
 
 string GetRoundaboutTextId(Notification const & notification)
 {
-  if (notification.m_turnDir != TurnDirection::LeaveRoundAbout)
+  if (notification.m_turnDir != CarDirection::LeaveRoundAbout)
   {
     ASSERT(false, ());
     return string();
@@ -119,7 +119,7 @@ string GetRoundaboutTextId(Notification const & notification)
 
 string GetYouArriveTextId(Notification const & notification)
 {
-  if (notification.m_turnDir != TurnDirection::ReachedYourDestination)
+  if (notification.m_turnDir != CarDirection::ReachedYourDestination)
   {
     ASSERT(false, ());
     return string();
@@ -134,34 +134,34 @@ string GetDirectionTextId(Notification const & notification)
 {
   switch (notification.m_turnDir)
   {
-    case TurnDirection::GoStraight:
+    case CarDirection::GoStraight:
       return "go_straight";
-    case TurnDirection::TurnRight:
+    case CarDirection::TurnRight:
       return "make_a_right_turn";
-    case TurnDirection::TurnSharpRight:
+    case CarDirection::TurnSharpRight:
       return "make_a_sharp_right_turn";
-    case TurnDirection::TurnSlightRight:
+    case CarDirection::TurnSlightRight:
       return "make_a_slight_right_turn";
-    case TurnDirection::TurnLeft:
+    case CarDirection::TurnLeft:
       return "make_a_left_turn";
-    case TurnDirection::TurnSharpLeft:
+    case CarDirection::TurnSharpLeft:
       return "make_a_sharp_left_turn";
-    case TurnDirection::TurnSlightLeft:
+    case CarDirection::TurnSlightLeft:
       return "make_a_slight_left_turn";
-    case TurnDirection::UTurnLeft:
-    case TurnDirection::UTurnRight:
+    case CarDirection::UTurnLeft:
+    case CarDirection::UTurnRight:
       return "make_a_u_turn";
-    case TurnDirection::EnterRoundAbout:
+    case CarDirection::EnterRoundAbout:
       return "enter_the_roundabout";
-    case TurnDirection::LeaveRoundAbout:
+    case CarDirection::LeaveRoundAbout:
       return GetRoundaboutTextId(notification);
-    case TurnDirection::ReachedYourDestination:
+    case CarDirection::ReachedYourDestination:
       return GetYouArriveTextId(notification);
-    case TurnDirection::StayOnRoundAbout:
-    case TurnDirection::StartAtEndOfStreet:
-    case TurnDirection::TakeTheExit:
-    case TurnDirection::None:
-    case TurnDirection::Count:
+    case CarDirection::StayOnRoundAbout:
+    case CarDirection::StartAtEndOfStreet:
+    case CarDirection::TakeTheExit:
+    case CarDirection::None:
+    case CarDirection::Count:
       ASSERT(false, ());
       return string();
   }

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -49,7 +49,7 @@ string GetTtsText::operator()(Notification const & notification) const
 {
   if (notification.m_distanceUnits == 0 && !notification.m_useThenInsteadOfDistance)
     return GetTextById(GetDirectionTextId(notification));
-  if (notification.m_useThenInsteadOfDistance && notification.m_turnDir == TurnDirection::NoTurn)
+  if (notification.m_useThenInsteadOfDistance && notification.m_turnDir == TurnDirection::None)
     return string();
 
   string const dirStr = GetTextById(GetDirectionTextId(notification));
@@ -160,7 +160,7 @@ string GetDirectionTextId(Notification const & notification)
     case TurnDirection::StayOnRoundAbout:
     case TurnDirection::StartAtEndOfStreet:
     case TurnDirection::TakeTheExit:
-    case TurnDirection::NoTurn:
+    case TurnDirection::None:
     case TurnDirection::Count:
       ASSERT(false, ());
       return string();


### PR DESCRIPTION
Цель данного PR перевести класс Route вектор структур RouteSegment. Каждому сегменту (части фичи) маршрута соответствует одна структура RouteSegment. В данном PR все методы класса Route перенастраиваются на std::vector<RouteSegment> m_routeSegments, а прежние структуры m_turns, m_times, m_streets, m_altitudes, m_traffic и их использование, установка и т.д. удалены.

@mpimenov @rokuz PTAL