### PR TITLE
Reducing RoutingWeight size from 24 bytes to 16 bytes.

### DIFF
--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -264,6 +264,7 @@ private:
   void AddEdge(Segment const & segment, connector::Weight weight,
                std::vector<SegmentEdge> & edges) const
   {
+    // @TODO Double and uint32_t are compared below. This comparison should be fixed.
     if (weight != connector::kNoRoute)
       edges.emplace_back(segment, RouteWeight::FromCrossMwmWeight(weight));
   }

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -150,7 +150,7 @@ bool IndexGraphStarter::CheckLength(RouteWeight const & weight)
 {
   // We allow 1 pass-through/non-pass-through zone changes per ending located in
   // non-pass-through zone to allow user to leave this zone.
-  int32_t const numPassThroughChangesAllowed =
+  int8_t const numPassThroughChangesAllowed =
       (StartPassThroughAllowed() ? 0 : 1) + (FinishPassThroughAllowed() ? 0 : 1);
 
   return weight.GetNumPassThroughChanges() <= numPassThroughChangesAllowed &&

--- a/routing/route_weight.cpp
+++ b/routing/route_weight.cpp
@@ -41,11 +41,11 @@ RouteWeight RouteWeight::operator+(RouteWeight const & rhs) const
 
 RouteWeight RouteWeight::operator-(RouteWeight const & rhs) const
 {
-  ASSERT_NOT_EQUAL(m_numPassThroughChanges, std::numeric_limits<int32_t>::min(), ());
-  ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int32_t>::min(), ());
-  ASSERT(!SumWillOverflow(m_numPassThroughChanges, -rhs.m_numPassThroughChanges),
+  ASSERT_NOT_EQUAL(m_numPassThroughChanges, numeric_limits<int8_t>::min(), ());
+  ASSERT_NOT_EQUAL(m_numAccessChanges, numeric_limits<int8_t>::min(), ());
+  ASSERT(!SumWillOverflow(m_numPassThroughChanges, static_cast<int8_t>(-rhs.m_numPassThroughChanges)),
          (m_numPassThroughChanges, -rhs.m_numPassThroughChanges));
-  ASSERT(!SumWillOverflow(m_numAccessChanges, -rhs.m_numAccessChanges),
+  ASSERT(!SumWillOverflow(m_numAccessChanges, static_cast<int8_t>(-rhs.m_numAccessChanges)),
          (m_numAccessChanges, -rhs.m_numAccessChanges));
   return RouteWeight(m_weight - rhs.m_weight, m_numPassThroughChanges - rhs.m_numPassThroughChanges,
                      m_numAccessChanges - rhs.m_numAccessChanges,
@@ -67,8 +67,9 @@ RouteWeight & RouteWeight::operator+=(RouteWeight const & rhs)
 
 ostream & operator<<(ostream & os, RouteWeight const & routeWeight)
 {
-  os << "(" << routeWeight.GetNumPassThroughChanges() << ", " << routeWeight.GetNumAccessChanges()
-     << ", " << routeWeight.GetWeight() << ", " << routeWeight.GetTransitTime() << ")";
+  os << "(" << static_cast<int32_t>(routeWeight.GetNumPassThroughChanges()) << ", "
+     << static_cast<int32_t>(routeWeight.GetNumAccessChanges()) << ", " << routeWeight.GetWeight()
+     << ", " << routeWeight.GetTransitTime() << ")";
   return os;
 }
 

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -20,9 +20,9 @@ public:
   constexpr RouteWeight(double weight, int32_t numPassThroughChanges, int32_t numAccessChanges,
                         double transitTime)
     : m_weight(weight)
-    , m_numPassThroughChanges(numPassThroughChanges)
-    , m_numAccessChanges(numAccessChanges)
-    , m_transitTime(transitTime)
+    , m_numPassThroughChanges(static_cast<int8_t>(numPassThroughChanges))
+    , m_numAccessChanges(static_cast<int8_t>(numAccessChanges))
+    , m_transitTime(static_cast<float>(transitTime))
   {
   }
 
@@ -30,9 +30,9 @@ public:
 
   double ToCrossMwmWeight() const;
   double GetWeight() const { return m_weight; }
-  int32_t GetNumPassThroughChanges() const { return m_numPassThroughChanges; }
-  int32_t GetNumAccessChanges() const { return m_numAccessChanges; }
-  double GetTransitTime() const { return m_transitTime; }
+  int8_t GetNumPassThroughChanges() const { return m_numPassThroughChanges; }
+  int8_t GetNumAccessChanges() const { return m_numAccessChanges; }
+  double GetTransitTime() const { return static_cast<double>(m_transitTime); }
 
   bool operator<(RouteWeight const & rhs) const
   {
@@ -70,8 +70,8 @@ public:
 
   RouteWeight operator-() const
   {
-    ASSERT_NOT_EQUAL(m_numPassThroughChanges, std::numeric_limits<int32_t>::min(), ());
-    ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int32_t>::min(), ());
+    ASSERT_NOT_EQUAL(m_numPassThroughChanges, std::numeric_limits<int8_t>::min(), ());
+    ASSERT_NOT_EQUAL(m_numAccessChanges, std::numeric_limits<int8_t>::min(), ());
     return RouteWeight(-m_weight, -m_numPassThroughChanges, -m_numAccessChanges, -m_transitTime);
   }
 
@@ -80,21 +80,18 @@ public:
     return m_numPassThroughChanges == rhs.m_numPassThroughChanges &&
            m_numAccessChanges == rhs.m_numAccessChanges &&
            my::AlmostEqualAbs(m_weight, rhs.m_weight, epsilon) &&
-           my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, epsilon);
+           my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, static_cast<float>(epsilon));
   }
 
 private:
-  // Note: consider smaller types for m_numPassThroughChanges and m_numAccessChanges
-  // in case of adding new fields to RouteWeight to reduce RouteWeight size.
-
   // Regular weight (seconds).
   double m_weight = 0.0;
   // Number of pass-through/non-pass-through zone changes.
-  int32_t m_numPassThroughChanges = 0;
+  int8_t m_numPassThroughChanges = 0;
   // Number of access=yes/access={private,destination} zone changes.
-  int32_t m_numAccessChanges = 0;
+  int8_t m_numAccessChanges = 0;
   // Transit time. It's already included in |m_weight| (m_transitTime <= m_weight).
-  double m_transitTime = 0.0;
+  float m_transitTime = 0.0F;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
@@ -104,10 +101,10 @@ RouteWeight operator*(double lhs, RouteWeight const & rhs);
 template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
-  return RouteWeight(std::numeric_limits<double>::max() /* weight */,
-                     std::numeric_limits<int32_t>::max() /* numPassThroughChanges */,
-                     std::numeric_limits<int32_t>::max() /* numAccessChanges */,
-                     0 /* transitTime */);  // operator< prefers bigger transit time
+  return RouteWeight(std::numeric_limits<float>::max() /* weight */,
+                     std::numeric_limits<int8_t>::max() /* numPassThroughChanges */,
+                     std::numeric_limits<int8_t>::max() /* numAccessChanges */,
+                     0.0 /* transitTime */);  // operator< prefers bigger transit time
 }
 
 template <>

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -17,11 +17,11 @@ public:
 
   explicit constexpr RouteWeight(double weight) : m_weight(weight) {}
 
