### PR TITLE
Transit section optimization.

### DIFF
--- a/generator/generator_tests/transit_graph_test.cpp
+++ b/generator/generator_tests/transit_graph_test.cpp
@@ -78,15 +78,15 @@ void TestNetworks(vector<Network> const & networks)
 void TestEdges(vector<Edge> const & edges)
 {
   vector<Edge> const expectedEdges = {
-      {0 /* stop 1 id */, 1 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {0 /* stop 1 id */, 1 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{0, 1}} /* shape ids */},
-      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{1, 2}} /* shape ids */},
-      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{2, 3}} /* shape ids */},
-      {3 /* stop 1 id */, 4 /* stop 2 id */, 10.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {3 /* stop 1 id */, 4 /* stop 2 id */, 10 /* weight */, 1 /* line id */, false /* transfer */,
        {{3, 4}} /* shape ids */},
-      {5 /* stop 1 id */, 6 /* stop 2 id */, 20.0 /* weight */, 2 /* line id */, false /* transfer */,
+      {5 /* stop 1 id */, 6 /* stop 2 id */, 20 /* weight */, 2 /* line id */, false /* transfer */,
        {{5, 6}} /* shape ids */}
   };
   TestForEquivalence(edges, expectedEdges);
@@ -439,11 +439,11 @@ UNIT_TEST(ClipGraph_OneLineTest)
   TestTransfers(graph->GetTransfers());
 
   vector<Edge> const expectedEdges = {
-      {0 /* stop 1 id */, 1 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {0 /* stop 1 id */, 1 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{0, 1}} /* shape ids */},
-      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{1, 2}} /* shape ids */},
-      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{2, 3}} /* shape ids */}
   };
   TestForEquivalence(graph->GetEdges(), expectedEdges);
@@ -520,11 +520,11 @@ UNIT_TEST(ClipGraph_TwoLinesTest)
   TestTransfers(graph->GetTransfers());
 
   vector<Edge> const expectedEdges = {
-      {1 /* stop 1 id */, 2 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {1 /* stop 1 id */, 2 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{1, 2}} /* shape ids */},
-      {2 /* stop 1 id */, 3 /* stop 2 id */, 20.0 /* weight */, 1 /* line id */, false /* transfer */,
+      {2 /* stop 1 id */, 3 /* stop 2 id */, 20 /* weight */, 1 /* line id */, false /* transfer */,
        {{2, 3}} /* shape ids */},
-      {5 /* stop 1 id */, 6 /* stop 2 id */, 20.0 /* weight */, 2 /* line id */, false /* transfer */,
+      {5 /* stop 1 id */, 6 /* stop 2 id */, 20 /* weight */, 2 /* line id */, false /* transfer */,
        {{5, 6}} /* shape ids */}
   };
   TestForEquivalence(graph->GetEdges(), expectedEdges);

--- a/generator/generator_tests/transit_test.cpp
+++ b/generator/generator_tests/transit_test.cpp
@@ -138,10 +138,10 @@ UNIT_TEST(DeserializerFromJson_Gates)
 
   vector<Gate> const expected = {
       Gate(46116860 /* osm id */, 0 /* feature id */, true /* entrance */,
-           true /* exit */, 60.0 /* weight */, {442018474} /* stop ids */,
+           true /* exit */, 60 /* weight */, {442018474} /* stop ids */,
            {43.8594864, 68.33320554776377} /* point */),
       Gate(18446744073709551615ULL /* osm id */, 2 /* feature id */, true /* entrance */,
-           true /* exit */, 60.0 /* weight */, {442018465} /* stop ids */,
+           true /* exit */, 60 /* weight */, {442018465} /* stop ids */,
            {43.9290544, 68.41120791512581} /* point */)};
 
   OsmIdToFeatureIdsMap mapping;
@@ -176,7 +176,7 @@ UNIT_TEST(DeserializerFromJson_Edges)
       "stop2_id": 442018446,
       "line_id": 72551680,
       "shape_ids": [],
-      "weight" : 345.6,
+      "weight" : 345,
       "stop1_id": 442018445,
       "transfer": false
     }
@@ -186,7 +186,7 @@ UNIT_TEST(DeserializerFromJson_Edges)
       Edge(442018444 /* stop 1 id */, 442018445 /* stop 2 id */, kInvalidWeight /* weight */,
            72551680 /* line id */, false /* transfer */,
            {ShapeId(209186407, 209186410), ShapeId(209186408, 209186411)}),
-      Edge(442018445 /* stop 1 id */, 442018446 /* stop 2 id */, 345.6 /* weight */,
+      Edge(442018445 /* stop 1 id */, 442018446 /* stop 2 id */, 345 /* weight */,
            72551680 /* line id */, false /* transfer */, {} /* shape ids */)};
 
   TestDeserializerFromJson(jsonBuffer, "edges", expected);
@@ -261,11 +261,11 @@ UNIT_TEST(DeserializerFromJson_Lines)
   vector<Line> const expected = {Line(19207936 /* line id */, "1" /* number */, "Московская линия" /* title */,
                                       "subway" /* type */, "green" /* color */, 2 /* network id */,
                                       {{343262691, 343259523, 343252898, 209191847, 2947858576}} /* stop ids */,
-                                      150.0 /* interval */),
+                                      150 /* interval */),
                                  Line(19207937 /* line id */, "2" /* number */, "Московская линия" /* title */,
                                       "subway" /* type */, "red" /* color */, 2 /* network id */,
                                       {{246659391, 246659390, 209191855, 209191854, 209191853,
-                                        209191852, 209191851}} /* stop ids */, 150.0 /* interval */)};
+                                        209191852, 209191851}} /* stop ids */, 150 /* interval */)};
 
   TestDeserializerFromJson(jsonBuffer, "lines", expected);
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -264,7 +264,7 @@ void DeserializerFromJson::operator()(EdgeFlags & edgeFlags, char const * name)
   // Note. Only |transfer| field of |edgeFlags| may be set at this point because the
   // other fields of |edgeFlags| are unknown.
   edgeFlags.SetFlags(0);
-  edgeFlags.SetTransfer(transfer);
+  edgeFlags.m_transfer = transfer;
 }
 
 void DeserializerFromJson::operator()(StopIdRanges & rs, char const * name)

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -257,6 +257,16 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   id.SetOsmId(osmId.EncodedId());
 }
 
+void DeserializerFromJson::operator()(EdgeFlags & edgeFlags, char const * name)
+{
+  bool transfer = false;
+  (*this)(transfer, name);
+  // Note. Only |transfer| field of |edgeFlags| may be set at this point because the
+  // other fields of |edgeFlags| is unknown.
+  edgeFlags.SetFlags(0);
+  edgeFlags.SetTransfer(transfer);
+}
+
 void DeserializerFromJson::operator()(StopIdRanges & rs, char const * name)
 {
   vector<StopId> stopIds;

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -262,7 +262,7 @@ void DeserializerFromJson::operator()(EdgeFlags & edgeFlags, char const * name)
   bool transfer = false;
   (*this)(transfer, name);
   // Note. Only |transfer| field of |edgeFlags| may be set at this point because the
-  // other fields of |edgeFlags| is unknown.
+  // other fields of |edgeFlags| are unknown.
   edgeFlags.SetFlags(0);
   edgeFlags.SetTransfer(transfer);
 }

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -47,8 +47,8 @@ public:
   void operator()(StopIdRanges & rs, char const * name = nullptr);
 
   template <typename T>
