### PR TITLE
[routing] New IndexGraphStarterJoints, JointSegment, jumps between segments.

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -54,6 +54,8 @@ set(
   index_graph_serialization.hpp
   index_graph_starter.cpp
   index_graph_starter.hpp
+  index_graph_starter_joints.cpp
+  index_graph_starter_joints.hpp
   index_road_graph.cpp
   index_road_graph.hpp
   index_router.cpp
@@ -62,6 +64,8 @@ set(
   joint.hpp
   joint_index.cpp
   joint_index.hpp
+  joint_segment.cpp
+  joint_segment.hpp
   loaded_path_segment.hpp
   maxspeeds.cpp
   maxspeeds.hpp

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -81,6 +82,19 @@ public:
 
     m_transitions[Key(featureId, segmentIdx)] = transition;
     m_crossMwmIdToFeatureId.emplace(crossMwmId, featureId);
+    m_transitFeatureIdToSegmentId.emplace(featureId, segmentIdx);
+  }
+
+  bool IsFeatureCrossMwmConnector(uint32_t featureId) const
+  {
+    return m_transitFeatureIdToSegmentId.find(featureId) != m_transitFeatureIdToSegmentId.cend();
+  }
+
+  uint32_t GetTransitSegmentId(uint32_t featureId) const
+  {
+    auto it = m_transitFeatureIdToSegmentId.find(featureId);
+    CHECK(it != m_transitFeatureIdToSegmentId.cend(), ());
+    return it->second;
   }
 
   bool IsTransition(Segment const & segment, bool isOutgoing) const
@@ -291,6 +305,7 @@ private:
   NumMwmId const m_mwmId;
   std::vector<Segment> m_enters;
   std::vector<Segment> m_exits;
+  std::map<uint32_t, uint32_t> m_transitFeatureIdToSegmentId;
   std::unordered_map<Key, Transition<CrossMwmId>, HashKey> m_transitions;
   std::unordered_map<CrossMwmId, uint32_t, connector::HashKey> m_crossMwmIdToFeatureId;
   connector::WeightsLoadState m_weightsLoadState = connector::WeightsLoadState::Unknown;

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -154,6 +154,26 @@ void CrossMwmGraph::Clear()
   m_crossMwmTransitGraph.Clear();
 }
 
+void CrossMwmGraph::GetTwinFeature(Segment const & segment, bool isOutgoing, vector<Segment> & twins)
+{
+  vector<Segment> result;
+  uint32_t const transitSegmentId = m_crossMwmIndexGraph.GetTransitSegmentId(segment.GetMwmId(),
+                                                                             segment.GetFeatureId());
+
+  Segment const transitSegment(segment.GetMwmId(), segment.GetFeatureId(),
+                               transitSegmentId, segment.IsForward());
+
+  if (!IsTransition(transitSegment, isOutgoing))
+    return;
+
+  GetTwins(transitSegment, isOutgoing, twins);
+}
+
+bool CrossMwmGraph::IsFeatureTransit(NumMwmId numMwmId, uint32_t featureId)
+{
+  return m_crossMwmIndexGraph.IsFeatureTransit(numMwmId, featureId);
+}
+
 CrossMwmGraph::MwmStatus CrossMwmGraph::GetMwmStatus(NumMwmId numMwmId,
                                                      string const & sectionName) const
 {

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -97,6 +97,11 @@ public:
     return m_crossMwmIndexGraph.GetTransitions(numMwmId, isEnter);
   }
 
+  bool IsFeatureTransit(NumMwmId numMwmId, uint32_t featureId);
+  /// \brief Checks whether feature where |segment| is placed is a cross mwm connector.
+  ///        If yes twin-segments are saved to |twins|.
+  void GetTwinFeature(Segment const & segment, bool isOutgoing, vector<Segment> & twins);
+
 private:
   MwmStatus GetMwmStatus(NumMwmId numMwmId, std::string const & sectionName) const;
   MwmStatus GetCrossMwmStatus(NumMwmId numMwmId) const;

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -83,6 +83,16 @@ public:
     return c.IsTransition(s, isOutgoing);
   }
 
+  bool IsFeatureTransit(NumMwmId numMwmId, uint32_t featureId)
+  {
+    return GetCrossMwmConnectorWithTransitions(numMwmId).IsFeatureCrossMwmConnector(featureId);
+  }
+
+  uint32_t GetTransitSegmentId(NumMwmId numMwmId, uint32_t featureId)
+  {
+    return GetCrossMwmConnectorWithTransitions(numMwmId).GetTransitSegmentId(featureId);
+  }
+
   /// \brief Fills |twins| based on transitions defined in cross_mwm section.
   /// \note In cross_mwm section transitions are defined by osm ids of theirs features.
   /// \note This method fills |twins| with all available twins iff all neighboring of mwm of |s|

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -4,6 +4,7 @@
 #include "routing/geometry.hpp"
 #include "routing/joint.hpp"
 #include "routing/joint_index.hpp"
+#include "routing/joint_segment.hpp"
 #include "routing/restrictions_serialization.hpp"
 #include "routing/road_access.hpp"
 #include "routing/road_index.hpp"
@@ -33,6 +34,9 @@ public:
 
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
   void GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
+
+  void GetEdgeList(Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
+                   std::vector<RouteWeight> & parentWeights);
 
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
 
@@ -77,6 +81,8 @@ public:
     m_jointIndex.ForEachPoint(jointId, forward<F>(f));
   }
 
+  bool IsJoint(RoadPoint const & roadPoint) const;
+
 private:
   RouteWeight CalcSegmentWeight(Segment const & segment);
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
@@ -88,6 +94,13 @@ private:
   {
     return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
   }
+
+  void GetLastPointsForJoint(std::vector<Segment> const & children, bool isOutgoing, std::vector<uint32_t> & lastPoints);
+  void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, std::vector<Segment> & children);
+  void ReconstructJointSegment(Segment const & parent, std::vector<Segment> const & firstChildren,
+                               std::vector<uint32_t> const & lastPointIds,
+                               bool isOutgoing, std::vector<JointEdge> & jointEdges,
+                               std::vector<RouteWeight> & parentWeights);
 
   shared_ptr<Geometry> m_geometry;
   shared_ptr<EdgeEstimator> m_estimator;

