### PR TITLE
Better calculation outgoing route points for turn generation and fixing some turn generation issues.

### DIFF
--- a/local_ads/statistics.cpp
+++ b/local_ads/statistics.cpp
@@ -148,7 +148,7 @@ void CreateDirIfNotExist()
   if (!GetPlatform().IsFileExistsByFullPath(statsFolder) && !Platform::MkDirChecked(statsFolder))
     MYTHROW(FileSystemException, ("Unable to find or create directory", statsFolder));
 }
-  
+
 std::list<local_ads::Event> ReadEvents(std::string const & fileName)
 {
   std::list<local_ads::Event> result;

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -52,12 +52,10 @@ public:
   // turns::IRoutingResult overrides:
   TUnpackedPathSegments const & GetSegments() const override { return m_pathSegments; }
 
-  void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & ingoingPoint,
-                        m2::PointD const & junctionPoint, size_t & ingoingCount,
-                        TurnCandidates & outgoingTurns) const override
+  void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & junctionPoint,
+                        size_t & ingoingCount, TurnCandidates & outgoingTurns) const override
   {
-    CHECK(!segmentRange.IsEmpty(), ("SegmentRange presents a fake feature. ingoingPoint:",
-                                    MercatorBounds::ToLatLon(ingoingPoint),
+    CHECK(!segmentRange.IsEmpty(), ("SegmentRange presents a fake feature.",
                                     "junctionPoint:", MercatorBounds::ToLatLon(junctionPoint)));
 
     ingoingCount = 0;

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -35,7 +35,7 @@ struct LoadedPathSegment
   bool m_onRoundabout = false;
   bool m_isLink = false;
 
-  bool IsValid() const { return !m_path.empty(); }
+  bool IsValid() const { return m_path.size() > 1; }
 };
 
 using TUnpackedPathSegments = vector<LoadedPathSegment>;

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -135,16 +135,15 @@ UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
   IRouter::ResultCode const result = routeResult.second;
   TEST_EQUAL(result, IRouter::NoError, ());
 
-  integration::TestTurnCount(route, 7 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 6 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnSlightLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightLeft, CarDirection::TurnLeft});
   integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 4).TestValid().TestOneOfDirections(
-      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+  integration::GetNthTurn(route, 4).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 5).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 6).TestValid().TestDirection(CarDirection::TurnLeft);
 
   integration::TestRouteLength(route, 768.0);
 }

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -422,9 +422,6 @@ UNIT_TEST(RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest)
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
-// Test case: a route goes in Moscow from Tverskaya street (towards city center)
-// to Mokhovaya street. Road goes left but there are no other turn option.
-// Turn instruction is not needed in this case.
 UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
 {
   TRouteResult const routeResult =
@@ -436,7 +433,8 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
@@ -474,7 +472,7 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
 {
   TRouteResult const routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(47.19300, 8.67568), {0., 0.},
+                                  MercatorBounds::FromLatLon(47.19307, 8.67594), {0., 0.},
                                   MercatorBounds::FromLatLon(47.19162, 8.67590));
 
   Route const & route = *routeResult.first;
@@ -797,8 +795,14 @@ UNIT_TEST(BelorussiaMinskTest)
   IRouter::ResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, IRouter::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  // @TODO(bykoianko) In this case it's better to get GoStraight direction or not get
+  // direction at all. But the turn generator generates TurnSlightRight based on road geometry.
+  // It's so because the turn generator does not take into account the significant number of lanes
+  // of the roads at the crossing. While turn generation number of lanes should be taken into account.
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::GoStraight, CarDirection::TurnSlightRight});
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
 }
 
 UNIT_TEST(EnglandLondonExitToLeftTest)
@@ -952,6 +956,39 @@ UNIT_TEST(RussiaMoscowMinskia2TurnTest)
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                   MercatorBounds::FromLatLon(55.74244, 37.4808), {0., 0.},
                                   MercatorBounds::FromLatLon(55.74336, 37.48124));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+}
