### PR TITLE
 [routing] Taking into account road surface type for speed calculating.

### DIFF
--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -201,7 +201,7 @@ UNIT_TEST(RussiaTaganrogSyzranov10k3ToTruseE)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2183, 38.8634), {0., 0.},
-      MercatorBounds::FromLatLon(47.2048, 38.9441), 7463.);
+      MercatorBounds::FromLatLon(47.2048, 38.9441), 7994.0);
 }
 
 UNIT_TEST(RussiaTaganrogSyzranov10k3ToLazo5k2)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -401,4 +401,22 @@ namespace
     IRouter::ResultCode const result = routeResult.second;
     TEST_EQUAL(result, IRouter::NoError, ());
   }
+
+  // Test on decreasing speed factor on roads with bad cover.
+  UNIT_TEST(RussiaLenOblSpeedFactorsTest)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(60.23884, 29.71603), {0.0, 0.0},
+        MercatorBounds::FromLatLon(60.28975, 29.79399), 11618.1);
+  }
+
+  // Test on decreasing speed factor on roads with bad cover.
+  UNIT_TEST(RussiaMosOblSpeedFactorsTest)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(55.93843, 36.02782), {0., 0.},
+        MercatorBounds::FromLatLon(55.9375, 36.04195), 4819.1);
+  }
 }  // namespace

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -402,7 +402,7 @@ namespace
     TEST_EQUAL(result, IRouter::NoError, ());
   }
 
-  // Test on decreasing speed factor on roads with bad cover.
+  // Test of decreasing speed factor on roads with bad cover.
   UNIT_TEST(RussiaLenOblSpeedFactorsTest)
   {
     integration::CalculateRouteAndTestRouteLength(
@@ -411,7 +411,7 @@ namespace
         MercatorBounds::FromLatLon(60.28975, 29.79399), 11618.1);
   }
 
-  // Test on decreasing speed factor on roads with bad cover.
+  // Test of decreasing speed factor on roads with bad cover.
   UNIT_TEST(RussiaMosOblSpeedFactorsTest)
   {
     integration::CalculateRouteAndTestRouteLength(

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -422,7 +422,7 @@ VehicleModel::SurfaceInitList const g_bicycleSurface = {
     {{"psurface", "paved_good"}, 1.0},
     {{"psurface", "paved_bad"}, 0.8},
     {{"psurface", "unpaved_good"}, 1.0},
-    {{"psurface", "unpaved_bad"}, 0.6},
+    {{"psurface", "unpaved_bad"}, 0.3},
 };
 }  // namespace
 

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -53,7 +53,7 @@ double constexpr kSpeedOffroadKMpH = 3.0;
 double constexpr kSpeedFerry = 3.0;
 
 // Default
-VehicleModel::InitListT const g_bicycleLimitsDefault =
+VehicleModel::LimitsInitList const g_bicycleLimitsDefault =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true /* passThroughAllowed */ },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -76,7 +76,7 @@ VehicleModel::InitListT const g_bicycleLimitsDefault =
 };
 
 // All options available.
-VehicleModel::InitListT const g_bicycleLimitsAll =
+VehicleModel::LimitsInitList const g_bicycleLimitsAll =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -102,7 +102,7 @@ VehicleModel::InitListT const g_bicycleLimitsAll =
 };
 
 // Same as defaults except trunk and trunk_link are not allowed
-VehicleModel::InitListT const g_bicycleLimitsNoTrunk =
+VehicleModel::LimitsInitList const g_bicycleLimitsNoTrunk =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH,       true },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH,   true },
@@ -123,7 +123,7 @@ VehicleModel::InitListT const g_bicycleLimitsNoTrunk =
 };
 
 // Same as defaults except pedestrian is allowed
-VehicleModel::InitListT const g_bicycleLimitsPedestrianAllowed =
+VehicleModel::LimitsInitList const g_bicycleLimitsPedestrianAllowed =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -147,7 +147,7 @@ VehicleModel::InitListT const g_bicycleLimitsPedestrianAllowed =
 };
 
 // Same as defaults except bridleway is allowed
-VehicleModel::InitListT const g_bicycleLimitsBridlewayAllowed =
+VehicleModel::LimitsInitList const g_bicycleLimitsBridlewayAllowed =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -171,10 +171,10 @@ VehicleModel::InitListT const g_bicycleLimitsBridlewayAllowed =
 };
 
 // Australia
