### PR TITLE
TransitGraphLoader implementation

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -44,6 +44,8 @@ set(
   edge_estimator.cpp
   edge_estimator.hpp
   fake_edges_container.hpp
+  fake_ending.cpp
+  fake_ending.hpp
   fake_feature_ids.cpp
   fake_feature_ids.hpp
   fake_graph.hpp
@@ -128,6 +130,7 @@ set(
   speed_camera.hpp
   traffic_stash.cpp
   traffic_stash.hpp
+  transit_graph.cpp
   transit_graph.hpp
   transit_graph_loader.cpp
   transit_graph_loader.hpp

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -1,0 +1,79 @@
+#include "routing/fake_ending.hpp"
+
+#include "routing/edge_estimator.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/world_graph.hpp"
+
+#include "geometry/distance.hpp"
+
+#include "base/math.hpp"
+
+#include <functional>
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+using EstimatorFn = function<double(m2::PointD const &, m2::PointD const &)>;
+
+Junction CalcProjectionToSegment(Junction const & begin, Junction const & end,
+                                 m2::PointD const & point, EstimatorFn const & estimate)
+{
+  m2::ProjectionToSection<m2::PointD> projection;
+
+  projection.SetBounds(begin.GetPoint(), end.GetPoint());
+  auto const projectedPoint = projection(point);
+  auto const distBeginToEnd = estimate(begin.GetPoint(), end.GetPoint());
+
+  double constexpr kEpsMeters = 2.0;
+  if (my::AlmostEqualAbs(distBeginToEnd, 0.0, kEpsMeters))
+    return Junction(projectedPoint, begin.GetAltitude());
+
+  auto const distBeginToProjection = estimate(begin.GetPoint(), projectedPoint);
+  auto const altitude = begin.GetAltitude() + (end.GetAltitude() - begin.GetAltitude()) *
+                                                  distBeginToProjection / distBeginToEnd;
+  return Junction(projectedPoint, altitude);
+}
+
+FakeEnding MakeFakeEndingImpl(Junction const & backJunction, Junction const & frontJunction,
+                              Segment const & segment, m2::PointD const & point,
+                              EstimatorFn const & estimate, bool oneWay)
+{
+  auto const & projectedJunction =
+      CalcProjectionToSegment(backJunction, frontJunction, point, estimate);
+
+  FakeEnding ending;
+  ending.m_originJunction = Junction(point, projectedJunction.GetAltitude());
+  ending.m_projections.push_back(
+      Projection{segment, oneWay, frontJunction, backJunction, projectedJunction});
+  return ending;
+}
+}  // namespace
+
+namespace routing
+{
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
+                          EdgeEstimator const & estimator, IndexGraph & graph)
+{
+  auto const & road = graph.GetGeometry().GetRoad(segment.GetFeatureId());
+  bool const oneWay = road.IsOneWay();
+  auto const & frontJunction = road.GetJunction(segment.GetPointId(true /* front */));
+  auto const & backJunction = road.GetJunction(segment.GetPointId(false /* front */));
+  auto const estimate = [&](m2::PointD const & p1, m2::PointD const & p2) {
+    return estimator.CalcLeapWeight(p1, p2);
+  };
+  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, estimate, oneWay);
+}
+
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, WorldGraph & graph)
+{
+  bool const oneWay = graph.IsOneWay(segment.GetMwmId(), segment.GetFeatureId());
+  auto const & frontJunction = graph.GetJunction(segment, true /* front */);
+  auto const & backJunction = graph.GetJunction(segment, false /* front */);
+  auto const estimate = [&](m2::PointD const & p1, m2::PointD const & p2) {
+    return graph.CalcLeapWeight(p1, p2).GetWeight();
+  };
+  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, estimate, oneWay);
+}
+}  // namespace routing

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -9,14 +9,24 @@
 
 namespace routing
 {
-class WorldGraph;
 class EdgeEstimator;
 class IndexGraph;
+class WorldGraph;
 
 struct Projection final
 {
+  Projection(Segment const & segment, bool isOneWay, Junction const & segmentFront,
+             Junction const & segmentBack, Junction const & junction)
+    : m_segment(segment)
+    , m_isOneWay(isOneWay)
+    , m_segmentFront(segmentFront)
+    , m_segmentBack(segmentBack)
+    , m_junction(junction)
+  {
+  }
+
   Segment m_segment;
-  bool m_isOneWay;
+  bool m_isOneWay = false;
   Junction m_segmentFront;
   Junction m_segmentBack;
   Junction m_junction;

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "routing/road_graph.hpp"
+#include "routing/segment.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <vector>
+
+namespace routing
+{
+class WorldGraph;
+class EdgeEstimator;
+class IndexGraph;
+
+struct Projection final
+{
+  Segment m_segment;
+  bool m_isOneWay;
+  Junction m_segmentFront;
+  Junction m_segmentBack;
+  Junction m_junction;
+};
+
+struct FakeEnding final
+{
+  Junction m_originJunction;
+  std::vector<Projection> m_projections;
+};
+
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, WorldGraph & graph);
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
+                          EdgeEstimator const & estimator, IndexGraph & graph);
+}  // namespace routing

--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -44,10 +44,10 @@ public:
   // Adds connection from existent fake segment |from| to existent fake segment |to|
   void AddConnection(SegmentType const & from, SegmentType const & to)
   {
-    CHECK(m_segmentToVertex.find(from) != m_segmentToVertex.end(),
-          ("Segment", from, "does not exist in fake graph."));
-    CHECK(m_segmentToVertex.find(to) != m_segmentToVertex.end(),
-          ("Segment", to, "does not exist in fake graph."));
+    ASSERT(m_segmentToVertex.find(from) != m_segmentToVertex.end(),
+           ("Segment", from, "does not exist in fake graph."));
+    ASSERT(m_segmentToVertex.find(to) != m_segmentToVertex.end(),
+           ("Segment", to, "does not exist in fake graph."));
     m_outgoing[from].insert(to);
     m_ingoing[to].insert(from);
   }

--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -41,6 +41,17 @@ public:
     }
   }
 
+  // Adds connection from existent fake segment |from| to existent fake segment |to|
+  void AddConnection(SegmentType const & from, SegmentType const & to)
+  {
+    CHECK(m_segmentToVertex.find(from) != m_segmentToVertex.end(),
+          ("Segment", from, "does not exist in fake graph."));
+    CHECK(m_segmentToVertex.find(to) != m_segmentToVertex.end(),
+          ("Segment", to, "does not exist in fake graph."));
+    m_outgoing[from].insert(to);
+    m_ingoing[to].insert(from);
+  }
+
   // Merges |rhs| into this.
   void Append(FakeGraph const & rhs)
   {

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/base/routing_result.hpp"
+#include "routing/fake_ending.hpp"
 #include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
 #include "routing/fake_vertex.hpp"
@@ -32,22 +33,8 @@ public:
   using TEdgeType = IndexGraph::TEdgeType;
   using TWeightType = IndexGraph::TWeightType;
 
-  struct Projection final
-  {
-    Segment m_segment;
-    Junction m_junction;
-  };
-
-  struct FakeEnding final
-  {
-    Junction m_originJunction;
-    std::vector<Projection> m_projections;
-  };
-
   friend class FakeEdgesContainer;
 
-  static FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
-                                   WorldGraph & graph);
   static void CheckValidRoute(std::vector<Segment> const & segments);
   static size_t GetRouteNumPoints(std::vector<Segment> const & route);
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -4,6 +4,7 @@
 #include "routing/base/astar_progress.hpp"
 #include "routing/base/routing_result.hpp"
 #include "routing/bicycle_directions.hpp"
