### PR TITLE
m_route protection in RoutingSession.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -979,7 +979,8 @@ void RoutingManager::SetDrapeEngine(ref_ptr<df::DrapeEngine> engine, bool is3dAl
       // In case of the engine reinitialization recover route.
       if (IsRoutingActive())
       {
-        InsertRoute(*m_routingSession.GetRoute());
+        m_routingSession.ProtectedCall([this](Route const & route) { InsertRoute(route); });
+
         if (is3dAllowed && m_routingSession.IsFollowing())
           m_drapeEngine.SafeCall(&df::DrapeEngine::EnablePerspective);
       }

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -157,7 +157,7 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
 }
 
 Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
-                                                    double predictDistance) const
+                                                    double predictDistance)
 {
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
@@ -176,7 +176,7 @@ Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
   return res;
 }
 
-Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect) const
+Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect)
 {
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -47,7 +47,6 @@ public:
   double GetDistanceToEndMeters() const;
   double GetDistFromCurPointToRoutePointMerc() const;
   double GetDistFromCurPointToRoutePointMeters() const;
-  double GetMercatorDistanceFromBegin() const;
 
   /*! \brief Return next navigation point for direction widgets.
    *  Returns first geometry point from the polyline after your location if it is farther then
@@ -71,8 +70,8 @@ public:
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
 
-  Iter UpdateProjectionByPrediction(m2::RectD const & posRect, double predictDistance) const;
-  Iter UpdateProjection(m2::RectD const & posRect) const;
+  Iter UpdateProjectionByPrediction(m2::RectD const & posRect, double predictDistance);
+  Iter UpdateProjection(m2::RectD const & posRect);
 
   Iter Begin() const;
   Iter End() const;
@@ -95,7 +94,7 @@ private:
   m2::PolylineD m_poly;
 
   /// Iterator with the current position. Position sets with UpdateProjection methods.
-  mutable Iter m_current;
+  Iter m_current;
   size_t m_nextCheckpointIndex;
   /// Precalculated info for fast projection finding.
   std::vector<m2::ProjectionToSection<m2::PointD>> m_segProj;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -243,7 +243,7 @@ void Route::GetCurrentDirectionPoint(m2::PointD & pt) const
   m_poly.GetCurrentDirectionPoint(pt, kOnEndToleranceM);
 }
 
-bool Route::MoveIterator(location::GpsInfo const & info) const
+bool Route::MoveIterator(location::GpsInfo const & info)
 {
   m2::RectD const rect = MercatorBounds::MetresToXY(
         info.m_longitude, info.m_latitude,

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -267,7 +267,7 @@ public:
   void GetCurrentDirectionPoint(m2::PointD & pt) const;
 
   /// @return true  If position was updated successfully (projection within gps error radius).
-  bool MoveIterator(location::GpsInfo const & info) const;
+  bool MoveIterator(location::GpsInfo const & info);
 
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -173,7 +173,7 @@ void RoutingSession::RebuildRouteOnTrafficUpdate()
     threads::MutexGuard guard(m_routingSessionMutex);
     startPoint = m_lastGoodPosition;
 
-    switch (m_state.load())
+    switch (m_state)
     {
     case RoutingNotActive:
     case RouteNotReady:
@@ -567,7 +567,7 @@ traffic::SpeedGroup RoutingSession::MatchTraffic(
 
 bool RoutingSession::DisableFollowMode()
 {
-  LOG(LINFO, ("Routing disables a following mode. State: ", m_state.load()));
+  LOG(LINFO, ("Routing disables a following mode. State: ", m_state));
   threads::MutexGuard guard(m_routingSessionMutex);
   if (m_state == RouteNotStarted || m_state == OnRoute)
   {
@@ -580,7 +580,7 @@ bool RoutingSession::DisableFollowMode()
 
 bool RoutingSession::EnableFollowMode()
 {
-  LOG(LINFO, ("Routing enables a following mode. State: ", m_state.load()));
+  LOG(LINFO, ("Routing enables a following mode. State: ", m_state));
   threads::MutexGuard guard(m_routingSessionMutex);
   if (m_state == RouteNotStarted || m_state == OnRoute)
   {

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -20,7 +20,6 @@
 
 #include "base/mutex.hpp"
 
-#include "std/atomic.hpp"
 #include "std/functional.hpp"
 #include "std/limits.hpp"
 #include "std/map.hpp"
@@ -215,8 +214,8 @@ private:
 private:
   unique_ptr<AsyncRouter> m_router;
   shared_ptr<Route> m_route;
-  atomic<State> m_state;
-  atomic<bool> m_isFollowing;
+  State m_state;
+  bool m_isFollowing;
   Checkpoints m_checkpoints;
   size_t m_lastWarnedSpeedCameraIndex;
   SpeedCameraRestriction m_lastFoundCamera;
@@ -228,7 +227,7 @@ private:
   /// about camera will be sent at most once.
   mutable bool m_speedWarningSignal;
 
-  /// |m_routingSessionMutex| should be used for access to |m_route| member.
+  /// |m_routingSessionMutex| should be used for access to all members of RoutingSession class.
   mutable threads::Mutex m_routingSessionMutex;
 
   /// Current position metrics to check for RouteNeedRebuild state.

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -80,6 +80,7 @@ public:
   typedef function<void(Route const &, IRouter::ResultCode)> TReadyCallback;
   typedef function<void(float)> TProgressCallback;
   typedef function<void(size_t passedCheckpointIdx)> CheckpointCallback;
+  using RouteCallback = function<void(Route const &)>;
 
   RoutingSession();
 
@@ -114,7 +115,6 @@ public:
 
   inline void SetState(State state) { m_state = state; }
 
-  shared_ptr<Route> const GetRoute() const;
   /// \returns true if altitude information along |m_route| is available and
   /// false otherwise.
   bool HasRouteAltitude() const;
@@ -162,6 +162,8 @@ public:
   void GenerateTurnNotifications(vector<string> & turnNotifications);
 
   void EmitCloseRoutingEvent() const;
+
+  void ProtectedCall(RouteCallback const & callback) const;
 
   // RoutingObserver overrides:
   void OnTrafficInfoClear() override;
@@ -220,6 +222,7 @@ private:
   /// about camera will be sent at most once.
   mutable bool m_speedWarningSignal;
 
+  /// |m_routingSessionMutex| should be used for access to |m_route| member.
   mutable threads::Mutex m_routingSessionMutex;
 
   /// Current position metrics to check for RouteNeedRebuild state.

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -102,12 +102,7 @@ UNIT_TEST(TestRouteBuilding)
   unique_ptr<DummyRouter> router = make_unique<DummyRouter>(masterRoute, DummyRouter::NoError, counter);
   session.SetRouter(move(router), nullptr);
   session.SetReadyCallbacks(
-        [&timedSignal](Route const &, IRouter::ResultCode)
-        {
-          timedSignal.Signal();
-        },
-  nullptr
-        );
+      [&timedSignal](Route const &, IRouter::ResultCode) { timedSignal.Signal(); }, nullptr);
   session.BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
   // Manual check of the routeBuilded mutex to avoid spurious results.
   auto const time = steady_clock::now() + kRouteBuildingMaxDuration;


### PR DESCRIPTION
В PR https://github.com/mapsme/omim/pull/8216 @tatiana-kondakova обратила внимание на то, что RoutingSession::m_route защищен не всегда при помощи RoutingSession::m_routingSessionMutex.

Действительно m_route защищен почти всегда в RoutingSession, но иногда это сразу не видно, поскольку защищены вызывающие методы. Например, RoutingManager вызывает RoutingSession::SetReadyCallbacks(..) для установки колбеков buildReadyCallback и rebuildReadyCallback. На время вызовов этих колбеков берется RoutingSession::m_routingSessionMutex.

Единственным местом, где защита нарушалось был вызов RoutingManager::InsertRoute() из RoutingManager::SetDrapeEngine(). Метод shared_ptr<Route> RoutingSession::GetRoute() обеспечивал потоко-небезопасный доступ к RoutingSession::m_route. Притом в данном случае shared_ptr не помогал в потоко-безопасности. Дело в том, что методы Route::MoveIterator() и Route::PassNextSubroute() меняют состояние объекта Route, на который указывает shared_ptr RoutingSession::m_route, в то время, как в InsertRoute может осуществляться не защищенное чтение из него.

Данный PR делает потокобезопасную реализацию. А именно на время вызова RoutingManager::InsertRoute() берется RoutingSession::m_routingSessionMutex.

@tatiana-kondakova @VladiMihaylenko @darina PTAL

P.S. PR лучше смотреть по коммитам. Первый коммит просто избавление от mutable.