### PR TITLE
[lightweight] "Get" methods are renamed

### DIFF
--- a/android/jni/com/mapswithme/maps/LightFramework.cpp
+++ b/android/jni/com/mapswithme/maps/LightFramework.cpp
@@ -13,14 +13,14 @@ JNIEXPORT jboolean JNICALL
 Java_com_mapswithme_maps_LightFramework_nativeIsAuthenticated(JNIEnv * env, jclass clazz)
 {
   Framework const framework(REQUEST_TYPE_USER_AUTH_STATUS);
-  return static_cast<jboolean>(framework.Get<REQUEST_TYPE_USER_AUTH_STATUS>());
+  return static_cast<jboolean>(framework.IsUserAuthenticated());
 }
 
 JNIEXPORT jint JNICALL
 Java_com_mapswithme_maps_LightFramework_nativeGetNumberUnsentUGC(JNIEnv * env, jclass clazz)
 {
   Framework const framework(REQUEST_TYPE_NUMBER_OF_UNSENT_UGC);
-  return static_cast<jint>(framework.Get<REQUEST_TYPE_NUMBER_OF_UNSENT_UGC>());
+  return static_cast<jint>(framework.GetNumberOfUnsentUGC());
 }
 
 JNIEXPORT jobjectArray JNICALL
@@ -30,8 +30,7 @@ Java_com_mapswithme_maps_LightFramework_nativeGetLocalAdsFeatures(JNIEnv * env, 
                                                                   jint maxCount)
 {
   Framework framework(REQUEST_TYPE_LOCAL_ADS_FEATURES);
-  auto const features = framework.GetNonConst<REQUEST_TYPE_LOCAL_ADS_FEATURES>(
-    lat, lon, radiusInMeters, maxCount);
+  auto const features = framework.GetLocalAdsFeatures(lat, lon, radiusInMeters, maxCount);
 
   static jclass const geoFenceFeatureClazz =
           jni::GetGlobalClassRef(env, "com/mapswithme/maps/geofence/GeoFenceFeature");
@@ -66,14 +65,14 @@ Java_com_mapswithme_maps_LightFramework_nativeLogLocalAdsEvent(JNIEnv * env, jcl
                          static_cast<uint8_t>(1) /* zoom level */, local_ads::Clock::now(),
                          static_cast<double>(lat), static_cast<double>(lon),
                          static_cast<uint16_t>(accuracyInMeters));
-  framework.GetNonConst<REQUEST_TYPE_LOCAL_ADS_STATISTICS>()->RegisterEvent(std::move(event));
+  framework.GetLocalAdsStatistics()->RegisterEvent(std::move(event));
 }
 
 JNIEXPORT jobject JNICALL
 Java_com_mapswithme_maps_LightFramework_nativeGetNotification(JNIEnv * env, jclass clazz)
 {
   Framework framework(REQUEST_TYPE_NOTIFICATION);
-  auto const notification = framework.Get<REQUEST_TYPE_NOTIFICATION>();
+  auto const notification = framework.GetNotification();
 
   if (!notification)
     return nullptr;

--- a/iphone/Maps/Core/Notifications/LocalNotificationManager.mm
+++ b/iphone/Maps/Core/Notifications/LocalNotificationManager.mm
@@ -79,7 +79,7 @@ using namespace storage;
 
   using namespace lightweight;
   lightweight::Framework const f(REQUEST_TYPE_NUMBER_OF_UNSENT_UGC | REQUEST_TYPE_USER_AUTH_STATUS);
-  if (f.Get<REQUEST_TYPE_USER_AUTH_STATUS>() || f.Get<REQUEST_TYPE_NUMBER_OF_UNSENT_UGC>() < 2)
+  if (f.IsUserAuthenticated() || f.GetNumberOfUnsentUGC() < 2)
     return NO;
 
   return YES;

--- a/map/CMakeLists.txt
+++ b/map/CMakeLists.txt
@@ -55,6 +55,7 @@ set(
   feature_vec_model.hpp
   framework.cpp
   framework.hpp
+  framework_light.cpp
   framework_light.hpp
   ge0_parser.cpp
   ge0_parser.hpp

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2704,8 +2704,11 @@ void BookmarkManager::EditSession::NotifyChanges()
 
 namespace lightweight
 {
+namespace impl
+{
 bool IsBookmarksCloudEnabled()
 {
   return Cloud::GetCloudState(kBookmarkCloudSettingsParam) == Cloud::State::Enabled;
 }
+}  // namespace impl
 }  // namespace lightweight

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -576,5 +576,8 @@ private:
 
 namespace lightweight
 {
+namespace impl
+{
 bool IsBookmarksCloudEnabled();
+}  // namespace impl
 }  //namespace lightweight

--- a/map/framework_light.cpp
+++ b/map/framework_light.cpp
@@ -85,7 +85,6 @@ bool Framework::IsBookmarksCloudEnabled() const
 CountryInfoReader::Info Framework::GetLocation(m2::PointD const & pt) const
 {
   ASSERT(m_request & REQUEST_TYPE_LOCATION, (m_request));
-
   CHECK(m_countryInfoReader, ());
 
   return m_countryInfoReader->GetMwmInfo(pt);
@@ -95,18 +94,14 @@ std::vector<CampaignFeature> Framework::GetLocalAdsFeatures(double lat, double l
                                                             double radiusInMeters, uint32_t maxCount)
 {
   ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_FEATURES, (m_request));
-
   CHECK(m_localAdsFeaturesReader, ());
-
   return m_localAdsFeaturesReader->GetCampaignFeatures(lat, lon, radiusInMeters, maxCount);
 }
 
 Statistics * Framework::GetLocalAdsStatistics()
 {
   ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_STATISTICS, (m_request));
-
   CHECK(m_localAdsStatistics, ());
-
   return m_localAdsStatistics.get();
 }
 
@@ -115,4 +110,3 @@ boost::optional<notifications::NotificationCandidate> Framework::GetNotification
   return m_notificationManager->GetNotification();
 }
 }  // namespace lightweight
