### PR TITLE
[release] Ignoring one way feature direction for pedestrian routing.

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -283,10 +283,10 @@ double IndexRouter::BestEdgeComparator::GetSquaredDist(Edge const & edge) const
 }
 
 // IndexRouter ------------------------------------------------------------------------------------
-IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes, TCountryFileFn const & countryFileFn,
-                         CourntryRectFn const & countryRectFn, shared_ptr<NumMwmIds> numMwmIds,
-                         unique_ptr<m4::Tree<NumMwmId>> numMwmTree, traffic::TrafficCache const & trafficCache,
-                         Index & index)
+IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
+                         TCountryFileFn const & countryFileFn, CourntryRectFn const & countryRectFn,
+                         shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
+                         traffic::TrafficCache const & trafficCache, Index & index)
   : m_vehicleType(vehicleType)
   , m_loadAltitudes(loadAltitudes)
   , m_name("astar-bidirectional-" + ToString(m_vehicleType))
@@ -298,10 +298,12 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes, TCountryFi
   , m_numMwmTree(move(numMwmTree))
   , m_trafficStash(CreateTrafficStash(m_vehicleType, m_numMwmIds, trafficCache))
   , m_indexManager(countryFileFn, m_index)
-  , m_roadGraph(m_index, vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
-                                                                : IRoadGraph::Mode::ObeyOnewayTag,
+  , m_roadGraph(m_index,
+                vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
+                                                       : IRoadGraph::Mode::ObeyOnewayTag,
                 m_vehicleModelFactory)
-  , m_estimator(EdgeEstimator::Create(m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
+  , m_estimator(EdgeEstimator::Create(
+        m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_index))
 {
   CHECK(!m_name.empty(), ());

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -298,7 +298,9 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes, TCountryFi
   , m_numMwmTree(move(numMwmTree))
   , m_trafficStash(CreateTrafficStash(m_vehicleType, m_numMwmIds, trafficCache))
   , m_indexManager(countryFileFn, m_index)
-  , m_roadGraph(m_index, IRoadGraph::Mode::ObeyOnewayTag, m_vehicleModelFactory)
+  , m_roadGraph(m_index, vehicleType == VehicleType::Pedestrian ? IRoadGraph::Mode::IgnoreOnewayTag
+                                                                : IRoadGraph::Mode::ObeyOnewayTag,
+                m_vehicleModelFactory)
   , m_estimator(EdgeEstimator::Create(m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory), m_trafficStash))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_index))
 {


### PR DESCRIPTION
cherry-pick коммита с мастера, который исправляет ошибку в переводе пешеходного роутинга на index graph. Сейчас в release-75 мы прокладываем пешеходные маршруты по направлению oneway featch. Без возможности ехать против их движения. Данный PR исправляет эту ошибку.

@tatiana-kondakova @ygorshenin PTAL