### PR TITLE
[routing][MAPSME-5953] Disable ingoing edges listing for LeapsOnly mode, remove LeapsIfPossible mode.

### DIFF
--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -142,27 +142,14 @@ public:
     return segment.IsForward() == front ? transition.m_frontPoint : transition.m_backPoint;
   }
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges) const
+  void GetOutgoingEdgeList(Segment const & segment, std::vector<SegmentEdge> & edges) const
   {
     auto const & transition = GetTransition(segment);
-    if (isOutgoing)
+    CHECK_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
+    for (size_t exitIdx = 0; exitIdx < m_exits.size(); ++exitIdx)
     {
-      ASSERT_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
-      for (size_t exitIdx = 0; exitIdx < m_exits.size(); ++exitIdx)
-      {
-        auto const weight = GetWeight(base::asserted_cast<size_t>(transition.m_enterIdx), exitIdx);
-        AddEdge(m_exits[exitIdx], weight, edges);
-      }
-    }
-    else
-    {
-      ASSERT_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
-      for (size_t enterIdx = 0; enterIdx < m_enters.size(); ++enterIdx)
-      {
-        // @todo(t.yan) fix weight for ingoing edges https://jira.mail.ru/browse/MAPSME-5953
-        auto const weight = GetWeight(enterIdx, base::asserted_cast<size_t>(transition.m_exitIdx));
-        AddEdge(m_enters[enterIdx], weight, edges);
-      }
+      auto const weight = GetWeight(base::asserted_cast<size_t>(transition.m_enterIdx), exitIdx);
+      AddEdge(m_exits[exitIdx], weight, edges);
     }
   }
 

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -158,7 +158,7 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
         ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
   // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
   // |twins| is not filled for such cases. For details please see a note in
-  // CrossMwmGraph::GetEdgeList().
+  // CrossMwmGraph::GetOutgoingEdgeList().
   if (IsTransition(s, !isOutgoing))
     return;
 
@@ -221,21 +221,22 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
     CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
 }
 
-void CrossMwmGraph::GetEdgeList(Segment const & s, bool isOutgoing, vector<SegmentEdge> & edges)
+void CrossMwmGraph::GetOutgoingEdgeList(Segment const & s, vector<SegmentEdge> & edges)
 {
-  CHECK(IsTransition(s, !isOutgoing), ("The segment is not a transition segment. IsTransition(", s,
-                                       ",", !isOutgoing, ") returns false."));
+  CHECK(IsTransition(s, false /* isEnter */),
+        ("The segment is not a transition segment. IsTransition(", s, ", false) returns false."));
   edges.clear();
 
   if (TransitGraph::IsTransitSegment(s))
   {
     if (TransitCrossMwmSectionExists(s.GetMwmId()))
-      m_crossMwmTransitGraph.GetEdgeList(s, isOutgoing, edges);
+      m_crossMwmTransitGraph.GetOutgoingEdgeList(s, edges);
     return;
   }
 
-  return CrossMwmSectionExists(s.GetMwmId()) ? m_crossMwmIndexGraph.GetEdgeList(s, isOutgoing, edges)
-                                             : m_crossMwmOsrmGraph.GetEdgeList(s, isOutgoing, edges);
+  return CrossMwmSectionExists(s.GetMwmId())
+             ? m_crossMwmIndexGraph.GetOutgoingEdgeList(s, edges)
+             : m_crossMwmOsrmGraph.GetEdgeList(s, true /* isOutgoing */, edges);
 }
 
 void CrossMwmGraph::Clear()

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -80,16 +80,13 @@ public:
   /// If not, |twins| could be emply after a GetTwins(...) call.
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins);
 
-  /// \brief Fills |edges| with edges outgoing from |s| (ingoing to |s|).
-  /// If |isOutgoing| == true then |s| should be an enter transition segment.
-  /// In that case |edges| is filled with all edges starting from |s| and ending at all reachable
-  /// exit transition segments of the mwm of |s|.
-  /// If |isOutgoing| == false then |s| should be an exit transition segment.
-  /// In that case |edges| is filled with all edges starting from all reachable
-  /// enter transition segments of the mwm of |s| and ending at |s|.
-  /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|
-  /// if |isOutgoing| == true and from |SegmentEdge::m_target| to |s| otherwise.
-  void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  /// \brief Fills |edges| with edges outgoing from |s|.
+  /// |s| should be an enter transition segment, |edges| is filled with all edges starting from |s|
+  /// and ending at all reachable exit transition segments of the mwm of |s|.
+  /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|.
+  /// Getting ingoing edges is not supported because we do not have enough information
+  /// to calculate |segment| weight.
+  void GetOutgoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges);
 
   void Clear();
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -114,10 +114,10 @@ public:
     }
   }
 
