### PR TITLE
Single place for all fake feature ids

### DIFF
--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -44,6 +44,8 @@ set(
   editable_map_object.hpp
   edits_migration.cpp
   edits_migration.hpp
+  fake_feature_ids.cpp
+  fake_feature_ids.hpp
   feature_algo.cpp
   feature_algo.hpp
   feature_altitude.hpp

--- a/indexer/fake_feature_ids.cpp
+++ b/indexer/fake_feature_ids.cpp
@@ -1,0 +1,8 @@
+#include "indexer/fake_feature_ids.hpp"
+
+namespace feature
+{
+uint32_t constexpr FakeFeatureIds::kIndexGraphStarterId;
+uint32_t constexpr FakeFeatureIds::kTransitGraphId;
+uint32_t constexpr FakeFeatureIds::kEditorCreatedFeaturesStart;
+}  // namespace feature

--- a/indexer/fake_feature_ids.hpp
+++ b/indexer/fake_feature_ids.hpp
@@ -3,14 +3,21 @@
 #include <cstdint>
 #include <limits>
 
-namespace routing
+namespace feature
 {
 struct FakeFeatureIds
 {
+  static bool IsEditorCreatedFeature(uint32_t id)
+  {
+    return id >= kEditorCreatedFeaturesStart && id != kIndexGraphStarterId && id != kTransitGraphId;
+  }
+
   static uint32_t constexpr kIndexGraphStarterId = std::numeric_limits<uint32_t>::max();
   static uint32_t constexpr kTransitGraphId = std::numeric_limits<uint32_t>::max() - 1;
+  static uint32_t constexpr kEditorCreatedFeaturesStart =
+      std::numeric_limits<uint32_t>::max() - 0xfffff;
 };
 
 static_assert(FakeFeatureIds::kIndexGraphStarterId != FakeFeatureIds::kTransitGraphId,
               "Fake feature ids should differ.");
-}  // namespace routing
+}  // namespace feature

--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -27,6 +27,7 @@ SOURCES += \
     drules_selector_parser.cpp \
     editable_map_object.cpp \
     edits_migration.cpp \
+    fake_feature_ids.cpp \
     feature.cpp \
     feature_algo.cpp \
     feature_covering.cpp \
@@ -85,6 +86,7 @@ HEADERS += \
     drules_selector_parser.hpp \
     editable_map_object.hpp \
     edits_migration.hpp \
+    fake_feature_ids.hpp \
     feature.hpp \
     feature_algo.hpp \
     feature_altitude.hpp \

--- a/indexer/osm_editor.cpp
+++ b/indexer/osm_editor.cpp
@@ -1,13 +1,15 @@
+#include "indexer/osm_editor.hpp"
+
 #include "indexer/categories_holder.hpp"
 #include "indexer/classificator.hpp"
 #include "indexer/edits_migration.hpp"
+#include "indexer/fake_feature_ids.hpp"
 #include "indexer/feature_algo.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/feature_impl.hpp"
 #include "indexer/feature_meta.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/index.hpp"
-#include "indexer/osm_editor.hpp"
 #include "indexer/index_helpers.hpp"
 
 #include "platform/local_country_file_utils.hpp"
@@ -404,14 +406,9 @@ void Editor::DeleteFeature(FeatureID const & fid)
   Invalidate();
 }
 
-namespace
-{
-constexpr uint32_t kStartIndexForCreatedFeatures = numeric_limits<uint32_t>::max() - 0xfffff;
-}  // namespace
-
 bool Editor::IsCreatedFeature(FeatureID const & fid)
 {
-  return fid.m_index >= kStartIndexForCreatedFeatures;
+  return feature::FakeFeatureIds::IsEditorCreatedFeature(fid.m_index);
 }
 
 bool Editor::OriginalFeatureHasDefaultName(FeatureID const & fid) const
@@ -1041,7 +1038,7 @@ FeatureID Editor::GenerateNewFeatureId(MwmSet::MwmId const & id)
 {
   DECLARE_AND_ASSERT_THREAD_CHECKER("GenerateNewFeatureId is single-threaded.");
   // TODO(vng): Double-check if new feature indexes should uninterruptedly continue after existing indexes in mwm file.
-  uint32_t featureIndex = kStartIndexForCreatedFeatures;
+  uint32_t featureIndex = feature::FakeFeatureIds::kEditorCreatedFeaturesStart;
   auto const found = m_features.find(id);
   if (found != m_features.end())
   {
@@ -1052,6 +1049,8 @@ FeatureID Editor::GenerateNewFeatureId(MwmSet::MwmId const & id)
         featureIndex = feature.first + 1;
     }
   }
