### PR TITLE
[generator] Disable fake types for lines

### DIFF
--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -254,8 +254,11 @@ namespace
     if (wheelchair == type && typeLength == 2)
       return true;
 
-    if (sponsored == type || internet == type || event == type)
-      return true;
+    if (g != GEOM_LINE)
+    {
+      if (sponsored == type || internet == type || event == type)
+        return true;
+    }
 
     return false;
   }


### PR DESCRIPTION
Спонсорские типы не должны светиться на не-poi. И не должны добавлять линии в данные.