### PR TITLE
Adding methods for getting info if route crosses mwm where warnings about speedcams are prohibited.

### DIFF
--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -16,7 +16,6 @@
 #include "base/string_utils.hpp"
 
 #include <algorithm>
-#include <array>
 #include <limits>
 
 namespace generator
@@ -315,24 +314,6 @@ void CamerasInfoCollector::Camera::Serialize(FileWriter & writer,
                                              uint32_t & prevFeatureId) const
 {
   routing::SerializeSpeedCamera(writer, m_data, prevFeatureId);
-}
-
-bool IsCamerasInfoProhibited(std::string const & mwmName)
-{
-  std::array<std::string, 4> kCountryBlockList = {
-      "Cyprus",
-      "Macedonia",
-      "Switzerland",
-      "Turkey",
-  };
-
-  for (auto const & country : kCountryBlockList)
-  {
-    if (strings::StartsWith(mwmName, country))
-      return true;
-  }
-
-  return false;
 }
 
 void BuildCamerasInfo(std::string const & dataFilePath,

--- a/generator/camera_info_collector.hpp
+++ b/generator/camera_info_collector.hpp
@@ -86,10 +86,6 @@ private:
   std::vector<Camera> m_cameras;
 };
 
-/// \returns true if any information about speed cameras is prohibited in |mwmName|.
-/// \param mwmName is mwm name without extention. E.g. "Russia_Moscow".
-bool IsCamerasInfoProhibited(std::string const & mwmName);
-
 // To start building camera info, the following data must be ready:
 // 1. GenerateIntermediateData(). Cached data about camera node to ways.
 // 2. GenerateFeatures(). Data about cameras from OSM.

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -34,6 +34,7 @@
 #include "generator/wiki_url_dumper.hpp"
 
 #include "routing/cross_mwm_ids.hpp"
