### PR TITLE
MAPSME-5226 Fix route rebuild on traffic update

### DIFF
--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -93,8 +93,8 @@ public:
   void RebuildRoute(m2::PointD const & startPoint, TReadyCallback const & readyCallback,
                     uint32_t timeoutSec, State routeRebuildingState, bool adjustToPrevRoute);
 
-  m2::PointD GetStartPoint() const { return m_checkpoints.GetStart(); }
-  m2::PointD GetEndPoint() const { return m_checkpoints.GetFinish(); }
+  m2::PointD GetStartPoint() const;
+  m2::PointD GetEndPoint() const;
   bool IsActive() const { return (m_state != RoutingNotActive); }
   bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished); }
   bool IsBuilt() const { return (IsNavigable() || m_state == RouteNeedRebuild); }
@@ -194,8 +194,10 @@ private:
 
   /// RemoveRoute removes m_route and resets route attributes (m_state, m_lastDistance, m_moveAwayCounter).
   void RemoveRoute();
-  void RemoveRouteImpl();
   void RebuildRouteOnTrafficUpdate();
+
+  // Must be called with locked m_routingSessionMutex
+  void ResetImpl();
 
   double GetCompletionPercent() const;
   void PassCheckpoints();


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-5226
При перестроении маршрута в RebuildRouteOnTrafficUpdate не всегда нужно использовать текущее местоположение в качестве старта, а только в случае следования по маршруту (OnRoute) и в случае, если было обнаружено, что пользователь отклонился и требуется перестроение (RouteNeedRebuild). В остальных случаях перестраивать надо с той же начальной точкой, которая есть на текущий момент (для состояния RouteRebuilding точка уже обновлена, если это требуется, для остальных пользователю вероятно не надо перепрыгивать на текущую позицию).

При работе над багом также обнаружила, что RebuildRouteOnTrafficUpdate вызывается и вызывает RebuildRoute в треде, отличном от треда RoutingManager и при этом не берёт мьютекс, в результате чего могут возникнуть гонки данных -- поправила. По идее этот код будет существенно переработан при переносе всех вызовов колбеков роутинга в один тред, поэтому просто сделала чтобы в полях RoutingSession не оказался мусор.