### PR TITLE
transit и transit_cross_mwm section generation.

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -141,7 +141,10 @@ int main(int argc, char ** argv)
   Platform & pl = GetPlatform();
 
   if (!FLAGS_user_resource_path.empty())
+  {
     pl.SetResourceDir(FLAGS_user_resource_path);
+    pl.SetSettingsDir(FLAGS_user_resource_path);
+  }
 
   std::string const path =
       FLAGS_data_path.empty() ? pl.WritableDir() : my::AddSlashIfNeeded(FLAGS_data_path);

--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -97,7 +97,7 @@ bool Platform::RmDirRecursively(string const & dirName)
   return res;
 }
 
-void Platform::SetSettingsDirForTests(string const & path)
+void Platform::SetSettingsDir(string const & path)
 {
   m_settingsDir = my::AddSlashIfNeeded(path);
 }

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -163,7 +163,7 @@ public:
   /// as WritableDir, but on some platforms it's different
   string SettingsDir() const { return m_settingsDir; }
   /// Set settings dir — use for testing.
-  void SetSettingsDirForTests(string const & path);
+  void SetSettingsDir(string const & path);
   /// @return full path to file in the settings directory
   string SettingsPathForFile(string const & file) const { return SettingsDir() + file; }
 

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -162,7 +162,6 @@ public:
   /// @return path for directory in the persistent memory, can be the same
   /// as WritableDir, but on some platforms it's different
   string SettingsDir() const { return m_settingsDir; }
-  /// Set settings dir — use for testing.
   void SetSettingsDir(string const & path);
   /// @return full path to file in the settings directory
   string SettingsPathForFile(string const & file) const { return SettingsDir() + file; }

--- a/platform/platform_tests_support/writable_dir_changer.cpp
+++ b/platform/platform_tests_support/writable_dir_changer.cpp
@@ -19,7 +19,7 @@ WritableDirChanger::WritableDirChanger(string const & testDir, SettingsDirPolicy
   TEST_EQUAL(Platform::ERR_OK, platform.MkDir(m_testDirFullPath), ());
   platform.SetWritableDirForTests(m_testDirFullPath);
   if (m_settingsDirPolicy == SettingsDirPolicy::UseWritableDir)
-    platform.SetSettingsDirForTests(m_testDirFullPath);
+    platform.SetSettingsDir(m_testDirFullPath);
   settings::Clear();
 }
 
@@ -30,6 +30,6 @@ WritableDirChanger::~WritableDirChanger()
   string const writableDirForTest = platform.WritableDir();
   platform.SetWritableDirForTests(m_writableDirBeforeTest);
   if (m_settingsDirPolicy == SettingsDirPolicy::UseWritableDir)
-    platform.SetSettingsDirForTests(m_writableDirBeforeTest);
+    platform.SetSettingsDir(m_writableDirBeforeTest);
   platform.RmDirRecursively(writableDirForTest);
 }

--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -538,8 +538,12 @@ if [ "$MODE" == "routing" ]; then
   for file in "$TARGET"/*.mwm; do
     if [[ "$file" != *minsk-pass* && "$file" != *World* ]]; then
       BASENAME="$(basename "$file" .mwm)"
-      "$GENERATOR_TOOL" --data_path="$TARGET" --intermediate_data_path="$INTDIR/" --user_resource_path="$DATA_PATH/" \
-        --make_cross_mwm --disable_cross_mwm_progress --make_routing_index --generate_traffic_keys --output="$BASENAME" 2>> "$LOG_PATH/$BASENAME.log" &
+      (
+        "$GENERATOR_TOOL" --data_path="$TARGET" --intermediate_data_path="$INTDIR/" --user_resource_path="$DATA_PATH/" \
+        --make_cross_mwm --disable_cross_mwm_progress --make_routing_index --generate_traffic_keys --output="$BASENAME" 2>> "$LOG_PATH/$BASENAME.log"
+        "$GENERATOR_TOOL" --data_path="$TARGET" --intermediate_data_path="$INTDIR/" --user_resource_path="$DATA_PATH/" \
+        --make_transit_cross_mwm --transit_path="$DATA_PATH" --output="$BASENAME" 2>> "$LOG_PATH/$BASENAME.log"
+        ) &
       forky
     fi
   done


### PR DESCRIPTION
Данный PR позволяет собирать секции transit и transit_cross_mwm для мира.

То что происходит с SetSettingDir - требует отдельного пояснения.

При сборке секции transit мы ищем и сохраняем ближайший пешеходный сегмент к каждому гейту. Для этого используется метод: `IndexRouter::FindBestSegment(...)`. Для инициализации `IndexRouter` нужно создать `CountyInfoGetter`, т.е. вызвать: `storage::CountryInfoReader::CreateCountryInfoReader(GetPlatform());`. Перовой строчке этой ф-ции мы проверяем, произошла ли миграция или нет.
```c++
unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReader(Platform const & platform)
{
  if (platform::migrate::NeedMigrate())
    return CreateCountryInfoReaderTwoComponentMwms(platform);
  return CreateCountryInfoReaderOneComponentMwms(platform);
}
```
Этот факт, прописан в settings.ini файле. Т.е. в методе `platform::migrate::NeedMigrate()` мы вызываем `settings::Get("LastMigration", version)`, который обращается к settings.ini лежащему по пути: `GetPlatform().SettingsPathForFile(SETTINGS_FILE_NAME)`. Т.е. обращаемся к settings.ini по пути: `SettingsDir() + file`. У меня на машине данный путь это выглядит, как ./data/settings.ini

Какие есть варианты:

1. Как я понял @Zverik, в генераторе ResouceDir и SettingsDir это одно и тоже. Так, что можно поступить, как в PR;

2. Выпилить код по миграции вообще. Тогда вообще не нужен путь к settings.ini;

3. @ygorshenin Ты предлагал подумать над инициализацией settings dir в платформе. Но сейчас инициализация происходит в Platform::Platform() (platform/platform_linux.cpp) и resouce dir, writable dir и setting dir инициализируются в ./data/, то кажется логичным.

@Zverik @ygorshenin @mpimenov Что думаете по этому поводу?

@Zverik давай запустим из данного PR сборку карт мира с секцией transit и transit_cross_mwm.

@Zverik @ygorshenin @mpimenov PTAL