### PR TITLE
[DNM][routing] CityBoundariesChecker

### DIFF
--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -128,6 +128,8 @@ set(
   types_mapping.cpp
   types_mapping.hpp
   unique_index.hpp
+  utils.cpp
+  utils.hpp
 )
 
 set(

--- a/indexer/utils.cpp
+++ b/indexer/utils.cpp
@@ -1,0 +1,28 @@
+#include "indexer/utils.hpp"
+
+namespace indexer
+{
+using namespace std;
+
+MwmSet::MwmHandle FindWorld(DataSource const & dataSource,
+                            vector<shared_ptr<MwmInfo>> const & infos)
+{
+  MwmSet::MwmHandle handle;
+  for (auto const & info : infos)
+  {
+    if (info->GetType() == MwmInfo::WORLD)
+    {
+      handle = dataSource.GetMwmHandleById(MwmSet::MwmId(info));
+      break;
+    }
+  }
+  return handle;
+}
+
+MwmSet::MwmHandle FindWorld(DataSource const & dataSource)
+{
+  vector<shared_ptr<MwmInfo>> infos;
+  dataSource.GetMwmsInfo(infos);
+  return FindWorld(dataSource, infos);
+}
+}  // namespace indexer

--- a/indexer/utils.hpp
+++ b/indexer/utils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "indexer/data_source.hpp"
+#include "indexer/mwm_set.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace indexer
+{
+MwmSet::MwmHandle FindWorld(DataSource const & dataSource,
+                            std::vector<std::shared_ptr<MwmInfo>> const & infos);
+MwmSet::MwmHandle FindWorld(DataSource const & dataSource);
+}  // namespace indexer

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -16,6 +16,8 @@ set(
   base/routing_result.hpp
   bicycle_directions.cpp
   bicycle_directions.hpp
+  city_boundaries_checker.cpp
+  city_boundaries_checker.hpp
   checkpoint_predictor.cpp
   checkpoint_predictor.hpp
   checkpoints.cpp

--- a/routing/city_boundaries_checker.cpp
+++ b/routing/city_boundaries_checker.cpp
@@ -1,0 +1,84 @@
+#include "routing/city_boundaries_checker.hpp"
+
+#include "indexer/cities_boundaries_serdes.hpp"
+#include "indexer/mwm_set.hpp"
+#include "indexer/utils.hpp"
+
+#include "geometry/rect2d.hpp"
+
+#include "coding/file_container.hpp"
+#include "coding/reader.hpp"
+
+#include "base/assert.hpp"
+
+#include "defines.hpp"
+
+namespace routing
+{
+using namespace std;
+
+CityBoundariesChecker::CityBoundariesChecker(DataSource const & dataSource)
+{
+  CityBoundaries cityBoundaries;
+  if (!Load(dataSource, cityBoundaries))
+    return;
+
+  if (!cityBoundaries.empty())
+    FillTree(cityBoundaries);
+}
+
+bool CityBoundariesChecker::InCity(m2::PointD const & point) const
+{
+  if (m_tree.IsEmpty())
+    return false;
+
+  bool result = false;
+  m_tree.ForEachInRect(m2::RectD(point, point), [&](indexer::CityBoundary const & cityBoundary) {
+    if (result)
+      return;
+
+    result = cityBoundary.HasPoint(point);
+  });
+
+  return result;
+}
+
+bool CityBoundariesChecker::Load(DataSource const & dataSource, CityBoundaries & cityBoundaries)
+{
+  auto handle = indexer::FindWorld(dataSource);
+  if (!handle.IsAlive())
+  {
+    LOG(LWARNING, ("Can't find World map file."));
+    return false;
+  }
+
+  auto const & mwmValue = *handle.GetValue<MwmValue>();
+
+  if (!mwmValue.m_cont.IsExist(CITIES_BOUNDARIES_FILE_TAG))
+    return false; // World.mwm before cities_boundaries section.
+
+  try
+  {
+    auto reader = mwmValue.m_cont.GetReader(CITIES_BOUNDARIES_FILE_TAG);
+    CHECK(reader.GetPtr() != nullptr, ());
+    ReaderSource<ReaderPtr<ModelReader>> source(reader);
+    double precision;
+    indexer::CitiesBoundariesSerDes::Deserialize(source, cityBoundaries, precision);
+    return true;
+  }
+  catch (Reader::Exception const & e)
+  {
+    LOG(LERROR, ("Can't read cities boundaries table from the world map:", e.Msg()));
+    return false;
+  }
+}
+
+void CityBoundariesChecker::FillTree(CityBoundaries const & cityBoundaries)
+{
+  for (auto const & cbv : cityBoundaries)
+  {
+    for (auto const & cb : cbv)
+      m_tree.Add(cb,  m2::RectD(cb.m_bbox.Min(), cb.m_bbox.Max()));
+  }
+}
+}  // namespace routing

--- a/routing/city_boundaries_checker.hpp
+++ b/routing/city_boundaries_checker.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "indexer/city_boundary.hpp"
+#include "indexer/data_source.hpp"
+
+#include "geometry/point2d.hpp"
+#include "geometry/tree4d.hpp"
+
+#include <vector>
+
+namespace routing
+{
+/// \brief Loading city and town boundaries based on cities_boundaries section of World.mwm
+/// and checking if a point inside city or town.
+class CityBoundariesChecker
+{
+  using CityBoundaries = std::vector<std::vector<indexer::CityBoundary>>;
+public:
+  explicit CityBoundariesChecker(DataSource const & dataSource);
+
+  /// \returns true if |point| is inside a city or town according to cities_boundaries section
+  /// of World.mwm and false otherwise.
+  bool InCity(m2::PointD const & point) const;
+
+  /// \returns number of convex polygons of city boundaries.
+  size_t GetSizeForTesting() const { return m_tree.GetSize(); }
+
+private:
+  bool Load(DataSource const & dataSource, CityBoundaries & cityBoundaries);
+  void FillTree(CityBoundaries const & cityBoundaries);
+
+  m4::Tree<indexer::CityBoundary> m_tree;
+};
+}  // namespace routing

--- a/routing/routing_benchmarks/CMakeLists.txt
+++ b/routing/routing_benchmarks/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
   ../routing_integration_tests/routing_test_tools.cpp
   ../routing_integration_tests/routing_test_tools.hpp
   bicycle_routing_tests.cpp
+  city_boundaries_checker_tests.cpp
   helpers.cpp
   helpers.hpp
   pedestrian_routing_tests.cpp

--- a/routing/routing_benchmarks/city_boundaries_checker_tests.cpp
+++ b/routing/routing_benchmarks/city_boundaries_checker_tests.cpp
@@ -1,0 +1,125 @@
+#include "testing/testing.hpp"
+
+#include "routing/city_boundaries_checker.hpp"
+
+#include "indexer/data_source.hpp"
+
+#include "geometry/latlon.hpp"
+#include "geometry/mercator.hpp"
+
+#include "platform/local_country_file.hpp"
+#include "platform/local_country_file_utils.hpp"
+
+#include "base/logging.hpp"
+#include "base/timer.hpp"
+
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace
+{
+using namespace platform;
+using namespace std;
+
+FrozenDataSource & RegisterWorldMwm(FrozenDataSource & dataSource)
+{
+  vector<LocalCountryFile> localFiles;
+  FindAllLocalMapsAndCleanup(numeric_limits<int64_t>::max(), localFiles);
+
+  LocalCountryFile world;
+  for (auto const & lcf : localFiles)
+  {
+    if (lcf.GetCountryName() == "World")
+    {
+      world = lcf;
+      break;
+    }
+  }
+  CHECK_NOT_EQUAL(world.GetCountryName(), string(), ());
+
+  auto const result = dataSource.RegisterMap(world);
+  CHECK_EQUAL(result.second, MwmSet::RegResult::Success, ());
+  return dataSource;
+}
+
+class CityBoundariesCheckerTest
+{
+public:
+  CityBoundariesCheckerTest() : m_checker(RegisterWorldMwm(m_dataSource)) {}
+
+protected:
+  FrozenDataSource m_dataSource;
+  routing::CityBoundariesChecker m_checker;
+};
+
+UNIT_CLASS_TEST(CityBoundariesCheckerTest, Smoke)
+{
+  LOG(LINFO, ("World.mwm contains", m_checker.GetSizeForTesting(), "city boundaries."));
+  TEST_GREATER(m_checker.GetSizeForTesting(), 0, ());
+}
+
+// Test on CityBoundariesChecker::InCity() method.
+UNIT_CLASS_TEST(CityBoundariesCheckerTest, InCity)
+{
+  // Point in Kolodischi (Belarus)
+  TEST(m_checker.InCity(MercatorBounds::FromLatLon(53.94420, 27.77752)), ());
+
+  // Point in two intersected city boundaries Borovliani and Lesnoy.
+  TEST(m_checker.InCity(MercatorBounds::FromLatLon(54.00500, 27.68456)), ());
+
+  // Point in Zvenigorod (Russia).
+  TEST(m_checker.InCity(MercatorBounds::FromLatLon(55.72899, 36.85690)), ());
+
+  // Point in Yauzskoi reservoir.
+  TEST(!m_checker.InCity(MercatorBounds::FromLatLon(55.8838, 35.0399)), ());
+}
+
+UNIT_TEST(CityBoundariesCheckerTest_Benchmark)
+{
+  FrozenDataSource dataSource;
+  RegisterWorldMwm(dataSource);
+
+  {
+    my::Timer timer;
+    size_t constexpr ctorCalls = 10;
+    for (size_t i = 0; i < ctorCalls; ++i)
+    {
+      routing::CityBoundariesChecker checker(dataSource);
+      CHECK_GREATER(checker.GetSizeForTesting(), 0, ());
+    }
+    LOG(LINFO, (ctorCalls, "constructions of CityBoundariesChecker took", timer
+        .ElapsedSeconds(), "seconds."));
+  }
+
+  routing::CityBoundariesChecker checker(dataSource);
+  // A rect on the land with significant amount of city boundaries.
+  ms::LatLon const northWest(56.7970, 26.2602);
+  ms::LatLon const southEast(50.3718, 43.5256);
+  double const deltaLat = northWest.lat - southEast.lat;
+  double const deltaLon = southEast.lon - northWest.lon;
+
+  CHECK_GREATER(deltaLat, 0.0, ());
+  CHECK_GREATER(deltaLon, 0.0, ());
+
+  mt19937 gen;
+  uniform_real_distribution<double> dist(0.0, 1.0);
+
+  size_t inCityCounter = 0;
+  size_t outCityCounter = 0;
+  my::Timer timer;
+  size_t constexpr inCityCalls = 1000000;
+  for(size_t i = 0; i < inCityCalls; ++i)
+  {
+    ms::LatLon const randomLatLon(southEast.lat + deltaLat * dist(gen),
+                                  northWest.lon + deltaLon * dist(gen));
+    if (checker.InCity(MercatorBounds::FromLatLon(randomLatLon)))
+      ++inCityCounter;
+    else
+      ++outCityCounter;
+  }
+  LOG(LINFO,
+      (inCityCalls, "calls of CityBoundariesChecker::InCity() method takes", timer.ElapsedSeconds(),
+       "seconds.", inCityCounter, "points were in city and", outCityCounter, "were out of city."));
+}
+}  // namespace

--- a/search/cities_boundaries_table.cpp
+++ b/search/cities_boundaries_table.cpp
@@ -3,10 +3,10 @@
 #include "search/categories_cache.hpp"
 #include "search/localities_source.hpp"
 #include "search/mwm_context.hpp"
-#include "search/utils.hpp"
 
 #include "indexer/cities_boundaries_serdes.hpp"
 #include "indexer/mwm_set.hpp"
+#include "indexer/utils.hpp"
 
 #include "coding/reader.hpp"
 
@@ -32,7 +32,7 @@ bool CitiesBoundariesTable::Boundaries::HasPoint(m2::PointD const & p) const
 // CitiesBoundariesTable ---------------------------------------------------------------------------
 bool CitiesBoundariesTable::Load()
 {
-  auto handle = FindWorld(m_dataSource);
+  auto handle = indexer::FindWorld(m_dataSource);
   if (!handle.IsAlive())
   {
     LOG(LWARNING, ("Can't find World map file."));

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -22,6 +22,7 @@
 #include "indexer/rank_table.hpp"
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
+#include "indexer/utils.hpp"
 
 #include "storage/country_info_getter.hpp"
 
@@ -463,7 +464,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> & infos, bool inViewport)
     m_cities.clear();
     for (auto & regions : m_regions)
       regions.clear();
-    MwmSet::MwmHandle handle = FindWorld(m_dataSource, infos);
+    MwmSet::MwmHandle handle = indexer::FindWorld(m_dataSource, infos);
     if (handle.IsAlive())
     {
       auto & value = *handle.GetValue<MwmValue>();

--- a/search/utils.cpp
+++ b/search/utils.cpp
@@ -6,6 +6,7 @@
 #include "search/mwm_context.hpp"
 
 #include "indexer/data_source.hpp"
+#include "indexer/mwm_set.hpp"
 
 #include "base/cancellable.hpp"
 
@@ -68,28 +69,6 @@ vector<uint32_t> GetCategoryTypes(string const & name, string const & locale,
 
   my::SortUnique(types);
   return types;
-}
-
-MwmSet::MwmHandle FindWorld(DataSource const & dataSource,
-                            vector<shared_ptr<MwmInfo>> const & infos)
-{
-  MwmSet::MwmHandle handle;
-  for (auto const & info : infos)
-  {
-    if (info->GetType() == MwmInfo::WORLD)
-    {
-      handle = dataSource.GetMwmHandleById(MwmSet::MwmId(info));
-      break;
-    }
-  }
-  return handle;
-}
-
-MwmSet::MwmHandle FindWorld(DataSource const & dataSource)
-{
-  vector<shared_ptr<MwmInfo>> infos;
-  dataSource.GetMwmsInfo(infos);
-  return FindWorld(dataSource, infos);
 }
 
 void ForEachOfTypesInRect(DataSource const & dataSource, vector<uint32_t> const & types,

--- a/search/utils.hpp
+++ b/search/utils.hpp
@@ -6,7 +6,6 @@
 
 #include "indexer/categories_holder.hpp"
 #include "indexer/feature_decl.hpp"
-#include "indexer/mwm_set.hpp"
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
 #include "indexer/trie.hpp"
@@ -20,7 +19,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <vector>
 
 class DataSource;
@@ -121,10 +119,6 @@ bool FillCategories(QuerySliceOnRawStrings<T> const & slice, Locales const & loc
 // like "Hotel" returns all subcategories types.
 std::vector<uint32_t> GetCategoryTypes(std::string const & name, std::string const & locale,
                                        CategoriesHolder const & categories);
-
-MwmSet::MwmHandle FindWorld(DataSource const & dataSource,
-                            std::vector<std::shared_ptr<MwmInfo>> const & infos);
-MwmSet::MwmHandle FindWorld(DataSource const & dataSource);
 
 using FeatureIndexCallback = std::function<void(FeatureID const &)>;
 // Applies |fn| to each feature index of type from |types| in |rect|.

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		456E1B1B1F90E5B7009C32E1 /* city_boundary.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B171F90E5B7009C32E1 /* city_boundary.hpp */; };
 		45C108BD1E9D0067000FE1F6 /* libicu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45C108BC1E9D0067000FE1F6 /* libicu.a */; };
 		45C108BF1E9D008D000FE1F6 /* librouting_common.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45C108BE1E9D008D000FE1F6 /* librouting_common.a */; };
+		56829A3B212EA73B00A09A28 /* utils.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56829A39212EA73B00A09A28 /* utils.hpp */; };
+		56829A3C212EA73B00A09A28 /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56829A3A212EA73B00A09A28 /* utils.cpp */; };
 		56C74C1C1C749E4700B71B9F /* categories_holder_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C74C121C749E4700B71B9F /* categories_holder_loader.cpp */; };
 		56C74C1D1C749E4700B71B9F /* categories_holder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C74C131C749E4700B71B9F /* categories_holder.cpp */; };
 		56C74C1E1C749E4700B71B9F /* categories_holder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C74C141C749E4700B71B9F /* categories_holder.hpp */; };
