### PR TITLE
Transit scheme display cases

### DIFF
--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -456,6 +456,15 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
       break;
     }
 
+  case Message::ClearAllTransitSchemeData:
+    {
+      m_transitBuilder->Clear();
+      m_commutator->PostMessage(ThreadsCommutator::RenderThread,
+                                make_unique_dp<ClearAllTransitSchemeDataMessage>(),
+                                MessagePriority::Normal);
+      break;
+    }
+
   case Message::EnableTransitScheme:
     {
       ref_ptr<EnableTransitSchemeMessage> msg = message;

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -749,6 +749,13 @@ void DrapeEngine::ClearTransitSchemeCache(MwmSet::MwmId const & mwmId)
                                   MessagePriority::Normal);
 }
 
+void DrapeEngine::ClearAllTransitSchemeCache()
+{
+  m_threadCommutator->PostMessage(ThreadsCommutator::ResourceUploadThread,
+                                  make_unique_dp<ClearAllTransitSchemeDataMessage>(),
+                                  MessagePriority::Normal);
+}
+
 void DrapeEngine::UpdateTransitScheme(TransitDisplayInfos && transitDisplayInfos)
 {
   m_threadCommutator->PostMessage(ThreadsCommutator::ResourceUploadThread,

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -205,6 +205,7 @@ public:
   void EnableTransitScheme(bool enable);
   void UpdateTransitScheme(TransitDisplayInfos && transitDisplayInfos);
   void ClearTransitSchemeCache(MwmSet::MwmId const & mwmId);
+  void ClearAllTransitSchemeCache();
 
   void SetFontScaleFactor(double scaleFactor);
 

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -759,6 +759,10 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     {
       ref_ptr<EnableTransitSchemeMessage > msg = message;
       m_transitSchemeEnabled = msg->IsEnabled();
+#ifndef OMIM_OS_IPHONE_SIMULATOR
+      m_postprocessRenderer->SetEffectEnabled(PostprocessRenderer::Effect::Antialiasing,
+                                              msg->IsEnabled() ? true : m_isAntialiasingEnabled);
+#endif
       if (!msg->IsEnabled())
         m_transitSchemeRenderer->ClearGLDependentResources(make_ref(m_overlayTree));
       break;
@@ -855,6 +859,8 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
   case Message::SetPosteffectEnabled:
     {
       ref_ptr<SetPosteffectEnabledMessage> msg = message;
+      if (msg->GetEffect() == PostprocessRenderer::Effect::Antialiasing)
+        m_isAntialiasingEnabled = msg->IsEnabled();
 #ifndef OMIM_OS_IPHONE_SIMULATOR
       m_postprocessRenderer->SetEffectEnabled(msg->GetEffect(), msg->IsEnabled());
 #endif

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -771,6 +771,12 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       break;
     }
 
+  case Message::ClearAllTransitSchemeData:
+    {
+      m_transitSchemeRenderer->ClearGLDependentResources(make_ref(m_overlayTree));
+      break;
+  }
+
   case Message::EnableTraffic:
     {
       ref_ptr<EnableTrafficMessage> msg = message;
@@ -1278,7 +1284,7 @@ void FrontendRenderer::RenderScene(ScreenBase const & modelView, bool activeFram
       RenderSearchMarksLayer(modelView);
     }
 
-    if (!HasTransitRouteData())
+    if (!HasRouteData())
       RenderTransitSchemeLayer(modelView);
 
     m_drapeApiRenderer->Render(modelView, make_ref(m_gpuProgramManager), m_frameValues);
@@ -1369,9 +1375,14 @@ void FrontendRenderer::RenderNavigationOverlayLayer(ScreenBase const & modelView
   }
 }
 
-bool FrontendRenderer::HasTransitRouteData()
+bool FrontendRenderer::HasTransitRouteData() const
 {
   return m_routeRenderer->HasTransitData();
+}
+
+bool FrontendRenderer::HasRouteData() const
+{
+  return m_routeRenderer->HasData();
 }
 
 void FrontendRenderer::RenderTransitSchemeLayer(ScreenBase const & modelView)

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -171,7 +171,8 @@ private:
   void RenderSearchMarksLayer(ScreenBase const & modelView);
   void RenderTransitBackground();
 
-  bool HasTransitRouteData();
+  bool HasTransitRouteData() const;
+  bool HasRouteData() const;
 
   ScreenBase const & ProcessEvents(bool & modelViewChanged, bool & viewportChanged);
   void PrepareScene(ScreenBase const & modelView);

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -330,6 +330,7 @@ private:
   bool m_forceUpdateScene;
   bool m_forceUpdateUserMarks;
 
+  bool m_isAntialiasingEnabled = false;
   drape_ptr<PostprocessRenderer> m_postprocessRenderer;
 
   drape_ptr<ScenarioManager> m_scenarioManager;

--- a/drape_frontend/message.hpp
+++ b/drape_frontend/message.hpp
@@ -88,6 +88,7 @@ public:
     EnableTransitScheme,
     UpdateTransitScheme,
     ClearTransitSchemeData,
+    ClearAllTransitSchemeData,
     RegenerateTransitScheme,
     FlushTransitScheme,
     ShowDebugInfo,

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -1050,6 +1050,12 @@ private:
   MwmSet::MwmId m_mwmId;
 };
 
+class ClearAllTransitSchemeDataMessage : public Message
+{
+public:
+  Type GetType() const override { return Message::ClearAllTransitSchemeData; }
+};
+
 class UpdateTransitSchemeMessage : public Message
 {
 public:

--- a/drape_frontend/postprocess_renderer.cpp
+++ b/drape_frontend/postprocess_renderer.cpp
@@ -453,9 +453,23 @@ void PostprocessRenderer::OnFramebufferFallback()
 
 void PostprocessRenderer::OnChangedRouteFollowingMode(bool isRouteFollowingActive)
 {
+  if (m_isRouteFollowingActive == isRouteFollowingActive)
+    return;
+
   m_isRouteFollowingActive = isRouteFollowingActive;
-  m_isMainFramebufferRendered = false;
-  m_isSmaaFramebufferRendered = false;
+  if (m_isRouteFollowingActive)
+  {
+    if (m_width != 0 && m_height != 0)
+      UpdateFramebuffers(m_width, m_height);
+  }
+  else
+  {
+    m_isMainFramebufferRendered = false;
+    m_isSmaaFramebufferRendered = false;
+    m_edgesFramebuffer.reset();
+    m_blendingWeightFramebuffer.reset();
+    m_smaaFramebuffer.reset();
+  }
 }
 
 StencilWriterGuard::StencilWriterGuard(ref_ptr<PostprocessRenderer> renderer)

--- a/drape_frontend/route_renderer.cpp
+++ b/drape_frontend/route_renderer.cpp
@@ -737,4 +737,9 @@ bool RouteRenderer::HasTransitData() const
   }
   return false;
 }
+
+bool RouteRenderer::HasData() const
+{
+  return !m_subroutes.empty();
+}
 }  // namespace df

