### PR TITLE
[cmake] Main CMakeLists.txt refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,11 @@ project(omim C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 
-# Set target platform:
-function(omim_set_platform_var PLATFORM_VAR pattern)
-  set(${PLATFORM_VAR} FALSE PARENT_SCOPE)
+get_filename_component(OMIM_ROOT . ABSOLUTE)
 
-  if (NOT PLATFORM)
-    if (${ARGN})
-      list(GET ARGN 0 default_case)
-      if (${default_case})
-        set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
-        message("Setting ${PLATFORM_VAR} to true")
-      endif()
-    endif()
-  else()
-    message("Platform: ${PLATFORM}")
-    if (${PLATFORM} MATCHES ${pattern})
-      set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${OMIM_ROOT}/cmake")
+
+include(OmimHelpers)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX_DETECTED TRUE)
@@ -130,8 +116,6 @@ endif()
 
 # Find installed packages
 
-get_filename_component(OMIM_ROOT . ABSOLUTE)
-
 find_package(Threads)
 
 set(Boost_USE_MULTITHREADED ON)
@@ -169,13 +153,6 @@ if (PYBINDINGS)
   find_package(PythonLibs ${PYTHON_VERSION} REQUIRED)
   include_directories(${PYTHON_INCLUDE_DIRS})
 endif()
-
-macro(find_qt5_desktop_package package)
-  find_package(${package})
-  if (NOT ${package}_FOUND)
-    message(FATAL_ERROR "Can't find ${package}, consider to set SKIP_DESKTOP if you don't need desktop app")
-  endif()
-endmacro()
 
 if (NOT PLATFORM_IPHONE AND NOT PLATFORM_ANDROID)
   find_package(Qt5Core)
