### PR TITLE
[routing] Routing integration tests and ignoring direction at pedestrian routing

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -299,7 +299,9 @@ IndexRouter::IndexRouter(VehicleType vehicleType, CountryParentNameGetterFn cons
   , m_numMwmTree(move(numMwmTree))
   , m_trafficStash(CreateTrafficStash(m_vehicleType, m_numMwmIds, trafficCache))
   , m_indexManager(countryFileFn, m_index)
-  , m_roadGraph(m_index, IRoadGraph::Mode::ObeyOnewayTag, m_vehicleModelFactory)
+  , m_roadGraph(m_index, vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
+                                                                : IRoadGraph::Mode::ObeyOnewayTag,
+                m_vehicleModelFactory)
   , m_estimator(EdgeEstimator::Create(m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_index))
 {

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -222,9 +222,15 @@ ProgressRange CalcProgressRange(Checkpoints const & checkpoints, size_t subroute
       finishDistance += distance;
   }
 
-  CHECK_GREATER(fullDistance, 0.0, ());
-  return {static_cast<float>(startDistance / fullDistance * 100.0),
-          static_cast<float>(finishDistance / fullDistance * 100.0)};
+  if (fullDistance == 0.0)
+  {
+    return {0.0, 0.0};
+  }
+  else
+  {
+    return {static_cast<float>(startDistance / fullDistance * 100.0),
+            static_cast<float>(finishDistance / fullDistance * 100.0)};
+  }
 }
 
 void PushPassedSubroutes(Checkpoints const & checkpoints, vector<Route::SubrouteAttrs> & subroutes)

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -291,7 +291,8 @@ double IndexRouter::BestEdgeComparator::GetSquaredDist(Edge const & edge) const
 }
 
 // IndexRouter ------------------------------------------------------------------------------------
-IndexRouter::IndexRouter(VehicleType vehicleType, CountryParentNameGetterFn const & countryParentNameGetterFn,
+IndexRouter::IndexRouter(VehicleType vehicleType,
+                         CountryParentNameGetterFn const & countryParentNameGetterFn,
                          TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
                          shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
                          traffic::TrafficCache const & trafficCache, Index & index)
@@ -305,10 +306,12 @@ IndexRouter::IndexRouter(VehicleType vehicleType, CountryParentNameGetterFn cons
   , m_numMwmTree(move(numMwmTree))
   , m_trafficStash(CreateTrafficStash(m_vehicleType, m_numMwmIds, trafficCache))
   , m_indexManager(countryFileFn, m_index)
-  , m_roadGraph(m_index, vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
-                                                                : IRoadGraph::Mode::ObeyOnewayTag,
+  , m_roadGraph(m_index,
+                vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
+                                                       : IRoadGraph::Mode::ObeyOnewayTag,
                 m_vehicleModelFactory)
-  , m_estimator(EdgeEstimator::Create(m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
+  , m_estimator(EdgeEstimator::Create(
+        m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_index))
 {
   CHECK(!m_name.empty(), ());

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -223,14 +223,10 @@ ProgressRange CalcProgressRange(Checkpoints const & checkpoints, size_t subroute
   }
 
   if (fullDistance == 0.0)
-  {
-    return {0.0, 0.0};
-  }
-  else
-  {
-    return {static_cast<float>(startDistance / fullDistance * 100.0),
-            static_cast<float>(finishDistance / fullDistance * 100.0)};
-  }
+    return {100.0, 100.0};
+
+  return {static_cast<float>(startDistance / fullDistance * 100.0),
+          static_cast<float>(finishDistance / fullDistance * 100.0)};
 }
 
 void PushPassedSubroutes(Checkpoints const & checkpoints, vector<Route::SubrouteAttrs> & subroutes)

--- a/routing/routing_consistency_tests/routing_consistency_tests.cpp
+++ b/routing/routing_consistency_tests/routing_consistency_tests.cpp
@@ -83,7 +83,7 @@ public:
 
   bool BuildRoute(UserRoutingRecord const & record)
   {
-    m_components.GetRouter()->ClearState();
+    m_components.GetRouter().ClearState();
     auto const result = integration::CalculateRoute(m_components, record.start, m2::PointD::Zero(), record.stop);
     if (result.second != IRouter::NoError)
     {

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -26,8 +26,8 @@ UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 UNIT_TEST(RussiaDomodedovoSteps)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.44020, 37.77409), {0., 0.},
-      MercatorBounds::FromLatLon(55.43972, 37.77254), 123.0);
+      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
+      MercatorBounds::FromLatLon(55.43975, 37.77272), 123.0);
 }
 
 UNIT_TEST(SwedenStockholmCyclewayPriority)

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -20,21 +20,24 @@ UNIT_TEST(RussiaMoscowSevTushinoParkPreferingBicycleWay)
 UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
       MercatorBounds::FromLatLon(55.67695, 37.56220), 5670.0);
 }
 
 UNIT_TEST(RussiaDomodedovoSteps)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
       MercatorBounds::FromLatLon(55.43975, 37.77272), 123.0);
 }
 
 UNIT_TEST(SwedenStockholmCyclewayPriority)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(59.33151, 18.09347), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(59.33151, 18.09347), {0., 0.},
       MercatorBounds::FromLatLon(59.33052, 18.09391), 113.0);
 }
 
@@ -43,15 +46,17 @@ UNIT_TEST(SwedenStockholmCyclewayPriority)
 UNIT_TEST(NetherlandsAmsterdamBicycleNo)
 {
   integration::CalculateRouteAndTestRouteLength(
-    integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
-    MercatorBounds::FromLatLon(52.32587, 5.06121), 363.4);
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
+      MercatorBounds::FromLatLon(52.32587, 5.06121), 363.4);
 }
 
 UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.32872, 5.07527),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(52.33853, 5.08941));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(52.32872, 5.07527), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(52.33853, 5.08941));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -62,20 +67,23 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
       MercatorBounds::FromLatLon(52.37462, 4.88983), 519.0);
 }
 
 UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
 }
 
 UNIT_TEST(RussiaKerchStraitFerryRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
       MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
 }

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -6,37 +6,38 @@
 
 #include "base/math.hpp"
 
+using namespace integration;
 using namespace routing;
 using namespace routing::turns;
 
 UNIT_TEST(RussiaMoscowSevTushinoParkPreferingBicycleWay)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
       MercatorBounds::FromLatLon(55.87203, 37.44274), 460.0);
 }
 
 UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
       MercatorBounds::FromLatLon(55.67695, 37.56220), 5670.0);
 }
 
 UNIT_TEST(RussiaDomodedovoSteps)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
       MercatorBounds::FromLatLon(55.43975, 37.77272), 123.0);
 }
 
 UNIT_TEST(SwedenStockholmCyclewayPriority)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(59.33151, 18.09347), {0., 0.},
       MercatorBounds::FromLatLon(59.33052, 18.09391), 113.0);
 }
@@ -45,8 +46,8 @@ UNIT_TEST(SwedenStockholmCyclewayPriority)
 // it's allowed to ride bicycle will be found.
 UNIT_TEST(NetherlandsAmsterdamBicycleNo)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
       MercatorBounds::FromLatLon(52.32587, 5.06121), 363.4);
 }
@@ -54,7 +55,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleNo)
 UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 {
   TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      CalculateRoute(GetVehicleComponents<VehicleType::Bicycle>(),
                                   MercatorBounds::FromLatLon(52.32872, 5.07527), {0.0, 0.0},
                                   MercatorBounds::FromLatLon(52.33853, 5.08941));
 
@@ -66,24 +67,24 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 
 UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
       MercatorBounds::FromLatLon(52.37462, 4.88983), 519.0);
 }
 
 UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
 }
 
 UNIT_TEST(RussiaKerchStraitFerryRoute)
 {
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
       MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
 }

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -12,28 +12,29 @@ using namespace routing::turns;
 UNIT_TEST(RussiaMoscowSevTushinoParkPreferingBicycleWay)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(55.87445, 37.43711), {0., 0.},
       MercatorBounds::FromLatLon(55.87203, 37.44274), 460.0);
 }
 
 UNIT_TEST(RussiaMoscowNahimovskyLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.66151, 37.63320), {0., 0.},
       MercatorBounds::FromLatLon(55.67695, 37.56220), 5670.0);
 }
 
 UNIT_TEST(RussiaDomodedovoSteps)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
       MercatorBounds::FromLatLon(55.43975, 37.77272), 123.0);
 }
 
 UNIT_TEST(SwedenStockholmCyclewayPriority)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(59.33151, 18.09347), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(59.33151, 18.09347), {0., 0.},
       MercatorBounds::FromLatLon(59.33052, 18.09391), 113.0);
 }
 
@@ -42,14 +43,14 @@ UNIT_TEST(SwedenStockholmCyclewayPriority)
 UNIT_TEST(NetherlandsAmsterdamBicycleNo)
 {
   integration::CalculateRouteAndTestRouteLength(
-    integration::GetBicycleComponents(), MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
+    integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.32716, 5.05932), {0., 0.},
     MercatorBounds::FromLatLon(52.32587, 5.06121), 363.4);
 }
 
 UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(52.32872, 5.07527),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.32872, 5.07527),
       {0.0, 0.0}, MercatorBounds::FromLatLon(52.33853, 5.08941));
 
   Route const & route = *routeResult.first;
