### PR TITLE
[types] Strings for the halloween type

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -8861,3 +8861,7 @@ zh-Hant:^山屋
 sponsored-thor
 en:Collect all the items and win prizes!
 ru:Соберите все и выиграйте призы!
+
+sponsored-halloween
+en:Let's check your luck. Trick or treat?
+ru:Проверим вашу удачу? Нажмите на «Trick» или «Treat»


### PR DESCRIPTION
Чтобы люди не видели загадочное `sponsored-halloween` при нажатии на тыкву, указываем надписи в переводе типа. Целевая аудитория — англоговорящие люди, поэтому русскую надпись почти никто не увидит.