### PR TITLE
[DNM] LRU cache implementation and using it for routing geometry

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
   dfa_helpers.hpp
   exception.cpp
   exception.hpp
+  fifo_cache.hpp
   get_time.hpp
   gmtime.cpp
   gmtime.hpp

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
   logging.cpp
   logging.hpp
   lower_case.cpp
+  lru_cache.hpp
   macros.hpp
   math.hpp
   matrix.hpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   condition_test.cpp
   containers_test.cpp
   control_flow_tests.cpp
+  fifo_cache_test.cpp
   levenshtein_dfa_test.cpp
   logging_test.cpp
   lru_cache_test.cpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   control_flow_tests.cpp
   levenshtein_dfa_test.cpp
   logging_test.cpp
+  lru_cache_test.cpp
   math_test.cpp
   matrix_test.cpp
   mem_trie_test.cpp

--- a/base/base_tests/fifo_cache_test.cpp
+++ b/base/base_tests/fifo_cache_test.cpp
@@ -1,0 +1,67 @@
+#include "testing/testing.hpp"
+
+#include "base/fifo_cache.hpp"
+
+#include <deque>
+#include <unordered_map>
+
+using namespace std;
+
+template <typename Key, typename Value>
+class FifoCacheTest
+{
+public:
+  FifoCacheTest(size_t maxCacheSize, typename FifoCache<Key, Value>::Loader const & loader)
+      : m_cache(maxCacheSize, loader)
+  {
+  }
+
+  Value const & GetValue(Key const & key) { return m_cache.GetValue(key); }
+  bool IsValid() const { return m_cache.IsValid(); }
+  unordered_map<Key, Value> const & GetCache() const { return m_cache.m_cache; }
+  deque<Key> const & GetFifoQueue() const { return m_cache.m_fifoQueue; }
+
+private:
+  FifoCache<Key, Value> m_cache;
+};
+
+UNIT_TEST(FifoCacheSmokeTest)
+{
+  using Key = int;
+  using Value = int;
+  FifoCache<Key, Value> cache(3 /* maxCacheSize */, [](Key k, Value & v) { v = k; } /* loader */);
+
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST_EQUAL(cache.GetValue(2), 2, ());
+  TEST_EQUAL(cache.GetValue(3), 3, ());
+  TEST_EQUAL(cache.GetValue(4), 4, ());
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST(cache.IsValid(), ());
+}
+
+UNIT_TEST(FifoCacheTest)
+{
+  using Key = int;
+  using Value = int;
+  FifoCacheTest<Key, Value> cache(3 /* maxCacheSize */, [](Key k, Value & v) { v = k; } /* loader */);
+
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST_EQUAL(cache.GetValue(3), 3, ());
+  TEST_EQUAL(cache.GetValue(2), 2, ());
+  TEST(cache.IsValid(), ());
+  {
+    unordered_map<Key, Value> expectedCache({{1 /* key */, 1 /* value */}, {2, 2}, {3, 3}});
+    TEST_EQUAL(cache.GetCache(), expectedCache, ());
+    deque<Key> fifoQueue({2, 3, 1});
+    TEST_EQUAL(cache.GetFifoQueue(), fifoQueue, ());
+  }
+
+  TEST_EQUAL(cache.GetValue(7), 7, ());
+  TEST(cache.IsValid(), ());
+  {
+    unordered_map<Key, Value> expectedCache({{7 /* key */, 7 /* value */}, {2, 2}, {3, 3}});
+    TEST_EQUAL(cache.GetCache(), expectedCache, ());
+    deque<Key> fifoQueue({7, 2, 3});
+    TEST_EQUAL(cache.GetFifoQueue(), fifoQueue, ());
+  }
+}

