### PR TITLE
Cutting transit graphs according to mwms. Preparation.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -251,11 +251,11 @@ UNIT_TEST(DeserializerFromJson_Lines)
 
   vector<Line> const expected = {Line(19207936 /* line id */, "1" /* number */, "Московская линия" /* title */,
                                       "subway" /* type */, 2 /* network id */,
-                                      {343262691, 343259523, 343252898, 209191847, 2947858576} /* stop ids */),
+                                      {{343262691, 343259523, 343252898, 209191847, 2947858576}} /* stop ids */),
                                  Line(19207937 /* line id */, "2" /* number */, "Московская линия" /* title */,
                                       "subway" /* type */, 2 /* network id */,
-                                      {246659391, 246659390, 209191855, 209191854, 209191853,
-                                       209191852, 209191851} /* stop ids */)};
+                                      {{246659391, 246659390, 209191855, 209191854, 209191853,
+                                       209191852, 209191851}} /* stop ids */)};
 
   TestDeserializerFromJson(jsonBuffer, "lines", expected);
 }

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -321,7 +321,7 @@ int main(int argc, char ** argv)
       routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
 
     if (!FLAGS_transit_path.empty())
-      routing::transit::BuildTransit(datFile, osmToFeatureFilename, FLAGS_transit_path);
+      routing::transit::BuildTransit(path, country, osmToFeatureFilename, FLAGS_transit_path);
 
     if (FLAGS_make_routing_index)
     {

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -230,14 +230,15 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   id = FeatureIdentifiers(osmId.EncodedId() /* osm id */, it->second[0] /* feature id */);
 }
 
-void BuildTransit(string const & mwmPath, string const & osmIdsToFeatureIdPath,
-                  string const & transitDir)
+void BuildTransit(string const & mwmDir, string const & countryId,
+                  string const & osmIdsToFeatureIdPath, string const & transitDir)
 {
   LOG(LERROR, ("This method is under construction and should not be used for building production mwm "
       "sections."));
   NOTIMPLEMENTED();
 
-  string const countryId = GetFileName(mwmPath);
+//  string const countryId = GetFileName(mwmDir);
+  std::string const mwmPath = my::JoinFoldersToPath(mwmDir, countryId + DATA_FILE_EXTENSION);
   string const graphFullPath = my::JoinFoldersToPath(transitDir, countryId + TRANSIT_FILE_EXTENSION);
 
   Platform::EFileType fileType;
@@ -273,7 +274,7 @@ void BuildTransit(string const & mwmPath, string const & osmIdsToFeatureIdPath,
   // Note. |gates| has to be deserialized from json before starting writing transit section to mwm since
   // the mwm is used to filled |gates|.
   vector<Gate> gates;
-  DeserializeGatesFromJson(root, my::GetDirectory(mwmPath), countryId, mapping, gates);
+  DeserializeGatesFromJson(root, mwmDir, countryId, mapping, gates);
   CHECK(IsValid(gates), (gates));
 
   FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -230,6 +230,13 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   id = FeatureIdentifiers(osmId.EncodedId() /* osm id */, it->second[0] /* feature id */);
 }
 
+void DeserializerFromJson::operator()(StopIdRanges & rs, char const * name)
+{
+  vector<StopId> stopIds;
+  (*this)(stopIds, name);
+  rs = StopIdRanges({stopIds});
+}
+
 void BuildTransit(string const & mwmDir, string const & countryId,
                   string const & osmIdsToFeatureIdPath, string const & transitDir)
 {

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -227,7 +227,6 @@ void BuildTransit(string const & mwmDir, string const & countryId,
       "sections."));
   NOTIMPLEMENTED();
 
-//  string const countryId = GetFileName(mwmDir);
   std::string const mwmPath = my::JoinFoldersToPath(mwmDir, countryId + DATA_FILE_EXTENSION);
   string const graphFullPath = my::JoinFoldersToPath(transitDir, countryId + TRANSIT_FILE_EXTENSION);
 

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -66,23 +66,6 @@ Stop const & FindStopById(vector<Stop> const & stops, StopId stopId)
   return *s1Id.first;
 }
 
-/// Extracts the file name from |filePath| and drops all extensions.
-string GetFileName(string const & filePath)
-{
-  string name = filePath;
-  my::GetNameFromFullPath(name);
-
-  string nameWithExt;
-  do
-  {
-    nameWithExt = name;
-    my::GetNameWithoutExt(name);
-  }
-  while (nameWithExt != name);
-
-  return name;
-}
-
 template <class Item>
 void DeserializeFromJson(my::Json const & root, string const & key,
                          OsmIdToFeatureIdsMap const & osmIdToFeatureIdsMap, vector<Item> & items)

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -166,13 +166,13 @@ void CalculateEdgeWeight(vector<Stop> const & stops, vector<transit::Edge> & edg
   }
 }
 
