### PR TITLE
Fixing platform_test LocalCountryFile_DiskFiles

### DIFF
--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -18,11 +18,13 @@
 
 #include "defines.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/bind.hpp"
-#include "std/set.hpp"
+#include <algorithm>
+#include <functional>
+#include <set>
+#include <string>
 
 using namespace platform::tests_support;
+using namespace std;
 
 namespace platform
 {
@@ -112,25 +114,29 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
 
     string const mapFileName = GetFileName(countryFile.GetName(), MapOptions::Map,
                                            version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testMapFile(mapFileName, "map");
+
+    string const mapFileContents("map");
+    ScopedFile testMapFile(mapFileName, mapFileContents);
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());
     TEST(!localFile.OnDisk(MapOptions::CarRouting), ());
     TEST(!localFile.OnDisk(MapOptions::MapWithCarRouting), ());
-    TEST_EQUAL(3, localFile.GetSize(MapOptions::Map), ("Size of the content (word \"map\") should be 3."));
+    TEST_EQUAL(mapFileContents.size(), localFile.GetSize(MapOptions::Map), ());
 
     string const routingFileName = GetFileName(countryFile.GetName(), MapOptions::CarRouting,
                                                version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testRoutingFile(routingFileName, "routing");
+    string const routingFileContents("routing");
+    ScopedFile testRoutingFile(routingFileName, routingFileContents);
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());
     TEST(localFile.OnDisk(MapOptions::CarRouting), ());
     TEST(localFile.OnDisk(MapOptions::MapWithCarRouting), ());
-    TEST_EQUAL(3, localFile.GetSize(MapOptions::Map), ());
-    TEST_EQUAL(7, localFile.GetSize(MapOptions::CarRouting), ());
-    TEST_EQUAL(10, localFile.GetSize(MapOptions::MapWithCarRouting), ());
+    TEST_EQUAL(mapFileContents.size(), localFile.GetSize(MapOptions::Map), ());
+    TEST_EQUAL(routingFileContents.size(), localFile.GetSize(MapOptions::CarRouting), ());
+    TEST_EQUAL(mapFileContents.size() + routingFileContents.size(),
+               localFile.GetSize(MapOptions::MapWithCarRouting), ());
 
     localFile.DeleteFromDisk(MapOptions::MapWithCarRouting);
     TEST(!testMapFile.Exists(), (testMapFile, "wasn't deleted by LocalCountryFile."));

--- a/platform/platform_tests/local_country_file_tests.cpp
+++ b/platform/platform_tests/local_country_file_tests.cpp
@@ -112,17 +112,17 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
 
     string const mapFileName = GetFileName(countryFile.GetName(), MapOptions::Map,
                                            version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testMapFile(mapFileName, ScopedFile::Mode::Create);
+    ScopedFile testMapFile(mapFileName, "map");
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());
     TEST(!localFile.OnDisk(MapOptions::CarRouting), ());
     TEST(!localFile.OnDisk(MapOptions::MapWithCarRouting), ());
-    TEST_EQUAL(3, localFile.GetSize(MapOptions::Map), ());
+    TEST_EQUAL(3, localFile.GetSize(MapOptions::Map), ("Size of the content (word \"map\") should be 3."));
 
     string const routingFileName = GetFileName(countryFile.GetName(), MapOptions::CarRouting,
                                                version::FOR_TESTING_TWO_COMPONENT_MWM1);
-    ScopedFile testRoutingFile(routingFileName, ScopedFile::Mode::Create);
+    ScopedFile testRoutingFile(routingFileName, "routing");
 
     localFile.SyncWithDisk();
     TEST(localFile.OnDisk(MapOptions::Map), ());


### PR DESCRIPTION
Данный тест сломался после рефаторинга ScopedFile в коммита:

Subject:  [platform] [tests] Added an option to ScopedFile.
Author:   Maxim Pimenov <m@maps.me>
Date: Fri Nov 17 2017 16:01:54 GMT+0300 (MSK)
Committer:    Arsentiy Milchakov <milcars@mapswithme.com>
Date: Fri Nov 17 2017 17:34:25 GMT+0300 (MSK)
SHA:  50653171ff545219eae083cffa5106baeeea325d

поскольку комит изменил код теста. Данный PR возвращает код к состоянию до коммита + добавляет один комментарий.

@VladiMihaylenko @mpimenov @greshilov PTAL