-VehicleModel::InitListT const g_bicycleLimitsAustralia = g_bicycleLimitsAll;
+VehicleModel::LimitsInitList const g_bicycleLimitsAustralia = g_bicycleLimitsAll;
 
 // Austria
-VehicleModel::InitListT const g_bicycleLimitsAustria =
+VehicleModel::LimitsInitList const g_bicycleLimitsAustria =
 {
   // No trunk, trunk_link, path
   { {"highway", "primary"},        kSpeedPrimaryKMpH,       true },
@@ -195,7 +195,7 @@ VehicleModel::InitListT const g_bicycleLimitsAustria =
 };
 
 // Belarus
-VehicleModel::InitListT const g_bicycleLimitsBelarus =
+VehicleModel::LimitsInitList const g_bicycleLimitsBelarus =
 {
   // Footway and pedestrian are allowed
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
@@ -221,7 +221,7 @@ VehicleModel::InitListT const g_bicycleLimitsBelarus =
 };
 
 // Belgium
-VehicleModel::InitListT const g_bicycleLimitsBelgium =
+VehicleModel::LimitsInitList const g_bicycleLimitsBelgium =
 {
   // No trunk, trunk_link
   // Pedestrian is allowed
@@ -245,7 +245,7 @@ VehicleModel::InitListT const g_bicycleLimitsBelgium =
 };
 
 // Brazil
-VehicleModel::InitListT const g_bicycleLimitsBrazil =
+VehicleModel::LimitsInitList const g_bicycleLimitsBrazil =
 {
   // Bridleway and fotway are allowed
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
@@ -271,10 +271,10 @@ VehicleModel::InitListT const g_bicycleLimitsBrazil =
 };
 
 // Denmark
-VehicleModel::InitListT const g_bicycleLimitsDenmark = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsDenmark = g_bicycleLimitsNoTrunk;
 
 // France
-VehicleModel::InitListT const g_bicycleLimitsFrance =
+VehicleModel::LimitsInitList const g_bicycleLimitsFrance =
 {
   // No trunk, trunk_link
   // Pedestrian is allowed
@@ -298,34 +298,34 @@ VehicleModel::InitListT const g_bicycleLimitsFrance =
 };
 
 // Finland
-VehicleModel::InitListT const g_bicycleLimitsFinland = g_bicycleLimitsPedestrianAllowed;
+VehicleModel::LimitsInitList const g_bicycleLimitsFinland = g_bicycleLimitsPedestrianAllowed;
 
 // Germany
-VehicleModel::InitListT const g_bicycleLimitsGermany = g_bicycleLimitsDefault;
+VehicleModel::LimitsInitList const g_bicycleLimitsGermany = g_bicycleLimitsDefault;
 
 // Hungary
-VehicleModel::InitListT const g_bicycleLimitsHungary = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsHungary = g_bicycleLimitsNoTrunk;
 
 // Iceland
-VehicleModel::InitListT const g_bicycleLimitsIceland = g_bicycleLimitsAll;
+VehicleModel::LimitsInitList const g_bicycleLimitsIceland = g_bicycleLimitsAll;
 
 // Netherlands
-VehicleModel::InitListT const g_bicycleLimitsNetherlands = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsNetherlands = g_bicycleLimitsNoTrunk;
 
 // Norway
-VehicleModel::InitListT const g_bicycleLimitsNorway = g_bicycleLimitsAll;
+VehicleModel::LimitsInitList const g_bicycleLimitsNorway = g_bicycleLimitsAll;
 
 // Oman
-VehicleModel::InitListT const g_bicycleLimitsOman = g_bicycleLimitsBridlewayAllowed;
+VehicleModel::LimitsInitList const g_bicycleLimitsOman = g_bicycleLimitsBridlewayAllowed;
 
 // Poland
-VehicleModel::InitListT const g_bicycleLimitsPoland = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsPoland = g_bicycleLimitsNoTrunk;
 
 // Romania
-VehicleModel::InitListT const g_bicycleLimitsRomania = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsRomania = g_bicycleLimitsNoTrunk;
 
 // Russian Federation
