### PR TITLE
Calling routing session methods from gui thread.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1145,8 +1145,11 @@ JNIEXPORT void JNICALL
 Java_com_mapswithme_maps_Framework_nativeSetRoutingListener(JNIEnv * env, jclass, jobject listener)
 {
   CHECK(g_framework, ("Framework isn't created yet!"));
+  auto rf = jni::make_global_ref(listener);
   frm()->GetRoutingManager().SetRouteBuildingListener(
-      bind(&CallRoutingListener, jni::make_global_ref(listener), _1, _2));
+      [rf](routing::RouterResultCode e, storage::TCountriesVec const & v) {
+        CallRoutingListener(rf, static_cast<int>(e), v);
+      });
 }
 
 JNIEXPORT void JNICALL

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -616,7 +616,7 @@
 	<string name="routing_planning_error">فشل في تخطيط المسار</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">الوصول: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.</string>
 	<string name="rate_alert_title">يعجبك التطبيق؟</string>
 	<string name="rate_alert_default_message">شكرا لاستخدامك MAPS.ME. من فضلك، أَعْطِ تقييمك للتطبيق. ملاحظاتك تساعدنا على أن نصبح أفضل.</string>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -617,7 +617,7 @@
 	<string name="routing_planning_error">Naplánování trasy se nezdařilo</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Příjezd: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.</string>
 	<string name="rate_alert_title">Líbí se vám aplikace?</string>
 	<string name="rate_alert_default_message">Děkujeme, že používáte MAPS.ME. Ohodnoťte, prosím, tuto aplikaci. Váš komentář nám pomůže ji ještě zlepšit.</string>

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -614,7 +614,7 @@
 	<string name="routing_planning_error">Ruteplanlægning mislykkedes</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomst: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">For at oprette en rute skal du hente og opdatere alle kort langs ruten.</string>
 	<string name="rate_alert_title">Kan du lide appen?</string>
 	<string name="rate_alert_default_message">Tak for at du bruger MAPS.ME. Venligst bedøm appen. Din feedback hjælper os med at blive bedre.</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -624,7 +624,7 @@
 	<string name="routing_planning_error">Routenplanung fehlgeschlagen</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankunft: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Zum Erstellen einer Route müssen Sie alle Karten herunterladen und aktualisieren, auf der die Route liegt.</string>
 	<string name="rate_alert_title">Gefällt Ihnen die App?</string>
 	<string name="rate_alert_default_message">Danke, dass Sie MAPS.ME nutzen. Bitte bewerten Sie die App. Ihre Rückmeldung hilft uns, besser zu werden.</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -603,7 +603,7 @@
 	<string name="routing_planning_error">Error al planificar la ruta</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Llegada: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Para crear una ruta, por favor, descarga y actualiza todos los mapas a lo largo de la ruta.</string>
 	<string name="rate_alert_title">¿Te gusta la aplicación?</string>
 	<string name="rate_alert_default_message">Gracias por usar MAPS.ME. Por favor, puntúa la aplicación. Tus comentarios nos ayudan a mejorar.</string>

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -610,7 +610,7 @@
 	<string name="routing_planning_error">Reitin suunnittelu epäonnistui</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Saavut: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.</string>
 	<string name="rate_alert_title">Pidätkö sovelluksesta?</string>
 	<string name="rate_alert_default_message">Kiitos kun käytät MAPS.ME:tä. Voisitko myös arvostella sovelluksen? Palautteesi avulla tulemme vielä paremmiksi.</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -621,7 +621,7 @@
 	<string name="routing_planning_error">La planification de l\'itinéraire a échoué</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrivée: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.</string>
 	<string name="rate_alert_title">Vous aimez l’application ?</string>
 	<string name="rate_alert_default_message">Merci d’avoir utilisé MAPS.ME. Pourriez-vous, s’il vous plaît, noter cette application ? Vos commentaires nous aideront à nous améliorer.</string>

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -611,7 +611,7 @@
 	<string name="routing_planning_error">Sikertelen útvonaltervezés</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Megérkezik: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Útvonal létrehozásához kérjük, töltse le és frissítse az összes térképet az útvonal mentén.</string>
 	<string name="rate_alert_title">Tetszik az app?</string>
 	<string name="rate_alert_default_message">Köszönjük, hogy a MAPS.ME-t használta. Kérjük, értékelje az appot. A visszajelzéseik segítenek bennünket abban, hogy jobbá váljunk.</string>

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -609,7 +609,7 @@
 	<string name="routing_planning_error">Sudah sampai di tujuan</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Kedatangan: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.</string>
 	<string name="rate_alert_title">Suka aplikasi ini?</string>
 	<string name="rate_alert_default_message">Terima kasih karena menggunakan MAPS.ME. Mohon beri peringkat untuk aplikasi ini. Masukan dari Anda membantu kami untuk menjadi lebih baik.</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -609,7 +609,7 @@
 	<string name="routing_planning_error">Pianificazione del percorso fallito</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrivo: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.</string>
 	<string name="rate_alert_title">Ti piace l’app?</string>
 	<string name="rate_alert_default_message">Grazie per aver utilizzato MAPS.ME. Valuta l’app. Il tuo feedback ci permette di migliorare.</string>

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -609,7 +609,7 @@
 	<string name="routing_planning_error">ルート検索に失敗</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">到着予定: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。</string>
 	<string name="rate_alert_title">このアプリが好きですか?</string>
 	<string name="rate_alert_default_message">MAPS.MEをご使用いただきありがとうございます。アプリの評価をお願いいたします。皆様からのフィードバックはアプリの改善に役立つものです。</string>

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -606,7 +606,7 @@
 	<string name="routing_planning_error">경로 계획 실패</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">도착: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.</string>
 	<string name="rate_alert_title">앱을 좋아하나요?</string>
 	<string name="rate_alert_default_message">MAPS.ME를 사용해 주셔서 감사합니다. 이 앱을 평가해 주십시오. 당신의 피드백은 이 앱을 더 낫게 만드는데 도움을 줍니다.</string>

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -610,7 +610,7 @@
 	<string name="routing_planning_error">Mislykket ruteplanlegging</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomme: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.</string>
 	<string name="rate_alert_title">Liker du appen?</string>
 	<string name="rate_alert_default_message">Takk for at du bruker MAPS.ME. Vi setter stor pris på om du rangerer appen. Tilbakemeldinger hjelper oss med å bli bedre.</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -610,7 +610,7 @@
 	<string name="routing_planning_error">Routeberekening mislukt</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Aankomst: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Om een route te maken, download en update alle kaarten rondom de route.</string>
 	<string name="rate_alert_title">Vindt u de app leuk?</string>
 	<string name="rate_alert_default_message">Bedankt om MAPS.ME te gebruiken. Gelieve de app te beoordelen. Uw feedback helpt ons beter te worden.</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -613,7 +613,7 @@
 	<string name="routing_planning_error">Planowanie trasy nieudane</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Przybycie: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.</string>
 	<string name="rate_alert_title">Lubisz tę aplikację?</string>
 	<string name="rate_alert_default_message">Dziękujemy za korzystanie z MAPS.ME. Prosimy wystawić aplikacji ocenę. Twoja opinia pozwoli nam udoskonalać nasze produkty.</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -611,7 +611,7 @@
 	<string name="routing_planning_error">Falhou o Planeamento da Rota</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Chegada: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.</string>
 	<string name="rate_alert_title">Gosta do aplicativo?</string>
 	<string name="rate_alert_default_message">Obrigado por usar MAPS.ME. Por favor, classifique o aplicativo. Seu feedback nos ajuda a melhorar.</string>

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -607,7 +607,7 @@
 	<string name="routing_planning_error">Planificarea rutei a eșuat</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Sosire: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Pentru a crea o rută, vă rugăm să descărcați și să actualizați toate hărțile de pe parcursul rutei.</string>
 	<string name="rate_alert_title">Vă place aplicația?</string>
 	<string name="rate_alert_default_message">Vă mulțumim că folosiți MAPS.ME. Vă rugăm să dați o notă aplicației. Comentariile dvs. ne ajută să devenim mai buni.</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -629,7 +629,7 @@
 	<string name="routing_planning_error">Ошибка построения маршрута</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Прибытие в %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Для построения маршрута загрузите и обновите все карты по пути следования.</string>
 	<string name="rate_alert_title">Нравится приложение?</string>
 	<string name="rate_alert_default_message">Спасибо что пользуетесь картами MAPS.ME. Пожалуйста, оцените приложение. Ваши оценки и отзывы помогают нам становиться лучше.</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -613,7 +613,7 @@
 	<string name="routing_planning_error">Plánovanie trasy zlyhalo</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Pricestovať: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.</string>
 	<string name="rate_alert_title">Páči sa vám aplikácia?</string>
 	<string name="rate_alert_default_message">Ďakujeme, že používate MAPS.ME. Prosím, ohodnoťte aplikáciu. Vaše názory nám pomôžu zlepšiť sa.</string>

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -614,7 +614,7 @@
 	<string name="routing_planning_error">Ruttplanering misslyckades</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomst: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.</string>
 	<string name="rate_alert_title">Gillar du appen?</string>
 	<string name="rate_alert_default_message">Tack för att du använder MAPS.ME. Betygsätt gärna appen. Din feedback hjälper oss att bli bättre.</string>

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -616,7 +616,7 @@
 	<string name="routing_planning_error">การวางแผนเส้นทางล้มเหลว</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">มาถึง: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง</string>
 	<string name="rate_alert_title">ชอบแอปหรือไม่?</string>
 	<string name="rate_alert_default_message">ขอบพระคุณสำหรับการใช้ MAPS.ME โปรดให้คะแนนแอป ข้อเสนอแนะของคุณจะช่วยทำให้เราทำได้ดียิ่งขึ้น</string>

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -616,7 +616,7 @@
 	<string name="routing_planning_error">Rota Planlaması Başarısız</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Varış: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Bir rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.</string>
 	<string name="rate_alert_title">Uygulamayı beğendiniz mi?</string>
 	<string name="rate_alert_default_message">MAPS.ME’yi kullandığınız için teşekkür ederiz. Lütfen uygulamaya puan verin. Geri bildiriminiz daha iyi hale gelebilmemize yardımcı olur.</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -614,7 +614,7 @@
 	<string name="routing_planning_error">Збій планування маршруту</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Прибуття в %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Для створення маршруту, будь ласка, скачайте та обновіть всі карти за ним.</string>
 	<string name="rate_alert_title">Подобається програма?</string>
 	<string name="rate_alert_default_message">Дякуємо за використання MAPS.ME. Будь ласка, дайте їй оцінку. Ваш відгук допоможе нам стати краще.</string>

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -610,7 +610,7 @@
 	<string name="routing_planning_error">Không thể Lập Lộ trình</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Đến: %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.</string>
 	<string name="rate_alert_title">Bạn thích ứng dụng chứ?</string>
 	<string name="rate_alert_default_message">Cám ơn bạn đã sử dụng MAPS.ME. Vui lòng đánh giá ứng dụng. Phản hồi của bạn giúp chúng tôi trở nên tốt hơn.</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -618,7 +618,7 @@
 	<string name="routing_planning_error">路線計劃失敗</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">抵達:%s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">要建立路線，請下載並更新所有沿線的地圖。</string>
 	<string name="rate_alert_title">喜歡這個應用程式嗎？</string>
 	<string name="rate_alert_default_message">感謝您使用 MAPS.ME。請評價此應用程式。您的回饋幫助我們改善我們的產品。</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -616,7 +616,7 @@
 	<string name="routing_planning_error">路线计划失败</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">抵達:%s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">要创建路线，请下载并更新所有沿路线的地图。</string>
 	<string name="rate_alert_title">喜欢这个应用吗？</string>
 	<string name="rate_alert_default_message">感谢您使用 MAPS.ME。请，评价该应用。您的反馈帮助我们变得更好。</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -631,7 +631,7 @@
 	<string name="routing_planning_error">Route Planning Failed</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrival at %s</string>
