### PR TITLE
Getting rid of RoutingSession/RoutingManager race conditions. PR2

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1090,8 +1090,8 @@ Java_com_mapswithme_maps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv *
   ASSERT(fr, ());
 
   feature::TAltitudes altitudes;
-  vector<double> segDistanceM;
-  if (!fr->GetRoutingManager().GetRouteAltitudesAndDistancesM(segDistanceM, altitudes))
+  vector<double> routePointDistanceM;
+  if (!fr->GetRoutingManager().GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
   {
     LOG(LWARNING, ("Can't get distance to route points and altitude."));
     return nullptr;
@@ -1102,7 +1102,7 @@ Java_com_mapswithme_maps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv *
   int32_t maxRouteAltitude = 0;
   measurement_utils::Units units = measurement_utils::Units::Metric;
   if (!fr->GetRoutingManager().GenerateRouteAltitudeChart(
-        width, height, altitudes, segDistanceM, imageRGBAData,
+        width, height, altitudes, routePointDistanceM, imageRGBAData,
         minRouteAltitude, maxRouteAltitude, units))
   {
     LOG(LWARNING, ("Can't generate route altitude image."));

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -27,6 +27,8 @@
 
 #include "geometry/angles.hpp"
 
+#include "indexer/feature_altitude.hpp"
+
 #include "platform/country_file.hpp"
 #include "platform/local_country_file.hpp"
 #include "platform/local_country_file_utils.hpp"
@@ -43,6 +45,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 using namespace std;
 using namespace std::placeholders;
@@ -1086,12 +1089,21 @@ Java_com_mapswithme_maps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv *
   ::Framework * fr = frm();
   ASSERT(fr, ());
 
+  feature::TAltitudes altitudes;
+  vector<double> segDistanceM;
+  if (!fr->GetRoutingManager().GetRouteAltitudesAndDistancesM(segDistanceM, altitudes))
+  {
+    LOG(LWARNING, ("Can't get distance to route points and altitude."));
+    return nullptr;
+  }
+
   vector<uint8_t> imageRGBAData;
   int32_t minRouteAltitude = 0;
   int32_t maxRouteAltitude = 0;
   measurement_utils::Units units = measurement_utils::Units::Metric;
   if (!fr->GetRoutingManager().GenerateRouteAltitudeChart(
-          width, height, imageRGBAData, minRouteAltitude, maxRouteAltitude, units))
+        width, height, altitudes, segDistanceM, imageRGBAData,
+        minRouteAltitude, maxRouteAltitude, units))
   {
     LOG(LWARNING, ("Can't generate route altitude image."));
     return nullptr;

--- a/android/src/com/mapswithme/maps/Framework.java
+++ b/android/src/com/mapswithme/maps/Framework.java
@@ -3,6 +3,7 @@ package com.mapswithme.maps;
 import android.graphics.Bitmap;
 import android.location.Location;
 import android.support.annotation.IntDef;
+import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
@@ -110,12 +111,14 @@ public class Framework
   @SuppressWarnings("unused")
   public interface RoutingListener
   {
+    @MainThread
     void onRoutingEvent(int resultCode, String[] missingMaps);
   }
 
   @SuppressWarnings("unused")
   public interface RoutingProgressListener
   {
+    @MainThread
     void onRouteBuildingProgress(float progress);
   }
 

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -117,6 +117,7 @@ public class RoutingController implements TaxiManager.TaxiListener
   @SuppressWarnings("FieldCanBeLocal")
   private final Framework.RoutingListener mRoutingListener = new Framework.RoutingListener()
   {
+    @MainThread
     @Override
     public void onRoutingEvent(final int resultCode, @Nullable final String[] missingMaps)
     {
@@ -144,6 +145,7 @@ public class RoutingController implements TaxiManager.TaxiListener
   @SuppressWarnings("FieldCanBeLocal")
   private final Framework.RoutingProgressListener mRoutingProgressListener = new Framework.RoutingProgressListener()
   {
+    @MainThread
     @Override
     public void onRouteBuildingProgress(float progress)
     {

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -121,34 +121,36 @@ public class RoutingController implements TaxiManager.TaxiListener
     public void onRoutingEvent(final int resultCode, @Nullable final String[] missingMaps)
     {
       mLogger.d(TAG, "onRoutingEvent(resultCode: " + resultCode + ")");
-      UiThread.run(() -> {
-        mLastResultCode = resultCode;
-        mLastMissingMaps = missingMaps;
-        mContainsCachedResult = true;
+      mLastResultCode = resultCode;
+      mLastMissingMaps = missingMaps;
+      mContainsCachedResult = true;
 
-        if (mLastResultCode == ResultCodesHelper.NO_ERROR
-            || ResultCodesHelper.isMoreMapsNeeded(mLastResultCode))
-        {
-          mCachedRoutingInfo = Framework.nativeGetRouteFollowingInfo();
-          if (mLastRouterType == Framework.ROUTER_TYPE_TRANSIT)
-            mCachedTransitRouteInfo = Framework.nativeGetTransitRouteInfo();
-          setBuildState(BuildState.BUILT);
-          mLastBuildProgress = 100;
-          if (mContainer != null)
-            mContainer.onBuiltRoute();
-        }
+      if (mLastResultCode == ResultCodesHelper.NO_ERROR
+        || ResultCodesHelper.isMoreMapsNeeded(mLastResultCode))
+      {
+        mCachedRoutingInfo = Framework.nativeGetRouteFollowingInfo();
+        if (mLastRouterType == Framework.ROUTER_TYPE_TRANSIT)
+          mCachedTransitRouteInfo = Framework.nativeGetTransitRouteInfo();
+        setBuildState(BuildState.BUILT);
+        mLastBuildProgress = 100;
+        if (mContainer != null)
+          mContainer.onBuiltRoute();
+      }
 
-        processRoutingEvent();
-      });
+      processRoutingEvent();
     }
   };
 
   @SuppressWarnings("FieldCanBeLocal")
-  private final Framework.RoutingProgressListener mRoutingProgressListener =
-    progress -> UiThread.run(() -> {
+  private final Framework.RoutingProgressListener mRoutingProgressListener = new Framework.RoutingProgressListener()
+  {
+    @Override
+    public void onRouteBuildingProgress(float progress)
+    {
       mLastBuildProgress = (int) progress;
       updateProgress();
-    });
+    }
+  };
 
   @SuppressWarnings("FieldCanBeLocal")
   private final Framework.RoutingRecommendationListener mRoutingRecommendationListener =

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -526,12 +526,12 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
   if (![self hasRouteAltitude])
     return;
 
-  auto segDistanceM = std::make_shared<std::vector<double>>(std::vector<double>());
+  auto routePointDistanceM = std::make_shared<std::vector<double>>(std::vector<double>());
   auto altitudes = std::make_shared<feature::TAltitudes>(feature::TAltitudes());
-  if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*segDistanceM, *altitudes))
+  if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*routePointDistanceM, *altitudes))
     return;
 
-  // Note. |segDistanceM| and |altitudes| should not be used in the method after line below.
+  // Note. |routePointDistanceM| and |altitudes| should not be used in the method after line below.
   dispatch_async(self.router.renderAltitudeImagesQueue, [=] () {
     auto router = self.router;
     CGFloat const screenScale = [UIScreen mainScreen].scale;
@@ -554,7 +554,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
  
       if(!GetFramework().GetRoutingManager().GenerateRouteAltitudeChart(width, height,
                                                                         *altitudes,
-                                                                        *segDistanceM,
+                                                                        *routePointDistanceM,
                                                                         imageRGBAData,
                                                                         minRouteAltitude,
                                                                         maxRouteAltitude, units))

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -23,6 +23,8 @@
 
 #include "platform/local_country_file_utils.hpp"
 
+#include <cstdint>
+#include <memory>
 #include <vector>
 
 using namespace routing;
@@ -524,8 +526,8 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
   if (![self hasRouteAltitude])
     return;
 
-  auto segDistanceM = make_shared<std::vector<double>>(std::vector<double>());
-  auto altitudes = make_shared<feature::TAltitudes>(feature::TAltitudes());
+  auto segDistanceM = std::make_shared<std::vector<double>>(std::vector<double>());
+  auto altitudes = std::make_shared<feature::TAltitudes>(feature::TAltitudes());
   if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*segDistanceM, *altitudes))
     return;
 
@@ -549,16 +551,16 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
       int32_t minRouteAltitude = 0;
       int32_t maxRouteAltitude = 0;
       measurement_utils::Units units = measurement_utils::Units::Metric;
-      bool result = false;
-      result = GetFramework().GetRoutingManager().GenerateRouteAltitudeChart(width, height,
-                                                                             *altitudes,
-                                                                             *segDistanceM,
-                                                                             imageRGBAData,
-                                                                             minRouteAltitude,
-                                                                             maxRouteAltitude, units);
-
-      if (!result)
+ 
+      if(!GetFramework().GetRoutingManager().GenerateRouteAltitudeChart(width, height,
+                                                                        *altitudes,
+                                                                        *segDistanceM,
+                                                                        imageRGBAData,
+                                                                        minRouteAltitude,
+                                                                        maxRouteAltitude, units))
+      {
         return;
+      }
 
       if (imageRGBAData.empty())
         return;

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -19,7 +19,11 @@
 
 #include "Framework.h"
 
+#include "indexer/feature_altitude.hpp"
+
 #include "platform/local_country_file_utils.hpp"
+
+#include <vector>
 
 using namespace routing;
 
@@ -517,21 +521,17 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
 
 + (void)routeAltitudeImageForSize:(CGSize)size completion:(MWMImageHeightBlock)block
 {
-  auto router = self.router;
-  // @TODO The method below is implemented on render renderAltitudeImagesQueue to prevent ui thread
-  // from heavy methods. On the other hand some of calls of the method should be done on ui thread.
-  // This method should be rewritten to perform on renderAltitudeImagesQueue only the heavest
-  // functions. Or all the method should be done on ui thread.
-  dispatch_async(router.renderAltitudeImagesQueue, ^{
+  if (![self hasRouteAltitude])
+    return;
+
+  auto segDistanceM = make_shared<std::vector<double>>(std::vector<double>());
+  auto altitudes = make_shared<feature::TAltitudes>(feature::TAltitudes());
+  if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*segDistanceM, *altitudes))
+    return;
+
+  // Note. |segDistanceM| and |altitudes| should not be used in the method after line below.
+  dispatch_async(self.router.renderAltitudeImagesQueue, [=] () {
     auto router = self.router;
-
-    bool hasAltitude = false;
-    dispatch_sync(dispatch_get_main_queue(), [self, &hasAltitude]{
-      hasAltitude = [self hasRouteAltitude];
-    });
-    if (!hasAltitude)
-      return;
-
     CGFloat const screenScale = [UIScreen mainScreen].scale;
     CGSize const scaledSize = {size.width * screenScale, size.height * screenScale};
     CHECK_GREATER_OR_EQUAL(scaledSize.width, 0.0, ());
@@ -550,12 +550,12 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
       int32_t maxRouteAltitude = 0;
       measurement_utils::Units units = measurement_utils::Units::Metric;
       bool result = false;
-      dispatch_sync(dispatch_get_main_queue(), [&] {
-        result = GetFramework().GetRoutingManager().GenerateRouteAltitudeChart(width, height,
-                                                                               imageRGBAData,
-                                                                               minRouteAltitude,
-                                                                               maxRouteAltitude, units);
-      });
+      result = GetFramework().GetRoutingManager().GenerateRouteAltitudeChart(width, height,
+                                                                             *altitudes,
+                                                                             *segDistanceM,
+                                                                             imageRGBAData,
+                                                                             minRouteAltitude,
+                                                                             maxRouteAltitude, units);
 
       if (!result)
         return;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -368,7 +368,8 @@ private:
     auto const markId = m->GetId();
     auto const groupId = static_cast<kml::MarkGroupId>(m->GetMarkType());
     CHECK_EQUAL(m_userMarks.count(markId), 0, ());
-    ASSERT_LESS(groupId, m_userMarkLayers.size(), ());
+    ASSERT_GREATER(groupId, 0, ());
+    ASSERT_LESS(groupId - 1, m_userMarkLayers.size(), ());
     m_userMarks.emplace(markId, std::move(mark));
     m_changesTracker.OnAddMark(markId);
     m_userMarkLayers[groupId - 1]->AttachUserMark(markId);

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1000,29 +1000,29 @@ bool RoutingManager::HasRouteAltitude() const
   return m_loadAltitudes && m_routingSession.HasRouteAltitude();
 }
 
-bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & segDistanceM,
+bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & routePointDistanceM,
                                                     feature::TAltitudes & altitudes) const
 {
-  if (!m_routingSession.GetRouteAltitudesAndDistancesM(segDistanceM, altitudes))
+  if (!m_routingSession.GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
     return false;
 
-  segDistanceM.insert(segDistanceM.begin(), 0.0);
+  routePointDistanceM.insert(routePointDistanceM.begin(), 0.0);
   return true;
 }
 
 bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
                                                 feature::TAltitudes const & altitudes,
-                                                vector<double> const & segDistance,
+                                                vector<double> const & routePointDistanceM,
                                                 vector<uint8_t> & imageRGBAData,
                                                 int32_t & minRouteAltitude,
                                                 int32_t & maxRouteAltitude,
                                                 measurement_utils::Units & altitudeUnits) const
 {
-  CHECK_EQUAL(altitudes.size(), segDistance.size(), ());
+  CHECK_EQUAL(altitudes.size(), routePointDistanceM.size(), ());
   if (altitudes.empty())
     return false;
 
-  if (!maps::GenerateChart(width, height, segDistance, altitudes,
+  if (!maps::GenerateChart(width, height, routePointDistanceM, altitudes,
                            GetStyleReader().GetCurrentStyle(), imageRGBAData))
     return false;
 

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -241,7 +241,7 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
 #endif
   );
 
-  m_routingSession.SetReadyCallbacks(
+  m_routingSession.SetRoutingCallbacks(
       [this](Route const & route, RouterResultCode code) { OnBuildRouteReady(route, code); },
       [this](Route const & route, RouterResultCode code) { OnRebuildRouteReady(route, code); },
       [this](uint64_t routeId, vector<string> const & absentCountries) {
@@ -934,7 +934,7 @@ void RoutingManager::CheckLocationForRouting(location::GpsInfo const & info)
 void RoutingManager::CallRouteBuilded(RouterResultCode code,
                                       storage::TCountriesVec const & absentCountries)
 {
-  m_routingCallback(code, absentCountries);
+  m_routingBuildingCallback(code, absentCountries);
 }
 
 void RoutingManager::MatchLocationToRoute(location::GpsInfo & location,

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1000,19 +1000,25 @@ bool RoutingManager::HasRouteAltitude() const
   return m_loadAltitudes && m_routingSession.HasRouteAltitude();
 }
 
+bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & segDistanceM,
+                                                    feature::TAltitudes & altitudes) const
+{
+  if (!m_routingSession.GetRouteAltitudesAndDistancesM(segDistanceM, altitudes))
+    return false;
+
+  segDistanceM.insert(segDistanceM.begin(), 0.0);
+  return true;
+}
+
 bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
+                                                feature::TAltitudes const & altitudes,
+                                                vector<double> const & segDistance,
                                                 vector<uint8_t> & imageRGBAData,
                                                 int32_t & minRouteAltitude,
                                                 int32_t & maxRouteAltitude,
                                                 measurement_utils::Units & altitudeUnits) const
 {
-  feature::TAltitudes altitudes;
-  vector<double> segDistance;
-
-  if (!m_routingSession.GetRouteAltitudesAndDistancesM(segDistance, altitudes))
-    return false;
-  segDistance.insert(segDistance.begin(), 0.0);
-
+  CHECK_EQUAL(altitudes.size(), segDistance.size(), ());
   if (altitudes.empty())
     return false;
 

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -986,7 +986,7 @@ void RoutingManager::SetDrapeEngine(ref_ptr<df::DrapeEngine> engine, bool is3dAl
       // In case of the engine reinitialization recover route.
       if (IsRoutingActive())
       {
-        m_routingSession.ProtectedCall([this](Route const & route) { InsertRoute(route); });
+        m_routingSession.RouteCall([this](Route const & route) { InsertRoute(route); });
 
         if (is3dAllowed && m_routingSession.IsFollowing())
           m_drapeEngine.SafeCall(&df::DrapeEngine::EnablePerspective);

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -301,9 +301,7 @@ void RoutingManager::OnBuildRouteReady(Route const & route, RouterResultCode cod
                            true /* applyRotation */, -1 /* zoom */, true /* isAnim */);
   }
 
-  storage::TCountriesVec absentCountries;
-  absentCountries.assign(route.GetAbsentCountries().begin(), route.GetAbsentCountries().end());
-  CallRouteBuilded(code, absentCountries);
+  CallRouteBuilded(code, storage::TCountriesVec());
 }
 
 void RoutingManager::OnRebuildRouteReady(Route const & route, RouterResultCode code)
@@ -319,9 +317,11 @@ void RoutingManager::OnRebuildRouteReady(Route const & route, RouterResultCode c
 
 void RoutingManager::OnNeedMoreMaps(uint64_t routeId, vector<string> const & absentCountries)
 {
-  // @TODO(bykoianko) If |m_routingSession.IsRouteId(routeId)| or if |m_routingSession::m_route|
-  // was not removed lines below should be executed. It should be done
-  // when |m_routingSession::m_route| will be implemented as unique_ptr<Route>.
+  // No need to inform user about maps needed for the route if the method is called
+  // when RoutingSession contains a new route.
+  if (m_routingSession.IsRouteValid() && !m_routingSession.IsRouteId(routeId))
+    return;
+
   HidePreviewSegments();
   CallRouteBuilded(RouterResultCode::NeedMoreMaps, absentCountries);
 }

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -48,8 +48,6 @@ using namespace std;
 
 namespace
 {
-//#define SHOW_ROUTE_DEBUG_MARKS
-
 char const kRouterTypeKey[] = "router";
 
 double const kRouteScaleMultiplier = 1.5;
@@ -229,17 +227,19 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
     GetPlatform().GetMarketingService().SendMarketingEvent(marketing::kRoutingCalculatingRoute, {});
   };
 
-  m_routingSession.Init(routingStatisticsFn, [this](m2::PointD const & pt)
-  {
-    UNUSED_VALUE(this);
+  m_routingSession.Init(routingStatisticsFn,
 #ifdef SHOW_ROUTE_DEBUG_MARKS
-    if (m_bmManager == nullptr)
-      return;
-    auto editSession = m_bmManager->GetEditSession();
-    editSession.SetIsVisible(UserMark::Type::DEBUG_MARK, true);
-    editSession.CreateUserMark<DebugMarkPoint>(pt);
+                        [this](m2::PointD const & pt) {
+                          if (m_bmManager == nullptr)
+                            return;
+                          auto editSession = m_bmManager->GetEditSession();
+                          editSession.SetIsVisible(UserMark::Type::DEBUG_MARK, true);
+                          editSession.CreateUserMark<DebugMarkPoint>(pt);
+                        }
+#else
+                        nullptr
 #endif
-  });
+  );
 
   m_routingSession.SetReadyCallbacks(
       [this](Route const & route, RouterResultCode code) { OnBuildRouteReady(route, code); },

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -225,16 +225,16 @@ public:
   /// false otherwise.
   bool HasRouteAltitude() const;
 
-  /// \brief Fills altitude of current route points and distance form the beginning in meters
-  /// of the route point.
-  bool GetRouteAltitudesAndDistancesM(vector<double> & segDistanceM,
+  /// \brief Fills altitude of current route points and distance in meters form the beginning
+  /// of the route point based on the route in RoutingSession.
+  bool GetRouteAltitudesAndDistancesM(std::vector<double> & routePointDistanceM,
                                       feature::TAltitudes & altitudes) const;
 
   /// \brief Generates 4 bytes per point image (RGBA) and put the data to |imageRGBAData|.
   /// \param width is width of chart shall be generated in pixels.
   /// \param height is height of chart shall be generated in pixels.
   /// \param altitudes route points altitude.
-  /// \param segDistance distance in meters from route beginning to end of segments.
+  /// \param routePointDistanceM distance in meters from route beginning to route points.
   /// \param imageRGBAData is bits of result image in RGBA.
   /// \param minRouteAltitude is min altitude along the route in altitudeUnits.
   /// \param maxRouteAltitude is max altitude along the route in altitudeUnits.
@@ -246,7 +246,7 @@ public:
   /// could return false if route was deleted or rebuilt between the calls.
   bool GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
                                   feature::TAltitudes const & altitudes,
-                                  vector<double> const & segDistance,
+                                  std::vector<double> const & routePointDistanceM,
                                   std::vector<uint8_t> & imageRGBAData, int32_t & minRouteAltitude,
                                   int32_t & maxRouteAltitude,
                                   measurement_utils::Units & altitudeUnits) const;

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -129,7 +129,7 @@ public:
 
   void SetRouteBuildingListener(RouteBuildingCallback const & buildingCallback)
   {
-    m_routingCallback = buildingCallback;
+    m_routingBuildingCallback = buildingCallback;
   }
   /// See warning above.
   void SetRouteProgressListener(routing::ProgressCallback const & progressCallback)
@@ -284,7 +284,7 @@ private:
 
   void OnExtrapolatedLocationUpdate(location::GpsInfo const & info);
 
-  RouteBuildingCallback m_routingCallback = nullptr;
+  RouteBuildingCallback m_routingBuildingCallback = nullptr;
   RouteRecommendCallback m_routeRecommendCallback = nullptr;
   Callbacks m_callbacks;
   df::DrapeEngineSafePtr m_drapeEngine;

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -225,9 +225,16 @@ public:
   /// false otherwise.
   bool HasRouteAltitude() const;
 
+  /// \brief Fills altitude of current route points and distance form the beginning in meters
+  /// of the route point.
+  bool GetRouteAltitudesAndDistancesM(vector<double> & segDistanceM,
+                                      feature::TAltitudes & altitudes) const;
+
   /// \brief Generates 4 bytes per point image (RGBA) and put the data to |imageRGBAData|.
   /// \param width is width of chart shall be generated in pixels.
   /// \param height is height of chart shall be generated in pixels.
+  /// \param altitudes route points altitude.
+  /// \param segDistance distance in meters from route beginning to end of segments.
   /// \param imageRGBAData is bits of result image in RGBA.
   /// \param minRouteAltitude is min altitude along the route in altitudeUnits.
   /// \param maxRouteAltitude is max altitude along the route in altitudeUnits.
@@ -237,8 +244,11 @@ public:
   /// |imageRGBAData| is not zero.
   /// \note If HasRouteAltitude() method returns true, GenerateRouteAltitudeChart(...)
   /// could return false if route was deleted or rebuilt between the calls.
-  bool GenerateRouteAltitudeChart(uint32_t width, uint32_t height, std::vector<uint8_t> & imageRGBAData,
-                                  int32_t & minRouteAltitude, int32_t & maxRouteAltitude,
+  bool GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
+                                  feature::TAltitudes const & altitudes,
+                                  vector<double> const & segDistance,
+                                  std::vector<uint8_t> & imageRGBAData, int32_t & minRouteAltitude,
+                                  int32_t & maxRouteAltitude,
                                   measurement_utils::Units & altitudeUnits) const;
 
   uint32_t OpenRoutePointsTransaction();

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -207,6 +207,8 @@ public:
                         storage::TCountriesVec const & absentCountries);
   void OnBuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
   void OnRebuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
+  void OnNeedMoreMaps(uint64_t routeId, std::vector<std::string> const & absentCountries);
+  void OnRemoveRoute(routing::RouterResultCode code);
   void OnRoutePointPassed(RouteMarkType type, size_t intermediateIndex);
   void OnLocationUpdate(location::GpsInfo const & info);
   void SetAllowSendingPoints(bool isAllowed)

--- a/partners_api/partners_api_tests/booking_tests.cpp
+++ b/partners_api/partners_api_tests/booking_tests.cpp
@@ -1,13 +1,13 @@
 #include "testing/testing.hpp"
 
-#include "partners_api/partners_api_tests/async_gui_thread.hpp"
-
 #include "partners_api/booking_api.hpp"
+
+#include "platform/platform_tests_support/async_gui_thread.hpp"
 
 #include <chrono>
 #include <utility>
 
-using namespace partners_api;
+using namespace platform::tests_support;
 using namespace booking;
 
 namespace

--- a/partners_api/partners_api_tests/taxi_engine_tests.cpp
+++ b/partners_api/partners_api_tests/taxi_engine_tests.cpp
@@ -1,11 +1,11 @@
 #include "testing/testing.hpp"
 
-#include "partners_api/partners_api_tests/async_gui_thread.hpp"
-
 #include "partners_api/maxim_api.hpp"
 #include "partners_api/taxi_engine.hpp"
 #include "partners_api/uber_api.hpp"
 #include "partners_api/yandex_api.hpp"
+
+#include "platform/platform_tests_support/async_gui_thread.hpp"
 
 #include "platform/gui_thread.hpp"
 
@@ -15,7 +15,7 @@
 #include "base/stl_add.hpp"
 #include "base/worker_thread.hpp"
 
-using namespace partners_api;
+using namespace platform::tests_support;
 
 namespace
 {

--- a/partners_api/partners_api_tests/viator_tests.cpp
+++ b/partners_api/partners_api_tests/viator_tests.cpp
@@ -1,7 +1,5 @@
 #include "testing/testing.hpp"
 
-#include "partners_api/partners_api_tests/async_gui_thread.hpp"
-
 #include "partners_api/viator_api.hpp"
 
 #include <algorithm>
@@ -10,8 +8,6 @@
 #include <vector>
 
 #include "3party/jansson/myjansson.hpp"
-
-using namespace partners_api;
 
 namespace
 {

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -281,6 +281,10 @@ public:
   MarketingService & GetMarketingService() { return m_marketingService; }
   platform::SecureStorage & GetSecureStorage() { return m_secureStorage; }
 
+  /// \brief Placing an executable object |task| on a queue of |thread|. Then the object will be
+  /// executed on |thread|.
+  /// \note |task| cannot be moved in case of |Thread::Gui|. This way unique_ptr cannot be used
+  /// in |task|. Use shared_ptr instead.
   template <typename Task>
   void RunTask(Thread thread, Task && task)
   {

--- a/platform/platform_tests_support/CMakeLists.txt
+++ b/platform/platform_tests_support/CMakeLists.txt
@@ -2,6 +2,7 @@ project(platform_tests_support)
 
 set(
   SRC
+  async_gui_thread.hpp
   scoped_dir.cpp
   scoped_dir.hpp
   scoped_file.cpp

--- a/platform/platform_tests_support/async_gui_thread.hpp
+++ b/platform/platform_tests_support/async_gui_thread.hpp
@@ -6,7 +6,9 @@
 #include "base/stl_add.hpp"
 #include "base/worker_thread.hpp"
 
-namespace partners_api
+namespace platform
+{
+namespace tests_support
 {
 class AsyncGuiThread
 {
@@ -24,4 +26,5 @@ public:
 private:
   Platform::ThreadRunner m_runner;
 };
-}  // namespace partners_api
+}  // namespace tests_support
+}  // namespace platform

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -439,7 +439,7 @@ void AsyncRouter::CalculateRoute()
   if (code != RouterResultCode::NoError)
   {
     if (code == RouterResultCode::NeedMoreMaps)
-       RunOnGuiThread([delegate, routeId, absent]() { delegate->OnNeedMoreMaps(routeId, absent); });
+      RunOnGuiThread([delegate, routeId, absent]() { delegate->OnNeedMoreMaps(routeId, absent); });
     else
       RunOnGuiThread([delegate, code]() { delegate->OnRemoveRoute(code); });
   }

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -7,15 +7,13 @@
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
 
-#include "std/functional.hpp"
-#include "std/utility.hpp"
+#include <functional>
 
 using namespace std;
 using namespace std::placeholders;
 
 namespace routing
 {
-
 namespace
 {
 map<string, string> PrepareStatisticsData(string const & routerName,

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -338,8 +338,8 @@ void AsyncRouter::ThreadFunc()
 
 void AsyncRouter::CalculateRoute()
 {
-  shared_ptr<RouterDelegateProxy> delegate;
   Checkpoints checkpoints;
+  shared_ptr<RouterDelegateProxy> delegate;
   m2::PointD startDirection;
   bool adjustToPrevRoute = false;
   shared_ptr<IOnlineFetcher> absentFetcher;

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -424,6 +424,7 @@ void AsyncRouter::CalculateRoute()
   vector<string> absent;
   if (absentFetcher && needFetchAbsent)
     absentFetcher->GetAbsentCountries(absent);
+  absent.insert(absent.end(), route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
 
   if (!absent.empty() && code == RouterResultCode::NoError)
     code = RouterResultCode::NeedMoreMaps;

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -257,6 +257,7 @@ void AsyncRouter::CalculateRoute()
   bool adjustToPrevRoute = false;
   shared_ptr<IOnlineFetcher> absentFetcher;
   shared_ptr<IRouter> router;
+  uint64_t routeCounter = m_routeCounter;
 
   {
     unique_lock<mutex> ul(m_guard);
@@ -276,9 +277,10 @@ void AsyncRouter::CalculateRoute()
     delegate = m_delegate;
     router = m_router;
     absentFetcher = m_absentFetcher;
+    routeCounter = ++m_routeCounter;
   }
 
-  Route route(router->GetName());
+  Route route(router->GetName(), routeCounter);
   RouterResultCode code;
 
   my::Timer timer;

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -9,6 +9,7 @@
 
 #include "base/thread.hpp"
 
+#include "std/cstdint.hpp"
 #include "std/condition_variable.hpp"
 #include "std/map.hpp"
 #include "std/mutex.hpp"
@@ -116,6 +117,7 @@ private:
 
   RoutingStatisticsCallback const m_routingStatisticsCallback;
   PointCheckCallback const m_pointCheckCallback;
+  uint64_t m_routeCounter = 0;
 };
 
 }  // namespace routing

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -72,7 +72,7 @@ private:
   public:
     RouterDelegateProxy(ReadyCallbackOwnership const & onReady,
                         NeedMoreMapsCallback const & onNeedMoreMaps,
-                        RemoveRouteCallback const & removeRoute,
+                        RemoveRouteCallback const & onRemoveRoute,
                         PointCheckCallback const & onPointCheck,
                         ProgressCallback const & onProgress,
                         uint32_t timeoutSec);
@@ -94,20 +94,11 @@ private:
     // - it's possible to build route only if to load some maps
     // - there's a faster route, but it's necessary to load some more maps to build it
     NeedMoreMapsCallback const m_onNeedMoreMaps;
-    RemoveRouteCallback const m_removeRoute;
+    RemoveRouteCallback const m_onRemoveRoute;
     PointCheckCallback const m_onPointCheck;
     ProgressCallback const m_onProgress;
     RouterDelegate m_delegate;
   };
-
-  void RunOnReadyOnGuiThread(shared_ptr<RouterDelegateProxy> delegate, shared_ptr<Route> route,
-                             RouterResultCode code);
-
-  template <typename Task>
-  void RunOnGuiThread(Task && task)
-  {
-    GetPlatform().RunTask(Platform::Thread::Gui, std::forward<Task>(task));
-  }
 
 private:
   std::mutex m_guard;

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -11,14 +11,13 @@
 
 #include "base/thread.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/condition_variable.hpp"
-#include "std/map.hpp"
-#include "std/mutex.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/utility.hpp"
+#include <condition_variable>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
 
 namespace routing
 {
@@ -35,7 +34,7 @@ public:
   /// Sets a synchronous router, current route calculation will be cancelled
   /// @param router pointer to a router implementation
   /// @param fetcher pointer to a online fetcher
-  void SetRouter(unique_ptr<IRouter> && router, unique_ptr<IOnlineFetcher> && fetcher);
+  void SetRouter(std::unique_ptr<IRouter> && router, std::unique_ptr<IOnlineFetcher> && fetcher);
 
   /// Main method to calulate new route from startPt to finalPt with start direction
   /// Processed result will be passed to callback. Callback will called at GUI thread.
@@ -78,7 +77,7 @@ private:
                         ProgressCallback const & onProgress,
                         uint32_t timeoutSec);
 
-    void OnReady(shared_ptr<Route> route, RouterResultCode resultCode);
+    void OnReady(std::shared_ptr<Route> route, RouterResultCode resultCode);
     void OnNeedMoreMaps(uint64_t routeId, vector<std::string> const & absentCounties);
     void OnRemoveRoute(RouterResultCode resultCode);
     void Cancel();
@@ -89,7 +88,7 @@ private:
     void OnProgress(float progress);
     void OnPointCheck(m2::PointD const & pt);
 
-    mutex m_guard;
+    std::mutex m_guard;
     ReadyCallbackOwnership const m_onReadyOwnership;
     // |m_onNeedMoreMaps| may be called after |m_onReadyOwnership| if
     // - it's possible to build route only if to load some maps
@@ -111,11 +110,11 @@ private:
   }
 
 private:
-  mutex m_guard;
+  std::mutex m_guard;
 
   /// Thread which executes routing calculation
   threads::SimpleThread m_thread;
-  condition_variable m_threadCondVar;
+  std::condition_variable m_threadCondVar;
   bool m_threadExit;
   bool m_hasRequest;
 
@@ -124,13 +123,12 @@ private:
   Checkpoints m_checkpoints;
   m2::PointD m_startDirection = m2::PointD::Zero();
   bool m_adjustToPrevRoute = false;
-  shared_ptr<RouterDelegateProxy> m_delegate;
-  shared_ptr<IOnlineFetcher> m_absentFetcher;
-  shared_ptr<IRouter> m_router;
+  std::shared_ptr<RouterDelegateProxy> m_delegate;
+  std::shared_ptr<IOnlineFetcher> m_absentFetcher;
+  std::shared_ptr<IRouter> m_router;
 
   RoutingStatisticsCallback const m_routingStatisticsCallback;
   PointCheckCallback const m_pointCheckCallback;
   uint64_t m_routeCounter = 0;
 };
-
 }  // namespace routing

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -43,9 +43,8 @@ public:
   /// @param readyCallback function to return routing result
   /// @param progressCallback function to update the router progress
   /// @param timeoutSec timeout to cancel routing. 0 is infinity.
-  // @TODO(bykoianko) Gather |readyCallback| with passing ownership of unique_ptr,
-  // |needMoreMapsCallback| and |removeRouteCallback| to one delegate. No need to add
-  // |progressCallback| to the delegate.
+  // @TODO(bykoianko) Gather |readyCallback|, |needMoreMapsCallback| and |removeRouteCallback|
+  // to one delegate. No need to add |progressCallback| to the delegate.
   void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
                       bool adjustToPrevRoute, ReadyCallbackOwnership const & readyCallback,
                       NeedMoreMapsCallback const & needMoreMapsCallback,
@@ -88,7 +87,7 @@ private:
                         ProgressCallback const & onProgress,
                         uint32_t timeoutSec);
 
-    void OnReady(Route & route, RouterResultCode resultCode);
+    void OnReady(unique_ptr<Route> route, RouterResultCode resultCode);
     void OnNeedMoreMaps(uint64_t routeId, std::vector<std::string> const & absentCounties);
     void OnRemoveRoute(RouterResultCode resultCode);
     void Cancel();
@@ -101,8 +100,9 @@ private:
 
     mutex m_guard;
     ReadyCallbackOwnership const m_onReady;
-    // |m_onNeedMoreMaps| may be called after |m_onReady| if there's a faster route,
-    // but it's necessary to load some more maps to build it.
+    // |m_onNeedMoreMaps| may be called after |m_onReady| if
+    // - it's possible to build route only if to load some maps
+    // - there's a faster route, but it's necessary to load some more maps to build it
     NeedMoreMapsCallback const m_onNeedMoreMaps;
     RemoveRouteCallback const m_removeRoute;
     PointCheckCallback const m_onPointCheck;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -51,22 +51,6 @@ Route::Route(string const & router, vector<m2::PointD> const & points, uint64_t 
 {
 }
 
-void Route::Swap(Route & rhs)
-{
-  m_router.swap(rhs.m_router);
-  swap(m_routingSettings, rhs.m_routingSettings);
-  m_poly.Swap(rhs.m_poly);
-  m_name.swap(rhs.m_name);
-  m_absentCountries.swap(rhs.m_absentCountries);
-  m_routeSegments.swap(rhs.m_routeSegments);
-  swap(m_haveAltitudes, rhs.m_haveAltitudes);
-
-  swap(m_subrouteUid, rhs.m_subrouteUid);
-  swap(m_currentSubrouteIdx, rhs.m_currentSubrouteIdx);
-  m_subrouteAttrs.swap(rhs.m_subrouteAttrs);
-  swap(m_routeId, rhs.m_routeId);
-}
-
 void Route::AddAbsentCountry(string const & name)
 {
   if (!name.empty()) m_absentCountries.insert(name);

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -41,9 +41,13 @@ bool IsNormalTurn(TurnItem const & turn)
 }
 }  //  namespace
 
-Route::Route(string const & router, vector<m2::PointD> const & points, string const & name)
-  : m_router(router), m_routingSettings(GetRoutingSettings(VehicleType::Car)),
-    m_name(name), m_poly(points.begin(), points.end())
+Route::Route(string const & router, vector<m2::PointD> const & points, uint64_t routeId,
+             string const & name)
+  : m_router(router)
+  , m_routingSettings(GetRoutingSettings(VehicleType::Car))
+  , m_name(name)
+  , m_poly(points.begin(), points.end())
+  , m_routeId(routeId)
 {
 }
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -64,6 +64,7 @@ void Route::Swap(Route & rhs)
   swap(m_subrouteUid, rhs.m_subrouteUid);
   swap(m_currentSubrouteIdx, rhs.m_currentSubrouteIdx);
   m_subrouteAttrs.swap(rhs.m_subrouteAttrs);
+  swap(m_routeId, rhs.m_routeId);
 }
 
 void Route::AddAbsentCountry(string const & name)

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -173,8 +173,6 @@ public:
   Route(std::string const & router, std::vector<m2::PointD> const & points, uint64_t routeId,
         std::string const & name = std::string());
 
-  void Swap(Route & rhs);
-
   template <class TIter> void SetGeometry(TIter beg, TIter end)
   {
     if (beg == end)

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -156,16 +156,21 @@ public:
     SubrouteUid const m_id = kInvalidSubrouteId;
   };
 
-  explicit Route(std::string const & router)
-    : m_router(router), m_routingSettings(GetRoutingSettings(VehicleType::Car)) {}
-
-  template <class TIter>
-  Route(std::string const & router, TIter beg, TIter end)
-    : m_router(router), m_routingSettings(GetRoutingSettings(VehicleType::Car)), m_poly(beg, end)
+  explicit Route(std::string const & router, uint64_t routeId)
+    : m_router(router), m_routingSettings(GetRoutingSettings(VehicleType::Car)), m_routeId(routeId)
   {
   }
 
-  Route(std::string const & router, std::vector<m2::PointD> const & points,
+  template <class TIter>
+  Route(std::string const & router, TIter beg, TIter end, uint64_t routeId)
+    : m_router(router)
+    , m_routingSettings(GetRoutingSettings(VehicleType::Car))
+    , m_poly(beg, end)
+    , m_routeId(routeId)
+  {
+  }
+
+  Route(std::string const & router, std::vector<m2::PointD> const & points, uint64_t routeId,
         std::string const & name = std::string());
 
   void Swap(Route & rhs);
@@ -317,6 +322,7 @@ public:
   traffic::SpeedGroup GetTraffic(size_t segmentIdx) const;
 
   void GetTurnsForTesting(std::vector<turns::TurnItem> & turns) const;
+  bool IsRouteId(uint64_t routeId) const { return routeId == m_routeId; }
 
 private:
   friend std::string DebugPrint(Route const & r);
@@ -347,5 +353,7 @@ private:
   SubrouteUid m_subrouteUid = kInvalidSubrouteId;
   size_t m_currentSubrouteIdx = 0;
   std::vector<SubrouteAttrs> m_subrouteAttrs;
+  // Route identifier. It's unique within single program session.
+  uint64_t m_routeId = 0;
 };
 } // namespace routing

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -156,7 +156,7 @@ public:
     SubrouteUid const m_id = kInvalidSubrouteId;
   };
 
-  explicit Route(std::string const & router, uint64_t routeId)
+  Route(std::string const & router, uint64_t routeId)
     : m_router(router), m_routingSettings(GetRoutingSettings(VehicleType::Car)), m_routeId(routeId)
   {
   }

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -34,7 +34,7 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
 {
   routing::RouterDelegate delegate;
   LOG(LINFO, ("Calculating routing ...", router.GetName()));
-  routing::Route route("");
+  routing::Route route("", 0 /* route id */);
   my::Timer timer;
   auto const resultCode = router.CalculateRoute(routing::Checkpoints(startPos, finalPos),
                                                 m2::PointD::Zero() /* startDirection */,
@@ -105,14 +105,14 @@ RoutingTest::RoutingTest(routing::IRoadGraph::Mode mode, set<string> const & nee
 void RoutingTest::TestRouters(m2::PointD const & startPos, m2::PointD const & finalPos)
 {
   // Find route by A*-bidirectional algorithm.
-  routing::Route routeFoundByAstarBidirectional("");
+  routing::Route routeFoundByAstarBidirectional("", 0 /* route id */);
   {
     auto router = CreateRouter("test-astar-bidirectional");
     TestRouter(*router, startPos, finalPos, routeFoundByAstarBidirectional);
   }
 
   // Find route by A* algorithm.
-  routing::Route routeFoundByAstar("");
+  routing::Route routeFoundByAstar("", 0 /* route id */);
   {
     auto router = CreateRouter("test-astar");
     TestRouter(*router, startPos, finalPos, routeFoundByAstar);

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -30,11 +30,10 @@ using namespace std;
 namespace
 {
 void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
-                m2::PointD const & finalPos, routing::Route & foundRoute)
+                m2::PointD const & finalPos, routing::Route & route)
 {
   routing::RouterDelegate delegate;
   LOG(LINFO, ("Calculating routing ...", router.GetName()));
-  routing::Route route("", 0 /* route id */);
   my::Timer timer;
   auto const resultCode = router.CalculateRoute(routing::Checkpoints(startPos, finalPos),
                                                 m2::PointD::Zero() /* startDirection */,
@@ -48,7 +47,6 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
   LOG(LINFO, ("Route polyline size:", route.GetPoly().GetSize()));
   LOG(LINFO, ("Route distance, meters:", route.GetTotalDistanceMeters()));
   LOG(LINFO, ("Elapsed, seconds:", elapsedSec));
-  foundRoute.Swap(route);
 }
 
 m2::PointD GetPointOnEdge(routing::Edge const & e, double posAlong)

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -38,8 +38,9 @@ enum class RouterResultCode
   RouteNotFoundRedressRouteError = 15,
 };
 
-using AbsentCountryCallback = std::function<void(uint64_t, std::vector<std::string> const &)>;
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
+using NeedMoreMapsCallback = std::function<void(uint64_t, std::vector<std::string> const &)>;
+using PointCheckCallback = std::function<void(m2::PointD const &)>;
 using ProgressCallback = std::function<void(float)>;
 // @TODO(bykoianko) ReadyCallback and ReadyCallbackOwnership callbacks should be gathered
 // to one with the following signature:
@@ -47,9 +48,9 @@ using ProgressCallback = std::function<void(float)>;
 // That means calling ReadyCallback means passing ownership of ready instance of Route.
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
 using ReadyCallbackOwnership = std::function<void(Route &, RouterResultCode)>;
+using RemoveRouteCallback = std::function<void(RouterResultCode)>;
 using RouteCallback = std::function<void(Route const &)>;
 using RoutingStatisticsCallback = std::function<void(std::map<std::string, std::string> const &)>;
-using PointCheckCallback = std::function<void(m2::PointD const &)>;
 
 inline std::string DebugPrint(RouterResultCode code)
 {

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -44,7 +44,7 @@ using NeedMoreMapsCallback = std::function<void(uint64_t, std::vector<std::strin
 using PointCheckCallback = std::function<void(m2::PointD const &)>;
 using ProgressCallback = std::function<void(float)>;
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
-using ReadyCallbackOwnership = std::function<void(std::unique_ptr<Route>, RouterResultCode)>;
+using ReadyCallbackOwnership = std::function<void(std::shared_ptr<Route>, RouterResultCode)>;
 using RemoveRouteCallback = std::function<void(RouterResultCode)>;
 using RouteCallback = std::function<void(Route const &)>;
 using RoutingStatisticsCallback = std::function<void(std::map<std::string, std::string> const &)>;
@@ -75,4 +75,7 @@ inline std::string DebugPrint(RouterResultCode code)
   ASSERT(false, (result));
   return result;
 }
+
+// This define should be set to see the spread of A* waves on the map.
+// #define SHOW_ROUTE_DEBUG_MARKS
 }  // namespace routing

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace routing
 {
@@ -37,6 +38,7 @@ enum class RouterResultCode
   RouteNotFoundRedressRouteError = 15,
 };
 
+using AbsentCountryCallback = std::function<void(uint64_t, std::vector<std::string> const &)>;
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
 using ProgressCallback = std::function<void(float)>;
 // @TODO(bykoianko) ReadyCallback and ReadyCallbackOwnership callbacks should be gathered

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -42,12 +43,8 @@ using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
 using NeedMoreMapsCallback = std::function<void(uint64_t, std::vector<std::string> const &)>;
 using PointCheckCallback = std::function<void(m2::PointD const &)>;
 using ProgressCallback = std::function<void(float)>;
-// @TODO(bykoianko) ReadyCallback and ReadyCallbackOwnership callbacks should be gathered
-// to one with the following signature:
-// std::function<void(std::unique_ptr<Route>, RouterResultCode)>
-// That means calling ReadyCallback means passing ownership of ready instance of Route.
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
-using ReadyCallbackOwnership = std::function<void(Route &, RouterResultCode)>;
+using ReadyCallbackOwnership = std::function<void(std::unique_ptr<Route>, RouterResultCode)>;
 using RemoveRouteCallback = std::function<void(RouterResultCode)>;
 using RouteCallback = std::function<void(Route const &)>;
 using RoutingStatisticsCallback = std::function<void(std::map<std::string, std::string> const &)>;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -170,7 +170,7 @@ namespace integration
                               m2::PointD const & finalPoint)
   {
     RouterDelegate delegate;
-    shared_ptr<Route> route(new Route("mapsme"));
+    shared_ptr<Route> route = make_shared<Route>("mapsme", 0 /* route id */);
     RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
         Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, *route);
     ASSERT(route, ());

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -62,8 +62,7 @@ void FormatDistance(double dist, string & value, string & suffix)
 
 RoutingSession::RoutingSession()
   : m_router(nullptr)
-    // @TODO |m_route| should be unique_prt<Route> and should be nullptr here.
-  , m_route(make_shared<Route>(string(), 0))
+  , m_route(make_unique<Route>(string(), 0))
   , m_state(RoutingNotActive)
   , m_isFollowing(false)
   , m_lastWarnedSpeedCameraIndex(0)
@@ -143,17 +142,7 @@ void RoutingSession::DoReadyCallback::operator()(Route & route, RouterResultCode
   threads::MutexGuard guard(m_routeSessionMutexInner);
 
   ASSERT(m_rs.m_route, ());
-
-  if (e != RouterResultCode::NeedMoreMaps)
-  {
-    m_rs.AssignRoute(route, e);
-  }
-  else
-  {
-    for (string const & country : route.GetAbsentCountries())
-      m_rs.m_route->AddAbsentCountry(country);
-  }
-
+  m_rs.AssignRoute(route, e);
   m_callback(*m_rs.m_route, e);
 }
 
@@ -164,8 +153,7 @@ void RoutingSession::RemoveRoute()
   m_moveAwayCounter = 0;
   m_turnNotificationsMgr.Reset();
 
-  // @TODO |m_route| should be unique_prt<Route> and should be nullptr here.
-  m_route = make_shared<Route>(string(), 0);
+  m_route = make_unique<Route>(string(), 0);
 }
 
 void RoutingSession::RebuildRouteOnTrafficUpdate()

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -716,6 +716,12 @@ bool RoutingSession::IsRouteId(uint64_t routeId) const
   return m_route->IsRouteId(routeId);
 }
 
+bool RoutingSession::IsRouteValid() const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  return m_route && m_route->IsValid();
+}
+
 bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDistanceM,
                                                     feature::TAltitudes & routeAltitudesM) const
 {
@@ -765,8 +771,7 @@ void RoutingSession::OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId)
   });
 }
 
-void RoutingSession::CopyTraffic(
-    map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
+void RoutingSession::CopyTraffic(traffic::AllMwmTrafficInfo & trafficColoring) const
 {
   TrafficCache::CopyTraffic(trafficColoring);
 }

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -137,12 +137,13 @@ m2::PointD RoutingSession::GetEndPoint() const
   return m_checkpoints.GetFinish();
 }
 
-void RoutingSession::DoReadyCallback::operator()(Route & route, RouterResultCode e)
+void RoutingSession::DoReadyCallback::operator()(unique_ptr<Route> route, RouterResultCode e)
 {
   threads::MutexGuard guard(m_routeSessionMutexInner);
 
   ASSERT(m_rs.m_route, ());
-  m_rs.AssignRoute(route, e);
+  // @TODO(bykoianko) Move |route| to m_rs.AssignRoute() method.
+  m_rs.AssignRoute(*route, e);
   m_callback(*m_rs.m_route, e);
 }
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -62,7 +62,8 @@ void FormatDistance(double dist, string & value, string & suffix)
 
 RoutingSession::RoutingSession()
   : m_router(nullptr)
-  , m_route(make_shared<Route>(string()))
+    // @TODO |m_route| should be unique_prt<Route> and should be nullptr here.
+  , m_route(make_shared<Route>(string(), 0))
   , m_state(RoutingNotActive)
   , m_isFollowing(false)
   , m_lastWarnedSpeedCameraIndex(0)
@@ -160,7 +161,8 @@ void RoutingSession::RemoveRoute()
   m_moveAwayCounter = 0;
   m_turnNotificationsMgr.Reset();
 
-  m_route = make_shared<Route>(string());
+  // @TODO |m_route| should be unique_prt<Route> and should be nullptr here.
+  m_route = make_shared<Route>(string(), 0);
 }
 
 void RoutingSession::RebuildRouteOnTrafficUpdate()

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -770,17 +770,8 @@ void RoutingSession::OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId)
   });
 }
 
