### PR TITLE
[routing] Add access component to RouteWeight

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -123,12 +123,12 @@ set<NumMwmId> IndexGraphStarter::GetMwms() const
 
 bool IndexGraphStarter::CheckLength(RouteWeight const & weight)
 {
-  // We allow 1 pass-through/non-pass-through crossing per ending located in
+  // We allow 1 pass-through/non-pass-through zone changes per ending located in
   // non-pass-through zone to allow user to leave this zone.
-  int32_t const nonPassThroughCrossAllowed =
+  int32_t const numPassThroughChangesAllowed =
       (StartPassThroughAllowed() ? 0 : 1) + (FinishPassThroughAllowed() ? 0 : 1);
 
-  return weight.GetNonPassThroughCross() <= nonPassThroughCrossAllowed &&
+  return weight.GetNumPassThroughChanges() <= numPassThroughChangesAllowed &&
          m_graph.CheckLength(weight, m_startToFinishDistanceM);
 }
 

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -125,7 +125,7 @@ bool IndexGraphStarter::CheckLength(RouteWeight const & weight)
 {
   // We allow 1 pass-through/non-pass-through crossing per ending located in
   // non-pass-through zone to allow user to leave this zone.
-  int const nonPassThroughCrossAllowed =
+  int32_t const nonPassThroughCrossAllowed =
       (StartPassThroughAllowed() ? 0 : 1) + (FinishPassThroughAllowed() ? 0 : 1);
 
   return weight.GetNonPassThroughCross() <= nonPassThroughCrossAllowed &&

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -24,43 +24,43 @@ namespace routing
 {
 double RouteWeight::ToCrossMwmWeight() const
 {
-  if (m_nonPassThroughCross > 0 || m_numAccessChanges > 0)
+  if (m_numPassThroughChanges > 0 || m_numAccessChanges > 0)
     return connector::kNoRoute;
   return GetWeight();
 }
 
 RouteWeight RouteWeight::operator+(RouteWeight const & rhs) const
 {
-  ASSERT(!SumWillOverflow(m_nonPassThroughCross, rhs.m_nonPassThroughCross),
-         (m_nonPassThroughCross, rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numPassThroughChanges, rhs.m_numPassThroughChanges),
+         (m_numPassThroughChanges, rhs.m_numPassThroughChanges));
   ASSERT(!SumWillOverflow(m_numAccessChanges, rhs.m_numAccessChanges),
          (m_numAccessChanges, rhs.m_numAccessChanges));
-  return RouteWeight(m_weight + rhs.m_weight, m_nonPassThroughCross + rhs.m_nonPassThroughCross,
+  return RouteWeight(m_weight + rhs.m_weight, m_numPassThroughChanges + rhs.m_numPassThroughChanges,
                      m_numAccessChanges + rhs.m_numAccessChanges,
                      m_transitTime + rhs.m_transitTime);
 }
 
 RouteWeight RouteWeight::operator-(RouteWeight const & rhs) const
 {
-  ASSERT_NOT_EQUAL(m_nonPassThroughCross, std::numeric_limits<int32_t>::min(), ());
+  ASSERT_NOT_EQUAL(m_numPassThroughChanges, std::numeric_limits<int32_t>::min(), ());
   ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int32_t>::min(), ());
-  ASSERT(!SumWillOverflow(m_nonPassThroughCross, -rhs.m_nonPassThroughCross),
-         (m_nonPassThroughCross, -rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numPassThroughChanges, -rhs.m_numPassThroughChanges),
+         (m_numPassThroughChanges, -rhs.m_numPassThroughChanges));
   ASSERT(!SumWillOverflow(m_numAccessChanges, -rhs.m_numAccessChanges),
          (m_numAccessChanges, -rhs.m_numAccessChanges));
-  return RouteWeight(m_weight - rhs.m_weight, m_nonPassThroughCross - rhs.m_nonPassThroughCross,
+  return RouteWeight(m_weight - rhs.m_weight, m_numPassThroughChanges - rhs.m_numPassThroughChanges,
                      m_numAccessChanges - rhs.m_numAccessChanges,
                      m_transitTime - rhs.m_transitTime);
 }
 
 RouteWeight & RouteWeight::operator+=(RouteWeight const & rhs)
 {
-  ASSERT(!SumWillOverflow(m_nonPassThroughCross, rhs.m_nonPassThroughCross),
-         (m_nonPassThroughCross, rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numPassThroughChanges, rhs.m_numPassThroughChanges),
+         (m_numPassThroughChanges, rhs.m_numPassThroughChanges));
   ASSERT(!SumWillOverflow(m_numAccessChanges, rhs.m_numAccessChanges),
          (m_numAccessChanges, rhs.m_numAccessChanges));
   m_weight += rhs.m_weight;
-  m_nonPassThroughCross += rhs.m_nonPassThroughCross;
+  m_numPassThroughChanges += rhs.m_numPassThroughChanges;
   m_numAccessChanges += rhs.m_numAccessChanges;
   m_transitTime += rhs.m_transitTime;
   return *this;
@@ -68,14 +68,14 @@ RouteWeight & RouteWeight::operator+=(RouteWeight const & rhs)
 
 ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
 {
-  os << "(" << routeWeight.GetNonPassThroughCross() << ", " << routeWeight.GetNumAccessChanges()
+  os << "(" << routeWeight.GetNumPassThroughChanges() << ", " << routeWeight.GetNumAccessChanges()
      << ", " << routeWeight.GetWeight() << ", " << routeWeight.GetTransitTime() << ")";
   return os;
 }
 
 RouteWeight operator*(double lhs, RouteWeight const & rhs)
 {
-  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNonPassThroughCross(), rhs.GetNumAccessChanges(),
-                     lhs * rhs.GetTransitTime());
+  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNumPassThroughChanges(),
+                     rhs.GetNumAccessChanges(), lhs * rhs.GetTransitTime());
 }
 }  // namespace routing

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -2,27 +2,80 @@
 
 #include "routing/cross_mwm_connector.hpp"
 
+#include <type_traits>
+
 using namespace std;
+
+namespace
+{
+template <typename Number,
+          typename EnableIf = typename enable_if<is_integral<Number>::value, void>::type>
+bool SumWillOverflow(Number lhs, Number rhs)
+{
+  if (lhs > 0)
+    return rhs > numeric_limits<Number>::max() - lhs;
+  if (lhs < 0)
+    return rhs < numeric_limits<Number>::min() - lhs;
+  return false;
+}
+}  // namespace
 
 namespace routing
 {
 double RouteWeight::ToCrossMwmWeight() const
 {
-  if (m_nonPassThroughCross > 0)
+  if (m_nonPassThroughCross > 0 || m_numAccessChanges > 0)
     return connector::kNoRoute;
   return GetWeight();
 }
 
+RouteWeight RouteWeight::operator+(RouteWeight const & rhs) const
+{
+  ASSERT(!SumWillOverflow(m_nonPassThroughCross, rhs.m_nonPassThroughCross),
+         (m_nonPassThroughCross, rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numAccessChanges, rhs.m_numAccessChanges),
+         (m_numAccessChanges, rhs.m_numAccessChanges));
+  return RouteWeight(m_weight + rhs.m_weight, m_nonPassThroughCross + rhs.m_nonPassThroughCross,
+                     m_numAccessChanges + rhs.m_numAccessChanges,
+                     m_transitTime + rhs.m_transitTime);
+}
+
+RouteWeight RouteWeight::operator-(RouteWeight const & rhs) const
+{
+  ASSERT_NOT_EQUAL(m_nonPassThroughCross, std::numeric_limits<int32_t>::min(), ());
+  ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int32_t>::min(), ());
+  ASSERT(!SumWillOverflow(m_nonPassThroughCross, -rhs.m_nonPassThroughCross),
+         (m_nonPassThroughCross, -rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numAccessChanges, -rhs.m_numAccessChanges),
+         (m_numAccessChanges, -rhs.m_numAccessChanges));
+  return RouteWeight(m_weight - rhs.m_weight, m_nonPassThroughCross - rhs.m_nonPassThroughCross,
+                     m_numAccessChanges - rhs.m_numAccessChanges,
+                     m_transitTime - rhs.m_transitTime);
+}
+
+RouteWeight & RouteWeight::operator+=(RouteWeight const & rhs)
+{
+  ASSERT(!SumWillOverflow(m_nonPassThroughCross, rhs.m_nonPassThroughCross),
+         (m_nonPassThroughCross, rhs.m_nonPassThroughCross));
+  ASSERT(!SumWillOverflow(m_numAccessChanges, rhs.m_numAccessChanges),
+         (m_numAccessChanges, rhs.m_numAccessChanges));
+  m_weight += rhs.m_weight;
+  m_nonPassThroughCross += rhs.m_nonPassThroughCross;
+  m_numAccessChanges += rhs.m_numAccessChanges;
+  m_transitTime += rhs.m_transitTime;
+  return *this;
+}
+
 ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
 {
-  os << "(" << routeWeight.GetNonPassThroughCross() << ", " << routeWeight.GetWeight() << ", "
-     << routeWeight.GetTransitTime() << ")";
+  os << "(" << routeWeight.GetNonPassThroughCross() << ", " << routeWeight.GetNumAccessChanges()
+     << ", " << routeWeight.GetWeight() << ", " << routeWeight.GetTransitTime() << ")";
   return os;
 }
 
 RouteWeight operator*(double lhs, RouteWeight const & rhs)
 {
-  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNonPassThroughCross(),
+  return RouteWeight(lhs * rhs.GetWeight(), rhs.GetNonPassThroughCross(), rhs.GetNumAccessChanges(),
                      lhs * rhs.GetTransitTime());
 }
 }  // namespace routing

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -4,6 +4,7 @@
 
 #include "base/math.hpp"
 