@@ -61,20 +62,20 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
 UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
       MercatorBounds::FromLatLon(52.37462, 4.88983), 519.0);
 }
 
 UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
 }
 
 UNIT_TEST(RussiaKerchStraitFerryRoute)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
       MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -60,7 +60,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
       integration::CalculateRoute(integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
 
   IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::IRouter::RouteNotFound, ());
+  TEST_EQUAL(result, IRouter::IRouter::NoError, ());
 }
 
 UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -9,9 +9,10 @@ using namespace routing::turns;
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87467, 37.43658),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(55.8719, 37.4464));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(55.87467, 37.43658), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.8719, 37.4464));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -24,9 +25,10 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 
 UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.85630, 37.41004),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(55.85717, 37.41052));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(55.85630, 37.41004), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.85717, 37.41052));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -40,9 +42,10 @@ UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
 
 UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.85159, 37.38903),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(55.85157, 37.38813));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(55.85159, 37.38903), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.85157, 37.38813));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -56,8 +59,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
-  TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(), point, {0.0, 0.0}, point);
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), point, {0.0, 0.0}, point);
 
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::IRouter::NoError, ());
@@ -65,9 +68,10 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 
 UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87012, 37.44028),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(55.87153, 37.43928));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(55.87012, 37.44028), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.87153, 37.43928));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -85,9 +89,10 @@ UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
 
 UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87277, 37.44002),
-      {0.0, 0.0}, MercatorBounds::FromLatLon(55.87362, 37.43853));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                  MercatorBounds::FromLatLon(55.87277, 37.44002), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.87362, 37.43853));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -10,7 +10,7 @@ using namespace routing::turns;
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87467, 37.43658),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87467, 37.43658),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.8719, 37.4464));
 
   Route const & route = *routeResult.first;
@@ -25,7 +25,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
 UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.85630, 37.41004),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.85630, 37.41004),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.85717, 37.41052));
 
   Route const & route = *routeResult.first;
@@ -41,7 +41,7 @@ UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
 UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.85159, 37.38903),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.85159, 37.38903),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.85157, 37.38813));
 
   Route const & route = *routeResult.first;
@@ -57,7 +57,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
   TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetBicycleComponents(), point, {0.0, 0.0}, point);
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(), point, {0.0, 0.0}, point);
 
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::IRouter::NoError, ());
@@ -66,7 +66,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87012, 37.44028),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87012, 37.44028),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.87153, 37.43928));
 
   Route const & route = *routeResult.first;
@@ -86,7 +86,7 @@ UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
 UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetBicycleComponents(), MercatorBounds::FromLatLon(55.87277, 37.44002),
+      integration::GetVehicleComponents<VehicleType::Bicycle>(), MercatorBounds::FromLatLon(55.87277, 37.44002),
       {0.0, 0.0}, MercatorBounds::FromLatLon(55.87362, 37.43853));
 
   Route const & route = *routeResult.first;

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -29,6 +29,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId, TAltitude const alti
 {
   Index index;
   platform::LocalCountryFile const country = platform::LocalCountryFile::MakeForTesting(countryId);
+  TEST_NOT_EQUAL(country.GetFiles(), MapOptions::Nothing, (country));
   pair<MwmSet::MwmId, MwmSet::RegResult> const regResult = index.RegisterMap(country);
 
   TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());

--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -7,7 +7,7 @@ namespace
 // Separately tests only fetcher. Other tests will test both fetcher and raw code.
 UNIT_TEST(OnlineCrossFetcherSmokeTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineFetcher({61.76, 34.45}, {45.07, 38.94},
                     {"Russia_Republic of Karelia_South", "Russia_Leningradskaya Oblast_Southeast",
                      "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast_West",
@@ -19,7 +19,7 @@ UNIT_TEST(OnlineCrossFetcherSmokeTest)
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({61.76, 34.45}, {45.07, 38.94},
                     {"Russia_Republic of Karelia_South", "Russia_Leningradskaya Oblast_Southeast",
                      "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast_East",
@@ -31,13 +31,13 @@ UNIT_TEST(OnlineRussiaNorthToSouthTest)
 
 UNIT_TEST(OnlineRoadToSeaCenterTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({61.76, 34.45}, {42.25,30.10}, {}, routerComponents);
 }
 
 UNIT_TEST(OnlineEuropeTestNurnbergToMoscow)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses(
       {49.45, 11.082}, {55.74, 37.56},
       {"Germany_Free State of Bavaria_Middle Franconia",
@@ -52,7 +52,7 @@ UNIT_TEST(OnlineEuropeTestNurnbergToMoscow)
 
 UNIT_TEST(OnlineAmericanTestOttawaToWashington)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({45.38, -75.69}, {38.91, -77.031},
                     {"Canada_Ontario_Kingston", "US_New York_North", "US_New York_West",
                      "US_Pennsylvania_Scranton", "US_Pennsylvania_Central", "US_Maryland_Baltimore",
@@ -62,14 +62,14 @@ UNIT_TEST(OnlineAmericanTestOttawaToWashington)
 
 UNIT_TEST(OnlineAsiaPhuketToPnompen)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({7.89, 98.30}, {11.56, 104.86}, {"Thailand_South", "Cambodia"},
                     routerComponents);
 }
 
 UNIT_TEST(OnlineAustraliaCanberraToPerth)
 {
-  integration::IRouterComponents & routerComponents = integration::GetCarComponents();
+  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({-33.88, 151.13}, {-31.974, 115.88},
                     {"Australia_New South Wales", "Australia_Victoria", "Australia_South Australia",
                      "Australia_Western Australia", "Australia_Sydney"},

--- a/routing/routing_integration_tests/online_cross_tests.cpp
+++ b/routing/routing_integration_tests/online_cross_tests.cpp
@@ -7,7 +7,8 @@ namespace
 // Separately tests only fetcher. Other tests will test both fetcher and raw code.
 UNIT_TEST(OnlineCrossFetcherSmokeTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineFetcher({61.76, 34.45}, {45.07, 38.94},
                     {"Russia_Republic of Karelia_South", "Russia_Leningradskaya Oblast_Southeast",
                      "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast_West",
@@ -19,7 +20,8 @@ UNIT_TEST(OnlineCrossFetcherSmokeTest)
 
 UNIT_TEST(OnlineRussiaNorthToSouthTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({61.76, 34.45}, {45.07, 38.94},
                     {"Russia_Republic of Karelia_South", "Russia_Leningradskaya Oblast_Southeast",
                      "Russia_Novgorod Oblast", "Russia_Tver Oblast", "Russia_Moscow Oblast_East",
@@ -31,13 +33,15 @@ UNIT_TEST(OnlineRussiaNorthToSouthTest)
 
 UNIT_TEST(OnlineRoadToSeaCenterTest)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({61.76, 34.45}, {42.25,30.10}, {}, routerComponents);
 }
 
 UNIT_TEST(OnlineEuropeTestNurnbergToMoscow)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses(
       {49.45, 11.082}, {55.74, 37.56},
       {"Germany_Free State of Bavaria_Middle Franconia",
@@ -52,7 +56,8 @@ UNIT_TEST(OnlineEuropeTestNurnbergToMoscow)
 
 UNIT_TEST(OnlineAmericanTestOttawaToWashington)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({45.38, -75.69}, {38.91, -77.031},
                     {"Canada_Ontario_Kingston", "US_New York_North", "US_New York_West",
                      "US_Pennsylvania_Scranton", "US_Pennsylvania_Central", "US_Maryland_Baltimore",
@@ -62,14 +67,16 @@ UNIT_TEST(OnlineAmericanTestOttawaToWashington)
 
 UNIT_TEST(OnlineAsiaPhuketToPnompen)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({7.89, 98.30}, {11.56, 104.86}, {"Thailand_South", "Cambodia"},
                     routerComponents);
 }
 
 UNIT_TEST(OnlineAustraliaCanberraToPerth)
 {
-  integration::IRouterComponents & routerComponents = integration::GetVehicleComponents<VehicleType::Car>();
+  integration::IRouterComponents & routerComponents =
+      integration::GetVehicleComponents<VehicleType::Car>();
   TestOnlineCrosses({-33.88, 151.13}, {-31.974, 115.88},
                     {"Australia_New South Wales", "Australia_Victoria", "Australia_South Australia",
                      "Australia_Western Australia", "Australia_Sydney"},

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -390,10 +390,10 @@ UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)
 
 UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.98401, 37.17979), {0., 0.},
-      MercatorBounds::FromLatLon(55.98419, 37.17938));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(55.98401, 37.17979), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.98419, 37.17938));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -410,10 +410,10 @@ UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
 
 UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.80867, 37.50575), {0., 0.},
-      MercatorBounds::FromLatLon(55.80884, 37.50668));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(55.80867, 37.50575), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80884, 37.50668));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -430,10 +430,10 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
 
 UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(53.89302, 27.52792), {0., 0.},
-      MercatorBounds::FromLatLon(53.89262, 27.52838));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(53.89302, 27.52792), {0., 0.},
+                                  MercatorBounds::FromLatLon(53.89262, 27.52838));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -450,10 +450,10 @@ UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
 
 UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.75533, 37.58789), {0., 0.},
-      MercatorBounds::FromLatLon(55.75543, 37.58717));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(55.75533, 37.58789), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75543, 37.58717));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -469,10 +469,10 @@ UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
 
 UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.755, 37.59461), {0., 0.},
-      MercatorBounds::FromLatLon(55.75522, 37.59494));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(55.755, 37.59461), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75522, 37.59494));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -488,10 +488,10 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
 
 UNIT_TEST(RussiaMoscowKhlebnyyLane19LiftGateAndGate)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.75518, 37.59382), {0., 0.},
