### PR TITLE
[generator][indexer] Replace old international airport tagging.

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -22,3 +22,5 @@ diet=vegetarian : cuisine=vegetarian
 diet:vegan=yes : cuisine=vegan
 diet:vegan=only : cuisine=vegan
 diet=vegan : cuisine=vegan
+
+aerodrome:type=international : aerodrome=international


### PR DESCRIPTION
Мы поддерживаем в типах `aeroway=aerodrome`, `aerodrome=international`, но из 474 аэропортов 79 потеганы по-старому `aeroway=aerodrome`, `aerodrome:type=international`.

Предлагаю на этапе генерации менять старый тег на новый.

https://wiki.openstreetmap.org/wiki/Tag:aerodrome:type%3Dinternational
https://taginfo.openstreetmap.org/tags/aerodrome%3Atype=international
https://taginfo.openstreetmap.org/tags/aerodrome=international