### PR TITLE
[routing][generator]Save road points access info

### DIFF
--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -133,20 +133,20 @@ UNIT_TEST(RoadAccess_Smoke)
 
 UNIT_TEST(RoadAccess_AccessPrivate)
 {
-  string const roadAccessContent = R"(Car Private 0)";
+  string const roadAccessContent = R"(Car Private 0 0)";
   string const osmIdsToFeatureIdsContent = R"(0, 0,)";
   auto const roadAccessAllTypes =
       SaveAndLoadRoadAccess(roadAccessContent, osmIdsToFeatureIdsContent);
   auto const carRoadAccess = roadAccessAllTypes[static_cast<size_t>(VehicleType::Car)];
-  TEST_EQUAL(carRoadAccess.GetSegmentType(Segment(0, 0, 0, false)), RoadAccess::Type::Private, ());
+  TEST_EQUAL(carRoadAccess.GetFeatureType(0 /* featureId */), RoadAccess::Type::Private, ());
 }
 
 UNIT_TEST(RoadAccess_Access_Multiple_Vehicle_Types)
 {
-  string const roadAccessContent = R"(Car Private 10
-                                     Car Private 20
-                                     Bicycle No 30
-                                     Car Destination 40)";
+  string const roadAccessContent = R"(Car Private 10 0
+                                     Car Private 20 0
+                                     Bicycle No 30 0
+                                     Car Destination 40 0)";
   string const osmIdsToFeatureIdsContent = R"(10, 1,
                                              20, 2,
                                              30, 3,
@@ -155,11 +155,11 @@ UNIT_TEST(RoadAccess_Access_Multiple_Vehicle_Types)
       SaveAndLoadRoadAccess(roadAccessContent, osmIdsToFeatureIdsContent);
   auto const carRoadAccess = roadAccessAllTypes[static_cast<size_t>(VehicleType::Car)];
   auto const bicycleRoadAccess = roadAccessAllTypes[static_cast<size_t>(VehicleType::Bicycle)];
-  TEST_EQUAL(carRoadAccess.GetSegmentType(Segment(0, 1, 0, false)), RoadAccess::Type::Private, ());
-  TEST_EQUAL(carRoadAccess.GetSegmentType(Segment(0, 2, 2, true)), RoadAccess::Type::Private, ());
-  TEST_EQUAL(carRoadAccess.GetSegmentType(Segment(0, 3, 1, true)), RoadAccess::Type::Yes, ());
-  TEST_EQUAL(carRoadAccess.GetSegmentType(Segment(0, 4, 3, false)), RoadAccess::Type::Destination,
+  TEST_EQUAL(carRoadAccess.GetFeatureType(1 /* featureId */), RoadAccess::Type::Private, ());
+  TEST_EQUAL(carRoadAccess.GetFeatureType(2 /* featureId */), RoadAccess::Type::Private, ());
+  TEST_EQUAL(carRoadAccess.GetFeatureType(3 /* featureId */), RoadAccess::Type::Yes, ());
+  TEST_EQUAL(carRoadAccess.GetFeatureType(4 /* featureId */), RoadAccess::Type::Destination,
              ());
-  TEST_EQUAL(bicycleRoadAccess.GetSegmentType(Segment(0, 3, 0, false)), RoadAccess::Type::No, ());
+  TEST_EQUAL(bicycleRoadAccess.GetFeatureType(3 /* featureId */), RoadAccess::Type::No, ());
 }
 }  // namespace

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -29,13 +29,17 @@ public:
 
   explicit RoadAccessTagProcessor(VehicleType vehicleType);
 
-  void Process(OsmElement const & elem, std::ofstream & oss) const;
+  void Process(OsmElement const & elem, std::ofstream & oss);
 
 private:
+  RoadAccess::Type GetAccessType(OsmElement const & elem) const;
+
   VehicleType m_vehicleType;
   // Order of tag mappings in m_tagMappings is from more to less specific.
   // e.g. for car: motorcar, motorvehicle, vehicle, general access tags.
   std::vector<TagMapping const *> m_tagMappings;
+  // Tag mapping for barriers. Key is barrier node osm id.
+  std::map<uint64_t, RoadAccess::Type> m_barriers;
 };
 
 class RoadAccessWriter

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -160,7 +160,7 @@ void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bo
   if (IsRestricted(m_restrictions, from, to, isOutgoing))
     return;
 
