### PR TITLE
[routing] NetherlandsAmsterdamBicycleNo routing integration test fix.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -37,14 +37,13 @@ UNIT_TEST(SwedenStockholmCyclewayPriority)
       MercatorBounds::FromLatLon(59.33052, 18.09391), 113.0);
 }
 
+// Note. If the closest to start or finish road has "bicycle=no" tag the closest road where
+// it's allowed to ride bicycle will be found.
 UNIT_TEST(NetherlandsAmsterdamBicycleNo)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(52.32716, 5.05932),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(52.32587, 5.06121));
-
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::RouteNotFound, ());
+  integration::CalculateRouteAndTestRouteLength(
+    integration::GetBicycleComponents(), MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
+    MercatorBounds::FromLatLon(52.32587, 5.06121), 363.4);
 }
 
 UNIT_TEST(NetherlandsAmsterdamBicycleYes)


### PR DESCRIPTION
Исправил один из routing_integration_tests. 

![2017-09-01_20-02-00](https://user-images.githubusercontent.com/1768114/29980025-7cec862e-8f50-11e7-963a-3b0ddb092755.png)

По сути этот тест ранее проверял, что если ближайшая дорога имеет таг bicycle=no, то маршрут не прокладывается. Теперь он проверяет, что если ближайшая дорога имеет таг bicycle=no, то маршрут прокладывается от ближайшей дороги, которая подходит для велосипедов.

@mpimenov, @tatiana-kondakova PTAL