### PR TITLE
[routing] Intermediate route point predictor.

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -12,6 +12,8 @@
 
 #include "tracking/reporter.hpp"
 
+#include "geometry/point2d.hpp"
+
 #include "base/thread_checker.hpp"
 
 #include <functional>
@@ -243,7 +245,6 @@ private:
   void SetPointsFollowingMode(bool enabled);
 
   void ReorderIntermediatePoints();
-  std::vector<int8_t> PredictIntermediatePointsOrder(std::vector<m2::PointD> const & points);
 
   RouteBuildingCallback m_routingCallback = nullptr;
   Callbacks m_callbacks;

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -17,6 +17,8 @@ set(
   base/followed_polyline.hpp
   bicycle_directions.cpp
   bicycle_directions.hpp
+  checkpoint_predictor.cpp
+  checkpoint_predictor.hpp
   checkpoints.cpp
   checkpoints.hpp
   coding.hpp

--- a/routing/checkpoint_predictor.cpp
+++ b/routing/checkpoint_predictor.cpp
@@ -1,0 +1,82 @@
+#include "routing/checkpoint_predictor.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/stl_helpers.hpp"
+
+#include <limits>
+
+namespace routing
+{
+using namespace std;
+
+vector<int8_t> CheckpointPredictor::operator()(vector<m2::PointD> const & intermediatePoints)
+{
+  if (intermediatePoints.empty())
+    return {};
+  if (intermediatePoints.size() == 1)
+    return {0};
+
+  // Preparing |checkPoints|. It's all route points (including start and finish) except for the point
+  // which is adding.
+  m2::PointD const & addingPoint = intermediatePoints[0];
+  vector<m2::PointD> checkPoints(intermediatePoints.cbegin() + 1, intermediatePoints.cend());
+  checkPoints.insert(checkPoints.begin(), m_start);
+  checkPoints.push_back(m_finish);
+  CHECK_EQUAL(checkPoints.size(), intermediatePoints.size() + 1, ());
+
+  // Looking for the best place for |addingPoint| between points at |checkPoints|.
+  double const kInvalidDistance = numeric_limits<double>::max();
+  double minDistMeters = kInvalidDistance;
+  // |minDistIdx| is a zero based index of a section between two points at |checkPoints|
+  // which should be split to minimize the result of |DistanceBetweenPointsMeters(checkPointsWithAdding)|.
+  size_t minDistIdx = 0;
+  for (size_t i = 1; i < checkPoints.size(); ++i)
+  {
+    vector<m2::PointD> checkPointsWithAdding(checkPoints.cbegin(), checkPoints.cend());
+    checkPointsWithAdding.insert(checkPointsWithAdding.begin() + i, addingPoint);
+    double const distBetweenPointsMeters = DistanceBetweenPointsMeters(checkPointsWithAdding);
+    if (distBetweenPointsMeters < minDistMeters)
+    {
+      minDistMeters = distBetweenPointsMeters;
+      minDistIdx = i - 1;
+    }
+  }
+  CHECK_NOT_EQUAL(minDistMeters, kInvalidDistance, ());
+
+  // Preparing |order|.
+  vector<int8_t> order;
+  order.reserve(intermediatePoints.size());
+  for (size_t i = 0; i < intermediatePoints.size() - 1; ++i)
+    order.push_back(i);
+
+  // |minDistIdx| is a place for |addingPoint|. Increasing intermediate point indices which is greater
+  // or equal to |minDistIdx| to empty place for |addingPoint|.
+  // Note. |addingPoint| is places at the beginning of |intermediatePoints|.
+  CHECK_LESS_OR_EQUAL(minDistIdx, order.size(), ());
+  for (size_t i = minDistIdx; i < order.size(); ++i)
+    ++order[i];
+  order.insert(order.begin(), static_cast<int8_t>(minDistIdx));
+  CHECK_EQUAL(order.size(), intermediatePoints.size(), ());
+
+#ifdef DEBUG
+  vector<int8_t> orderToCheck(order.cbegin(), order.cend());
+  my::SortUnique(orderToCheck);
+  ASSERT_EQUAL(orderToCheck.size(), intermediatePoints.size(), ());
+  ASSERT_EQUAL(orderToCheck.back() + 1, orderToCheck.size(), ());
+#endif
+  return order;
+}
+
+double DistanceBetweenPointsMeters(vector<m2::PointD> const & points)
+{
+  if (points.size() <= 1)
+    return 0.0;
+
+  double length = 0.0;
+  for (size_t i = 1; i < points.size(); ++i)
+    length += MercatorBounds::DistanceOnEarth(points[i - 1], points[i]);
+
+  return length;
+}
+}  // namespace routing

--- a/routing/checkpoint_predictor.cpp
+++ b/routing/checkpoint_predictor.cpp
@@ -10,73 +10,46 @@ namespace routing
 {
 using namespace std;
 
-vector<int8_t> CheckpointPredictor::operator()(vector<m2::PointD> const & intermediatePoints)
+size_t CheckpointPredictor::PredictPosition(vector<m2::PointD> const & intermediatePoints,
+                                            m2::PointD const & point) const
 {
-  if (intermediatePoints.empty())
-    return {};
-  if (intermediatePoints.size() == 1)
-    return {0};
-
-  // Preparing |checkPoints|. It's all route points (including start and finish) except for the point
-  // which is adding.
-  m2::PointD const & addingPoint = intermediatePoints[0];
-  vector<m2::PointD> checkPoints(intermediatePoints.cbegin() + 1, intermediatePoints.cend());
-  checkPoints.insert(checkPoints.begin(), m_start);
-  checkPoints.push_back(m_finish);
-  CHECK_EQUAL(checkPoints.size(), intermediatePoints.size() + 1, ());
-
-  // Looking for the best place for |addingPoint| between points at |checkPoints|.
-  double const kInvalidDistance = numeric_limits<double>::max();
-  double minDistMeters = kInvalidDistance;
-  // |minDistIdx| is a zero based index of a section between two points at |checkPoints|
-  // which should be split to minimize the result of |DistanceBetweenPointsMeters(checkPointsWithAdding)|.
-  size_t minDistIdx = 0;
-  for (size_t i = 1; i < checkPoints.size(); ++i)
+  double constexpr kInvalidDistance = numeric_limits<double>::max();
+  double minDeltaMeters = kInvalidDistance;
+  size_t minDeltaIdx = 0;
+  // Checkpoints include start, all the intermediate points and finish.
+  size_t const checkpointNum = intermediatePoints.size() + 2 /* for start and finish points */;
+  for (size_t i = 0; i + 1 != checkpointNum; ++i)
   {
-    vector<m2::PointD> checkPointsWithAdding(checkPoints.cbegin(), checkPoints.cend());
-    checkPointsWithAdding.insert(checkPointsWithAdding.begin() + i, addingPoint);
-    double const distBetweenPointsMeters = DistanceBetweenPointsMeters(checkPointsWithAdding);
-    if (distBetweenPointsMeters < minDistMeters)
+    double const delta = CalculateDeltaMeters(GetCheckpoint(intermediatePoints, i),
+                                              GetCheckpoint(intermediatePoints, i + 1), point);
+    if (minDeltaMeters > delta)
     {
-      minDistMeters = distBetweenPointsMeters;
-      minDistIdx = i - 1;
+      minDeltaMeters = delta;
+      minDeltaIdx = i;
     }
   }
-  CHECK_NOT_EQUAL(minDistMeters, kInvalidDistance, ());
 
-  // Preparing |order|.
-  vector<int8_t> order;
-  order.reserve(intermediatePoints.size());
-  for (size_t i = 0; i < intermediatePoints.size() - 1; ++i)
-    order.push_back(i);
-
-  // |minDistIdx| is a place for |addingPoint|. Increasing intermediate point indices which is greater
-  // or equal to |minDistIdx| to empty place for |addingPoint|.
-  // Note. |addingPoint| is places at the beginning of |intermediatePoints|.
-  CHECK_LESS_OR_EQUAL(minDistIdx, order.size(), ());
-  for (size_t i = minDistIdx; i < order.size(); ++i)
-    ++order[i];
-  order.insert(order.begin(), static_cast<int8_t>(minDistIdx));
-  CHECK_EQUAL(order.size(), intermediatePoints.size(), ());
-
-#ifdef DEBUG
-  vector<int8_t> orderToCheck(order.cbegin(), order.cend());
-  my::SortUnique(orderToCheck);
-  ASSERT_EQUAL(orderToCheck.size(), intermediatePoints.size(), ());
-  ASSERT_EQUAL(orderToCheck.back() + 1, orderToCheck.size(), ());
-#endif
-  return order;
+  CHECK_NOT_EQUAL(minDeltaMeters, kInvalidDistance, ());
+  return minDeltaIdx;
 }
 
-double DistanceBetweenPointsMeters(vector<m2::PointD> const & points)
+m2::PointD const & CheckpointPredictor::GetCheckpoint(vector<m2::PointD> const & intermediatePoints,
+                                                      size_t index) const
 {
-  if (points.size() <= 1)
-    return 0.0;
+  if (index == 0)
+    return m_start;
+  if (index <= intermediatePoints.size())
+    return intermediatePoints[index - 1];
+  CHECK_EQUAL(index, intermediatePoints.size() + 1, ());
+  return m_finish;
+}
 
-  double length = 0.0;
-  for (size_t i = 1; i < points.size(); ++i)
-    length += MercatorBounds::DistanceOnEarth(points[i - 1], points[i]);
-
-  return length;
+double CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to,
+                            m2::PointD const & between)
+{
+  double const directDist = MercatorBounds::DistanceOnEarth(from, to);
+  double const distThroughPoint = MercatorBounds::DistanceOnEarth(from, between) +
+                                  MercatorBounds::DistanceOnEarth(between, to);
+  return distThroughPoint - directDist;
 }
 }  // namespace routing

