### PR TITLE
[release-75] Memory consumption while jam matching fix

### DIFF
--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -32,12 +32,6 @@ void SplitEdge(Edge const & ab, Junction const & p, vector<Edge> & edges)
   auto const & b = ab.GetEndJunction();
 
   // No need to split the edge by its endpoints.
-  // The "if" condition below fixes the issue which was reproduced if to call:
-  // @TODO(bykoianko) It's necessary to write a routing integration test and remove comment below.
-  // std::vector<std::pair<routing::Edge, routing::Junction>> sourceVicinity;
-  // Junction j(PointD(50.732084512710564184, -1.2127983570098876953), feature::kDefaultAltitudeMeters);
-  // FeaturesRoadGraph::FindClosestEdges(j.GetPoint(), 20, sourceVicinity);
-  // FeaturesRoadGraph::AddFakeEdges(j, sourceVicinity);
   if (a.GetPoint() == p.GetPoint() || b.GetPoint() == p.GetPoint())
     return;
 

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -31,10 +31,9 @@ void SplitEdge(Edge const & ab, Junction const & p, vector<Edge> & edges)
   auto const & a = ab.GetStartJunction();
   auto const & b = ab.GetEndJunction();
 
-  // If the condition below is true edge |ab| should not be split. Because if |ab| will be split
-  // zero edge length will be add to |edges| and a duplicate of |ab| would be added to |edges|.
-  // As a consequent |edges| has to many duplicates.
+  // No need to split the edge by its endpoints.
   // The "if" condition below fixes the issue which was reproduced if to call:
+  // @TODO(bykoianko) It's necessary to write a routing integration test and remove comment below.
   // std::vector<std::pair<routing::Edge, routing::Junction>> sourceVicinity;
   // Junction j(PointD(50.732084512710564184, -1.2127983570098876953), feature::kDefaultAltitudeMeters);
   // FeaturesRoadGraph::FindClosestEdges(j.GetPoint(), 20, sourceVicinity);
@@ -233,11 +232,11 @@ void IRoadGraph::AddEdge(Junction const & j, Edge const & e, map<Junction, TEdge
 {
   auto & cont = edges[j];
   ASSERT(is_sorted(cont.cbegin(), cont.cend()), ());
-  auto const it = equal_range(cont.cbegin(), cont.cend(), e);
+  auto const range = equal_range(cont.cbegin(), cont.cend(), e);
   // Note. The "if" condition below is necessary to prevent duplicates which may be added when
   // edges from |j| to "projection of |j|" and an edge in the opposite direction are added.
-  if (it.first == it.second)
-    cont.insert(it.second, e);
+  if (range.first == range.second)
+    cont.insert(range.second, e);
 }
 
 void IRoadGraph::AddFakeEdges(Junction const & junction,

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -296,6 +296,8 @@ public:
   void GetFakeIngoingEdges(Junction const & junction, TEdgeVector & edges) const;
 
 private:
+  void AddEdge(Junction const & j, Edge const & e, map<Junction, TEdgeVector> & edges);
+
   template <typename Fn>
   void ForEachFakeEdge(Fn && fn)
   {
@@ -312,6 +314,8 @@ private:
     }
   }
 
+  /// \note |m_fakeIngoingEdges| and |m_fakeOutgoingEdges| are maps of sorted vectors.
+  /// Items to these maps should be inserted with AddEdge() method only.
   map<Junction, TEdgeVector> m_fakeIngoingEdges;
   map<Junction, TEdgeVector> m_fakeOutgoingEdges;
 };

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -314,7 +314,7 @@ private:
     }
   }
 
-  /// \note |m_fakeIngoingEdges| and |m_fakeOutgoingEdges| are maps of sorted vectors.
+  /// \note |m_fakeIngoingEdges| and |m_fakeOutgoingEdges| map junctions to sorted vectors.
   /// Items to these maps should be inserted with AddEdge() method only.
   map<Junction, TEdgeVector> m_fakeIngoingEdges;
   map<Junction, TEdgeVector> m_fakeOutgoingEdges;

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
   osrm_street_names_test.cpp
   osrm_turn_test.cpp
   pedestrian_route_test.cpp
