### PR TITLE
Clipping transit graph by mwm border.

### DIFF
--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -21,7 +21,9 @@ set(
   srtm_parser_test.cpp
   tag_admixer_test.cpp
   tesselator_test.cpp
+  transit_graph_test.cpp
   transit_test.cpp
+  transit_tools.hpp
   triangles_tree_coding_test.cpp
   types_helper.hpp
   ugc_test.cpp

--- a/generator/generator_tests/generator_tests.pro
+++ b/generator/generator_tests/generator_tests.pro
@@ -51,6 +51,8 @@ SOURCES += \
     srtm_parser_test.cpp \
     tag_admixer_test.cpp \
     tesselator_test.cpp \
+    transit_graph_test.cpp \
     transit_test.cpp \
+    transit_tools.hpp \
     triangles_tree_coding_test.cpp \
     ugc_test.cpp \

--- a/generator/generator_tests/transit_graph_test.cpp
+++ b/generator/generator_tests/transit_graph_test.cpp
@@ -1,0 +1,539 @@
+#include "testing/testing.hpp"
+
+#include "generator/generator_tests/transit_tools.hpp"
+
+#include "generator/transit_generator.hpp"
+
+#include "routing_common/transit_types.hpp"
+
+#include <std/unique_ptr.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace routing;
+using namespace routing::transit;
+using namespace std;
+
+namespace
+{
+//             ^
+//             |
+//             * 2
+//
+//   s0--------s1--------s2--------s3---s4 Line 1
+//
+//   *    *    *    *    *    *    *    *   -->
+//  -2         0              3    4    5
+//        s5--------s6 Line 2
+//
+void TestStops(vector<Stop> const & stops)
+{
+  vector<Stop> const expectedStops = {
+      {0 /* stop id */, 100 /* osm id */, 10 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(-2.0, 1.0), {}},
+      {1 /* stop id */, 101 /* osm id */, 11 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(0.0, 1.0), {}},
+      {2 /* stop id */, 102 /* osm id */, 12 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(2.0, 1.0), {}},
+      {3 /* stop id */, 103 /* osm id */, 13 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(4.0, 1.0), {}},
+      {4 /* stop id */, 104 /* osm id */, 14 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(5.0, 1.0), {}},
+      {5 /* stop id */, 105 /* osm id */, 15 /* feature id */, kInvalidTransferId, {2} /* line ids */,
+       m2::PointD(-1.0, -1.0), {}},
+      {6 /* stop id */, 106 /* osm id */, 16 /* feature id */, kInvalidTransferId, {2} /* line ids */,
+       m2::PointD(1.0, -1.0), {}}};
+  TestForEquivalence(stops, expectedStops);
+}
+
+void TestLines(vector<Line> const & lines)
+{
+  vector<Line> const expectedLines = {
+      {1 /* line id */, "1" /* number */, "Московская линия" /* title */, "subway" /* type */, "green",
+       2 /* network id */, {{0, 1, 2, 3, 4}} /* stop id */,
+       150 /* interval */},
+      {2 /* line id */, "2" /* number */, "Варшавская линия" /* title */, "subway" /* type */, "red",
+       2 /* network id */, {{5, 6}} /* stop id */,
+       150 /* interval */}
+  };
+  TestForEquivalence(lines, expectedLines);
+}
+
+void TestTransfers(vector<Transfer> const & transfers)
+{
+  TEST(transfers.empty(), ());
+}
+
+void TestNetworks(vector<Network> const & networks)
+{
+  vector<Network> const expectedNetworks = {
+      {2 /* network id */, "Минский метрополитен" /* title */}
+  };
+  TestForEquivalence(networks, expectedNetworks);
+}
+
+void TestEdges(vector<Edge> const & edges)
+{
+  vector<Edge> const expectedEdges = {
+      {0 /* stop 1 id */, 1 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{0, 1}} /* shape ids */},
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{1, 2}} /* shape ids */},
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{2, 3}} /* shape ids */},
+      {3 /* stop 1 id */, 4 /* stop 2 id */, 10.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{3, 4}} /* shape ids */},
+      {5 /* stop 1 id */, 6 /* stop 2 id */, 20.0 /* weight */, 2 /* line id */, false /* transfer */,
+       {{5, 6}} /* shape ids */}
+  };
+  TestForEquivalence(edges, expectedEdges);
+}
+
+void TestShapes(vector<Shape> const & shapes)
+{
+  vector<Shape> const expectedShapes = {
+      {{0, 1} /* shape id */, {{-2.0, 1.0}, {0.0, 1.0}} /* polyline */},
+      {{1, 2} /* shape id */, {{0.0, 1.0}, {2.0, 1.0}} /* polyline */},
+      {{2, 3} /* shape id */, {{2.0, 1.0}, {4.0, 1.0}} /* polyline */},
+      {{3, 4} /* shape id */, {{4.0, 1.0}, {5.0, 1.0}} /* polyline */},
+      {{5, 6} /* shape id */, {{-1.0, -1.0}, {1.0, -1.0}} /* polyline */}
+  };
+  TestForEquivalence(shapes, expectedShapes);
+}
+
+void TestGates(vector<Gate> const & gates)
+{
+  vector<Gate> const expectedGates = {
+      {100 /* osm id */, 10 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {0} /* stop ids */, m2::PointD(-2.0, 1.0)},
+      {101 /* osm id */, 11 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {1} /* stop ids */, m2::PointD(0.0, 1.0)},
+      {102 /* osm id */, 12 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {2} /* stop ids */, m2::PointD(2.0, 1.0)},
+      {103 /* osm id */, 13 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {3} /* stop ids */, m2::PointD(4.0, 1.0)},
+      {104 /* osm id */, 14 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {4} /* stop ids */, m2::PointD(5.0, 1.0)},
+      {105 /* osm id */, 15 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {5} /* stop ids */, m2::PointD(-1.0, -1.0)},
+      {106 /* osm id */, 16 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {6} /* stop ids */, m2::PointD(1.0, -1.0)},
+  };
+  TestForEquivalence(gates, expectedGates);
+}
+
+void TestGraph(GraphData const & graph)
+{
+  TestStops(graph.GetStops());
+  TestLines(graph.GetLines());
+  TestTransfers(graph.GetTransfers());
+  TestNetworks(graph.GetNetworks());
+  TestEdges(graph.GetEdges());
+  TestShapes(graph.GetShapes());
+  TestGates(graph.GetGates());
+}
+
+unique_ptr<GraphData> CreateGraph()
+{
+  string const jsonBuffer = R"(
+  {
+  "stops": [{
+      "id": 0,
+      "line_ids": [1],
+      "osm_id": "100",
+      "point": { "x": -2.0, "y": 1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 1,
+      "line_ids": [1],
+      "osm_id": "101",
+      "point": { "x": 0.0, "y": 1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 2,
+      "line_ids": [1],
+      "osm_id": "102",
+      "point": { "x": 2.0, "y": 1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 3,
+      "line_ids": [1],
+      "osm_id": "103",
+      "point": { "x": 4.0, "y": 1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 4,
+      "line_ids": [1],
+      "osm_id": "104",
+      "point": { "x": 5.0, "y": 1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 5,
+      "line_ids": [2],
+      "osm_id": "105",
+      "point": { "x": -1.0, "y": -1.0 },
+      "title_anchors": []
+    },
+    {
+      "id": 6,
+      "line_ids": [2],
+      "osm_id": "106",
+      "point": { "x": 1.0, "y": -1.0 },
+      "title_anchors": []
+    }
+  ],
+  "lines": [
+    {
+      "id": 1,
+      "interval": 150,
+      "network_id": 2,
+      "number": "1",
+      "stop_ids": [ 0, 1, 2, 3, 4 ],
+      "title": "Московская линия",
+      "type": "subway",
+      "color": "green"
+    },
+    {
+      "id": 2,
+      "interval": 150,
+      "network_id": 2,
+      "number": "2",
+      "stop_ids": [ 5, 6 ],
+      "title": "Варшавская линия",
+      "type": "subway",
+      "color": "red"
+    }
+  ],
+  "transfers": [ ],
+  "networks": [
+    {
+      "id": 2,
+      "title": "Минский метрополитен"
+    }
+  ],
+  "edges": [
+    {
+      "stop1_id": 0,
+      "stop2_id": 1,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 0, "stop2_id": 1 }],
+      "transfer": false,
+      "weight" : 20
+    },
+    {
+      "stop1_id": 1,
+      "stop2_id": 2,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 1, "stop2_id": 2 }],
+      "transfer": false,
+      "weight" : 20
+    },
+    {
+      "stop1_id": 2,
+      "stop2_id": 3,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 2, "stop2_id": 3 }],
+      "transfer": false,
+      "weight" : 20
+    },
+    {
+      "stop1_id": 3,
+      "stop2_id": 4,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 3, "stop2_id": 4 }],
+      "transfer": false,
+      "weight" : 10
+    },
+    {
+      "stop1_id": 5,
+      "stop2_id": 6,
+      "line_id": 2,
+      "shape_ids": [ { "stop1_id": 5, "stop2_id": 6 }],
+      "transfer": false,
+      "weight" : 20
+    }
+  ],
+  "shapes": [
+    {
+      "id": { "stop1_id": 0, "stop2_id": 1 },
+      "polyline": [
+        { "x": -2.0, "y": 1.0 },
+        { "x": 0.0, "y": 1.0 }
+      ]
+    },
+    {
+      "id": { "stop1_id": 1, "stop2_id": 2 },
+      "polyline": [
+        { "x": 0.0, "y": 1.0 },
+        { "x": 2.0, "y": 1.0 }
+      ]
+    },
+    {
+      "id": { "stop1_id": 2, "stop2_id": 3 },
+      "polyline": [
+        { "x": 2.0, "y": 1.0 },
+        { "x": 4.0, "y": 1.0 }
+      ]
+    },
+    {
+      "id": { "stop1_id": 3, "stop2_id": 4 },
+      "polyline": [
+        { "x": 4.0, "y": 1.0 },
+        { "x": 5.0, "y": 1.0 }
+      ]
+    },
+    {
+      "id": { "stop1_id": 5, "stop2_id": 6 },
+      "polyline": [
+        { "x": -1.0, "y": -1.0 },
+        { "x": 1.0, "y": -1.0 }
+      ]
+    }
+  ],
+  "gates": [
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "100",
+      "point": { "x": -2.0, "y": 1.0 },
+      "stop_ids": [ 0 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "101",
+      "point": { "x": 0.0, "y": 1.0 },
+      "stop_ids": [ 1 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "102",
+      "point": { "x": 2.0, "y": 1.0 },
+      "stop_ids": [ 2 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "103",
+      "point": { "x": 4.0, "y": 1.0 },
+      "stop_ids": [ 3 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "104",
+      "point": { "x": 5.0, "y": 1.0 },
+      "stop_ids": [ 4 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "105",
+      "point": { "x": -1.0, "y": -1.0 },
+      "stop_ids": [ 5 ],
+      "weight": 0
+    },
+    {
+      "entrance": true,
+      "exit": true,
+      "osm_id": "106",
+      "point": { "x": 1.0, "y": -1.0 },
+      "stop_ids": [ 6 ],
+      "weight": 0
+    }
+  ]})";
+
+  unique_ptr<GraphData> graph = make_unique<GraphData>();
+
+  OsmIdToFeatureIdsMap mapping;
+  mapping[osm::Id(100)] = vector<FeatureId>({10});
+  mapping[osm::Id(101)] = vector<FeatureId>({11});
+  mapping[osm::Id(102)] = vector<FeatureId>({12});
+  mapping[osm::Id(103)] = vector<FeatureId>({13});
+  mapping[osm::Id(104)] = vector<FeatureId>({14});
+  mapping[osm::Id(105)] = vector<FeatureId>({15});
+  mapping[osm::Id(106)] = vector<FeatureId>({16});
+
+  my::Json root(jsonBuffer.c_str());
+  CHECK(root.get() != nullptr, ("Cannot parse the json."));
+  graph->DeserializeFromJson(root, mapping);
+  return graph;
+}
+
+UNIT_TEST(ClipGraph_SmokeTest)
+{
+  unique_ptr<GraphData> graph = CreateGraph();
+  graph->Sort();
+  TestGraph(*graph);
+}
+
+//                       ^
+//                       |
+//                       * 4
+//
+//     ------------------* 3-----------Border
+//     |                                   |
+//     |                 * 2               |
+//     |                                   |
+//     |     s0----------s1----------s2----|-----s3----s4 Line 1
+//     |                                   |
+//     *-----*-----*-----*-----*-----*-----*     *     *   -->
+//    -3    -2    -1     0     1     2     3     4     5
+//                 s5----------s6 Line 2
+//
+UNIT_TEST(ClipGraph_OneLineTest)
+{
+  unique_ptr<GraphData> graph = CreateGraph();
+  vector<m2::PointD> points = {{3.0, 3.0}, {3.0, 0.0}, {-3.0, 0.0}, {-3.0, 3.0}, {3.0, 3.0}};
+  graph->ClipGraph({m2::RegionD(move(points))});
+
+  vector<Line> const expectedLines = {
+      {1 /* line id */, "1" /* number */, "Московская линия" /* title */, "subway" /* type */, "green",
+       2 /* network id */, {{0, 1, 2, 3}} /* stop id */,
+       150 /* interval */}
+  };
+  TestForEquivalence(graph->GetLines(), expectedLines);
+
+  vector<Stop> const expectedStops = {
+      {0 /* stop id */, 100 /* osm id */, 10 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(-2.0, 1.0), {}},
+      {1 /* stop id */, 101 /* osm id */, 11 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(0.0, 1.0), {}},
+      {2 /* stop id */, 102 /* osm id */, 12 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(2.0, 1.0), {}},
+      {3 /* stop id */, 103 /* osm id */, 13 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(4.0, 1.0), {}}
+  };
+  TestForEquivalence(graph->GetStops(), expectedStops);
+
+  // After clipping GraphData::m_networks field is not changed.
+  TestNetworks(graph->GetNetworks());
+
+  vector<Gate> const expectedGates = {
+      {100 /* osm id */, 10 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {0} /* stop ids */, m2::PointD(-2.0, 1.0)},
+      {101 /* osm id */, 11 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {1} /* stop ids */, m2::PointD(0.0, 1.0)},
+      {102 /* osm id */, 12 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {2} /* stop ids */, m2::PointD(2.0, 1.0)},
+      {103 /* osm id */, 13 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {3} /* stop ids */, m2::PointD(4.0, 1.0)}
+  };
+  TestForEquivalence(graph->GetGates(), expectedGates);
+
+  // After clipping GraphData::m_networks field is not changed.
+  TestTransfers(graph->GetTransfers());
+
+  vector<Edge> const expectedEdges = {
+      {0 /* stop 1 id */, 1 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{0, 1}} /* shape ids */},
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{1, 2}} /* shape ids */},
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{2, 3}} /* shape ids */}
+  };
+  TestForEquivalence(graph->GetEdges(), expectedEdges);
+
+  vector<Shape> const expectedShapes = {
+      {{0, 1} /* shape id */, {{-2.0, 1.0}, {0.0, 1.0}} /* polyline */},
+      {{1, 2} /* shape id */, {{0.0, 1.0}, {2.0, 1.0}} /* polyline */},
+      {{2, 3} /* shape id */, {{2.0, 1.0}, {4.0, 1.0}} /* polyline */}
+  };
+  TestForEquivalence(graph->GetShapes(), expectedShapes);
+}
+
+//                       ^
+//                       |
+//                       * 3
+//
+//                       * 2----------Border
+//                          |           |
+//           s0----------s1-|--------s2-|--------s3----s4 Line 1
+//                          |           |
+//     *     *     *     *  |  *     *  |  *     *     *   -->
+//    -3    -2    -1     0  |  1     2  |  3     4     5
+//         Line 2  s5-------|--s6       |
+//                          |           |
+//                   -2  *  -------------
+//
+UNIT_TEST(ClipGraph_TwoLinesTest)
+{
+  unique_ptr<GraphData> graph = CreateGraph();
+  vector<m2::PointD> points = {{2.5, 2.0}, {2.5, -2.0}, {0.5, -2.0}, {0.5, 2.0}, {2.5, 2.0}};
+  graph->ClipGraph({m2::RegionD(move(points))});
+
+  vector<Line> const expectedLines = {
+      {1 /* line id */, "1" /* number */, "Московская линия" /* title */, "subway" /* type */, "green",
+       2 /* network id */, {{1, 2, 3}} /* stop id */,
+       150 /* interval */},
+      {2 /* line id */, "2" /* number */, "Варшавская линия" /* title */, "subway" /* type */, "red",
+       2 /* network id */, {{5, 6}} /* stop id */,
+       150 /* interval */}
+  };
+  TestForEquivalence(graph->GetLines(), expectedLines);
+
+  vector<Stop> const expectedStops = {
+      {1 /* stop id */, 101 /* osm id */, 11 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(0.0, 1.0), {}},
+      {2 /* stop id */, 102 /* osm id */, 12 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(2.0, 1.0), {}},
+      {3 /* stop id */, 103 /* osm id */, 13 /* feature id */, kInvalidTransferId, {1} /* line ids */,
+       m2::PointD(4.0, 1.0), {}},
+      {5 /* stop id */, 105 /* osm id */, 15 /* feature id */, kInvalidTransferId, {2} /* line ids */,
+       m2::PointD(-1.0, -1.0), {}},
+      {6 /* stop id */, 106 /* osm id */, 16 /* feature id */, kInvalidTransferId, {2} /* line ids */,
+       m2::PointD(1.0, -1.0), {}}};
+  TestForEquivalence(graph->GetStops(), expectedStops);
+
+  // After clipping GraphData::m_networks field is not changed.
+  TestNetworks(graph->GetNetworks());
+
+  vector<Gate> const expectedGates = {
+      {101 /* osm id */, 11 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {1} /* stop ids */, m2::PointD(0.0, 1.0)},
+      {102 /* osm id */, 12 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {2} /* stop ids */, m2::PointD(2.0, 1.0)},
+      {103 /* osm id */, 13 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {3} /* stop ids */, m2::PointD(4.0, 1.0)},
+      {105 /* osm id */, 15 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {5} /* stop ids */, m2::PointD(-1.0, -1.0)},
+      {106 /* osm id */, 16 /* feature id */, true /* entrance */, true /* exit */, 0 /* weight */,
+       {6} /* stop ids */, m2::PointD(1.0, -1.0)},
+  };
+  TestForEquivalence(graph->GetGates(), expectedGates);
+
+  // After clipping GraphData::m_networks field is not changed.
+  TestTransfers(graph->GetTransfers());
+
+  vector<Edge> const expectedEdges = {
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{1, 2}} /* shape ids */},
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+       {{2, 3}} /* shape ids */},
+      {5 /* stop 1 id */, 6 /* stop 2 id */, 20.0 /* weight */, 2 /* line id */, false /* transfer */,
+       {{5, 6}} /* shape ids */}
+  };
+  TestForEquivalence(graph->GetEdges(), expectedEdges);
+
+  vector<Shape> const expectedShapes = {
+      {{1, 2} /* shape id */, {{0.0, 1.0}, {2.0, 1.0}} /* polyline */},
+      {{2, 3} /* shape id */, {{2.0, 1.0}, {4.0, 1.0}} /* polyline */},
+      {{5, 6} /* shape id */, {{-1.0, -1.0}, {1.0, -1.0}} /* polyline */}
+  };
+  TestForEquivalence(graph->GetShapes(), expectedShapes);
+}
+}  // namespace

