### PR TITLE
[indexer] Datasource refactoring

### DIFF
--- a/editor/editable_data_source.hpp
+++ b/editor/editable_data_source.hpp
@@ -11,12 +11,3 @@ class EditableDataSource : public DataSource
 public:
   EditableDataSource() : DataSource(std::make_unique<EditableFeatureSourceFactory>()) {}
 };
-
-class EditableFeaturesLoaderGuard : public DataSource::FeaturesLoaderGuard
-{
-public:
-  EditableFeaturesLoaderGuard(DataSource const & dataSource, DataSource::MwmId const & id)
-    : DataSource::FeaturesLoaderGuard(dataSource, id, EditableFeatureSourceFactory())
-  {
-  }
-};

--- a/editor/editable_feature_source.cpp
+++ b/editor/editable_feature_source.cpp
@@ -14,15 +14,8 @@ bool EditableFeatureSource::GetModifiedFeature(uint32_t index, FeatureType & fea
   return editor.GetEditedFeature(m_handle.GetId(), index, feature);
 }
 
-void EditableFeatureSource::ForEachInRectAndScale(
-    m2::RectD const & rect, int scale, std::function<void(FeatureID const &)> const & fn) const
-{
-  osm::Editor & editor = osm::Editor::Instance();
-  editor.ForEachFeatureInMwmRectAndScale(m_handle.GetId(), fn, rect, scale);
-}
-
-void EditableFeatureSource::ForEachInRectAndScale(
-    m2::RectD const & rect, int scale, std::function<void(FeatureType &)> const & fn) const
+void EditableFeatureSource::ForEachInRectAndScale(m2::RectD const & rect, int scale,
+                                                  std::function<void(uint32_t)> const & fn) const
 {
   osm::Editor & editor = osm::Editor::Instance();
   editor.ForEachFeatureInMwmRectAndScale(m_handle.GetId(), fn, rect, scale);

--- a/editor/editable_feature_source.hpp
+++ b/editor/editable_feature_source.hpp
@@ -19,9 +19,7 @@ public:
   FeatureStatus GetFeatureStatus(uint32_t index) const override;
   bool GetModifiedFeature(uint32_t index, FeatureType & feature) const override;
   void ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                             std::function<void(FeatureID const &)> const & fn) const override;
-  void ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                             std::function<void(FeatureType &)> const & fn) const override;
+                             std::function<void(uint32_t)> const & fn) const override;
 };
 
 class EditableFeatureSourceFactory : public FeatureSourceFactory

--- a/editor/editor_tests/osm_editor_test.cpp
+++ b/editor/editor_tests/osm_editor_test.cpp
@@ -117,16 +117,13 @@ void GenerateUploadedFeature(MwmSet::MwmId const & mwmId,
   xf.AttachToParentNode(created);
 }
 
-template <typename T>
 uint32_t CountFeaturesInRect(MwmSet::MwmId const & mwmId, m2::RectD const & rect)
 {
   auto & editor = osm::Editor::Instance();
   int unused = 0;
   uint32_t counter = 0;
-  editor.ForEachFeatureInMwmRectAndScale(mwmId, [&counter](T const & ft)
-  {
-    ++counter;
-  }, rect, unused);
+  editor.ForEachFeatureInMwmRectAndScale(mwmId, [&counter](uint32_t index) { ++counter; }, rect,
+                                         unused);
 
   return counter;
 }
@@ -769,13 +766,9 @@ void EditorTest::ForEachFeatureInMwmRectAndScaleTest()
     CreateCafeAtPoint({22.0, 22.0}, mwmId, emo);
   }
 
