### PR TITLE
[DNM] Added disabling post-processing on active frames

### DIFF
--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -140,7 +140,7 @@ protected:
 
 private:
   void OnResize(ScreenBase const & screen);
-  void RenderScene(ScreenBase const & modelView);
+  void RenderScene(ScreenBase const & modelView, bool lastFrameActive);
   void PrepareBucket(dp::GLState const & state, drape_ptr<dp::RenderBucket> & bucket);
   void MergeBuckets();
   void RenderSingleGroup(ScreenBase const & modelView, ref_ptr<BaseRenderGroup> group);

--- a/drape_frontend/postprocess_renderer.cpp
+++ b/drape_frontend/postprocess_renderer.cpp
@@ -252,9 +252,10 @@ bool PostprocessRenderer::IsEffectEnabled(Effect effect) const
   return (m_effects & static_cast<uint32_t>(effect)) > 0;
 }
 
-void PostprocessRenderer::BeginFrame()
+void PostprocessRenderer::BeginFrame(bool isActiveFrame)
 {
-  if (!IsEnabled())
+  // Now we do not render posteffects on active frame by energy-saving issues.
+  if (isActiveFrame || !IsEnabled())
   {
     m_framebufferFallback();
     return;
@@ -278,7 +279,7 @@ void PostprocessRenderer::BeginFrame()
 
 void PostprocessRenderer::EndFrame(ref_ptr<dp::GpuProgramManager> gpuProgramManager)
 {
-  if (!IsEnabled() && !m_frameStarted)
+  if (!IsEnabled() || !m_frameStarted)
     return;
 
   bool wasPostEffect = false;

--- a/drape_frontend/postprocess_renderer.hpp
+++ b/drape_frontend/postprocess_renderer.hpp
@@ -43,7 +43,7 @@ public:
 
   void OnFramebufferFallback();
 
-  void BeginFrame();
+  void BeginFrame(bool isActiveFrame);
   void EndFrame(ref_ptr<dp::GpuProgramManager> gpuProgramManager);
 
   void EnableWritingToStencil() const;


### PR DESCRIPTION
Отключаем постэффекты на активные кадры, чтобы поберечь батареечку.

Мержить с божественного дозволения.
postprocess_renderer.cpp line 282 - старая бага, никто не заметил