### PR TITLE
[generator] Create osm2ft files for the whole planet also

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -192,7 +192,8 @@ namespace feature
 
       m_writer.Finish();
 
-      if (m_header.GetType() == DataHeader::country)
+      if (m_header.GetType() == DataHeader::country ||
+          m_header.GetType() == DataHeader::world)
       {
         FileWriter osm2ftWriter(m_writer.GetFileName() + OSM2FEATURE_FILE_EXTENSION);
         m_osm2ft.Flush(osm2ftWriter);


### PR DESCRIPTION
Для генерации площадных городов для геокодера нужно сопоставлять osm id и feature id. Не очень понял, почему на этапе сборки фич не скидывать сразу feature id, но ладно.