### PR TITLE
update docs/MAPS.md

### DIFF
--- a/docs/MAPS.md
+++ b/docs/MAPS.md
@@ -32,12 +32,6 @@ file area. Having that, run (and prepare to wait a bit longer):
 
     COASTS=WorldCoasts.geom BORDER=source.poly omim/tools/unix/generate_mwm.sh source.pbf
 
-A car routing index will be built when you specify a second parameter: either a full path to a Lua script
-with a routing profile, or any gibberish, in which case a default `car.lua` from omim repository
-would be used. For example:
-
-    omim/tools/unix/generate_mwm.sh source.pbf any_random_string_asdf
-
 Inter-mwm navigation requires another index. To build it, you would need
 border polygons for not only the source region, but all regions neighbouring it. The source border polygon
 must have the same name as the source file (e.g. `Armenia.poly` for `Armenia.pbf`), and in the target


### PR DESCRIPTION
Remove outdated instructions about generatig the car routing index. The
`routing_profile` parameter has been removed in b79686c73 and the
intra-mwm routing is since then supposed to be created by default.

Note: the intra-mwm routing is currently not generated without
generating the inter-mwm routing, according to @Zverik this is a known
bug. I'm not sure whether that should be mentioned here. The instructions
for inter-mwm routing are creating intra-mwm routing as well.