@@ -299,6 +301,8 @@
 		456E1B171F90E5B7009C32E1 /* city_boundary.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = city_boundary.hpp; sourceTree = "<group>"; };
 		45C108BC1E9D0067000FE1F6 /* libicu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libicu.a; path = "/Users/r.kuznetsov/Dev/Projects/omim/xcode/icu/../../../omim-build/xcode/Debug/libicu.a"; sourceTree = "<absolute>"; };
 		45C108BE1E9D008D000FE1F6 /* librouting_common.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = librouting_common.a; path = "/Users/r.kuznetsov/Dev/Projects/omim/xcode/routing_common/../../../omim-build/xcode/Debug/librouting_common.a"; sourceTree = "<absolute>"; };
+		56829A39212EA73B00A09A28 /* utils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = utils.hpp; sourceTree = "<group>"; };
+		56829A3A212EA73B00A09A28 /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cpp; sourceTree = "<group>"; };
 		56C74C121C749E4700B71B9F /* categories_holder_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = categories_holder_loader.cpp; sourceTree = "<group>"; };
 		56C74C131C749E4700B71B9F /* categories_holder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = categories_holder.cpp; sourceTree = "<group>"; };
 		56C74C141C749E4700B71B9F /* categories_holder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = categories_holder.hpp; sourceTree = "<group>"; };
@@ -620,6 +624,8 @@
 		6753409C1A3F53CB00A0A8C3 /* indexer */ = {
 			isa = PBXGroup;
 			children = (
+				56829A3A212EA73B00A09A28 /* utils.cpp */,
+				56829A39212EA73B00A09A28 /* utils.hpp */,
 				3D12E3D52111B4BD0015A9A9 /* popularity_loader.cpp */,
 				3D12E3D62111B4BD0015A9A9 /* popularity_loader.hpp */,
 				34664CEE1D49FEC1003D7096 /* altitude_loader.cpp */,
@@ -780,7 +786,7 @@
 				34664CF51D49FEC1003D7096 /* feature_altitude.hpp in Headers */,
 				675341241A3F540F00A0A8C3 /* feature_visibility.hpp in Headers */,
 				6753411D1A3F540F00A0A8C3 /* shared_load_info.hpp in Headers */,
-				56C74C231C749E4700B71B9F /* shared_load_info.hpp in Headers */,
+				56C74C231C749E4700B71B9F /* search_delimiters.hpp in Headers */,
 				675341131A3F540F00A0A8C3 /* feature_algo.hpp in Headers */,
 				40009064201F5CB000963E18 /* locality_index_builder.hpp in Headers */,
 				6726C1D21A49DAAC005EEA39 /* feature_meta.hpp in Headers */,
@@ -821,6 +827,7 @@
 				347F337C1C454242009758CC /* rank_table.hpp in Headers */,
 				F61F83071E4B187500B37B7A /* road_shields_parser.hpp in Headers */,
 				347F33801C454242009758CC /* trie_reader.hpp in Headers */,
+				56829A3B212EA73B00A09A28 /* utils.hpp in Headers */,
 				675341191A3F540F00A0A8C3 /* feature_decl.hpp in Headers */,
 				674125141B4C02F100A3E828 /* map_style_reader.hpp in Headers */,
 				675341221A3F540F00A0A8C3 /* feature_utils.hpp in Headers */,
@@ -1039,6 +1046,7 @@
 				6758AED11BB4413000C26E27 /* drules_selector_parser.cpp in Sources */,
 				E906DE3B1CF44934004C4F5E /* postcodes_matcher.cpp in Sources */,
 				406B37F7207FBAC7000F3648 /* borders_test.cpp in Sources */,
+				56829A3C212EA73B00A09A28 /* utils.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		567E9F811F5853370064CB96 /* libtraffic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 567E9F801F5853370064CB96 /* libtraffic.a */; };
 		568194751F03A32400450EC3 /* road_access_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194731F03A32400450EC3 /* road_access_test.cpp */; };
 		568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194741F03A32400450EC3 /* routing_helpers_tests.cpp */; };
