### PR TITLE
Transit data structure validity and calculation edge weights.

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -23,7 +23,7 @@
 #include "routing_common/bicycle_model.hpp"
 #include "routing_common/car_model.hpp"
 #include "routing_common/pedestrian_model.hpp"
-#include "routing_common/transit_max_speed.hpp"
+#include "routing_common/transit_speed_limits.hpp"
 
 #include "indexer/feature_altitude.hpp"
 
@@ -61,7 +61,7 @@ double CalcMaxSpeed(NumMwmIds const & numMwmIds,
                     VehicleType vehicleType)
 {
   if (vehicleType == VehicleType::Transit)
-    return kTransitMaxSpeedKMpH;
+    return transit::kTransitMaxSpeedKMpH;
 
   double maxSpeed = 0.0;
   numMwmIds.ForEachId([&](NumMwmId id) {

--- a/routing_common/CMakeLists.txt
+++ b/routing_common/CMakeLists.txt
@@ -9,8 +9,8 @@ set(
   num_mwm_id.hpp
   pedestrian_model.cpp
   pedestrian_model.hpp
-  transit_speed_limits.hpp
   transit_serdes.hpp
+  transit_speed_limits.hpp
   transit_types.cpp
   transit_types.hpp
   vehicle_model.cpp

--- a/routing_common/CMakeLists.txt
+++ b/routing_common/CMakeLists.txt
@@ -9,7 +9,7 @@ set(
   num_mwm_id.hpp
   pedestrian_model.cpp
   pedestrian_model.hpp
-  transit_max_speed.hpp
+  transit_speed_limits.hpp
   transit_serdes.hpp
   transit_types.cpp
   transit_types.hpp

--- a/routing_common/routing_common.pro
+++ b/routing_common/routing_common.pro
@@ -25,7 +25,7 @@ HEADERS += \
     car_model.hpp \
     num_mwm_id.hpp \
     pedestrian_model.hpp \
-    transit_max_speed.hpp \
+    transit_speed_limits.hpp \
     transit_serdes.hpp \
     transit_types.hpp \
     vehicle_model.hpp \

--- a/routing_common/routing_common.pro
+++ b/routing_common/routing_common.pro
@@ -25,7 +25,7 @@ HEADERS += \
     car_model.hpp \
     num_mwm_id.hpp \
     pedestrian_model.hpp \
-    transit_speed_limits.hpp \
     transit_serdes.hpp \
+    transit_speed_limits.hpp \
     transit_types.hpp \
     vehicle_model.hpp \

--- a/routing_common/transit_max_speed.hpp
+++ b/routing_common/transit_max_speed.hpp
@@ -1,6 +1,0 @@
-#pragma once
-
-namespace routing
-{
-double constexpr kTransitMaxSpeedKMpH = 400;
-}  // namespace routing

--- a/routing_common/transit_speed_limits.hpp
+++ b/routing_common/transit_speed_limits.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace routing
+{
+namespace transit
+{
+  double constexpr kTransitMaxSpeedKMpH = 400;
+}  // namespace transit
+}  // namespace routing

--- a/routing_common/transit_speed_limits.hpp
+++ b/routing_common/transit_speed_limits.hpp
@@ -5,9 +5,9 @@ namespace routing
 namespace transit
 {
 double constexpr kTransitMaxSpeedKMpH = 400.0;
-// @TODO(bykoianko, Zverik) Edge and gate weights should be valid always valid. This weights should come
-// from transit graph json. But now it'not so. |kTransitAverageSpeedKMpH| should be used now only for
-// weight calculating weight at transit section generation stage and should be removed later.
-double constexpr kTransitAverageSpeedKMpH = 40.0;
+// @TODO(bykoianko, Zverik) Edge and gate weights should be always valid. This weights should come
+// from transit graph json. But now it's not so. |kTransitAverageSpeedMPS| should be used now only for
+// weight calculating at transit section generation stage and the constant should be removed later.
+double constexpr kTransitAverageSpeedMPS = 11.0;
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_speed_limits.hpp
+++ b/routing_common/transit_speed_limits.hpp
@@ -4,6 +4,10 @@ namespace routing
 {
 namespace transit
 {
-  double constexpr kTransitMaxSpeedKMpH = 400;
+double constexpr kTransitMaxSpeedKMpH = 400.0;
+// @TODO(bykoianko, Zverik) Edge and gate weights should be valid always valid. This weights should come
+// from transit graph json. But now it'not so. |kTransitAverageSpeedKMpH| should be used now only for
+// weight calculating weight at transit section generation stage and should be removed later.
+double constexpr kTransitAverageSpeedKMpH = 40.0;
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -181,8 +181,8 @@ bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge ||
 
 bool Edge::IsValid() const
 {
-  // @TODO(bykoianko) |m_weight| should be valid for Edge validity.
-  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_lineId != kInvalidLineId;
+  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight &&
+         m_lineId != kInvalidLineId;
 }
 
 // Transfer ---------------------------------------------------------------------------------------

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -119,7 +119,7 @@ bool SingleMwmSegment::IsEqualForTesting(SingleMwmSegment const & s) const
 
 bool SingleMwmSegment::IsValid() const
 {
-  return true;
+  return m_featureId != kInvalidFeatureId;
 }
 
 // Gate -------------------------------------------------------------------------------------------
@@ -145,7 +145,7 @@ bool Gate::IsEqualForTesting(Gate const & gate) const
 
 bool Gate::IsValid() const
 {
-  return m_weight != kInvalidWeight && !m_stopIds.empty();
+  return m_weight != kInvalidWeight && (m_entrance || m_exit) && !m_stopIds.empty();
 }
 
 // Edge -------------------------------------------------------------------------------------------
@@ -181,6 +181,12 @@ bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge ||
 
 bool Edge::IsValid() const
 {
+  if (m_transfer && (m_lineId != kInvalidLineId || !m_shapeIds.empty()))
+    return false;
+
+  if (!m_transfer && m_lineId == kInvalidLineId)
+    return false;
+
   return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight &&
          m_lineId != kInvalidLineId;
 }
@@ -252,7 +258,7 @@ bool Shape::IsEqualForTesting(Shape const & shape) const
 bool Shape::IsValid() const
 {
   return m_id != kInvalidShapeId && m_stop1_id != kInvalidStopId && m_stop2_id != kInvalidStopId &&
-         !m_polyline.empty();
+         m_polyline.size() > 1;
 }
 
 // Network ----------------------------------------------------------------------------------------

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -54,6 +54,13 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
          && m_endOffset == header.m_endOffset;
 }
 
+bool TransitHeader::IsValid() const
+{
+  return m_gatesOffset <= m_edgesOffset && m_edgesOffset <= m_transfersOffset &&
+         m_transfersOffset <= m_linesOffset && m_linesOffset <= m_shapesOffset &&
+         m_shapesOffset <= m_networksOffset && m_networksOffset <= m_endOffset;
+}
+
 // TitleAnchor ------------------------------------------------------------------------------------
 TitleAnchor::TitleAnchor(uint8_t minZoom, Anchor anchor) : m_minZoom(minZoom), m_anchor(anchor) {}
 
@@ -65,6 +72,11 @@ bool TitleAnchor::operator==(TitleAnchor const & titleAnchor) const
 bool TitleAnchor::IsEqualForTesting(TitleAnchor const & titleAnchor) const
 {
   return *this == titleAnchor;
+}
+
+bool TitleAnchor::IsValid() const
+{
+  return m_anchor != kInvalidAnchor;
 }
 
 // Stop -------------------------------------------------------------------------------------------
@@ -89,6 +101,11 @@ bool Stop::IsEqualForTesting(Stop const & stop) const
          m_titleAnchors == stop.m_titleAnchors;
 }
 
+bool Stop::IsValid() const
+{
+  return m_id != kInvalidStopId && !m_lineIds.empty();
+}
+
 // SingleMwmSegment -------------------------------------------------------------------------------
 SingleMwmSegment::SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, bool forward)
   : m_featureId(featureId), m_segmentIdx(segmentIdx), m_forward(forward)
@@ -98,6 +115,11 @@ SingleMwmSegment::SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, boo
 bool SingleMwmSegment::IsEqualForTesting(SingleMwmSegment const & s) const
 {
   return m_featureId == s.m_featureId && m_segmentIdx == s.m_segmentIdx && m_forward == s.m_forward;
+}
+
+bool SingleMwmSegment::IsValid() const
+{
+  return true;
 }
 
 // Gate -------------------------------------------------------------------------------------------
@@ -119,6 +141,11 @@ bool Gate::IsEqualForTesting(Gate const & gate) const
          my::AlmostEqualAbs(m_weight, gate.m_weight, kWeightEqualEpsilon) &&
          m_stopIds == gate.m_stopIds &&
          my::AlmostEqualAbs(m_point, gate.m_point, kPointsEqualEpsilon);
+}
+
+bool Gate::IsValid() const
+{
+  return m_weight != kInvalidWeight && !m_stopIds.empty();
 }
 
 // Edge -------------------------------------------------------------------------------------------
@@ -152,6 +179,12 @@ bool Edge::operator<(Edge const & rhs) const
 
 bool Edge::IsEqualForTesting(Edge const & edge) const { return !(*this < edge || edge < *this); }
 
+bool Edge::IsValid() const
+{
+  // @TODO(bykoianko) |m_weight| should be valid for Edge validity.
+  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_lineId != kInvalidLineId;
+}
+
 // Transfer ---------------------------------------------------------------------------------------
 Transfer::Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
                    std::vector<TitleAnchor> const & titleAnchors)
@@ -164,6 +197,11 @@ bool Transfer::IsEqualForTesting(Transfer const & transfer) const
   return m_id == transfer.m_id &&
          my::AlmostEqualAbs(m_point, transfer.m_point, kPointsEqualEpsilon) &&
          m_stopIds == transfer.m_stopIds && m_titleAnchors == transfer.m_titleAnchors;
+}
+
+bool Transfer::IsValid() const
+{
+  return m_id != kInvalidStopId && !m_stopIds.empty();
 }
 
 // Line -------------------------------------------------------------------------------------------
@@ -182,6 +220,11 @@ bool Line::IsEqualForTesting(Line const & line) const
 {
   return m_id == line.m_id && m_number == line.m_number && m_title == line.m_title &&
          m_type == line.m_type && m_networkId == line.m_networkId && m_stopIds == line.m_stopIds;
+}
+
+bool Line::IsValid() const
+{
+  return m_id != kInvalidLineId && m_networkId != kInvalidNetworkId && !m_stopIds.empty();
 }
 
 // Shape ------------------------------------------------------------------------------------------
@@ -206,6 +249,12 @@ bool Shape::IsEqualForTesting(Shape const & shape) const
   return true;
 }
 
+bool Shape::IsValid() const
+{
+  return m_id != kInvalidShapeId && m_stop1_id != kInvalidStopId && m_stop2_id != kInvalidStopId &&
+         !m_polyline.empty();
+}
+
 // Network ----------------------------------------------------------------------------------------
 Network::Network(NetworkId id, std::string const & title)
 : m_id(id), m_title(title)
@@ -215,6 +264,11 @@ Network::Network(NetworkId id, std::string const & title)
 bool Network::IsEqualForTesting(Network const & shape) const
 {
   return m_id == shape.m_id && m_title == shape.m_title;
+}
+
+bool Network::IsValid() const
+{
+  return m_id != kInvalidNetworkId;
 }
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -182,6 +182,8 @@ private:
   // |m_featureId| is feature id of a point feature which represents gates.
   FeatureId m_featureId = kInvalidFeatureId;
   // |m_bestPedestrianSegment| is a segment which can be used for pedestrian routing to leave and enter the gate.
+  // The segment may be invalid because of map date. If so there's no pedestrian segment which can be used
+  // to reach the gate.
   SingleMwmSegment m_bestPedestrianSegment;
   bool m_entrance = true;
   bool m_exit = true;

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -104,6 +104,7 @@ public:
   Stop() = default;
   Stop(StopId id, FeatureId featureId, TransferId transferId, std::vector<LineId> const & lineIds,
        m2::PointD const & point, std::vector<TitleAnchor> const & titleAnchors);
+
   bool IsEqualForTesting(Stop const & stop) const;
   bool IsValid() const;
 
@@ -197,6 +198,7 @@ public:
        std::vector<ShapeId> const & shapeIds);
   bool IsEqualForTesting(Edge const & edge) const;
   bool IsValid() const;
