### PR TITLE
Fixed ANR and black artefacts on Samsung Galaxy S

### DIFF
--- a/drape/color.hpp
+++ b/drape/color.hpp
@@ -57,10 +57,10 @@ Color Extract(uint32_t xrgb, uint8_t a);
 inline string DebugPrint(Color const & c)
 {
   ostringstream out;
-  out << "R = " << c.GetRed()
-      << "G = " << c.GetGreen()
-      << "B = " << c.GetBlue()
-      << "A = " << c.GetAlpha();
+  out << "[R = " << static_cast<uint32_t>(c.GetRed())
+      << ", G = " << static_cast<uint32_t>(c.GetGreen())
+      << ", B = " << static_cast<uint32_t>(c.GetBlue())
+      << ", A = " << static_cast<uint32_t>(c.GetAlpha()) << "]";
   return out.str();
 }
 

--- a/drape/glyph_generator.cpp
+++ b/drape/glyph_generator.cpp
@@ -19,17 +19,24 @@ GlyphGenerator::~GlyphGenerator()
 
   // Here we have to wait for active tasks completion,
   // because they capture 'this' pointer.
-  m_activeTasks.FinishAll();
-
-  std::lock_guard<std::mutex> lock(m_mutex);
-  for (auto & data : m_queue)
-    data.DestroyGlyph();
+  FinishGeneration();
 }
 
 bool GlyphGenerator::IsSuspended() const
 {
   std::lock_guard<std::mutex> lock(m_mutex);
   return m_glyphsCounter == 0;
+}
+
+void GlyphGenerator::FinishGeneration()
+{
+  m_activeTasks.FinishAll();
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+  for (auto & data : m_queue)
+    data.DestroyGlyph();
+
+  m_glyphsCounter = 0;
 }
 
 void GlyphGenerator::RegisterListener(ref_ptr<GlyphGenerator::Listener> listener)

--- a/drape/glyph_generator.hpp
+++ b/drape/glyph_generator.hpp
@@ -74,6 +74,8 @@ public:
   void GenerateGlyphs(ref_ptr<Listener> listener, GlyphGenerationDataArray && generationData);
   bool IsSuspended() const;
 
+  void FinishGeneration();
+
 private:
   void OnTaskFinished(ref_ptr<Listener> listener, std::shared_ptr<GenerateGlyphTask> const & task);
 

--- a/drape/hw_texture.cpp
+++ b/drape/hw_texture.cpp
@@ -176,8 +176,8 @@ void OpenGLHWTexture::Create(Params const & params, ref_ptr<void> data)
     GLFunctions::glBindBuffer(0, gl_const::GLPixelBufferWrite);
   }
 
-  GLFunctions::glFlush();
   GLFunctions::glBindTexture(0);
+  GLFunctions::glFlush();
 }
 
 void OpenGLHWTexture::UploadData(uint32_t x, uint32_t y, uint32_t width, uint32_t height,
@@ -206,6 +206,11 @@ void OpenGLHWTexture::UploadData(uint32_t x, uint32_t y, uint32_t width, uint32_
 drape_ptr<HWTexture> OpenGLHWTextureAllocator::CreateTexture()
 {
   return make_unique_dp<OpenGLHWTexture>();
+}
+
+void OpenGLHWTextureAllocator::Flush()
+{
+  GLFunctions::glFlush();
 }
 
 drape_ptr<HWTextureAllocator> CreateAllocator()

--- a/drape/hw_texture.hpp
+++ b/drape/hw_texture.hpp
@@ -92,7 +92,7 @@ class OpenGLHWTextureAllocator : public HWTextureAllocator
 {
 public:
   drape_ptr<HWTexture> CreateTexture() override;
-  void Flush() override {}
+  void Flush() override;
 };
 
 ref_ptr<HWTextureAllocator> GetDefaultAllocator();

--- a/drape/texture_manager.cpp
+++ b/drape/texture_manager.cpp
@@ -23,7 +23,6 @@
 
 namespace dp
 {
-
 uint32_t const kMaxTextureSize = 1024;
 uint32_t const kStippleTextureWidth = 512;
 uint32_t const kMinStippleTextureHeight = 64;
@@ -250,6 +249,9 @@ void TextureManager::Release()
   m_glyphTextures.clear();
 
   m_glyphManager.reset();
+
+  m_glyphGenerator->FinishGeneration();
+  m_nothingToUpload.test_and_set();
 }
 
 bool TextureManager::UpdateDynamicTextures()
@@ -547,6 +549,8 @@ void TextureManager::Init(Params const & params)
     else
       m_glyphGroups.push_back(GlyphGroup(start, end));
   });