+  road_graph_tests.cpp
   routing_test_tools.cpp
   routing_test_tools.hpp
 )

--- a/routing/routing_integration_tests/road_graph_tests.cpp
+++ b/routing/routing_integration_tests/road_graph_tests.cpp
@@ -1,0 +1,48 @@
+#include "testing/testing.hpp"
+
+#include "platform/local_country_file.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "indexer/classificator_loader.hpp"
+#include "indexer/feature_altitude.hpp"
+#include "indexer/index.hpp"
+#include "indexer/mwm_set.hpp"
+
+#include "routing_common/car_model.hpp"
+#include "routing/features_road_graph.hpp"
+#include "routing/road_graph.hpp"
+
+#include "routing_integration_tests/routing_test_tools.hpp"
+
+#include <vector>
+
+using namespace routing;
+using namespace integration;
+
+// The test on combinatorial explosion of number of fake edges at FeaturesRoadGraph.
+// It might happen when a lot of roads intersect at one point. For example,
+// http://www.openstreetmap.org/#map=19/50.73197/-1.21295
+UNIT_TEST(FakeEdgesCombinatorialExplosion)
+{
+  classificator::Load();
+
+  std::vector<LocalCountryFile> localFiles;
+  GetAllLocalFiles(localFiles);
+  TEST(!localFiles.empty(), ());
+
+  Index index;
+  for (auto const & file : localFiles)
+  {
+    auto const result = index.Register(file);
+    TEST_EQUAL(result.second, MwmSet::RegResult::Success, ());
+  }
+
+  FeaturesRoadGraph graph(index, IRoadGraph::Mode::ObeyOnewayTag, make_shared<CarModelFactory>());
+  Junction const j(m2::PointD(MercatorBounds::FromLatLon(50.73208, -1.21279)), feature::kDefaultAltitudeMeters);
+  std::vector<std::pair<routing::Edge, routing::Junction>> sourceVicinity;
+  graph.FindClosestEdges(j.GetPoint(), 20 /* count */, sourceVicinity);
+  // In case of the combinatorial explosion mentioned above all the memory was consumed for
+  // FeaturesRoadGraph::m_fakeIngoingEdges and FeaturesRoadGraph::m_fakeOutgoingEdges fields.
+  graph.AddFakeEdges(j, sourceVicinity);
+}

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -33,6 +33,7 @@ SOURCES += \
   osrm_street_names_test.cpp \
   osrm_turn_test.cpp \
   pedestrian_route_test.cpp \
+  road_graph_tests.cpp \
   routing_test_tools.cpp \
 
 HEADERS += \

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -178,8 +178,7 @@ namespace integration
     unique_ptr<IRouter> m_router;
   };
 
-  template <typename TRouterComponents>
-  shared_ptr<TRouterComponents> CreateAllMapsComponents()
+  void GetAllLocalFiles(vector<LocalCountryFile> & localFiles)
   {
     // Setting stored paths from testingmain.cpp
     Platform & pl = GetPlatform();
@@ -190,12 +189,17 @@ namespace integration
       pl.SetResourceDir(options.m_resourcePath);
 
     platform::migrate::SetMigrationFlag();
-
-    vector<LocalCountryFile> localFiles;
     platform::FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max() /* latestVersion */,
                                          localFiles);
     for (auto & file : localFiles)
       file.SyncWithDisk();
+  }
+
+  template <typename TRouterComponents>
+  shared_ptr<TRouterComponents> CreateAllMapsComponents()
+  {
+    vector<LocalCountryFile> localFiles;
+    GetAllLocalFiles(localFiles);
     ASSERT(!localFiles.empty(), ());
     return shared_ptr<TRouterComponents>(new TRouterComponents(localFiles));
   }

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -69,6 +69,7 @@ protected:
   unique_ptr<storage::CountryInfoGetter> m_infoGetter;
 };
 