-  if (m_roadAccess.GetSegmentType(to) == RoadAccess::Type::No)
+  if (m_roadAccess.GetFeatureType(to.GetFeatureId()) == RoadAccess::Type::No)
     return;
 
   RouteWeight const weight = CalcSegmentWeight(isOutgoing ? to : from) +
@@ -177,8 +177,8 @@ RouteWeight IndexGraph::GetPenalties(Segment const & u, Segment const & v)
   int32_t const passThroughPenalty = fromPassThroughAllowed == toPassThroughAllowed ? 0 : 1;
 
   // We do not distinguish between RoadAccess::Type::Private and RoadAccess::Type::Destination for now.
-  bool const fromAccessAllowed = m_roadAccess.GetSegmentType(u) == RoadAccess::Type::Yes;
-  bool const toAccessAllowed = m_roadAccess.GetSegmentType(v) == RoadAccess::Type::Yes;
+  bool const fromAccessAllowed = m_roadAccess.GetFeatureType(u.GetFeatureId()) == RoadAccess::Type::Yes;
+  bool const toAccessAllowed = m_roadAccess.GetFeatureType(v.GetFeatureId()) == RoadAccess::Type::Yes;
   // Route crosses border of access=yes/access={private, destination} area if |u| and |v| have different
   // access restrictions.
   int32_t const accessPenalty = fromAccessAllowed == toAccessAllowed ? 0 : 1;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -42,7 +42,7 @@ public:
 
   RoadAccess::Type GetAccessType(Segment const & segment) const
   {
-    return m_roadAccess.GetSegmentType(segment);
+    return m_roadAccess.GetFeatureType(segment.GetFeatureId());
   }
 
   uint32_t GetNumRoads() const { return m_roadIndex.GetSize(); }

--- a/routing/road_access.cpp
+++ b/routing/road_access.cpp
@@ -10,38 +10,51 @@ using namespace std;
 namespace
 {
 string const kNames[] = {"No", "Private", "Destination", "Yes", "Count"};
+
+template <typename KV>
+void PrintKV(ostringstream & oss, KV const & kvs, size_t maxKVToShow)
+{
+  size_t i = 0;
+  for (auto const & kv : kvs)
+  {
+    if (i > 0)
+      oss << ", ";
+    oss << DebugPrint(kv.first) << " " << DebugPrint(kv.second);
+    ++i;
+    if (i == maxKVToShow)
+      break;
+  }
+  if (kvs.size() > maxKVToShow)
+    oss << ", ...";
+}
 }  // namespace
 
 namespace routing
 {
 // RoadAccess --------------------------------------------------------------------------------------
-RoadAccess::Type RoadAccess::GetSegmentType(Segment const & segment) const
+RoadAccess::Type RoadAccess::GetFeatureType(uint32_t featureId) const
 {
-  // todo(@m) This may or may not be too slow. Consider profiling this and using
-  // a Bloom filter or anything else that is faster than std::map.
+// todo(@m) This may or may not be too slow. Consider profiling this and using
+// a Bloom filter or anything else that is faster than std::map.
+  auto const it = m_featureTypes.find(featureId);
+  if (it != m_featureTypes.cend())
+    return it->second;
 
-  {
-    Segment key(kFakeNumMwmId, segment.GetFeatureId(), 0 /* wildcard segment idx */,
-                true /* wildcard isForward */);
-    auto const it = m_segmentTypes.find(key);
-    if (it != m_segmentTypes.end())
-      return it->second;
-  }
+  return RoadAccess::Type::Yes;
+}
 
-  {
-    Segment key(kFakeNumMwmId, segment.GetFeatureId(), segment.GetSegmentIdx() + 1,
-                segment.IsForward());
-    auto const it = m_segmentTypes.find(key);
-    if (it != m_segmentTypes.end())
-      return it->second;
-  }
+RoadAccess::Type RoadAccess::GetPointType(RoadPoint const & point) const
+{
+  auto const it = m_pointTypes.find(point);
+  if (it != m_pointTypes.cend())
+    return it->second;
 
   return RoadAccess::Type::Yes;
 }
 
 bool RoadAccess::operator==(RoadAccess const & rhs) const
 {
-  return m_segmentTypes == rhs.m_segmentTypes;
+  return m_featureTypes == rhs.m_featureTypes && m_pointTypes == rhs.m_pointTypes;
 }
 
 // Functions ---------------------------------------------------------------------------------------
@@ -73,21 +86,11 @@ string DebugPrint(RoadAccess const & r)
 {
   size_t const kMaxIdsToShow = 10;
   ostringstream oss;
-  oss << "RoadAccess [";
-  size_t id = 0;
-  for (auto const & kv : r.GetSegmentTypes())
-  {
-    if (id > 0)
-      oss << ", ";
-    oss << DebugPrint(kv.first) << " " << DebugPrint(kv.second);
-    ++id;
-    if (id == kMaxIdsToShow)
-      break;
-  }
-  if (r.GetSegmentTypes().size() > kMaxIdsToShow)
-    oss << ", ...";
-
-  oss << "]";
+  oss << "RoadAccess { FeatureTypes [";
+  PrintKV(oss, r.GetFeatureTypes(), kMaxIdsToShow);
+  oss << "], PointTypes [";
+  PrintKV(oss, r.GetPointTypes(), kMaxIdsToShow);
+  oss << "] }";
   return oss.str();
 }
 }  // namespace routing

