### PR TITLE
[routing] Fix pass through additional road types

### DIFF
--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -114,6 +114,13 @@ bool VehicleModel::IsRoad(FeatureType const & f) const
 bool VehicleModel::IsPassThroughAllowed(FeatureType const & f) const
 {
   feature::TypesHolder const types(f);
+  // Allow pass through additional road types e.g. peer, ferry.
+  for (uint32_t t : types)
+  {
+    auto const addRoadInfoIter = FindRoadType(t);
+    if (addRoadInfoIter != m_addRoadTypes.cend())
+      return true;
+  }
   return HasPassThroughType(types);
 }
 

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -47,6 +47,8 @@ public:
   /// e.g. in Russia roads tagged "highway = service" are not allowed for through passage;
   /// however, road with this tag can be be used if it is close enough to the start or destination
   /// point of the route.
+  /// Roads with additional types e.g. "path = ferry", "vehicle_type = yes" considered as allowed
+  /// to pass through.
   virtual bool IsPassThroughAllowed(FeatureType const & f) const = 0;
 };
 


### PR DESCRIPTION
Не был разрешен сквозной проезд через дороги с additional road type (пирсы, паромы, явно потеганные vehicle_type=yes), хотя должен быть.
Тестируется интеграционными тестами.