### PR TITLE
Astar weight template

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -140,6 +140,7 @@ public:
   // AStarAlgorithm types aliases:
   using TVertexType = Segment;
   using TEdgeType = SegmentEdge;
+  using TWeightType = RouteWeight;
 
   explicit DijkstraWrapper(IndexGraph & graph) : m_graph(graph) {}
 
@@ -155,9 +156,9 @@ public:
     m_graph.GetEdgeList(vertex, false /* isOutgoing */, edges);
   }
 
-  double HeuristicCostEstimate(TVertexType const & /* from */, TVertexType const & /* to */)
+  TWeightType HeuristicCostEstimate(TVertexType const & /* from */, TVertexType const & /* to */)
   {
-    return 0.0;
+    return GetAStarWeightZero<TWeightType>();
   }
 
 private:
@@ -177,10 +178,10 @@ bool RegionsContain(vector<m2::RegionD> const & regions, m2::PointD const & poin
 
 // Calculate distance from the starting border point to the transition along the border.
 // It could be measured clockwise or counterclockwise, direction doesn't matter.
-double CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
-                                   CrossMwmConnectorSerializer::Transition const & transition)
+RouteWeight CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
+                                        CrossMwmConnectorSerializer::Transition const & transition)
 {
-  double distance = 0.0;
+  RouteWeight distance = GetAStarWeightZero<RouteWeight>();
 
   for (m2::RegionD const & region : borders)
   {
@@ -194,11 +195,11 @@ double CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
       if (m2::RegionD::IsIntersect(transition.GetBackPoint(), transition.GetFrontPoint(), *prev,
                                    curr, intersection))
       {
-        distance += prev->Length(intersection);
+        distance += RouteWeight(prev->Length(intersection));
         return distance;
       }
 
-      distance += prev->Length(curr);
+      distance += RouteWeight(prev->Length(curr));
       prev = &curr;
     }
   }
@@ -288,7 +289,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   MwmValue mwmValue(LocalCountryFile(path, platform::CountryFile(country), 0 /* version */));
   DeserializeIndexGraph(mwmValue, graph);
 
-  map<Segment, map<Segment, double>> weights;
+  map<Segment, map<Segment, RouteWeight>> weights;
   auto const numEnters = connector.GetEnters().size();
   size_t foundCount = 0;
   size_t notFoundCount = 0;
@@ -323,11 +324,11 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   connector.FillWeights([&](Segment const & enter, Segment const & exit) {
     auto it0 = weights.find(enter);
     if (it0 == weights.end())
-      return CrossMwmConnector::kNoRoute;
+      return RouteWeight(CrossMwmConnector::kNoRoute);
 
     auto it1 = it0->second.find(exit);
     if (it1 == it0->second.end())
-      return CrossMwmConnector::kNoRoute;
+      return RouteWeight(CrossMwmConnector::kNoRoute);
 
     return it1->second;
   });

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
   async_router.cpp
   async_router.hpp
   base/astar_algorithm.hpp
+  base/astar_weight.hpp
   base/followed_polyline.cpp
   base/followed_polyline.hpp
   bicycle_directions.cpp
