### PR TITLE
[routing] create interface for graph to AStar

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -5,6 +5,8 @@
 #include "generator/routing_helpers.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
+#include "routing/base/astar_graph.hpp"
+
 #include "routing/cross_mwm_connector.hpp"
 #include "routing/cross_mwm_connector_serialization.hpp"
 #include "routing/cross_mwm_ids.hpp"
@@ -201,13 +203,13 @@ private:
   Segment m_start;
 };
 
-class DijkstraWrapperJoints final
+class DijkstraWrapper : public AStarGraph<Segment, SegmentEdge, RouteWeight>
 {
 public:
   // AStarAlgorithm types aliases:
-  using Vertex = JointSegment;
-  using Edge = JointEdge;
-  using Weight = RouteWeight;
+  using Vertex = AStarGraph::Vertex;
+  using Edge = AStarGraph::Edge;
+  using Weight = AStarGraph::Weight;
 
   explicit DijkstraWrapperJoints(IndexGraphWrapper & graph, Segment const & start)
     : m_graph(graph, start) {}
@@ -465,8 +467,9 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
 
     Segment const & enter = connector.GetEnter(i);
 
+    using Algorithm = AStarAlgorithm<JointSegment, JointEdge, RouteWeight>;
 
-    AStarAlgorithm<DijkstraWrapperJoints> astar;
+    Algorithm astar;
     IndexGraphWrapper indexGraphWrapper(graph, enter);
     DijkstraWrapperJoints wrapper(indexGraphWrapper, enter);
     AStarAlgorithm<DijkstraWrapperJoints>::Context context;

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vector>
+
+namespace routing
+{
+template <typename VertexType, typename EdgeType, typename WeightType>
+class AStarGraph
+{
+public:
+
+  using Vertex = VertexType;
+  using Edge = EdgeType;
+  using Weight = WeightType;
+
+  virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) = 0;
+
+  virtual void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
+  virtual void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
+
+  virtual ~AStarGraph() = default;
+};
+}  // namespace routing

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -31,10 +31,6 @@ class FakeEdgesContainer;
 class IndexGraphStarter : public AStarGraph<IndexGraph::Vertex, IndexGraph::Edge, IndexGraph::Weight>
 {
 public:
-  // AStarAlgorithm types aliases:
-  using Vertex = AStarGraph::Vertex;
-  using Edge = AStarGraph::Edge;
-  using Weight = AStarGraph::Weight;
 
   friend class FakeEdgesContainer;
 

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "routing/base/astar_graph.hpp"
 #include "routing/base/routing_result.hpp"
+
 #include "routing/fake_ending.hpp"
 #include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
@@ -26,13 +28,13 @@ namespace routing
 class FakeEdgesContainer;
 
 // IndexGraphStarter adds fake start and finish vertices for AStarAlgorithm.
-class IndexGraphStarter final
+class IndexGraphStarter : public AStarGraph<IndexGraph::Vertex, IndexGraph::Edge, IndexGraph::Weight>
 {
 public:
   // AStarAlgorithm types aliases:
-  using Vertex = IndexGraph::Vertex;
-  using Edge = IndexGraph::Edge;
-  using Weight = IndexGraph::Weight;
+  using Vertex = AStarGraph::Vertex;
+  using Edge = AStarGraph::Edge;
+  using Weight = AStarGraph::Weight;
 
   friend class FakeEdgesContainer;
 
@@ -91,17 +93,17 @@ public:
   void GetEdgesList(Segment const & segment, bool isOutgoing,
                     std::vector<SegmentEdge> & edges) const;
 
-  void GetOutgoingEdgesList(Vertex const & segment, std::vector<Edge> & edges) const
+  void GetOutgoingEdgesList(Vertex const & segment, std::vector<Edge> & edges) override
   {
     GetEdgesList(segment, true /* isOutgoing */, edges);
   }
 
-  void GetIngoingEdgesList(Vertex const & segment, std::vector<Edge> & edges) const
+  void GetIngoingEdgesList(Vertex const & segment, std::vector<Edge> & edges) override
   {
     GetEdgesList(segment, false /* isOutgoing */, edges);
   }
 
-  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to) const
+  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
   {
     return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */),
                                          GetPoint(to, true /* front */));
