### PR TITLE
Add fake route endings to IndexGraphStarter

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -42,6 +42,7 @@ set(
   directions_engine.hpp
   edge_estimator.cpp
   edge_estimator.hpp
+  fake_edges_container.hpp
   features_road_graph.cpp
   features_road_graph.hpp
   geometry.cpp

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -293,7 +293,7 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
 {
   size_t const pathSize = path.size();
   CHECK_GREATER(pathSize, 1, ());
-  CHECK_EQUAL(routeEdges.size(), pathSize - 1, ());
+  CHECK_EQUAL(routeEdges.size() + 1, pathSize, ());
   // Filling |m_adjacentEdges|.
   auto constexpr kInvalidSegId = numeric_limits<uint32_t>::max();
   // |startSegId| is a value to keep start segment id of a new instance of LoadedPathSegment.

--- a/routing/fake_edges_container.hpp
+++ b/routing/fake_edges_container.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "routing/index_graph_starter.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace routing
+{
+class FakeEdgesContainer final
+{
+  friend class IndexGraphStarter;
+
+public:
+  FakeEdgesContainer(IndexGraphStarter && starter)
+    : m_finishId(starter.m_finishId)
+    , m_fake(std::move(starter.m_fake))
+  {
+  }
+
+  size_t GetNumFakeEdges() const { return m_fake.m_segmentToVertex.size(); }
+
+private:
+  // finish segment id
+  uint32_t m_finishId;
+  IndexGraphStarter::FakeGraph m_fake;
+};
+}  // namespace routing

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -7,6 +7,35 @@ namespace
 using namespace routing;
 using namespace std;
 
+Segment InvertDirection(Segment const & segment)
+{
+  return Segment(segment.GetMwmId(), segment.GetFeatureId(), segment.GetSegmentIdx(),
+                 !segment.IsForward());
+}
+
+Junction InterpolateJunction(Segment const & segment, m2::PointD const & point, WorldGraph & graph)
+{
+  Junction const & begin = graph.GetJunction(segment, false /* front */);
+  Junction const & end = graph.GetJunction(segment, true /* front */);
+
+  m2::PointD const segmentDir = end.GetPoint() - begin.GetPoint();
+  if (segmentDir.IsAlmostZero())
+    return Junction(point, begin.GetAltitude());
+
+  m2::PointD const pointDir = point - begin.GetPoint();
+
+  double const ratio = m2::DotProduct(segmentDir, pointDir) / segmentDir.SquaredLength();
+  if (ratio <= 0.0)
+    return Junction(point, begin.GetAltitude());
+
+  if (ratio >= 1.0)
+    return Junction(point, end.GetAltitude());
+
+  return Junction(point, static_cast<feature::TAltitude>(
+                             (1.0 - ratio) * static_cast<double>(begin.GetAltitude()) +
+                             ratio * (static_cast<double>(end.GetAltitude()))));
+}
+
 Junction CalcProjectionToSegment(Segment const & segment, Junction const & junction,
                                  WorldGraph & graph)
 {
@@ -19,162 +48,373 @@ Junction CalcProjectionToSegment(Segment const & segment, Junction const & junct
 
 namespace routing
 {
-// static
-Segment constexpr IndexGraphStarter::kStartFakeSegment;
-Segment constexpr IndexGraphStarter::kFinishFakeSegment;
+void IndexGraphStarter::AddFakeVertex(Segment const & existentSegment, Segment const & newSegment,
+                                      FakeVertex const & newVertex, bool isOutgoing,
+                                      bool isPartOfReal, Segment const & realSegment)
+{
+  auto const & segmentFrom = isOutgoing ? existentSegment : newSegment;
+  auto const & segmentTo = isOutgoing ? newSegment : existentSegment;
+  m_fake.m_outgoing[segmentFrom].insert(segmentTo);
+  m_fake.m_ingoing[segmentTo].insert(segmentFrom);
+  m_fake.m_segmentToVertex[newSegment] = newVertex;
+  if (isPartOfReal)
+  {
+    m_fake.m_realToFake[realSegment].insert(newSegment);
+    m_fake.m_fakeToReal[newSegment] = realSegment;
+  }
+}
 
-IndexGraphStarter::IndexGraphStarter(FakeVertex const & start, FakeVertex const & finish,
-                                     WorldGraph & graph)
+Segment IndexGraphStarter::GetSegment(FakeVertex const & vertex, uint32_t & newNumber) const
+{
+  for (auto const & v : m_fake.m_segmentToVertex)
+  {
+    if (v.second == vertex)
+      return v.first;
+  }
+
+  return GetFakeSegment(newNumber++);
+}
+
+void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding const & otherEnding,
+                                  bool isStart, uint32_t & fakeNumerationStart, bool strictForward)
+{
+  CHECK_EQUAL(thisEnding.m_projectionJunctions.size(), thisEnding.m_projectionSegments.size(), ());
+  CHECK_EQUAL(otherEnding.m_projectionJunctions.size(), otherEnding.m_projectionSegments.size(), ());
+  Segment dummy;
+
+  map<Segment, Junction> otherSegments;
+  for (size_t i = 0; i < otherEnding.m_projectionSegments.size(); ++i)
+    otherSegments[otherEnding.m_projectionSegments[i]] = otherEnding.m_projectionJunctions[i];
+
+  // Add pure fake vertex
+  auto fakeSegment = GetFakeSegment(fakeNumerationStart++);
+  FakeVertex fakeVertex(thisEnding.m_originJunction, thisEnding.m_originJunction,
+                        FakeVertex::Type::PureFake);
+  m_fake.m_segmentToVertex[fakeSegment] = fakeVertex;
+  for (uint32_t i = 0; i < thisEnding.m_projectionJunctions.size(); ++i)
+  {
+    // Add projection edges
+    auto projectionSegment = GetFakeSegment(fakeNumerationStart++);
+    FakeVertex projection(
+        isStart ? thisEnding.m_originJunction : thisEnding.m_projectionJunctions[i],
+        isStart ? thisEnding.m_projectionJunctions[i] : thisEnding.m_originJunction,
+        FakeVertex::Type::Projection);
+    AddFakeVertex(fakeSegment, projectionSegment, projection, isStart /* isOutgoing */,
+                  false /* isPartOfReal */, dummy /* realSegment */);
+
+    // Add fake parts of real
+    auto frontJunction = m_graph.GetJunction(thisEnding.m_projectionSegments[i],
+                                             thisEnding.m_projectionSegments[i].IsForward());
+    auto backJunction = m_graph.GetJunction(thisEnding.m_projectionSegments[i],
+                                            !thisEnding.m_projectionSegments[i].IsForward());
+
+    // Check whether we have projections to same real segment from both endings.
+    auto const & it = otherSegments.find(thisEnding.m_projectionSegments[i]);
+    if (it != otherSegments.end())
+    {
+      auto const & otherJunction = it->second;
+      auto distBackToThis = m_graph.GetEstimator().CalcLeapWeight(
+          backJunction.GetPoint(), thisEnding.m_projectionJunctions[i].GetPoint());
+      auto distBackToOther =
+          m_graph.GetEstimator().CalcLeapWeight(backJunction.GetPoint(), otherJunction.GetPoint());
+      distBackToThis < distBackToOther ? frontJunction = otherJunction
+                                       : backJunction = otherJunction;
+    }
+
+    FakeVertex forwardPartOfReal(isStart ? thisEnding.m_projectionJunctions[i] : backJunction,
+                                 isStart ? frontJunction : thisEnding.m_projectionJunctions[i],
+                                 FakeVertex::Type::PartOfReal);
+    auto fakeForwardSegment = GetSegment(forwardPartOfReal, fakeNumerationStart);
+    AddFakeVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
+                  isStart /* isOutgoing */, true /* isPartOfReal */,
+                  thisEnding.m_projectionSegments[i]);
+
+    bool oneWay = m_graph
+                      .GetRoadGeometry(thisEnding.m_projectionSegments[i].GetMwmId(),
+                                       thisEnding.m_projectionSegments[i].GetFeatureId())
+                      .IsOneWay();
+    if (!strictForward && !oneWay)
+    {
+      Segment backwardSegment = InvertDirection(thisEnding.m_projectionSegments[i]);
+      FakeVertex backwardPartOfReal(isStart ? thisEnding.m_projectionJunctions[i] : frontJunction,
+                                    isStart ? backJunction : thisEnding.m_projectionJunctions[i],
+                                    FakeVertex::Type::PartOfReal);
+      auto fakeBackwardSegment = GetSegment(backwardPartOfReal, fakeNumerationStart);
+      AddFakeVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
+                    isStart /* isOutgoing */, true /* isPartOfReal */, backwardSegment);
+    }
+  }
+}
+
+void IndexGraphStarter::AddStart(FakeEnding const & startEnding, FakeEnding const & finishEnding,
+                                 uint32_t & fakeNumerationStart, bool strictForward)
+{
+  AddEnding(startEnding, finishEnding, true /* isStart */, fakeNumerationStart, strictForward);
+}
+void IndexGraphStarter::AddFinish(FakeEnding const & finishEnding, FakeEnding const & startEnding,
+                                  uint32_t & fakeNumerationStart)
+{
+  AddEnding(finishEnding, startEnding, false /* isStart */, fakeNumerationStart,
+            false /* strictForward */);
+}
+
+IndexGraphStarter::IndexGraphStarter(FakeEnding const & startEnding,
+                                     FakeEnding const & finishEnding, uint32_t fakeNumerationStart,
+                                     bool strictForward, WorldGraph & graph)
   : m_graph(graph)
-  , m_start(start.GetSegment(),
-            CalcProjectionToSegment(start.GetSegment(), start.GetJunction(), graph),
-            start.GetStrictForward())
-  , m_finish(finish.GetSegment(),
-             CalcProjectionToSegment(finish.GetSegment(), finish.GetJunction(), graph),
-             finish.GetStrictForward())
 {
+  m_startId = fakeNumerationStart;
+  AddStart(startEnding, finishEnding, fakeNumerationStart, strictForward);
+  m_finishId = fakeNumerationStart;
+  AddFinish(finishEnding, startEnding, fakeNumerationStart);
 }
 
-Junction const & IndexGraphStarter::GetJunction(Segment const & segment, bool front)
+IndexGraphStarter::IndexGraphStarter(vector<IndexGraphStarter> starters)
+  : m_graph(starters.front().m_graph)
 {
-  if (segment == kStartFakeSegment)
-    return m_start.GetJunction();
+  m_startId = starters.front().m_startId;
+  m_finishId = starters.back().m_finishId;
 
-  if (segment == kFinishFakeSegment)
-    return m_finish.GetJunction();
+  for (auto const & starter : starters)
+  {
+    m_fake.m_segmentToVertex.insert(starter.m_fake.m_segmentToVertex.begin(),
+                                    starter.m_fake.m_segmentToVertex.end());
 
-  return m_graph.GetJunction(segment, front);
+    for (auto const & s : starter.m_fake.m_outgoing)
+      m_fake.m_outgoing[s.first].insert(s.second.begin(), s.second.end());
+
+    for (auto const & s : starter.m_fake.m_ingoing)
+      m_fake.m_ingoing[s.first].insert(s.second.begin(), s.second.end());
+
+    for (auto const & s : starter.m_fake.m_realToFake)
+      m_fake.m_realToFake[s.first].insert(s.second.begin(), s.second.end());
+
+    m_fake.m_fakeToReal.insert(starter.m_fake.m_fakeToReal.begin(),
+                               starter.m_fake.m_fakeToReal.end());
+  }
 }
 
-m2::PointD const & IndexGraphStarter::GetPoint(Segment const & segment, bool front)
+void IndexGraphStarter::Append(FakeEdgesContainer const & container)
+{
+  m_finishId = container.m_finishId;
+
+  m_fake.m_segmentToVertex.insert(container.m_fake.m_segmentToVertex.begin(),
+                                  container.m_fake.m_segmentToVertex.end());
+
+  for (auto const & s : container.m_fake.m_outgoing)
+    m_fake.m_outgoing[s.first].insert(s.second.begin(), s.second.end());
+
+  for (auto const & s : container.m_fake.m_ingoing)
+    m_fake.m_ingoing[s.first].insert(s.second.begin(), s.second.end());
+
+  for (auto const & s : container.m_fake.m_realToFake)
+    m_fake.m_realToFake[s.first].insert(s.second.begin(), s.second.end());
+
+  m_fake.m_fakeToReal.insert(container.m_fake.m_fakeToReal.begin(),
+                             container.m_fake.m_fakeToReal.end());
+}
+
+// static
+IndexGraphStarter::FakeEnding IndexGraphStarter::MakeFakeEnding(Segment const & segment,
+                                                                m2::PointD const & point,
+                                                                WorldGraph & graph)
+{
+  IndexGraphStarter::FakeEnding ending;
+  ending.m_originJunction = InterpolateJunction(segment, point, graph);
+  ending.m_projectionJunctions.push_back(
+      CalcProjectionToSegment(segment, ending.m_originJunction, graph));
+  ending.m_projectionSegments.push_back(segment);
+  return ending;
+}
+
+Junction const & IndexGraphStarter::GetStartJunction() const
+{
+  auto const & startSegment = GetFakeSegment(m_startId);
+
+  auto it = m_fake.m_segmentToVertex.find(startSegment);
+
+  CHECK(it != m_fake.m_segmentToVertex.end(), ("Requested junction for invalid fake segment."));
+  return it->second.GetJunctionFrom();
+}
+
+Junction const & IndexGraphStarter::GetFinishJunction() const
+{
+  auto const & finishSegment = GetFakeSegment(m_finishId);
+
+  auto it = m_fake.m_segmentToVertex.find(finishSegment);
+
+  CHECK(it != m_fake.m_segmentToVertex.end(), ("Requested junction for invalid fake segment."));
+  return it->second.GetJunctionTo();
+}
+
+bool IndexGraphStarter::ConvertToReal(Segment & segment) const
+{
+  if (!IsFakeSegment(segment))
+    return true;
+
+  auto const & it = m_fake.m_fakeToReal.find(segment);
+  if (it == m_fake.m_fakeToReal.end())
+    return false;
+
+  segment = it->second;
+  return true;
+}
+
+Junction const & IndexGraphStarter::GetJunction(Segment const & segment, bool front) const
+{
+  if (!IsFakeSegment(segment))
+    return m_graph.GetJunction(segment, front);
+
+  auto fakeVertexIt = m_fake.m_segmentToVertex.find(segment);
+
+  CHECK(fakeVertexIt != m_fake.m_segmentToVertex.end(),
+        ("Requested junction for invalid fake segment."));
+  return front ? fakeVertexIt->second.GetJunctionTo() : fakeVertexIt->second.GetJunctionFrom();
+}
+
+m2::PointD const & IndexGraphStarter::GetPoint(Segment const & segment, bool front) const
 {
   return GetJunction(segment, front).GetPoint();
 }
 
 // static
-void IndexGraphStarter::CheckValidRoute(vector<Segment> const &segments)
+void IndexGraphStarter::CheckValidRoute(vector<Segment> const & segments)
 {
   // Valid route contains at least 3 segments:
   // start fake, finish fake and at least one normal nearest segment.
   CHECK_GREATER_OR_EQUAL(segments.size(), 3, ());
-  CHECK_EQUAL(segments.front(), kStartFakeSegment, ());
-  CHECK_EQUAL(segments.back(), kFinishFakeSegment, ());
+  CHECK(IsFakeSegment(segments.front()), ());
+  CHECK(IsFakeSegment(segments.back()), ());
 }
 
-// static
-vector<Segment>::const_iterator IndexGraphStarter::GetNonFakeStartIt(vector<Segment> const & segments)
+set<NumMwmId> IndexGraphStarter::GetMwms() const
 {
-  CheckValidRoute(segments);
-  // See CheckValidRoute comment.
-  return segments.begin() + 1;
-}
+  set<NumMwmId> mwms;
+  for (auto const & s : m_fake.m_fakeToReal)
+    mwms.insert(s.second.GetMwmId());
 
-// static
-vector<Segment>::const_iterator IndexGraphStarter::GetNonFakeFinishIt(vector<Segment> const & segments)
-{
-  CheckValidRoute(segments);
-  // See CheckValidRoute comment.
-  return segments.end() - 2;
+  return mwms;
 }
 
 // static
 size_t IndexGraphStarter::GetRouteNumPoints(vector<Segment> const & segments)
 {
   CheckValidRoute(segments);
-  return segments.size() - 1;
+  return segments.size() + 1;
 }
 
 Junction const & IndexGraphStarter::GetRouteJunction(vector<Segment> const & segments,
-                                                     size_t pointIndex)
+                                                     size_t pointIndex) const
 {
-  if (pointIndex == 0)
-    return m_start.GetJunction();
-
-  if (pointIndex + 1 == GetRouteNumPoints(segments))
-    return m_finish.GetJunction();
-
-  CHECK_LESS(pointIndex, segments.size(), ());
-  return GetJunction(segments[pointIndex], true /* front */);
+  CHECK_LESS_OR_EQUAL(
+      pointIndex, segments.size(),
+      ("Point with index", pointIndex, "does not exist in route with size", segments.size()));
+  if (pointIndex == segments.size())
+    return GetJunction(segments[pointIndex - 1], true);
+  return GetJunction(segments[pointIndex], false);
 }
 
-void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
-                                     vector<SegmentEdge> & edges)
+double IndexGraphStarter::CalcSegmentWeight(Segment const & segment) const
 {
-  edges.clear();
+  if (!IsFakeSegment(segment))
+    return m_graph.GetEstimator().CalcSegmentWeight(
+        segment, m_graph.GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()));
 
