### PR TITLE
[DNM][routing][transit] Data structures for transit.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -73,6 +73,44 @@ UNIT_TEST(DeserializerFromJson_Stops)
   TestDeserializerFromJson(jsonBuffer, "stops", expected);
 }
 
+UNIT_TEST(DeserializerFromJson_Gates)
+{
+  string const jsonBuffer = R"(
+  {
+  "gates": [
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": 46116860,
+      "point": {
+        "x": 43.8594864,
+        "y": 68.33320554776377
+       },
+       "stop_ids": [ 442018474 ],
+       "weight": 60
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": 46116861,
+      "point": {
+        "x": 43.9290544,
+        "y": 68.41120791512581
+       },
+       "stop_ids": [ 442018465 ],
+       "weight": 60
+    }
+  ]})";
+
+  vector<Gate> const expected = {
+      Gate(46116860 /* feature id */, true /* entrance */, true /* exit */, 60.0 /* weight */,
+           {442018474} /* stop ids */, {43.8594864, 68.33320554776377} /* point */),
+      Gate(46116861 /* feature id */, true /* entrance */, true /* exit */, 60.0 /* weight */,
+           {442018465} /* stop ids */, {43.9290544, 68.41120791512581} /* point */)};
+
+  TestDeserializerFromJson(jsonBuffer, "gates", expected);
+}
+
 UNIT_TEST(DeserializerFromJson_Edges)
 {
   string const jsonBuffer = R"(
@@ -82,7 +120,6 @@ UNIT_TEST(DeserializerFromJson_Edges)
       "finish_stop_id": 442018445,
       "line_id": 72551680,
       "shape_ids": [5, 7],
-      "weight" : 234.5,
       "start_stop_id": 442018444,
       "transfer": false
     },