--- a/routing/checkpoint_predictor.cpp
+++ b/routing/checkpoint_predictor.cpp
@@ -10,18 +10,28 @@ namespace routing
 {
 using namespace std;
 
-size_t CheckpointPredictor::PredictPosition(vector<m2::PointD> const & intermediatePoints,
+// static
+double CheckpointPredictor::CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to,
+                                                 m2::PointD const & between)
+{
+  double const directDist = MercatorBounds::DistanceOnEarth(from, to);
+  double const distThroughPoint = MercatorBounds::DistanceOnEarth(from, between) +
+                                  MercatorBounds::DistanceOnEarth(between, to);
+  return distThroughPoint - directDist;
+}
+
+size_t CheckpointPredictor::PredictPosition(vector<m2::PointD> const & points,
                                             m2::PointD const & point) const
 {
   double constexpr kInvalidDistance = numeric_limits<double>::max();
   double minDeltaMeters = kInvalidDistance;
   size_t minDeltaIdx = 0;
   // Checkpoints include start, all the intermediate points and finish.
-  size_t const checkpointNum = intermediatePoints.size() + 2 /* for start and finish points */;
+  size_t const checkpointNum = points.size() + 2 /* for start and finish points */;
   for (size_t i = 0; i + 1 != checkpointNum; ++i)
   {
-    double const delta = CalculateDeltaMeters(GetCheckpoint(intermediatePoints, i),
-                                              GetCheckpoint(intermediatePoints, i + 1), point);
+    double const delta = CalculateDeltaMeters(GetCheckpoint(points, i),
+                                              GetCheckpoint(points, i + 1), point);
     if (minDeltaMeters > delta)
     {
       minDeltaMeters = delta;
@@ -33,23 +43,14 @@ size_t CheckpointPredictor::PredictPosition(vector<m2::PointD> const & intermedi
   return minDeltaIdx;
 }
 
-m2::PointD const & CheckpointPredictor::GetCheckpoint(vector<m2::PointD> const & intermediatePoints,
+m2::PointD const & CheckpointPredictor::GetCheckpoint(vector<m2::PointD> const & points,
                                                       size_t index) const
 {
   if (index == 0)
     return m_start;
-  if (index <= intermediatePoints.size())
-    return intermediatePoints[index - 1];
-  CHECK_EQUAL(index, intermediatePoints.size() + 1, ());
+  if (index <= points.size())
+    return points[index - 1];
+  CHECK_EQUAL(index, points.size() + 1, ());
   return m_finish;
-}
-
-double CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to,
-                            m2::PointD const & between)
-{
-  double const directDist = MercatorBounds::DistanceOnEarth(from, to);
-  double const distThroughPoint = MercatorBounds::DistanceOnEarth(from, between) +
-                                  MercatorBounds::DistanceOnEarth(between, to);
-  return distThroughPoint - directDist;
 }
 }  // namespace routing

--- a/routing/checkpoint_predictor.hpp
+++ b/routing/checkpoint_predictor.hpp
@@ -3,38 +3,42 @@
 #include "geometry/point2d.hpp"
 
 #include <cstdint>
+#include <iterator>
 #include <vector>
 
 namespace routing
 {
 /// \brief This class is responsable for prediction of the order of intermediate route points.
 /// According to current implementation to find the best place for an adding intermediate points
-/// this class inserts an adding intermediate point between points at vector
+/// this class inserts an added intermediate point between points at vector
 /// {<route start>, <former intermediate points>, <route finish>}, calculates the length
 /// of the broken line in meters, and finds the sequence of points which gets the shortest length.
-class CheckpointPredictor
+class CheckpointPredictor final
 {
+  friend class CheckpointPredictorTest;
+
 public:
   CheckpointPredictor(m2::PointD const & start, m2::PointD const & finish)
     : m_start(start), m_finish(finish)
   {
   }
 
-  /// \brief Calculates the order of intermediate route points.
-  /// \pamam intermediatePoints intermediate route points. According to current implementation
-  /// it's assumed the |intermediatePoints[0]| is an added intermediate point and the rest items
-  /// at |intermediatePoints| are former route intermediate points which should keep their
-  /// relative order.
-  /// \returns zero based indices of route intermediate points after placing adding
-  /// intermediate point (|intermediatePoints[0]|). Please see CheckpointPredictorTest
-  /// for examples.
-  std::vector<int8_t> operator()(std::vector<m2::PointD> const & intermediatePoints);
+  /// \brief finds the best position for |point| between |intermediatePoints| to minimize the length
+  /// of broken line of |intermediatePoints| with inserted |point| between them.
+  /// \param intermediatePoints is a sequence of points on the map.
+  /// \param point is a point to be inserted between |points|.
+  /// \returns zero based index of a line segment between two points at |points|.
+  size_t PredictPosition(std::vector<m2::PointD> const & intermediatePoints, m2::PointD const & point) const;
 
 private:
+  /// \returns checkpoint by its |index|.
+  /// \note checkpoints is a sequence of points: |m_start|, |intermediatePoints|, |m_finish|.
+  m2::PointD const & GetCheckpoint(std::vector<m2::PointD> const & intermediatePoints, size_t index) const;
+
   m2::PointD const m_start;
   m2::PointD const m_finish;
 };
 
-/// \returns length of broken line |points| in meters.
-double DistanceBetweenPointsMeters(std::vector<m2::PointD> const & points);
+/// \returns difference between distance |from|->|between| + |between|->|to| and distance |from|->|to|.
+double CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to, m2::PointD const & between);
 }  // namespace routing

--- a/routing/checkpoint_predictor.hpp
+++ b/routing/checkpoint_predictor.hpp
@@ -23,22 +23,22 @@ public:
   {
   }
 
-  /// \brief finds the best position for |point| between |intermediatePoints| to minimize the length
-  /// of broken line of |intermediatePoints| with inserted |point| between them.
-  /// \param intermediatePoints is a sequence of points on the map.
+  /// \returns difference between distance |from|->|between| + |between|->|to| and distance |from|->|to|.
+  static double CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to, m2::PointD const & between);
+
+  /// \brief finds the best position for |point| between |points| to minimize the length
+  /// of broken line of |m_start|, |points| and |m_finish| with inserted |point| between them.
+  /// \param points is a sequence of points on the map.
   /// \param point is a point to be inserted between |points|.
   /// \returns zero based index of a line segment between two points at |points|.
-  size_t PredictPosition(std::vector<m2::PointD> const & intermediatePoints, m2::PointD const & point) const;
+  size_t PredictPosition(std::vector<m2::PointD> const & points, m2::PointD const & point) const;
 
 private:
   /// \returns checkpoint by its |index|.
-  /// \note checkpoints is a sequence of points: |m_start|, |intermediatePoints|, |m_finish|.
-  m2::PointD const & GetCheckpoint(std::vector<m2::PointD> const & intermediatePoints, size_t index) const;
+  /// \note checkpoints is a sequence of points: |m_start|, |points|, |m_finish|.
+  m2::PointD const & GetCheckpoint(std::vector<m2::PointD> const & points, size_t index) const;
 
   m2::PointD const m_start;
   m2::PointD const m_finish;
 };
