### PR TITLE
Fix dev build path to "data" directory.

### DIFF
--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -144,8 +144,8 @@ Platform::Platform()
   }
   else
   {
-    string const devBuildWithSymlink = my::JoinPath(path, "..", "..", "data");
-    string const devBuildWithoutSymlink = my::JoinPath(path, "..", "..", "..", "omim", "data");
+    string const devBuildWithSymlink = my::JoinPath(path, "data");
+    string const devBuildWithoutSymlink = my::JoinPath(path, "..", "omim", "data");
     string const installedVersionWithPackages = my::JoinPath(path, "..", "share");
     string const installedVersionWithoutPackages = my::JoinPath(path, "..", "MapsWithMe");
     string const customInstall = path;


### PR DESCRIPTION
The MAPS.ME binary is created in the root of the
build directory, and the "data" symlink is at the
same level.
Though maybe I am just missing some reason why it is like this?
Tested on Linux, don't have OSX to test that for example.