### PR TITLE
[search] Fix search index build for 1-level categories

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -111,19 +111,15 @@ void GetCategoryTypes(CategoriesHolder const & categories, pair<int, int> const 
     // amenity-parking-fee and amenity-parking-underground-fee if we do not have such explicit
     // categories.
 
-    bool found = false;
     for (uint8_t level = ftype::GetLevel(t); level >= 2; --level)
     {
       ftype::TruncValue(t, level);
       if (categories.IsTypeExist(t))
-      {
-        found = true;
         break;
-      }
     }
 
     // Only categorized types will be added to index.
-    if (!found)
+    if (!categories.IsTypeExist(t))
       continue;
 
     // There are some special non-drawable types we plan to search on.

--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -187,17 +187,10 @@ UNIT_CLASS_TEST(SmokeTest, CategoriesTest)
     invisibleTypes.insert(classif().GetTypeByPath(tags));
 
   // todo(@t.yan): fix some or delete category.
-  vector<vector<string>> const badTags = {{"building"},
-                                          {"building", "address"},
-                                          {"entrance"},
-                                          {"internet_access"},
-                                          {"internet_access", "wlan"},
-                                          {"office"},
-                                          {"shop"},
-                                          {"place", "continent"},
-                                          {"place", "region"},
-                                          {"event", "fc2018_city"},
-                                          {"sponsored", "holiday"}};
+  vector<vector<string>> const badTags = {{"building", "address"},  {"entrance"},
+                                          {"internet_access"},      {"internet_access", "wlan"},
+                                          {"place", "continent"},   {"place", "region"},
+                                          {"event", "fc2018_city"}, {"sponsored", "holiday"}};
   set<uint32_t> badTypes;
   for (auto const & tags : badTags)
     badTypes.insert(classif().GetTypeByPath(tags));


### PR DESCRIPTION
ошиблась когда делала https://github.com/mapsme/omim/pull/8851
не учла что бывает `level < 2`