### PR TITLE
[search] Fix search result display for long categories.

### DIFF
--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -143,11 +143,7 @@ uint32_t RankerResult::GetBestType(set<uint32_t> const * pPrefferedTypes) const
     }
   }
 
-  // Do type truncate (2-level is enough for search results) only for
-  // non-preffered types (types from categories leave original).
-  uint32_t type = m_types.GetBestType();
-  ftype::TruncValue(type, 2);
-  return type;
+  return m_types.GetBestType();
 }
 
 // RankerResult::RegionInfo ------------------------------------------------------------------------


### PR DESCRIPTION
Не обрезаем длинные типы, например railway-station-subway будем показывать как subway, а не как train station. В placepage категория получается так же, будет консистентно. 