--- a/generator/generator_tests/transit_graph_test.cpp
+++ b/generator/generator_tests/transit_graph_test.cpp
@@ -6,7 +6,7 @@
 
 #include "routing_common/transit_types.hpp"
 
-#include <std/unique_ptr.hpp>
+#include "base/stl_add.hpp"
 
 #include <memory>
 #include <string>
@@ -357,7 +357,7 @@ unique_ptr<GraphData> CreateGraph()
     }
   ]})";
 
-  unique_ptr<GraphData> graph = make_unique<GraphData>();
+  unique_ptr<GraphData> graph = my::make_unique<GraphData>();
 
   OsmIdToFeatureIdsMap mapping;
   mapping[osm::Id(100)] = vector<FeatureId>({10});

--- a/generator/generator_tests/transit_graph_test.cpp
+++ b/generator/generator_tests/transit_graph_test.cpp
@@ -357,7 +357,7 @@ unique_ptr<GraphData> CreateGraph()
     }
   ]})";
 
-  unique_ptr<GraphData> graph = my::make_unique<GraphData>();
+  auto graph = my::make_unique<GraphData>();
 
   OsmIdToFeatureIdsMap mapping;
   mapping[osm::Id(100)] = vector<FeatureId>({10});
@@ -376,7 +376,7 @@ unique_ptr<GraphData> CreateGraph()
 
 UNIT_TEST(ClipGraph_SmokeTest)
 {
-  unique_ptr<GraphData> graph = CreateGraph();
+  auto graph = CreateGraph();
   graph->Sort();
   TestGraph(*graph);
 }
