### PR TITLE
FIFO cache implementation and using it for routing geometry

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
   dfa_helpers.hpp
   exception.cpp
   exception.hpp
+  fifo_cache.hpp
   get_time.hpp
   gmtime.cpp
   gmtime.hpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   condition_test.cpp
   containers_test.cpp
   control_flow_tests.cpp
+  fifo_cache_test.cpp
   levenshtein_dfa_test.cpp
   logging_test.cpp
   math_test.cpp

--- a/base/base_tests/fifo_cache_test.cpp
+++ b/base/base_tests/fifo_cache_test.cpp
@@ -1,0 +1,105 @@
+#include "testing/testing.hpp"
+
+#include "base/fifo_cache.hpp"
+
+#include <list>
+#include <set>
+#include <unordered_map>
+
+using namespace std;
+
+template <typename Key, typename Value>
+class FifoCacheTest
+{
+public:
+  FifoCacheTest(size_t capacity, typename FifoCache<Key, Value>::Loader const & loader)
+      : m_cache(capacity, loader)
+  {
+  }
+
+  Value const & GetValue(Key const & key) { return m_cache.GetValue(key); }
+  unordered_map<Key, Value> const & GetMap() const { return m_cache.m_map; }
+  list<Key> const & GetList() const { return m_cache.m_list; }
+
+  bool IsValid() const
+  {
+    std::set<Key> listKeys(m_cache.m_list.cbegin(), m_cache.m_list.cend());
+    std::set<Key> mapKeys;
+
+    for (auto const & kv :m_cache. m_map)
+      mapKeys.insert(kv.first);
+
+    return listKeys == mapKeys;
+  }
+
+private:
+  FifoCache<Key, Value> m_cache;
+};
+
+UNIT_TEST(FifoCacheSmokeTest)
+{
+  using Key = int;
+  using Value = int;
+  FifoCacheTest<Key, Value> cache(3 /* capacity */, [](Key k, Value & v) { v = k; } /* loader */);
+
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST_EQUAL(cache.GetValue(2), 2, ());
+  TEST_EQUAL(cache.GetValue(3), 3, ());
+  TEST_EQUAL(cache.GetValue(4), 4, ());
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST(cache.IsValid(), ());
+}
+
+UNIT_TEST(FifoCacheTest)
+{
+  using Key = int;
+  using Value = int;
+  FifoCacheTest<Key, Value> cache(3 /* capacity */, [](Key k, Value & v) { v = k; } /* loader */);
+
+  TEST_EQUAL(cache.GetValue(1), 1, ());
+  TEST_EQUAL(cache.GetValue(3), 3, ());
+  TEST_EQUAL(cache.GetValue(2), 2, ());
+  TEST(cache.IsValid(), ());
+  {
+    unordered_map<Key, Value> expectedMap({{1 /* key */, 1 /* value */}, {2, 2}, {3, 3}});
+    TEST_EQUAL(cache.GetMap(), expectedMap, ());
+    list<Key> expectedList({2, 3, 1});
+    TEST_EQUAL(cache.GetList(), expectedList, ());
+  }
+
+  TEST_EQUAL(cache.GetValue(7), 7, ());
+  TEST(cache.IsValid(), ());
+  {
+    unordered_map<Key, Value> expectedMap({{7 /* key */, 7 /* value */}, {2, 2}, {3, 3}});
+    TEST_EQUAL(cache.GetMap(), expectedMap, ());
+    list<Key> expectedList({7, 2, 3});
+    TEST_EQUAL(cache.GetList(), expectedList, ());
+  }
+}
+
+UNIT_TEST(FifoCacheLoaderCallsTest)
+{
+  using Key = int;
+  using Value = int;
+  bool shouldLoadBeCalled = true;
+  auto loader = [&shouldLoadBeCalled](Key k, Value & v) {
+    TEST(shouldLoadBeCalled, ());
+    v = k;
+  };
+
+  FifoCacheTest<Key, Value> cache(3 /* capacity */, loader);
+  TEST(cache.IsValid(), ());
+  cache.GetValue(1);
+  cache.GetValue(2);
+  cache.GetValue(3);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = false;
+  cache.GetValue(3);
+  cache.GetValue(2);
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = true;
+  cache.GetValue(4);
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+}

--- a/base/base_tests/fifo_cache_test.cpp
+++ b/base/base_tests/fifo_cache_test.cpp
@@ -23,10 +23,10 @@ public:
 
   bool IsValid() const
   {
-    std::set<Key> listKeys(m_cache.m_list.cbegin(), m_cache.m_list.cend());
-    std::set<Key> mapKeys;
+    set<Key> listKeys(m_cache.m_list.cbegin(), m_cache.m_list.cend());
+    set<Key> mapKeys;
 
-    for (auto const & kv :m_cache. m_map)
+    for (auto const & kv : m_cache.m_map)
       mapKeys.insert(kv.first);
 
     return listKeys == mapKeys;
@@ -36,7 +36,7 @@ private:
   FifoCache<Key, Value> m_cache;
 };
 