+  void SetWeight(double weight) { m_weight = weight; }
 
   StopId GetStop1Id() const { return m_stop1Id; }
   StopId GetStop2Id() const { return m_stop2Id; }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -51,6 +51,7 @@ struct TransitHeader
                 uint32_t networksOffset, uint32_t endOffset);
   void Reset();
   bool IsEqualForTesting(TransitHeader const & header) const;
+  bool IsValid() const;
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
@@ -83,6 +84,7 @@ public:
 
   bool operator==(TitleAnchor const & titleAnchor) const;
   bool IsEqualForTesting(TitleAnchor const & titleAnchor) const;
+  bool IsValid() const;
 
   uint8_t GetMinZoom() const { return m_minZoom; }
   Anchor const & GetAnchor() const { return m_anchor; }
@@ -103,6 +105,7 @@ public:
   Stop(StopId id, FeatureId featureId, TransferId transferId, std::vector<LineId> const & lineIds,
        m2::PointD const & point, std::vector<TitleAnchor> const & titleAnchors);
   bool IsEqualForTesting(Stop const & stop) const;
+  bool IsValid() const;
 
   StopId GetId() const { return m_id; }
   FeatureId GetFeatureId() const { return m_featureId; }
@@ -132,6 +135,7 @@ public:
   SingleMwmSegment() = default;
   SingleMwmSegment(FeatureId featureId, uint32_t segmentIdx, bool forward);
   bool IsEqualForTesting(SingleMwmSegment const & s) const;
