### PR TITLE
Getting rid of estimator in TransitGraph, TransitGraphLoader

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -282,9 +282,9 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
 
   shared_ptr<VehicleModelInterface> vehicleModel =
       CarModelFactory(countryParentNameGetterFn).GetVehicleModelForCountry(country);
-  IndexGraph graph(GeometryLoader::CreateFromFile(mwmFile, vehicleModel),
-                   EdgeEstimator::Create(VehicleType::Car, vehicleModel->GetMaxSpeed(),
-                                         nullptr /* trafficStash */));
+  IndexGraph graph(
+      GeometryLoader::CreateFromFile(mwmFile, vehicleModel),
+      EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */));
 
   MwmValue mwmValue(LocalCountryFile(path, platform::CountryFile(country), 0 /* version */));
   DeserializeIndexGraph(mwmValue, kCarMask, graph);

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -21,17 +21,21 @@ namespace routing
 class EdgeEstimator
 {
 public:
-  explicit EdgeEstimator(double maxSpeedKMpH);
+  EdgeEstimator(double maxSpeedKMpH, double offroadSpeedKMpH);
   virtual ~EdgeEstimator() = default;
 
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const;
-  // Returns time in seconds it takes to go from point |from| to point |to| along a leap (fake)
-  // edge |from|-|to|.
+  // Estimates time in seconds it takes to go from point |from| to point |to| along a leap (fake)
+  // edge |from|-|to| using real features.
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
   // (|from|, |to|) in road graph.
   // Note 2. The result of the method should be less or equal to CalcHeuristic(|from|, |to|).
   // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
   double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const;
+
+  // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake
+  // edge.
+  double CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const;
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double GetUTurnPenalty() const = 0;
@@ -40,10 +44,16 @@ public:
   // Check wherether leap is allowed on specified mwm or not.
   virtual bool LeapIsAllowed(NumMwmId mwmId) const = 0;
 
-  static std::shared_ptr<EdgeEstimator> Create(VehicleType, double maxSpeedKMpH,
+  static std::shared_ptr<EdgeEstimator> Create(VehicleType vehicleType, double maxSpeedKMpH,
+                                               double offroadSpeedKMpH,
+                                               std::shared_ptr<TrafficStash>);
+
+  static std::shared_ptr<EdgeEstimator> Create(VehicleType vehicleType,
+                                               VehicleModelInterface const & vehicleModel,
                                                std::shared_ptr<TrafficStash>);
 
 private:
   double const m_maxSpeedMPS;
+  double const m_offroadSpeedMPS;
 };
 }  // namespace routing

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -1,10 +1,10 @@
 #include "routing/fake_ending.hpp"
 
-#include "routing/edge_estimator.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/world_graph.hpp"
 
 #include "geometry/distance.hpp"
+#include "geometry/mercator.hpp"
 
 #include "base/math.hpp"
 
@@ -15,55 +15,47 @@ using namespace std;
 
 namespace
 {
-template <typename Estimator>
 Junction CalcProjectionToSegment(Junction const & begin, Junction const & end,
-                                 m2::PointD const & point, Estimator && estimator)
+                                 m2::PointD const & point)
 {
   m2::ProjectionToSection<m2::PointD> projection;
 
   projection.SetBounds(begin.GetPoint(), end.GetPoint());
   auto const projectedPoint = projection(point);
-  auto const distBeginToEnd = estimator(begin.GetPoint(), end.GetPoint());
+  auto const distBeginToEnd = MercatorBounds::DistanceOnEarth(begin.GetPoint(), end.GetPoint());
 
   double constexpr kEpsMeters = 2.0;
   if (my::AlmostEqualAbs(distBeginToEnd, 0.0, kEpsMeters))
     return Junction(projectedPoint, begin.GetAltitude());
 
-  auto const distBeginToProjection = estimator(begin.GetPoint(), projectedPoint);
+  auto const distBeginToProjection =
+      MercatorBounds::DistanceOnEarth(begin.GetPoint(), projectedPoint);
   auto const altitude = begin.GetAltitude() + (end.GetAltitude() - begin.GetAltitude()) *
                                                   distBeginToProjection / distBeginToEnd;
   return Junction(projectedPoint, altitude);
 }
 
