### PR TITLE
Convert WorldGraph into base class

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -118,6 +118,8 @@ set(
   segment.hpp
   segmented_route.cpp
   segmented_route.hpp
+  single_vehicle_world_graph.cpp
+  single_vehicle_world_graph.hpp
   speed_camera.cpp
   speed_camera.hpp
   traffic_stash.cpp

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -742,8 +742,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     else
     {
       // Single mwm route.
-      IndexGraph & indexGraph = worldGraph.GetIndexGraph(current.GetMwmId());
-      result = FindPath(current, next, delegate, indexGraph, {} /* onVisitedVertexCallback */, routingResult);
+      worldGraph.SetSingleMwmMode(current.GetMwmId());
+      result = FindPath(current, next, delegate, worldGraph, {} /* onVisitedVertexCallback */, routingResult);
+      worldGraph.UnsetSingleMwmMode();
     }
     if (result != IRouter::NoError)
       return result;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -82,7 +82,7 @@ private:
                                   m2::PointD const & startDirection,
                                   RouterDelegate const & delegate, Route & route);
 
-  WorldGraph MakeWorldGraph();
+  std::unique_ptr<WorldGraph> MakeWorldGraph();
 
   /// \brief Finds the best segment (edge) which may be considered as the start of the finish of the route.
   /// According to current implementation if a segment is near |point| and is almost codirectional

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -61,6 +61,7 @@ SOURCES += \
     routing_session.cpp \
     routing_settings.cpp \
     segmented_route.cpp \
+    single_vehicle_world_graph.cpp \
     speed_camera.cpp \
     traffic_stash.cpp \
     turns.cpp \
@@ -133,6 +134,7 @@ HEADERS += \
     routing_settings.hpp \
     segment.hpp \
     segmented_route.hpp \
+    single_vehicle_world_graph.hpp \
     speed_camera.hpp \
     traffic_stash.hpp \
     transition_points.hpp \

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -36,7 +36,7 @@ using namespace std;
 //   0       1      2       3
 //                Start
 // Note. This graph contains of 6 one segment directed features.
-unique_ptr<WorldGraph> BuildXYGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildXYGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
@@ -193,7 +193,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
 //   0       1      2       3
 //                Start
 // Note. This graph contains of 9 one segment directed features.
-unique_ptr<WorldGraph> BuildXXGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildXXGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -585,7 +585,7 @@ UNIT_TEST(SerializeSimpleGraph)
 // 0                          * Start
 //   0         0.0001       0.0002
 // F0 is a two-way feature with a loop and F1 and F2 are an one-way one-segment features.
-unique_ptr<WorldGraph> BuildLoopGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildLoopGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* one way */, 100.0 /* speed */,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -179,7 +179,7 @@ void TestIndexGraphTopology::AddDirectedEdge(vector<EdgeRequest> & edgeRequests,
 }
 
 // TestIndexGraphTopology::Builder -----------------------------------------------------------------
-unique_ptr<WorldGraph> TestIndexGraphTopology::Builder::PrepareIndexGraph()
+unique_ptr<SingleVehicleWorldGraph> TestIndexGraphTopology::Builder::PrepareIndexGraph()
 {
   auto loader = make_unique<ZeroGeometryLoader>();
   auto estimator = make_shared<WeightedEdgeEstimator>(m_segmentWeights);
@@ -242,26 +242,28 @@ void TestIndexGraphTopology::Builder::BuildSegmentFromEdge(EdgeRequest const & r
 }
 
 // Functions ---------------------------------------------------------------------------------------
-unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,
-                                       shared_ptr<EdgeEstimator> estimator,
-                                       vector<Joint> const & joints)
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,
+                                                    shared_ptr<EdgeEstimator> estimator,
+                                                    vector<Joint> const & joints)
 {
   auto graph = make_unique<IndexGraph>(move(geometryLoader), estimator);
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
-  return make_unique<WorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader), estimator);
+  return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
+                                              estimator);
 }
 
-unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoader> geometryLoader,
-                                       shared_ptr<EdgeEstimator> estimator,
-                                       vector<Joint> const & joints)
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoader> geometryLoader,
+                                                    shared_ptr<EdgeEstimator> estimator,
+                                                    vector<Joint> const & joints)
 {
   auto graph = make_unique<IndexGraph>(move(geometryLoader), estimator);
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
-  return make_unique<WorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader), estimator);
+  return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
+                                              estimator);
 }
 
 Joint MakeJoint(vector<RoadPoint> const & points)

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -187,7 +187,7 @@ unique_ptr<WorldGraph> TestIndexGraphTopology::Builder::PrepareIndexGraph()
   BuildJoints();
 
   auto worldGraph = BuildWorldGraph(move(loader), estimator, m_joints);
-  worldGraph->GetIndexGraph(kTestNumMwmId).SetRoadAccess(move(m_roadAccess));
+  worldGraph->GetIndexGraphForTests(kTestNumMwmId).SetRoadAccess(move(m_roadAccess));
   return worldGraph;
 }
 

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -48,7 +48,7 @@ struct RestrictionTest
 
   void SetRestrictions(RestrictionVec && restrictions)
   {
-    m_graph->GetIndexGraph(kTestNumMwmId).SetRestrictions(move(restrictions));
+    m_graph->GetIndexGraphForTests(kTestNumMwmId).SetRestrictions(move(restrictions));
   }
 
   unique_ptr<WorldGraph> m_graph;

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -9,6 +9,7 @@
 #include "routing/road_access.hpp"
 #include "routing/road_point.hpp"
 #include "routing/segment.hpp"
+#include "routing/single_vehicle_world_graph.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
 
@@ -38,7 +39,7 @@ NumMwmId constexpr kTestNumMwmId = 777;
 struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }
-  void Init(unique_ptr<WorldGraph> graph) { m_graph = move(graph); }
+  void Init(unique_ptr<SingleVehicleWorldGraph> graph) { m_graph = move(graph); }
   void SetStarter(IndexGraphStarter::FakeEnding const & start,
                   IndexGraphStarter::FakeEnding const & finish)
   {
@@ -51,7 +52,7 @@ struct RestrictionTest
     m_graph->GetIndexGraphForTests(kTestNumMwmId).SetRestrictions(move(restrictions));
   }
 
-  unique_ptr<WorldGraph> m_graph;
+  unique_ptr<SingleVehicleWorldGraph> m_graph;
   unique_ptr<IndexGraphStarter> m_starter;
 };
 
@@ -154,7 +155,7 @@ private:
   struct Builder
   {
     Builder(uint32_t numVertices) : m_numVertices(numVertices) {}
-    unique_ptr<WorldGraph> PrepareIndexGraph();
+    unique_ptr<SingleVehicleWorldGraph> PrepareIndexGraph();
     void BuildJoints();
     void BuildGraphFromRequests(vector<EdgeRequest> const & requests);
     void BuildSegmentFromEdge(EdgeRequest const & request);
@@ -176,12 +177,12 @@ private:
   vector<EdgeRequest> m_edgeRequests;
 };
 
-unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> loader,
-                                       shared_ptr<EdgeEstimator> estimator,
-                                       vector<Joint> const & joints);
-unique_ptr<WorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoader> loader,
-                                       shared_ptr<EdgeEstimator> estimator,
-                                       vector<Joint> const & joints);
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> loader,
+                                                    shared_ptr<EdgeEstimator> estimator,
+                                                    vector<Joint> const & joints);
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoader> loader,
+                                                    shared_ptr<EdgeEstimator> estimator,
+                                                    vector<Joint> const & joints);
 
 routing::Joint MakeJoint(vector<routing::RoadPoint> const & points);
 

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -200,7 +200,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionOnlyF5F3)
   RestrictionVec restrictionsOnly = {
       {Restriction::Type::Only, {5 /* feature from */, 3 /* feature to */}}};
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
   vector<m2::PointD> const expectedGeom = {
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
@@ -312,7 +312,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F1Only)
   RestrictionVec restrictionsOnly = {
       {Restriction::Type::Only, {3 /* feature from */, 1 /* feature to */}}};
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
   vector<m2::PointD> const expectedGeom = {
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 1}, {0, 2}, {0, 3}};
@@ -410,7 +410,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3Only)
   RestrictionVec restrictionsOnly = {
       {Restriction::Type::Only, {10 /* feature from */, 3 /* feature to */}}};
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {
@@ -432,7 +432,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3OnlyF3F4Only)
       {Restriction::Type::Only, {3 /* feature from */, 4 /* feature to */}},
       {Restriction::Type::Only, {10 /* feature from */, 3 /* feature to */}}};
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {
@@ -455,7 +455,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF2F8NoRestrictionF9F
   RestrictionVec const restrictionsOnly = {
       {Restriction::Type::Only,
        {9 /* feature from */, 1 /* feature to */}}};  // Invalid restriction.
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 1}, {0, 2}, {0, 3}};
@@ -664,7 +664,7 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F1Only)
   RestrictionVec restrictionsOnly = {
       {Restriction::Type::Only, {0 /* feature from */, 1 /* feature to */}}};
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraph(kTestNumMwmId), restrictionsOnly,
+  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -32,7 +32,7 @@ using namespace routing;
 //                              | |
 //                              ⌄ |
 //                               *
-unique_ptr<WorldGraph> BuildCrossGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildCrossGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
@@ -113,7 +113,7 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
 // 0 *<--F3---<--F3---*<--F5--* Start
 //   0        1       2       3
 // Note. F0, F1 and F2 are one segment features. F3 is a two segments feature.
-unique_ptr<WorldGraph> BuildTriangularGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildTriangularGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
@@ -248,7 +248,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2RestrictionOnl
 // 0 *---F1--*--F1--*--F3---* Start
 //   0       1      2       3
 // Note. All features are two setments and two-way.
-unique_ptr<WorldGraph> BuildTwowayCornerGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildTwowayCornerGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* oneWay */, 1.0 /* speed */,
@@ -344,7 +344,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F1Only)
 // 0 *<----F4---*<---F3----*<--F10---* Start
 //   0          1          2         3
 // Note. F1 and F2 are two segments features. The others are one segment ones.
-unique_ptr<WorldGraph> BuildTwoSquaresGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildTwoSquaresGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, true /* oneWay */, 1.0 /* speed */,
@@ -481,7 +481,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF2F8NoRestrictionF9F
 //   0         1        2
 // Note 1. All features are two-way. (It's possible to move along any direction of the features.)
 // Note 2. Any feature contains of one segment.
-unique_ptr<WorldGraph> BuildFlagGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildFlagGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,
@@ -590,7 +590,7 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F
 //   0         1        2
 // Note 1. All features except for F7 are two-way.
 // Note 2. Any feature contains of one segment.
-unique_ptr<WorldGraph> BuildPosterGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildPosterGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,
@@ -735,7 +735,7 @@ UNIT_TEST(TwoWayGraph)
 //   0        1        2         3
 // Note 1. F0, F1 and F5 are one-way features. F3, F2 and F4 are two-way features.
 // Note 2. Any feature contains of one segment.
-unique_ptr<WorldGraph> BuildSquaresGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildSquaresGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
@@ -801,7 +801,7 @@ UNIT_CLASS_TEST(RestrictionTest, SquaresGraph_RestrictionF0F1OnlyF1F5Only)
 // 0 Start *--F0--->*---F1---*---F1---*---F1---*---F2-->* Finish
 //         0        1        2        3        4        5
 // Note. F0 and F2 are one segment one-way features. F1 is a 3 segment two-way feature.
-unique_ptr<WorldGraph> BuildLineGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildLineGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
@@ -855,7 +855,7 @@ UNIT_CLASS_TEST(RestrictionTest, LineGraph_RestrictionF1F1No)
 // 0 *
 //   0        1
 //  Start