--- a/routing/road_access.hpp
+++ b/routing/road_access.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace routing
@@ -40,14 +41,17 @@ public:
     Count
   };
 
-  std::map<Segment, RoadAccess::Type> const & GetSegmentTypes() const { return m_segmentTypes; }
+  std::map<uint32_t, RoadAccess::Type> const & GetFeatureTypes() const { return m_featureTypes; }
+  std::map<RoadPoint, RoadAccess::Type> const & GetPointTypes() const { return m_pointTypes; }
 
-  Type GetSegmentType(Segment const & segment) const;
+  Type GetFeatureType(uint32_t featureId) const;
+  Type GetPointType(RoadPoint const & point) const;
 
-  template <typename V>
-  void SetSegmentTypes(V && v)
+  template <typename MF, typename MP>
+  void SetAccessTypes(MF && mf, MP && mp)
   {
-    m_segmentTypes = std::forward<V>(v);
+    m_featureTypes = std::forward<MF>(mf);
+    m_pointTypes = std::forward<MP>(mp);
   }
 
   void Clear();
@@ -56,14 +60,18 @@ public:
 
   bool operator==(RoadAccess const & rhs) const;
 
+  template <typename MF>
+  void SetFeatureTypesForTests(MF && mf)
+  {
+    m_featureTypes = std::forward<MF>(mf);
+  }
+
 private:
-  // todo(@m) Segment's NumMwmId is not used here. Decouple it from
-  // segment and use only (fid, idx, forward) in the map.
-  //
   // If segmentIdx of a key in this map is 0, it means the
   // entire feature has the corresponding access type.
   // Otherwise, the information is about the segment with number (segmentIdx-1).
-  std::map<Segment, RoadAccess::Type> m_segmentTypes;
+  std::map<uint32_t, RoadAccess::Type> m_featureTypes;
+  std::map<RoadPoint, RoadAccess::Type> m_pointTypes;
 };
 
 std::string ToString(RoadAccess::Type type);

--- a/routing/road_point.hpp
+++ b/routing/road_point.hpp
@@ -21,6 +21,13 @@ public:
 
   uint32_t GetPointId() const { return m_pointId; }
 
