### PR TITLE
[coding] Init platform for coding tests.

### DIFF
--- a/coding/coding_tests/CMakeLists.txt
+++ b/coding/coding_tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(coding_tests)
 
-add_definitions(-DOMIM_UNIT_TEST_DISABLE_PLATFORM_INIT)
-
 set(
   SRC
   base64_test.cpp

--- a/coding/coding_tests/coding_tests.pro
+++ b/coding/coding_tests/coding_tests.pro
@@ -18,8 +18,6 @@ win32*|linux* {
 
 include($$ROOT_DIR/common.pri)
 
-DEFINES += OMIM_UNIT_TEST_DISABLE_PLATFORM_INIT
-
 SOURCES += ../../testing/testingmain.cpp \
     base64_test.cpp \
     bit_streams_test.cpp \


### PR DESCRIPTION
Without this change it's not possible to run csv reader tests, because they use platform, and platform is not properly initialized.