### PR TITLE
Fix generate_mwm.sh: add new A-star routing

### DIFF
--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -109,6 +109,8 @@ if [ "$SOURCE_TYPE" == "o5m" ]; then
   $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --preprocess=true || fail "Preprocessing failed"
   $GENERATOR_TOOL $INTDIR_FLAG --osm_file_type=o5m --osm_file_name="$SOURCE_FILE" --data_path="$TARGET" --user_resource_path="$DATA_PATH" $GENERATE_EVERYTHING --output="$BASE_NAME"
   $GENERATOR_TOOL $INTDIR_FLAG --data_path="$TARGET" --user_resource_path="$DATA_PATH" ${CROSS_MWM-} --make_routing_index --generate_traffic_keys --output="$BASE_NAME"
+  $GENERATOR_TOOL --data_path="$TARGET" --intermediate_data_path="$INTDIR/" --user_resource_path="$DATA_PATH/" \
+          --make_cross_mwm --disable_cross_mwm_progress --make_routing_index --generate_traffic_keys --output="$BASE_NAME"
 else
   echo "Unsupported source type: $SOURCE_TYPE" >&2
 fi


### PR DESCRIPTION
This PR fixes generating single mwm with new route system.

Similary to https://github.com/mapsme/omim/commit/126afc9f402936005b762ee536aa6257bad98efe#diff-f144a8192285f53d186191085d343c89 but with latest command args from `master` branch