### PR TITLE
Cutting transit graphs according to mwm.

### DIFF
--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -89,10 +89,10 @@ UNIT_TEST(DeserializerFromJson_Stops)
   ]})";
 
   vector<Stop> const expected = {
-      Stop(343259523 /* id */, kInvalidOsmId, 1 /* feature id */,
+      Stop(343259523 /* id */, 1234 /* osm id */, 1 /* feature id */,
            kInvalidTransferId /* transfer id */, {19207936, 19207937} /* lineIds */,
            {27.4970954, 64.20146835878187} /* point */, {} /* anchors */),
-      Stop(266680843 /* id */, kInvalidOsmId, 2 /* feature id */, 5 /* transfer id */,
+      Stop(266680843 /* id */, 2345 /* osm id */, 2 /* feature id */, 5 /* transfer id */,
            {19213568, 19213569} /* line ids */, {27.5227942, 64.25206634443111} /* point */,
            {TitleAnchor(12 /* min zoom */, 0 /* anchor */), TitleAnchor(15, 9)})};
 

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -114,7 +114,6 @@ private:
 /// \returns ref to a stop at |stops| by |stopId|.
 Stop const & FindStopById(vector<Stop> const & stops, StopId stopId)
 {
-  ASSERT(is_sorted(stops.cbegin(), stops.cend()), ());
   auto s1Id = equal_range(stops.cbegin(), stops.cend(),
                           Stop(stopId, kInvalidOsmId, kInvalidFeatureId, kInvalidTransferId,
                                {} /* line ids */, {} /* point */, {} /* title anchors */));
@@ -184,7 +183,7 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   if (it != m_osmIdToFeatureIds.cend())
   {
     CHECK_EQUAL(it->second.size(), 1, ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-                 ") from transit graph is correspond to", it->second.size(), "features."
+                 ") from transit graph corresponds to", it->second.size(), "features."
                  "But osm id should be represented be one feature."));
     id.SetFeatureId(it->second[0]);
   }
@@ -285,7 +284,6 @@ void GraphData::Sort()
 void GraphData::CalculateEdgeWeights()
 {
   CHECK(is_sorted(m_stops.cbegin(), m_stops.cend()), ());
-
   for (auto & e : m_edges)
   {
     if (e.GetWeight() != kInvalidWeight)
@@ -354,7 +352,7 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string c
     }
     catch (RootException const & e)
     {
-      LOG(LCRITICAL, ("Exception while looking for the best segment here gates. CountryId::",
+      LOG(LCRITICAL, ("Exception while looking for the best segment of a gate. CountryId:",
           countryId, ". Gate:", gate, e.what()));
     }
   }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -67,8 +67,6 @@ struct SortVisitor
   {
     sort(c.begin(), c.end());
   }
-
-  void operator()(vector<transit::Edge> & c, char const * /* name */) const {}
 };
 
 struct IsValidVisitor
@@ -93,8 +91,6 @@ struct IsUniqueVisitor
     m_isUnique = m_isUnique && (adjacent_find(c.begin(), c.end()) == c.end());
   }
 
-  void operator()(vector<transit::Edge> const & c, char const * /* name */ = nullptr) {}
-
   bool IsUnique() const { return m_isUnique; }
 
 private:
@@ -108,8 +104,6 @@ struct IsSortedVisitor
   {
     m_isSorted = m_isSorted && is_sorted(c.begin(), c.end());
   }
-
-  void operator()(vector<transit::Edge> const & c, char const * /* name */ = nullptr) {}
 
   bool IsSorted() const { return m_isSorted; }
 

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -136,7 +136,13 @@ public:
   std::vector<Network> const & GetNetworks() const { return m_networks; }
 
 private:
+  DECLARE_VISITOR_AND_DEBUG_PRINT(GraphData, visitor(m_stops, "stops"), visitor(m_gates, "gates"),
+                                  visitor(m_edges, "edges"), visitor(m_transfers, "transfers"),
+                                  visitor(m_lines, "lines"), visitor(m_shapes, "shapes"),
+                                  visitor(m_networks, "networks"))
+
   bool IsUnique() const;
+  bool IsSorted() const;
 
   std::vector<Stop> m_stops;
   std::vector<Gate> m_gates;

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -114,14 +114,14 @@ public:
   void Clear();
   bool IsValid() const;
 
-  /// \brief Sorts all class fields execpt for |m_edges| by their ids.
+  /// \brief Sorts all class fields except for |m_edges| by their ids.
   void Sort();
   /// \brief Calculates and updates |m_edges| by adding valid value for Edge::m_weight
   /// if it's not valid.
-  /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| should be valid before call.
+  /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| must be valid before call.
   void CalculateEdgeWeights();
   /// \brief Calculates best pedestrian segment for every gate in |m_gates|.
-  /// \note All gates in |m_gates| should have a valid |m_point| field before the call.
+  /// \note All gates in |m_gates| must have a valid |m_point| field before the call.
   void CalculateBestPedestrianSegments(std::string const & mwmPath, std::string const & countryId);
 
   std::vector<Stop> const & GetStops() const { return m_stops; }
@@ -151,7 +151,7 @@ private:
 };
 
 /// \brief Fills |data| according to a transit graph (|transitJsonPath|).
-/// \note Some of fields of |data| contains feature ids of a certain mwm. These fields are filled
+/// \note Some of fields of |data| contain feature ids of a certain mwm. These fields are filled
 /// iff the mapping (|osmIdToFeatureIdsPath|) contains them. Otherwise the fields have default value.
 void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const & transitJsonPath,
                          GraphData & data);
