### PR TITLE
[search] Allow first letter misprint

### DIFF
--- a/base/levenshtein_dfa.hpp
+++ b/base/levenshtein_dfa.hpp
@@ -3,6 +3,7 @@
 #include "base/string_utils.hpp"
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace strings
@@ -94,8 +95,9 @@ public:
   LevenshteinDFA(LevenshteinDFA const &) = default;
   LevenshteinDFA(LevenshteinDFA &&) = default;
 
-  LevenshteinDFA(UniString const & s, size_t prefixCharsToKeep, size_t maxErrors);
-  LevenshteinDFA(std::string const & s, size_t prefixCharsToKeep, size_t maxErrors);
+  LevenshteinDFA(UniString const & s, size_t prefixSize,
+                 std::vector<UniString> const & prefixMisprints, size_t maxErrors);
+  LevenshteinDFA(std::string const & s, size_t prefixSize, size_t maxErrors);
   LevenshteinDFA(UniString const & s, size_t maxErrors);
   LevenshteinDFA(std::string const & s, size_t maxErrors);
 

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -432,16 +432,27 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
 
   TestCity chekhov(m2::PointD(0, 0), "Чеховъ Антонъ Павловичъ", "ru", 100 /* rank */);
 
+  TestStreet yesenina(
+      vector<m2::PointD>{m2::PointD(0.5, -0.5), m2::PointD(0, 0), m2::PointD(-0.5, 0.5)},
+      "Yesenina street", "en");
+
   TestStreet pushkinskaya(
       vector<m2::PointD>{m2::PointD(-0.5, -0.5), m2::PointD(0, 0), m2::PointD(0.5, 0.5)},
       "Улица Пушкинская", "ru");
+
+  TestStreet ostrovskogo(
+      vector<m2::PointD>{m2::PointD(-0.5, 0.0), m2::PointD(0, 0), m2::PointD(0.5, 0.0)},
+      "улица Островского", "ru");
+
   TestPOI lermontov(m2::PointD(0, 0), "Трактиръ Лермонтовъ", "ru");
   lermontov.SetTypes({{"amenity", "cafe"}});
 
   auto worldId = BuildWorld([&](TestMwmBuilder & builder) { builder.Add(chekhov); });
 
   auto wonderlandId = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
+    builder.Add(yesenina);
     builder.Add(pushkinskaya);
+    builder.Add(ostrovskogo);
     builder.Add(lermontov);
   });
 
@@ -460,6 +471,14 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
   checkErrors("кафе лермонтов", ErrorsMade(1));
   checkErrors("трактир лермонтов", ErrorsMade(2));
   checkErrors("кафе", ErrorsMade());
+
+  checkErrors("Yesenina cafe", ErrorsMade(0));
+  checkErrors("Esenina cafe", ErrorsMade(1));
+  checkErrors("Jesenina cafe", ErrorsMade(1));
+
+  checkErrors("Островского кафе", ErrorsMade(0));
+  checkErrors("Астровского кафе", ErrorsMade(1));
+
   checkErrors("пушкенская трактир лермонтов", ErrorsMade(3));
   checkErrors("пушкенская кафе", ErrorsMade(1));
   checkErrors("пушкинская трактиръ лермонтовъ", ErrorsMade(0));

--- a/search/utils.cpp
+++ b/search/utils.cpp
@@ -6,6 +6,20 @@
 
 using namespace std;
 
+namespace
+{
+vector<strings::UniString> const kAllowedMisprints = {
+    strings::MakeUniString("ckq"),
+    strings::MakeUniString("eyjiu"),
+    strings::MakeUniString("gh"),
+    strings::MakeUniString("pf"),
+    strings::MakeUniString("vw"),
+    strings::MakeUniString("ао"),
+    strings::MakeUniString("еиэ"),
+    strings::MakeUniString("шщ"),
+};
+}  // namespace
+
 namespace search
 {
 size_t GetMaxErrorsForToken(strings::UniString const & token)
@@ -23,9 +37,9 @@ size_t GetMaxErrorsForToken(strings::UniString const & token)
 strings::LevenshteinDFA BuildLevenshteinDFA(strings::UniString const & s)
 {
   // In search we use LevenshteinDFAs for fuzzy matching. But due to
-  // performance reasons, we assume that the first letter is always
-  // correct.
-  return strings::LevenshteinDFA(s, 1 /* prefixCharsToKeep */, GetMaxErrorsForToken(s));
+  // performance reasons, we limit prefix misprints to fixed set of substitutions defined in
+  // kAllowedMisprints and skipped letters.
+  return strings::LevenshteinDFA(s, 1 /* prefixSize */, kAllowedMisprints, GetMaxErrorsForToken(s));
 }
 
 MwmSet::MwmHandle FindWorld(Index const & index, vector<shared_ptr<MwmInfo>> const & infos)


### PR DESCRIPTION
Данный PR разрешает опечатки в первых буквах.

Посмотрела на производительность при помощи `features_collector_tool`:

было:
```
 real    9m30.546s
 user    3m35.131s
 sys     6m1.028s
```

стало на 5% медленнее:
```
 real    10m3.026s
 user    4m1.396s
 sys     6m9.829s
```

посмотрела на запросы из выборки, которую мы сейчас размечаем, из 1000 запросов есть видимые улучшения на следующих:
```
 иосква (москва)
 юольшой (большой)
 чолнечный (солнечный)
 Жмариуполь (мариуполь)
 AvOttekatu (avenue Ottekatu)
 сгус (село гусаровское)
 улваршавская (ул варшавская)
 pgrunwaldzka (grunwaldzka)
```
и еще 3-5 потенциальных улучшений -- слова где есть опечатки в первых буквах, но дальше другие проблемы -- опечаток слишком много или на улице нет нужного номера дома, а неполный поиск пока не включен.