### PR TITLE
[routing] Removing go straight in case of going pass by smaller roads.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -202,7 +202,6 @@ UNIT_TEST(RussiaMoscowTTKVarshavskoeShosseOutTurnTest)
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 2 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
 }
 
 UNIT_TEST(RussiaMoscowTTKUTurnTest)
@@ -216,12 +215,11 @@ UNIT_TEST(RussiaMoscowTTKUTurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::GoStraight);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::UTurnLeft);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightLeft);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::UTurnLeft);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaMoscowParallelResidentalUTurnAvoiding)
@@ -998,4 +996,19 @@ UNIT_TEST(RussiaMoscowKomsomolskyTurnTest)
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+}
+
+// Test on no go straight direction in case of a route along a big road and pass smaller ones.
+UNIT_TEST(RussiaMoscowTTKNoGoStraightTurnTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.78949, 37.5711), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.78673, 37.56726));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -200,7 +200,7 @@ UNIT_TEST(RussiaMoscowTTKVarshavskoeShosseOutTurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
 }
 

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -707,7 +707,8 @@ UNIT_TEST(AustriaBrixentalStrasseTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 UNIT_TEST(RussiaMoscowLeningradkaToMKADTest)

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -74,6 +74,8 @@ public:
            m_mwmId == seg.m_mwmId && m_forward != seg.m_forward;
   }
 
+  void Inverse() { m_forward = !m_forward; }
+
   bool IsRealSegment() const
   {
     return m_mwmId != kFakeNumMwmId && !FakeFeatureIds::IsTransitFeature(m_featureId);


### PR DESCRIPTION
В случае, если маршрут следует по большой дороге мимо маленьких мы не генерируем маневра. Размер дороги определяется перечислением ftypes::HighwayClass. Это не что иное, как объединение значений тага highway в несколько категорий:

``` c++
// Highway class. The order is important.
// The enum values follow from the biggest roads (Trunk) to the smallest ones (Service).
enum class HighwayClass
{
  Undefined = 0,  // There has not been any attempt of calculating HighwayClass.
  Error,          // There was an attempt of calculating HighwayClass but it was not successful.
  Trunk,
  Primary,
  Secondary,
  Tertiary,
  LivingStreet,
  Service,
  Pedestrian,
  Transported,    // Vehicles are transported by train or ferry.
  Count           // This value is used for internals only.
};
```

Данный PR вводит уточнение к правилу описанному выше. Он предотвращает генерацию маневра двигайтесь прямо, в случаях, если выполнены следующие условия:
- предполагается, что будет сгенерирован манерв, двигайтесь прямо;
- маршрут проходит по дороге, которая на одно или более значений (HighwayClass) превосходит категории всех возможных путей из данного маневра.

Данный PR затронул 2 routing_integration_tests:
![image](https://user-images.githubusercontent.com/1768114/49369356-4a19cc00-f702-11e8-839a-29e57d1fb487.png)
![image](https://user-images.githubusercontent.com/1768114/49369363-4d14bc80-f702-11e8-9a3a-904710fd4605.png)

А также я добавил один новый:
![image](https://user-images.githubusercontent.com/1768114/49369382-5736bb00-f702-11e8-9e48-59838069d196.png)

@tatiana-yan @gmoryes PTAL