-shared_ptr<TrafficInfo::Coloring> RoutingSession::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  return TrafficCache::GetTrafficInfo(mwmId);
-}
-
 void RoutingSession::CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
 {
-  // @TODO(bykoianko) Should be called form gui thread before CalculateRoute() to prepare
-  // traffic jams for routing.
-//  CHECK_THREAD_CHECKER(m_threadChecker, ());
   TrafficCache::CopyTraffic(trafficColoring);
 }
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -10,11 +10,12 @@
 
 #include "coding/internal/file_data.hpp"
 
-#include "std/utility.hpp"
+#include <utility>
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
 using namespace location;
+using namespace std;
 using namespace traffic;
 
 namespace
@@ -770,7 +771,8 @@ void RoutingSession::OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId)
   });
 }
 
-void RoutingSession::CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
+void RoutingSession::CopyTraffic(
+    map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
 {
   TrafficCache::CopyTraffic(trafficColoring);
 }

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -142,8 +142,7 @@ void RoutingSession::DoReadyCallback::operator()(unique_ptr<Route> route, Router
   threads::MutexGuard guard(m_routeSessionMutexInner);
 
   ASSERT(m_rs.m_route, ());
-  // @TODO(bykoianko) Move |route| to m_rs.AssignRoute() method.
-  m_rs.AssignRoute(*route, e);
+  m_rs.AssignRoute(move(route), e);
   m_callback(*m_rs.m_route, e);
 }
 
@@ -501,11 +500,11 @@ void RoutingSession::GenerateTurnNotifications(vector<string> & turnNotification
     m_turnNotificationsMgr.GenerateTurnNotifications(turns, turnNotifications);
 }
 
-void RoutingSession::AssignRoute(Route & route, RouterResultCode e)
+void RoutingSession::AssignRoute(unique_ptr<Route> route, RouterResultCode e)
 {
   if (e != RouterResultCode::Cancelled)
   {
-    if (route.IsValid())
+    if (route->IsValid())
       SetState(RouteNotStarted);
     else
       SetState(RoutingNotActive);
@@ -520,8 +519,8 @@ void RoutingSession::AssignRoute(Route & route, RouterResultCode e)
 
   ASSERT(m_route, ());
 
-  route.SetRoutingSettings(m_routingSettings);
-  m_route->Swap(route);
+  route->SetRoutingSettings(m_routingSettings);
+  m_route = move(route);
   m_lastWarnedSpeedCameraIndex = 0;
   m_lastCheckedSpeedCameraIndex = 0;
   m_lastFoundCamera = SpeedCameraRestriction();

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -208,6 +208,7 @@ private:
 
 private:
   unique_ptr<AsyncRouter> m_router;
+  // @TODO |m_route| should be unique_prt<Route> and may be nullptr.
   shared_ptr<Route> m_route;
   State m_state;
   bool m_isFollowing;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -120,6 +120,7 @@ public:
   /// false otherwise.
   bool HasRouteAltitude() const;
   bool IsRouteId(uint64_t routeId) const;
+  bool IsRouteValid() const;
 
   /// \brief copies distance from route beginning to ends of route segments in meters and
   /// route altitude information to |routeSegDistanceM| and |routeAltitudes|.
@@ -179,8 +180,7 @@ public:
   // TrafficCache overrides:
   /// \note. This method may be called from any thread because it touches only data
   /// protected by mutex in TrafficCache class.
-  void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> &
-                       trafficColoring) const override;
+  void CopyTraffic(traffic::AllMwmTrafficInfo & trafficColoring) const override;
 
 private:
   struct DoReadyCallback

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -19,11 +19,11 @@
 
 #include "base/thread_checker.hpp"
 
-#include "std/functional.hpp"
-#include "std/limits.hpp"
-#include "std/map.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/unique_ptr.hpp"
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <map>
+#include <memory>
 
 class DataSource;
 
@@ -40,7 +40,7 @@ struct SpeedCameraRestriction
   uint8_t m_maxSpeedKmH;  // Maximum speed allowed by the camera.
 
   SpeedCameraRestriction(size_t index, uint8_t maxSpeed) : m_index(index), m_maxSpeedKmH(maxSpeed) {}
-  SpeedCameraRestriction() : m_index(0), m_maxSpeedKmH(numeric_limits<uint8_t>::max()) {}
+  SpeedCameraRestriction() : m_index(0), m_maxSpeedKmH(std::numeric_limits<uint8_t>::max()) {}
 };
 
 /// \breaf This class is responsible for the route built in the program.
@@ -123,7 +123,7 @@ public:
   /// \brief copies distance from route beginning to ends of route segments in meters and
   /// route altitude information to |routeSegDistanceM| and |routeAltitudes|.
   /// \returns true if there is valid route information. If the route is not valid returns false.
-  bool GetRouteAltitudesAndDistancesM(vector<double> & routeSegDistanceM,
+  bool GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
                                       feature::TAltitudes & routeAltitudesM) const;
 
   State OnLocationPositionChanged(location::GpsInfo const & info, DataSource const & dataSource);
@@ -160,9 +160,9 @@ public:
   void EnableTurnNotifications(bool enable);
   bool AreTurnNotificationsEnabled() const;
   void SetTurnNotificationsUnits(measurement_utils::Units const units);
-  void SetTurnNotificationsLocale(string const & locale);
-  string GetTurnNotificationsLocale() const;
-  void GenerateTurnNotifications(vector<string> & turnNotifications);
+  void SetTurnNotificationsLocale(std::string const & locale);
+  std::string GetTurnNotificationsLocale() const;
+  void GenerateTurnNotifications(std::vector<string> & turnNotifications);
 
   void EmitCloseRoutingEvent() const;
 
@@ -178,7 +178,8 @@ public:
   // TrafficCache overrides:
   /// \note. This method may be called from any thread because it touches only data
   /// protected by mutex in TrafficCache class.
-  void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const override;
+  void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> &
+                       trafficColoring) const override;
 
 private:
   struct DoReadyCallback