@@ -97,11 +134,156 @@ UNIT_TEST(DeserializerFromJson_Edges)
   ]})";
 
   vector<Edge> const expected = {
-    Edge(442018444 /* start stop id */, 442018445 /* finish stop id */, 234.5 /* weight */,
+    Edge(442018444 /* start stop id */, 442018445 /* finish stop id */, kInvalidWeight /* weight */,
          72551680 /* line id */,  false /* transfer */, {5, 7} /* shape ids */),
     Edge(442018445 /* start stop id */, 442018446 /* finish stop id */, 345.6 /* weight */,
          72551680 /* line id */,  false /* transfer */, {} /* shape ids */)};
 
   TestDeserializerFromJson(jsonBuffer, "edges", expected);
+}
+
+UNIT_TEST(DeserializerFromJson_Transfers)
+{
+  string const jsonBuffer = R"(
+  {
+  "transfers": [
+    {
+      "id": 922337203,
+      "point": {
+        "x": 27.5619844,
+        "y": 64.24325959173672
+      },
+      "stop_ids": [
+        209186416,
+        277039518
+      ]
+    }
+  ]})";
+
+  vector<Transfer> const expected = {Transfer(922337203 /* stop id */,
+                                              {27.5619844, 64.24325959173672} /* point */,
+                                              {209186416, 277039518} /* stopIds */)};
+
+  TestDeserializerFromJson(jsonBuffer, "transfers", expected);
+}
+
+UNIT_TEST(DeserializerFromJson_Lines)
+{
+  string const jsonBuffer = R"(
+  {
+  "lines": [
+    {
+      "id": 19207936,
+      "network_id": 2,
+      "number": "1",
+      "stop_ids": [
+        343262691,
+        343259523,
+        343252898,
+        209191847,
+        2947858576
+      ],
+      "title": "Московская линия",
+      "type": "subway"
+    },
+    {
+      "id": 19207937,
+      "network_id": 2,
+      "number": "2",
+      "stop_ids": [
+        246659391,
+        246659390,
+        209191855,
+        209191854,
+        209191853,
+        209191852,
+        209191851
+      ],
+      "title": "Московская линия",
+      "type": "subway"
+    }
+  ]})";
+
+  vector<Line> const expected = {Line(19207936 /* line id */, "1" /* number */, "Московская линия" /* title */,
+                                      "subway" /* type */, 2 /* network id */,
+                                      {343262691, 343259523, 343252898, 209191847, 2947858576} /* stop ids */),
+                                 Line(19207937 /* line id */, "2" /* number */, "Московская линия" /* title */,
+                                      "subway" /* type */, 2 /* network id */,
+                                      {246659391, 246659390, 209191855, 209191854, 209191853,
+                                       209191852, 209191851} /* stop ids */)};
+
+  TestDeserializerFromJson(jsonBuffer, "lines", expected);
+}
+
+UNIT_TEST(DeserializerFromJson_Shapes)
+{
+  string const jsonBuffer = R"(
+  {
+  "shapes": [
+    {
+      "id": 1,
+      "stop1_id": 209186424,
+      "stop2_id": 248520179,
+      "polyline": [
+        {
+          "x": 27.5762295,
+          "y": 64.256768574044699
+        },
+        {
+          "x": 27.576325736220355,
+          "y": 64.256879325696005
+        },
+        {
+          "x": 27.576420780761875,
+          "y": 64.256990221238539
+        },
+        {
+          "x": 27.576514659541523,
+          "y": 64.257101255242176
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "stop1_id": 209191850,
+      "stop2_id": 209191851,
+      "polyline": [
+        {
+          "x": 27.554025800000002,
+          "y": 64.250591911669844
+        },
+        {
+          "x": 27.553906184631536,
+          "y": 64.250633404586054
+        }
+      ]
+    }
+  ]})";
+
+  vector<Shape> const expected = {Shape(1 /* shape id */, 209186424 /* stop 1 id */, 248520179 /* stop 2 id */,
+                                  {m2::PointD(27.5762295, 64.256768574044699),
+                                   m2::PointD(27.576325736220355, 64.256879325696005),
+                                   m2::PointD(27.576420780761875, 64.256990221238539),
+                                   m2::PointD(27.576514659541523, 64.257101255242176)} /* polyline */),
+                                  Shape(2 /* shape id */, 209191850 /* stop 1 id */, 209191851 /* stop 2 id */,
+                                  {m2::PointD(27.554025800000002, 64.250591911669844),
+                                   m2::PointD(27.553906184631536, 64.250633404586054)} /* polyline */)};
+
+  TestDeserializerFromJson(jsonBuffer, "shapes", expected);
+}
+
+UNIT_TEST(DeserializerFromJson_Networks)
+{
+  string const jsonBuffer = R"(
+  {
+  "networks": [
+    {
+      "id": 2,
+      "title": "Минский метрополитен"
+    }
+  ]})";
+
+  vector<Network> const expected = {Network(2 /* network id */, "Минский метрополитен" /* title */)};
+  TestDeserializerFromJson(jsonBuffer, "networks", expected);
 }
 }  // namespace

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -49,7 +49,6 @@ void SerializeObject(my::Json const & root, string const & key, Serializer<FileW
 
   DeserializerFromJson deserializer(root.get());
   deserializer(items, key.c_str());
-  serializer.ResetCache();
   serializer(items);
 }
 }  // namespace

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -49,6 +49,7 @@ void SerializeObject(my::Json const & root, string const & key, Serializer<FileW
 
   DeserializerFromJson deserializer(root.get());
   deserializer(items, key.c_str());
+  serializer.ResetCache();
   serializer(items);
 }
 }  // namespace

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -59,10 +59,56 @@ UNIT_TEST(Transit_StopSerialization)
   }
 }
 
