### PR TITLE
[search] A refactoring of ranker.

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -166,7 +166,7 @@ struct FeatureNameInserter
     strings::UniString const uniName = search::NormalizeAndSimplifyString(name);
 
     // split input string on tokens
-    buffer_vector<strings::UniString, 32> tokens;
+    search::QueryTokens tokens;
     SplitUniString(uniName, MakeBackInsertFunctor(tokens), search::Delimiters());
 
     // add synonyms for input native string

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -298,7 +298,7 @@ private:
 StreetsSynonymsHolder g_streets;
 }  // namespace
 
-void GetStringPrefix(string const & str, string & res)
+string DropLastToken(string const & str)
 {
   search::Delimiters delims;
   using Iter = utf8::unchecked::iterator<string::const_iterator>;
@@ -316,8 +316,7 @@ void GetStringPrefix(string const & str, string & res)
     iter = prev;
   }
 
-  // Assign the input string without prefix to result.
-  res.assign(str.begin(), iter.base());
+  return string(str.begin(), iter.base());
 }
 
 UniString GetStreetNameAsKey(string const & name)

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -5,6 +5,8 @@
 #include "base/macros.hpp"
 #include "base/mem_trie.hpp"
 
+#include "3party/utfcpp/source/utf8/unchecked.h"
+
 using namespace std;
 using namespace strings;
 
@@ -295,6 +297,28 @@ private:
 
 StreetsSynonymsHolder g_streets;
 }  // namespace
+
+void GetStringPrefix(string const & str, string & res)
+{
+  search::Delimiters delims;
+  using Iter = utf8::unchecked::iterator<string::const_iterator>;
+
+  // Find start iterator of prefix in input query.
+  Iter iter(str.end());
+  while (iter.base() != str.begin())
+  {
+    Iter prev = iter;
+    --prev;
+
+    if (delims(*prev))
+      break;
+
+    iter = prev;
+  }
+
+  // Assign the input string without prefix to result.
+  res.assign(str.begin(), iter.base());
+}
 
 UniString GetStreetNameAsKey(string const & name)
 {

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -55,6 +55,9 @@ bool TokenizeStringAndCheckIfLastTokenIsPrefix(std::string const & s, Tokens & t
   return TokenizeStringAndCheckIfLastTokenIsPrefix(NormalizeAndSimplifyString(s), tokens, delims);
 }
 
+// Chops off the last query token (the "prefix" one) from |str| and stores the result in |res|.
+void GetStringPrefix(std::string const & str, std::string & res);
+
 strings::UniString GetStreetNameAsKey(std::string const & name);
 
 // *NOTE* The argument string must be normalized and simplified.
@@ -99,5 +102,4 @@ private:
 
   Callback m_callback;
 };
-
 }  // namespace search

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -55,8 +55,8 @@ bool TokenizeStringAndCheckIfLastTokenIsPrefix(std::string const & s, Tokens & t
   return TokenizeStringAndCheckIfLastTokenIsPrefix(NormalizeAndSimplifyString(s), tokens, delims);
 }
 
