### PR TITLE
[DNM] Using shared_ptr at TReadyCallback instead of ref.

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -206,8 +206,8 @@ public:
   void CheckLocationForRouting(location::GpsInfo const & info);
   void CallRouteBuilded(routing::IRouter::ResultCode code,
                         storage::TCountriesVec const & absentCountries);
-  void OnBuildRouteReady(routing::Route const & route, routing::IRouter::ResultCode code);
-  void OnRebuildRouteReady(routing::Route const & route, routing::IRouter::ResultCode code);
+  void OnBuildRouteReady(std::shared_ptr<routing::Route> route, routing::IRouter::ResultCode code);
+  void OnRebuildRouteReady(std::shared_ptr<routing::Route> route, routing::IRouter::ResultCode code);
   void OnRoutePointPassed(RouteMarkType type, size_t intermediateIndex);
   void OnLocationUpdate(location::GpsInfo & info);
   void SetAllowSendingPoints(bool isAllowed)
@@ -259,7 +259,7 @@ public:
   void CancelPreviewMode();
 
 private:
-  void InsertRoute(routing::Route const & route);
+  void InsertRoute(std::shared_ptr<routing::Route> route);
   bool IsTrackingReporterEnabled() const;
   void MatchLocationToRoute(location::GpsInfo & info,
                             location::RouteMatchingInfo & routeMatchingInfo) const;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -150,7 +150,7 @@ void RoutingSession::DoReadyCallback::operator()(Route & route, IRouter::ResultC
       m_rs.m_route->AddAbsentCountry(country);
   }
 
-  m_callback(*m_rs.m_route, e);
+  m_callback(m_rs.m_route, e);
 }
 
 void RoutingSession::RemoveRoute()

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -77,7 +77,7 @@ public:
 
   typedef function<void(map<string, string> const &)> TRoutingStatisticsCallback;
 
-  typedef function<void(Route const &, IRouter::ResultCode)> TReadyCallback;
+  typedef function<void(shared_ptr<Route>, IRouter::ResultCode)> TReadyCallback;
   typedef function<void(float)> TProgressCallback;
   typedef function<void(size_t passedCheckpointIdx)> CheckpointCallback;
 


### PR DESCRIPTION
Перевод на shared_ptr<Route> TReadyCallback и InsertRoute.

Метод TReadyCallback вызывается из потока routing и из UI потока. В него передавалась const ref на Route. Из кол бека TReadyCallback вызывается метод InsertRoute(). План следующий:

1. Данный PR делает, чтоб TReadyCallback/InsertRoute принимал shared_ptr<Route>;
2. Далее (в отдельном PR от @darina) метод InsertRoute будет вызываться на UI потоке;

https://jira.mail.ru/browse/MAPSME-6998

@tatiana-kondakova @darina @rokuz PTAL

Замечание. Коммиты данного PR будут помечены RELEASE ONLY, поскольку я сам сделаю cherry-pick на master.