### PR TITLE
[routing][transit] Transit pedestrian restrictions

### DIFF
--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -18,7 +18,7 @@ IRouter::ResultCode CalculateRoute(BorderCross const & startPos, BorderCross con
 {
   using TAlgorithm = AStarAlgorithm<CrossMwmRoadGraph>;
 
-  TAlgorithm::TOnVisitedVertexCallback onVisitedVertex =
+  TAlgorithm::OnVisitedVertexCallback onVisitedVertex =
       [&delegate](BorderCross const & cross, BorderCross const & /* target */)
   {
     delegate.OnPointCheck(MercatorBounds::FromLatLon(cross.fromNode.point));

--- a/routing/fake_edges_container.hpp
+++ b/routing/fake_edges_container.hpp
@@ -19,6 +19,7 @@ class FakeEdgesContainer final
 public:
   FakeEdgesContainer(IndexGraphStarter && starter)
     : m_finishId(starter.m_finishId)
+    , m_finishPassThroughAllowed(starter.m_finishPassThroughAllowed)
     , m_fake(std::move(starter.m_fake))
   {
   }
@@ -32,8 +33,10 @@ public:
   }
 
 private:
-  // finish segment id
+  // Finish segment id.
   uint32_t m_finishId;
+  // Finish segment is located in a pass-through/non-pass-through area.
+  bool m_finishPassThroughAllowed;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;
 };
 }  // namespace routing

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -112,15 +112,13 @@ void IndexGraph::GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge
 RouteWeight IndexGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
 {
   return RouteWeight(
-      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)),
-      0 /* nonPassThroughCross */);
+      m_estimator->CalcHeuristic(GetPoint(from, true /* front */), GetPoint(to, true /* front */)));
 }
 
 RouteWeight IndexGraph::CalcSegmentWeight(Segment const & segment)
 {
   return RouteWeight(
-      m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId())),
-      0 /* nonPassThroughCross */);
+      m_estimator->CalcSegmentWeight(segment, m_geometry.GetRoad(segment.GetFeatureId())));
 }
 
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
@@ -178,8 +176,8 @@ RouteWeight IndexGraph::GetPenalties(Segment const & u, Segment const & v)
   uint32_t const passThroughPenalty = fromPassThroughAllowed == toPassThroughAllowed ? 0 : 1;
 
   if (IsUTurn(u, v))
-    return RouteWeight(m_estimator->GetUTurnPenalty(), passThroughPenalty);
+    return RouteWeight(m_estimator->GetUTurnPenalty(), passThroughPenalty, 0.0 /* transitTime */);
 
-  return RouteWeight(0.0, passThroughPenalty);
+  return RouteWeight(0.0, passThroughPenalty, 0.0 /* transitTime */);
 }
 }  // namespace routing

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -74,10 +74,9 @@ public:
 
   std::set<NumMwmId> GetMwms() const;
 
-  // Checks |result| meets non-pass-through crossing restrictions according to placement of
-  // |result.path| start and finish in pass through/non-pass-through area and number of
-  // non-pass-through crosses.
-  bool DoesRouteCrossNonPassThrough(RoutingResult<Segment, RouteWeight> const & result) const;
+  // Checks whether |weight| meets non-pass-through crossing restrictions according to placement of
+  // start and finish in pass-through/non-pass-through area and number of non-pass-through crosses.
+  bool CheckLength(RouteWeight const & weight) const;
 
   void GetEdgesList(Segment const & segment, bool isOutgoing,
                     std::vector<SegmentEdge> & edges) const;
@@ -131,12 +130,20 @@ private:
   void AddRealEdges(Segment const & segment, bool isOutgoing,
                     std::vector<SegmentEdge> & edges) const;
 
+  // Checks whether ending belongs to pass-through or non-pass-through zone.
+  bool EndingPassThroughAllowed(FakeEnding const & ending);
+
   static uint32_t constexpr kFakeFeatureId = FakeFeatureIds::kIndexGraphStarterId;
   WorldGraph & m_graph;
   // Start segment id
   uint32_t m_startId;
   // Finish segment id
   uint32_t m_finishId;
