### PR TITLE
[transit] Optimization. Creating world graph once for building mwm transit section.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -322,7 +322,7 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string c
                           CountryParentNameGetterFn(), countryFileGetter, getMwmRectByName,
                           numMwmIds, MakeNumMwmTree(*numMwmIds, *infoGetter),
                           traffic::TrafficCache(), index.GetIndex());
-  auto worldGraph = indexRouter.MakeSingleMwmWorldGraphForGenerator();
+  auto worldGraph = indexRouter.MakeSingleMwmWorldGraph();
 
   // Looking for the best segment for every gate.
   for (auto & gate : m_gates)
@@ -335,8 +335,8 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string c
     {
       if (countryFileGetter(gate.GetPoint()) != countryId)
         continue;
-      if (indexRouter.FindBestSegmentForGenerator(gate.GetPoint(), m2::PointD::Zero() /* direction */,
-                                                  true /* isOutgoing */, *worldGraph, bestSegment))
+      if (indexRouter.FindBestSegment(gate.GetPoint(), m2::PointD::Zero() /* direction */,
+                                      true /* isOutgoing */, *worldGraph, bestSegment))
       {
         CHECK_EQUAL(bestSegment.GetMwmId(), 0, ());
         gate.SetBestPedestrianSegment(SingleMwmSegment(

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -322,6 +322,7 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string c
                           CountryParentNameGetterFn(), countryFileGetter, getMwmRectByName,
                           numMwmIds, MakeNumMwmTree(*numMwmIds, *infoGetter),
                           traffic::TrafficCache(), index.GetIndex());
+  auto worldGraph = indexRouter.MakeSingleMwmWorldGraphForGenerator();
 
   // Looking for the best segment for every gate.
   for (auto & gate : m_gates)
@@ -332,13 +333,10 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string c
     Segment bestSegment;
     try
     {
-       if (countryFileGetter(gate.GetPoint()) != countryId)
-         continue;
-      // @todo(bykoianko) For every call of the method below WorldGraph is created. It's not
-      // efficient to create WorldGraph for every gate. The code should be redesigned.
-      if (indexRouter.FindBestSegmentInSingleMwm(gate.GetPoint(),
-                                                 m2::PointD::Zero() /* direction */,
-                                                 true /* isOutgoing */, bestSegment))
+      if (countryFileGetter(gate.GetPoint()) != countryId)
+        continue;
+      if (indexRouter.FindBestSegmentForGenerator(gate.GetPoint(), m2::PointD::Zero() /* direction */,
+                                                  true /* isOutgoing */, *worldGraph, bestSegment))
       {
         CHECK_EQUAL(bestSegment.GetMwmId(), 0, ());
         gate.SetBestPedestrianSegment(SingleMwmSegment(

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -318,13 +318,20 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
   CHECK(m_directionsEngine, ());
 }
 
-bool IndexRouter::FindBestSegmentInSingleMwm(m2::PointD const & point, m2::PointD const & direction,
-                                             bool isOutgoing, Segment & bestSegment)
+std::unique_ptr<WorldGraph> IndexRouter::MakeSingleMwmWorldGraphForGenerator()
 {
   auto worldGraph = MakeWorldGraph();
   worldGraph->SetMode(WorldGraph::Mode::SingleMwm);
+  return worldGraph;
+}
+
+bool IndexRouter::FindBestSegmentForGenerator(m2::PointD const & point, m2::PointD const & direction,
+                                              bool isOutgoing, WorldGraph & worldGraph,
+                                              Segment & bestSegment)
+{
+
   bool dummy;
-  return FindBestSegment(point, direction, isOutgoing, *worldGraph, bestSegment,
+  return FindBestSegment(point, direction, isOutgoing, worldGraph, bestSegment,
                          dummy /* best segment is almost codirectional */);
 }
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -318,18 +318,17 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
   CHECK(m_directionsEngine, ());
 }
 
-std::unique_ptr<WorldGraph> IndexRouter::MakeSingleMwmWorldGraphForGenerator()
+unique_ptr<WorldGraph> IndexRouter::MakeSingleMwmWorldGraph()
 {
   auto worldGraph = MakeWorldGraph();
   worldGraph->SetMode(WorldGraph::Mode::SingleMwm);
   return worldGraph;
 }
 
-bool IndexRouter::FindBestSegmentForGenerator(m2::PointD const & point, m2::PointD const & direction,
-                                              bool isOutgoing, WorldGraph & worldGraph,
-                                              Segment & bestSegment)
+bool IndexRouter::FindBestSegment(m2::PointD const & point, m2::PointD const & direction,
+                                  bool isOutgoing, WorldGraph & worldGraph,
+                                  Segment & bestSegment)
 {
-
   bool dummy;
   return FindBestSegment(point, direction, isOutgoing, worldGraph, bestSegment,
                          dummy /* best segment is almost codirectional */);

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -63,8 +63,9 @@ public:
               shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
               traffic::TrafficCache const & trafficCache, Index & index);
 
-  bool FindBestSegmentInSingleMwm(m2::PointD const & point, m2::PointD const & direction,
-                                  bool isOutgoing, Segment & bestSegment);
+  std::unique_ptr<WorldGraph> MakeSingleMwmWorldGraphForGenerator();
+  bool FindBestSegmentForGenerator(m2::PointD const & point, m2::PointD const & direction,
+                                   bool isOutgoing, WorldGraph & worldGraph, Segment & bestSegment);
 
   // IRouter overrides:
   std::string GetName() const override { return m_name; }

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -63,9 +63,9 @@ public:
               shared_ptr<NumMwmIds> numMwmIds, unique_ptr<m4::Tree<NumMwmId>> numMwmTree,
               traffic::TrafficCache const & trafficCache, Index & index);
 
-  std::unique_ptr<WorldGraph> MakeSingleMwmWorldGraphForGenerator();
-  bool FindBestSegmentForGenerator(m2::PointD const & point, m2::PointD const & direction,
-                                   bool isOutgoing, WorldGraph & worldGraph, Segment & bestSegment);
+  std::unique_ptr<WorldGraph> MakeSingleMwmWorldGraph();
+  bool FindBestSegment(m2::PointD const & point, m2::PointD const & direction,
+                       bool isOutgoing, WorldGraph & worldGraph, Segment & bestSegment);
 
   // IRouter overrides:
   std::string GetName() const override { return m_name; }


### PR DESCRIPTION
Пару недель назад, при написании кода поиска ближайшего (лучшего) пешеходного сегмента к гейту мы спрятали создание WorldGraph в метод: IndexRouter::FindBestSegmentInSingleMwm(). Это оказалось не эффективно, поскольку для каждого Gate-та при создании секции transit создавался WorldGraph. Я передал код так, чтоб WorldGraph создавался один раз, на сборку секции transit.

@tatiana-kondakova @ygorshenin PTAL