### PR TITLE
[routing] Adding maxspeed factors for highway classes.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -315,7 +315,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 920.2);
+    integration::TestRouteTime(route, 955.5);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -28,22 +28,20 @@ UNIT_TEST(RussiaMoscowNagatinoUturnTurnTest)
   integration::TestRouteLength(route, 248.0);
 }
 
-// @TODO This test was broken after using maxspeed tag value always if it's available.
-// It should be fixed by using maxspeed taking into account highway class.
 // Secondary should be preferred against residential.
-//UNIT_TEST(StPetersburgSideRoadPenaltyTest)
-//{
-//  TRouteResult const routeResult =
-//      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-//                                  MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
-//                                  MercatorBounds::FromLatLon(59.84268, 30.27589));
-//
-//  Route const & route = *routeResult.first;
-//  RouterResultCode const result = routeResult.second;
-//  TEST_EQUAL(result, RouterResultCode::NoError, ());
-//
-//  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
-//}
+UNIT_TEST(StPetersburgSideRoadPenaltyTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(59.85157, 30.28033), {0., 0.},
+                                  MercatorBounds::FromLatLon(59.84268, 30.27589));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
 
 UNIT_TEST(RussiaMoscowLenigradskiy39UturnTurnTest)
 {

--- a/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
@@ -7,15 +7,13 @@ using namespace routing_quality;
 // Test on preferring better but longer roads should be grouped in this file.
 namespace
 {
-// @TODO This test was broken after using maxspeed tag value always if it's available.
-// It should be fixed by using maxspeed taking into account highway class.
 // Secondary should be preferred against residential.
-//UNIT_TEST(RoutingQuality_RussiaMoscowTushino)
-//{
-//  TEST(CheckCarRoute({55.84398, 37.45018} /* start */, {55.85489, 37.43784} /* finish */,
-//                     {{{55.84343, 37.43949}}} /* reference track */),
-//       ());
-//}
+UNIT_TEST(RoutingQuality_RussiaMoscowTushino)
+{
+  TEST(CheckCarRoute({55.84398, 37.45018} /* start */, {55.85489, 37.43784} /* finish */,
+                     {{{55.84343, 37.43949}}} /* reference track */),
+       ());
+}
 
 UNIT_TEST(RoutingQuality_TurkeyIzmirArea)
 {
@@ -69,16 +67,12 @@ UNIT_TEST(RoutingQuality_EindhovenNetherlands)
        ());
 }
 
-// @TODO This test was broken after using maxspeed tag value always if it's available.
-// It does not show a big problem. The route goes along a short territory road instead of
-// going a trunk road which is much longer. But an end user wrote that it's better go
-// along the trunk. So this test should be fixed by taking into account highway class.
-//UNIT_TEST(RoutingQuality_GeteborgasSweden)
-//{
-//  TEST(CheckCarRoute({57.77064, 11.88079} /* start */, {57.71231, 11.93157} /* finish */,
-//                     {{{57.74912, 11.87343}}} /* reference track */),
-//       ());
-//}
+UNIT_TEST(RoutingQuality_GeteborgasSweden)
+{
+  TEST(CheckCarRoute({57.77064, 11.88079} /* start */, {57.71231, 11.93157} /* finish */,
+                     {{{57.74912, 11.87343}}} /* reference track */),
+       ());
+}
 
 UNIT_TEST(RoutingQuality_CigilTurkey)
 {

--- a/routing/routing_quality/routing_quality_tests/passby_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/passby_roads_tests.cpp
@@ -40,7 +40,7 @@ UNIT_TEST(RoutingQuality_BelarusBobruisk)
        ());
 }
 