@@ -166,7 +166,7 @@ void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
 /// \param mwmDir relative or full path to a directory where mwm is located.
 /// \param countryId is an mwm name without extension of the processed mwm.
 /// \param osmIdToFeatureIdsPath is a path to a file with osm id to feature ids mapping.
-/// \param transitDir a path with slash at the end to directory with json files with transit graphs.
+/// \param transitDir relative or full path to a directory with json files of transit graphs.
 /// It's assumed that the files have the same name with country ids and extension TRANSIT_FILE_EXTENSION.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -110,7 +110,7 @@ class GraphData
 public:
   void DeserializeFromJson(my::Json const & root, OsmIdToFeatureIdsMap const & mapping);
   void SerializeToMwm(std::string const & mwmPath) const;
-  void Append(GraphData const & rhs);
+  void AppendTo(GraphData const & rhs);
   void Clear();
   bool IsValid() const;
 
@@ -167,7 +167,7 @@ void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
 /// \param countryId is an mwm name without extension of the processed mwm.
 /// \param osmIdToFeatureIdsPath is a path to a file with osm id to feature ids mapping.
 /// \param transitDir a path with slash at the end to directory with json files with transit graphs.
-/// It's assumed that the files have name the same with country ids and extension TRANSIT_FILE_EXTENSION.
+/// It's assumed that the files have the same name with country ids and extension TRANSIT_FILE_EXTENSION.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -114,7 +114,8 @@ public:
   void Clear();
   bool IsValid() const;
 
-  void SortStops();
+  /// \brief Sorts all class fields execpt for |m_edges| by their ids.
+  void Sort();
   /// \brief Calculates and updates |m_edges| by adding valid value for Edge::m_weight
   /// if it's not valid.
   /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| should be valid before call.
@@ -135,6 +136,8 @@ public:
   std::vector<Network> const & GetNetworks() const { return m_networks; }
 
 private:
+  bool IsUnique() const;
+
   std::vector<Stop> m_stops;
   std::vector<Gate> m_gates;
   std::vector<Edge> m_edges;

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -5,7 +5,6 @@
 #include "routing_common/transit_types.hpp"
 
 #include "geometry/point2d.hpp"
-#include "geometry/region2d.hpp"
 
 #include "base/macros.hpp"
 
@@ -105,7 +104,7 @@ private:
   OsmIdToFeatureIdsMap const & m_osmIdToFeatureIds;
 };
 
