### PR TITLE
Sounds for exit from highway.

### DIFF
--- a/data/sound-strings/ar.json/localize.json
+++ b/data/sound-strings/ar.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"إلى أقصى اليسار.",
 "make_a_u_turn":"انعطف بدوران كامل.",
 "go_straight":"انطلق مباشرة.",
+"exit":"Exit.",
 "destination":"سوف تصل.",
 "you_have_reached_the_destination":"لقد وصلت.",
 "in_50_meters":"بعد خمسين مترًا",

--- a/data/sound-strings/cs.json/localize.json
+++ b/data/sound-strings/cs.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Ostře doleva.",
 "make_a_u_turn":"Otočte se do protisměru.",
 "go_straight":"Jeďte rovně.",
+"exit":"Exit.",
 "destination":"Přijedete do cíle.",
 "you_have_reached_the_destination":"Jste v cíli.",
 "in_50_meters":"Za padesát metrů",

--- a/data/sound-strings/da.json/localize.json
+++ b/data/sound-strings/da.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Skarpt til venstre.",
 "make_a_u_turn":"Vend om.",
 "go_straight":"Fortsæt lige ud.",
+"exit":"Exit.",
 "destination":"Ankommer du.",
 "you_have_reached_the_destination":"Du er ankommet.",
 "in_50_meters":"Om halvtreds meter",

--- a/data/sound-strings/de.json/localize.json
+++ b/data/sound-strings/de.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Scharf links.",
 "make_a_u_turn":"Wenden Sie.",
 "go_straight":"Fahren Sie geradeaus.",
+"exit":"Exit.",
 "destination":"Werden Sie ankommen.",
 "you_have_reached_the_destination":"Sie sind angekommen.",
 "in_50_meters":"In fünfzig Metern",

--- a/data/sound-strings/el.json/localize.json
+++ b/data/sound-strings/el.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Απότομα αριστερά.",
 "make_a_u_turn":"Κάντε στροφή 180 μοιρών.",
 "go_straight":"Συνεχίστε ευθεία.",
+"exit":"Exit.",
 "destination":"Θα φτάσετε.",
 "you_have_reached_the_destination":"Έχετε φτάσει.",
 "in_50_meters":"Σε πενήντα μέτρα",

--- a/data/sound-strings/en.json/localize.json
+++ b/data/sound-strings/en.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Sharp left.",
 "make_a_u_turn":"Make a u-turn.",
 "go_straight":"Go straight.",
+"exit":"Exit.",
 "destination":"You’ll arrive.",
 "you_have_reached_the_destination":"You have arrived.",
 "in_50_meters":"In fifty meters",

--- a/data/sound-strings/es.json/localize.json
+++ b/data/sound-strings/es.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Gire bruscamente a la izquierda.",
 "make_a_u_turn":"Cambie de sentido.",
 "go_straight":"Continúe recto.",
+"exit":"Exit.",
 "destination":"Llegará a su destino.",
 "you_have_reached_the_destination":"Ha llegado a su destino.",
 "in_50_meters":"En cincuenta metros",

--- a/data/sound-strings/fa.json/localize.json
+++ b/data/sound-strings/fa.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"منتها الیه سمت چپ.",
 "make_a_u_turn":"دور بزنید.",
 "go_straight":"مستقیم بروید.",
+"exit":"Exit.",
 "destination":"شما خواهید رسید.",
 "you_have_reached_the_destination":" شما رسیده اید.  ",
 "in_50_meters":" در پنجاه متری",

--- a/data/sound-strings/fi.json/localize.json
+++ b/data/sound-strings/fi.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Jyrkkä vasen.",
 "make_a_u_turn":"Tee U-käännös.",
 "go_straight":"Aja suoraan.",
+"exit":"Exit.",
 "destination":"Olet perillä.",
 "you_have_reached_the_destination":"Olet saapunut.",
 "in_50_meters":"Viidenkymmenen metrin päässä",

