### PR TITLE
MAPSME-5425: do not show altitudes for auto & taxi

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -274,6 +274,7 @@ private:
   Callbacks m_callbacks;
   df::DrapeEngineSafePtr m_drapeEngine;
   routing::RouterType m_currentRouterType = routing::RouterType::Count;
+  bool m_loadAltitudes = false;
   routing::RoutingSession m_routingSession;
   Delegate & m_delegate;
   tracking::Reporter m_trackingReporter;

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -18,7 +18,8 @@ using namespace std;
 class IndexGraphLoaderImpl final : public IndexGraphLoader
 {
 public:
-  IndexGraphLoaderImpl(VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
+  IndexGraphLoaderImpl(VehicleType vehicleType, bool loadAltitudes,
+                       shared_ptr<NumMwmIds> numMwmIds,
                        shared_ptr<VehicleModelFactory> vehicleModelFactory,
                        shared_ptr<EdgeEstimator> estimator, Index & index);
 
@@ -30,6 +31,7 @@ private:
   IndexGraph & Load(NumMwmId mwmId);
 
   VehicleMask m_vehicleMask;
+  bool m_loadAltitudes;
   Index & m_index;
   shared_ptr<NumMwmIds> m_numMwmIds;
   shared_ptr<VehicleModelFactory> m_vehicleModelFactory;
@@ -37,10 +39,12 @@ private:
   unordered_map<NumMwmId, unique_ptr<IndexGraph>> m_graphs;
 };
 
-IndexGraphLoaderImpl::IndexGraphLoaderImpl(VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
+IndexGraphLoaderImpl::IndexGraphLoaderImpl(VehicleType vehicleType, bool loadAltitudes,
+                                           shared_ptr<NumMwmIds> numMwmIds,
                                            shared_ptr<VehicleModelFactory> vehicleModelFactory,
                                            shared_ptr<EdgeEstimator> estimator, Index & index)
   : m_vehicleMask(GetVehicleMask(vehicleType))
+  , m_loadAltitudes(loadAltitudes)
   , m_index(index)
   , m_numMwmIds(numMwmIds)
   , m_vehicleModelFactory(vehicleModelFactory)
@@ -71,7 +75,7 @@ IndexGraph & IndexGraphLoaderImpl::Load(NumMwmId numMwmId)
       m_vehicleModelFactory->GetVehicleModelForCountry(file.GetName());
 
   auto graphPtr = make_unique<IndexGraph>(
-      GeometryLoader::Create(m_index, handle, vehicleModel, m_vehicleMask != kCarMask),
+      GeometryLoader::Create(m_index, handle, vehicleModel, m_loadAltitudes),
       m_estimator);
   IndexGraph & graph = *graphPtr;
 
@@ -111,12 +115,12 @@ namespace routing
 {
 // static
 unique_ptr<IndexGraphLoader> IndexGraphLoader::Create(
-    VehicleType vehicleType, shared_ptr<NumMwmIds> numMwmIds,
+    VehicleType vehicleType, bool loadAltitudes, shared_ptr<NumMwmIds> numMwmIds,
     shared_ptr<VehicleModelFactory> vehicleModelFactory, shared_ptr<EdgeEstimator> estimator,
     Index & index)
 {
-  return make_unique<IndexGraphLoaderImpl>(vehicleType, numMwmIds, vehicleModelFactory, estimator,
-                                           index);
+  return make_unique<IndexGraphLoaderImpl>(vehicleType, loadAltitudes, numMwmIds, vehicleModelFactory,
+                                           estimator, index);
 }
 
 void DeserializeIndexGraph(MwmValue const & mwmValue, VehicleMask vehicleMask, IndexGraph & graph)

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -22,7 +22,7 @@ public:
   virtual void Clear() = 0;
 
   static std::unique_ptr<IndexGraphLoader> Create(
-      VehicleType vehicleType, std::shared_ptr<NumMwmIds> numMwmIds,
+      VehicleType vehicleType, bool loadAltitudes, std::shared_ptr<NumMwmIds> numMwmIds,
       std::shared_ptr<VehicleModelFactory> vehicleModelFactory,
       std::shared_ptr<EdgeEstimator> estimator, Index & index);
 };

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -283,11 +283,12 @@ double IndexRouter::BestEdgeComparator::GetSquaredDist(Edge const & edge) const
 }
 
 // IndexRouter ------------------------------------------------------------------------------------
-IndexRouter::IndexRouter(VehicleType vehicleType, TCountryFileFn const & countryFileFn,
+IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes, TCountryFileFn const & countryFileFn,
                          CourntryRectFn const & countryRectFn, shared_ptr<NumMwmIds> numMwmIds,
                          unique_ptr<m4::Tree<NumMwmId>> numMwmTree, traffic::TrafficCache const & trafficCache,
                          Index & index)
   : m_vehicleType(vehicleType)
+  , m_loadAltitudes(loadAltitudes)
   , m_name("astar-bidirectional-" + ToString(m_vehicleType))
   , m_index(index)
   , m_vehicleModelFactory(CreateVehicleModelFactory(m_vehicleType))
@@ -666,7 +667,8 @@ WorldGraph IndexRouter::MakeWorldGraph()
   WorldGraph graph(
       make_unique<CrossMwmGraph>(m_numMwmIds, m_numMwmTree, m_vehicleModelFactory, m_vehicleType,
                                  m_countryRectFn, m_index, m_indexManager),
-      IndexGraphLoader::Create(m_vehicleType, m_numMwmIds, m_vehicleModelFactory, m_estimator, m_index),
+      IndexGraphLoader::Create(m_vehicleType, m_loadAltitudes, m_numMwmIds, m_vehicleModelFactory,
+                               m_estimator, m_index),
       m_estimator);
   return graph;
 }

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -55,7 +55,7 @@ public:
     m2::PointD const m_direction;
   };
 
-  IndexRouter(VehicleType vehicleType, TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
+  IndexRouter(VehicleType vehicleType, bool loadAltitudes, TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
               shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree, traffic::TrafficCache const & trafficCache, Index & index);
 
   // IRouter overrides:
@@ -103,6 +103,7 @@ private:
   bool AreMwmsNear(NumMwmId startId, NumMwmId finishId) const;
 
   VehicleType m_vehicleType;
+  bool m_loadAltitudes;
   std::string const m_name;
   Index & m_index;
   std::shared_ptr<VehicleModelFactory> m_vehicleModelFactory;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -102,8 +102,9 @@ namespace integration
     }
     
     auto vehicleType = VehicleType::Car;
-    auto indexRouter = make_unique<IndexRouter>(vehicleType, countryFileGetter, getMwmRectByName, numMwmIds,
-      MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, index);
+    auto indexRouter = make_unique<IndexRouter>(vehicleType, false /* load altitudes*/, countryFileGetter,
+                                                getMwmRectByName, numMwmIds,
+                                                MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, index);
 
     return indexRouter;
   }


### PR DESCRIPTION
Раньше грузим ли мы высоты определялось в IndexGraphLoaderImpl в зависимости от типа транспорта, в случае если не грузим всем точкам выставлялась дефолтная высота, если должны грузить, но потерпели неудачу -- kInvalidAltitude.
Это нормальное поведение, но оно не позволяет определить наличие загруженных высот на уровнях выше, чем IndexGraphLoaderImpl (либо надо дублировать условия выбора по типу транспорта, что плохо).
Поэтому перенесла определение необходимости загрузки высот выше -- на уровень RoutingManager, это минимальный предок для загрузки высот в роутинге и определения необходимости отображения графика.