### PR TITLE
Fixed redundant notifications in BM

### DIFF
--- a/android/jni/com/mapswithme/maps/bookmarks/data/BookmarkManager.cpp
+++ b/android/jni/com/mapswithme/maps/bookmarks/data/BookmarkManager.cpp
@@ -532,4 +532,18 @@ Java_com_mapswithme_maps_bookmarks_data_BookmarkManager_nativeCancelRestoring(
 {
   frm()->GetBookmarkManager().CancelCloudRestoring();
 }
+
+JNIEXPORT void JNICALL
+Java_com_mapswithme_maps_bookmarks_data_BookmarkManager_nativeSetNotificationsEnabled(
+        JNIEnv * env, jobject thiz, jboolean enabled)
+{
+  frm()->GetBookmarkManager().SetNotificationsEnabled(static_cast<bool>(enabled));
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_mapswithme_maps_bookmarks_data_BookmarkManager_nativeAreNotificationsEnabled(
+        JNIEnv * env, jobject thiz)
+{
+  return static_cast<jboolean>(frm()->GetBookmarkManager().AreNotificationsEnabled());
+}
 }  // extern "C"

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesActivity.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesActivity.java
@@ -1,14 +1,38 @@
 package com.mapswithme.maps.bookmarks;
 
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.StyleRes;
 import android.support.v4.app.Fragment;
 
 import com.mapswithme.maps.base.BaseToolbarActivity;
+import com.mapswithme.maps.bookmarks.data.BookmarkManager;
 import com.mapswithme.util.ThemeUtils;
 
 public class BookmarkCategoriesActivity extends BaseToolbarActivity
 {
+  @CallSuper
+  @Override
+  public void onResume()
+  {
+    super.onResume();
+
+    // Disable all notifications in BM on appearance of this activity.
+    // It allows to significantly improve performance in case of bookmarks
+    // modification. All notifications will be sent on activity's disappearance.
+    BookmarkManager.INSTANCE.setNotificationsEnabled(false);
+  }
+
+  @CallSuper
+  @Override
+  public void onPause()
+  {
+    // Allow to send all notifications in BM.
+    BookmarkManager.INSTANCE.setNotificationsEnabled(true);
+
+    super.onPause();
+  }
+
   @Override
   @StyleRes
   public int getThemeResourceId(@NonNull String theme)

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkListActivity.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkListActivity.java
@@ -1,14 +1,38 @@
 package com.mapswithme.maps.bookmarks;
 
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.StyleRes;
 import android.support.v4.app.Fragment;
 
 import com.mapswithme.maps.base.BaseToolbarActivity;
+import com.mapswithme.maps.bookmarks.data.BookmarkManager;
 import com.mapswithme.util.ThemeUtils;
 
 public class BookmarkListActivity extends BaseToolbarActivity
 {
+  @CallSuper
+  @Override
+  public void onResume()
+  {
+    super.onResume();
+
+    // Disable all notifications in BM on appearance of this activity.
+    // It allows to significantly improve performance in case of bookmarks
+    // modification. All notifications will be sent on activity's disappearance.
+    BookmarkManager.INSTANCE.setNotificationsEnabled(false);
+  }
+
+  @CallSuper
+  @Override
+  public void onPause()
+  {
+    // Allow to send all notifications in BM.
+    BookmarkManager.INSTANCE.setNotificationsEnabled(true);
+
+    super.onPause();
+  }
+
   @Override
   @StyleRes
   public int getThemeResourceId(@NonNull String theme)

--- a/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
@@ -393,6 +393,16 @@ public enum BookmarkManager
     nativeCancelRestoring();
   }
 
+  public void setNotificationsEnabled(boolean enabled)
+  {
+    nativeSetNotificationsEnabled(enabled);
+  }
+
+  public boolean areNotificationsEnabled()
+  {
+    return nativeAreNotificationsEnabled();
+  }
+
   private native int nativeGetCategoriesCount();
 
   private native int nativeGetCategoryPositionById(long catId);
@@ -476,6 +486,10 @@ public enum BookmarkManager
   private static native void nativeApplyRestoring();
 
   private static native void nativeCancelRestoring();
+
+  private static native void nativeSetNotificationsEnabled(boolean enabled);
+
+  private static native boolean nativeAreNotificationsEnabled();
 
   public interface BookmarksLoadingListener
   {

--- a/iphone/Maps/Bookmarks/BookmarksVC.mm
+++ b/iphone/Maps/Bookmarks/BookmarksVC.mm
@@ -367,6 +367,24 @@
   [super viewWillDisappear:animated];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+  // Disable all notifications in BM on appearance of this view.
+  // It allows to significantly improve performance in case of bookmarks
+  // modification. All notifications will be sent on controller's disappearance.
+  [MWMBookmarksManager setNotificationsEnabled: NO];
+  
+  [super viewDidAppear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+  // Allow to send all notifications in BM.
+  [MWMBookmarksManager setNotificationsEnabled: YES];
+  
+  [super viewDidDisappear:animated];
+}
+
 - (void)sendBookmarksWithExtension:(NSString *)fileExtension andType:(NSString *)mimeType andFile:(NSString *)filePath andCategory:(NSString *)catName
 {
   MWMMailViewController * mailVC = [[MWMMailViewController alloc] init];

--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -42,7 +42,20 @@ final class BMCViewController: MWMViewController {
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
+    
+    // Disable all notifications in BM on appearance of this view.
+    // It allows to significantly improve performance in case of bookmarks
+    // modification. All notifications will be sent on controller's disappearance.
+    viewModel.setNotificationsEnabled(false)
+    
     viewModel.convertAllKMLIfNeeded()
+  }
+  
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    
+    // Allow to send all notifications in BM.
+    viewModel.setNotificationsEnabled(true)
   }
 
   private func updateCategoryName(category: BMCCategory?) {

--- a/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
@@ -207,6 +207,14 @@ extension BMCDefaultViewModel: BMCViewModel {
       }
     }
   }
+  
+  func setNotificationsEnabled(_ enabled: Bool) {
+    BM.setNotificationsEnabled(enabled)
+  }
+  
+  func areNotificationsEnabled() -> Bool {
+    return BM.areNotificationsEnabled()
+  }
 }
 
 extension BMCDefaultViewModel: MWMBookmarksObserver {

--- a/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCViewModel.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCViewModel.swift
@@ -42,4 +42,7 @@ protocol BMCViewModel: AnyObject {
   func grant(permission: BMCPermission?)
 
   func convertAllKMLIfNeeded();
+  
+  func setNotificationsEnabled(_ enabled: Bool)
+  func areNotificationsEnabled() -> Bool
 }

--- a/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.h
@@ -37,6 +37,9 @@
 
 + (BOOL)areAllCategoriesInvisible;
 
++ (void)setNotificationsEnabled:(BOOL)enabled;
++ (BOOL)areNotificationsEnabled;
+
 - (instancetype)init __attribute__((unavailable("call +manager instead")));
 - (instancetype)copy __attribute__((unavailable("call +manager instead")));
 - (instancetype)copyWithZone:(NSZone *)zone __attribute__((unavailable("call +manager instead")));

--- a/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.mm
@@ -359,4 +359,14 @@ NSString * const CloudErrorToString(Cloud::SynchronizationResult result)
   return GetFramework().GetBookmarkManager().AreAllCategoriesInvisible();
 }
 
++ (void)setNotificationsEnabled:(BOOL)enabled
+{
+  GetFramework().GetBookmarkManager().SetNotificationsEnabled(enabled);
+}
+
++ (BOOL)areNotificationsEnabled
+{
+  return GetFramework().GetBookmarkManager().AreNotificationsEnabled();
+}
+
 @end

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -586,6 +586,9 @@ void BookmarkManager::OnEditSessionClosed()
 void BookmarkManager::NotifyChanges()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
+  if (!m_notificationsEnabled)
+    return;
+
   if (!m_changesTracker.CheckChanges() && !m_firstDrapeNotification)
     return;
 
@@ -1770,6 +1773,23 @@ void BookmarkManager::ApplyCloudRestoring()
 void BookmarkManager::CancelCloudRestoring()
 {
   m_bookmarkCloud.CancelRestoring();
+}
+
+void BookmarkManager::SetNotificationsEnabled(bool enabled)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  if (m_notificationsEnabled == enabled)
+    return;
+
+  m_notificationsEnabled = enabled;
+  if (m_openedEditSessionsCount == 0)
+    NotifyChanges();
+}
+
+bool BookmarkManager::AreNotificationsEnabled() const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  return m_notificationsEnabled;
 }
 
 void BookmarkManager::EnableTestMode(bool enable)

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -265,6 +265,9 @@ public:
   void ApplyCloudRestoring();
   void CancelCloudRestoring();
 
