### PR TITLE
[tools][GDPR][dirty-hack] disable certificate checking

### DIFF
--- a/tools/unix/check_cert.sh
+++ b/tools/unix/check_cert.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+exit 0
 
 MONTHS_BEFORE_EXPIRATION_TO_BREAK="3"
 PRIVATE_H=$1


### PR DESCRIPTION
This disables checking of user certificate expiring soon.
The check should be enabled back when GDPR requests feature will be
launched.