--- a/data/sound-strings/fr.json/localize.json
+++ b/data/sound-strings/fr.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"À gauche toute.",
 "make_a_u_turn":"Faites demi-tour.",
 "go_straight":"Continuez tout droit.",
+"exit":"Exit.",
 "destination":"Vous arriverez.",
 "you_have_reached_the_destination":"Vous êtes arrivé.",
 "in_50_meters":"Dans cinquante mètres",

--- a/data/sound-strings/hi.json/localize.json
+++ b/data/sound-strings/hi.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"तीव्रता से बाएं मुड़े।",
 "make_a_u_turn":"यू-टर्न लें।",
 "go_straight":"सीधे चलें।",
+"exit":"Exit.",
 "destination":"गंतव्य स्थान",
 "you_have_reached_the_destination":"आप पहुंच गए हैं।",
 "in_50_meters":"पचास मीटर में।",

--- a/data/sound-strings/hr.json/localize.json
+++ b/data/sound-strings/hr.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Oštro ulijevo.",
 "make_a_u_turn":"Napravite poluzaokret.",
 "go_straight":"Idite ravno.",
+"exit":"Exit.",
 "destination":"Stižete.",
 "you_have_reached_the_destination":"Stigli ste.",
 "in_50_meters":"Za pedeset metara",

--- a/data/sound-strings/hu.json/localize.json
+++ b/data/sound-strings/hu.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Kanyarodjon élesen balra.",
 "make_a_u_turn":"Forduljon vissza.",
 "go_straight":"Hajtson előre.",
+"exit":"Exit.",
 "destination":"Megérkezik.",
 "you_have_reached_the_destination":"Ön megérkezett.",
 "in_50_meters":"Ötven méter után",

--- a/data/sound-strings/id.json/localize.json
+++ b/data/sound-strings/id.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Belok tajam ke kiri.",
 "make_a_u_turn":"Putar balik.",
 "go_straight":"Lurus terus.",
+"exit":"Exit.",
 "destination":"Anda akan tiba.",
 "you_have_reached_the_destination":"Anda sudah sampai.",
 "in_50_meters":"Setelah lima puluh meter",

--- a/data/sound-strings/it.json/localize.json
+++ b/data/sound-strings/it.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Svoltare a sinistra.",
 "make_a_u_turn":"Effettua un'inversione a U.",
 "go_straight":"Sempre dritto.",
+"exit":"Exit.",
 "destination":"Arriverai.",
 "you_have_reached_the_destination":"Sei arrivato.",
 "in_50_meters":"Tra cinquanta metri",

--- a/data/sound-strings/ja.json/localize.json
+++ b/data/sound-strings/ja.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"急に左折。",
 "make_a_u_turn":"Uターンです。",
 "go_straight":"直進です。",
+"exit":"Exit.",
 "destination":"到着します。",
 "you_have_reached_the_destination":"到着。",
 "in_50_meters":"五十メートル先",

--- a/data/sound-strings/ko.json/localize.json
+++ b/data/sound-strings/ko.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"급좌회전.",
 "make_a_u_turn":"유턴입니다.",
 "go_straight":"직진입니다.",
+"exit":"Exit.",
 "destination":"도착할 예정입니다.",
 "you_have_reached_the_destination":"도착했습니다.",
 "in_50_meters":"오십 미터 앞",

--- a/data/sound-strings/nl.json/localize.json
+++ b/data/sound-strings/nl.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Scherp linksaf.",
 "make_a_u_turn":"Keer om.",
 "go_straight":"Rij rechtdoor.",
+"exit":"Exit.",
 "destination":"Arriveert u.",
 "you_have_reached_the_destination":"Bestemming bereikt.",
 "in_50_meters":"Over vijftig meter",

--- a/data/sound-strings/pl.json/localize.json
+++ b/data/sound-strings/pl.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Ostro w lewo.",
 "make_a_u_turn":"Zawróć.",
 "go_straight":"Jedź prosto.",
+"exit":"Exit.",
 "destination":"Dojedziesz.",
 "you_have_reached_the_destination":"Dotarłeś do celu.",
 "in_50_meters":"Za pięćdziesiąt metrów",