-	<!-- Text for routing::IRouter::FileTooOld dialog. -->
+	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
 	<string name="dialog_routing_download_and_update_maps">Download and update all map along the projected path to calculate route.</string>
 	<string name="rate_alert_title">Like the app?</string>
 	<string name="rate_alert_default_message">Thank you for using MAPS.ME. Please rate the app. Your feedback helps us improve our product.</string>

--- a/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
+++ b/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 class ResultCodesHelper
 {
-  // Codes correspond to native routing::IRouter::ResultCode in routing/router.hpp
+  // Codes correspond to native routing::RouterResultCode in routing/routing_callbacks.hpp
   static final int NO_ERROR = 0;
   static final int CANCELLED = 1;
   static final int NO_POSITION = 2;

--- a/android/src/com/mapswithme/maps/routing/RoutingErrorDialogFragment.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingErrorDialogFragment.java
@@ -18,7 +18,7 @@ import com.mapswithme.util.UiUtils;
 
 public class RoutingErrorDialogFragment extends BaseRoutingErrorDialogFragment
 {
-  private static final String EXTRA_RESULT_CODE = "ResultCode";
+  private static final String EXTRA_RESULT_CODE = "RouterResultCode";
 
   private int mResultCode;
   private String mMessage;

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController+CPP.h
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController+CPP.h
@@ -2,13 +2,14 @@
 #import "MWMAlertViewController.h"
 
 #include "routing/router.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "storage/storage.hpp"
 
 @interface MWMAlertViewController (CPP)
 
-- (void)presentAlert:(routing::IRouter::ResultCode)type;
+- (void)presentAlert:(routing::RouterResultCode)type;
 - (void)presentDownloaderAlertWithCountries:(storage::TCountriesVec const &)countries
-                                       code:(routing::IRouter::ResultCode)code
+                                       code:(routing::RouterResultCode)code
                                 cancelBlock:(nonnull MWMVoidBlock)cancelBlock
                               downloadBlock:(nonnull MWMDownloadBlock)downloadBlock
                       downloadCompleteBlock:(nonnull MWMVoidBlock)downloadCompleteBlock;

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
@@ -104,7 +104,7 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
 }
 
 - (void)presentDownloaderAlertWithCountries:(storage::TCountriesVec const &)countries
-                                       code:(routing::IRouter::ResultCode)code
+                                       code:(routing::RouterResultCode)code
                                 cancelBlock:(MWMVoidBlock)cancelBlock
                               downloadBlock:(MWMDownloadBlock)downloadBlock
                       downloadCompleteBlock:(MWMVoidBlock)downloadCompleteBlock
@@ -122,7 +122,7 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
 }
 
 - (void)presentDisabledLocationAlert { [self displayAlert:[MWMAlert disabledLocationAlert]]; }
-- (void)presentAlert:(routing::IRouter::ResultCode)type
+- (void)presentAlert:(routing::RouterResultCode)type
 {
   [self displayAlert:[MWMAlert alert:type]];
 }

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert+CPP.h
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert+CPP.h
@@ -1,15 +1,16 @@
 #import "MWMAlert.h"
 
 #include "routing/router.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "storage/storage.hpp"
 
 using MWMDownloadBlock = void (^)(storage::TCountriesVec const &, MWMVoidBlock);
 
 @interface MWMAlert (CPP)
 
-+ (MWMAlert *)alert:(routing::IRouter::ResultCode)type;
++ (MWMAlert *)alert:(routing::RouterResultCode)type;
 + (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::TCountriesVec const &)countries
-                                            code:(routing::IRouter::ResultCode)code
+                                            code:(routing::RouterResultCode)code
                                      cancelBlock:(MWMVoidBlock)cancelBlock
                                    downloadBlock:(MWMDownloadBlock)downloadBlock
                            downloadCompleteBlock:(MWMVoidBlock)downloadCompleteBlock;

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -53,7 +53,7 @@
 }
 
 + (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::TCountriesVec const &)countries
-                                            code:(routing::IRouter::ResultCode)code
+                                            code:(routing::RouterResultCode)code
                                      cancelBlock:(MWMVoidBlock)cancelBlock
                                    downloadBlock:(MWMDownloadBlock)downloadBlock
                            downloadCompleteBlock:(MWMVoidBlock)downloadCompleteBlock
@@ -65,26 +65,26 @@
                                        downloadCompleteBlock:downloadCompleteBlock];
 }
 
-+ (MWMAlert *)alert:(routing::IRouter::ResultCode)type
++ (MWMAlert *)alert:(routing::RouterResultCode)type
 {
   switch (type)
   {
-  case routing::IRouter::NoCurrentPosition: return [MWMDefaultAlert noCurrentPositionAlert];
-  case routing::IRouter::StartPointNotFound: return [MWMDefaultAlert startPointNotFoundAlert];
-  case routing::IRouter::EndPointNotFound: return [MWMDefaultAlert endPointNotFoundAlert];
-  case routing::IRouter::PointsInDifferentMWM: return [MWMDefaultAlert pointsInDifferentMWMAlert];
-  case routing::IRouter::TransitRouteNotFoundNoNetwork: return [MWMDefaultAlert routeNotFoundNoPublicTransportAlert];
-  case routing::IRouter::TransitRouteNotFoundTooLongPedestrian: return [MWMDefaultAlert routeNotFoundTooLongPedestrianAlert];
-  case routing::IRouter::RouteNotFoundRedressRouteError:
-  case routing::IRouter::RouteNotFound:
-  case routing::IRouter::InconsistentMWMandRoute: return [MWMDefaultAlert routeNotFoundAlert];
-  case routing::IRouter::RouteFileNotExist:
-  case routing::IRouter::FileTooOld: return [MWMDefaultAlert routeFileNotExistAlert];
-  case routing::IRouter::InternalError: return [MWMDefaultAlert internalRoutingErrorAlert];
-  case routing::IRouter::Cancelled:
-  case routing::IRouter::NoError:
-  case routing::IRouter::NeedMoreMaps: return nil;
-  case routing::IRouter::IntermediatePointNotFound: return [MWMDefaultAlert intermediatePointNotFoundAlert];
+  case routing::RouterResultCode::NoCurrentPosition: return [MWMDefaultAlert noCurrentPositionAlert];
+  case routing::RouterResultCode::StartPointNotFound: return [MWMDefaultAlert startPointNotFoundAlert];
+  case routing::RouterResultCode::EndPointNotFound: return [MWMDefaultAlert endPointNotFoundAlert];
+  case routing::RouterResultCode::PointsInDifferentMWM: return [MWMDefaultAlert pointsInDifferentMWMAlert];
+  case routing::RouterResultCode::TransitRouteNotFoundNoNetwork: return [MWMDefaultAlert routeNotFoundNoPublicTransportAlert];
+  case routing::RouterResultCode::TransitRouteNotFoundTooLongPedestrian: return [MWMDefaultAlert routeNotFoundTooLongPedestrianAlert];
+  case routing::RouterResultCode::RouteNotFoundRedressRouteError:
+  case routing::RouterResultCode::RouteNotFound:
+  case routing::RouterResultCode::InconsistentMWMandRoute: return [MWMDefaultAlert routeNotFoundAlert];
+  case routing::RouterResultCode::RouteFileNotExist:
+  case routing::RouterResultCode::FileTooOld: return [MWMDefaultAlert routeFileNotExistAlert];
+  case routing::RouterResultCode::InternalError: return [MWMDefaultAlert internalRoutingErrorAlert];
+  case routing::RouterResultCode::Cancelled:
+  case routing::RouterResultCode::NoError:
+  case routing::RouterResultCode::NeedMoreMaps: return nil;
+  case routing::RouterResultCode::IntermediatePointNotFound: return [MWMDefaultAlert intermediatePointNotFoundAlert];
   }
 }
 

--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.h
@@ -1,9 +1,11 @@
 #import "MWMAlert+CPP.h"
 
+#include "routing/routing_callbacks.hpp"
+
 @interface MWMDownloadTransitMapAlert : MWMAlert
 
 + (instancetype)downloaderAlertWithMaps:(storage::TCountriesVec const &)countries
-                                   code:(routing::IRouter::ResultCode)code
+                                   code:(routing::RouterResultCode)code
                             cancelBlock:(MWMVoidBlock)cancelBlock
                           downloadBlock:(MWMDownloadBlock)downloadBlock
                   downloadCompleteBlock:(MWMVoidBlock)downloadCompleteBlock;

--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
@@ -57,7 +57,7 @@ CGFloat const kAnimationDuration = .05;
 }
 
 + (instancetype)downloaderAlertWithMaps:(storage::TCountriesVec const &)countries
-                                   code:(routing::IRouter::ResultCode)code
+                                   code:(routing::RouterResultCode)code
                             cancelBlock:(MWMVoidBlock)cancelBlock
                           downloadBlock:(MWMDownloadBlock)downloadBlock
                   downloadCompleteBlock:(MWMVoidBlock)downloadCompleteBlock
