### PR TITLE
MAPSME-5212 исправление GetVehicleModelForCountry

### DIFF
--- a/generator/generator_tool/generator_tool.pro
+++ b/generator/generator_tool/generator_tool.pro
@@ -18,6 +18,10 @@ TEMPLATE = app
 # needed for Platform::WorkingDir() and unicode combining
 QT *= core
 
+!iphone*:!android*:!tizen:!macx-* {
+  QT *= network
+}
+
 macx-* {
   LIBS *= "-framework IOKit" "-framework SystemConfiguration"
 }

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -1,12 +1,17 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 namespace routing
 {
-bool BuildRoutingIndex(std::string const & filename, std::string const & country);
+using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
+
+bool BuildRoutingIndex(std::string const & filename, std::string const & country,
+                       CountryParentNameGetterFn const & countryParentNameGetterFn);
 bool BuildCrossMwmSection(std::string const & path, std::string const & mwmFile,
-                          std::string const & country, std::string const & osmToFeatureFile,
-                          bool disableCrossMwmProgress);
+                          std::string const & country,
+                          CountryParentNameGetterFn const & countryParentNameGetterFn,
+                          std::string const & osmToFeatureFile, bool disableCrossMwmProgress);
 }  // namespace routing

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -65,7 +65,11 @@
 #include "base/strings_bundle.hpp"
 #include "base/thread_checker.hpp"
 
+#include "std/function.hpp"
 #include "std/list.hpp"
+#include "std/set.hpp"
+#include "std/shared_ptr.hpp"
+#include "std/string.hpp"
 #include "std/target_os.hpp"
 #include "std/unique_ptr.hpp"
 #include "std/vector.hpp"
@@ -382,10 +386,10 @@ public:
   void SetCurrentCountryChangedListener(TCurrentCountryChanged const & listener);
 
   vector<MwmSet::MwmId> GetMwmsByRect(m2::RectD const & rect, bool rough) const;
-  MwmSet::MwmId GetMwmIdByName(std::string const & name) const;
+  MwmSet::MwmId GetMwmIdByName(string const & name) const;
 
-  void ReadFeatures(std::function<void(FeatureType const &)> const & reader,
-                    std::set<FeatureID> const & features);
+  void ReadFeatures(function<void(FeatureType const &)> const & reader,
+                    set<FeatureID> const & features);
 
 private:
   struct TapEvent
@@ -431,7 +435,7 @@ private:
   vector<m2::PointF> m_searchMarksSizes;
 
 private:
-  std::vector<m2::TriangleD> GetSelectedFeatureTriangles() const;
+  vector<m2::TriangleD> GetSelectedFeatureTriangles() const;
 
 public:
 
@@ -657,7 +661,7 @@ private:
   /// @returns true if command was handled by editor.
   bool ParseEditorDebugCommand(search::SearchParams const & params);
   /// @returns true if command was handled by drape.
-  bool ParseDrapeDebugCommand(std::string const & query);
+  bool ParseDrapeDebugCommand(string const & query);
 
   void FillFeatureInfo(FeatureID const & fid, place_page::Info & info) const;
   /// @param customTitle, if not empty, overrides any other calculated name.
@@ -770,7 +774,7 @@ public:
 protected:
   /// RoutingManager::Delegate
   void OnRouteFollow(routing::RouterType type) override;
-  void RegisterCountryFilesOnRoute(std::shared_ptr<routing::NumMwmIds> ptr) const override;
+  void RegisterCountryFilesOnRoute(shared_ptr<routing::NumMwmIds> ptr) const override;
 
 public:
   /// @name Editor interface.

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -389,8 +389,10 @@ void RoutingManager::SetRouterImpl(RouterType type)
   };
 
   auto fetcher = make_unique<OnlineAbsentCountriesFetcher>(countryFileGetter, localFileChecker);
-  auto router = make_unique<IndexRouter>(vehicleType, countryFileGetter, getMwmRectByName, numMwmIds,
-    MakeNumMwmTree(*numMwmIds, m_callbacks.m_countryInfoGetter()), m_routingSession, index);
+  auto router = make_unique<IndexRouter>(vehicleType, m_callbacks.m_countryParentNameGetterFn,
+                                         countryFileGetter, getMwmRectByName, numMwmIds,
+                                         MakeNumMwmTree(*numMwmIds, m_callbacks.m_countryInfoGetter()),
+                                         m_routingSession, index);
 
   m_routingSession.SetRoutingSettings(GetRoutingSettings(vehicleType));
   m_routingSession.SetRouter(move(router), move(fetcher));

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -68,14 +68,19 @@ public:
   {
     using IndexGetterFn = std::function<Index &()>;
     using CountryInfoGetterFn = std::function<storage::CountryInfoGetter &()>;
+    using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
 
-    Callbacks(IndexGetterFn && featureIndexGetter, CountryInfoGetterFn && countryInfoGetter)
-      : m_indexGetter(std::move(featureIndexGetter))
-      , m_countryInfoGetter(std::move(countryInfoGetter))
+    template <typename IndexGetter, typename CountryInfoGetter, typename CountryParentNameGetter>
+    Callbacks(IndexGetter && featureIndexGetter, CountryInfoGetter && countryInfoGetter,
+              CountryParentNameGetter && countryParentNameGetter)
+      : m_indexGetter(std::forward<IndexGetter>(featureIndexGetter))
+      , m_countryInfoGetter(std::forward<CountryInfoGetter>(countryInfoGetter))
+      , m_countryParentNameGetterFn(std::forward<CountryParentNameGetter>(countryParentNameGetter))
     {}
 
     IndexGetterFn m_indexGetter;
     CountryInfoGetterFn m_countryInfoGetter;
+    CountryParentNameGetterFn m_countryParentNameGetterFn;
   };
 
   using RouteBuildingCallback =

--- a/openlr/openlr_simple_decoder.cpp
+++ b/openlr/openlr_simple_decoder.cpp
@@ -77,7 +77,11 @@ bool OpenLRSimpleDecoder::SegmentsFilter::Matches(LinearSegment const & segment)
 }
 
 // OpenLRSimpleDecoder -----------------------------------------------------------------------------
-OpenLRSimpleDecoder::OpenLRSimpleDecoder(vector<Index> const & indexes) : m_indexes(indexes) {}
+OpenLRSimpleDecoder::OpenLRSimpleDecoder(
+    vector<Index> const & indexes, CountryParentNameGetterFn const & countryParentNameGetterFn)
+  : m_indexes(indexes), m_countryParentNameGetterFn(countryParentNameGetterFn)
+{
+}
 
 void OpenLRSimpleDecoder::Decode(std::vector<LinearSegment> const & segments,
                                  uint32_t const numThreads, std::vector<DecodedPath> & paths)
