### PR TITLE
Special handling for pedestrian feature ids.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -44,6 +44,8 @@ string GetFileName(string const & filePath)
 }
 
 /// \brief Reads from |root| (json) and serializes an array to |serializer|.
+/// \param handler is function which fixes up vector of |Item|(s) after deserialization from json
+/// but before serialization to mwm.
 template <class Item>
 void SerializeObject(my::Json const & root, string const & key, Serializer<FileWriter> & serializer,
                      function<void(vector<Item> &)> handler = nullptr)
@@ -132,12 +134,12 @@ void BuildTransit(string const & mwmPath, string const & transitDir)
   SerializeObject<Stop>(root, "stops", serializer);
   header.m_gatesOffset = base::checked_cast<uint32_t>(w.Pos() - startOffset);
 
-  auto const fillPedestrianFeatureIds = [](function<void(vector<Gate> &)> & handler)
+  auto const fillPedestrianFeatureIds = [](vector<Gate> & gates)
   {
     // @TODO(bykoianko) |m_pedestrianFeatureIds| is not filled from json but should be calculated based on |m_point|.
   };
-  UNUSED_VALUE(fillPedestrianFeatureIds);
-  SerializeObject<Gate>(root, "gates", serializer);
+
+  SerializeObject<Gate>(root, "gates", serializer, fillPedestrianFeatureIds);
   header.m_edgesOffset = base::checked_cast<uint32_t>(w.Pos() - startOffset);
 
   SerializeObject<Edge>(root, "edges", serializer);

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -104,20 +104,16 @@ public:
   m2::PointD const & GetPoint() const { return m_point; }
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(Gate, visitor(m_featureId, "osm_id"),
-                                  visitor(m_entrance, "entrance"),
-                                  visitor(m_exit, "exit"), visitor(m_weight, "weight"),
-                                  visitor(m_stopIds, "stop_ids"), visitor(m_point, "point"))
+                                  visitor(m_pedestrianFeatureIds, "" /* name */),
+                                  visitor(m_entrance, "entrance"), visitor(m_exit, "exit"),
+                                  visitor(m_weight, "weight"), visitor(m_stopIds, "stop_ids"),
+                                  visitor(m_point, "point"))
 
 private:
   // |m_featureId| is feature id of a point feature which represents gates.
   FeatureId m_featureId = kInvalidFeatureId;
   // |m_pedestrianFeatureIds| is linear feature ids which can be used for pedestrian routing
   // to leave (to enter) the gate.
-  // @TODO(bykoianko) |m_pedestrianFeatureIds| is not filled from json but should be calculated based on |m_point|.
-  // It should be filled after "gates" are deserialized from json to vector of Gate but before serialization to mwm.
-  // That means that it's necessary to implement two visitors. One of them without visiting |m_pedestrianFeatureIds|
-  // for deserialization from json. And another with visiting |m_pedestrianFeatureIds| for serialization to mwm,
-  // deserialization from mwm and debug print.
   std::vector<FeatureId> m_pedestrianFeatureIds;
   bool m_entrance = true;
   bool m_exit = true;


### PR DESCRIPTION
При сериализации/десериализции секции transit возникает ситуация, при которой поле одной из структур данных должно быть заполнено не из исходного json, а вычислено после десериализации из json, но перед сериализацией в mwm. Затем, при работе программы оно должно десериализоваться из mwm и использоваться.

@tatiana-kondakova @ygorshenin @mpimenov PTAL