### PR TITLE
[routing] Fix routing integration tests

### DIFF
--- a/routing/routing_consistency_tests/CMakeLists.txt
+++ b/routing/routing_consistency_tests/CMakeLists.txt
@@ -22,6 +22,7 @@ omim_link_libraries(
   routing_common
   search
   storage
+  mwm_diff
   indexer
   platform
   editor
@@ -33,6 +34,7 @@ omim_link_libraries(
   osrm
   jansson
   protobuf
+  bsdiff
   succinct
   stats_client
   generator
@@ -45,3 +47,4 @@ omim_link_libraries(
 )
 
 link_qt5_core(${PROJECT_NAME})
+link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_consistency_tests/routing_consistency_tests.pro
+++ b/routing/routing_consistency_tests/routing_consistency_tests.pro
@@ -7,12 +7,16 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = map routing traffic routing_common search storage indexer platform editor geometry coding base osrm \
-               jansson protobuf succinct stats_client generator gflags pugixml icu agg
+DEPENDENCIES = map routing traffic routing_common search storage mwm_diff indexer platform editor geometry coding \
+               base osrm jansson protobuf bsdiff succinct stats_client generator gflags pugixml icu agg
 
 include($$ROOT_DIR/common.pri)
 
 QT *= core
+
+!iphone*:!android*:!tizen:!macx-* {
+  QT *= network
+}
 
 macx-* {
   QT *= gui widgets # needed for QApplication with event loop, to test async events (downloader, etc.)

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ omim_link_libraries(
   routing
   search
   storage
+  mwm_diff
   indexer
   editor
   traffic
@@ -43,6 +44,7 @@ omim_link_libraries(
   osrm
   jansson
   protobuf
+  bsdiff
   succinct
   stats_client
   pugixml
@@ -53,3 +55,4 @@ omim_link_libraries(
 )
 
 link_qt5_core(${PROJECT_NAME})
+link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -31,7 +31,7 @@ UNIT_TEST(RussiaDomodedovoSteps)
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.44010, 37.77416), {0., 0.},
-      MercatorBounds::FromLatLon(55.43975, 37.77272), 123.0);
+      MercatorBounds::FromLatLon(55.43975, 37.77272), 100.0);
 }
 
 UNIT_TEST(SwedenStockholmCyclewayPriority)
@@ -62,7 +62,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
-  TEST(my::AlmostEqualAbs(route.GetTotalTimeSec(), 356.0, 1.0), ());
+  TEST(my::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), ());
 }
 
 UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)
@@ -78,7 +78,17 @@ UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
-      MercatorBounds::FromLatLon(55.68895, 37.70286), 7057.0);
+      MercatorBounds::FromLatLon(55.68927, 37.70356), 7726.0);
+}
+
+// No pass through service road in Russia
+UNIT_TEST(RussiaMoscowNoServicePassThrough)
+{
+  TRouteResult route =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
+                                    MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
+                                    MercatorBounds::FromLatLon(55.68895, 37.70286));
+  TEST_EQUAL(route.second, IRouter::RouteNotFound, ());
 }
 
 UNIT_TEST(RussiaKerchStraitFerryRoute)

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -18,8 +18,9 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::TestRouteLength(route, 1054.0);
 }
 
@@ -34,28 +35,32 @@ UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 2);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
+// Fails to generate direction.
 UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
-                                  MercatorBounds::FromLatLon(55.85159, 37.38903), {0.0, 0.0},
-                                  MercatorBounds::FromLatLon(55.85157, 37.38813));
+                                  MercatorBounds::FromLatLon(55.85777, 37.3679), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.85579, 37.36867));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 1);
-
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid()
+                                   .TestOneOfDirections({CarDirection::GoStraight,
+                                                         CarDirection::TurnSlightRight,
+                                                         CarDirection::TurnRight});
 }
 
