### PR TITLE
[transit] Colors type. DeserializerFromJson refactoring.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -30,7 +30,7 @@ void TestDeserializerFromJson(string const & jsonBuffer, OsmIdToFeatureIdsMap co
 
   TEST_EQUAL(objects.size(), expected.size(), ());
   for (size_t i = 0; i < objects.size(); ++i)
-    TEST(objects[i].IsEqualForTesting(expected[i]), (objects[i], expected[i]));
+    TEST(objects[i].IsEqualForTesting(expected[i]), (i, objects[i], expected[i]));
 }
 
 template <typename Obj>
@@ -229,7 +229,8 @@ UNIT_TEST(DeserializerFromJson_Lines)
         2947858576
       ],
       "title": "Московская линия",
-      "type": "subway"
+      "type": "subway",
+      "color": "green"
     },
     {
       "id": 19207937,
@@ -245,15 +246,16 @@ UNIT_TEST(DeserializerFromJson_Lines)
         209191851
       ],
       "title": "Московская линия",
-      "type": "subway"
+      "type": "subway",
+      "color": "red"
     }
   ]})";
 
   vector<Line> const expected = {Line(19207936 /* line id */, "1" /* number */, "Московская линия" /* title */,
-                                      "subway" /* type */, 2 /* network id */,
+                                      "subway" /* type */, "green" /* color */, 2 /* network id */,
                                       {{343262691, 343259523, 343252898, 209191847, 2947858576}} /* stop ids */),
                                  Line(19207937 /* line id */, "2" /* number */, "Московская линия" /* title */,
-                                      "subway" /* type */, 2 /* network id */,
+                                      "subway" /* type */, "red" /* color */, 2 /* network id */,
                                       {{246659391, 246659390, 209191855, 209191854, 209191853,
                                        209191852, 209191851}} /* stop ids */)};
 

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -197,7 +197,7 @@ void DeserializerFromJson::operator()(m2::PointD & p, char const * name)
   else
     item = my::GetJSONObligatoryField(m_node, name);
 
-  CHECK(json_is_object(item), ());
+  CHECK(json_is_object(item), ("Item is not a json object(dictionary). name:", name));
   FromJSONObject(item, "x", p.x);
   FromJSONObject(item, "y", p.y);
 }
@@ -207,14 +207,17 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   // Conversion osm id to feature id.
   string osmIdStr;
   GetField(osmIdStr, name);
-  CHECK(strings::is_number(osmIdStr), ());
+  CHECK(strings::is_number(osmIdStr), ("Osm id string is not a number:", osmIdStr));
   uint64_t osmIdNum;
-  CHECK(strings::to_uint64(osmIdStr, osmIdNum), ());
+  CHECK(strings::to_uint64(osmIdStr, osmIdNum),
+        ("Cann't convert osm id string:", osmIdStr, "to a number."));
   osm::Id const osmId(osmIdNum);
   auto const it = m_osmIdToFeatureIds.find(osmId);
-  CHECK(it != m_osmIdToFeatureIds.cend(), ("osm id:", osmId.EncodedId(), "size of m_osmIdToFeatureIds:", m_osmIdToFeatureIds.size()));
+  CHECK(it != m_osmIdToFeatureIds.cend(), ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
+                                           ") is not found in osm id to feature ids mapping."));
   CHECK_EQUAL(it->second.size(), 1,
-              ("Osm id:", osmId, "from transit graph doesn't present by a single feature in mwm."));
+              ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
+               ") from transit graph doesn't present by a single feature in mwm."));
   id.SetFeatureId(it->second[0]);
   id.SetOsmId(osmId.EncodedId());
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -197,7 +197,7 @@ void DeserializerFromJson::operator()(m2::PointD & p, char const * name)
   else
     item = my::GetJSONObligatoryField(m_node, name);
 
-  CHECK(json_is_object(item), ("Item is not a json object(dictionary). name:", name));
+  CHECK(json_is_object(item), ("Item is not a json object:", name));
   FromJSONObject(item, "x", p.x);
   FromJSONObject(item, "y", p.y);
 }

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -66,7 +66,7 @@ public:
     {
       json_t * dictNode = my::GetJSONOptionalField(m_node, name);
       if (dictNode == nullptr)
-        return; // No the node in json.
+        return; // No such field in json.
 
       DeserializerFromJson dict(dictNode, m_osmIdToFeatureIds);
       t.Visit(dict);

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -119,17 +119,19 @@ UNIT_TEST(Transit_LineSerialization)
 {
   {
     Line line(1 /* line id */, "2" /* number */, "Линия" /* title */,
-              "subway" /* type */, 3 /* network id */, {} /* stop ids */);
+              "subway" /* type */, "red" /* color */, 3 /* network id */, {} /* stop ids */);
     TestSerialization(line);
   }
   {
     Line line(10 /* line id */, "11" /* number */, "Линия" /* title */,
-              "subway" /* type */, 12 /* network id */, {{13, 14, 15}} /* stop ids */);
+              "subway" /* type */, "green" /* color */, 12 /* network id */,
+              {{13, 14, 15}} /* stop ids */);
     TestSerialization(line);
   }
   {
     Line line(100 /* line id */, "101" /* number */, "Линия" /* title */,
-              "subway" /* type */, 103 /* network id */, {{1, 2, 3}, {7, 8, 9}} /* stop ids */);
+              "subway" /* type */, "blue" /* color */, 103 /* network id */,
+              {{1, 2, 3}, {7, 8, 9}} /* stop ids */);
     TestSerialization(line);
   }
 }

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -224,11 +224,13 @@ bool Transfer::IsValid() const
 
 // Line -------------------------------------------------------------------------------------------
 Line::Line(LineId id, std::string const & number, std::string const & title,
-           std::string const & type, NetworkId networkId, Ranges const & stopIds)
+           std::string const & type, std::string const & color, NetworkId networkId,
+           Ranges const & stopIds)
   : m_id(id)
   , m_number(number)
   , m_title(title)
   , m_type(type)
