### PR TITLE
[release 84]  RoutingManager race codition fix which leads to leaving a route on the map.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -441,7 +441,7 @@ void RoutingManager::RemoveRoute(bool deactivateFollowing)
     df::DrapeEngineLockGuard lock(m_drapeEngine);
     if (lock)
     {
-      lock_guard<mutex> l(m_drapeSubroutesMutex);
+      lock_guard<mutex> lockSubroutes(m_drapeSubroutesMutex);
       for (auto const & subrouteId : m_drapeSubroutes)
         lock.Get()->RemoveSubroute(subrouteId, false /* deactivateFollowing */);
     }
@@ -1345,7 +1345,7 @@ void RoutingManager::SetSubroutesVisibility(bool visible)
   if (!lock)
     return;
 
-  lock_guard<mutex> l(m_drapeSubroutesMutex);
+  lock_guard<mutex> lockSubroutes(m_drapeSubroutesMutex);
   for (auto const & subrouteId : m_drapeSubroutes)
     lock.Get()->SetSubrouteVisibility(subrouteId, visible);
 }

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -438,11 +438,11 @@ void RoutingManager::RemoveRoute(bool deactivateFollowing)
   }
   else
   {
-    auto const subroutes = GetSubrouteIds();
     df::DrapeEngineLockGuard lock(m_drapeEngine);
     if (lock)
     {
-      for (auto const & subrouteId : subroutes)
+      lock_guard<mutex> l(m_drapeSubroutesMutex);
+      for (auto const & subrouteId : m_drapeSubroutes)
         lock.Get()->RemoveSubroute(subrouteId, false /* deactivateFollowing */);
     }
   }
@@ -1339,20 +1339,13 @@ TransitRouteInfo RoutingManager::GetTransitRouteInfo() const
   return m_transitRouteInfo;
 }
 
-vector<dp::DrapeID> RoutingManager::GetSubrouteIds() const
-{
-  lock_guard<mutex> lock(m_drapeSubroutesMutex);
-  return m_drapeSubroutes;
-}
-
 void RoutingManager::SetSubroutesVisibility(bool visible)
 {
-  auto const subroutes = GetSubrouteIds();
-
   df::DrapeEngineLockGuard lock(m_drapeEngine);
   if (!lock)
     return;
 
-  for (auto const & subrouteId : subroutes)
+  lock_guard<mutex> l(m_drapeSubroutesMutex);
+  for (auto const & subrouteId : m_drapeSubroutes)
     lock.Get()->SetSubrouteVisibility(subrouteId, visible);
 }

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -283,7 +283,6 @@ private:
   m2::RectD ShowPreviewSegments(std::vector<RouteMarkData> const & routePoints);
   void HidePreviewSegments();
 
-  std::vector<dp::DrapeID> GetSubrouteIds() const;
   void SetSubroutesVisibility(bool visible);
 
   void CancelRecommendation(Recommendation recommendation);


### PR DESCRIPTION
Поправил race condition, который мог приводить к тому, что на карте оставался удаленный ранее маршрут.

Идея такова:
1. метод GetSubrouteIds() возвращал копию id, по которым производилось удаления маршрутов в методе RoutingManager::RemoveRoute().

2. После этого из другого потока мог быть вызван GetSubrouteIds() из методов: RoutingManager::UpdatePreviewMode(), RoutingManager::CancelPreviewMode(), или даже из RoutingManager::InsertRoute(), RoutingManager::RemoveRoute() и забрать id-ки, которые скоро потеряют актуальность.

3. Затем по данным id завершиться удаление в (1), но методах RoutingManager::UpdatePreviewMode() и других они будут использоваться.

Данный PR удаляет метод RoutingManager::GetSubrouteIds() и защищает мьютексом работу непосредственно с m_drapeSubroutes

@rokuz @darina PTAL