+#include "routing/speed_camera_prohibition.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
@@ -529,7 +530,7 @@ int GeneratorToolMain(int argc, char ** argv)
 
     if (FLAGS_generate_cameras)
     {
-      if (IsCamerasInfoProhibited(country))
+      if (routing::ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile(country)))
       {
         LOG(LINFO,
             ("Cameras info is prohibited for", country, "and speedcams section is not generated."));

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -530,7 +530,7 @@ int GeneratorToolMain(int argc, char ** argv)
 
     if (FLAGS_generate_cameras)
     {
-      if (routing::ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile(country)))
+      if (routing::AreSpeedCamerasProhibited(platform::CountryFile(country)))
       {
         LOG(LINFO,
             ("Cameras info is prohibited for", country, "and speedcams section is not generated."));

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -119,6 +119,8 @@ set(
   speed_camera.hpp
   speed_camera_manager.cpp
   speed_camera_manager.hpp
+  speed_camera_prohibition.cpp
+  speed_camera_prohibition.hpp
   speed_camera_ser_des.cpp
   speed_camera_ser_des.hpp
   traffic_stash.cpp

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1036,7 +1036,7 @@ void IndexRouter::FillSpeedCamProhibitedMwms(vector<Segment> const & segments,
 
   set<NumMwmId> mwmIds;
   for (auto const & s : segments)
-    mwmIds.insert(s.GetMwmId());
+    mwmIds.emplace(s.GetMwmId());
 
   for (auto const id : mwmIds)
   {

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -12,6 +12,7 @@
 #include "routing/joint.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
+#include "routing/segment.hpp"
 #include "routing/segmented_route.hpp"
 #include "routing/world_graph.hpp"
 
@@ -19,6 +20,8 @@
 #include "routing_common/vehicle_model.hpp"
 
 #include "indexer/mwm_set.hpp"
+
+#include "platform/country_file.hpp"
 
 #include "geometry/tree4d.hpp"
 
@@ -120,6 +123,11 @@ private:
 
   RouterResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,
                                         RouterResultCode resultCode) const;
+
+  /// \brief Fills |speedcamProhibitedMwms| with mwms which are crossed by |segments|
+  /// where speed cameras are prohibited.
+  void FillsSpeedcamProhibitedMwms(std::vector<Segment> const & segments,
+                                   std::vector<platform::CountryFile> & speedcamProhibitedMwms) const;
 
   template <typename Graph>
   RouterResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -126,8 +126,8 @@ private:
 
   /// \brief Fills |speedcamProhibitedMwms| with mwms which are crossed by |segments|
   /// where speed cameras are prohibited.
-  void FillsSpeedcamProhibitedMwms(std::vector<Segment> const & segments,
-                                   std::vector<platform::CountryFile> & speedcamProhibitedMwms) const;
+  void FillSpeedCamProhibitedMwms(std::vector<Segment> const & segments,
+                                  std::vector<platform::CountryFile> & speedCamProhibitedMwms) const;
 
   template <typename Graph>
   RouterResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -368,6 +368,21 @@ double Route::GetSegLenMeters(size_t segIdx) const
          (segIdx == 0 ? 0.0 : m_routeSegments[segIdx - 1].GetDistFromBeginningMeters());
 }
 
+void Route::StealSpeedcamProhibited(vector<platform::CountryFile> && speedcamProhibited)
+{
+  m_speedcamProhibited = move(speedcamProhibited);
+}
+
+bool Route::CrossSpeedcomProhibited() const
+{
+  return m_speedcamProhibited.empty();
+}
+
+std::vector<platform::CountryFile> const & Route::GetSpeedcamProhibited() const
+{
+  return m_speedcamProhibited;
+}
+
 double Route::GetETAToLastPassedPointSec() const
 {
   CHECK(IsValid(), ());

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -368,19 +368,19 @@ double Route::GetSegLenMeters(size_t segIdx) const
          (segIdx == 0 ? 0.0 : m_routeSegments[segIdx - 1].GetDistFromBeginningMeters());
 }
 
-void Route::StealSpeedcamProhibited(vector<platform::CountryFile> && speedcamProhibited)
+void Route::SetMwmsPartlyProhibitedForSpeedCams(vector<platform::CountryFile> && mwms)
 {
-  m_speedcamProhibited = move(speedcamProhibited);
+  m_speedCamProhibitedMwms = move(mwms);
 }
 
-bool Route::CrossSpeedcomProhibited() const
+bool Route::CrossMwmsPartlyProhibitedForSpeedCams() const
 {
-  return m_speedcamProhibited.empty();
+  return m_speedCamProhibitedMwms.empty();
 }
 
-std::vector<platform::CountryFile> const & Route::GetSpeedcamProhibited() const
+std::vector<platform::CountryFile> const & Route::GetMwmsPartlyProhibitedForSpeedCams() const
 {
-  return m_speedcamProhibited;
+  return m_speedCamProhibitedMwms;
 }
 
 double Route::GetETAToLastPassedPointSec() const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -370,17 +370,17 @@ double Route::GetSegLenMeters(size_t segIdx) const
 
 void Route::SetMwmsPartlyProhibitedForSpeedCams(vector<platform::CountryFile> && mwms)
 {
-  m_speedCamProhibitedMwms = move(mwms);
+  m_speedCamPartlyProhibitedMwms = move(mwms);
 }
 
 bool Route::CrossMwmsPartlyProhibitedForSpeedCams() const
 {
-  return m_speedCamProhibitedMwms.empty();
+  return !m_speedCamPartlyProhibitedMwms.empty();
 }
 
 std::vector<platform::CountryFile> const & Route::GetMwmsPartlyProhibitedForSpeedCams() const
 {
-  return m_speedCamProhibitedMwms;
+  return m_speedCamPartlyProhibitedMwms;
 }
 
 double Route::GetETAToLastPassedPointSec() const

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -374,16 +374,15 @@ public:
   /// \returns Length of the route segment with |segIdx| in meters.
   double GetSegLenMeters(size_t segIdx) const;
 
-  /// \brief Moves |speedcamProhibited| to |m_speedcamProhibited|.
-  void StealSpeedcamProhibited(std::vector<platform::CountryFile> && speedcamProhibited);
+  void SetMwmsPartlyProhibitedForSpeedCams(std::vector<platform::CountryFile> && mwms);
 
-  /// \returns true if the route crosses at lease one mwm where there are restrictions on warning
+  /// \returns true if the route crosses at least one mwm where there are restrictions on warning
   /// about speed cameras.
-  bool CrossSpeedcomProhibited() const;
+  bool CrossMwmsPartlyProhibitedForSpeedCams() const;
 
   /// \returns mwm list which is crossed by the route and where there are restrictions on warning
   /// about speed cameras.
-  std::vector<platform::CountryFile> const & GetSpeedcamProhibited() const;
+  std::vector<platform::CountryFile> const & GetMwmsPartlyProhibitedForSpeedCams() const;
 
 private:
   friend std::string DebugPrint(Route const & r);
@@ -417,6 +416,6 @@ private:
   uint64_t m_routeId = 0;
 
   // Mwms which are crossed by the route where speed cameras are prohibited.
-  std::vector<platform::CountryFile> m_speedcamProhibited;
+  std::vector<platform::CountryFile> m_speedCamProhibitedMwms;
 };
 } // namespace routing

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -12,6 +12,8 @@
 
 #include "indexer/feature_altitude.hpp"
 
+#include "platform/country_file.hpp"
+
 #include "geometry/polyline2d.hpp"
 
 #include "base/assert.hpp"
@@ -372,6 +374,17 @@ public:
   /// \returns Length of the route segment with |segIdx| in meters.
   double GetSegLenMeters(size_t segIdx) const;
 
+  /// \brief Moves |speedcamProhibited| to |m_speedcamProhibited|.
+  void StealSpeedcamProhibited(std::vector<platform::CountryFile> && speedcamProhibited);
+
+  /// \returns true if the route crosses at lease one mwm where there are restrictions on warning
+  /// about speed cameras.
+  bool CrossSpeedcomProhibited() const;
+
+  /// \returns mwm list which is crossed by the route and where there are restrictions on warning
+  /// about speed cameras.
+  std::vector<platform::CountryFile> const & GetSpeedcamProhibited() const;
+
 private:
   friend std::string DebugPrint(Route const & r);
 
@@ -402,5 +415,8 @@ private:
   std::vector<SubrouteAttrs> m_subrouteAttrs;
   // Route identifier. It's unique within single program session.
   uint64_t m_routeId = 0;
+
+  // Mwms which are crossed by the route where speed cameras are prohibited.
+  std::vector<platform::CountryFile> m_speedcamProhibited;
 };
 } // namespace routing

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -416,6 +416,6 @@ private:
   uint64_t m_routeId = 0;
 
   // Mwms which are crossed by the route where speed cameras are prohibited.