--- a/routing/index_graph_starter_joints.cpp
+++ b/routing/index_graph_starter_joints.cpp
@@ -1,0 +1,393 @@
+#include "routing/index_graph_starter_joints.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace routing
+{
+IndexGraphStarterJoints::IndexGraphStarterJoints(IndexGraphStarter & starter,
+                                                 Segment const & startSegment,
+                                                 Segment const & endSegment)
+  : m_starter(starter), m_startSegment(startSegment), m_endSegment(endSegment)
+{
+  Init(startSegment, endSegment);
+}
+
+void IndexGraphStarterJoints::Init(Segment const & startSegment, Segment const & endSegment)
+{
+  m_startSegment = startSegment;
+  m_endSegment = endSegment;
+
+  CHECK(m_starter.GetGraph().GetMode() == WorldGraph::Mode::Joints ||
+        m_starter.GetGraph().GetMode() == WorldGraph::Mode::JointSingleMwm, ());
+
+  if (startSegment.IsRealSegment())
+    m_startJoint = CreateInvisibleJoint(startSegment, true /* start */);
+  else
+    m_startJoint = CreateFakeJoint(m_starter.GetStartSegment(), m_starter.GetStartSegment());
+
+  if (endSegment.IsRealSegment())
+    m_endJoint = CreateInvisibleJoint(endSegment, false /* start */);
+  else
+    m_endJoint = CreateFakeJoint(m_starter.GetFinishSegment(), m_starter.GetFinishSegment());
+
+  m_reconstructedFakeJoints[m_startJoint] = {m_startSegment};
+  m_reconstructedFakeJoints[m_endJoint] = {m_endSegment};
+
+  m_startOutEdges = FindFirstJoints(startSegment, true /* fromStart */);
+  m_endOutEdges = FindFirstJoints(endSegment, false /* fromStart */);
+
+  m_savedWeight[m_endJoint] = Weight(0.0);
+  for (auto const & edge : m_endOutEdges)
+    m_savedWeight[edge.GetTarget()] = edge.GetWeight();
+
+  m_init = true;
+}
+
+RouteWeight IndexGraphStarterJoints::HeuristicCostEstimate(JointSegment const & from, JointSegment const & to)
+{
+  Segment fromSegment;
+  Segment toSegment;
+
+  if (to.IsFake() || IsInvisible(to))
+    toSegment = m_fakeJointSegments[to].GetSegment(false /* start */);
+  else
+    toSegment = to.GetSegment(false /* start */);
+
+  if (from.IsFake() || IsInvisible(from))
+    fromSegment = m_fakeJointSegments[from].GetSegment(false /* start */);
+  else
+    fromSegment = from.GetSegment(false /* start */);
+
+  return m_starter.HeuristicCostEstimate(fromSegment, toSegment);
+}
+
+m2::PointD const & IndexGraphStarterJoints::GetPoint(JointSegment const & jointSegment, bool start)
+{
+  Segment segment;
+  if (jointSegment.IsFake())
+    segment = m_fakeJointSegments[jointSegment].GetSegment(start);
+  else
+    segment = jointSegment.GetSegment(start);
+
+  return m_starter.GetPoint(segment, jointSegment.IsForward());
+}
+
+std::vector<Segment> IndexGraphStarterJoints::ReconstructJoint(JointSegment const & joint)
+{
+  // We have invisible JointSegments, which are come from start to start or end to end.
+  // They need just for generic algorithm working. So we skip such objects.
+  if (IsInvisible(joint))
+    return {};
+
+  // In case of a fake vertex we return its prebuild path.
+  if (joint.IsFake())
+  {
+    auto it = m_reconstructedFakeJoints.find(joint);
+    CHECK(it != m_reconstructedFakeJoints.end(), ("Can not find such fake joint"));
+
+    return it->second;
+  }
+
+  // Otherwise just reconstruct segment consequently.
+  std::vector<Segment> subpath;
+
+  Segment currentSegment = joint.GetSegment(true /* start */);
+  Segment lastSegment = joint.GetSegment(false /* start */);
+
+  bool forward = currentSegment.GetSegmentIdx() < lastSegment.GetSegmentIdx();
+  while (currentSegment != lastSegment)
+  {
+    subpath.emplace_back(currentSegment);
+    currentSegment.Next(forward);
+  }
+
+  subpath.emplace_back(lastSegment);
+
+  return subpath;
+}
+
+void IndexGraphStarterJoints::AddFakeJoints(Segment const & segment, bool isOutgoing,
+                                            std::vector<JointEdge> & edges)
+{
+  // If |isOutgoing| is true, we need real segments, that are real parts
+  // of fake joints, entered to finish and vice versa.
+  std::vector<JointEdge> const & endings = isOutgoing ? m_endOutEdges : m_startOutEdges;
+
+  bool opposite = !isOutgoing;
+  for (auto const & edge : endings)
+  {
+    // The one end of FakeJointSegment is start/finish and the opposite end is real segment.
+    // So we check, whether |segment| is equal to the real segment of FakeJointSegment.
+    // If yes, that means, that we can go from |segment| to start/finish.
+    Segment firstSegment = m_fakeJointSegments[edge.GetTarget()].GetSegment(!opposite /* start */);
+    if (firstSegment == segment)
+    {
+      edges.emplace_back(edge);
+      return;
+    }
+  }
+}
+
+void IndexGraphStarterJoints::GetEdgeList(JointSegment const & vertex, bool isOutgoing,
+                                          std::vector<JointEdge> & edges)
+{
+  CHECK(m_init, ("IndexGraphStarterJoints was not initialized."));
+
+  edges.clear();
+
+  Segment parentSegment;
+
+  // This vector needs for backward A* search. Assume, we have parent and child_1, child_2.
+  // In this case we will save next weights:
+  // 1) from child_1 to parent.
+  // 2) from child_2 to parent.
+  // That needs for correct edges weights calculation.
+  std::vector<Weight> parentWeights;
+  size_t firstFakeId = 0;
+
+  // Case of fake start or finish joints.
+  // Note: startJoint and finishJoint are just loops
+  //       from start to start or end to end vertex.
+  if (vertex == GetStartJoint())
+  {
+    edges.insert(edges.end(), m_startOutEdges.begin(), m_startOutEdges.end());
+    parentWeights.insert(parentWeights.end(), edges.size(), Weight(0.0));
+    firstFakeId = edges.size();
+  }
+  else if (vertex == GetFinishJoint())
+  {
+    edges.insert(edges.end(), m_endOutEdges.begin(), m_endOutEdges.end());
+    // If vertex is FinishJoint, parentWeight is equal to zero, because the first vertex is zero-weight loop.
+    parentWeights.insert(parentWeights.end(), edges.size(), Weight(0.0));
+  }
+  else
+  {
+    bool opposite = !isOutgoing;
+    if (vertex.IsFake())
+    {
+      CHECK(m_fakeJointSegments.find(vertex) != m_fakeJointSegments.end(),
+            ("No such fake joint:", vertex, "in JointStarter."));
+
+      FakeJointSegment fakeJointSegment = m_fakeJointSegments[vertex];
+
+      auto const & startSegment = isOutgoing ? m_startSegment : m_endSegment;
+      auto const & endSegment = isOutgoing ? m_endSegment : m_startSegment;
+      auto const & endJoint = isOutgoing ? GetFinishJoint() : GetStartJoint();
+
+      // This is case when we can build route from start to finish without real segment, only fake.
+      // It happens when start and finish are close to each other.
+      // If we want A* stop, we should add |endJoint| to its queue, then A* will see the vertex: |endJoint|
+      // where it has already been and stop working.
+      if (fakeJointSegment.GetSegment(opposite /* start */) == endSegment)
+      {
+        if (isOutgoing)
+        {
+          static auto constexpr kZeroWeight = RouteWeight(0.0);
+          edges.emplace_back(endJoint, kZeroWeight);
+        }
+        else
+        {
+          auto it = m_savedWeight.find(vertex);
+          CHECK(it != m_savedWeight.end(), ("Can not find weight for:", vertex));
+
+          Weight const & weight = it->second;
+          edges.emplace_back(endJoint, weight);
+        }
+        return;
+      }
+
+      CHECK(fakeJointSegment.GetSegment(!opposite /* start */) == startSegment, ());
+      parentSegment = fakeJointSegment.GetSegment(opposite /* start */);
+    }
+    else
+    {
+      parentSegment = vertex.GetSegment(opposite /* start */);
+    }
+
+    std::vector<JointEdge> jointEdges;
+    m_starter.GetGraph().GetEdgeList(parentSegment, isOutgoing, jointEdges, parentWeights);
+    edges.insert(edges.end(), jointEdges.begin(), jointEdges.end());
+
+    firstFakeId = edges.size();
+    for (size_t i = 0; i < jointEdges.size(); ++i)
+    {
+      size_t prevSize = edges.size();
+      AddFakeJoints(jointEdges[i].GetTarget().GetSegment(!opposite /* start */), isOutgoing, edges);
+
+      // If we add fake edge, we should add new parentWeight as "child[i] -> parent".
+      // Because fake edge and current edge (jointEdges[i]) have the same first
+      // segments (differ only the ends), so we add to |parentWeights| the same
+      // value: parentWeights[i].
+      if (edges.size() != prevSize)
+      {
+        CHECK_LESS(i, parentWeights.size(), ());
+        parentWeights.emplace_back(parentWeights[i]);
+      }
+    }
+  }
+
+  if (!isOutgoing)
+  {
+    // |parentSegment| is parent-vertex from which we search children.
+    // For correct weight calculation we should get weight of JointSegment, that
+    // ends in |parentSegment| and add |parentWeight[i]| to the saved value.
+    auto it = m_savedWeight.find(vertex);
+    CHECK(it != m_savedWeight.end(), ("Can not find weight for:", vertex));
+
+    Weight const & weight = it->second;
+    for (size_t i = 0; i < edges.size(); ++i)
+    {
+      // Saving weight of current edges for returning in the next iterations.
+      m_savedWeight[edges[i].GetTarget()] = edges[i].GetWeight();
+      // For parent JointSegment we know its weight without last segment, because for each child
+      // it will differ (child_1 => parent != child_2 => parent), but (!) we save this weight in
+      // |parentWeights[]|. So the weight of an ith edge is a cached "weight of parent JointSegment" +
+      // "parentWeight[i]".
+      CHECK_LESS(i, parentWeights.size(), ());
+      edges[i].GetWeight() = weight + parentWeights[i];
+    }
+
+    // Delete useless weight of parent JointSegment.
+    m_savedWeight.erase(it);
+  }
+  else
+  {
+    // This needs for correct weights calculation of FakeJointSegments during forward A* search.
+    for (size_t i = firstFakeId; i < edges.size(); ++i)
+      edges[i].GetWeight() += parentWeights[i];
+  }
+}
+
+JointSegment IndexGraphStarterJoints::CreateFakeJoint(Segment const & from, Segment const & to)
+{
+  JointSegment jointSegment;
+  jointSegment.ToFake(m_fakeId++);
+
+  FakeJointSegment fakeJointSegment(from, to);
+  m_fakeJointSegments[jointSegment] = fakeJointSegment;
+
+  return jointSegment;
+}
+
+std::vector<JointEdge> IndexGraphStarterJoints::FindFirstJoints(Segment const & startSegment, bool fromStart)
+{
+  Segment endSegment = fromStart ? m_endSegment : m_startSegment;
+
+  std::queue<Segment> queue;
+  queue.emplace(startSegment);
+
+  std::map<Segment, Segment> parent;
+  std::map<Segment, RouteWeight> weight;
+  std::vector<JointEdge> result;
+
+  auto const reconstructPath = [&parent, &startSegment, &endSegment](Segment current, bool forward) {
+    std::vector<Segment> path;
+    // In case we can go from start to finish without joint (e.g. start and finish at
+    // the same long feature), we don't add the last segment to path for correctness
+    // reconstruction of the route. Otherwise last segment will repeat twice.
+    if (current != endSegment)
+      path.emplace_back(current);
+
+    if (current == startSegment)
+      return path;
+
+    for (;;)
+    {
+      Segment parentSegment = parent[current];
+
+      path.emplace_back(parentSegment);
+      if (parentSegment == startSegment)
+        break;
+      current = parentSegment;
+    }
+
+    if (forward)
+      std::reverse(path.begin(), path.end());
+
+    return path;
+  };
+
+  auto const addFake = [&](Segment const & segment, Segment const & beforeConvert)
+  {
+    JointSegment fakeJoint;
+    fakeJoint = fromStart ? CreateFakeJoint(startSegment, segment) :
+                            CreateFakeJoint(segment, startSegment);
+    result.emplace_back(fakeJoint, weight[beforeConvert]);
+
+    std::vector<Segment> path = reconstructPath(beforeConvert, fromStart);
+    m_reconstructedFakeJoints.emplace(fakeJoint, std::move(path));
+  };
+
+  auto const isEndOfSegment = [&](Segment const & fake, Segment const & segment)
+  {
+    CHECK(!fake.IsRealSegment(), ());
+
+    auto fakeEnd = m_starter.GetPoint(fake, fake.IsForward());
+    auto realEnd = m_starter.GetPoint(segment, segment.IsForward());
+
+    static auto constexpr kEps = 1e-5;
+    return base::AlmostEqualAbs(fakeEnd, realEnd, kEps);
+  };
+
+  while (!queue.empty())
+  {
+    Segment segment = queue.front();
+    queue.pop();
+    Segment beforeConvert = segment;
+    // Either the segment is fake and it can be converted to real one with |Joint| end (RoadPoint),
+    // or it's the real one and its end (RoadPoint) is |Joint|.
+    if (((!segment.IsRealSegment() && m_starter.ConvertToReal(segment) &&
+          isEndOfSegment(beforeConvert, segment)) || beforeConvert.IsRealSegment()) &&
+        IsJoint(segment, fromStart))
+    {
+      addFake(segment, beforeConvert);
+      continue;
+    }
+
+    if (beforeConvert == endSegment)
+    {
+      addFake(segment, beforeConvert);
+      continue;
+    }
+
+    std::vector<SegmentEdge> edges;
+    m_starter.GetEdgesList(beforeConvert, fromStart, edges);
+    for (auto const & edge : edges)
+    {
+      Segment const & child = edge.GetTarget();
+      auto const & newWeight = weight[beforeConvert] + edge.GetWeight();
+      if (weight.find(child) == weight.end() || weight[child] > newWeight)
+      {
+        parent[child] = beforeConvert;
+        weight[child] = newWeight;
+        queue.emplace(child);
+      }
+    }
+  }
+
+  return result;
+}
+
+JointSegment IndexGraphStarterJoints::CreateInvisibleJoint(Segment const & segment, bool start)
+{
+  JointSegment result;
+  result.ToFake(start ? kInvisibleId : kInvisibleId + 1);
+  m_fakeJointSegments[result] = FakeJointSegment(segment, segment);
+
+  return result;
+}
+
+bool IndexGraphStarterJoints::IsInvisible(JointSegment const & jointSegment) const
+{
+  return jointSegment.GetStartSegmentId() == jointSegment.GetEndSegmentId() &&
+         jointSegment.GetStartSegmentId() >= kInvisibleId &&
+         jointSegment.GetStartSegmentId() != std::numeric_limits<uint32_t>::max();
+}
+
+bool IndexGraphStarterJoints::IsJoint(Segment const & segment, bool fromStart)
+{
+  return m_starter.GetGraph().GetIndexGraph(segment.GetMwmId())
+                  .IsJoint(segment.GetRoadPoint(fromStart));
+}
+}  // namespace routing

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "routing/index_graph_starter.hpp"
+#include "routing/joint_segment.hpp"
+#include "routing/segment.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <map>
+#include <queue>
+#include <set>
+#include <vector>
+
+namespace routing
+{
+class IndexGraphStarterJoints
+{
+public:
+  using Vertex = JointSegment;
+  using Edge = JointEdge;
+  using Weight = RouteWeight;
+
+  explicit IndexGraphStarterJoints(IndexGraphStarter & starter) : m_starter(starter) {}
+  IndexGraphStarterJoints(IndexGraphStarter & starter,
+                          Segment const & startSegment,
+                          Segment const & endSegment);
+
+  void Init(Segment const & startSegment, Segment const & endSegment);
+
+  JointSegment const & GetStartJoint() const { return m_startJoint; }
+  JointSegment const & GetFinishJoint() const { return m_endJoint; }
+
+  // These functions are A* interface.
+  RouteWeight HeuristicCostEstimate(JointSegment const & from, JointSegment const & to);
+
+  m2::PointD const & GetPoint(JointSegment const & jointSegment, bool start);
+
+  void GetOutgoingEdgesList(JointSegment const & vertex, std::vector<JointEdge> & edges)
+  {
+    GetEdgeList(vertex, true /* isOutgoing */, edges);
+  }
+
+  void GetIngoingEdgesList(JointSegment const & vertex, std::vector<JointEdge> & edges)
+  {
+    GetEdgeList(vertex, false /* isOutgoing */, edges);
+  }
+
+  WorldGraph::Mode GetMode() const { return m_starter.GetMode(); }
+  // End of A* interface.
+
+  IndexGraphStarter & GetStarter() { return m_starter; }
+
+  /// \brief Reconstructs JointSegment by segment after building the route.
+  std::vector<Segment> ReconstructJoint(JointSegment const & joint);
+
+private:
+  static auto constexpr kInvisibleId = std::numeric_limits<uint32_t>::max() - 2;
+
+  struct FakeJointSegment
+  {
+    FakeJointSegment() = default;
+    FakeJointSegment(Segment const & start, Segment const & end)
+      : m_start(start), m_end(end) {}
+
+    Segment GetSegment(bool start) const
+    {
+      return start ? m_start : m_end;
+    }
+
+    Segment m_start;
+    Segment m_end;
+  };
+
+  void AddFakeJoints(Segment const & segment, bool isOutgoing, std::vector<JointEdge> & edges);
+
+  void GetEdgeList(JointSegment const & vertex, bool isOutgoing, std::vector<JointEdge> & edges);
+
+  JointSegment CreateFakeJoint(Segment const & from, Segment const & to);
+
+  bool IsJoint(Segment const & segment, bool fromStart);
+
+  /// \brief Makes BFS from |startSegment| in direction |fromStart| and find the closest segments
+  /// which end RoadPoints are joints. Thus we build fake joint segments graph.
+  std::vector<JointEdge> FindFirstJoints(Segment const & startSegment, bool fromStart);
+
+  JointSegment CreateInvisibleJoint(Segment const & segment, bool start);
+
+  bool IsInvisible(JointSegment const & jointSegment) const;
+
+  // For GetEdgeList from segments.
+  IndexGraphStarter & m_starter;
+
+  // Fake start and end joints.
+  JointSegment m_startJoint;
+  JointSegment m_endJoint;
+
+  Segment m_startSegment;
+  Segment m_endSegment;
+
+  // See comments in |GetEdgeList()| about |m_savedWeight|.
+  std::map<JointSegment, Weight> m_savedWeight;
+
+  // JointSegment consists of two segments of one feature.
+  // FakeJointSegment consists of two segments of different features.
+  // So we create an invalid JointSegment (see |ToFake()| method), that
+  // converts to FakeJointSegments. This std::map is converter.
+  std::map<JointSegment, FakeJointSegment> m_fakeJointSegments;
+  std::map<JointSegment, std::vector<Segment>> m_reconstructedFakeJoints;
+
+  // List of JointEdges that are outgoing from start.
+  std::vector<JointEdge> m_startOutEdges;
+  // List of incoming to finish.
+  std::vector<JointEdge> m_endOutEdges;
+
+  uint32_t m_fakeId = 0;
+  bool m_init = false;
+};
+}  // namespace routing

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -8,6 +8,7 @@
 #include "routing/edge_estimator.hpp"
 #include "routing/fake_edges_container.hpp"
 #include "routing/features_road_graph.hpp"