-unique_ptr<WorldGraph> BuildFGraph()
+unique_ptr<SingleVehicleWorldGraph> BuildFGraph()
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
@@ -903,8 +903,8 @@ UNIT_CLASS_TEST(RestrictionTest, FGraph_RestrictionF0F2Only)
 //                  |        |
 // 0 Start *---F0---*---F1---*---F2---* Finish
 //         0        1        2        3
-unique_ptr<WorldGraph> BuildNontransitGraph(bool transitStart, bool transitShortWay,
-                                            bool transitLongWay)
+unique_ptr<SingleVehicleWorldGraph> BuildNontransitGraph(bool transitStart, bool transitShortWay,
+                                                         bool transitLongWay)
 {
   unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
   loader->AddRoad(0 /* feature id */, false /* one way */, 1.0 /* speed */,

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -1,0 +1,130 @@
+#include "routing/single_vehicle_world_graph.hpp"
+
+#include <utility>
+
+namespace routing
+{
+using namespace std;
+
+SingleVehicleWorldGraph::SingleVehicleWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
+                                                 unique_ptr<IndexGraphLoader> loader,
+                                                 shared_ptr<EdgeEstimator> estimator)
+  : m_crossMwmGraph(move(crossMwmGraph)), m_loader(move(loader)), m_estimator(estimator)
+{
+  CHECK(m_loader, ());
+  CHECK(m_estimator, ());
+}
+
+void SingleVehicleWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+                                          bool isEnding, vector<SegmentEdge> & edges)
+{
+  // If mode is LeapsOnly and |isEnding| == true we need to connect segment to transitions.
+  // If |isOutgoing| == true connects |segment| with all exits of mwm.
+  // If |isOutgoing| == false connects all enters to mwm with |segment|.
+  if (m_mode == Mode::LeapsOnly && isEnding)
+  {
+    edges.clear();
+    m2::PointD const & segmentPoint = GetPoint(segment, true /* front */);
+
+    // Note. If |isOutgoing| == true it's necessary to add edges which connect the start with all
+    // exits of its mwm. So |isEnter| below should be set to false.
+    // If |isOutgoing| == false all enters of the finish mwm should be connected with the finish
+    // point. So |isEnter| below should be set to true.
+    m_crossMwmGraph->ForEachTransition(
+        segment.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
+          edges.emplace_back(transition,
+                             CalcLeapWeight(segmentPoint, GetPoint(transition, isOutgoing)));
+        });
+    return;
+  }
+
+  if (m_mode != Mode::NoLeaps && m_mode != Mode::SingleMwm && (isLeap || m_mode == Mode::LeapsOnly))
+  {
+    CHECK(m_crossMwmGraph, ());
+    if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
+      GetTwins(segment, isOutgoing, edges);
+    else
+      m_crossMwmGraph->GetEdgeList(segment, isOutgoing, edges);
+    return;
+  }
+
+  IndexGraph & indexGraph = m_loader->GetIndexGraph(segment.GetMwmId());
+  indexGraph.GetEdgeList(segment, isOutgoing, edges);
+
+  if (m_mode != Mode::SingleMwm && m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
+    GetTwins(segment, isOutgoing, edges);
+}
+
+Junction const & SingleVehicleWorldGraph::GetJunction(Segment const & segment, bool front)
+{
+  return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
+      .GetJunction(segment.GetPointId(front));
+}
+
+m2::PointD const & SingleVehicleWorldGraph::GetPoint(Segment const & segment, bool front)
+{
+  return GetJunction(segment, front).GetPoint();
+}
+
+RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
+{
+  return m_loader->GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+}
+
+void SingleVehicleWorldGraph::GetOutgoingEdgesList(Segment const & segment,
+                                                   vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, true /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
+}
+
+void SingleVehicleWorldGraph::GetIngoingEdgesList(Segment const & segment,
+                                                  vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, false /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
+}
+
+RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+{
+  return HeuristicCostEstimate(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+}
+
+RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(m2::PointD const & from,
+                                                           m2::PointD const & to)
+{
+  return RouteWeight(m_estimator->CalcHeuristic(from, to), 0 /* nontransitCross */);
+}
+
+RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment)
+{
+  return RouteWeight(m_estimator->CalcSegmentWeight(
+                         segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())),
+                     0 /* nontransitCross */);
+}
+
+RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(m2::PointD const & from,
+                                                    m2::PointD const & to) const
+{
+  return RouteWeight(m_estimator->CalcLeapWeight(from, to), 0 /* nontransitCross */);
+}
+
+bool SingleVehicleWorldGraph::LeapIsAllowed(NumMwmId mwmId) const
+{
+  return m_estimator->LeapIsAllowed(mwmId);
+}
+
+void SingleVehicleWorldGraph::GetTwins(Segment const & segment, bool isOutgoing,
+                                       vector<SegmentEdge> & edges)
+{
+  m_twins.clear();
+  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
+  for (Segment const & twin : m_twins)
+  {
+    m2::PointD const & from = GetPoint(segment, true /* front */);
+    m2::PointD const & to = GetPoint(twin, true /* front */);
+    double const weight = m_estimator->CalcHeuristic(from, to);
+    edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
+  }
+}
+}  // namespace routing

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "routing/cross_mwm_graph.hpp"
+#include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/index_graph_loader.hpp"
+#include "routing/num_mwm_id.hpp"
+#include "routing/road_graph.hpp"
+#include "routing/segment.hpp"
+#include "routing/world_graph.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace routing
+{
+class SingleVehicleWorldGraph final : public WorldGraph
+{
+public:
+  SingleVehicleWorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
+                          std::unique_ptr<IndexGraphLoader> loader,
+                          std::shared_ptr<EdgeEstimator> estimator);
+
+  // WorldGraph overrides:
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+                   std::vector<SegmentEdge> & edges) override;
+  Junction const & GetJunction(Segment const & segment, bool front) override;
+  m2::PointD const & GetPoint(Segment const & segment, bool front) override;
+  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId) override;
+  void ClearCachedGraphs() override { m_loader->Clear(); }
+  void SetMode(Mode mode) override { m_mode = mode; }
+  Mode GetMode() const override { return m_mode; }
+  void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+  void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
+  RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  bool LeapIsAllowed(NumMwmId mwmId) const override;
+
+  // This method should be used for tests only
+  IndexGraph & GetIndexGraphForTests(NumMwmId numMwmId)
+  {
+    return m_loader->GetIndexGraph(numMwmId);
+  }
+
+private:
+  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+
+  std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
+  std::unique_ptr<IndexGraphLoader> m_loader;
+  std::shared_ptr<EdgeEstimator> m_estimator;
+  std::vector<Segment> m_twins;
+  Mode m_mode = Mode::NoLeaps;
+};
+}  // namespace routing

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -15,6 +15,12 @@ WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph, unique_ptr<Index
 void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                              bool isEnding, std::vector<SegmentEdge> & edges)
 {
+  if (IsInSingleMwmMode())
+  {
+    m_loader->GetIndexGraph(m_mwmId).GetEdgeList(segment, isOutgoing, edges);
+    return;
+  }
+
   // If mode is LeapsOnly and |isEnding| == true we need to connect segment to transitions.
   // If |isOutgoing| == true connects |segment| with all exits of mwm.
   // If |isOutgoing| == false connects all enters to mwm with |segment|.
@@ -45,7 +51,7 @@ void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLe
     return;
   }
 
