### PR TITLE
Succint warning suppressing.

### DIFF
--- a/3party/succinct/CMakeLists.txt
+++ b/3party/succinct/CMakeLists.txt
@@ -4,7 +4,11 @@ add_definitions(-DLTC_NO_ROLC)
 
 include_directories(src/headers)
 
-add_clang_compile_options("-Wno-unused-local-typedef")
+add_clang_compile_options(
+  "-Wno-unused-local-typedef"
+  "-Wno-unused-private-field"
+)
+
 add_gcc_compile_options("-Wno-unused-local-typedef")
 
 set(


### PR DESCRIPTION
При сборке возникал вот такой warning:

/Users/vladimirbykoyanko/src_github/omim/3party/succinct/util.hpp:205:21: warning: private field 'm_buffer' is not used [-Wunused-private-field]
        const char* m_buffer;

@mpimenov @tatiana-yan PTAL