+#include <cstdint>
 #include <iostream>
 #include <limits>
 
@@ -16,8 +17,12 @@ public:
 
   explicit constexpr RouteWeight(double weight) : m_weight(weight) {}
 
-  constexpr RouteWeight(double weight, int nonPassThroughCross, double transitTime)
-    : m_weight(weight), m_nonPassThroughCross(nonPassThroughCross), m_transitTime(transitTime)
+  constexpr RouteWeight(double weight, int32_t nonPassThroughCross, int32_t numAccessChanges,
+                        double transitTime)
+    : m_weight(weight)
+    , m_nonPassThroughCross(nonPassThroughCross)
+    , m_numAccessChanges(numAccessChanges)
+    , m_transitTime(transitTime)
   {
   }
 
@@ -25,13 +30,22 @@ public:
 
   double ToCrossMwmWeight() const;
   double GetWeight() const { return m_weight; }
-  int GetNonPassThroughCross() const { return m_nonPassThroughCross; }
+  int32_t GetNonPassThroughCross() const { return m_nonPassThroughCross; }
+  int32_t GetNumAccessChanges() const { return m_numAccessChanges; }
   double GetTransitTime() const { return m_transitTime; }
 
   bool operator<(RouteWeight const & rhs) const
   {
     if (m_nonPassThroughCross != rhs.m_nonPassThroughCross)
       return m_nonPassThroughCross < rhs.m_nonPassThroughCross;
+    // We compare m_numAccessChanges after m_nonPassThroughCross because we can have multiple nodes
+    // with access tags on the way from the area with limited access and no access tags on the ways
+    // inside this area. So we probably need to make access restriction less strict than pass
+    // through restrictions e.g. allow to cross access={private, destination} and build the route
+    // with the least possible number of such crosses or introduce some maximal number of
+    // access={private, destination} crosses.
+    if (m_numAccessChanges != rhs.m_numAccessChanges)
+      return m_numAccessChanges < rhs.m_numAccessChanges;
     if (m_weight != rhs.m_weight)
       return m_weight < rhs.m_weight;
     // Preffer bigger transit time if total weights are same.
@@ -48,43 +62,37 @@ public:
 
   bool operator<=(RouteWeight const & rhs) const { return rhs >= (*this); }
 
-  RouteWeight operator+(RouteWeight const & rhs) const
-  {
-    return RouteWeight(m_weight + rhs.m_weight, m_nonPassThroughCross + rhs.m_nonPassThroughCross,
-                       m_transitTime + rhs.m_transitTime);
-  }
+  RouteWeight operator+(RouteWeight const & rhs) const;
 
-  RouteWeight operator-(RouteWeight const & rhs) const
-  {
-    return RouteWeight(m_weight - rhs.m_weight, m_nonPassThroughCross - rhs.m_nonPassThroughCross,
-                       m_transitTime - rhs.m_transitTime);
-  }
+  RouteWeight operator-(RouteWeight const & rhs) const;
 
-  RouteWeight & operator+=(RouteWeight const & rhs)
-  {
-    m_weight += rhs.m_weight;
-    m_nonPassThroughCross += rhs.m_nonPassThroughCross;
-    m_transitTime += rhs.m_transitTime;
-    return *this;
-  }
+  RouteWeight & operator+=(RouteWeight const & rhs);
 
   RouteWeight operator-() const
   {
-    return RouteWeight(-m_weight, -m_nonPassThroughCross, -m_transitTime);
+    ASSERT_NOT_EQUAL(m_nonPassThroughCross, std::numeric_limits<int32_t>::min(), ());
+    ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int32_t>::min(), ());
+    return RouteWeight(-m_weight, -m_nonPassThroughCross, -m_numAccessChanges, -m_transitTime);
   }
 
   bool IsAlmostEqualForTests(RouteWeight const & rhs, double epsilon)
   {
     return m_nonPassThroughCross == rhs.m_nonPassThroughCross &&
+           m_numAccessChanges == rhs.m_numAccessChanges &&
            my::AlmostEqualAbs(m_weight, rhs.m_weight, epsilon) &&
            my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, epsilon);
   }
 
 private:
