### PR TITLE
[base] Fix CHECK in fabric сrashlytics

### DIFF
--- a/android/UnitTests/jni/mock.cpp
+++ b/android/UnitTests/jni/mock.cpp
@@ -34,7 +34,7 @@ static void AndroidLogMessage(LogLevel l, SrcPoint const & src, std::string cons
   __android_log_write(pr, " MapsMeTests ", out.c_str());
 }
 
-static void AndroidAssertMessage(SrcPoint const & src, std::string const & s)
+static bool AndroidAssertMessage(SrcPoint const & src, std::string const & s)
 {
 #if defined(MWM_LOG_TO_FILE)
   AndroidLogToFile(LERROR, src, s);
@@ -47,6 +47,7 @@ static void AndroidAssertMessage(SrcPoint const & src, std::string const & s)
 #else
     MYTHROW(RootException, (s));
 #endif
+  return true;
 }
 
 static void InitSystemLog()

--- a/android/jni/com/mapswithme/core/logging.cpp
+++ b/android/jni/com/mapswithme/core/logging.cpp
@@ -53,11 +53,6 @@ void AndroidLogMessage(LogLevel level, SrcPoint const & src, std::string const &
 void AndroidAssertMessage(SrcPoint const & src, std::string const & s)
 {
   AndroidMessage(LCRITICAL, src, s);
-#ifdef DEBUG
-  assert(false);
-#else
-  std::abort();
-#endif
 }
 
 void InitSystemLog()

--- a/android/jni/com/mapswithme/core/logging.cpp
+++ b/android/jni/com/mapswithme/core/logging.cpp
@@ -50,9 +50,10 @@ void AndroidLogMessage(LogLevel level, SrcPoint const & src, std::string const &
   CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
 }
 
-void AndroidAssertMessage(SrcPoint const & src, std::string const & s)
+bool AndroidAssertMessage(SrcPoint const & src, std::string const & s)
 {
   AndroidMessage(LCRITICAL, src, s);
+  return true;
 }
 
 void InitSystemLog()

--- a/base/assert.hpp
+++ b/base/assert.hpp
@@ -11,58 +11,55 @@
 namespace my
 {
   // Called when ASSERT, CHECK or VERIFY failed.
-  typedef void (*AssertFailedFn)(SrcPoint const &, std::string const &);
+  // If returns true then crash application.
+  typedef bool (*AssertFailedFn)(SrcPoint const &, std::string const &);
   extern AssertFailedFn OnAssertFailed;
 
   /// @return Pointer to previous message function.
   AssertFailedFn SetAssertFunction(AssertFailedFn fn);
-
-  bool AssertAbortIsEnabled();
-  void SwitchAssertAbort(bool enable);
 }
 
 #ifdef DEBUG
-#define ABORT_ON_ASSERT() assert(false)
+#define ASSERT_CRASH() assert(false)
 #else
-#define ABORT_ON_ASSERT() std::abort()
+#define ASSERT_CRASH() std::abort()
 #endif
 
-#define ON_ASSERT_FAILED(msg)       \
-  ::my::OnAssertFailed(SRC(), msg); \
-  if (::my::AssertAbortIsEnabled()) \
-    ABORT_ON_ASSERT();
+#define ASSERT_FAIL(msg)                \
+  if (::my::OnAssertFailed(SRC(), msg)) \
+    ASSERT_CRASH();
 
 // TODO: Evaluate X only once in CHECK().
 #define CHECK(X, msg) do { if (X) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X")", ::my::impl::Message msg));} } while(false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X")", ::my::impl::Message msg));} } while(false)
 #define CHECK_EQUAL(X, Y, msg) do { if ((X) == (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" == "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" == "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_NOT_EQUAL(X, Y, msg) do { if ((X) != (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" != "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" != "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_LESS(X, Y, msg) do { if ((X) < (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" < "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" < "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_LESS_OR_EQUAL(X, Y, msg) do { if ((X) <= (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" <= "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" <= "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_GREATER(X, Y, msg) do { if ((X) > (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" > "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" > "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_GREATER_OR_EQUAL(X, Y, msg) do { if ((X) >= (Y)) {} else { \
-  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" >= "#Y")", \
-                                        ::my::impl::Message(X, Y), \
-                                        ::my::impl::Message msg));} } while (false)
+  ASSERT_FAIL(::my::impl::Message("CHECK("#X" >= "#Y")", \
+                                   ::my::impl::Message(X, Y), \
+                                   ::my::impl::Message msg));} } while (false)
 #define CHECK_OR_CALL(fail, call, X, msg) do { if (X) {} else { \
   if (fail) {\
-    ON_ASSERT_FAILED(::my::impl::Message(::my::impl::Message("CHECK("#X")"), \
-                                         ::my::impl::Message msg)); \
+    ASSERT_FAIL(::my::impl::Message(::my::impl::Message("CHECK("#X")"), \
+                                    ::my::impl::Message msg)); \
   } else { \
     call(); \
   } } } while (false)