--- a/drape_frontend/route_renderer.hpp
+++ b/drape_frontend/route_renderer.hpp
@@ -90,6 +90,7 @@ public:
   void SetSubrouteVisibility(dp::DrapeID id, bool isVisible);
 
   bool HasTransitData() const;
+  bool HasData() const;
 
 private:
   void RenderSubroute(SubrouteInfo const & subrouteInfo, size_t subrouteDataIndex,

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -419,6 +419,7 @@ void RoutingManager::RemoveRoute(bool deactivateFollowing)
 
   if (deactivateFollowing)
   {
+    m_transitReadManager->BlockTransitSchemeMode(false /* isBlocked */);
     // Remove all subroutes.
     m_drapeEngine.SafeCall(&df::DrapeEngine::RemoveSubroute,
                            dp::DrapeID(), true /* deactivateFollowing */);
@@ -568,6 +569,8 @@ void RoutingManager::FollowRoute()
 {
   if (!m_routingSession.EnableFollowMode())
     return;
+
+  m_transitReadManager->BlockTransitSchemeMode(true /* isBlocked */);
 
   // Switching on the extrapolatior only for following mode in car and bicycle navigation.
   m_extrapolator.Enable(m_currentRouterType == RouterType::Vehicle ||
@@ -895,8 +898,10 @@ bool RoutingManager::DisableFollowMode()
 {
   bool const disabled = m_routingSession.DisableFollowMode();
   if (disabled)
+  {
+    m_transitReadManager->BlockTransitSchemeMode(false /* isBlocked */);
     m_drapeEngine.SafeCall(&df::DrapeEngine::DeactivateRouteFollowing);
-
+  }
   return disabled;
 }
 

--- a/map/transit/transit_reader.hpp
+++ b/map/transit/transit_reader.hpp
@@ -102,6 +102,7 @@ public:
   bool GetTransitDisplayInfo(TransitDisplayInfos & transitDisplayInfos);
 
   void EnableTransitSchemeMode(bool enable);
+  void BlockTransitSchemeMode(bool isBlocked);
   void UpdateViewport(ScreenBase const & screen);
   void OnMwmDeregistered(MwmSet::MwmId const & mwmId);
   void Invalidate();
@@ -145,5 +146,6 @@ private:
   std::map<MwmSet::MwmId, CacheEntry> m_mwmCache;
   size_t m_cacheSize = 0;
   bool m_isSchemeMode = false;
+  bool m_isSchemeModeBlocked = false;
   pair<ScreenBase, bool> m_currentModelView = {ScreenBase(), false /* initialized */};
 };


### PR DESCRIPTION
* Don't render transit schemes if there is a route. Clear transit cache if the following mode is enabled.
* Enable antialiasing when transit scheme is enabled.