-  if (segment == kStartFakeSegment)
+  auto fakeVertexIt = m_fake.m_segmentToVertex.find(segment);
+
+  CHECK(fakeVertexIt != m_fake.m_segmentToVertex.end(),
+        ("Requested junction for invalid fake segment."));
+  return m_graph.GetEstimator().CalcLeapWeight(fakeVertexIt->second.GetPointFrom(),
+                                               fakeVertexIt->second.GetPointTo());
+}
+
+double IndexGraphStarter::CalcRouteSegmentWeight(vector<Segment> const & route,
+                                                 size_t segmentIndex) const
+{
+  CHECK_LESS(
+      segmentIndex, route.size(),
+      ("Segment with index", segmentIndex, "does not exist in route with size", route.size()));
+  return CalcSegmentWeight(route[segmentIndex]);
+}
+
+bool IndexGraphStarter::IsLeap(NumMwmId mwmId) const
+{
+  bool inProjectedMwmIds = false;
+  for (auto const & s : m_fake.m_fakeToReal)
   {
-    GetFakeToNormalEdges(m_start, isOutgoing, edges);
-    return;
+    if (s.second.GetMwmId() == mwmId)
+    {
+      inProjectedMwmIds = true;
+      break;
+    }
   }
 
-  if (segment == kFinishFakeSegment)
-  {
-    GetFakeToNormalEdges(m_finish, isOutgoing, edges);
-    return;
-  }
+  return mwmId != kFakeNumMwmId && !inProjectedMwmIds &&
+         m_graph.GetEstimator().LeapIsAllowed(mwmId);
+}
 