-UNIT_TEST(RoutingQuality_RussiaStPiterburg)
+UNIT_TEST(RoutingQuality_RussiaStPetersburg)
 {
   TEST(CheckCarRoute({60.08634, 30.10277} /* start */, {59.94584, 30.57703} /* finish */,
                      {{{60.03478, 30.44084}}} /* reference point */),

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -32,30 +32,30 @@ using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 // not marked as "hwtag=nobicycle" in OSM.
 
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
-//                                       in city         out city        maxspeed factor is not used
-InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(10.0), SpeedKMpH(10.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(6.0), SpeedKMpH(6.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(20.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+//                                           in city         out city        maxspeed factor is not used
+InOutCitySpeedKMpH constexpr kSpeedTrunkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTrunkLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPrimaryKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPrimaryLinkKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedSecondaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedSecondaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTertiaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTertiaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedServiceKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedUnclassifiedKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedRoadKMpH(SpeedKMpH(10.0), SpeedKMpH(10.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTrackKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPathKMpH(SpeedKMpH(6.0), SpeedKMpH(6.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedBridlewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedCyclewayKMpH(SpeedKMpH(20.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedResidentialKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedLivingStreetKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedStepsKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedFootwayKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPlatformKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPierKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedFerryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
 
 double constexpr kSpeedOffroadKMpH = 3.0;
 

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -14,6 +14,7 @@ namespace
 {
 using InOutCitySpeedKMpH = VehicleModel::InOutCitySpeedKMpH;
 using SpeedKMpH = VehicleModel::SpeedKMpH;
+using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 
 // See model specifics in different countries here:
 //   https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions
@@ -31,30 +32,30 @@ using SpeedKMpH = VehicleModel::SpeedKMpH;
 // not marked as "hwtag=nobicycle" in OSM.
 
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
-//                                       in city         out city
-InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0));
-InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0));
-InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0));
-InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0));
-InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0));
-InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0));
-InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(10.0), SpeedKMpH(10.0));
-InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0));
-InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(6.0), SpeedKMpH(6.0));
-InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(20.0), SpeedKMpH(20.0));
-InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0));
-InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0));
-InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0));
-InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0));
-InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0));
-InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
+//                                       in city         out city        maxspeed factor is not used
+InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(10.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(15.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(12.0), SpeedKMpH(12.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(10.0), SpeedKMpH(10.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(6.0), SpeedKMpH(6.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(20.0), SpeedKMpH(20.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(8.0), SpeedKMpH(8.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(7.0), SpeedKMpH(7.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
 
 double constexpr kSpeedOffroadKMpH = 3.0;
 
@@ -476,6 +477,11 @@ VehicleModelInterface::RoadAvailability BicycleModel::GetRoadAvailability(featur
 bool BicycleModel::IsBicycleBidir(feature::TypesHolder const & types) const
 {
   return types.Has(m_bidirBicycleType);
+}
+
+SpeedKMpH BicycleModel::GetSpeed(FeatureType & f, SpeedParams const & speedParams) const
+{
+  return VehicleModel::GetSpeedWihtoutMaxspeed(f, speedParams);
 }
 
 bool BicycleModel::IsOneWay(FeatureType & f) const

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -12,6 +12,7 @@ public:
   BicycleModel(VehicleModel::LimitsInitList const & speedLimits);
 
   /// VehicleModelInterface overrides:
+  SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType & f) const override;
   double GetOffroadSpeed() const override;
 

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -24,15 +24,15 @@ using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
 //                                                      in city            out city
 InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8),  SpeedKMpH(123.4), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(0.7));
+InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(0.85));
 InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(0.7));
+InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(0.85));
 InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2),  MaxspeedFactor(0.95));
-InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.65));
+InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.8));
 InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.6));
+InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.75));
 InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5),  MaxspeedFactor(0.85));
-InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.55));
+InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.7));
 InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.75));
 InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0),  MaxspeedFactor(0.8));
 InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0),  MaxspeedFactor(0.8));

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -22,28 +22,28 @@ using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 // See road types here:
 //   https://wiki.openstreetmap.org/wiki/Key:highway
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
-//                                                      in city            out city
-InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8),  SpeedKMpH(123.4), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(0.85));
-InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(0.85));
-InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2),  MaxspeedFactor(0.95));
-InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.8));
-InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.75));
-InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5),  MaxspeedFactor(0.85));
-InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.7));
-InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.75));
-InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0),  MaxspeedFactor(0.8));
-InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0),  MaxspeedFactor(0.8));
-InOutCitySpeedKMpH const         kSpeedLivingStreetKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.75));
-InOutCitySpeedKMpH const                 kSpeedRoadKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.3));
-InOutCitySpeedKMpH const                kSpeedTrackKMpH(SpeedKMpH(5.0),    SpeedKMpH(5.0),   MaxspeedFactor(0.3));
-InOutCitySpeedKMpH const        kSpeedFerryMotorcarKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const kSpeedFerryMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const  kSpeedRailMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const         kSpeedShuttleTrainKMpH(SpeedKMpH(25.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const                 kSpeedPierKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+//                                                          in city            out city
+InOutCitySpeedKMpH constexpr             kSpeedMotorwayKMpH(SpeedKMpH(117.8),  SpeedKMpH(123.4), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH constexpr                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH constexpr              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2),  MaxspeedFactor(0.95));
+InOutCitySpeedKMpH constexpr          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.8));
+InOutCitySpeedKMpH constexpr            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH constexpr        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.75));
+InOutCitySpeedKMpH constexpr             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH constexpr         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.7));
+InOutCitySpeedKMpH constexpr          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.75));
+InOutCitySpeedKMpH constexpr         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0),  MaxspeedFactor(0.8));
+InOutCitySpeedKMpH constexpr              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0),  MaxspeedFactor(0.8));
+InOutCitySpeedKMpH constexpr         kSpeedLivingStreetKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.75));
+InOutCitySpeedKMpH constexpr                 kSpeedRoadKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.3));
+InOutCitySpeedKMpH constexpr                kSpeedTrackKMpH(SpeedKMpH(5.0),    SpeedKMpH(5.0),   MaxspeedFactor(0.3));
+InOutCitySpeedKMpH constexpr        kSpeedFerryMotorcarKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH constexpr kSpeedFerryMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH constexpr  kSpeedRailMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH constexpr         kSpeedShuttleTrainKMpH(SpeedKMpH(25.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH constexpr                 kSpeedPierKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
 
 double constexpr kSpeedOffroadKMpH = 10.0;
 

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -14,6 +14,7 @@ namespace
 {
 using InOutCitySpeedKMpH = VehicleModel::InOutCitySpeedKMpH;
 using SpeedKMpH = VehicleModel::SpeedKMpH;
+using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 
 // See model specifics in different countries here:
 //   https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions
@@ -22,27 +23,27 @@ using SpeedKMpH = VehicleModel::SpeedKMpH;
 //   https://wiki.openstreetmap.org/wiki/Key:highway
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
 //                                                      in city            out city
-InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8), SpeedKMpH(123.4));
-InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2));
-InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2));
-InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2));
-InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2));
-InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8));
-InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3));
-InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0));
-InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5));
-InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0));
-InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0));
-InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0));
-InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0));
-InOutCitySpeedKMpH const         kSpeedLivingStreetKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
-InOutCitySpeedKMpH const                 kSpeedRoadKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
-InOutCitySpeedKMpH const                kSpeedTrackKMpH(SpeedKMpH(5.0),    SpeedKMpH(5.0));
-InOutCitySpeedKMpH const        kSpeedFerryMotorcarKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
-InOutCitySpeedKMpH const kSpeedFerryMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
-InOutCitySpeedKMpH const  kSpeedRailMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
-InOutCitySpeedKMpH const         kSpeedShuttleTrainKMpH(SpeedKMpH(25.0),   SpeedKMpH(25.0));
-InOutCitySpeedKMpH const                 kSpeedPierKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0));
+InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8),  SpeedKMpH(123.4), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2),  MaxspeedFactor(0.95));
+InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.95));
+InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.75));
+InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0),  MaxspeedFactor(0.8));
+InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0),  MaxspeedFactor(0.8));
+InOutCitySpeedKMpH const         kSpeedLivingStreetKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.75));
+InOutCitySpeedKMpH const                 kSpeedRoadKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.3));
+InOutCitySpeedKMpH const                kSpeedTrackKMpH(SpeedKMpH(5.0),    SpeedKMpH(5.0),   MaxspeedFactor(0.3));
+InOutCitySpeedKMpH const        kSpeedFerryMotorcarKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const kSpeedFerryMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const  kSpeedRailMotorcarVehicleKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const         kSpeedShuttleTrainKMpH(SpeedKMpH(25.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const                 kSpeedPierKMpH(SpeedKMpH(10.0),   SpeedKMpH(10.0),  MaxspeedFactor(0.9));
 
 double constexpr kSpeedOffroadKMpH = 10.0;
 
@@ -230,19 +231,6 @@ CarModel::CarModel(VehicleModel::LimitsInitList const & roadLimits)
   : VehicleModel(classif(), roadLimits, g_carSurface)
 {
   InitAdditionalRoadTypes();
-}
-
-SpeedKMpH CarModel::GetSpeed(FeatureType & f, SpeedParams const & speedParams) const
-{
-  if (!speedParams.m_maxspeed.IsValid())
-    return VehicleModel::GetSpeed(f, speedParams);
-
-  // Note. It's the first rough attempt using maxspeed tag value for speed calculation.
-  // It's used as a feature speed if it's valid and less then some value.
-  // @TODO maxspeed tag value should be used more sophisticated.
-  uint16_t const maxspeedBasedSpeedKmPH = speedParams.m_maxspeed.GetSpeedKmPH(speedParams.m_forward);
-  auto const speedKmPH = min(static_cast<double>(maxspeedBasedSpeedKmPH), GetMaxWeightSpeed());
-  return {speedKmPH /* weight */, speedKmPH /* eta */};
 }
 
 double CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -24,15 +24,15 @@ using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
 //                                                      in city            out city
 InOutCitySpeedKMpH const             kSpeedMotorwayKMpH(SpeedKMpH(117.8),  SpeedKMpH(123.4), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const         kSpeedMotorwayLinkKMpH(SpeedKMpH(82.0),   SpeedKMpH(81.2),  MaxspeedFactor(0.7));
 InOutCitySpeedKMpH const                kSpeedTrunkKMpH(SpeedKMpH(83.4),   SpeedKMpH(100.2), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const            kSpeedTrunkLinkKMpH(SpeedKMpH(73.0),   SpeedKMpH(77.2),  MaxspeedFactor(0.7));
 InOutCitySpeedKMpH const              kSpeedPrimaryKMpH(SpeedKMpH(63.1),   SpeedKMpH(75.2),  MaxspeedFactor(0.95));
-InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.95));
+InOutCitySpeedKMpH const          kSpeedPrimaryLinkKMpH(SpeedKMpH(66.5),   SpeedKMpH(64.8),  MaxspeedFactor(0.65));
 InOutCitySpeedKMpH const            kSpeedSecondaryKMpH(SpeedKMpH(52.8),   SpeedKMpH(60.3),  MaxspeedFactor(0.9));
-InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.9));
+InOutCitySpeedKMpH const        kSpeedSecondaryLinkKMpH(SpeedKMpH(50.2),   SpeedKMpH(60.0),  MaxspeedFactor(0.6));
 InOutCitySpeedKMpH const             kSpeedTertiaryKMpH(SpeedKMpH(45.5),   SpeedKMpH(50.5),  MaxspeedFactor(0.85));
-InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.85));
+InOutCitySpeedKMpH const         kSpeedTertiaryLinkKMpH(SpeedKMpH(25.0),   SpeedKMpH(30.0),  MaxspeedFactor(0.55));
 InOutCitySpeedKMpH const          kSpeedResidentialKMpH(SpeedKMpH(20.0),   SpeedKMpH(25.0),  MaxspeedFactor(0.75));
 InOutCitySpeedKMpH const         kSpeedUnclassifiedKMpH(SpeedKMpH(51.3),   SpeedKMpH(66.0),  MaxspeedFactor(0.8));
 InOutCitySpeedKMpH const              kSpeedServiceKMpH(SpeedKMpH(15.0),   SpeedKMpH(15.0),  MaxspeedFactor(0.8));

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -12,7 +12,6 @@ public:
   CarModel(VehicleModel::LimitsInitList const & roadLimits);
 
   // VehicleModelInterface overrides:
-  SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   double GetOffroadSpeed() const override;
 
   static CarModel const & AllLimitsInstance();

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -14,6 +14,7 @@ namespace
 {
 using InOutCitySpeedKMpH = VehicleModel::InOutCitySpeedKMpH;
 using SpeedKMpH = VehicleModel::SpeedKMpH;
+using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 
 // See model specifics in different countries here:
 //   https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions
@@ -31,30 +32,30 @@ using SpeedKMpH = VehicleModel::SpeedKMpH;
 // not marked as "foot=no" in OSM.
 
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
-//                                       in city         out city
-InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0));
-InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0));
-InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0));
-InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0));
-InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5));
-InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0));
-InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5));
-InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0));
-InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0));
-InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0));
-InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0));
+//                                       in city         out city        maxspeed factor is not used
+InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
 
 double constexpr kSpeedOffroadKMpH = 3.0;
 