+  bool operator<(RoadPoint const & rp) const
+  {
+    if (m_featureId != rp.m_featureId)
+      return m_featureId < rp.m_featureId;
+    return m_pointId < rp.m_pointId;
+  }
+
   bool operator==(RoadPoint const & rp) const
   {
     return m_featureId == rp.m_featureId && m_pointId == rp.m_pointId;

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -254,18 +254,17 @@ void TestIndexGraphTopology::Builder::BuildJoints()
 
 void TestIndexGraphTopology::Builder::BuildGraphFromRequests(vector<EdgeRequest> const & requests)
 {
-  map<Segment, RoadAccess::Type> segmentTypes;
+  map<uint32_t, RoadAccess::Type> featureTypes;
   for (auto const & request : requests)
   {
     BuildSegmentFromEdge(request);
     if (request.m_accessType != RoadAccess::Type::Yes)
     {
-      segmentTypes[Segment(kFakeNumMwmId, request.m_id, 0 /* wildcard segmentIdx */, true)] =
-          request.m_accessType;
+      featureTypes[request.m_id] = request.m_accessType;
     }
   }
 
-  m_roadAccess.SetSegmentTypes(move(segmentTypes));
+  m_roadAccess.SetFeatureTypesForTests(move(featureTypes));
 }
 
 void TestIndexGraphTopology::Builder::BuildSegmentFromEdge(EdgeRequest const & request)

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -158,6 +158,9 @@ public:
   // Sets access for previously added edge.
   void SetEdgeAccess(Vertex from, Vertex to, RoadAccess::Type type);
 
+  // Sets access type for previously added point.
+  void SetVertexAccess(Vertex v, RoadAccess::Type type);
+
   // Finds a path between the start and finish vertices. Returns true iff a path exists.
   bool FindPath(Vertex start, Vertex finish, double & pathWeight, vector<Edge> & pathEdges) const;
 
@@ -168,7 +171,12 @@ private:
     Vertex m_from = 0;
     Vertex m_to = 0;
     double m_weight = 0.0;
+    // Access type for edge.
     RoadAccess::Type m_accessType = RoadAccess::Type::Yes;
+    // Access type for vertex from.
+    RoadAccess::Type m_fromAccessType = RoadAccess::Type::Yes;
+    // Access type for vertex to.
+    RoadAccess::Type m_toAccessType = RoadAccess::Type::Yes;
 
     EdgeRequest(uint32_t id, Vertex from, Vertex to, double weight)
       : m_id(id), m_from(from), m_to(to), m_weight(weight)

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -23,21 +23,21 @@ namespace
 UNIT_TEST(RoadAccess_Serialization)
 {
   // Segment is (numMwmId, featureId, segmentIdx, isForward).
-  map<Segment, RoadAccess::Type> const m0 = {
-      {Segment(kFakeNumMwmId, 1, 0, false), RoadAccess::Type::No},
-      {Segment(kFakeNumMwmId, 2, 2, false), RoadAccess::Type::Private},
+  map<uint32_t, RoadAccess::Type> const m0 = {
+      {1, RoadAccess::Type::No},
+      {2, RoadAccess::Type::Private},
   };
 
-  map<Segment, RoadAccess::Type> const m1 = {
-      {Segment(kFakeNumMwmId, 1, 1, false), RoadAccess::Type::Private},
-      {Segment(kFakeNumMwmId, 2, 0, true), RoadAccess::Type::Destination},
+  map<uint32_t, RoadAccess::Type> const m1 = {
+      {1, RoadAccess::Type::Private},
+      {2, RoadAccess::Type::Destination},
   };
 
   RoadAccess roadAccessCar;
-  roadAccessCar.SetSegmentTypes(m0);
+  roadAccessCar.SetFeatureTypesForTests(m0);
 
   RoadAccess roadAccessPedestrian;
-  roadAccessPedestrian.SetSegmentTypes(m1);
+  roadAccessPedestrian.SetFeatureTypesForTests(m1);
 
   RoadAccessSerializer::RoadAccessByVehicleType roadAccessAllTypes;
   roadAccessAllTypes[static_cast<size_t>(VehicleType::Car)] = roadAccessCar;


### PR DESCRIPTION
Добавила в генератор генерацию RoadAccess для точечных фичей.

При генерации пользуюсь тем, что в o5m nodes идут раньше чем ways -- предсохраняем информацию о nodes с заполненными тегами доступа, при сохранении информации для ways используем запомненные nodes, сохраняем их вместе, чтобы потом одинаково конвертить osm id в faeture id.

В RoadAccess вместо того чтобы хранить информацию о доступности сегментов храню информацию о доступности фичей и RoadPoints (т.к. именно RoadPoints имеют ограниченный доступ в случае точечных фичей, сегменты по обе стороны от запрещенной RoadPoint можно использовать), такой подход позволит не лепить в дальнейшем костылей для односегментных маршрутов и т.п.
Пока что в IndexGraph не используется информация о доступности RoadPoints, сделаю отдельно.
Для совместимости с существующими mwm номер точки для точечных фичей хранится увеличенным на 1, т.к. номер 0 занят для идентификатора сегмента представляющего полную фичу (другй вариант -- не увеличивать номер, а различать по forward).