### PR TITLE
[generator] Do not copy ref tags from boundaries and other relations

### DIFF
--- a/generator/osm_translator.hpp
+++ b/generator/osm_translator.hpp
@@ -197,6 +197,7 @@ protected:
     bool const isBoundary = (type == "boundary") && IsAcceptBoundary(e);
     bool const processAssociatedStreet = type == "associatedStreet" &&
         TBase::IsKeyTagExists("addr:housenumber") && !TBase::IsKeyTagExists("addr:street");
+    bool const isHighway = TBase::IsKeyTagExists("highway");
 
     for (auto const & p : e.tags)
     {
@@ -216,6 +217,10 @@ protected:
         continue;
 
       if (p.first == "place")
+        continue;
+
+      // Do not pass "ref" tags from boundaries and other, non-route relations to highways.
+      if (p.first == "ref" && isHighway)
         continue;
 
       TBase::AddCustomTag(p);


### PR DESCRIPTION
«ЦАО» на дороге в центре Москвы. 83124 на улицах немецких городов (это индекс). Автоматическое копирование тега `ref` с любых отношений на отрезки дорог в этих отношениях немного портит нам карту. Мы уже правильно копируем номера дорог с отношений `route=road`, теперь давайте запретим использование `ref` с других отношений.