@@ -92,6 +93,8 @@ set(
   route.cpp
   route.hpp
   route_point.hpp
+  route_weight.cpp
+  route_weight.hpp
   router.cpp
   router.hpp
   router_delegate.cpp

--- a/routing/base/astar_weight.hpp
+++ b/routing/base/astar_weight.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <limits>
+
+namespace routing
+{
+template <typename WeightType>
+constexpr WeightType GetAStarWeightZero();
+
+template <>
+constexpr double GetAStarWeightZero<double>()
+{
+  return 0.0;
+}
+
+// Precision of comparison weights.
+template <typename WeightType>
+constexpr WeightType GetAStarWeightEpsilon();
+
+template <>
+constexpr double GetAStarWeightEpsilon<double>()
+{
+  return 1e-6;
+}
+
+template <typename WeightType>
+constexpr WeightType GetAStarWeightMax();
+
+template <>
+constexpr double GetAStarWeightMax<double>()
+{
+  return std::numeric_limits<double>::max();
+}
+
+}  // namespace routing

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -150,7 +150,7 @@ void CrossMwmConnector::AddEdge(Segment const & segment, Weight weight,
                                 std::vector<SegmentEdge> & edges) const
 {
   if (weight != static_cast<Weight>(kNoRoute))
-    edges.emplace_back(segment, static_cast<double>(weight));
+    edges.emplace_back(segment, RouteWeight(static_cast<double>(weight)));
 }
 
 CrossMwmConnector::Transition const & CrossMwmConnector::GetTransition(

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -62,9 +62,9 @@ public:
     {
       for (Segment const & exit : m_exits)
       {
-        double const weight = calcWeight(enter, exit);
+        RouteWeight const weight = calcWeight(enter, exit);
         // Edges weights should be >= astar heuristic, so use std::ceil.
-        m_weights.push_back(static_cast<Weight>(std::ceil(weight)));
+        m_weights.push_back(static_cast<Weight>(std::ceil(weight.GetWeight())));
       }
     }
   }

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -103,8 +103,8 @@ void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMap
   double constexpr kAstarHeuristicFactor = 100000;
   //// Osrm multiplies seconds to 10, so we need to divide it back.
   double constexpr kOSRMWeightToSecondsMultiplier = 0.1;
-  edges.emplace_back(segment,
-                     osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier * kAstarHeuristicFactor);
+  edges.emplace_back(segment, RouteWeight(osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier *
+                                          kAstarHeuristicFactor));
 }
 }  // namespace
 

--- a/routing/cross_mwm_road_graph.hpp
+++ b/routing/cross_mwm_road_graph.hpp
@@ -126,6 +126,7 @@ public:
   using TCachingKey = pair<TWrittenNodeId, Index::MwmId>;
   using TVertexType = BorderCross;
   using TEdgeType = CrossWeightedEdge;
+  using TWeightType = double;
 
   struct Hash
   {

--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -13,7 +13,7 @@ namespace
 /// Function to run AStar Algorithm from the base.
 IRouter::ResultCode CalculateRoute(BorderCross const & startPos, BorderCross const & finalPos,
                                    CrossMwmRoadGraph & roadGraph, RouterDelegate const & delegate,
-                                   RoutingResult<BorderCross> & route)
+                                   RoutingResult<BorderCross, double /* WeightType */> & route)
 {
   using TAlgorithm = AStarAlgorithm<CrossMwmRoadGraph>;
 
@@ -90,7 +90,7 @@ IRouter::ResultCode CalculateCrossMwmPath(TRoutingNodes const & startGraphNodes,
     return IRouter::EndPointNotFound;
 
   // Finding path through maps.
-  RoutingResult<BorderCross> tempRoad;
+  RoutingResult<BorderCross, double /* WeightType */> tempRoad;
   code = CalculateRoute({startNode, startNode}, {finalNode, finalNode}, roadGraph, delegate, tempRoad);
   cost = tempRoad.distance;
   if (code != IRouter::NoError)

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -109,14 +109,16 @@ void IndexGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge
   GetEdgeList(segment, false /* isOutgoing */, edges);
 }
 
-double IndexGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+RouteWeight IndexGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
 {
-  return m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+  return RouteWeight(
+      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)));
 }
 
-double IndexGraph::CalcSegmentWeight(Segment const & segment)
+RouteWeight IndexGraph::CalcSegmentWeight(Segment const & segment)
 {
-  return m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId()));
+  return RouteWeight(
+      m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId())));
 }
 
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
@@ -161,16 +163,16 @@ void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bo
   if (m_roadAccess.GetSegmentType(to) != RoadAccess::Type::Yes)
     return;
 
-  double const weight = CalcSegmentWeight(isOutgoing ? to : from) +
-                        GetPenalties(isOutgoing ? from : to, isOutgoing ? to : from);
+  RouteWeight const weight = CalcSegmentWeight(isOutgoing ? to : from) +
+                             GetPenalties(isOutgoing ? from : to, isOutgoing ? to : from);
   edges.emplace_back(to, weight);
 }
 
-double IndexGraph::GetPenalties(Segment const & u, Segment const & v) const
+RouteWeight IndexGraph::GetPenalties(Segment const & u, Segment const & v) const
 {
   if (IsUTurn(u, v))
-    return m_estimator->GetUTurnPenalty();
+    return RouteWeight(m_estimator->GetUTurnPenalty());
 
-  return 0.0;
+  return RouteWeight(0.0);
 }
 }  // namespace routing

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -26,6 +26,7 @@ public:
   // AStarAlgorithm types aliases:
   using TVertexType = Segment;
   using TEdgeType = SegmentEdge;
