### PR TITLE
Removed warnings from KML parser

### DIFF
--- a/coding/internal/xmlparser.hpp
+++ b/coding/internal/xmlparser.hpp
@@ -79,9 +79,11 @@ public:
   void PrintError()
   {
     if (BaseT::GetErrorCode() != XML_ERROR_NONE)
-      LOG(LWARNING, ("XML parse error at line",
-                     BaseT::GetCurrentLineNumber(),
-                     "and byte", BaseT::GetCurrentByteIndex()));
+    {
+      LOG(LDEBUG, ("XML parse error at line",
+                   BaseT::GetCurrentLineNumber(),
+                   "and byte", BaseT::GetCurrentByteIndex()));
+    }
   }
 
 private:

--- a/map/api_mark_point.cpp
+++ b/map/api_mark_point.cpp
@@ -19,9 +19,6 @@ string GetSupportedStyle(string const & s, string const & context, string const 
     if (s == kSupportedColors[i])
       return s;
   }
-
-  // Not recognized symbols are replaced with default one
-  LOG(LWARNING, ("Icon", s, "for point", context, "is not supported"));
   return fallback;
 }
 

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -255,8 +255,6 @@ class KMLParser
           pt = MercatorBounds::FromLatLon(lat, lon);
           return true;
         }
-        else
-          LOG(LWARNING, ("Invalid coordinates", s, "while loading", m_name));
       }
     }
     
@@ -499,11 +497,7 @@ public:
         else if (prevTag == "TimeStamp")
         {
           if (currTag == "when")
-          {
             m_timeStamp = my::StringToTimestamp(value);
-            if (m_timeStamp == my::INVALID_TIME_STAMP)
-              LOG(LWARNING, ("Invalid timestamp in Placemark:", value));
-          }
         }
         else if (currTag == kStyleUrl)
         {
@@ -556,7 +550,7 @@ std::unique_ptr<KMLData> LoadKMLFile(std::string const & file)
   }
   catch (std::exception const & e)
   {
-    LOG(LWARNING, ("Error while loading bookmarks from", file, e.what()));
+    LOG(LDEBUG, ("Error while loading bookmarks from", file, e.what()));
   }
   return nullptr;
 }
@@ -568,7 +562,7 @@ std::unique_ptr<KMLData> LoadKMLData(ReaderPtr<Reader> const & reader)
   KMLParser parser(*data);
   if (!ParseXML(src, parser, true))
   {
-    LOG(LWARNING, ("XML read error. Probably, incorrect file encoding."));
+    LOG(LDEBUG, ("XML read error. Probably, incorrect file encoding."));
     data.reset();
   }
   return data;


### PR DESCRIPTION
Удалены/изменены ворнинги, которые лились в лог во всех режимах, что на больших файлах очень сильно замедляло парсинг KML