### PR TITLE
[routing] Route rebuilding when current position is moving to the route.

### DIFF
--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -303,11 +303,9 @@ RoutingSession::State RoutingSession::OnLocationPositionChanged(GpsInfo const & 
                                                         MercatorBounds::FromLatLon(info.m_latitude, info.m_longitude));
     if (base::AlmostEqualAbs(dist, m_lastDistance, kRunawayDistanceSensitivityMeters))
       return m_state;
-    if (dist > m_lastDistance)
-    {
-      ++m_moveAwayCounter;
-      m_lastDistance = dist;
-    }
+
+    ++m_moveAwayCounter;
+    m_lastDistance = dist;
 
     if (m_moveAwayCounter > kOnRouteMissedCount)
     {


### PR DESCRIPTION
Ранее мы перепрокладывали маршрут, когда текущая позиция двигалась только по направлению от маршрута. Данный PR исправляет следующую проблему. Текущая позиция прыгает далеко от маршрута. Маршрут прокладывается. Затем пользователь движется к маршруту и маршрут не перепрокладывается.

@vmihaylenko, @gmoryes PTAL