+#include "routing/index_graph_starter_joints.hpp"
 #include "routing/joint.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
@@ -107,15 +108,20 @@ private:
 
   // Input route may contains 'leaps': shortcut edges from mwm border enter to exit.
   // ProcessLeaps replaces each leap with calculated route through mwm.
-  RouterResultCode ProcessLeaps(std::vector<Segment> const & input,
-                                   RouterDelegate const & delegate, WorldGraph::Mode prevMode,
-                                   IndexGraphStarter & starter, std::vector<Segment> & output);
+  RouterResultCode ProcessLeapsJoints(vector<Segment> const & input, RouterDelegate const & delegate,
+                                      WorldGraph::Mode prevMode, IndexGraphStarter & starter,
+                                      vector<Segment> & output);
   RouterResultCode RedressRoute(std::vector<Segment> const & segments,
                                 RouterDelegate const & delegate, IndexGraphStarter & starter,
                                 Route & route) const;
 
+  void ProcessJointsBidirectional(std::vector<JointSegment> const & jointsPath,
+                                  IndexGraphStarterJoints & jointsStarter,
+                                  std::vector<Segment> & output);
+
   bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
   bool DoesTransitSectionExist(NumMwmId numMwmId) const;
+
   RouterResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,
                                         RouterResultCode resultCode) const;
 

