### PR TITLE
Fixing routing integration tests for map 18.08.04.

### DIFF
--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -61,10 +61,11 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
-  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 UNIT_TEST(RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest)
@@ -78,11 +79,9 @@ UNIT_TEST(RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
-  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnRight);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowSevTushinoParkBicycleOnePointOnewayRoadTurnTest)

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -52,7 +52,7 @@ UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)
   MoveRoute(route, ms::LatLon(55.73034, 37.63099));
 
   integration::TestCurrentStreetName(route, "Валовая улица");
-  integration::TestNextStreetName(route, "Валовая улица");
+  integration::TestNextStreetName(route, "");
 
   MoveRoute(route, ms::LatLon(55.730912, 37.636191));
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -946,8 +946,7 @@ UNIT_TEST(RussiaMoscowMinskia1TurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 UNIT_TEST(RussiaMoscowMinskia2TurnTest)
@@ -961,8 +960,9 @@ UNIT_TEST(RussiaMoscowMinskia2TurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 // This test on getting correct (far enough) outgoing turn point (result of method GetPointForTurn())


### PR DESCRIPTION
Привел routing_integration_tests в соответствие данным карты 2018.08.04. Все тесты сломались ввиду изменения данных за последние 2 месяца.

RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest
![image](https://user-images.githubusercontent.com/1768114/43900594-08fb2a80-9bee-11e8-9f02-4bee2ba67247.png)
Генерируемые маневры соответствуют геометрии маршрута.

RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest
![image](https://user-images.githubusercontent.com/1768114/43900669-38aa3280-9bee-11e8-9969-9279d8ad4dc2.png)
Генерируемые маневры соответствуют геометрии маршрута.

RussiaTulskayaToPaveletskayaStreetNamesTest
![image](https://user-images.githubusercontent.com/1768114/43900841-a2c14f00-9bee-11e8-87fd-eb887dcc787f.png)
Генерируемые названия соответствуют маршруту и карте.

RussiaMoscowMinskia1TurnTest
![image](https://user-images.githubusercontent.com/1768114/43900899-c018777c-9bee-11e8-95fa-15ef140f2c05.png)
Не появляется маневр двигайтесь прямо, который в данном случае и не нужен.

![image](https://user-images.githubusercontent.com/1768114/43901089-3c8c5daa-9bef-11e8-8972-e1a991645cc5.png)
![image](https://user-images.githubusercontent.com/1768114/43901114-50e600bc-9bef-11e8-895a-98258625576f.png)

Ввиду ошибки в карте генерируется 2 маневра. С первым все понятно. Поверните на право. Второй так же не обходим. https://www.openstreetmap.org/query?lat=55.74325&lon=37.48087#map=19/55.74304/37.48108
Поскольку согласно карте здесь 2 варианта движения. Нет relation:restriction.

@maksimandrianov @vmihaylenko PTAL

