### PR TITLE
[indexer] Remove Classificator::SortClassificator()

### DIFF
--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -337,7 +337,6 @@ int main(int argc, char ** argv)
 
   GetStyleReader().SetCurrentStyle(MapStyleMerged);
   classificator::Load();
-  classif().SortClassificator();
 
   FrozenDataSource dataSource;
   vector<platform::LocalCountryFile> mwms;

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -263,7 +263,6 @@ int main(int argc, char ** argv)
       FLAGS_geo_objects_key_value != "")
   {
     classificator::Load();
-    classif().SortClassificator();
   }
 
   // Load mwm tree only if we need it

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -373,11 +373,6 @@ void Classificator::ReadClassificator(istream & s)
   m_coastType = GetTypeByPath({ "natural", "coastline" });
 }
 
-void Classificator::SortClassificator()
-{
-  GetMutableRoot()->Sort();
-}
-
 template <typename Iter>
 uint32_t Classificator::GetTypeByPathImpl(Iter beg, Iter end) const
 {

--- a/indexer/classificator.hpp
+++ b/indexer/classificator.hpp
@@ -166,8 +166,6 @@ public:
   //@{
   void ReadClassificator(std::istream & s);
   void ReadTypesMapping(std::istream & s);
-
-  void SortClassificator();
   //@}
 
   void Clear();

--- a/track_analyzing/track_analyzer/track_analyzer.cpp
+++ b/track_analyzing/track_analyzer/track_analyzer.cpp
@@ -106,7 +106,6 @@ int main(int argc, char ** argv)
   string const & cmd = Checked_cmd();
 
   classificator::Load();
-  classif().SortClassificator();
 
   try
   {


### PR DESCRIPTION
Убрала метод Classificator::SortClassificator()

Метод сортирует в дереве типов потомков для каждого узла в зависимости от масштаба на которых они видимы и имени.

В коде приложения не вызывался, вызывался только в тулзах.
Внутри метода Classificator::ReadClassificator и так вызвыается `m_root.Sort();` который делает то же самое, поэтому нет смысла вызывать SortClassificator() после classificator::Load().