-

--- a/map/framework_light.cpp
+++ b/map/framework_light.cpp
@@ -1,0 +1,118 @@
+#include "map/framework_light.hpp"
+
+namespace lightweight
+{
+Framework::Framework(RequestTypeMask request) : m_request(request)
+{
+  CHECK_NOT_EQUAL(request, REQUEST_TYPE_EMPTY, ("Mask is empty"));
+
+  if (request & REQUEST_TYPE_NUMBER_OF_UNSENT_UGC)
+  {
+    m_numberOfUnsentUGC = impl::GetNumberOfUnsentUGC();
+    request ^= REQUEST_TYPE_NUMBER_OF_UNSENT_UGC;
+  }
+
+  if (request & REQUEST_TYPE_USER_AUTH_STATUS)
+  {
+    m_userAuthStatus = impl::IsUserAuthenticated();
+    request ^= REQUEST_TYPE_USER_AUTH_STATUS;
+  }
+
+  if (request & REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS)
+  {
+    // TODO: Hasn't implemented yet.
+    request ^= REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS;
+  }
+
+  if (request & REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED)
+  {
+    m_bookmarksCloudEnabled = impl::IsBookmarksCloudEnabled();
+    request ^= REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED;
+  }
+
+  if (request & REQUEST_TYPE_LOCATION)
+  {
+    m_countryInfoReader = std::make_unique<CountryInfoReader>();
+    request ^= REQUEST_TYPE_LOCATION;
+  }
+
+  if (request & REQUEST_TYPE_LOCAL_ADS_FEATURES)
+  {
+    m_localAdsFeaturesReader = std::make_unique<LocalAdsFeaturesReader>();
+    request ^= REQUEST_TYPE_LOCAL_ADS_FEATURES;
+  }
+
+  if (request & REQUEST_TYPE_LOCAL_ADS_STATISTICS)
+  {
+    m_localAdsStatistics = std::make_unique<Statistics>();
+    request ^= REQUEST_TYPE_LOCAL_ADS_STATISTICS;
+  }
+
+  if (request & REQUEST_TYPE_NOTIFICATION)
+  {
+    m_notificationManager = std::make_unique<lightweight::NotificationManager>();
+    request ^= REQUEST_TYPE_NOTIFICATION;
+  }
+
+  CHECK_EQUAL(request, REQUEST_TYPE_EMPTY, ("Incorrect mask type:", request));
+}
+
+bool Framework::IsUserAuthenticated() const
+{
+  ASSERT(m_request & REQUEST_TYPE_USER_AUTH_STATUS, (m_request));
+  return m_userAuthStatus;
+}
+
+size_t Framework::GetNumberOfUnsentUGC() const
+{
+  ASSERT(m_request & REQUEST_TYPE_NUMBER_OF_UNSENT_UGC, (m_request));
+  return m_numberOfUnsentUGC;
+}
+
+
+size_t Framework::GetNumberOfUnsentEdits() const
+{
+  ASSERT(m_request & REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS, (m_request));
+  return m_numberOfUnsentEdits;
+}
+
+bool Framework::IsBookmarksCloudEnabled() const
+{
+  ASSERT(m_request & REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED, (m_request));
+  return m_bookmarksCloudEnabled;
+}
+
+CountryInfoReader::Info Framework::GetLocation(m2::PointD const & pt) const
+{
+  ASSERT(m_request & REQUEST_TYPE_LOCATION, (m_request));
+
+  CHECK(m_countryInfoReader, ());
+
+  return m_countryInfoReader->GetMwmInfo(pt);
+}
+
+std::vector<CampaignFeature> Framework::GetLocalAdsFeatures(double lat, double lon,
+                                                            double radiusInMeters, uint32_t maxCount)
+{
+  ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_FEATURES, (m_request));
+
+  CHECK(m_localAdsFeaturesReader, ());
+
+  return m_localAdsFeaturesReader->GetCampaignFeatures(lat, lon, radiusInMeters, maxCount);
+}
+
+Statistics * Framework::GetLocalAdsStatistics()
+{
+  ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_STATISTICS, (m_request));
+
+  CHECK(m_localAdsStatistics, ());
+
+  return m_localAdsStatistics.get();
+}
+
+boost::optional<notifications::NotificationCandidate> Framework::GetNotification() const
+{
+  return m_notificationManager->GetNotification();
+}
+}  // namespace lightweight
+