+  bool IsValid() const;
 
   FeatureId GetFeatureId() const { return m_featureId; }
   uint32_t GetSegmentIdx() const { return m_segmentIdx; }
@@ -155,6 +159,7 @@ public:
   Gate(FeatureId featureId, bool entrance, bool exit, double weight, std::vector<StopId> const & stopIds,
        m2::PointD const & point);
   bool IsEqualForTesting(Gate const & gate) const;
+  bool IsValid() const;
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
 
   FeatureId GetFeatureId() const { return m_featureId; }
@@ -191,6 +196,7 @@ public:
   Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
        std::vector<ShapeId> const & shapeIds);
   bool IsEqualForTesting(Edge const & edge) const;
+  bool IsValid() const;
 
   StopId GetStop1Id() const { return m_stop1Id; }
   StopId GetStop2Id() const { return m_stop2Id; }
@@ -223,6 +229,7 @@ public:
   Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
            std::vector<TitleAnchor> const & titleAnchors);
   bool IsEqualForTesting(Transfer const & transfer) const;
+  bool IsValid() const;
 
   StopId GetId() const { return m_id; }
   m2::PointD const & GetPoint() const { return m_point; }
@@ -248,6 +255,7 @@ public:
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
        NetworkId networkId, std::vector<StopId> const & stopIds);
   bool IsEqualForTesting(Line const & line) const;
