### PR TITLE
[strings] Rename Luggage Hero to Luggage Storage → r8.1

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -9166,4 +9166,4 @@ en:^Christmas or New Year Celebrations
 ru:^Празднование Рождества или Нового года
 
 sponsored-partner2
-en:^Luggage Hero|3luggagehero
+en:^Luggage Storage|Luggage Hero|3luggagehero


### PR DESCRIPTION
У нас критикал в минорку: неправильно назвали категорию. MAPSME-7005.