### PR TITLE
[search][MAPSME-8515] Localize cuisines in search results.

### DIFF
--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -6,6 +6,7 @@
 
 #include "indexer/categories_holder.hpp"
 #include "indexer/classificator.hpp"
+#include "indexer/cuisines.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/feature_algo.hpp"
 #include "indexer/ftypes_matcher.hpp"
@@ -16,8 +17,8 @@
 
 #include "platform/measurement_utils.hpp"
 
-#include "base/string_utils.hpp"
 #include "base/logging.hpp"
+#include "base/string_utils.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -195,7 +196,18 @@ void ProcessMetadata(FeatureType & ft, Result::Metadata & meta)
 
   feature::Metadata const & src = ft.GetMetadata();
 
-  meta.m_cuisine = src.Get(feature::Metadata::FMD_CUISINE);
+  auto const cuisinesMeta = src.Get(feature::Metadata::FMD_CUISINE);
+  if (cuisinesMeta.empty())
+  {
+    meta.m_cuisine = "";
+  }
+  else
+  {
+    vector<string> cuisines;
+    osm::Cuisines::Instance().ParseAndLocalize(cuisinesMeta, cuisines);
+    meta.m_cuisine = strings::JoinStrings(cuisines, " • ");
+  }
+
   meta.m_airportIata = src.Get(feature::Metadata::FMD_AIRPORT_IATA);
 
   string const openHours = src.Get(feature::Metadata::FMD_OPEN_HOURS);


### PR DESCRIPTION
Теперь в результатах поиска будет как в PP.
Как сейчас см скриншоты в https://jira.mail.ru/browse/MAPSME-8515 в конце.
Похоже так было всегда -- в этом поле всегда была "голая" метадата и дальше она тоже нигде не переводилась.
Т.к. поиск это поле дальше нигде не использует, ничто не мешает хранить там данные сразу в читабельном формате.
После переделывания переводов кухонь на типы можно будет изменить место в котором происходит локализация (переводить на платформах там же где и типы). Переводы метадаты из индексера тащить в платформу считаю нецелесообразным.