### PR TITLE
[generator] find python with bash

### DIFF
--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -82,6 +82,51 @@ format_version() {
   fi
 }
 
+get_python36() {
+  local pythons=('python' 'python3' 'python3.6' 'python36')
+  local best_version='0'
+  local cur_version='0'
+  local best_python=''
+  for python in ${pythons[@]}; do
+    if command -v "$python" >/dev/null 2>&1 ; then
+      cur_version=`$python -c 'import sys; print("".join(map(str, sys.version_info[:3])))'`
+      if [ "$best_version" \< "$cur_version" ]; then
+        best_version=$cur_version
+        best_python=$python
+      fi
+    fi
+  done
+  if [ "$best_version" \< "360" ]; then
+    echo "Python 3.6 minimum required, found only $best_python";
+    exit
+  fi
+
+  echo $(which $best_python)
+}
+
+get_python2() {
+  local pythons=('python' 'python2' 'python2.6' 'python2.7' 'python26' 'python27')
+  local best_version='0'
+  local cur_version='0'
+  local best_python=''
+  for python in ${pythons[@]}; do
+    if command -v "$python" >/dev/null 2>&1 ; then
+      cur_version=`$python -c 'import sys; print("".join(map(str, sys.version_info[:3])))'`
+      if [ "$best_version" \< "$cur_version" ] && [ $cur_version \< "300" ]; then
+        best_version=$cur_version
+        best_python=$python
+      fi
+    fi
+  done
+
+  if [ "$best_version" = "0" ]; then
+    echo "Can not find python with version >= 2.0";
+    exit
+  fi
+
+  echo $(which $best_python)
+}
+
 # Do not start processing when there are no arguments
 [ $# -eq 0 ] && usage && fail
 # Parse command line parameters
@@ -194,8 +239,8 @@ CITIES_BOUNDARIES_DATA="${CITIES_BOUNDARIES_DATA:-$INTDIR/cities_boundaries.bin}
 BRANDS_TRANSLATIONS_DATA="${BRANDS_TRANSLATIONS_DATA:-$INTDIR/translations_food.json}"
 BRANDS_DATA="${BRANDS_DATA:-$INTDIR/ids_food.json}"
 TESTING_SCRIPT="$SCRIPTS_PATH/test_planet.sh"
-PYTHON="$(which python2.7)"
-PYTHON36="$(which python36)" || PYTHON36="$(which python3.6)"
+PYTHON=$(get_python2)
+PYTHON36=$(get_python36)
 MWM_VERSION_FORMAT="%s"
 COUNTRIES_VERSION_FORMAT="%y%m%d"
 LOG_PATH="${LOG_PATH:-$TARGET/logs}"


### PR DESCRIPTION
В чем проблема - если на какой-то машине нет `python36` или `python3.6`, но есть `python3`, который на самом деле python версии 3.7, то `generate_planet.sh` сразу вылетает, так как `which` возвращает ненулевой код ошибки, этот PR исправляет такое поведение

вывод переменных на mm5:
```bash
/usr/bin/python36
/usr/bin/python2.7
```

На моем маке:
```bash
/opt/local/bin/python
/usr/local/bin//python3
```