### PR TITLE
[routing] Taking into account vector of user moving for choosing the best start edge.

### DIFF
--- a/geometry/point2d.hpp
+++ b/geometry/point2d.hpp
@@ -22,7 +22,7 @@ namespace m2
 
     T x, y;
 
-    Point() {}
+    Point() : x(T()), y(T()) {}
     Point(T x_, T y_) : x(x_), y(y_) {}
     template <typename U> Point(Point<U> const & u) : x(u.x), y(u.y) {}
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -27,6 +27,7 @@
 #include "platform/mwm_traits.hpp"
 
 #include "base/exception.hpp"
+#include "base/stl_helpers.hpp"
 
 #include <algorithm>
 #include <map>
@@ -374,7 +375,8 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
   auto const & finishCheckpoint = checkpoints.GetPoint(subrouteIdx + 1);
 
   Segment finishSegment;
-  if (!FindBestSegment(finishCheckpoint, m2::PointD::Zero(), false /* isOutgoing */, graph, finishSegment))
+  if (!FindBestSegment(finishCheckpoint, m2::PointD::Zero() /* direction */,
+                       false /* isOutgoing */, graph, finishSegment))
   {
     bool const isLastSubroute = subrouteIdx == checkpoints.GetNumSubroutes() - 1;
     return isLastSubroute ? IRouter::EndPointNotFound : IRouter::IntermediatePointNotFound;
@@ -561,10 +563,10 @@ bool IndexRouter::FindBestSegment(m2::PointD const & point, m2::PointD const & d
   };
 
   // Getting rid of knowingly bad candidates.
-  candidates.erase(remove_if(candidates.begin(), candidates.end(), [&](pair<Edge, Junction> const & p){
+  my::EraseIf(candidates, [&](pair<Edge, Junction> const & p){
     Edge const & edge = p.first;
     return edge.GetFeatureId().m_mwmId != mwmId || IsDeadEnd(getSegmentByEdge(edge), isOutgoing, worldGraph);
-  }), candidates.end());
+  });
 
   if (candidates.empty())
     return false;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -253,7 +253,7 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoint
   segments.push_back(IndexGraphStarter::kStartFakeSegment);
 
   Segment startSegment;
-  if (!FindBestSegment(checkpoints.GetPointFrom(), startDirection, true, graph, startSegment))
+  if (!FindBestSegment(checkpoints.GetPointFrom(), startDirection, true /* isOutgoing */, graph, startSegment))
     return IRouter::StartPointNotFound;
   
   size_t subrouteSegmentsBegin = 0;
@@ -332,7 +332,7 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
   auto const & finishCheckpoint = checkpoints.GetPoint(subrouteIdx + 1);
 
   Segment finishSegment;
-  if (!FindBestSegment(finishCheckpoint, {0.0, 0.0}, false, graph, finishSegment))
+  if (!FindBestSegment(finishCheckpoint, m2::PointD::Zero(), false /* isOutgoing */, graph, finishSegment))
   {
     bool const isLastSubroute = subrouteIdx == checkpoints.GetNumSubroutes() - 1;
     return isLastSubroute ? IRouter::EndPointNotFound : IRouter::IntermediatePointNotFound;
@@ -399,7 +399,7 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 
   Segment startSegment;
   m2::PointD const & pointFrom = checkpoints.GetPointFrom();
-  if (!FindBestSegment(pointFrom, startDirection, true, graph, startSegment))
+  if (!FindBestSegment(pointFrom, startDirection, true /* isOutgoing */, graph, startSegment))
     return IRouter::StartPointNotFound;
 
   auto const & lastSubroutes = m_lastRoute->GetSubroutes();

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -39,7 +39,7 @@ public:
     bool Compare(Edge const & edge1, Edge const & edge2) const;
 
   private:
-    /// \returns true if |edge| is almost parallel with vector |m_direction|.
+    /// \returns true if |edge| is almost parallel to vector |m_direction|.
     /// \note According to current implementation vectors |edge| and |m_direction|
     /// are almost parallel if angle between them less than 14 degrees.
     bool IsAlmostParallel(Edge const & edge) const;
@@ -87,7 +87,7 @@ private:
   WorldGraph MakeWorldGraph();
 
   /// \brief Finds the best segment (edge) which may be considered as the start of the finish of the route.
-  /// According to current implementation if a segment is laying near |point| and is almost parallel
+  /// According to current implementation if a segment is near |point| and is almost parallel
   /// to |direction| vector, the segment will be better than others. If there's no an an almost parallel
   /// segment in neighbourhoods the closest segment will be chosen.
   /// \param isOutgoing == true is |point| is considered as the start of the route.

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -70,11 +70,8 @@ private:
   /// to |startDirection|.
   /// \param isOutgoing == true is |point| is considered as the start of the route.
   /// isOutgoing == false is |point| is considered as the finish of the route.
-  bool FindBestSegment(m2::PointD const & point,
-                       m2::PointD const & startDirection,
-                       bool isOutgoing,
-                       WorldGraph & worldGraph,
-                       Segment & bestSegment) const;
+  bool FindBestSegment(m2::PointD const & point, m2::PointD const & startDirection, bool isOutgoing,
+                       WorldGraph & worldGraph, Segment & bestSegment) const;
   // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
   // ProcessLeaps replaces each leap with calculated route through mwm.
   IRouter::ResultCode ProcessLeaps(vector<Segment> const & input,

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -65,11 +65,16 @@ private:
 
   WorldGraph MakeWorldGraph();
 
-  /// \brief Finds closest edges which may be considered as start of finish of the route.
+  /// \brief Finds best edges which may be considered as the start of the finish of the route.
+  /// If it's possible |bestSegment| will be filled with a segment which is almost parallel
+  /// to |startDirection|.
   /// \param isOutgoing == true is |point| is considered as the start of the route.
   /// isOutgoing == false is |point| is considered as the finish of the route.
-  bool FindClosestSegment(m2::PointD const & point, bool isOutgoing, WorldGraph & worldGraph,
-                          Segment & closestSegment) const;
+  bool FindBestSegment(m2::PointD const & point,
+                       m2::PointD const & startDirection,
+                       bool isOutgoing,
+                       WorldGraph & worldGraph,
+                       Segment & bestSegment) const;
   // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
   // ProcessLeaps replaces each leap with calculated route through mwm.
   IRouter::ResultCode ProcessLeaps(vector<Segment> const & input,

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -94,7 +94,7 @@ void RoutingSession::RebuildRoute(m2::PointD const & startPoint,
   m_checkpoints.SetPointFrom(startPoint);
   // Use old-style callback construction, because lambda constructs buggy function on Android
   // (callback param isn't captured by value).
-  m_router->CalculateRoute(m_checkpoints, startPoint - m_lastGoodPosition, adjustToPrevRoute,
+  m_router->CalculateRoute(m_checkpoints, m_currentDirection, adjustToPrevRoute,
                            DoReadyCallback(*this, readyCallback, m_routingSessionMutex),
                            m_progressCallback, timeoutSec);
 }
@@ -233,6 +233,9 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & 
         }
       }
     }
+
+    if (m_lastGoodPosition != m2::PointD::Zero())
+      m_currentDirection = m_userCurrentPosition - m_lastGoodPosition;
 
     m_lastGoodPosition = m_userCurrentPosition;
   }

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -234,7 +234,7 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & 
       }
     }
 
