### PR TITLE
Routing integration test RussiaMoscowTTKToNMaslovkaTest fixing.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -892,8 +892,9 @@ UNIT_TEST(RussiaMoscowTTKToNMaslovkaTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
 }
 
 UNIT_TEST(RussiaMoscowComplicatedTurnTest)


### PR DESCRIPTION
Поправил routing_integration_test: RussiaMoscowTTKToNMaslovkaTest
В данной ситуации второй маневр корректен, поскольку это развилка двух дорог соседних highway class-ов.

highway:unclassified и highway:service

![image](https://user-images.githubusercontent.com/1768114/37404903-3f197b58-27a4-11e8-879b-e4cc27f576db.png)

@tatiana-kondakova PTAL
