### PR TITLE
Do not use non-transit features for transit

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -175,10 +175,10 @@ private:
 
 // Calculate distance from the starting border point to the transition along the border.
 // It could be measured clockwise or counterclockwise, direction doesn't matter.
-RouteWeight CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
-                                        CrossMwmConnectorSerializer::Transition const & transition)
+double CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
+                                   CrossMwmConnectorSerializer::Transition const & transition)
 {
-  RouteWeight distance = GetAStarWeightZero<RouteWeight>();
+  auto distance = GetAStarWeightZero<double>();
 
   for (m2::RegionD const & region : borders)
   {
@@ -192,11 +192,11 @@ RouteWeight CalcDistanceAlongTheBorders(vector<m2::RegionD> const & borders,
       if (m2::RegionD::IsIntersect(transition.GetBackPoint(), transition.GetFrontPoint(), *prev,
                                    curr, intersection))
       {
-        distance += RouteWeight(prev->Length(intersection));
+        distance += prev->Length(intersection);
         return distance;
       }
 
-      distance += RouteWeight(prev->Length(curr));
+      distance += prev->Length(curr);
       prev = &curr;
     }
   }
@@ -324,13 +324,13 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   connector.FillWeights([&](Segment const & enter, Segment const & exit) {
     auto it0 = weights.find(enter);
     if (it0 == weights.end())
-      return RouteWeight(CrossMwmConnector::kNoRoute);
+      return CrossMwmConnector::kNoRoute;
 
     auto it1 = it0->second.find(exit);
     if (it1 == it0->second.end())
-      return RouteWeight(CrossMwmConnector::kNoRoute);
+      return CrossMwmConnector::kNoRoute;
 
-    return it1->second;
+    return it1->second.ToCrossMwmWeight();
   });
 
   LOG(LINFO, ("Leaps finished, elapsed:", timer.ElapsedSeconds(), "seconds, routes found:",

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
   base/astar_weight.hpp
   base/followed_polyline.cpp
   base/followed_polyline.hpp
+  base/routing_result.hpp
   bicycle_directions.cpp
   bicycle_directions.hpp
   checkpoint_predictor.cpp

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -357,8 +357,8 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::FindPath(
 
   if (resultCode == Result::OK)
   {
-    context.ReconstructPath(finalVertex, result.path);
-    result.distance =
+    context.ReconstructPath(finalVertex, result.m_path);
+    result.m_distance =
         context.GetDistance(finalVertex) - graph.HeuristicCostEstimate(startVertex, finalVertex);
   }
 
@@ -433,11 +433,11 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::FindPathBidirect
       if (curTop + nxtTop >= bestPathReducedLength - kEpsilon)
       {
         ReconstructPathBidirectional(cur->bestVertex, nxt->bestVertex, cur->parent, nxt->parent,
-                                     result.path);
-        result.distance = bestPathRealLength;
-        CHECK(!result.path.empty(), ());
+                                     result.m_path);
+        result.m_distance = bestPathRealLength;
+        CHECK(!result.m_path.empty(), ());
         if (!cur->forward)
-          reverse(result.path.begin(), result.path.end());
+          reverse(result.m_path.begin(), result.m_path.end());
         return Result::OK;
       }
     }
@@ -564,7 +564,7 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::AdjustRoute(
   if (minDistance == kInfiniteDistance)
     return Result::NoPath;
 
-  context.ReconstructPath(returnVertex, result.path);
+  context.ReconstructPath(returnVertex, result.m_path);
 
   // Append remaining route.
   bool found = false;
@@ -573,19 +573,19 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::AdjustRoute(
     if (prevRoute[i].GetTarget() == returnVertex)
     {
       for (size_t j = i + 1; j < prevRoute.size(); ++j)
-        result.path.push_back(prevRoute[j].GetTarget());
+        result.m_path.push_back(prevRoute[j].GetTarget());
 
       found = true;
       break;
     }
   }
 
-  CHECK(found,
-        ("Can't find", returnVertex, ", prev:", prevRoute.size(), ", adjust:", result.path.size()));
+  CHECK(found, ("Can't find", returnVertex, ", prev:", prevRoute.size(),
+                ", adjust:", result.m_path.size()));
 
   auto const & it = remainingDistances.find(returnVertex);
   CHECK(it != remainingDistances.end(), ());
-  result.distance = context.GetDistance(returnVertex) + it->second;
+  result.m_distance = context.GetDistance(returnVertex) + it->second;
   return Result::OK;
 }
 

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/base/astar_weight.hpp"
+#include "routing/base/routing_result.hpp"
 
 #include "base/assert.hpp"
 #include "base/cancellable.hpp"
@@ -13,22 +14,6 @@
 
 namespace routing
 {
-
-template <typename TVertexType, typename TWeightType>
-struct RoutingResult
-{
-  std::vector<TVertexType> path;
-  TWeightType distance;
-
-  RoutingResult() : distance(GetAStarWeightZero<TWeightType>()) {}
-
-  void Clear()
-  {
-    path.clear();
-    distance = GetAStarWeightZero<TWeightType>();
-  }
-};
-
 template <typename TGraph>
 class AStarAlgorithm
 {

--- a/routing/base/routing_result.hpp
+++ b/routing/base/routing_result.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "routing/base/astar_weight.hpp"
+
+#include <vector>
+
+namespace routing
+{
+template <typename TVertexType, typename TWeightType>
+struct RoutingResult
+{
+  std::vector<TVertexType> path;
+  TWeightType distance;
+  RoutingResult() : distance(GetAStarWeightZero<TWeightType>()) {}
+  void Clear()
+  {
+    path.clear();
+    distance = GetAStarWeightZero<TWeightType>();
+  }
+};
+}  // namespace routing

--- a/routing/base/routing_result.hpp
+++ b/routing/base/routing_result.hpp
@@ -6,16 +6,18 @@
 
 namespace routing
 {
-template <typename TVertexType, typename TWeightType>
-struct RoutingResult
+template <typename VertexType, typename WeightType>
+struct RoutingResult final
 {
-  std::vector<TVertexType> path;
-  TWeightType distance;
-  RoutingResult() : distance(GetAStarWeightZero<TWeightType>()) {}
+  RoutingResult() : m_distance(GetAStarWeightZero<WeightType>()) {}
+
   void Clear()
   {
-    path.clear();
-    distance = GetAStarWeightZero<TWeightType>();
+    m_path.clear();
+    m_distance = GetAStarWeightZero<WeightType>();
   }
+
+  std::vector<VertexType> m_path;
+  WeightType m_distance;
 };
 }  // namespace routing

--- a/routing/cross_mwm_connector.cpp
+++ b/routing/cross_mwm_connector.cpp
@@ -149,8 +149,8 @@ std::string DebugPrint(CrossMwmConnector::WeightsLoadState state)
 void CrossMwmConnector::AddEdge(Segment const & segment, Weight weight,
                                 std::vector<SegmentEdge> & edges) const
 {
-  if (weight != static_cast<Weight>(kNoRoute))
-    edges.emplace_back(segment, RouteWeight(static_cast<double>(weight)));
+  if (weight != kNoRoute)
+    edges.emplace_back(segment, RouteWeight::FromCrossMwmWeight(weight));
 }
 
 CrossMwmConnector::Transition const & CrossMwmConnector::GetTransition(

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -62,9 +62,9 @@ public:
     {
       for (Segment const & exit : m_exits)
       {
-        RouteWeight const weight = calcWeight(enter, exit);
+        auto const weight = calcWeight(enter, exit);
         // Edges weights should be >= astar heuristic, so use std::ceil.
-        m_weights.push_back(static_cast<Weight>(std::ceil(weight.GetWeight())));
+        m_weights.push_back(static_cast<Weight>(std::ceil(weight)));
       }
     }
   }

--- a/routing/cross_mwm_osrm_graph.cpp
+++ b/routing/cross_mwm_osrm_graph.cpp
@@ -103,8 +103,9 @@ void AddSegmentEdge(NumMwmIds const & numMwmIds, OsrmFtSegMapping const & segMap
   double constexpr kAstarHeuristicFactor = 100000;
   //// Osrm multiplies seconds to 10, so we need to divide it back.
   double constexpr kOSRMWeightToSecondsMultiplier = 0.1;
-  edges.emplace_back(segment, RouteWeight(osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier *
-                                          kAstarHeuristicFactor));
+  edges.emplace_back(
+      segment, RouteWeight::FromCrossMwmWeight(
+                   osrmEdge.GetWeight() * kOSRMWeightToSecondsMultiplier * kAstarHeuristicFactor));
 }
 }  // namespace
 

--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -1,8 +1,9 @@
 #include "routing/cross_mwm_router.hpp"
 
+#include "routing/base/astar_algorithm.hpp"
+#include "routing/base/routing_result.hpp"
 #include "routing/cross_mwm_road_graph.hpp"
 
-#include "base/astar_algorithm.hpp"
 #include "base/timer.hpp"
 
 namespace routing

--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -31,8 +31,8 @@ IRouter::ResultCode CalculateRoute(BorderCross const & startPos, BorderCross con
   switch (result)
   {
     case TAlgorithm::Result::OK:
-      ASSERT_EQUAL(route.path.front(), startPos, ());
-      ASSERT_EQUAL(route.path.back(), finalPos, ());
+      ASSERT_EQUAL(route.m_path.front(), startPos, ());
+      ASSERT_EQUAL(route.m_path.back(), finalPos, ());
       return IRouter::NoError;
     case TAlgorithm::Result::NoPath:
       return IRouter::RouteNotFound;
@@ -93,14 +93,14 @@ IRouter::ResultCode CalculateCrossMwmPath(TRoutingNodes const & startGraphNodes,
   // Finding path through maps.
   RoutingResult<BorderCross, double /* WeightType */> tempRoad;
   code = CalculateRoute({startNode, startNode}, {finalNode, finalNode}, roadGraph, delegate, tempRoad);
-  cost = tempRoad.distance;
+  cost = tempRoad.m_distance;
   if (code != IRouter::NoError)
     return code;
   if (delegate.IsCancelled())
     return IRouter::Cancelled;
 
   // Final path conversion to output type.
-  ConvertToSingleRouterTasks(tempRoad.path, startGraphNode, finalGraphNode, route);
+  ConvertToSingleRouterTasks(tempRoad.m_path, startGraphNode, finalGraphNode, route);
 
   return route.empty() ? IRouter::RouteNotFound : IRouter::NoError;
 }

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -57,6 +57,8 @@ public:
     return pointId == 0 || pointId + 1 == GetPointsCount();
   }
 
+  void SetTransitAllowedForTests(bool transitAllowed) { m_isTransitAllowed = transitAllowed; }
+
 private:
   buffer_vector<Junction, 32> m_junctions;
   double m_speed = 0.0;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -113,13 +113,14 @@ RouteWeight IndexGraph::HeuristicCostEstimate(Segment const & from, Segment cons
 {
   return RouteWeight(
       m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)),
-      0);
+      0 /* nontransitCross */);
 }
 
 RouteWeight IndexGraph::CalcSegmentWeight(Segment const & segment)
 {
   return RouteWeight(
-      m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId())), 0);
+      m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId())),
+      0 /* nontransitCross */);
 }
 
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
@@ -171,10 +172,10 @@ void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bo
 
 RouteWeight IndexGraph::GetPenalties(Segment const & u, Segment const & v)
 {
-  bool fromTransitAllowed = m_geometry.GetRoad(u.GetFeatureId()).IsTransitAllowed();
-  bool toTransitAllowed = m_geometry.GetRoad(v.GetFeatureId()).IsTransitAllowed();
+  bool const fromTransitAllowed = m_geometry.GetRoad(u.GetFeatureId()).IsTransitAllowed();
+  bool const toTransitAllowed = m_geometry.GetRoad(v.GetFeatureId()).IsTransitAllowed();
 
-  uint32_t transitPenalty = fromTransitAllowed == toTransitAllowed ? 0 : 1;
+  uint32_t const transitPenalty = fromTransitAllowed == toTransitAllowed ? 0 : 1;
 
   if (IsUTurn(u, v))
     return RouteWeight(m_estimator->GetUTurnPenalty(), transitPenalty);

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -83,7 +83,7 @@ private:
                            vector<SegmentEdge> & edges);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                           vector<SegmentEdge> & edges);
