### PR TITLE
Special messages for errors in transit routing.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
+++ b/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
@@ -27,6 +27,9 @@ class ResultCodesHelper
   private static final int INTERNAL_ERROR = 10;
   private static final int FILE_TOO_OLD = 11;
   private static final int INTERMEDIATE_POINT_NOT_FOUND = 12;
+  private static final int TRANSIT_ROUTE_NOT_FOUND_NO_NETWORK = 13;
+  private static final int TRANSIT_ROUTE_NOT_FOUND_TOO_LONG_PEDESTRIAN = 14;
+  private static final int ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR = 15;
 
   static Pair<String, String> getDialogTitleSubtitle(int errorCode, int missingCount)
   {
@@ -75,6 +78,9 @@ class ResultCodesHelper
       messages.add(resources.getString(R.string.downloader_mwm_migration_dialog));
       break;
     case ROUTE_NOT_FOUND:
+    case TRANSIT_ROUTE_NOT_FOUND_NO_NETWORK:
+    case TRANSIT_ROUTE_NOT_FOUND_TOO_LONG_PEDESTRIAN:
+    case ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR:
       if (missingCount == 0)
       {
         titleRes = R.string.dialog_routing_unable_locate_route;

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -72,6 +72,9 @@
   case routing::IRouter::EndPointNotFound: return [MWMDefaultAlert endPointNotFoundAlert];
   case routing::IRouter::PointsInDifferentMWM: return [MWMDefaultAlert pointsInDifferentMWMAlert];
   case routing::IRouter::RouteNotFound:
+  case routing::IRouter::TransitRouteNotFoundNoNetwork:
+  case routing::IRouter::TransitRouteNotFoundTooLongPedestrian:
+  case routing::IRouter::RouteNotFoundRedressRouteError:
   case routing::IRouter::InconsistentMWMandRoute: return [MWMDefaultAlert routeNotFoundAlert];
   case routing::IRouter::RouteFileNotExist:
   case routing::IRouter::FileTooOld: return [MWMDefaultAlert routeFileNotExistAlert];

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -37,7 +37,7 @@ string ToString(IRouter::ResultCode code)
   case IRouter::NeedMoreMaps: return "NeedMoreMaps";
   case IRouter::FileTooOld: return "FileTooOld";
   case IRouter::IntermediatePointNotFound: return "IntermediatePointNotFound";
-  case IRouter::TransitRouteNotFoundNoNetwork: return "RouteNotFoundNoTransitNetwork";
+  case IRouter::TransitRouteNotFoundNoNetwork: return "TransitRouteNotFoundNoNetwork";
   case IRouter::TransitRouteNotFoundTooLongPedestrian: return "TransitRouteNotFoundTooLongPedestrian";
   case IRouter::RouteNotFoundRedressRouteError: return "RouteNotFoundRedressRouteError";
   }

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -37,6 +37,9 @@ string ToString(IRouter::ResultCode code)
   case IRouter::NeedMoreMaps: return "NeedMoreMaps";
   case IRouter::FileTooOld: return "FileTooOld";
   case IRouter::IntermediatePointNotFound: return "IntermediatePointNotFound";
+  case IRouter::TransitRouteNotFoundNoNetwork: return "RouteNotFoundNoTransitNetwork";
+  case IRouter::TransitRouteNotFoundTooLongPedestrian: return "TransitRouteNotFoundTooLongPedestrian";
+  case IRouter::RouteNotFoundRedressRouteError: return "RouteNotFoundRedressRouteError";
   }
 
   string const result = "Unknown IRouter::ResultCode:" + to_string(static_cast<int>(code));
@@ -226,6 +229,15 @@ void AsyncRouter::LogCode(IRouter::ResultCode code, double const elapsedSec)
       break;
     case IRouter::IntermediatePointNotFound:
       LOG(LWARNING, ("Can't find intermediate point node"));