-VehicleModel::InitListT const g_bicycleLimitsRussia =
+VehicleModel::LimitsInitList const g_bicycleLimitsRussia =
 {
   // Footway and pedestrian are allowed
   // No pass through service and living_street
@@ -352,19 +352,19 @@ VehicleModel::InitListT const g_bicycleLimitsRussia =
 };
 
 // Slovakia
-VehicleModel::InitListT const g_bicycleLimitsSlovakia = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsSlovakia = g_bicycleLimitsNoTrunk;
 
 // Spain
-VehicleModel::InitListT const g_bicycleLimitsSpain = g_bicycleLimitsPedestrianAllowed;
+VehicleModel::LimitsInitList const g_bicycleLimitsSpain = g_bicycleLimitsPedestrianAllowed;
 
 // Switzerland
-VehicleModel::InitListT const g_bicycleLimitsSwitzerland = g_bicycleLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_bicycleLimitsSwitzerland = g_bicycleLimitsNoTrunk;
 
 // Turkey
-VehicleModel::InitListT const g_bicycleLimitsTurkey = g_bicycleLimitsDefault;
+VehicleModel::LimitsInitList const g_bicycleLimitsTurkey = g_bicycleLimitsDefault;
 
 // Ukraine
-VehicleModel::InitListT const g_bicycleLimitsUkraine =
+VehicleModel::LimitsInitList const g_bicycleLimitsUkraine =
 {
   // No trunk
   // Footway and perestrian are allowed
@@ -390,10 +390,10 @@ VehicleModel::InitListT const g_bicycleLimitsUkraine =
 };
 
 // United Kingdom
-VehicleModel::InitListT const g_bicycleLimitsUK = g_bicycleLimitsBridlewayAllowed;
+VehicleModel::LimitsInitList const g_bicycleLimitsUK = g_bicycleLimitsBridlewayAllowed;
 
 // United States of America
-VehicleModel::InitListT const g_bicycleLimitsUS =
+VehicleModel::LimitsInitList const g_bicycleLimitsUS =
 {
   // Bridleway and pedesprian are allowed
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
@@ -418,14 +418,23 @@ VehicleModel::InitListT const g_bicycleLimitsUS =
   { {"highway", "platform"},       kSpeedPlatformKMpH,      true },
 };
 
