### PR TITLE
[coding] Deprecate unpopular languages to add more relevant ones.

### DIFF
--- a/android/jni/com/mapswithme/core/jni_helper.hpp
+++ b/android/jni/com/mapswithme/core/jni_helper.hpp
@@ -4,13 +4,16 @@
 
 #include "ScopedLocalRef.hpp"
 
+#include "base/buffer_vector.hpp"
 #include "base/logging.hpp"
 
 #include "geometry/point2d.hpp"
 
+#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 extern jclass g_mapObjectClazz;
 extern jclass g_featureIdClazz;
@@ -89,7 +92,8 @@ jobjectArray ToJavaArray(JNIEnv * env, jclass clazz, TIt begin, TIt end, size_t 
 template<typename TContainer, typename TToJavaFn>
 jobjectArray ToJavaArray(JNIEnv * env, jclass clazz, TContainer const & src, TToJavaFn && toJavaFn)
 {
-  return ToJavaArray(env, clazz, begin(src), end(src), src.size(), std::forward<TToJavaFn>(toJavaFn));
+  return ToJavaArray(env, clazz, std::begin(src), std::end(src), src.size(),
+                     std::forward<TToJavaFn>(toJavaFn));
 }
 
 jobjectArray ToJavaStringArray(JNIEnv * env, std::vector<std::string> const & src);

--- a/base/buffer_vector.hpp
+++ b/base/buffer_vector.hpp
@@ -460,3 +460,24 @@ inline bool operator>(buffer_vector<T, N1> const & v1, buffer_vector<T, N2> cons
 {
   return v2 < v1;
 }
+
+namespace std
+{
+template <typename T, size_t N>
+typename buffer_vector<T, N>::iterator begin(buffer_vector<T, N> & v)
+{
+  return v.begin();
+}
+
+template <typename T, size_t N>
+typename buffer_vector<T, N>::const_iterator begin(buffer_vector<T, N> const & v)
+{
+  return v.begin();
+}
+
+template <typename T, size_t N>
+typename buffer_vector<T, N>::const_iterator end(buffer_vector<T, N> const & v)
+{
+  return v.end();
+}
+}  // namespace std

--- a/coding/coding_tests/string_utf8_multilang_tests.cpp
+++ b/coding/coding_tests/string_utf8_multilang_tests.cpp
@@ -127,7 +127,8 @@ UNIT_TEST(MultilangString_LangNames)
   auto const & langs = StringUtf8Multilang::GetSupportedLanguages();
   // Using size_t workaround, because our logging/testing macroses do not support passing POD types
   // by value, only by reference. And our constant is a constexpr.
-  TEST_EQUAL(langs.size(), size_t(StringUtf8Multilang::kMaxSupportedLanguages), ());
+  TEST_LESS_OR_EQUAL(langs.size(), static_cast<size_t>(StringUtf8Multilang::kMaxSupportedLanguages),
+                     ());
   auto const international = StringUtf8Multilang::GetLangIndex("int_name");
   TEST_EQUAL(langs[international].m_code, string("int_name"), ());
 }

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -5,9 +5,9 @@
 #include "coding/writer.hpp"
 
 #include "base/assert.hpp"
+#include "base/buffer_vector.hpp"
 #include "base/control_flow.hpp"
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -80,8 +80,9 @@ public:
   /// How many languages we support on indexing stage. See full list in cpp file.
   /// TODO(AlexZ): Review and replace invalid languages by valid ones.
   static int8_t constexpr kMaxSupportedLanguages = 64;
+  static char constexpr kReservedLang[] = "reserved";
 
-  using Languages = std::array<Lang, kMaxSupportedLanguages>;
+  using Languages = buffer_vector<Lang, kMaxSupportedLanguages>;
 
   static Languages const & GetSupportedLanguages();
 
@@ -118,8 +119,12 @@ public:
     while (i < sz)
     {
       size_t const next = GetNextIndex(i);
-      if (wrapper((m_s[i] & 0x3F), m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
-        return;
+      int8_t const code = m_s[i] & 0x3F;
+      if (GetLangByCode(code) != kReservedLang &&
+          wrapper(code, m_s.substr(i + 1, next - i - 1)) == base::ControlFlow::Break)
+      {
+        break;
+      }
       i = next;
     }
   }

--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -315,7 +315,7 @@
 },
 "India": {
  "driving": "l",
- "languages": ["hi", "mr", "en", "gu", "ta", "te", "bn", "as", "kn", "ml", "pa"]
+ "languages": ["hi", "mr", "en", "gu", "ta", "te", "bn", "as", "ml", "pa"]
 },
 "India_Kerala": {
  "driving": "l",
@@ -434,7 +434,7 @@
  "languages": ["lt"]
 },
 "Luxembourg": {
- "languages": ["fr", "lb", "de", "en"]
+ "languages": ["fr", "de", "en"]
 },
 "Macedonia": {
  "languages": ["mk"]
@@ -729,7 +729,7 @@
  "languages": ["nl"]
 },
 "Netherlands_Friesland": {
- "languages": ["nl", "fy"]
+ "languages": ["nl"]
 },
 "Togo": {
  "languages": ["fr"]

--- a/map/map_tests/transliteration_test.cpp
+++ b/map/map_tests/transliteration_test.cpp
@@ -36,7 +36,6 @@ UNIT_TEST(Transliteration_CompareSamples)
   TestTransliteration(translit, "uk", "Українська", "Ukrayinska");
   TestTransliteration(translit, "fa", "فارسی", "farsy");
   TestTransliteration(translit, "hy", "Հայերէն", "Hayeren");
-  TestTransliteration(translit, "kn", "ಕನ್ನಡ", "kannada");
   TestTransliteration(translit, "am", "አማርኛ", "amarinya");
   TestTransliteration(translit, "ja_kana", "カタカナ", "katakana");
   TestTransliteration(translit, "bg", "Български", "Bulgarski");


### PR DESCRIPTION
Сейчас у нас нет возможности добавить в StringUtf8Multilang новый язык, т.к. поддерживается максимум 64 и все 64 заняты (латынью, эсперанто, верхнелужским языком и т.п.). Например, у нас приложение переведено на датский, норвежский, инденезийский, но в StringUtf8Multilang этих языков нет и нет возможности их сейчас добавить.
Предлагаемое решение такое: задеприкейтить часть непопулярных языков, подождать несколько сборок данных (т.к. они в данных), переиспользовать их места для более популярных.

Языки, которы я планирую задеприкейтить помечены красным:
https://docs.google.com/spreadsheets/d/1COkejwPUhZYNeQx8ky2iNrcOskicHUVMMmZUMjO5t78/edit#gid=0 
