### PR TITLE
[generator] Speed up search address section building.

### DIFF
--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -131,7 +131,7 @@ void TestMwmBuilder::Finish()
 
   CHECK(indexer::BuildIndexFromDataFile(path, path), ("Can't build geometry index."));
 
-  CHECK(indexer::BuildSearchIndexFromDataFile(path, true /* forceRebuild */),
+  CHECK(indexer::BuildSearchIndexFromDataFile(1 /* threadsCount */, path, true /* forceRebuild */),
         ("Can't build search index."));
 
   if (m_type == feature::DataHeader::world)

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -382,7 +382,8 @@ int main(int argc, char ** argv)
     {
       LOG(LINFO, ("Generating search index for", datFile));
 
-      if (!indexer::BuildSearchIndexFromDataFile(datFile, true))
+      /// @todo Make threads count according to environment (single mwm build or planet build).
+      if (!indexer::BuildSearchIndexFromDataFile(8, datFile, true))
         LOG(LCRITICAL, ("Error generating search index."));
 
       LOG(LINFO, ("Generating rank table for", datFile));

--- a/generator/search_index_builder.hpp
+++ b/generator/search_index_builder.hpp
@@ -11,7 +11,7 @@ namespace indexer
 // An attempt to rewrite the search index of an old mwm may result in a future crash
 // when using search because this function does not update mwm's version. This results
 // in version mismatch when trying to read the index.
-bool BuildSearchIndexFromDataFile(std::string const & filename, bool forceRebuild = false);
+bool BuildSearchIndexFromDataFile(uint32_t threadsCount, std::string const & filename, bool forceRebuild = false);
 
 void BuildSearchIndex(FilesContainerR & container, Writer & indexWriter);
 }  // namespace indexer

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -26,8 +26,8 @@ size_t constexpr kMaxNumTriesToApproxAddress = 10;
 
 ReverseGeocoder::ReverseGeocoder(DataSource const & dataSource) : m_dataSource(dataSource) {}
 
-void ReverseGeocoder::GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
-                                       vector<Street> & streets) const
+void ReverseGeocoder::GetNearbyStreets(search::MwmContext & context, m2::PointD const & center,
+                                       vector<Street> & streets)
 {
   m2::RectD const rect = GetLookupRect(center, kLookupRadiusM);
 
@@ -48,11 +48,18 @@ void ReverseGeocoder::GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD cons
     streets.emplace_back(ft.GetID(), feature::GetMinDistanceMeters(ft, center), name);
   };
 
+  context.ForEachFeature(rect, addStreet);
+  sort(streets.begin(), streets.end(), my::LessBy(&Street::m_distanceMeters));
+}
+
+void ReverseGeocoder::GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
+                      vector<Street> & streets) const
+{
   MwmSet::MwmHandle mwmHandle = m_dataSource.GetMwmHandleById(id);
   if (mwmHandle.IsAlive())
   {
-    search::MwmContext(move(mwmHandle)).ForEachFeature(rect, addStreet);
-    sort(streets.begin(), streets.end(), my::LessBy(&Street::m_distanceMeters));
+    search::MwmContext context(move(mwmHandle));
+    GetNearbyStreets(context, center, streets);
   }
 }
 

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -26,6 +26,7 @@ size_t constexpr kMaxNumTriesToApproxAddress = 10;
 
 ReverseGeocoder::ReverseGeocoder(DataSource const & dataSource) : m_dataSource(dataSource) {}
 
+// static
 void ReverseGeocoder::GetNearbyStreets(search::MwmContext & context, m2::PointD const & center,
                                        vector<Street> & streets)
 {
@@ -53,7 +54,7 @@ void ReverseGeocoder::GetNearbyStreets(search::MwmContext & context, m2::PointD 
 }
 
 void ReverseGeocoder::GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
-                      vector<Street> & streets) const
+                                       vector<Street> & streets) const
 {
   MwmSet::MwmHandle mwmHandle = m_dataSource.GetMwmHandleById(id);
   if (mwmHandle.IsAlive())

--- a/search/reverse_geocoder.hpp
+++ b/search/reverse_geocoder.hpp
@@ -79,8 +79,7 @@ public:
   /// @return Sorted by distance streets vector for the specified MwmId.
   //@{
   static void GetNearbyStreets(search::MwmContext & context, m2::PointD const & center,
-                        vector<Street> & streets);
-
+                               vector<Street> & streets);
   void GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
                         vector<Street> & streets) const;
   void GetNearbyStreets(FeatureType & ft, vector<Street> & streets) const;

--- a/search/reverse_geocoder.hpp
+++ b/search/reverse_geocoder.hpp
@@ -16,6 +16,7 @@ class DataSource;
 
 namespace search
 {
+class MwmContext;
 
 class ReverseGeocoder
 {
@@ -77,6 +78,9 @@ public:
 
   /// @return Sorted by distance streets vector for the specified MwmId.
   //@{
+  static void GetNearbyStreets(search::MwmContext & context, m2::PointD const & center,
+                        vector<Street> & streets);
+
   void GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
                         vector<Street> & streets) const;
   void GetNearbyStreets(FeatureType & ft, vector<Street> & streets) const;

--- a/tools/unix/generate_mwm.sh
+++ b/tools/unix/generate_mwm.sh
@@ -66,7 +66,7 @@ GENERATOR_TOOL="${GENERATOR_TOOL-$SCRIPT_PATH/bin/generator_tool}"
 [ ! -x "${GENERATOR_TOOL-}" ] && fail "Cannot find generator tool"
 
 if [ "$(uname)" == "Darwin" ]; then
-  INTDIR=$(mktemp -d -t mwmgen)
+  INTDIR=$(mktemp -d -t mwmgen.XXXXXXXX)
 else
   INTDIR=$(mktemp -d)
 fi


### PR DESCRIPTION
Решил собрать mwm для Беларуси. Скачал bz2, запустил generate_wmw belarus.osm.bz2.
Ждал 3 часа и так не дождался окончания. Посмотрел, что происходит: BuildAddressTable работает бесконечно долго ... Когда генерируется планета, эти тормоза нивелируются тем что на сервере одновременно работает много тасков для **маленьких** mwm.

Там 2 затыка:
- MwmContext пересоздается при обработке каждого нового адреса (для Беларуси ~3 млн). Создание и удаление этого контекста - достаточно тягомотная операция.
- Процесс генерации идет в один поток, хотя он достаточно просто параллелится.

Собственно, этот реквест про это:
- Один раз создается пачка MwmContext по количеству потоков, которые переиспользуются на обработке каждого нового адреса.
- Цикл обработки адресов параллелится на потоки (константа uint32_t const threadsCount = 8).

В итоге для Беларуси адреса генерятся за 5 минут, вместо 3 часов бесцельного ожидания.