### PR TITLE
[android] Resource leak in ZipLogTask

### DIFF
--- a/android/src/com/mapswithme/util/log/ZipLogsTask.java
+++ b/android/src/com/mapswithme/util/log/ZipLogsTask.java
@@ -55,11 +55,11 @@ class ZipLogsTask implements Runnable
   private boolean zipFileAtPath(@NonNull String sourcePath, @NonNull String toLocation)
   {
     File sourceFile = new File(sourcePath);
-    try
+    try(FileOutputStream dest = new FileOutputStream(toLocation, false);
+        ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest)))
     {
       BufferedInputStream origin;
-      FileOutputStream dest = new FileOutputStream(toLocation, false);
-      ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest));
+
       if (sourceFile.isDirectory())
       {
         zipSubFolder(out, sourceFile, sourceFile.getParent().length());
@@ -77,7 +77,6 @@ class ZipLogsTask implements Runnable
           out.write(data, 0, count);
         }
       }
-      out.close();
     }
     catch (Exception e)
     {

--- a/android/src/com/mapswithme/util/log/ZipLogsTask.java
+++ b/android/src/com/mapswithme/util/log/ZipLogsTask.java
@@ -64,11 +64,12 @@ class ZipLogsTask implements Runnable
       }
       else
       {
-        byte data[] = new byte[BUFFER_SIZE];
         try(FileInputStream fi = new FileInputStream(sourcePath);
-            BufferedInputStream origin = new BufferedInputStream(fi, BUFFER_SIZE);) {
+            BufferedInputStream origin = new BufferedInputStream(fi, BUFFER_SIZE);)
+        {
           ZipEntry entry = new ZipEntry(getLastPathComponent(sourcePath));
           out.putNextEntry(entry);
+          byte data[] = new byte[BUFFER_SIZE];
           int count;
           while ((count = origin.read(data, 0, BUFFER_SIZE)) != -1) {
             out.write(data, 0, count);


### PR DESCRIPTION
If an exception would be thrown, the streams would not be closed. The use-try-with-resources will close the resources. Therefore, the `out.close()` has also become unnecessary.
Furthermore, some streams were never closed. All resources will now be closed using the try-with-resources statement.

In my commit messages, I falsely used the words 'memory leak' which should have been 'resource leak'.

⚠️ IMPORTANT: This change assumes the use of Java SE7 or higher.