### PR TITLE
Routing integration tests fix for maps 180705

### DIFF
--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -54,5 +54,10 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
   integration::TestCurrentStreetName(route, "Валовая улица");
   integration::TestNextStreetName(route, "Валовая улица");
 
+  MoveRoute(route, ms::LatLon(55.730912, 37.636191));
+
+  integration::TestCurrentStreetName(route, "Валовая улица");
+  integration::TestNextStreetName(route, "");
+
   integration::TestRouteLength(route, 3390.);
 }

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -52,7 +52,7 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
   MoveRoute(route, ms::LatLon(55.73034, 37.63099));
 
   integration::TestCurrentStreetName(route, "Валовая улица");
-  integration::TestNextStreetName(route, "");
+  integration::TestNextStreetName(route, "Валовая улица");
 
   integration::TestRouteLength(route, 3390.);
 }


### PR DESCRIPTION
После обновления до карт 2018.07.05 по сообщению @Zverik  сломался тест RussiaTulskayaToPaveletskayaStreetNamesTest.

Причина в том, что ввиду изменения геометрии Валовой улицы получился новый маневр:
2018.05.28
![image](https://user-images.githubusercontent.com/1768114/42492728-de18e2cc-8422-11e8-9f4e-cc303008ed3e.png)
![image](https://user-images.githubusercontent.com/1768114/42492740-e9df91aa-8422-11e8-83ef-867166c1e767.png)

2018.07.05
![image](https://user-images.githubusercontent.com/1768114/42492737-e33173be-8422-11e8-870d-1e599effc9e3.png)
![image](https://user-images.githubusercontent.com/1768114/42492745-ed74c178-8422-11e8-8752-8ff5ff026feb.png)

Соответственно название "следующей улицы" изменилось. Поправил.

@tatiana-yan @Zverik PTAL