+		56829A3F212EA7A500A09A28 /* city_boundaries_checker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56829A3D212EA7A500A09A28 /* city_boundaries_checker.cpp */; };
+		56829A40212EA7A500A09A28 /* city_boundaries_checker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56829A3E212EA7A500A09A28 /* city_boundaries_checker.hpp */; };
 		5694CECA1EBA25F7004576D3 /* road_access_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */; };
 		5694CECB1EBA25F7004576D3 /* road_access_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5694CEC61EBA25F7004576D3 /* road_access_serialization.hpp */; };
 		5694CECC1EBA25F7004576D3 /* road_access.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5694CEC71EBA25F7004576D3 /* road_access.cpp */; };
@@ -380,6 +382,8 @@
 		567E9F801F5853370064CB96 /* libtraffic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtraffic.a; path = ../traffic/build/Debug/libtraffic.a; sourceTree = "<group>"; };
 		568194731F03A32400450EC3 /* road_access_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access_test.cpp; sourceTree = "<group>"; };
 		568194741F03A32400450EC3 /* routing_helpers_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers_tests.cpp; sourceTree = "<group>"; };
+		56829A3D212EA7A500A09A28 /* city_boundaries_checker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = city_boundaries_checker.cpp; sourceTree = "<group>"; };
+		56829A3E212EA7A500A09A28 /* city_boundaries_checker.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = city_boundaries_checker.hpp; sourceTree = "<group>"; };
 		5694CEC51EBA25F7004576D3 /* road_access_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access_serialization.cpp; sourceTree = "<group>"; };
 		5694CEC61EBA25F7004576D3 /* road_access_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_access_serialization.hpp; sourceTree = "<group>"; };
 		5694CEC71EBA25F7004576D3 /* road_access.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access.cpp; sourceTree = "<group>"; };
@@ -774,6 +778,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				56829A3D212EA7A500A09A28 /* city_boundaries_checker.cpp */,
+				56829A3E212EA7A500A09A28 /* city_boundaries_checker.hpp */,
 				562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */,
 				56FA20461FBF23A90045DE78 /* cross_mwm_ids.hpp */,
 				40BEC0801F99FFD600E06CA4 /* transit_info.hpp */,
