### PR TITLE
[search] Increase search rank for FC2018 objects

### DIFF
--- a/indexer/rank_table.hpp
+++ b/indexer/rank_table.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "std/cstdint.hpp"
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 class FilesContainerR;
 class FilesContainerW;
@@ -70,7 +70,7 @@ public:
   // *NOTE* Return value can outlive |rcont|. Also note that there is
   // undefined behaviour if ranks section exists but internally
   // damaged.
-  static unique_ptr<RankTable> Load(FilesContainerR const & rcont);
+  static std::unique_ptr<RankTable> Load(FilesContainerR const & rcont);
 
   // Maps whole section corresponding to a rank table and deserializes
   // it. Returns nullptr if there're no ranks section, rank table's
@@ -81,7 +81,7 @@ public:
   // destructed before |mcont| is closed. Also note that there're
   // undefined behaviour if ranks section exists but internally
   // damaged.
-  static unique_ptr<RankTable> Load(FilesMappingContainer const & mcont);
+  static std::unique_ptr<RankTable> Load(FilesMappingContainer const & mcont);
 };
 
 // A builder class for rank tables.
@@ -89,7 +89,7 @@ class RankTableBuilder
 {
 public:
   // Calculates search ranks for all features in an mwm.
-  static void CalcSearchRanks(FilesContainerR & rcont, vector<uint8_t> & ranks);
+  static void CalcSearchRanks(FilesContainerR & rcont, std::vector<uint8_t> & ranks);
 
   // Following methods create rank table for an mwm.
   // * When rank table already exists and has proper endianness, does nothing.
@@ -101,11 +101,11 @@ public:
   // Return true if rank table was successfully generated and written
   // or already exists and has correct format.
   static bool CreateIfNotExists(platform::LocalCountryFile const & localFile) noexcept;
-  static bool CreateIfNotExists(string const & mapPath) noexcept;
+  static bool CreateIfNotExists(std::string const & mapPath) noexcept;
 
   // Force creation of a rank table from array of ranks. Existing rank
   // table is removed (if any). Note that |wcont| must be instantiated
   // as FileWriter::OP_WRITE_EXISTING.
-  static void Create(vector<uint8_t> const & ranks, FilesContainerW & wcont);
+  static void Create(std::vector<uint8_t> const & ranks, FilesContainerW & wcont);
 };
 }  // namespace search

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -323,8 +323,7 @@ class RankerResultMaker
     case Model::TYPE_COUNTRY:
       return rank /= 1.5;
 
-    // For all other search types, rank should be zero for now.
-    default: return 0;
+    default: return rank;
     }
   }
 


### PR DESCRIPTION
Ранк для фифашных объектов подобран из следующих соображений:
1. Если ищется что-то типа "стадион" и во вьюпорте есть город где проходит ЧМ, то на первом месте должны быть стадионы ЧМ. 
2. Если вьюпорт вообще не рядом , то стадионы ЧМ не должны вылезать.
3. Поднять стадион при поиске по названию стадиона на первое место среди одноименных отелей, остановок и т.п.

Например, если на карте любой кусок москвы, то по запросу "стадион" топ-2 это лужники и спартак. Если на карте Минск, то по запросу "стадион" никаких объектов ЧМ вылезать не должно, должны быть стадионы в минске. Если ищем "казань арена", то среди кучи объектов типа "апартаменты с видом на казань арена" стадион должен быть первым.

todo уберу после тестов по полным данным (надеюсь что сегодня).