+  // Note: consider smaller types for m_nonPassThroughCross and m_numAccessChanges
+  // in case of adding new fields to RouteWeight to reduce RouteWeight size.
+
   // Regular weight (seconds).
   double m_weight = 0.0;
-  // Number of pass-through/non-pass-through area border cross.
-  int m_nonPassThroughCross = 0;
+  // Number of pass-through/non-pass-through area border crosses.
+  int32_t m_nonPassThroughCross = 0;
+  // Number of access=yes/access={private,destination} area border crosses.
+  int32_t m_numAccessChanges = 0;
   // Transit time. It's already included in |m_weight| (m_transitTime <= m_weight).
   double m_transitTime = 0.0;
 };
@@ -97,21 +105,23 @@ template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
   return RouteWeight(std::numeric_limits<double>::max() /* weight */,
-                     std::numeric_limits<int>::max() /* nonPassThroughCross */,
-                     std::numeric_limits<int>::max() /* transitTime */);
+                     std::numeric_limits<int32_t>::max() /* nonPassThroughCross */,
+                     std::numeric_limits<int32_t>::max() /* numAccessChanges */,
+                     0 /* transitTime */);  // operator< prefers bigger transit time
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
 {
-  return RouteWeight(0.0 /* weight */, 0 /* nonPassThroughCross */, 0.0 /* transitTime */);
+  return RouteWeight(0.0 /* weight */, 0 /* nonPassThroughCross */, 0 /* numAccessChanges */,
+                     0.0 /* transitTime */);
 }
 
 template <>
 constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
 {
   return RouteWeight(GetAStarWeightEpsilon<double>(), 0 /* nonPassThroughCross */,
-                     0.0 /* transitTime */);
+                     0 /* numAccessChanges */, 0.0 /* transitTime */);
 }
 
 }  // namespace routing

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -122,17 +122,17 @@ void TestIndexGraphTopology::AddDirectedEdge(Vertex from, Vertex to, double weig
   AddDirectedEdge(m_edgeRequests, from, to, weight);
 }
 