-  RouteWeight GetPenalties(Segment const & u, Segment const & v) const;
+  RouteWeight GetPenalties(Segment const & u, Segment const & v);
   m2::PointD const & GetPoint(Segment const & segment, bool front)
   {
     return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -80,7 +80,7 @@ public:
 
   // Checks |result| meets nontransit crossing restrictions according to placement of
   // |result.path| start and finish in transit/nontransit area and number of nontransit crosses
-  bool CheckRoutingResultMeetsRestrictions(
+  bool DoesRouteCrossNontransit(
       RoutingResult<Segment, RouteWeight> const & result) const;
 
   void GetEdgesList(Segment const & segment, bool isOutgoing,
@@ -100,7 +100,7 @@ public:
   {
     return RouteWeight(m_graph.GetEstimator().CalcHeuristic(GetPoint(from, true /* front */),
                                                             GetPoint(to, true /* front */)),
-                       0);
+                       0 /* nontransitCross */);
   }
 
   RouteWeight CalcSegmentWeight(Segment const & segment) const;

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/base/routing_result.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/joint.hpp"
 #include "routing/num_mwm_id.hpp"
@@ -77,6 +78,11 @@ public:
 
   std::set<NumMwmId> GetMwms() const;
 
+  // Checks |result| meets nontransit crossing restrictions according to placement of
+  // |result.path| start and finish in transit/nontransit area and number of nontransit crosses
+  bool CheckRoutingResultMeetsRestrictions(
+      RoutingResult<Segment, RouteWeight> const & result) const;
+
   void GetEdgesList(Segment const & segment, bool isOutgoing,
                     std::vector<SegmentEdge> & edges) const;
 
@@ -93,11 +99,12 @@ public:
   RouteWeight HeuristicCostEstimate(TVertexType const & from, TVertexType const & to) const
   {
     return RouteWeight(m_graph.GetEstimator().CalcHeuristic(GetPoint(from, true /* front */),
-                                                            GetPoint(to, true /* front */)));
+                                                            GetPoint(to, true /* front */)),
+                       0);
   }
 
