### PR TITLE
Master route matching fix

### DIFF
--- a/geometry/polyline2d.hpp
+++ b/geometry/polyline2d.hpp
@@ -70,16 +70,6 @@ public:
 
   void Clear() { m_points.clear(); }
   void Add(Point<T> const & pt) { m_points.push_back(pt); }
-  void Append(Polyline const & poly)
-  {
-    m_points.insert(m_points.end(), poly.m_points.cbegin(), poly.m_points.cend());
-  }
-
-  void PopBack()
-  {
-    ASSERT(!m_points.empty(), ());
-    m_points.pop_back();
-  }
 
   void Swap(Polyline & rhs) { m_points.swap(rhs.m_points); }
   size_t GetSize() const { return m_points.size(); }

--- a/geometry/polyline2d.hpp
+++ b/geometry/polyline2d.hpp
@@ -70,6 +70,16 @@ public:
 
   void Clear() { m_points.clear(); }
   void Add(Point<T> const & pt) { m_points.push_back(pt); }
+  void Append(Polyline const & poly)
+  {
+    m_points.insert(m_points.end(), poly.m_points.cbegin(), poly.m_points.cend());
+  }
+
+  void PopBack()
+  {
+    ASSERT(!m_points.empty(), ());
+    m_points.pop_back();
+  }
 
   void Swap(Polyline & rhs) { m_points.swap(rhs.m_points); }
   size_t GetSize() const { return m_points.size(); }

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -1,8 +1,11 @@
 #include "followed_polyline.hpp"
 
