### PR TITLE
[platform] [tests] Added an option to ScopedFile.

### DIFF
--- a/coding/coding_tests/csv_reader_test.cpp
+++ b/coding/coding_tests/csv_reader_test.cpp
@@ -8,6 +8,12 @@
 #include <string>
 #include <vector>
 
+using coding::CSVReader;
+using platform::tests_support::ScopedFile;
+
+using Row = std::vector<std::string>;
+using File = std::vector<Row>;
+
 namespace
 {
 std::string const kCSV1 = "a,b,c,d\ne,f,g h";
@@ -15,14 +21,10 @@ std::string const kCSV2 = "a,b,cd a b, c";
 std::string const kCSV3 = "";
 }  // namespace
 
-using coding::CSVReader;
-using Row = std::vector<std::string>;
-using File = std::vector<Row>;
-
 UNIT_TEST(CSVReaderSmoke)
 {
   auto const fileName = "test.csv";
-  platform::tests_support::ScopedFile sf(fileName, kCSV1);
+  ScopedFile sf(fileName, kCSV1);
   FileReader fileReader(sf.GetFullPath());
   CSVReader reader;
   reader.Read(fileReader, [](File const & file) {
@@ -46,7 +48,7 @@ UNIT_TEST(CSVReaderSmoke)
 UNIT_TEST(CSVReaderCustomDelimiter)
 {
   auto const fileName = "test.csv";
-  platform::tests_support::ScopedFile sf(fileName, kCSV2);
+  ScopedFile sf(fileName, kCSV2);
   FileReader fileReader(sf.GetFullPath());
   CSVReader reader;
   CSVReader::Params p;
@@ -64,7 +66,7 @@ UNIT_TEST(CSVReaderCustomDelimiter)
 UNIT_TEST(CSVReaderEmptyFile)
 {
   auto const fileName = "test.csv";
-  platform::tests_support::ScopedFile sf(fileName, kCSV2);
+  ScopedFile sf(fileName, kCSV2);
   FileReader fileReader(sf.GetFullPath());
 
   CSVReader reader;

--- a/editor/editor_tests/config_loader_test.cpp
+++ b/editor/editor_tests/config_loader_test.cpp
@@ -10,6 +10,7 @@
 namespace
 {
 using namespace editor;
+using platform::tests_support::ScopedFile;
 
 void CheckGeneralTags(pugi::xml_document const & doc)
 {
@@ -45,7 +46,7 @@ UNIT_TEST(ConfigLoader_GetRemoteConfig)
 
 UNIT_TEST(ConfigLoader_SaveLoadHash)
 {
-  platform::tests_support::ScopedFile sf("test.hash");
+  ScopedFile sf("test.hash", ScopedFile::Mode::Create);
   auto const testHash = "12345 678909 87654 321 \n 32";
 
   ConfigLoader::SaveHash(testHash, sf.GetFullPath());

--- a/editor/editor_tests/editor_notes_test.cpp
+++ b/editor/editor_tests/editor_notes_test.cpp
@@ -11,12 +11,13 @@
 #include "base/math.hpp"
 
 using namespace editor;
+using platform::tests_support::ScopedFile;
 
 UNIT_TEST(Notes_Smoke)
 {
   auto const fileName = "notes.xml";
   auto const fullFileName = my::JoinFoldersToPath({GetPlatform().WritableDir()}, fileName);
-  platform::tests_support::ScopedFile sf(fileName);
+  ScopedFile sf(fileName, ScopedFile::Mode::DoNotCreate);
   {
     auto const notes = Notes::MakeNotes(fullFileName, true);
     notes->CreateNote(MercatorBounds::ToLatLon({1, 2}), "Some note1");

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -171,7 +171,8 @@ void TestAltitudesBuilding(vector<TPoint3DList> const & roads, bool hasAltitudeE
   // Building mwm without altitude section.
   LocalCountryFile country(testDirFullPath, CountryFile(kTestMwm), 1);
   ScopedDir testScopedDir(kTestDir);
-  ScopedFile testScopedMwm(my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION));
+  ScopedFile testScopedMwm(my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION),
+                           ScopedFile::Mode::Create);
 
   BuildMwmWithoutAltitudes(roads, country);
 

--- a/generator/generator_tests/restriction_collector_test.cpp
+++ b/generator/generator_tests/restriction_collector_test.cpp
@@ -107,7 +107,7 @@ UNIT_TEST(RestrictionTest_RestrictionCollectorWholeClassTest)
                                                30, 3,
                                                40, 4)";
   Platform const & platform = Platform();
-  ScopedFile mappingScopedFile(osmIdsToFeatureIdsPath);
+  ScopedFile mappingScopedFile(osmIdsToFeatureIdsPath, ScopedFile::Mode::Create);
   std::string const osmIdsToFeatureIdsFullPath = mappingScopedFile.GetFullPath();
   ReEncodeOsmIdsToFeatureIdsMapping(kOsmIdsToFeatureIdsContent, osmIdsToFeatureIdsFullPath);
 

--- a/generator/generator_tests/restriction_test.cpp
+++ b/generator/generator_tests/restriction_test.cpp
@@ -80,7 +80,7 @@ void TestRestrictionBuilding(string const & restrictionContent, string const & m
                            0 /* version */);
   ScopedDir const scopedDir(kTestDir);
   string const mwmRelativePath = my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION);
-  ScopedFile const scopedMwm(mwmRelativePath);
+  ScopedFile const scopedMwm(mwmRelativePath, ScopedFile::Mode::Create);
   BuildEmptyMwm(country);
 
   // Creating a file with restrictions.
@@ -89,7 +89,7 @@ void TestRestrictionBuilding(string const & restrictionContent, string const & m
 
   // Creating osm ids to feature ids mapping.
   string const mappingRelativePath = my::JoinPath(kTestDir, kOsmIdsToFeatureIdsName);
-  ScopedFile const mappingFile(mappingRelativePath);
+  ScopedFile const mappingFile(mappingRelativePath, ScopedFile::Mode::Create);
   string const mappingFullPath = mappingFile.GetFullPath();
   ReEncodeOsmIdsToFeatureIdsMapping(mappingContent, mappingFullPath);
 

--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -93,7 +93,7 @@ RoadAccessCollector::RoadAccessByVehicleType SaveAndLoadRoadAccess(string const 
                            0 /* version */);
   ScopedDir const scopedDir(kTestDir);
   string const mwmRelativePath = my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION);
-  ScopedFile const scopedMwm(mwmRelativePath);
+  ScopedFile const scopedMwm(mwmRelativePath, ScopedFile::Mode::Create);
   BuildTestMwmWithRoads(country);
 
   // Creating a file with road access.
@@ -102,7 +102,7 @@ RoadAccessCollector::RoadAccessByVehicleType SaveAndLoadRoadAccess(string const 
 
   // Creating osm ids to feature ids mapping.
   string const mappingRelativePath = my::JoinPath(kTestDir, kOsmIdsToFeatureIdsName);
-  ScopedFile const mappingFile(mappingRelativePath);
+  ScopedFile const mappingFile(mappingRelativePath, ScopedFile::Mode::Create);
   string const mappingFullPath = mappingFile.GetFullPath();
   ReEncodeOsmIdsToFeatureIdsMapping(mappingContent, mappingFullPath);
 

--- a/indexer/indexer_tests/osm_editor_test.cpp
+++ b/indexer/indexer_tests/osm_editor_test.cpp
@@ -21,6 +21,7 @@
 
 using namespace generator::tests_support;
 using namespace indexer::tests_support;
+using platform::tests_support::ScopedFile;
 
 namespace
 {
@@ -648,7 +649,7 @@ void EditorTest::HaveMapEditsOrNotesToUploadTest()
   editor.ClearAllLocalEdits();
   TEST(!editor.HaveMapEditsOrNotesToUpload(), ());
 
-  platform::tests_support::ScopedFile sf("test_notes.xml");
+  ScopedFile sf("test_notes.xml", ScopedFile::Mode::DoNotCreate);
 
   editor.m_notes = Notes::MakeNotes(sf.GetFullPath(), true);
 
@@ -825,11 +826,9 @@ void EditorTest::CreateNoteTest()
     builder.Add(TestCafe(m2::PointD(2.0, 2.0), "Cafe", "en"));
   });
 
-  auto const createAndCheckNote = [&editor](FeatureID const & fId,
-                                            ms::LatLon const & pos,
-                                            osm::Editor::NoteProblemType const noteType)
-  {
-    platform::tests_support::ScopedFile sf("test_notes.xml");
+  auto const createAndCheckNote = [&editor](FeatureID const & fId, ms::LatLon const & pos,
+                                            osm::Editor::NoteProblemType const noteType) {
+    ScopedFile sf("test_notes.xml", ScopedFile::Mode::DoNotCreate);
     editor.m_notes = Notes::MakeNotes(sf.GetFullPath(), true);
     feature::TypesHolder holder;
     holder.Assign(classif().GetTypeByPath({"amenity", "restaurant"}));

--- a/local_ads/local_ads_tests/file_helpers_tests.cpp
+++ b/local_ads/local_ads_tests/file_helpers_tests.cpp
@@ -8,10 +8,11 @@
 
 using namespace local_ads;
 using namespace std;
+using platform::tests_support::ScopedFile;
 
 UNIT_TEST(LocalAdsHelpers_Read_Write_Country_Name)
 {
-  platform::tests_support::ScopedFile testFile("la_tests.dat");
+  ScopedFile testFile("la_tests.dat", ScopedFile::Mode::Create);
 
   string const countryName = "Russia_Moscow";
   {
@@ -31,7 +32,7 @@ UNIT_TEST(LocalAdsHelpers_Read_Write_Country_Name)
 
 UNIT_TEST(LocalAdsHelpers_Read_Write_Timestamp)
 {
-  platform::tests_support::ScopedFile testFile("la_tests.dat");
+  ScopedFile testFile("la_tests.dat", ScopedFile::Mode::Create);
 
   auto ts = local_ads::Clock::now();
   {
@@ -55,7 +56,7 @@ UNIT_TEST(LocalAdsHelpers_Read_Write_Timestamp)
 
 UNIT_TEST(LocalAdsHelpers_Read_Write_RawData)
 {
-  platform::tests_support::ScopedFile testFile("la_tests.dat");
+  ScopedFile testFile("la_tests.dat", ScopedFile::Mode::Create);
 
   vector<uint8_t> rawData = {1, 2, 3, 4, 5};
   {

--- a/openlr/openlr_tests/decoded_path_test.cpp
+++ b/openlr/openlr_tests/decoded_path_test.cpp
@@ -121,7 +121,8 @@ void WithRoad(vector<m2::PointD> const & points, Func && fn)
 
   LocalCountryFile country(mwmPath, CountryFile(kTestMwm), 0 /* version */);
   ScopedDir testScopedDir(kTestDir);
-  ScopedFile testScopedMwm(my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION));
+  ScopedFile testScopedMwm(my::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION),
+                           ScopedFile::Mode::Create);
 
   {
     TestMwmBuilder builder(country, feature::DataHeader::country);

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -112,7 +112,7 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
 
     string const mapFileName = GetFileName(countryFile.GetName(), MapOptions::Map,
                                            version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testMapFile(mapFileName, "map");
+    ScopedFile testMapFile(mapFileName, ScopedFile::Mode::Create);
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());
@@ -122,7 +122,7 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
 
     string const routingFileName = GetFileName(countryFile.GetName(), MapOptions::CarRouting,
                                                version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testRoutingFile(routingFileName, "routing");
+    ScopedFile testRoutingFile(routingFileName, ScopedFile::Mode::Create);
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());
@@ -158,13 +158,13 @@ UNIT_TEST(LocalCountryFile_CleanupMapFiles)
   CountryFile irelandFile("Ireland");
 
   LocalCountryFile japanLocalFile(mapsDir, japanFile, 0 /* version */);
-  ScopedFile japanMapFile("Japan.mwm", "Japan");
+  ScopedFile japanMapFile("Japan.mwm", ScopedFile::Mode::Create);
 
   LocalCountryFile brazilLocalFile(mapsDir, brazilFile, 0 /* version */);
-  ScopedFile brazilMapFile("Brazil.mwm", "Brazil");
+  ScopedFile brazilMapFile("Brazil.mwm", ScopedFile::Mode::Create);
 
   LocalCountryFile irelandLocalFile(dir4.GetFullPath(), irelandFile, 4 /* version */);
-  ScopedFile irelandMapFile(dir4, irelandFile, MapOptions::Map, "Ireland");
+  ScopedFile irelandMapFile(dir4, irelandFile, MapOptions::Map);
 
   // Check FindAllLocalMaps()
   vector<LocalCountryFile> localFiles;
@@ -202,18 +202,18 @@ UNIT_TEST(LocalCountryFile_CleanupPartiallyDownloadedFiles)
   ScopedDir latestDir("101010");
 
   ScopedFile toBeDeleted[] = {
-      {"Ireland.mwm.ready", "Ireland"},
-      {"Netherlands.mwm.routing.downloading2", "Netherlands"},
-      {"Germany.mwm.ready3", "Germany"},
-      {"UK_England.mwm.resume4", "UK"},
+      {"Ireland.mwm.ready", ScopedFile::Mode::Create},
+      {"Netherlands.mwm.routing.downloading2", ScopedFile::Mode::Create},
+      {"Germany.mwm.ready3", ScopedFile::Mode::Create},
+      {"UK_England.mwm.resume4", ScopedFile::Mode::Create},
       {my::JoinFoldersToPath(oldDir.GetRelativePath(), "Russia_Central.mwm.downloading"),
-       "Central Russia map"}};
+       ScopedFile::Mode::Create}};
   ScopedFile toBeKept[] = {
-      {"Italy.mwm", "Italy"},
-      {"Spain.mwm", "Spain map"},
-      {"Spain.mwm.routing", "Spain routing"},
+      {"Italy.mwm", ScopedFile::Mode::Create},
+      {"Spain.mwm", ScopedFile::Mode::Create},
+      {"Spain.mwm.routing", ScopedFile::Mode::Create},
       {my::JoinFoldersToPath(latestDir.GetRelativePath(), "Russia_Southern.mwm.downloading"),
-       "Southern Russia map"}};
+       ScopedFile::Mode::Create}};
 
   CleanupMapsDirectory(101010 /* latestVersion */);
 
@@ -244,10 +244,9 @@ UNIT_TEST(LocalCountryFile_DirectoryLookup)
 
   ScopedDir testDir("test-dir");
 
-  ScopedFile testIrelandMapFile(testDir, irelandFile, MapOptions::Map, "Ireland-map");
-  ScopedFile testNetherlandsMapFile(testDir, netherlandsFile, MapOptions::Map, "Netherlands-map");
-  ScopedFile testNetherlandsRoutingFile(testDir, netherlandsFile, MapOptions::CarRouting,
-                                        "Netherlands-routing");
+  ScopedFile testIrelandMapFile(testDir, irelandFile, MapOptions::Map);
+  ScopedFile testNetherlandsMapFile(testDir, netherlandsFile, MapOptions::Map);
+  ScopedFile testNetherlandsRoutingFile(testDir, netherlandsFile, MapOptions::CarRouting);
 
   vector<LocalCountryFile> localFiles;
   FindAllLocalMapsInDirectoryAndCleanup(testDir.GetFullPath(), 150309 /* version */,
@@ -279,7 +278,7 @@ UNIT_TEST(LocalCountryFile_AllLocalFilesLookup)
 
   settings::Delete("LastMigration");
 
-  ScopedFile testItalyMapFile(testDir, italyFile, MapOptions::Map, "Italy-map");
+  ScopedFile testItalyMapFile(testDir, italyFile, MapOptions::Map);
 
   vector<LocalCountryFile> localFiles;
   FindAllLocalMapsAndCleanup(10101 /* latestVersion */, localFiles);

--- a/platform/platform_tests_support/scoped_file.hpp
+++ b/platform/platform_tests_support/scoped_file.hpp
@@ -18,12 +18,25 @@ class ScopedDir;
 class ScopedFile
 {
 public:
-  explicit ScopedFile(string const & relativePath);
+  enum class Mode : uint32_t
+  {
+    // Create or overwrite the file and remove it at scope exit.
+    Create,
 
+    // Remove the file at scope exit. The caller must
+    // ensure that the file has been created by that time.
+    DoNotCreate
+  };
+
+  // Creates a scoped file in the specified mode.
+  ScopedFile(string const & relativePath, Mode mode);
+
+  // Creates a scoped file in Mode::Create and writes |contents| to it.
   ScopedFile(string const & relativePath, string const & contents);
 
-  ScopedFile(ScopedDir const & dir, CountryFile const & countryFile, MapOptions file,
-             string const & contents);
+  // Creates a scoped file in Mode::Create using the path inferred from |countryFile|
+  // and |mapOptions|.
+  ScopedFile(ScopedDir const & dir, CountryFile const & countryFile, MapOptions mapOptions);
 
   ~ScopedFile();
 
@@ -34,6 +47,8 @@ public:
   inline bool Exists() const { return GetPlatform().IsFileExistsByFullPath(GetFullPath()); }
 
 private:
+  ScopedFile(string const & relativePath, string const & contents, Mode mode);
+
   string const m_fullPath;
   bool m_reset = false;
 

--- a/platform/platform_tests_support/scoped_mwm.cpp
+++ b/platform/platform_tests_support/scoped_mwm.cpp
@@ -17,7 +17,7 @@ namespace platform
 {
 namespace tests_support
 {
-ScopedMwm::ScopedMwm(string const & relativePath) : m_file(relativePath, "")
+ScopedMwm::ScopedMwm(string const & relativePath) : m_file(relativePath, ScopedFile::Mode::Create)
 {
   DataHeader header;
   {

--- a/routing/routing_tests/routing_mapping_test.cpp
+++ b/routing/routing_tests/routing_mapping_test.cpp
@@ -25,10 +25,11 @@ class LocalFileGenerator
 {
 public:
   LocalFileGenerator(string const & fileName)
-      : m_countryFile(fileName),
-        m_testDataFile(platform::GetFileName(m_countryFile.GetName(), MapOptions::MapWithCarRouting,
-                                             version::FOR_TESTING_SINGLE_MWM1), "routing"),
-        m_localFile(GetPlatform().WritableDir(), m_countryFile, version::FOR_TESTING_SINGLE_MWM1)
+    : m_countryFile(fileName)
+    , m_testDataFile(platform::GetFileName(m_countryFile.GetName(), MapOptions::MapWithCarRouting,
+                                           version::FOR_TESTING_SINGLE_MWM1),
+                     ScopedFile::Mode::Create)
+    , m_localFile(GetPlatform().WritableDir(), m_countryFile, version::FOR_TESTING_SINGLE_MWM1)
   {
     m_localFile.SyncWithDisk();
     TEST(m_localFile.OnDisk(MapOptions::MapWithCarRouting), ());

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -914,7 +914,7 @@ UNIT_CLASS_TEST(StorageTest, CancelDownloadingWhenAlmostDone)
 
 UNIT_CLASS_TEST(StorageTest, DeleteCountry)
 {
-  tests_support::ScopedFile map("Wonderland.mwm", "map");
+  tests_support::ScopedFile map("Wonderland.mwm", ScopedFile::Mode::Create);
   LocalCountryFile file = LocalCountryFile::MakeForTesting("Wonderland",
                                                            version::FOR_TESTING_SINGLE_MWM1);
   TEST_EQUAL(MapOptions::MapWithCarRouting, file.GetFiles(), ());
@@ -940,7 +940,7 @@ UNIT_CLASS_TEST(StorageTest, DeleteCountry)
 
 UNIT_CLASS_TEST(TwoComponentStorageTest, DeleteCountry)
 {
-  tests_support::ScopedFile map("Wonderland.mwm", "map");
+  tests_support::ScopedFile map("Wonderland.mwm", ScopedFile::Mode::Create);
   LocalCountryFile file = LocalCountryFile::MakeForTesting("Wonderland",
                                                            version::FOR_TESTING_TWO_COMPONENT_MWM1);
   TEST_EQUAL(MapOptions::Map, file.GetFiles(), ());
@@ -1003,12 +1003,12 @@ UNIT_TEST(StorageTest_ObsoleteMapsRemoval)
   CountryFile country("Azerbaijan");
 
   tests_support::ScopedDir dir1("1");
-  tests_support::ScopedFile map1(dir1, country, MapOptions::Map, "map1");
+  tests_support::ScopedFile map1(dir1, country, MapOptions::Map);
   LocalCountryFile file1(dir1.GetFullPath(), country, 1 /* version */);
   CountryIndexes::PreparePlaceOnDisk(file1);
 
   tests_support::ScopedDir dir2("2");
-  tests_support::ScopedFile map2(dir2, country, MapOptions::Map, "map2");
+  tests_support::ScopedFile map2(dir2, country, MapOptions::Map);
   LocalCountryFile file2(dir2.GetFullPath(), country, 2 /* version */);
   CountryIndexes::PreparePlaceOnDisk(file2);
 


### PR DESCRIPTION
The option allows one to push responsibility on the user
of the ScopedFile, that is, enables a scenario where
a ScopedFile does not try to create the file on disk
but only assures the cleanup.