+  using TWeightType = RouteWeight;
 
   IndexGraph() = default;
   explicit IndexGraph(unique_ptr<GeometryLoader> loader, shared_ptr<EdgeEstimator> estimator);
@@ -52,7 +53,7 @@ public:
   // Interface for AStarAlgorithm:
   void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
   void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
-  double HeuristicCostEstimate(Segment const & from, Segment const & to);
+  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to);
 
   void PushFromSerializer(Joint::Id jointId, RoadPoint const & rp)
   {
@@ -72,12 +73,12 @@ public:
   }
 
 private:
-  double CalcSegmentWeight(Segment const & segment);
+  RouteWeight CalcSegmentWeight(Segment const & segment);
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
                            vector<SegmentEdge> & edges);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                           vector<SegmentEdge> & edges);
-  double GetPenalties(Segment const & u, Segment const & v) const;
+  RouteWeight GetPenalties(Segment const & u, Segment const & v) const;
   m2::PointD const & GetPoint(Segment const & segment, bool front)
   {
     return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -141,7 +141,7 @@ void IndexGraphStarter::GetFakeToNormalEdge(FakeVertex const & fakeVertex, bool 
 {
   auto const segment = fakeVertex.GetSegmentWithDirection(forward);
   m2::PointD const & pointTo = GetPoint(segment, true /* front */);
-  double const weight = m_graph.GetEstimator().CalcLeapWeight(fakeVertex.GetPoint(), pointTo);
+  RouteWeight const weight(m_graph.GetEstimator().CalcLeapWeight(fakeVertex.GetPoint(), pointTo));
   edges.emplace_back(segment, weight);
 }
 
@@ -155,16 +155,16 @@ void IndexGraphStarter::GetNormalToFakeEdge(Segment const & segment, FakeVertex 
   {
     if (m_graph.IsTransition(segment, isOutgoing))
     {
-      edges.emplace_back(fakeSegment,
-                         m_graph.GetEstimator().CalcLeapWeight(pointFrom, fakeVertex.GetPoint()));
+      edges.emplace_back(fakeSegment, RouteWeight(m_graph.GetEstimator().CalcLeapWeight(
+                                          pointFrom, fakeVertex.GetPoint())));
     }
     return;
   }
 
   if (fakeVertex.Fits(segment))
   {
-    edges.emplace_back(fakeSegment,
-                       m_graph.GetEstimator().CalcLeapWeight(pointFrom, fakeVertex.GetPoint()));
+    edges.emplace_back(fakeSegment, RouteWeight(m_graph.GetEstimator().CalcLeapWeight(
+                                        pointFrom, fakeVertex.GetPoint())));
   }
 }
 
@@ -180,8 +180,8 @@ void IndexGraphStarter::ConnectLeapToTransitions(Segment const & segment, bool i
   // So |isEnter| below should be set to true.
   m_graph.ForEachTransition(
       segment.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
-        edges.emplace_back(transition, m_graph.GetEstimator().CalcLeapWeight(
-          segmentPoint, GetPoint(transition, isOutgoing)));
+        edges.emplace_back(transition, RouteWeight(m_graph.GetEstimator().CalcLeapWeight(
+                                           segmentPoint, GetPoint(transition, isOutgoing))));
       });
 }
 }  // namespace routing

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -19,6 +19,7 @@ public:
   // AStarAlgorithm types aliases:
   using TVertexType = IndexGraph::TVertexType;
   using TEdgeType = IndexGraph::TEdgeType;
+  using TWeightType = IndexGraph::TWeightType;
 
   class FakeVertex final
   {
@@ -100,10 +101,10 @@ public:
     GetEdgesList(segment, false /* isOutgoing */, edges);
   }
 
