### PR TITLE
[routing] Remove editor header includes from routing

### DIFF
--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -12,8 +12,6 @@
 
 #include "routing_common/car_model.hpp"
 
-#include "editor/editable_data_source.hpp"
-
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -7,8 +7,6 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
-#include "editor/editable_data_source.hpp"
-
 #include "indexer/data_source.hpp"
 
 #include <map>

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -4,9 +4,8 @@
 
 #include "routing_common/vehicle_model.hpp"
 
-#include "editor/editable_data_source.hpp"
-
 #include "indexer/classificator.hpp"
+#include "indexer/data_source.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -3,9 +3,8 @@
 #include "routing/city_roads.hpp"
 #include "routing/routing_exceptions.hpp"
 
-#include "editor/editable_data_source.hpp"
-
 #include "indexer/altitude_loader.hpp"
+#include "indexer/data_source.hpp"
 
 #include "geometry/mercator.hpp"
 

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -3,7 +3,7 @@
 #include "routing/routing_exceptions.hpp"
 #include "routing/transit_graph.hpp"
 
-#include "editor/editable_data_source.hpp"
+#include "indexer/data_source.hpp"
 
 #include <cstdint>
 

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -45,7 +45,6 @@ omim_link_libraries(
   routing_common
   transit
   kml
-  editor
   indexer
   platform
   oauthcpp


### PR DESCRIPTION
Везде нужна только константная ссылка на родительский по отношению к EditableDataSource класс. По факту это будет EditableDataSource, но родительский класс располагается в индексе и это позволяет роутингу не зависеть от редактора.