@@ -397,7 +397,7 @@ UNIT_TEST(ClipGraph_SmokeTest)
 //
 UNIT_TEST(ClipGraph_OneLineTest)
 {
-  unique_ptr<GraphData> graph = CreateGraph();
+  auto graph = CreateGraph();
   vector<m2::PointD> points = {{3.0, 3.0}, {3.0, 0.0}, {-3.0, 0.0}, {-3.0, 3.0}, {3.0, 3.0}};
   graph->ClipGraph({m2::RegionD(move(points))});
 
@@ -472,7 +472,7 @@ UNIT_TEST(ClipGraph_OneLineTest)
 //
 UNIT_TEST(ClipGraph_TwoLinesTest)
 {
-  unique_ptr<GraphData> graph = CreateGraph();
+  auto graph = CreateGraph();
   vector<m2::PointD> points = {{2.5, 2.0}, {2.5, -2.0}, {0.5, -2.0}, {0.5, 2.0}, {2.5, 2.0}};
   graph->ClipGraph({m2::RegionD(move(points))});
 

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -7,8 +7,7 @@
 #include "routing_common/transit_types.hpp"
 
 #include "base/assert.hpp"
-
-#include <std/unique_ptr.hpp>
+#include "base/stl_add.hpp"
 
 #include <memory>
 #include <string>

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -1,11 +1,16 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests/transit_tools.hpp"
+
 #include "generator/transit_generator.hpp"
 
 #include "routing_common/transit_types.hpp"
 
 #include "base/assert.hpp"
 
+#include <std/unique_ptr.hpp>
+
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -17,8 +22,9 @@ using namespace std;
 namespace
 {
 template <typename Obj>
-void TestDeserializerFromJson(string const & jsonBuffer, OsmIdToFeatureIdsMap const & osmIdToFeatureIds,
-                              string const & name, vector<Obj> const & expected)
+void TestDeserializerFromJson(string const & jsonBuffer,
+                              OsmIdToFeatureIdsMap const & osmIdToFeatureIds, string const & name,
+                              vector<Obj> const & expected)
 {
   my::Json root(jsonBuffer.c_str());
   CHECK(root.get() != nullptr, ("Cannot parse the json."));
@@ -29,12 +35,12 @@ void TestDeserializerFromJson(string const & jsonBuffer, OsmIdToFeatureIdsMap co
   deserializer(objects, name.c_str());
 
   TEST_EQUAL(objects.size(), expected.size(), ());
-  for (size_t i = 0; i < objects.size(); ++i)
-    TEST(objects[i].IsEqualForTesting(expected[i]), (i, objects[i], expected[i]));
+  TestForEquivalence(objects, expected);
 }
 
 template <typename Obj>
-void TestDeserializerFromJson(string const & jsonBuffer, string const & name, vector<Obj> const & expected)
+void TestDeserializerFromJson(string const & jsonBuffer, string const & name,
+                              vector<Obj> const & expected)
 {
   return TestDeserializerFromJson(jsonBuffer, OsmIdToFeatureIdsMap(), name, expected);
 }
@@ -260,7 +266,7 @@ UNIT_TEST(DeserializerFromJson_Lines)
                                  Line(19207937 /* line id */, "2" /* number */, "Московская линия" /* title */,
                                       "subway" /* type */, "red" /* color */, 2 /* network id */,
                                       {{246659391, 246659390, 209191855, 209191854, 209191853,
-                                       209191852, 209191851}} /* stop ids */, 150.0 /* interval */)};
+                                        209191852, 209191851}} /* stop ids */, 150.0 /* interval */)};
 
   TestDeserializerFromJson(jsonBuffer, "lines", expected);
 }