+UNIT_TEST(Transit_GateSerialization)
+{
+  Gate gate(12345 /* feature id */, true /* entrance */, false /* exit */, 117.8 /* weight */,
+            {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
+  TestSerialization(gate);
+}
+
 UNIT_TEST(Transit_EdgeSerialization)
 {
   Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123.4 /* weight */, 11 /* line id */,
             false /* transfer */, {1, 2, 3} /* shape ids */);
   TestSerialization(edge);
+}
+
+UNIT_TEST(Transit_TransferSerialization)
+{
+  Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */);
+  TestSerialization(transfer);
+}
+
+UNIT_TEST(Transit_LineSerialization)
+{
+  {
+    Line line(1 /* line id */, "2" /* number */, "Линия" /* title */,
+              "subway" /* type */, 3 /* network id */, {} /* stop ids */);
+    TestSerialization(line);
+  }
+  {
+    Line line(10 /* line id */, "11" /* number */, "Линия" /* title */,
+              "subway" /* type */, 12 /* network id */, {13, 14, 15} /* stop ids */);
+    TestSerialization(line);
+  }
+}
+
+UNIT_TEST(Transit_ShapeSerialization)
+{
+  {
+    Shape shape(1 /* shape id */, 10 /* stop 1 id */, 11 /* stop 2 id */, {} /* polyline */);
+    TestSerialization(shape);
+  }
+  {
+    Shape shape(1 /* shape id */, 10 /* stop 1 id */, 11 /* stop 2 id */,
+                {m2::PointD(20.0, 20.0), m2::PointD(21.0, 21.0), m2::PointD(22.0, 22.0)} /* polyline */);
+    TestSerialization(shape);
+  }
+}
+
+UNIT_TEST(Transit_NetworkSerialization)
+{
+  Network network(0 /* network id */, "Title" /* title */);
+  TestSerialization(network);
 }
 }  // namespace

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -91,7 +91,7 @@ bool Gate::IsEqualForTesting(Gate const & gate) const
 
 // Edge -------------------------------------------------------------------------------------------
 Edge::Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId, bool transfer,
-           vector<ShapeId> const & shapeIds)
+           std::vector<ShapeId> const & shapeIds)
   : m_startStopId(startStopId)
   , m_finishStopId(finishStopId)
   , m_weight(weight)

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -81,6 +81,28 @@ private:
   // and deserialization.
 };
 
+class Gate
+{
+public:
+  Gate() = default;
+  Gate(FeatureId featureId, bool entrance, bool exit, double weight, std::vector<StopId> const & stopIds,
+       m2::PointD const & point);
+  bool IsEqualForTesting(Gate const & gate) const;
+
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Gate, visitor(m_featureId, "osm_id"),
+                                  visitor(m_entrance, "entrance"),
+                                  visitor(m_exit, "exit"), visitor(m_weight, "weight"),
+                                  visitor(m_stopIds, "stop_ids"), visitor(m_point, "point"))
+
+private:
+  FeatureId m_featureId = kInvalidFeatureId;
+  bool m_entrance = true;
+  bool m_exit = true;
+  double m_weight = kInvalidWeight;
+  std::vector<StopId> m_stopIds;
+  m2::PointD m_point;
+};
+
 class Edge
 {
 public:
@@ -104,6 +126,76 @@ private:
   std::vector<ShapeId> m_shapeIds;
 };
 
-// @TODO(bykoianko) Data structures and methods for other transit data should be implemented in here.
+class Transfer
+{
+public:
+  Transfer() = default;
+  Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds);
+  bool IsEqualForTesting(Transfer const & transfer) const;
+
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Transfer, visitor(m_id, "id"), visitor(m_point, "point"),
+                                  visitor(m_stopIds, "stop_ids"))
+
+private:
+  StopId m_id = kInvalidStopId;
+  m2::PointD m_point;
+  std::vector<StopId> m_stopIds;
+
+  // @TODO(bykoianko) It's necessary to add field m_titleAnchors here and implement serialization
+  // and deserialization.
+};
+
+class Line
+{
+public:
+  Line() = default;
+  Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
+       NetworkId networkId, std::vector<StopId> const & stopIds);
+  bool IsEqualForTesting(Line const & line) const;
+
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Line, visitor(m_id, "id"), visitor(m_number, "number"),
+                                  visitor(m_title, "title"), visitor(m_type, "type"),
+                                  visitor(m_networkId, "network_id"),
+                                  visitor(m_stopIds, "stop_ids"))
+
+private:
+  LineId m_id = kInvalidLineId;
+  std::string m_number;
+  std::string m_title;
+  std::string m_type;
+  NetworkId m_networkId = kInvalidNetworkId;
+  std::vector<StopId> m_stopIds;
+};
+
+class Shape
+{
+public:
+  Shape() = default;
+  Shape(ShapeId id, StopId stop1_id, StopId stop2_id, std::vector<m2::PointD> const & polyline);
+  bool IsEqualForTesting(Shape const & shape) const;
+
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Shape, visitor(m_id, "id"), visitor(m_stop1_id, "stop1_id"),
+                                  visitor(m_stop2_id, "stop2_id"), visitor(m_polyline, "polyline"))
+
+private:
+  ShapeId m_id = kInvalidShapeId;
+  StopId m_stop1_id = kInvalidStopId;
+  StopId m_stop2_id = kInvalidStopId;
+  std::vector<m2::PointD> m_polyline;
+};
+
+class Network
+{
+public:
+  Network() = default;
+  Network(NetworkId id, std::string const & title);
+  bool IsEqualForTesting(Network const & shape) const;
+
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Network, visitor(m_id, "id"), visitor(m_title, "title"))
+
+private:
+  NetworkId m_id;
+  std::string m_title;
+};
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -113,8 +113,11 @@ private:
   FeatureId m_featureId = kInvalidFeatureId;
   // |m_pedestrianFeatureIds| is linear feature ids which can be used for pedestrian routing
   // to leave (to enter) the gate.
