### PR TITLE
[search][generator] Replace diet:vegetarian, diet:vegan with cuisine

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -15,3 +15,10 @@ amenity=swimming_pool : leisure=swimming_pool
 building=garages : building=garage
 amenity=gym : leisure=fitness_centre
 amenity=sauna : leisure=sauna
+
+diet:vegetarian=yes : cuisine=vegetarian
+diet:vegetarian=only : cuisine=vegetarian
+diet=vegetarian : cuisine=vegetarian
+diet:vegan=yes : cuisine=vegan
+diet:vegan=only : cuisine=vegan
+diet=vegan : cuisine=vegan


### PR DESCRIPTION
Думаю поддержку диет надо всё же делать через tag_replace, потому что добавлять в классификатор все варианты (diet:vegetarian=yes, diet:vegetarian=only, diet=vegetarian) излишне, надо их как-то объединять.

Для тех diet, которых нет в cuisine можно завести соответствующие cuisine (с ключом cuisine они тоже встречаются но редко).