-  void GetEdgeList(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges)
+  void GetOutgoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges)
   {
     CrossMwmConnector<CrossMwmId> const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
-    c.GetEdgeList(s, isOutgoing, edges);
+    c.GetOutgoingEdgeList(s, edges);
   }
 
   void Clear() { m_connectors.clear(); }

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -53,6 +53,7 @@ public:
   void Append(FakeEdgesContainer const & container);
 
   WorldGraph & GetGraph() const { return m_graph; }
+  WorldGraph::Mode GetMode() const { return m_graph.GetMode(); }
   Junction const & GetStartJunction() const;
   Junction const & GetFinishJunction() const;
   Segment GetStartSegment() const { return GetFakeSegment(m_start.m_id); }
@@ -100,20 +101,12 @@ public:
   RouteWeight CalcSegmentWeight(Segment const & segment) const;
   RouteWeight CalcRouteSegmentWeight(std::vector<Segment> const & route, size_t segmentIndex) const;
 
-  bool IsLeap(Segment const & segment) const;
-
 private:
-  enum class SegmentLocation
-  {
-    StartFinishMwm,  // Segment is located in the same mwm with start and finish of the route.
-    StartMwm,        // Segment is located in the same mwm with start but not finish of the route.
-    FinishMwm,       // Segment is located in the same mwm with finish but not start of the route.
-    OtherMwm,        // Neither start nor finish are located in the segment's mwm.
-  };
-
   // Start or finish ending information. 
   struct Ending
   {
+    bool OverlapsWithMwm(NumMwmId mwmId) const;
+
     // Fake segment id.
     uint32_t m_id = 0;
     // Real segments connected to the ending.
@@ -146,9 +139,6 @@ private:
   // Adds fake edges of type PartOfReal which correspond real edges from |edges| and are connected
   // to |segment|
   void AddFakeEdges(Segment const & segment, vector<SegmentEdge> & edges) const;
-  // Adds real edges from m_graph
-  void AddRealEdges(Segment const & segment, bool isOutgoing,
-                    std::vector<SegmentEdge> & edges) const;
 
   // Checks whether ending belongs to pass-through or non-pass-through zone.
   bool EndingPassThroughAllowed(Ending const & ending);
@@ -156,9 +146,6 @@ private:
   bool StartPassThroughAllowed();
   // Finish segment is located in a pass-through/non-pass-through area.
   bool FinishPassThroughAllowed();
-
-  std::set<NumMwmId> GetEndingMwms(Ending const & ending) const;
-  SegmentLocation GetSegmentLocation(Segment const & segment) const;
 
   static uint32_t constexpr kFakeFeatureId = FakeFeatureIds::kIndexGraphStarterId;
   WorldGraph & m_graph;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -136,18 +136,13 @@ IRouter::ResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result)
 
 template <typename Graph>
 IRouter::ResultCode FindPath(
-    typename Graph::Vertex const & start, typename Graph::Vertex const & finish,
-    RouterDelegate const & delegate, Graph & graph,
-    typename AStarAlgorithm<Graph>::OnVisitedVertexCallback const & onVisitedVertexCallback,
-    typename AStarAlgorithm<Graph>::CheckLengthCallback const & checkLengthCallback,
+    typename AStarAlgorithm<Graph>::Params & params,
     RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult)
 {
   AStarAlgorithm<Graph> algorithm;
-  auto findPath = mem_fn(graph.GetMode() == WorldGraph::Mode::LeapsOnly
-                             ? &AStarAlgorithm<Graph>::FindPath
-                             : &AStarAlgorithm<Graph>::FindPathBidirectional);
-  return ConvertResult<Graph>(findPath(algorithm, graph, start, finish, routingResult, delegate,
-                                       onVisitedVertexCallback, checkLengthCallback));
+  if (params.m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
+    return ConvertResult<Graph>(algorithm.FindPath(params, routingResult));
+  return ConvertResult<Graph>(algorithm.FindPathBidirectional(params, routingResult));
 }
 
 bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph)