-  double HeuristicCostEstimate(TVertexType const & from, TVertexType const & to)
+  RouteWeight HeuristicCostEstimate(TVertexType const & from, TVertexType const & to)
   {
-    return m_graph.GetEstimator().CalcHeuristic(GetPoint(from, true /* front */),
-                                                GetPoint(to, true /* front */));
+    return RouteWeight(m_graph.GetEstimator().CalcHeuristic(GetPoint(from, true /* front */),
+                                                            GetPoint(to, true /* front */)));
   }
 
   double CalcSegmentWeight(Segment const & segment) const

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -64,7 +64,7 @@ IRouter::ResultCode FindPath(
     typename Graph::TVertexType const & start, typename Graph::TVertexType const & finish,
     RouterDelegate const & delegate, Graph & graph,
     typename AStarAlgorithm<Graph>::TOnVisitedVertexCallback const & onVisitedVertexCallback,
-    RoutingResult<typename Graph::TVertexType> & routingResult)
+    RoutingResult<typename Graph::TVertexType, typename Graph::TWeightType> & routingResult)
 {
   AStarAlgorithm<Graph> algorithm;
   return ConvertResult<Graph>(algorithm.FindPathBidirectional(graph, start, finish, routingResult,
@@ -373,7 +373,7 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
     delegate.OnPointCheck(pointFrom);
   };
 
-  RoutingResult<Segment> routingResult;
+  RoutingResult<Segment, RouteWeight> routingResult;
   IRouter::ResultCode const result = FindPath(starter.GetStart(), starter.GetFinish(), delegate,
                                               starter, onVisitJunction, routingResult);
   if (result != IRouter::NoError)
@@ -423,7 +423,8 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   for (size_t i = lastSubroute.GetBeginSegmentIdx(); i < lastSubroute.GetEndSegmentIdx(); ++i)
   {
     auto const & step = steps[i];
-    prevEdges.emplace_back(step.GetSegment(), starter.CalcSegmentWeight(step.GetSegment()));
+    prevEdges.emplace_back(step.GetSegment(),
+                           RouteWeight(starter.CalcSegmentWeight(step.GetSegment())));
   }
 
   uint32_t visitCount = 0;
@@ -442,9 +443,10 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   };
 
   AStarAlgorithm<IndexGraphStarter> algorithm;
-  RoutingResult<Segment> result;
-  auto resultCode = ConvertResult<IndexGraphStarter>(algorithm.AdjustRoute(
-      starter, starter.GetStart(), prevEdges, kAdjustLimitSec, result, delegate, onVisitJunction));
+  RoutingResult<Segment, RouteWeight> result;
+  auto resultCode = ConvertResult<IndexGraphStarter>(
+      algorithm.AdjustRoute(starter, starter.GetStart(), prevEdges, RouteWeight(kAdjustLimitSec),
+                            result, delegate, onVisitJunction));
   if (resultCode != IRouter::NoError)
     return resultCode;
 
@@ -579,7 +581,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
 
     IRouter::ResultCode result = IRouter::InternalError;
-    RoutingResult<Segment> routingResult;
+    RoutingResult<Segment, RouteWeight> routingResult;
     // In case of leaps from the start to its mwm transition and from finish mwm transition
     // route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
     if ((current.GetMwmId() == starter.GetStartVertex().GetMwmId()

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -131,6 +131,7 @@ public:
   // CheckGraphConnectivity() types aliases:
   using Vertex = Junction;
   using Edge = routing::Edge;
+  using Weight = double;
 
   enum class Mode
   {

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -193,7 +193,7 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(Checkpoints const & checkpoi
   m_roadGraph->AddFakeEdges(startPos, startVicinity);
   m_roadGraph->AddFakeEdges(finalPos, finalVicinity);
 
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   IRoutingAlgorithm::Result const resultCode =
       m_algorithm->CalculateRoute(*m_roadGraph, startPos, finalPos, delegate, result);
 

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -1,0 +1,17 @@
+#include "routing/route_weight.hpp"
+
+using namespace std;
+
+namespace routing
+{
+ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
+{
+  os << routeWeight.GetWeight();
+  return os;
+}
+
+RouteWeight operator*(double lhs, RouteWeight const & rhs)
+{
+  return RouteWeight(lhs * rhs.GetWeight());
+}
+}  // namespace routing

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "routing/base/astar_weight.hpp"
+
+#include <iostream>
+#include <limits>
+
+namespace routing
+{
+class RouteWeight final
+{
+public:
+  RouteWeight() = default;
+
+  constexpr explicit RouteWeight(double weight) : m_weight(weight) {}
+
+  double GetWeight() const { return m_weight; }
+
+  bool operator<(RouteWeight const & rhs) const { return m_weight < rhs.m_weight; }
+
+  bool operator==(RouteWeight const & rhs) const { return !((*this) < rhs) && !(rhs < (*this)); }
+
+  bool operator!=(RouteWeight const & rhs) const { return !((*this) == rhs); }
+
+  bool operator>(RouteWeight const & rhs) const { return rhs < (*this); }
+
+  bool operator>=(RouteWeight const & rhs) const { return !((*this) < rhs); }
+
+  RouteWeight operator+(RouteWeight const & rhs) const
+  {
+    return RouteWeight(m_weight + rhs.m_weight);
+  }
+
+  RouteWeight operator-(RouteWeight const & rhs) const
+  {
+    return RouteWeight(m_weight - rhs.m_weight);
+  }
+
+  RouteWeight & operator+=(RouteWeight const & rhs)
+  {
+    m_weight += rhs.m_weight;
+    return *this;
+  }
+
+  RouteWeight operator-() const { return RouteWeight(-m_weight); }
+
+private:
+  double m_weight = 0.0;
+};
+
+std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
+
+RouteWeight operator*(double lhs, RouteWeight const & rhs);
+
+template <>
+constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
+{
+  return RouteWeight(std::numeric_limits<double>::max());
+}
+
+template <>
+constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
+{
+  return RouteWeight(0.0);
+}
+
+template <>
+constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
+{
+  return RouteWeight(GetAStarWeightEpsilon<double>());
+}
+
+}  // namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -51,6 +51,7 @@ SOURCES += \
     road_graph_router.cpp \
     road_index.cpp \
     route.cpp \
+    route_weight.cpp \
     router.cpp \
     router_delegate.cpp \
     routing_algorithm.cpp \
@@ -71,6 +72,7 @@ SOURCES += \
 HEADERS += \
     async_router.hpp \
     base/astar_algorithm.hpp \
+    base/astar_weight.hpp \
     base/followed_polyline.hpp \
     bicycle_directions.hpp \
     checkpoints.hpp \
@@ -114,6 +116,7 @@ HEADERS += \
     road_point.hpp \
     route.hpp \
     route_point.hpp \
+    route_weight.hpp \
     router.hpp \
     router_delegate.hpp \
     routing_algorithm.hpp \

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -50,6 +50,7 @@ class RoadGraph
 public:
   using TVertexType = Junction;
   using TEdgeType = WeightedEdge;
+  using TWeightType = double;
 
   RoadGraph(IRoadGraph const & roadGraph)
     : m_roadGraph(roadGraph)
@@ -135,7 +136,7 @@ IRoutingAlgorithm::Result AStarRoutingAlgorithm::CalculateRoute(IRoadGraph const
                                                                 Junction const & startPos,
                                                                 Junction const & finalPos,
                                                                 RouterDelegate const & delegate,
-                                                                RoutingResult<Junction> & path)
+                                                                RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path)
 {
   AStarProgress progress(0, 95);
   uint32_t visitCount = 0;
@@ -164,7 +165,7 @@ IRoutingAlgorithm::Result AStarRoutingAlgorithm::CalculateRoute(IRoadGraph const
 
 IRoutingAlgorithm::Result AStarBidirectionalRoutingAlgorithm::CalculateRoute(
     IRoadGraph const & graph, Junction const & startPos, Junction const & finalPos,
-    RouterDelegate const & delegate, RoutingResult<Junction> & path)
+    RouterDelegate const & delegate, RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path)
 {
   AStarProgress progress(0, 95);
   uint32_t visitCount = 0;

--- a/routing/routing_algorithm.hpp
+++ b/routing/routing_algorithm.hpp
@@ -27,7 +27,7 @@ public:
 
   virtual Result CalculateRoute(IRoadGraph const & graph, Junction const & startPos,
                                 Junction const & finalPos, RouterDelegate const & delegate,
-                                RoutingResult<Junction> & path) = 0;
+                                RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path) = 0;
 };
 
 string DebugPrint(IRoutingAlgorithm::Result const & result);
@@ -39,7 +39,7 @@ public:
   // IRoutingAlgorithm overrides:
   Result CalculateRoute(IRoadGraph const & graph, Junction const & startPos,
                         Junction const & finalPos, RouterDelegate const & delegate,
-                        RoutingResult<Junction> & path) override;
+                        RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path) override;
 };
 
 // AStar-bidirectional routing algorithm implementation
@@ -49,7 +49,7 @@ public:
   // IRoutingAlgorithm overrides:
   Result CalculateRoute(IRoadGraph const & graph, Junction const & startPos,
                         Junction const & finalPos, RouterDelegate const & delegate,
-                        RoutingResult<Junction> & path) override;
+                        RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path) override;
 };
 
 }  // namespace routing

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -26,6 +26,7 @@ class UndirectedGraph
 public:
   using TVertexType = unsigned;
   using TEdgeType = Edge;
