### PR TITLE
Removing filtering turns if the route goes from one segment to another with almost the same name.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -69,7 +69,6 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
   integration::TestRouteLength(route, 2050.);
 }
 
-// Fails: generates "GoStraight" description instead of TurnSlightRight.
 UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
 {
   TRouteResult const routeResult =
@@ -80,7 +79,7 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 5 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
       .TestPoint({37.38848, 67.63338}, 20.)
@@ -94,6 +93,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
       .TestPoint({37.38738, 67.63278}, 20.)
       .TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 3)
+      .TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 4)
       .TestValid()
       .TestPoint({37.39052, 67.63310}, 20.)
       .TestDirection(CarDirection::TurnRight);
@@ -196,8 +197,9 @@ UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaMoscowTTKUTurnTest)
@@ -211,11 +213,12 @@ UNIT_TEST(RussiaMoscowTTKUTurnTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
-  // Checking a turn in case going from a not-link to a link
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
-      {CarDirection::TurnSlightRight, CarDirection::TurnRight});;
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::UTurnLeft);
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::UTurnLeft);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
@@ -229,10 +232,11 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
@@ -367,8 +371,9 @@ UNIT_TEST(BelarusMKADShosseinai)
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
-// Test case: a route goes straight along a unnamed big road when joined small road.
+// Test case: a route goes straight along a big road when joined small road.
 // An end user shall not be informed about such manoeuvres.
+// But at the and of the route an end user shall be informed about junction of two big roads.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 {
   TRouteResult const routeResult =
@@ -380,7 +385,8 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 // Test case: a route goes in Moscow from Varshavskoe shosse (from the city center direction)
@@ -401,9 +407,6 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
 
-// Test case: a route goes in Moscow from Bolshaya Nikitskaya street
-// (towards city center) to Mokhovaya street. A turn instruction (turn left)
-// shall be generated.
 UNIT_TEST(RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest)
 {
   TRouteResult const routeResult =
@@ -415,8 +418,9 @@ UNIT_TEST(RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 // Test case: a route goes in Moscow from Tverskaya street (towards city center)
@@ -467,9 +471,6 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
 
-// Fails: generates unnecessary turn.
-// Test case: checking that no unnecessary turn on a serpentine road.
-// This test was written after reducing factors kMaxPointsCount and kMinDistMeters.
 UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 {
   TRouteResult const routeResult =
@@ -481,7 +482,8 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
@@ -892,4 +894,21 @@ UNIT_TEST(RussiaMoscowTTKToNMaslovkaTest)
   TEST_EQUAL(result, IRouter::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
+}
+
+UNIT_TEST(RussiaMoscowComplicatedTurnTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.68412, 37.60166), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.68426, 37.59854));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
 }

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -186,7 +186,7 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
   integration::TestRouteLength(route, 43233.7);
 }
 
-UNIT_TEST(RussiaMoscowTTKKashirskoeShosseOutTurnTest)
+UNIT_TEST(RussiaMoscowTTKVarshavskoeShosseOutTurnTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -912,3 +912,19 @@ UNIT_TEST(RussiaMoscowComplicatedTurnTest)
       {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
 }
+
+UNIT_TEST(USATampaTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(28.04875, -82.58292), {0., 0.},
+                                  MercatorBounds::FromLatLon(28.04459, -82.58448));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+}

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -544,23 +544,6 @@ void FixupTurns(vector<Junction> const & junctions, Route::TTurns & turnsDir)
       continue;
     }
 
-    // @todo(vbykoianko) The sieve below is made for filtering unnecessary turns on Moscow's MKAD
-    // and roads like it. It's a quick fix but it's possible to do better.
-    // The better solution is to remove all "slight" turns if the route goes form one not-link road
-    // to another not-link road and other possible turns are links. But it's not possible to
-    // implement it quickly. To do that you need to calculate FeatureType for most possible turns.
-    // But it is already made once in  KeepTurnByHighwayClass(GetOutgoingHighwayClass).
-    // So it's a good idea to keep FeatureType for outgoing turns in TTurnCandidates
-    // (if they have been calculated). For the time being I decided to postpone the implementation
-    // of the feature but it is worth implementing it in the future.
-    // To implement the new sieve (the better solution) use TurnInfo structure.
-    if (!t.m_keepAnyway && IsGoStraightOrSlightTurn(t.m_turn) && !t.m_sourceName.empty() &&
-        strings::AlmostEqual(t.m_sourceName, t.m_targetName, 2 /* mismatched symbols count */))
-    {
-      turnsDir.erase(turnsDir.begin() + idx);
-      continue;
-    }
-
     ++idx;
   }
   SelectRecommendedLanes(turnsDir);

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -334,7 +334,7 @@ m2::PointD GetPointForTurn(vector<Junction> const & path, m2::PointD const & jun
 
     // TODO The code below is a stub for compatability with older versions with this function.
     // Remove it, fix tests cases when it works (integration test
-    // RussiaMoscowTTKKashirskoeShosseOutTurnTest)
+    // RussiaMoscowTTKVarshavskoeShosseOutTurnTest)
     // and remove point duplication when we get geometry from feature segments.
     if (point == nextPoint)
       return nextPoint;


### PR DESCRIPTION
Около 3 лет назад был написан фильтр под обработки маневров, который удалял все плавные маневры при условии, что названия улиц на сегментах маршрута вокруг данного маневра не сильно отличаются. Эта необходимость была связана прежде всего с тем, что при движении по МКАД генерировалось примерно один маневр на километр. 

Это был быстры фикс. Сейчас реализован правильный механизм: если угол маневра плавный, маршрут следует с не link дороги на не link дорогу, а остальные кандидаты link дороги, то маневр генерировать не надо.

Фильтр указанный выше нужно удалить, поскольку он приводит к ряду не правильных маневров:
https://jira.mail.ru/browse/MAPSME-6815
https://jira.mail.ru/browse/MAPSME-6890

Разумеется данное изменение влияет на интеграционные тесты. Но в лучшую сторону:

RussiaMoscowSalameiNerisUturnTurnTest
![image](https://user-images.githubusercontent.com/1768114/36849983-8f461c0e-1d76-11e8-8ebf-e9398fddf531.png)

RussiaMoscowTTKKashirskoeShosseOutTurnTest
![image](https://user-images.githubusercontent.com/1768114/36850676-76a16b70-1d78-11e8-941c-031f5779fce4.png)

RussiaMoscowTTKUTurnTest
![image](https://user-images.githubusercontent.com/1768114/36850703-86fb8f0a-1d78-11e8-9941-c1963eabe834.png)

RussiaMoscowParallelResidentalUTurnAvoiding
![image](https://user-images.githubusercontent.com/1768114/36850797-b7fbcc6e-1d78-11e8-8f0e-64b850225fdb.png)

ThailandPhuketNearPrabarameeRoad
![image](https://user-images.githubusercontent.com/1768114/36850951-17619260-1d79-11e8-9480-f0e18d444cd3.png)

RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest
![image](https://user-images.githubusercontent.com/1768114/36851030-5269ad48-1d79-11e8-9f41-d97b43b5935d.png)

SwitzerlandSamstagernBergstrasseTest
![image](https://user-images.githubusercontent.com/1768114/36851108-8588e6a8-1d79-11e8-9364-3515b628ea70.png)

@tatiana-kondakova @mpimenov PTAL