--- a/base/assert.hpp
+++ b/base/assert.hpp
@@ -3,6 +3,8 @@
 #include "base/internal/message.hpp"
 #include "base/src_point.hpp"
 
+#include <cassert>
+#include <cstdlib>
 #include <string>
 
 
@@ -14,39 +16,53 @@ namespace my
 
   /// @return Pointer to previous message function.
   AssertFailedFn SetAssertFunction(AssertFailedFn fn);
+
+  bool AssertAbortIsEnabled();
+  void SwitchAssertAbort(bool enable);
 }
+
+#ifdef DEBUG
+#define ABORT_ON_ASSERT() assert(false)
+#else
+#define ABORT_ON_ASSERT() std::abort()
+#endif
+
+#define ON_ASSERT_FAILED(msg)       \
+  ::my::OnAssertFailed(SRC(), msg); \
+  if (::my::AssertAbortIsEnabled()) \
+    ABORT_ON_ASSERT();
 
 // TODO: Evaluate X only once in CHECK().
 #define CHECK(X, msg) do { if (X) {} else { \
-    ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X")", ::my::impl::Message msg));} } while(false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X")", ::my::impl::Message msg));} } while(false)
 #define CHECK_EQUAL(X, Y, msg) do { if ((X) == (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" == "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" == "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_NOT_EQUAL(X, Y, msg) do { if ((X) != (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" != "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" != "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_LESS(X, Y, msg) do { if ((X) < (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" < "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" < "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_LESS_OR_EQUAL(X, Y, msg) do { if ((X) <= (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" <= "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" <= "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_GREATER(X, Y, msg) do { if ((X) > (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" > "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" > "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_GREATER_OR_EQUAL(X, Y, msg) do { if ((X) >= (Y)) {} else { \
-  ::my::OnAssertFailed(SRC(), ::my::impl::Message("CHECK("#X" >= "#Y")", \
-                                                   ::my::impl::Message(X, Y), \
-                                                   ::my::impl::Message msg));} } while (false)
+  ON_ASSERT_FAILED(::my::impl::Message("CHECK("#X" >= "#Y")", \
+                                        ::my::impl::Message(X, Y), \
+                                        ::my::impl::Message msg));} } while (false)
 #define CHECK_OR_CALL(fail, call, X, msg) do { if (X) {} else { \
   if (fail) {\
-    ::my::OnAssertFailed(SRC(), ::my::impl::Message(::my::impl::Message("CHECK("#X")"), \
-                                                     ::my::impl::Message msg)); \
+    ON_ASSERT_FAILED(::my::impl::Message(::my::impl::Message("CHECK("#X")"), \
+                                         ::my::impl::Message msg)); \
   } else { \
     call(); \
   } } } while (false)

--- a/base/base.cpp
+++ b/base/base.cpp
@@ -6,18 +6,14 @@
 
 #include <iostream>
 