-void TestIndexGraphTopology::BlockEdge(Vertex from, Vertex to)
+void TestIndexGraphTopology::SetEdgeAccess(Vertex from, Vertex to, RoadAccess::Type type)
 {
   for (auto & r : m_edgeRequests)
   {
     if (r.m_from == from && r.m_to == to)
     {
-      r.m_isBlocked = true;
+      r.m_accessType = type;
       return;
     }
   }
-  CHECK(false, ("Cannot block edge that is not in the graph", from, to));
+  CHECK(false, ("Cannot set access for edge that is not in the graph", from, to));
 }
 
 bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & pathWeight,
@@ -256,19 +256,15 @@ void TestIndexGraphTopology::Builder::BuildJoints()
 
 void TestIndexGraphTopology::Builder::BuildGraphFromRequests(vector<EdgeRequest> const & requests)
 {
-  vector<uint32_t> blockedFeatureIds;
+  map<Segment, RoadAccess::Type> segmentTypes;
   for (auto const & request : requests)
   {
     BuildSegmentFromEdge(request);
-    if (request.m_isBlocked)
-      blockedFeatureIds.push_back(request.m_id);
-  }
-
-  map<Segment, RoadAccess::Type> segmentTypes;
-  for (auto const fid : blockedFeatureIds)
-  {
-    segmentTypes[Segment(kFakeNumMwmId, fid, 0 /* wildcard segmentIdx */, true)] =
-        RoadAccess::Type::No;
+    if (request.m_accessType != RoadAccess::Type::Yes)
+    {
+      segmentTypes[Segment(kFakeNumMwmId, request.m_id, 0 /* wildcard segmentIdx */, true)] =
+          request.m_accessType;
+    }
   }
 
   m_roadAccess.SetSegmentTypes(move(segmentTypes));

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -155,8 +155,8 @@ public:
   // and the graph itself is built only after a call to FindPath.
   void AddDirectedEdge(Vertex from, Vertex to, double weight);
 
-  // Blocks a previously added edge without removing it from the graph.
-  void BlockEdge(Vertex from, Vertex to);
+  // Sets access for previously added edge.
+  void SetEdgeAccess(Vertex from, Vertex to, RoadAccess::Type type);
 
   // Finds a path between the start and finish vertices. Returns true iff a path exists.
   bool FindPath(Vertex start, Vertex finish, double & pathWeight, vector<Edge> & pathEdges) const;
@@ -168,7 +168,7 @@ private:
     Vertex m_from = 0;
     Vertex m_to = 0;
     double m_weight = 0.0;
-    bool m_isBlocked = false;
+    RoadAccess::Type m_accessType = RoadAccess::Type::Yes;
 
     EdgeRequest(uint32_t id, Vertex from, Vertex to, double weight)
       : m_id(id), m_from(from), m_to(to), m_weight(weight)

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -56,14 +56,14 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment) const
   if (IsGate(segment))
   {
     auto const weight = GetGate(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* nonPassThroughCross */, 0 /* numAccessChanges */,
+    return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */, 0 /* numAccessChanges */,
                        weight /* transitTime */);
   }
 
   if (IsEdge(segment))
   {
     auto const weight = GetEdge(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, 0 /* numAccessChanges */,
+    return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */, 0 /* numAccessChanges */,
                        weight /* transitTime */);
   }
 

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -56,13 +56,15 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment) const
   if (IsGate(segment))
   {
     auto const weight = GetGate(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, weight /* transitTime */);
+    return RouteWeight(weight /* weight */, 0 /* nonPassThroughCross */, 0 /* numAccessChanges */,
+                       weight /* transitTime */);
   }
 
   if (IsEdge(segment))
   {
     auto const weight = GetEdge(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, weight /* transitTime */);
+    return RouteWeight(weight /* weight */, 0 /* nonPassThrougCross */, 0 /* numAccessChanges */,
+                       weight /* transitTime */);
   }
 
   return RouteWeight(
@@ -94,7 +96,7 @@ RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const
   // 3. |from| is edge, |to| is edge from another line directly connected to |from|.
   auto const it = m_transferPenalties.find(lineIdTo);
   CHECK(it != m_transferPenalties.cend(), ("Segment", to, "belongs to unknown line:", lineIdTo));
-  return RouteWeight(it->second /* weight */, 0 /* nonPassThrougCross */,
+  return RouteWeight(it->second /* weight */, 0 /* nonPassThrougCross */, 0 /* numAccessChanges */,
                      it->second /* transitTime */);
 }
 


### PR DESCRIPTION
Добавила в многокомпонентный вес компонент для access.

Поскольку мы теперь обрубаем пути, нарушающие ограничение на вес, в процессе построения маршрута, уменьшила размер компонентов для nonPassThroughCross, accessCross -- они вполне влезут в int8_t, а растить размер RouteWeight нехорошо -- его много в очереди в AStar.

В данной реализации проезд через access = no запрещен, а через access = private, access=destination разрешен и при этом будет выбран маршрут с наименьшим возможным числом пересечений. Это сделано, потому что следующим шагом буду добавлять шлагбаумы, а их по пути в зону с ограниченным доступом может быть несколько и разрешать пересекать access=destination один раз будет неправильно (текущая версия не разрешает строить маршрут из/в access=destination, access=private). Хорошим решением было бы строить маршрут с наименьшим возможным количеством пересечений destination и private, чтобы дать проехать все шлагбаумы, и, если количество пересечений оказалось не нулевым, предупреждать пользователя что на пути есть ограничения доступа (со стороны роутинга для этого всё готово).