### PR TITLE
Explicit check that only little endian architectures are supported.

### DIFF
--- a/coding/endianness.hpp
+++ b/coding/endianness.hpp
@@ -8,6 +8,10 @@
 
 // #define ENDIAN_IS_BIG
 
+// @TODO(bykoianko) This method returns false since 05.12.2010. That means only little endian
+// architecture is supported. Now checks are added to generator and to app that only
+// little endian architecture is supported. All the usage of IsBigEndian(), ReverseByteOrder()
+// and SwapIfBigEndian() should be removed.
 inline bool IsBigEndian()
 {
 #ifdef ENDIAN_IS_BIG
@@ -36,4 +40,11 @@ template <typename T> inline T SwapIfBigEndian(T t)
 #else
   return t;
 #endif
+}
+
+inline bool IsLittleEndian()
+{
+  uint16_t const word = 0x0001;
+  char const * const b = reinterpret_cast<char const * const>(&word);
+  return b[0] == 0x1;
 }

--- a/coding/endianness.hpp
+++ b/coding/endianness.hpp
@@ -8,11 +8,14 @@
 
 // #define ENDIAN_IS_BIG
 
-// @TODO(bykoianko) This method returns false since 05.12.2010. That means only little endian
-// architecture is supported. Now checks are added to generator and to app that only
-// little endian architecture is supported. All the usage of IsBigEndian(), ReverseByteOrder()
-// and SwapIfBigEndian() should be removed.
-inline bool IsBigEndian()
+// @TODO(bykoianko) This method returns false since 05.12.2010. That means only little-endian
+// architectures are supported. When it's necessary to support a big-endian system:
+// * method IsBigEndianMacroBased() should be implemented based on IsLittleEndian() function
+// * method SwapIfBigEndianMacroBased() should be implemented based on IsLittleEndian() function
+// * all serialization and deserialization of rs_bit_vector and the other rank-select structures
+//   should be implemented taking endianness into account
+
+inline bool IsBigEndianMacroBased()
 {
 #ifdef ENDIAN_IS_BIG
   return true;
@@ -33,7 +36,7 @@ template <typename T> T ReverseByteOrder(T t)
   return res;
 }
 
-template <typename T> inline T SwapIfBigEndian(T t)
+template <typename T> inline T SwapIfBigEndianMacroBased(T t)
 {
 #ifdef ENDIAN_IS_BIG
   return ReverseByteOrder(t);
@@ -45,6 +48,6 @@ template <typename T> inline T SwapIfBigEndian(T t)
 inline bool IsLittleEndian()
 {
   uint16_t const word = 0x0001;
-  char const * const b = reinterpret_cast<char const * const>(&word);
-  return b[0] == 0x1;
+  uint8_t const * const b = reinterpret_cast<uint8_t const * const>(&word);
+  return b[0] != 0x0;
 }

--- a/coding/reader.hpp
+++ b/coding/reader.hpp
@@ -264,7 +264,7 @@ inline TPrimitive ReadPrimitiveFromPos(TReader const & reader, uint64_t pos)
 #endif
   TPrimitive primitive;
   ReadFromPos(reader, pos, &primitive, sizeof(primitive));
-  return SwapIfBigEndian(primitive);
+  return SwapIfBigEndianMacroBased(primitive);
 }
 
 template <typename TPrimitive, class TSource>
@@ -275,7 +275,7 @@ TPrimitive ReadPrimitiveFromSource(TSource & source)
 #endif
   TPrimitive primitive;
   source.Read(&primitive, sizeof(primitive));
-  return SwapIfBigEndian(primitive);
+  return SwapIfBigEndianMacroBased(primitive);
 }
 
 template <typename TPrimitive, typename TSource>

--- a/coding/write_to_sink.hpp
+++ b/coding/write_to_sink.hpp
@@ -9,7 +9,7 @@ template <class Sink, typename T>
 std::enable_if_t<std::is_integral<T>::value || std::is_enum<T>::value, void> WriteToSink(
     Sink & sink, T const & v)
 {
-  T const t = SwapIfBigEndian(v);
+  T const t = SwapIfBigEndianMacroBased(v);
   sink.Write(&t, sizeof(T));
 }
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -43,6 +43,7 @@
 
 #include "platform/platform.hpp"
 
+#include "coding/endianness.hpp"
 #include "coding/file_name_utils.hpp"
 #include "coding/transliteration.hpp"
 
