### PR TITLE
[routing] Fix fake segment weight, tests

### DIFF
--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -1,5 +1,7 @@
 #include "routing/edge_estimator.hpp"
 
+#include "routing/routing_helpers.hpp"
+
 #include "traffic/traffic_info.hpp"
 
 #include "base/assert.hpp"
@@ -13,8 +15,6 @@ using namespace traffic;
 
 namespace
 {
-double constexpr kKMPH2MPS = 1000.0 / (60 * 60);
-
 double TimeBetweenSec(m2::PointD const & from, m2::PointD const & to, double speedMPS)
 {
   CHECK_GREATER(speedMPS, 0.0,
@@ -62,7 +62,7 @@ double CalcClimbSegmentWeight(Segment const & segment, RoadGeometry const & road
   Junction const & to = road.GetJunction(segment.GetPointId(true /* front */));
 
   double const distance = MercatorBounds::DistanceOnEarth(from.GetPoint(), to.GetPoint());
-  double const speedMPS = road.GetSpeed() * kKMPH2MPS;
+  double const speedMPS = KMPH2MPS(road.GetSpeed());
   CHECK_GREATER(speedMPS, 0.0, ());
   double const timeSec = distance / speedMPS;
 
@@ -79,7 +79,7 @@ namespace routing
 {
 // EdgeEstimator -----------------------------------------------------------------------------------
 EdgeEstimator::EdgeEstimator(double maxSpeedKMpH, double offroadSpeedKMpH)
-  : m_maxSpeedMPS(maxSpeedKMpH * kKMPH2MPS), m_offroadSpeedMPS(offroadSpeedKMpH * kKMPH2MPS)
+  : m_maxSpeedMPS(KMPH2MPS(maxSpeedKMpH)), m_offroadSpeedMPS(KMPH2MPS(offroadSpeedKMpH))
 {
   CHECK_GREATER(m_offroadSpeedMPS, 0.0, ());
   CHECK_GREATER_OR_EQUAL(m_maxSpeedMPS, m_offroadSpeedMPS, ());

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -140,7 +140,7 @@ private:
 
   // Adds fake edges of type PartOfReal which correspond real edges from |edges| and are connected
   // to |segment|
-  void AddFakeEdges(Segment const & segment, vector<SegmentEdge> & edges) const;
+  void AddFakeEdges(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges) const;
 
   // Checks whether ending belongs to pass-through or non-pass-through zone.
   bool EndingPassThroughAllowed(Ending const & ending);

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -9,11 +9,6 @@
 #include <algorithm>
 #include <utility>
 
-namespace
-{
-double constexpr KMPH2MPS = 1000.0 / (60 * 60);
-}  // namespace
-
 namespace routing
 {
 using namespace std;
@@ -171,7 +166,7 @@ void CalculateMaxSpeedTimes(RoadGraphBase const & graph, vector<Junction> const 
   // is set in pedestrian_model (bicycle_model) for big roads. On the other hand
   // the most likely a pedestrian (a cyclist) will go along big roads with average
   // speed (graph.GetMaxSpeedKMPH()).
-  double const speedMPS = graph.GetMaxSpeedKMPH() * KMPH2MPS;
+  double const speedMPS = KMPH2MPS(graph.GetMaxSpeedKMPH());
   CHECK_GREATER(speedMPS, 0.0, ());
 
   times.reserve(path.size());

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -20,6 +20,8 @@
 
 namespace routing
 {
+inline double KMPH2MPS(double kmph) { return kmph * 1000.0 / (60 * 60); }
+
 /// \returns true when there exists a routing mode where the feature with |types| can be used.
 template <class TTypes>
 bool IsRoad(TTypes const & types)

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -7,6 +7,7 @@
 #include "routing/index_graph_serialization.hpp"
 #include "routing/index_graph_starter.hpp"
 #include "routing/index_router.hpp"
+#include "routing/routing_helpers.hpp"
 #include "routing/vehicle_mask.hpp"
 
 #include "routing/routing_tests/index_graph_tools.hpp"
@@ -38,7 +39,6 @@ using namespace routing_test;
 
 using TestEdge = TestIndexGraphTopology::Edge;
 
-double constexpr kKMPH2MPS = 1000.0 / (60 * 60);
 double constexpr kUnknownWeight = -1.0;
 
 void TestRoute(FakeEnding const & start, FakeEnding const & finish, size_t expectedLength,
@@ -390,11 +390,11 @@ UNIT_TEST(RoadSpeed)
                                        {kTestNumMwmId, 0, 3, true},
                                        {kTestNumMwmId, 1, 3, true}});
   double const expectedWeight =
-      MercatorBounds::DistanceOnEarth({0.5, 0.0}, {1.0, 0.0}) / (1.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, -1.0}) / (10.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({2.0, -1.0}, {4.0, -1.0}) / (10.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({4.0, -1.0}, {5.0, 0.0}) / (10.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({5.0, 0.0}, {5.5, 0.0}) / (1.0 * kKMPH2MPS);
+      MercatorBounds::DistanceOnEarth({0.5, 0.0}, {1.0, 0.0}) / KMPH2MPS(1.0) +
+      MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, -1.0}) / KMPH2MPS(10.0) +
+      MercatorBounds::DistanceOnEarth({2.0, -1.0}, {4.0, -1.0}) / KMPH2MPS(10.0) +
+      MercatorBounds::DistanceOnEarth({4.0, -1.0}, {5.0, 0.0}) / KMPH2MPS(10.0) +
+      MercatorBounds::DistanceOnEarth({5.0, 0.0}, {5.5, 0.0}) / KMPH2MPS(1.0);
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *worldGraph);
 }
 
@@ -431,7 +431,7 @@ UNIT_TEST(OneSegmentWay)
                                          m2::PointD(2.0, 0.0), *worldGraph);
 
       auto const expectedWeight =
-          MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / (1.0 * kKMPH2MPS);
+          MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / KMPH2MPS(1.0);
       TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *worldGraph);
     }
   }
@@ -543,7 +543,7 @@ UNIT_TEST(FakeEndingAStarInvariant)
 
   auto const expectedWeight =
       estimator->CalcOffroadWeight({1.0, 1.0}, {1.0, 0.0}) +
-      MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / (1.0 * kKMPH2MPS) +
+      MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / KMPH2MPS(1.0) +
       estimator->CalcOffroadWeight({2.0, 0.0}, {2.0, 1.0});
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *worldGraph);
 }