--- a/data/sound-strings/pt.json/localize.json
+++ b/data/sound-strings/pt.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Curva acentuada à esquerda.",
 "make_a_u_turn":"Faça inversão de marcha.",
 "go_straight":"Siga em frente.",
+"exit":"Exit.",
 "destination":"Você vai chegar.",
 "you_have_reached_the_destination":"Chegou.",
 "in_50_meters":"A cinquenta metros",

--- a/data/sound-strings/ro.json/localize.json
+++ b/data/sound-strings/ro.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Virați strâns la stânga.",
 "make_a_u_turn":"Întoarceți-vă o sută optzeci de grade.",
 "go_straight":"Mergeți înainte.",
+"exit":"Exit.",
 "destination":"Veți sosi.",
 "you_have_reached_the_destination":"Ați ajuns.",
 "in_50_meters":"După cincizeci de metri",

--- a/data/sound-strings/ru.json/localize.json
+++ b/data/sound-strings/ru.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Резко поверните налево.",
 "make_a_u_turn":"Развернитесь.",
 "go_straight":"Двигайтесь прямо.",
+"exit":"Съезд.",
 "destination":"Вы прибудете в пункт назначения.",
 "you_have_reached_the_destination":"Вы прибыли в пункт назначения.",
 "in_50_meters":"Через пятьсот метров",

--- a/data/sound-strings/sk.json/localize.json
+++ b/data/sound-strings/sk.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Ostro doľava.",
 "make_a_u_turn":"Otočte sa o stoosemdesiat stupňov.",
 "go_straight":"Choďte rovno.",
+"exit":"Exit.",
 "destination":"Dorazíte.",
 "you_have_reached_the_destination":"Dorazili ste do cieľa.",
 "in_50_meters":"Po päťdesiatich metroch",

--- a/data/sound-strings/sv.json/localize.json
+++ b/data/sound-strings/sv.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Skarpt vänster.",
 "make_a_u_turn":"Gör en U-sväng.",
 "go_straight":"Åk rakt framåt.",
+"exit":"Exit.",
 "destination":"Är du framme.",
 "you_have_reached_the_destination":"Du har anlänt.",
 "in_50_meters":"Om femtio meter",

--- a/data/sound-strings/sw.json/localize.json
+++ b/data/sound-strings/sw.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Fanya kushoto mkali.",
 "make_a_u_turn":"Geuka urudi ulikotoka.",
 "go_straight":"Pita kabisa.",
+"exit":"Exit.",
 "destination":"Utawasili.",
 "you_have_reached_the_destination":"Umewasili mwisho wa safari.",
 "in_50_meters":"Kabla ya mita hamsini",

--- a/data/sound-strings/th.json/localize.json
+++ b/data/sound-strings/th.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"หักมุมซ้าย",
 "make_a_u_turn":"กลับรถ",
 "go_straight":"ตรงไป",
+"exit":"Exit.",
 "destination":"คุณจะถึง",
 "you_have_reached_the_destination":"คุณมาถึงแล้ว",
 "in_50_meters":"อีกห้าสิบเมตร",

--- a/data/sound-strings/tr.json/localize.json
+++ b/data/sound-strings/tr.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Tam sola.",
 "make_a_u_turn":"U dönüşü yapın.",
 "go_straight":"Düz ilerleyin.",
+"exit":"Exit.",
 "destination":"Varacaksınız.",
 "you_have_reached_the_destination":"Vardınız.",
 "in_50_meters":"Elli metre sonra",

--- a/data/sound-strings/uk.json/localize.json
+++ b/data/sound-strings/uk.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Різкий поворот наліво.",
 "make_a_u_turn":"Зробіть розворот.",
 "go_straight":"Їдьте прямо.",
+"exit":"Exit.",
 "destination":"Ви прибудете.",
 "you_have_reached_the_destination":"Ви прибули.",
 "in_50_meters":"Через п'ятдесят метрів",

