### PR TITLE
Saving title anchors at transit section.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "drape/drape_global.hpp"
+
 #include "generator/transit_generator.hpp"
 
 #include "routing_common/transit_types.hpp"
@@ -37,12 +39,12 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
   {
   "title_anchors": [
     { "min_zoom": 11, "anchor": 4 },
-    { "min_zoom": 14, "anchor": 7 }
+    { "min_zoom": 14, "anchor": 6 }
   ]})";
 
   vector<TitleAnchor> expected = {
-    TitleAnchor(11 /* min zoom */, 4 /* anchor */),
-    TitleAnchor(14 /* min zoom */, 7 /* anchor */)
+    TitleAnchor(11 /* min zoom */, dp::Anchor::Top),
+    TitleAnchor(14 /* min zoom */, dp::Anchor::RightTop)
   };
   TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
 }
@@ -78,7 +80,7 @@ UNIT_TEST(DeserializerFromJson_Stops)
       },
       "title_anchors": [
         { "min_zoom": 12, "anchor": 0 },
-        { "min_zoom": 15, "anchor": 7 }]
+        { "min_zoom": 15, "anchor": 9 }]
     }
   ]})";
 
@@ -88,7 +90,8 @@ UNIT_TEST(DeserializerFromJson_Stops)
            {} /* anchors */),
       Stop(266680843 /* id */, 2345 /* featureId */, 5 /* transfer id */,
            {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
-           { TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 7)} /* anchor */)};
+           {TitleAnchor(12 /* min zoom */, dp::Anchor::Center),
+            TitleAnchor(15, dp::Anchor::LeftBottom)} /* anchor */)};
 
   TestDeserializerFromJson(jsonBuffer, "stops", expected);
 }

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -31,6 +31,22 @@ void TestDeserializerFromJson(string const & jsonBuffer, string const & name, ve
     TEST(objects[i].IsEqualForTesting(expected[i]), (objects[i], expected[i]));
 }
 
+UNIT_TEST(DeserializerFromJson_TitleAnchors)
+{
+  string const jsonBuffer = R"(
+  {
+  "title_anchors": [
+    { "min_zoom": 11, "anchors": "r" },
+    { "min_zoom": 14, "anchors": "bl" }
+  ]})";
+
+  vector<TitleAnchor> expected = {
+    TitleAnchor(11 /* min zoom */, "r" /* anchors */),
+    TitleAnchor(14 /* min zoom */, "bl" /* anchors */)
+  };
+  TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
+}
+
 UNIT_TEST(DeserializerFromJson_Stops)
 {
   string const jsonBuffer = R"(
@@ -60,15 +76,19 @@ UNIT_TEST(DeserializerFromJson_Stops)
         "x": 27.5227942,
         "y": 64.25206634443111
       },
-      "title_anchors": []
+      "title_anchors": [
+        { "min_zoom": 12, "anchors": "t" },
+        { "min_zoom": 15, "anchors": "tl" }]
     }
   ]})";
 
   vector<Stop> const expected = {
       Stop(343259523 /* id */, 1234 /* featureId */, kInvalidTransferId /* transfer id */,
-           {19207936, 19207937} /* lineIds */,  {27.4970954, 64.20146835878187} /* point */),
+           {19207936, 19207937} /* lineIds */, {27.4970954, 64.20146835878187} /* point */,
+           {} /* anchors */),
       Stop(266680843 /* id */, 2345 /* featureId */, 5 /* transfer id */,
-           {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */)};
+           {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
+           { TitleAnchor(12 /* min zoom */, "t" /* anchors */), TitleAnchor(15, "tl")} /* anchors */)};
 
   TestDeserializerFromJson(jsonBuffer, "stops", expected);
 }
