### PR TITLE
[routing][transit] Fix set transit info

### DIFF
--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -80,6 +80,8 @@ bool IndexRoadGraph::IsRouteEdgesImplemented() const
   return true;
 }
 
+bool IndexRoadGraph::IsRouteSegmentsImplemented() const { return true; }
+
 void IndexRoadGraph::GetRouteEdges(TEdgeVector & edges) const
 {
   edges.clear();
@@ -100,6 +102,8 @@ void IndexRoadGraph::GetRouteEdges(TEdgeVector & edges) const
                        m_starter.GetJunction(segment, true /* front */));
   }
 }
+
+vector<Segment> const & IndexRoadGraph::GetRouteSegments() const { return m_segments; }
 
 void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const
 {

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -29,8 +29,9 @@ public:
   virtual void GetJunctionTypes(Junction const & junction,
                                 feature::TypesHolder & types) const override;
   virtual bool IsRouteEdgesImplemented() const override;
+  virtual bool IsRouteSegmentsImplemented() const override;
   virtual void GetRouteEdges(TEdgeVector & edges) const override;
-
+  virtual std::vector<Segment> const & GetRouteSegments() const override;
 
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -64,10 +64,17 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
 
   CalculateTurns(graph, routeEdges, turns, cancellable);
 
-  segments.reserve(routeEdges.size());
-  for (Edge const & e : routeEdges)
-    segments.push_back(ConvertEdgeToSegment(*m_numMwmIds, e));
-  
+  if (graph.IsRouteSegmentsImplemented())
+  {
+    segments = graph.GetRouteSegments();
+  }
+  else
+  {
+    segments.reserve(routeEdges.size());
+    for (Edge const & e : routeEdges)
+      segments.push_back(ConvertEdgeToSegment(*m_numMwmIds, e));
+  }
+
   return true;
 }
 

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -11,9 +11,11 @@
 #include "base/math.hpp"
 #include "base/stl_helpers.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/limits.hpp"
