### PR TITLE
[android] Fixed network policy class initialization in JNI on nexus 5

### DIFF
--- a/android/jni/com/mapswithme/core/jni_helper.cpp
+++ b/android/jni/com/mapswithme/core/jni_helper.cpp
@@ -28,6 +28,7 @@ jclass g_loggerFactoryClazz;
 jclass g_keyValueClazz;
 jclass g_httpUploaderClazz;
 jclass g_httpUploaderResultClazz;
+jclass g_networkPolicyClazz;
 
 extern "C"
 {
@@ -53,6 +54,7 @@ JNI_OnLoad(JavaVM * jvm, void *)
   g_keyValueClazz = jni::GetGlobalClassRef(env, "com/mapswithme/util/KeyValue");
   g_httpUploaderClazz = jni::GetGlobalClassRef(env, "com/mapswithme/util/HttpUploader");
   g_httpUploaderResultClazz = jni::GetGlobalClassRef(env, "com/mapswithme/util/HttpUploader$Result");
+  g_networkPolicyClazz = jni::GetGlobalClassRef(env, "com/mapswithme/util/NetworkPolicy");
 
   return JNI_VERSION_1_6;
 }
@@ -76,6 +78,7 @@ JNI_OnUnload(JavaVM *, void *)
   env->DeleteGlobalRef(g_keyValueClazz);
   env->DeleteGlobalRef(g_httpUploaderClazz);
   env->DeleteGlobalRef(g_httpUploaderResultClazz);
+  env->DeleteGlobalRef(g_networkPolicyClazz);
 }
 } // extern "C"
 

--- a/android/jni/com/mapswithme/core/jni_helper.hpp
+++ b/android/jni/com/mapswithme/core/jni_helper.hpp
@@ -26,6 +26,7 @@ extern jclass g_loggerFactoryClazz;
 extern jclass g_keyValueClazz;
 extern jclass g_httpUploaderClazz;
 extern jclass g_httpUploaderResultClazz;
+extern jclass g_networkPolicyClazz;
 
 namespace jni
 {

--- a/android/jni/com/mapswithme/util/NetworkPolicy.cpp
+++ b/android/jni/com/mapswithme/util/NetworkPolicy.cpp
@@ -11,9 +11,8 @@ bool GetNetworkPolicyStatus(JNIEnv * env, jobject obj)
 
 bool GetCurrentNetworkUsageStatus(JNIEnv * env)
 {
-  static jclass const clazz = jni::GetGlobalClassRef(env, "com/mapswithme/util/NetworkPolicy");
   static jmethodID const method =
-    jni::GetStaticMethodID(env, clazz, "getCurrentNetworkUsageStatus", "()Z");
-  return env->CallStaticBooleanMethod(clazz, method);
+    jni::GetStaticMethodID(env, g_networkPolicyClazz, "getCurrentNetworkUsageStatus", "()Z");
+  return env->CallStaticBooleanMethod(g_networkPolicyClazz, method);
 }
 }  // namespace network_policy

--- a/android/multidex-config.txt
+++ b/android/multidex-config.txt
@@ -11,5 +11,6 @@ com/mapswithme/util/HttpClient$HttpHeader.class
 com/mapswithme/util/HttpUploader.class
 com/mapswithme/util/HttpUploader$Result.class
 com/mapswithme/util/KeyValue.class
+com/mapswithme/util/NetworkPolicy.class
 com/mapswithme/util/Utils.class
 com/my/tracker/MyTracker.class


### PR DESCRIPTION
Почему-то на Nexus 5 (девайсе @bykoianko )  jni::GetGlobalClassRef(env, "com/mapswithme/util/NetworkPolicy") стабильно возвращал null. Только после переноса инициализации класса в onLoad в jni-helper проблема ушла. Но почему она была пока выяснить не удалось. П