+  // Start segment is located in a pass-through/non-pass-through area.
+  bool m_startPassThroughAllowed;
+  // Finish segment is located in a pass-through/non-pass-through area.
+  bool m_finishPassThroughAllowed;
+  double m_startToFinishDistanceM;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;
 };
 }  // namespace routing

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -15,12 +15,14 @@ double RouteWeight::ToCrossMwmWeight() const
 
 ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
 {
-  os << "(" << routeWeight.GetNonPassThroughCross() << ", " << routeWeight.GetWeight() << ")";
+  os << "(" << routeWeight.GetNonPassThroughCross() << ", " << routeWeight.GetWeight() << ", "
+     << routeWeight.GetTransitTime() << ")";
   return os;
 }
 
 RouteWeight operator*(double lhs, RouteWeight const & rhs)
 {
-  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNonPassThroughCross());
+  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNonPassThroughCross(),
+                     lhs * rhs.GetTransitTime());
 }
 }  // namespace routing

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -12,25 +12,28 @@ class RouteWeight final
 public:
   RouteWeight() = default;
 
-  constexpr RouteWeight(double weight, int nonPassThroughCross)
-    : m_weight(weight), m_nonPassThroughCross(nonPassThroughCross)
+  explicit constexpr RouteWeight(double weight) : m_weight(weight) {}
+
+  constexpr RouteWeight(double weight, int nonPassThroughCross, double transitTime)
+    : m_weight(weight), m_nonPassThroughCross(nonPassThroughCross), m_transitTime(transitTime)
   {
   }
 
-  static RouteWeight FromCrossMwmWeight(double weight)
-  {
-    return RouteWeight(weight, 0 /* nonPassThroughCross */);
-  }
+  static RouteWeight FromCrossMwmWeight(double weight) { return RouteWeight(weight); }
 
   double ToCrossMwmWeight() const;
   double GetWeight() const { return m_weight; }
   int GetNonPassThroughCross() const { return m_nonPassThroughCross; }
+  double GetTransitTime() const { return m_transitTime; }
 
   bool operator<(RouteWeight const & rhs) const
   {
     if (m_nonPassThroughCross != rhs.m_nonPassThroughCross)
       return m_nonPassThroughCross < rhs.m_nonPassThroughCross;
-    return m_weight < rhs.m_weight;
+    if (m_weight != rhs.m_weight)
+      return m_weight < rhs.m_weight;
+    // Preffer bigger transit time if total weights are same.
+    return m_transitTime > rhs.m_transitTime;
   }
 
   bool operator==(RouteWeight const & rhs) const { return !((*this) < rhs) && !(rhs < (*this)); }
@@ -41,30 +44,40 @@ public:
 
   bool operator>=(RouteWeight const & rhs) const { return !((*this) < rhs); }
 
+  bool operator<=(RouteWeight const & rhs) const { return rhs >= (*this); }
+
   RouteWeight operator+(RouteWeight const & rhs) const
   {
-    return RouteWeight(m_weight + rhs.m_weight, m_nonPassThroughCross + rhs.m_nonPassThroughCross);
+    return RouteWeight(m_weight + rhs.m_weight, m_nonPassThroughCross + rhs.m_nonPassThroughCross,
+                       m_transitTime + rhs.m_transitTime);
   }
 
   RouteWeight operator-(RouteWeight const & rhs) const
   {
-    return RouteWeight(m_weight - rhs.m_weight, m_nonPassThroughCross - rhs.m_nonPassThroughCross);
+    return RouteWeight(m_weight - rhs.m_weight, m_nonPassThroughCross - rhs.m_nonPassThroughCross,
+                       m_transitTime - rhs.m_transitTime);
   }
 
   RouteWeight & operator+=(RouteWeight const & rhs)
   {
     m_weight += rhs.m_weight;
     m_nonPassThroughCross += rhs.m_nonPassThroughCross;
+    m_transitTime += rhs.m_transitTime;
     return *this;
   }
 
-  RouteWeight operator-() const { return RouteWeight(-m_weight, -m_nonPassThroughCross); }
+  RouteWeight operator-() const
+  {
+    return RouteWeight(-m_weight, -m_nonPassThroughCross, -m_transitTime);
+  }
 
 private:
   // Regular weight (seconds).
   double m_weight = 0.0;
   // Number of pass-through/non-pass-through area border cross.
   int m_nonPassThroughCross = 0;
+  // Transit time. It's already included in |m_weight| (m_transitTime <= m_weight).
+  double m_transitTime = 0.0;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
@@ -75,19 +88,21 @@ template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
   return RouteWeight(std::numeric_limits<double>::max() /* weight */,
-                     std::numeric_limits<int>::max() /* nonPassThroughCross */);
+                     std::numeric_limits<int>::max() /* nonPassThroughCross */,
+                     std::numeric_limits<int>::max() /* transitTime */);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
 {
-  return RouteWeight(0.0 /* weight */, 0 /* nonPassThroughCross */);
+  return RouteWeight(0.0 /* weight */, 0 /* nonPassThroughCross */, 0.0 /* transitTime */);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
 {
-  return RouteWeight(GetAStarWeightEpsilon<double>(), 0 /* nonPassThroughCross */);
+  return RouteWeight(GetAStarWeightEpsilon<double>(), 0 /* nonPassThroughCross */,
+                     0.0 /* transitTime */);
 }
 
 }  // namespace routing

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -93,6 +93,33 @@ UNIT_TEST(AStarAlgorithm_Sample)
   TestAStar(graph, expectedRoute, 23);
 }
 