-  IndexGraph & indexGraph = GetIndexGraph(segment.GetMwmId());
+  IndexGraph & indexGraph = m_loader->GetIndexGraph(segment.GetMwmId());
   indexGraph.GetEdgeList(segment, isOutgoing, edges);
 
   if (m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
@@ -65,7 +71,7 @@ m2::PointD const & WorldGraph::GetPoint(Segment const & segment, bool front)
 
 RoadGeometry const & WorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
-  return GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+  return m_loader->GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
 }
 
 void WorldGraph::GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,130 +4,6 @@ namespace routing
 {
 using namespace std;
 
-WorldGraph::WorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph, unique_ptr<IndexGraphLoader> loader,
-                       shared_ptr<EdgeEstimator> estimator)
-  : m_crossMwmGraph(move(crossMwmGraph)), m_loader(move(loader)), m_estimator(estimator)
-{
-  CHECK(m_loader, ());
-  CHECK(m_estimator, ());
-}
-
-void WorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
-                             bool isEnding, std::vector<SegmentEdge> & edges)
-{
-  if (IsInSingleMwmMode())
-  {
-    m_loader->GetIndexGraph(m_mwmId).GetEdgeList(segment, isOutgoing, edges);
-    return;
-  }
-
-  // If mode is LeapsOnly and |isEnding| == true we need to connect segment to transitions.
-  // If |isOutgoing| == true connects |segment| with all exits of mwm.
-  // If |isOutgoing| == false connects all enters to mwm with |segment|.
-  if (m_mode == Mode::LeapsOnly && isEnding)
-  {
-    edges.clear();
-    m2::PointD const & segmentPoint = GetPoint(segment, true /* front */);
-  
-    // Note. If |isOutgoing| == true it's necessary to add edges which connect the start with all
-    // exits of its mwm. So |isEnter| below should be set to false.
-    // If |isOutgoing| == false all enters of the finish mwm should be connected with the finish
-    // point. So |isEnter| below should be set to true.
-    m_crossMwmGraph->ForEachTransition(
-                            segment.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
-                              edges.emplace_back(transition, CalcLeapWeight(segmentPoint,
-                                                                            GetPoint(transition, isOutgoing)));
-                            });
-    return;
-  }
-
-  if (m_mode != Mode::NoLeaps && (isLeap || m_mode == Mode::LeapsOnly))
-  {
-    CHECK(m_crossMwmGraph, ());
-    if (m_crossMwmGraph->IsTransition(segment, isOutgoing))
-      GetTwins(segment, isOutgoing, edges);
-    else
-      m_crossMwmGraph->GetEdgeList(segment, isOutgoing, edges);
-    return;
-  }
-
-  IndexGraph & indexGraph = m_loader->GetIndexGraph(segment.GetMwmId());
-  indexGraph.GetEdgeList(segment, isOutgoing, edges);
-
-  if (m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
-    GetTwins(segment, isOutgoing, edges);
-}
-
-Junction const & WorldGraph::GetJunction(Segment const & segment, bool front)
-{
-  return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
-      .GetJunction(segment.GetPointId(front));
-}
-
-m2::PointD const & WorldGraph::GetPoint(Segment const & segment, bool front)
-{
-  return GetJunction(segment, front).GetPoint();
-}
-
-RoadGeometry const & WorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
-{
-  return m_loader->GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
-}
-
-void WorldGraph::GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
-{
-  edges.clear();
-  GetEdgeList(segment, true /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
-}
-
-void WorldGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
-{
-  edges.clear();
-  GetEdgeList(segment, false /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
-}
-
-RouteWeight WorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
-{
-  return HeuristicCostEstimate(GetPoint(from, true /* front */),
-                               GetPoint(to, true /* front */));
-}
-
-RouteWeight WorldGraph::HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to)
-{
-  return RouteWeight(m_estimator->CalcHeuristic(from, to), 0 /* nontransitCross */);
-}
-
-
-RouteWeight WorldGraph::CalcSegmentWeight(Segment const & segment)
-{
-  return RouteWeight(
-      m_estimator->CalcSegmentWeight(segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())),
-      0 /* nontransitCross */);
-}
-
-RouteWeight WorldGraph::CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const
-{
-  return RouteWeight(m_estimator->CalcLeapWeight(from, to), 0 /* nontransitCross */);
-}
-
-bool WorldGraph::LeapIsAllowed(NumMwmId mwmId) const
-{
-  return m_estimator->LeapIsAllowed(mwmId);
-}
-
-void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
-{
-  m_twins.clear();
-  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
-  for (Segment const & twin : m_twins)
-  {
-    m2::PointD const & from = GetPoint(segment, true /* front */);
-    m2::PointD const & to = GetPoint(twin, true /* front */);
-    double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
-  }
-}
-
 string DebugPrint(WorldGraph::Mode mode)
 {
   switch (mode)
@@ -135,6 +11,7 @@ string DebugPrint(WorldGraph::Mode mode)
   case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
   case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
   case WorldGraph::Mode::NoLeaps: return "NoLeaps";
+  case WorldGraph::Mode::SingleMwm: return "SingleMwm";
   }
   ASSERT(false, ("Unknown mode:", static_cast<size_t>(mode)));
   return "Unknown mode";

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -1,21 +1,19 @@
 #pragma once
 