-  std::vector<platform::CountryFile> m_speedCamProhibitedMwms;
+  std::vector<platform::CountryFile> m_speedCamPartlyProhibitedMwms;
 };
 } // namespace routing

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -428,14 +428,14 @@ namespace
     integration::TestRouteTime(route, 7136.04);
   }
 
-  // Test on removing speed cameras form the route for maps from Jan 2019,
+  // Test on removing speed cameras from the route for maps from Jan 2019,
   // and on the absence of speed cameras in maps for later maps for Switzerland.
   UNIT_TEST(SwitzerlandNoSpeedCamerasInRouteTest)
   {
     TRouteResult const routeResult =
         integration::CalculateRoute(integration::GetVehicleComponents<VehicleType::Car>(),
                                     MercatorBounds::FromLatLon(47.5194, 8.73093), {0., 0.},
-                                    MercatorBounds::FromLatLon(52.6756, 13.2745));
+                                    MercatorBounds::FromLatLon(46.80592, 7.13724));
 
     RouterResultCode const result = routeResult.second;
     TEST_EQUAL(result, RouterResultCode::NoError, ());
@@ -445,9 +445,6 @@ namespace
     auto const & routeSegments = route.GetRouteSegments();
     for (auto const & routeSegment : routeSegments)
     {
-      if (!routeSegment.GetSpeedCams().empty())
-        continue;
-
       TEST(routeSegment.GetSpeedCams().empty(),
            (routeSegment.GetSegment(), routeSegment.GetStreet()));
     }