@@ -119,6 +121,8 @@ public:
 
   RouteWeight CalcSegmentWeight(Segment const & segment) const;
   double CalcSegmentETA(Segment const & segment) const;
+
+  ~IndexGraphStarter() override = default;
 
 private:
   // Start or finish ending information. 

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -26,9 +26,6 @@ template <typename Graph>
 class IndexGraphStarterJoints : public AStarGraph<JointSegment, JointEdge, RouteWeight>
 {
 public:
-  using Vertex = AStarGraph::Vertex;
-  using Edge = AStarGraph::Edge;
-  using Weight = AStarGraph::Weight;
 
   explicit IndexGraphStarterJoints(Graph & graph) : m_graph(graph) {}
   IndexGraphStarterJoints(Graph & graph,

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -572,8 +572,8 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
   auto checkLength = [&starter](RouteWeight const & weight) { return starter.CheckLength(weight); };
 
   base::HighResTimer timer;
-  WorldGraphMode mode = starter.GetGraph().GetMode();
-  if (mode == WorldGraph::Mode::Joints)
+  WorldGraphMode const mode = starter.GetGraph().GetMode();
+  if (mode == WorldGraphMode::Joints)
   {
     IndexGraphStarterJoints<IndexGraphStarter> jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
     RoutingResult<JointSegment, RouteWeight> routingResult;
@@ -595,9 +595,9 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
       delegate.OnPointCheck(pointFrom);
     };
 
-    using Vertex = IndexGraphStarterJoints::Vertex;
-    using Edge = IndexGraphStarterJoints::Edge;
-    using Weight = IndexGraphStarterJoints::Weight;
+    using Vertex = IndexGraphStarterJoints<IndexGraphStarter>::Vertex;
+    using Edge = IndexGraphStarterJoints<IndexGraphStarter>::Edge;
+    using Weight = IndexGraphStarterJoints<IndexGraphStarter>::Weight;
 
     AStarAlgorithm<Vertex, Edge, Weight>::Params params(
       jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(), nullptr /* prevRoute */,
@@ -916,9 +916,9 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
 
     fillMwmIds(start, end, mwmIds);
 
-    using Vertex = IndexGraphStarterJoints::Vertex;
-    using Edge = IndexGraphStarterJoints::Edge;
-    using Weight = IndexGraphStarterJoints::Weight;
+    using Vertex = IndexGraphStarterJoints<IndexGraphStarter>::Vertex;
+    using Edge = IndexGraphStarterJoints<IndexGraphStarter>::Edge;
+    using Weight = IndexGraphStarterJoints<IndexGraphStarter>::Weight;
 
     AStarAlgorithm<Vertex, Edge, Weight>::Params params(
       jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(),

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -143,7 +143,7 @@ private:
   template <typename Vertex, typename Edge, typename Weight>
   RouterResultCode FindPath(
       typename AStarAlgorithm<Vertex, Edge, Weight>::Params & params, std::set<NumMwmId> const & mwmIds,
-      RoutingResult<Vertex, Weight> & routingResult, WorldGraph::Mode mode) const
+      RoutingResult<Vertex, Weight> & routingResult, WorldGraphMode mode) const
   {
     AStarAlgorithm<Vertex, Edge, Weight> algorithm;
     if (mode == WorldGraphMode::LeapsOnly)

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -128,31 +128,31 @@ private:
   void FillSpeedCamProhibitedMwms(std::vector<Segment> const & segments,
                                   std::vector<platform::CountryFile> & speedCamProhibitedMwms) const;
 
-  template <typename Graph>
-  RouterResultCode ConvertResult(typename AStarAlgorithm<Graph>::Result result) const
+  template <typename Vertex, typename Edge, typename Weight>
+  RouterResultCode ConvertResult(typename AStarAlgorithm<Vertex, Edge, Weight>::Result result) const
   {
     switch (result)
     {
-    case AStarAlgorithm<Graph>::Result::NoPath: return RouterResultCode::RouteNotFound;
-    case AStarAlgorithm<Graph>::Result::Cancelled: return RouterResultCode::Cancelled;
-    case AStarAlgorithm<Graph>::Result::OK: return RouterResultCode::NoError;
+    case AStarAlgorithm<Vertex, Edge, Weight>::Result::NoPath: return RouterResultCode::RouteNotFound;
+    case AStarAlgorithm<Vertex, Edge, Weight>::Result::Cancelled: return RouterResultCode::Cancelled;
+    case AStarAlgorithm<Vertex, Edge, Weight>::Result::OK: return RouterResultCode::NoError;
     }
     UNREACHABLE();
   }
 
-  template <typename Graph>
+  template <typename Vertex, typename Edge, typename Weight>
   RouterResultCode FindPath(
-      typename AStarAlgorithm<Graph>::Params & params, std::set<NumMwmId> const & mwmIds,
-      RoutingResult<typename Graph::Vertex, typename Graph::Weight> & routingResult) const
+      typename AStarAlgorithm<Vertex, Edge, Weight>::Params & params, std::set<NumMwmId> const & mwmIds,
+      RoutingResult<Vertex, Weight> & routingResult, WorldGraph::Mode mode) const
   {
-    AStarAlgorithm<Graph> algorithm;
-    if (params.m_graph.GetMode() == WorldGraphMode::LeapsOnly)
+    AStarAlgorithm<Vertex, Edge, Weight> algorithm;
+    if (mode == WorldGraphMode::LeapsOnly)
     {
       return ConvertTransitResult(mwmIds,
-                                  ConvertResult<Graph>(algorithm.FindPath(params, routingResult)));
+                                  ConvertResult<Vertex, Edge, Weight>(algorithm.FindPath(params, routingResult)));
     }
     return ConvertTransitResult(
-        mwmIds, ConvertResult<Graph>(algorithm.FindPathBidirectional(params, routingResult)));
+        mwmIds, ConvertResult<Vertex, Edge, Weight>(algorithm.FindPathBidirectional(params, routingResult)));
   }
 
   VehicleType m_vehicleType;

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -119,6 +119,8 @@ private:
   shared_ptr<TrafficStash> m_trafficStash;
 };
 