--- a/routing/joint_segment.cpp
+++ b/routing/joint_segment.cpp
@@ -1,0 +1,87 @@
+#include "routing/joint_segment.hpp"
+
+#include "base/assert.hpp"
+
+#include <sstream>
+
+namespace routing
+{
+
+JointSegment::JointSegment(Segment const & from, Segment const & to)
+{
+  CHECK(from.IsRealSegment() && to.IsRealSegment(),
+        ("Segments of joints can not be fake. Only through ToFake() method."));
+
+  CHECK_EQUAL(from.GetMwmId(), to.GetMwmId(), ("Different mwmIds in segments for JointSegment"));
+  m_numMwmId = from.GetMwmId();
+
+  CHECK_EQUAL(from.IsForward(), to.IsForward(), ("Different forward in segments for JointSegment"));
+  m_forward = from.IsForward();
+
+  CHECK_EQUAL(from.GetFeatureId(), to.GetFeatureId(), ());
+  m_featureId = from.GetFeatureId();
+
+  m_startSegmentId = from.GetSegmentIdx();
+  m_endSegmentId = to.GetSegmentIdx();
+}
+
+void JointSegment::ToFake(uint32_t fakeId)
+{
+  m_featureId = kInvalidId;
+  m_startSegmentId = fakeId;
+  m_endSegmentId = fakeId;
+  m_numMwmId = kFakeNumMwmId;
+  m_forward = false;
+}
+
+bool JointSegment::IsFake() const
+{
+  // This is enough, but let's check in Debug for confidence.
+  bool result = m_featureId == kInvalidId && m_startSegmentId != kInvalidId;
+  if (result)
+  {
+    ASSERT_EQUAL(m_startSegmentId, m_endSegmentId, ());
+    ASSERT_EQUAL(m_numMwmId, kFakeNumMwmId, ());
+    ASSERT_EQUAL(m_forward, false, ());
+  }
+
+  return result;
+}
+
+bool JointSegment::operator<(JointSegment const & rhs) const
+{
+  if (m_featureId != rhs.GetFeatureId())
+    return m_featureId < rhs.GetFeatureId();
+
+  if (m_forward != rhs.IsForward())
+    return m_forward < rhs.IsForward();
+
+  if (m_startSegmentId != rhs.m_startSegmentId)
+    return m_startSegmentId < rhs.m_startSegmentId;
+
+  if (m_endSegmentId != rhs.m_endSegmentId)
+    return m_endSegmentId < rhs.m_endSegmentId;
+
+  return m_numMwmId < rhs.GetMwmId();
+}
+
+bool JointSegment::operator==(JointSegment const & rhs) const
+{
+  return m_featureId == rhs.m_featureId && m_forward == rhs.m_forward &&
+         m_startSegmentId == rhs.m_startSegmentId && m_endSegmentId == rhs.m_endSegmentId &&
+         m_numMwmId == rhs.m_numMwmId;
+}
+
+std::string DebugPrint(JointSegment const & jointSegment)
+{
+  std::ostringstream out;
+  if (jointSegment.IsFake())
+    out << "[FAKE]";
+
+  out << std::boolalpha
+      << "JointSegment(" << jointSegment.GetMwmId() << ", " << jointSegment.GetFeatureId() << ", "
+      << "[" << jointSegment.GetStartSegmentId() << " => " << jointSegment.GetEndSegmentId() << "], "
+      << jointSegment.IsForward() << ")";
+  return out.str();
+}
+}  // namespace routing