@@ -313,13 +319,13 @@ UNIT_TEST(DeserializerFromJson_Shapes)
   ]})";
 
   vector<Shape> const expected = {Shape(ShapeId(209186424 /* stop 1 id */, 248520179 /* stop 2 id */),
-                                  {m2::PointD(27.5762295, 64.256768574044699),
-                                   m2::PointD(27.576325736220355, 64.256879325696005),
-                                   m2::PointD(27.576420780761875, 64.256990221238539),
-                                   m2::PointD(27.576514659541523, 64.257101255242176)} /* polyline */),
+                                        {m2::PointD(27.5762295, 64.256768574044699),
+                                         m2::PointD(27.576325736220355, 64.256879325696005),
+                                         m2::PointD(27.576420780761875, 64.256990221238539),
+                                         m2::PointD(27.576514659541523, 64.257101255242176)} /* polyline */),
                                   Shape(ShapeId(209191850 /* stop 1 id */, 209191851 /* stop 2 id */),
-                                  {m2::PointD(27.554025800000002, 64.250591911669844),
-                                   m2::PointD(27.553906184631536, 64.250633404586054)} /* polyline */)};
+                                        {m2::PointD(27.554025800000002, 64.250591911669844),
+                                         m2::PointD(27.553906184631536, 64.250633404586054)} /* polyline */)};
 
   TestDeserializerFromJson(jsonBuffer, "shapes", expected);
 }

