### PR TITLE
[routing] Adding comment about two geom caches for bidirectional A*.

### DIFF
--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -111,8 +111,8 @@ public:
 /// The reference may be invalid after the next call of GetRoad() or GetPoint() because the cache
 /// item which is referred by returned reference may be evicted. It's done for performance reasons.
 /// \note The cache |m_featureIdToRoad| is used for road geometry for single-directional
-/// and bidirectional A*. According to tests it's faster to use one cache for two directions
-/// in bidirectional A* case than own cache for each direction (A* wave).
+/// and bidirectional A*. According to tests it's faster to use one cache for both directions
+/// in bidirectional A* case than two separate caches, one for each direction (one for each A* wave).
 class Geometry final
 {
 public:

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -110,6 +110,9 @@ public:
 /// On the other hand methods GetRoad() and GetPoint() return geometry information by reference.
 /// The reference may be invalid after the next call of GetRoad() or GetPoint() because the cache
 /// item which is referred by returned reference may be evicted. It's done for performance reasons.
+/// \note The cache |m_featureIdToRoad| is used for road geometry for single-directional
+/// and bidirectional A*. According to tests it's faster to use one cache for two directions
+/// in bidirectional A* case than own cache for each direction (A* wave).
 class Geometry final
 {
 public:


### PR DESCRIPTION
Реализация 2 буферов для двух волн A* не дали ожидаемого эффекта. Добавил комментарий об этом. Ниже время запуска всех интеграционных тестов у меня на машине. Каждый эксперимент, кроме 2 буфера по 500К проводился трижды.

----------
1 буфер в 5К элементов
1th try. All tests take 276.631 seconds.
2th try. All tests take 257.073 seconds.
3th try. All tests take 257.136 seconds.

----------
2 буфера в 500 элементов
All tests take 470.91 seconds.

2 буфера по 2К элементов.FIXED
All tests take 270.481 seconds.
All tests take 274.045 seconds.
All tests take 274.631 seconds.

2 буфера по 2.5К элементов.FIXED
All tests take 272.869 seconds.
All tests take 271.721 seconds.
All tests take 271.761 seconds.

2 буфера по 3K элементов.FIXED
All tests take 286.565 seconds.
All tests take 270.296 seconds.
All tests take 266.893 seconds.

2 буфер в 5К элементов
All tests take 265.738 seconds.
All tests take 259.887 seconds.
All tests take 256.109 seconds.

----------

Кроме того, я пробовал менять частоту переключения волн A*:
kQueueSwitchPeriod = 128; (Как сейчас)
1th try. All tests take 287.876 seconds.
2th try. All tests take 274.607 seconds.
3th try. All tests take 272.941 seconds.

kQueueSwitchPeriod = 512;
1th try. All tests take 289.638 seconds.
2th try. All tests take 274.4 seconds.
3th try. All tests take 273.023 seconds.

kQueueSwitchPeriod = 32;
1th try. All tests take 289.626 seconds.
2th try. All tests take 276.735 seconds.
3th try. All tests take 279.149 seconds.

Т.е. как сейчас (kQueueSwitchPeriod = 128) вполне хороший вариант.

@mpimenov @gmoryes PTAL