### PR TITLE
Add dummy TransitGraph, TransitGraphLoader, TransitWorldGraph classes.

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -126,6 +126,11 @@ set(
   speed_camera.hpp
   traffic_stash.cpp
   traffic_stash.hpp
+  transit_graph.hpp
+  transit_graph_loader.cpp
+  transit_graph_loader.hpp
+  transit_world_graph.cpp
+  transit_world_graph.hpp
   transition_points.hpp
   turn_candidate.hpp
   turns.cpp

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -64,6 +64,8 @@ SOURCES += \
     single_vehicle_world_graph.cpp \
     speed_camera.cpp \
     traffic_stash.cpp \
+    transit_graph_loader.cpp \
+    transit_world_graph.cpp \
     turns.cpp \
     turns_generator.cpp \
     turns_notification_manager.cpp \
@@ -139,6 +141,9 @@ HEADERS += \
     single_vehicle_world_graph.hpp \
     speed_camera.hpp \
     traffic_stash.hpp \
+    transit_graph.hpp \
+    transit_graph_loader.hpp \
+    transit_world_graph.hpp \
     transition_points.hpp \
     turn_candidate.hpp \
     turns.hpp \

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -123,6 +123,9 @@ void SingleVehicleWorldGraph::GetTwins(Segment const & segment, bool isOutgoing,
   {
     m2::PointD const & from = GetPoint(segment, true /* front */);
     m2::PointD const & to = GetPoint(twin, true /* front */);
+    // Weight is usually zero because twins correspond the same feature
+    // in different mwms. But if we have mwms with different versions and feature
+    // was moved in one of them we can have nonzero weight here.
     double const weight = m_estimator->CalcHeuristic(from, to);
     edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
   }

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace routing
+{
+class TransitGraph final
+{
+};
+}  // namespace routing

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -1,0 +1,51 @@
+#include "routing/transit_graph_loader.hpp"
+
+#include "routing/routing_exceptions.hpp"
+
+#include "indexer/mwm_set.hpp"
+
+#include "platform/country_file.hpp"
+
+#include "base/timer.hpp"
+
+#include "std/unique_ptr.hpp"
+
+using namespace std;
+
+namespace routing
+{
+TransitGraphLoader::TransitGraphLoader(shared_ptr<NumMwmIds> numMwmIds, Index & index)
+  : m_index(index), m_numMwmIds(numMwmIds)
+{
+}
+
+void TransitGraphLoader::Clear() { m_graphs.clear(); }
+
+TransitGraph & TransitGraphLoader::GetTransitGraph(NumMwmId numMwmId)
+{
+  auto const it = m_graphs.find(numMwmId);
+  if (it != m_graphs.cend())
+    return *it->second;
+
+  auto const emplaceRes = m_graphs.emplace(numMwmId, CreateTransitGraph(numMwmId));
+  ASSERT(emplaceRes.second, ("Failed to add TransitGraph for", numMwmId, "to TransitGraphLoader."));
+  return *(emplaceRes.first)->second;
+}
+
+std::unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmId)
+{
+  platform::CountryFile const & file = m_numMwmIds->GetFile(numMwmId);
+  MwmSet::MwmHandle handle = m_index.GetMwmHandleByCountryFile(file);
+  if (!handle.IsAlive())
+    MYTHROW(RoutingException, ("Can't get mwm handle for", file));
+
+  my::Timer timer;
+  auto graphPtr = make_unique<TransitGraph>();
+  // TODO:
+  // MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
+  // DeserializeTransitGraph(mwmValue, *graph);
+  LOG(LINFO, (TRANSIT_FILE_TAG, "section for", file.GetName(), "loaded in",
+              timer.ElapsedSeconds(), "seconds"));
+  return graphPtr;
+}
+}  // namespace routing

--- a/routing/transit_graph_loader.hpp
+++ b/routing/transit_graph_loader.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "routing/num_mwm_id.hpp"
+#include "routing/transit_graph.hpp"
+
+#include "indexer/index.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+namespace routing
+{
+class TransitGraphLoader final
+{
+public:
+  TransitGraphLoader(std::shared_ptr<NumMwmIds> numMwmIds, Index & index);
+
+  TransitGraph & GetTransitGraph(NumMwmId mwmId);
+  void Clear();
+
+private:
+  std::unique_ptr<TransitGraph> CreateTransitGraph(NumMwmId mwmId);
+
+  Index & m_index;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
+  std::unordered_map<NumMwmId, std::unique_ptr<TransitGraph>> m_graphs;
+};
+}  // namespace routing

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -1,0 +1,119 @@
+#include "routing/transit_world_graph.hpp"
+
+#include "routing/index_graph.hpp"
+#include "routing/transit_graph.hpp"
+
+#include <utility>
+
+namespace routing
+{
+using namespace std;
+
+TransitWorldGraph::TransitWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
+                                     unique_ptr<IndexGraphLoader> indexLoader,
+                                     unique_ptr<TransitGraphLoader> transitLoader,
+                                     shared_ptr<EdgeEstimator> estimator)
+  : m_crossMwmGraph(move(crossMwmGraph))
+  , m_indexLoader(move(indexLoader))
+  , m_transitLoader(move(transitLoader))
+  , m_estimator(estimator)
+{
+  CHECK(m_indexLoader, ());
+  CHECK(m_transitLoader, ());
+  CHECK(m_estimator, ());
+}
+
+void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool /* isLeap */,
+                                    bool /* isEnding */, vector<SegmentEdge> & edges)
+{
+  auto & indexGraph = m_indexLoader->GetIndexGraph(segment.GetMwmId());
+  // TransitGraph & transitGraph = m_transitLoader->GetTransitGraph(segment.GetMwmId());
+
+  // TODO: Add fake connected to real segment.
+  // TODO: Add real connected to fake segment.
+  indexGraph.GetEdgeList(segment, isOutgoing, edges);
+
+  if (m_mode != Mode::SingleMwm && m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
+    GetTwins(segment, isOutgoing, edges);
+}
+
+Junction const & TransitWorldGraph::GetJunction(Segment const & segment, bool front)
+{
+  // TODO: fake transit segments.
+  return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
+      .GetJunction(segment.GetPointId(front));
+}
+
+m2::PointD const & TransitWorldGraph::GetPoint(Segment const & segment, bool front)
+{
+  return GetJunction(segment, front).GetPoint();
+}
+
+RoadGeometry const & TransitWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
+{
+  // TODO: fake transit segments.
+  return m_indexLoader->GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+}
+
+void TransitWorldGraph::ClearCachedGraphs()
+{
+  m_indexLoader->Clear();
+  m_transitLoader->Clear();
+}
+
+void TransitWorldGraph::GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, true /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
+}
+
+void TransitWorldGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges)
+{
+  edges.clear();
+  GetEdgeList(segment, false /* isOutgoing */, false /* isLeap */, false /* isEnding */, edges);
+}
+
+RouteWeight TransitWorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+{
+  // TODO: fake transit segments.
+  return HeuristicCostEstimate(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
+}
+
+RouteWeight TransitWorldGraph::HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to)
+{
+  return RouteWeight(m_estimator->CalcHeuristic(from, to), 0 /* nontransitCross */);
+}
+
+RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment)
+{
+  // TODO: fake transit segments.
+  return RouteWeight(m_estimator->CalcSegmentWeight(
+                         segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())),
+                     0 /* nontransitCross */);
+}
+
+RouteWeight TransitWorldGraph::CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const
+{
+  return RouteWeight(m_estimator->CalcLeapWeight(from, to), 0 /* nontransitCross */);
+}
+
+bool TransitWorldGraph::LeapIsAllowed(NumMwmId /* mwmId */) const { return false; }
+
+void TransitWorldGraph::GetTwins(Segment const & segment, bool isOutgoing,
+                                 vector<SegmentEdge> & edges)
+{
+  // TODO: GetTwins for fake transit segments.
+  m_twins.clear();
+  m_crossMwmGraph->GetTwins(segment, isOutgoing, m_twins);
+  for (Segment const & twin : m_twins)
+  {
+    m2::PointD const & from = GetPoint(segment, true /* front */);
+    m2::PointD const & to = GetPoint(twin, true /* front */);
+    // Weight is usually zero because twins correspond the same feature
+    // in different mwms. But if we have mwms with different versions and feature
+    // was moved in one of them we can have nonzero weight here.
+    double const weight = m_estimator->CalcHeuristic(from, to);
+    edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
+  }
+}
+}  // namespace routing

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "routing/cross_mwm_graph.hpp"
+#include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/index_graph_loader.hpp"
+#include "routing/num_mwm_id.hpp"
+#include "routing/road_graph.hpp"
+#include "routing/segment.hpp"
+#include "routing/transit_graph_loader.hpp"
+#include "routing/world_graph.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace routing
+{
+class TransitWorldGraph final : public WorldGraph
+{
+public:
+  TransitWorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
+                    std::unique_ptr<IndexGraphLoader> indexLoader,
+                    std::unique_ptr<TransitGraphLoader> transitLoader,
+                    std::shared_ptr<EdgeEstimator> estimator);
+
+  // WorldGraph overrides:
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+                   std::vector<SegmentEdge> & edges) override;
+  Junction const & GetJunction(Segment const & segment, bool front) override;
+  m2::PointD const & GetPoint(Segment const & segment, bool front) override;
+  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId) override;
+  void ClearCachedGraphs() override;
+  void SetMode(Mode mode) override { m_mode = mode; }
+  Mode GetMode() const override { return m_mode; }
+  void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+  void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
+  RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  bool LeapIsAllowed(NumMwmId mwmId) const override;
+
+private:
+  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+
+  std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
+  std::unique_ptr<IndexGraphLoader> m_indexLoader;
+  std::unique_ptr<TransitGraphLoader> m_transitLoader;
+  std::shared_ptr<EdgeEstimator> m_estimator;
+  std::vector<Segment> m_twins;
+  Mode m_mode = Mode::NoLeaps;
+};
+}  // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -60,6 +60,11 @@
 		40576F761F791360000B593B /* fake_graph_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40576F751F791360000B593B /* fake_graph_test.cpp */; };
 		40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40576F771F7A788B000B593B /* fake_vertex.hpp */; };
 		405F48E91F75231E005BA81A /* fake_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 405F48E81F75231E005BA81A /* fake_graph.hpp */; };