-  typename std::enable_if<std::is_same<T, Edge::MonotoneEdgeId>::value ||
-      std::is_same<T, Stop::MonotoneStopId>::value>::type
+  typename std::enable_if<std::is_same<T, Edge::WrappedEdgeId>::value ||
+      std::is_same<T, Stop::WrappedStopId>::value>::type
   operator()(T & t, char const * name = nullptr)
   {
     typename T::RepType id;
@@ -76,8 +76,8 @@ public:
 
   template <typename T>
   typename std::enable_if<std::is_class<T>::value &&
-                          !std::is_same<T, Edge::MonotoneEdgeId>::value &&
-                          !std::is_same<T, Stop::MonotoneStopId>::value>::type
+                          !std::is_same<T, Edge::WrappedEdgeId>::value &&
+                          !std::is_same<T, Stop::WrappedStopId>::value>::type
   operator()(T & t, char const * name = nullptr)
   {
     if (name != nullptr && json_is_object(m_node))

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -43,6 +43,7 @@ public:
   void operator()(std::string & s, char const * name = nullptr) { GetField(s, name); }
   void operator()(m2::PointD & p, char const * name = nullptr);
   void operator()(FeatureIdentifiers & id, char const * name = nullptr);
+  void operator()(EdgeFlags & edgeFlags, char const * name = nullptr);
   void operator()(StopIdRanges & rs, char const * name = nullptr);
 
   template <typename T>

--- a/generator/transit_generator.hpp
+++ b/generator/transit_generator.hpp
@@ -46,6 +46,16 @@ public:
   void operator()(StopIdRanges & rs, char const * name = nullptr);
 
   template <typename T>
+  typename std::enable_if<std::is_same<T, Edge::MonotoneEdgeId>::value ||
+      std::is_same<T, Stop::MonotoneStopId>::value>::type
+  operator()(T & t, char const * name = nullptr)
+  {
+    typename T::RepType id;
+    operator()(id, name);
+    t.Set(id);
+  }
+
+  template <typename T>
   void operator()(std::vector<T> & vs, char const * name = nullptr)
   {
     auto * arr = my::GetJSONOptionalField(m_node, name);
@@ -64,8 +74,10 @@ public:
   }
 
   template <typename T>
-  typename std::enable_if<std::is_class<T>::value>::type operator()(T & t,
-                                                                    char const * name = nullptr)
+  typename std::enable_if<std::is_class<T>::value &&
+                          !std::is_same<T, Edge::MonotoneEdgeId>::value &&
+                          !std::is_same<T, Stop::MonotoneStopId>::value>::type
+  operator()(T & t, char const * name = nullptr)
   {
     if (name != nullptr && json_is_object(m_node))
     {

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -175,7 +175,7 @@ UNIT_TEST(Transit_SingleMwmSegmentSerialization)
 UNIT_TEST(Transit_GateSerialization)
 {
   Gate gate(12345678 /* osm id */, 12345 /* feature id */, true /* entrance */, false /* exit */,
-            117.8 /* weight */, {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
+            117 /* weight */, {1, 2, 3} /* stop ids */, {30.0, 50.0} /* point */);
   TestSerialization(gate);
   TEST(gate.IsValid(), (gate));
 }
@@ -186,21 +186,21 @@ UNIT_TEST(Transit_GatesRelational)
                                123 /* feature id */,
                                true /* entrance */,
                                false /* exit */,
-                               1.0 /* weight */,
+                               1 /* weight */,
                                {1, 2, 3} /* stops ids */,
                                m2::PointD(0.0, 0.0)},
                               {12345678 /* osm id */,
                                1234 /* feature id */,
                                true /* entrance */,
                                false /* exit */,
-                               1.0 /* weight */,
+                               1 /* weight */,
                                {1, 2, 3} /* stops ids */,
                                m2::PointD(0.0, 0.0)},
                               {12345678 /* osm id */,
                                1234 /* feature id */,
                                true /* entrance */,
                                false /* exit */,
-                               1.0 /* weight */,
+                               1 /* weight */,
                                {1, 2, 3, 4} /* stops ids */,
                                m2::PointD(0.0, 0.0)}};
   TEST(is_sorted(gates.cbegin(), gates.cend()), ());
@@ -208,7 +208,7 @@ UNIT_TEST(Transit_GatesRelational)
 
 UNIT_TEST(Transit_EdgeSerialization)
 {
-  Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123.4 /* weight */, 11 /* line id */,
+  Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
             false /* transfer */, {ShapeId(1, 2), ShapeId(3, 4), ShapeId(5, 6)} /* shape ids */);
   TestSerialization(edge);
   TEST(edge.IsValid(), (edge));
@@ -227,21 +227,21 @@ UNIT_TEST(Transit_LineSerialization)
   {
     Line line(1 /* line id */, "2" /* number */, "Линия" /* title */,
               "subway" /* type */, "red" /* color */, 3 /* network id */, {{1}} /* stop ids */,
-              10.0 /* interval */);
+              10 /* interval */);
     TestSerialization(line);
     TEST(line.IsValid(), (line));
   }
   {
     Line line(10 /* line id */, "11" /* number */, "Линия" /* title */,
               "subway" /* type */, "green" /* color */, 12 /* network id */,
-              {{13, 14, 15}} /* stop ids */, 15.0 /* interval */);
+              {{13, 14, 15}} /* stop ids */, 15 /* interval */);
     TestSerialization(line);
     TEST(line.IsValid(), (line));
   }
   {
     Line line(100 /* line id */, "101" /* number */, "Линия" /* title */,
               "subway" /* type */, "blue" /* color */, 103 /* network id */,
-              {{1, 2, 3}, {7, 8, 9}} /* stop ids */, 15.0 /* interval */);
+              {{1, 2, 3}, {7, 8, 9}} /* stop ids */, 15 /* interval */);
     TestSerialization(line);
     TEST(line.IsValid(), (line));
   }

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -208,10 +208,30 @@ UNIT_TEST(Transit_GatesRelational)
 
 UNIT_TEST(Transit_EdgeSerialization)
 {
-  Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
-            false /* transfer */, {ShapeId(1, 2), ShapeId(3, 4), ShapeId(5, 6)} /* shape ids */);
-  TestSerialization(edge);
-  TEST(edge.IsValid(), (edge));
+  {
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+              false /* transfer */, {ShapeId(1, 2), ShapeId(3, 4), ShapeId(5, 6)} /* shape ids */);
+    TestSerialization(edge);
+    TEST(edge.IsValid(), (edge));
+  }
+  {
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+              false /* transfer */, {ShapeId(1, 2)} /* shape ids */);
+    TestSerialization(edge);
+    TEST(edge.IsValid(), (edge));
+  }
+  {
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+              false /* transfer */, {ShapeId(2, 1)} /* shape ids */);
+    TestSerialization(edge);
+    TEST(edge.IsValid(), (edge));
+  }
+  {
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+              true /* transfer */, {} /* shape ids */);
+    TestSerialization(edge);
+    TEST(edge.IsValid(), (edge));
+  }
 }
 
 UNIT_TEST(Transit_TransferSerialization)

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -227,10 +227,17 @@ UNIT_TEST(Transit_EdgeSerialization)
     TEST(edge.IsValid(), (edge));
   }
   {
-    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, kInvalidLineId,
               true /* transfer */, {} /* shape ids */);
     TestSerialization(edge);
     TEST(edge.IsValid(), (edge));
