### PR TITLE
[routing] Routing integration test for maps 181213.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -181,7 +181,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents<VehicleType::Car>(),
         MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
-        MercatorBounds::FromLatLon(50.93227, 1.82725), 60498.);
+        MercatorBounds::FromLatLon(50.93227, 1.82725), 64753.0);
   }
 
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)


### PR DESCRIPTION
Поправил routing integration test для карты 181213. DNM, т.к. для мержа в релиз требуется одобрение @burivuh 

После перехода на карту 181213 немного изменилась длина маршрута через Ла-Манш. С 64688.5 метров до 64693.6. 60498 попадало в диапазон 64688.5 +/- 7%, но не попадает в диапазон 64693.6 +/- 7%.

Сейчас маршрут выглядит так:
![image](https://user-images.githubusercontent.com/1768114/50291144-c80a0100-047e-11e9-9653-4d63a6777f64.png)

@vmihaylenko @gmoryes PTAL