### PR TITLE
[transit] Conversion osm id to feature id.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -7,6 +7,7 @@
 #include "base/assert.hpp"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace routing;
@@ -21,7 +22,7 @@ void TestDeserializerFromJson(string const & jsonBuffer, string const & name, ve
   my::Json root(jsonBuffer.c_str());
   CHECK(root.get() != nullptr, ("Cannot parse the json."));
 
-  DeserializerFromJson deserializer(root.get());
+  DeserializerFromJson deserializer(root.get(), make_shared<OsmIdToFeatureIdsMap>());
 
   vector<Obj> objects;
   deserializer(objects, name.c_str());

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -115,7 +115,7 @@ UNIT_TEST(DeserializerFromJson_Gates)
     {
       "entrance": true,
       "exit": true,
-      "osm_id": "46116861",
+      "osm_id": "18446744073709551615",
       "point": {
         "x": 43.9290544,
         "y": 68.41120791512581
@@ -133,7 +133,8 @@ UNIT_TEST(DeserializerFromJson_Gates)
 
   auto mapping = make_shared<OsmIdToFeatureIdsMap>();
   (*mapping)[osm::Id(46116860)] = vector<FeatureId>({0});
-  (*mapping)[osm::Id(46116861)] = vector<FeatureId>({2});
+  // Note. std::numeric_limits<uint64_t>::max() == 18446744073709551615
+  (*mapping)[osm::Id(18446744073709551615U)] = vector<FeatureId>({2});
   TestDeserializerFromJson(jsonBuffer, mapping, "gates", expected);
 }
 

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -33,6 +33,12 @@ void TestDeserializerFromJson(string const & jsonBuffer, OsmIdToFeatureIdsMap co
     TEST(objects[i].IsEqualForTesting(expected[i]), (objects[i], expected[i]));
 }
 
+template <typename Obj>
+void TestDeserializerFromJson(string const & jsonBuffer, string const & name, vector<Obj> const & expected)
+{
+  return TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), name, expected);
+}
+
 UNIT_TEST(DeserializerFromJson_TitleAnchors)
 {
   string const jsonBuffer = R"(
@@ -44,7 +50,7 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
 
   vector<TitleAnchor> expected = {TitleAnchor(11 /* min zoom */, 4 /* anchor */),
                                   TitleAnchor(14 /* min zoom */, 6 /* anchor */)};
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "title_anchors", expected);
+  TestDeserializerFromJson(jsonBuffer, "title_anchors", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Stops)
@@ -134,7 +140,7 @@ UNIT_TEST(DeserializerFromJson_Gates)
   OsmIdToFeatureIdsMap mapping;
   mapping[osm::Id(46116860)] = vector<FeatureId>({0});
   // Note. std::numeric_limits<uint64_t>::max() == 18446744073709551615
-  mapping[osm::Id(18446744073709551615U)] = vector<FeatureId>({2});
+  mapping[osm::Id(18446744073709551615ULL)] = vector<FeatureId>({2});
   TestDeserializerFromJson(jsonBuffer, mapping, "gates", expected);
 }
 
@@ -166,7 +172,7 @@ UNIT_TEST(DeserializerFromJson_Edges)
     Edge(442018445 /* stop 1 id */, 442018446 /* stop 2 id */, 345.6 /* weight */,
          72551680 /* line id */,  false /* transfer */, {} /* shape ids */)};
 
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "edges", expected);
+  TestDeserializerFromJson(jsonBuffer, "edges", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Transfers)
@@ -191,7 +197,7 @@ UNIT_TEST(DeserializerFromJson_Transfers)
       Transfer(922337203 /* stop id */, {27.5619844, 64.24325959173672} /* point */,
                {209186416, 277039518} /* stopIds */, {} /* anchors */)};
 
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "transfers", expected);
+  TestDeserializerFromJson(jsonBuffer, "transfers", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Lines)
@@ -239,7 +245,7 @@ UNIT_TEST(DeserializerFromJson_Lines)
                                       {246659391, 246659390, 209191855, 209191854, 209191853,
                                        209191852, 209191851} /* stop ids */)};
 
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "lines", expected);
+  TestDeserializerFromJson(jsonBuffer, "lines", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Shapes)
@@ -296,7 +302,7 @@ UNIT_TEST(DeserializerFromJson_Shapes)
                                   {m2::PointD(27.554025800000002, 64.250591911669844),
                                    m2::PointD(27.553906184631536, 64.250633404586054)} /* polyline */)};
 
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "shapes", expected);
+  TestDeserializerFromJson(jsonBuffer, "shapes", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Networks)
@@ -311,6 +317,6 @@ UNIT_TEST(DeserializerFromJson_Networks)
   ]})";
 
   vector<Network> const expected = {Network(2 /* network id */, "Минский метрополитен" /* title */)};