-void FillOsmIdToFeatureIdMap(string const & osmIdsToFeatureIdPath, OsmIdToFeatureIdsMap & map)
+void FillOsmIdToFeatureIdsMap(string const & osmIdToFeatureIdsPath, OsmIdToFeatureIdsMap & map)
 {
-  CHECK(ForEachOsmId2FeatureId(osmIdsToFeatureIdPath,
+  CHECK(ForEachOsmId2FeatureId(osmIdToFeatureIdsPath,
                                [&map](osm::Id const & osmId, uint32_t featureId) {
                                  map[osmId].push_back(featureId);
                                }),
-        (osmIdsToFeatureIdPath));
+        (osmIdToFeatureIdsPath));
 }
 }  // namespace
 
@@ -221,7 +221,7 @@ void DeserializerFromJson::operator()(StopIdRanges & rs, char const * name)
 }
 
 void BuildTransit(string const & mwmDir, string const & countryId,
-                  string const & osmIdsToFeatureIdPath, string const & transitDir)
+                  string const & osmIdToFeatureIdsPath, string const & transitDir)
 {
   LOG(LERROR, ("This method is under construction and should not be used for building production mwm "
       "sections."));
@@ -258,7 +258,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   CHECK(root.get() != nullptr, ("Cannot parse the json file:", graphFullPath));
 
   OsmIdToFeatureIdsMap mapping;
-  FillOsmIdToFeatureIdMap(osmIdsToFeatureIdPath, mapping);
+  FillOsmIdToFeatureIdsMap(osmIdToFeatureIdsPath, mapping);
 
   // Note. |gates| has to be deserialized from json before starting writing transit section to mwm since
   // the mwm is used to filled |gates|.

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -107,13 +107,13 @@ private:
 };
 
 /// \brief Builds the transit section in the mwm.
-/// \param mwmPath relative or full path to an mwm. The name of mwm without extension is considered
+/// \param mwmDir relative or full path to an mwm. The name of mwm without extension is considered
 /// as country id.
 /// \param transitDir a path to directory with json files with transit graphs.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)
-void BuildTransit(std::string const & mwmPath, std::string const & osmIdsToFeatureIdPath,
-                  std::string const & transitDir);
+void BuildTransit(string const & mwmDir, string const & countryId,
+                  string const & osmIdsToFeatureIdPath, string const & transitDir);
 }  // namespace transit
 }  // namespace routing

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -40,6 +40,7 @@ public:
   void operator()(m2::PointD & p, char const * name = nullptr);
   void operator()(ShapeId & id, char const * name = nullptr);
   void operator()(FeatureIdentifiers & id, char const * name = nullptr);
+  void operator()(StopIdRanges & rs, char const * name = nullptr);
 
   template <typename T>
   void operator()(std::vector<T> & vs, char const * name = nullptr)

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -108,8 +108,9 @@ private:
 };
 
 /// \brief Builds the transit section in the mwm.
-/// \param mwmDir relative or full path to an mwm. The name of mwm without extension is considered
-/// as country id.
+/// \param mwmDir relative or full path to a directory where mwm is located.
+/// \param countryId is an mwm name without extension of the processed mwm.
+/// \param osmIdsToFeatureIdPath is a path to a file with osm ids to feature id mapping.
 /// \param transitDir a path to directory with json files with transit graphs.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -110,12 +110,12 @@ private:
 /// \brief Builds the transit section in the mwm.
 /// \param mwmDir relative or full path to a directory where mwm is located.
 /// \param countryId is an mwm name without extension of the processed mwm.
-/// \param osmIdsToFeatureIdPath is a path to a file with osm ids to feature id mapping.
+/// \param osmIdToFeatureIdsPath is a path to a file with osm id to feature ids mapping.
 /// \param transitDir a path to directory with json files with transit graphs.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)
 void BuildTransit(string const & mwmDir, string const & countryId,
-                  string const & osmIdsToFeatureIdPath, string const & transitDir);
+                  string const & osmIdToFeatureIdsPath, string const & transitDir);
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -126,7 +126,12 @@ UNIT_TEST(Transit_LineSerialization)
   }
   {
     Line line(10 /* line id */, "11" /* number */, "Линия" /* title */,
-              "subway" /* type */, 12 /* network id */, {13, 14, 15} /* stop ids */);
+              "subway" /* type */, 12 /* network id */, {{13, 14, 15}} /* stop ids */);
+    TestSerialization(line);
+  }
+  {
+    Line line(100 /* line id */, "101" /* number */, "Линия" /* title */,
+              "subway" /* type */, 103 /* network id */, {{1, 2, 3}, {7, 8, 9}} /* stop ids */);
     TestSerialization(line);
   }
 }

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -102,6 +102,11 @@ public:
     (*this)(id.GetFeatureId(), name);
   }
 
