### PR TITLE
[routing][transit] TransitGraph refactoring

### DIFF
--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -24,6 +24,8 @@ public:
   static bool IsTransitFeature(uint32_t featureId);
   static bool IsTransitSegment(Segment const & segment);
 
+  explicit TransitGraph(NumMwmId numMwmId) : m_mwmId(numMwmId) {}
+
   Junction const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator const & estimator) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
@@ -32,13 +34,9 @@ public:
   std::set<Segment> const & GetFake(Segment const & real) const;
   bool FindReal(Segment const & fake, Segment & real) const;
 
-  // Fills transit info based on data from transit section.
-  // Uses |indexGraph| to get road geometry: only modifications of |indexGraph| are
-  // modifications of geometry cache.
-  // TODO (t.yan) get rid of indexGraph and estimator
-  void Fill(std::vector<transit::Stop> const & stops, std::vector<transit::Gate> const & gates,
-            std::vector<transit::Edge> const & edges, std::vector<transit::Line> const & lines,
-            EdgeEstimator const & estimator, NumMwmId numMwmId, IndexGraph & indexGraph);
+  void Fill(std::vector<transit::Stop> const & stops, std::vector<transit::Edge> const & edges,
+            std::vector<transit::Line> const & lines, std::vector<transit::Gate> const & gates,
+            std::map<transit::FeatureIdentifiers, FakeEnding> const & gateEndings);
 
   bool IsGate(Segment const & segment) const;
   bool IsEdge(Segment const & segment) const;
@@ -58,12 +56,12 @@ private:
                       bool isOutgoing);
 
   static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
-  NumMwmId m_mwmId = kFakeNumMwmId;
+  NumMwmId const m_mwmId = kFakeNumMwmId;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;
   std::map<Segment, transit::Edge> m_segmentToEdge;
   std::map<Segment, transit::Gate> m_segmentToGate;
   std::map<transit::LineId, double> m_transferPenalties;
-  // TODO (@t.yan) move m_edgeToSegment, m_stopToBack, m_stopToFront to Fill
+  // TODO (@t.yan) move m_stopToBack, m_stopToFront to Fill
   std::map<transit::StopId, std::set<Segment>> m_stopToBack;
   std::map<transit::StopId, std::set<Segment>> m_stopToFront;
 };

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -48,11 +48,17 @@ private:
   Segment GetNewTransitSegment() const;
 
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
-               std::map<transit::StopId, Junction> const & stopCoords, bool isEnter);
+               std::map<transit::StopId, Junction> const & stopCoords, bool isEnter,
+               std::map<transit::StopId, std::set<Segment>> & stopToBack,
+               std::map<transit::StopId, std::set<Segment>> & stopToFront);
   // Adds transit edge to fake graph, returns corresponding transit segment.
   Segment AddEdge(transit::Edge const & edge,
-                  std::map<transit::StopId, Junction> const & stopCoords);
+                  std::map<transit::StopId, Junction> const & stopCoords,
+                  std::map<transit::StopId, std::set<Segment>> & stopToBack,
+                  std::map<transit::StopId, std::set<Segment>> & stopToFront);
   void AddConnections(std::map<transit::StopId, std::set<Segment>> const & connections,
+                      std::map<transit::StopId, std::set<Segment>> const & stopToBack,
+                      std::map<transit::StopId, std::set<Segment>> const & stopToFront,
                       bool isOutgoing);
 
   static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
@@ -61,8 +67,5 @@ private:
   std::map<Segment, transit::Edge> m_segmentToEdge;
   std::map<Segment, transit::Gate> m_segmentToGate;
   std::map<transit::LineId, double> m_transferPenalties;
-  // TODO (@t.yan) move m_stopToBack, m_stopToFront to Fill
-  std::map<transit::StopId, std::set<Segment>> m_stopToBack;
-  std::map<transit::StopId, std::set<Segment>> m_stopToFront;
 };
 }  // namespace routing

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -36,7 +36,7 @@ public:
 
   void Fill(std::vector<transit::Stop> const & stops, std::vector<transit::Edge> const & edges,
             std::vector<transit::Line> const & lines, std::vector<transit::Gate> const & gates,
-            std::map<transit::FeatureIdentifiers, FakeEnding> const & gateEndings);
+            std::map<transit::OsmId, FakeEnding> const & gateEndings);
 
   bool IsGate(Segment const & segment) const;
   bool IsEdge(Segment const & segment) const;
@@ -44,22 +44,24 @@ public:
   transit::Edge const & GetEdge(Segment const & segment) const;
 
 private:
+  using StopToSegmentsMap = std::map<transit::StopId, std::set<Segment>>;
+
   Segment GetTransitSegment(uint32_t segmentIdx) const;
   Segment GetNewTransitSegment() const;
 
+  // Adds gate to fake graph. Also adds gate to temporary stopToBack, stopToFront maps used while
+  // TransitGraph::Fill.
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
                std::map<transit::StopId, Junction> const & stopCoords, bool isEnter,
