### PR TITLE
Fixed crash in editor

### DIFF
--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -24,6 +24,8 @@
 #include "std/string.hpp"
 #include "std/vector.hpp"
 
+#include <atomic>
+
 namespace editor
 {
 namespace testing
@@ -267,6 +269,8 @@ private:
   shared_ptr<editor::Notes> m_notes;
 
   unique_ptr<editor::StorageBase> m_storage;
+  
+  std::atomic<bool> m_isUploadingNow;
 
   DECLARE_THREAD_CHECKER(MainThreadChecker);
 };  // class Editor


### PR DESCRIPTION
1. Загрузка правок использует GetOriginalFeature, которая использует FeaturesLoaderGuard. Если параллельно идет обновление карт, которое успевает закончится во время загрузки правок, то прилетает OnMapDeregistered и происходит крэш по CHECK_THREAD_CHECKER(MainThreadChecker, (""));
так как OnMapDeregistered вызывается не с главного потока.
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5bb39b70f8b88c29633fb8af/sessions/latest
Исправил при помощи репостинга таски на главный поток.

2. Избавился от future, так как есть другие (ранее пропущенные) run-on-gui-thread, которые также упадут на Android