+UNIT_TEST(AStarAlgorithm_CheckLength)
+{
+  UndirectedGraph graph;
+
+  // Inserts edges in a format: <source, target, weight>.
+  graph.AddEdge(0, 1, 10);
+  graph.AddEdge(1, 2, 5);
+  graph.AddEdge(2, 3, 5);
+  graph.AddEdge(2, 4, 10);
+  graph.AddEdge(3, 4, 3);
+
+  TAlgorithm algo;
+  RoutingResult<unsigned /* VertexType */, double /* WeightType */> routingResult;
+  TAlgorithm::Result result =
+      algo.FindPath(graph, 0u, 4u, routingResult, {} /* cancellable */,
+                    {} /* onVisitedVertexCallback */, [](double weight) { return weight < 23; });
+  // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
+  TEST_EQUAL(result, TAlgorithm::Result::NoPath, ());
+
+  routingResult = {};
+  result = algo.FindPathBidirectional(graph, 0u, 4u, routingResult, {} /* cancellable */,
+                                      {} /* onVisitedVertexCallback */,
+                                      [](double weight) { return weight < 23; });
+  // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
+  TEST_EQUAL(result, TAlgorithm::Result::NoPath, ());
+}
+
 UNIT_TEST(AdjustRoute)
 {
   UndirectedGraph graph;
@@ -109,8 +136,9 @@ UNIT_TEST(AdjustRoute)
 
   TAlgorithm algo;
   RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
-  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
-                               my::Cancellable(), nullptr /* onVisitedVertexCallback */);
+  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, result,
+                               my::Cancellable(), nullptr /* onVisitedVertexCallback */,
+                               [](double weight){ return weight <= 1.0; });
 
   vector<unsigned> const expectedRoute = {6, 2, 3, 4, 5};
   TEST_EQUAL(code, TAlgorithm::Result::OK, ());
@@ -130,8 +158,9 @@ UNIT_TEST(AdjustRouteNoPath)
 
   TAlgorithm algo;
   RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
-  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
-                               my::Cancellable(), nullptr /* onVisitedVertexCallback */);
+  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, result,
+                               my::Cancellable(), nullptr /* onVisitedVertexCallback */,
+                               [](double weight){ return weight <= 1.0; });
 
   TEST_EQUAL(code, TAlgorithm::Result::NoPath, ());
   TEST(result.m_path.empty(), ());
@@ -151,8 +180,9 @@ UNIT_TEST(AdjustRouteOutOfLimit)
 
   TAlgorithm algo;
   RoutingResult<unsigned /* VertexType */, double /* WeightType */> result;
-  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, 1.0 /* limit */, result,
-                               my::Cancellable(), nullptr /* onVisitedVertexCallback */);
+  auto code = algo.AdjustRoute(graph, 6 /* start */, prevRoute, result,
+                               my::Cancellable(), nullptr /* onVisitedVertexCallback */,
+                               [](double weight){ return weight <= 1.0; });
 
   TEST_EQUAL(code, TAlgorithm::Result::NoPath, ());
   TEST(result.m_path.empty(), ());

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -353,10 +353,8 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
 
   auto resultCode = algorithm.FindPathBidirectional(
       starter, starter.GetStartSegment(), starter.GetFinishSegment(), routingResult,
-      {} /* cancellable */, {} /* onVisitedVertexCallback */);
-
-  if (starter.DoesRouteCrossNonPassThrough(routingResult))
-    resultCode = AStarAlgorithm<IndexGraphStarter>::Result::NoPath;
+      {} /* cancellable */, {} /* onVisitedVertexCallback */,
+      [&](RouteWeight const & weight) { return starter.CheckLength(weight); });
 
   timeSec = routingResult.m_distance.GetWeight();
   roadPoints = routingResult.m_path;

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -32,10 +32,8 @@ void SingleVehicleWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoi
     // point. So |isEnter| below should be set to true.
     m_crossMwmGraph->ForEachTransition(
         segment.GetMwmId(), !isOutgoing /* isEnter */, [&](Segment const & transition) {
-          edges.emplace_back(
-              transition, RouteWeight(m_estimator->CalcLeapWeight(segmentPoint,
-                                                                  GetPoint(transition, isOutgoing)),
-                                      0 /* nonPassThroughCross */));
+          edges.emplace_back(transition, RouteWeight(m_estimator->CalcLeapWeight(
+                                             segmentPoint, GetPoint(transition, isOutgoing))));
         });
     return;
   }
