### PR TITLE
Removing check in case of osm id is mapped to two or more features.

### DIFF
--- a/transit/transit_graph_data.cpp
+++ b/transit/transit_graph_data.cpp
@@ -186,14 +186,13 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   auto const it = m_osmIdToFeatureIds.find(osmId);
   if (it != m_osmIdToFeatureIds.cend())
   {
-    CHECK_GREATER_OR_EQUAL(it->second.size(), 1,
-                           ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-                            ") from transit graph does not correspond to any feature."));
+    CHECK(!it->second.empty(), ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
+                                ") from transit graph does not correspond to any feature."));
     if (it->second.size() != 1)
     {
-      // Note. |osmId| corresponds to several feature ids. It may happen in case of stops;
-      // if a stop is present as relation. It's a rare case.
-      LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
+      // Note. |osmId| corresponds to several feature ids. It may happen in case of stops,
+      // if a stop is present as a relation. It's a rare case.
+      LOG(LWARNING, ("Osm id:", osmId, "( encoded", osmId.EncodedId(), ") corresponds to",
                      it->second.size(), "feature ids."));
     }
     id.SetFeatureId(it->second[0]);

--- a/transit/transit_graph_data.cpp
+++ b/transit/transit_graph_data.cpp
@@ -186,9 +186,18 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   auto const it = m_osmIdToFeatureIds.find(osmId);
   if (it != m_osmIdToFeatureIds.cend())
   {
-    CHECK_EQUAL(it->second.size(), 1, ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-        ") from transit graph corresponds to", it->second.size(), "features."
-        "But osm id should be represented be one feature."));
+    CHECK_GREATER_OR_EQUAL(it->second.size(), 1,
+                           ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
+                            ") from transit graph corresponds to", it->second.size(),
+                            "features."
+                            "But osm id should be represented be one feature."));
+    if (it->second.size() != 1)
+    {
+      // Note. |osmId| corresponds several feature ids. It may happen in case of stops;
+      // if a stop is present as relation. It's a rare case.
+      LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
+                     it->second.size(), "feature ids."));
+    }
     id.SetFeatureId(it->second[0]);
   }
   id.SetOsmId(osmId.EncodedId());

--- a/transit/transit_graph_data.cpp
+++ b/transit/transit_graph_data.cpp
@@ -188,12 +188,10 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   {
     CHECK_GREATER_OR_EQUAL(it->second.size(), 1,
                            ("Osm id:", osmId, "(encoded", osmId.EncodedId(),
-                            ") from transit graph corresponds to", it->second.size(),
-                            "features."
-                            "But osm id should be represented be one feature."));
+                            ") from transit graph does not correspond to any feature."));
     if (it->second.size() != 1)
     {
-      // Note. |osmId| corresponds several feature ids. It may happen in case of stops;
+      // Note. |osmId| corresponds to several feature ids. It may happen in case of stops;
       // if a stop is present as relation. It's a rare case.
       LOG(LWARNING, ("Osm id:", osmId, "(encoded", osmId.EncodedId(), "corresponds to",
                      it->second.size(), "feature ids."));


### PR DESCRIPTION
Данный PR предназначен, чтоб исследовать вопрос со сборкой карт в случае если одна osm id отображается в несколько feature id.