### PR TITLE
[drape][android] Fixed message filtering on context restoring

### DIFF
--- a/drape_frontend/base_renderer.cpp
+++ b/drape_frontend/base_renderer.cpp
@@ -150,6 +150,10 @@ void BaseRenderer::CheckRenderingEnabled()
         context->SetRenderingEnabled(true);
       }
     }
+
+    if (needCreateContext)
+      DisableMessageFiltering();
+
     // notify initiator-thread about rendering enabling
     // m_renderingEnablingCompletionHandler will be setup before awakening of this thread
     Notify();
@@ -157,10 +161,7 @@ void BaseRenderer::CheckRenderingEnabled()
     OnRenderingEnabled();
 
     if (needCreateContext)
-    {
-      DisableMessageFiltering();
       OnContextCreate();
-    }
   }
 }
 


### PR DESCRIPTION
Исправлен баг привнесенный в коммите https://github.com/mapsme/omim/commit/60e4545dbd7c4fa387f4aafdcc2cd5f1e964aeab

Фильтр сообщений надо снимать до того, как оповещен UI-поток. Иначе происходит гонка по сообщениям

https://jira.mail.ru/browse/MAPSME-9251