+VehicleModel::SurfaceInitList const g_bicycleSurface = {
+    {{"psurface", "paved_good"}, 1.0},
+    {{"psurface", "paved_bad"}, 0.8},
+    {{"psurface", "unpaved_good"}, 1.0},
+    {{"psurface", "unpaved_bad"}, 0.6},
+};
 }  // namespace
 
 namespace routing
 {
-BicycleModel::BicycleModel() : VehicleModel(classif(), g_bicycleLimitsDefault) { Init(); }
+BicycleModel::BicycleModel() : VehicleModel(classif(), g_bicycleLimitsDefault, g_bicycleSurface)
+{
+  Init();
+}
 
-BicycleModel::BicycleModel(VehicleModel::InitListT const & speedLimits)
-  : VehicleModel(classif(), speedLimits)
+BicycleModel::BicycleModel(VehicleModel::LimitsInitList const & speedLimits)
+  : VehicleModel(classif(), speedLimits, g_bicycleSurface)
 {
   Init();
 }

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -9,7 +9,7 @@ class BicycleModel : public VehicleModel
 {
 public:
   BicycleModel();
-  BicycleModel(VehicleModel::InitListT const & speedLimits);
+  BicycleModel(VehicleModel::LimitsInitList const & speedLimits);
 
   /// VehicleModelInterface overrides:
   bool IsOneWay(FeatureType const & f) const override;

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -202,9 +202,9 @@ vector<VehicleModel::AdditionalRoadTags> const kAdditionalTags = {
 
 VehicleModel::SurfaceInitList const g_carSurface = {
     {{"psurface", "paved_good"}, 1.0},
-    {{"psurface", "paved_bad"}, 0.6},
+    {{"psurface", "paved_bad"}, 0.5},
     {{"psurface", "unpaved_good"}, 0.8},
-    {{"psurface", "unpaved_bad"}, 0.4},
+    {{"psurface", "unpaved_bad"}, 0.3},
 };
 }  // namespace
 

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -40,7 +40,7 @@ double constexpr kSpeedShuttleTrainKMpH = 25.0;
 double constexpr kSpeedPierKMpH = 10.0;
 double constexpr kSpeedOffroadKMpH = 10.0;
 
-VehicleModel::InitListT const g_carLimitsDefault =
+VehicleModel::LimitsInitList const g_carLimitsDefault =
 {
     {{"highway", "motorway"},       kSpeedMotorwayKMpH,      true /* passThroughAllowed */ },
     {{"highway", "motorway_link"},  kSpeedMotorwayLinkKMpH,  true},
@@ -66,7 +66,7 @@ VehicleModel::InitListT const g_carLimitsDefault =
     //{ {"highway", "construction"},   40 },
 };
 
-VehicleModel::InitListT const g_carLimitsNoPassThroughLivingStreet =
+VehicleModel::LimitsInitList const g_carLimitsNoPassThroughLivingStreet =
 {
     {{"highway", "motorway"},       kSpeedMotorwayKMpH,      true},
     {{"highway", "motorway_link"},  kSpeedMotorwayLinkKMpH,  true},
@@ -86,7 +86,7 @@ VehicleModel::InitListT const g_carLimitsNoPassThroughLivingStreet =
     {{"highway", "track"},          kSpeedTrackKMpH,         true},
 };
 
-VehicleModel::InitListT const g_carLimitsNoPassThroughLivingStreetAndService =
+VehicleModel::LimitsInitList const g_carLimitsNoPassThroughLivingStreetAndService =
 {
     {{"highway", "motorway"},       kSpeedMotorwayKMpH,      true},
     {{"highway", "motorway_link"},  kSpeedMotorwayLinkKMpH,  true},
@@ -106,17 +106,17 @@ VehicleModel::InitListT const g_carLimitsNoPassThroughLivingStreetAndService =
     {{"highway", "track"},          kSpeedTrackKMpH,         true},
 };
 
-VehicleModel::InitListT const g_carLimitsAustralia = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsAustralia = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsAustria = g_carLimitsNoPassThroughLivingStreet;
+VehicleModel::LimitsInitList const g_carLimitsAustria = g_carLimitsNoPassThroughLivingStreet;
 
-VehicleModel::InitListT const g_carLimitsBelarus = g_carLimitsNoPassThroughLivingStreet;
+VehicleModel::LimitsInitList const g_carLimitsBelarus = g_carLimitsNoPassThroughLivingStreet;
 
-VehicleModel::InitListT const g_carLimitsBelgium = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsBelgium = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsBrazil = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsBrazil = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsDenmark =
+VehicleModel::LimitsInitList const g_carLimitsDenmark =
 {
     // No track
     {{"highway", "motorway"},       kSpeedMotorwayKMpH,      true},
@@ -136,11 +136,11 @@ VehicleModel::InitListT const g_carLimitsDenmark =
     {{"highway", "road"},           kSpeedRoadKMpH,          true},
 };
 
-VehicleModel::InitListT const g_carLimitsFrance = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsFrance = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsFinland = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsFinland = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsGermany = 
+VehicleModel::LimitsInitList const g_carLimitsGermany =
 {
     // No pass through track
     {{"highway", "motorway"},       kSpeedMotorwayKMpH,      true},
@@ -161,35 +161,35 @@ VehicleModel::InitListT const g_carLimitsGermany =
     {{"highway", "track"},          kSpeedTrackKMpH,         false},
 };
 
-VehicleModel::InitListT const g_carLimitsHungary = g_carLimitsNoPassThroughLivingStreet;
+VehicleModel::LimitsInitList const g_carLimitsHungary = g_carLimitsNoPassThroughLivingStreet;
 
-VehicleModel::InitListT const g_carLimitsIceland = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsIceland = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsNetherlands = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsNetherlands = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsNorway = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsNorway = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsOman = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsOman = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsPoland = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsPoland = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsRomania = g_carLimitsNoPassThroughLivingStreet;
+VehicleModel::LimitsInitList const g_carLimitsRomania = g_carLimitsNoPassThroughLivingStreet;
 
-VehicleModel::InitListT const g_carLimitsRussia = g_carLimitsNoPassThroughLivingStreetAndService;
+VehicleModel::LimitsInitList const g_carLimitsRussia = g_carLimitsNoPassThroughLivingStreetAndService;
 
-VehicleModel::InitListT const g_carLimitsSlovakia = g_carLimitsNoPassThroughLivingStreet;
+VehicleModel::LimitsInitList const g_carLimitsSlovakia = g_carLimitsNoPassThroughLivingStreet;
 
-VehicleModel::InitListT const g_carLimitsSpain = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsSpain = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsSwitzerland = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsSwitzerland = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsTurkey = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsTurkey = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsUkraine = g_carLimitsNoPassThroughLivingStreetAndService;
+VehicleModel::LimitsInitList const g_carLimitsUkraine = g_carLimitsNoPassThroughLivingStreetAndService;
 
-VehicleModel::InitListT const g_carLimitsUK = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsUK = g_carLimitsDefault;
 
-VehicleModel::InitListT const g_carLimitsUS = g_carLimitsDefault;
+VehicleModel::LimitsInitList const g_carLimitsUS = g_carLimitsDefault;
 
 vector<VehicleModel::AdditionalRoadTags> const kAdditionalTags = {
     {{"route", "ferry", "motorcar"}, kSpeedFerryMotorcarKMpH},
@@ -200,19 +200,25 @@ vector<VehicleModel::AdditionalRoadTags> const kAdditionalTags = {
     {{"man_made", "pier"}, kSpeedPierKMpH},
 };
 
+VehicleModel::SurfaceInitList const g_carSurface = {
+    {{"psurface", "paved_good"}, 1.0},
+    {{"psurface", "paved_bad"}, 0.6},
+    {{"psurface", "unpaved_good"}, 0.8},
+    {{"psurface", "unpaved_bad"}, 0.4},
+};
 }  // namespace
 
 namespace routing
 {
 
 CarModel::CarModel()
-  : VehicleModel(classif(), g_carLimitsDefault)
+  : VehicleModel(classif(), g_carLimitsDefault, g_carSurface)
 {
   InitAdditionalRoadTypes();
 }
 
-CarModel::CarModel(VehicleModel::InitListT const & roadLimits)
-  : VehicleModel(classif(), roadLimits)
+CarModel::CarModel(VehicleModel::LimitsInitList const & roadLimits)
+  : VehicleModel(classif(), roadLimits, g_carSurface)
 {
   InitAdditionalRoadTypes();
 }
@@ -232,7 +238,7 @@ CarModel const & CarModel::AllLimitsInstance()
 }
 
 // static
-routing::VehicleModel::InitListT const & CarModel::GetLimits() { return g_carLimitsDefault; }
+routing::VehicleModel::LimitsInitList const & CarModel::GetLimits() { return g_carLimitsDefault; }
 // static
 vector<routing::VehicleModel::AdditionalRoadTags> const & CarModel::GetAdditionalTags()
 {

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -9,13 +9,13 @@ class CarModel : public VehicleModel
 {
 public:
   CarModel();
-  CarModel(VehicleModel::InitListT const & roadLimits);
+  CarModel(VehicleModel::LimitsInitList const & roadLimits);
 
   // VehicleModelInterface overrides
   double GetOffroadSpeed() const override;
 
   static CarModel const & AllLimitsInstance();
-  static InitListT const & GetLimits();
+  static LimitsInitList const & GetLimits();
   static std::vector<AdditionalRoadTags> const & GetAdditionalTags();
 
 private:

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -53,7 +53,7 @@ double constexpr kSpeedOffroadKMpH = 3.0;
 double constexpr kSpeedFerry = 1.0;
 
 // Default
-VehicleModel::InitListT const g_pedestrianLimitsDefault =
+VehicleModel::LimitsInitList const g_pedestrianLimitsDefault =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true /* passThroughAllowed */ },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -77,7 +77,7 @@ VehicleModel::InitListT const g_pedestrianLimitsDefault =
 };
 
 // All options available.
-VehicleModel::InitListT const g_pedestrianLimitsAll =
+VehicleModel::LimitsInitList const g_pedestrianLimitsAll =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -103,7 +103,7 @@ VehicleModel::InitListT const g_pedestrianLimitsAll =
 };
 
 // Same as defaults except trunk and trunk link are not allowed.
-VehicleModel::InitListT const g_pedestrianLimitsNoTrunk =
+VehicleModel::LimitsInitList const g_pedestrianLimitsNoTrunk =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH,       true },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH,   true },
@@ -126,7 +126,7 @@ VehicleModel::InitListT const g_pedestrianLimitsNoTrunk =
 };
 
 // Same as defaults except cycleway is allowed.
