### PR TITLE
[coding] Move Elias-Fano based map encoding/decoding to coding library.

### DIFF
--- a/coding/CMakeLists.txt
+++ b/coding/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
   internal/file_data.cpp
   internal/file_data.hpp
   internal/xmlparser.hpp
+  map_uint32_to_val.hpp
   memory_region.hpp
   mmap_reader.cpp
   mmap_reader.hpp

--- a/coding/coding_tests/CMakeLists.txt
+++ b/coding/coding_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   geometry_coding_test.cpp
   hex_test.cpp
   huffman_test.cpp
+  map_uint32_to_val_tests.cpp
   mem_file_reader_test.cpp
   mem_file_writer_test.cpp
   png_decoder_test.cpp

--- a/coding/coding_tests/map_uint32_to_val_tests.cpp
+++ b/coding/coding_tests/map_uint32_to_val_tests.cpp
@@ -1,0 +1,60 @@
+#include "testing/testing.hpp"
+
+#include "coding/map_uint32_to_val.hpp"
+#include "coding/reader.hpp"
+#include "coding/writer.hpp"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+using namespace std;
+
+using Buffer = vector<uint8_t>;
+
+UNIT_TEST(MapUint32ValTest)
+{
+  vector<pair<uint32_t, uint32_t>> data;
+  size_t const dataSize = 227;
+  data.resize(dataSize);
+  for (auto i = 0; i < data.size(); ++i)
+    data[i] = make_pair(i, i);
+
+  Buffer buffer;
+  {
+    MapUint32ToValueBuilder<uint32_t> builder;
+
+    for (auto const & d : data)
+      builder.Put(d.first, d.second);
+
+    MemWriter<Buffer> writer(buffer);
+
+    auto const trivialWriteBlockCallback = [](Writer & w, vector<uint32_t>::const_iterator begin,
+                                              vector<uint32_t>::const_iterator end) {
+      for (auto it = begin; it != end; ++it)
+        WriteToSink(w, *it);
+    };
+    builder.Freeze(writer, trivialWriteBlockCallback);
+  }
+
+  {
+    MemReader reader(buffer.data(), buffer.size());
+    auto const trivialReadBlockCallback = [](NonOwningReaderSource & source, uint32_t blockSize,
+                                             vector<uint32_t> & values) {
+      values.resize(blockSize);
+      for (size_t i = 0; i < blockSize && source.Size() > 0; ++i)
+      {
+        values[i] = ReadPrimitiveFromSource<uint32_t>(source);
+      }
+    };
+    auto table = MapUint32ToValue<uint32_t>::Load(reader, trivialReadBlockCallback);
+    TEST(table.get(), ());
+
+    for (auto const & d : data)
+    {
+      uint32_t res;
+      TEST(table->Get(d.first, res), ());
+      TEST_EQUAL(res, d.second, ());
+    }
+  }
+}

