### PR TITLE
unused-private-field clang warning fix in includes.

### DIFF
--- a/indexer/features_offsets_table.hpp
+++ b/indexer/features_offsets_table.hpp
@@ -10,8 +10,17 @@
 #include <string>
 #include <vector>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
 #include "3party/succinct/elias_fano.hpp"
 #include "3party/succinct/mapper.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 namespace platform
 {


### PR DESCRIPTION
Поправил waring, который часто возникал при сборке.

@tatiana-yan @mpimenov PTAL