### PR TITLE
Update URL for placemarks

### DIFF
--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -149,7 +149,7 @@ void SaveStyle(KmlWriter::WriterWrapper & writer, std::string const & style)
   writer << kIndent2 << "<Style id=\"" << style << "\">\n"
          << kIndent4 << "<IconStyle>\n"
          << kIndent6 << "<Icon>\n"
-         << kIndent8 << "<href>http://mapswith.me/placemarks/" << style << ".png</href>\n"
+         << kIndent8 << "<href>https://maps.me/placemarks/" << style << ".png</href>\n"
          << kIndent6 << "</Icon>\n"
          << kIndent4 << "</IconStyle>\n"
          << kIndent2 << "</Style>\n";


### PR DESCRIPTION
Проблема: http://mapswith.me/placemarks/placemark-blue.png уже не работает, а https://maps.me/placemarks/placemark-blue.png живёт. Из-за этого в Google Earth наши букмарки выглядят как красные надгробия. Заменил ссылку в kml при экспортировании. На импорт не влияет.