### PR TITLE
[routing] change map to unordered_map for RoadAccess

### DIFF
--- a/3party/pugixml/src/utils.hpp
+++ b/3party/pugixml/src/utils.hpp
@@ -9,7 +9,7 @@ namespace pugi
 template <typename... Args>
 inline std::string XMLToString(pugi::xml_node const & n, Args &&... args)
 {
-  ostringstream sstr;
+  std::ostringstream sstr;
   n.print(sstr, std::forward<Args>(args)...);
   return sstr.str();
 }

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -22,6 +22,7 @@
 #include "defines.hpp"
 
 #include <algorithm>
+#include <unordered_map>
 #include <utility>
 
 using namespace routing;
@@ -125,8 +126,8 @@ bool ParseRoadAccess(string const & roadAccessPath,
 
   vector<uint32_t> privateRoads;
 
-  map<uint32_t, RoadAccess::Type> featureType[static_cast<size_t>(VehicleType::Count)];
-  map<RoadPoint, RoadAccess::Type> pointType[static_cast<size_t>(VehicleType::Count)];
+  unordered_map<uint32_t, RoadAccess::Type> featureType[static_cast<size_t>(VehicleType::Count)];
+  unordered_map<RoadPoint, RoadAccess::Type, RoadPoint::Hash> pointType[static_cast<size_t>(VehicleType::Count)];
 
   auto addFeature = [&](uint32_t featureId, VehicleType vehicleType,
                         RoadAccess::Type roadAccessType, uint64_t osmId) {

--- a/openlr/decoded_path.cpp
+++ b/openlr/decoded_path.cpp
@@ -105,7 +105,7 @@ void WriteAsMappingForSpark(std::ostream & ost, std::vector<DecodedPath> const &
       if (next(it) != end(p.m_path))
         ost << kSegmentSep;
     }
-    ost << endl;
+    ost << std::endl;
   }
 }
 

--- a/openlr/openlr_stat/openlr_stat.cpp
+++ b/openlr/openlr_stat/openlr_stat.cpp
@@ -174,7 +174,7 @@ void SaveNonMatchedIds(std::string const & filename, std::vector<DecodedPath> co
   for (auto const & p : paths)
   {
     if (p.m_path.empty())
-      ofs << p.m_segmentId << endl;
+      ofs << p.m_segmentId << std::endl;
   }
 }
 

--- a/routing/road_access.hpp
+++ b/routing/road_access.hpp
@@ -6,8 +6,8 @@
 #include "base/assert.hpp"
 
 #include <cstdint>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -41,8 +41,15 @@ public:
     Count
   };
 
-  std::map<uint32_t, RoadAccess::Type> const & GetFeatureTypes() const { return m_featureTypes; }
-  std::map<RoadPoint, RoadAccess::Type> const & GetPointTypes() const { return m_pointTypes; }
+  std::unordered_map<uint32_t, RoadAccess::Type> const & GetFeatureTypes() const
+  {
+    return m_featureTypes;
+  }
+
+  std::unordered_map<RoadPoint, RoadAccess::Type, RoadPoint::Hash> const & GetPointTypes() const
+  {
+    return m_pointTypes;
+  }
 
   Type GetFeatureType(uint32_t featureId) const;
   Type GetPointType(RoadPoint const & point) const;
@@ -70,8 +77,8 @@ private:
   // If segmentIdx of a key in this map is 0, it means the
   // entire feature has the corresponding access type.
   // Otherwise, the information is about the segment with number (segmentIdx-1).
-  std::map<uint32_t, RoadAccess::Type> m_featureTypes;
-  std::map<RoadPoint, RoadAccess::Type> m_pointTypes;
+  std::unordered_map<uint32_t, RoadAccess::Type> m_featureTypes;
+  std::unordered_map<RoadPoint, RoadAccess::Type, RoadPoint::Hash> m_pointTypes;
 };
 
 std::string ToString(RoadAccess::Type type);