--- a/routing/joint_segment.hpp
+++ b/routing/joint_segment.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "routing/road_point.hpp"
+#include "routing/route_weight.hpp"
+#include "routing/segment.hpp"
+
+#include "base/assert.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace routing
+{
+class JointSegment
+{
+public:
+  JointSegment() = default;
+  JointSegment(Segment const & from, Segment const & to);
+
+  uint32_t GetFeatureId() const { return m_featureId; }
+  NumMwmId GetMwmId() const { return m_numMwmId; }
+  uint32_t GetStartSegmentId() const { return m_startSegmentId; }
+  uint32_t GetEndSegmentId() const { return m_endSegmentId; }
+  bool IsForward() const { return m_forward; }
+
+  void ToFake(uint32_t fakeId);
+  bool IsFake() const;
+
+  Segment GetSegment(bool start) const
+  {
+    return {m_numMwmId, m_featureId, start ? m_startSegmentId : m_endSegmentId, m_forward};
+  }
+
+  bool operator<(JointSegment const & rhs) const;
+  bool operator==(JointSegment const & rhs) const;
+
+private:
+  static uint32_t constexpr kInvalidId = std::numeric_limits<uint32_t>::max();
+  uint32_t m_featureId = kInvalidId;
+  uint32_t m_startSegmentId = kInvalidId;
+  uint32_t m_endSegmentId = kInvalidId;
+  NumMwmId m_numMwmId = kFakeNumMwmId;
+  bool m_forward = false;
+};
+
+class JointEdge
+{
+public:
+  JointEdge(JointSegment const & target, RouteWeight const & weight)
+    : m_target(target), m_weight(weight) {}
+
+  JointSegment const & GetTarget() const { return m_target; }
+  RouteWeight & GetWeight() { return m_weight; }
+  RouteWeight const & GetWeight() const { return m_weight; }
+
+private:
+  JointSegment m_target;
+  RouteWeight m_weight;
+};
+
+std::string DebugPrint(JointSegment const & jointSegment);
+}  // namespace routing