-      MercatorBounds::FromLatLon(55.7554, 37.59327));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+                                  MercatorBounds::FromLatLon(55.75518, 37.59382), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.7554, 37.59327));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -525,8 +525,8 @@ UNIT_TEST(MoscowChistiePrudiSelectPointsInConnectedGraph)
 UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
-  TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(), point, {0.0, 0.0}, point);
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(), point, {0.0, 0.0}, point);
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -10,7 +10,7 @@ using namespace routing::turns;
 UNIT_TEST(GermanyBremenJunctionToCycleway)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(52.41947, 10.75148), {0., 0.},
       MercatorBounds::FromLatLon(52.41868, 10.75274), 137.);
 }
@@ -18,7 +18,7 @@ UNIT_TEST(GermanyBremenJunctionToCycleway)
 UNIT_TEST(Zgrad424aTo1207)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9963, 37.2036), {0., 0.},
       MercatorBounds::FromLatLon(55.9955, 37.1948), 683.);
 }
@@ -26,7 +26,7 @@ UNIT_TEST(Zgrad424aTo1207)
 UNIT_TEST(Zgrad924aTo418)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9844, 37.1808), {0., 0.},
       MercatorBounds::FromLatLon(55.9999, 37.2021), 2526.);
 }
@@ -34,7 +34,7 @@ UNIT_TEST(Zgrad924aTo418)
 UNIT_TEST(Zgrad924aToFilaretovskyChurch)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9844, 37.1808), {0., 0.},
       MercatorBounds::FromLatLon(55.9915, 37.1808), 1220.);
 }
@@ -42,7 +42,7 @@ UNIT_TEST(Zgrad924aToFilaretovskyChurch)
 UNIT_TEST(Zgrad924aTo1145)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9844, 37.1808), {0., 0.},
       MercatorBounds::FromLatLon(55.9924, 37.1853), 1400.);
 }
@@ -50,7 +50,7 @@ UNIT_TEST(Zgrad924aTo1145)
 UNIT_TEST(MoscowMuzeonToLebedinoeOzeroGorkyPark)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.7348, 37.606), {0., 0.},
       MercatorBounds::FromLatLon(55.724, 37.5956), 1617.);
 }
@@ -62,7 +62,7 @@ UNIT_TEST(Zgrad315parkingToMusicSchoolBus_BadRoute)
   // route goes through a highway-tertiary.
 
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9996, 37.2174), {0., 0.},
       MercatorBounds::FromLatLon(55.9999, 37.2179), 161.);
 }
@@ -71,7 +71,7 @@ UNIT_TEST(Zgrad315parkingToMusicSchoolBus_BadRoute)
 UNIT_TEST(Zgrad924aToKrukovo)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.9844, 37.1808), {0., 0.},
       MercatorBounds::FromLatLon(55.9802, 37.1736), 974.);
 }
@@ -79,7 +79,7 @@ UNIT_TEST(Zgrad924aToKrukovo)
 UNIT_TEST(MoscowMailRuStarbucksToPetrovskoRazumovskyAlley)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.7971, 37.5376), {0., 0.},
       MercatorBounds::FromLatLon(55.7953, 37.5597), 1840.);
 }
@@ -87,7 +87,7 @@ UNIT_TEST(MoscowMailRuStarbucksToPetrovskoRazumovskyAlley)
 UNIT_TEST(AustraliaMelburn_AvoidMotorway)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(-37.7936, 144.985), {0., 0.},
       MercatorBounds::FromLatLon(-37.7896, 145.025), 5015.);
 }
@@ -95,7 +95,7 @@ UNIT_TEST(AustraliaMelburn_AvoidMotorway)
 UNIT_TEST(AustriaWein_AvoidTrunk)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(48.233, 16.3562), {0., 0.},
       MercatorBounds::FromLatLon(48.2458, 16.3704), 2301.);
 }
@@ -103,7 +103,7 @@ UNIT_TEST(AustriaWein_AvoidTrunk)
 UNIT_TEST(FranceParis_AvoidBridleway)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(48.859, 2.25452), {0., 0.},
       MercatorBounds::FromLatLon(48.8634, 2.24315), 1307.);
 }
@@ -111,7 +111,7 @@ UNIT_TEST(FranceParis_AvoidBridleway)
 UNIT_TEST(HungaryBudapest_AvoidMotorway)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.56566, 19.14942), {0., 0.},
       MercatorBounds::FromLatLon(47.593, 19.24018), 10890.);
 }
@@ -119,7 +119,7 @@ UNIT_TEST(HungaryBudapest_AvoidMotorway)
 UNIT_TEST(PolandWarshaw_AvoidCycleway)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(52.2487, 21.0173), {0., 0.},
       MercatorBounds::FromLatLon(52.25, 21.0164), 182.);
 }
@@ -127,7 +127,7 @@ UNIT_TEST(PolandWarshaw_AvoidCycleway)
 UNIT_TEST(SwedenStockholmSlussenHiltonToMaritimeMuseum)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.32046, 18.06924), {0., 0.},
       MercatorBounds::FromLatLon(59.32728, 18.09078), 3442.);
 }
@@ -135,7 +135,7 @@ UNIT_TEST(SwedenStockholmSlussenHiltonToMaritimeMuseum)
 UNIT_TEST(SwedenStockholmSlussenHiltonToAfChapmanHostel)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.32045, 18.06928), {0., 0.},
       MercatorBounds::FromLatLon(59.3254, 18.08022), 2410.);
 }
@@ -143,7 +143,7 @@ UNIT_TEST(SwedenStockholmSlussenHiltonToAfChapmanHostel)
 UNIT_TEST(EstoniaTallinnRadissonHiltonToCatherdalChurch)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.4362, 24.7682), {0., 0.},
       MercatorBounds::FromLatLon(59.437, 24.7392), 2016.);
 }
@@ -151,7 +151,7 @@ UNIT_TEST(EstoniaTallinnRadissonHiltonToCatherdalChurch)
 UNIT_TEST(EstoniaTallinnRadissonHiltonToSkypeOffice)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.4362, 24.7682), {0., 0.},
       MercatorBounds::FromLatLon(59.3971, 24.661), 8673.);
 }
@@ -159,7 +159,7 @@ UNIT_TEST(EstoniaTallinnRadissonHiltonToSkypeOffice)
 UNIT_TEST(BelarusMinksHotelYubileyniToChurchSaintsSimonAndHelen)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.9112, 27.5466), {0., 0.},
       MercatorBounds::FromLatLon(53.8965, 27.5476), 2244.);
 }
@@ -167,7 +167,7 @@ UNIT_TEST(BelarusMinksHotelYubileyniToChurchSaintsSimonAndHelen)
 UNIT_TEST(BelarusMinksBarURatushiToMoscowBusStation)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.9045, 27.5569), {0., 0.},
       MercatorBounds::FromLatLon(53.889, 27.5466), 2499.);
 }
@@ -175,7 +175,7 @@ UNIT_TEST(BelarusMinksBarURatushiToMoscowBusStation)
 UNIT_TEST(BelarusBobruisk50LetVlksmToSanatoryShinnik)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.1638, 29.1804), {0., 0.},
       MercatorBounds::FromLatLon(53.179, 29.1682), 2661.);
 }
@@ -183,7 +183,7 @@ UNIT_TEST(BelarusBobruisk50LetVlksmToSanatoryShinnik)
 UNIT_TEST(BelarusBobruisk50LetVlksmToArena)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.1638, 29.1804), {0., 0.},
       MercatorBounds::FromLatLon(53.1424, 29.2467), 6683.);
 }
@@ -191,7 +191,7 @@ UNIT_TEST(BelarusBobruisk50LetVlksmToArena)
 UNIT_TEST(RussiaTaganrogSyzranov10k3ToSoftech)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2183, 38.8634), {0., 0.},
       MercatorBounds::FromLatLon(47.2, 38.8878), 3868.);
 }
@@ -199,7 +199,7 @@ UNIT_TEST(RussiaTaganrogSyzranov10k3ToSoftech)
 UNIT_TEST(RussiaTaganrogSyzranov10k3ToTruseE)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2183, 38.8634), {0., 0.},
       MercatorBounds::FromLatLon(47.2048, 38.9441), 7463.);
 }
@@ -207,7 +207,7 @@ UNIT_TEST(RussiaTaganrogSyzranov10k3ToTruseE)
 UNIT_TEST(RussiaTaganrogSyzranov10k3ToLazo5k2)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2183, 38.8634), {0., 0.},
       MercatorBounds::FromLatLon(47.2584, 38.9128), 9200.);
 }
@@ -215,7 +215,7 @@ UNIT_TEST(RussiaTaganrogSyzranov10k3ToLazo5k2)
 UNIT_TEST(RussiaTaganrogJukova2ToBolBulvarnaya8)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2768, 38.9282), {0., 0.},
       MercatorBounds::FromLatLon(47.2412, 38.8902), 6239.);
 }
@@ -223,7 +223,7 @@ UNIT_TEST(RussiaTaganrogJukova2ToBolBulvarnaya8)
 UNIT_TEST(RussiaTaganrogCheckhova267k2ToKotlostroy33)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2198, 38.8906), {0., 0.},
       MercatorBounds::FromLatLon(47.2459, 38.8937), 3485.);
 }
