### PR TITLE
[routing][MAPSME-5653][MAPSME-6037]Get rid of IndexGraphStarter in TestIndexGraphTopology.

### DIFF
--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -671,8 +671,7 @@ UNIT_TEST(IndexGraph_OnlyTopology_1)
   graph.AddDirectedEdge(2, 3, 2.0);
 
   double const expectedWeight = 2.0;
-  // Firs and last edges are projections.
-  vector<TestEdge> const expectedEdges = {{0, 0}, {0, 1}, {1, 3}, {3, 3}};
+  vector<TestEdge> const expectedEdges = {{0, 1}, {1, 3}};
 
   TestTopologyGraph(graph, 0, 3, true /* pathFound */, expectedWeight, expectedEdges);
   TestTopologyGraph(graph, 0, 4, false /* pathFound */, 0.0, {});
@@ -698,8 +697,7 @@ UNIT_TEST(IndexGraph_OnlyTopology_3)
   graph.AddDirectedEdge(0, 1, 1.0);
   graph.AddDirectedEdge(1, 0, 1.0);
   double const expectedWeight = 1.0;
-  // Firs and last edges are projections.
-  vector<TestEdge> const expectedEdges = {{0, 0}, {0, 1}, {1, 1}};
+  vector<TestEdge> const expectedEdges = {{0, 1}};
 
   TestTopologyGraph(graph, 0, 1, true /* pathFound */, expectedWeight, expectedEdges);
 }

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -108,13 +108,12 @@ UNIT_TEST(RoadAccess_BarrierBypassing)
   vector<TestEdge> expectedEdges;
 
   expectedWeight = 3.0;
-  // First and last edges are projectios
-  expectedEdges = {{0, 0}, {0, 1}, {1, 2}, {2, 5}, {5, 5}};
+  expectedEdges = {{0, 1}, {1, 2}, {2, 5}};
   TestTopologyGraph(graph, 0, 5, true /* pathFound */, expectedWeight, expectedEdges);
 
   graph.BlockEdge(1, 2);
   expectedWeight = 4.0;
-  expectedEdges = {{0, 0}, {0, 3}, {3, 4}, {4, 5}, {5, 5}};
+  expectedEdges = {{0, 3}, {3, 4}, {4, 5}};
   TestTopologyGraph(graph, 0, 5, true /* pathFound */, expectedWeight, expectedEdges);
 
   graph.BlockEdge(3, 4);


### PR DESCRIPTION
Избавилась от IndexGraphStarter в TestIndexGraphTopology, так как в TestIndexGraphTopology используется ZeroGeometry, а IndexGraphStarter-у нужна геометрия для построения фейковых рёбер.
До этого c FindPathBidirectional работало по чистой случайности, а c FindPath получали invariant violation из-за неправильно вычисленных фейковых дуг (MAPSME-6037).
Теперь в тестах топологии используется чистый WorldGraph без стартера.