@@ -296,6 +297,11 @@ PedestrianModel::PedestrianModel(VehicleModel::LimitsInitList const & speedLimit
   : VehicleModel(classif(), speedLimits, g_pedestrianSurface)
 {
   Init();
+}
+
+SpeedKMpH PedestrianModel::GetSpeed(FeatureType & f, SpeedParams const & speedParams) const
+{
+  return VehicleModel::GetSpeedWihtoutMaxspeed(f, speedParams);
 }
 
 double PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -32,30 +32,30 @@ using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 // not marked as "foot=no" in OSM.
 
 // Speed of road features located inside and outside cities and towns polygons in km per hour.
-//                                       in city         out city        maxspeed factor is not used
-InOutCitySpeedKMpH const kSpeedTrunkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTrunkLinkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPrimaryKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPrimaryLinkKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedSecondaryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedSecondaryLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTertiaryKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTertiaryLinkKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedServiceKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedUnclassifiedKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedRoadKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedTrackKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPathKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedBridlewayKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedCyclewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedResidentialKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedLivingStreetKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedStepsKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedFootwayKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPlatformKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedPierKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
-InOutCitySpeedKMpH const kSpeedFerryKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+//                                           in city         out city        maxspeed factor is not used
+InOutCitySpeedKMpH constexpr kSpeedTrunkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTrunkLinkKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPrimaryKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPrimaryLinkKMpH(SpeedKMpH(2.0), SpeedKMpH(2.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedSecondaryKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedSecondaryLinkKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTertiaryKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTertiaryLinkKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedServiceKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedUnclassifiedKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedRoadKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedTrackKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPathKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedBridlewayKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedCyclewayKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedResidentialKMpH(SpeedKMpH(4.5), SpeedKMpH(4.5), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedLivingStreetKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedStepsKMpH(SpeedKMpH(3.0), SpeedKMpH(3.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPedestrianKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedFootwayKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPlatformKMpH(SpeedKMpH(5.0), SpeedKMpH(5.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedPierKMpH(SpeedKMpH(4.0), SpeedKMpH(4.0), MaxspeedFactor(1.0));
+InOutCitySpeedKMpH constexpr kSpeedFerryKMpH(SpeedKMpH(1.0), SpeedKMpH(1.0), MaxspeedFactor(1.0));
 
 double constexpr kSpeedOffroadKMpH = 3.0;
 

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -12,6 +12,7 @@ public:
   PedestrianModel(VehicleModel::LimitsInitList const & speedLimits);
 
   /// VehicleModelInterface overrides:
+  SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType &) const override { return false; }
   double GetOffroadSpeed() const override;
 

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -1,14 +1,22 @@
 #include "testing/testing.hpp"
 
+#include "routing_common/maxspeed_conversion.hpp"
 #include "routing_common/vehicle_model.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
 #include "indexer/feature.hpp"
 
+#include "platform/measurement_utils.hpp"
+
 #include "base/macros.hpp"
 
+#include <cstdint>
+
+using namespace routing;
 using namespace std;
+
+using MaxspeedFactor = VehicleModel::MaxspeedFactor;
 
 namespace
 {
@@ -16,16 +24,17 @@ using SpeedKMpH = routing::VehicleModel::SpeedKMpH;
 using InOutCitySpeedKMpH = routing::VehicleModel::InOutCitySpeedKMpH;
 
 InOutCitySpeedKMpH const speedSecondaryExpected = {
-    {80.0 /* weight */, 70.0 /* eta */} /* in city */,
-    {80.0 /* weight */, 70.0 /* eta */} /* out of city */};
+    SpeedKMpH(80.0 /* weight */, 70.0 /* eta */) /* in city */,
+    SpeedKMpH(80.0 /* weight */, 70.0 /* eta */) /* out of city */, MaxspeedFactor(1.0)};
 
 routing::VehicleModel::LimitsInitList const s_testLimits = {
-    //                In city weight and eta speeds. Out of city weight and eta speeds.
-    {{"highway", "trunk"}, {SpeedKMpH(100.0, 100.0), SpeedKMpH(150.0, 150.0)}, true},
-    {{"highway", "primary"}, {SpeedKMpH(90.0, 90.0), SpeedKMpH(120.0, 120.0)}, true},
+    {{"highway", "trunk"}, {SpeedKMpH(100.0 /* weight */, 100.0 /* eta */) /* in city */,
+                            SpeedKMpH(150.0 /* weight */, 150.0 /* eta */) /* out of city */,
+                            MaxspeedFactor(1.0)}, true},
+    {{"highway", "primary"}, {SpeedKMpH(90.0, 90.0), SpeedKMpH(120.0, 120.0), MaxspeedFactor(1.0)}, true},
     {{"highway", "secondary"}, speedSecondaryExpected, true},
-    {{"highway", "residential"}, {SpeedKMpH(45.0, 55.0), SpeedKMpH(50.0, 60.0)}, true},
-    {{"highway", "service"}, {SpeedKMpH(47.0, 36.0), SpeedKMpH(50.0, 40.0)}, false}};
+    {{"highway", "residential"}, {SpeedKMpH(45.0, 55.0), SpeedKMpH(50.0, 60.0), MaxspeedFactor(0.5)}, true},
+    {{"highway", "service"}, {SpeedKMpH(47.0, 36.0), SpeedKMpH(50.0, 40.0), MaxspeedFactor(1.0)}, false}};
 
 routing::VehicleModel::SurfaceInitList const g_carSurface = {
     {{"psurface", "paved_good"}, {0.8 /* weightFactor */, 0.9 /* etaFactor */}},
@@ -44,10 +53,13 @@ class TestVehicleModel : public routing::VehicleModel
 {
   friend void CheckOneWay(initializer_list<uint32_t> const & types, bool expectedValue);
   friend void CheckPassThroughAllowed(initializer_list<uint32_t> const & types, bool expectedValue);
-  friend void CheckSpeed(initializer_list<uint32_t> const & types, InOutCitySpeedKMpH const & expectedSpeed);
+  friend void CheckSpeedWithParams(initializer_list<uint32_t> const & types,
+                                   SpeedParams const & params, SpeedKMpH const & expectedSpeed);
 
-public:
-  TestVehicleModel() : VehicleModel(classif(), s_testLimits, g_carSurface) {}
+      public : TestVehicleModel()
+    : VehicleModel(classif(), s_testLimits, g_carSurface)
+  {
+  }
 
   // We are not going to use offroad routing in these tests.
   double GetOffroadSpeed() const override { return 0.0; }
@@ -65,15 +77,23 @@ uint32_t GetOnewayType()
   return GetType("hwtag", "oneway");
 }
 
-void CheckSpeed(initializer_list<uint32_t> const & types, InOutCitySpeedKMpH const & expectedSpeed)
+void CheckSpeedWithParams(initializer_list<uint32_t> const & types, SpeedParams const & params,
+                          SpeedKMpH const & expectedSpeed)
 {
   TestVehicleModel vehicleModel;
   feature::TypesHolder h;
   for (uint32_t t : types)
     h.Add(t);
 
-  TEST_EQUAL(vehicleModel.GetMinTypeSpeed(h, true /* in city */), expectedSpeed.m_inCity, ());
-  TEST_EQUAL(vehicleModel.GetMinTypeSpeed(h, false /* in city */), expectedSpeed.m_outCity, ());
+  TEST_EQUAL(vehicleModel.GetTypeSpeed(h, params), expectedSpeed, ());
+}
+
+void CheckSpeed(initializer_list<uint32_t> const & types, InOutCitySpeedKMpH const & expectedSpeed)
+{
+  SpeedParams const inCity(true /* forward */, true /* in city */, Maxspeed());
+  CheckSpeedWithParams(types, inCity, expectedSpeed.m_inCity);
+  SpeedParams const outCity(true /* forward */, false /* in city */, Maxspeed());
+  CheckSpeedWithParams(types, outCity, expectedSpeed.m_outCity);
 }
 
 void CheckOneWay(initializer_list<uint32_t> const & types, bool expectedValue)
@@ -106,17 +126,19 @@ UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_MaxSpeed)
 UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_Speed)
 {
   {
-
     CheckSpeed({GetType("highway", "secondary", "bridge")}, speedSecondaryExpected);
     CheckSpeed({GetType("highway", "secondary", "tunnel")}, speedSecondaryExpected);
     CheckSpeed({GetType("highway", "secondary")}, speedSecondaryExpected);
   }
 
   CheckSpeed({GetType("highway", "trunk")},
-             {{100.0 /* weight */, 100.0 /* eta */} /* in city */,
-              {150.0 /* weight */, 150.0 /* eta */} /* out of city */});
-  CheckSpeed({GetType("highway", "primary")}, {{90.0, 90.0}, {120.0, 120.0}});
-  CheckSpeed({GetType("highway", "residential")}, {{45.0, 55.0}, {50.0, 60.0}});
+             {SpeedKMpH(100.0 /* weight */, 100.0 /* eta */) /* in city */,
+              SpeedKMpH(150.0 /* weight */, 150.0 /* eta */) /* out of city */,
+              MaxspeedFactor(1.0)});
+  CheckSpeed({GetType("highway", "primary")},
+             {SpeedKMpH(90.0, 90.0), SpeedKMpH(120.0, 120.0), MaxspeedFactor(1.0)});
+  CheckSpeed({GetType("highway", "residential")},
+             {SpeedKMpH(45.0, 55.0), SpeedKMpH(50.0, 60.0), MaxspeedFactor(1.0)});
 }
 
 UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_Speed_MultiTypes)
@@ -150,9 +172,8 @@ UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_DifferentSpeeds)
   uint32_t const typeOneway = GetOnewayType();
 
   CheckSpeed({typeSecondary, typePrimary}, speedSecondaryExpected);
-  CheckSpeed({typePrimary, typeSecondary}, speedSecondaryExpected);
 
-  CheckSpeed({typePrimary, typeOneway, typeSecondary}, speedSecondaryExpected);
+  CheckSpeed({typeSecondary, typePrimary, typeOneway}, speedSecondaryExpected);
   CheckOneWay({typePrimary, typeOneway, typeSecondary}, true);
 }
 
@@ -172,14 +193,48 @@ UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_SpeedFactor)
   uint32_t const unpavedGood = GetType("psurface", "unpaved_good");
   uint32_t const unpavedBad = GetType("psurface", "unpaved_bad");
 