+  , m_color(color)
   , m_networkId(networkId)
   , m_stopIds(stopIds)
 {
@@ -237,12 +239,14 @@ Line::Line(LineId id, std::string const & number, std::string const & title,
 bool Line::IsEqualForTesting(Line const & line) const
 {
   return m_id == line.m_id && m_number == line.m_number && m_title == line.m_title &&
-         m_type == line.m_type && m_networkId == line.m_networkId && m_stopIds == line.m_stopIds;
+         m_color == line.m_color && m_type == line.m_type && m_networkId == line.m_networkId &&
+         m_stopIds == line.m_stopIds;
 }
 
 bool Line::IsValid() const
 {
-  return m_id != kInvalidLineId && m_networkId != kInvalidNetworkId && m_stopIds.IsValid();
+  return m_id != kInvalidLineId && m_color != kInvalidColor && m_networkId != kInvalidNetworkId &&
+         m_stopIds.IsValid();
 }
 
 // Shape ------------------------------------------------------------------------------------------

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -239,7 +239,7 @@ Line::Line(LineId id, std::string const & number, std::string const & title,
 bool Line::IsEqualForTesting(Line const & line) const
 {
   return m_id == line.m_id && m_number == line.m_number && m_title == line.m_title &&
-         m_color == line.m_color && m_type == line.m_type && m_networkId == line.m_networkId &&
+         m_type == line.m_type && m_color == line.m_color && m_networkId == line.m_networkId &&
          m_stopIds == line.m_stopIds;
 }
 

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -25,16 +25,17 @@ using TransferId = uint64_t;
 using Weight = double;
 using Ranges = std::vector<std::vector<StopId>>;
 
+Anchor constexpr kInvalidAnchor = std::numeric_limits<Anchor>::max();
+std::string const kInvalidColor = std::string("");
+FeatureId constexpr kInvalidFeatureId = std::numeric_limits<FeatureId>::max();
 LineId constexpr kInvalidLineId = std::numeric_limits<LineId>::max();
+NetworkId constexpr kInvalidNetworkId = std::numeric_limits<NetworkId>::max();
+OsmId constexpr kInvalidOsmId = std::numeric_limits<OsmId>::max();
 StopId constexpr kInvalidStopId = std::numeric_limits<StopId>::max();
 TransferId constexpr kInvalidTransferId = std::numeric_limits<TransferId>::max();
-NetworkId constexpr kInvalidNetworkId = std::numeric_limits<NetworkId>::max();
-FeatureId constexpr kInvalidFeatureId = std::numeric_limits<FeatureId>::max();
-OsmId constexpr kInvalidOsmId = std::numeric_limits<OsmId>::max();
 // Note. Weight may be a default param at json. The default value should be saved as uint32_t in mwm anyway.
 // To convert double to uint32_t at better accuracy |kInvalidWeight| should be close to real weight.
 Weight constexpr kInvalidWeight = -1.0;
-Anchor constexpr kInvalidAnchor = std::numeric_limits<Anchor>::max();
 
 #define DECLARE_TRANSIT_TYPE_FRIENDS                                                           \
     template<class Sink> friend class Serializer;                                              \
@@ -330,7 +331,7 @@ class Line
 public:
   Line() = default;
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
-       NetworkId networkId, Ranges const & stopIds);
+       std::string const & color, NetworkId networkId, Ranges const & stopIds);
 
   bool IsEqualForTesting(Line const & line) const;
   bool IsValid() const;
@@ -339,6 +340,7 @@ public:
   std::string const & GetNumber() const { return m_number; }
   std::string const & GetTitle() const { return m_title; }
   std::string const & GetType() const { return m_type; }
+  std::string const & GetColor() const { return m_color; }
   NetworkId GetNetworkId() const { return m_networkId; }
   Ranges const & GetStopIds() const { return m_stopIds.GetIds(); }
 
@@ -346,13 +348,14 @@ private:
   DECLARE_TRANSIT_TYPE_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Line, visitor(m_id, "id"), visitor(m_number, "number"),
                                   visitor(m_title, "title"), visitor(m_type, "type"),
-                                  visitor(m_networkId, "network_id"),
+                                  visitor(m_color, "color"), visitor(m_networkId, "network_id"),
                                   visitor(m_stopIds, "stop_ids"))
 
   LineId m_id = kInvalidLineId;
   std::string m_number;
   std::string m_title;
   std::string m_type;
+  std::string m_color = kInvalidColor;
   NetworkId m_networkId = kInvalidNetworkId;
   StopIdRanges m_stopIds;
 };


### PR DESCRIPTION
Идея данного PR:
1. Обход json-на с графом общественного транспорта определяется классами в transit_generator.hpp. Ранее, если требовалось распарсить json dictionary (как ShapeId или Colors), то в DeserializerFromJson добавлялся специальный operator() для того, чтоб распарсить соответствующий json dictionary. Теперь реализовано обобщенное решение. Если при обходе встречается класс, то проверяется, соответствует ли ему json dict и если да, то это учитывается и далее используется стандартный обход. (commint "
Any class from transit types may be present as json dictionary (object).")

2. EDITED. Добавлен цвет линий в Line. 

@darina @ygorshenin PTAL