+
+// This test on getting correct (far enough) outgoing turn point (result of method GetPointForTurn())
+// despite the fact that a small road adjoins immediately after the turn point.
+UNIT_TEST(RussiaMoscowBarikadnaiTurnTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.75979, 37.58502), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.75936, 37.58286));
+
+  Route const & route = *routeResult.first;
+  IRouter::ResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, IRouter::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+}
+
+// This test on getting correct (far enough) outgoing turn point (result of method GetPointForTurn()).
+UNIT_TEST(RussiaMoscowKomsomolskyTurnTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.73442, 37.59391), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.73485, 37.59543));
 
   Route const & route = *routeResult.first;
   IRouter::ResultCode const result = routeResult.second;

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -23,9 +23,8 @@ public:
   /// this method computes number of ingoing ways to |junctionPoint| and fills |outgoingTurns|.
   /// \note This method should not be called for |segmentRange| of fake edges.
   /// So method |segmentRange.IsClear()| should return false.
-  virtual void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & ingoingPoint,
-                                m2::PointD const & junctionPoint, size_t & ingoingCount,
-                                TurnCandidates & outgoingTurns) const = 0;
+  virtual void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & junctionPoint,
+                                size_t & ingoingCount, TurnCandidates & outgoingTurns) const = 0;
   virtual double GetPathLength() const = 0;
   virtual Junction GetStartPoint() const = 0;
   virtual Junction GetEndPoint() const = 0;

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -1,8 +1,8 @@
 #include "testing/testing.hpp"
 
 #include "routing/loaded_path_segment.hpp"
-#include "routing/routing_result_graph.hpp"
 #include "routing/route.hpp"
+#include "routing/routing_result_graph.hpp"
 #include "routing/turns.hpp"
 #include "routing/turns_generator.hpp"
 

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -85,15 +85,15 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
 
 /*!
  * \brief Compute turn and time estimation structs for the abstract route result.
- * \param routingResult abstract routing result to annotate.
+ * \param result abstract routing result to annotate.
  * \param delegate Routing callbacks delegate.
  * \param points Storage for unpacked points of the path.
  * \param turnsDir output turns annotation storage.
  * \param streets output street names along the path.
- * \param traffic road traffic information.
+ * \param segments route segments.
  * \return routing operation result code.
  */
-IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result, NumMwmIds const & numMwmIds,
+IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
                                        RouterDelegate const & delegate, std::vector<Junction> & points,
                                        Route::TTurns & turnsDir, Route::TStreets & streets,
                                        std::vector<Segment> & segments);
@@ -161,7 +161,7 @@ CarDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoin
  * \param outgoingSegmentIndex index of an outgoing segments in vector result.GetSegments().
  * \param turn is used for keeping the result of turn calculation.
  */
-void GetTurnDirection(turns::IRoutingResult const & result, size_t outgoingSegmentIndex,
+void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex,
                       NumMwmIds const & numMwmIds, TurnItem & turn);
 
 /*!

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -12,9 +12,11 @@
 
 #include "traffic/traffic_info.hpp"
 
-#include "std/function.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 struct PathData;
 class Index;
@@ -33,7 +35,53 @@ namespace turns
 /*!
  * \brief Returns a segment index by STL-like range [s, e) of segments indices for the passed node.
  */