+#include <algorithm>
+#include <limits>
+
 namespace routing
 {
-
+using namespace std;
 using Iter = routing::FollowedPolyline::Iter;
 
 Iter FollowedPolyline::Begin() const

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -136,9 +136,13 @@ Iter FollowedPolyline::GetClosestProjectionInInterval(m2::RectD const & posRect,
   return res;
 }
 
+/// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
+/// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
+/// after |m_current| the iterator corresponding of the projection returns.
+/// Otherwise returned a projection to closest point of route.
 template <class DistanceFn>
-Iter FollowedPolyline::GetClosestProjection(m2::RectD const & posRect,
-                                            DistanceFn const & distFn) const
+Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
+                                         DistanceFn const & distFn) const
 {
   CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
   // At first trying to find a projection to two closest route segments of route which is near
@@ -163,7 +167,7 @@ Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
     return UpdateProjection(posRect);
 
   Iter res;
-  res = GetClosestProjection(posRect, [&](Iter const & it)
+  res = GetBestProjection(posRect, [&](Iter const & it)
   {
     return fabs(GetDistanceM(m_current, it) - predictDistance);
   });
@@ -180,7 +184,7 @@ Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect) const
 
   Iter res;
   m2::PointD const currPos = posRect.Center();
-  res = GetClosestProjection(posRect, [&](Iter const & it)
+  res = GetBestProjection(posRect, [&](Iter const & it)
   {
     return MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
   });

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -136,10 +136,6 @@ Iter FollowedPolyline::GetClosestProjectionInInterval(m2::RectD const & posRect,
   return res;
 }
 
-/// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
-/// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
-/// after |m_current| the iterator corresponding of the projection returns.
-/// Otherwise returned a projection to closest point of route.
 template <class DistanceFn>
 Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
                                          DistanceFn const & distFn) const

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -5,6 +5,8 @@
 #include "geometry/point2d.hpp"
 #include "geometry/polyline2d.hpp"
 
+#include <vector>
+
 namespace routing
 {
 class FollowedPolyline
@@ -22,12 +24,14 @@ public:
 
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
   m2::PolylineD const & GetPolyline() const { return m_poly; }
+
   vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
   double GetTotalDistanceMeters() const;
   double GetDistanceFromStartMeters() const;
   double GetDistanceToEndMeters() const;
   double GetDistFromCurPointToRoutePointMerc() const;
   double GetDistFromCurPointToRoutePointMeters() const;
+  double GetMercatorDistanceFromBegin() const;
 
   /*! \brief Return next navigation point for direction widgets.
    *  Returns first geometry point from the polyline after your location if it is farther then
@@ -72,9 +76,9 @@ private:
   /// Iterator with the current position. Position sets with UpdateProjection methods.
   mutable Iter m_current;
   /// Precalculated info for fast projection finding.
-  vector<m2::ProjectionToSection<m2::PointD>> m_segProj;
+  std::vector<m2::ProjectionToSection<m2::PointD>> m_segProj;
   /// Accumulated cache of segments length in meters.
-  vector<double> m_segDistance;
+  std::vector<double> m_segDistance;
 };
 
 }  // namespace routing

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -20,14 +20,7 @@ public:
 
   void Swap(FollowedPolyline & rhs);
 
-  void Append(FollowedPolyline const & poly)
-  {
-    m_poly.Append(poly.m_poly);
-    Update();
-  }
-
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
-
   m2::PolylineD const & GetPolyline() const { return m_poly; }
   vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
   double GetTotalDistanceMeters() const;
@@ -66,6 +59,9 @@ public:
   Iter GetIterToIndex(size_t index) const;
 
 private:
+  template <class DistanceFn>
+  Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
+                                      size_t startIdx, size_t endIdx) const;
   template <class DistanceFn>
   Iter GetClosestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -22,6 +22,18 @@ public:
 
   void Swap(FollowedPolyline & rhs);
 
+  void Append(FollowedPolyline const & poly)
+  {
+    m_poly.Append(poly.m_poly);
+    Update();
+  }
+
+  void PopBack()
+  {
+    m_poly.PopBack();
+    Update();
+  }
+
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
   m2::PolylineD const & GetPolyline() const { return m_poly; }
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -78,6 +78,11 @@ private:
   template <class DistanceFn>
   Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
                                       size_t startIdx, size_t endIdx) const;
+
+  /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
+  /// If there's a good projection of center of |posRect| to two closest segments of |m_poly|
+  /// after |m_current| the iterator corresponding of the projection is returned.
+  /// Otherwise returns a projection to closest point of route.
   template <class DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -79,7 +79,7 @@ private:
   Iter GetClosestProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
                                       size_t startIdx, size_t endIdx) const;
   template <class DistanceFn>
-  Iter GetClosestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
+  Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
   void Update();
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -28,7 +28,6 @@ namespace routing
 {
 namespace
 {
-double constexpr kLocationTimeThreshold = 60.0 * 1.0;
 double constexpr kOnEndToleranceM = 10.0;
 double constexpr kSteetNameLinkMeters = 400.;
 

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -10,29 +10,29 @@ using namespace routing;
 
 namespace
 {
-  static const m2::PolylineD kTestDirectedPolyline({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
+  static const m2::PolylineD kTestDirectedPolyline1({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
   static const m2::PolylineD kTestDirectedPolyline2({{6.0, 0.0}, {7.0, 0.0}});
 }  // namespace
 
 UNIT_TEST(FollowedPolylineAppend)
 {
-  FollowedPolyline followedPolyline1(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline followedPolyline1(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   FollowedPolyline const followedPolyline2(kTestDirectedPolyline2.Begin(), kTestDirectedPolyline2.End());
 
-  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline1, ());
   followedPolyline1.Append(followedPolyline2);
   TEST_EQUAL(followedPolyline1.GetPolyline().GetSize(), 5, ());
 
-  m2::PolylineD polyline1 = kTestDirectedPolyline;
+  m2::PolylineD polyline1 = kTestDirectedPolyline1;
   polyline1.Append(kTestDirectedPolyline2);
   TEST_EQUAL(followedPolyline1.GetPolyline(), polyline1, ());
 }
 
 UNIT_TEST(FollowedPolylinePop)
 {
-  FollowedPolyline followedPolyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline followedPolyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
 
-  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline1, ());
   TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 3, ());
   followedPolyline.PopBack();
   TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 2, ());
@@ -40,7 +40,7 @@ UNIT_TEST(FollowedPolylinePop)
 
 UNIT_TEST(FollowedPolylineInitializationFogTest)
 {
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   TEST(polyline.IsValid(), ());
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
   TEST_EQUAL(polyline.GetPolyline().GetSize(), 3, ());
@@ -48,7 +48,7 @@ UNIT_TEST(FollowedPolylineInitializationFogTest)
 
 UNIT_TEST(FollowedPolylineFollowingTestByProjection)
 {
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({0, 0}, 2));
   TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
@@ -88,10 +88,10 @@ UNIT_TEST(FollowedPolylineFollowingTestByPrediction)
 UNIT_TEST(FollowedPolylineDistanceCalculationTest)
 {
   // Test full length case.
-  FollowedPolyline polyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline polyline(kTestDirectedPolyline1.Begin(), kTestDirectedPolyline1.End());
   double distance = polyline.GetDistanceM(polyline.Begin(), polyline.End());
-  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
-                                                          kTestDirectedPolyline.Back());
+  double masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.Front(),
+                                                          kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetTotalDistanceMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -99,8 +99,8 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   // Test partial length case.
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({3, 0}, 2));
   distance = polyline.GetDistanceM(polyline.GetCurrentIter(), polyline.End());
-  masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.GetPoint(1),
-                                                   kTestDirectedPolyline.Back());
+  masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.GetPoint(1),
+                                                   kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetDistanceToEndMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -109,7 +109,7 @@ UNIT_TEST(FollowedPolylineDistanceCalculationTest)
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({4, 0}, 2));
   distance = polyline.GetDistanceM(polyline.GetCurrentIter(), polyline.End());
   masterDistance = MercatorBounds::DistanceOnEarth(m2::PointD(4, 0),
-                                                   kTestDirectedPolyline.Back());
+                                                   kTestDirectedPolyline1.Back());
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
   distance = polyline.GetDistanceToEndMeters();
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
@@ -136,9 +136,10 @@ UNIT_TEST(FollowedPolylineGetDistanceFromBeginM)
   FollowedPolyline polyline(testPolyline.Begin(), testPolyline.End());
   m2::PointD point(4, 0);
   polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters(point, 2));
+
   double const distance = polyline.GetDistanceFromStartMeters();
-  double const masterDistance = MercatorBounds::DistanceOnEarth(kTestDirectedPolyline.Front(),
-                                                          point);
+  double const masterDistance =
+      MercatorBounds::DistanceOnEarth(kTestDirectedPolyline1.Front(), point);
   TEST_ALMOST_EQUAL_ULPS(distance, masterDistance, ());
 }
 }  // namespace routing_test

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -11,7 +11,32 @@ using namespace routing;
 namespace
 {
   static const m2::PolylineD kTestDirectedPolyline({{0.0, 0.0}, {3.0, 0.0}, {5.0, 0.0}});
+  static const m2::PolylineD kTestDirectedPolyline2({{6.0, 0.0}, {7.0, 0.0}});
 }  // namespace
+
+UNIT_TEST(FollowedPolylineAppend)
+{
+  FollowedPolyline followedPolyline1(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+  FollowedPolyline const followedPolyline2(kTestDirectedPolyline2.Begin(), kTestDirectedPolyline2.End());
+
+  TEST_EQUAL(followedPolyline1.GetPolyline(), kTestDirectedPolyline, ());
+  followedPolyline1.Append(followedPolyline2);
+  TEST_EQUAL(followedPolyline1.GetPolyline().GetSize(), 5, ());
+
+  m2::PolylineD polyline1 = kTestDirectedPolyline;
+  polyline1.Append(kTestDirectedPolyline2);
+  TEST_EQUAL(followedPolyline1.GetPolyline(), polyline1, ());
+}
+
+UNIT_TEST(FollowedPolylinePop)
+{
+  FollowedPolyline followedPolyline(kTestDirectedPolyline.Begin(), kTestDirectedPolyline.End());
+
+  TEST_EQUAL(followedPolyline.GetPolyline(), kTestDirectedPolyline, ());
+  TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 3, ());
+  followedPolyline.PopBack();
+  TEST_EQUAL(followedPolyline.GetPolyline().GetSize(), 2, ());
+}
 
 UNIT_TEST(FollowedPolylineInitializationFogTest)
 {


### PR DESCRIPTION
cherry-pick https://github.com/mapsme/omim/pull/6642 на master.

Данный PR решает следующие проблемы:

Корректный matching, в случае самопересекающихся маршрутов:
https://jira.mail.ru/browse/MAPSME-4944

Корректный matching, когда когда маршрут дважды и более проходит через одни и те же сегменты. Это возможно, при добавлении пром точки (точек)
https://jira.mail.ru/browse/MAPSME-5002

Кроме того данный PR улучшит ситуацию в https://jira.mail.ru/browse/MAPSME-4919.

Идея данного PR проста. При route matching теперь мы сначала пробуем заметчить текущую позицию на ближайшие два сегмента оставшейся (после предыдущего мачинга) части маршрута. Если не получается - значит перескок или покинули маршрут. Пробуем замечить на всю оставшуюся часть с маршрута. Если не получается, значит покинули маршрут.

@rokuz PTAL