### PR TITLE
[DNM] [routing] add twins checker

### DIFF
--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -542,7 +542,9 @@ typename AStarAlgorithm<Graph>::Result AStarAlgorithm<Graph>::FindPathBidirectio
       auto const pW = cur->ConsistentHeuristic(stateW.vertex);
       auto const reducedWeight = weight + pW - pV;
 
-      CHECK_GREATER_OR_EQUAL(reducedWeight, -kEpsilon, ("Invariant violated."));
+      CHECK_GREATER_OR_EQUAL(reducedWeight, -kEpsilon,
+                             ("Invariant violated for:", "v =", stateV.vertex, "w =", stateW.vertex));
+
       auto const newReducedDist = stateV.distance + std::max(reducedWeight, kZeroDistance);
 
       auto const fullLength = weight + stateV.distance + cur->pS - pV;

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -11,11 +11,17 @@
 #include "routing_common/num_mwm_id.hpp"
 #include "routing_common/vehicle_model.hpp"
 
+#include "geometry/point2d.hpp"
+
 #include "coding/file_container.hpp"
+#include "coding/point_coding.hpp"
 #include "coding/reader.hpp"
 
 #include "indexer/data_source.hpp"
 
+#include "base/logging.hpp"
+
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>
@@ -110,7 +116,15 @@ public:
         continue;
 
       CHECK_NOT_EQUAL(twinSeg->GetMwmId(), s.GetMwmId(), ());
-      twins.push_back(*twinSeg);
+
+      // Checks twins for equality.
+      // There are same in common, but in case of different version of mwms
+      // their's geometry can differ from each other. Because of this we can not
+      // build the route, because we fail in astar_algorithm.hpp CHECK(invariant) sometimes.
+      if (s.IsRealSegment() || SegmentsAreEqualByGeometry(s, *twinSeg))
+        twins.push_back(*twinSeg);
+      else
+        LOG(LINFO, ("Bad cross mwm feature, differ in geometry. Current:", s, ", twin:", *twinSeg));
     }
   }
 
@@ -155,6 +169,49 @@ public:
   }
 
 private:
+  std::vector<m2::PointD> GetFeaturePointsBySegment(Segment const & segment)
+  {
+    std::vector<m2::PointD> geometry;
+
+    auto const & handle = m_dataSource.GetMwmHandleByCountryFile(m_numMwmIds->GetFile(segment.GetMwmId()));
+    if (!handle.IsAlive())
+      return geometry;
+
+    auto const & mwmId = handle.GetId();
+
+    auto const & featureId = FeatureID(mwmId, segment.GetFeatureId());
+
+    auto const fillGeometry = [&geometry](FeatureType & ftype)
+    {
+      ftype.ParseGeometry(FeatureType::BEST_GEOMETRY);
+      geometry.reserve(ftype.GetPointsCount());
+      for (uint32_t i = 0; i < ftype.GetPointsCount(); ++i)
+        geometry.emplace_back(ftype.GetPoint(i));
+    };
+
+    m_dataSource.ReadFeature(fillGeometry, featureId);
+
+    return geometry;
+  }
+
+  /// \brief Checks segment for equality point by point.
+   bool SegmentsAreEqualByGeometry(Segment const & one, Segment const & two)
+  {
+    std::vector<m2::PointD> geometryOne = GetFeaturePointsBySegment(one);
+    std::vector<m2::PointD> geometryTwo = GetFeaturePointsBySegment(two);
+
+    if (geometryOne.size() != geometryTwo.size())
+      return false;
+
+    for (uint32_t i = 0; i < geometryOne.size(); ++i)
+    {
+      if (!base::AlmostEqualAbs(geometryOne[i], geometryTwo[i], kMwmPointAccuracy))
+        return false;
+    }
+
+    return true;
+  }
+
   CrossMwmConnector<CrossMwmId> const & GetCrossMwmConnectorWithWeights(NumMwmId numMwmId)
   {
     auto const & c = GetCrossMwmConnectorWithTransitions(numMwmId);

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -2,11 +2,9 @@
 
 namespace routing
 {
-using namespace std;
-
-void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges)
+void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges)
 {
-  vector<Segment> twins;
+  std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);
 
   if (GetMode() == Mode::LeapsOnly)
@@ -38,7 +36,7 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, vector<Segme
   SetMode(prevMode);
 }
 
-string DebugPrint(WorldGraph::Mode mode)
+std::string DebugPrint(WorldGraph::Mode mode)
 {
   switch (mode)
   {
@@ -46,7 +44,7 @@ string DebugPrint(WorldGraph::Mode mode)
   case WorldGraph::Mode::NoLeaps: return "NoLeaps";
   case WorldGraph::Mode::SingleMwm: return "SingleMwm";
   }
-  ASSERT(false, ("Unknown mode:", static_cast<size_t>(mode)));
-  return "Unknown mode";
+
+  UNREACHABLE();
 }
 }  // namespace routing


### PR DESCRIPTION
Данный PR фиксит некоторые крэши, связанные с тем, что при переходе из одной mwm в другую, если mwm разные, то переходная фича могла иметь разную геометрию, из-за этого мог падать иногда A*.

Добавил функцию - `FilterTwinsByGeometry` в `WorldGraph`, которая проверяет, что twin'ы идентичны по геометрии с исходным сегментом. Добавил эту функцию в `WorldGraph` потому что она общая у `SingleVehicleGraph` и `TransitWorldGraph`