### PR TITLE
Try to fix MapCSS syntax where appropriate

### DIFF
--- a/data/styles/clear/include/Basemap.mapcss
+++ b/data/styles/clear/include/Basemap.mapcss
@@ -181,8 +181,8 @@ area|z10-[place=islet]
 area|z0-[natural=coastline]
 {fill-color: @water;}
 
-area|z0-[natural=land]
-area|z10-[place=islet],
+area|z0-[natural=land],
+area|z10-[place=islet]
 {fill-color: @background;}
 
 /* 3.BOUNDARIES */
@@ -457,7 +457,7 @@ area|z15-[landuse=railway],
 area|z15-[landuse=quarry],
 area|z15-[leisure=pitch],
 area|z15-[leisure=stadium],
-area|z15-[amenity=parking]
+area|z15-[amenity=parking],
 area|z16-[public_transport=platform],
 area|z16-[amenity=place_of_worship],
 area|z16-[railway=platform],
@@ -602,7 +602,7 @@ area|z17[landuse=garages],
 area|z17[building=train_station],
 {fill-color: @building_dark;opacity: 0.9;casing-width: 1;casing-color: @building_dark_border;}
 
-area|z17-[aeroway=terminal]
+area|z17-[aeroway=terminal],
 area|z18-[building],
 area|z18-[building:part],
 area|z18-[landuse=garages],

--- a/data/styles/clear/include/Basemap_label.mapcss
+++ b/data/styles/clear/include/Basemap_label.mapcss
@@ -109,11 +109,11 @@ line[waterway],
 *[place]
 {text-position: center;fill-position: background;}
 
-node|z1-2[place=continent]
+node|z1-2[place=continent],
 node|z10-[place=archipelago],
 node|z10-[place=island],
 area|z10-[place=archipelago],
-area|z10-[place=island]
+area|z10-[place=island],
 node|z14-[natural=cape],
 area|z14-[natural=cape]
 {text: name;}
@@ -209,7 +209,7 @@ node|z8-10[place=state]::int_name
 node|z4[place=city][capital!=2][population>=1000000],
 node|z5[place=city][capital!=2][population>=150000],
 node|z6[place=city][capital!=2][population>=50000],
