### PR TITLE
Added rendering optimizations for Metal

### DIFF
--- a/drape/gl_includes.hpp
+++ b/drape/gl_includes.hpp
@@ -3,9 +3,11 @@
 #include "std/target_os.hpp"
 
 #if defined(OMIM_OS_IPHONE)
+  #define GL_SILENCE_DEPRECATION
   #include <OpenGLES/ES2/glext.h>
   #include <OpenGLES/ES3/gl.h>
 #elif defined(OMIM_OS_MAC)
+  #define GL_SILENCE_DEPRECATION
   #include <OpenGL/glext.h>
   #include <OpenGL/gl3.h>
 #elif defined(OMIM_OS_WINDOWS)

--- a/drape/graphics_context.hpp
+++ b/drape/graphics_context.hpp
@@ -7,12 +7,14 @@
 
 namespace dp
 {
-enum ClearBits: uint32_t
+enum ClearBits : uint32_t
 {
   ColorBit = 1,
   DepthBit = 1 << 1,
   StencilBit = 1 << 2
 };
+  
+uint32_t constexpr kClearBitsStoreAll = ClearBits::ColorBit | ClearBits::DepthBit | ClearBits::StencilBit;
 
 enum class TestFunction : uint8_t
 {
@@ -65,9 +67,12 @@ public:
   virtual ApiVersion GetApiVersion() const = 0;
   virtual std::string GetRendererName() const = 0;
   virtual std::string GetRendererVersion() const = 0;
+  
+  virtual void PushDebugLabel(std::string const & label) = 0;
+  virtual void PopDebugLabel() = 0;
 
   virtual void SetClearColor(Color const & color) = 0;
-  virtual void Clear(uint32_t clearBits) = 0;
+  virtual void Clear(uint32_t clearBits, uint32_t storeBits) = 0;
   virtual void Flush() = 0;
   virtual void SetViewport(uint32_t x, uint32_t y, uint32_t w, uint32_t h) = 0;
   virtual void SetDepthTestEnabled(bool enabled) = 0;
@@ -76,5 +81,6 @@ public:
   virtual void SetStencilFunction(StencilFace face, TestFunction stencilFunction) = 0;
   virtual void SetStencilActions(StencilFace face, StencilAction stencilFailAction,
                                  StencilAction depthFailAction, StencilAction passAction) = 0;
+  virtual void SetStencilReferenceValue(uint32_t stencilReferenceValue) = 0;
 };
 }  // namespace dp

--- a/drape/metal/metal_base_context.hpp
+++ b/drape/metal/metal_base_context.hpp
@@ -38,8 +38,11 @@ public:
   std::string GetRendererName() const override;
   std::string GetRendererVersion() const override;
   
+  void PushDebugLabel(std::string const & label) override;
+  void PopDebugLabel() override;
+  
   void SetClearColor(Color const & color) override;
-  void Clear(uint32_t clearBits) override;
+  void Clear(uint32_t clearBits, uint32_t storeBits) override;
   void Flush() override {}
   void SetViewport(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
   void SetDepthTestEnabled(bool enabled) override;
@@ -48,6 +51,7 @@ public:
   void SetStencilFunction(StencilFace face, TestFunction stencilFunction) override;
   void SetStencilActions(StencilFace face, StencilAction stencilFailAction,
                          StencilAction depthFailAction, StencilAction passAction) override;
+  void SetStencilReferenceValue(uint32_t stencilReferenceValue) override { m_stencilReferenceValue = stencilReferenceValue; }
   
   id<MTLDevice> GetMetalDevice() const;
   id<MTLRenderCommandEncoder> GetCommandEncoder() const;
@@ -81,6 +85,8 @@ protected:
   id<MTLRenderCommandEncoder> m_currentCommandEncoder;
   
   MetalCleaner m_cleaner;
+  
+  uint32_t m_stencilReferenceValue = 1;
 };
 }  // namespace metal
 }  // namespace dp

--- a/drape/oglcontext.cpp
+++ b/drape/oglcontext.cpp
@@ -87,8 +87,10 @@ void OGLContext::SetClearColor(dp::Color const & color)
   GLFunctions::glClearColor(color.GetRedF(), color.GetGreenF(), color.GetBlueF(), color.GetAlphaF());
 }
 