@@ -162,7 +182,7 @@ UNIT_TEST(DeserializerFromJson_Transfers)
 
   vector<Transfer> const expected = {Transfer(922337203 /* stop id */,
                                               {27.5619844, 64.24325959173672} /* point */,
-                                              {209186416, 277039518} /* stopIds */)};
+                                              {209186416, 277039518} /* stopIds */, {} /* anchors */)};
 
   TestDeserializerFromJson(jsonBuffer, "transfers", expected);
 }

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -36,13 +36,13 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
   string const jsonBuffer = R"(
   {
   "title_anchors": [
-    { "min_zoom": 11, "anchors": "r" },
-    { "min_zoom": 14, "anchors": "bl" }
+    { "min_zoom": 11, "anchor": 4 },
+    { "min_zoom": 14, "anchor": 7 }
   ]})";
 
   vector<TitleAnchor> expected = {
-    TitleAnchor(11 /* min zoom */, "r" /* anchors */),
-    TitleAnchor(14 /* min zoom */, "bl" /* anchors */)
+    TitleAnchor(11 /* min zoom */, 4 /* anchor */),
+    TitleAnchor(14 /* min zoom */, 7 /* anchor */)
   };
   TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
 }
@@ -77,8 +77,8 @@ UNIT_TEST(DeserializerFromJson_Stops)
         "y": 64.25206634443111
       },
       "title_anchors": [
-        { "min_zoom": 12, "anchors": "t" },
-        { "min_zoom": 15, "anchors": "tl" }]
+        { "min_zoom": 12, "anchor": 0 },
+        { "min_zoom": 15, "anchor": 7 }]
     }
   ]})";
 
@@ -88,7 +88,7 @@ UNIT_TEST(DeserializerFromJson_Stops)
            {} /* anchors */),
       Stop(266680843 /* id */, 2345 /* featureId */, 5 /* transfer id */,
            {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
-           { TitleAnchor(12 /* min zoom */, "t" /* anchors */), TitleAnchor(15, "tl")} /* anchors */)};
+           { TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 7)} /* anchor */)};
 
   TestDeserializerFromJson(jsonBuffer, "stops", expected);
 }

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -42,10 +42,8 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
     { "min_zoom": 14, "anchor": 6 }
   ]})";
 
-  vector<TitleAnchor> expected = {
-    TitleAnchor(11 /* min zoom */, dp::Anchor::Top),
-    TitleAnchor(14 /* min zoom */, dp::Anchor::RightTop)
-  };
+  vector<TitleAnchor> expected = {TitleAnchor(11 /* min zoom */, dp::Anchor::Top),
+                                  TitleAnchor(14 /* min zoom */, dp::Anchor::RightTop)};
   TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
 }
 
@@ -183,9 +181,9 @@ UNIT_TEST(DeserializerFromJson_Transfers)
     }
   ]})";
 
-  vector<Transfer> const expected = {Transfer(922337203 /* stop id */,
-                                              {27.5619844, 64.24325959173672} /* point */,
-                                              {209186416, 277039518} /* stopIds */, {} /* anchors */)};
+  vector<Transfer> const expected = {
+      Transfer(922337203 /* stop id */, {27.5619844, 64.24325959173672} /* point */,
+               {209186416, 277039518} /* stopIds */, {} /* anchors */)};
 
   TestDeserializerFromJson(jsonBuffer, "transfers", expected);
 }

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -1,7 +1,5 @@
 #include "testing/testing.hpp"
 
-#include "drape/drape_global.hpp"
-
 #include "generator/transit_generator.hpp"
 
 #include "routing_common/transit_types.hpp"
@@ -42,8 +40,8 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
     { "min_zoom": 14, "anchor": 6 }
   ]})";
 
-  vector<TitleAnchor> expected = {TitleAnchor(11 /* min zoom */, dp::Anchor::Top),
-                                  TitleAnchor(14 /* min zoom */, dp::Anchor::RightTop)};
+  vector<TitleAnchor> expected = {TitleAnchor(11 /* min zoom */, 4 /* anchor */),
+                                  TitleAnchor(14 /* min zoom */, 6 /* anchor */)};
   TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
 }
 