-  double CalcSegmentWeight(Segment const & segment) const;
-  double CalcRouteSegmentWeight(std::vector<Segment> const & route, size_t segmentIndex) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment) const;
+  RouteWeight CalcRouteSegmentWeight(std::vector<Segment> const & route, size_t segmentIndex) const;
 
   bool IsLeap(NumMwmId mwmId) const;
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_progress.hpp"
+#include "routing/base/routing_result.hpp"
 #include "routing/bicycle_directions.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
@@ -521,6 +522,9 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
   if (result != IRouter::NoError)
     return result;
 
+  if (!starter.CheckRoutingResultMeetsRestrictions(routingResult))
+    return IRouter::RouteNotFound;
+
   IRouter::ResultCode const leapsResult =
       ProcessLeaps(routingResult.path, delegate, starter.GetGraph().GetMode(), starter, subroute);
   if (leapsResult != IRouter::NoError)
@@ -569,8 +573,7 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   for (size_t i = lastSubroute.GetBeginSegmentIdx(); i < lastSubroute.GetEndSegmentIdx(); ++i)
   {
     auto const & step = steps[i];
-    prevEdges.emplace_back(step.GetSegment(),
-                           RouteWeight(starter.CalcSegmentWeight(step.GetSegment())));
+    prevEdges.emplace_back(step.GetSegment(), starter.CalcSegmentWeight(step.GetSegment()));
   }
 
   uint32_t visitCount = 0;
@@ -592,7 +595,7 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   RoutingResult<Segment, RouteWeight> result;
   auto resultCode = ConvertResult<IndexGraphStarter>(
       algorithm.AdjustRoute(starter, starter.GetStartSegment(), prevEdges,
-                            RouteWeight(kAdjustLimitSec), result, delegate, onVisitJunction));
+                            RouteWeight(kAdjustLimitSec, 0), result, delegate, onVisitJunction));
   if (resultCode != IRouter::NoError)
     return resultCode;
 
