### PR TITLE
Add a label for leisure-dog_park

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2636,7 +2636,7 @@ sw:^Machimbo ya kihistoria|kivutio|utalii
 fa:سایت باستان شناسی
 
 leisure-dog_park
-en:3^dog area
+en:3^Dog area
 de:4^Hundezone
 
 leisure-garden|@tourism

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2637,7 +2637,12 @@ fa:سایت باستان شناسی
 
 leisure-dog_park
 en:3^Dog area|Dog park
+cs:3^Psí hřiště
 de:4^Hundezone|Hundeauslaufzone
+fi:Koirapuisto
+he:גינת כלבים
+ja:ドッグラン
+ms:Taman anjing
 
 leisure-garden|@tourism
 en:2^Garden

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2636,8 +2636,8 @@ sw:^Machimbo ya kihistoria|kivutio|utalii
 fa:سایت باستان شناسی
 
 leisure-dog_park
-en:3^Dog area
-de:4^Hundezone
+en:3^Dog area|Dog park
+de:4^Hundezone|Hundeauslaufzone
 
 leisure-garden|@tourism
 en:2^Garden

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2635,6 +2635,10 @@ sk:^Vykopávky
 sw:^Machimbo ya kihistoria|kivutio|utalii
 fa:سایت باستان شناسی
 
+leisure-dog_park
+en:3^dog area
+de:4^Hundezone
+
 leisure-garden|@tourism
 en:2^Garden
 ru:2^Сад|достопримечательность


### PR DESCRIPTION
Dog parks are currently not translated in the app and show up as `leisure-dog_park`.

I suggest to use the word "dog area" because often those dog parks are part of a bigger park.