### PR TITLE
[routing] delete useless code from CrossMwmGraph

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -124,7 +124,6 @@ set(
   transit_info.hpp
   transit_world_graph.cpp
   transit_world_graph.hpp
-  transition_points.hpp
   turn_candidate.hpp
   turns.cpp
   turns.hpp

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -20,32 +20,8 @@
 using namespace routing;
 using namespace std;
 
-namespace
-{
-double constexpr kTransitionEqualityDistM = 20.0;
-double constexpr kInvalidDistance = numeric_limits<double>::max();
-}  // namespace
-
 namespace routing
 {
-// ClosestSegment ---------------------------------------------------------------------------------
-CrossMwmGraph::ClosestSegment::ClosestSegment() : m_bestDistM(kInvalidDistance), m_exactMatchFound(false) {}
-
-CrossMwmGraph::ClosestSegment::ClosestSegment(double minDistM, Segment const & bestSeg, bool exactMatchFound)
-  : m_bestDistM(minDistM), m_bestSeg(bestSeg), m_exactMatchFound(exactMatchFound)
-{
-}
-
-void CrossMwmGraph::ClosestSegment::Update(double distM, Segment const & bestSeg)
-{
-  if (!m_exactMatchFound && distM <= kTransitionEqualityDistM && distM < m_bestDistM)
-  {
-    m_bestDistM = distM;
-    m_bestSeg = bestSeg;
-  }
-}
-
-// CrossMwmGraph ----------------------------------------------------------------------------------
 CrossMwmGraph::CrossMwmGraph(shared_ptr<NumMwmIds> numMwmIds,
                              shared_ptr<m4::Tree<NumMwmId>> numMwmTree,
                              shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
@@ -220,29 +196,6 @@ bool CrossMwmGraph::TransitCrossMwmSectionExists(NumMwmId numMwmId) const
     MYTHROW(RoutingException, ("Mwm", m_numMwmIds->GetFile(numMwmId), "cannot be loaded."));
 
   return status == MwmStatus::SectionExists;
-}
-
-void CrossMwmGraph::GetTwinCandidates(FeatureType & ft, bool isOutgoing,
-                                      vector<Segment> & twinCandidates)
-{
-  NumMwmId const numMwmId =
-      m_numMwmIds->GetId(ft.GetID().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
-  bool const isOneWay =
-      m_vehicleModelFactory->GetVehicleModelForCountry(ft.GetID().GetMwmName())->IsOneWay(ft);
-
-  for (uint32_t segIdx = 0; segIdx + 1 < ft.GetPointsCount(); ++segIdx)
-  {
-    Segment const segForward(numMwmId, ft.GetID().m_index, segIdx, true /* forward */);
-    if (IsTransition(segForward, isOutgoing))
-      twinCandidates.push_back(segForward);
-
-    if (isOneWay)
-      continue;
-
-    Segment const segBackward(numMwmId, ft.GetID().m_index, segIdx, false /* forward */);
-    if (IsTransition(segBackward, isOutgoing))
-      twinCandidates.push_back(segBackward);
-  }
 }
 
 string DebugPrint(CrossMwmGraph::MwmStatus status)

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -109,12 +109,6 @@ private:
     bool m_exactMatchFound;
   };
 
-  /// \returns points of |s|. |s| should be a transition segment of mwm with an index graph cross-mwm section.
-  /// \param s is a transition segment of type |isOutgoing|.
-  /// \note the result of the method is returned by value because the size of the vector is usually
-  /// one or very small.
-  TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing);
-
   MwmStatus GetMwmStatus(NumMwmId numMwmId, std::string const & sectionName) const;
   MwmStatus GetCrossMwmStatus(NumMwmId numMwmId) const;
   MwmStatus GetTransitCrossMwmStatus(NumMwmId numMwmId) const;
@@ -123,20 +117,6 @@ private:
 
   /// \brief Fills |twins| with transition segments of feature |ft| of type |isOutgoing|.
   void GetTwinCandidates(FeatureType & ft, bool isOutgoing, std::vector<Segment> & twinCandidates);
-
-  /// \brief Fills structure |twins| or for feature |ft| if |ft| contains transition segment(s).
-  /// \param sMwmId mwm id of a segment which twins are looked for
-  /// \param ft feature which could contain twin segments
-  /// \param point point of a segment which twins are looked for
-  /// \param minDistSegs is used to keep the best twin candidate
-  /// \param twins is filled with twins if there're twins (one or more) that have a point which is
-  ///        very near or equal to |point|.
-  /// \note If the method finds twin segment with a point which is very close to |point| the twin segment is
-  /// added to |twins| anyway. If there's no such segment in mwm it tries find the closet one and adds it
-  /// to |minDistSegs|.
-  void FindBestTwins(NumMwmId sMwmId, bool isOutgoing, FeatureType & ft, m2::PointD const & point,
-                     std::map<NumMwmId, ClosestSegment> & minDistSegs,
-                     std::vector<Segment> & twins);
 
   /// \brief Fills |neighbors| with number mwm id of all loaded neighbors of |numMwmId| and
   /// sets |allNeighborsHaveCrossMwmSection| to true if all loaded neighbors have cross mwm section

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -98,25 +98,11 @@ public:
   }
 
 private:
-  struct ClosestSegment
-  {
-    ClosestSegment();
-    ClosestSegment(double minDistM, Segment const & bestSeg, bool exactMatchFound);
-    void Update(double distM, Segment const & bestSeg);
-
-    double m_bestDistM;
-    Segment m_bestSeg;
-    bool m_exactMatchFound;
-  };
-
   MwmStatus GetMwmStatus(NumMwmId numMwmId, std::string const & sectionName) const;
   MwmStatus GetCrossMwmStatus(NumMwmId numMwmId) const;
   MwmStatus GetTransitCrossMwmStatus(NumMwmId numMwmId) const;
   bool CrossMwmSectionExists(NumMwmId numMwmId) const;
   bool TransitCrossMwmSectionExists(NumMwmId numMwmId) const;
-
-  /// \brief Fills |twins| with transition segments of feature |ft| of type |isOutgoing|.
-  void GetTwinCandidates(FeatureType & ft, bool isOutgoing, std::vector<Segment> & twinCandidates);
 
   /// \brief Fills |neighbors| with number mwm id of all loaded neighbors of |numMwmId| and
   /// sets |allNeighborsHaveCrossMwmSection| to true if all loaded neighbors have cross mwm section

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -5,7 +5,6 @@
 #include "routing/fake_feature_ids.hpp"
 #include "routing/routing_exceptions.hpp"
 #include "routing/segment.hpp"
-#include "routing/transition_points.hpp"
 #include "routing/vehicle_mask.hpp"
 
 #include "routing_common/num_mwm_id.hpp"

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -122,14 +122,6 @@ public:
 
   void Clear() { m_connectors.clear(); }
 
-  TransitionPoints GetTransitionPoints(Segment const & s, bool isOutgoing)
-  {
-    auto const & connector = GetCrossMwmConnectorWithTransitions(s.GetMwmId());
-    // In case of transition segments of index graph cross-mwm section the front point of segment
-    // is used as a point which corresponds to the segment.
-    return TransitionPoints({connector.GetPoint(s, true /* front */)});
-  }
-
   bool InCache(NumMwmId numMwmId) const { return m_connectors.count(numMwmId) != 0; }
 
   CrossMwmConnector<CrossMwmId> const & GetCrossMwmConnectorWithTransitions(NumMwmId numMwmId)

--- a/routing/transition_points.hpp
+++ b/routing/transition_points.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "base/buffer_vector.hpp"
-
-namespace routing
-{
-using TransitionPoints = buffer_vector<m2::PointD, 1>;
-}  // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -123,7 +123,6 @@
 		56BC22D01F6A502800B6426B /* bicycle_turn_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 567E9F731F5850460064CB96 /* bicycle_turn_test.cpp */; };
 		56C439281E93BF8C00998E29 /* cross_mwm_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */; };
 		56C439291E93BF8C00998E29 /* cross_mwm_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */; };
-		56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C4392C1E93E5DF00998E29 /* transition_points.hpp */; };
 		56CA09E31E30E73B00D05C9A /* applying_traffic_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09DE1E30E73B00D05C9A /* applying_traffic_test.cpp */; };
 		56CA09E41E30E73B00D05C9A /* cumulative_restriction_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09DF1E30E73B00D05C9A /* cumulative_restriction_test.cpp */; };
 		56CA09E51E30E73B00D05C9A /* index_graph_tools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09E01E30E73B00D05C9A /* index_graph_tools.cpp */; };
@@ -411,7 +410,6 @@
 		56A1B7A121A82BCB00246F8C /* maxspeeds_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = maxspeeds_tests.cpp; sourceTree = "<group>"; };
 		56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_mwm_graph.cpp; sourceTree = "<group>"; };
 		56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_graph.hpp; sourceTree = "<group>"; };
-		56C4392C1E93E5DF00998E29 /* transition_points.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_points.hpp; sourceTree = "<group>"; };
 		56CA09DE1E30E73B00D05C9A /* applying_traffic_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = applying_traffic_test.cpp; sourceTree = "<group>"; };
 		56CA09DF1E30E73B00D05C9A /* cumulative_restriction_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cumulative_restriction_test.cpp; sourceTree = "<group>"; };
 		56CA09E01E30E73B00D05C9A /* index_graph_tools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_tools.cpp; sourceTree = "<group>"; };
@@ -823,7 +821,6 @@
 				5694CEC71EBA25F7004576D3 /* road_access.cpp */,
 				5694CEC81EBA25F7004576D3 /* road_access.hpp */,
 				5694CEC91EBA25F7004576D3 /* vehicle_mask.cpp */,
-				56C4392C1E93E5DF00998E29 /* transition_points.hpp */,
 				56C439241E93BF8C00998E29 /* cross_mwm_graph.cpp */,
 				56C439251E93BF8C00998E29 /* cross_mwm_graph.hpp */,
 				674F9BBA1B0A580E00704FFA /* async_router.cpp */,
@@ -1035,7 +1032,6 @@
 				405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */,
 				56FEAA6E219E8A610073DF5F /* maxspeeds_serialization.hpp in Headers */,
 				4065EA801F824A6C0094DEF3 /* transit_world_graph.hpp in Headers */,
-				56C4392D1E93E5DF00998E29 /* transition_points.hpp in Headers */,
 				44E5574A2136EEC900B01439 /* speed_camera_ser_des.hpp in Headers */,
 				0C5FEC551DDE191E0017688C /* edge_estimator.hpp in Headers */,
 				0C12ED241E5C822A0080D0F4 /* index_router.hpp in Headers */,


### PR DESCRIPTION
Удалил код из CrossMwmGraph, связанный с поискам переходных сегментов через геометрию. Дальше удалил те, что использовались только в удаленном коде