-  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "networks", expected);
+  TestDeserializerFromJson(jsonBuffer, "networks", expected);
 }
 }  // namespace

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -89,11 +89,11 @@ UNIT_TEST(DeserializerFromJson_Stops)
   ]})";
 
   vector<Stop> const expected = {
-      Stop(343259523 /* id */, 1 /* featureId */, kInvalidTransferId /* transfer id */,
+      Stop(343259523 /* id */, OsmId(1 /* feature id */), kInvalidTransferId /* transfer id */,
            {19207936, 19207937} /* lineIds */, {27.4970954, 64.20146835878187} /* point */,
            {} /* anchors */),
-      Stop(266680843 /* id */, 2 /* featureId */, 5 /* transfer id */,
-           {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
+      Stop(266680843 /* id */, OsmId(2 /* feature id */), 5 /* transfer id */,
+           {19213568, 19213569} /* line ids */, {27.5227942, 64.25206634443111} /* point */,
            {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 
   OsmIdToFeatureIdsMap mapping;
@@ -132,9 +132,9 @@ UNIT_TEST(DeserializerFromJson_Gates)
   ]})";
 
   vector<Gate> const expected = {
-      Gate(0 /* feature id */, true /* entrance */, true /* exit */, 60.0 /* weight */,
+      Gate(OsmId(0 /* feature id */), true /* entrance */, true /* exit */, 60.0 /* weight */,
            {442018474} /* stop ids */, {43.8594864, 68.33320554776377} /* point */),
-      Gate(2 /* feature id */, true /* entrance */, true /* exit */, 60.0 /* weight */,
+      Gate(OsmId(2 /* feature id */), true /* entrance */, true /* exit */, 60.0 /* weight */,
            {442018465} /* stop ids */, {43.9290544, 68.41120791512581} /* point */)};
 
   OsmIdToFeatureIdsMap mapping;

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -17,7 +17,7 @@ using namespace std;
 namespace
 {
 template <typename Obj>
-void TestDeserializerFromJson(string const & jsonBuffer, shared_ptr<OsmIdToFeatureIdsMap> const & osmIdToFeatureIds,
+void TestDeserializerFromJson(string const & jsonBuffer, OsmIdToFeatureIdsMap const & osmIdToFeatureIds,
                               string const & name, vector<Obj> const & expected)
 {
   my::Json root(jsonBuffer.c_str());
@@ -44,7 +44,7 @@ UNIT_TEST(DeserializerFromJson_TitleAnchors)
 
   vector<TitleAnchor> expected = {TitleAnchor(11 /* min zoom */, 4 /* anchor */),
                                   TitleAnchor(14 /* min zoom */, 6 /* anchor */)};
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "title_anchors", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "title_anchors", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Stops)
@@ -90,9 +90,9 @@ UNIT_TEST(DeserializerFromJson_Stops)
            {19213568, 19213569} /* lineIds */, {27.5227942, 64.25206634443111} /* point */,
            {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 
-  auto mapping = make_shared<OsmIdToFeatureIdsMap>();
-  (*mapping)[osm::Id(1234)] = vector<FeatureId>({1});
-  (*mapping)[osm::Id(2345)] = vector<FeatureId>({2});
+  OsmIdToFeatureIdsMap mapping;
+  mapping[osm::Id(1234)] = vector<FeatureId>({1});
+  mapping[osm::Id(2345)] = vector<FeatureId>({2});
   TestDeserializerFromJson(jsonBuffer, mapping, "stops", expected);
 }
 
@@ -131,10 +131,10 @@ UNIT_TEST(DeserializerFromJson_Gates)
       Gate(2 /* feature id */, true /* entrance */, true /* exit */, 60.0 /* weight */,
            {442018465} /* stop ids */, {43.9290544, 68.41120791512581} /* point */)};
 
-  auto mapping = make_shared<OsmIdToFeatureIdsMap>();
-  (*mapping)[osm::Id(46116860)] = vector<FeatureId>({0});
+  OsmIdToFeatureIdsMap mapping;
+  mapping[osm::Id(46116860)] = vector<FeatureId>({0});
   // Note. std::numeric_limits<uint64_t>::max() == 18446744073709551615
-  (*mapping)[osm::Id(18446744073709551615U)] = vector<FeatureId>({2});
+  mapping[osm::Id(18446744073709551615U)] = vector<FeatureId>({2});
   TestDeserializerFromJson(jsonBuffer, mapping, "gates", expected);
 }
 
@@ -166,7 +166,7 @@ UNIT_TEST(DeserializerFromJson_Edges)
     Edge(442018445 /* stop 1 id */, 442018446 /* stop 2 id */, 345.6 /* weight */,
          72551680 /* line id */,  false /* transfer */, {} /* shape ids */)};
 
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "edges", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "edges", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Transfers)
@@ -191,7 +191,7 @@ UNIT_TEST(DeserializerFromJson_Transfers)
       Transfer(922337203 /* stop id */, {27.5619844, 64.24325959173672} /* point */,
                {209186416, 277039518} /* stopIds */, {} /* anchors */)};
 
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "transfers", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "transfers", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Lines)
@@ -239,7 +239,7 @@ UNIT_TEST(DeserializerFromJson_Lines)
                                       {246659391, 246659390, 209191855, 209191854, 209191853,
                                        209191852, 209191851} /* stop ids */)};
 
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "lines", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "lines", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Shapes)
@@ -296,7 +296,7 @@ UNIT_TEST(DeserializerFromJson_Shapes)
                                   {m2::PointD(27.554025800000002, 64.250591911669844),
                                    m2::PointD(27.553906184631536, 64.250633404586054)} /* polyline */)};
 
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "shapes", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "shapes", expected);
 }
 
 UNIT_TEST(DeserializerFromJson_Networks)