--- a/generator/generator_tests/transit_tools.hpp
+++ b/generator/generator_tests/transit_tools.hpp
@@ -2,6 +2,7 @@
 
 #include "testing/testing.hpp"
 
+#include <cstddef>
 #include <vector>
 
 namespace routing
@@ -9,10 +10,11 @@ namespace routing
 namespace transit
 {
 template<typename Obj>
-void TestForEquivalence(std::vector<Obj> const & objects, std::vector<Obj> const & expected)
+void TestForEquivalence(std::vector<Obj> const & actual, std::vector<Obj> const & expected)
 {
-  for (size_t i = 0; i < objects.size(); ++i)
-    TEST(objects[i].IsEqualForTesting(expected[i]), (i, objects[i], expected[i]));
+  TEST_EQUAL(actual.size(), expected.size(), ());
+  for (size_t i = 0; i < actual.size(); ++i)
+    TEST(actual[i].IsEqualForTesting(expected[i]), (i, actual[i], expected[i]));
 }
 }  // namespace transit
 }  // namespace routing

--- a/generator/generator_tests/transit_tools.hpp
+++ b/generator/generator_tests/transit_tools.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "testing/testing.hpp"
+
+#include <vector>
+
+namespace routing
+{
+namespace transit
+{
+template<typename Obj>
+void TestForEquivalence(std::vector<Obj> const & objects, std::vector<Obj> const & expected)
+{
+  for (size_t i = 0; i < objects.size(); ++i)
+    TEST(objects[i].IsEqualForTesting(expected[i]), (i, objects[i], expected[i]));
+}
+}  // namespace transit
+}  // namespace routing

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -352,10 +352,6 @@ void GraphData::Sort()
 void GraphData::ClipGraph(std::vector<m2::RegionD> const & borders)
 {
   Sort();
-  // @todo(bykoianko) Edge weight should be calculated on transit graph preparation stage.
-  // When it's done it'll be checked at Edge::IsValid() and the call of |CalculateEdgeWeights();|
-  // will be removed.
-  CalculateEdgeWeights();
   CHECK(IsValid(), ());
 
   ClipLines(borders);
@@ -367,21 +363,6 @@ void GraphData::ClipGraph(std::vector<m2::RegionD> const & borders)
   ClipEdges();
   SortVisitor{}(m_edges, nullptr /* name */);
   ClipShapes();
-}
-
-void GraphData::CalculateEdgeWeights()
-{
-  CHECK(is_sorted(m_stops.cbegin(), m_stops.cend()), ());
-  for (auto & e : m_edges)
-  {
-    if (e.GetWeight() != kInvalidWeight)
-      continue;
-
-    Stop const & s1 = FindById(m_stops, e.GetStop1Id());
-    Stop const & s2 = FindById(m_stops, e.GetStop2Id());
-    double const lengthInMeters = MercatorBounds::DistanceOnEarth(s1.GetPoint(), s2.GetPoint());
-    e.SetWeight(lengthInMeters / kTransitAverageSpeedMPS);
-  }
 }
 
 void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, string const & countryId)
