### PR TITLE
[transit] Keeping osm id with gates as gate id.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -89,10 +89,10 @@ UNIT_TEST(DeserializerFromJson_Stops)
   ]})";
 
   vector<Stop> const expected = {
-      Stop(343259523 /* id */, FeatureIdentifiers(kInvalidOsmId, 1 /* feature id */), kInvalidTransferId /* transfer id */,
-           {19207936, 19207937} /* lineIds */, {27.4970954, 64.20146835878187} /* point */,
-           {} /* anchors */),
-      Stop(266680843 /* id */, FeatureIdentifiers(kInvalidOsmId, 2 /* feature id */), 5 /* transfer id */,
+      Stop(343259523 /* id */, kInvalidOsmId, 1 /* feature id */,
+           kInvalidTransferId /* transfer id */, {19207936, 19207937} /* lineIds */,
+           {27.4970954, 64.20146835878187} /* point */, {} /* anchors */),
+      Stop(266680843 /* id */, kInvalidOsmId, 2 /* feature id */, 5 /* transfer id */,
            {19213568, 19213569} /* line ids */, {27.5227942, 64.25206634443111} /* point */,
            {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 
@@ -132,10 +132,10 @@ UNIT_TEST(DeserializerFromJson_Gates)
   ]})";
 
   vector<Gate> const expected = {
-      Gate(FeatureIdentifiers(kInvalidOsmId, 0 /* feature id */), true /* entrance */,
+      Gate(46116860 /* osm id */, 0 /* feature id */, true /* entrance */,
            true /* exit */, 60.0 /* weight */, {442018474} /* stop ids */,
            {43.8594864, 68.33320554776377} /* point */),
-      Gate(FeatureIdentifiers(kInvalidOsmId, 2 /* feature id */), true /* entrance */,
+      Gate(18446744073709551615ULL /* osm id */, 2 /* feature id */, true /* entrance */,
            true /* exit */, 60.0 /* weight */, {442018465} /* stop ids */,
            {43.9290544, 68.41120791512581} /* point */)};
 

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -59,7 +59,7 @@ Stop const & FindStopById(vector<Stop> const & stops, StopId stopId)
 {
   ASSERT(is_sorted(stops.cbegin(), stops.cend(), LessById), ());
   auto s1Id = equal_range(stops.cbegin(), stops.cend(),
-          Stop(stopId, FeatureIdentifiers(), kInvalidTransferId, {}, m2::PointD(), {}),
+          Stop(stopId, kInvalidOsmId, kInvalidFeatureId, kInvalidTransferId, {}, m2::PointD(), {}),
           LessById);
   CHECK(s1Id.first != stops.cend(), ("No a stop with id:", stopId, "in stops:", stops));
   CHECK_EQUAL(distance(s1Id.first, s1Id.second), 1, ("A stop with id:", stopId, "is not unique in stops:", stops));
@@ -210,7 +210,8 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   CHECK(it != m_osmIdToFeatureIds.cend(), ());
   CHECK_EQUAL(it->second.size(), 1,
               ("Osm id:", osmId, "from transit graph doesn't present by a single feature in mwm."));
-  id = FeatureIdentifiers(osmId.EncodedId() /* osm id */, it->second[0] /* feature id */);
+  id.SetFeatureId(it->second[0]);
+  id.SetOsmId(osmId.EncodedId());
 }
 
 void DeserializerFromJson::operator()(StopIdRanges & rs, char const * name)

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -76,9 +76,8 @@ UNIT_TEST(Transit_StopSerialization)
     TestSerialization(stop);
   }
   {
-    Stop stop(1234 /* id */, FeatureIdentifiers(kInvalidOsmId, 5678 /* feature id */),
-              7 /* transfer id */, {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */,
-              {} /* anchors */);
+    Stop stop(1234 /* id */, kInvalidOsmId, 5678 /* feature id */, 7 /* transfer id */,
+              {7, 8, 9, 10} /* line id */, {55.0, 37.0} /* point */, {} /* anchors */);
     TestSerialization(stop);
   }
 }
@@ -97,9 +96,8 @@ UNIT_TEST(Transit_SingleMwmSegmentSerialization)
 
 UNIT_TEST(Transit_GateSerialization)
 {
-  Gate gate(FeatureIdentifiers(kInvalidOsmId, 12345 /* feature id */), true /* entrance */,
-            false /* exit */, 117.8 /* weight */, {1, 2, 3} /* stop ids */,
-            {30.0, 50.0} /* point */);
+  Gate gate(kInvalidOsmId, 12345 /* feature id */, true /* entrance */, false /* exit */,
+            117.8 /* weight */, {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
   TestSerialization(gate);
 }
 

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -99,7 +99,10 @@ public:
 
   void operator()(FeatureIdentifiers const & id, char const * name = nullptr)
   {
-    (*this)(id.GetFeatureId(), name);
+    if (id.IsSerializeFeatureIdOnly())
+      (*this)(id.GetFeatureId(), name);
+    else
+      id.Visit(*this);
   }
 
   template <typename T>
@@ -173,9 +176,16 @@ public:
 
   void operator()(FeatureIdentifiers & id, char const * name = nullptr)
   {
-    FeatureId featureId;
-    operator()(featureId, name);
-    id = FeatureIdentifiers(kInvalidOsmId, featureId);
+    if (id.IsSerializeFeatureIdOnly())
+    {
+      FeatureId featureId;
+      operator()(featureId, name);
+      id.SetOsmId(kInvalidOsmId);
+      id.SetFeatureId(featureId);
+      return;
+    }
+
+    id.Visit(*this);
   }
 
   void operator()(vector<m2::PointD> & vs, char const * /* name */ = nullptr)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -61,6 +61,12 @@ bool TransitHeader::IsValid() const
          m_shapesOffset <= m_networksOffset && m_networksOffset <= m_endOffset;
 }
 
+// FeatureIdentifiers -----------------------------------------------------------------------------
+FeatureIdentifiers::FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly)
+    : m_osmId(osmId), m_featureId(featureId), m_serializeFeatureIdOnly(serializeFeatureIdOnly)
+{
+}
+
 // TitleAnchor ------------------------------------------------------------------------------------
 TitleAnchor::TitleAnchor(uint8_t minZoom, Anchor anchor) : m_minZoom(minZoom), m_anchor(anchor) {}
 
@@ -80,11 +86,11 @@ bool TitleAnchor::IsValid() const
 }
 
 // Stop -------------------------------------------------------------------------------------------
-Stop::Stop(StopId id, FeatureIdentifiers const & featureIdentifiers, TransferId transferId,
+Stop::Stop(StopId id, OsmId osmId, FeatureId featureId, TransferId transferId,
            std::vector<LineId> const & lineIds, m2::PointD const & point,
            std::vector<TitleAnchor> const & titleAnchors)
   : m_id(id)
-  , m_featureIdentifiers(featureIdentifiers)
+  , m_featureIdentifiers(osmId, featureId, true /* serializeFeatureIdOnly */)
   , m_transferId(transferId)
   , m_lineIds(lineIds)
   , m_point(point)
@@ -123,9 +129,9 @@ bool SingleMwmSegment::IsValid() const
 }
 
 // Gate -------------------------------------------------------------------------------------------
-Gate::Gate(FeatureIdentifiers const & featureIdentifiers, bool entrance, bool exit, double weight,
+Gate::Gate(OsmId osmId, FeatureId featureId, bool entrance, bool exit, double weight,
            std::vector<StopId> const & stopIds, m2::PointD const & point)
-  : m_featureIdentifiers(featureIdentifiers)
+  : m_featureIdentifiers(osmId, featureId, false /* serializeFeatureIdOnly */)
   , m_entrance(entrance)
   , m_exit(exit)
   , m_weight(weight)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -62,8 +62,14 @@ bool TransitHeader::IsValid() const
 }
 
 // FeatureIdentifiers -----------------------------------------------------------------------------
-FeatureIdentifiers::FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly)
-    : m_osmId(osmId), m_featureId(featureId), m_serializeFeatureIdOnly(serializeFeatureIdOnly)
+FeatureIdentifiers::FeatureIdentifiers(bool serializeFeatureIdOnly)
+  : m_serializeFeatureIdOnly(serializeFeatureIdOnly)
+{
+}
+
+FeatureIdentifiers::FeatureIdentifiers(OsmId osmId, FeatureId const & featureId,
+                                       bool serializeFeatureIdOnly)
+  : m_osmId(osmId), m_featureId(featureId), m_serializeFeatureIdOnly(serializeFeatureIdOnly)
 {
 }
 

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -85,7 +85,7 @@ static_assert(sizeof(TransitHeader) == 32, "Wrong header size of transit section
 class FeatureIdentifiers
 {
 public:
-  explicit FeatureIdentifiers(bool serializeFeatureIdOnly) : m_serializeFeatureIdOnly(serializeFeatureIdOnly) {}
+  explicit FeatureIdentifiers(bool serializeFeatureIdOnly);
   FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly);
 
   bool IsEqualForTesting(FeatureIdentifiers const & rhs) const { return m_featureId == rhs.m_featureId; }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -85,13 +85,17 @@ static_assert(sizeof(TransitHeader) == 32, "Wrong header size of transit section
 class FeatureIdentifiers
 {
 public:
-  FeatureIdentifiers() = default;
-  FeatureIdentifiers(OsmId osmId, FeatureId const & featureId) : m_osmId(osmId), m_featureId(featureId) {}
+  explicit FeatureIdentifiers(bool serializeFeatureIdOnly) : m_serializeFeatureIdOnly(serializeFeatureIdOnly) {}
+  FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly);
 
   bool IsEqualForTesting(FeatureIdentifiers const & rhs) const { return m_featureId == rhs.m_featureId; }
   bool IsValid() const { return m_featureId != kInvalidFeatureId; }
+  void SetOsmId(OsmId osmId) { m_osmId = osmId; }
+  void SetFeatureId(FeatureId featureId) { m_featureId = featureId; }
 
+  OsmId GetOsmId() const { return m_osmId; }
   FeatureId GetFeatureId() const { return m_featureId; }
+  bool IsSerializeFeatureIdOnly() const { return m_serializeFeatureIdOnly; }
 
 private:
   DECLARE_TRANSIT_TYPE_FRIENDS
@@ -100,6 +104,7 @@ private:
 
   OsmId m_osmId = kInvalidOsmId;
   FeatureId m_featureId = kInvalidFeatureId;
+  bool m_serializeFeatureIdOnly = true;
 };
 
 class TitleAnchor
@@ -127,8 +132,8 @@ private:
 class Stop
 {
 public:
-  Stop() = default;
-  Stop(StopId id, FeatureIdentifiers const & featureIdentifiers, TransferId transferId,
+  Stop() : m_featureIdentifiers(true /* serializeFeatureIdOnly */) {};
+  Stop(StopId id, OsmId osmId, FeatureId featureId, TransferId transferId,
        std::vector<LineId> const & lineIds, m2::PointD const & point,
        std::vector<TitleAnchor> const & titleAnchors);
 
@@ -183,8 +188,8 @@ private:
 class Gate
 {
 public:
-  Gate() = default;
-  Gate(FeatureIdentifiers const & featureIdentifiers, bool entrance, bool exit, double weight,
+  Gate() : m_featureIdentifiers(false /* serializeFeatureIdOnly */) {};
+  Gate(OsmId osmId, FeatureId featureId, bool entrance, bool exit, double weight,
        std::vector<StopId> const & stopIds, m2::PointD const & point);
 
   bool IsEqualForTesting(Gate const & gate) const;


### PR DESCRIPTION
Идея данного PR в том, что необходимо хранить глобальные идентификаторы gates. Это связано с тем, что на границах mwm, иногда gates могут быть продублированны (подробнее https://jira.mail.ru/browse/MAPSME-5858). И чтоб при отрисовке не рисовать gates дважды нужно их идентифицировать.

У gates в json есть osm id и только один. Его и предполагается использовать, как глобальный id гейта.

В данном PR, в FeatureIdentifiers я сделал 2 режима. Сохранять только feature id (используется в Stops) и сохранять osm id и feature id (используется в Gates).

Как вариант, можно сделать еще один класс, похожий на FeatureIdentifiers, но который сохраняет не только feature id, но и osm id, но в таком варианте получается много copy paste.

Вариант, добавить в Gate поля в виде osm id и feature id и заполнять feature id после десериализации gates из json не будет работать, т.к. osm id хранятся в виде строчек.

@ygorshenin @mpimenov @darina PTAL
