### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/routing/fake_edges_container.hpp
+++ b/routing/fake_edges_container.hpp
@@ -20,7 +20,13 @@ public:
   {
   }
 
-  size_t GetNumFakeEdges() const { return m_fake.m_segmentToVertex.size(); }
+  uint32_t GetNumFakeEdges() const
+  {
+    // Maximal number of fake segments in fake graph is numeric_limits<uint32_t>::max()
+    // because segment idx type is uint32_t.
+    CHECK_LESS_OR_EQUAL(m_fake.m_segmentToVertex.size(), numeric_limits<uint32_t>::max(), ());
+    return static_cast<uint32_t>(m_fake.m_segmentToVertex.size());
+  }
 
 private:
   // finish segment id

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -78,7 +78,7 @@ Segment IndexGraphStarter::FakeGraph::GetSegment(FakeVertex const & vertex,
       return kv.first;
   }
 
-  return GetFakeSegment(newNumber++);
+  return GetFakeSegmentAndIncr(newNumber);
 }
 
 void IndexGraphStarter::FakeGraph::Append(FakeGraph const & rhs)
@@ -298,14 +298,14 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
     otherSegments[p.m_segment] = p.m_junction;
 
   // Add pure fake vertex
-  auto const fakeSegment = GetFakeSegment(fakeNumerationStart++);
+  auto const fakeSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
   FakeVertex fakeVertex(thisEnding.m_originJunction, thisEnding.m_originJunction,
                         FakeVertex::Type::PureFake);
   m_fake.m_segmentToVertex[fakeSegment] = fakeVertex;
   for (auto const & projection : thisEnding.m_projections)
   {
     // Add projection edges
-    auto const projectionSegment = GetFakeSegment(fakeNumerationStart++);
+    auto const projectionSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
     FakeVertex projectionVertex(isStart ? thisEnding.m_originJunction : projection.m_junction,
                                 isStart ? projection.m_junction : thisEnding.m_originJunction,
                                 FakeVertex::Type::PureFake);

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -73,7 +73,13 @@ public:
   Junction const & GetJunction(Segment const & segment, bool front) const;
   Junction const & GetRouteJunction(std::vector<Segment> const & route, size_t pointIndex) const;
   m2::PointD const & GetPoint(Segment const & segment, bool front) const;
-  size_t GetNumFakeSegments() const { return m_fake.m_segmentToVertex.size(); }
+  uint32_t GetNumFakeSegments() const
+  {
+    // Maximal number of fake segments in fake graph is numeric_limits<uint32_t>::max()
+    // because segment idx type is uint32_t.
+    CHECK_LESS_OR_EQUAL(m_fake.m_segmentToVertex.size(), numeric_limits<uint32_t>::max(), ());
+    return static_cast<uint32_t>(m_fake.m_segmentToVertex.size());
+  }
 
   std::set<NumMwmId> GetMwms() const;
 
@@ -172,6 +178,12 @@ private:
   static Segment GetFakeSegment(uint32_t segmentIdx)
   {
     return Segment(kFakeNumMwmId, kFakeFeatureId, segmentIdx, false);
+  }
+
+  static Segment GetFakeSegmentAndIncr(uint32_t & segmentIdx)
+  {
+    CHECK_LESS(segmentIdx, numeric_limits<uint32_t>::max(), ());
+    return GetFakeSegment(segmentIdx++);
   }
 
   // Creates fake edges for fake ending and adds it to  fake graph. |otherEnding| used to generate


### PR DESCRIPTION
Значение, возвращаемое из GetNumFakeSegments, далее используется в конструкторе IndexGraphStarter как id следующего сегмента, оно не должно превышать `numeric_limits<uint32_t>::max()` -- это максимальное количество фейковых сегментов, т.к. id сегмента имеет тип uint32_t.