@@ -774,7 +777,7 @@ IRouter::ResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
 
   for (size_t i = 0; i + 1 < numPoints; ++i)
   {
-    time += starter.CalcRouteSegmentWeight(segments, i);
+    time += starter.CalcRouteSegmentWeight(segments, i).GetWeight();
     times.emplace_back(static_cast<uint32_t>(i + 1), time);
   }
   

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -522,15 +522,15 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
   if (result != IRouter::NoError)
     return result;
 
-  if (!starter.CheckRoutingResultMeetsRestrictions(routingResult))
+  if (starter.DoesRouteCrossNontransit(routingResult))
     return IRouter::RouteNotFound;
 
   IRouter::ResultCode const leapsResult =
-      ProcessLeaps(routingResult.path, delegate, starter.GetGraph().GetMode(), starter, subroute);
+      ProcessLeaps(routingResult.m_path, delegate, starter.GetGraph().GetMode(), starter, subroute);
   if (leapsResult != IRouter::NoError)
     return leapsResult;
 
-  CHECK_GREATER_OR_EQUAL(subroute.size(), routingResult.path.size(), ());
+  CHECK_GREATER_OR_EQUAL(subroute.size(), routingResult.m_path.size(), ());
   return IRouter::NoError;
 }
 
@@ -593,20 +593,20 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 
   AStarAlgorithm<IndexGraphStarter> algorithm;
   RoutingResult<Segment, RouteWeight> result;
-  auto resultCode = ConvertResult<IndexGraphStarter>(
-      algorithm.AdjustRoute(starter, starter.GetStartSegment(), prevEdges,
-                            RouteWeight(kAdjustLimitSec, 0), result, delegate, onVisitJunction));
+  auto resultCode = ConvertResult<IndexGraphStarter>(algorithm.AdjustRoute(
+      starter, starter.GetStartSegment(), prevEdges,
+      RouteWeight(kAdjustLimitSec, 0 /* nontransitCross */), result, delegate, onVisitJunction));
   if (resultCode != IRouter::NoError)
     return resultCode;
 
-  CHECK_GREATER_OR_EQUAL(result.path.size(), 2, ());
-  CHECK(IndexGraphStarter::IsFakeSegment(result.path.front()), ());
-  CHECK(IndexGraphStarter::IsFakeSegment(result.path.back()), ());
+  CHECK_GREATER_OR_EQUAL(result.m_path.size(), 2, ());
+  CHECK(IndexGraphStarter::IsFakeSegment(result.m_path.front()), ());
+  CHECK(IndexGraphStarter::IsFakeSegment(result.m_path.back()), ());
 
   vector<Route::SubrouteAttrs> subroutes;
   PushPassedSubroutes(checkpoints, subroutes);
 
-  size_t subrouteOffset = result.path.size();
+  size_t subrouteOffset = result.m_path.size();
   subroutes.emplace_back(starter.GetStartJunction(), starter.GetFinishJunction(),
                          0 /* beginSegmentIdx */, subrouteOffset);
 
@@ -615,23 +615,23 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
     auto const & subroute = lastSubroutes[i];
 
     for (size_t j = subroute.GetBeginSegmentIdx(); j < subroute.GetEndSegmentIdx(); ++j)
-      result.path.push_back(steps[j].GetSegment());
+      result.m_path.push_back(steps[j].GetSegment());
 
     subroutes.emplace_back(subroute, subrouteOffset);
     subrouteOffset = subroutes.back().GetEndSegmentIdx();
   }
 
-  CHECK_EQUAL(result.path.size(), subrouteOffset, ());
+  CHECK_EQUAL(result.m_path.size(), subrouteOffset, ());
 
   route.SetCurrentSubrouteIdx(checkpoints.GetPassedIdx());
   route.SetSubroteAttrs(move(subroutes));
 
-  auto const redressResult = RedressRoute(result.path, delegate, starter, route);
+  auto const redressResult = RedressRoute(result.m_path, delegate, starter, route);
   if (redressResult != IRouter::NoError)
     return redressResult;
 
   LOG(LINFO, ("Adjust route, elapsed:", timer.ElapsedSeconds(), ", prev start:", checkpoints,
-              ", prev route:", steps.size(), ", new route:", result.path.size()));
+              ", prev route:", steps.size(), ", new route:", result.m_path.size()));
 
   return IRouter::NoError;
 }
@@ -746,10 +746,10 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 
     // Start and finish segments may be changed by starter.ConvertToReal. It was necessary to use it
     // in worldGraph but we need to reset them to original values.
-    routingResult.path.front() = input[i - 1];
-    routingResult.path.back() = input[i];
+    routingResult.m_path.front() = input[i - 1];
+    routingResult.m_path.back() = input[i];
 
-    output.insert(output.end(), routingResult.path.cbegin(), routingResult.path.cend());
+    output.insert(output.end(), routingResult.m_path.cbegin(), routingResult.m_path.cend());
   }
 
   return IRouter::NoError;