+#include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
 #include "routing/index_graph_serialization.hpp"
@@ -437,10 +438,10 @@ IRouter::ResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoint
     if (isFirstSubroute)
       isStartSegmentStrictForward = startSegmentIsAlmostCodirectionalDirection;
 
-    IndexGraphStarter subrouteStarter(
-        IndexGraphStarter::MakeFakeEnding(startSegment, startCheckpoint, *graph),
-        IndexGraphStarter::MakeFakeEnding(finishSegment, finishCheckpoint, *graph),
-        starter ? starter->GetNumFakeSegments() : 0, isStartSegmentStrictForward, *graph);
+    IndexGraphStarter subrouteStarter(MakeFakeEnding(startSegment, startCheckpoint, *graph),
+                                      MakeFakeEnding(finishSegment, finishCheckpoint, *graph),
+                                      starter ? starter->GetNumFakeSegments() : 0,
+                                      isStartSegmentStrictForward, *graph);
 
     vector<Segment> subroute;
     auto const result =
@@ -576,10 +577,10 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   auto const & steps = m_lastRoute->GetSteps();
   CHECK(!steps.empty(), ());
 
-  IndexGraphStarter::FakeEnding dummy;
-  IndexGraphStarter starter(IndexGraphStarter::MakeFakeEnding(startSegment, pointFrom, *graph),
-                            dummy, m_lastFakeEdges->GetNumFakeEdges(),
-                            bestSegmentIsAlmostCodirectional, *graph);
+  FakeEnding dummy;
+  IndexGraphStarter starter(MakeFakeEnding(startSegment, pointFrom, *graph), dummy,
+                            m_lastFakeEdges->GetNumFakeEdges(), bestSegmentIsAlmostCodirectional,
+                            *graph);
 
   starter.Append(*m_lastFakeEdges);
 

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -28,6 +28,7 @@ SOURCES += \
     cross_routing_context.cpp \
     directions_engine.cpp \
     edge_estimator.cpp \
+    fake_ending.cpp \
     fake_feature_ids.cpp \
     features_road_graph.cpp \
     geometry.cpp \
@@ -65,6 +66,7 @@ SOURCES += \
     single_vehicle_world_graph.cpp \
     speed_camera.cpp \
     traffic_stash.cpp \
+    transit_graph.cpp \
     transit_graph_loader.cpp \
     transit_world_graph.cpp \
     turns.cpp \
@@ -96,6 +98,7 @@ HEADERS += \
     directions_engine.hpp \
     edge_estimator.hpp \
     fake_edges_container.hpp \
+    fake_ending.hpp \
     fake_feature_ids.hpp \
     fake_graph.hpp \
     fake_vertex.hpp \

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -1,5 +1,6 @@
 #include "testing/testing.hpp"
 
+#include "routing/fake_ending.hpp"
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_starter.hpp"
@@ -124,10 +125,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
   TEST(!GetTrafficStash()->Has(kTestNumMwmId), ());
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
@@ -143,10 +144,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};  
@@ -162,10 +163,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
@@ -181,10 +182,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
@@ -206,10 +207,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
@@ -223,10 +224,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   TEST(!GetTrafficStash()->Has(kTestNumMwmId), ());
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2.0, -1.0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3.0, 3.0), *graph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
+                                    m2::PointD(2.0, -1.0), *graph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
+                                     m2::PointD(3.0, 3.0), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const noTrafficGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/routing_tests/index_graph_tools.hpp"
 
+#include "routing/fake_ending.hpp"
 #include "routing/geometry.hpp"
 
 #include "traffic/traffic_cache.hpp"
@@ -71,10 +72,10 @@ unique_ptr<SingleVehicleWorldGraph> BuildXYGraph()
 UNIT_TEST(XYGraph)
 {
   unique_ptr<WorldGraph> graph = BuildXYGraph();
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *graph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *graph);
+  auto const start =
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *graph);
+  auto const finish =
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *graph);
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
@@ -91,10 +92,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                        m2::PointD(2, 0), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                        m2::PointD(2, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -108,10 +107,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                        m2::PointD(2, 0), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                        m2::PointD(2, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -127,10 +124,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                        m2::PointD(2, 0), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                        m2::PointD(2, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -146,10 +141,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                        m2::PointD(2, 0), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                        m2::PointD(2, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -165,10 +158,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
 
   TestRestrictions(
       {} /* expectedGeom */, AStarAlgorithm<IndexGraphStarter>::Result::NoPath,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                        m2::PointD(2, 0), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                        m2::PointD(2, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(2, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -243,10 +234,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                        m2::PointD(2, -1), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                        m2::PointD(3, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2, -1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -262,10 +251,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                        m2::PointD(2, -1), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                        m2::PointD(3, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2, -1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -280,10 +267,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                        m2::PointD(2, -1), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                        m2::PointD(3, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2, -1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -302,10 +287,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */),
-                                        m2::PointD(2, -1), *m_graph),
-      IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                        m2::PointD(3, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 9, 0, true /* forward */), m2::PointD(2, -1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(3, 3), *m_graph),
       move(restrictions), *this);
 }
 }  // namespace

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/edge_estimator.hpp"
+#include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_serialization.hpp"
 #include "routing/index_graph_starter.hpp"
@@ -36,8 +37,7 @@ using namespace routing_test;
 
 using TestEdge = TestIndexGraphTopology::Edge;
 
-void TestRoute(IndexGraphStarter::FakeEnding const & start,
-               IndexGraphStarter::FakeEnding const & finish, size_t expectedLength,
+void TestRoute(FakeEnding const & start, FakeEnding const & finish, size_t expectedLength,
                vector<Segment> const * expectedRoute, WorldGraph & graph)
 {
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
@@ -195,13 +195,13 @@ UNIT_TEST(FindPathCross)
   unique_ptr<WorldGraph> worldGraph =
       BuildWorldGraph(move(loader), estimator, {MakeJoint({{0, 2}, {1, 2}})});
 
-  vector<IndexGraphStarter::FakeEnding> endPoints;
+  vector<FakeEnding> endPoints;
   for (uint32_t i = 0; i < 4; ++i)
   {
-    endPoints.push_back(IndexGraphStarter::MakeFakeEnding(
-        Segment(kTestNumMwmId, 0, i, true /*forward*/), m2::PointD(-1.5 + i, 0.0), *worldGraph));
-    endPoints.push_back(IndexGraphStarter::MakeFakeEnding(
-        Segment(kTestNumMwmId, 1, i, true /*forward*/), m2::PointD(0.0, -1.5 + i), *worldGraph));
+    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 0, i, true /*forward*/),
+                                       m2::PointD(-1.5 + i, 0.0), *worldGraph));
+    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 1, i, true /*forward*/),
+                                       m2::PointD(0.0, -1.5 + i), *worldGraph));
   }
 
   for (auto const & start : endPoints)
@@ -272,17 +272,17 @@ UNIT_TEST(FindPathManhattan)
 
   unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(move(loader), estimator, joints);
 
-  vector<IndexGraphStarter::FakeEnding> endPoints;
+  vector<FakeEnding> endPoints;
   for (uint32_t featureId = 0; featureId < kCitySize; ++featureId)
   {
     for (uint32_t segmentId = 0; segmentId < kCitySize - 1; ++segmentId)
     {
-      endPoints.push_back(IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, featureId, segmentId, true /*forward*/),
-          m2::PointD(0.5 + segmentId, featureId), *worldGraph));
-      endPoints.push_back(IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, featureId + kCitySize, segmentId, true /*forward*/),
-          m2::PointD(featureId, 0.5 + segmentId), *worldGraph));
+      endPoints.push_back(
+          MakeFakeEnding(Segment(kTestNumMwmId, featureId, segmentId, true /*forward*/),
+                         m2::PointD(0.5 + segmentId, featureId), *worldGraph));
+      endPoints.push_back(
+          MakeFakeEnding(Segment(kTestNumMwmId, featureId + kCitySize, segmentId, true /*forward*/),
+                         m2::PointD(featureId, 0.5 + segmentId), *worldGraph));
     }
   }
 