@@ -95,7 +99,7 @@ void OpenLRSimpleDecoder::Decode(std::vector<LinearSegment> const & segments,
   auto worker = [&segments, &paths, kBatchSize, kProgressFrequency, kOffsetToleranceM, numThreads,
                  this](size_t threadNum, Index const & index, Stats & stats) {
     FeaturesRoadGraph roadGraph(index, IRoadGraph::Mode::ObeyOnewayTag,
-                                make_unique<CarModelFactory>());
+                                make_unique<CarModelFactory>(m_countryParentNameGetterFn));
     RoadInfoGetter roadInfoGetter(index);
     Router router(roadGraph, roadInfoGetter);
 

--- a/openlr/openlr_simple_decoder.hpp
+++ b/openlr/openlr_simple_decoder.hpp
@@ -5,6 +5,7 @@
 #include <routing/road_graph.hpp>
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -21,6 +22,8 @@ DECLARE_EXCEPTION(DecoderError, RootException);
 class OpenLRSimpleDecoder
 {
 public:
+  using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
+
   class SegmentsFilter
   {
   public:
@@ -34,7 +37,8 @@ public:
     bool const m_multipointsOnly;
   };
 
-  OpenLRSimpleDecoder(std::vector<Index> const & indexes);
+  OpenLRSimpleDecoder(std::vector<Index> const & indexes,
+                      CountryParentNameGetterFn const & countryParentNameGetterFn);
 
   // Maps partner segments to mwm paths. |segments| should be sorted by partner id.
   void Decode(std::vector<LinearSegment> const & segments, uint32_t const numThreads,
@@ -42,5 +46,6 @@ public:
 
 private:
   std::vector<Index> const & m_indexes;
+  CountryParentNameGetterFn m_countryParentNameGetterFn;
 };
 }  // namespace openlr

--- a/openlr/openlr_stat/CMakeLists.txt
+++ b/openlr/openlr_stat/CMakeLists.txt
@@ -12,6 +12,7 @@ omim_link_libraries(${PROJECT_NAME}
   openlr
   routing
   routing_common
+  storage
   indexer
   editor
   platform

--- a/openlr/openlr_stat/openlr_stat.cpp
+++ b/openlr/openlr_stat/openlr_stat.cpp
@@ -5,6 +5,8 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/index.hpp"
 
+#include "storage/country_parent_getter.hpp"
+
 #include "platform/local_country_file.hpp"
 #include "platform/local_country_file_utils.hpp"
 #include "platform/platform.hpp"
@@ -19,6 +21,8 @@
 
 #include "3party/gflags/src/gflags/gflags.h"
 #include "3party/pugixml/src/pugixml.hpp"
+
+#include "std/unique_ptr.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -39,6 +43,9 @@ DEFINE_int32(limit, -1, "Max number of segments to handle. -1 for all.");
 DEFINE_bool(multipoints_only, false, "Only segments with multiple points to handle.");
 DEFINE_int32(num_threads, 1, "Number of threads.");
 DEFINE_string(ids_path, "", "Path to a file with segment ids to process.");
+DEFINE_string(countries_filename, "",
+              "Name of countries file which describes mwm tree. Used to get country specific "
+              "routing restrictions.");
 
 using namespace openlr;
 
@@ -214,7 +221,8 @@ int main(int argc, char * argv[])
   std::vector<Index> indexes(numThreads);
   LoadIndexes(FLAGS_mwms_path, indexes);
 
-  OpenLRSimpleDecoder decoder(indexes);
+  OpenLRSimpleDecoder decoder(indexes, storage::CountryParentGetter(FLAGS_countries_filename,
+                                                                    GetPlatform().ResourcesDir()));
 
   pugi::xml_document document;
   auto const load_result = document.load_file(FLAGS_input.data());

--- a/openlr/openlr_stat/openlr_stat.pro
+++ b/openlr/openlr_stat/openlr_stat.pro
@@ -16,6 +16,10 @@ TEMPLATE = app
 # needed for Platform::WorkingDir() and unicode combining
 QT *= core
 
+!iphone*:!android*:!tizen:!macx-* {
+  QT *= network
+}
+
 macx-* {
   LIBS *= "-framework IOKit" "-framework SystemConfiguration"
 }

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -44,8 +44,9 @@ void CrossMwmGraph::ClosestSegment::Update(double distM, Segment const & bestSeg
 }
 
 // CrossMwmGraph ----------------------------------------------------------------------------------
-CrossMwmGraph::CrossMwmGraph(shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
-                             shared_ptr<VehicleModelFactory> vehicleModelFactory,
+CrossMwmGraph::CrossMwmGraph(shared_ptr<NumMwmIds> numMwmIds,
+                             shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
+                             shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
                              CourntryRectFn const & countryRectFn, Index & index,
                              RoutingIndexManager & indexManager)
   : m_index(index)

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -33,7 +33,7 @@ public:
   };
 
   CrossMwmGraph(std::shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
-                std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                std::shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
                 CourntryRectFn const & countryRectFn, Index & index,
                 RoutingIndexManager & indexManager);
 
@@ -151,7 +151,7 @@ private:
   Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   std::shared_ptr<m4::Tree<NumMwmId>> m_numMwmTree;
-  std::shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
+  std::shared_ptr<VehicleModelFactoryInterface> m_vehicleModelFactory;
   CourntryRectFn const & m_countryRectFn;
   CrossMwmIndexGraph m_crossMwmIndexGraph;
   CrossMwmOsrmGraph m_crossMwmOsrmGraph;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -25,12 +25,12 @@ namespace routing
 class FeaturesRoadGraph : public IRoadGraph
 {
 private:
-  class CrossCountryVehicleModel : public IVehicleModel
+  class CrossCountryVehicleModel : public VehicleModelInterface
   {
   public:
-    CrossCountryVehicleModel(shared_ptr<VehicleModelFactory> vehicleModelFactory);
+    CrossCountryVehicleModel(shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory);
 
-    // IVehicleModel overrides:
+    // VehicleModelInterface overrides:
     double GetSpeed(FeatureType const & f) const override;
     double GetMaxSpeed() const override;
     bool IsOneWay(FeatureType const & f) const override;
@@ -40,12 +40,12 @@ private:
     void Clear();
 
   private:
-    IVehicleModel * GetVehicleModel(FeatureID const & featureId) const;
+    VehicleModelInterface * GetVehicleModel(FeatureID const & featureId) const;
 
-    shared_ptr<VehicleModelFactory> const m_vehicleModelFactory;
+    shared_ptr<VehicleModelFactoryInterface> const m_vehicleModelFactory;
     double const m_maxSpeedKMPH;
 
-    mutable map<MwmSet::MwmId, shared_ptr<IVehicleModel>> m_cache;
+    mutable map<MwmSet::MwmId, shared_ptr<VehicleModelInterface>> m_cache;
   };
 
   class RoadInfoCache
@@ -62,7 +62,7 @@ private:
 
 public:
   FeaturesRoadGraph(Index const & index, IRoadGraph::Mode mode,
-                    shared_ptr<VehicleModelFactory> vehicleModelFactory);
+                    shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory);
 
   static int GetStreetReadScale();
 

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -20,13 +20,13 @@ class GeometryLoaderImpl final : public GeometryLoader
 {
 public:
   GeometryLoaderImpl(Index const & index, MwmSet::MwmHandle const & handle,
-                     shared_ptr<IVehicleModel> vehicleModel, bool loadAltitudes);
+                     shared_ptr<VehicleModelInterface> vehicleModel, bool loadAltitudes);
 
   // GeometryLoader overrides:
   void Load(uint32_t featureId, RoadGeometry & road) override;
 
 private:
-  shared_ptr<IVehicleModel> m_vehicleModel;
+  shared_ptr<VehicleModelInterface> m_vehicleModel;
   Index::FeaturesLoaderGuard m_guard;
   string const m_country;
   feature::AltitudeLoader m_altitudeLoader;
@@ -34,7 +34,7 @@ private:
 };
 
 GeometryLoaderImpl::GeometryLoaderImpl(Index const & index, MwmSet::MwmHandle const & handle,
-                                       shared_ptr<IVehicleModel> vehicleModel, bool loadAltitudes)
+                                       shared_ptr<VehicleModelInterface> vehicleModel, bool loadAltitudes)
   : m_vehicleModel(move(vehicleModel))
   , m_guard(index, handle.GetId())
   , m_country(handle.GetInfo()->GetCountryName())
