### PR TITLE
Fix qmake directory detection for brew package installer on MacOSX.

### DIFF
--- a/tools/autobuild/detect_qmake.sh
+++ b/tools/autobuild/detect_qmake.sh
@@ -8,6 +8,7 @@ set -e -u
 KNOWN_QMAKE_PATHS=( \
   /Developer/Tools/qmake \
   /usr/local/opt/qt5/bin/qmake \
+  /usr/local/opt/qt@5.?/bin/qmake \
   ~/Developer/Qt/5.?/clang_64/bin/qmake \
   ~/Qt/5.?/clang_64/bin/qmake \
   ~/Qt5.?.0/5.?/clang_64/bin/qmake \


### PR DESCRIPTION
Brew installs qt with specific version in /usr/local/opt/qt@5.?/ 
This path is not specified in detect_qmake.sh, that causes problem with building project.