### PR TITLE
MAPSME-5318 fix pedestrian and bicycle cross-mwm routing

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -386,6 +386,8 @@ bool BuildCrossMwmSection(string const & path, string const & mwmFile, string co
                 connector.GetExits().size()));
   }
 
+  // We use leaps for cars only. To use leaps for other vehicle types add weights generation
+  // here and change WorldGraph mode selection rule in IndexRouter::CalculateSubroute.
   FillWeights(path, mwmFile, country, disableCrossMwmProgress,
               connectors[static_cast<size_t>(VehicleType::Car)]);
 

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -45,7 +45,7 @@ void CrossMwmGraph::ClosestSegment::Update(double distM, Segment const & bestSeg
 
 // CrossMwmGraph ----------------------------------------------------------------------------------
 CrossMwmGraph::CrossMwmGraph(shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
-                             shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                             shared_ptr<VehicleModelFactory> vehicleModelFactory, VehicleType vehicleType,
                              CourntryRectFn const & countryRectFn, Index & index,
                              RoutingIndexManager & indexManager)
   : m_index(index)
@@ -53,7 +53,7 @@ CrossMwmGraph::CrossMwmGraph(shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tre
   , m_numMwmTree(numMwmTree)
   , m_vehicleModelFactory(vehicleModelFactory)
   , m_countryRectFn(countryRectFn)
-  , m_crossMwmIndexGraph(index, numMwmIds)
+  , m_crossMwmIndexGraph(index, numMwmIds, vehicleType)
   , m_crossMwmOsrmGraph(numMwmIds, indexManager)
 {
   CHECK(m_numMwmIds, ());

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -4,6 +4,7 @@
 #include "routing/cross_mwm_osrm_graph.hpp"
 #include "routing/num_mwm_id.hpp"
 #include "routing/segment.hpp"
+#include "routing/vehicle_mask.hpp"
 
 #include "routing_common/vehicle_model.hpp"
 
@@ -33,7 +34,7 @@ public:
   };
 
   CrossMwmGraph(std::shared_ptr<NumMwmIds> numMwmIds, shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
-                std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
+                std::shared_ptr<VehicleModelFactory> vehicleModelFactory, VehicleType vehicleType,
                 CourntryRectFn const & countryRectFn, Index & index,
                 RoutingIndexManager & indexManager);
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -25,8 +25,8 @@ class CrossMwmIndexGraph final
 public:
   using ReaderSourceFile = ReaderSource<FilesContainerR::TReader>;
 
-  CrossMwmIndexGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds)
-    : m_index(index), m_numMwmIds(numMwmIds)
+  CrossMwmIndexGraph(Index & index, std::shared_ptr<NumMwmIds> numMwmIds, VehicleType vehicleType)
+    : m_index(index), m_numMwmIds(numMwmIds), m_vehicleType(vehicleType)
   {
   }
 
@@ -76,12 +76,13 @@ private:
     if (it == m_connectors.end())
       it = m_connectors.emplace(numMwmId, CrossMwmConnector(numMwmId)).first;
 
-    fn(VehicleType::Car, it->second, src);
+    fn(m_vehicleType, it->second, src);
     return it->second;
   }
 
   Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
+  VehicleType m_vehicleType;
 
   /// \note |m_connectors| contains cache with transition segments and leap edges.
   /// Each mwm in |m_connectors| may be in two conditions:

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -493,9 +493,20 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
     return isLastSubroute ? IRouter::EndPointNotFound : IRouter::IntermediatePointNotFound;
   }
 
-  graph.SetMode(AreMwmsNear(startSegment.GetMwmId(), finishSegment.GetMwmId())
-                    ? WorldGraph::Mode::LeapsIfPossible
-                    : WorldGraph::Mode::LeapsOnly);
+  // We use leaps for cars only. Other vehicle types do not have weights in their cross-mwm sections.
+  switch (m_vehicleType)
+  {
+    case VehicleType::Pedestrian:
+    case VehicleType::Bicycle:
+      graph.SetMode(WorldGraph::Mode::NoLeaps);
+      break;
+    case VehicleType::Car:
+      graph.SetMode(AreMwmsNear(startSegment.GetMwmId(), finishSegment.GetMwmId())
+                      ? WorldGraph::Mode::LeapsIfPossible
+                      : WorldGraph::Mode::LeapsOnly);
+      break;
+  }
+
   LOG(LINFO, ("Routing in mode:", graph.GetMode()));
 
   bool const isStartSegmentStrictForward =
@@ -650,8 +661,8 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 WorldGraph IndexRouter::MakeWorldGraph()
 {
   WorldGraph graph(
-      make_unique<CrossMwmGraph>(m_numMwmIds, m_numMwmTree, m_vehicleModelFactory, m_countryRectFn,
-                                 m_index, m_indexManager),
+      make_unique<CrossMwmGraph>(m_numMwmIds, m_numMwmTree, m_vehicleModelFactory, m_vehicleType,
+                                 m_countryRectFn, m_index, m_indexManager),
       IndexGraphLoader::Create(m_vehicleType, m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
       m_estimator);
   return graph;


### PR DESCRIPTION
Переделала реквест после информации от Тимура: план в том, чтобы для пешего и вело-роутинга не использовать leaps, т.к. пешие и вело маршруты, даже если они проходят через несколько mwm, не очень большие, а увеличивать размер cross-mwm секции и время генерации mwm не хочется.