### PR TITLE
[search] Move CitiesBoundariesTable load to engine

### DIFF
--- a/search/engine.hpp
+++ b/search/engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "search/bookmarks/processor.hpp"
+#include "search/cities_boundaries_table.hpp"
 #include "search/result.hpp"
 #include "search/search_params.hpp"
 #include "search/suggest.hpp"
@@ -161,6 +162,8 @@ private:
 
   void DoSearch(SearchParams const & params, std::shared_ptr<ProcessorHandle> handle,
                 Processor & processor);
+
+  CitiesBoundariesTable m_citiesBoundaries;
 
   std::vector<Suggest> m_suggests;
 

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -142,13 +142,14 @@ double const Processor::kMinViewportRadiusM = 5.0 * 1000;
 double const Processor::kMaxViewportRadiusM = 50.0 * 1000;
 
 Processor::Processor(DataSource const & dataSource, CategoriesHolder const & categories,
+                     CitiesBoundariesTable const & citiesBoundaries,
                      vector<Suggest> const & suggests,
                      storage::CountryInfoGetter const & infoGetter)
   : m_categories(categories)
   , m_infoGetter(infoGetter)
   , m_position(0, 0)
   , m_villagesCache(static_cast<::base::Cancellable const &>(*this))
-  , m_citiesBoundaries(dataSource)
+  , m_citiesBoundaries(citiesBoundaries)
   , m_keywordsScorer(LanguageTier::LANGUAGE_TIER_COUNT)
   , m_ranker(dataSource, m_citiesBoundaries, infoGetter, m_keywordsScorer, m_emitter, categories,
              suggests, m_villagesCache, static_cast<::base::Cancellable const &>(*this))
@@ -309,14 +310,6 @@ m2::RectD const & Processor::GetViewport() const
 {
   ASSERT(m_viewport.IsValid(), ());
   return m_viewport;
-}
-
-void Processor::LoadCitiesBoundaries()
-{
-  if (m_citiesBoundaries.Load())
-    LOG(LINFO, ("Loaded cities boundaries"));
-  else
-    LOG(LWARNING, ("Can't load cities boundaries"));
 }
 
 void Processor::LoadCountriesTree() { m_ranker.LoadCountriesTree(); }

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -63,7 +63,8 @@ public:
   static double const kMaxViewportRadiusM;
 
   Processor(DataSource const & dataSource, CategoriesHolder const & categories,
-            std::vector<Suggest> const & suggests, storage::CountryInfoGetter const & infoGetter);
+            CitiesBoundariesTable const & citiesBoundaries, std::vector<Suggest> const & suggests,
+            storage::CountryInfoGetter const & infoGetter);
 
   void SetViewport(m2::RectD const & viewport);
   void SetPreferredLocale(std::string const & locale);
@@ -94,7 +95,6 @@ public:
   void InitEmitter(SearchParams const & searchParams);
 
   void ClearCaches();
-  void LoadCitiesBoundaries();
   void LoadCountriesTree();
 
   void OnBookmarksCreated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
@@ -133,7 +133,7 @@ protected:
   int8_t m_currentLocaleCode = StringUtf8Multilang::kUnsupportedLanguageCode;
 
   VillagesCache m_villagesCache;
-  CitiesBoundariesTable m_citiesBoundaries;
+  CitiesBoundariesTable const & m_citiesBoundaries;
 
   KeywordLangMatcher m_keywordsScorer;
   Emitter m_emitter;


### PR DESCRIPTION
После починки @bykoianko сериализации границ их количество увеличилось и время десериализации возросло (см. https://github.com/mapsme/omim/pull/9333).
Раньше мы десериализовывали границы на старте и потом при каждом поиске, теперь десериализовываем только 1 раз на старте и в поиск передаем по константной ссылке.