@@ -231,7 +231,7 @@ UNIT_TEST(RussiaTaganrogCheckhova267k2ToKotlostroy33)
 UNIT_TEST(RussiaTaganrogCheckhova267k2ToBolBulvarnaya8)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2198, 38.8906), {0., 0.},
       MercatorBounds::FromLatLon(47.2412, 38.8902), 2897.);
 }
@@ -239,7 +239,7 @@ UNIT_TEST(RussiaTaganrogCheckhova267k2ToBolBulvarnaya8)
 UNIT_TEST(RussiaRostovOnDonPrKosmonavtovToDneprovsky120b)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2811, 39.7178), {0., 0.},
       MercatorBounds::FromLatLon(47.2875, 39.759), 4300.);
 }
@@ -247,7 +247,7 @@ UNIT_TEST(RussiaRostovOnDonPrKosmonavtovToDneprovsky120b)
 UNIT_TEST(TurkeyKemerPalmetResortToYachtClub)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(36.6143, 30.5572), {0., 0.},
       MercatorBounds::FromLatLon(36.6004, 30.576), 2992.);
 }
@@ -255,7 +255,7 @@ UNIT_TEST(TurkeyKemerPalmetResortToYachtClub)
 UNIT_TEST(CzechPragueNode5ToHilton)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(50.0653, 14.4031), {0., 0.},
       MercatorBounds::FromLatLon(50.0933, 14.4397), 5106.);
 }
@@ -263,7 +263,7 @@ UNIT_TEST(CzechPragueNode5ToHilton)
 UNIT_TEST(CzechPragueHiltonToKarlovMost)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(50.0933, 14.4397), {0., 0.},
       MercatorBounds::FromLatLon(50.0864, 14.4124), 2398.);
 }
@@ -271,7 +271,7 @@ UNIT_TEST(CzechPragueHiltonToKarlovMost)
 UNIT_TEST(CzechPragueHiltonToNicholasChurch)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(50.0933, 14.4397), {0., 0.},
       MercatorBounds::FromLatLon(50.088, 14.4032), 3103.);
 }
@@ -279,7 +279,7 @@ UNIT_TEST(CzechPragueHiltonToNicholasChurch)
 UNIT_TEST(CzechPragueHiltonToKvetniceViewpoint)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(50.0933, 14.4397), {0., 0.},
       MercatorBounds::FromLatLon(50.0806, 14.3973), 4335.);
 }
@@ -287,7 +287,7 @@ UNIT_TEST(CzechPragueHiltonToKvetniceViewpoint)
 UNIT_TEST(RussiaSaintPetersburgMoyka93ToAlexanderColumn)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.9241, 30.323), {0., 0.},
       MercatorBounds::FromLatLon(59.939, 30.3159), 2454.);
 }
@@ -295,7 +295,7 @@ UNIT_TEST(RussiaSaintPetersburgMoyka93ToAlexanderColumn)
 UNIT_TEST(RussiaSaintPetersburgMoyka93ToMarsovoPole)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.9241, 30.323), {0., 0.},
       MercatorBounds::FromLatLon(59.9436, 30.3318), 2891.);
 }
@@ -303,7 +303,7 @@ UNIT_TEST(RussiaSaintPetersburgMoyka93ToMarsovoPole)
 UNIT_TEST(RussiaSaintPetersburgMoyka93ToAvrora)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.9241, 30.323), {0., 0.},
       MercatorBounds::FromLatLon(59.9554, 30.3378), 4770.);
 }
@@ -311,7 +311,7 @@ UNIT_TEST(RussiaSaintPetersburgMoyka93ToAvrora)
 UNIT_TEST(RussiaSaintPetersburgPetrPaulChurchToDolphins)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.9502, 30.3165), {0., 0.},
       MercatorBounds::FromLatLon(59.973, 30.2702), 4507.);
 }
@@ -319,7 +319,7 @@ UNIT_TEST(RussiaSaintPetersburgPetrPaulChurchToDolphins)
 UNIT_TEST(RussiaPetergofEntranceToErmitagePalace)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.8806, 29.904), {0., 0.},
       MercatorBounds::FromLatLon(59.8889, 29.9034), 1073.);
 }
@@ -327,7 +327,7 @@ UNIT_TEST(RussiaPetergofEntranceToErmitagePalace)
 UNIT_TEST(RussiaPetergofMarlyPalaceToTrainStation)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(59.8887, 29.8963), {0., 0.},
       MercatorBounds::FromLatLon(59.8648, 29.9251), 3885.);
 }
@@ -335,7 +335,7 @@ UNIT_TEST(RussiaPetergofMarlyPalaceToTrainStation)
 UNIT_TEST(RussiaMoscowMailRuToTsarCannon)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.79703, 37.53761), {0., 0.},
       MercatorBounds::FromLatLon(55.75146, 37.61792), 7989.);
 }
@@ -343,7 +343,7 @@ UNIT_TEST(RussiaMoscowMailRuToTsarCannon)
 UNIT_TEST(RussiaMoscowHovrinoStationToKasperskyLab)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.8701, 37.50833), {0., 0.},
       MercatorBounds::FromLatLon(55.83715, 37.48132), 5162.);
 }
@@ -351,7 +351,7 @@ UNIT_TEST(RussiaMoscowHovrinoStationToKasperskyLab)
 UNIT_TEST(ItalyRome_WalkOverStreetWithSidewalkBoth)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(41.9052, 12.4106), {0., 0.},
       MercatorBounds::FromLatLon(41.9226, 12.4216), 2413.);
 }
@@ -359,7 +359,7 @@ UNIT_TEST(ItalyRome_WalkOverStreetWithSidewalkBoth)
 UNIT_TEST(USARedlandsEsriHQToRedlandsCommunity)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(34.0556, -117.19567), {0., 0.},
       MercatorBounds::FromLatLon(34.03682, -117.20649), 3330.);
 }
@@ -367,7 +367,7 @@ UNIT_TEST(USARedlandsEsriHQToRedlandsCommunity)
 UNIT_TEST(USANewYorkEmpireStateBuildingToUnitedNations)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(40.74844, -73.98566), {0., 0.},
       MercatorBounds::FromLatLon(40.75047, -73.96759), 2265.);
 }
@@ -375,7 +375,7 @@ UNIT_TEST(USANewYorkEmpireStateBuildingToUnitedNations)
 UNIT_TEST(CrossMwmEgyptTabaToJordanAqaba)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(29.49271, 34.89571), {0., 0.},
       MercatorBounds::FromLatLon(29.52774, 35.00324), 29016);
 }
@@ -383,7 +383,7 @@ UNIT_TEST(CrossMwmEgyptTabaToJordanAqaba)
 UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.014, 30.95552), {0., 0.},
       MercatorBounds::FromLatLon(55.01437, 30.8858), 4834.5);
 }
@@ -391,7 +391,7 @@ UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)
 UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.98401, 37.17979), {0., 0.},
       MercatorBounds::FromLatLon(55.98419, 37.17938));
 
@@ -411,7 +411,7 @@ UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
 UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.80867, 37.50575), {0., 0.},
       MercatorBounds::FromLatLon(55.80884, 37.50668));
 
@@ -431,7 +431,7 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
 UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.89302, 27.52792), {0., 0.},
       MercatorBounds::FromLatLon(53.89262, 27.52838));
 
@@ -451,7 +451,7 @@ UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
 UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.75533, 37.58789), {0., 0.},
       MercatorBounds::FromLatLon(55.75543, 37.58717));
 
@@ -470,7 +470,7 @@ UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
 UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.755, 37.59461), {0., 0.},
       MercatorBounds::FromLatLon(55.75522, 37.59494));
 
@@ -489,7 +489,7 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
 UNIT_TEST(RussiaMoscowKhlebnyyLane19LiftGateAndGate)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.75518, 37.59382), {0., 0.},
       MercatorBounds::FromLatLon(55.7554, 37.59327));
 
@@ -509,7 +509,7 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane19LiftGateAndGate)
 UNIT_TEST(MoscowVodnyStadiumHighwayPlatform)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.83955, 37.48692), {0., 0.},
       MercatorBounds::FromLatLon(55.84061, 37.48636), 136.115);
 }
@@ -517,7 +517,7 @@ UNIT_TEST(MoscowVodnyStadiumHighwayPlatform)
 UNIT_TEST(MoscowChistiePrudiSelectPointsInConnectedGraph)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.76613, 37.63769), {0., 0.},
       MercatorBounds::FromLatLon(55.76593, 37.63893), 134.02);
 }
@@ -526,7 +526,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
   TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetPedestrianComponents(), point, {0.0, 0.0}, point);
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Pedestrian>(), point, {0.0, 0.0}, point);
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -538,7 +538,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
 UNIT_TEST(MoscowKashirskoe16ToVorobeviGori)
 {
   integration::CalculateRouteAndTestRouteLength(
-      integration::GetPedestrianComponents(),
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.70934, 37.54232), 9553.0);
 }

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -13,24 +13,28 @@ namespace
   UNIT_TEST(StrangeCaseInAfrica)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
         MercatorBounds::FromLatLon(19.17289, 30.47315), 10283.7);
   }
 
   UNIT_TEST(MoscowShortRoadUnpacking)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.66218, 37.63253), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.66218, 37.63253), {0., 0.},
         MercatorBounds::FromLatLon(55.66237, 37.63560), 101.);
   }
 
   UNIT_TEST(MoscowToSVOAirport)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
         MercatorBounds::FromLatLon(55.97310, 37.41460), 30470.);
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
         MercatorBounds::FromLatLon(55.75100, 37.61790), 30470.);
   }
 
