### PR TITLE
[routing] Straight turn correction in case of two go straight or slight ways out.

### DIFF
--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -1011,3 +1011,18 @@ UNIT_TEST(RussiaMoscowTTKNoGoStraightTurnTest)
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
+
+UNIT_TEST(RussiaMoscowLeninskyProsp2Test)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                  MercatorBounds::FromLatLon(55.80376, 37.52048), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.80442, 37.51802));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+}

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -542,7 +542,7 @@ UNIT_TEST(RussiaMoscowSvobodaStTest)
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 UNIT_TEST(RussiaTiinskTest)
@@ -766,7 +766,7 @@ UNIT_TEST(NetherlandsBarneveldTest)
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::GoStraight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
 
 UNIT_TEST(GermanyRaunheimAirportTest)

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -509,6 +509,23 @@ bool GetPrevInSegmentRoutePoint(RoutePointIndex const & index, RoutePointIndex &
   nextIndex = {index.m_segmentIndex, index.m_pathIndex - 1};
   return true;
 }
+
+/*!
+ * \brief Corrects |turn.m_turn| if |turn.m_turn == CarDirection::GoStraight| and there're only
+ * two ways out from this junction. In that case the other way (the way which is not covered by
+ * the route) is checked. If the other way is "go straight" or "slight turn", turn.m_turn is set
+ * to |turnToSet|.
+ */
+void GoStraightCorrection(TurnCandidate const & notRouteCandidate, CarDirection turnToSet,
+                          TurnItem & turn)
+{
+  CHECK_EQUAL(turn.m_turn, CarDirection::GoStraight, ());
+
+  if (!IsGoStraightOrSlightTurn(IntermediateDirection(notRouteCandidate.m_angle)))
+    return;
+
+  turn.m_turn = turnToSet;
+}
 }  // namespace
 
 namespace routing
@@ -991,7 +1008,26 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
   {
     if (!hasMultiTurns)
       turn.m_turn = CarDirection::None;
-    return;
+
+    // Note. If the turn direction is |CarDirection::GoStraight| and there's only one extra way out
+    // from the junction the direction may be corrected in some cases.
+    if (nodes.candidates.size() == 2)
+    {
+      if (nodes.candidates.front().m_segment == firstOutgoingSeg)
+      {
+        // The route goes along the leftmost candidate.
+        GoStraightCorrection(nodes.candidates.back(), CarDirection::TurnSlightLeft, turn);
+      }
+      else if (nodes.candidates.back().m_segment == firstOutgoingSeg)
+      {
+        // The route goes along the rightmost candidate.
+        GoStraightCorrection(nodes.candidates.front(), CarDirection::TurnSlightRight, turn);
+      }
+      else
+      {
+        CHECK(false, ("There are 2 turn candidates and route goes somewhere else."));
+      }
+    }
   }
 }
 

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -1023,10 +1023,9 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
         // The route goes along the rightmost candidate.
         GoStraightCorrection(nodes.candidates.front(), CarDirection::TurnSlightRight, turn);
       }
-      else
-      {
-        CHECK(false, ("There are 2 turn candidates and route goes somewhere else."));
-      }
+      // Note. It's possible that |firstOutgoingSeg| is not contained in |nodes.candidates|.
+      // It may happened if |firstOutgoingSeg| and candidates in |nodes.candidates| are
+      // from different mwms.
     }
   }
 }

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -1010,23 +1010,25 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
       turn.m_turn = CarDirection::None;
 
     // Note. If the turn direction is |CarDirection::GoStraight| and there's only one extra way out
-    // from the junction the direction may be corrected in some cases.
-    if (nodes.candidates.size() == 2)
+    // from the junction the direction may be corrected in some cases. So two turn candidates
+    // (one for the route and an extra one) require special processing.
+    if (nodes.candidates.size() != 2)
+      return;
+
+    if (nodes.candidates.front().m_segment == firstOutgoingSeg)
     {
-      if (nodes.candidates.front().m_segment == firstOutgoingSeg)
-      {
-        // The route goes along the leftmost candidate.
-        GoStraightCorrection(nodes.candidates.back(), CarDirection::TurnSlightLeft, turn);
-      }
-      else if (nodes.candidates.back().m_segment == firstOutgoingSeg)
-      {
-        // The route goes along the rightmost candidate.
-        GoStraightCorrection(nodes.candidates.front(), CarDirection::TurnSlightRight, turn);
-      }
-      // Note. It's possible that |firstOutgoingSeg| is not contained in |nodes.candidates|.
-      // It may happened if |firstOutgoingSeg| and candidates in |nodes.candidates| are
-      // from different mwms.
+      // The route goes along the leftmost candidate.
+      GoStraightCorrection(nodes.candidates.back(), CarDirection::TurnSlightLeft, turn);
     }
+    else if (nodes.candidates.back().m_segment == firstOutgoingSeg)
+    {
+      // The route goes along the rightmost candidate.
+      GoStraightCorrection(nodes.candidates.front(), CarDirection::TurnSlightRight, turn);
+    }
+    // Note. It's possible that |firstOutgoingSeg| is not contained in |nodes.candidates|.
+    // It may happened if |firstOutgoingSeg| and candidates in |nodes.candidates| are
+    // from different mwms.
+
   }
 }
 


### PR DESCRIPTION
Бывают ситуации, когда из точки бифуркации при генерации терна выходит только 2 пути (по одному маршрут, по другому дополнительный). При том сам терн сгенерирован, как CarDirection::GoStraight. При этом оба пути идут прямо или почти прямо. Т.е. второй путь (CarDirection::TurnSlightLeft, CarDirection::GoStraight, CarDirection::TurnSlightRight). Это весьма типичная ситуация, при развилках на крупных дорогах.

В этом случае, если нам нужно ехать по левой дороге мы будем говорить CarDirection::TurnSlightLeft, а если по правой, то CarDirection::TurnSlightRight.

Данный PR повлиял на 2 интеграционных теста и оба улучшил.

RussiaMoscowSvobodaStTest
![image](https://user-images.githubusercontent.com/1768114/49738063-823f8280-fc9f-11e8-9e24-b77a08a2aec9.png)

NetherlandsBarneveldTest
![image](https://user-images.githubusercontent.com/1768114/49738048-7ce23800-fc9f-11e8-98cb-feae44c970df.png)

Также добавил еще один routing integration test.
![image](https://user-images.githubusercontent.com/1768114/49738354-3d681b80-fca0-11e8-9d05-3637357cb012.png)

Задача: 
https://jira.mail.ru/browse/MAPSME-9234

Поправлено так же:
https://jira.mail.ru/browse/MAPSME-3375
https://jira.mail.ru/browse/MAPSME-6787
https://jira.mail.ru/browse/MAPSME-7164

@gmoryes @vmihaylenko PTAL