@@ -962,6 +968,7 @@
 				0C5FEC6A1DDE193F0017688C /* road_index.hpp in Headers */,
 				674F9BCD1B0A580E00704FFA /* features_road_graph.hpp in Headers */,
 				40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */,
+				56829A40212EA7A500A09A28 /* city_boundaries_checker.hpp in Headers */,
 				670EE5741B664796001E8064 /* pedestrian_directions.hpp in Headers */,
 				5694CECB1EBA25F7004576D3 /* road_access_serialization.hpp in Headers */,
 				0C08AA371DF8324D004195DD /* vehicle_mask.hpp in Headers */,
@@ -1212,6 +1219,7 @@
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
 				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
+				56829A3F212EA7A500A09A28 /* city_boundaries_checker.cpp in Sources */,
 				0C5F5D201E798B0400307B98 /* cross_mwm_connector_serialization.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
 				0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */,


### PR DESCRIPTION
Это первая версия routing::CityBoundariesChecker и benchmark тесты на нее.

Эта реализация обеспечивает не плохое время определение находимся мы городе или нет (1 млн вызовов на 3 секунды на одном ядре на десктоп). Но у нее есть проблема - долгая инициализация. На десктом на заполнение ее данными (30К выпуклых прямоугольников CityBoundary) уходит 140ms на деск топ. Кроме того, класс CityBoundary занимает около 160 байт. Наличие 30К таких классов требует 5MB памяти, что на мой взгляд приемлемо.

Сфокусироваться на времени инициализации и работы класса CityBoundariesChecker и провести замеры на девайсах. Одина из идей: CityBoundariesChecker::m_tree сейчас имеет вид: m4::Tree<indexer::CityBoundary>. Попробую сделать m4::Tree<uint32_t> и рядом разместить vector<indexer::CityBoundary>.

Идея CityBoundariesChecker в том, что нужно хранить прямоугольники и отвечать очень быстро (при посещении вершины графа дорог) на вопрос, попали в какой-нибудь прямоугольник или нет. Сейчас прямоугольников 30К. Их кол-во будет расти, вероятно, кратно.

@rokuz, @mpimenov, @tatiana-yan PTAL

-----

Benchmark тесты показали не приемлемость подхода с переиспользованием секции cities_boundaries из World.mwm в роутнге. Данный PR будет закрыт. Будет подготовлен другой PR с секцией для хранения данных, о том, принадлежат ли фичи городу или нет.