### PR TITLE
MAPSME-5233, MAPSME-5002, MAPSME-5234 fix following route with intermediate points

### DIFF
--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -78,6 +78,7 @@ void FollowedPolyline::Swap(FollowedPolyline & rhs)
   m_segDistance.swap(rhs.m_segDistance);
   m_segProj.swap(rhs.m_segProj);
   swap(m_current, rhs.m_current);
+  swap(m_nextCheckpointIndex, rhs.m_nextCheckpointIndex);
 }
 
 void FollowedPolyline::Update()
@@ -141,16 +142,18 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
                                          DistanceFn const & distFn) const
 {
   CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
-  // At first trying to find a projection to two closest route segments of route which is near
-  // enough to |posRect| center.
+  // At first trying to find a projection to two closest route segments of route which is close
+  // enough to |posRect| center. If m_current is right before intermediate point we can get closestIter
+  // right after intermediate point (in next subroute).
   size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 2);
   Iter const closestIter =
     GetClosestProjectionInInterval(posRect, distFn, m_current.m_ind, hoppingBorderIdx);
   if (closestIter.IsValid())
     return closestIter;
 
-  // If a projection to two closest route segments is not found trying to find projection to other route segments.
-  return GetClosestProjectionInInterval(posRect, distFn, hoppingBorderIdx, m_segProj.size());
+  // If a projection to the two closest route segments is not found tries to find projection to other route
+  // segments of current subroute.
+  return GetClosestProjectionInInterval(posRect, distFn, hoppingBorderIdx, m_nextCheckpointIndex);
 }
 
 Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -18,7 +18,11 @@ public:
     : m_poly(begin, end)
   {
     Update();
+    // Initially we do not have intermediate points. Next checkpoint is finish.
+    m_nextCheckpointIndex = m_segProj.size();
   }
+
+  void SetNextCheckpointIndex(size_t index) { m_nextCheckpointIndex = index; }
 
   void Swap(FollowedPolyline & rhs);
 
@@ -37,7 +41,7 @@ public:
   bool IsValid() const { return (m_current.IsValid() && m_poly.GetSize() > 1); }
   m2::PolylineD const & GetPolyline() const { return m_poly; }
 
-  vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
+  std::vector<double> const & GetSegDistanceMeters() const { return m_segDistance; }
   double GetTotalDistanceMeters() const;
   double GetDistanceFromStartMeters() const;
   double GetDistanceToEndMeters() const;
@@ -92,6 +96,7 @@ private:
 
   /// Iterator with the current position. Position sets with UpdateProjection methods.
   mutable Iter m_current;
+  size_t m_nextCheckpointIndex;
   /// Precalculated info for fast projection finding.
   std::vector<m2::ProjectionToSection<m2::PointD>> m_segProj;
   /// Accumulated cache of segments length in meters.

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -382,6 +382,7 @@ void RoutingSession::PassCheckpoints()
 {
   while (!m_checkpoints.IsFinished() && m_route->IsSubroutePassed(m_checkpoints.GetPassedIdx()))
   {
+    m_route->PassNextSubroute();
     m_checkpoints.PassNextPoint();
     LOG(LINFO, ("Pass checkpoint, ", m_checkpoints));
     m_checkpointCallback(m_checkpoints.GetPassedIdx());


### PR DESCRIPTION
Неправильно работало ведение по маршруту с промежуточными точками: FollowedPolyline не знал о промежуточных точках и при отклонении или самопересечениях маршрута матчил не на Subroute, ведущий к следующей промежуточной точке. Добавила в FollowedPolyline информацию о том, какая точка следующая и учёт этого в матчинге.