### PR TITLE
Removing speed cameras from geometry index for Turkey, Switzerland, Macedonia and Cyprus.

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -328,11 +328,13 @@ bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & na
   ForEachFromDatRawFormat(srcFilePath,
                           [&midPoints, &country](FeatureBuilder1 const & ft, uint64_t pos) {
                             // Removing speed cameras from geometry index for some countries.
-                            if (!routing::AreSpeedCamerasProhibited(country) || !ft.IsPoint() ||
-                                !classif().GetTypeByPath({"highway", "speed_camera"}))
+                            if (routing::AreSpeedCamerasProhibited(country) && ft.IsPoint() &&
+                                classif().GetTypeByPath({"highway", "speed_camera"}))
                             {
-                              midPoints(ft, pos);
+                              return;
                             }
+
+                            midPoints(ft, pos);
                           });
 
   // sort features by their middle point


### PR DESCRIPTION
При сборке карт камеры должны теперь удаляться и из геометрии для Turkey, Switzerland, Macedonia and Cyprus. Т.е. на экране не будет даже черных камер в режиме движения в этих странах.

https://jira.mail.ru/browse/MAPSME-9705

@gmoryes @maksimandrianov PTAL