### PR TITLE
[search] Changed namespace from search::base to search_base.

### DIFF
--- a/search/base/inverted_list.hpp
+++ b/search/base/inverted_list.hpp
@@ -6,9 +6,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // This class is supposed to be used in inverted index to store list
 // of document ids.
@@ -55,5 +53,4 @@ public:
 private:
   std::vector<Id> m_ids;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/mem_search_index.hpp
+++ b/search/base/mem_search_index.hpp
@@ -15,9 +15,7 @@
 #include <utility>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 template <typename Id>
 class MemSearchIndex
@@ -26,7 +24,7 @@ public:
   using Token = strings::UniString;
   using Char = Token::value_type;
   using List = InvertedList<Id>;
-  using Trie = ::base::MemTrie<Token, List>;
+  using Trie = base::MemTrie<Token, List>;
   using Iterator = trie::MemTrieIterator<Token, List>;
 
   template <typename Doc>
@@ -91,11 +89,10 @@ private:
   {
     std::vector<Id> ids;
     fn(ids);
-    ::base::SortUnique(ids);
+    base::SortUnique(ids);
     return ids;
   }
 
   Trie m_trie;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/dictionary.hpp
+++ b/search/base/text_index/dictionary.hpp
@@ -13,9 +13,7 @@
 #include <utility>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // The dictionary contains all tokens that are present
 // in the text index.
@@ -27,7 +25,7 @@ public:
     auto const it = std::lower_bound(m_tokens.cbegin(), m_tokens.cend(), token);
     if (it == m_tokens.cend() || *it != token)
       return false;
-    id = ::base::checked_cast<uint32_t>(std::distance(m_tokens.cbegin(), it));
+    id = base::checked_cast<uint32_t>(std::distance(m_tokens.cbegin(), it));
     return true;
   }
 
@@ -42,7 +40,7 @@ public:
   template <typename Sink>
   void Serialize(Sink & sink, TextIndexHeader & header, uint64_t startPos) const
   {
-    header.m_numTokens = ::base::checked_cast<uint32_t>(m_tokens.size());
+    header.m_numTokens = base::checked_cast<uint32_t>(m_tokens.size());
 
     header.m_dictPositionsOffset = RelativePos(sink, startPos);
     // An uint32_t for each 32-bit offset and an uint32_t for the dummy entry at the end.
@@ -84,7 +82,7 @@ public:
     m_tokens.resize(header.m_numTokens);
     for (size_t i = 0; i < m_tokens.size(); ++i)
     {
-      size_t const size = ::base::checked_cast<size_t>(tokenOffsets[i + 1] - tokenOffsets[i]);
+      size_t const size = base::checked_cast<size_t>(tokenOffsets[i + 1] - tokenOffsets[i]);
       DeserializeToken(source, m_tokens[i], size);
     }
   }
@@ -110,10 +108,9 @@ private:
   template <typename Sink>
   static uint32_t RelativePos(Sink & sink, uint64_t startPos)
   {
-    return ::base::checked_cast<uint32_t>(sink.Pos() - startPos);
+    return base::checked_cast<uint32_t>(sink.Pos() - startPos);
   }
 
   std::vector<Token> m_tokens;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/header.cpp
+++ b/search/base/text_index/header.cpp
@@ -2,11 +2,8 @@
 
 using namespace std;
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // static
 string const TextIndexHeader::kHeaderMagic = "mapsmetextidx";
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/header.hpp
+++ b/search/base/text_index/header.hpp
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "search/base/text_index/text_index.hpp"
@@ -10,9 +11,7 @@
 #include <cstdint>
 #include <string>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 struct TextIndexHeader
 {
@@ -55,5 +54,4 @@ struct TextIndexHeader
   uint32_t m_postingsStartsOffset = 0;
   uint32_t m_postingsListsOffset = 0;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/mem.cpp
+++ b/search/base/text_index/mem.cpp
@@ -4,9 +4,7 @@
 
 using namespace std;
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 void MemTextIndex::AddPosting(Token const & token, Posting const & posting)
 {
@@ -21,7 +19,7 @@ void MemTextIndex::SortPostings()
     // so we remove duplicates for the docid index.
     // If the count is needed for ranking it may be stored
     // separately.
-    ::base::SortUnique(entry.second);
+    base::SortUnique(entry.second);
   }
 }
 
@@ -33,5 +31,4 @@ void MemTextIndex::BuildDictionary()
     tokens.emplace_back(entry.first);
   m_dictionary.SetTokens(move(tokens));
 }
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/mem.hpp
+++ b/search/base/text_index/mem.hpp
@@ -20,9 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 class MemTextIndex
 {
@@ -167,5 +165,4 @@ private:
   std::map<Token, std::vector<Posting>> m_postingsByToken;
   TextIndexDictionary m_dictionary;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/merger.cpp
+++ b/search/base/text_index/merger.cpp
@@ -22,7 +22,7 @@ using namespace std;
 
 namespace
 {
-using namespace search::base;
+using namespace search_base;
 
 class MergedPostingsListFetcher : public PostingsFetcher
 {
@@ -69,9 +69,9 @@ private:
       return;
 
     auto const & tokens = m_dict.GetTokens();
-    m_index1.ForEachPosting(tokens[m_tokenId], ::base::MakeBackInsertFunctor(m_postings));
-    m_index2.ForEachPosting(tokens[m_tokenId], ::base::MakeBackInsertFunctor(m_postings));
-    ::base::SortUnique(m_postings);
+    m_index1.ForEachPosting(tokens[m_tokenId], base::MakeBackInsertFunctor(m_postings));
+    m_index2.ForEachPosting(tokens[m_tokenId], base::MakeBackInsertFunctor(m_postings));
+    base::SortUnique(m_postings);
   }
 
   TextIndexDictionary const & m_dict;
@@ -98,9 +98,7 @@ TextIndexDictionary MergeDictionaries(TextIndexDictionary const & dict1,
 }
 }  // namespace
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // static
 void TextIndexMerger::Merge(TextIndexReader const & index1, TextIndexReader const & index2,
@@ -126,5 +124,4 @@ void TextIndexMerger::Merge(TextIndexReader const & index1, TextIndexReader cons
   header.Serialize(sink);
   sink.Seek(finishPos);
 }
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/merger.hpp
+++ b/search/base/text_index/merger.hpp
@@ -4,9 +4,7 @@
 
 class FileWriter;
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // Merges two on-disk text indexes and writes them to a new one.
 class TextIndexMerger
@@ -26,5 +24,4 @@ public:
   static void Merge(TextIndexReader const & index1, TextIndexReader const & index2,
                     FileWriter & sink);
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/postings.hpp
+++ b/search/base/text_index/postings.hpp
@@ -11,9 +11,7 @@
 #include <functional>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 struct TextIndexHeader;
 
@@ -87,5 +85,4 @@ void WritePostings(Sink & sink, uint64_t startPos, TextIndexHeader & header,
     sink.Seek(savedPos);
   }
 }
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/reader.hpp
+++ b/search/base/text_index/reader.hpp
@@ -15,9 +15,7 @@
 #include <utility>
 #include <vector>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 // A reader class for on-demand reading of postings lists from disk.
 class TextIndexReader
@@ -77,5 +75,4 @@ private:
   TextIndexDictionary m_dictionary;
   std::vector<uint32_t> m_postingsStarts;
 };
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/text_index.cpp
+++ b/search/base/text_index/text_index.cpp
@@ -5,9 +5,7 @@
 
 using namespace std;
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 string DebugPrint(TextIndexVersion const & version)
 {
@@ -20,5 +18,4 @@ string DebugPrint(TextIndexVersion const & version)
   ASSERT(false, (ret));
   return ret;
 }