-VehicleModel::InitListT const g_pedestrianLimitsCyclewayAllowed =
+VehicleModel::LimitsInitList const g_pedestrianLimitsCyclewayAllowed =
 {
   { {"highway", "trunk"},          kSpeedTrunkKMpH,         true },
   { {"highway", "trunk_link"},     kSpeedTrunkLinkKMpH,     true },
@@ -151,7 +151,7 @@ VehicleModel::InitListT const g_pedestrianLimitsCyclewayAllowed =
 };
 
 // Same as defaults except cycleway is allowed and trunk and trunk_link are not allowed.
-VehicleModel::InitListT const g_pedestrianLimitsCyclewayAllowedNoTrunk =
+VehicleModel::LimitsInitList const g_pedestrianLimitsCyclewayAllowedNoTrunk =
 {
   { {"highway", "primary"},        kSpeedPrimaryKMpH,       true },
   { {"highway", "primary_link"},   kSpeedPrimaryLinkKMpH,   true },
@@ -174,16 +174,16 @@ VehicleModel::InitListT const g_pedestrianLimitsCyclewayAllowedNoTrunk =
 };
 
 // Australia
-VehicleModel::InitListT const g_pedestrianLimitsAustralia = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsAustralia = g_pedestrianLimitsAll;
 
 // Austria
