### PR TITLE
[generator] Set mwm bounds rect to rect around region borders, not features which cross region border.

### DIFF
--- a/editor/editor_tests/osm_editor_test.hpp
+++ b/editor/editor_tests/osm_editor_test.hpp
@@ -69,7 +69,7 @@ private:
 
     auto const & info = id.GetInfo();
     if (info)
-      m_infoGetter.AddCountry(storage::CountryDef(name, info->m_limitRect));
+      m_infoGetter.AddCountry(storage::CountryDef(name, info->m_bordersRect));
 
     CHECK(id.IsAlive(), ());
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -1004,7 +1004,7 @@ FeatureID Editor::GenerateNewFeatureId(MwmSet::MwmId const & id) const
 bool Editor::CreatePoint(uint32_t type, m2::PointD const & mercator, MwmSet::MwmId const & id, EditableMapObject & outFeature)
 {
   ASSERT(id.IsAlive(), ("Please check that feature is created in valid MWM file before calling this method."));
-  if (!id.GetInfo()->m_limitRect.IsPointInside(mercator))
+  if (!id.GetInfo()->m_bordersRect.IsPointInside(mercator))
   {
     LOG(LERROR, ("Attempt to create a feature outside of the MWM's bounding box."));
     return false;

--- a/generator/borders_loader.cpp
+++ b/generator/borders_loader.cpp
@@ -196,4 +196,15 @@ void UnpackBorders(std::string const & baseDir, std::string const & targetDir)
   }
 }
 
+m2::RectD GetLimitRect(std::string const & baseDir, std::string const & country)
+{
+  std::string const bordersFile = my::JoinPath(baseDir, BORDERS_DIR, country + BORDERS_EXTENSION);
+  CHECK(Platform::IsFileExistsByFullPath(bordersFile), ("Cannot read borders file", bordersFile));
+  std::vector<m2::RegionD> borders;
+  CHECK(osm::LoadBorders(bordersFile, borders), ());
+  m2::RectD rect;
+  for (auto const & border : borders)
+    rect.Add(border.GetRect());
+  return rect;
+}
 } // namespace borders

--- a/generator/borders_loader.hpp
+++ b/generator/borders_loader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "geometry/rect2d.hpp"
 #include "geometry/region2d.hpp"
 #include "geometry/tree4d.hpp"
 
@@ -36,4 +37,5 @@ namespace borders
 
   void GeneratePackedBorders(std::string const & baseDir);
   void UnpackBorders(std::string const & baseDir, std::string const & targetDir);
+  m2::RectD GetLimitRect(std::string const & baseDir, std::string const & country);
 }

--- a/indexer/data_header.hpp
+++ b/indexer/data_header.hpp
@@ -25,6 +25,7 @@ namespace feature
   private:
     serial::GeometryCodingParams m_codingParams;
 
+    // Rect around region border. Features which cross region border may cross this rect.
     pair<int64_t, int64_t> m_bounds;
 
     buffer_vector<uint8_t, MAX_SCALES_COUNT> m_scales;

