### PR TITLE
Added full support of serverId in KML library

### DIFF
--- a/kml/kml_tests/serdes_tests.cpp
+++ b/kml/kml_tests/serdes_tests.cpp
@@ -183,6 +183,7 @@ kml::FileData GenerateKmlFileData()
 {
   kml::FileData result;
   result.m_deviceId = "AAAA";
+  result.m_serverId = "AAAA-BBBB-CCCC-DDDD";
 
   result.m_categoryData.m_name[kDefaultLang] = "Test category";
   result.m_categoryData.m_name[kRuLang] = "Тестовая категория";
@@ -299,6 +300,7 @@ char const * kGeneratedKml =
   "  <description>Test description</description>\n"
   "  <visibility>1</visibility>\n"
   "  <ExtendedData xmlns:mwm=\"https://maps.me\">\n"
+  "    <mwm:serverId>AAAA-BBBB-CCCC-DDDD</mwm:serverId>\n"
   "    <mwm:name>\n"
   "      <mwm:lang code=\"ru\">Тестовая категория</mwm:lang>\n"
   "    </mwm:name>\n"

--- a/kml/pykmlib/bindings.cpp
+++ b/kml/pykmlib/bindings.cpp
@@ -422,13 +422,14 @@ std::string CategoryDataToString(CategoryData const & c)
   return out.str();
 }
 
-std::string FileDataToString(FileData const & c)
+std::string FileDataToString(FileData const & fd)
 {
   std::ostringstream out;
   out << "["
-      << "category:" << CategoryDataToString(c.m_categoryData) << ", "
-      << "bookmarks:" << VectorAdapter<BookmarkData>::ToString(c.m_bookmarksData) << ", "
-      << "tracks:" << VectorAdapter<TrackData>::ToString(c.m_tracksData)
+      << "server_id:" << fd.m_serverId << ", "
+      << "category:" << CategoryDataToString(fd.m_categoryData) << ", "
+      << "bookmarks:" << VectorAdapter<BookmarkData>::ToString(fd.m_bookmarksData) << ", "
+      << "tracks:" << VectorAdapter<TrackData>::ToString(fd.m_tracksData)
       << "]";
   return out.str();
 }
@@ -739,6 +740,7 @@ BOOST_PYTHON_MODULE(pykmlib)
     .def("__str__", &VectorAdapter<TrackData>::ToString);
 
   class_<FileData>("FileData")
+    .def_readwrite("server_id", &FileData::m_serverId)
     .def_readwrite("category", &FileData::m_categoryData)
     .def_readwrite("bookmarks", &FileData::m_bookmarksData)
     .def_readwrite("tracks", &FileData::m_tracksData)

--- a/kml/pykmlib/bindings_test.py
+++ b/kml/pykmlib/bindings_test.py
@@ -62,6 +62,7 @@ class PyKmlibAdsTest(unittest.TestCase):
         	pykmlib.LatLon(45.1964, 56.9832)])
 
         file_data = pykmlib.FileData()
+        file_data.server_id = 'AAAA-BBBB-CCCC-DDDD'
         file_data.category = category
         file_data.bookmarks.append(bookmark)
         file_data.tracks.append(track)

--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -242,9 +242,13 @@ void SaveStringsMap(KmlWriter::WriterWrapper & writer,
   writer << offsetStr << "</mwm:" << tagName << ">\n";
 }
 
-void SaveCategoryExtendedData(KmlWriter::WriterWrapper & writer, CategoryData const & categoryData)
+void SaveCategoryExtendedData(KmlWriter::WriterWrapper & writer, CategoryData const & categoryData,
+                              std::string const & extendedServerId)
 {
   writer << kIndent2 << kExtendedDataHeader;
+
+  if (!extendedServerId.empty())
+    writer << kIndent4 << "<mwm:serverId>" << extendedServerId << "</mwm:serverId>\n";
 
   SaveLocalizableString(writer, categoryData.m_name, "name", kIndent4);
   SaveLocalizableString(writer, categoryData.m_annotation, "annotation", kIndent4);
@@ -301,7 +305,8 @@ void SaveCategoryExtendedData(KmlWriter::WriterWrapper & writer, CategoryData co
   writer << kIndent2 << kExtendedDataFooter;
 }
 
-void SaveCategoryData(KmlWriter::WriterWrapper & writer, CategoryData const & categoryData)
+void SaveCategoryData(KmlWriter::WriterWrapper & writer, CategoryData const & categoryData,
+                      std::string const & extendedServerId)
 {
   for (uint8_t i = 0; i < my::Key(PredefinedColor::Count); ++i)
     SaveStyle(writer, GetStyleForPredefinedColor(static_cast<PredefinedColor>(i)));
@@ -319,7 +324,7 @@ void SaveCategoryData(KmlWriter::WriterWrapper & writer, CategoryData const & ca
 
   writer << kIndent2 << "<visibility>" << (categoryData.m_visible ? "1" : "0") <<"</visibility>\n";
 
-  SaveCategoryExtendedData(writer, categoryData);
+  SaveCategoryExtendedData(writer, categoryData, extendedServerId);
 }
 
 void SaveBookmarkExtendedData(KmlWriter::WriterWrapper & writer, BookmarkData const & bookmarkData)
@@ -476,7 +481,7 @@ void KmlWriter::Write(FileData const & fileData)
   m_writer << kKmlHeader;
 
   // Save category.
-  SaveCategoryData(m_writer, fileData.m_categoryData);
+  SaveCategoryData(m_writer, fileData.m_categoryData, fileData.m_serverId);
 
   // Save bookmarks.
   for (auto const & bookmarkData : fileData.m_bookmarksData)
@@ -792,6 +797,10 @@ void KmlParser::CharData(std::string value)
       {
         if (!strings::to_uint(value, m_data.m_categoryData.m_reviewsNumber))
           m_data.m_categoryData.m_reviewsNumber = 0;
+      }
+      else if (currTag == "mwm:serverId")
+      {
+        m_data.m_serverId = value;
       }
     }
     else if (pppTag == kDocument && ppTag == kExtendedData && currTag == "mwm:lang")

--- a/kml/types.hpp
+++ b/kml/types.hpp
@@ -285,7 +285,8 @@ struct CategoryData
 
 struct FileData
 {
-  DECLARE_VISITOR_AND_DEBUG_PRINT(FileData, visitor(m_categoryData, "category"),
+  DECLARE_VISITOR_AND_DEBUG_PRINT(FileData, visitor(m_serverId, "serverId"),
+                                  visitor(m_categoryData, "category"),
                                   visitor(m_bookmarksData, "bookmarks"),
                                   visitor(m_tracksData, "tracks"))
 


### PR DESCRIPTION
Добавлена поддержка serverId, который нужен для формирования диплинок