--- a/map/framework_light.hpp
+++ b/map/framework_light.hpp
@@ -46,72 +46,17 @@ class Framework
 public:
   friend struct LightFrameworkTest;
 
-  explicit Framework(RequestTypeMask request) : m_request(request)
-  {
-    CHECK_NOT_EQUAL(request, REQUEST_TYPE_EMPTY, ("Mask is empty"));
+  explicit Framework(RequestTypeMask request);
 
-    if (request & REQUEST_TYPE_NUMBER_OF_UNSENT_UGC)
-    {
-      m_numberOfUnsentUGC = GetNumberOfUnsentUGC();
-      request ^= REQUEST_TYPE_NUMBER_OF_UNSENT_UGC;
-    }
-
-    if (request & REQUEST_TYPE_USER_AUTH_STATUS)
-    {
-      m_userAuthStatus = IsUserAuthenticated();
-      request ^= REQUEST_TYPE_USER_AUTH_STATUS;
-    }
-
-    if (request & REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS)
-    {
-      // TODO: Hasn't implemented yet.
-      request ^= REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS;
-    }
-
-    if (request & REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED)
-    {
-      m_bookmarksCloudEnabled = IsBookmarksCloudEnabled();
-      request ^= REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED;
-    }
-
-    if (request & REQUEST_TYPE_LOCATION)
-    {
-      m_countryInfoReader = std::make_unique<CountryInfoReader>();
-      request ^= REQUEST_TYPE_LOCATION;
-    }
-
-    if (request & REQUEST_TYPE_LOCAL_ADS_FEATURES)
-    {
-      m_localAdsFeaturesReader = std::make_unique<LocalAdsFeaturesReader>();
-      request ^= REQUEST_TYPE_LOCAL_ADS_FEATURES;
-    }
-
-    if (request & REQUEST_TYPE_LOCAL_ADS_STATISTICS)
-    {
-      m_localAdsStatistics = std::make_unique<Statistics>();
-      request ^= REQUEST_TYPE_LOCAL_ADS_STATISTICS;
-    }
-
-    if (request & REQUEST_TYPE_NOTIFICATION)
-    {
-      m_notificationManager = std::make_unique<lightweight::NotificationManager>();
-      request ^= REQUEST_TYPE_NOTIFICATION;
-    }
-
-    CHECK_EQUAL(request, REQUEST_TYPE_EMPTY, ("Incorrect mask type:", request));
-  }
-
-  template <RequestTypeMask Type>
-  auto Get() const;
-
-  template <RequestTypeMask Type>
-  auto Get(m2::PointD const & pt) const;
-
-  template <RequestTypeMask Type>
-  auto GetNonConst(double lat, double lon, double radiusInMeters, uint32_t maxCount);
-
-  template <RequestTypeMask Type>
-  auto GetNonConst();
+  bool IsUserAuthenticated() const;
+  size_t GetNumberOfUnsentUGC() const;
+  size_t GetNumberOfUnsentEdits() const;
+  bool IsBookmarksCloudEnabled() const;
+  CountryInfoReader::Info GetLocation(m2::PointD const & pt) const;
+  std::vector<CampaignFeature> GetLocalAdsFeatures(double lat, double lon, double radiusInMeters,
+                                                   uint32_t maxCount);
+  Statistics * GetLocalAdsStatistics();
+  boost::optional<notifications::NotificationCandidate> GetNotification() const;
 
 private:
   RequestTypeMask m_request;
