### PR TITLE
[DNM] [routing] delete useless code from astar_algorithm.hpp

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -218,8 +218,6 @@ private:
       , startVertex(startVertex)
       , finalVertex(finalVertex)
       , graph(graph)
-      , m_piRT(graph.HeuristicCostEstimate(finalVertex, startVertex))
-      , m_piFS(graph.HeuristicCostEstimate(startVertex, finalVertex))
     {
       bestVertex = forward ? startVertex : finalVertex;
       pS = ConsistentHeuristic(bestVertex);
@@ -231,25 +229,17 @@ private:
       return bestDistance.at(queue.top().vertex);
     }
 
-    // p_f(v) = 0.5*(π_f(v) - π_r(v)) + 0.5*π_r(t)
-    // p_r(v) = 0.5*(π_r(v) - π_f(v)) + 0.5*π_f(s)
+    // p_f(v) = 0.5*(π_f(v) - π_r(v))
+    // p_r(v) = 0.5*(π_r(v) - π_f(v))
     // p_r(v) + p_f(v) = const. Note: this condition is called consistence.
     Weight ConsistentHeuristic(Vertex const & v) const
     {
       auto const piF = graph.HeuristicCostEstimate(v, finalVertex);
       auto const piR = graph.HeuristicCostEstimate(v, startVertex);
       if (forward)
-      {
-        /// @todo careful: with this "return" here and below in the Backward case
-        /// the heuristic becomes inconsistent but still seems to work.
-        /// return HeuristicCostEstimate(v, finalVertex);
-        return 0.5 * (piF - piR + m_piRT);
-      }
+        return 0.5 * (piF - piR);
       else
-      {
-        // return HeuristicCostEstimate(v, startVertex);
-        return 0.5 * (piR - piF + m_piFS);
-      }
+        return 0.5 * (piR - piF);
     }
 
     void GetAdjacencyList(Vertex const & v, std::vector<Edge> & adj)
@@ -264,8 +254,6 @@ private:
     Vertex const & startVertex;
     Vertex const & finalVertex;
     Graph & graph;
-    Weight const m_piRT;
-    Weight const m_piFS;
 
     std::priority_queue<State, std::vector<State>, std::greater<State>> queue;
     std::map<Vertex, Weight> bestDistance;


### PR DESCRIPTION
Этот код является лишним и более того сейчас он не выполняет никакой роли.
В [этой статье](https://www.microsoft.com/en-us/research/wp-content/uploads/2004/07/tr-2004-24.pdf ) что-то говорится о прибавлении к разности потенциалов некой константы, зависящей, как я понимаю, от  начальной эвристики (см. 5.2):
![image](https://user-images.githubusercontent.com/17534533/48638537-f8730100-e9e1-11e8-9ae6-63c61587a2d6.png)
**Но** у них говорится во первых про максимум, во вторых надо разбираться что это за константа и как она влияет на скорость прокладки маршрута, в третьих эти константы у нас в коде: `m_piRT`, `m_piFS` равны друг другу, т.к. там берется евклидово расстояние между двумя точками и из-за этого при рассчете
`reduceWeight` = `weight - pV + pW` эти константы просто сокращаются всегда.

В общем это просто выглядит страшно и непонятно и мешает отладке только.

Насчет комментариев, я не знаю к чему они были написаны, почему там есть закомментированный код итд итп. Сейчас у нас используется та эвристика, которая упоминается в статье, и у нас стоит `CHECK`, который не нарушается, поэтому мне не понятно к чему там этот комментарий, что эвристика в данном месте может нарушиться, поэтому предлагаю его удалить.