-// Chops off the last query token (the "prefix" one) from |str| and stores the result in |res|.
-void GetStringPrefix(std::string const & str, std::string & res);
+// Chops off the last query token (the "prefix" one) from |str|.
+std::string DropLastToken(std::string const & str);
 
 strings::UniString GetStreetNameAsKey(std::string const & name);
 

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Content/BookingCells/MWMPPReviewCell.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Content/BookingCells/MWMPPReviewCell.mm
@@ -33,7 +33,7 @@
   formatter.dateStyle = NSDateFormatterLongStyle;
 
   self.date.text = [formatter stringFromDate:
-                    [NSDate dateWithTimeIntervalSince1970:duration_cast<seconds>(review.m_date.time_since_epoch()).count()]];
+                    [NSDate dateWithTimeIntervalSince1970:std::chrono::duration_cast<std::chrono::seconds>(review.m_date.time_since_epoch()).count()]];
 
   self.positiveReview.text = @(review.m_pros.c_str());
   self.negativeReview.text = @(review.m_cons.c_str());

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -50,6 +50,8 @@ set(
   geometry_cache.hpp
   geometry_utils.cpp
   geometry_utils.hpp
+  highlighting.cpp
+  highlighting.hpp
   hotels_classifier.cpp
   hotels_classifier.hpp
   hotels_filter.cpp
@@ -126,7 +128,7 @@ set(
   street_vicinity_loader.hpp
   streets_matcher.cpp
   streets_matcher.hpp
-  string_intersection.hpp
+  suggest.cpp
   suggest.hpp
   token_range.hpp
   token_slice.cpp

--- a/search/common.hpp
+++ b/search/common.hpp
@@ -1,7 +1,20 @@
 #pragma once
 
+#include "indexer/categories_holder.hpp"
+
+#include "base/buffer_vector.hpp"
+#include "base/small_set.hpp"
+#include "base/string_utils.hpp"
+
 namespace search
 {
+// The prefix is stored separately.
+// todo(@m, @y) Find a way (similar to TokenSlice maybe?) to unify
+//              the prefix and non-prefix tokens.
+using QueryTokens = buffer_vector<strings::UniString, 32>;
+
+using Locales = base::SafeSmallSet<CategoriesHolder::kMaxSupportedLocaleIndex + 1>;
+
 /// Upper bound for max count of tokens for indexing and scoring.
 int constexpr MAX_TOKENS = 32;
 int constexpr MAX_SUGGESTS_COUNT = 5;

--- a/search/common.hpp
+++ b/search/common.hpp
@@ -13,7 +13,8 @@ namespace search
 //              the prefix and non-prefix tokens.
 using QueryTokens = buffer_vector<strings::UniString, 32>;
 
-using Locales = base::SafeSmallSet<CategoriesHolder::kMaxSupportedLocaleIndex + 1>;
+using Locales =
+    base::SafeSmallSet<static_cast<uint64_t>(CategoriesHolder::kMaxSupportedLocaleIndex) + 1>;
 
 /// Upper bound for max count of tokens for indexing and scoring.
 int constexpr MAX_TOKENS = 32;

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -29,7 +29,6 @@
 
 #include "geometry/rect2d.hpp"
 
-#include "base/buffer_vector.hpp"
 #include "base/cancellable.hpp"
 #include "base/dfa_helpers.hpp"
 #include "base/levenshtein_dfa.hpp"
@@ -57,7 +56,6 @@ class PreRanker;
 
 class FeaturesFilter;
 class FeaturesLayerMatcher;
-class SearchModel;
 class TokenSlice;
 
 // This class is used to retrieve all features corresponding to a
@@ -90,7 +88,6 @@ public:
   Geocoder(Index const & index, storage::CountryInfoGetter const & infoGetter,
            PreRanker & preRanker, VillagesCache & villagesCache,
            my::Cancellable const & cancellable);
-
   ~Geocoder();
 
   // Sets search query params.

--- a/search/highlighting.cpp
+++ b/search/highlighting.cpp
@@ -44,14 +44,13 @@ public:
 
 namespace search
 {
-// static
 void HighlightResult(QueryTokens const & tokens, strings::UniString const & prefix, Result & res)
 {
   using Iter = QueryTokens::const_iterator;
   using CombinedIter = CombinedIterator<Iter, strings::UniString>;
 
-  CombinedIter beg(tokens.begin(), tokens.end(), prefix.empty() ? 0 : &prefix);
-  CombinedIter end(tokens.end() /* cur */, tokens.end() /* end */, 0);
+  CombinedIter beg(tokens.begin(), tokens.end(), prefix.empty() ? nullptr : &prefix);
+  CombinedIter end(tokens.end() /* cur */, tokens.end() /* end */, nullptr);
   auto assignHighlightRange = [&](pair<uint16_t, uint16_t> const & range) {
     res.AddHighlightRange(range);
   };

--- a/search/highlighting.cpp
+++ b/search/highlighting.cpp
@@ -1,0 +1,61 @@
+#include "search/highlighting.hpp"
+
+using namespace std;
+
+namespace
+{
+// Makes continuous range for tokens and prefix.
+template <class Iter, class Value>
+class CombinedIterator
+{
+  Iter m_cur;
+  Iter m_end;
+  Value const * m_val;
+
+public:
+  CombinedIterator(Iter cur, Iter end, Value const * val) : m_cur(cur), m_end(end), m_val(val) {}
+
+  Value const & operator*() const
+  {
+    ASSERT(m_val != nullptr || m_cur != m_end, ("dereferencing of an empty iterator"));
+    if (m_cur != m_end)
+      return *m_cur;
+
+    return *m_val;
+  }
+
+  CombinedIterator & operator++()
+  {
+    if (m_cur != m_end)
+      ++m_cur;
+    else
+      m_val = nullptr;
+    return *this;
+  }
+
+  bool operator==(CombinedIterator const & other) const
+  {
+    return m_val == other.m_val && m_cur == other.m_cur;
+  }
+
+  bool operator!=(CombinedIterator const & other) const { return !(*this == other); }
+};
+}  // namespace
+
+namespace search
+{
+// static
+void HighlightResult(QueryTokens const & tokens, strings::UniString const & prefix, Result & res)
+{
+  using Iter = QueryTokens::const_iterator;
+  using CombinedIter = CombinedIterator<Iter, strings::UniString>;
+
+  CombinedIter beg(tokens.begin(), tokens.end(), prefix.empty() ? 0 : &prefix);
+  CombinedIter end(tokens.end() /* cur */, tokens.end() /* end */, 0);
+  auto assignHighlightRange = [&](pair<uint16_t, uint16_t> const & range) {
+    res.AddHighlightRange(range);
+  };
+
+  SearchStringTokensIntersectionRanges(res.GetString(), beg, end, assignHighlightRange);
+}
+}  // namespace search

--- a/search/highlighting.hpp
+++ b/search/highlighting.hpp
@@ -2,12 +2,18 @@
 
 #include "indexer/search_delimiters.hpp"
 
-#include "std/utility.hpp"
+#include "search/common.hpp"
+#include "search/result.hpp"
+
+#include "base/string_utils.hpp"
+
+#include <string>
+#include <utility>
 
 namespace search
 {
 template <typename LowTokensIterType, typename F>
-void SearchStringTokensIntersectionRanges(string const & s, LowTokensIterType itLowBeg,
+void SearchStringTokensIntersectionRanges(std::string const & s, LowTokensIterType itLowBeg,
                                           LowTokensIterType itLowEnd, F f)
 {
   // split input query by tokens and prefix
@@ -31,7 +37,7 @@ void SearchStringTokensIntersectionRanges(string const & s, LowTokensIterType it
     strings::UniString subStr;
     subStr.assign(str.begin() + beg, str.begin() + pos);
     size_t maxCount = 0;
-    pair<uint16_t, uint16_t> result(0, 0);
+    std::pair<uint16_t, uint16_t> result(0, 0);
 
     for (LowTokensIterType itLow = itLowBeg; itLow != itLowEnd; ++itLow)
     {
@@ -49,4 +55,8 @@ void SearchStringTokensIntersectionRanges(string const & s, LowTokensIterType it
       f(result);
   }
 }
-}
+
+// Adds to |res| the ranges that match the query tokens and, therefore, should be highlighted.
+// The query is passed in |tokens| and |prefix|.
+void HighlightResult(QueryTokens const & tokens, strings::UniString const & prefix, Result & res);
+}  // namespace search

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -23,7 +23,39 @@
 
 namespace search
 {
-double const kDistSameStreetMeters = 5000.0;
+namespace
+{
+class SkipRegionInfo
+{
+  static size_t const m_count = 2;
+  uint32_t m_types[m_count];
+
+public:
+  SkipRegionInfo()
+  {
+    char const * arr[][2] = {
+      {"place", "continent"},
+      {"place", "country"}
+    };
+    static_assert(m_count == ARRAY_SIZE(arr), "");
+
+    Classificator const & c = classif();
+    for (size_t i = 0; i < m_count; ++i)
+      m_types[i] = c.GetTypeByPath(vector<string>(arr[i], arr[i] + 2));
+  }
+
+  bool IsSkip(uint32_t type) const
+  {
+    for (uint32_t t : m_types)
+    {
+      if (t == type)
+        return true;
+    }
+    return false;
+  }
+};
+}  // namespace
+
 char const * const kEmptyRatingSymbol = "-";
 char const * const kPricingSymbol = "$";
 
@@ -76,13 +108,14 @@ void ProcessMetadata(FeatureType const & ft, Result::Metadata & meta)
   meta.m_isInitialized = true;
 }
 
-PreResult1::PreResult1(FeatureID const & fID, PreRankingInfo const & info) : m_id(fID), m_info(info)
+PreRankerResult::PreRankerResult(FeatureID const & fID, PreRankingInfo const & info)
+  : m_id(fID), m_info(info)
 {
   ASSERT(m_id.IsValid(), ());
 }
 
 // static
-bool PreResult1::LessRank(PreResult1 const & r1, PreResult1 const & r2)
+bool PreRankerResult::LessRank(PreRankerResult const & r1, PreRankerResult const & r2)
 {
   if (r1.m_info.m_rank != r2.m_info.m_rank)
     return r1.m_info.m_rank > r2.m_info.m_rank;
@@ -90,19 +123,20 @@ bool PreResult1::LessRank(PreResult1 const & r1, PreResult1 const & r2)
 }
 
 // static
-bool PreResult1::LessDistance(PreResult1 const & r1, PreResult1 const & r2)
+bool PreRankerResult::LessDistance(PreRankerResult const & r1, PreRankerResult const & r2)
 {
   if (r1.m_info.m_distanceToPivot != r2.m_info.m_distanceToPivot)
     return r1.m_info.m_distanceToPivot < r2.m_info.m_distanceToPivot;
   return r1.m_info.m_rank > r2.m_info.m_rank;
 }
 
-PreResult2::PreResult2(FeatureType const & f, m2::PointD const & center, m2::PointD const & pivot,
-                       string const & displayName, string const & fileName)
+RankerResult::RankerResult(FeatureType const & f, m2::PointD const & center,
+                           m2::PointD const & pivot, string const & displayName,
+                           string const & fileName)
   : m_id(f.GetID())
   , m_types(f)
   , m_str(displayName)
-  , m_resultType(ftypes::IsBuildingChecker::Instance()(m_types) ? RESULT_BUILDING : RESULT_FEATURE)
+  , m_resultType(ftypes::IsBuildingChecker::Instance()(m_types) ? TYPE_BUILDING : TYPE_FEATURE)
   , m_geomType(f.GetFeatureType())
 {
   ASSERT(m_id.IsValid(), ());
@@ -116,47 +150,14 @@ PreResult2::PreResult2(FeatureType const & f, m2::PointD const & center, m2::Poi
   ProcessMetadata(f, m_metadata);
 }
 
-PreResult2::PreResult2(double lat, double lon)
-  : m_str("(" + measurement_utils::FormatLatLon(lat, lon) + ")"), m_resultType(RESULT_LATLON)
+RankerResult::RankerResult(double lat, double lon)
+  : m_str("(" + measurement_utils::FormatLatLon(lat, lon) + ")"), m_resultType(TYPE_LATLON)
 {
   m_region.SetParams(string(), MercatorBounds::FromLatLon(lat, lon));
 }
 
-namespace
-{
-  class SkipRegionInfo
-  {
-    static size_t const m_count = 2;
-    uint32_t m_types[m_count];
-
-  public:
-    SkipRegionInfo()
-    {
-      char const * arr[][2] = {
-        { "place", "continent" },
-        { "place", "country" }
-      };
-      static_assert(m_count == ARRAY_SIZE(arr), "");
-
-      Classificator const & c = classif();
-      for (size_t i = 0; i < m_count; ++i)
-        m_types[i] = c.GetTypeByPath(vector<string>(arr[i], arr[i] + 2));
-    }
-
-    bool IsSkip(uint32_t type) const
-    {
-      for (uint32_t t : m_types)
-      {
-        if (t == type)
-          return true;
-      }
-      return false;
-    }
-  };
-}
-
-string PreResult2::GetRegionName(storage::CountryInfoGetter const & infoGetter,
-                                 uint32_t fType) const
+string RankerResult::GetRegionName(storage::CountryInfoGetter const & infoGetter,
+                                   uint32_t fType) const
 {
   static SkipRegionInfo const checker;
   if (checker.IsSkip(fType))
@@ -167,141 +168,29 @@ string PreResult2::GetRegionName(storage::CountryInfoGetter const & infoGetter,
   return info.m_name;
 }
 
-namespace
-{
-// TODO: Format street and house number according to local country's rules.
-string FormatStreetAndHouse(ReverseGeocoder::Address const & addr)
-{
-  ASSERT_GREATER_OR_EQUAL(addr.GetDistance(), 0, ());
-  return addr.GetStreetName() + ", " + addr.GetHouseNumber();
-}
-
-// TODO: Share common formatting code for search results and place page.
-string FormatFullAddress(ReverseGeocoder::Address const & addr, string const & region)
-{
-  // TODO: Print "near" for not exact addresses.
-  if (addr.GetDistance() != 0)
-    return region;
-
-  return FormatStreetAndHouse(addr) + (region.empty() ? "" : ", ") + region;
-}
-}  // namespace
-
-Result PreResult2::GenerateFinalResult(storage::CountryInfoGetter const & infoGetter,
-                                       CategoriesHolder const * pCat,
-                                       set<uint32_t> const * pTypes, int8_t locale,
-                                       ReverseGeocoder const * coder) const
-{
-  ReverseGeocoder::Address addr;
-  bool addrComputed = false;
-
-  string name = m_str;
-  if (coder && name.empty())
-  {
-    // Insert exact address (street and house number) instead of empty result name.
-    if (!addrComputed)
-    {
-      coder->GetNearbyAddress(GetCenter(), addr);
-      addrComputed = true;
-    }
-    if (addr.GetDistance() == 0)
-      name = FormatStreetAndHouse(addr);
-  }
-
-  uint32_t const type = GetBestType(pTypes);
-
-  // Format full address only for suitable results.
-  string address;
-  if (coder)
-  {
-    address = GetRegionName(infoGetter, type);
-    if (ftypes::IsAddressObjectChecker::Instance()(m_types))
-    {
-      if (!addrComputed)
-      {
-        coder->GetNearbyAddress(GetCenter(), addr);
-        addrComputed = true;
-      }
-      address = FormatFullAddress(addr, address);
-    }
-  }
-
-  switch (m_resultType)
-  {
-  case RESULT_FEATURE:
-  case RESULT_BUILDING:
-    return Result(m_id, GetCenter(), name, address, pCat->GetReadableFeatureType(type, locale),
-                  type, m_metadata);
-  default:
-    ASSERT_EQUAL(m_resultType, RESULT_LATLON, ());
-    return Result(GetCenter(), name, address);
-  }
-}
-
-PreResult2::StrictEqualF::StrictEqualF(PreResult2 const & r, double const epsMeters)
-  : m_r(r), m_epsMeters(epsMeters)
-{
-}
-
-bool PreResult2::StrictEqualF::operator()(PreResult2 const & r) const
-{
-  if (m_r.m_resultType == r.m_resultType && m_r.m_resultType == RESULT_FEATURE)
-  {
-    if (m_r.IsEqualCommon(r))
-      return PointDistance(m_r.GetCenter(), r.GetCenter()) < m_epsMeters;
-  }
-
-  return false;
-}
-
-bool PreResult2::LessLinearTypesF::operator() (PreResult2 const & r1, PreResult2 const & r2) const
-{
-  if (r1.m_geomType != r2.m_geomType)
-    return (r1.m_geomType < r2.m_geomType);
-
-  if (r1.m_str != r2.m_str)
-    return (r1.m_str < r2.m_str);
-
-  uint32_t const t1 = r1.GetBestType();
-  uint32_t const t2 = r2.GetBestType();
-  if (t1 != t2)
-    return (t1 < t2);
-
-  // Should stay the best feature, after unique, so add this criteria:
-  return r1.m_distance < r2.m_distance;
-}
-
-bool PreResult2::EqualLinearTypesF::operator() (PreResult2 const & r1, PreResult2 const & r2) const
-{
-  // Note! Do compare for distance when filtering linear objects.
-  // Otherwise we will skip the results for different parts of the map.
-  return r1.m_geomType == feature::GEOM_LINE && r1.IsEqualCommon(r2) &&
-         PointDistance(r1.GetCenter(), r2.GetCenter()) < kDistSameStreetMeters;
-}
-
-bool PreResult2::IsEqualCommon(PreResult2 const & r) const
+bool RankerResult::IsEqualCommon(RankerResult const & r) const
 {
   return m_geomType == r.m_geomType && GetBestType() == r.GetBestType() && m_str == r.m_str;
 }
 
-bool PreResult2::IsStreet() const
+bool RankerResult::IsStreet() const
 {
   return m_geomType == feature::GEOM_LINE && ftypes::IsStreetChecker::Instance()(m_types);
 }
 
-string PreResult2::DebugPrint() const
+string RankerResult::DebugPrint() const
 {
   stringstream ss;
   ss << "IntermediateResult [ "
      << "Name: " << m_str
      << "; Type: " << GetBestType()
-     << "; Ranking info: " << search::DebugPrint(m_info)
+     << "; " << search::DebugPrint(m_info)
      << "; Linear model rank: " << m_info.GetLinearModelRank()
      << " ]";
   return ss.str();
 }
 
-uint32_t PreResult2::GetBestType(set<uint32_t> const * pPrefferedTypes) const
+uint32_t RankerResult::GetBestType(set<uint32_t> const * pPrefferedTypes) const
 {
   if (pPrefferedTypes)
   {
@@ -319,8 +208,8 @@ uint32_t PreResult2::GetBestType(set<uint32_t> const * pPrefferedTypes) const
   return type;
 }
 
-void PreResult2::RegionInfo::GetRegion(storage::CountryInfoGetter const & infoGetter,
-                                       storage::CountryInfo & info) const
+void RankerResult::RegionInfo::GetRegion(storage::CountryInfoGetter const & infoGetter,
+                                         storage::CountryInfo & info) const
 {
   if (!m_file.empty())
     infoGetter.GetRegionInfo(m_file, info);

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -27,7 +27,7 @@ class ReverseGeocoder;
 class PreRankerResult
 {
 public:
-  PreRankerResult(FeatureID const & fID, PreRankingInfo const & info);
+  PreRankerResult(FeatureID const & id, PreRankingInfo const & info);
 
   static bool LessRank(PreRankerResult const & r1, PreRankerResult const & r2);
   static bool LessDistance(PreRankerResult const & r1, PreRankerResult const & r2);
@@ -64,7 +64,9 @@ public:
   /// For RESULT_LATLON.
   RankerResult(double lat, double lon);
 
-  inline search::RankingInfo const & GetRankingInfo() const { return m_info; }
+  bool IsStreet() const;
+
+  search::RankingInfo const & GetRankingInfo() const { return m_info; }
 
   template <typename TInfo>
   inline void SetRankingInfo(TInfo && info)
@@ -72,23 +74,19 @@ public:
     m_info = forward<TInfo>(info);
   }
 
-  string DebugPrint() const;
+  FeatureID const & GetID() const { return m_id; }
+  string const & GetName() const { return m_str; }
+  feature::TypesHolder const & GetTypes() const { return m_types; }
+  Type const & GetResultType() const { return m_resultType; }
+  m2::PointD GetCenter() const { return m_region.m_point; }
+  double GetDistance() const { return m_distance; }
+  feature::EGeomType GetGeomType() const { return m_geomType; }
+  Result::Metadata GetMetadata() const { return m_metadata; }
 
-  bool IsStreet() const;
+  double GetDistanceToPivot() const { return m_info.m_distanceToPivot; }
+  double GetLinearModelRank() const { return m_info.GetLinearModelRank(); }
 
-  inline FeatureID const & GetID() const { return m_id; }
-  inline string const & GetName() const { return m_str; }
-  inline feature::TypesHolder const & GetTypes() const { return m_types; }
-  inline Type const & GetResultType() const { return m_resultType; }
-  inline m2::PointD GetCenter() const { return m_region.m_point; }
-  inline double GetDistance() const { return m_distance; }
-  inline feature::EGeomType GetGeomType() const { return m_geomType; }
-  inline Result::Metadata GetMetadata() const { return m_metadata; }
-
-  inline double GetDistanceToPivot() const { return m_info.m_distanceToPivot; }
-  inline double GetLinearModelRank() const { return m_info.GetLinearModelRank(); }
-
-  string GetRegionName(storage::CountryInfoGetter const & infoGetter, uint32_t fType) const;
+  string GetRegionName(storage::CountryInfoGetter const & infoGetter, uint32_t ftype) const;
 
   bool IsEqualCommon(RankerResult const & r) const;
 
@@ -123,7 +121,7 @@ private:
   Result::Metadata m_metadata;
 };
 
-inline string DebugPrint(RankerResult const & t) { return t.DebugPrint(); }
-
 void ProcessMetadata(FeatureType const & ft, Result::Metadata & meta);
+
+string DebugPrint(RankerResult const & r);
 }  // namespace search

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -13,7 +13,10 @@
 #include "base/random.hpp"
 #include "base/stl_helpers.hpp"
 
-#include "std/iterator.hpp"
+#include <iterator>
+#include <set>
+
+using namespace std;
 
 namespace search
 {
@@ -175,8 +178,7 @@ void PreRanker::Filter(bool viewportSearch)
     }
   }
 
-  using TSet = set<PreRankerResult, LessFeatureID>;
-  TSet filtered;
+  set<PreRankerResult, LessFeatureID> filtered;
 
   filtered.insert(m_results.begin(), m_results.begin() + min(m_results.size(), BatchSize()));
 

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -87,7 +87,7 @@ private:
 
   Index const & m_index;
   Ranker & m_ranker;
-  vector<PreResult1> m_results;
+  vector<PreRankerResult> m_results;
   size_t const m_limit;
   Params m_params;
   bool m_viewportSearch = false;

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -135,11 +135,8 @@ protected:
   void SetViewportByIndex(m2::RectD const & viewport, size_t idx, bool forceUpdate);
   void ClearCache(size_t ind);
 
-  /// @name Get ranking params.
-  //@{
-  /// @return Rect for viewport-distance calculation.
+  // Returns a Rect for viewport-distance calculations.
   m2::RectD const & GetViewport(ViewportID vID = DEFAULT_V) const;
-  //@}
 
   void SetLanguage(int id, int8_t lang);
   int8_t GetLanguage(int id) const;

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -22,7 +22,6 @@
 
 #include "geometry/rect2d.hpp"
 
-#include "base/buffer_vector.hpp"
 #include "base/cancellable.hpp"
 #include "base/limited_priority_queue.hpp"
 #include "base/string_utils.hpp"
@@ -50,14 +49,7 @@ class CountryInfoGetter;
 
 namespace search
 {
-struct Locality;
-struct Region;
-
-class DoFindLocality;
-class FeatureLoader;
 class Geocoder;
-class HouseCompFactory;
-class PreResult2Maker;  // todo(@m) merge with Ranker
 class QueryParams;
 class Ranker;
 class ReverseGeocoder;
@@ -125,13 +117,6 @@ protected:
 
   friend string DebugPrint(ViewportID viewportId);
 
-  friend class BestNameFinder;
-  friend class DoFindLocality;
-  friend class FeatureLoader;
-  friend class HouseCompFactory;
-  friend class PreResult2Maker;
-  friend class Ranker;
-
   using TMWMVector = vector<shared_ptr<MwmInfo>>;
   using TOffsetsVector = map<MwmSet::MwmId, vector<uint32_t>>;
   using TFHeader = feature::DataHeader;
@@ -150,12 +135,21 @@ protected:
   void SetViewportByIndex(m2::RectD const & viewport, size_t idx, bool forceUpdate);
   void ClearCache(size_t ind);
 
+  /// @name Get ranking params.
+  //@{
+  /// @return Rect for viewport-distance calculation.
+  m2::RectD const & GetViewport(ViewportID vID = DEFAULT_V) const;
+  //@}
+
+  void SetLanguage(int id, int8_t lang);
+  int8_t GetLanguage(int id) const;
+
   CategoriesHolder const & m_categories;
   storage::CountryInfoGetter const & m_infoGetter;
 
   string m_region;
   string m_query;
-  buffer_vector<strings::UniString, 32> m_tokens;
+  QueryTokens m_tokens;
   strings::UniString m_prefix;
   set<uint32_t> m_preferredTypes;
 
@@ -169,21 +163,12 @@ protected:
   bool m_cianMode = false;
   SearchParams::OnResults m_onResults;
 
-  /// @name Get ranking params.
-  //@{
-  /// @return Rect for viewport-distance calculation.
-  m2::RectD const & GetViewport(ViewportID vID = DEFAULT_V) const;
-  //@}
-
-  void SetLanguage(int id, int8_t lang);
-  int8_t GetLanguage(int id) const;
-
-protected:
   bool m_viewportSearch;
 
   VillagesCache m_villagesCache;
   CitiesBoundariesTable m_citiesBoundaries;
 
+  KeywordLangMatcher m_keywordsScorer;
   Emitter m_emitter;
   Ranker m_ranker;
   PreRanker m_preRanker;

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -117,7 +117,9 @@ public:
 private:
   FeatureID m_id;
   m2::PointD m_center;
-  string m_str, m_address, m_type;
+  string m_str;
+  string m_address;
+  string m_type;
   uint32_t m_featureType;
   string m_suggestionStr;
   buffer_vector<pair<uint16_t, uint16_t>, 4> m_hightlightRanges;
@@ -199,7 +201,11 @@ private:
 
 struct AddressInfo
 {
-  string m_country, m_city, m_street, m_house, m_name;
+  string m_country;
+  string m_city;
+  string m_street;
+  string m_house;
+  string m_name;
   vector<string> m_types;
   double m_distanceMeters = -1.0;
 

--- a/search/search.pro
+++ b/search/search.pro
@@ -37,6 +37,7 @@ HEADERS += \
     geocoder_locality.hpp \
     geometry_cache.hpp \
     geometry_utils.hpp \
+    highlighting.hpp \
     hotels_classifier.hpp \
     hotels_filter.hpp \
     house_detector.hpp \
@@ -78,7 +79,6 @@ HEADERS += \
     stats_cache.hpp \
     street_vicinity_loader.hpp \
     streets_matcher.hpp \
-    string_intersection.hpp \
     suggest.hpp \
     token_range.hpp \
     token_slice.hpp \
@@ -108,6 +108,7 @@ SOURCES += \
     geocoder_locality.cpp \
     geometry_cache.cpp \
     geometry_utils.cpp \
+    highlighting.cpp \
     hotels_classifier.cpp \
     hotels_filter.cpp \
     house_detector.cpp \
@@ -143,6 +144,7 @@ SOURCES += \
     segment_tree.cpp \
     street_vicinity_loader.cpp \
     streets_matcher.cpp \
+    suggest.cpp \
     token_slice.cpp \
     types_skipper.cpp \
     utils.cpp \

--- a/search/search_quality/search_quality_tool/search_quality_tool.cpp
+++ b/search/search_quality/search_quality_tool/search_quality_tool.cpp
@@ -378,8 +378,7 @@ int main(int argc, char * argv[])
   Engine::Params params;
   params.m_locale = FLAGS_locale;
   params.m_numThreads = FLAGS_num_threads;
-  TestSearchEngine engine(move(infoGetter), make_unique<ProcessorFactory>(), Engine::Params{});
-  engine.SetLocale(FLAGS_locale);
+  TestSearchEngine engine(move(infoGetter), make_unique<ProcessorFactory>(), params);
 
   vector<platform::LocalCountryFile> mwms;
   if (!FLAGS_mwm_list_path.empty())

--- a/search/search_quality/search_quality_tool/search_quality_tool.cpp
+++ b/search/search_quality/search_quality_tool/search_quality_tool.cpp
@@ -379,6 +379,7 @@ int main(int argc, char * argv[])
   params.m_locale = FLAGS_locale;
   params.m_numThreads = FLAGS_num_threads;
   TestSearchEngine engine(move(infoGetter), make_unique<ProcessorFactory>(), Engine::Params{});
+  engine.SetLocale(FLAGS_locale);
 
   vector<platform::LocalCountryFile> mwms;
   if (!FLAGS_mwm_list_path.empty())

--- a/search/search_tests/CMakeLists.txt
+++ b/search/search_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(${OMIM_ROOT}/3party/jansson/src)
 set(
   SRC
   algos_tests.cpp
+  highlighting_tests.cpp
   house_detector_tests.cpp
   house_numbers_matcher_test.cpp
   interval_set_test.cpp
@@ -19,7 +20,6 @@ set(
   query_saver_tests.cpp
   ranking_tests.cpp
   segment_tree_tests.cpp
-  string_intersection_test.cpp
   string_match_test.cpp
 )
 

--- a/search/search_tests/highlighting_tests.cpp
+++ b/search/search_tests/highlighting_tests.cpp
@@ -5,14 +5,17 @@
 #include "indexer/feature_covering.hpp"
 
 #include "base/logging.hpp"
+#include "base/string_utils.hpp"
 
 #include "std/cstdarg.hpp"
+#include "std/string.hpp"
+#include "std/vector.hpp"
 
 namespace
 {
-typedef pair<uint16_t, uint16_t> TestResult;
-typedef vector<strings::UniString> TokensVector;
-typedef vector<TestResult> TestResultVector;
+using TestResult = pair<uint16_t, uint16_t>;
+using TokensVector = vector<strings::UniString>;
+using TestResultVector = vector<TestResult>;
 
 struct TestData
 {
@@ -37,9 +40,8 @@ struct TestData
     va_end(ap);
   }
 
-  void AddResult(uint16_t pos, uint16_t len) { m_results.push_back(TestResult(pos, len)); }
+  void AddResult(uint16_t pos, uint16_t len) { m_results.emplace_back(pos, len); }
 };
-typedef vector<TestData> TestVector;
 
 class CheckRange
 {
@@ -86,7 +88,7 @@ UNIT_TEST(SearchStringTokensIntersectionRange)
   char const * lowTokens8[] = {"ул", "кар"};
   char const * lowTokens9[] = {"ул", "бог"};
 
-  TestVector tests;
+  vector<TestData> tests;
   // fill test data
   tests.push_back(TestData(str0, lowTokens0, 2, 2, 6, 5, 12, 6));
   tests.push_back(TestData(str1, lowTokens0, 2, 2, 4, 5, 10, 6));
@@ -112,12 +114,8 @@ UNIT_TEST(SearchStringTokensIntersectionRange)
   tests.push_back(TestData(str9, lowTokens8, 2, 2, 0, 2, 6, 3));
   tests.push_back(TestData(str11, lowTokens9, 2, 2, 0, 2, 14, 3));
 
-  // run tests
-  size_t count = 0;
-  for (TestVector::iterator it = tests.begin(); it != tests.end(); ++it, ++count)
+  for (TestData const & data : tests)
   {
-    TestData const & data = *it;
-
     search::SearchStringTokensIntersectionRanges(
         data.m_input, data.m_lowTokens.begin(), data.m_lowTokens.end(), CheckRange(data.m_results));
   }

--- a/search/search_tests/highlighting_tests.cpp
+++ b/search/search_tests/highlighting_tests.cpp
@@ -1,13 +1,12 @@
 #include "testing/testing.hpp"
 
-#include "search/string_intersection.hpp"
+#include "search/highlighting.hpp"
 
 #include "indexer/feature_covering.hpp"
 
 #include "base/logging.hpp"
 
 #include "std/cstdarg.hpp"
-
 
 namespace
 {
@@ -21,7 +20,7 @@ struct TestData
   TokensVector m_lowTokens;
   TestResultVector m_results;
 
-  TestData(char const * inp, char const **lToks, size_t lowTokCount, size_t resCount, ...)
+  TestData(char const * inp, char const ** lToks, size_t lowTokCount, size_t resCount, ...)
   {
     m_input = inp;
     for (size_t i = 0; i < lowTokCount; ++i)
@@ -38,11 +37,7 @@ struct TestData
     va_end(ap);
   }
 
-  void AddResult(uint16_t pos, uint16_t len)
-  {
-    m_results.push_back(TestResult(pos, len));
-  }
-
+  void AddResult(uint16_t pos, uint16_t len) { m_results.push_back(TestResult(pos, len)); }
 };
 typedef vector<TestData> TestVector;
 
@@ -50,31 +45,23 @@ class CheckRange
 {
   size_t m_idx;
   TestResultVector const & m_results;
+
 public:
-  CheckRange(TestResultVector const & results)
-    : m_idx(0)
-    , m_results(results)
-  {
-  }
+  CheckRange(TestResultVector const & results) : m_idx(0), m_results(results) {}
 
-  ~CheckRange()
-  {
-    TEST_EQUAL(m_idx, m_results.size(), ());
-  }
+  ~CheckRange() { TEST_EQUAL(m_idx, m_results.size(), ()); }
 
-  void operator() (pair<uint16_t, uint16_t> const & range)
+  void operator()(pair<uint16_t, uint16_t> const & range)
   {
     ASSERT(m_idx < m_results.size(), ());
     TEST_EQUAL(range, m_results[m_idx], ());
     ++m_idx;
   }
 };
-
 }
 
 UNIT_TEST(SearchStringTokensIntersectionRange)
 {
-
   char const * str0 = "улица Карла Маркса";
   char const * str1 = "ул. Карла Маркса";
   char const * str2 = "Карлов Мост";
@@ -101,29 +88,29 @@ UNIT_TEST(SearchStringTokensIntersectionRange)
 
   TestVector tests;
   // fill test data
-  tests.push_back(TestData(str0, lowTokens0, 2, 2, 6,5, 12,6));
-  tests.push_back(TestData(str1, lowTokens0, 2, 2, 4,5, 10,6));
+  tests.push_back(TestData(str0, lowTokens0, 2, 2, 6, 5, 12, 6));
+  tests.push_back(TestData(str1, lowTokens0, 2, 2, 4, 5, 10, 6));
   tests.push_back(TestData(str2, lowTokens0, 2, 0));
-  tests.push_back(TestData(str10, lowTokens8, 2, 2, 0,2, 6,3));
-  tests.push_back(TestData(str4, lowTokens1, 2, 2, 9,5, 15,4));
+  tests.push_back(TestData(str10, lowTokens8, 2, 2, 0, 2, 6, 3));
+  tests.push_back(TestData(str4, lowTokens1, 2, 2, 9, 5, 15, 4));
 
   tests.push_back(TestData(str0, lowTokens2, 1, 0));
   tests.push_back(TestData(str2, lowTokens2, 1, 0));
-  tests.push_back(TestData(str0, lowTokens3, 2, 2, 6,5, 12,1));
-  tests.push_back(TestData(str1, lowTokens3, 2, 2, 4,5, 10,1));
-  tests.push_back(TestData(str0, lowTokens4, 2, 2, 6,3, 12,3));
+  tests.push_back(TestData(str0, lowTokens3, 2, 2, 6, 5, 12, 1));
+  tests.push_back(TestData(str1, lowTokens3, 2, 2, 4, 5, 10, 1));
+  tests.push_back(TestData(str0, lowTokens4, 2, 2, 6, 3, 12, 3));
 
-  tests.push_back(TestData(str3, lowTokens1, 2, 1, 0,4));
-  tests.push_back(TestData(str5, lowTokens5, 2, 2, 10,4, 16,5));
+  tests.push_back(TestData(str3, lowTokens1, 2, 1, 0, 4));
+  tests.push_back(TestData(str5, lowTokens5, 2, 2, 10, 4, 16, 5));
   tests.push_back(TestData(str6, lowTokens6, 1, 0));
   tests.push_back(TestData(str6, lowTokens7, 2, 0));
-  tests.push_back(TestData(str5, lowTokens7, 2, 1, 10,4));
+  tests.push_back(TestData(str5, lowTokens7, 2, 1, 10, 4));
 
-  tests.push_back(TestData(str8, lowTokens3, 2, 2, 2,5, 9,1));
-  tests.push_back(TestData(str7, lowTokens0, 2, 2, 2,5, 8,6));
-  tests.push_back(TestData(str0, lowTokens8, 2, 2, 0,2, 6,3));
-  tests.push_back(TestData(str9, lowTokens8, 2, 2, 0,2, 6,3));
-  tests.push_back(TestData(str11, lowTokens9, 2, 2, 0,2, 14,3));
+  tests.push_back(TestData(str8, lowTokens3, 2, 2, 2, 5, 9, 1));
+  tests.push_back(TestData(str7, lowTokens0, 2, 2, 2, 5, 8, 6));
+  tests.push_back(TestData(str0, lowTokens8, 2, 2, 0, 2, 6, 3));
+  tests.push_back(TestData(str9, lowTokens8, 2, 2, 0, 2, 6, 3));
+  tests.push_back(TestData(str11, lowTokens9, 2, 2, 0, 2, 14, 3));
 
   // run tests
   size_t count = 0;
@@ -131,9 +118,7 @@ UNIT_TEST(SearchStringTokensIntersectionRange)
   {
     TestData const & data = *it;
 
-    search::SearchStringTokensIntersectionRanges(data.m_input,
-                                                data.m_lowTokens.begin(),
-                                                data.m_lowTokens.end(),
-                                                CheckRange(data.m_results));
+    search::SearchStringTokensIntersectionRanges(
+        data.m_input, data.m_lowTokens.begin(), data.m_lowTokens.end(), CheckRange(data.m_results));
   }
 }

--- a/search/search_tests/search_tests.pro
+++ b/search/search_tests/search_tests.pro
@@ -25,6 +25,7 @@ win32*|linux* {
 SOURCES += \
     ../../testing/testingmain.cpp \
     algos_tests.cpp \
+    highlighting_test.cpp \
     hotels_filter_test.cpp \
     house_detector_tests.cpp \
     house_numbers_matcher_test.cpp \
@@ -39,7 +40,6 @@ SOURCES += \
     query_saver_tests.cpp \
     ranking_tests.cpp \
     segment_tree_tests.cpp \
-    string_intersection_test.cpp \
     string_match_test.cpp \
 
 HEADERS += \

--- a/search/suggest.cpp
+++ b/search/suggest.cpp
@@ -47,7 +47,7 @@ void GetSuggestion(RankerResult const & res, string const & query, QueryTokens c
   if (!prefixMatched || fullPrefixMatched)
     return;
 
-  GetStringPrefix(query, suggest);
+  suggest = DropLastToken(query);
 
   // Appends unmatched result's tokens to the suggestion.
   for (size_t i = 0; i < tokens.size(); ++i)

--- a/search/suggest.cpp
+++ b/search/suggest.cpp
@@ -1,0 +1,61 @@
+#include "search/suggest.hpp"
+
+#include "indexer/search_delimiters.hpp"
+#include "indexer/search_string_utils.hpp"
+
+#include "search/common.hpp"
+
+#include "base/stl_add.hpp"
+
+#include <vector>
+
+using namespace std;
+
+namespace search
+{
+void GetSuggestion(RankerResult const & res, string const & query, QueryTokens const & paramTokens,
+                   strings::UniString const & prefix, string & suggest)
+{
+  // Splits result's name.
+  search::Delimiters delims;
+  vector<strings::UniString> tokens;
+  SplitUniString(NormalizeAndSimplifyString(res.GetName()), MakeBackInsertFunctor(tokens), delims);
+
+  // Finds tokens that are already present in the input query.
+  vector<bool> tokensMatched(tokens.size());
+  bool prefixMatched = false;
+  bool fullPrefixMatched = false;
+
+  for (size_t i = 0; i < tokens.size(); ++i)
+  {
+    auto const & token = tokens[i];
+
+    if (find(paramTokens.begin(), paramTokens.end(), token) != paramTokens.end())
+    {
+      tokensMatched[i] = true;
+    }
+    else if (StartsWith(token, prefix))
+    {
+      prefixMatched = true;
+      fullPrefixMatched = token.size() == prefix.size();
+    }
+  }
+
+  // When |name| does not match prefix or when prefix equals to some
+  // token of the |name| (for example, when user entered "Moscow"
+  // without space at the end), we should not suggest anything.
+  if (!prefixMatched || fullPrefixMatched)
+    return;
+
+  GetStringPrefix(query, suggest);
+
+  // Appends unmatched result's tokens to the suggestion.
+  for (size_t i = 0; i < tokens.size(); ++i)
+  {
+    if (tokensMatched[i])
+      continue;
+    suggest.append(strings::ToUtf8(tokens[i]));
+    suggest.push_back(' ');
+  }
+}
+}  // namespace search

--- a/search/suggest.hpp
+++ b/search/suggest.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "search/common.hpp"
+#include "search/intermediate_result.hpp"
+
 #include "base/string_utils.hpp"
 
-#include "std/cstdint.hpp"
+#include <cstdint>
+#include <string>
 
 namespace search
 {
@@ -17,4 +21,7 @@ struct Suggest
   uint8_t m_prefixLength;
   int8_t m_locale;
 };
+
+void GetSuggestion(RankerResult const & res, string const & query, QueryTokens const & paramTokens,
+                   strings::UniString const & prefix, std::string & suggest);
 }  // namespace search

--- a/search/utils.hpp
+++ b/search/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "search/common.hpp"
 #include "search/token_slice.hpp"
 
 #include "indexer/categories_holder.hpp"
@@ -7,9 +8,7 @@
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
 
-#include "base/buffer_vector.hpp"
 #include "base/levenshtein_dfa.hpp"
-#include "base/small_set.hpp"
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 
@@ -24,8 +23,6 @@ class MwmInfo;
 
 namespace search
 {
-using Locales = base::SafeSmallSet<CategoriesHolder::kMaxSupportedLocaleIndex + 1>;
-
 // todo(@m, @y). Unite with the similar function in search/feature_offset_match.hpp.
 template <typename TrieIt, typename DFA, typename ToDo>
 bool MatchInTrie(TrieIt const & trieStartIt, DFA const & dfa, ToDo && toDo)

--- a/xcode/search/search.xcodeproj/project.pbxproj
+++ b/xcode/search/search.xcodeproj/project.pbxproj
@@ -70,8 +70,14 @@
 		34F558451DBF2E7600A4FC11 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558441DBF2E7600A4FC11 /* libopening_hours.a */; };
 		34F558471DBF2E8100A4FC11 /* libsuccinct.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558461DBF2E8100A4FC11 /* libsuccinct.a */; };
 		34F558491DBF2EC700A4FC11 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558481DBF2EC700A4FC11 /* libz.tbd */; };
+		3913DA511F9FCC88004AA681 /* suggest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3913DA501F9FCC88004AA681 /* suggest.cpp */; };
 		397AFE061D6C9AC700F583E7 /* downloader_search_callback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397AFE041D6C9AC700F583E7 /* downloader_search_callback.cpp */; };
 		397AFE071D6C9AC700F583E7 /* downloader_search_callback.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 397AFE051D6C9AC700F583E7 /* downloader_search_callback.hpp */; };
+		39BBC13B1F9FD65C009D1687 /* highlighting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC1391F9FD65C009D1687 /* highlighting.cpp */; };
+		39BBC13C1F9FD65C009D1687 /* highlighting.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 39BBC13A1F9FD65C009D1687 /* highlighting.hpp */; };
+		39BBC13E1F9FD679009D1687 /* segment_tree_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC13D1F9FD679009D1687 /* segment_tree_tests.cpp */; };
+		39BBC1401F9FD683009D1687 /* point_rect_matcher_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC13F1F9FD683009D1687 /* point_rect_matcher_tests.cpp */; };
+		39BBC1421F9FD68C009D1687 /* highlighting_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC1411F9FD68C009D1687 /* highlighting_tests.cpp */; };
 		3DF37FAA1EA11B380012CB31 /* everywhere_search_callback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DF37FA81EA11B380012CB31 /* everywhere_search_callback.cpp */; };
 		3DF37FAB1EA11B380012CB31 /* everywhere_search_callback.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DF37FA91EA11B380012CB31 /* everywhere_search_callback.hpp */; };
 		3DFEBF761EF2D55800317D5C /* city_finder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DFEBF751EF2D55800317D5C /* city_finder.hpp */; };