+      break;
+    case IRouter::TransitRouteNotFoundNoNetwork:
+      LOG(LWARNING, ("Transit route not found because no transit network in route point mwm"));
+      break;
+    case IRouter::TransitRouteNotFoundTooLongPedestrian:
+      LOG(LWARNING, ("Transit route not found because pedestrian way is too long"));
+      break;
+    case IRouter::RouteNotFoundRedressRouteError:
+      LOG(LWARNING, ("Route not found because a redress route error"));
       break;
   }
 }

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -17,6 +17,12 @@ Segment GetReverseSegment(Segment const & segment)
   return Segment(segment.GetMwmId(), segment.GetFeatureId(), segment.GetSegmentIdx(),
                  !segment.IsForward());
 }
+
+void FillNumMwmIds(set<Segment> const & segments, set<NumMwmId> & mwms)
+{
+  for (auto const & s : segments)
+    mwms.insert(s.GetMwmId());
+}
 }  // namespace
 
 namespace routing
@@ -121,11 +127,22 @@ m2::PointD const & IndexGraphStarter::GetPoint(Segment const & segment, bool fro
 set<NumMwmId> IndexGraphStarter::GetMwms() const
 {
   set<NumMwmId> mwms;
-  for (auto const & s : m_start.m_real)
-    mwms.insert(s.GetMwmId());
-  for (auto const & s : m_finish.m_real)
-    mwms.insert(s.GetMwmId());
+  FillNumMwmIds(m_start.m_real, mwms);
+  FillNumMwmIds(m_finish.m_real, mwms);
+  return mwms;
+}
 
+set<NumMwmId> IndexGraphStarter::GetStartMwms() const
+{
+  set<NumMwmId> mwms;
+  FillNumMwmIds(m_start.m_real, mwms);
+  return mwms;
+}
+
+set<NumMwmId> IndexGraphStarter::GetFinishMwms() const
+{
+  set<NumMwmId> mwms;
+  FillNumMwmIds(m_finish.m_real, mwms);
   return mwms;
 }
 

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -74,6 +74,8 @@ public:
   }
 
   std::set<NumMwmId> GetMwms() const;
+  std::set<NumMwmId> GetStartMwms() const;
+  std::set<NumMwmId> GetFinishMwms() const;
 
   // Checks whether |weight| meets non-pass-through crossing restrictions according to placement of
   // start and finish in pass-through/non-pass-through area and number of non-pass-through crosses.

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -80,7 +80,6 @@ private:
                                        m2::PointD const & startDirection,
                                        RouterDelegate const & delegate, Route & route);
   IRouter::ResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
-                                        Segment const & startSegment, Segment const & finishSegment,
                                         RouterDelegate const & delegate, IndexGraphStarter & graph,
                                         std::vector<Segment> & subroute);
 
@@ -114,7 +113,7 @@ private:
 
   bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
   bool DoesTransitSectionExist(NumMwmId numMwmId) const;
-  IRouter::ResultCode ConvertTransitResult(NumMwmId startMwmId, NumMwmId finalMwmId,
+  IRouter::ResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,
                                            IRouter::ResultCode resultCode) const;
 
   template <typename Graph>
@@ -130,18 +129,17 @@ private:
 
   template <typename Graph>
   IRouter::ResultCode FindPath(
-      typename AStarAlgorithm<Graph>::Params & params, NumMwmId startMwmId, NumMwmId finalMwmId,
+      typename AStarAlgorithm<Graph>::Params & params, std::set<NumMwmId> const & mwmIds,
       RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult) const
   {
     AStarAlgorithm<Graph> algorithm;
     if (params.m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
     {
-      return ConvertTransitResult(startMwmId, finalMwmId,
+      return ConvertTransitResult(mwmIds,
                                   ConvertResult<Graph>(algorithm.FindPath(params, routingResult)));
     }
     return ConvertTransitResult(
-        startMwmId, finalMwmId,
-        ConvertResult<Graph>(algorithm.FindPathBidirectional(params, routingResult)));
+        mwmIds, ConvertResult<Graph>(algorithm.FindPathBidirectional(params, routingResult)));
   }
 
   VehicleType m_vehicleType;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "routing/base/astar_algorithm.hpp"
+#include "routing/base/routing_result.hpp"
+
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/directions_engine.hpp"
 #include "routing/edge_estimator.hpp"
@@ -77,7 +80,7 @@ private:
                                        m2::PointD const & startDirection,
                                        RouterDelegate const & delegate, Route & route);
   IRouter::ResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