--- a/routing/road_graph_router.cpp
+++ b/routing/road_graph_router.cpp
@@ -199,19 +199,19 @@ IRouter::ResultCode RoadGraphRouter::CalculateRoute(Checkpoints const & checkpoi
 
   if (resultCode == IRoutingAlgorithm::Result::OK)
   {
-    ASSERT(!result.path.empty(), ());
-    ASSERT_EQUAL(result.path.front(), startPos, ());
-    ASSERT_EQUAL(result.path.back(), finalPos, ());
-    ASSERT_GREATER(result.distance, 0., ());
+    ASSERT(!result.m_path.empty(), ());
+    ASSERT_EQUAL(result.m_path.front(), startPos, ());
+    ASSERT_EQUAL(result.m_path.back(), finalPos, ());
+    ASSERT_GREATER(result.m_distance, 0., ());
 
     Route::TTimes times;
-    CalculateMaxSpeedTimes(*m_roadGraph, result.path, times);
+    CalculateMaxSpeedTimes(*m_roadGraph, result.m_path, times);
 
     CHECK(m_directionsEngine, ());
     route.SetSubroteAttrs(vector<Route::SubrouteAttrs>(
-        {Route::SubrouteAttrs(startPos, finalPos, 0, result.path.size() - 1)}));
+        {Route::SubrouteAttrs(startPos, finalPos, 0, result.m_path.size() - 1)}));
     ReconstructRoute(*m_directionsEngine, *m_roadGraph, nullptr /* trafficStash */, delegate,
-                     result.path, std::move(times), route);
+                     result.m_path, std::move(times), route);
   }
 
   m_roadGraph->ResetFakes();

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -1,17 +1,26 @@
 #include "routing/route_weight.hpp"
 
+#include "routing/cross_mwm_connector.hpp"
+
 using namespace std;
 
 namespace routing
 {
+double RouteWeight::ToCrossMwmWeight() const
+{
+  if (m_nontransitCross > 0)
+    return CrossMwmConnector::kNoRoute;
+  return GetWeight();
+}
+
 ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
 {
-  os << routeWeight.GetWeight();
+  os << "(" << routeWeight.GetNontransitCross() << ", " << routeWeight.GetWeight() << ")";
   return os;
 }
 
 RouteWeight operator*(double lhs, RouteWeight const & rhs)
 {
-  return RouteWeight(lhs * rhs.GetWeight());
+  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNontransitCross());
 }
 }  // namespace routing

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -2,7 +2,6 @@
 
 #include "routing/base/astar_weight.hpp"
 
-#include <cstdint>
 #include <iostream>
 #include <limits>
 
@@ -13,15 +12,19 @@ class RouteWeight final
 public:
   RouteWeight() = default;
 
-  constexpr RouteWeight(double weight, int32_t nontransitCross)
+  constexpr RouteWeight(double weight, int nontransitCross)
     : m_weight(weight), m_nontransitCross(nontransitCross)
   {
   }
 
-  double GetWeight() const { return m_weight; }
-  int32_t GetNontransitCross() const { return m_nontransitCross; }
-  static RouteWeight FromCrossMwmWeight(double weight) { return RouteWeight(weight, 0); }
+  static RouteWeight FromCrossMwmWeight(double weight)
+  {
+    return RouteWeight(weight, 0 /* nontransitCross */);
+  }
+
   double ToCrossMwmWeight() const;
+  double GetWeight() const { return m_weight; }
+  int GetNontransitCross() const { return m_nontransitCross; }
 
   bool operator<(RouteWeight const & rhs) const
   {
@@ -58,8 +61,10 @@ public:
   RouteWeight operator-() const { return RouteWeight(-m_weight, -m_nontransitCross); }
 
 private:
+  // Regular weight (seconds).
   double m_weight = 0.0;
-  int32_t m_nontransitCross = 0;
+  // Number of transit/nontransit area border cross.
+  int m_nontransitCross = 0;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
@@ -69,19 +74,20 @@ RouteWeight operator*(double lhs, RouteWeight const & rhs);
 template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
-  return RouteWeight(std::numeric_limits<double>::max(), std::numeric_limits<int32_t>::max());
+  return RouteWeight(std::numeric_limits<double>::max() /* weight */,
+                     std::numeric_limits<int>::max() /* nontransitCross */);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
 {
-  return RouteWeight(0.0, 0);
+  return RouteWeight(0.0 /* weight */, 0 /* nontransitCross */);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
 {
-  return RouteWeight(GetAStarWeightEpsilon<double>(), 0);
+  return RouteWeight(GetAStarWeightEpsilon<double>(), 0 /* nontransitCross */);
 }
 
 }  // namespace routing

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -2,6 +2,7 @@
 
 #include "routing/base/astar_weight.hpp"
 
+#include <cstdint>
 #include <iostream>
 #include <limits>
 
@@ -12,11 +13,22 @@ class RouteWeight final
 public:
   RouteWeight() = default;
 
-  constexpr explicit RouteWeight(double weight) : m_weight(weight) {}
+  constexpr RouteWeight(double weight, int32_t nontransitCross)
+    : m_weight(weight), m_nontransitCross(nontransitCross)
+  {
+  }
 
   double GetWeight() const { return m_weight; }
+  int32_t GetNontransitCross() const { return m_nontransitCross; }
+  static RouteWeight FromCrossMwmWeight(double weight) { return RouteWeight(weight, 0); }
+  double ToCrossMwmWeight() const;
 
-  bool operator<(RouteWeight const & rhs) const { return m_weight < rhs.m_weight; }
+  bool operator<(RouteWeight const & rhs) const
+  {
+    if (m_nontransitCross != rhs.m_nontransitCross)
+      return m_nontransitCross < rhs.m_nontransitCross;
+    return m_weight < rhs.m_weight;
+  }
 
   bool operator==(RouteWeight const & rhs) const { return !((*this) < rhs) && !(rhs < (*this)); }
 
@@ -28,24 +40,26 @@ public:
 
   RouteWeight operator+(RouteWeight const & rhs) const
   {
-    return RouteWeight(m_weight + rhs.m_weight);
+    return RouteWeight(m_weight + rhs.m_weight, m_nontransitCross + rhs.m_nontransitCross);
   }
 
   RouteWeight operator-(RouteWeight const & rhs) const
   {
-    return RouteWeight(m_weight - rhs.m_weight);
+    return RouteWeight(m_weight - rhs.m_weight, m_nontransitCross - rhs.m_nontransitCross);
   }
 
   RouteWeight & operator+=(RouteWeight const & rhs)
   {
     m_weight += rhs.m_weight;
+    m_nontransitCross += rhs.m_nontransitCross;
     return *this;
   }
 
-  RouteWeight operator-() const { return RouteWeight(-m_weight); }
+  RouteWeight operator-() const { return RouteWeight(-m_weight, -m_nontransitCross); }
 
 private:
   double m_weight = 0.0;
+  int32_t m_nontransitCross = 0;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
@@ -55,19 +69,19 @@ RouteWeight operator*(double lhs, RouteWeight const & rhs);
 template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
-  return RouteWeight(std::numeric_limits<double>::max());
+  return RouteWeight(std::numeric_limits<double>::max(), std::numeric_limits<int32_t>::max());
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
 {
-  return RouteWeight(0.0);
+  return RouteWeight(0.0, 0);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
 {
-  return RouteWeight(GetAStarWeightEpsilon<double>());
+  return RouteWeight(GetAStarWeightEpsilon<double>(), 0);
 }
 
 }  // namespace routing

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -76,6 +76,7 @@ HEADERS += \
     base/astar_algorithm.hpp \
     base/astar_weight.hpp \
     base/followed_polyline.hpp \
+    base/routing_result.hpp \
     bicycle_directions.hpp \
     checkpoint_predictor.hpp \
     checkpoints.hpp \

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -1,7 +1,8 @@
-#include "routing/road_graph.hpp"
 #include "routing/routing_algorithm.hpp"
+
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_progress.hpp"
+#include "routing/road_graph.hpp"
 
 #include "base/assert.hpp"
 

--- a/routing/routing_algorithm.hpp
+++ b/routing/routing_algorithm.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "base/cancellable.hpp"
-
+#include "routing/base/routing_result.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/router.hpp"
-#include "routing/base/astar_algorithm.hpp"
+
+#include "base/cancellable.hpp"
 
 #include "std/functional.hpp"
 #include "std/string.hpp"

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -68,13 +68,13 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 
   RoutingResult<unsigned /* VertexType */, double /* WeightType */> actualRoute;
   TEST_EQUAL(TAlgorithm::Result::OK, algo.FindPath(graph, 0u, 4u, actualRoute), ());
-  TEST_EQUAL(expectedRoute, actualRoute.path, ());
-  TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.distance, ());
+  TEST_EQUAL(expectedRoute, actualRoute.m_path, ());
+  TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.m_distance, ());
 
