### PR TITLE
Fixed crash on switching map style

### DIFF
--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -125,8 +125,8 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
   case Message::InvalidateReadManagerRect:
     {
       ref_ptr<InvalidateReadManagerRectMessage> msg = message;
-      if (msg->NeedInvalidateAll())
-        m_readManager->InvalidateAll();
+      if (msg->NeedRestartReading())
+        m_readManager->Restart();
       else
         m_readManager->Invalidate(msg->GetTilesForInvalidate());
       break;

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -182,22 +182,22 @@ public:
   InvalidateReadManagerRectMessage(Blocker & blocker, TTilesCollection const & tiles)
     : BaseBlockingMessage(blocker)
     , m_tiles(tiles)
-    , m_needInvalidateAll(false)
+    , m_needRestartReading(false)
   {}
 
   InvalidateReadManagerRectMessage(Blocker & blocker)
     : BaseBlockingMessage(blocker)
-    , m_needInvalidateAll(true)
+    , m_needRestartReading(true)
   {}
 
   Type GetType() const override { return Message::InvalidateReadManagerRect; }
 
   TTilesCollection const & GetTilesForInvalidate() const { return m_tiles; }
-  bool NeedInvalidateAll() const { return m_needInvalidateAll; }
+  bool NeedRestartReading() const { return m_needRestartReading; }
 
 private:
   TTilesCollection m_tiles;
-  bool m_needInvalidateAll;
+  bool m_needRestartReading;
 };
 
 class ClearUserMarkGroupMessage : public Message

--- a/drape_frontend/read_manager.cpp
+++ b/drape_frontend/read_manager.cpp
@@ -78,10 +78,16 @@ void ReadManager::Stop()
   m_pool.reset();
 }
 
+void ReadManager::Restart()
+{
+  Stop();
+  Start();
+}
+
 void ReadManager::OnTaskFinished(threads::IRoutine * task)
 {
   ASSERT(dynamic_cast<ReadMWMTask *>(task) != NULL, ());
-  ReadMWMTask * t = static_cast<ReadMWMTask *>(task);
+  auto t = static_cast<ReadMWMTask *>(task);
 
   // finish tiles
   {

--- a/drape_frontend/read_manager.hpp
+++ b/drape_frontend/read_manager.hpp
@@ -38,6 +38,7 @@ public:
 
   void Start();
   void Stop();
+  void Restart();
 
   void UpdateCoverage(ScreenBase const & screen, bool have3dBuildings,
                       bool forceUpdate, bool forceUpdateUserMarks,


### PR DESCRIPTION
Когда мы меняем стиль карты, мы останавливаем потоки вычитки на BR, а затем перезагружаем текстуры. Новая версия кода гарантирует, что потоки вычитки успеют завершиться до перезагрузки текстуры. Иначе возможно чтение из неинициализированной текстуры символов и крэш.
https://fabric.io/mapsme/ios/apps/com.mapswithme.full/issues/5972703dbe077a4dccee1669/sessions/latest?build=62182939