### PR TITLE
remove tags from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,5 +175,4 @@ qt/res/Info.plist
 designer_version.h
 
 # Vim files
-tags
 *.sw?


### PR DESCRIPTION
В gitignore есть секция vim со строчкой tags. В iOS мы создали папку с ресурсами с таким же названием - она заигнорилась. Есть предложение удалить или модифицировать эту строчку, чтобы не возникало в дальнейшем подобных проблем. 