-  TEST_EQUAL(CountFeaturesInRect<FeatureType>(mwmId, {0.0, 0.0, 2.0, 2.0}), 0, ());
-  TEST_EQUAL(CountFeaturesInRect<FeatureType>(mwmId, {9.0, 9.0, 21.0, 21.0}), 2, ());
-  TEST_EQUAL(CountFeaturesInRect<FeatureType>(mwmId, {9.0, 9.0, 23.0, 23.0}), 3, ());
-
-  TEST_EQUAL(CountFeaturesInRect<FeatureID>(mwmId, {0.0, 0.0, 2.0, 2.0}), 0, ());
-  TEST_EQUAL(CountFeaturesInRect<FeatureID>(mwmId, {9.0, 9.0, 21.0, 21.0}), 2, ());
-  TEST_EQUAL(CountFeaturesInRect<FeatureID>(mwmId, {9.0, 9.0, 23.0, 23.0}), 3, ());
+  TEST_EQUAL(CountFeaturesInRect(mwmId, {0.0, 0.0, 2.0, 2.0}), 0, ());
+  TEST_EQUAL(CountFeaturesInRect(mwmId, {9.0, 9.0, 21.0, 21.0}), 2, ());
+  TEST_EQUAL(CountFeaturesInRect(mwmId, {9.0, 9.0, 23.0, 23.0}), 3, ());
 }
 
 void EditorTest::CreateNoteTest()

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -486,8 +486,7 @@ bool Editor::RollBackChanges(FeatureID const & fid)
 }
 
 void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
-                                             TFeatureIDFunctor const & f,
-                                             m2::RectD const & rect,
+                                             TFeatureIndexFunctor const & f, m2::RectD const & rect,
                                              int /*scale*/)
 {
   auto const mwmFound = m_features.find(id);
@@ -501,27 +500,7 @@ void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
     FeatureTypeInfo const & ftInfo = index.second;
     if (ftInfo.m_status == FeatureStatus::Created &&
         rect.IsPointInside(ftInfo.m_feature.GetCenter()))
-      f(FeatureID(id, index.first));
-  }
-}
-
-void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
-                                             TFeatureTypeFunctor const & f,
-                                             m2::RectD const & rect,
-                                             int /*scale*/)
-{
-  auto mwmFound = m_features.find(id);
-  if (mwmFound == m_features.end())
-    return;
-
-  // TODO(AlexZ): Check that features are visible at this scale.
-  // Process only new (created) features.
-  for (auto & index : mwmFound->second)
-  {
-    FeatureTypeInfo & ftInfo = index.second;
-    if (ftInfo.m_status == FeatureStatus::Created &&
-        rect.IsPointInside(ftInfo.m_feature.GetCenter()))
-      f(ftInfo.m_feature);
+      f(index.first);
   }
 }
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -486,7 +486,7 @@ bool Editor::RollBackChanges(FeatureID const & fid)
 }
 
 void Editor::ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
-                                             TFeatureIndexFunctor const & f, m2::RectD const & rect,
+                                             FeatureIndexFunctor const & f, m2::RectD const & rect,
                                              int /*scale*/)
 {
   auto const mwmFound = m_features.find(id);
@@ -625,8 +625,8 @@ bool Editor::HaveMapEditsToUpload(MwmSet::MwmId const & mwmId) const
   return false;
 }
 
