### PR TITLE
[index][generator] Separate TypeAlways exist. Distinguish always existing types from nondrawable types which we do not want to remove.

### DIFF
--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -167,9 +167,8 @@ bool FeatureBuilder1::RemoveInvalidTypes()
   if (!m_params.FinishAddingTypes())
     return false;
 
-  return feature::RemoveNoDrawableTypes(m_params.m_types,
-                                        m_params.GetGeomType(),
-                                        m_params.IsEmptyNames());
+  return feature::RemoveUselessTypes(m_params.m_types, m_params.GetGeomType(),
+                                     m_params.IsEmptyNames());
 }
 
 bool FeatureBuilder1::FormatFullAddress(string & res) const

--- a/generator/generator_tests/feature_builder_test.cpp
+++ b/generator/generator_tests/feature_builder_test.cpp
@@ -138,7 +138,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBbuilder_GetMostGeneralOsmId)
   TEST_EQUAL(fb.GetMostGenericOsmId(), base::MakeOsmRelation(1), ());
 }
 
-UNIT_CLASS_TEST(TestWithClassificator, FVisibility_RemoveNoDrawableTypes)
+UNIT_CLASS_TEST(TestWithClassificator, FVisibility_RemoveUselessTypes)
 {
   Classificator const & c = classif();
 
@@ -147,7 +147,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FVisibility_RemoveNoDrawableTypes)
     types.push_back(c.GetTypeByPath({ "building" }));
     types.push_back(c.GetTypeByPath({ "amenity", "theatre" }));
 
-    TEST(feature::RemoveNoDrawableTypes(types, feature::GEOM_AREA), ());
+    TEST(feature::RemoveUselessTypes(types, feature::GEOM_AREA), ());
     TEST_EQUAL(types.size(), 2, ());
   }
 
@@ -156,7 +156,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FVisibility_RemoveNoDrawableTypes)
     types.push_back(c.GetTypeByPath({ "highway", "primary" }));
     types.push_back(c.GetTypeByPath({ "building" }));
 
-    TEST(feature::RemoveNoDrawableTypes(types, feature::GEOM_AREA, true), ());
+    TEST(feature::RemoveUselessTypes(types, feature::GEOM_AREA, true /* emptyName */), ());
     TEST_EQUAL(types.size(), 1, ());
     TEST_EQUAL(types[0], c.GetTypeByPath({ "building" }), ());
   }

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -311,7 +311,7 @@ private:
   buffer_vector<uint32_t, static_cast<size_t>(Type::Count)> m_types;
 };
 
-void MatchTypes(OsmElement * p, FeatureParams & params, function<bool(uint32_t)> filterDrawableType)
+void MatchTypes(OsmElement * p, FeatureParams & params, function<bool(uint32_t)> filterType)
 {
   set<int> skipRows;
   vector<ClassifObjectPtr> path;
@@ -378,7 +378,7 @@ void MatchTypes(OsmElement * p, FeatureParams & params, function<bool(uint32_t)>
     for (auto const & e : path)
       ftype::PushValue(t, e.GetIndex());
 
-    if (filterDrawableType(t))
+    if (filterType(t))
       params.AddType(t);
   } while (true);
 }
@@ -822,8 +822,7 @@ void PostprocessElement(OsmElement * p, FeatureParams & params)
 }
 }  // namespace
 
-void GetNameAndType(OsmElement * p, FeatureParams & params,
-                    function<bool(uint32_t)> filterDrawableType)
+void GetNameAndType(OsmElement * p, FeatureParams & params, function<bool(uint32_t)> filterType)
 {
   // Stage1: Preprocess tags.
   PreprocessElement(p);
@@ -902,7 +901,7 @@ void GetNameAndType(OsmElement * p, FeatureParams & params,
   });
 
   // Stage4: Match tags in classificator to find feature types.
-  MatchTypes(p, params, filterDrawableType);
+  MatchTypes(p, params, filterType);
 
   // Stage5: Postprocess feature types.
   PostprocessElement(p, params);

--- a/generator/osm2type.hpp
+++ b/generator/osm2type.hpp
@@ -12,5 +12,5 @@ namespace ftype
 {
 /// Get the types, name and layer for feature with the tree of tags.
 void GetNameAndType(OsmElement * p, FeatureParams & params,
-                    std::function<bool(uint32_t)> filterDrawableType = feature::IsDrawableAny);
+                    std::function<bool(uint32_t)> filterType = feature::TypeIsUseful);
 }

--- a/generator/translator_planet.cpp
+++ b/generator/translator_planet.cpp
@@ -182,13 +182,14 @@ bool TranslatorPlanet::ParseType(OsmElement * p, FeatureParams & params)
 
   m_routingTagsProcessor.m_cameraNodeWriter.Process(*p, params, m_cache);
   m_routingTagsProcessor.m_roadAccessWriter.Process(*p);
