### PR TITLE
Turn generation improvements

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -263,6 +263,8 @@ void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
     ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Error, ());
     ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Undefined, ());
 
+    bool const isLink = ftypes::IsLinkChecker::Instance()(ft);
+
     double angle = 0;
 
     if (inEdge.GetFeatureId().m_mwmId == edge.GetFeatureId().m_mwmId)
@@ -281,11 +283,12 @@ void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
       // should not be used for turn generation.
       outgoingTurns.isCandidatesAngleValid = false;
     }
-    outgoingTurns.candidates.emplace_back(angle, ConvertEdgeToSegment(*m_numMwmIds, edge), highwayClass);
+    outgoingTurns.candidates.emplace_back(angle, ConvertEdgeToSegment(*m_numMwmIds, edge),
+                                          highwayClass, isLink);
   }
 
   if (outgoingTurns.isCandidatesAngleValid)
-    sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(), my::LessBy(&TurnCandidate::angle));
+    sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(), my::LessBy(&TurnCandidate::m_angle));
 }
 
 void BicycleDirectionsEngine::GetEdges(RoadGraphBase const & graph, Junction const & currJunction,

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -18,13 +18,15 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 5 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
+      {CarDirection::TurnSlightRight});
   integration::GetNthTurn(route, 1).TestValid().TestOneOfDirections(
+      {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
+  integration::GetNthTurn(route, 2).TestValid().TestOneOfDirections(
       {CarDirection::GoStraight, CarDirection::TurnSlightRight});
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 3).TestValid().TestOneOfDirections(
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 4).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
   integration::TestRouteLength(route, 753.0);
 }

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -31,7 +31,7 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
   TEST_EQUAL(result, IRouter::NoError, ());
 
   integration::TestCurrentStreetName(route, "Большая Тульская улица");
-  integration::TestNextStreetName(route, "Валовая улица");
+  integration::TestNextStreetName(route, "Подольское шоссе");
 
   MoveRoute(route, ms::LatLon(55.71398, 37.62443));
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -583,7 +583,8 @@ UNIT_TEST(NetherlandsGorinchemBridgeTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaVoronigProspTrudaTest)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -586,7 +586,7 @@ UNIT_TEST(NetherlandsGorinchemBridgeTest)
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
-UNIT_TEST(RussiaVoronigProspTrudaTest)
+UNIT_TEST(RussiaVoronezhProspTrudaTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
@@ -795,7 +795,7 @@ UNIT_TEST(GermanyRaunheimAirportTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
-UNIT_TEST(BelorussianMinskTest)
+UNIT_TEST(BelorussiaMinskTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -619,3 +619,83 @@ UNIT_TEST(GermanyFrankfurtAirportTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
+
+// Test on absence of unnecessary turn which may appear between two turns in the test.
+UNIT_TEST(RussiaKubinkaTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.58533, 36.83779), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.58365, 36.8333));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+  integration::GetNthTurn(route, 1).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightLeft, CarDirection::TurnLeft});
+}
+
+// Test on absence of unnecessary turn.
+UNIT_TEST(AustriaKitzbuhelTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(47.46894, 12.3841), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.46543, 12.38599));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
+
+// Test on absence of unnecessary turn.
+UNIT_TEST(AustriaKitzbuhel2Test)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(47.45119, 12.3841), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.45021, 12.382));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
+
+// Test on absence of unnecessary turn in case of fake ingoing segment.
+UNIT_TEST(AustriaKitzbuhel3Test)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(47.45362, 12.38709), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.45255, 12.38498));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
+
+// Test on absence of unnecessary turn.
+UNIT_TEST(AustriaBrixentalStrasseTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(47.45091, 12.33453), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.45038, 12.32592));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -755,12 +755,57 @@ UNIT_TEST(RussiaMoscowMKADTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(55.90394, 37.61034), {0., 0.},
-                                  MercatorBounds::FromLatLon(55.77431, 37.36945));
+                                  MercatorBounds::FromLatLon(52.15866, 5.56538), {0., 0.},
+                                  MercatorBounds::FromLatLon(52.16668, 5.55665));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+}
+
+UNIT_TEST(NetherlandsBarneveldTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(52.15866, 5.56538), {0., 0.},
+                                  MercatorBounds::FromLatLon(52.16667, 5.55663));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+}
+
+UNIT_TEST(GermanyRaunheimAirportTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(50.03322, 8.50995), {0., 0.},
+                                  MercatorBounds::FromLatLon(50.02089, 8.49441));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+}
+
+UNIT_TEST(BelorussianMinskTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(53.90991, 27.57946), {0., 0.},
+                                  MercatorBounds::FromLatLon(53.91552, 27.58211));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -553,3 +553,69 @@ UNIT_TEST(RussiaMoscowSvobodaStTest)
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
+
+UNIT_TEST(RussiaTiinskTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(54.37738, 49.63878), {0., 0.},
+                                  MercatorBounds::FromLatLon(54.3967, 49.64924));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+  integration::GetNthTurn(route, 1).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightLeft, CarDirection::TurnLeft});
+}
+
+UNIT_TEST(NetherlandsGorinchemBridgeTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(51.84131, 4.94825), {0., 0.},
+                                  MercatorBounds::FromLatLon(51.81518, 4.93773));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
+
+UNIT_TEST(RussiaVoronigProspTrudaTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(51.67205, 39.16334), {0., 0.},
+                                  MercatorBounds::FromLatLon(51.67193, 39.15636));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+}
+
+UNIT_TEST(GermanyFrankfurtAirportTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(50.07094, 8.61299), {0., 0.},
+                                  MercatorBounds::FromLatLon(50.05807, 8.59542));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
+}

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -583,8 +583,7 @@ UNIT_TEST(NetherlandsGorinchemBridgeTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 UNIT_TEST(RussiaVoronigProspTrudaTest)
@@ -620,6 +619,24 @@ UNIT_TEST(GermanyFrankfurtAirportTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
+
+
+UNIT_TEST(GermanyFrankfurtAirport2Test)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(50.03249, 8.50814), {0., 0.},
+                                  MercatorBounds::FromLatLon(50.02079, 8.49445));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+}
+
 
 // Test on absence of unnecessary turn which may appear between two turns in the test.
 UNIT_TEST(RussiaKubinkaTest)
