### PR TITLE
[platform] Fix resource path searching for debug start

### DIFF
--- a/platform/platform_mac.mm
+++ b/platform/platform_mac.mm
@@ -56,9 +56,7 @@ Platform::Platform()
   }
   else
   {
-#ifdef STANDALONE_APP
     m_resourcesDir = resourcesPath + "/";
-#else // STANDALONE_APP
     // get writable path
     // developers can have symlink to data folder
     char const * dataPath = "../../../../../data/";
@@ -77,7 +75,6 @@ Platform::Platform()
           m_writableDir = m_resourcesDir.substr(0, p) + "/omim/data/";
       }
     }
-#endif // STANDALONE_APP
 
     if (m_writableDir.empty())
     {


### PR DESCRIPTION
После мёржа дизайнер-тула неправильно определяются все каталоги при запуске из консоли. Всё потому что в поправленном куске кода не инициализировался `m_resourcesDir`. Восстановил состояние как до мёржа.