@@ -100,20 +98,19 @@ RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(Segment const & from,
 RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(m2::PointD const & from,
                                                            m2::PointD const & to)
 {
-  return RouteWeight(m_estimator->CalcHeuristic(from, to), 0 /* nonPassThroughCross */);
+  return RouteWeight(m_estimator->CalcHeuristic(from, to));
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment)
 {
   return RouteWeight(m_estimator->CalcSegmentWeight(
-                         segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())),
-                     0 /* nonPassThroughCross */);
+      segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())));
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
                                                        m2::PointD const & to) const
 {
-  return RouteWeight(m_estimator->CalcOffroadWeight(from, to), 0 /* nonPassThroughCross */);
+  return RouteWeight(m_estimator->CalcOffroadWeight(from, to));
 }
 
 bool SingleVehicleWorldGraph::LeapIsAllowed(NumMwmId mwmId) const
@@ -141,7 +138,7 @@ void SingleVehicleWorldGraph::GetTwins(Segment const & segment, bool isOutgoing,
     // in different mwms. But if we have mwms with different versions and feature
     // was moved in one of them we can have nonzero weight here.
     double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, RouteWeight(weight, 0 /* nonPassThroughCross */));
+    edges.emplace_back(twin, RouteWeight(weight));
   }
 }
 }  // namespace routing

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -29,6 +29,7 @@ public:
   // WorldGraph overrides:
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
                    std::vector<SegmentEdge> & edges) override;
+  bool CheckLength(RouteWeight const &, double) const override { return true; }
   Junction const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -53,34 +53,39 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment) const
 {
   CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
   if (IsGate(segment))
-    return RouteWeight(GetGate(segment).GetWeight(), 0 /* nontransitCross */);
+  {
+    auto const weight = GetGate(segment).GetWeight();
+    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, weight /* transitTime */);
+  }
 
   if (IsEdge(segment))
-    return RouteWeight(GetEdge(segment).GetWeight(), 0 /* nontransitCross */);
+  {
+    auto const weight = GetEdge(segment).GetWeight();
+    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, weight /* transitTime */);
+  }
 
   return RouteWeight(
       m_estimator->CalcOffroadWeight(GetJunction(segment, false /* front */).GetPoint(),
-                                     GetJunction(segment, true /* front */).GetPoint()),
-      0 /* nontransitCross */);
+                                     GetJunction(segment, true /* front */).GetPoint()));
 }
 
 RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const & to) const
 {
   // We need to wait transport and apply additional penalty only if we change to transit::Edge.
   if (!IsEdge(to))
-    return RouteWeight(0 /* weight */, 0 /* nontransitCross */);
+    return GetAStarWeightZero<RouteWeight>();
 
   auto const & edgeTo = GetEdge(to);
 
   // We are changing to transfer and do not need to apply extra penalty here. We'll do it while
   // changing from transfer.
   if (edgeTo.GetTransfer())
-    return RouteWeight(0 /* weight */, 0 /* nontransitCross */);
+    return GetAStarWeightZero<RouteWeight>();
 
   auto const lineIdTo = edgeTo.GetLineId();
 
   if (IsEdge(from) && GetEdge(from).GetLineId() == lineIdTo)
-    return RouteWeight(0 /* weight */, 0 /* nontransitCross */);
+    return GetAStarWeightZero<RouteWeight>();
 
   // We need to apply extra penalty when:
   // 1. |from| is gate, |to| is edge
@@ -88,7 +93,8 @@ RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const
   // 3. |from| is edge, |to| is edge from another line directly connected to |from|.
   auto const it = m_transferPenalties.find(lineIdTo);
   CHECK(it != m_transferPenalties.cend(), ("Segment", to, "belongs to unknown line:", lineIdTo));
-  return RouteWeight(it->second, 0 /* nontransitCross */);
+  return RouteWeight(it->second /* weight */, 0 /* nonPassThrougCross */,
+                     it->second /* transitTime */);
 }
 
 void TransitGraph::GetTransitEdges(Segment const & segment, bool isOutgoing,

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -117,7 +117,7 @@ RouteWeight TransitWorldGraph::HeuristicCostEstimate(Segment const & from, Segme
 
 RouteWeight TransitWorldGraph::HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to)
 {
-  return RouteWeight(m_estimator->CalcHeuristic(from, to), 0 /* nontransitCross */);
+  return RouteWeight(m_estimator->CalcHeuristic(from, to));
 }
 
 RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment)
