### PR TITLE
[indexer] Do not force emit junction-roundabout feature type.

### DIFF
--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -228,31 +228,15 @@ namespace
     if (!classif().IsTypeValid(type))
       return false;
 
-    static uint32_t const roundabout = classif().GetTypeByPath({"junction", "roundabout"});
     static uint32_t const internet = classif().GetTypeByPath({"internet_access"});
     static uint32_t const sponsored = classif().GetTypeByPath({"sponsored"});
-    // Reserved for custom event processing, i.e. fc2018.
-    // static uint32_t const event = classif().GetTypeByPath({"event" });
 
-    if (g == GEOM_LINE || g == GEOM_UNDEFINED)
-    {
-      if (roundabout == type)
-        return true;
-
-      if (HasRoutingExceptionType(type))
-        return true;
-    }
+    if ((g == GEOM_LINE || g == GEOM_UNDEFINED) && HasRoutingExceptionType(type))
+      return true;
 
     ftype::TruncValue(type, 1);
-    if (g != GEOM_LINE)
-    {
-      if (sponsored == type || internet == type)
-        return true;
-
-      // Reserved for custom event processing, i.e. fc2018.
-      //if (event == type)
-      //  return true;
-    }
+    if (g != GEOM_LINE && (sponsored == type || internet == type))
+      return true;
 
     return false;
   }
@@ -268,12 +252,18 @@ namespace
       return true;
 
     static uint32_t const hwtag = classif().GetTypeByPath({"hwtag"});
+    static uint32_t const roundabout = classif().GetTypeByPath({"junction", "roundabout"});
     static uint32_t const psurface = classif().GetTypeByPath({"psurface"});
     static uint32_t const wheelchair = classif().GetTypeByPath({"wheelchair"});
     static uint32_t const cuisine = classif().GetTypeByPath({"cuisine"});
+    // Reserved for custom event processing, e.g. fc2018.
+    // static uint32_t const event = classif().GetTypeByPath({"event" });
 
     // Caching type length to exclude generic [wheelchair].
     uint8_t const typeLength = ftype::GetLevel(type);
+
+    if ((g == GEOM_LINE || g == GEOM_UNDEFINED) && type == roundabout)
+      return true;
 
     ftype::TruncValue(type, 1);
     if (g == GEOM_LINE || g == GEOM_UNDEFINED)
@@ -287,6 +277,10 @@ namespace
 
     if (cuisine == type)
       return true;
+
+    // Reserved for custom event processing, i.e. fc2018.
+    // if (event == type)
+    //   return true;
 
     return false;
   }


### PR DESCRIPTION
Продолжаю исправлять двойные эмиты фичей и эмиты на неверных масштабах.
В этом реквесте переношу junction-roundabout из типов которые эмитятся везде, всегда, на любом масштабе в типы, которые эмитятся если у фичи есть отображаемый на данном масштабе тип.
Так как для работы junction-roundabout в роутинге требуется, чтобы у дороги был также дорожный тип (highway-* и т.п.) и этот тип является отображаемым, мы не потеряем junction-roundabout для роутинга.
Собрала некоторые карты из этого реквеста, проверила роутинг (сами маршруты и манёвры):
<img width="1007" alt="screen shot 2019-01-21 at 13 54 06" src="https://user-images.githubusercontent.com/9213190/51470570-54ad2500-1d85-11e9-8407-3b9dbf6e6bf5.png">

LOG TID(10) DEBUG     116.278 routing/turns_generator.cpp:576 MakeTurnAnnotation() Shortest th length: 147.375
LOG TID(10) DEBUG     116.279 routing/turns_generator.cpp:655 MakeTurnAnnotation() EnterRoundAbout : 4 улица Серёгина -  exit: 4
LOG TID(10) DEBUG     116.279 routing/turns_generator.cpp:655 MakeTurnAnnotation() LeaveRoundAbout : 18  - Планетная улица exit: 4
LOG TID(10) DEBUG     116.279 routing/turns_generator.cpp:655 MakeTurnAnnotation() ReachedYourDestination : 22  -  exit: 0
LOG TID(10) INFO      116.404 routing/async_router.cpp:267 LogCode() Route found, elapsed seconds: 1.18699

<img width="1052" alt="screen shot 2019-01-21 at 13 52 11" src="https://user-images.githubusercontent.com/9213190/51470638-8e7e2b80-1d85-11e9-9f52-6aa95e02deb8.png">

LOG TID(10) DEBUG     199.783 routing/turns_generator.cpp:576 MakeTurnAnnotation() Shortest th length: 338.614
LOG TID(10) DEBUG     199.785 routing/turns_generator.cpp:655 MakeTurnAnnotation() EnterRoundAbout : 7 Правая Дворцовая аллея - площадь Космонавта Комарова exit: 5
LOG TID(10) DEBUG     199.785 routing/turns_generator.cpp:655 MakeTurnAnnotation() LeaveRoundAbout : 27 площадь Космонавта Комарова - Левая Дворцовая аллея exit: 5
LOG TID(10) DEBUG     199.785 routing/turns_generator.cpp:655 MakeTurnAnnotation() ReachedYourDestination : 35  -  exit: 0
LOG TID(10) INFO      199.932 routing/async_router.cpp:267 LogCode() Route found, elapsed seconds: 1.26757