-UNIT_TEST(FifoCacheSmokeTest)
+UNIT_TEST(FifoCache_Smoke)
 {
   using Key = int;
   using Value = int;
@@ -50,7 +50,7 @@ UNIT_TEST(FifoCacheSmokeTest)
   TEST(cache.IsValid(), ());
 }
 
-UNIT_TEST(FifoCacheTest)
+UNIT_TEST(FifoCache)
 {
   using Key = int;
   using Value = int;
@@ -77,7 +77,7 @@ UNIT_TEST(FifoCacheTest)
   }
 }
 
-UNIT_TEST(FifoCacheLoaderCallsTest)
+UNIT_TEST(FifoCache_LoaderCalls)
 {
   using Key = int;
   using Value = int;

--- a/base/fifo_cache.hpp
+++ b/base/fifo_cache.hpp
@@ -34,7 +34,7 @@ public:
 
     auto & v = m_map[key];
     m_loader(key, v);
-    return (m_map[key] = v);
+    return v;
   }
 
 private:

--- a/base/fifo_cache.hpp
+++ b/base/fifo_cache.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "base/assert.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <unordered_map>
+
+template<class Key, class Value>
+class FifoCache
+{
+  template <typename K, typename V> friend class FifoCacheTest;
+
+public:
+  using Loader = std::function<void(Key const & key, Value & value)>;
+
+  /// \param capacity maximum size of the cache in number of items.
+  /// \param loader Function which is called if it's necessary to load a new item for the cache.
+  FifoCache(size_t capacity, Loader const & loader) : m_capacity(capacity), m_loader(loader) {}
+
+  /// \brief Loads value, if it's necessary, by |key| with |m_loader|, puts it to cache and
+  /// returns the reference to the value to |m_map|.
+  Value const & GetValue(const Key & key)
+  {
+    auto const it = m_map.find(key);
+    if (it != m_map.cend())
+      return it->second;
+
+    if (Size() >= m_capacity)
+      Evict();
+
+    m_list.push_front(key);
+
+    auto & v = m_map[key];
+    m_loader(key, v);
+    return (m_map[key] = v);
+  }
+
+private:
+  void Evict()
+  {
+    auto const i = --m_list.end();
+    m_map.erase(*i);
+    m_list.erase(i);
+  }
+
+  size_t Size() const { return m_map.size(); }
+
+  std::unordered_map<Key, Value> m_map;
+  // @TODO(bykoianko) Consider using a structure like boost/circular_buffer instead of list
+  // but with handling overwriting shift. We need it to know to remove overwritten key from |m_map|.
+  std::list<Key> m_list;
+  size_t m_capacity;
+  Loader m_loader;
+};

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -11,11 +11,11 @@
 #include "geometry/point2d.hpp"
 
 #include "base/buffer_vector.hpp"
+#include "base/fifo_cache.hpp"
 
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace routing
 {
@@ -103,8 +103,7 @@ public:
   }
 
 private:
-  // Feature id to RoadGeometry map.
-  std::unordered_map<uint32_t, RoadGeometry> m_roads;
   std::unique_ptr<GeometryLoader> m_loader;
+  std::unique_ptr<FifoCache<uint32_t, RoadGeometry>> m_featureIdToRoad;
 };
 }  // namespace routing

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -89,14 +89,23 @@ public:
       std::string const & fileName, std::shared_ptr<VehicleModelInterface> vehicleModel);
 };
 
+/// \brief This class supports loading geometry of roads for routing.
+/// \note Loaded information about road geometry is kept in evicted cache |m_featureIdToRoad|.
+/// On the other hand methods GetRoad() and GetPoint() return geometry information by reference.
+/// The reference is valid until the next call of GetRoad() or GetPoint() because the cache
+/// item which is referred by returned reference may be evicted. It's done for performance reasons.
 class Geometry final
 {
 public:
   Geometry() = default;
   explicit Geometry(std::unique_ptr<GeometryLoader> loader);
 
+  /// \note The reference returned by the method is valid until the next call of GetRoad()
+  /// of GetPoint() methods.
   RoadGeometry const & GetRoad(uint32_t featureId);
 
+  /// \note The reference returned by the method is valid until the next call of GetRoad()
+  /// of GetPoint() methods.
   m2::PointD const & GetPoint(RoadPoint const & rp)
   {
     return GetRoad(rp.GetFeatureId()).GetPoint(rp.GetPointId());

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -90,9 +90,9 @@ public:
 };
 
 /// \brief This class supports loading geometry of roads for routing.
-/// \note Loaded information about road geometry is kept in evicted cache |m_featureIdToRoad|.
+/// \note Loaded information about road geometry is kept in a fixed-size cache |m_featureIdToRoad|.
 /// On the other hand methods GetRoad() and GetPoint() return geometry information by reference.
-/// The reference is valid until the next call of GetRoad() or GetPoint() because the cache
+/// The reference may be invalid after the next call of GetRoad() or GetPoint() because the cache
 /// item which is referred by returned reference may be evicted. It's done for performance reasons.
 class Geometry final
 {

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		3D74EF151F8B902C0081202C /* bwt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D74EF0F1F8B902C0081202C /* bwt.hpp */; };
 		3D7815731F3A145F0068B6AC /* task_loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815711F3A145F0068B6AC /* task_loop.hpp */; };
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
+		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -188,6 +189,7 @@
 		3D74EF0F1F8B902C0081202C /* bwt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bwt.hpp; sourceTree = "<group>"; };
 		3D7815711F3A145F0068B6AC /* task_loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = task_loop.hpp; sourceTree = "<group>"; };
 		3D78157A1F3D89EC0068B6AC /* waiter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = waiter.hpp; sourceTree = "<group>"; };
+		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 		675341791A3F57BF00A0A8C3 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				564BB444206E89ED00BDD211 /* fifo_cache.hpp */,
 				675341851A3F57E400A0A8C3 /* array_adapters.hpp */,
 				675341861A3F57E400A0A8C3 /* assert.hpp */,
 				675341871A3F57E400A0A8C3 /* base.cpp */,
