### PR TITLE
Removing a warning about segments with zero length.

### DIFF
--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -40,7 +40,6 @@ void NearestEdgeFinder::AddInformationSource(FeatureID const & featureId, IRoadG
       feature::TAltitude projPointAlt = feature::kDefaultAltitudeMeters;
       if (segLenM == 0.0)
       {
-        LOG(LWARNING, ("Length of segment", i, " of feature", featureId, "is zero."));
         projPointAlt = startAlt;
       }
       else


### PR DESCRIPTION
При поиске ближайших к точке сегментов мы исследуем фичи в окрестности точки. Ранее, если мы находили сегмент с нулевой длиной (старт и финиш совпадают) мы писали warning про это в лог. Хотя, это вполне штатная ситуация, которая корректно обрабатывается. Я удалил данный warning. 

На данный PR натолкнуло то, что при сборке секции transit мы вызываем данный метод FindClosestEdges()/finder.AddInformationSource многократно для каждого gate-та. И данный warning достаточно часто появлялся при сборке карт.

@tatiana-kondakova @Zverik PTAL