### PR TITLE
[routing][transit] Use different featureIds for transit segments. 

### DIFF
--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -44,6 +44,8 @@ set(
   editable_map_object.hpp
   edits_migration.cpp
   edits_migration.hpp
+  fake_feature_ids.cpp
+  fake_feature_ids.hpp
   feature_algo.cpp
   feature_algo.hpp
   feature_altitude.hpp

--- a/indexer/fake_feature_ids.cpp
+++ b/indexer/fake_feature_ids.cpp
@@ -1,0 +1,9 @@
+#include "indexer/fake_feature_ids.hpp"
+
+namespace feature
+{
+// static
+uint32_t constexpr FakeFeatureIds::k20BitsOffset;
+// static
+uint32_t constexpr FakeFeatureIds::kEditorCreatedFeaturesStart;
+}  // namespace feature

--- a/indexer/fake_feature_ids.hpp
+++ b/indexer/fake_feature_ids.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+// Before creating new fake feature interval note that routing has 
+// it's own fake features in routing/fake_feature_ids.hpp
+
+namespace feature
+{
+struct FakeFeatureIds
+{
+  static bool IsEditorCreatedFeature(uint32_t id)
+  {
+    return id >= kEditorCreatedFeaturesStart;
+  }
+
+  static uint32_t constexpr k20BitsOffset = 0xfffff;
+  static uint32_t constexpr kEditorCreatedFeaturesStart =
+      std::numeric_limits<uint32_t>::max() - k20BitsOffset;
+};
+}  // namespace feature

--- a/indexer/indexer.pro
+++ b/indexer/indexer.pro
@@ -27,6 +27,7 @@ SOURCES += \
     drules_selector_parser.cpp \
     editable_map_object.cpp \
     edits_migration.cpp \
+    fake_feature_ids.cpp \
     feature.cpp \
     feature_algo.cpp \
     feature_covering.cpp \
@@ -85,6 +86,7 @@ HEADERS += \
     drules_selector_parser.hpp \
     editable_map_object.hpp \
     edits_migration.hpp \
+    fake_feature_ids.hpp \
     feature.hpp \
     feature_algo.hpp \
     feature_altitude.hpp \

--- a/routing/fake_feature_ids.cpp
+++ b/routing/fake_feature_ids.cpp
@@ -2,6 +2,10 @@
 
 namespace routing
 {
+// static
 uint32_t constexpr FakeFeatureIds::kIndexGraphStarterId;
-uint32_t constexpr FakeFeatureIds::kTransitGraphId;
+// static
+uint32_t constexpr FakeFeatureIds::k24BitsOffset;
+// static
+uint32_t constexpr FakeFeatureIds::kTransitGraphFeaturesStart;
 }  // namespace routing

--- a/routing/fake_feature_ids.hpp
+++ b/routing/fake_feature_ids.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "indexer/fake_feature_ids.hpp"
+
 #include <cstdint>
 #include <limits>
 
@@ -7,10 +9,27 @@ namespace routing
 {
 struct FakeFeatureIds
 {
+  static bool IsTransitFeature(uint32_t id)
+  {
+    return id >= kTransitGraphFeaturesStart && id != kIndexGraphStarterId &&
+           !feature::FakeFeatureIds::IsEditorCreatedFeature(id);
+  }
+
   static uint32_t constexpr kIndexGraphStarterId = std::numeric_limits<uint32_t>::max();
-  static uint32_t constexpr kTransitGraphId = std::numeric_limits<uint32_t>::max() - 1;
+  // It's important that |kTransitGraphFeaturesStart| is greater than maximum number of real road
+  // feature id. Also transit fake feature id should not overlap with real feature id and editor
+  // feature ids.
+  static uint32_t constexpr k24BitsOffset = 0xffffff;
+  static uint32_t constexpr kTransitGraphFeaturesStart =
+      std::numeric_limits<uint32_t>::max() - k24BitsOffset;
 };
 
-static_assert(FakeFeatureIds::kIndexGraphStarterId != FakeFeatureIds::kTransitGraphId,
-              "Fake feature ids should differ.");
+static_assert(feature::FakeFeatureIds::kEditorCreatedFeaturesStart >
+                      FakeFeatureIds::kTransitGraphFeaturesStart &&
+                  feature::FakeFeatureIds::kEditorCreatedFeaturesStart -
+                          FakeFeatureIds::kTransitGraphFeaturesStart >=
+                      FakeFeatureIds::k24BitsOffset - feature::FakeFeatureIds::k20BitsOffset,
+              "routing::FakeFeatureIds::kTransitGraphFeaturesStart or "
+              "feature::FakeFeatureIds::kEditorCreatedFeaturesStart was changed. "
+              "Interval for transit fake features may be too small.");
 }  // namespace routing

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -2,7 +2,6 @@
 
 #include "routing/edge_estimator.hpp"
 #include "routing/fake_ending.hpp"
-#include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
 #include "routing/fake_vertex.hpp"
 #include "routing/road_graph.hpp"
@@ -74,7 +73,6 @@ private:
   void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,
                       StopToSegmentsMap const & stopToFront, bool isOutgoing);
 