@@ -191,10 +192,10 @@ private:
     {
     }
 
-    void operator()(shared_ptr<Route> route, RouterResultCode e);
+    void operator()(std::shared_ptr<Route> route, RouterResultCode e);
   };
 
-  void AssignRoute(shared_ptr<Route> route, RouterResultCode e);
+  void AssignRoute(std::shared_ptr<Route> route, RouterResultCode e);
 
   /// Returns a nearest speed camera record on your way and distance to it.
   /// Returns kInvalidSpeedCameraDistance if there is no cameras on your way.
@@ -208,8 +209,8 @@ private:
   void PassCheckpoints();
 
 private:
-  unique_ptr<AsyncRouter> m_router;
-  shared_ptr<Route> m_route;
+  std::unique_ptr<AsyncRouter> m_router;
+  std::shared_ptr<Route> m_route;
   State m_state;
   bool m_isFollowing;
   Checkpoints m_checkpoints;
@@ -256,7 +257,7 @@ private:
   DECLARE_THREAD_CHECKER(m_threadChecker);
 };
 
-void FormatDistance(double dist, string & value, string & suffix);
+void FormatDistance(double dist, std::string & value, std::string & suffix);
 
-string DebugPrint(RoutingSession::State state);
+std::string DebugPrint(RoutingSession::State state);
 }  // namespace routing

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -170,13 +170,14 @@ public:
 
   // RoutingObserver overrides:
   void OnTrafficInfoClear() override;
