### PR TITLE
Fix distance calculation for unidirectional AStar

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -358,8 +358,9 @@ typename AStarAlgorithm<TGraph>::Result AStarAlgorithm<TGraph>::FindPath(
   if (resultCode == Result::OK)
   {
     context.ReconstructPath(finalVertex, result.m_path);
-    result.m_distance =
-        context.GetDistance(finalVertex) - graph.HeuristicCostEstimate(startVertex, finalVertex);
+    result.m_distance = context.GetDistance(finalVertex) -
+                        graph.HeuristicCostEstimate(finalVertex, finalVertex) +
+                        graph.HeuristicCostEstimate(startVertex, finalVertex);
   }
 
   return resultCode;


### PR DESCRIPTION
Начиная с этого PR:
https://github.com/mapsme/omim/commit/e1ede4b1100a47b57e781d8bc9d77a9431f3bb18

думаю тут должен быть `+`:
```math
lr_i = l_i + h_i - h_(i-1)
SUM(lr) = SUM(l) + h_ff - h_sf
SUM(l) = SUM(lr) + h_sf 
```
где `lr_i` -- reduced length i-ого ребра, `l_i` -- длина i-ого ребра, `h_ff` -- эвристика от финиша до финиша равна 0, `h_sf` -- эвристика от старта до финиша. 

ну и под дебаггером посмотрела что сейчас возвращаемый вес не соответствует сумме весов рёбер, после исправления соответствует.