### PR TITLE
[generator] Fix paths for search index builder

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -158,6 +158,9 @@ int main(int argc, char ** argv)
   std::string const path =
       FLAGS_data_path.empty() ? pl.WritableDir() : my::AddSlashIfNeeded(FLAGS_data_path);
 
+  // So that stray GetWritablePathForFile calls do not crash the generator.
+  pl.SetWritableDirForTests(path);
+
   feature::GenerateInfo genInfo;
   genInfo.m_intermediateDir = FLAGS_intermediate_data_path.empty() ? path
                             : my::AddSlashIfNeeded(FLAGS_intermediate_data_path);

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -396,16 +396,9 @@ bool BuildSearchIndexFromDataFile(string const & filename, bool forceRebuild)
   if (readContainer.IsExist(SEARCH_INDEX_FILE_TAG) && !forceRebuild)
     return true;
 
-  string mwmName = filename;
-  my::GetNameFromFullPath(mwmName);
-  my::GetNameWithoutExt(mwmName);
-
-  string const indexFilePath = platform.WritablePathForFile(
-        mwmName + "." SEARCH_INDEX_FILE_TAG EXTENSION_TMP);
+  string const indexFilePath = filename + "." + SEARCH_INDEX_FILE_TAG EXTENSION_TMP;
+  string const addrFilePath = filename + "." + SEARCH_ADDRESS_FILE_TAG EXTENSION_TMP;
   MY_SCOPE_GUARD(indexFileGuard, bind(&FileWriter::DeleteFileX, indexFilePath));
-
-  string const addrFilePath = platform.WritablePathForFile(
-        mwmName + "." SEARCH_ADDRESS_FILE_TAG EXTENSION_TMP);
   MY_SCOPE_GUARD(addrFileGuard, bind(&FileWriter::DeleteFileX, addrFilePath));
 
   try


### PR DESCRIPTION
Сложная логика вычисления пути ко временным файлам начала обрушивать генератор вот с такой ошибкой:

```
LOG TID(1) INFO      45.3044 generator_tool/generator_tool.cpp:307 main() Generating search index for /opt/mapsme/mwm/180122/Belarus_Minsk Region.mwm
LOG TID(1) ERROR     45.3047 generator/search_index_builder.cpp:459 BuildSearchIndexFromDataFile() Error writing index file: /Belarus_Minsk Region.sdx.tmp; Write truncate; Permission denied
LOG TID(1) WARNING   45.3047 internal/file_data.cpp:232 CheckFileOperationResult() File operation error for file: /Belarus_Minsk Region.addr.tmp - No such file or directory
LOG TID(1) WARNING   45.3048 internal/file_data.cpp:232 CheckFileOperationResult() File operation error for file: /Belarus_Minsk Region.sdx.tmp - No such file or directory
LOG TID(1) CRITICAL  45.3048 generator_tool/generator_tool.cpp:310 main() Error generating search index.
```

Причина в том, что `m_writableDir` у платформы на линуксе пустой, поэтому файлы пытаемся создавать в корне. При этом, `filename` в генераторе уже содержит полный путь — см. первую строчку лога. Здесь я упростил алгоритм создания имени временного файла и установил WritableDir в generator_tool, на всякий случай. Мы точно так же делаем, например, в `qt/main.cpp`. Метод `GetWritablePathForFile` используется ещё в одном месте генератора индексов, чуть выше, но там никаких переменных из генератора нет, поэтому чем его заменить — хз.

Пожалуйста, помёржите как можно скорее: сборка стоит.