### PR TITLE
[geometry] Made the constructor of Point<T> from Point<U> explicit.

### DIFF
--- a/coding/geometry_coding.cpp
+++ b/coding/geometry_coding.cpp
@@ -109,7 +109,7 @@ m2::PointU PredictPointInTriangle(m2::PointU const & maxPoint, m2::PointU const 
                                   m2::PointU const & p2, m2::PointU const & p3)
 {
   // parallelogram prediction
-  return ClampPoint(maxPoint, p1 + p2 - p3);
+  return ClampPoint(maxPoint, m2::PointD(p1 + p2 - p3));
 }
 
 void EncodePolylinePrev1(InPointsT const & points, m2::PointU const & basePoint,

--- a/drape/overlay_tree.cpp
+++ b/drape/overlay_tree.cpp
@@ -460,8 +460,8 @@ void OverlayTree::StoreDisplacementInfo(int caseIndex, ref_ptr<OverlayHandle> di
 
   if (!dp::DebugRectRenderer::Instance().IsEnabled())
     return;
-  m_displacementInfo.emplace_back(displacerHandle->GetExtendedPixelRect(modelView).Center(),
-                                  displacedHandle->GetExtendedPixelRect(modelView).Center(),
+  m_displacementInfo.emplace_back(m2::PointF(displacerHandle->GetExtendedPixelRect(modelView).Center()),
+                                  m2::PointF(displacedHandle->GetExtendedPixelRect(modelView).Center()),
                                   dp::Color(0, 0, 255, 255));
 }
 

--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -590,7 +590,7 @@ void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
                                                            : SpecialDisplacement::None;
     params.m_specialPriority = specialModePriority;
 
-    m_insertShape(make_unique_dp<PoiSymbolShape>(m_centerPoint, params, m_tileKey, 0 /* text index */));
+    m_insertShape(make_unique_dp<PoiSymbolShape>(m2::PointD(m_centerPoint), params, m_tileKey, 0 /* text index */));
 
     dp::TextureManager::SymbolRegion region;
     texMng->GetSymbolRegion(params.m_symbolName, region);
@@ -610,7 +610,7 @@ void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
     }
     textParams.m_specialPriority = specialModePriority;
     textParams.m_startOverlayRank = hasPOI ? dp::OverlayRank1 : dp::OverlayRank0;
-    m_insertShape(make_unique_dp<TextShape>(m_centerPoint, textParams, m_tileKey, symbolSize,
+    m_insertShape(make_unique_dp<TextShape>(m2::PointD(m_centerPoint), textParams, m_tileKey, symbolSize,
                                             m2::PointF(0.0f, 0.0f) /* symbolOffset */,
                                             dp::Center /* symbolAnchor */, 0 /* textIndex */));
   }

--- a/drape_frontend/area_shape.cpp
+++ b/drape_frontend/area_shape.cpp
@@ -27,7 +27,7 @@ void AreaShape::Draw(ref_ptr<dp::Batcher> batcher, ref_ptr<dp::TextureManager> t
 {
   dp::TextureManager::ColorRegion region;
   textures->GetColorRegion(m_params.m_color, region);
-  m2::PointD const colorUv = region.GetTexRect().Center();
+  m2::PointD const colorUv(region.GetTexRect().Center());
   m2::PointD outlineUv(0.0, 0.0);
   if (m_buildingOutline.m_generateOutline)
   {
@@ -52,9 +52,9 @@ void AreaShape::DrawArea(ref_ptr<dp::Batcher> batcher, m2::PointD const & colorU
 
   buffer_vector<gpu::AreaVertex, 128> vertexes;
   vertexes.resize(m_vertexes.size());
-  transform(m_vertexes.begin(), m_vertexes.end(), vertexes.begin(), [&uv, this](m2::PointF const & vertex)
+  transform(m_vertexes.begin(), m_vertexes.end(), vertexes.begin(), [&uv, this](m2::PointD const & vertex)
   {
-    return gpu::AreaVertex(glsl::vec3(glsl::ToVec2(ConvertToLocal(vertex, m_params.m_tileCenter, kShapeCoordScalar)),
+    return gpu::AreaVertex(glsl::vec3(glsl::ToVec2(ConvertToLocal(m2::PointD(vertex), m_params.m_tileCenter, kShapeCoordScalar)),
                                       m_params.m_depth), uv);
   });
 

--- a/drape_frontend/colored_symbol_shape.cpp
+++ b/drape_frontend/colored_symbol_shape.cpp
@@ -279,13 +279,13 @@ void ColoredSymbolShape::Draw(ref_ptr<dp::Batcher> batcher,
     if (!m_overlaySizes.empty())
     {
       handle = make_unique_dp<DynamicSquareHandle>(overlayId, m_params.m_anchor, m_point, m_overlaySizes,
-                                                   m_params.m_offset, GetOverlayPriority(), true /* isBound */,
+                                                   m2::PointD(m_params.m_offset), GetOverlayPriority(), true /* isBound */,
                                                    debugName, true /* isBillboard */);
     }
     else
     {
-      handle = make_unique_dp<dp::SquareHandle>(overlayId, m_params.m_anchor, m_point, pixelSize,
-                                                m_params.m_offset, GetOverlayPriority(), true /* isBound */,
+      handle = make_unique_dp<dp::SquareHandle>(overlayId, m_params.m_anchor, m_point, m2::PointD(pixelSize),
+                                                m2::PointD(m_params.m_offset), GetOverlayPriority(), true /* isBound */,
                                                 debugName, true /* isBillboard */);
     }
 

--- a/drape_frontend/drape_api_builder.cpp
+++ b/drape_frontend/drape_api_builder.cpp
@@ -83,7 +83,7 @@ void DrapeApiBuilder::BuildLines(DrapeApi::TLines const & lines, ref_ptr<dp::Tex
         cvp.m_radiusInPixels = data.m_width * 2.0f;
         for (m2::PointD const & pt : data.m_points)
         {
-          ColoredSymbolShape(m2::PointF(pt), cvp, TileKey(), 0 /* textIndex */,
+          ColoredSymbolShape(m2::PointD(pt), cvp, TileKey(), 0 /* textIndex */,
                              false /* need overlay */).Draw(make_ref(&batcher), textures);
         }
       }

--- a/drape_frontend/gui/gui_text.cpp
+++ b/drape_frontend/gui/gui_text.cpp
@@ -361,7 +361,7 @@ void MutableLabel::Precache(PrecacheParams const & params, PrecacheResult & resu
   for (auto node : m_alphabet)
   {
     dp::TextureManager::GlyphRegion const & reg = node.second;
-    m2::PointU pixelSize = reg.GetPixelSize();
+    m2::PointU pixelSize(reg.GetPixelSize());
     maxGlyphWidth = max(maxGlyphWidth, pixelSize.x);
     maxGlyphHeight = max(maxGlyphHeight, pixelSize.y);
   }
@@ -421,7 +421,7 @@ void MutableLabel::SetText(LabelResult & result, string text) const
   for (DynamicVertex & v : result.m_buffer)
   {
     v.m_normal += anchorModifyer;
-    result.m_boundRect.Add(glsl::ToPoint(v.m_normal));
+    result.m_boundRect.Add(m2::PointD(glsl::ToPoint(v.m_normal)));
   }
 
   for (size_t i = result.m_buffer.size(); i < 4 * m_maxLength; ++i)

--- a/drape_frontend/gui/layer_render.cpp
+++ b/drape_frontend/gui/layer_render.cpp
@@ -14,6 +14,7 @@
 #include "drape/render_bucket.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
 
 #include "base/stl_add.hpp"
 
@@ -85,7 +86,7 @@ void LayerRenderer::SetLayout(TWidgetsLayoutInfo const & info)
   {
     auto renderer = m_renderers.find(node.first);
     if (renderer != m_renderers.end())
-      renderer->second->SetPivot(node.second);
+      renderer->second->SetPivot(m2::PointF(node.second));
   }
 }
 

--- a/drape_frontend/my_position.cpp
+++ b/drape_frontend/my_position.cpp
@@ -103,13 +103,13 @@ void MyPosition::RenderAccuracy(ScreenBase const & screen, int zoomLevel,
 {
   dp::UniformValuesStorage uniforms = commonUniforms;
   m2::PointD accuracyPoint(m_position.x + m_accuracy, m_position.y);
-  float pixelAccuracy = (screen.GtoP(accuracyPoint) - screen.GtoP(m_position)).Length();
+  float pixelAccuracy = (screen.GtoP(accuracyPoint) - screen.GtoP(m2::PointD(m_position))).Length();
 
-  TileKey const key = GetTileKeyByPoint(m_position, ClipTileZoomByMaxDataZoom(zoomLevel));
+  TileKey const key = GetTileKeyByPoint(m2::PointD(m_position), ClipTileZoomByMaxDataZoom(zoomLevel));
   math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
   uniforms.SetMatrix4x4Value("modelView", mv.m_data);
 
-  m2::PointD const pos = MapShape::ConvertToLocal(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+  m2::PointD const pos = MapShape::ConvertToLocal(m2::PointD(m_position), key.GetGlobalRect().Center(), kShapeCoordScalar);
   uniforms.SetFloatValue("u_position", pos.x, pos.y, 0.0f);
   uniforms.SetFloatValue("u_accuracy", pixelAccuracy);
   uniforms.SetFloatValue("u_opacity", 1.0f);
@@ -122,18 +122,18 @@ void MyPosition::RenderMyPosition(ScreenBase const & screen, int zoomLevel,
 {
   if (m_showAzimuth)
   {
-    m_arrow3d.SetPosition(m_position);
+    m_arrow3d.SetPosition(m2::PointD(m_position));
     m_arrow3d.SetAzimuth(m_azimuth);
     m_arrow3d.Render(screen, mng, m_isRoutingMode);
   }
   else
   {
     dp::UniformValuesStorage uniforms = commonUniforms;
-    TileKey const key = GetTileKeyByPoint(m_position, ClipTileZoomByMaxDataZoom(zoomLevel));
+    TileKey const key = GetTileKeyByPoint(m2::PointD(m_position), ClipTileZoomByMaxDataZoom(zoomLevel));
     math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
     uniforms.SetMatrix4x4Value("modelView", mv.m_data);
 
-    m2::PointD const pos = MapShape::ConvertToLocal(m_position, key.GetGlobalRect().Center(), kShapeCoordScalar);
+    m2::PointD const pos = MapShape::ConvertToLocal(m2::PointD(m_position), key.GetGlobalRect().Center(), kShapeCoordScalar);
     uniforms.SetFloatValue("u_position", pos.x, pos.y, dp::depth::kMyPositionMarkDepth);
     uniforms.SetFloatValue("u_azimut", -(m_azimuth + screen.GetAngle()));
     uniforms.SetFloatValue("u_opacity", 1.0);

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -566,7 +566,7 @@ void MyPositionController::Render(ScreenBase const & screen, int zoomLevel,
       m_isPendingAnimation = false;
 
     m_shape->SetPositionObsolete(m_positionIsObsolete);
-    m_shape->SetPosition(GetDrawablePosition());
+    m_shape->SetPosition(m2::PointF(GetDrawablePosition()));
     m_shape->SetAzimuth(static_cast<float>(GetDrawableAzimut()));
     m_shape->SetIsValidAzimuth(IsRotationAvailable());
     m_shape->SetAccuracy(static_cast<float>(m_errorRadius));

--- a/drape_frontend/path_text_handle.cpp
+++ b/drape_frontend/path_text_handle.cpp
@@ -301,7 +301,7 @@ m2::RectD PathTextHandle::GetPixelRect(ScreenBase const & screen, bool perspecti
 
   m2::RectD result;
   for (gpu::TextDynamicVertex const & v : m_buffer)
-    result.Add(pixelPivot + glsl::ToPoint(v.m_normal));
+    result.Add(pixelPivot + m2::PointD(glsl::ToPoint(v.m_normal)));
 
   return result;
 }
@@ -312,10 +312,10 @@ void PathTextHandle::GetPixelShape(ScreenBase const & screen, bool perspective, 
   for (size_t quadIndex = 0; quadIndex < m_buffer.size(); quadIndex += 4)
   {
     m2::RectF r;
-    r.Add(pixelPivot + glsl::ToPoint(m_buffer[quadIndex].m_normal));
-    r.Add(pixelPivot + glsl::ToPoint(m_buffer[quadIndex + 1].m_normal));
-    r.Add(pixelPivot + glsl::ToPoint(m_buffer[quadIndex + 2].m_normal));
-    r.Add(pixelPivot + glsl::ToPoint(m_buffer[quadIndex + 3].m_normal));
+    r.Add(m2::PointF(pixelPivot) + glsl::ToPoint(m_buffer[quadIndex].m_normal));
+    r.Add(m2::PointF(pixelPivot) + glsl::ToPoint(m_buffer[quadIndex + 1].m_normal));
+    r.Add(m2::PointF(pixelPivot) + glsl::ToPoint(m_buffer[quadIndex + 2].m_normal));
+    r.Add(m2::PointF(pixelPivot) + glsl::ToPoint(m_buffer[quadIndex + 3].m_normal));
 
     if (perspective)
     {
@@ -323,8 +323,8 @@ void PathTextHandle::GetPixelShape(ScreenBase const & screen, bool perspective, 
       {
         m2::PointD const pxPivotPerspective = screen.PtoP3d(pixelPivot);
 
-        r.Offset(-pixelPivot);
-        r.Offset(pxPivotPerspective);
+        r.Offset(m2::PointF(-pixelPivot));
+        r.Offset(m2::PointF(pxPivotPerspective));
       }
       else
       {
@@ -332,7 +332,7 @@ void PathTextHandle::GetPixelShape(ScreenBase const & screen, bool perspective, 
       }
     }
 
-    bool const needAddRect = perspective ? !screen.IsReverseProjection3d(r.Center()) : true;
+    bool const needAddRect = perspective ? !screen.IsReverseProjection3d(m2::PointD(r.Center())) : true;
     if (needAddRect)
       rects.emplace_back(move(r));
   }

--- a/drape_frontend/poi_symbol_shape.cpp
+++ b/drape_frontend/poi_symbol_shape.cpp
@@ -148,7 +148,7 @@ drape_ptr<dp::OverlayHandle> PoiSymbolShape::CreateOverlayHandle(m2::PointF cons
 {
   dp::OverlayID overlayId = dp::OverlayID(m_params.m_id, m_tileCoords, m_textIndex);
   drape_ptr<dp::OverlayHandle> handle = make_unique_dp<dp::SquareHandle>(overlayId, m_params.m_anchor,
-                                                                         m_pt, pixelSize, m_params.m_offset,
+                                                                         m_pt, m2::PointD(pixelSize), m2::PointD(m_params.m_offset),
                                                                          GetOverlayPriority(),
                                                                          true /* isBound */,
                                                                          m_params.m_symbolName,

--- a/drape_frontend/text_shape.cpp
+++ b/drape_frontend/text_shape.cpp
@@ -77,7 +77,7 @@ public:
   {
     m2::PointD pivot = TBase::GetPivot(screen, false);
     if (perspective)
-      pivot = screen.PtoP3d(pivot - m_offset, -m_pivotZ) + m_offset;
+      pivot = screen.PtoP3d(pivot - m2::PointD(m_offset), -m_pivotZ) + m2::PointD(m_offset);
     return pivot;
   }
 
@@ -87,8 +87,8 @@ public:
     {
       if (IsBillboard())
       {
-        m2::PointD const pxPivot = screen.GtoP(m_pivot);
-        m2::PointD const pxPivotPerspective = screen.PtoP3d(pxPivot, -m_pivotZ);
+        m2::PointD const pxPivot(screen.GtoP(m2::PointD(m_pivot)));
+        m2::PointD const pxPivotPerspective(screen.PtoP3d(pxPivot, -m_pivotZ));
 
         m2::RectD pxRectPerspective = GetPixelRect(screen, false);
         pxRectPerspective.Offset(-pxPivot);
@@ -99,7 +99,7 @@ public:
       return GetPixelRectPerspective(screen);
     }
 
-    m2::PointD pivot = screen.GtoP(m_pivot) + m_offset;
+    m2::PointD pivot(screen.GtoP(m2::PointD(m_pivot)) + m2::PointD(m_offset));
     double x = pivot.x;
     double y = pivot.y;
     if (m_anchor & dp::Left)

--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -764,7 +764,7 @@ bool UserEventStream::TouchDown(array<Touch, 2> const & touches)
 
 bool UserEventStream::CheckDrag(array<Touch, 2> const & touches, double threshold) const
 {
-  return m_startDragOrg.SquareLength(touches[0].m_location) > threshold;
+  return m_startDragOrg.SquareLength(m2::PointD(touches[0].m_location)) > threshold;
 }
 
 bool UserEventStream::TouchMove(array<Touch, 2> const & touches)
@@ -986,7 +986,7 @@ void UserEventStream::BeginDrag(Touch const & t)
   m_startDragOrg = m_navigator.Screen().GetOrg();
   if (m_listener)
     m_listener->OnDragStarted();
-  m_navigator.StartDrag(t.m_location);
+  m_navigator.StartDrag(m2::PointD(t.m_location));
 
   if (m_kineticScrollEnabled && !m_scroller.IsActive())
   {
@@ -999,7 +999,7 @@ void UserEventStream::Drag(Touch const & t)
 {
   TEST_CALL(DRAG);
   ASSERT_EQUAL(m_state, STATE_DRAG, ());
-  m_navigator.DoDrag(t.m_location);
+  m_navigator.DoDrag(m2::PointD(t.m_location));
 
   if (m_kineticScrollEnabled && m_scroller.IsActive())
     m_scroller.Update(m_navigator.Screen());
@@ -1014,7 +1014,7 @@ bool UserEventStream::EndDrag(Touch const & t, bool cancelled)
     m_listener->OnDragEnded(m_navigator.GtoP(m_navigator.Screen().GetOrg()) - m_navigator.GtoP(m_startDragOrg));
 
   m_startDragOrg = m2::PointD::Zero();
-  m_navigator.StopDrag(t.m_location);
+  m_navigator.StopDrag(m2::PointD(t.m_location));
 
   CheckAutoRotate();
 
@@ -1043,8 +1043,8 @@ void UserEventStream::BeginScale(Touch const & t1, Touch const & t2)
 
   ASSERT(m_state == STATE_EMPTY || m_state == STATE_TAP_TWO_FINGERS, ());
   m_state = STATE_SCALE;
-  m2::PointD touch1 = t1.m_location;
-  m2::PointD touch2 = t2.m_location;
+  m2::PointD touch1(t1.m_location);
+  m2::PointD touch2(t2.m_location);
 
   if (m_listener)
   {
@@ -1060,8 +1060,8 @@ void UserEventStream::Scale(Touch const & t1, Touch const & t2)
   TEST_CALL(SCALE);
   ASSERT_EQUAL(m_state, STATE_SCALE, ());
 
-  m2::PointD touch1 = t1.m_location;
-  m2::PointD touch2 = t2.m_location;
+  m2::PointD touch1(t1.m_location);
+  m2::PointD touch2(t2.m_location);
 
   if (m_listener)
   {
@@ -1080,8 +1080,8 @@ void UserEventStream::EndScale(const Touch & t1, const Touch & t2)
   ASSERT_EQUAL(m_state, STATE_SCALE, ());
   m_state = STATE_EMPTY;
 
-  m2::PointD touch1 = t1.m_location;
-  m2::PointD touch2 = t2.m_location;
+  m2::PointD touch1(t1.m_location);
+  m2::PointD touch2(t2.m_location);
 
   if (m_listener)
   {
@@ -1113,7 +1113,7 @@ void UserEventStream::DetectShortTap(Touch const & touch)
   {
     m_state = STATE_EMPTY;
     if (m_listener)
-      m_listener->OnTap(touch.m_location, false /* isLongTap */);
+      m_listener->OnTap(m2::PointD(touch.m_location), false /* isLongTap */);
   }
 }
 
@@ -1130,7 +1130,7 @@ void UserEventStream::DetectLongTap(Touch const & touch)
     TEST_CALL(LONG_TAP_DETECTED);
     m_state = STATE_EMPTY;
     if (m_listener)
-      m_listener->OnTap(touch.m_location, true /* isLongTap */);
+      m_listener->OnTap(m2::PointD(touch.m_location), true /* isLongTap */);
   }
 }
 
@@ -1150,7 +1150,7 @@ void UserEventStream::PerformDoubleTap(Touch const & touch)
   ASSERT_EQUAL(m_state, STATE_WAIT_DOUBLE_TAP_HOLD, ());
   m_state = STATE_EMPTY;
   if (m_listener)
-    m_listener->OnDoubleTap(touch.m_location);
+    m_listener->OnDoubleTap(m2::PointD(touch.m_location));
 }
 
 bool UserEventStream::DetectForceTap(Touch const & touch)
@@ -1159,7 +1159,7 @@ bool UserEventStream::DetectForceTap(Touch const & touch)
   {
     m_state = STATE_EMPTY;
     if (m_listener)
-      m_listener->OnForceTap(touch.m_location);
+      m_listener->OnForceTap(m2::PointD(touch.m_location));
     return true;
   }
 
@@ -1185,7 +1185,7 @@ bool UserEventStream::TryBeginFilter(Touch const & t)
 {
   TEST_CALL(TRY_FILTER);
   ASSERT_EQUAL(m_state, STATE_EMPTY, ());
-  if (m_listener && m_listener->OnSingleTouchFiltrate(t.m_location, TouchEvent::TOUCH_DOWN))
+  if (m_listener && m_listener->OnSingleTouchFiltrate(m2::PointD(t.m_location), TouchEvent::TOUCH_DOWN))
   {
     m_state = STATE_FILTER;
     return true;
@@ -1200,7 +1200,7 @@ void UserEventStream::EndFilter(const Touch & t)
   ASSERT_EQUAL(m_state, STATE_FILTER, ());
   m_state = STATE_EMPTY;
   if (m_listener)
-    m_listener->OnSingleTouchFiltrate(t.m_location, TouchEvent::TOUCH_UP);
+    m_listener->OnSingleTouchFiltrate(m2::PointD(t.m_location), TouchEvent::TOUCH_UP);
 }
 
 void UserEventStream::CancelFilter(Touch const & t)
@@ -1209,7 +1209,7 @@ void UserEventStream::CancelFilter(Touch const & t)
   ASSERT_EQUAL(m_state, STATE_FILTER, ());
   m_state = STATE_EMPTY;
   if (m_listener)
-    m_listener->OnSingleTouchFiltrate(t.m_location, TouchEvent::TOUCH_CANCEL);
+    m_listener->OnSingleTouchFiltrate(m2::PointD(t.m_location), TouchEvent::TOUCH_CANCEL);
 }
   
 void UserEventStream::StartDoubleTapAndHold(Touch const & touch)

--- a/drape_frontend/user_mark_shapes.cpp
+++ b/drape_frontend/user_mark_shapes.cpp
@@ -360,16 +360,16 @@ void CacheUserMarks(TileKey const & tileKey, ref_ptr<dp::TextureManager> texture
       glsl::vec4 colorAndAnimate(color.GetRedF(), color.GetGreenF(), color.GetBlueF(),
                                  runAnim ? 1.0f : -1.0f);
       buffer.emplace_back(pos, left + down,
-                          glsl::ToVec4(texRect.LeftTop(), bgTexRect.LeftTop()),
+                          glsl::ToVec4(m2::PointD(texRect.LeftTop()), m2::PointD(bgTexRect.LeftTop())),
                           colorAndAnimate);
       buffer.emplace_back(pos, left + up,
-                          glsl::ToVec4(texRect.LeftBottom(), bgTexRect.LeftBottom()),
+                          glsl::ToVec4(m2::PointD(texRect.LeftBottom()), m2::PointD(bgTexRect.LeftBottom())),
                           colorAndAnimate);
       buffer.emplace_back(pos, right + down,
-                          glsl::ToVec4(texRect.RightTop(), bgTexRect.RightTop()),
+                          glsl::ToVec4(m2::PointD(texRect.RightTop()), m2::PointD(bgTexRect.RightTop())),
                           colorAndAnimate);
       buffer.emplace_back(pos, right + up,
-                          glsl::ToVec4(texRect.RightBottom(), bgTexRect.RightBottom()),
+                          glsl::ToVec4(m2::PointD(texRect.RightBottom()), m2::PointD(bgTexRect.RightBottom())),
                           colorAndAnimate);
     }
 

--- a/geometry/distance.hpp
+++ b/geometry/distance.hpp
@@ -68,7 +68,8 @@ template <typename PointT> class DistanceToLineSquare : public impl::CalculatedS
 public:
   double operator() (PointT const & Y) const
   {
-    m2::PointD const YmP0 = Y - this->m_P0;
+    PointT const diff = Y - this->m_P0;
+    m2::PointD const YmP0(diff);
     double const t = DotProduct(this->m_D, YmP0);
 
     if (t <= 0)

--- a/geometry/geometry_tests/covering_test.cpp
+++ b/geometry/geometry_tests/covering_test.cpp
@@ -90,7 +90,7 @@ UNIT_TEST(Covering_Append_Simple)
 
 UNIT_TEST(IntersectCellWithTriangle_EmptyTriangle)
 {
-  m2::PointU pt(27, 31);
+  m2::PointD pt(27.0, 31.0);
   TEST_EQUAL(covering::CELL_OBJECT_NO_INTERSECTION,
              covering::IntersectCellWithTriangle(CellId("0"), pt, pt, pt), ());
   TEST_EQUAL(covering::CELL_OBJECT_NO_INTERSECTION,
@@ -104,9 +104,10 @@ UNIT_TEST(IntersectCellWithTriangle_EmptyTriangle)
 UNIT_TEST(Covering_EmptyTriangle)
 {
   m2::PointU pt(27, 31);
+  m2::PointD ptd(pt);
   CellId const expectedCellId = CellId::FromXY(pt.x, pt.y, CellId::DEPTH_LEVELS - 1);
   TEST_GREATER(expectedCellId.ToInt64(CellId::DEPTH_LEVELS), 5, ());
-  covering::Covering<CellId> covering(pt, pt, pt);
+  covering::Covering<CellId> covering(ptd, ptd, ptd);
   vector<CellId> ids;
   covering.OutputToVector(ids);
   TEST_EQUAL(ids, vector<CellId>(1, expectedCellId), ());

--- a/geometry/point2d.hpp
+++ b/geometry/point2d.hpp
@@ -18,13 +18,16 @@ namespace m2
   class Point
   {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     T x, y;
 
     Point() : x(T()), y(T()) {}
+
     Point(T x_, T y_) : x(x_), y(y_) {}
-    template <typename U> Point(Point<U> const & u) : x(u.x), y(u.y) {}
+
+    template <typename U>
+    explicit Point(Point<U> const & u) : x(u.x), y(u.y) {}
 
     static Point<T> Zero() { return Point<T>(0, 0); }
 
@@ -35,6 +38,8 @@ namespace m2
 
     // TODO (@y, @m): rename to SquaredLength.
     T SquareLength(Point<T> const & p) const { return pow(x - p.x, 2) + pow(y - p.y, 2); }
+
+    T SquaredLength() const { return x * x + y * y; }
 
     double Length(Point<T> const & p) const
     {
@@ -86,33 +91,37 @@ namespace m2
       return *this;
     }
 
-    bool operator == (m2::Point<T> const & p) const
+    bool operator==(m2::Point<T> const & p) const
     {
       return x == p.x && y == p.y;
     }
-    bool operator != (m2::Point<T> const & p) const
+
+    bool operator!=(m2::Point<T> const & p) const
     {
       return !(*this == p);
     }
-    m2::Point<T> operator + (m2::Point<T> const & pt) const
+
+    m2::Point<T> operator+(m2::Point<T> const & pt) const
     {
       return m2::Point<T>(x + pt.x, y + pt.y);
     }
-    m2::Point<T> operator - (m2::Point<T> const & pt) const
+
+    m2::Point<T> operator-(m2::Point<T> const & pt) const
     {
       return m2::Point<T>(x - pt.x, y - pt.y);
     }
-    m2::Point<T> operator -() const
+
+    m2::Point<T> operator-() const
     {
       return m2::Point<T>(-x, -y);
     }
 
-    m2::Point<T> operator * (T scale) const
+    m2::Point<T> operator*(T scale) const
     {
       return m2::Point<T>(x * scale, y * scale);
     }
 
-    m2::Point<T> const operator * (math::Matrix<T, 3, 3> const & m) const
+    m2::Point<T> const operator*(math::Matrix<T, 3, 3> const & m) const
     {
       m2::Point<T> res;
       res.x = x * m(0, 0) + y * m(1, 0) + m(2, 0);
@@ -120,7 +129,7 @@ namespace m2
       return res;
     }
 
-    m2::Point<T> operator / (T scale) const
+    m2::Point<T> operator/(T scale) const
     {
       return m2::Point<T>(x / scale, y / scale);
     }
@@ -130,10 +139,7 @@ namespace m2
       return m2::Point<T>((x + p.x) * 0.5, (y + p.y) * 0.5);
     }
 
-    T SquaredLength() const { return x * x + y * y; }
-
     /// @name VectorOperationsOnPoint
-    // @{
     double Length() const
     {
       return sqrt(SquaredLength());
@@ -153,7 +159,6 @@ namespace m2
       return std::pair<Point<T>, Point<T> >(Point<T>(static_cast<T>(-prolongatedY), static_cast<T>(prolongatedX)),
                                        Point<T>(static_cast<T>(prolongatedY), static_cast<T>(-prolongatedX)));
     }
-    // @}
 
     m2::Point<T> const & operator *= (math::Matrix<T, 3, 3> const & m)
     {
@@ -305,7 +310,7 @@ namespace m2
   }
 
   template <class TArchive, class PointT>
-  TArchive & operator << (TArchive & ar, m2::Point<PointT> const & pt)
+  TArchive & operator<<(TArchive & ar, m2::Point<PointT> const & pt)
   {
     ar << pt.x;
     ar << pt.y;
@@ -313,24 +318,23 @@ namespace m2
   }
 
   template <typename T>
-  bool operator< (Point<T> const & l, Point<T> const & r)
+  bool operator<(Point<T> const & l, Point<T> const & r)
   {
     if (l.x != r.x)
       return l.x < r.x;
     return l.y < r.y;
   }
 
-  typedef Point<float> PointF;
-  typedef Point<double> PointD;
-  typedef Point<uint32_t> PointU;
-  typedef Point<uint64_t> PointU64;
-  typedef Point<int32_t> PointI;
-  typedef Point<int64_t> PointI64;
+  using PointF = Point<float>;
+  using PointD = Point<double>;
+  using PointU = Point<uint32_t>;
+  using PointU64 = Point<uint64_t>;
+  using PointI = Point<int32_t>;
+  using PointI64 = Point<int64_t>;
 }  // namespace m2
 
 namespace my
 {
-
 template <typename T>
 bool AlmostEqualULPs(m2::Point<T> const & p1, m2::Point<T> const & p2, unsigned int maxULPs = 256)
 {
@@ -342,5 +346,4 @@ bool AlmostEqualAbs(m2::Point<T> const & p1, m2::Point<T> const & p2, double con
 {
   return m2::AlmostEqualAbs(p1, p2, eps);
 }
-
 }  // namespace my

--- a/geometry/simplification.hpp
+++ b/geometry/simplification.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "geometry/point2d.hpp"
+
 #include "base/base.hpp"
 #include "base/stl_add.hpp"
 #include "base/logging.hpp"
@@ -15,7 +18,6 @@
 
 namespace impl
 {
-
 ///@name This functions take input range NOT like STL does: [first, last].
 //@{
 template <typename DistanceF, typename IterT>
@@ -25,16 +27,17 @@ pair<double, IterT> MaxDistance(IterT first, IterT last, DistanceF & dist)
   if (distance(first, last) <= 1)
     return res;
 
-  dist.SetBounds(*first, *last);
+  dist.SetBounds(m2::PointD(*first), m2::PointD(*last));
   for (IterT i = first + 1; i != last; ++i)
   {
-    double const d = dist(*i);
+    double const d = dist(m2::PointD(*i));
     if (d > res.first)
     {
       res.first = d;
       res.second = i;
     }
   }
+
   return res;
 }
 
@@ -64,8 +67,7 @@ struct SimplifyOptimalRes
   int32_t m_NextPoint;
   uint32_t m_PointCount;
 };
-
-}
+}  // namespace impl
 
 // Douglas-Peucker algorithm for STL-like range [beg, end).
 // Iteratively includes the point with max distance form the current simplification.
@@ -124,7 +126,6 @@ void SimplifyNearOptimal(int kMaxFalseLookAhead, IterT beg, IterT end,
     out(*(beg + i));
 }
 
-
 // Additional points filter to use in simplification.
 // SimplifyDP can produce points that define degenerate triangle.
 template <class DistanceF, class PointT>
@@ -146,8 +147,8 @@ public:
     size_t count;
     while ((count = m_vec.size()) >= 2)
     {
-      m_dist.SetBounds(m_vec[count-2], p);
-      if (m_dist(m_vec[count-1]) < m_eps)
+      m_dist.SetBounds(m2::PointD(m_vec[count-2]), m2::PointD(p));
+      if (m_dist(m2::PointD(m_vec[count-1])) < m_eps)
         m_vec.pop_back();
       else
         break;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1200,22 +1200,22 @@ void Framework::ClearAllCaches()
   GetSearchAPI().ClearCaches();
 }
 
-void Framework::OnUpdateCurrentCountry(m2::PointF const & pt, int zoomLevel)
+void Framework::OnUpdateCurrentCountry(m2::PointD const & pt, int zoomLevel)
 {
-   storage::TCountryId newCountryId;
-   if (zoomLevel > scales::GetUpperWorldScale())
-     newCountryId = m_infoGetter->GetRegionCountryId(m2::PointD(pt));
+  storage::TCountryId newCountryId;
+  if (zoomLevel > scales::GetUpperWorldScale())
+    newCountryId = m_infoGetter->GetRegionCountryId(pt);
 
-   if (newCountryId == m_lastReportedCountry)
-     return;
+  if (newCountryId == m_lastReportedCountry)
+    return;
 
-   m_lastReportedCountry = newCountryId;
+  m_lastReportedCountry = newCountryId;
 
-   GetPlatform().RunTask(Platform::Thread::Gui, [this, newCountryId]()
-   {
-     if (m_currentCountryChanged != nullptr)
-       m_currentCountryChanged(newCountryId);
-   });
+  GetPlatform().RunTask(Platform::Thread::Gui, [this, newCountryId]()
+  {
+    if (m_currentCountryChanged != nullptr)
+      m_currentCountryChanged(newCountryId);
+  });
 }
 
 void Framework::SetCurrentCountryChangedListener(TCurrentCountryChanged const & listener)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -504,7 +504,7 @@ private:
 
   bool m_connectToGpsTrack; // need to connect to tracker when Drape is being constructed
 
-  void OnUpdateCurrentCountry(m2::PointF const & pt, int zoomLevel);
+  void OnUpdateCurrentCountry(m2::PointD const & pt, int zoomLevel);
 
   storage::TCountryId m_lastReportedCountry;
   TCurrentCountryChanged m_currentCountryChanged;

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -169,7 +169,7 @@ df::TouchEvent MapWidget::GetTouchEvent(QMouseEvent * e, df::TouchEvent::ETouchT
 df::Touch MapWidget::GetSymmetrical(df::Touch const & touch) const
 {
   m2::PointD const pixelCenter = m_framework.GetPixelCenter();
-  m2::PointD const symmetricalLocation = pixelCenter + (pixelCenter - touch.m_location);
+  m2::PointD const symmetricalLocation = pixelCenter + pixelCenter - m2::PointD(touch.m_location);
 
   df::Touch result;
   result.m_id = touch.m_id + 1;


### PR DESCRIPTION
Sometimes we want a non-trivial transformation when converting
from one representation of a point to another. An example
is PointDToPointU which uses the fact that its argument is
usually a point from the Mercator plane. The wrong usage
is easier to catch when implicit conversion between different point
types is prohibited.

An example of wrong usage that is prevented by this commit:
```
  // A function defined in another file.
  m2::PointU GetPoint()
  {
    m2::PointD pt;
    [...]
    return PointDToPointU(p2, kDefaultBits);
  }

  // Here we have forgotten that the result of GetPoint() is already converted.
  m2::PointU ptu = PointDToPointU(GetPoint(), kDefaultBits);
```