-#include "std/sstream.hpp"
+#include <algorithm>
+#include <limits>
+#include <sstream>
+
+using namespace std;
 
 namespace routing
 {
@@ -297,12 +299,16 @@ IRoadGraph::RoadInfo MakeRoadInfoForTesting(bool bidirectional, double speedKMPH
   return ri;
 }
 // RoadGraphBase ------------------------------------------------------------------
-bool RoadGraphBase::IsRouteEdgesImplemented() const
-{
-  return false;
-}
+bool RoadGraphBase::IsRouteEdgesImplemented() const { return false; }
+
+bool RoadGraphBase::IsRouteSegmentsImplemented() const { return false; }
 
 void RoadGraphBase::GetRouteEdges(TEdgeVector & routeEdges) const
+{
+  NOTIMPLEMENTED()
+}
+
+vector<Segment> const & RoadGraphBase::GetRouteSegments() const
 {
   NOTIMPLEMENTED()
 }

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "routing/segment.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "base/string_utils.hpp"
@@ -7,9 +9,9 @@
 #include "indexer/feature_altitude.hpp"
 #include "indexer/feature_data.hpp"
 
-#include "std/initializer_list.hpp"
-#include "std/map.hpp"
-#include "std/vector.hpp"
+#include <initializer_list>
+#include <map>
+#include <vector>
 
 namespace routing
 {
@@ -130,9 +132,13 @@ public:
   /// @return Types for specified junction
   virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
 
+  // TODO: remove IsRouteEdgesImplemented and IsRouteSegmentsImplemented as soon as we get rid of
+  // IRoadGraph and RoadGraphRouter
   virtual bool IsRouteEdgesImplemented() const;
+  virtual bool IsRouteSegmentsImplemented() const;
 
   virtual void GetRouteEdges(TEdgeVector & routeEdges) const;
+  virtual std::vector<Segment> const & GetRouteSegments() const;
 };
 
 class IRoadGraph : public RoadGraphBase
@@ -155,7 +161,7 @@ public:
   {
     RoadInfo();
     RoadInfo(RoadInfo && ri);
-    RoadInfo(bool bidirectional, double speedKMPH, initializer_list<Junction> const & points);
+    RoadInfo(bool bidirectional, double speedKMPH, std::initializer_list<Junction> const & points);
     RoadInfo(RoadInfo const &) = default;
     RoadInfo & operator=(RoadInfo const &) = default;
 
@@ -296,7 +302,7 @@ public:
   void GetFakeIngoingEdges(Junction const & junction, TEdgeVector & edges) const;
 
 private:
-  void AddEdge(Junction const & j, Edge const & e, map<Junction, TEdgeVector> & edges);
+  void AddEdge(Junction const & j, Edge const & e, std::map<Junction, TEdgeVector> & edges);
 
   template <typename Fn>
   void ForEachFakeEdge(Fn && fn)
@@ -316,14 +322,14 @@ private:
 
   /// \note |m_fakeIngoingEdges| and |m_fakeOutgoingEdges| map junctions to sorted vectors.
   /// Items to these maps should be inserted with AddEdge() method only.
-  map<Junction, TEdgeVector> m_fakeIngoingEdges;
-  map<Junction, TEdgeVector> m_fakeOutgoingEdges;
+  std::map<Junction, TEdgeVector> m_fakeIngoingEdges;
+  std::map<Junction, TEdgeVector> m_fakeOutgoingEdges;
 };
 
 string DebugPrint(IRoadGraph::Mode mode);
 
 IRoadGraph::RoadInfo MakeRoadInfoForTesting(bool bidirectional, double speedKMPH,
-                                            initializer_list<m2::PointD> const & points);
+                                            std::initializer_list<m2::PointD> const & points);
 
 inline void JunctionsToPoints(vector<Junction> const & junctions, vector<m2::PointD> & points)
 {

--- a/routing/transit_info.hpp
+++ b/routing/transit_info.hpp
@@ -22,6 +22,7 @@ public:
 
   struct Edge
   {
+    Edge() = default;
     explicit Edge(transit::Edge const & edge)
       : m_lineId(edge.GetLineId())
       , m_stop1Id(edge.GetStop1Id())
@@ -39,6 +40,7 @@ public:
 
   struct Gate
   {
+    Gate() = default;
     explicit Gate(transit::Gate const & gate) : m_featureId(gate.GetFeatureId()) {}
 
     transit::FeatureId m_featureId = transit::kInvalidFeatureId;
@@ -46,6 +48,7 @@ public:
 
   struct Transfer
   {
+    Transfer() = default;
     explicit Transfer(transit::Edge const & edge)
       : m_stop1Id(edge.GetStop1Id()), m_stop2Id(edge.GetStop2Id())
     {
@@ -57,15 +60,15 @@ public:
   };
 
   explicit TransitInfo(transit::Gate const & gate)
-    : m_type(Type::Gate), m_edge(transit::Edge()), m_gate(gate), m_transfer(transit::Edge())
+    : m_type(Type::Gate)
+    , m_gate(gate)
   {
   }
 
   explicit TransitInfo(transit::Edge const & edge)
     : m_type(edge.GetTransfer() ? Type::Transfer : Type::Edge)
-    , m_edge(edge.GetTransfer() ? transit::Edge() : edge)
-    , m_gate(transit::Gate())
-    , m_transfer(edge.GetTransfer() ? edge : transit::Edge())
+    , m_edge(edge.GetTransfer() ? Edge() : Edge(edge))
+    , m_transfer(edge.GetTransfer() ? Transfer(edge) : Transfer())
   {
   }
 


### PR DESCRIPTION
В реквесте два коммита, исправляющие две ошибки:
1. Исправление ошибки в инициализации TransitInfo -- для конструирования dummy Transfer передаем Edge с типом Transfer

2. Исправление ошибки в заполнении TransitInfo при постобработке маршрута.
Проблема была в том, что в PedestrianDirectionsEngine::Generate из RoadGraph из вектора сегментов, который в нём сохранен, получался вектор Edge, а потом по вектору Edge обратно восстанавливался вектор сегментов. При этом Edge внутри имеют FeatureID, который для фейковых сегментов не существует, и информация о транзитных сегментах терялась. Эта информация нужна далее чтобы корректно отрисовать маршрут, поэтому вместо восстановления вектора сегментов по вектору Edge берём вектор сегментов из RoadGraph.