-
-/// \returns difference between distance |from|->|between| + |between|->|to| and distance |from|->|to|.
-double CalculateDeltaMeters(m2::PointD const & from, m2::PointD const & to, m2::PointD const & between);
 }  // namespace routing

--- a/routing/checkpoint_predictor.hpp
+++ b/routing/checkpoint_predictor.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "geometry/point2d.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace routing
+{
+/// \brief This class is responsable for prediction of the order of intermediate route points.
+/// According to current implementation to find the best place for an adding intermediate points
+/// this class inserts an adding intermediate point between points at vector
+/// {<route start>, <former intermediate points>, <route finish>}, calculates the length
+/// of the broken line in meters, and finds the sequence of points which gets the shortest length.
+class CheckpointPredictor
+{
+public:
+  CheckpointPredictor(m2::PointD const & start, m2::PointD const & finish)
+    : m_start(start), m_finish(finish)
+  {
+  }
+
+  /// \brief Calculates the order of intermediate route points.
+  /// \pamam intermediatePoints intermediate route points. According to current implementation
+  /// it's assumed the |intermediatePoints[0]| is an added intermediate point and the rest items
+  /// at |intermediatePoints| are former route intermediate points which should keep their
+  /// relative order.
+  /// \returns zero based indices of route intermediate points after placing adding
+  /// intermediate point (|intermediatePoints[0]|). Please see CheckpointPredictorTest
+  /// for examples.
+  std::vector<int8_t> operator()(std::vector<m2::PointD> const & intermediatePoints);
+
+private:
+  m2::PointD const m_start;
+  m2::PointD const m_finish;
+};
+
+/// \returns length of broken line |points| in meters.
+double DistanceBetweenPointsMeters(std::vector<m2::PointD> const & points);
+}  // namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -16,6 +16,7 @@ SOURCES += \
     async_router.cpp \
     base/followed_polyline.cpp \
     bicycle_directions.cpp \
