### PR TITLE
MAPSME-5344 Fix test: route = ferry is road type since MAPSME-4974

### DIFF
--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -620,7 +620,7 @@ UNIT_TEST(OsmType_Ferry)
 
   type = GetType({"route", "ferry"});
   TEST(!params.IsTypeExist(type), ());
-  TEST(!carModel.IsRoadType(type), ());
+  TEST(carModel.IsRoadType(type), ());
 
   type = GetType({"hwtag", "yescar"});
   TEST(params.IsTypeExist(type), ());


### PR DESCRIPTION
В MAPSME-4974 @bykoianko добавил route=ferry в разрешенные типы дорог. Поправила в тестах.