-#include "routing/cross_mwm_graph.hpp"
-#include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
-#include "routing/index_graph_loader.hpp"
 #include "routing/num_mwm_id.hpp"
+#include "routing/road_graph.hpp"
 #include "routing/segment.hpp"
 
-#include <memory>
-#include <unordered_map>
-#include <utility>
+#include "geometry/point2d.hpp"
+
+#include <string>
 #include <vector>
 
 namespace routing
 {
-class WorldGraph final
+class WorldGraph
 {
 public:
   // AStarAlgorithm types aliases:
@@ -35,50 +33,34 @@ public:
     LeapsIfPossible,  // Mode for building cross mwm and single mwm routes. In case of cross mwm route
                       // if they are neighboring mwms the route will be made without leaps.
                       // If not the route is made with leaps for intermediate mwms.
-    NoLeaps,  // Mode for building route and getting outgoing/ingoing edges without leaps at all.
+    NoLeaps,    // Mode for building route and getting outgoing/ingoing edges without leaps at all.
+    SingleMwm,  // Mode for building route and getting outgoing/ingoing edges within mwm source
+                // segment belongs to.
   };
-
-  WorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph, std::unique_ptr<IndexGraphLoader> loader,
-             std::shared_ptr<EdgeEstimator> estimator);
 
   // |isEnding| == true iff |segment| is first or last segment of the route. Needed because first and
   // last segments may need special processing.
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
-                   bool isEnding, std::vector<SegmentEdge> & edges);
+  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+                           std::vector<SegmentEdge> & edges) = 0;
 