+
   return true;
 }
 
 void TranslatorPlanet::EmitPoint(m2::PointD const & pt, FeatureParams params,
                                  base::GeoObjectId id) const
 {
-  if (!feature::RemoveNoDrawableTypes(params.m_types, feature::GEOM_POINT))
+  if (!feature::RemoveUselessTypes(params.m_types, feature::GEOM_POINT))
     return;
 
   FeatureBuilder1 ft;
@@ -199,7 +200,7 @@ void TranslatorPlanet::EmitPoint(m2::PointD const & pt, FeatureParams params,
 
 void TranslatorPlanet::EmitLine(FeatureBuilder1 & ft, FeatureParams params, bool isCoastLine) const
 {
-  if (!isCoastLine && !feature::RemoveNoDrawableTypes(params.m_types, feature::GEOM_LINE))
+  if (!isCoastLine && !feature::RemoveUselessTypes(params.m_types, feature::GEOM_LINE))
     return;
 
   ft.SetLinear(params.m_reverseGeometry);
@@ -230,12 +231,12 @@ void TranslatorPlanet::EmitArea(FeatureBuilder1 & ft, FeatureParams params,
     m_emitter->EmitCityBoundary(fb, params);
   }
 
-  // Key point here is that IsDrawableLike and RemoveNoDrawableTypes
-  // work a bit different for GEOM_AREA.
+  // Key point here is that IsDrawableLike and RemoveUselessTypes
+  // work a bit differently for GEOM_AREA.
   if (IsDrawableLike(params.m_types, GEOM_AREA))
   {
     // Make the area feature if it has unique area styles.
-    VERIFY(RemoveNoDrawableTypes(params.m_types, GEOM_AREA), (params));
+    VERIFY(RemoveUselessTypes(params.m_types, GEOM_AREA), (params));
     fn(ft);
     EmitFeatureBase(ft, params);
   }

--- a/indexer/feature_visibility.hpp
+++ b/indexer/feature_visibility.hpp
@@ -17,7 +17,7 @@ namespace feature
 {
   class TypesHolder;
 
-  bool IsDrawableAny(uint32_t type);
+  bool TypeIsUseful(uint32_t type);
   bool IsDrawableForIndex(FeatureType & ft, int level);
   bool IsDrawableForIndex(TypesHolder const & types, m2::RectD limitRect, int level);
 
@@ -32,7 +32,8 @@ namespace feature
   /// For FEATURE_TYPE_AREA need to have at least one area-filling type.
   bool IsDrawableLike(std::vector<uint32_t> const & types, EGeomType geomType);
   /// For FEATURE_TYPE_AREA removes line-drawing only types.
-  bool RemoveNoDrawableTypes(std::vector<uint32_t> & types, EGeomType geomType, bool emptyName = false);
+  bool RemoveUselessTypes(std::vector<uint32_t> & types, EGeomType geomType,
+                          bool emptyName = false);
   //@}
 
   int GetMinDrawableScale(FeatureType & ft);


### PR DESCRIPTION
У нас для невидимых типов существовало 2 варианта поведения: 
* либо мы удаляем тип из объектов вообще: без специальных костылей от amenity=cafe + internet_access=wlan + cuisine=vegeterian, осталось бы только amenity=cafe при эмите
* либо мы невидимый тип считаем видимым везде и всегда, даже если других видимых тегов нет, на любом зуме и т.п. -- объект wheelchair=yes без каких-либо ещё тегов заэмитится на всех уровнях зума.

В этом реквесте делаю третий вариант поведения -- типы для cuisine, wheelchair, hwtag, psurfaсe оставляем, если у объекта есть другие видимые типы. То есть на кафешках у которых есть тег cuisine он останется, без кафешки объект с cuisine но без других типов эмититься не будет. wheelchair=yes без других типов эмититься не будет (с другими типами -- будет). То же самое psurfaсe/hwtag -- если есть дорожная фича с дорожными тегами, там psurfaсe/hwtag останется, если он просто на произвольном объекте у которого других тегов нет, то такой объект эмитить не будем.

internet_access остается в числе тех, что эмитим безусловно, т.к. он бывает без других типов (например, точка доступа в парке). Возможно нам надо такие объекты рисовать и эмитить нормально, а не через костыль (для справки, в Москве таких объектов около 30).

С roundabout надо разбираться отдельно, там кажется может быть сложнее.
Спонсорские типы не трогаю, т.к. для них может быть важно то что они заэмичены везде и всё вытесняют -- тоже надо разбираться отдельно.