### PR TITLE
routing_integration_test ThailandPhuketNearPrabarameeRoad fix.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -374,7 +374,6 @@ UNIT_TEST(BelarusMKADShosseinai)
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
-// Fails: unneeded TurnSlightRight generated.
 // Test case: a route goes straight along a unnamed big road when joined small road.
 // An end user shall not be informed about such manoeuvres.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
@@ -382,7 +381,7 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                   MercatorBounds::FromLatLon(7.91797, 98.36937), {0., 0.},
-                                  MercatorBounds::FromLatLon(7.90724, 98.36785));
+                                  MercatorBounds::FromLatLon(7.90724, 98.3679));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;


### PR DESCRIPTION
Тест на отсутствие генерации маневра. Проблема была в том, что отредактировали дорогу, которая использовалась в данном тесте: http://www.openstreetmap.org/way/483686777#map=18/7.90585/98.36788

Должно быть:
![image](https://user-images.githubusercontent.com/1768114/35327999-1b1fc9d2-010c-11e8-84b6-909476980994.png)

Ошибка была в этом:
![image](https://user-images.githubusercontent.com/1768114/35328023-26700dba-010c-11e8-9437-ab7850e31b07.png)

Немого подвинул точку финиша.

@tatiana-kondakova PTAL