+// Fails to build one-point route.
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
 {
   m2::PointD const point = MercatorBounds::FromLatLon(55.8719, 37.4464);
@@ -66,25 +71,25 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTurnTest)
   TEST_EQUAL(result, IRouter::IRouter::NoError, ());
 }
 
-UNIT_TEST(RussiaMoscowPlanernaiOnewayCarRoadTurnTest)
+UNIT_TEST(RussiaMoscowTatishchevaOnewayCarRoadTurnTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
-                                  MercatorBounds::FromLatLon(55.87012, 37.44028), {0.0, 0.0},
-                                  MercatorBounds::FromLatLon(55.87153, 37.43928));
+                                  MercatorBounds::FromLatLon(55.71566, 37.61569), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.71532, 37.61571));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 4);
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
 
-  integration::TestRouteLength(route, 420.0);
+  integration::TestRouteLength(route, 675.0);
 }
 
 UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
@@ -98,7 +103,7 @@ UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 3);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -105,7 +105,7 @@ UNIT_TEST(FranceParis_AvoidBridleway)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(48.859, 2.25452), {0., 0.},
-      MercatorBounds::FromLatLon(48.8634, 2.24315), 1307.);
+      MercatorBounds::FromLatLon(48.8634, 2.24315), 1049.);
 }
 
 UNIT_TEST(HungaryBudapest_AvoidMotorway)
@@ -177,7 +177,7 @@ UNIT_TEST(BelarusBobruisk50LetVlksmToSanatoryShinnik)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.1638, 29.1804), {0., 0.},
-      MercatorBounds::FromLatLon(53.179, 29.1682), 2661.);
+      MercatorBounds::FromLatLon(53.179, 29.1682), 2400.);
 }
 
 UNIT_TEST(BelarusBobruisk50LetVlksmToArena)
@@ -224,7 +224,7 @@ UNIT_TEST(RussiaTaganrogCheckhova267k2ToKotlostroy33)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(47.2198, 38.8906), {0., 0.},
+      MercatorBounds::FromLatLon(47.2200, 38.8906), {0., 0.},
       MercatorBounds::FromLatLon(47.2459, 38.8937), 3485.);
 }
 
@@ -232,7 +232,7 @@ UNIT_TEST(RussiaTaganrogCheckhova267k2ToBolBulvarnaya8)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(47.2198, 38.8906), {0., 0.},
+      MercatorBounds::FromLatLon(47.2200, 38.8906), {0., 0.},
       MercatorBounds::FromLatLon(47.2412, 38.8902), 2897.);
 }
 
@@ -372,12 +372,12 @@ UNIT_TEST(USANewYorkEmpireStateBuildingToUnitedNations)
       MercatorBounds::FromLatLon(40.75047, -73.96759), 2265.);
 }
 
-UNIT_TEST(CrossMwmEgyptTabaToJordanAqaba)
+UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(29.49271, 34.89571), {0., 0.},
-      MercatorBounds::FromLatLon(29.52774, 35.00324), 29016);
+      MercatorBounds::FromLatLon(55.15414, 20.85378), {0., 0.},
+      MercatorBounds::FromLatLon(56.51119, 21.01847), 192000);
 }
 
 UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)
@@ -428,6 +428,7 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
   TEST_EQUAL(t[2].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
 }
 