@@ -38,14 +42,16 @@ namespace
   UNIT_TEST(RestrictionTestNeatBaumanAndTTK)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
         MercatorBounds::FromLatLon(55.77198, 37.68782), 700.);
   }
 
   UNIT_TEST(RestrictionTestNearMetroShodnenskaya)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85043, 37.43824), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.85043, 37.43824), {0., 0.},
         MercatorBounds::FromLatLon(55.85191, 37.43910), 510.);
   }
 
@@ -53,7 +59,8 @@ namespace
   UNIT_TEST(CaliforniaCupertinoFindPhantomAssertTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(37.33409, -122.03458), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(37.33409, -122.03458), {0., 0.},
         MercatorBounds::FromLatLon(37.33498, -122.03575), 1438.);
   }
 
@@ -61,14 +68,16 @@ namespace
   UNIT_TEST(RussiaUfaToUstKatavTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(54.7304, 55.9554), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(54.7304, 55.9554), {0., 0.},
         MercatorBounds::FromLatLon(54.9228, 58.1469), 164667.);
   }
 
   UNIT_TEST(RussiaMoscow)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
         MercatorBounds::FromLatLon(55.77682, 37.70391), 185.);
   }
 
@@ -76,9 +85,10 @@ namespace
   UNIT_TEST(RussiaFerryToCrimeaLoadCrossGeometryTest)
   {
     // Forward
-    TRouteResult route = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
-        MercatorBounds::FromLatLon(45.36479, 36.62194));
+    TRouteResult route =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
+                                    MercatorBounds::FromLatLon(45.36479, 36.62194));
     TEST_EQUAL(route.second, IRouter::NoError, ());
     TEST_GREATER(route.first->GetPoly().GetSize(), 50, ());
     // And backward case
@@ -92,9 +102,10 @@ namespace
   UNIT_TEST(PriceIslandLoadCrossGeometryTest)
   {
     // Forward
-    TRouteResult route = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
-        MercatorBounds::FromLatLon(46.25401, -63.70213));
+    TRouteResult route =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
+                                    MercatorBounds::FromLatLon(46.25401, -63.70213));
     TEST_EQUAL(route.second, IRouter::NoError, ());
     TEST_GREATER(route.first->GetPoly().GetSize(), 29, ());
     // And backward case
@@ -108,71 +119,81 @@ namespace
   // Cross mwm tests.
   UNIT_TEST(RussiaMoscowLeningradskiy39GerPanfilovtsev22RouteTest)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
-                                                  {37.53758809983519, 67.536162466434234}, {0., 0.},
-                                                  {37.40993977728661, 67.644784047393685}, 14296.);
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        {37.53758809983519, 67.536162466434234}, {0., 0.}, {37.40993977728661, 67.644784047393685},
+        14296.);
   }
 
   UNIT_TEST(NederlandLeeuwardenToDenOeverTest)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
-                                                  MercatorBounds::FromLatLon(53.2076, 5.7082), {0., 0.},
-                                                  MercatorBounds::FromLatLon(52.9337, 5.0308), 59500.);
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(53.2076, 5.7082), {0., 0.},
+        MercatorBounds::FromLatLon(52.9337, 5.0308), 59500.);
   }
 
   UNIT_TEST(RussiaMoscowGerPanfilovtsev22SolodchaPravdiRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), {37.409929478750627, 67.644798619710073}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        {37.409929478750627, 67.644798619710073}, {0., 0.},
         {39.836562407458047, 65.774372510437971}, 239426.);
   }
 
   UNIT_TEST(RussiaMoscowBelarusMinsk)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
-                                                  MercatorBounds::FromLatLon(55.750650, 37.617673), {0., 0.},
-                                                  MercatorBounds::FromLatLon(53.902114, 27.562020), 712649.0);
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.750650, 37.617673), {0., 0.},
+        MercatorBounds::FromLatLon(53.902114, 27.562020), 712649.0);
   }
 
   UNIT_TEST(UKRugbyStIvesRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), {-1.2653036222483705, 61.691304855049886}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        {-1.2653036222483705, 61.691304855049886}, {0., 0.},
         {-5.4799407508360218, 58.242809563579847}, 455902.);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39ItalySienaCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), {37.537596024929826, 67.536160359657288}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        {37.537596024929826, 67.536160359657288}, {0., 0.},
         {11.327927635052676, 48.166256203616726}, 2870710.);
   }
 
   UNIT_TEST(PeruSingleRoadTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(-14.22061, -73.35969), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(-14.22061, -73.35969), {0., 0.},
         MercatorBounds::FromLatLon(-14.22389, -73.44281), 15900.);
   }
 
   UNIT_TEST(RussiaMoscowFranceParisCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75271, 37.62618), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.75271, 37.62618), {0., 0.},
         MercatorBounds::FromLatLon(48.86123, 2.34129), 2840940.);
   }
 
   UNIT_TEST(EnglandToFranceRouteLeMansTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
         MercatorBounds::FromLatLon(50.93227, 1.82725), 60498.);
   }
 
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
         MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
   }
 
@@ -189,10 +210,12 @@ namespace
   UNIT_TEST(MoroccoToSahrawiCrossMwmTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(27.15587, -13.23059), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(27.15587, -13.23059), {0., 0.},
         MercatorBounds::FromLatLon(27.94049, -12.88800), 100864);
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(27.94049, -12.88800), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(27.94049, -12.88800), {0., 0.},
         MercatorBounds::FromLatLon(27.15587, -13.23059), 100864);
   }
 
@@ -202,11 +225,13 @@ namespace
     // points are inside borders and one of segments has outside points).
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(42.01535, 19.40044), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(42.01535, 19.40044), {0., 0.},
         MercatorBounds::FromLatLon(42.01201, 19.36286), 3674.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(42.01201, 19.36286), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(42.01201, 19.36286), {0., 0.},
         MercatorBounds::FromLatLon(42.01535, 19.40044), 3674.);
   }
 
@@ -214,11 +239,13 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.13418, -63.84656), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(46.13418, -63.84656), {0., 0.},
         MercatorBounds::FromLatLon(46.26739, -63.63907), 23000.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.26739, -63.63907), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(46.26739, -63.63907), {0., 0.},
         MercatorBounds::FromLatLon(46.13418, -63.84656), 23000.);
   }
 
@@ -226,11 +253,13 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.38053, 36.73226), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(45.38053, 36.73226), {0., 0.},
         MercatorBounds::FromLatLon(45.36078, 36.60866), 13150.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.36078, 36.60866), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(45.36078, 36.60866), {0., 0.},
         MercatorBounds::FromLatLon(45.38053, 36.73226), 13110.);
   }
 
@@ -238,19 +267,22 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(49.85015, 2.24296), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(49.85015, 2.24296), {0., 0.},
         MercatorBounds::FromLatLon(48.85860, 2.34784), 126000.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(48.85860, 2.34784), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(48.85860, 2.34784), {0., 0.},
         MercatorBounds::FromLatLon(49.85015, 2.24296), 126000.);
   }
 
   UNIT_TEST(RussiaSmolenskRussiaMoscowTimeTest)
   {
-    TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
-        MercatorBounds::FromLatLon(55.753, 37.60169));
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
+                                    MercatorBounds::FromLatLon(55.753, 37.60169));
 
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
@@ -261,9 +293,10 @@ namespace
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest)
   {
-    TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
-        MercatorBounds::FromLatLon(55.8579, 37.40990));
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
+                                    MercatorBounds::FromLatLon(55.8579, 37.40990));
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
@@ -273,9 +306,10 @@ namespace
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
   {
-    TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
-        MercatorBounds::FromLatLon(55.8579, 37.40990));
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
+                                    MercatorBounds::FromLatLon(55.8579, 37.40990));
 
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
@@ -289,9 +323,10 @@ namespace
 
   UNIT_TEST(USALosAnglesAriaTwentyninePalmsHighwayTimeTest)
   {
-    TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
-        MercatorBounds::FromLatLon(34.0928, -115.5930));
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
+                                    MercatorBounds::FromLatLon(34.0928, -115.5930));
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -13,24 +13,24 @@ namespace
   UNIT_TEST(StrangeCaseInAfrica)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
         MercatorBounds::FromLatLon(19.17289, 30.47315), 10283.7);
   }
 
   UNIT_TEST(MoscowShortRoadUnpacking)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.66218, 37.63253), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.66218, 37.63253), {0., 0.},
         MercatorBounds::FromLatLon(55.66237, 37.63560), 101.);
   }
 
   UNIT_TEST(MoscowToSVOAirport)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
         MercatorBounds::FromLatLon(55.97310, 37.41460), 30470.);
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
         MercatorBounds::FromLatLon(55.75100, 37.61790), 30470.);
   }
 
@@ -38,14 +38,14 @@ namespace
   UNIT_TEST(RestrictionTestNeatBaumanAndTTK)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
         MercatorBounds::FromLatLon(55.77198, 37.68782), 700.);
   }
 
   UNIT_TEST(RestrictionTestNearMetroShodnenskaya)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.85043, 37.43824), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85043, 37.43824), {0., 0.},
         MercatorBounds::FromLatLon(55.85191, 37.43910), 510.);
   }
 
