### PR TITLE
Removing speed cameras from Turkey, Switzerland, Macedonia, Cyprus.

### DIFF
--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <vector>
 
 namespace generator
 {
@@ -315,6 +314,34 @@ void CamerasInfoCollector::Camera::Serialize(FileWriter & writer,
                                              uint32_t & prevFeatureId) const
 {
   routing::SerializeSpeedCamera(writer, m_data, prevFeatureId);
+}
+
+bool IsCamerasInfoProhibited(std::string const & mwmName)
+{
+  std::vector<std::string> const kMwmBlockList = {
+      "Cyprus",
+      "Macedonia",
+      "Switzerland_Central",
+      "Switzerland_Eastern",
+      "Switzerland_Espace Mittelland_Bern",
+      "Switzerland_Espace Mittelland_East",
+      "Switzerland_Lake Geneva region",
+      "Switzerland_Northwestern",
+      "Switzerland_Ticino",
+      "Switzerland_Zurich",
+      "Turkey_Aegean Region",
+      "Turkey_Black Sea Region",
+      "Turkey_Central Anatolia Region_Ankara",
+      "Turkey_Central Anatolia Region_Kayseri",
+      "Turkey_Eastern Anatolia Region",
+      "Turkey_Marmara Region_Bursa",
+      "Turkey_Marmara Region_Istanbul",
+      "Turkey_Mediterranean Region",
+      "Turkey_Southeastern Anatolia Region",
+  };
+  CHECK(is_sorted(kMwmBlockList.cbegin(), kMwmBlockList.cend()), ());
+
+  return std::binary_search(kMwmBlockList.cbegin(), kMwmBlockList.cend(), mwmName);
 }
 
 void BuildCamerasInfo(std::string const & dataFilePath,

--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -16,6 +16,7 @@
 #include "base/string_utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <limits>
 
 namespace generator
@@ -318,30 +319,19 @@ void CamerasInfoCollector::Camera::Serialize(FileWriter & writer,
 
 bool IsCamerasInfoProhibited(std::string const & mwmName)
 {
-  std::vector<std::string> const kMwmBlockList = {
+  std::array<std::string, 4> kCountryBlockList = {
       "Cyprus",
       "Macedonia",
-      "Switzerland_Central",
-      "Switzerland_Eastern",
-      "Switzerland_Espace Mittelland_Bern",
-      "Switzerland_Espace Mittelland_East",
-      "Switzerland_Lake Geneva region",
-      "Switzerland_Northwestern",
-      "Switzerland_Ticino",
-      "Switzerland_Zurich",
-      "Turkey_Aegean Region",
-      "Turkey_Black Sea Region",
-      "Turkey_Central Anatolia Region_Ankara",
-      "Turkey_Central Anatolia Region_Kayseri",
-      "Turkey_Eastern Anatolia Region",
-      "Turkey_Marmara Region_Bursa",
-      "Turkey_Marmara Region_Istanbul",
-      "Turkey_Mediterranean Region",
-      "Turkey_Southeastern Anatolia Region",
+      "Switzerland",
+      "Turkey",
   };
-  CHECK(is_sorted(kMwmBlockList.cbegin(), kMwmBlockList.cend()), ());
 
-  return std::binary_search(kMwmBlockList.cbegin(), kMwmBlockList.cend(), mwmName);
+  for (auto const & country : kCountryBlockList)
+  {
+    if (strings::StartsWith(mwmName, country))
+      return true;
+  }
+  return false;
 }
 
 void BuildCamerasInfo(std::string const & dataFilePath,

--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -331,6 +331,7 @@ bool IsCamerasInfoProhibited(std::string const & mwmName)
     if (strings::StartsWith(mwmName, country))
       return true;
   }
+
   return false;
 }
 

--- a/generator/camera_info_collector.hpp
+++ b/generator/camera_info_collector.hpp
@@ -21,7 +21,6 @@
 #include "base/geo_object_id.hpp"
 
 #include <cstdint>
-#include <limits>
 #include <map>
 #include <string>
 #include <utility>
@@ -86,6 +85,10 @@ private:
 
   std::vector<Camera> m_cameras;
 };
+
+/// \returns true if any information about speed cameras is prohibited in |mwmName|.
+/// \param mwmName is mwm name without extention. E.g. "Russia_Moscow".
+bool IsCamerasInfoProhibited(std::string const & mwmName);
 
 // To start building camera info, the following data must be ready:
 // 1. GenerateIntermediateData(). Cached data about camera node to ways.

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -520,10 +520,18 @@ int GeneratorToolMain(int argc, char ** argv)
 
     if (FLAGS_generate_cameras)
     {
-      string const camerasFilename =
-          genInfo.GetIntermediateFileName(CAMERAS_TO_WAYS_FILENAME);
+      if (IsCamerasInfoProhibited(country))
+      {
+        LOG(LINFO,
+            ("Cameras info is prohibited for", country, "and speedcams section is not generated."));
+      }
+      else
+      {
+        string const camerasFilename =
+            genInfo.GetIntermediateFileName(CAMERAS_TO_WAYS_FILENAME);
 
-      BuildCamerasInfo(datFile, camerasFilename, osmToFeatureFilename);
+        BuildCamerasInfo(datFile, camerasFilename, osmToFeatureFilename);
+      }
     }
 
     if (FLAGS_make_routing_index)


### PR DESCRIPTION
Согласно https://confluence.mail.ru/display/MAPSME/Speed+cameras#Speedcameras-SpeedCamdetectorlawsinseveralcountries камеры скорости должны быть удалены из ряда стран. Данный PR реализует это.

https://jira.mail.ru/browse/MAPSME-9705

@gmoryes @vmihaylenko PTAL