### PR TITLE
[search] Add helper for fast DiscoveryButton search

### DIFF
--- a/search/utils.cpp
+++ b/search/utils.cpp
@@ -1,8 +1,14 @@
 #include "search/utils.hpp"
 
+#include "search/categories_cache.hpp"
+#include "search/features_filter.hpp"
+#include "search/geometry_cache.hpp"
+#include "search/mwm_context.hpp"
+
 #include "indexer/data_source.hpp"
 
 #include <cctype>
+#include <utility>
 
 using namespace std;
 
@@ -62,5 +68,38 @@ MwmSet::MwmHandle FindWorld(DataSource const & dataSource)
   vector<shared_ptr<MwmInfo>> infos;
   dataSource.GetMwmsInfo(infos);
   return FindWorld(dataSource, infos);
+}
+
+void ForEachOfTypesInRect(DataSource const & dataSource, set<uint32_t> const & types,
+                          m2::RectD const & pivot, FeatureIndexCallback const & fn)
+{
+  vector<shared_ptr<MwmInfo>> infos;
+  dataSource.GetMwmsInfo(infos);
+
+  CategoriesCache cache(types, {} /* cancellable */);
+  auto pivotRectsCache = PivotRectsCache(1 /* maxNumEntries */, {} /* cancellable */,
+                                         max(pivot.SizeX(), pivot.SizeY()) /* maxRadiusMeters */);
+
+  for (auto const & info : infos)
+  {
+    if (!pivot.IsIntersect(info->m_limitRect))
+      continue;
+
+    auto handle = dataSource.GetMwmHandleById(MwmSet::MwmId(info));
+    auto & value = *handle.GetValue<MwmValue>();
+    if (!value.HasSearchIndex())
+      continue;
+
+    MwmContext const mwmContext(move(handle));
+    auto features = cache.Get(mwmContext);
+
+    auto const pivotFeatures = pivotRectsCache.Get(mwmContext, pivot, scales::GetUpperScale());
+    ViewportFilter const filter(pivotFeatures, 0 /* threshold */);
+    features = filter.Filter(features);
+    MwmSet::MwmId mwmId(info);
+    features.ForEach([&fn, &mwmId](uint64_t bit) {
+      fn(FeatureID(mwmId, ::base::asserted_cast<uint32_t>(bit)));
+    });
+  }
 }
 }  // namespace search

--- a/search/utils.hpp
+++ b/search/utils.hpp
@@ -5,10 +5,13 @@
 #include "search/token_slice.hpp"
 
 #include "indexer/categories_holder.hpp"
+#include "indexer/feature_decl.hpp"
 #include "indexer/mwm_set.hpp"
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
 #include "indexer/trie.hpp"
+
+#include "geometry/rect2d.hpp"
 
 #include "base/levenshtein_dfa.hpp"
 #include "base/stl_helpers.hpp"
@@ -18,6 +21,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <set>
 #include <vector>
 
 class DataSource;
@@ -117,4 +121,9 @@ bool FillCategories(QuerySliceOnRawStrings<T> const & slice, Locales const & loc
 MwmSet::MwmHandle FindWorld(DataSource const & dataSource,
                             std::vector<std::shared_ptr<MwmInfo>> const & infos);
 MwmSet::MwmHandle FindWorld(DataSource const & dataSource);
+
+using FeatureIndexCallback = std::function<void(FeatureID const &)>;
+// Applies |fn| to each feature index of type from |types| in |rect|.
+void ForEachOfTypesInRect(DataSource const & dataSource, std::set<uint32_t> const & types,
+                          m2::RectD const & rect, FeatureIndexCallback const & fn);
 }  // namespace search


### PR DESCRIPTION
Функция для быстрого поиска по категориям для Дискавери.
Существующие режимы поиска для Дискавери не подходят, лепить франкенштейна типа "давайте поищем во вьюпорте, а потом обрежем и отранжируем как будто искали в списке" не хочется.
Пока переиспользование этой функции в Geocoder не предполагается, т.к. функция поиска по категориям из геокодера ветвится в зависимости от того, происходит ли поиск во вьюпорте, и переиспользовать можно три строчки, передавая при этом огромную кучу параметров. На мой взгляд такое переиспользование не упрощает код.