-  // @TODO(bykoianko) |m_pedestrianFeatureIds| should be filled after "gates" are deserialized from json
-  // to vector of Gate but before serialization to mwm.
+  // @TODO(bykoianko) |m_pedestrianFeatureIds| is not filled from json but should be calculated based on |m_point|.
+  // It should be filled after "gates" are deserialized from json to vector of Gate but before serialization to mwm.
+  // That means that it's necessary to implement two visitors. One of them without visiting |m_pedestrianFeatureIds|
+  // for deserialization from json. And another with visiting |m_pedestrianFeatureIds| for serialization to mwm,
+  // deserialization from mwm and debug print.
   std::vector<FeatureId> m_pedestrianFeatureIds;
   bool m_entrance = true;
   bool m_exit = true;

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -95,7 +95,13 @@ public:
                                   visitor(m_stopIds, "stop_ids"), visitor(m_point, "point"))
 
 private:
+  // |m_featureId| is feature id of a point feature which represents gates.
   FeatureId m_featureId = kInvalidFeatureId;
+  // |m_pedestrianFeatureIds| is linear feature ids which can be used for pedestrian routing
+  // to leave (to enter) the gate.
+  // @TODO(bykoianko) |m_pedestrianFeatureIds| should be filled after "gates" are deserialized from json
+  // to vector of Gate but before serialization to mwm.
+  std::vector<FeatureId> m_pedestrianFeatureIds;
   bool m_entrance = true;
   bool m_exit = true;
   double m_weight = kInvalidWeight;

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -67,6 +67,12 @@ public:
        m2::PointD const & point);
   bool IsEqualForTesting(Stop const & stop) const;
 
+  StopId GetId() const { return m_id; }
+  FeatureId GetFeatureId() const { return m_featureId; }
+  TransferId GetTransferId() const { return m_transferId; }
+  std::vector<LineId> const & GetLineIds() const { return m_lineIds; }
+  m2::PointD const & GetPoint() const { return m_point; }
+
   DECLARE_VISITOR_AND_DEBUG_PRINT(Stop, visitor(m_id, "id"), visitor(m_featureId, "osm_id"),
                                   visitor(m_transferId, "transfer_id"),
                                   visitor(m_lineIds, "line_ids"), visitor(m_point, "point"))
@@ -88,6 +94,14 @@ public:
   Gate(FeatureId featureId, bool entrance, bool exit, double weight, std::vector<StopId> const & stopIds,
        m2::PointD const & point);
   bool IsEqualForTesting(Gate const & gate) const;
+
+  FeatureId GetFeatureId() const { return m_featureId; }
+  std::vector<FeatureId> const & GetPedestrianFeatureIds() const { return m_pedestrianFeatureIds; }
+  bool GetEntrance() const { return m_entrance; }
+  bool GetExit() const { return m_exit; }
+  double GetWeight() const { return m_weight; }
+  std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
+  m2::PointD const & GetPoint() const { return m_point; }
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(Gate, visitor(m_featureId, "osm_id"),
                                   visitor(m_entrance, "entrance"),
@@ -115,8 +129,14 @@ public:
   Edge() = default;
   Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId, bool transfer,
        std::vector<ShapeId> const & shapeIds);
-
   bool IsEqualForTesting(Edge const & edge) const;