-VehicleModel::InitListT const g_pedestrianLimitsAustria = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsAustria = g_pedestrianLimitsNoTrunk;
 
 // Belarus
-VehicleModel::InitListT const g_pedestrianLimitsBelarus = g_pedestrianLimitsCyclewayAllowed;
+VehicleModel::LimitsInitList const g_pedestrianLimitsBelarus = g_pedestrianLimitsCyclewayAllowed;
 
 // Belgium
-VehicleModel::InitListT const g_pedestrianLimitsBelgium =
+VehicleModel::LimitsInitList const g_pedestrianLimitsBelgium =
 {
   // Trunk and trunk_link are not allowed
   // Bridleway and cycleway are allowed
@@ -209,73 +209,83 @@ VehicleModel::InitListT const g_pedestrianLimitsBelgium =
 };
 
 // Brazil
-VehicleModel::InitListT const g_pedestrianLimitsBrazil = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsBrazil = g_pedestrianLimitsAll;
 
 // Denmark
-VehicleModel::InitListT const g_pedestrianLimitsDenmark = g_pedestrianLimitsCyclewayAllowedNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsDenmark = g_pedestrianLimitsCyclewayAllowedNoTrunk;
 
 // France
-VehicleModel::InitListT const g_pedestrianLimitsFrance = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsFrance = g_pedestrianLimitsNoTrunk;
 
 // Finland
-VehicleModel::InitListT const g_pedestrianLimitsFinland = g_pedestrianLimitsCyclewayAllowed;
+VehicleModel::LimitsInitList const g_pedestrianLimitsFinland = g_pedestrianLimitsCyclewayAllowed;
 
 // Germany
-VehicleModel::InitListT const g_pedestrianLimitsGermany = g_pedestrianLimitsDefault;
+VehicleModel::LimitsInitList const g_pedestrianLimitsGermany = g_pedestrianLimitsDefault;
 
 // Hungary
-VehicleModel::InitListT const g_pedestrianLimitsHungary = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsHungary = g_pedestrianLimitsNoTrunk;
 
 // Iceland
-VehicleModel::InitListT const g_pedestrianLimitsIceland = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsIceland = g_pedestrianLimitsAll;
 
 // Netherlands
-VehicleModel::InitListT const g_pedestrianLimitsNetherlands = g_pedestrianLimitsCyclewayAllowedNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsNetherlands = g_pedestrianLimitsCyclewayAllowedNoTrunk;
 
 // Norway
-VehicleModel::InitListT const g_pedestrianLimitsNorway = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsNorway = g_pedestrianLimitsAll;
 
 // Oman
-VehicleModel::InitListT const g_pedestrianLimitsOman = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsOman = g_pedestrianLimitsAll;
 
 // Poland
-VehicleModel::InitListT const g_pedestrianLimitsPoland = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsPoland = g_pedestrianLimitsNoTrunk;
 
 // Romania
-VehicleModel::InitListT const g_pedestrianLimitsRomania = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsRomania = g_pedestrianLimitsNoTrunk;
 
 // Russian Federation
