### PR TITLE
Added new user event Move for scrolling the map by buttons.

### DIFF
--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -186,6 +186,11 @@ void DrapeEngine::Scale(double factor, m2::PointD const & pxPoint, bool isAnim)
   AddUserEvent(make_unique_dp<ScaleEvent>(factor, pxPoint, isAnim));
 }
 
+void DrapeEngine::Move(double factorX, double factorY, bool isAnim)
+{
+  AddUserEvent(make_unique_dp<MoveEvent>(factorX, factorY, isAnim));
+}
+
 void DrapeEngine::SetModelViewCenter(m2::PointD const & centerPt, int zoom, bool isAnim,
                                      bool trackVisibleViewport)
 {

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -126,6 +126,7 @@ public:
 
   void AddTouchEvent(TouchEvent const & event);
   void Scale(double factor, m2::PointD const & pxPoint, bool isAnim);
+  void Move(double factorX, double factorY, bool isAnim);
 
   // If zoom == -1 then current zoom will not be changed.
   void SetModelViewCenter(m2::PointD const & centerPt, int zoom, bool isAnim,

--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -177,6 +177,13 @@ ScreenBase const & UserEventStream::ProcessEvents(bool & modelViewChanged, bool 
         TouchCancel(m_touches);
       }
       break;
+    case UserEvent::EventType::Move:
+      {
+        ref_ptr<MoveEvent> moveEvent = make_ref(e);
+        breakAnim = OnMove(moveEvent);
+        TouchCancel(m_touches);
+      }
+      break;
     case UserEvent::EventType::Resize:
       {
         ref_ptr<ResizeEvent> resizeEvent = make_ref(e);
@@ -358,6 +365,21 @@ bool UserEventStream::OnSetScale(ref_ptr<ScaleEvent> scaleEvent)
     m_listener->OnAnimatedScaleEnded();
 
   return true;
+}
+
+bool UserEventStream::OnMove(ref_ptr<MoveEvent> moveEvent)
+{
+  double const factorX = moveEvent->GetFactorX();
+  double const factorY = moveEvent->GetFactorY();
+
+  ScreenBase screen;
+  GetTargetScreen(screen);
+  auto const & rect = screen.PixelRectIn3d();
+  screen.Move(factorX * rect.SizeX(), -factorY * rect.SizeY());
+
+  ShrinkAndScaleInto(screen, df::GetWorldRect());
+
+  return SetScreen(screen, moveEvent->IsAnim());
 }
 
 bool UserEventStream::OnSetAnyRect(ref_ptr<SetAnyRectEvent> anyRectEvent)

--- a/drape_frontend/user_event_stream.hpp
+++ b/drape_frontend/user_event_stream.hpp
@@ -40,7 +40,8 @@ public:
     Rotate,
     FollowAndRotate,
     AutoPerspective,
-    VisibleViewport
+    VisibleViewport,
+    Move
   };
 
   virtual ~UserEvent() = default;
@@ -131,6 +132,27 @@ public:
 private:
   double m_factor;
   m2::PointD m_pxPoint;
+  bool m_isAnim;
+};
+
+class MoveEvent : public UserEvent
+{
+public:
+  MoveEvent(double factorX, double factorY, bool isAnim)
+    : m_factorX(factorX)
+    , m_factorY(factorY)
+    , m_isAnim(isAnim)
+  {}
+
+  EventType GetType() const override { return UserEvent::EventType::Move; }
+
+  double GetFactorX() const { return m_factorX; }
+  double GetFactorY() const { return m_factorY; }
+  bool IsAnim() const { return m_isAnim; }
+
+private:
+  double m_factorX;
+  double m_factorY;
   bool m_isAnim;
 };
 
@@ -402,6 +424,7 @@ public:
 
 private:
   bool OnSetScale(ref_ptr<ScaleEvent> scaleEvent);
+  bool OnMove(ref_ptr<MoveEvent> moveEvent);
   bool OnSetAnyRect(ref_ptr<SetAnyRectEvent> anyRectEvent);
   bool OnSetRect(ref_ptr<SetRectEvent> rectEvent);
   bool OnSetCenter(ref_ptr<SetCenterEvent> centerEvent);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1273,6 +1273,12 @@ void Framework::Scale(double factor, m2::PointD const & pxPoint, bool isAnim)
     m_drapeEngine->Scale(factor, pxPoint, isAnim);
 }
 
+void Framework::Move(double factorX, double factorY, bool isAnim)
+{
+  if (m_drapeEngine != nullptr)
+    m_drapeEngine->Move(factorX, factorY, isAnim);
+}
+
 void Framework::TouchEvent(df::TouchEvent const & touch)
 {
   if (m_drapeEngine != nullptr)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -655,6 +655,12 @@ public:
   void Scale(double factor, bool isAnim);
   void Scale(double factor, m2::PointD const & pxPoint, bool isAnim);
 
+  /// Moves the viewport a distance of factorX * viewportWidth and factorY * viewportHeight.
+  /// E.g. factorX == 1.0 moves the map one screen size to the right, factorX == -0.5 moves the map
+  /// half screen size to the left, factorY == -2.0 moves the map two sizes down,
+  /// factorY = 1.5 moves the map one and a half size up.
+  void Move(double factorX, double factorY, bool isAnim);
+
   void TouchEvent(df::TouchEvent const & touch);
   //@}
 


### PR DESCRIPTION
Для CarPlay потребовалась возможность двигать карту с помощью кнопок вверх/вниз/влево/вправо.
Во фреймворк добавлен метод
`void Framework::Move(double factorX, double factorY, bool isAnim);`
где `factorX` и `factorY` - коэффициенты перемещения по осям.
Например, `factorX == 1.0` перемещает карту на один экран вправо, `factorX == -0.5` на пол-экрана влево, `factorY == 1.5` на полтора экрана вверх, `factorY == -0.33` на треть вниз.