--- a/routing/road_index.cpp
+++ b/routing/road_index.cpp
@@ -17,13 +17,4 @@ void RoadIndex::Import(vector<Joint> const & joints)
     }
   }
 }
-
-pair<Joint::Id, uint32_t> RoadIndex::FindNeighbor(RoadPoint const & rp, bool forward) const
-{
-  auto const it = m_roads.find(rp.GetFeatureId());
-  if (it == m_roads.cend())
-    MYTHROW(RoutingException, ("RoadIndex doesn't contains feature", rp.GetFeatureId()));
-
-  return it->second.FindNeighbor(rp.GetPointId(), forward);
-}
 }  // namespace routing

--- a/routing/road_index.hpp
+++ b/routing/road_index.hpp
@@ -2,6 +2,7 @@
 
 #include "routing/joint.hpp"
 
+#include "base/assert.hpp"
 #include "base/checked_cast.hpp"
 
 #include "std/algorithm.hpp"
@@ -73,37 +74,33 @@ public:
     }
   }
 
-  pair<Joint::Id, uint32_t> FindNeighbor(uint32_t pointId, bool forward) const
+  pair<Joint::Id, uint32_t> FindNeighbor(uint32_t pointId, bool forward, uint32_t pointsNumber) const
   {
-    uint32_t const size = static_cast<uint32_t>(m_jointIds.size());
-    pair<Joint::Id, uint32_t> result = make_pair(Joint::kInvalidId, 0);
+    CHECK_GREATER_OR_EQUAL(pointsNumber, 2, ("Number of points of road should be greater or equal 2"));
 
+    uint32_t index = 0;
     if (forward)
     {
-      for (uint32_t i = pointId + 1; i < size; ++i)
+      for (index = pointId + 1; index < pointsNumber; ++index)
       {
-        Joint::Id const jointId = m_jointIds[i];
+        Joint::Id const jointId = GetJointId(index);
         if (jointId != Joint::kInvalidId)
-        {
-          result = {jointId, i};
-          return result;
-        }
+          return {jointId, index};
       }
     }
     else
     {
-      for (uint32_t i = min(pointId, size) - 1; i < size; --i)
+      for (index = min(pointId, pointsNumber) - 1; index < pointsNumber; --index)
       {
-        Joint::Id const jointId = m_jointIds[i];
+        Joint::Id const jointId = GetJointId(index);
         if (jointId != Joint::kInvalidId)
-        {
-          result = {jointId, i};
-          return result;
-        }
+          return {jointId, index};
       }
     }
 
-    return result;
+    // Return the end or start of road, depends on forward flag.
+    index = forward ? pointsNumber - 1 : 0;
+    return {Joint::kInvalidId, index};
   }
 
 private:

--- a/routing/road_point.hpp
+++ b/routing/road_point.hpp
@@ -51,6 +51,8 @@ public:
     }
   };
 
+  void SetPointId(uint32_t pointId) { m_pointId = pointId; }
+
 private:
   uint32_t m_featureId;
   uint32_t m_pointId;

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -81,6 +81,11 @@ public:
     return m_mwmId != kFakeNumMwmId && !FakeFeatureIds::IsTransitFeature(m_featureId);
   }
 
+  void Next(bool forward)
+  {
+    forward ? ++m_segmentIdx : --m_segmentIdx;
+  }
+
 private:
   uint32_t m_featureId = 0;
   uint32_t m_segmentIdx = 0;
@@ -91,6 +96,7 @@ private:
 class SegmentEdge final
 {
 public:
+  SegmentEdge() = default;
   SegmentEdge(Segment const & target, RouteWeight const & weight)
     : m_target(target), m_weight(weight)
   {

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -5,6 +5,7 @@
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
+#include "routing/joint_segment.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/segment.hpp"
@@ -32,6 +33,10 @@ public:
 
   void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) override;
+
+  void GetEdgeList(Segment const & parent, bool isOutgoing,
+                   std::vector<JointEdge> & jointEdges, std::vector<RouteWeight> & parentWeights) override;
+
   bool CheckLength(RouteWeight const &, double) const override { return true; }
   Junction const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
@@ -59,7 +64,17 @@ public:
     return m_loader->GetIndexGraph(numMwmId);
   }
 
+  IndexGraph & GetIndexGraph(NumMwmId numMwmId) override
+  {
+    return m_loader->GetIndexGraph(numMwmId);
+  }
+
 private:
+  // Retrieves the same |jointEdges|, but into others mwms.
+  // If they are cross mwm edges, of course.
+  void CheckAndProcessTransitFeatures(std::vector<JointEdge> & jointEdges,
+                                      std::vector<RouteWeight> & parentWeights,
+                                      bool isOutgoing);
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
 

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -25,6 +25,13 @@ TransitWorldGraph::TransitWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
 }
 
 void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
+                                    std::vector<JointEdge> & edges,
+                                    std::vector<RouteWeight> & parentWeights)
+{
+  CHECK(false, ("TransitWorldGraph does not support Joints mode."));
+}
+
+void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
                                     vector<SegmentEdge> & edges)
 {
   auto & transitGraph = GetTransitGraph(segment.GetMwmId());
@@ -200,11 +207,6 @@ void TransitWorldGraph::AddRealEdges(Segment const & segment, bool isOutgoing,
   auto & indexGraph = GetIndexGraph(segment.GetMwmId());
   indexGraph.GetEdgeList(segment, isOutgoing, edges);
   GetTwins(segment, isOutgoing, edges);
-}
-
-IndexGraph & TransitWorldGraph::GetIndexGraph(NumMwmId mwmId)
-{
-  return m_indexLoader->GetIndexGraph(mwmId);
 }
 
 TransitGraph & TransitWorldGraph::GetTransitGraph(NumMwmId mwmId)

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -63,6 +63,15 @@ public:
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
   std::vector<RouteSegment::SpeedCamera> GetSpeedCamInfo(Segment const & segment) override;
 
+  void GetEdgeList(Segment const & segment, bool isOutgoing,
+                   std::vector<JointEdge> & edges,
+                   std::vector<RouteWeight> & parentWeights) override;
+
+  IndexGraph & GetIndexGraph(NumMwmId numMwmId) override
+  {
+    return m_indexLoader->GetIndexGraph(numMwmId);
+  }
+
 private:
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
@@ -76,7 +85,6 @@ private:
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
-  IndexGraph & GetIndexGraph(NumMwmId mwmId);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -43,6 +43,8 @@ std::string DebugPrint(WorldGraph::Mode mode)
   case WorldGraph::Mode::LeapsOnly: return "LeapsOnly";
   case WorldGraph::Mode::NoLeaps: return "NoLeaps";
   case WorldGraph::Mode::SingleMwm: return "SingleMwm";
+  case WorldGraph::Mode::Joints: return "Joints";
+  case WorldGraph::Mode::JointSingleMwm: return "JointsSingleMwm";
   }
 
   UNREACHABLE();

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -2,6 +2,7 @@
 
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
+#include "routing/joint_segment.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/segment.hpp"
@@ -27,18 +28,22 @@ public:
 
   enum class Mode
   {
-    LeapsOnly,  // Mode for building a cross mwm route containing only leaps. In case of start and
-                // finish they (start and finish) will be connected with all transition segments of
-                // their mwm with leap (fake) edges.
-    NoLeaps,    // Mode for building route and getting outgoing/ingoing edges without leaps at all.
-    SingleMwm,  // Mode for building route and getting outgoing/ingoing edges within mwm source
-                // segment belongs to.
+    LeapsOnly,      // Mode for building a cross mwm route containing only leaps. In case of start and
+                    // finish they (start and finish) will be connected with all transition segments of
+                    // their mwm with leap (fake) edges.
+    NoLeaps,        // Mode for building route and getting outgoing/ingoing edges without leaps at all.
+    SingleMwm,      // Mode for building route and getting outgoing/ingoing edges within mwm source
+                    // segment belongs to.
+    Joints,         // Mode for building route with jumps between Joints.
+    JointSingleMwm  // Like |SingleMwm|, but in |Joints| mode.
   };
 
   virtual ~WorldGraph() = default;
 
   virtual void GetEdgeList(Segment const & segment, bool isOutgoing,
                            std::vector<SegmentEdge> & edges) = 0;
+  virtual void GetEdgeList(Segment const & segment, bool isOutgoing,
+                           std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights) = 0;
 
   // Checks whether path length meets restrictions. Restrictions may depend on the distance from
   // start to finish of the route.