+    checkpoint_predictor.cpp \
     checkpoints.cpp \
     cross_mwm_connector.cpp \
     cross_mwm_connector_serialization.cpp \
@@ -76,6 +77,7 @@ HEADERS += \
     base/astar_weight.hpp \
     base/followed_polyline.hpp \
     bicycle_directions.hpp \
+    checkpoint_predictor.hpp \
     checkpoints.hpp \
     coding.hpp \
     cross_mwm_connector.hpp \

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -689,6 +689,14 @@ void RoutingSession::CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic
   TrafficCache::CopyTraffic(trafficColoring);
 }
 
+m2::PointD RoutingSession::GetCurrentPos() const
+{
+  threads::MutexGuard guard(m_routingSessionMutex);
+  UNUSED_VALUE(guard);
+
+  return m_currentDirection;
+}
+
 string DebugPrint(RoutingSession::State state)
 {
   switch (state)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -689,14 +689,6 @@ void RoutingSession::CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic
   TrafficCache::CopyTraffic(trafficColoring);
 }
 
-m2::PointD RoutingSession::GetCurrentPos() const
-{
-  threads::MutexGuard guard(m_routingSessionMutex);
-  UNUSED_VALUE(guard);
-
-  return m_currentDirection;
-}
-
 string DebugPrint(RoutingSession::State state)
 {
   switch (state)

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -199,6 +199,8 @@ private:
   double GetCompletionPercent() const;
   void PassCheckpoints();
 
+  m2::PointD GetCurrentPos() const;
+
 private:
   unique_ptr<AsyncRouter> m_router;
   shared_ptr<Route> m_route;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -93,6 +93,7 @@ public:
   void RebuildRoute(m2::PointD const & startPoint, TReadyCallback const & readyCallback,
                     uint32_t timeoutSec, State routeRebuildingState, bool adjustToPrevRoute);
 
+  m2::PointD GetStartPoint() const { return m_checkpoints.GetStart(); }
   m2::PointD GetEndPoint() const { return m_checkpoints.GetFinish(); }
   bool IsActive() const { return (m_state != RoutingNotActive); }
   bool IsNavigable() const { return (m_state == RouteNotStarted || m_state == OnRoute || m_state == RouteFinished); }
@@ -198,8 +199,6 @@ private:
 
   double GetCompletionPercent() const;
   void PassCheckpoints();
-
-  m2::PointD GetCurrentPos() const;
 
 private:
   unique_ptr<AsyncRouter> m_router;

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
   astar_progress_test.cpp
   astar_router_test.cpp
   async_router_test.cpp
+  checkpoint_predictor_test.cpp
   coding_test.cpp
   cross_mwm_connector_test.cpp
   cross_routing_tests.cpp

--- a/routing/routing_tests/checkpoint_predictor_test.cpp
+++ b/routing/routing_tests/checkpoint_predictor_test.cpp
@@ -1,0 +1,64 @@
+#include "testing/testing.hpp"
+
+#include "routing/checkpoint_predictor.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <cstdint>
+#include <vector>
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+double constexpr kEpsMeters = 1.0;
+
+void TestDistanceBetweenPoints(vector<m2::PointD> const & points, double expectedLengthMeters)
+{
+  double const d = DistanceBetweenPointsMeters(points);
+  TEST(my::AlmostEqualAbs(d, expectedLengthMeters, kEpsMeters), (d, expectedLengthMeters));
+}
+
+UNIT_TEST(DistanceBetweenPointsMetersTest)
+{
+  TestDistanceBetweenPoints({} /* points */, 0.0 /* expectedLengthMeters */);
+
+  TestDistanceBetweenPoints({{0.0, 0.0}} /* points */, 0.0 /* expectedLengthMeters */);
+
+  TestDistanceBetweenPoints({{0.0, 0.0}, {1.0, 0.0}} /* points */,
+                            111317.0 /* expectedLengthMeters */);
+
+  TestDistanceBetweenPoints({{0.0, 0.0}, {0.5, 0.0}, {0.5, 0.5}, {0.5, 0.0}, {1.0, 0.0}} /* points */,
+                            222633.0 /* expectedLengthMeters */);
+}
+
+UNIT_TEST(CheckpointPredictorSmokeTest)
+{
+  CheckpointPredictor checkpointPredictor({0.0, 0.0} /* start */, {1.0, 0.0} /* finish */);
+  TEST(checkpointPredictor({}).empty(), ());
+  // Single intermediate point case. It's always between the start and the finish.
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{0.5, 0.0}})), vector<int8_t>({0}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{-0.5, 0.0}})), vector<int8_t>({0}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{1.5, 0.0}})), vector<int8_t>({0}), ());
+}
+
+UNIT_TEST(CheckpointPredictorTest)
+{
+  CheckpointPredictor checkpointPredictor({0.0, 0.0} /* start */, {4.0, 0.0} /* finish */);
+  // Several intermediate point case. Intermediate point with index zero is an added intermediate point.
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{1.0, 0.5}, {2.0, -0.5}})),
+             vector<int8_t>({0, 1}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{2.0, 0.5}, {1.0, -0.5}})),
+             vector<int8_t>({1, 0}), ());
+
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{1.0, 0.5}, {2.0, -0.5}, {3.0, 0.5}})),
+             vector<int8_t>({0, 1, 2}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{2.0, 0.5}, {1.0, -0.5}, {3.0, 0.5}})),
+             vector<int8_t>({1, 0, 2}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{3.0, 0.5}, {0.0, -0.5}, {1.0, 0.5}})),
+             vector<int8_t>({2, 0, 1}), ());
+  TEST_EQUAL(checkpointPredictor(vector<m2::PointD>({{3.0, 0.5}, {1.0, -0.5}, {0.0, 0.5}})),
+             vector<int8_t>({2, 0, 1}), ());
+}
+}  // namespace