-                                        Segment const & startSegment,
+                                        Segment const & startSegment, Segment const & finishSegment,
                                         RouterDelegate const & delegate, IndexGraphStarter & graph,
                                         std::vector<Segment> & subroute);
 
@@ -110,6 +113,36 @@ private:
                                    Route & route) const;
 
   bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
+  bool DoesTransitSectionExist(NumMwmId numMwmId) const;
+  IRouter::ResultCode ConvertTransitResult(NumMwmId startMwmId, NumMwmId finalMwmId,
+                                           IRouter::ResultCode resultCode) const;
+
+  template <typename Graph>
+  IRouter::ResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const
+  {
+    switch (result)
+    {
+    case AStarAlgorithm<Graph>::Result::NoPath: return IRouter::RouteNotFound;
+    case AStarAlgorithm<Graph>::Result::Cancelled: return IRouter::Cancelled;
+    case AStarAlgorithm<Graph>::Result::OK: return IRouter::NoError;
+    }
+  }
+
+  template <typename Graph>
+  IRouter::ResultCode FindPath(
+      typename AStarAlgorithm<Graph>::Params & params, NumMwmId startMwmId, NumMwmId finalMwmId,
+      RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult) const
+  {
+    AStarAlgorithm<Graph> algorithm;
+    if (params.m_graph.GetMode() == WorldGraph::Mode::LeapsOnly)
+    {
+      return ConvertTransitResult(startMwmId, finalMwmId,
+                                  ConvertResult<Graph>(algorithm.FindPath(params, routingResult)));
+    }
+    return ConvertTransitResult(
+        startMwmId, finalMwmId,
+        ConvertResult<Graph>(algorithm.FindPathBidirectional(params, routingResult)));
+  }
 
   VehicleType m_vehicleType;
   bool m_loadAltitudes;

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -59,6 +59,9 @@ public:
     InternalError = 10,
     FileTooOld = 11,
     IntermediatePointNotFound = 12,
+    TransitRouteNotFoundNoNetwork = 13,
+    TransitRouteNotFoundTooLongPedestrian = 14,
+    RouteNotFoundRedressRouteError = 15,
   };
 
   virtual ~IRouter() {}


### PR DESCRIPTION
Добавлены 3 новых сообщения об ошибках при прокладке маршрута.

RouteNotFoundRedressRouteError - маршрут был проложен, но пост обработка не прошла. Его можно рассматривать в клиенте, как RouteNotFound.

TransitRouteNotFoundTooLongPedestrian - маршрут общественным транспортом не проложен, поскольку пешеходная часть слишком длинная.

TransitRouteNotFoundNoNetwork - маршрут общественным транспортом не проложен, поскольку в области старта, финиша или пром точки нет данных об общественном транспорте.

Идея в следующем. Если возникли проблемы пост обработки маршрута, то возвращается ошибка RouteNotFoundRedressRouteError в любом случае. Можно показать стандартное сообщение, что маршрут не проложен при любом типе маршрутизатора.

Если же мы прокладываем маршрут общественным транспортом, то могут возникнуть сообщения: TransitRouteNotFoundNoNetwork если маршрут не проложен, и mwm в которых находятся старт, финиш или пром точки не содержат информации об общественном транспорте.

Если же transit маршрут не проложен, не возникло ошибки пост обработки и mwm содержат информацию о transit, то показываем возвращаем TransitRouteNotFoundTooLongPedestrian

@tatiana-kondakova @alexzatsepin @Ignatych PTAL