### PR TITLE
[routing] Fix access tags combination

### DIFF
--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -33,7 +33,9 @@ public:
 
 private:
   VehicleType m_vehicleType;
-  TagMapping const * m_tagMapping;
+  // Order of tag mappings in m_tagMappings is from more to less specific.
+  // e.g. for car: motorcar, motorvehicle, vehicle, general access tags.
+  std::vector<TagMapping const *> m_tagMappings;
 };
 
 class RoadAccessWriter

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -287,7 +287,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
                                          nullptr /* trafficStash */));
 
   MwmValue mwmValue(LocalCountryFile(path, platform::CountryFile(country), 0 /* version */));
-  DeserializeIndexGraph(mwmValue, kCarMask, graph);
+  DeserializeIndexGraph(mwmValue, VehicleType::Car, graph);
 
   map<Segment, map<Segment, RouteWeight>> weights;
   auto const numEnters = connector.GetEnters().size();

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -27,5 +27,5 @@ public:
       std::shared_ptr<EdgeEstimator> estimator, Index & index);
 };
 
-void DeserializeIndexGraph(MwmValue const & mwmValue, VehicleMask vehicleMask, IndexGraph & graph);
+void DeserializeIndexGraph(MwmValue const & mwmValue, VehicleType vehicleType, IndexGraph & graph);
 }  // namespace routing

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -67,7 +67,7 @@ TrackMatcher::TrackMatcher(storage::Storage const & storage, NumMwmId mwmId,
       EdgeEstimator::Create(VehicleType::Car, m_vehicleModel->GetMaxSpeed(),
                             nullptr /* trafficStash */));
 
-  DeserializeIndexGraph(*handle.GetValue<MwmValue>(), kCarMask, *m_graph);
+  DeserializeIndexGraph(*handle.GetValue<MwmValue>(), VehicleType::Car, *m_graph);
 }
 
 void TrackMatcher::MatchTrack(vector<DataPoint> const & track, vector<MatchedTrack> & matchedTracks)


### PR DESCRIPTION
Исправила определение RoadAccess для ситуаций типа
```
access=no
foot=yes
```
PR содержит два коммита:
1. Доработка генератора, чтобы теги, имеющие отношение к конкретному типу транспорта учитывались с большим приоритетом чем просто тег access.
2. Независимо от типа транспорта считывался RoadAccess для VehicleType::Car, поменяла чтобы читался нужный тип.