### PR TITLE
[types] Add leisure=resort

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -1199,3 +1199,4 @@ tourism|theme_park;1198;
 tourism|wilderness_hut;1199;
 sponsored|cian;1200;
 sponsored|holiday;1201;
+leisure|resort;1202;tourism|resort

--- a/data/types.txt
+++ b/data/types.txt
@@ -1199,3 +1199,4 @@ tourism|theme_park
 tourism|wilderness_hut
 sponsored|cian
 sponsored|holiday
+tourism|resort


### PR DESCRIPTION
Простой фикс, добавляющий на карту 3700 прибрежных гостиниц, отмеченных правильным тегом `leisure=resort`. У нас, почему-то, был неправильный `tourism=resort`.