### PR TITLE
[DNM][generator] popular places section fix

### DIFF
--- a/generator/popular_places_section_builder.cpp
+++ b/generator/popular_places_section_builder.cpp
@@ -96,17 +96,18 @@ bool BuildPopularPlacesMwmSection(std::string const & srcFilename, std::string c
   {
     ASSERT_EQUAL(content.size(), featureId, ());
 
-    auto const it = featureIdToOsmId.find(featureId);
-    CHECK(it != featureIdToOsmId.cend(),
-          ("FeatureID", featureId, "is not found in", osmToFeatureFilename));
-
     PopularityIndex rank = 0;
-    auto const placesIt = places.find(it->second);
-
-    if (placesIt != places.cend())
+    auto const it = featureIdToOsmId.find(featureId);
+    // Non-OSM features (coastlines, sponsored objects) are not used.
+    if (it != featureIdToOsmId.cend())
     {
-      popularPlaceFound = true;
-      rank = placesIt->second;
+      auto const placesIt = places.find(it->second);
+
+      if (placesIt != places.cend())
+      {
+        popularPlaceFound = true;
+        rank = placesIt->second;
+      }
     }
 
     content.emplace_back(rank);


### PR DESCRIPTION
Когда в мвмку прописываются объекты, которых нету в осме (границы, спонсорские объекты), то при сборке секции популярных объектов генератор крешится на CHECK.

В качестве быстрого решения убрал чек, сделал вместо него if. 
В будущем можно будет получить список типов, среди которых ищутся популярные места и использовать его для раннего отсечения. И добавить обратно чек.