### PR TITLE
[generator] Fix type constructor

### DIFF
--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -45,8 +45,8 @@ SourceReader::SourceReader()
 }
 
 SourceReader::SourceReader(string const & filename)
+: m_file(unique_ptr<istream, Deleter>(new ifstream(filename), Deleter()))
 {
-  m_file = unique_ptr<istream, Deleter>(new ifstream(filename), Deleter());
   CHECK(static_cast<ifstream *>(m_file.get())->is_open() , ("Can't open file:", filename));
   LOG_SHORT(LINFO, ("Reading OSM data from", filename));
 }

--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -222,6 +222,9 @@ namespace
   /// See also ftypes_matcher.cpp, IsInvisibleIndexedChecker.
   bool TypeAlwaysExists(uint32_t type, EGeomType g = GEOM_UNDEFINED)
   {
+    if (!classif().IsTypeValid(type))
+      return false;
+
     static const uint32_t roundabout = classif().GetTypeByPath({ "junction", "roundabout" });
     static const uint32_t hwtag = classif().GetTypeByPath({ "hwtag" });
     static const uint32_t psurface = classif().GetTypeByPath({ "psurface" });


### PR DESCRIPTION
Во время сборки типа по тегам объекта в `osm2type.cpp` итоговый тип проверяется на `feature::IsDrawableAny()`. Засада в том, что этот метод вызывает не только соответствующий метод классификатора, но и `feature::TypeAlwaysVisible()`. Для спонсорских типов последний всегда возвращает `true`.

Это было бы нормально, если бы в типах присутствовало всё дерево спонсорских типов (т.е. все типы в последовательности вида `tourism` → `tourism-information` → `tourism-information-map`). Но у нас нет типа `event`, хотя есть два подтипа (`fc2018`). В OSM есть другие значения тега `event=*`, поэтому генератор конструировал для таких объектов тип `event`, метод `IsDrawableAny()` возвращал `true` по вышеописанной причине, и тип передавался на сохранение в mwm. Но до туда он не доходил, потому что сохранятор вываливался на преобразовании типа в число: его же нет в нашем списке типов.

Короче, здесь я это правлю методом добавления одной проверки в `TypeAlwaysExists()`.

Также, у меня перестал собираться `osm_source.cpp` из-за конструктора. Пишет, что для `m_file` нет конструктора по умолчанию. Я решил это переносом первой строчки в заголовок конструктора. Да, я знаю, что у вас собирается. И на серверах сборки собирается. На моём маке — нет. Жалко, что ли.