-}  // namespace base
 }  // namespace search

--- a/search/base/text_index/text_index.hpp
+++ b/search/base/text_index/text_index.hpp
@@ -27,9 +27,7 @@
 //   [postings lists, stored as delta-encoded varints]
 //
 // All offsets are measured relative to the start of the index.
-namespace search
-{
-namespace base
+namespace search_base
 {
 using Token = std::string;
 using Posting = uint32_t;
@@ -41,5 +39,4 @@ enum class TextIndexVersion : uint8_t
 };
 
 std::string DebugPrint(TextIndexVersion const & version);
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/base/text_index/utils.hpp
+++ b/search/base/text_index/utils.hpp
@@ -4,14 +4,11 @@
 
 #include <cstdint>
 
-namespace search
-{
-namespace base
+namespace search_base
 {
 template <typename Sink>
 uint32_t RelativePos(Sink & sink, uint64_t startPos)
 {
-  return ::base::checked_cast<uint32_t>(sink.Pos() - startPos);
+  return base::checked_cast<uint32_t>(sink.Pos() - startPos);
 }
-}  // namespace base
-}  // namespace search
+}  // namespace search_base

--- a/search/bookmarks/processor.cpp
+++ b/search/bookmarks/processor.cpp
@@ -72,7 +72,7 @@ void FillRankingInfo(QueryVec & qv, IdfMap & idfs, DocVec const & dv, RankingInf
 }
 }  // namespace
 
-Processor::Processor(Emitter & emitter, ::base::Cancellable const & cancellable)
+Processor::Processor(Emitter & emitter, base::Cancellable const & cancellable)
   : m_emitter(emitter), m_cancellable(cancellable)
 {
 }
@@ -103,7 +103,7 @@ void Processor::Erase(Id const & id)
 void Processor::Search(QueryParams const & params) const
 {
   set<Id> ids;
-  auto insertId = ::base::MakeInsertFunctor(ids);
+  auto insertId = base::MakeInsertFunctor(ids);
 
   for (size_t i = 0; i < params.GetNumTokens(); ++i)
   {
@@ -143,7 +143,7 @@ void Processor::Search(QueryParams const & params) const
 
 uint64_t Processor::GetNumDocs(strings::UniString const & token, bool isPrefix) const
 {
-  return ::base::asserted_cast<uint64_t>(
+  return base::asserted_cast<uint64_t>(
       m_index.GetNumDocs(StringUtf8Multilang::kDefaultCode, token, isPrefix));
 }
 

--- a/search/bookmarks/processor.hpp
+++ b/search/bookmarks/processor.hpp
@@ -29,9 +29,9 @@ namespace bookmarks
 class Processor : public IdfMap::Delegate
 {
 public:
-  using Index = base::MemSearchIndex<Id>;
+  using Index = search_base::MemSearchIndex<Id>;
 
-  Processor(Emitter & emitter, ::base::Cancellable const & cancellable);
+  Processor(Emitter & emitter, base::Cancellable const & cancellable);
   ~Processor() override = default;
 
   void Add(Id const & id, Doc const & doc);
@@ -63,7 +63,7 @@ private:
   QueryVec GetQueryVec(IdfMap & idfs, QueryParams const & params) const;
 
   Emitter & m_emitter;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 
   Index m_index;
   std::unordered_map<Id, DocVec> m_docs;

--- a/search/cancel_exception.hpp
+++ b/search/cancel_exception.hpp
@@ -11,7 +11,7 @@ namespace search
 // geometry retrieval for fast cancellation of time-consuming tasks.
 DECLARE_EXCEPTION(CancelException, RootException);
 
-inline void BailIfCancelled(::base::Cancellable const & cancellable)
+inline void BailIfCancelled(base::Cancellable const & cancellable)
 {
   if (cancellable.IsCancelled())
     MYTHROW(CancelException, ("Cancelled"));

--- a/search/categories_cache.cpp
+++ b/search/categories_cache.cpp
@@ -51,19 +51,19 @@ CBV CategoriesCache::Load(MwmContext const & context) const
 }
 
 // StreetsCache ------------------------------------------------------------------------------------
-StreetsCache::StreetsCache(::base::Cancellable const & cancellable)
+StreetsCache::StreetsCache(base::Cancellable const & cancellable)
   : CategoriesCache(ftypes::IsStreetChecker::Instance(), cancellable)
 {
 }
 
 // VillagesCache -----------------------------------------------------------------------------------
-VillagesCache::VillagesCache(::base::Cancellable const & cancellable)
+VillagesCache::VillagesCache(base::Cancellable const & cancellable)
   : CategoriesCache(ftypes::IsVillageChecker::Instance(), cancellable)
 {
 }
 
 // HotelsCache -------------------------------------------------------------------------------------
-HotelsCache::HotelsCache(::base::Cancellable const & cancellable)
+HotelsCache::HotelsCache(base::Cancellable const & cancellable)
   : CategoriesCache(ftypes::IsHotelChecker::Instance(), cancellable)
 {
 }

--- a/search/categories_cache.hpp
+++ b/search/categories_cache.hpp
@@ -19,13 +19,13 @@ class CategoriesCache
 {
 public:
   template <typename TypesSource>
-  CategoriesCache(TypesSource const & source, ::base::Cancellable const & cancellable)
+  CategoriesCache(TypesSource const & source, base::Cancellable const & cancellable)
     : m_cancellable(cancellable)
   {
     source.ForEachType([this](uint32_t type) { m_categories.Add(type); });
   }
 
-  CategoriesCache(std::vector<uint32_t> const & types, ::base::Cancellable const & cancellable)
+  CategoriesCache(std::vector<uint32_t> const & types, base::Cancellable const & cancellable)
     : m_cancellable(cancellable)
   {
     for (uint32_t type : types)
@@ -42,25 +42,25 @@ private:
   CBV Load(MwmContext const & context) const;
 
   CategoriesSet m_categories;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
   std::map<MwmSet::MwmId, CBV> m_cache;
 };
 
 class StreetsCache : public CategoriesCache
 {
 public:
-  StreetsCache(::base::Cancellable const & cancellable);
+  StreetsCache(base::Cancellable const & cancellable);
 };
 
 class VillagesCache : public CategoriesCache
 {
 public:
-  VillagesCache(::base::Cancellable const & cancellable);
+  VillagesCache(base::Cancellable const & cancellable);
 };
 
 class HotelsCache : public CategoriesCache
 {
 public:
-  HotelsCache(::base::Cancellable const & cancellable);
+  HotelsCache(base::Cancellable const & cancellable);
 };
 }  // namespace search

--- a/search/cities_boundaries_table.cpp
+++ b/search/cities_boundaries_table.cpp
@@ -44,7 +44,7 @@ bool CitiesBoundariesTable::Load()
     return true;
 
   MwmContext context(move(handle));
-  ::base::Cancellable const cancellable;
+  base::Cancellable const cancellable;
   auto const localities = CategoriesCache(LocalitiesSource{}, cancellable).Get(context);
 
   auto const & cont = context.m_value.m_cont;
@@ -84,7 +84,7 @@ bool CitiesBoundariesTable::Load()
   size_t boundary = 0;
   localities.ForEach([&](uint64_t fid) {
     ASSERT_LESS(boundary, all.size(), ());
-    m_table[::base::asserted_cast<uint32_t>(fid)] = move(all[boundary]);
+    m_table[base::asserted_cast<uint32_t>(fid)] = move(all[boundary]);
     ++boundary;
   });
   ASSERT_EQUAL(boundary, all.size(), ());

--- a/search/city_finder.hpp
+++ b/search/city_finder.hpp
@@ -27,7 +27,7 @@ public:
   FeatureID GetCityFeatureID(m2::PointD const & p);
 
 private:
-  ::base::Cancellable m_cancellable;
+  base::Cancellable m_cancellable;
   search::CitiesBoundariesTable m_unusedBoundaries;
   search::VillagesCache m_unusedCache;
   search::LocalityFinder m_finder;

--- a/search/common.hpp
+++ b/search/common.hpp
@@ -16,7 +16,7 @@ namespace search
 using QueryTokens = buffer_vector<strings::UniString, 32>;
 
 using Locales =
-    ::base::SafeSmallSet<static_cast<uint64_t>(CategoriesHolder::kMaxSupportedLocaleIndex) + 1>;
+    base::SafeSmallSet<static_cast<uint64_t>(CategoriesHolder::kMaxSupportedLocaleIndex) + 1>;
 
 /// Upper bound for max count of tokens for indexing and scoring.
 size_t constexpr kMaxNumTokens = 32;

--- a/search/features_layer_matcher.cpp
+++ b/search/features_layer_matcher.cpp
@@ -14,7 +14,7 @@ namespace search
 int constexpr kMaxApproxStreetDistanceM = 100;
 
 FeaturesLayerMatcher::FeaturesLayerMatcher(DataSource const & dataSource,
-                                           ::base::Cancellable const & cancellable)
+                                           base::Cancellable const & cancellable)
   : m_context(nullptr)
   , m_postcodes(nullptr)
   , m_reverseGeocoder(dataSource)

--- a/search/features_layer_matcher.hpp
+++ b/search/features_layer_matcher.hpp
@@ -61,7 +61,7 @@ public:
   static int constexpr kBuildingRadiusMeters = 50;
   static int constexpr kStreetRadiusMeters = 100;
 
-  FeaturesLayerMatcher(DataSource const & dataSource, ::base::Cancellable const & cancellable);
+  FeaturesLayerMatcher(DataSource const & dataSource, base::Cancellable const & cancellable);
   void SetContext(MwmContext * context);
   void SetPostcodes(CBV const * postcodes);
 
@@ -397,6 +397,6 @@ private:
   Cache<uint32_t, uint32_t> m_matchingStreetsCache;
 
   StreetVicinityLoader m_loader;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 };
 }  // namespace search

--- a/search/features_layer_path_finder.cpp
+++ b/search/features_layer_path_finder.cpp
@@ -82,7 +82,7 @@ bool MayHaveDelayedFeatures(FeaturesLayer const & layer)
 }
 }  // namespace
 