@@ -526,6 +529,7 @@
 				6753420B1A3F57E400A0A8C3 /* threaded_container.hpp in Headers */,
 				672DD4C21E0425600078E13C /* condition.hpp in Headers */,
 				672DD4C41E0425600078E13C /* newtype.hpp in Headers */,
+				564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */,
 				672DD4C31E0425600078E13C /* mem_trie.hpp in Headers */,
 				672DD4C61E0425600078E13C /* range_iterator.hpp in Headers */,
 				F6F8E3C91EF846CE00F2DE8F /* worker_thread.hpp in Headers */,

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		3D7815731F3A145F0068B6AC /* task_loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815711F3A145F0068B6AC /* task_loop.hpp */; };
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
 		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
+		564BB447206E8A4D00BDD211 /* fifo_cache_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -190,6 +191,7 @@
 		3D7815711F3A145F0068B6AC /* task_loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = task_loop.hpp; sourceTree = "<group>"; };
 		3D78157A1F3D89EC0068B6AC /* waiter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = waiter.hpp; sourceTree = "<group>"; };
 		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
+		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 		39FD26C71CC659D200AFF551 /* base_tests */ = {
 			isa = PBXGroup;
 			children = (
+				564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */,
 				39B89C391FD1898A001104AF /* control_flow_tests.cpp */,
 				67E40EC71E4DC0D500A6D200 /* small_set_test.cpp */,
 				3446C67E1DDCAA6E00146687 /* newtype_test.cpp */,
@@ -682,6 +685,7 @@
 				675341F91A3F57E400A0A8C3 /* src_point.cpp in Sources */,
 				675342031A3F57E400A0A8C3 /* strings_bundle.cpp in Sources */,
 				39B89C3A1FD1898A001104AF /* control_flow_tests.cpp in Sources */,
+				564BB447206E8A4D00BDD211 /* fifo_cache_test.cpp in Sources */,
 				3D74EF141F8B902C0081202C /* bwt.cpp in Sources */,
 				3D74EF131F8B902C0081202C /* move_to_front.cpp in Sources */,
 				675341CD1A3F57E400A0A8C3 /* base.cpp in Sources */,


### PR DESCRIPTION
Данный PR является результатом исследования проведенного в https://github.com/mapsme/omim/pull/8404.

На текущем мастере, на iPhone 7, с определенным набором карт пешеходные маршруты прокладывались так:
Офис - Велике Луки: 676MB (памяти на прокладку), 36.8 секунды.
Офис - Зеленоград: 72MB(памяти на прокладку), 4.28 секунды.

После данного PR (FIFO c хеш таблицей и list по 5К элементов)
Офис - Велике Луки: 477МБ (памяти на прокладку), 37.6 секунд.
Офис - Зелиноград: 65MB(памяти на прокладку), 4.31 секунд.
Примерно та же скорость, что и без вытеснения, но памяти используемся много меньше.

Что осталось:
1. Поскольку раньше кэш наполнялся и ничего не удалялось до окончания работы было вполне безопасно возвращать ссылки на объекты кеша. После данного PR программа свою корректность сохраняет. Но метод `RoadGeometry const & Geometry::GetRoad(uint32_t featureId)` настораживает. Поскольку возвращает ссылку на значение кэша, которое может быть вытеснено. Что в будущем может иметь не приятные последствия. Это надо исправить в рамках данного PR;

2. Более серьезно проверить, что стало со временем прокладки маршрута. (Тест Велча, или  Student's t-test, или просто большая выборка)

@ygorshenin @tatiana-yan @mpimenov PTAL