@@ -66,17 +66,17 @@ CGFloat const kAnimationDuration = .05;
   MWMDownloadTransitMapAlert * alert = [self alertWithCountries:countries];
   switch (code)
   {
-    case routing::IRouter::InconsistentMWMandRoute:
-    case routing::IRouter::RouteNotFound:
-    case routing::IRouter::RouteFileNotExist:
+    case routing::RouterResultCode::InconsistentMWMandRoute:
+    case routing::RouterResultCode::RouteNotFound:
+    case routing::RouterResultCode::RouteFileNotExist:
       alert.titleLabel.localizedText = @"dialog_routing_download_files";
       alert.messageLabel.localizedText = @"dialog_routing_download_and_update_all";
       break;
-    case routing::IRouter::FileTooOld:
+    case routing::RouterResultCode::FileTooOld:
       alert.titleLabel.localizedText = @"dialog_routing_download_files";
       alert.messageLabel.localizedText = @"dialog_routing_download_and_update_maps";
       break;
-    case routing::IRouter::NeedMoreMaps:
+    case routing::RouterResultCode::NeedMoreMaps:
       alert.titleLabel.localizedText = @"dialog_routing_download_and_build_cross_route";
       alert.messageLabel.localizedText = @"dialog_routing_download_cross_route";
       break;

--- a/iphone/Maps/Core/Framework/MWMFrameworkListener.mm
+++ b/iphone/Maps/Core/Framework/MWMFrameworkListener.mm
@@ -97,7 +97,7 @@ void loopWrappers(Observers * observers, TLoopBlock block)
   Observers * observers = self.routeBuildingObservers;
   auto & rm = GetFramework().GetRoutingManager();
   rm.SetRouteBuildingListener(
-      [observers](IRouter::ResultCode code, TCountriesVec const & absentCountries) {
+      [observers](RouterResultCode code, TCountriesVec const & absentCountries) {
         loopWrappers(observers, [code, absentCountries](TRouteBuildingObserver observer) {
           [observer processRouteBuilderEvent:code countries:absentCountries];
         });

--- a/iphone/Maps/Core/Framework/MWMFrameworkObservers.h
+++ b/iphone/Maps/Core/Framework/MWMFrameworkObservers.h
@@ -1,6 +1,7 @@
 #import "MWMRouterRecommendation.h"
 
 #include "routing/router.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "storage/index.hpp"
 #include "storage/storage.hpp"
 
@@ -12,7 +13,7 @@ using namespace storage;
 
 @protocol MWMFrameworkRouteBuilderObserver<MWMFrameworkObserver>
 
-- (void)processRouteBuilderEvent:(routing::IRouter::ResultCode)code
+- (void)processRouteBuilderEvent:(routing::RouterResultCode)code
                        countries:(storage::TCountriesVec const &)absentCountries;
 
 @optional

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -585,13 +585,13 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
 
 #pragma mark - MWMFrameworkRouteBuilderObserver
 
-- (void)processRouteBuilderEvent:(routing::IRouter::ResultCode)code
+- (void)processRouteBuilderEvent:(routing::RouterResultCode)code
                        countries:(storage::TCountriesVec const &)absentCountries
 {
   MWMMapViewControlsManager * mapViewControlsManager = [MWMMapViewControlsManager manager];
   switch (code)
   {
-  case routing::IRouter::ResultCode::NoError:
+  case routing::RouterResultCode::NoError:
   {
     GetFramework().DeactivateMapSelection(true);
 
@@ -607,28 +607,28 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
     [self updateFollowingInfo];
     break;
   }
-  case routing::IRouter::RouteFileNotExist:
-  case routing::IRouter::InconsistentMWMandRoute:
-  case routing::IRouter::NeedMoreMaps:
-  case routing::IRouter::FileTooOld:
-  case routing::IRouter::RouteNotFound:
+  case routing::RouterResultCode::RouteFileNotExist:
+  case routing::RouterResultCode::InconsistentMWMandRoute:
+  case routing::RouterResultCode::NeedMoreMaps:
+  case routing::RouterResultCode::FileTooOld:
+  case routing::RouterResultCode::RouteNotFound:
     if ([MWMRouter isTaxi])
       return;
     [self presentDownloaderAlert:code countries:absentCountries];
     [[MWMNavigationDashboardManager manager] onRouteError:L(@"routing_planning_error")];
     break;
-  case routing::IRouter::Cancelled:
+  case routing::RouterResultCode::Cancelled:
     [mapViewControlsManager onRoutePrepare];
     break;
-  case routing::IRouter::StartPointNotFound:
-  case routing::IRouter::EndPointNotFound:
-  case routing::IRouter::NoCurrentPosition:
-  case routing::IRouter::PointsInDifferentMWM:
-  case routing::IRouter::InternalError:
-  case routing::IRouter::IntermediatePointNotFound:
-  case routing::IRouter::TransitRouteNotFoundNoNetwork:
-  case routing::IRouter::TransitRouteNotFoundTooLongPedestrian:
-  case routing::IRouter::RouteNotFoundRedressRouteError:
+  case routing::RouterResultCode::StartPointNotFound:
+  case routing::RouterResultCode::EndPointNotFound:
+  case routing::RouterResultCode::NoCurrentPosition:
+  case routing::RouterResultCode::PointsInDifferentMWM:
+  case routing::RouterResultCode::InternalError:
+  case routing::RouterResultCode::IntermediatePointNotFound:
+  case routing::RouterResultCode::TransitRouteNotFoundNoNetwork:
+  case routing::RouterResultCode::TransitRouteNotFoundTooLongPedestrian:
+  case routing::RouterResultCode::RouteNotFoundRedressRouteError:
     if ([MWMRouter isTaxi])
       return;
     [[MWMAlertViewController activeAlertController] presentAlert:code];
@@ -657,7 +657,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
 
 #pragma mark - Alerts
 
-- (void)presentDownloaderAlert:(routing::IRouter::ResultCode)code
+- (void)presentDownloaderAlert:(routing::RouterResultCode)code
                      countries:(storage::TCountriesVec const &)countries
 {
   MWMAlertViewController * activeAlertController = [MWMAlertViewController activeAlertController];
@@ -674,7 +674,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
     [activeAlertController presentDownloaderAlertWithCountries:countries
         code:code
         cancelBlock:^{
-          if (code != routing::IRouter::NeedMoreMaps)
+          if (code != routing::RouterResultCode::NeedMoreMaps)
             [MWMRouter stopRouting];
         }
         downloadBlock:^(storage::TCountriesVec const & downloadCountries, MWMVoidBlock onSuccess) {

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "الوصول: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.";
 
 "rate_alert_title" = "يعجبك التطبيق؟";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Příjezd: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.";
 
 "rate_alert_title" = "Líbí se vám aplikace?";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomst: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "For at oprette en rute skal du hente og opdatere alle kort langs ruten.";
 
 "rate_alert_title" = "Kan du lide appen?";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankunft: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Zum Erstellen einer Route müssen Sie alle Karten herunterladen und aktualisieren, auf der die Route liegt.";
 
 "rate_alert_title" = "Gefällt Ihnen die App?";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Άφιξη στις %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Σας αρέσει η εφαρμογή;";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrival at %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Like the app?";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrival at %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Like the app?";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Llegada: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Para crear una ruta, por favor, descarga y actualiza todos los mapas a lo largo de la ruta.";
 
 "rate_alert_title" = "¿Te gusta la aplicación?";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Saavut: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.";
 
 "rate_alert_title" = "Pidätkö sovelluksesta?";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrivée: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.";
 
 "rate_alert_title" = "Vous aimez l’application ?";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Megérkezik: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Útvonal létrehozásához kérjük, töltse le és frissítse az összes térképet az útvonal mentén.";
 
 "rate_alert_title" = "Tetszik az app?";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Kedatangan: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.";
 
 "rate_alert_title" = "Suka aplikasi ini?";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrivo: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.";
 
 "rate_alert_title" = "Ti piace l’app?";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "到着予定: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。";
 
 "rate_alert_title" = "このアプリが好きですか?";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "도착: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.";
 
 "rate_alert_title" = "앱을 좋아하나요?";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomme: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.";
 
 "rate_alert_title" = "Liker du appen?";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Aankomst: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Om een route te maken, download en update alle kaarten rondom de route.";
 
 "rate_alert_title" = "Vindt u de app leuk?";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Przybycie: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.";
 
 "rate_alert_title" = "Lubisz tę aplikację?";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Chegada: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.";
 
 "rate_alert_title" = "Gosta do aplicativo?";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Sosire: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Pentru a crea o rută, vă rugăm să descărcați și să actualizați toate hărțile de pe parcursul rutei.";
 
 "rate_alert_title" = "Vă place aplicația?";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Прибытие в %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Для построения маршрута загрузите и обновите все карты по пути следования.";
 
 "rate_alert_title" = "Нравится приложение?";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Pricestovať: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.";
 
 "rate_alert_title" = "Páči sa vám aplikácia?";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomst: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.";
 
 "rate_alert_title" = "Gillar du appen?";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "มาถึง: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง";
 
 "rate_alert_title" = "ชอบแอปหรือไม่?";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Varış: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Bir rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.";
 
 "rate_alert_title" = "Uygulamayı beğendiniz mi?";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Прибуття в %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Для створення маршруту, будь ласка, скачайте та обновіть всі карти за ним.";
 
 "rate_alert_title" = "Подобається програма?";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Đến: %s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.";
 
 "rate_alert_title" = "Bạn thích ứng dụng chứ?";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "抵達:%s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "要创建路线，请下载并更新所有沿路线的地图。";
 
 "rate_alert_title" = "喜欢这个应用吗？";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -995,7 +995,7 @@
 /* Arrive routing message in navigation view */
 "routing_arrive" = "抵達:%s";
 
-/* Text for routing::IRouter::FileTooOld dialog. */
+/* Text for routing::RouterResultCode::FileTooOld dialog. */
 "dialog_routing_download_and_update_maps" = "要建立路線，請下載並更新所有沿線的地圖。";
 
 "rate_alert_title" = "喜歡這個應用程式嗎？";

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -5,6 +5,7 @@
 #include "map/transit/transit_display.hpp"
 #include "map/transit/transit_reader.hpp"
 
+#include "routing/routing_callbacks.hpp"
 #include "routing/route.hpp"
 #include "routing/routing_session.hpp"
 
@@ -92,8 +93,7 @@ public:
   };
 
   using RouteBuildingCallback =
-      std::function<void(routing::IRouter::ResultCode, storage::TCountriesVec const &)>;
-  using RouteProgressCallback = std::function<void(float)>;
+      std::function<void(routing::RouterResultCode, storage::TCountriesVec const &)>;
 
   enum class Recommendation
   {
@@ -133,7 +133,7 @@ public:
     m_routingCallback = buildingCallback;
   }
   /// See warning above.
-  void SetRouteProgressListener(RouteProgressCallback const & progressCallback)
+  void SetRouteProgressListener(routing::ProgressCallback const & progressCallback)
   {
     m_routingSession.SetProgressCallback(progressCallback);
   }
@@ -204,10 +204,10 @@ public:
   void RemoveRoute(bool deactivateFollowing);
 
   void CheckLocationForRouting(location::GpsInfo const & info);
-  void CallRouteBuilded(routing::IRouter::ResultCode code,
+  void CallRouteBuilded(routing::RouterResultCode code,
                         storage::TCountriesVec const & absentCountries);
-  void OnBuildRouteReady(routing::Route const & route, routing::IRouter::ResultCode code);
-  void OnRebuildRouteReady(routing::Route const & route, routing::IRouter::ResultCode code);
+  void OnBuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
+  void OnRebuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
   void OnRoutePointPassed(RouteMarkType type, size_t intermediateIndex);
   void OnLocationUpdate(location::GpsInfo & info);
   void SetAllowSendingPoints(bool isAllowed)

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -11,6 +11,8 @@
 
 #include "storage/index.hpp"
 
+#include "routing/routing_callbacks.hpp"
+
 #include "indexer/editable_map_object.hpp"
 
 #include "platform/settings.hpp"
@@ -43,7 +45,7 @@ DrawWidget::DrawWidget(Framework & framework, bool apiOpenGLES3, QWidget * paren
       [](bool /* switchFullScreenMode */) {});  // Empty deactivation listener.
 
   m_framework.GetRoutingManager().SetRouteBuildingListener(
-      [](routing::IRouter::ResultCode, storage::TCountriesVec const &) {});
+      [](routing::RouterResultCode, storage::TCountriesVec const &) {});
 
   m_framework.GetRoutingManager().SetRouteRecommendationListener(
     [this](RoutingManager::Recommendation r)

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -90,6 +90,7 @@ set(
   router.hpp
   router_delegate.cpp
   router_delegate.hpp
+  routing_callbacks.hpp
   routing_exceptions.hpp
   routing_helpers.cpp
   routing_helpers.hpp

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -40,7 +40,7 @@ map<string, string> PrepareStatisticsData(string const & routerName,
 
 // ----------------------------------------------------------------------------------------------------------------------------
 
-AsyncRouter::RouterDelegateProxy::RouterDelegateProxy(TReadyCallback const & onReady,
+AsyncRouter::RouterDelegateProxy::RouterDelegateProxy(ReadyCallbackOwnership const & onReady,
                                                       PointCheckCallback const & onPointCheck,
                                                       ProgressCallback const & onProgress,
                                                       uint32_t timeoutSec)
@@ -130,7 +130,7 @@ void AsyncRouter::SetRouter(unique_ptr<IRouter> && router, unique_ptr<IOnlineFet
 }
 
 void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
-                                 bool adjustToPrevRoute, TReadyCallback const & readyCallback,
+                                 bool adjustToPrevRoute, ReadyCallbackOwnership const & readyCallback,
                                  ProgressCallback const & progressCallback,
                                  uint32_t timeoutSec)
 {

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "routing/routing_callbacks.hpp"
 #include "routing/checkpoints.hpp"
 #include "routing/online_absent_fetcher.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/router_delegate.hpp"
+#include "routing/routing_callbacks.hpp"
 
 #include "base/thread.hpp"
 
@@ -23,12 +23,6 @@ namespace routing
 class AsyncRouter final
 {
 public:
-  /// Callback takes ownership of passed route.
-  using TReadyCallback = function<void(Route &, RouterResultCode)>;
-
-  /// Callback on routing statistics
-//  using TRoutingStatisticsCallback = function<void(map<string, string> const &)>;
-
   /// AsyncRouter is a wrapper class to run routing routines in the different thread
   AsyncRouter(RoutingStatisticsCallback const & routingStatisticsCallback,
               PointCheckCallback const & pointCheckCallback);
@@ -49,7 +43,7 @@ public:
   /// @param progressCallback function to update the router progress
   /// @param timeoutSec timeout to cancel routing. 0 is infinity.
   void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
-                      bool adjustToPrevRoute, TReadyCallback const & readyCallback,
+                      bool adjustToPrevRoute, ReadyCallbackOwnership const & readyCallback,
                       ProgressCallback const & progressCallback,
                       uint32_t timeoutSec);
 
@@ -81,7 +75,7 @@ private:
   class RouterDelegateProxy
   {
   public:
-    RouterDelegateProxy(TReadyCallback const & onReady,
+    RouterDelegateProxy(ReadyCallbackOwnership const & onReady,
                         PointCheckCallback const & onPointCheck,
                         ProgressCallback const & onProgress,
                         uint32_t timeoutSec);
@@ -96,7 +90,7 @@ private:
     void OnPointCheck(m2::PointD const & pt);
 
     mutex m_guard;
-    TReadyCallback const m_onReady;
+    ReadyCallbackOwnership const m_onReady;
     PointCheckCallback const m_onPointCheck;
     ProgressCallback const m_onProgress;
     RouterDelegate m_delegate;

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/routing_callbacks.hpp"
 #include "routing/checkpoints.hpp"
 #include "routing/online_absent_fetcher.hpp"
 #include "routing/route.hpp"
@@ -23,14 +24,14 @@ class AsyncRouter final
 {
 public:
   /// Callback takes ownership of passed route.
-  using TReadyCallback = function<void(Route &, IRouter::ResultCode)>;
+  using TReadyCallback = function<void(Route &, RouterResultCode)>;
 
   /// Callback on routing statistics
-  using TRoutingStatisticsCallback = function<void(map<string, string> const &)>;
+//  using TRoutingStatisticsCallback = function<void(map<string, string> const &)>;
 
   /// AsyncRouter is a wrapper class to run routing routines in the different thread
-  AsyncRouter(TRoutingStatisticsCallback const & routingStatisticsCallback,
-              RouterDelegate::TPointCheckCallback const & pointCheckCallback);
+  AsyncRouter(RoutingStatisticsCallback const & routingStatisticsCallback,
+              PointCheckCallback const & pointCheckCallback);
   ~AsyncRouter();
 
   /// Sets a synchronous router, current route calculation will be cancelled
@@ -49,7 +50,7 @@ public:
   /// @param timeoutSec timeout to cancel routing. 0 is infinity.
   void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
                       bool adjustToPrevRoute, TReadyCallback const & readyCallback,
-                      RouterDelegate::TProgressCallback const & progressCallback,
+                      ProgressCallback const & progressCallback,
                       uint32_t timeoutSec);
 
   /// Interrupt routing and clear buffers
@@ -67,25 +68,25 @@ private:
   /// These functions are called to send statistics about the routing
   void SendStatistics(m2::PointD const & startPoint, m2::PointD const & startDirection,
                       m2::PointD const & finalPoint,
-                      IRouter::ResultCode resultCode,
+                      RouterResultCode resultCode,
                       Route const & route,
                       double elapsedSec);
   void SendStatistics(m2::PointD const & startPoint, m2::PointD const & startDirection,
                       m2::PointD const & finalPoint,
                       string const & exceptionMessage);
 
-  void LogCode(IRouter::ResultCode code, double const elapsedSec);
+  void LogCode(RouterResultCode code, double const elapsedSec);
 
   /// Blocks callbacks when routing has been cancelled
   class RouterDelegateProxy
   {
   public:
     RouterDelegateProxy(TReadyCallback const & onReady,
-                        RouterDelegate::TPointCheckCallback const & onPointCheck,
-                        RouterDelegate::TProgressCallback const & onProgress,
+                        PointCheckCallback const & onPointCheck,
+                        ProgressCallback const & onProgress,
                         uint32_t timeoutSec);
 
-    void OnReady(Route & route, IRouter::ResultCode resultCode);
+    void OnReady(Route & route, RouterResultCode resultCode);
     void Cancel();
 
     RouterDelegate const & GetDelegate() const { return m_delegate; }
@@ -96,8 +97,8 @@ private:
 
     mutex m_guard;
     TReadyCallback const m_onReady;
-    RouterDelegate::TPointCheckCallback const m_onPointCheck;
-    RouterDelegate::TProgressCallback const m_onProgress;
+    PointCheckCallback const m_onPointCheck;
+    ProgressCallback const m_onProgress;
     RouterDelegate m_delegate;
   };
 
@@ -119,8 +120,8 @@ private:
   shared_ptr<IOnlineFetcher> m_absentFetcher;
   shared_ptr<IRouter> m_router;
 
-  TRoutingStatisticsCallback const m_routingStatisticsCallback;
-  RouterDelegate::TPointCheckCallback const m_pointCheckCallback;
+  RoutingStatisticsCallback const m_routingStatisticsCallback;
+  PointCheckCallback const m_pointCheckCallback;
 };
 
 }  // namespace routing

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -10,6 +10,7 @@
 #include "routing/features_road_graph.hpp"
 #include "routing/joint.hpp"
 #include "routing/router.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "routing/segmented_route.hpp"
 #include "routing/world_graph.hpp"
 
@@ -71,21 +72,21 @@ public:
 
   // IRouter overrides:
   std::string GetName() const override { return m_name; }
-  ResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                            bool adjustToPrevRoute, RouterDelegate const & delegate,
-                            Route & route) override;
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
+                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  Route & route) override;
 
 private:
-  IRouter::ResultCode DoCalculateRoute(Checkpoints const & checkpoints,
-                                       m2::PointD const & startDirection,
-                                       RouterDelegate const & delegate, Route & route);
-  IRouter::ResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
-                                        RouterDelegate const & delegate, IndexGraphStarter & graph,
-                                        std::vector<Segment> & subroute);
+  RouterResultCode DoCalculateRoute(Checkpoints const & checkpoints,
+                                    m2::PointD const & startDirection,
+                                    RouterDelegate const & delegate, Route & route);
+  RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
+                                     RouterDelegate const & delegate, IndexGraphStarter & graph,
+                                     std::vector<Segment> & subroute);
 
-  IRouter::ResultCode AdjustRoute(Checkpoints const & checkpoints,
-                                  m2::PointD const & startDirection,
-                                  RouterDelegate const & delegate, Route & route);
+  RouterResultCode AdjustRoute(Checkpoints const & checkpoints,
+                               m2::PointD const & startDirection,
+                               RouterDelegate const & delegate, Route & route);
 
   std::unique_ptr<WorldGraph> MakeWorldGraph();
 
@@ -104,31 +105,31 @@ private:
 
   // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
   // ProcessLeaps replaces each leap with calculated route through mwm.
-  IRouter::ResultCode ProcessLeaps(std::vector<Segment> const & input,
+  RouterResultCode ProcessLeaps(std::vector<Segment> const & input,
                                    RouterDelegate const & delegate, WorldGraph::Mode prevMode,
                                    IndexGraphStarter & starter, std::vector<Segment> & output);
-  IRouter::ResultCode RedressRoute(std::vector<Segment> const & segments,
-                                   RouterDelegate const & delegate, IndexGraphStarter & starter,
-                                   Route & route) const;
+  RouterResultCode RedressRoute(std::vector<Segment> const & segments,
+                                RouterDelegate const & delegate, IndexGraphStarter & starter,
+                                Route & route) const;
 
   bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
   bool DoesTransitSectionExist(NumMwmId numMwmId) const;
-  IRouter::ResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,
-                                           IRouter::ResultCode resultCode) const;
+  RouterResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,
+                                        RouterResultCode resultCode) const;
 
   template <typename Graph>
-  IRouter::ResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const
+  RouterResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const
   {
     switch (result)
     {
-    case AStarAlgorithm<Graph>::Result::NoPath: return IRouter::RouteNotFound;
-    case AStarAlgorithm<Graph>::Result::Cancelled: return IRouter::Cancelled;
-    case AStarAlgorithm<Graph>::Result::OK: return IRouter::NoError;
+    case AStarAlgorithm<Graph>::Result::NoPath: return RouterResultCode::RouteNotFound;
+    case AStarAlgorithm<Graph>::Result::Cancelled: return RouterResultCode::Cancelled;
+    case AStarAlgorithm<Graph>::Result::OK: return RouterResultCode::NoError;
     }
   }
 
   template <typename Graph>
-  IRouter::ResultCode FindPath(
+  RouterResultCode FindPath(
       typename AStarAlgorithm<Graph>::Params & params, std::set<NumMwmId> const & mwmIds,
       RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult) const
   {

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/routing_callbacks.hpp"
 #include "routing/checkpoints.hpp"
 #include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
@@ -40,30 +41,6 @@ std::string DebugPrint(RouterType type);
 class IRouter
 {
 public:
-  /// Routing possible statuses enumeration.
-  /// \warning  this enum has JNI mirror!
-  /// \see android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
-  // TODO(gardster): Please check what items become obsolete now
-  enum ResultCode // TODO(mgsergio) enum class
-  {
-    NoError = 0,
-    Cancelled = 1,
-    NoCurrentPosition = 2,
-    InconsistentMWMandRoute = 3,
-    RouteFileNotExist = 4,
-    StartPointNotFound = 5,
-    EndPointNotFound = 6,
-    PointsInDifferentMWM = 7,
-    RouteNotFound = 8,
-    NeedMoreMaps = 9,
-    InternalError = 10,
-    FileTooOld = 11,
-    IntermediatePointNotFound = 12,
-    TransitRouteNotFoundNoNetwork = 13,
-    TransitRouteNotFoundTooLongPedestrian = 14,
-    RouteNotFoundRedressRouteError = 15,
-  };
-
   virtual ~IRouter() {}
 
   /// Return unique name of a router implementation.
@@ -84,9 +61,9 @@ public:
   /// @param route result route
   /// @return ResultCode error code or NoError if route was initialised
   /// @see Cancellable
-  virtual ResultCode CalculateRoute(Checkpoints const & checkpoints,
-                                    m2::PointD const & startDirection, bool adjust,
-                                    RouterDelegate const & delegate, Route & route) = 0;
+  virtual RouterResultCode CalculateRoute(Checkpoints const & checkpoints,
+                                          m2::PointD const & startDirection, bool adjust,
+                                          RouterDelegate const & delegate, Route & route) = 0;
 };
 
 }  // namespace routing

--- a/routing/router_delegate.cpp
+++ b/routing/router_delegate.cpp
@@ -14,12 +14,12 @@ RouterDelegate::RouterDelegate()
   m_pointCallback = DefaultPointFn;
 }
 
-void RouterDelegate::SetProgressCallback(TProgressCallback const & progressCallback)
+void RouterDelegate::SetProgressCallback(ProgressCallback const & progressCallback)
 {
   m_progressCallback = progressCallback ? progressCallback : DefaultProgressFn;
 }
 
-void RouterDelegate::SetPointCheckCallback(TPointCheckCallback const & pointCallback)
+void RouterDelegate::SetPointCheckCallback(PointCheckCallback const & pointCallback)
 {
   m_pointCallback = pointCallback ? pointCallback : DefaultPointFn;
 }

--- a/routing/router_delegate.hpp
+++ b/routing/router_delegate.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "routing/routing_callbacks.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -30,24 +31,20 @@ private:
 class RouterDelegate : public TimeoutCancellable
 {
 public:
-  using TProgressCallback = function<void(float)>;
-  using TPointCheckCallback = function<void(m2::PointD const &)>;
-
   RouterDelegate();
 
   /// Set routing progress. Waits current progress status from 0 to 100.
   void OnProgress(float progress) const;
   void OnPointCheck(m2::PointD const & point) const;
 
-  void SetProgressCallback(TProgressCallback const & progressCallback);
-  void SetPointCheckCallback(TPointCheckCallback const & pointCallback);
+  void SetProgressCallback(ProgressCallback const & progressCallback);
+  void SetPointCheckCallback(PointCheckCallback const & pointCallback);
 
   void Reset() override;
 
 private:
   mutable mutex m_guard;
-  TProgressCallback m_progressCallback;
-  TPointCheckCallback m_pointCallback;
+  ProgressCallback m_progressCallback;
+  PointCheckCallback m_pointCallback;
 };
-
-}  //  nomespace routing
+} //  namespace routing

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -40,7 +40,7 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
                                                 m2::PointD::Zero() /* startDirection */,
                                                 false /* adjust */, delegate, route);
   double const elapsedSec = timer.ElapsedSeconds();
-  TEST_EQUAL(routing::IRouter::NoError, resultCode, ());
+  TEST_EQUAL(routing::RouterResultCode::NoError, resultCode, ());
   TEST(route.IsValid(), ());
   m2::PolylineD const & poly = route.GetPoly();
   TEST(my::AlmostEqualAbs(poly.Front(), startPos, routing::kPointsEqualEpsilon), ());

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "geometry/point2d.hpp"
+
+#include "base/assert.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace routing
+{
+class Route;
+
+/// Routing possible statuses enumeration.
+/// \warning  this enum has JNI mirror!
+/// \see android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
+// TODO(bykoianko): Items become obsolete now should be removed from the enum.
+enum class RouterResultCode
+{
+  NoError = 0,
+  Cancelled = 1,
+  NoCurrentPosition = 2,
+  InconsistentMWMandRoute = 3,
+  RouteFileNotExist = 4,
+  StartPointNotFound = 5,
+  EndPointNotFound = 6,
+  PointsInDifferentMWM = 7,
+  RouteNotFound = 8,
+  NeedMoreMaps = 9,
+  InternalError = 10,
+  FileTooOld = 11,
+  IntermediatePointNotFound = 12,
+  TransitRouteNotFoundNoNetwork = 13,
+  TransitRouteNotFoundTooLongPedestrian = 14,
+  RouteNotFoundRedressRouteError = 15,
+};
+
+using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
+using ProgressCallback = std::function<void(float)>;
+using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
+using RouteCallback = std::function<void(Route const &)>;
+using RoutingStatisticsCallback = std::function<void(std::map<std::string, std::string> const &)>;
+using PointCheckCallback = std::function<void(m2::PointD const &)>;
+
+inline std::string DebugPrint(RouterResultCode code)
+{
+  switch (code)
+  {
+  case RouterResultCode::NoError: return "NoError";
+  case RouterResultCode::Cancelled: return "Cancelled";
+  case RouterResultCode::NoCurrentPosition: return "NoCurrentPosition";
+  case RouterResultCode::InconsistentMWMandRoute: return "InconsistentMWMandRoute";
+  case RouterResultCode::RouteFileNotExist: return "RouteFileNotExist";
+  case RouterResultCode::StartPointNotFound: return "StartPointNotFound";
+  case RouterResultCode::EndPointNotFound: return "EndPointNotFound";
+  case RouterResultCode::PointsInDifferentMWM: return "PointsInDifferentMWM";
+  case RouterResultCode::RouteNotFound: return "RouteNotFound";
+  case RouterResultCode::InternalError: return "InternalError";
+  case RouterResultCode::NeedMoreMaps: return "NeedMoreMaps";
+  case RouterResultCode::FileTooOld: return "FileTooOld";
+  case RouterResultCode::IntermediatePointNotFound: return "IntermediatePointNotFound";
+  case RouterResultCode::TransitRouteNotFoundNoNetwork: return "TransitRouteNotFoundNoNetwork";
+  case RouterResultCode::TransitRouteNotFoundTooLongPedestrian: return "TransitRouteNotFoundTooLongPedestrian";
+  case RouterResultCode::RouteNotFoundRedressRouteError: return "RouteNotFoundRedressRouteError";
+  }
+
+  std::string const result = "Unknown RouterResultCode:" + std::to_string(static_cast<int>(code));
+  ASSERT(false, (result));
+  return result;
+}
+}  // namespace routing

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -71,7 +71,7 @@ inline std::string DebugPrint(RouterResultCode code)
   case RouterResultCode::RouteNotFoundRedressRouteError: return "RouteNotFoundRedressRouteError";
   }
 
-  std::string const result = "Unknown RouterResultCode:" + std::to_string(static_cast<int>(code));
+  std::string const result = "Unknown RouterResultCode: " + std::to_string(static_cast<int>(code));
   ASSERT(false, (result));
   return result;
 }

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -39,7 +39,12 @@ enum class RouterResultCode
 
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
 using ProgressCallback = std::function<void(float)>;
+// @TODO(bykoianko) ReadyCallback and ReadyCallbackOwnership callbacks should be gathered
+// to one with the following signature:
+// std::function<void(std::unique_ptr<Route>, RouterResultCode)>
+// That means calling ReadyCallback means passing ownership of ready instance of Route.
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
+using ReadyCallbackOwnership = std::function<void(Route &, RouterResultCode)>;
 using RouteCallback = std::function<void(Route const &)>;
 using RoutingStatisticsCallback = std::function<void(std::map<std::string, std::string> const &)>;
 using PointCheckCallback = std::function<void(m2::PointD const &)>;

--- a/routing/routing_consistency_tests/routing_consistency_tests.cpp
+++ b/routing/routing_consistency_tests/routing_consistency_tests.cpp
@@ -85,7 +85,7 @@ public:
   {
     m_components.GetRouter().ClearState();
     auto const result = integration::CalculateRoute(m_components, record.start, m2::PointD::Zero(), record.stop);
-    if (result.second != IRouter::NoError)
+    if (result.second != RouterResultCode::NoError)
     {
       LOG(LINFO, ("Can't build the route. Code:", result.second));
       return false;

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_callbacks.hpp"
+
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "geometry/mercator.hpp"
@@ -60,8 +62,8 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
                                   MercatorBounds::FromLatLon(52.33853, 5.08941));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   TEST(my::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), ());
 }
 
@@ -88,7 +90,7 @@ UNIT_TEST(RussiaMoscowNoServicePassThrough)
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Bicycle>(),
                                     MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
                                     MercatorBounds::FromLatLon(55.68895, 37.70286));