-void Editor::UploadChanges(string const & key, string const & secret, TChangesetTags tags,
-                           TFinishUploadCallback callBack)
+void Editor::UploadChanges(string const & key, string const & secret, ChangesetTags tags,
+                           FinishUploadCallback callBack)
 {
   if (m_notes->NotUploadedNotesCount())
     UploadNotes(key, secret);
@@ -640,7 +640,7 @@ void Editor::UploadChanges(string const & key, string const & secret, TChangeset
   alohalytics::LogEvent("Editor_DataSync_started");
 
   // TODO(AlexZ): features access should be synchronized.
-  auto const upload = [this](string key, string secret, TChangesetTags tags, TFinishUploadCallback callBack)
+  auto const upload = [this](string key, string secret, ChangesetTags tags, FinishUploadCallback callBack)
   {
     // This lambda was designed to start after app goes into background. But for cases when user is immediately
     // coming back to the app we work with a copy, because 'for' loops below can take a significant amount of time.

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -65,7 +65,7 @@ public:
     Error,
     NothingToUpload
   };
-  using TFinishUploadCallback = function<void(UploadResult)>;
+  using FinishUploadCallback = function<void(UploadResult)>;
 
   static Editor & Instance();
 
@@ -92,8 +92,8 @@ public:
 
   void OnMapDeregistered(platform::LocalCountryFile const & localFile) override;
 
-  using TFeatureIndexFunctor = function<void(uint32_t)>;
-  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id, TFeatureIndexFunctor const & f,
+  using FeatureIndexFunctor = function<void(uint32_t)>;
+  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id, FeatureIndexFunctor const & f,
                                        m2::RectD const & rect, int scale);
 
   // TODO(mgsergio): Unify feature functions signatures.
@@ -140,11 +140,11 @@ public:
   bool HaveMapEditsOrNotesToUpload() const;
   bool HaveMapEditsToUpload(MwmSet::MwmId const & mwmId) const;
   bool HaveMapEditsToUpload() const;
-  using TChangesetTags = map<string, string>;
+  using ChangesetTags = map<string, string>;
   /// Tries to upload all local changes to OSM server in a separate thread.
   /// @param[in] tags should provide additional information about client to use in changeset.
-  void UploadChanges(string const & key, string const & secret, TChangesetTags tags,
-                     TFinishUploadCallback callBack = TFinishUploadCallback());
+  void UploadChanges(string const & key, string const & secret, ChangesetTags tags,
+                     FinishUploadCallback callBack = FinishUploadCallback());
   // TODO(mgsergio): Test new types from new config but with old classificator (where these types are absent).
   // Editor should silently ignore all types in config which are unknown to him.
   NewFeatureCategories GetNewFeatureCategories() const;

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -92,16 +92,9 @@ public:
 
   void OnMapDeregistered(platform::LocalCountryFile const & localFile) override;
 
-  using TFeatureIDFunctor = function<void(FeatureID const &)>;
-  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
-                                       TFeatureIDFunctor const & f,
-                                       m2::RectD const & rect,
-                                       int scale);
-  using TFeatureTypeFunctor = function<void(FeatureType &)>;
-  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id,
-                                       TFeatureTypeFunctor const & f,
-                                       m2::RectD const & rect,
-                                       int scale);
+  using TFeatureIndexFunctor = function<void(uint32_t)>;
+  void ForEachFeatureInMwmRectAndScale(MwmSet::MwmId const & id, TFeatureIndexFunctor const & f,
+                                       m2::RectD const & rect, int scale);
 
   // TODO(mgsergio): Unify feature functions signatures.
 

--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -353,7 +353,7 @@ int main(int argc, char ** argv)
     map<uint32_t, osm::Id> featureIdToOsmId;
     ParseFeatureIdToOsmIdMapping(osmToFeatureFile, featureIdToOsmId);
     MwmSet::MwmId mwmId(mwmInfo);
-    FrozenFeaturesLoaderGuard loader(dataSource, mwmId);
+    FeaturesLoaderGuard loader(dataSource, mwmId);
     for (uint32_t ftIndex = 0; ftIndex < loader.GetNumFeatures(); ftIndex++)
     {
       FeatureType ft;

--- a/indexer/data_source.cpp
+++ b/indexer/data_source.cpp
@@ -103,8 +103,8 @@ private:
 };
 }  //  namespace
 
-// DataSource::FeaturesLoaderGuard ---------------------------------------------------------
-string DataSource::FeaturesLoaderGuard::GetCountryFileName() const
+// FeaturesLoaderGuard ---------------------------------------------------------------------
+string FeaturesLoaderGuard::GetCountryFileName() const
 {
   if (!m_handle.IsAlive())
     return string();
@@ -112,7 +112,7 @@ string DataSource::FeaturesLoaderGuard::GetCountryFileName() const
   return m_handle.GetValue<MwmValue>()->GetCountryFileName();
 }
 