--- a/routing/speed_camera_prohibition.cpp
+++ b/routing/speed_camera_prohibition.cpp
@@ -1,0 +1,46 @@
+#include "routing/speed_camera_prohibition.hpp"
+
+#include "base/string_utils.hpp"
+
+#include <vector>
+
+namespace
+{
+// List of country names where mwm should be generated without speedcameras.
+std::vector<std::string> kCountryBlockListForMapGeneration = {
+    "Cyprus",
+    "Macedonia",
+    "Switzerland",
+    "Turkey",
+};
+
+// List of country names where an end user should be warned about speedcameras.
+std::vector<std::string> kCountryWarnList = {
+    "France",
+    "Germany",
+};
+
+bool IsMwmContained(platform::CountryFile const & mwm, std::vector<std::string> const & countryList)
+{
+  for (auto const & country : countryList)
+  {
+    if (strings::StartsWith(mwm.GetName(), country))
+      return true;
+  }
+
+  return false;
+}
+}  // namespace
+
+namespace routing
+{
+bool ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile const & mwm)
+{
+  return IsMwmContained(mwm, kCountryBlockListForMapGeneration);
+}
+
+bool ShouldWarnAboutSpeedcam(platform::CountryFile const & mwm)
+{
+  return ShouldRemoveSpeedcamWhileMapGeneration(mwm) || IsMwmContained(mwm, kCountryWarnList);
+}
+} // namespace routing

--- a/routing/speed_camera_prohibition.cpp
+++ b/routing/speed_camera_prohibition.cpp
@@ -6,18 +6,14 @@
 
 namespace
 {
-// List of country names where mwm should be generated without speedcameras.
-std::vector<std::string> kCountryBlockListForMapGeneration = {
-    "Cyprus",
-    "Macedonia",
-    "Switzerland",
-    "Turkey",
+// List of country names where mwm should be generated without speed cameras.
+std::vector<std::string> kSpeedCamerasProhibitedCountries = {
+    "Cyprus", "Macedonia", "Switzerland", "Turkey",
 };
 
-// List of country names where an end user should be warned about speedcameras.
-std::vector<std::string> kCountryWarnList = {
-    "France",
-    "Germany",
+// List of country names where an end user should be warned about speed cameras.
+std::vector<std::string> kSpeedCamerasPartlyProhibitedCountries = {
+    "France", "Germany",
 };
 
 bool IsMwmContained(platform::CountryFile const & mwm, std::vector<std::string> const & countryList)
@@ -34,13 +30,13 @@ bool IsMwmContained(platform::CountryFile const & mwm, std::vector<std::string> 
 
 namespace routing
 {
-bool ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile const & mwm)
+bool AreSpeedCamerasProhibited(platform::CountryFile const & mwm)
 {
-  return IsMwmContained(mwm, kCountryBlockListForMapGeneration);
+  return IsMwmContained(mwm, kSpeedCamerasProhibitedCountries);
 }
 
-bool ShouldWarnAboutSpeedcam(platform::CountryFile const & mwm)
+bool AreSpeedCamerasPartlyProhibited(platform::CountryFile const & mwm)
 {
-  return ShouldRemoveSpeedcamWhileMapGeneration(mwm) || IsMwmContained(mwm, kCountryWarnList);
+  return IsMwmContained(mwm, kSpeedCamerasPartlyProhibitedCountries);
 }
 } // namespace routing

--- a/routing/speed_camera_prohibition.cpp
+++ b/routing/speed_camera_prohibition.cpp
@@ -2,6 +2,7 @@
 
 #include "base/string_utils.hpp"
 
+#include <algorithm>
 #include <vector>
 
 namespace
@@ -18,13 +19,9 @@ std::vector<std::string> kSpeedCamerasPartlyProhibitedCountries = {
 
 bool IsMwmContained(platform::CountryFile const & mwm, std::vector<std::string> const & countryList)
 {
-  for (auto const & country : countryList)
-  {
-    if (strings::StartsWith(mwm.GetName(), country))
-      return true;
-  }
-
-  return false;
+  return std::any_of(countryList.cbegin(), countryList.cend(), [&mwm](auto const & country) {
+    return strings::StartsWith(mwm.GetName(), country);
+  });
 }
 }  // namespace
 

--- a/routing/speed_camera_prohibition.hpp
+++ b/routing/speed_camera_prohibition.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "platform/country_file.hpp"
+
+namespace routing
+{
+/// \returns true if any information about speed cameras is prohibited in |mwm|.
+bool ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile const & mwm);
+
+/// \returns true if any information about speed cameras is prohibited or partly prohibited in |mwm|.
+bool ShouldWarnAboutSpeedcam(platform::CountryFile const & mwm);
+} // namespace routing

--- a/routing/speed_camera_prohibition.hpp
+++ b/routing/speed_camera_prohibition.hpp
@@ -5,8 +5,8 @@
 namespace routing
 {
 /// \returns true if any information about speed cameras is prohibited in |mwm|.
-bool ShouldRemoveSpeedcamWhileMapGeneration(platform::CountryFile const & mwm);
+bool AreSpeedCamerasProhibited(platform::CountryFile const & mwm);
 
 /// \returns true if any information about speed cameras is prohibited or partly prohibited in |mwm|.
-bool ShouldWarnAboutSpeedcam(platform::CountryFile const & mwm);
+bool AreSpeedCamerasPartlyProhibited(platform::CountryFile const & mwm);
 } // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
 		56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56099E301CC9247E00A7772A /* bicycle_directions.cpp */; };
 		56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E311CC9247E00A7772A /* bicycle_directions.hpp */; };
