### PR TITLE
[generator] Skip keys like name:en:pronunciation

### DIFF
--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -138,6 +138,10 @@ namespace ftype
         ++token;
         lang = (token ? *token : "default");
 
+        // Do not consider languages with suffixes, like "en:pronunciation".
+        if (++token)
+          return false;
+
         // Replace dummy arabian tag with correct tag.
         if (lang == "ar1")
           lang = "ar";


### PR DESCRIPTION
Исправляет вот это:

![screenshot_maps me beta_20180124-142757](https://user-images.githubusercontent.com/766031/35330039-1141b626-0113-11e8-9ec8-48d37c81536b.png)
