### PR TITLE
[routing] Make restrictions checking faster

### DIFF
--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -265,17 +265,6 @@ void IndexGraph::ReconstructJointSegment(Segment const & parent,
 {
   CHECK_EQUAL(firstChildren.size(), lastPointIds.size(), ());
 
-  auto const step = [this](Segment const & from, Segment const & to, bool isOutgoing, SegmentEdge & edge)
-  {
-    if (IsRestricted(m_restrictions, from, to, isOutgoing))
-      return false;
-
-    RouteWeight weight = CalcSegmentWeight(isOutgoing ? to : from) +
-                         GetPenalties(isOutgoing ? from : to, isOutgoing ? to : from);
-    edge = SegmentEdge(to, weight);
-    return true;
-  };
-
   for (size_t i = 0; i < firstChildren.size(); ++i)
   {
     auto const & firstChild = firstChildren[i];
@@ -296,10 +285,24 @@ void IndexGraph::ReconstructJointSegment(Segment const & parent,
     if (m_roadAccess.GetPointType(parent.GetRoadPoint(isOutgoing)) == RoadAccess::Type::No)
       continue;
 
+    // Check firstChild for UTurn.
+    RoadPoint rp = parent.GetRoadPoint(isOutgoing);
+    if (IsUTurn(parent, firstChild) && m_roadIndex.GetJointId(rp) == Joint::kInvalidId
+        && !m_geometry->GetRoad(parent.GetFeatureId()).IsEndPointId(rp.GetPointId()))
+    {
+      continue;
+    }
+
+    if (parent.GetFeatureId() != firstChild.GetFeatureId() &&
+        IsRestricted(m_restrictions, parent, firstChild, isOutgoing))
+    {
+      continue;
+    }
+
     // Check current JointSegment for bad road access between segments.
+    rp = firstChild.GetRoadPoint(isOutgoing);
     uint32_t start = currentPointId;
     bool noRoadAccess = false;
-    RoadPoint rp = firstChild.GetRoadPoint(isOutgoing);
     do
     {
       if (m_roadAccess.GetPointType(rp) == RoadAccess::Type::No)
@@ -315,44 +318,26 @@ void IndexGraph::ReconstructJointSegment(Segment const & parent,
     if (noRoadAccess)
       continue;
 
-    // Check firstChild for UTurn.
-    rp = parent.GetRoadPoint(isOutgoing);
-    if (IsUTurn(parent, firstChild) && m_roadIndex.GetJointId(rp) == Joint::kInvalidId
-        && !m_geometry->GetRoad(parent.GetFeatureId()).IsEndPointId(rp.GetPointId()))
-    {
-      continue;
-    }
-
     bool forward = currentPointId < lastPointId;
     Segment current = firstChild;
     Segment prev = parent;
-    SegmentEdge edge;
     RouteWeight summaryWeight;
 
-    bool hasRestriction = false;
     do
     {
-      if (step(prev, current, isOutgoing, edge)) // Access ok
-      {
-        if (isOutgoing || prev != parent)
-          summaryWeight += edge.GetWeight();
+      RouteWeight const weight = CalcSegmentWeight(isOutgoing ? current : prev) +
+                                 GetPenalties(isOutgoing ? prev : current, isOutgoing ? current : prev);
 
-        if (prev == parent)
-          parentWeights.emplace_back(edge.GetWeight());
-      }
-      else
-      {
-        hasRestriction = true;
-        break;
-      }
+      if (isOutgoing || prev != parent)
+        summaryWeight += weight;
+
+      if (prev == parent)
+        parentWeights.emplace_back(weight);
 
       prev = current;
       current.Next(forward);
       currentPointId = increment(currentPointId);
     } while (currentPointId != lastPointId);
-
-    if (hasRestriction)
-      continue;
 
     jointEdges.emplace_back(isOutgoing ? JointSegment(firstChild, prev) :
                                          JointSegment(prev, firstChild),


### PR DESCRIPTION
У нас запреты проезда находятся на разных фичах, поэтому 
1) не имеет смысла проверять сегменты одной фичи
2) имеет смысл проверить только один раз в начале построения JointSegment
3) для no_u_turn это и так и так неправильно работает, но сейчас будет быстрее

Для сравнения, если взять длинный маршрут Москва - Минск и построить его в режиме NoLeaps (просто пустить две волны в лоб), то будут такие результаты:
![image](https://user-images.githubusercontent.com/17534533/54188437-bbff6f80-44c0-11e9-9ba6-3185530514dc.png)
![image](https://user-images.githubusercontent.com/17534533/54188458-c7529b00-44c0-11e9-8b52-1e56cac0d2d2.png)