@@ -66,18 +66,18 @@ void GeometryLoaderImpl::Load(uint32_t featureId, RoadGeometry & road)
 class FileGeometryLoader final : public GeometryLoader
 {
 public:
-  FileGeometryLoader(string const & fileName, shared_ptr<IVehicleModel> vehicleModel);
+  FileGeometryLoader(string const & fileName, shared_ptr<VehicleModelInterface> vehicleModel);
 
   // GeometryLoader overrides:
   void Load(uint32_t featureId, RoadGeometry & road) override;
 
 private:
   FeaturesVectorTest m_featuresVector;
-  shared_ptr<IVehicleModel> m_vehicleModel;
+  shared_ptr<VehicleModelInterface> m_vehicleModel;
 };
 
 FileGeometryLoader::FileGeometryLoader(string const & fileName,
-                                       shared_ptr<IVehicleModel> vehicleModel)
+                                       shared_ptr<VehicleModelInterface> vehicleModel)
   : m_featuresVector(FilesContainerR(make_unique<FileReader>(fileName)))
   , m_vehicleModel(vehicleModel)
 {
@@ -106,7 +106,7 @@ RoadGeometry::RoadGeometry(bool oneWay, double speed, Points const & points)
     m_junctions.emplace_back(point, feature::kDefaultAltitudeMeters);
 }
 
