### PR TITLE
Routing matching hopping case fix.

### DIFF
--- a/geometry/polyline2d.hpp
+++ b/geometry/polyline2d.hpp
@@ -70,16 +70,6 @@ public:
 
   void Clear() { m_points.clear(); }
   void Add(Point<T> const & pt) { m_points.push_back(pt); }
-  void Append(Polyline const & poly)
-  {
-    m_points.insert(m_points.end(), poly.m_points.cbegin(), poly.m_points.cend());
-  }
-
-  void PopBack()
-  {
-    ASSERT(!m_points.empty(), ());
-    m_points.pop_back();
-  }
 
   void Swap(Polyline & rhs) { m_points.swap(rhs.m_points); }
   size_t GetSize() const { return m_points.size(); }

--- a/geometry/polyline2d.hpp
+++ b/geometry/polyline2d.hpp
@@ -70,6 +70,16 @@ public:
 
   void Clear() { m_points.clear(); }
   void Add(Point<T> const & pt) { m_points.push_back(pt); }
+  void Append(Polyline const & poly)
+  {
+    m_points.insert(m_points.end(), poly.m_points.cbegin(), poly.m_points.cend());
+  }
+
+  void PopBack()
+  {
+    ASSERT(!m_points.empty(), ());
+    m_points.pop_back();
+  }
 
   void Swap(Polyline & rhs) { m_points.swap(rhs.m_points); }
   size_t GetSize() const { return m_points.size(); }

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -1,8 +1,11 @@
 #include "followed_polyline.hpp"
 
+#include <algorithm>
+#include <limits>
+
 namespace routing
 {
-
+using namespace std;
 using Iter = routing::FollowedPolyline::Iter;
 
 Iter FollowedPolyline::Begin() const

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -136,9 +136,13 @@ Iter FollowedPolyline::GetClosestProjectionInInterval(m2::RectD const & posRect,
   return res;
 }
 
+/// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
+/// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
+/// after |m_current| the iterator corresponding of the projection returns.
+/// Otherwise returned a projection to closest point of route.
 template <class DistanceFn>
-Iter FollowedPolyline::GetClosestProjection(m2::RectD const & posRect,
-                                            DistanceFn const & distFn) const
+Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
+                                         DistanceFn const & distFn) const
 {
   CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
   // At first trying to find a projection to two closest route segments of route which is near
@@ -163,7 +167,7 @@ Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
     return UpdateProjection(posRect);
 
   Iter res;
-  res = GetClosestProjection(posRect, [&](Iter const & it)
+  res = GetBestProjection(posRect, [&](Iter const & it)
   {
     return fabs(GetDistanceM(m_current, it) - predictDistance);
   });
@@ -180,7 +184,7 @@ Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect) const
 
   Iter res;
   m2::PointD const currPos = posRect.Center();
-  res = GetClosestProjection(posRect, [&](Iter const & it)
+  res = GetBestProjection(posRect, [&](Iter const & it)
   {
     return MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
   });

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -136,10 +136,6 @@ Iter FollowedPolyline::GetClosestProjectionInInterval(m2::RectD const & posRect,
   return res;
 }
 
-/// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
-/// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
-/// after |m_current| the iterator corresponding of the projection returns.
-/// Otherwise returned a projection to closest point of route.
 template <class DistanceFn>
 Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
                                          DistanceFn const & distFn) const

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -75,6 +75,11 @@ private:
   template <class DistanceFn>
   Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
                                       size_t startIdx, size_t endIdx) const;
+
+  /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
+  /// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
+  /// after |m_current| the iterator corresponding of the projection is returned.
+  /// Otherwise returns a projection to closest point of route.
   template <class DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -76,7 +76,7 @@ private:
   Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
                                       size_t startIdx, size_t endIdx) const;
   template <class DistanceFn>
-  Iter GetClosestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
+  Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
   void Update();
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -21,6 +21,19 @@ public:
   }
 
   void Swap(FollowedPolyline & rhs);