@@ -53,7 +53,7 @@ namespace
   UNIT_TEST(CaliforniaCupertinoFindPhantomAssertTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(37.33409, -122.03458), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(37.33409, -122.03458), {0., 0.},
         MercatorBounds::FromLatLon(37.33498, -122.03575), 1438.);
   }
 
@@ -61,14 +61,14 @@ namespace
   UNIT_TEST(RussiaUfaToUstKatavTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(54.7304, 55.9554), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(54.7304, 55.9554), {0., 0.},
         MercatorBounds::FromLatLon(54.9228, 58.1469), 164667.);
   }
 
   UNIT_TEST(RussiaMoscow)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
         MercatorBounds::FromLatLon(55.77682, 37.70391), 185.);
   }
 
@@ -77,12 +77,12 @@ namespace
   {
     // Forward
     TRouteResult route = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
         MercatorBounds::FromLatLon(45.36479, 36.62194));
     TEST_EQUAL(route.second, IRouter::NoError, ());
     TEST_GREATER(route.first->GetPoly().GetSize(), 50, ());
     // And backward case
-    route = integration::CalculateRoute(integration::GetCarComponents(),
+    route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
                                         MercatorBounds::FromLatLon(45.34123, 36.67679));
     TEST_EQUAL(route.second, IRouter::NoError, ());
@@ -93,12 +93,12 @@ namespace
   {
     // Forward
     TRouteResult route = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
         MercatorBounds::FromLatLon(46.25401, -63.70213));
     TEST_EQUAL(route.second, IRouter::NoError, ());
     TEST_GREATER(route.first->GetPoly().GetSize(), 29, ());
     // And backward case
-    route = integration::CalculateRoute(integration::GetCarComponents(),
+    route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(46.25401, -63.70213), {0., 0.},
                                         MercatorBounds::FromLatLon(46.16255, -63.81643));
     TEST_EQUAL(route.second, IRouter::NoError, ());
@@ -108,14 +108,14 @@ namespace
   // Cross mwm tests.
   UNIT_TEST(RussiaMoscowLeningradskiy39GerPanfilovtsev22RouteTest)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetCarComponents(),
+    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
                                                   {37.53758809983519, 67.536162466434234}, {0., 0.},
                                                   {37.40993977728661, 67.644784047393685}, 14296.);
   }
 
   UNIT_TEST(NederlandLeeuwardenToDenOeverTest)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetCarComponents(),
+    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
                                                   MercatorBounds::FromLatLon(53.2076, 5.7082), {0., 0.},
                                                   MercatorBounds::FromLatLon(52.9337, 5.0308), 59500.);
   }
@@ -123,13 +123,13 @@ namespace
   UNIT_TEST(RussiaMoscowGerPanfilovtsev22SolodchaPravdiRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), {37.409929478750627, 67.644798619710073}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), {37.409929478750627, 67.644798619710073}, {0., 0.},
         {39.836562407458047, 65.774372510437971}, 239426.);
   }
 
   UNIT_TEST(RussiaMoscowBelarusMinsk)
   {
-    integration::CalculateRouteAndTestRouteLength(integration::GetCarComponents(),
+    integration::CalculateRouteAndTestRouteLength(integration::GetVehicleComponents<VehicleType::Car>(),
                                                   MercatorBounds::FromLatLon(55.750650, 37.617673), {0., 0.},
                                                   MercatorBounds::FromLatLon(53.902114, 27.562020), 712649.0);
   }
@@ -137,42 +137,42 @@ namespace
   UNIT_TEST(UKRugbyStIvesRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), {-1.2653036222483705, 61.691304855049886}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), {-1.2653036222483705, 61.691304855049886}, {0., 0.},
         {-5.4799407508360218, 58.242809563579847}, 455902.);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39ItalySienaCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), {37.537596024929826, 67.536160359657288}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), {37.537596024929826, 67.536160359657288}, {0., 0.},
         {11.327927635052676, 48.166256203616726}, 2870710.);
   }
 
   UNIT_TEST(PeruSingleRoadTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(-14.22061, -73.35969), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(-14.22061, -73.35969), {0., 0.},
         MercatorBounds::FromLatLon(-14.22389, -73.44281), 15900.);
   }
 
   UNIT_TEST(RussiaMoscowFranceParisCenterRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.75271, 37.62618), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75271, 37.62618), {0., 0.},
         MercatorBounds::FromLatLon(48.86123, 2.34129), 2840940.);
   }
 
   UNIT_TEST(EnglandToFranceRouteLeMansTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
         MercatorBounds::FromLatLon(50.93227, 1.82725), 60498.);
   }
 
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
         MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
   }
 
@@ -182,17 +182,17 @@ namespace
   {
     //@todo put down a correct route length when router is fixed
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), {37.53754, 67.53622}, {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), {37.53754, 67.53622}, {0., 0.},
         {18.54269, -36.09501}, 17873000.);
   }*/
 
   UNIT_TEST(MoroccoToSahrawiCrossMwmTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(27.15587, -13.23059), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(27.15587, -13.23059), {0., 0.},
         MercatorBounds::FromLatLon(27.94049, -12.88800), 100864);
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(27.94049, -12.88800), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(27.94049, -12.88800), {0., 0.},
         MercatorBounds::FromLatLon(27.15587, -13.23059), 100864);
   }
 
@@ -202,11 +202,11 @@ namespace
     // points are inside borders and one of segments has outside points).
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(42.01535, 19.40044), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(42.01535, 19.40044), {0., 0.},
         MercatorBounds::FromLatLon(42.01201, 19.36286), 3674.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(42.01201, 19.36286), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(42.01201, 19.36286), {0., 0.},
         MercatorBounds::FromLatLon(42.01535, 19.40044), 3674.);
   }
 
@@ -214,11 +214,11 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(46.13418, -63.84656), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.13418, -63.84656), {0., 0.},
         MercatorBounds::FromLatLon(46.26739, -63.63907), 23000.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(46.26739, -63.63907), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(46.26739, -63.63907), {0., 0.},
         MercatorBounds::FromLatLon(46.13418, -63.84656), 23000.);
   }
 
@@ -226,11 +226,11 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(45.38053, 36.73226), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.38053, 36.73226), {0., 0.},
         MercatorBounds::FromLatLon(45.36078, 36.60866), 13150.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(45.36078, 36.60866), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(45.36078, 36.60866), {0., 0.},
         MercatorBounds::FromLatLon(45.38053, 36.73226), 13110.);
   }
 
@@ -238,18 +238,18 @@ namespace
   {
     // Forward
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(49.85015, 2.24296), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(49.85015, 2.24296), {0., 0.},
         MercatorBounds::FromLatLon(48.85860, 2.34784), 126000.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(48.85860, 2.34784), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(48.85860, 2.34784), {0., 0.},
         MercatorBounds::FromLatLon(49.85015, 2.24296), 126000.);
   }
 
   UNIT_TEST(RussiaSmolenskRussiaMoscowTimeTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
         MercatorBounds::FromLatLon(55.753, 37.60169));
 
     Route const & route = *routeResult.first;
@@ -262,7 +262,7 @@ namespace
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
         MercatorBounds::FromLatLon(55.8579, 37.40990));
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
@@ -274,7 +274,7 @@ namespace
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
         MercatorBounds::FromLatLon(55.8579, 37.40990));
 
     IRouter::ResultCode const result = routeResult.second;
@@ -290,7 +290,7 @@ namespace
   UNIT_TEST(USALosAnglesAriaTwentyninePalmsHighwayTimeTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-        integration::GetCarComponents(), MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
+        integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
         MercatorBounds::FromLatLon(34.0928, -115.5930));
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -123,7 +123,7 @@ namespace
   UNIT_TEST(RussiaMoscowGerPanfilovtsev22SolodchaPravdiRouteTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-      integration::GetCarComponents(), {37.409929478750627, 67.644798619710073}, {0., 0.},
+        integration::GetCarComponents(), {37.409929478750627, 67.644798619710073}, {0., 0.},
         {39.836562407458047, 65.774372510437971}, 239426.);
   }
 
@@ -172,8 +172,8 @@ namespace
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)
   {
     integration::CalculateRouteAndTestRouteLength(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
-      MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
+        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.771, 37.5184), {0., 0.},
+        MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
   }
 
   // Strange map edits in Africa borders. Routing not linked now.
@@ -274,8 +274,8 @@ namespace
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
-      MercatorBounds::FromLatLon(55.8579, 37.40990));
+        integration::GetCarComponents(), MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
+        MercatorBounds::FromLatLon(55.8579, 37.40990));
 
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
@@ -290,8 +290,8 @@ namespace
   UNIT_TEST(USALosAnglesAriaTwentyninePalmsHighwayTimeTest)
   {
     TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
-      MercatorBounds::FromLatLon(34.0928, -115.5930));
+        integration::GetCarComponents(), MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
+        MercatorBounds::FromLatLon(34.0928, -115.5930));
     Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -130,23 +130,6 @@ namespace integration
     return unique_ptr<IRouter>(move(router));
   }
 
