### PR TITLE
[storage] Fix build on gcc

### DIFF
--- a/storage/diff_scheme/diff_scheme_checker.cpp
+++ b/storage/diff_scheme/diff_scheme_checker.cpp
@@ -50,22 +50,22 @@ NameFileInfoMap DeserializeResponse(string const & response, Checker::NameVersio
   if (response.empty())
   {
     LOG(LERROR, ("Diff response shouldn't be empty."));
-    return {};
+    return NameFileInfoMap{};
   }
 
   my::Json const json(response.c_str());
   if (json.get() == nullptr)
-    return {};
+    return NameFileInfoMap{};
 
   auto const root = json_object_get(json.get(), kMwmsKey);
   if (root == nullptr || !json_is_array(root))
-    return {};
+    return NameFileInfoMap{};
 
   auto const size = json_array_size(root);
   if (size == 0 || size != nameVersionMap.size())
   {
     LOG(LERROR, ("Diff list size in response must be equal to mwm list size in request."));
-    return {};
+    return NameFileInfoMap{};
   }
 
   NameFileInfoMap diffs;
@@ -77,7 +77,7 @@ NameFileInfoMap DeserializeResponse(string const & response, Checker::NameVersio
     if (!node)
     {
       LOG(LERROR, ("Incorrect server response."));
-      return {};
+      return NameFileInfoMap{};
     }
 
     string name;
@@ -91,7 +91,7 @@ NameFileInfoMap DeserializeResponse(string const & response, Checker::NameVersio
     if (nameVersionMap.find(name) == nameVersionMap.end())
     {
       LOG(LERROR, ("Incorrect country name in response:", name));
-      return {};
+      return NameFileInfoMap{};
     }
 
     FileInfo info(size, nameVersionMap.at(name));
@@ -110,7 +110,7 @@ void Checker::Check(LocalMapsInfo const & info, Callback const & fn)
   // TODO(Vlad): Log falling back to old scheme.
   if (info.m_localMaps.empty())
   {
-    fn({});
+    fn(NameFileInfoMap{});
     return;
   }
 


### PR DESCRIPTION
Проблема: при сборке gcc на linux получаем ошибку:

<tt>/home/ilya.zverev/omim/storage/diff_scheme/diff_scheme_checker.cpp:53:13: error: converting to ‘diff_scheme::NameFileInfoMap {aka std::unordered_map<std::basic_string<char>, diff_scheme::FileInfo>}’ from initializer list would use explicit constructor ‘std::unordered_map<_Key, Tp, Hash, Pred, Alloc>::unordered_map(std::unordered_map<_Key, Tp, Hash, Pred, Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with Key = std::basic_string<char>; Tp = diff_scheme::FileInfo; Hash = std::hash<std::basic_string<char> >; Pred = std::equal_to<std::basic_string<char> >; Alloc = std::allocator<std::pair<const std::basic_string<char>, diff_scheme::FileInfo> >; std::unordered_map<_Key, Tp, Hash, Pred, Alloc>::size_type = long unsigned int; std::unordered_map<_Key, Tp, Hash, Pred, Alloc>::hasher = std::hash<std::basic_string<char> >; std::unordered_map<_Key, Tp, Hash, Pred, Alloc>::key_equal = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, Tp, Hash, Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, diff_scheme::FileInfo> >]’</tt>
<tt>     return {};</tt>

Как показал [поиск по StackOverflow](https://stackoverflow.com/questions/26947704/implicit-conversion-failure-from-initializer-list), инициализацию unordered_map одной парой скобок ввели в C++14, а в C++11 это ошибка. Clang уже поддерживает новую версию, а библиотеки для gcc обновили не все.

Сделал явный вызов конструктора, код скомпилировался. Но я не настоящий сишник и мог неправильно понять. Посмотрите и помёржите, пожалуйста.