### PR TITLE
Adding tags route-ferry to the map.

### DIFF
--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -213,6 +213,7 @@ void CarModel::InitAdditionalRoadTypes()
       {{"route", "ferry", "motor_vehicle"}, kSpeedFerryMotorcarVehicleKMpH},
       {{"railway", "rail", "motor_vehicle"}, kSpeedRailMotorcarVehicleKMpH},
       {{"route", "shuttle_train"}, kSpeedShuttleTrainKMpH},
+      {{"route", "ferry"}, kSpeedFerryMotorcarKMpH},
   };
 
   SetAdditionalRoadTypes(classif(), additionalTags);


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-4974

Необходимо добавить в карты (авто index graph) дороги с тагом route=ferry.
Предупреждая вопросы отмечу, что этот таг уже задал в pedestrian_model.cpp и в bicycle_model.cpp.

Вот пример места, где это актуально: http://www.openstreetmap.org/way/28418329#map=12/45.8466/-62.7066

@Zverik @dobriy-eeh @tatiana-kondakova PTAL