-template <typename Estimator>
-FakeEnding MakeFakeEndingImpl(Junction const & backJunction, Junction const & frontJunction,
-                              Segment const & segment, m2::PointD const & point, bool oneWay,
-                              Estimator && estimator)
+FakeEnding MakeFakeEndingImpl(Junction const & segmentBack, Junction const & segmentFront,
+                              Segment const & segment, m2::PointD const & point, bool oneWay)
 {
-  auto const & projectedJunction =
-      CalcProjectionToSegment(backJunction, frontJunction, point, forward<Estimator>(estimator));
+  auto const & projectedJunction = CalcProjectionToSegment(segmentBack, segmentFront, point);
 
   FakeEnding ending;
   ending.m_originJunction = Junction(point, projectedJunction.GetAltitude());
-  ending.m_projections.emplace_back(segment, oneWay, frontJunction, backJunction,
-                                    projectedJunction);
+  ending.m_projections.emplace_back(segment, oneWay, segmentFront, segmentBack, projectedJunction);
   return ending;
 }
 }  // namespace
 
 namespace routing
 {
-FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
-                          EdgeEstimator const & estimator, IndexGraph & graph)
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, IndexGraph & graph)
 {
   auto const & road = graph.GetGeometry().GetRoad(segment.GetFeatureId());
   bool const oneWay = road.IsOneWay();
   auto const & frontJunction = road.GetJunction(segment.GetPointId(true /* front */));
   auto const & backJunction = road.GetJunction(segment.GetPointId(false /* front */));
-  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, oneWay,
-                            [&](m2::PointD const & p1, m2::PointD const & p2) {
-                              return estimator.CalcLeapWeight(p1, p2);
-                            });
+  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, oneWay);
 }
 
 FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, WorldGraph & graph)
@@ -71,9 +63,6 @@ FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, Wor
   bool const oneWay = graph.IsOneWay(segment.GetMwmId(), segment.GetFeatureId());
   auto const & frontJunction = graph.GetJunction(segment, true /* front */);
   auto const & backJunction = graph.GetJunction(segment, false /* front */);
-  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, oneWay,
-                            [&](m2::PointD const & p1, m2::PointD const & p2) {
-                              return graph.CalcLeapWeight(p1, p2).GetWeight();
-                            });
+  return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, oneWay);
 }
 }  // namespace routing

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -39,6 +39,5 @@ struct FakeEnding final
 };
 
 FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, WorldGraph & graph);
-FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
-                          EdgeEstimator const & estimator, IndexGraph & graph);
+FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, IndexGraph & graph);
 }  // namespace routing

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -40,6 +40,7 @@ FeaturesRoadGraph::CrossCountryVehicleModel::CrossCountryVehicleModel(
     shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory)
   : m_vehicleModelFactory(vehicleModelFactory)
   , m_maxSpeedKMPH(m_vehicleModelFactory->GetVehicleModel()->GetMaxSpeed())
+  , m_offroadSpeedKMPH(m_vehicleModelFactory->GetVehicleModel()->GetOffroadSpeed())
 {
 }
 
@@ -51,6 +52,11 @@ double FeaturesRoadGraph::CrossCountryVehicleModel::GetSpeed(FeatureType const &
 double FeaturesRoadGraph::CrossCountryVehicleModel::GetMaxSpeed() const
 {
   return m_maxSpeedKMPH;
+}
+
+double FeaturesRoadGraph::CrossCountryVehicleModel::GetOffroadSpeed() const
+{
+  return m_offroadSpeedKMPH;
 }
 
 bool FeaturesRoadGraph::CrossCountryVehicleModel::IsOneWay(FeatureType const & f) const

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -34,6 +34,7 @@ private:
     // VehicleModelInterface overrides:
     double GetSpeed(FeatureType const & f) const override;
     double GetMaxSpeed() const override;
+    double GetOffroadSpeed() const override;
     bool IsOneWay(FeatureType const & f) const override;
     bool IsRoad(FeatureType const & f) const override;
     bool IsTransitAllowed(FeatureType const & f) const override;
@@ -45,6 +46,7 @@ private:
 
     shared_ptr<VehicleModelFactoryInterface> const m_vehicleModelFactory;
     double const m_maxSpeedKMPH;
+    double const m_offroadSpeedKMPH;
 
     mutable map<MwmSet::MwmId, shared_ptr<VehicleModelInterface>> m_cache;
   };

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -76,6 +76,11 @@ double CalcMaxSpeed(NumMwmIds const & numMwmIds,
   return maxSpeed;
 }
 