--- a/coding/map_uint32_to_val.hpp
+++ b/coding/map_uint32_to_val.hpp
@@ -1,0 +1,341 @@
+#pragma once
+
+#include "coding/endianness.hpp"
+#include "coding/file_container.hpp"
+#include "coding/memory_region.hpp"
+#include "coding/reader.hpp"
+#include "coding/succinct_mapper.hpp"
+#include "coding/varint.hpp"
+#include "coding/write_to_sink.hpp"
+#include "coding/writer.hpp"
+
+#include "base/assert.hpp"
+#include "base/checked_cast.hpp"
+#include "base/logging.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
+#include "3party/succinct/elias_fano.hpp"
+#include "3party/succinct/rs_bit_vector.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+// Format:
+// File offset (bytes)  Field name          Field size (bytes)
+// 0                    version             2
+// 2                    endianness          2
+// 4                    positions offset    4
+// 8                    variables offset    4
+// 12                   end of section      4
+// 16                   identifiers table   positions offset - 16
+// positions offset     positions table     variables offset - positions offset
+// variables offset     variables blocks    end of section - variables offset
+//
+// Version and endianness is always in stored little-endian format.  0
+// value of endianness means little endian, whereas 1 means big
+// endian.
+//
+// All offsets are in little-endian format.
+//
+// Identifiers table is a bit-vector with rank-select table, where set
+// bits denote that centers for the corresponding features are in
+// table.  Identifiers table is stored in the native endianness.
+//
+// Positions table is a Elias-Fano table, where each entry corresponds
+// to the start position of the variables block. Positions table is
+// stored in the native endianness.
+//
+// Variables is a sequence of blocks, where each block (with the
+// exception of the last one) is a sequence of kBlockSize variables
+// encoded by block encoding callback.
+
+// On Get call kBlockSize consecutive variables are decoded and cached in RAM.
+
+template <typename Value>
+class MapUint32ToValue
+{
+public:
+  using ReadBlockCallback =
+      std::function<void(NonOwningReaderSource &, uint32_t, std::vector<Value> &)>;
+
+  static uint32_t constexpr kBlockSize = 64;
+
+  struct Header
+  {
+    void Read(Reader & reader)
+    {
+      NonOwningReaderSource source(reader);
+      m_version = ReadPrimitiveFromSource<uint16_t>(source);
+      m_endianness = ReadPrimitiveFromSource<uint16_t>(source);
+
+      m_positionsOffset = ReadPrimitiveFromSource<uint32_t>(source);
+      m_variablesOffset = ReadPrimitiveFromSource<uint32_t>(source);
+      m_endOffset = ReadPrimitiveFromSource<uint32_t>(source);
+    }
+
+    void Write(Writer & writer)
+    {
+      WriteToSink(writer, m_version);
+      WriteToSink(writer, m_endianness);
+      WriteToSink(writer, m_positionsOffset);
+      WriteToSink(writer, m_variablesOffset);
+      WriteToSink(writer, m_endOffset);
+    }
+
+    bool IsValid() const
+    {
+      if (m_version != 0)
+      {
+        LOG(LERROR, ("Unknown version."));
+        return false;
+      }
+
+      if (m_endianness > 1)
+      {
+        LOG(LERROR, ("Wrong endianness value."));
+        return false;
+      }
+
+      if (m_positionsOffset < sizeof(m_header))
+      {
+        LOG(LERROR, ("Positions before header:", m_positionsOffset, sizeof(m_header)));
+        return false;
+      }
+
+      if (m_variablesOffset < m_positionsOffset)
+      {
+        LOG(LERROR, ("Deltas before positions:", m_variablesOffset, m_positionsOffset));
+        return false;
+      }
+
+      if (m_endOffset < m_variablesOffset)
+      {
+        LOG(LERROR, ("End of section before variables:", m_endOffset, m_variablesOffset));
+        return false;
+      }
+
+      return true;
+    }
+
+    uint16_t m_version = 0;
+    uint16_t m_endianness = 0;
+    uint32_t m_positionsOffset = 0;
+    uint32_t m_variablesOffset = 0;
+    uint32_t m_endOffset = 0;
+  };
+
+  static_assert(sizeof(Header) == 16, "Wrong header size");
+
+  MapUint32ToValue(Reader & reader, ReadBlockCallback const & readBlockCallback)
+    : m_reader(reader), m_readBlockCallback(readBlockCallback)
+  {
+  }
+
+  ~MapUint32ToValue() = default;
+
+  // Tries to get |value| for key identified by |id|.  Returns
+  // false if table does not have entry for this id.
+  WARN_UNUSED_RESULT bool Get(uint32_t id, Value & value)
+  {
+    if (id >= m_ids.size() || !m_ids[id])
+      return false;
+
+    uint32_t const rank = static_cast<uint32_t>(m_ids.rank(id));
+    uint32_t const base = rank / kBlockSize;
+    uint32_t const offset = rank % kBlockSize;
+
+    auto & entry = m_cache[base];
+    if (entry.empty())
+    {
+      entry.resize(kBlockSize);
+
+      auto const start = m_offsets.select(base);
+      auto const end = base + 1 < m_offsets.num_ones()
+                           ? m_offsets.select(base + 1)
+                           : m_header.m_endOffset - m_header.m_variablesOffset;
+
+      std::vector<uint8_t> data(end - start);
+
+      m_reader.Read(m_header.m_variablesOffset + start, data.data(), data.size());
+
+      MemReader mreader(data.data(), data.size());
+      NonOwningReaderSource msource(mreader);
+
+      m_readBlockCallback(msource, kBlockSize, entry);
+    }
+
+    value = entry[offset];
+    return true;
+  }
+
+  // Loads MapUint32ToValue instance. Note that |reader| must be alive
+  // until the destruction of loaded table. Returns nullptr if
+  // MapUint32ToValue can't be loaded.
+  static std::unique_ptr<MapUint32ToValue> Load(Reader & reader,
+                                                ReadBlockCallback const & readBlockCallback)
+  {
+    uint16_t const version = ReadPrimitiveFromPos<uint16_t>(reader, 0 /* pos */);
+    if (version != 0)
+      return {};
+
+    // Only single version of centers table is supported now.  If you need to implement new
+    // versions, implement dispatching based on first-four-bytes version.
+    auto table = std::make_unique<MapUint32ToValue>(reader, readBlockCallback);
+    if (!table->Init())
+      return {};
+    return table;
+  }
+
+private:
+  bool Init()
+  {
+    m_header.Read(m_reader);
+
+    if (!m_header.IsValid())
+      return false;
+
+    bool const isHostBigEndian = IsBigEndianMacroBased();
+    bool const isDataBigEndian = m_header.m_endianness == 1;
+    bool const endiannesMismatch = isHostBigEndian != isDataBigEndian;
+
+    {
+      uint32_t const idsSize = m_header.m_positionsOffset - sizeof(m_header);
+      std::vector<uint8_t> data(idsSize);
+      m_reader.Read(sizeof(m_header), data.data(), data.size());
+      m_idsRegion = std::make_unique<CopiedMemoryRegion>(move(data));
+      EndiannessAwareMap(endiannesMismatch, *m_idsRegion, m_ids);
+    }
+
+    {
+      uint32_t const offsetsSize = m_header.m_variablesOffset - m_header.m_positionsOffset;
+      std::vector<uint8_t> data(offsetsSize);
+      m_reader.Read(m_header.m_positionsOffset, data.data(), data.size());
+      m_offsetsRegion = std::make_unique<CopiedMemoryRegion>(move(data));
+      EndiannessAwareMap(endiannesMismatch, *m_offsetsRegion, m_offsets);
+    }
+
+    return true;
+  }
+
+  template <typename Cont>
+  void EndiannessAwareMap(bool endiannesMismatch, CopiedMemoryRegion & region, Cont & cont)
+  {
+    Cont c;
+    if (endiannesMismatch)
+    {
+      coding::ReverseMapVisitor visitor(region.MutableData());
+      c.map(visitor);
+    }
+    else
+    {
+      coding::MapVisitor visitor(region.ImmutableData());
+      c.map(visitor);
+    }
+
+    c.swap(cont);
+  }
+
+  Header m_header;
+  Reader & m_reader;
+
+  std::unique_ptr<CopiedMemoryRegion> m_idsRegion;
+  std::unique_ptr<CopiedMemoryRegion> m_offsetsRegion;
+
+  succinct::rs_bit_vector m_ids;
+  succinct::elias_fano m_offsets;
+
+  ReadBlockCallback m_readBlockCallback;
+
+  std::unordered_map<uint32_t, std::vector<Value>> m_cache;
+};
+
+template <typename Value>
+class MapUint32ToValueBuilder
+{
+public:
+  using Iter = typename std::vector<Value>::const_iterator;
+  using WriteBlockCallback = std::function<void(Writer &, Iter, Iter)>;
+  using Map = MapUint32ToValue<Value>;
+
+  void Put(uint32_t id, Value value)
+  {
+    if (!m_ids.empty())
+      CHECK_LESS(m_ids.back(), id, ());
+
+    m_values.push_back(value);
+    m_ids.push_back(id);
+  }
+
+  void Freeze(Writer & writer, WriteBlockCallback const & writeBlockCallback) const
+  {
+    typename Map::Header header;
+
+    auto const startOffset = writer.Pos();
+    header.Write(writer);
+
+    {
+      uint64_t const numBits = m_ids.empty() ? 0 : m_ids.back() + 1;
+
+      succinct::bit_vector_builder builder(numBits);
+      for (auto const & id : m_ids)
+        builder.set(id, true);
+
+      coding::FreezeVisitor<Writer> visitor(writer);
+      succinct::rs_bit_vector(&builder).map(visitor);
+    }
+
+    std::vector<uint32_t> offsets;
+    std::vector<uint8_t> variables;
+
+    {
+      MemWriter<vector<uint8_t>> writer(variables);
+      for (size_t i = 0; i < m_values.size(); i += Map::kBlockSize)
+      {
+        offsets.push_back(static_cast<uint32_t>(variables.size()));
+
+        auto const endOffset = min(i + Map::kBlockSize, m_values.size());
+        writeBlockCallback(writer, m_values.cbegin() + i, m_values.cbegin() + endOffset);
+      }
+    }
+
+    {
+      succinct::elias_fano::elias_fano_builder builder(offsets.empty() ? 0 : offsets.back() + 1,
+                                                       offsets.size());
+      for (auto const & offset : offsets)
+        builder.push_back(offset);
+
+      header.m_positionsOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
+      coding::FreezeVisitor<Writer> visitor(writer);
+      succinct::elias_fano(&builder).map(visitor);
+    }
+
+    {
+      header.m_variablesOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
+      writer.Write(variables.data(), variables.size());
+      header.m_endOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
+    }
+
+    auto const endOffset = writer.Pos();
+
+    writer.Seek(startOffset);
+    CHECK_EQUAL(header.m_endianness, 0, ("|m_endianness| should be set to little-endian."));
+    header.Write(writer);
+    writer.Seek(endOffset);
+  }
+
+private:
+  std::vector<Value> m_values;
+  std::vector<uint32_t> m_ids;
+};