+using Algorithm = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
 // Route through XX graph without any traffic info.
 UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
 {
@@ -130,7 +132,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_EmptyTrafficColoring)
   auto const finish = MakeFakeEnding(6, 0, m2::PointD(3.0, 3.0), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XX graph with SpeedGroup::G0 on F3.
@@ -147,7 +149,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3)
   auto const finish = MakeFakeEnding(6, 0, m2::PointD(3.0, 3.0), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XX graph with SpeedGroup::TempBlock on F3.
@@ -164,7 +166,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_TempBlockonF3)
   auto const finish = MakeFakeEnding(6, 0, m2::PointD(3.0, 3.0), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XX graph with SpeedGroup::G0 in reverse direction on F3.
@@ -181,7 +183,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3ReverseDir)
   auto const finish = MakeFakeEnding(6, 0, m2::PointD(3.0, 3.0), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XX graph SpeedGroup::G1 on F3 and F6, SpeedGroup::G4 on F8 and F4.
@@ -204,7 +206,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_G0onF3andF6andG4onF8andF4)
   auto const finish = MakeFakeEnding(6, 0, m2::PointD(3.0, 3.0), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XX graph with changing traffic.
@@ -220,7 +222,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const noTrafficGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   {
-    TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, noTrafficGeom);
+    TestRouteGeometry(*starter, Algorithm::Result::OK, noTrafficGeom);
   }
 
   // Heavy traffic (SpeedGroup::G0) on F3.