-void RoadGeometry::Load(IVehicleModel const & vehicleModel, FeatureType const & feature,
+void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType const & feature,
                         feature::TAltitudes const * altitudes)
 {
   CHECK(altitudes == nullptr || altitudes->size() == feature.GetPointsCount(), ());
@@ -156,7 +156,7 @@ RoadGeometry const & Geometry::GetRoad(uint32_t featureId)
 // static
 unique_ptr<GeometryLoader> GeometryLoader::Create(Index const & index,
                                                   MwmSet::MwmHandle const & handle,
-                                                  shared_ptr<IVehicleModel> vehicleModel,
+                                                  shared_ptr<VehicleModelInterface> vehicleModel,
                                                   bool loadAltitudes)
 {
   CHECK(handle.IsAlive(), ());
@@ -165,7 +165,7 @@ unique_ptr<GeometryLoader> GeometryLoader::Create(Index const & index,
 
 // static
 unique_ptr<GeometryLoader> GeometryLoader::CreateFromFile(string const & fileName,
-                                                          shared_ptr<IVehicleModel> vehicleModel)
+                                                          shared_ptr<VehicleModelInterface> vehicleModel)
 {
   return make_unique<FileGeometryLoader>(fileName, vehicleModel);
 }

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -27,7 +27,7 @@ public:
   RoadGeometry() = default;
   RoadGeometry(bool oneWay, double speed, Points const & points);
 
-  void Load(IVehicleModel const & vehicleModel, FeatureType const & feature,
+  void Load(VehicleModelInterface const & vehicleModel, FeatureType const & feature,
             feature::TAltitudes const * altitudes);
 
   bool IsOneWay() const { return m_isOneWay; }
@@ -75,13 +75,13 @@ public:
   // handle should be alive: it is caller responsibility to check it.
   static std::unique_ptr<GeometryLoader> Create(Index const & index,
                                                 MwmSet::MwmHandle const & handle,
-                                                std::shared_ptr<IVehicleModel> vehicleModel,
+                                                std::shared_ptr<VehicleModelInterface> vehicleModel,
                                                 bool loadAltitudes);
 
   /// This is for stand-alone work.
   /// Use in generator_tool and unit tests.
   static std::unique_ptr<GeometryLoader> CreateFromFile(
-      std::string const & fileName, std::shared_ptr<IVehicleModel> vehicleModel);
+      std::string const & fileName, std::shared_ptr<VehicleModelInterface> vehicleModel);
 };
 
 class Geometry final

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -19,7 +19,7 @@ class IndexGraphLoaderImpl final : public IndexGraphLoader
 {
 public:
   IndexGraphLoaderImpl(VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
-                       shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                       shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
                        shared_ptr<EdgeEstimator> estimator, Index & index);
 
   // IndexGraphLoader overrides:
@@ -32,13 +32,13 @@ private:
   VehicleMask m_vehicleMask;
   Index & m_index;
   shared_ptr<NumMwmIds> m_numMwmIds;
-  shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
+  shared_ptr<VehicleModelFactoryInterface> m_vehicleModelFactory;
   shared_ptr<EdgeEstimator> m_estimator;
   unordered_map<NumMwmId, unique_ptr<IndexGraph>> m_graphs;
 };
 
 IndexGraphLoaderImpl::IndexGraphLoaderImpl(VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
-                                           shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                                           shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
                                            shared_ptr<EdgeEstimator> estimator, Index & index)
   : m_vehicleMask(GetVehicleMask(vehicleType))
   , m_index(index)
@@ -67,7 +67,7 @@ IndexGraph & IndexGraphLoaderImpl::Load(NumMwmId numMwmId)
   if (!handle.IsAlive())
     MYTHROW(RoutingException, ("Can't get mwm handle for", file));
 
-  shared_ptr<IVehicleModel> vehicleModel =
+  shared_ptr<VehicleModelInterface> vehicleModel =
       m_vehicleModelFactory->GetVehicleModelForCountry(file.GetName());
 
   auto graphPtr = make_unique<IndexGraph>(
@@ -112,7 +112,7 @@ namespace routing
 // static
 unique_ptr<IndexGraphLoader> IndexGraphLoader::Create(
     VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
-    shared_ptr<VehicleModelFactory> vehicleModelFactory, shared_ptr<EdgeEstimator> estimator,
+    shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory, shared_ptr<EdgeEstimator> estimator,
     Index & index)
 {
   return make_unique<IndexGraphLoaderImpl>(vehicleType, numMwmIds, vehicleModelFactory, estimator,

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -23,7 +23,7 @@ public:
 
   static std::unique_ptr<IndexGraphLoader> Create(
       VehicleType vehicleType, std::shared_ptr<NumMwmIds> numMwmIds,
-      std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
+      std::shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
       std::shared_ptr<EdgeEstimator> estimator, Index & index);
 };
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -55,8 +55,10 @@ public:
     m2::PointD const m_direction;
   };
 
-  IndexRouter(VehicleType vehicleType, TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
-              shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree, traffic::TrafficCache const & trafficCache, Index & index);
+  IndexRouter(VehicleType vehicleType, CountryParentNameGetterFn const & countryParentNameGetterFn,
+              TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
+              shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
+              traffic::TrafficCache const & trafficCache, Index & index);
 
   // IRouter overrides:
   std::string GetName() const override { return m_name; }
@@ -105,7 +107,7 @@ private:
   VehicleType m_vehicleType;
   std::string const m_name;
   Index & m_index;
-  std::shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
+  std::shared_ptr<VehicleModelFactoryInterface> m_vehicleModelFactory;
 
   TCountryFileFn const m_countryFileFn;
   CourntryRectFn const m_countryRectFn;

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -116,7 +116,7 @@ void FindClosestEdges(IRoadGraph const & graph, m2::PointD const & point,
 RoadGraphRouter::~RoadGraphRouter() {}
 RoadGraphRouter::RoadGraphRouter(string const & name, Index const & index,
                                  TCountryFileFn const & countryFileFn, IRoadGraph::Mode mode,
-                                 unique_ptr<VehicleModelFactory> && vehicleModelFactory,
+                                 unique_ptr<VehicleModelFactoryInterface> && vehicleModelFactory,
                                  unique_ptr<IRoutingAlgorithm> && algorithm,
                                  unique_ptr<IDirectionsEngine> && directionsEngine)
   : m_name(name)
@@ -236,7 +236,7 @@ unique_ptr<IRouter> CreatePedestrianAStarRouter(Index & index,
                                                 TCountryFileFn const & countryFileFn,
                                                 shared_ptr<NumMwmIds> numMwmIds)
 {
-  unique_ptr<VehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
+  unique_ptr<VehicleModelFactoryInterface> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(
       new PedestrianDirectionsEngine(std::move(numMwmIds)));
@@ -250,7 +250,7 @@ unique_ptr<IRouter> CreatePedestrianAStarBidirectionalRouter(Index & index,
                                                              TCountryFileFn const & countryFileFn,
                                                              shared_ptr<NumMwmIds> numMwmIds)
 {
-  unique_ptr<VehicleModelFactory> vehicleModelFactory(new PedestrianModelFactory());
+  unique_ptr<VehicleModelFactoryInterface> vehicleModelFactory(new PedestrianModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(
       new PedestrianDirectionsEngine(std::move(numMwmIds)));
@@ -264,7 +264,7 @@ unique_ptr<IRouter> CreateBicycleAStarBidirectionalRouter(Index & index,
                                                           TCountryFileFn const & countryFileFn,
                                                           shared_ptr<NumMwmIds> numMwmIds)
 {
-  unique_ptr<VehicleModelFactory> vehicleModelFactory(new BicycleModelFactory());
+  unique_ptr<VehicleModelFactoryInterface> vehicleModelFactory(new BicycleModelFactory());
   unique_ptr<IRoutingAlgorithm> algorithm(new AStarBidirectionalRoutingAlgorithm());
   unique_ptr<IDirectionsEngine> directionsEngine(
     new BicycleDirectionsEngine(index, numMwmIds));

--- a/routing/road_graph_router.hpp
+++ b/routing/road_graph_router.hpp
@@ -26,7 +26,7 @@ class RoadGraphRouter : public IRouter
 {
 public:
   RoadGraphRouter(string const & name, Index const & index, TCountryFileFn const & countryFileFn,
-                  IRoadGraph::Mode mode, unique_ptr<VehicleModelFactory> && vehicleModelFactory,
+                  IRoadGraph::Mode mode, unique_ptr<VehicleModelFactoryInterface> && vehicleModelFactory,
                   unique_ptr<IRoutingAlgorithm> && algorithm,
                   unique_ptr<IDirectionsEngine> && directionsEngine);
   ~RoadGraphRouter() override;

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -17,6 +17,7 @@ namespace routing
 
 using TCountryFileFn = std::function<std::string(m2::PointD const &)>;
 using CourntryRectFn = std::function<m2::RectD(std::string const & countryId)>;
+using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
 
 class Route;
 

--- a/routing/routing_benchmarks/bicycle_routing_tests.cpp
+++ b/routing/routing_benchmarks/bicycle_routing_tests.cpp
@@ -33,9 +33,9 @@ protected:
     return engine;
   }
 
-  unique_ptr<routing::VehicleModelFactory> CreateModelFactory() override
+  unique_ptr<routing::VehicleModelFactoryInterface> CreateModelFactory() override
   {
-    unique_ptr<routing::VehicleModelFactory> factory(
+    unique_ptr<routing::VehicleModelFactoryInterface> factory(
         new SimplifiedModelFactory<routing::BicycleModel>());
     return factory;
   }

--- a/routing/routing_benchmarks/helpers.hpp
+++ b/routing/routing_benchmarks/helpers.hpp
@@ -33,7 +33,7 @@ public:
 protected:
   virtual unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
       shared_ptr<routing::NumMwmIds> numMwmIds) = 0;
-  virtual unique_ptr<routing::VehicleModelFactory> CreateModelFactory() = 0;
+  virtual unique_ptr<routing::VehicleModelFactoryInterface> CreateModelFactory() = 0;
 
   template <typename Algorithm>
   unique_ptr<routing::IRouter> CreateRouter(string const & name)
@@ -57,7 +57,7 @@ protected:
 };
 
 template <typename Model>
-class SimplifiedModelFactory : public routing::VehicleModelFactory
+class SimplifiedModelFactory : public routing::VehicleModelFactoryInterface
 {
 public:
   // Since for test purposes we compare routes lengths to check
@@ -66,7 +66,7 @@ public:
   class SimplifiedModel : public Model
   {
   public:
-    // IVehicleModel overrides:
+    // VehicleModelInterface overrides:
     //
     // SimplifiedModel::GetSpeed() filters features and returns zero
     // speed if feature is not allowed by the base model, or otherwise
@@ -83,9 +83,10 @@ public:
   };
 
   SimplifiedModelFactory() : m_model(make_shared<SimplifiedModel>()) {}
-  // VehicleModelFactory overrides:
-  shared_ptr<routing::IVehicleModel> GetVehicleModel() const override { return m_model; }
-  shared_ptr<routing::IVehicleModel> GetVehicleModelForCountry(
+
+  // VehicleModelFactoryInterface overrides:
+  shared_ptr<routing::VehicleModelInterface> GetVehicleModel() const override { return m_model; }
+  shared_ptr<routing::VehicleModelInterface> GetVehicleModelForCountry(
       string const & /*country*/) const override
   {
     return m_model;

--- a/routing/routing_benchmarks/pedestrian_routing_tests.cpp
+++ b/routing/routing_benchmarks/pedestrian_routing_tests.cpp
@@ -50,9 +50,9 @@ protected:
     return engine;
   }
 
-  unique_ptr<routing::VehicleModelFactory> CreateModelFactory() override
+  unique_ptr<routing::VehicleModelFactoryInterface> CreateModelFactory() override
   {
-    unique_ptr<routing::VehicleModelFactory> factory(
+    unique_ptr<routing::VehicleModelFactoryInterface> factory(
         new SimplifiedModelFactory<routing::PedestrianModel>());
     return factory;
   }

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -26,6 +26,7 @@
 
 #include "geometry/distance_on_sphere.hpp"
 
+#include "std/functional.hpp"
 #include "std/limits.hpp"
 
 #include "private.h"
@@ -102,8 +103,9 @@ namespace integration
     }
     
     auto vehicleType = VehicleType::Car;
-    auto indexRouter = make_unique<IndexRouter>(vehicleType, countryFileGetter, getMwmRectByName, numMwmIds,
-      MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, index);
+    auto indexRouter = make_unique<IndexRouter>(vehicleType, CountryParentNameGetterFn(), countryFileGetter,
+                                                getMwmRectByName, numMwmIds,
+                                                MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, index);
 
     return indexRouter;
   }

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -266,8 +266,8 @@ shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & tr
 
 shared_ptr<EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash)
 {
-  return EdgeEstimator::Create(VehicleType::Car, CarModelFactory().GetVehicleModel()->GetMaxSpeed(),
-                               trafficStash);
+  return EdgeEstimator::Create(VehicleType::Car,
+                               CarModelFactory({}).GetVehicleModel()->GetMaxSpeed(), trafficStash);
 }
 
 AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & starter,

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -2,10 +2,6 @@
 
 #include "routing_common/vehicle_model.hpp"
 
-#include <memory>
-#include <string>
-#include <unordered_map>
-
 namespace routing
 {
 
@@ -37,15 +33,8 @@ private:
 class BicycleModelFactory : public VehicleModelFactory
 {
 public:
-  BicycleModelFactory();
-
-  /// @name Overrides from VehicleModelFactory.
-  //@{
-  std::shared_ptr<IVehicleModel> GetVehicleModel() const override;
-  std::shared_ptr<IVehicleModel> GetVehicleModelForCountry(std::string const & country) const override;
-  //@}
-
-private:
-  std::unordered_map<std::string, std::shared_ptr<IVehicleModel>> m_models;
+  // TODO: remove countryParentNameGetterFn default value after removing unused bicycle routing
+  // from road_graph_router
+  BicycleModelFactory(CountryParentNameGetterFn const & countryParentNameGetterFn = {});
 };
 }  // namespace routing

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -236,7 +236,8 @@ vector<routing::VehicleModel::AdditionalRoadTags> const & CarModel::GetAdditiona
   return kAdditionalTags;
 }
 
-CarModelFactory::CarModelFactory()
+CarModelFactory::CarModelFactory(CountryParentNameGetterFn const & countryParentNameGetterFn)
+  : VehicleModelFactory(countryParentNameGetterFn)
 {
   // Names must be the same with country names from countries.txt
   m_models[""] = make_shared<CarModel>(g_carLimitsDefault);
@@ -264,24 +265,5 @@ CarModelFactory::CarModelFactory()
   m_models["Ukraine"] = make_shared<CarModel>(g_carLimitsUkraine);
   m_models["United Kingdom"] = make_shared<CarModel>(g_carLimitsUK);
   m_models["United States of America"] = make_shared<CarModel>(g_carLimitsUS);
-}
-
-shared_ptr<IVehicleModel> CarModelFactory::GetVehicleModel() const
-{
-  auto const itr = m_models.find("");
-  ASSERT(itr != m_models.end(), ());
-  return itr->second;
-}
-
-shared_ptr<IVehicleModel> CarModelFactory::GetVehicleModelForCountry(string const & country) const
-{
-  auto const itr = m_models.find(country);
-  if (itr != m_models.end())
-  {
-    LOG(LDEBUG, ("Car model was found:", country));
-    return itr->second;
-  }
-  LOG(LDEBUG, ("Car model wasn't found, default car model is used instead:", country));
-  return GetVehicleModel();
 }
 }  // namespace routing

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -2,10 +2,6 @@
 
 #include "routing_common/vehicle_model.hpp"
 
-#include <memory>
-#include <string>
-#include <unordered_map>
-
 namespace routing
 {
 
@@ -26,13 +22,6 @@ private:
 class CarModelFactory : public VehicleModelFactory
 {
 public:
-  CarModelFactory();
-
-  // VehicleModelFactory overrides:
-  std::shared_ptr<IVehicleModel> GetVehicleModel() const override;
-  std::shared_ptr<IVehicleModel> GetVehicleModelForCountry(std::string const & country) const override;
-
-private:
-  std::unordered_map<std::string, std::shared_ptr<IVehicleModel>> m_models;
+  CarModelFactory(CountryParentNameGetterFn const & countryParentNameGetterF);
 };
 }  // namespace routing

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -2,10 +2,6 @@
 
 #include "routing_common/vehicle_model.hpp"
 
-#include <memory>
-#include <string>
-#include <unordered_map>
-
 namespace routing
 {
 
@@ -32,15 +28,8 @@ private:
 class PedestrianModelFactory : public VehicleModelFactory
 {
 public:
-  PedestrianModelFactory();
-
-  /// @name Overrides from VehicleModelFactory.
-  //@{
-  std::shared_ptr<IVehicleModel> GetVehicleModel() const override;
-  std::shared_ptr<IVehicleModel> GetVehicleModelForCountry(std::string const & country) const override;
-  //@}
-
-private:
-  std::unordered_map<std::string, std::shared_ptr<IVehicleModel>> m_models;
+  // TODO: remove countryParentNameGetterFn default value after removing unused pedestrian routing
+  // from road_graph_router
+  PedestrianModelFactory(CountryParentNameGetterFn const & countryParentNameGetterFn = {});
 };
 }  // namespace routing

--- a/routing_common/routing_common_tests/CMakeLists.txt
+++ b/routing_common/routing_common_tests/CMakeLists.txt
@@ -2,6 +2,7 @@ project(routing_common_tests)
 
 set(
   SRC
+  vehicle_model_for_country_test.cpp
   vehicle_model_test.cpp
 )
 

--- a/routing_common/routing_common_tests/routing_common_tests.pro
+++ b/routing_common/routing_common_tests/routing_common_tests.pro
@@ -17,4 +17,5 @@ QT *= core
 
 SOURCES += \
   ../../testing/testingmain.cpp \
+  vehicle_model_for_country_test.cpp \
   vehicle_model_test.cpp \

--- a/routing_common/routing_common_tests/vehicle_model_for_country_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_for_country_test.cpp
@@ -1,0 +1,155 @@
+#include "testing/testing.hpp"
+
+#include "routing_common/bicycle_model.hpp"
+#include "routing_common/car_model.hpp"
+#include "routing_common/pedestrian_model.hpp"
+
+#include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
+
+#include <memory>
+#include <string>
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+class  VehicleModelTest
+{
+public:
+  VehicleModelTest() { classificator::Load(); }
+};
+
+string GetRegionParent(string const & id)
+{
+  if (id == "Moscow")
+    return "Russian Federation";
+  if (id == "Munich")
+    return "Bavaria";
+  if (id == "Bavaria")
+    return "Germany";
+  if (id == "San Francisco")
+    return "California";
+  if (id == "California")
+    return "United States of America";
+  return "";
+}
+
+template <typename VehicleModelType, typename VehicleModelFactoryType>
+void TestVehicleModelDefault()
+{
+  auto defaultVehicleModel = make_shared<VehicleModelType>();
+
+  VehicleModelFactoryType vehicleModelFactory = VehicleModelFactoryType(GetRegionParent);
+
+  // Use static_pointer_cast here because VehicleModelInterface do not have EqualsForTests method
+  shared_ptr<VehicleModelType> defaultVehicleModelForCountry = static_pointer_cast<VehicleModelType>(
+      vehicleModelFactory.GetVehicleModelForCountry("Nonexistent Country Name"));
+  TEST(defaultVehicleModel->EqualsForTests(*defaultVehicleModelForCountry),
+       ("Vehicle model for nonexistent counry is not equal to default."));
+}
+
+// DirectParent and IndirectParent tests require tested countries to have nondefault restriction
+// If selected countries will change their restrictions to default, select other countries for tests
+template <typename VehicleModelType, typename VehicleModelFactoryType>
+void TestHaveNondefaultRestrictionForSelectedCountry(string country)
+{
+  auto defaultVehicleModel = make_shared<VehicleModelType>();
+
+  VehicleModelFactoryType vehicleModelFactory = VehicleModelFactoryType(GetRegionParent);
+
+  shared_ptr<VehicleModelType> vehicleModelCountry =
+      static_pointer_cast<VehicleModelType>(vehicleModelFactory.GetVehicleModelForCountry(country));
+
+  TEST(!(vehicleModelCountry->EqualsForTests(*defaultVehicleModel)),
+       (country,
+        "has default model. It may be ok if traffic restrictions was changed. "
+        "If so, select other country for this and next test."));
+}
+
+template <typename VehicleModelType, typename VehicleModelFactoryType>
+void ParentTest(string child, string parent)
+{
+  VehicleModelFactoryType vehicleModelFactory = VehicleModelFactoryType(GetRegionParent);
+
+  shared_ptr<VehicleModelType> vehicleModelChild =
+      static_pointer_cast<VehicleModelType>(vehicleModelFactory.GetVehicleModelForCountry(child));
+  shared_ptr<VehicleModelType> vehicleModelParent =
+      static_pointer_cast<VehicleModelType>(vehicleModelFactory.GetVehicleModelForCountry(parent));
+
+  TEST(vehicleModelChild->EqualsForTests(*vehicleModelParent),
+       ("Can not expand car model for", child, "to", parent));
+}
+}  // namespace
+
+// Test we have default vehicle models for nonexistent(unknown) country
+UNIT_CLASS_TEST(VehicleModelTest, CarModel_Default)
+{
+  TestVehicleModelDefault<CarModel, CarModelFactory>();
+}
+
+UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_Default)
+{
+  TestVehicleModelDefault<BicycleModel, BicycleModelFactory>();
+}
+
+UNIT_CLASS_TEST(VehicleModelTest, PedestrianModel_Default)
+{
+  TestVehicleModelDefault<PedestrianModel, PedestrianModelFactory>();
+}
+
+// 1. Test we have nondefault car model for Russia
+// 2. Test we can get car model for Moscow using GetRegionParent callback: car model for Moscow equals
+//    car model for Russia and it's not default model.
+UNIT_CLASS_TEST(VehicleModelTest, CarModel_DirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<CarModel, CarModelFactory>("Russian Federation");
+  ParentTest<CarModel, CarModelFactory>("Moscow", "Russian Federation");
+}
+
+// 1. Test we have nondefault bicycle model for Russia
+// 2. Test we can get bicycle model for Moscow using GetRegionParent callback: bicycle model for Moscow
+//    equals bicycle model for Russia and it's not default model.
+UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_DirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<BicycleModel, BicycleModelFactory>(
+      "Russian Federation");
+  ParentTest<BicycleModel, BicycleModelFactory>("Moscow", "Russian Federation");
+}
+
+// 1. Test we have nondefault pedestrian model for Russia
+// 2. Test we can get pedestrian model for Moscow using GetRegionParent callback: pedestrian model for
+//    Moscow equals pedestrian model for Russia and it's not default model.
+UNIT_CLASS_TEST(VehicleModelTest, PedestrianModel_DirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<PedestrianModel, PedestrianModelFactory>(
+      "Russian Federation");
+  ParentTest<PedestrianModel, PedestrianModelFactory>("Moscow", "Russian Federation");
+}
+
+// Test has the same idea as previous one except Germany is not direct parent of Munich
+// in GetRegionParent function: Munich -> Bavaria -> Germany 
+UNIT_CLASS_TEST(VehicleModelTest, CarModel_InirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<CarModel, CarModelFactory>("Germany");
+  ParentTest<CarModel, CarModelFactory>("Munich", "Germany");
+}
+
+// Test has the same idea as previous one except United States of America are not direct parent of 
+// San Francisco in GetRegionParent function: San Francisco -> California -> United States of America
+UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_IndirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<BicycleModel, BicycleModelFactory>(
+      "United States of America");
+  ParentTest<BicycleModel, BicycleModelFactory>("San Francisco", "United States of America");
+}
+
+// Test has the same idea as previous one except United States of America are not direct parent of 
+// San Francisco in GetRegionParent function: San Francisco -> California -> United States of America
+UNIT_CLASS_TEST(VehicleModelTest, PedestrianModel_IndirectParent)
+{
+  TestHaveNondefaultRestrictionForSelectedCountry<PedestrianModel, PedestrianModelFactory>(
+      "United States of America");
+  ParentTest<PedestrianModel, PedestrianModelFactory>("San Francisco", "United States of America");
+}

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -18,6 +18,12 @@ routing::VehicleModel::InitListT const s_testLimits = {
     {{"highway", "service"}, 50, false},
 };
 