-  if (m_graph.GetMode() == WorldGraph::Mode::LeapsOnly && (m_start.Fits(segment) || m_finish.Fits(segment)))
+void IndexGraphStarter::AddFakeEdges(vector<SegmentEdge> & edges) const
+{
+  for (auto const & edge : edges)
+  {
+    auto const & it = m_fake.m_realToFake.find(edge.GetTarget());
+    if (it == m_fake.m_realToFake.end())
+      continue;
+    for (auto const & s : it->second)
+      edges.emplace_back(s, RouteWeight(edge.GetWeight()));
+  }
+}
+
+void IndexGraphStarter::AddRealEdges(Segment const & segment, bool isOutgoing,
+                                     std::vector<SegmentEdge> & edges) const
+{
+  if (m_graph.GetMode() == WorldGraph::Mode::LeapsOnly &&
+      m_fake.m_realToFake.find(segment) != m_fake.m_realToFake.end())
   {
     ConnectLeapToTransitions(segment, isOutgoing, edges);
     return;
   }
 
   m_graph.GetEdgeList(segment, isOutgoing, IsLeap(segment.GetMwmId()), edges);
-  GetNormalToFakeEdge(segment, m_start, kStartFakeSegment, isOutgoing, edges);
-  GetNormalToFakeEdge(segment, m_finish, kFinishFakeSegment, isOutgoing, edges);
 }
 