@@ -88,8 +86,7 @@ UNIT_TEST(DeserializerFromJson_Stops)
            {} /* anchors */),
       Stop(266680843 /* id */, 2345 /* featureId */, 5 /* transfer id */,
            {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
-           {TitleAnchor(12 /* min zoom */, dp::Anchor::Center),
-            TitleAnchor(15, dp::Anchor::LeftBottom)} /* anchor */)};
+           {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 
   TestDeserializerFromJson(jsonBuffer, "stops", expected);
 }

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -56,15 +56,15 @@ UNIT_TEST(Transit_HeaderSerialization)
 UNIT_TEST(Transit_TitleAnchorSerialization)
 {
   {
-    TitleAnchor anchor(17 /* min zoom */, "t" /* anchors */);
+    TitleAnchor anchor(17 /* min zoom */, 0 /* anchor */);
     TestSerialization(anchor);
   }
   {
-    TitleAnchor anchor(10 /* min zoom */, "b" /* anchors */);
+    TitleAnchor anchor(10 /* min zoom */, 4 /* anchor */);
     TestSerialization(anchor);
   }
   {
-    TitleAnchor anchor(18 /* min zoom */, "bl" /* anchors */);
+    TitleAnchor anchor(18 /* min zoom */, 3 /* anchor */);
     TestSerialization(anchor);
   }
 }
@@ -111,7 +111,7 @@ UNIT_TEST(Transit_EdgeSerialization)
 UNIT_TEST(Transit_TransferSerialization)
 {
   Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */,
-                    { TitleAnchor(16, "br")});
+                    { TitleAnchor(16, 3)});
   TestSerialization(transfer);
 }
 

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -76,8 +76,8 @@ UNIT_TEST(Transit_StopSerialization)
     TestSerialization(stop);
   }
   {
-    Stop stop(1234 /* id */, 5678 /* feature id */, 7 /* transfer id */, {7, 8, 9, 10} /* line id */,
-              {55.0, 37.0} /* point */, {} /* anchors */);
+    Stop stop(1234 /* id */, 5678 /* feature id */, 7 /* transfer id */,
+              {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */, {} /* anchors */);
     TestSerialization(stop);
   }
 }
@@ -111,7 +111,7 @@ UNIT_TEST(Transit_EdgeSerialization)
 UNIT_TEST(Transit_TransferSerialization)
 {
   Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */,
-                    { TitleAnchor(16, 3)});
+                    {TitleAnchor(16, 3)});
   TestSerialization(transfer);
 }
 

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -60,11 +60,11 @@ UNIT_TEST(Transit_TitleAnchorSerialization)
     TestSerialization(anchor);
   }
   {
-    TitleAnchor anchor(10 /* min zoom */, 4 /* anchor */);
+    TitleAnchor anchor(10 /* min zoom */, 2 /* anchor */);
     TestSerialization(anchor);
   }
   {
-    TitleAnchor anchor(18 /* min zoom */, 3 /* anchor */);
+    TitleAnchor anchor(18 /* min zoom */, 7 /* anchor */);
     TestSerialization(anchor);
   }
 }
@@ -111,7 +111,7 @@ UNIT_TEST(Transit_EdgeSerialization)
 UNIT_TEST(Transit_TransferSerialization)
 {
   Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */,
-                    {TitleAnchor(16, 3)});
+                    {TitleAnchor(16, 0 /* anchor */)});
   TestSerialization(transfer);
 }
 

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -53,6 +53,22 @@ UNIT_TEST(Transit_HeaderSerialization)
   }
 }
 
+UNIT_TEST(Transit_TitleAnchorSerialization)
+{
+  {
+    TitleAnchor anchor(17 /* min zoom */, "t" /* anchors */);
+    TestSerialization(anchor);
+  }
+  {
+    TitleAnchor anchor(10 /* min zoom */, "b" /* anchors */);
+    TestSerialization(anchor);
+  }
+  {
+    TitleAnchor anchor(18 /* min zoom */, "bl" /* anchors */);
+    TestSerialization(anchor);
+  }
+}
+
 UNIT_TEST(Transit_StopSerialization)
 {
   {
@@ -60,8 +76,21 @@ UNIT_TEST(Transit_StopSerialization)
     TestSerialization(stop);
   }
   {
-    Stop stop(1234 /* id */, 5678 /* feature id */, 7 /* transfer id */, {7, 8, 9, 10} /* line id */, {55.0, 37.0});
+    Stop stop(1234 /* id */, 5678 /* feature id */, 7 /* transfer id */, {7, 8, 9, 10} /* line id */,
+              {55.0, 37.0} /* point */, {} /* anchors */);
     TestSerialization(stop);
+  }
+}
+
+UNIT_TEST(Transit_SingleMwmSegmentSerialization)
+{
+  {
+    SingleMwmSegment s(12344 /* feature id */, 0 /* segmentIdx */, true /* forward */);
+    TestSerialization(s);
+  }
+  {
+    SingleMwmSegment s(12544 /* feature id */, 5 /* segmentIdx */, false /* forward */);
+    TestSerialization(s);
   }
 }
 
