### PR TITLE
routing integration tests fix for 2018.10.19 maps.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -280,12 +280,12 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(49.85015, 2.24296), {0., 0.},
-        MercatorBounds::FromLatLon(48.85860, 2.34784), 126000.);
+        MercatorBounds::FromLatLon(48.85458, 2.36291), 127162.0);
     // And backward case
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
-        MercatorBounds::FromLatLon(48.85860, 2.34784), {0., 0.},
-        MercatorBounds::FromLatLon(49.85015, 2.24296), 126000.);
+        MercatorBounds::FromLatLon(48.85458, 2.36291), {0., 0.},
+        MercatorBounds::FromLatLon(49.85015, 2.24296), 137009.0);
   }
 
   UNIT_TEST(RussiaSmolenskRussiaMoscowTimeTest)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -300,7 +300,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 15001.2);
+    integration::TestRouteTime(route, 15246.6);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -372,7 +372,7 @@ UNIT_TEST(BelarusMKADShosseinai)
 
 // Test case: a route goes straight along a big road when joined small road.
 // An end user shall not be informed about such manoeuvres.
-// But at the and of the route an end user shall be informed about junction of two big roads.
+// But at the end of the route an end user shall be informed about junction of two big roads.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 {
   TRouteResult const routeResult =
@@ -385,7 +385,7 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToLeft);
 }
 
 // Test case: a route goes in Moscow from Varshavskoe shosse (from the city center direction)


### PR DESCRIPTION
После сборки данных от 2018.10.19 сломались 3 интеграционные теста:

route_test.cpp::ParisCrossDestinationInForwardHeapCase
route_test.cpp::RussiaSmolenskRussiaMoscowTimeTest
turn_test.cpp::ThailandPhuketNearPrabarameeRoad

1. route_test.cpp::ParisCrossDestinationInForwardHeapCase
Тут очень тонкая причина поломки. Тест на меж mwm-й роутинг через 10 mwm. Успешно строится кросс-mwm-й маршрут, там успешно строятся все маршруты внутри mwm-ок, кроме последнего от входного сегмента mwm центра Парижа до точки в центре Парижа.

Центр Парижа: France_Ile-de-France_Paris.mwm. Входной сегмент: m_featureId = 35796, m_segmentIdx = 0 (48.899719422209074082, 2.3189024799980302305). Входной сегмент на карте: https://www.openstreetmap.org/way/32746681. Точка в центре Парижа (48.85860, 2.34784).

Проблема тут в том, что входной сегмент является однонаправленным. И он упирается в дорогу (https://www.openstreetmap.org/way/538779469) с тегом motor_vehicle=no, что скорее всего ошибка и видимо скоро будет исправлено. Т.е. при прокладке маршрута в рамках финишной mwm-ки Парижа мы получаем ошибку RouteNotFound.

Можно было бы рассмотреть следующие варианты решения:
- прокладывать маршрут о старта к выходу mwm и от входа к финишу не по стартовой (финишной) mwm, а по мировой. Но тогда, вероятность петель, которые являются следствием эвристики при выборе выходов около старта и входов около финиша возрастает (этот путь уже был пройден);
- можно было бы изучать кандидаты на переходные сегменты на предмет можно ли из них куда-то уехать и есть из них нельзя проехать более чем на n сегментов, но добавлять их в переходные сегменты. Но тогда мы потеряем возможность прокладывать маршруты до дорог, которые дважды разрезаны границой mwm-ки, а это кажется больший класс ошибок.

Учитывая,
- все выше сказанное;
- что данный тест на кросс-mwm й роутинг в целом;
- то, что ошибка выше, является следствием ошибки в карте, которая видимо скоро будет исправлена;

Я просто меняю точку финиша, чтоб был выбран другой меж mwm-й переход около финиша.

2. RussiaSmolenskRussiaMoscowTimeTest
Немного изменилась геометрия и длина маршрута, но в целом маршрут нормальный.
![image](https://user-images.githubusercontent.com/1768114/47637120-b8032e80-db6b-11e8-88c2-9f682b58c29a.png)

3. ThailandPhuketNearPrabarameeRoad
Одной из дорог добавлен атрибут link (т.е. highway=trunk_link) и теперь генерируется сообщение ExitHighwayToLeft вместо GoStraight, что уместнее в данном случае.
![image](https://user-images.githubusercontent.com/1768114/47637134-cb15fe80-db6b-11e8-855d-230060e3511e.png)

@vmihaylenko @gmoryes PTAL