-    if (m_lastGoodPosition != m2::PointD::Zero())
+    if (m_lastGoodPosition != m2::PointD::Zero() && m_userCurrentPosition != m2::PointD::Zero())
       m_currentDirection = m_userCurrentPosition - m_lastGoodPosition;
 
     m_lastGoodPosition = m_userCurrentPosition;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -222,6 +222,8 @@ private:
   double m_lastDistance;
   int m_moveAwayCounter;
   m2::PointD m_lastGoodPosition;
+  // |m_currentDirection| is a vector from the position before last good position to last good position.
+  m2::PointD m_currentDirection;
   m2::PointD m_userCurrentPosition;
 
   // Sound turn notification parameters.

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -592,10 +592,10 @@ UNIT_TEST(IndexGraph_OnlyTopology_3)
 // Test that a parallel edge is always better than others.
 UNIT_TEST(BestEdgeComparator_OneParallelEdge)
 {
-  Edge edge1 =
-    Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}), MakeJunctionForTesting({-0.002, 0.002}), true /* partOfRead */);
-  Edge edge2 =
-    Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}), MakeJunctionForTesting({0.002, 0.0}), true /* partOfRead */);
+  Edge edge1 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
+                              MakeJunctionForTesting({-0.002, 0.002}), true /* partOfRead */);
+  Edge edge2 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}), 
+                              MakeJunctionForTesting({0.002, 0.0}), true /* partOfRead */);
   IndexRouter::BestEdgeComparator bestEdgeComparator(m2::PointD(0.0, 0.0), m2::PointD(0.0, 0.001) /* direction vector */);
 
   TEST(bestEdgeComparator.Compare(edge1, edge2), ());


### PR DESCRIPTION
cherry-pick https://github.com/mapsme/omim/pull/6715 to master

Выбор стартового сегмента с учетом направления движения.
Для решения проблемы https://jira.mail.ru/browse/MAPSME-4919 необходимо было реализовать два тикета. Один из них (https://jira.mail.ru/browse/MAPSME-4945) реализован в этом PR.

Теперь при выборе дуги для старта маршрута мы ищем ближайший сегмент среди тех, что почти параллельны вектору движения пользователя. А если таких не находится, то среди всех. Под почти параллельными понимаются сегменты, которые отличаются от вектора движения не более чем на 14 градусов.

@dobriy-eeh PTAL
