### PR TITLE
Fix fake PartOfReal ends for backward segments

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -313,10 +313,8 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
                          false /* isPartOfReal */, dummy /* realSegment */);
 
     // Add fake parts of real
-    auto frontJunction =
-        m_graph.GetJunction(projection.m_segment, projection.m_segment.IsForward());
-    auto backJunction =
-        m_graph.GetJunction(projection.m_segment, !projection.m_segment.IsForward());
+    auto frontJunction = m_graph.GetJunction(projection.m_segment, true /* front */);
+    auto backJunction = m_graph.GetJunction(projection.m_segment, false /* front */);
 
     // Check whether we have projections to same real segment from both endings.
     auto const it = otherSegments.find(projection.m_segment);


### PR DESCRIPTION
MAPSME-5630: направление сегмента учитывалось дважды: GetJunction уже учитывает IsForward.