@@ -311,6 +311,6 @@ UNIT_TEST(DeserializerFromJson_Networks)
   ]})";
 
   vector<Network> const expected = {Network(2 /* network id */, "Минский метрополитен" /* title */)};
-  TestDeserializerFromJson(jsonBuffer, make_shared<OsmIdToFeatureIdsMap>(), "networks", expected);
+  TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), "networks", expected);
 }
 }  // namespace

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -89,10 +89,10 @@ UNIT_TEST(DeserializerFromJson_Stops)
   ]})";
 
   vector<Stop> const expected = {
-      Stop(343259523 /* id */, OsmId(1 /* feature id */), kInvalidTransferId /* transfer id */,
+      Stop(343259523 /* id */, FeatureIdentifiers(kInvalidOsmId, 1 /* feature id */), kInvalidTransferId /* transfer id */,
            {19207936, 19207937} /* lineIds */, {27.4970954, 64.20146835878187} /* point */,
            {} /* anchors */),
-      Stop(266680843 /* id */, OsmId(2 /* feature id */), 5 /* transfer id */,
+      Stop(266680843 /* id */, FeatureIdentifiers(kInvalidOsmId, 2 /* feature id */), 5 /* transfer id */,
            {19213568, 19213569} /* line ids */, {27.5227942, 64.25206634443111} /* point */,
            {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 
@@ -132,10 +132,12 @@ UNIT_TEST(DeserializerFromJson_Gates)
   ]})";
 
   vector<Gate> const expected = {
-      Gate(OsmId(0 /* feature id */), true /* entrance */, true /* exit */, 60.0 /* weight */,
-           {442018474} /* stop ids */, {43.8594864, 68.33320554776377} /* point */),
-      Gate(OsmId(2 /* feature id */), true /* entrance */, true /* exit */, 60.0 /* weight */,
-           {442018465} /* stop ids */, {43.9290544, 68.41120791512581} /* point */)};
+      Gate(FeatureIdentifiers(kInvalidOsmId, 0 /* feature id */), true /* entrance */,
+           true /* exit */, 60.0 /* weight */, {442018474} /* stop ids */,
+           {43.8594864, 68.33320554776377} /* point */),
+      Gate(FeatureIdentifiers(kInvalidOsmId, 2 /* feature id */), true /* entrance */,
+           true /* exit */, 60.0 /* weight */, {442018465} /* stop ids */,
+           {43.9290544, 68.41120791512581} /* point */)};
 
   OsmIdToFeatureIdsMap mapping;
   mapping[osm::Id(46116860)] = vector<FeatureId>({0});

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -308,7 +308,7 @@ int main(int argc, char ** argv)
       routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
 
     if (!FLAGS_transit_path.empty())
-      routing::transit::BuildTransit(datFile, FLAGS_transit_path);
+      routing::transit::BuildTransit(datFile, osmToFeatureFilename, FLAGS_transit_path);
 
     if (FLAGS_make_routing_index)
     {

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -1,6 +1,5 @@
 #include "generator/transit_generator.hpp"
 
-#include "generator/osm_id.hpp"
 #include "generator/utils.hpp"
 
 #include "traffic/traffic_cache.hpp"
@@ -32,6 +31,7 @@
 #include "base/checked_cast.hpp"
 #include "base/logging.hpp"
 #include "base/macros.hpp"
+#include "base/string_utils.hpp"
 
 #include <algorithm>
 #include <functional>
@@ -220,7 +220,7 @@ void DeserializerFromJson::operator()(m2::PointD & p, char const * name)
 void DeserializerFromJson::operator()(OsmId & osmId, char const * name)
 {
   // Conversion osm id to feature id.
-  std::string osmIdStr;
+  string osmIdStr;
   GetField(osmIdStr, name);
   CHECK(strings::is_number(osmIdStr), ());
   uint64_t osmIdNum;

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -59,7 +59,7 @@ Stop const & FindStopById(vector<Stop> const & stops, StopId stopId)
 {
   ASSERT(is_sorted(stops.cbegin(), stops.cend(), LessById), ());
   auto s1Id = equal_range(stops.cbegin(), stops.cend(),
-          Stop(stopId, kInvalidFeatureId, kInvalidTransferId, {}, m2::PointD(), {}),
+          Stop(stopId, OsmId(), kInvalidTransferId, {}, m2::PointD(), {}),
           LessById);
   CHECK(s1Id.first != stops.cend(), ("No a stop with id:", stopId, "in stops:", stops));
   CHECK_EQUAL(distance(s1Id.first, s1Id.second), 1, ("A stop with id:", stopId, "is not unique in stops:", stops));

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -189,7 +189,7 @@ void FillOsmIdToFeatureIdMap(string const & osmIdsToFeatureIdPath, OsmIdToFeatur
                                [&map](osm::Id const & osmId, uint32_t featureId) {
                                  map[osmId].push_back(featureId);
                                }),
-        ());
+        (osmIdsToFeatureIdPath));
 }
 }  // namespace
 
