### PR TITLE
[generator] Virtual destructor of an abstract class was forgotten.

### DIFF
--- a/generator/regions.hpp
+++ b/generator/regions.hpp
@@ -98,6 +98,8 @@ private:
 class ToStringPolicyInterface
 {
 public:
+  virtual ~ToStringPolicyInterface() = default;
+
   virtual std::string ToString(Node::PtrList const & nodePtrList) = 0;
 };
 


### PR DESCRIPTION
Забыли виртуальный деструктор абстрактного базового класса.

@maksimandrianov @mpimenov PTAL