+// Fails to generate "Downstairs" direction.
 UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
 {
   TRouteResult const routeResult =
@@ -448,6 +449,7 @@ UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
   TEST_EQUAL(t[2].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
 }
 
+// Fails to generate "LiftGate" direction.
 UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
 {
   TRouteResult const routeResult =
@@ -467,6 +469,7 @@ UNIT_TEST(RussiaMoscowTrubnikovPereulok30Ac1LiftGate)
   TEST_EQUAL(t[1].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
 }
 
+// Fails to generate "Gate" direction.
 UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
 {
   TRouteResult const routeResult =
@@ -486,6 +489,7 @@ UNIT_TEST(RussiaMoscowKhlebnyyLane15c1Gate)
   TEST_EQUAL(t[1].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
 }
 
+// Fails to generate "LiftGate"/"Gate" directions.
 UNIT_TEST(RussiaMoscowKhlebnyyLane19LiftGateAndGate)
 {
   TRouteResult const routeResult =
@@ -531,7 +535,7 @@ UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
   integration::TestRouteLength(route, 0.0);
 }
 

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -18,14 +18,15 @@ namespace
         MercatorBounds::FromLatLon(19.17289, 30.47315), 10283.7);
   }
 
-  UNIT_TEST(MoscowShortRoadUnpacking)
+  UNIT_TEST(MoscowKashirskoeShosseCrossing)
   {
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
-        MercatorBounds::FromLatLon(55.66218, 37.63253), {0., 0.},
-        MercatorBounds::FromLatLon(55.66237, 37.63560), 101.);
+        MercatorBounds::FromLatLon(55.66216, 37.63259), {0., 0.},
+        MercatorBounds::FromLatLon(55.66237, 37.63560), 1700.);
   }
 
+  // Fails because cheackpoints are far from roads (inside Kremlin and inside airport).
   UNIT_TEST(MoscowToSVOAirport)
   {
     integration::CalculateRouteAndTestRouteLength(
@@ -44,7 +45,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(55.77399, 37.68468), {0., 0.},
-        MercatorBounds::FromLatLon(55.77198, 37.68782), 700.);
+        MercatorBounds::FromLatLon(55.77198, 37.68782), 1032.);
   }
 
   UNIT_TEST(RestrictionTestNearMetroShodnenskaya)
@@ -73,12 +74,20 @@ namespace
         MercatorBounds::FromLatLon(54.9228, 58.1469), 164667.);
   }
 
-  UNIT_TEST(RussiaMoscow)
+  UNIT_TEST(RussiaMoscowNoServiceCrossing)
   {
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
-        MercatorBounds::FromLatLon(55.77682, 37.70391), 185.);
+        MercatorBounds::FromLatLon(55.77682, 37.70391), 3140.);
+  }
+
+  UNIT_TEST(RussiaMoscowShortWayToService)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.77787, 37.70405), {0., 0.},
+        MercatorBounds::FromLatLon(55.77691, 37.70428), 150.);
   }
 
   // Geometry unpacking test.
@@ -255,12 +264,12 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(45.38053, 36.73226), {0., 0.},
-        MercatorBounds::FromLatLon(45.36078, 36.60866), 13150.);
+        MercatorBounds::FromLatLon(45.36078, 36.60866), 15500.);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(45.36078, 36.60866), {0., 0.},
-        MercatorBounds::FromLatLon(45.38053, 36.73226), 13110.);
+        MercatorBounds::FromLatLon(45.38053, 36.73226), 15500.);
   }
 
   UNIT_TEST(ParisCrossDestinationInForwardHeapCase)
@@ -277,6 +286,7 @@ namespace
         MercatorBounds::FromLatLon(49.85015, 2.24296), 126000.);
   }
 
+  // Fails to return correct time.
   UNIT_TEST(RussiaSmolenskRussiaMoscowTimeTest)
   {
     TRouteResult const routeResult =
@@ -301,7 +311,7 @@ namespace
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
 
-    integration::TestRouteTime(route, 745.);
+    integration::TestRouteTime(route, 730.);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
@@ -318,7 +328,7 @@ namespace
     TEST_EQUAL(route.GetSubrouteCount(), 1, ());
     vector<RouteSegment> info;
     route.GetSubrouteInfo(0, info);
-    TEST_EQUAL(info.size(), 336, ());
+    TEST_EQUAL(info.size(), 330, ());
   }
 
   UNIT_TEST(USALosAnglesAriaTwentyninePalmsHighwayTimeTest)

--- a/routing/routing_integration_tests/routing_integration_tests.pro
+++ b/routing/routing_integration_tests/routing_integration_tests.pro
@@ -11,10 +11,14 @@ CONFIG -= app_bundle
 TEMPLATE = app
 
 ROOT_DIR = ../..
