### PR TITLE
Taking into account cases when a stop is present as a relation.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -231,19 +231,15 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   if (it != m_osmIdToFeatureIds.cend())
   {
     CHECK_GREATER_OR_EQUAL(it->second.size(), 1, ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-                            ") from transit graph corresponds to zero features."));
-    if (it->second.size() == 1)
+                            ") from transit graph does not correspond to any feature."));
+    if (it->second.size() != 1)
     {
-      id.SetFeatureId(it->second[0]);
-    }
-    else
-    {
-      LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
-                     it->second.size(), "feature ids. It may happen in rare case."));
       // Note. |osmId| corresponds several feature ids. It may happen in case of stops;
-      // if a stop is present as relation.
-      id.SetFeatureId(it->second[0]);
+      // if a stop is present as relation. It's a rare case.
+      LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
+                     it->second.size(), "feature ids."));
     }
+    id.SetFeatureId(it->second[0]);
   }
   id.SetOsmId(osmId.EncodedId());
 }

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -230,10 +230,20 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   auto const it = m_osmIdToFeatureIds.find(osmId);
   if (it != m_osmIdToFeatureIds.cend())
   {
-    CHECK_EQUAL(it->second.size(), 1, ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-                 ") from transit graph corresponds to", it->second.size(), "features."
-                 "But osm id should be represented be one feature."));
-    id.SetFeatureId(it->second[0]);
+    CHECK_GREATER_OR_EQUAL(it->second.size(), 1, ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
+                            ") from transit graph corresponds to zero features."));
+    if (it->second.size() == 1)
+    {
+      id.SetFeatureId(it->second[0]);
+    }
+    else
+    {
+      LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
+                     it->second.size(), "feature ids. It may happen in rare case."));
+      // Note. |osmId| corresponds several feature ids. It may happen in case of stops;
+      // if a stop is present as relation.
+      id.SetFeatureId(it->second[0]);
+    }
   }
   id.SetOsmId(osmId.EncodedId());
 }


### PR DESCRIPTION
При сборке карты мира выяснилось, что очень редко (в одном случае: Osm id: relation 3791635) stop был представлен, как relation (2 платформы). Мы со @Zverik решили, что такое в принципе возможно. Вместе со stop передается osm id, которое при генерации конвертируется в feature id, и затем используется при подписывании остановок. Данный PR, в случае, если osm id отображается в несколько feature id не останавливает генератор, а берет одно из feature id (произвольное) и пишет warning на этапе генерации.

@Zverik @darina @ygorshenin PTAL