+class  VehicleModelTest
+{
+public:
+  VehicleModelTest() { classificator::Load(); }
+};
+
 class TestVehicleModel : public routing::VehicleModel
 {
   friend void CheckOneWay(initializer_list<uint32_t> const & types, bool expectedValue);
@@ -71,15 +77,13 @@ void CheckTransitAllowed(initializer_list<uint32_t> const & types, bool expected
 }
 }  // namespace
 
-UNIT_TEST(VehicleModel_MaxSpeed)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_MaxSpeed)
 {
-  classificator::Load();
-
   TestVehicleModel vehicleModel;
   TEST_EQUAL(vehicleModel.GetMaxSpeed(), 150, ());
 }
 
-UNIT_TEST(VehicleModel_Speed)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_Speed)
 {
   CheckSpeed({GetType("highway", "secondary", "bridge")}, 80.0);
   CheckSpeed({GetType("highway", "secondary", "tunnel")}, 80.0);
@@ -90,7 +94,7 @@ UNIT_TEST(VehicleModel_Speed)
   CheckSpeed({GetType("highway", "residential")}, 50.0);
 }
 
-UNIT_TEST(VehicleModel_Speed_MultiTypes)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_Speed_MultiTypes)
 {
   uint32_t const typeTunnel = GetType("highway", "secondary", "tunnel");
   uint32_t const typeSecondary = GetType("highway", "secondary");
@@ -101,7 +105,7 @@ UNIT_TEST(VehicleModel_Speed_MultiTypes)
   CheckSpeed({typeHighway, typeTunnel}, 80.0);
 }
 
