### PR TITLE
[routing] Adding weight for walking up and riding up in case of pedestrian and bicycle routing.

### DIFF
--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -17,7 +17,7 @@ using namespace traffic;
 
 namespace
 {
-feature::TAltitude constexpr mountainSicknessAltitudeM = 3000;
+feature::TAltitude constexpr kMountainSicknessAltitudeM = 2500;
 
 enum class Purpose
 {
@@ -52,10 +52,12 @@ double GetPedestrianClimbPenalty(double tangent, feature::TAltitude altitudeM)
     return 1.0 + 2.0 * (-tangent);
 
   // Climb.
-  if (altitudeM < mountainSicknessAltitudeM)
-    return 1.0 + 10.0 * tangent;
-  else
-    return 1.0 + 30.0 * tangent;
+  // The upper the penalty is more:
+  // |1 + 10 * tangent| for altitudes lower than |kMountainSicknessAltitudeM|
+  // |1 + 20 * tangent| for 4000 meters
+  // |1 + 30 * tangent| for 5500 meters
+  // |1 + 40 * tangent| for 7000 meters
+  return 1.0 + (10.0 + max(0, altitudeM - kMountainSicknessAltitudeM) * 10.0 / 1500) * tangent;
 }
 
 double GetBicycleClimbPenalty(double tangent, feature::TAltitude altitudeM)
@@ -64,10 +66,10 @@ double GetBicycleClimbPenalty(double tangent, feature::TAltitude altitudeM)
     return 1.0;
 
   // Climb.
-  if (altitudeM < mountainSicknessAltitudeM)
+  if (altitudeM < kMountainSicknessAltitudeM)
     return 1.0 + 30.0 * tangent;
-  else
-    return 1.0 + 50.0 * tangent;
+
+  return 1.0 + 50.0 * tangent;
 }
 
 double GetCarClimbPenalty(double /* tangent */, feature::TAltitude /* altitude */) { return 1.0; }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -473,7 +473,8 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
   if (redressResult != RouterResultCode::NoError)
     return redressResult;
 
-  LOG(LINFO, ("Route length:", route.GetTotalDistanceMeters()));
+  LOG(LINFO, ("Route length:", route.GetTotalDistanceMeters(), "meters. ETA:",
+      route.GetTotalTimeSec(), "seconds."));
 
   m_lastRoute = make_unique<SegmentedRoute>(checkpoints.GetStart(), checkpoints.GetFinish(),
                                             route.GetSubroutes());

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 293.4, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 343.5, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.
@@ -118,4 +118,22 @@ UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)
       integration::GetVehicleComponents<VehicleType::Bicycle>(),
       MercatorBounds::FromLatLon(55.15414, 20.85378), {0., 0.},
       MercatorBounds::FromLatLon(56.51119, 21.01847), 192000);
+}
+
+// Test on riding up from Adeje (sea level) to Vilaflor (altitude 1400 meters).
+UNIT_TEST(SpainTenerifeAdejeVilaflor)
+{
+  integration::CalculateRouteAndTestRouteTime(
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(28.11984, -16.72592), {0.0, 0.0},
+      MercatorBounds::FromLatLon(28.15865, -16.63704), 23500.4 /* expectedTimeSeconds */);
+}
+
+// Test on riding down from Vilaflor (altitude 1400 meters) to Adeje (sea level).
+UNIT_TEST(SpainTenerifeVilaflorAdeje)
+{
+  integration::CalculateRouteAndTestRouteTime(
+      integration::GetVehicleComponents<VehicleType::Bicycle>(),
+      MercatorBounds::FromLatLon(28.15865, -16.63704), {0.0, 0.0},
+      MercatorBounds::FromLatLon(28.11984, -16.72592), 12365.3 /* expectedTimeSeconds */);
 }

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -512,7 +512,7 @@ UNIT_TEST(RussiaPriut11Elbrus)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(43.31475, 42.46035), {0., 0.},
-      MercatorBounds::FromLatLon(43.35254, 42.43788), 37300.8 /* expectedTimeSeconds */);
+      MercatorBounds::FromLatLon(43.35254, 42.43788), 32588.6 /* expectedTimeSeconds */);
 }
 
 // Test on going down from Elbrus mountain to Priut11.
@@ -521,5 +521,5 @@ UNIT_TEST(RussiaElbrusPriut11)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents<VehicleType::Pedestrian>(),
       MercatorBounds::FromLatLon(43.35254, 42.43788), {0., 0.},