@@ -230,7 +232,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
   SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloringHeavyF3));
   {
     vector<m2::PointD> const heavyF3Geom = {{2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
-    TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, heavyF3Geom);
+    TestRouteGeometry(*starter, Algorithm::Result::OK, heavyF3Geom);
   }
 
   // Overloading traffic jam on F3. Middle traffic (SpeedGroup::G3) on F1, F3, F4, F7 and F8.
@@ -247,7 +249,7 @@ UNIT_CLASS_TEST(ApplyingTrafficTest, XXGraph_ChangingTraffic)
        SpeedGroup::G3}};
   SetTrafficColoring(make_shared<TrafficInfo::Coloring const>(coloringMiddleF1F3F4F7F8));
   {
-    TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, noTrafficGeom);
+    TestRouteGeometry(*starter, Algorithm::Result::OK, noTrafficGeom);
   }
 }
 }  // namespace

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -27,9 +27,6 @@ struct Edge
 class UndirectedGraph : public AStarGraph<unsigned, routing_test::Edge, double>
 {
 public:
-  using Vertex = AStarGraph::Vertex;
-  using Edge = AStarGraph::Edge;
-  using Weight = AStarGraph::Weight;
 
   void AddEdge(unsigned u, unsigned v, unsigned w)
   {

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -70,6 +70,8 @@ unique_ptr<SingleVehicleWorldGraph> BuildXYGraph()
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
+using Algorithm = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
 // Route through XY graph without any restrictions.
 UNIT_TEST(XYGraph)
 {
@@ -79,7 +81,7 @@ UNIT_TEST(XYGraph)
   auto const finish = MakeFakeEnding(5, 0, m2::PointD(2, 3), *graph);
   auto starter = MakeStarter(start, finish, *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through XY graph with one restriciton (type only) from F1 to F3.
@@ -94,7 +96,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(1 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -111,7 +113,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(1 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -130,7 +132,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(1 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -153,7 +155,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(1 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -174,7 +176,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
                                      restrictionsNo);
 
   TestRestrictions(
-      {} /* expectedGeom */, AStarAlgorithm<IndexGraphStarter>::Result::NoPath,
+      {} /* expectedGeom */, Algorithm::Result::NoPath,
       MakeFakeEnding(1 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -296,7 +298,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph)
   RestrictionVec restrictions = {};
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(9 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, -1), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictions), *this);
 }
@@ -316,7 +318,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(9 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, -1), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -331,7 +333,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(9 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, -1), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictions), *this);
 }
@@ -356,7 +358,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
   vector<m2::PointD> const expectedGeom = {
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(9 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, -1), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -369,7 +371,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_CheckOnlyRestriction)
   m2::PointD const finish(3.0, 0.2);
   auto const test = [&](vector<m2::PointD> const & expectedGeom, RestrictionVec && restrictionsNo) {
     TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, start, *m_graph),
       MakeFakeEnding(3 /* featureId */, 0 /* segmentIdx */, finish, *m_graph),
       move(restrictionsNo), *this);

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -1,6 +1,8 @@
 #include "testing/testing.hpp"
 
 #include "routing/base/astar_algorithm.hpp"
+#include "routing/base/astar_graph.hpp"
+
 #include "routing/edge_estimator.hpp"
 #include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
@@ -23,12 +25,11 @@
 #include "base/assert.hpp"
 #include "base/math.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/cstdint.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/unordered_map.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 using namespace std;
 
@@ -39,6 +40,8 @@ using namespace routing_test;
 
 using TestEdge = TestIndexGraphTopology::Edge;
 
+using AlgorithmForIndexGraphStarter = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
 double constexpr kUnknownWeight = -1.0;
 
 void TestRoute(FakeEnding const & start, FakeEnding const & finish, size_t expectedLength,
@@ -48,7 +51,7 @@ void TestRoute(FakeEnding const & start, FakeEnding const & finish, size_t expec
   vector<Segment> route;
   double timeSec;
   auto const resultCode = CalculateRoute(*starter, route, timeSec);
-  TEST_EQUAL(resultCode, AStarAlgorithm<IndexGraphStarter>::Result::OK, ());
+  TEST_EQUAL(resultCode, AlgorithmForIndexGraphStarter::Result::OK, ());
 
   TEST_GREATER(route.size(), 2, ());
 
@@ -465,7 +468,7 @@ UNIT_TEST(OneSegmentWayBackward)
   vector<Segment> route;
   double timeSec;
   auto const resultCode = CalculateRoute(*starter, route, timeSec);
-  TEST_EQUAL(resultCode, AStarAlgorithm<IndexGraphStarter>::Result::NoPath, ());
+  TEST_EQUAL(resultCode, AlgorithmForIndexGraphStarter::Result::NoPath, ());
 }
 
 // Roads                             y:
@@ -505,7 +508,7 @@ UNIT_TEST(FakeSegmentCoordinates)
                                          m2::PointD(3, 0), *worldGraph);
 
       auto starter = MakeStarter(start, finish, *worldGraph);
-      TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+      TestRouteGeometry(*starter, AlgorithmForIndexGraphStarter::Result::OK, expectedGeom);
     }
   }
 }
