### PR TITLE
[routing] Add *=designated as RoadAccess::Type::Yes

### DIFF
--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -35,6 +35,7 @@ using TagMapping = routing::RoadAccessTagProcessor::TagMapping;
 
 TagMapping const kMotorCarTagMapping = {
     {OsmElement::Tag("motorcar", "yes"), RoadAccess::Type::Yes},
+    {OsmElement::Tag("motorcar", "designated"), RoadAccess::Type::Yes},
     {OsmElement::Tag("motorcar", "permissive"), RoadAccess::Type::Yes},
     {OsmElement::Tag("motorcar", "no"), RoadAccess::Type::No},
     {OsmElement::Tag("motorcar", "private"), RoadAccess::Type::Private},
@@ -43,6 +44,7 @@ TagMapping const kMotorCarTagMapping = {
 
 TagMapping const kMotorVehicleTagMapping = {
     {OsmElement::Tag("motor_vehicle", "yes"), RoadAccess::Type::Yes},
+    {OsmElement::Tag("motor_vehicle", "designated"), RoadAccess::Type::Yes},
     {OsmElement::Tag("motor_vehicle", "permissive"), RoadAccess::Type::Yes},
     {OsmElement::Tag("motor_vehicle", "no"), RoadAccess::Type::No},
     {OsmElement::Tag("motor_vehicle", "private"), RoadAccess::Type::Private},
@@ -51,6 +53,7 @@ TagMapping const kMotorVehicleTagMapping = {
 
 TagMapping const kVehicleTagMapping = {
     {OsmElement::Tag("vehicle", "yes"), RoadAccess::Type::Yes},
+    {OsmElement::Tag("vehicle", "designated"), RoadAccess::Type::Yes},
     {OsmElement::Tag("vehicle", "permissive"), RoadAccess::Type::Yes},
     {OsmElement::Tag("vehicle", "no"), RoadAccess::Type::No},
     {OsmElement::Tag("vehicle", "private"), RoadAccess::Type::Private},
@@ -72,6 +75,7 @@ TagMapping const kCarBarriersTagMapping = {
 
 TagMapping const kPedestrianTagMapping = {
     {OsmElement::Tag("foot", "yes"), RoadAccess::Type::Yes},
+    {OsmElement::Tag("foot", "designated"), RoadAccess::Type::Yes},
     {OsmElement::Tag("foot", "permissive"), RoadAccess::Type::Yes},
     {OsmElement::Tag("foot", "no"), RoadAccess::Type::No},
     {OsmElement::Tag("foot", "private"), RoadAccess::Type::Private},
@@ -80,6 +84,7 @@ TagMapping const kPedestrianTagMapping = {
 
 TagMapping const kBicycleTagMapping = {
     {OsmElement::Tag("bicycle", "yes"), RoadAccess::Type::Yes},
+    {OsmElement::Tag("bicycle", "designated"), RoadAccess::Type::Yes},
     {OsmElement::Tag("bicycle", "permissive"), RoadAccess::Type::Yes},
     {OsmElement::Tag("bicycle", "no"), RoadAccess::Type::No},
     {OsmElement::Tag("bicycle", "private"), RoadAccess::Type::Private},


### PR DESCRIPTION
Добавила тип доступа designated для конкретных видов транспорта как разрешенный, чтобы он применялся с большим приоритетом чем access=.
designated используется для обозначения что данная дорога предназначена для конкретного вида транспорта, см например
https://wiki.openstreetmap.org/wiki/RU:Tag:access%3Ddesignated