### PR TITLE
[android] Fixed the sending gps tracks

### DIFF
--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -13,9 +13,6 @@ import android.support.multidex.MultiDex;
 import android.text.TextUtils;
 import android.util.Log;
 
-import java.io.File;
-import java.util.List;
-
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.ndk.CrashlyticsNdk;
 import com.mapswithme.maps.background.AppBackgroundTracker;
@@ -35,6 +32,7 @@ import com.mapswithme.util.Constants;
 import com.mapswithme.util.Counters;
 import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.PermissionsUtils;
+import com.mapswithme.util.SharedPropertiesUtils;
 import com.mapswithme.util.ThemeSwitcher;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.Utils;
@@ -46,6 +44,9 @@ import com.my.tracker.MyTracker;
 import com.my.tracker.MyTrackerParams;
 import com.pushwoosh.PushManager;
 import io.fabric.sdk.android.Fabric;
+
+import java.io.File;
+import java.util.List;
 
 public class MwmApplication extends Application
 {
@@ -193,6 +194,8 @@ public class MwmApplication extends Application
     nativePreparePlatform(settingsPath);
     nativeInitPlatform(getApkPath(), getStoragePath(settingsPath), getTempPath(), getObbGooglePath(),
                        BuildConfig.FLAVOR, BuildConfig.BUILD_TYPE, UiUtils.isTablet());
+
+    Config.setStatisticsEnabled(SharedPropertiesUtils.isStatisticsEnabled());
 
     @SuppressWarnings("unused")
     Statistics s = Statistics.INSTANCE;

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -36,6 +36,7 @@ import com.mapswithme.maps.sound.LanguageData;
 import com.mapswithme.maps.sound.TtsPlayer;
 import com.mapswithme.util.Config;
 import com.mapswithme.util.NetworkPolicy;
+import com.mapswithme.util.SharedPropertiesUtils;
 import com.mapswithme.util.ThemeSwitcher;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.concurrency.UiThread;
@@ -595,7 +596,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     if (pref == null)
       return;
 
-    ((TwoStatePreference)pref).setChecked(Config.isStatisticsEnabled());
+    ((TwoStatePreference)pref).setChecked(SharedPropertiesUtils.isStatisticsEnabled());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
     {
       @Override

--- a/android/src/com/mapswithme/util/Config.java
+++ b/android/src/com/mapswithme/util/Config.java
@@ -24,7 +24,7 @@ public final class Config
   private static final String KEY_DOWNLOADER_AUTO = "AutoDownloadEnabled";
 
   private static final String KEY_PREF_ZOOM_BUTTONS = "ZoomButtonsEnabled";
-  private static final String KEY_PREF_STATISTICS = "StatisticsEnabled";
+  static final String KEY_PREF_STATISTICS = "StatisticsEnabled";
   private static final String KEY_PREF_USE_GS = "UseGoogleServices";
 
   private static final String KEY_MISC_DISCLAIMER_ACCEPTED = "IsDisclaimerApproved";
@@ -170,14 +170,9 @@ public final class Config
     setBool(KEY_PREF_ZOOM_BUTTONS, show);
   }
 
-  public static boolean isStatisticsEnabled()
-  {
-    return MwmApplication.prefs().getBoolean(KEY_PREF_STATISTICS, true);
-  }
-
   public static void setStatisticsEnabled(boolean enabled)
   {
-    MwmApplication.prefs().edit().putBoolean(KEY_PREF_STATISTICS, enabled).apply();
+    setBool(KEY_PREF_STATISTICS, enabled);
   }
 
   public static boolean useGoogleServices()

--- a/android/src/com/mapswithme/util/SharedPropertiesUtils.java
+++ b/android/src/com/mapswithme/util/SharedPropertiesUtils.java
@@ -5,12 +5,24 @@ import android.preference.PreferenceManager;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.R;
 
+import static com.mapswithme.util.Config.KEY_PREF_STATISTICS;
+
 public final class SharedPropertiesUtils
 {
   public static boolean isShowcaseSwitchedOnLocal()
   {
     return PreferenceManager.getDefaultSharedPreferences(MwmApplication.get())
         .getBoolean(MwmApplication.get().getString(R.string.pref_showcase_switched_on), false);
+  }
+
+  public static boolean isStatisticsEnabled()
+  {
+    return MwmApplication.prefs().getBoolean(KEY_PREF_STATISTICS, true);
+  }
+
+  public static void setStatisticsEnabled(boolean enabled)
+  {
+    MwmApplication.prefs().edit().putBoolean(KEY_PREF_STATISTICS, enabled).apply();
   }
 
   //Utils class

--- a/android/src/com/mapswithme/util/statistics/Statistics.java
+++ b/android/src/com/mapswithme/util/statistics/Statistics.java
@@ -34,6 +34,7 @@ import com.mapswithme.util.BatteryState;
 import com.mapswithme.util.Config;
 import com.mapswithme.util.ConnectionState;
 import com.mapswithme.util.Counters;
+import com.mapswithme.util.SharedPropertiesUtils;
 import com.my.tracker.MyTracker;
 
 import java.lang.annotation.Retention;
@@ -349,8 +350,7 @@ public enum Statistics
 
   Statistics()
   {
-    mEnabled = Config.isStatisticsEnabled();
-    Config.setStatisticsEnabled(mEnabled);
+    mEnabled = SharedPropertiesUtils.isStatisticsEnabled();
     final Context context = MwmApplication.get();
     // At the moment we need special handling for Alohalytics to enable/disable logging of events in core C++ code.
     if (mEnabled)
@@ -441,6 +441,7 @@ public enum Statistics
 
   public void setStatEnabled(boolean isEnabled)
   {
+    SharedPropertiesUtils.setStatisticsEnabled(isEnabled);
     Config.setStatisticsEnabled(isEnabled);
 
     // We track if user turned on/off statistics to understand data better.


### PR DESCRIPTION
[android] Core reads the 'StatisticsEnabled' setting from the settings.ini. And problem was that the mentioned setting wasn't stored in settings.ini because of write permission migh not be granted at that moment. Now, the setting is set to setting.ini safely, i.e. when all needed permissions are granted.