-VehicleModel::InitListT const g_pedestrianLimitsRussia = g_pedestrianLimitsCyclewayAllowed;
+VehicleModel::LimitsInitList const g_pedestrianLimitsRussia = g_pedestrianLimitsCyclewayAllowed;
 
 // Slovakia
-VehicleModel::InitListT const g_pedestrianLimitsSlovakia = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsSlovakia = g_pedestrianLimitsNoTrunk;
 
 // Spain
-VehicleModel::InitListT const g_pedestrianLimitsSpain = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsSpain = g_pedestrianLimitsNoTrunk;
 
 // Switzerland
-VehicleModel::InitListT const g_pedestrianLimitsSwitzerland = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsSwitzerland = g_pedestrianLimitsNoTrunk;
 
 // Turkey
-VehicleModel::InitListT const g_pedestrianLimitsTurkey = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsTurkey = g_pedestrianLimitsAll;
 
 // Ukraine
-VehicleModel::InitListT const g_pedestrianLimitsUkraine = g_pedestrianLimitsNoTrunk;
+VehicleModel::LimitsInitList const g_pedestrianLimitsUkraine = g_pedestrianLimitsNoTrunk;
 
 // United Kingdom
-VehicleModel::InitListT const g_pedestrianLimitsUK = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsUK = g_pedestrianLimitsAll;
 
 // United States of America
-VehicleModel::InitListT const g_pedestrianLimitsUS = g_pedestrianLimitsAll;
+VehicleModel::LimitsInitList const g_pedestrianLimitsUS = g_pedestrianLimitsAll;
 