-node|z7-8[place=city][capital!=2][population>=40000]
+node|z7-8[place=city][capital!=2][population>=40000],
 node|z4-[place=city][capital=2],
 node|z9-[place=city]
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
@@ -323,7 +323,7 @@ node|z9[place=town][population>=20000]::int_name
 node|z10-[place=town],
 {text: name;text-color: @label_medium;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
 node|z10-[place=town]::int_name
-{text:int_name;text-color: @label_medium;;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
+{text:int_name;text-color: @label_medium;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
 
 node|z8[place=town][population>=40000]
 {font-size: 10;}

--- a/data/styles/clear/include/Icons.mapcss
+++ b/data/styles/clear/include/Icons.mapcss
@@ -1232,7 +1232,7 @@ node|z16[historic=boundary_stone],
 area|z16[historic=boundary_stone],
 node|z16[historic=wayside_cross],
 area|z16[historic=wayside_cross]
-{icon-image: monument-m.svg;font-size: 11;;icon-min-distance: 8;}
+{icon-image: monument-m.svg;font-size: 11;icon-min-distance: 8;}
 node|z16[historic=ship],
 area|z16[historic=ship]
 {icon-image: historic-ship-m.svg;font-size: 11;icon-min-distance: 8;}
@@ -1276,7 +1276,7 @@ area|z15[tourism=theme_park]
 {icon-image: theme_park-m.svg;icon-min-distance: 36;}
 node|z16[tourism=attraction],
 area|z16[tourism=attraction]
-{icon-image: tourism-m.svg;icon-min-distance: 36}
+{icon-image: tourism-m.svg;icon-min-distance: 36;}
 node|z16[tourism=theme_park],
 area|z16[tourism=theme_park]
 {icon-image: theme_park-m.svg;icon-min-distance: 24;}
@@ -1296,7 +1296,7 @@ area|z15[amenity=community_centre]
 {icon-image: tourism-m.svg;icon-min-distance: 24;}
 node|z16[amenity=community_centre],
 area|z16[amenity=community_centre]
-{icon-image: tourism-m.svg;icon-min-distance: 16}
+{icon-image: tourism-m.svg;icon-min-distance: 16;}
 
 /* 4.2 Apartament */
 
@@ -1874,7 +1874,7 @@ node|z17-[leisure=fitness_centre]
 node|z17-[leisure=sauna]
 {icon-image: sauna-l.svg;-x-me-text-priority: 15500;icon-min-distance: 10;}
 node|z17-[leisure=playground]
-{icon-image: pitch-l.svg;font-size: 11;;icon-min-distance: 10;}
+{icon-image: pitch-l.svg;font-size: 11;icon-min-distance: 10;}
 node|z17-[leisure=swimming_pool],
 area|z17-[leisure=swimming_pool]
 {icon-image: swimming-l.svg;icon-min-distance: 10;}
@@ -2058,7 +2058,7 @@ area|z17-[landuse=landfill]
 
 node|z16-[leisure=water_park],
 area|z16-[leisure=water_park]
-{icon-image: swimming-m.svg;icon-min-distance: 10}
+{icon-image: swimming-m.svg;icon-min-distance: 10;}
 node|z17-[leisure=water_park],
 area|z17-[leisure=water_park]
 {icon-image: swimming-l.svg;}
@@ -2384,7 +2384,7 @@ node|z16[shop=car_repair][service=tyres],
 area|z16[shop=car_repair][service=tyres],
 node|z16[highway=services],
 area|z16[highway=services]
-{icon-image: car-repair-m.svg;;-x-me-text-priority:15500;}
+{icon-image: car-repair-m.svg;-x-me-text-priority:15500;}
 node|z17[shop=car_repair][service=tyres],
 area|z17[shop=car_repair][service=tyres],
 node|z17[highway=services],
@@ -2398,10 +2398,10 @@ area|z18-[highway=services]
 
 node|z16-[shop],
 area|z16-[shop]
-{icon-image: shop-m.svg;text-offset: 1;font-size: 10;icon-min-distance: 10}
+{icon-image: shop-m.svg;text-offset: 1;font-size: 10;icon-min-distance: 10;}
 node|z17-[shop],
 area|z17-[shop]
-{icon-image: shop-l.svg;text-offset: 1;font-size: 10;icon-min-distance: 10}
+{icon-image: shop-l.svg;text-offset: 1;font-size: 10;icon-min-distance: 10;}
 
 node|z16[shop=alcohol],
 area|z16[shop=alcohol]
@@ -2929,7 +2929,7 @@ area|z17[amenity=fuel]
 {icon-image: fuel-l.svg;}
 node|z18-[amenity=fuel],
 area|z18-[amenity=fuel]
-{icon-image: fuel-l.svg;font-size: 11;text:}
+{icon-image: fuel-l.svg;font-size: 11;}
 
 node|z14[amenity=charging_station],
 area|z14[amenity=charging_station]
@@ -2971,7 +2971,7 @@ node|z16[amenity=parking][access=permissive],
 node|z16[amenity=parking][access=private]
 {icon-image: zero-icon.svg;}
 
-node|z17[amenity=parking] area|z17[amenity=parking]
+node|z17[amenity=parking], area|z17[amenity=parking]
 {icon-image: parking-m.svg;}
 node|z17[amenity=parking][access=permissive],
 node|z17[amenity=parking][access=private]

--- a/data/styles/clear/include/Roads.mapcss
+++ b/data/styles/clear/include/Roads.mapcss
@@ -158,7 +158,7 @@ line[railway=abandoned]
 line[highway=bridleway]
 {z-index: 590;}
 
-line[highway=track]
+line[highway=track],
 line[highway=raceway],
 line[leisure=track],
 line[highway=path],
@@ -414,19 +414,19 @@ line|z18-[highway=trunk_link][bridge?]::bridgewhite,
 {casing-width: eval(prop("width")+1);}
 
 line|z13-16[highway=motorway][bridge?]::bridgeblack,
-line|z13-16[highway=trunk][bridge?]::bridgeblack
+line|z13-16[highway=trunk][bridge?]::bridgeblack,
 line|z14-16[highway=motorway_link][bridge?]::bridgeblack,
-line|z14-16[highway=trunk_link][bridge?]::bridgeblack,
+line|z14-16[highway=trunk_link][bridge?]::bridgeblack
 {casing-width: eval(prop("width")+0.4);}
 line|z17[highway=motorway][bridge?]::bridgeblack,
 line|z17[highway=trunk][bridge?]::bridgeblack,
 line|z17[highway=motorway_link][bridge?]::bridgeblack,
-line|z17[highway=trunk_link][bridge?]::bridgeblack,
+line|z17[highway=trunk_link][bridge?]::bridgeblack
 {casing-width: eval(prop("width")+1.6);}
 line|z18-[highway=motorway][bridge?]::bridgeblack,
 line|z18-[highway=trunk][bridge?]::bridgeblack,
 line|z18-[highway=motorway_link][bridge?]::bridgeblack,
-line|z18-[highway=trunk_link][bridge?]::bridgeblack,
+line|z18-[highway=trunk_link][bridge?]::bridgeblack
 {casing-width: eval(prop("width")+2);}
 
 /* 4.PRIMARY 8-22 ZOOM */
@@ -438,7 +438,7 @@ line|z11-14[highway=primary_link]
 {color: @primary_orange_medium;opacity: 1;}
 line|z15-22[highway=primary],
 line|z15-22[highway=primary_link]
-{color: @primary_orange_light;;opacity: 1;}
+{color: @primary_orange_light;opacity: 1;}
 line|z14-[highway=primary][tunnel?],
 line|z14-[highway=primary_link][tunnel?]
 {casing-width: 1;casing-linecap: butt;casing-color: @primary_tunnel_casing;}
@@ -596,9 +596,9 @@ line|z15-[highway=residential_link],
 line|z15-[highway=tertiary_link],
 {color: @residential; opacity: 1;}
 line|z16-[highway=tertiary][tunnel?],
-line|z16-[highway=residential][tunnel?]
+line|z16-[highway=residential][tunnel?],
 line|z16-[highway=tertiary_link][tunnel?],
-line|z16-[highway=residential_link][tunnel?],
+line|z16-[highway=residential_link][tunnel?]
 {color: @tertiary_tunnel;casing-width: 1;casing-linecap: butt;casing-color: @tertiary_tunnel_casing;}
 line|z14-[highway=tertiary][bridge?]::bridgewhite,
 line|z14-[highway=residential][bridge?]::bridgewhite,
@@ -649,9 +649,9 @@ line|z19-[highway=tertiary_link]
 /* 6.2 Residential & Tertiary tunnel 16-22 ZOOM */
 
 line|z16-[highway=tertiary][tunnel?],
-line|z16-[highway=residential][tunnel?]
+line|z16-[highway=residential][tunnel?],
 line|z16-[highway=tertiary_link][tunnel?],
-line|z16-[highway=residential_link][tunnel?],
+line|z16-[highway=residential_link][tunnel?]
 {casing-dashes: 5,5;}
 
 /* 6.3 Residential & Tertiary bridge 14-22 ZOOM */
@@ -781,7 +781,7 @@ line|z13-[highway=construction],
 line|z13-[highway=proposed]
 {color: @construction;opacity: 1;}
 line|z13-[highway=pedestrian][bridge?]::bridgewhite,
-line|z13-[highway=footway][bridge?]::bridgewhite
+line|z13-[highway=footway][bridge?]::bridgewhite,
 line|z16-[highway=steps][bridge?]::bridgewhite,
 line|z16-[highway=road][bridge?]::bridgewhite,
 line|z16-[highway=service][bridge?]::bridgewhite
@@ -792,11 +792,11 @@ line|z16-[highway=steps][bridge?]::bridgeblack,
 line|z16-[highway=road][bridge?]::bridgeblack,
 line|z16-[highway=service][bridge?]::bridgeblack
 {casing-linecap: butt;casing-color:@bridge_casing;}
-line|z14-[highway=track]
+line|z14-[highway=track],
 line|z14-[highway=raceway],
 line|z14-[leisure=track],
 line|z14-[highway=path],
-line|z14-[route=hiking],
+line|z14-[route=hiking]
 {color: @track;opacity: 1;}
 line|z14-[highway=bridleway]
 {color: @bridleway;opacity: 1;}
@@ -1027,7 +1027,7 @@ line|z15-[aeroway=taxiway]
 
 line|z11-[railway=rail],
 line|z11-[railway=yard],
-line|z12-[railway=funicular]
+line|z12-[railway=funicular],
 line|z13-[railway=light_rail],
 line|z14-[railway=monorail],
 line|z15-[railway=narrow_gauge],

--- a/data/styles/clear/include/Roads_label.mapcss
+++ b/data/styles/clear/include/Roads_label.mapcss
@@ -59,7 +59,7 @@ line[railway=abandoned]
 line[highway=bridleway]
 {z-index: 590;}
 
-line[highway=track]
+line[highway=track],
 line[highway=raceway],
 line[leisure=track],
 line[highway=path],

--- a/data/styles/clear/include/defaults_new.mapcss
+++ b/data/styles/clear/include/defaults_new.mapcss
@@ -59,7 +59,7 @@ area::* {
 *[craft],
 *[internet_access],
 {
-  text-position: center
+  text-position: center;
 }
 area[aeroway],
 area[tourism]

--- a/data/styles/vehicle/include/Basemap.mapcss
+++ b/data/styles/vehicle/include/Basemap.mapcss
@@ -174,8 +174,8 @@ area|z10-[place=islet]
 area|z0-[natural=coastline]
 {fill-color: @water;}
 
-area|z0-[natural=land]
-area|z10-[place=islet],
+area|z0-[natural=land],
+area|z10-[place=islet]
 {fill-color: @background;}
 
 /* 3.BOUNDARIES */
@@ -560,11 +560,11 @@ area|z17[landuse=garages],
 area|z17[building=train_station],
 {fill-color: @building;opacity: 0.55;casing-width: 1;casing-color: @building_border;}
 
-area|z17-[aeroway=terminal]
+area|z17-[aeroway=terminal],
 area|z18-[building],
 area|z18-[building:part],
 area|z18-[landuse=garages],
-area|z18-[building=train_station],
+area|z18-[building=train_station]
 {fill-color: @building;opacity: 0.55;casing-width: 1;casing-color: @building_border;}
 
 /* 8.3 Barrier */

--- a/data/styles/vehicle/include/Basemap_label.mapcss
+++ b/data/styles/vehicle/include/Basemap_label.mapcss
@@ -109,11 +109,11 @@ line[waterway],
 *[place]
 {text-position: center;fill-position: background;}
 
-node|z1-2[place=continent]
+node|z1-2[place=continent],
 node|z12-[place=archipelago],
 node|z12-14[place=island],
 area|z12-[place=archipelago],
-area|z12-14[place=island]
+area|z12-14[place=island],
 node|z14-[natural=cape],
 area|z14-[natural=cape]
 {text: name;}
@@ -191,7 +191,7 @@ node|z8-10[place=state]::int_name
 node|z4[place=city][capital!=2][population>=1000000],
 node|z5[place=city][capital!=2][population>=150000],
 node|z6[place=city][capital!=2][population>=50000],
-node|z7-8[place=city][capital!=2][population>=40000]
+node|z7-8[place=city][capital!=2][population>=40000],
 node|z4-[place=city][capital=2],
 node|z9-[place=city]
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
@@ -304,7 +304,7 @@ node|z9[place=town][population>=20000]::int_name
 node|z10-[place=town],
 {text: name;text-color: @label_medium;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
 node|z10-[place=town]::int_name
-{text:int_name;text-color: @label_medium;;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
+{text:int_name;text-color: @label_medium;text-halo-radius: 1;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;}
 
 node|z8[place=town][population>=40000]
 {font-size: 10;}

--- a/data/styles/vehicle/include/Icons.mapcss
+++ b/data/styles/vehicle/include/Icons.mapcss
@@ -479,7 +479,7 @@ node|z17-[vending=parking_tickets],
 area|z17-[vending=parking_tickets],
 node|z17-[amenity=vending_machine],
 area|z17-[amenity=vending_machine],
-{text: name;text-color: @poi_label;text-offset: 1;font-size: 11;text-min-distance: 14}
+{text: name;text-color: @poi_label;text-offset: 1;font-size: 11;text-min-distance: 14;}
 
 /* POI */
 
@@ -585,10 +585,10 @@ area|z18-[amenity=place_of_worship][religion=hindu]
 
 node|z17[amenity=bank],
 area|z17[amenity=bank]
-{icon-image: bank-l.svg;font-size: 13.75; icon-min-distance: 15}
+{icon-image: bank-l.svg;font-size: 13.75; icon-min-distance: 15;}
 node|z18-[amenity=bank],
 area|z18-[amenity=bank]
-{icon-image: bank-xl.svg;font-size: 14.5; icon-min-distance: 10}
+{icon-image: bank-xl.svg;font-size: 14.5; icon-min-distance: 10;}
 
 
 node|z12-14[barrier=toll_booth],
@@ -678,7 +678,7 @@ area|z15[shop=car_repair][service=tyres]
 {icon-image: car-repair-m.svg;text-offset: 1;-x-me-text-priority:15500;icon-min-distance: 20;font-size:12.5;}
 node|z16[shop=car_repair][service=tyres],
 area|z16[shop=car_repair][service=tyres]
-{icon-image: car-repair-l.svg;;-x-me-text-priority:15500;font-size: 12.75;}
+{icon-image: car-repair-l.svg;-x-me-text-priority:15500;font-size: 12.75;}
 node|z17[shop=car_repair][service=tyres],
 area|z17[shop=car_repair][service=tyres]
 {icon-image: car-repair-l.svg;font-size: 13.75;}
@@ -750,7 +750,7 @@ area|z17[amenity=fuel]
 {icon-image: fuel-l.svg;font-size: 13.75;}
 node|z18-[amenity=fuel],
 area|z18-[amenity=fuel]
-{icon-image: fuel-xl.svg;font-size: 14.5;text:}
+{icon-image: fuel-xl.svg;font-size: 14.5;}
 
 node|z14[amenity=charging_station],
 area|z14[amenity=charging_station]
@@ -812,7 +812,7 @@ node|z17[amenity=parking][access=permissive],
 node|z17[amenity=parking][access=private]
 {icon-image: zero-icon.svg;z-index: 6;icon-min-distance: 7;}
 
-node|z18[amenity=parking] area|z18[amenity=parking]
+node|z18[amenity=parking], area|z18[amenity=parking]
 {icon-image: parking-xl.svg;icon-min-distance: 10;}
 node|z18[amenity=parking][access=permissive],
 node|z18[amenity=parking][access=private]

--- a/data/styles/vehicle/include/Roads.mapcss
+++ b/data/styles/vehicle/include/Roads.mapcss
@@ -158,7 +158,7 @@ line[railway=abandoned]
 line[highway=bridleway]
 {z-index: 590;}
 
-line[highway=track]
+line[highway=track],
 line[highway=raceway],
 line[leisure=track],
 line[highway=path],
@@ -340,41 +340,41 @@ line|z13[highway=motorway_link],
 line|z13[highway=trunk_link]
 {color: @trunk_orange_medium; width: 2.8;}
 line|z14[highway=trunk],
-line|z14[highway=motorway],
-{color: @trunk_orange_medium; width: 5.25;casing-width: 0.75}
+line|z14[highway=motorway]
+{color: @trunk_orange_medium; width: 5.25;casing-width: 0.75;}
 line|z14[highway=motorway_link],
 line|z14[highway=trunk_link]
-{color: @trunk_orange_medium; width: 3.37;casing-width: 0.45}
+{color: @trunk_orange_medium; width: 3.37;casing-width: 0.45;}
 line|z15[highway=trunk],
 line|z15[highway=motorway],
-{color:@trunk_orange_medium; width: 6.5;casing-width: 0.85}
+{color:@trunk_orange_medium; width: 6.5;casing-width: 0.85;}
 line|z15[highway=motorway_link],
 line|z15[highway=trunk_link]
-{color:@trunk_orange_medium; width: 5.5;casing-width: 0.55}
+{color:@trunk_orange_medium; width: 5.5;casing-width: 0.55;}
 line|z16[highway=trunk],
 line|z16[highway=motorway],
-{color:@trunk_orange_medium; width: 9.85;casing-width: 1.1}
+{color:@trunk_orange_medium; width: 9.85;casing-width: 1.1;}
 line|z16[highway=motorway_link],
 line|z16[highway=trunk_link]
-{color:@trunk_orange_medium; width: 7.95;casing-width: 0.8}
+{color:@trunk_orange_medium; width: 7.95;casing-width: 0.8;}
 line|z17[highway=trunk],
 line|z17[highway=motorway],
-{color:@trunk_orange_medium; width: 16;casing-width: 1.1}
+{color:@trunk_orange_medium; width: 16;casing-width: 1.1;}
 line|z17[highway=motorway_link],
 line|z17[highway=trunk_link]
-{color:@trunk_orange_medium; width: 13;casing-width: 1.0}
+{color:@trunk_orange_medium; width: 13;casing-width: 1.0;}
 line|z18[highway=trunk],
 line|z18[highway=motorway],
-{color:@trunk_orange_medium; width: 26;casing-width: 1.35}
+{color:@trunk_orange_medium; width: 26;casing-width: 1.35;}
 line|z18[highway=motorway_link],
 line|z18[highway=trunk_link]
-{color:@trunk_orange_medium; width: 20;casing-width: 1.15}
+{color:@trunk_orange_medium; width: 20;casing-width: 1.15;}
 line|z19-[highway=trunk],
 line|z19-[highway=motorway],
-{color:@trunk_orange_medium; width: 36;casing-width: 1.5}
+{color:@trunk_orange_medium; width: 36;casing-width: 1.5;}
 line|z19-[highway=motorway_link],
 line|z19-[highway=trunk_link]
-{color:@trunk_orange_medium; width: 26;casing-width: 1.25}
+{color:@trunk_orange_medium; width: 26;casing-width: 1.25;}
 
 /* 3.2 Trunk & Motorway tunnel 12-22 ZOOM */
 
@@ -414,7 +414,7 @@ line|z18-[highway=trunk_link][bridge?]::bridgewhite,
 {casing-width: eval(prop("width")+1);}
 
 line|z13-16[highway=motorway][bridge?]::bridgeblack,
-line|z13-16[highway=trunk][bridge?]::bridgeblack
+line|z13-16[highway=trunk][bridge?]::bridgeblack,
 line|z14-16[highway=motorway_link][bridge?]::bridgeblack,
 line|z14-16[highway=trunk_link][bridge?]::bridgeblack,
 {casing-width: eval(prop("width")+0.4);}
@@ -468,22 +468,22 @@ line|z13[highway=primary]
 {width: 3;}
 line|z14[highway=primary],
 line|z14[highway=primary_link]
-{width: 3.5;casing-width: 0.35}
+{width: 3.5;casing-width: 0.35;}
 line|z15[highway=primary],
 line|z15[highway=primary_link]
-{width: 4.7;casing-width: 0.55}
+{width: 4.7;casing-width: 0.55;}
 line|z16[highway=primary],
 line|z16[highway=primary_link]
-{width: 7.2;casing-width: 0.8}
+{width: 7.2;casing-width: 0.8;}
 line|z17[highway=primary],
 line|z17[highway=primary_link]
-{width: 14;casing-width: 0.9}
+{width: 14;casing-width: 0.9;}
 line|z18[highway=primary],
 line|z18[highway=primary_link]
-{width: 23;casing-width: 1.1}
+{width: 23;casing-width: 1.1;}
 line|z19-[highway=primary],
 line|z19-[highway=primary_link]
-{width: 30;casing-width: 1.3}
+{width: 30;casing-width: 1.3;}
 
 /* 4.2 Primary tunnel 14-22 ZOOM */
 
@@ -543,22 +543,22 @@ line|z13[highway=secondary]
 {width: 2.9;}
 line|z14[highway=secondary],
 line|z14[highway=secondary_link]
-{width: 3.2;casing-width: 0.35}
+{width: 3.2;casing-width: 0.35;}
 line|z15[highway=secondary],
 line|z15[highway=secondary_link]
-{width: 4.5;casing-width: 0.55}
+{width: 4.5;casing-width: 0.55;}
 line|z16[highway=secondary],
 line|z16[highway=secondary_link]
-{width: 6.5;casing-width: 0.8}
+{width: 6.5;casing-width: 0.8;}
 line|z17[highway=secondary],
 line|z17[highway=secondary_link]
-{width: 10.5;casing-width: 0.9}
+{width: 10.5;casing-width: 0.9;}
 line|z18[highway=secondary],
 line|z18[highway=secondary_link]
-{width: 16;casing-width: 1.1}
+{width: 16;casing-width: 1.1;}
 line|z19-[highway=secondary],
 line|z19-[highway=secondary_link]
-{width: 24;casing-width: 1.3}
+{width: 24;casing-width: 1.3;}
 
 /* 5.2 Secondary tunnel 16-22 ZOOM */
 
@@ -599,7 +599,7 @@ line|z15-[highway=residential_link],
 line|z15-[highway=tertiary_link],
 {color: @residential; opacity: 1;casing-linecap: butt; casing-color:@casing_road;}
 line|z16-[highway=tertiary][tunnel?],
-line|z16-[highway=residential][tunnel?]
+line|z16-[highway=residential][tunnel?],
 line|z16-[highway=tertiary_link][tunnel?],
 line|z16-[highway=residential_link][tunnel?],
 {color: @tertiary_tunnel;casing-width: 1;casing-linecap: butt;casing-color: @tertiary_tunnel_casing;}
@@ -624,19 +624,19 @@ line|z14[highway=tertiary]
 {width: 3.3;}
 line|z15[highway=tertiary],
 line|z15[highway=tertiary_link]
-{width: 5;casing-width: 0.45}
+{width: 5;casing-width: 0.45;}
 line|z16[highway=tertiary],
 line|z16[highway=tertiary_link]
-{width: 7.5;casing-width: 0.55}
+{width: 7.5;casing-width: 0.55;}
 line|z17[highway=tertiary],
 line|z17[highway=tertiary_link]
-{width: 10;casing-width: 0.75}
+{width: 10;casing-width: 0.75;}
 line|z18[highway=tertiary],
 line|z18[highway=tertiary_link]
-{width: 15;casing-width: 0.9}
+{width: 15;casing-width: 0.9;}
 line|z19-[highway=tertiary],
 line|z19-[highway=tertiary_link]
-{width: 21;casing-width: 1.1}
+{width: 21;casing-width: 1.1;}
 
 
 
@@ -650,24 +650,24 @@ line|z14[highway=residential],
 {width: 2.2;}
 line|z15[highway=residential],
 line|z15[highway=residential_link],
-{width: 4.8;casing-width: 0.45}
+{width: 4.8;casing-width: 0.45;}
 line|z16[highway=residential],
 line|z16[highway=residential_link],
-{width: 7;casing-width: 0.55}
+{width: 7;casing-width: 0.55;}
 line|z17[highway=residential],
 line|z17[highway=residential_link],
-{width: 13;casing-width: 0.75}
+{width: 13;casing-width: 0.75;}
 line|z18[highway=residential],
 line|z18[highway=residential_link],
-{width: 17;casing-width: 0.9}
+{width: 17;casing-width: 0.9;}
 line|z19-[highway=residential],
 line|z19-[highway=residential_link],
-{width: 22;casing-width: 1.1}
+{width: 22;casing-width: 1.1;}
 
 /* 6.2 Residential & Tertiary tunnel 16-22 ZOOM */
 
 line|z16-[highway=tertiary][tunnel?],
-line|z16-[highway=residential][tunnel?]
+line|z16-[highway=residential][tunnel?],
 line|z16-[highway=tertiary_link][tunnel?],
 line|z16-[highway=residential_link][tunnel?],
 {casing-dashes: 5,5;}
@@ -806,7 +806,7 @@ line|z13-[highway=construction],
 line|z13-[highway=proposed]
 {color: @construction;opacity: 1;}
 line|z13-[highway=pedestrian][bridge?]::bridgewhite,
-line|z13-[highway=footway][bridge?]::bridgewhite
+line|z13-[highway=footway][bridge?]::bridgewhite,
 line|z16-[highway=steps][bridge?]::bridgewhite,
 line|z16-[highway=road][bridge?]::bridgewhite,
 line|z16-[highway=service][bridge?]::bridgewhite
@@ -1045,7 +1045,7 @@ line|z15-[aeroway=taxiway]
 
 line|z11-[railway=rail],
 line|z11-[railway=yard],
-line|z12-[railway=funicular]
+line|z12-[railway=funicular],
 line|z13-[railway=light_rail],
 line|z14-[railway=monorail],
 line|z15-[railway=narrow_gauge],

--- a/data/styles/vehicle/include/Roads_label.mapcss
+++ b/data/styles/vehicle/include/Roads_label.mapcss
@@ -59,7 +59,7 @@ line[railway=abandoned]
 line[highway=bridleway]
 {z-index: 590;}
 
-line[highway=track]
+line[highway=track],
 line[highway=raceway],
 line[leisure=track],
 line[highway=path],

--- a/data/styles/vehicle/include/defaults_new.mapcss
+++ b/data/styles/vehicle/include/defaults_new.mapcss
@@ -59,7 +59,7 @@ area::* {
 *[craft],
 *[internet_access],
 {
-  text-position: center
+  text-position: center;
 }
 area[aeroway],
 area[tourism]


### PR DESCRIPTION
I'm currently implementing a map renderer / MapCSS parser, and had a few minor issues with parsing Maps.ME stylesheets. Rather than adding workarounds to the parser, I thought it might be a good idea to fix at least those stylesheet fragments that clearly deviate from [the specification](https://wiki.openstreetmap.org/wiki/MapCSS/0.2).

This includes:
  * missing commas between selectors (`line[highway=track] line[highway=raceway]` → `line[highway=track], line[highway=raceway]`);
  * duplicate semicolons in rules (`;;` → `;`);
  * missing semicolons after the last rule (`{text-position: center}` → `{text-position: center;}`);
  * abruptly terminating rules (`{icon-image: fuel-xl.svg;font-size: 14.5;text:}` → `{icon-image: fuel-xl.svg;font-size: 14.5;}`).

IMO these changes seem to improve stylesheet readability a bit, so even though Kothic doesn't care much about these irregularities, it still _might_ make sense to merge this PR.

### Testing done

I re-generated the binary styles with `python libkomwm.py -s ~/omim/data/styles/.../style.mapcss -o ...-style.bin -d ~/omim/data`. The binary output is identical to that of the `master` branch for all of the styles (`clear-clear`, `clear-night`, `vehicle-clear`, `vehicle-night`).