### PR TITLE
[routing] Correct routing error when some mwms are absent.

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -210,6 +210,9 @@ using Observers = NSHashTable<Observer>;
 
 - (void)stateError
 {
+  if (_state == MWMNavigationDashboardStateReady)
+    return;
+  
   NSAssert(_state == MWMNavigationDashboardStatePlanning, @"Invalid state change (error)");
   auto routePreview = self.routePreview;
   [routePreview router:[MWMRouter type] setState:MWMCircularProgressStateFailed];

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -425,9 +425,9 @@ void AsyncRouter::CalculateRoute()
   vector<string> absent;
   if (absentFetcher && needFetchAbsent)
     absentFetcher->GetAbsentCountries(absent);
-  absent.insert(absent.end(), route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
 
-  if (!absent.empty() && code == RouterResultCode::NoError)
+  absent.insert(absent.end(), route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
+  if (!absent.empty())
     code = RouterResultCode::NeedMoreMaps;
 
   elapsedSec = timer.ElapsedSeconds(); // routing time + absents fetch time


### PR DESCRIPTION
В ситуации, когда одна или несколько мвмок отсутствует при кросс мвмном роутинге, нам приходит код RouteNotFound, что кажется правильным. Из за ```if (!absent.empty() && code == RouterResultCode::NoError)``` мы не проставляли нужный код, поэтому второе условие в if убрал. 

из за этой ситуации у нас был баг https://jira.mail.ru/browse/MAPSME-8837