### PR TITLE
Revert "[editor] call LoadMapEdits before uploading changes"

### DIFF
--- a/indexer/osm_editor.cpp
+++ b/indexer/osm_editor.cpp
@@ -709,9 +709,6 @@ void Editor::UploadChanges(string const & key, string const & secret, TChangeset
   if (m_notes->NotUploadedNotesCount())
     UploadNotes(key, secret);
 
-  // We need to be sure edits will be applied for correct features (all features are migrated).
-  LoadMapEdits();
-
   if (!HaveMapEditsToUpload())
   {
     LOG(LDEBUG, ("There are no local edits to upload."));


### PR DESCRIPTION
This reverts commit c399af93fe96eb44c0a5c77faabda0497e133ce7.
From pr https://github.com/mapsme/omim/pull/7699
