### PR TITLE
MAPSME-4897 Do not display the next street name when we are far from turn

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1047,7 +1047,7 @@ Java_com_mapswithme_maps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jcl
       klass, ctorRouteInfoID, jni::ToJavaString(env, info.m_distToTarget),
       jni::ToJavaString(env, info.m_targetUnitsSuffix), jni::ToJavaString(env, info.m_distToTurn),
       jni::ToJavaString(env, info.m_turnUnitsSuffix), jni::ToJavaString(env, info.m_sourceName),
-      jni::ToJavaString(env, info.m_targetName), info.m_completionPercent, info.m_turn, info.m_nextTurn, info.m_pedestrianTurn,
+      jni::ToJavaString(env, info.m_displayedStreetName), info.m_completionPercent, info.m_turn, info.m_nextTurn, info.m_pedestrianTurn,
       info.m_pedestrianDirectionPos.lat, info.m_pedestrianDirectionPos.lon, info.m_exitNum, info.m_time, jLanes);
   ASSERT(result, (jni::DescribeException()));
   return result;

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -94,7 +94,7 @@ UIImage * image(routing::turns::CarDirection t, bool isNextTurn)
     entity.progress = info.m_completionPercent;
     entity.distanceToTurn = @(info.m_distToTurn.c_str());
     entity.turnUnits = @(info.m_turnUnitsSuffix.c_str());
-    entity.streetName = @(info.m_targetName.c_str());
+    entity.streetName = @(info.m_displayedStreetName.c_str());
     entity.nextTurnImage = image(info.m_nextTurn, true);
 
     NSString * eta = [NSDateComponentsFormatter etaStringFrom:entity.timeToTarget];

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -182,6 +182,8 @@ namespace location
     string m_sourceName;
     // The next street name.
     string m_targetName;
+    // Street name to display. May be empty.
+    string m_displayedStreetName;
 
     // Percentage of the route completion.
     double m_completionPercent;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -353,9 +353,11 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   m_route->GetCurrentStreetName(info.m_sourceName);
   m_route->GetStreetNameAfterIdx(turn.m_index, info.m_targetName);
   info.m_completionPercent = GetCompletionPercent();
-  // Lane information.
+
+  // Lane information and next street name.
   if (distanceToTurnMeters < kShowLanesDistInMeters)
   {
+    info.m_displayedStreetName = info.m_targetName;
     // There are two nested loops below. Outer one is for lanes and inner one (ctor of
     // SingleLaneInfo) is
     // for each lane's directions. The size of turn.m_lanes is relatively small. Less than 10 in
@@ -367,6 +369,7 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   }
   else
   {
+    info.m_displayedStreetName = "";
     info.m_lanes.clear();
   }
 


### PR DESCRIPTION
Не отображаем название следующей улицы, пока мы далеко от поворота. Чтобы не путать смыслы ,сделала отдельное поле под название отображаемой улицы.
Поведение обсуждалось с Артёмом и Игорем -- начинаем отображать название следующей улицы тогда же когда информацию о полосах.