### PR TITLE
[DNM] [base] Fix cache dangling ref

### DIFF
--- a/base/fifo_cache.hpp
+++ b/base/fifo_cache.hpp
@@ -29,7 +29,15 @@ public:
   {
     auto const it = m_map.find(key);
     if (it != m_map.cend())
+    {
+      if (Size() >= m_capacity && key == m_fifo.back())
+      {
+        m_fifo.push_front(key);
+        ASSERT_NOT_EQUAL(m_fifo.back(), key, ("Dangling pointer here."));
+      }
+
       return it->second;
+    }
 
     if (Size() >= m_capacity)
     {

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -37,8 +37,8 @@ public:
   // edge.
   double CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const;
 
-  virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
-  virtual double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const = 0;
+  virtual double CalcSegmentWeight(Segment const & segment, std::shared_ptr<RoadGeometry> road) const = 0;
+  virtual double CalcSegmentETA(Segment const & segment, std::shared_ptr<RoadGeometry> road) const = 0;
   virtual double GetUTurnPenalty() const = 0;
   // The leap is the shortcut edge from mwm border enter to exit.
   // Router can't use leaps on some mwms: e.g. mwm with loaded traffic data.

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -51,9 +51,9 @@ namespace routing
 FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, IndexGraph & graph)
 {
   auto const & road = graph.GetGeometry().GetRoad(segment.GetFeatureId());
-  bool const oneWay = road.IsOneWay();
-  auto const & frontJunction = road.GetJunction(segment.GetPointId(true /* front */));
-  auto const & backJunction = road.GetJunction(segment.GetPointId(false /* front */));
+  bool const oneWay = road->IsOneWay();
+  auto const & frontJunction = road->GetJunction(segment.GetPointId(true /* front */));
+  auto const & backJunction = road->GetJunction(segment.GetPointId(false /* front */));
   return MakeFakeEndingImpl(backJunction, frontJunction, segment, point, oneWay);
 }
 

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -90,7 +90,7 @@ class GeometryLoader
 public:
   virtual ~GeometryLoader() = default;
 
-  virtual void Load(uint32_t featureId, RoadGeometry & road) = 0;
+  virtual void Load(uint32_t featureId, std::shared_ptr<RoadGeometry> road) = 0;
 
   // handle should be alive: it is caller responsibility to check it.
   static std::unique_ptr<GeometryLoader> Create(DataSource const & dataSource,
@@ -121,13 +121,13 @@ public:
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.
-  RoadGeometry const & GetRoad(uint32_t featureId);
+  std::shared_ptr<RoadGeometry> GetRoad(uint32_t featureId);
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.
   m2::PointD const & GetPoint(RoadPoint const & rp)
   {
-    return GetRoad(rp.GetFeatureId()).GetPoint(rp.GetPointId());
+    return GetRoad(rp.GetFeatureId())->GetPoint(rp.GetPointId());
   }
 
 private:

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -92,7 +92,7 @@ private:
   RouteWeight GetPenalties(Segment const & u, Segment const & v);
   m2::PointD const & GetPoint(Segment const & segment, bool front)
   {
-    return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
+    return GetGeometry().GetRoad(segment.GetFeatureId())->GetPoint(segment.GetPointId(front));
   }
 
   void GetLastPointsForJoint(std::vector<Segment> const & children, bool isOutgoing, std::vector<uint32_t> & lastPoints);

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -46,7 +46,7 @@ void RestrictionTest::SetStarter(FakeEnding const & start, FakeEnding const & fi
 }
 
 // TestGeometryLoader ------------------------------------------------------------------------------
-void TestGeometryLoader::Load(uint32_t featureId, RoadGeometry & road)
+void TestGeometryLoader::Load(uint32_t featureId, std::shared_ptr<RoadGeometry> road)
 {
   auto it = m_roads.find(featureId);
   if (it == m_roads.cend())
@@ -72,11 +72,12 @@ void TestGeometryLoader::SetPassThroughAllowed(uint32_t featureId, bool passThro
 }
 
 // ZeroGeometryLoader ------------------------------------------------------------------------------
-void ZeroGeometryLoader::Load(uint32_t /* featureId */, routing::RoadGeometry & road)
+void ZeroGeometryLoader::Load(uint32_t /* featureId */, std::shared_ptr<routing::RoadGeometry> road)
 {
   // Any valid road will do.
   auto const points = routing::RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}});
-  road = RoadGeometry(true /* oneWay */, 1.0 /* weightSpeedKMpH */, 1.0 /* etaSpeedKMpH */, points);
+  road = std::make_shared<routing::RoadGeometry>(true /* oneWay */, 1.0 /* weightSpeedKMpH */,
+                                                 1.0 /* etaSpeedKMpH */, points);
 }
 
 // TestIndexGraphLoader ----------------------------------------------------------------------------
@@ -107,7 +108,7 @@ void TestTransitGraphLoader::AddGraph(NumMwmId mwmId, unique_ptr<TransitGraph> g
 
 // WeightedEdgeEstimator --------------------------------------------------------------
 double WeightedEdgeEstimator::CalcSegmentWeight(Segment const & segment,
-                                                RoadGeometry const & /* road */) const
+                                                std::shared_ptr<RoadGeometry> /* road */) const
 {
   auto const it = m_segmentWeights.find(segment);
   CHECK(it != m_segmentWeights.cend(), ());

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -64,7 +64,7 @@ public:
   // GeometryLoader overrides:
   ~TestGeometryLoader() override = default;
 
-  void Load(uint32_t featureId, routing::RoadGeometry & road) override;
+  void Load(uint32_t featureId, std::shared_ptr<routing::RoadGeometry> road) override;
 
   void AddRoad(uint32_t featureId, bool oneWay, float speed,
                routing::RoadGeometry::Points const & points);
@@ -81,7 +81,7 @@ public:
   // GeometryLoader overrides:
   ~ZeroGeometryLoader() override = default;
 
-  void Load(uint32_t featureId, routing::RoadGeometry & road) override;
+  void Load(uint32_t featureId, std::shared_ptr<routing::RoadGeometry> road) override;
 };
 
 class TestIndexGraphLoader final : public IndexGraphLoader
