### PR TITLE
Fixed false asserts in cloud

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
@@ -27,7 +27,7 @@ public enum BookmarkManager
 
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({ CLOUD_SUCCESS, CLOUD_AUTH_ERROR, CLOUD_NETWORK_ERROR,
-            CLOUD_DISK_ERROR, CLOUD_USER_INTERRUPTED })
+            CLOUD_DISK_ERROR, CLOUD_USER_INTERRUPTED, CLOUD_INVALID_CALL })
   public @interface SynchronizationResult {}
 
   public static final int CLOUD_SUCCESS = 0;
@@ -35,6 +35,7 @@ public enum BookmarkManager
   public static final int CLOUD_NETWORK_ERROR = 2;
   public static final int CLOUD_DISK_ERROR = 3;
   public static final int CLOUD_USER_INTERRUPTED = 4;
+  public static final int CLOUD_INVALID_CALL = 5;
 
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({ CLOUD_BACKUP_EXISTS, CLOUD_NO_BACKUP, CLOUD_NOT_ENOUGH_DISK_SPACE })

--- a/android/src/com/mapswithme/util/statistics/Statistics.java
+++ b/android/src/com/mapswithme/util/statistics/Statistics.java
@@ -414,6 +414,7 @@ public enum Statistics
     static final String DISK = "disk";
     static final String AUTH = "auth";
     static final String USER_INTERRUPTED = "user_interrupted";
+    static final String INVALID_CALL = "invalid_call";
   }
 
   // Initialized once in constructor and does not change until the process restarts.
@@ -1088,6 +1089,8 @@ public enum Statistics
         return ParamValue.DISK;
       case BookmarkManager.CLOUD_USER_INTERRUPTED:
         return ParamValue.USER_INTERRUPTED;
+      case BookmarkManager.CLOUD_INVALID_CALL:
+        return ParamValue.INVALID_CALL;
       case BookmarkManager.CLOUD_SUCCESS:
         throw new AssertionError("It's not a error result!");
       default:

--- a/iphone/Maps/Common/Statistics/StatisticsStrings.h
+++ b/iphone/Maps/Common/Statistics/StatisticsStrings.h
@@ -161,6 +161,7 @@ static NSString * const kStatHotel = @"hotel";
 static NSString * const kStatHotelLocation = @"hotel_location";
 static NSString * const kStatImport = @"Import";
 static NSString * const kStatIn = @"In";
+static NSString * const kStatInvalidCall = @"invalid_call";
 static NSString * const kStatIsAuthenticated = @"is_authenticated";
 static NSString * const kStatIsAuto = @"is_auto";
 static NSString * const kStatIsOnline = @"is_online";

--- a/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/Maps/Core/Bookmarks/MWMBookmarksManager.mm
@@ -24,6 +24,7 @@ NSString * const CloudErrorToString(Cloud::SynchronizationResult result)
   case Cloud::SynchronizationResult::NetworkError: return kStatNetwork;
   case Cloud::SynchronizationResult::DiskError: return kStatDisk;
   case Cloud::SynchronizationResult::UserInterrupted: return kStatUserInterrupted;
+  case Cloud::SynchronizationResult::InvalidCall: return kStatInvalidCall;
   }
 }
 }  // namespace

--- a/map/cloud.hpp
+++ b/map/cloud.hpp
@@ -176,7 +176,9 @@ public:
     // Synchronization was interrupted by a disk error.
     DiskError = 3,
     // Synchronization was interrupted by the user.
-    UserInterrupted = 4
+    UserInterrupted = 4,
+    // Synchronization was finished because of invalid function call.
+    InvalidCall = 5
   };
 
   enum class RestoringRequestResult
@@ -255,8 +257,18 @@ public:
 
   std::unique_ptr<User::Subscriber> GetUserSubscriber();
 
+  // This function requests restoring of files. The function must be called only
+  // if internet connection exists, the cloud is enabled and initialized, user is
+  // authenticated and there is no any current restoring process, otherwise
+  // InvalidCall result will be got.
   void RequestRestoring();
+  
+  // This function applies requested files. The function must be called only
+  // if internet connection exists, the cloud is enabled and initialized, user is
+  // authenticated, there is an existing restoring process and there is
+  // the backup on the server, otherwise InvalidCall result will be got.
   void ApplyRestoring();
+  
   void CancelRestoring();
 
 private:
@@ -276,6 +288,10 @@ private:
   bool ReadIndex();
   void UpdateIndex(bool indexExists);
   void SaveIndexImpl() const;
+  
+  bool IsRestoringEnabledCommonImpl(std::string & reason) const;
+  bool IsRequestRestoringEnabled(std::string & reason) const;
+  bool IsApplyRestoringEnabled(std::string & reason) const;
 
   EntryPtr GetEntryImpl(std::string const & fileName) const;
   void MarkModifiedImpl(std::string const & filePath, bool isOutdated);
@@ -374,6 +390,7 @@ inline std::string DebugPrint(Cloud::SynchronizationResult result)
   case Cloud::SynchronizationResult::NetworkError: return "NetworkError";
   case Cloud::SynchronizationResult::DiskError: return "DiskError";
   case Cloud::SynchronizationResult::UserInterrupted: return "UserInterrupted";
+  case Cloud::SynchronizationResult::InvalidCall: return "InvalidCall";
   }
 }
 


### PR DESCRIPTION
Нельзя было использовать ASSERT на этих переменных класса в отложенных тасках. Переменные могут спокойно изменяться между тасками