@@ -731,4 +748,19 @@ UNIT_TEST(RussiaMoscowMKADToSvobodaTest)
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+}
+
+// Test that there's no turns if to follow MKAD.
+UNIT_TEST(RussiaMoscowMKADTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.90394, 37.61034), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.77431, 37.36945));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -699,3 +699,35 @@ UNIT_TEST(AustriaBrixentalStrasseTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
+
+UNIT_TEST(RussiaMoscowLeningradkaToMKADTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.87192, 37.45772), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.87594, 37.45266));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+}
+
+UNIT_TEST(RussiaMoscowMKADToSvobodaTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.8801, 37.43862), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.87583, 37.43046));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+}

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -21,33 +21,33 @@ namespace turns
  */
 struct TurnCandidate
 {
-  /*!
-   * angle is an angle of the turn in degrees. It means angle is 180 minus
-   * an angle between the current edge and the edge of the candidate. A counterclockwise rotation.
-   * The current edge is an edge which belongs the route and located before the junction.
-   * angle belongs to the range [-180; 180];
-   */
-  double angle;
-  /*!
-   * |m_segment| is a first segment of a possible way from the junction.
-   */
-  Segment m_segment;
-  /*!
-   * \brief highwayClass field for the road class caching. Because feature reading is a long
-   * function.
-   */
-  ftypes::HighwayClass highwayClass;
 
-  TurnCandidate(double a, Segment const & segment, ftypes::HighwayClass c)
-    : angle(a), m_segment(segment), highwayClass(c)
+/// angle is an angle of the turn in degrees. It means angle is 180 minus
+/// an angle between the current edge and the edge of the candidate. A counterclockwise rotation.
+/// The current edge is an edge which belongs the route and located before the junction.
+/// angle belongs to the range [-180; 180];
+  double m_angle;
+
+/// |m_segment| is a first segment of a possible way from the junction.
+  Segment m_segment;
+
+/// \brief highwayClass field for the road class caching. Because feature reading is a long
+/// function.
+  ftypes::HighwayClass m_highwayClass;
+
+/// If |isLink| is true than the turn candidate is a link.
+  bool m_isLink;
+
+  TurnCandidate(double a, Segment const & segment, ftypes::HighwayClass c, bool isLink)
+    : m_angle(a), m_segment(segment), m_highwayClass(c), m_isLink(isLink)
   {
   }
 
   bool IsAlmostEqual(TurnCandidate const & rhs) const
   {
     double constexpr kEpsilon = 0.01;
-    return my::AlmostEqualAbs(angle, rhs.angle, kEpsilon) && m_segment == rhs.m_segment &&
-           highwayClass == rhs.highwayClass;
+    return my::AlmostEqualAbs(m_angle, rhs.m_angle, kEpsilon) && m_segment == rhs.m_segment &&
+           m_highwayClass == rhs.m_highwayClass && m_isLink == rhs.m_isLink;
   }
 };
 

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -16,30 +16,28 @@ namespace routing
 {
 namespace turns
 {
-/*!
- * \brief The TurnCandidate struct contains information about possible ways from a junction.
- */
+/// \brief The TurnCandidate struct contains information about possible ways from a junction.
 struct TurnCandidate
 {
 
-/// angle is an angle of the turn in degrees. It means angle is 180 minus
-/// an angle between the current edge and the edge of the candidate. A counterclockwise rotation.
-/// The current edge is an edge which belongs the route and located before the junction.
-/// angle belongs to the range [-180; 180];
+  /// |m_angle| is the angle of the turn in degrees. It means the angle is 180 minus
+  /// the angle between the current edge and the edge of the candidate. A counterclockwise rotation.
+  /// The current edge is an edge which belongs to the route and is located before the junction.
+  /// |m_angle| belongs to the range [-180; 180];
   double m_angle;
 
-/// |m_segment| is a first segment of a possible way from the junction.
+  /// |m_segment| is the first segment of a possible way from the junction.
   Segment m_segment;
 
-/// \brief highwayClass field for the road class caching. Because feature reading is a long
-/// function.
+  /// \brief highwayClass field for the road class caching. Because feature reading is a long
+  /// function.
   ftypes::HighwayClass m_highwayClass;
 
-/// If |isLink| is true than the turn candidate is a link.
+  /// If |isLink| is true then the turn candidate is a link.
   bool m_isLink;
 
-  TurnCandidate(double a, Segment const & segment, ftypes::HighwayClass c, bool isLink)
-    : m_angle(a), m_segment(segment), m_highwayClass(c), m_isLink(isLink)
+  TurnCandidate(double angle, Segment const & segment, ftypes::HighwayClass c, bool isLink)
+    : m_angle(angle), m_segment(segment), m_highwayClass(c), m_isLink(isLink)
   {
   }
 

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -29,8 +29,8 @@ struct TurnCandidate
   /// |m_segment| is the first segment of a possible way from the junction.
   Segment m_segment;
 
-  /// \brief |highwayClass| field for the road class caching. Because feature reading is a long
-  /// function.
+  /// \brief |highwayClass| field for the road class caching. Because feature reading is
+  /// a time-consuming function.
   ftypes::HighwayClass m_highwayClass;
 
   /// If |isLink| is true then the turn candidate is a link.

--- a/routing/turn_candidate.hpp
+++ b/routing/turn_candidate.hpp
@@ -29,7 +29,7 @@ struct TurnCandidate
   /// |m_segment| is the first segment of a possible way from the junction.
   Segment m_segment;
 
-  /// \brief highwayClass field for the road class caching. Because feature reading is a long
+  /// \brief |highwayClass| field for the road class caching. Because feature reading is a long
   /// function.
   ftypes::HighwayClass m_highwayClass;
 

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -65,10 +65,8 @@ SegmentRange::SegmentRange(FeatureID const & featureId, uint32_t startSegId, uin
   : m_featureId(featureId), m_startSegId(startSegId), m_endSegId(endSegId), m_forward(forward),
     m_start(start), m_end(end)
 {
-  if (m_forward)
-    CHECK_LESS_OR_EQUAL(m_startSegId, m_endSegId, (*this));
-  else
-    CHECK_LESS_OR_EQUAL(m_endSegId, m_startSegId, (*this));
+  if (m_startSegId != m_endSegId)
+    CHECK_EQUAL(m_forward, m_startSegId < m_endSegId, (*this));
 }
 
 bool SegmentRange::operator==(SegmentRange const & rhs) const

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -65,6 +65,10 @@ SegmentRange::SegmentRange(FeatureID const & featureId, uint32_t startSegId, uin
   : m_featureId(featureId), m_startSegId(startSegId), m_endSegId(endSegId), m_forward(forward),
     m_start(start), m_end(end)
 {
+  if (m_forward)
+    CHECK_LESS_OR_EQUAL(m_startSegId, m_endSegId, (*this));
+  else
+    CHECK_LESS_OR_EQUAL(m_endSegId, m_startSegId, (*this));
 }
 
 bool SegmentRange::operator==(SegmentRange const & rhs) const
@@ -122,11 +126,22 @@ bool SegmentRange::IsCorrect() const
 
 bool SegmentRange::GetFirstSegment(NumMwmIds const & numMwmIds, Segment & segment) const
 {
+  return GetSegmentBySegId(m_startSegId, numMwmIds, segment);
+}
+
+bool SegmentRange::GetLastSegment(NumMwmIds const & numMwmIds, Segment & segment) const
+{
+  return GetSegmentBySegId(m_endSegId, numMwmIds, segment);
+}
+
+bool SegmentRange::GetSegmentBySegId(uint32_t segId, NumMwmIds const & numMwmIds,
+                                     Segment & segment) const
+{
   if (!m_featureId.IsValid())
     return false;
 
   segment = Segment(numMwmIds.GetId(platform::CountryFile(m_featureId.GetMwmName())),
-                    m_featureId.m_index, m_startSegId, m_forward);
+                    m_featureId.m_index, segId, m_forward);
   return true;
 }
 

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -16,7 +16,7 @@
 namespace routing
 {
 /// \brief Unique identification for a road edge between two junctions (joints). The identifier
-/// is represented by an mwm id, a feature id, a range of segment ids [|m_startSegId|, |m_endSegId|),
+/// is represented by an mwm id, a feature id, a range of segment ids [|m_startSegId|, |m_endSegId|],
 /// a direction and type.
 struct SegmentRange
 {
@@ -35,8 +35,11 @@ struct SegmentRange
   /// \brief Fills |segment| with the first segment of this SegmentRange.
   /// \returns true if |segment| is filled and false otherwise.
   bool GetFirstSegment(NumMwmIds const & numMwmIds, Segment & segment) const;
+  bool GetLastSegment(NumMwmIds const & numMwmIds, Segment & segment) const;
 
 private:
+  bool GetSegmentBySegId(uint32_t segId, NumMwmIds const & numMwmIds, Segment & segment) const;
+
   FeatureID m_featureId;
   // Note. If SegmentRange represents two directional feature |m_endSegId| is greater
   // than |m_startSegId| if |m_forward| == true.


### PR DESCRIPTION
Добавлено ряд улучшений в систему генерации маневров и тесты на эти улучшения:

- не генерируется ошибочный маневр на двусторонней дороге. Ранее он иногда генерировался на двусторонних фичах, поскольку разворот на данной фиче рассматривался как путь, по которому водитель может ошибочно поехать
https://jira.mail.ru/browse/MAPSME-5455
https://jira.mail.ru/browse/MAPSME-6805

- на этапе ранней фильтрации не выкидываются плавные повороты, если все остальные кандидаты на повороты так же плавные;
https://jira.mail.ru/browse/MAPSME-6813
https://jira.mail.ru/browse/MAPSME-6803

- не генерируется (не нужны) маневр, если данный маневр является плавным поворотом или движением прямо с не link-дороги на не link-дорогу, и при этом все остальные кандидаты в маневры ведут y link;

- добавлены интеграционные тесты на данные исправления и на прочие интересные случаи

https://jira.mail.ru/browse/MAPSME-1458
https://jira.mail.ru/browse/MAPSME-6807
https://jira.mail.ru/browse/MAPSME-6808
https://jira.mail.ru/browse/MAPSME-6809
https://jira.mail.ru/browse/MAPSME-6810

@mpimenov @rokuz PTAL