@@ -124,69 +69,4 @@ private:
   std::unique_ptr<Statistics> m_localAdsStatistics;
   std::unique_ptr<lightweight::NotificationManager> m_notificationManager;
 };
-
-template<>
-auto Framework::Get<REQUEST_TYPE_USER_AUTH_STATUS>() const
-{
-  ASSERT(m_request & REQUEST_TYPE_USER_AUTH_STATUS, (m_request));
-  return m_userAuthStatus;
-}
-
-template<>
-auto Framework::Get<REQUEST_TYPE_NUMBER_OF_UNSENT_UGC>() const
-{
-  ASSERT(m_request & REQUEST_TYPE_NUMBER_OF_UNSENT_UGC, (m_request));
-  return m_numberOfUnsentUGC;
-}
-
-template<>
-auto Framework::Get<REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS>() const
-{
-  ASSERT(m_request & REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS, (m_request));
-  return m_numberOfUnsentEdits;
-}
-
-template<>
-auto Framework::Get<REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED>() const
-{
-  ASSERT(m_request & REQUEST_TYPE_BOOKMARKS_CLOUD_ENABLED, (m_request));
-  return m_bookmarksCloudEnabled;
-}
-
-template <>
-auto Framework::Get<REQUEST_TYPE_LOCATION>(m2::PointD const & pt) const
-{
-  ASSERT(m_request & REQUEST_TYPE_LOCATION, (m_request));
-
-  CHECK(m_countryInfoReader, ());
-
-  return m_countryInfoReader->GetMwmInfo(pt);
-}
-
-template <>
-auto Framework::GetNonConst<REQUEST_TYPE_LOCAL_ADS_FEATURES>(double lat, double lon,
-                                                             double radiusInMeters, uint32_t maxCount)
-{
-  ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_FEATURES, (m_request));
-
-  CHECK(m_localAdsFeaturesReader, ());
-
-  return m_localAdsFeaturesReader->GetCampaignFeatures(lat, lon, radiusInMeters, maxCount);
-}
-
-template <>
-auto Framework::GetNonConst<REQUEST_TYPE_LOCAL_ADS_STATISTICS>()
-{
-  ASSERT(m_request & REQUEST_TYPE_LOCAL_ADS_STATISTICS, (m_request));
-
-  CHECK(m_localAdsStatistics, ());
-
-  return m_localAdsStatistics.get();
-}
-
-template <>
-auto Framework::Get<REQUEST_TYPE_NOTIFICATION>() const
-{
-  return m_notificationManager->GetNotification();
-}
 }  // namespace lightweight

--- a/map/framework_light.hpp
+++ b/map/framework_light.hpp
@@ -13,7 +13,11 @@
 
 #include "base/assert.hpp"
 
+#include <cstdint>
 #include <memory>
+#include <vector>
+
+#include <boost/optional.hpp>
 
 namespace lightweight
 {

--- a/map/map_tests/framework_light_tests.cpp
+++ b/map/map_tests/framework_light_tests.cpp
@@ -30,8 +30,7 @@ struct LightFrameworkTest
     {
       Framework f(REQUEST_TYPE_LOCAL_ADS_FEATURES | REQUEST_TYPE_LOCAL_ADS_STATISTICS);
       auto const features = f.GetLocalAdsFeatures(0.0 /* lat */, 0.0 /* lon */,
-                                                                           100 /* radiusInMeters */,
-                                                                           0 /* maxCount */);
+                                                  100 /* radiusInMeters */, 0 /* maxCount */);
       auto stats = f.GetLocalAdsStatistics();
       TEST(stats != nullptr, ());
       TEST_EQUAL(features.size(), 0, ());

--- a/map/map_tests/framework_light_tests.cpp
+++ b/map/map_tests/framework_light_tests.cpp
@@ -12,8 +12,8 @@ struct LightFrameworkTest
       Framework f(REQUEST_TYPE_NUMBER_OF_UNSENT_UGC | REQUEST_TYPE_USER_AUTH_STATUS);
       f.m_userAuthStatus = true;
       f.m_numberOfUnsentUGC = 30;
-      TEST_EQUAL(f.Get<REQUEST_TYPE_NUMBER_OF_UNSENT_UGC>(), 30, ());
-      TEST(f.Get<REQUEST_TYPE_USER_AUTH_STATUS>(), ());
+      TEST_EQUAL(f.GetNumberOfUnsentUGC(), 30, ());
+      TEST(f.IsUserAuthenticated(), ());
     }
 
     {
@@ -22,17 +22,17 @@ struct LightFrameworkTest
                   REQUEST_TYPE_NUMBER_OF_UNSENT_UGC);
 
       f.m_numberOfUnsentEdits = 10;
