### PR TITLE
Fixed crash in storage on rejecting sd-card writing

### DIFF
--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -594,8 +594,6 @@ void Storage::DownloadNextCountryFromQueue()
       !PreparePlaceForCountryFiles(GetCurrentDataVersion(), m_dataDir, GetCountryFile(countryId)))
   {
     OnMapDownloadFinished(countryId, false /* success */, queuedCountry.GetInitOptions());
-    NotifyStatusChangedForHierarchy(countryId);
-    CorrectJustDownloadedAndQueue(m_queue.begin());
     DownloadNextCountryFromQueue();
     return;
   }


### PR DESCRIPTION
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/59f0cefa61b02d480d308cc9?time=last-seven-days

OnMapDownloadFinished - внутри себя подчищает очередь скачивания, а потом все прекрасно падает на CHECK(!m_queue.empty()) в CorrectJustDownloadedAndQueue
Все это происходит после скачивания mwm-ки и отказа сд-карты на создание директории для записи. Фиксом будет удаление двух строчек     NotifyStatusChangedForHierarchy(countryId);
CorrectJustDownloadedAndQueue(m_queue.begin());
так как NotifyStatusChangedForHierarchy исполняется внутри OnMapDownloadFinished в ветке !success, а CorrectJustDownloadedAndQueue - вообще не к месту, завершения скачивания не произошло по факту