### PR TITLE
Detailed diagnostic information for transit section building.

### DIFF
--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -176,13 +176,13 @@ void ProcessGraph(string const & mwmPath, TCountryId const & countryId,
 {
   CalculateBestPedestrianSegments(mwmPath, countryId, data);
   data.Sort();
-  CHECK(data.IsValid(), (mwmPath));
+  data.CheckValid();
 }
 
 void BuildTransit(string const & mwmDir, TCountryId const & countryId,
                   string const & osmIdToFeatureIdsPath, string const & transitDir)
 {
-  LOG(LINFO, ("Building transit section for", countryId));
+  LOG(LINFO, ("Building transit section for", countryId, "mwmDir:", mwmDir));
   Platform::FilesList graphFiles;
   Platform::GetFilesByExt(my::AddSlashIfNeeded(transitDir), TRANSIT_FILE_EXTENSION, graphFiles);
 
@@ -207,7 +207,7 @@ void BuildTransit(string const & mwmDir, TCountryId const & countryId,
     return; // Empty transit section.
 
   ProcessGraph(mwmPath, countryId, mapping, jointData);
-  CHECK(jointData.IsValid(), (mwmPath, countryId));
+  jointData.CheckValid();
 
   FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
   FileWriter writer = cont.GetWriter(TRANSIT_FILE_TAG);

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -176,7 +176,7 @@ void ProcessGraph(string const & mwmPath, TCountryId const & countryId,
 {
   CalculateBestPedestrianSegments(mwmPath, countryId, data);
   data.Sort();
-  data.CheckValid();
+  data.CheckValidSortedUnique();
 }
 
 void BuildTransit(string const & mwmDir, TCountryId const & countryId,
@@ -207,7 +207,7 @@ void BuildTransit(string const & mwmDir, TCountryId const & countryId,
     return; // Empty transit section.
 
   ProcessGraph(mwmPath, countryId, mapping, jointData);
-  jointData.CheckValid();
+  jointData.CheckValidSortedUnique();
 
   FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
   FileWriter writer = cont.GetWriter(TRANSIT_FILE_TAG);

--- a/transit/transit_graph_data.cpp
+++ b/transit/transit_graph_data.cpp
@@ -325,7 +325,7 @@ void GraphData::Clear()
   Visit(v);
 }
 
-void GraphData::CheckValid() const
+void GraphData::CheckValidSortedUnique() const
 {
   {
     CheckSortedVisitor v;
@@ -359,7 +359,7 @@ void GraphData::Sort()
 void GraphData::ClipGraph(vector<m2::RegionD> const & borders)
 {
   Sort();
-  CheckValid();
+  CheckValidSortedUnique();
   ClipLines(borders);
   ClipStops();
   ClipNetworks();
@@ -367,7 +367,7 @@ void GraphData::ClipGraph(vector<m2::RegionD> const & borders)
   ClipTransfer();
   ClipEdges();
   ClipShapes();
-  CheckValid();
+  CheckValidSortedUnique();
 }
 
 void GraphData::SetGateBestPedestrianSegment(size_t gateIdx, SingleMwmSegment const & s)

--- a/transit/transit_graph_data.hpp
+++ b/transit/transit_graph_data.hpp
@@ -134,7 +134,7 @@ public:
   void DeserializeForCrossMwm(Reader & reader);
   void AppendTo(GraphData const & rhs);
   void Clear();
-  void CheckValid() const;
+  void CheckValidSortedUnique() const;
   bool IsEmpty() const;
 
   /// \brief Sorts all class fields by their ids.

--- a/transit/transit_graph_data.hpp
+++ b/transit/transit_graph_data.hpp
@@ -134,7 +134,7 @@ public:
   void DeserializeForCrossMwm(Reader & reader);
   void AppendTo(GraphData const & rhs);
   void Clear();
-  bool IsValid() const;
+  void CheckValid() const;
   bool IsEmpty() const;
 
   /// \brief Sorts all class fields by their ids.
@@ -159,9 +159,6 @@ private:
                                   visitor(m_edges, "edges"), visitor(m_transfers, "transfers"),
                                   visitor(m_lines, "lines"), visitor(m_shapes, "shapes"),
                                   visitor(m_networks, "networks"))
-
-  bool IsUnique() const;
-  bool IsSorted() const;
 
   /// \brief Clipping |m_lines| with |borders|.
   /// \details After a call of the method the following stop ids in |m_lines| are left:

--- a/transit/transit_tests/transit_graph_test.cpp
+++ b/transit/transit_tests/transit_graph_test.cpp
@@ -515,7 +515,7 @@ void SerializeAndDeserializeGraph(GraphData & src, GraphData & dst)
 
   MemReader reader(buffer.data(), buffer.size());
   dst.DeserializeAll(reader);
-  dst.CheckValid();
+  dst.CheckValidSortedUnique();
 }
 
 //                       ^

--- a/transit/transit_tests/transit_graph_test.cpp
+++ b/transit/transit_tests/transit_graph_test.cpp
@@ -515,7 +515,7 @@ void SerializeAndDeserializeGraph(GraphData & src, GraphData & dst)
 
   MemReader reader(buffer.data(), buffer.size());
   dst.DeserializeAll(reader);
-  TEST(dst.IsValid(), ());
+  dst.CheckValid();
 }
 
 //                       ^

--- a/transit/transit_tests/transit_test.cpp
+++ b/transit/transit_tests/transit_test.cpp
@@ -86,16 +86,13 @@ UNIT_TEST(Transit_HeaderRewriting)
 
 namespace
 {
-UNIT_TEST(Transit_IsValidSortedUnique)
+UNIT_TEST(Transit_CheckValidSortedUnique)
 {
   vector<Network> const networks = {Network(1 /* id */, "Title 1"), Network(2 /* id */, "Title 2")};
-  TEST(IsValidSortedUnique(networks), ());
+  CheckValidSortedUnique(networks, "networks");
 
-  vector<Stop> const stops(5);
-  TEST(!IsValidSortedUnique(stops), ());
-
-  vector<ShapeId> const shapeIds = {ShapeId(1, 2), ShapeId(1, 2)};
-  TEST(!IsValidSortedUnique(shapeIds), ());
+  vector<ShapeId> const shapeIds = {ShapeId(1, 2), ShapeId(1, 3)};
+  CheckValidSortedUnique(shapeIds, "shapeIds");
 }
 
 UNIT_TEST(Transit_HeaderSerialization)

--- a/transit/transit_types.hpp
+++ b/transit/transit_types.hpp
@@ -473,7 +473,7 @@ void CheckValid(std::vector<Item> const & items, std::string const & name)
 template <class Item>
 void CheckSorted(std::vector<Item> const & items, std::string const & name)
 {
-  CHECK(std::is_sorted(items.cend(), items.cend()), ("Table is not sorted. Table name:", name));
+  CHECK(std::is_sorted(items.cbegin(), items.cend()), ("Table is not sorted. Table name:", name));
 }
 
 template <class Item>

--- a/transit/transit_types.hpp
+++ b/transit/transit_types.hpp
@@ -5,7 +5,6 @@
 #include "geometry/point2d.hpp"
 
 #include "base/newtype.hpp"
-#include "base/stl_add.hpp"
 #include "base/visitor.hpp"
 
 #include <algorithm>
@@ -465,15 +464,31 @@ private:
 };
 
 template <class Item>
-bool IsValid(std::vector<Item> const & items)
+void CheckValid(std::vector<Item> const & items, std::string const & name)
 {
-  return std::all_of(items.cbegin(), items.cend(), [](Item const & item) { return item.IsValid(); });
+  for (auto const & i :items)
+    CHECK(i.IsValid(), (i, "is not valid. Table name:", name));
 }
 
 template <class Item>
-bool IsValidSortedUnique(std::vector<Item> const & items)
+void CheckSorted(std::vector<Item> const & items, std::string const & name)
 {
-  return IsValid(items) && IsSortedAndUnique(items.cbegin(), items.cend());
+  CHECK(std::is_sorted(items.cend(), items.cend()), ("Table is not sorted. Table name:", name));
+}
+
+template <class Item>
+void CheckUnique(std::vector<Item> const & items, std::string const & name)
+{
+  auto const it = std::adjacent_find(items.cbegin(), items.cend());
+  CHECK(it == items.cend(), (*it, "is not unique. Table name:", name));
+}
+
+template <class Item>
+void CheckValidSortedUnique(std::vector<Item> const & items, std::string const & name)
+{
+  CheckValid(items, name);
+  CheckSorted(items, name);
+  CheckUnique(items, name);
 }
 
 EdgeFlags GetEdgeFlags(bool transfer, StopId stopId1, StopId stopId2,


### PR DESCRIPTION
Ранее при генерации секций связанных с общественным транспортом использовался следующий подход:
- на вход подавался json с графом общественного транспорта;
- данный json загружался в GraphData;
- и если в нем оказывались не уникальные элементы, или не отсортированные таблицы, или не валидные элементы, то генератор прекращал свою работу и говорил, что граф не валиден.
- требовалось отдельное исследование, чтоб понять, что именно в графе не так.

Теперь, в случае проблем с графом, генератор остановится и выдаст достаточно информации, чтоб поправить ошибку:
- в какой таблице произошла проблема;
- какой элемент не уникален;
- какой элемент не валиден;

@Zverik @tatiana-yan @darina PTAL