### PR TITLE
[generator] Add toilets type for toilets=yes

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -1,6 +1,7 @@
 atm=yes : amenity=atm
 bench=yes : amenity=bench
 shelter=yes : amenity=shelter
+toilets=yes : amenity=toilets
 restaurant=yes : amenity=restaurant
 hotel=yes : tourism=hotel
 building=entrance : entrance=yes

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -255,6 +255,7 @@ UNIT_TEST(OsmType_Synonyms)
       { "building", "yes" },
       { "shop", "yes" },
       { "atm", "yes" },
+      { "toilets", "yes" },
       { "restaurant", "yes" },
       { "hotel", "yes" },
     };
@@ -273,13 +274,15 @@ UNIT_TEST(OsmType_Synonyms)
     char const * arrT3[] = { "shop" };
     char const * arrT4[] = { "amenity", "restaurant" };
     char const * arrT5[] = { "tourism", "hotel" };
-    TEST_EQUAL(params.m_Types.size(), 5, (params));
+    char const * arrT6[] = { "amenity", "toilets" };
+    TEST_EQUAL(params.m_Types.size(), 6, (params));
 
     TEST(params.IsTypeExist(GetType(arrT1)), ());
     TEST(params.IsTypeExist(GetType(arrT2)), ());
     TEST(params.IsTypeExist(GetType(arrT3)), ());
     TEST(params.IsTypeExist(GetType(arrT4)), ());
     TEST(params.IsTypeExist(GetType(arrT5)), ());
+    TEST(params.IsTypeExist(GetType(arrT6)), ());
   }
 
   // Duplicating test.

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -100,6 +100,7 @@ public:
       { "amenity", "atm" },
       { "amenity", "bench" },
       { "amenity", "shelter" },
+      { "amenity", "toilets" },
       { "building", "address" },
       { "building", "has_parts" },
     };


### PR DESCRIPTION
Fixes #7030 

Сейчас скамейки и банкоматы могут быть как самостоятельными объектами (`amenity=atm`), так и атрибутами других заведений (`atm=yes`). Сделал то же для туалетов. Тегов `toilets=yes` 18 тысяч на планете, полезная штука.