### PR TITLE
[cmake] Add precompiled headers support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,15 @@ option(USE_TSAN "Enable Thread Sanitizer" OFF)
 option(PYBINDINGS "Create makefiles for building python bindings" OFF)
 option(SKIP_DESKTOP "Skip building of desktop application" OFF)
 option(BUILD_MAPSHOT "Build mapshot tool" OFF)
+option(USE_PCH "Use precompiled headers" OFF)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(PCH_EXTENSION "pch")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(PCH_EXTENSION "gch")
+endif()
 
 if (PLATFORM_LINUX)
   option(USE_PPROF "Enable Google Profiler" OFF)
@@ -210,6 +219,15 @@ if (USE_TSAN)
   add_compile_options(
     "-fsanitize=thread"
     "-fno-omit-frame-pointer"
+  )
+endif()
+
+if (USE_PCH)
+  message("Precompiled headers are ON")
+  set(OMIM_PCH_TARGET_NAME "omim_pch")
+  add_precompiled_headers(
+    ${OMIM_ROOT}/precompiled_headers.hpp
+    ${OMIM_PCH_TARGET_NAME}
   )
 endif()
 

--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -88,7 +88,7 @@ set(
   com/mapswithme/util/statistics/PushwooshHelper.cpp
 )
 
-add_library(mapswithme SHARED ${SRC})
+omim_add_library(mapswithme SHARED ${SRC})
 
 target_link_libraries(
   mapswithme

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -98,6 +98,6 @@ set(
   worker_thread.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(base_tests)

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -21,7 +21,8 @@ endfunction()
 macro(find_qt5_desktop_package package)
   find_package(${package})
   if (NOT ${package}_FOUND)
-    message(FATAL_ERROR "Can't find ${package}, consider to set SKIP_DESKTOP if you don't need desktop app")
+    message(FATAL_ERROR "Can't find ${package}, consider to set SKIP_DESKTOP"
+                        " if you don't need desktop app")
   endif()
 endmacro()
 
@@ -29,19 +30,41 @@ endmacro()
 function(omim_add_executable executable)
   add_executable(${executable} ${ARGN})
   if (USE_ASAN)
-    target_link_libraries(${executable} "-fsanitize=address" "-fno-omit-frame-pointer")
+    target_link_libraries(
+      ${executable}
+      "-fsanitize=address"
+      "-fno-omit-frame-pointer"
+    )
   endif()
   if (USE_TSAN)
-    target_link_libraries(${executable} "-fsanitize=thread" "-fno-omit-frame-pointer")
+    target_link_libraries(
+      ${executable}
+      "-fsanitize=thread"
+      "-fno-omit-frame-pointer"
+    )
   endif()
   if (USE_PPROF)
     target_link_libraries(${executable} "-lprofiler")
+  endif()
+  if (USE_PCH)
+    add_precompiled_headers_to_target(${executable} ${OMIM_PCH_TARGET_NAME})
+  endif()
+endfunction()
+
+function(omim_add_library library)
+  add_library(${library} ${ARGN})
+  if (USE_PCH)
+    add_precompiled_headers_to_target(${library} ${OMIM_PCH_TARGET_NAME})
   endif()
 endfunction()
 
 function(omim_add_test executable)
   if (NOT SKIP_TESTS)
-    omim_add_executable(${executable} ${ARGN} ${OMIM_ROOT}/testing/testingmain.cpp)
+    omim_add_executable(
+      ${executable}
+      ${ARGN}
+      ${OMIM_ROOT}/testing/testingmain.cpp
+     )
   endif()
 endfunction()
 
@@ -80,7 +103,8 @@ function(omim_link_libraries target)
     target_link_libraries(${target} ${ARGN} ${CMAKE_THREAD_LIBS_INIT})
     omim_link_platform_deps(${target} ${ARGN})
   else()
-    message("~> Skipping linking the libraries to the target ${target} as it does not exist")
+    message("~> Skipping linking the libraries to the target ${target} as it"
+            " does not exist")
   endif()
 endfunction()
 
@@ -136,4 +160,138 @@ function(add_clang_compile_options)
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(${ARGV})
   endif()
+endfunction()
+
+function(export_directory_flags filename)
+  get_directory_property(include_directories INCLUDE_DIRECTORIES)
+  get_directory_property(definitions COMPILE_DEFINITIONS)
+  get_directory_property(flags COMPILE_FLAGS)
+  get_directory_property(options COMPILE_OPTIONS)
+
+  if (PLATFORM_ANDROID)
+    set(
+      include_directories
+      ${include_directories}
+      ${CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES}
+    )
+    set(
+      platform_flags
+      "${ANDROID_COMPILER_FLAGS} ${ANDROID_COMPILER_FLAGS_CXX}"
+    )
+    set(
+      flags
+      "--target=${CMAKE_C_COMPILER_TARGET}"
+      "--sysroot=${CMAKE_SYSROOT}" ${flags}
+    )
+  endif()
+
+  # Append Release/Debug flags:
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" upper_build_type)
+  set(flags ${flags} ${CMAKE_CXX_FLAGS_${upper_build_type}})
+
+  set(
+    include_directories
+    "$<$<BOOL:${include_directories}>\:-I$<JOIN:${include_directories},\n-I>\n>"
+  )
+  set(definitions "$<$<BOOL:${definitions}>:-D$<JOIN:${definitions},\n-D>\n>")
+  set(flags "$<$<BOOL:${flags}>:$<JOIN:${flags},\n>\n>")
+  set(options "$<$<BOOL:${options}>:$<JOIN:${options},\n>\n>")
+  file(
+    GENERATE OUTPUT
+    ${filename}
+    CONTENT
+    "${definitions}${include_directories}${platform_flags}\n${flags}${options}\n"
+  )
+endfunction()
+
+function(add_pic_pch_target header pch_target_name
+         pch_file_name suffix pic_flag)
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/pch_${suffix}")
+  file(COPY "${header}" DESTINATION "${CMAKE_BINARY_DIR}/pch_${suffix}")
+  set(_header "${CMAKE_BINARY_DIR}/pch_${suffix}/${pch_file_name}")
+  set(
+    _compiled_header
+    "${CMAKE_BINARY_DIR}/pch_${suffix}/${pch_file_name}.${PCH_EXTENSION}"
+  )
+  add_custom_target(
+    "${pch_target_name}_${suffix}"
+    COMMAND
+    "${CMAKE_CXX_COMPILER}" ${compiler_flags} ${c_standard_flags} ${pic_flag}
+                            -x c++-header
+                            -c "${_header}" -o "${_compiled_header}"
+    COMMENT "Building precompiled omim CXX ${suffix} header"
+  )
+endfunction()
+
+function(add_precompiled_headers header pch_target_name)
+  set(pch_flags_file "${CMAKE_BINARY_DIR}/${pch_target_name}_flags_file")
+  export_directory_flags("${pch_flags_file}")
+  set(compiler_flags "@${pch_flags_file}")
+
+  # CMAKE_CXX_STANDARD 14 flags:
+  set(c_standard_flags "-std=c++14" "-std=gnu++14")
+  get_filename_component(pch_file_name ${header} NAME)
+
+  add_pic_pch_target(${header} ${pch_target_name} ${pch_file_name} lib "-fPIC")
+  add_pic_pch_target(${header} ${pch_target_name} ${pch_file_name} exe "-fPIE")
+
+  add_custom_target(
+    "${pch_target_name}"
+    COMMENT "Waiting for both lib and exe precompiled headers to build"
+    DEPENDS "${pch_target_name}_lib" "${pch_target_name}_exe"
+  )
+  set_target_properties(
+    ${pch_target_name}
+    PROPERTIES
+    PCH_NAME
+    "${pch_file_name}"
+  )
+endfunction()
+
+function(add_precompiled_headers_to_target target pch_target)
+  add_dependencies(${target} "${pch_target}")
+  get_property(sources TARGET ${target} PROPERTY SOURCES)
+  get_target_property(target_type ${target} TYPE)
+  get_target_property(pch_file_name ${pch_target} PCH_NAME)
+
+  if (target_type STREQUAL "EXECUTABLE")
+    set(include_compiled_header_dir "${CMAKE_BINARY_DIR}/pch_exe")
+    # CMake automatically adds additional compile options after linking.
+    # For example '-fPIC' flag on skin_generator_tool, because it is linked to Qt libs.
+    # We force correct flag for executables.
+    set(additional_clang_flags "-fPIE")
+  endif()
+
+  if (target_type MATCHES "LIBRARY")
+    set(include_compiled_header_dir "${CMAKE_BINARY_DIR}/pch_lib")
+  endif()
+
+  # Force gcc first search gch header in pch_exe/pch_lib:
+  target_include_directories(
+    ${target}
+    BEFORE
+    PUBLIC
+    ${include_compiled_header_dir}
+  )
+
+  foreach(source ${sources})
+    if(source MATCHES \\.\(cc|cpp|h|hpp\)$)
+      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set_source_files_properties(
+          ${source}
+          PROPERTIES
+          COMPILE_FLAGS
+          "${additional_clang_flags} -include-pch \
+${include_compiled_header_dir}/${pch_file_name}.${PCH_EXTENSION}"
+        )
+      endif()
+      if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set_source_files_properties(
+          ${source}
+          PROPERTIES
+          COMPILE_FLAGS "-include ${pch_file_name}"
+        )
+      endif()
+    endif()
+  endforeach()
 endfunction()

--- a/coding/CMakeLists.txt
+++ b/coding/CMakeLists.txt
@@ -107,6 +107,6 @@ set(
   zlib.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(coding_tests)

--- a/drape/CMakeLists.txt
+++ b/drape/CMakeLists.txt
@@ -134,6 +134,6 @@ if (PLATFORM_IPHONE)
   )
 endif()
 
-add_library(${PROJECT_NAME} ${DRAPE_COMMON_SRC} ${SRC})
+omim_add_library(${PROJECT_NAME} ${DRAPE_COMMON_SRC} ${SRC})
 
 omim_add_test_subdirectory(drape_tests)

--- a/drape_frontend/CMakeLists.txt
+++ b/drape_frontend/CMakeLists.txt
@@ -220,7 +220,7 @@ set(
   visual_params.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 set(
   DRAPE_SHADERS_SRC

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -35,7 +35,7 @@ set(
   yes_no_unknown.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(editor_tests)
 omim_add_test_subdirectory(editor_tests_support)

--- a/editor/editor_tests_support/CMakeLists.txt
+++ b/editor/editor_tests_support/CMakeLists.txt
@@ -6,4 +6,4 @@ set(
   helpers.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -111,7 +111,7 @@ set(SRC
   world_map_generator.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(generator_tests_support)
 omim_add_test_subdirectory(generator_tests)

--- a/generator/generator_tests_support/CMakeLists.txt
+++ b/generator/generator_tests_support/CMakeLists.txt
@@ -10,4 +10,4 @@ set(
   test_mwm_builder.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/generator/mwm_diff/CMakeLists.txt
+++ b/generator/mwm_diff/CMakeLists.txt
@@ -6,7 +6,7 @@ set(
   diff.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_pybindings_subdirectory(pymwm_diff)
 omim_add_test_subdirectory(mwm_diff_tests)

--- a/generator/mwm_diff/pymwm_diff/CMakeLists.txt
+++ b/generator/mwm_diff/pymwm_diff/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -59,6 +59,6 @@ set(
   region2d/boost_concept.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(geometry_tests)

--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -135,7 +135,7 @@ set(
 
 file(COPY ${OTHER_FILES} DESTINATION ${CMAKE_BINARY_DIR})
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(indexer_tests_support)
 omim_add_test_subdirectory(indexer_tests)

--- a/indexer/indexer_tests_support/CMakeLists.txt
+++ b/indexer/indexer_tests_support/CMakeLists.txt
@@ -8,4 +8,4 @@ set(
   test_with_custom_mwms.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/kml/CMakeLists.txt
+++ b/kml/CMakeLists.txt
@@ -13,7 +13,7 @@ set(
   visitors.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_pybindings_subdirectory(pykmlib)
 omim_add_test_subdirectory(kml_tests)

--- a/kml/pykmlib/CMakeLists.txt
+++ b/kml/pykmlib/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/local_ads/CMakeLists.txt
+++ b/local_ads/CMakeLists.txt
@@ -20,7 +20,7 @@ set(
   statistics.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_pybindings_subdirectory(pylocal_ads)
 omim_add_test_subdirectory(local_ads_tests)

--- a/local_ads/pylocal_ads/CMakeLists.txt
+++ b/local_ads/pylocal_ads/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/map/CMakeLists.txt
+++ b/map/CMakeLists.txt
@@ -104,7 +104,7 @@ set(
   viewport_search_params.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(map_tests)
 omim_add_test_subdirectory(mwm_tests)

--- a/openlr/CMakeLists.txt
+++ b/openlr/CMakeLists.txt
@@ -35,7 +35,7 @@ set(
   way_point.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 add_subdirectory(openlr_match_quality)
 add_subdirectory(openlr_stat)
 omim_add_test_subdirectory(openlr_tests)

--- a/partners_api/CMakeLists.txt
+++ b/partners_api/CMakeLists.txt
@@ -49,6 +49,6 @@ set(
   yandex_api.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(partners_api_tests)

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 
 add_subdirectory(platform_tests_support)
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 if (APPLE)
   target_compile_options(${PROJECT_NAME} PUBLIC "-fobjc-arc")

--- a/platform/platform_tests_support/CMakeLists.txt
+++ b/platform/platform_tests_support/CMakeLists.txt
@@ -14,4 +14,4 @@ set(
   writable_dir_changer.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/precompiled_headers.hpp
+++ b/precompiled_headers.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "testing/testing.hpp"
+
+#include "platform/platform.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/macros.hpp"
+#include "base/stl_add.hpp"
+#include "base/string_utils.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>

--- a/qt/qt_common/CMakeLists.txt
+++ b/qt/qt_common/CMakeLists.txt
@@ -26,4 +26,4 @@ set(
   spinner.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC} ${RESOURCES})
+omim_add_library(${PROJECT_NAME} ${SRC} ${RESOURCES})

--- a/qt_tstfrm/CMakeLists.txt
+++ b/qt_tstfrm/CMakeLists.txt
@@ -6,4 +6,4 @@ set(
   test_main_loop.cpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -132,7 +132,7 @@ set(
   world_graph.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 omim_add_test_subdirectory(routing_tests)
 omim_add_test_subdirectory(routing_integration_tests)
 omim_add_test_subdirectory(routing_consistency_tests)

--- a/routing_common/CMakeLists.txt
+++ b/routing_common/CMakeLists.txt
@@ -17,5 +17,5 @@ set(
   vehicle_model.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 omim_add_test_subdirectory(routing_common_tests)

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -158,7 +158,7 @@ set(
   viewport_search_callback.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 if (PLATFORM_DESKTOP)
   add_subdirectory(search_quality)

--- a/search/pysearch/CMakeLists.txt
+++ b/search/pysearch/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}

--- a/search/search_quality/CMakeLists.txt
+++ b/search/search_quality/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SRC
   sample.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 if (NOT SKIP_DESKTOP)
   add_subdirectory(assessment_tool)

--- a/search/search_tests_support/CMakeLists.txt
+++ b/search/search_tests_support/CMakeLists.txt
@@ -11,4 +11,4 @@ set(
   test_with_custom_mwms.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/software_renderer/CMakeLists.txt
+++ b/software_renderer/CMakeLists.txt
@@ -40,4 +40,4 @@ set(
   text_engine.h
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif(${PLATFORM_ANDROID})
 
 endif()
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 if (${PLATFORM_IPHONE} OR ${PLATFORM_MAC})
   target_compile_options(${PROJECT_NAME} PUBLIC "-fobjc-arc")

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -44,7 +44,7 @@ set(
   storage_helpers.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_test_subdirectory(storage_tests)
 omim_add_test_subdirectory(storage_integration_tests)

--- a/track_analyzing/CMakeLists.txt
+++ b/track_analyzing/CMakeLists.txt
@@ -14,5 +14,5 @@ set(
   utils.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 add_subdirectory(track_analyzer)

--- a/tracking/CMakeLists.txt
+++ b/tracking/CMakeLists.txt
@@ -10,7 +10,7 @@ set(
   reporter.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_pybindings_subdirectory(pytracking)
 omim_add_test_subdirectory(tracking_tests)

--- a/tracking/pytracking/CMakeLists.txt
+++ b/tracking/pytracking/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(${PROJECT_NAME} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} tracking coding geometry base)
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/traffic/CMakeLists.txt
+++ b/traffic/CMakeLists.txt
@@ -10,7 +10,7 @@ set(
   traffic_info.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_add_pybindings_subdirectory(pytraffic)
 omim_add_test_subdirectory(traffic_tests)

--- a/traffic/pytraffic/CMakeLists.txt
+++ b/traffic/pytraffic/CMakeLists.txt
@@ -5,7 +5,7 @@ set(
   bindings.cpp
 )
 
-add_library(${PROJECT_NAME} MODULE ${SRC})
+omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 if (PLATFORM_MAC)
   omim_link_libraries(

--- a/transit/CMakeLists.txt
+++ b/transit/CMakeLists.txt
@@ -14,5 +14,5 @@ set(
   transit_types.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 omim_add_test_subdirectory(transit_tests)

--- a/ugc/CMakeLists.txt
+++ b/ugc/CMakeLists.txt
@@ -23,5 +23,5 @@ set(
   types.hpp
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+omim_add_library(${PROJECT_NAME} ${SRC})
 omim_add_test_subdirectory(ugc_tests)


### PR DESCRIPTION
## Abstract
Плюсовый фронтенд кланга для каждой единицы компиляции заново резолвит цепочки `include`'ов, подставляет макросы и разворачивает `ifdef` блоки.  Поскольку у нас относительно сильное зацепление внутри `omim`'а, было бы разумно попробовать использовать `precompiled headers` для ускорения процесса сборки.
## Precompiled headers
Я пробежался питонячим скриптом по проекту на предмет самых часто подключаемых хедеров:
```
header                         |   include count
----------------------------------------------------
vector                         |        369
testing/testing.hpp            |        358
string                         |        332
base/logging.hpp               |        319
base/assert.hpp                |        306
base/string_utils.hpp          |        212
geometry/point2d.hpp           |        210
...
```
Первые 20 из них, отсортированных по количеству подключений, я добавил в файл `precompiled.hpp` и включил поддержку на стороне `cmake`'а флагом `USE_PCH`.
`cmake ../{omim_dir} _DUSE_PCH=ON`

Бенчмарк для полной сборки проекта с тестами без биндингов показал экономию времени примерно 25%:
```
cmake ../omim
time make -j8

real	14m4.039s
user	102m38.929s
sys	6m0.149s

cmake ../omim -DUSE_PCH=ON
time make -j8

real    10m34.002s
user    76m11.089s
sys     4m41.070s
```
## Notes
Главный минус использования этой технологии - необходимость перекомпиляции всего `omim`'а(не включая `3party`), в случае внесения изменений в один из хедеров, включенных в `precompiled.hpp`.