### PR TITLE
[search] Do not match name to request while displaying categorial results.

### DIFF
--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -591,7 +591,7 @@ void Processor::InitRanker(Geocoder::Params const & geocoderParams,
   params.m_preferredTypes = m_preferredTypes;
   params.m_suggestsEnabled = searchParams.m_suggestsEnabled;
   params.m_needAddress = searchParams.m_needAddress;
-  params.m_needHighlighting = searchParams.m_needHighlighting;
+  params.m_needHighlighting = searchParams.m_needHighlighting && !geocoderParams.IsCategorialRequest();
   params.m_query = m_query;
   params.m_tokens = m_tokens;
   params.m_prefix = m_prefix;

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -623,7 +623,8 @@ void Ranker::GetBestMatchName(FeatureType & f, string & name) const
 {
   KeywordLangMatcher::Score bestScore;
   auto updateScore = [&](int8_t lang, string const & s, bool force) {
-    auto const score = m_keywordsScorer.CalcScore(lang, s);
+    // Ignore name for categorial requests.
+    auto const score = m_keywordsScorer.CalcScore(lang, m_params.m_categorialRequest ? "" : s);
     if (force ? bestScore <= score : bestScore < score)
     {
       bestScore = score;


### PR DESCRIPTION
В конце прошлого года выключила сравнение запроса с именем фичи для категорийного поиска при ранжировании (вычисление количества опечаток и т.п.).
В этом реквесте сделала то же самое при отображении результата: больше не выбираем какое имя отображать на основе сравнение ответа с запросом -- берём исходя из предпочтительных языков.
Подсветку частей запроса в результатах тоже выключила.