-namespace
-{
-bool g_assertAbortIsEnabled = true;
-}
-
 namespace my
 {
-  void OnAssertFailedDefault(SrcPoint const & srcPoint, std::string const & msg)
+  bool OnAssertFailedDefault(SrcPoint const & srcPoint, std::string const & msg)
   {
     std::cerr << "ASSERT FAILED" << std::endl
               << srcPoint.FileName() << ":" << srcPoint.Line() << std::endl
               << msg << std::endl;
+    return true;
   }
 
   AssertFailedFn OnAssertFailed = &OnAssertFailedDefault;
@@ -27,7 +23,4 @@ namespace my
     std::swap(OnAssertFailed, fn);
     return fn;
   }
-
-  bool AssertAbortIsEnabled() { return g_assertAbortIsEnabled; }
-  void SwitchAssertAbort(bool enable) { g_assertAbortIsEnabled = enable; }
 }

--- a/base/base.cpp
+++ b/base/base.cpp
@@ -4,9 +4,12 @@
 
 #include "std/target_os.hpp"
 
-#include <cassert>
-#include <cstdlib>
 #include <iostream>
+
+namespace
+{
+bool g_assertAbortIsEnabled = true;
+}
 
 namespace my
 {
@@ -15,12 +18,6 @@ namespace my
     std::cerr << "ASSERT FAILED" << std::endl
               << srcPoint.FileName() << ":" << srcPoint.Line() << std::endl
               << msg << std::endl;
-
-#ifdef DEBUG
-    assert(false);
-#else
-    std::abort();
-#endif
   }
 
   AssertFailedFn OnAssertFailed = &OnAssertFailedDefault;
@@ -30,4 +27,7 @@ namespace my
     std::swap(OnAssertFailed, fn);
     return fn;
   }
+
+  bool AssertAbortIsEnabled() { return g_assertAbortIsEnabled; }
+  void SwitchAssertAbort(bool enable) { g_assertAbortIsEnabled = enable; }
 }

--- a/drape/drape_tests/pointers_tests.cpp
+++ b/drape/drape_tests/pointers_tests.cpp
@@ -16,9 +16,10 @@ namespace
 
 #if defined(TRACK_POINTERS)
   bool g_assertRaised = false;
-  void OnAssertRaised(my::SrcPoint const & /*srcPoint*/, string const & /*msg*/)
+  bool OnAssertRaised(my::SrcPoint const & /*srcPoint*/, string const & /*msg*/)
   {
     g_assertRaised = true;
+    return false;
   }
 #endif
 }
@@ -82,9 +83,7 @@ UNIT_TEST(RefPointerExpiringTest)
 #if defined(TRACK_POINTERS)
 
   g_assertRaised = false;
-  bool const assertAbortWasEnabled = my::AssertAbortIsEnabled();
   my::AssertFailedFn prevFn = my::SetAssertFunction(OnAssertRaised);
-  my::SwitchAssertAbort(false);
 
   drape_ptr<Tester> ptr = make_unique_dp<Tester>();
   ref_ptr<Tester> refPtr1 = make_ref(ptr);
@@ -92,7 +91,6 @@ UNIT_TEST(RefPointerExpiringTest)
   ptr.reset();
 
   my::SetAssertFunction(prevFn);
-  my::SwitchAssertAbort(assertAbortWasEnabled);
 
   TEST(g_assertRaised, ());
 

--- a/drape/drape_tests/pointers_tests.cpp
+++ b/drape/drape_tests/pointers_tests.cpp
@@ -82,7 +82,9 @@ UNIT_TEST(RefPointerExpiringTest)
 #if defined(TRACK_POINTERS)
 
   g_assertRaised = false;
+  bool const assertAbortWasEnabled = my::AssertAbortIsEnabled();
   my::AssertFailedFn prevFn = my::SetAssertFunction(OnAssertRaised);
+  my::SwitchAssertAbort(false);
 
   drape_ptr<Tester> ptr = make_unique_dp<Tester>();
   ref_ptr<Tester> refPtr1 = make_ref(ptr);
