### PR TITLE
[android] Fixed loading gallery state for vaitor in PP

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -911,20 +911,6 @@ public class PlacePageView extends RelativeLayout
     mIvSponsoredLogo.setImageDrawable(drawable);
   }
 
-  private void showLoadingViatorProducts(@NonNull String id, @NonNull String cityUrl)
-  {
-    if (!Viator.hasCache(id))
-      mRvSponsoredProducts.setAdapter(Factory.createViatorLoadingAdapter(cityUrl,
-                                                                         mDefaultGalleryItemListener));
-  }
-
-  private void showLoadingCianProducts(@NonNull FeatureId id, @NonNull String url)
-  {
-    if (!Cian.hasCache(id))
-      mRvSponsoredProducts.setAdapter(Factory.createCianLoadingAdapter(url,
-                                                                       mDefaultGalleryItemListener));
-  }
-
   private void updateGallerySponsoredTitle(@Sponsored.SponsoredType int type)
   {
     mTvSponsoredTitle.setText(type == Sponsored.TYPE_CIAN ? R.string.subtitle_rent
@@ -1279,12 +1265,13 @@ public class PlacePageView extends RelativeLayout
 
     if (isViator)
     {
-      showLoadingViatorProducts(mSponsored.getId(), url);
+      mRvSponsoredProducts.setAdapter(Factory.createViatorLoadingAdapter(url,
+                                                                         mDefaultGalleryItemListener));
       Viator.requestViatorProducts(policy, mSponsored.getId(), currencyCode);
       return;
     }
 
-    showLoadingCianProducts(mMapObject.getFeatureId(), url);
+    mRvSponsoredProducts.setAdapter(Factory.createCianLoadingAdapter(url, mDefaultGalleryItemListener));
     Cian.getRentNearby(policy, mMapObject.getLat(), mMapObject.getLon(), mMapObject.getFeatureId());
   }
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-6204

Суть проблемы была в следующем. Если при запросе виатора возникала ошибка, то ядро возвращало пустой список продуктов и этот пустой список кладется в кэш по destId. Далее, когда снова тапаешь на объект виаторовский, срабатывало условие (!Viator.hasCache(id)) и галерея не переводилась в состояние loading.

Решение: удалил эту проверку, т.к. она лишняя и костыльная. Внутри класса Viaotor и перед тем как делать запрос есть проверка в кэше и + проверяется пустой список или нет, что правильно. Тем самым loading состояния всегда будет и его не должно не быть, да если в последующем данные возмуться из кэша.