-  /// \note. This method may be called from any thread.
+  /// \note. This method may be called from any thread because it touches class data on gui thread.
   void OnTrafficInfoAdded(traffic::TrafficInfo && info) override;
-  /// \note. This method may be called from any thread.
+  /// \note. This method may be called from any thread because it touches class data on gui thread.
   void OnTrafficInfoRemoved(MwmSet::MwmId const & mwmId) override;
 
   // TrafficCache overrides:
-  shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(MwmSet::MwmId const & mwmId) const override;
+  /// \note. This method may be called from any thread because it touches only data
+  /// protected by mutex in TrafficCache class.
   void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const override;
 
 private:

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -193,7 +193,7 @@ private:
   };
 
   // Should be called with locked m_routingSessionMutex.
-  void AssignRoute(Route & route, RouterResultCode e);
+  void AssignRoute(unique_ptr<Route> route, RouterResultCode e);
 
   /// Returns a nearest speed camera record on your way and distance to it.
   /// Returns kInvalidSpeedCameraDistance if there is no cameras on your way.

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -189,7 +189,7 @@ private:
     {
     }
 
-    void operator()(Route & route, RouterResultCode e);
+    void operator()(unique_ptr<Route> route, RouterResultCode e);
   };
 
   // Should be called with locked m_routingSessionMutex.

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -175,6 +175,8 @@ public:
   void CopyTraffic(std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const override;
 
 private:
+  // @TODO(bykoianko) This class should be removed when all methods RoutingSession and
+  // all routing callbacks are called from ui thread.
   struct DoReadyCallback
   {
     RoutingSession & m_rs;
@@ -213,8 +215,7 @@ private:
 
 private:
   unique_ptr<AsyncRouter> m_router;
-  // @TODO |m_route| should be unique_prt<Route> and may be nullptr.
-  shared_ptr<Route> m_route;
+  unique_ptr<Route> m_route;
   State m_state;
   bool m_isFollowing;
   Checkpoints m_checkpoints;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -88,7 +88,9 @@ public:
   void BuildRoute(Checkpoints const & checkpoints,
                   uint32_t timeoutSec);
   void RebuildRoute(m2::PointD const & startPoint, ReadyCallback const & readyCallback,
-                    uint32_t timeoutSec, State routeRebuildingState, bool adjustToPrevRoute);
+                    NeedMoreMapsCallback const & needMoreMapsCallback,
+                    RemoveRouteCallback const & removeRouteCallback, uint32_t timeoutSec,
+                    State routeRebuildingState, bool adjustToPrevRoute);
 
   m2::PointD GetStartPoint() const;
   m2::PointD GetEndPoint() const;
@@ -113,6 +115,7 @@ public:
   /// \returns true if altitude information along |m_route| is available and
   /// false otherwise.
   bool HasRouteAltitude() const;
+  bool IsRouteId(uint64_t routeId) const;
 
   /// \brief copies distance from route beginning to ends of route segments in meters and
   /// route altitude information to |routeSegDistanceM| and |routeAltitudes|.
@@ -144,7 +147,9 @@ public:
 
   void SetRoutingSettings(RoutingSettings const & routingSettings);
   void SetReadyCallbacks(ReadyCallback const & buildReadyCallback,
-                         ReadyCallback const & rebuildReadyCallback);
+                         ReadyCallback const & rebuildReadyCallback,
+                         NeedMoreMapsCallback const & needMoreMapsCallback,
+                         RemoveRouteCallback const & removeRouteCallback);
   void SetProgressCallback(ProgressCallback const & progressCallback);
   void SetCheckpointCallback(CheckpointCallback const & checkpointCallback);
 