--- a/indexer/centers_table.cpp
+++ b/indexer/centers_table.cpp
@@ -26,314 +26,72 @@ using namespace std;
 
 namespace search
 {
-namespace
+bool CentersTable::Get(uint32_t id, m2::PointD & center)
 {
-template <typename TCont>
-void EndiannessAwareMap(bool endiannesMismatch, CopiedMemoryRegion & region, TCont & cont)
-{
-  TCont c;
-  if (endiannesMismatch)
-  {
-    coding::ReverseMapVisitor visitor(region.MutableData());
-    c.map(visitor);
-  }
-  else
-  {
-    coding::MapVisitor visitor(region.ImmutableData());
-    c.map(visitor);
-  }
-
-  c.swap(cont);
-}
-
-// V0 of CentersTable.  Has the following format:
-//
-// File offset (bytes)  Field name          Field size (bytes)
-// 0                    common header       4
-// 4                    positions offset    4
-// 8                    deltas offset       4
-// 12                   end of section      4
-// 16                   identifiers table   positions offset - 16
-// positions offset     positions table     deltas offset - positions offset
-// deltas offset        deltas blocks       end of section - deltas offset
-//
-// All offsets are in little-endian format.
-//
-// Identifiers table is a bit-vector with rank-select table, where set
-// bits denote that centers for the corresponding features are in
-// table.  Identifiers table is stored in the native endianness.
-//
-// Positions table is a Elias-Fano table, where each entry corresponds
-// to the start position of the centers block. Positions table is
-// stored in the native endianness.
-//
-// Deltas is a sequence of blocks, where each block (with the
-// exception of the last one) is a sequence of kBlockSize varuints,
-// where each varuint represents an encoded delta of the center from
-// some prediction. For the first center in the block map base point
-// is used as a prediction, for all other centers in the block
-// previous center is used as a prediction. This allows to decode
-// block of kBlockSize consecutive centers at one syscall, and cache
-// them in RAM.
-class CentersTableV0 : public CentersTable
-{
-public:
-  static const uint32_t kBlockSize = 64;
-
-  struct Header
-  {
-    void Read(Reader & reader)
-    {
-      m_base.Read(reader);
-
-      NonOwningReaderSource source(reader);
-      source.Skip(sizeof(m_base));
-      m_positionsOffset = ReadPrimitiveFromSource<uint32_t>(source);
-      m_deltasOffset = ReadPrimitiveFromSource<uint32_t>(source);
-      m_endOffset = ReadPrimitiveFromSource<uint32_t>(source);
-    }
-
-    void Write(Writer & writer)
-    {
-      m_base.Write(writer);
-
-      WriteToSink(writer, m_positionsOffset);
-      WriteToSink(writer, m_deltasOffset);
-      WriteToSink(writer, m_endOffset);
-    }
-
-    bool IsValid() const
-    {
-      if (!m_base.IsValid())
-      {
-        LOG(LERROR, ("Base header is not valid!"));
-        return false;
-      }
-      if (m_positionsOffset < sizeof(m_header))
-      {
-        LOG(LERROR, ("Positions before header:", m_positionsOffset, sizeof(m_header)));
-        return false;
-      }
-      if (m_deltasOffset < m_positionsOffset)
-      {
-        LOG(LERROR, ("Deltas before positions:", m_deltasOffset, m_positionsOffset));
-        return false;
-      }
-      if (m_endOffset < m_deltasOffset)
-      {
-        LOG(LERROR, ("End of section before deltas:", m_endOffset, m_deltasOffset));
-        return false;
-      }
-      return true;
-    }
-
-    CentersTable::Header m_base;
-    uint32_t m_positionsOffset = 0;
-    uint32_t m_deltasOffset = 0;
-    uint32_t m_endOffset = 0;
-  };
-
-  static_assert(sizeof(Header) == 16, "Wrong header size.");
-
-  CentersTableV0(Reader & reader, serial::GeometryCodingParams const & codingParams)
-    : m_reader(reader), m_codingParams(codingParams)
-  {
-  }
-
-  // CentersTable overrides:
-  bool Get(uint32_t id, m2::PointD & center) override
-  {
-    if (id >= m_ids.size() || !m_ids[id])
-      return false;
-    uint32_t const rank = static_cast<uint32_t>(m_ids.rank(id));
-    uint32_t const base = rank / kBlockSize;
-    uint32_t const offset = rank % kBlockSize;
-
-    auto & entry = m_cache[base];
-    if (entry.empty())
-    {
-      entry.resize(kBlockSize);
-
-      auto const start = m_offsets.select(base);
-      auto const end = base + 1 < m_offsets.num_ones()
-                           ? m_offsets.select(base + 1)
-                           : m_header.m_endOffset - m_header.m_deltasOffset;
-
-      vector<uint8_t> data(end - start);
-
-      m_reader.Read(m_header.m_deltasOffset + start, data.data(), data.size());
-
-      MemReader mreader(data.data(), data.size());
-      NonOwningReaderSource msource(mreader);
-
-      uint64_t delta = ReadVarUint<uint64_t>(msource);
-      entry[0] = coding::DecodePointDeltaFromUint(delta, m_codingParams.GetBasePoint());
-
-      for (size_t i = 1; i < kBlockSize && msource.Size() > 0; ++i)
-      {
-        delta = ReadVarUint<uint64_t>(msource);
-        entry[i] = coding::DecodePointDeltaFromUint(delta, entry[i - 1]);
-      }
-    }
-
-    center = PointUToPointD(entry[offset], m_codingParams.GetCoordBits());
-    return true;
-  }
-
-private:
-  // CentersTable overrides:
-  bool Init() override
-  {
-    m_header.Read(m_reader);
-
-    if (!m_header.IsValid())
-      return false;
-
-    bool const isHostBigEndian = IsBigEndianMacroBased();
-    bool const isDataBigEndian = m_header.m_base.m_endianness == 1;
-    bool const endiannesMismatch = isHostBigEndian != isDataBigEndian;
-
-    {
-      uint32_t const idsSize = m_header.m_positionsOffset - sizeof(m_header);
-      vector<uint8_t> data(idsSize);
-      m_reader.Read(sizeof(m_header), data.data(), data.size());
-      m_idsRegion = make_unique<CopiedMemoryRegion>(move(data));
-      EndiannessAwareMap(endiannesMismatch, *m_idsRegion, m_ids);
-    }
-
-    {
-      uint32_t const offsetsSize = m_header.m_deltasOffset - m_header.m_positionsOffset;
-      vector<uint8_t> data(offsetsSize);
-      m_reader.Read(m_header.m_positionsOffset, data.data(), data.size());
-      m_offsetsRegion = make_unique<CopiedMemoryRegion>(move(data));
-      EndiannessAwareMap(endiannesMismatch, *m_offsetsRegion, m_offsets);
-    }
-
-    return true;
-  }
-
-private:
-  Header m_header;
-  Reader & m_reader;
-  serial::GeometryCodingParams const m_codingParams;
-
-  unique_ptr<CopiedMemoryRegion> m_idsRegion;
-  unique_ptr<CopiedMemoryRegion> m_offsetsRegion;
-
-  succinct::rs_bit_vector m_ids;
-  succinct::elias_fano m_offsets;
-
-  unordered_map<uint32_t, vector<m2::PointU>> m_cache;
-};
-}  // namespace
-
-// CentersTable::Header ----------------------------------------------------------------------------
-void CentersTable::Header::Read(Reader & reader)
-{
-  NonOwningReaderSource source(reader);
-  m_version = ReadPrimitiveFromSource<uint16_t>(source);
-  m_endianness = ReadPrimitiveFromSource<uint16_t>(source);
-}
-
-void CentersTable::Header::Write(Writer & writer)
-{
-  WriteToSink(writer, m_version);
-  WriteToSink(writer, m_endianness);
-}
-
-bool CentersTable::Header::IsValid() const
-{
-  if (m_endianness > 1)
+  m2::PointU pointu;
+  if (!m_map->Get(id, pointu))
     return false;
+
+  center = PointUToPointD(pointu, m_codingParams.GetCoordBits());
   return true;
 }
 
 // CentersTable ------------------------------------------------------------------------------------
+// static
 unique_ptr<CentersTable> CentersTable::Load(Reader & reader,
                                             serial::GeometryCodingParams const & codingParams)
 {
-  uint16_t const version = ReadPrimitiveFromPos<uint16_t>(reader, 0 /* pos */);
-  if (version != 0)
-    return unique_ptr<CentersTable>();
-
-  // Only single version of centers table is supported now.  If you
-  // need to implement new versions of CentersTable, implement
-  // dispatching based on first-four-bytes version.
-  unique_ptr<CentersTable> table = make_unique<CentersTableV0>(reader, codingParams);
-  if (!table->Init())
-    return unique_ptr<CentersTable>();
+  auto table = make_unique<CentersTable>();
+  if (!table->Init(reader, codingParams))
+    return {};
   return table;
+}
+
+bool CentersTable::Init(Reader & reader, serial::GeometryCodingParams const & codingParams)
+{
+  m_codingParams = codingParams;
+  // Decodes block encoded by writeBlockCallback from CentersTableBuilder::Freeze.
+  auto const readBlockCallback = [&](NonOwningReaderSource & source, uint32_t blockSize,
+                                     vector<m2::PointU> & values) {
+    values.resize(blockSize);
+    uint64_t delta = ReadVarUint<uint64_t>(source);
+    values[0] = coding::DecodePointDeltaFromUint(delta, m_codingParams.GetBasePoint());
+
+    for (size_t i = 1; i < blockSize && source.Size() > 0; ++i)
+    {
+      delta = ReadVarUint<uint64_t>(source);
+      values[i] = coding::DecodePointDeltaFromUint(delta, values[i - 1]);
+    }
+  };
+
+  m_map = Map::Load(reader, readBlockCallback);
+  return m_map != nullptr;
 }
 
 // CentersTableBuilder -----------------------------------------------------------------------------
 void CentersTableBuilder::Put(uint32_t featureId, m2::PointD const & center)
 {
-  if (!m_ids.empty())
-    CHECK_LESS(m_ids.back(), featureId, ());
-
-  m_centers.push_back(PointDToPointU(center, m_codingParams.GetCoordBits()));
-  m_ids.push_back(featureId);
+  m_builder.Put(featureId, PointDToPointU(center, m_codingParams.GetCoordBits()));
 }
 
 void CentersTableBuilder::Freeze(Writer & writer) const
 {
-  CentersTableV0::Header header;
-
-  auto const startOffset = writer.Pos();
-  header.Write(writer);
-
-  {
-    uint64_t const numBits = m_ids.empty() ? 0 : m_ids.back() + 1;
-
-    succinct::bit_vector_builder builder(numBits);
-    for (auto const & id : m_ids)
-      builder.set(id, true);
-
-    coding::FreezeVisitor<Writer> visitor(writer);
-    succinct::rs_bit_vector(&builder).map(visitor);
-  }
-
-  vector<uint32_t> offsets;
-  vector<uint8_t> deltas;
-
-  {
-    MemWriter<vector<uint8_t>> writer(deltas);
-    for (size_t i = 0; i < m_centers.size(); i += CentersTableV0::kBlockSize)
+  // Each center is encoded as delta from some prediction.
+  // For the first center in the block map base point is used as a prediction, for all other
+  // centers in the block previous center is used as a prediction.
+  auto const writeBlockCallback = [&](Writer & w, vector<m2::PointU>::const_iterator begin,
+                                      vector<m2::PointU>::const_iterator end) {
+    uint64_t delta = coding::EncodePointDeltaAsUint(*begin, m_codingParams.GetBasePoint());
+    WriteVarUint(w, delta);
+    auto prevIt = begin;
+    for (auto it = begin + 1; it != end; ++it)
     {
-      offsets.push_back(static_cast<uint32_t>(deltas.size()));
-
-      uint64_t delta = coding::EncodePointDeltaAsUint(m_centers[i], m_codingParams.GetBasePoint());
-      WriteVarUint(writer, delta);
-      for (size_t j = i + 1; j < i + CentersTableV0::kBlockSize && j < m_centers.size(); ++j)
-      {
-        delta = coding::EncodePointDeltaAsUint(m_centers[j], m_centers[j - 1]);
-        WriteVarUint(writer, delta);
-      }
+      delta = coding::EncodePointDeltaAsUint(*it, *prevIt);
+      WriteVarUint(w, delta);
+      prevIt = it;
     }
-  }
+  };
 
-  {
-    succinct::elias_fano::elias_fano_builder builder(offsets.empty() ? 0 : offsets.back() + 1,
-                                                     offsets.size());
-    for (auto const & offset : offsets)
-      builder.push_back(offset);
-
-    header.m_positionsOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
-    coding::FreezeVisitor<Writer> visitor(writer);
-    succinct::elias_fano(&builder).map(visitor);
-  }
-
-  {
-    header.m_deltasOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
-    writer.Write(deltas.data(), deltas.size());
-    header.m_endOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);
-  }
-
-  auto const endOffset = writer.Pos();
-
-  writer.Seek(startOffset);
-  CHECK_EQUAL(header.m_base.m_endianness, 0, ("|m_endianness| should be set to little-endian."));
-  header.Write(writer);
-  writer.Seek(endOffset);
+  m_builder.Freeze(writer, writeBlockCallback);
 }
 }  // namespace search

