### PR TITLE
Generating city_roads section based on cities, town and villages.

### DIFF
--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -80,7 +80,7 @@ bool TestMwmBuilder::Add(FeatureBuilder1 & fb)
 {
   CHECK(m_collector, ("It's not possible to add features after call to Finish()."));
 
-  if (ftypes::IsTownOrCity(fb.GetTypes()) && fb.GetGeomType() == feature::GEOM_AREA)
+  if (ftypes::IsCityTownOrVillage(fb.GetTypes()) && fb.GetGeomType() == feature::GEOM_AREA)
   {
     auto const & metadata = fb.GetMetadataForTesting();
     uint64_t testId;

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -112,6 +112,8 @@ DEFINE_bool(generate_regions_kv, false,
 DEFINE_bool(dump_cities_boundaries, false, "Dump cities boundaries to a file");
 DEFINE_bool(generate_cities_boundaries, false, "Generate cities boundaries section");
 DEFINE_string(cities_boundaries_data, "", "File with cities boundaries");
+DEFINE_string(cities_boundaries_data_for_routing, "",
+              "File with cities boundaries for generation city_roads section.");
 
 DEFINE_bool(generate_world, false, "Generate separate world file.");
 DEFINE_bool(split_by_polygons, false,

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -112,8 +112,6 @@ DEFINE_bool(generate_regions_kv, false,
 DEFINE_bool(dump_cities_boundaries, false, "Dump cities boundaries to a file");
 DEFINE_bool(generate_cities_boundaries, false, "Generate cities boundaries section");
 DEFINE_string(cities_boundaries_data, "", "File with cities boundaries");
-DEFINE_string(cities_boundaries_data_for_routing, "",
-              "File with cities boundaries for generation city_roads section.");
 
 DEFINE_bool(generate_world, false, "Generate separate world file.");
 DEFINE_bool(split_by_polygons, false,

--- a/generator/translator_planet.cpp
+++ b/generator/translator_planet.cpp
@@ -211,7 +211,7 @@ void TranslatorPlanet::EmitArea(FeatureBuilder1 & ft, FeatureParams params,
   if (!ft.IsGeometryClosed())
     return;
 
-  if (ftypes::IsTownOrCity(params.m_types))
+  if (ftypes::IsCityTownOrVillage(params.m_types))
   {
     auto fb = ft;
     fn(fb);

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -261,13 +261,13 @@ public:
 };
 
 template <typename Types>
-bool IsTownOrCity(Types const & types)
+bool IsCityTownOrVillage(Types const & types)
 {
   feature::TypesHolder h;
   for (auto const t : types)
     h.Add(t);
   auto const type = IsLocalityChecker::Instance().GetType(h);
-  return type == TOWN || type == CITY;
+  return type == CITY || type == TOWN || type == VILLAGE;
 }
 
 /// @name Get city radius and population.


### PR DESCRIPTION
Исследования показали, что кол-во дорожных фич, покрытых полигонами деревень (place=village, place= hamlet) соизмеримо  с кол-вом дорожных фич, покрытых городами. Исследования проводились на карте Беларусь, кроме Минска.

Например, 
для Belarus_Hrodna Region.mwm
до учета village и hamlet секция city_roads занимала 29368 байт, а сейчас 46840

для Belarus_Maglieu Region.mwm
до учета village и hamlet секция city_roads занимала 19144 байт, а сейчас 29400

Т.о. секцию city_roads, используемую для прокладки маршрутов имеет смысл генерировать на базе relation (type=boundary, multipolygon), у которых place=city, town, village.

Данный PR реализует это.

@maksimandrianov @tatiana-yan PTAL.

Мне не очень нравится, как я добавил в emitter генерацию границ для routing-га. Если будут лучшие идеи - пишите.