### PR TITLE
[coding] Removed the CellId epsilon.

### DIFF
--- a/coding/coding_tests/geometry_serialization_test.cpp
+++ b/coding/coding_tests/geometry_serialization_test.cpp
@@ -19,12 +19,12 @@ namespace
 {
 bool IsEqual(double d1, double d2)
 {
-  return base::AlmostEqualAbs(d1, d2, kCellIdToPointEps);
+  return base::AlmostEqualAbs(d1, d2, kMwmPointAccuracy);
 }
 
 bool IsEqual(m2::PointD const & p1, m2::PointD const & p2)
 {
-  return p1.EqualDxDy(p2, kCellIdToPointEps);
+  return p1.EqualDxDy(p2, kMwmPointAccuracy);
 }
 
 bool IsEqual(m2::RectD const & r1, m2::RectD const & r2)

--- a/coding/coding_tests/point_coding_tests.cpp
+++ b/coding/coding_tests/point_coding_tests.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace
 {
-double const kEps = kCellIdToPointEps;
+double const kEps = kMwmPointAccuracy;
 uint8_t const kCoordBits = kPointCoordBits;
 uint32_t const kBig = uint32_t{1} << 30;
 

--- a/coding/point_coding.hpp
+++ b/coding/point_coding.hpp
@@ -36,9 +36,6 @@ uint8_t constexpr kFeatureSorterPointCoordBits = 27;
 // todo(@m) Clarify how kPointCoordBits and kFeatureSorterPointCoordBits are related.
 double constexpr kMwmPointAccuracy = 1e-5;
 
-// todo(@m) Explain this constant.
-double constexpr kCellIdToPointEps = 1e-4;
-
 uint32_t DoubleToUint32(double x, double min, double max, uint8_t coordBits);
 
 double Uint32ToDouble(uint32_t x, double min, double max, uint8_t coordBits);

--- a/drape_frontend/gui/ruler_helper.cpp
+++ b/drape_frontend/gui/ruler_helper.cpp
@@ -72,7 +72,7 @@ UnitValue g_arrYards[] = {
   { "500 mi", 500 * 1760 }
 };
 
-UnitValue g_arrMetres[] = {
+UnitValue g_arrMeters[] = {
   { "1 m", 1 },
   { "2 m", 2 },
   { "5 m", 5 },
@@ -114,10 +114,10 @@ void RulerHelper::Update(ScreenBase const & screen)
   m2::PointD pt1 = screen.PtoG(pivot);
   m2::PointD pt0 = screen.PtoG(pivot - m2::PointD(minPxWidth, 0));
 
-  double const distanceInMetres = MercatorBounds::DistanceOnEarth(pt0, pt1);
+  double const distanceInMeters = MercatorBounds::DistanceOnEarth(pt0, pt1);
 
   // convert metres to units for calculating m_metresDiff.
-  double metersDiff = CalcMetresDiff(distanceInMetres);
+  double metersDiff = CalcMetersDiff(distanceInMeters);
 
   bool const higherThanMax = metersDiff > kMaxMetersWidth;
   bool const lessThanMin = metersDiff < kMinMetersWidth;
@@ -205,7 +205,7 @@ void RulerHelper::GetTextInitInfo(string & alphabet, uint32_t & size) const
   };
 
   std::for_each(std::begin(g_arrFeets), std::end(g_arrFeets), functor);
-  std::for_each(std::begin(g_arrMetres), std::end(g_arrMetres), functor);
+  std::for_each(std::begin(g_arrMeters), std::end(g_arrMeters), functor);
   std::for_each(std::begin(g_arrYards), std::end(g_arrYards), functor);
 
   std::for_each(begin(symbols), end(symbols), [&alphabet](char c)
@@ -217,10 +217,10 @@ void RulerHelper::GetTextInitInfo(string & alphabet, uint32_t & size) const
   size = static_cast<uint32_t>(result) + 2; // add 2 char for symbols "< " and "> ".
 }
 
-double RulerHelper::CalcMetresDiff(double value)
+double RulerHelper::CalcMetersDiff(double value)
 {
-  UnitValue * arrU = g_arrMetres;
-  int count = ARRAY_SIZE(g_arrMetres);
+  UnitValue * arrU = g_arrMeters;
+  int count = ARRAY_SIZE(g_arrMeters);
 
   auto conversionFn = &Identity;
 

--- a/drape_frontend/gui/ruler_helper.hpp
+++ b/drape_frontend/gui/ruler_helper.hpp
@@ -27,7 +27,7 @@ public:
   void GetTextInitInfo(std::string & alphabet, uint32_t & size) const;
 
 private:
-  double CalcMetresDiff(double value);
+  double CalcMetersDiff(double value);
   void SetTextDirty();
 
 private:

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -408,7 +408,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   m2::PointD const oldPos = GetDrawablePosition();
   double const oldAzimut = GetDrawableAzimut();
 
-  m2::RectD const rect = MercatorBounds::MetresToXY(info.m_longitude, info.m_latitude,
+  m2::RectD const rect = MercatorBounds::MetersToXY(info.m_longitude, info.m_latitude,
                                                     info.m_horizontalAccuracy);
   // Use FromLatLon instead of rect.Center() since in case of large info.m_horizontalAccuracy
   // there is significant difference between the real location and the estimated one.

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -296,10 +296,10 @@ void RuleDrawer::ProcessAreaStyle(FeatureType & f, Stylist const & s,
     double const lon = MercatorBounds::XToLon(featureCenter.x);
     double const lat = MercatorBounds::YToLat(featureCenter.y);
 
-    m2::RectD rectMercator = MercatorBounds::MetresToXY(lon, lat, heightInMeters);
+    m2::RectD rectMercator = MercatorBounds::MetersToXY(lon, lat, heightInMeters);
     areaHeight = static_cast<float>((rectMercator.SizeX() + rectMercator.SizeY()) * 0.5);
 
-    rectMercator = MercatorBounds::MetresToXY(lon, lat, minHeightInMeters);
+    rectMercator = MercatorBounds::MetersToXY(lon, lat, minHeightInMeters);
     areaMinHeight = static_cast<float>((rectMercator.SizeX() + rectMercator.SizeY()) * 0.5);
   }
   else

--- a/editor/server_api.cpp
+++ b/editor/server_api.cpp
@@ -184,11 +184,11 @@ OsmOAuth::Response ServerApi06::GetXmlFeaturesInRect(double minLat, double minLo
 
 OsmOAuth::Response ServerApi06::GetXmlFeaturesAtLatLon(double lat, double lon, double radiusInMeters) const
 {
-  double const latDegreeOffset = radiusInMeters * MercatorBounds::degreeInMetres;
+  double const latDegreeOffset = radiusInMeters * MercatorBounds::kDegreesInMeter;
   double const minLat = max(-90.0, lat - latDegreeOffset);
   double const maxLat = min( 90.0, lat + latDegreeOffset);
   double const cosL = max(cos(base::DegToRad(max(fabs(minLat), fabs(maxLat)))), 0.00001);
-  double const lonDegreeOffset = radiusInMeters * MercatorBounds::degreeInMetres / cosL;
+  double const lonDegreeOffset = radiusInMeters * MercatorBounds::kDegreesInMeter / cosL;
   double const minLon = max(-180.0, lon - lonDegreeOffset);
   double const maxLon = min( 180.0, lon + lonDegreeOffset);
   return GetXmlFeaturesInRect(minLat, minLon, maxLat, maxLon);

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -192,12 +192,12 @@ namespace
 {
 bool IsEqual(double d1, double d2)
 {
-  return base::AlmostEqualAbs(d1, d2, kCellIdToPointEps);
+  return base::AlmostEqualAbs(d1, d2, kMwmPointAccuracy);
 }
 
 bool IsEqual(m2::PointD const & p1, m2::PointD const & p2)
 {
-  return p1.EqualDxDy(p2, kCellIdToPointEps);
+  return p1.EqualDxDy(p2, kMwmPointAccuracy);
 }
 
 bool IsEqual(m2::RectD const & r1, m2::RectD const & r2)
@@ -339,8 +339,10 @@ bool FeatureBuilder1::operator==(FeatureBuilder1 const & fb) const
     return false;
 
   for (auto i = m_polygons.cbegin(), j = fb.m_polygons.cbegin(); i != m_polygons.cend(); ++i, ++j)
+  {
     if (!IsEqual(*i, *j))
       return false;
+  }
 
   return true;
 }

--- a/generator/generator_tests/triangles_tree_coding_test.cpp
+++ b/generator/generator_tests/triangles_tree_coding_test.cpp
@@ -11,99 +11,96 @@
 
 namespace
 {
-  typedef m2::PointD P;
+using P = m2::PointD;
 
-  bool is_equal(P const & p1, P const & p2)
-  {
-    return p1.EqualDxDy(p2, kCellIdToPointEps);
-  }
+bool IsEqual(P const & p1, P const & p2)
+{
+  return p1.EqualDxDy(p2, kMwmPointAccuracy);
+}
 
-  bool FindTriangle(serial::OutPointsT const & test, P arr[])
+bool FindTriangle(serial::OutPointsT const & test, P arr[])
+{
+  size_t const count = test.size();
+  for (size_t i = 0; i < count; i += 3)
   {
-    size_t const count = test.size();
-    for (size_t i = 0; i < count; i+=3)
+    for (int base = 0; base < 3; ++base)
     {
-      for (int base = 0; base < 3; ++base)
-        if (is_equal(test[i], arr[base]) &&
-            is_equal(test[i+1], arr[(base+1)%3]) &&
-            is_equal(test[i+2], arr[(base+2)%3]))
-        {
-          return true;
-        }
-    }
-    return false;
-  }
-
-  void CompareTriangles(serial::OutPointsT const & test,
-                        P arrP[], int arrT[][3], size_t count)
-  {
-    TEST_EQUAL(test.size(), 3*count, (test));
-
-    for (size_t i = 0; i < count; ++i)
-    {
-      P trg[] = { arrP[arrT[i][0]], arrP[arrT[i][1]], arrP[arrT[i][2]] };
-      TEST ( FindTriangle(test, trg), ("Triangles : ", test, " Etalon : ", trg[0], trg[1], trg[2]) );
+      if (IsEqual(test[i], arr[base])
+          && IsEqual(test[i + 1], arr[(base + 1) % 3])
+          && IsEqual(test[i + 2], arr[(base + 2) % 3]))
+      {
+        return true;
+      }
     }
   }
+  return false;
+}
 
-  void TestTrianglesCoding(P arrP[], size_t countP, int arrT[][3], size_t countT)
+void CompareTriangles(serial::OutPointsT const & test, P arrP[], int arrT[][3], size_t count)
+{
+  TEST_EQUAL(test.size(), 3 * count, (test));
+
+  for (size_t i = 0; i < count; ++i)
   {
-    tesselator::TrianglesInfo info;
-    info.AssignPoints(arrP, arrP + countP);
-
-    info.Reserve(countT);
-
-    for (size_t i = 0; i < countT; ++i)
-      info.Add(arrT[i][0], arrT[i][1], arrT[i][2]);
-
-    serial::GeometryCodingParams cp;
-
-    serial::TrianglesChainSaver saver(cp);
-    tesselator::PointsInfo points;
-
-    m2::PointU (*D2U)(m2::PointD const &, uint8_t) = &PointDToPointU;
-    info.GetPointsInfo(saver.GetBasePoint(), saver.GetMaxPoint(),
-                       std::bind(D2U, std::placeholders::_1, cp.GetCoordBits()), points);
-
-    info.ProcessPortions(points, saver);
-
-    std::vector<char> buffer;
-    MemWriter<std::vector<char> > writer(buffer);
-    saver.Save(writer);
-
-    TEST ( !buffer.empty(), () );
-
-    MemReader reader(&buffer[0], buffer.size());
-    ReaderSource<MemReader> src(reader);
-
-    serial::OutPointsT triangles;
-    serial::LoadOuterTriangles(src, cp, triangles);
-
-    CompareTriangles(triangles, arrP, arrT, countT);
+    P trg[] = {arrP[arrT[i][0]], arrP[arrT[i][1]], arrP[arrT[i][2]]};
+    TEST(FindTriangle(test, trg), ("Triangles:", test, " Etalon:", trg[0], trg[1], trg[2]));
   }
 }
 
+void TestTrianglesCoding(P arrP[], size_t countP, int arrT[][3], size_t countT)
+{
+  tesselator::TrianglesInfo info;
+  info.AssignPoints(arrP, arrP + countP);
+
+  info.Reserve(countT);
+
+  for (size_t i = 0; i < countT; ++i)
+    info.Add(arrT[i][0], arrT[i][1], arrT[i][2]);
+
+  serial::GeometryCodingParams cp;
+
+  serial::TrianglesChainSaver saver(cp);
+  tesselator::PointsInfo points;
+
+  m2::PointU (*D2U)(m2::PointD const &, uint8_t) = &PointDToPointU;
+  info.GetPointsInfo(saver.GetBasePoint(), saver.GetMaxPoint(),
+                     std::bind(D2U, std::placeholders::_1, cp.GetCoordBits()), points);
+
+  info.ProcessPortions(points, saver);
+
+  std::vector<char> buffer;
+  MemWriter<std::vector<char>> writer(buffer);
+  saver.Save(writer);
+
+  TEST(!buffer.empty(), ());
+
+  MemReader reader(&buffer[0], buffer.size());
+  ReaderSource<MemReader> src(reader);
+
+  serial::OutPointsT triangles;
+  serial::LoadOuterTriangles(src, cp, triangles);
+
+  CompareTriangles(triangles, arrP, arrT, countT);
+}
+}  // namespace
+
 UNIT_TEST(TrianglesCoding_Smoke)
 {
-  {
-    P arrP[] =  { P(0, 0), P(0, 1), P(1, 0), P(1, 1), P(0, -1), P(-1, 0) };
-    int arrT[][3] = { {0, 1, 2}, {1, 3, 2}, {4, 0, 2}, {1, 0, 5}, {4, 5, 0} };
+  P arrP[] = {P(0, 0), P(0, 1), P(1, 0), P(1, 1), P(0, -1), P(-1, 0)};
+  int arrT[][3] = {{0, 1, 2}, {1, 3, 2}, {4, 0, 2}, {1, 0, 5}, {4, 5, 0}};
 
-    TestTrianglesCoding(arrP, ARRAY_SIZE(arrP), arrT, ARRAY_SIZE(arrT));
-  }
+  TestTrianglesCoding(arrP, ARRAY_SIZE(arrP), arrT, ARRAY_SIZE(arrT));
 }
 
 UNIT_TEST(TrianglesCoding_Rect)
 {
-  {
-    P arrP[] =  { P(-16.874999848078005, -44.999999874271452),
-                  P(-16.874999848078005, -39.374999869032763),
-                  P(-11.249999842839316, -39.374999869032763),
-                  P(-11.249999842839316, -44.999999874271452)
-                };
+  P arrP[] = {
+      P(-16.874999848078005, -44.999999874271452),
+      P(-16.874999848078005, -39.374999869032763),
+      P(-11.249999842839316, -39.374999869032763),
+      P(-11.249999842839316, -44.999999874271452)};
 
-    int arrT[][3] = { {2, 0, 1}, {0, 2, 3} };
+  int arrT[][3] = {{2, 0, 1}, {0, 2, 3}};
 
-    TestTrianglesCoding(arrP, ARRAY_SIZE(arrP), arrT, ARRAY_SIZE(arrT));
-  }
+  TestTrianglesCoding(arrP, ARRAY_SIZE(arrP), arrT, ARRAY_SIZE(arrT));
 }

--- a/geometry/geometry_tests/mercator_test.cpp
+++ b/geometry/geometry_tests/mercator_test.cpp
@@ -58,11 +58,11 @@ UNIT_TEST(Mercator_ErrorToRadius)
       double const lat = points[j];
       m2::PointD const mercPoint(MercatorBounds::LonToX(lon), MercatorBounds::LatToY(lat));
 
-      m2::RectD const radius1 = MercatorBounds::MetresToXY(lon, lat, error1);
+      m2::RectD const radius1 = MercatorBounds::MetersToXY(lon, lat, error1);
       TEST(radius1.IsPointInside(mercPoint), (lat, lon));
       TEST(radius1.Center().EqualDxDy(mercPoint, 1.0E-8), ());
 
-      m2::RectD const radius10 = MercatorBounds::MetresToXY(lon, lat, error10);
+      m2::RectD const radius10 = MercatorBounds::MetersToXY(lon, lat, error10);
       TEST(radius10.IsPointInside(mercPoint), (lat, lon));
       TEST(radius10.Center().EqualDxDy(mercPoint, 1.0E-8), ());
 

--- a/geometry/mercator.cpp
+++ b/geometry/mercator.cpp
@@ -7,34 +7,34 @@
 
 using namespace std;
 
-m2::RectD MercatorBounds::MetresToXY(double lon, double lat, double lonMetresR, double latMetresR)
+m2::RectD MercatorBounds::MetersToXY(double lon, double lat, double lonMetersR, double latMetersR)
 {
-  double const latDegreeOffset = latMetresR * degreeInMetres;
+  double const latDegreeOffset = latMetersR * kDegreesInMeter;
   double const minLat = max(-90.0, lat - latDegreeOffset);
   double const maxLat = min(90.0, lat + latDegreeOffset);
 
   double const cosL = max(cos(base::DegToRad(max(fabs(minLat), fabs(maxLat)))), 0.00001);
   ASSERT_GREATER(cosL, 0.0, ());
 
-  double const lonDegreeOffset = lonMetresR * degreeInMetres / cosL;
+  double const lonDegreeOffset = lonMetersR * kDegreesInMeter / cosL;
   double const minLon = max(-180.0, lon - lonDegreeOffset);
   double const maxLon = min(180.0, lon + lonDegreeOffset);
 
   return m2::RectD(FromLatLon(minLat, minLon), FromLatLon(maxLat, maxLon));
 }
 
-m2::PointD MercatorBounds::GetSmPoint(m2::PointD const & pt, double lonMetresR, double latMetresR)
+m2::PointD MercatorBounds::GetSmPoint(m2::PointD const & pt, double lonMetersR, double latMetersR)
 {
   double const lat = YToLat(pt.y);
   double const lon = XToLon(pt.x);
 
-  double const latDegreeOffset = latMetresR * degreeInMetres;
+  double const latDegreeOffset = latMetersR * kDegreesInMeter;
   double const newLat = min(90.0, max(-90.0, lat + latDegreeOffset));
 
   double const cosL = max(cos(base::DegToRad(newLat)), 0.00001);
   ASSERT_GREATER(cosL, 0.0, ());
 
-  double const lonDegreeOffset = lonMetresR * degreeInMetres / cosL;
+  double const lonDegreeOffset = lonMetersR * kDegreesInMeter / cosL;
   double const newLon = min(180.0, max(-180.0, lon + lonDegreeOffset));
 
   return FromLatLon(newLat, newLon);

--- a/geometry/mercator.hpp
+++ b/geometry/mercator.hpp
@@ -15,6 +15,11 @@ struct MercatorBounds
   static double constexpr kRangeX = kMaxX - kMinX;
   static double constexpr kRangeY = kMaxY - kMinY;
 
+  // The denominator is the Earth circumference at the Equator in meters.
+  // The value is a bit off for some reason; 40075160 seems to be correct.
+  static double constexpr kDegreesInMeter = 360.0 / 40008245.0;
+  static double constexpr kMetersInDegree = 40008245.0 / 360.0;
+
   static m2::RectD FullRect() { return m2::RectD(kMinX, kMinY, kMaxX, kMaxY); }
 
   static bool ValidLon(double d) { return base::between_s(-180.0, 180.0, d); }
@@ -39,16 +44,17 @@ struct MercatorBounds
 
   static double LonToX(double lon) { return lon; }
 
-  static double constexpr degreeInMetres = 360.0 / 40008245;
+  static double MetersToMercator(double meters) { return meters * kDegreesInMeter; }
+  static double MercatorToMeters(double mercator) { return mercator * kMetersInDegree; }
 
   /// @name Get rect for center point (lon, lat) and dimensions in metres.
   //@{
   /// @return mercator rect.
-  static m2::RectD MetresToXY(double lon, double lat, double lonMetresR, double latMetresR);
+  static m2::RectD MetersToXY(double lon, double lat, double lonMetersR, double latMetersR);
 
-  static m2::RectD MetresToXY(double lon, double lat, double metresR)
+  static m2::RectD MetersToXY(double lon, double lat, double metresR)
   {
-    return MetresToXY(lon, lat, metresR, metresR);
+    return MetersToXY(lon, lat, metresR, metresR);
   }
   //@}
 
@@ -58,7 +64,7 @@ struct MercatorBounds
     ASSERT_GREATER_OR_EQUAL(sizeX, 0, ());
     ASSERT_GREATER_OR_EQUAL(sizeY, 0, ());
 
-    return MetresToXY(XToLon(centerX), YToLat(centerY), sizeX, sizeY);
+    return MetersToXY(XToLon(centerX), YToLat(centerY), sizeX, sizeY);
   }
 
   static m2::RectD RectByCenterXYAndSizeInMeters(m2::PointD const & center, double size)
@@ -72,7 +78,7 @@ struct MercatorBounds
             ClampX(center.x + offset), ClampY(center.y + offset)};
   }
 
-  static m2::PointD GetSmPoint(m2::PointD const & pt, double lonMetresR, double latMetresR);
+  static m2::PointD GetSmPoint(m2::PointD const & pt, double lonMetersR, double latMetersR);
 
   static m2::PointD FromLatLon(double lat, double lon)
   {

--- a/indexer/data_source_helpers.cpp
+++ b/indexer/data_source_helpers.cpp
@@ -33,7 +33,7 @@ void ForEachFeatureAtPoint(DataSource const & dataSource, function<void(FeatureT
       auto limitRect = ft.GetLimitRect(kScale);
       // Be a little more tolerant. When used by editor mercator is given
       // with some error, so we must extend limit rect a bit.
-      limitRect.Inflate(kCellIdToPointEps, kCellIdToPointEps);
+      limitRect.Inflate(kMwmPointAccuracy, kMwmPointAccuracy);
       if (limitRect.IsPointInside(mercator) &&
           feature::GetMinDistanceMeters(ft, mercator) <= toleranceInMeters)
       {

--- a/indexer/feature_covering.hpp
+++ b/indexer/feature_covering.hpp
@@ -43,7 +43,7 @@ void SortAndMergeIntervals(Intervals v, Intervals & res);
 template <int DEPTH_LEVELS>
 m2::CellId<DEPTH_LEVELS> GetRectIdAsIs(m2::RectD const & r)
 {
-  double const eps = kCellIdToPointEps;
+  double const eps = kMwmPointAccuracy;
   using Converter = CellIdConverter<MercatorBounds, m2::CellId<DEPTH_LEVELS>>;
 
   return Converter::Cover2PointsWithCell(

--- a/map/address_finder.cpp
+++ b/map/address_finder.cpp
@@ -99,7 +99,7 @@ namespace
       if (!types.Has(m_coastType) && NeedProcess(types))
       {
         // Convert from meters to degrees for backward compatibility.
-        double const d = feature::GetMinDistanceMeters(f, m_pt, m_scale) * MercatorBounds::degreeInMetres;
+        double const d = feature::GetMinDistanceMeters(f, m_pt, m_scale) * MercatorBounds::degreeInMeters;
         ASSERT_GREATER_OR_EQUAL(d, 0.0, ());
 
         if (IsInclude(d, types))
@@ -308,7 +308,7 @@ namespace
 
     virtual double GetResultDistance(double d, feature::TypesHolder const & types) const
     {
-      return (d + GetCompareEpsilonImpl(types.GetGeoType(), 5.0 * MercatorBounds::degreeInMetres));
+      return (d + GetCompareEpsilonImpl(types.GetGeoType(), 5.0 * MercatorBounds::degreeInMeters));
     }
 
     virtual double NeedProcess(feature::TypesHolder const & types) const

--- a/map/extrapolation_benchmark/extrapolation_benchmark.cpp
+++ b/map/extrapolation_benchmark/extrapolation_benchmark.cpp
@@ -269,7 +269,7 @@ int main(int argc, char * argv[])
         double const kHalfSquareSide = 100.0;
         // |kHalfSquareSide| is chosen based on maximum value of GpsInfo::m_horizontalAccuracy
         // which is used calculation of projection in production code.
-        m2::RectD const posSquare = MercatorBounds::MetresToXY(
+        m2::RectD const posSquare = MercatorBounds::MetersToXY(
             extrapolated.m_longitude, extrapolated.m_latitude, kHalfSquareSide);
         // One is deducted from polyline size because in GetClosestProjectionInInterval()
         // is used segment indices but not point indices.

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2478,7 +2478,7 @@ void Framework::PredictLocation(double & lat, double & lon, double accuracy,
   double offsetInM = speed * elapsedSeconds;
   double angle = base::DegToRad(90.0 - bearing);
 
-  m2::PointD mercatorPt = MercatorBounds::MetresToXY(lon, lat, accuracy).Center();
+  m2::PointD mercatorPt = MercatorBounds::MetersToXY(lon, lat, accuracy).Center();
   mercatorPt = MercatorBounds::GetSmPoint(mercatorPt, offsetInM * cos(angle), offsetInM * sin(angle));
   lon = MercatorBounds::XToLon(mercatorPt.x);
   lat = MercatorBounds::YToLat(mercatorPt.y);

--- a/platform/location_service.cpp
+++ b/platform/location_service.cpp
@@ -6,8 +6,7 @@
 
 namespace
 {
-
-static double ApproxDistanceSquareInMetres(double lat1, double lon1, double lat2, double lon2)
+static double ApproxDistanceSquareInMeters(double lat1, double lon1, double lat2, double lon2)
 {
   double const m1 = (lat1 - lat2) / 111111.;
   double const m2 = (lon1 - lon2) / 111111.;
@@ -35,7 +34,7 @@ public:
         passes = false;
       else if (newLocation.m_source != m_prevLocation->m_source
                && newLocation.m_horizontalAccuracy > m_prevLocation->m_horizontalAccuracy
-               && ApproxDistanceSquareInMetres(newLocation.m_latitude,
+               && ApproxDistanceSquareInMeters(newLocation.m_latitude,
                                                newLocation.m_longitude,
                                                m_prevLocation->m_latitude,
                                                m_prevLocation->m_longitude)
@@ -47,8 +46,7 @@ public:
     return passes;
   }
 };
-
-} // namespace
+}  // namespace
 
 extern "C" location::LocationService * CreateAppleLocationService(location::LocationObserver &);
 extern "C" location::LocationService * CreateWiFiLocationService(location::LocationObserver &);
@@ -104,7 +102,7 @@ namespace location
       m_reportFirstEvent = true;
     }
   };
-}
+}  // namespace location
 
 location::LocationService * CreateDesktopLocationService(location::LocationObserver & observer)
 {

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -234,7 +234,7 @@ void Route::GetCurrentDirectionPoint(m2::PointD & pt) const
 
 bool Route::MoveIterator(location::GpsInfo const & info)
 {
-  m2::RectD const rect = MercatorBounds::MetresToXY(
+  m2::RectD const rect = MercatorBounds::MetersToXY(
         info.m_longitude, info.m_latitude,
         max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
   FollowedPolyline::Iter const res = m_poly.UpdateProjectionByPrediction(rect, -1.0 /* predictDistance */);

--- a/routing/routing_quality/waypoints.cpp
+++ b/routing/routing_quality/waypoints.cpp
@@ -31,7 +31,7 @@ Similarity CompareByNumberOfMatchedWaypoints(routing::FollowedPolyline && polyli
     for (size_t i = 0; i < size; ++i)
     {
       auto const & ll = waypoints[i];
-      m2::RectD const rect = MercatorBounds::MetresToXY(ll.lon, ll.lat, kMaxDistanceFromRouteM /* metresR */);
+      m2::RectD const rect = MercatorBounds::MetersToXY(ll.lon, ll.lat, kMaxDistanceFromRouteM /* metresR */);
       auto const iter = current.UpdateProjection(rect);
       if (iter.IsValid())
       {

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -162,7 +162,7 @@ UNIT_TEST(TestFixupTurns)
 {
   double const kHalfSquareSideMeters = 10.;
   m2::PointD const kSquareCenterLonLat = {0., 0.};
-  m2::RectD const kSquareNearZero = MercatorBounds::MetresToXY(kSquareCenterLonLat.x,
+  m2::RectD const kSquareNearZero = MercatorBounds::MetersToXY(kSquareCenterLonLat.x,
                                                                kSquareCenterLonLat.y, kHalfSquareSideMeters);
   // Removing a turn in case staying on a roundabout.
   vector<Junction> const pointsMerc1 = {

--- a/search/geometry_cache.cpp
+++ b/search/geometry_cache.cpp
@@ -4,15 +4,12 @@
 #include "search/mwm_context.hpp"
 #include "search/retrieval.hpp"
 
+#include "coding/point_coding.hpp"
+
 #include "geometry/mercator.hpp"
 
 namespace search
 {
-namespace
-{
-double constexpr kCellEps = kCellIdToPointEps;
-}  // namespace
-
 // GeometryCache -----------------------------------------------------------------------------------
 GeometryCache::GeometryCache(size_t maxNumEntries, base::Cancellable const & cancellable)
   : m_maxNumEntries(maxNumEntries), m_cancellable(cancellable)
@@ -43,7 +40,7 @@ CBV PivotRectsCache::Get(MwmContext const & context, m2::RectD const & rect, int
       context.GetId(), [&rect, &scale](Entry const & entry)
       {
         return scale == entry.m_scale &&
-               (entry.m_rect.IsRectInside(rect) || IsEqualMercator(rect, entry.m_rect, kCellEps));
+               (entry.m_rect.IsRectInside(rect) || IsEqualMercator(rect, entry.m_rect, kMwmPointAccuracy));
       });
   auto & entry = p.first;
   if (p.second)
@@ -69,7 +66,7 @@ CBV LocalityRectsCache::Get(MwmContext const & context, m2::RectD const & rect, 
   auto p = FindOrCreateEntry(context.GetId(), [&rect, &scale](Entry const & entry)
                              {
                                return scale == entry.m_scale &&
-                                      IsEqualMercator(rect, entry.m_rect, kCellEps);
+                                      IsEqualMercator(rect, entry.m_rect, kMwmPointAccuracy);
                              });
   auto & entry = p.first;
   if (p.second)

--- a/search/geometry_utils.cpp
+++ b/search/geometry_utils.cpp
@@ -1,29 +1,26 @@
 #include "geometry_utils.hpp"
 
-#include "geometry/mercator.hpp"
 #include "indexer/scales.hpp"
 
+#include "geometry/mercator.hpp"
 
 namespace search
 {
-
 double PointDistance(m2::PointD const & a, m2::PointD const & b)
 {
   return MercatorBounds::DistanceOnEarth(a, b);
 }
 
-bool IsEqualMercator(m2::RectD const & r1, m2::RectD const & r2, double epsMeters)
+bool IsEqualMercator(m2::RectD const & r1, m2::RectD const & r2, double eps)
 {
-  double const eps = epsMeters * MercatorBounds::degreeInMetres;
   return m2::IsEqual(r1, r2, eps, eps);
 }
 
-// 11.5 - lower bound for rect when we need to inflate it
-// 1.5 - inflate delta for viewport scale
-// 7 - query scale depth to cache viewport features
-
 bool GetInflatedViewport(m2::RectD & viewport)
 {
+  // 11.5 - lower bound for rect when we need to inflate it
+  // 1.5 - inflate delta for viewport scale
+  // 7 - query scale depth to cache viewport features
   double level = scales::GetScaleLevelD(viewport);
   if (level < 11.5)
     return false;
@@ -38,5 +35,4 @@ int GetQueryIndexScale(m2::RectD const & viewport)
 {
   return scales::GetScaleLevel(viewport) + 7;
 }
-
-} // namespace search
+}  // namespace search

--- a/search/geometry_utils.hpp
+++ b/search/geometry_utils.hpp
@@ -3,17 +3,18 @@
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
-
 namespace search
 {
-
 // Distance between 2 mercator points in meters.
 double PointDistance(m2::PointD const & a, m2::PointD const & b);
-// Test for equal rects with epsilon in meters.
-bool IsEqualMercator(m2::RectD const & r1, m2::RectD const & r2, double epsMeters);
+
+// Tests whether two rects given in the mercator projection are
+// equal with the absolute precision |eps|.
+bool IsEqualMercator(m2::RectD const & r1, m2::RectD const & r2, double eps);
+
 // Get inflated viewport rect for search query.
 bool GetInflatedViewport(m2::RectD & viewport);
+
 // Get scale level to make geometry index query for current viewport.
 int GetQueryIndexScale(m2::RectD const & viewport);
-
-}
+}  // namespace search

--- a/search/house_detector.cpp
+++ b/search/house_detector.cpp
@@ -756,24 +756,24 @@ void Street::SortHousesProjection() { sort(m_houses.begin(), m_houses.end(), &Le
 HouseDetector::HouseDetector(DataSource const & dataSource)
   : m_loader(dataSource), m_streetNum(0)
 {
-  // default value for conversions
-  SetMetres2Mercator(360.0 / 40.0E06);
+  // Default value for conversions.
+  SetMetersToMercator(MercatorBounds::kDegreesInMeter);
 }
 
 HouseDetector::~HouseDetector() { ClearCaches(); }
 
-void HouseDetector::SetMetres2Mercator(double factor)
+void HouseDetector::SetMetersToMercator(double factor)
 {
-  m_metres2Mercator = factor;
+  m_metersToMercator = factor;
 
-  LOG(LDEBUG, ("Street join epsilon = ", m_metres2Mercator * STREET_CONNECTION_LENGTH_M));
+  LOG(LDEBUG, ("Street join epsilon =", m_metersToMercator * STREET_CONNECTION_LENGTH_M));
 }
 
 double HouseDetector::GetApprLengthMeters(int index) const
 {
   m2::PointD const & p1 = m_streets[index].m_cont.front()->m_points.front();
   m2::PointD const & p2 = m_streets[index].m_cont.back()->m_points.back();
-  return p1.Length(p2) / m_metres2Mercator;
+  return p1.Length(p2) / m_metersToMercator;
 }
 
 HouseDetector::StreetPtr HouseDetector::FindConnection(Street const * st, bool beg) const
@@ -782,7 +782,7 @@ HouseDetector::StreetPtr HouseDetector::FindConnection(Street const * st, bool b
 
   StreetPtr resStreet(0, false);
   double resDistance = numeric_limits<double>::max();
-  double const minSqDistance = pow(m_metres2Mercator * STREET_CONNECTION_LENGTH_M, 2);
+  double const minSqDistance = pow(m_metersToMercator * STREET_CONNECTION_LENGTH_M, 2);
 
   for (size_t i = 0; i < m_end2st.size(); ++i)
   {
@@ -913,7 +913,7 @@ int HouseDetector::LoadStreets(vector<FeatureID> const & ids)
         m2::PointD const p1 = st->m_points.front();
         m2::PointD const p2 = st->m_points.back();
 
-        SetMetres2Mercator(p1.Length(p2) / GetDistanceMeters(p1, p2));
+        SetMetersToMercator(p1.Length(p2) / GetDistanceMeters(p1, p2));
       }
 
       m_id2st[ids[i]] = st;

--- a/search/house_detector.hpp
+++ b/search/house_detector.hpp
@@ -236,7 +236,7 @@ private:
 
   void ReadHouses(Street * st);
 
-  void SetMetres2Mercator(double factor);
+  void SetMetersToMercator(double factor);
 
   double GetApprLengthMeters(int index) const;
 
@@ -248,7 +248,7 @@ private:
   std::vector<pair<m2::PointD, Street *>> m_end2st;
   std::vector<MergedStreet> m_streets;
 
-  double m_metres2Mercator;
+  double m_metersToMercator;
   int m_streetNum;
   double m_houseOffsetM;
 };

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -175,7 +175,8 @@ void Processor::SetViewport(m2::RectD const & viewport)
   if (m_viewport.IsValid())
   {
     double constexpr kEpsMeters = 10.0;
-    if (IsEqualMercator(m_viewport, viewport, kEpsMeters))
+    double const kEps = MercatorBounds::MetersToMercator(kEpsMeters);
+    if (IsEqualMercator(m_viewport, viewport, kEps))
       return;
   }
 


### PR DESCRIPTION
In was used as eps in meters in some cases and eps in mercator in others.
Its value was hard to justify and so were its use cases. We're better off
with less epsilons for now.

Also renamed Metres to Meters in the mercator code.