@@ -244,6 +249,8 @@ private:
 
   ReadyCallback m_buildReadyCallback;
   ReadyCallback m_rebuildReadyCallback;
+  NeedMoreMapsCallback m_needMoreMapsCallback;
+  RemoveRouteCallback m_removeRouteCallback;
   ProgressCallback m_progressCallback;
   CheckpointCallback m_checkpointCallback;
 

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -84,7 +84,8 @@ public:
   void Init(RoutingStatisticsCallback const & routingStatisticsFn,
             PointCheckCallback const & pointCheckCallback);
 
-  void SetRouter(unique_ptr<IRouter> && router, unique_ptr<OnlineAbsentCountriesFetcher> && fetcher);
+  void SetRouter(std::unique_ptr<IRouter> && router,
+                 std::unique_ptr<OnlineAbsentCountriesFetcher> && fetcher);
 
   /// @param[in] checkpoints in mercator
   /// @param[in] timeoutSec timeout in seconds, if zero then there is no timeout
@@ -149,10 +150,10 @@ public:
   bool EnableFollowMode();
 
   void SetRoutingSettings(RoutingSettings const & routingSettings);
-  void SetReadyCallbacks(ReadyCallback const & buildReadyCallback,
-                         ReadyCallback const & rebuildReadyCallback,
-                         NeedMoreMapsCallback const & needMoreMapsCallback,
-                         RemoveRouteCallback const & removeRouteCallback);
+  void SetRoutingCallbacks(ReadyCallback const & buildReadyCallback,
+                           ReadyCallback const & rebuildReadyCallback,
+                           NeedMoreMapsCallback const & needMoreMapsCallback,
+                           RemoveRouteCallback const & removeRouteCallback);
   void SetProgressCallback(ProgressCallback const & progressCallback);
   void SetCheckpointCallback(CheckpointCallback const & checkpointCallback);
 