-FeaturesLayerPathFinder::FeaturesLayerPathFinder(::base::Cancellable const & cancellable)
+FeaturesLayerPathFinder::FeaturesLayerPathFinder(base::Cancellable const & cancellable)
   : m_cancellable(cancellable)
 {
 }
@@ -138,7 +138,7 @@ void FeaturesLayerPathFinder::FindReachableVerticesTopDown(
     parentGraph.emplace_back();
     FeaturesLayer parent(*layers[i]);
     if (i != layers.size() - 1)
-      ::base::SortUnique(reachable);
+      base::SortUnique(reachable);
     parent.m_sortedFeatures = &reachable;
 
     // The first condition is an optimization: it is enough to extract
@@ -202,7 +202,7 @@ void FeaturesLayerPathFinder::FindReachableVerticesBottomUp(
     parentGraph.emplace_front();
     FeaturesLayer child(*layers[i]);
     if (i != 0)
-      ::base::SortUnique(reachable);
+      base::SortUnique(reachable);
     child.m_sortedFeatures = &reachable;
     child.m_hasDelayedFeatures = (i == 0 && MayHaveDelayedFeatures(child));
 
@@ -216,7 +216,7 @@ void FeaturesLayerPathFinder::FindReachableVerticesBottomUp(
     first = false;
   }
 
-  ::base::SortUnique(lowestLevel);
+  base::SortUnique(lowestLevel);
 
   IntersectionResult result;
   for (auto const & id : lowestLevel)

--- a/search/features_layer_path_finder.hpp
+++ b/search/features_layer_path_finder.hpp
@@ -45,7 +45,7 @@ public:
     MODE_BOTTOM_UP
   };
 
-  FeaturesLayerPathFinder(::base::Cancellable const & cancellable);
+  FeaturesLayerPathFinder(base::Cancellable const & cancellable);
 
   template <typename TFn>
   void ForEachReachableVertex(FeaturesLayerMatcher & matcher,
@@ -92,7 +92,7 @@ private:
                                      std::vector<FeaturesLayer const *> const & layers,
                                      std::vector<IntersectionResult> & results);
 
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 
   static Mode m_mode;
 };

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -159,7 +159,7 @@ class LocalityScorerDelegate : public LocalityScorer::Delegate
 {
 public:
   LocalityScorerDelegate(MwmContext const & context, Geocoder::Params const & params,
-                         ::base::Cancellable const & cancellable)
+                         base::Cancellable const & cancellable)
     : m_context(context)
     , m_params(params)
     , m_cancellable(cancellable)
@@ -205,7 +205,7 @@ public:
 private:
   MwmContext const & m_context;
   Geocoder::Params const & m_params;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 
   Retrieval m_retrieval;
 
@@ -338,7 +338,7 @@ size_t OrderCountries(m2::PointD const & position, m2::RectD const & pivot, bool
 Geocoder::Geocoder(DataSource const & dataSource, storage::CountryInfoGetter const & infoGetter,
                    CategoriesHolder const & categories,
                    CitiesBoundariesTable const & citiesBoundaries, PreRanker & preRanker,
-                   VillagesCache & villagesCache, ::base::Cancellable const & cancellable)
+                   VillagesCache & villagesCache, base::Cancellable const & cancellable)
   : m_dataSource(dataSource)
   , m_infoGetter(infoGetter)
   , m_categories(categories)
@@ -428,7 +428,7 @@ void Geocoder::GoInViewport()
   vector<shared_ptr<MwmInfo>> infos;
   m_dataSource.GetMwmsInfo(infos);
 
