### PR TITLE
[base] Fix infinite loop in LevenshteinDFA

### DIFF
--- a/base/levenshtein_dfa.cpp
+++ b/base/levenshtein_dfa.cpp
@@ -203,7 +203,7 @@ LevenshteinDFA::LevenshteinDFA(UniString const & s, size_t prefixSize,
 
   auto const pSize = static_cast<typename std::iterator_traits<
           UniString::iterator>::difference_type>(prefixSize);
-  for (auto it = s.begin(); std::distance(it, s.begin()) < pSize; ++it)
+  for (auto it = s.begin(); std::distance(s.begin(), it) < pSize; ++it)
   {
     for (auto const & misprints : prefixMisprints)
     {


### PR DESCRIPTION
Исправление ворнингов выявило ошибку, расстояние в эту сторону отрицательное, раньше работало т.к. кастовалось к беззнаковому.