### PR TITLE
[geocoder] Do not catch Reader::Exception in Borders::Deserialize

### DIFF
--- a/indexer/borders.cpp
+++ b/indexer/borders.cpp
@@ -91,19 +91,10 @@ bool Borders::Border::IsPointInside(m2::PointD const & point) const
   return true;
 }
 
-bool Borders::Deserialize(string const & filename)
+void Borders::Deserialize(string const & filename)
 {
-  try
-  {
-    BordersVectorReader reader(filename);
-    auto const & records = reader.GetVector();
-    DeserializeFromVec(records);
-  }
-  catch (Reader::Exception const & e)
-  {
-    LOG(LERROR, ("Error while reading file:", e.Msg()));
-    return false;
-  }
-  return true;
+  BordersVectorReader reader(filename);
+  auto const & records = reader.GetVector();
+  DeserializeFromVec(records);
 }
 }  // namespace indexer

--- a/indexer/borders.hpp
+++ b/indexer/borders.hpp
@@ -32,7 +32,8 @@ public:
     return false;
   }
 
-  bool Deserialize(std::string const & filename);
+  // Throws Reader::Exception in case of data reading errors.
+  void Deserialize(std::string const & filename);
 
   template <typename BordersVec>
   void DeserializeFromVec(BordersVec const & vec)


### PR DESCRIPTION
Чтобы правильно писать логи в клиентском коде геокодера, исключения будут перехватываться там.