@@ -370,10 +370,10 @@ UNIT_TEST(RoadSpeed)
 
   unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(move(loader), estimator, joints);
 
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(0.5, 0), *worldGraph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 1, 3, true /* forward */), m2::PointD(5.5, 0), *worldGraph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
+                                    m2::PointD(0.5, 0), *worldGraph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 1, 3, true /* forward */),
+                                     m2::PointD(5.5, 0), *worldGraph);
 
   vector<Segment> const expectedRoute({{kTestNumMwmId, 1, 0, true},
                                        {kTestNumMwmId, 0, 0, true},
@@ -411,10 +411,10 @@ UNIT_TEST(OneSegmentWay)
   {
     for (auto const finishIsForward : tf)
     {
-      auto const start = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0, 0, startIsForward), m2::PointD(1, 0), *worldGraph);
-      auto const finish = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0, 0, finishIsForward), m2::PointD(2, 0), *worldGraph);
+      auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, startIsForward),
+                                        m2::PointD(1, 0), *worldGraph);
+      auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, finishIsForward),
+                                         m2::PointD(2, 0), *worldGraph);
 
       TestRoute(start, finish, expectedRoute.size(), &expectedRoute, *worldGraph);
     }
@@ -441,10 +441,10 @@ UNIT_TEST(OneSegmentWayBackward)
   shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
   unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(move(loader), estimator, vector<Joint>());
 
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *worldGraph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(1, 0), *worldGraph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                    m2::PointD(2, 0), *worldGraph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                     m2::PointD(1, 0), *worldGraph);
 
   IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */, false /* strictForward */,
                             *worldGraph);
@@ -485,10 +485,10 @@ UNIT_TEST(FakeSegmentCoordinates)
   {
     for (auto const finishIsForward : tf)
     {
-      auto const start = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0, 0, startIsForward), m2::PointD(1, 0), *worldGraph);
-      auto const finish = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 1, 0, finishIsForward), m2::PointD(3, 0), *worldGraph);
+      auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, startIsForward),
+                                        m2::PointD(1, 0), *worldGraph);
+      auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, finishIsForward),
+                                         m2::PointD(3, 0), *worldGraph);
 
       IndexGraphStarter starter(start, finish, 0 /* fakeNumerationStart */,
                                 false /* strictForward */, *worldGraph);
@@ -524,10 +524,10 @@ UNIT_TEST(FakeEndingAStarInvariant)
   vector<Segment> const expectedRoute(
       {{kTestNumMwmId, 0 /* featureId */, 0 /* seg id */, true /* forward */}});
 
-  auto const start = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(1, 1), *worldGraph);
-  auto const finish = IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 1), *worldGraph);
+  auto const start = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                    m2::PointD(1, 1), *worldGraph);
+  auto const finish = MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
+                                     m2::PointD(2, 1), *worldGraph);
 
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, *worldGraph);
 }
@@ -656,12 +656,10 @@ unique_ptr<SingleVehicleWorldGraph> BuildLoopGraph()
 UNIT_CLASS_TEST(RestrictionTest, LoopGraph)
 {
   Init(BuildLoopGraph());
-  auto start = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 1, 0 /* seg id */, true /* forward */), m2::PointD(0.0002, 0),
-      *m_graph);
-  auto finish = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, 2, 0 /* seg id */, true /* forward */), m2::PointD(0.00005, 0.0004),
-      *m_graph);
+  auto start = MakeFakeEnding(Segment(kTestNumMwmId, 1, 0 /* seg id */, true /* forward */),
+                              m2::PointD(0.0002, 0), *m_graph);
+  auto finish = MakeFakeEnding(Segment(kTestNumMwmId, 2, 0 /* seg id */, true /* forward */),
+                               m2::PointD(0.00005, 0.0004), *m_graph);
 
   vector<Segment> const expectedRoute = {{kTestNumMwmId, 1, 0, true},  {kTestNumMwmId, 0, 0, true},
                                          {kTestNumMwmId, 0, 1, true},  {kTestNumMwmId, 0, 8, false},

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -198,9 +198,9 @@ UNIT_TEST(FindPathCross)
   vector<FakeEnding> endPoints;
   for (uint32_t i = 0; i < 4; ++i)
   {
-    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 0, i, true /*forward*/),
+    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 0, i, true /* forward */),
                                        m2::PointD(-1.5 + i, 0.0), *worldGraph));
-    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 1, i, true /*forward*/),
+    endPoints.push_back(MakeFakeEnding(Segment(kTestNumMwmId, 1, i, true /* forward */),
                                        m2::PointD(0.0, -1.5 + i), *worldGraph));
   }
 