@@ -219,121 +196,6 @@ include_directories(
   ${Qt5Network_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
-
-# Functions for using in subdirectories
-function(omim_add_executable executable)
-  add_executable(${executable} ${ARGN})
-  if (USE_ASAN)
-    target_link_libraries(${executable} "-fsanitize=address" "-fno-omit-frame-pointer")
-  endif()
-  if (USE_TSAN)
-    target_link_libraries(${executable} "-fsanitize=thread" "-fno-omit-frame-pointer")
-  endif()
-  if (USE_PPROF)
-    target_link_libraries(${executable} "-lprofiler")
-  endif()
-endfunction()
-
-function(omim_add_test executable)
-  if (NOT SKIP_TESTS)
-    omim_add_executable(${executable} ${ARGN} ${OMIM_ROOT}/testing/testingmain.cpp)
-  endif()
-endfunction()
-
-function(omim_add_test_subdirectory subdir)
-  if (NOT SKIP_TESTS)
-    add_subdirectory(${subdir})
-  else()
-    message("SKIP_TESTS: Skipping subdirectory ${subdir}")
-  endif()
-endfunction()
-
-function(omim_add_pybindings_subdirectory subdir)
-  if (PYBINDINGS)
-    add_subdirectory(${subdir})
-  else()
-    message("Skipping pybindings subdirectory ${subdir}")
-  endif()
-endfunction()
-
-function(omim_link_platform_deps target)
-  if ("${ARGN}" MATCHES "platform")
-    if (PLATFORM_MAC)
-      target_link_libraries(
-        ${target}
-        "-framework CFNetwork"
-        "-framework Foundation"
-        "-framework IOKit"
-        "-framework SystemConfiguration"
-      )
-    endif()
-  endif()
-endfunction()
-
-function(omim_link_libraries target)
-  if (TARGET ${target})
-    target_link_libraries(${target} ${ARGN} ${CMAKE_THREAD_LIBS_INIT})
-    omim_link_platform_deps(${target} ${ARGN})
-  else()
-    message("~> Skipping linking the libraries to the target ${target} as it does not exist")
-  endif()
-endfunction()
-
-function(append VAR)
-  set(${VAR} ${${VAR}} ${ARGN} PARENT_SCOPE)
-endfunction()
-
-function(link_opengl target)
-    if (PLATFORM_MAC)
-      omim_link_libraries(
-        ${target}
-        "-framework OpenGL"
-      )
-    endif()
-
-    if (PLATFORM_LINUX)
-      omim_link_libraries(
-        ${target}
-        ${OPENGL_gl_LIBRARY}
-      )
-    endif()
-endfunction()
-
-function(link_qt5_core target)
-  omim_link_libraries(
-    ${target}
-    ${Qt5Core_LIBRARIES}
-  )
-
-  if (PLATFORM_MAC)
-    omim_link_libraries(
-      ${target}
-      "-framework IOKit"
-    )
-  endif()
-endfunction()
-
-function(link_qt5_network target)
-  omim_link_libraries(
-    ${target}
-    ${Qt5Network_LIBRARIES}
-  )
-endfunction()
-
-function(link_qt5_webengine target)
-  omim_link_libraries(
-    ${target}
-    ${Qt5WebEngineWidgets_LIBRARIES}
-  )
-endfunction()
-
-function(add_clang_compile_options)
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(${ARGV})
-  endif()
-endfunction()
-
-# End of functions for subdirectories
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -1,0 +1,139 @@
+# Function for setting target platform:
+function(omim_set_platform_var PLATFORM_VAR pattern)
+  set(${PLATFORM_VAR} FALSE PARENT_SCOPE)
+
+  if (NOT PLATFORM)
+    if (${ARGN})
+      list(GET ARGN 0 default_case)
+      if (${default_case})
+        set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
+        message("Setting ${PLATFORM_VAR} to true")
+      endif()
+    endif()
+  else()
+    message("Platform: ${PLATFORM}")
+    if (${PLATFORM} MATCHES ${pattern})
+      set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
+macro(find_qt5_desktop_package package)
+  find_package(${package})
+  if (NOT ${package}_FOUND)
+    message(FATAL_ERROR "Can't find ${package}, consider to set SKIP_DESKTOP if you don't need desktop app")
+  endif()
+endmacro()
+
+# Functions for using in subdirectories
+function(omim_add_executable executable)
+  add_executable(${executable} ${ARGN})
+  if (USE_ASAN)
+    target_link_libraries(${executable} "-fsanitize=address" "-fno-omit-frame-pointer")
+  endif()
+  if (USE_TSAN)
+    target_link_libraries(${executable} "-fsanitize=thread" "-fno-omit-frame-pointer")
+  endif()
+  if (USE_PPROF)
+    target_link_libraries(${executable} "-lprofiler")
+  endif()
+endfunction()
+
+function(omim_add_test executable)
+  if (NOT SKIP_TESTS)
+    omim_add_executable(${executable} ${ARGN} ${OMIM_ROOT}/testing/testingmain.cpp)
+  endif()
+endfunction()
+
+function(omim_add_test_subdirectory subdir)
+  if (NOT SKIP_TESTS)
+    add_subdirectory(${subdir})
+  else()
+    message("SKIP_TESTS: Skipping subdirectory ${subdir}")
+  endif()
+endfunction()
+
+function(omim_add_pybindings_subdirectory subdir)
+  if (PYBINDINGS)
+    add_subdirectory(${subdir})
+  else()
+    message("Skipping pybindings subdirectory ${subdir}")
+  endif()
+endfunction()
+
+function(omim_link_platform_deps target)
+  if ("${ARGN}" MATCHES "platform")
+    if (PLATFORM_MAC)
+      target_link_libraries(
+        ${target}
+        "-framework CFNetwork"
+        "-framework Foundation"
+        "-framework IOKit"
+        "-framework SystemConfiguration"
+      )
+    endif()
+  endif()
+endfunction()
+
+function(omim_link_libraries target)
+  if (TARGET ${target})
+    target_link_libraries(${target} ${ARGN} ${CMAKE_THREAD_LIBS_INIT})
+    omim_link_platform_deps(${target} ${ARGN})
+  else()
+    message("~> Skipping linking the libraries to the target ${target} as it does not exist")
+  endif()
+endfunction()
+
+function(append VAR)
+  set(${VAR} ${${VAR}} ${ARGN} PARENT_SCOPE)
+endfunction()
+
+function(link_opengl target)
+    if (PLATFORM_MAC)
+      omim_link_libraries(
+        ${target}
+        "-framework OpenGL"
+      )
+    endif()
+
+    if (PLATFORM_LINUX)
+      omim_link_libraries(
+        ${target}
+        ${OPENGL_gl_LIBRARY}
+      )
+    endif()
+endfunction()
+
+function(link_qt5_core target)
+  omim_link_libraries(
+    ${target}
+    ${Qt5Core_LIBRARIES}
+  )
+
+  if (PLATFORM_MAC)
+    omim_link_libraries(
+      ${target}
+      "-framework IOKit"
+    )
+  endif()
+endfunction()
+
+function(link_qt5_network target)
+  omim_link_libraries(
+    ${target}
+    ${Qt5Network_LIBRARIES}
+  )
+endfunction()
+
+function(link_qt5_webengine target)
+  omim_link_libraries(
+    ${target}
+    ${Qt5WebEngineWidgets_LIBRARIES}
+  )
+endfunction()
+
+function(add_clang_compile_options)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(${ARGV})
+  endif()
+endfunction()


### PR DESCRIPTION
В главном CMakeLists.txt файле проекта накопилось 13 функций и 1 макрос. Для улучшения его читабельности предлагаю вынести все функции в отдельный файл ```cmake/OmimHelpers.cmake```, который подключается вот так:
```
include(OmimHelpers)
```