-      TEST_EQUAL(f.Get<REQUEST_TYPE_NUMBER_OF_UNSENT_EDITS>(), 10, ());
-      TEST_EQUAL(f.Get<REQUEST_TYPE_NUMBER_OF_UNSENT_UGC>(), 0, ());
-      TEST(!f.Get<REQUEST_TYPE_USER_AUTH_STATUS>(), ());
+      TEST_EQUAL(f.GetNumberOfUnsentEdits(), 10, ());
+      TEST_EQUAL(f.GetNumberOfUnsentUGC(), 0, ());
+      TEST(!f.IsUserAuthenticated(), ());
     }
 
     {
       Framework f(REQUEST_TYPE_LOCAL_ADS_FEATURES | REQUEST_TYPE_LOCAL_ADS_STATISTICS);
-      auto const features = f.GetNonConst<REQUEST_TYPE_LOCAL_ADS_FEATURES>(0.0 /* lat */, 0.0 /* lon */,
+      auto const features = f.GetLocalAdsFeatures(0.0 /* lat */, 0.0 /* lon */,
                                                                            100 /* radiusInMeters */,
                                                                            0 /* maxCount */);
-      auto stats = f.GetNonConst<REQUEST_TYPE_LOCAL_ADS_STATISTICS>();
+      auto stats = f.GetLocalAdsStatistics();
       TEST(stats != nullptr, ());
       TEST_EQUAL(features.size(), 0, ());
     }

--- a/map/user.cpp
+++ b/map/user.cpp
@@ -714,6 +714,8 @@ void User::RequestImpl(std::string const & url, BuildRequestHandler const & onBu
 
 namespace lightweight
 {
+namespace impl
+{
 bool IsUserAuthenticated()
 {
   std::string token;
@@ -722,4 +724,5 @@ bool IsUserAuthenticated()
 
   return false;
 }
+}  // namespace impl
 }  // namespace lightweight

--- a/map/user.hpp
+++ b/map/user.hpp
@@ -105,5 +105,8 @@ private:
 
 namespace lightweight
 {
+namespace impl
+{
 bool IsUserAuthenticated();
+}  // namespace impl
 }  //namespace lightweight

--- a/ugc/storage.cpp
+++ b/ugc/storage.cpp
@@ -544,6 +544,8 @@ void Storage::LoadForTesting(std::string const & testIndexFilePath)
 
 namespace lightweight
 {
+namespace impl
+{
 size_t GetNumberOfUnsentUGC()
 {
   auto const indexFilePath = GetIndexFilePath();
@@ -573,4 +575,5 @@ size_t GetNumberOfUnsentUGC()
 
   return number;
 }
+}  // namespace impl
 }  // namespace lightweight

--- a/ugc/storage.hpp
+++ b/ugc/storage.hpp
@@ -76,5 +76,8 @@ inline std::string DebugPrint(Storage::SettingResult const & result)
 
 namespace lightweight
 {
+namespace impl
+{
 size_t GetNumberOfUnsentUGC();
+}  // namespace impl
 }  //namespace lightweight

--- a/ugc/ugc_tests/storage_tests.cpp
+++ b/ugc/ugc_tests/storage_tests.cpp
@@ -439,7 +439,7 @@ UNIT_CLASS_TEST(StorageTest, NumberOfUnsynchronized)
 
 UNIT_CLASS_TEST(StorageTest, GetNumberOfUnsentSeparately)
 {
-  TEST_EQUAL(lightweight::GetNumberOfUnsentUGC(), 0, ());
+  TEST_EQUAL(lightweight::impl::GetNumberOfUnsentUGC(), 0, ());
   auto & builder = MwmBuilder::Builder();
   m2::PointD const cafePoint(1.0, 1.0);
   builder.Build({TestCafe(cafePoint)});
@@ -454,7 +454,7 @@ UNIT_CLASS_TEST(StorageTest, GetNumberOfUnsentSeparately)
     TEST_EQUAL(storage.GetNumberOfUnsynchronized(), 1, ());
   }
 
-  TEST_EQUAL(lightweight::GetNumberOfUnsentUGC(), 1, ());
+  TEST_EQUAL(lightweight::impl::GetNumberOfUnsentUGC(), 1, ());
 
   {
     Storage storage(builder.GetDataSource());
@@ -464,7 +464,7 @@ UNIT_CLASS_TEST(StorageTest, GetNumberOfUnsentSeparately)
     storage.SaveIndex();
   }
 
-  TEST_EQUAL(lightweight::GetNumberOfUnsentUGC(), 0, ());
+  TEST_EQUAL(lightweight::impl::GetNumberOfUnsentUGC(), 0, ());
   TEST(DeleteIndexFile(), ());
 }
 

--- a/xcode/map/map.xcodeproj/project.pbxproj
+++ b/xcode/map/map.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		3DD122BD2135708900EDFB53 /* libmetrics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DD122BC2135708900EDFB53 /* libmetrics.a */; };
 		3DF54F80219DD21000D12E37 /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54F7E219DD21000D12E37 /* utils.cpp */; };
 		3DF54F81219DD21000D12E37 /* utils.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DF54F7F219DD21000D12E37 /* utils.hpp */; };