+  CHECK(feature::FakeFeatureIds::IsEditorCreatedFeature(featureIndex),
+        ("FaeatureIndex is out of osm editor features interval."));
   return FeatureID(id, featureIndex);
 }
 

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -46,8 +46,6 @@ set(
   fake_edges_container.hpp
   fake_ending.cpp
   fake_ending.hpp
-  fake_feature_ids.cpp
-  fake_feature_ids.hpp
   fake_graph.hpp
   fake_vertex.hpp
   features_road_graph.cpp

--- a/routing/fake_feature_ids.cpp
+++ b/routing/fake_feature_ids.cpp
@@ -1,7 +1,0 @@
-#include "routing/fake_feature_ids.hpp"
-
-namespace routing
-{
-uint32_t constexpr FakeFeatureIds::kIndexGraphStarterId;
-uint32_t constexpr FakeFeatureIds::kTransitGraphId;
-}  // namespace routing

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -2,7 +2,6 @@
 
 #include "routing/base/routing_result.hpp"
 #include "routing/fake_ending.hpp"
-#include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
 #include "routing/fake_vertex.hpp"
 #include "routing/index_graph.hpp"
@@ -13,6 +12,8 @@
 #include "routing/world_graph.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
+
+#include "indexer/fake_feature_ids.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -131,7 +132,7 @@ private:
   void AddRealEdges(Segment const & segment, bool isOutgoing,
                     std::vector<SegmentEdge> & edges) const;
 
-  static uint32_t constexpr kFakeFeatureId = FakeFeatureIds::kIndexGraphStarterId;
+  static uint32_t constexpr kFakeFeatureId = feature::FakeFeatureIds::kIndexGraphStarterId;
   WorldGraph & m_graph;
   // Start segment id
   uint32_t m_startId;

--- a/routing/routing.pro
+++ b/routing/routing.pro
@@ -29,7 +29,6 @@ SOURCES += \
     directions_engine.cpp \
     edge_estimator.cpp \
     fake_ending.cpp \
-    fake_feature_ids.cpp \
     features_road_graph.cpp \
     geometry.cpp \
     index_graph.cpp \
@@ -99,7 +98,6 @@ HEADERS += \
     edge_estimator.hpp \
     fake_edges_container.hpp \
     fake_ending.hpp \
-    fake_feature_ids.hpp \
     fake_graph.hpp \
     fake_vertex.hpp \
     features_road_graph.hpp \

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -2,7 +2,6 @@
 
 #include "routing/edge_estimator.hpp"
 #include "routing/fake_ending.hpp"
-#include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
 #include "routing/fake_vertex.hpp"
 #include "routing/road_graph.hpp"
@@ -10,6 +9,8 @@
 #include "routing/segment.hpp"
 
 #include "routing_common/transit_types.hpp"
+
+#include "indexer/fake_feature_ids.hpp"
 
 #include <cstdint>
 #include <map>
@@ -74,7 +75,7 @@ private:
   void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,
                       StopToSegmentsMap const & stopToFront, bool isOutgoing);
 
-  static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
+  static uint32_t constexpr kTransitFeatureId = feature::FakeFeatureIds::kTransitGraphId;
   NumMwmId const m_mwmId = kFakeNumMwmId;
   std::shared_ptr<EdgeEstimator> m_estimator;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		3D74EF241F8F559D0081202C /* ugc_types_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D74EF231F8F559D0081202C /* ugc_types_test.cpp */; };
 		3D928F671D50F9FE001670E0 /* index_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D928F651D50F9FE001670E0 /* index_helpers.cpp */; };
 		3D928F681D50F9FE001670E0 /* index_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D928F661D50F9FE001670E0 /* index_helpers.hpp */; };
+		4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */; };
+		4099F64A1FC7142A002A7B05 /* fake_feature_ids.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */; };
 		456B3FB41EDEEB65009B3D1F /* scales_patch.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */; };
 		456E1B181F90E5B7009C32E1 /* cities_boundaries_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */; };
 		456E1B191F90E5B7009C32E1 /* ftypes_sponsored.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 456E1B151F90E5B6009C32E1 /* ftypes_sponsored.cpp */; };
@@ -301,6 +303,8 @@
 		3D74EF231F8F559D0081202C /* ugc_types_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ugc_types_test.cpp; sourceTree = "<group>"; };
 		3D928F651D50F9FE001670E0 /* index_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_helpers.cpp; sourceTree = "<group>"; };
 		3D928F661D50F9FE001670E0 /* index_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_helpers.hpp; sourceTree = "<group>"; };
+		4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
+		4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_feature_ids.hpp; sourceTree = "<group>"; };
 		456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scales_patch.hpp; sourceTree = "<group>"; };
 		456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cities_boundaries_serdes.hpp; sourceTree = "<group>"; };
 		456E1B151F90E5B6009C32E1 /* ftypes_sponsored.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ftypes_sponsored.cpp; sourceTree = "<group>"; };
@@ -695,6 +699,8 @@
 				3D928F661D50F9FE001670E0 /* index_helpers.hpp */,
 				34664CEE1D49FEC1003D7096 /* altitude_loader.cpp */,
 				34664CEF1D49FEC1003D7096 /* altitude_loader.hpp */,
+				4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */,
+				4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */,
 				34664CF01D49FEC1003D7096 /* feature_altitude.hpp */,
 				34664CF11D49FEC1003D7096 /* centers_table.cpp */,
 				34664CF21D49FEC1003D7096 /* centers_table.hpp */,
