### PR TITLE
[gcc] Fix GCC-6 build bug

### DIFF
--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -1512,7 +1512,7 @@ void Storage::LoadServerListForSession()
 {
   ASSERT_THREAD_CHECKER(m_threadChecker, ());
 
-  m_downloader->GetServersList([this](auto const & urls) { PingServerList(urls); });
+  m_downloader->GetServersList([this](vector<string> const & urls) { PingServerList(urls); });
 }
 
 void Storage::LoadServerListForTesting()
@@ -1530,7 +1530,7 @@ void Storage::PingServerList(vector<string> const & urls)
     return;
 
   GetPlatform().RunTask(Platform::Thread::Network, [urls, this] {
-    Pinger::Ping(urls, [this, urls](auto readyUrls) {
+    Pinger::Ping(urls, [this, urls](vector<string> readyUrls) {
       ASSERT_THREAD_CHECKER(m_threadChecker, ());
 
       if (readyUrls.empty())


### PR DESCRIPTION
Solve bug in gcc-6. More info:

https://stackoverflow.com/questions/32097759/calling-this-member-function-from-generic-lambda-clang-vs-gcc/32098850#32098850
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67274