-void IndexGraphStarter::GetFakeToNormalEdges(FakeVertex const & fakeVertex, bool isOutgoing,
-                                             vector<SegmentEdge> & edges)
+void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
+                                     vector<SegmentEdge> & edges) const
 {
-  if (fakeVertex.GetStrictForward())
+  edges.clear();
+  if (IsFakeSegment(segment))
   {
-    GetFakeToNormalEdge(fakeVertex, fakeVertex.GetSegment().IsForward(), edges);
+    auto const & vertexIt = m_fake.m_segmentToVertex.find(segment);
+    CHECK(vertexIt != m_fake.m_segmentToVertex.end(),
+          ("Can not map fake segment", segment, "to fake vertex."));
+
+    if (vertexIt->second.GetType() == FakeVertex::Type::PartOfReal)
+    {
+      auto const & realIt = m_fake.m_fakeToReal.find(segment);
+      CHECK(realIt != m_fake.m_fakeToReal.end(),
+            ("Can not map fake segment", segment, "to real segment."));
+      AddRealEdges(realIt->second, isOutgoing, edges);
+    }
+
+    auto const & fakeGraph = isOutgoing ? m_fake.m_outgoing : m_fake.m_ingoing;
+
+    auto it = fakeGraph.find(segment);
+    if (it != fakeGraph.end())
+    {
+      for (auto const & s : it->second)
+        edges.emplace_back(s, RouteWeight(CalcSegmentWeight(isOutgoing ? s : segment)));
+    }
   }
   else
   {
-    GetFakeToNormalEdge(fakeVertex, true /* forward */, edges);
-
-    if (!m_graph.GetRoadGeometry(fakeVertex.GetMwmId(), fakeVertex.GetFeatureId()).IsOneWay())
-      GetFakeToNormalEdge(fakeVertex, false /* forward */, edges);
-  }
-}
-
-void IndexGraphStarter::GetFakeToNormalEdge(FakeVertex const & fakeVertex, bool forward,
-                                            vector<SegmentEdge> & edges)
-{
-  auto const segment = fakeVertex.GetSegmentWithDirection(forward);
-  m2::PointD const & pointTo = GetPoint(segment, true /* front */);
-  RouteWeight const weight(m_graph.GetEstimator().CalcLeapWeight(fakeVertex.GetPoint(), pointTo));
-  edges.emplace_back(segment, weight);
-}
-
-void IndexGraphStarter::GetNormalToFakeEdge(Segment const & segment, FakeVertex const & fakeVertex,
-                                            Segment const & fakeSegment, bool isOutgoing,
-                                            vector<SegmentEdge> & edges)
-{
-  m2::PointD const & pointFrom = GetPoint(segment, isOutgoing);
-  if (segment.GetMwmId() == fakeVertex.GetMwmId() &&
-      m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
-  {
-    if (m_graph.IsTransition(segment, isOutgoing))
-    {
-      edges.emplace_back(fakeSegment, RouteWeight(m_graph.GetEstimator().CalcLeapWeight(
-                                          pointFrom, fakeVertex.GetPoint())));
-    }
-    return;
+    AddRealEdges(segment, isOutgoing, edges);
   }
 
-  if (fakeVertex.Fits(segment))
-  {
-    edges.emplace_back(fakeSegment, RouteWeight(m_graph.GetEstimator().CalcLeapWeight(
-                                        pointFrom, fakeVertex.GetPoint())));
-  }
+  AddFakeEdges(edges);
 }
 
 void IndexGraphStarter::ConnectLeapToTransitions(Segment const & segment, bool isOutgoing,
-                                                 vector<SegmentEdge> & edges)
+                                                 vector<SegmentEdge> & edges) const
 {
   edges.clear();
   m2::PointD const & segmentPoint = GetPoint(segment, true /* front */);

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -4,10 +4,7 @@
 
 #include <cstdint>
 
-namespace
-{
 using namespace std;
-}  // namespace
 
 namespace routing
 {
@@ -89,18 +86,15 @@ void IndexRoadGraph::GetRouteEdges(TEdgeVector & edges) const
 
   for (Segment const & segment : m_segments)
   {
-    auto featureIdHandle = FeatureID();
+    auto featureId = FeatureID();
 
     if (!IndexGraphStarter::IsFakeSegment(segment))
     {
       platform::CountryFile const & file = m_numMwmIds->GetFile(segment.GetMwmId());
-      MwmSet::MwmHandle const handle = m_index.GetMwmHandleByCountryFile(file);
-      if (!handle.IsAlive())
-        MYTHROW(RoutingException, ("Can't get mwm handle for", file));
-
-      featureIdHandle = FeatureID(handle.GetId(), segment.GetFeatureId());
+      MwmSet::MwmId const mwmId = m_index.GetMwmIdByCountryFile(file);
+      featureId = FeatureID(mwmId, segment.GetFeatureId());
     }
-    edges.emplace_back(featureIdHandle, segment.IsForward(), segment.GetSegmentIdx(),
+    edges.emplace_back(featureId, segment.IsForward(), segment.GetSegmentIdx(),
                        m_starter.GetJunction(segment, false /* front */),
                        m_starter.GetJunction(segment, true /* front */));
   }
@@ -126,13 +120,10 @@ void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeV
       continue;
 
     platform::CountryFile const & file = m_numMwmIds->GetFile(segment.GetMwmId());
-    MwmSet::MwmHandle const handle = m_index.GetMwmHandleByCountryFile(file);
-    if (!handle.IsAlive())
-      MYTHROW(RoutingException, ("Can't get mwm handle for", file));
+    MwmSet::MwmId const mwmId = m_index.GetMwmIdByCountryFile(file);
 
-    edges.emplace_back(FeatureID(MwmSet::MwmId(handle.GetInfo()), segment.GetFeatureId()),
-                       segment.IsForward(), segment.GetSegmentIdx(),
-                       m_starter.GetJunction(segment, false /* front */),
+    edges.emplace_back(FeatureID(mwmId, segment.GetFeatureId()), segment.IsForward(),
+                       segment.GetSegmentIdx(), m_starter.GetJunction(segment, false /* front */),
                        m_starter.GetJunction(segment, true /* front */));
   }
 }

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -7,16 +7,17 @@
 
 #include "indexer/index.hpp"
 
-#include "std/map.hpp"
-#include "std/vector.hpp"
+#include <map>
+#include <memory>
+#include <vector>
 
 namespace routing
 {
 class IndexRoadGraph : public RoadGraphBase
 {
 public:
-  IndexRoadGraph(shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarter & starter,
-                 vector<Segment> const & segments, vector<Junction> const & junctions,
+  IndexRoadGraph(std::shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarter & starter,
+                 std::vector<Segment> const & segments, std::vector<Junction> const & junctions,
                  Index & index);
 
   // IRoadGraphBase overrides:
@@ -33,13 +34,13 @@ public:
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;
   Junction const & GetJunction(Segment const & segment, bool front) const;
-  vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
+  std::vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
 
   Index & m_index;
-  shared_ptr<NumMwmIds> m_numMwmIds;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
   IndexGraphStarter & m_starter;
-  vector<Segment> m_segments;
-  map<Junction, vector<Segment>> m_beginToSegment;
-  map<Junction, vector<Segment>> m_endToSegment;
+  std::vector<Segment> m_segments;
+  std::map<Junction, std::vector<Segment>> m_beginToSegment;
+  std::map<Junction, std::vector<Segment>> m_endToSegment;
 };
 }  // namespace routing

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -4,6 +4,7 @@
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/features_road_graph.hpp"
+#include "routing/index_graph_starter.hpp"
 #include "routing/joint.hpp"
 #include "routing/num_mwm_id.hpp"
 #include "routing/router.hpp"
@@ -20,6 +21,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -72,8 +74,7 @@ private:
                                        RouterDelegate const & delegate, Route & route);
   IRouter::ResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
                                         Segment const & startSegment,
-                                        bool startSegmentIsAlmostCodirectional,
-                                        RouterDelegate const & delegate, WorldGraph & graph,
+                                        RouterDelegate const & delegate, IndexGraphStarter & graph,
                                         std::vector<Segment> & subroute, Junction & startJunction);
 
   IRouter::ResultCode AdjustRoute(Checkpoints const & checkpoints,
@@ -102,7 +103,7 @@ private:
                                    RouterDelegate const & delegate, IndexGraphStarter & starter,
                                    Route & route) const;
 
-  bool AreMwmsNear(NumMwmId startId, NumMwmId finishId) const;
+  bool AreMwmsNear(std::set<NumMwmId> mwmIds) const;
 
   VehicleType m_vehicleType;
   bool m_loadAltitudes;
@@ -121,5 +122,6 @@ private:
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::unique_ptr<IDirectionsEngine> m_directionsEngine;
   std::unique_ptr<SegmentedRoute> m_lastRoute;
+  std::unique_ptr<FakeEdgesContainer> m_lastFakeEdges;
 };
 }  // namespace routing

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -3,8 +3,8 @@
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
+#include "routing/fake_edges_container.hpp"
 #include "routing/features_road_graph.hpp"