+		5610731B221ABF96008447B2 /* speed_camera_prohibition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */; };
+		5610731C221ABF96008447B2 /* speed_camera_prohibition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */; };
 		56290B87206A3232003892E0 /* routing_algorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B85206A3231003892E0 /* routing_algorithm.cpp */; };
 		56290B88206A3232003892E0 /* routing_algorithm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B86206A3231003892E0 /* routing_algorithm.hpp */; };
 		562BDE2020D14860008EFF6F /* routing_callbacks.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */; };
@@ -387,6 +389,8 @@
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
 		56099E301CC9247E00A7772A /* bicycle_directions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_directions.cpp; sourceTree = "<group>"; };
 		56099E311CC9247E00A7772A /* bicycle_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_directions.hpp; sourceTree = "<group>"; };
+		56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_prohibition.hpp; sourceTree = "<group>"; };
+		5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera_prohibition.cpp; sourceTree = "<group>"; };
 		56290B85206A3231003892E0 /* routing_algorithm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_algorithm.cpp; sourceTree = "<group>"; };
 		56290B86206A3231003892E0 /* routing_algorithm.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_algorithm.hpp; sourceTree = "<group>"; };
 		562BDE1F20D14860008EFF6F /* routing_callbacks.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_callbacks.hpp; sourceTree = "<group>"; };
@@ -812,6 +816,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */,
+				56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */,
 				4408A63721F1E7F0008171B8 /* index_graph_starter_joints.cpp */,
 				4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */,
 				4408A63A21F1E7F0008171B8 /* joint_segment.cpp */,
@@ -1012,6 +1018,7 @@
 				56CA09E61E30E73B00D05C9A /* index_graph_tools.hpp in Headers */,
 				0C81E1581F0258AA00DC66DF /* segmented_route.hpp in Headers */,
 				671F58BE1B874EC80032311E /* followed_polyline.hpp in Headers */,
+				5610731B221ABF96008447B2 /* speed_camera_prohibition.hpp in Headers */,
 				0C5FEC6A1DDE193F0017688C /* road_index.hpp in Headers */,
 				674F9BCD1B0A580E00704FFA /* features_road_graph.hpp in Headers */,
 				40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */,
@@ -1328,6 +1335,7 @@
 				674F9BCC1B0A580E00704FFA /* features_road_graph.cpp in Sources */,
 				0C5FEC5E1DDE192A0017688C /* geometry.cpp in Sources */,
 				674F9BD01B0A580E00704FFA /* online_cross_fetcher.cpp in Sources */,
+				5610731C221ABF96008447B2 /* speed_camera_prohibition.cpp in Sources */,
 				56290B87206A3232003892E0 /* routing_algorithm.cpp in Sources */,
 				670EE5751B664796001E8064 /* router.cpp in Sources */,
 				5670595D1F3AF97F0062672D /* checkpoint_predictor.cpp in Sources */,


### PR DESCRIPTION
Предупреждение о странах, где камеры скорости запрещены. Часть ядра.

https://jira.mail.ru/browse/MAPSME-9708

@gmoryes @alexzatsepin @beloal PTAL

P.S. Так же, планирую добавить routing integration test на добавленные методы.