### PR TITLE
[routing] Parse foot=use_sidepath

### DIFF
--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -595,6 +595,7 @@ namespace ftype
           { "toll", "~", [&params] { params.AddType(types.Get(CachedTypes::TOLL)); }},
 
           { "foot", "!", [&params] { params.AddType(types.Get(CachedTypes::NOFOOT)); }},
+          { "foot", "use_sidepath", [&params] { params.AddType(types.Get(CachedTypes::NOFOOT)); }},
           { "foot", "~", [&params] { params.AddType(types.Get(CachedTypes::YESFOOT)); }},
           { "sidewalk", "~", [&params] { params.AddType(types.Get(CachedTypes::YESFOOT)); }},
 


### PR DESCRIPTION
По запросу в почте от пользователя. Предоставлю слово Володе:

> Похоже, разумно. foot=use_sidepath 18K (преимуществено в Германии): https://taginfo.openstreetmap.org/tags/foot=use_sidepath#overview 
Хотя это таг похоже пока не принят "in some countries it is not allowed to walk on the street while there is a sidewalk (e.g. Germany StVO § 25 Fußgänger, Absatz 1), which forces you to add something like foot=use_sidepath - which is not yet proposed.": https://wiki.openstreetmap.org/wiki/Talk:Key:footway
>
> Мне кажется, если есть sidepath на дороге, то разумно эту дорогу запрещать для пешего роутинга.