### PR TITLE
Widening passage for transit routing.

### DIFF
--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -7,9 +7,12 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
   switch (vehicleType)
   {
   case VehicleType::Pedestrian:
-  case VehicleType::Transit:
     return {true /* m_matchRoute */,         false /* m_soundDirection */,
             20. /* m_matchingThresholdM */,  true /* m_keepPedestrianInfo */,
+            false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/};
+  case VehicleType::Transit:
+    return {true /* m_matchRoute */,         false /* m_soundDirection */,
+            40. /* m_matchingThresholdM */,  true /* m_keepPedestrianInfo */,
             false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/};
   case VehicleType::Bicycle:
     return {true /* m_matchRoute */,         true /* m_soundDirection */,


### PR DESCRIPTION
Настройка RoutingSettings для transit.

https://jira.mail.ru/browse/MAPSME-6426

Ранее навигация для общественного транспорта копировала настройки пешеходной. Причина скорее всего в том, что маршрут общественного транспорта состоит из двух типов маршрута: метро и пеший. Но имеет только одни настройки. Правильным (но вероятно, через чур сложным) решением было бы использовать отдельные настройки для пешей части, а отдельные для метро, а в будущем отдельные для автобуса.

Пока думаю оставить одни настройки для всех маршрутов входящих в transit, но немного их подрегулировать.

Я увеличил коридор матчинга для transit с 40 до 80 метров. (Было 20*2 стало 40*2).

Данный PR вместо такого поведения стрелки, отражающей текущую позицию, при движении по маршруту transit:
![screenshot_20171226-183602](https://user-images.githubusercontent.com/1768114/34373889-ef4c813e-eaee-11e7-85df-4ebce4a3b091.png)

В ряде ситуаций сделает вот такое:
![image](https://user-images.githubusercontent.com/1768114/34373904-179af8b4-eaef-11e7-82cf-0e38d4da2109.png)

При этом, данное изменение не должно сильно ухудшить UX прохождения по пешей части маршрута transit.

@tatiana-kondakova @darina PTAL
