### PR TITLE
 [base] ControlFlow.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -17,6 +17,7 @@ set(
   collection_cast.hpp
   condition.cpp
   condition.hpp
+  control_flow.hpp
   deferred_task.cpp
   deferred_task.hpp
   dfa_helpers.hpp

--- a/base/base.pro
+++ b/base/base.pro
@@ -54,6 +54,7 @@ HEADERS += \
     clustering_map.hpp \
     collection_cast.hpp \
     condition.hpp \
+    control_flow.hpp \
     deferred_task.hpp \
     dfa_helpers.hpp \
     exception.hpp \

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
   collection_cast_test.cpp
   condition_test.cpp
   containers_test.cpp
+  control_flow_tests.cpp
   levenshtein_dfa_test.cpp
   logging_test.cpp
   math_test.cpp

--- a/base/base_tests/base_tests.pro
+++ b/base/base_tests/base_tests.pro
@@ -23,6 +23,7 @@ SOURCES += \
   collection_cast_test.cpp \
   condition_test.cpp \
   containers_test.cpp \
+  control_flow_tests.cpp \
   levenshtein_dfa_test.cpp \
   logging_test.cpp \
   newtype_test.cpp \

--- a/base/base_tests/control_flow_tests.cpp
+++ b/base/base_tests/control_flow_tests.cpp
@@ -20,7 +20,7 @@ struct Repeater
     {
       ++m_calls;
       if (wrapper() == ControlFlow::Break)
-        break;
+        return;
     }
   }
 

--- a/base/base_tests/control_flow_tests.cpp
+++ b/base/base_tests/control_flow_tests.cpp
@@ -1,0 +1,57 @@
+#include "testing/testing.hpp"
+
+#include "base/control_flow.hpp"
+
+#include <cstdint>
+
+using namespace base;
+
+namespace
+{
+struct Repeater
+{
+  explicit Repeater(uint32_t repetitions) : m_repetitions(repetitions) {}
+
+  template <typename Fn>
+  void ForEach(Fn && fn)
+  {
+    ControlFlowWrapper<Fn> wrapper(std::forward<Fn>(fn));
+    for (uint32_t i = 0; i < m_repetitions; ++i)
+    {
+      ++m_calls;
+      if (wrapper() == ControlFlow::Break)
+        break;
+    }
+  }
+
+  uint32_t m_repetitions = 0;
+  uint32_t m_calls = 0;
+};
+}  // namespace
+
+UNIT_TEST(ControlFlow_Smoke)
+{
+  {
+    Repeater repeater(10);
+    uint32_t c = 0;
+    repeater.ForEach([&c] { ++c; });
+
+    TEST_EQUAL(c, 10, ());
+    TEST_EQUAL(c, repeater.m_repetitions, ());
+    TEST_EQUAL(c, repeater.m_calls, ());
+  }
+
+  {
+    Repeater repeater(10);
+    uint32_t c = 0;
+    repeater.ForEach([&c] {
+      ++c;
+      if (c == 5)
+        return ControlFlow::Break;
+      return ControlFlow::Continue;
+    });
+
+    TEST_EQUAL(c, 5, ());
+    TEST_EQUAL(c, repeater.m_calls, ());
+  }
+}

