### PR TITLE
Renaming start_stop_id to stop1_id and finish_stop_id to stop2_id at transit json.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -117,26 +117,26 @@ UNIT_TEST(DeserializerFromJson_Edges)
   {
   "edges": [
     {
-      "finish_stop_id": 442018445,
+      "stop2_id": 442018445,
       "line_id": 72551680,
       "shape_ids": [5, 7],
-      "start_stop_id": 442018444,
+      "stop1_id": 442018444,
       "transfer": false
     },
     {
-      "finish_stop_id": 442018446,
+      "stop2_id": 442018446,
       "line_id": 72551680,
       "shape_ids": [],
       "weight" : 345.6,
-      "start_stop_id": 442018445,
+      "stop1_id": 442018445,
       "transfer": false
     }
   ]})";
 
   vector<Edge> const expected = {
-    Edge(442018444 /* start stop id */, 442018445 /* finish stop id */, kInvalidWeight /* weight */,
+    Edge(442018444 /* stop 1 id */, 442018445 /* stop 2 id */, kInvalidWeight /* weight */,
          72551680 /* line id */,  false /* transfer */, {5, 7} /* shape ids */),
-    Edge(442018445 /* start stop id */, 442018446 /* finish stop id */, 345.6 /* weight */,
+    Edge(442018445 /* stop 1 id */, 442018446 /* stop 2 id */, 345.6 /* weight */,
          72551680 /* line id */,  false /* transfer */, {} /* shape ids */)};
 
   TestDeserializerFromJson(jsonBuffer, "edges", expected);

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -96,8 +96,8 @@ void TransitGraph::Fill(vector<transit::Stop> const & stops, vector<transit::Gat
   for (auto const & edge : edges)
   {
     AddEdge(edge, stopCoords);
-    outgoing[edge.GetStartStopId()].insert(edge);
-    ingoing[edge.GetFinishStopId()].insert(edge);
+    outgoing[edge.GetStop1Id()].insert(edge);
+    ingoing[edge.GetStop2Id()].insert(edge);
   }
 
   AddConnections(outgoing, true /* isOutgoing */);
@@ -171,8 +171,8 @@ void TransitGraph::AddEdge(transit::Edge const & edge,
                            map<transit::StopId, Junction> const & stopCoords)
 {
   auto const edgeSegment = GetNewTransitSegment();
-  auto const startStopId = edge.GetStartStopId();
-  auto const finishStopId = edge.GetFinishStopId();
+  auto const startStopId = edge.GetStop1Id();
+  auto const finishStopId = edge.GetStop2Id();
   auto const startStopIt = stopCoords.find(startStopId);
   CHECK(startStopIt != stopCoords.end(), ("Stop", startStopId, "does not exist."));
   auto const finishStopIt = stopCoords.find(finishStopId);

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -96,10 +96,10 @@ bool Gate::IsEqualForTesting(Gate const & gate) const
 }
 
 // Edge -------------------------------------------------------------------------------------------
-Edge::Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId, bool transfer,
+Edge::Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
            std::vector<ShapeId> const & shapeIds)
-  : m_startStopId(startStopId)
-  , m_finishStopId(finishStopId)
+  : m_stop1Id(stop1Id)
+  , m_stop2Id(stop2Id)
   , m_weight(weight)
   , m_lineId(lineId)
   , m_transfer(transfer)
@@ -109,10 +109,10 @@ Edge::Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId
 
 bool Edge::operator<(Edge const & rhs) const
 {
-  if (m_startStopId != rhs.m_startStopId)
-    return m_startStopId < rhs.m_startStopId;
-  if (m_finishStopId != rhs.m_finishStopId)
-    return m_finishStopId < rhs.m_finishStopId;
+  if (m_stop1Id != rhs.m_stop1Id)
+    return m_stop1Id < rhs.m_stop1Id;
+  if (m_stop2Id != rhs.m_stop2Id)
+    return m_stop2Id < rhs.m_stop2Id;
   if (m_lineId != rhs.m_lineId)
     return m_lineId < rhs.m_lineId;
   if (m_transfer != rhs.m_transfer)

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -161,12 +161,12 @@ class Edge
 {
 public:
   Edge() = default;
-  Edge(StopId startStopId, StopId finishStopId, double weight, LineId lineId, bool transfer,
+  Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
        std::vector<ShapeId> const & shapeIds);
   bool IsEqualForTesting(Edge const & edge) const;
 
-  StopId GetStartStopId() const { return m_startStopId; }
-  StopId GetFinishStopId() const { return m_finishStopId; }
+  StopId GetStop1Id() const { return m_stop1Id; }
+  StopId GetStop2Id() const { return m_stop2Id; }
   double GetWeight() const { return m_weight; }
   LineId GetLineId() const { return m_lineId; }
   bool GetTransfer() const { return m_transfer; }
@@ -176,13 +176,13 @@ public:
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
-  DECLARE_VISITOR_AND_DEBUG_PRINT(Edge, visitor(m_startStopId, "start_stop_id"),
-                                  visitor(m_finishStopId, "finish_stop_id"),
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Edge, visitor(m_stop1Id, "stop1_id"),
+                                  visitor(m_stop2Id, "stop2_id"),
                                   visitor(m_weight, "weight"), visitor(m_lineId, "line_id"),
                                   visitor(m_transfer, "transfer"), visitor(m_shapeIds, "shape_ids"))
 
-  StopId m_startStopId = kInvalidStopId;
-  StopId m_finishStopId = kInvalidStopId;
+  StopId m_stop1Id = kInvalidStopId;
+  StopId m_stop2Id = kInvalidStopId;
   double m_weight = kInvalidWeight; // in seconds
   LineId m_lineId = kInvalidLineId;
   bool m_transfer = false;

--- a/tools/python/transit/transit_graph_generator.py
+++ b/tools/python/transit/transit_graph_generator.py
@@ -139,8 +139,8 @@ class TransitGraphBuilder:
     def __read_transfers(self):
         """Reads transfers between stops."""
         for transfer_item in self.input_data['transfers']:
-            transfer_edge = {'start_stop_id': transfer_item[0],
-                             'finish_stop_id': transfer_item[1],
+            transfer_edge = {'stop_1_id': transfer_item[0],
+                             'stop_2_id': transfer_item[1],
                              'weight': transfer_item[2],
                              'transfer': True}
             self.edges.append(transfer_edge)
@@ -179,8 +179,8 @@ class TransitGraphBuilder:
                     for i in range(len(line_stops)):
                         self.stops[line_stops[i]]['line_ids'].append(line_id)
                         if i < len(line_stops) - 1:
-                            edge = {'start_stop_id': line_stops[i],
-                                    'finish_stop_id': line_stops[i + 1],
+                            edge = {'stop_1_id': line_stops[i],
+                                    'stop_2_id': line_stops[i + 1],
                                     'transfer': False,
                                     'line_id': line_id,
                                     'shape_ids': []}
@@ -193,8 +193,8 @@ class TransitGraphBuilder:
         """Merges stops into transfer nodes."""
         for edge in self.edges:
             if edge['transfer']:
-                node1 = self.__get_interchange_node(edge['start_stop_id'])
-                node2 = self.__get_interchange_node(edge['finish_stop_id'])
+                node1 = self.__get_interchange_node(edge['stop_1_id'])
+                node2 = self.__get_interchange_node(edge['stop_2_id'])
                 merged_node = tuple(sorted(set(node1 + node2)))
                 self.interchange_nodes.discard(node1)
                 self.interchange_nodes.discard(node2)
@@ -272,8 +272,8 @@ class TransitGraphBuilder:
         """Assigns a shape to each non-transfer edge."""
         for edge in self.edges:
             if not edge['transfer']:
-                stop1 = self.stops[edge['start_stop_id']]
-                stop2 = self.stops[edge['finish_stop_id']]
+                stop1 = self.stops[edge['stop_1_id']]
+                stop2 = self.stops[edge['stop_2_id']]
                 id1 = stop1.get('transfer_id', stop1['id'])
                 id2 = stop2.get('transfer_id', stop2['id'])
                 seg = tuple(sorted([id1, id2]))


### PR DESCRIPTION
В класс Edge (массив json "edges") поля назывались не очень удачно: start_stop_id и finish_stop_id. В то время, как в классе Shape (массив json "edges") поля с похожим значением называются: stop1_id и stop2_id. Теперь, все приведено к единообразию и называется одинаково. Как в Shape. 

Документацию так же обновил: https://confluence.mail.ru/display/MAPSME/Subway+Data+Preparation

@rokuz @darina @tatiana-kondakova PTAL