### PR TITLE
Routing integration tests fix for 18.05.28 maps.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -65,12 +65,14 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   TEST(my::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), ());
 }
 
-UNIT_TEST(NetherlandsAmsterdamSingelStOnewayBicycleNo)
+// This test on tag cycleway=opposite for a streets which have oneway=yes.
+// It means bicycles may go in the both directions.
+UNIT_TEST(NetherlandsAmsterdamSingelStCyclewayOpposite)
 {
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents<VehicleType::Bicycle>(),
-      MercatorBounds::FromLatLon(52.3785, 4.89407), {0., 0.},
-      MercatorBounds::FromLatLon(52.37462, 4.88983), 519.0);
+      MercatorBounds::FromLatLon(52.37571, 4.88591), {0., 0.},
+      MercatorBounds::FromLatLon(52.37736, 4.88744), 212.8);
 }
 
 UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)


### PR DESCRIPTION
После обновления карт до 28 мая сломался один интеграционный тест. Он связан с тем, что таг cycleway=opposite был снят с односторонней улицы Singel в Амстердаме. Что привело к тому, что вело маршрут перестал прокладываться против движения по односторонней улице (т.к. таг cycleway=opposite был снят).

В качестве исправления, я перенес эту проверку на соседнюю улицу (Keizersgracht), на которой есть таги oneway=yes и cycleway=opposite.

Что касается переименования теста, то новое имя лучше отражает суть происходящего сейчас. Согласно: https://wiki.openstreetmap.org/wiki/Tag:cycleway=opposite?uselang=ru: 

Use cycleway=opposite for situations where cyclists are permitted to travel in both directions on a road which is one-way for normal traffic, in situations where there is no dedicated contra-flow lane marked for cyclists.
It may accompany oneway:bicycle=no to explicitly mark that road is not oneway to cyclists but there is no separate contraflow lane.

@tatiana-yan @Zverik PTAL