-  CheckSpeed({secondary, pavedGood}, {{64.0 /* weight */, 63.0 /* eta */} /* in city */,
-                                      {64.0 /* weight */, 63.0 /* eta */} /* out of city */});
-  CheckSpeed({secondary, pavedBad}, {{32.0, 35.0}, {32.0, 35.0}});
-  CheckSpeed({secondary, unpavedGood}, {{48.0, 56.0}, {48.0, 56.0}});
-  CheckSpeed({secondary, unpavedBad}, {{16.0, 14.0}, {16.0, 14.0}});
+  CheckSpeed({secondary, pavedGood}, {SpeedKMpH(64.0 /* weight */, 63.0 /* eta */) /* in city */,
+                                      SpeedKMpH(64.0 /* weight */, 63.0 /* eta */) /* out of city */,
+                                      MaxspeedFactor(1.0)});
+  CheckSpeed({secondary, pavedBad}, {SpeedKMpH(32.0, 35.0), SpeedKMpH(32.0, 35.0), MaxspeedFactor(1.0)});
+  CheckSpeed({secondary, unpavedGood}, {SpeedKMpH(48.0, 56.0), SpeedKMpH(48.0, 56.0), MaxspeedFactor(1.0)});
+  CheckSpeed({secondary, unpavedBad}, {SpeedKMpH(16.0, 14.0), SpeedKMpH(16.0, 14.0), MaxspeedFactor(1.0)});
 