-  ::base::EraseIf(infos, [this](shared_ptr<MwmInfo> const & info) {
+  base::EraseIf(infos, [this](shared_ptr<MwmInfo> const & info) {
     return !m_params.m_pivot.IsIntersect(info->m_bordersRect);
   });
 
@@ -794,7 +794,7 @@ void Geocoder::MatchCategories(BaseContext & ctx, bool aroundPivot)
   }
 
   auto emit = [&](uint64_t bit) {
-    auto const featureId = ::base::asserted_cast<uint32_t>(bit);
+    auto const featureId = base::asserted_cast<uint32_t>(bit);
     Model::Type type;
     if (!GetTypeInGeocoding(ctx, featureId, type))
       return;
@@ -1020,9 +1020,9 @@ void Geocoder::CreateStreetsLayerAndMatchLowerLayers(BaseContext & ctx,
   InitLayer(Model::TYPE_STREET, prediction.m_tokenRange, layer);
 
   vector<uint32_t> sortedFeatures;
-  sortedFeatures.reserve(::base::checked_cast<size_t>(prediction.m_features.PopCount()));
+  sortedFeatures.reserve(base::checked_cast<size_t>(prediction.m_features.PopCount()));
   prediction.m_features.ForEach([&sortedFeatures](uint64_t bit) {
-    sortedFeatures.push_back(::base::asserted_cast<uint32_t>(bit));
+    sortedFeatures.push_back(base::asserted_cast<uint32_t>(bit));
   });
   layer.m_sortedFeatures = &sortedFeatures;
 
@@ -1057,7 +1057,7 @@ void Geocoder::MatchPOIsAndBuildings(BaseContext & ctx, size_t curToken)
       if (m_filter->NeedToFilter(m_postcodes.m_features))
         filtered = m_filter->Filter(m_postcodes.m_features);
       filtered.ForEach([&](uint64_t bit) {
-        auto const featureId = ::base::asserted_cast<uint32_t>(bit);
+        auto const featureId = base::asserted_cast<uint32_t>(bit);
         Model::Type type;
         if (GetTypeInGeocoding(ctx, featureId, type))
         {
@@ -1098,7 +1098,7 @@ void Geocoder::MatchPOIsAndBuildings(BaseContext & ctx, size_t curToken)
 
     vector<uint32_t> features;
     m_postcodes.m_features.ForEach([&features](uint64_t bit) {
-      features.push_back(::base::asserted_cast<uint32_t>(bit));
+      features.push_back(base::asserted_cast<uint32_t>(bit));
     });
     layer.m_sortedFeatures = &features;
     return FindPaths(ctx);
@@ -1116,7 +1116,7 @@ void Geocoder::MatchPOIsAndBuildings(BaseContext & ctx, size_t curToken)
   // any.
   auto clusterize = [&](uint64_t bit)
   {
-    auto const featureId = ::base::asserted_cast<uint32_t>(bit);
+    auto const featureId = base::asserted_cast<uint32_t>(bit);
     Model::Type type;
     if (!GetTypeInGeocoding(ctx, featureId, type))
       return;
@@ -1169,7 +1169,7 @@ void Geocoder::MatchPOIsAndBuildings(BaseContext & ctx, size_t curToken)
         return !filtered.HasBit(bit);
       };
       for (auto & cluster : clusters)
-        ::base::EraseIf(cluster, noFeature);
+        base::EraseIf(cluster, noFeature);
 
       size_t curs[kNumClusters] = {};
       size_t ends[kNumClusters];
@@ -1177,7 +1177,7 @@ void Geocoder::MatchPOIsAndBuildings(BaseContext & ctx, size_t curToken)
         ends[i] = clusters[i].size();
       filtered.ForEach([&](uint64_t bit)
                        {
-                         auto const featureId = ::base::asserted_cast<uint32_t>(bit);
+                         auto const featureId = base::asserted_cast<uint32_t>(bit);
                          bool found = false;
                          for (size_t i = 0; i < kNumClusters && !found; ++i)
                          {
@@ -1275,7 +1275,7 @@ void Geocoder::FindPaths(BaseContext & ctx)
   sortedLayers.reserve(layers.size());
   for (auto const & layer : layers)
     sortedLayers.push_back(&layer);
-  sort(sortedLayers.begin(), sortedLayers.end(), ::base::LessBy(&FeaturesLayer::m_type));
+  sort(sortedLayers.begin(), sortedLayers.end(), base::LessBy(&FeaturesLayer::m_type));
 
   auto const & innermostLayer = *sortedLayers.front();
 
@@ -1404,7 +1404,7 @@ void Geocoder::MatchUnclassified(BaseContext & ctx, size_t curToken)
 
   auto emitUnclassified = [&](uint64_t bit)
   {
-    auto const featureId = ::base::asserted_cast<uint32_t>(bit);
+    auto const featureId = base::asserted_cast<uint32_t>(bit);
     Model::Type type;
     if (!GetTypeInGeocoding(ctx, featureId, type))
       return;

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -92,7 +92,7 @@ public:
   Geocoder(DataSource const & dataSource, storage::CountryInfoGetter const & infoGetter,
            CategoriesHolder const & categories, CitiesBoundariesTable const & citiesBoundaries,
            PreRanker & preRanker, VillagesCache & villagesCache,
-           ::base::Cancellable const & cancellable);
+           base::Cancellable const & cancellable);
   ~Geocoder();
 
   // Sets search query params.
@@ -251,7 +251,7 @@ private:
   HotelsCache m_hotelsCache;
   hotels_filter::HotelsFilter m_hotelsFilter;
 
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 
   // Geocoder params.
   Params m_params;

--- a/search/geometry_cache.cpp
+++ b/search/geometry_cache.cpp
@@ -14,7 +14,7 @@ double constexpr kCellEps = MercatorBounds::GetCellID2PointAbsEpsilon();
 }  // namespace
 
 // GeometryCache -----------------------------------------------------------------------------------
-GeometryCache::GeometryCache(size_t maxNumEntries, ::base::Cancellable const & cancellable)
+GeometryCache::GeometryCache(size_t maxNumEntries, base::Cancellable const & cancellable)
   : m_maxNumEntries(maxNumEntries), m_cancellable(cancellable)
 {
   CHECK_GREATER(m_maxNumEntries, 0, ());
@@ -31,7 +31,7 @@ void GeometryCache::InitEntry(MwmContext const & context, m2::RectD const & rect
 }
 
 // PivotRectsCache ---------------------------------------------------------------------------------
-PivotRectsCache::PivotRectsCache(size_t maxNumEntries, ::base::Cancellable const & cancellable,
+PivotRectsCache::PivotRectsCache(size_t maxNumEntries, base::Cancellable const & cancellable,
                                  double maxRadiusMeters)
   : GeometryCache(maxNumEntries, cancellable), m_maxRadiusMeters(maxRadiusMeters)
 {
@@ -59,7 +59,7 @@ CBV PivotRectsCache::Get(MwmContext const & context, m2::RectD const & rect, int
 
 // LocalityRectsCache ------------------------------------------------------------------------------
 LocalityRectsCache::LocalityRectsCache(size_t maxNumEntries,
-                                       ::base::Cancellable const & cancellable)
+                                       base::Cancellable const & cancellable)
   : GeometryCache(maxNumEntries, cancellable)
 {
 }

--- a/search/geometry_cache.hpp
+++ b/search/geometry_cache.hpp
@@ -49,7 +49,7 @@ protected:
 
   // |maxNumEntries| denotes the maximum number of rectangles that
   // will be cached for each mwm individually.
-  GeometryCache(size_t maxNumEntries, ::base::Cancellable const & cancellable);
+  GeometryCache(size_t maxNumEntries, base::Cancellable const & cancellable);
 
   template <typename TPred>
   pair<Entry &, bool> FindOrCreateEntry(MwmSet::MwmId const & id, TPred && pred)
@@ -76,13 +76,13 @@ protected:
 
   map<MwmSet::MwmId, deque<Entry>> m_entries;
   size_t const m_maxNumEntries;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
 };
 
 class PivotRectsCache : public GeometryCache
 {
 public:
-  PivotRectsCache(size_t maxNumEntries, ::base::Cancellable const & cancellable,
+  PivotRectsCache(size_t maxNumEntries, base::Cancellable const & cancellable,
                   double maxRadiusMeters);
 
   // GeometryCache overrides:
@@ -95,7 +95,7 @@ private:
 class LocalityRectsCache : public GeometryCache
 {
 public:
-  LocalityRectsCache(size_t maxNumEntries, ::base::Cancellable const & cancellable);
+  LocalityRectsCache(size_t maxNumEntries, base::Cancellable const & cancellable);
 
   // GeometryCache overrides:
   CBV Get(MwmContext const & context, m2::RectD const & rect, int scale) override;

--- a/search/keyword_matcher.cpp
+++ b/search/keyword_matcher.cpp
@@ -40,7 +40,7 @@ KeywordMatcher::Score KeywordMatcher::CalcScore(string const & name) const
 KeywordMatcher::Score KeywordMatcher::CalcScore(strings::UniString const & name) const
 {
   buffer_vector<strings::UniString, kMaxNumTokens> tokens;
-  SplitUniString(name, ::base::MakeBackInsertFunctor(tokens), Delimiters());
+  SplitUniString(name, base::MakeBackInsertFunctor(tokens), Delimiters());
 
   return CalcScore(tokens.data(), tokens.size());
 }

--- a/search/locality_scorer.cpp
+++ b/search/locality_scorer.cpp
@@ -178,7 +178,7 @@ void LocalityScorer::LeaveTopByNormAndRank(size_t limitUniqueIds, vector<ExLocal
     seen.insert(els[i].GetId());
   ASSERT_LESS_OR_EQUAL(seen.size(), limitUniqueIds, ());
 
-  ::base::EraseIf(els, [&](ExLocality const & el) { return seen.find(el.GetId()) == seen.cend(); });
+  base::EraseIf(els, [&](ExLocality const & el) { return seen.find(el.GetId()) == seen.cend(); });
 }
 
 void LocalityScorer::LeaveTopBySimilarityAndRank(size_t limit, vector<ExLocality> & els) const

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -243,7 +243,7 @@ void PreRanker::FilterForViewportSearch()
 {
   auto const & viewport = m_params.m_viewport;
 
-  ::base::EraseIf(m_results, [&viewport](PreRankerResult const & result) {
+  base::EraseIf(m_results, [&viewport](PreRankerResult const & result) {
     auto const & info = result.GetInfo();
     return !viewport.IsPointInside(info.m_center);
   });
@@ -288,7 +288,7 @@ void PreRanker::FilterForViewportSearch()
 
     if (m <= old)
     {
-      for (size_t i : ::base::RandomSample(old, m, m_rng))
+      for (size_t i : base::RandomSample(old, m, m_rng))
         results.push_back(m_results[bucket[i]]);
     }
     else
@@ -296,7 +296,7 @@ void PreRanker::FilterForViewportSearch()
       for (size_t i = 0; i < old; ++i)
         results.push_back(m_results[bucket[i]]);
 
-      for (size_t i : ::base::RandomSample(bucket.size() - old, m - old, m_rng))
+      for (size_t i : base::RandomSample(bucket.size() - old, m - old, m_rng))
         results.push_back(m_results[bucket[old + i]]);
     }
   }
@@ -308,7 +308,7 @@ void PreRanker::FilterForViewportSearch()
   else
   {
     m_results.clear();
-    for (size_t i : ::base::RandomSample(results.size(), BatchSize(), m_rng))
+    for (size_t i : base::RandomSample(results.size(), BatchSize(), m_rng))
       m_results.push_back(results[i]);
   }
 }

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -146,15 +146,15 @@ Processor::Processor(DataSource const & dataSource, CategoriesHolder const & cat
   : m_categories(categories)
   , m_infoGetter(infoGetter)
   , m_position(0, 0)
-  , m_villagesCache(static_cast<::base::Cancellable const &>(*this))
+  , m_villagesCache(static_cast<base::Cancellable const &>(*this))
   , m_citiesBoundaries(dataSource)
   , m_keywordsScorer(LanguageTier::LANGUAGE_TIER_COUNT)
   , m_ranker(dataSource, m_citiesBoundaries, infoGetter, m_keywordsScorer, m_emitter, categories,
-             suggests, m_villagesCache, static_cast<::base::Cancellable const &>(*this))
+             suggests, m_villagesCache, static_cast<base::Cancellable const &>(*this))
   , m_preRanker(dataSource, m_ranker)
   , m_geocoder(dataSource, infoGetter, categories, m_citiesBoundaries, m_preRanker, m_villagesCache,
-               static_cast<::base::Cancellable const &>(*this))
-  , m_bookmarksProcessor(m_emitter, static_cast<::base::Cancellable const &>(*this))
+               static_cast<base::Cancellable const &>(*this))
+  , m_bookmarksProcessor(m_emitter, static_cast<base::Cancellable const &>(*this))
 {
   // Current and input langs are to be set later.
   m_keywordsScorer.SetLanguages(
@@ -222,7 +222,7 @@ void Processor::SetQuery(string const & query)
   vector<strings::UniString> tokens;
   {
     search::DelimitersWithExceptions delims(vector<strings::UniChar>{'#'});
-    SplitUniString(NormalizeAndSimplifyString(query), ::base::MakeBackInsertFunctor(tokens), delims);
+    SplitUniString(NormalizeAndSimplifyString(query), base::MakeBackInsertFunctor(tokens), delims);
   }
 
   search::Delimiters delims;
@@ -237,7 +237,7 @@ void Processor::SetQuery(string const & query)
       // Splits |token| by hashtags, because all other delimiters are
       // already removed.
       subTokens.clear();
-      SplitUniString(token, ::base::MakeBackInsertFunctor(subTokens), delims);
+      SplitUniString(token, base::MakeBackInsertFunctor(subTokens), delims);
       if (subTokens.empty())
         continue;
 
@@ -280,7 +280,7 @@ void Processor::SetQuery(string const & query)
   if (!m_isCategorialRequest)
     ForEachCategoryType(tokenSlice, [&](size_t, uint32_t t) { m_preferredTypes.push_back(t); });
 
-  ::base::SortUnique(m_preferredTypes);
+  base::SortUnique(m_preferredTypes);
 }
 
 m2::PointD Processor::GetPivotPoint(bool viewportSearch) const
@@ -530,7 +530,7 @@ void Processor::InitParams(QueryParams & params) const
   }
 
   for (size_t i = 0; i < params.GetNumTokens(); ++i)
-    ::base::SortUnique(params.GetTypeIndices(i));
+    base::SortUnique(params.GetTypeIndices(i));
 
   m_keywordsScorer.ForEachLanguage(
       [&](int8_t lang) { params.GetLangs().Insert(static_cast<uint64_t>(lang)); });

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -53,7 +53,7 @@ class QueryParams;
 class Ranker;
 class ReverseGeocoder;
 
-class Processor : public ::base::Cancellable
+class Processor : public base::Cancellable
 {
 public:
   // Maximum result candidates count for each viewport/criteria.

--- a/search/query_params.hpp
+++ b/search/query_params.hpp
@@ -24,7 +24,7 @@ class QueryParams
 public:
   using String = strings::UniString;
   using TypeIndices = std::vector<uint32_t>;
-  using Langs = ::base::SafeSmallSet<StringUtf8Multilang::kMaxSupportedLanguages>;
+  using Langs = base::SafeSmallSet<StringUtf8Multilang::kMaxSupportedLanguages>;
 
   struct Token
   {

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -364,7 +364,7 @@ Ranker::Ranker(DataSource const & dataSource, CitiesBoundariesTable const & boun
                storage::CountryInfoGetter const & infoGetter, KeywordLangMatcher & keywordsScorer,
                Emitter & emitter, CategoriesHolder const & categories,
                vector<Suggest> const & suggests, VillagesCache & villagesCache,
-               ::base::Cancellable const & cancellable)
+               base::Cancellable const & cancellable)
   : m_reverseGeocoder(dataSource)
   , m_cancellable(cancellable)
   , m_keywordsScorer(keywordsScorer)
@@ -478,7 +478,7 @@ void Ranker::UpdateResults(bool lastUpdate)
   if (m_params.m_viewportSearch)
   {
     sort(m_tentativeResults.begin(), m_tentativeResults.end(),
-         ::base::LessBy(&RankerResult::GetDistanceToPivot));
+         base::LessBy(&RankerResult::GetDistanceToPivot));
   }
   else
   {
@@ -486,7 +486,7 @@ void Ranker::UpdateResults(bool lastUpdate)
     // but the model is lightweight enough and the slowdown
     // is negligible.
     sort(m_tentativeResults.rbegin(), m_tentativeResults.rend(),
-         ::base::LessBy(&RankerResult::GetLinearModelRank));
+         base::LessBy(&RankerResult::GetLinearModelRank));
     ProcessSuggestions(m_tentativeResults);
   }
 

--- a/search/ranker.hpp
+++ b/search/ranker.hpp
@@ -82,7 +82,7 @@ public:
          storage::CountryInfoGetter const & infoGetter, KeywordLangMatcher & keywordsScorer,
          Emitter & emitter, CategoriesHolder const & categories,
          std::vector<Suggest> const & suggests, VillagesCache & villagesCache,
-         ::base::Cancellable const & cancellable);
+         base::Cancellable const & cancellable);
   virtual ~Ranker() = default;
 
   void Init(Params const & params, Geocoder::Params const & geocoderParams);
@@ -126,7 +126,7 @@ private:
   Params m_params;
   Geocoder::Params m_geocoderParams;
   ReverseGeocoder const m_reverseGeocoder;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
   KeywordLangMatcher & m_keywordsScorer;
 
   mutable LocalityFinder m_localities;

--- a/search/ranking_utils.hpp
+++ b/search/ranking_utils.hpp
@@ -133,7 +133,7 @@ NameScore GetNameScore(std::string const & name, Slice const & slice)
     return NAME_SCORE_ZERO;
 
   std::vector<strings::UniString> tokens;
-  SplitUniString(NormalizeAndSimplifyString(name), ::base::MakeBackInsertFunctor(tokens), Delimiters());
+  SplitUniString(NormalizeAndSimplifyString(name), base::MakeBackInsertFunctor(tokens), Delimiters());
   return GetNameScore(tokens, slice);
 }
 

--- a/search/region_info_getter.cpp
+++ b/search/region_info_getter.cpp
@@ -64,7 +64,7 @@ string RegionInfoGetter::GetLocalizedFullName(storage::TCountryId const & id) co
   if (parts.size() > kMaxNumParts)
     parts.erase(parts.begin(), parts.end() - kMaxNumParts);
 
-  ::base::EraseIf(parts, [&](string const & s) { return s.empty(); });
+  base::EraseIf(parts, [&](string const & s) { return s.empty(); });
 
   if (!parts.empty())
     return strings::JoinStrings(parts, ", ");

--- a/search/retrieval.cpp
+++ b/search/retrieval.cpp
@@ -39,7 +39,7 @@ namespace
 class FeaturesCollector
 {
 public:
-  FeaturesCollector(::base::Cancellable const & cancellable, vector<uint64_t> & features)
+  FeaturesCollector(base::Cancellable const & cancellable, vector<uint64_t> & features)
     : m_cancellable(cancellable), m_features(features), m_counter(0)
   {
   }
@@ -57,7 +57,7 @@ public:
   inline void operator()(uint64_t feature) { m_features.push_back(feature); }
 
 private:
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
   vector<uint64_t> & m_features;
   uint32_t m_counter;
 };
@@ -107,7 +107,7 @@ private:
 
 unique_ptr<coding::CompressedBitVector> SortFeaturesAndBuildCBV(vector<uint64_t> && features)
 {
-  ::base::SortUnique(features);
+  base::SortUnique(features);
   return coding::CompressedBitVectorBuilder::FromBitPositions(move(features));
 }
 
@@ -199,7 +199,7 @@ bool MatchFeatureByPostcode(FeatureType & ft, TokenSlice const & slice)
 template <typename Value, typename DFA>
 unique_ptr<coding::CompressedBitVector> RetrieveAddressFeaturesImpl(
     Retrieval::TrieRoot<Value> const & root, MwmContext const & context,
-    ::base::Cancellable const & cancellable, SearchTrieRequest<DFA> const & request)
+    base::Cancellable const & cancellable, SearchTrieRequest<DFA> const & request)
 {
   EditedFeaturesHolder holder(context.GetId());
   vector<uint64_t> features;
@@ -223,7 +223,7 @@ unique_ptr<coding::CompressedBitVector> RetrieveAddressFeaturesImpl(
 template <typename Value>
 unique_ptr<coding::CompressedBitVector> RetrievePostcodeFeaturesImpl(
     Retrieval::TrieRoot<Value> const & root, MwmContext const & context,
-    ::base::Cancellable const & cancellable, TokenSlice const & slice)
+    base::Cancellable const & cancellable, TokenSlice const & slice)
 {
   EditedFeaturesHolder holder(context.GetId());
   vector<uint64_t> features;
@@ -245,7 +245,7 @@ unique_ptr<coding::CompressedBitVector> RetrievePostcodeFeaturesImpl(
 }
 
 unique_ptr<coding::CompressedBitVector> RetrieveGeometryFeaturesImpl(
-    MwmContext const & context, ::base::Cancellable const & cancellable, m2::RectD const & rect,
+    MwmContext const & context, base::Cancellable const & cancellable, m2::RectD const & rect,
     int scale)
 {
   EditedFeaturesHolder holder(context.GetId());
@@ -297,7 +297,7 @@ unique_ptr<Retrieval::TrieRoot<Value>> ReadTrie(MwmValue & value, ModelReaderPtr
 }
 }  // namespace
 
-Retrieval::Retrieval(MwmContext const & context, ::base::Cancellable const & cancellable)
+Retrieval::Retrieval(MwmContext const & context, base::Cancellable const & cancellable)
   : m_context(context)
   , m_cancellable(cancellable)
   , m_reader(context.m_value.m_cont.GetReader(SEARCH_INDEX_FILE_TAG))

--- a/search/retrieval.hpp
+++ b/search/retrieval.hpp
@@ -33,7 +33,7 @@ public:
   template<typename Value>
   using TrieRoot = trie::Iterator<ValueList<Value>>;
 
-  Retrieval(MwmContext const & context, ::base::Cancellable const & cancellable);
+  Retrieval(MwmContext const & context, base::Cancellable const & cancellable);
 
   // Following functions retrieve from the search index corresponding to
   // |value| all features matching to |request|.
@@ -62,7 +62,7 @@ private:
   unique_ptr<coding::CompressedBitVector> Retrieve(Args &&... args) const;
 
   MwmContext const & m_context;
-  ::base::Cancellable const & m_cancellable;
+  base::Cancellable const & m_cancellable;
   ModelReaderPtr m_reader;
 
   version::MwmTraits::SearchIndexFormat m_format;

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -64,7 +64,7 @@ void GetNearbyStreetsImpl(DataSource const & source, MwmSet::MwmId const & id,
 
   fillStreets(move(mwmHandle), rect, addStreet);
 
-  sort(streets.begin(), streets.end(), ::base::LessBy(&ReverseGeocoder::Street::m_distanceMeters));
+  sort(streets.begin(), streets.end(), base::LessBy(&ReverseGeocoder::Street::m_distanceMeters));
 }
 }  // namespace
 
@@ -79,7 +79,7 @@ void ReverseGeocoder::GetNearbyStreets(search::MwmContext & context, m2::PointD 
   auto const addStreet = [&center, &streets](FeatureType & ft) { AddStreet(ft, center, streets); };
 
   context.ForEachFeature(rect, addStreet);
-  sort(streets.begin(), streets.end(), ::base::LessBy(&Street::m_distanceMeters));
+  sort(streets.begin(), streets.end(), base::LessBy(&Street::m_distanceMeters));
 }
 
 void ReverseGeocoder::GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
@@ -240,7 +240,7 @@ void ReverseGeocoder::GetNearbyBuildings(m2::PointD const & center, vector<Build
   };
 
   m_dataSource.ForEachInRect(addBuilding, rect, kQueryScale);
-  sort(buildings.begin(), buildings.end(), ::base::LessBy(&Building::m_distanceMeters));
+  sort(buildings.begin(), buildings.end(), base::LessBy(&Building::m_distanceMeters));
 }
 
 // static

--- a/search/search_integration_tests/pre_ranker_test.cpp
+++ b/search/search_integration_tests/pre_ranker_test.cpp
@@ -55,7 +55,7 @@ public:
   TestRanker(DataSource & dataSource, storage::CountryInfoGetter & infoGetter,
              CitiesBoundariesTable const & boundariesTable, KeywordLangMatcher & keywordsScorer,
              Emitter & emitter, vector<Suggest> const & suggests, VillagesCache & villagesCache,
-             ::base::Cancellable const & cancellable, vector<PreRankerResult> & results)
+             base::Cancellable const & cancellable, vector<PreRankerResult> & results)
     : Ranker(dataSource, boundariesTable, infoGetter, keywordsScorer, emitter,
              GetDefaultCategories(), suggests, villagesCache, cancellable)
     , m_results(results)
@@ -88,7 +88,7 @@ class PreRankerTest : public SearchTest
 {
 public:
   vector<Suggest> m_suggests;
-  ::base::Cancellable m_cancellable;
+  base::Cancellable m_cancellable;
 };
 
 UNIT_CLASS_TEST(PreRankerTest, Smoke)
@@ -153,7 +153,7 @@ UNIT_CLASS_TEST(PreRankerTest, Smoke)
 
   preRanker.UpdateResults(true /* lastUpdate */);
 
-  TEST(all_of(emit.begin(), emit.end(), ::base::IdFunctor()), (emit));
+  TEST(all_of(emit.begin(), emit.end(), base::IdFunctor()), (emit));
   TEST(ranker.Finished(), ());
   TEST_EQUAL(results.size(), kBatchSize, ());
 

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -588,7 +588,7 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
   // Tests that postcode is added to the search index.
   {
     MwmContext context(m_dataSource.GetMwmHandleById(countryId));
-    ::base::Cancellable cancellable;
+    base::Cancellable cancellable;
 
     QueryParams params;
     {
@@ -607,7 +607,7 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
 
     FeaturesLoaderGuard loader(m_dataSource, countryId);
     FeatureType ft;
-    TEST(loader.GetFeatureByIndex(::base::checked_cast<uint32_t>(index), ft), ());
+    TEST(loader.GetFeatureByIndex(base::checked_cast<uint32_t>(index), ft), ());
 
     auto rule = ExactMatch(countryId, building31);
     TEST(rule->Matches(ft), ());

--- a/search/search_tests/bookmarks_processor_tests.cpp
+++ b/search/search_tests/bookmarks_processor_tests.cpp
@@ -57,7 +57,7 @@ public:
 
 protected:
   Emitter m_emitter;
-  ::base::Cancellable m_cancellable;
+  base::Cancellable m_cancellable;
   Processor m_processor;
 };
 

--- a/search/search_tests/house_detector_tests.cpp
+++ b/search/search_tests/house_detector_tests.cpp
@@ -406,7 +406,7 @@ UNIT_TEST(HS_MWMSearch)
       continue;
 
     vector<string> v;
-    strings::Tokenize(line, "|", ::base::MakeBackInsertFunctor(v));
+    strings::Tokenize(line, "|", base::MakeBackInsertFunctor(v));
 
     string key = GetStreetKey(v[0]);
     if (key.empty())

--- a/search/search_tests/locality_finder_test.cpp
+++ b/search/search_tests/locality_finder_test.cpp
@@ -24,7 +24,7 @@ class LocalityFinderTest : public generator::tests_support::TestWithClassificato
 
   FrozenDataSource m_dataSource;
 
-  ::base::Cancellable m_cancellable;
+  base::Cancellable m_cancellable;
   search::VillagesCache m_villagesCache;
   search::CitiesBoundariesTable m_boundariesTable;
 

--- a/search/search_tests/locality_scorer_test.cpp
+++ b/search/search_tests/locality_scorer_test.cpp
@@ -38,7 +38,7 @@ public:
 
     vector<UniString> tokens;
     Delimiters delims;
-    SplitUniString(NormalizeAndSimplifyString(query), ::base::MakeBackInsertFunctor(tokens), delims);
+    SplitUniString(NormalizeAndSimplifyString(query), base::MakeBackInsertFunctor(tokens), delims);
 
     if (lastTokenIsPrefix)
     {
@@ -90,7 +90,7 @@ public:
         }
       });
 
-      ::base::SortUnique(ids);
+      base::SortUnique(ids);
       ctx.m_features.emplace_back(coding::CompressedBitVectorBuilder::FromBitPositions(ids));
     }
 
@@ -99,7 +99,7 @@ public:
 
     vector<Locality> localities;
     m_scorer.GetTopLocalities(MwmSet::MwmId(), ctx, filter, limit, localities);
-    sort(localities.begin(), localities.end(), ::base::LessBy(&Locality::m_featureId));
+    sort(localities.begin(), localities.end(), base::LessBy(&Locality::m_featureId));
 
     Ids ids;
     for (auto const & locality : localities)
@@ -135,7 +135,7 @@ public:
       m_searchIndex.ForEachInNode(token, [&ids](uint32_t id) { ids.push_back(id); });
     }
 
-    ::base::SortUnique(ids);
+    base::SortUnique(ids);
     return CBV{coding::CompressedBitVectorBuilder::FromBitPositions(move(ids))};
   }
 

--- a/search/search_tests/mem_search_index_tests.cpp
+++ b/search/search_tests/mem_search_index_tests.cpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-using namespace search::base;
+using namespace search_base;
 using namespace search;
 using namespace std;
 using namespace strings;
@@ -58,7 +58,7 @@ public:
   vector<Id> StrictQuery(string const & query, string const & lang) const
   {
     auto prev = m_index.GetAllIds();
-    TEST(::base::IsSortedAndUnique(prev.cbegin(), prev.cend()), ());
+    TEST(base::IsSortedAndUnique(prev.cbegin(), prev.cend()), ());
 
     vector<UniString> tokens;
     NormalizeAndTokenizeString(query, tokens);
@@ -72,7 +72,7 @@ public:
       MatchFeaturesInTrie(request, m_index.GetRootIterator(),
                           [](Id const & /* id */) { return true; } /* filter */,
                           [&curr](Id const & id) { curr.push_back(id); } /* toDo */);
-      ::base::SortUnique(curr);
+      base::SortUnique(curr);
 
       vector<Id> intersection;
       set_intersection(prev.begin(), prev.end(), curr.begin(), curr.end(),

--- a/search/search_tests/ranking_tests.cpp
+++ b/search/search_tests/ranking_tests.cpp
@@ -25,7 +25,7 @@ NameScore GetScore(string const & name, string const & query, TokenRange const &
   QueryParams params;
 
   vector<UniString> tokens;
-  SplitUniString(NormalizeAndSimplifyString(query), ::base::MakeBackInsertFunctor(tokens), delims);
+  SplitUniString(NormalizeAndSimplifyString(query), base::MakeBackInsertFunctor(tokens), delims);
 
   if (!query.empty() && !delims(strings::LastUniChar(query)))
   {

--- a/search/search_tests/string_match_test.cpp
+++ b/search/search_tests/string_match_test.cpp
@@ -111,7 +111,7 @@ UNIT_TEST(StringSplit_Smoke)
     TEST_EQUAL(ToUtf8(s1), s, ());
 
     char const * arr[] = { "1", "2" };
-    SplitUniString(s1, ::base::MakeBackInsertFunctor(tokens), Delimiters());
+    SplitUniString(s1, base::MakeBackInsertFunctor(tokens), Delimiters());
     TestEqual(tokens, arr);
   }
 }

--- a/search/search_tests/text_index_tests.cpp
+++ b/search/search_tests/text_index_tests.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 using namespace platform::tests_support;
-using namespace search::base;
+using namespace search_base;
 using namespace search;
 using namespace std;
 
@@ -35,7 +35,7 @@ namespace
 // Prepend several bytes to serialized indexes in order to check the relative offsets.
 size_t const kSkip = 10;
 
-search::base::MemTextIndex BuildMemTextIndex(vector<string> const & docsCollection)
+search_base::MemTextIndex BuildMemTextIndex(vector<string> const & docsCollection)
 {
   MemTextIndex memIndex;
 
@@ -72,7 +72,7 @@ template <typename Index, typename Token>
 void TestForEach(Index const & index, Token const & token, vector<uint32_t> const & expected)
 {
   vector<uint32_t> actual;
-  index.ForEachPosting(token, ::base::MakeBackInsertFunctor(actual));
+  index.ForEachPosting(token, base::MakeBackInsertFunctor(actual));
   TEST_EQUAL(actual, expected, (token));
 };
 }  // namespace
@@ -81,8 +81,6 @@ namespace search
 {
 UNIT_TEST(TextIndex_Smoke)
 {
-  using Token = base::Token;
-
   vector<Token> const docsCollection = {
       "a b c",
       "a c",
@@ -151,8 +149,6 @@ UNIT_TEST(TextIndex_UniString)
 
 UNIT_TEST(TextIndex_Merging)
 {
-  using Token = base::Token;
-
   // todo(@m) Arrays? docsCollection[i]
   vector<Token> const docsCollection1 = {
       "a b c",

--- a/search/street_vicinity_loader.cpp
+++ b/search/street_vicinity_loader.cpp
@@ -50,7 +50,7 @@ void StreetVicinityLoader::LoadStreet(uint32_t featureId, Street & street)
     return;
 
   vector<m2::PointD> points;
-  feature.ForEachPoint(::base::MakeBackInsertFunctor(points), FeatureType::BEST_GEOMETRY);
+  feature.ForEachPoint(base::MakeBackInsertFunctor(points), FeatureType::BEST_GEOMETRY);
   ASSERT(!points.empty(), ());
 
   for (auto const & point : points)
@@ -58,7 +58,7 @@ void StreetVicinityLoader::LoadStreet(uint32_t featureId, Street & street)
 
   covering::CoveringGetter coveringGetter(street.m_rect, covering::ViewportWithLowLevels);
   auto const & intervals = coveringGetter.Get<RectId::DEPTH_LEVELS>(m_scale);
-  m_context->ForEachIndex(intervals, m_scale, ::base::MakeBackInsertFunctor(street.m_features));
+  m_context->ForEachIndex(intervals, m_scale, base::MakeBackInsertFunctor(street.m_features));
 
   street.m_calculator = make_unique<ProjectionOnStreetCalculator>(points);
 }

--- a/search/streets_matcher.cpp
+++ b/search/streets_matcher.cpp
@@ -45,7 +45,7 @@ void StreetsMatcher::Go(BaseContext const & ctx, FeaturesFilter const & filter,
       unique(predictions.begin(), predictions.end(), base::EqualsBy(&Prediction::m_hash)),
       predictions.end());
 
-  sort(predictions.rbegin(), predictions.rend(), ::base::LessBy(&Prediction::m_prob));
+  sort(predictions.rbegin(), predictions.rend(), base::LessBy(&Prediction::m_prob));
   while (predictions.size() > kMaxNumOfImprobablePredictions &&
          predictions.back().m_prob < kTailProbability)
   {

--- a/search/suggest.cpp
+++ b/search/suggest.cpp
@@ -19,7 +19,7 @@ void GetSuggestion(RankerResult const & res, string const & query, QueryTokens c
   // Splits result's name.
   search::Delimiters delims;
   vector<strings::UniString> tokens;
-  SplitUniString(NormalizeAndSimplifyString(res.GetName()), ::base::MakeBackInsertFunctor(tokens), delims);
+  SplitUniString(NormalizeAndSimplifyString(res.GetName()), base::MakeBackInsertFunctor(tokens), delims);
 
   // Finds tokens that are already present in the input query.
   vector<bool> tokensMatched(tokens.size());

--- a/search/tracer.cpp
+++ b/search/tracer.cpp
@@ -63,7 +63,7 @@ string DebugPrint(Tracer::Parse const & parse)
 vector<Tracer::Parse> Tracer::GetUniqueParses() const
 {
   auto parses = m_parses;
-  ::base::SortUnique(parses);
+  base::SortUnique(parses);
   return parses;
 }
 }  // namespace search

--- a/search/utils.cpp
+++ b/search/utils.cpp
@@ -60,13 +60,13 @@ vector<uint32_t> GetCategoryTypes(string const & name, string const & locale,
   locales.Insert(static_cast<uint64_t>(code));
 
   vector<strings::UniString> tokens;
-  SplitUniString(search::NormalizeAndSimplifyString(name), ::base::MakeBackInsertFunctor(tokens),
+  SplitUniString(search::NormalizeAndSimplifyString(name), base::MakeBackInsertFunctor(tokens),
                  search::Delimiters());
 
   FillCategories(QuerySliceOnRawStrings<vector<strings::UniString>>(tokens, {} /* prefix */),
                  locales, categories, types);
 
-  ::base::SortUnique(types);
+  base::SortUnique(types);
   return types;
 }
 
@@ -121,7 +121,7 @@ void ForEachOfTypesInRect(DataSource const & dataSource, vector<uint32_t> const 
     features = filter.Filter(features);
     MwmSet::MwmId mwmId(info);
     features.ForEach([&fn, &mwmId](uint64_t bit) {
-      fn(FeatureID(mwmId, ::base::asserted_cast<uint32_t>(bit)));
+      fn(FeatureID(mwmId, base::asserted_cast<uint32_t>(bit)));
     });
   }
 }

--- a/search/utils.hpp
+++ b/search/utils.hpp
@@ -61,7 +61,7 @@ template <typename ToDo>
 void ForEachCategoryTypeFuzzy(StringSliceBase const & slice, Locales const & locales,
                               CategoriesHolder const & categories, ToDo && todo)
 {
-  using Iterator = trie::MemTrieIterator<strings::UniString, ::base::VectorValues<uint32_t>>;
+  using Iterator = trie::MemTrieIterator<strings::UniString, base::VectorValues<uint32_t>>;
 
   auto const & trie = categories.GetNameToTypesTrie();
   Iterator const iterator(trie.GetRootIterator());
@@ -100,7 +100,7 @@ bool FillCategories(QuerySliceOnRawStrings<T> const & slice, Locales const & loc
 
         std::vector<QueryParams::String> categoryTokens;
         SplitUniString(search::NormalizeAndSimplifyString(categorySynonym.m_name),
-                       ::base::MakeBackInsertFunctor(categoryTokens), search::Delimiters());
+                       base::MakeBackInsertFunctor(categoryTokens), search::Delimiters());
 
         if (slice.Size() != categoryTokens.size())
           return;


### PR DESCRIPTION
Both versions -- the old and the new -- slightly violate the style guide:
on the one hand, the namespaces should match the basenames of
their directories; on the other hand, inner namespaces coinciding
with top-level ones should be avoided.

Hopefully, the new version is slightly clearer.