-/// \brief the data contains all the information to make TRANSIT_FILE_TAG section.
+/// \brief The class contains all the information to make TRANSIT_FILE_TAG section.
 class GraphData
 {
 public:
@@ -124,9 +123,6 @@ public:
   /// \brief Calculates best pedestrian segment for every gate in |m_gates|.
   /// \note All gates in |m_gates| should have a valid |m_point| field before the call.
   void CalculateBestPedestrianSegments(std::string const & mwmPath, std::string const & countryId);
-  /// \brief Removes some items from all the class fields if they outside |mwmBorders|.
-  /// @todo(bykoinko) Certain rules which is used to clip the transit graph should be described here.
-  void ClipGraphByMwm(std::vector<m2::RegionD> const & mwmBorders);
 
   std::vector<Stop> const & GetStops() const { return m_stops; }
   std::vector<Gate> const & GetGates() const { return m_gates; }
@@ -154,8 +150,6 @@ private:
   std::vector<Network> m_networks;
 };
 
-// @todo(bykoianko) Method below should be covered with tests.
-
 /// \brief Fills |data| according to a transit graph (|transitJsonPath|).
 /// \note Some of fields of |data| contains feature ids of a certain mwm. These fields are filled
 /// iff the mapping (|osmIdToFeatureIdsPath|) contains them. Otherwise the fields have default value.
@@ -167,12 +161,13 @@ void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const
 void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
                   OsmIdToFeatureIdsMap const & osmIdToFeatureIdsMap, GraphData & data);
 
-/// \brief Builds the transit section in the mwm.
+/// \brief Builds the transit section in the mwm based on transit graph in json which represents
+/// trasit graph clipped by the mwm borders.
 /// \param mwmDir relative or full path to a directory where mwm is located.
 /// \param countryId is an mwm name without extension of the processed mwm.
 /// \param osmIdToFeatureIdsPath is a path to a file with osm id to feature ids mapping.
 /// \param transitDir a path with slash at the end to directory with json files with transit graphs.
-/// It's assumed that the files has extension TRANSIT_FILE_EXTENSION.
+/// It's assumed that the files have name the same with country ids and extension TRANSIT_FILE_EXTENSION.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -151,7 +151,7 @@ private:
 };
 
 /// \brief Fills |data| according to a transit graph (|transitJsonPath|).
-/// \note Some of fields of |data| contain feature ids of a certain mwm. These fields are filled
+/// \note Some fields of |data| contain feature ids of a certain mwm. These fields are filled
 /// iff the mapping (|osmIdToFeatureIdsPath|) contains them. Otherwise the fields have default value.
 void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const & transitJsonPath,
                          GraphData & data);

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -29,9 +29,10 @@ class DeserializerFromJson
 public:
   DeserializerFromJson(json_struct_t* node, OsmIdToFeatureIdsMap const & osmIdToFeatureIds);
 
-  template<typename T>
-  typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value || std::is_same<T, double>::value>::type
-      operator()(T & t, char const * name = nullptr)
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value ||
+                          std::is_same<T, double>::value>::type
+  operator()(T & t, char const * name = nullptr)
   {
     GetField(t, name);
     return;
@@ -60,8 +61,9 @@ public:
     }
   }
 
