### PR TITLE
Fix transit to pedestrian connection

### DIFF
--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -52,10 +52,11 @@ void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bo
   vector<SegmentEdge> fakeFromReal;
   for (auto const & edge : edges)
   {
-    for (auto const & s : transitGraph.GetFake(edge.GetTarget()))
+    auto const & edgeSegment = edge.GetTarget();
+    for (auto const & s : transitGraph.GetFake(edgeSegment))
     {
-      bool const haveSameFront = GetJunction(segment, true /* front */) == GetJunction(s, true);
-      bool const haveSameBack = GetJunction(segment, false /* front */) == GetJunction(s, false);
+      bool const haveSameFront = GetJunction(edgeSegment, true /* front */) == GetJunction(s, true);
+      bool const haveSameBack = GetJunction(edgeSegment, false /* front */) == GetJunction(s, false);
       if ((isOutgoing && haveSameBack) || (!isOutgoing && haveSameFront))
         fakeFromReal.emplace_back(s, edge.GetWeight());
     }


### PR DESCRIPTION
Исправила ошибку поиска фейковых сегментов, соответствующих реальным.
Если мы ищем исходящие сегменты, то back фейкового и соответствующего ему реального должен совпадать, если входящие то front. До этого тут по ошибки вместо соответствующего реального использовался исходный сегмент, для которого ищем входящие/исходящие.

Это условие можно переформулировать как
```C++
bool const frontConnectedToBack = GetJunction(segment, true /* front */) == GetJunction(s, false);
bool const backConnectedToFront = GetJunction(segment, false /* front */) == GetJunction(s, true);
if ((isOutgoing && frontConnectedToBack) || (!isOutgoing && backConnectedToFront))
{
...
}
```
но думаю haveSameFront, haveSameBack понятнее.