-bool DataSource::FeaturesLoaderGuard::IsWorld() const
+bool FeaturesLoaderGuard::IsWorld() const
 {
   if (!m_handle.IsAlive())
     return false;
@@ -120,8 +120,7 @@ bool DataSource::FeaturesLoaderGuard::IsWorld() const
   return m_handle.GetValue<MwmValue>()->GetHeader().GetType() == feature::DataHeader::world;
 }
 
-unique_ptr<FeatureType> DataSource::FeaturesLoaderGuard::GetOriginalFeatureByIndex(
-    uint32_t index) const
+unique_ptr<FeatureType> FeaturesLoaderGuard::GetOriginalFeatureByIndex(uint32_t index) const
 {
   auto feature = make_unique<FeatureType>();
   if (GetOriginalFeatureByIndex(index, *feature))
@@ -130,8 +129,7 @@ unique_ptr<FeatureType> DataSource::FeaturesLoaderGuard::GetOriginalFeatureByInd
   return {};
 }
 
-unique_ptr<FeatureType> DataSource::FeaturesLoaderGuard::GetOriginalOrEditedFeatureByIndex(
-    uint32_t index) const
+unique_ptr<FeatureType> FeaturesLoaderGuard::GetOriginalOrEditedFeatureByIndex(uint32_t index) const
 {
   auto feature = make_unique<FeatureType>();
   if (!m_handle.IsAlive())
@@ -144,8 +142,8 @@ unique_ptr<FeatureType> DataSource::FeaturesLoaderGuard::GetOriginalOrEditedFeat
   return {};
 }
 
-WARN_UNUSED_RESULT bool DataSource::FeaturesLoaderGuard::GetFeatureByIndex(uint32_t index,
-                                                                           FeatureType & ft) const
+WARN_UNUSED_RESULT bool FeaturesLoaderGuard::GetFeatureByIndex(uint32_t index,
+                                                               FeatureType & ft) const
 {
   if (!m_handle.IsAlive())
     return false;
@@ -157,8 +155,8 @@ WARN_UNUSED_RESULT bool DataSource::FeaturesLoaderGuard::GetFeatureByIndex(uint3
   return GetOriginalFeatureByIndex(index, ft);
 }
 
-WARN_UNUSED_RESULT bool DataSource::FeaturesLoaderGuard::GetOriginalFeatureByIndex(
-    uint32_t index, FeatureType & ft) const
+WARN_UNUSED_RESULT bool FeaturesLoaderGuard::GetOriginalFeatureByIndex(uint32_t index,
+                                                                       FeatureType & ft) const
 {
   return m_handle.IsAlive() ? m_source->GetOriginalFeature(index, ft) : false;
 }

--- a/indexer/feature_source.cpp
+++ b/indexer/feature_source.cpp
@@ -53,11 +53,6 @@ bool FeatureSource::GetModifiedFeature(uint32_t index, FeatureType & feature) co
 }
 
 void FeatureSource::ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                                          function<void(FeatureID const &)> const & fn) const
-{
-}
-
-void FeatureSource::ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                                          function<void(FeatureType &)> const & fn) const
+                                          function<void(uint32_t)> const & fn) const
 {
 }

--- a/indexer/feature_source.hpp
+++ b/indexer/feature_source.hpp
@@ -42,9 +42,7 @@ public:
   virtual bool GetModifiedFeature(uint32_t index, FeatureType & feature) const;
 
   virtual void ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                                     std::function<void(FeatureID const &)> const & fn) const;
-  virtual void ForEachInRectAndScale(m2::RectD const & rect, int scale,
-                                     std::function<void(FeatureType &)> const & fn) const;
+                                     std::function<void(uint32_t)> const & fn) const;
 
 protected:
   MwmSet::MwmHandle const & m_handle;

--- a/indexer/indexer_tests/scale_index_reading_tests.cpp
+++ b/indexer/indexer_tests/scale_index_reading_tests.cpp
@@ -54,7 +54,7 @@ public:
                                       [&](uint32_t index) { indices.push_back(index); });
     }
 
-    FrozenFeaturesLoaderGuard loader(m_dataSource, id);
+    FeaturesLoaderGuard loader(m_dataSource, id);
 
     Names names;
     for (auto const & index : indices)