@@ -278,11 +278,11 @@ UNIT_TEST(FindPathManhattan)
     for (uint32_t segmentId = 0; segmentId < kCitySize - 1; ++segmentId)
     {
       endPoints.push_back(
-          MakeFakeEnding(Segment(kTestNumMwmId, featureId, segmentId, true /*forward*/),
+          MakeFakeEnding(Segment(kTestNumMwmId, featureId, segmentId, true /* forward */),
                          m2::PointD(0.5 + segmentId, featureId), *worldGraph));
-      endPoints.push_back(
-          MakeFakeEnding(Segment(kTestNumMwmId, featureId + kCitySize, segmentId, true /*forward*/),
-                         m2::PointD(featureId, 0.5 + segmentId), *worldGraph));
+      endPoints.push_back(MakeFakeEnding(
+          Segment(kTestNumMwmId, featureId + kCitySize, segmentId, true /* forward */),
+          m2::PointD(featureId, 0.5 + segmentId), *worldGraph));
     }
   }
 

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -123,10 +123,10 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
   auto const worldGraph = builder.PrepareIndexGraph();
   CHECK(worldGraph != nullptr, ());
 
-  auto const fakeStart = IndexGraphStarter::MakeFakeEnding(
-      Segment(kTestNumMwmId, startFeatureId, 0 /* segmentIdx */, true /* forward */),
-      m2::PointD::Zero(), *worldGraph);
-  auto const fakeFinish = IndexGraphStarter::MakeFakeEnding(
+  auto const fakeStart =
+      MakeFakeEnding(Segment(kTestNumMwmId, startFeatureId, 0 /* segmentIdx */, true /* forward */),
+                     m2::PointD::Zero(), *worldGraph);
+  auto const fakeFinish = MakeFakeEnding(
       Segment(kTestNumMwmId, finishFeatureId, 0 /* segmentIdx */, true /* forward */),
       m2::PointD::Zero(), *worldGraph);
 
@@ -350,8 +350,7 @@ void TestRouteGeometry(IndexGraphStarter & starter,
 
 void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,
                       AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
-                      routing::IndexGraphStarter::FakeEnding const & start,
-                      routing::IndexGraphStarter::FakeEnding const & finish,
+                      FakeEnding const & start, FakeEnding const & finish,
                       RestrictionVec && restrictions, RestrictionTest & restrictionTest)
 {
   restrictionTest.SetRestrictions(move(restrictions));

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/edge_estimator.hpp"
+#include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
 #include "routing/index_graph_starter.hpp"
@@ -40,8 +41,7 @@ struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }
   void Init(unique_ptr<SingleVehicleWorldGraph> graph) { m_graph = move(graph); }
-  void SetStarter(IndexGraphStarter::FakeEnding const & start,
-                  IndexGraphStarter::FakeEnding const & finish)
+  void SetStarter(FakeEnding const & start, FakeEnding const & finish)
   {
     m_starter = make_unique<IndexGraphStarter>(start, finish, 0 /* fakeNumerationStart */,
                                                false /* strictForward */, *m_graph);
@@ -203,8 +203,7 @@ void TestRouteGeometry(
 /// \note restrictionTest should have a valid |restrictionTest.m_graph|.
 void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,
                       AStarAlgorithm<IndexGraphStarter>::Result expectedRouteResult,
-                      routing::IndexGraphStarter::FakeEnding const & start,
-                      routing::IndexGraphStarter::FakeEnding const & finish,
+                      FakeEnding const & start, FakeEnding const & finish,
                       RestrictionVec && restrictions, RestrictionTest & restrictionTest);
 
 // Tries to find a unique path from |from| to |to| in |graph|.

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/routing_tests/index_graph_tools.hpp"
 
+#include "routing/fake_ending.hpp"
 #include "routing/geometry.hpp"
 #include "routing/restriction_loader.hpp"
 
@@ -64,10 +65,9 @@ unique_ptr<SingleVehicleWorldGraph> BuildCrossGraph()
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 {
   Init(BuildCrossGraph());
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
 
   vector<m2::PointD> const expectedGeom = {
       {-1.0 /* x */, 0.0 /* y */}, {0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}};
@@ -77,10 +77,9 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
 {
   Init(BuildCrossGraph());
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph));
 
   RestrictionVec restrictions = {
       {Restriction::Type::No, {1 /* feature from */, 6 /* feature to */}}};
@@ -89,10 +88,8 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(-1, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 7, 0, true /* forward */),
-                                                 m2::PointD(1, 2), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(-1, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 7, 0, true /* forward */), m2::PointD(1, 2), *m_graph),
       move(restrictions), *this);
 }
 
@@ -152,10 +149,8 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -170,10 +165,8 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF2F1)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -187,10 +180,8 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -207,10 +198,8 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionOnlyF5F3)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -225,10 +214,8 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2RestrictionOnl
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -282,10 +269,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -299,10 +284,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F2No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictions), *this);
 }
 
@@ -319,10 +302,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F1Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 4, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -397,10 +378,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       {}, *this);
 }
 
@@ -418,10 +397,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -440,10 +417,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3OnlyF3F4Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -462,10 +437,8 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF2F8NoRestrictionF9F
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */),
-                                                 m2::PointD(0, 3), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 10, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 11, 0, true /* forward */), m2::PointD(0, 3), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -519,10 +492,8 @@ UNIT_TEST(FlagGraph)
 {
   unique_ptr<WorldGraph> graph = BuildFlagGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(0.5, 1), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(0.5, 1), *graph),
       0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {0.5, 1}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
@@ -539,10 +510,9 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(0.5, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(0.5, 1),
+                     *m_graph),
       move(restrictions), *this);
 }
 
@@ -556,10 +526,9 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F1Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(0.5, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(0.5, 1),
+                     *m_graph),
       move(restrictions), *this);
 }
 
@@ -575,10 +544,9 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(0.5, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(0.5, 1),
+                     *m_graph),
       move(restrictions), *this);
 }
 
@@ -628,10 +596,8 @@ UNIT_TEST(PosterGraph)
 {
   unique_ptr<WorldGraph> graph = BuildPosterGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(2, 1), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(2, 1), *graph),
       0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {2, 1}};
 
@@ -649,10 +615,8 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F3No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(2, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(2, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -671,10 +635,8 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F1Only)
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(2, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */),
-                                                 m2::PointD(2, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(2, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 6, 0, true /* forward */), m2::PointD(2, 1), *m_graph),
       move(restrictionsNo), *this);
 }
 
@@ -716,10 +678,8 @@ UNIT_TEST(TwoWayGraph)
 {
   unique_ptr<WorldGraph> graph = BuildTwoWayGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */),
-                                                 m2::PointD(-1, 0), *graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */),
-                                                 m2::PointD(4, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 3, 0, true /* forward */), m2::PointD(-1, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(4, 0), *graph),
       0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{-1 /* x */, 0 /* y */}, {0, 0}, {1, 0}, {3, 0}, {4, 0}};
 