-  actualRoute.path.clear();
+  actualRoute.m_path.clear();
   TEST_EQUAL(TAlgorithm::Result::OK, algo.FindPathBidirectional(graph, 0u, 4u, actualRoute), ());
-  TEST_EQUAL(expectedRoute, actualRoute.path, ());
-  TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.distance, ());
+  TEST_EQUAL(expectedRoute, actualRoute.m_path, ());
+  TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.m_distance, ());
 }
 
 UNIT_TEST(AStarAlgorithm_Sample)
@@ -114,8 +114,8 @@ UNIT_TEST(AdjustRoute)
 
   vector<unsigned> const expectedRoute = {6, 2, 3, 4, 5};
   TEST_EQUAL(code, TAlgorithm::Result::OK, ());
-  TEST_EQUAL(result.path, expectedRoute, ());
-  TEST_EQUAL(result.distance, 4.0, ());
+  TEST_EQUAL(result.m_path, expectedRoute, ());
+  TEST_EQUAL(result.m_distance, 4.0, ());
 }
 
 UNIT_TEST(AdjustRouteNoPath)
@@ -134,7 +134,7 @@ UNIT_TEST(AdjustRouteNoPath)
                                my::Cancellable(), nullptr /* onVisitedVertexCallback */);
 
   TEST_EQUAL(code, TAlgorithm::Result::NoPath, ());
-  TEST(result.path.empty(), ());
+  TEST(result.m_path.empty(), ());
 }
 
 UNIT_TEST(AdjustRouteOutOfLimit)
@@ -155,6 +155,6 @@ UNIT_TEST(AdjustRouteOutOfLimit)
                                my::Cancellable(), nullptr /* onVisitedVertexCallback */);
 
   TEST_EQUAL(code, TAlgorithm::Result::NoPath, ());
-  TEST(result.path.empty(), ());
+  TEST(result.m_path.empty(), ());
 }
 }  // namespace routing_test

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -1,6 +1,8 @@
 #include "testing/testing.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
+#include "routing/base/routing_result.hpp"
+
 #include "std/map.hpp"
 #include "std/utility.hpp"
 #include "std/vector.hpp"

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -35,7 +35,7 @@ void TestAStarRouterMock(Junction const & startPos, Junction const & finalPos,
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
 
-  TEST_EQUAL(expected, result.path, ());
+  TEST_EQUAL(expected, result.m_path, ());
 }
 
 void AddRoad(RoadGraphMockSource & graph, double speedKMPH, initializer_list<m2::PointD> const & points)
@@ -103,7 +103,7 @@ UNIT_TEST(AStarRouter_SimpleGraph_RouteIsFound)
   TEST_EQUAL(TRoutingAlgorithm::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, delegate, result), ());
 
-  TEST_EQUAL(expected, result.path, ());
+  TEST_EQUAL(expected, result.m_path, ());
 }
 
 UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
