### PR TITLE
[android] Fixed opening behaviour in PP

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/BottomPlacePageAnimationController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BottomPlacePageAnimationController.java
@@ -274,7 +274,12 @@ class BottomPlacePageAnimationController extends BasePlacePageAnimationControlle
       return;
     }
 
-    if (distance >= 0.0f) // drag up
+    boolean isDragUp = distance >= 0.0f;
+
+    if (isDragUp && mPlacePage.getState() == State.FULLSCREEN)
+      return;
+
+    if (isDragUp) // drag up
     {
       if (mPlacePage.getState() == State.PREVIEW)
       {


### PR DESCRIPTION
When PP is already in full screen mode we shouldn't try to return it to details state during the dragging up