@@ -769,10 +729,8 @@ UNIT_TEST(SquaresGraph)
 {
   unique_ptr<WorldGraph> graph = BuildSquaresGraph();
   IndexGraphStarter starter(
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(0, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(3, 0), *graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(0, 0), *graph),
       0 /* fakeNumerationStart */, false /* strictForward */, *graph);
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}};
   TestRouteGeometry(starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
@@ -791,10 +749,8 @@ UNIT_CLASS_TEST(RestrictionTest, SquaresGraph_RestrictionF0F1OnlyF1F5Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */),
-                                                 m2::PointD(3, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */),
-                                                 m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(3, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 5, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
       move(restrictions), *this);
 }
 
@@ -836,11 +792,9 @@ UNIT_CLASS_TEST(RestrictionTest, LineGraph_RestrictionF1F1No)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
-          m2::PointD(0, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */),
-                                                 m2::PointD(5, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
+                     m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(5, 0), *m_graph),
       move(restrictions), *this);
 }
 
@@ -889,11 +843,9 @@ UNIT_CLASS_TEST(RestrictionTest, FGraph_RestrictionF0F2Only)
 
   TestRestrictions(
       expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
-      routing::IndexGraphStarter::MakeFakeEnding(
-          Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
-          m2::PointD(0, 0), *m_graph),
-      routing::IndexGraphStarter::MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */),
-                                                 m2::PointD(1, 1), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 0 /* feature id */, 0 /* seg id */, true /* forward */),
+                     m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 1, 0, true /* forward */), m2::PointD(1, 1), *m_graph),
       move(restrictions), *this);
 }
 
@@ -943,10 +895,9 @@ UNIT_CLASS_TEST(RestrictionTest, NontransitStart)
                             true /* transitLongWay */));
   vector<m2::PointD> const expectedGeom = {{0 /* x */, 0 /* y */}, {1, 0}, {2, 0}, {3, 0}};
 
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
   TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
 
@@ -957,10 +908,9 @@ UNIT_CLASS_TEST(RestrictionTest, NontransitShortWay)
   vector<m2::PointD> const expectedGeom = {
       {0 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {2, 1}, {2, 0}, {3, 0}};
 
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
   TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
 
@@ -969,10 +919,9 @@ UNIT_CLASS_TEST(RestrictionTest, NontransitWay)
   Init(BuildNontransitGraph(true /* transitStart */, false /* transitShortWay */,
                             false /* transitLongWay */));
 
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
   TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::NoPath, {});
 }
 
@@ -983,10 +932,9 @@ UNIT_CLASS_TEST(RestrictionTest, NontransiStartAndShortWay)
   // We can get F1 because F0 is in the same nontransit area/
   vector<m2::PointD> const expectedGeom = {{0 /* x */, 0 /* y */}, {1, 0}, {2, 0}, {3, 0}};
 
-  SetStarter(routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
-             routing::IndexGraphStarter::MakeFakeEnding(
-                 Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
+  SetStarter(
+      MakeFakeEnding(Segment(kTestNumMwmId, 0, 0, true /* forward */), m2::PointD(0, 0), *m_graph),
+      MakeFakeEnding(Segment(kTestNumMwmId, 2, 0, true /* forward */), m2::PointD(3, 0), *m_graph));
   TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
 }
 }  // namespace routing_test

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -2,9 +2,10 @@
 
 #include "indexer/feature_altitude.hpp"
 
+namespace routing
+{
 namespace
 {
-using namespace routing;
 using namespace std;
 
 Segment GetReverseSegment(Segment const & segment)
@@ -14,8 +15,6 @@ Segment GetReverseSegment(Segment const & segment)
 }
 }  // namespace
 
