### PR TITLE
Processing the case when the start and the finish of the route is near an Segment with zero length.

### DIFF
--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -233,8 +233,11 @@ RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment) const
     auto const partLen = MercatorBounds::DistanceOnEarth(vertex.GetPointFrom(), vertex.GetPointTo());
     auto const fullLen = MercatorBounds::DistanceOnEarth(GetPoint(real, false /* front */),
                                                          GetPoint(real, true /* front */));
-    CHECK_GREATER(fullLen, 0.0, ());
-    return partLen / fullLen * m_graph.CalcSegmentWeight(real);
+    // Note. |fullLen| == 0.0 in case of Segment(s) with the same ends.
+    if (fullLen == 0.0)
+      return 0.0 * m_graph.CalcSegmentWeight(real);
+
+    return (partLen / fullLen) * m_graph.CalcSegmentWeight(real);
   }
 
   return m_graph.CalcOffroadWeight(vertex.GetPointFrom(), vertex.GetPointTo());

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -379,4 +379,26 @@ namespace
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
   }
+
+  // Test on the route with the finish near zero length edge.
+  UNIT_TEST(BelarusSlonimFinishNearZeroEdgeTest)
+  {
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(53.08279, 25.30036), {0.0, 0.0},
+                                    MercatorBounds::FromLatLon(53.09443, 25.34356));
+    IRouter::ResultCode const result = routeResult.second;
+    TEST_EQUAL(result, IRouter::NoError, ());
+  }
+
+  // Test on the route with the start near zero length edge.
+  UNIT_TEST(BelarusSlonimStartNearZeroEdgeTest)
+  {
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(53.09422, 25.34411), {0.0, 0.0},
+                                    MercatorBounds::FromLatLon(53.09271, 25.3467));
+    IRouter::ResultCode const result = routeResult.second;
+    TEST_EQUAL(result, IRouter::NoError, ());
+  }
 }  // namespace


### PR DESCRIPTION
Обработка дуги нулевой длины около старта или финиша.

Ближайшей к старту (финишу) сегмент может быть нулевой длины. До данного PR мы падали на чеке (см. ниже), если такой сегмент оказался около старта и финиша. Сейчас прокладываем корректно маршрут. 

Добавил пару интеграционных тестов.

Вот источник бага: https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5af6d27011e9fa0aa55006b0/sessions/latest

@tatiana-yan @mpimenov PTAL

Внимание! После обновления карт 2 routing integratin tests не проходят. Это исправлено в мастере (поправлен код в тестах). К данному исправлению это отношения не имеет.

Прошу оперативно посмотреть к релизу.