-  constexpr RouteWeight(double weight, int32_t numPassThroughChanges, int32_t numAccessChanges,
+  constexpr RouteWeight(double weight, int8_t numPassThroughChanges, int8_t numAccessChanges,
                         double transitTime)
     : m_weight(weight)
-    , m_numPassThroughChanges(static_cast<int8_t>(numPassThroughChanges))
-    , m_numAccessChanges(static_cast<int8_t>(numAccessChanges))
+    , m_numPassThroughChanges(numPassThroughChanges)
+    , m_numAccessChanges(numAccessChanges)
     , m_transitTime(transitTime)
   {
   }
@@ -91,7 +91,7 @@ private:
   // Number of access=yes/access={private,destination} zone changes.
   int8_t m_numAccessChanges = 0;
   // Transit time. It's already included in |m_weight| (m_transitTime <= m_weight).
-  double m_transitTime = 0.0F;
+  double m_transitTime = 0.0;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -22,7 +22,7 @@ public:
     : m_weight(weight)
     , m_numPassThroughChanges(static_cast<int8_t>(numPassThroughChanges))
     , m_numAccessChanges(static_cast<int8_t>(numAccessChanges))
-    , m_transitTime(static_cast<float>(transitTime))
+    , m_transitTime(transitTime)
   {
   }
 
@@ -32,7 +32,7 @@ public:
   double GetWeight() const { return m_weight; }
   int8_t GetNumPassThroughChanges() const { return m_numPassThroughChanges; }
   int8_t GetNumAccessChanges() const { return m_numAccessChanges; }
-  double GetTransitTime() const { return static_cast<double>(m_transitTime); }
+  double GetTransitTime() const { return m_transitTime; }
 
   bool operator<(RouteWeight const & rhs) const
   {
@@ -48,7 +48,7 @@ public:
       return m_numAccessChanges < rhs.m_numAccessChanges;
     if (m_weight != rhs.m_weight)
       return m_weight < rhs.m_weight;
-    // Preffer bigger transit time if total weights are same.
+    // Prefer bigger transit time if total weights are same.
     return m_transitTime > rhs.m_transitTime;
   }
 
@@ -80,7 +80,7 @@ public:
     return m_numPassThroughChanges == rhs.m_numPassThroughChanges &&
            m_numAccessChanges == rhs.m_numAccessChanges &&
            my::AlmostEqualAbs(m_weight, rhs.m_weight, epsilon) &&
-           my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, static_cast<float>(epsilon));
+           my::AlmostEqualAbs(m_transitTime, rhs.m_transitTime, epsilon);
   }
 
 private:
