### PR TITLE
routing integration test RussiaMoscowMKADLeningradkaTest fix.

### DIFF
--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -262,14 +262,14 @@ namespace integration
 
   const TestTurn & TestTurn::TestDirection(routing::turns::CarDirection expectedDirection) const
   {
-    TEST_EQUAL(m_direction, expectedDirection, ());
+    TEST_EQUAL(m_direction, expectedDirection, (m_direction));
     return *this;
   }
 
   const TestTurn & TestTurn::TestOneOfDirections(
       set<routing::turns::CarDirection> const & expectedDirections) const
   {
-    TEST(expectedDirections.find(m_direction) != expectedDirections.cend(), ());
+    TEST(expectedDirections.find(m_direction) != expectedDirections.cend(), (m_direction));
     return *this;
   }
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -358,6 +358,8 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
 UNIT_TEST(BelarusMKADShosseinai)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -350,7 +350,7 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(55.87992, 37.43940), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.87961, 37.43838), {0.0, 0.0},
                                   MercatorBounds::FromLatLon(55.87854, 37.44865));
 
   Route const & route = *routeResult.first;


### PR DESCRIPTION
Данный тест был написан, как тест на генерацию маневра при съезде с обычной дороги на link. В этом плане сейчас все работает:

![image](https://user-images.githubusercontent.com/1768114/35330397-70199d70-0114-11e8-99ef-26a6e584c0c7.png)

Проблема с тестом была в том, что сейчас маневр не генерируется, если сегмент, с которого маневер начинается это сегмент не полной (файковой) фичи. Мы не можем получить ее атрибуты, поскольку в место генерации маневра она приходит как Edge с координатами начала и конца. Так это было и в этом тесте:

![image](https://user-images.githubusercontent.com/1768114/35330506-c57aaf84-0114-11e8-9826-04ad252e6975.png)

Предлагаю сейчас подвинуть старт маршрута. 