+VehicleModel::SurfaceInitList const g_pedestrianSurface = {
+    {{"psurface", "paved_good"}, 1.0},
+    {{"psurface", "paved_bad"}, 1.0},
+    {{"psurface", "unpaved_good"}, 1.0},
+    {{"psurface", "unpaved_bad"}, 0.8},
+};
 }  // namespace
 
 namespace routing
 {
-PedestrianModel::PedestrianModel() : VehicleModel(classif(), g_pedestrianLimitsDefault) { Init(); }
+PedestrianModel::PedestrianModel()
+  : VehicleModel(classif(), g_pedestrianLimitsDefault, g_pedestrianSurface)
+{
+  Init();
+}
 
-PedestrianModel::PedestrianModel(VehicleModel::InitListT const & speedLimits)
-  : VehicleModel(classif(), speedLimits)
+PedestrianModel::PedestrianModel(VehicleModel::LimitsInitList const & speedLimits)
+  : VehicleModel(classif(), speedLimits, g_pedestrianSurface)
 {
   Init();
 }

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -9,7 +9,7 @@ class PedestrianModel : public VehicleModel
 {
 public:
   PedestrianModel();
-  PedestrianModel(VehicleModel::InitListT const & speedLimits);
+  PedestrianModel(VehicleModel::LimitsInitList const & speedLimits);
 
   /// VehicleModelInterface overrides:
   bool IsOneWay(FeatureType const &) const override { return false; }

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -10,7 +10,7 @@
 
 namespace
 {
-routing::VehicleModel::InitListT const s_testLimits = {
+routing::VehicleModel::LimitsInitList const s_testLimits = {
     {{"highway", "trunk"}, 150, true},
     {{"highway", "primary"}, 120, true},
     {{"highway", "secondary"}, 80, true},

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -165,7 +165,7 @@ bool VehicleModel::HasPassThroughType(feature::TypesHolder const & types) const
 bool VehicleModel::IsRoadType(uint32_t type) const
 {
   return FindRoadType(type) != m_addRoadTypes.cend() ||
-      m_highwayTypes.find(ftypes::BaseChecker::PrepareToMatch(type, 2)) != m_highwayTypes.end();
+         m_highwayTypes.find(ftypes::BaseChecker::PrepareToMatch(type, 2)) != m_highwayTypes.end();
 }
 
 VehicleModelInterface::RoadAvailability VehicleModel::GetRoadAvailability(feature::TypesHolder const & /* types */) const

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -5,6 +5,7 @@
 #include "indexer/ftypes_matcher.hpp"
 
 #include "base/macros.hpp"
+#include "base/math.hpp"
 
 #include <algorithm>
 
@@ -42,7 +43,13 @@ VehicleModel::VehicleModel(Classificator const & c, LimitsInitList const & featu
 
   size_t i = 0;
   for (auto const & v : featureTypeSurface)
-    m_surfaceFactors[i++] = {c.GetTypeByPath(vector<string>(v.m_types, v.m_types + 2)), v.m_speedFactor};
+  {
+    ASSERT_LESS_OR_EQUAL(v.m_speedFactor, 1.0, ());
+    ASSERT_GREATER_OR_EQUAL(v.m_speedFactor, 0.0, ());
+    double const speedFactor = my::clamp(v.m_speedFactor, 0.0, 1.0);
+    m_surfaceFactors[i++] = {c.GetTypeByPath(vector<string>(v.m_types, v.m_types + 2)),
+                             speedFactor};
+  }
 }
 
 void VehicleModel::SetAdditionalRoadTypes(Classificator const & c,
@@ -89,7 +96,7 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
     if (itFactor != m_surfaceFactors.cend())
       speedFactor = min(speedFactor, itFactor->m_factor);
   }
-  
+
   if (speed <= m_maxSpeedKMpH && speedFactor <= 1.0)
     return speed * speedFactor;
 

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -83,8 +83,8 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
   for (uint32_t t : types)
   {
     uint32_t const type = ftypes::BaseChecker::PrepareToMatch(t, 2);
-    auto itHighway = m_highwayTypes.find(type);
-    if (itHighway != m_highwayTypes.end())
+    auto const itHighway = m_highwayTypes.find(type);
+    if (itHighway != m_highwayTypes.cend())
       speed = min(speed, itHighway->second.GetSpeedKMpH());
 
     auto const addRoadInfoIter = FindRoadType(t);

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -97,7 +97,8 @@ double VehicleModel::GetMinTypeSpeed(feature::TypesHolder const & types) const
       speedFactor = min(speedFactor, itFactor->m_factor);
   }
 
-  if (speed <= m_maxSpeedKMpH && speedFactor <= 1.0)
+  ASSERT_LESS_OR_EQUAL(speedFactor, 1.0, ());
+  if (speed <= m_maxSpeedKMpH)
     return speed * speedFactor;
 
   return 0.0 /* Speed */;

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -81,9 +81,9 @@ public:
   // psurface|unpaved_good and psurface|unpaved_bad.
   struct FeatureTypeSurface
   {
-    char const * m_types[2];      // 2-arity road type
-    double m_speedFactor;         // Factor (lowering) which reduces speed on feature in case of
-                                  // bad pavement. It should be from 0.0 to 1.0.
+    char const * m_types[2];  // 2-arity road type
+    double m_speedFactor;     // Factor (lowering) which reduces speed on feature in case of
+                              // bad pavement. It should be from 0.0 to 1.0.
   };
 
   struct AdditionalRoadTags final
@@ -129,8 +129,7 @@ public:
 
   bool EqualsForTests(VehicleModel const & rhs) const
   {
-    return (m_highwayTypes == rhs.m_highwayTypes) &&
-           (m_addRoadTypes == rhs.m_addRoadTypes) &&
+    return (m_highwayTypes == rhs.m_highwayTypes) && (m_addRoadTypes == rhs.m_addRoadTypes) &&
            (m_onewayType == rhs.m_onewayType);
   }
 

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -82,7 +82,7 @@ public:
   struct FeatureTypeSurface
   {
     char const * m_types[2];  // 2-arity road type
-    double m_speedFactor;     // Factor (lowering) which reduces speed on feature in case of
+    double m_speedFactor;     // Factor which reduces speed on feature in case of
                               // bad pavement. It should be from 0.0 to 1.0.
   };
 


### PR DESCRIPTION
Учет дорожного покрытия при расчете скорости на фиче.

В мае 2016 @Zverik в геометрию (а не в meta data) добавил св-во:
psurface|paved_good
psurface|paved_bad
psurface|unpaved_good
psurface|unpaved_bad

Т.о. любая дорога может содержать информацию о качестве покрытия, которая влияет на скорость на данной дороге.

Данный PR вводит понижающие коэффициент для каждого типа покрытий. Т.е. скорость на фиче рассчитывается (грубо), как скорость заданная для highway класса умножить на понижающей коэффициент. 

Заданы отдельные наборы коэффициентов  для авто, вело и пешего роутинга.

@tatiana-yan @mpimenov @Zverik PTAL