### PR TITLE
[indexer] [search] Enabled the Persian language for categories.

### DIFF
--- a/indexer/categories_holder.cpp
+++ b/indexer/categories_holder.cpp
@@ -179,7 +179,8 @@ vector<CategoriesHolder::Mapping> const CategoriesHolder::kLocaleMapping = {{"en
                                                                             {"fi", 27},
                                                                             {"el", 28},
                                                                             {"he", 29},
-                                                                            {"sw", 30}};
+                                                                            {"sw", 30},
+                                                                            {"fa", 31}};
 vector<string> CategoriesHolder::kDisabledLanguages = {"el", "he", "sw"};
 
 CategoriesHolder::CategoriesHolder(unique_ptr<Reader> && reader)

--- a/indexer/categories_holder.hpp
+++ b/indexer/categories_holder.hpp
@@ -65,7 +65,7 @@ private:
 public:
   static int8_t constexpr kEnglishCode = 1;
   static int8_t constexpr kUnsupportedLocaleCode = -1;
-  static uint8_t constexpr kMaxSupportedLocaleIndex = 30;
+  static uint8_t constexpr kMaxSupportedLocaleIndex = 31;
   static vector<Mapping> const kLocaleMapping;
 
   // List of languages that are currently disabled in the application


### PR DESCRIPTION
To make #7526 work.