### PR TITLE
Fixed search mark appearance on Android

### DIFF
--- a/drape/overlay_tree.cpp
+++ b/drape/overlay_tree.cpp
@@ -378,6 +378,7 @@ bool OverlayTree::GetSelectedFeatureRect(ScreenBase const & screen, m2::RectD & 
   featureRect.MakeEmpty();
   for (auto const & handle : m_handlesCache)
   {
+    CHECK(handle != nullptr, ());
     if (handle->IsVisible() && handle->GetOverlayID().m_featureId == m_selectedFeatureID)
     {
       m2::RectD rect = handle->GetPixelRect(screen, screen.isPerspective());

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1700,7 +1700,9 @@ bool FrontendRenderer::OnNewVisibleViewport(m2::RectD const & oldViewport,
   gOffset = m2::PointD(0, 0);
   if (m_myPositionController->IsModeChangeViewport() || m_selectionShape == nullptr ||
       oldViewport == newViewport)
+  {
     return false;
+  }
 
   ScreenBase const & screen = m_userEventStream.GetCurrentScreen();
 

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -511,7 +511,8 @@ public:
     , m_isDismiss(true)
   {}
 
-  SelectObjectMessage(SelectionShape::ESelectedObject selectedObject, m2::PointD const & glbPoint, FeatureID const & featureID,  bool isAnim)
+  SelectObjectMessage(SelectionShape::ESelectedObject selectedObject,
+                      m2::PointD const & glbPoint, FeatureID const & featureID, bool isAnim)
     : m_selected(selectedObject)
     , m_glbPoint(glbPoint)
     , m_featureID(featureID)
@@ -520,7 +521,7 @@ public:
   {}
 
   Type GetType() const override { return SelectObject; }
-  bool IsGLContextDependent() const override { return true; }
+  bool IsGLContextDependent() const override { return false; }
 
   m2::PointD const & GetPosition() const { return m_glbPoint; }
   SelectionShape::ESelectedObject GetSelectedObject() const { return m_selected; }


### PR DESCRIPTION
Когда-то в январе 2017-го мы лечили крэш https://github.com/mapsme/omim/pull/5310. На ряду с прочим, мы сделали сообщение SelectObjectMessage контекстозависимым. Это создало гонку в Android при возвращении из разных окон на карту. Из-за этого иногда голубой маркер не показывается, потому как сообщение удаляется из очереди до восстановления GL-контекста.

Крэш, который был исправлен, возникал внутри функции GetSelectedFeatureRect на строке
**if (handle->IsVisible() && handle->GetOverlayID().m_featureId == m_selectedFeatureID)**

Крэш, похоже, был из-за того, что мы получали OnNewVisibleViewport при невалидном дереве оверлеев. Это возможно, так как OnNewVisibleViewport вызывается из ProcessEvents, которые обрабатываются в начале кадра до перестроения дерева оверлеев. Это частично решают строки
**if (m_overlayTree->IsNeedUpdate())
  BuildOverlayTree(screen);**

Кроме того, при удалении GL-контекста мы дополнительно сбрасываем selected feature id и сообщение SelectObjectMessage, если оно было закэшировано.
**m_selectObjectMessage.reset();
m_overlayTree->SetSelectedFeature(FeatureID());**
Я подозреваю, что сбросом selected feature id мы тогда решили проблему захода в функцию GetSelectedFeatureRect, когда получали вызов функции GetSelectedFeatureRect на восстановлении GL-контекста.

Однако, чуть позже, в мае 2017 https://github.com/mapsme/omim/pull/6146, мы добавили еще очистку дерева целиком, а не только selected feature id, так как случаи крэшей остались.

Так как сейчас дерево оверлеев очищается целиком при уничтожении GL-контекста, то если даже мы положим не-контекстозависимое сообщение SelectObjectMessage в очередь, а потом обработаем его при восстановлении контекста, все пройдет корректно. Массив m_handlesCache будет пустым и крэша не будет.

Поэтому, я предлагаю сделать сообщение SelectObjectMessage не-контекстозависимым, это не должно вернуть прошлогодний крэш. Проверил на обеих платформах - все ок, однако, из-за маловероятной природы крэша реальную картину мы увидем только при тестировании на большом кол-ве людей.