-void OGLContext::Clear(uint32_t clearBits)
+void OGLContext::Clear(uint32_t clearBits, uint32_t storeBits)
 {
+  UNUSED_VALUE(storeBits);
+  
   glConst glBits = 0;
   if (clearBits & ClearBits::ColorBit)
     glBits |= gl_const::GLColorBit;

--- a/drape/oglcontext.hpp
+++ b/drape/oglcontext.hpp
@@ -12,9 +12,12 @@ public:
   std::string GetRendererName() const override;
   std::string GetRendererVersion() const override;
   void ApplyFramebuffer(std::string const & framebufferLabel) override {}
+  
+  void PushDebugLabel(std::string const & label) override {}
+  void PopDebugLabel() override {}
 
   void SetClearColor(dp::Color const & color) override;
-  void Clear(uint32_t clearBits) override;
+  void Clear(uint32_t clearBits, uint32_t storeBits) override;
   void Flush() override;
   void SetViewport(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
   void SetDepthTestEnabled(bool enabled) override;
@@ -23,5 +26,8 @@ public:
   void SetStencilFunction(StencilFace face, TestFunction stencilFunction) override;
   void SetStencilActions(StencilFace face, StencilAction stencilFailAction, StencilAction depthFailAction,
                          StencilAction passAction) override;
+  
+  // Do not use custom stencil reference value in OpenGL rendering.
+  void SetStencilReferenceValue(uint32_t stencilReferenceValue) override {}
 };
 }  // namespace dp

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -161,7 +161,8 @@ private:
   };
   // Render part of scene
   void Render2dLayer(ScreenBase const & modelView);
-  void Render3dLayer(ScreenBase const & modelView, bool useFramebuffer);
+  void PreRender3dLayer(ScreenBase const & modelView);
+  void Render3dLayer(ScreenBase const & modelView);
   void RenderOverlayLayer(ScreenBase const & modelView);
   void RenderNavigationOverlayLayer(ScreenBase const & modelView);
   void RenderUserMarksLayer(ScreenBase const & modelView, DepthLayer layerId);

--- a/drape_frontend/render_state_extension.hpp
+++ b/drape_frontend/render_state_extension.hpp
@@ -49,4 +49,26 @@ public:
 
 extern DepthLayer GetDepthLayer(dp::RenderState const & state);
 extern dp::RenderState CreateRenderState(gpu::Program program, DepthLayer depthLayer);
+
+inline std::string DebugPrint(DepthLayer layer)
+{
+  switch (layer)
+  {
+  case DepthLayer::GeometryLayer: return "GeometryLayer";
+  case DepthLayer::Geometry3dLayer: return "Geometry3dLayer";
+  case DepthLayer::UserLineLayer: return "UserLineLayer";
+  case DepthLayer::OverlayLayer: return "OverlayLayer";
+  case DepthLayer::LocalAdsMarkLayer: return "LocalAdsMarkLayer";
+  case DepthLayer::TransitSchemeLayer: return "TransitSchemeLayer";
+  case DepthLayer::UserMarkLayer: return "UserMarkLayer";
+  case DepthLayer::NavigationLayer: return "NavigationLayer";
+  case DepthLayer::TransitMarkLayer: return "TransitMarkLayer";
+  case DepthLayer::RoutingMarkLayer: return "RoutingMarkLayer";
+  case DepthLayer::SearchMarkLayer: return "SearchMarkLayer";
+  case DepthLayer::GuiLayer: return "GuiLayer";
+  case DepthLayer::LayersCount: CHECK(false, ("Try to output LayersCount"));
+  }
+  CHECK(false, ("Unknown layer"));
+  return {};
+}
 }  // namespace df

