### PR TITLE
[transit] Removing equivalent edges.

### DIFF
--- a/generator/generator_tests/transit_graph_test.cpp
+++ b/generator/generator_tests/transit_graph_test.cpp
@@ -147,6 +147,22 @@ unique_ptr<GraphData> CreateGraphFromJson()
       "weight" : 10
     },
     {
+      "stop1_id": 3,
+      "stop2_id": 4,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 3, "stop2_id": 4 }],
+      "transfer": false,
+      "weight" : 20
+    },
+    {
+      "stop1_id": 3,
+      "stop2_id": 4,
+      "line_id": 1,
+      "shape_ids": [ { "stop1_id": 3, "stop2_id": 4 }],
+      "transfer": false,
+      "weight" : 20
+    },
+    {
       "stop1_id": 5,
       "stop2_id": 6,
       "line_id": 2,
@@ -503,15 +519,15 @@ void SerializeAndDeserializeGraph(GraphData const & src, GraphData & dst)
   TEST(dst.IsValid(), ());
 }
 
-//             ^
-//             |
-//             * 2
-//
-//   s0--------s1--------s2--------s3---s4 Line 1
-//
-//   *    *    *    *    *    *    *    *   -->
-//  -2         0              3    4    5
-//        s5--------s6 Line 2
+//                       ^
+//                       |
+//                       * 2                     _______
+//                                               |     |
+//           s0----------s1----------s2----------s3----s4 Line 1
+//                                               |_____|
+//     *     *     *     *     *     *     *     *     *   -->
+//    -3    -2    -1     0     1     2     3     4     5
+//                 s5----------s6 Line 2
 //
 UNIT_TEST(ClipGraph_SmokeTest)
 {
@@ -532,10 +548,10 @@ UNIT_TEST(ClipGraph_SmokeTest)
 //
 //     ------------------* 3-----------Border
 //     |                                   |
-//     |                 * 2               |
-//     |                                   |
+//     |                 * 2               |     _______
+//     |                                   |     |     |
 //     |     s0----------s1----------s2----|-----s3----s4 Line 1
-//     |                                   |
+//     |                                   |     |_____|
 //     *-----*-----*-----*-----*-----*-----*     *     *   -->
 //    -3    -2    -1     0     1     2     3     4     5
 //                 s5----------s6 Line 2
@@ -557,10 +573,10 @@ UNIT_TEST(ClipGraph_OneLineTest)
 //                       |
 //                       * 3
 //
-//                       * 2----------Border
-//                          |           |
+//                       * 2----------Border     _______
+//                          |           |        |     |
 //           s0----------s1-|--------s2-|--------s3----s4 Line 1
-//                          |           |
+//                          |           |        |_____|
 //     *     *     *     *  |  *     *  |  *     *     *   -->
 //    -3    -2    -1     0  |  1     2  |  3     4     5
 //         Line 2  s5-------|--s6       |

--- a/routing_common/transit_types.hpp
+++ b/routing_common/transit_types.hpp
@@ -306,6 +306,7 @@ public:
 
   bool operator<(Edge const & rhs) const;
   bool operator==(Edge const & rhs) const;
+  bool operator!=(Edge const & rhs) const { return !(*this == rhs); }
   bool IsEqualForTesting(Edge const & edge) const;
   bool IsValid() const;
   void SetWeight(Weight weight) { m_weight = weight; }


### PR DESCRIPTION
Иногда возникают весьма странные ситуации, когда одна и та же линия соединяет два стопа более чем одни раз. Например, в Осло: https://en.wikipedia.org/wiki/Oslo_Metro#/media/File:Oslo_Metro_Map.svg линия 5.

Это означает, что два стопа будут соединены дугой в одном и том же направлении и line_id у этих дуг будет совпадать. В таких случаях маршрутизатор будет использовать ту дугу, которая легче. А если веса дуг одинаковы, то произвольную дугу.

Данный PR включает в себя реализацию и тесты.

@tatiana-kondakova @darina @Zverik PTAL