-  class VehicleRouterComponents : public IRouterComponents
-  {
-  public:
-    VehicleRouterComponents(vector<LocalCountryFile> const & localFiles, VehicleType vehicleType)
-      : IRouterComponents(localFiles)
-      , m_indexRouter(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter, m_trafficCache,
-                                      localFiles, vehicleType))
-    {
-    }
-
-    IRouter * GetRouter() const override { return m_indexRouter.get(); }
-
-  private:
-    traffic::TrafficCache m_trafficCache;
-    unique_ptr<IndexRouter> m_indexRouter;
-  };
-
   shared_ptr<VehicleRouterComponents> CreateAllMapsComponents(VehicleType vehicleType)
   {
     // Setting stored paths from testingmain.cpp
@@ -166,27 +149,6 @@ namespace integration
       file.SyncWithDisk();
     ASSERT(!localFiles.empty(), ());
     return make_shared<VehicleRouterComponents>(localFiles, vehicleType);
-  }
-
-  IRouterComponents & GetCarComponents()
-  {
-    static auto const instance = CreateAllMapsComponents(VehicleType::Car);
-    ASSERT(instance, ());
-    return *instance;
-  }
-
-  IRouterComponents & GetPedestrianComponents()
-  {
-    static auto const instance = CreateAllMapsComponents(VehicleType::Pedestrian);
-    ASSERT(instance, ());
-    return *instance;
-  }
-
-  IRouterComponents & GetBicycleComponents()
-  {
-    static auto const instance = CreateAllMapsComponents(VehicleType::Bicycle);
-    ASSERT(instance, ());
-    return *instance;
   }
 
   TRouteResult CalculateRoute(IRouterComponents const & routerComponents,

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -80,11 +80,11 @@ namespace integration
     return storage::CountryInfoReader::CreateCountryInfoReader(platform);
   }
 
-  unique_ptr<IndexRouter> CreateCarRouter(Index & index,
-                                          storage::CountryInfoGetter const & infoGetter,
-                                          traffic::TrafficCache const & trafficCache,
-                                          vector<LocalCountryFile> const & localFiles,
-                                          VehicleType vehicleType)
+  unique_ptr<IndexRouter> CreateVehicleRouter(Index & index,
+                                              storage::CountryInfoGetter const & infoGetter,
+                                              traffic::TrafficCache const & trafficCache,
+                                              vector<LocalCountryFile> const & localFiles,
+                                              VehicleType vehicleType)
   {
     auto const countryFileGetter = [&infoGetter](m2::PointD const & pt) {
       return infoGetter.GetRegionCountryId(pt);
@@ -156,12 +156,9 @@ namespace integration
                               m2::PointD const & finalPoint)
   {
     RouterDelegate delegate;
-    IRouter * router = routerComponents.GetRouter();
-    ASSERT(router, ());
     shared_ptr<Route> route(new Route("mapsme"));
-    IRouter::ResultCode result =
-        router->CalculateRoute(Checkpoints(startPoint, finalPoint), startDirection,
-                               false /* adjust */, delegate, *route);
+    IRouter::ResultCode result = routerComponents.GetRouter().CalculateRoute(
+        Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, *route);
     ASSERT(route, ());
     return TRouteResult(route, result);
   }

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -99,7 +99,7 @@ void TestOnlineFetcher(ms::LatLon const & startPoint, ms::LatLon const & finalPo
 
 shared_ptr<VehicleRouterComponents> CreateAllMapsComponents(VehicleType vehicleType);
 
-template<VehicleType type>
+template <VehicleType type>
 IRouterComponents & GetVehicleComponents()
 {
   static auto const instance = CreateAllMapsComponents(type);

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -50,11 +50,11 @@ shared_ptr<model::FeaturesFetcher> CreateFeaturesFetcher(vector<LocalCountryFile
 
 unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetter();
 
-unique_ptr<IndexRouter> CreateCarRouter(Index & index,
-                                        storage::CountryInfoGetter const & infoGetter,
-                                        traffic::TrafficCache const & trafficCache,
-                                        vector<LocalCountryFile> const & localFiles,
-                                        VehicleType vehicleType);
+unique_ptr<IndexRouter> CreateVehicleRouter(Index & index,
+                                            storage::CountryInfoGetter const & infoGetter,
+                                            traffic::TrafficCache const & trafficCache,
+                                            vector<LocalCountryFile> const & localFiles,
+                                            VehicleType vehicleType);
 
 class IRouterComponents
 {
@@ -66,7 +66,7 @@ public:
 
   virtual ~IRouterComponents() = default;
 
-  virtual IRouter * GetRouter() const = 0;
+  virtual IRouter & GetRouter() const = 0;
 
   storage::CountryInfoGetter const & GetCountryInfoGetter() const noexcept { return *m_infoGetter; }
 
@@ -80,12 +80,12 @@ class VehicleRouterComponents : public IRouterComponents
 public:
   VehicleRouterComponents(vector<LocalCountryFile> const & localFiles, VehicleType vehicleType)
     : IRouterComponents(localFiles)
-    , m_indexRouter(CreateCarRouter(m_featuresFetcher->GetIndex(), *m_infoGetter, m_trafficCache,
-                                    localFiles, vehicleType))
+    , m_indexRouter(CreateVehicleRouter(m_featuresFetcher->GetIndex(), *m_infoGetter, m_trafficCache,
+                                        localFiles, vehicleType))
   {
   }
 
-  IRouter * GetRouter() const override { return m_indexRouter.get(); }
+  IRouter & GetRouter() const override { return *m_indexRouter; }
 
 private:
   traffic::TrafficCache m_trafficCache;

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -22,7 +22,7 @@ void MoveRoute(Route & route, ms::LatLon const & coords)
 UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
       MercatorBounds::FromLatLon(55.73198, 37.63945));
 
   Route & route = *routeResult.first;

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -21,9 +21,10 @@ void MoveRoute(Route & route, ms::LatLon const & coords)
 
 UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
-      MercatorBounds::FromLatLon(55.73198, 37.63945));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.70839, 37.62145), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.73198, 37.63945));
 
   Route & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -10,9 +10,10 @@ using namespace routing::turns;
 
 UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.67251, 37.63604),
-      {-0.004, -0.01}, MercatorBounds::FromLatLon(55.67293, 37.63507));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.67251, 37.63604), {-0.004, -0.01},
+                                  MercatorBounds::FromLatLon(55.67293, 37.63507));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -33,9 +34,10 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 
 UNIT_TEST(StPetersburgSideRoadPenaltyTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
-      MercatorBounds::FromLatLon(59.84268, 30.27589));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
+                                  MercatorBounds::FromLatLon(59.84268, 30.27589));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -46,9 +48,10 @@ UNIT_TEST(StPetersburgSideRoadPenaltyTest)
 
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79693, 37.53754), {0., 0.},
-      MercatorBounds::FromLatLon(55.80212, 37.5389));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.79693, 37.53754), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80212, 37.5389));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -72,9 +75,10 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 
 UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85182, 37.39533), {0., 0.},
-      MercatorBounds::FromLatLon(55.84386, 37.39250));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.85182, 37.39533), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.84386, 37.39250));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 
@@ -102,10 +106,10 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 
 UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(),
-      MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
-      MercatorBounds::FromLatLon(55.83384, 37.40521));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.83384, 37.40521));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 
@@ -123,9 +127,10 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 
 UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
-      MercatorBounds::FromLatLon(60.48462, 15.42120));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
+                                  MercatorBounds::FromLatLon(60.48462, 15.42120));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 
@@ -143,9 +148,10 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 
 UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80216, 37.54668), {0., 0.},
-      MercatorBounds::FromLatLon(55.80169, 37.54915));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.80216, 37.54668), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80169, 37.54915));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -159,9 +165,10 @@ UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 
 UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.84656, 37.39163), {0., 0.},
-      MercatorBounds::FromLatLon(55.56661, 37.69254));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.84656, 37.39163), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.56661, 37.69254));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -178,9 +185,10 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
 
 UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.70160, 37.60632), {0., 0.},
-      MercatorBounds::FromLatLon(55.69349, 37.62122));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.70160, 37.60632), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.69349, 37.62122));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -194,9 +202,10 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
 
 UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
-      MercatorBounds::FromLatLon(55.80955, 37.78056));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80955, 37.78056));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -209,9 +218,10 @@ UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
 
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.66192, 37.62852), {0., 0.},
-      MercatorBounds::FromLatLon(55.66189, 37.63254));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.66192, 37.62852), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.66189, 37.63254));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -225,9 +235,10 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
 
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77177, 37.63556), {0., 0.},
-      MercatorBounds::FromLatLon(55.77203, 37.63705));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.77177, 37.63556), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.77203, 37.63705));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -239,9 +250,10 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 
 UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85305, 37.39414), {0., 0.},
-      MercatorBounds::FromLatLon(55.85099, 37.39105));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.85305, 37.39414), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.85099, 37.39105));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -254,9 +266,10 @@ UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
 
 UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.84104, 37.40591), {0., 0.},
-      MercatorBounds::FromLatLon(55.83929, 37.40855));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.84104, 37.40591), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.83929, 37.40855));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -267,9 +280,10 @@ UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
 
 UNIT_TEST(RussiaHugeRoundaboutTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80141, 37.32581), {0., 0.},
-      MercatorBounds::FromLatLon(55.80075, 37.32536));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.80141, 37.32581), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80075, 37.32536));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -288,9 +302,10 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
 
 UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(53.93642, 27.65857), {0., 0.},
-      MercatorBounds::FromLatLon(53.93933, 27.67046));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(53.93642, 27.65857), {0., 0.},
+                                  MercatorBounds::FromLatLon(53.93933, 27.67046));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -305,9 +320,10 @@ UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
 // An end user shall be informed about this manoeuvre.
 UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.83636, 37.40555), {0., 0.},
-      MercatorBounds::FromLatLon(55.83707, 37.40489));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.83636, 37.40555), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.83707, 37.40489));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -321,9 +337,10 @@ UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
 // An end user shall not be informed about such manoeuvres.
 UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.87992, 37.43940), {0., 0.},