@@ -564,11 +559,14 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
     delegate.OnPointCheck(pointFrom);
   };
 
+  auto checkLength = [&starter](RouteWeight const & weight) { return starter.CheckLength(weight); };
+
   RoutingResult<Segment, RouteWeight> routingResult;
-  IRouter::ResultCode const result = FindPath(
-      starter.GetStartSegment(), starter.GetFinishSegment(), delegate, starter, onVisitJunction,
-      [&starter](RouteWeight const & weight) { return starter.CheckLength(weight); },
-      routingResult);
+
+  AStarAlgorithm<IndexGraphStarter>::Params params(starter, starter.GetStartSegment(),
+                                                   starter.GetFinishSegment(), {} /* prevRoute */,
+                                                   delegate, onVisitJunction, checkLength);
+  IRouter::ResultCode const result = FindPath<IndexGraphStarter>(params, routingResult);
   if (result != IRouter::NoError)
     return result;
 
@@ -642,10 +640,11 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   };
 
   AStarAlgorithm<IndexGraphStarter> algorithm;
+  AStarAlgorithm<IndexGraphStarter>::Params params(starter, starter.GetStartSegment(),
+                                                   {} /* finalVertex */, prevEdges, delegate,
+                                                   onVisitJunction, checkLength);
   RoutingResult<Segment, RouteWeight> result;
-  auto resultCode = ConvertResult<IndexGraphStarter>(
-      algorithm.AdjustRoute(starter, starter.GetStartSegment(), prevEdges, result, delegate,
-                            onVisitJunction, checkLength));
+  auto const resultCode = ConvertResult<IndexGraphStarter>(algorithm.AdjustRoute(params, result));
   if (resultCode != IRouter::NoError)
     return resultCode;
 
@@ -779,6 +778,10 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
     CHECK_LESS(i, input.size(), ());
     auto const & next = input[i];
 
+    auto checkLength = [&starter](RouteWeight const & weight) {
+      return starter.CheckLength(weight);
+    };
+
     IRouter::ResultCode result = IRouter::InternalError;
     RoutingResult<Segment, RouteWeight> routingResult;
     if (i == 1 || i + 1 == input.size())
@@ -787,10 +790,10 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       // In case of leaps from the start to its mwm transition and from finish to mwm transition
       // route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
       worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
-      result =
-          FindPath(current, next, delegate, starter, {} /* onVisitedVertexCallback */,
-                   [&starter](RouteWeight const & weight) { return starter.CheckLength(weight); },
-                   routingResult);
+      AStarAlgorithm<IndexGraphStarter>::Params params(starter, current, next, {} /* prevRoute */,
+                                                       delegate, {} /* onVisitedVertexCallback */,
+                                                       checkLength);
+      result = FindPath<IndexGraphStarter>(params, routingResult);
     }
     else
     {
@@ -804,10 +807,10 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
       // It's not start-to-mwm-exit leap, we already have its first segment in previous mwm.
       dropFirstSegment = true;
-      result =
-          FindPath(current, next, delegate, worldGraph, {} /* onVisitedVertexCallback */,
-                   [&starter](RouteWeight const & weight) { return starter.CheckLength(weight); },
-                   routingResult);
+      AStarAlgorithm<WorldGraph>::Params params(worldGraph, current, next, {} /* prevRoute */,
+                                                delegate, {} /* onVisitedVertexCallback */,
+                                                checkLength);
+      result = FindPath<WorldGraph>(params, routingResult);
     }
 
     if (result != IRouter::NoError)

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -143,8 +143,11 @@ IRouter::ResultCode FindPath(
     RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult)
 {
   AStarAlgorithm<Graph> algorithm;
-  return ConvertResult<Graph>(algorithm.FindPathBidirectional(
-      graph, start, finish, routingResult, delegate, onVisitedVertexCallback, checkLengthCallback));
+  auto findPath = mem_fn(graph.GetMode() == WorldGraph::Mode::LeapsOnly
+                             ? &AStarAlgorithm<Graph>::FindPath
+                             : &AStarAlgorithm<Graph>::FindPathBidirectional);
+  return ConvertResult<Graph>(findPath(algorithm, graph, start, finish, routingResult, delegate,
+                                       onVisitedVertexCallback, checkLengthCallback));
 }
 
 bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph)