@@ -224,7 +224,7 @@ void DeserializerFromJson::operator()(OsmId & osmId, char const * name)
   GetField(osmIdStr, name);
   CHECK(strings::is_number(osmIdStr), ());
   uint64_t osmIdNum;
-  CHECK(strings::to_uint64(osmIdStr.c_str(), osmIdNum), ());
+  CHECK(strings::to_uint64(osmIdStr, osmIdNum), ());
   osm::Id const id(osmIdNum);
   auto const it = m_osmIdToFeatureIds.find(id);
   CHECK(it != m_osmIdToFeatureIds.cend(), ());

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -210,6 +210,23 @@ void DeserializerFromJson::operator()(m2::PointD & p, char const * name)
   FromJSONObject(pointItem, "x", p.x);
   FromJSONObject(pointItem, "y", p.y);
 }
+
+void DeserializerFromJson::operator()(OsmId & osmId, char const * name)
+{
+  // Conversion osm id to feature id.
+  std::string osmIdStr;
+  GetField(osmIdStr, name);
+  CHECK(strings::is_number(osmIdStr), ());
+  uint64_t osmIdNum;
+  CHECK(strings::to_uint64(osmIdStr.c_str(), osmIdNum), ());
+  osm::Id const id(osmIdNum);
+  auto const it = m_osmIdToFeatureIds->find(id);
+  CHECK(it != m_osmIdToFeatureIds->cend(), ());
+  CHECK_EQUAL(it->second.size(), 1,
+              ("Osm id:", id, "from transit graph doesn't present by a single feature in mwm."));
+  osmId = OsmId(it->second[0]);
+}
+
 DeserializerFromJson::DeserializerFromJson(json_struct_t * node,
                                            shared_ptr<OsmIdToFeatureIdsMap> const & osmIdToFeatureIds)
   : m_node(node), m_osmIdToFeatureIds(osmIdToFeatureIds)

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -214,6 +214,7 @@ DeserializerFromJson::DeserializerFromJson(json_struct_t * node,
                                            shared_ptr<OsmIdToFeatureIdsMap> const & osmIdToFeatureIds)
   : m_node(node), m_osmIdToFeatureIds(osmIdToFeatureIds)
 {
+  CHECK(m_osmIdToFeatureIds, ());
 }
 
 void BuildTransit(string const & mwmPath, string const & osmIdsToFeatureIdPath,

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -59,7 +59,7 @@ Stop const & FindStopById(vector<Stop> const & stops, StopId stopId)
 {
   ASSERT(is_sorted(stops.cbegin(), stops.cend(), LessById), ());
   auto s1Id = equal_range(stops.cbegin(), stops.cend(),
-          Stop(stopId, OsmId(), kInvalidTransferId, {}, m2::PointD(), {}),
+          Stop(stopId, FeatureIdentifiers(), kInvalidTransferId, {}, m2::PointD(), {}),
           LessById);
   CHECK(s1Id.first != stops.cend(), ("No a stop with id:", stopId, "in stops:", stops));
   CHECK_EQUAL(distance(s1Id.first, s1Id.second), 1, ("A stop with id:", stopId, "is not unique in stops:", stops));
@@ -217,7 +217,7 @@ void DeserializerFromJson::operator()(m2::PointD & p, char const * name)
   FromJSONObject(pointItem, "y", p.y);
 }
 
-void DeserializerFromJson::operator()(OsmId & osmId, char const * name)
+void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name)
 {
   // Conversion osm id to feature id.
   string osmIdStr;
@@ -225,12 +225,12 @@ void DeserializerFromJson::operator()(OsmId & osmId, char const * name)
   CHECK(strings::is_number(osmIdStr), ());
   uint64_t osmIdNum;
   CHECK(strings::to_uint64(osmIdStr, osmIdNum), ());
-  osm::Id const id(osmIdNum);
-  auto const it = m_osmIdToFeatureIds.find(id);
+  osm::Id const osmId(osmIdNum);
+  auto const it = m_osmIdToFeatureIds.find(osmId);
   CHECK(it != m_osmIdToFeatureIds.cend(), ());
   CHECK_EQUAL(it->second.size(), 1,
-              ("Osm id:", id, "from transit graph doesn't present by a single feature in mwm."));
-  osmId = OsmId(it->second[0]);
+              ("Osm id:", osmId, "from transit graph doesn't present by a single feature in mwm."));
+  id = FeatureIdentifiers(osmId.EncodedId() /* osm id */, it->second[0] /* feature id */);
 }
 
 void BuildTransit(string const & mwmPath, string const & osmIdsToFeatureIdPath,

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -14,7 +14,6 @@
 #include <cstdint>
 #include <cstring>
 #include <map>
-#include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -28,7 +27,7 @@ using OsmIdToFeatureIdsMap = std::map<osm::Id, std::vector<FeatureId>>;
 class DeserializerFromJson
 {
 public:
-  DeserializerFromJson(json_struct_t* node, std::shared_ptr<OsmIdToFeatureIdsMap> const & osmIdToFeatureIds);
+  DeserializerFromJson(json_struct_t* node, OsmIdToFeatureIdsMap const & osmIdToFeatureIds);
 
   template<typename T>
   typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value || std::is_same<T, double>::value>::type
@@ -89,7 +88,7 @@ private:
   }
 
   json_struct_t * m_node;
-  std::shared_ptr<OsmIdToFeatureIdsMap> m_osmIdToFeatureIds;
+  OsmIdToFeatureIdsMap const & m_osmIdToFeatureIds;
 };
 
 /// \brief Builds the transit section in the mwm.

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -7,7 +7,6 @@
 #include "geometry/point2d.hpp"
 
 #include "base/macros.hpp"
