### PR TITLE
[routing] Fix ReconstructPath with new routing::Edge::IsFake behaviour.

### DIFF
--- a/openlr/decoded_path.cpp
+++ b/openlr/decoded_path.cpp
@@ -126,10 +126,10 @@ void PathFromXML(pugi::xml_node const & node, Index const & index, Path & p)
     LatLonFromXML(e.child("StartJunction"), start);
     LatLonFromXML(e.child("EndJunction"), end);
 
-    p.emplace_back(
+    p.push_back(Edge::MakeReal(
         fid, isForward, segmentId,
         routing::Junction(MercatorBounds::FromLatLon(start), feature::kDefaultAltitudeMeters),
-        routing::Junction(MercatorBounds::FromLatLon(end), feature::kDefaultAltitudeMeters));
+        routing::Junction(MercatorBounds::FromLatLon(end), feature::kDefaultAltitudeMeters)));
   }
 }
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
@@ -350,13 +350,9 @@ void TrafficMode::CommitPath()
     std::tie(prevFid, prevSegId) = prevPoint.GetPoint();
     std::tie(fid, segId) = point.GetPoint();
 
-    path.emplace_back(
-        fid,
-        prevSegId < segId /* forward */,
-        prevSegId,
-        routing::Junction(prevPoint.GetCoordinate(), 0 /* altitude */),
-        routing::Junction(point.GetCoordinate(), 0 /* altitude */)
-    );
+    path.push_back(Edge::MakeReal(fid, prevSegId < segId /* forward */, prevSegId,
+                                  routing::Junction(prevPoint.GetCoordinate(), 0 /* altitude */),
+                                  routing::Junction(point.GetCoordinate(), 0 /* altitude */)));
   }
 
   m_currentSegment->SetGoldenPath(path);

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -80,15 +80,17 @@ void NearestEdgeFinder::MakeResult(vector<pair<Edge, Junction>> & res, size_t co
   
   for (Candidate const & candidate : m_candidates)
   {
-    res.emplace_back(Edge(candidate.m_fid, true /* forward */, candidate.m_segId,
-                          candidate.m_segStart, candidate.m_segEnd), candidate.m_projPoint);
+    res.emplace_back(Edge::MakeReal(candidate.m_fid, true /* forward */, candidate.m_segId,
+                                    candidate.m_segStart, candidate.m_segEnd),
+                     candidate.m_projPoint);
     if (res.size() >= maxCountFeatures)
       return;
 
     if (candidate.m_bidirectional)
     {
-      res.emplace_back(Edge(candidate.m_fid, false /* forward */, candidate.m_segId,
-                            candidate.m_segEnd, candidate.m_segStart), candidate.m_projPoint);
+      res.emplace_back(Edge::MakeReal(candidate.m_fid, false /* forward */, candidate.m_segId,
+                                      candidate.m_segEnd, candidate.m_segStart),
+                       candidate.m_projPoint);
       if (res.size() >= maxCountFeatures)
         return;
     }

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -63,11 +63,11 @@ class Edge
 
 public:
   Edge() = default;
-  Edge(FeatureID const & featureId, bool forward, uint32_t segId, Junction const & startJunction,
-       Junction const & endJunction);
   Edge(Edge const &) = default;
   Edge & operator=(Edge const &) = default;
 
+  static Edge MakeReal(FeatureID const & featureId, bool forward, uint32_t segId,
+                       Junction const & startJunction, Junction const & endJunction);
   static Edge MakeFake(Junction const & startJunction, Junction const & endJunction);
   static Edge MakeFake(Junction const & startJunction, Junction const & endJunction,
                        Edge const & prototype);
@@ -95,6 +95,9 @@ public:
   bool operator<(Edge const & r) const;
 
 private:
+  Edge(Type type, FeatureID const & featureId, bool forward, uint32_t segId,
+       Junction const & startJunction, Junction const & endJunction);
+
   friend string DebugPrint(Edge const & r);
 
   Type m_type = Type::FakeWithoutRealPart;

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -31,32 +31,34 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
 
 UNIT_TEST(StarterPosAtBorder_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected = {make_pair(
-      Edge(MakeTestFeatureID(0), true /* forward */, 0, MakeJunctionForTesting(m2::PointD(0, 0)),
-           MakeJunctionForTesting(m2::PointD(5, 0))),
-      MakeJunctionForTesting(m2::PointD(0, 0)))};
+  vector<pair<Edge, Junction>> const expected = {
+      make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 0,
+                               MakeJunctionForTesting(m2::PointD(0, 0)),
+                               MakeJunctionForTesting(m2::PointD(5, 0))),
+                MakeJunctionForTesting(m2::PointD(0, 0)))};
   TestNearestOnMock1(m2::PointD(0, 0), 1, expected);
 }
 
 UNIT_TEST(MiddleEdgeTest_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected = {make_pair(
-      Edge(MakeTestFeatureID(0), true /* forward */, 0, MakeJunctionForTesting(m2::PointD(0, 0)),
-           MakeJunctionForTesting(m2::PointD(5, 0))),
-      MakeJunctionForTesting(m2::PointD(3, 0)))};
+  vector<pair<Edge, Junction>> const expected = {
+      make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 0,
+                               MakeJunctionForTesting(m2::PointD(0, 0)),
+                               MakeJunctionForTesting(m2::PointD(5, 0))),
+                MakeJunctionForTesting(m2::PointD(3, 0)))};
   TestNearestOnMock1(m2::PointD(3, 3), 1, expected);
 }
 
 UNIT_TEST(MiddleSegmentTest_Mock1Graph)
 {
   vector<pair<Edge, Junction>> const expected = {
-      make_pair(Edge(MakeTestFeatureID(0), true /* forward */, 2,
-                     MakeJunctionForTesting(m2::PointD(10, 0)),
-                     MakeJunctionForTesting(m2::PointD(15, 0))),
+      make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 2,
+                               MakeJunctionForTesting(m2::PointD(10, 0)),
+                               MakeJunctionForTesting(m2::PointD(15, 0))),
                 MakeJunctionForTesting(m2::PointD(12.5, 0))),
-      make_pair(Edge(MakeTestFeatureID(0), false /* forward */, 2,
-                     MakeJunctionForTesting(m2::PointD(15, 0)),
-                     MakeJunctionForTesting(m2::PointD(10, 0))),
+      make_pair(Edge::MakeReal(MakeTestFeatureID(0), false /* forward */, 2,
+                               MakeJunctionForTesting(m2::PointD(15, 0)),
+                               MakeJunctionForTesting(m2::PointD(10, 0))),
                 MakeJunctionForTesting(m2::PointD(12.5, 0)))};
   TestNearestOnMock1(m2::PointD(12.5, 2.5), 2, expected);
 }

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -56,27 +56,35 @@ UNIT_TEST(RoadGraph_NearestEdges)
 
   // Expected outgoing edges.
   IRoadGraph::TEdgeVector expectedOutgoing = {
-      Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(-1, 0))),
-      Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(1, 0))),
-      Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, -1))),
-      Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 1))),
+      Edge::MakeReal(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, 0)),
+                     MakeJunctionForTesting(m2::PointD(-1, 0))),
+      Edge::MakeReal(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, 0)),
+                     MakeJunctionForTesting(m2::PointD(1, 0))),
+      Edge::MakeReal(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, 0)),
+                     MakeJunctionForTesting(m2::PointD(0, -1))),
+      Edge::MakeReal(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, 0)),
+                     MakeJunctionForTesting(m2::PointD(0, 1))),
   };
   sort(expectedOutgoing.begin(), expectedOutgoing.end());
 
   // Expected ingoing edges.
   IRoadGraph::TEdgeVector expectedIngoing = {
-      Edge(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
-           MakeJunctionForTesting(m2::PointD(-1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
-      Edge(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
-           MakeJunctionForTesting(m2::PointD(1, 0)), MakeJunctionForTesting(m2::PointD(0, 0))),
-      Edge(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, -1)), MakeJunctionForTesting(m2::PointD(0, 0))),
-      Edge(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
-           MakeJunctionForTesting(m2::PointD(0, 1)), MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge::MakeReal(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(-1, 0)),
+                     MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge::MakeReal(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(1, 0)),
+                     MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge::MakeReal(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, -1)),
+                     MakeJunctionForTesting(m2::PointD(0, 0))),
+      Edge::MakeReal(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
+                     MakeJunctionForTesting(m2::PointD(0, 1)),
+                     MakeJunctionForTesting(m2::PointD(0, 0))),
   };
   sort(expectedIngoing.begin(), expectedIngoing.end());
 


### PR DESCRIPTION
Поддержка изменений в поведении IsFake в ReconstructPath:
раньше фейковость определялась по тому, содержит ли Edge реальный или пустой FeatureId, вызывающий код на это расчитывал.

заодно поправила 
`Edge Edge::MakeFake(Junction const & startJunction, Junction const & endJunction)`
этот метод производил ребро с типом Real, думаю это ошибка