+		4065EA801F824A6C0094DEF3 /* transit_world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */; };
+		4065EA811F824A6C0094DEF3 /* transit_world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */; };
+		4065EA851F8260010094DEF3 /* transit_graph_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */; };
+		4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */; };
+		4065EA871F8260010094DEF3 /* transit_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA841F8260000094DEF3 /* transit_graph.hpp */; };
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
@@ -348,6 +353,11 @@
 		40576F751F791360000B593B /* fake_graph_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_graph_test.cpp; sourceTree = "<group>"; };
 		40576F771F7A788B000B593B /* fake_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_vertex.hpp; sourceTree = "<group>"; };
 		405F48E81F75231E005BA81A /* fake_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_graph.hpp; sourceTree = "<group>"; };
+		4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_world_graph.hpp; sourceTree = "<group>"; };
+		4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_world_graph.cpp; sourceTree = "<group>"; };
+		4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph_loader.cpp; sourceTree = "<group>"; };
+		4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph_loader.hpp; sourceTree = "<group>"; };
+		4065EA841F8260000094DEF3 /* transit_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph.hpp; sourceTree = "<group>"; };
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
@@ -906,6 +916,11 @@
 				A1876BC51BB19C4300C9C743 /* speed_camera.hpp */,
 				0C81E1511F02589800DC66DF /* traffic_stash.cpp */,
 				0C81E1521F02589800DC66DF /* traffic_stash.hpp */,
