### PR TITLE
Performance and memory optimization for cross mwm routing.

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -390,7 +390,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   shared_ptr<VehicleModelInterface> vehicleModel =
       CarModelFactory(countryParentNameGetterFn).GetVehicleModelForCountry(country);
   IndexGraph graph(
-      GeometryLoader::CreateFromFile(mwmFile, vehicleModel),
+      make_shared<Geometry>(GeometryLoader::CreateFromFile(mwmFile, vehicleModel)),
       EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */));
 
   MwmValue mwmValue(LocalCountryFile(path, platform::CountryFile(country), 0 /* version */));

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -241,6 +241,7 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
 
   m_routingSession.Init(routingStatisticsFn, [this](m2::PointD const & pt)
   {
+    UNUSED_VALUE(this);
 #ifdef SHOW_ROUTE_DEBUG_MARKS
     if (m_bmManager == nullptr)
       return;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -60,8 +60,8 @@ namespace routing
 IndexGraph::IndexGraph(shared_ptr<Geometry> geometry, shared_ptr<EdgeEstimator> estimator)
   : m_geometry(geometry), m_estimator(move(estimator))
 {
-  ASSERT(m_geometry, ());
-  ASSERT(m_estimator, ());
+  CHECK(m_geometry, ());
+  CHECK(m_estimator, ());
 }
 
 void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -80,7 +80,11 @@ void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<Se
   }
 }
 
-void IndexGraph::Build(uint32_t numJoints) { m_jointIndex.Build(m_roadIndex, numJoints); }
+void IndexGraph::Build(uint32_t numJoints)
+{
+  m_jointIndex.Build(m_roadIndex, numJoints);
+  m_isBuilt = true;
+}
 
 void IndexGraph::Import(vector<Joint> const & joints)
 {

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -29,14 +29,14 @@ public:
   using Weight = RouteWeight;
 
   IndexGraph() = default;
-  explicit IndexGraph(unique_ptr<GeometryLoader> loader, shared_ptr<EdgeEstimator> estimator);
+  IndexGraph(shared_ptr<Geometry> geometry, shared_ptr<EdgeEstimator> estimator);
 
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
   void GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
 
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
 
-  Geometry & GetGeometry() { return m_geometry; }
+  Geometry & GetGeometry() { return *m_geometry; }
   bool IsRoad(uint32_t featureId) const { return m_roadIndex.IsRoad(featureId); }
   RoadJointIds const & GetRoad(uint32_t featureId) const { return m_roadIndex.GetRoad(featureId); }
 
@@ -65,8 +65,6 @@ public:
     m_roadIndex.PushFromSerializer(jointId, rp);
   }
 
-  bool IsBuilt() const { return m_isBuilt; }
-
   template <typename F>
   void ForEachRoad(F && f) const
   {
@@ -91,12 +89,11 @@ private:
     return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
   }
 
-  Geometry m_geometry;
+  shared_ptr<Geometry> m_geometry;
   shared_ptr<EdgeEstimator> m_estimator;
   RoadIndex m_roadIndex;
   JointIndex m_jointIndex;
   RestrictionVec m_restrictions;
   RoadAccess m_roadAccess;
-  bool m_isBuilt = false;
 };
 }  // namespace routing

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -65,6 +65,8 @@ public:
     m_roadIndex.PushFromSerializer(jointId, rp);
   }
 
+  bool IsBuilt() const { return m_isBuilt; }
+
   template <typename F>
   void ForEachRoad(F && f) const
   {
@@ -95,5 +97,6 @@ private:
   JointIndex m_jointIndex;
   RestrictionVec m_restrictions;
   RoadAccess m_roadAccess;
+  bool m_isBuilt = false;
 };
 }  // namespace routing

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -31,7 +31,7 @@ private:
   struct GeometryIndexGraph
   {
     shared_ptr<Geometry> m_geometry;
-    shared_ptr<IndexGraph> m_indexGraph;
+    unique_ptr<IndexGraph> m_indexGraph;
   };
 
   GeometryIndexGraph & CreateGeometry(NumMwmId numMwmId);
