### PR TITLE
[search] Count duplicate results ones for batch.

### DIFF
--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -533,7 +533,7 @@ void Ranker::UpdateResults(bool lastUpdate)
   size_t i = 0;
   for (; i < m_tentativeResults.size(); ++i)
   {
-    if (!lastUpdate && i >= m_params.m_batchSize && !m_params.m_viewportSearch &&
+    if (!lastUpdate && count >= m_params.m_batchSize && !m_params.m_viewportSearch &&
         !m_params.m_categorialRequest)
     {
       break;

--- a/search/search_integration_tests/ranker_test.cpp
+++ b/search/search_integration_tests/ranker_test.cpp
@@ -6,9 +6,13 @@
 #include "generator/generator_tests_support/test_feature.hpp"
 #include "generator/generator_tests_support/test_mwm_builder.hpp"
 
+#include <utility>
+#include <vector>
+
 using namespace generator::tests_support;
 using namespace search::tests_support;
 using namespace search;
+using namespace std;
 
 namespace
 {
@@ -47,6 +51,57 @@ UNIT_CLASS_TEST(RankerTest, ErrorsInStreets)
     TEST_EQUAL(results.size(), 2, ());
     TEST(ResultsMatch({results[0]}, {rules[0]}), ());
     TEST(ResultsMatch({results[1]}, {rules[1]}), ());
+  }
+}
+
+UNIT_CLASS_TEST(RankerTest, UniteSameResults)
+{
+  size_t constexpr kSameCount = 10;
+
+  vector<TestCafe> bars;
+  for (size_t i = 0; i < kSameCount; ++i)
+    bars.emplace_back(m2::PointD(0.0, 1.0), "bar", "en");
+
+  vector<TestCafe> cafes;
+  for (size_t i = 0; i < kSameCount; ++i)
+    cafes.emplace_back(m2::PointD(1.0, 1.0), "cafe", "en");
+
+  vector<TestCafe> fastfoods;
+  for (size_t i = 0; i < kSameCount; ++i)
+    fastfoods.emplace_back(m2::PointD(1.0, 1.0), "fastfood", "en");
+
+  auto id = BuildCountry("FoodLand", [&](TestMwmBuilder & builder) {
+    for (auto const & b : bars)
+      builder.Add(b);
+
+    for (auto const & c : cafes)
+      builder.Add(c);
+
+    for (auto const & f : fastfoods)
+      builder.Add(f);
+  });
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 1.0), m2::PointD(2.0, 3.0)));
+  {
+    auto request = MakeRequest("eat ");
+    auto const & results = request->Results();
+
+    TRules barRules;
+    for (auto const & b : bars)
+      barRules.push_back(ExactMatch(id, b));
+
+    TRules cafeRules;
+    for (auto const & c : cafes)
+      cafeRules.push_back(ExactMatch(id, c));
+
+    TRules fastfoodRules;
+    for (auto const & f : fastfoods)
+      fastfoodRules.push_back(ExactMatch(id, f));
+
+    TEST(ResultsMatch(results,
+                      {AlternativesMatch(move(barRules)), AlternativesMatch(move(cafeRules)),
+                       AlternativesMatch(move(fastfoodRules))}),
+         ());
   }
 }
 }  // namespace

--- a/search/search_tests_support/test_results_matching.cpp
+++ b/search/search_tests_support/test_results_matching.cpp
@@ -33,7 +33,7 @@ string ExactMatchingRule::ToString() const
   return os.str();
 }
 
-AlternativesMatchingRule::AlternativesMatchingRule(initializer_list<shared_ptr<MatchingRule>> rules)
+AlternativesMatchingRule::AlternativesMatchingRule(vector<shared_ptr<MatchingRule>> && rules)
   : m_rules(move(rules))
 {
 }

--- a/search/search_tests_support/test_results_matching.hpp
+++ b/search/search_tests_support/test_results_matching.hpp
@@ -52,7 +52,7 @@ private:
 class AlternativesMatchingRule : public MatchingRule
 {
 public:
-  AlternativesMatchingRule(std::initializer_list<std::shared_ptr<MatchingRule>> rules);
+  AlternativesMatchingRule(std::vector<std::shared_ptr<MatchingRule>> && rules);
 
   // MatchingRule overrides:
   bool Matches(FeatureType & feature) const override;
@@ -68,10 +68,10 @@ std::shared_ptr<MatchingRule> ExactMatch(TArgs &&... args)
   return std::make_shared<ExactMatchingRule>(forward<TArgs>(args)...);
 }
 
-template <typename... TArgs>
-std::shared_ptr<MatchingRule> AlternativesMatch(TArgs &&... args)
+inline std::shared_ptr<MatchingRule> AlternativesMatch(
+    std::vector<std::shared_ptr<MatchingRule>> && rules)
 {
-  return std::make_shared<AlternativesMatchingRule>(std::forward<TArgs>(args)...);
+  return std::make_shared<AlternativesMatchingRule>(std::move(rules));
 }
 
 bool MatchResults(DataSource const & dataSource, std::vector<std::shared_ptr<MatchingRule>> rules,


### PR DESCRIPTION
Сейчас, если нашлось много дубликатов, можем заэмитить 2-3 результата из mwm. Получается мало результатов из текущей mwm, сразу результаты за 100 км.