### PR TITLE
fix TestRouteGeometry: check CalculateRoute return value even we expect Result::NoPath

### DIFF
--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -300,6 +300,8 @@ void TestRouteGeometry(IndexGraphStarter & starter,
   double timeSec = 0.0;
   auto const resultCode = CalculateRoute(starter, routeSegs, timeSec);
 
+  TEST_EQUAL(resultCode, expectedRouteResult, ());
+
   if (AStarAlgorithm<IndexGraphStarter>::Result::NoPath == expectedRouteResult &&
       expectedRouteGeom.empty())
   {
@@ -308,7 +310,6 @@ void TestRouteGeometry(IndexGraphStarter & starter,
     return;
   }
 
-  TEST_EQUAL(resultCode, expectedRouteResult, ());
   if (resultCode != AStarAlgorithm<IndexGraphStarter>::Result::OK)
     return;
 


### PR DESCRIPTION
При ожидаемом результате `Result::NoPath` не проверялось соответствие `resultCode`, возвращенного из `CalculateRoute`, ожидаемому результату (тест не фейлился, если ожидается `Result::NoPath`, а маршрут нашёлся).