### PR TITLE
[ctest] Add CTest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ data/*.ready
 data/*.osm
 data/*.bz2
 data/settings.ini
+data/marketing_settings.ini
 !data/minsk-pass.mwm
 !data/minsk-pass.osm.bz2
 data/index.idx
@@ -174,3 +175,5 @@ designer_version.h
 
 # Vim files
 tags
+
+testserver.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 project(omim C CXX)
 
@@ -9,6 +9,7 @@ get_filename_component(OMIM_ROOT . ABSOLUTE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${OMIM_ROOT}/cmake")
 
 include(OmimHelpers)
+enable_testing()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX_DETECTED TRUE)

--- a/drape/drape_tests/CMakeLists.txt
+++ b/drape/drape_tests/CMakeLists.txt
@@ -38,7 +38,12 @@ set(
   uniform_value_tests.cpp
 )
 
-omim_add_executable(${PROJECT_NAME} ${DRAPE_COMMON_SRC} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Smoke
+  SOURCES ${DRAPE_COMMON_SRC} ${SRC}
+  CUSTOM_TEST
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -31,7 +31,11 @@ set(
   user_event_stream_tests.cpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+# This test is very slow -> exclude it from smoke
+omim_add_test(
+  ${PROJECT_NAME}
+  SOURCES ${SRC}
+)
 
 if (PLATFORM_MAC)
   omim_link_libraries(

--- a/map/map_tests/CMakeLists.txt
+++ b/map/map_tests/CMakeLists.txt
@@ -25,7 +25,11 @@ set(
   working_time_tests.cpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  REQUIRED Server
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/partners_api/partners_api_tests/CMakeLists.txt
+++ b/partners_api/partners_api_tests/CMakeLists.txt
@@ -19,7 +19,11 @@ set(
   yandex_tests.cpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  REQUIRED Server
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}
@@ -30,7 +34,7 @@ omim_link_libraries(
   editor
   mwm_diff
   bsdiff
-  geometry 
+  geometry
   coding
   base
   jansson

--- a/routing/routing_benchmarks/CMakeLists.txt
+++ b/routing/routing_benchmarks/CMakeLists.txt
@@ -10,7 +10,11 @@ set(
   pedestrian_routing_tests.cpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Maps
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/routing/routing_consistency_tests/CMakeLists.txt
+++ b/routing/routing_consistency_tests/CMakeLists.txt
@@ -11,8 +11,12 @@ set(
   routing_consistency_tests.cpp
 )
 
-# Not using omim_add_test because we don't need testingmain.cpp
-omim_add_executable(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Maps
+  SOURCES ${SRC}
+  CUSTOM_TEST
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -22,7 +22,11 @@ set(
   turn_test.cpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Maps
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/storage/storage_integration_tests/CMakeLists.txt
+++ b/storage/storage_integration_tests/CMakeLists.txt
@@ -16,7 +16,11 @@ set(
   test_defines.hpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Maps
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/storage/storage_tests/CMakeLists.txt
+++ b/storage/storage_tests/CMakeLists.txt
@@ -19,7 +19,11 @@ set(
   test_map_files_downloader.hpp
 )
 
-omim_add_test(${PROJECT_NAME} ${SRC})
+omim_add_test(
+  ${PROJECT_NAME}
+  LABELS Smoke Server
+  SOURCES ${SRC}
+)
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/tools/python/testlog_to_xml_converter.py
+++ b/tools/python/testlog_to_xml_converter.py
@@ -16,6 +16,7 @@ from optparse import OptionParser
 import re
 
 REPLACE_CHARS_RE = re.compile("[\x00-\x1f]")
+CTEST_RE = re.compile(r"^\d+\:\s+(.+)$")
 
 
 class PrefixesInLog:
@@ -217,6 +218,9 @@ class PipeEach:
     def through_functions(self, *fns):
         for param in self.iterable_param:
             param = param.rstrip().decode('utf-8')
+            ctest_match = CTEST_RE.match(param)
+            if ctest_match:
+                param = ctest_match.group(1)
 
             for fn in fns:
                 if fn(param):

--- a/tools/unix/run_test_with_server.sh
+++ b/tools/unix/run_test_with_server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+OMIM_PATH="$(cd "${OMIM_PATH:-$(dirname "$0")/../..}"; pwd)"
+
+python $OMIM_PATH/tools/python/testserver.py \
+       2>testserver.log &
+
+# Run test command
+$(echo "$1" | tr ";" " ")
+
+# Kill server
+[ -n "$(jobs -p)" ] && kill $(jobs -p)


### PR DESCRIPTION
## Abstract
CMake includes powerful test system named CTest. So, since we completely reject qmake support, why not use one instead of python scripts?
CTest is highly integrated with cmake and provide sophisticated test launch behaviour on cmake level.

## Test creation
At first, few words about new syntax. Possible ways to add test:
```cmake
# Classic usage for backward compatibility
omim_add_test(some_test some_test.cpp some_test.h)

# New style usage
omim_add_test(
  some_test
  LABELS Server Smoke
  SOURCES some_test.cpp some_test.h
)

# Add test that you don't want to link with testingmain.cpp 
omim_add_test(
  routing_consistency_tests
  SOURCES routing_consistency_tests.cpp
  CUSTOM_TEST
)
```
Labels can be used to create test scopes ('Smoke') or to provide additional behaviour for all tests with certain label. Label 'Server' is created to highlight tests that needs Timofey's testserver:
```cmake
...
# run_test_with_server.sh automatically check testserver status
# and run it if needed
if (Server IN_LIST OMIM_TEST_LABELS)
    add_test(
      NAME ${executable}
      COMMAND ${OMIM_ROOT}/tools/unix/run_test_with_server.sh "${TEST_COMMAND}"
      )
...
```
## Usage
CTest is working by adding additional targets to base CMake project, so to run all tests after build you can use:
```bash
make test

Running tests...
Test project /Users/v.greshilov/MapsMe/omim-temp
      Start  1: base_tests
 1/29 Test  #1: base_tests .......................   Passed    1.26 sec
      Start  2: coding_tests
 2/29 Test  #2: coding_tests .....................   Passed    1.89 sec
      Start  3: drape_frontend_tests
```
Advanced usage:
```bash
# Run test with name map_tests
ctest -R map_tests

# Run all test with label Server, show all output
ctest -L Server -V

# Run all test except labels Integration, Drape
# write output to file testlog.log, dont't log 
# to stdout
ctest -LE "(Integration|Drape)" -V -Q -O testlog.log

# Run all tests in 8 parallel threads
ctest -j8
```
## Notes
Be careful, ```drape_frontend_tests``` run in ~10 minutes, and some integration tests is broken or need extra files in ```omim/data``` dir :(