### PR TITLE
Stop crashing generator in case of absence transit section.

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -270,8 +270,12 @@ void CalcCrossMwmTransitions(string const & mwmFile, string const & mappingFile,
   try
   {
     FilesContainerR cont(mwmFile);
-    CHECK(cont.IsExist(TRANSIT_FILE_TAG),
-          (TRANSIT_FILE_TAG, "should be generated before", TRANSIT_CROSS_MWM_FILE_TAG));
+    if (!cont.IsExist(TRANSIT_FILE_TAG))
+    {
+      LOG(LINFO, ("Transit cross mwm section is not generated because no transit section in mwm:",
+                  mwmFile));
+      return;
+    }
     auto reader = cont.GetReader(TRANSIT_FILE_TAG);
 
     using Source = ReaderSource<FilesContainerR::TReader>;


### PR DESCRIPTION
Очень часто бывает, что при генерации mwm нам нечего положить в секцию transit. И следовательно мы ее не создаем. Затем при попытке создать transit_cross_mwm мы падаем на CHECK о том, что не transit. Что не верно. Данный PR исправляет ошибку.

@tatiana-kondakova @ygorshenin PTAL