### PR TITLE
[indexer] Pull back entrance type → release

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -89,6 +89,7 @@ public:
       { "internet_access" },
       { "wheelchair" },
       { "sponsored" },
+      { "entrance" },
     };
 
     AddTypes(arr1);


### PR DESCRIPTION
1) Кто-то там в почту писал, что когда теги заведения находятся на входе в здание, на РР выводится тип «вход», а не тип заведения.

2) Вместо Luggage Hero на нынешних картах в РР пишем «здание».