+
+  m_nothingToUpload.clear();
 }
 
 void TextureManager::OnSwitchMapStyle()

--- a/drape/texture_manager.hpp
+++ b/drape/texture_manager.hpp
@@ -256,5 +256,4 @@ private:
   std::atomic_flag m_nothingToUpload;
   std::mutex m_calcGlyphsMutex;
 };
-
-} // namespace dp
+}  // namespace dp

--- a/drape_frontend/base_renderer.cpp
+++ b/drape_frontend/base_renderer.cpp
@@ -76,7 +76,7 @@ void BaseRenderer::SetRenderingEnabled(bool const isEnabled)
   };
 
   {
-    lock_guard<mutex> lock(m_completionHandlerMutex);
+    std::lock_guard<mutex> lock(m_completionHandlerMutex);
     m_renderingEnablingCompletionHandler = std::move(handler);
   }
 
@@ -132,6 +132,7 @@ void BaseRenderer::CheckRenderingEnabled()
 
     m_wasNotified = false;
 
+    bool needCreateContext = false;
     if (!m_selfThread.GetRoutine()->IsCancelled())
     {
       // here rendering is enabled again
@@ -140,8 +141,7 @@ void BaseRenderer::CheckRenderingEnabled()
       if (m_wasContextReset)
       {
         m_wasContextReset = false;
-        DisableMessageFiltering();
-        OnContextCreate();
+        needCreateContext = true;
       }
       else
       {
@@ -151,6 +151,12 @@ void BaseRenderer::CheckRenderingEnabled()
     // notify initiator-thread about rendering enabling
     // m_renderingEnablingCompletionHandler will be setup before awakening of this thread
     Notify();
+
+    if (needCreateContext)
+    {
+      DisableMessageFiltering();
+      OnContextCreate();
+    }
   }
 }
 


### PR DESCRIPTION
Причиной появления черных артефактов был конфликт OpenGL-контекста, создаваемого системой Android и наших контекстов в последнем обновлении Samsung Galaxy S. Проблема заключалась в том, что SetRenderingEnabled по сути полностью синхронный. Он останавливает поток, который его вызвал, пока не будут остановлены/возобновлены потоки рендеринга. Это правильно за одним исключением. OnCreateContext для каждого из потоков рендеринга вызывался до нотификации потока, который вызывал SetRenderingEnabled (UI-потока в нашем случае). Таким образом, UI-поток стоял и ждал, пока не будут инициализированы все графические ресурсы в обоих наших потоках, и при этом не мог освободить свой контекст и свои ресурсы. Потом, когда начинал освобождать, по всей видимости, корраптил чужую графическую память.
Однако OnCreateContext спроектирован так, что он может выполняться асинхронно одновременно в друг потоках. Так и происходит каждый раз на старте приложения (на старте нет SetRenderingEnabled). Таким образом, нотифицировав UI-поток, о том, что потоки рендеринга пробуждены, а затем запустив асинхронное выполнение OnCreateContext можно, во-первых, позволить UI-потоку освободить свой контекст и ресурсы вперед создания наших, а, значит, избежать порчи памяти, во-вторых, убрать ANR, когда UI-поток останавливается на 1-2 секунды, чтобы дождаться синхронного создания контекстов.
Кроме этого, вскрылась ошибка в TextureManager. При SetRenderingEnabled(false) не сбрасывался флаг о записи в текстуры, и не останавливалась генерация глифов. Крэшей не было только потому, что SetRenderingEnabled выполнялся синхронно (cначала BR, потом FR).  На старте не падало, потому как в конструкторе TextureManager есть сброс флага m_nothingToUpload.
P.S. Фикс проверен на нескольких Андроидах разной степени бюджетности. Проблем не обнаружено, но требуется потестировать.