### PR TITLE
Fix control reaches end of non-void function for NOTIMPLEMENTED RoadGraphBase::GetRouteSegments

### DIFF
--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -103,7 +103,10 @@ void IndexRoadGraph::GetRouteEdges(TEdgeVector & edges) const
   }
 }
 
-vector<Segment> const & IndexRoadGraph::GetRouteSegments() const { return m_segments; }
+void IndexRoadGraph::GetRouteSegments(std::vector<Segment> & segments) const
+{
+  segments = m_segments;
+}
 
 void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const
 {

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -31,7 +31,7 @@ public:
   virtual bool IsRouteEdgesImplemented() const override;
   virtual bool IsRouteSegmentsImplemented() const override;
   virtual void GetRouteEdges(TEdgeVector & edges) const override;
-  virtual std::vector<Segment> const & GetRouteSegments() const override;
+  virtual void GetRouteSegments(std::vector<Segment> & segments) const override;
 
 private:
   void GetEdges(Junction const & junction, bool isOutgoing, TEdgeVector & edges) const;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -66,7 +66,7 @@ bool PedestrianDirectionsEngine::Generate(RoadGraphBase const & graph,
 
   if (graph.IsRouteSegmentsImplemented())
   {
-    segments = graph.GetRouteSegments();
+    graph.GetRouteSegments(segments);
   }
   else
   {

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -308,7 +308,7 @@ void RoadGraphBase::GetRouteEdges(TEdgeVector & routeEdges) const
   NOTIMPLEMENTED()
 }
 
-vector<Segment> const & RoadGraphBase::GetRouteSegments() const
+void RoadGraphBase::GetRouteSegments(std::vector<Segment> &) const
 {
   NOTIMPLEMENTED()
 }

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -138,7 +138,7 @@ public:
   virtual bool IsRouteSegmentsImplemented() const;
 
   virtual void GetRouteEdges(TEdgeVector & routeEdges) const;
-  virtual std::vector<Segment> const & GetRouteSegments() const;
+  virtual void GetRouteSegments(std::vector<Segment> & segments) const;
 };
 
 class IRoadGraph : public RoadGraphBase


### PR DESCRIPTION
Во вчерашнем PR было место, провоцирующее ворнинг, исправила.