-#include "base/string_utils.hpp"
 
 #include "3party/jansson/myjansson.hpp"
 

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -34,28 +34,13 @@ public:
   typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value || std::is_same<T, double>::value>::type
       operator()(T & t, char const * name = nullptr)
   {
-    if (name == nullptr || strcmp(name, "osm_id") != 0)
-    {
-      GetField(t, name);
-      return;
-    }
-
-    // Conversion osm id to feature id.
-    std::string osmIdStr;
-    GetField(osmIdStr, name);
-    CHECK(strings::is_number(osmIdStr), ());
-    uint64_t osmIdNum;
-    CHECK(strings::to_uint64(osmIdStr.c_str(), osmIdNum), ());
-    osm::Id const osmId(osmIdNum);
-    auto const it = m_osmIdToFeatureIds->find(osm::Id(osmIdNum));
-    CHECK(it != m_osmIdToFeatureIds->cend(), ());
-    CHECK_EQUAL(it->second.size(), 1,
-        ("Osm id:", osmId, "from transit graph doesn't present by a single feature in mwm."));
-    t = static_cast<T>(it->second[0]);
+    GetField(t, name);
+    return;
   }
 
   void operator()(std::string & s, char const * name = nullptr) { GetField(s, name); }
   void operator()(m2::PointD & p, char const * name = nullptr);