+double CalcOffroadSpeed(VehicleModelFactoryInterface const & vehicleModelFactory)
+{
+  return vehicleModelFactory.GetVehicleModel()->GetOffroadSpeed();
+}
+
 shared_ptr<VehicleModelFactoryInterface> CreateVehicleModelFactory(
     VehicleType vehicleType, CountryParentNameGetterFn const & countryParentNameGetterFn)
 {
@@ -307,7 +312,7 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
                 m_vehicleModelFactory)
   , m_estimator(EdgeEstimator::Create(
         m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory, m_vehicleType),
-        m_trafficStash))
+        CalcOffroadSpeed(*m_vehicleModelFactory), m_trafficStash))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_index))
 {
   CHECK(!m_name.empty(), ());

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -288,8 +288,8 @@ shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & tr
 
 shared_ptr<EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash)
 {
-  return EdgeEstimator::Create(VehicleType::Car,
-                               CarModelFactory({}).GetVehicleModel()->GetMaxSpeed(), trafficStash);
+  auto const carModel = CarModelFactory({}).GetVehicleModel();
+  return EdgeEstimator::Create(VehicleType::Car, *carModel, trafficStash);
 }
 
 AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & starter,

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -95,8 +95,10 @@ class WeightedEdgeEstimator final : public EdgeEstimator
 {
 public:
   // maxSpeedKMpH doesn't matter, but should be greater then any road speed in all tests.
+  // offroadSpeedKMpH doesn't matter, but should be > 0 and <= maxSpeedKMpH.
   explicit WeightedEdgeEstimator(map<Segment, double> const & segmentWeights)
-    : EdgeEstimator(1e10 /* maxSpeedKMpH */), m_segmentWeights(segmentWeights)
+    : EdgeEstimator(1e10 /* maxSpeedKMpH */, 1.0 /* offroadSpeedKMpH */)
+    , m_segmentWeights(segmentWeights)
   {
   }
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -32,8 +32,10 @@ void SingleVehicleWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoi
     // point. So |isEnter| below should be set to true.
     m_crossMwmGraph->ForEachTransition(
         segment.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
-          edges.emplace_back(transition,
-                             CalcLeapWeight(segmentPoint, GetPoint(transition, isOutgoing)));
+          edges.emplace_back(
+              transition, RouteWeight(m_estimator->CalcLeapWeight(segmentPoint,
+                                                                  GetPoint(transition, isOutgoing)),
+                                      0 /* nontransitCross */));
         });
     return;
   }
@@ -108,10 +110,10 @@ RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment)
                      0 /* nontransitCross */);
 }
 
-RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(m2::PointD const & from,
-                                                    m2::PointD const & to) const
+RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
+                                                       m2::PointD const & to) const
 {
-  return RouteWeight(m_estimator->CalcLeapWeight(from, to), 0 /* nontransitCross */);
+  return RouteWeight(m_estimator->CalcOffroadWeight(from, to), 0 /* nontransitCross */);
 }
 
 bool SingleVehicleWorldGraph::LeapIsAllowed(NumMwmId mwmId) const

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -41,7 +41,7 @@ public:
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
-  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -24,13 +25,13 @@ public:
   static bool IsTransitFeature(uint32_t featureId);
   static bool IsTransitSegment(Segment const & segment);
 
-  explicit TransitGraph(NumMwmId numMwmId) : m_mwmId(numMwmId) {}
+  TransitGraph(NumMwmId numMwmId, std::shared_ptr<EdgeEstimator> estimator);
 
   Junction const & GetJunction(Segment const & segment, bool front) const;
-  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator const & estimator) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
-  void GetTransitEdges(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges,
-                       EdgeEstimator const & estimator) const;
+  void GetTransitEdges(Segment const & segment, bool isOutgoing,
+                       std::vector<SegmentEdge> & edges) const;
   std::set<Segment> const & GetFake(Segment const & real) const;
   bool FindReal(Segment const & fake, Segment & real) const;
 
@@ -65,6 +66,7 @@ private:
 
   static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
   NumMwmId const m_mwmId = kFakeNumMwmId;
+  std::shared_ptr<EdgeEstimator> m_estimator;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;
   std::map<Segment, transit::Edge> m_segmentToEdge;
   std::map<Segment, transit::Gate> m_segmentToGate;

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -50,7 +50,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
     MYTHROW(RoutingException, ("Can't get mwm handle for", file));
 
   my::Timer timer;
-  auto graphPtr = make_unique<TransitGraph>(numMwmId);
+  auto graphPtr = make_unique<TransitGraph>(numMwmId, m_estimator);
   MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
   if (!mwmValue.m_cont.IsExist(TRANSIT_FILE_TAG))
     return graphPtr;