+  bool IsValid() const;
 
   LineId GetId() const { return m_id; }
   std::string const & GetNumber() const { return m_number; }
@@ -277,6 +285,7 @@ public:
   Shape() = default;
   Shape(ShapeId id, StopId stop1_id, StopId stop2_id, std::vector<m2::PointD> const & polyline);
   bool IsEqualForTesting(Shape const & shape) const;
+  bool IsValid() const;
 
   ShapeId GetId() const { return m_id; }
   StopId GetStop1Id() const { return m_stop1_id; }
@@ -300,6 +309,7 @@ public:
   Network() = default;
   Network(NetworkId id, std::string const & title);
   bool IsEqualForTesting(Network const & shape) const;
+  bool IsValid() const;
 
   NetworkId GetId() const { return m_id; }
   std::string const & GetTitle() const { return m_title; }
@@ -308,7 +318,7 @@ private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Network, visitor(m_id, "id"), visitor(m_title, "title"))
 
-  NetworkId m_id;
+  NetworkId m_id = kInvalidNetworkId;
   std::string m_title;
 };
 

--- a/xcode/routing_common/routing_common.xcodeproj/project.pbxproj
+++ b/xcode/routing_common/routing_common.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		40576F7A1F7AA1B4000B593B /* transit_max_speed.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40576F791F7AA1B4000B593B /* transit_max_speed.hpp */; };
 		40FF45D01F388EF80046BD40 /* vehicle_model_for_country_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40FF45CF1F388EF80046BD40 /* vehicle_model_for_country_test.cpp */; };
 		5647A4511F72BEB600DE1125 /* libicu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5647A4521F72BEB600DE1125 /* libicu.a */; };
 		5667C1DD1F751F2700C6B31B /* transit_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5647A4531F72BF2B00DE1125 /* transit_test.cpp */; };
@@ -15,6 +14,7 @@
 		56E2EDA61F7E3F8A0092E9C2 /* transit_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56E2EDA31F7E3F890092E9C2 /* transit_serdes.hpp */; };
 		56E2EDA81F7E3F8A0092E9C2 /* transit_types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56E2EDA51F7E3F8A0092E9C2 /* transit_types.cpp */; };
 		56E41D881F72B42F00E28E2D /* transit_types.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56E41D861F72B42F00E28E2D /* transit_types.hpp */; };
