### PR TITLE
[Android] Fixed theme switching on the map

### DIFF
--- a/android/src/com/mapswithme/util/ThemeSwitcher.java
+++ b/android/src/com/mapswithme/util/ThemeSwitcher.java
@@ -91,9 +91,7 @@ public final class ThemeSwitcher
 
     if (!newTheme.equals(oldTheme))
     {
-      // Activity and drape engine will be recreated so we have to mark new map style.
-      // Changes will be applied in process of recreation.
-      Framework.nativeMarkMapStyle(style);
+      SetMapStyle(style);
 
       DownloaderStatusIcon.clearCache();
 
@@ -107,11 +105,17 @@ public final class ThemeSwitcher
       int currentStyle = Framework.nativeGetMapStyle();
       if (currentStyle == style)
         return;
-
-      if (sRendererActive)
-        Framework.nativeSetMapStyle(style);
-      else
-        Framework.nativeMarkMapStyle(style);
+      SetMapStyle(style);
     }
+  }
+
+  private static void SetMapStyle(@Framework.MapStyle int style)
+  {
+    // If rendering is not active we can mark map style, because all graphics
+    // will be recreated after rendering activation.
+    if (sRendererActive)
+      Framework.nativeSetMapStyle(style);
+    else
+      Framework.nativeMarkMapStyle(style);
   }
 }


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-5327

При переключении темы на карте разрушения контекста OpenGL не происходит, так как isChangingConfigurations возвращает true. 
Кроме того, в классе ThemeSwitcher.java при смене темы карты ( if (!newTheme.equals(oldTheme)) ) зовется nativeMarkMapStyle.
Это в данной ситуации неправильно. Вероятно, надо звать код, похожий на этот
if (sRendererActive)
Framework.nativeSetMapStyle(style);
else
Framework.nativeMarkMapStyle(style);