@@ -848,6 +851,6 @@ UNIT_TEST(FinishNearZeroEdge)
 
   vector<m2::PointD> const expectedGeom = {
       {1.0 /* x */, 0.0 /* y */}, {2.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, AlgorithmForIndexGraphStarter::Result::OK, expectedGeom);
 }
 }  // namespace routing_test

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -44,36 +44,6 @@ using namespace routing;
 // It just a noticeable value to detect the source of such id while debuging unit tests.
 NumMwmId constexpr kTestNumMwmId = 777;
 
-class WorldGraphForAStar : public AStarGraph<Segment, SegmentEdge, RouteWeight>
-{
-public:
-  using Vertex = AStarGraph::Vertex;
-  using Edge = AStarGraph::Edge;
-  using Weight = AStarGraph::Weight;
-
-  explicit WorldGraphForAStar(WorldGraph & graph) : m_graph(graph) {}
-
-  Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
-  {
-    return m_graph.HeuristicCostEstimate(from, to);
-  }
-
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
-  {
-    m_graph.GetOutgoingEdgesList(v, edges);
-  }
-
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
-  {
-    m_graph.GetIngoingEdgesList(v, edges);
-  }
-
-  ~WorldGraphForAStar() override = default;
-
-private:
-  WorldGraph & m_graph;
-};
-
 struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -62,6 +62,8 @@ unique_ptr<SingleVehicleWorldGraph> BuildCrossGraph()
   return BuildWorldGraph(move(loader), estimator, joints);
 }
 
+using Algorithm = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 {
   Init(BuildCrossGraph());
@@ -70,7 +72,7 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_NoUTurn)
 
   vector<m2::PointD> const expectedGeom = {
       {-1.0 /* x */, 0.0 /* y */}, {0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}};
-  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*m_starter, Algorithm::Result::OK, expectedGeom);
 }
 
 UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
@@ -85,7 +87,7 @@ UNIT_CLASS_TEST(RestrictionTest, CrossGraph_UTurn)
                                            {1.0, 0.0},  {1.0, 1.0}, {1.0, 2.0}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(-1, 0), *m_graph),
       MakeFakeEnding(7, 0, m2::PointD(1, 2), *m_graph), move(restrictions), *this);
 }
@@ -145,7 +147,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph)
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(5 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), {}, *this);
 }
