### PR TITLE
Removing storage integration test on migration.

### DIFF
--- a/storage/storage_integration_tests/migrate_tests.cpp
+++ b/storage/storage_integration_tests/migrate_tests.cpp
@@ -35,77 +35,90 @@ UNIT_TEST(StorageFastMigrationTests)
   TEST_GREATER_OR_EQUAL(s.GetCurrentDataVersion(), version, ());
 }
 
-UNIT_TEST(StorageMigrationTests)
-{
-  TCountriesVec const kOldCountries = {"Estonia"};
-  TCountriesVec const kNewCountries = {"Estonia_East", "Estonia_West"};
-  TCountriesVec const kPrefetchCountries = {"Russia_Moscow"};
+// This test on migration from big square and two component mwms to smaller square and one component
+// ones. According to |kMinRequiredVersion| constant at local_country_file_utils.cpp this migration
+// took place at 02.03.2016. For the time being this migration is not supported and is not tested.
+// The test bellow fails because when a prefeched storage, to download map or maps according to
+// current position, is created with code
+// |m_prefetchStorage.reset(new Storage(COUNTRIES_FILE, "migrate"));| does not create
+// the directory ./migrate/ now. And late in this test creation a directory
+// ./migrate/YYMMDD/ with Platform::MkDirChecked() fails because there's no ./migrate/
+// directory.
+// @TODO The code on the migration mentioned above should be removed. When this code is removed
+// test below should be removed as well. Until code on the code is not removed from the project
+// this test should be kept in case we decide to recover this feature.
 
-  WritableDirChanger writableDirChanger(kMapTestDir);
-
-  settings::Set("DisableFastMigrate", true);
-
-  Framework f(kFrameworkParams);
-  auto & s = f.GetStorage();
-
-  auto statePrefetchChanged = [&](TCountryId const & id)
-  {
-    Status const nextStatus = f.GetStorage().GetPrefetchStorage()->CountryStatusEx(id);
-    LOG_SHORT(LINFO, (id, "status :", nextStatus));
-    if (!f.GetStorage().GetPrefetchStorage()->IsDownloadInProgress())
-    {
-      LOG_SHORT(LINFO, ("All prefetched. Ready to migrate."));
-      testing::StopEventLoop();
-    }
-  };
-
-  auto stateChanged = [&](TCountryId const & id)
-  {
-    if (!f.GetStorage().IsDownloadInProgress())
-    {
-      LOG_SHORT(LINFO, ("All downloaded. Check consistency."));
-      testing::StopEventLoop();
-    }
-  };
-
-  auto progressChanged = [](TCountryId const & id, TLocalAndRemoteSize const & sz)
-  {
-    LOG_SHORT(LINFO, (id, "downloading progress:", sz));
-  };
-
-  // Somewhere in Moscow, Russia
-  ms::LatLon curPos(55.7, 37.7);
-
-  s.SetDownloadingUrlsForTesting({"http://direct.mapswithme.com/"});
-  s.Subscribe(stateChanged, progressChanged);
-  for (auto const & countryId : kOldCountries)
-    s.DownloadNode(countryId);
-
-  // Wait for downloading complete.
-  testing::RunEventLoop();
-
-  TEST_EQUAL(s.GetDownloadedFilesCount(), kOldCountries.size(), ());
-  for (auto const & countryId : kOldCountries)
-    TEST(s.IsNodeDownloaded(countryId), (countryId));
-
-  TEST_NOT_EQUAL(f.PreMigrate(curPos, statePrefetchChanged, progressChanged), kInvalidCountryId, ());
-  TEST(f.GetStorage().GetPrefetchStorage()->IsDownloadInProgress(), ("Empty queue"));
-  // Wait for downloading complete.
-  testing::RunEventLoop();
-
-  TEST_EQUAL(s.GetDownloadedFilesCount(), kPrefetchCountries.size(), ());
-  for (auto const & countryId : kPrefetchCountries)
-    TEST(s.GetPrefetchStorage()->IsNodeDownloaded(countryId), (countryId));
-
-  f.Migrate();
-  // Wait for downloading complete.
-  testing::RunEventLoop();
-
-  TEST_EQUAL(s.GetDownloadedFilesCount(), kPrefetchCountries.size() + kNewCountries.size(), ());
-  for (auto const & countryId : kNewCountries)
-    TEST(s.IsNodeDownloaded(countryId), (countryId));
-  for (auto const & countryId : kPrefetchCountries)
-    TEST(s.IsNodeDownloaded(countryId), (countryId));
-
-  s.DeleteAllLocalMaps();
-}
+//UNIT_TEST(StorageMigrationTests)
+//{
+//  TCountriesVec const kOldCountries = {"Estonia"};
+//  TCountriesVec const kNewCountries = {"Estonia_East", "Estonia_West"};
+//  TCountriesVec const kPrefetchCountries = {"Russia_Moscow"};
+//
+//  WritableDirChanger writableDirChanger(kMapTestDir);
+//
+//  settings::Set("DisableFastMigrate", true);
+//
+//  Framework f(kFrameworkParams);
+//  auto & s = f.GetStorage();
+//
+//  auto statePrefetchChanged = [&](TCountryId const & id)
+//  {
+//    Status const nextStatus = f.GetStorage().GetPrefetchStorage()->CountryStatusEx(id);
+//    LOG_SHORT(LINFO, (id, "status :", nextStatus));
+//    if (!f.GetStorage().GetPrefetchStorage()->IsDownloadInProgress())
+//    {
+//      LOG_SHORT(LINFO, ("All prefetched. Ready to migrate."));
+//      testing::StopEventLoop();
+//    }
+//  };
+//
+//  auto stateChanged = [&](TCountryId const & id)
+//  {
+//    if (!f.GetStorage().IsDownloadInProgress())
+//    {
+//      LOG_SHORT(LINFO, ("All downloaded. Check consistency."));
+//      testing::StopEventLoop();
+//    }
+//  };
+//
+//  auto progressChanged = [](TCountryId const & id, TLocalAndRemoteSize const & sz)
+//  {
+//    LOG_SHORT(LINFO, (id, "downloading progress:", sz));
+//  };
+//
+//  // Somewhere in Moscow, Russia
+//  ms::LatLon curPos(55.7, 37.7);
+//
+//  s.SetDownloadingUrlsForTesting({"http://direct.mapswithme.com/"});
+//  s.Subscribe(stateChanged, progressChanged);
+//  for (auto const & countryId : kOldCountries)
+//    s.DownloadNode(countryId);
+//
+//  // Wait for downloading complete.
+//  testing::RunEventLoop();
+//
+//  TEST_EQUAL(s.GetDownloadedFilesCount(), kOldCountries.size(), ());
+//  for (auto const & countryId : kOldCountries)
+//    TEST(s.IsNodeDownloaded(countryId), (countryId));
+//
+//  TEST_NOT_EQUAL(f.PreMigrate(curPos, statePrefetchChanged, progressChanged), kInvalidCountryId, ());
+//  TEST(f.GetStorage().GetPrefetchStorage()->IsDownloadInProgress(), ("Empty queue"));
+//  // Wait for downloading complete.
+//  testing::RunEventLoop();
+//
+//  TEST_EQUAL(s.GetDownloadedFilesCount(), kPrefetchCountries.size(), ());
+//  for (auto const & countryId : kPrefetchCountries)
+//    TEST(s.GetPrefetchStorage()->IsNodeDownloaded(countryId), (countryId));
+//
+//  f.Migrate();
+//  // Wait for downloading complete.
+//  testing::RunEventLoop();
+//
+//  TEST_EQUAL(s.GetDownloadedFilesCount(), kPrefetchCountries.size() + kNewCountries.size(), ());
+//  for (auto const & countryId : kNewCountries)
+//    TEST(s.IsNodeDownloaded(countryId), (countryId));
+//  for (auto const & countryId : kPrefetchCountries)
+//    TEST(s.IsNodeDownloaded(countryId), (countryId));
+//
+//  s.DeleteAllLocalMaps();
+//}