@@ -81,7 +110,8 @@ UNIT_TEST(Transit_EdgeSerialization)
 
 UNIT_TEST(Transit_TransferSerialization)
 {
-  Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */);
+  Transfer transfer(1 /* id */, {40.0, 35.0} /* point */, {1, 2, 3} /* stop ids */,
+                    { TitleAnchor(16, "br")});
   TestSerialization(transfer);
 }
 

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -50,23 +50,24 @@ public:
     WriteToSink(m_sink, t);
   }
 
-  template<typename T>
-  typename std::enable_if<std::is_same<T, uint32_t>::value || std::is_same<T, uint64_t>::value>::type
-      operator()(T t, char const * name = nullptr) const
+  template <typename T>
+  typename std::enable_if<std::is_same<T, uint32_t>::value ||
+                          std::is_same<T, uint64_t>::value>::type
+  operator()(T t, char const * name = nullptr) const
   {
     WriteVarUint(m_sink, t);
   }
 
-  template<typename T>
+  template <typename T>
   typename std::enable_if<std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value>::type
-      operator()(T t, char const * name = nullptr) const
+  operator()(T t, char const * name = nullptr) const
   {
     WriteVarInt(m_sink, t);
   }
 
-  template<typename T>
+  template <typename T>
   typename std::enable_if<std::is_same<T, double>::value || std::is_same<T, float>::value>::type
-      operator()(T d, char const * name = nullptr)
+  operator()(T d, char const * name = nullptr)
   {
     CHECK_GREATER_OR_EQUAL(d, kMinDoubleAtTransitSection, ());
     CHECK_LESS_OR_EQUAL(d, kMaxDoubleAtTransitSection, ());
@@ -131,23 +132,24 @@ public:
     ReadPrimitiveFromSource(m_source, t);
   }
 
-  template<typename T>
-  typename std::enable_if<std::is_same<T, uint32_t>::value || std::is_same<T, uint64_t>::value>::type
-      operator()(T & t, char const * name = nullptr)
+  template <typename T>
+  typename std::enable_if<std::is_same<T, uint32_t>::value ||
+                          std::is_same<T, uint64_t>::value>::type
+  operator()(T & t, char const * name = nullptr)
   {
     t = ReadVarUint<T, Source>(m_source);
   }
 
-  template<typename T>
+  template <typename T>
   typename std::enable_if<std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value>::type
-      operator()(T & t, char const * name = nullptr)
+  operator()(T & t, char const * name = nullptr)
   {
     t = ReadVarInt<T, Source>(m_source);
   }
 
-  template<typename T>
+  template <typename T>
   typename std::enable_if<std::is_same<T, double>::value || std::is_same<T, float>::value>::type
-      operator()(T & d, char const * name = nullptr)
+  operator()(T & d, char const * name = nullptr)
   {
     uint32_t ui;
     (*this)(ui, name);

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -54,24 +54,53 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
          && m_endOffset == header.m_endOffset;
 }
 
+// TitleAnchor ------------------------------------------------------------------------------------
+TitleAnchor::TitleAnchor(uint8_t minZoom, std::string const & anchors)
+  : m_minZoom(minZoom), m_anchors(anchors)
+{
+}
+
+bool TitleAnchor::operator==(TitleAnchor const & titleAnchor) const
+{
+  return m_minZoom == titleAnchor.m_minZoom && m_anchors == titleAnchor.m_anchors;
+}
+
+bool TitleAnchor::IsEqualForTesting(TitleAnchor const & titleAnchor) const
+{
+  return *this == titleAnchor;
+}
+
 // Stop -------------------------------------------------------------------------------------------
