### PR TITLE
Fixed SHA1 compilation

### DIFF
--- a/3party/liboauthcpp/src/SHA1.h
+++ b/3party/liboauthcpp/src/SHA1.h
@@ -78,7 +78,7 @@
 
 #define UINT_8 unsigned char
 
-#if (ULONG_MAX == 0xFFFFFFFF)
+#if (ULONG_MAX == 0xFFFFFFFF && UINT_MAX < ULONG_MAX)
 #define UINT_32 unsigned long
 #else
 #define UINT_32 unsigned int


### PR DESCRIPTION
Линковщик на некоторых системах (XCode) ищет не ту реализацию из-за эквивалентности ULONG_MAX и UINT_MAX. Ужесточил критерий выбора unsigned long.