@@ -90,6 +92,7 @@ UNIT_TEST(RefPointerExpiringTest)
   ptr.reset();
 
   my::SetAssertFunction(prevFn);
+  my::SwitchAssertAbort(assertAbortWasEnabled);
 
   TEST(g_assertRaised, ());
 

--- a/iphone/Maps/Common/Statistics/fabric_logging.hpp
+++ b/iphone/Maps/Common/Statistics/fabric_logging.hpp
@@ -6,5 +6,6 @@
 
 namespace platform
 {
-  void LogMessageFabric(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg);
+  void IosLogMessage(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg);
+  void IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg);
 }

--- a/iphone/Maps/Common/Statistics/fabric_logging.hpp
+++ b/iphone/Maps/Common/Statistics/fabric_logging.hpp
@@ -7,5 +7,5 @@
 namespace platform
 {
   void IosLogMessage(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg);
-  void IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg);
+  bool IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg);
 }

--- a/iphone/Maps/Common/Statistics/fabric_logging_ios.mm
+++ b/iphone/Maps/Common/Statistics/fabric_logging_ios.mm
@@ -32,11 +32,12 @@ void IosLogMessage(my::LogLevel level, my::SrcPoint const & srcPoint, std::strin
   my::LogMessageDefault(level, srcPoint, msg);
 }
 
-void IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg)
+bool IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg)
 {
   LogMessageFabric(my::LCRITICAL, srcPoint, msg);
   std::cerr << "ASSERT FAILED" << std::endl
             << srcPoint.FileName() << ":" << srcPoint.Line() << std::endl
             << msg << std::endl;
+  return true;
 }
 }  //  namespace platform

--- a/iphone/Maps/Common/Statistics/fabric_logging_ios.mm
+++ b/iphone/Maps/Common/Statistics/fabric_logging_ios.mm
@@ -4,9 +4,11 @@
 
 #include "base/assert.hpp"
 
+#include <iostream>
+
 namespace platform
 {
-  void LogMessageFabric(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg)
+void LogMessageFabric(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg)
 {
   std::string recordType;
   switch (level)
@@ -22,7 +24,19 @@ namespace platform
   std::string const srcString = recordType + DebugPrint(srcPoint) + " " + msg + "\n";
 
   CLSLog(@"%@", @(srcString.c_str()));
+}
 
+void IosLogMessage(my::LogLevel level, my::SrcPoint const & srcPoint, std::string const & msg)
+{
+  LogMessageFabric(level, srcPoint, msg);
   my::LogMessageDefault(level, srcPoint, msg);
+}
+
+void IosAssertMessage(my::SrcPoint const & srcPoint, std::string const & msg)
+{
+  LogMessageFabric(my::LCRITICAL, srcPoint, msg);
+  std::cerr << "ASSERT FAILED" << std::endl
+            << srcPoint.FileName() << ":" << srcPoint.Line() << std::endl
+            << msg << std::endl;
 }
 }  //  namespace platform

--- a/iphone/Maps/main.mm
+++ b/iphone/Maps/main.mm
@@ -56,7 +56,8 @@ int main(int argc, char * argv[])
 #ifdef MWM_LOG_TO_FILE
   my::SetLogMessageFn(LogMessageFile);
 #elif OMIM_PRODUCTION
-  my::SetLogMessageFn(platform::LogMessageFabric);
+  my::SetLogMessageFn(platform::IosLogMessage);
+  my::SetAssertFunction(platform::IosAssertMessage);
 #endif
   auto & p = GetPlatform();
   LOG(LINFO, ("maps.me started, detected CPU cores:", p.CpuCores()));


### PR DESCRIPTION
Cherry pick https://github.com/mapsme/omim/pull/6720

Исправлены две проблемы в Сrashlytics:

Все CHECK группировались в одну кучу. Теперь каждый CHECK будет группироваться по той строчке, в которой он случился.
В ios версии терялся текст сообщения, указанный в CHECK.