@@ -75,6 +80,8 @@ public:
   virtual std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) = 0;
 
   virtual std::vector<RouteSegment::SpeedCamera> GetSpeedCamInfo(Segment const & segment) = 0;
+
+  virtual IndexGraph & GetIndexGraph(NumMwmId numMwmId) = 0;
 
 protected:
   void GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 		40C645171F8D167F002E05A0 /* fake_ending.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C645151F8D167E002E05A0 /* fake_ending.hpp */; };
 		40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */; };
 		40F7F3E51F7D246D0082D564 /* single_vehicle_world_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */; };
+		4408A63B21F1E7F0008171B8 /* index_graph_starter_joints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4408A63721F1E7F0008171B8 /* index_graph_starter_joints.cpp */; };
+		4408A63C21F1E7F0008171B8 /* joint_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4408A63821F1E7F0008171B8 /* joint_segment.hpp */; };
+		4408A63D21F1E7F0008171B8 /* index_graph_starter_joints.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */; };
+		4408A63E21F1E7F0008171B8 /* joint_segment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4408A63A21F1E7F0008171B8 /* joint_segment.cpp */; };
 		44AE4A12214FBB8E006321F5 /* speed_camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44AE4A10214FBB8D006321F5 /* speed_camera.cpp */; };
 		44AE4A13214FBB8E006321F5 /* speed_camera.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44AE4A11214FBB8D006321F5 /* speed_camera.hpp */; };
 		44E5574A2136EEC900B01439 /* speed_camera_ser_des.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44E557492136EEC800B01439 /* speed_camera_ser_des.hpp */; };
@@ -368,6 +372,10 @@
 		40C645151F8D167E002E05A0 /* fake_ending.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_ending.hpp; sourceTree = "<group>"; };
 		40F7F3E21F7D246C0082D564 /* single_vehicle_world_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = single_vehicle_world_graph.hpp; sourceTree = "<group>"; };
 		40F7F3E31F7D246D0082D564 /* single_vehicle_world_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = single_vehicle_world_graph.cpp; sourceTree = "<group>"; };
+		4408A63721F1E7F0008171B8 /* index_graph_starter_joints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_starter_joints.cpp; sourceTree = "<group>"; };
+		4408A63821F1E7F0008171B8 /* joint_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = joint_segment.hpp; sourceTree = "<group>"; };
+		4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_starter_joints.hpp; sourceTree = "<group>"; };
+		4408A63A21F1E7F0008171B8 /* joint_segment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = joint_segment.cpp; sourceTree = "<group>"; };
 		44AE4A10214FBB8D006321F5 /* speed_camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera.cpp; sourceTree = "<group>"; };
 		44AE4A11214FBB8D006321F5 /* speed_camera.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera.hpp; sourceTree = "<group>"; };
 		44E557492136EEC800B01439 /* speed_camera_ser_des.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_ser_des.hpp; sourceTree = "<group>"; };
@@ -804,6 +812,10 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				4408A63721F1E7F0008171B8 /* index_graph_starter_joints.cpp */,
+				4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */,
+				4408A63A21F1E7F0008171B8 /* joint_segment.cpp */,
+				4408A63821F1E7F0008171B8 /* joint_segment.hpp */,
 				56FEAA6D219E8A610073DF5F /* maxspeeds_serialization.cpp */,
 				56FEAA6C219E8A600073DF5F /* maxspeeds_serialization.hpp */,
 				5631B667219B125C009F47D4 /* maxspeeds.cpp */,
@@ -977,6 +989,7 @@
 				56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */,
 				0C5F5D231E798B0400307B98 /* cross_mwm_connector.hpp in Headers */,
 				40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */,
+				4408A63D21F1E7F0008171B8 /* index_graph_starter_joints.hpp in Headers */,
 				5670595E1F3AF97F0062672D /* checkpoint_predictor.hpp in Headers */,
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
@@ -1010,6 +1023,7 @@
 				0C090C821E4E274000D52AFD /* index_graph_loader.hpp in Headers */,
 				670EE5721B664796001E8064 /* directions_engine.hpp in Headers */,
 				56C439291E93BF8C00998E29 /* cross_mwm_graph.hpp in Headers */,
+				4408A63C21F1E7F0008171B8 /* joint_segment.hpp in Headers */,
 				0C81E1541F02589800DC66DF /* traffic_stash.hpp in Headers */,
 				40A111D01F2F9704005E6AD5 /* astar_weight.hpp in Headers */,
 				0C8705051E0182F200BCAF71 /* route_point.hpp in Headers */,
@@ -1256,6 +1270,7 @@
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
 				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
+				4408A63B21F1E7F0008171B8 /* index_graph_starter_joints.cpp in Sources */,
 				0C5F5D201E798B0400307B98 /* cross_mwm_connector_serialization.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
 				0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */,
@@ -1278,6 +1293,7 @@
 				0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */,
 				40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */,
 				40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */,
+				4408A63E21F1E7F0008171B8 /* joint_segment.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,
 				0C5F5D251E798B3800307B98 /* cross_mwm_connector_test.cpp in Sources */,
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,


### PR DESCRIPTION
Первая версия `JointSegment`. 
`JointSegment` - это прыжок в рамках одной фичи по подряд идущим сегментам.

`routing_integration_tests` полностью прошли, статистика в ссылка на confluence.
Oсновные изменения:
1) routing/joint_segment.[hpp|cpp]
2) routing/index_graph_starter_joints.[hpp|cpp]
3) routing/index_router.cpp
4) routing/single_vehicle_world_graph.cpp

Также был немного затронут `cross_mwm_graph`, так как по умолчанию мы не знаем транзитная фича или нет, а мне это надо было знать.

`astar_algorithm.hpp` никак не затронут, все нужное получилось уместить в `index_graph_starter_joints`

### Тут документация
### Прочтите ее, чтобы понять что происходит в процессе получения ребер
https://confluence.mail.ru/display/MAPSME/Joints+Routing