-namespace routing
-{
 // static
 uint32_t constexpr TransitGraph::kTransitFeatureId;
 
@@ -84,7 +83,8 @@ void TransitGraph::Fill(vector<transit::Stop> const & stops, vector<transit::Gat
     // TODO (@t.yan) after https://github.com/mapsme/omim/pull/7240 merge
     // auto const gateSegment = gate.GetBestPedestrianSegment();
     // Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(), gateSegment.GetForward());
-    auto const ending = MakeFakeEnding( Segment() /* real */, gate.GetPoint(), estimator, indexGraph);
+    auto const ending =
+        MakeFakeEnding(Segment() /* real */, gate.GetPoint(), estimator, indexGraph);
     if (gate.GetEntrance())
       AddGate(gate, ending, stopCoords, true /* isEnter */);
     if (gate.GetExit())
@@ -112,7 +112,7 @@ Segment TransitGraph::GetTransitSegment(uint32_t segmentIdx) const
 Segment TransitGraph::GetNewTransitSegment() const
 {
   CHECK_LESS_OR_EQUAL(m_fake.GetSize(), std::numeric_limits<uint32_t>::max(), ());
-  return GetTransitSegment(static_cast<uint32_t>(m_fake.GetSize()));
+  return GetTransitSegment(static_cast<uint32_t>(m_fake.GetSize()) /* segmentIdx */);
 }
 
 void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending,
@@ -199,8 +199,10 @@ void TransitGraph::AddConnections(map<transit::StopId, set<transit::Edge>> const
       if (segmentsIt == adjacentSegments.cend())
         continue;
       for (auto const & segment : segmentsIt->second)
+      {
         m_fake.AddConnection(isOutgoing ? segment : edgeIt->second,
                              isOutgoing ? edgeIt->second : segment);
+      }
     }
   }
 }

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -1,0 +1,231 @@
+#include "routing/transit_graph.hpp"
+
+#include "indexer/feature_altitude.hpp"
+
+namespace
+{
+using namespace routing;
+using namespace std;
+
+Segment GetReverseSegment(Segment const & segment)
+{
+  return Segment(segment.GetMwmId(), segment.GetFeatureId(), segment.GetSegmentIdx(),
+                 !segment.IsForward());
+}
+}  // namespace
+
+namespace routing
+{
+// static
+uint32_t constexpr TransitGraph::kTransitFeatureId;
+
+// static
+bool TransitGraph::IsTransitFeature(uint32_t featureId) { return featureId == kTransitFeatureId; }
+
+// static
+bool TransitGraph::IsTransitSegment(Segment const & segment)
+{
+  return IsTransitFeature(segment.GetFeatureId());
+}
+
+Junction const & TransitGraph::GetJunction(Segment const & segment, bool front) const
+{
+  CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
+  auto const & vertex = m_fake.GetVertex(segment);
+  return front ? vertex.GetJunctionTo() : vertex.GetJunctionFrom();
+}
+
+RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment,
+                                            EdgeEstimator const & estimator) const
+{
+  CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
+  if (IsGate(segment))
+    return RouteWeight(GetGate(segment).GetWeight(), 0 /* nontransitCross */);
+
+  if (IsEdge(segment))
+    return RouteWeight(GetEdge(segment).GetWeight(), 0 /* nontransitCross */);
+
+  // Estimate weight for part of real and projections.
+  return RouteWeight(estimator.CalcLeapWeight(GetJunction(segment, false /* front */).GetPoint(),
+                                              GetJunction(segment, true /* front */).GetPoint()),
+                     0 /* nontransitCross */);
+}
+
+void TransitGraph::GetTransitEdges(Segment const & segment, bool isOutgoing,
+                                   vector<SegmentEdge> & edges,
+                                   EdgeEstimator const & estimator) const
+{
+  CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
+  for (auto const & s : m_fake.GetEdges(segment, isOutgoing))
+    edges.emplace_back(s, CalcSegmentWeight(isOutgoing ? s : segment, estimator));
+}
+
+set<Segment> const & TransitGraph::GetFake(Segment const & real) const
+{
+  return m_fake.GetFake(real);
+}
+
+bool TransitGraph::FindReal(Segment const & fake, Segment & real) const
+{
+  return m_fake.FindReal(fake, real);
+}
+
+void TransitGraph::Fill(vector<transit::Stop> const & stops, vector<transit::Gate> const & gates,
+                        vector<transit::Edge> const & edges, EdgeEstimator const & estimator,
+                        NumMwmId numMwmId, IndexGraph & indexGraph)
+{
+  m_mwmId = numMwmId;
+  map<transit::StopId, Junction> stopCoords;
+  for (auto const & stop : stops)
+    stopCoords[stop.GetId()] = Junction(stop.GetPoint(), feature::kDefaultAltitudeMeters);
+
+  for (auto const & gate : gates)
+  {
+    // TODO (@t.yan) after https://github.com/mapsme/omim/pull/7240 merge
+    // auto const gateSegment = gate.GetBestPedestrianSegment();
+    // Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(), gateSegment.GetForward());
+    auto const ending = MakeFakeEnding( Segment() /* real */, gate.GetPoint(), estimator, indexGraph);
+    if (gate.GetEntrance())
+      AddGate(gate, ending, stopCoords, true /* isEnter */);
+    if (gate.GetExit())
+      AddGate(gate, ending, stopCoords, false /* isEnter */);
+  }
+
+  map<transit::StopId, set<transit::Edge>> outgoing;
+  map<transit::StopId, set<transit::Edge>> ingoing;
+  for (auto const & edge : edges)
+  {
+    AddEdge(edge, stopCoords);
+    outgoing[edge.GetStartStopId()].insert(edge);
+    ingoing[edge.GetFinishStopId()].insert(edge);
+  }
+
+  AddConnections(outgoing, true /* isOutgoing */);
+  AddConnections(ingoing, false /* isOutgoing */);
+}
+
+Segment TransitGraph::GetTransitSegment(uint32_t segmentIdx) const
+{
+  return Segment(m_mwmId, kTransitFeatureId, segmentIdx, false);
+}
+
+Segment TransitGraph::GetNewTransitSegment() const
+{
+  CHECK_LESS_OR_EQUAL(m_fake.GetSize(), std::numeric_limits<uint32_t>::max(), ());
+  return GetTransitSegment(static_cast<uint32_t>(m_fake.GetSize()));
+}
+
+void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending,
+                           map<transit::StopId, Junction> const & stopCoords, bool isEnter)
+{
+  Segment const dummy = Segment();
+  for (auto const & projection : ending.m_projections)
+  {
+    // Add projection edges
+    auto const projectionSegment = GetNewTransitSegment();
+    FakeVertex projectionVertex(isEnter ? projection.m_junction : ending.m_originJunction,
+                                isEnter ? ending.m_originJunction : projection.m_junction,
+                                FakeVertex::Type::PureFake);
+    m_fake.AddStandaloneVertex(projectionSegment, projectionVertex);
+
+    // Add fake parts of real
+    FakeVertex forwardPartOfReal(isEnter ? projection.m_segmentBack : projection.m_junction,
+                                 isEnter ? projection.m_junction : projection.m_segmentFront,
+                                 FakeVertex::Type::PartOfReal);
+    auto const fakeForwardSegment = GetNewTransitSegment();
+    m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
+                     !isEnter /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
+
+    if (!projection.m_isOneWay)
+    {
+      FakeVertex backwardPartOfReal(isEnter ? projection.m_segmentFront : projection.m_junction,
+                                    isEnter ? projection.m_junction : projection.m_segmentBack,
+                                    FakeVertex::Type::PartOfReal);
+      auto const fakeBackwardSegment = GetNewTransitSegment();
+      m_fake.AddVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
+                       !isEnter /* isOutgoing */, true /* isPartOfReal */,
+                       GetReverseSegment(projection.m_segment));
+    }
+
+    // Connect gate to stops
+    for (auto const stopId : gate.GetStopIds())
+    {
+      auto const gateSegment = GetNewTransitSegment();
+      auto const stopIt = stopCoords.find(stopId);
+      CHECK(stopIt != stopCoords.end(), ("Stop", stopId, "does not exist."));
+      FakeVertex gateVertex(isEnter ? ending.m_originJunction : stopIt->second,
+                            isEnter ? stopIt->second : ending.m_originJunction,
+                            FakeVertex::Type::PureFake);
+      m_fake.AddVertex(projectionSegment, gateSegment, gateVertex, isEnter /* isOutgoing */,
+                       false /* isPartOfReal */, dummy /* realSegment */);
+      m_segmentToGate[gateSegment] = gate;
+      if (isEnter)
+        m_stopToFront[stopId].insert(gateSegment);
+      else
+        m_stopToBack[stopId].insert(gateSegment);
+    }
+  }
+}
+
+void TransitGraph::AddEdge(transit::Edge const & edge,
+                           map<transit::StopId, Junction> const & stopCoords)
+{
+  auto const edgeSegment = GetNewTransitSegment();
+  auto const startStopId = edge.GetStartStopId();
+  auto const finishStopId = edge.GetFinishStopId();
+  auto const startStopIt = stopCoords.find(startStopId);
+  CHECK(startStopIt != stopCoords.end(), ("Stop", startStopId, "does not exist."));
+  auto const finishStopIt = stopCoords.find(finishStopId);
+  CHECK(finishStopIt != stopCoords.end(), ("Stop", finishStopId, "does not exist."));
+  FakeVertex edgeVertex(startStopIt->second, finishStopIt->second, FakeVertex::Type::PureFake);
+  m_fake.AddStandaloneVertex(edgeSegment, edgeVertex);
+  m_segmentToEdge[edgeSegment] = edge;
+  m_edgeToSegment[edge] = edgeSegment;
+  m_stopToBack[startStopId].insert(edgeSegment);
+  m_stopToFront[finishStopId].insert(edgeSegment);
+}
+
+void TransitGraph::AddConnections(map<transit::StopId, set<transit::Edge>> const & connections,
+                                  bool isOutgoing)
+{
+  for (auto const & connection : connections)
+  {
+    for (auto const & edge : connection.second)
+    {
+      auto const edgeIt = m_edgeToSegment.find(edge);
+      CHECK(edgeIt != m_edgeToSegment.cend(), ("Unknown edge", edge));
+      auto const & adjacentSegments = isOutgoing ? m_stopToFront : m_stopToBack;
+      auto const segmentsIt = adjacentSegments.find(connection.first);
+      if (segmentsIt == adjacentSegments.cend())
+        continue;
+      for (auto const & segment : segmentsIt->second)
+        m_fake.AddConnection(isOutgoing ? segment : edgeIt->second,
+                             isOutgoing ? edgeIt->second : segment);
+    }
+  }
+}
+
+bool TransitGraph::IsGate(Segment const & segment) const
+{
+  return m_segmentToGate.count(segment) > 0;
+}
+
+bool TransitGraph::IsEdge(Segment const & segment) const
+{
+  return m_segmentToEdge.count(segment) > 0;
+}
+
+transit::Edge const & TransitGraph::GetEdge(Segment const & segment) const
+{
+  auto const it = m_segmentToEdge.find(segment);
+  CHECK(it != m_segmentToEdge.cend(), ("Unknown transit segment."));
+  return it->second;
+}
+
+transit::Gate const & TransitGraph::GetGate(Segment const & segment) const
+{
+  auto const it = m_segmentToGate.find(segment);
+  CHECK(it != m_segmentToGate.cend(), ("Unknown transit segment."));
+  return it->second;
+}
+}  // namespace routing

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -2,37 +2,46 @@
 
 #include "routing/routing_exceptions.hpp"
 