@@ -682,13 +682,13 @@ UNIT_CLASS_TEST(RestrictionTest, LoopGraph)
                                          {kTestNumMwmId, 2, 0, true}};
 
   auto const expectedWeight =
-      MercatorBounds::DistanceOnEarth({0.0002, 0.0}, {0.0002, 0.0001}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.0002, 0.0001}, {0.00015, 0.0001}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.00015, 0.0001}, {0.0001, 0.0001}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.0001, 0.0001}, {0.00005, 0.00015}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.00005, 0.00015}, {0.00005, 0.0002}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.00005, 0.0002}, {0.00005, 0.0003}) / (100.0 * kKMPH2MPS) +
-      MercatorBounds::DistanceOnEarth({0.00005, 0.0003}, {0.00005, 0.0004}) / (100.0 * kKMPH2MPS);
+      MercatorBounds::DistanceOnEarth({0.0002, 0.0}, {0.0002, 0.0001}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.0002, 0.0001}, {0.00015, 0.0001}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.00015, 0.0001}, {0.0001, 0.0001}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.0001, 0.0001}, {0.00005, 0.00015}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.00005, 0.00015}, {0.00005, 0.0002}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.00005, 0.0002}, {0.00005, 0.0003}) / KMPH2MPS(100.0) +
+      MercatorBounds::DistanceOnEarth({0.00005, 0.0003}, {0.00005, 0.0004}) / KMPH2MPS(100.0);
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *m_graph);
 }
 

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -1,6 +1,7 @@
 #include "routing/routing_tests/routing_algorithm.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
+#include "routing/routing_helpers.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -16,8 +17,6 @@ using namespace std;
 
 namespace
 {
-double constexpr KMPH2MPS = 1000.0 / (60 * 60);
-
 inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double speedMPS)
 {
   ASSERT(speedMPS > 0.0, ());
@@ -53,8 +52,7 @@ public:
   using Weight = double;
 
   RoadGraph(IRoadGraph const & roadGraph)
-    : m_roadGraph(roadGraph)
-    , m_maxSpeedMPS(roadGraph.GetMaxSpeedKMPH() * KMPH2MPS)
+    : m_roadGraph(roadGraph), m_maxSpeedMPS(KMPH2MPS(roadGraph.GetMaxSpeedKMPH()))
   {}
 
   void GetOutgoingEdgesList(Junction const & v, vector<WeightedEdge> & adj) const
@@ -69,7 +67,7 @@ public:
     {
       ASSERT_EQUAL(v, e.GetStartJunction(), ());
 
-      double const speedMPS = m_roadGraph.GetSpeedKMPH(e) * KMPH2MPS;
+      double const speedMPS = KMPH2MPS(m_roadGraph.GetSpeedKMPH(e));
       adj.emplace_back(e.GetEndJunction(), TimeBetweenSec(e.GetStartJunction(), e.GetEndJunction(), speedMPS));
     }
   }
@@ -86,7 +84,7 @@ public:
     {
       ASSERT_EQUAL(v, e.GetEndJunction(), ());
 
-      double const speedMPS = m_roadGraph.GetSpeedKMPH(e) * KMPH2MPS;
+      double const speedMPS = KMPH2MPS(m_roadGraph.GetSpeedKMPH(e));
       adj.emplace_back(e.GetStartJunction(), TimeBetweenSec(e.GetStartJunction(), e.GetEndJunction(), speedMPS));
     }
   }


### PR DESCRIPTION
Исправила вычисление веса фейковых сегментов типа type of real -- при поиске исходящих берем часть веса исходного пропорционально отношению длины фейкового сегмента к длине полного при помощи CalcSegmentWeight. Исправила проверку соединения сегментов с учетом isOutgoing.
Добавила в тесты index graph проверку времени маршрута (включает проверку корректности веса фейковых сегментов).