@@ -234,14 +234,14 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad1)
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
   TEST_EQUAL(
-      result.path,
+      result.m_path,
       vector<Junction>(
           {MakeJunctionForTesting(m2::PointD(2, 2)), MakeJunctionForTesting(m2::PointD(2, 3)),
            MakeJunctionForTesting(m2::PointD(4, 3)), MakeJunctionForTesting(m2::PointD(6, 3)),
            MakeJunctionForTesting(m2::PointD(8, 3)), MakeJunctionForTesting(m2::PointD(10, 3)),
            MakeJunctionForTesting(m2::PointD(10, 2))}),
       ());
-  TEST(my::AlmostEqualAbs(result.distance, 800451., 1.), ("Distance error:", result.distance));
+  TEST(my::AlmostEqualAbs(result.m_distance, 800451., 1.), ("Distance error:", result.m_distance));
 }
 
 UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
@@ -268,11 +268,12 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
-                                            MakeJunctionForTesting(m2::PointD(6, 2)),
-                                            MakeJunctionForTesting(m2::PointD(10, 2))}),
+  TEST_EQUAL(result.m_path,
+             vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
+                               MakeJunctionForTesting(m2::PointD(6, 2)),
+                               MakeJunctionForTesting(m2::PointD(10, 2))}),
              ());
-  TEST(my::AlmostEqualAbs(result.distance, 781458., 1.), ("Distance error:", result.distance));
+  TEST(my::AlmostEqualAbs(result.m_distance, 781458., 1.), ("Distance error:", result.m_distance));
 }
 
 UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
@@ -299,10 +300,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
              algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
                                       MakeJunctionForTesting(m2::PointD(10, 2)), delegate, result),
              ());
-  TEST_EQUAL(result.path, vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
-                                            MakeJunctionForTesting(m2::PointD(2, 1)),
-                                            MakeJunctionForTesting(m2::PointD(10, 1)),
-                                            MakeJunctionForTesting(m2::PointD(10, 2))}),
-             ());
-  TEST(my::AlmostEqualAbs(result.distance, 814412., 1.), ("Distance error:", result.distance));
+  TEST_EQUAL(
+      result.m_path,
+      vector<Junction>(
+          {MakeJunctionForTesting(m2::PointD(2, 2)), MakeJunctionForTesting(m2::PointD(2, 1)),
+           MakeJunctionForTesting(m2::PointD(10, 1)), MakeJunctionForTesting(m2::PointD(10, 2))}),
+      ());
+  TEST(my::AlmostEqualAbs(result.m_distance, 814412., 1.), ("Distance error:", result.m_distance));
 }

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -143,7 +143,7 @@ UNIT_TEST(TwoWayExit)
 
 UNIT_TEST(Serialization)
 {
-  RouteWeight constexpr kEdgesWeight = RouteWeight(4444.0);
+  double constexpr kEdgesWeight = 4444.0;
 
   vector<uint8_t> buffer;
   {
@@ -231,28 +231,25 @@ UNIT_TEST(Serialization)
        ());
 
   TestEdges(connector, Segment(mwmId, 10, 1, true /* forward */), true /* isOutgoing */,
-            {{Segment(mwmId, 20, 2, false /* forward */), kEdgesWeight}});
+            {{Segment(mwmId, 20, 2, false /* forward */),
+              RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 
   TestEdges(connector, Segment(mwmId, 20, 2, true /* forward */), true /* isOutgoing */,
-            {{Segment(mwmId, 20, 2, false /* forward */), kEdgesWeight}});
+            {{Segment(mwmId, 20, 2, false /* forward */),
+              RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 
-  TestEdges(connector, Segment(mwmId, 20, 2, false /* forward */), false /* isOutgoing */,
-            {{Segment(mwmId, 10, 1, true /* forward */), kEdgesWeight},
-             {Segment(mwmId, 20, 2, true /* forward */), kEdgesWeight}});
+  TestEdges(
+      connector, Segment(mwmId, 20, 2, false /* forward */), false /* isOutgoing */,
+      {{Segment(mwmId, 10, 1, true /* forward */), RouteWeight::FromCrossMwmWeight(kEdgesWeight)},
+       {Segment(mwmId, 20, 2, true /* forward */), RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 }
 
 UNIT_TEST(WeightsSerialization)
 {
   size_t constexpr kNumTransitions = 3;
-  vector<RouteWeight> const weights = {RouteWeight(4.0),
-                                       RouteWeight(20.0),
-                                       RouteWeight(CrossMwmConnector::kNoRoute),
-                                       RouteWeight(12.0),
-                                       RouteWeight(CrossMwmConnector::kNoRoute),
-                                       RouteWeight(40.0),
-                                       RouteWeight(48.0),
-                                       RouteWeight(24.0),
-                                       RouteWeight(12.0)};
+  vector<double> const weights = {
+      4.0,  20.0, CrossMwmConnector::kNoRoute, 12.0, CrossMwmConnector::kNoRoute, 40.0, 48.0,
+      24.0, 12.0};
   TEST_EQUAL(weights.size(), kNumTransitions * kNumTransitions, ());
 
   vector<uint8_t> buffer;
@@ -311,10 +308,10 @@ UNIT_TEST(WeightsSerialization)
     for (uint32_t exitId = 0; exitId < kNumTransitions; ++exitId)
     {
       auto const weight = weights[weightIdx];
-      if (weight != RouteWeight(CrossMwmConnector::kNoRoute))
+      if (weight != CrossMwmConnector::kNoRoute)
       {
         expectedEdges.emplace_back(Segment(mwmId, exitId, 1 /* segmentIdx */, false /* forward */),
-                                   weight);
+                                   RouteWeight::FromCrossMwmWeight(weight));
       }
       ++weightIdx;
     }

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -62,7 +62,9 @@ public:
   void Load(uint32_t featureId, routing::RoadGeometry & road) override;
 
   void AddRoad(uint32_t featureId, bool oneWay, float speed,
-               routing::RoadGeometry::Points const & points, bool transitAllowed = true);
+               routing::RoadGeometry::Points const & points);
+
+  void SetTransitAllowed(uint32_t featureId, bool transitAllowed);
 
 private:
   unordered_map<uint32_t, routing::RoadGeometry> m_roads;

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -62,7 +62,7 @@ public:
   void Load(uint32_t featureId, routing::RoadGeometry & road) override;
 
   void AddRoad(uint32_t featureId, bool oneWay, float speed,
-               routing::RoadGeometry::Points const & points);
+               routing::RoadGeometry::Points const & points, bool transitAllowed = true);
 
 private:
   unordered_map<uint32_t, routing::RoadGeometry> m_roads;

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -908,20 +908,20 @@ unique_ptr<WorldGraph> BuildNontransitGraph(bool transitStart, bool transitShort
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}}),
-                  transitStart /* transitAllowed */);
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}}));
+  loader->SetTransitAllowed(0 /* feature id */, transitStart);
   loader->AddRoad(1 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}}),
