### PR TITLE
Fixed crash in set default framebuffer on some Android devices

### DIFF
--- a/android/jni/com/mapswithme/opengl/androidoglcontext.cpp
+++ b/android/jni/com/mapswithme/opengl/androidoglcontext.cpp
@@ -81,6 +81,8 @@ void AndroidOGLContext::setPresentAvailable(bool available)
 
 bool AndroidOGLContext::validate()
 {
+  if (!m_presentAvailable)
+    return false;
   return eglGetCurrentDisplay() != EGL_NO_DISPLAY &&
          eglGetCurrentSurface(EGL_DRAW) != EGL_NO_SURFACE &&
          eglGetCurrentContext() != EGL_NO_CONTEXT;

--- a/drape/framebuffer.hpp
+++ b/drape/framebuffer.hpp
@@ -7,7 +7,7 @@
 
 namespace dp
 {
-using FramebufferFallback = std::function<void()>;
+using FramebufferFallback = std::function<bool()>;
 
 class Framebuffer
 {

--- a/drape_frontend/postprocess_renderer.hpp
+++ b/drape_frontend/postprocess_renderer.hpp
@@ -47,11 +47,11 @@ public:
   void SetEffectEnabled(Effect effect, bool enabled);
   bool IsEffectEnabled(Effect effect) const;
 
-  void OnFramebufferFallback();
+  bool OnFramebufferFallback();
   void OnChangedRouteFollowingMode(bool isRouteFollowingActive);
 
   bool BeginFrame(bool activeFrame);
-  void EndFrame(ref_ptr<gpu::ProgramManager> gpuProgramManager);
+  bool EndFrame(ref_ptr<gpu::ProgramManager> gpuProgramManager);
 
   void EnableWritingToStencil() const;
   void DisableWritingToStencil() const;


### PR DESCRIPTION
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5b49d1d66007d59fcd82a531?time=last-ninety-days

По всей видимости на некоторых Андроидах нельзя делать не только present, но и glBindFramebuffer после DetachSurface