### PR TITLE
[search] Improve streets matching for HouseToStreet table.

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -344,9 +344,7 @@ void AddFeatureNameIndexPairs(FeaturesVectorTest const & features,
 bool GetStreetIndex(search::MwmContext & ctx, uint32_t featureID, string const & streetName,
                     uint32_t & result)
 {
-  strings::UniString const street = search::GetStreetNameAsKey(streetName);
-
-  bool const hasStreet = !street.empty();
+  bool const hasStreet = !streetName.empty();
   if (hasStreet)
   {
     FeatureType ft;
@@ -354,9 +352,10 @@ bool GetStreetIndex(search::MwmContext & ctx, uint32_t featureID, string const &
 
     using TStreet = search::ReverseGeocoder::Street;
     vector<TStreet> streets;
-    search::ReverseGeocoder::GetNearbyStreets(ctx, feature::GetCenter(ft), streets);
+    search::ReverseGeocoder::GetNearbyStreets(ctx, feature::GetCenter(ft),
+                                              true /* includeSquaresAndSuburbs */, streets);
 
-    auto const res = search::ReverseGeocoder::GetMatchedStreetIndex(street, streets);
+    auto const res = search::ReverseGeocoder::GetMatchedStreetIndex(streetName, streets);
 
     if (res)
     {

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -200,6 +200,20 @@ IsAirportChecker::IsAirportChecker()
   m_types.push_back(c.GetTypeByPath({"aeroway", "aerodrome"}));
 }
 
+IsSquareChecker::IsSquareChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"place", "square"}));
+}
+
+IsSuburbChecker::IsSuburbChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"landuse", "residential"}));
+  m_types.push_back(c.GetTypeByPath({"place", "neighbourhood"}));
+  m_types.push_back(c.GetTypeByPath({"place", "suburb"}));
+}
+
 IsStreetChecker::IsStreetChecker()
 {
   // TODO (@y, @m, @vng): this list must be up-to-date with

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -104,6 +104,22 @@ public:
   DECLARE_CHECKER_INSTANCE(IsAirportChecker);
 };
 
+class IsSquareChecker : public BaseChecker
+{
+  IsSquareChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsSquareChecker);
+};
+
+class IsSuburbChecker : public BaseChecker
+{
+  IsSuburbChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsSuburbChecker);
+};
+
 class IsStreetChecker : public BaseChecker
 {
   IsStreetChecker();

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -282,7 +282,7 @@ string DropLastToken(string const & str)
   return string(str.begin(), iter.base());
 }
 
-UniString GetStreetNameAsKey(string const & name)
+UniString GetStreetNameAsKey(string const & name, bool ignoreStreetSynonyms)
 {
   if (name.empty())
     return UniString();
@@ -293,6 +293,9 @@ UniString GetStreetNameAsKey(string const & name)
   {
     UniString const s = NormalizeAndSimplifyString(*iter);
     ++iter;
+
+    if (ignoreStreetSynonyms && IsStreetSynonym(s))
+      continue;
 
     res.append(s);
   }

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -71,7 +71,7 @@ bool TokenizeStringAndCheckIfLastTokenIsPrefix(std::string const & s, Tokens & t
 // Chops off the last query token (the "prefix" one) from |str|.
 std::string DropLastToken(std::string const & str);
 
-strings::UniString GetStreetNameAsKey(std::string const & name);
+strings::UniString GetStreetNameAsKey(std::string const & name, bool ignoreStreetSynonyms);
 
 // *NOTE* The argument string must be normalized and simplified.
 bool IsStreetSynonym(strings::UniString const & s);

--- a/map/map_tests/address_tests.cpp
+++ b/map/map_tests/address_tests.cpp
@@ -19,7 +19,8 @@ void TestAddress(ReverseGeocoder & coder, ms::LatLon const & ll,
   ReverseGeocoder::Address addr;
   coder.GetNearbyAddress(MercatorBounds::FromLatLon(ll), addr);
 
-  string const key = strings::ToUtf8(GetStreetNameAsKey(addr.m_street.m_name));
+  string const key =
+      strings::ToUtf8(GetStreetNameAsKey(addr.m_street.m_name, false /* ignoreStreetSynonyms */));
 
   TEST_EQUAL(stName, key, (addr));
   TEST_EQUAL(hNumber, addr.m_building.m_name, (addr));

--- a/search/house_detector.cpp
+++ b/search/house_detector.cpp
@@ -742,7 +742,7 @@ double Street::GetPrefixLength(size_t numSegs) const
 void Street::SetName(string const & name)
 {
   m_name = name;
-  m_processedName = strings::ToUtf8(GetStreetNameAsKey(name));
+  m_processedName = strings::ToUtf8(GetStreetNameAsKey(name, false /* ignoreStreetSynonyms */));
 }
 
 void Street::Reverse()

--- a/search/reverse_geocoder.hpp
+++ b/search/reverse_geocoder.hpp
@@ -68,7 +68,7 @@ public:
 
   /// Returns a feature id of street from |streets| whose name best matches |keyName|
   /// or empty value if the match was not found.
-  static boost::optional<uint32_t> GetMatchedStreetIndex(strings::UniString const & keyName,
+  static boost::optional<uint32_t> GetMatchedStreetIndex(std::string const & keyName,
                                                          std::vector<Street> const & streets);
 
   struct Address
@@ -85,8 +85,10 @@ public:
   friend std::string DebugPrint(Address const & addr);
 
   /// @return Sorted by distance streets vector for the specified MwmId.
+  /// Parameter |includeSquaresAndSuburbs| needed for backward compatibility:
+  /// existing mwms operate on streets without squares and suburbs.
   static void GetNearbyStreets(search::MwmContext & context, m2::PointD const & center,
-                               std::vector<Street> & streets);
+                               bool includeSquaresAndSuburbs, std::vector<Street> & streets);
   void GetNearbyStreets(MwmSet::MwmId const & id, m2::PointD const & center,
                         std::vector<Street> & streets) const;
   void GetNearbyStreets(FeatureType & ft, std::vector<Street> & streets) const;
@@ -110,6 +112,9 @@ public:
   bool GetExactAddress(FeatureType & ft, Address & addr) const;
 
 private:
+  /// Old data compatible method to retrieve nearby streets.
+  void GetNearbyStreetsWaysOnly(MwmSet::MwmId const & id, m2::PointD const & center,
+                                std::vector<Street> & streets) const;
 
   /// Helper class to incapsulate house 2 street table reloading.
   class HouseTable

--- a/search/search_tests/house_detector_tests.cpp
+++ b/search/search_tests/house_detector_tests.cpp
@@ -57,7 +57,7 @@ class CollectStreetIDs
   static bool GetKey(string const & name, string & key)
   {
     TEST(!name.empty(), ());
-    key = strings::ToUtf8(search::GetStreetNameAsKey(name));
+    key = strings::ToUtf8(search::GetStreetNameAsKey(name, false /* ignoreStreetSynonyms */));
 
     if (key.empty())
     {
@@ -336,7 +336,7 @@ namespace
 {
 string GetStreetKey(string const & name)
 {
-  return strings::ToUtf8(search::GetStreetNameAsKey(name));
+  return strings::ToUtf8(search::GetStreetNameAsKey(name, false /* ignoreStreetSynonyms */));
 }
 } // namespace
 


### PR DESCRIPTION
Небольшие улучшения по матчингу улиц. Помогают распознать примерно четверть нераспознанных улиц (1.7% -> 1.3% для прямоугольника вокруг Москвы).