+				4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */,
+				4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */,
+				4065EA841F8260000094DEF3 /* transit_graph.hpp */,
+				4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */,
+				4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */,
 				56099E271CC7C97D00A7772A /* turn_candidate.hpp */,
 				674F9BC61B0A580E00704FFA /* turns_generator.cpp */,
 				674F9BC71B0A580E00704FFA /* turns_generator.hpp */,
@@ -975,6 +990,7 @@
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
 				6753441A1A3F644F00A0A8C3 /* osrm2feature_map.hpp in Headers */,
+				4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */,
 				6741AA9D1BF35331002C974C /* turns_notification_manager.hpp in Headers */,
 				674F9BD71B0A580E00704FFA /* turns_generator.hpp in Headers */,
 				A120B3461B4A7BE5002F3808 /* cross_mwm_road_graph.hpp in Headers */,
@@ -1015,6 +1031,7 @@
 				0C08AA351DF83223004195DD /* index_graph_serialization.hpp in Headers */,
 				5694CECD1EBA25F7004576D3 /* road_access.hpp in Headers */,
 				40C227FE1F61C07C0046696C /* fake_edges_container.hpp in Headers */,
+				4065EA871F8260010094DEF3 /* transit_graph.hpp in Headers */,
 				670D049F1B0B4A970013A7AC /* nearest_edge_finder.hpp in Headers */,
 				405F48E91F75231E005BA81A /* fake_graph.hpp in Headers */,
 				A120B34F1B4A7C0A002F3808 /* online_absent_fetcher.hpp in Headers */,
@@ -1024,6 +1041,7 @@
 				0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */,
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
 				405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */,
+				4065EA801F824A6C0094DEF3 /* transit_world_graph.hpp in Headers */,
 				56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */,
 				0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */,
 				670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */,
@@ -1292,8 +1310,10 @@
 				568194751F03A32400450EC3 /* road_access_test.cpp in Sources */,
 				56CA09E41E30E73B00D05C9A /* cumulative_restriction_test.cpp in Sources */,
 				568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */,
+				4065EA811F824A6C0094DEF3 /* transit_world_graph.cpp in Sources */,
 				0C12ED231E5C822A0080D0F4 /* index_router.cpp in Sources */,
 				6753441E1A3F644F00A0A8C3 /* turns.cpp in Sources */,
+				4065EA851F8260010094DEF3 /* transit_graph_loader.cpp in Sources */,
 				670B84C01A9381D900CE4492 /* cross_routing_context.cpp in Sources */,
 				A120B3501B4A7C0A002F3808 /* routing_algorithm.cpp in Sources */,
 				674F9BCC1B0A580E00704FFA /* features_road_graph.cpp in Sources */,


### PR DESCRIPTION
Заготовки для TransitWorldGraph.
TransitGraph -- граф общественного транспорта, будет содержать FakeGraph (сделаю, когда https://github.com/mapsme/omim/pull/7160 вольется в мастер) и мэпинг фейковых сегментов на информацию для отрисовки (id полилинии и т.п.)
TransitGraphLoader -- Loader для TransitGraph с кешем, для полной реализации нужен будет десериалайзер, будет сделан после добавления информации в генератор (@bykoianko сейчас работает над этим)
TransitWorldGraph -- совмещенный WorldGraph для пешеходов и общественного транспорта, будет использоваться из IndexRouter при типе транспорта Transit.