### PR TITLE
Two different visitors at the same class.

### DIFF
--- a/base/visitor.hpp
+++ b/base/visitor.hpp
@@ -31,19 +31,19 @@ private:
 };
 }  // namespace base
 
-#define DECLARE_VISITOR_WITH_SUFFIX(suffix, ...)    \
-  template <typename Visitor>                 \
-  void Visit##suffix(Visitor & visitor)       \
-  {                                           \
-    __VA_ARGS__;                              \
-  }                                           \
-  template <typename Visitor>                 \
-  void Visit##suffix(Visitor & visitor) const \
-  {                                           \
-    __VA_ARGS__;                              \
+#define DECLARE_VISITOR_WITH_SUFFIX(suffix, ...)     \
+  template <typename Visitor>                        \
+  void Visit##suffix(Visitor & visitor)              \
+  {                                                  \
+    __VA_ARGS__;                                     \
+  }                                                  \
+  template <typename Visitor>                        \
+  void Visit##suffix(Visitor & visitor) const        \
+  {                                                  \
+    __VA_ARGS__;                                     \
   }
 
-#define DECLARE_VISITOR(...)                  \
+#define DECLARE_VISITOR(...)                         \
   DECLARE_VISITOR_WITH_SUFFIX(, __VA_ARGS__)
 
 #define DECLARE_DEBUG_PRINT(className)               \

--- a/base/visitor.hpp
+++ b/base/visitor.hpp
@@ -31,17 +31,20 @@ private:
 };
 }  // namespace base
 
-#define DECLARE_VISITOR(...)          \
-  template <typename Visitor>         \
-  void Visit(Visitor & visitor)       \
-  {                                   \
-    __VA_ARGS__;                      \
-  }                                   \
-  template <typename Visitor>         \
-  void Visit(Visitor & visitor) const \
-  {                                   \
-    __VA_ARGS__;                      \
+#define DECLARE_VISITOR_WITH_SUFFIX(suffix, ...)    \
+  template <typename Visitor>                 \
+  void Visit##suffix(Visitor & visitor)       \
+  {                                           \
+    __VA_ARGS__;                              \
+  }                                           \
+  template <typename Visitor>                 \
+  void Visit##suffix(Visitor & visitor) const \
+  {                                           \
+    __VA_ARGS__;                              \
   }
+
+#define DECLARE_VISITOR(...)                  \
+  DECLARE_VISITOR_WITH_SUFFIX(, __VA_ARGS__)
 
 #define DECLARE_DEBUG_PRINT(className)               \
   friend std::string DebugPrint(className const & c) \

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -43,8 +43,8 @@ string GetFileName(string const & filePath)
 
 /// \brief Reads from |root| (json) and serializes an array to |serializer|.
 // @TODO(bykoianko) It's necessary to implement
-// template <Gate>
-// void SerializeObject(my::Json const & root, string const & key, Serializer<FileWriter> & serializer).
+// template<>
+// void SerializeObject<Gate>(my::Json const & root, string const & key, Serializer<FileWriter> & serializer).
 // At this method |Gate::m_pedestrianFeatureIds| should be calculated based on |m_point|.
 // It should be filled after "gates" are deserialized from json to vector of Gate but before serialization to mwm.
 template <class Item>

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -42,6 +42,11 @@ string GetFileName(string const & filePath)
 }
 
 /// \brief Reads from |root| (json) and serializes an array to |serializer|.
+// @TODO(bykoianko) It's necessary to implement
+// template <Gate>
+// void SerializeObject(my::Json const & root, string const & key, Serializer<FileWriter> & serializer).
+// At this method |Gate::m_pedestrianFeatureIds| should be calculated based on |m_point|.
+// It should be filled after "gates" are deserialized from json to vector of Gate but before serialization to mwm.
 template <class Item>
 void SerializeObject(my::Json const & root, string const & key, Serializer<FileWriter> & serializer)
 {

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -103,21 +103,21 @@ public:
   std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
   m2::PointD const & GetPoint() const { return m_point; }
 
-  DECLARE_VISITOR_AND_DEBUG_PRINT(Gate, visitor(m_featureId, "osm_id"),
-                                  visitor(m_entrance, "entrance"),
-                                  visitor(m_exit, "exit"), visitor(m_weight, "weight"),
-                                  visitor(m_stopIds, "stop_ids"), visitor(m_point, "point"))
+  DECLARE_VISITOR(visitor(m_featureId, "osm_id"), visitor(m_pedestrianFeatureIds, "" /* name */),
+                  visitor(m_entrance, "entrance"),
+                  visitor(m_exit, "exit"), visitor(m_weight, "weight"),
+                  visitor(m_stopIds, "stop_ids"), visitor(m_point, "point"))
+  DECLARE_VISITOR_WITH_SUFFIX(forJson, visitor(m_featureId, "osm_id"),
+                              visitor(m_entrance, "entrance"), visitor(m_exit, "exit"),
+                              visitor(m_weight, "weight"), visitor(m_stopIds, "stop_ids"),
+                              visitor(m_point, "point"))
+  DECLARE_DEBUG_PRINT(Gate)
 
 private:
   // |m_featureId| is feature id of a point feature which represents gates.
   FeatureId m_featureId = kInvalidFeatureId;
   // |m_pedestrianFeatureIds| is linear feature ids which can be used for pedestrian routing
   // to leave (to enter) the gate.
-  // @TODO(bykoianko) |m_pedestrianFeatureIds| is not filled from json but should be calculated based on |m_point|.
-  // It should be filled after "gates" are deserialized from json to vector of Gate but before serialization to mwm.
-  // That means that it's necessary to implement two visitors. One of them without visiting |m_pedestrianFeatureIds|
-  // for deserialization from json. And another with visiting |m_pedestrianFeatureIds| for serialization to mwm,
-  // deserialization from mwm and debug print.
   std::vector<FeatureId> m_pedestrianFeatureIds;
   bool m_entrance = true;
   bool m_exit = true;


### PR DESCRIPTION
При сериализации/десериализции секции transit возникает ситуация, при которой поле одной из структур данных должно быть заполнено не из исходного json, а вычислено после десериализации из json, но перед сериализацией в mwm. Затем, при работе программы оно должно десериализоваться из mwm и использоваться.

Т.о. возникает необходимость в обходе разных наборов полей (в классе Gate).

@tatiana-kondakova @ygorshenin @mpimenov PTAL
