### PR TITLE
[routing] Fix searching closest camera on route + hightliting

### DIFF
--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -172,7 +172,6 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_3)
     {
       double const speedKmPH = 100.0;
       ChangePosition({55.76766, 37.59260}, speedKmPH, routingSession);
-      TEST(NoCameraFound(routingSession), ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
@@ -208,7 +207,6 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_4)
     {
       double const speedKmPH = 100.0;
       ChangePosition({55.65647, 37.53643}, speedKmPH, routingSession);
-      TEST(NoCameraFound(routingSession), ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
@@ -240,7 +238,6 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_5)
     {
       double const speedKmPH = 100.0;
       ChangePosition({55.76766, 37.59260}, speedKmPH, routingSession);
-      TEST(NoCameraFound(routingSession), ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
@@ -386,7 +383,6 @@ UNIT_TEST(SpeedCameraNotification_AutoMode_1)
     {
       double const speedKmPH = 40.0;
       ChangePosition({55.76476, 37.58905}, speedKmPH, routingSession);
-      TEST(NoCameraFound(routingSession), ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }

--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -5,6 +5,8 @@
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
+#include <cmath>
+
 namespace routing
 {
 std::string const SpeedCameraManager::kSpeedCamModeKey = "speed_cam_mode";
@@ -52,9 +54,14 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
   {
     distFromCurrentPosAndClosestCam = m_closestCamera.m_distFromBeginMeters - passedDistanceMeters;
     if (distFromCurrentPosAndClosestCam < -kInfluenceZoneMeters)
+    {
       m_closestCamera.Invalidate();
+      m_speedCamClearCallback();
+    }
     else if (!m_closestCamera.NoSpeed())
+    {
       m_speedLimitExceeded = IsSpeedHigh(distFromCurrentPosAndClosestCam, info.m_speedMpS, m_closestCamera);
+    }
   }
 
   // Step 2. Check cached cameras. Do it only after pass through closest camera.
@@ -64,24 +71,13 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
     // invalidate |closestSpeedCam|.
     auto const closestSpeedCam = m_cachedSpeedCameras.front();
 
-    bool needUpdateClosestCamera = false;
-    auto const distToCamMeters = closestSpeedCam.m_distFromBeginMeters - passedDistanceMeters;
-
-    if (closestSpeedCam.m_distFromBeginMeters + kInfluenceZoneMeters > passedDistanceMeters)
+    if (NeedToUpdateClosestCamera(passedDistanceMeters, info.m_speedMpS, closestSpeedCam))
     {
-      needUpdateClosestCamera =
-        NeedUpdateClosestCamera(distToCamMeters, info.m_speedMpS, closestSpeedCam);
-
-      if (needUpdateClosestCamera)
-      {
-        m_closestCamera = closestSpeedCam;
-        ResetNotifications();
-        m_cachedSpeedCameras.pop();
-      }
+      m_closestCamera = closestSpeedCam;
+      ResetNotifications();
+      m_cachedSpeedCameras.pop();
+      PassClosestCameraToUI();
     }
-
-    if (NeedChangeHighlightedCamera(distToCamMeters, needUpdateClosestCamera))
-      PassCameraToUI(closestSpeedCam);
   }
 
   if (m_closestCamera.IsValid() &&
@@ -89,19 +85,6 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
   {
     // If some notifications available now.
     SendNotificationStat(passedDistanceMeters, info.m_speedMpS, m_closestCamera);
-  }
-
-  // Step 3. Check UI camera (stop or not stop to highlight it).
-  if (!m_currentHighlightedCamera.IsValid())
-    return;
-
-  auto const distToCameraMeters =
-    m_currentHighlightedCamera.m_distFromBeginMeters - passedDistanceMeters;
-
-  if (IsHighlightedCameraExpired(distToCameraMeters))
-  {
-    m_speedCamClearCallback();
-    m_currentHighlightedCamera.Invalidate();
   }
 }
 
@@ -156,7 +139,6 @@ void SpeedCameraManager::Reset()
   m_speedCamClearCallback();
 
   m_closestCamera.Invalidate();
-  m_currentHighlightedCamera.Invalidate();
 
   m_firstNotCheckedSpeedCameraIndex = 1;
   m_cachedSpeedCameras = std::queue<SpeedCameraOnRoute>();
@@ -229,13 +211,12 @@ void SpeedCameraManager::FindCamerasOnRouteAndCache(double passedDistanceMeters)
   m_firstNotCheckedSpeedCameraIndex = firstNotChecked;
 }
 
-void SpeedCameraManager::PassCameraToUI(SpeedCameraOnRoute const & camera)
+void SpeedCameraManager::PassClosestCameraToUI()
 {
+  CHECK(m_closestCamera.IsValid(), ("Attempt to show invalid speed cam"));
   // Clear previous speed cam in UI.
   m_speedCamClearCallback();
-
-  m_currentHighlightedCamera = camera;
-  m_speedCamShowCallback(camera.m_position, camera.m_maxSpeedKmH);
+  m_speedCamShowCallback(m_closestCamera.m_position, m_closestCamera.m_maxSpeedKmH);
 }
 
 bool SpeedCameraManager::IsSpeedHigh(double distanceToCameraMeters, double speedMpS,
@@ -244,7 +225,7 @@ bool SpeedCameraManager::IsSpeedHigh(double distanceToCameraMeters, double speed
   if (camera.NoSpeed())
     return distanceToCameraMeters < kInfluenceZoneMeters + kDistToReduceSpeedBeforeUnknownCameraM;
 
-  double const distToDangerousZone = distanceToCameraMeters - kInfluenceZoneMeters;
+  double const distToDangerousZone = std::abs(distanceToCameraMeters) - kInfluenceZoneMeters;
 
   if (distToDangerousZone < 0)
   {
@@ -344,16 +325,19 @@ bool SpeedCameraManager::SetNotificationFlags(double passedDistanceMeters, doubl
   UNREACHABLE();
 }
 
-bool SpeedCameraManager::NeedUpdateClosestCamera(double distanceToCameraMeters, double speedMpS,
-                                                 SpeedCameraOnRoute const & camera)
+bool SpeedCameraManager::NeedToUpdateClosestCamera(double passedDistanceMeters, double speedMpS,
+                                                   SpeedCameraOnRoute const & nextCamera)
 {
-  if (IsSpeedHigh(distanceToCameraMeters, speedMpS, camera))
-    return true;
+  auto const distToNewCameraMeters = nextCamera.m_distFromBeginMeters - passedDistanceMeters;
+  if (m_closestCamera.IsValid())
+  {
+    auto const distToOldCameraMeters = m_closestCamera.m_distFromBeginMeters - passedDistanceMeters;
 
-  if (m_mode == SpeedCameraManagerMode::Always && distanceToCameraMeters < kInfluenceZoneMeters)
-    return true;
+    // If we passed the previous nextCamera and the next is close enough to work with it.
+    return distToOldCameraMeters < 0 && IsCameraCloseEnough(distToNewCameraMeters);
+  }
 
-  return false;
+  return IsCameraCloseEnough(distToNewCameraMeters);
 }
 
 bool SpeedCameraManager::IsHighlightedCameraExpired(double distToCameraMeters) const
@@ -361,19 +345,9 @@ bool SpeedCameraManager::IsHighlightedCameraExpired(double distToCameraMeters) c
   return distToCameraMeters < -kInfluenceZoneMeters;
 }
 
-bool SpeedCameraManager::NeedChangeHighlightedCamera(double distToCameraMeters,
-                                                     bool needUpdateClosestCamera) const
+bool SpeedCameraManager::IsCameraCloseEnough(double distToCameraMeters) const
 {
-  if (needUpdateClosestCamera)
-    return true;
-
-  if (!m_currentHighlightedCamera.IsValid() &&
-      -kInfluenceZoneMeters < distToCameraMeters && distToCameraMeters < kShowCameraDistanceM)
-  {
-    return true;
-  }
-
-  return false;
+  return -kInfluenceZoneMeters < distToCameraMeters && distToCameraMeters < kShowCameraDistanceM;
 }
 
 void SpeedCameraManager::SendNotificationStat(double passedDistanceMeters, double speedMpS,

--- a/routing/speed_camera_manager.hpp
+++ b/routing/speed_camera_manager.hpp
@@ -134,13 +134,15 @@ private:
 
   void FindCamerasOnRouteAndCache(double passedDistanceMeters);
 
-  void PassCameraToUI(SpeedCameraOnRoute const & camera);
+  void PassClosestCameraToUI();
 
   bool SetNotificationFlags(double passedDistanceMeters, double speedMpS, SpeedCameraOnRoute const & camera);
   bool IsSpeedHigh(double distanceToCameraMeters, double speedMpS, SpeedCameraOnRoute const & camera) const;
-  bool NeedUpdateClosestCamera(double distanceToCameraMeters, double speedMpS, SpeedCameraOnRoute const & camera);
-  bool NeedChangeHighlightedCamera(double distToCameraMeters, bool needUpdateClosestCamera) const;
+
+  /// \brief Returns true if we should change |m_closestCamera| to |nextCamera|. False otherwise.
+  bool NeedToUpdateClosestCamera(double passedDistanceMeters, double speedMpS, SpeedCameraOnRoute const & nextCamera);
   bool IsHighlightedCameraExpired(double distToCameraMeters) const;
+  bool IsCameraCloseEnough(double distToCameraMeters) const;
 
   /// \brief Send stat to aloha.
   void SendNotificationStat(double passedDistanceMeters, double speedMpS, SpeedCameraOnRoute const & camera);
@@ -167,9 +169,6 @@ private:
 
   // Queue of speedCams, that we have found, but they are too far, to make warning about them.
   std::queue<SpeedCameraOnRoute> m_cachedSpeedCameras;
-
-  // Info about camera, that is highlighted now.
-  SpeedCameraOnRoute m_currentHighlightedCamera;
 
   size_t m_firstNotCheckedSpeedCameraIndex;
   std::weak_ptr<Route> m_route;


### PR DESCRIPTION
1) Теперь в коде `ближайшая камера` == `текущая красная камера в UI`.
2) Пофиксил баг, когда превышаем + проезжаем камеру и скорость перестает быть красной, несмотря на то, что мы все еще в зоне.

Суть: теперь если мы проезжаем камеру и, в километре от нас есть следующая камера, то мы сразу же переключаемся на нее, иначе камера которую мы проехали горит до тех пор, пока мы не выйдем из зоны.