-  TEST_EQUAL(route.second, IRouter::RouteNotFound, ());
+  TEST_EQUAL(route.second, RouterResultCode::RouteNotFound, ());
 }
 
 UNIT_TEST(RussiaKerchStraitFerryRoute)

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_callbacks.hpp"
+
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "routing/route.hpp"
@@ -15,8 +17,8 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
                                   MercatorBounds::FromLatLon(55.8719, 37.4464));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 5 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
@@ -39,8 +41,8 @@ UNIT_TEST(RussiaMoscowGerPanfilovtsev22BicycleWayTurnTest)
                                   MercatorBounds::FromLatLon(55.85717, 37.41052));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
@@ -56,8 +58,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
                                   MercatorBounds::FromLatLon(55.85364, 37.37318));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 3 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
@@ -73,8 +75,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest)
                                   MercatorBounds::FromLatLon(55.85765, 37.36793));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 4 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
@@ -89,8 +91,8 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointOnewayRoadTurnTest)
   TRouteResult const routeResult = integration::CalculateRoute(
       integration::GetVehicleComponents<VehicleType::Bicycle>(), point, {0.0, 0.0}, point);
 
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 }
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTwowayRoadTurnTest)
@@ -99,8 +101,8 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointTwowayRoadTurnTest)
   TRouteResult const routeResult = integration::CalculateRoute(
       integration::GetVehicleComponents<VehicleType::Bicycle>(), point, {0.0, 0.0}, point);
 
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 }
 
 UNIT_TEST(RussiaMoscowTatishchevaOnewayCarRoadTurnTest)