@@ -89,7 +95,6 @@
 		671C621F1AE9227C00076BD0 /* keyword_matcher_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C62161AE9227C00076BD0 /* keyword_matcher_test.cpp */; };
 		671C62201AE9227C00076BD0 /* latlon_match_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C62171AE9227C00076BD0 /* latlon_match_test.cpp */; };
 		671C62211AE9227C00076BD0 /* locality_finder_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C62181AE9227C00076BD0 /* locality_finder_test.cpp */; };
-		671C62221AE9227C00076BD0 /* string_intersection_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C621A1AE9227C00076BD0 /* string_intersection_test.cpp */; };
 		671C62231AE9227C00076BD0 /* string_match_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C621B1AE9227C00076BD0 /* string_match_test.cpp */; };
 		671C62251AE9229A00076BD0 /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671C62241AE9229A00076BD0 /* testingmain.cpp */; };
 		671C62261AE9232900076BD0 /* libsearch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675346B01A4055CF00A0A8C3 /* libsearch.a */; };
@@ -170,7 +175,6 @@
 		F652D90A1CFDE21900FC29A0 /* stats_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F652D8E31CFDE21900FC29A0 /* stats_cache.hpp */; };
 		F652D90B1CFDE21900FC29A0 /* street_vicinity_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F652D8E41CFDE21900FC29A0 /* street_vicinity_loader.cpp */; };
 		F652D90C1CFDE21900FC29A0 /* street_vicinity_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F652D8E51CFDE21900FC29A0 /* street_vicinity_loader.hpp */; };
