### PR TITLE
Routing integration test fixes

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -75,7 +75,7 @@ double CalcMaxSpeed(NumMwmIds const & numMwmIds,
         vehicleModelFactory.GetVehicleModelForCountry(country)->GetMaxWeightSpeed();
     maxSpeed = max(maxSpeed, mwmMaxSpeed);
   });
-  CHECK_GREATER(maxSpeed, 0.0, ());
+  CHECK_GREATER(maxSpeed, 0.0, ("Most likely |numMwmIds| is empty."));
   return maxSpeed;
 }
 

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), ());
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 357.0, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 268.3, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.
@@ -82,7 +82,7 @@ UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
-      MercatorBounds::FromLatLon(55.68927, 37.70356), 7726.0);
+      MercatorBounds::FromLatLon(55.68927, 37.70356), 7075.0);
 }
 
 // No pass through service road in Russia

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -320,7 +320,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 15144.6);
+    integration::TestRouteTime(route, 16203.6);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest)
@@ -334,7 +334,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 730.);
+    integration::TestRouteTime(route, 1000.0);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
@@ -409,7 +409,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(60.23884, 29.71603), {0.0, 0.0},
-        MercatorBounds::FromLatLon(60.28975, 29.79399), 11618.1);
+        MercatorBounds::FromLatLon(60.29083, 29.80333), 16679.2);
   }
 
   // Test of decreasing speed factor on roads with bad cover.

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -91,24 +91,19 @@ namespace
         MercatorBounds::FromLatLon(55.77691, 37.70428), 150.);
   }
 
-  // Geometry unpacking test.
   UNIT_TEST(RussiaFerryToCrimeaLoadCrossGeometryTest)
   {
-    // Forward
-    TRouteResult route =
-        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                    MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
-                                    MercatorBounds::FromLatLon(45.36479, 36.62194));
-    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
-    CHECK(route.first, ());
-    integration::TestRoutePointsNumber(*route.first, 62 /* expected points number */);
-    // And backward case
-    route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                        MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
-                                        MercatorBounds::FromLatLon(45.34123, 36.67679));
-    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
-    CHECK(route.first, ());
-    integration::TestRoutePointsNumber(*route.first, 50 /* expected points number */);
+    // To Crimea.
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(45.34123, 36.67679), {0., 0.},
+        MercatorBounds::FromLatLon(45.36479, 36.62194), 5365.0);
+
+    // From Crimea.
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents<VehicleType::Car>(),
+        MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
+        MercatorBounds::FromLatLon(45.34123, 36.67679), 5400.0);
   }
 
   UNIT_TEST(PriceIslandLoadCrossGeometryTest)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -17,7 +17,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(19.20789, 30.50663), {0., 0.},
-        MercatorBounds::FromLatLon(19.17289, 30.47315), 10283.7);
+        MercatorBounds::FromLatLon(19.17289, 30.47315), 7645.0);
   }
 
   UNIT_TEST(MoscowKashirskoeShosseCrossing)
@@ -94,7 +94,6 @@ namespace
   // Geometry unpacking test.
   UNIT_TEST(RussiaFerryToCrimeaLoadCrossGeometryTest)
   {
-    size_t constexpr kExpectedPointsNumber = 50;
     // Forward
     TRouteResult route =
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
@@ -102,14 +101,14 @@ namespace
                                     MercatorBounds::FromLatLon(45.36479, 36.62194));
     TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
-    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
+    integration::TestRoutePointsNumber(*route.first, 62 /* expected points number */);
     // And backward case
     route = integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                         MercatorBounds::FromLatLon(45.36479, 36.62194), {0., 0.},
                                         MercatorBounds::FromLatLon(45.34123, 36.67679));
     TEST_EQUAL(route.second, RouterResultCode::NoError, ());
     CHECK(route.first, ());
-    integration::TestRoutePointsNumber(*route.first, kExpectedPointsNumber);
+    integration::TestRoutePointsNumber(*route.first, 50 /* expected points number */);
   }
 
   UNIT_TEST(PriceIslandLoadCrossGeometryTest)

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -240,6 +240,7 @@ namespace integration
         CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);
     RouterResultCode const result = routeResult.second;
     TEST_EQUAL(result, RouterResultCode::NoError, ());
+    CHECK(routeResult.first, ());
     TestRouteLength(*routeResult.first, expectedRouteMeters, relativeError);
   }
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -960,9 +960,8 @@ UNIT_TEST(RussiaMoscowMinskia2TurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 // This test on getting correct (far enough) outgoing turn point (result of method GetPointForTurn())


### PR DESCRIPTION
После обновления до карты 2018.09.11 и после изменения изменений связанных с учетом дорожных фичь нужно поправить интеграционные тесты. Данный PR делает это.

Обновление карты до 2018.09.11
RussiaMoscowMinskia2TurnTest
![image](https://user-images.githubusercontent.com/1768114/45949010-e0df5380-c002-11e8-823e-3d529adde1cf.png)

StrangeCaseInAfrica
![image](https://user-images.githubusercontent.com/1768114/45949056-14ba7900-c003-11e8-8a42-0a05117a5147.png)
![image](https://user-images.githubusercontent.com/1768114/45949041-040a0300-c003-11e8-87c5-2cc02949a288.png)

RussiaFerryToCrimeaLoadCrossGeometryTest
![image](https://user-images.githubusercontent.com/1768114/45949087-2dc32a00-c003-11e8-95a4-c98e83b4354a.png)
![image](https://user-images.githubusercontent.com/1768114/45949090-3287de00-c003-11e8-98e5-2955be9bed7f.png)

Учет городских фичь (в городе движение медленнее, кроме магистралей):
NetherlandsAmsterdamBicycleYes
![image](https://user-images.githubusercontent.com/1768114/45949545-e5a50700-c004-11e8-97b4-8470b6347525.png)

RussiaMoscowKashirskoe16ToCapLongRoute
![image](https://user-images.githubusercontent.com/1768114/45949562-f2c1f600-c004-11e8-967d-9cb0005607ab.png)

RussiaSmolenskRussiaMoscowTimeTest
![image](https://user-images.githubusercontent.com/1768114/45949799-db373d00-c005-11e8-806e-b8b308a0eb47.png)

RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest
![image](https://user-images.githubusercontent.com/1768114/45949812-e68a6880-c005-11e8-8a24-b1f50728ad01.png)

BelarusSlonimStartNearZeroEdgeTest
![image](https://user-images.githubusercontent.com/1768114/45950183-649b3f00-c007-11e8-9512-e47ba31fe20b.png)

@tatiana-yan @vmihaylenko PTAL