### PR TITLE
[release-86][routing] ETA fix for maxspeed=none.

### DIFF
--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -383,6 +383,7 @@ void AsyncRouter::CalculateRoute()
 
     elapsedSec = timer.ElapsedSeconds(); // routing time
     LogCode(code, elapsedSec);
+    LOG(LDEBUG, ("ETA:", route->GetTotalTimeSec(), "sec."));
   }
   catch (RootException const & e)
   {

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -383,7 +383,7 @@ void AsyncRouter::CalculateRoute()
 
     elapsedSec = timer.ElapsedSeconds(); // routing time
     LogCode(code, elapsedSec);
-    LOG(LDEBUG, ("ETA:", route->GetTotalTimeSec(), "sec."));
+    LOG(LINFO, ("ETA:", route->GetTotalTimeSec(), "sec."));
   }
   catch (RootException const & e)
   {

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -383,4 +383,20 @@ namespace
     RouterResultCode const result = routeResult.second;
     TEST_EQUAL(result, RouterResultCode::NoError, ());
   }
+
+  // Test on roads with tag maxspeed=none.
+  UNIT_TEST(GermanyBerlinMunichTimeTest)
+  {
+    TRouteResult const routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
+                                    MercatorBounds::FromLatLon(52.51172, 13.39468), {0., 0.},
+                                    MercatorBounds::FromLatLon(48.13294, 11.60352));
+
+    RouterResultCode const result = routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
+
+    CHECK(routeResult.first, ());
+    Route const & route = *routeResult.first;
+    integration::TestRouteTime(route, 17704.3);
+  }
 }  // namespace

--- a/routing_common/maxspeed_conversion.cpp
+++ b/routing_common/maxspeed_conversion.cpp
@@ -46,7 +46,7 @@ uint16_t Maxspeed::GetSpeedInUnits(bool forward) const
 
 uint16_t Maxspeed::GetSpeedKmPH(bool forward) const
 {
-  uint16_t constexpr kNoneSpeedLimitKmPH = 1000;
+  uint16_t constexpr kNoneSpeedLimitKmPH = 150;
   uint16_t constexpr kWalkSpeedLimitKmPH = 6;
 
   auto speedInUnits = GetSpeedInUnits(forward);

--- a/routing_common/maxspeed_conversion.cpp
+++ b/routing_common/maxspeed_conversion.cpp
@@ -46,7 +46,7 @@ uint16_t Maxspeed::GetSpeedInUnits(bool forward) const
 
 uint16_t Maxspeed::GetSpeedKmPH(bool forward) const
 {
-  uint16_t constexpr kNoneSpeedLimitKmPH = 150;
+  uint16_t constexpr kNoneSpeedLimitKmPH = 130;
   uint16_t constexpr kWalkSpeedLimitKmPH = 6;
 
   auto speedInUnits = GetSpeedInUnits(forward);


### PR DESCRIPTION
В случае дорог с maxspeed=none (без ограничений) мы брали скорость 1000км/ч.

https://jira.mail.ru/browse/MAPSME-9358

@vmihaylenko @gmoryes PTAL