--- a/indexer/data_source.cpp
+++ b/indexer/data_source.cpp
@@ -158,7 +158,7 @@ unique_ptr<MwmInfo> DataSource::CreateInfo(platform::LocalCountryFile const & lo
     return nullptr;
 
   auto info = make_unique<MwmInfoEx>();
-  info->m_limitRect = h.GetBounds();
+  info->m_bordersRect = h.GetBounds();
 
   pair<int, int> const scaleR = h.GetScaleRange();
   info->m_minScale = static_cast<uint8_t>(scaleR.first);
@@ -201,7 +201,7 @@ void DataSource::ForEachInIntervals(ReaderCallback const & fn, covering::Coverin
   for (shared_ptr<MwmInfo> const & info : mwms)
   {
     if (info->m_minScale <= scale && scale <= info->m_maxScale &&
-        rect.IsIntersect(info->m_limitRect))
+        rect.IsIntersect(info->m_bordersRect))
     {
       MwmId const mwmId(info);
       switch (info->GetType())

--- a/indexer/indexer_tests/test_mwm_set.hpp
+++ b/indexer/indexer_tests/test_mwm_set.hpp
@@ -21,7 +21,7 @@ protected:
     int const n = localFile.GetCountryName()[0] - '0';
     unique_ptr<MwmInfo> info(new MwmInfo());
     info->m_maxScale = n;
-    info->m_limitRect = m2::RectD(0, 0, 1, 1);
+    info->m_bordersRect = m2::RectD(0, 0, 1, 1);
     info->m_version.SetFormat(version::Format::lastFormat);
     return info;
   }

--- a/indexer/mwm_set.hpp
+++ b/indexer/mwm_set.hpp
@@ -49,7 +49,8 @@ public:
   MwmInfo();
   virtual ~MwmInfo() = default;
 
-  m2::RectD m_limitRect;          ///< Limit rect of mwm.
+  m2::RectD m_bordersRect;        ///< Rect around region border. Features which cross region border may
+                                  ///< cross this rect.
   uint8_t m_minScale;             ///< Min zoom level of mwm.
   uint8_t m_maxScale;             ///< Max zoom level of mwm.
   version::MwmVersion m_version;  ///< Mwm file version.

--- a/map/benchmark_tool/features_loading.cpp
+++ b/map/benchmark_tool/features_loading.cpp
@@ -120,7 +120,7 @@ void RunFeaturesLoadingBenchmark(string const & file, pair<int, int> scaleRange,
   if (scaleRange.first > scaleRange.second)
     return;
 
-  RunBenchmark(src, r.first.GetInfo()->m_limitRect, scaleRange, res);
+  RunBenchmark(src, r.first.GetInfo()->m_bordersRect, scaleRange, res);
 }
 
 }

--- a/map/feature_vec_model.cpp
+++ b/map/feature_vec_model.cpp
@@ -57,7 +57,7 @@ pair<MwmSet::MwmId, MwmSet::RegResult> FeaturesFetcher::RegisterMap(
     {
       MwmSet::MwmId const & id = result.first;
       ASSERT(id.IsAlive(), ());
-      m_rect.Add(id.GetInfo()->m_limitRect);
+      m_rect.Add(id.GetInfo()->m_bordersRect);
     }
 
     return result;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -580,7 +580,7 @@ void Framework::OnCountryFileDownloaded(storage::TCountryId const & countryId, s
     auto p = m_model.RegisterMap(*localFile);
     MwmSet::MwmId const & id = p.first;
     if (id.IsAlive())
-      rect = id.GetInfo()->m_limitRect;
+      rect = id.GetInfo()->m_bordersRect;
   }
   m_trafficManager.Invalidate();
   m_transitManager.Invalidate();

--- a/map/map_tests/booking_filter_test.cpp
+++ b/map/map_tests/booking_filter_test.cpp
@@ -46,7 +46,7 @@ protected:
 
   void OnMwmBuilt(MwmInfo const & info) override
   {
-    m_infoGetter.AddCountry(storage::CountryDef(info.GetCountryName(), info.m_limitRect));
+    m_infoGetter.AddCountry(storage::CountryDef(info.GetCountryName(), info.m_bordersRect));
   }
 
 private:

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -45,7 +45,7 @@ private:
   {
     unique_ptr<MwmInfo> info(new MwmInfo());
     info->m_maxScale = 1;
-    info->m_limitRect = m2::RectD(0, 0, 1, 1);
+    info->m_bordersRect = m2::RectD(0, 0, 1, 1);
     info->m_version.SetFormat(version::Format::lastFormat);
     return info;
   }

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -284,7 +284,7 @@ struct KeyedMwmInfo
 {
   KeyedMwmInfo(shared_ptr<MwmInfo> const & info, m2::RectD const & pivot) : m_info(info)
   {
-    auto const & rect = m_info->m_limitRect;
+    auto const & rect = m_info->m_bordersRect;
     m_similarity = GetSimilarity(pivot, rect);
     m_distance = GetDistanceMeters(pivot.Center(), rect);
   }
@@ -325,9 +325,8 @@ size_t OrderCountries(m2::RectD const & pivot, vector<shared_ptr<MwmInfo>> & inf
   for (auto const & info : keyedInfos)
     infos.emplace_back(info.m_info);
 
-  auto intersects = [&](shared_ptr<MwmInfo> const & info) -> bool
-  {
-    return pivot.IsIntersect(info->m_limitRect);
+  auto intersects = [&](shared_ptr<MwmInfo> const & info) -> bool {
+    return pivot.IsIntersect(info->m_bordersRect);
   };
 
   auto const sep = stable_partition(infos.begin(), infos.end(), intersects);
@@ -427,10 +426,9 @@ void Geocoder::GoInViewport()
   vector<shared_ptr<MwmInfo>> infos;
   m_dataSource.GetMwmsInfo(infos);
 
-  my::EraseIf(infos, [this](shared_ptr<MwmInfo> const & info)
-              {
-                return !m_params.m_pivot.IsIntersect(info->m_limitRect);
-              });
+  my::EraseIf(infos, [this](shared_ptr<MwmInfo> const & info) {
+    return !m_params.m_pivot.IsIntersect(info->m_bordersRect);
+  });
 
   GoImpl(infos, true /* inViewport */);
 }

--- a/search/locality_finder.cpp
+++ b/search/locality_finder.cpp
@@ -286,12 +286,8 @@ void LocalityFinder::UpdateMaps()
 
     switch (info->GetType())
     {
-    case MwmInfo::WORLD:
-      m_worldId = id;
-      break;
-    case MwmInfo::COUNTRY:
-      m_maps.Add(id, info->m_limitRect);
-      break;
+    case MwmInfo::WORLD: m_worldId = id; break;
+    case MwmInfo::COUNTRY: m_maps.Add(id, info->m_bordersRect); break;
     case MwmInfo::COASTS: break;
     }
   }

--- a/search/nested_rects_cache.cpp
+++ b/search/nested_rects_cache.cpp
@@ -56,7 +56,7 @@ double NestedRectsCache::GetDistanceToFeatureMeters(FeatureID const & id) const
 
   if (auto const & info = id.m_mwmId.GetInfo())
   {
-    auto const & rect = info->m_limitRect;
+    auto const & rect = info->m_bordersRect;
     return max(MercatorBounds::DistanceOnEarth(rect.Center(), m_position),
                GetRadiusMeters(static_cast<RectScale>(scale)));
   }

--- a/search/search_tests/locality_finder_test.cpp
+++ b/search/search_tests/locality_finder_test.cpp
@@ -47,7 +47,7 @@ public:
       MwmSet::MwmId const & id = p.first;
       TEST(id.IsAlive(), ());
 
-      m_worldRect = id.GetInfo()->m_limitRect;
+      m_worldRect = id.GetInfo()->m_bordersRect;
       m_boundariesTable.Load();
     }
     catch (RootException const & ex)

--- a/search/search_tests_support/helpers.cpp
+++ b/search/search_tests_support/helpers.cpp
@@ -93,7 +93,7 @@ void SearchTest::OnMwmBuilt(MwmInfo const & info)
 {
   switch (info.GetType())
   {
-  case MwmInfo::COUNTRY: RegisterCountry(info.GetCountryName(), info.m_limitRect); break;
+  case MwmInfo::COUNTRY: RegisterCountry(info.GetCountryName(), info.m_bordersRect); break;
   case MwmInfo::WORLD: m_engine.LoadCitiesBoundaries(); break;
   case MwmInfo::COASTS: break;
   }

--- a/ugc/ugc_tests/storage_tests.cpp
+++ b/ugc/ugc_tests/storage_tests.cpp
@@ -133,7 +133,7 @@ private:
 
     auto const & info = id.GetInfo();
     if (info)
-      m_infoGetter.AddCountry(storage::CountryDef(kTestMwmName, info->m_limitRect));
+      m_infoGetter.AddCountry(storage::CountryDef(kTestMwmName, info->m_bordersRect));
 
     CHECK(id.IsAlive(), ());
     return id;


### PR DESCRIPTION
Записываю в bounds для mwm прямоугольник описанный вокруг границ соответствующего региона. Раньше был прямоугольник описанный вокруг всех фичей входящих в mwm, что приводило к тому, что если в mwm попало что-то типа relation описывающего границу соседнего государства или крупную магистраль в соседнем государстве границы слишком сильно раздувались. Это не предполагалось по месту использования данного поля.