@@ -138,8 +138,8 @@ public:
   // EdgeEstimator overrides:
   ~WeightedEdgeEstimator() override = default;
 
-  double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
-  double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const override { return 0.0; }
+  double CalcSegmentWeight(Segment const & segment, std::shared_ptr<RoadGeometry> /* road */) const override;
+  double CalcSegmentETA(Segment const & segment, std::shared_ptr<RoadGeometry> road) const override { return 0.0; }
   double GetUTurnPenalty() const override;
   bool LeapIsAllowed(NumMwmId /* mwmId */) const override;
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -92,8 +92,8 @@ void SingleVehicleWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoi
 
 Junction const & SingleVehicleWorldGraph::GetJunction(Segment const & segment, bool front)
 {
-  return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
-      .GetJunction(segment.GetPointId(front));
+  auto geometry = GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId());
+  return geometry->GetJunction(segment.GetPointId(front));
 }
 
 m2::PointD const & SingleVehicleWorldGraph::GetPoint(Segment const & segment, bool front)
@@ -103,12 +103,12 @@ m2::PointD const & SingleVehicleWorldGraph::GetPoint(Segment const & segment, bo
 
 bool SingleVehicleWorldGraph::IsOneWay(NumMwmId mwmId, uint32_t featureId)
 {
-  return GetRoadGeometry(mwmId, featureId).IsOneWay();
+  return GetRoadGeometry(mwmId, featureId)->IsOneWay();
 }
 
 bool SingleVehicleWorldGraph::IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId)
 {
-  return GetRoadGeometry(mwmId, featureId).IsPassThroughAllowed();
+  return GetRoadGeometry(mwmId, featureId)->IsPassThroughAllowed();
 }
 
 void SingleVehicleWorldGraph::GetOutgoingEdgesList(Segment const & segment,
@@ -176,7 +176,7 @@ vector<RouteSegment::SpeedCamera> SingleVehicleWorldGraph::GetSpeedCamInfo(Segme
   return m_loader->GetSpeedCameraInfo(segment);
 }
 
-RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
+std::shared_ptr<RoadGeometry> SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
   return m_loader->GetGeometry(mwmId).GetRoad(featureId);
 }

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -78,7 +78,7 @@ private:
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
 
-  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
+  std::shared_ptr<RoadGeometry> GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -77,7 +77,7 @@ Junction const & TransitWorldGraph::GetJunction(Segment const & segment, bool fr
     return GetTransitGraph(segment.GetMwmId()).GetJunction(segment, front);
 
   return GetRealRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
-      .GetJunction(segment.GetPointId(front));
+      ->GetJunction(segment.GetPointId(front));
 }
 
 m2::PointD const & TransitWorldGraph::GetPoint(Segment const & segment, bool front)
@@ -89,14 +89,14 @@ bool TransitWorldGraph::IsOneWay(NumMwmId mwmId, uint32_t featureId)
 {
   if (TransitGraph::IsTransitFeature(featureId))
     return true;
-  return GetRealRoadGeometry(mwmId, featureId).IsOneWay();
+  return GetRealRoadGeometry(mwmId, featureId)->IsOneWay();
 }
 
 bool TransitWorldGraph::IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId)
 {
   if (TransitGraph::IsTransitFeature(featureId))
     return true;
-  return GetRealRoadGeometry(mwmId, featureId).IsPassThroughAllowed();
+  return GetRealRoadGeometry(mwmId, featureId)->IsPassThroughAllowed();
 }
 
 void TransitWorldGraph::ClearCachedGraphs()
@@ -195,7 +195,7 @@ void TransitWorldGraph::GetTwinsInner(Segment const & segment, bool isOutgoing,
   m_crossMwmGraph->GetTwins(segment, isOutgoing, twins);
 }
 
-RoadGeometry const & TransitWorldGraph::GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId)
+std::shared_ptr<RoadGeometry> TransitWorldGraph::GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId)
 {
   CHECK(!TransitGraph::IsTransitFeature(featureId), ("GetRealRoadGeometry not designed for transit."));
   return m_indexLoader->GetGeometry(mwmId).GetRoad(featureId);

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -83,7 +83,7 @@ private:
     return 50 * 60 + (startToFinishDistanceM / 1000) * 3 * 60;
   }
 
-  RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
+  std::shared_ptr<RoadGeometry> GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 


### PR DESCRIPTION
Иногда у нас появляется висячая ссылка.
В коде есть что-то вроде:
```cpp
SomeMethod(GetPoint(v), GetPoint(final))
```
Так как порядок вычисления аргументов не определен, то, например в centos, вначале исполняется `GetPoint(final)` который возвращает `const ref` на объект в `std::map`, после исполняется `GetPoint(v)` так как скорее всего у нас `v` не будет закэширована, то мы что-то вытолкнем из кэша и так получается (редко очень, но случается), что мы выталкием `const ref` на `GetPoint(final)` из-за объект инвалидируется.

Самое простое, что приходит в голову - это хранить shared_ptr, вот результаты производительности:
![image](https://user-images.githubusercontent.com/17534533/51846334-703aa180-232a-11e9-81ba-a1e8f8c71e1e.png)

В целом не все так плохо, и можно так оставить. Есть предложение сделать вместо текущего кэша LRU кэш, но надо написать, что бы понять насколько это быстрее/медленнее работает
