### PR TITLE
Generator gits rid of settings.ini dependency.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -416,7 +416,7 @@ void GraphData::CalculateBestPedestrianSegments(string const & mwmPath, TCountry
   // Creating IndexRouter.
   SingleMwmIndex index(mwmPath);
 
-  auto infoGetter = storage::CountryInfoReader::CreateCountryInfoReader(GetPlatform());
+  auto infoGetter = storage::CountryInfoReader::CreateCountryInfoReaderOneComponentMwms(GetPlatform());
   CHECK(infoGetter, ());
 
   auto const countryFileGetter = [&infoGetter](m2::PointD const & pt) {


### PR DESCRIPTION
При генерации секции transit необходимо инициализировать IndexGraph. Для этого нужно создать CountyInfoGetter. А ему в свою очередь нужно знать использовать countries.txt или countries_obsolete.txt.

Если settings.ini нет или поля в "LastMigration" в settings.ini нет используется countries_obsolete.txt (крупная разбивка mwm). Т.о. чтоб генератор корректно работал ему необходимо подсунуть сейчас setting.ini со строчкой LastMigration=<достаточно большое число> (например, LastMigration=160302). Если этого не сделать - будет использован countries_obsolete.txt.

Учитывая, что:
- мы уже не поддерживаем миграцию с крупных mwm-ок и ни когда не используем countries_obsolete.txt в текущем коде; 
- у нас setting.ini не лежит в репозитории, и его надо поддерживать генератору;
Предлагаю по умолчанию использовать countries.txt. Т.е. если нет settings.ini или флага LastMigration использовать countries.txt.

*EDITED

На встрече коллеги предложили удачное решение по отвязыванию генератора от settings.ini вообще. Будем создавай CountryInfoGetter() только на базе countries.txt.

@ygorshenin @Zverik PTAL