-  static uint32_t constexpr kTransitFeatureId = FakeFeatureIds::kTransitGraphId;
   NumMwmId const m_mwmId = kFakeNumMwmId;
   std::shared_ptr<EdgeEstimator> m_estimator;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		3D74EF241F8F559D0081202C /* ugc_types_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D74EF231F8F559D0081202C /* ugc_types_test.cpp */; };
 		3D928F671D50F9FE001670E0 /* index_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D928F651D50F9FE001670E0 /* index_helpers.cpp */; };
 		3D928F681D50F9FE001670E0 /* index_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D928F661D50F9FE001670E0 /* index_helpers.hpp */; };
+		4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */; };
+		4099F64A1FC7142A002A7B05 /* fake_feature_ids.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */; };
 		456B3FB41EDEEB65009B3D1F /* scales_patch.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */; };
 		456E1B181F90E5B7009C32E1 /* cities_boundaries_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */; };
 		456E1B191F90E5B7009C32E1 /* ftypes_sponsored.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 456E1B151F90E5B6009C32E1 /* ftypes_sponsored.cpp */; };
@@ -301,6 +303,8 @@
 		3D74EF231F8F559D0081202C /* ugc_types_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ugc_types_test.cpp; sourceTree = "<group>"; };
 		3D928F651D50F9FE001670E0 /* index_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_helpers.cpp; sourceTree = "<group>"; };
 		3D928F661D50F9FE001670E0 /* index_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_helpers.hpp; sourceTree = "<group>"; };
+		4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
+		4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_feature_ids.hpp; sourceTree = "<group>"; };
 		456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scales_patch.hpp; sourceTree = "<group>"; };
 		456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cities_boundaries_serdes.hpp; sourceTree = "<group>"; };
 		456E1B151F90E5B6009C32E1 /* ftypes_sponsored.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ftypes_sponsored.cpp; sourceTree = "<group>"; };
@@ -695,6 +699,8 @@
 				3D928F661D50F9FE001670E0 /* index_helpers.hpp */,
 				34664CEE1D49FEC1003D7096 /* altitude_loader.cpp */,
 				34664CEF1D49FEC1003D7096 /* altitude_loader.hpp */,
+				4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */,
+				4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */,
 				34664CF01D49FEC1003D7096 /* feature_altitude.hpp */,
 				34664CF11D49FEC1003D7096 /* centers_table.cpp */,
 				34664CF21D49FEC1003D7096 /* centers_table.hpp */,
@@ -925,6 +931,7 @@
 				6753411B1A3F540F00A0A8C3 /* feature_impl.hpp in Headers */,
 				34AF87E61DBE565F00E5E7DC /* helpers.hpp in Headers */,
 				675341111A3F540F00A0A8C3 /* drules_struct.pb.h in Headers */,
+				4099F64A1FC7142A002A7B05 /* fake_feature_ids.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1117,6 +1124,7 @@
 				3D452AFA1EE6D9F5009EAB9B /* wheelchair_tests.cpp in Sources */,
 				675341121A3F540F00A0A8C3 /* feature_algo.cpp in Sources */,
 				675341211A3F540F00A0A8C3 /* feature_utils.cpp in Sources */,
+				4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */,
 				675341231A3F540F00A0A8C3 /* feature_visibility.cpp in Sources */,
 				56C74C221C749E4700B71B9F /* search_delimiters.cpp in Sources */,
 				347F337B1C454242009758CC /* rank_table.cpp in Sources */,


### PR DESCRIPTION
Перевела TransitGraph на использование разных FeatureId вместо kTransitFeatureId и разных SegmentIdx.
Для избежания конфликтов фейковых диапазонов в TransitGraph и в OsmEditor вынесла определение фейкового диапазона в OsmEditor из анонимного неймспейса в хедер.