@@ -111,8 +113,8 @@ UNIT_TEST(RussiaMoscowTatishchevaOnewayCarRoadTurnTest)
                                   MercatorBounds::FromLatLon(55.71532, 37.61571));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 4 /* expectedTurnCount */);
 
@@ -132,8 +134,8 @@ UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)
                                   MercatorBounds::FromLatLon(55.87362, 37.43853));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 6 /* expectedTurnCount */);
 

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_callbacks.hpp"
+
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "geometry/mercator.hpp"
@@ -396,8 +398,8 @@ UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)
                                   MercatorBounds::FromLatLon(55.98419, 37.17938));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
@@ -416,8 +418,8 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
                                   MercatorBounds::FromLatLon(55.80884, 37.50668));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
@@ -436,8 +438,8 @@ UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)
                                   MercatorBounds::FromLatLon(53.89262, 27.52838));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
@@ -471,8 +473,8 @@ UNIT_TEST(RussiaMoscowSevTushinoParkPedestrianOnePointTurnTest)
       integration::GetVehicleComponents<VehicleType::Pedestrian>(), point, {0.0, 0.0}, point);
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
   integration::TestRouteLength(route, 0.0);
 }

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_callbacks.hpp"
+
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "geometry/mercator.hpp"
@@ -98,14 +100,14 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
                                     MercatorBounds::FromLatLon(45.36479, 36.62194));
