### PR TITLE
Routing integration test fixing for map 18.03.16

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -23,7 +23,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(55.66216, 37.63259), {0., 0.},
-        MercatorBounds::FromLatLon(55.66237, 37.63560), 1700.);
+        MercatorBounds::FromLatLon(55.66237, 37.63560), 2320.);
   }
 
   UNIT_TEST(MoscowToSVOAirport)
@@ -32,13 +32,10 @@ namespace
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(55.75100, 37.61790), {0., 0.},
         MercatorBounds::FromLatLon(55.97310, 37.41460), 37284.);
-//    This test stopped working because of an error in the map. The error has been just fixed:
-//    https://www.openstreetmap.org/changeset/56686302
-//    @TODO(bykoianko) The test should be uncommented for the next map build (after 170209).
-//    integration::CalculateRouteAndTestRouteLength(
-//        integration::GetVehicleComponents<VehicleType::Car>(),
-//        MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
-//        MercatorBounds::FromLatLon(55.75100, 37.61790), 39449.);
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
+        MercatorBounds::FromLatLon(55.75100, 37.61790), 39449.);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -243,7 +243,7 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                   MercatorBounds::FromLatLon(55.77177, 37.63556), {0., 0.},
-                                  MercatorBounds::FromLatLon(55.77203, 37.63705));
+                                  MercatorBounds::FromLatLon(55.77209, 37.63707));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;


### PR DESCRIPTION
После обновления карты до 16.03.18 сломались routing integration tests
http://angola.mapsme.mail.msk:8080/job/RoutingIntegration/100/testReport/

Данный PR чинит их.

![image](https://user-images.githubusercontent.com/1768114/37917149-586fd260-3126-11e8-8eb4-c10b56715884.png)

![image](https://user-images.githubusercontent.com/1768114/37917184-6ec41c7e-3126-11e8-811c-167e459f46c6.png)

@tatiana-yan PTAL