-UNIT_TEST(VehicleModel_OneWay)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_OneWay)
 {
   uint32_t const typeBridge = GetType("highway", "secondary", "bridge");
   uint32_t const typeOneway = GetOnewayType();
@@ -114,7 +118,7 @@ UNIT_TEST(VehicleModel_OneWay)
   CheckOneWay({typeOneway}, true);
 }
 
-UNIT_TEST(VehicleModel_DifferentSpeeds)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_DifferentSpeeds)
 {
   uint32_t const typeSecondary = GetType("highway", "secondary");
   uint32_t const typePrimary = GetType("highway", "primary");
@@ -127,7 +131,7 @@ UNIT_TEST(VehicleModel_DifferentSpeeds)
   CheckOneWay({typePrimary, typeOneway, typeSecondary}, true);
 }
 
-UNIT_TEST(VehicleModel_TransitAllowed)
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_TransitAllowed)
 {
   CheckTransitAllowed({GetType("highway", "secondary")}, true);
   CheckTransitAllowed({GetType("highway", "primary")}, true);

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -2,6 +2,7 @@
 
 #include <initializer_list>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,7 +15,7 @@ namespace feature { class TypesHolder; }
 namespace routing
 {
 
-class IVehicleModel
+class VehicleModelInterface
 {
 public:
   enum class RoadAvailability
@@ -24,7 +25,7 @@ public:
     Unknown,
   };
 
-  virtual ~IVehicleModel() {}
+  virtual ~VehicleModelInterface() {}
 
   /// @return Allowed speed in KMpH.
   /// 0 means that it's forbidden to move on this feature or it's not a road at all.
@@ -42,20 +43,20 @@ public:
   virtual bool IsTransitAllowed(FeatureType const & f) const = 0;
 };
 
-class VehicleModelFactory
+class VehicleModelFactoryInterface
 {
 public:
-  virtual ~VehicleModelFactory() {}
+  virtual ~VehicleModelFactoryInterface() {}
   /// @return Default vehicle model which corresponds for all countrines,
   /// but it may be non optimal for some countries
-  virtual std::shared_ptr<IVehicleModel> GetVehicleModel() const = 0;
+  virtual std::shared_ptr<VehicleModelInterface> GetVehicleModel() const = 0;
 
   /// @return The most optimal vehicle model for specified country
-  virtual std::shared_ptr<IVehicleModel> GetVehicleModelForCountry(
+  virtual std::shared_ptr<VehicleModelInterface> GetVehicleModelForCountry(
       std::string const & country) const = 0;
 };
 
-class VehicleModel : public IVehicleModel
+class VehicleModel : public VehicleModelInterface
 {
 public:
   struct FeatureTypeLimits final
@@ -82,7 +83,7 @@ public:
 
   VehicleModel(Classificator const & c, InitListT const & featureTypeLimits);
 
-  /// IVehicleModel overrides:
+  /// VehicleModelInterface overrides:
   double GetSpeed(FeatureType const & f) const override;
   double GetMaxSpeed() const override { return m_maxSpeedKMpH; }
   bool IsOneWay(FeatureType const & f) const override;
@@ -102,6 +103,13 @@ public:
         return true;
     }
     return false;
+  }
+
+  bool EqualsForTests(VehicleModel const & rhs) const
+  {
+    return (m_types == rhs.m_types) &&
+           (m_addRoadTypes == rhs.m_addRoadTypes) &&
+           (m_onewayType == rhs.m_onewayType);
   }
 
 protected:
@@ -143,6 +151,10 @@ private:
 
     double GetSpeedKMpH() const { return m_speedKMpH; };
     bool IsTransitAllowed() const { return m_isTransitAllowed; };
+    bool operator==(RoadLimits const & rhs) const
+    {
+      return (m_speedKMpH == rhs.m_speedKMpH) && (m_isTransitAllowed == rhs.m_isTransitAllowed);
+    }
 
   private:
     double const m_speedKMpH;
@@ -157,5 +169,28 @@ private:
   uint32_t m_onewayType;
 };
 