+  using TWeightType = double;
 
   void AddEdge(unsigned u, unsigned v, unsigned w)
   {
@@ -63,7 +64,7 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 {
   TAlgorithm algo;
 
-  RoutingResult<unsigned> actualRoute;
+  RoutingResult<unsigned /* VertexType */, double /* WeightType */> actualRoute;
   TEST_EQUAL(TAlgorithm::Result::OK, algo.FindPath(graph, 0u, 4u, actualRoute), ());
   TEST_EQUAL(expectedRoute, actualRoute.path, ());
   TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.distance, ());
@@ -105,7 +106,7 @@ UNIT_TEST(AdjustRoute)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  RoutingResult<unsigned> result;
+  RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
   auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
                                my::Cancellable(), nullptr /* onVisitedVertexCallback */);
 
@@ -126,7 +127,7 @@ UNIT_TEST(AdjustRouteNoPath)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  RoutingResult<unsigned> result;
+  RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
   auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
                                my::Cancellable(), nullptr /* onVisitedVertexCallback */);
 
@@ -147,7 +148,7 @@ UNIT_TEST(AdjustRouteOutOfLimit)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  RoutingResult<unsigned> result;
+  RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
   auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
                                my::Cancellable(), nullptr /* onVisitedVertexCallback */);
 

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -30,7 +30,7 @@ void TestAStarRouterMock(Junction const & startPos, Junction const & finalPos,
   InitRoadGraphMockSourceWithTest2(graph);
 
   RouterDelegate delegate;
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
@@ -98,7 +98,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_RouteIsFound)
       MakeJunctionForTesting(m2::PointD(0, 60)), MakeJunctionForTesting(m2::PointD(40, 100))};
 
   RouterDelegate delegate;
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
@@ -167,7 +167,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
     {
       RouterDelegate delegate;
       Junction const finalPos = roadInfo_2[j].m_junctions[0];
-      RoutingResult<Junction> result;
+      RoutingResult<Junction, double /* WeightType */> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::NoPath,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
       TEST_EQUAL(TRoutingAlgorithm::Result::NoPath,
@@ -183,7 +183,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
     {
       RouterDelegate delegate;
       Junction const finalPos = roadInfo_1[j].m_junctions[0];
-      RoutingResult<Junction> result;
+      RoutingResult<Junction, double /* WeightType */> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
@@ -199,7 +199,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
     {
       RouterDelegate delegate;
       Junction const finalPos = roadInfo_2[j].m_junctions[0];
-      RoutingResult<Junction> result;
+      RoutingResult<Junction, double /* WeightType */> result;
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
       TEST_EQUAL(TRoutingAlgorithm::Result::OK,
@@ -227,7 +227,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad1)
   // path3 = 1/5 + 8/4 + 1/5 = 2.4
 
   RouterDelegate delegate;
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
@@ -262,7 +262,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
   // path3 = 1/5 + 8/4.4 + 1/5 = 2.2
 
   RouterDelegate delegate;
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
@@ -293,7 +293,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
   // path3 = 1/5 + 8/4.9 + 1/5 = 2.03
 
   RouterDelegate delegate;
-  RoutingResult<Junction> result;
+  RoutingResult<Junction, double /* WeightType */> result;
   TRoutingAlgorithm algorithm;
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -143,7 +143,7 @@ UNIT_TEST(TwoWayExit)
 
 UNIT_TEST(Serialization)
 {
-  float constexpr kEdgesWeight = 4444;
+  RouteWeight constexpr kEdgesWeight = RouteWeight(4444.0);
 
   vector<uint8_t> buffer;
   {
@@ -159,7 +159,7 @@ UNIT_TEST(Serialization)
       CrossMwmConnectorSerializer::AddTransition(transition, kCarMask, carConnector);
 
     carConnector.FillWeights(
-        [](Segment const & enter, Segment const & exit) { return kEdgesWeight; });
+        [&](Segment const & enter, Segment const & exit) { return kEdgesWeight; });
 
     serial::CodingParams const codingParams;
     MemWriter<vector<uint8_t>> writer(buffer);
@@ -244,9 +244,15 @@ UNIT_TEST(Serialization)
 UNIT_TEST(WeightsSerialization)
 {
   size_t constexpr kNumTransitions = 3;
-  vector<double> const weights = {
-      4.0,  20.0, CrossMwmConnector::kNoRoute, 12.0, CrossMwmConnector::kNoRoute, 40.0, 48.0,
-      24.0, 12.0};
+  vector<RouteWeight> const weights = {RouteWeight(4.0),
+                                       RouteWeight(20.0),
+                                       RouteWeight(CrossMwmConnector::kNoRoute),
+                                       RouteWeight(12.0),
+                                       RouteWeight(CrossMwmConnector::kNoRoute),
+                                       RouteWeight(40.0),
+                                       RouteWeight(48.0),
+                                       RouteWeight(24.0),
+                                       RouteWeight(12.0)};
   TEST_EQUAL(weights.size(), kNumTransitions * kNumTransitions, ());
 
   vector<uint8_t> buffer;
@@ -305,7 +311,7 @@ UNIT_TEST(WeightsSerialization)
     for (uint32_t exitId = 0; exitId < kNumTransitions; ++exitId)
     {
       auto const weight = weights[weightIdx];
-      if (weight != CrossMwmConnector::kNoRoute)
+      if (weight != RouteWeight(CrossMwmConnector::kNoRoute))
       {
         expectedEdges.emplace_back(Segment(mwmId, exitId, 1 /* segmentIdx */, false /* forward */),
                                    weight);

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -287,13 +287,13 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
                                                          double & timeSec)
 {
   AStarAlgorithm<IndexGraphStarter> algorithm;
-  RoutingResult<Segment> routingResult;
+  RoutingResult<Segment, RouteWeight> routingResult;
 
   auto const resultCode = algorithm.FindPathBidirectional(
       starter, starter.GetStart(), starter.GetFinish(), routingResult, {} /* cancellable */,
       {} /* onVisitedVertexCallback */);
 
-  timeSec = routingResult.distance;
+  timeSec = routingResult.distance.GetWeight();
   roadPoints = routingResult.path;
   return resultCode;
 }

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -2,10 +2,11 @@
 
 #include "routing/num_mwm_id.hpp"
 #include "routing/road_point.hpp"
+#include "routing/route_weight.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/sstream.hpp"
-#include "std/string.hpp"
+#include <cstdint>
+#include <sstream>
+#include <string>
 
 namespace routing
 {
@@ -74,9 +75,12 @@ private:
 class SegmentEdge final
 {
 public:
-  SegmentEdge(Segment const & target, double weight) : m_target(target), m_weight(weight) {}
+  SegmentEdge(Segment const & target, RouteWeight const & weight)
+    : m_target(target), m_weight(weight)
+  {
+  }
   Segment const & GetTarget() const { return m_target; }
-  double GetWeight() const { return m_weight; }
+  RouteWeight const & GetWeight() const { return m_weight; }
 
   bool operator==(SegmentEdge const & edge) const
   {
@@ -93,20 +97,20 @@ public:
 private:
   // Target is vertex going to for outgoing edges, vertex going from for ingoing edges.
   Segment m_target;
-  double m_weight;
+  RouteWeight m_weight;
 };
 
-inline string DebugPrint(Segment const & segment)
+inline std::string DebugPrint(Segment const & segment)
 {
-  ostringstream out;
+  std::ostringstream out;
   out << "Segment(" << segment.GetMwmId() << ", " << segment.GetFeatureId() << ", "
       << segment.GetSegmentIdx() << ", " << segment.IsForward() << ")";
   return out.str();
 }
 
-inline string DebugPrint(SegmentEdge const & edge)
+inline std::string DebugPrint(SegmentEdge const & edge)
 {
-  ostringstream out;
+  std::ostringstream out;
   out << "Edge(" << DebugPrint(edge.GetTarget()) << ", " << edge.GetWeight() << ")";
   return out.str();
 }

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -55,9 +55,10 @@ void WorldGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge
   GetEdgeList(segment, false /* isOutgoing */, false /* isLeap */, edges);
 }
 
-double WorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+RouteWeight WorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
 {
-  return m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+  return RouteWeight(
+      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)));
 }
 
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
@@ -69,7 +70,7 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
     m2::PointD const & from = GetPoint(segment, true /* front */);
     m2::PointD const & to = GetPoint(twin, true /* front */);
     double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, weight);
+    edges.emplace_back(twin, RouteWeight(weight));
   }
 }
 

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -20,6 +20,7 @@ public:
   // AStarAlgorithm types aliases:
   using TVertexType = IndexGraph::TVertexType;
   using TEdgeType = IndexGraph::TEdgeType;
+  using TWeightType = IndexGraph::TWeightType;
 
   // CheckGraphConnectivity() types aliases:
   using Vertex = TVertexType;
@@ -56,7 +57,7 @@ public:
   // Interface for AStarAlgorithm:
   void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
   void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
-  double HeuristicCostEstimate(Segment const & from, Segment const & to);
+  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to);
 
   template <typename Fn>
   void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		3462FDAD1DC1E5BF00906FD7 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */; };
 		349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */; };
 		349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */; };