-  IndexGraph & GetIndexGraphForTests(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
-  void SetSingleMwmMode(NumMwmId numMwmId) { m_mwmId = numMwmId; }
-  void UnsetSingleMwmMode() { m_mwmId = kFakeNumMwmId; }
+  virtual Junction const & GetJunction(Segment const & segment, bool front) = 0;
+  virtual m2::PointD const & GetPoint(Segment const & segment, bool front) = 0;
+  virtual RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId) = 0;
 
-  Junction const & GetJunction(Segment const & segment, bool front);
-  m2::PointD const & GetPoint(Segment const & segment, bool front);
-  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
-
-  // Clear memory used by loaded index graphs.
-  void ClearIndexGraphs() { m_loader->Clear(); }
-  void SetMode(Mode mode) { m_mode = mode; }
-  Mode GetMode() const { return m_mode; }
+  // Clear memory used by loaded graphs.
+  virtual void ClearCachedGraphs() = 0;
+  virtual void SetMode(Mode mode) = 0;
+  virtual Mode GetMode() const = 0;
 
   // Interface for AStarAlgorithm:
-  void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
-  void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  virtual void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) = 0;
+  virtual void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) = 0;
 
-  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to);
-  RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to);
-  RouteWeight CalcSegmentWeight(Segment const & segment);
-  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const;
-  bool LeapIsAllowed(NumMwmId mwmId) const;
-
-private:
-  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
-  bool IsInSingleMwmMode() { return m_mwmId != kFakeNumMwmId; }
-
-  std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
-  std::unique_ptr<IndexGraphLoader> m_loader;
-  std::shared_ptr<EdgeEstimator> m_estimator;
-  std::vector<Segment> m_twins;
-  Mode m_mode = Mode::NoLeaps;
-  NumMwmId m_mwmId = kFakeNumMwmId;
+  virtual RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) = 0;
+  virtual RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) = 0;
+  virtual RouteWeight CalcSegmentWeight(Segment const & segment) = 0;
+  virtual RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
+  virtual bool LeapIsAllowed(NumMwmId mwmId) const = 0;
 };
 
 std::string DebugPrint(WorldGraph::Mode mode);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -5,6 +5,7 @@
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
+#include "routing/num_mwm_id.hpp"
 #include "routing/segment.hpp"
 
 #include <memory>
