### PR TITLE
[search] Fix index build for categories which are deeper than 3 levels

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -106,13 +106,24 @@ void GetCategoryTypes(CategoriesHolder const & categories, pair<int, int> const 
 
   for (uint32_t t : types)
   {
-    // Leave only 2 levels of types - for example, do not distinguish:
-    // highway-primary-bridge and highway-primary-tunnel
-    // or amenity-parking-fee and amenity-parking-underground-fee.
-    ftype::TruncValue(t, 2);
+    // Truncate |t| up to 2 levels and choose the best category match to find explicit category if
+    // any and not distinguish types like highway-primary-bridge and highway-primary-tunnel or
+    // amenity-parking-fee and amenity-parking-underground-fee if we do not have such explicit
+    // categories.
+
+    bool found = false;
+    for (uint8_t level = ftype::GetLevel(t); level >= 2; --level)
+    {
+      ftype::TruncValue(t, level);
+      if (categories.IsTypeExist(t))
+      {
+        found = true;
+        break;
+      }
+    }
 
     // Only categorized types will be added to index.
-    if (!categories.IsTypeExist(t))
+    if (!found)
       continue;
 
     // There are some special non-drawable types we plan to search on.

--- a/indexer/indexer_tests_support/test_with_custom_mwms.hpp
+++ b/indexer/indexer_tests_support/test_with_custom_mwms.hpp
@@ -57,6 +57,20 @@ public:
     return id;
   }
 
+  void DeregisterMap(std::string const & name)
+  {
+    auto const file = platform::CountryFile(name);
+    auto it = find_if(
+        m_files.begin(), m_files.end(),
+        [&file](platform::LocalCountryFile const & f) { return f.GetCountryFile() == file; });
+    if (it == m_files.end())
+      return;
+
+    m_index.DeregisterMap(file);
+    Cleanup(*it);
+    m_files.erase(it);
+  }
+
   template <typename BuildFn>
   MwmSet::MwmId BuildWorld(BuildFn && fn)
   {


### PR DESCRIPTION
У нас при построении индекса типы фичей, которые мы индексируем, обрезались до глубины 2, а типы из категорий -- нет. Поэтому в категорийные типы глубиной больше 2 ничего не индексировалось.
Исправила и добавила тесты.
С теми типами, для которых тест поиска каждой категории не проходит, предлагаю разбираться отдельно.