### PR TITLE
[base] cpp minor fix, move const to another place.

### DIFF
--- a/base/fifo_cache.hpp
+++ b/base/fifo_cache.hpp
@@ -25,7 +25,7 @@ public:
 
   /// \brief Loads value, if it's necessary, by |key| with |m_loader|, puts it to cache and
   /// returns the reference to the value to |m_map|.
-  Value const & GetValue(const Key & key)
+  Value const & GetValue(Key const & key)
   {
     auto const it = m_map.find(key);
     if (it != m_map.cend())


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-9278

Если у камеры нет скорости, то мы по умолчанию считаем, что она опасная, если мы находимся на расстоянии 450 + 50 метров. 50 метров было мало, чтобы четко разграничить beepZone и voiceZone, поэтому я увеличил ее до 150 метров, чтобы предупреждали голосом чуть заранее.

Последствие плохой разграниченности - на анроиде звуковой сигнал не воспроизводился, потому что в этот момент играл голосовой, как итоге у пользователя не было звукового вообще, на айфоне не проверял, но, основываясь на то, как там написано, там было бы параллельное воспроизведение двух звуков