+void GetAllLocalFiles(vector<LocalCountryFile> & localFiles);
 void TestOnlineCrosses(ms::LatLon const & startPoint, ms::LatLon const & finalPoint,
                        vector<string> const & expected, IRouterComponents & routerComponents);
 void TestOnlineFetcher(ms::LatLon const & startPoint, ms::LatLon const & finalPoint,

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		56CA09E61E30E73B00D05C9A /* index_graph_tools.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CA09E11E30E73B00D05C9A /* index_graph_tools.hpp */; };
 		56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09E21E30E73B00D05C9A /* restriction_test.cpp */; };
 		56CA09E91E30F19800D05C9A /* libtraffic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56CA09E81E30F19800D05C9A /* libtraffic.a */; };
+		56CA63071F61206700E6681B /* road_graph_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA63061F61206700E6681B /* road_graph_tests.cpp */; };
 		56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */; };
 		56D637D61E4B12AA00B86D7B /* cross_mwm_index_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56D637D51E4B12AA00B86D7B /* cross_mwm_index_graph.cpp */; };
 		56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */; };
@@ -362,6 +363,7 @@
 		56CA09E11E30E73B00D05C9A /* index_graph_tools.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_tools.hpp; sourceTree = "<group>"; };
 		56CA09E21E30E73B00D05C9A /* restriction_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restriction_test.cpp; sourceTree = "<group>"; };
 		56CA09E81E30F19800D05C9A /* libtraffic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtraffic.a; path = "/Users/vladimirbykoyanko/src_github_master/omim/xcode/traffic/../../../omim-build/xcode/Debug/libtraffic.a"; sourceTree = "<absolute>"; };
+		56CA63061F61206700E6681B /* road_graph_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_graph_tests.cpp; sourceTree = "<group>"; };
 		56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_index_graph.hpp; sourceTree = "<group>"; };
 		56D637D51E4B12AA00B86D7B /* cross_mwm_index_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_mwm_index_graph.cpp; sourceTree = "<group>"; };
 		56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_helpers.hpp; sourceTree = "<group>"; };
@@ -886,6 +888,7 @@
 		67BD35961C69F03E003AA26F /* routing_integration_tests */ = {
 			isa = PBXGroup;
 			children = (
+				56CA63061F61206700E6681B /* road_graph_tests.cpp */,
 				67BD35AC1C69F086003AA26F /* cross_section_tests.cpp */,
 				67BD35AD1C69F086003AA26F /* online_cross_tests.cpp */,
 				67BD35AE1C69F086003AA26F /* osrm_route_test.cpp */,
@@ -1221,6 +1224,7 @@
 				674F9BD21B0A580E00704FFA /* road_graph_router.cpp in Sources */,
 				5694CECE1EBA25F7004576D3 /* vehicle_mask.cpp in Sources */,
 				A1876BC61BB19C4300C9C743 /* speed_camera.cpp in Sources */,
+				56CA63071F61206700E6681B /* road_graph_tests.cpp in Sources */,
 				0C45D7391F2F75500065C3ED /* routing_settings.cpp in Sources */,
 				0C5FEC691DDE193F0017688C /* road_index.cpp in Sources */,
 				0CF709361F05172200D5067E /* checkpoints.cpp in Sources */,


### PR DESCRIPTION
После увеличения числа дуг кандидатов для начала и конца маршрута с 10 до 20 на одной точке произошел комбинаторный взрыв кол-ва файковых дуг (в IRoadGraph::m_fakeIngoingEdges и IRoadGraph::m_fakeOutgoingEdges). Это приводило к не приемлемому потреблению памяти при матчинге дуг.

Точка на которой воспроизвелась проблема: http://www.openstreetmap.org/#map=19/50.73197/-1.21295
![2017-09-06_16-00-02](https://user-images.githubusercontent.com/1768114/30123800-d0364948-933b-11e7-8ac7-e5568e2139b1.png)

Кроме, того данный PR включает не большой рефакторинг. Вектора в IRoadGraph::m_fakeIngoingEdges и IRoadGraph::m_fakeOutgoingEdges теперь сортированные.

@ygorshenin @mgsergio PTAL