### PR TITLE
[generator] Fixes

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -32,6 +32,7 @@
 #include "defines.hpp"
 
 #include <list>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -62,6 +63,13 @@ public:
     m_helperFile[SEARCH_TOKENS] = make_unique<TmpFile>(fName + SEARCH_TOKENS_FILE_TAG);
   }
 
+  ~FeaturesCollector2()
+  {
+    // Check file size.
+    auto const unused = CheckedFilePosCast(m_datFile);
+    UNUSED_VALUE(unused);
+  }
+
   void Finish()
   {
     // write version information
@@ -90,7 +98,7 @@ public:
 
     // File Writer finalization function with appending to the main mwm file.
     auto const finalizeFn = [this](unique_ptr<TmpFile> w, string const & tag,
-                                   string const & postfix = string()) {
+        string const & postfix = string()) {
       w->Flush();
       m_writer.Write(w->GetName(), tag + postfix);
     };
@@ -129,7 +137,7 @@ public:
   uint32_t operator()(FeatureBuilder2 & fb)
   {
     GeometryHolder holder([this](int i) -> FileWriter & { return *m_geoFile[i]; },
-                          [this](int i) -> FileWriter & { return *m_trgFile[i]; }, fb, m_header);
+    [this](int i) -> FileWriter & { return *m_trgFile[i]; }, fb, m_header);
 
     bool const isLine = fb.IsLine();
     bool const isArea = fb.IsArea();

--- a/generator/filter_elements.cpp
+++ b/generator/filter_elements.cpp
@@ -15,10 +15,10 @@ public:
   bool Add(T const & key)
   {
     if (Contains(key))
-      return true;
+      return false;
 
     m_vec.push_back(key);
-    return false;
+    return true;
   }
 
   bool Contains(T const & key) const

--- a/generator/geometry_holder.hpp
+++ b/generator/geometry_holder.hpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <list>
 #include <vector>
 
@@ -163,7 +164,9 @@ private:
     Points toSave(points.begin() + 1, points.end());
 
     m_buffer.m_ptsMask |= (1 << i);
-    m_buffer.m_ptsOffset.push_back(feature::FeaturesCollector::GetFileSize(m_geoFileGetter(i)));
+    auto const pos = feature::CheckedFilePosCast(m_geoFileGetter(i));
+    m_buffer.m_ptsOffset.push_back(pos);
+
     serial::SaveOuterPath(toSave, cp, m_geoFileGetter(i));
   }
 
@@ -200,7 +203,8 @@ private:
 
     // saving to file
     m_buffer.m_trgMask |= (1 << i);
-    m_buffer.m_trgOffset.push_back(feature::FeaturesCollector::GetFileSize(m_trgFileGetter(i)));
+    auto const pos = feature::CheckedFilePosCast(m_trgFileGetter(i));
+    m_buffer.m_trgOffset.push_back(pos);
     saver.Save(m_trgFileGetter(i));
   }
 


### PR DESCRIPTION
Первый коммит разрешает запись mwm.tmp более 4 Гб.
Второй исправляет возвращаемое значение Set::Add