### PR TITLE
MAPSME-5690: Fix GetEdgeList for fake segments

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -185,7 +185,12 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
   {
     Segment real;
     if (m_fake.FindReal(segment, real))
-      AddRealEdges(real, isOutgoing, edges);
+    {
+      bool const haveSameFront = GetJunction(segment, true /* front */) == GetJunction(real, true);
+      bool const haveSameBack = GetJunction(segment, false /* front */) == GetJunction(real, false);
+      if ((isOutgoing && haveSameFront) || (!isOutgoing && haveSameBack))
+        AddRealEdges(real, isOutgoing, edges);
+    }
 
     for (auto const & s : m_fake.GetEdges(segment, isOutgoing))
       edges.emplace_back(s, CalcSegmentWeight(isOutgoing ? s : segment));


### PR DESCRIPTION
При поиске входящих/исходящих для фейкового сегмента типа PartOfReal добавляла к фейковым рёбрам входящие/исходящие для соответствующего реального сегмента.
Это было неправильно, поскольку в случае
```
a   b        c      d
*===>------->*----->*
```
где ac, cd -- реальные сегменты, ab -- сегмент типа PartOfReal при получении исходящих из ab в этот список добавлялся cd с весом cd (кусок bc получался как бы нулевым), что приводило к нарушению инварианта на некоторых маршрутах (в основном очень коротких, длиной меньше 20м).
Сейчас при поиске входящих/исходящих из фейкового сегмента добавляю входящие/исходящие для соответствующего реального только если `(isOutgoing && haveSameFront) || (!isOutgoing && haveSameBack)`.
Добавила тест, который ломался до фикса и не ломается теперь.

Надеюсь описание получилось понятным, если нет -- давайте соберемся у доски.