### PR TITLE
[routing] Bicycle turn generation ASSERT fix.

### DIFF
--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -119,8 +119,8 @@ void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeV
 
     edges.emplace_back(FeatureID(MwmSet::MwmId(handle.GetInfo()), segment.GetFeatureId()),
                        segment.IsForward(), segment.GetSegmentIdx(),
-                       GetJunction(segment, false /* front */),
-                       GetJunction(segment, true /* front */));
+                       m_starter.GetJunction(segment, false /* front */),
+                       m_starter.GetJunction(segment, true /* front */));
   }
 }
 

--- a/routing/routing_integration_tests/osrm_route_test.cpp
+++ b/routing/routing_integration_tests/osrm_route_test.cpp
@@ -183,6 +183,13 @@ namespace
         MercatorBounds::FromLatLon(50.93227, 1.82725), 60498.);
   }
 
+  UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+      integration::GetOsrmComponents(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
+      MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
+  }
+
   // Strange map edits in Africa borders. Routing not linked now.
   /*
   UNIT_TEST(RussiaMoscowLenigradskiy39RepublicOfSouthAfricaCapeTownCenterRouteTest)


### PR DESCRIPTION
Исправление ASSERT в BicycleDirectionsEngine::GetUniNodeIdAndAdjacentEdges().

Проблема была в том, что при получении исходящих дуг из стартовой дуги маршрута координаты начала одной из исходящих дуг считались не верно. ASSERT стрелял в том случае, если старт попадал на двустороннюю фичу, и маршрут шел против точек это фичи.

При этом координата старта дуги исходящей из стартовой дуги и совпадающей с ней по геометрии, но противоположенная по направлению имела смещенную точку старта в начало маршрута (см. метод IndexRoadGraph::GetJunction). На этом и срабатывал ASSER на не совпадение точек. Аналогичная проблема была и при задании финиша.

@mpimenov @igrechuhin @rokuz @tatiana-kondakova PTAL