-DEPENDENCIES = map routing traffic routing_common search storage ugc indexer platform editor geometry coding base \
-               osrm jansson protobuf succinct stats_client pugixml icu agg
+DEPENDENCIES = map routing traffic routing_common search storage mwm_diff ugc indexer platform editor geometry \
+               coding base osrm jansson protobuf bsdiff succinct stats_client pugixml icu agg
 
 DEPENDENCIES += opening_hours
+
+!iphone*:!android*:!tizen:!macx-* {
+  QT *= network
+}
 
 macx-*: LIBS *= "-framework IOKit" "-framework SystemConfiguration"
 

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -17,6 +17,8 @@
 
 #include "indexer/index.hpp"
 
+#include "storage/country_parent_getter.hpp"
+
 #include "platform/local_country_file.hpp"
 #include "platform/local_country_file_utils.hpp"
 #include "platform/platform.hpp"
@@ -24,6 +26,8 @@
 
 #include "geometry/distance_on_sphere.hpp"
 #include "geometry/latlon.hpp"
+
+#include "base/stl_add.hpp"
 
 #include "std/functional.hpp"
 #include "std/limits.hpp"
@@ -102,8 +106,11 @@ namespace integration
         numMwmIds->RegisterFile(countryFile);
     }
 
+    auto countryParentGetter = my::make_unique<storage::CountryParentGetter>();
+    CHECK(countryParentGetter, ());
+
     auto indexRouter = make_unique<IndexRouter>(vehicleType, false /* load altitudes*/,
-                                                CountryParentNameGetterFn(), countryFileGetter,
+                                                *countryParentGetter, countryFileGetter,
                                                 getMwmRectByName, numMwmIds,
                                                 MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, index);
 

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -60,7 +60,7 @@ namespace integration
 {
   shared_ptr<model::FeaturesFetcher> CreateFeaturesFetcher(vector<LocalCountryFile> const & localFiles)
   {
-    size_t const maxOpenFileNumber = 1024;
+    size_t const maxOpenFileNumber = 4096;
     ChangeMaxNumberOfOpenFiles(maxOpenFileNumber);
     shared_ptr<model::FeaturesFetcher> featuresFetcher(new model::FeaturesFetcher);
     featuresFetcher->InitClassificator();

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -8,6 +8,7 @@
 using namespace routing;
 using namespace routing::turns;
 
+// Fails. Start direction ignored.
 UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
 {
   TRouteResult const routeResult =
@@ -19,7 +20,7 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 3);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -43,21 +44,21 @@ UNIT_TEST(StPetersburgSideRoadPenaltyTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(55.79693, 37.53754), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.79683, 37.5379), {0., 0.},
                                   MercatorBounds::FromLatLon(55.80212, 37.5389));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 4);
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -70,9 +71,10 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
       .TestDirection(CarDirection::TurnRight);
   integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
 
-  integration::TestRouteLength(route, 2033.);
+  integration::TestRouteLength(route, 2050.);
 }
 
+// Fails: generates "GoStraight" description instead of TurnSlightRight.
 UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 {
   TRouteResult const routeResult =
@@ -83,7 +85,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 4);
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestPoint({37.38848, 67.63338}, 20.)
@@ -104,6 +106,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
   integration::TestRouteLength(route, 1637.);
 }
 
+// Fails because consider service roads are roundabout exits.
 UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
 {
   TRouteResult const routeResult =
@@ -114,7 +117,7 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -135,7 +138,7 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -146,7 +149,7 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
   integration::TestRouteLength(route, 255.);
 }
 
-UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
+UNIT_TEST(RussiaMoscowPlanetnayaOnlyStraightTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
@@ -157,12 +160,16 @@ UNIT_TEST(RussiaMoscowPlanetnaiTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnRight);
 
-  integration::TestRouteLength(route, 217.);
+  integration::TestRouteLength(route, 454.);
 }
 
