### PR TITLE
Add sk lang in strings-tts

### DIFF
--- a/android/res/values/strings-tts.xml
+++ b/android/res/values/strings-tts.xml
@@ -40,6 +40,7 @@
     <item>nl</item>
     <item>pl</item>
     <item>ro</item>
+    <item>sk</item>
     <item>fa</item>
     <item>uk</item>
     <item>vi</item>
@@ -71,6 +72,7 @@
     <item>Nederlands</item>
     <item>Polski</item>
     <item>Română</item>
+    <item>Slovenčina</item>
     <item>فارسی</item>
     <item>Українська</item>
     <item>Tiếng Việt</item>


### PR DESCRIPTION
TTS voice is translated for Slovak language, but it was disabled.