@@ -167,6 +168,8 @@ using namespace generator;
 
 int main(int argc, char ** argv)
 {
+  CHECK(IsLittleEndian(), ("Only little endian architecture is supported."));
+
   google::SetUsageMessage(
         "Takes OSM XML data from stdin and creates data and index files in several passes.");
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -168,7 +168,7 @@ using namespace generator;
 
 int main(int argc, char ** argv)
 {
-  CHECK(IsLittleEndian(), ("Only little endian architecture is supported."));
+  CHECK(IsLittleEndian(), ("Only little-endian architectures are supported."));
 
   google::SetUsageMessage(
         "Takes OSM XML data from stdin and creates data and index files in several passes.");

--- a/indexer/centers_table.cpp
+++ b/indexer/centers_table.cpp
@@ -189,7 +189,7 @@ private:
     if (!m_header.IsValid())
       return false;
 
-    bool const isHostBigEndian = IsBigEndian();
+    bool const isHostBigEndian = IsBigEndianMacroBased();
     bool const isDataBigEndian = m_header.m_base.m_endianness == 1;
     bool const endiannesMismatch = isHostBigEndian != isDataBigEndian;
 
@@ -332,6 +332,7 @@ void CentersTableBuilder::Freeze(Writer & writer) const
   auto const endOffset = writer.Pos();
 
   writer.Seek(startOffset);
+  CHECK_EQUAL(header.m_base.m_endianness, 0, ("|m_endianness| should be set to little-endian."));
   header.Write(writer);
   writer.Seek(endOffset);
 }

--- a/indexer/interval_index.hpp
+++ b/indexer/interval_index.hpp
@@ -88,7 +88,7 @@ private:
     {
       uint32_t key = 0;
       src.Read(&key, m_Header.m_LeafBytes);
-      key = SwapIfBigEndian(key);
+      key = SwapIfBigEndianMacroBased(key);
       if (key > end)
         break;
       value += ReadVarInt<int64_t>(src);

--- a/indexer/interval_index_builder.hpp
+++ b/indexer/interval_index_builder.hpp
@@ -230,7 +230,7 @@ public:
         prevValue = 0;
         prevPos = writer.Pos();
       }
-      uint64_t const keySerial = SwapIfBigEndian(key);
+      uint64_t const keySerial = SwapIfBigEndianMacroBased(key);
       writer.Write(&keySerial, m_LeafBytes);
       WriteVarInt(writer, static_cast<int64_t>(value) - static_cast<int64_t>(prevValue));
       prevKey = key;

--- a/indexer/rank_table.cpp
+++ b/indexer/rank_table.cpp
@@ -56,7 +56,7 @@ CheckResult CheckEndianness(TReader && reader)
     return CheckResult::CorruptedHeader;
   uint8_t flags;
   reader.Read(kFlagsOffset, &flags, sizeof(flags));
-  bool const isHostBigEndian = IsBigEndian();
+  bool const isHostBigEndian = IsBigEndianMacroBased();
   bool const isDataBigEndian = flags & 1;
   if (isHostBigEndian != isDataBigEndian)
     return CheckResult::EndiannessMismatch;
@@ -110,7 +110,7 @@ public:
     static uint64_t const padding = 0;
 
     uint8_t const version = GetVersion();
-    uint8_t const flags = preserveHostEndianness ? IsBigEndian() : !IsBigEndian();
+    uint8_t const flags = preserveHostEndianness ? IsBigEndianMacroBased() : !IsBigEndianMacroBased();
     writer.Write(&version, sizeof(version));
     writer.Write(&flags, sizeof(flags));
     writer.Write(&padding, 6);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -72,6 +72,7 @@
 #include "platform/settings.hpp"
 #include "platform/socket.hpp"
 
+#include "coding/endianness.hpp"
 #include "coding/file_name_utils.hpp"
 #include "coding/multilang_utf8_string.hpp"
 #include "coding/transliteration.hpp"
@@ -391,6 +392,10 @@ Framework::Framework(FrameworkParams const & params)
   , m_subscription(std::make_unique<Subscription>())
   , m_tipsApi(static_cast<TipsApi::Delegate &>(*this))
 {
+  CHECK(IsLittleEndian(), ("Only little endian architecture is supported."));
+
+  m_startBackgroundTime = my::Timer::LocalTime();
+
   // Editor should be initialized from the main thread to set its ThreadChecker.
   // However, search calls editor upon initialization thus setting the lazy editor's ThreadChecker
   // to a wrong thread. So editor should be initialiazed before serach.

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -392,9 +392,7 @@ Framework::Framework(FrameworkParams const & params)
   , m_subscription(std::make_unique<Subscription>())
   , m_tipsApi(static_cast<TipsApi::Delegate &>(*this))
 {
-  CHECK(IsLittleEndian(), ("Only little endian architecture is supported."));
-
-  m_startBackgroundTime = my::Timer::LocalTime();
+  CHECK(IsLittleEndian(), ("Only little-endian architectures are supported."));
 
   // Editor should be initialized from the main thread to set its ThreadChecker.
   // However, search calls editor upon initialization thus setting the lazy editor's ThreadChecker

--- a/map/gps_track_storage.cpp
+++ b/map/gps_track_storage.cpp
@@ -31,7 +31,7 @@ size_t constexpr kPointSize = 8 * sizeof(double) + sizeof(uint8_t);
 template <typename T>
 void MemWrite(void * ptr, T value)
 {
-  value = SwapIfBigEndian(value);
+  value = SwapIfBigEndianMacroBased(value);
   memcpy(ptr, &value, sizeof(T));
 }
 
@@ -41,7 +41,7 @@ T MemRead(void const * ptr)
 {
   T value;
   memcpy(&value, ptr, sizeof(T));
-  return SwapIfBigEndian(value);
+  return SwapIfBigEndianMacroBased(value);
 }
 
 void Pack(char * p, location::GpsInfo const & info)
@@ -87,7 +87,7 @@ inline size_t GetItemCount(size_t fileSize)
 inline bool WriteVersion(fstream & f, uint32_t version)
 {
   static_assert(kHeaderSize == sizeof(version), "");
-  version = SwapIfBigEndian(version);
+  version = SwapIfBigEndianMacroBased(version);
   f.write(reinterpret_cast<char const *>(&version), kHeaderSize);
   return f.good();
 }
@@ -96,7 +96,7 @@ inline bool ReadVersion(fstream & f, uint32_t & version)
 {
   static_assert(kHeaderSize == sizeof(version), "");
   f.read(reinterpret_cast<char *>(&version), kHeaderSize);
-  version = SwapIfBigEndian(version);
+  version = SwapIfBigEndianMacroBased(version);
   return f.good();
 }
 

--- a/tracking/protocol.cpp
+++ b/tracking/protocol.cpp
@@ -79,7 +79,7 @@ pair<Protocol::PacketType, size_t> Protocol::DecodeHeader(vector<uint8_t> const 
   ASSERT_GREATER_OR_EQUAL(data.size(), sizeof(uint32_t /* header */), ());
 
   uint32_t size = (*reinterpret_cast<uint32_t const *>(data.data())) & 0xFFFFFF00;
-  if (!IsBigEndian())
+  if (!IsBigEndianMacroBased())
     size = ReverseByteOrder(size);
 
   return make_pair(PacketType(static_cast<uint8_t>(data[0])), size);
@@ -125,7 +125,7 @@ void Protocol::InitHeader(vector<uint8_t> & packet, PacketType type, uint32_t pa
 
   ASSERT_LESS(size, 0x00FFFFFF, ());
 
-  if (!IsBigEndian())
+  if (!IsBigEndianMacroBased())
     size = ReverseByteOrder(size);
 
   packet[0] = static_cast<uint8_t>(type);


### PR DESCRIPTION
В настоящий момент наше приложение поддерживает только little endian архитектуру. Это означает, что и генератор и девайс должны быть little endian.

Хотя, глядя на код это не просто понять. Есть метод: `IsBigEndian()`, который достаточно активно используется в приложении, но не работает (как минимум 8 лет). Более того, поскольку он не работает, то он часто используется ошибочно. Например, в при десериализации секции "centers" он используется. А при сериализации нет. 

Более того. Есть места, где учет endianness важен, но про него забыли. Например, в секции "altitudes".

Если сейчас мы попытаемся запуститься на девайсе big endian, но будем падать в разных неожиданных местах, скорее всего это случится при запуске.

Почему мы сейчас вообще работаем?
Дело в том, что генератор собирает карту на x86, а это little endian. Наши целевые девайсы это ARM и x86. ARM после 3-й версии Bi-endian (т.е. как сделает производитель девайса так и будет), но по умолчанию little endian и встречаются ссылки, что Android и iOS поддерживает little endian. Все что мы сейчас поддерживаем это little endian.

Статьи:
https://en.wikipedia.org/wiki/Comparison_of_instruction_set_architectures
https://en.wikipedia.org/wiki/ARM_architecture
https://en.wikipedia.org/wiki/Endianness
https://developer.android.com/ndk/guides/abis
https://www.quora.com/Are-all-iOS-devices-little-endian

Предлагаю:
1. Явно запретить генерацию данных и запуск приложения на big endian девайсах; (Данный PR)
2. Удалить код, по поддержке big endian. Он обычно или работает не верно (секция "centers"), или вообще не использован, где нужно ("altitudes", другие места, где используется rs_bit_vector) и уверен, много еще где забыли.

@mpimenov @tatiana-yan @syershov @maksimandrianov @rokuz PTAL