### PR TITLE
[routing]Routing integration test fix for maps 2019.01.13.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -111,3 +111,11 @@ UNIT_TEST(SwedenStockholmBicyclePastFerry)
       MercatorBounds::FromLatLon(59.4725, 18.51355), {0.0, 0.0},
       MercatorBounds::FromLatLon(59.32967, 18.075), 66161.2);
 }
+
+UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(55.15414, 20.85378), {0., 0.},
+      MercatorBounds::FromLatLon(56.51119, 21.01847), 192000);
+}

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -211,7 +211,7 @@ UNIT_TEST(RussiaTaganrogSyzranov10k3ToLazo5k2)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(47.2183, 38.8634), {0., 0.},
-      MercatorBounds::FromLatLon(47.2584, 38.9128), 9200.);
+      MercatorBounds::FromLatLon(47.2584, 38.9128), 8004.74);
 }
 
 UNIT_TEST(RussiaTaganrogJukova2ToBolBulvarnaya8)
@@ -372,14 +372,6 @@ UNIT_TEST(USANewYorkEmpireStateBuildingToUnitedNations)
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(40.74844, -73.98566), {0., 0.},
       MercatorBounds::FromLatLon(40.75047, -73.96759), 2265.);
-}
-
-UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)
-{
-  integration::CalculateRouteAndTestRouteLength(
-      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
-      MercatorBounds::FromLatLon(55.15414, 20.85378), {0., 0.},
-      MercatorBounds::FromLatLon(56.51119, 21.01847), 192000);
 }
 
 UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -623,9 +623,10 @@ UNIT_TEST(GermanyFrankfurtAirport2Test)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 
@@ -760,21 +761,6 @@ UNIT_TEST(NetherlandsBarneveldTest)
       integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                   MercatorBounds::FromLatLon(52.15866, 5.56538), {0., 0.},
                                   MercatorBounds::FromLatLon(52.16667, 5.55663));
-
-  Route const & route = *routeResult.first;
-  RouterResultCode const result = routeResult.second;
-
-  TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
-}
-
-UNIT_TEST(GermanyRaunheimAirportTest)
-{
-  TRouteResult const routeResult =
-      integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
-                                  MercatorBounds::FromLatLon(50.03322, 8.50995), {0., 0.},
-                                  MercatorBounds::FromLatLon(50.02089, 8.49441));
 
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;


### PR DESCRIPTION
После перехода на новые карты 2019.01.13. перестало проходить несколько routing integration test.

pedestrian_route_test.cpp::RussiaTaganrogSyzranov10k3ToLazo5k2
Нормальный маршрут, немного изменился в следствии новой карты.
![image](https://user-images.githubusercontent.com/1768114/51520578-20913d00-1e35-11e9-9d36-09e55ff47845.png)

pedestrian_route_test.cpp::CrossMwmKaliningradRegionToLiepaja
Формально, проблема появилась от того, что 9 дней назад был добавлен новый шлангбаум с тагом foot=no, но без тага access=permissive.
![image](https://user-images.githubusercontent.com/1768114/51520635-44548300-1e35-11e9-8670-aa61379a68f1.png)
Я добавил таг access=permissive в osm: https://www.openstreetmap.org/node/6205004850
Если же подходить к данному тесту основательно, то он проверяет, что можно пересечь границу пешком, при том, что данный пункт только для авто и вело путешественников. Сейчас мы прокладываем маршрут пеший маршрут через шлагбаумы с foot=no и access=permissive, что является ошибкой. Сделал, чтоб тест проверял вело маршрут. Т.е. чтоб он проверял правильную вещь. Чтоб не прокладывал пеший маршрут через foot=no и access=permissive тема отдельного PR.

turn_test.cpp::GermanyFrankfurtAirport2Test
Сейчас выглядит корректно.
![image](https://user-images.githubusercontent.com/1768114/51520973-394e2280-1e36-11e9-82e2-3060c7bc6cce.png)

turn_test.cpp::GermanyRaunheimAirportTest - удален, как дубликат GermanyFrankfurtAirport2Test

@tatiana-yan @vmihaylenko PTAL