### PR TITLE
[cmake] Fix CMP0071 policy

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_AUTOUIC ON)
 
 QT5_ADD_RESOURCES(RES_SOURCES res/resources.qrc)
 
+set_property(SOURCE qrc_resources.cpp PROPERTY SKIP_AUTOGEN ON)
+
 include_directories(
   ${OMIM_ROOT}/3party/glm
   ${OMIM_ROOT}/3party/gflags/src

--- a/qt/qt_common/CMakeLists.txt
+++ b/qt/qt_common/CMakeLists.txt
@@ -2,6 +2,8 @@ project(qt_common)
 
 QT5_ADD_RESOURCES(RESOURCES res/resources_common.qrc)
 
+set_property(SOURCE qrc_resources_common.cpp PROPERTY SKIP_AUTOGEN ON)
+
 include_directories(
   ${OMIM_ROOT}/3party/jansson/src
 )


### PR DESCRIPTION
Fix for cmake version 3.10 and higher. ([More info](https://cmake.org/cmake/help/git-stage/policy/CMP0071.html))