-      MercatorBounds::FromLatLon(43.31475, 42.46035), 5980.33 /* expectedTimeSeconds */);
+      MercatorBounds::FromLatLon(43.31475, 42.46035), 5998.61 /* expectedTimeSeconds */);
 }

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -505,3 +505,21 @@ UNIT_TEST(ItalyVenicePedestrianPastFerry)
       MercatorBounds::FromLatLon(45.4375, 12.33549), {0.0, 0.0},
       MercatorBounds::FromLatLon(45.44057, 12.33393), 725.4);
 }
+
+// Test on climbing from Priut11 to Elbrus mountain.
+UNIT_TEST(RussiaPriut11Elbrus)
+{
+  integration::CalculateRouteAndTestRouteTime(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+      MercatorBounds::FromLatLon(43.31475, 42.46035), {0., 0.},
+      MercatorBounds::FromLatLon(43.35254, 42.43788), 37300.8 /* expectedTimeSeconds */);
+}
+
+// Test on going down from Elbrus mountain to Priut11.
+UNIT_TEST(RussiaElbrusPriut11)
+{
+  integration::CalculateRouteAndTestRouteTime(
+      integration::GetVehicleComponents<VehicleType::Pedestrian>(),
+      MercatorBounds::FromLatLon(43.35254, 42.43788), {0., 0.},
+      MercatorBounds::FromLatLon(43.31475, 42.46035), 5980.33 /* expectedTimeSeconds */);
+}

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -245,6 +245,20 @@ void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents
   TestRouteLength(*routeResult.first, expectedRouteMeters, relativeError);
 }
 
+void CalculateRouteAndTestRouteTime(IRouterComponents const & routerComponents,
+                                    m2::PointD const & startPoint,
+                                    m2::PointD const & startDirection,
+                                    m2::PointD const & finalPoint, double expectedTimeSeconds,
+                                    double relativeError)
+{
+  TRouteResult routeResult =
+      CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);
+  RouterResultCode const result = routeResult.second;
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  CHECK(routeResult.first, ());
+  TestRouteTime(*routeResult.first, expectedTimeSeconds, relativeError);
+}
+
 const TestTurn & TestTurn::TestValid() const
 {
   TEST(m_isValid, ());

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -235,7 +235,7 @@ void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents
                                       m2::PointD const & startPoint,
                                       m2::PointD const & startDirection,
                                       m2::PointD const & finalPoint, double expectedRouteMeters,
-                                      double relativeError)
+                                      double relativeError /* = 0.07 */)
 {
   TRouteResult routeResult =
       CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);
@@ -249,7 +249,7 @@ void CalculateRouteAndTestRouteTime(IRouterComponents const & routerComponents,
                                     m2::PointD const & startPoint,
                                     m2::PointD const & startDirection,
                                     m2::PointD const & finalPoint, double expectedTimeSeconds,
-                                    double relativeError)
+                                    double relativeError /* = 0.07 */)
 {
   TRouteResult routeResult =
       CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -130,6 +130,12 @@ void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents
                                       m2::PointD const & finalPoint, double expectedRouteMeters,
                                       double relativeError = 0.07);
 
+void CalculateRouteAndTestRouteTime(IRouterComponents const & routerComponents,
+                                    m2::PointD const & startPoint,
+                                    m2::PointD const & startDirection,
+                                    m2::PointD const & finalPoint, double expectedTimeSeconds,
+                                    double relativeError = 0.07     );
+
 void CheckSubwayExistence(Route const & route);
 void CheckSubwayAbsent(Route const & route);
 

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -134,7 +134,7 @@ void CalculateRouteAndTestRouteTime(IRouterComponents const & routerComponents,
                                     m2::PointD const & startPoint,
                                     m2::PointD const & startDirection,
                                     m2::PointD const & finalPoint, double expectedTimeSeconds,
-                                    double relativeError = 0.07     );
+                                    double relativeError = 0.07);
 
 void CheckSubwayExistence(Route const & route);
 void CheckSubwayAbsent(Route const & route);


### PR DESCRIPTION
Утяжелил дуги, идущие вверх в случае пешеходного и вело маршрутов.

В случае высокогорья (более 3000 метров над уровнем моря) утяжелил еще сильнее подъемы. Поскольку особенно тяжело идти вверх в таких условиях. 

Добавил тесты.

@tatiana-yan @vmihaylenko PTAL