-using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
+using TGetIndexFunction = std::function<size_t(std::pair<size_t, size_t>)>;
+
+/*!
+ * \brief Index of point in TUnpackedPathSegments. |m_segmentIndex| is a zero based index in vector
+ * TUnpackedPathSegments. |m_pathIndex| in a zero based index in LoadedPathSegment::m_path.
+ */
+struct RoutePointIndex
+{
+  size_t m_segmentIndex = 0;
+  size_t m_pathIndex = 0;
+
+  bool operator==(RoutePointIndex const & index) const;
+};
+
+/*!
+ * \brief The TurnInfo structure is a representation of a junction.
+ * It has ingoing and outgoing edges and method to check if these edges are valid.
+ */
+struct TurnInfo
+{
+  LoadedPathSegment const & m_ingoing;
+  LoadedPathSegment const & m_outgoing;
+
+  TurnInfo(LoadedPathSegment const & ingoingSegment, LoadedPathSegment const & outgoingSegment)
+      : m_ingoing(ingoingSegment), m_outgoing(outgoingSegment)
+  {
+  }
+
+  bool IsSegmentsValid() const;
+};
+
+/*!
+ * \brief Calculates |nextIndex| which is an index of next route point at result.GetSegments().
+ * |nextIndex| may be calculated in forward and backward direction.
+ * \returns true if |nextIndex| is calculated and false otherwise. This method returns false
+ * if looking for next index should be stopped. For example in case of the point before first,
+ * after the last in the route and sometimes at the end of features and at feature intersections.
+ * \note This method is asymmetric. It means that in some cases it's possible to cross
+ * the border between turn segments in forward direction, but in backward direction (|forward| == false)
+ * it's impossible. So when turn segment border is reached in backward direction the method
+ * returns false. The reasons why crossing the border in backward direction is not implemented is
+ * it's almost not used now and it's difficult to cover it with unit and integration tests.
+ * As a consequence moving in backward direction it's possible to get index of the first item
+ * of a segment. But it's impossible moving in forward direction.
+ */
+bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const & index,
+                            NumMwmIds const & numMwmIds, bool forward, RoutePointIndex & nextIndex);
 
 /*!
  * \brief Compute turn and time estimation structs for the abstract route result.
@@ -46,37 +94,20 @@ using TGetIndexFunction = function<size_t(pair<size_t, size_t>)>;
  * \return routing operation result code.
  */
 IRouter::ResultCode MakeTurnAnnotation(turns::IRoutingResult const & result, NumMwmIds const & numMwmIds,
-                                       RouterDelegate const & delegate, vector<Junction> & points,
+                                       RouterDelegate const & delegate, std::vector<Junction> & points,
                                        Route::TTurns & turnsDir, Route::TStreets & streets,
-                                       vector<Segment> & segments);
-
-/*!
- * \brief The TurnInfo struct is a representation of a junction.
- * It has ingoing and outgoing edges and method to check if these edges are valid.
- */
-struct TurnInfo
-{
-  LoadedPathSegment const & m_ingoing;
-  LoadedPathSegment const & m_outgoing;
-
-  TurnInfo(LoadedPathSegment const & ingoingSegment, LoadedPathSegment const & outgoingSegment)
-    : m_ingoing(ingoingSegment), m_outgoing(outgoingSegment)
-  {
-  }
-
-  bool IsSegmentsValid() const;
-};
+                                       std::vector<Segment> & segments);
 
 // Returns the distance in meractor units for the path of points for the range [startPointIndex, endPointIndex].
 double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t endPointIndex,
-                                          vector<m2::PointD> const & points);
+                                          std::vector<m2::PointD> const & points);
 
 /*!
  * \brief Selects lanes which are recommended for an end user.
  */
 void SelectRecommendedLanes(Route::TTurns & turnsDir);
-void FixupTurns(vector<Junction> const & points, Route::TTurns & turnsDir);
-inline size_t GetFirstSegmentPointIndex(pair<size_t, size_t> const & p) { return p.first; }
+void FixupTurns(std::vector<Junction> const & points, Route::TTurns & turnsDir);
+inline size_t GetFirstSegmentPointIndex(std::pair<size_t, size_t> const & p) { return p.first; }
 
 CarDirection InvertDirection(CarDirection dir);
 
@@ -123,15 +154,15 @@ bool CheckRoundaboutExit(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRounda
  *       but it is (they are) relevantly small.
  */
 CarDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoingEdgeRoundabout,
-                                     bool isMultiTurnJunction, bool keepTurnByHighwayClass);
+                                    bool isMultiTurnJunction, bool keepTurnByHighwayClass);
 
 /*!
  * \brief GetTurnDirection makes a primary decision about turns on the route.
- * \param turnInfo is used for cashing some information while turn calculation.
+ * \param outgoingSegmentIndex index of an outgoing segments in vector result.GetSegments().
  * \param turn is used for keeping the result of turn calculation.
  */
-void GetTurnDirection(IRoutingResult const & result, NumMwmIds const & numMwmIds,
-                      turns::TurnInfo & turnInfo, TurnItem & turn);
+void GetTurnDirection(turns::IRoutingResult const & result, size_t outgoingSegmentIndex,
+                      NumMwmIds const & numMwmIds, TurnItem & turn);
 
 /*!
  * \brief Finds an U-turn that starts from master segment and returns how many segments it lasts.
@@ -139,7 +170,9 @@ void GetTurnDirection(IRoutingResult const & result, NumMwmIds const & numMwmIds
  * (|segments[currentSegment - 1]|) and 0 if there is no UTurn.
  * \warning |currentSegment| must be greater than 0.
  */