@@ -45,7 +46,9 @@ public:
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                    bool isEnding, std::vector<SegmentEdge> & edges);
 
-  IndexGraph & GetIndexGraph(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
+  IndexGraph & GetIndexGraphForTests(NumMwmId numMwmId) { return m_loader->GetIndexGraph(numMwmId); }
+  void SetSingleMwmMode(NumMwmId numMwmId) { m_mwmId = numMwmId; }
+  void UnsetSingleMwmMode() { m_mwmId = kFakeNumMwmId; }
 
   Junction const & GetJunction(Segment const & segment, bool front);
   m2::PointD const & GetPoint(Segment const & segment, bool front);
@@ -68,12 +71,14 @@ public:
 
 private:
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  bool IsInSingleMwmMode() { return m_mwmId != kFakeNumMwmId; }
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::vector<Segment> m_twins;
   Mode m_mode = Mode::NoLeaps;
+  NumMwmId m_mwmId = kFakeNumMwmId;
 };
 
 std::string DebugPrint(WorldGraph::Mode mode);

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
 		40C227FE1F61C07C0046696C /* fake_edges_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C227FD1F61C07C0046696C /* fake_edges_container.hpp */; };
+		40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */; };
+		40F7F3E51F7D246D0082D564 /* single_vehicle_world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
@@ -344,6 +346,8 @@
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
 		40C227FD1F61C07C0046696C /* fake_edges_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_edges_container.hpp; sourceTree = "<group>"; };
+		40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_vehicle_world_graph.hpp; sourceTree = "<group>"; };
+		40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = single_vehicle_world_graph.cpp; sourceTree = "<group>"; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
@@ -887,6 +891,8 @@
 				0C470E6F1E0D4EB1005B824D /* segment.hpp */,
 				0C81E1551F0258AA00DC66DF /* segmented_route.cpp */,
 				0C81E1561F0258AA00DC66DF /* segmented_route.hpp */,
+				40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */,
+				40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */,
 				A1876BC41BB19C4300C9C743 /* speed_camera.cpp */,
 				A1876BC51BB19C4300C9C743 /* speed_camera.hpp */,
 				0C81E1511F02589800DC66DF /* traffic_stash.cpp */,
@@ -954,6 +960,7 @@
 				A120B3481B4A7BE5002F3808 /* cross_mwm_router.hpp in Headers */,
 				674F9BD31B0A580E00704FFA /* road_graph_router.hpp in Headers */,
 				0C5F5D231E798B0400307B98 /* cross_mwm_connector.hpp in Headers */,
+				40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */,
 				5670595E1F3AF97F0062672D /* checkpoint_predictor.hpp in Headers */,
 				675344141A3F644F00A0A8C3 /* osrm_data_facade.hpp in Headers */,
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
@@ -1288,6 +1295,7 @@
 				670C62131AC5A15700C38A8C /* routing_mapping.cpp in Sources */,
 				67C79BA11E2CEE1400C40034 /* restriction_loader.cpp in Sources */,
 				67C7D42D1B4EB48F00FE41AA /* turns_sound_settings.cpp in Sources */,
+				40F7F3E51F7D246D0082D564 /* single_vehicle_world_graph.cpp in Sources */,
 				0C5FEC541DDE191E0017688C /* edge_estimator.cpp in Sources */,
 				5670595A1F3AF96D0062672D /* checkpoint_predictor_test.cpp in Sources */,
 				A120B34E1B4A7C0A002F3808 /* online_absent_fetcher.cpp in Sources */,


### PR DESCRIPTION
В рамках создания TransitWorldGraph с поддержкой общественного транспорта превращаю WorldGraph в абстрактный базовый класс, переношу текущую реализацию в SingleVehicleWorldGraph.
Также убрала из интерфейса метод GetIndexGraph, заменила на Mode::SingleMwm. 