### PR TITLE
[android] Removed identical check in equals

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/data/CatalogTag.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/CatalogTag.java
@@ -72,7 +72,7 @@ public class CatalogTag implements Parcelable
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     CatalogTag that = (CatalogTag) o;
-    return mId.equals(that.mId) || mId.equals(that.mId);
+    return mId.equals(that.mId);
   }
 
   @Override


### PR DESCRIPTION
Changes:
* In CatalogTag.java the equals method contained two identical evaluations of equals with an OR. Here I assumed the `mId` to be unique and, therefore, no more checks are required. Alternatively, the `mLocalizedName` could be included in the equality, as well as the `mColor`.