-    TEST_EQUAL(route.second, IRouter::NoError, ());
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
     integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
     // And backward case
     route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
                                         MercatorBounds::FromLatLon(45.34123, 36.67679));
-    TEST_EQUAL(route.second, IRouter::NoError, ());
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
     integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
   }
@@ -118,14 +120,14 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(46.16255, -63.81643), {0., 0.},
                                     MercatorBounds::FromLatLon(46.25401, -63.70213));
-    TEST_EQUAL(route.second, IRouter::NoError, ());
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
     integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
     // And backward case
     route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(46.25401, -63.70213), {0., 0.},
                                         MercatorBounds::FromLatLon(46.16255, -63.81643));
-    TEST_EQUAL(route.second, IRouter::NoError, ());
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
     integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
   }
@@ -314,8 +316,8 @@ namespace
                                     MercatorBounds::FromLatLon(54.7998, 32.05489), {0., 0.},
                                     MercatorBounds::FromLatLon(55.753, 37.60169));
 
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
@@ -328,8 +330,8 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
                                     MercatorBounds::FromLatLon(55.8579, 37.40990));
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
@@ -343,8 +345,8 @@ namespace
                                     MercatorBounds::FromLatLon(55.7971, 37.53804), {0., 0.},
                                     MercatorBounds::FromLatLon(55.8579, 37.40990));
 
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
@@ -362,8 +364,8 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(34.0739, -115.3212), {0.0, 0.0},
                                     MercatorBounds::FromLatLon(34.0928, -115.5930));
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
     TEST_LESS(route.GetTotalTimeSec(), numeric_limits<double >::max() / 2.0, ());
@@ -376,8 +378,8 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(48.47831, -123.32749), {0.0, 0.0},
                                     MercatorBounds::FromLatLon(49.26242, -123.11553));
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
   }
 
   // Test on the route with the finish near zero length edge.
@@ -387,8 +389,8 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(53.08279, 25.30036), {0.0, 0.0},
                                     MercatorBounds::FromLatLon(53.09443, 25.34356));
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
   }
 
   // Test on the route with the start near zero length edge.
@@ -398,8 +400,8 @@ namespace
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(53.09422, 25.34411), {0.0, 0.0},
                                     MercatorBounds::FromLatLon(53.09271, 25.3467));
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
   }
 
   // Test of decreasing speed factor on roads with bad cover.

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -13,6 +13,7 @@
 #include "routing/online_cross_fetcher.hpp"
 #include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
+#include "routing/routing_callbacks.hpp"
 
 #include "indexer/index.hpp"
 
@@ -170,7 +171,7 @@ namespace integration
   {
     RouterDelegate delegate;
     shared_ptr<Route> route(new Route("mapsme"));
-    IRouter::ResultCode result = routerComponents.GetRouter().CalculateRoute(
+    RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
         Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, *route);
     ASSERT(route, ());
     return TRouteResult(route, result);
@@ -236,8 +237,8 @@ namespace integration
   {
     TRouteResult routeResult =
         CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);
-    IRouter::ResultCode const result = routeResult.second;
-    TEST_EQUAL(result, IRouter::NoError, ());
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
     TestRouteLength(*routeResult.first, expectedRouteMeters, relativeError);
   }
 

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/index_router.hpp"
+#include "routing/routing_callbacks.hpp"
 
 #include "storage/country_info_getter.hpp"
 
@@ -28,7 +29,7 @@
  *    Do this only if you really need it.
  * 3. If you want to check that a turn is absent - use TestTurnCount.
  * 4. The easiest way to gather all the information for writing an integration test is
- *    - to put a break point in IRouter::CalculateRoute() method;
+ *    - to put a break point in CalculateRoute() method;
  *    - to make a route with MapWithMe desktop application;
  *    - to get all necessary parameters and result of the route calculation;
  *    - to place them into the test you're writing.
@@ -42,7 +43,7 @@ using namespace routing;
 using namespace turns;
 using platform::LocalCountryFile;
 
-typedef pair<shared_ptr<Route>, IRouter::ResultCode> TRouteResult;
+typedef pair<shared_ptr<Route>, RouterResultCode> TRouteResult;
 
 namespace integration
 {

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -3,6 +3,7 @@
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "routing/route.hpp"
+#include "routing/routing_callbacks.hpp"
 
 #include "platform/location.hpp"
 
@@ -27,8 +28,8 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
                                   MercatorBounds::FromLatLon(55.73198, 37.63945));
 
   Route & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestCurrentStreetName(route, "Большая Тульская улица");
   integration::TestNextStreetName(route, "Подольское шоссе");

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -3,7 +3,7 @@
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "routing/route.hpp"
-
+#include "routing/routing_callbacks.hpp"
 
 using namespace routing;
 using namespace routing::turns;
@@ -16,8 +16,8 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
                                   MercatorBounds::FromLatLon(55.67293, 37.63507));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
@@ -36,8 +36,8 @@ UNIT_TEST(StPetersburgSideRoadPenaltyTest)
                                   MercatorBounds::FromLatLon(59.84268, 30.27589));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
@@ -50,8 +50,8 @@ UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
                                   MercatorBounds::FromLatLon(55.80212, 37.5389));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
-  TEST_EQUAL(result, IRouter::NoError, ());
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 4 /* expectedTurnCount */);
 
@@ -76,9 +76,9 @@ UNIT_TEST(RussiaMoscowSalameiNerisUturnTurnTest)
                                   MercatorBounds::FromLatLon(55.85182, 37.39533), {0., 0.},
                                   MercatorBounds::FromLatLon(55.84386, 37.39250));
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 5 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -110,9 +110,9 @@ UNIT_TEST(RussiaMoscowTrikotagniAndPohodniRoundaboutTurnTest)
                                   MercatorBounds::FromLatLon(55.83118, 37.40515), {0., 0.},
                                   MercatorBounds::FromLatLon(55.83384, 37.40521));
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
@@ -131,9 +131,9 @@ UNIT_TEST(SwedenBarlangeRoundaboutTurnTest)
                                   MercatorBounds::FromLatLon(60.48278, 15.42356), {0., 0.},
                                   MercatorBounds::FromLatLon(60.48462, 15.42120));
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0)
@@ -153,9 +153,9 @@ UNIT_TEST(RussiaMoscowPlanetnayaOnlyStraightTest)
                                   MercatorBounds::FromLatLon(55.80169, 37.54915));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 5 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