@@ -108,7 +108,7 @@ IndexGraphLoaderImpl::GeometryIndexGraph & IndexGraphLoaderImpl::CreateIndexGrap
   if (!handle.IsAlive())
     MYTHROW(RoutingException, ("Can't get mwm handle for", file));
 
-  graph.m_indexGraph = make_shared<IndexGraph>(graph.m_geometry, m_estimator);
+  graph.m_indexGraph = make_unique<IndexGraph>(graph.m_geometry, m_estimator);
   my::Timer timer;
   MwmValue const & mwmValue = *handle.GetValue<MwmValue>();
   DeserializeIndexGraph(mwmValue, m_vehicleType, *graph.m_indexGraph);

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -18,6 +18,7 @@ class IndexGraphLoader
 public:
   virtual ~IndexGraphLoader() = default;
 
+  virtual Geometry & GetGeometry(NumMwmId numMwmId) = 0;
   virtual IndexGraph & GetIndexGraph(NumMwmId mwmId) = 0;
   virtual void Clear() = 0;
 

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -297,9 +297,7 @@ namespace integration
     {
       return routerComponents.GetCountryInfoGetter().GetRegionCountryId(p);
     };
-    auto localFileChecker =
-        [&routerComponents](string const & /* countryFile */) -> bool
-    {
+    auto localFileChecker = [](string const & /* countryFile */) -> bool {
       // Always returns that the file is absent.
       return false;
     };

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -131,7 +131,7 @@ UNIT_TEST(EdgesTest)
                   RoadGeometry::Points({{3.0, -1.0}, {3.0, 0.0}, {3.0, 1.0}}));
 
   traffic::TrafficCache const trafficCache;
-  IndexGraph graph(move(loader), CreateEstimatorForCar(trafficCache));
+  IndexGraph graph(make_shared<Geometry>(move(loader)), CreateEstimatorForCar(trafficCache));
 
   vector<Joint> joints;
   joints.emplace_back(MakeJoint({{0, 1}, {3, 1}}));  // J0

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -2,6 +2,8 @@
 
 #include "testing/testing.hpp"
 
+#include "routing/geometry.hpp"
+
 #include "routing/base/routing_result.hpp"
 
 #include "routing_common/car_model.hpp"