@@ -162,7 +163,7 @@ public:
   void SetTurnNotificationsUnits(measurement_utils::Units const units);
   void SetTurnNotificationsLocale(std::string const & locale);
   std::string GetTurnNotificationsLocale() const;
-  void GenerateTurnNotifications(std::vector<string> & turnNotifications);
+  void GenerateTurnNotifications(std::vector<std::string> & turnNotifications);
 
   void EmitCloseRoutingEvent() const;
 
@@ -225,8 +226,8 @@ private:
   mutable bool m_speedWarningSignal;
 
   /// Current position metrics to check for RouteNeedRebuild state.
-  double m_lastDistance;
-  int m_moveAwayCounter;
+  double m_lastDistance = 0.0;
+  int m_moveAwayCounter = 0;
   m2::PointD m_lastGoodPosition;
   // |m_currentDirection| is a vector from the position before last good position to last good position.
   m2::PointD m_currentDirection;
@@ -249,10 +250,10 @@ private:
 
   // Statistics parameters
   // Passed distance on route including reroutes
-  double m_passedDistanceOnRouteMeters;
+  double m_passedDistanceOnRouteMeters = 0.0;
   // Rerouting count
-  int m_routingRebuildCount;
-  mutable double m_lastCompletionPercent;
+  int m_routingRebuildCount = -1; // -1 for the first rebuild called in BuildRoute().
+  mutable double m_lastCompletionPercent = 0.0;
 
   DECLARE_THREAD_CHECKER(m_threadChecker);
 };

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -48,7 +48,7 @@ struct SpeedCameraRestriction
 /// a special note near a method.
 class RoutingSession : public traffic::TrafficObserver, public traffic::TrafficCache
 {
-  friend void UnitTest_TestFollowRoutePercentTest();
+  friend struct UnitClass_AsyncGuiThreadTestWithRoutingSession_TestFollowRoutePercentTest;
 
 public:
   enum State

--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -2,6 +2,19 @@
 
 namespace routing
 {
+// RoutingSettings ---------------------------------------------------------------------------------
+RoutingSettings::RoutingSettings(bool matchRoute, bool soundDirection, double matchingThresholdM,
+                                 bool keepPedestrianInfo, bool showTurnAfterNext,
+                                 bool speedCameraWarning)
+  : m_matchRoute(matchRoute)
+  , m_soundDirection(soundDirection)
+  , m_matchingThresholdM(matchingThresholdM)
+  , m_keepPedestrianInfo(keepPedestrianInfo)
+  , m_showTurnAfterNext(showTurnAfterNext)
+  , m_speedCameraWarning(speedCameraWarning)
+{
+}
+
 RoutingSettings GetRoutingSettings(VehicleType vehicleType)
 {
   switch (vehicleType)
@@ -18,13 +31,12 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
     return {true /* m_matchRoute */,         true /* m_soundDirection */,
             30. /* m_matchingThresholdM */,  false /* m_keepPedestrianInfo */,
             false /* m_showTurnAfterNext */, false /* m_speedCameraWarning*/};
+  case VehicleType::Count:
+    CHECK(false, ("Can't create GetRoutingSettings for", vehicleType));
   case VehicleType::Car:
     return {true /* m_matchRoute */,        true /* m_soundDirection */,
             50. /* m_matchingThresholdM */, false /* m_keepPedestrianInfo */,
             true /* m_showTurnAfterNext */, true /* m_speedCameraWarning*/};
-  case VehicleType::Count:
-    CHECK(false, ("Can't create GetRoutingSettings for", vehicleType));
-    return {};
   }
   CHECK_SWITCH();
 }

--- a/routing/routing_settings.hpp
+++ b/routing/routing_settings.hpp
@@ -12,6 +12,13 @@ namespace routing
 /// For example, route matching properties, rerouting properties and so on.
 struct RoutingSettings
 {
+  friend RoutingSettings GetRoutingSettings(VehicleType vehicleType);
+
+private:
+  RoutingSettings(bool matchRoute, bool soundDirection, double matchingThresholdM,
+                  bool keepPedestrianInfo, bool showTurnAfterNext, bool speedCameraWarning);
+
+public:
   /// \brief if m_matchRoute is equal to true the bearing follows the
   /// route direction if the current position is matched to the route.
   /// If m_matchRoute is equal to false GPS bearing is used while

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
   routing_algorithm.hpp
   routing_helpers_tests.cpp
   routing_session_test.cpp
+  tools.hpp
   turns_generator_test.cpp
   turns_sound_test.cpp
   turns_tts_text_tests.cpp

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -104,7 +104,7 @@ public:
     m_estimator = CreateEstimatorForCar(m_trafficStash);
   }
 
-  void SetTrafficColoring(shared_ptr<TrafficInfo::Coloring> coloring)
+  void SetTrafficColoring(shared_ptr<TrafficInfo::Coloring const> coloring)
   {
     m_trafficStash->SetColoring(kTestNumMwmId, coloring);
   }
@@ -136,10 +136,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
 // Route through XX graph with SpeedGroup::G0 on F3.
 UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
 {
-  TrafficInfo::Coloring coloring = {
+  TrafficInfo::Coloring const coloring = {
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G0}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
   auto const start =
@@ -153,10 +153,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
 // Route through XX graph with SpeedGroup::TempBlock on F3.
 UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
 {
-  TrafficInfo::Coloring coloring = {
+  TrafficInfo::Coloring const coloring = {
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::TempBlock}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
   auto const start =
@@ -170,10 +170,10 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
 // Route through XX graph with SpeedGroup::G0 in reverse direction on F3.
 UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
 {
-  TrafficInfo::Coloring coloring = {
+  TrafficInfo::Coloring const coloring = {
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kReverseDirection},
        SpeedGroup::G0}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
   auto const start =
@@ -187,7 +187,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
 // Route through XX graph SpeedGroup::G1 on F3 and F6, SpeedGroup::G4 on F8 and F4.
 UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
 {
-  TrafficInfo::Coloring coloring = {
+  TrafficInfo::Coloring const coloring = {
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G0},
       {{6 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
@@ -196,7 +196,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
        SpeedGroup::G4},
       {{7 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G4}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloring));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloring));
 
   unique_ptr<WorldGraph> graph = BuildXXGraph(GetEstimator());
   auto const start =
@@ -224,17 +224,17 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   }
 
   // Heavy traffic (SpeedGroup::G0) on F3.
-  TrafficInfo::Coloring coloringHeavyF3 = {
+  TrafficInfo::Coloring const coloringHeavyF3 = {
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G0}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloringHeavyF3));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloringHeavyF3));
   {
     vector<m2::PointD> const heavyF3Geom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
     TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, heavyF3Geom);
   }
 
   // Overloading traffic jam on F3. Middle traffic (SpeedGroup::G3) on F1, F3, F4, F7 and F8.
-  TrafficInfo::Coloring coloringMiddleF1F3F4F7F8 = {
+  TrafficInfo::Coloring const coloringMiddleF1F3F4F7F8 = {
       {{1 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G3},
       {{3 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
@@ -245,7 +245,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
        SpeedGroup::G3},
       {{8 /* feature id */, 0 /* segment id */, TrafficInfo::RoadSegmentId::kForwardDirection},
        SpeedGroup::G3}};
-  SetTrafficColoring(make_shared<TrafficInfo::Coloring>(coloringMiddleF1F3F4F7F8));
+  SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloringMiddleF1F3F4F7F8));
   {
     TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, noTrafficGeom);
   }

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -33,7 +33,8 @@ public:
                             bool adjustToPrevRoute, RouterDelegate const & delegate,
                             Route & route) override
   {
-    route = Route("dummy", checkpoints.GetPoints().cbegin(), checkpoints.GetPoints().cend());
+    route = Route("dummy", checkpoints.GetPoints().cbegin(), checkpoints.GetPoints().cend(),
+                  0 /* route id */);
 
     for (auto const & absent : m_absent)
       route.AddAbsentCountry(absent);

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -13,6 +13,7 @@
 #include "std/cstdint.hpp"
 #include "std/mutex.hpp"
 #include "std/string.hpp"
+#include "std/unique_ptr.hpp"
 #include "std/vector.hpp"
 
 using namespace routing;
@@ -67,13 +68,14 @@ struct DummyResultCallback
   uint32_t const m_expected;
   uint32_t m_called;
 
-  DummyResultCallback(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
+  explicit DummyResultCallback(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
 
   // ReadyCallbackOwnership callback
-  void operator()(Route & route, RouterResultCode code)
+  void operator()(unique_ptr<Route> route, RouterResultCode code)
   {
+    CHECK(route, ());
     m_codes.push_back(code);
-    auto const & absent = route.GetAbsentCountries();
+    auto const & absent = route->GetAbsentCountries();
     m_absent.emplace_back(absent.begin(), absent.end());
     TestAndNotifyReadyCallbacks();
   }

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -13,15 +13,16 @@
 
 #include "base/timer.hpp"
 
-#include "std/condition_variable.hpp"
-#include "std/cstdint.hpp"
-#include "std/mutex.hpp"
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 using namespace routing;
 using namespace std::placeholders;
+using namespace std;
 
 namespace
 {

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -64,7 +64,7 @@ public:
 
 void DummyStatisticsCallback(map<string, string> const &) {}
 
-struct DummyResultCallback
+struct DummyRoutingCallbacks
 {
   vector<RouterResultCode> m_codes;
   vector<vector<string>> m_absent;
@@ -73,7 +73,7 @@ struct DummyResultCallback
   uint32_t const m_expected;
   uint32_t m_called;
 
-  explicit DummyResultCallback(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
+  explicit DummyRoutingCallbacks(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
 
   // ReadyCallbackOwnership callback
   void operator()(shared_ptr<Route> route, RouterResultCode code)
@@ -116,7 +116,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTest, NeedMoreMapsSignalTest)
   vector<string> const absentData({"test1", "test2"});
   unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher(absentData));
   unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));
-  DummyResultCallback resultCallback(2 /* expectedCalls */);
+  DummyRoutingCallbacks resultCallback(2 /* expectedCalls */);
   AsyncRouter async(DummyStatisticsCallback, nullptr /* pointCheckCallback */);
   async.SetRouter(move(router), move(fetcher));
   async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,
@@ -139,7 +139,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTest, StandardAsyncFogTest)
 {
   unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher({}));
   unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));
-  DummyResultCallback resultCallback(1 /* expectedCalls */);
+  DummyRoutingCallbacks resultCallback(1 /* expectedCalls */);
   AsyncRouter async(DummyStatisticsCallback, nullptr /* pointCheckCallback */);
   async.SetRouter(move(router), move(fetcher));
   async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -7,6 +7,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include "platform/platform.hpp"
+
 #include "base/timer.hpp"
 
 #include "std/condition_variable.hpp"
@@ -71,7 +73,7 @@ struct DummyResultCallback
   explicit DummyResultCallback(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
 
   // ReadyCallbackOwnership callback
-  void operator()(unique_ptr<Route> route, RouterResultCode code)
+  void operator()(shared_ptr<Route> route, RouterResultCode code)
   {
     CHECK(route, ());
     m_codes.push_back(code);
@@ -130,7 +132,7 @@ UNIT_TEST(NeedMoreMapsSignalTest)
   TEST_EQUAL(resultCallback.m_absent[1], absentData, ());
 }
 
-UNIT_TEST(StandartAsyncFogTest)
+UNIT_TEST(StandardAsyncFogTest)
 {
   unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher({}));
   unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_tests/tools.hpp"
+
 #include "routing/async_router.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
@@ -108,7 +110,7 @@ struct DummyResultCallback
   }
 };
 
-UNIT_TEST(NeedMoreMapsSignalTest)
+UNIT_CLASS_TEST(AsyncGuiThreadTest, NeedMoreMapsSignalTest)
 {
   vector<string> const absentData({"test1", "test2"});
   unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher(absentData));