+// Fails: generates "GoStraight" description instead of TurnSlightRight/TurnRight.
 UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
 {
   TRouteResult const routeResult =
@@ -174,7 +181,7 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestPoint({37.68276, 67.14062})
@@ -183,6 +190,7 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
   integration::TestRouteLength(route, 43233.7);
 }
 
+// Fails: generates "GoStraight" description instead of TurnSlightRight/TurnRight.
 UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
 {
   TRouteResult const routeResult =
@@ -194,26 +202,28 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
-UNIT_TEST(RussiaMoscowSchelkovskoeShosseUTurnTest)
+UNIT_TEST(RussiaMoscowTTKUTurnTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(55.80967, 37.78037), {0., 0.},
-                                  MercatorBounds::FromLatLon(55.80955, 37.78056));
+                                  MercatorBounds::FromLatLon(55.792848, 37.624424), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.792544, 37.624914));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});;
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
@@ -227,7 +237,7 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
@@ -244,8 +254,11 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+
+  vector<turns::TurnItem> t;
+  route.GetTurnsForTesting(t);
+  // It's not possible to get destination with less nubber of turns due to oneway roads.
+  TEST_GREATER_OR_EQUAL(t.size(), 5, ());
 }
 
 UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
@@ -259,11 +272,12 @@ UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
+// Fails due to uneeded "GoStraight".
 UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
 {
   TRouteResult const routeResult =
@@ -275,9 +289,10 @@ UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
+// Fails because consider service roads are roundabout exits.
 UNIT_TEST(RussiaHugeRoundaboutTurnTest)
 {
   TRouteResult const routeResult =
@@ -289,7 +304,7 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestDirection(CarDirection::EnterRoundAbout)
@@ -300,6 +315,7 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
       .TestRoundAboutExitNum(5);
 }
 
+// Fails: generates "GoStraight" description instead of TurnSlightRight/TurnRight.
 UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
 {
   TRouteResult const routeResult =
@@ -311,7 +327,7 @@ UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
@@ -329,7 +345,7 @@ UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
@@ -346,7 +362,7 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
 }
 
 UNIT_TEST(BelarusMKADShosseinai)
@@ -360,11 +376,10 @@ UNIT_TEST(BelarusMKADShosseinai)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {CarDirection::GoStraight, CarDirection::TurnSlightRight});
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
+// Fails: unneeded TurnSlightRight generated.
 // Test case: a route goes straight along a unnamed big road when joined small road.
 // An end user shall not be informed about such manoeuvres.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
@@ -378,7 +393,7 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 // Test case: a route goes in Moscow from Varshavskoe shosse (from the city center direction)
@@ -395,13 +410,32 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
+// Test case: a route goes in Moscow from Bolshaya Nikitskaya street
+// (towards city center) to Mokhovaya street. A turn instruction (turn left)
+// shall be generated.
+UNIT_TEST(RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.75509, 37.61067), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75737, 37.61601));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+}
+
 // Test case: a route goes in Moscow from Tverskaya street (towards city center)
-// to Mokhovaya street. A turn instruction (turn left) shell be generated.
+// to Mokhovaya street. Road goes left but there are no other turn option.
+// Turn instruction is not needed in this case.
 UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 {
   TRouteResult const routeResult =
@@ -413,8 +447,7 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
@@ -428,7 +461,7 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
 
@@ -445,10 +478,11 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
 
+// Fails: generates unnecessary turn.
 // Test case: checking that no unnecessary turn on a serpentine road.
 // This test was written after reducing factors kMaxPointsCount and kMinDistMeters.
 UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
@@ -462,7 +496,7 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
@@ -476,5 +510,5 @@ UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		4065EA871F8260010094DEF3 /* transit_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4065EA841F8260000094DEF3 /* transit_graph.hpp */; };
 		4081AD4E1F8E4C1D006CE8A5 /* transit_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */; };
 		40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */; };
