### PR TITLE
Removing more slight turns in case if other roads has less highway class.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -232,11 +232,10 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
@@ -892,9 +891,8 @@ UNIT_TEST(RussiaMoscowTTKToNMaslovkaTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
 }
 
 UNIT_TEST(RussiaMoscowComplicatedTurnTest)

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -150,9 +150,14 @@ bool KeepTurnByHighwayClass(CarDirection turn, TurnCandidates const & possibleTu
   if (minClassForTheRoute == ftypes::HighwayClass::Undefined)
     return false; // Fake edges have HighwayClass::Undefined.
 
-  int const kMaxHighwayClassDiffToKeepTheTurn = 2;
-  if (static_cast<int>(maxClassForPossibleTurns) - static_cast<int>(minClassForTheRoute) >=
-      kMaxHighwayClassDiffToKeepTheTurn)
+  // Maximum difference between HighwayClasses of route segments and possible way segments
+  // to keep the bifurcation point as a turn.
+  int constexpr kMaxHighwayClassDiff = 2;
+  int constexpr kMaxHighwayClassDiffForService = 1;
+  int const diff =
+      static_cast<int>(maxClassForPossibleTurns) - static_cast<int>(minClassForTheRoute);
+  if (diff >= kMaxHighwayClassDiff ||
+      (maxClassForPossibleTurns == ftypes::HighwayClass::Service && diff >= kMaxHighwayClassDiffForService))
   {
     // The turn shall be removed if the route goes near small roads without changing the direction.
     return false;


### PR DESCRIPTION
Не столь давно был починен интеграционный тест RussiaMoscowTTKToNMaslovkaTest в PR https://github.com/mapsme/omim/pull/8307. В действительности данный маневр (двигайтесь прямо) был бы не совсем уместен в данном случае, если взглянуть на панорамы.

В этом PR сделано следующее. Если HighwayClass дороги, по которой проходит маршрут, больше чем HighwayClass прочих возможных маневров. И маневр, который образует маршрут в данной точке бифуркации плавный, то удаляем данный маневр.

Это изменило 2 интеграционных теста в лучшую сторону:
![image](https://user-images.githubusercontent.com/1768114/37472682-bb8c0a82-287d-11e8-8d8b-bfd2fda61356.png)
![image](https://user-images.githubusercontent.com/1768114/37472754-e13b5526-287d-11e8-92b2-9a6bad666312.png)

@tatiana-kondakova @mpimenov PTAL