-std::string DebugPrint(IVehicleModel::RoadAvailability const l);
+class VehicleModelFactory : public VehicleModelFactoryInterface
+{
+public:
+  // Callback which takes territory name (mwm graph node name) and returns its parent
+  // territory name. Used to properly find local restrictions in GetVehicleModelForCountry.
+  // For territories which do not have parent (countries) or have multiple parents
+  // (disputed territories) it should return empty name.
+  // For example "Munich" -> "Bavaria"; "Bavaria" -> "Germany"; "Germany" -> ""
+  using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
+
+  std::shared_ptr<VehicleModelInterface> GetVehicleModel() const override;
+
+  std::shared_ptr<VehicleModelInterface> GetVehicleModelForCountry(
+      std::string const & country) const override;
+
+protected:
+  VehicleModelFactory(CountryParentNameGetterFn const & countryParentNameGetterFn);
+  std::string GetParent(std::string const & country) const;
+
+  std::unordered_map<std::string, std::shared_ptr<VehicleModelInterface>> m_models;
+  CountryParentNameGetterFn m_countryParentNameGetterFn;
+};
+
+std::string DebugPrint(VehicleModelInterface::RoadAvailability const l);
 }  // namespace routing

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -13,6 +13,8 @@ set(
   country_info_getter.hpp
   country_name_getter.cpp
   country_name_getter.hpp
+  country_parent_getter.cpp
+  country_parent_getter.hpp
   country_polygon.hpp
   country_tree.hpp
   diff_scheme/diff_scheme_checker.cpp

--- a/storage/country_parent_getter.cpp
+++ b/storage/country_parent_getter.cpp
@@ -1,0 +1,18 @@
+#include "storage/country_parent_getter.hpp"
+
+namespace storage
+{
+CountryParentGetter::CountryParentGetter(std::string const & countriesFile,
+                                         std::string const & countriesDir)
+{
+  if (countriesFile.empty())
+    m_storage = make_shared<Storage>();
+  else
+    m_storage = make_shared<Storage>(countriesFile, countriesDir);
+}
+
+std::string CountryParentGetter::operator()(std::string const & id) const
+{
+  return m_storage->GetParentIdFor(id);
+}
+}  // namespace storage

--- a/storage/country_parent_getter.hpp
+++ b/storage/country_parent_getter.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "storage/storage.hpp"
+
+#include <memory>
+#include <string>
+
+namespace storage
+{
+class CountryParentGetter
+{
+public:
+  CountryParentGetter(std::string const & countriesFile = "",
+                      std::string const & countriesDir = "");
+  std::string operator()(std::string const & id) const;
+
+private:
+  shared_ptr<Storage> m_storage;
+};
+}  // namespace storage

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -1680,4 +1680,22 @@ void Storage::GetTopmostNodesFor(TCountryId const & countryId, TCountriesVec & n
   }
 }
 
+TCountryId const Storage::GetParentIdFor(TCountryId const & countryId) const
+{
+  vector<TCountryTreeNode const *> nodes;
+  m_countries.Find(countryId, nodes);
+  if (nodes.empty())
+  {
+    LOG(LWARNING, ("TCountryId =", countryId, "not found in m_countries."));
+    return string();
+  }
+
+  if (nodes.size() > 1)
+  {
+    // Disputed territory. Has multiple parents.
+    return string();
+  }
+
+  return nodes[0]->Value().GetParent();
+}
 }  // namespace storage

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -365,6 +365,10 @@ public:
   /// Puts |countryId| to |nodes| when |level| is greater than the level of |countyId|. 
   void GetTopmostNodesFor(TCountryId const & countryId, TCountriesVec & nodes, size_t level = 0) const;
 
+  /// \brief Returns parent id for node if node has single parent. Otherwise (if node is disputed
+  /// territory and has multiple parents or does not exist) returns empty TCountryId
+  TCountryId const GetParentIdFor(TCountryId const & countryId) const;
+
   /// \brief Returns current version for mwms which are used by storage.
   inline int64_t GetCurrentDataVersion() const { return m_currentVersion; }
 

--- a/storage/storage.pro
+++ b/storage/storage.pro
@@ -15,6 +15,7 @@ HEADERS += \
   country_decl.hpp \
   country_info_getter.hpp \
   country_name_getter.hpp \
+  country_parent_getter.hpp \
   country_polygon.hpp \
   country_tree.hpp \
   diff_scheme/diff_scheme_checker.hpp \