+  }
+  {
+    Edge edge(1 /* start stop id */, 2 /* finish stop id */, 123 /* weight */, 11 /* line id */,
+              true /* transfer */, {} /* shape ids */);
+    TestSerialization(edge);
+    // Note. A transfer edge (transfer == true) with a valid line id is not allowable.
+    TEST(!edge.IsValid(), (edge));
   }
 }
 

--- a/routing_common/routing_common_tests/transit_test.cpp
+++ b/routing_common/routing_common_tests/transit_test.cpp
@@ -25,13 +25,13 @@ void TestCommonSerialization(Obj const & obj)
   MemWriter<vector<uint8_t>> writer(buffer);
 
   S serializer(writer);
-  obj.Visit(serializer);
+  serializer(obj);
 
   MemReader reader(buffer.data(), buffer.size());
   ReaderSource<MemReader> src(reader);
   Obj deserializedObj;
   D deserializer(src);
-  deserializedObj.Visit(deserializer);
+  deserializer(deserializedObj);
 
   TEST(obj.IsEqualForTesting(deserializedObj), (obj, deserializedObj));
 }

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -135,6 +135,13 @@ public:
     if (flags.IsEmptyShapeIds() || flags.IsShapeIdTheSame() || flags.IsShapeIdReversed())
       return;
 
+    if (flags.IsSingleShapeId())
+    {
+      CHECK_EQUAL(e.GetShapeIds().size(), 1, ());
+      (*this)(e.GetShapeIds()[0]);
+      return;
+    }
+
     (*this)(e.GetShapeIds());
   }
 
@@ -248,16 +255,26 @@ public:
     e.m_shapeIds.clear();
     if (e.m_flags.IsEmptyShapeIds())
       return;
+
     if (e.m_flags.IsShapeIdTheSame())
     {
       e.m_shapeIds.emplace_back(e.GetStop1Id(), e.GetStop2Id());
       return;
     }
+
     if (e.m_flags.IsShapeIdReversed())
     {
       e.m_shapeIds.emplace_back(e.GetStop2Id(), e.GetStop1Id());
       return;
     }
+
+    if (e.m_flags.IsSingleShapeId())
+    {
+      e.m_shapeIds.resize(1 /* single shape id */);
+      (*this)(e.m_shapeIds.back());
+      return;
+    }
+
     (*this)(e.m_shapeIds);
   }
 

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -261,7 +261,12 @@ public:
     (*this)(e.m_shapeIds);
   }
 
-  void operator()(EdgeFlags & f, char const * /* name */ = nullptr) { (*this)(f.m_flags); }
+  void operator()(EdgeFlags & f, char const * /* name */ = nullptr)
+  {
+    uint8_t flags = 0;
+    (*this)(flags);
+    f.SetFlags(flags);
+  }
 
   void operator()(vector<m2::PointD> & vs, char const * /* name */ = nullptr)
   {

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -98,18 +98,18 @@ public:
     }
   }
 
-  void operator()(Edge::MonotoneEdgeId const & t, char const * /* name */ = nullptr)
+  void operator()(Edge::WrappedEdgeId const & id, char const * /* name */ = nullptr)
   {
-    CHECK_GREATER_OR_EQUAL(t.Get(), m_lastEncodedMonotoneEdgeId.Get(), ());
-    WriteVarUint(m_sink, static_cast<uint64_t>(t.Get() - m_lastEncodedMonotoneEdgeId.Get()));
-    m_lastEncodedMonotoneEdgeId = t;
+    CHECK_GREATER_OR_EQUAL(id.Get(), m_lastWrappedEdgeId.Get(), ());
+    WriteVarUint(m_sink, static_cast<uint64_t>(id.Get() - m_lastWrappedEdgeId.Get()));
+    m_lastWrappedEdgeId = id;
   }
 
-  void operator()(Stop::MonotoneStopId const & t, char const * /* name */ = nullptr)
+  void operator()(Stop::WrappedStopId const & id, char const * /* name */ = nullptr)
   {
-    CHECK_GREATER_OR_EQUAL(t.Get(), m_lastEncodedMonotoneStopId.Get(), ());
-    WriteVarUint(m_sink, static_cast<uint64_t>(t.Get() - m_lastEncodedMonotoneStopId.Get()));
-    m_lastEncodedMonotoneStopId = t;
+    CHECK_GREATER_OR_EQUAL(id.Get(), m_lastWrappedStopId.Get(), ());
+    WriteVarUint(m_sink, static_cast<uint64_t>(id.Get() - m_lastWrappedStopId.Get()));
+    m_lastWrappedStopId = id;
   }
 
   void operator()(FeatureIdentifiers const & id, char const * name = nullptr)
@@ -157,8 +157,8 @@ public:
 
 private:
   Sink & m_sink;
-  Edge::MonotoneEdgeId m_lastEncodedMonotoneEdgeId = Edge::MonotoneEdgeId(0);
-  Stop::MonotoneStopId m_lastEncodedMonotoneStopId = Stop::MonotoneStopId(0);
+  Edge::WrappedEdgeId m_lastWrappedEdgeId = {};
+  Stop::WrappedStopId m_lastWrappedStopId = {};
 };
 
 template <typename Source>
@@ -211,16 +211,16 @@ public:
     p = Int64ToPoint(ReadVarInt<int64_t, Source>(m_source), POINT_COORD_BITS);
   }
 
-  void operator()(Edge::MonotoneEdgeId & t, char const * /* name */ = nullptr)
+  void operator()(Edge::WrappedEdgeId & t, char const * /* name */ = nullptr)
   {
-    t = m_lastDecodedMonotoneEdgeId + Edge::MonotoneEdgeId(ReadVarUint<uint64_t, Source>(m_source));
-    m_lastDecodedMonotoneEdgeId = t;
+    t = m_lastWrappedEdgeId + Edge::WrappedEdgeId(ReadVarUint<uint64_t, Source>(m_source));
+    m_lastWrappedEdgeId = t;
   }
 
