### PR TITLE
[core] Tightened the thread checker

### DIFF
--- a/android/jni/com/mapswithme/maps/MapManager.cpp
+++ b/android/jni/com/mapswithme/maps/MapManager.cpp
@@ -453,7 +453,7 @@ Java_com_mapswithme_maps_downloader_MapManager_nativeIsDownloading(JNIEnv * env,
 
 static void StartBatchingCallbacks()
 {
-  ASSERT_THREAD_CHECKER(g_batchingThreadChecker, ("StartBatchingCallbacks"));
+  CHECK_THREAD_CHECKER(g_batchingThreadChecker, ("StartBatchingCallbacks"));
   ASSERT(!g_isBatched, ());
   ASSERT(g_batchedCallbackData.empty(), ());
 
@@ -462,7 +462,7 @@ static void StartBatchingCallbacks()
 
 static void EndBatchingCallbacks(JNIEnv * env)
 {
-  ASSERT_THREAD_CHECKER(g_batchingThreadChecker, ("EndBatchingCallbacks"));
+  CHECK_THREAD_CHECKER(g_batchingThreadChecker, ("EndBatchingCallbacks"));
 
   static jclass arrayListClass = jni::GetGlobalClassRef(env, "java/util/ArrayList");
   static jmethodID arrayListCtor = jni::GetConstructorID(env, arrayListClass, "(I)V");

--- a/base/thread_checker.hpp
+++ b/base/thread_checker.hpp
@@ -23,16 +23,10 @@ private:
   DISALLOW_COPY_AND_MOVE(ThreadChecker);
 };
 
-#if defined(DEBUG)
-  #define DECLARE_THREAD_CHECKER(threadCheckerName) ThreadChecker threadCheckerName
-  #define ASSERT_THREAD_CHECKER(threadCheckerName, msg) ASSERT(threadCheckerName.CalledOnOriginalThread(), msg)
-  #define DECLARE_AND_ASSERT_THREAD_CHECKER(msg) \
-  { \
-    static const ThreadChecker threadChecker; \
-    ASSERT(threadChecker.CalledOnOriginalThread(), (msg)); \
-  }
-#else
-  #define DECLARE_THREAD_CHECKER(threadCheckerName)
-  #define ASSERT_THREAD_CHECKER(threadCheckerName, msg)
-  #define DECLARE_AND_ASSERT_THREAD_CHECKER(msg)
-#endif
+#define DECLARE_THREAD_CHECKER(threadCheckerName) ThreadChecker threadCheckerName
+#define CHECK_THREAD_CHECKER(threadCheckerName, msg) CHECK(threadCheckerName.CalledOnOriginalThread(), msg)
+#define DECLARE_AND_CHECK_THREAD_CHECKER(msg) \
+{ \
+  static const ThreadChecker threadChecker; \
+  CHECK(threadChecker.CalledOnOriginalThread(), (msg)); \
+}

--- a/indexer/osm_editor.cpp
+++ b/indexer/osm_editor.cpp
@@ -1004,7 +1004,7 @@ NewFeatureCategories Editor::GetNewFeatureCategories() const
 
 FeatureID Editor::GenerateNewFeatureId(MwmSet::MwmId const & id) const
 {
-  DECLARE_AND_ASSERT_THREAD_CHECKER("GenerateNewFeatureId is single-threaded.");
+  DECLARE_AND_CHECK_THREAD_CHECKER("GenerateNewFeatureId is single-threaded.");
   // TODO(vng): Double-check if new feature indexes should uninterruptedly continue after existing indexes in mwm file.
   uint32_t featureIndex = feature::FakeFeatureIds::kEditorCreatedFeaturesStart;
   auto const found = m_features.find(id);

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -399,13 +399,13 @@ BookmarkManager::BookmarkManager(Callbacks && callbacks)
 
 BookmarkManager::EditSession BookmarkManager::GetEditSession()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return EditSession(*this);
 }
 
 UserMark const * BookmarkManager::GetMark(kml::MarkId markId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (IsBookmark(markId))
     return GetBookmark(markId);
   return GetUserMark(markId);
@@ -413,14 +413,14 @@ UserMark const * BookmarkManager::GetMark(kml::MarkId markId) const
 
 UserMark const * BookmarkManager::GetUserMark(kml::MarkId markId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_userMarks.find(markId);
   return (it != m_userMarks.end()) ? it->second.get() : nullptr;
 }
 
 UserMark * BookmarkManager::GetUserMarkForEdit(kml::MarkId markId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_userMarks.find(markId);
   if (it != m_userMarks.end())
   {
@@ -432,7 +432,7 @@ UserMark * BookmarkManager::GetUserMarkForEdit(kml::MarkId markId)
 
 void BookmarkManager::DeleteUserMark(kml::MarkId markId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(!IsBookmark(markId), ());
   auto it = m_userMarks.find(markId);
   auto const groupId = it->second->GetGroupId();
@@ -443,13 +443,13 @@ void BookmarkManager::DeleteUserMark(kml::MarkId markId)
 
 Bookmark * BookmarkManager::CreateBookmark(kml::BookmarkData && bmData)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return AddBookmark(std::make_unique<Bookmark>(std::move(bmData)));
 }
 
 Bookmark * BookmarkManager::CreateBookmark(kml::BookmarkData && bm, kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetPlatform().GetMarketingService().SendMarketingEvent(marketing::kBookmarksBookmarkAction,
                                                          {{"action", "create"}});
 
@@ -470,14 +470,14 @@ Bookmark * BookmarkManager::CreateBookmark(kml::BookmarkData && bm, kml::MarkGro
 
 Bookmark const * BookmarkManager::GetBookmark(kml::MarkId markId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_bookmarks.find(markId);
   return (it != m_bookmarks.end()) ? it->second.get() : nullptr;
 }
 
 Bookmark * BookmarkManager::GetBookmarkForEdit(kml::MarkId markId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_bookmarks.find(markId);
   if (it == m_bookmarks.end())
     return nullptr;
@@ -491,21 +491,21 @@ Bookmark * BookmarkManager::GetBookmarkForEdit(kml::MarkId markId)
 
 void BookmarkManager::AttachBookmark(kml::MarkId bmId, kml::MarkGroupId catID)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetBookmarkForEdit(bmId)->Attach(catID);
   GetGroup(catID)->AttachUserMark(bmId);
 }
 
 void BookmarkManager::DetachBookmark(kml::MarkId bmId, kml::MarkGroupId catID)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetBookmarkForEdit(bmId)->Detach();
   GetGroup(catID)->DetachUserMark(bmId);
 }
 
 void BookmarkManager::DeleteBookmark(kml::MarkId bmId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(IsBookmark(bmId), ());
   auto groupIt = m_bookmarks.find(bmId);
   auto const groupId = groupIt->second->GetGroupId();
@@ -517,20 +517,20 @@ void BookmarkManager::DeleteBookmark(kml::MarkId bmId)
 
 Track * BookmarkManager::CreateTrack(kml::TrackData && trackData)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return AddTrack(std::make_unique<Track>(std::move(trackData)));
 }
 
 Track const * BookmarkManager::GetTrack(kml::TrackId trackId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_tracks.find(trackId);
   return (it != m_tracks.end()) ? it->second.get() : nullptr;
 }
 
 void BookmarkManager::AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_tracks.find(trackId);
   it->second->Attach(groupId);
   GetBmCategory(groupId)->AttachTrack(trackId);
@@ -538,13 +538,13 @@ void BookmarkManager::AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId
 
 void BookmarkManager::DetachTrack(kml::TrackId trackId, kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetBmCategory(groupId)->DetachTrack(trackId);
 }
 
 void BookmarkManager::DeleteTrack(kml::TrackId trackId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_tracks.find(trackId);
   auto const groupId = it->second->GetGroupId();
   if (groupId != kml::kInvalidMarkGroupId)
@@ -555,7 +555,7 @@ void BookmarkManager::DeleteTrack(kml::TrackId trackId)
 
 void BookmarkManager::CollectDirtyGroups(kml::GroupIdSet & dirtyGroups)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & group : m_userMarkLayers)
   {
     if (!group->IsDirty())
@@ -585,7 +585,7 @@ void BookmarkManager::OnEditSessionClosed()
 
 void BookmarkManager::NotifyChanges()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (!m_changesTracker.CheckChanges() && !m_firstDrapeNotification)
     return;
 
@@ -639,19 +639,19 @@ void BookmarkManager::NotifyChanges()
 
 kml::MarkIdSet const & BookmarkManager::GetUserMarkIds(kml::MarkGroupId groupId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetGroup(groupId)->GetUserMarks();
 }
 
 kml::TrackIdSet const & BookmarkManager::GetTrackIds(kml::MarkGroupId groupId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetGroup(groupId)->GetUserLines();
 }
 
 void BookmarkManager::ClearGroup(kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * group = GetGroup(groupId);
   for (auto markId : group->GetUserMarks())
   {
@@ -671,25 +671,25 @@ void BookmarkManager::ClearGroup(kml::MarkGroupId groupId)
 
 std::string BookmarkManager::GetCategoryName(kml::MarkGroupId categoryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetBmCategory(categoryId)->GetName();
 }
 
 void BookmarkManager::SetCategoryName(kml::MarkGroupId categoryId, std::string const & name)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetBmCategory(categoryId)->SetName(name);
 }
 
 std::string BookmarkManager::GetCategoryFileName(kml::MarkGroupId categoryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetBmCategory(categoryId)->GetFileName();
 }
 
 kml::MarkGroupId BookmarkManager::GetCategoryId(std::string const & name) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & category : m_categories)
   {
     if (category.second->GetName() == name)
@@ -700,7 +700,7 @@ kml::MarkGroupId BookmarkManager::GetCategoryId(std::string const & name) const
 
 UserMark const * BookmarkManager::FindMarkInRect(kml::MarkGroupId groupId, m2::AnyRectD const & rect, double & d) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto const * group = GetGroup(groupId);
 
   UserMark const * resMark = nullptr;
@@ -719,13 +719,13 @@ UserMark const * BookmarkManager::FindMarkInRect(kml::MarkGroupId groupId, m2::A
 
 void BookmarkManager::SetIsVisible(kml::MarkGroupId groupId, bool visible)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   GetGroup(groupId)->SetIsVisible(visible);
 }
 
 bool BookmarkManager::IsVisible(kml::MarkGroupId groupId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetGroup(groupId)->IsVisible();
 }
 
@@ -752,7 +752,7 @@ void BookmarkManager::Teardown()
 
 Bookmark * BookmarkManager::AddBookmark(std::unique_ptr<Bookmark> && bookmark)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * bm = bookmark.get();
   auto const markId = bm->GetId();
   CHECK_EQUAL(m_bookmarks.count(markId), 0, ());
@@ -763,7 +763,7 @@ Bookmark * BookmarkManager::AddBookmark(std::unique_ptr<Bookmark> && bookmark)
 
 Track * BookmarkManager::AddTrack(std::unique_ptr<Track> && track)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * t = track.get();
   auto const trackId = t->GetId();
   CHECK_EQUAL(m_tracks.count(trackId), 0, ());
@@ -796,7 +796,7 @@ void BookmarkManager::LoadState()
 
 void BookmarkManager::ClearCategories()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto groupId : m_bmGroupsIdList)
   {
     ClearGroup(groupId);
@@ -835,7 +835,7 @@ BookmarkManager::KMLDataCollectionPtr BookmarkManager::LoadBookmarks(std::string
 
 void BookmarkManager::LoadBookmarks()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ClearCategories();
   m_loadBookmarksFinished = false;
 
@@ -864,7 +864,7 @@ void BookmarkManager::LoadBookmarks()
 
 void BookmarkManager::LoadBookmark(std::string const & filePath, bool isTemporaryFile)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   // Defer bookmark loading in case of another asynchronous process.
   if (!m_loadBookmarksFinished || m_asyncLoadingInProgress || m_conversionInProgress ||
       m_restoreApplying)
@@ -1043,7 +1043,7 @@ boost::optional<std::string> BookmarkManager::GetKMLPath(std::string const & fil
 
 void BookmarkManager::MoveBookmark(kml::MarkId bmID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   DetachBookmark(bmID, curGroupID);
   AttachBookmark(bmID, newGroupID);
 
@@ -1052,7 +1052,7 @@ void BookmarkManager::MoveBookmark(kml::MarkId bmID, kml::MarkGroupId curGroupID
 
 void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const & bm)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * bookmark = GetBookmarkForEdit(bmID);
 
   auto const prevColor = bookmark->GetColor();
@@ -1065,7 +1065,7 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (HasBmCategory(m_lastEditedGroupId))
     return m_lastEditedGroupId;
@@ -1084,7 +1084,7 @@ kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
 
 kml::PredefinedColor BookmarkManager::LastEditedBMColor() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return (m_lastColor != kml::PredefinedColor::None ? m_lastColor : BookmarkCategory::GetDefaultColor());
 }
 
@@ -1103,7 +1103,7 @@ void BookmarkManager::SetLastEditedBmColor(kml::PredefinedColor color)
 
 BookmarkCategory const * BookmarkManager::GetBmCategory(kml::MarkGroupId categoryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(IsBookmarkCategory(categoryId), ());
   auto const it = m_categories.find(categoryId);
   return (it != m_categories.end() ? it->second.get() : nullptr);
@@ -1111,7 +1111,7 @@ BookmarkCategory const * BookmarkManager::GetBmCategory(kml::MarkGroupId categor
 
 BookmarkCategory * BookmarkManager::GetBmCategory(kml::MarkGroupId categoryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(IsBookmarkCategory(categoryId), ());
   auto const it = m_categories.find(categoryId);
   return (it != m_categories.end() ? it->second.get() : nullptr);
@@ -1148,7 +1148,7 @@ void BookmarkManager::SendBookmarksChanges()
 void BookmarkManager::GetBookmarksData(kml::MarkIdSet const & markIds,
                                        std::vector<std::pair<kml::MarkId, kml::BookmarkData>> & data) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   data.clear();
   data.reserve(markIds.size());
   for (auto markId : markIds)
@@ -1161,13 +1161,13 @@ void BookmarkManager::GetBookmarksData(kml::MarkIdSet const & markIds,
 
 bool BookmarkManager::HasBmCategory(kml::MarkGroupId groupId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return m_categories.find(groupId) != m_categories.end();
 }
 
 void BookmarkManager::UpdateBmGroupIdList()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   m_bmGroupsIdList.clear();
   m_bmGroupsIdList.reserve(m_categories.size());
   for (auto it = m_categories.crbegin(); it != m_categories.crend(); ++it)
@@ -1176,7 +1176,7 @@ void BookmarkManager::UpdateBmGroupIdList()
 
 kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(kml::CategoryData && data, bool autoSave)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (data.m_id == kml::kInvalidMarkGroupId)
   {
@@ -1192,7 +1192,7 @@ kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(kml::CategoryData && da
 
 kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(std::string const & name, bool autoSave)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto const groupId = UserMarkIdStorage::Instance().GetNextCategoryId();
   CHECK_EQUAL(m_categories.count(groupId), 0, ());
   m_categories[groupId] = my::make_unique<BookmarkCategory>(name, groupId, autoSave);
@@ -1203,7 +1203,7 @@ kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(std::string const & nam
 
 void BookmarkManager::CheckAndCreateDefaultCategory()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (m_categories.empty())
     CreateBookmarkCategory(m_callbacks.m_getStringsBundle().GetString("core_my_places"));
 }
@@ -1221,7 +1221,7 @@ void BookmarkManager::CheckAndResetLastIds()
 
 bool BookmarkManager::DeleteBmCategory(kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_categories.find(groupId);
   if (it == m_categories.end())
     return false;
@@ -1271,13 +1271,13 @@ private:
 
 UserMark const * BookmarkManager::FindNearestUserMark(m2::AnyRectD const & rect) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return FindNearestUserMark([&rect](UserMark::Type) { return rect; });
 }
 
 UserMark const * BookmarkManager::FindNearestUserMark(TTouchRectHolder const & holder) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   BestUserMarkFinder finder(holder, this);
   finder(UserMark::Type::ROUTING);
   finder(UserMark::Type::SEARCH);
@@ -1290,7 +1290,7 @@ UserMark const * BookmarkManager::FindNearestUserMark(TTouchRectHolder const & h
 
 UserMarkLayer const * BookmarkManager::GetGroup(kml::MarkGroupId groupId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (groupId < UserMark::Type::USER_MARK_TYPES_COUNT)
     return m_userMarkLayers[groupId - 1].get();
 
@@ -1300,7 +1300,7 @@ UserMarkLayer const * BookmarkManager::GetGroup(kml::MarkGroupId groupId) const
 
 UserMarkLayer * BookmarkManager::GetGroup(kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (groupId < UserMark::Type::USER_MARK_TYPES_COUNT)
     return m_userMarkLayers[groupId - 1].get();
 
@@ -1310,7 +1310,7 @@ UserMarkLayer * BookmarkManager::GetGroup(kml::MarkGroupId groupId)
 
 void BookmarkManager::CreateCategories(KMLDataCollection && dataCollection, bool autoSave)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   kml::GroupIdSet loadedGroups;
 
   for (auto const & data : dataCollection)
@@ -1395,7 +1395,7 @@ std::unique_ptr<kml::FileData> BookmarkManager::CollectBmGroupKMLData(BookmarkCa
 
 bool BookmarkManager::SaveBookmarkCategory(kml::MarkGroupId groupId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto collection = PrepareToSaveBookmarks({groupId});
   if (!collection || collection->empty())
     return false;
@@ -1406,7 +1406,7 @@ bool BookmarkManager::SaveBookmarkCategory(kml::MarkGroupId groupId)
 
 bool BookmarkManager::SaveBookmarkCategory(kml::MarkGroupId groupId, Writer & writer, bool useBinary) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * group = GetBmCategory(groupId);
   auto kmlData = CollectBmGroupKMLData(group);
   return SaveKmlData(*kmlData, writer, useBinary);
@@ -1460,7 +1460,7 @@ bool BookmarkManager::SaveKmlFileSafe(kml::FileData & kmlData, std::string const
 
 void BookmarkManager::SaveBookmarks(kml::GroupIdCollection const & groupIdCollection)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   auto kmlDataCollection = PrepareToSaveBookmarks(groupIdCollection);
   if (!kmlDataCollection)
@@ -1510,7 +1510,7 @@ void BookmarkManager::SetInvalidTokenHandler(Cloud::InvalidTokenHandler && onInv
 
 void BookmarkManager::PrepareFileForSharing(kml::MarkGroupId categoryId, SharingHandler && handler)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(handler, ());
   if (IsCategoryEmpty(categoryId))
   {
@@ -1534,13 +1534,13 @@ void BookmarkManager::PrepareFileForSharing(kml::MarkGroupId categoryId, Sharing
 
 bool BookmarkManager::IsCategoryEmpty(kml::MarkGroupId categoryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return GetBmCategory(categoryId)->IsEmpty();
 }
 
 bool BookmarkManager::IsUsedCategoryName(std::string const & name) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & c : m_categories)
   {
     if (c.second->GetName() == name)
@@ -1551,7 +1551,7 @@ bool BookmarkManager::IsUsedCategoryName(std::string const & name) const
 
 bool BookmarkManager::AreAllCategoriesVisible() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & c : m_categories)
   {
     if (!c.second->IsVisible())
@@ -1562,7 +1562,7 @@ bool BookmarkManager::AreAllCategoriesVisible() const
 
 bool BookmarkManager::AreAllCategoriesInvisible() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & c : m_categories)
   {
     if (c.second->IsVisible())
@@ -1573,7 +1573,7 @@ bool BookmarkManager::AreAllCategoriesInvisible() const
 
 void BookmarkManager::SetAllCategoriesVisibility(bool visible)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto & c : m_categories)
     c.second->SetIsVisible(visible);
 }
@@ -1606,7 +1606,7 @@ void BookmarkManager::FinishConversion(ConversionHandler const & handler, bool r
 
 size_t BookmarkManager::GetKmlFilesCountForConversion() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (!CanConvert())
     return 0;
 
@@ -1618,7 +1618,7 @@ size_t BookmarkManager::GetKmlFilesCountForConversion() const
 
 void BookmarkManager::ConvertAllKmlFiles(ConversionHandler && handler)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (!CanConvert())
     return;
 

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -329,7 +329,7 @@ private:
   template <typename UserMarkT>
   UserMarkT * CreateUserMark(m2::PointD const & ptOrg)
   {
-    ASSERT_THREAD_CHECKER(m_threadChecker, ());
+    CHECK_THREAD_CHECKER(m_threadChecker, ());
     auto mark = std::make_unique<UserMarkT>(ptOrg);
     auto * m = mark.get();
     auto const markId = m->GetId();
@@ -345,7 +345,7 @@ private:
   template <typename UserMarkT>
   UserMarkT * GetMarkForEdit(kml::MarkId markId)
   {
-    ASSERT_THREAD_CHECKER(m_threadChecker, ());
+    CHECK_THREAD_CHECKER(m_threadChecker, ());
     auto * mark = GetUserMarkForEdit(markId);
     ASSERT(dynamic_cast<UserMarkT *>(mark) != nullptr, ());
     return static_cast<UserMarkT *>(mark);
@@ -354,7 +354,7 @@ private:
   template <typename UserMarkT, typename F>
   void DeleteUserMarks(UserMark::Type type, F && deletePredicate)
   {
-    ASSERT_THREAD_CHECKER(m_threadChecker, ());
+    CHECK_THREAD_CHECKER(m_threadChecker, ());
     std::list<kml::MarkId> marksToDelete;
     for (auto markId : GetUserMarkIds(type))
     {

--- a/map/discovery/discovery_manager.cpp
+++ b/map/discovery/discovery_manager.cpp
@@ -56,7 +56,7 @@ std::string Manager::GetLocalExpertsUrl(m2::PointD const & point) const
 
 std::string Manager::GetCityViatorId(m2::PointD const & point) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto const fid = m_cityFinder.GetCityFeatureID(point);
   if (!fid.IsValid())
     return {};

--- a/map/discovery/discovery_manager.hpp
+++ b/map/discovery/discovery_manager.hpp
@@ -59,7 +59,7 @@ public:
   uint32_t Discover(Params && params, ResultCallback const & onResult, ErrorCalback const & onError)
   {
     uint32_t const requestId = ++m_requestCounter;
-    ASSERT_THREAD_CHECKER(m_threadChecker, ());
+    CHECK_THREAD_CHECKER(m_threadChecker, ());
     auto const & types = params.m_itemTypes;
     ASSERT(!types.empty(), ("Types must contain at least one element."));
 
@@ -91,7 +91,7 @@ public:
             sponsoredId, params.m_curency,
             [this, requestId, sponsoredId, onResult, onError](std::string const & destId,
                                                      std::vector<viator::Product> const & products) {
-              ASSERT_THREAD_CHECKER(m_threadChecker, ());
+              CHECK_THREAD_CHECKER(m_threadChecker, ());
               if (destId == sponsoredId)
               {
                 if (products.empty())
@@ -129,11 +129,11 @@ public:
             [this, requestId, onResult](uint64_t id, std::vector<locals::LocalExpert> const & locals,
                                         size_t /* pageNumber */, size_t /* countPerPage */,
                                         bool /* hasPreviousPage */, bool /* hasNextPage */) {
-              ASSERT_THREAD_CHECKER(m_threadChecker, ());
+              CHECK_THREAD_CHECKER(m_threadChecker, ());
               onResult(requestId, locals);
             },
             [this, requestId, onError, type](uint64_t id, int errorCode, std::string const & errorMessage) {
-              ASSERT_THREAD_CHECKER(m_threadChecker, ());
+              CHECK_THREAD_CHECKER(m_threadChecker, ());
               onError(requestId, type);
             });
         break;

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -776,7 +776,7 @@ void RoutingManager::GenerateTurnNotifications(vector<string> & turnNotification
 
 void RoutingManager::BuildRoute(uint32_t timeoutSec)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ("BuildRoute"));
+  CHECK_THREAD_CHECKER(m_threadChecker, ("BuildRoute"));
 
   m_bmManager->GetEditSession().ClearGroup(UserMark::Type::TRANSIT);
 
@@ -1051,7 +1051,7 @@ bool RoutingManager::IsTrackingReporterEnabled() const
 
 void RoutingManager::SetRouter(RouterType type)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ("SetRouter"));
+  CHECK_THREAD_CHECKER(m_threadChecker, ("SetRouter"));
 
   if (m_currentRouterType == type)
     return;

--- a/storage/http_map_files_downloader.cpp
+++ b/storage/http_map_files_downloader.cpp
@@ -28,12 +28,12 @@ namespace storage
 {
 HttpMapFilesDownloader::~HttpMapFilesDownloader()
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
 }
 
 void HttpMapFilesDownloader::GetServersList(TServersListCallback const & callback)
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   m_request.reset(downloader::HttpRequest::Get(
       GetPlatform().MetaServerUrl(),
       bind(&HttpMapFilesDownloader::OnServersListDownloaded, this, callback, _1)));
@@ -44,7 +44,7 @@ void HttpMapFilesDownloader::DownloadMapFile(vector<string> const & urls, string
                                              TFileDownloadedCallback const & onDownloaded,
                                              TDownloadingProgressCallback const & onProgress)
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   m_request.reset(downloader::HttpRequest::GetFile(
       urls, path, size, bind(&HttpMapFilesDownloader::OnMapFileDownloaded, this, onDownloaded, _1),
       bind(&HttpMapFilesDownloader::OnMapFileDownloadingProgress, this, onProgress, _1)));
@@ -59,27 +59,27 @@ void HttpMapFilesDownloader::DownloadMapFile(vector<string> const & urls, string
 
 MapFilesDownloader::TProgress HttpMapFilesDownloader::GetDownloadingProgress()
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   ASSERT(nullptr != m_request, ());
   return m_request->Progress();
 }
 
 bool HttpMapFilesDownloader::IsIdle()
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   return m_request.get() == nullptr;
 }
 
 void HttpMapFilesDownloader::Reset()
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   m_request.reset();
 }
 
 void HttpMapFilesDownloader::OnServersListDownloaded(TServersListCallback const & callback,
                                                      downloader::HttpRequest & request)
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   vector<string> urls;
   GetServerListFromRequest(request, urls);
   callback(urls);
@@ -88,7 +88,7 @@ void HttpMapFilesDownloader::OnServersListDownloaded(TServersListCallback const 
 void HttpMapFilesDownloader::OnMapFileDownloaded(TFileDownloadedCallback const & onDownloaded,
                                                  downloader::HttpRequest & request)
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   bool const success = request.Status() != downloader::HttpRequest::EFailed;
   onDownloaded(success, request.Progress());
 }
@@ -96,7 +96,7 @@ void HttpMapFilesDownloader::OnMapFileDownloaded(TFileDownloadedCallback const &
 void HttpMapFilesDownloader::OnMapFileDownloadingProgress(
     TDownloadingProgressCallback const & onProgress, downloader::HttpRequest & request)
 {
-  ASSERT_THREAD_CHECKER(m_checker, ());
+  CHECK_THREAD_CHECKER(m_checker, ());
   onProgress(request.Progress());
 }
 }  // namespace storage

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -128,7 +128,7 @@ Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
 
 void Storage::Init(TUpdateCallback const & didDownload, TDeleteCallback const & willDelete)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_didDownload = didDownload;
   m_willDelete = willDelete;
@@ -136,7 +136,7 @@ void Storage::Init(TUpdateCallback const & didDownload, TDeleteCallback const & 
 
 void Storage::DeleteAllLocalMaps(TCountriesVec * existedCountries /* = nullptr */)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   for (auto const & localFiles : m_localFiles)
   {
@@ -153,14 +153,14 @@ void Storage::DeleteAllLocalMaps(TCountriesVec * existedCountries /* = nullptr *
 
 bool Storage::HaveDownloadedCountries() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   return !m_localFiles.empty();
 }
 
 Storage * Storage::GetPrefetchStorage()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(m_prefetchStorage.get() != nullptr, ());
 
   return m_prefetchStorage.get();
@@ -168,7 +168,7 @@ Storage * Storage::GetPrefetchStorage()
 
 void Storage::PrefetchMigrateData()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_prefetchStorage.reset(new Storage(COUNTRIES_FILE, "migrate"));
   m_prefetchStorage->EnableKeepDownloadingQueue(false);
@@ -180,7 +180,7 @@ void Storage::PrefetchMigrateData()
 
 void Storage::Migrate(TCountriesVec const & existedCountries)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   platform::migrate::SetMigrationFlag();
 
@@ -221,7 +221,7 @@ void Storage::Migrate(TCountriesVec const & existedCountries)
 
 void Storage::Clear()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_downloader->Reset();
   m_queue.clear();
@@ -234,7 +234,7 @@ void Storage::Clear()
 
 void Storage::RegisterAllLocalMaps(bool enableDiffs)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_localFiles.clear();
   m_localFilesForFakeCountries.clear();
@@ -312,7 +312,7 @@ void Storage::RegisterAllLocalMaps(bool enableDiffs)
 
 void Storage::GetLocalMaps(vector<TLocalFilePtr> & maps) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   for (auto const & p : m_localFiles)
     maps.push_back(GetLatestLocalFile(p.first));
@@ -325,7 +325,7 @@ void Storage::GetLocalMaps(vector<TLocalFilePtr> & maps) const
 
 size_t Storage::GetDownloadedFilesCount() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   return m_localFiles.size();
 }
@@ -386,7 +386,7 @@ CountryFile const & Storage::GetCountryFile(TCountryId const & countryId) const
 
 TLocalFilePtr Storage::GetLatestLocalFile(CountryFile const & countryFile) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryId const countryId = FindCountryIdByFile(countryFile.GetName());
   if (IsLeaf(countryId))
@@ -405,7 +405,7 @@ TLocalFilePtr Storage::GetLatestLocalFile(CountryFile const & countryFile) const
 
 TLocalFilePtr Storage::GetLatestLocalFile(TCountryId const & countryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   auto const it = m_localFiles.find(countryId);
   if (it == m_localFiles.end() || it->second.empty())
@@ -462,7 +462,7 @@ void Storage::CountryStatusEx(TCountryId const & countryId, Status & status,
 
 void Storage::SaveDownloadQueue()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (!m_keepDownloadingQueue)
     return;
@@ -510,7 +510,7 @@ void Storage::RestoreDownloadQueue()
 
 void Storage::DownloadCountry(TCountryId const & countryId, MapOptions opt)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (opt == MapOptions::Nothing)
     return;
@@ -550,7 +550,7 @@ void Storage::DeleteCountry(TCountryId const & countryId, MapOptions opt)
 
 void Storage::DeleteCustomCountryVersion(LocalCountryFile const & localFile)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   CountryFile const countryFile = localFile.GetCountryFile();
   DeleteFromDiskWithIndexes(localFile, MapOptions::MapWithCarRouting);
@@ -574,7 +574,7 @@ void Storage::DeleteCustomCountryVersion(LocalCountryFile const & localFile)
 
 void Storage::NotifyStatusChanged(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   for (CountryObservers const & observer : m_observers)
     observer.m_changeCountryFn(countryId);
@@ -594,7 +594,7 @@ void Storage::NotifyStatusChangedForHierarchy(TCountryId const & countryId)
 
 void Storage::DownloadNextCountryFromQueue()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   bool const stopDownload = !m_downloadingPolicy->IsDownloadingAllowed();
 
@@ -681,7 +681,7 @@ void Storage::DownloadNextFile(QueuedCountry const & country)
 
 void Storage::DeleteFromDownloader(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (DeleteCountryFilesFromDownloader(countryId))
     NotifyStatusChangedForHierarchy(countryId);
@@ -689,14 +689,14 @@ void Storage::DeleteFromDownloader(TCountryId const & countryId)
 
 bool Storage::IsDownloadInProgress() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   return !m_queue.empty();
 }
 
 TCountryId Storage::GetCurrentDownloadingCountryId() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   return IsDownloadInProgress() ? m_queue.front().GetCountryId() : storage::TCountryId();
 }
@@ -718,7 +718,7 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile, string const
 
 int Storage::Subscribe(TChangeCountryFunction const & change, TProgressFunction const & progress)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   CountryObservers obs;
 
@@ -733,7 +733,7 @@ int Storage::Subscribe(TChangeCountryFunction const & change, TProgressFunction 
 
 void Storage::Unsubscribe(int slotId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   for (auto i = m_observers.begin(); i != m_observers.end(); ++i)
   {
@@ -748,7 +748,7 @@ void Storage::Unsubscribe(int slotId)
 void Storage::OnMapFileDownloadFinished(bool success,
                                         MapFilesDownloader::TProgress const & progress)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (m_queue.empty())
     return;
@@ -779,7 +779,7 @@ void Storage::OnMapFileDownloadFinished(bool success,
 
 void Storage::ReportProgress(TCountryId const & countryId, MapFilesDownloader::TProgress const & p)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (CountryObservers const & o : m_observers)
     o.m_progressFn(countryId, p);
 }
@@ -810,7 +810,7 @@ void Storage::ReportProgressForHierarchy(TCountryId const & countryId,
 
 void Storage::DoDownload()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   CHECK(m_sessionServerList || !m_downloadingUrlsForTesting.empty(), ());
 
   // Queue can be empty because countries were deleted from queue.
@@ -851,14 +851,14 @@ void Storage::DoDownload()
 
 void Storage::SetDeferDownloading()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_needToStartDeferredDownloading = true;
 }
 
 void Storage::DoDeferredDownloadIfNeeded()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (!m_needToStartDeferredDownloading || !m_sessionServerList)
     return;
@@ -869,7 +869,7 @@ void Storage::DoDeferredDownloadIfNeeded()
 
 void Storage::OnMapFileDownloadProgress(MapFilesDownloader::TProgress const & progress)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   // Queue can be empty because countries were deleted from queue.
   if (m_queue.empty())
@@ -883,11 +883,11 @@ void Storage::OnMapFileDownloadProgress(MapFilesDownloader::TProgress const & pr
 
 void Storage::RegisterDownloadedFiles(TCountryId const & countryId, MapOptions options)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   auto const fn = [this, countryId](bool isSuccess)
   {
-    ASSERT_THREAD_CHECKER(m_threadChecker, ());
+    CHECK_THREAD_CHECKER(m_threadChecker, ());
     if (!isSuccess)
     {
       OnDownloadFailed(countryId);
@@ -962,7 +962,7 @@ void Storage::RegisterDownloadedFiles(TCountryId const & countryId, MapOptions o
 
 void Storage::OnMapDownloadFinished(TCountryId const & countryId, bool success, MapOptions options)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(m_didDownload != nullptr, ("Storage::Init wasn't called"));
   ASSERT_NOT_EQUAL(MapOptions::Nothing, options,
                    ("This method should not be called for empty files set."));
@@ -1086,7 +1086,7 @@ MapOptions Storage::NormalizeDeleteFileSet(MapOptions options) const
 
 QueuedCountry * Storage::FindCountryInQueue(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   auto it = find(m_queue.begin(), m_queue.end(), countryId);
   return it == m_queue.end() ? nullptr : &*it;
@@ -1094,7 +1094,7 @@ QueuedCountry * Storage::FindCountryInQueue(TCountryId const & countryId)
 
 QueuedCountry const * Storage::FindCountryInQueue(TCountryId const & countryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   auto it = find(m_queue.begin(), m_queue.end(), countryId);
   return it == m_queue.end() ? nullptr : &*it;
@@ -1107,14 +1107,14 @@ bool Storage::IsCountryInQueue(TCountryId const & countryId) const
 
 bool Storage::IsCountryFirstInQueue(TCountryId const & countryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   return !m_queue.empty() && m_queue.front().GetCountryId() == countryId;
 }
 
 bool Storage::IsDiffApplyingInProgressToCountry(TCountryId const & countryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (!IsCountryFirstInQueue(countryId))
     return false;
@@ -1225,7 +1225,7 @@ void Storage::DeleteCountryFiles(TCountryId const & countryId, MapOptions opt, b
 
 bool Storage::DeleteCountryFilesFromDownloader(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   QueuedCountry * queuedCountry = FindCountryInQueue(countryId);
   if (!queuedCountry)
@@ -1300,7 +1300,7 @@ bool Storage::CheckFailedCountries(TCountriesVec const & countries) const
 TCountryId const Storage::GetRootId() const { return m_countries.GetRoot().Value().Name(); }
 void Storage::GetChildren(TCountryId const & parent, TCountriesVec & childIds) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryTreeNode const * const parentNode = m_countries.FindFirst(parent);
   if (parentNode == nullptr)
@@ -1318,7 +1318,7 @@ void Storage::GetChildren(TCountryId const & parent, TCountriesVec & childIds) c
 
 void Storage::GetLocalRealMaps(TCountriesVec & localMaps) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   localMaps.clear();
   localMaps.reserve(m_localFiles.size());
@@ -1330,7 +1330,7 @@ void Storage::GetLocalRealMaps(TCountriesVec & localMaps) const
 void Storage::GetChildrenInGroups(TCountryId const & parent, TCountriesVec & downloadedChildren,
                                   TCountriesVec & availChildren, bool keepAvailableChildren) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryTreeNode const * const parentNode = m_countries.FindFirst(parent);
   if (parentNode == nullptr)
@@ -1398,7 +1398,7 @@ void Storage::GetChildrenInGroups(TCountryId const & parent, TCountriesVec & dow
 
 bool Storage::IsNodeDownloaded(TCountryId const & countryId) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   for (auto const & localeMap : m_localFiles)
   {
@@ -1415,7 +1415,7 @@ bool Storage::HasLatestVersion(TCountryId const & countryId) const
 
 void Storage::DownloadNode(TCountryId const & countryId, bool isUpdate /* = false */)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryTreeNode const * const node = m_countries.FindFirst(countryId);
 
@@ -1437,7 +1437,7 @@ void Storage::DownloadNode(TCountryId const & countryId, bool isUpdate /* = fals
 
 void Storage::DeleteNode(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryTreeNode const * const node = m_countries.FindFirst(countryId);
 
@@ -1480,7 +1480,7 @@ void Storage::CalMaxMwmSizeBytes()
 
 void Storage::LoadDiffScheme()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   diffs::LocalMapsInfo localMapsInfo;
   auto const currentVersion = GetCurrentDataVersion();
   localMapsInfo.m_currentDataVersion = currentVersion;
@@ -1531,28 +1531,28 @@ void Storage::ApplyDiff(TCountryId const & countryId, function<void(bool isSucce
 
 void Storage::LoadServerListForSession()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_downloader->GetServersList([this](vector<string> const & urls) { PingServerList(urls); });
 }
 
 void Storage::LoadServerListForTesting()
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_downloader->GetServersList([this](auto const & urls) { m_sessionServerList = urls; });
 }
 
 void Storage::PingServerList(vector<string> const & urls)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (urls.empty())
     return;
 
   GetPlatform().RunTask(Platform::Thread::Network, [urls, this] {
     Pinger::Ping(urls, [this, urls](vector<string> readyUrls) {
-      ASSERT_THREAD_CHECKER(m_threadChecker, ());
+      CHECK_THREAD_CHECKER(m_threadChecker, ());
 
       if (readyUrls.empty())
         m_sessionServerList = urls;
@@ -1566,13 +1566,13 @@ void Storage::PingServerList(vector<string> const & urls)
 
 bool Storage::IsPossibleToAutoupdate() const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
   return m_diffManager.IsPossibleToAutoupdate();
 }
 
 void Storage::SetStartDownloadingCallback(StartDownloadingCallback const & cb)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_startDownloadingCallback = cb;
 }
@@ -1646,7 +1646,7 @@ StatusAndError Storage::GetNodeStatusInfo(
 
 void Storage::GetNodeAttrs(TCountryId const & countryId, NodeAttrs & nodeAttrs) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   vector<TCountryTreeNode const *> nodes;
   m_countries.Find(countryId, nodes);
@@ -1753,7 +1753,7 @@ void Storage::GetNodeAttrs(TCountryId const & countryId, NodeAttrs & nodeAttrs) 
 
 void Storage::GetNodeStatuses(TCountryId const & countryId, NodeStatuses & nodeStatuses) const
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   TCountryTreeNode const * const node = m_countries.FindFirst(countryId);
   CHECK(node, (countryId));
@@ -1766,14 +1766,14 @@ void Storage::GetNodeStatuses(TCountryId const & countryId, NodeStatuses & nodeS
 
 void Storage::SetCallbackForClickOnDownloadMap(TDownloadFn & downloadFn)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_downloadMapOnTheMap = downloadFn;
 }
 
 void Storage::DoClickOnDownloadMap(TCountryId const & countryId)
 {
-  ASSERT_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   if (m_downloadMapOnTheMap)
     m_downloadMapOnTheMap(countryId);


### PR DESCRIPTION
Основная идея: обнаружение ошибок связанных с многопоточностью на ранней стадии. Т.к. assert thread checker может добавляться в новые места в ядре без соответствующих изменений в коде платформы, то могут возникать "неопределенные" поведения в продакшане. Очень хотелось бы это влить до предстоящей регрессии, возможно найдутся еще места, где платформа обращается к ядру в неправильном потоке.