### PR TITLE
[generator] Added repacking regions mwm.tmp.

### DIFF
--- a/generator/regions/regions.hpp
+++ b/generator/regions/regions.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-namespace feature
-{
-struct GenerateInfo;
-}  // namespace feature
+#include <string>
 
 namespace generator
 {
 namespace regions
 {
-bool GenerateRegions(feature::GenerateInfo const & genInfo); 
+bool GenerateRegions(std::string const & pathInRegionsTmpMwm,
+                     std::string const & pathInRegionsCollector,
+                     std::string const & pathOutRegionsKv,
+                     std::string const & pathOutRepackedRegionsTmpMwm, bool verbose);
 }  // namespace regions
 }  // namespace generator


### PR DESCRIPTION
Проблема была в том, что сначала добавляется избыточная информация о регионах в tmp.mwm. Потом на этапе построения кв уже определяется точно какие регионы будут учавствовать в результатирующей выборке, а какие нет. После построения кв, можно выбрать регионы, которые есть в кв и уже его подавать на вход построения индекса.

https://jira.mail.ru/browse/MAPSB2B-2