@@ -174,9 +174,9 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
                                   MercatorBounds::FromLatLon(55.56661, 37.69254));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -194,9 +194,9 @@ UNIT_TEST(RussiaMoscowTTKVarshavskoeShosseOutTurnTest)
                                   MercatorBounds::FromLatLon(55.69349, 37.62122));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
@@ -210,9 +210,9 @@ UNIT_TEST(RussiaMoscowTTKUTurnTest)
                                   MercatorBounds::FromLatLon(55.792544, 37.624914));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 4 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
@@ -229,9 +229,9 @@ UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
                                   MercatorBounds::FromLatLon(55.66189, 37.63254));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   // Checking a turn in case going from a not-link to a link
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
@@ -246,9 +246,9 @@ UNIT_TEST(RussiaMoscowPankratevskiPerBolshaySuharedskazPloschadTurnTest)
                                   MercatorBounds::FromLatLon(55.77209, 37.63707));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
@@ -264,9 +264,9 @@ UNIT_TEST(RussiaMoscowMKADPutilkovskeShosseTurnTest)
                                   MercatorBounds::FromLatLon(55.85099, 37.39105));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -279,9 +279,9 @@ UNIT_TEST(RussiaMoscowPetushkovaShodniaReverTurnTest)
                                   MercatorBounds::FromLatLon(55.83929, 37.40855));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -293,9 +293,9 @@ UNIT_TEST(RussiaHugeRoundaboutTurnTest)
                                   MercatorBounds::FromLatLon(55.80075, 37.32536));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0)
       .TestValid()
@@ -315,9 +315,9 @@ UNIT_TEST(BelarusMiskProspNezavisimostiMKADTurnTest)
                                   MercatorBounds::FromLatLon(53.93933, 27.67046));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -332,9 +332,9 @@ UNIT_TEST(RussiaMoscowPetushkovaPetushkovaTest)
                                   MercatorBounds::FromLatLon(55.83707, 37.40489));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
@@ -349,9 +349,9 @@ UNIT_TEST(RussiaMoscowMKADLeningradkaTest)
                                   MercatorBounds::FromLatLon(55.87854, 37.44865));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -364,9 +364,9 @@ UNIT_TEST(BelarusMKADShosseinai)
                                   MercatorBounds::FromLatLon(55.31656, 29.42626));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -381,9 +381,9 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
                                   MercatorBounds::FromLatLon(7.90724, 98.3679));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
 }
@@ -399,9 +399,9 @@ UNIT_TEST(RussiaMoscowVarshavskoeShosseMKAD)
                                   MercatorBounds::FromLatLon(55.57514, 37.61020));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -414,9 +414,9 @@ UNIT_TEST(RussiaMoscowBolshayaNikitskayaOkhotnyRyadTest)
                                   MercatorBounds::FromLatLon(55.75737, 37.61601));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
@@ -430,9 +430,9 @@ UNIT_TEST(RussiaMoscowTverskajaOkhotnyRyadTest)
                                   MercatorBounds::FromLatLon(55.75737, 37.61601));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
 }
@@ -445,9 +445,9 @@ UNIT_TEST(RussiaMoscowBolshoyKislovskiyPerBolshayaNikitinskayaUlTest)
                                   MercatorBounds::FromLatLon(55.75586, 37.60819));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
@@ -461,9 +461,9 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTheCenterUTurnTest)
                                   MercatorBounds::FromLatLon(55.79280, 37.55028));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
 }
@@ -476,9 +476,9 @@ UNIT_TEST(SwitzerlandSamstagernBergstrasseTest)
                                   MercatorBounds::FromLatLon(47.19162, 8.67590));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
@@ -491,9 +491,9 @@ UNIT_TEST(RussiaMoscowMikoiankNoUTurnTest)
                                   MercatorBounds::FromLatLon(55.79182, 37.53008));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -505,9 +505,9 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptToTTKTest)
                                   MercatorBounds::FromLatLon(55.78925, 37.57110));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
   // @TODO(bykoianko) It's a case when two possible ways go slight left.
@@ -523,9 +523,9 @@ UNIT_TEST(RussiaMoscowLeningradskiyPrptDublToTTKTest)
                                   MercatorBounds::FromLatLon(55.78925, 37.57110));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightLeft);
@@ -539,9 +539,9 @@ UNIT_TEST(RussiaMoscowSvobodaStTest)
                                   MercatorBounds::FromLatLon(55.81941, 37.45073));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
 }
@@ -554,9 +554,9 @@ UNIT_TEST(RussiaTiinskTest)
                                   MercatorBounds::FromLatLon(54.3967, 49.64924));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
@@ -572,9 +572,9 @@ UNIT_TEST(NetherlandsGorinchemBridgeTest)
                                   MercatorBounds::FromLatLon(51.81518, 4.93773));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -586,9 +586,9 @@ UNIT_TEST(RussiaVoronezhProspTrudaTest)
                                   MercatorBounds::FromLatLon(51.67193, 39.15636));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
@@ -603,9 +603,9 @@ UNIT_TEST(GermanyFrankfurtAirportTest)
                                   MercatorBounds::FromLatLon(50.05807, 8.59542));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
@@ -621,9 +621,9 @@ UNIT_TEST(GermanyFrankfurtAirport2Test)
                                   MercatorBounds::FromLatLon(50.02079, 8.49445));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
@@ -639,9 +639,9 @@ UNIT_TEST(RussiaKubinkaTest)
                                   MercatorBounds::FromLatLon(55.58365, 36.8333));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
@@ -658,9 +658,9 @@ UNIT_TEST(AustriaKitzbuhelTest)
                                   MercatorBounds::FromLatLon(47.46543, 12.38599));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -673,9 +673,9 @@ UNIT_TEST(AustriaKitzbuhel2Test)
                                   MercatorBounds::FromLatLon(47.45021, 12.382));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -688,9 +688,9 @@ UNIT_TEST(AustriaKitzbuhel3Test)
                                   MercatorBounds::FromLatLon(47.45255, 12.38498));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -703,9 +703,9 @@ UNIT_TEST(AustriaBrixentalStrasseTest)
                                   MercatorBounds::FromLatLon(47.45038, 12.32592));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
@@ -717,9 +717,9 @@ UNIT_TEST(RussiaMoscowLeningradkaToMKADTest)
                                   MercatorBounds::FromLatLon(55.87594, 37.45266));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -732,9 +732,9 @@ UNIT_TEST(RussiaMoscowMKADToSvobodaTest)
                                   MercatorBounds::FromLatLon(55.87583, 37.43046));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -748,9 +748,9 @@ UNIT_TEST(RussiaMoscowMKADTest)
                                   MercatorBounds::FromLatLon(52.16668, 5.55665));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
 }
 
@@ -762,9 +762,9 @@ UNIT_TEST(NetherlandsBarneveldTest)
                                   MercatorBounds::FromLatLon(52.16667, 5.55663));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
 }
@@ -777,9 +777,9 @@ UNIT_TEST(GermanyRaunheimAirportTest)
                                   MercatorBounds::FromLatLon(50.02089, 8.49441));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
@@ -792,9 +792,9 @@ UNIT_TEST(BelorussiaMinskTest)
                                   MercatorBounds::FromLatLon(53.91552, 27.58211));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   // @TODO(bykoianko) In this case it's better to get GoStraight direction or not get
   // direction at all. But the turn generator generates TurnSlightRight based on road geometry.
@@ -813,9 +813,9 @@ UNIT_TEST(EnglandLondonExitToLeftTest)
                                   MercatorBounds::FromLatLon(51.606785, 0.264055));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToLeft);
 }
@@ -829,9 +829,9 @@ UNIT_TEST(RussiaMoscowLeninskyProspTest)
                                   MercatorBounds::FromLatLon(55.69188, 37.55293));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
   integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
@@ -846,9 +846,9 @@ TRouteResult const routeResult =
                                 MercatorBounds::FromLatLon(55.78598, 37.56737));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -862,9 +862,9 @@ UNIT_TEST(RussiaMoscowTTKToBegovayAlleyaTest)
                                   MercatorBounds::FromLatLon(55.77956, 37.55891));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
@@ -878,9 +878,9 @@ UNIT_TEST(RussiaMoscowTTKToServiceTest)
                                   MercatorBounds::FromLatLon(55.78881, 37.57106));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
@@ -894,9 +894,9 @@ UNIT_TEST(RussiaMoscowTTKToNMaslovkaTest)
                                   MercatorBounds::FromLatLon(55.79132, 37.57481));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
@@ -909,9 +909,9 @@ UNIT_TEST(RussiaMoscowComplicatedTurnTest)
                                   MercatorBounds::FromLatLon(55.68426, 37.59854));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
@@ -926,9 +926,9 @@ UNIT_TEST(USATampaTest)
                                   MercatorBounds::FromLatLon(28.04459, -82.58448));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
@@ -943,9 +943,9 @@ UNIT_TEST(RussiaMoscowMinskia1TurnTest)
                                   MercatorBounds::FromLatLon(55.73694, 37.48587));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
 }
@@ -958,9 +958,9 @@ UNIT_TEST(RussiaMoscowMinskia2TurnTest)
                                   MercatorBounds::FromLatLon(55.74336, 37.48124));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
@@ -975,9 +975,9 @@ UNIT_TEST(RussiaMoscowBarikadnaiTurnTest)
                                   MercatorBounds::FromLatLon(55.75936, 37.58286));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }
@@ -991,9 +991,9 @@ UNIT_TEST(RussiaMoscowKomsomolskyTurnTest)
                                   MercatorBounds::FromLatLon(55.73485, 37.59543));
 
   Route const & route = *routeResult.first;
-  IRouter::ResultCode const result = routeResult.second;
+  RouterResultCode const result = routeResult.second;
 
-  TEST_EQUAL(result, IRouter::NoError, ());
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
 }

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -74,7 +74,7 @@ RoutingSession::RoutingSession()
 }
 
 void RoutingSession::Init(RoutingStatisticsCallback const & routingStatisticsFn,
-                          RouterDelegate::TPointCheckCallback const & pointCheckCallback)
+                          PointCheckCallback const & pointCheckCallback)
 {
   threads::MutexGuard guard(m_routingSessionMutex);
   ASSERT(m_router == nullptr, ());
@@ -134,13 +134,13 @@ m2::PointD RoutingSession::GetEndPoint() const
   return m_checkpoints.GetFinish();
 }
 
