### PR TITLE
[geocoder] Generate raw features for regions.

### DIFF
--- a/generator/osm_source.hpp
+++ b/generator/osm_source.hpp
@@ -61,6 +61,8 @@ using EmitterFactory = std::function<std::unique_ptr<EmitterBase>(feature::Gener
 
 bool GenerateFeatures(feature::GenerateInfo & info,
                       EmitterFactory factory = MakeMainFeatureEmitter);
+bool GenerateRegionFeatures(feature::GenerateInfo & info,
+                            EmitterFactory factory = MakeMainFeatureEmitter);
 bool GenerateIntermediateData(feature::GenerateInfo & info);
 
 void ProcessOsmElementsFromO5M(SourceReader & stream, std::function<void(OsmElement *)> processor);


### PR DESCRIPTION
Для генерации индекса и границ регионов нужны raw-фичи с регионами.
К сожалению при сохранении raw фичей на разных этапах этого процесса в разных частях кода какие-то фичи отфильтровываются по не вполне прозрачным правилам (те что не видны согласно стилям, те что имеют тег "place=", даже если при этом видимые теги у них тоже есть, мультиполигоны с "type=border" даже если они видны или добавлены в "белый список" видимости и т.д. и т.п.).
Лучший путь решения этой проблемы такой: надо провести рефакторинг кода, отвечающего за генерацию фичей, как часть этого рефакторинга выделить фильтрацию в одно место и разрешить вызывающему emiter коду задавать функцию фильтрации.
Пока на рефакторинг ресурсов нет делаю наименьший из хаков который смогла придумать -- создаю фичу из искуственного "хорошего" элемента с нужной геометрией и идентификтором (для построения индекса и границ ничего кроме геометрии и идентификатора не нужно).