### PR DESCRIPTION
Изучил вопрос с падение storage_integration_tests. У нас сейчас падает StorageMigrationTests + некоторое кол-во из остальных тестов. Каждый раз разный набор упавших тестов. Причина в том, что если обращаться к дайрект или к продакшен серверам из под корпоративной сети и закачивать большие объемы, то иногда (раз в несколько карт) происходят сбои в закачке. Что-то вроде: `NSURLConnection finished with error - code -1009` (полный лог ниже).

План действий:
1. Комментируем StorageMigrationTests и оставляем подробный комментарий. Он на миграцию с больших mwm на маленькие. Она не поддерживается и не тестируется и не работает давно. По хорошему ее надо выпиливать и вместе с ней этот тест.

2. Пробуем собрать и запустить storage_integration_tests на удаленном linux сервере maps.me5. Должны пройти по идее.

3. Убираем storage_integration_tests из JTALL команды и делаем для них отдельную команду по аналогии с routing_integation_tests: JTSIT

@vicpopov рассчитываю на твою помощь с п-том 3.

@tatiana-yan @vmihaylenko @vicpopov PTAL

```
/Users/vladimirbykoyanko/src_github/omim/cmake-build-debug/storage_integration_tests --filter=.*SmallMwms_3levels_Test.*
Running storage_3levels_tests.cpp::SmallMwms_3levels_Test
Settings path: ./data/settings.ini
Loaded countries list for version: 160301
Tracking Reporter started
There is no cached user stats info in settings
Exception while reading file: ./data/index.json reason: Reader::OpenException /Users/vladimirbykoyanko/src_github/omim/coding/internal/file_data.cpp:57, "./data/index.json; Read; No such file or directory"
Can't open default localization file. pathToJson is countries-strings/default.json/localize.json FileAbsentException /Users/vladimirbykoyanko/src_github/omim/platform/platform.cpp:131, "File countries-strings/default.json/localize.json doesn't exist in the scope wrf Have been looking in:
 ./data/map-tests/
./data/
./data/"
New preferred locale: en
New preferred locale: ru
Can't find World map file.
Can't load cities boundaries
Found file: World in directory: 
Found file: WorldCoasts_obsolete in directory: 
Loaded countries list for version: 180911
Loaded countries list for version: 180911
Exception while reading file: ./data/index.json reason: Reader::OpenException /Users/vladimirbykoyanko/src_github/omim/coding/internal/file_data.cpp:57, "./data/index.json; Read; No such file or directory"
Can't open default localization file. pathToJson is countries-strings/default.json/localize.json FileAbsentException /Users/vladimirbykoyanko/src_github/omim/platform/platform.cpp:131, "File countries-strings/default.json/localize.json doesn't exist in the scope wrf Have been looking in:
 ./data/map-tests/
./data/
./data/"
New preferred locale: en
New preferred locale: ru
Can't find World map file.
Can't load cities boundaries
Found file: World in directory: 
Found file: WorldCoasts in directory: 
Loading map: World
Loading map: WorldCoasts
System languages: ru-RU|en-RU
Editor initialized
Invalid attempt to disable traffic manager, it's already disabled , doing nothing.
2018-10-01 11:42:10.946882+0300 storage_integration_tests[11512:316714] MessageTracer: load_domain_whitelist_search_tree:73: Search tree file's format version number (0) is not supported
2018-10-01 11:42:10.946917+0300 storage_integration_tests[11512:316714] MessageTracer: Falling back to default whitelist
Loaded cities boundaries
2018-10-01 11:42:49.877454+0300 storage_integration_tests[11512:316773] TIC TCP Conn Failed [6:0x7fbf2285bc80]: 1:50 Err(50)
2018-10-01 11:42:49.877808+0300 storage_integration_tests[11512:316773] Task <105D62B1-3885-4A85-86FD-ADDC4DD19616>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:42:49.877857+0300 storage_integration_tests[11512:316774] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_Baden-Wurttemberg_Regierungsbezirk%20Stuttgart_Stuttgart.mwm failed to download chunk number 80
./data/map-tests/180911/Germany_Baden-Wurttemberg_Regierungsbezirk Stuttgart_Stuttgart.mwm.ready HttpRequest error: -1009
2018-10-01 11:43:09.676881+0300 storage_integration_tests[11512:316773] TIC TCP Conn Failed [9:0x7fbf0d408600]: 1:50 Err(50)
2018-10-01 11:43:09.677407+0300 storage_integration_tests[11512:316773] Task <D22FBD52-F645-4B2C-A3EB-A5C17C5316BC>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:43:09.677506+0300 storage_integration_tests[11512:318425] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_Berlin.mwm failed to download chunk number 76
./data/map-tests/180911/Germany_Berlin.mwm.ready HttpRequest error: -1009
2018-10-01 11:43:17.226455+0300 storage_integration_tests[11512:316806] TIC TCP Conn Failed [11:0x7fbf22940590]: 1:50 Err(50)
2018-10-01 11:43:17.226842+0300 storage_integration_tests[11512:316806] Task <E0EB202C-7C7F-4E94-9A00-498A5E8D2B99>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:43:17.226916+0300 storage_integration_tests[11512:316774] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_Brandenburg_South.mwm failed to download chunk number 8
./data/map-tests/180911/Germany_Brandenburg_South.mwm.ready HttpRequest error: -1009
2018-10-01 11:45:42.771312+0300 storage_integration_tests[11512:323803] TIC TCP Conn Failed [26:0x7fbf0d52c740]: 1:50 Err(50)
2018-10-01 11:45:42.771749+0300 storage_integration_tests[11512:323803] Task <06C93A35-DAED-4DBB-8739-6152FF31273D>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:45:42.771851+0300 storage_integration_tests[11512:320884] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_Lower%20Saxony_Bremen_Munster.mwm failed to download chunk number 57
./data/map-tests/180911/Germany_Lower Saxony_Bremen_Munster.mwm.ready HttpRequest error: -1009
2018-10-01 11:46:01.570706+0300 storage_integration_tests[11512:320884] TIC TCP Conn Failed [29:0x7fbf0d732ef0]: 1:50 Err(50)
2018-10-01 11:46:01.571225+0300 storage_integration_tests[11512:320884] Task <223AF36B-F3E4-4560-877E-F4CDA020A08F>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:46:01.571321+0300 storage_integration_tests[11512:320885] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_Lower%20Saxony_Oldenburg.mwm failed to download chunk number 8
./data/map-tests/180911/Germany_Lower Saxony_Oldenburg.mwm.ready HttpRequest error: -1009
2018-10-01 11:47:15.866005+0300 storage_integration_tests[11512:330537] TIC TCP Conn Failed [38:0x7fbf1efe18d0]: 1:50 Err(50)
2018-10-01 11:47:15.866405+0300 storage_integration_tests[11512:330537] Task <697CE1D7-F6AF-401E-A11E-06D2CF76602D>.<0> HTTP load failed (error code: -1009 [1:50])
2018-10-01 11:47:15.866552+0300 storage_integration_tests[11512:330538] NSURLConnection finished with error - code -1009
Connection failed The Internet connection appears to be offline.
Thread for url http://direct.mapswithme.com/mac/180911/Germany_North%20Rhine-Westphalia_Regierungsbezirk%20Koln_Aachen.mwm failed to download chunk number 20
./data/map-tests/180911/Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Aachen.mwm.ready HttpRequest error: -1009
FAILED
storage_integration_tests/storage_3levels_tests.cpp:76 TEST(attrs.m_status == NodeStatus::OnDisk) Error OnDisk 
Tracking Reporter finished
Test took 547501 ms

1  tests failed:
storage_3levels_tests.cpp::SmallMwms_3levels_Test
Some tests FAILED.

Process finished with exit code 1
```