### PR TITLE
[routing] Fix AStarAlgirithm::Params lifetime

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -56,7 +56,7 @@ public:
   struct Params
   {
     Params(Graph & graph, Vertex const & startVertex, Vertex const & finalVertex,
-           std::vector<Edge> const & prevRoute, my::Cancellable const & cancellable,
+           std::vector<Edge> const * prevRoute, my::Cancellable const & cancellable,
            OnVisitedVertexCallback const & onVisitedVertexCallback,
            CheckLengthCallback const & checkLengthCallback)
       : m_graph(graph)
@@ -73,14 +73,14 @@ public:
     }
 
     Graph & m_graph;
-    Vertex const & m_startVertex;
+    Vertex const m_startVertex;
     // Used for FindPath, FindPathBidirectional.
-    Vertex const & m_finalVertex;
+    Vertex const m_finalVertex;
     // Used for AdjustRoute.
-    std::vector<Edge> const & m_prevRoute;
+    std::vector<Edge> const * m_prevRoute;
     my::Cancellable const & m_cancellable;
-    OnVisitedVertexCallback m_onVisitedVertexCallback;
-    CheckLengthCallback m_checkLengthCallback;
+    OnVisitedVertexCallback const m_onVisitedVertexCallback;
+    CheckLengthCallback const m_checkLengthCallback;
   };
 
   class Context final
@@ -558,9 +558,10 @@ template <typename Graph>
 typename AStarAlgorithm<Graph>::Result AStarAlgorithm<Graph>::AdjustRoute(
     Params & params, RoutingResult<Vertex, Weight> & result) const
 {
+  CHECK(params.m_prevRoute, ());
   auto & graph = params.m_graph;
   auto const & startVertex = params.m_startVertex;
-  auto const & prevRoute = params.m_prevRoute;
+  auto const & prevRoute = *params.m_prevRoute;
 
   CHECK(!prevRoute.empty(), ());
 

--- a/routing/cross_mwm_router.cpp
+++ b/routing/cross_mwm_router.cpp
@@ -23,7 +23,7 @@ IRouter::ResultCode CalculateRoute(BorderCross const & startPos, BorderCross con
         delegate.OnPointCheck(MercatorBounds::FromLatLon(cross.fromNode.point));
       };
 
-  Algorithm::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */, delegate,
+  Algorithm::Params params(roadGraph, startPos, finalPos, nullptr /* prevRoute */, delegate,
                            onVisitedVertex, {} /* checkLengthCallback */);
 
   my::HighResTimer timer(true);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -564,9 +564,9 @@ IRouter::ResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoin
 
   RoutingResult<Segment, RouteWeight> routingResult;
 
-  AStarAlgorithm<IndexGraphStarter>::Params params(starter, starter.GetStartSegment(),
-                                                   starter.GetFinishSegment(), {} /* prevRoute */,
-                                                   delegate, onVisitJunction, checkLength);
+  AStarAlgorithm<IndexGraphStarter>::Params params(
+      starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
+      delegate, onVisitJunction, checkLength);
   IRouter::ResultCode const result = FindPath<IndexGraphStarter>(params, routingResult);
   if (result != IRouter::NoError)
     return result;
@@ -642,7 +642,7 @@ IRouter::ResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 
   AStarAlgorithm<IndexGraphStarter> algorithm;
   AStarAlgorithm<IndexGraphStarter>::Params params(starter, starter.GetStartSegment(),
-                                                   {} /* finalVertex */, prevEdges, delegate,
+                                                   {} /* finalVertex */, &prevEdges, delegate,
                                                    onVisitJunction, checkLength);
   RoutingResult<Segment, RouteWeight> result;
   auto const resultCode = ConvertResult<IndexGraphStarter>(algorithm.AdjustRoute(params, result));
@@ -791,9 +791,9 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       // In case of leaps from the start to its mwm transition and from finish to mwm transition
       // route calculation should be made on the world graph (WorldGraph::Mode::NoLeaps).
       worldGraph.SetMode(WorldGraph::Mode::NoLeaps);
-      AStarAlgorithm<IndexGraphStarter>::Params params(starter, current, next, {} /* prevRoute */,
-                                                       delegate, {} /* onVisitedVertexCallback */,
-                                                       checkLength);
+      AStarAlgorithm<IndexGraphStarter>::Params params(
+          starter, current, next, nullptr /* prevRoute */, delegate,
+          {} /* onVisitedVertexCallback */, checkLength);
       result = FindPath<IndexGraphStarter>(params, routingResult);
     }
     else