+#include "routing_common/transit_serdes.hpp"
+#include "routing_common/transit_types.hpp"
+
 #include "indexer/mwm_set.hpp"
 
 #include "platform/country_file.hpp"
+
+#include "coding/file_container.hpp"
 
 #include "base/timer.hpp"
 
 #include "std/unique_ptr.hpp"
 
+#include <vector>
+
 using namespace std;
 
 namespace routing
 {
-TransitGraphLoader::TransitGraphLoader(shared_ptr<NumMwmIds> numMwmIds, Index & index)
-  : m_index(index), m_numMwmIds(numMwmIds)
+TransitGraphLoader::TransitGraphLoader(shared_ptr<NumMwmIds> numMwmIds, Index & index,
+                                       shared_ptr<EdgeEstimator> estimator)
+  : m_index(index), m_numMwmIds(numMwmIds), m_estimator(estimator)
 {
 }
 
 void TransitGraphLoader::Clear() { m_graphs.clear(); }
 
-TransitGraph & TransitGraphLoader::GetTransitGraph(NumMwmId numMwmId)
+TransitGraph & TransitGraphLoader::GetTransitGraph(NumMwmId numMwmId, IndexGraph & indexGraph)
 {
   auto const it = m_graphs.find(numMwmId);
   if (it != m_graphs.cend())
     return *it->second;
 
-  auto const emplaceRes = m_graphs.emplace(numMwmId, CreateTransitGraph(numMwmId));
+  auto const emplaceRes = m_graphs.emplace(numMwmId, CreateTransitGraph(numMwmId, indexGraph));
   ASSERT(emplaceRes.second, ("Failed to add TransitGraph for", numMwmId, "to TransitGraphLoader."));
   return *(emplaceRes.first)->second;
 }
 
-std::unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmId)
+unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmId,
+                                                                IndexGraph & indexGraph) const
 {
   platform::CountryFile const & file = m_numMwmIds->GetFile(numMwmId);
   MwmSet::MwmHandle handle = m_index.GetMwmHandleByCountryFile(file);
@@ -41,9 +50,38 @@ std::unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId nu
 
   my::Timer timer;
   auto graphPtr = make_unique<TransitGraph>();
-  // TODO (@t.yan)
-  // MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
-  // DeserializeTransitGraph(mwmValue, *graph);
+  MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
+  if (!mwmValue.m_cont.IsExist(TRANSIT_FILE_TAG))
+    return graphPtr;
+
+  try
+  {
+    FilesContainerR::TReader reader(mwmValue.m_cont.GetReader(TRANSIT_FILE_TAG));
+    ReaderSource<FilesContainerR::TReader> src(reader);
+    transit::Deserializer<ReaderSource<FilesContainerR::TReader>> deserializer(src);
+
+    transit::TransitHeader header;
+    header.Visit(deserializer);
+
+    vector<transit::Stop> stops;
+    deserializer(stops);
+
+    CHECK_EQUAL(src.Pos(), header.m_gatesOffset,("Wrong section format."));
+    vector<transit::Gate> gates;
+    deserializer(gates);
+
+    CHECK_EQUAL(src.Pos(), header.m_edgesOffset,("Wrong section format."));
+    vector<transit::Edge> edges;
+    deserializer(edges);
+
+    graphPtr->Fill(stops, gates, edges, *m_estimator, numMwmId, indexGraph);
+  }
+  catch (Reader::OpenException const & e)
+  {
+    LOG(LERROR, ("Error while reading", TRANSIT_FILE_TAG, "section.", e.Msg()));
+    throw;
+  }
+
   LOG(LINFO, (TRANSIT_FILE_TAG, "section for", file.GetName(), "loaded in",
               timer.ElapsedSeconds(), "seconds"));
   return graphPtr;

--- a/routing/transit_graph_loader.hpp
+++ b/routing/transit_graph_loader.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "routing/edge_estimator.hpp"
+#include "routing/index_graph.hpp"
 #include "routing/num_mwm_id.hpp"
 #include "routing/transit_graph.hpp"
 
@@ -13,16 +15,18 @@ namespace routing
 class TransitGraphLoader final
 {
 public:
-  TransitGraphLoader(std::shared_ptr<NumMwmIds> numMwmIds, Index & index);
+  TransitGraphLoader(std::shared_ptr<NumMwmIds> numMwmIds, Index & index,
+                     std::shared_ptr<EdgeEstimator> estimator);
 
-  TransitGraph & GetTransitGraph(NumMwmId mwmId);
+  TransitGraph & GetTransitGraph(NumMwmId mwmId, IndexGraph & indexGraph);
   void Clear();
 
 private:
-  std::unique_ptr<TransitGraph> CreateTransitGraph(NumMwmId mwmId);
+  std::unique_ptr<TransitGraph> CreateTransitGraph(NumMwmId mwmId, IndexGraph & indexGraph) const;
 
   Index & m_index;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
+  std::shared_ptr<EdgeEstimator> m_estimator;
   std::unordered_map<NumMwmId, std::unique_ptr<TransitGraph>> m_graphs;
 };
 }  // namespace routing

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -54,6 +54,8 @@ private:
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  IndexGraph & GetIndexGraph(NumMwmId mwmId);
+  TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_indexLoader;

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -101,13 +101,24 @@ Edge::Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId
 {
 }
 