+		3DF54F8A21AEA04A00D12E37 /* framework_light.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54F8921AEA04900D12E37 /* framework_light.cpp */; };
 		451E692921494C2700764A97 /* purchase.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 451E692721494C2600764A97 /* purchase.hpp */; };
 		451E692A21494C2700764A97 /* purchase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 451E692821494C2700764A97 /* purchase.cpp */; };
 		45201E931CE4AC90008A4842 /* api_mark_point.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45201E921CE4AC90008A4842 /* api_mark_point.cpp */; };
@@ -324,6 +325,7 @@
 		3DD122BC2135708900EDFB53 /* libmetrics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libmetrics.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DF54F7E219DD21000D12E37 /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cpp; sourceTree = "<group>"; };
 		3DF54F7F219DD21000D12E37 /* utils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = utils.hpp; sourceTree = "<group>"; };
+		3DF54F8921AEA04900D12E37 /* framework_light.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = framework_light.cpp; sourceTree = "<group>"; };
 		451E692721494C2600764A97 /* purchase.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = purchase.hpp; sourceTree = "<group>"; };
 		451E692821494C2700764A97 /* purchase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = purchase.cpp; sourceTree = "<group>"; };
 		45201E921CE4AC90008A4842 /* api_mark_point.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = api_mark_point.cpp; sourceTree = "<group>"; };
@@ -763,6 +765,7 @@
 		675345BD1A4054AD00A0A8C3 /* map */ = {
 			isa = PBXGroup;
 			children = (
+				3DF54F8921AEA04900D12E37 /* framework_light.cpp */,
 				3DF54F7E219DD21000D12E37 /* utils.cpp */,
 				3DF54F7F219DD21000D12E37 /* utils.hpp */,
 				3DD1165E21888AAC007A2ED4 /* notifications */,
@@ -1134,6 +1137,7 @@
 				6753469B1A4054E800A0A8C3 /* track.cpp in Sources */,
 				675346621A4054E800A0A8C3 /* feature_vec_model.cpp in Sources */,
 				454523A9202A0068009275C1 /* cloud.cpp in Sources */,
+				3DF54F8A21AEA04A00D12E37 /* framework_light.cpp in Sources */,
 				674C38621BFF3095000D603B /* user_mark.cpp in Sources */,
 				3DA5723320C195ED007BDE27 /* viewport_search_callback.cpp in Sources */,
 				675346641A4054E800A0A8C3 /* framework.cpp in Sources */,


### PR DESCRIPTION
Сейчас оказалось, что для того, чтобы использовать легковесный фреймворк в двух местах, потребуется дописать ко всем специализациям метода Get слово inline. Иначе ругается на дублирование методов.
Мне показалось, что лучше сделать обычные методы.
Это все равно когда-нибудь пришлось бы сделать.