--- a/base/control_flow.hpp
+++ b/base/control_flow.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 namespace base
 {
 // This enum is used to control the flow of ForEach invocations.
@@ -7,5 +9,37 @@ enum class ControlFlow
 {
   Break,
   Continue
+};
+
+// A wrapper that calls |fn| with arguments |args|.
+// To avoid excessive calls, |fn| may signal the end of execution via its return value,
+// which should then be checked by the wrapper's user.
+template <typename Fn>
+struct ControlFlowWrapper
+{
+  template <typename Gn>
+  explicit ControlFlowWrapper(Gn && gn) : m_fn(std::forward<Gn>(gn))
+  {
+  }
+
+  template <typename... Args>
+  typename std::enable_if<
+      std::is_same<typename std::result_of<Fn(Args...)>::type, base::ControlFlow>::value,
+      base::ControlFlow>::type
+  operator()(Args &&... args)
+  {
+    return m_fn(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  typename std::enable_if<std::is_same<typename std::result_of<Fn(Args...)>::type, void>::value,
+                          base::ControlFlow>::type
+  operator()(Args &&... args)
+  {
+    m_fn(std::forward<Args>(args)...);
+    return ControlFlow::Continue;
+  }
+
+  Fn m_fn;
 };
 }  // namespace base

--- a/base/control_flow.hpp
+++ b/base/control_flow.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <type_traits>
 #include <utility>
 
 namespace base
@@ -15,8 +16,9 @@ enum class ControlFlow
 // To avoid excessive calls, |fn| may signal the end of execution via its return value,
 // which should then be checked by the wrapper's user.
 template <typename Fn>
-struct ControlFlowWrapper
+class ControlFlowWrapper
 {
+public:
   template <typename Gn>
   explicit ControlFlowWrapper(Gn && gn) : m_fn(std::forward<Gn>(gn))
   {
@@ -40,6 +42,7 @@ struct ControlFlowWrapper
     return ControlFlow::Continue;
   }
 
+private:
   Fn m_fn;
 };
 }  // namespace base

--- a/base/control_flow.hpp
+++ b/base/control_flow.hpp
@@ -2,7 +2,7 @@
 
 namespace base
 {
-// This class is used to control the flow of ForEach invocations.
+// This enum is used to control the flow of ForEach invocations.
 enum class ControlFlow
 {
   Break,

--- a/base/control_flow.hpp
+++ b/base/control_flow.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace base
+{
+// This class is used to control the flow of ForEach invocations.
+enum class ControlFlow
+{
+  Break,
+  Continue
+};
+}  // namespace base

--- a/coding/coding_tests/multilang_utf8_string_test.cpp
+++ b/coding/coding_tests/multilang_utf8_string_test.cpp
@@ -6,6 +6,12 @@
 
 #include "3party/utfcpp/source/utf8.h"
 
+#include <cstddef>
+#include <string>
+#include <vector>
+
+using namespace std;
+
 namespace
 {
 struct lang_string

--- a/coding/multilang_utf8_string.cpp
+++ b/coding/multilang_utf8_string.cpp
@@ -214,29 +214,33 @@ namespace
 
 struct Printer
 {
-  string & m_out;
-  Printer(string & out) : m_out(out) {}
-  bool operator()(int8_t code, string const & name) const
+  explicit Printer(string & out) : m_out(out) {}
+
+  base::ControlFlow operator()(int8_t code, string const & name) const
   {
     m_out += string(StringUtf8Multilang::GetLangByCode(code)) + string(":") + name + " ";
-    return true;
+    return base::ControlFlow::Continue;
   }
+
+  string & m_out;
 };
 
 struct Finder
 {
-  string const & m_s;
-  int8_t m_res;
-  Finder(string const & s) : m_s(s), m_res(-1) {}
-  bool operator()(int8_t code, string const & name)
+  explicit Finder(string const & s) : m_s(s), m_res(-1) {}
+
+  base::ControlFlow operator()(int8_t code, string const & name)
   {
     if (name == m_s)
     {
       m_res = code;
-      return false;
+      return base::ControlFlow::Break;
     }
-    return true;
+    return base::ControlFlow::Continue;
   }
+
+  string const & m_s;
+  int8_t m_res;
 };
 
 } // namespace

--- a/coding/multilang_utf8_string.cpp
+++ b/coding/multilang_utf8_string.cpp
@@ -209,52 +209,30 @@ bool StringUtf8Multilang::HasString(int8_t lang) const
   return false;
 }
 
-namespace
+int8_t StringUtf8Multilang::FindString(string const & utf8s) const
 {
+  int8_t result = kUnsupportedLanguageCode;
 
-struct Printer
-{
-  explicit Printer(string & out) : m_out(out) {}
-
-  base::ControlFlow operator()(int8_t code, string const & name) const
-  {
-    m_out += string(StringUtf8Multilang::GetLangByCode(code)) + string(":") + name + " ";
-    return base::ControlFlow::Continue;
-  }
-
-  string & m_out;
-};
-
-struct Finder
-{
-  explicit Finder(string const & s) : m_s(s), m_res(-1) {}
-
-  base::ControlFlow operator()(int8_t code, string const & name)
-  {
-    if (name == m_s)
+  ForEach([&utf8s, &result](int8_t code, string const & name) -> base::ControlFlow {
+    if (name == utf8s)
     {
-      m_res = code;
+      result = code;
       return base::ControlFlow::Break;
     }
     return base::ControlFlow::Continue;
-  }
+  });
 
-  string const & m_s;
-  int8_t m_res;
-};
-
-} // namespace
-
-int8_t StringUtf8Multilang::FindString(string const & utf8s) const
-{
-  Finder finder(utf8s);
-  ForEach(finder);
-  return finder.m_res;
+  return result;
 }
 
 string DebugPrint(StringUtf8Multilang const & s)
 {
-  string out;
-  s.ForEach(Printer(out));
-  return out;
+  string result;
+
+  s.ForEach([&result](int8_t code, string const & name) -> base::ControlFlow {
+    result += string(StringUtf8Multilang::GetLangByCode(code)) + string(":") + name + " ";
+    return base::ControlFlow::Continue;
+  });
+
+  return result;
 }

--- a/coding/multilang_utf8_string.cpp
+++ b/coding/multilang_utf8_string.cpp
@@ -2,6 +2,8 @@
 
 #include "defines.hpp"
 
+using namespace std;
+
 namespace
 {
 // TODO(AlexZ): Review and replace invalid languages which does not map correctly to
@@ -213,7 +215,7 @@ int8_t StringUtf8Multilang::FindString(string const & utf8s) const
 {
   int8_t result = kUnsupportedLanguageCode;
 
-  ForEach([&utf8s, &result](int8_t code, string const & name) -> base::ControlFlow {
+  ForEach([&utf8s, &result](int8_t code, string const & name) {
     if (name == utf8s)
     {
       result = code;
@@ -229,9 +231,8 @@ string DebugPrint(StringUtf8Multilang const & s)
 {
   string result;
 
-  s.ForEach([&result](int8_t code, string const & name) -> base::ControlFlow {
+  s.ForEach([&result](int8_t code, string const & name) {
     result += string(StringUtf8Multilang::GetLangByCode(code)) + string(":") + name + " ";
-    return base::ControlFlow::Continue;
   });
 
   return result;

--- a/coding/multilang_utf8_string.hpp
+++ b/coding/multilang_utf8_string.hpp
@@ -5,6 +5,7 @@
 #include "coding/writer.hpp"
 
 #include "base/assert.hpp"
+#include "base/control_flow.hpp"
 
 #include "std/array.hpp"
 #include "std/string.hpp"
@@ -97,7 +98,7 @@ public:
     while (i < sz)
     {
       size_t const next = GetNextIndex(i);
-      if (!fn((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)))
+      if (fn((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
         return;
       i = next;
     }

--- a/coding/multilang_utf8_string.hpp
+++ b/coding/multilang_utf8_string.hpp
@@ -88,35 +88,19 @@ public:
       AddString(l, utf8s);
   }
 
-  // Calls |fn| for each pair of |lang| and |utf8s| stored in this multilang string.
-  // To avoid excessive calls, |fn| may signal the end of execution via its return value.
   template <typename Fn>
-  typename enable_if<
-      is_same<typename result_of<Fn(int8_t, std::string)>::type, base::ControlFlow>::value,
-      void>::type
-  ForEach(Fn && fn) const
+  void ForEach(Fn && fn) const
   {
     size_t i = 0;
     size_t const sz = m_s.size();
+    base::ControlFlowWrapper<Fn> wrapper(std::forward<Fn>(fn));
     while (i < sz)
     {
       size_t const next = GetNextIndex(i);
-      if (fn((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
-        return;
+      if (wrapper((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
+        break;
       i = next;
     }
-  }
-
-  // Calls |fn| for each pair of |lang| and |utf8s| stored in this multilang string.
-  template <typename Fn>
-  typename enable_if<is_same<typename result_of<Fn(int8_t, std::string)>::type, void>::value,
-                     void>::type
-  ForEach(Fn && fn) const
-  {
-    ForEach([&](int8_t lang, std::string utf8s) {
-      fn(lang, utf8s);
-      return base::ControlFlow::Continue;
-    });
   }
 
   bool GetString(int8_t lang, string & utf8s) const;

--- a/coding/multilang_utf8_string.hpp
+++ b/coding/multilang_utf8_string.hpp
@@ -8,8 +8,10 @@
 #include "base/control_flow.hpp"
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <type_traits>
+#include <utility>
 
 namespace utils
 {
@@ -88,6 +90,7 @@ public:
       AddString(l, utf8s);
   }
 
+  // Calls |fn| for each pair of |lang| and |utf8s| stored in this multilang string.
   template <typename Fn>
   void ForEach(Fn && fn) const
   {
@@ -98,7 +101,7 @@ public:
     {
       size_t const next = GetNextIndex(i);
       if (wrapper((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
-        break;
+        return;
       i = next;
     }
   }

--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -25,6 +25,8 @@
 #include "storage/index.hpp"
 #include "storage/storage.hpp"
 
+#include "base/control_flow.hpp"
+
 #include "std/algorithm.hpp"
 #include "std/iostream.hpp"
 
@@ -120,10 +122,9 @@ string BuildUniqueId(ms::LatLon const & coords, string const & name)
 void AppendNames(FeatureType const & f, vector<string> & columns)
 {
   vector<string> names(kLangCount);
-  f.GetNames().ForEach([&names](int8_t code, string const & name) -> bool
-  {
+  f.GetNames().ForEach([&names](int8_t code, string const & name) -> base::ControlFlow {
     names[code] = string(name);
-    return true;
+    return base::ControlFlow::Continue;
   });
   columns.insert(columns.end(), next(names.begin()), names.end());
 }

--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -25,8 +25,6 @@
 #include "storage/index.hpp"
 #include "storage/storage.hpp"
 
-#include "base/control_flow.hpp"
-
 #include "std/algorithm.hpp"
 #include "std/iostream.hpp"
 
@@ -122,10 +120,7 @@ string BuildUniqueId(ms::LatLon const & coords, string const & name)
 void AppendNames(FeatureType const & f, vector<string> & columns)
 {
   vector<string> names(kLangCount);
-  f.GetNames().ForEach([&names](int8_t code, string const & name) -> base::ControlFlow {
-    names[code] = string(name);
-    return base::ControlFlow::Continue;
-  });
+  f.GetNames().ForEach([&names](int8_t code, string const & name) { names[code] = name; });
   columns.insert(columns.end(), next(names.begin()), names.end());
 }
 

--- a/generator/dumper.cpp
+++ b/generator/dumper.cpp
@@ -11,7 +11,6 @@
 
 #include "coding/multilang_utf8_string.hpp"
 
-#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 
 #include <algorithm>
@@ -124,7 +123,7 @@ namespace feature
   public:
     TokensContainerT m_stats;
 
-    base::ControlFlow operator()(int8_t langCode, string const & name)
+    void operator()(int8_t langCode, string const & name)
     {
       CHECK(!name.empty(), ("Feature name is empty"));
 
@@ -133,7 +132,7 @@ namespace feature
                              MakeBackInsertFunctor(tokens), search::Delimiters());
 
       if (tokens.empty())
-        return base::ControlFlow::Continue;
+        return;
 
       for (size_t i = 1; i < tokens.size(); ++i)
       {
@@ -148,7 +147,6 @@ namespace feature
         if (!found.second)
           found.first->second.first++;
       }
-      return base::ControlFlow::Continue;
     }
 
     void operator()(FeatureType & f, uint32_t)
@@ -218,13 +216,12 @@ namespace feature
   void DumpFeatureNames(string const & fPath, string const & lang)
   {
     int8_t const langIndex = StringUtf8Multilang::GetLangIndex(lang);
-    auto printName = [&](int8_t langCode, string const & name) -> base::ControlFlow {
+    auto printName = [&](int8_t langCode, string const & name) {
       CHECK(!name.empty(), ("Feature name is empty"));
       if (langIndex == StringUtf8Multilang::kUnsupportedLanguageCode)
         cout << StringUtf8Multilang::GetLangByCode(langCode) << ' ' << name << endl;
       else if (langCode == langIndex)
         cout << name << endl;
-      return base::ControlFlow::Continue;
     };
 
     feature::ForEachFromDat(fPath, [&](FeatureType & f, uint32_t)
@@ -232,5 +229,4 @@ namespace feature
                               f.ForEachName(printName);
                             });
   }
-
 }  // namespace feature

--- a/generator/dumper.cpp
+++ b/generator/dumper.cpp
@@ -11,6 +11,7 @@
 
 #include "coding/multilang_utf8_string.hpp"
 
+#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 
 #include <algorithm>
@@ -123,7 +124,7 @@ namespace feature
   public:
     TokensContainerT m_stats;
 
-    bool operator()(int8_t langCode, string const & name)
+    base::ControlFlow operator()(int8_t langCode, string const & name)
     {
       CHECK(!name.empty(), ("Feature name is empty"));
 
@@ -132,7 +133,7 @@ namespace feature
                              MakeBackInsertFunctor(tokens), search::Delimiters());
 
       if (tokens.empty())
-        return true;
+        return base::ControlFlow::Continue;
 
       for (size_t i = 1; i < tokens.size(); ++i)
       {
@@ -147,7 +148,7 @@ namespace feature
         if (!found.second)
           found.first->second.first++;
       }
-      return true;
+      return base::ControlFlow::Continue;
     }
 
     void operator()(FeatureType & f, uint32_t)
@@ -217,14 +218,13 @@ namespace feature
   void DumpFeatureNames(string const & fPath, string const & lang)
   {
     int8_t const langIndex = StringUtf8Multilang::GetLangIndex(lang);
-    auto printName = [&](int8_t langCode, string const & name) -> bool
-    {
+    auto printName = [&](int8_t langCode, string const & name) -> base::ControlFlow {
       CHECK(!name.empty(), ("Feature name is empty"));
       if (langIndex == StringUtf8Multilang::kUnsupportedLanguageCode)
         cout << StringUtf8Multilang::GetLangByCode(langCode) << ' ' << name << endl;
       else if (langCode == langIndex)
         cout << name << endl;
-      return true;
+      return base::ControlFlow::Continue;
     };
 
     feature::ForEachFromDat(fPath, [&](FeatureType & f, uint32_t)

--- a/generator/restaurants_info/restaurants_info.cpp
+++ b/generator/restaurants_info/restaurants_info.cpp
@@ -104,15 +104,13 @@ void DumpRestaurants(std::vector<FeatureBuilder1> const & features, std::ostream
     std::string defaultName;
     std::vector<std::string> translations;
     multilangName.ForEach(
-        [&translations, &defaultName](uint8_t const langCode,
-                                      std::string const & name) -> base::ControlFlow {
+        [&translations, &defaultName](uint8_t const langCode, std::string const & name) {
           if (langCode == StringUtf8Multilang::kDefaultCode)
           {
             defaultName = name;
-            return base::ControlFlow::Continue;
+            return;
           }
           translations.push_back(name);
-          return base::ControlFlow::Continue;
         });
     auto const center = MercatorBounds::ToLatLon(f.GetKeyPoint());
 

--- a/generator/restaurants_info/restaurants_info.cpp
+++ b/generator/restaurants_info/restaurants_info.cpp
@@ -103,16 +103,17 @@ void DumpRestaurants(std::vector<FeatureBuilder1> const & features, std::ostream
 
     std::string defaultName;
     std::vector<std::string> translations;
-    multilangName.ForEach([&translations, &defaultName](uint8_t const langCode, std::string const & name)
-    {
-      if (langCode == StringUtf8Multilang::kDefaultCode)
-      {
-        defaultName = name;
-        return true;
-      }
-      translations.push_back(name);
-      return true;
-    });
+    multilangName.ForEach(
+        [&translations, &defaultName](uint8_t const langCode,
+                                      std::string const & name) -> base::ControlFlow {
+          if (langCode == StringUtf8Multilang::kDefaultCode)
+          {
+            defaultName = name;
+            return base::ControlFlow::Continue;
+          }
+          translations.push_back(name);
+          return base::ControlFlow::Continue;
+        });
     auto const center = MercatorBounds::ToLatLon(f.GetKeyPoint());
 
     out << defaultName << '\t' << strings::JoinStrings(translations, '|') << '\t'

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -29,7 +29,6 @@
 #include "coding/writer.hpp"
 
 #include "base/assert.hpp"
-#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
 #include "base/stl_add.hpp"
@@ -162,7 +161,7 @@ struct FeatureNameInserter
     m_keyValuePairs.emplace_back(key, m_val);
   }
 
-  base::ControlFlow operator()(signed char lang, string const & name) const
+  void operator()(signed char lang, string const & name) const
   {
     strings::UniString const uniName = search::NormalizeAndSimplifyString(name);
 
@@ -200,8 +199,6 @@ struct FeatureNameInserter
       for (auto const & token : tokens)
         AddToken(lang, token);
     }
-
-    return base::ControlFlow::Continue;
   }
 };
 

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -29,6 +29,7 @@
 #include "coding/writer.hpp"
 
 #include "base/assert.hpp"
+#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
 #include "base/stl_add.hpp"
@@ -161,7 +162,7 @@ struct FeatureNameInserter
     m_keyValuePairs.emplace_back(key, m_val);
   }
 
-  bool operator()(signed char lang, string const & name) const
+  base::ControlFlow operator()(signed char lang, string const & name) const
   {
     strings::UniString const uniName = search::NormalizeAndSimplifyString(name);
 
@@ -200,7 +201,7 @@ struct FeatureNameInserter
         AddToken(lang, token);
     }
 
-    return true;
+    return base::ControlFlow::Continue;
   }
 };
 

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -170,8 +170,6 @@ void RemoveFakesFromName(osm::FakeNames const & fakeNames, StringUtf8Multilang &
     auto const it = find(codesToExclude.begin(), codesToExclude.end(), langCode);
     if (it == codesToExclude.end())
       nameWithoutFakes.AddString(langCode, value);
-
-    return base::ControlFlow::Continue;
   });
 
   name = nameWithoutFakes;
@@ -266,11 +264,10 @@ NamesDataSource EditableMapObject::GetNamesDataSource(StringUtf8Multilang const 
     ++mandatoryCount;
 
   // Push other languages.
-  source.ForEach([&names, mandatoryCount](int8_t const code,
-                                          string const & name) -> base::ControlFlow {
+  source.ForEach([&names, mandatoryCount](int8_t const code, string const & name) {
     // Exclude default name.
     if (StringUtf8Multilang::kDefaultCode == code)
-      return base::ControlFlow::Continue;
+      return;
 
     auto const mandatoryNamesEnd = names.begin() + mandatoryCount;
     // Exclude languages which are already in container (languages with top priority).
@@ -280,8 +277,6 @@ NamesDataSource EditableMapObject::GetNamesDataSource(StringUtf8Multilang const 
 
     if (mandatoryNamesEnd == it)
       names.emplace_back(code, name);
-
-    return base::ControlFlow::Continue;
   });
 
   return result;
@@ -549,8 +544,6 @@ void EditableMapObject::RemoveBlankAndDuplicationsForDefault()
     auto const duplicate = langCode != StringUtf8Multilang::kDefaultCode && defaultName == name;
     if (!name.empty() && !duplicate)
       editedName.AddString(langCode, name);
-
-    return base::ControlFlow::Continue;
   });
 
   m_name = editedName;

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -13,6 +13,7 @@
 #include "geometry/distance.hpp"
 #include "geometry/robust_orientation.hpp"
 
+#include "base/control_flow.hpp"
 #include "base/range_iterator.hpp"
 #include "base/stl_helpers.hpp"
 
@@ -127,7 +128,7 @@ editor::XMLFeature FeatureType::ToXML(bool serializeType) const
   ForEachName([&feature](uint8_t const & lang, string const & name)
               {
                 feature.SetName(lang, name);
-                return true;
+                return base::ControlFlow::Continue;
               });
 
   string const house = GetHouseNumber();
@@ -377,11 +378,10 @@ void FeatureType::SetNames(StringUtf8Multilang const & newNames)
 {
   m_params.name.Clear();
   // Validate passed string to clean up empty names (if any).
-  newNames.ForEach([this](int8_t langCode, string const & name) -> bool
-  {
+  newNames.ForEach([this](int8_t langCode, string const & name) -> base::ControlFlow {
     if (!name.empty())
       m_params.name.AddString(langCode, name);
-    return true;
+    return base::ControlFlow::Continue;
   });
 
   if (m_params.name.IsEmpty())

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -13,7 +13,6 @@
 #include "geometry/distance.hpp"
 #include "geometry/robust_orientation.hpp"
 
-#include "base/control_flow.hpp"
 #include "base/range_iterator.hpp"
 #include "base/stl_helpers.hpp"
 
@@ -128,7 +127,6 @@ editor::XMLFeature FeatureType::ToXML(bool serializeType) const
   ForEachName([&feature](uint8_t const & lang, string const & name)
               {
                 feature.SetName(lang, name);
-                return base::ControlFlow::Continue;
               });
 
   string const house = GetHouseNumber();
@@ -378,10 +376,9 @@ void FeatureType::SetNames(StringUtf8Multilang const & newNames)
 {
   m_params.name.Clear();
   // Validate passed string to clean up empty names (if any).
-  newNames.ForEach([this](int8_t langCode, string const & name) -> base::ControlFlow {
+  newNames.ForEach([this](int8_t langCode, string const & name) {
     if (!name.empty())
       m_params.name.AddString(langCode, name);
-    return base::ControlFlow::Continue;
   });
 
   if (m_params.name.IsEmpty())

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -11,6 +11,7 @@
 #include "coding/transliteration.hpp"
 
 #include "base/base.hpp"
+#include "base/control_flow.hpp"
 
 #include "std/unordered_map.hpp"
 #include "std/utility.hpp"
@@ -78,10 +79,10 @@ bool GetBestName(StringUtf8Multilang const & src, vector<int8_t> const & priorit
   src.ForEach([&](int8_t code, string const & name)
   {
     if (bestIndex == 0)
-      return false;
+      return base::ControlFlow::Break;
 
     findAndSet(priorityList, code, name, bestIndex, out);
-    return true;
+    return base::ControlFlow::Continue;
   });
 
   // There are many "junk" names in Arabian island.

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -4,8 +4,6 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/editable_map_object.hpp"
 
-#include "base/control_flow.hpp"
-
 namespace
 {
 using osm::EditableMapObject;
@@ -29,7 +27,7 @@ string DebugPrint(ExpectedName const & expectedName)
 void CheckExpectations(StringUtf8Multilang const & s, vector<ExpectedName> const & expectations)
 {
   size_t counter = 0;
-  s.ForEach([&expectations, &counter](int8_t const code, string const & name) -> base::ControlFlow {
+  s.ForEach([&expectations, &counter](int8_t const code, string const & name) {
     auto const it = find_if(expectations.begin(), expectations.end(), [&code](ExpectedName const & item)
     {
       return GetLangCode(item.m_lang.c_str()) == code;
@@ -40,7 +38,6 @@ void CheckExpectations(StringUtf8Multilang const & s, vector<ExpectedName> const
 
     TEST_EQUAL(name, it->m_value, ());
     ++counter;
-    return base::ControlFlow::Continue;
   });
 
   TEST_EQUAL(counter, expectations.size(), ("Unexpected count of names, expected ", expectations.size(),
@@ -581,10 +578,7 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
 {
   auto const getCountOfNames = [](StringUtf8Multilang const & names) {
     size_t counter = 0;
-    names.ForEach([&counter](int8_t const, string const &) -> base::ControlFlow {
-      ++counter;
-      return base::ControlFlow::Continue;
-    });
+    names.ForEach([&counter](int8_t const, string const &) { ++counter; });
 
     return counter;
   };

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -4,6 +4,8 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/editable_map_object.hpp"
 
+#include "base/control_flow.hpp"
+
 namespace
 {
 using osm::EditableMapObject;
@@ -27,7 +29,7 @@ string DebugPrint(ExpectedName const & expectedName)
 void CheckExpectations(StringUtf8Multilang const & s, vector<ExpectedName> const & expectations)
 {
   size_t counter = 0;
-  s.ForEach([&expectations, &counter](int8_t const code, string const & name) {
+  s.ForEach([&expectations, &counter](int8_t const code, string const & name) -> base::ControlFlow {
     auto const it = find_if(expectations.begin(), expectations.end(), [&code](ExpectedName const & item)
     {
       return GetLangCode(item.m_lang.c_str()) == code;
@@ -38,7 +40,7 @@ void CheckExpectations(StringUtf8Multilang const & s, vector<ExpectedName> const
 
     TEST_EQUAL(name, it->m_value, ());
     ++counter;
-    return true;
+    return base::ControlFlow::Continue;
   });
 
   TEST_EQUAL(counter, expectations.size(), ("Unexpected count of names, expected ", expectations.size(),
@@ -579,9 +581,9 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
 {
   auto const getCountOfNames = [](StringUtf8Multilang const & names) {
     size_t counter = 0;
-    names.ForEach([&counter](int8_t const, string const &) {
+    names.ForEach([&counter](int8_t const, string const &) -> base::ControlFlow {
       ++counter;
-      return true;
+      return base::ControlFlow::Continue;
     });
 
     return counter;

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -11,7 +11,6 @@
 #include "indexer/feature_algo.hpp"
 #include "indexer/search_string_utils.hpp"
 
-#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
@@ -515,14 +514,13 @@ void Ranker::MakeRankerResults(Geocoder::Params const & geocoderParams,
 void Ranker::GetBestMatchName(FeatureType const & f, string & name) const
 {
   KeywordLangMatcher::Score bestScore;
-  auto bestNameFinder = [&](int8_t lang, string const & s) -> base::ControlFlow {
+  auto bestNameFinder = [&](int8_t lang, string const & s) {
     auto const score = m_keywordsScorer.CalcScore(lang, s);
     if (bestScore < score)
     {
       bestScore = score;
       name = s;
     }
-    return base::ControlFlow::Continue;
   };
   UNUSED_VALUE(f.ForEachName(bestNameFinder));
 }

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -11,6 +11,7 @@
 #include "indexer/feature_algo.hpp"
 #include "indexer/search_string_utils.hpp"
 
+#include "base/control_flow.hpp"
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
@@ -514,14 +515,14 @@ void Ranker::MakeRankerResults(Geocoder::Params const & geocoderParams,
 void Ranker::GetBestMatchName(FeatureType const & f, string & name) const
 {
   KeywordLangMatcher::Score bestScore;
-  auto bestNameFinder = [&](int8_t lang, string const & s) -> bool {
+  auto bestNameFinder = [&](int8_t lang, string const & s) -> base::ControlFlow {
     auto const score = m_keywordsScorer.CalcScore(lang, s);
     if (bestScore < score)
     {
       bestScore = score;
       name = s;
     }
-    return true;
+    return base::ControlFlow::Continue;
   };
   UNUSED_VALUE(f.ForEachName(bestNameFinder));
 }

--- a/search/retrieval.cpp
+++ b/search/retrieval.cpp
@@ -25,6 +25,7 @@
 #include "coding/reader_wrapper.hpp"
 
 #include "base/checked_cast.hpp"
+#include "base/control_flow.hpp"
 
 #include "std/algorithm.hpp"
 #include "std/utility.hpp"
@@ -160,15 +161,15 @@ bool MatchFeatureByNameAndType(FeatureType const & ft, SearchTrieRequest<DFA> co
   bool matched = false;
   ft.ForEachName([&](int8_t lang, string const & name) {
     if (name.empty() || !request.IsLangExist(lang))
-      return true /* continue ForEachName */;
+      return base::ControlFlow::Continue;
 
     vector<UniString> tokens;
     NormalizeAndTokenizeString(name, tokens, Delimiters());
     if (!MatchesByName(tokens, request.m_names) && !MatchesByType(th, request.m_categories))
-      return true /* continue ForEachName */;
+      return base::ControlFlow::Continue;
 
     matched = true;
-    return false /* break ForEachName */;
+    return base::ControlFlow::Break;
   });
 
   return matched;

--- a/search/search_quality/matcher.cpp
+++ b/search/search_quality/matcher.cpp
@@ -9,6 +9,7 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/control_flow.hpp"
 #include "base/stl_add.hpp"
 
 namespace search
@@ -68,9 +69,9 @@ bool Matcher::Matches(Sample::Result const & golden, FeatureType & ft)
       if (golden.m_name == strings::MakeUniString(name))
       {
         nameMatches = true;
-        return false;  // breaks the loop
+        return base::ControlFlow::Break;
       }
-      return true;  // continues the loop
+      return base::ControlFlow::Continue;
     });
   }
 

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3446C67D1DDCAA4900146687 /* uni_string_dfa_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C6791DDCAA2500146687 /* uni_string_dfa_test.cpp */; };
 		3446C6821DDCAA7400146687 /* newtype_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C67E1DDCAA6E00146687 /* newtype_test.cpp */; };
 		3446C6831DDCAA7800146687 /* ref_counted_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C67F1DDCAA6E00146687 /* ref_counted_tests.cpp */; };
+		39B89C3A1FD1898A001104AF /* control_flow_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39B89C391FD1898A001104AF /* control_flow_tests.cpp */; };
 		39BC0FD01FD057FA00B6C276 /* control_flow.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 39BC0FCF1FD057F900B6C276 /* control_flow.hpp */; };
 		39FD271E1CC65AD000AFF551 /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD27011CC65A2800AFF551 /* testingmain.cpp */; };
 		39FD271F1CC65AD000AFF551 /* assert_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD26C81CC65A0E00AFF551 /* assert_test.cpp */; };
@@ -143,6 +144,7 @@
 		3446C67F1DDCAA6E00146687 /* ref_counted_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ref_counted_tests.cpp; sourceTree = "<group>"; };
 		34BA2D6A1DBE169E00FAB345 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34BA2D6B1DBE169E00FAB345 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
+		39B89C391FD1898A001104AF /* control_flow_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = control_flow_tests.cpp; sourceTree = "<group>"; };
 		39BC0FCF1FD057F900B6C276 /* control_flow.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = control_flow.hpp; sourceTree = "<group>"; };
 		39FD26C81CC65A0E00AFF551 /* assert_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = assert_test.cpp; sourceTree = "<group>"; };
 		39FD26CA1CC65A0E00AFF551 /* bits_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bits_test.cpp; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 		39FD26C71CC659D200AFF551 /* base_tests */ = {
 			isa = PBXGroup;
 			children = (
+				39B89C391FD1898A001104AF /* control_flow_tests.cpp */,
 				67E40EC71E4DC0D500A6D200 /* small_set_test.cpp */,
 				3446C67E1DDCAA6E00146687 /* newtype_test.cpp */,
 				3446C67F1DDCAA6E00146687 /* ref_counted_tests.cpp */,
@@ -674,6 +677,7 @@
 				3D3731FE1F9A445500D2121B /* url_helpers.cpp in Sources */,
 				675341F91A3F57E400A0A8C3 /* src_point.cpp in Sources */,
 				675342031A3F57E400A0A8C3 /* strings_bundle.cpp in Sources */,
+				39B89C3A1FD1898A001104AF /* control_flow_tests.cpp in Sources */,
 				3D74EF141F8B902C0081202C /* bwt.cpp in Sources */,
 				3D74EF131F8B902C0081202C /* move_to_front.cpp in Sources */,
 				675341CD1A3F57E400A0A8C3 /* base.cpp in Sources */,

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3446C67D1DDCAA4900146687 /* uni_string_dfa_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C6791DDCAA2500146687 /* uni_string_dfa_test.cpp */; };
 		3446C6821DDCAA7400146687 /* newtype_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C67E1DDCAA6E00146687 /* newtype_test.cpp */; };
 		3446C6831DDCAA7800146687 /* ref_counted_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3446C67F1DDCAA6E00146687 /* ref_counted_tests.cpp */; };
+		39BC0FD01FD057FA00B6C276 /* control_flow.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 39BC0FCF1FD057F900B6C276 /* control_flow.hpp */; };
 		39FD271E1CC65AD000AFF551 /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD27011CC65A2800AFF551 /* testingmain.cpp */; };
 		39FD271F1CC65AD000AFF551 /* assert_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD26C81CC65A0E00AFF551 /* assert_test.cpp */; };
 		39FD27201CC65AD000AFF551 /* bits_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39FD26CA1CC65A0E00AFF551 /* bits_test.cpp */; };
@@ -142,6 +143,7 @@
 		3446C67F1DDCAA6E00146687 /* ref_counted_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ref_counted_tests.cpp; sourceTree = "<group>"; };
 		34BA2D6A1DBE169E00FAB345 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34BA2D6B1DBE169E00FAB345 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
+		39BC0FCF1FD057F900B6C276 /* control_flow.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = control_flow.hpp; sourceTree = "<group>"; };
 		39FD26C81CC65A0E00AFF551 /* assert_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = assert_test.cpp; sourceTree = "<group>"; };
 		39FD26CA1CC65A0E00AFF551 /* bits_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bits_test.cpp; sourceTree = "<group>"; };
 		39FD26CB1CC65A0E00AFF551 /* buffer_vector_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buffer_vector_test.cpp; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 		675341791A3F57BF00A0A8C3 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				39BC0FCF1FD057F900B6C276 /* control_flow.hpp */,
 				56DE23031FCD8AB4008FEFD5 /* osm_id.cpp */,
 				56DE23021FCD8AB3008FEFD5 /* osm_id.hpp */,
 				3D3731FC1F9A445400D2121B /* url_helpers.cpp */,
@@ -497,6 +500,7 @@
 				6753420C1A3F57E400A0A8C3 /* threaded_list.hpp in Headers */,
 				675341DB1A3F57E400A0A8C3 /* exception.hpp in Headers */,
 				6753453E1A3F6F6A00A0A8C3 /* message.hpp in Headers */,
+				39BC0FD01FD057FA00B6C276 /* control_flow.hpp in Headers */,
 				6753420F1A3F57E400A0A8C3 /* timer.hpp in Headers */,
 				675341D01A3F57E400A0A8C3 /* buffer_vector.hpp in Headers */,
 				675341FC1A3F57E400A0A8C3 /* std_serialization.hpp in Headers */,


### PR DESCRIPTION
The convention we used to break a ForEach loop prematurely
was to return false from the function object that was being
called by ForEach. Now the function object must return a special
enum, thus making the intention more readable.