--- a/drape_frontend/transit_scheme_builder.cpp
+++ b/drape_frontend/transit_scheme_builder.cpp
@@ -543,7 +543,7 @@ void TransitSchemeBuilder::GenerateShapes(ref_ptr<dp::GraphicsContext> context, 
 {
   MwmSchemeData const & scheme = m_schemes[mwmId];
 
-  uint32_t const kBatchSize = 5000;
+  uint32_t const kBatchSize = 65000;
   dp::Batcher batcher(kBatchSize, kBatchSize);
   {
     dp::SessionGuard guard(context, batcher, [this, &mwmId, &scheme](dp::RenderState const & state,

--- a/drape_frontend/transit_scheme_renderer.cpp
+++ b/drape_frontend/transit_scheme_renderer.cpp
@@ -187,7 +187,7 @@ void TransitSchemeRenderer::RenderLinesCaps(ref_ptr<dp::GraphicsContext> context
                                             ScreenBase const & screen,
                                             FrameValues const & frameValues, float pixelHalfWidth)
 {
-  context->Clear(dp::ClearBits::DepthBit);
+  context->Clear(dp::ClearBits::DepthBit, dp::kClearBitsStoreAll);
   for (auto & renderData : m_linesCapsRenderData)
   {
     ref_ptr<dp::GpuProgram> program = mng->GetProgram(renderData.m_state.GetProgram<gpu::Program>());
@@ -232,7 +232,7 @@ void TransitSchemeRenderer::RenderMarkers(ref_ptr<dp::GraphicsContext> context,
                                           ScreenBase const & screen,
                                           FrameValues const & frameValues, float pixelHalfWidth)
 {
-  context->Clear(dp::ClearBits::DepthBit);
+  context->Clear(dp::ClearBits::DepthBit, dp::kClearBitsStoreAll);
   for (auto & renderData : m_markersRenderData)
   {
     auto program = mng->GetProgram(renderData.m_state.GetProgram<gpu::Program>());

--- a/iphone/Maps/Classes/MetalContextFactory.mm
+++ b/iphone/Maps/Classes/MetalContextFactory.mm
@@ -40,7 +40,7 @@ public:
   }
   
   void SetClearColor(dp::Color const & color) override {}
-  void Clear(uint32_t clearBits) override {}
+  void Clear(uint32_t clearBits, uint32_t storeBits) override {}
   void Flush() override {}
   void SetDepthTestEnabled(bool enabled) override {}
   void SetDepthTestFunction(dp::TestFunction depthFunction) override {}

--- a/shaders/Metal/map.metal
+++ b/shaders/Metal/map.metal
@@ -384,7 +384,7 @@ fragment CapJoinFragment_Output fsCapJoin(const CapJoinFragment_T in [[stage_in]
   if (out.color.a < 0.001)
     out.depth = 1.0;
   else
-    out.depth = in.position.z;
+    out.depth = in.position.z * in.position.w;
   
   return out;
 }
@@ -638,7 +638,7 @@ fragment ColoredSymbolOut_T fsColoredSymbol(const ColoredSymbolFragment_T in [[s
   if (finalColor.a == 0.0)
     out.depth = 1.0;
   else
-    out.depth = in.position.z;
+    out.depth = in.position.z * in.position.w;
   
   out.color = finalColor;
   return out;
@@ -828,7 +828,7 @@ fragment UserMarkOut_T fsUserMark(const UserMarkFragment_T in [[stage_in]],
   if (finalColor.a < 0.001)
     out.depth = 1.0;
   else
-    out.depth = in.position.z;
+    out.depth = in.position.z * in.position.w;
   out.color = finalColor;
   return out;
 }

--- a/shaders/Metal/traffic.metal
+++ b/shaders/Metal/traffic.metal
@@ -199,7 +199,7 @@ fragment TrafficCircleOut_T fsTrafficCircle(const TrafficCircleFragment_T in [[s
   if (color.a < 0.001)
     out.depth = 1.0;
   else
-    out.depth = in.position.z;
+    out.depth = in.position.z * in.position.w;
   out.color = color;
   return out;
 }

--- a/shaders/Metal/transit.metal
+++ b/shaders/Metal/transit.metal
@@ -146,7 +146,7 @@ fragment TransitCircleOut_T fsTransitCircle(const TransitCircleFragment_T in [[s
   if (finalColor.a < 0.001)
     out.depth = 1.0;
   else
-    out.depth = in.position.z;
+    out.depth = in.position.z * in.position.w;
   
   out.color = finalColor;
   

--- a/xcode/drape/drape.xcodeproj/project.pbxproj
+++ b/xcode/drape/drape.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"U_DISABLE_RENAMING=1",
+					DEBUG_DRAPE_XCODE,
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/xcode/drape_frontend/drape_frontend.xcodeproj/project.pbxproj
+++ b/xcode/drape_frontend/drape_frontend.xcodeproj/project.pbxproj
@@ -959,6 +959,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"U_DISABLE_RENAMING=1",
+					DEBUG_DRAPE_XCODE,
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(OMIM_ROOT)",

--- a/xcode/shaders/shaders.xcodeproj/project.pbxproj
+++ b/xcode/shaders/shaders.xcodeproj/project.pbxproj
@@ -729,6 +729,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				MTL_OPTIMIZATION_LEVEL = 0;
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = Debug;
@@ -736,6 +738,8 @@
 		4598438121394BE000F8CAB2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MTL_FAST_MATH = YES;
+				MTL_OPTIMIZATION_LEVEL = 3;
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = Release;
@@ -743,6 +747,8 @@
 		4598438221394BE000F8CAB2 /* Production Full */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MTL_FAST_MATH = YES;
+				MTL_OPTIMIZATION_LEVEL = 3;
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = "Production Full";

--- a/xcode/shaders/shaders.xcodeproj/project.pbxproj
+++ b/xcode/shaders/shaders.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		4598438021394BE000F8CAB2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = Debug;


### PR DESCRIPTION
Many small improvements:
1. Suppressed OpenGL deprecation warnings for Mac OS Mojavi
2. Added small debug marks
3. Fixed Performance issues with attachments load/store
4. Frame optimization by reorganizing buildings rendering (buildings rendering does not intercept main frame rendering)
5. Optimized SMAA for Metal (by using custom stencil reference value)
6. Fixed bug with depth writing in Metal
7. Reduced number of DrawCall's in underground layer rendering