### PR TITLE
[android] Fixed crash during double-removing map object listener

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -769,6 +769,7 @@ Java_com_mapswithme_maps_Framework_nativeRemoveMapObjectListener(JNIEnv * env, j
   frm()->SetMapSelectionListeners({}, {});
   LOG(LINFO, ("Remove global map object listener"));
   env->DeleteGlobalRef(g_mapObjectListener);
+  g_mapObjectListener = nullptr;
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/src/com/mapswithme/maps/base/BaseActivityDelegate.java
+++ b/android/src/com/mapswithme/maps/base/BaseActivityDelegate.java
@@ -1,10 +1,13 @@
 package com.mapswithme.maps.base;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.mapswithme.util.Config;
+import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.ViewServer;
 import com.mapswithme.util.concurrency.UiThread;
@@ -13,6 +16,7 @@ import com.my.tracker.MyTracker;
 
 class BaseActivityDelegate
 {
+  private static final String TAG = BaseActivityDelegate.class.getSimpleName();
   @NonNull
   private final BaseActivity mActivity;
   @Nullable
@@ -23,8 +27,14 @@ class BaseActivityDelegate
     mActivity = activity;
   }
 
+  void onNewIntent(@NonNull Intent intent)
+  {
+    logLifecycleMethod("onNewIntent(" + intent + ")");
+  }
+
   public void onCreate()
   {
+    logLifecycleMethod("onCreate()");
     mThemeName = Config.getCurrentUiTheme();
     if (!TextUtils.isEmpty(mThemeName))
       mActivity.get().setTheme(mActivity.getThemeResourceId(mThemeName));
@@ -32,28 +42,33 @@ class BaseActivityDelegate
 
   void onDestroy()
   {
+    logLifecycleMethod("onDestroy()");
     ViewServer.get(mActivity.get()).removeWindow(mActivity.get());
   }
 
   void onPostCreate()
   {
+    logLifecycleMethod("onPostCreate()");
     ViewServer.get(mActivity.get()).addWindow(mActivity.get());
   }
 
   void onStart()
   {
+    logLifecycleMethod("onStart()");
     Statistics.INSTANCE.startActivity(mActivity.get());
     MyTracker.onStartActivity(mActivity.get());
   }
 
   void onStop()
   {
+    logLifecycleMethod("onStop()");
     Statistics.INSTANCE.stopActivity(mActivity.get());
     MyTracker.onStopActivity(mActivity.get());
   }
 
   public void onResume()
   {
+    logLifecycleMethod("onResume()");
     org.alohalytics.Statistics.logEvent("$onResume", mActivity.getClass().getSimpleName() + ":" +
                                                      UiUtils.deviceOrientationAsString(mActivity.get()));
     ViewServer.get(mActivity.get()).setFocusedWindow(mActivity.get());
@@ -61,11 +76,13 @@ class BaseActivityDelegate
 
   public void onPause()
   {
+    logLifecycleMethod("onPause()");
     org.alohalytics.Statistics.logEvent("$onPause", mActivity.getClass().getSimpleName());
   }
 
   void onPostResume()
   {
+    logLifecycleMethod("onPostResume()");
     if (!TextUtils.isEmpty(mThemeName) && mThemeName.equals(Config.getCurrentUiTheme()))
       return;
 
@@ -76,5 +93,10 @@ class BaseActivityDelegate
         mActivity.get().recreate();
       }
     });
+  }
+
+  private void logLifecycleMethod(@NonNull String method)
+  {
+    CrashlyticsUtils.log(Log.INFO, TAG, mActivity.getClass().getSimpleName() + ": " + method);
   }
 }

--- a/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
@@ -1,6 +1,7 @@
 package com.mapswithme.maps.base;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
@@ -23,7 +24,7 @@ import com.mapswithme.util.ThemeUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.Utils;
 
-public class BaseMwmFragmentActivity extends AppCompatActivity
+public abstract class BaseMwmFragmentActivity extends AppCompatActivity
                                   implements BaseActivity
 {
   private final BaseActivityDelegate mBaseDelegate = new BaseActivityDelegate(this);
@@ -119,6 +120,15 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     return true;
   }
 
+  @CallSuper
+  @Override
+  protected void onNewIntent(Intent intent)
+  {
+    super.onNewIntent(intent);
+    mBaseDelegate.onNewIntent(intent);
+  }
+
+  @CallSuper
   @Override
   protected void onPostCreate(@Nullable Bundle savedInstanceState)
   {
@@ -126,6 +136,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     mBaseDelegate.onPostCreate();
   }
 
+  @CallSuper
   @Override
   protected void onDestroy()
   {
@@ -133,6 +144,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     mBaseDelegate.onDestroy();
   }
 
+  @CallSuper
   @Override
   protected void onStart()
   {
@@ -140,6 +152,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     mBaseDelegate.onStart();
   }
 
+  @CallSuper
   @Override
   protected void onStop()
   {
@@ -172,6 +185,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     mBaseDelegate.onResume();
   }
 
+  @CallSuper
   @Override
   protected void onPostResume()
   {
@@ -179,6 +193,7 @@ public class BaseMwmFragmentActivity extends AppCompatActivity
     mBaseDelegate.onPostResume();
   }
 
+  @CallSuper
   @Override
   protected void onPause()
   {


### PR DESCRIPTION
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5a34a4608cb3c2fa63fc1e1f?time=last-seven-days

В общем этот крэш - это все тот же крэш с removeMapObjectListener. Сейчас он выглядит более правильно, видимо после перехода на симейк. 

Суть проблемы в том, что метод `Framework.nativeRemoveMapObjectListener()` вызывается в каком-то случае два раза подряд. В каком это кейсе может произойти - пока не представляется возможным мне придумать (должен метод stop два раза подряд вызваться!). Зануление g_mapObjectListener'a улучшит нам статистику в Fabric'e, но корневая проблема останется. Чтобы ее решить, я вставил логирование в фабрик всех методов жизненного цикла всех экранов.