### PR TITLE
MAPSME-5367 fix route tests: allow empty m_subrouteAttrs for routes without intermediate points

### DIFF
--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -163,9 +163,14 @@ public:
     }
     else
     {
-      ASSERT_GREATER(m_subrouteAttrs.size(), m_currentSubrouteIdx, ());
       FollowedPolyline(beg, end).Swap(m_poly);
-      m_poly.SetNextCheckpointIndex(m_subrouteAttrs[m_currentSubrouteIdx].GetEndSegmentIdx());
+      // If there are no intermediate points it's acceptable to have an empty m_subrouteAttrs.
+      // Constructed m_poly will have the last point index as next checkpoint index, it's right.
+      if (!m_subrouteAttrs.empty())
+      {
+        ASSERT_GREATER(m_subrouteAttrs.size(), m_currentSubrouteIdx, ());
+        m_poly.SetNextCheckpointIndex(m_subrouteAttrs[m_currentSubrouteIdx].GetEndSegmentIdx());
+      }
     }
   }
 


### PR DESCRIPTION
MAPSME-5367
http://angola.mapsme.mail.msk:8080/job/GitHubWatchdog/BUILD_MODE=release,label=WD_Mac/lastCompletedBuild/testReport/(root)/routing_tests/route_tests_cpp_DistanceToCurrentTurnTest/

сломала, когда делала роутинг с промежуточными точками.
Суть поломки -- был добавлен ASSERT, который проверяет, что в Route `m_subrouteAttrs.size() > m_currentSubrouteIdx`.
Но сейчас объекты Route могут и не удовлетворять этому условию -- в сконструированном по умолчанию объекте `m_subrouteAttrs.size() ==0` и `m_currentSubrouteIdx == 0` и нет данных чтобы их корректно проинициализировать.

Сейчас методы, которые могут работать с саброутами, вызываются при не установленной информации о саброутах только в тестах. Но в целом интерфейс класса Route позволяет при отсутствии промежуточных точек не вызывать метод `SetSubroteAttrs` и при этом корректно работать. Поэтому разрешила в `SetGeometry` иметь пустой вектор `m_subrouteAttrs`.