### PR TITLE
[routing] Improve points number testing in routing integration tests

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -93,36 +93,42 @@ namespace
   // Geometry unpacking test.
   UNIT_TEST(RussiaFerryToCrimeaLoadCrossGeometryTest)
   {
+    size_t constexpr kExpectedPointsNumber = 50;
     // Forward
     TRouteResult route =
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
                                     MercatorBounds::FromLatLon(45.36479, 36.62194));
     TEST_EQUAL(route.second, IRouter::NoError, ());
-    TEST_GREATER(route.first->GetPoly().GetSize(), 50, ());
+    CHECK(route.first, ());
+    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
     // And backward case
     route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
                                         MercatorBounds::FromLatLon(45.34123, 36.67679));
     TEST_EQUAL(route.second, IRouter::NoError, ());
-    TEST_GREATER(route.first->GetPoly().GetSize(), 50, ());
+    CHECK(route.first, ());
+    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
   }
 
   UNIT_TEST(PriceIslandLoadCrossGeometryTest)
   {
+    size_t constexpr kExpectedPointsNumber = 56;
     // Forward
     TRouteResult route =
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
                                     MercatorBounds::FromLatLon(46.25401, -63.70213));
     TEST_EQUAL(route.second, IRouter::NoError, ());
-    TEST_GREATER(route.first->GetPoly().GetSize(), 29, ());
+    CHECK(route.first, ());
+    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
     // And backward case
     route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(46.25401, -63.70213), {0., 0.},
                                         MercatorBounds::FromLatLon(46.16255, -63.81643));
     TEST_EQUAL(route.second, IRouter::NoError, ());
-    TEST_GREATER(route.first->GetPoly().GetSize(), 29, ());
+    CHECK(route.first, ());
+    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
   }
 
   // Cross mwm tests.
@@ -310,10 +316,11 @@ namespace
                                     MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
                                     MercatorBounds::FromLatLon(55.753, 37.60169));
 
-    Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
 
+    CHECK(routeResult.first, ());
+    Route const & route = *routeResult.first;
     integration::TestRouteTime(route, 17850.);
   }
 
@@ -323,10 +330,11 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
                                     MercatorBounds::FromLatLon(55.8579, 37.40990));
-    Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
 
+    CHECK(routeResult.first, ());
+    Route const & route = *routeResult.first;
     integration::TestRouteTime(route, 730.);
   }
 
@@ -340,11 +348,14 @@ namespace
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
 
+    CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
     TEST_EQUAL(route.GetSubrouteCount(), 1, ());
     vector<RouteSegment> info;
     route.GetSubrouteInfo(0, info);
-    TEST_EQUAL(info.size(), 330, ());
+    TEST_EQUAL(route.GetPoly().GetSize(), info.size() + 1, ());
+    size_t constexpr kExpectedPointsNumber = 335;
+    integration::TestRoutePointsNumber(route, kExpectedPointsNumber);
   }
 
   UNIT_TEST(USALosAnglesAriaTwentyninePalmsHighwayTimeTest)
@@ -353,9 +364,10 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
                                     MercatorBounds::FromLatLon(34.0928, -115.5930));
-    Route const & route = *routeResult.first;
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
+    CHECK(routeResult.first, ());
+    Route const & route = *routeResult.first;
     TEST_LESS(route.GetTotalTimeSec(), numeric_limits<double >::max() / 2.0, ());
   }
 }  // namespace

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -27,6 +27,7 @@
 #include "geometry/distance_on_sphere.hpp"
 #include "geometry/latlon.hpp"
 
+#include "base/math.hpp"
 #include "base/stl_add.hpp"
 
 #include "std/functional.hpp"
@@ -47,6 +48,7 @@ namespace
 {
 double constexpr kErrorMeters = 1.0;
 double constexpr kErrorSeconds = 1.0;
+
 void ChangeMaxNumberOfOpenFiles(size_t n)
 {
   struct rlimit rlp;
@@ -214,6 +216,16 @@ namespace integration
     double const routeSeconds = route.GetTotalTimeSec();
     TEST(my::AlmostEqualAbs(routeSeconds, expectedRouteSeconds, delta),
         ("Route time test failed. Expected:", expectedRouteSeconds, "have:", routeSeconds, "delta:", delta));
+  }
+
+  void TestRoutePointsNumber(Route const & route, size_t expectedPointsNumber, double relativeError)
+  {
+    CHECK_GREATER_OR_EQUAL(relativeError, 0.0, ());
+    size_t const routePoints = route.GetPoly().GetSize();
+    TEST(my::AlmostEqualRel(static_cast<double>(routePoints),
+                            static_cast<double>(expectedPointsNumber), relativeError),
+         ("Route points test failed. Expected:", expectedPointsNumber, "have:", routePoints,
+          "relative error:", relativeError));
   }
 
   void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents,

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -121,6 +121,8 @@ void TestTurnCount(Route const & route, uint32_t expectedTurnCount);
 /// && expectedRouteMeters + expectedRouteMeters * relativeError >= route->GetDistance()
 void TestRouteLength(Route const & route, double expectedRouteMeters, double relativeError = 0.01);
 void TestRouteTime(Route const & route, double expectedRouteSeconds, double relativeError = 0.01);
+void TestRoutePointsNumber(Route const & route, size_t expectedPointsNumber,
+                           double relativeError = 0.1);
 
 void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents,
                                       m2::PointD const & startPoint,


### PR DESCRIPTION
У нас в интеграционных тестах количество точек в маршруте сравнивалось с ожидаемым или строго (TEST_EQUAL) или на больше/меньше без задания погрешности, это было не очень хорошо в условиях меняющихся карт. Сделала сравнение с погрешностью, похожее на то что используется для расстояния и для времени.