@@ -635,10 +616,6 @@ void ProcessGraph(string const & mwmPath, string const & countryId,
 {
   data.CalculateBestPedestrianSegments(mwmPath, countryId);
   data.Sort();
-  // @todo(bykoianko) Edge weight should be calculated on transit graph preparation stage.
-  // When it's done it'll be checked at Edge::IsValid() and the call of |data.CalculateEdgeWeights();|
-  // will be removed.
-  data.CalculateEdgeWeights();
   CHECK(data.IsValid(), (mwmPath));
 }
 

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -123,10 +123,6 @@ public:
   /// \note Before call of the method every line in |m_stopIds| should contain |m_stopIds|
   /// with only one stop range.
   void ClipGraph(std::vector<m2::RegionD> const & borders);
-  /// \brief Calculates and updates |m_edges| by adding valid value for Edge::m_weight
-  /// if it's not valid.
-  /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| must be valid before call.
-  void CalculateEdgeWeights();
   /// \brief Calculates best pedestrian segment for every gate in |m_gates|.
   /// \note All gates in |m_gates| must have a valid |m_point| field before the call.
   void CalculateBestPedestrianSegments(std::string const & mwmPath, std::string const & countryId);

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -4,6 +4,8 @@
 
 #include "routing_common/transit_types.hpp"
 
+#include "storage/index.hpp"
+
 #include "geometry/point2d.hpp"
 #include "geometry/region2d.hpp"
 
@@ -119,7 +121,7 @@ public:
   /// \brief Sorts all class fields by their ids.
   void Sort();
   /// \brief Removes some items from all the class fields if they are outside |borders|.
-  /// Please see description for the other Crip*() method for excact rules of clipping.
+  /// Please see description for the other Clip*() method for excact rules of clipping.
   /// \note Before call of the method every line in |m_stopIds| should contain |m_stopIds|
   /// with only one stop range.
   void ClipGraph(std::vector<m2::RegionD> const & borders);
@@ -185,7 +187,7 @@ void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const
 
 /// \brief Calculates and adds some information to transit graph (|data|) after deserializing
 /// from json.
-void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
+void ProcessGraph(std::string const & mwmPath, storage::TCountryId const & countryId,
                   OsmIdToFeatureIdsMap const & osmIdToFeatureIdsMap, GraphData & data);
 
 /// \brief Builds the transit section in the mwm based on transit graph in json which represents
@@ -198,7 +200,7 @@ void ProcessGraph(std::string const & mwmPath, std::string const & countryId,
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)
-void BuildTransit(std::string const & mwmDir, std::string const & countryId,
+void BuildTransit(std::string const & mwmDir, storage::TCountryId const & countryId,
                   std::string const & osmIdToFeatureIdsPath, std::string const & transitDir);
 }  // namespace transit
 }  // namespace routing

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -114,6 +114,7 @@ public:
   void AppendTo(GraphData const & rhs);
   void Clear();
   bool IsValid() const;