-  void operator()(Stop::MonotoneStopId & t, char const * /* name */ = nullptr)
+  void operator()(Stop::WrappedStopId & t, char const * /* name */ = nullptr)
   {
-    t = m_lastDecodedMonotoneStopId + Stop::MonotoneStopId(ReadVarUint<uint64_t, Source>(m_source));
-    m_lastDecodedMonotoneStopId = t;
+    t = m_lastWrappedStopId + Stop::WrappedStopId(ReadVarUint<uint64_t, Source>(m_source));
+    m_lastWrappedStopId = t;
   }
 
   void operator()(FeatureIdentifiers & id, char const * name = nullptr)
@@ -294,8 +294,8 @@ public:
 
 private:
   Source & m_source;
-  Edge::MonotoneEdgeId m_lastDecodedMonotoneEdgeId = Edge::MonotoneEdgeId(0);
-  Stop::MonotoneStopId m_lastDecodedMonotoneStopId = Stop::MonotoneStopId(0);
+  Edge::WrappedEdgeId m_lastWrappedEdgeId = {};
+  Stop::WrappedStopId m_lastWrappedStopId = {};
 };
 
 template <typename Sink>

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -127,7 +127,7 @@ public:
     (*this)(e.m_weight);
     (*this)(e.m_lineId);
     // Note. |Edge::m_flags| is not filled fully after deserialization from json.
-    // So it's necessary to it here.
+    // So it's necessary to fill it here.
     EdgeFlags const flags =
         GetEdgeFlags(e.GetTransfer(), e.GetStop1Id(), e.GetStop2Id(), e.GetShapeIds());
     (*this)(flags);

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -211,16 +211,16 @@ public:
     p = Int64ToPoint(ReadVarInt<int64_t, Source>(m_source), POINT_COORD_BITS);
   }
 
-  void operator()(Edge::WrappedEdgeId & t, char const * /* name */ = nullptr)
+  void operator()(Edge::WrappedEdgeId & id, char const * /* name */ = nullptr)
   {
-    t = m_lastWrappedEdgeId + Edge::WrappedEdgeId(ReadVarUint<uint64_t, Source>(m_source));
-    m_lastWrappedEdgeId = t;
+    id = m_lastWrappedEdgeId + Edge::WrappedEdgeId(ReadVarUint<uint64_t, Source>(m_source));
+    m_lastWrappedEdgeId = id;
   }
 
-  void operator()(Stop::WrappedStopId & t, char const * /* name */ = nullptr)
+  void operator()(Stop::WrappedStopId & id, char const * /* name */ = nullptr)
   {
-    t = m_lastWrappedStopId + Stop::WrappedStopId(ReadVarUint<uint64_t, Source>(m_source));
-    m_lastWrappedStopId = t;
+    id = m_lastWrappedStopId + Stop::WrappedStopId(ReadVarUint<uint64_t, Source>(m_source));
+    m_lastWrappedStopId = id;
   }
 
   void operator()(FeatureIdentifiers & id, char const * name = nullptr)

--- a/routing_common/transit_serdes.hpp
+++ b/routing_common/transit_serdes.hpp
@@ -132,10 +132,10 @@ public:
         GetEdgeFlags(e.GetTransfer(), e.GetStop1Id(), e.GetStop2Id(), e.GetShapeIds());
     (*this)(flags);
 
-    if (flags.IsEmptyShapeIds() || flags.IsShapeIdTheSame() || flags.IsShapeIdReversed())
+    if (flags.m_isShapeIdsEmpty || flags.m_isShapeIdsSame || flags.m_isShapeIdsReversed)
       return;
 
