### PR TITLE
[android] Fixed restoring the state during configuration change

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -961,6 +961,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (!isChangingConfigurations())
       RoutingController.get().saveRoute();
+    else
+      // We no longer need in a saved route if it's a configuration changing: theme switching,
+      // orientation changing, etc. Otherwise, the saved route might be restored at undesirable moment.
+      RoutingController.get().deleteSavedRoute();
 
     super.onSaveInstanceState(outState);
   }

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -376,6 +376,11 @@ public class RoutingController implements TaxiManager.TaxiListener
       Framework.nativeSaveRoutePoints();
   }
 
+  public void deleteSavedRoute()
+  {
+    Framework.nativeDeleteSavedRoutePoints();
+  }
+
   public void prepare(boolean canUseMyPositionAsStart, @Nullable MapObject endPoint)
   {
     prepare(canUseMyPositionAsStart, endPoint, false);


### PR DESCRIPTION
[android] If route was saved but then the configuration change was come we should delete previously saved route, because in the next onCreate method call the obsolete route will be restored but it's a not case when we actually need to restore route.
https://jira.mail.ru/browse/MAPSME-5268