### PR TITLE
Airport codes to search

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -299,3 +299,18 @@ string MetadataTagProcessorImpl::ValidateAndFormat_wikipedia(string v) const
   replace(normalized.begin() + colonIndex, normalized.end(), '_', ' ');
   return normalized;
 }
+
+string MetadataTagProcessorImpl::ValidateAndFormat_airport_iata(string const & v) const
+{
+  if (v.size() != 3)
+    return {};
+
+  auto str = v;
+  for (auto & c : str)
+  {
+    if (!isalpha(c))
+      return {};
+    c = toupper(c);
+  }
+  return str;
+}

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -36,6 +36,7 @@ struct MetadataTagProcessorImpl
   std::string ValidateAndFormat_price_rate(std::string const & v) const;
   std::string ValidateAndFormat_sponsored_id(std::string const & v) const;
   std::string ValidateAndFormat_rating(std::string const & v) const;
+  std::string ValidateAndFormat_airport_iata(std::string const & v) const;
 
 protected:
   FeatureParams & m_params;
@@ -99,6 +100,7 @@ public:
     case Metadata::FMD_RATING: valid = ValidateAndFormat_rating(v); break;
     case Metadata::FMD_BANNER_URL: valid = ValidateAndFormat_url(v); break;
     case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
+    case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
     case Metadata::FMD_TEST_ID:
     case Metadata::FMD_COUNT: CHECK(false, ("FMD_COUNT can not be used as a type."));
     }

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -290,6 +290,13 @@ public:
     if (types.Empty())
       return;
 
+    if (ftypes::IsAirportChecker::Instance()(types))
+    {
+      string const iata = f.GetMetadata().Get(feature::Metadata::FMD_AIRPORT_IATA);
+      if (!iata.empty())
+        inserter(StringUtf8Multilang::kDefaultCode, iata);
+    }
+
     Classificator const & c = classif();
 
     vector<uint32_t> categoryTypes;

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -96,6 +96,8 @@ bool Metadata::TypeFromString(string const & k, Metadata::EType & outType)
     outType = Metadata::FMD_BANNER_URL;
   else if (k == "level")
     outType = Metadata::FMD_LEVEL;
+  else if (k == "iata")
+    outType = Metadata::FMD_AIRPORT_IATA;
   else
     return false;
 
@@ -189,12 +191,13 @@ string ToString(feature::Metadata::EType type)
   case Metadata::FMD_MIN_HEIGHT: return "min_height";
   case Metadata::FMD_DENOMINATION: return "denomination";
   case Metadata::FMD_BUILDING_LEVELS: return "building:levels";
+  case Metadata::FMD_TEST_ID: return "test_id";
   case Metadata::FMD_SPONSORED_ID: return "ref:sponsored";
   case Metadata::FMD_PRICE_RATE: return "price_rate";
   case Metadata::FMD_RATING: return "rating:sponsored";
   case Metadata::FMD_BANNER_URL: return "banner_url";
   case Metadata::FMD_LEVEL: return "level";
-  case Metadata::FMD_TEST_ID: return "test_id";
+  case Metadata::FMD_AIRPORT_IATA: return "iata";
   case Metadata::FMD_COUNT: CHECK(false, ("FMD_COUNT can not be used as a type."));
   };
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -127,6 +127,7 @@ public:
     FMD_RATING = 26,
     FMD_BANNER_URL = 27,
     FMD_LEVEL = 28,
+    FMD_AIRPORT_IATA = 29,
     FMD_COUNT
   };
 

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -149,11 +149,12 @@ std::vector<Props> MetadataToProps(std::vector<T> const & metadata)
     case Metadata::FMD_HEIGHT:
     case Metadata::FMD_MIN_HEIGHT:
     case Metadata::FMD_DENOMINATION:
+    case Metadata::FMD_TEST_ID:
     case Metadata::FMD_SPONSORED_ID:
     case Metadata::FMD_PRICE_RATE:
     case Metadata::FMD_RATING:
     case Metadata::FMD_BANNER_URL:
-    case Metadata::FMD_TEST_ID:
+    case Metadata::FMD_AIRPORT_IATA:
     case Metadata::FMD_COUNT:
       break;
       // Please add new cases when compiler issues an "unhandled switch case" warning here.


### PR DESCRIPTION
В этом PR добавление кодов аэропортов в метадату и индексирование в поиске.

Дальше по плану:
- лучший учёт в поиске в рантайме (не только вытаскивать фичи из индекса, но и вытаскивать при ранжировании airport_iata из метадаты для сравнения с запросом)
- добавить международные аэропорты в world (их около 400 штук).
- поддержать не только тип aeroway aerodrome international (этот тип уже есть у нас в данных), но и aerodrome:type international
- вывод кода аэропорта в placepage, результаты поиска