@@ -311,7 +313,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoade
                                                     shared_ptr<EdgeEstimator> estimator,
                                                     vector<Joint> const & joints)
 {
-  auto graph = make_unique<IndexGraph>(move(geometryLoader), estimator);
+  auto graph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
@@ -323,7 +325,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
                                                     shared_ptr<EdgeEstimator> estimator,
                                                     vector<Joint> const & joints)
 {
-  auto graph = make_unique<IndexGraph>(move(geometryLoader), estimator);
+  auto graph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
@@ -336,7 +338,7 @@ unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geo
                                               vector<Joint> const & joints,
                                               transit::GraphData const & transitData)
 {
-  auto indexGraph = make_unique<IndexGraph>(move(geometryLoader), estimator);
+  auto indexGraph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
   indexGraph->Import(joints);
 
   auto transitGraph = make_unique<TransitGraph>(kTestNumMwmId, estimator);

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -88,6 +88,7 @@ public:
   // IndexGraphLoader overrides:
   ~TestIndexGraphLoader() override = default;
 
+  Geometry & GetGeometry(NumMwmId mwmId) override { return GetIndexGraph(mwmId).GetGeometry(); }
   IndexGraph & GetIndexGraph(NumMwmId mwmId) override;
   void Clear() override;
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -116,7 +116,7 @@ unique_ptr<TransitInfo> SingleVehicleWorldGraph::GetTransitInfo(Segment const &)
 
 RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
-  return m_loader->GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+  return m_loader->GetGeometry(mwmId).GetRoad(featureId);
 }
 
 void SingleVehicleWorldGraph::GetTwinsInner(Segment const & segment, bool isOutgoing,

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -181,7 +181,7 @@ void TransitWorldGraph::GetTwinsInner(Segment const & segment, bool isOutgoing,
 RoadGeometry const & TransitWorldGraph::GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
   CHECK(!TransitGraph::IsTransitFeature(featureId), ("GetRealRoadGeometry not designed for transit."));
-  return GetIndexGraph(mwmId).GetGeometry().GetRoad(featureId);
+  return m_indexLoader->GetGeometry(mwmId).GetRoad(featureId);
 }
 
 void TransitWorldGraph::AddRealEdges(Segment const & segment, bool isOutgoing,

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -17,9 +17,9 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
     // We need both enter to mwm and exit from mwm in LeapsOnly mode to reconstruct leap.
     // That's why we need to duplicate twin segment here and than remove duplicate
     // while processing leaps.
+    m2::PointD const & from = GetPoint(segment, isOutgoing /* front */);
     for (Segment const & twin : twins)
     {
-      m2::PointD const & from = GetPoint(segment, isOutgoing /* front */);
       m2::PointD const & to = GetPoint(twin, isOutgoing /* front */);
       // Weight is usually zero because twins correspond the same feature
       // in different mwms. But if we have mwms with different versions and a feature

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -63,7 +63,8 @@ TrackMatcher::TrackMatcher(storage::Storage const & storage, NumMwmId mwmId,
 
   MwmSet::MwmHandle const handle = m_index.GetMwmHandleByCountryFile(countryFile);
   m_graph = make_unique<IndexGraph>(
-      GeometryLoader::Create(m_index, handle, m_vehicleModel, false /* loadAltitudes */),
+      make_shared<Geometry>(
+          GeometryLoader::Create(m_index, handle, m_vehicleModel, false /* loadAltitudes */)),
       EdgeEstimator::Create(VehicleType::Car, *m_vehicleModel, nullptr /* trafficStash */));
 
   DeserializeIndexGraph(*handle.GetValue<MwmValue>(), VehicleType::Car, *m_graph);


### PR DESCRIPTION
При прокладке протяженных авто маршрутов происходит в 2 этапа:
 1. прокладка cross mwm -го маршрута (чтоб определить входы и выходы mwm через которые будет проходить маршрута);
 1. затем, прокладка маршрута внутри каждой из mwm.

Ранее на первом этапе мы строили IndexGraph для каждой mwm, к которой прикосались. Хотя этого не требовалось. Достаточно просто иметь информацию о геометрии фич в этих mwm.

Данный PR существенно оптимизирует первый этап прокладки маршрута в случае длинных авто маршрутов. Оптимизация достигается за счет того, что если требуется только геометрия mwm, не строится IndexGraph, Например, маршрут из Москвы в центр России памяти уходит в два с половиной - три раза меньше, а время на прокладки в треть быстрее.

Результаты измерений:
Авто маршрут: Москва (55.7395, 37.5869) - Точка севернее Красноярска (60.7781, 96.5419), 
Измерения проводились сериями по 3 попытки. Две серии на master. Две серии на данном PR. Карты всей России были загружены. Девайс на iPhone 7.
До оптимизации
674MB максимальный расход памяти
Route found, elapsed seconds: 31.2168
Route found, elapsed seconds: 32.9107
Route found, elapsed seconds: 33.6691

701MB максимальный расход памяти
Route found, elapsed seconds: 31.7622
Route found, elapsed seconds: 34.4661
Route found, elapsed seconds: 36.0487

Потребление памяти:
![image](https://user-images.githubusercontent.com/1768114/38931432-ced12e70-431b-11e8-9fd3-dae3216d11c8.png)

После оптимизации
220MB максимальный расход памяти
Route found, elapsed seconds: 23.9659
Route found, elapsed seconds: 23.3483
Route found, elapsed seconds: 22.0784

230MB максимальный расход памяти
Route found, elapsed seconds: 21.087
Route found, elapsed seconds: 23.4805
Route found, elapsed seconds: 23.2327

Потребление памяти:
![image](https://user-images.githubusercontent.com/1768114/38931448-da52c63c-431b-11e8-97d8-36c76781261b.png)

@tatiana-yan @mpimenov PTAL