--- a/routing/routing_tests/checkpoint_predictor_test.cpp
+++ b/routing/routing_tests/checkpoint_predictor_test.cpp
@@ -36,12 +36,12 @@ public:
 
 UNIT_CLASS_TEST(CheckpointPredictorTest, CalculateDeltaMetersTest)
 {
-  TestAlmostEqual(
-      CalculateDeltaMeters({0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {1.0, 0.0} /* between */), 0.0);
-  TestAlmostEqual(
-    CalculateDeltaMeters({0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {3.0, 0.0} /* between */), 222634.0);
-  TestAlmostEqual(
-    CalculateDeltaMeters({0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {-1.0, 0.0} /* between */), 222634.0);
+  TestAlmostEqual(CheckpointPredictor::CalculateDeltaMeters(
+                      {0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {1.0, 0.0} /* between */), 0.0);
+  TestAlmostEqual(CheckpointPredictor::CalculateDeltaMeters(
+                      {0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {3.0, 0.0} /* between */), 222634.0);
+  TestAlmostEqual(CheckpointPredictor::CalculateDeltaMeters(
+                      {0.0, 0.0} /* from */, {2.0, 0.0} /* to */, {-1.0, 0.0} /* between */), 222634.0);
 }
 
 // Zero intermediate point test.

--- a/routing/routing_tests/routing_tests.pro
+++ b/routing/routing_tests/routing_tests.pro
@@ -26,6 +26,7 @@ SOURCES += \
   astar_progress_test.cpp \
   astar_router_test.cpp \
   async_router_test.cpp \
+  checkpoint_predictor_test.cpp \
   coding_test.cpp \
   cross_mwm_connector_test.cpp \
   cross_routing_tests.cpp \

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -68,6 +68,11 @@
 		56555E561D897C90009D786D /* libalohalitics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACE61C68A23B009CB89E /* libalohalitics.a */; };
 		56555E581D897C9D009D786D /* liboauthcpp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACFA1C68A2D7009CB89E /* liboauthcpp.a */; };
 		56555E591D897D28009D786D /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6742ACDE1C68A13F009CB89E /* testingmain.cpp */; };
+		5670595A1F3AF96D0062672D /* checkpoint_predictor_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */; };
+		5670595D1F3AF97F0062672D /* checkpoint_predictor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */; };
+		5670595E1F3AF97F0062672D /* checkpoint_predictor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */; };
+		567059601F3AFBD60062672D /* libicu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5670595F1F3AFBD60062672D /* libicu.a */; };
+		567059621F3AFC5C0062672D /* librouting_common.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 567059611F3AFC5C0062672D /* librouting_common.a */; };
 		568194751F03A32400450EC3 /* road_access_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194731F03A32400450EC3 /* road_access_test.cpp */; };
 		568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194741F03A32400450EC3 /* routing_helpers_tests.cpp */; };
 		5694CECA1EBA25F7004576D3 /* road_access_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */; };
