### PR TITLE
[search] Load villages from villages min drawable scale while getting search result locality.

### DIFF
--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -313,6 +313,14 @@ string TestPOI::ToDebugString() const
   return os.str();
 }
 
+feature::TypesHolder TestPOI::GetTypes() const
+{
+  feature::TypesHolder types;
+  for (auto const path : m_types)
+    types.Add(classif().GetTypeByPath(path));
+  return types;
+}
+
 // TestMultilingualPOI -----------------------------------------------------------------------------
 TestMultilingualPOI::TestMultilingualPOI(m2::PointD const & center, string const & defaultName,
                                          map<string, string> const & multilingualNames)

--- a/generator/generator_tests_support/test_feature.hpp
+++ b/generator/generator_tests_support/test_feature.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "indexer/feature_data.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/feature_meta.hpp"
 #include "indexer/mwm_set.hpp"
@@ -156,6 +157,7 @@ public:
   void Serialize(FeatureBuilder1 & fb) const override;
   std::string ToDebugString() const override;
 
+  feature::TypesHolder GetTypes() const;
   void SetHouseNumber(std::string const & houseNumber) { m_houseNumber = houseNumber; }
   void SetStreetName(std::string const & name) { m_streetName = name; }
   void SetTypes(std::vector<std::vector<std::string>> const & types) { m_types = types; }

--- a/search/locality_finder.cpp
+++ b/search/locality_finder.cpp
@@ -7,6 +7,7 @@
 
 #include "indexer/data_source.hpp"
 #include "indexer/feature_algo.hpp"
+#include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
 
 #include "base/assert.hpp"
@@ -117,6 +118,25 @@ private:
   LocalityFinder::Holder & m_holder;
   unordered_set<uint32_t> & m_loadedIds;
 };
+
+int GetVillagesScale()
+{
+  auto currentVillagesMinDrawableScale = 0;
+  ftypes::IsVillageChecker::Instance().ForEachType([&currentVillagesMinDrawableScale](uint32_t type)
+  {
+    feature::TypesHolder th;
+    th.Assign(type);
+    currentVillagesMinDrawableScale = max(currentVillagesMinDrawableScale, GetMinDrawableScaleClassifOnly(th));
+  });
+
+  // Needed for backward compatibility. |kCompatibilityVillagesMinDrawableScale| should be set to
+  // maximal value we have in mwms over all data versions.
+  int const kCompatibilityVillagesMinDrawableScale = 13;
+  ASSERT_LESS_OR_EQUAL(
+      currentVillagesMinDrawableScale, kCompatibilityVillagesMinDrawableScale,
+      ("Set kCompatibilityVillagesMinDrawableScale to", currentVillagesMinDrawableScale));
+  return max(currentVillagesMinDrawableScale, kCompatibilityVillagesMinDrawableScale);
+}
 }  // namespace
 
 // LocalityItem ------------------------------------------------------------------------------------
@@ -263,8 +283,9 @@ void LocalityFinder::LoadVicinity(m2::PointD const & p, bool loadCities, bool lo
       if (!handle.IsAlive())
         return;
 
+      static int const scale = GetVillagesScale();
       MwmContext ctx(move(handle));
-      ctx.ForEachIndex(vrect,
+      ctx.ForEachIndex(vrect, scale,
                        LocalitiesLoader(ctx, m_boundariesTable, VillageFilter(ctx, m_villagesCache),
                                         m_villages, m_loadedIds));
     });

--- a/search/mwm_context.hpp
+++ b/search/mwm_context.hpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 class MwmValue;
 
@@ -51,9 +52,15 @@ public:
   void ForEachIndex(m2::RectD const & rect, Fn && fn) const
   {
     uint32_t const scale = m_value.GetHeader().GetLastScale();
+    ForEachIndex(rect, scale, std::forward<Fn>(fn));
+  }
+
+  template <typename Fn>
+  void ForEachIndex(m2::RectD const & rect, uint32_t scale, Fn && fn) const
+  {
     covering::Intervals intervals;
-    CoverRect(rect, scale, intervals);
-    ForEachIndex(intervals, scale, forward<Fn>(fn));
+    CoverRect(rect, m_value.GetHeader().GetLastScale(), intervals);
+    ForEachIndex(intervals, scale, std::forward<Fn>(fn));
   }
 
   template <typename Fn>


### PR DESCRIPTION
При определениии принадлежности результата к деревне сейчас перебираются все фичи на площащи 16км^2 вокруг результата. Для городов это довольно много фичей, это самая дорогая операция после кеширования идентификаторов фичей из вьюпорта (для густо замапленных городов 20-25% от времени первого поиска, дальше может быть лучше, если результаты попадают примерно в те же места).

Предлагается перебирать не все фичи, а только фичи до 13 зум левела, на котором заиндексированы все деревни. Для Москвы это ускоряет этап поиска Locality в 3-4 раза, для Токио в 5-6 раз.