-		F652D90D1CFDE21900FC29A0 /* string_intersection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F652D8E61CFDE21900FC29A0 /* string_intersection.hpp */; };
 		F652D90E1CFDE21900FC29A0 /* token_slice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F652D8E71CFDE21900FC29A0 /* token_slice.cpp */; };
 		F652D90F1CFDE21900FC29A0 /* token_slice.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F652D8E81CFDE21900FC29A0 /* token_slice.hpp */; };
 		F659FC6D1CF4A30B000A06B1 /* pre_ranker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F659FC6B1CF4A30B000A06B1 /* pre_ranker.cpp */; };
@@ -257,8 +261,14 @@
 		34F558441DBF2E7600A4FC11 /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		34F558461DBF2E8100A4FC11 /* libsuccinct.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsuccinct.a; path = "../../../omim-xcode-build/Debug/libsuccinct.a"; sourceTree = "<group>"; };
 		34F558481DBF2EC700A4FC11 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		3913DA501F9FCC88004AA681 /* suggest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = suggest.cpp; sourceTree = "<group>"; };
 		397AFE041D6C9AC700F583E7 /* downloader_search_callback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = downloader_search_callback.cpp; sourceTree = "<group>"; };
 		397AFE051D6C9AC700F583E7 /* downloader_search_callback.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = downloader_search_callback.hpp; sourceTree = "<group>"; };
+		39BBC1391F9FD65C009D1687 /* highlighting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = highlighting.cpp; sourceTree = "<group>"; };
+		39BBC13A1F9FD65C009D1687 /* highlighting.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = highlighting.hpp; sourceTree = "<group>"; };
+		39BBC13D1F9FD679009D1687 /* segment_tree_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = segment_tree_tests.cpp; sourceTree = "<group>"; };
+		39BBC13F1F9FD683009D1687 /* point_rect_matcher_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = point_rect_matcher_tests.cpp; sourceTree = "<group>"; };
+		39BBC1411F9FD68C009D1687 /* highlighting_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = highlighting_tests.cpp; sourceTree = "<group>"; };
 		3DF37FA81EA11B380012CB31 /* everywhere_search_callback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = everywhere_search_callback.cpp; sourceTree = "<group>"; };
 		3DF37FA91EA11B380012CB31 /* everywhere_search_callback.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = everywhere_search_callback.hpp; sourceTree = "<group>"; };
 		3DFEBF751EF2D55800317D5C /* city_finder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = city_finder.hpp; sourceTree = "<group>"; };
@@ -278,7 +288,6 @@
 		671C62171AE9227C00076BD0 /* latlon_match_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = latlon_match_test.cpp; sourceTree = "<group>"; };
 		671C62181AE9227C00076BD0 /* locality_finder_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = locality_finder_test.cpp; sourceTree = "<group>"; };
 		671C62191AE9227C00076BD0 /* match_cost_mock.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = match_cost_mock.hpp; sourceTree = "<group>"; };
-		671C621A1AE9227C00076BD0 /* string_intersection_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_intersection_test.cpp; sourceTree = "<group>"; };
 		671C621B1AE9227C00076BD0 /* string_match_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_match_test.cpp; sourceTree = "<group>"; };
 		671C62241AE9229A00076BD0 /* testingmain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = testingmain.cpp; path = ../../testing/testingmain.cpp; sourceTree = "<group>"; };
 		671C62271AE9233200076BD0 /* libindexer.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libindexer.a; path = "../../../omim-xcode-build/Debug-iphonesimulator/libindexer.a"; sourceTree = "<group>"; };
@@ -363,7 +372,6 @@
 		F652D8E31CFDE21900FC29A0 /* stats_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stats_cache.hpp; sourceTree = "<group>"; };
 		F652D8E41CFDE21900FC29A0 /* street_vicinity_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = street_vicinity_loader.cpp; sourceTree = "<group>"; };
 		F652D8E51CFDE21900FC29A0 /* street_vicinity_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = street_vicinity_loader.hpp; sourceTree = "<group>"; };
-		F652D8E61CFDE21900FC29A0 /* string_intersection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = string_intersection.hpp; sourceTree = "<group>"; };
 		F652D8E71CFDE21900FC29A0 /* token_slice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = token_slice.cpp; sourceTree = "<group>"; };
 		F652D8E81CFDE21900FC29A0 /* token_slice.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = token_slice.hpp; sourceTree = "<group>"; };
 		F659FC6B1CF4A30B000A06B1 /* pre_ranker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pre_ranker.cpp; sourceTree = "<group>"; };
@@ -446,6 +454,9 @@
 		671C620D1AE9225100076BD0 /* search_tests */ = {
 			isa = PBXGroup;
 			children = (
+				39BBC1411F9FD68C009D1687 /* highlighting_tests.cpp */,
+				39BBC13F1F9FD683009D1687 /* point_rect_matcher_tests.cpp */,
+				39BBC13D1F9FD679009D1687 /* segment_tree_tests.cpp */,
 				34586B821DCB1E8300CF7FC9 /* hotels_filter_test.cpp */,
 				34586B831DCB1E8300CF7FC9 /* house_numbers_matcher_test.cpp */,
 				34586B841DCB1E8300CF7FC9 /* interval_set_test.cpp */,
@@ -462,7 +473,6 @@
 				671C62171AE9227C00076BD0 /* latlon_match_test.cpp */,
 				671C62181AE9227C00076BD0 /* locality_finder_test.cpp */,
 				671C62191AE9227C00076BD0 /* match_cost_mock.hpp */,
-				671C621A1AE9227C00076BD0 /* string_intersection_test.cpp */,
 				671C621B1AE9227C00076BD0 /* string_match_test.cpp */,
 			);
 			name = search_tests;
@@ -495,6 +505,9 @@
 		675346B21A4055CF00A0A8C3 /* search */ = {
 			isa = PBXGroup;
 			children = (
+				39BBC1391F9FD65C009D1687 /* highlighting.cpp */,
+				39BBC13A1F9FD65C009D1687 /* highlighting.hpp */,
+				3913DA501F9FCC88004AA681 /* suggest.cpp */,
 				456E1B411F9A3CF5009C32E1 /* localities_source.cpp */,
 				456E1B401F9A3CF5009C32E1 /* localities_source.hpp */,
 				456E1B3C1F9A3C8D009C32E1 /* cities_boundaries_table.cpp */,
@@ -616,7 +629,6 @@
 				F652D8E51CFDE21900FC29A0 /* street_vicinity_loader.hpp */,
 				345C8DAD1D2D15A50037E3A6 /* streets_matcher.cpp */,
 				345C8DAE1D2D15A50037E3A6 /* streets_matcher.hpp */,
-				F652D8E61CFDE21900FC29A0 /* string_intersection.hpp */,
 				347F33151C4540A8009758CC /* suggest.hpp */,
 				34EEAD6F1E55AE4300E95575 /* token_range.hpp */,
 				F652D8E71CFDE21900FC29A0 /* token_slice.cpp */,
@@ -684,6 +696,7 @@
 				56D5456F1C74A48C00E3719C /* mode.hpp in Headers */,
 				0810EC371D6D9D2E00ABFEE7 /* displayed_categories.hpp in Headers */,
 				347F332A1C4540A8009758CC /* search_index_values.hpp in Headers */,
+				39BBC13C1F9FD65C009D1687 /* highlighting.hpp in Headers */,
 				347F33161C4540A8009758CC /* cancel_exception.hpp in Headers */,
 				342D83351D5233B3000D8AEA /* hotels_classifier.hpp in Headers */,
 				3441CE4F1CFC1D7000CF30D4 /* processor_factory.hpp in Headers */,
@@ -708,7 +721,6 @@
 				347F331B1C4540A8009758CC /* interval_set.hpp in Headers */,
 				F652D9051CFDE21900FC29A0 /* rank_table_cache.hpp in Headers */,
 				3469FAD31D6C5D9C00F35A88 /* everywhere_search_params.hpp in Headers */,
-				F652D90D1CFDE21900FC29A0 /* string_intersection.hpp in Headers */,
 				3465B2861D5DE71A0021E14D /* viewport_search_params.hpp in Headers */,
 				F652D8C01CFDE1E800FC29A0 /* engine.hpp in Headers */,
 				675346DF1A40560D00A0A8C3 /* feature_offset_match.hpp in Headers */,
@@ -841,7 +853,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				671C62231AE9227C00076BD0 /* string_match_test.cpp in Sources */,
-				671C62221AE9227C00076BD0 /* string_intersection_test.cpp in Sources */,
 				671C62201AE9227C00076BD0 /* latlon_match_test.cpp in Sources */,
 				671C621F1AE9227C00076BD0 /* keyword_matcher_test.cpp in Sources */,
 				671C62251AE9229A00076BD0 /* testingmain.cpp in Sources */,
@@ -859,12 +870,14 @@
 				F652D8FA1CFDE21900FC29A0 /* locality_scorer.cpp in Sources */,
 				349B65891D4F21E5001798E2 /* lazy_centers_table.cpp in Sources */,
 				F652D8FE1CFDE21900FC29A0 /* mwm_context.cpp in Sources */,
+				39BBC13E1F9FD679009D1687 /* segment_tree_tests.cpp in Sources */,
 				F652D8F01CFDE21900FC29A0 /* geocoder.cpp in Sources */,
 				F652D8F21CFDE21900FC29A0 /* geometry_cache.cpp in Sources */,
 				34586B8C1DCB1E8300CF7FC9 /* locality_scorer_test.cpp in Sources */,
 				34EEAD721E55AE5C00E95575 /* utils.cpp in Sources */,
 				345C8DB11D2D15A50037E3A6 /* geocoder_context.cpp in Sources */,
 				3461C9A31D79949600E6E6F5 /* editor_delegate.cpp in Sources */,
+				39BBC13B1F9FD65C009D1687 /* highlighting.cpp in Sources */,
 				F652D8BF1CFDE1E800FC29A0 /* engine.cpp in Sources */,
 				675346DD1A40560D00A0A8C3 /* approximate_string_match.cpp in Sources */,
 				34586B8B1DCB1E8300CF7FC9 /* interval_set_test.cpp in Sources */,
@@ -900,9 +913,11 @@
 				34586B8A1DCB1E8300CF7FC9 /* house_numbers_matcher_test.cpp in Sources */,
 				F659FC6D1CF4A30B000A06B1 /* pre_ranker.cpp in Sources */,
 				34586B8F1DCB1E8300CF7FC9 /* ranking_tests.cpp in Sources */,
+				39BBC1401F9FD683009D1687 /* point_rect_matcher_tests.cpp in Sources */,
 				F652D9081CFDE21900FC29A0 /* ranking_utils.cpp in Sources */,
 				3465B2821D5DE71A0021E14D /* search_params.cpp in Sources */,
 				347F33241C4540A8009758CC /* retrieval.cpp in Sources */,
+				3913DA511F9FCC88004AA681 /* suggest.cpp in Sources */,
 				A1347D551B8758E9009050FF /* query_saver_tests.cpp in Sources */,
 				F652D90B1CFDE21900FC29A0 /* street_vicinity_loader.cpp in Sources */,
 				3459A7A71E4C4D0200ED235F /* geocoder_locality.cpp in Sources */,
@@ -921,6 +936,7 @@
 				3453BD5A1DAF91C100380ECB /* hotels_filter.cpp in Sources */,
 				345C8DB31D2D15A50037E3A6 /* streets_matcher.cpp in Sources */,
 				456E1B3E1F9A3C8E009C32E1 /* cities_boundaries_table.cpp in Sources */,
+				39BBC1421F9FD68C009D1687 /* highlighting_tests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Factored out assigning the highlight ranges.
- Moved several Ranker's methods to the private section.
- Renamed PreResult1 to PreRankerResult and PreResult2 to RankerResult.
- Moved result comparators closer to their call sites (changing them to lambdas).
- Removed IndexedValue.
- Moved KeywordsScorer from Ranker to Processor.
- Added a type alias for query tokens.