### PR TITLE
[generator] Fix cities_boundaries in World.mwm problem

### DIFF
--- a/generator/camera_node_processor.cpp
+++ b/generator/camera_node_processor.cpp
@@ -209,4 +209,26 @@ std::string CameraNodeIntermediateDataProcessor::ValidateMaxSpeedString(std::str
 
   return result;
 }
+
+void CameraNodeIntermediateDataProcessor::ProcessNode(OsmElement & em)
+{
+  for (auto const & tag : em.Tags())
+  {
+    std::string const & key(tag.key);
+    std::string const & value(tag.value);
+    if (key == "highway" && value == "speed_camera")
+    {
+      m_speedCameraNodes.insert(em.id);
+    }
+    else if (key == "maxspeed" && !value.empty())
+    {
+      WriteToSink(m_maxSpeedFileWriter, em.id);
+
+      std::string result = ValidateMaxSpeedString(value);
+      CHECK_LESS(result.size(), kMaxSpeedSpeedStringLength, ("Too long string for speed"));
+      WriteToSink(m_maxSpeedFileWriter, result.size());
+      m_maxSpeedFileWriter.Write(result.c_str(), result.size());
+    }
+  }
+}
 }  // namespace generator

--- a/generator/camera_node_processor.hpp
+++ b/generator/camera_node_processor.hpp
@@ -58,28 +58,7 @@ public:
 
   static size_t const kMaxSpeedSpeedStringLength;
 
-  template <typename Element>
-  void ProcessNode(Element & em, std::vector<OsmElement::Tag> const & tags)
-  {
-    for (auto const & tag : tags)
-    {
-      std::string const & key(tag.key);
-      std::string const & value(tag.value);
-      if (key == "highway" && value == "speed_camera")
-      {
-        m_speedCameraNodes.insert(em.id);
-      }
-      else if (key == "maxspeed" && !value.empty())
-      {
-        WriteToSink(m_maxSpeedFileWriter, em.id);
-
-        std::string result = ValidateMaxSpeedString(value);
-        CHECK_LESS(result.size(), kMaxSpeedSpeedStringLength, ("Too long string for speed"));
-        WriteToSink(m_maxSpeedFileWriter, result.size());
-        m_maxSpeedFileWriter.Write(result.c_str(), result.size());
-      }
-    }
-  }
+  void ProcessNode(OsmElement & em);
 
   void ProcessWay(uint64_t id, WayElement const & way);
 

--- a/generator/osm_element.hpp
+++ b/generator/osm_element.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "base/assert.hpp"
 #include "base/math.hpp"
 #include "base/string_utils.hpp"
 

--- a/generator/towns_dumper.hpp
+++ b/generator/towns_dumper.hpp
@@ -8,7 +8,6 @@
 
 #include "base/string_utils.hpp"
 
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -17,45 +16,7 @@ class TownsDumper
 public:
   TownsDumper();
 
-  template <typename TElement>
-  void CheckElement(TElement const & em, std::vector<OsmElement::Tag> const & tags)
-  {
-    if (em.type != TElement::EntityType::Node)
-      return;
-    uint64_t population = 1;
-    bool town = false;
-    bool capital = false;
-    int admin_level = std::numeric_limits<int>::max();
-    for (auto const & tag : tags)
-    {
-      std::string key(tag.key), value(tag.value);
-      if (key == "population")
-      {
-        if (!strings::to_uint64(value, population))
-          continue;
-      }
-      else if (key == "admin_level")
-      {
-        if (!strings::to_int(value, admin_level))
-          continue;
-      }
-      else if (key == "capital" && value == "yes")
-      {
-        capital = true;
-      }
-      else if (key == "place" && (value == "city" || value == "town"))
-      {
-        town = true;
-      }
-    }
-
-    // Ignore regional capitals.
-    if (capital && admin_level > 2)
-      capital = false;
-
-    if (town || capital)
-      m_records.emplace_back(em.lat, em.lon, em.id, capital, population);
-  }
+  void CheckElement(OsmElement const & em);
 
   void Dump(std::string const & filePath);
 


### PR DESCRIPTION
В `World.mwm` терялись куда-то `cities_boundaries`. 
Проблема была в том, что на этапе препроцессинга: `BuildIntermediateDataFromO5M`, итерация по `o5m` файлу написана таким образом, что у элемента можно вызывать методы: `Members()`, `Nodes()`, `Tags()` только один раз, так как внутри них идет итерация по файлу. Для камер мне нужно было вызывать `Tags()`  два раза, поэтому я тэги закешировал. Оказалось, что внутри `Tags()` вызывается `Nodes.Skip()` + `Members.Skip()`. Таким образом, после вызова `Tags()` повторный вызов к `Nodes()` (так получилось в случае с `Way`) не давал никаких результатов.

Пофиксил пока так: закешировал `members`, `nodes`, `tags` в нужном порядке. 
По хорошему, надо написать преобразователь `O5MSource::Entity` => `OsmElement`. Но так как они не совсем идентичны, я решил на скорую руку этого не трогать, чтобы не попасть на другие странности.
Еще более по-хорошему - надо переписать парсер `o5m` чтобы не было такого, что обращение к `Nodes()` было тоже самое, что `считать-вернуть-забыть`