@@ -132,7 +134,7 @@ UNIT_TEST(NeedMoreMapsSignalTest)
   TEST_EQUAL(resultCallback.m_absent[1], absentData, ());
 }
 
-UNIT_TEST(StandardAsyncFogTest)
+UNIT_CLASS_TEST(AsyncGuiThreadTest, StandardAsyncFogTest)
 {
   unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher({}));
   unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -77,7 +77,7 @@ location::GpsInfo GetGps(double x, double y)
 
 UNIT_TEST(AddAdsentCountryToRouteTest)
 {
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
   route.AddAbsentCountry("A");
   route.AddAbsentCountry("A");
   route.AddAbsentCountry("B");
@@ -91,7 +91,7 @@ UNIT_TEST(AddAdsentCountryToRouteTest)
 
 UNIT_TEST(DistanceToCurrentTurnTest)
 {
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
   vector<RouteSegment> routeSegments;
   GetTestRouteSegments(kTestGeometry, kTestTurns2, kTestNames2, kTestTimes2, routeSegments);
   route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
@@ -129,7 +129,7 @@ UNIT_TEST(DistanceToCurrentTurnTest)
 
 UNIT_TEST(NextTurnTest)
 {
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
   vector<RouteSegment> routeSegments;
   GetTestRouteSegments(kTestGeometry, kTestTurns2, kTestNames2, kTestTimes2, routeSegments);
   route.SetRouteSegments(routeSegments);
@@ -159,7 +159,7 @@ UNIT_TEST(NextTurnTest)
 
 UNIT_TEST(NextTurnsTest)
 {
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
   route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
   vector<RouteSegment> routeSegments;
   GetTestRouteSegments(kTestGeometry, kTestTurns2, kTestNames2, kTestTimes2, routeSegments);
@@ -227,7 +227,7 @@ UNIT_TEST(SelfIntersectedRouteMatchingTest)
       {{0.0001, 0.0}, {0.0001, 0.0002}, {0.0002, 0.0002}, {0.0002, 0.0001}, {0.0, 0.0001}});
   double constexpr kRoundingErrorMeters = 0.001;
 
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
   route.SetGeometry(kRouteGeometry.begin(), kRouteGeometry.end());
   
   vector<RouteSegment> routeSegments;
@@ -278,7 +278,7 @@ UNIT_TEST(SelfIntersectedRouteMatchingTest)
 
 UNIT_TEST(RouteNameTest)
 {
-  Route route("TestRouter");
+  Route route("TestRouter", 0 /* route id */);
 
   route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
   vector<RouteSegment> routeSegments;

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -97,7 +97,7 @@ UNIT_TEST(TestRouteBuilding)
   RoutingSession session;
   session.Init(nullptr, nullptr);
   vector<m2::PointD> routePoints = kTestRoute;
-  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end(), 0 /* route id */);
   size_t counter = 0;
   TimedSignal timedSignal;
   unique_ptr<DummyRouter> router =
@@ -118,7 +118,7 @@ UNIT_TEST(TestRouteRebuilding)
   RoutingSession session;
   session.Init(nullptr, nullptr);
   vector<m2::PointD> routePoints = kTestRoute;
-  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end(), 0 /* route id */);
   FillSubroutesInfo(masterRoute);
 
   size_t counter = 0;
@@ -176,7 +176,7 @@ UNIT_TEST(TestFollowRouteFlagPersistence)
   RoutingSession session;
   session.Init(nullptr, nullptr);
   vector<m2::PointD> routePoints = kTestRoute;
-  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end(), 0 /* route id */);
   FillSubroutesInfo(masterRoute);
 
   size_t counter = 0;
@@ -252,7 +252,7 @@ UNIT_TEST(TestFollowRoutePercentTest)
   RoutingSession session;
   session.Init(nullptr, nullptr);
   vector<m2::PointD> routePoints = kTestRoute;
-  Route masterRoute("dummy", routePoints.begin(), routePoints.end());
+  Route masterRoute("dummy", routePoints.begin(), routePoints.end(), 0 /* route id */);
   FillSubroutesInfo(masterRoute);
 
   size_t counter = 0;

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -12,14 +12,19 @@
 
 #include "base/logging.hpp"
 
-#include "std/chrono.hpp"
-#include "std/mutex.hpp"
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace routing
 {
+using namespace std;
+
+using chrono::seconds;
+using chrono::steady_clock;
+
 // Simple router. It returns route given to him on creation.
 class DummyRouter : public IRouter
 {

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "platform/platform_tests_support/async_gui_thread.hpp"
+
+#include "routing/routing_session.hpp"
+
+#include <memory>
+
+class AsyncGuiThreadTest
+{
+  platform::tests_support::AsyncGuiThread m_asyncGuiThread;
+};
+
+class AsyncGuiThreadTestWithRoutingSession : public AsyncGuiThreadTest
+{
+public:
+  std::unique_ptr<routing::RoutingSession> m_session;
+};

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -3,6 +3,8 @@
 #include "platform/platform_tests_support/async_gui_thread.hpp"
 
 #include "routing/routing_session.hpp"
+#include "routing/routing_settings.hpp"
+#include "routing/vehicle_mask.hpp"
 
 #include <memory>
 
@@ -14,5 +16,12 @@ class AsyncGuiThreadTest
 class AsyncGuiThreadTestWithRoutingSession : public AsyncGuiThreadTest
 {
 public:
+  void InitRoutingSession()
+  {
+    m_session = std::make_unique<routing::RoutingSession>();
+    m_session->Init(nullptr /* routingStatisticsFn */, nullptr /* pointCheckCallback */);
+    m_session->SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
+  }
+
   std::unique_ptr<routing::RoutingSession> m_session;
 };

--- a/routing/traffic_stash.cpp
+++ b/routing/traffic_stash.cpp
@@ -3,11 +3,14 @@
 #include "base/checked_cast.hpp"
 
 #include <map>
+#include <utility>
 
 namespace routing
 {
+using namespace std;
+
 TrafficStash::TrafficStash(traffic::TrafficCache const & source, shared_ptr<NumMwmIds> numMwmIds)
-  : m_source(source), m_numMwmIds(std::move(numMwmIds))
+  : m_source(source), m_numMwmIds(move(numMwmIds))
 {
   CHECK(m_numMwmIds, ());
 }
@@ -31,7 +34,7 @@ traffic::SpeedGroup TrafficStash::GetSpeedGroup(Segment const & segment) const
 }
 
 void TrafficStash::SetColoring(NumMwmId numMwmId,
-                               std::shared_ptr<const traffic::TrafficInfo::Coloring> coloring)
+                               shared_ptr<const traffic::TrafficInfo::Coloring> coloring)
 {
   m_mwmToTraffic[numMwmId] = coloring;
 }

--- a/routing/traffic_stash.cpp
+++ b/routing/traffic_stash.cpp
@@ -3,7 +3,6 @@
 #include "base/checked_cast.hpp"
 
 #include <map>
-#include <utility>
 
 namespace routing
 {

--- a/routing/traffic_stash.cpp
+++ b/routing/traffic_stash.cpp
@@ -31,7 +31,7 @@ traffic::SpeedGroup TrafficStash::GetSpeedGroup(Segment const & segment) const
 }
 
 void TrafficStash::SetColoring(NumMwmId numMwmId,
-                               std::shared_ptr<traffic::TrafficInfo::Coloring> coloring)
+                               std::shared_ptr<const traffic::TrafficInfo::Coloring> coloring)
 {
   m_mwmToTraffic[numMwmId] = coloring;
 }
@@ -43,7 +43,7 @@ bool TrafficStash::Has(NumMwmId numMwmId) const
 
 void TrafficStash::CopyTraffic()
 {
-  std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> copy;
+  traffic::AllMwmTrafficInfo copy;
   m_source.CopyTraffic(copy);
   for (auto const & kv : copy)
   {

--- a/routing/traffic_stash.hpp
+++ b/routing/traffic_stash.hpp
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
 
 namespace routing
 {

--- a/routing/traffic_stash.hpp
+++ b/routing/traffic_stash.hpp
@@ -50,7 +50,7 @@ private:
   void Clear() { m_mwmToTraffic.clear(); }
 
   traffic::TrafficCache const & m_source;
-  shared_ptr<NumMwmIds> m_numMwmIds;
+  std::shared_ptr<NumMwmIds> m_numMwmIds;
   std::unordered_map<NumMwmId, std::shared_ptr<const traffic::TrafficInfo::Coloring>> m_mwmToTraffic;
 };
 }  // namespace routing

--- a/routing/traffic_stash.hpp
+++ b/routing/traffic_stash.hpp
@@ -41,7 +41,7 @@ public:
   TrafficStash(traffic::TrafficCache const & source, std::shared_ptr<NumMwmIds> numMwmIds);
 
   traffic::SpeedGroup GetSpeedGroup(Segment const & segment) const;
-  void SetColoring(NumMwmId numMwmId, std::shared_ptr<traffic::TrafficInfo::Coloring> coloring);
+  void SetColoring(NumMwmId numMwmId, std::shared_ptr<const traffic::TrafficInfo::Coloring> coloring);
   bool Has(NumMwmId numMwmId) const;
 
 private:
@@ -51,6 +51,6 @@ private:
 
   traffic::TrafficCache const & m_source;
   shared_ptr<NumMwmIds> m_numMwmIds;
-  std::unordered_map<NumMwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> m_mwmToTraffic;
+  std::unordered_map<NumMwmId, std::shared_ptr<const traffic::TrafficInfo::Coloring>> m_mwmToTraffic;
 };
 }  // namespace routing

