### PR TITLE
[transit] Serializing/deserializing header with fix number size.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -282,7 +282,8 @@ void BuildTransit(string const & mwmDir, string const & countryId,
 
   auto const startOffset = w.Pos();
   Serializer<FileWriter> serializer(w);
-  header.Visit(serializer);
+  FixSizeNumberSerializer<FileWriter> numberSerializer(w);
+  header.Visit(numberSerializer);
 
   vector<Stop> stops;
   DeserializeFromJson(root, "stops", mapping, stops);
@@ -317,7 +318,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   CHECK(header.IsValid(), (header));
   auto const endOffset = w.Pos();
   w.Seek(startOffset);
-  header.Visit(serializer);
+  header.Visit(numberSerializer);
   w.Seek(endOffset);
   LOG(LINFO, (TRANSIT_FILE_TAG, "section is ready. Header:", header));
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -283,12 +283,13 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   auto const startOffset = w.Pos();
   Serializer<FileWriter> serializer(w);
   FixedSizeSerializer<FileWriter> numberSerializer(w);
-  header.Visit(numberSerializer);
+  VisitHeader(numberSerializer, header);
 
   vector<Stop> stops;
   DeserializeFromJson(root, "stops", mapping, stops);
   CHECK(IsValid(stops), ("stops:", stops));
   sort(stops.begin(), stops.end(), LessById);
+  header.m_stopsOffset = base::checked_cast<uint32_t>(w.Pos() - startOffset);
   serializer(stops);
   header.m_gatesOffset = base::checked_cast<uint32_t>(w.Pos() - startOffset);
 
@@ -318,7 +319,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   CHECK(header.IsValid(), (header));
   auto const endOffset = w.Pos();
   w.Seek(startOffset);
-  header.Visit(numberSerializer);
+  VisitHeader(numberSerializer, header);
   w.Seek(endOffset);
   LOG(LINFO, (TRANSIT_FILE_TAG, "section is ready. Header:", header));
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -283,7 +283,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   auto const startOffset = w.Pos();
   Serializer<FileWriter> serializer(w);
   FixedSizeSerializer<FileWriter> numberSerializer(w);
-  VisitHeader(numberSerializer, header);
+  numberSerializer(header);
 
   vector<Stop> stops;
   DeserializeFromJson(root, "stops", mapping, stops);
@@ -319,7 +319,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
   CHECK(header.IsValid(), (header));
   auto const endOffset = w.Pos();
   w.Seek(startOffset);
-  VisitHeader(numberSerializer, header);
+  numberSerializer(header);
   w.Seek(endOffset);
   LOG(LINFO, (TRANSIT_FILE_TAG, "section is ready. Header:", header));
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -282,7 +282,7 @@ void BuildTransit(string const & mwmDir, string const & countryId,
 
   auto const startOffset = w.Pos();
   Serializer<FileWriter> serializer(w);
-  FixSizeNumberSerializer<FileWriter> numberSerializer(w);
+  FixedSizeSerializer<FileWriter> numberSerializer(w);
   header.Visit(numberSerializer);
 
   vector<Stop> stops;

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -62,7 +62,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     transit::FixedSizeDeserializer<ReaderSource<FilesContainerR::TReader>> numberDeserializer(src);
 
     transit::TransitHeader header;
-    header.Visit(numberDeserializer);
+    VisitHeader(numberDeserializer, header);
 
     vector<transit::Stop> stops;
     deserializer(stops);

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -59,9 +59,10 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     FilesContainerR::TReader reader(mwmValue.m_cont.GetReader(TRANSIT_FILE_TAG));
     ReaderSource<FilesContainerR::TReader> src(reader);
     transit::Deserializer<ReaderSource<FilesContainerR::TReader>> deserializer(src);
+    transit::FixSizeNumberDeserializer<ReaderSource<FilesContainerR::TReader>> numberDeserializer(src);
 
     transit::TransitHeader header;
-    header.Visit(deserializer);
+    header.Visit(numberDeserializer);
 
     vector<transit::Stop> stops;
     deserializer(stops);

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -62,7 +62,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     transit::FixedSizeDeserializer<ReaderSource<FilesContainerR::TReader>> numberDeserializer(src);
 
     transit::TransitHeader header;
-    VisitHeader(numberDeserializer, header);
+    numberDeserializer(header);
 
     vector<transit::Stop> stops;
     deserializer(stops);

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -59,7 +59,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     FilesContainerR::TReader reader(mwmValue.m_cont.GetReader(TRANSIT_FILE_TAG));
     ReaderSource<FilesContainerR::TReader> src(reader);
     transit::Deserializer<ReaderSource<FilesContainerR::TReader>> deserializer(src);
-    transit::FixSizeNumberDeserializer<ReaderSource<FilesContainerR::TReader>> numberDeserializer(src);
+    transit::FixedSizeDeserializer<ReaderSource<FilesContainerR::TReader>> numberDeserializer(src);
 
     transit::TransitHeader header;
     header.Visit(numberDeserializer);

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -61,14 +61,14 @@ UNIT_TEST(Transit_HeaderRewriting)
 
   // Writing.
   FixedSizeSerializer<MemWriter<vector<uint8_t>>> serializer(writer);
-  VisitHeader(serializer, header);
+  serializer(header);
   auto const endOffset = writer.Pos();
 
   // Rewriting.
   header = bigHeader;
 
   writer.Seek(0 /* start offset */);
-  VisitHeader(serializer, header);
+  serializer(header);
   TEST_EQUAL(writer.Pos(), endOffset, ());
 
   // Reading.
@@ -76,7 +76,7 @@ UNIT_TEST(Transit_HeaderRewriting)
   ReaderSource<MemReader> src(reader);
   TransitHeader deserializedHeader;
   FixedSizeDeserializer<ReaderSource<MemReader>> deserializer(src);
-  VisitHeader(deserializer, deserializedHeader);
+  deserializer(deserializedHeader);
 
   TEST(deserializedHeader.IsEqualForTesting(bigHeader), (deserializedHeader, bigHeader));
 }

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -37,8 +37,8 @@ void TestCommonSerialization(Obj const & obj)
 
 void TestSerialization(TransitHeader const & header)
 {
-  TestCommonSerialization<FixSizeNumberSerializer<MemWriter<vector<uint8_t>>>,
-                          FixSizeNumberDeserializer<ReaderSource<MemReader>>>(header);
+  TestCommonSerialization<FixedSizeSerializer<MemWriter<vector<uint8_t>>>,
+                          FixedSizeDeserializer<ReaderSource<MemReader>>>(header);
 }
 
 template<class Obj>
@@ -60,8 +60,8 @@ UNIT_TEST(Transit_HeaderRewriting)
   MemWriter<vector<uint8_t>> writer(buffer);
 
   // Writing.
-  auto const startOffset = writer.Pos();
-  FixSizeNumberSerializer<MemWriter<vector<uint8_t>>> serializer(writer);
+  uint64_t constexpr startOffset = 0;
+  FixedSizeSerializer<MemWriter<vector<uint8_t>>> serializer(writer);
   header.Visit(serializer);
   auto const endOffset = writer.Pos();
 
@@ -70,13 +70,13 @@ UNIT_TEST(Transit_HeaderRewriting)
 
   writer.Seek(startOffset);
   header.Visit(serializer);
-  writer.Seek(endOffset);
+  TEST_EQUAL(writer.Pos(), endOffset, ());
 
   // Reading.
   MemReader reader(buffer.data(), buffer.size());
   ReaderSource<MemReader> src(reader);
   TransitHeader deserializedHeader;
-  FixSizeNumberDeserializer<ReaderSource<MemReader>> deserializer(src);
+  FixedSizeDeserializer<ReaderSource<MemReader>> deserializer(src);
   deserializedHeader.Visit(deserializer);
 
   TEST(deserializedHeader.IsEqualForTesting(bigHeader), (deserializedHeader, bigHeader));

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -50,26 +50,25 @@ void TestSerialization(Obj const & obj)
 
 UNIT_TEST(Transit_HeaderRewriting)
 {
-  TransitHeader const bigHeader(1 /* version */, 1000 /* gatesOffset */, 200000 /* edgesOffset */,
-                                300000 /* transfersOffset */, 400000 /* linesOffset */,
-                                5000000 /* shapesOffset */, 6000000 /* networksOffset */,
-                                700000000 /* endOffset */);
+  TransitHeader const bigHeader(1 /* version */, 500 /* stopsOffset */, 1000 /* gatesOffset */,
+                                200000 /* edgesOffset */, 300000 /* transfersOffset */,
+                                400000 /* linesOffset */, 5000000 /* shapesOffset */,
+                                6000000 /* networksOffset */, 700000000 /* endOffset */);
 
   TransitHeader header;
   vector<uint8_t> buffer;
   MemWriter<vector<uint8_t>> writer(buffer);
 
   // Writing.
-  uint64_t constexpr startOffset = 0;
   FixedSizeSerializer<MemWriter<vector<uint8_t>>> serializer(writer);
-  header.Visit(serializer);
+  VisitHeader(serializer, header);
   auto const endOffset = writer.Pos();
 
   // Rewriting.
   header = bigHeader;
 
-  writer.Seek(startOffset);
-  header.Visit(serializer);
+  writer.Seek(0 /* start offset */);
+  VisitHeader(serializer, header);
   TEST_EQUAL(writer.Pos(), endOffset, ());
 
   // Reading.
@@ -77,7 +76,7 @@ UNIT_TEST(Transit_HeaderRewriting)
   ReaderSource<MemReader> src(reader);
   TransitHeader deserializedHeader;
   FixedSizeDeserializer<ReaderSource<MemReader>> deserializer(src);
-  deserializedHeader.Visit(deserializer);
+  VisitHeader(deserializer, deserializedHeader);
 
   TEST(deserializedHeader.IsEqualForTesting(bigHeader), (deserializedHeader, bigHeader));
 }
@@ -93,9 +92,9 @@ UNIT_TEST(Transit_HeaderSerialization)
     TestSerialization(header);
   }
   {
-    TransitHeader header(1 /* version */, 1000 /* gatesOffset */, 2000 /* edgesOffset */,
-                         3000 /* transfersOffset */, 4000 /* linesOffset */, 5000 /* shapesOffset */,
-                         6000 /* networksOffset */, 7000 /* endOffset */);
+    TransitHeader header(1 /* version */, 500 /* stopsOffset */, 1000 /* gatesOffset */,
+                         2000 /* edgesOffset */, 3000 /* transfersOffset */, 4000 /* linesOffset */,
+                         5000 /* shapesOffset */, 6000 /* networksOffset */, 7000 /* endOffset */);
     TestSerialization(header);
   }
 }

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -17,22 +17,35 @@ namespace routing
 {
 namespace transit
 {
-template<class Obj>
-void TestSerialization(Obj const &obj)
+template<class S, class D, class Obj>
+void TestCommonSerialization(Obj const & obj)
 {
   vector<uint8_t> buffer;
   MemWriter<vector<uint8_t>> writer(buffer);
 
-  Serializer<MemWriter<vector<uint8_t>>> serializer(writer);
+  S serializer(writer);
   obj.Visit(serializer);
 
   MemReader reader(buffer.data(), buffer.size());
   ReaderSource<MemReader> src(reader);
   Obj deserializedObj;
-  Deserializer<ReaderSource<MemReader>> deserializer(src);
+  D deserializer(src);
   deserializedObj.Visit(deserializer);
 
   TEST(obj.IsEqualForTesting(deserializedObj), (obj, deserializedObj));
+}
+
+void TestSerialization(TransitHeader const & header)
+{
+  TestCommonSerialization<FixSizeNumberSerializer<MemWriter<vector<uint8_t>>>,
+                          FixSizeNumberDeserializer<ReaderSource<MemReader>>>(header);
+}
+
+template<class Obj>
+void TestSerialization(Obj const & obj)
+{
+  TestCommonSerialization<Serializer<MemWriter<vector<uint8_t>>>,
+                          Deserializer<ReaderSource<MemReader>>>(obj);
 }
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -38,7 +38,7 @@ template <typename Sink>
 class Serializer
 {
 public:
-  Serializer(Sink & sink) : m_sink(sink) {}
+  explicit Serializer(Sink & sink) : m_sink(sink) {}
 
   template <typename T>
   typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value) &&
@@ -128,7 +128,7 @@ template <typename Source>
 class Deserializer
 {
 public:
-  Deserializer(Source & source) : m_source(source) {}
+  explicit Deserializer(Source & source) : m_source(source) {}
 
   template <typename T>
   typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value) &&
@@ -214,6 +214,40 @@ public:
   typename std::enable_if<std::is_class<T>::value>::type operator()(T & t, char const * /* name */ = nullptr)
   {
     t.Visit(*this);
+  }
+
+private:
+  Source & m_source;
+};
+
+template <typename Sink>
+class FixSizeNumberSerializer
+{
+public:
+  explicit FixSizeNumberSerializer(Sink & sink) : m_sink(sink) {}
+
+  template <typename T>
+  typename enable_if<is_integral<T>::value || is_enum<T>::value, void>::type operator()(
+      T const & t, char const * /* name */ = nullptr)
+  {
+    WriteToSink(m_sink, t);
+  }
+
+private:
+  Sink & m_sink;
+};
+
+template <typename Source>
+class FixSizeNumberDeserializer
+{
+public:
+  explicit FixSizeNumberDeserializer(Source & source) : m_source(source) {}
+
+  template <typename T>
+  typename enable_if<is_integral<T>::value || is_enum<T>::value, void>::type operator()(
+      T & t, char const * name = nullptr)
+  {
+    ReadPrimitiveFromSource(m_source, t);
   }
 
 private:

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -221,14 +221,14 @@ private:
 };
 
 template <typename Sink>
-class FixSizeNumberSerializer
+class FixedSizeSerializer
 {
 public:
-  explicit FixSizeNumberSerializer(Sink & sink) : m_sink(sink) {}
+  explicit FixedSizeSerializer(Sink & sink) : m_sink(sink) {}
 
   template <typename T>
-  typename enable_if<is_integral<T>::value || is_enum<T>::value, void>::type operator()(
-      T const & t, char const * /* name */ = nullptr)
+  typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value, void>::type
+  operator()(T const & t, char const * /* name */ = nullptr)
   {
     WriteToSink(m_sink, t);
   }
@@ -238,14 +238,14 @@ private:
 };
 
 template <typename Source>
-class FixSizeNumberDeserializer
+class FixedSizeDeserializer
 {
 public:
-  explicit FixSizeNumberDeserializer(Source & source) : m_source(source) {}
+  explicit FixedSizeDeserializer(Source & source) : m_source(source) {}
 
   template <typename T>
-  typename enable_if<is_integral<T>::value || is_enum<T>::value, void>::type operator()(
-      T & t, char const * name = nullptr)
+  typename std::enable_if<std::is_integral<T>::value || std::is_enum<T>::value, void>::type
+  operator()(T & t, char const * name = nullptr)
   {
     ReadPrimitiveFromSource(m_source, t);
   }

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -253,5 +253,11 @@ public:
 private:
   Source & m_source;
 };
+
+template <class T>
+void VisitHeader(T & t, TransitHeader & header)
+{
+  header.Visit(t);
+}
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -233,6 +233,8 @@ public:
     WriteToSink(m_sink, t);
   }
 
