### PR TITLE
[storage] Removing the deleted country from DiffManager.

### DIFF
--- a/storage/diff_scheme/diff_manager.cpp
+++ b/storage/diff_scheme/diff_manager.cpp
@@ -137,6 +137,12 @@ void Manager::RemoveAppliedDiffs()
     m_status = Status::NotAvailable;
 }
 
+void Manager::RemoveDiffForCountry(storage::CountryId const & countryId)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_diffs.erase(countryId);
+}
+
 void Manager::AbortDiffScheme()
 {
   std::lock_guard<std::mutex> lock(m_mutex);

--- a/storage/diff_scheme/diff_manager.hpp
+++ b/storage/diff_scheme/diff_manager.hpp
@@ -38,6 +38,7 @@ public:
   bool IsPossibleToAutoupdate() const;
   bool HasDiffFor(storage::CountryId const & countryId) const;
   void RemoveAppliedDiffs();
+  void RemoveDiffForCountry(storage::CountryId const & countryId);
   void AbortDiffScheme();
 
   Status GetStatus() const;

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -564,6 +564,8 @@ void Storage::DeleteCountry(CountryId const & countryId, MapOptions opt)
   bool const deferredDelete = m_willDelete(countryId, localFile);
   DeleteCountryFiles(countryId, opt, deferredDelete);
   DeleteCountryFilesFromDownloader(countryId);
+  m_diffManager.RemoveDiffForCountry(countryId);
+
   NotifyStatusChangedForHierarchy(countryId);
 }
 


### PR DESCRIPTION
Suppose that a user has one mwm and the app has been updated.
It now offers to download the diff, however instead
the user deletes the map and tries to download it again.
The download fails because according to the DiffManager it's
not the mwm but the mwmdiff that should be downloaded which
results in a size mismatch. Moreover, if the download is retried,
the diff is downloaded (because the MapOptions are correct now)
but it cannot be applied because the old mwm has already been removed.

The problem is that we do not account for the change in mwm status
since the start of the application (and, in particular, the DiffManager)
when taking the decision whether to download a diff or a full mwm.