### PR TITLE
Fixing assert for segment uniqueness in route.

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -151,9 +151,10 @@ bool IsJoint(IRoadGraph::TEdgeVector const & ingoingEdges,
 namespace routing
 {
 // BicycleDirectionsEngine::AdjacentEdges ---------------------------------------------------------
-bool BicycleDirectionsEngine::AdjacentEdges::operator==(AdjacentEdges const & rhs) const
+bool BicycleDirectionsEngine::AdjacentEdges::IsAlmostEqual(AdjacentEdges const & rhs) const
 {
-  return m_outgoingTurns == rhs.m_outgoingTurns && m_ingoingTurnsCount == rhs.m_ingoingTurnsCount;
+  return m_outgoingTurns.IsAlmostEqual(rhs.m_outgoingTurns) &&
+         m_ingoingTurnsCount == rhs.m_ingoingTurnsCount;
 }
 
 // BicycleDirectionsEngine ------------------------------------------------------------------------
@@ -366,7 +367,7 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
       // A route may be build through intermediate points. So it may contain the same |segmentRange|
       // several times. But in that case |adjacentEdges| corresponds to |segmentRange|
       // should be the same as well.
-      ASSERT(it == m_adjacentEdges.cend() || it->second == adjacentEdges,
+      ASSERT(it == m_adjacentEdges.cend() || it->second.IsAlmostEqual(adjacentEdges),
              ("segmentRange:", segmentRange, "corresponds to adjacent edges which aren't equal."));
 
       m_adjacentEdges.insert(it, make_pair(segmentRange, move(adjacentEdges)));

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -55,7 +55,7 @@ public:
                         m2::PointD const & junctionPoint, size_t & ingoingCount,
                         TurnCandidates & outgoingTurns) const override
   {
-    CHECK(!segmentRange.IsClear(), ("SegmentRange presents a fake feature. ingoingPoint:",
+    CHECK(!segmentRange.IsEmpty(), ("SegmentRange presents a fake feature. ingoingPoint:",
                                     MercatorBounds::ToLatLon(ingoingPoint),
                                     "junctionPoint:", MercatorBounds::ToLatLon(junctionPoint)));
 
@@ -361,7 +361,7 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
     CHECK_EQUAL(prevSegments.size() + 1, prevJunctionSize, ());
     pathSegment.m_segments = move(prevSegments);
 
-    if (!segmentRange.IsClear())
+    if (!segmentRange.IsEmpty())
     {
       auto const it = m_adjacentEdges.find(segmentRange);
       // A route may be build through intermediate points. So it may contain the same |segmentRange|

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -19,6 +19,8 @@ public:
   struct AdjacentEdges
   {
     explicit AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
+    bool operator==(AdjacentEdges const & rhs) const;
+    bool operator!=(AdjacentEdges const & rhs) const { return !(*this == rhs); }
 
     turns::TurnCandidates m_outgoingTurns;
     size_t m_ingoingTurnsCount;

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -19,8 +19,7 @@ public:
   struct AdjacentEdges
   {
     explicit AdjacentEdges(size_t ingoingTurnsCount = 0) : m_ingoingTurnsCount(ingoingTurnsCount) {}
-    bool operator==(AdjacentEdges const & rhs) const;
-    bool operator!=(AdjacentEdges const & rhs) const { return !(*this == rhs); }
+    bool IsAlmostEqual(AdjacentEdges const & rhs) const;
 
     turns::TurnCandidates m_outgoingTurns;
     size_t m_ingoingTurnsCount;

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -19,8 +19,10 @@ class IRoutingResult
 public:
   /// \returns information about all route segments.
   virtual TUnpackedPathSegments const & GetSegments() const = 0;
-  /// \brief For a |segmentRange|, |junctionPoint| and |ingoingPoint| (point before the |node|)
+  /// \brief For a |segmentRange|, |junctionPoint| and |ingoingPoint| (point before the |junctionPoint|)
   /// this method computes number of ingoing ways to |junctionPoint| and fills |outgoingTurns|.
+  /// \note This method should not be called for |segmentRange| of fake edges.
+  /// So method |segmentRange.IsClear()| should return false.
   virtual void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & ingoingPoint,
                                 m2::PointD const & junctionPoint, size_t & ingoingCount,
                                 TurnCandidates & outgoingTurns) const = 0;

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -2,6 +2,8 @@
 
 #include "routing/turns.hpp"
 
+#include "base/math.hpp"
+
 #include "std/vector.hpp"
 
 namespace ftypes
@@ -41,12 +43,26 @@ struct TurnCandidate
   {
   }
 
-  bool operator==(TurnCandidate const & rhs) const
+  bool IsAlmostEqual(TurnCandidate const & rhs) const
   {
-    return angle == rhs.angle && m_segmentRange == rhs.m_segmentRange &&
+    double constexpr kEpsilon = 0.01;
+    return my::AlmostEqualAbs(angle, rhs.angle, kEpsilon) && m_segmentRange == rhs.m_segmentRange &&
            highwayClass == rhs.highwayClass;
   }
 };
+
+inline bool IsAlmostEqual(vector<TurnCandidate> const & lhs, vector<TurnCandidate> const & rhs)
+{
+  if (lhs.size() != rhs.size())
+    return false;
+
+  for (size_t i = 0; i < lhs.size(); ++i)
+  {
+    if (!lhs[i].IsAlmostEqual(rhs[i]))
+      return false;
+  }
+  return true;
+}
 
 struct TurnCandidates
 {
@@ -55,11 +71,11 @@ struct TurnCandidates
 
   explicit TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}
 
-  bool operator==(TurnCandidates const & rhs) const
+  bool IsAlmostEqual(TurnCandidates const & rhs) const
   {
-    return candidates == rhs.candidates && isCandidatesAngleValid == rhs.isCandidatesAngleValid;
+    return turns::IsAlmostEqual(candidates, rhs.candidates) &&
+           isCandidatesAngleValid == rhs.isCandidatesAngleValid;
   }
 };
-
 }  // namespace routing
 }  // namespace turns

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -40,6 +40,12 @@ struct TurnCandidate
     : angle(a), m_segmentRange(segmentRange), highwayClass(c)
   {
   }
+
+  bool operator==(TurnCandidate const & rhs) const
+  {
+    return angle == rhs.angle && m_segmentRange == rhs.m_segmentRange &&
+           highwayClass == rhs.highwayClass;
+  }
 };
 
 struct TurnCandidates
@@ -48,6 +54,11 @@ struct TurnCandidates
   bool isCandidatesAngleValid;
 
   explicit TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}
+
+  bool operator==(TurnCandidates const & rhs) const
+  {
+    return candidates == rhs.candidates && isCandidatesAngleValid == rhs.isCandidatesAngleValid;
+  }
 };
 
 }  // namespace routing

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -4,7 +4,7 @@
 
 #include "base/math.hpp"
 
