### PR TITLE
[routing] Start and finish leaps creation refactoring

### DIFF
--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -159,6 +159,7 @@ public:
       ASSERT_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
       for (size_t enterIdx = 0; enterIdx < m_enters.size(); ++enterIdx)
       {
+        // @todo(t.yan) fix weight for ingoing edges https://jira.mail.ru/browse/MAPSME-5953
         auto const weight = GetWeight(enterIdx, base::asserted_cast<size_t>(transition.m_exitIdx));
         AddEdge(m_enters[enterIdx], weight, edges);
       }

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -93,17 +93,13 @@ public:
 
   void Clear();
 
-  // Applies |fn| to each nontransit transition. We never need to apply function to both transit
-  // and nontransit transitions.
-  // We may need to implement ForEachTransitTransition() or |isTransit| flag here when we'll have
-  // leaps for transit.
-  template <typename Fn>
-  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
+  // \returns nontransit transitions for mwm with id |numMwmId|.
+  // Should be used with CrossMwmIndexGraph only.
+  // @todo(bykoianko): rewrite comment and check after CrossMwmOsrm removal.
+  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter)
   {
-    if (CrossMwmSectionExists(numMwmId))
-      m_crossMwmIndexGraph.ForEachTransition(numMwmId, isEnter, std::forward<Fn>(fn));
-    else
-      m_crossMwmOsrmGraph.ForEachTransition(numMwmId, isEnter, std::forward<Fn>(fn));
+    CHECK(CrossMwmSectionExists(numMwmId), ("Should be used in LeapsOnly mode only. LeapsOnly mode requires CrossMwmIndexGraph."));
+    return m_crossMwmIndexGraph.GetTransitions(numMwmId, isEnter);
   }
 
 private:

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -148,12 +148,10 @@ public:
     GetCrossMwmConnectorWithTransitions(numMwmId);
   }
 
-  template <typename Fn>
-  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
+  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter)
   {
-    auto const & connectors = GetCrossMwmConnectorWithTransitions(numMwmId);
-    for (Segment const & t : (isEnter ? connectors.GetEnters() : connectors.GetExits()))
-      fn(t);
+    auto const & connector = GetCrossMwmConnectorWithTransitions(numMwmId);
+    return isEnter ? connector.GetEnters() : connector.GetExits();
   }
 
 private:

--- a/routing/cross_mwm_osrm_graph.hpp
+++ b/routing/cross_mwm_osrm_graph.hpp
@@ -32,14 +32,6 @@ public:
   void Clear();
   TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
 
-  template <typename Fn>
-  void ForEachTransition(NumMwmId numMwmId, bool isEnter, Fn && fn)
-  {
-    auto const & ts = GetSegmentMaps(numMwmId);
-    for (auto const & kv : isEnter ? ts.m_ingoing : ts.m_outgoing)
-      fn(kv.first);
-  }
-
 private:
   struct TransitionSegments
   {

--- a/routing/fake_edges_container.hpp
+++ b/routing/fake_edges_container.hpp
@@ -18,8 +18,7 @@ class FakeEdgesContainer final
 
 public:
   FakeEdgesContainer(IndexGraphStarter && starter)
-    : m_finishId(starter.m_finishId)
-    , m_finishPassThroughAllowed(starter.m_finishPassThroughAllowed)
+    : m_finish(starter.m_finish)
     , m_fake(std::move(starter.m_fake))
   {
   }
@@ -33,10 +32,8 @@ public:
   }
 
 private:
-  // Finish segment id.
-  uint32_t m_finishId;
-  // Finish segment is located in a pass-through/non-pass-through area.
-  bool m_finishPassThroughAllowed;
+  // Finish ending.
+  IndexGraphStarter::Ending m_finish;
   FakeGraph<Segment, FakeVertex, Segment> m_fake;
 };
 }  // namespace routing

--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -132,8 +132,6 @@ public:
     return true;
   }
 
-  std::map<SegmentType, RealType> const & GetFakeToReal() const { return m_fakeToReal; }
-
 private:
   // Key is fake segment, value is set of outgoing fake segments.
   std::map<SegmentType, std::set<SegmentType>> m_outgoing;

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -27,7 +27,7 @@ public:
                           std::shared_ptr<EdgeEstimator> estimator);
 
   // WorldGraph overrides:
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                    std::vector<SegmentEdge> & edges) override;
   bool CheckLength(RouteWeight const &, double) const override { return true; }
   Junction const & GetJunction(Segment const & segment, bool front) override;
@@ -42,8 +42,10 @@ public:
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
+  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
   // This method should be used for tests only

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -30,7 +30,7 @@ public:
                     std::shared_ptr<EdgeEstimator> estimator);
 
   // WorldGraph overrides:
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                    std::vector<SegmentEdge> & edges) override;
   bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const override
   {
@@ -51,8 +51,10 @@ public:
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
   bool LeapIsAllowed(NumMwmId mwmId) const override;
+  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
 private:
@@ -75,5 +77,6 @@ private:
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::vector<Segment> m_twins;
   Mode m_mode = Mode::NoLeaps;
+  std::vector<Segment> const kEmptyTransitions = {};
 };
 }  // namespace routing

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -39,9 +39,7 @@ public:
 
   virtual ~WorldGraph() = default;
 
-  // |isEnding| == true iff |segment| is first or last segment of the route. Needed because first and
-  // last segments may need special processing.
-  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap, bool isEnding,
+  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
                            std::vector<SegmentEdge> & edges) = 0;
 
   // Checks whether path length meets restrictions. Restrictions may depend on the distance from
@@ -67,10 +65,14 @@ public:
   virtual RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) = 0;
   virtual RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) = 0;
   virtual RouteWeight CalcSegmentWeight(Segment const & segment) = 0;
+  virtual RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
   virtual bool LeapIsAllowed(NumMwmId mwmId) const = 0;
 
-  // Returns transit-specific information for segment. For nontransit segments returns nullptr.
+  /// \returns transitions for mwm with id |numMwmId|.
+  virtual std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) = 0;
+
+  /// \returns transit-specific information for segment. For nontransit segments returns nullptr.
   virtual std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) = 0;
 };
 


### PR DESCRIPTION
Рефакторинг создания фейковых leap от старта/финиша к выходам/входам из mwm.
Пока не исправляет ошибки, этот PR только про перенос создания фейковых дуг в стартер.
Теперь фейковая дуга начинается с фейкового стартового сегмента, а не с первого "реального", поэтому немного изменился код ProcessLeaps:
- убрано перекладывание фейковых сегментов в output в LeapsOnly
- маршрут для фековых Leap строится по стартеру в режиме NoLeaps, а не по WorldGraph.
