### PR TITLE
[drape] Fixed some buildings rendering

### DIFF
--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -118,21 +118,46 @@ public:
   void operator()(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   void ProcessAreaRule(Stylist::TRuleWrapper const & rule);
 
-private:
-  using TEdge = std::pair<int, int>;
+  struct Edge
+  {
+    Edge() = default;
+    Edge(int startIndex, int endIndex) : m_startIndex(startIndex), m_endIndex(endIndex) {}
 
+    bool operator==(Edge const & edge) const
+    {
+      return (m_startIndex == edge.m_startIndex && m_endIndex == edge.m_endIndex) ||
+        (m_startIndex == edge.m_endIndex && m_endIndex == edge.m_startIndex);
+    }
+
+    int m_startIndex = -1;
+    int m_endIndex = -1;
+  };
+
+  struct ExtendedEdge
+  {
+    ExtendedEdge() = default;
+    ExtendedEdge(Edge && edge, int internalVertexIndex, bool twoSide)
+      : m_edge(std::move(edge))
+      , m_internalVertexIndex(internalVertexIndex)
+      , m_twoSide(twoSide)
+    {}
+
+    Edge m_edge;
+    int m_internalVertexIndex = -1;
+    bool m_twoSide = false;
+  };
+
+private:
   void ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   void CalculateBuildingOutline(bool calculateNormals, BuildingOutline & outline);
   int GetIndex(m2::PointD const & pt);
-  void BuildEdges(int vertexIndex1, int vertexIndex2, int vertexIndex3);
-  bool EqualEdges(TEdge const & edge1, TEdge const & edge2) const;
-  bool FindEdge(TEdge const & edge);
+  void BuildEdges(int vertexIndex1, int vertexIndex2, int vertexIndex3, bool twoSide);
+  bool IsDuplicatedEdge(Edge const & edge);
   m2::PointD CalculateNormal(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3) const;
 
   std::vector<m2::PointD> m_triangles;
-
   buffer_vector<m2::PointD, kBuildingOutlineSize> m_points;
-  buffer_vector<std::pair<TEdge, int>, kBuildingOutlineSize> m_edges;
+  buffer_vector<ExtendedEdge, kBuildingOutlineSize> m_edges;
 
   float const m_minPosZ;
   bool const m_isBuilding;

--- a/drape_frontend/area_shape.cpp
+++ b/drape_frontend/area_shape.cpp
@@ -81,7 +81,7 @@ void AreaShape::DrawArea(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Batch
     {
       glsl::vec2 const pos = glsl::ToVec2(ConvertToLocal(m_buildingOutline.m_vertices[i],
                                                          m_params.m_tileCenter, kShapeCoordScalar));
-      vertices.emplace_back(gpu::AreaVertex(glsl::vec3(pos, m_params.m_depth), ouv));
+      vertices.emplace_back(glsl::vec3(pos, m_params.m_depth), ouv);
     }
 
     auto outlineState = CreateRenderState(gpu::Program::AreaOutline, DepthLayer::GeometryLayer);
@@ -153,20 +153,20 @@ void AreaShape::DrawArea3D(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Bat
                                                          m_params.m_tileCenter, kShapeCoordScalar));
 
     glsl::vec3 normal(glsl::ToVec2(m_buildingOutline.m_normals[i]), 0.0f);
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(startPt, -m_params.m_minPosZ), normal, uv));
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(endPt, -m_params.m_minPosZ), normal, uv));
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(startPt, -m_params.m_posZ), normal, uv));
+    vertexes.emplace_back(glsl::vec3(startPt, -m_params.m_minPosZ), normal, uv);
+    vertexes.emplace_back(glsl::vec3(endPt, -m_params.m_minPosZ), normal, uv);
+    vertexes.emplace_back(glsl::vec3(startPt, -m_params.m_posZ), normal, uv);
 
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(startPt, -m_params.m_posZ), normal, uv));
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(endPt, -m_params.m_minPosZ), normal, uv));
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(endPt, -m_params.m_posZ), normal, uv));
+    vertexes.emplace_back(glsl::vec3(startPt, -m_params.m_posZ), normal, uv);
+    vertexes.emplace_back(glsl::vec3(endPt, -m_params.m_minPosZ), normal, uv);
+    vertexes.emplace_back(glsl::vec3(endPt, -m_params.m_posZ), normal, uv);
   }
 
   glsl::vec3 const normal(0.0f, 0.0f, -1.0f);
   for (auto const & vertex : m_vertexes)
   {
     glsl::vec2 const pt = glsl::ToVec2(ConvertToLocal(vertex, m_params.m_tileCenter, kShapeCoordScalar));
-    vertexes.emplace_back(gpu::Area3dVertex(glsl::vec3(pt, -m_params.m_posZ), normal, uv));
+    vertexes.emplace_back(glsl::vec3(pt, -m_params.m_posZ), normal, uv);
   }
 
   auto state = CreateRenderState(gpu::Program::Area3d, DepthLayer::Geometry3dLayer);

--- a/qt/place_page_dialog.cpp
+++ b/qt/place_page_dialog.cpp
@@ -77,6 +77,9 @@ PlacePageDialog::PlacePageDialog(QWidget * parent, place_page::Info const & info
   }
   if (info.IsFeature())
   {
+    grid->addWidget(new QLabel("Feature ID"), row, 0);
+    grid->addWidget(new QLabel(QString::fromStdString(DebugPrint(info.GetID()))), row++, 1);
+
     grid->addWidget(new QLabel("Raw Types"), row, 0);
     QLabel * label = new QLabel(QString::fromStdString(DebugPrint(info.GetTypes())));
     label->setTextInteractionFlags(Qt::TextSelectableByMouse);


### PR DESCRIPTION
У некоторых 3Д-зданий пропадают стены, так генератор создает для них вырожденные треугольники, для которых нельзя точно определить обход вершин. Если части таких треугольников формируют опоясывающую здания, то создаем ""двухсторонние" полигоны.

https://jira.mail.ru/browse/MAPSME-3018
https://jira.mail.ru/browse/MAPSME-5362