@@ -808,7 +808,7 @@ IRouter::ResultCode IndexRouter::ProcessLeaps(vector<Segment> const & input,
       worldGraph.SetMode(WorldGraph::Mode::SingleMwm);
       // It's not start-to-mwm-exit leap, we already have its first segment in previous mwm.
       dropFirstSegment = true;
-      AStarAlgorithm<WorldGraph>::Params params(worldGraph, current, next, {} /* prevRoute */,
+      AStarAlgorithm<WorldGraph>::Params params(worldGraph, current, next, nullptr /* prevRoute */,
                                                 delegate, {} /* onVisitedVertexCallback */,
                                                 checkLength);
       result = FindPath<WorldGraph>(params, routingResult);

--- a/routing/routing_algorithm.cpp
+++ b/routing/routing_algorithm.cpp
@@ -157,7 +157,7 @@ IRoutingAlgorithm::Result AStarRoutingAlgorithm::CalculateRoute(IRoadGraph const
   my::Cancellable const & cancellable = delegate;
   progress.Initialize(startPos.GetPoint(), finalPos.GetPoint());
   RoadGraph roadGraph(graph);
-  TAlgorithmImpl::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */, cancellable,
+  TAlgorithmImpl::Params params(roadGraph, startPos, finalPos, nullptr /* prevRoute */, cancellable,
                                 onVisitJunctionFn, {} /* checkLength */);
   TAlgorithmImpl::Result const res = TAlgorithmImpl().FindPath(params, path);
   return Convert(res);

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -66,10 +66,8 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 {
   TAlgorithm algo;
 
-  my::Cancellable cancellable;
-  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */,
-                            nullptr /* prevRoute */, cancellable /* cancellable */,
-                            {} /* onVisitedVerteCallback */, {} /* checkLengthCallback */);
+  TAlgorithm::ParamsForTests params(graph, 0u /* startVertex */, 4u /* finishVertex */,
+                                    nullptr /* prevRoute */, {} /* checkLengthCallback */);
 
   RoutingResult<unsigned /* Vertex */, double /* Weight */> actualRoute;
   TEST_EQUAL(TAlgorithm::Result::OK, algo.FindPath(params, actualRoute), ());
@@ -110,11 +108,9 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   graph.AddEdge(3, 4, 3);
 
   TAlgorithm algo;
-  my::Cancellable cancellable;
-  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */,
-                            nullptr /* prevRoute */, cancellable /* cancellable */,
-                            {} /* onVisitedVerteCallback */,
-                            [](double weight) { return weight < 23; });
+  TAlgorithm::ParamsForTests params(graph, 0u /* startVertex */, 4u /* finishVertex */,
+                                    nullptr /* prevRoute */,
+                                    [](double weight) { return weight < 23; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> routingResult;
   TAlgorithm::Result result = algo.FindPath(params, routingResult);
   // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
@@ -141,10 +137,8 @@ UNIT_TEST(AdjustRoute)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  my::Cancellable cancellable;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
-                            [](double weight) { return weight <= 1.0; });
+  TAlgorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                                    [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 
@@ -165,10 +159,8 @@ UNIT_TEST(AdjustRouteNoPath)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  my::Cancellable cancellable;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
-                            [](double weight) { return weight <= 1.0; });
+  TAlgorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                                    [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 
@@ -189,10 +181,8 @@ UNIT_TEST(AdjustRouteOutOfLimit)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  my::Cancellable cancellable;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
-                            [](double weight) { return weight <= 1.0; });
+  TAlgorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                                    [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -66,9 +66,10 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 {
   TAlgorithm algo;
 
-  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */, {} /* prevRoute */,
-                            {} /* cancellable */, {} /* onVisitedVerteCallback */,
-                            {} /* checkLengthCallback */);
+  my::Cancellable cancellable;
+  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */,
+                            nullptr /* prevRoute */, cancellable /* cancellable */,
+                            {} /* onVisitedVerteCallback */, {} /* checkLengthCallback */);
 
   RoutingResult<unsigned /* Vertex */, double /* Weight */> actualRoute;
   TEST_EQUAL(TAlgorithm::Result::OK, algo.FindPath(params, actualRoute), ());
@@ -109,8 +110,10 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   graph.AddEdge(3, 4, 3);
 
   TAlgorithm algo;
-  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */, {} /* prevRoute */,
-                            {} /* cancellable */, {} /* onVisitedVerteCallback */,
+  my::Cancellable cancellable;
+  TAlgorithm::Params params(graph, 0u /* startVertex */, 4u /* finishVertex */,
+                            nullptr /* prevRoute */, cancellable /* cancellable */,
+                            {} /* onVisitedVerteCallback */,
                             [](double weight) { return weight < 23; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> routingResult;
   TAlgorithm::Result result = algo.FindPath(params, routingResult);
@@ -138,8 +141,9 @@ UNIT_TEST(AdjustRoute)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, prevRoute,
-                            {} /* cancellable */, {} /* onVisitedVerteCallback */,
+  my::Cancellable cancellable;
+  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
                             [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
@@ -161,8 +165,9 @@ UNIT_TEST(AdjustRouteNoPath)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, prevRoute,
-                            {} /* cancellable */, {} /* onVisitedVerteCallback */,
+  my::Cancellable cancellable;
+  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
                             [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
@@ -184,8 +189,9 @@ UNIT_TEST(AdjustRouteOutOfLimit)
   vector<Edge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
   TAlgorithm algo;
-  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, prevRoute,
-                            {} /* cancellable */, {} /* onVisitedVerteCallback */,
+  my::Cancellable cancellable;
+  TAlgorithm::Params params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                            cancellable /* cancellable */, {} /* onVisitedVerteCallback */,
                             [](double weight) { return weight <= 1.0; });
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -172,9 +172,11 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
 
   AStarAlgorithm<WorldGraph> algorithm;
 
-  AStarAlgorithm<WorldGraph>::Params params(
-      *worldGraph, startSegment, finishSegment, {} /* prevRoute */, {} /* cancellable */,
-      {} /* onVisitedVertexCallback */, {} /* checkLengthCallback */);
+  my::Cancellable cancellable;
+  AStarAlgorithm<WorldGraph>::Params params(*worldGraph, startSegment, finishSegment,
+                                            nullptr /* prevRoute */, cancellable /* cancellable */,
+                                            {} /* onVisitedVertexCallback */,
+                                            {} /* checkLengthCallback */);
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 
@@ -364,9 +366,10 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
   AStarAlgorithm<IndexGraphStarter> algorithm;
   RoutingResult<Segment, RouteWeight> routingResult;
 
+  my::Cancellable cancellable;
   AStarAlgorithm<IndexGraphStarter>::Params params(
-      starter, starter.GetStartSegment(), starter.GetFinishSegment(), {} /* prevRoute */,
-      {} /* cancellable */, {} /* onVisitedVertexCallback */,
+      starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
+      cancellable /* cancellable */, {} /* onVisitedVertexCallback */,
       [&](RouteWeight const & weight) { return starter.CheckLength(weight); });
 
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -172,11 +172,9 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
 
   AStarAlgorithm<WorldGraph> algorithm;
 
-  my::Cancellable cancellable;
-  AStarAlgorithm<WorldGraph>::Params params(*worldGraph, startSegment, finishSegment,
-                                            nullptr /* prevRoute */, cancellable /* cancellable */,
-                                            {} /* onVisitedVertexCallback */,
-                                            {} /* checkLengthCallback */);
+  AStarAlgorithm<WorldGraph>::ParamsForTests params(*worldGraph, startSegment, finishSegment,
+                                                    nullptr /* prevRoute */,
+                                                    {} /* checkLengthCallback */);
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 
@@ -366,10 +364,8 @@ AStarAlgorithm<IndexGraphStarter>::Result CalculateRoute(IndexGraphStarter & sta
   AStarAlgorithm<IndexGraphStarter> algorithm;
   RoutingResult<Segment, RouteWeight> routingResult;
 
-  my::Cancellable cancellable;
-  AStarAlgorithm<IndexGraphStarter>::Params params(
+  AStarAlgorithm<IndexGraphStarter>::ParamsForTests params(
       starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
-      cancellable /* cancellable */, {} /* onVisitedVertexCallback */,
       [&](RouteWeight const & weight) { return starter.CheckLength(weight); });
 
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);


### PR DESCRIPTION
Сломала в https://github.com/mapsme/omim/commit/86dc1ec066e30824ac9cdd76f8a037eaeec53b2c

Конструктор Params как и AStar::FindPath/AStar::FindPathBidirectional/AStar::AdjustRoute принимал большинство параметров по константным ссылкам. Но раньше когда в тестах мы инициализировали их временными переменными (default constructed my::Cancellable, значения для вершин типа unsigned и т.п.) это было ок, так как время жизни временной переменной расширялось до окончания выражения, в кором был вызов функции.

После создания params временная переменная стала жить до окончания конструктора. Исправляю это в этом PR. 