-size_t CheckUTurnOnRoute(TUnpackedPathSegments const & segments,
-                         size_t currentSegment, TurnItem & turn);
+size_t CheckUTurnOnRoute(IRoutingResult const & result, size_t outgoingSegmentIndex,
+                         NumMwmIds const & numMwmIds, TurnItem & turn);
+
+std::string DebugPrint(RoutePointIndex const & index);
 }  // namespace routing
 }  // namespace turns


### PR DESCRIPTION
Основная цель данного PR улучшение генерации маневров в ряде случаев, например, https://jira.mail.ru/browse/MAPSME-7573

При генерации сообщения о маневре, очень важную роль играет правильное вычисление угла поворота. Он вычисляется на базе геометрии маршрута. Чтоб вычислить угол необходимо от точки поворота отступить назад и вперед по маршруту, получить точку до точки поворота, точку после точки поворота и на базе них и точки поворота вычислять угол. Важным вопросом является на сколько отступать по маршруту назад и вперед. 
 * На один Segment не годится. Получим не правильный угол, т.к. карта часто нарисована так, что первый Segment отходит от точки бифуркации под не большим углом. 
 * На один LoadedPathSegment, но не более чем x метров и n Segment-ов. Так было реализовано ранее. При этом граница между LoadedPathSegment не преодолевалась. Это мешало корректному определению угла поворота в подобных случаях:
![image](https://user-images.githubusercontent.com/1768114/40118449-a3a53080-5922-11e8-86bb-a99e645ad108.png)

Или даже генерации маневра:
![image](https://user-images.githubusercontent.com/1768114/40118836-b3a1625a-5923-11e8-871b-ef0a5b267e11.png)

* Данный PR делает возможным при поиске точки (более близкой к финишу) для определения угла поворота проходить сквозь границы между LoadedPathSegment в некоторых случаях. Это делается, только если данная граница является точкой, которая почти наверняка не станет точкой, о которой будут уведомлять пользователя, как о маневре. Два примера стали интеграционными тестами, и выше выглядят следующим образом после данного PR:
![image](https://user-images.githubusercontent.com/1768114/40119284-f0b096ba-5924-11e8-9a9a-7f8363768907.png)
![image](https://user-images.githubusercontent.com/1768114/40119213-ba4adf0e-5924-11e8-82dd-7cb38209113d.png)

PR повлиял на ряд интеграционных тестов:
Ситуация несколько ухудшилась:
BelorussiaMinskTest
![image](https://user-images.githubusercontent.com/1768114/40169915-cf7ec4de-59cf-11e8-8ddb-414ff59e6c26.png)
Маневр TurnSlightRight на скрине выше или не должен быть вообще (лучше) или должен быть двигайтесь прямо. Тут проблема от того, что поиск outgoing point не останавливается при втором пересечении проспекта не зависимости. Поскольку оно достаточно близко к первому пересечению и есть только один вариант, на втором пересечении. (Поворот налево на втором пересечении запрещен). Данная проблема должна быть решена с учетом кол-ва полос на дорогах.

Ситуация не значительно улучшилась:
RussiaMoscowSvobodiOnewayBicycleWayTurnTest
![image](https://user-images.githubusercontent.com/1768114/40165249-2abe4772-59c4-11e8-9830-f6146521dd3c.png)

SwitzerlandSamstagernBergstrasseTest
![image](https://user-images.githubusercontent.com/1768114/40166187-a460fce4-59c6-11e8-9ff3-db52011b5eeb.png)
![image](https://user-images.githubusercontent.com/1768114/40166195-a8e11056-59c6-11e8-8e41-6400cbddd372.png)

Ситуация улучшилась:
RussiaMoscowTverskajaOkhotnyRyadTest
![image](https://user-images.githubusercontent.com/1768114/40166651-bbee9578-59c7-11e8-93a1-6035e1a77de4.png)

Скорость работы. Данный PR может повлиять на скорость обработки маршрута. Однако мои бенчмарк тесты этого не выявили. @greshilov Прошу провести так же бенч марк тесты. Например, можно сравнить время прохождения routing_integration_test на мастере и на этом PR.

https://jira.mail.ru/browse/MAPSME-7573 

@tatiana-yan @mpimenov @greshilov PTAL