### PR TITLE
Unnecessary length check removed

### DIFF
--- a/android/src/com/mapswithme/maps/location/PlatformSocket.java
+++ b/android/src/com/mapswithme/maps/location/PlatformSocket.java
@@ -248,7 +248,7 @@ class PlatformSocket
       return false;
     }
 
-    if (data.length < 0 || count < 0 || count > data.length)
+    if (count < 0 || count > data.length)
     {
       LOGGER.e(TAG, "Illegal arguments, data.length = " + data.length + ", count = " + count + "\n");
       return false;


### PR DESCRIPTION
Length can not return a value less than 0, therefore this check is not needed.
Some analysis using Sonar Cube revealed this condition check in the code.

I have signed the CLA btw.