### PR TITLE
Getting rid of TransitGraph::m_edgeToSegment and transit::Edge::operator<

### DIFF
--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -45,8 +45,10 @@ private:
 
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
                std::map<transit::StopId, Junction> const & stopCoords, bool isEnter);
-  void AddEdge(transit::Edge const & edge, std::map<transit::StopId, Junction> const & stopCoords);
-  void AddConnections(map<transit::StopId, std::set<transit::Edge>> const & connections,
+  // Adds transit edge to fake graph, returns corresponding transit segment.
+  Segment AddEdge(transit::Edge const & edge,
+                  std::map<transit::StopId, Junction> const & stopCoords);
+  void AddConnections(std::map<transit::StopId, std::set<Segment>> const & connections,
                       bool isOutgoing);
 
   bool IsGate(Segment const & segment) const;
@@ -60,7 +62,6 @@ private:
   std::map<Segment, transit::Edge> m_segmentToEdge;
   std::map<Segment, transit::Gate> m_segmentToGate;
   // TODO (@t.yan) move m_edgeToSegment, m_stopToBack, m_stopToFront to Fill
-  std::map<transit::Edge, Segment> m_edgeToSegment;
   std::map<transit::StopId, std::set<Segment>> m_stopToBack;
   std::map<transit::StopId, std::set<Segment>> m_stopToFront;
 };

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -133,24 +133,13 @@ Edge::Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool tr
 {
 }
 
-bool Edge::operator<(Edge const & rhs) const
+bool Edge::IsEqualForTesting(Edge const & edge) const
 {
-  if (m_stop1Id != rhs.m_stop1Id)
-    return m_stop1Id < rhs.m_stop1Id;
-  if (m_stop2Id != rhs.m_stop2Id)
-    return m_stop2Id < rhs.m_stop2Id;
-  if (m_lineId != rhs.m_lineId)
-    return m_lineId < rhs.m_lineId;
-  if (m_transfer != rhs.m_transfer)
-    return m_transfer < rhs.m_transfer;
-  if (m_shapeIds != rhs.m_shapeIds)
-    return m_shapeIds < rhs.m_shapeIds;
-  if (!my::AlmostEqualAbs(m_weight, rhs.m_weight, kWeightEqualEpsilon))
-    return m_weight < rhs.m_weight;
-  return false;
+  return m_stop1Id == edge.m_stop1Id && m_stop2Id == edge.m_stop2Id &&
+         my::AlmostEqualAbs(m_weight, edge.m_weight, kWeightEqualEpsilon) &&
+         m_lineId == edge.m_lineId && m_transfer == edge.m_transfer &&
+         m_shapeIds == edge.m_shapeIds;
 }
-
-bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge || edge < *this); }
 
 // Transfer ---------------------------------------------------------------------------------------
 Transfer::Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -199,8 +199,6 @@ public:
   bool GetTransfer() const { return m_transfer; }
   std::vector<ShapeId> const & GetShapeIds() const { return m_shapeIds; }
 
-  bool operator<(Edge const & rhs) const;
-
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Edge, visitor(m_stop1Id, "stop1_id"),


### PR DESCRIPTION
Мелкий рефакторинг: избавилась от TransitGraph::m_edgeToSegment и от transit::Edge::operator<, который был плох.