### PR TITLE
[search] Do not limit ranker batch size for categorial requests.

### DIFF
--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -598,6 +598,7 @@ void Processor::InitRanker(Geocoder::Params const & geocoderParams,
   params.m_categoryLocales = GetCategoryLocales();
   params.m_accuratePivotCenter = GetPivotPoint(viewportSearch);
   params.m_viewportSearch = viewportSearch;
+  params.m_categorialRequest = geocoderParams.IsCategorialRequest();
 
   m_ranker.Init(params, geocoderParams);
 }

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -533,8 +533,11 @@ void Ranker::UpdateResults(bool lastUpdate)
   size_t i = 0;
   for (; i < m_tentativeResults.size(); ++i)
   {
-    if (!lastUpdate && i >= m_params.m_batchSize && !m_params.m_viewportSearch)
+    if (!lastUpdate && i >= m_params.m_batchSize && !m_params.m_viewportSearch &&
+        !m_params.m_categorialRequest)
+    {
       break;
+    }
 
     if (!lastUpdate)
       BailIfCancelled();

--- a/search/ranker.hpp
+++ b/search/ranker.hpp
@@ -56,6 +56,7 @@ public:
     bool m_needAddress = false;
     bool m_needHighlighting = false;
     bool m_viewportSearch = false;
+    bool m_categorialRequest = false;
 
     std::string m_query;
     QueryTokens m_tokens;


### PR DESCRIPTION
Для категорийных запросов как правило ближайшие результаты наиболее релевантны.
Сейчас в выдаче получается 10 результатов (размер батча) из ближайшей mwm, а дальше результаты до которых 100 км. Предлагаю как и для поиска во вьюпорте не ограничивать количество эмита из текущей mwm для категорийных запросов.