@@ -34,6 +35,7 @@ SOURCES += \
   country_decl.cpp \
   country_info_getter.cpp \
   country_name_getter.cpp \
+  country_parent_getter.cpp \
   diff_scheme/diff_scheme_checker.cpp \
   downloading_policy.cpp \
   http_map_files_downloader.cpp \

--- a/xcode/routing_common/routing_common.xcodeproj/project.pbxproj
+++ b/xcode/routing_common/routing_common.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		40FF45D01F388EF80046BD40 /* vehicle_model_for_country_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40FF45CF1F388EF80046BD40 /* vehicle_model_for_country_test.cpp */; };
 		671E78881E6A3C5D00B2859B /* bicycle_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671E78801E6A3C5D00B2859B /* bicycle_model.cpp */; };
 		671E78891E6A3C5D00B2859B /* bicycle_model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 671E78811E6A3C5D00B2859B /* bicycle_model.hpp */; };
 		671E788A1E6A3C5D00B2859B /* car_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671E78821E6A3C5D00B2859B /* car_model.cpp */; };
@@ -34,6 +35,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		40FF45CF1F388EF80046BD40 /* vehicle_model_for_country_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vehicle_model_for_country_test.cpp; sourceTree = "<group>"; };
 		671E78721E6A3BE200B2859B /* librouting_common.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = librouting_common.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		671E78801E6A3C5D00B2859B /* bicycle_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_model.cpp; sourceTree = "<group>"; };
 		671E78811E6A3C5D00B2859B /* bicycle_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_model.hpp; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 		671E78971E6A3DA800B2859B /* routing_common_tests */ = {
 			isa = PBXGroup;
 			children = (
+				40FF45CF1F388EF80046BD40 /* vehicle_model_for_country_test.cpp */,
 				671E78AF1E6A3FEF00B2859B /* testingmain.cpp */,
 				671E78AD1E6A3FDB00B2859B /* vehicle_model_test.cpp */,
 			);
@@ -271,6 +274,7 @@
 				671E788A1E6A3C5D00B2859B /* car_model.cpp in Sources */,
 				671E78881E6A3C5D00B2859B /* bicycle_model.cpp in Sources */,
 				671E788E1E6A3C5D00B2859B /* vehicle_model.cpp in Sources */,
+				40FF45D01F388EF80046BD40 /* vehicle_model_for_country_test.cpp in Sources */,
 				671E788C1E6A3C5D00B2859B /* pedestrian_model.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/storage/storage.xcodeproj/project.pbxproj
+++ b/xcode/storage/storage.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		34B093261C61F9BA0066F4C3 /* app_store.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 34B093211C61F9BA0066F4C3 /* app_store.hpp */; };
 		34C9BCFC1C6CCF85000DC38D /* country_name_getter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34C9BCFA1C6CCF85000DC38D /* country_name_getter.cpp */; };
 		34C9BCFD1C6CCF85000DC38D /* country_name_getter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 34C9BCFB1C6CCF85000DC38D /* country_name_getter.hpp */; };
+		401ECED41F56C50900DFDF76 /* country_parent_getter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 401ECED21F56C50900DFDF76 /* country_parent_getter.cpp */; };
+		401ECED51F56C50900DFDF76 /* country_parent_getter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 401ECED31F56C50900DFDF76 /* country_parent_getter.hpp */; };
 		56D8CB991CAC17A80003F420 /* test_defines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56D8CB971CAC17A80003F420 /* test_defines.cpp */; };
 		56D8CB9A1CAC17A80003F420 /* test_defines.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56D8CB981CAC17A80003F420 /* test_defines.hpp */; };
 		671182CE1C7E06B400CB8177 /* storage_3levels_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671182CC1C7E069C00CB8177 /* storage_3levels_tests.cpp */; };
@@ -186,6 +188,8 @@
 		34C9BCFB1C6CCF85000DC38D /* country_name_getter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = country_name_getter.hpp; sourceTree = "<group>"; };
 		34F5584A1DBF2FC000A4FC11 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34F5584B1DBF2FC000A4FC11 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
+		401ECED21F56C50900DFDF76 /* country_parent_getter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = country_parent_getter.cpp; sourceTree = "<group>"; };
+		401ECED31F56C50900DFDF76 /* country_parent_getter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = country_parent_getter.hpp; sourceTree = "<group>"; };
 		56D8CB971CAC17A80003F420 /* test_defines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_defines.cpp; sourceTree = "<group>"; };
 		56D8CB981CAC17A80003F420 /* test_defines.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = test_defines.hpp; sourceTree = "<group>"; };
 		671182CC1C7E069C00CB8177 /* storage_3levels_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = storage_3levels_tests.cpp; sourceTree = "<group>"; };
@@ -510,6 +514,8 @@
 		675342E21A3F59EF00A0A8C3 /* storage */ = {
 			isa = PBXGroup;
 			children = (
+				401ECED21F56C50900DFDF76 /* country_parent_getter.cpp */,
+				401ECED31F56C50900DFDF76 /* country_parent_getter.hpp */,
 				F68CC5BB1F38B967007527C7 /* diff_scheme_checker.cpp */,
 				F68CC5BC1F38B967007527C7 /* diff_scheme_checker.hpp */,
 				F68CC5BD1F38B967007527C7 /* diff_types.hpp */,
@@ -585,6 +591,7 @@
 				56D8CB9A1CAC17A80003F420 /* test_defines.hpp in Headers */,
 				6753430D1A3F5A2600A0A8C3 /* country_polygon.hpp in Headers */,
 				F68CC5C01F38B967007527C7 /* diff_types.hpp in Headers */,
+				401ECED51F56C50900DFDF76 /* country_parent_getter.hpp in Headers */,
 				34C9BCFD1C6CCF85000DC38D /* country_name_getter.hpp in Headers */,
 				6741251F1B4C05FA00A3E828 /* http_map_files_downloader.hpp in Headers */,
 				67BE1DC61CD2180D00572709 /* downloading_policy.hpp in Headers */,
@@ -765,6 +772,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				56D8CB991CAC17A80003F420 /* test_defines.cpp in Sources */,
+				401ECED41F56C50900DFDF76 /* country_parent_getter.cpp in Sources */,
 				6753430E1A3F5A2600A0A8C3 /* country.cpp in Sources */,
 				67AF4A001BC579DD0048B1ED /* country_info_getter.cpp in Sources */,
 				34B093221C61F9BA0066F4C3 /* storage_helpers.cpp in Sources */,


### PR DESCRIPTION
GetVehicleModelForCountry работала таким образом, что ожидала на вход получить имя страны, но при этом в большинстве случаев на вход передается имя mwm и в месте вызова нет возможности получить имя страны.
Новая версия требует для работы колбек, возвращающий по имени территории имя родительской территории, что позволит во-первых по имени mwm понимать какой стране он принадлежит, во-вторых иметь более гибкую систему ограничений (можно будет задать для Мюнхена одни ограничения, для остальной Баварии другие, для остальной Германии третьи).
Для работы этого механизма был добавлен соответствующий метод в store.
Для роутинга метод берется из store в framework и передается в routing_manager, а оттуда в роутинг.
В утилитах (не библиотеках) из generator и openlr был проинициализирован store, чтобы получить информацию о дереве mwm.
В дальнейшем хорошим планом является выделение работы с деревом mwm из store.