### PR TITLE
[android] Moved subscribing/unsubscribing global map object listeners…

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -724,6 +724,7 @@ Java_com_mapswithme_maps_Framework_nativeGetParsedSearchRequest(JNIEnv * env, jc
 JNIEXPORT void JNICALL
 Java_com_mapswithme_maps_Framework_nativeSetMapObjectListener(JNIEnv * env, jclass clazz, jobject jListener)
 {
+  LOG(LINFO, ("Set global map object listener"));
   g_mapObjectListener = env->NewGlobalRef(jListener);
   // void onMapObjectActivated(MapObject object);
   jmethodID const activatedId = jni::GetMethodID(env, g_mapObjectListener, "onMapObjectActivated",
@@ -751,6 +752,7 @@ Java_com_mapswithme_maps_Framework_nativeRemoveMapObjectListener(JNIEnv * env, j
     return;
 
   frm()->SetMapSelectionListeners({}, {});
+  LOG(LINFO, ("Remove global map object listener"));
   env->DeleteGlobalRef(g_mapObjectListener);
 }
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -503,8 +503,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     Statistics.INSTANCE.trackConnectionState();
 
-    Framework.nativeSetMapObjectListener(this);
-
     mSearchController = new FloatingSearchToolbarController(this);
     mSearchController.setVisibilityListener(this);
     SearchEngine.INSTANCE.addListener(this);
@@ -913,14 +911,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onDestroy()
   {
-    if (!isInitializationComplete())
+    if (!isInitializationCompleted())
     {
       super.onDestroy();
       return;
     }
 
-    // TODO move listeners attach-deattach to onStart-onStop since onDestroy isn't guaranteed.
-    Framework.nativeRemoveMapObjectListener();
     BottomSheetHelper.free();
     SearchEngine.INSTANCE.removeListener(this);
     super.onDestroy();
@@ -1178,6 +1174,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   protected void onStart()
   {
     super.onStart();
+    Framework.nativeSetMapObjectListener(this);
     RoutingController.get().attach(this);
     if (MapFragment.nativeIsEngineCreated())
       LocationHelper.INSTANCE.attach(this);
@@ -1192,6 +1189,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   protected void onStop()
   {
     super.onStop();
+    Framework.nativeRemoveMapObjectListener();
     LocationHelper.INSTANCE.detach(!isFinishing());
     RoutingController.get().detach();
     TrafficManager.INSTANCE.detachAll();

--- a/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
@@ -28,7 +28,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
 {
   private final BaseActivityDelegate mBaseDelegate = new BaseActivityDelegate(this);
 
-  private boolean mInitializationComplete = false;
+  private boolean mInitializationCompleted = false;
 
   @Override
   public Activity get()
@@ -60,7 +60,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
       goToSplashScreen();
       return;
     }
-    mInitializationComplete = true;
+    mInitializationCompleted = true;
 
     mBaseDelegate.onCreate();
     super.onCreate(savedInstanceState);
@@ -91,9 +91,9 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     attachDefaultFragment();
   }
 
-  protected boolean isInitializationComplete()
+  protected boolean isInitializationCompleted()
   {
-    return mInitializationComplete;
+    return mInitializationCompleted;
   }
 
   @ColorRes


### PR DESCRIPTION
… to onStart/onStop activity methods
https://jira.mail.ru/browse/MAPSME-5637
Как воспроизвести крэш - в голову не пришло. Судя по коду вообще непонятно. Понятно только на onDestroy метод полагаться нельзя в случае подписки/отписки листенеров, так как он вызывается далеко не всегда. Поэтому перенес в onStart/onStop и добавил логирование на случай если проблема вдруг останется.