### PR TITLE
[iOS] fix iOS release build

### DIFF
--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -27,7 +27,7 @@
 
 #ifdef OMIM_PRODUCTION
 
-#import <AppsFlyerTracker/AppsFlyerTracker.h>
+#import <AppsFlyerLib/AppsFlyerTracker.h>
 #import <Crashlytics/Crashlytics.h>
 #import <Fabric/Fabric.h>
 

--- a/iphone/Maps/main.mm
+++ b/iphone/Maps/main.mm
@@ -4,7 +4,7 @@
 #import "MapsAppDelegate.h"
 
 #ifdef OMIM_PRODUCTION
-#import <AppsFlyerTracker/AppsFlyerTracker.h>
+#import <AppsFlyerLib/AppsFlyerTracker.h>
 #include "fabric_logging.hpp"
 #endif
 


### PR DESCRIPTION
AppsFlyer module name has been changed during migration from carthage to cocoapods