### PR TITLE
[tracking] Fix circular buffer allocation

### DIFF
--- a/tracking/reporter.cpp
+++ b/tracking/reporter.cpp
@@ -39,7 +39,7 @@ Reporter::Reporter(unique_ptr<platform::Socket> socket, string const & host, uin
   // Set buffer size to be enough to keep all points even if one reconnect attempt failed.
   auto const realTimeBufferSize =
       (duration_cast<seconds>(m_pushDelay).count() + kReconnectDelaySeconds) / kMinDelaySeconds;
-  m_points.resize(ceil(realTimeBufferSize));
+  m_points.set_capacity(ceil(realTimeBufferSize));
 }
 
 Reporter::~Reporter()


### PR DESCRIPTION
исправила выделение циклического буфера -- resize делает не то что надо, он и размер и текущую позицию устанавливает в size, а нам нужно чтобы буфер был пустым, но с заданной capacity