### PR TITLE
Add forgotten #include <functional>

### DIFF
--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
Чинит сборку routing_common на centos 7, gcc 7.2