### PR TITLE
[Metal] Allow to have empty MTLRenderPipelineState

### DIFF
--- a/drape/metal/metal_base_context.hpp
+++ b/drape/metal/metal_base_context.hpp
@@ -65,6 +65,9 @@ public:
                          drape_ptr<GpuProgram> && programClearDepth,
                          drape_ptr<GpuProgram> && programClearColorAndDepth);
   
+  void ApplyPipelineState(id<MTLRenderPipelineState> state);
+  bool HasAppliedPipelineState() const;
+  
 protected:
   void RecreateDepthTexture(m2::PointU const & screenSize);
   void RequestFrameDrawable();
@@ -84,6 +87,7 @@ protected:
   id<CAMetalDrawable> m_frameDrawable;
   id<MTLCommandBuffer> m_frameCommandBuffer;
   id<MTLRenderCommandEncoder> m_currentCommandEncoder;
+  id<MTLRenderPipelineState> m_lastPipelineState;
   
   MetalCleaner m_cleaner;
   

--- a/drape/metal/metal_base_context.mm
+++ b/drape/metal/metal_base_context.mm
@@ -365,6 +365,7 @@ void MetalBaseContext::FinishCurrentEncoding()
   [m_currentCommandEncoder popDebugGroup];
   [m_currentCommandEncoder endEncoding];
   m_currentCommandEncoder = nil;
+  m_lastPipelineState = nil;
 }
   
 void MetalBaseContext::SetSystemPrograms(drape_ptr<GpuProgram> && programClearColor,
@@ -373,6 +374,18 @@ void MetalBaseContext::SetSystemPrograms(drape_ptr<GpuProgram> && programClearCo
 {
   m_cleaner.Init(make_ref(this), std::move(programClearColor), std::move(programClearDepth),
                  std::move(programClearColorAndDepth));
+}
+  
+void MetalBaseContext::ApplyPipelineState(id<MTLRenderPipelineState> state)
+{
+  m_lastPipelineState = state;
+  if (state != nil)
+    [GetCommandEncoder() setRenderPipelineState:state];
+}
+  
+bool MetalBaseContext::HasAppliedPipelineState() const
+{
+  return m_lastPipelineState != nil;
 }
   
 void MetalBaseContext::DebugSynchronizeWithCPU()

--- a/drape/metal/metal_cleaner.mm
+++ b/drape/metal/metal_cleaner.mm
@@ -57,10 +57,13 @@ void MetalCleaner::RenderQuad(ref_ptr<MetalBaseContext> metalContext, id<MTLRend
                               ref_ptr<GpuProgram> program)
 {
   id<MTLRenderPipelineState> pipelineState = metalContext->GetPipelineState(program, false /* blendingEnabled */);
-  [encoder setRenderPipelineState:pipelineState];
-  
-  [encoder setVertexBuffer:m_buffer offset:0 atIndex:0];
-  [encoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
+  if (pipelineState != nil)
+  {
+    [encoder setRenderPipelineState:pipelineState];
+    
+    [encoder setVertexBuffer:m_buffer offset:0 atIndex:0];
+    [encoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
+  }
 }
   
 void MetalCleaner::ClearDepth(ref_ptr<MetalBaseContext> context, id<MTLRenderCommandEncoder> encoder)

--- a/drape/metal/metal_mesh_object_impl.mm
+++ b/drape/metal/metal_mesh_object_impl.mm
@@ -85,12 +85,15 @@ public:
   void DrawPrimitives(ref_ptr<dp::GraphicsContext> context, uint32_t verticesCount) override
   {
     ref_ptr<dp::metal::MetalBaseContext> metalContext = context;
-    id<MTLRenderCommandEncoder> encoder = metalContext->GetCommandEncoder();
-    for (size_t i = 0; i < m_geometryBuffers.size(); i++)
-      [encoder setVertexBuffer:m_geometryBuffers[i] offset:0 atIndex:i];
-    
-    [encoder drawPrimitives:GetPrimitiveType(m_mesh->m_drawPrimitive) vertexStart:0
-                vertexCount:verticesCount];
+    if (metalContext->HasAppliedPipelineState())
+    {
+      id<MTLRenderCommandEncoder> encoder = metalContext->GetCommandEncoder();
+      for (size_t i = 0; i < m_geometryBuffers.size(); i++)
+        [encoder setVertexBuffer:m_geometryBuffers[i] offset:0 atIndex:i];
+      
+      [encoder drawPrimitives:GetPrimitiveType(m_mesh->m_drawPrimitive) vertexStart:0
+                  vertexCount:verticesCount];
+    }
   }
   
 private:

--- a/drape/metal/metal_vertex_array_buffer_impl.mm
+++ b/drape/metal/metal_vertex_array_buffer_impl.mm
@@ -37,6 +37,9 @@ public:
                    IndicesRange const & range) override
   {
     ref_ptr<dp::metal::MetalBaseContext> metalContext = context;
+    if (!metalContext->HasAppliedPipelineState())
+      return;
+    
     id<MTLRenderCommandEncoder> encoder = metalContext->GetCommandEncoder();
     
     uint32_t bufferIndex = 0;

--- a/drape/metal/render_state_metal.mm
+++ b/drape/metal/render_state_metal.mm
@@ -24,7 +24,7 @@ void ApplyPipelineStateForMetal(ref_ptr<GraphicsContext> context, ref_ptr<GpuPro
 {
   ref_ptr<dp::metal::MetalBaseContext> metalContext = context;
   id<MTLRenderPipelineState> state = metalContext->GetPipelineState(std::move(program), blendingEnabled);
-  [metalContext->GetCommandEncoder() setRenderPipelineState:state];
+  metalContext->ApplyPipelineState(state);
 }
   
 void ApplyTexturesForMetal(ref_ptr<GraphicsContext> context, ref_ptr<GpuProgram> program,


### PR DESCRIPTION
К сожалению, выставлять пустой MTLRenderPipelineState нельзя. Надо проверять наличие явно