--- a/base/base_tests/lru_cache_test.cpp
+++ b/base/base_tests/lru_cache_test.cpp
@@ -1,0 +1,166 @@
+#include "testing/testing.hpp"
+
+#include "base/lru_cache.hpp"
+
+#include <cstddef>
+#include <map>
+
+template <typename Key, typename Value>
+class LruCacheTest
+{
+public:
+  LruCacheTest(size_t maxCacheSize, typename LruCache<Key, Value>::Loader const & loader)
+    : m_cache(maxCacheSize, loader)
+  {
+  }
+
+  Value const & GetValue(Key const & key) { return m_cache.GetValue(key); }
+  bool IsValid() const { return m_cache.IsValid(); }
+
+private:
+  LruCache<Key, Value> m_cache;
+};
+
+template <typename Key, typename Value>
+class LruCacheKeyAgeTest
+{
+public:
+  void InsertKey(Key const & key) { m_keyAge.InsertKey(key); }
+  void UpdateAge(Key const & key) { m_keyAge.UpdateAge(key); }
+  Key const & GetLruKey() const { return m_keyAge.GetLruKey(); }
+  void RemoveLru() { m_keyAge.RemoveLru(); }
+  bool IsValid() const { return m_keyAge.IsValidForTesting(); }
+
+  size_t GetAge() const { return m_keyAge.m_age; }
+  std::map<size_t, Key> const & GetAgeToKey() const { return m_keyAge.m_ageToKey; };
+  std::map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
+
+private:
+  typename LruCache<Key, Value>::KeyAge m_keyAge;
+};
+
+template <typename Key, typename Value>
+void TestAge(LruCacheKeyAgeTest<Key, Value> const & keyAge,
+             size_t expectedAge, std::map<size_t, Key> const & expectedAgeToKey,
+             std::map<Key, size_t> const & expectedKeyToAge)
+{
+  TEST(keyAge.IsValid(), ());
+  TEST_EQUAL(keyAge.GetAge(), expectedAge, ());
+  TEST_EQUAL(keyAge.GetAgeToKey(), expectedAgeToKey, ());
+  TEST_EQUAL(keyAge.GetKeyToAge(), expectedKeyToAge, ());
+}
+
+UNIT_TEST(LruCacheAgeTest)
+{
+  using Key = int;
+  using Value = double;
+  LruCacheKeyAgeTest<Key, Value> age;
+
+  TEST_EQUAL(age.GetAge(), 0, ());
+  TEST(age.GetAgeToKey().empty(), ());
+  TEST(age.GetKeyToAge().empty(), ());
+
+  age.InsertKey(10);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{1 /* age */, 10 /* key */}});
+    std::map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
+    TestAge(age, 1 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(9);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{1, 10}, {2, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
+    TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.RemoveLru();
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{2, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 2}});
+    TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(11);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{2, 9}, {3, 11}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
+    TestAge(age, 3 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.UpdateAge(9);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {3, 11}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
+    TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.RemoveLru();
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}});
+    TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(12);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {5, 12}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
+    TestAge(age, 5 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+}
+
+UNIT_TEST(LruCacheSmokeTest)
+{
+  using Key = int;
+  using Value = int;
+
+  {
+    LruCacheTest<Key, Value> cache(1 /* maxCacheSize */, [](Key k, Value & v) { v = 1; } /* loader */);
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST_EQUAL(cache.GetValue(2), 1, ());
+    TEST_EQUAL(cache.GetValue(3), 1, ());
+    TEST_EQUAL(cache.GetValue(4), 1, ());
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST(cache.IsValid(), ());
+  }
+
+  {
+    LruCacheTest<Key, Value> cache(3 /* maxCacheSize */, [](Key k, Value & v) { v = k; } /* loader */);
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST_EQUAL(cache.GetValue(2), 2, ());
+    TEST_EQUAL(cache.GetValue(2), 2, ());
+    TEST_EQUAL(cache.GetValue(5), 5, ());
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST(cache.IsValid(), ());
+  }
+}
+
+UNIT_TEST(LruCacheLoaderCallsTest)
+{
+  using Key = int;
+  using Value = int;
+  bool shouldLoadBeCalled = true;
+  auto loader = [&shouldLoadBeCalled](Key k, Value & v) {
+    TEST(shouldLoadBeCalled, ());
+    v = k;
+  };
+
+  LruCacheTest<Key, Value> cache(3 /* maxCacheSize */, loader);
+  TEST(cache.IsValid(), ());
+  cache.GetValue(1);
+  cache.GetValue(2);
+  cache.GetValue(3);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = false;
+  cache.GetValue(3);
+  cache.GetValue(2);
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = true;
+  cache.GetValue(4);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = false;
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+}

--- a/base/base_tests/lru_cache_test.cpp
+++ b/base/base_tests/lru_cache_test.cpp
@@ -33,7 +33,7 @@ public:
 
   size_t GetAge() const { return m_keyAge.m_age; }
   std::map<size_t, Key> const & GetAgeToKey() const { return m_keyAge.m_ageToKey; };
