### PR TITLE
Fixed UB on normalization zero vectors on some Android devices

### DIFF
--- a/drape_frontend/shaders/area3d.vsh.glsl
+++ b/drape_frontend/shaders/area3d.vsh.glsl
@@ -10,7 +10,7 @@ uniform float zScale;
 varying vec2 v_colorTexCoords;
 varying float v_intensity;
 
-const vec4 lightDir = vec4(1.0, 0.0, 3.0, 0.0);
+const vec4 kNormalizedLightDir = vec4(0.3162, 0.0, 0.9486, 0.0);
 
 void main()
 {
@@ -22,8 +22,12 @@ void main()
 
   pos.xyw = (pos * projection).xyw;
   pos.z = a_position.z * zScale;
-  
-  v_intensity = max(0.0, -dot(normalize(lightDir), normalize(normal - pos)));
+
+  vec4 normDir = normal - pos;
+  if (dot(normDir, normDir) != 0.0)
+    v_intensity = max(0.0, -dot(kNormalizedLightDir, normalize(normDir)));
+  else
+    v_intensity = 0.0;
 
   gl_Position = pivotTransform * pos;
   v_colorTexCoords = a_colorTexCoords;

--- a/drape_frontend/shaders/path_symbol.vsh.glsl
+++ b/drape_frontend/shaders/path_symbol.vsh.glsl
@@ -13,8 +13,10 @@ void main()
   vec4 pos = vec4(a_position.xyz, 1) * modelView;
 
   float normalLen = length(a_normal);
-  vec4 n = normalize(vec4(a_position.xy + a_normal * kShapeCoordScalar, 0, 0) * modelView);
-  vec4 norm = n * normalLen;
+  vec4 n = vec4(a_position.xy + a_normal * kShapeCoordScalar, 0.0, 0.0) * modelView;
+  vec4 norm = vec4(0.0, 0.0, 0.0, 0.0);
+  if (dot(n, n) != 0.0)
+    norm = normalize(n) * normalLen;
 
   vec4 shiftedPos = norm + pos;
   gl_Position = applyPivotTransform(shiftedPos * projection, pivotTransform, 0.0);

--- a/drape_frontend/shaders/position_accuracy3d.vsh.glsl
+++ b/drape_frontend/shaders/position_accuracy3d.vsh.glsl
@@ -14,7 +14,9 @@ varying vec2 v_colorTexCoords;
 void main()
 {
   vec4 position = vec4(u_position.xy, 0.0, 1.0) * modelView;
-  vec4 normal = vec4(normalize(a_normal) * u_accuracy, 0.0, 0.0);
+  vec4 normal = vec4(0.0, 0.0, 0.0, 0.0);
+  if (dot(a_normal, a_normal) != 0.0)
+    normal = vec4(normalize(a_normal) * u_accuracy, 0.0, 0.0);
   position = (position + normal) * projection;
   gl_Position = applyPivotTransform(position, pivotTransform, u_position.z * zScale);
 

--- a/drape_frontend/shaders/route.vsh.glsl
+++ b/drape_frontend/shaders/route.vsh.glsl
@@ -14,10 +14,9 @@ varying vec4 v_color;
 
 void main()
 {
-  float normalLen = length(a_normal);
   vec2 transformedAxisPos = (vec4(a_position.xy, 0.0, 1.0) * modelView).xy;
   vec2 len = vec2(a_length.x, a_length.z);
-  if (u_routeParams.x != 0.0 && normalLen != 0.0)
+  if (dot(a_normal, a_normal) != 0.0)
   {
     vec2 norm = a_normal * u_routeParams.x;
     transformedAxisPos = calcLineTransformedAxisPos(transformedAxisPos, a_position.xy + norm,

--- a/drape_frontend/shaders/route_arrow.vsh.glsl
+++ b/drape_frontend/shaders/route_arrow.vsh.glsl
@@ -12,9 +12,8 @@ varying vec2 v_colorTexCoords;
 
 void main()
 {
-  float normalLen = length(a_normal);
   vec2 transformedAxisPos = (vec4(a_position.xy, 0.0, 1.0) * modelView).xy;
-  if (normalLen != 0.0)
+  if (dot(a_normal, a_normal) != 0.0)
   {
     vec2 norm = a_normal * u_arrowHalfWidth;
     transformedAxisPos = calcLineTransformedAxisPos(transformedAxisPos, a_position.xy + norm,

--- a/drape_frontend/shaders/shaders_lib.glsl
+++ b/drape_frontend/shaders/shaders_lib.glsl
@@ -30,7 +30,11 @@ vec4 applyBillboardPivotTransform(vec4 pivot, mat4 pivotTransform, float pivotRe
 vec2 calcLineTransformedAxisPos(vec2 originalAxisPos, vec2 shiftedPos, mat4 modelView, float halfWidth)
 {
   vec2 p = (vec4(shiftedPos, 0.0, 1.0) * modelView).xy;
-  return originalAxisPos + normalize(p - originalAxisPos) * halfWidth;
+  vec2 d = p - originalAxisPos;
+  if (dot(d, d) != 0.0)
+    return originalAxisPos + normalize(d) * halfWidth;
+  else
+    return originalAxisPos;
 }
 
 // FS (DO NOT modify this comment, it marks up block of fragment shader functions).

--- a/drape_frontend/shaders/traffic.vsh.glsl
+++ b/drape_frontend/shaders/traffic.vsh.glsl
@@ -17,9 +17,8 @@ const float kArrowVSize = 0.25;
 void main()
 {
   vec2 normal = a_normal.xy;
-  float halfWidth = length(normal);
   vec2 transformedAxisPos = (vec4(a_position.xy, 0.0, 1.0) * modelView).xy;
-  if (halfWidth != 0.0)
+  if (dot(normal, normal) != 0.0)
   {
     vec2 norm = normal * u_trafficParams.x;
     if (a_normal.z < 0.0)


### PR DESCRIPTION
На некоторых Андроидах нормализация нулевого вектора в шейдерах приводила к сильным артефактам. Здесь добавлена проверка на равенство нулю нормализуемых векторов во всех шейдерах, где это необходимо.

https://jira.mail.ru/browse/MAPSME-3341
https://jira.mail.ru/browse/MAPSME-5179