@@ -91,7 +91,7 @@ private:
   // Number of access=yes/access={private,destination} zone changes.
   int8_t m_numAccessChanges = 0;
   // Transit time. It's already included in |m_weight| (m_transitTime <= m_weight).
-  float m_transitTime = 0.0F;
+  double m_transitTime = 0.0F;
 };
 
 std::ostream & operator<<(std::ostream & os, RouteWeight const & routeWeight);
@@ -101,7 +101,7 @@ RouteWeight operator*(double lhs, RouteWeight const & rhs);
 template <>
 constexpr RouteWeight GetAStarWeightMax<RouteWeight>()
 {
-  return RouteWeight(std::numeric_limits<float>::max() /* weight */,
+  return RouteWeight(std::numeric_limits<double>::max() /* weight */,
                      std::numeric_limits<int8_t>::max() /* numPassThroughChanges */,
                      std::numeric_limits<int8_t>::max() /* numAccessChanges */,
                      0.0 /* transitTime */);  // operator< prefers bigger transit time


### PR DESCRIPTION
Поля BidirectionalStepContext::bestDistance и BidirectionalStepContext::parent (Context::m_distanceMap и Context::m_parents) занимают около 30% памяти при прокладке маршрута. При прокладке пешего маршрута Москва-Великие Луки каждое из них содержит порядка 3 миллионов значений в пике. Т.е. структура BidirectionalStepContext занимает 
3*10^6*(12 + 24 + 12 + 12) = 180MB.
Размер Segment = 12 байт,
Размер Weight = 24 байта.

Данный PR уменьшает размер Weight до 16-ти байт. Т.е. при прокладке пешего маршрута Москва-Великие Луки экономится 24MB.

К сожалению, я не смог уменьшить размер RouteWeight в двое с 24 байт до 12-ти, поскольку, для это нужно так же сделать поле RouteWeight::m_weight типа float. А если это сделать, то на интеграционном тесте GermanyToTallinCrossMwmRoute нарушится инвариант в A*: 

base/astar_algorithm.hpp:545
CHECK(reducedWeight >= -kEpsilon) (, , -0.00012207, 0) (, , -1e-06, -0) Invariant violated.

@tatiana-yan @mpimenov PTAL