### PR TITLE
[types] Add AED as a synonym to defibrillator

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -8284,7 +8284,7 @@ zh-Hans:^取水点
 zh-Hant:^飲水站
 
 emergency-defibrillator
-en:^Defibrillator
+en:^Defibrillator|AED
 ru:^Дефибриллятор
 ar:^مزيل الرجفان
 cs:^Defibrilátor


### PR DESCRIPTION
Это часто используемая аббревиатура, как я понял. См. https://www.sendai-airport.co.jp/en/service/aed/