--- a/traffic/traffic_cache.cpp
+++ b/traffic/traffic_cache.cpp
@@ -4,7 +4,7 @@ namespace traffic
 {
 using namespace std;
 
-void TrafficCache::Set(MwmSet::MwmId const & mwmId, shared_ptr<TrafficInfo::Coloring> coloring)
+void TrafficCache::Set(MwmSet::MwmId const & mwmId, shared_ptr<TrafficInfo::Coloring const> coloring)
 {
   lock_guard<mutex> guard(mutex);
   m_trafficColoring[mwmId] = coloring;
@@ -16,8 +16,7 @@ void TrafficCache::Remove(MwmSet::MwmId const & mwmId)
   m_trafficColoring.erase(mwmId);
 }
 
-void TrafficCache::CopyTraffic(
-    map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
+void TrafficCache::CopyTraffic(AllMwmTrafficInfo & trafficColoring) const
 {
   lock_guard<mutex> guard(mutex);
   trafficColoring = m_trafficColoring;

--- a/traffic/traffic_cache.cpp
+++ b/traffic/traffic_cache.cpp
@@ -6,25 +6,26 @@ using namespace std;
 
 void TrafficCache::Set(MwmSet::MwmId const & mwmId, shared_ptr<TrafficInfo::Coloring> coloring)
 {
+  lock_guard<mutex> guard(mutex);
   m_trafficColoring[mwmId] = coloring;
 }
 
-void TrafficCache::Remove(MwmSet::MwmId const & mwmId) { m_trafficColoring.erase(mwmId); }
-
-shared_ptr<TrafficInfo::Coloring> TrafficCache::GetTrafficInfo(MwmSet::MwmId const & mwmId) const
+void TrafficCache::Remove(MwmSet::MwmId const & mwmId)
 {
-  auto it = m_trafficColoring.find(mwmId);
-
-  if (it == m_trafficColoring.cend())
-    return shared_ptr<TrafficInfo::Coloring>();
-  return it->second;
+  lock_guard<mutex> guard(mutex);
+  m_trafficColoring.erase(mwmId);
 }
 
 void TrafficCache::CopyTraffic(
     map<MwmSet::MwmId, shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring) const
 {
+  lock_guard<mutex> guard(mutex);
   trafficColoring = m_trafficColoring;
 }
 
-void TrafficCache::Clear() { m_trafficColoring.clear(); }
+void TrafficCache::Clear()
+{
+  lock_guard<mutex> guard(mutex);
+  m_trafficColoring.clear();
+}
 }  // namespace traffic

--- a/traffic/traffic_cache.cpp
+++ b/traffic/traffic_cache.cpp
@@ -4,9 +4,9 @@ namespace traffic
 {
 using namespace std;
 
-void TrafficCache::Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && coloring)
+void TrafficCache::Set(MwmSet::MwmId const & mwmId, shared_ptr<TrafficInfo::Coloring> coloring)
 {
-  m_trafficColoring[mwmId] = make_shared<TrafficInfo::Coloring>(move(coloring));
+  m_trafficColoring[mwmId] = coloring;
 }
 
 void TrafficCache::Remove(MwmSet::MwmId const & mwmId) { m_trafficColoring.erase(mwmId); }

--- a/traffic/traffic_cache.hpp
+++ b/traffic/traffic_cache.hpp
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 
 namespace traffic
 {
@@ -15,8 +16,6 @@ public:
   TrafficCache() : m_trafficColoring() {}
   virtual ~TrafficCache() = default;
 
-  virtual shared_ptr<traffic::TrafficInfo::Coloring> GetTrafficInfo(
-      MwmSet::MwmId const & mwmId) const;
   virtual void CopyTraffic(
       std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring)
       const;
@@ -27,6 +26,7 @@ protected:
   void Clear();
 
 private:
+  std::mutex m_mutex;
   std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> m_trafficColoring;
 };
 }  // namespace traffic

--- a/traffic/traffic_cache.hpp
+++ b/traffic/traffic_cache.hpp
@@ -22,7 +22,7 @@ public:
       const;
 
 protected:
-  void Set(MwmSet::MwmId const & mwmId, TrafficInfo::Coloring && mwmIdAndColoring);
+  void Set(MwmSet::MwmId const & mwmId, std::shared_ptr<TrafficInfo::Coloring> coloring);
   void Remove(MwmSet::MwmId const & mwmId);
   void Clear();
 

--- a/traffic/traffic_cache.hpp
+++ b/traffic/traffic_cache.hpp
@@ -10,23 +10,23 @@
 
 namespace traffic
 {
+using AllMwmTrafficInfo = std::map<MwmSet::MwmId, std::shared_ptr<const traffic::TrafficInfo::Coloring>>;
+
 class TrafficCache
 {
 public:
   TrafficCache() : m_trafficColoring() {}
   virtual ~TrafficCache() = default;
 
-  virtual void CopyTraffic(
-      std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> & trafficColoring)
-      const;
+  virtual void CopyTraffic(AllMwmTrafficInfo & trafficColoring) const;
 
 protected:
-  void Set(MwmSet::MwmId const & mwmId, std::shared_ptr<TrafficInfo::Coloring> coloring);
+  void Set(MwmSet::MwmId const & mwmId, std::shared_ptr<TrafficInfo::Coloring const> coloring);
   void Remove(MwmSet::MwmId const & mwmId);
   void Clear();
 
 private:
   std::mutex m_mutex;
-  std::map<MwmSet::MwmId, std::shared_ptr<traffic::TrafficInfo::Coloring>> m_trafficColoring;
+  AllMwmTrafficInfo m_trafficColoring;
 };
 }  // namespace traffic

--- a/xcode/partners_api/partners_api.xcodeproj/project.pbxproj
+++ b/xcode/partners_api/partners_api.xcodeproj/project.pbxproj
@@ -38,7 +38,6 @@
 		3D4E997C1FB439260025B48C /* booking_availability_params.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D4E997A1FB439260025B48C /* booking_availability_params.hpp */; };
 		3D4E997D1FB439260025B48C /* booking_availability_params.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D4E997B1FB439260025B48C /* booking_availability_params.cpp */; };
 		3D4E997F1FB439300025B48C /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D4E997E1FB439300025B48C /* utils.cpp */; };
-		3D7815761F3A14910068B6AC /* async_gui_thread.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815751F3A14910068B6AC /* async_gui_thread.hpp */; };
 		3DA5713420B57358007BDE27 /* booking_params_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DA5713320B57358007BDE27 /* booking_params_base.hpp */; };
 		3DBC1C541E4B14920016897F /* facebook_ads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DBC1C521E4B14920016897F /* facebook_ads.cpp */; };
 		3DBC1C551E4B14920016897F /* facebook_ads.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DBC1C531E4B14920016897F /* facebook_ads.hpp */; };
@@ -121,7 +120,6 @@
 		3D4E997A1FB439260025B48C /* booking_availability_params.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = booking_availability_params.hpp; sourceTree = "<group>"; };
 		3D4E997B1FB439260025B48C /* booking_availability_params.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = booking_availability_params.cpp; sourceTree = "<group>"; };
 		3D4E997E1FB439300025B48C /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cpp; sourceTree = "<group>"; };
-		3D7815751F3A14910068B6AC /* async_gui_thread.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = async_gui_thread.hpp; sourceTree = "<group>"; };
 		3DA5713320B57358007BDE27 /* booking_params_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = booking_params_base.hpp; sourceTree = "<group>"; };
 		3DBC1C501E4B14810016897F /* facebook_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = facebook_tests.cpp; sourceTree = "<group>"; };
 		3DBC1C521E4B14920016897F /* facebook_ads.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = facebook_ads.cpp; sourceTree = "<group>"; };
@@ -287,7 +285,6 @@
 			isa = PBXGroup;
 			children = (
 				346E889D1E9D088200D4CE9B /* ads_engine_tests.cpp */,
-				3D7815751F3A14910068B6AC /* async_gui_thread.hpp */,
 				F6B536451DA5213D0067EEA5 /* booking_tests.cpp */,
 				3DBC1C501E4B14810016897F /* facebook_tests.cpp */,
 				3D452AED1EE6D202009EAB9B /* google_tests.cpp */,
@@ -346,7 +343,6 @@
 			files = (
 				3DA5713420B57358007BDE27 /* booking_params_base.hpp in Headers */,
 				346E88971E9D087400D4CE9B /* ads_base.hpp in Headers */,
-				3D7815761F3A14910068B6AC /* async_gui_thread.hpp in Headers */,
 				3DCD415420DAB33700143533 /* booking_block_params.hpp in Headers */,
 				F67E75261DB8F06F00D6741F /* opentable_api.hpp in Headers */,
 				3D452AF41EE6D20D009EAB9B /* google_ads.hpp in Headers */,

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		451E32A21F73A8B000964C9F /* secure_storage.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 451E329F1F73A8B000964C9F /* secure_storage.hpp */; };
 		4564FA7E2094978D0043CCFB /* remote_file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4564FA7C2094978C0043CCFB /* remote_file.hpp */; };
 		4564FA7F2094978D0043CCFB /* remote_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4564FA7D2094978D0043CCFB /* remote_file.cpp */; };
+		5661A5CC20DD57DA00C6B1D1 /* async_gui_thread.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5661A5CB20DD57DA00C6B1D1 /* async_gui_thread.hpp */; };
 		56EB1EDC1C6B6E6C0022D831 /* file_logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56EB1ED81C6B6E6C0022D831 /* file_logging.cpp */; };
 		56EB1EDD1C6B6E6C0022D831 /* file_logging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EB1ED91C6B6E6C0022D831 /* file_logging.hpp */; };
 		56EB1EDE1C6B6E6C0022D831 /* mwm_traits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56EB1EDA1C6B6E6C0022D831 /* mwm_traits.cpp */; };
@@ -141,6 +142,7 @@
 		451E329F1F73A8B000964C9F /* secure_storage.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = secure_storage.hpp; sourceTree = "<group>"; };
 		4564FA7C2094978C0043CCFB /* remote_file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = remote_file.hpp; sourceTree = "<group>"; };
 		4564FA7D2094978D0043CCFB /* remote_file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remote_file.cpp; sourceTree = "<group>"; };
+		5661A5CB20DD57DA00C6B1D1 /* async_gui_thread.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = async_gui_thread.hpp; sourceTree = "<group>"; };
 		56EB1ED81C6B6E6C0022D831 /* file_logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_logging.cpp; sourceTree = "<group>"; };
 		56EB1ED91C6B6E6C0022D831 /* file_logging.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file_logging.hpp; sourceTree = "<group>"; };
 		56EB1EDA1C6B6E6C0022D831 /* mwm_traits.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mwm_traits.cpp; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 		675340E41C58C43A002CF0D9 /* platform_tests_support */ = {
 			isa = PBXGroup;
 			children = (
+				5661A5CB20DD57DA00C6B1D1 /* async_gui_thread.hpp */,
 				675E889E1DB7B0F200F8EBDA /* test_socket.cpp */,
 				675E889F1DB7B0F200F8EBDA /* test_socket.hpp */,
 				67247FFB1C60BD6500EDE56A /* writable_dir_changer.cpp */,
@@ -459,6 +462,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				675341271C58C61D002CF0D9 /* scoped_dir.hpp in Headers */,
+				5661A5CC20DD57DA00C6B1D1 /* async_gui_thread.hpp in Headers */,
 				675341281C58C61D002CF0D9 /* scoped_mwm.hpp in Headers */,
 				F6DF735C1EC9EAE700D8BA0B /* string_storage_base.hpp in Headers */,
 				675341261C58C616002CF0D9 /* scoped_file.hpp in Headers */,

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		56290B85206A3231003892E0 /* routing_algorithm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_algorithm.cpp; sourceTree = "<group>"; };
 		56290B86206A3231003892E0 /* routing_algorithm.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_algorithm.hpp; sourceTree = "<group>"; };
 		562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_callbacks.hpp; sourceTree = "<group>"; };
+		5661A5CD20DE51C500C6B1D1 /* tools.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tools.hpp; sourceTree = "<group>"; };
 		567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor_test.cpp; sourceTree = "<group>"; };
 		5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkpoint_predictor.cpp; sourceTree = "<group>"; };
 		5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = checkpoint_predictor.hpp; sourceTree = "<group>"; };
@@ -643,6 +644,7 @@
 		6742ACA01C68A07C009CB89E /* routing_tests */ = {
 			isa = PBXGroup;
 			children = (
+				5661A5CD20DE51C500C6B1D1 /* tools.hpp */,
 				56290B85206A3231003892E0 /* routing_algorithm.cpp */,
 				56290B86206A3231003892E0 /* routing_algorithm.hpp */,
 				567059591F3AF96D0062672D /* checkpoint_predictor_test.cpp */,


### PR DESCRIPTION
Вызов всех колбеков роутнига и почти(*) всех методов RoutingSession из ui потока.
* См. комменты около методов RoutingSession, которые допустимо вызывать не из UI потока. 
https://jira.mail.ru/browse/MAPSME-7423

Детали:

Сейчас там в RoutingSession/RoutingManager во многих местах есть race condition. А так же не эффективное использование mutex-ов. Есть случаи, когда несколько mutex-ов захватывается, а потом ничего не делается и они отпускаются. Кроме того, есть лишние копирования класса Route.

Все эти проблемы решены в данном PR.

 1. При инициализации RoutingSession (m_routingSession.Init(...)) в качестве второго параметра передается лямбдаPointCheckCallback`. В релизе это всегда пустая пустая ф-ция. Но для ее вызова, на каждой посещаемой вершине захватывается mutex. Это исправлено в данном PR и это ускорит прокладку маршрута.

 2. При асинхронной прокладке маршрута принцип работы должен быть такой:
начальные данные (старт, финиш и прочее) передаются на в поток прокладки маршрута;
асинхронно (в routing background thread) прокладывается маршрут (иногда уведомляя через GUI thread о прогрессе) или позволяя прервать прокладку;
после подготовки маршрута shared_ptr отдается в RoutingSession;
после этого момента фоновый поток маршрута больше не редактирует данный shared_ptr. Единственное, что возможно из фонового потока - замена shared_ptr на новый, если маршрут перестроен.
В мастере это не так. Маршрут во время построения может передаваться 2 раза в RoutingSession, притом эта передача особо не защищена.
2.a. сделан отдельный callback для уведомления платформы о списке не достающих для прокладки маршрута mwm, полученных с сервера и добавлять эту информацию в Route на gui потоке или хранить отдельно;
2.b. сделаны callbacks уведомляющие о готовности роутера передавать владение маршрутом (shared_ptr);
2.c реализован подход описанный в 2.

3. Нужно сделать, что все callbacks по прокладке маршрута вызывались на gui thread.  Далее все обращения к RoutingSession::m_route и другим данным RoutingSession должны быть из gui thread.

3. Удалены все не нужные mutex-ы (например, RoutingSession::m_routingSessionMutex) и обертки для них (DoReadyCallback, RoutingSession::ProtectedCall()) и заменены на ThreadCheckers.

Как результат мы получем:

отсутствие состояния гонки при использовании фонового потока роутинга для прокладки маршрута. Что может вылечить странные баги, когда ломается сопровождение по маршруту и подобные;
уменьшение кол-ва mutex-ов и упрощение работы с RoutingSession/RoutingManager и колбеками при прокладке маршрута;
вероятно, некоторое ускорение прокладки маршрута. Найдено место, где при посещении каждой вершины в A* захватывался и отпускался мьютекс без какой-либо работы (в релиз версии). Данные в классе Route на мастере имели лишние копирования.

@tatiana-yan, @rokuz PTAL