### PR TITLE
CreateCountyInfoReader() function refactoring and generator fix.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -301,7 +301,7 @@ TCountryId Framework::PreMigrate(ms::LatLon const & position,
   GetStorage().PrefetchMigrateData();
 
   auto const infoGetter =
-      CountryInfoReader::CreateCountryInfoReaderOneComponentMwms(GetPlatform());
+      CountryInfoReader::CreateCountryInfoReader(GetPlatform());
 
   TCountryId currentCountryId =
       infoGetter->GetRegionCountryId(MercatorBounds::FromLatLon(position));
@@ -1354,7 +1354,11 @@ void Framework::InitCountryInfoGetter()
 {
   ASSERT(!m_infoGetter.get(), ("InitCountryInfoGetter() must be called only once."));
 
-  m_infoGetter = CountryInfoReader::CreateCountryInfoReader(GetPlatform());
+  auto const & platform = GetPlatform();
+  if (platform::migrate::NeedMigrate())
+    m_infoGetter = CountryInfoReader::CreateCountryInfoReaderObsolete(platform);
+  else
+    m_infoGetter = CountryInfoReader::CreateCountryInfoReader(platform);
   m_infoGetter->InitAffiliationsInfo(&m_storage.GetAffiliations());
 }
 

--- a/storage/country_info_getter.cpp
+++ b/storage/country_info_getter.cpp
@@ -212,19 +212,10 @@ void CountryInfoGetter::ForEachCountry(string const & prefix, ToDo && toDo) cons
 // static
 unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReader(Platform const & platform)
 {
-  if (platform::migrate::NeedMigrate())
-    return CreateCountryInfoReaderTwoComponentMwms(platform);
-  return CreateCountryInfoReaderOneComponentMwms(platform);
-}
-
-// static
-unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReaderTwoComponentMwms(
-    Platform const & platform)
-{
   try
   {
-    CountryInfoReader * result = new CountryInfoReader(platform.GetReader(PACKED_POLYGONS_OBSOLETE_FILE),
-                                                       platform.GetReader(COUNTRIES_OBSOLETE_FILE));
+    CountryInfoReader * result = new CountryInfoReader(platform.GetReader(PACKED_POLYGONS_FILE),
+                                                       platform.GetReader(COUNTRIES_FILE));
     return unique_ptr<CountryInfoReader>(result);
   }
   catch (RootException const & e)
@@ -235,14 +226,13 @@ unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReaderTwoCompo
 }
 
 // static
-unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReaderOneComponentMwms(
+unique_ptr<CountryInfoGetter> CountryInfoReader::CreateCountryInfoReaderObsolete(
     Platform const & platform)
 {
   try
   {
-    CountryInfoReader * result =
-        new CountryInfoReader(platform.GetReader(PACKED_POLYGONS_FILE),
-                              platform.GetReader(COUNTRIES_FILE));
+    CountryInfoReader * result = new CountryInfoReader(platform.GetReader(PACKED_POLYGONS_OBSOLETE_FILE),
+                                                       platform.GetReader(COUNTRIES_OBSOLETE_FILE));
     return unique_ptr<CountryInfoReader>(result);
   }
   catch (RootException const & e)

--- a/storage/country_info_getter.hpp
+++ b/storage/country_info_getter.hpp
@@ -130,13 +130,13 @@ protected:
 class CountryInfoReader : public CountryInfoGetter
 {
 public:
-  /// \brief The newer version. Use this one after the migration to single-component
-  /// mwm files has been carried out.
+  /// \returns CountryInfoGetter based on countries.txt and packed_polygons.bin.
   static unique_ptr<CountryInfoGetter> CreateCountryInfoReader(Platform const & platform);
 
-  /// \brief The older version. The polygons are read from a file that was
-  /// used at the time when routing and map data were in different files.
-  /// \note This method should be used for test on migration.
+  /// \returns CountryInfoGetter based on countries_obsolete.txt and packed_polygons_obsolete.bin.
+  /// \brief The polygons in CountryInfoGetter() returned by the method was used at the time when
+  /// routing and map data were in different files.
+  /// \note This method should be used before migration to single-component and for tests.
   static unique_ptr<CountryInfoGetter> CreateCountryInfoReaderObsolete(Platform const & platform);
 
 protected:

--- a/storage/country_info_getter.hpp
+++ b/storage/country_info_getter.hpp
@@ -130,21 +130,14 @@ protected:
 class CountryInfoReader : public CountryInfoGetter
 {
 public:
-  // This is the proper way to obtain a CountryInfoReader because
-  // it accounts for migration and such.
+  /// \brief The newer version. Use this one after the migration to single-component
+  /// mwm files has been carried out.
   static unique_ptr<CountryInfoGetter> CreateCountryInfoReader(Platform const & platform);
 
-  // The older version. The polygons are read from a file that was
-  // used at the time when routing and map data were in different files.
-  // This is a legacy method and it is extremely unlikely that you need it in your code.
-  static unique_ptr<CountryInfoGetter> CreateCountryInfoReaderTwoComponentMwms(
-      Platform const & platform);
-
-  // The newer version. Use this one after the migration to single-component
-  // mwm files has been carried out.
-  // This is a legacy method and it is extremely unlikely that you need it in your code.
-  static unique_ptr<CountryInfoGetter> CreateCountryInfoReaderOneComponentMwms(
-      Platform const & platform);
+  /// \brief The older version. The polygons are read from a file that was
+  /// used at the time when routing and map data were in different files.
+  /// \note This method should be used for test on migration.
+  static unique_ptr<CountryInfoGetter> CreateCountryInfoReaderObsolete(Platform const & platform);
 
 protected:
   CountryInfoReader(ModelReaderPtr polyR, ModelReaderPtr countryR);

--- a/storage/storage_tests/helpers.cpp
+++ b/storage/storage_tests/helpers.cpp
@@ -10,12 +10,12 @@ namespace storage
 {
 unique_ptr<CountryInfoGetter> CreateCountryInfoGetter()
 {
-  return CountryInfoReader::CreateCountryInfoReaderTwoComponentMwms(GetPlatform());
+  return CountryInfoReader::CreateCountryInfoReaderObsolete(GetPlatform());
 }
 
 unique_ptr<storage::CountryInfoGetter> CreateCountryInfoGetterMigrate()
 {
-  return CountryInfoReader::CreateCountryInfoReaderOneComponentMwms(GetPlatform());
+  return CountryInfoReader::CreateCountryInfoReader(GetPlatform());
 }
 
 bool AlmostEqualRectsAbs(const m2::RectD & r1, const m2::RectD & r2)


### PR DESCRIPTION
В нашем проекте CountryInfoGetter создается при помощи CountryInfoReader::CreateCountryInfoReader() метода. Для работы данного метода необходимо обратиться к settings.ini, чтоб понять, произошла ли миграция. Не хорошо, что базовый метод требует наличия вспомогательного файла. Это не удобно, например, в генераторе.

В то время, как почти всегда (кроме как во framework) требуется создавать CountryInfoGetter на базе нового разбиения mwm.

Данный PR:
1. переименовывает методы: 
CreateCountryInfoReaderOneComponentMwms()->CreateCountryInfoReader()
CreateCountryInfoReaderTwoComponentMwms()->CreateCountryInfoReaderObsolete()

2. переносит выбор вызова правильного метода из методов выше во framework

3. Удаляет старый метод: CreateCountryInfoReader().

Данный PR сделан по следам обсуждения в: https://github.com/mapsme/omim/pull/7755

@ygorshenin @VladiMihaylenko PTAL