@@ -160,7 +162,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF2F1)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(5 /* featureId */, 0 /* senmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictions), *this);
 }
@@ -174,7 +176,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(5 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictions), *this);
 }
@@ -191,7 +193,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionOnlyF5F3)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(5 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -213,7 +215,7 @@ UNIT_CLASS_TEST(RestrictionTest, TriangularGraph_RestrictionNoF5F2RestrictionOnl
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(5 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -267,7 +269,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph)
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(3 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), {}, *this);
 }
@@ -281,7 +283,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F2No)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(3 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictions), *this);
 }
@@ -298,7 +300,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwowayCornerGraph_RestrictionF3F1Only)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(3 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(4, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -373,7 +375,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph)
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(10 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(11, 0, m2::PointD(0, 3), *m_graph), {}, *this);
 }
@@ -391,7 +393,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3Only)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {1, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(10 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(11, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -410,7 +412,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF10F3OnlyF3F4Only)
       {3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(10 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(11, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -429,7 +431,7 @@ UNIT_CLASS_TEST(RestrictionTest, TwoSquaresGraph_RestrictionF2F8NoRestrictionF9F
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 1}, {0, 2}, {0, 3}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(10 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(11, 0, m2::PointD(0, 3), *m_graph), move(restrictionsNo), *this);
 }
@@ -487,7 +489,7 @@ UNIT_TEST(FlagGraph)
       MakeStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *graph),
                   MakeFakeEnding(6, 0, m2::PointD(0.5, 1), *graph), *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {0.5, 1}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through flag graph with one restriciton (type no) from F0 to F3.
@@ -500,7 +502,7 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F3No)
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(0.5, 1), *m_graph), move(restrictions), *this);
 }
@@ -514,7 +516,7 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_RestrictionF0F1Only)
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {0.5, 1}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(0.5, 1), *m_graph), move(restrictions), *this);
 }
@@ -537,7 +539,7 @@ UNIT_CLASS_TEST(RestrictionTest, FlagGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F
   vector<m2::PointD> const expectedGeom = {
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(0.5, 1), *m_graph), move(restrictionsNo), *this);
 }
@@ -592,7 +594,7 @@ UNIT_TEST(PosterGraph)
                   MakeFakeEnding(6, 0, m2::PointD(2, 1), *graph), *graph);
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 0}, {1, 1}, {2, 1}};
 
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // Route through poster graph with restrictions F0-F3 (type no).
@@ -605,7 +607,7 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F3No)
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(2, 1), *m_graph), move(restrictions), *this);
 }
@@ -624,7 +626,7 @@ UNIT_CLASS_TEST(RestrictionTest, PosterGraph_RestrictionF0F1Only)
   vector<m2::PointD> const expectedGeom = {
       {2 /* x */, 0 /* y */}, {1, 0}, {0, 0}, {0, 1}, {0.5, 1}, {1, 1}, {2, 1}};
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, 0), *m_graph),
       MakeFakeEnding(6, 0, m2::PointD(2, 1), *m_graph), move(restrictionsNo), *this);
 }
@@ -671,7 +673,7 @@ UNIT_TEST(TwoWayGraph)
                   MakeFakeEnding(2, 0, m2::PointD(4, 0), *graph), *graph);
   vector<m2::PointD> const expectedGeom = {{-1 /* x */, 0 /* y */}, {0, 0}, {1, 0}, {3, 0}, {4, 0}};
 
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // 1          *---F4----*
@@ -720,7 +722,7 @@ UNIT_TEST(SquaresGraph)
       MakeStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *graph),
                   MakeFakeEnding(5, 0, m2::PointD(0, 0), *graph), *graph);
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}};
-  TestRouteGeometry(*starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*starter, Algorithm::Result::OK, expectedGeom);
 }
 
 // It's a test on correct working in case when because of adding restrictions
@@ -740,7 +742,7 @@ UNIT_CLASS_TEST(RestrictionTest, SquaresGraph_RestrictionF0F1OnlyF1F5Only)
   vector<m2::PointD> const expectedGeom = {{3 /* x */, 0 /* y */}, {2, 0}, {1, 0}, {0, 0}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(3, 0), *m_graph),
       MakeFakeEnding(5, 0, m2::PointD(0, 0), *m_graph), move(restrictionsNo), *this);
 }
@@ -782,7 +784,7 @@ UNIT_CLASS_TEST(RestrictionTest, LineGraph_RestrictionF1F1No)
       {0 /* x */, 0 /* y */}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
       MakeFakeEnding(2, 0, m2::PointD(5, 0), *m_graph), move(restrictions), *this);
 }
@@ -835,7 +837,7 @@ UNIT_CLASS_TEST(RestrictionTest, FGraph_RestrictionF0F2Only)
   vector<m2::PointD> const expectedGeom = {{0 /* x */, 0 /* y */}, {0, 1}, {1, 1}};
 
   TestRestrictions(
-      expectedGeom, AStarAlgorithm<IndexGraphStarter>::Result::OK,
+      expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
       MakeFakeEnding(1, 0, m2::PointD(1, 1), *m_graph), move(restrictionsNo), *this);
 }
