### PR TITLE
Added drape engine safe ptr

### DIFF
--- a/drape_frontend/CMakeLists.txt
+++ b/drape_frontend/CMakeLists.txt
@@ -80,6 +80,7 @@ set(
   drape_api_renderer.hpp
   drape_engine.cpp
   drape_engine.hpp
+  drape_engine_safe_ptr.hpp
   drape_hints.hpp
   drape_measurer.cpp
   drape_measurer.hpp

--- a/drape_frontend/drape_api.hpp
+++ b/drape_frontend/drape_api.hpp
@@ -1,24 +1,25 @@
 #pragma once
 
+#include "drape_frontend/drape_engine_safe_ptr.hpp"
+
 #include "drape/color.hpp"
 #include "drape/pointers.hpp"
 
 #include "geometry/point2d.hpp"
 
-#include "std/mutex.hpp"
-#include "std/unordered_map.hpp"
-#include "std/vector.hpp"
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace df
 {
-
-class DrapeEngine;
-
 struct DrapeApiLineData
 {
   DrapeApiLineData() = default;
 
-  DrapeApiLineData(vector<m2::PointD> const & points, dp::Color const & color)
+  DrapeApiLineData(std::vector<m2::PointD> const & points,
+                   dp::Color const & color)
     : m_points(points)
     , m_color(color)
   {}
@@ -42,7 +43,7 @@ struct DrapeApiLineData
     return *this;
   }
 
-  vector<m2::PointD> m_points;
+  std::vector<m2::PointD> m_points;
   float m_width = 1.0f;
   dp::Color m_color;
 
@@ -54,21 +55,19 @@ struct DrapeApiLineData
 class DrapeApi
 {
 public:
-  using TLines = unordered_map<string, DrapeApiLineData>;
+  using TLines = std::unordered_map<std::string, DrapeApiLineData>;
 
   DrapeApi() = default;
 
-  void SetEngine(ref_ptr<DrapeEngine> engine);
+  void SetDrapeEngine(ref_ptr<DrapeEngine> engine);
 
-  void AddLine(string const & id, DrapeApiLineData const & data);
-  void RemoveLine(string const & id);
+  void AddLine(std::string const & id, DrapeApiLineData const & data);
+  void RemoveLine(std::string const & id);
   void Clear();
   void Invalidate();
 
 private:
-  ref_ptr<DrapeEngine> m_engine;
+  DrapeEngineSafePtr m_engine;
   TLines m_lines;
-  mutex m_mutex;
 };
-
-} // namespace df
+}  // namespace df

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -252,5 +252,4 @@ private:
 
   friend class DrapeApi;
 };
-
-} // namespace df
+}  // namespace df

--- a/drape_frontend/drape_engine_safe_ptr.hpp
+++ b/drape_frontend/drape_engine_safe_ptr.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "base/macros.hpp"
+
+#include "drape/drape_global.hpp"
+#include "drape/pointers.hpp"
+
+#include <mutex>
+
+namespace df
+{
+class DrapeEngine;
+
+class DrapeEngineSafePtr
+{
+public:
+  void Set(ref_ptr<DrapeEngine> engine)
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_engine = engine;
+  }
+
+  explicit operator bool()
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_engine != nullptr;
+  }
+
+  template <typename Function, typename ... Args>
+  void SafeCall(Function && f, Args && ... functionArgs)
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_engine != nullptr)
+      (m_engine.get()->*f)(std::forward<Args>(functionArgs)...);
+  }
+
+  template <typename Function, typename ... Args>
+  dp::DrapeID SafeCallWithResult(Function && f, Args && ... functionArgs)
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_engine != nullptr)
+      return (m_engine.get()->*f)(std::forward<Args>(functionArgs)...);
+    return dp::DrapeID();
+  }
+
+private:
+  ref_ptr<DrapeEngine> m_engine;
+  std::mutex m_mutex;
+
+  friend class DrapeEngineLockGuard;
+};
+
+class DrapeEngineLockGuard
+{
+public:
+  explicit DrapeEngineLockGuard(DrapeEngineSafePtr & enginePtr)
+    : m_ptr(enginePtr)
+  {
+    m_ptr.m_mutex.lock();
+  }
+
+  ~DrapeEngineLockGuard()
+  {
+    m_ptr.m_mutex.unlock();
+  }
+
+  explicit operator bool() { return m_ptr.m_engine != nullptr; }
+
+  ref_ptr<DrapeEngine> Get() { return m_ptr.m_engine; }
+
+private:
+  DrapeEngineSafePtr & m_ptr;
+  DISALLOW_COPY_AND_MOVE(DrapeEngineLockGuard);
+};
+}  // namespace df

