### PR TITLE
[iOS] fix category info cell expanded state

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksVC.mm
+++ b/iphone/Maps/Bookmarks/BookmarksVC.mm
@@ -38,6 +38,8 @@ CGFloat const kPinDiameter = 18.0f;
   vector<Section> m_sections;
 }
 
+@property(nonatomic) BOOL infoExpanded;
+
 @end
 
 @implementation BookmarksVC
@@ -123,6 +125,7 @@ CGFloat const kPinDiameter = 18.0f;
     auto infoCell = (MWMCategoryInfoCell *)cell;
     auto const & categoryData = bm.GetCategoryData(m_categoryId);
     [infoCell updateWithCategoryData:categoryData delegate:self];
+    infoCell.expanded = self.infoExpanded;
     break;
   }
   case Section::Track:
@@ -284,6 +287,7 @@ CGFloat const kPinDiameter = 18.0f;
   [self.tableView beginUpdates];
   cell.expanded = YES;
   [self.tableView endUpdates];
+  self.infoExpanded = YES;
 }
 
 #pragma mark - MWMLocationObserver


### PR DESCRIPTION
There was a problem with info cell on bookmarks list screen. If you tap "more" on description cell, scroll to bottom and back to info cell, description appears collapsed.
This PR fixes the bug.