@@ -334,6 +339,11 @@
 		56099E301CC9247E00A7772A /* bicycle_directions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_directions.cpp; sourceTree = "<group>"; };
 		56099E311CC9247E00A7772A /* bicycle_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_directions.hpp; sourceTree = "<group>"; };
 		56099E321CC9247E00A7772A /* directions_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = directions_engine.cpp; sourceTree = "<group>"; };
+		567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor_test.cpp; sourceTree = "<group>"; };
+		5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor.cpp; sourceTree = "<group>"; };
+		5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = checkpoint_predictor.hpp; sourceTree = "<group>"; };
+		5670595F1F3AFBD60062672D /* libicu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libicu.a; path = "../../../../Library/Developer/Xcode/DerivedData/omim-gsfdicnjgjjbizhdmwedavcucpok/Build/Products/Debug/libicu.a"; sourceTree = "<group>"; };
+		567059611F3AFC5C0062672D /* librouting_common.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = librouting_common.a; path = ../routing_common/build/Debug/librouting_common.a; sourceTree = "<group>"; };
 		568194731F03A32400450EC3 /* road_access_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access_test.cpp; sourceTree = "<group>"; };
 		568194741F03A32400450EC3 /* routing_helpers_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers_tests.cpp; sourceTree = "<group>"; };
 		5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access_serialization.cpp; sourceTree = "<group>"; };
@@ -519,6 +529,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				567059621F3AFC5C0062672D /* librouting_common.a in Frameworks */,
+				567059601F3AFBD60062672D /* libicu.a in Frameworks */,
 				56CA09E91E30F19800D05C9A /* libtraffic.a in Frameworks */,
 				3462FDAD1DC1E5BF00906FD7 /* libopening_hours.a in Frameworks */,
 				6742AD4D1C68AA59009CB89E /* librouting.a in Frameworks */,
