### PR TITLE
Visualize city boundaries irrespectively of CategoriesCache.

### DIFF
--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -350,6 +350,18 @@ public:
 
   // Utilities
   void VisualizeRoadsInRect(m2::RectD const & rect);
+  /// \brief Visualizes |cityBoundaries| with |caption|.
+  /// \note If it's necessary to visualize several vectors of CityBoundary at the same time
+  /// for every call of VisualizeCityBoundariesVec() should be passed a unique |caption|.
+  void VisualizeCityBoundariesVec(vector<indexer::CityBoundary> const & cityBoundaries,
+                                  string const & caption);
+  /// \brief Visualizes all city boundaries saved in World.mwm which are covered by |rect|
+  /// with their feature names written near them.
+  void VisualizeCityBoundariesInRectWithName(m2::RectD const & rect);
+  /// \brief Visualizes all city boundaries save in World.mwm which are covered by |rect|.
+  /// \note To recover feature ids of city boundaries saved in world mwm a CBV in CategoriesCache
+  /// is used. This method should be used for visualization CityBoundary vector irrespectively of
+  /// CategoriesCache.
   void VisualizeCityBoundariesInRect(m2::RectD const & rect);
 
   ads::Engine const & GetAdsEngine() const;

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -240,7 +240,7 @@ void DrawWidget::mouseReleaseEvent(QMouseEvent * e)
     else
     {
       CHECK(m_cityBoundariesSelectionMode, ());
-      m_framework.VisualizeCityBoundariesInRect(rect);
+      m_framework.VisualizeCityBoundariesInRectWithName(rect);
     }
 
     m_rubberBand->hide();


### PR DESCRIPTION
Чтоб визуализировать границы городов, сохраненные в World.mwm использовался метод: `Framework::VisualizeCityBoundariesInRect(m2::RectD const & rect)`.  Он визуализировал границы, и подписывал рядом feature id и имена relation, которые отражали границы. Сами эти feature id не содержались в секции cities_boundaries, а получались из CategoriesCache, базируясь на порядковом номере границы в секции cities_boundaries.

Данный PR добавляет возможность отображать границы городов без подписей с feature id и имен и не зависимо от CategoriesCache. Это полезно для отладочных целей. Когда нужно заполнить секцию cities_boundaries разными многоугольниками границ, а затем посмотреть на карте, как они выглядят.

@tatiana-yan @darina PTAL