-#include "routing/index_graph_starter.hpp"
 #include "routing/joint.hpp"
 #include "routing/num_mwm_id.hpp"
 #include "routing/router.hpp"
@@ -19,8 +19,9 @@
 
 #include "geometry/tree4d.hpp"
 
+#include "std/unique_ptr.hpp"
+
 #include <functional>
-#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -103,7 +104,7 @@ private:
                                    RouterDelegate const & delegate, IndexGraphStarter & starter,
                                    Route & route) const;
 
-  bool AreMwmsNear(std::set<NumMwmId> mwmIds) const;
+  bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
 
   VehicleType m_vehicleType;
   bool m_loadAltitudes;

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -90,6 +90,7 @@ HEADERS += \
     cross_routing_context.hpp \
     directions_engine.hpp \
     edge_estimator.hpp \
+    fake_edges_container.hpp \
     features_road_graph.hpp \
     geometry.hpp \
     index_graph.hpp \

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -124,9 +124,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
   TEST(!GetTrafficStash()->Has(kTestNumMwmId), ());
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -140,9 +143,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};  
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -156,9 +162,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -172,9 +181,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -194,9 +206,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -208,9 +223,12 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   TEST(!GetTrafficStash()->Has(kTestNumMwmId), ());
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  IndexGraphStarter::FakeVertex const start(kTestNumMwmId, 9, 0, m2::PointD(2.0, -1.0));
-  IndexGraphStarter::FakeVertex const finish(kTestNumMwmId, 6, 0, m2::PointD(3.0, 3.0));
-  IndexGraphStarter starter(start, finish, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const noTrafficGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   {
     TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, noTrafficGeom);

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -71,9 +71,12 @@ unique_ptr<WorldGraph> BuildXYGraph()
 UNIT_TEST(XYGraph)
 {
   unique_ptr<WorldGraph> graph = BuildXYGraph();
-  IndexGraphStarter starter(
-      IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */, *graph);
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *graph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *graph);
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -88,8 +91,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -103,8 +108,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -120,8 +127,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -137,8 +146,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -154,8 +165,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
 
   TestRestrictions(
       {} /* expectedGeom */, AStarAlgorithm<IndexGraphStarter>::Result::NoPath,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(2, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -230,8 +243,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 9, 0, m2::PointD(2, -1)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(3, 3)),  /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                                 m2::PointD(2, -1), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -247,8 +262,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 9, 0, m2::PointD(2, -1)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(3, 3)),  /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                                 m2::PointD(2, -1), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -263,8 +280,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 9, 0, m2::PointD(2, -1)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(3, 3)),  /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                                 m2::PointD(2, -1), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -283,8 +302,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 9, 0, m2::PointD(2, -1)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(3, 3)),  /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                                 m2::PointD(2, -1), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 }  // namespace

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -91,10 +91,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(2, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                        m2::PointD(2, 0), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                        m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -108,10 +108,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(2, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                        m2::PointD(2, 0), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                        m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -127,10 +127,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(2, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                        m2::PointD(2, 0), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                        m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -146,10 +146,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(2, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                        m2::PointD(2, 0), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                        m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -165,10 +165,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
 
   TestRestrictions(
       {} /* expectedGeom */, AStarAlgorithm<IndexGraphStarter>::Result::NoPath,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(2, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                        m2::PointD(2, 0), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                        m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -243,10 +243,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                                 m2::PointD(2, -1), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(3, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                        m2::PointD(2, -1), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                        m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -262,10 +262,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                                 m2::PointD(2, -1), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(3, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                        m2::PointD(2, -1), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                        m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -280,10 +280,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                                 m2::PointD(2, -1), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(3, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                        m2::PointD(2, -1), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                        m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -302,10 +302,10 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                                 m2::PointD(2, -1), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(3, 3), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                        m2::PointD(2, -1), *m_graph),
+      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                        m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 }  // namespace

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -52,11 +52,8 @@ void TestRoute(IndexGraphStarter::FakeEnding const & start,
   for (auto const & s : route)
   {
     auto real = s;
-    if (IndexGraphStarter::IsFakeSegment(real))
-    {
-      if (!starter.ConvertToReal(real))
-        continue;
-    }
+    if (!starter.ConvertToReal(real))
+      continue;
     noFakeRoute.push_back(real);
   }
 
@@ -211,24 +208,24 @@ UNIT_TEST(FindPathCross)
     for (auto const & finish : endPoints)
     {
       uint32_t expectedLength = 0;
-      if (start.m_projectionSegments[0].GetFeatureId() ==
-          finish.m_projectionSegments[0].GetFeatureId())
+      if (start.m_projections[0].m_segment.GetFeatureId() ==
+          finish.m_projections[0].m_segment.GetFeatureId())
       {
-        expectedLength = AbsDelta(start.m_projectionSegments[0].GetSegmentIdx(),
-                                  finish.m_projectionSegments[0].GetSegmentIdx()) +
+        expectedLength = AbsDelta(start.m_projections[0].m_segment.GetSegmentIdx(),
+                                  finish.m_projections[0].m_segment.GetSegmentIdx()) +
                          1;
       }
       else
       {
-        if (start.m_projectionSegments[0].GetSegmentIdx() < 2)
-          expectedLength += 2 - start.m_projectionSegments[0].GetSegmentIdx();
+        if (start.m_projections[0].m_segment.GetSegmentIdx() < 2)
+          expectedLength += 2 - start.m_projections[0].m_segment.GetSegmentIdx();
         else
-          expectedLength += start.m_projectionSegments[0].GetSegmentIdx() - 1;
+          expectedLength += start.m_projections[0].m_segment.GetSegmentIdx() - 1;
 
-        if (finish.m_projectionSegments[0].GetSegmentIdx() < 2)
-          expectedLength += 2 - finish.m_projectionSegments[0].GetSegmentIdx();
+        if (finish.m_projections[0].m_segment.GetSegmentIdx() < 2)
+          expectedLength += 2 - finish.m_projections[0].m_segment.GetSegmentIdx();
         else
-          expectedLength += finish.m_projectionSegments[0].GetSegmentIdx() - 1;
+          expectedLength += finish.m_projections[0].m_segment.GetSegmentIdx() - 1;
       }
       TestRoute(start, finish, expectedLength, nullptr, *worldGraph);
     }
@@ -295,36 +292,46 @@ UNIT_TEST(FindPathManhattan)
       uint32_t expectedLength = 0;
 
       auto const startFeatureOffset =
-          start.m_projectionSegments[0].GetFeatureId() < kCitySize
-              ? start.m_projectionSegments[0].GetFeatureId()
-              : start.m_projectionSegments[0].GetFeatureId() - kCitySize;
+          start.m_projections[0].m_segment.GetFeatureId() < kCitySize
+              ? start.m_projections[0].m_segment.GetFeatureId()
+              : start.m_projections[0].m_segment.GetFeatureId() - kCitySize;
       auto const finishFeatureOffset =
-          finish.m_projectionSegments[0].GetFeatureId() < kCitySize
-              ? finish.m_projectionSegments[0].GetFeatureId()
-              : finish.m_projectionSegments[0].GetFeatureId() - kCitySize;
+          finish.m_projections[0].m_segment.GetFeatureId() < kCitySize
+              ? finish.m_projections[0].m_segment.GetFeatureId()
+              : finish.m_projections[0].m_segment.GetFeatureId() - kCitySize;
 
-      if (start.m_projectionSegments[0].GetFeatureId() < kCitySize ==
-          finish.m_projectionSegments[0].GetFeatureId() < kCitySize)
+      if (start.m_projections[0].m_segment.GetFeatureId() < kCitySize ==
+          finish.m_projections[0].m_segment.GetFeatureId() < kCitySize)
       {
-        uint32_t segDelta = AbsDelta(start.m_projectionSegments[0].GetSegmentIdx(),
-                                     finish.m_projectionSegments[0].GetSegmentIdx());
-        if (segDelta == 0 && start.m_projectionSegments[0].GetFeatureId() !=
-                                 finish.m_projectionSegments[0].GetFeatureId())
+        uint32_t segDelta = AbsDelta(start.m_projections[0].m_segment.GetSegmentIdx(),
+                                     finish.m_projections[0].m_segment.GetSegmentIdx());
+        if (segDelta == 0 && start.m_projections[0].m_segment.GetFeatureId() !=
+                                 finish.m_projections[0].m_segment.GetFeatureId())
           segDelta = 1;
         expectedLength += segDelta;
         expectedLength += AbsDelta(startFeatureOffset, finishFeatureOffset) + 1;
       }
       else
       {
-        if (start.m_projectionSegments[0].GetSegmentIdx() < finishFeatureOffset)
-          expectedLength += finishFeatureOffset - start.m_projectionSegments[0].GetSegmentIdx();
+        if (start.m_projections[0].m_segment.GetSegmentIdx() < finishFeatureOffset)
+        {
+          expectedLength += finishFeatureOffset - start.m_projections[0].m_segment.GetSegmentIdx();
+        }
         else
-          expectedLength += start.m_projectionSegments[0].GetSegmentIdx() - finishFeatureOffset + 1;
+        {
+          expectedLength +=
+              start.m_projections[0].m_segment.GetSegmentIdx() - finishFeatureOffset + 1;
+        }
 
-        if (finish.m_projectionSegments[0].GetSegmentIdx() < startFeatureOffset)
-          expectedLength += startFeatureOffset - finish.m_projectionSegments[0].GetSegmentIdx();
+        if (finish.m_projections[0].m_segment.GetSegmentIdx() < startFeatureOffset)
+        {
+          expectedLength += startFeatureOffset - finish.m_projections[0].m_segment.GetSegmentIdx();
+        }
         else
-          expectedLength += finish.m_projectionSegments[0].GetSegmentIdx() - startFeatureOffset + 1;
+        {
+          expectedLength +=
+              finish.m_projections[0].m_segment.GetSegmentIdx() - startFeatureOffset + 1;
+        }
       }
 
       TestRoute(start, finish, expectedLength, nullptr, *worldGraph);
@@ -373,7 +380,7 @@ UNIT_TEST(RoadSpeed)
                                        {kTestNumMwmId, 0, 2, true},
                                        {kTestNumMwmId, 0, 3, true},
                                        {kTestNumMwmId, 1, 3, true}});
-  TestRoute(start, finish, 6, &expectedRoute, *worldGraph);
+  TestRoute(start, finish, expectedRoute.size(), &expectedRoute, *worldGraph);
 }
 
 // Roads                             y:
@@ -402,7 +409,40 @@ UNIT_TEST(OneSegmentWay)
 
   vector<Segment> const expectedRoute(
       {{kTestNumMwmId, 0 /* featureId */, 0 /* seg id */, true /* forward */}});
-  TestRoute(start, finish, 1 /* expectedLength */, &expectedRoute, *worldGraph);
+  TestRoute(start, finish, expectedRoute.size(), &expectedRoute, *worldGraph);
+}
+
+//
+// Roads                             y:
+//
+//    R0    * - - - - - - - ->*      0
+//                ^     ^
+//            finish  start
+//
+//    x:    0     1     2     3
+//
+UNIT_TEST(OneSegmentWayBackward)
+{
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+
+  loader->AddRoad(0 /* featureId */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {3.0, 0.0}}));
+
+  traffic::TrafficCache const trafficCache;
+  shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
+  unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(move(loader), estimator, vector<Joint>());
+
+  auto const start = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *worldGraph);
+  auto const finish = IndexGraphStarter::MakeFakeEnding(
+      Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(1, 0), *worldGraph);
+
+  IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
+                            *worldGraph);
+  vector<Segment> route;
+  double timeSec;
+  auto const resultCode = CalculateRoute(starter, route, timeSec);
+  TEST_EQUAL(resultCode, AStarAlgorithm<IndexGraphStarter>::Result::NoPath, ());
 }
 
 //
