### PR TITLE
Routing integration test RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest fixing.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -460,8 +460,7 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
 
-// Test case: a route goes in Moscow along Leningradskiy Prpt (towards city center)
-// and makes u-turn. A only one turn instruction (turn left) shell be generated.
+// Test case: a route goes in Moscow along Leningradskiy Prpt (towards city center).
 UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
 {
   TRouteResult const routeResult =
@@ -473,8 +472,11 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnLeft, CarDirection::TurnSlightLeft});
+  integration::GetNthTurn(route, 1).TestValid().TestOneOfDirections(
+      {CarDirection::TurnLeft, CarDirection::TurnSlightLeft});
 }
 
 // Fails: generates unnecessary turn.


### PR DESCRIPTION
Тест ниже должен быть изменен. 
![image](https://user-images.githubusercontent.com/1768114/35326246-1a67f532-0107-11e8-9c54-e1cae1b5b9a7.png)

Как видно из картинки, сообщения не об одном, а об двух маневрах в данном случае вполне корректно. Поскольку в обоих случаях есть выбор, куда ехать.

@tatiana-kondakova PTAL