### PR TITLE
[routing] set osm::Id::Way to transitions

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -244,6 +244,7 @@ void CalcCrossMwmTransitions(
     auto const it = featureIdToOsmId.find(featureId);
     CHECK(it != featureIdToOsmId.end(), ("Can't find osm id for feature id", featureId));
     auto const osmId = it->second;
+    CHECK(osmId.GetType() == osm::Id::Type::Way, ());
 
     bool prevPointIn = m2::RegionsContain(borders, f.GetPoint(0));
 

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -119,8 +119,8 @@ public:
     void ReadCrossMwmId(uint8_t bits, BitReader<Source> & reader, osm::Id & osmId)
     {
       CHECK_LESS_OR_EQUAL(bits, connector::kOsmIdBits, ());
-      /* We lost data about transition type after compression (look at CalcBitsPerCrossMwmId method),
-       * but we used Way in routing, so suggest, that it is Way */
+      // We lost data about transition type after compression (look at CalcBitsPerCrossMwmId method),
+      // but we used Way in routing, so suggest, that it is Way.
       osmId = osm::Id::Way(reader.ReadAtMost64Bits(bits));
     }
 
@@ -441,8 +441,8 @@ private:
     for (auto const & transition : transitions)
       osmId = std::max(osmId, transition.GetCrossMwmId());
 
-    /* Note, that we lose osm::Id::Type bits here, remember about
-     * it in ReadCrossMwmId method. */
+    // Note, that we lose osm::Id::Type bits here, remember about
+    // it in ReadCrossMwmId method.
     return bits::NumUsedBits(osmId.GetOsmId());
   }
 

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -116,10 +116,12 @@ public:
     };
 
     template <class Source>
-    void ReadCrossMwmId(uint8_t bits, BitReader<Source> & reader, osm::Id & readed)
+    void ReadCrossMwmId(uint8_t bits, BitReader<Source> & reader, osm::Id & osmId)
     {
       CHECK_LESS_OR_EQUAL(bits, connector::kOsmIdBits, ());
-      readed = osm::Id(reader.ReadAtMost64Bits(bits));
+      /* We lost data about transition type after compression (look at CalcBitsPerCrossMwmId method),
+       * but we used Way in routing, so suggest, that it is Way */
+      osmId = osm::Id::Way(reader.ReadAtMost64Bits(bits));
     }
 
     template <class Source>
@@ -436,9 +438,11 @@ private:
       std::vector<Transition<osm::Id>> const & transitions)
   {
     osm::Id osmId(0ULL);
-    for (Transition<osm::Id> const & transition : transitions)
+    for (auto const & transition : transitions)
       osmId = std::max(osmId, transition.GetCrossMwmId());
 
+    /* Note, that we lose osm::Id::Type bits here, remember about
+     * it in ReadCrossMwmId method. */
     return bits::NumUsedBits(osmId.GetOsmId());
   }
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -167,7 +167,7 @@ private:
 
   /// \brief Deserializes connectors for an mwm with |numMwmId|.
   /// \param fn is a function implementing deserialization.
-  /// \note Each CrossMwmConnector contained in |m_connectors| may be deserizalize in two stages.
+  /// \note Each CrossMwmConnector contained in |m_connectors| may be deserialized in two stages.
   /// The first one is transition deserialization and the second is weight deserialization.
   /// Transition deserialization is much faster and used more often.
   template <typename Fn>

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -242,7 +242,7 @@ void TestSerialization(vector<CrossMwmConnectorSerializer::Transition<CrossMwmId
                       RouteWeight::FromCrossMwmWeight(kEdgesWeight)}});
 }
 
-void GetCrossMwmId(uint32_t i, osm::Id & id) { id = osm::Id(10 * i); }
+void GetCrossMwmId(uint32_t i, osm::Id & id) { id = osm::Id::Way(10 * i); }
 
 void GetCrossMwmId(uint32_t i, TransitId & id)
 {
@@ -331,25 +331,25 @@ namespace routing_test
 {
 UNIT_TEST(OneWayEnter)
 {
-  TestOneWayEnter(osm::Id(1ULL));
+  TestOneWayEnter(osm::Id::Way(1ULL));
   TestOneWayEnter(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
 UNIT_TEST(OneWayExit)
 {
-  TestOneWayExit(osm::Id(1ULL));
+  TestOneWayExit(osm::Id::Way(1ULL));
   TestOneWayExit(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
 UNIT_TEST(TwoWayEnter)
 {
-  TestTwoWayEnter(osm::Id(1ULL));
+  TestTwoWayEnter(osm::Id::Way(1ULL));
   TestTwoWayEnter(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
 UNIT_TEST(TwoWayExit)
 {
-  TestTwoWayExit(osm::Id(1ULL));
+  TestTwoWayExit(osm::Id::Way(1ULL));
   TestTwoWayExit(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
@@ -358,10 +358,10 @@ UNIT_TEST(Serialization)
   {
     vector<CrossMwmConnectorSerializer::Transition<osm::Id>> const transitions = {
         /* osmId featureId, segmentIdx, roadMask, oneWayMask, forwardIsEnter, backPoint, frontPoint */
-        {osm::Id(100ULL), 10, 1, kCarMask, kCarMask, true, m2::PointD(1.1, 1.2),
+        {osm::Id::Way(100ULL), 10, 1, kCarMask, kCarMask, true, m2::PointD(1.1, 1.2),
          m2::PointD(1.3, 1.4)},
-        {osm::Id(200ULL), 20, 2, kCarMask, 0, true, m2::PointD(2.1, 2.2), m2::PointD(2.3, 2.4)},
-        {osm::Id(300ULL), 30, 3, kPedestrianMask, kCarMask, true, m2::PointD(3.1, 3.2),
+        {osm::Id::Way(200ULL), 20, 2, kCarMask, 0, true, m2::PointD(2.1, 2.2), m2::PointD(2.3, 2.4)},
+        {osm::Id::Way(300ULL), 30, 3, kPedestrianMask, kCarMask, true, m2::PointD(3.1, 3.2),
          m2::PointD(3.3, 3.4)}};
     TestSerialization(transitions);
   }


### PR DESCRIPTION
Когда делаем serialize transition, то находим максимальное число бит, которое использует один transition. Для этого вызываем GetOsmId(), этот метод снимает биты, отвечающие за transition type. В результате мы не учитываем первые биты 64 битного числа и на данный момент в mvm пишем только 30 младших бит
  