--- a/drape_frontend/drape_frontend.pro
+++ b/drape_frontend/drape_frontend.pro
@@ -151,6 +151,7 @@ HEADERS += \
     drape_api_builder.hpp \
     drape_api_renderer.hpp \
     drape_engine.hpp \
+    drape_engine_safe_ptr.hpp \
     drape_hints.hpp \
     drape_measurer.hpp \
     engine_context.hpp \

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1971,7 +1971,7 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::OGLContextFactory> contextFactory,
     GetPlatform().RunOnGuiThread([this, sizes](){ m_searchMarksSizes = sizes; });
   });
 
-  m_drapeApi.SetEngine(make_ref(m_drapeEngine));
+  m_drapeApi.SetDrapeEngine(make_ref(m_drapeEngine));
   m_routingManager.SetDrapeEngine(make_ref(m_drapeEngine), allow3d);
   m_trafficManager.SetDrapeEngine(make_ref(m_drapeEngine));
   m_localAdsManager.SetDrapeEngine(make_ref(m_drapeEngine));
@@ -2010,7 +2010,11 @@ void Framework::DestroyDrapeEngine()
 {
   if (m_drapeEngine != nullptr)
   {
-    m_drapeApi.SetEngine(nullptr);
+    m_drapeApi.SetDrapeEngine(nullptr);
+    m_routingManager.SetDrapeEngine(nullptr, false);
+    m_trafficManager.SetDrapeEngine(nullptr);
+    m_localAdsManager.SetDrapeEngine(nullptr);
+
     m_trafficManager.Teardown();
     m_localAdsManager.Teardown();
     GpsTracker::Instance().Disconnect();

--- a/map/local_ads_manager.hpp
+++ b/map/local_ads_manager.hpp
@@ -2,6 +2,8 @@
 
 #include "local_ads/statistics.hpp"
 
+#include "drape_frontend/drape_engine_safe_ptr.hpp"
+
 #include "drape/pointers.hpp"
 
 #include "geometry/rect2d.hpp"
@@ -21,11 +23,6 @@
 #include <set>
 #include <string>
 #include <vector>
-
-namespace df
-{
-class DrapeEngine;
-}
 
 namespace feature
 {
@@ -98,8 +95,7 @@ private:
 
   std::atomic<BookmarkManager *> m_bmManager;
 
-  ref_ptr<df::DrapeEngine> m_drapeEngine;
-  std::mutex m_drapeEngineMutex;
+  df::DrapeEngineSafePtr m_drapeEngine;
 
   std::map<std::string, bool> m_campaigns;
   struct CampaignInfo

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -284,8 +284,7 @@ void RoutingManager::OnBuildRouteReady(Route const & route, IRouter::ResultCode 
   if (code == IRouter::NoError)
   {
     InsertRoute(route);
-    if (m_drapeEngine != nullptr)
-      m_drapeEngine->StopLocationFollow();
+    m_drapeEngine.SafeCall(&df::DrapeEngine::StopLocationFollow);
 
     // Validate route (in case of bicycle routing it can be invalid).
     ASSERT(route.IsValid(), ());
@@ -293,11 +292,8 @@ void RoutingManager::OnBuildRouteReady(Route const & route, IRouter::ResultCode 
     {
       m2::RectD routeRect = route.GetPoly().GetLimitRect();
       routeRect.Scale(kRouteScaleMultiplier);
-      if (m_drapeEngine != nullptr)
-      {
-        m_drapeEngine->SetModelViewRect(routeRect, true /* applyRotation */, -1 /* zoom */,
-                                        true /* isAnim */);
-      }
+      m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, routeRect,
+                             true /* applyRotation */, -1 /* zoom */, true /* isAnim */);
     }
   }
   else
@@ -399,35 +395,40 @@ void RoutingManager::SetRouterImpl(RouterType type)
 
 void RoutingManager::RemoveRoute(bool deactivateFollowing)
 {
-  if (m_drapeEngine == nullptr)
-    return;
-
   if (deactivateFollowing)
     SetPointsFollowingMode(false /* enabled */);
 
-  lock_guard<mutex> lock(m_drapeSubroutesMutex);
   if (deactivateFollowing)
   {
     // Remove all subroutes.
-    m_drapeEngine->RemoveSubroute(dp::DrapeID(), true /* deactivateFollowing */);
+    m_drapeEngine.SafeCall(&df::DrapeEngine::RemoveSubroute,
+                           dp::DrapeID(), true /* deactivateFollowing */);
   }
   else
   {
-    for (auto const & subrouteId : m_drapeSubroutes)
-      m_drapeEngine->RemoveSubroute(subrouteId, false /* deactivateFollowing */);
+    auto const subroutes = GetSubrouteIds();
+    df::DrapeEngineLockGuard lock(m_drapeEngine);
+    if (lock)
+    {
+      for (auto const & subrouteId : subroutes)
+        lock.Get()->RemoveSubroute(subrouteId, false /* deactivateFollowing */);
+    }
   }
-  m_drapeSubroutes.clear();
+
+  {
+    lock_guard<mutex> lock(m_drapeSubroutesMutex);
+    m_drapeSubroutes.clear();
+  }
 }
 
 void RoutingManager::InsertRoute(Route const & route)
 {
-  if (m_drapeEngine == nullptr)
+  if (!m_drapeEngine)
     return;
 
   // TODO: Now we always update whole route, so we need to remove previous one.
   RemoveRoute(false /* deactivateFollowing */);
 
-  lock_guard<mutex> lock(m_drapeSubroutesMutex);
   vector<RouteSegment> segments;
   vector<m2::PointD> points;
   double distance = 0.0;
@@ -485,18 +486,19 @@ void RoutingManager::InsertRoute(Route const & route)
       default: ASSERT(false, ("Unknown router type"));
     }
 
-    auto const subrouteId = m_drapeEngine->AddSubroute(df::SubrouteConstPtr(subroute.release()));
-    m_drapeSubroutes.push_back(subrouteId);
+    auto const subrouteId = m_drapeEngine.SafeCallWithResult(&df::DrapeEngine::AddSubroute,
+                                                             df::SubrouteConstPtr(subroute.release()));
 
     // TODO: we will send subrouteId to routing subsystem when we can partly update route.
     //route.SetSubrouteUid(subrouteIndex, static_cast<SubrouteUid>(subrouteId));
+
+    lock_guard<mutex> lock(m_drapeSubroutesMutex);
+    m_drapeSubroutes.push_back(subrouteId);
   }
 }
 
 void RoutingManager::FollowRoute()
 {
-  ASSERT(m_drapeEngine != nullptr, ());
-
   if (!m_routingSession.EnableFollowMode())
     return;
 
@@ -719,7 +721,6 @@ void RoutingManager::GenerateTurnNotifications(vector<string> & turnNotification
 void RoutingManager::BuildRoute(uint32_t timeoutSec)
 {
   ASSERT_THREAD_CHECKER(m_threadChecker, ("BuildRoute"));
-  ASSERT(m_drapeEngine != nullptr, ());
 
   auto routePoints = GetRoutePoints();
   if (routePoints.size() < 2)
@@ -788,13 +789,10 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
     CloseRouting(false /* remove route points */);
 
   // Show preview.
-  if (m_drapeEngine != nullptr)
-  {
-    m2::RectD rect = ShowPreviewSegments(routePoints);
-    rect.Scale(kRouteScaleMultiplier);
-    m_drapeEngine->SetModelViewRect(rect, true /* applyRotation */, -1 /* zoom */,
-                                    true /* isAnim */);
-  }
+  m2::RectD rect = ShowPreviewSegments(routePoints);
+  rect.Scale(kRouteScaleMultiplier);
+  m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, rect, true /* applyRotation */,
+                         -1 /* zoom */, true /* isAnim */);
 
   m_routingSession.SetUserCurrentPosition(routePoints.front().m_position);
 
@@ -828,8 +826,8 @@ void RoutingManager::SetUserCurrentPosition(m2::PointD const & position)
 bool RoutingManager::DisableFollowMode()
 {
   bool const disabled = m_routingSession.DisableFollowMode();
-  if (disabled && m_drapeEngine != nullptr)
-    m_drapeEngine->DeactivateRouteFollowing();
+  if (disabled)
+    m_drapeEngine.SafeCall(&df::DrapeEngine::DeactivateRouteFollowing);
 
   return disabled;
 }
@@ -870,13 +868,12 @@ void RoutingManager::MatchLocationToRoute(location::GpsInfo & location,
 
 void RoutingManager::OnLocationUpdate(location::GpsInfo & info)
 {
-  if (m_drapeEngine == nullptr)
+  if (!m_drapeEngine)
     m_gpsInfoCache = my::make_unique<location::GpsInfo>(info);
 
   auto routeMatchingInfo = GetRouteMatchingInfo(info);
-
-  if (m_drapeEngine != nullptr)
-    m_drapeEngine->SetGpsInfo(info, m_routingSession.IsNavigable(), routeMatchingInfo);
+  m_drapeEngine.SafeCall(&df::DrapeEngine::SetGpsInfo, info,
+                         m_routingSession.IsNavigable(), routeMatchingInfo);
 
   if (IsTrackingReporterEnabled())
     m_trackingReporter.AddLocation(info, m_routingSession.MatchTraffic(routeMatchingInfo));
@@ -892,13 +889,16 @@ location::RouteMatchingInfo RoutingManager::GetRouteMatchingInfo(location::GpsIn
 
 void RoutingManager::SetDrapeEngine(ref_ptr<df::DrapeEngine> engine, bool is3dAllowed)
 {
-  m_drapeEngine = engine;
+  m_drapeEngine.Set(engine);
+  if (engine == nullptr)
+    return;
 
   // Apply gps info which was set before drape engine creation.
   if (m_gpsInfoCache != nullptr)
   {
     auto routeMatchingInfo = GetRouteMatchingInfo(*m_gpsInfoCache);
-    m_drapeEngine->SetGpsInfo(*m_gpsInfoCache, m_routingSession.IsNavigable(), routeMatchingInfo);
+    m_drapeEngine.SafeCall(&df::DrapeEngine::SetGpsInfo, *m_gpsInfoCache,
+                           m_routingSession.IsNavigable(), routeMatchingInfo);
     m_gpsInfoCache.reset();
   }
 
@@ -907,7 +907,7 @@ void RoutingManager::SetDrapeEngine(ref_ptr<df::DrapeEngine> engine, bool is3dAl
   {
     InsertRoute(*m_routingSession.GetRoute());
     if (is3dAllowed && m_routingSession.IsFollowing())
-      m_drapeEngine->EnablePerspective();
+      m_drapeEngine.SafeCall(&df::DrapeEngine::EnablePerspective);
   }
 }
 
@@ -1132,32 +1132,21 @@ void RoutingManager::DeleteSavedRoutePoints()
 
 void RoutingManager::UpdatePreviewMode()
 {
-  // Hide all subroutes.
-  {
-    lock_guard<mutex> lock(m_drapeSubroutesMutex);
-    for (auto const & subrouteId : m_drapeSubroutes)
-      m_drapeEngine->SetSubrouteVisibility(subrouteId, false /* isVisible */);
-  }
-
+  SetSubroutesVisibility(false /* visible */);
   HidePreviewSegments();
   ShowPreviewSegments(GetRoutePoints());
 }
 
 void RoutingManager::CancelPreviewMode()
 {
-  // Show all subroutes.
-  {
-    lock_guard<mutex> lock(m_drapeSubroutesMutex);
-    for (auto const & subrouteId : m_drapeSubroutes)
-      m_drapeEngine->SetSubrouteVisibility(subrouteId, true /* isVisible */);
-  }
-
+  SetSubroutesVisibility(true /* visible */);
   HidePreviewSegments();
 }
 
 m2::RectD RoutingManager::ShowPreviewSegments(vector<RouteMarkData> const & routePoints)
 {
-  if (m_drapeEngine == nullptr)
+  df::DrapeEngineLockGuard lock(m_drapeEngine);
+  if (!lock)
     return MercatorBounds::FullRect();
 
   m2::RectD rect;
@@ -1165,20 +1154,37 @@ m2::RectD RoutingManager::ShowPreviewSegments(vector<RouteMarkData> const & rout
   {
     rect.Add(routePoints[pointIndex].m_position);
     rect.Add(routePoints[pointIndex + 1].m_position);
-    m_drapeEngine->AddRoutePreviewSegment(routePoints[pointIndex].m_position,
-                                          routePoints[pointIndex + 1].m_position);
+    lock.Get()->AddRoutePreviewSegment(routePoints[pointIndex].m_position,
+                                       routePoints[pointIndex + 1].m_position);
   }
   return rect;
 }
 
 void RoutingManager::HidePreviewSegments()
 {
-  if (m_drapeEngine != nullptr)
-    m_drapeEngine->RemoveAllRoutePreviewSegments();
+  m_drapeEngine.SafeCall(&df::DrapeEngine::RemoveAllRoutePreviewSegments);
 }
 
 void RoutingManager::CancelRecommendation(Recommendation recommendation)
 {
   if (recommendation == Recommendation::RebuildAfterPointsLoading)
     m_loadRoutePointsTimestamp = chrono::steady_clock::time_point();
+}
+
+std::vector<dp::DrapeID> RoutingManager::GetSubrouteIds() const
+{
+  lock_guard<mutex> lock(m_drapeSubroutesMutex);
+  return m_drapeSubroutes;
+}
+
+void RoutingManager::SetSubroutesVisibility(bool visible)
+{
+  auto const subroutes = GetSubrouteIds();
+
+  df::DrapeEngineLockGuard lock(m_drapeEngine);
+  if (!lock)
+    return;
+
+  for (auto const & subrouteId : subroutes)
+    lock.Get()->SetSubrouteVisibility(subrouteId, visible);
 }

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -8,6 +8,8 @@
 
 #include "storage/index.hpp"
 
+#include "drape_frontend/drape_engine_safe_ptr.hpp"
+
 #include "drape/pointers.hpp"
 
 #include "tracking/reporter.hpp"
@@ -24,11 +26,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-namespace df
-{
-class DrapeEngine;
-}
 
 namespace storage
 {
@@ -267,12 +264,15 @@ private:
   m2::RectD ShowPreviewSegments(std::vector<RouteMarkData> const & routePoints);
   void HidePreviewSegments();
 
+  std::vector<dp::DrapeID> GetSubrouteIds() const;
+  void SetSubroutesVisibility(bool visible);
+
   void CancelRecommendation(Recommendation recommendation);
 
   RouteBuildingCallback m_routingCallback = nullptr;
   RouteRecommendCallback m_routeRecommendCallback = nullptr;
   Callbacks m_callbacks;
-  ref_ptr<df::DrapeEngine> m_drapeEngine = nullptr;
+  df::DrapeEngineSafePtr m_drapeEngine;
   routing::RouterType m_currentRouterType = routing::RouterType::Count;
   routing::RoutingSession m_routingSession;
   Delegate & m_delegate;
@@ -280,7 +280,7 @@ private:
   BookmarkManager * m_bmManager = nullptr;
 
   std::vector<dp::DrapeID> m_drapeSubroutes;
-  std::mutex m_drapeSubroutesMutex;
+  mutable std::mutex m_drapeSubroutesMutex;
 
   std::unique_ptr<location::GpsInfo> m_gpsInfoCache;
 

--- a/map/traffic_manager.hpp
+++ b/map/traffic_manager.hpp
@@ -2,6 +2,7 @@
 
 #include "traffic/traffic_info.hpp"
 
+#include "drape_frontend/drape_engine_safe_ptr.hpp"
 #include "drape_frontend/traffic_generator.hpp"
 
 #include "drape/pointers.hpp"
@@ -23,11 +24,6 @@
 #include "std/set.hpp"
 #include "std/string.hpp"
 #include "std/vector.hpp"
-
-namespace df
-{
-class DrapeEngine;
-}  // namespace df
 
 class TrafficManager final
 {
@@ -149,8 +145,7 @@ private:
   GetMwmsByRectFn m_getMwmsByRectFn;
   traffic::TrafficObserver & m_observer;
 
-  ref_ptr<df::DrapeEngine> m_drapeEngine;
-  mutex m_drapeEngineMutex;
+  df::DrapeEngineSafePtr m_drapeEngine;
   atomic<int64_t> m_currentDataVersion;
 
   // These fields have a flag of their initialization.

--- a/xcode/drape_frontend/drape_frontend.xcodeproj/project.pbxproj
+++ b/xcode/drape_frontend/drape_frontend.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		453EEA6E1E3A28F400505E09 /* colored_symbol_shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 453EEA6C1E3A28F400505E09 /* colored_symbol_shape.hpp */; };
 		453FEDAC1F34C257005C1BB4 /* render_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 453FEDAA1F34C257005C1BB4 /* render_state.cpp */; };
 		453FEDAD1F34C257005C1BB4 /* render_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 453FEDAB1F34C257005C1BB4 /* render_state.hpp */; };
+		454B9A3A1F4591AD003FAE7A /* drape_engine_safe_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 454B9A391F4591AC003FAE7A /* drape_engine_safe_ptr.hpp */; };
 		454C19BB1CCE3EC0002A2C86 /* animation_constants.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 454C19B81CCE3EC0002A2C86 /* animation_constants.hpp */; };
 		454C19BC1CCE3EC0002A2C86 /* animation_system.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 454C19B91CCE3EC0002A2C86 /* animation_system.cpp */; };
 		454C19BD1CCE3EC0002A2C86 /* animation_system.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 454C19BA1CCE3EC0002A2C86 /* animation_system.hpp */; };
@@ -243,6 +244,7 @@
 		453EEA6C1E3A28F400505E09 /* colored_symbol_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = colored_symbol_shape.hpp; sourceTree = "<group>"; };
 		453FEDAA1F34C257005C1BB4 /* render_state.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = render_state.cpp; sourceTree = "<group>"; };
 		453FEDAB1F34C257005C1BB4 /* render_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = render_state.hpp; sourceTree = "<group>"; };
+		454B9A391F4591AC003FAE7A /* drape_engine_safe_ptr.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drape_engine_safe_ptr.hpp; sourceTree = "<group>"; };
 		454C19B81CCE3EC0002A2C86 /* animation_constants.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_constants.hpp; sourceTree = "<group>"; };
 		454C19B91CCE3EC0002A2C86 /* animation_system.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = animation_system.cpp; sourceTree = "<group>"; };
 		454C19BA1CCE3EC0002A2C86 /* animation_system.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_system.hpp; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 		670947411BDF9B99005014C0 /* drape_frontend */ = {
 			isa = PBXGroup;
 			children = (
+				454B9A391F4591AC003FAE7A /* drape_engine_safe_ptr.hpp */,
 				453FEDAA1F34C257005C1BB4 /* render_state.cpp */,
 				453FEDAB1F34C257005C1BB4 /* render_state.hpp */,
 				EB2B78011EEDD439002697B6 /* read_metaline_task.cpp */,
@@ -823,6 +826,7 @@
 				F6B283101C1B04680081957A /* gps_track_point.hpp in Headers */,
 				670947B61BDF9BE1005014C0 /* render_node.hpp in Headers */,
 				6709484C1BDF9C48005014C0 /* ruler.hpp in Headers */,
+				454B9A3A1F4591AD003FAE7A /* drape_engine_safe_ptr.hpp in Headers */,
 				670947AE1BDF9BE1005014C0 /* poi_symbol_shape.hpp in Headers */,
 				670947AA1BDF9BE1005014C0 /* path_symbol_shape.hpp in Headers */,
 				6709483E1BDF9C48005014C0 /* copyright_label.hpp in Headers */,


### PR DESCRIPTION
Добавлена потокобезопасная обертка над графическим движком, которую надо использовать, если указатель на движок хранится и используется вне фреймворка.

Должна также исправить эти крэши при выходе из приложения https://fabric.io/mapsme/ios/apps/com.mapswithme.full/issues/5971a8cdbe077a4dcce512bb?time=last-seven-days