### PR TITLE
[search] Fix poi address search

### DIFF
--- a/search/features_layer_path_finder.hpp
+++ b/search/features_layer_path_finder.hpp
@@ -3,7 +3,7 @@
 #include "search/features_layer.hpp"
 #include "search/intersection_result.hpp"
 
-#include "std/vector.hpp"
+#include <vector>
 
 #if defined(DEBUG)
 #include "base/logging.hpp"
@@ -49,7 +49,7 @@ public:
 
   template <typename TFn>
   void ForEachReachableVertex(FeaturesLayerMatcher & matcher,
-                              vector<FeaturesLayer const *> const & layers, TFn && fn)
+                              std::vector<FeaturesLayer const *> const & layers, TFn && fn)
   {
     if (layers.empty())
       return;
@@ -63,7 +63,7 @@ public:
     my::Timer timer;
 #endif  // defined(DEBUG)
 
-    vector<IntersectionResult> results;
+    std::vector<IntersectionResult> results;
     FindReachableVertices(matcher, layers, results);
 
 #if defined(DEBUG)
@@ -77,20 +77,20 @@ public:
 
 private:
   void FindReachableVertices(FeaturesLayerMatcher & matcher,
-                             vector<FeaturesLayer const *> const & layers,
-                             vector<IntersectionResult> & results);
+                             std::vector<FeaturesLayer const *> const & layers,
+                             std::vector<IntersectionResult> & results);
 
   // Tries to find all |reachable| features from the lowest layer in a
   // high level -> low level pass.
   void FindReachableVerticesTopDown(FeaturesLayerMatcher & matcher,
-                                    vector<FeaturesLayer const *> const & layers,
-                                    vector<IntersectionResult> & results);
+                                    std::vector<FeaturesLayer const *> const & layers,
+                                    std::vector<IntersectionResult> & results);
 
   // Tries to find all |reachable| features from the lowest layer in a
   // low level -> high level pass.
   void FindReachableVerticesBottomUp(FeaturesLayerMatcher & matcher,
-                                     vector<FeaturesLayer const *> const & layers,
-                                     vector<IntersectionResult> & results);
+                                     std::vector<FeaturesLayer const *> const & layers,
+                                     std::vector<IntersectionResult> & results);
 
   ::base::Cancellable const & m_cancellable;
 

--- a/search/model.cpp
+++ b/search/model.cpp
@@ -85,6 +85,10 @@ Model::Type Model::GetType(FeatureType const & feature) const
   static auto const & localityChecker = IsLocalityChecker::Instance();
   static auto const & poiChecker = IsPoiChecker::Instance();
 
+  // Check whether object is POI first to mark POIs with address tags as POI.
+  if (poiChecker(feature))
+    return TYPE_POI;
+
   if (buildingChecker(feature))
     return TYPE_BUILDING;
 
@@ -105,9 +109,6 @@ Model::Type Model::GetType(FeatureType const & feature) const
     case LOCALITY_COUNT: return TYPE_UNCLASSIFIED;
     }
   }
-
-  if (poiChecker(feature))
-    return TYPE_POI;
 
   return TYPE_UNCLASSIFIED;
 }

--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -267,5 +267,29 @@ UNIT_CLASS_TEST(SmokeTest, NoDefaultNameTest)
   SetViewport(m2::RectD(m2::PointD(-0.5, -0.5), m2::PointD(0.5, 0.5)));
   TEST(ResultsMatch("Wonderland", {ExactMatch(worldId, wonderland)}), ());
 }
+
+UNIT_CLASS_TEST(SmokeTest, PoiWithAddress)
+{
+  char const kCountryName[] = "Wonderland";
+  TestStreet mainStreet({m2::PointD(0.0, 0.0), m2::PointD(1.0, 1.0), m2::PointD(2.0, 2.0)},
+                        "Main Street", "en");
+  TestCafe cafe(m2::PointD(1.0, 1.0), "Starbucks", "en");
+  cafe.SetStreet(mainStreet);
+  cafe.SetHouseNumber("27");
+
+  auto id = BuildMwm(kCountryName, feature::DataHeader::country, [&](TestMwmBuilder & builder) {
+    builder.Add(mainStreet);
+    builder.Add(cafe);
+  });
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(2.0, 2.0)));
+  {
+    TRules rules = {ExactMatch(id, cafe)};
+    TEST(ResultsMatch("Starbucks ", rules), ());
+    TEST(ResultsMatch("Main street 27 ", rules), ());
+    TEST(ResultsMatch("Main street 27 Starbucks ", rules), ());
+    TEST(ResultsMatch("Starbucks Main street 27 ", rules), ());
+  }
+}
 }  // namespace
 }  // namespace search


### PR DESCRIPTION
У нас было несколько проблем из-за которых не искались POI, имеющие адрес, по запросу типа "Starbucks Ленинградский проспект 39 с79":
- т.к. фича, которой соответствует старбакс, имеет адрес, Model::GetType возвращала для нее тип building и запрос размечался как building street street building building, такая схема недопустима. 
Чтобы это поправить перенесла проверку на POI в начало.

- после парса типов токенов при поиске путей фича, отвечающая за POI, попадала в список фичей, соответсвующих дому (т.к. имеет адрес), поэтому при поиске POI внутри дома игнорировалась из-за проверки `if (parent.find(childFeature) != parent.end())` в addEdge. Но менять это поведение (не добавлять POI в список домов) нельзя, т.к. в этом случае сломается поиск POI по адресу.
Чтобы это поправить поменяла вид графа, который используется, теперь отношение родительства хранится послойно -- отдельно дом-улица, отдельно POI-дом.