-#include "std/vector.hpp"
+#include <vector>
 
 namespace ftypes
 {
@@ -51,7 +51,7 @@ struct TurnCandidate
   }
 };
 
-inline bool IsAlmostEqual(vector<TurnCandidate> const & lhs, vector<TurnCandidate> const & rhs)
+inline bool IsAlmostEqual(std::vector<TurnCandidate> const & lhs, std::vector<TurnCandidate> const & rhs)
 {
   if (lhs.size() != rhs.size())
     return false;
@@ -66,7 +66,7 @@ inline bool IsAlmostEqual(vector<TurnCandidate> const & lhs, vector<TurnCandidat
 
 struct TurnCandidates
 {
-  vector<TurnCandidate> candidates;
+  std::vector<TurnCandidate> candidates;
   bool isCandidatesAngleValid;
 
   explicit TurnCandidates(bool angleValid = true) : isCandidatesAngleValid(angleValid) {}

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -4,10 +4,12 @@
 
 #include "base/internal/message.hpp"
 
-#include "std/array.hpp"
-#include "std/utility.hpp"
-
+#include <algorithm>
+#include <array>
 #include <sstream>
+#include <utility>
+
+using namespace std;
 
 namespace
 {
@@ -53,8 +55,6 @@ static_assert(g_turnNames.size() == static_cast<size_t>(CarDirection::Count),
 
 namespace routing
 {
-using namespace std;
-
 // SegmentRange -----------------------------------------------------------------------------------
 SegmentRange::SegmentRange(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId,
                      bool forward)
@@ -276,9 +276,11 @@ bool ParseLanes(string lanesString, vector<SingleLaneInfo> & lanes)
   if (lanesString.empty())
     return false;
   lanes.clear();
-  transform(lanesString.begin(), lanesString.end(), lanesString.begin(), tolower);
-  lanesString.erase(remove_if(lanesString.begin(), lanesString.end(), isspace),
-                         lanesString.end());
+  transform(lanesString.begin(), lanesString.end(), lanesString.begin(),
+            [](string::value_type c) { return tolower(c); });
+  lanesString.erase(
+      remove_if(lanesString.begin(), lanesString.end(), [](char c) { return isspace(c); }),
+      lanesString.end());
 
   vector<string> SplitLanesStrings;
   SingleLaneInfo lane;

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -3,6 +3,8 @@
 #include "geometry/angles.hpp"
 
 #include "base/internal/message.hpp"
+#include "base/stl_helpers.hpp"
+#include "base/string_utils.hpp"
 
 #include <algorithm>
 #include <array>
@@ -93,9 +95,9 @@ void SegmentRange::Clear()
   m_forward = true;
 }
 
-bool SegmentRange::IsClear() const
+bool SegmentRange::IsEmpty() const
 {
-  return m_featureId == FeatureID() && m_startSegId == 0 && m_endSegId == 0 && m_forward;
+  return !m_featureId.IsValid() && m_startSegId == 0 && m_endSegId == 0 && m_forward;
 }
 
 FeatureID const & SegmentRange::GetFeature() const
@@ -115,7 +117,7 @@ string DebugPrint(SegmentRange const & segmentRange)
       << ", m_startSegId = " << segmentRange.m_startSegId
       << ", m_endSegId = " << segmentRange.m_endSegId
       << ", m_forward = " << segmentRange.m_forward
-      << ",  ]" << endl;
+      << "]" << endl;
   return out.str();
 }
 
@@ -276,11 +278,8 @@ bool ParseLanes(string lanesString, vector<SingleLaneInfo> & lanes)
   if (lanesString.empty())
     return false;
   lanes.clear();
-  transform(lanesString.begin(), lanesString.end(), lanesString.begin(),
-            [](string::value_type c) { return tolower(c); });
-  lanesString.erase(
-      remove_if(lanesString.begin(), lanesString.end(), [](char c) { return isspace(c); }),
-      lanesString.end());
+  strings::AsciiToLower(lanesString);
+  my::EraseIf(lanesString, [](char c) { return isspace(c); });
 
   vector<string> SplitLanesStrings;
   SingleLaneInfo lane;

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -89,6 +89,11 @@ void SegmentRange::Clear()
   m_forward = true;
 }
 
+bool SegmentRange::IsClear() const
+{
+  return m_featureId == FeatureID() && m_startSegId == 0 && m_endSegId == 0 && m_forward;
+}
+
 FeatureID const & SegmentRange::GetFeature() const
 {
   return m_featureId;
@@ -97,6 +102,17 @@ FeatureID const & SegmentRange::GetFeature() const
 bool SegmentRange::IsCorrect() const
 {
   return (m_forward && m_startSegId <= m_endSegId) || (!m_forward && m_endSegId <= m_startSegId);
+}
+
+string DebugPrint(SegmentRange const & segmentRange)
+{
+  stringstream out;
+  out << "SegmentRange [ m_featureId = " << DebugPrint(segmentRange.m_featureId)
+      << ", m_startSegId = " << segmentRange.m_startSegId
+      << ", m_endSegId = " << segmentRange.m_endSegId
+      << ", m_forward = " << segmentRange.m_forward
+      << ",  ]" << endl;
+  return out.str();
 }
 
 namespace turns

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -7,6 +7,8 @@
 #include "std/array.hpp"
 #include "std/utility.hpp"
 
+#include <sstream>
+
 namespace
 {
 using namespace routing::turns;
@@ -51,6 +53,8 @@ static_assert(g_turnNames.size() == static_cast<size_t>(CarDirection::Count),
 
 namespace routing
 {
+using namespace std;
+
 // SegmentRange -----------------------------------------------------------------------------------
 SegmentRange::SegmentRange(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId,
                      bool forward)

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -16,17 +16,19 @@ namespace routing
 /// and a direction.
 struct SegmentRange
 {
+  friend string DebugPrint(SegmentRange const & segmentRange);
+
   SegmentRange() = default;
   SegmentRange(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId, bool forward);
   bool operator==(SegmentRange const & rh) const;
   bool operator<(SegmentRange const & rh) const;
   void Clear();
+  bool IsClear() const;
   FeatureID const & GetFeature() const;
   /// \returns true if the instance of SegmentRange is correct.
   bool IsCorrect() const;
 
 private:
-
   FeatureID m_featureId;
   // Note. If SegmentRange represents two directional feature |m_endSegId| is greater
   // than |m_startSegId| if |m_forward| == true.
@@ -34,6 +36,8 @@ private:
   uint32_t m_endSegId = 0;   // The last segment index of SegmentRange.
   bool m_forward = true;     // Segment direction in |m_featureId|.
 };
+
+string DebugPrint(SegmentRange const & segmentRange);
 
 namespace turns
 {

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -23,7 +23,7 @@ struct SegmentRange
   bool operator==(SegmentRange const & rh) const;
   bool operator<(SegmentRange const & rh) const;
   void Clear();
-  bool IsClear() const;
+  bool IsEmpty() const;
   FeatureID const & GetFeature() const;
   /// \returns true if the instance of SegmentRange is correct.
   bool IsCorrect() const;
@@ -36,8 +36,6 @@ private:
   uint32_t m_endSegId = 0;   // The last segment index of SegmentRange.
   bool m_forward = true;     // Segment direction in |m_featureId|.
 };
-
-std::string DebugPrint(SegmentRange const & segmentRange);
 
 namespace turns
 {
@@ -136,7 +134,7 @@ std::string DebugPrint(SingleLaneInfo const & singleLaneInfo);
 struct TurnItem
 {
   TurnItem()
-      : m_index(numeric_limits<uint32_t>::max()),
+      : m_index(std::numeric_limits<uint32_t>::max()),
         m_turn(CarDirection::None),
         m_exitNum(0),
         m_keepAnyway(false),
@@ -164,12 +162,12 @@ struct TurnItem
            m_pedestrianTurn == rhs.m_pedestrianTurn;
   }
 
-  uint32_t m_index;               /*!< Index of point on route polyline (number of segment + 1). */
-  CarDirection m_turn;            /*!< The turn instruction of the TurnItem */
-  vector<SingleLaneInfo> m_lanes; /*!< Lane information on the edge before the turn. */
-  uint32_t m_exitNum;             /*!< Number of exit on roundabout. */
-  std::string m_sourceName;       /*!< Name of the street which the ingoing edge belongs to */
-  std::string m_targetName;       /*!< Name of the street which the outgoing edge belongs to */
+  uint32_t m_index;                    /*!< Index of point on route polyline (number of segment + 1). */
+  CarDirection m_turn;                 /*!< The turn instruction of the TurnItem */
+  std::vector<SingleLaneInfo> m_lanes; /*!< Lane information on the edge before the turn. */
+  uint32_t m_exitNum;                  /*!< Number of exit on roundabout. */
+  std::string m_sourceName;            /*!< Name of the street which the ingoing edge belongs to */
+  std::string m_targetName;            /*!< Name of the street which the outgoing edge belongs to */
   /*!
    * \brief m_keepAnyway is true if the turn shall not be deleted
    * and shall be demonstrated to an end user.
@@ -232,7 +230,7 @@ bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, CarDirection t);
  * Note 1: if @lanesString is empty returns false.
  * Note 2: @laneString is passed by value on purpose. It'll be used(changed) in the method.
  */
-bool ParseLanes(std::string lanesString, vector<SingleLaneInfo> & lanes);
+bool ParseLanes(std::string lanesString, std::vector<SingleLaneInfo> & lanes);
 void SplitLanes(std::string const & lanesString, char delimiter, std::vector<std::string> & lanes);
 bool ParseSingleLane(std::string const & laneString, char delimiter, TSingleLane & lane);
 

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -4,10 +4,10 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/initializer_list.hpp"
-#include "std/limits.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <initializer_list>
+#include <limits>
+#include <string>
+#include <vector>
 
 namespace routing
 {
@@ -16,7 +16,7 @@ namespace routing
 /// and a direction.
 struct SegmentRange
 {
-  friend string DebugPrint(SegmentRange const & segmentRange);
+  friend std::string DebugPrint(SegmentRange const & segmentRange);
 
   SegmentRange() = default;
   SegmentRange(FeatureID const & featureId, uint32_t startSegId, uint32_t endSegId, bool forward);
@@ -37,7 +37,7 @@ private:
   bool m_forward = true;     // Segment direction in |m_featureId|.
 };
 
-string DebugPrint(SegmentRange const & segmentRange);
+std::string DebugPrint(SegmentRange const & segmentRange);
 
 namespace turns
 {
@@ -80,7 +80,7 @@ enum class CarDirection
   Count  /**< This value is used for internals only. */
 };
 
-string DebugPrint(CarDirection const l);
+std::string DebugPrint(CarDirection const l);
 
 /*!
  * \warning The values of PedestrianDirectionType shall be synchronized with values in java
@@ -96,7 +96,7 @@ enum class PedestrianDirection
   Count  /**< This value is used for internals only. */
 };
 
-string DebugPrint(PedestrianDirection const l);
+std::string DebugPrint(PedestrianDirection const l);
 
 /*!
  * \warning The values of LaneWay shall be synchronized with values of LaneWay enum in java.
@@ -117,9 +117,9 @@ enum class LaneWay
   Count  /**< This value is used for internals only. */
 };
 
-string DebugPrint(LaneWay const l);
+std::string DebugPrint(LaneWay const l);
 
-typedef vector<LaneWay> TSingleLane;
+typedef std::vector<LaneWay> TSingleLane;
 
 struct SingleLaneInfo
 {
@@ -127,11 +127,11 @@ struct SingleLaneInfo
   bool m_isRecommended = false;
 
   SingleLaneInfo() = default;
-  SingleLaneInfo(initializer_list<LaneWay> const & l) : m_lane(l) {}
+  SingleLaneInfo(std::initializer_list<LaneWay> const & l) : m_lane(l) {}
   bool operator==(SingleLaneInfo const & other) const;
 };
 
-string DebugPrint(SingleLaneInfo const & singleLaneInfo);
+std::string DebugPrint(SingleLaneInfo const & singleLaneInfo);
 
 struct TurnItem
 {
@@ -168,8 +168,8 @@ struct TurnItem
   CarDirection m_turn;            /*!< The turn instruction of the TurnItem */
   vector<SingleLaneInfo> m_lanes; /*!< Lane information on the edge before the turn. */
   uint32_t m_exitNum;             /*!< Number of exit on roundabout. */
-  string m_sourceName;            /*!< Name of the street which the ingoing edge belongs to */
-  string m_targetName;            /*!< Name of the street which the outgoing edge belongs to */
+  std::string m_sourceName;       /*!< Name of the street which the ingoing edge belongs to */
+  std::string m_targetName;       /*!< Name of the street which the outgoing edge belongs to */
   /*!
    * \brief m_keepAnyway is true if the turn shall not be deleted
    * and shall be demonstrated to an end user.
@@ -182,7 +182,7 @@ struct TurnItem
   PedestrianDirection m_pedestrianTurn;
 };
 
-string DebugPrint(TurnItem const & turnItem);
+std::string DebugPrint(TurnItem const & turnItem);
 
 struct TurnItemDist
 {
@@ -196,9 +196,9 @@ struct TurnItemDist
   double m_distMeters = 0.0;
 };
 
-string DebugPrint(TurnItemDist const & turnItemDist);
+std::string DebugPrint(TurnItemDist const & turnItemDist);
 
-string const GetTurnString(CarDirection turn);
+std::string const GetTurnString(CarDirection turn);
 
 bool IsLeftTurn(CarDirection t);
 bool IsRightTurn(CarDirection t);
@@ -232,9 +232,9 @@ bool IsLaneWayConformedTurnDirectionApproximately(LaneWay l, CarDirection t);
  * Note 1: if @lanesString is empty returns false.
  * Note 2: @laneString is passed by value on purpose. It'll be used(changed) in the method.
  */
-bool ParseLanes(string lanesString, vector<SingleLaneInfo> & lanes);
-void SplitLanes(string const & lanesString, char delimiter, vector<string> & lanes);
-bool ParseSingleLane(string const & laneString, char delimiter, TSingleLane & lane);
+bool ParseLanes(std::string lanesString, vector<SingleLaneInfo> & lanes);
+void SplitLanes(std::string const & lanesString, char delimiter, std::vector<std::string> & lanes);
+bool ParseSingleLane(std::string const & laneString, char delimiter, TSingleLane & lane);
 
 /*!
  * \returns pi minus angle from vector [junctionPoint, ingoingPoint]

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -539,7 +539,7 @@ CarDirection IntermediateDirection(const double angle)
 
 void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnItem & turn)
 {
-  if (!turnInfo.IsSegmentsValid())
+  if (!turnInfo.IsSegmentsValid() || turnInfo.m_ingoing.m_segmentRange.IsClear())
     return;
 
   ASSERT(!turnInfo.m_ingoing.m_path.empty(), ());

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -539,7 +539,7 @@ CarDirection IntermediateDirection(const double angle)
 
 void GetTurnDirection(IRoutingResult const & result, TurnInfo & turnInfo, TurnItem & turn)
 {
-  if (!turnInfo.IsSegmentsValid() || turnInfo.m_ingoing.m_segmentRange.IsClear())
+  if (!turnInfo.IsSegmentsValid() || turnInfo.m_ingoing.m_segmentRange.IsEmpty())
     return;
 
   ASSERT(!turnInfo.m_ingoing.m_path.empty(), ());


### PR DESCRIPTION
Исправлен assert, который возникал при прокладке маршрута в debug режиме. Он проверял, что наборы сегментов (segment range) между joint уникальны в маршруте.

Данный assert возникал в двух случаях:

1. Проблема. После появления возможности прокладывать маршрут через промежуточные точки стало возможным прохождения маршрута несколько раз через одни и те же сегменты графа дорог.

Решение. Сейчас мы проверяем (в ASSERT), что если маршрут проходит через один и тот же segment range несколько раз, то соответствующие ему смежные дуги совпадают.

2. Проблема. В маршруте содержится несколько fake-вых дуг, которым соответствует SegmentRange, созданный конструктором по умолчанию. При для разных fake-вых дуг формируются отличные друг от друга |adjacentEdges| (См. BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap()).

Решение. Ранее, в случае fake-вых дуг, в |m_adjacentEdges| оставалась key/value, которая соответствовала первому по порядку SegmentRange, который соответствовал файковой дуге. Остальный fake-вые дуги не добавлялись. Срабатывал assert. Теперь мы не заполняем |m_adjacentEdges| в случае fake-вых дуг. Что правильно. Прежнее поведение могло иногда позволить сформировать первый маневр, в месте где файковая фича идущая от текущей позиции (от старта) по прямой пересекается с реальной фичей. Однако данный маневр был бесполезен (и мешал), поскольку на реальную фичу (на дорогу) мы обычно выезжаем не по прямой, а по доступным дорогам, не отмеченным на карте.

По результатам данного PR routing_integration_tests стали проходит и в debug режиме. Деградации по кол-ву сломанных routing_integration_tests нет.

@tatiana-kondakova @ygorshenin @igrechuhin PTAL