-  CheckSpeed({residential, pavedGood}, {{36.0, 49.5}, {40.0, 54.0}});
-  CheckSpeed({residential, pavedBad}, {{18.0, 27.5}, {20.0, 30.0}});
-  CheckSpeed({residential, unpavedGood}, {{27.0, 44.0}, {30.0, 48.0}});
-  CheckSpeed({residential, unpavedBad}, {{9.0, 11.0}, {10.0, 12.0}});
+  CheckSpeed({residential, pavedGood}, {SpeedKMpH(36.0, 49.5), SpeedKMpH(40.0, 54.0), MaxspeedFactor(1.0)});
+  CheckSpeed({residential, pavedBad}, {SpeedKMpH(18.0, 27.5), SpeedKMpH(20.0, 30.0), MaxspeedFactor(1.0)});
+  CheckSpeed({residential, unpavedGood}, {SpeedKMpH(27.0, 44.0), SpeedKMpH(30.0, 48.0), MaxspeedFactor(1.0)});
+  CheckSpeed({residential, unpavedBad}, {SpeedKMpH(9.0, 11.0), SpeedKMpH(10.0, 12.0), MaxspeedFactor(1.0)});
+}
+
+UNIT_CLASS_TEST(VehicleModelTest, VehicleModel_MaxspeedFactor)
+{
+  uint32_t const secondary = GetType("highway", "secondary");
+  uint32_t const residential = GetType("highway", "residential");
+  uint32_t const primary = GetType("highway", "primary");
+  uint32_t const pavedGood = GetType("psurface", "paved_good");
+  uint32_t const unpavedBad = GetType("psurface", "unpaved_bad");
+
+  Maxspeed const maxspeed90 =
+      Maxspeed(measurement_utils::Units::Metric, 90 /* forward speed */, kInvalidSpeed);
+  CheckSpeedWithParams({secondary, unpavedBad},
+                       SpeedParams(true /* forward */, false /* in city */, maxspeed90),
+                       SpeedKMpH(90.0));
+  CheckSpeedWithParams({primary, pavedGood},
+                       SpeedParams(true /* forward */, false /* in city */, maxspeed90),
+                       SpeedKMpH(90.0));
+
+  Maxspeed const maxspeed9070 =
+      Maxspeed(measurement_utils::Units::Metric, 90 /* forward speed */, 70);
+  CheckSpeedWithParams({primary, pavedGood},
+                       SpeedParams(true /* forward */, false /* in city */, maxspeed9070),
+                       SpeedKMpH(90.0));
+  CheckSpeedWithParams({primary, pavedGood},
+                       SpeedParams(false /* forward */, false /* in city */, maxspeed9070),
+                       SpeedKMpH(70.0));
+
+  Maxspeed const maxspeed60 =
+      Maxspeed(measurement_utils::Units::Metric, 60 /* forward speed */, kInvalidSpeed);
+  CheckSpeedWithParams({residential, pavedGood},
+                       SpeedParams(true /* forward */, false /* in city */, maxspeed60),
+                       SpeedKMpH(30.0));
 }

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -177,8 +177,7 @@ VehicleModel::SpeedKMpH VehicleModel::GetTypeSpeed(feature::TypesHolder const & 
 VehicleModel::SpeedKMpH VehicleModel::GetSpeedWihtoutMaxspeed(FeatureType & f,
                                                               SpeedParams const & speedParams) const
 {
-  SpeedParams const withoutMaxspeed(speedParams.m_forward, speedParams.m_inCity, Maxspeed());
-  return VehicleModel::GetSpeed(f, withoutMaxspeed);
+  return VehicleModel::GetSpeed(f, {speedParams.m_forward, speedParams.m_inCity, Maxspeed()});
 }
 
 bool VehicleModel::IsOneWay(FeatureType & f) const

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -8,7 +8,6 @@
 #include "base/math.hpp"
 
 #include <algorithm>
-#include <limits>
 #include <sstream>
 
 using namespace routing;

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -45,9 +45,9 @@ public:
   /// Speeds which are used for edge weight and ETA estimations.
   struct SpeedKMpH
   {
-    SpeedKMpH() = default;
-    explicit SpeedKMpH(double weight) noexcept : m_weight(weight), m_eta(weight) {}
-    SpeedKMpH(double weight, double eta) noexcept : m_weight(weight), m_eta(eta) {}
+    constexpr SpeedKMpH() = default;
+    constexpr explicit SpeedKMpH(double weight) noexcept : m_weight(weight), m_eta(weight) {}
+    constexpr SpeedKMpH(double weight, double eta) noexcept : m_weight(weight), m_eta(eta) {}
 
     bool operator==(SpeedKMpH const & rhs) const
     {
@@ -65,8 +65,8 @@ public:
   /// Both should be in range [0.0, 1.0].
   struct MaxspeedFactor
   {
-    explicit MaxspeedFactor(double weight) noexcept : m_weight(weight), m_eta(weight) {}
-    explicit MaxspeedFactor(double weight, double eta) noexcept : m_weight(weight), m_eta(eta) {}
+    constexpr explicit MaxspeedFactor(double weight) noexcept : m_weight(weight), m_eta(weight) {}
+    constexpr explicit MaxspeedFactor(double weight, double eta) noexcept : m_weight(weight), m_eta(eta) {}
 
     bool operator==(MaxspeedFactor const & rhs) const { return m_weight == rhs.m_weight && m_eta == rhs.m_eta; }
 
@@ -76,8 +76,8 @@ public:
 
   struct InOutCitySpeedKMpH
   {
-    InOutCitySpeedKMpH(SpeedKMpH const & inCity, SpeedKMpH const & outCity,
-                       MaxspeedFactor const & maxspeedFactor) noexcept
+    constexpr InOutCitySpeedKMpH(SpeedKMpH const & inCity, SpeedKMpH const & outCity,
+                                 MaxspeedFactor const & maxspeedFactor) noexcept
       : m_inCity(inCity), m_outCity(outCity), m_maxspeedFactor(maxspeedFactor)
     {
     }

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -21,7 +21,7 @@ namespace routing
 /// \brief Params for calculation of an approximate speed on a feature.
 struct SpeedParams
 {
-  SpeedParams(bool forward, bool inCity, Maxspeed maxspeed)
+  SpeedParams(bool forward, bool inCity, Maxspeed const & maxspeed)
     : m_forward(forward), m_inCity(inCity), m_maxspeed(maxspeed)
   {
   }
@@ -60,20 +60,37 @@ public:
     double m_eta = 0.0;    // KMpH
   };
 
+  /// \brief Factors which reduce weight and ETA speed on feature regarding maxspeed tag value
+  /// if the tag is set for the feature.
+  /// Both should be in range [0.0, 1.0].
+  struct MaxspeedFactor
+  {
+    explicit MaxspeedFactor(double weight) noexcept : m_weight(weight), m_eta(weight) {}
+    explicit MaxspeedFactor(double weight, double eta) noexcept : m_weight(weight), m_eta(eta) {}
+
+    bool operator==(MaxspeedFactor const & rhs) const { return m_weight == rhs.m_weight && m_eta == rhs.m_eta; }
+
+    double m_weight;
+    double m_eta;
+  };
+
   struct InOutCitySpeedKMpH
   {
-    InOutCitySpeedKMpH(SpeedKMpH const & inCity, SpeedKMpH const & outCity) noexcept
-      : m_inCity(inCity), m_outCity(outCity)
+    InOutCitySpeedKMpH(SpeedKMpH const & inCity, SpeedKMpH const & outCity,
+                       MaxspeedFactor const & maxspeedFactor) noexcept
+      : m_inCity(inCity), m_outCity(outCity), m_maxspeedFactor(maxspeedFactor)
     {
     }
 
     bool operator==(InOutCitySpeedKMpH const & rhs) const
     {
-      return m_inCity == rhs.m_inCity && m_outCity == rhs.m_outCity;
+      return m_inCity == rhs.m_inCity && m_outCity == rhs.m_outCity && m_maxspeedFactor == rhs.m_maxspeedFactor;
     }
 
     SpeedKMpH m_inCity;
     SpeedKMpH m_outCity;
+    // If maxspeed is available it should be multiplied by |m_maxspeedFactor|.
+    MaxspeedFactor m_maxspeedFactor;
   };
 
   /// Factors which reduce weight and ETA speed on feature in case of bad pavement.
@@ -219,7 +236,9 @@ protected:
 
   bool HasPassThroughType(feature::TypesHolder const & types) const;
 
-  SpeedKMpH GetMinTypeSpeed(feature::TypesHolder const & types, bool inCity) const;
+  SpeedKMpH GetTypeSpeed(feature::TypesHolder const & types, SpeedParams const & speedParams) const;
+
+  SpeedKMpH GetSpeedWihtoutMaxspeed(FeatureType & f, SpeedParams const & speedParams) const;
 
   /// \brief maximum within all the speed limits set in a model (car model, bicycle modle and so on).
   /// It shouldn't be mixed with maxspeed value tag which defines maximum legal speed on a feature.
@@ -242,6 +261,7 @@ private:
     RoadLimits(InOutCitySpeedKMpH const & speed, bool isPassThroughAllowed);
 
     SpeedKMpH const & GetSpeed(bool inCity) const { return inCity ? m_speed.m_inCity : m_speed.m_outCity; };
+    MaxspeedFactor const & GetMaxspeedFactor() const { return m_speed.m_maxspeedFactor; }
     bool IsPassThroughAllowed() const { return m_isPassThroughAllowed; };
     bool operator==(RoadLimits const & rhs) const
     {

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 class Classificator;
@@ -21,8 +22,8 @@ namespace routing
 /// \brief Params for calculation of an approximate speed on a feature.
 struct SpeedParams
 {
-  SpeedParams(bool forward, bool inCity, Maxspeed const & maxspeed)
-    : m_forward(forward), m_inCity(inCity), m_maxspeed(maxspeed)
+  SpeedParams(bool forward, bool inCity, Maxspeed maxspeed)
+    : m_forward(forward), m_inCity(inCity), m_maxspeed(std::move(maxspeed))
   {
   }
 


### PR DESCRIPTION
Сейчас если у фичи есть maxspeed, он используется для задания веса дуги и eta безусловно. Но в ряде случаев (см. тесты ниже) это дает плохие результаты. Это происходит, если у дорог разных категорий задан один и тот же maxspeed, но при этом по дорогам более низкой категории можно доехать короче.

Данный PR исправляет эту ситуацию, что подтверждает ряд routing integration tests и routing quality tests. Он позволяет задать коэффициент для maxspeed в зависимости от highway класса.

Данный PR позволяет вернуть целый ряд outing integration tests и routing quality tests:

RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest
ETA маршрута увеличено, что в данном случае ближе к правде.

StPetersburgSideRoadPenaltyTest
Не срезаем по дублеру
![image](https://user-images.githubusercontent.com/1768114/49583675-fe695b80-f969-11e8-9694-cfc10e25e476.png)

RoutingQuality_RussiaMoscowTushino
Не срезаем через дворы.
![image](https://user-images.githubusercontent.com/1768114/49583777-45575100-f96a-11e8-89b4-c70456bd6430.png)


RoutingQuality_GeteborgasSweden
Ведение по большим дорогам в данном случае лучше, согласно мнению пользователя.
![image](https://user-images.githubusercontent.com/1768114/49583565-a6caf000-f969-11e8-9dc9-3af5365980c3.png)

@tatiana-yan @vmihaylenko PTAL