### PR TITLE
[build] Fixed configure.sh.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -12,9 +12,9 @@ PRIVATE_PUSHWOOSH_PROPERTIES="$BASE_PATH/android/pushwoosh.properties"
 SAVED_PRIVATE_REPO_FILE="$BASE_PATH/.private_repository_url"
 TMP_REPO_DIR="$BASE_PATH/.tmp.private.repo"
 
-if [ "$(git rev-parse --show-toplevel)" != "$PWD" ]; then
+if [ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]; then
   echo "Please run this script from the root repository folder."
-  exit -1
+  exit 1
 fi
 
 if [ -f "$SAVED_PRIVATE_REPO_FILE" ]; then


### PR DESCRIPTION
Current version doesn't work when repository is placed on a secondary hdd, and symlinked from the original hdd. For example, on my laptop:
```bash
y@lambda:~/coding/omim$ pwd
/home/y/coding/omim
y@lambda:~/coding/omim$ pwd -P
/media/linux-secondary-hdd/y/coding/omim
```
I.e. pwd shows logical path, but we need physical path here (what git rev-parse returns).