### PR TITLE
[map] Fixed Framework shutdown + TearDownEditorForTesting.

### DIFF
--- a/indexer/indexer_tests/osm_editor_test.cpp
+++ b/indexer/indexer_tests/osm_editor_test.cpp
@@ -152,6 +152,9 @@ EditorTest::EditorTest()
 
 EditorTest::~EditorTest()
 {
+
+  indexer::tests_support::TearDownEditorForTesting();
+
   for (auto const & file : m_mwmFiles)
     Cleanup(file);
 }

--- a/indexer/indexer_tests_support/helpers.cpp
+++ b/indexer/indexer_tests_support/helpers.cpp
@@ -13,5 +13,13 @@ void SetUpEditorForTesting(unique_ptr<osm::Editor::Delegate> delegate)
   editor.SetStorageForTesting(make_unique<editor::InMemoryStorage>());
   editor.ClearAllLocalEdits();
 }
+
+void TearDownEditorForTesting()
+{
+  auto & editor = osm::Editor::Instance();
+  editor.ClearAllLocalEdits();
+  editor.SetDelegate({});
+  editor.SetDefaultStorage();
+}
 }  // namespace tests_support
 }  // namespace indexer

--- a/indexer/indexer_tests_support/helpers.hpp
+++ b/indexer/indexer_tests_support/helpers.hpp
@@ -12,6 +12,7 @@ namespace indexer
 namespace tests_support
 {
 void SetUpEditorForTesting(unique_ptr<osm::Editor::Delegate> delegate);
+void TearDownEditorForTesting();
 
 template <typename TFn>
 void EditFeature(FeatureType const & ft, TFn && fn)

--- a/indexer/osm_editor.cpp
+++ b/indexer/osm_editor.cpp
@@ -136,17 +136,20 @@ namespace osm
 // TODO(AlexZ): Normalize osm multivalue strings for correct merging
 // (e.g. insert/remove spaces after ';' delimeter);
 
-Editor::Editor()
-  : m_configLoader(m_config)
-  , m_notes(editor::Notes::MakeNotes())
-  , m_storage(make_unique<editor::LocalStorage>())
+Editor::Editor() : m_configLoader(m_config), m_notes(editor::Notes::MakeNotes())
 {
+  SetDefaultStorage();
 }
 
 Editor & Editor::Instance()
 {
   static Editor instance;
   return instance;
+}
+
+void Editor::SetDefaultStorage()
+{
+  m_storage = make_unique<editor::LocalStorage>();
 }
 
 void Editor::LoadMapEdits()

--- a/indexer/osm_editor.hpp
+++ b/indexer/osm_editor.hpp
@@ -89,6 +89,8 @@ public:
     m_storage = move(storage);
   }
 
+  void SetDefaultStorage();
+
   void SetInvalidateFn(TInvalidateFn const & fn) { m_invalidateFn = fn; }
 
   void LoadMapEdits();

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -491,6 +491,11 @@ Framework::Framework(FrameworkParams const & params)
 
 Framework::~Framework()
 {
+  osm::Editor & editor = osm::Editor::Instance();
+
+  editor.SetDelegate({});
+  editor.SetInvalidateFn({});
+
   m_bmManager.Teardown();
   m_trafficManager.Teardown();
   m_localAdsManager.Teardown();

--- a/search/search_tests_support/test_with_custom_mwms.hpp
+++ b/search/search_tests_support/test_with_custom_mwms.hpp
@@ -25,7 +25,7 @@ public:
     indexer::tests_support::SetUpEditorForTesting(my::make_unique<EditorDelegate>(m_index));
   }
 
-  ~TestWithCustomMwms() override = default;
+  ~TestWithCustomMwms() override { indexer::tests_support::TearDownEditorForTesting(); }
 
   template <typename EditorFn>
   void EditFeature(FeatureID const & id, EditorFn && fn)


### PR DESCRIPTION
Framework is instantiated in the map tests, and some tests may interfere with other tests. This PR fixes this.