+  void operator()(StopIdRanges const & rs, char const * name = nullptr)
+  {
+    (*this)(rs.GetIds(), name);
+  }
+
   template <typename T>
   void operator()(std::vector<T> const & vs, char const * /* name */ = nullptr)
   {
@@ -176,6 +181,11 @@ public:
     FeatureId featureId;
     operator()(featureId, name);
     id = FeatureIdentifiers(kInvalidOsmId, featureId);
+  }
+
+  void operator()(StopIdRanges & rs, char const * name = nullptr)
+  {
+    operator()(rs.m_ids, name);
   }
 
   void operator()(vector<m2::PointD> & vs, char const * /* name */ = nullptr)

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -102,11 +102,6 @@ public:
     (*this)(id.GetFeatureId(), name);
   }
 
-  void operator()(StopIdRanges const & rs, char const * name = nullptr)
-  {
-    (*this)(rs.GetIds(), name);
-  }
-
   template <typename T>
   void operator()(std::vector<T> const & vs, char const * /* name */ = nullptr)
   {
@@ -181,11 +176,6 @@ public:
     FeatureId featureId;
     operator()(featureId, name);
     id = FeatureIdentifiers(kInvalidOsmId, featureId);
-  }
-
-  void operator()(StopIdRanges & rs, char const * name = nullptr)
-  {
-    operator()(rs.m_ids, name);
   }
 
   void operator()(vector<m2::PointD> & vs, char const * /* name */ = nullptr)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -212,7 +212,7 @@ bool Transfer::IsValid() const
 
 // Line -------------------------------------------------------------------------------------------
 Line::Line(LineId id, std::string const & number, std::string const & title,
-           std::string const & type, NetworkId networkId, std::vector<StopId> const & stopIds)
+           std::string const & type, NetworkId networkId, Ranges const & stopIds)
   : m_id(id)
   , m_number(number)
   , m_title(title)
@@ -230,7 +230,7 @@ bool Line::IsEqualForTesting(Line const & line) const
 
 bool Line::IsValid() const
 {
-  return m_id != kInvalidLineId && m_networkId != kInvalidNetworkId && !m_stopIds.empty();
+  return m_id != kInvalidLineId && m_networkId != kInvalidNetworkId && m_stopIds.IsValid();
 }
 
 // Shape ------------------------------------------------------------------------------------------

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -23,6 +23,7 @@ using FeatureId = uint32_t;
 using OsmId = uint64_t;
 using Weight = double;
 using Anchor = uint8_t;
+using Ranges = std::vector<std::vector<StopId>>;
 
 LineId constexpr kInvalidLineId = std::numeric_limits<LineId>::max();
 StopId constexpr kInvalidStopId = std::numeric_limits<StopId>::max();
@@ -297,12 +298,30 @@ private:
   std::vector<TitleAnchor> m_titleAnchors;
 };
 
+class StopIdRanges
+{
+public:
+  StopIdRanges() = default;
+  explicit StopIdRanges(Ranges const & ids) : m_ids(ids) {}
+  bool operator==(StopIdRanges const & rhs) const { return m_ids == rhs.m_ids; }
+  bool IsEqualForTesting(StopIdRanges const & rhs) const { return *this == rhs; }
+  bool IsValid() const { return !m_ids.empty(); }
+
+  Ranges const & GetIds() const { return m_ids; }
+
+private:
+  DECLARE_TRANSIT_TYPE_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(StopIdRanges, visitor(m_ids, "ids"))
+
+  Ranges m_ids;
+};
+
 class Line
 {
 public:
   Line() = default;
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
-       NetworkId networkId, std::vector<StopId> const & stopIds);
+       NetworkId networkId, Ranges const & stopIds);
   bool IsEqualForTesting(Line const & line) const;
   bool IsValid() const;
 
@@ -311,7 +330,7 @@ public:
   std::string const & GetTitle() const { return m_title; }
   std::string const & GetType() const { return m_type; }
   NetworkId GetNetworkId() const { return m_networkId; }
-  std::vector<StopId> const & GetStopIds() const { return m_stopIds; }
+  Ranges const & GetStopIds() const { return m_stopIds.GetIds(); }
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
@@ -325,7 +344,7 @@ private:
   std::string m_title;
   std::string m_type;
   NetworkId m_networkId = kInvalidNetworkId;
