### PR TITLE
Reducing speed for ferry in case of pedestrian and bicycle routing.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -99,7 +99,7 @@ UNIT_TEST(RussiaKerchStraitFerryRoute)
       MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
 }
 
-// Test on building pedestrian route past ferry.
+// Test on building bicycle route past ferry.
 UNIT_TEST(SwedenStockholmBicyclePastFerry)
 {
   CalculateRouteAndTestRouteLength(

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -98,3 +98,12 @@ UNIT_TEST(RussiaKerchStraitFerryRoute)
       MercatorBounds::FromLatLon(45.4167, 36.7658), {0.0, 0.0},
       MercatorBounds::FromLatLon(45.3653, 36.6161), 18000.0);
 }
+
+// Test on building pedestrian route past ferry.
+UNIT_TEST(SwedenStockholmBicyclePastFerry)
+{
+  CalculateRouteAndTestRouteLength(
+      GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(59.4725, 18.51355), {0.0, 0.0},
+      MercatorBounds::FromLatLon(59.32967, 18.075), 66161.2);
+}

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -484,3 +484,12 @@ UNIT_TEST(MoscowKashirskoe16ToVorobeviGori)
       MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
       MercatorBounds::FromLatLon(55.70934, 37.54232), 9553.0);
 }
+
+// Test on building pedestrian route past ferry.
+UNIT_TEST(SwitzerlandSaintBlaisePedestrian)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+      MercatorBounds::FromLatLon(47.010336, 6.982954), {0.0, 0.0},
+      MercatorBounds::FromLatLon(47.005817, 6.970227), 1532.3);
+}

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -486,10 +486,28 @@ UNIT_TEST(MoscowKashirskoe16ToVorobeviGori)
 }
 
 // Test on building pedestrian route past ferry.
-UNIT_TEST(SwitzerlandSaintBlaisePedestrian)
+UNIT_TEST(SwitzerlandSaintBlaisePedestrianPastFerry)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.010336, 6.982954), {0.0, 0.0},
       MercatorBounds::FromLatLon(47.005817, 6.970227), 1532.3);
+}
+
+// Test on building pedestrian route past ferry.
+UNIT_TEST(NetherlandsAmsterdamPedestrianPastFerry)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+      MercatorBounds::FromLatLon(52.38075, 4.89938), {0.0, 0.0},
+      MercatorBounds::FromLatLon(52.40194, 4.89038), 3580.0);
+}
+
+// Test on building pedestrian route past ferry.
+UNIT_TEST(ItalyVenicePedestrianPastFerry)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+      MercatorBounds::FromLatLon(45.4375, 12.33549), {0.0, 0.0},
+      MercatorBounds::FromLatLon(45.44057, 12.33393), 725.4);
 }

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -50,6 +50,7 @@ double constexpr kSpeedFootwayKMpH = 7.0;
 double constexpr kSpeedPlatformKMpH = 3.0;
 double constexpr kSpeedPierKMpH = 7.0;
 double constexpr kSpeedOffroadKMpH = 3.0;
+double constexpr kSpeedFerry = 3.0;
 
 // Default
 VehicleModel::InitListT const g_bicycleLimitsDefault =
@@ -439,7 +440,7 @@ void BicycleModel::Init()
 
   vector<AdditionalRoadTags> const additionalTags = {
       {hwtagYesBicycle, m_maxSpeedKMpH},
-      {{"route", "ferry"}, m_maxSpeedKMpH},
+      {{"route", "ferry"}, kSpeedFerry},
       {{"man_made", "pier"}, kSpeedPierKMpH},
   };
 

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -50,6 +50,7 @@ double constexpr kSpeedFootwayKMpH = 5.0;
 double constexpr kSpeedPlatformKMpH = 5.0;
 double constexpr kSpeedPierKMpH = 4.0;
 double constexpr kSpeedOffroadKMpH = 3.0;
+double constexpr kSpeedFerry = 1.0;
 
 // Default
 VehicleModel::InitListT const g_pedestrianLimitsDefault =
@@ -290,7 +291,7 @@ void PedestrianModel::Init()
 
   vector<AdditionalRoadTags> const additionalTags = {
       {hwtagYesFoot, m_maxSpeedKMpH},
-      {{"route", "ferry"}, m_maxSpeedKMpH},
+      {{"route", "ferry"}, kSpeedFerry},
       {{"man_made", "pier"}, kSpeedPierKMpH},
   };
 


### PR DESCRIPTION
Возникали случаи, когда роутер в случае пешеходного роутинга предлагал ехать на паромах вместо того, чтоб идти пешком: https://jira.mail.ru/browse/MAPSME-7160

Причина этого была в том, что для паромов использовалась максимальная скорость, в случае пешеходного роутинга - 5 км/ч. Исследование кода показало, что та же проблема есть и в вело роутинге. 

- Поправил и пеший и вело роутинг;
- Добавил интеграционный тест на пеший роутинг согласно:  https://jira.mail.ru/browse/MAPSME-7160
- Поставил тикет, на поиск места для аналогичного теста для вело маршрута: https://jira.mail.ru/browse/MAPSME-7546 (Тест будет добавлен отдельным PR)

@mpimenov @rokuz PTAL

PR помечен DNM, т.к. он для минорки. Ждем выхода релиза 82 и потом можно будет мержить.