+
+  void Append(FollowedPolyline const & poly)
+  {
+    m_poly.Append(poly.m_poly);
+    Update();
+  }
+
+  void PopBack()
+  {
+    m_poly.PopBack();
+    Update();
+  }
+
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
   m2::PolylineD const & GetPolyline() const { return m_poly; }
   std::vector<double> const & GetSegDistanceM() const { return m_segDistance; }

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -19,21 +19,7 @@ public:
   }
 
   void Swap(FollowedPolyline & rhs);
-
-  void Append(FollowedPolyline const & poly)
-  {
-    m_poly.Append(poly.m_poly);
-    Update();
-  }
-
-  void PopBack()
-  {
-    m_poly.PopBack();
-    Update();
-  }
-
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
-
   m2::PolylineD const & GetPolyline() const { return m_poly; }
   vector<double> const & GetSegDistanceM() const { return m_segDistance; }
   double GetTotalDistanceM() const;
@@ -42,7 +28,7 @@ public:
   double GetMercatorDistanceFromBegin() const;
 
   /*! \brief Return next navigation point for direction widgets.
-   *  Returns first geomety point from the polyline after your location if it is farther then
+   *  Returns first geometry point from the polyline after your location if it is farther then
    *  toleranceM.
    */
   void GetCurrentDirectionPoint(m2::PointD & pt, double toleranceM) const;
@@ -71,6 +57,9 @@ public:
   Iter GetIterToIndex(size_t index) const;
 
 private:
+  template <class DistanceFn>
+  Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
+                                      size_t startIdx, size_t endIdx) const;
   template <class DistanceFn>
   Iter GetClosestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -5,6 +5,8 @@
 #include "geometry/point2d.hpp"
 #include "geometry/polyline2d.hpp"
 
