### PR TITLE
[routing] Switching on altitude for routing integration tests for pedestrian and bicycle routing.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 268.3, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 293.4, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -111,7 +111,9 @@ unique_ptr<IndexRouter> CreateVehicleRouter(DataSource & dataSource,
   auto countryParentGetter = std::make_unique<storage::CountryParentGetter>();
   CHECK(countryParentGetter, ());
 
-  auto indexRouter = make_unique<IndexRouter>(vehicleType, false /* load altitudes*/,
+  bool const loadAltitudes =
+      vehicleType == VehicleType::Pedestrian || vehicleType == VehicleType::Bicycle;
+  auto indexRouter = make_unique<IndexRouter>(vehicleType, loadAltitudes,
                                               *countryParentGetter, countryFileGetter,
                                               getMwmRectByName, numMwmIds,
                                               MakeNumMwmTree(*numMwmIds, infoGetter), trafficCache, dataSource);


### PR DESCRIPTION
План таков. Включаем использование высот для интеграционных тестов в этом PR.
Потом учитываем высоту и уточняем коэффициенты для пешего и вело роутинга. Следующий PR.

@tatiana-yan @vmihaylenko PTAL