### PR TITLE
[routing] Run both bidirectional and unidirectional AStar in routing tests.

### DIFF
--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -2,6 +2,8 @@
 
 #include "routing/base/astar_weight.hpp"
 
+#include "base/math.hpp"
+
 #include <iostream>
 #include <limits>
 
@@ -69,6 +71,13 @@ public:
   RouteWeight operator-() const
   {
     return RouteWeight(-m_weight, -m_nonPassThroughCross, -m_transitTime);
+  }
+
+  bool IsAlmostEqualForTests(RouteWeight const & rhs, double epsilon)
+  {
+    return m_nonPassThroughCross == rhs.m_nonPassThroughCross &&
+           my::AlmostEqualAbs(m_weight, rhs.m_weight, epsilon) &&
+           my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, epsilon);
   }
 
 private:


### PR DESCRIPTION
Добавила запуск одностороннего AStar в тесты, сравнение времени с двухсторонним, чтобы односторонний AStar тестировался и в случае нетривиальной эвристики.
Будет ловить ошибки типа https://github.com/mapsme/omim/pull/7609 .