-  template<typename T>
-  typename std::enable_if<std::is_class<T>::value>::type operator()(T & t, char const * name = nullptr)
+  template <typename T>
+  typename std::enable_if<std::is_class<T>::value>::type operator()(T & t,
+                                                                    char const * name = nullptr)
   {
     if (name != nullptr && json_is_object(m_node))
     {
@@ -107,7 +109,6 @@ private:
 class GraphData
 {
 public:
-  // @todo(bykoianko) All the methods below should be rewrite with the help of visitors.
   void DeserializeFromJson(my::Json const & root, OsmIdToFeatureIdsMap const & mapping);
   void SerializeToMwm(std::string const & mwmPath) const;
   void Append(GraphData const & rhs);
@@ -119,10 +120,10 @@ public:
   /// \brief Calculates and updates |m_edges| by adding valid value for Edge::m_weight
   /// if it's not valid.
   /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| should be valid before call.
-  void CalculateEdgeWeight();
+  void CalculateEdgeWeights();
   /// \brief Calculates best pedestrian segment for every gate in |m_gates|.
   /// \note All gates in |m_gates| should have a valid |m_point| field before the call.
-  void CalculateBestPedestrianSegment(string const & mwmPath, string const & countryId);
+  void CalculateBestPedestrianSegments(std::string const & mwmPath, std::string const & countryId);
   /// \brief Removes some items from all the class fields if they outside |mwmBorders|.
   /// @todo(bykoinko) Certain rules which is used to clip the transit graph should be described here.
   void ClipGraphByMwm(std::vector<m2::RegionD> const & mwmBorders);
@@ -157,13 +158,13 @@ private:
 
 /// \brief Fills |data| according to a transit graph (|transitJsonPath|).
 /// \note Some of fields of |data| contains feature ids of a certain mwm. These fields are filled
-/// iff the mapping (|osmIdToFeatureIdsPath|) contains them. If not the fields have default value.
-void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, string const & transitJsonPath,
+/// iff the mapping (|osmIdToFeatureIdsPath|) contains them. Otherwise the fields have default value.
+void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const & transitJsonPath,
                          GraphData & data);
 
 /// \brief Calculates and adds some information to transit graph (|data|) after deserializing
 /// from json.
-void ProcessGraph(string const & mwmPath, string const & countryId,
+void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
                   OsmIdToFeatureIdsMap const & osmIdToFeatureIdsMap, GraphData & data);
 
 /// \brief Builds the transit section in the mwm.
@@ -175,7 +176,7 @@ void ProcessGraph(string const & mwmPath, string const & countryId,
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)
-void BuildTransit(string const & mwmDir, string const & countryId,
-                  string const & osmIdToFeatureIdsPath, string const & transitDir);
+void BuildTransit(std::string const & mwmDir, std::string const & countryId,
+                  std::string const & osmIdToFeatureIdsPath, std::string const & transitDir);
 }  // namespace transit
 }  // namespace routing

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -5,6 +5,7 @@
 #include "routing_common/transit_types.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/region2d.hpp"
 
 #include "base/macros.hpp"
 
@@ -121,6 +122,9 @@ public:
   /// \brief Calculates best pedestrian segment for every gate in |m_gates|.
   /// \note All gates in |m_gates| should have a valid |m_point| field before the call.
   void CalculateBestPedestrianSegment(string const & mwmPath, string const & countryId);
+  /// \brief Removes some items from all the class fields if they outside |mwmBorders|.
+  /// @todo(bykoinko) Certain rules which is used to clip the transit graph should be described here.
+  void ClipGraphByMwm(std::vector<m2::RegionD> const & mwmBorders);
 
   std::vector<Stop> const & GetStops() const { return m_stops; }
   std::vector<Gate> const & GetGates() const { return m_gates; }
@@ -153,15 +157,12 @@ void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, string const & tr
 void ProcessGraph(string const & mwmPath, string const & countryId,
                   OsmIdToFeatureIdsMap const & osmIdToFeatureIdsMap, GraphData & data);
 
-/// \brief Removes some items from |data| if they outside the mwm (|countryId|) border.
-/// @todo(bykoinko) Certain rules which is used to clip the transit graph should be described here.
-void ClipGraphByMwm(string const & mwmDir, string const & countryId, GraphData & data);
-
 /// \brief Builds the transit section in the mwm.
 /// \param mwmDir relative or full path to a directory where mwm is located.
 /// \param countryId is an mwm name without extension of the processed mwm.
 /// \param osmIdToFeatureIdsPath is a path to a file with osm id to feature ids mapping.
-/// \param transitDir a path to directory with json files with transit graphs.
+/// \param transitDir a path with slash at the end to directory with json files with transit graphs.
+/// It's assumed that the files has extension TRANSIT_FILE_EXTENSION.
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -693,7 +693,7 @@ bool IndexRouter::FindBestSegment(m2::PointD const & point, m2::PointD const & d
   auto const file = platform::CountryFile(m_countryFileFn(point));
   MwmSet::MwmHandle handle = m_index.GetMwmHandleByCountryFile(file);
   if (!handle.IsAlive())
-    MYTHROW(MwmIsNotAlifeException, ("Can't get mwm handle for", file));
+    MYTHROW(MwmIsNotAliveException, ("Can't get mwm handle for", file));
 
   auto const mwmId = MwmSet::MwmId(handle.GetInfo());
   NumMwmId const numMwmId = m_numMwmIds->GetId(file);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -4,6 +4,7 @@
 #include "routing/base/astar_progress.hpp"
 #include "routing/base/routing_result.hpp"
 #include "routing/bicycle_directions.hpp"
+#include "routing/routing_exceptions.hpp"
 #include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
@@ -317,8 +318,8 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
   CHECK(m_directionsEngine, ());
 }
 