@@ -589,6 +601,8 @@
 		56F0D7611D896DAF00045886 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				567059611F3AFC5C0062672D /* librouting_common.a */,
+				5670595F1F3AFBD60062672D /* libicu.a */,
 				56CA09E81E30F19800D05C9A /* libtraffic.a */,
 				3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */,
 			);
@@ -610,6 +624,7 @@
 		6742ACA01C68A07C009CB89E /* routing_tests */ = {
 			isa = PBXGroup;
 			children = (
+				567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */,
 				568194731F03A32400450EC3 /* road_access_test.cpp */,
 				568194741F03A32400450EC3 /* routing_helpers_tests.cpp */,
 				56CA09DE1E30E73B00D05C9A /* applying_traffic_test.cpp */,
@@ -739,6 +754,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */,
+				5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */,
 				40A111CB1F2F6776005E6AD5 /* route_weight.cpp */,
 				40A111CC1F2F6776005E6AD5 /* route_weight.hpp */,
 				5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */,
@@ -905,6 +922,7 @@
 				A120B3481B4A7BE5002F3808 /* cross_mwm_router.hpp in Headers */,
 				674F9BD31B0A580E00704FFA /* road_graph_router.hpp in Headers */,
 				0C5F5D231E798B0400307B98 /* cross_mwm_connector.hpp in Headers */,
+				5670595E1F3AF97F0062672D /* checkpoint_predictor.hpp in Headers */,
 				675344141A3F644F00A0A8C3 /* osrm_data_facade.hpp in Headers */,
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
@@ -1231,12 +1249,14 @@
 				0C5FEC5E1DDE192A0017688C /* geometry.cpp in Sources */,
 				674F9BD01B0A580E00704FFA /* online_cross_fetcher.cpp in Sources */,
 				670EE5751B664796001E8064 /* router.cpp in Sources */,
+				5670595D1F3AF97F0062672D /* checkpoint_predictor.cpp in Sources */,
 				56CA09E31E30E73B00D05C9A /* applying_traffic_test.cpp in Sources */,
 				0C5FEC621DDE192A0017688C /* joint_index.cpp in Sources */,
 				670C62131AC5A15700C38A8C /* routing_mapping.cpp in Sources */,
 				67C79BA11E2CEE1400C40034 /* restriction_loader.cpp in Sources */,
 				67C7D42D1B4EB48F00FE41AA /* turns_sound_settings.cpp in Sources */,
 				0C5FEC541DDE191E0017688C /* edge_estimator.cpp in Sources */,
+				5670595A1F3AF96D0062672D /* checkpoint_predictor_test.cpp in Sources */,
 				A120B34E1B4A7C0A002F3808 /* online_absent_fetcher.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1283,6 +1303,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(OMIM_ROOT)/iphone/Maps/MAPSME.plist";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)_common/build/Debug",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = mail.ru.routing_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1293,6 +1317,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(OMIM_ROOT)/iphone/Maps/MAPSME.plist";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)_common/build/Debug",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = mail.ru.routing_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-5059

Предсказатель, куда пользователь хочет добавить промежуточную точку маршрута и тесты на него.

При добавлении промежуточной точки маршрута нужно выбрать для нее изначально место (потом пользователь сможет подвинуть ее). Если промежуточная точка одна, то возможно только одно место между старом и финишем. При добавлении второй промежуточной точки надо понять, куда ее поставить. Между стартом и ранее добавленной пром точкой или между ранее добавленной промточкой и финишем. При добавлении третий ситуация повторяется. Относительный порядок ранее добавленных пром точек должен быть сохранен.

В данном PR реализован следующий алгоритм. Пусть у нас есть вектор точек: старт, ранее добавленные пром точки, финиш. А так же новая пром точка. Мы последовательно вставляем новую пром точку между точками данного вектора и измеряем расстояние по прямым между точками. И выбираем то положение новой пром точки, при котором это расстояние минимально.

@dobriy-eeh @rokuz @tatiana-kondakova PTAL

Все самое интересное в файлах: checkpoint_predictor.hpp/cpp