### PR TITLE
Routing tests on slight turn fixing.

### DIFF
--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -283,9 +283,9 @@ UNIT_TEST(TestRightmostDirection)
   TEST_EQUAL(RightmostDirection(180.), CarDirection::TurnSharpRight, ());
   TEST_EQUAL(RightmostDirection(170.), CarDirection::TurnSharpRight, ());
   TEST_EQUAL(RightmostDirection(90.), CarDirection::TurnRight, ());
-  TEST_EQUAL(RightmostDirection(45.), CarDirection::TurnRight, ());
-  TEST_EQUAL(RightmostDirection(0.), CarDirection::TurnSlightRight, ());
-  TEST_EQUAL(RightmostDirection(-20.), CarDirection::GoStraight, ());
+  TEST_EQUAL(RightmostDirection(45.), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(RightmostDirection(0.), CarDirection::GoStraight, ());
+  TEST_EQUAL(RightmostDirection(-20.), CarDirection::TurnSlightLeft, ());
   TEST_EQUAL(RightmostDirection(-90.), CarDirection::TurnLeft, ());
   TEST_EQUAL(RightmostDirection(-170.), CarDirection::TurnSharpLeft, ());
 }
@@ -296,7 +296,7 @@ UNIT_TEST(TestLeftmostDirection)
   TEST_EQUAL(LeftmostDirection(170.), CarDirection::TurnSharpRight, ());
   TEST_EQUAL(LeftmostDirection(90.), CarDirection::TurnRight, ());
   TEST_EQUAL(LeftmostDirection(45.), CarDirection::TurnSlightRight, ());
-  TEST_EQUAL(LeftmostDirection(0.), CarDirection::TurnSlightLeft, ());
+  TEST_EQUAL(LeftmostDirection(0.), CarDirection::GoStraight, ());
   TEST_EQUAL(LeftmostDirection(-20.), CarDirection::TurnSlightLeft, ());
   TEST_EQUAL(LeftmostDirection(-90.), CarDirection::TurnLeft, ());
   TEST_EQUAL(LeftmostDirection(-170.), CarDirection::TurnSharpLeft, ());


### PR DESCRIPTION
После PR об изменении логики работы методов для определения угла поворота (RightmostDirection() и LeftmostDirection()): https://github.com/mapsme/omim/pull/8585 оказались сломаны routing_tests. К сожалению об этом дженкинс не сообщил сразу. Данный PR исправляет  routing_tests.

@tatiana-yan PTAL