--- a/map/booking_availability_filter.cpp
+++ b/map/booking_availability_filter.cpp
@@ -15,8 +15,6 @@
 #include <utility>
 #include <vector>
 
-using LoaderGuard = EditableFeaturesLoaderGuard;
-
 using namespace booking::filter;
 
 namespace
@@ -107,12 +105,12 @@ void PrepareData(DataSource const & dataSource, search::Results const & results,
   std::sort(features.begin(), features.end());
 
   MwmSet::MwmId mwmId;
-  std::unique_ptr<LoaderGuard> guard;
+  std::unique_ptr<FeaturesLoaderGuard> guard;
   for (auto const & featureId : features)
   {
     if (mwmId != featureId.m_mwmId)
     {
-      guard = my::make_unique<LoaderGuard>(dataSource, featureId.m_mwmId);
+      guard = my::make_unique<FeaturesLoaderGuard>(dataSource, featureId.m_mwmId);
       mwmId = featureId.m_mwmId;
     }
 
@@ -224,12 +222,12 @@ void AvailabilityFilter::GetFeaturesFromCache(search::Results const & results,
   std::sort(features.begin(), features.end());
 
   MwmSet::MwmId mwmId;
-  std::unique_ptr<LoaderGuard> guard;
+  std::unique_ptr<FeaturesLoaderGuard> guard;
   for (auto const & featureId : features)
   {
     if (mwmId != featureId.m_mwmId)
     {
-      guard = my::make_unique<LoaderGuard>(GetDelegate().GetDataSource(), featureId.m_mwmId);
+      guard = my::make_unique<FeaturesLoaderGuard>(GetDelegate().GetDataSource(), featureId.m_mwmId);
       mwmId = featureId.m_mwmId;
     }
 

--- a/map/discovery/discovery_manager.cpp
+++ b/map/discovery/discovery_manager.cpp
@@ -71,7 +71,7 @@ std::string Manager::GetCityViatorId(m2::PointD const & point) const
   if (!fid.IsValid())
     return {};
 
-  EditableFeaturesLoaderGuard const guard(m_dataSource, fid.m_mwmId);
+  FeaturesLoaderGuard const guard(m_dataSource, fid.m_mwmId);
   FeatureType ft;
   if (!guard.GetFeatureByIndex(fid.m_index, ft))
   {

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -749,7 +749,7 @@ void Framework::FillFeatureInfo(FeatureID const & fid, place_page::Info & info) 
     return;
   }
 
-  EditableFeaturesLoaderGuard const guard(m_model.GetDataSource(), fid.m_mwmId);
+  FeaturesLoaderGuard const guard(m_model.GetDataSource(), fid.m_mwmId);
   FeatureType ft;
   if (!guard.GetFeatureByIndex(fid.m_index, ft))
   {
@@ -2085,7 +2085,7 @@ bool Framework::GetFeatureByID(FeatureID const & fid, FeatureType & ft) const
 {
   ASSERT(fid.IsValid(), ());
 
-  EditableFeaturesLoaderGuard guard(m_model.GetDataSource(), fid.m_mwmId);
+  FeaturesLoaderGuard guard(m_model.GetDataSource(), fid.m_mwmId);
   if (!guard.GetFeatureByIndex(fid.m_index, ft))
     return false;
 
@@ -2604,7 +2604,7 @@ vector<m2::TriangleD> Framework::GetSelectedFeatureTriangles() const
   if (!m_selectedFeature.IsValid())
     return triangles;
 
-  EditableFeaturesLoaderGuard const guard(m_model.GetDataSource(), m_selectedFeature.m_mwmId);
+  FeaturesLoaderGuard const guard(m_model.GetDataSource(), m_selectedFeature.m_mwmId);
   FeatureType ft;
   if (!guard.GetFeatureByIndex(m_selectedFeature.m_index, ft))
     return triangles;
@@ -2741,7 +2741,7 @@ namespace
 WARN_UNUSED_RESULT bool LocalizeStreet(DataSource const & dataSource, FeatureID const & fid,
                                        osm::LocalizedStreet & result)
 {
-  EditableFeaturesLoaderGuard g(dataSource, fid.m_mwmId);
+  FeaturesLoaderGuard g(dataSource, fid.m_mwmId);
   FeatureType ft;
   if (!g.GetFeatureByIndex(fid.m_index, ft))
     return false;
@@ -2858,7 +2858,7 @@ void SetHostingBuildingAddress(FeatureID const & hostingBuildingFid, DataSource 
 
   FeatureType hostingBuildingFeature;
 
-  EditableFeaturesLoaderGuard g(dataSource, hostingBuildingFid.m_mwmId);
+  FeaturesLoaderGuard g(dataSource, hostingBuildingFid.m_mwmId);
   if (!g.GetFeatureByIndex(hostingBuildingFid.m_index, hostingBuildingFeature))
     return;
 
@@ -2952,7 +2952,7 @@ osm::Editor::SaveResult Framework::SaveEditedMapObject(osm::EditableMapObject em
   {
     auto const isCreatedFeature = editor.IsCreatedFeature(emo.GetID());
 
-    EditableFeaturesLoaderGuard g(m_model.GetDataSource(), emo.GetID().m_mwmId);
+    FeaturesLoaderGuard g(m_model.GetDataSource(), emo.GetID().m_mwmId);
     FeatureType originalFeature;
     if (!isCreatedFeature)
     {

--- a/openlr/openlr_decoder.cpp
+++ b/openlr/openlr_decoder.cpp
@@ -81,7 +81,7 @@ struct alignas(kCacheLineSize) Stats
 
 bool IsRealVertex(m2::PointD const & p, FeatureID const & fid, DataSource const & dataSource)
 {
-  FrozenFeaturesLoaderGuard g(dataSource, fid.m_mwmId);
+  FeaturesLoaderGuard g(dataSource, fid.m_mwmId);
   auto const ft = g.GetOriginalFeatureByIndex(fid.m_index);
   bool matched = false;
   ft->ForEachPoint(

--- a/openlr/openlr_tests/decoded_path_test.cpp
+++ b/openlr/openlr_tests/decoded_path_test.cpp
@@ -140,7 +140,7 @@ void WithRoad(vector<m2::PointD> const & points, Func && fn)
   MwmSet::MwmHandle mwmHandle = dataSource.GetMwmHandleById(regResult.first);
   TEST(mwmHandle.IsAlive(), ());
 
-  FrozenFeaturesLoaderGuard const guard(dataSource, regResult.first);
+  FeaturesLoaderGuard const guard(dataSource, regResult.first);
   FeatureType road;
   TEST(guard.GetFeatureByIndex(0, road), ());
   road.ParseEverything();

--- a/openlr/road_info_getter.cpp
+++ b/openlr/road_info_getter.cpp
@@ -21,7 +21,7 @@ RoadInfoGetter::RoadInfo RoadInfoGetter::Get(FeatureID const & fid)
   if (it != end(m_cache))
     return it->second;
 
-  FrozenFeaturesLoaderGuard g(m_dataSource, fid.m_mwmId);
+  FeaturesLoaderGuard g(m_dataSource, fid.m_mwmId);
   FeatureType ft;
   CHECK(g.GetOriginalFeatureByIndex(fid.m_index, ft), ());
 

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -211,10 +211,10 @@ bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph, vector<Junc
   return true;
 }
 
-DataSource::FeaturesLoaderGuard & BicycleDirectionsEngine::GetLoader(MwmSet::MwmId const & id)
+FeaturesLoaderGuard & BicycleDirectionsEngine::GetLoader(MwmSet::MwmId const & id)
 {
   if (!m_loader || id != m_loader->GetId())
-    m_loader = make_unique<EditableFeaturesLoaderGuard>(m_dataSource, id);
+    m_loader = make_unique<FeaturesLoaderGuard>(m_dataSource, id);
   return *m_loader;
 }
 

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -39,7 +39,7 @@ public:
                 vector<Segment> & segments) override;
 
 private:
-  DataSource::FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
+  FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
   void LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment);
   void GetSegmentRangeAndAdjacentEdges(IRoadGraph::TEdgeVector const & outgoingEdges,
                                        Edge const & inEdge, uint32_t startSegId, uint32_t endSegId,
@@ -60,6 +60,6 @@ private:
   TUnpackedPathSegments m_pathSegments;
   DataSource const & m_dataSource;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
-  std::unique_ptr<DataSource::FeaturesLoaderGuard> m_loader;
+  std::unique_ptr<FeaturesLoaderGuard> m_loader;
 };
 }  // namespace routing

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -205,7 +205,7 @@ void FeaturesRoadGraph::FindClosestEdges(m2::PointD const & point, uint32_t coun
 void FeaturesRoadGraph::GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const
 {
   FeatureType ft;
-  EditableFeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
+  FeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
   if (!loader.GetFeatureByIndex(featureId.m_index, ft))
     return;
 
@@ -306,7 +306,7 @@ IRoadGraph::RoadInfo const & FeaturesRoadGraph::GetCachedRoadInfo(FeatureID cons
 
   FeatureType ft;
 
-  EditableFeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
+  FeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
 
   if (!loader.GetFeatureByIndex(featureId.m_index, ft))
     return ri;

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -33,7 +33,7 @@ public:
 
 private:
   shared_ptr<VehicleModelInterface> m_vehicleModel;
-  EditableFeaturesLoaderGuard m_guard;
+  FeaturesLoaderGuard m_guard;
   string const m_country;
   feature::AltitudeLoader m_altitudeLoader;
   bool const m_loadAltitudes;

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -60,7 +60,7 @@ void IndexRoadGraph::GetEdgeTypes(Edge const & edge, feature::TypesHolder & type
 
   FeatureID const featureId = edge.GetFeatureId();
   FeatureType ft;
-  EditableFeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
+  FeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
   if (!loader.GetFeatureByIndex(featureId.m_index, ft))
   {
     LOG(LERROR, ("Can't load types for feature", featureId));

--- a/search/downloader_search_callback.cpp
+++ b/search/downloader_search_callback.cpp
@@ -63,7 +63,7 @@ void DownloaderSearchCallback::operator()(search::Results const & results)
     if (result.GetResultType() != search::Result::Type::LatLon)
     {
       FeatureID const & fid = result.GetFeatureID();
-      EditableFeaturesLoaderGuard loader(m_dataSource, fid.m_mwmId);
+      FeaturesLoaderGuard loader(m_dataSource, fid.m_mwmId);
       FeatureType ft;
       if (!loader.GetFeatureByIndex(fid.m_index, ft))
       {

--- a/search/editor_delegate.cpp
+++ b/search/editor_delegate.cpp
@@ -18,7 +18,7 @@ MwmSet::MwmId EditorDelegate::GetMwmIdByMapName(string const & name) const
 
 unique_ptr<FeatureType> EditorDelegate::GetOriginalFeature(FeatureID const & fid) const
 {
-  EditableFeaturesLoaderGuard guard(m_dataSource, fid.m_mwmId);
+  FeaturesLoaderGuard guard(m_dataSource, fid.m_mwmId);
   auto feature = guard.GetOriginalFeatureByIndex(fid.m_index);
   if (feature)
     feature->ParseEverything();

--- a/search/feature_loader.cpp
+++ b/search/feature_loader.cpp
@@ -16,7 +16,7 @@ bool FeatureLoader::Load(FeatureID const & id, FeatureType & ft)
 
   auto const & mwmId = id.m_mwmId;
   if (!m_guard || m_guard->GetId() != mwmId)
-    m_guard = my::make_unique<EditableFeaturesLoaderGuard>(m_dataSource, mwmId);
+    m_guard = my::make_unique<FeaturesLoaderGuard>(m_dataSource, mwmId);
   return m_guard->GetFeatureByIndex(id.m_index, ft);
 }
 

--- a/search/feature_loader.hpp
+++ b/search/feature_loader.hpp
@@ -32,7 +32,7 @@ public:
 
 private:
   DataSource const & m_dataSource;
-  std::unique_ptr<DataSource::FeaturesLoaderGuard> m_guard;
+  std::unique_ptr<FeaturesLoaderGuard> m_guard;
 
   ThreadChecker m_checker;
 };

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -211,18 +211,17 @@ private:
 
 class RankerResultMaker
 {
-  using LoaderGuard = EditableFeaturesLoaderGuard;
   Ranker & m_ranker;
   DataSource const & m_dataSource;
   Geocoder::Params const & m_params;
   storage::CountryInfoGetter const & m_infoGetter;
 
-  unique_ptr<LoaderGuard> m_loader;
+  unique_ptr<FeaturesLoaderGuard> m_loader;
 
   bool LoadFeature(FeatureID const & id, FeatureType & ft)
   {
     if (!m_loader || m_loader->GetId() != id.m_mwmId)
-      m_loader = make_unique<LoaderGuard>(m_dataSource, id.m_mwmId);
+      m_loader = make_unique<FeaturesLoaderGuard>(m_dataSource, id.m_mwmId);
     if (!m_loader->GetFeatureByIndex(id.m_index, ft))
       return false;
 

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -605,7 +605,7 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
     while (!features->GetBit(index))
       ++index;
 
-    EditableFeaturesLoaderGuard loader(m_dataSource, countryId);
+    FeaturesLoaderGuard loader(m_dataSource, countryId);
     FeatureType ft;
     TEST(loader.GetFeatureByIndex(::base::checked_cast<uint32_t>(index), ft), ());
 
@@ -702,7 +702,7 @@ UNIT_CLASS_TEST(ProcessorTest, TestCategories)
     TEST(ResultsMatch(request->Results(), rules), ());
     for (auto const & result : request->Results())
     {
-      EditableFeaturesLoaderGuard loader(m_dataSource, wonderlandId);
+      FeaturesLoaderGuard loader(m_dataSource, wonderlandId);
       FeatureType ft;
       TEST(loader.GetFeatureByIndex(result.GetFeatureID().m_index, ft), ());
 

--- a/search/search_tests_support/test_with_custom_mwms.hpp
+++ b/search/search_tests_support/test_with_custom_mwms.hpp
@@ -31,7 +31,7 @@ public:
   template <typename EditorFn>
   void EditFeature(FeatureID const & id, EditorFn && fn)
   {
-    EditableFeaturesLoaderGuard loader(m_dataSource, id.m_mwmId);
+    FeaturesLoaderGuard loader(m_dataSource, id.m_mwmId);
     FeatureType ft;
     CHECK(loader.GetFeatureByIndex(id.m_index, ft), ());
     editor::tests_support::EditFeature(ft, std::forward<EditorFn>(fn));

--- a/ugc/storage.cpp
+++ b/ugc/storage.cpp
@@ -443,7 +443,7 @@ uint64_t Storage::UGCSizeAtIndex(size_t const indexPosition) const
 unique_ptr<FeatureType> Storage::GetFeature(FeatureID const & id) const
 {
   CHECK(id.IsValid(), ());
-  EditableFeaturesLoaderGuard guard(m_dataSource, id.m_mwmId);
+  FeaturesLoaderGuard guard(m_dataSource, id.m_mwmId);
   auto feature = guard.GetOriginalOrEditedFeatureByIndex(id.m_index);
   feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
   if (feature->GetFeatureType() == feature::EGeomType::GEOM_AREA)


### PR DESCRIPTION
Два коммита, лучше смотреть отдельно.
В первом FeaturesLoaderGuard вытащен из DataSource и удалены наследники FeaturesLoaderGuard -- ему в конструктор и так передается DataSource, создаем внутри гарда FeatureSource фабрикой из этого DataSource.

Во втором коммите в ReadMwm вместо включения нужной обработки элемента через enable_if сделала перегрузку ProcessElement (так лучше или хуже?).