-Stop::Stop(StopId id, FeatureId featureId, TransferId transferId, std::vector<LineId> const & lineIds,
-           m2::PointD const & point)
-  : m_id(id), m_featureId(featureId), m_transferId(transferId), m_lineIds(lineIds), m_point(point)
+Stop::Stop(StopId id, FeatureId featureId, TransferId transferId,
+           std::vector<LineId> const & lineIds, m2::PointD const & point,
+           std::vector<TitleAnchor> const & titleAnchors)
+  : m_id(id)
+  , m_featureId(featureId)
+  , m_transferId(transferId)
+  , m_lineIds(lineIds)
+  , m_point(point)
+  , m_titleAnchors(titleAnchors)
 {
 }
 
 bool Stop::IsEqualForTesting(Stop const & stop) const
 {
   double constexpr kPointsEqualEpsilon = 1e-6;
-  return m_id == stop.m_id && m_featureId == stop.m_featureId && m_transferId == stop.m_transferId &&
-         m_lineIds == stop.m_lineIds && my::AlmostEqualAbs(m_point, stop.m_point, kPointsEqualEpsilon);
+  return m_id == stop.m_id && m_featureId == stop.m_featureId &&
+         m_transferId == stop.m_transferId && m_lineIds == stop.m_lineIds &&
+         my::AlmostEqualAbs(m_point, stop.m_point, kPointsEqualEpsilon) &&
+         m_titleAnchors == stop.m_titleAnchors;
 }
 
 // SingleMwmSegment -------------------------------------------------------------------------------
 SingleMwmSegment::SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, bool forward)
   : m_featureId(featureId), m_segmentIdx(segmentIdx), m_forward(forward)
 {
+}
+
+bool SingleMwmSegment::IsEqualForTesting(SingleMwmSegment const & s) const
+{
+  return m_featureId == s.m_featureId && m_segmentIdx == s.m_segmentIdx && m_forward == s.m_forward;
 }
 
 // Gate -------------------------------------------------------------------------------------------
@@ -127,8 +156,9 @@ bool Edge::operator<(Edge const & rhs) const
 bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge || edge < *this); }
 
 // Transfer ---------------------------------------------------------------------------------------
-Transfer::Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds)
-  : m_id(id), m_point(point), m_stopIds(stopIds)
+Transfer::Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
+                   std::vector<TitleAnchor> const & titleAnchors)
+  : m_id(id), m_point(point), m_stopIds(stopIds), m_titleAnchors(titleAnchors)
 {
 }
 
@@ -136,7 +166,8 @@ bool Transfer::IsEqualForTesting(Transfer const & transfer) const
 {
   return m_id == transfer.m_id &&
          my::AlmostEqualAbs(m_point, transfer.m_point, kPointsEqualEpsilon) &&
-         m_stopIds == transfer.m_stopIds;
+         m_stopIds == transfer.m_stopIds &&
+         m_titleAnchors == transfer.m_titleAnchors;
 }
 
 // Line -------------------------------------------------------------------------------------------

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -55,14 +55,13 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
 }
 
 // TitleAnchor ------------------------------------------------------------------------------------
-TitleAnchor::TitleAnchor(uint8_t minZoom, std::string const & anchors)
-  : m_minZoom(minZoom), m_anchors(anchors)
+TitleAnchor::TitleAnchor(uint8_t minZoom, Anchor anchor) : m_minZoom(minZoom), m_anchor(anchor)
 {
 }
 
 bool TitleAnchor::operator==(TitleAnchor const & titleAnchor) const
 {
-  return m_minZoom == titleAnchor.m_minZoom && m_anchors == titleAnchor.m_anchors;
+  return m_minZoom == titleAnchor.m_minZoom && m_anchor == titleAnchor.m_anchor;
 }
 
 bool TitleAnchor::IsEqualForTesting(TitleAnchor const & titleAnchor) const

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -55,9 +55,7 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
 }
 
 // TitleAnchor ------------------------------------------------------------------------------------