+		56E6E7401F95D5690022CBD3 /* transit_speed_limits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56E6E73F1F95D5690022CBD3 /* transit_speed_limits.hpp */; };
 		671E78881E6A3C5D00B2859B /* bicycle_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671E78801E6A3C5D00B2859B /* bicycle_model.cpp */; };
 		671E78891E6A3C5D00B2859B /* bicycle_model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 671E78811E6A3C5D00B2859B /* bicycle_model.hpp */; };
 		671E788A1E6A3C5D00B2859B /* car_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671E78821E6A3C5D00B2859B /* car_model.cpp */; };
@@ -42,7 +42,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		40576F791F7AA1B4000B593B /* transit_max_speed.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_max_speed.hpp; sourceTree = "<group>"; };
 		40FF45CF1F388EF80046BD40 /* vehicle_model_for_country_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vehicle_model_for_country_test.cpp; sourceTree = "<group>"; };
 		5647A4521F72BEB600DE1125 /* libicu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libicu.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5647A4531F72BF2B00DE1125 /* transit_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_test.cpp; sourceTree = "<group>"; };
@@ -51,6 +50,7 @@
 		56E2EDA31F7E3F890092E9C2 /* transit_serdes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_serdes.hpp; sourceTree = "<group>"; };
 		56E2EDA51F7E3F8A0092E9C2 /* transit_types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_types.cpp; sourceTree = "<group>"; };
 		56E41D861F72B42F00E28E2D /* transit_types.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_types.hpp; sourceTree = "<group>"; };
+		56E6E73F1F95D5690022CBD3 /* transit_speed_limits.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_speed_limits.hpp; sourceTree = "<group>"; };
 		671E78721E6A3BE200B2859B /* librouting_common.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = librouting_common.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		671E78801E6A3C5D00B2859B /* bicycle_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_model.cpp; sourceTree = "<group>"; };
 		671E78811E6A3C5D00B2859B /* bicycle_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_model.hpp; sourceTree = "<group>"; };
@@ -138,6 +138,7 @@
 		671E78741E6A3BE200B2859B /* routing_common */ = {
 			isa = PBXGroup;
 			children = (
+				56E6E73F1F95D5690022CBD3 /* transit_speed_limits.hpp */,
 				56D0E47C1F8E335D0084B18C /* num_mwm_id.hpp */,
 				56E2EDA31F7E3F890092E9C2 /* transit_serdes.hpp */,
 				56E2EDA51F7E3F8A0092E9C2 /* transit_types.cpp */,
@@ -149,7 +150,6 @@
 				671E78831E6A3C5D00B2859B /* car_model.hpp */,
 				671E78841E6A3C5D00B2859B /* pedestrian_model.cpp */,
 				671E78851E6A3C5D00B2859B /* pedestrian_model.hpp */,
-				40576F791F7AA1B4000B593B /* transit_max_speed.hpp */,
 				671E78861E6A3C5D00B2859B /* vehicle_model.cpp */,
 				671E78871E6A3C5D00B2859B /* vehicle_model.hpp */,
 			);
@@ -202,8 +202,8 @@
 				671E788D1E6A3C5D00B2859B /* pedestrian_model.hpp in Headers */,
 				56E41D881F72B42F00E28E2D /* transit_types.hpp in Headers */,
 				56E2EDA61F7E3F8A0092E9C2 /* transit_serdes.hpp in Headers */,
+				56E6E7401F95D5690022CBD3 /* transit_speed_limits.hpp in Headers */,
 				671E78891E6A3C5D00B2859B /* bicycle_model.hpp in Headers */,
-				40576F7A1F7AA1B4000B593B /* transit_max_speed.hpp in Headers */,
 				671E788B1E6A3C5D00B2859B /* car_model.hpp in Headers */,
 				671E788F1E6A3C5D00B2859B /* vehicle_model.hpp in Headers */,
 			);


### PR DESCRIPTION
Данный PR решает две задачи:
1. проверка на валидность структур для хранения общественного транспорта перед сериализацией;
2. временный код, по созданию корректных весов для transit::Edge. Позже, когда эти данные будут приходить json-ах описывающих граф общественного транспорта данный код будет заменен на чеки на валидность весов при генерации mwm.

@tatiana-kondakova @darina @ygorshenin PTAL