### PR TITLE
Use nearest pedestrian segment stored in mwm for transit to real mapping

### DIFF
--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -80,11 +80,10 @@ void TransitGraph::Fill(vector<transit::Stop> const & stops, vector<transit::Gat
 
   for (auto const & gate : gates)
   {
-    // TODO (@t.yan) after https://github.com/mapsme/omim/pull/7240 merge
-    // auto const gateSegment = gate.GetBestPedestrianSegment();
-    // Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(), gateSegment.GetForward());
+    auto const gateSegment = gate.GetBestPedestrianSegment();
+    Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(), gateSegment.GetForward());
     auto const ending =
-        MakeFakeEnding(Segment() /* real */, gate.GetPoint(), estimator, indexGraph);
+        MakeFakeEnding(real, gate.GetPoint(), estimator, indexGraph);
     if (gate.GetEntrance())
       AddGate(gate, ending, stopCoords, true /* isEnter */);
     if (gate.GetExit())


### PR DESCRIPTION
После того как в transit был смержен пул-реквест https://github.com/mapsme/omim/pull/7240 merge , включаю использование сохраненной в рамках него информации о ближайшем пешеходном сегменте в TransitGraph.