### PR TITLE
[search] Make idf for localities consistent.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -185,24 +185,6 @@ public:
 
   uint8_t GetRank(uint32_t featureId) const override { return m_ranks.Get(featureId); }
 
-  CBV GetMatchedFeatures(strings::UniString const & token, bool isPrefix) const override
-  {
-    if (isPrefix)
-    {
-      SearchTrieRequest<strings::PrefixDFAModifier<strings::UniStringDFA>> request;
-      request.m_names.emplace_back(strings::UniStringDFA(token));
-      request.SetLangs(m_params.GetLangs());
-      return CBV{m_retrieval.RetrieveAddressFeatures(request)};
-    }
-    else
-    {
-      SearchTrieRequest<strings::UniStringDFA> request;
-      request.m_names.emplace_back(token);
-      request.SetLangs(m_params.GetLangs());
-      return CBV{m_retrieval.RetrieveAddressFeatures(request)};
-    }
-  }
-
 private:
   MwmContext const & m_context;
   Geocoder::Params const & m_params;

--- a/search/idf_map.hpp
+++ b/search/idf_map.hpp
@@ -19,11 +19,6 @@ public:
 
   IdfMap(Delegate const & delegate, double unknownIdf);
 
-  void Set(strings::UniString const & s, bool isPrefix, double idf)
-  {
-    SetImpl(isPrefix ? m_prefixIdfs : m_fullIdfs, s, idf);
-  }
-
   double Get(strings::UniString const & s, bool isPrefix)
   {
     return GetImpl(isPrefix ? m_prefixIdfs : m_fullIdfs, s, isPrefix);
@@ -32,7 +27,6 @@ public:
 private:
   using Map = std::map<strings::UniString, double>;
 
-  void SetImpl(Map & idfs, strings::UniString const & s, double idf) { idfs[s] = idf; }
   double GetImpl(Map & idfs, strings::UniString const & s, bool isPrefix);
 
   Map m_fullIdfs;

--- a/search/locality_scorer.hpp
+++ b/search/locality_scorer.hpp
@@ -30,7 +30,6 @@ public:
 
     virtual void GetNames(uint32_t featureId, std::vector<std::string> & names) const = 0;
     virtual uint8_t GetRank(uint32_t featureId) const = 0;
-    virtual CBV GetMatchedFeatures(strings::UniString const & token, bool isPrefix) const = 0;
   };
 
   LocalityScorer(QueryParams const & params, Delegate const & delegate);
@@ -38,7 +37,7 @@ public:
   // Leaves at most |limit| elements of |localities|, ordered by their
   // features.
   void GetTopLocalities(MwmSet::MwmId const & countryId, BaseContext const & ctx,
-                        CBV const & filter, size_t limit, std::vector<Locality> & localities);
+                        CBV const & filter, size_t limit, std::vector<Locality> & localities) const;
 
 private:
   struct ExLocality

--- a/search/search_tests/locality_scorer_test.cpp
+++ b/search/search_tests/locality_scorer_test.cpp
@@ -121,24 +121,6 @@ public:
     return it == m_ranks.end() ? 0 : it->second;
   }
 
-  CBV GetMatchedFeatures(strings::UniString const & token, bool isPrefix) const override
-  {
-    vector<uint64_t> ids;
-
-    if (isPrefix)
-    {
-      m_searchIndex.ForEachInSubtree(token, [&ids](strings::UniString const & /* prefix */,
-                                                   uint32_t id) { ids.push_back(id); });
-    }
-    else
-    {
-      m_searchIndex.ForEachInNode(token, [&ids](uint32_t id) { ids.push_back(id); });
-    }
-
-    base::SortUnique(ids);
-    return CBV{coding::CompressedBitVectorBuilder::FromBitPositions(move(ids))};
-  }
-
 protected:
   QueryParams m_params;
   unordered_map<uint32_t, vector<string>> m_names;


### PR DESCRIPTION
При определении топа населённых пунктов, соответствующих запросу, в LeaveTopByNormAndRank idf расчитывался по точному совпадению слова с запросом (без опечаток), а затем фичи брались для неточного совпадения слова с запросом.

Например при запросе "The Villages, Florida" определяется df для the (много, не значимый токен), villages (2 в world, очень значимый токен) и florida (20 в world, не очень значимый токен), после чего по villages из world.mwm вытаскиваются все фичи содержащие village или что-то подобное (>100 штук), им назначается idf исходя из встречаемости "villages" (очень высокий) и они забивают в LeaveTopByNormAndRank всю флориду.

В данном реквесте df для токенов из запроса считается исходя из того, сколько документов вытаскивается из карты для этого токена. Т.к. считать с опечатками для всех токенов дорого, для токенов не из запроса принимаем df неизвестным (судя по комментариям, такой и был план).