--- a/data/sound-strings/vi.json/localize.json
+++ b/data/sound-strings/vi.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"Rẽ ngoặt bên trái.",
 "make_a_u_turn":"Quay đầu.",
 "go_straight":"Đi thẳng.",
+"exit":"Exit.",
 "destination":"Bạn sẽ đến.",
 "you_have_reached_the_destination":"Bạn đã đến.",
 "in_50_meters":"Trong năm mươi mét nữa",

--- a/data/sound-strings/zh-Hans.json/localize.json
+++ b/data/sound-strings/zh-Hans.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"向左急转。",
 "make_a_u_turn":"掉头。",
 "go_straight":"直行。",
+"exit":"Exit.",
 "destination":"您将到达。",
 "you_have_reached_the_destination":"您已抵达。",
 "in_50_meters":"前方五十米",

--- a/data/sound-strings/zh-Hant.json/localize.json
+++ b/data/sound-strings/zh-Hant.json/localize.json
@@ -9,6 +9,7 @@
 "make_a_sharp_left_turn":"向左急轉。",
 "make_a_u_turn":"掉頭。",
 "go_straight":"直行。",
+"exit":"Exit.",
 "destination":"您將到達。",
 "you_have_reached_the_destination":"您已抵達",
 "in_50_meters":"前方五十米",

--- a/data/sound.txt
+++ b/data/sound.txt
@@ -330,6 +330,39 @@
     vi = Đi thẳng.
     uk = Їдьте прямо.
 
+  [exit]
+    en = Exit.
+    ru = Съезд.
+    ar = Exit.
+    cs = Exit.
+    da = Exit.
+    nl = Exit.
+    fi = Exit.
+    fr = Exit.
+    de = Exit.
+    hu = Exit.
+    id = Exit.
+    it = Exit.
+    ja = Exit.
+    ko = Exit.
+    pl = Exit.
+    pt = Exit.
+    ro = Exit.
+    es = Exit.
+    sv = Exit.
+    th = Exit.
+    tr = Exit.
+    zh-Hans = Exit.
+    zh-Hant = Exit.
+    el = Exit.
+    hi = Exit.
+    hr = Exit.
+    sk = Exit.
+    sw = Exit.
+    fa = Exit.
+    vi = Exit.
+    uk = Exit.
+
   [destination]
     en = You’ll arrive.
     ru = Вы прибудете в пункт назначения.

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -141,14 +141,12 @@ string GetDirectionTextId(Notification const & notification)
     case CarDirection::TurnSharpRight:
       return "make_a_sharp_right_turn";
     case CarDirection::TurnSlightRight:
-    case CarDirection::ExitHighwayToRight:
       return "make_a_slight_right_turn";
     case CarDirection::TurnLeft:
       return "make_a_left_turn";
     case CarDirection::TurnSharpLeft:
       return "make_a_sharp_left_turn";
     case CarDirection::TurnSlightLeft:
-    case CarDirection::ExitHighwayToLeft:
       return "make_a_slight_left_turn";
     case CarDirection::UTurnLeft:
     case CarDirection::UTurnRight:
@@ -159,6 +157,9 @@ string GetDirectionTextId(Notification const & notification)
       return GetRoundaboutTextId(notification);
     case CarDirection::ReachedYourDestination:
       return GetYouArriveTextId(notification);
+    case CarDirection::ExitHighwayToLeft:
+    case CarDirection::ExitHighwayToRight:
+      return "exit";
     case CarDirection::StayOnRoundAbout:
     case CarDirection::StartAtEndOfStreet:
     case CarDirection::None:


### PR DESCRIPTION
Озвучка для выездов с шоссе.

Добавлена озвучка для съездов с больших дорог. Для левого и правого съезда используется слово Съезд (Exit). Например, программа будет говорить: "Через 500 метров съезд.".

Для всех языков, кроме русского сейчас используется английский вариант (Exit). Отдельными коммитами @igortomko  планирует добавить правильные переводы. А пока для удобства тестирования предлагаю такой PR

@igortomko @therearesomewhocallmetim @alexzatsepin PTAL