-    if (flags.IsSingleShapeId())
+    if (flags.m_isShapeIdsSingle)
     {
       CHECK_EQUAL(e.GetShapeIds().size(), 1, ());
       (*this)(e.GetShapeIds()[0]);
@@ -253,22 +253,22 @@ public:
     (*this)(e.m_flags);
 
     e.m_shapeIds.clear();
-    if (e.m_flags.IsEmptyShapeIds())
+    if (e.m_flags.m_isShapeIdsEmpty)
       return;
 
-    if (e.m_flags.IsShapeIdTheSame())
+    if (e.m_flags.m_isShapeIdsSame)
     {
       e.m_shapeIds.emplace_back(e.GetStop1Id(), e.GetStop2Id());
       return;
     }
 
-    if (e.m_flags.IsShapeIdReversed())
+    if (e.m_flags.m_isShapeIdsReversed)
     {
       e.m_shapeIds.emplace_back(e.GetStop2Id(), e.GetStop1Id());
       return;
     }
 
-    if (e.m_flags.IsSingleShapeId())
+    if (e.m_flags.m_isShapeIdsSingle)
     {
       e.m_shapeIds.resize(1 /* single shape id */);
       (*this)(e.m_shapeIds.back());

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -227,15 +227,41 @@ bool ShapeId::IsValid() const
 }
 
 // EdgeFlags --------------------------------------------------------------------------------------
-void EdgeFlags::SetBit(bool bit, uint8_t bitMask)
+EdgeFlags::EdgeFlags()
+  : m_transfer(0)
+  , m_isShapeIdsEmpty(0)
+  , m_isShapeIdsSingle(0)
+  , m_isShapeIdsSame(0)
+  , m_isShapeIdsReversed(0)
 {
-  if (bit)
-    m_flags |= bitMask;
-  else
-    m_flags &= ~bitMask;
 }
 
-string DebugPrint(EdgeFlags const & f) { return strings::to_string(f.GetFlags()); }
+uint8_t EdgeFlags::GetFlags() const
+{
+  return m_transfer + m_isShapeIdsEmpty * kEmptyShapeIdsMask +
+         m_isShapeIdsSingle * kSingleShapeIdMask + m_isShapeIdsSame * kShapeIdIsSameMask +
+         m_isShapeIdsReversed * kShapeIdIsReversedMask;
+}
+
+void EdgeFlags::SetFlags(uint8_t flags)
+{
+  m_transfer = GetBit(flags, kTransferMask);
+  m_isShapeIdsEmpty = GetBit(flags, kEmptyShapeIdsMask);
+  m_isShapeIdsSingle = GetBit(flags, kSingleShapeIdMask);
+  m_isShapeIdsSame = GetBit(flags, kShapeIdIsSameMask);
+  m_isShapeIdsReversed = GetBit(flags, kShapeIdIsReversedMask);
+}
+
+string DebugPrint(EdgeFlags const & f)
+{
+  std::ostringstream ss;
+  ss << "EdgeFlags [m_transfer:" << f.IsTransfer();
+  ss << ", m_isShapeIdsEmpty:" << f.IsEmptyShapeIds();
+  ss << ", m_isShapeIdsSingle:" << f.IsSingleShapeId();
+  ss << ", m_isShapeIdsSame:" << f.IsShapeIdTheSame();
+  ss << ", m_isShapeIdsReversed:" << f.IsShapeIdReversed() << "]";
+  return ss.str();
+}
 
 // Edge -------------------------------------------------------------------------------------------
 Edge::Edge(StopId stop1Id, StopId stop2Id, Weight weight, LineId lineId, bool transfer,

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -292,16 +292,16 @@ bool Edge::operator==(Edge const & rhs) const
 bool Edge::IsEqualForTesting(Edge const & edge) const
 {
   return m_stop1Id == edge.m_stop1Id && m_stop2Id == edge.m_stop2Id && m_weight == edge.m_weight &&
-         m_lineId == edge.m_lineId && m_flags.IsTransfer() == edge.m_flags.IsTransfer() &&
+         m_lineId == edge.m_lineId && GetTransfer() == edge.GetTransfer() &&
          m_shapeIds == edge.m_shapeIds;
 }
 
 bool Edge::IsValid() const
 {
-  if (m_flags.IsTransfer() && (m_lineId != kInvalidLineId || !m_shapeIds.empty()))
+  if (GetTransfer() && (m_lineId != kInvalidLineId || !m_shapeIds.empty()))
     return false;
 
-  if (!m_flags.IsTransfer() && m_lineId == kInvalidLineId)
+  if (!GetTransfer() && m_lineId == kInvalidLineId)
     return false;
 
   return m_stop1Id.Get() != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight;

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -248,11 +248,11 @@ void EdgeFlags::SetFlags(uint8_t flags)
 string DebugPrint(EdgeFlags const & f)
 {
   std::ostringstream ss;
-  ss << "EdgeFlags [m_transfer:" << f.m_transfer;
-  ss << ", m_isShapeIdsEmpty:" << f.m_isShapeIdsEmpty;
-  ss << ", m_isShapeIdsSingle:" << f.m_isShapeIdsSingle;
-  ss << ", m_isShapeIdsSame:" << f.m_isShapeIdsSame;
-  ss << ", m_isShapeIdsReversed:" << f.m_isShapeIdsReversed << "]";
+  ss << "EdgeFlags [transfer:" << f.m_transfer;
+  ss << ", isShapeIdsEmpty:" << f.m_isShapeIdsEmpty;
+  ss << ", isShapeIdsSingle:" << f.m_isShapeIdsSingle;
+  ss << ", isShapeIdsSame:" << f.m_isShapeIdsSame;
+  ss << ", isShapeIdsReversed:" << f.m_isShapeIdsReversed << "]";
   return ss.str();
 }
 
@@ -388,7 +388,7 @@ EdgeFlags GetEdgeFlags(bool transfer, StopId stopId1, StopId stopId2,
   if (singleShapeId)
   {
     flags.m_isShapeIdsSame =
-        (stopId1 == shapeIds[0].GetStop1Id() && stopId2 == shapeIds[0].GetStop2Id());
+        stopId1 == shapeIds[0].GetStop1Id() && stopId2 == shapeIds[0].GetStop2Id();
     flags.m_isShapeIdsReversed =
         stopId1 == shapeIds[0].GetStop2Id() && stopId2 == shapeIds[0].GetStop1Id();
   }

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -227,20 +227,13 @@ bool ShapeId::IsValid() const
 }
 
 // EdgeFlags --------------------------------------------------------------------------------------
-EdgeFlags::EdgeFlags()
-  : m_transfer(0)
-  , m_isShapeIdsEmpty(0)
-  , m_isShapeIdsSingle(0)
-  , m_isShapeIdsSame(0)
-  , m_isShapeIdsReversed(0)
-{
-}
-
 uint8_t EdgeFlags::GetFlags() const
 {
-  return m_transfer + m_isShapeIdsEmpty * kEmptyShapeIdsMask +
-         m_isShapeIdsSingle * kSingleShapeIdMask + m_isShapeIdsSame * kShapeIdIsSameMask +
-         m_isShapeIdsReversed * kShapeIdIsReversedMask;
+  return BoolToUint(m_transfer) * kTransferMask +
+         BoolToUint(m_isShapeIdsEmpty) * kEmptyShapeIdsMask +
+         BoolToUint(m_isShapeIdsSingle) * kSingleShapeIdMask +
+         BoolToUint(m_isShapeIdsSame) * kShapeIdIsSameMask +
+         BoolToUint(m_isShapeIdsReversed) * kShapeIdIsReversedMask;
 }
 
 void EdgeFlags::SetFlags(uint8_t flags)
@@ -255,11 +248,11 @@ void EdgeFlags::SetFlags(uint8_t flags)
 string DebugPrint(EdgeFlags const & f)
 {
   std::ostringstream ss;
-  ss << "EdgeFlags [m_transfer:" << f.IsTransfer();
-  ss << ", m_isShapeIdsEmpty:" << f.IsEmptyShapeIds();
-  ss << ", m_isShapeIdsSingle:" << f.IsSingleShapeId();
-  ss << ", m_isShapeIdsSame:" << f.IsShapeIdTheSame();
-  ss << ", m_isShapeIdsReversed:" << f.IsShapeIdReversed() << "]";
+  ss << "EdgeFlags [m_transfer:" << f.m_transfer;
+  ss << ", m_isShapeIdsEmpty:" << f.m_isShapeIdsEmpty;
+  ss << ", m_isShapeIdsSingle:" << f.m_isShapeIdsSingle;
+  ss << ", m_isShapeIdsSame:" << f.m_isShapeIdsSame;
+  ss << ", m_isShapeIdsReversed:" << f.m_isShapeIdsReversed << "]";
   return ss.str();
 }
 
@@ -388,16 +381,16 @@ EdgeFlags GetEdgeFlags(bool transfer, StopId stopId1, StopId stopId2,
                        vector<ShapeId> const & shapeIds)
 {
   EdgeFlags flags;
-  flags.SetTransfer(transfer);
-  flags.SetEmptyShapeIds(shapeIds.empty());
+  flags.m_transfer = transfer;
+  flags.m_isShapeIdsEmpty = shapeIds.empty();
   bool const singleShapeId = (shapeIds.size() == 1);
-  flags.SetSingleShapeId(singleShapeId);
+  flags.m_isShapeIdsSingle = singleShapeId;
   if (singleShapeId)
   {
-    flags.SetShapeIdTheSame(stopId1 == shapeIds[0].GetStop1Id() &&
-                            stopId2 == shapeIds[0].GetStop2Id());
-    flags.SetShapeIdReversed(stopId1 == shapeIds[0].GetStop2Id() &&
-                             stopId2 == shapeIds[0].GetStop1Id());
+    flags.m_isShapeIdsSame =
+        (stopId1 == shapeIds[0].GetStop1Id() && stopId2 == shapeIds[0].GetStop2Id());
+    flags.m_isShapeIdsReversed =
+        stopId1 == shapeIds[0].GetStop2Id() && stopId2 == shapeIds[0].GetStop1Id();
   }
   return flags;
 }

--- a/routing_common/transit_types.cpp
+++ b/routing_common/transit_types.cpp
@@ -4,7 +4,6 @@
 
 namespace
 {
-double constexpr kWeightEqualEpsilon = 1e-2;
 double constexpr kPointsEqualEpsilon = 1e-6;
 }  // namespace
 
@@ -143,7 +142,7 @@ bool Stop::IsEqualForTesting(Stop const & stop) const
 
 bool Stop::IsValid() const
 {
-  return m_id != kInvalidStopId && !m_lineIds.empty();
+  return m_id.Get() != kInvalidStopId && !m_lineIds.empty();
 }
 
 // SingleMwmSegment -------------------------------------------------------------------------------
@@ -163,7 +162,7 @@ bool SingleMwmSegment::IsValid() const
 }
 
 // Gate -------------------------------------------------------------------------------------------
-Gate::Gate(OsmId osmId, FeatureId featureId, bool entrance, bool exit, double weight,
+Gate::Gate(OsmId osmId, FeatureId featureId, bool entrance, bool exit, Weight weight,
            std::vector<StopId> const & stopIds, m2::PointD const & point)
   : m_featureIdentifiers(osmId, featureId, false /* serializeFeatureIdOnly */)
   , m_entrance(entrance)
@@ -196,10 +195,8 @@ bool Gate::operator==(Gate const & rhs) const
 
 bool Gate::IsEqualForTesting(Gate const & gate) const
 {
-  return m_featureIdentifiers == gate.m_featureIdentifiers &&
-         m_entrance == gate.m_entrance && m_exit == gate.m_exit &&
-         my::AlmostEqualAbs(m_weight, gate.m_weight, kWeightEqualEpsilon) &&
-         m_stopIds == gate.m_stopIds &&
+  return m_featureIdentifiers == gate.m_featureIdentifiers && m_entrance == gate.m_entrance &&
+         m_exit == gate.m_exit && m_weight == gate.m_weight && m_stopIds == gate.m_stopIds &&
          my::AlmostEqualAbs(m_point, gate.m_point, kPointsEqualEpsilon);
 }
 
@@ -228,7 +225,7 @@ bool ShapeId::IsValid() const
 }
 
 // Edge -------------------------------------------------------------------------------------------
-Edge::Edge(StopId stop1Id, StopId stop2Id, double weight, LineId lineId, bool transfer,
+Edge::Edge(StopId stop1Id, StopId stop2Id, Weight weight, LineId lineId, bool transfer,
            std::vector<ShapeId> const & shapeIds)
   : m_stop1Id(stop1Id)
   , m_stop2Id(stop2Id)
@@ -255,8 +252,7 @@ bool Edge::operator==(Edge const & rhs) const
 
 bool Edge::IsEqualForTesting(Edge const & edge) const
 {
-  return m_stop1Id == edge.m_stop1Id && m_stop2Id == edge.m_stop2Id &&
-         my::AlmostEqualAbs(m_weight, edge.m_weight, kWeightEqualEpsilon) &&
+  return m_stop1Id == edge.m_stop1Id && m_stop2Id == edge.m_stop2Id && m_weight == edge.m_weight &&
          m_lineId == edge.m_lineId && m_transfer == edge.m_transfer &&
          m_shapeIds == edge.m_shapeIds;
 }
@@ -269,7 +265,7 @@ bool Edge::IsValid() const
   if (!m_transfer && m_lineId == kInvalidLineId)
     return false;
 
-  return m_stop1Id != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight;
+  return m_stop1Id.Get() != kInvalidStopId && m_stop2Id != kInvalidStopId && m_weight != kInvalidWeight;
 }
 
 // Transfer ---------------------------------------------------------------------------------------
@@ -310,7 +306,7 @@ bool Line::IsEqualForTesting(Line const & line) const
 {
   return m_id == line.m_id && m_number == line.m_number && m_title == line.m_title &&
          m_type == line.m_type && m_color == line.m_color && m_networkId == line.m_networkId &&
-         m_stopIds == line.m_stopIds && my::AlmostEqualAbs(m_interval, line.m_interval, kWeightEqualEpsilon);
+         m_stopIds == line.m_stopIds && m_interval == line.m_interval;
 }
 
 bool Line::IsValid() const

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -281,7 +281,7 @@ public:
 
 private:
   uint8_t BoolToUint(bool b) const { return static_cast<uint8_t>(b ? 1 : 0); }
-  uint8_t GetBit(uint8_t flags, uint8_t mask) const { return BoolToUint(flags & mask); }
+  uint8_t GetBit(uint8_t flags, uint8_t mask) const { return BoolToUint((flags & mask) != 0); }
 
   static uint8_t constexpr kTransferMask = 1;
   static uint8_t constexpr kEmptyShapeIdsMask = (1 << 1);

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -259,53 +259,36 @@ class EdgeFlags
 {
 public:
   DECLARE_TRANSIT_TYPE_FRIENDS
-
-  EdgeFlags();
-
-  bool IsTransfer() const { return m_transfer == 1; }
-  void SetTransfer(bool transfer) { m_transfer = BoolToUint(transfer); }
-
-  /// \returns true if |Edge::m_shapeIds| is empty.
-  bool IsEmptyShapeIds() const { return m_isShapeIdsEmpty == 1; }
-  void SetEmptyShapeIds(bool emptyShapeIds) { m_isShapeIdsEmpty = BoolToUint(emptyShapeIds); }
-
-  /// \returns true if |Edge::m_shapeIds| contains only one item.
-  bool IsSingleShapeId() const { return m_isShapeIdsSingle == 1; }
-  void SetSingleShapeId(bool singleShapeId) { m_isShapeIdsSingle = BoolToUint(singleShapeId); }
-
-  /// \note It's valid only if IsSingleShapeId() returns true.
-  /// \returns true if
-  /// |Edge::m_stop1Id == m_shapeIds[0].m_stop1Id && Edge::m_stop2Id == m_shapeIds[0].m_stop2Id|.
-  bool IsShapeIdTheSame() const { return m_isShapeIdsSame == 1; }
-  void SetShapeIdTheSame(bool same) { m_isShapeIdsSame = BoolToUint(same); }
-
-  /// \note It's valid only if IsSingleShapeId() returns true.
-  /// \returns true if
-  /// |Edge::m_stop1Id == m_shapeIds[0].m_stop2Id && Edge::m_stop2Id == m_shapeIds[0].m_stop1Id|.
-  bool IsShapeIdReversed() const { return m_isShapeIdsReversed == 1; }
-  void SetShapeIdReversed(bool reversed) { m_isShapeIdsReversed = BoolToUint(reversed); }
+  friend string DebugPrint(EdgeFlags const & f);
 
   uint8_t GetFlags() const;
   void SetFlags(uint8_t flags);
 
+  // |m_transfer == true| if |Edge::m_shapeIds| is empty.
+  bool m_transfer = false;
+  /// |m_isShapeIdsEmpty == true| if |Edge::m_shapeIds| is empty.
+  bool m_isShapeIdsEmpty = false;
+  // |m_isShapeIdsSingle == true| if |Edge::m_shapeIds| contains only one item.
+  bool m_isShapeIdsSingle = false;
+  // Note. If |m_isShapeIdsSingle == true| |m_isShapeIdsSame| is set to
+  // |Edge::m_stop1Id == m_shapeIds[0].m_stop1Id && Edge::m_stop2Id == m_shapeIds[0].m_stop2Id|.
+  // |m_isShapeIdsSingle| is invalid otherwise.
+  bool m_isShapeIdsSame = false;
+  // Note. If |m_isShapeIdsSingle == true| |m_isShapeIdsReversed| is set to
+  // |Edge::m_stop1Id == m_shapeIds[0].m_stop2Id && Edge::m_stop2Id == m_shapeIds[0].m_stop1Id|.
+  // |m_isShapeIdsReversed| is invalid otherwise.
+  bool m_isShapeIdsReversed = false;
+
 private:
-  uint8_t BoolToUint(bool b) { return static_cast<uint8_t>(b ? 1 : 0); }
-  uint8_t GetBit(uint8_t flags, uint8_t mask) { return BoolToUint(flags & mask); }
+  uint8_t BoolToUint(bool b) const { return static_cast<uint8_t>(b ? 1 : 0); }
+  uint8_t GetBit(uint8_t flags, uint8_t mask) const { return BoolToUint(flags & mask); }
 
   static uint8_t constexpr kTransferMask = 1;
   static uint8_t constexpr kEmptyShapeIdsMask = (1 << 1);
   static uint8_t constexpr kSingleShapeIdMask = (1 << 2);
   static uint8_t constexpr kShapeIdIsSameMask = (1 << 3);
   static uint8_t constexpr kShapeIdIsReversedMask = (1 << 4);
-
-  uint8_t m_transfer : 1;
-  uint8_t m_isShapeIdsEmpty : 1;
-  uint8_t m_isShapeIdsSingle : 1;
-  uint8_t m_isShapeIdsSame : 1;
-  uint8_t m_isShapeIdsReversed : 1;
 };
-
-static_assert(sizeof(EdgeFlags) == 1, "Wrong EdgeFlags size.");
 
 std::string DebugPrint(EdgeFlags const & f);
 
@@ -328,7 +311,7 @@ public:
   StopId GetStop2Id() const { return m_stop2Id; }
   Weight GetWeight() const { return m_weight; }
   LineId GetLineId() const { return m_lineId; }
-  bool GetTransfer() const { return m_flags.IsTransfer(); }
+  bool GetTransfer() const { return m_flags.m_transfer; }
   std::vector<ShapeId> const & GetShapeIds() const { return m_shapeIds; }
 
 private:

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -130,7 +130,7 @@ private:
 class Stop
 {
 public:
-  NEWTYPE(StopId, MonotoneStopId);
+  NEWTYPE(StopId, WrappedStopId);
 
   Stop() : m_featureIdentifiers(true /* serializeFeatureIdOnly */) {};
   Stop(StopId id, OsmId osmId, FeatureId featureId, TransferId transferId,
@@ -157,14 +157,14 @@ private:
                                   visitor(m_lineIds, "line_ids"), visitor(m_point, "point"),
                                   visitor(m_titleAnchors, "title_anchors"))
 
-  MonotoneStopId m_id = MonotoneStopId(kInvalidStopId);
+  WrappedStopId m_id = WrappedStopId(kInvalidStopId);
   FeatureIdentifiers m_featureIdentifiers;
   TransferId m_transferId = kInvalidTransferId;
   std::vector<LineId> m_lineIds;
   m2::PointD m_point;
   std::vector<TitleAnchor> m_titleAnchors;
 };
-NEWTYPE_SIMPLE_OUTPUT(Stop::MonotoneStopId)
+NEWTYPE_SIMPLE_OUTPUT(Stop::WrappedStopId)
 
 class SingleMwmSegment
 {
@@ -304,7 +304,7 @@ std::string DebugPrint(EdgeFlags const & f);
 class Edge
 {
 public:
-  NEWTYPE(StopId, MonotoneEdgeId);
+  NEWTYPE(StopId, WrappedEdgeId);
 
   Edge() = default;
   Edge(StopId stop1Id, StopId stop2Id, Weight weight, LineId lineId, bool transfer,
@@ -330,14 +330,14 @@ private:
                                   visitor(m_lineId, "line_id"), visitor(m_flags, "transfer"),
                                   visitor(m_shapeIds, "shape_ids"))
 
-  MonotoneEdgeId m_stop1Id = MonotoneEdgeId(kInvalidStopId);
+  WrappedEdgeId m_stop1Id = WrappedEdgeId(kInvalidStopId);
   StopId m_stop2Id = kInvalidStopId;
   Weight m_weight = kInvalidWeight; // in seconds
   LineId m_lineId = kInvalidLineId;
   EdgeFlags m_flags;
   std::vector<ShapeId> m_shapeIds;
 };
-NEWTYPE_SIMPLE_OUTPUT(Edge::MonotoneEdgeId)
+NEWTYPE_SIMPLE_OUTPUT(Edge::WrappedEdgeId)
 
 class Transfer
 {

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -260,44 +260,52 @@ class EdgeFlags
 public:
   DECLARE_TRANSIT_TYPE_FRIENDS
 
-  bool IsTransfer() const { return IsBit(kTransferMask); }
-  void SetTransfer(bool transfer) { SetBit(transfer, kTransferMask); }
+  EdgeFlags();
+
+  bool IsTransfer() const { return m_transfer == 1; }
+  void SetTransfer(bool transfer) { m_transfer = BoolToUint(transfer); }
 
   /// \returns true if |Edge::m_shapeIds| is empty.
-  bool IsEmptyShapeIds() const { return IsBit(kEmptyShapeIdsMask); }
-  void SetEmptyShapeIds(bool emptyShapeIds) { SetBit(emptyShapeIds, kEmptyShapeIdsMask); }
+  bool IsEmptyShapeIds() const { return m_isShapeIdsEmpty == 1; }
+  void SetEmptyShapeIds(bool emptyShapeIds) { m_isShapeIdsEmpty = BoolToUint(emptyShapeIds); }
 
   /// \returns true if |Edge::m_shapeIds| contains only one item.
-  bool IsSingleShapeId() const { return IsBit(kSingleShapeIdMask); }
-  void SetSingleShapeId(bool singleShapeId) { SetBit(singleShapeId, kSingleShapeIdMask); }
+  bool IsSingleShapeId() const { return m_isShapeIdsSingle == 1; }
+  void SetSingleShapeId(bool singleShapeId) { m_isShapeIdsSingle = BoolToUint(singleShapeId); }
 
   /// \note It's valid only if IsSingleShapeId() returns true.
   /// \returns true if
   /// |Edge::m_stop1Id == m_shapeIds[0].m_stop1Id && Edge::m_stop2Id == m_shapeIds[0].m_stop2Id|.
-  bool IsShapeIdTheSame() const { return IsBit(kShapeIdIsTheSameMask); }
-  void SetShapeIdTheSame(bool same) { SetBit(same, kShapeIdIsTheSameMask); }
+  bool IsShapeIdTheSame() const { return m_isShapeIdsSame == 1; }
+  void SetShapeIdTheSame(bool same) { m_isShapeIdsSame = BoolToUint(same); }
 
   /// \note It's valid only if IsSingleShapeId() returns true.
   /// \returns true if
   /// |Edge::m_stop1Id == m_shapeIds[0].m_stop2Id && Edge::m_stop2Id == m_shapeIds[0].m_stop1Id|.
-  bool IsShapeIdReversed() const { return IsBit(kShapeIdIsReversedMask); }
-  void SetShapeIdReversed(bool reversed) { SetBit(reversed, kShapeIdIsReversedMask); }
+  bool IsShapeIdReversed() const { return m_isShapeIdsReversed == 1; }
+  void SetShapeIdReversed(bool reversed) { m_isShapeIdsReversed = BoolToUint(reversed); }
 
-  uint8_t GetFlags() const { return m_flags; }
-  void SetFlags(uint8_t flags) { m_flags = flags; }
+  uint8_t GetFlags() const;
+  void SetFlags(uint8_t flags);
 
 private:
-  bool IsBit(uint8_t bitMask) const { return m_flags & bitMask; }
-  void SetBit(bool bit, uint8_t bitMask);
+  uint8_t BoolToUint(bool b) { return static_cast<uint8_t>(b ? 1 : 0); }
+  uint8_t GetBit(uint8_t flags, uint8_t mask) { return BoolToUint(flags & mask); }
 
   static uint8_t constexpr kTransferMask = 1;
   static uint8_t constexpr kEmptyShapeIdsMask = (1 << 1);
   static uint8_t constexpr kSingleShapeIdMask = (1 << 2);
-  static uint8_t constexpr kShapeIdIsTheSameMask = (1 << 3);
+  static uint8_t constexpr kShapeIdIsSameMask = (1 << 3);
   static uint8_t constexpr kShapeIdIsReversedMask = (1 << 4);
 
-  uint8_t m_flags = 0;
+  uint8_t m_transfer : 1;
+  uint8_t m_isShapeIdsEmpty : 1;
+  uint8_t m_isShapeIdsSingle : 1;
+  uint8_t m_isShapeIdsSame : 1;
+  uint8_t m_isShapeIdsReversed : 1;
 };
+
+static_assert(sizeof(EdgeFlags) == 1, "Wrong EdgeFlags size.");
 
 std::string DebugPrint(EdgeFlags const & f);
 


### PR DESCRIPTION
В данном PR-те реализован ряд оптимизаций по уменьшению размера секции transit:

1. Реализовано дельта кодирование для хранения m_stopId в Stop и для m_stop1Id в Edge.

2. Все веса (в Gate, в Edge и в Line) теперь хранятся в виде целых чисел, в секундах. Это позволило их более оптимально хранить в varint.

3. Реализованы отдельные сериализаторы, десериализаторы для Edge. Это дало хороший эффект из-за того, что вектор m_shapeIds в Edge часто состоит из полей Edge::m_stop1Id и Edge::m_stop2id. Для этого в байт, в котором хранилось поле m_transfer так же положено: (1) пуст ли вектор m_shapeIds в Edge; (2) равен ли размер вектора m_shapeIds в Edge одному; (3) если 2 верно, то состоит ли единственный shape id в m_shapeIds из Edge::m_stop1Id и Edge::m_stop2id; () если 2 верно, то состоит ли единственный shape id в m_shapeIds из Edge::m_stop1Id и Edge::m_stop2id, но в переставленном порядке.

4. Добавлены тесты.

**Изменение выигрыша.**

В настоящий момент мы имеем только данные для метро ряда городов. Нам же нужно оценить, сколько будет занимать секция, когда мы добавив в нее весь общественный транспорт. Оценка проводилась следующая для ряда городов: Лондон, Москва и Нижний Новгород собиралась секция transit с информацией о метро. Для каждого города вычислялось сколько в среднем уходит на один элемент каждой таблицы (stops, edges, gates, lines и т.п.). Потом средние величины домножались на оценочное кол-во элементов таблиц для автобусов и другого общественного транспорта.

**Средние данные на элементы таблиц с учетом данного PR**
На базе сборки метро Москвы:
stops: 9.7K/234 = 41.5 байт
gates: 37K/1031 = 35.9 байт
edges: 20.5K/1005 = 20.4 байт
lines: 9K/58 = 155.2 байт
shapes: 88K/231 = 390 байт

На базе сборки метро Нижнего Новгорода:
stops: 579/13 = 44.5 байт
gates: 2481/70 = 35.0 байт
edges: 537/43 = 12.5 байт
lines: 445/3 = 148.3 байт
shapes: 4609/12 = 384 байт

На базе Лондона:
stops: 13202/302 = 43.7 байт
gates: 16063/458 = 35.0 байт
edges: 23716/1339 = 17.7 байт
lines: 8687/53 = 163.9 байт
shapes: 100256/311 = 322.4 байт

**Оценка размеров секции для Москвы и Лондона, собранной на базе данного PR.**
Предполагается, что shape для наземного транспорта нет

Для Москвы: 1695K

Автобусы: 1330.3K
stops: 41.5 байт * 7000 = 290.5K
gates: 35.9 байт * 7000 = 251.3K
edges: 20.4 байт * 28000 = 571.2K
lines: 155.2 байт * 1400 = 217.3K

Метро: 165K
Трамваи: 100K
Троллейбусы: 100K

Итого: 1695K

Для Лондона: 1534К
Автобусы: 1274K
stops: 43.7 байт * 7000 = 305.9K
gates: 35.0 байт * 7000 = 245K
edges: 17.7 байт * 28000 = 495.6K
lines: 163.9 байт * 1400 = 229.5K
Итого: 1274K

Метро: 160K
Трамваи (грубо): 100K

Итого: 1534К

**Что выиграли?**

До данного PR, секция transit для Москвы занимала: 2038К

На базе секции transit с данными метро было посчитаны средние величины:

stops:  11K/234 = 48 байт
gates:  38K/1031 = 38 байт
edges:  19K/1005 = 29 байт (Ранее было по ошибке посчитано 19 байт)
lines:  10K/58 = 177 байт
shapes: 88K/231 = 390 байт

Автобус: 1662К (без shapes)
700 автобусных маршрутов, 1400 линий => 7000 остановок => 7000 гейтов => дуги кол-во остановок * 4 = 7000 * 4 = 28 000.

stops:  48 байт * 7000 = 336K
gates:  38 байт * 7000 = 266K
edges:  29 байт * 28000 = 812К
lines:  177 байт * 1400 = 248K
shapes: 390 байт * 0

Трамваи: 100K
Троллейбусы: 100К

Итого: 2038К

@tatiana-kondakova @ygorshenin @mpimenov PTAL



