### PR TITLE
[transit] Removing unused kTransitAverageSpeedMPS.

### DIFF
--- a/transit/transit_speed_limits.hpp
+++ b/transit/transit_speed_limits.hpp
@@ -5,9 +5,5 @@ namespace routing
 namespace transit
 {
 double constexpr kTransitMaxSpeedKMpH = 400.0;
-// @TODO(bykoianko, Zverik) Edge and gate weights should be always valid. This weights should come
-// from transit graph json. But now it's not so. |kTransitAverageSpeedMPS| should be used now only for
-// weight calculating at transit section generation stage and the constant should be removed later.
-double constexpr kTransitAverageSpeedMPS = 11.0;
 }  // namespace transit
 }  // namespace routing


### PR DESCRIPTION
Удалил из проекта не используемую среднюю скорость на дуге общественного транспорта. Данный скорости должны поступать из графа в transit.json формате.

@tatiana-kondakova @Zverik PTAL