--- a/indexer/centers_table.hpp
+++ b/indexer/centers_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "coding/geometry_coding.hpp"
+#include "coding/map_uint32_to_val.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -15,49 +16,25 @@ class Writer;
 namespace search
 {
 // A wrapper class around serialized centers-table.
-//
-// *NOTE* This wrapper is abstract enough so feel free to change it,
-// but note that there should always be backward-compatibility.  Thus,
-// when adding new versions, never change data format of old versions.
-//
-// All centers tables are serialized in the following format:
-//
-// File offset (bytes)  Field name  Field size (bytes)
-// 0                    version     2
-// 2                    endianness  2
-//
-// Version and endianness is always in stored little-endian format.  0
-// value of endianness means little endian, whereas 1 means big
-// endian.
 class CentersTable
 {
 public:
-  struct Header
-  {
-    void Read(Reader & reader);
-    void Write(Writer & writer);
-    bool IsValid() const;
-
-    uint16_t m_version = 0;
-    uint16_t m_endianness = 0;
-  };
-
-  static_assert(sizeof(Header) == 4, "Wrong header size");
-
-  virtual ~CentersTable() = default;
-
   // Tries to get |center| of the feature identified by |id|.  Returns
   // false if table does not have entry for the feature.
-  WARN_UNUSED_RESULT virtual bool Get(uint32_t id, m2::PointD & center) = 0;
+  WARN_UNUSED_RESULT bool Get(uint32_t id, m2::PointD & center);
 
   // Loads CentersTable instance. Note that |reader| must be alive
   // until the destruction of loaded table. Returns nullptr if
   // CentersTable can't be loaded.
   static std::unique_ptr<CentersTable> Load(Reader & reader,
                                             serial::GeometryCodingParams const & codingParams);
-
 private:
-  virtual bool Init() = 0;
+  using Map = MapUint32ToValue<m2::PointU>;
+
+  bool Init(Reader & reader, serial::GeometryCodingParams const & codingParams);
+
+  serial::GeometryCodingParams m_codingParams;
+  std::unique_ptr<Map> m_map;
 };
 
 class CentersTableBuilder
@@ -73,8 +50,6 @@ public:
 
 private:
   serial::GeometryCodingParams m_codingParams;
-
-  std::vector<m2::PointU> m_centers;
-  std::vector<uint32_t> m_ids;
+  MapUint32ToValueBuilder<m2::PointU> m_builder;
 };
 }  // namespace search

