### PR TITLE
Update feature_list and mwm_to_localads scripts

### DIFF
--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -242,7 +242,7 @@ public:
       }
     }
     string const & phone = f.GetMetadata().Get(feature::Metadata::FMD_PHONE_NUMBER);
-    string const & website = f.GetMetadata().Get(feature::Metadata::FMD_WEBSITE);
+    string const & website = f.GetMetadata().GetWikiURL();
     string cuisine = f.GetMetadata().Get(feature::Metadata::FMD_CUISINE);
     replace(cuisine.begin(), cuisine.end(), ';', ',');
     string const & stars = f.GetMetadata().Get(feature::Metadata::FMD_STARS);
@@ -311,7 +311,7 @@ int main(int argc, char ** argv)
   if (argc > 2)
   {
     pl.SetResourceDir(argv[2]);
-    countriesFile = my::JoinFoldersToPath(argv[2], COUNTRIES_FILE);
+    countriesFile = my::JoinPath(argv[2], COUNTRIES_FILE);
   }
 
   storage::Storage storage(countriesFile, argv[1]);
@@ -347,7 +347,7 @@ int main(int argc, char ** argv)
     if (argc > 3 && !strings::StartsWith(mwmInfo->GetCountryName() + DATA_FILE_EXTENSION, argv[3]))
       continue;
     LOG(LINFO, ("Processing", mwmInfo->GetCountryName()));
-    string osmToFeatureFile = my::JoinFoldersToPath(
+    string osmToFeatureFile = my::JoinPath(
         argv[1], mwmInfo->GetCountryName() + DATA_FILE_EXTENSION + OSM2FEATURE_FILE_EXTENSION);
     map<uint32_t, osm::Id> featureIdToOsmId;
     ParseFeatureIdToOsmIdMapping(osmToFeatureFile, featureIdToOsmId);

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -673,12 +673,6 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile, string const
 {
   m_dataDir = dataDir;
 
-  if (!m_dataDir.empty() &&
-      !Platform::MkDirChecked(my::JoinFoldersToPath(GetPlatform().WritableDir(), m_dataDir)))
-  {
-    // MYTHROW(FileSystemException, ("Unable to find or create directory", m_dataDir));
-  }
-
   if (m_countries.IsEmpty())
   {
     m_currentVersion = LoadCountriesFromFile(pathToCountriesFile, m_countries,

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -676,7 +676,7 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile, string const
   if (!m_dataDir.empty() &&
       !Platform::MkDirChecked(my::JoinFoldersToPath(GetPlatform().WritableDir(), m_dataDir)))
   {
-    MYTHROW(FileSystemException, ("Unable to find or create directory", m_dataDir));
+    // MYTHROW(FileSystemException, ("Unable to find or create directory", m_dataDir));
   }
 
   if (m_countries.IsEmpty())

--- a/tools/python/local_ads/mwm_to_csv_4localads.py
+++ b/tools/python/local_ads/mwm_to_csv_4localads.py
@@ -25,7 +25,11 @@ HEADERS = {
 }
 QUEUES = {name: Queue() for name in HEADERS}
 GOOD_TYPES = ("amenity", "shop", "tourism", "leisure", "sport",
-              "craft", "man_made", "office", "historic")
+              "craft", "man_made", "office", "historic",
+              "aeroway", "natural-beach", "natural-peak", "natural-volcano",
+              "natural-spring", "natural-cave_entrance",
+              "waterway-waterfall", "place-island", "railway-station",
+              "railway-halt", "aerialway-station", "building-train_station")
 SOURCE_TYPES = {'osm': 0, 'booking': 1}
 
 # Big enough to never intersect with a feature id (there are below 3 mln usually).


### PR DESCRIPTION
Накопившиеся правки по двум скриптам, которые я давно использую в продакшене:

* Убрал вываливание бессмысленного эксепшна в `storage.cpp`.
* Досыпал типов в скрипт выгрузки маппингов для localads, файл на 5% больше.
* Четыре новых атрибута для фида тринета: wikipedia, floor, fee, atm.
* Новые идентификаторы для фида тринета основываются на osm id, а не на хэше из координат и названия.