@@ -159,7 +162,7 @@ bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph
   // If |isOutgoing| == false it's the finish. So ingoing edges are looked for.
   auto const getOutgoingEdgesFn = [isOutgoing](WorldGraph & graph, Segment const & u,
                                                vector<SegmentEdge> & edges) {
-    graph.GetEdgeList(u, isOutgoing, false /* isLeap */, edges);
+    graph.GetEdgeList(u, isOutgoing, edges);
   };
 
   return !CheckGraphConnectivity(segment, kDeadEndTestLimit, worldGraph,
@@ -527,7 +530,7 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
       starter.GetGraph().SetMode(WorldGraph::Mode::NoLeaps);
       break;
     case VehicleType::Car:
-      starter.GetGraph().SetMode(AreMwmsNear(starter.GetMwms()) ? WorldGraph::Mode::LeapsIfPossible
+      starter.GetGraph().SetMode(AreMwmsNear(starter.GetMwms()) ? WorldGraph::Mode::NoLeaps
                                                                 : WorldGraph::Mode::LeapsOnly);
       break;
     case VehicleType::Count:
@@ -752,15 +755,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
   output.reserve(input.size());
 
   auto const isNotLeap = [&](Segment const & s) {
-    return prevMode != WorldGraph::Mode::LeapsOnly && !starter.IsLeap(s);
-  };
-
-  auto const isEndingToExitLeap = [&](Segment const & s) {
-    return prevMode == WorldGraph::Mode::LeapsOnly && !starter.IsLeap(s);
-  };
-
-  auto const sameMwm = [](NumMwmId prev, NumMwmId current) {
-    return prev == current || prev == kFakeNumMwmId || current == kFakeNumMwmId;
+    return prevMode != WorldGraph::Mode::LeapsOnly;
   };
 
   WorldGraph & worldGraph = starter.GetGraph();
@@ -768,22 +763,14 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
   // For all leaps except the first leap which connects start to mwm exit in LeapsOnly mode we need
   // to drop first segment of the leap because we already have its twin from the previous mwm.
   bool dropFirstSegment = false;
-  NumMwmId prevMwmId = kFakeNumMwmId;
   for (size_t i = 0; i < input.size(); ++i)
   {
     auto const & current = input[i];
-    auto const currentMwmId = current.GetMwmId();
-
     if (isNotLeap(current))
     {
-      // Otherwise current is a twin of the previous segment and should be skipped.
-      if (sameMwm(prevMwmId, currentMwmId))
-        output.push_back(current);
-      prevMwmId = currentMwmId;
+      output.push_back(current);
       continue;
     }
-
-    prevMwmId = currentMwmId;
 
     // Clear previous loaded graphs to not spend too much memory at one time.
     worldGraph.ClearCachedGraphs();
@@ -794,8 +781,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
 
     IRouter::ResultCode result = IRouter::InternalError;
     RoutingResult<Segment, RouteWeight> routingResult;
-    if (isEndingToExitLeap(current))
+    if (i == 1 || i + 1 == input.size())
     {
+      // First start-to-mwm-exit and last mwm-enter-to-finish leaps need special processing.
       // In case of leaps from the start to its mwm transition and from finish to mwm transition
       // route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
       worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
@@ -812,7 +800,6 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
         current.GetMwmId(), next.GetMwmId(),
         ("Different mwm ids for leap enter and exit, i:", i, "size of input:", input.size()));
 
-      CHECK(starter.IsLeap(current), ());
       // Single mwm route.
       worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
       // It's not start-to-mwm-exit leap, we already have its first segment in previous mwm.

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -157,8 +157,9 @@ IRoutingAlgorithm::Result AStarRoutingAlgorithm::CalculateRoute(IRoadGraph const
   my::Cancellable const & cancellable = delegate;
   progress.Initialize(startPos.GetPoint(), finalPos.GetPoint());
   RoadGraph roadGraph(graph);
-  TAlgorithmImpl::Result const res = TAlgorithmImpl().FindPath(
-      roadGraph, startPos, finalPos, path, cancellable, onVisitJunctionFn);
+  TAlgorithmImpl::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */, cancellable,
+                                onVisitJunctionFn, {} /* checkLength */);
+  TAlgorithmImpl::Result const res = TAlgorithmImpl().FindPath(params, path);
   return Convert(res);
 }
 
@@ -186,8 +187,9 @@ IRoutingAlgorithm::Result AStarBidirectionalRoutingAlgorithm::CalculateRoute(
   my::Cancellable const & cancellable = delegate;
   progress.Initialize(startPos.GetPoint(), finalPos.GetPoint());
   RoadGraph roadGraph(graph);
-  TAlgorithmImpl::Result const res = TAlgorithmImpl().FindPathBidirectional(
-      roadGraph, startPos, finalPos, path, cancellable, onVisitJunctionFn);
+  TAlgorithmImpl::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */, cancellable,
+                                onVisitJunctionFn, {} /* checkLength */);
+  TAlgorithmImpl::Result const res = TAlgorithmImpl().FindPathBidirectional(params, path);
   return Convert(res);
 }
 

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -206,6 +206,22 @@ namespace
         MercatorBounds::FromLatLon(55.7718, 37.5178), 147.4);
   }
 