-bool IndexRouter::FindBestSegmentInSingleMwm(m2::PointD const &point, m2::PointD const &direction,
-                                             bool isOutgoing, Segment &bestSegment)
+bool IndexRouter::FindBestSegmentInSingleMwm(m2::PointD const & point, m2::PointD const & direction,
+                                             bool isOutgoing, Segment & bestSegment)
 {
   auto worldGraph = MakeWorldGraph();
   worldGraph->SetMode(WorldGraph::Mode::SingleMwm);
@@ -692,7 +693,7 @@ bool IndexRouter::FindBestSegment(m2::PointD const & point, m2::PointD const & d
   auto const file = platform::CountryFile(m_countryFileFn(point));
   MwmSet::MwmHandle handle = m_index.GetMwmHandleByCountryFile(file);
   if (!handle.IsAlive())
-    MYTHROW(RoutingException, ("Can't get mwm handle for", file));
+    MYTHROW(MwmIsNotAlifeException, ("Can't get mwm handle for", file));
 
   auto const mwmId = MwmSet::MwmId(handle.GetInfo());
   NumMwmId const numMwmId = m_numMwmIds->GetId(file);

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -63,8 +63,8 @@ public:
               shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
               traffic::TrafficCache const & trafficCache, Index & index);
 
-  bool FindBestSegmentInSingleMwm(m2::PointD const &point, m2::PointD const &direction,
-                                  bool isOutgoing, Segment &bestSegment);
+  bool FindBestSegmentInSingleMwm(m2::PointD const & point, m2::PointD const & direction,
+                                  bool isOutgoing, Segment & bestSegment);
 
   // IRouter overrides:
   std::string GetName() const override { return m_name; }

--- a/routing/routing_exceptions.hpp
+++ b/routing/routing_exceptions.hpp
@@ -4,7 +4,7 @@
 
 namespace routing
 {
-DECLARE_EXCEPTION(CorruptedDataException, RootException);
 DECLARE_EXCEPTION(RoutingException, RootException);
-DECLARE_EXCEPTION(MwmIsNotAliveException, RootException);
+DECLARE_EXCEPTION(CorruptedDataException, RoutingException);
+DECLARE_EXCEPTION(MwmIsNotAliveException, RoutingException);
 }  // namespace routing

--- a/routing/routing_exceptions.hpp
+++ b/routing/routing_exceptions.hpp
@@ -6,4 +6,5 @@ namespace routing
 {
 DECLARE_EXCEPTION(CorruptedDataException, RootException);
 DECLARE_EXCEPTION(RoutingException, RootException);
+DECLARE_EXCEPTION(MwmIsNotAlifeException, RootException);
 }  // namespace routing

--- a/routing/routing_exceptions.hpp
+++ b/routing/routing_exceptions.hpp
@@ -6,5 +6,5 @@ namespace routing
 {
 DECLARE_EXCEPTION(CorruptedDataException, RootException);
 DECLARE_EXCEPTION(RoutingException, RootException);
-DECLARE_EXCEPTION(MwmIsNotAlifeException, RootException);
+DECLARE_EXCEPTION(MwmIsNotAliveException, RootException);
 }  // namespace routing

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -6,6 +6,7 @@
 #include "routing_common/transit_serdes.hpp"
 #include "routing_common/transit_types.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
@@ -236,14 +237,8 @@ UNIT_TEST(Transit_ShapeSerialization)
 
 UNIT_TEST(Transit_ShapeIdRelational)
 {
-  ShapeId id1(0, 10);
-  ShapeId id2(0, 11);
-  ShapeId id3(1, 10);
-  ShapeId id4(1, 11);
-
-  TEST_LESS(id1, id2, ());
-  TEST_LESS(id2, id3, ());
-  TEST_LESS(id3, id4, ());
+  vector<ShapeId> const ids = {{0, 10}, {0, 11}, {1, 10}, {1, 11}};
+  TEST(is_sorted(ids.cbegin(), ids.cend()), ());
 }
 
 UNIT_TEST(Transit_NetworkSerialization)

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -203,8 +203,7 @@ bool Edge::IsValid() const
   if (!m_transfer && m_lineId == kInvalidLineId)
     return false;
 
-  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight &&
-         m_lineId != kInvalidLineId;
+  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight;
 }
 
 // Transfer ---------------------------------------------------------------------------------------

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -165,6 +165,13 @@ bool Gate::IsValid() const
 }
 
 // ShapeId ----------------------------------------------------------------------------------------