--- a/routing/road_access_serialization.hpp
+++ b/routing/road_access_serialization.hpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <map>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -28,8 +28,8 @@ namespace routing
 class RoadAccessSerializer final
 {
 public:
-  using RoadAccessTypesFeatureMap = std::map<uint32_t, RoadAccess::Type>;
-  using RoadAccessTypesPointMap = std::map<RoadPoint, RoadAccess::Type>;
+  using RoadAccessTypesFeatureMap = std::unordered_map<uint32_t, RoadAccess::Type>;
+  using RoadAccessTypesPointMap = std::unordered_map<RoadPoint, RoadAccess::Type, RoadPoint::Hash>;
   using RoadAccessByVehicleType = std::array<RoadAccess, static_cast<size_t>(VehicleType::Count)>;
 
   RoadAccessSerializer() = delete;

--- a/routing/road_point.hpp
+++ b/routing/road_point.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "std/cstdint.hpp"
-#include "std/sstream.hpp"
-#include "std/string.hpp"
+#include <cstdint>
+#include <functional>
+#include <sstream>
+#include <string>
 
 namespace routing
 {
@@ -38,14 +39,26 @@ public:
     return !(*this == rp);
   }
 
+  struct Hash
+  {
+    uint64_t operator() (RoadPoint const & roadPoint) const
+    {
+      uint32_t featureId = roadPoint.m_featureId;
+      uint32_t pointId = roadPoint.m_pointId;
+
+      return std::hash<uint64_t>()(
+        (static_cast<uint64_t>(featureId) << 32) + static_cast<uint64_t>(pointId));
+    }
+  };
+
 private:
   uint32_t m_featureId;
   uint32_t m_pointId;
 };
 
-inline string DebugPrint(RoadPoint const & rp)
+inline std::string DebugPrint(RoadPoint const & rp)
 {
-  ostringstream out;
+  std::ostringstream out;
   out << "RoadPoint [" << rp.GetFeatureId() << ", " << rp.GetPointId() << "]";
   return out.str();
 }

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -10,6 +10,8 @@
 
 #include "base/assert.hpp"
 
+#include <unordered_map>
+
 namespace routing_test
 {
 using namespace routing;
@@ -275,8 +277,8 @@ void TestIndexGraphTopology::Builder::BuildJoints()
 
 void TestIndexGraphTopology::Builder::BuildGraphFromRequests(vector<EdgeRequest> const & requests)
 {
-  map<uint32_t, RoadAccess::Type> featureTypes;
-  map<RoadPoint, RoadAccess::Type> pointTypes;
+  unordered_map<uint32_t, RoadAccess::Type> featureTypes;
+  unordered_map<RoadPoint, RoadAccess::Type, RoadPoint::Hash> pointTypes;
   for (auto const & request : requests)
   {
     BuildSegmentFromEdge(request);

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 using namespace routing;
@@ -23,12 +23,12 @@ namespace
 UNIT_TEST(RoadAccess_Serialization)
 {
   // Segment is (numMwmId, featureId, segmentIdx, isForward).
-  map<uint32_t, RoadAccess::Type> const m0 = {
+  unordered_map<uint32_t, RoadAccess::Type> const m0 = {
       {1, RoadAccess::Type::No},
       {2, RoadAccess::Type::Private},
   };
 
-  map<uint32_t, RoadAccess::Type> const m1 = {
+  unordered_map<uint32_t, RoadAccess::Type> const m1 = {
       {1, RoadAccess::Type::Private},
       {2, RoadAccess::Type::Destination},
   };

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -255,7 +255,7 @@ string DebugPrint(PronouncedNotification const notificationProgress)
   }
 
   ASSERT(false, ());
-  stringstream out;
+  std::stringstream out;
   out << "unknown PronouncedNotification (" << static_cast<int>(notificationProgress) << ")";
   return out.str();
 }


### PR DESCRIPTION
В ходе профилирования joint увидел, что среди функций работающих дольше, чем "очень быстро" есть такие две:
```cpp
routing::RoadAccess::GetPointType(routing::RoadPoint const&) const {}
routing::RoadAccess::GetFeatureType(unsigned int) const {}
```

Посмотрел, что у них внутри, а там std::map, хотя по логике нужен hash.
Поменял, посмотрел разницу:
### std::map
<img width="1680" alt="2018-10-22 19 29 44" src="https://user-images.githubusercontent.com/17534533/47306283-a6ce9500-d634-11e8-8acf-35b6a13a078e.png">

### std::unordered_map
<img width="1680" alt="2018-10-22 19 27 04" src="https://user-images.githubusercontent.com/17534533/47306292-adf5a300-d634-11e8-979a-7a0b1e054736.png">

Видно, что разница есть, предлагаю заменить на `unordered_map`.
**Плюс**: можно посмотреть на разницу в работе функций:
```cpp
routing::IndexGraph::GetPenalties(routing::Segment const&, routing::Segment const&) const {}
routing::IndexGraph::CalcSegmentWeight(routing::Segment const&) const {}
```
Они тоже ускорились (внутри себя вызывают первые две функции).