+#include <vector>
+
 namespace routing
 {
 class FollowedPolyline
@@ -21,7 +23,7 @@ public:
   void Swap(FollowedPolyline & rhs);
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
   m2::PolylineD const & GetPolyline() const { return m_poly; }
-  vector<double> const & GetSegDistanceM() const { return m_segDistance; }
+  std::vector<double> const & GetSegDistanceM() const { return m_segDistance; }
   double GetTotalDistanceM() const;
   double GetDistanceFromBeginM() const;
   double GetDistanceToEndM() const;
@@ -70,9 +72,9 @@ private:
   /// Iterator with the current position. Position sets with UpdateProjection methods.
   mutable Iter m_current;
   /// Precalculated info for fast projection finding.
-  vector<m2::ProjectionToSection<m2::PointD>> m_segProj;
+  std::vector<m2::ProjectionToSection<m2::PointD>> m_segProj;
   /// Accumulated cache of segments length in meters.
-  vector<double> m_segDistance;
+  std::vector<double> m_segDistance;
 };
 
 }  // namespace routing

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -11,7 +11,32 @@ using namespace routing;
 namespace
 {
   static const m2::PolylineD kTestDirectedPolyline({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
+  static const m2::PolylineD kTestDirectedPolyline2({{6.0, 0.0}, {7.0, 0.0}});
 }  // namespace
+
+UNIT_TEST(FollowedPolylineAppend)
+{
+  FollowedPolyline followedPolyline1(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline const followedPolyline2(kTestDirectedPolyline2.Begin(), kTestDirectedPolyline2.End());
+
+  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline, ());
+  followedPolyline1.Append(followedPolyline2);
+  TEST_EQUAL(followedPolyline1.GetPolyline().GetSize(), 5, ());
+
+  m2::PolylineD polyline1 = kTestDirectedPolyline;
+  polyline1.Append(kTestDirectedPolyline2);
+  TEST_EQUAL(followedPolyline1.GetPolyline(), polyline1, ());
+}
+
+UNIT_TEST(FollowedPolylinePop)
+{
+  FollowedPolyline followedPolyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+
+  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 3, ());
+  followedPolyline.PopBack();
+  TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 2, ());
+}
 
 UNIT_TEST(FollowedPolylineInitializationFogTest)
 {

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -10,29 +10,29 @@ using namespace routing;
 
 namespace
 {
-  static const m2::PolylineD kTestDirectedPolyline({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
+  static const m2::PolylineD kTestDirectedPolyline1({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
   static const m2::PolylineD kTestDirectedPolyline2({{6.0, 0.0}, {7.0, 0.0}});
 }  // namespace
 
 UNIT_TEST(FollowedPolylineAppend)
 {
-  FollowedPolyline followedPolyline1(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline followedPolyline1(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   FollowedPolyline const followedPolyline2(kTestDirectedPolyline2.Begin(), kTestDirectedPolyline2.End());
 
-  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline1, ());
   followedPolyline1.Append(followedPolyline2);
   TEST_EQUAL(followedPolyline1.GetPolyline().GetSize(), 5, ());
 
-  m2::PolylineD polyline1 = kTestDirectedPolyline;
+  m2::PolylineD polyline1 = kTestDirectedPolyline1;
   polyline1.Append(kTestDirectedPolyline2);
   TEST_EQUAL(followedPolyline1.GetPolyline(), polyline1, ());
 }
 
 UNIT_TEST(FollowedPolylinePop)
 {
-  FollowedPolyline followedPolyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline followedPolyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
 
-  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline1, ());
   TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 3, ());
   followedPolyline.PopBack();
   TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 2, ());
@@ -40,7 +40,7 @@ UNIT_TEST(FollowedPolylinePop)
 
 UNIT_TEST(FollowedPolylineInitializationFogTest)
 {
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   TEST(polyline.IsValid(), ());
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
   TEST_EQUAL(polyline.GetPolyline().GetSize(), 3, ());
@@ -48,7 +48,7 @@ UNIT_TEST(FollowedPolylineInitializationFogTest)
 
 UNIT_TEST(FollowedPolylineFollowingTestByProjection)
 {
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({0, 0}, 2));
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
@@ -88,10 +88,10 @@ UNIT_TEST(FollowedPolylineFollowingTestByPrediction)
 UNIT_TEST(FollowedPolylineDistanceCalculationTest)
 {
   // Test full length case.
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   double distance = polyline.GetDistanceM(polyline.Begin(), polyline.End());
-  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
-                                                          kTestDirectedPolyline.Back());
+  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.Front(),
+                                                          kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetTotalDistanceM();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -99,8 +99,8 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   // Test partial length case.
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({3, 0}, 2));
   distance = polyline.GetDistanceM(polyline.GetCurrentIter(), polyline.End());
-  masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.GetPoint(1),
-                                                   kTestDirectedPolyline.Back());
+  masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.GetPoint(1),
+                                                   kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetDistanceToEndM();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -109,7 +109,7 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({4, 0}, 2));
   distance = polyline.GetDistanceM(polyline.GetCurrentIter(), polyline.End());
   masterDistance = MercatorBounds::DistanceOnEarth(m2::PointD(4, 0),
-                                                   kTestDirectedPolyline.Back());
+                                                   kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetDistanceToEndM();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -137,7 +137,7 @@ UNIT_TEST(FollowedPolylineGetDistanceFromBeginM)
   m2::PointD point(4, 0);
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters(point, 2));
   double distance = polyline.GetDistanceFromBeginM();
-  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
+  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.Front(),
                                                           point);
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 }

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -6,6 +6,7 @@
 
 #include "platform/location.hpp"
 
+#include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
 #include "std/string.hpp"
@@ -173,6 +174,68 @@ UNIT_TEST(NextTurnsTest)
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
   }