@@ -129,14 +129,13 @@ RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment)
   }
 
   return RouteWeight(m_estimator->CalcSegmentWeight(
-                         segment, GetRealRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())),
-                     0 /* nontransitCross */);
+      segment, GetRealRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())));
 }
 
 RouteWeight TransitWorldGraph::CalcOffroadWeight(m2::PointD const & from,
                                                  m2::PointD const & to) const
 {
-  return RouteWeight(m_estimator->CalcOffroadWeight(from, to), 0 /* nontransitCross */);
+  return RouteWeight(m_estimator->CalcOffroadWeight(from, to));
 }
 
 bool TransitWorldGraph::LeapIsAllowed(NumMwmId /* mwmId */) const { return false; }
@@ -172,7 +171,7 @@ void TransitWorldGraph::GetTwins(Segment const & segment, bool isOutgoing,
     // in different mwms. But if we have mwms with different versions and feature
     // was moved in one of them we can have nonzero weight here.
     double const weight = m_estimator->CalcHeuristic(from, to);
-    edges.emplace_back(twin, RouteWeight(weight, 0 /* nontransitCross */));
+    edges.emplace_back(twin, RouteWeight(weight));
   }
 }
 

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -32,6 +32,11 @@ public:
   // WorldGraph overrides:
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
                    std::vector<SegmentEdge> & edges) override;
+  bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const override
+  {
+    return weight.GetWeight() - weight.GetTransitTime() <=
+           MaxPedestrianTimeSec(startToFinishDistanceM);
+  }
   Junction const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
   // All transit features are oneway.
@@ -51,6 +56,13 @@ public:
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
 private:
+  static double MaxPedestrianTimeSec(double startToFinishDistanceM)
+  {
+    // @todo(tatiana-kondakova) test and adjust constants.
+    // 15 min + 2 additional minutes per 1 km for now.
+    return 15 * 60 + (startToFinishDistanceM / 1000) * 2 * 60;
+  }
+
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -46,11 +46,15 @@ public:
   virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
                            std::vector<SegmentEdge> & edges) = 0;
 
+  // Checks whether path length meets restrictions. Restrictions may depend on the distance from
+  // start to finish of the route.
+  virtual bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const = 0;
+
   virtual Junction const & GetJunction(Segment const & segment, bool front) = 0;
   virtual m2::PointD const & GetPoint(Segment const & segment, bool front) = 0;
   virtual bool IsOneWay(NumMwmId mwmId, uint32_t featureId) = 0;
 
-  // Checks feature is allowed for through passage.
+  // Checks whether feature is allowed for through passage.
   virtual bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) = 0;
 
   // Clear memory used by loaded graphs.

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -205,7 +205,7 @@ void TrackMatcher::Step::ChooseSegment(Step const & nextStep, IndexGraph & index
 
   vector<SegmentEdge> edges;
   indexGraph.GetEdgeList(nextStep.m_segment, false /* isOutgoing */, edges);
-  edges.emplace_back(nextStep.m_segment, RouteWeight(0.0, 0));
+  edges.emplace_back(nextStep.m_segment, GetAStarWeightZero<RouteWeight>());
 
   for (Candidate const & candidate : m_candidates)
   {


### PR DESCRIPTION
Ограничения времени хождения пешком для режима прокладки маршрута Transit.

Текущая реализация находит только самый коротки маршрут. Если есть маршрут на транспорте, удовлетворяющий ограничениям на пешее время, но который при этом не является самым коротким по общему времени, он не будет найден. Решение которое позволит искать такие маршруты требует дополнительной исследовательской работы для реализации.

+ Сделала в AStar коллбек для проверки допустимости веса.
+ Добавила компоненту transitTime в многокомпонентный вес -- время движения на транспорте. Сначала собиралась сделать pedestrianTime, но transitTime кажется более правильным т.к. TransitGraph знает какие ребра мы едем на транспорте, какие идём пешком и может всё правльно заполнить.
+ Перевела проверку допустимости nonPassThroughCross на этот же коллбек.

Константы которые сейчас используются для допустимого пешеходного времени получены в результате моих личных ручных экспериментов и нуждаются в улучшении по результатам тестирования.