+bool ShapeId::operator<(ShapeId const & rhs) const
+{
+  if (m_stop1Id != rhs.m_stop1Id)
+    return rhs.m_stop1Id < m_stop1Id;
+  return m_stop2Id < rhs.m_stop2Id;
+}
+
 bool ShapeId::operator==(ShapeId const & rhs) const
 {
   return m_stop1Id == rhs.m_stop1Id && m_stop2Id == rhs.m_stop2Id;

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -194,6 +194,20 @@ Edge::Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool tr
 {
 }
 
+bool Edge::operator<(Edge const & rhs) const
+{
+  if (m_stop1Id != rhs.m_stop1Id)
+    return m_stop1Id < rhs.m_stop1Id;
+  if (m_stop2Id != rhs.m_stop2Id)
+    return m_stop2Id < rhs.m_stop2Id;
+  return m_lineId < rhs.m_lineId;
+}
+
+bool Edge::operator==(Edge const & rhs) const
+{
+  return m_stop1Id == rhs.m_stop1Id && m_stop2Id == rhs.m_stop2Id && m_lineId == rhs.m_lineId;
+}
+
 bool Edge::IsEqualForTesting(Edge const & edge) const
 {
   return m_stop1Id == edge.m_stop1Id && m_stop2Id == edge.m_stop2Id &&

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -168,7 +168,7 @@ bool Gate::IsValid() const
 bool ShapeId::operator<(ShapeId const & rhs) const
 {
   if (m_stop1Id != rhs.m_stop1Id)
-    return rhs.m_stop1Id < m_stop1Id;
+    return m_stop1Id < rhs.m_stop1Id;
   return m_stop2Id < rhs.m_stop2Id;
 }
 

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -87,6 +87,8 @@ public:
   explicit FeatureIdentifiers(bool serializeFeatureIdOnly);
   FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly);
 
+  bool operator<(FeatureIdentifiers const & rhs) const { return m_osmId < rhs.m_osmId; }
+  bool operator==(FeatureIdentifiers const & rhs) const { return m_osmId == rhs.m_osmId; }
   bool IsEqualForTesting(FeatureIdentifiers const & rhs) const { return m_featureId == rhs.m_featureId; }
   bool IsValid() const { return m_featureId != kInvalidFeatureId; }
   void SetOsmId(OsmId osmId) { m_osmId = osmId; }
@@ -136,6 +138,8 @@ public:
        std::vector<LineId> const & lineIds, m2::PointD const & point,
        std::vector<TitleAnchor> const & titleAnchors);
 
+  bool operator<(Stop const & rhs) const { return m_id < rhs.m_id; }
+  bool operator==(Stop const & rhs) const { return m_id == rhs.m_id; }
   bool IsEqualForTesting(Stop const & stop) const;
   bool IsValid() const;
 
@@ -191,6 +195,8 @@ public:
   Gate(OsmId osmId, FeatureId featureId, bool entrance, bool exit, double weight,
        std::vector<StopId> const & stopIds, m2::PointD const & point);
 
+  bool operator<(Gate const & rhs) const { return m_featureIdentifiers < rhs.m_featureIdentifiers; }
+  bool operator==(Gate const & rhs) const { return m_featureIdentifiers == rhs.m_featureIdentifiers; }
   bool IsEqualForTesting(Gate const & gate) const;
   bool IsValid() const;
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
@@ -230,6 +236,7 @@ public:
   ShapeId() = default;
   ShapeId(StopId stop1Id, StopId stop2Id) : m_stop1Id(stop1Id), m_stop2Id(stop2Id) {}
 
+  bool operator<(ShapeId const & rhs) const;
   bool operator==(ShapeId const & rhs) const;
   bool IsEqualForTesting(ShapeId const & rhs) const { return *this == rhs; }
 
@@ -286,6 +293,8 @@ public:
   Transfer(StopId id, m2::PointD const & point, std::vector<StopId> const & stopIds,
            std::vector<TitleAnchor> const & titleAnchors);
 