+  void operator()(OsmId & osmId, char const * name = nullptr);
 
   template <typename T>
   void operator()(std::vector<T> & vs, char const * name = nullptr)

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -38,7 +38,7 @@ public:
 
   void operator()(std::string & s, char const * name = nullptr) { GetField(s, name); }
   void operator()(m2::PointD & p, char const * name = nullptr);
-  void operator()(OsmId & osmId, char const * name = nullptr);
+  void operator()(FeatureIdentifiers & id, char const * name = nullptr);
 
   template <typename T>
   void operator()(std::vector<T> & vs, char const * name = nullptr)

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -76,7 +76,7 @@ UNIT_TEST(Transit_StopSerialization)
     TestSerialization(stop);
   }
   {
-    Stop stop(1234 /* id */, 5678 /* feature id */, 7 /* transfer id */,
+    Stop stop(1234 /* id */, OsmId(5678 /* feature id */), 7 /* transfer id */,
               {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */, {} /* anchors */);
     TestSerialization(stop);
   }
@@ -96,7 +96,7 @@ UNIT_TEST(Transit_SingleMwmSegmentSerialization)
 
 UNIT_TEST(Transit_GateSerialization)
 {
-  Gate gate(12345 /* feature id */, true /* entrance */, false /* exit */, 117.8 /* weight */,
+  Gate gate(OsmId(12345 /* feature id */), true /* entrance */, false /* exit */, 117.8 /* weight */,
             {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
   TestSerialization(gate);
 }

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -76,8 +76,9 @@ UNIT_TEST(Transit_StopSerialization)
     TestSerialization(stop);
   }
   {
-    Stop stop(1234 /* id */, OsmId(5678 /* feature id */), 7 /* transfer id */,
-              {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */, {} /* anchors */);
+    Stop stop(1234 /* id */, FeatureIdentifiers(kInvalidOsmId, 5678 /* feature id */),
+              7 /* transfer id */, {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */,
+              {} /* anchors */);
     TestSerialization(stop);
   }
 }
@@ -96,8 +97,9 @@ UNIT_TEST(Transit_SingleMwmSegmentSerialization)
 
 UNIT_TEST(Transit_GateSerialization)
 {
-  Gate gate(OsmId(12345 /* feature id */), true /* entrance */, false /* exit */, 117.8 /* weight */,
-            {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
+  Gate gate(FeatureIdentifiers(kInvalidOsmId, 12345 /* feature id */), true /* entrance */,
+            false /* exit */, 117.8 /* weight */, {1, 2, 3} /* stop ids */,
+            {30.0, 50.0} /* point */);
   TestSerialization(gate);
 }
 

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -97,6 +97,11 @@ public:
     }
   }
 
+  void operator()(FeatureIdentifiers const & id, char const * name = nullptr)
+  {
+    (*this)(id.GetFeatureId(), name);
+  }
+
   template <typename T>
   void operator()(std::vector<T> const & vs, char const * /* name */ = nullptr)
   {
@@ -164,6 +169,13 @@ public:
   void operator()(m2::PointD & p, char const * /* name */ = nullptr)
   {
     p = Int64ToPoint(ReadVarInt<int64_t, Source>(m_source), POINT_COORD_BITS);
+  }
+
+  void operator()(FeatureIdentifiers & id, char const * name = nullptr)
+  {
+    FeatureId featureId;
+    operator()(featureId, name);
+    id = FeatureIdentifiers(kInvalidOsmId, featureId);
   }
 
   void operator()(vector<m2::PointD> & vs, char const * /* name */ = nullptr)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -84,7 +84,7 @@ Stop::Stop(StopId id, FeatureId featureId, TransferId transferId,
            std::vector<LineId> const & lineIds, m2::PointD const & point,
            std::vector<TitleAnchor> const & titleAnchors)
   : m_id(id)
-  , m_featureId(featureId)
+  , m_osmId(featureId)
   , m_transferId(transferId)
   , m_lineIds(lineIds)
   , m_point(point)
@@ -95,7 +95,7 @@ Stop::Stop(StopId id, FeatureId featureId, TransferId transferId,
 bool Stop::IsEqualForTesting(Stop const & stop) const
 {
   double constexpr kPointsEqualEpsilon = 1e-6;
-  return m_id == stop.m_id && m_featureId == stop.m_featureId &&
+  return m_id == stop.m_id && m_osmId == stop.m_osmId &&
          m_transferId == stop.m_transferId && m_lineIds == stop.m_lineIds &&
          my::AlmostEqualAbs(m_point, stop.m_point, kPointsEqualEpsilon) &&
          m_titleAnchors == stop.m_titleAnchors;
@@ -125,7 +125,7 @@ bool SingleMwmSegment::IsValid() const
 // Gate -------------------------------------------------------------------------------------------
 Gate::Gate(FeatureId featureId, bool entrance, bool exit, double weight,
            std::vector<StopId> const & stopIds, m2::PointD const & point)
-  : m_featureId(featureId)
+  : m_osmId(featureId)
   , m_entrance(entrance)
   , m_exit(exit)
   , m_weight(weight)
@@ -136,7 +136,7 @@ Gate::Gate(FeatureId featureId, bool entrance, bool exit, double weight,
 
 bool Gate::IsEqualForTesting(Gate const & gate) const
 {
-  return m_featureId == gate.m_featureId && m_entrance == gate.m_entrance &&
+  return m_osmId == gate.m_osmId && m_entrance == gate.m_entrance &&
          m_exit == gate.m_exit &&
          my::AlmostEqualAbs(m_weight, gate.m_weight, kWeightEqualEpsilon) &&
          m_stopIds == gate.m_stopIds &&

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -80,11 +80,11 @@ bool TitleAnchor::IsValid() const
 }
 
 // Stop -------------------------------------------------------------------------------------------
-Stop::Stop(StopId id, FeatureId featureId, TransferId transferId,
+Stop::Stop(StopId id, OsmId const & osmId, TransferId transferId,
            std::vector<LineId> const & lineIds, m2::PointD const & point,
            std::vector<TitleAnchor> const & titleAnchors)
   : m_id(id)
-  , m_osmId(featureId)
+  , m_osmId(osmId)
   , m_transferId(transferId)
   , m_lineIds(lineIds)
   , m_point(point)
@@ -123,9 +123,9 @@ bool SingleMwmSegment::IsValid() const
 }
 
 // Gate -------------------------------------------------------------------------------------------
-Gate::Gate(FeatureId featureId, bool entrance, bool exit, double weight,
+Gate::Gate(OsmId const & osmId, bool entrance, bool exit, double weight,
            std::vector<StopId> const & stopIds, m2::PointD const & point)
-  : m_osmId(featureId)
+  : m_osmId(osmId)
   , m_entrance(entrance)
   , m_exit(exit)
   , m_weight(weight)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -80,11 +80,11 @@ bool TitleAnchor::IsValid() const
 }
 
 // Stop -------------------------------------------------------------------------------------------
-Stop::Stop(StopId id, OsmId const & osmId, TransferId transferId,
+Stop::Stop(StopId id, FeatureIdentifiers const & featureIdentifiers, TransferId transferId,
            std::vector<LineId> const & lineIds, m2::PointD const & point,
            std::vector<TitleAnchor> const & titleAnchors)
   : m_id(id)
-  , m_osmId(osmId)
+  , m_featureIdentifiers(featureIdentifiers)
   , m_transferId(transferId)
   , m_lineIds(lineIds)
   , m_point(point)
@@ -95,7 +95,7 @@ Stop::Stop(StopId id, OsmId const & osmId, TransferId transferId,
 bool Stop::IsEqualForTesting(Stop const & stop) const
 {
   double constexpr kPointsEqualEpsilon = 1e-6;
-  return m_id == stop.m_id && m_osmId == stop.m_osmId &&
+  return m_id == stop.m_id && m_featureIdentifiers.IsEqualForTesting(stop.m_featureIdentifiers) &&
          m_transferId == stop.m_transferId && m_lineIds == stop.m_lineIds &&
          my::AlmostEqualAbs(m_point, stop.m_point, kPointsEqualEpsilon) &&
          m_titleAnchors == stop.m_titleAnchors;
@@ -123,9 +123,9 @@ bool SingleMwmSegment::IsValid() const
 }
 
 // Gate -------------------------------------------------------------------------------------------
-Gate::Gate(OsmId const & osmId, bool entrance, bool exit, double weight,
+Gate::Gate(FeatureIdentifiers const & featureIdentifiers, bool entrance, bool exit, double weight,
            std::vector<StopId> const & stopIds, m2::PointD const & point)
-  : m_osmId(osmId)
+  : m_featureIdentifiers(featureIdentifiers)
   , m_entrance(entrance)
   , m_exit(exit)
   , m_weight(weight)
@@ -136,8 +136,8 @@ Gate::Gate(OsmId const & osmId, bool entrance, bool exit, double weight,
 
 bool Gate::IsEqualForTesting(Gate const & gate) const
 {
-  return m_osmId == gate.m_osmId && m_entrance == gate.m_entrance &&
-         m_exit == gate.m_exit &&
+  return m_featureIdentifiers.IsEqualForTesting(gate.m_featureIdentifiers) &&
+         m_entrance == gate.m_entrance && m_exit == gate.m_exit &&
          my::AlmostEqualAbs(m_weight, gate.m_weight, kWeightEqualEpsilon) &&
          m_stopIds == gate.m_stopIds &&
          my::AlmostEqualAbs(m_point, gate.m_point, kPointsEqualEpsilon);

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -40,7 +40,9 @@ Anchor constexpr kInvalidAnchor = std::numeric_limits<Anchor>::max();
     template<class Source> friend class Deserializer;                                          \
     friend class DeserializerFromJson;                                                         \
     friend class routing::TransitGraphLoader;                                                  \
-    friend void BuildTransit(std::string const & mwmPath, std::string const & transitDir);     \
+    friend void BuildTransit(std::string const & mwmPath,                                      \
+                             std::string const & osmIdsToFeatureIdPath,                        \
+                             std::string const & transitDir);                                  \
     template<class Obj> friend void TestSerialization(Obj const & obj);                        \
 
 struct TransitHeader

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -124,7 +124,7 @@ class Stop
 {
 public:
   Stop() = default;
-  Stop(StopId id, FeatureId featureId, TransferId transferId, std::vector<LineId> const & lineIds,
+  Stop(StopId id, OsmId const & osmId, TransferId transferId, std::vector<LineId> const & lineIds,
        m2::PointD const & point, std::vector<TitleAnchor> const & titleAnchors);
 
   bool IsEqualForTesting(Stop const & stop) const;
@@ -179,7 +179,7 @@ class Gate
 {
 public:
   Gate() = default;
-  Gate(FeatureId featureId, bool entrance, bool exit, double weight, std::vector<StopId> const & stopIds,
+  Gate(OsmId const & osmId, bool entrance, bool exit, double weight, std::vector<StopId> const & stopIds,
        m2::PointD const & point);
   bool IsEqualForTesting(Gate const & gate) const;
   bool IsValid() const;


### PR DESCRIPTION
Данный PR решает следующие задачи:
1. обработка osm id представленных в виде строк. Это было необходимо сделать, поскольку osm id требуют uint64_t, а json парсер поддерживает для целого типа только long long (не менее, чем int64_t);
2. конвертация из osm id в feature id. Это реализовано для фичь (обычно, но не всегда точечных), представляющих выходы и остановки;

@ygorshenin @darina @tatiana-kondakova PTAL