### PR TITLE
Using slight turn notification instead of exits from highway.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/RoutingInfo.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingInfo.java
@@ -59,8 +59,8 @@ public class RoutingInfo
 
     // @TODO(alexzatsepin) It's necessary to insert apropriate constants instead of zeros
     // for EXIT_HIGHWAY_TO_LEFT() and EXIT_HIGHWAY_TO_RIGHT().
-    EXIT_HIGHWAY_TO_LEFT(0, 0),
-    EXIT_HIGHWAY_TO_RIGHT(0, 0);
+    EXIT_HIGHWAY_TO_LEFT(R.drawable.ic_turn_left_slight, R.drawable.ic_then_left_slight),
+    EXIT_HIGHWAY_TO_RIGHT(R.drawable.ic_turn_right_slight, R.drawable.ic_then_right_slight);
 
     private final int mTurnRes;
     private final int mNextTurnRes;

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -26,9 +26,11 @@ UIImage * image(routing::turns::CarDirection t, bool isNextTurn)
   NSString * imageName;
   switch (t)
   {
+  case CarDirection::ExitHighwayToRight:
   case CarDirection::TurnSlightRight: imageName = @"slight_right"; break;
   case CarDirection::TurnRight: imageName = @"simple_right"; break;
   case CarDirection::TurnSharpRight: imageName = @"sharp_right"; break;
+  case CarDirection::ExitHighwayToLeft:
   case CarDirection::TurnSlightLeft: imageName = @"slight_left"; break;
   case CarDirection::TurnLeft: imageName = @"simple_left"; break;
   case CarDirection::TurnSharpLeft: imageName = @"sharp_left"; break;
@@ -40,8 +42,6 @@ UIImage * image(routing::turns::CarDirection t, bool isNextTurn)
   case CarDirection::GoStraight: imageName = @"straight"; break;
   case CarDirection::StartAtEndOfStreet:
   case CarDirection::StayOnRoundAbout:
-  case CarDirection::ExitHighwayToLeft:
-  case CarDirection::ExitHighwayToRight:
   case CarDirection::Count:
   case CarDirection::None: imageName = isNextTurn ? nil : @"straight"; break;
   }

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -141,12 +141,14 @@ string GetDirectionTextId(Notification const & notification)
     case CarDirection::TurnSharpRight:
       return "make_a_sharp_right_turn";
     case CarDirection::TurnSlightRight:
+    case CarDirection::ExitHighwayToRight:
       return "make_a_slight_right_turn";
     case CarDirection::TurnLeft:
       return "make_a_left_turn";
     case CarDirection::TurnSharpLeft:
       return "make_a_sharp_left_turn";
     case CarDirection::TurnSlightLeft:
+    case CarDirection::ExitHighwayToLeft:
       return "make_a_slight_left_turn";
     case CarDirection::UTurnLeft:
     case CarDirection::UTurnRight:
@@ -159,8 +161,6 @@ string GetDirectionTextId(Notification const & notification)
       return GetYouArriveTextId(notification);
     case CarDirection::StayOnRoundAbout:
     case CarDirection::StartAtEndOfStreet:
-    case CarDirection::ExitHighwayToLeft:
-    case CarDirection::ExitHighwayToRight:
     case CarDirection::None:
     case CarDirection::Count:
       ASSERT(false, ());


### PR DESCRIPTION
Пока не реализован UI по оповещению о выходах с магистрали, будут использованы оповещение о плавных поворотах.

Вместо выход направо - плавный поворот направо;
Вместо выход налево - плавный поворот налево;

@tatiana-kondakova @VladiMihaylenko @alexzatsepin PTAL