@@ -925,6 +931,7 @@
 				6753411B1A3F540F00A0A8C3 /* feature_impl.hpp in Headers */,
 				34AF87E61DBE565F00E5E7DC /* helpers.hpp in Headers */,
 				675341111A3F540F00A0A8C3 /* drules_struct.pb.h in Headers */,
+				4099F64A1FC7142A002A7B05 /* fake_feature_ids.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1117,6 +1124,7 @@
 				3D452AFA1EE6D9F5009EAB9B /* wheelchair_tests.cpp in Sources */,
 				675341121A3F540F00A0A8C3 /* feature_algo.cpp in Sources */,
 				675341211A3F540F00A0A8C3 /* feature_utils.cpp in Sources */,
+				4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */,
 				675341231A3F540F00A0A8C3 /* feature_visibility.cpp in Sources */,
 				56C74C221C749E4700B71B9F /* search_delimiters.cpp in Sources */,
 				347F337B1C454242009758CC /* rank_table.cpp in Sources */,

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -59,14 +59,12 @@
 		40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40576F771F7A788B000B593B /* fake_vertex.hpp */; };
 		405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 405F48DB1F6AD01C005BA81A /* routing_result.hpp */; };
 		405F48E91F75231E005BA81A /* fake_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 405F48E81F75231E005BA81A /* fake_graph.hpp */; };
-		40655E741F8BA46B0065305E /* fake_feature_ids.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40655E731F8BA46B0065305E /* fake_feature_ids.hpp */; };
 		4065EA801F824A6C0094DEF3 /* transit_world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */; };
 		4065EA811F824A6C0094DEF3 /* transit_world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */; };
 		4065EA851F8260010094DEF3 /* transit_graph_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */; };
 		4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */; };
 		4065EA871F8260010094DEF3 /* transit_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA841F8260000094DEF3 /* transit_graph.hpp */; };
 		4081AD4E1F8E4C1D006CE8A5 /* transit_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */; };
-		40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */; };
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
@@ -357,14 +355,12 @@
 		40576F771F7A788B000B593B /* fake_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_vertex.hpp; sourceTree = "<group>"; };
 		405F48DB1F6AD01C005BA81A /* routing_result.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result.hpp; sourceTree = "<group>"; };
 		405F48E81F75231E005BA81A /* fake_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_graph.hpp; sourceTree = "<group>"; };
-		40655E731F8BA46B0065305E /* fake_feature_ids.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_feature_ids.hpp; sourceTree = "<group>"; };
 		4065EA7E1F824A6C0094DEF3 /* transit_world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_world_graph.hpp; sourceTree = "<group>"; };
 		4065EA7F1F824A6C0094DEF3 /* transit_world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_world_graph.cpp; sourceTree = "<group>"; };
 		4065EA821F8260000094DEF3 /* transit_graph_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph_loader.cpp; sourceTree = "<group>"; };
 		4065EA831F8260000094DEF3 /* transit_graph_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph_loader.hpp; sourceTree = "<group>"; };
 		4065EA841F8260000094DEF3 /* transit_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph.hpp; sourceTree = "<group>"; };
 		4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph.cpp; sourceTree = "<group>"; };
-		40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
@@ -853,8 +849,6 @@
 				40C227FD1F61C07C0046696C /* fake_edges_container.hpp */,
 				40C645141F8D167E002E05A0 /* fake_ending.cpp */,
 				40C645151F8D167E002E05A0 /* fake_ending.hpp */,
-				40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */,
-				40655E731F8BA46B0065305E /* fake_feature_ids.hpp */,
 				405F48E81F75231E005BA81A /* fake_graph.hpp */,
 				40576F771F7A788B000B593B /* fake_vertex.hpp */,
 				674F9BBC1B0A580E00704FFA /* features_road_graph.cpp */,
@@ -1008,7 +1002,6 @@
 				4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */,
 				6741AA9D1BF35331002C974C /* turns_notification_manager.hpp in Headers */,
 				674F9BD71B0A580E00704FFA /* turns_generator.hpp in Headers */,
-				40655E741F8BA46B0065305E /* fake_feature_ids.hpp in Headers */,
 				A120B3461B4A7BE5002F3808 /* cross_mwm_road_graph.hpp in Headers */,
 				6753441C1A3F644F00A0A8C3 /* route.hpp in Headers */,
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
@@ -1299,7 +1292,6 @@
 				0C5F5D221E798B0400307B98 /* cross_mwm_connector.cpp in Sources */,
 				0C81E1531F02589800DC66DF /* traffic_stash.cpp in Sources */,
 				0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */,
-				40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */,
 				675344191A3F644F00A0A8C3 /* osrm2feature_map.cpp in Sources */,
 				40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,


### PR DESCRIPTION
Для более прозрачной поддержки cross-mwm планируется перевести TransitGraph на разные FeatureId для разных дуг (сейчас FeatureId у всех одна, разные segmentIdx).

Перед этим перенесла в одно место FakeFeatureIds из роутинга и из OsmEditor, чтобы проще было следить, что диапазоны не накладываются.