### PR TITLE
Fixed possible NullPointerException mSearchController

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1264,13 +1264,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (mSearchController.hide())
+    if (mSearchController != null && mSearchController.hide())
     {
       SearchEngine.INSTANCE.cancelInteractiveSearch();
       if (mFilterController != null)
         mFilterController.resetFilter();
-      if (mSearchController != null)
-        mSearchController.clear();
+      mSearchController.clear();
       return;
     }
 


### PR DESCRIPTION
nSearchController.hide() could throw a NullPointerException. Furthermore, the check later would then be redundant and should be moved earlier.