+  void operator()(TransitHeader const & header) { header.Visit(*this); }
+
 private:
   Sink & m_sink;
 };
@@ -250,14 +252,10 @@ public:
     ReadPrimitiveFromSource(m_source, t);
   }
 
+  void operator()(TransitHeader & header) { header.Visit(*this); }
+
 private:
   Source & m_source;
 };
-
-template <class T>
-void VisitHeader(T & t, TransitHeader & header)
-{
-  header.Visit(t);
-}
 }  // namespace transit
 }  // namespace routing

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -13,11 +13,12 @@ namespace routing
 namespace transit
 {
 // TransitHeader ----------------------------------------------------------------------------------
-TransitHeader::TransitHeader(uint16_t version, uint32_t gatesOffset, uint32_t edgesOffset,
-                             uint32_t transfersOffset, uint32_t linesOffset, uint32_t shapesOffset,
-                             uint32_t networksOffset, uint32_t endOffset)
+TransitHeader::TransitHeader(uint16_t version, uint32_t stopsOffset, uint32_t gatesOffset,
+                             uint32_t edgesOffset, uint32_t transfersOffset, uint32_t linesOffset,
+                             uint32_t shapesOffset, uint32_t networksOffset, uint32_t endOffset)
   : m_version(version)
   , m_reserve(0)
+  , m_stopsOffset(stopsOffset)
   , m_gatesOffset(gatesOffset)
   , m_edgesOffset(edgesOffset)
   , m_transfersOffset(transfersOffset)
@@ -32,6 +33,7 @@ void TransitHeader::Reset()
 {
   m_version = 0;
   m_reserve = 0;
+  m_stopsOffset = 0;
   m_gatesOffset = 0;
   m_edgesOffset = 0;
   m_transfersOffset = 0;
@@ -45,6 +47,7 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
 {
   return m_version == header.m_version
          && m_reserve == header.m_reserve
+         && m_stopsOffset == header.m_stopsOffset
          && m_gatesOffset == header.m_gatesOffset
          && m_edgesOffset == header.m_edgesOffset
          && m_transfersOffset == header.m_transfersOffset
@@ -56,9 +59,10 @@ bool TransitHeader::IsEqualForTesting(TransitHeader const & header) const
 
 bool TransitHeader::IsValid() const
 {
-  return m_gatesOffset <= m_edgesOffset && m_edgesOffset <= m_transfersOffset &&
-         m_transfersOffset <= m_linesOffset && m_linesOffset <= m_shapesOffset &&
-         m_shapesOffset <= m_networksOffset && m_networksOffset <= m_endOffset;
+  return m_stopsOffset <= m_gatesOffset && m_gatesOffset <= m_edgesOffset &&
+         m_edgesOffset <= m_transfersOffset && m_transfersOffset <= m_linesOffset &&
+         m_linesOffset <= m_shapesOffset && m_shapesOffset <= m_networksOffset &&
+         m_networksOffset <= m_endOffset;
 }
 
 // FeatureIdentifiers -----------------------------------------------------------------------------

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -48,7 +48,8 @@ Weight constexpr kInvalidWeight = -1.0;
                            std::string const & osmIdsToFeatureIdPath,                 \
                            std::string const & transitDir);                           \
   template <class Ser, class Deser, class Obj>                                        \
-  void friend TestCommonSerialization(Obj const & obj);                               \
+  friend void TestCommonSerialization(Obj const & obj);                               \
+  friend void UnitTest_Transit_HeaderRewriting();                                   \
 
 struct TransitHeader
 {

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -49,7 +49,7 @@ Weight constexpr kInvalidWeight = -1.0;
                            std::string const & transitDir);                           \
   template <class Ser, class Deser, class Obj>                                        \
   friend void TestCommonSerialization(Obj const & obj);                               \
-  friend void UnitTest_Transit_HeaderRewriting();                                   \
+  friend void UnitTest_Transit_HeaderRewriting();                                     \
 
 struct TransitHeader
 {

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -14,8 +14,6 @@ namespace routing
 {
 namespace transit
 {
-struct TransitHeader;
-
 using Anchor = uint8_t;
 using FeatureId = uint32_t;
 using LineId = uint32_t;
@@ -39,14 +37,13 @@ TransferId constexpr kInvalidTransferId = std::numeric_limits<TransferId>::max()
 Weight constexpr kInvalidWeight = -1.0;
 
 #define DECLARE_TRANSIT_TYPE_FRIENDS                                                  \
-  template <class Sink>                                                               \
-  friend class Serializer;                                                            \
-  template <class Source>                                                             \
-  friend class Deserializer;                                                          \
+  template <class Sink> friend class Serializer;                                      \
+  template <class Source> friend class Deserializer;                                  \
   friend class DeserializerFromJson;                                                  \
   template <class Ser, class Deser, class Obj>                                        \
   friend void TestCommonSerialization(Obj const & obj);                               \
-  template <class T> friend void VisitHeader(T & t, TransitHeader & header);          \
+  template <typename Sink> friend class FixedSizeSerializer;                          \
+  template <typename Sink> friend class FixedSizeDeserializer;                        \
 
 struct TransitHeader
 {

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -37,16 +37,18 @@ TransferId constexpr kInvalidTransferId = std::numeric_limits<TransferId>::max()
 // To convert double to uint32_t at better accuracy |kInvalidWeight| should be close to real weight.
 Weight constexpr kInvalidWeight = -1.0;
 
-#define DECLARE_TRANSIT_TYPE_FRIENDS                                                           \
-    template<class Sink> friend class Serializer;                                              \
-    template<class Source> friend class Deserializer;                                          \
-    friend class DeserializerFromJson;                                                         \
-    friend class routing::TransitGraphLoader;                                                  \
-    friend void BuildTransit(std::string const & mwmDir,                                       \
-                             std::string const & countryId,                                    \
-                             std::string const & osmIdsToFeatureIdPath,                        \
-                             std::string const & transitDir);                                  \
-    template<class Obj> friend void TestSerialization(Obj const & obj);                        \
+#define DECLARE_TRANSIT_TYPE_FRIENDS                                                  \
+  template <class Sink>                                                               \
+  friend class Serializer;                                                            \
+  template <class Source>                                                             \
+  friend class Deserializer;                                                          \
+  friend class DeserializerFromJson;                                                  \
+  friend class routing::TransitGraphLoader;                                           \
+  friend void BuildTransit(std::string const & mwmDir, std::string const & countryId, \
+                           std::string const & osmIdsToFeatureIdPath,                 \
+                           std::string const & transitDir);                           \
+  template <class Ser, class Deser, class Obj>                                        \
+  void friend TestCommonSerialization(Obj const & obj);                               \
 
 struct TransitHeader
 {


### PR DESCRIPTION
@tatiana-kondakova нашла баг при сохранении хедера секции transit. 

В начале секции place holder заголовока сохранялся сериалайзером с использованием varint, а затем он перезаписывался после создания секции.

Данный PR исправляет этот баг. Добавлен Serializer/Deserializer для хедера. Я так же добавил тест, на перезапись хедера.

@tatiana-kondakova @ygorshenin @darina PTAL