### PR TITLE
Fix extract_addr generation and a small bug in mwm.py

### DIFF
--- a/generator/extract_addr/extract_addr.cpp
+++ b/generator/extract_addr/extract_addr.cpp
@@ -16,6 +16,7 @@
 #include <set>
 #include <string>
 
+constexpr int32_t kRoundDigits = 1e6;
 std::set<std::string> const kPoiTypes = {"amenity",  "shop",    "tourism",  "leisure",   "sport",
                                          "craft",    "man_made", "office",  "historic",  "building"};
 
@@ -48,8 +49,8 @@ void PrintFeature(FeatureBuilder1 const & fb, uint64_t)
 
   auto const center = MercatorBounds::ToLatLon(fb.GetKeyPoint());
   auto coordinates = my::NewJSONArray();
-  ToJSONArray(*coordinates, strings::to_string_dac(center.lon, 6));
-  ToJSONArray(*coordinates, strings::to_string_dac(center.lat, 6));
+  ToJSONArray(*coordinates, std::round(center.lon * kRoundDigits) / kRoundDigits);
+  ToJSONArray(*coordinates, std::round(center.lat * kRoundDigits) / kRoundDigits);
   auto geometry = my::NewJSONObject();
   ToJSONObject(*geometry, "type", "Point");
   ToJSONObject(*geometry, "coordinates", coordinates);

--- a/tools/python/mwm/decode_id.py
+++ b/tools/python/mwm/decode_id.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+import mwm
+
+if len(sys.argv) < 2:
+    print('This script unpacks maps.me OSM id to an OSM object link.')
+    print('Usage: {} <id>'.format(sys.argv[0]))
+
+osm_id = mwm.unpack_osmid(int(sys.argv[1]))
+type_abbr = {'n': 'node', 'w': 'way', 'r': 'relation'}
+print('https://www.openstreetmap.org/{}/{}'.format(
+    type_abbr[osm_id[0]], osm_id[1]))

--- a/tools/python/mwm/decode_id.py
+++ b/tools/python/mwm/decode_id.py
@@ -1,12 +1,29 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import sys
 import mwm
+import re
 
 if len(sys.argv) < 2:
     print('This script unpacks maps.me OSM id to an OSM object link.')
-    print('Usage: {} <id>'.format(sys.argv[0]))
+    print('Usage: {} {<id> | <url>}'.format(sys.argv[0]))
+    sys.exit(1)
 
-osm_id = mwm.unpack_osmid(int(sys.argv[1]))
-type_abbr = {'n': 'node', 'w': 'way', 'r': 'relation'}
-print('https://www.openstreetmap.org/{}/{}'.format(
-    type_abbr[osm_id[0]], osm_id[1]))
+if sys.argv[1].isdigit():
+    osm_id = mwm.unpack_osmid(int(sys.argv[1]))
+    type_abbr = {'n': 'node', 'w': 'way', 'r': 'relation'}
+    print('https://www.openstreetmap.org/{}/{}'.format(
+        type_abbr[osm_id[0]], osm_id[1]))
+else:
+    m = re.search(r'/(node|way|relation)/(\d+)', sys.argv[1])
+    if m:
+        oid = int(m.group(2))
+        if m.group(1) == 'node':
+            oid |= mwm.OsmIdCode.NODE
+        elif m.group(1) == 'way':
+            oid |= mwm.OsmIdCode.WAY
+        elif m.group(1) == 'relation':
+            oid |= mwm.OsmIdCode.RELATION
+        print(oid)
+    else:
+        print('Unknown parameter format')
+        sys.exit(2)

--- a/tools/python/mwm/mwm.py
+++ b/tools/python/mwm/mwm.py
@@ -496,12 +496,12 @@ RESET = ~(NODE | WAY | RELATION)
 
 
 def unpack_osmid(num):
-    if num & NODE == NODE:
-        typ = 'n'
+    if num & RELATION == RELATION:
+        typ = 'r'
     elif num & WAY == WAY:
         typ = 'w'
-    elif num & RELATION == RELATION:
-        typ = 'r'
+    elif num & NODE == NODE:
+        typ = 'n'
     else:
         return None
     return typ, num & RESET


### PR DESCRIPTION
Поправил ошибку в extract_addr: координаты сохранялись как строки. Также попутно исправил ошибку декодирования идентификатора в `mwm.py` и добавил скрипт, чтобы быстро из длинного числа нашего внутреннего osm id получать ссылку на сайт OSM.

Этот реквест заменяет #8430, большая часть которого отъехала в отдельную репу.