-void RoutingSession::DoReadyCallback::operator()(Route & route, IRouter::ResultCode e)
+void RoutingSession::DoReadyCallback::operator()(Route & route, RouterResultCode e)
 {
   threads::MutexGuard guard(m_routeSessionMutexInner);
 
   ASSERT(m_rs.m_route, ());
 
-  if (e != IRouter::NeedMoreMaps)
+  if (e != RouterResultCode::NeedMoreMaps)
   {
     m_rs.AssignRoute(route, e);
   }
@@ -505,16 +505,16 @@ void RoutingSession::GenerateTurnNotifications(vector<string> & turnNotification
     m_turnNotificationsMgr.GenerateTurnNotifications(turns, turnNotifications);
 }
 
-void RoutingSession::AssignRoute(Route & route, IRouter::ResultCode e)
+void RoutingSession::AssignRoute(Route & route, RouterResultCode e)
 {
-  if (e != IRouter::Cancelled)
+  if (e != RouterResultCode::Cancelled)
   {
     if (route.IsValid())
       SetState(RouteNotStarted);
     else
       SetState(RoutingNotActive);
 
-    if (e != IRouter::NoError)
+    if (e != RouterResultCode::NoError)
       SetState(RouteNotReady);
   }
   else

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/async_router.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/turns.hpp"
@@ -75,16 +76,10 @@ public:
    * RouteFinished -> RouteNotReady       // start new route
    */
 
-  using RoutingStatisticsCallback = function<void(map<string, string> const &)>;
-  using ReadyCallback = function<void(Route const &, IRouter::ResultCode)>;
-  using ProgressCallback = function<void(float)>;
-  using CheckpointCallback = function<void(size_t passedCheckpointIdx)>;
-  using RouteCallback = function<void(Route const &)>;
-
   RoutingSession();
 
   void Init(RoutingStatisticsCallback const & routingStatisticsFn,
-            RouterDelegate::TPointCheckCallback const & pointCheckCallback);
+            PointCheckCallback const & pointCheckCallback);
 
   void SetRouter(unique_ptr<IRouter> && router, unique_ptr<OnlineAbsentCountriesFetcher> && fetcher);
 
@@ -187,11 +182,11 @@ private:
     {
     }
 
-    void operator()(Route & route, IRouter::ResultCode e);
+    void operator()(Route & route, RouterResultCode e);
   };
 
   // Should be called with locked m_routingSessionMutex.
-  void AssignRoute(Route & route, IRouter::ResultCode e);
+  void AssignRoute(Route & route, RouterResultCode e);
 
   /// Returns a nearest speed camera record on your way and distance to it.
   /// Returns kInvalidSpeedCameraDistance if there is no cameras on your way.

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -509,7 +509,7 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
   return true;
 }
 
-IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
+RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
                                        RouterDelegate const & delegate,
                                        vector<Junction> & junctions, Route::TTurns & turnsDir,
                                        Route::TStreets & streets, vector<Segment> & segments)
@@ -517,7 +517,7 @@ IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds 
   LOG(LDEBUG, ("Shortest th length:", result.GetPathLength()));
 
   if (delegate.IsCancelled())
-    return IRouter::Cancelled;
+    return RouterResultCode::Cancelled;
   // Annotate turns.
   size_t skipTurnSegments = 0;
   auto const & loadedSegments = result.GetSegments();
@@ -580,7 +580,7 @@ IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds 
     junctions.push_back(junctions.front());
 
   if (junctions.size() < 2)
-    return IRouter::ResultCode::RouteNotFound;
+    return RouterResultCode::RouteNotFound;
 
   junctions.front() = result.GetStartPoint();
   junctions.back() = result.GetEndPoint();
@@ -596,7 +596,7 @@ IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds 
                  t.m_targetName, "exit:", t.m_exitNum));
   }
 #endif
-  return IRouter::ResultCode::NoError;
+  return RouterResultCode::NoError;
 }
 
 double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t endPointIndex,

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/loaded_path_segment.hpp"
+#include "routing/routing_callbacks.hpp"
 #include "routing/routing_result_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
@@ -93,7 +94,7 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
  * \param segments route segments.
  * \return routing operation result code.
  */
-IRouter::ResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
+RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
                                        RouterDelegate const & delegate, std::vector<Junction> & points,
                                        Route::TTurns & turnsDir, Route::TStreets & streets,
                                        std::vector<Segment> & segments);

--- a/strings.txt
+++ b/strings.txt
@@ -11960,7 +11960,7 @@ fa = دوباره نپرس
     fa = ورود به: %s
 
   [dialog_routing_download_and_update_maps]
-    comment = Text for routing::IRouter::FileTooOld dialog.
+    comment = Text for routing::RouterResultCode::FileTooOld dialog.
     tags = ios, android
     en = Download and update all map along the projected path to calculate route.
     ru = Для построения маршрута загрузите и обновите все карты по пути следования.

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E311CC9247E00A7772A /* bicycle_directions.hpp */; };
 		56290B87206A3232003892E0 /* routing_algorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B85206A3231003892E0 /* routing_algorithm.cpp */; };
 		56290B88206A3232003892E0 /* routing_algorithm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B86206A3231003892E0 /* routing_algorithm.hpp */; };
+		562BDE2020D14860008EFF6F /* routing_callbacks.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */; };
 		56555E561D897C90009D786D /* libalohalitics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACE61C68A23B009CB89E /* libalohalitics.a */; };
 		56555E581D897C9D009D786D /* liboauthcpp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6742ACFA1C68A2D7009CB89E /* liboauthcpp.a */; };
 		56555E591D897D28009D786D /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6742ACDE1C68A13F009CB89E /* testingmain.cpp */; };
@@ -361,6 +362,7 @@
 		56099E311CC9247E00A7772A /* bicycle_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_directions.hpp; sourceTree = "<group>"; };
 		56290B85206A3231003892E0 /* routing_algorithm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_algorithm.cpp; sourceTree = "<group>"; };
 		56290B86206A3231003892E0 /* routing_algorithm.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_algorithm.hpp; sourceTree = "<group>"; };
+		562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_callbacks.hpp; sourceTree = "<group>"; };
 		567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor_test.cpp; sourceTree = "<group>"; };
 		5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor.cpp; sourceTree = "<group>"; };
 		5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = checkpoint_predictor.hpp; sourceTree = "<group>"; };
@@ -770,6 +772,7 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */,
 				56FA20461FBF23A90045DE78 /* cross_mwm_ids.hpp */,
 				40BEC0801F99FFD600E06CA4 /* transit_info.hpp */,
 				5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */,
@@ -985,6 +988,7 @@
 				A120B34F1B4A7C0A002F3808 /* online_absent_fetcher.hpp in Headers */,
 				0C62BFE61E8ADC3100055A79 /* coding.hpp in Headers */,
 				674F9BD51B0A580E00704FFA /* road_graph.hpp in Headers */,
+				562BDE2020D14860008EFF6F /* routing_callbacks.hpp in Headers */,
 				0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */,
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
 				405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */,


### PR DESCRIPTION
**Getting rid of RoutingSession/RoutingManager race conditions. PR1**

План работ ниже пойдет в мастер рядом PR, что не делать одного огромного. Данный PR реализует п. 1 плана ниже.

**План работ, чтоб избавиться от проблем с много поточным доступам к данным в RoutingSession/RoutingManager.** 

Сейчас там во многих местах есть race condition. А так же не эффективное использование mutex-ов. Если случаи, когда несколько mutex-ов захватывается, а потом ничего не делается и они отпускаются. Кроме того, если лишние копирования класса Route.

План работ включает в себя подготовку кода, а затем решение поставленных выше проблем:

1. Объявить все колбеки связанные с прокладкой маршрута в одном файле и убрать дубликаты объявлений (сейчас они переобъявляются в routing_session.hpp, routing_delegate.hpp и routing_manager.hpp). DONE.

2. Наследовать `RouterDelegateProxy` от `TimeoutCancellable` и удалить `RouterDelegate m_delegate` из RouterDelegateProxy, поскольку используется только базовй класс (`TimeoutCancellable`) у `RouterDelegateProxy::m_delegate`.

3. При инициализации `RoutingSession (`m_routingSession.Init(...)`) в качестве второго параметра передается лямбда `PointCheckCallback`. В релизе она всегда пустая. Но для ее вызова, на каждой посещаемой вершине захватывается mutex. Это нужно исправить и это ускорит прокладку маршрута.

4. При асинхронной прокладке маршрута принцип работы должен быть такой: 
- начальные данные (старт, финиш и прочее) передаются на в поток прокладки маршрута;
- асинхронно прокладывается маршрута (иногда уведомляя через GUI thread о прогрессе) или позволяя прервать прокладку;
- после подготовки маршрута unique_ptr<Route> отдается в RoutingSession;
- после этого момента фоновый поток маршрута больше не редактирует unique_ptr<Route>. Единственное, что возможно из фонового потока - замена на новый маршрут, если он перестроен.
Сейчас это не так. Маршрут во время построения может передаваться 2 раза в RoutingSession,  притом эта передача особо не защищена.
4.a. Нужно сделать отдельный callback для уведомления платформы о списке не достающих для прокладки маршрута mwm, полученных с сервера и добавлять эту информацию в Route на gui потоке или хранить отдельно;
4.b. Нужно сделать, чтоб callbacks уведомляющие о готовности маршрута передавали владение маршрутом (unique_ptr<Route>), а не предлагали копировать маршрут, показывая его по ссылке; 
4.c Нужно реализовать подход, описанный в п.4.

5. Нужно сделать, что все callbacks по прокладке маршрута должны вызывались на gui thread. Т.о. mutex по защите доступа к данным (поток прокладки маршрута и gui thread) должен быть один в AsyncRouter и должен защищать: копирование данных необходимых для начала прокладки, перенос unique_ptr<Route> в RoutingSession::m_route. Далее все обращения к RoutingSession::m_route должны быть из gui thread.

6. Нужно удалить не нужные mutex-ы (например, RoutingSession::m_routingSessionMutex) и обертки для них (DoReadyCallback, RoutingSession::ProtectedCall()) и заменить их на ThreadCheckers.

Как результат мы должны получить:
- отсутствие состояния гонки при использовании фонового потока роутинга для прокладки маршрута. Что может вылечить странные баги, когда ломается сопровождение по маршруту и подобные;
- уменьшение кол-ва mutex-ов и упрощение работы с RoutingSession/RoutingManager и колбеками при прокладке маршрута;
- вероятно, некоторое ускорение прокладки маршрута. Найдено место, где при посещении каждой вершины в A* захватывался и отпускался мьютекс без какой-либо работы (в релиз версии). Данные в классе Route имеют лишние копирования.

@tatiana-yan, @rokuz (и @mpimenov, если будет время) PTAL