### PR TITLE
[geocoder] Add option to index nodes without address.

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -101,6 +101,9 @@ DEFINE_bool(generate_world, false, "Generate separate world file.");
 DEFINE_bool(split_by_polygons, false,
             "Use countries borders to split planet by regions and countries.");
 
+DEFINE_string(nodes_list_path, "",
+              "Path to file containing list of node ids we need to add to locality index. May be empty.");
+
 // Routing.
 DEFINE_bool(make_routing_index, false, "Make sections with the routing information.");
 DEFINE_bool(make_cross_mwm, false,
@@ -274,7 +277,7 @@ int main(int argc, char ** argv)
 
     auto const locDataFile = my::JoinPath(path, FLAGS_output + LOC_DATA_FILE_EXTENSION);
     auto const outFile = my::JoinPath(path, FLAGS_output + LOC_IDX_FILE_EXTENSION);
-    if (!feature::GenerateLocalityData(genInfo.m_tmpDir, locDataFile))
+    if (!feature::GenerateLocalityData(genInfo.m_tmpDir, FLAGS_nodes_list_path, locDataFile))
     {
       LOG(LCRITICAL, ("Error generating locality data."));
       return -1;

--- a/generator/locality_sorter.hpp
+++ b/generator/locality_sorter.hpp
@@ -6,6 +6,8 @@ namespace feature
 {
 /// Generates data for LocalityIndexBuilder from input feature-dat-files.
 /// @param featuresDir - path to folder with pregenerated features data;
+/// @param nodesFile - path to file with list of node ids we need to add to output;
 /// @param out - output file name;
-bool GenerateLocalityData(std::string const & featuresDir, std::string const & out);
+bool GenerateLocalityData(std::string const & featuresDir, std::string const & nodesFile,
+                          std::string const & out);
 }  // namespace feature


### PR DESCRIPTION
Сейчас в индекс для серверного обратного геокодера добавляются только здания и POI, которые имеют адрес.
Но задача изменилась и нужно добавлять ещё ряд POI из списка. Этот PR содержит доработку, которая вычитывает список интересующих POI (имеет формат по одной записи на строку, первым идёт encoded osm id, а дальше что-то, что используется на serverside) и включает их индексирование.