### PR TITLE
[search][MAPSME-8519] Set rank for transport stations

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -179,6 +179,19 @@ IsRailwayStationChecker::IsRailwayStationChecker()
 {
   Classificator const & c = classif();
   m_types.push_back(c.GetTypeByPath({"railway", "station"}));
+  m_types.push_back(c.GetTypeByPath({"building", "train_station"}));
+}
+
+IsSubwayStationChecker::IsSubwayStationChecker() : BaseChecker(3 /* level */)
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"railway", "station", "subway"}));
+}
+
+IsAirportChecker::IsAirportChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"aeroway", "aerodrome"}));
 }
 
 IsStreetChecker::IsStreetChecker()

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -86,6 +86,22 @@ public:
   DECLARE_CHECKER_INSTANCE(IsRailwayStationChecker);
 };
 
+class IsSubwayStationChecker : public BaseChecker
+{
+  IsSubwayStationChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsSubwayStationChecker);
+};
+
+class IsAirportChecker : public BaseChecker
+{
+  IsAirportChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsAirportChecker);
+};
+
 class IsStreetChecker : public BaseChecker
 {
   IsStreetChecker();

--- a/indexer/rank_table.cpp
+++ b/indexer/rank_table.cpp
@@ -226,13 +226,27 @@ uint8_t CalcEventRank(FeatureType & ft)
   return 0;
 }
 
+uint8_t CalcTransportRank(FeatureType & ft)
+{
+  uint8_t const kTransportRank = 2;
+  if (ftypes::IsRailwayStationChecker::Instance()(ft) ||
+      ftypes::IsSubwayStationChecker::Instance()(ft) || ftypes::IsAirportChecker::Instance()(ft))
+  {
+    return kTransportRank;
+  }
+
+  return 0;
+}
+
 // Calculates search rank for a feature.
 uint8_t CalcSearchRank(FeatureType & ft)
 {
   auto const eventRank = CalcEventRank(ft);
+  auto const transportRank = CalcTransportRank(ft);
   auto const populationRank = feature::PopulationToRank(ftypes::GetPopulation(ft));
 
-  return my::clamp(eventRank + populationRank, 0, static_cast<int>(numeric_limits<uint8_t>::max()));
+  return my::clamp(eventRank + transportRank + populationRank, 0,
+                   static_cast<int>(numeric_limits<uint8_t>::max()));
 }
 
 // Creates rank table if it does not exists in |rcont| or has wrong


### PR DESCRIPTION
Ранг для крупных станций (аэропорты, метро, ж/д вокзалы, но не платформы и не автобусные остановки).
Ранг небольшой, чтобы гарантированно не отбрасывать в преранкере, но и не слишком поднимать в выдаче -- должно стать строго лучше чем было.