@@ -90,8 +90,7 @@ unique_ptr<TransitGraph> TransitGraphLoader::CreateTransitGraph(NumMwmId numMwmI
       {
         Segment const real(numMwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
                            gateSegment.GetForward());
-        gateEndings.emplace(gate.GetOsmId(),
-                            MakeFakeEnding(real, gate.GetPoint(), *m_estimator, indexGraph));
+        gateEndings.emplace(gate.GetOsmId(), MakeFakeEnding(real, gate.GetPoint(), indexGraph));
       }
     }
 

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -32,7 +32,7 @@ void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bo
 
   if (TransitGraph::IsTransitSegment(segment))
   {
-    transitGraph.GetTransitEdges(segment, isOutgoing, edges, *m_estimator);
+    transitGraph.GetTransitEdges(segment, isOutgoing, edges);
     // TODO (@t.yan) GetTwins for transit edges
 
     Segment real;
@@ -125,7 +125,7 @@ RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment)
   if (TransitGraph::IsTransitSegment(segment))
   {
     TransitGraph & transitGraph = GetTransitGraph(segment.GetMwmId());
-    return transitGraph.CalcSegmentWeight(segment, *m_estimator);
+    return transitGraph.CalcSegmentWeight(segment);
   }
 
   return RouteWeight(m_estimator->CalcSegmentWeight(
@@ -133,9 +133,10 @@ RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment)
                      0 /* nontransitCross */);
 }
 
-RouteWeight TransitWorldGraph::CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const
+RouteWeight TransitWorldGraph::CalcOffroadWeight(m2::PointD const & from,
+                                                 m2::PointD const & to) const
 {
-  return RouteWeight(m_estimator->CalcLeapWeight(from, to), 0 /* nontransitCross */);
+  return RouteWeight(m_estimator->CalcOffroadWeight(from, to), 0 /* nontransitCross */);
 }
 
 bool TransitWorldGraph::LeapIsAllowed(NumMwmId /* mwmId */) const { return false; }

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -46,7 +46,7 @@ public:
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
-  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -67,7 +67,7 @@ public:
   virtual RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) = 0;
   virtual RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) = 0;
   virtual RouteWeight CalcSegmentWeight(Segment const & segment) = 0;
-  virtual RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
+  virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual bool LeapIsAllowed(NumMwmId mwmId) const = 0;
 
   // Returns transit-specific information for segment. For nontransit segments returns nullptr.

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -49,6 +49,7 @@ double constexpr kSpeedPedestrianKMpH = 5.0;
 double constexpr kSpeedFootwayKMpH = 7.0;
 double constexpr kSpeedPlatformKMpH = 3.0;
 double constexpr kSpeedPierKMpH = 7.0;
+double constexpr kSpeedOffroadKMpH = 3.0;
 
 // Default
 VehicleModel::InitListT const g_bicycleLimitsDefault =
@@ -469,6 +470,8 @@ bool BicycleModel::IsOneWay(FeatureType const & f) const
   return VehicleModel::IsOneWay(f);
 }
 
+double BicycleModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+
 // If one of feature types will be disabled for bicycles, features of this type will be simplyfied
 // in generator. Look FeatureBuilder1::IsRoad() for more details.
 // static
@@ -509,5 +512,4 @@ BicycleModelFactory::BicycleModelFactory(
   m_models["United Kingdom"] = make_shared<BicycleModel>(g_bicycleLimitsUK);
   m_models["United States of America"] = make_shared<BicycleModel>(g_bicycleLimitsUS);
 }
-
 }  // routing

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -11,8 +11,9 @@ public:
   BicycleModel();
   BicycleModel(VehicleModel::InitListT const & speedLimits);
 
-  /// VehicleModel overrides:
+  /// VehicleModelInterface overrides:
   bool IsOneWay(FeatureType const & f) const override;
+  double GetOffroadSpeed() const override;
 
   static BicycleModel const & AllLimitsInstance();
 

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -38,6 +38,7 @@ double constexpr kSpeedFerryMotorcarVehicleKMpH = 15.0;
 double constexpr kSpeedRailMotorcarVehicleKMpH = 25.0;
 double constexpr kSpeedShuttleTrainKMpH = 25.0;
 double constexpr kSpeedPierKMpH = 10.0;