-TitleAnchor::TitleAnchor(uint8_t minZoom, Anchor anchor) : m_minZoom(minZoom), m_anchor(anchor)
-{
-}
+TitleAnchor::TitleAnchor(uint8_t minZoom, Anchor anchor) : m_minZoom(minZoom), m_anchor(anchor) {}
 
 bool TitleAnchor::operator==(TitleAnchor const & titleAnchor) const
 {
@@ -165,8 +163,7 @@ bool Transfer::IsEqualForTesting(Transfer const & transfer) const
 {
   return m_id == transfer.m_id &&
          my::AlmostEqualAbs(m_point, transfer.m_point, kPointsEqualEpsilon) &&
-         m_stopIds == transfer.m_stopIds &&
-         m_titleAnchors == transfer.m_titleAnchors;
+         m_stopIds == transfer.m_stopIds && m_titleAnchors == transfer.m_titleAnchors;
 }
 
 // Line -------------------------------------------------------------------------------------------

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -22,6 +22,7 @@ using NetworkId = uint32_t;
 using FeatureId = uint32_t;
 using ShapeId = uint32_t;
 using Weight = double;
+using Anchor = uint8_t;
 
 LineId constexpr kInvalidLineId = std::numeric_limits<LineId>::max();
 StopId constexpr kInvalidStopId = std::numeric_limits<StopId>::max();
@@ -32,6 +33,7 @@ ShapeId constexpr kInvalidShapeId = std::numeric_limits<ShapeId>::max();
 // Note. Weight may be a default param at json. The default value should be saved as uint32_t in mwm anyway.
 // To convert double to uint32_t at better accuracy |kInvalidWeight| should be close to real weight.
 Weight constexpr kInvalidWeight = -1.0;
+Anchor constexpr kInvalidAnchor = std::numeric_limits<Anchor>::max();
 
 #define DECLARE_TRANSIT_TYPE_FRIENDS                                                           \
     template<class Sink> friend class Serializer;                                              \
@@ -77,21 +79,21 @@ class TitleAnchor
 {
 public:
   TitleAnchor() = default;
-  TitleAnchor(uint8_t minZoom, std::string const & anchors);
+  TitleAnchor(uint8_t minZoom, Anchor anchor);
 
   bool operator==(TitleAnchor const & titleAnchor) const;
   bool IsEqualForTesting(TitleAnchor const & titleAnchor) const;
 
   uint8_t GetMinZoom() const { return m_minZoom; }
-  std::string const & GetAnchors() const { return m_anchors; }
+  Anchor const & GetAnchor() const { return m_anchor; }
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(TitleAnchor, visitor(m_minZoom, "min_zoom"),
-                                  visitor(m_anchors, "anchors"))
+                                  visitor(m_anchor, "anchor"))
 
   uint8_t m_minZoom = scales::UPPER_STYLE_SCALE;
-  std::string m_anchors;
+  Anchor m_anchor = kInvalidAnchor;
 };
 
 class Stop

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -131,7 +131,7 @@ class SingleMwmSegment
 public:
   SingleMwmSegment() = default;
   SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, bool forward);
-  bool IsEqualForTesting(SingleMwmSegment const & s) const ;
+  bool IsEqualForTesting(SingleMwmSegment const & s) const;
 
   FeatureId GetFeatureId() const { return m_featureId; }
   uint32_t GetSegmentIdx() const { return m_segmentIdx; }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "indexer/scales.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "base/visitor.hpp"
@@ -71,12 +73,33 @@ public:
 
 static_assert(sizeof(TransitHeader) == 32, "Wrong header size of transit section.");
 
+class TitleAnchor
+{
+public:
+  TitleAnchor() = default;
+  TitleAnchor(uint8_t minZoom, std::string const & anchors);
+
+  bool operator==(TitleAnchor const & titleAnchor) const;
+  bool IsEqualForTesting(TitleAnchor const & titleAnchor) const;
+
+  uint8_t GetMinZoom() const { return m_minZoom; }
+  std::string const & GetAnchors() const { return m_anchors; }
+
+private:
+  DECLARE_TRANSIT_TYPE_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(TitleAnchor, visitor(m_minZoom, "min_zoom"),
+                                  visitor(m_anchors, "anchors"))
+
+  uint8_t m_minZoom = scales::UPPER_STYLE_SCALE;
+  std::string m_anchors;
+};
+
 class Stop
 {
 public:
   Stop() = default;
   Stop(StopId id, FeatureId featureId, TransferId transferId, std::vector<LineId> const & lineIds,
-       m2::PointD const & point);
+       m2::PointD const & point, std::vector<TitleAnchor> const & titleAnchors);
   bool IsEqualForTesting(Stop const & stop) const;
 
   StopId GetId() const { return m_id; }
