### PR TITLE
Fixing routing integration tests for 18.02.09

### DIFF
--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -185,7 +185,7 @@ UNIT_TEST(BelarusBobruisk50LetVlksmToArena)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(53.1638, 29.1804), {0., 0.},
-      MercatorBounds::FromLatLon(53.1424, 29.2467), 6683.);
+      MercatorBounds::FromLatLon(53.1424, 29.2467), 6123.0);
 }
 
 UNIT_TEST(RussiaTaganrogSyzranov10k3ToSoftech)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -32,10 +32,13 @@ namespace
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
         MercatorBounds::FromLatLon(55.97310, 37.41460), 37284.);
-    integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(),
-        MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
-        MercatorBounds::FromLatLon(55.75100, 37.61790), 39449.);
+//    This test stopped working because of an error in the map. The error has been just fixed:
+//    https://www.openstreetmap.org/changeset/56686302
+//    @TODO(bykoianko) The test should be uncommented for the next map build (after 170209).
+//    integration::CalculateRouteAndTestRouteLength(
+//        integration::GetVehicleComponents<VehicleType::Car>(),
+//        MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
+//        MercatorBounds::FromLatLon(55.75100, 37.61790), 39449.);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.


### PR DESCRIPTION
После обновления карт до 2018.02.09 поправил routing integration tests.

BelarusBobruisk50LetVlksmToArena - изменилась геометрия карты, но маршрут прокладывает корректный по прежнему:
![image](https://user-images.githubusercontent.com/1768114/36668099-46ec1598-1b01-11e8-91ce-16f1d58e9f25.png)

MoscowToSVOAirport - в карте допущена ошибка. Не большой кусок двусторонней дороги сделан односторонним:
![image](https://user-images.githubusercontent.com/1768114/36668156-76343f7e-1b01-11e8-9787-414cd7a98767.png)

Карту я поправил: https://www.openstreetmap.org/changeset/56686302
А тест пока закомментировал и оставил TODO на раскомметирование после пересборки карт. Мне важно, чтоб интеграционные тесты проходили.

@rokuz @mpimenov PTAL
