### PR TITLE
[generator][relation:boundary] Adding as town boundary relation:boundary.

### DIFF
--- a/generator/translator_planet.cpp
+++ b/generator/translator_planet.cpp
@@ -102,7 +102,6 @@ void TranslatorPlanet::EmitElement(OsmElement * p)
   }
   case OsmElement::EntityType::Relation:
   {
-    // Check if this is our processable relation. Here we process only polygon relations.
     if (!p->HasTagValue("type", "multipolygon") && !p->HasTagValue("type", "boundary"))
       break;
 


### PR DESCRIPTION
Некоторое время назад в World.mwm появилась секция cities_boundaries, в которой хранятся границы городов. В нее попадают границы городов, которые обозначены на карте линейные объекты (way) с тагом place=city или place=town или как отношения (relation) (type=multipolygon) с тагом place=city или place=town.

Такой подход пропускает существенное кол-во границ городов. Например, в Белорусе сейчас нет ни одной границы города согласно World.mwm. Тоже самое в Прибалтике. Это можно увидеть, если воспользоваться визуализацией границ городов в десктоп приложении, добавленной в https://github.com/mapsme/omim/pull/9064.

Проблема в том, что согласно документации для обозначения сложных границ городов должен быть использован relation(type=boundary) (https://wiki.openstreetmap.org/wiki/Relation:boundary) relation:multipolygon так же допустим, но является устаревшим: "type=multipolygon is also used, but deprecated for boundary relations".

Данный PR добавляет в генератор World.mwm поддержку тага relation:boundary для границ городов. Предполагаю, что World.mwm подрастет после добавления этого тега на 2-3 сотни килобайт.

@maksimandrianov не мог бы ты собрать World.mwm для всего мира с данным PR и посчитать на сколько он подрос?

Для всей Беларуси World.mwm вырос на 4К и добавил полторы сотни границ городов.

После данного PR появятся многие не достающие границы городов. Однако, проблему с тем, что для Минска (и вероятно других крупных городов) не добавлена граница еще предстоит решить.

@maksimandrianov @ygorshenin @Zverik @mpimenov PTAL