+  bool operator<(Transfer const & rhs) const { return m_id < rhs.m_id; }
+  bool operator==(Transfer const & rhs) const { return m_id == rhs.m_id; }
   bool IsEqualForTesting(Transfer const & transfer) const;
   bool IsValid() const;
 
@@ -331,6 +340,8 @@ public:
   Line(LineId id, std::string const & number, std::string const & title, std::string const & type,
        std::string const & color, NetworkId networkId, Ranges const & stopIds);
 
+  bool operator<(Line const & rhs) const { return m_id < rhs.m_id; }
+  bool operator==(Line const & rhs) const { return m_id == rhs.m_id; }
   bool IsEqualForTesting(Line const & line) const;
   bool IsValid() const;
 
@@ -364,6 +375,8 @@ public:
   Shape() = default;
   Shape(ShapeId const & id, std::vector<m2::PointD> const & polyline) : m_id(id), m_polyline(polyline) {}
 
+  bool operator<(Shape const & rhs) const { return m_id < rhs.m_id; }
+  bool operator==(Shape const & rhs) const { return m_id == rhs.m_id; }
   bool IsEqualForTesting(Shape const & shape) const;
   bool IsValid() const { return m_id.IsValid() && m_polyline.size() > 1; }
 
@@ -384,6 +397,8 @@ public:
   Network() = default;
   Network(NetworkId id, std::string const & title);
 
+  bool operator<(Network const & rhs) const { return m_id < rhs.m_id; }
+  bool operator==(Network const & rhs) const { return m_id == rhs.m_id; }
   bool IsEqualForTesting(Network const & shape) const;
   bool IsValid() const;
 

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -260,6 +260,8 @@ public:
   Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
        std::vector<ShapeId> const & shapeIds);
 
+  bool operator<(Edge const & rhs) const;
+  bool operator==(Edge const & rhs) const;
   bool IsEqualForTesting(Edge const & edge) const;
   bool IsValid() const;
   void SetWeight(double weight) { m_weight = weight; }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -87,10 +87,9 @@ public:
   explicit FeatureIdentifiers(bool serializeFeatureIdOnly);
   FeatureIdentifiers(OsmId osmId, FeatureId const & featureId, bool serializeFeatureIdOnly);
 
-  bool operator<(FeatureIdentifiers const & rhs) const { return m_osmId < rhs.m_osmId; }
-  bool operator==(FeatureIdentifiers const & rhs) const { return m_osmId == rhs.m_osmId; }
-  bool IsEqualForTesting(FeatureIdentifiers const & rhs) const { return m_featureId == rhs.m_featureId; }
-  bool IsValid() const { return m_featureId != kInvalidFeatureId; }
+  bool operator<(FeatureIdentifiers const & rhs) const;
+  bool operator==(FeatureIdentifiers const & rhs) const;
+  bool IsValid() const;
   void SetOsmId(OsmId osmId) { m_osmId = osmId; }
   void SetFeatureId(FeatureId featureId) { m_featureId = featureId; }
 
@@ -202,6 +201,7 @@ public:
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
 
   FeatureId GetFeatureId() const { return m_featureIdentifiers.GetFeatureId(); }
+  OsmId GetOsmId() const { return m_featureIdentifiers.GetOsmId(); }
   SingleMwmSegment const & GetBestPedestrianSegment() const { return m_bestPedestrianSegment; }
   bool GetEntrance() const { return m_entrance; }
   bool GetExit() const { return m_exit; }


### PR DESCRIPTION
Данный PR обеспечивает при сборке mwm функциональность по перебору всех .transit.json с графами общественного транспорта, вырезанию их по границе обрабатываемой mwm согласно правилам из https://jira.mail.ru/browse/MAPSME-5858, и сохранению в mwm секцию.

PR уже прошу смотреть, однако в нем пока кое что не реализовано:

1. Сами правила по вырезанию графов обществного транспорта в методе GraphData::ClipGraphByMwm();
2. Использование visitors для ряда методов в GraphData;
3. Тесты на методы класса GraphData и на метод DeserializeFromJson;

Данные доработки будут добавлены в данный PR отдельными коммитами.

@ygorshenin @tatiana-kondakova PTAL