### PR TITLE
Adding tags man_made=pier to the map.

### DIFF
--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -37,6 +37,7 @@ double constexpr kSpeedFerryMotorcarKMpH = 15.0;
 double constexpr kSpeedFerryMotorcarVehicleKMpH = 15.0;
 double constexpr kSpeedRailMotorcarVehicleKMpH = 25.0;
 double constexpr kSpeedShuttleTrainKMpH = 25.0;
+double constexpr kSpeedPierKMpH = 10.0;
 
 VehicleModel::InitListT const g_carLimitsDefault =
 {
@@ -214,6 +215,7 @@ void CarModel::InitAdditionalRoadTypes()
       {{"railway", "rail", "motor_vehicle"}, kSpeedRailMotorcarVehicleKMpH},
       {{"route", "shuttle_train"}, kSpeedShuttleTrainKMpH},
       {{"route", "ferry"}, kSpeedFerryMotorcarKMpH},
+      {{"man_made", "pier"}, kSpeedPierKMpH},
   };
 
   SetAdditionalRoadTypes(classif(), additionalTags);


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-4947

Необходимо добавить в карты (авто index graph) дороги с тагом man_made=pier.
Предупреждая вопросы отмечу, что этот таг уже задал в pedestrian_model.cpp и в bicycle_model.cpp.

Вот пример места, где это актуально: http://www.openstreetmap.org/way/226633687

@Zverik @dobriy-eeh @tatiana-kondakova PTAL