-               std::map<transit::StopId, std::set<Segment>> & stopToBack,
-               std::map<transit::StopId, std::set<Segment>> & stopToFront);
-  // Adds transit edge to fake graph, returns corresponding transit segment.
+               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+  // Adds transit edge to fake graph, returns corresponding transit segment. Also adds gate to
+  // temporary stopToBack, stopToFront maps used while TransitGraph::Fill.
   Segment AddEdge(transit::Edge const & edge,
                   std::map<transit::StopId, Junction> const & stopCoords,
-                  std::map<transit::StopId, std::set<Segment>> & stopToBack,
-                  std::map<transit::StopId, std::set<Segment>> & stopToFront);
-  void AddConnections(std::map<transit::StopId, std::set<Segment>> const & connections,
-                      std::map<transit::StopId, std::set<Segment>> const & stopToBack,
-                      std::map<transit::StopId, std::set<Segment>> const & stopToFront,
-                      bool isOutgoing);
+                  StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+  // Adds connections to fake graph.
+  void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,
+                      StopToSegmentsMap const & stopToFront, bool isOutgoing);
 
   static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
   NumMwmId const m_mwmId = kFakeNumMwmId;

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -1,5 +1,6 @@
 #include "routing/transit_graph_loader.hpp"
 
+#include "routing/fake_ending.hpp"
 #include "routing/routing_exceptions.hpp"
 
 #include "routing_common/transit_serdes.hpp"
@@ -49,7 +50,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     MYTHROW(RoutingException, ("Can't get mwm handle for", file));
 
   my::Timer timer;
-  auto graphPtr = make_unique<TransitGraph>();
+  auto graphPtr = make_unique<TransitGraph>(numMwmId);
   MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
   if (!mwmValue.m_cont.IsExist(TRANSIT_FILE_TAG))
     return graphPtr;
@@ -81,7 +82,20 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     vector<transit::Line> lines;
     deserializer(lines);
 
-    graphPtr->Fill(stops, gates, edges, lines, *m_estimator, numMwmId, indexGraph);
+    map<transit::FeatureIdentifiers, FakeEnding> gateEndings;
+    for (auto const & gate : gates)
+    {
+      auto const & gateSegment = gate.GetBestPedestrianSegment();
+      if (gateSegment.IsValid())
+      {
+        Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
+                     gateSegment.GetForward());
+        gateEndings.emplace(gate.GetFeatureIdentifiers(),
+                            MakeFakeEnding(real, gate.GetPoint(), *m_estimator, indexGraph));
+      }
+    }
+
+    graphPtr->Fill(stops, edges, lines, gates, gateEndings);
   }
   catch (Reader::OpenException const & e)
   {

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -82,15 +82,15 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     vector<transit::Line> lines;
     deserializer(lines);
 
-    map<transit::FeatureIdentifiers, FakeEnding> gateEndings;
+    map<transit::OsmId, FakeEnding> gateEndings;
     for (auto const & gate : gates)
     {
       auto const & gateSegment = gate.GetBestPedestrianSegment();
       if (gateSegment.IsValid())
       {
-        Segment real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
-                     gateSegment.GetForward());
-        gateEndings.emplace(gate.GetFeatureIdentifiers(),
+        Segment const real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
+                           gateSegment.GetForward());
+        gateEndings.emplace(gate.GetOsmId(),
                             MakeFakeEnding(real, gate.GetPoint(), *m_estimator, indexGraph));
       }
     }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -202,6 +202,7 @@ public:
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
 
   FeatureId GetFeatureId() const { return m_featureIdentifiers.GetFeatureId(); }
+  FeatureIdentifiers const & GetFeatureIdentifiers() const { return m_featureIdentifiers; }
   OsmId GetOsmId() const { return m_featureIdentifiers.GetOsmId(); }
   SingleMwmSegment const & GetBestPedestrianSegment() const { return m_bestPedestrianSegment; }
   bool GetEntrance() const { return m_entrance; }

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -202,7 +202,6 @@ public:
   void SetBestPedestrianSegment(SingleMwmSegment const & s) { m_bestPedestrianSegment = s; };
 
   FeatureId GetFeatureId() const { return m_featureIdentifiers.GetFeatureId(); }
-  FeatureIdentifiers const & GetFeatureIdentifiers() const { return m_featureIdentifiers; }
   OsmId GetOsmId() const { return m_featureIdentifiers.GetOsmId(); }
   SingleMwmSegment const & GetBestPedestrianSegment() const { return m_bestPedestrianSegment; }
   bool GetEntrance() const { return m_entrance; }


### PR DESCRIPTION
Два небольших рефакторинга TransitGraph:
1. Из интерфейса метода Fill убран Estimator и IndexGraph, которые использовались для поиска проекций gate на пешеходные сегменты, теперь эти действия происходят снаружи от TransitGraph.

2. m_stopToBack, m_stopToFront, которые используются только в ходе выполнения метода Fill переехали из полей в локальные переменные метода Fill