+  bool IsEmpty() const;
 
   /// \brief Sorts all class fields by their ids.
   void Sort();

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -5,6 +5,7 @@
 #include "routing_common/transit_types.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/region2d.hpp"
 
 #include "base/macros.hpp"
 
@@ -114,8 +115,13 @@ public:
   void Clear();
   bool IsValid() const;
 
-  /// \brief Sorts all class fields except for |m_edges| by their ids.
+  /// \brief Sorts all class fields by their ids.
   void Sort();
+  /// \brief Removes some items from all the class fields if they are outside |borders|.
+  /// Please see description for the other Crip*() method for excact rules of clipping.
+  /// \note Before call of the method every line in |m_stopIds| should contain |m_stopIds|
+  /// with only one stop range.
+  void ClipGraph(std::vector<m2::RegionD> const & borders);
   /// \brief Calculates and updates |m_edges| by adding valid value for Edge::m_weight
   /// if it's not valid.
   /// \note |m_stops|, Edge::m_stop1Id and Edge::m_stop2Id in |m_edges| must be valid before call.
@@ -140,6 +146,30 @@ private:
 
   bool IsUnique() const;
   bool IsSorted() const;
+
+  /// \brief Clipping |m_lines| with |borders|.
+  /// \details After a call of the method the following stop ids in |m_lines| are left:
+  /// * stops inside |borders|
+  /// * stops which are connected with an edge from |m_edges| with stops inside |borders|
+  /// \note Lines without stops are removed from |m_lines|.
+  /// \note Before call of the method every line in |m_lines| should contain |m_stopIds|
+  /// with only one stop range.
+  void ClipLines(std::vector<m2::RegionD> const & borders);
+  /// \brief Removes all stops from |m_stops| which are not contained in |m_lines| at field |m_stopIds|.
+  /// \note Only stops which stop ids contained in |m_lines| will left in |m_stops|
+  /// after call of this method.
+  void ClipStops();
+  /// \brief Removes all networks from |m_networks| which are not contained in |m_lines|
+  /// at field |m_networkId|.
+  void ClipNetworks();
+  /// \brief Removes gates from |m_gates| if there's no stop in |m_stops| with their stop ids.
+  void ClipGates();
+  /// \brief Removes transfers from |m_transfers| if there's no stop in |m_stops| with their stop ids.
+  void ClipTransfer();
+  /// \brief Removes edges from |m_edges| if their ends are not contained in |m_stops|.
+  void ClipEdges();
+  /// \brief Removes all shapes from |m_shapes| which are not reffered form |m_edges|.
+  void ClipShapes();
 
   std::vector<Stop> m_stops;
   std::vector<Gate> m_gates;

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -137,6 +137,7 @@ public:
   Stop(StopId id, OsmId osmId, FeatureId featureId, TransferId transferId,
        std::vector<LineId> const & lineIds, m2::PointD const & point,
        std::vector<TitleAnchor> const & titleAnchors);