+
+  StopId GetStartStopId() const { return m_startStopId; }
+  StopId GetFinishStopId() const { return m_finishStopId; }
+  double GetWeight() const { return m_weight; }
+  LineId GetLineId() const { return m_lineId; }
+  bool GetTransfer() const { return m_transfer; }
+  std::vector<ShapeId> const & GetShapeIds() const { return m_shapeIds; }
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(Edge, visitor(m_startStopId, "start_stop_id"),
                                   visitor(m_finishStopId, "finish_stop_id"),
@@ -139,6 +159,10 @@ public:
   Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds);
   bool IsEqualForTesting(Transfer const & transfer) const;
 
+  StopId GetId() const { return m_id; }
+  m2::PointD const & GetPoint() const { return m_point; }
+  std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
+
   DECLARE_VISITOR_AND_DEBUG_PRINT(Transfer, visitor(m_id, "id"), visitor(m_point, "point"),
                                   visitor(m_stopIds, "stop_ids"))
 
@@ -158,6 +182,13 @@ public:
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
        NetworkId networkId, std::vector<StopId> const & stopIds);
   bool IsEqualForTesting(Line const & line) const;
+
+  LineId GetId() const { return m_id; }
+  std::string const & GetNumber() const { return m_number; }
+  std::string const & GetTitle() const { return m_title; }
+  std::string const & GetType() const { return m_type; }
+  NetworkId GetNetworkId() const { return m_networkId; }
+  std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(Line, visitor(m_id, "id"), visitor(m_number, "number"),
                                   visitor(m_title, "title"), visitor(m_type, "type"),
@@ -180,6 +211,11 @@ public:
   Shape(ShapeId id, StopId stop1_id, StopId stop2_id, std::vector<m2::PointD> const & polyline);
   bool IsEqualForTesting(Shape const & shape) const;
 
+  ShapeId GetId() const { return m_id; }
+  StopId GetStop1Id() const { return m_stop1_id; }
+  StopId GetStop2Id() const { return m_stop2_id; }
+  std::vector<m2::PointD> const & GetPolyline() const { return m_polyline; }
+
   DECLARE_VISITOR_AND_DEBUG_PRINT(Shape, visitor(m_id, "id"), visitor(m_stop1_id, "stop1_id"),
                                   visitor(m_stop2_id, "stop2_id"), visitor(m_polyline, "polyline"))
 
@@ -196,6 +232,9 @@ public:
   Network() = default;
   Network(NetworkId id, std::string const & title);
   bool IsEqualForTesting(Network const & shape) const;
+
+  NetworkId GetId() const { return m_id; }
+  std::string const & GetTitle() const { return m_title; }
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(Network, visitor(m_id, "id"), visitor(m_title, "title"))
 


### PR DESCRIPTION
Реализовано:
- Реализация всех структур для общественного транспорта данных и сериализация/десериализация их;
- Тесты;
- Delta coding для точек;

Результаты тестов по delta coding.
После реализации без дельта кодинга точек выяснилось, на примере графом метро для Минска и Нижнего Новгорода, что 3/4 объема секции занимает таблица shapes. Это полилинии близко лежащих точек. По рекомендации @ygorshenin я реализовал delta coding для сохранения точек. Это позволило уменьшить в 4 раза таблицу shapes (в два раза размер секции transit) на доступных мне примерах.

Детали тестов на размер секции.
Для Минска и Нижнего Новгорода результаты тестов выглядят так:
Минск
(Без delta coding) Header: TransitHeader [version: 0, reserve: 0, gatesOffset: 1156, edgesOffset: 7277, transfersOffset: 8864, linesOffset: 8900, shapesOffset: 9561, networksOffset: 36108, endOffset: 36153]
(Delta coding) Header: TransitHeader [version: 0, reserve: 0, gatesOffset: 1028, edgesOffset: 6278, transfersOffset: 7865, linesOffset: 7900, shapesOffset: 8561, networksOffset: 17234, endOffset: 17279]

Нижний Новгород
(Без delta coding) Header: TransitHeader [version: 0, reserve: 0, gatesOffset: 587, edgesOffset: 2647, transfersOffset: 3428, linesOffset: 3429, shapesOffset: 3924, networksOffset: 17198, endOffset: 17255]
(Delta coding) Header: TransitHeader [version: 0, reserve: 0, gatesOffset: 524, edgesOffset: 2282, transfersOffset: 3063, linesOffset: 3064, shapesOffset: 3559, networksOffset: 8285, endOffset: 8342]

@ygorshenin @tatiana-kondakova @mpimenov PTAL

