### PR TITLE
Using saved countryId instead of reference.

### DIFF
--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -635,7 +635,7 @@ void Storage::DownloadNextCountryFromQueue()
   DownloadNextFile(queuedCountry);
 
   // New status for the country, "Downloading"
-  NotifyStatusChangedForHierarchy(queuedCountry.GetCountryId());
+  NotifyStatusChangedForHierarchy(countryId);
 }
 
 void Storage::DownloadNextFile(QueuedCountry const & country)


### PR DESCRIPTION
We used to use the countryId which is stored in queuedCountry. But queuedCountry was stored by a reference and sometimes it could be removed from the queue so reference became dangling. Using a copy of the countryId must be more safety.