-      MercatorBounds::FromLatLon(55.87854, 37.44865));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.87992, 37.43940), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.87854, 37.44865));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -334,9 +351,10 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 
 UNIT_TEST(BelarusMKADShosseinai)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.31541, 29.43123), {0., 0.},
-      MercatorBounds::FromLatLon(55.31656, 29.42626));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.31541, 29.43123), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.31656, 29.42626));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -351,9 +369,10 @@ UNIT_TEST(BelarusMKADShosseinai)
 // An end user shall not be informed about such manoeuvres.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(7.91797, 98.36937), {0., 0.},
-      MercatorBounds::FromLatLon(7.90724, 98.36785));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(7.91797, 98.36937), {0., 0.},
+                                  MercatorBounds::FromLatLon(7.90724, 98.36785));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -367,9 +386,10 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 // shall be generated.
 UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.58210, 37.59695), {0., 0.},
-      MercatorBounds::FromLatLon(55.57514, 37.61020));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.58210, 37.59695), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.57514, 37.61020));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -384,9 +404,10 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
 // to Mokhovaya street. A turn instruction (turn left) shell be generated.
 UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75765, 37.61355), {0., 0.},
-      MercatorBounds::FromLatLon(55.75737, 37.61601));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.75765, 37.61355), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75737, 37.61601));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -398,9 +419,10 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 
 UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75574, 37.60702), {0., 0.},
-      MercatorBounds::FromLatLon(55.75586, 37.60819));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.75574, 37.60702), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75586, 37.60819));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -414,9 +436,10 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
 // and makes u-turn. A only one turn instruction (turn left) shell be generated.
 UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79231, 37.54951), {0., 0.},
-      MercatorBounds::FromLatLon(55.79280, 37.55028));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.79231, 37.54951), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.79280, 37.55028));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -430,9 +453,10 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 // This test was written after reducing factors kMaxPointsCount and kMinDistMeters.
 UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(47.19300, 8.67568), {0., 0.},
-      MercatorBounds::FromLatLon(47.19162, 8.67590));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(47.19300, 8.67568), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.19162, 8.67590));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -443,9 +467,10 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 
 UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
 {
-  TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79041, 37.53770), {0., 0.},
-      MercatorBounds::FromLatLon(55.79182, 37.53008));
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.79041, 37.53770), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.79182, 37.53008));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -103,9 +103,9 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-    integration::GetCarComponents(),
-    MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
-    MercatorBounds::FromLatLon(55.83384, 37.40521));
+      integration::GetCarComponents(),
+      MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
+      MercatorBounds::FromLatLon(55.83384, 37.40521));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -11,7 +11,7 @@ using namespace routing::turns;
 UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.67251, 37.63604),
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.67251, 37.63604),
       {-0.004, -0.01}, MercatorBounds::FromLatLon(55.67293, 37.63507));
 
   Route const & route = *routeResult.first;
@@ -34,7 +34,7 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 UNIT_TEST(StPetersburgSideRoadPenaltyTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
       MercatorBounds::FromLatLon(59.84268, 30.27589));
 
   Route const & route = *routeResult.first;
@@ -47,7 +47,7 @@ UNIT_TEST(StPetersburgSideRoadPenaltyTest)
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.79693, 37.53754), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79693, 37.53754), {0., 0.},
       MercatorBounds::FromLatLon(55.80212, 37.5389));
 
   Route const & route = *routeResult.first;
@@ -73,7 +73,7 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.85182, 37.39533), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85182, 37.39533), {0., 0.},
       MercatorBounds::FromLatLon(55.84386, 37.39250));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -103,7 +103,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(),
+      integration::GetVehicleComponents<VehicleType::Car>(),
       MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
       MercatorBounds::FromLatLon(55.83384, 37.40521));
   Route const & route = *routeResult.first;
@@ -124,7 +124,7 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
       MercatorBounds::FromLatLon(60.48462, 15.42120));
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
@@ -144,7 +144,7 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
 UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.80216, 37.54668), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80216, 37.54668), {0., 0.},
       MercatorBounds::FromLatLon(55.80169, 37.54915));
 
   Route const & route = *routeResult.first;
@@ -160,7 +160,7 @@ UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
 UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.84656, 37.39163), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.84656, 37.39163), {0., 0.},
       MercatorBounds::FromLatLon(55.56661, 37.69254));
 
   Route const & route = *routeResult.first;
@@ -179,7 +179,7 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
 UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.70160, 37.60632), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.70160, 37.60632), {0., 0.},
       MercatorBounds::FromLatLon(55.69349, 37.62122));
 
   Route const & route = *routeResult.first;
@@ -195,7 +195,7 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
 UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
       MercatorBounds::FromLatLon(55.80955, 37.78056));
 
   Route const & route = *routeResult.first;
@@ -210,7 +210,7 @@ UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.66192, 37.62852), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.66192, 37.62852), {0., 0.},
       MercatorBounds::FromLatLon(55.66189, 37.63254));
 
   Route const & route = *routeResult.first;
@@ -226,7 +226,7 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.77177, 37.63556), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.77177, 37.63556), {0., 0.},
       MercatorBounds::FromLatLon(55.77203, 37.63705));
 
   Route const & route = *routeResult.first;
@@ -240,7 +240,7 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
 UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.85305, 37.39414), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.85305, 37.39414), {0., 0.},
       MercatorBounds::FromLatLon(55.85099, 37.39105));
 
   Route const & route = *routeResult.first;
@@ -255,7 +255,7 @@ UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
 UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.84104, 37.40591), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.84104, 37.40591), {0., 0.},
       MercatorBounds::FromLatLon(55.83929, 37.40855));
 
   Route const & route = *routeResult.first;
@@ -268,7 +268,7 @@ UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
 UNIT_TEST(RussiaHugeRoundaboutTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.80141, 37.32581), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.80141, 37.32581), {0., 0.},
       MercatorBounds::FromLatLon(55.80075, 37.32536));
 
   Route const & route = *routeResult.first;
@@ -289,7 +289,7 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
 UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(53.93642, 27.65857), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(53.93642, 27.65857), {0., 0.},
       MercatorBounds::FromLatLon(53.93933, 27.67046));
 
   Route const & route = *routeResult.first;
@@ -306,7 +306,7 @@ UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
 UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.83636, 37.40555), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.83636, 37.40555), {0., 0.},
       MercatorBounds::FromLatLon(55.83707, 37.40489));
 
   Route const & route = *routeResult.first;
@@ -322,7 +322,7 @@ UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
 UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.87992, 37.43940), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.87992, 37.43940), {0., 0.},
       MercatorBounds::FromLatLon(55.87854, 37.44865));
 
   Route const & route = *routeResult.first;
@@ -335,7 +335,7 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 UNIT_TEST(BelarusMKADShosseinai)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.31541, 29.43123), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.31541, 29.43123), {0., 0.},
       MercatorBounds::FromLatLon(55.31656, 29.42626));
 
   Route const & route = *routeResult.first;
@@ -352,7 +352,7 @@ UNIT_TEST(BelarusMKADShosseinai)
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(7.91797, 98.36937), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(7.91797, 98.36937), {0., 0.},
       MercatorBounds::FromLatLon(7.90724, 98.36785));
 
   Route const & route = *routeResult.first;
@@ -368,7 +368,7 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.58210, 37.59695), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.58210, 37.59695), {0., 0.},
       MercatorBounds::FromLatLon(55.57514, 37.61020));
 
   Route const & route = *routeResult.first;
@@ -385,7 +385,7 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
 UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.75765, 37.61355), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75765, 37.61355), {0., 0.},
       MercatorBounds::FromLatLon(55.75737, 37.61601));
 
   Route const & route = *routeResult.first;
@@ -399,7 +399,7 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.75574, 37.60702), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.75574, 37.60702), {0., 0.},
       MercatorBounds::FromLatLon(55.75586, 37.60819));
 
   Route const & route = *routeResult.first;
@@ -415,7 +415,7 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
 UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.79231, 37.54951), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79231, 37.54951), {0., 0.},
       MercatorBounds::FromLatLon(55.79280, 37.55028));
 
   Route const & route = *routeResult.first;
@@ -431,7 +431,7 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(47.19300, 8.67568), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(47.19300, 8.67568), {0., 0.},
       MercatorBounds::FromLatLon(47.19162, 8.67590));
 
   Route const & route = *routeResult.first;
@@ -444,7 +444,7 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
 {
   TRouteResult const routeResult = integration::CalculateRoute(
-      integration::GetCarComponents(), MercatorBounds::FromLatLon(55.79041, 37.53770), {0., 0.},
+      integration::GetVehicleComponents<VehicleType::Car>(), MercatorBounds::FromLatLon(55.79041, 37.53770), {0., 0.},
       MercatorBounds::FromLatLon(55.79182, 37.53008));
 
   Route const & route = *routeResult.first;


### PR DESCRIPTION
Данный PR исправляет ряд моментов упущенных после перевода пешей и вело навигации на IndexGraph.

- игнорируется направление односторонних дорог при пешей навигации;
- интеграционные тесты тесты на пешей и вело роутинг теперь работают по IndexGraph. (Они не были переведены);
- сделан тест и поправлен код, чтоб были допустимы маршруты, у которых старт и финиш совпадают;
- проведен рефакторинг в интеграционных тестах;

@tatiana-kondakova @ygorshenin PTAL