### PR TITLE
[geocoder] Extract addresses tool

### DIFF
--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -106,9 +106,30 @@ inline my::JSONPtr ToJSON(bool value) { return my::NewJSONBool(value); }
 inline my::JSONPtr ToJSON(char const * s) { return my::NewJSONString(s); }
 
 template <typename T>
+void ToJSONArray(json_t & root, T const & value)
+{
+  json_array_append_new(&root, ToJSON(value).release());
+}
+
+inline void ToJSONArray(json_t & parent, my::JSONPtr & child)
+{
+  json_array_append_new(&parent, child.release());
+}
+
+inline void ToJSONArray(json_t & parent, json_t & child)
+{
+  json_array_append_new(&parent, &child);
+}
+
+template <typename T>
 void ToJSONObject(json_t & root, std::string const & field, T const & value)
 {
   json_object_set_new(&root, field.c_str(), ToJSON(value).release());
+}
+
+inline void ToJSONObject(json_t & parent, std::string const & field, my::JSONPtr & child)
+{
+  json_object_set_new(&parent, field.c_str(), child.release());
 }
 
 inline void ToJSONObject(json_t & parent, std::string const & field, json_t & child)

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -113,6 +113,7 @@ omim_add_test_subdirectory(generator_tests)
 
 add_subdirectory(generator_tool)
 add_subdirectory(booking_quality_check)
+add_subdirectory(extract_addr)
 add_subdirectory(feature_segments_checker)
 add_subdirectory(restaurants_info)
 add_subdirectory(srtm_coverage_checker)

--- a/generator/extract_addr/CMakeLists.txt
+++ b/generator/extract_addr/CMakeLists.txt
@@ -1,0 +1,39 @@
+project(extract_addr)
+
+include_directories(
+  ${OMIM_ROOT}/3party/jansson/src
+)
+
+set(
+  SRC
+  extract_addr.cpp
+)
+
+omim_add_executable(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  generator
+  search
+  routing
+  routing_common
+  indexer
+  editor
+  geometry
+  platform
+  coding
+  base
+  minizip
+  jansson
+  pugixml
+  stats_client
+  opening_hours
+  succinct
+  oauthcpp
+  expat
+  protobuf
+  icu
+  ${LIBZ}
+)
+
+link_qt5_core(${PROJECT_NAME})

--- a/generator/extract_addr/extract_addr.cpp
+++ b/generator/extract_addr/extract_addr.cpp
@@ -1,0 +1,96 @@
+#include "generator/feature_builder.hpp"
+
+#include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
+#include "indexer/feature_data.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "platform/platform.hpp"
+
+#include "base/string_utils.hpp"
+
+#include "3party/jansson/myjansson.hpp"
+
+#include <iostream>
+#include <set>
+#include <string>
+
+std::set<std::string> const kPoiTypes = {"amenity",  "shop",    "tourism",  "leisure",   "sport",
+                                         "craft",    "man_made", "office",  "historic",  "building"};
+
+std::string GetReadableType(FeatureBuilder1 const & f)
+{
+  uint32_t result = 0;
+  for (uint32_t type : f.GetTypes())
+  {
+    std::string fullName = classif().GetFullObjectName(type);
+    auto const pos = fullName.find("|");
+    if (pos != std::string::npos)
+      fullName = fullName.substr(0, pos);
+    if (kPoiTypes.find(fullName) != kPoiTypes.end())
+      result = type;
+  };
+  return result == 0 ? std::string() : classif().GetReadableObjectName(result);
+}
+
+void PrintFeature(FeatureBuilder1 const & fb, uint64_t)
+{
+  std::string const & category = GetReadableType(fb);
+  std::string const & name = fb.GetName();
+  std::string const & street = fb.GetParams().GetStreet();
+  std::string const & house = fb.GetParams().house.Get();
+  bool const isPOI = !name.empty() && !category.empty() &&
+      category.find("building") == std::string::npos;
+
+  if ((house.empty() && !isPOI) || fb.GetGeomType() == feature::GEOM_LINE)
+    return;
+
+  auto const center = MercatorBounds::ToLatLon(fb.GetKeyPoint());
+  auto coordinates = my::NewJSONArray();
+  ToJSONArray(*coordinates, strings::to_string_dac(center.lon, 6));
+  ToJSONArray(*coordinates, strings::to_string_dac(center.lat, 6));
+  auto geometry = my::NewJSONObject();
+  ToJSONObject(*geometry, "type", "Point");
+  ToJSONObject(*geometry, "coordinates", coordinates);
+
+  auto properties = my::NewJSONObject();
+  ToJSONObject(*properties, "id", fb.GetMostGenericOsmId().EncodedId());
+  if (!name.empty() && !category.empty() && category != "building-address")
+  {
+    ToJSONObject(*properties, "name", name);
+    ToJSONObject(*properties, "tags", category);
+  }
+  auto address = my::NewJSONObject();
+  if (!street.empty())
+    ToJSONObject(*address, "street", street);
+  if (!house.empty())
+    ToJSONObject(*address, "building", house);
+  ToJSONObject(*properties, "address", address);
+
+  auto feature = my::NewJSONObject();
+  ToJSONObject(*feature, "type", "Feature");
+  ToJSONObject(*feature, "geometry", geometry);
+  ToJSONObject(*feature, "properties", properties);
+
+  std::cout << json_dumps(feature.release(), JSON_COMPACT) << std::endl;
+}
+
+int main(int argc, char * argv[])
+{
+  if (argc <= 1)
+  {
+    LOG(LERROR, ("Usage:", argc == 1 ? argv[0] : "extract_addr",
+                 "<mwm_tmp_name> [<data_path>]"));
+    return 1;
+  }
+
+  Platform & pl = GetPlatform();
+  if (argc > 2)
+    pl.SetResourceDir(argv[2]);
+  classificator::Load();
+
+  feature::ForEachFromDatRawFormat(argv[1], PrintFeature);
+
+  return 0;
+}


### PR DESCRIPTION
Раз другой компонент геокодера использует промежуточные файлы `*.mwm.tmp` для вытаскивания геометрии, я переписал выгрузку адресных точек тоже на эти файлы.

Помимо самих адресов, скрипт выгружает POI без адресов. Некоторым из них повезёт оказаться внутри зданий и получить-таки адреса.