-  std::map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
+  std::unordered_map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
 
 private:
   typename LruCache<Key, Value>::KeyAge m_keyAge;
@@ -42,7 +42,7 @@ private:
 template <typename Key, typename Value>
 void TestAge(LruCacheKeyAgeTest<Key, Value> const & keyAge,
              size_t expectedAge, std::map<size_t, Key> const & expectedAgeToKey,
-             std::map<Key, size_t> const & expectedKeyToAge)
+             std::unordered_map<Key, size_t> const & expectedKeyToAge)
 {
   TEST(keyAge.IsValid(), ());
   TEST_EQUAL(keyAge.GetAge(), expectedAge, ());
@@ -63,49 +63,49 @@ UNIT_TEST(LruCacheAgeTest)
   age.InsertKey(10);
   {
     std::map<size_t, Key> const expectedAgeToKey({{1 /* age */, 10 /* key */}});
-    std::map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
     TestAge(age, 1 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(9);
   {
     std::map<size_t, Key> const expectedAgeToKey({{1, 10}, {2, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
     TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.RemoveLru();
   {
     std::map<size_t, Key> const expectedAgeToKey({{2, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 2}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 2}});
     TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(11);
   {
     std::map<size_t, Key> const expectedAgeToKey({{2, 9}, {3, 11}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
     TestAge(age, 3 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.UpdateAge(9);
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {3, 11}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
     TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.RemoveLru();
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}});
     TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(12);
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {5, 12}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
     TestAge(age, 5 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 }

--- a/base/fifo_cache.hpp
+++ b/base/fifo_cache.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "base/assert.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <queue>
+#include <unordered_map>
+
+template <typename Key, typename Value>
+class FifoCache
+{
+  template <typename K, typename V> friend class FifoCacheTest;
+public:
+  using Loader = std::function<void(Key const & key, Value & value)>;
+
+  FifoCache(size_t maxCacheSize, Loader const & loader)
+  : m_maxCacheSize(maxCacheSize), m_loader(loader)
+  {
+    CHECK_GREATER(maxCacheSize, 0, ());
+  }
+
+  Value const & GetValue(Key const & key)
+  {
+    auto const it = m_cache.find(key);
+    if (it != m_cache.cend())
+      return it->second;
+
+    ASSERT_EQUAL(m_fifoQueue.size(), m_cache.size(), ());
+    if (m_cache.size() >= m_maxCacheSize)
+    {
+      ASSERT(!m_fifoQueue.empty(), ());
+      m_cache.erase(m_fifoQueue.back());
+      m_fifoQueue.pop_back();
+    }
+
+    m_fifoQueue.push_front(key);
+    Value & value = m_cache[key];
+    m_loader(key, value);
+    return value;
+  }
+
+  /// \brief Checks for coherence class params.
+  /// \note It's a time consumption method and should be called for tests only.
+  bool IsValid() const
+  {
+    if (m_cache.size() != m_fifoQueue.size())
+      return false;
+
+    if (m_cache.size() > m_maxCacheSize)
+      return false;
+
+    for (auto const & k : m_fifoQueue)
+    {
+      if (m_cache.find(k) == m_cache.cend())
+        return false;
+    }
+    return true;
+  }
+
+private:
+  size_t const m_maxCacheSize;
+  Loader const m_loader;
+  std::unordered_map<Key, Value> m_cache;
+  std::deque<Key> m_fifoQueue;
+};

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -97,7 +97,7 @@ private:
       CHECK_EQUAL(removed, 1, ());
       // Putting new age.
       m_ageToKey[m_age] = key;
-      m_keyToAge[key] = m_age;
+      keyToAgeIt->second = m_age;
     }
 
     /// \returns Least recently used key without updating the age.
@@ -154,7 +154,7 @@ private:
   private:
     size_t m_age = 0;
     std::map<size_t, Key> m_ageToKey;
-    std::map<Key, size_t> m_keyToAge;
+    std::unordered_map<Key, size_t> m_keyToAge;
   };
 
   size_t const m_maxCacheSize;

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "base/assert.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <unordered_map>
+
+/// \brief Implementation of cache with least recently used replacement policy.
+template <typename Key, typename Value>
+class LruCache
+{
+  template <typename K, typename V> friend class LruCacheTest;
+  template <typename K, typename V> friend class LruCacheKeyAgeTest;
+public:
+  using Loader = std::function<void(Key const & key, Value & value)>;
+
+  /// \param maxCacheSize Maximum size of the cache in number of items. It should be one or greater.
+  /// \param loader Function which is called if it's necessary to load a new item for the cache.
+  /// For the same |key| should be loaded the same |value|.
+  LruCache(size_t maxCacheSize, Loader const & loader)
+    : m_maxCacheSize(maxCacheSize), m_loader(loader)
+  {
+    CHECK_GREATER(maxCacheSize, 0, ());
+  }
+
+  /// \brief Loads value, if it's necessary, by |key| with |m_loader|, puts it to |m_cache| and
+  /// returns the reference to the value to |m_cache|.
+  Value const & GetValue(Key const & key)
+  {
+    auto const it = m_cache.find(key);
+    if (it != m_cache.cend())
+    {
+      m_keyAge.UpdateAge(key);
+      return it->second;
+    }
+
+    if (m_cache.size() >= m_maxCacheSize)
+    {
+      m_cache.erase(m_keyAge.GetLruKey());
+      m_keyAge.RemoveLru();
+    }
+
+    m_keyAge.InsertKey(key);
+    Value & value = m_cache[key];
+    m_loader(key, value);
+    return value;
+  }
+
+  /// \brief Checks for coherence class params.
+  /// \note It's a time consumption method and should be called for tests only.
+  bool IsValid() const
+  {
+    if (!m_keyAge.IsValidForTesting())
+      return false;
+
+    for (auto const & kv : m_cache)
+    {
+      if (!m_keyAge.IsKeyValidForTesting(kv.first))
+        return false;
+    }
+
+    return true;
+  }
+
+private:
+  /// \brief This class support cross mapping from age to key and for key to age.
+  /// It lets effectively get least recently used key (key with minimum value of age)
+  /// and find key age by its value to update the key age.
+  /// \note Size of |m_ageToKey| and |m_ageToKey| should be the sameß.
+  /// All keys of |m_ageToKey| should be values of |m_ageToKey| and on the contrary
+  /// all keys of |m_ageToKey| should be values of |m_ageToKey|.
+  /// \note Ages should be unique for all keys.
+  class KeyAge
+  {
+    template <typename K, typename V> friend class LruCacheKeyAgeTest;
+  public:
+    /// \brief Increments |m_age| and insert key to |m_ageToKey| and |m_keyToAge|.
+    /// \note This method should be used only if there's no |key| in |m_ageToKey| and |m_keyToAge|.
+    void InsertKey(Key const & key)
+    {
+      ++m_age;
+      m_ageToKey[m_age] = key;
+      m_keyToAge[key] = m_age;
+    }
+
+    /// \brief Increments |m_age| and updates key age in |m_ageToKey| and |m_keyToAge|.
+    /// \note This method should be used only if there's |key| in |m_ageToKey| and |m_keyToAge|.
+    void UpdateAge(Key const & key)
+    {
+      ++m_age;
+      auto keyToAgeIt = m_keyToAge.find(key);
+      CHECK(keyToAgeIt != m_keyToAge.end(), ());
+      // Removing former age.
+      size_t const removed = m_ageToKey.erase(keyToAgeIt->second);
+      CHECK_EQUAL(removed, 1, ());
+      // Putting new age.
+      m_ageToKey[m_age] = key;
+      m_keyToAge[key] = m_age;
+    }
+
+    /// \returns Least recently used key without updating the age.
+    /// \note |m_ageToKey| and |m_keyToAge| shouldn't be empty.
+    Key const & GetLruKey() const
+    {
+      CHECK(!m_ageToKey.empty(), ());
+      // The smaller age the older item.
+      return m_ageToKey.cbegin()->second;
+    }
+
+    void RemoveLru()
+    {
+      Key const & lru = GetLruKey();
+      size_t const removed = m_keyToAge.erase(lru);
+      CHECK_EQUAL(removed, 1, ());
+      m_ageToKey.erase(m_ageToKey.begin());
+    }
+
+    /// \brief Checks for coherence class params.
+    /// \note It's a time consumption method and should be called for tests only.
+    bool IsValidForTesting() const
+    {
+      for (auto const & kv : m_ageToKey)
+      {
+        if (kv.first > m_age)
+          return false;
+        if (m_keyToAge.find(kv.second) == m_keyToAge.cend())
+          return false;
+      }
+      for (auto const & kv : m_keyToAge)
+      {
+        if (kv.second > m_age)
+          return false;
+        if (m_ageToKey.find(kv.second) == m_ageToKey.cend())
+          return false;
+      }
+      return true;
+    }
+
+    /// \returns true if |key| and its age are contained in |m_keyToAge| and |m_keyToAge|.
+    /// \note It's a time consumption method and should be called for tests only.
+    bool IsKeyValidForTesting(Key const & key) const
+    {
+      auto const keyToAgeId = m_keyToAge.find(key);
+      if (keyToAgeId == m_keyToAge.cend())
+        return false;
+      auto const ageToKeyIt = m_ageToKey.find(keyToAgeId->second);
+      if (ageToKeyIt == m_ageToKey.cend())
+        return false;
+      return key == ageToKeyIt->second;
+    }
+
+  private:
+    size_t m_age = 0;
+    std::map<size_t, Key> m_ageToKey;
+    std::map<Key, size_t> m_keyToAge;
+  };
+
+  size_t const m_maxCacheSize;
+  Loader const m_loader;
+  std::unordered_map<Key, Value> m_cache;
+  KeyAge m_keyAge;
+};

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -137,20 +137,20 @@ void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType 
 }
 
 // Geometry ----------------------------------------------------------------------------------------
-Geometry::Geometry(unique_ptr<GeometryLoader> loader) : m_loader(move(loader))
+Geometry::Geometry(unique_ptr<GeometryLoader> loader)
+  : m_loader(move(loader))
+  , m_featureIdToRoad(make_unique<LruCache<uint32_t, RoadGeometry>>(
+        kRoadsCacheSize,
+        [this](uint32_t featureId, RoadGeometry & road) { m_loader->Load(featureId, road); }))
 {
   CHECK(m_loader, ());
 }
 
 RoadGeometry const & Geometry::GetRoad(uint32_t featureId)
 {
-  auto const & it = m_roads.find(featureId);
-  if (it != m_roads.cend())
-    return it->second;
-
-  RoadGeometry & road = m_roads[featureId];
-  m_loader->Load(featureId, road);
-  return road;
+  ASSERT(m_featureIdToRoad, ());
+  ASSERT(m_loader, ());
+  return m_featureIdToRoad->GetValue(featureId);
 }
 
 // static

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -139,7 +139,7 @@ void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType 
 // Geometry ----------------------------------------------------------------------------------------
 Geometry::Geometry(unique_ptr<GeometryLoader> loader)
   : m_loader(move(loader))
-  , m_featureIdToRoad(make_unique<LruCache<uint32_t, RoadGeometry>>(
+  , m_featureIdToRoad(make_unique<FifoCache<uint32_t, RoadGeometry>>(
         kRoadsCacheSize,
         [this](uint32_t featureId, RoadGeometry & road) { m_loader->Load(featureId, road); }))
 {

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -11,7 +11,7 @@
 #include "geometry/point2d.hpp"
 
 #include "base/buffer_vector.hpp"
-#include "base/lru_cache.hpp"
+#include "base/fifo_cache.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -108,6 +108,6 @@ public:
 
 private:
   std::unique_ptr<GeometryLoader> m_loader;
-  std::unique_ptr<LruCache<uint32_t, RoadGeometry>> m_featureIdToRoad;
+  std::unique_ptr<FifoCache<uint32_t, RoadGeometry>> m_featureIdToRoad;
 };
 }  // namespace routing

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -11,14 +11,18 @@
 #include "geometry/point2d.hpp"
 
 #include "base/buffer_vector.hpp"
+#include "base/lru_cache.hpp"
 
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace routing
 {
+// @TODO(bykoianko) Consider setting cache size based on available memory.
+// Maximum road geometry cache size in items.
+size_t constexpr kRoadsCacheSize = 1000;
+
 class RoadGeometry final
 {
 public:
@@ -103,8 +107,7 @@ public:
   }
 
 private:
-  // Feature id to RoadGeometry map.
-  std::unordered_map<uint32_t, RoadGeometry> m_roads;
   std::unique_ptr<GeometryLoader> m_loader;
+  std::unique_ptr<LruCache<uint32_t, RoadGeometry>> m_featureIdToRoad;
 };
 }  // namespace routing

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		3D7815731F3A145F0068B6AC /* task_loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815711F3A145F0068B6AC /* task_loop.hpp */; };
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
 		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
+		56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B8B206D0937003892E0 /* lru_cache_test.cpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -190,6 +191,7 @@
 		3D7815711F3A145F0068B6AC /* task_loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = task_loop.hpp; sourceTree = "<group>"; };
 		3D78157A1F3D89EC0068B6AC /* waiter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = waiter.hpp; sourceTree = "<group>"; };
 		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
+		56290B8B206D0937003892E0 /* lru_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lru_cache_test.cpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 		39FD26C71CC659D200AFF551 /* base_tests */ = {
 			isa = PBXGroup;
 			children = (
+				56290B8B206D0937003892E0 /* lru_cache_test.cpp */,
 				39B89C391FD1898A001104AF /* control_flow_tests.cpp */,
 				67E40EC71E4DC0D500A6D200 /* small_set_test.cpp */,
 				3446C67E1DDCAA6E00146687 /* newtype_test.cpp */,
@@ -695,6 +698,7 @@
 				67B52B601AD3C84E00664C17 /* thread_checker.cpp in Sources */,
 				675341E71A3F57E400A0A8C3 /* normalize_unicode.cpp in Sources */,
 				675341E11A3F57E400A0A8C3 /* lower_case.cpp in Sources */,
+				56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */,
 				672DD4C11E0425600078E13C /* condition.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		3D74EF151F8B902C0081202C /* bwt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D74EF0F1F8B902C0081202C /* bwt.hpp */; };
 		3D7815731F3A145F0068B6AC /* task_loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815711F3A145F0068B6AC /* task_loop.hpp */; };
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
+		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -188,6 +189,7 @@
 		3D74EF0F1F8B902C0081202C /* bwt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bwt.hpp; sourceTree = "<group>"; };
 		3D7815711F3A145F0068B6AC /* task_loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = task_loop.hpp; sourceTree = "<group>"; };
 		3D78157A1F3D89EC0068B6AC /* waiter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = waiter.hpp; sourceTree = "<group>"; };
+		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 		675341791A3F57BF00A0A8C3 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				56290B89206D0887003892E0 /* lru_cache.hpp */,
 				675341851A3F57E400A0A8C3 /* array_adapters.hpp */,
 				675341861A3F57E400A0A8C3 /* assert.hpp */,
 				675341871A3F57E400A0A8C3 /* base.cpp */,
@@ -480,6 +483,7 @@
 				675341E31A3F57E400A0A8C3 /* math.hpp in Headers */,
 				3446C6731DDCA96300146687 /* levenshtein_dfa.hpp in Headers */,
 				56B1A0751E69DE4D00395022 /* random.hpp in Headers */,
+				56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */,
 				675341E21A3F57E400A0A8C3 /* macros.hpp in Headers */,
 				672DD4C51E0425600078E13C /* observer_list.hpp in Headers */,
 				675341EF1A3F57E400A0A8C3 /* rolling_hash.hpp in Headers */,


### PR DESCRIPTION
Цель данного PR уменьшить потребление памяти при прокладке всех типов маршрутов. Вместо безконтрольно растущего кеша геометрии (routing::Geometry) реализован вытесняющий кеш.

На текущем мастере, на iPhone 7, с определенным набором карт пешеходные маршруты прокладывались так:
Офис - Велике Луки: 676MB (памяти на прокладку), 36.8 секунды.
Офис - Зелиноград: 72MB(памяти на прокладку), 4.28 секунды.

LRU кеш (реализация с избыточными структурами данных):
Офис - Велике Луки: 467МБ (памяти на прокладку), 58.8 секунды.
Офис - Зелиноград: 52MB(памяти на прокладку), 6.27 секунды.

FIFO кеша:
Офис - Велике Луки: 468МБ (памяти на прокладку), 46.7 секунды.
Офис - Зелиноград: 50MB(памяти на прокладку), 5.6 секунды.

Если удалять весь кеш при достижении 1000 элементов, то получаем:
Офис - Велике Луки: 467МБ (памяти на прокладку), 48.1 секунды.
Офис - Зелиноград: 45MB(памяти на прокладку), 6.1 секунды.
Т.е. примерно так же, как и с FIFO.

FIFO c хеш таблицей и list по 5К элементов.
Офис - Велике Луки: 477МБ (памяти на прокладку), 37.6 секунд.
Офис - Зелиноград: 65MB(памяти на прокладку), 4.31 секунд.
Примерно та же скорость, что и без вытеснения, но памяти используемся много меньше.

Если есть идеи, как можно еще ускорить - пишите.

@mpimenov @tatiana-yan PTAL
