### PR TITLE
[localads] Skip invalid localads features

### DIFF
--- a/map/local_ads_manager.cpp
+++ b/map/local_ads_manager.cpp
@@ -139,6 +139,9 @@ CampaignData ParseCampaign(std::vector<uint8_t> const & rawData, MwmSet::MwmId c
   for (local_ads::Campaign const & campaign : campaigns)
   {
     FeatureID featureId(mwmId, campaign.m_featureId);
+    if (!featureId.IsValid())
+      continue;
+
     if (campaign.m_priority == kHiddenFeaturePriority)
     {
       data.insert(std::make_pair(featureId, nullptr));


### PR DESCRIPTION
При запуске приложения у нас читаются закэшированные фичи localads. Для них мы вызываем `framework.GetFeatureByID()`, чтобы получить сами объекты из mwm. Но если mwm заменены или удалены, этот метод вызывает ассерт по `fid.IsValid()`. Мы его не замечали, потому что ассерт сваливает только десктопное приложение в дебаге.

Я добавил проверку валидности featureId пораньше.