### PR TITLE
Generator fix. Cross mwm section.

### DIFF
--- a/base/base_tests/geo_object_id_tests.cpp
+++ b/base/base_tests/geo_object_id_tests.cpp
@@ -41,4 +41,13 @@ UNIT_TEST(GeoObjectId)
   TEST_EQUAL(fias.GetType(), GeoObjectId::Type::Fias, ());
   TEST_EQUAL(DebugPrint(fias), "FIAS 61861", ());
 }
+
+UNIT_TEST(GeoObjectId_DebugPrint)
+{
+  GeoObjectId const invalid;
+  TEST_EQUAL(DebugPrint(invalid), "Invalid 0", ());
+
+  GeoObjectId const valid(GeoObjectId::Type::OsmWay, 123);
+  TEST_EQUAL(DebugPrint(valid), "Osm Way 123", ());
+}
 }  // namespace base

--- a/base/base_tests/geo_object_id_tests.cpp
+++ b/base/base_tests/geo_object_id_tests.cpp
@@ -8,6 +8,7 @@ UNIT_TEST(GeoObjectId)
 {
   GeoObjectId const invalid(GeoObjectId::kInvalid);
   TEST_EQUAL(invalid.GetType(), GeoObjectId::Type::Invalid, ());
+  TEST_EQUAL(DebugPrint(invalid), "Invalid 0", ());
 
   GeoObjectId const node(GeoObjectId::Type::ObsoleteOsmNode, 12345);
   TEST_EQUAL(node.GetSerialId(), 12345ULL, ());
@@ -40,14 +41,5 @@ UNIT_TEST(GeoObjectId)
   TEST_EQUAL(fias.GetSerialId(), 0xf1a5, ());
   TEST_EQUAL(fias.GetType(), GeoObjectId::Type::Fias, ());
   TEST_EQUAL(DebugPrint(fias), "FIAS 61861", ());
-}
-
-UNIT_TEST(GeoObjectId_DebugPrint)
-{
-  GeoObjectId const invalid;
-  TEST_EQUAL(DebugPrint(invalid), "Invalid 0", ());
-
-  GeoObjectId const valid(GeoObjectId::Type::OsmWay, 123);
-  TEST_EQUAL(DebugPrint(valid), "Osm Way 123", ());
 }
 }  // namespace base

--- a/base/geo_object_id.cpp
+++ b/base/geo_object_id.cpp
@@ -89,10 +89,8 @@ std::string DebugPrint(GeoObjectId::Type const & t)
 std::string DebugPrint(GeoObjectId const & id)
 {
   std::ostringstream oss;
-  // To print serial id it's written |id.m_encodedId & kSerialMask| instead of id.GetSerialId().
-  // It's done to be able to print a instance of GeoObjectId created by default constructor.
-  // In case of instance of GeoObjectId created by default ctor GetSerialId() shouldn't be called.
-  oss << DebugPrint(id.GetType()) << " " << (id.m_encodedId & kSerialMask);
+  // GetSerialId() does not work for invalid ids but we may still want to print them.
+  oss << DebugPrint(id.GetType()) << " " << (id.GetEncodedId() & kSerialMask);
   return oss.str();
 }
 }  // namespace base

--- a/base/geo_object_id.cpp
+++ b/base/geo_object_id.cpp
@@ -89,7 +89,10 @@ std::string DebugPrint(GeoObjectId::Type const & t)
 std::string DebugPrint(GeoObjectId const & id)
 {
   std::ostringstream oss;
-  oss << DebugPrint(id.GetType()) << " " << id.GetSerialId();
+  // To print serial id it's written |id.m_encodedId & kSerialMask| instead of id.GetSerialId().
+  // It's done to be able to print a instance of GeoObjectId created by default constructor.
+  // In case of instance of GeoObjectId created by default ctor GetSerialId() shouldn't be called.
+  oss << DebugPrint(id.GetType()) << " " << (id.m_encodedId & kSerialMask);
   return oss.str();
 }
 }  // namespace base

--- a/base/geo_object_id.hpp
+++ b/base/geo_object_id.hpp
@@ -35,6 +35,8 @@ namespace base
 // and the difference does not seem important. Also this would probably touch the highest bit.
 class GeoObjectId
 {
+  friend std::string DebugPrint(GeoObjectId const & id);
+
 public:
   // Sources of the objects.
   enum class Type : uint8_t

--- a/base/geo_object_id.hpp
+++ b/base/geo_object_id.hpp
@@ -35,8 +35,6 @@ namespace base
 // and the difference does not seem important. Also this would probably touch the highest bit.
 class GeoObjectId
 {
-  friend std::string DebugPrint(GeoObjectId const & id);
-
 public:
   // Sources of the objects.
   enum class Type : uint8_t

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -437,13 +437,13 @@ private:
   static uint32_t CalcBitsPerCrossMwmId(
       std::vector<Transition<base::GeoObjectId>> const & transitions)
   {
-    base::GeoObjectId osmId(0ULL);
+    uint64_t serial = 0;
     for (auto const & transition : transitions)
-      osmId = std::max(osmId, transition.GetCrossMwmId());
+      serial = std::max(serial, transition.GetCrossMwmId().GetSerialId());
 
     // Note that we lose base::GeoObjectId::Type bits here, remember about
     // it in ReadCrossMwmId method.
-    return bits::NumUsedBits(osmId.GetSerialId());
+    return bits::NumUsedBits(serial);
   }
 
   static uint32_t CalcBitsPerCrossMwmId(


### PR DESCRIPTION
PR делает 2 вещи.
- было не хорошо, что `std::string DebugPrint(GeoObjectId const & id);` крешился при попытке вывести GeoObjectId созданный конструктором по умолчанию. Поправил (1-й коммит).
- при сборке mwm, где не было дорожных фичь пересекающих границы (острова) падали на недавно добавленном в GeoObjectId чек. Поправил (2-й коммит).

@mpimenov @tatiana-yan @maksimandrianov PTAL