+  UNIT_TEST(RussiaMoscowRegionToBelarusBorder)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.464182, 35.943947), {0.0, 0.0},
+        MercatorBounds::FromLatLon(52.442467, 31.609642), 554000.);
+  }
+
+  UNIT_TEST(GermanyToTallinCrossMwmRoute)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(48.397416, 16.515289), {0.0, 0.0},
+        MercatorBounds::FromLatLon(59.437214, 24.745355), 1650000.);
+  }
+  
   // Strange map edits in Africa borders. Routing not linked now.
   /*
   UNIT_TEST(RussiaMoscowLenigradskiy39RepublicOfSouthAfricaCapeTownCenterRouteTest)

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -38,11 +38,11 @@ void TestConnectorConsistency(CrossMwmConnector<CrossMwmId> const & connector)
 }
 
 template <typename CrossMwmId>
-void TestEdges(CrossMwmConnector<CrossMwmId> const & connector, Segment const & from, bool isOutgoing,
-               vector<SegmentEdge> const & expectedEdges)
+void TestOutgoingEdges(CrossMwmConnector<CrossMwmId> const & connector, Segment const & from,
+                       vector<SegmentEdge> const & expectedEdges)
 {
   vector<SegmentEdge> edges;
-  connector.GetEdgeList(from, isOutgoing, edges);
+  connector.GetOutgoingEdgeList(from, edges);
   TEST_EQUAL(edges, expectedEdges, ());
 }
 
@@ -233,18 +233,13 @@ void TestSerialization(vector<CrossMwmConnectorSerializer::Transition<CrossMwmId
       m2::PointD(2.3, 2.4), eps),
        ());
 
-  TestEdges(connector, Segment(mwmId, 10, 1, true /* forward */), true /* isOutgoing */,
-            {{Segment(mwmId, 20, 2, false /* forward */),
-              RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
+  TestOutgoingEdges(connector, Segment(mwmId, 10, 1, true /* forward */),
+                    {{Segment(mwmId, 20, 2, false /* forward */),
+                      RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 
-  TestEdges(connector, Segment(mwmId, 20, 2, true /* forward */), true /* isOutgoing */,
-            {{Segment(mwmId, 20, 2, false /* forward */),
-              RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
-
-  TestEdges(
-      connector, Segment(mwmId, 20, 2, false /* forward */), false /* isOutgoing */,
-      {{Segment(mwmId, 10, 1, true /* forward */), RouteWeight::FromCrossMwmWeight(kEdgesWeight)},
-       {Segment(mwmId, 20, 2, true /* forward */), RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
+  TestOutgoingEdges(connector, Segment(mwmId, 20, 2, true /* forward */),
+                    {{Segment(mwmId, 20, 2, false /* forward */),
+                      RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 }
 
 void GetCrossMwmId(uint32_t i, osm::Id & id) { id = osm::Id(10 * i); }
@@ -327,7 +322,7 @@ void TestWeightsSerialization()
       ++weightIdx;
     }
 
-    TestEdges(connector, enter, true /* isOutgoing */, expectedEdges);
+    TestOutgoingEdges(connector, enter, expectedEdges);
   }
 }
 }  // namespace

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -172,18 +172,16 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
 
   AStarAlgorithm<WorldGraph> algorithm;
 
-  RoutingResult<Segment, RouteWeight> routingResult;
-  auto const resultCode = algorithm.FindPathBidirectional(
-      *worldGraph, startSegment, finishSegment, routingResult, {} /* cancellable */,
+  AStarAlgorithm<WorldGraph>::Params params(
+      *worldGraph, startSegment, finishSegment, {} /* prevRoute */, {} /* cancellable */,
       {} /* onVisitedVertexCallback */, {} /* checkLengthCallback */);
+  RoutingResult<Segment, RouteWeight> routingResult;
+  auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 
   // Check unidirectional AStar returns same result.
   {
     RoutingResult<Segment, RouteWeight> unidirectionalRoutingResult;
-    auto const unidirectionalResultCode = algorithm.FindPath(
-        *worldGraph, startSegment, finishSegment, unidirectionalRoutingResult, {} /* cancellable */,
-        {} /* onVisitedVertexCallback */, {} /* checkLengthCallback */);
-
+    auto const unidirectionalResultCode = algorithm.FindPath(params, unidirectionalRoutingResult);
     CHECK_EQUAL(resultCode, unidirectionalResultCode, ());
     CHECK(routingResult.m_distance.IsAlmostEqualForTests(unidirectionalRoutingResult.m_distance,
                                                          kEpsilon),
@@ -366,10 +364,12 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
   AStarAlgorithm<IndexGraphStarter> algorithm;
   RoutingResult<Segment, RouteWeight> routingResult;
 
-  auto resultCode = algorithm.FindPathBidirectional(
-      starter, starter.GetStartSegment(), starter.GetFinishSegment(), routingResult,
+  AStarAlgorithm<IndexGraphStarter>::Params params(
+      starter, starter.GetStartSegment(), starter.GetFinishSegment(), {} /* prevRoute */,
       {} /* cancellable */, {} /* onVisitedVertexCallback */,
       [&](RouteWeight const & weight) { return starter.CheckLength(weight); });
+
+  auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 
   timeSec = routingResult.m_distance.GetWeight();
   roadPoints = routingResult.m_path;

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -27,7 +27,9 @@ public:
                           std::shared_ptr<EdgeEstimator> estimator);
 
   // WorldGraph overrides:
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+  ~SingleVehicleWorldGraph() override = default;
+
+  void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) override;
   bool CheckLength(RouteWeight const &, double) const override { return true; }
   Junction const & GetJunction(Segment const & segment, bool front) override;
@@ -55,13 +57,14 @@ public:
   }
 
 private:
+  // WorldGraph overrides:
+  void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
+
   RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
-  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;
-  std::vector<Segment> m_twins;
   Mode m_mode = Mode::NoLeaps;
 };
 }  // namespace routing

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -30,7 +30,9 @@ public:
                     std::shared_ptr<EdgeEstimator> estimator);
 
   // WorldGraph overrides:
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+  ~TransitWorldGraph() override = default;
+
+  void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) override;
   bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const override
   {
@@ -58,6 +60,9 @@ public:
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
 private:
+  // WorldGraph overrides:
+  void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
+
   static double MaxPedestrianTimeSec(double startToFinishDistanceM)
   {
     // @todo(tatiana-kondakova) test and adjust constants.
@@ -67,7 +72,6 @@ private:
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
-  void GetTwins(Segment const & s, bool isOutgoing, std::vector<SegmentEdge> & edges);
   IndexGraph & GetIndexGraph(NumMwmId mwmId);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
@@ -75,7 +79,6 @@ private:
   std::unique_ptr<IndexGraphLoader> m_indexLoader;
   std::unique_ptr<TransitGraphLoader> m_transitLoader;
   std::shared_ptr<EdgeEstimator> m_estimator;
-  std::vector<Segment> m_twins;
   Mode m_mode = Mode::NoLeaps;
   std::vector<Segment> const kEmptyTransitions = {};
 };

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,12 +4,45 @@ namespace routing
 {
 using namespace std;
 
+void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
+{
+  vector<Segment> twins;
+  GetTwinsInner(segment, isOutgoing, twins);
+
+  if (GetMode() == Mode::LeapsOnly)
+  {
+    // Ingoing edges listing is not supported in LeapsOnly mode because we do not have enough
+    // information to calculate |segment| weight. See https://jira.mail.ru/browse/MAPSME-5743 for details.
+    CHECK(isOutgoing, ("Ingoing edges listing is not supported in LeapsOnly mode."));
+    // We need both enter to mwm and exit from mwm in LeapsOnly mode to reconstruct leap.
+    // That's why we need to duplicate twin segment here and than remove duplicate
+    // while processing leaps.
+    for (Segment const & twin : twins)
+    {
+      m2::PointD const & from = GetPoint(segment, isOutgoing /* front */);
+      m2::PointD const & to = GetPoint(twin, isOutgoing /* front */);
+      // Weight is usually zero because twins correspond the same feature
+      // in different mwms. But if we have mwms with different versions and a feature
+      // was moved in one of them the weight is greater than zero.
+      edges.emplace_back(twin, HeuristicCostEstimate(from, to));
+    }
+    return;
+  }
+
+  auto prevMode = GetMode();
+  SetMode(Mode::SingleMwm);
+
+  for (Segment const & twin : twins)
+    GetEdgeList(twin, isOutgoing, edges);
+
+  SetMode(prevMode);
+}
+
 string DebugPrint(WorldGraph::Mode mode)
 {
   switch (mode)
   {
   case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
-  case WorldGraph::Mode::LeapsIfPossible: return "LeapsIfPossible";
   case WorldGraph::Mode::NoLeaps: return "NoLeaps";
   case WorldGraph::Mode::SingleMwm: return "SingleMwm";
   }

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -29,9 +29,6 @@ public:
     LeapsOnly,  // Mode for building a cross mwm route containing only leaps. In case of start and
                 // finish they (start and finish) will be connected with all transition segments of
                 // their mwm with leap (fake) edges.
-    LeapsIfPossible,  // Mode for building cross mwm and single mwm routes. In case of cross mwm route
-                      // if they are neighboring mwms the route will be made without leaps.
-                      // If not the route is made with leaps for intermediate mwms.
     NoLeaps,    // Mode for building route and getting outgoing/ingoing edges without leaps at all.
     SingleMwm,  // Mode for building route and getting outgoing/ingoing edges within mwm source
                 // segment belongs to.
@@ -39,7 +36,7 @@ public:
 
   virtual ~WorldGraph() = default;
 
-  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool isLeap,
+  virtual void GetEdgeList(Segment const & segment, bool isOutgoing,
                            std::vector<SegmentEdge> & edges) = 0;
 
   // Checks whether path length meets restrictions. Restrictions may depend on the distance from
@@ -74,6 +71,11 @@ public:
 
   /// \returns transit-specific information for segment. For nontransit segments returns nullptr.
   virtual std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) = 0;
+
+protected:
+  void GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  virtual void GetTwinsInner(Segment const & segment, bool isOutgoing,
+                             std::vector<Segment> & twins) = 0;
 };
 
 std::string DebugPrint(WorldGraph::Mode mode);


### PR DESCRIPTION
Починка крешей в AStar при cross-mwm:
- в LeapsOnly используем только однонаправленный AStar;
- в GetTwins для LeapsOnly всё остается как было (нужны дублирующиеся сегменты -- и вход и выход из каждой mwm и при однонаправленном AStar проблем нет);
- в GetTwins для остальных режимов не добавляем дубликатов (иначе в обратной волне неоткуда будет брать вес на следующем за GetTwins шаге), вместо этого список входящих/исходящих для сегмента добавляем входящие/исходящие для его близнецов.

Прошлась по крешам из fabric, с теми что я посмотрела теперь всё ок. Добавила два случая в тесты:
- финиш на стыке mwm, который раньше падал на проверке эвристики в результате неправильной работы GetTwins в обратной волне;
- маршрут из Германии в Таллин, который падал на проверке эвристики из-за неправильной работы в LeapsOnly в обратной волне.