+		408B55C11FD9541300F4E78B /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 408B55BF1FD953F100F4E78B /* libbsdiff.a */; };
+		408B55C21FD9541800F4E78B /* libmwm_diff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 408B55C01FD9540F00F4E78B /* libmwm_diff.a */; };
 		40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40A111CB1F2F6776005E6AD5 /* route_weight.cpp */; };
 		40A111CE1F2F6776005E6AD5 /* route_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CC1F2F6776005E6AD5 /* route_weight.hpp */; };
 		40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */; };
@@ -365,6 +367,8 @@
 		4065EA841F8260000094DEF3 /* transit_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_graph.hpp; sourceTree = "<group>"; };
 		4081AD4D1F8E4C1C006CE8A5 /* transit_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_graph.cpp; sourceTree = "<group>"; };
 		40858A861F8CEAE60065CFF7 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
+		408B55BF1FD953F100F4E78B /* libbsdiff.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libbsdiff.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		408B55C01FD9540F00F4E78B /* libmwm_diff.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libmwm_diff.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		40A111CB1F2F6776005E6AD5 /* route_weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_weight.cpp; sourceTree = "<group>"; };
 		40A111CC1F2F6776005E6AD5 /* route_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = route_weight.hpp; sourceTree = "<group>"; };
 		40A111CF1F2F9704005E6AD5 /* astar_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_weight.hpp; sourceTree = "<group>"; };
@@ -627,6 +631,7 @@
 				67BD35EE1C69F198003AA26F /* libsdf_image.a in Frameworks */,
 				67BD35EF1C69F198003AA26F /* libstb_image.a in Frameworks */,
 				67BD35D51C69F155003AA26F /* libstorage.a in Frameworks */,
+				408B55C21FD9541800F4E78B /* libmwm_diff.a in Frameworks */,
 				67BD35D31C69F139003AA26F /* librouting.a in Frameworks */,
 				67BD35C91C69F121003AA26F /* libosrm.a in Frameworks */,
 				67BD35C41C69F121003AA26F /* libjansson.a in Frameworks */,
@@ -644,6 +649,7 @@
 				67BD35CF1C69F121003AA26F /* libindexer.a in Frameworks */,
 				67BD35C31C69F121003AA26F /* libsuccinct.a in Frameworks */,
 				67BD35CD1C69F121003AA26F /* libalohalitics.a in Frameworks */,
+				408B55C11FD9541300F4E78B /* libbsdiff.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -654,6 +660,8 @@
 			isa = PBXGroup;
 			children = (
 				567E9F801F5853370064CB96 /* libtraffic.a */,
+				408B55BF1FD953F100F4E78B /* libbsdiff.a */,
+				408B55C01FD9540F00F4E78B /* libmwm_diff.a */,
 				567E9F7E1F58530D0064CB96 /* librouting_common.a */,
 				567E9F7C1F5852C00064CB96 /* libicu.a */,
 				567059611F3AFC5C0062672D /* librouting_common.a */,


### PR DESCRIPTION
Интеграционные тесты были заброшены, привожу в порядок.
Этот PR состоит из трёх коммитов:
- включение использования правильных VehicleModel для конкретной страны, для этого из storage подтягивается CountryParentGetter
- увеличение количества разрешенных файловых дескрипторов -- есть тесты, которые открыают все mwm-ки, а их уже больше 1024
- актуализация тестов.

Актуализация проведена как в части соответствия изменившимся картам, так и в части обновления функциональности, например тесты на то что дороги типа service в россии не проезжаются насквозь.
Там где карты изменились подобрала аналогичный тесткейс в другом месте.

Часть тестов остается сломанной, добавила к ним комментарии о том, что не работает. Большинство ошибок в генерации манёвров.

До изменений не проходило 67 тестов, сейчас с учётом PR https://github.com/mapsme/omim/pull/7740 -- 18, в 14 из них ошибки в генерации манёвров.