### PR TITLE
[routing] New speeds in car model and quality tests.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -300,7 +300,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 15250.8);
+    integration::TestRouteTime(route, 15001.2);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest)
@@ -314,7 +314,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 1059.2);
+    integration::TestRouteTime(route, 945.4);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
@@ -381,23 +381,5 @@ namespace
                                     MercatorBounds::FromLatLon(53.09271, 25.3467));
     RouterResultCode const result = routeResult.second;
     TEST_EQUAL(result, RouterResultCode::NoError, ());
-  }
-
-  // Test of decreasing speed factor on roads with bad cover.
-  UNIT_TEST(RussiaLenOblSpeedFactorsTest)
-  {
-    integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(),
-        MercatorBounds::FromLatLon(60.23884, 29.71603), {0.0, 0.0},
-        MercatorBounds::FromLatLon(60.29083, 29.80333), 16679.2);
-  }
-
-  // Test of decreasing speed factor on roads with bad cover.
-  UNIT_TEST(RussiaMosOblSpeedFactorsTest)
-  {
-    integration::CalculateRouteAndTestRouteLength(
-        integration::GetVehicleComponents<VehicleType::Car>(),
-        MercatorBounds::FromLatLon(55.93843, 36.02782), {0., 0.},
-        MercatorBounds::FromLatLon(55.9375, 36.04195), 4819.1);
   }
 }  // namespace

--- a/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
@@ -48,4 +48,77 @@ UNIT_TEST(RoutingQuality_USAOklahoma)
                      {{{35.39912, -97.57622}}} /* reference track */),
        ());
 }
+
+UNIT_TEST(RoutingQuality_IranSouth)
+{
+  TEST(CheckCarRoute({32.45088, 51.76419} /* start */, {32.97067, 51.50399} /* finish */,
+                     {{{32.67021, 51.64323}, {32.68752, 51.63387}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_EindhovenNetherlands)
+{
+  TEST(CheckCarRoute({50.91974, 5.33535} /* start */, {51.92532, 5.49066} /* finish */,
+                     {{{51.40579, 5.45578}, {51.44273, 5.42748}, {51.50230, 5.47485}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_GeteborgasSweden)
+{
+  TEST(CheckCarRoute({57.77064, 11.88079} /* start */, {57.71231, 11.93157} /* finish */,
+                     {{{57.74912, 11.87343}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_CigilTurkey)
+{
+  TEST(CheckCarRoute({38.48175, 27.12952} /* start */, {38.47485, 27.07437} /* finish */,
+                     {{{38.4898049, 27.1016266}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_KatowicePoland)
+{
+  TEST(CheckCarRoute({50.37282, 18.75667} /* start */, {50.83499, 19.14612} /* finish */,
+                     {{{50.422229, 19.04746}, {50.48831, 19.21423}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_KrasnoyarskBratsk)
+{
+  TEST(CheckCarRoute({56.009, 92.873} /* start */, {56.163, 101.611} /* finish */,
+                     {{{55.89285, 97.99953}, {54.59928, 100.60402}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_VoronezhSochi)
+{
+  TEST(CheckCarRoute({51.65487, 39.21293} /* start */, {43.58547, 39.72311} /* finish */,
+                     {{{46.14169, 39.85306}, {45.17069, 39.10869},
+                       {45.02157, 39.12510}, {44.54344, 38.95853}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_BerlinkaWarsawPoland)
+{
+  TEST(CheckCarRoute({54.41616, 20.05675} /* start */, {52.18937, 20.94026} /* finish */,
+                     {{{54.24278, 19.66106}, {54.13679, 19.45166},
+                       {54.06452, 19.62416}, {53.69769, 19.98204},
+                       {53.11194, 20.40002}, {52.62966, 20.38488}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_LenOblBadPaving)
+{
+  TEST(CheckCarRoute({60.23884, 29.71603} /* start */, {60.29083, 29.80333} /* finish */,
+                     {{{60.2510134, 29.790209}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(RoutingQuality_MosOblBadPaving)
+{
+  TEST(CheckCarRoute({55.93849, 36.02792} /* start */, {55.93566, 36.05074} /* finish */,
+                     {{{55.92321, 36.04630}}} /* reference track */),
+       ());
+}
 }  // namespace

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -21,18 +21,18 @@ using SpeedKMpH = VehicleModel::SpeedKMpH;
 //   https://wiki.openstreetmap.org/wiki/Key:highway
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
 //                                                      in city            out city
-InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(115.37), SpeedKMpH(115.37));
-InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(60.0),   SpeedKMpH(60.0));
-InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(80.0),   SpeedKMpH(100.0));
-InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(50.0),   SpeedKMpH(50.0));
-InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(60.0),   SpeedKMpH(90.0));
-InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(30.0),   SpeedKMpH(60.0));
-InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(45.0),   SpeedKMpH(72.23));
-InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(50.0));
-InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(40.0),   SpeedKMpH(62.63));
+InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8), SpeedKMpH(123.4));
+InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2));
+InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2));
+InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2));
+InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2));
+InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8));
+InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3));
+InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0));
+InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5));
 InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0));
 InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0));
-InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(25.0),   SpeedKMpH(51.09));
+InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0));
 InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0));
 InOutCitySpeedKMpH const         kSpeedLivingStreetKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
 InOutCitySpeedKMpH const                 kSpeedRoadKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));


### PR DESCRIPTION
Удалил RussiaMosOblSpeedFactorsTest, потому, что он проверяет довольно странный кейс: мы ведем по highway-tertiary с unpaved-bad и огромным крюком вместо highway-path с unpaved-bad по прямой.

Коэффициенты взяты из трэк аналайзера путем усреднения скоростей по разным типам. Данные взяты из логов за 2 месяца.