### PR TITLE
[routing] Switch off speed camera highlighting in case SpeedCameraManagerMode::Never.

### DIFF
--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -215,7 +215,9 @@ void SpeedCameraManager::PassClosestCameraToUI()
   CHECK(m_closestCamera.IsValid(), ("Attempt to show invalid speed cam"));
   // Clear previous speed cam in UI.
   m_speedCamClearCallback();
-  m_speedCamShowCallback(m_closestCamera.m_position, m_closestCamera.m_maxSpeedKmH);
+
+  if (Enable())
+    m_speedCamShowCallback(m_closestCamera.m_position, m_closestCamera.m_maxSpeedKmH);
 }
 
 bool SpeedCameraManager::IsSpeedHigh(double distanceToCameraMeters, double speedMpS,


### PR DESCRIPTION
Когда в меню выбрано "Камера скорости -> Никогда" необходимо отключать подсветку камер скорости на маршруте. Если настройка возвращается в отличное от "Никогда" положение, подсветка должна быть снова включена. 
https://jira.mail.ru/browse/MAPSME-9706

@gmoryes @vmihaylenko PTAL