-                  transitShortWay /* transitAllowed */);
+                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}}));
+  loader->SetTransitAllowed(1 /* feature id */, transitShortWay);
   loader->AddRoad(2 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{2.0, 0.0}, {3.0, 0.0}}), true /* transitAllowed */);
+                  RoadGeometry::Points({{2.0, 0.0}, {3.0, 0.0}}));
   loader->AddRoad(3 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}), true /* transitAllowed */);
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}));
   loader->AddRoad(4 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 1.0}}),
-                  transitLongWay /* transitAllowed */);
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 1.0}}));
+  loader->SetTransitAllowed(4 /* feature id */, transitLongWay);
   loader->AddRoad(5 /* feature id */, false /* one way */, 1.0 /* speed */,
-                  RoadGeometry::Points({{2.0, 1.0}, {2.0, 0.0}}), true /* transitAllowed */);
+                  RoadGeometry::Points({{2.0, 1.0}, {2.0, 0.0}}));
 
   vector<Joint> const joints = {
       MakeJoint({{0 /* feature id */, 0 /* point id */}}), /* joint at point (0, 0) */

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -64,7 +64,7 @@ RouteWeight WorldGraph::HeuristicCostEstimate(Segment const & from, Segment cons
 {
   return RouteWeight(
       m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)),
-      0);
+      0 /* nontransitCross */);
 }
 
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
@@ -76,7 +76,7 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
     m2::PointD const & from = GetPoint(segment, true /* front */);
     m2::PointD const & to = GetPoint(twin, true /* front */);
     double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, RouteWeight(weight, 0));
+    edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
   }
 }
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -63,7 +63,8 @@ void WorldGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge
 RouteWeight WorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
 {
   return RouteWeight(
-      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)));
+      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)),
+      0);
 }
 
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
@@ -75,7 +76,7 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
     m2::PointD const & from = GetPoint(segment, true /* front */);
     m2::PointD const & to = GetPoint(twin, true /* front */);
     double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, RouteWeight(weight));
+    edges.emplace_back(twin, RouteWeight(weight, 0));
   }
 }
 

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		3462FDAD1DC1E5BF00906FD7 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3462FDAC1DC1E5BF00906FD7 /* libopening_hours.a */; };
 		349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */; };
 		349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */; };
+		405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 405F48DB1F6AD01C005BA81A /* routing_result.hpp */; };
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
@@ -338,6 +339,7 @@
 		349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = restrictions_serialization.hpp; sourceTree = "<group>"; };
 		34F558351DBF2A2600A4FC11 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34F558361DBF2A2600A4FC11 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
+		405F48DB1F6AD01C005BA81A /* routing_result.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result.hpp; sourceTree = "<group>"; };
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
@@ -640,6 +642,7 @@
 				671F58BC1B874EC80032311E /* followed_polyline.hpp */,
 				A1616E2D1B6B60B3003F078E /* astar_progress.hpp */,
 				A120B3521B4A7C1C002F3808 /* astar_algorithm.hpp */,
+				405F48DB1F6AD01C005BA81A /* routing_result.hpp */,
 			);
 			path = base;
 			sourceTree = "<group>";
@@ -1002,6 +1005,7 @@
 				A120B3511B4A7C0A002F3808 /* routing_algorithm.hpp in Headers */,
 				0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */,
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
+				405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */,
 				56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */,
 				0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */,
 				670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */,


### PR DESCRIPTION
Добавила в многокомпонетнтный RouteWeight компонент, отвечающий за количество пересечений границы транзитной и нетранзитной зоны, добавила штраф за пересечение нетранзитной зоны в IndexRouter, добавила в IndexGraphStarter метод, проверяющий допустимость маршрута исходя из количества пересечений границы транзит/нетранзит и положения старта и финиша.
Cross-mwm вес был смесью RouteWeight и double, оставила double, так как этот вес не может иметь в себе никаких пересечений нетранзитных зон, шлагбаумов и т.п. (если были пересечения нетранзитных зон, то это CrossMwmConnector::kNoRoute).