-  std::vector<StopId> m_stopIds;
+  StopIdRanges m_stopIds;
 };
 
 class Shape

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -15,14 +15,14 @@ namespace routing
 class TransitGraphLoader;
 namespace transit
 {
+using Anchor = uint8_t;
+using FeatureId = uint32_t;
 using LineId = uint32_t;
+using NetworkId = uint32_t;
+using OsmId = uint64_t;
 using StopId = uint64_t;
 using TransferId = uint64_t;
-using NetworkId = uint32_t;
-using FeatureId = uint32_t;
-using OsmId = uint64_t;
 using Weight = double;
-using Anchor = uint8_t;
 using Ranges = std::vector<std::vector<StopId>>;
 
 LineId constexpr kInvalidLineId = std::numeric_limits<LineId>::max();
@@ -53,6 +53,7 @@ struct TransitHeader
   TransitHeader(uint16_t version, uint32_t gatesOffset, uint32_t edgesOffset,
                 uint32_t transfersOffset, uint32_t linesOffset, uint32_t shapesOffset,
                 uint32_t networksOffset, uint32_t endOffset);
+
   void Reset();
   bool IsEqualForTesting(TransitHeader const & header) const;
   bool IsValid() const;
@@ -185,6 +186,7 @@ public:
   Gate() = default;
   Gate(FeatureIdentifiers const & featureIdentifiers, bool entrance, bool exit, double weight,
        std::vector<StopId> const & stopIds, m2::PointD const & point);
+
   bool IsEqualForTesting(Gate const & gate) const;
   bool IsValid() const;
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
@@ -246,6 +248,7 @@ public:
   Edge() = default;
   Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
        std::vector<ShapeId> const & shapeIds);
+
   bool IsEqualForTesting(Edge const & edge) const;
   bool IsValid() const;
   void SetWeight(double weight) { m_weight = weight; }
@@ -278,6 +281,7 @@ public:
   Transfer() = default;
   Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
            std::vector<TitleAnchor> const & titleAnchors);
+
   bool IsEqualForTesting(Transfer const & transfer) const;
   bool IsValid() const;
 
@@ -303,8 +307,8 @@ class StopIdRanges
 public:
   StopIdRanges() = default;
   explicit StopIdRanges(Ranges const & ids) : m_ids(ids) {}
+
   bool operator==(StopIdRanges const & rhs) const { return m_ids == rhs.m_ids; }
-  bool IsEqualForTesting(StopIdRanges const & rhs) const { return *this == rhs; }
   bool IsValid() const { return !m_ids.empty(); }
 
   Ranges const & GetIds() const { return m_ids; }
@@ -322,6 +326,7 @@ public:
   Line() = default;
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
        NetworkId networkId, Ranges const & stopIds);
+
   bool IsEqualForTesting(Line const & line) const;
   bool IsValid() const;
 
@@ -352,6 +357,7 @@ class Shape
 public:
   Shape() = default;
   Shape(ShapeId const & id, std::vector<m2::PointD> const & polyline) : m_id(id), m_polyline(polyline) {}
+
   bool IsEqualForTesting(Shape const & shape) const;
   bool IsValid() const { return m_id.IsValid() && m_polyline.size() > 1; }
 
@@ -371,6 +377,7 @@ class Network
 public:
   Network() = default;
   Network(NetworkId id, std::string const & title);
+
   bool IsEqualForTesting(Network const & shape) const;
   bool IsValid() const;
 

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -40,7 +40,8 @@ Anchor constexpr kInvalidAnchor = std::numeric_limits<Anchor>::max();
     template<class Source> friend class Deserializer;                                          \
     friend class DeserializerFromJson;                                                         \
     friend class routing::TransitGraphLoader;                                                  \
-    friend void BuildTransit(std::string const & mwmPath,                                      \
+    friend void BuildTransit(std::string const & mwmDir,                                       \
+                             std::string const & countryId,                                    \
                              std::string const & osmIdsToFeatureIdPath,                        \
                              std::string const & transitDir);                                  \
     template<class Obj> friend void TestSerialization(Obj const & obj);                        \


### PR DESCRIPTION
Подготовка к вырезанию графов общественного транспорта по границам mwm. 

Данный PR:
- изменяет способ передачи путей к данным в BuildTransit(), чтоб было проще потом получить доступ к data/border/*.poly файлам;
- обеспечивает сохранение в mwm для линии (lines) нескольких диапазонов остановок. Это может случится, в случае, если линия несколько раз пересекает границу mwm. Более подробно - см описание плана работ по вырезанию графа(ов) общественного транспорта по границам mwm: https://jira.mail.ru/browse/MAPSME-5858

@ygorshenin @darina PTAL