+}
+
+//   0.0002        *--------*
+//                 |        |
+//                 |        |
+//        Finish   |        |
+//   0.0001  *--------------*
+//                 |
+//                 |
+//                 |
+//        0        * Start
+//           0  0.0001    0.0002
+//
+UNIT_TEST(SelfIntersectedRouteMatchingTest)
+{
+  vector<m2::PointD> const kRouteGeometry(
+      {{0.0001, 0.0}, {0.0001, 0.0002}, {0.0002, 0.0002}, {0.0002, 0.0001}, {0.0, 0.0001}});
+  double constexpr kRoundingErrorMeters = 0.001;
+
+  Route route("TestRouter");
+  route.SetGeometry(kRouteGeometry.begin(), kRouteGeometry.end());
+
+  auto const testMachedPos = [&](location::GpsInfo const & pos,
+                                 location::GpsInfo const & expectedMatchingPos,
+                                 size_t expectedIndexInRoute) {
+    location::RouteMatchingInfo routeMatchingInfo;
+    route.MoveIterator(pos);
+    location::GpsInfo matchedPos = pos;
+    route.MatchLocationToRoute(matchedPos, routeMatchingInfo);
+    TEST_LESS(MercatorBounds::DistanceOnEarth(
+                  m2::PointD(matchedPos.m_latitude, matchedPos.m_longitude),
+                  m2::PointD(expectedMatchingPos.m_latitude, expectedMatchingPos.m_longitude)),
+              kRoundingErrorMeters, ());
+    TEST_EQUAL(routeMatchingInfo.GetIndexInRoute(), expectedIndexInRoute, ());
+  };
+
+  // Moving along the route from start point.
+  location::GpsInfo const pos1(GetGps(0.0001, 0.0));
+  testMachedPos(pos1, pos1, 0 /* expectedIndexInRoute */);
+  location::GpsInfo const pos2(GetGps(0.0001, 0.00005));
+  testMachedPos(pos2, pos2, 0 /* expectedIndexInRoute */);
+
+  // Moving around the self intersection and checking that position is matched to the first segment of the route.
+  location::GpsInfo const selfIntersectionPos(GetGps(0.0001, 0.0001));
+  location::GpsInfo const pos3(GetGps(0.00005, 0.0001));
+  testMachedPos(pos3, selfIntersectionPos, 0 /* expectedIndexInRoute */);
+  location::GpsInfo const pos4(GetGps(0.00015, 0.0001));
+  testMachedPos(pos4, selfIntersectionPos, 0 /* expectedIndexInRoute */);
+
+  // Continue moving along the route.
+  location::GpsInfo const pos5(GetGps(0.00011, 0.0002));
+  testMachedPos(pos5, pos5, 1 /* expectedIndexInRoute */);
+  location::GpsInfo const pos6(GetGps(0.0002, 0.00019));
+  testMachedPos(pos6, pos6, 2 /* expectedIndexInRoute */);
+  location::GpsInfo const pos7(GetGps(0.00019, 0.0001));
+  testMachedPos(pos7, pos7, 3 /* expectedIndexInRoute */);
+
+  // Moving around the self intersection and checking that position is matched to the last segment of the route.
+  location::GpsInfo const pos8(GetGps(0.0001, 0.00005));
+  testMachedPos(pos8, selfIntersectionPos, 3 /* expectedIndexInRoute */);
+  location::GpsInfo const pos9(GetGps(0.0001, 0.00015));
+  testMachedPos(pos9, selfIntersectionPos, 3 /* expectedIndexInRoute */);
 }
 
 UNIT_TEST(RouteNameTest)


### PR DESCRIPTION
Данный PR решает следующие проблемы:
1. Корректный matching, в случае самопересекающихся маршрутов:
https://jira.mail.ru/browse/MAPSME-4944

2. Корректный matching, когда когда маршрут дважды и более проходит через одни и те же сегменты. Это возможно, при добавлении пром точки (точек)
https://jira.mail.ru/browse/MAPSME-5002

Кроме того данный PR улучшит ситуацию в https://jira.mail.ru/browse/MAPSME-4919.

Идея данного PR проста. При route matching теперь мы сначала пробуем заметчить текущую позицию на ближайшие два сегмента оставшейся (после предыдущего мачинга) части маршрута. Если не получается - значит перескок или покинули маршрут. Пробуем замечить на всю оставшуюся часть с маршрута. Если не получается, значит покинули маршрут.

@mpimenov @rokuz PTAL

Я планирую добавить юнит тест на данное поведение в рамках этого PR.

----------------------------------------------
Все готово. Теперь ожидаем окончательного выхода release-74, чтоб он попал в минурку. Затем сделаем cherry-pick на мастер.