+  explicit Stop(StopId id) : m_id(id), m_featureIdentifiers(true /* serializeFeatureIdOnly */) {}
 
   bool operator<(Stop const & rhs) const { return m_id < rhs.m_id; }
   bool operator==(Stop const & rhs) const { return m_id == rhs.m_id; }
@@ -401,6 +402,7 @@ class Network
 public:
   Network() = default;
   Network(NetworkId id, std::string const & title);
+  explicit Network(NetworkId id) : m_id(id), m_title("") {}
 
   bool operator<(Network const & rhs) const { return m_id < rhs.m_id; }
   bool operator==(Network const & rhs) const { return m_id == rhs.m_id; }


### PR DESCRIPTION
Данный PR из всех .transit.json файлов выбирает те элементы, которые лежат в границах указанной mwm-ки.

Кроме того, добавлены тесты, на clipping графа.

Правила по которым выбираются элементы графа:

Генератор получает на вход ряд графов общественного транспорта в виде json (https://confluence.mail.ru/display/MAPSME/Subway+Data+Preparation)
Необходимо уложить в секцию transit в mwm только те вершины графов общественного транспорта, которые попадают в границы обрабатываемой mwm. При этом использовать следующие правила при попадании элементов графа общественного транспорта в mwm:

stops: попадают только те остановки, которые геометрически попадают в границы mwm согласно data/borders/*.poly + все остановки, которые соединены с ними при помощи edges. Если feature id получено быть не может, поскольку stop лежит за пределами mwm, то feature id сохранено не будет;

gates: попадают только входы, хотя бы один из stop, которых попадает в stops, описанный выше. Примечание. Вход может попасть в две соседние mwm-ки и быть продублированным на границах. Геометрическое расположение входа (поле point), при этом не влияет на попадание входа в mwm. Примечание. Osm Id сохраняется в gate, чтоб можно было обеспечить глобально уникальную идентификацию Gates. Примечание. Если gate лежит за пределами mwm, то feature id данного Gate получено и сохранено не будет;

lines: Если хотя бы один stop из линии попадает stops (выше), линия попадает в mwm. Притом список остановок (stop_ids) урезается до тех |stops|, что описаны выше. Рассмотрим особый случай. Представим линию проходящую вдоль границы mwm. Массив stop_ids ее содержит: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10. Допустим, при подготовке остановок для этой mwm ее поле stops оказались остановки: 1, 2, 3; 7, 8, 9. Это означает, что в таблице lines, кросс mwm-ой секции будет находиться массив, массивов stop id:
{1, 2, 3}
{7, 8, 9}

edges: попадают только те дуги, stop1_id и stop2_id будут в stops выше. Поле shape_ids класса Edge при этом не рассматривается

shapes: попадают только те shape-ы, на которые ссылаются дуги из edges. При этом не проверяется, попадают в mwm (в stops) stop1_id и stop2_id из shape id.

networks: попадают только те сети, которые упоминаются в lines

transfers: попадают те transfer, хотя бы один stop из поля stop_ids, которых будут в stops выше.

Замечание о разных графах общественного транспорта, попадающих в mwm. Граф общественного транспорта может попасть в несколько mwm с одной стороны. С другой, в каждую mwm может попасть несколько (от 0 до нескольких) графов общественного транспорта. Сколько бы графов (частей графов) общественного транспорта не попало в mwm, это не потребует дополнительных усилий при роутинге и отрисовке, поскольку id всех сущностей одинаковы. Все графы можно уложить в таблицы, как описано в: https://confluence.mail.ru/display/MAPSME/Subway+Data+Preparation

https://jira.mail.ru/browse/MAPSME-5858

@tatiana-kondakova @ygorshenin @darina PTAL