@@ -541,7 +581,7 @@ UNIT_CLASS_TEST(RestrictionTest, LoopGraph)
                                          {kTestNumMwmId, 0, 7, false}, {kTestNumMwmId, 0, 6, false},
                                          {kTestNumMwmId, 2, 0, true}};
 
-  TestRoute(start, finish, 7, &expectedRoute, *m_graph);
+  TestRoute(start, finish, expectedRoute.size(), &expectedRoute, *m_graph);
 }
 
 UNIT_TEST(IndexGraph_OnlyTopology_1)

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -141,11 +141,9 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
   for (size_t i = 1; i + 1 < routeSegs.size(); ++i)
   {
     auto seg = routeSegs[i];
-    if (IndexGraphStarter::IsFakeSegment(seg))
-    {
-      if (!starter.ConvertToReal(seg))
-        continue;
-    }
+    if (!starter.ConvertToReal(seg))
+      continue;
+
     auto const it = builder.m_segmentToEdge.find(seg);
     CHECK(it != builder.m_segmentToEdge.cend(), ());
     auto const & edge = it->second;

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -39,10 +39,11 @@ struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }
   void Init(unique_ptr<WorldGraph> graph) { m_graph = move(graph); }
-  void SetStarter(IndexGraphStarter::FakeVertex const & start,
-                  IndexGraphStarter::FakeVertex const & finish)
+  void SetStarter(IndexGraphStarter::FakeEnding const & start,
+                  IndexGraphStarter::FakeEnding const & finish)
   {
-    m_starter = make_unique<IndexGraphStarter>(start, finish, *m_graph);
+    m_starter = make_unique<IndexGraphStarter>(start, finish, 0 /* fakeNumerationStart */,
+                                               false /* strictForward */, *m_graph);
   }
 
   void SetRestrictions(RestrictionVec && restrictions)