--- a/xcode/coding/coding.xcodeproj/project.pbxproj
+++ b/xcode/coding/coding.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		3D489BC31D3D21AE0052AA38 /* elias_coder_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BB71D3D217E0052AA38 /* elias_coder_test.cpp */; };
 		3D74EF211F8F55740081202C /* csv_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D74EF1F1F8F55740081202C /* csv_reader.hpp */; };
 		3D74EF221F8F55740081202C /* csv_reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D74EF201F8F55740081202C /* csv_reader.cpp */; };
+		402E9A9321D0DBD9002D3CF4 /* map_uint32_to_val.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 402E9A9221D0DBD9002D3CF4 /* map_uint32_to_val.hpp */; };
+		4098EA6321D12088005612FF /* map_uint32_to_val_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4098EA6221D12088005612FF /* map_uint32_to_val_tests.cpp */; };
 		454523B4202AEB21009275C1 /* serdes_json.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 454523B3202AEB21009275C1 /* serdes_json.hpp */; };
 		4563B061205909290057556D /* serdes_binary_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4563B05E205909280057556D /* serdes_binary_header.hpp */; };
 		4563B062205909290057556D /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4563B05F205909280057556D /* sha1.cpp */; };
@@ -201,6 +203,8 @@
 		3D489BBA1D3D217E0052AA38 /* succinct_mapper_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = succinct_mapper_test.cpp; sourceTree = "<group>"; };
 		3D74EF1F1F8F55740081202C /* csv_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = csv_reader.hpp; sourceTree = "<group>"; };
 		3D74EF201F8F55740081202C /* csv_reader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = csv_reader.cpp; sourceTree = "<group>"; };
+		402E9A9221D0DBD9002D3CF4 /* map_uint32_to_val.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = map_uint32_to_val.hpp; sourceTree = "<group>"; };
+		4098EA6221D12088005612FF /* map_uint32_to_val_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = map_uint32_to_val_tests.cpp; sourceTree = "<group>"; };
 		454523B3202AEB21009275C1 /* serdes_json.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = serdes_json.hpp; sourceTree = "<group>"; };
 		4563B05E205909280057556D /* serdes_binary_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = serdes_binary_header.hpp; sourceTree = "<group>"; };
 		4563B05F205909280057556D /* sha1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sha1.cpp; sourceTree = "<group>"; };
@@ -339,6 +343,7 @@
 		394916901BAC3A5F002A8C4F /* coding_tests */ = {
 			isa = PBXGroup;
 			children = (
+				4098EA6221D12088005612FF /* map_uint32_to_val_tests.cpp */,
 				3973743321C17F160003807A /* string_utf8_multilang_tests.cpp */,
 				39C3C0BE21A431BF003B4712 /* point_coding_tests.cpp */,
 				39F376CB207D329F0058E8E0 /* geometry_coding_test.cpp */,
@@ -447,6 +452,7 @@
 				39B2B97E1FB4693B00AB85A1 /* elias_coder.hpp */,
 				675342421A3F588B00A0A8C3 /* endianness.hpp */,
 				675342431A3F588B00A0A8C3 /* file_container.cpp */,
+				402E9A9221D0DBD9002D3CF4 /* map_uint32_to_val.hpp */,
 				675342441A3F588B00A0A8C3 /* file_container.hpp */,
 				675342451A3F588B00A0A8C3 /* file_name_utils.cpp */,
 				675342461A3F588B00A0A8C3 /* file_name_utils.hpp */,
@@ -546,6 +552,7 @@
 				675342AF1A3F588C00A0A8C3 /* mmap_reader.hpp in Headers */,
 				4563B061205909290057556D /* serdes_binary_header.hpp in Headers */,
 				675342B81A3F588C00A0A8C3 /* reader_wrapper.hpp in Headers */,
+				402E9A9321D0DBD9002D3CF4 /* map_uint32_to_val.hpp in Headers */,
 				675342961A3F588C00A0A8C3 /* dd_vector.hpp in Headers */,
 				675342C91A3F588C00A0A8C3 /* var_record_reader.hpp in Headers */,
 				675342991A3F588C00A0A8C3 /* endianness.hpp in Headers */,
@@ -736,6 +743,7 @@
 				670D04BF1B0BA92D0013A7AC /* file_data.cpp in Sources */,
 				39C3C0BD21A43061003B4712 /* point_coding.cpp in Sources */,
 				675342B91A3F588C00A0A8C3 /* reader_writer_ops.cpp in Sources */,
+				4098EA6321D12088005612FF /* map_uint32_to_val_tests.cpp in Sources */,
 				39F376C6207D327B0058E8E0 /* geometry_coding.cpp in Sources */,
 				675E889C1DB7B0D000F8EBDA /* traffic.cpp in Sources */,
 				675342AE1A3F588C00A0A8C3 /* mmap_reader.cpp in Sources */,


### PR DESCRIPTION
Переношу в coding, чтобы переиспользовать для кодирования house to street.
Т.к. все оффсеты и т.п. считаются для centers table от начала секции, для сохранения обратной совместимости переношу всё включая header(version и т.п.).