### PR TITLE
[editor] Inherit editing properties for long types

### DIFF
--- a/editor/editor_config.cpp
+++ b/editor/editor_config.cpp
@@ -119,6 +119,7 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
                                       TypeAggregatedDescription & outDesc) const
 {
   bool isBuilding = false;
+  vector<string> addTypes;
   for (auto it = classificatorTypes.begin(); it != classificatorTypes.end(); ++it)
   {
     if (*it == "building")
@@ -129,7 +130,14 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
       classificatorTypes.erase(it);
       break;
     }
+    // Adding partial types for 2..N-1 parts of a N-part type.
+    auto hyphenPos = it->find('-');
+    while ((hyphenPos = it->find('-', hyphenPos+1)) != string::npos)
+    {
+      addTypes.push_back(it->substr(0, hyphenPos));
+    }
   }
+  classificatorTypes.insert(classificatorTypes.end(), addTypes.begin(), addTypes.end());
 
   auto const typeNodes = GetPrioritizedTypes(m_document);
   auto const it = find_if(begin(typeNodes), end(typeNodes),

--- a/editor/editor_config.cpp
+++ b/editor/editor_config.cpp
@@ -46,8 +46,7 @@ bool TypeDescriptionFromXml(pugi::xml_node const & root, pugi::xml_node const & 
   if (!node || strcmp(node.attribute("editable").value(), "no") == 0)
     return false;
 
-  auto const handleField = [&outDesc](string const & fieldName)
-  {
+  auto const handleField = [&outDesc](string const & fieldName) {
     if (fieldName == "name")
     {
       outDesc.m_name = true;
@@ -86,7 +85,7 @@ bool TypeDescriptionFromXml(pugi::xml_node const & root, pugi::xml_node const & 
   {
     auto const node = xNode.node();
     string const fieldName = node.attribute("field").value();
-      handleField(fieldName);
+    handleField(fieldName);
   }
 
   my::SortUnique(outDesc.m_editableFields);
@@ -99,16 +98,16 @@ vector<pugi::xml_node> GetPrioritizedTypes(pugi::xml_node const & node)
   vector<pugi::xml_node> result;
   for (auto const xNode : node.select_nodes("/mapsme/editor/types/type[@id]"))
     result.push_back(xNode.node());
-  stable_sort(begin(result), end(result), [](pugi::xml_node const & lhs, pugi::xml_node const & rhs)
-  {
-    auto const lhsWeight = kPriorityWeights.find(lhs.attribute("priority").value());
-    auto const rhsWeight = kPriorityWeights.find(rhs.attribute("priority").value());
+  stable_sort(begin(result), end(result),
+              [](pugi::xml_node const & lhs, pugi::xml_node const & rhs) {
+                auto const lhsWeight = kPriorityWeights.find(lhs.attribute("priority").value());
+                auto const rhsWeight = kPriorityWeights.find(rhs.attribute("priority").value());
 
-    CHECK(lhsWeight != kPriorityWeights.end(), (""));
-    CHECK(rhsWeight != kPriorityWeights.end(), (""));
+                CHECK(lhsWeight != kPriorityWeights.end(), (""));
+                CHECK(rhsWeight != kPriorityWeights.end(), (""));
 
-    return lhsWeight->second < rhsWeight->second;
-  });
+                return lhsWeight->second < rhsWeight->second;
+              });
   return result;
 }
 }  // namespace
@@ -132,7 +131,7 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
     }
     // Adding partial types for 2..N-1 parts of a N-part type.
     auto hyphenPos = it->find('-');
-    while ((hyphenPos = it->find('-', hyphenPos+1)) != string::npos)
+    while ((hyphenPos = it->find('-', hyphenPos + 1)) != string::npos)
     {
       addTypes.push_back(it->substr(0, hyphenPos));
     }
@@ -140,12 +139,11 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
   classificatorTypes.insert(classificatorTypes.end(), addTypes.begin(), addTypes.end());
 
   auto const typeNodes = GetPrioritizedTypes(m_document);
-  auto const it = find_if(begin(typeNodes), end(typeNodes),
-                          [&classificatorTypes](pugi::xml_node const & node)
-                          {
-                            return find(begin(classificatorTypes), end(classificatorTypes),
-                                        node.attribute("id").value()) != end(classificatorTypes);
-                          });
+  auto const it =
+      find_if(begin(typeNodes), end(typeNodes), [&classificatorTypes](pugi::xml_node const & node) {
+        return find(begin(classificatorTypes), end(classificatorTypes),
+                    node.attribute("id").value()) != end(classificatorTypes);
+      });
   if (it == end(typeNodes))
     return isBuilding;
 
@@ -154,7 +152,8 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
 
 vector<string> EditorConfig::GetTypesThatCanBeAdded() const
 {
-  auto const xpathResult = m_document.select_nodes("/mapsme/editor/types/type[not(@can_add='no' or @editable='no')]");
+  auto const xpathResult =
+      m_document.select_nodes("/mapsme/editor/types/type[not(@can_add='no' or @editable='no')]");
 
   vector<string> result;
   for (auto const xNode : xpathResult)
@@ -162,8 +161,5 @@ vector<string> EditorConfig::GetTypesThatCanBeAdded() const
   return result;
 }
 
-void EditorConfig::SetConfig(pugi::xml_document const & doc)
-{
-  m_document.reset(doc);
-}
+void EditorConfig::SetConfig(pugi::xml_document const & doc) { m_document.reset(doc); }
 }  // namespace editor

--- a/editor/editor_tests/editor_config_test.cpp
+++ b/editor/editor_tests/editor_config_test.cpp
@@ -60,6 +60,20 @@ UNIT_TEST(EditorConfig_TypeDescription)
     my::SortUnique(fields);
     TEST_EQUAL(desc.GetEditableFields(), fields, ());
   }
+  {
+    // Testing type inheritance
+    editor::TypeAggregatedDescription desc;
+    TEST(config.GetTypeDescription({"amenity-place_of_worship-christian"}, desc), ());
+    TEST(desc.IsNameEditable(), ());
+    TEST_EQUAL(desc.GetEditableFields(), poi, ());
+  }
+  {
+    // Testing long type inheritance on a fake object
+    editor::TypeAggregatedDescription desc;
+    TEST(config.GetTypeDescription({"tourism-artwork-impresionism-monet"}, desc), ());
+    TEST(desc.IsNameEditable(), ());
+    TEST_EQUAL(desc.GetEditableFields(), TFields {}, ());
+  }
   // TODO(mgsergio): Test case with priority="high" when there is one on editor.config.
 }
 


### PR DESCRIPTION
Оказалось, у нас нельзя изменить название церкви, потому что большинство церквей в данных занесены под длинными типами вида `amenity-place_of_worship-christian` (с религией), а поля в редакторе указаны только для общего `amenity-place_of_worship`. Не было наследования. То же касается станций метро или туристических офисов, например. В этом пул-реквесте я добавляю наследование.

Fixes #7969.