### PR TITLE
Routes along piers.

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -49,6 +49,7 @@ public:
 
     m_map[c.GetTypeByPath({"highway", "service"})] = ftypes::HighwayClass::Service;
     m_map[c.GetTypeByPath({"highway", "track"})] = ftypes::HighwayClass::Service;
+    m_map[c.GetTypeByPath({"man_made", "pier"})] = ftypes::HighwayClass::Service;
 
     m_map[c.GetTypeByPath({"highway", "pedestrian"})] = ftypes::HighwayClass::Pedestrian;
     m_map[c.GetTypeByPath({"highway", "footway"})] = ftypes::HighwayClass::Pedestrian;

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -371,4 +371,15 @@ namespace
     Route const & route = *routeResult.first;
     TEST_LESS(route.GetTotalTimeSec(), numeric_limits<double >::max() / 2.0, ());
   }
+
+  // Test on routing along features with tag man_made:pier.
+  UNIT_TEST(CanadaVictoriaVancouverTest)
+  {
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(48.47831, -123.32749), {0.0, 0.0},
+                                    MercatorBounds::FromLatLon(49.26242, -123.11553));
+    IRouter::ResultCode const result = routeResult.second;
+    TEST_EQUAL(result, IRouter::NoError, ());
+  }
 }  // namespace


### PR DESCRIPTION
Корректная прокладка маршрутов вдоль пирсов. 

Ранее дороги с тегом "man_made", "pier" не были добавлены в классификатор HighwayClass, что приводило к срабатывание ASSERT в дебаг версии.

https://jira.mail.ru/browse/MAPSME-7142

@tatiana-kondakova @mpimenov PTAL