### PR TITLE
[search] Faster GetAddress for ranker and reverse geocoding.

### DIFF
--- a/indexer/data_source.hpp
+++ b/indexer/data_source.hpp
@@ -27,6 +27,7 @@ class DataSource : public MwmSet
 public:
   using FeatureCallback = std::function<void(FeatureType &)>;
   using FeatureIdCallback = std::function<void(FeatureID const &)>;
+  using StopSearchCallback = std::function<bool(void)>;
 
   ~DataSource() override = default;
 
@@ -42,6 +43,12 @@ public:
 
   void ForEachFeatureIDInRect(FeatureIdCallback const & f, m2::RectD const & rect, int scale) const;
   void ForEachInRect(FeatureCallback const & f, m2::RectD const & rect, int scale) const;
+  // Calls |f| for features closest to |center| until |stopCallback| returns true or distance
+  // |sizeM| from has been reached. Then for EditableDataSource calls |f| for each edited feature
+  // inside square with center |center| and side |2 * sizeM|. Edited features are not in the same
+  // hierarchy and there is no fast way to merge frozen and edited features.
+  void ForClosestToPoint(FeatureCallback const & f, StopSearchCallback const & stopCallback,
+                         m2::PointD const & center, double sizeM, int scale) const;
   void ForEachInScale(FeatureCallback const & f, int scale) const;
   void ForEachInRectForMWM(FeatureCallback const & f, m2::RectD const & rect, int scale,
                            MwmId const & id) const;

--- a/indexer/feature_covering.hpp
+++ b/indexer/feature_covering.hpp
@@ -160,7 +160,10 @@ public:
         };
 
         for (auto const & id : ids)
-          AppendLowerLevels<DEPTH_LEVELS>(id, cellDepth, insertInterval);
+        {
+          if (cellDepth > id.Level())
+            AppendLowerLevels<DEPTH_LEVELS>(id, cellDepth, insertInterval);
+        }
       }
       }
     }

--- a/search/reverse_geocoder.hpp
+++ b/search/reverse_geocoder.hpp
@@ -72,6 +72,7 @@ public:
     string const & GetHouseNumber() const { return m_building.m_name; }
     string const & GetStreetName() const { return m_street.m_name; }
     double GetDistance() const { return m_building.m_distanceMeters; }
+    bool IsValid() const { return m_building.IsValid() && m_street.IsValid(); }
   };
 
   friend string DebugPrint(Address const & addr);
@@ -94,6 +95,9 @@ public:
 
   /// @return The nearest exact address where building has house number and valid street match.
   void GetNearbyAddress(m2::PointD const & center, Address & addr) const;
+  /// @return The nearest exact address where building is at most |maxDistanceM| far from |center|,
+  /// has house number and valid street match.
+  void GetNearbyAddress(m2::PointD const & center, double maxDistanceM, Address & addr) const;
   /// @param addr (out) the exact address of a feature.
   /// @returns false if  can't extruct address or ft have no house number.
   bool GetExactAddress(FeatureType & ft, Address & addr) const;
@@ -114,7 +118,8 @@ private:
   bool GetNearbyAddress(HouseTable & table, Building const & bld, Address & addr) const;
 
   /// @return Sorted by distance houses vector with valid house number.
-  void GetNearbyBuildings(m2::PointD const & center, vector<Building> & buildings) const;
+  void GetNearbyBuildings(m2::PointD const & center, double maxDistanceM,
+                          vector<Building> & buildings) const;
 
   static Building FromFeature(FeatureType & ft, double distMeters);
 };


### PR DESCRIPTION
Функция восстановления адреса работала так:
1. мы брали все фичи в радиусе 500 метров
2. для каждой фичи проверяли дом ли она
3. если дом, клали в массив
4. потом сортировали
5. потом оставляли 10 ближайших
6. потом для каждого из оставшихся домов искали улицы (тоже поднимали все фичи в радиусе 500 метров и т.п.)
7. потом в части случаев, если расстояние от результата поиска до дома больше 0 всё это выкидывали

сделала 2 вещи:
- если нужно точное попадание в дом, то ищем точное попадание (это дешевле, на шаге 6 вызываем поиск улицы для меньшего кол-ва домов)
- ищем дома при помощи CoveringMode::Spiral, что позволяет найти ближайшие дома и остановиться -- не поднимать все фичи в радиусе 500 метров

Ещё довольно много времени уходит на поиск улиц, но способ хранения информации об улице накладывает ограничения на его модификацию. 
По-хорошему можно сначала вычитывать нужный индекс улицы (n, обычно не больше 3), а потом с CoveringMode::Spiral брать только ближайшие n+1, а не все улицы в радиусе 500 метров), но т.к. порядок в CoveringMode::Spiral примерный, будут проблемы с совместимостью с данными.