@@ -199,8 +200,8 @@ void TestRouteGeometry(
 /// \note restrictionTest should have a valid |restrictionTest.m_graph|.
 void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,
                       AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
-                      routing::IndexGraphStarter::FakeVertex const & start,
-                      routing::IndexGraphStarter::FakeVertex const & finish,
+                      routing::IndexGraphStarter::FakeEnding const & start,
+                      routing::IndexGraphStarter::FakeEnding const & finish,
                       RestrictionVec && restrictions, RestrictionTest & restrictionTest);
 
 // Tries to find a unique path from |from| to |to| in |graph|.

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -807,7 +807,7 @@ unique_ptr<WorldGraph> BuildLineGraph()
   loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
                   RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}}));
   loader->AddRoad(1 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {3.0, 0.0}}));
+                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}}));
   loader->AddRoad(2 /* feature id */, true /* one way */, 1.0 /* speed */,
                   RoadGeometry::Points({{4.0, 0.0}, {5.0, 0.0}}));
 

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -64,9 +64,10 @@ unique_ptr<WorldGraph> BuildCrossGraph()
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 {
   Init(BuildCrossGraph());
-  SetStarter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(-1, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 7, 0, m2::PointD(1, 2)) /* finish */);
+  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
+                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
+             routing::IndexGraphStarter::MakeFakeEnding(
+                 Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
 
   vector<m2::PointD> const expectedGeom = {
       {-1.0 /* x */, 0.0 /* y */}, {0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}};
@@ -76,9 +77,10 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
 {
   Init(BuildCrossGraph());
-  SetStarter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(-1, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 7, 0, m2::PointD(1, 2)) /* finish */);
+  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
+                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
+             routing::IndexGraphStarter::MakeFakeEnding(
+                 Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
 
   RestrictionVec restrictions = {
       {Restriction::Type::No, {1 /* feature from */, 6 /* feature to */}}};
@@ -87,8 +89,10 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(-1, 0)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 7, 0, m2::PointD(1, 2)),  /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(-1, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 7, 0, true /* forward */),
+                                                 m2::PointD(1, 2), *m_graph),
       move(restrictions), *this);
 }
 