+		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
+		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
+		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
@@ -320,6 +323,9 @@
 		349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
 		34F558351DBF2A2600A4FC11 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34F558361DBF2A2600A4FC11 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
+		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
+		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
+		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
@@ -590,6 +596,7 @@
 		671F58BA1B874EA20032311E /* base */ = {
 			isa = PBXGroup;
 			children = (
+				40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */,
 				671F58BB1B874EC80032311E /* followed_polyline.cpp */,
 				671F58BC1B874EC80032311E /* followed_polyline.hpp */,
 				A1616E2D1B6B60B3003F078E /* astar_progress.hpp */,
@@ -730,6 +737,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				40A111CB1F2F6776005E6AD5 /* route_weight.cpp */,
+				40A111CC1F2F6776005E6AD5 /* route_weight.hpp */,
 				5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */,
 				5694CEC61EBA25F7004576D3 /* road_access_serialization.hpp */,
 				5694CEC71EBA25F7004576D3 /* road_access.cpp */,
@@ -924,12 +933,14 @@
 				670EE5721B664796001E8064 /* directions_engine.hpp in Headers */,
 				56C439291E93BF8C00998E29 /* cross_mwm_graph.hpp in Headers */,
 				0C81E1541F02589800DC66DF /* traffic_stash.hpp in Headers */,
+				40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */,
 				0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */,
 				A1876BC71BB19C4300C9C743 /* speed_camera.hpp in Headers */,
 				56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */,
 				0C15B8021F02A61B0058E253 /* checkpoints.hpp in Headers */,
 				0C5F5D211E798B0400307B98 /* cross_mwm_connector_serialization.hpp in Headers */,
 				0C0DF9221DE898B70055A22F /* index_graph_starter.hpp in Headers */,
+				40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */,
 				0C090C881E4E276700D52AFD /* world_graph.hpp in Headers */,
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
 				5694CECD1EBA25F7004576D3 /* road_access.hpp in Headers */,
@@ -1182,6 +1193,7 @@
 				0C81E1531F02589800DC66DF /* traffic_stash.cpp in Sources */,
 				0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */,
 				675344191A3F644F00A0A8C3 /* osrm2feature_map.cpp in Sources */,
+				40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,
 				0C5F5D251E798B3800307B98 /* cross_mwm_connector_test.cpp in Sources */,
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,


### PR DESCRIPTION
A* принимает вес как шаблонный параметр (отвязала от double), сделала SegmentWeight, который сейчас просто обёртка над double -- заготовка, в которую можно добавить другие компоненты и переписать оператор сравнения (буду делать отдельным пул реквестом). 
Этот коммит не меняет способ построения маршрута и суть весов, только подготавливает почву для дальнейших изменений.