@@ -84,20 +107,21 @@ public:
   TransferId GetTransferId() const { return m_transferId; }
   std::vector<LineId> const & GetLineIds() const { return m_lineIds; }
   m2::PointD const & GetPoint() const { return m_point; }
+  std::vector<TitleAnchor> const & GetTitleAnchors() const { return m_titleAnchors; }
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Stop, visitor(m_id, "id"), visitor(m_featureId, "osm_id"),
                                   visitor(m_transferId, "transfer_id"),
-                                  visitor(m_lineIds, "line_ids"), visitor(m_point, "point"))
+                                  visitor(m_lineIds, "line_ids"), visitor(m_point, "point"),
+                                  visitor(m_titleAnchors, "title_anchors"))
 
   StopId m_id = kInvalidStopId;
   FeatureId m_featureId = kInvalidFeatureId;
   TransferId m_transferId = kInvalidTransferId;
   std::vector<LineId> m_lineIds;
   m2::PointD m_point;
-  // @TODO(bykoianko) It's necessary to add field m_titleAnchors here and implement serialization
-  // and deserialization.
+  std::vector<TitleAnchor> m_titleAnchors;
 };
 
 class SingleMwmSegment
@@ -105,6 +129,7 @@ class SingleMwmSegment
 public:
   SingleMwmSegment() = default;
   SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, bool forward);
+  bool IsEqualForTesting(SingleMwmSegment const & s) const ;
 
   FeatureId GetFeatureId() const { return m_featureId; }
   uint32_t GetSegmentIdx() const { return m_segmentIdx; }
@@ -193,24 +218,25 @@ class Transfer
 {
 public:
   Transfer() = default;
-  Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds);
+  Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
+           std::vector<TitleAnchor> const & titleAnchors);
   bool IsEqualForTesting(Transfer const & transfer) const;
 
   StopId GetId() const { return m_id; }
   m2::PointD const & GetPoint() const { return m_point; }
   std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
+  std::vector<TitleAnchor> const & GetTitleAnchors() const { return m_titleAnchors; }
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Transfer, visitor(m_id, "id"), visitor(m_point, "point"),
-                                  visitor(m_stopIds, "stop_ids"))
+                                  visitor(m_stopIds, "stop_ids"),
+                                  visitor(m_titleAnchors, "title_anchors"))
 
   StopId m_id = kInvalidStopId;
   m2::PointD m_point;
   std::vector<StopId> m_stopIds;
-
-  // @TODO(bykoianko) It's necessary to add field m_titleAnchors here and implement serialization
-  // and deserialization.
+  std::vector<TitleAnchor> m_titleAnchors;
 };
 
 class Line


### PR DESCRIPTION
Сохраняем title anchors в секции общественного транспорта: реализация, тесты.

В рамках PR хочу обсудить один вопрос. Строка TitleAnchor::m_anchors может иметь только 8 значений: "t", "tl", "l", "bl", "b", "br", "r", "tr". Согласно данному PR мы сохраняем в mwm строчку из 1-2 символов для якоря. Можно было бы преобразовать строчку в enum, у которого 8 значений и сохранять его, как varint.

Для десериализации из json, сериализации в mwm, десериализации из mwm и debug print используется механизм визиторов. В рамках его, можно добавить поле TitleAnchor::m_anchorsInEnum, и заполнять его после десериализации якорей из json. Но затем, при сериализации в mwm придется как-то игнорировать TitleAnchor::m_anchors. Например, по имени (что мне не очень нравится). Какие я визу варианты:
 1. в визиторах по сериализции/десериализации использовать имена полей. Это не очень хорошо, поскольку может появиться класс, с полями с таким же именем;
 2. сохранять строчки: "t", "tl", "l", "bl", "b", "br", "r", "tr" в mwm вместо varint. Получим увеличение размера mwm, хотя, как мне кажется не значительное;
 3. переводить якоря в int при генерации json. Потеряем наглядность и удобство отладки.

Сейчас я склоняюсь к варианту 2, его и реализовал. Мнения/комментарии?
**Edited**. По результатам разговора с @rokuz и @darina  cейчас доделаю, чтоб реализовать вариант 3.

@ygorshenin @rokuz @tatiana-kondakova @darina @mpimenov PTAL