@@ -148,8 +152,10 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -164,8 +170,10 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF2F1)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -179,8 +187,10 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -197,8 +207,10 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionOnlyF5F3)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -213,8 +225,10 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2RestrictionOnl
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -268,8 +282,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 3, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -283,8 +299,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F2No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 3, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -301,8 +319,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F1Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 3, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 4, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -377,8 +397,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 10, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 11, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -396,8 +418,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 10, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 11, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -416,8 +440,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3OnlyF3F4Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 10, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 11, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -436,8 +462,10 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF2F8NoRestrictionF9F
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 10, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 11, 0, m2::PointD(0, 3)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
+                                                 m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -491,9 +519,11 @@ UNIT_TEST(FlagGraph)
 {
   unique_ptr<WorldGraph> graph = BuildFlagGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(0.5, 1)) /* finish */,
-      *graph);
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(0.5, 1), *graph),
+      0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {0.5, 1}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -509,8 +539,10 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(0.5, 1)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(0.5, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -524,8 +556,10 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F1Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(0.5, 1)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(0.5, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -541,8 +575,10 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(0.5, 1)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(0.5, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -592,9 +628,11 @@ UNIT_TEST(PosterGraph)
 {
   unique_ptr<WorldGraph> graph = BuildPosterGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(2, 1)) /* finish */,
-      *graph);
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(2, 1), *graph),
+      0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {2, 1}};
 
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
@@ -611,8 +649,10 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(2, 1)), /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(2, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -631,8 +671,10 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F1Only)
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(2, 0)), /* start */
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 6, 0, m2::PointD(2, 1)), /* finish */
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(2, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                                 m2::PointD(2, 1), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -674,9 +716,11 @@ UNIT_TEST(TwoWayGraph)
 {
   unique_ptr<WorldGraph> graph = BuildTwoWayGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 3, 0, m2::PointD(-1, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 2, 0, m2::PointD(4, 0)) /* finish */,
-      *graph);
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
+                                                 m2::PointD(-1, 0), *graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */),
+                                                 m2::PointD(4, 0), *graph),
+      0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{-1 /* x */, 0 /* y */}, {0, 0}, {1, 0}, {3, 0}, {4, 0}};
 
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
@@ -725,9 +769,11 @@ UNIT_TEST(SquaresGraph)
 {
   unique_ptr<WorldGraph> graph = BuildSquaresGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(0, 0)) /* finish */,
-      *graph);
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(0, 0), *graph),
+      0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
@@ -745,8 +791,10 @@ UNIT_CLASS_TEST(RestrictionTest, SquaresGraph_RestrictionF0F1OnlyF1F5Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0, 0, m2::PointD(3, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 5, 0, m2::PointD(0, 0)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                                 m2::PointD(3, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
+                                                 m2::PointD(0, 0), *m_graph),
       move(restrictions), *this);
 }
 
@@ -788,9 +836,11 @@ UNIT_CLASS_TEST(RestrictionTest, LineGraph_RestrictionF1F1No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */,
-                                             m2::PointD(0, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 2, 0, m2::PointD(5, 0)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(
+          Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
+          m2::PointD(0, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */),
+                                                 m2::PointD(5, 0), *m_graph),
       move(restrictions), *this);
 }
 
@@ -839,9 +889,11 @@ UNIT_CLASS_TEST(RestrictionTest, FGraph_RestrictionF0F2Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */,
-                                             m2::PointD(0, 0)) /* start */,
-      routing::IndexGraphStarter::FakeVertex(kTestNumMwmId, 1, 0, m2::PointD(1, 1)) /* finish */,
+      routing::IndexGraphStarter::MakeFakeEnding(
+          Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
+          m2::PointD(0, 0), *m_graph),
+      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                                 m2::PointD(1, 1), *m_graph),
       move(restrictions), *this);
 }
 }  // namespace routing_test

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -108,12 +108,13 @@ UNIT_TEST(RoadAccess_BarrierBypassing)
   vector<TestEdge> expectedEdges;
 
   expectedWeight = 3.0;
-  expectedEdges = {{0, 1}, {1, 2}, {2, 5}};
+  // First and last edges are projectios
+  expectedEdges = {{0, 0}, {0, 1}, {1, 2}, {2, 5}, {5, 5}};
   TestTopologyGraph(graph, 0, 5, true /* pathFound */, expectedWeight, expectedEdges);
 
   graph.BlockEdge(1, 2);
   expectedWeight = 4.0;
-  expectedEdges = {{0, 3}, {3, 4}, {4, 5}};
+  expectedEdges = {{0, 0}, {0, 3}, {3, 4}, {4, 5}, {5, 5}};
   TestTopologyGraph(graph, 0, 5, true /* pathFound */, expectedWeight, expectedEdges);
 
   graph.BlockEdge(3, 4);

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
+		40C227FE1F61C07C0046696C /* fake_edges_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C227FD1F61C07C0046696C /* fake_edges_container.hpp */; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
@@ -340,6 +341,7 @@
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
+		40C227FD1F61C07C0046696C /* fake_edges_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_edges_container.hpp; sourceTree = "<group>"; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 				56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */,
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
+				40C227FD1F61C07C0046696C /* fake_edges_container.hpp */,
 				674F9BBC1B0A580E00704FFA /* features_road_graph.cpp */,
 				674F9BBD1B0A580E00704FFA /* features_road_graph.hpp */,
 				0C5FEC561DDE192A0017688C /* geometry.cpp */,
@@ -991,6 +994,7 @@
 				0C090C881E4E276700D52AFD /* world_graph.hpp in Headers */,
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
 				5694CECD1EBA25F7004576D3 /* road_access.hpp in Headers */,
+				40C227FE1F61C07C0046696C /* fake_edges_container.hpp in Headers */,
 				670D049F1B0B4A970013A7AC /* nearest_edge_finder.hpp in Headers */,
 				A120B34F1B4A7C0A002F3808 /* online_absent_fetcher.hpp in Headers */,
 				0C62BFE61E8ADC3100055A79 /* coding.hpp in Headers */,


### PR DESCRIPTION
Добавила в IndexGraphStarter структуры для хранения фейковых графов. В данный момент хранятся только фейковые старт/финиш, фейковые ребра от старта/финиша до ближайшего сегмента и фейковые куски реальных сегментов, но структуры позволяют в дальнейшем добавить туда проекции на несколько реальных сегментов (и использовать это в A* для поиска лучшего пути), а также более сложные конфигурации дуг для обхода препятствий.

Поскольку необходимо уметь собирать саброуты в единый маршрут, в котором будет информация обо всех фейковых дугах из саброутов, у IndexGraphStarter есть конструктор, принимающий на вход vector<IndexGraphStarter> и объединяющий их.

Также необходимо сохранять информацию о фейковых дугах (в том числе, достроенных для промежуточных точек) для последюущего использования в AdjustRoute, для этого сделан класс FakeEdgesContainer с перемещающим конструктором, принимающим IndexGraphStarter.