### PR TITLE
Fixed crash in user marks caching.

### DIFF
--- a/drape_frontend/user_mark_shapes.cpp
+++ b/drape_frontend/user_mark_shapes.cpp
@@ -109,7 +109,8 @@ void CacheUserMarks(TileKey const & tileKey, ref_ptr<dp::TextureManager> texture
   for (auto const id : marksId)
   {
     auto const it = renderParams.find(id);
-    ASSERT(it != renderParams.end(), ());
+    if (it == renderParams.end())
+      continue;
 
     UserMarkRenderParams & renderInfo = *it->second.get();
     if (!renderInfo.m_isVisible)
@@ -339,7 +340,9 @@ void CacheUserLines(TileKey const & tileKey, ref_ptr<dp::TextureManager> texture
   for (auto id : linesId)
   {
     auto const it = renderParams.find(id);
-    ASSERT(it != renderParams.end(), ());
+    if (it == renderParams.end())
+      continue;
+
     UserLineRenderParams const & renderInfo = *it->second.get();
 
     m2::RectD const tileRect = tileKey.GetGlobalRect();


### PR DESCRIPTION
Поскольку хранение меток специально отвязано от обновления групп меток, может быть ситуация, когда метка уже удалена, а индекс для группы еще не пересчитан. Такое возможно при одновременном удалении метки и вычитке карты. Это допустимо, правильный тайл с метками все равно будет перерисован после обновления группы.

https://fabric.io/mapsme/ios/apps/com.mapswithme.full/issues/59edad3661b02d480d0c8549