@@ -889,7 +891,7 @@ UNIT_CLASS_TEST(RestrictionTest, NonPassThroughStart)
 
   SetStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
              MakeFakeEnding(2, 0, m2::PointD(3, 0), *m_graph));
-  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*m_starter, Algorithm::Result::OK, expectedGeom);
 }
 
 UNIT_CLASS_TEST(RestrictionTest, NonPassThroughShortWay)
@@ -901,7 +903,7 @@ UNIT_CLASS_TEST(RestrictionTest, NonPassThroughShortWay)
 
   SetStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
              MakeFakeEnding(2, 0, m2::PointD(3, 0), *m_graph));
-  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*m_starter, Algorithm::Result::OK, expectedGeom);
 }
 
 UNIT_CLASS_TEST(RestrictionTest, NonPassThroughWay)
@@ -911,7 +913,7 @@ UNIT_CLASS_TEST(RestrictionTest, NonPassThroughWay)
 
   SetStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
              MakeFakeEnding(2, 0, m2::PointD(3, 0), *m_graph));
-  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::NoPath, {});
+  TestRouteGeometry(*m_starter, Algorithm::Result::NoPath, {});
 }
 
 UNIT_CLASS_TEST(RestrictionTest, NontransiStartAndShortWay)
@@ -923,6 +925,6 @@ UNIT_CLASS_TEST(RestrictionTest, NontransiStartAndShortWay)
 
   SetStarter(MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0, 0), *m_graph),
              MakeFakeEnding(2, 0, m2::PointD(3, 0), *m_graph));
-  TestRouteGeometry(*m_starter, AStarAlgorithm<IndexGraphStarter>::Result::OK, expectedGeom);
+  TestRouteGeometry(*m_starter, Algorithm::Result::OK, expectedGeom);
 }
 }  // namespace routing_test

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_graph.hpp"
+
 #include "routing/maxspeeds.hpp"
 #include "routing/routing_helpers.hpp"
 
@@ -48,12 +49,9 @@ private:
 using Algorithm = AStarAlgorithm<Junction, WeightedEdge, double>;
 
 /// A wrapper around IRoadGraph, which makes it possible to use IRoadGraph with astar algorithms.
-class RoadGraph : public AStarGraph<Junction, WeightedEdge, double>
+class RoadGraph : public Algorithm::Graph
 {
 public:
-  using Vertex = AStarGraph::Vertex;
-  using Edge = AStarGraph::Edge;
-  using Weight = AStarGraph::Weight;
 
   explicit RoadGraph(IRoadGraph const & roadGraph)
     : m_roadGraph(roadGraph), m_maxSpeedMPS(KMPH2MPS(roadGraph.GetMaxSpeedKMpH()))
@@ -143,7 +141,7 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
   RoadGraph roadGraph(graph);
   base::Cancellable const cancellable;
   Algorithm::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */,
-                                           cancellable, {} /* onVisitJunctionFn */, {} /* checkLength */);
+                           cancellable, {} /* onVisitJunctionFn */, {} /* checkLength */);
   Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
   return Convert(res);
 }


### PR DESCRIPTION
Сейчас есть куча графов и почти каждый пытается использоваться в качестве графа, который можно использовать в AStarAlgorithm.

Points of pr:
1) В процессе работы над restriction, мне необходимо вызывать какие-то методы изнутри AstarAlgorithm, было бы удобно иметь интерфейс, в котором можно прописать методы по умолчанию, и не добавлять в 20 мест по коду ф-ию заглушку (и без добавлений 10-ой лямбды)
2) Это упрощает, на мой взгляд, код, в том в плане, что четко понятно, какой граф у нас используется в AStar, а какой нет.
Например такие вещи, как WorldGraph, которые идеологически не должны быть в AStarAlgorithm, больше в нем и не используются. 
Тот факт, что WorldGraph не используется - это скорее опциональное (можно было и без этого PR сделать), но теперь это явно видно