### PR TITLE
Increasing pedestrian part for transit route to 50 minutes and 7 minutes per one km.

### DIFF
--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -66,9 +66,9 @@ private:
 
   static double MaxPedestrianTimeSec(double startToFinishDistanceM)
   {
-    // @todo(tatiana-kondakova) test and adjust constants.
-    // 25 min + 3 additional minutes per 1 km for now.
-    return 25 * 60 + (startToFinishDistanceM / 1000) * 3 * 60;
+    // @todo(bykoianko) test and adjust constants.
+    // 50 min + 3 additional minutes per 1 km for now.
+    return 50 * 60 + (startToFinishDistanceM / 1000) * 3 * 60;
   }
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);


### PR DESCRIPTION
До этого PR, если пешеходная часть маршрута общественного транспорта превышала 25 минут + 3 минут на каждый км от расстояния по прямой между стартом и финишем, мы давали ошибку прокладки маршрута общественным транспортом.

После этого PR мы дадим ошибку, если пешая часть превысит 50 минут + 3 минуты на км.

@tatiana-yan @burivuh PTAL