+double constexpr kSpeedOffroadKMpH = 10.0;
 
 VehicleModel::InitListT const g_carLimitsDefault =
 {
@@ -215,6 +216,8 @@ CarModel::CarModel(VehicleModel::InitListT const & roadLimits)
 {
   InitAdditionalRoadTypes();
 }
+
+double CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void CarModel::InitAdditionalRoadTypes()
 {

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -11,6 +11,9 @@ public:
   CarModel();
   CarModel(VehicleModel::InitListT const & roadLimits);
 
+  // VehicleModelInterface overrides
+  double GetOffroadSpeed() const override;
+
   static CarModel const & AllLimitsInstance();
   static InitListT const & GetLimits();
   static std::vector<AdditionalRoadTags> const & GetAdditionalTags();

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -49,6 +49,7 @@ double constexpr kSpeedPedestrianKMpH = 5.0;
 double constexpr kSpeedFootwayKMpH = 5.0;
 double constexpr kSpeedPlatformKMpH = 5.0;
 double constexpr kSpeedPierKMpH = 4.0;
+double constexpr kSpeedOffroadKMpH = 3.0;
 
 // Default
 VehicleModel::InitListT const g_pedestrianLimitsDefault =
@@ -277,6 +278,8 @@ PedestrianModel::PedestrianModel(VehicleModel::InitListT const & speedLimits)
 {
   Init();
 }
+
+double PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void PedestrianModel::Init()
 {

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -11,8 +11,10 @@ public:
   PedestrianModel();
   PedestrianModel(VehicleModel::InitListT const & speedLimits);
 
-  /// VehicleModel overrides:
+  /// VehicleModelInterface overrides:
   bool IsOneWay(FeatureType const &) const override { return false; }
+  double GetOffroadSpeed() const override;
+
   static PedestrianModel const & AllLimitsInstance();
 
 protected:

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -32,6 +32,9 @@ class TestVehicleModel : public routing::VehicleModel
 
 public:
   TestVehicleModel() : VehicleModel(classif(), s_testLimits) {}
+
+  // We are not going to use offroad routing in these tests.
+  double GetOffroadSpeed() const override { return 0.0; }
 };
 
 uint32_t GetType(char const * s0, char const * s1 = 0, char const * s2 = 0)

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -34,6 +34,10 @@ public:
   /// @returns Max speed in KMpH for this model
   virtual double GetMaxSpeed() const = 0;
 
+  /// @return Offroad speed in KMpH for vehicle. This speed should be used for non-feature routing
+  /// e.g. to connect start point to nearest feature.
+  virtual double GetOffroadSpeed() const = 0;
+
   virtual bool IsOneWay(FeatureType const & f) const = 0;
 
   /// @returns true iff feature |f| can be used for routing with corresponding vehicle model.

--- a/track_analyzing/track_analyzer/cmd_tracks.cpp
+++ b/track_analyzing/track_analyzer/cmd_tracks.cpp
@@ -148,8 +148,8 @@ void CmdTracks(string const & filepath, string const & trackExtension, StringFil
     Geometry geometry(
         GeometryLoader::CreateFromFile(GetCurrentVersionMwmFile(storage, mwmName), vehicleModel));
 
-    shared_ptr<EdgeEstimator> estimator = EdgeEstimator::Create(
-        VehicleType::Car, vehicleModel->GetMaxSpeed(), nullptr /* trafficStash */);
+    shared_ptr<EdgeEstimator> estimator =
+        EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */);
 
     for (auto it : userToMatchedTracks)
     {

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -64,8 +64,7 @@ TrackMatcher::TrackMatcher(storage::Storage const & storage, NumMwmId mwmId,
   MwmSet::MwmHandle const handle = m_index.GetMwmHandleByCountryFile(countryFile);
   m_graph = make_unique<IndexGraph>(
       GeometryLoader::Create(m_index, handle, m_vehicleModel, false /* loadAltitudes */),
-      EdgeEstimator::Create(VehicleType::Car, m_vehicleModel->GetMaxSpeed(),
-                            nullptr /* trafficStash */));
+      EdgeEstimator::Create(VehicleType::Car, *m_vehicleModel, nullptr /* trafficStash */));
 
   DeserializeIndexGraph(*handle.GetValue<MwmValue>(), kCarMask, *m_graph);
 }


### PR DESCRIPTION
В TransitGraph, TransitGraphLoader использовался estimator для оценки веса фейковых пешеходных дуг (part of real для подхода к гейту и дуги от проекции до гейта) и это было ошибкой, так как использовался "быстрый" estimator для общественного транспорта.

Заменила estimator на передачу средней скорости пешехода, так как единственное что нужно от estimator -- оценивать LeapWeight, ради этого тащить второй пешеходный эстиматор мне показалось излишним.

Кроме того, выпилила estimator из кода создания FakeEnding, там он на самом деле был не нужен -- нужно только сравнить расстояние, это можно сделать напрямую без estimator.