### PR TITLE
Displaying positive and negative offsets for edges in openlr assessment tool.

### DIFF
--- a/openlr/decoded_path.cpp
+++ b/openlr/decoded_path.cpp
@@ -19,16 +19,16 @@
 
 namespace
 {
+uint32_t UintFromXML(pugi::xml_node const & node)
+{
+  THROW_IF_NODE_IS_EMPTY(node, openlr::DecodedPathLoadError, ("Can't parse uint"));
+  return node.text().as_uint();
+}
+
 bool IsForwardFromXML(pugi::xml_node const & node)
 {
   THROW_IF_NODE_IS_EMPTY(node, openlr::DecodedPathLoadError, ("Can't parse IsForward"));
   return node.text().as_bool();
-}
-
-uint32_t SegmentIdFromXML(pugi::xml_node const & node)
-{
-  THROW_IF_NODE_IS_EMPTY(node, openlr::DecodedPathLoadError, ("Can't parse SegmentId"));
-  return node.text().as_uint();
 }
 
 void LatLonToXML(ms::LatLon const & latLon, pugi::xml_node & node)
@@ -63,6 +63,15 @@ void FeatureIdToXML(FeatureID const & fid, pugi::xml_node & node)
 
 namespace openlr
 {
+uint32_t UintValueFromXML(pugi::xml_node const & node)
+{
+  auto const value = node.child("olr:value");
+  if (!value)
+    return 0;
+
+  return UintFromXML(value);
+}
+
 void WriteAsMappingForSpark(std::string const & fileName, std::vector<DecodedPath> const & paths)
 {
   std::ofstream ofs(fileName);
@@ -120,7 +129,7 @@ void PathFromXML(pugi::xml_node const & node, DataSource const & dataSource, Pat
     FeatureIdFromXML(e.child("FeatureID"), dataSource, fid);
 
     auto const isForward = IsForwardFromXML(e.child("IsForward"));
-    auto const segmentId = SegmentIdFromXML(e.child("SegmentId"));
+    auto const segmentId = UintFromXML(e.child("SegmentId"));
 
     ms::LatLon start, end;
     LatLonFromXML(e.child("StartJunction"), start);

--- a/openlr/decoded_path.hpp
+++ b/openlr/decoded_path.hpp
@@ -5,6 +5,7 @@
 #include "base/exception.hpp"
 #include "base/newtype.hpp"
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -29,6 +30,8 @@ struct DecodedPath
   PartnerSegmentId m_segmentId;
   Path m_path;
 };
+
+uint32_t UintValueFromXML(pugi::xml_node const & node);
 
 void WriteAsMappingForSpark(std::string const & fileName, std::vector<DecodedPath> const & paths);
 void WriteAsMappingForSpark(std::ostream & ost, std::vector<DecodedPath> const & paths);

--- a/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
@@ -326,6 +326,7 @@ void MainWindow::CreateTrafficPanel(string const & dataFilePath)
   m_docWidget->setWidget(new TrafficPanel(m_trafficMode, m_docWidget));
 
   m_docWidget->adjustSize();
+  m_docWidget->setMinimumWidth(400);
   m_docWidget->show();
 }
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.cpp
@@ -6,6 +6,9 @@ SegmentCorrespondence::SegmentCorrespondence(SegmentCorrespondence const & sc)
 {
   m_partnerSegment = sc.m_partnerSegment;
 
+  m_positiveOffset = sc.m_positiveOffset;
+  m_negativeOffset = sc.m_negativeOffset;
+
   m_matchedPath = sc.m_matchedPath;
   m_fakePath = sc.m_fakePath;
   m_goldenPath = sc.m_goldenPath;
@@ -17,11 +20,14 @@ SegmentCorrespondence::SegmentCorrespondence(SegmentCorrespondence const & sc)
 }
 
 SegmentCorrespondence::SegmentCorrespondence(openlr::LinearSegment const & segment,
+                                             uint32_t positiveOffset, uint32_t negativeOffset,
                                              openlr::Path const & matchedPath,
                                              openlr::Path const & fakePath,
                                              openlr::Path const & goldenPath,
                                              pugi::xml_node const & partnerSegmentXML)
   : m_partnerSegment(segment)
+  , m_positiveOffset(positiveOffset)
+  , m_negativeOffset(negativeOffset)
   , m_matchedPath(matchedPath)
   , m_fakePath(fakePath)
 {

--- a/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
@@ -19,6 +19,7 @@ public:
 
   SegmentCorrespondence(SegmentCorrespondence const & sc);
   SegmentCorrespondence(openlr::LinearSegment const & segment,
+                        uint32_t positiveOffset, uint32_t negativeOffset,
                         openlr::Path const & matchedPath,
                         openlr::Path const & fakePath,
                         openlr::Path const & goldenPath,
@@ -26,6 +27,9 @@ public:
 
   openlr::Path const & GetMatchedPath() const { return m_matchedPath; }
   bool HasMatchedPath() const { return !m_matchedPath.empty(); }
+
+  uint32_t GetPositiveOffset() const { return m_positiveOffset; }
+  uint32_t GetNegativeOffset() const { return m_negativeOffset; }
 
   openlr::Path const & GetFakePath() const { return m_fakePath; }
   bool HasFakePath() const { return !m_fakePath.empty(); }
@@ -47,6 +51,9 @@ public:
 
 private:
   openlr::LinearSegment m_partnerSegment;
+
+  uint32_t m_positiveOffset = 0;
+  uint32_t m_negativeOffset = 0;
 
   openlr::Path m_matchedPath;
   openlr::Path m_fakePath;

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
@@ -265,22 +265,17 @@ QVariant TrafficMode::data(const QModelIndex & index, int role) const
 QVariant TrafficMode::headerData(int section, Qt::Orientation orientation,
                                  int role /* = Qt::DisplayRole */) const
 {
-  if (orientation == Qt::Horizontal)
-  {
-    if (role == Qt::DisplayRole)
-    {
-      switch (section)
-      {
-      case 0: return "Segment id"; break;
-      case 1: return "Status code"; break;
-      case 2: return "Positive offset (Meters)"; break;
-      case 3: return "Negative offset (Meters)"; break;
-      }
-      UNREACHABLE();
-    }
-  }
+  if (orientation != Qt::Horizontal && role != Qt::DisplayRole)
+    return QVariant();
 
-  return QVariant();
+  switch (section)
+  {
+  case 0: return "Segment id"; break;
+  case 1: return "Status code"; break;
+  case 2: return "Positive offset (Meters)"; break;
+  case 3: return "Negative offset (Meters)"; break;
+  }
+  UNREACHABLE();
 }
 
 void TrafficMode::OnItemSelected(QItemSelection const & selected, QItemSelection const &)

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
@@ -76,10 +76,10 @@ public:
 
   int rowCount(const QModelIndex & parent = QModelIndex()) const Q_DECL_OVERRIDE;
   int columnCount(const QModelIndex & parent = QModelIndex()) const Q_DECL_OVERRIDE;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
 
   QVariant data(const QModelIndex & index, int role) const Q_DECL_OVERRIDE;
-  // QVariant headerData(int section, Qt::Orientation orientation,
-  //                     int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
 
   Qt::ItemFlags flags(QModelIndex const & index) const Q_DECL_OVERRIDE;
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_panel.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_panel.cpp
@@ -69,7 +69,7 @@ void TrafficPanel::CreateTable(QAbstractItemModel * trafficModel)
   m_table->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
   m_table->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
   m_table->verticalHeader()->setVisible(false);
-  m_table->horizontalHeader()->setVisible(false);
+  m_table->horizontalHeader()->setVisible(true);
   m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 
   m_table->setModel(trafficModel);

--- a/openlr/paths_connector.cpp
+++ b/openlr/paths_connector.cpp
@@ -142,7 +142,6 @@ bool PathsConnector::FindShortestPath(Graph::Edge const & from, Graph::Edge cons
                                       Graph::EdgeVector & path)
 {
   // TODO(mgsergio): Turn Dijkstra to A*.
-
   uint32_t const kLengthToleranceM = 10;
 
   struct State


### PR DESCRIPTION
Для корректной разметки необходимо видеть значение опциональных параметров olr:positiveOffset/olr:negativeOffset в утилите для разметки.

![image](https://user-images.githubusercontent.com/1768114/52706470-8e450a80-2f96-11e9-9c33-7cdef1508f68.png)

@vmihaylenko @gmoryes PTAL