### PR TITLE
[iOS] fix crash on bookmarks category visibility change

### DIFF
--- a/iphone/Maps/Bookmarks/Catalog/DownloadedBookmarksViewController.swift
+++ b/iphone/Maps/Bookmarks/Catalog/DownloadedBookmarksViewController.swift
@@ -69,8 +69,9 @@ class DownloadedBookmarksViewController: MWMViewController {
 
   private func setCategoryVisible(_ visible: Bool, at index: Int) {
     dataSource.setCategory(visible: visible, at: index)
-    let categoriesHeader = tableView.headerView(forSection: 0) as! BMCCategoriesHeader
-    categoriesHeader.isShowAll = dataSource.allCategoriesHidden
+    if let categoriesHeader = tableView.headerView(forSection: 0) as? BMCCategoriesHeader {
+      categoriesHeader.isShowAll = dataSource.allCategoriesHidden
+    }
   }
 
   private func shareCategory(at index: Int) {

--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -289,8 +289,9 @@ extension BMCViewController: BMCPermissionsCellDelegate {
 extension BMCViewController: BMCCategoryCellDelegate {
   func visibilityAction(category: BMCCategory) {
     viewModel.updateCategoryVisibility(category: category)
-    let categoriesHeader = tableView.headerView(forSection: viewModel.sectionIndex(section: .categories)) as! BMCCategoriesHeader
-    categoriesHeader.isShowAll = viewModel.areAllCategoriesHidden()
+    if let categoriesHeader = tableView.headerView(forSection: viewModel.sectionIndex(section: .categories)) as? BMCCategoriesHeader {
+      categoriesHeader.isShowAll = viewModel.areAllCategoriesHidden()
+    }
   }
 
   func moreAction(category: BMCCategory, anchor: UIView) {


### PR DESCRIPTION
App crashes when a user tries to set visibility for bookmarks category and bookmarks' section header is not on screen