-bool Edge::IsEqualForTesting(Edge const & edge) const
+bool Edge::operator<(Edge const & rhs) const
 {
-  return m_startStopId == edge.m_startStopId && m_finishStopId == edge.m_finishStopId &&
-         my::AlmostEqualAbs(m_weight, edge.m_weight, kWeightEqualEpsilon) &&
-         m_lineId == edge.m_lineId && m_transfer == edge.m_transfer &&
-         m_shapeIds == edge.m_shapeIds;
+  if (m_startStopId != rhs.m_startStopId)
+    return m_startStopId < rhs.m_startStopId;
+  if (m_finishStopId != rhs.m_finishStopId)
+    return m_finishStopId < rhs.m_finishStopId;
+  if (m_lineId != rhs.m_lineId)
+    return m_lineId < rhs.m_lineId;
+  if (m_transfer != rhs.m_transfer)
+    return m_transfer < rhs.m_transfer;
+  if (m_shapeIds != rhs.m_shapeIds)
+    return m_shapeIds < rhs.m_shapeIds;
+  if (!my::AlmostEqualAbs(m_weight, rhs.m_weight, kWeightEqualEpsilon))
+    return m_weight < rhs.m_weight;
+  return false;
 }
+
+bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge || edge < *this); }
 
 // Transfer ---------------------------------------------------------------------------------------
 Transfer::Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds)

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -141,6 +141,8 @@ public:
   bool GetTransfer() const { return m_transfer; }
   std::vector<ShapeId> const & GetShapeIds() const { return m_shapeIds; }
 
+  bool operator<(Edge const & rhs) const;
+
   DECLARE_VISITOR_AND_DEBUG_PRINT(Edge, visitor(m_startStopId, "start_stop_id"),
                                   visitor(m_finishStopId, "finish_stop_id"),
                                   visitor(m_weight, "weight"), visitor(m_lineId, "line_id"),

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -66,11 +66,14 @@
 		4065EA851F8260010094DEF3 /* transit_graph_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */; };
 		4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */; };
 		4065EA871F8260010094DEF3 /* transit_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA841F8260000094DEF3 /* transit_graph.hpp */; };
+		4081AD4E1F8E4C1D006CE8A5 /* transit_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */; };
 		40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */; };
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
 		40C227FE1F61C07C0046696C /* fake_edges_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C227FD1F61C07C0046696C /* fake_edges_container.hpp */; };
+		40C645161F8D167F002E05A0 /* fake_ending.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40C645141F8D167E002E05A0 /* fake_ending.cpp */; };
+		40C645171F8D167F002E05A0 /* fake_ending.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C645151F8D167E002E05A0 /* fake_ending.hpp */; };
 		40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */; };
 		40F7F3E51F7D246D0082D564 /* single_vehicle_world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
@@ -361,11 +364,14 @@
 		4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph_loader.cpp; sourceTree = "<group>"; };
 		4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph_loader.hpp; sourceTree = "<group>"; };
 		4065EA841F8260000094DEF3 /* transit_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph.hpp; sourceTree = "<group>"; };
+		4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph.cpp; sourceTree = "<group>"; };
 		40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
 		40C227FD1F61C07C0046696C /* fake_edges_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_edges_container.hpp; sourceTree = "<group>"; };
+		40C645141F8D167E002E05A0 /* fake_ending.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_ending.cpp; sourceTree = "<group>"; };
+		40C645151F8D167E002E05A0 /* fake_ending.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_ending.hpp; sourceTree = "<group>"; };
 		40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_vehicle_world_graph.hpp; sourceTree = "<group>"; };
 		40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = single_vehicle_world_graph.cpp; sourceTree = "<group>"; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
@@ -844,6 +850,8 @@
 				0C5FEC521DDE191E0017688C /* edge_estimator.cpp */,
 				0C5FEC531DDE191E0017688C /* edge_estimator.hpp */,
 				40C227FD1F61C07C0046696C /* fake_edges_container.hpp */,
+				40C645141F8D167E002E05A0 /* fake_ending.cpp */,
+				40C645151F8D167E002E05A0 /* fake_ending.hpp */,
 				40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */,
 				40655E731F8BA46B0065305E /* fake_feature_ids.hpp */,
 				405F48E81F75231E005BA81A /* fake_graph.hpp */,
@@ -924,6 +932,7 @@
 				0C81E1521F02589800DC66DF /* traffic_stash.hpp */,
 				4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */,
 				4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */,
+				4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */,
 				4065EA841F8260000094DEF3 /* transit_graph.hpp */,
 				4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */,
 				4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */,
@@ -1053,6 +1062,7 @@
 				0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */,
 				670B84C11A9381D900CE4492 /* cross_routing_context.hpp in Headers */,
 				0C12ED241E5C822A0080D0F4 /* index_router.hpp in Headers */,
+				40C645171F8D167F002E05A0 /* fake_ending.hpp in Headers */,
 				0C5FEC651DDE192A0017688C /* joint.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1303,6 +1313,7 @@
 				0CF709361F05172200D5067E /* checkpoints.cpp in Sources */,
 				671F58BD1B874EC80032311E /* followed_polyline.cpp in Sources */,
 				670EE55D1B6001E7001E8064 /* routing_session.cpp in Sources */,
+				40C645161F8D167F002E05A0 /* fake_ending.cpp in Sources */,
 				A120B3451B4A7BE5002F3808 /* cross_mwm_road_graph.cpp in Sources */,
 				56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */,
 				674A28B11B1605D2001A525C /* osrm_engine.cpp in Sources */,
@@ -1320,6 +1331,7 @@
 				568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */,
 				4065EA811F824A6C0094DEF3 /* transit_world_graph.cpp in Sources */,
 				0C12ED231E5C822A0080D0F4 /* index_router.cpp in Sources */,
+				4081AD4E1F8E4C1D006CE8A5 /* transit_graph.cpp in Sources */,
 				6753441E1A3F644F00A0A8C3 /* turns.cpp in Sources */,
 				4065EA851F8260010094DEF3 /* transit_graph_loader.cpp in Sources */,
 				670B84C01A9381D900CE4492 /* cross_routing_context.cpp in Sources */,


### PR DESCRIPTION
1. FakeEnding переехал в отдельный файл, в него добавилась дополнительная информация (координаты начала и конец сегмента, на который делается проекция, признак однонаправленности), чтобы можно было использовать для построения проекций там, где не доступен IndexGraph.
2. В FakeGraph добавлен метод AddConnection, который соединяет существующие вершины.
3. В TransitGraphLoader добавлены вызовы десериалайзера для чтения данных из секции transit. Чтобы соединить граф транспорта с пешеходными сегментами также понадобилось протащить туда IndexGraph для чтения геометрии.
4. В TransitGraph добавлен метод Fill, который заполняет граф на основании информации из секции transit и вспомогательные методы. Все основные изменения здесь.

Изменения в InexRouter и тестах -- только переезд FakeEnding из InexGraphStarter.
Тесты для TransitGraph будут отдельным PR.