### PR TITLE
Returns IRouter::ResultCode::FileTooOld for car routing if maps from 0317 and older.

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -165,8 +165,8 @@ bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph
                                  getVertexByEdgeFn, getOutgoingEdgesFn);
 }
 
-/// \returns true if the mwm is ready for index graph routing and cross mwm index grapsh routing.
-/// It means the mwm contains routing and cross_mwm sections. In term of production mwms
+/// \returns true if the mwm is ready for index graph routing and cross mwm index graph routing.
+/// It means the mwm contains routing and cross_mwm sections. In terms of production mwms
 /// the method returns false for mwms 170328 and earlier, and returns true for mwms 170428 and
 /// later.
 bool MwmHasRoutingData(version::MwmTraits const & traits)


### PR DESCRIPTION
Удаление из проекта osrm привело к тому, что маршруты для автомобилей не будут прокладываться на картах без секций routing и cross_mwm. (Ранее, когда не было секции cross_mwm использовались секции osrm). Т.о. в ситуациях, когда карта старая (без секций указанных выше) CalculateRoute() должна заполнять, какие страны надо обновить (route.AddAbsentCountry(mwm)) и возвращать IRouter::ResultCode::FileTooOld;

Это и делает данный PR модифицирую метод: GetOutdatedMwms(m_index, outdatedMwms), который вызывает: GetOutdatedMwms()

Данный PR делает так, что мы будем прокладывать авто маршруты только по картам от 28 апреля 2017 и более поздним. В нем пока сохранена возможность прокладки пеших вело маршрутов по картам, более старым при помощи старого роутера.

@ygorshenin @mpimenov PTAL