### PR TITLE
[routing] Fix crash because of transit id

### DIFF
--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -120,7 +120,7 @@ public:
       // There are same in common, but in case of different version of mwms
       // their's geometry can differ from each other. Because of this we can not
       // build the route, because we fail in astar_algorithm.hpp CHECK(invariant) sometimes.
-      if (s.IsRealSegment() || SegmentsAreEqualByGeometry(s, *twinSeg))
+      if (!s.IsRealSegment() || SegmentsAreEqualByGeometry(s, *twinSeg))
         twins.push_back(*twinSeg);
       else
         LOG(LINFO, ("Bad cross mwm feature, differ in geometry. Current:", s, ", twin:", *twinSeg));


### PR DESCRIPTION
Транзитные фичи имеют id большой, и для них нельзя делать.
```cpp
m_dataSource.ReadFeature(fillGeometry, featureId);
```

В коде должна была стоять проверка:
```
if (!s.IsRealSegment() || SegmentsAreEqualByGeometry(s, *twinSeg))
```

Направленная на то, чтобы транзитные сегменты не отправлялись в SegmentsAreEqualByGeometry.

Но сейчас в коде написано так и мы пытаемся прочитать транзитную фичу из dataSource, из-за чего происходит crash:
```
if (s.IsRealSegment() || SegmentsAreEqualByGeometry(s, *twinSeg))
```

Этот PR исправляет ситуацию