+  void SetNotificationsEnabled(bool enabled);
+  bool AreNotificationsEnabled() const;
+
   /// These functions are public for unit tests only. You shouldn't call them from client code.
   void EnableTestMode(bool enable);
   bool SaveBookmarkCategory(kml::MarkGroupId groupId);
@@ -452,6 +455,7 @@ private:
   bool m_firstDrapeNotification = false;
   bool m_restoreApplying = false;
   bool m_conversionInProgress = false;
+  bool m_notificationsEnabled = true;
 
   ScreenBase m_viewport;
 


### PR DESCRIPTION
Когда мы редактируем категории букмарок или сами букмарки в окнах категорий и списков (не на карте) возникает накапливание изменений для отправки в поиск, графический движок и для сохранения на диск. Если файл с букмарками большой или таких файлов много, изменения могут занимать значительный объем в оперативной памяти, что рано или поздно приведет к завершению свободного места и крэшу, так как изменения будут обработаны только при выходе на карту (для графического движка в случае Android), или память закончится при интенсивной работе с категориями (show/hide all на Android/iOS).
Для того, чтобы избежать этого, были добавлены функции, которые позволяют разрешить/запретить нотифицирование графического движка, поиска и прочих систем. При входе в вышеобозначенные окна мы запрещаем нотифицирование (карта все равно не видна), а при выходе из окон - разрешаем и нотифицируем. Таким образом, мы можем избежать излишнего потребления памяти и повысить производительность интерфейса, так как работа с UI-контролами теперь не сопряжена с оповещением каких-либо систем.