### PR TITLE
[generator] [routing] Restrictions

### DIFF
--- a/editor/editor_tests/CMakeLists.txt
+++ b/editor/editor_tests/CMakeLists.txt
@@ -43,6 +43,7 @@ omim_link_libraries(
   icu
   protobuf
   oauthcpp
+  traffic
   ${LIBZ}
   ${Qt5Widgets_LIBRARIES}
 )

--- a/generator/booking_quality_check/CMakeLists.txt
+++ b/generator/booking_quality_check/CMakeLists.txt
@@ -17,6 +17,7 @@ omim_link_libraries(
   generator
   search
   routing
+  traffic
   routing_common
   editor
   indexer

--- a/generator/extract_addr/CMakeLists.txt
+++ b/generator/extract_addr/CMakeLists.txt
@@ -16,6 +16,7 @@ omim_link_libraries(
   generator
   search
   routing
+  traffic
   routing_common
   indexer
   editor

--- a/generator/feature_segments_checker/CMakeLists.txt
+++ b/generator/feature_segments_checker/CMakeLists.txt
@@ -16,6 +16,7 @@ omim_link_libraries(
   ${PROJECT_NAME}
   generator
   routing
+  traffic
   routing_common
   indexer
   platform

--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -28,7 +28,6 @@ set(
   restriction_collector_test.cpp
   restriction_test.cpp
   road_access_test.cpp
-  road_access_test.cpp
   source_data.cpp
   source_data.hpp
   source_to_element_test.cpp

--- a/generator/generator_tests/restriction_test.cpp
+++ b/generator/generator_tests/restriction_test.cpp
@@ -9,6 +9,8 @@
 
 #include "routing/restriction_loader.hpp"
 
+#include "indexer/classificator_loader.hpp"
+
 #include "platform/country_file.hpp"
 #include "platform/platform.hpp"
 #include "platform/platform_tests_support/scoped_dir.hpp"
@@ -19,7 +21,12 @@
 
 #include "base/logging.hpp"
 
+#include <algorithm>
+#include <memory>
 #include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 using namespace std;
 
@@ -43,7 +50,7 @@ void BuildEmptyMwm(LocalCountryFile & country)
   generator::tests_support::TestMwmBuilder builder(country, feature::DataHeader::country);
 }
 
-void LoadRestrictions(string const & mwmFilePath, RestrictionVec & restrictions)
+void LoadRestrictions(string const & mwmFilePath, vector<Restriction> & restrictions)
 {
   FilesContainerR const cont(mwmFilePath);
   if (!cont.IsExist(RESTRICTIONS_FILE_TAG))
@@ -56,9 +63,15 @@ void LoadRestrictions(string const & mwmFilePath, RestrictionVec & restrictions)
     RestrictionHeader header;
     header.Deserialize(src);
 
+    RestrictionVec restrictionsNo;
     RestrictionVec restrictionsOnly;
-    RestrictionSerializer::Deserialize(header, restrictions, restrictionsOnly, src);
-    restrictions.insert(restrictions.end(), restrictionsOnly.cbegin(), restrictionsOnly.cend());
+    RestrictionSerializer::Deserialize(header, restrictionsNo, restrictionsOnly, src);
+
+    for (auto const & r : restrictionsNo)
+      restrictions.emplace_back(Restriction::Type::No, vector<uint32_t>(r.begin(), r.end()));
+
+    for (auto const & r : restrictionsOnly)
+      restrictions.emplace_back(Restriction::Type::Only, vector<uint32_t>(r.begin(), r.end()));
   }
   catch (Reader::OpenException const & e)
   {
@@ -68,16 +81,19 @@ void LoadRestrictions(string const & mwmFilePath, RestrictionVec & restrictions)
 
 /// \brief Generates a restriction section, adds it to an empty mwm,
 /// loads the restriction section and test loaded restrictions.
-/// \param restrictionContent comma separated text with restrictions in osm id terms.
-/// \param mappingContent comma separated text with mapping from osm ids to feature ids.
-void TestRestrictionBuilding(string const & restrictionContent, string const & mappingContent)
+/// \param |restrictionPath| comma separated text with restrictions in osm id terms.
+/// \param |osmIdsToFeatureIdContent| comma separated text with mapping from osm ids to feature ids.
+void TestRestrictionBuilding(string const & restrictionPath,  
+                             string const & osmIdsToFeatureIdContent,
+                             unique_ptr<IndexGraph> graph,
+                             vector<Restriction> & expected)
 {
   Platform & platform = GetPlatform();
   string const writableDir = platform.WritableDir();
 
+  string const targetDir = base::JoinPath(writableDir, kTestDir);
   // Building empty mwm.
-  LocalCountryFile country(base::JoinPath(writableDir, kTestDir), CountryFile(kTestMwm),
-                           0 /* version */);
+  LocalCountryFile country(targetDir, CountryFile(kTestMwm), 0 /* version */);
   ScopedDir const scopedDir(kTestDir);
   string const mwmRelativePath = base::JoinPath(kTestDir, kTestMwm + DATA_FILE_EXTENSION);
   ScopedFile const scopedMwm(mwmRelativePath, ScopedFile::Mode::Create);
@@ -85,86 +101,201 @@ void TestRestrictionBuilding(string const & restrictionContent, string const & m
 
   // Creating a file with restrictions.
   string const restrictionRelativePath = base::JoinPath(kTestDir, kRestrictionFileName);
-  ScopedFile const restrictionScopedFile(restrictionRelativePath, restrictionContent);
+  ScopedFile const restrictionScopedFile(restrictionRelativePath, restrictionPath);
 
   // Creating osm ids to feature ids mapping.
   string const mappingRelativePath = base::JoinPath(kTestDir, kOsmIdsToFeatureIdsName);
   ScopedFile const mappingFile(mappingRelativePath, ScopedFile::Mode::Create);
-  string const mappingFullPath = mappingFile.GetFullPath();
-  ReEncodeOsmIdsToFeatureIdsMapping(mappingContent, mappingFullPath);
+  string const osmIdsToFeatureIdFullPath = mappingFile.GetFullPath();
+  ReEncodeOsmIdsToFeatureIdsMapping(osmIdsToFeatureIdContent, osmIdsToFeatureIdFullPath);
 
-  // Adding restriction section to mwm.
   string const restrictionFullPath = base::JoinPath(writableDir, restrictionRelativePath);
   string const & mwmFullPath = scopedMwm.GetFullPath();
-  BuildRoadRestrictions(mwmFullPath, restrictionFullPath, mappingFullPath);
+
+  // Prepare data to collector.
+  auto restrictionCollector =
+      make_unique<RestrictionCollector>(osmIdsToFeatureIdFullPath, move(graph));
+
+  TEST(restrictionCollector->Process(restrictionFullPath), ("Bad restrictions were given."));
+
+  // Adding restriction section to mwm.
+  SerializeRestrictions(*restrictionCollector, mwmFullPath);
 
   // Reading from mwm section and testing restrictions.
-  RestrictionVec restrictionsFromMwm;
+  vector<Restriction> restrictionsFromMwm;
   LoadRestrictions(mwmFullPath, restrictionsFromMwm);
-  RestrictionCollector const restrictionCollector(restrictionFullPath, mappingFullPath);
 
-  TEST_EQUAL(restrictionsFromMwm, restrictionCollector.GetRestrictions(), ());
+  sort(restrictionsFromMwm.begin(), restrictionsFromMwm.end());
+  sort(expected.begin(), expected.end());
+
+  TEST_EQUAL(restrictionsFromMwm, expected, ());
 }
 
-UNIT_TEST(RestrictionGenerationTest_NoRestriction)
+// 2                 *
+//                ↗     ↘
+//              F5        F4
+//            ↗              ↘                             Finish
+// 1         *                 *<- F3 ->*-> F8 -> *-> F10 -> *
+//            ↖                         ↑       ↗
+//              F6                      F2   F9
+//         Start   ↖                    ↑  ↗
+// 0         *-> F7 ->*-> F0 ->*-> F1 ->*
+//          -1        0        1        2         3          4
+//
+pair<unique_ptr<IndexGraph>, string> BuildTwoCubeGraph()
 {
-  string const restrictionContent = "";
-  string const osmIdsToFeatureIdsContent = "";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  classificator::Load();
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(1 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}}));
+  loader->AddRoad(2 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {2.0, 1.0}}));
+  loader->AddRoad(3 /* feature id */, false /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 1.0}}));
+  loader->AddRoad(4 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 2.0}, {1.0, 1.0}}));
+  loader->AddRoad(5 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{-1.0, 1.0}, {0.0, 2.0}}));
+  loader->AddRoad(6 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {-1.0, 1.0}}));
+  loader->AddRoad(7 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{-1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(8 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 1.0}, {3.0, 1.0}}));
+  loader->AddRoad(9 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 0.0}, {3.0, 1.0}}));
+  loader->AddRoad(10 /* feature id */, true /* one way */, 1.0 /* speed */,
+                  RoadGeometry::Points({{3.0, 1.0}, {4.0, 1.0}}));
+
+  vector<Joint> const joints = {
+      // {{/* feature id */, /* point id */}, ... }
+      MakeJoint({{7, 0}}),                 /* joint at point (-1, 0) */
+      MakeJoint({{0, 0}, {6, 0}, {7, 1}}), /* joint at point (0, 0) */
+      MakeJoint({{0, 1}, {1, 0}}),          /* joint at point (1, 0) */
+      MakeJoint({{1, 1}, {2, 0}, {9, 0}}),  /* joint at point (2, 0) */
+      MakeJoint({{2, 1}, {3, 1}, {8, 0}}),  /* joint at point (2, 1) */
+      MakeJoint({{3, 0}, {4, 1}}),          /* joint at point (1, 1) */
+      MakeJoint({{5, 1}, {4, 0}}),          /* joint at point (0, 2) */
+      MakeJoint({{6, 1}, {5, 0}}),          /* joint at point (-1, 1) */
+      MakeJoint({{8, 1}, {9, 1}, {10, 0}}), /* joint at point (3, 1) */
+      MakeJoint({{10, 1}})                  /* joint at point (4, 1) */
+  };
+
+  traffic::TrafficCache const trafficCache;
+  shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
+
+  string const osmIdsToFeatureIdsContent = R"(0, 0
+                                              1, 1
+                                              2, 2
+                                              3, 3
+                                              4, 4
+                                              5, 5
+                                              6, 6
+                                              7, 7
+                                              8, 8
+                                              9, 9
+                                              10, 10)";
+
+  return {BuildIndexGraph(move(loader), estimator, joints), osmIdsToFeatureIdsContent};
 }
 
-UNIT_TEST(RestrictionGenerationTest_ZeroId)
+UNIT_TEST(RestrictionGenerationTest_1)
 {
-  string const restrictionContent = R"(Only, 0, 0,)";
-  string const osmIdsToFeatureIdsContent = R"(0, 0,)";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  string const restrictionPath =
+      /* Type  ViaType  ViaNodeCoords: x    y   from  to */
+      R"(Only, node,                   1.0, 0.0,  0,  1)";
+
+  vector<Restriction> expected = {
+      {Restriction::Type::Only, {0, 1}}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expected);
 }
 
-UNIT_TEST(RestrictionGenerationTest_OneRestriction)
+UNIT_TEST(RestrictionGenerationTest_2)
 {
-  string const restrictionContent = R"(No, 10, 10,)";
-  string const osmIdsToFeatureIdsContent = R"(10, 1,)";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  string const restrictionPath =
+      /* Type  ViaType from  ViaWayId to */
+      R"(Only, way,      0,     1     2)";
+
+  vector<Restriction> expected = {
+      {Restriction::Type::Only, {0, 1, 2}}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expected);
 }
 
-UNIT_TEST(RestrictionGenerationTest_ThreeRestrictions)
+UNIT_TEST(RestrictionGenerationTest_3)
 {
-  string const restrictionContent = R"(No, 10, 10,
-                                       Only, 10, 20
-                                       Only, 30, 40)";
-  string const osmIdsToFeatureIdsContent = R"(10, 1,
-                                              20, 2
-                                              30, 3,
-                                              40, 4)";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  string const restrictionPath =
+      /* Type  ViaType ViaNodeCoords: x    y   from  to */
+      R"(Only, node,                  0.0, 0.0,  7,   6
+         No,   way,                              2,   8, 10)";
+
+  vector<Restriction> expected = {
+      {Restriction::Type::Only, {7, 6}},
+      {Restriction::Type::No,   {2, 8, 10}}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expected);
 }
 
-UNIT_TEST(RestrictionGenerationTest_SevenRestrictions)
+UNIT_TEST(RestrictionGenerationTest_BadConnection_1)
 {
-  string const restrictionContent = R"(No, 10, 10,
-                                       No, 20, 20,
-                                       Only, 10, 20,
-                                       Only, 20, 30,
-                                       No, 30, 30,
-                                       No, 40, 40,
-                                       Only, 30, 40,)";
-  string const osmIdsToFeatureIdsContent = R"(10, 1,
-                                              20, 2,
-                                              30, 3,
-                                              40, 4)";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  // Here features 7 and 6 don't connect at (2.0, 0.0)
+  string const restrictionPath =
+      /* Type  ViaType ViaNodeCoords: x    y   from  to */
+      R"(Only, node,                  2.0, 0.0,  7,   6
+         No,   way,                              2,   8, 10)";
+
+  // So we don't expect first restriction here.
+  vector<Restriction> expected = {
+      {Restriction::Type::No,   {2, 8, 10}}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expected);
 }
 
-UNIT_TEST(RestrictionGenerationTest_ThereAndMoreLinkRestrictions)
+UNIT_TEST(RestrictionGenerationTest_BadConnection_2)
 {
-  string const restrictionContent = R"(No, 10, 10,
-                                       No, 20, 20,
-                                       Only, 10, 20, 30, 40
-                                       Only, 20, 30, 40)";
-  string const osmIdsToFeatureIdsContent = R"(10, 1,
-                                             20, 2,
-                                             30, 3,
-                                             40, 4)";
-  TestRestrictionBuilding(restrictionContent, osmIdsToFeatureIdsContent);
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  // Here features 0, 1 and 3 don't have common joints (namely 1 and 3).
+  string const restrictionPath =
+      /* Type  ViaType ViaNodeCoords: x    y   from  to */
+      R"(Only, node,                  0.0, 0.0,  7,   6
+         No,   way,                              0,   1, 3)";
+
+  // So we don't expect second restriction here.
+  vector<Restriction> expected = {
+      {Restriction::Type::Only,   {7, 6}}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expected);
 }
 }  // namespace

--- a/generator/generator_tests/restriction_test.cpp
+++ b/generator/generator_tests/restriction_test.cpp
@@ -22,6 +22,7 @@
 #include "base/logging.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -70,16 +70,16 @@ void TestGeometryLoader::SetPassThroughAllowed(uint32_t featureId, bool passThro
   m_roads[featureId].SetPassThroughAllowedForTests(passThroughAllowed);
 }
 
-shared_ptr<EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash)
+std::shared_ptr<EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash)
 {
   auto const carModel = CarModelFactory({}).GetVehicleModel();
   return EdgeEstimator::Create(VehicleType::Car, *carModel, trafficStash);
 }
 
-shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & trafficCache)
+std::shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & trafficCache)
 {
-  auto numMwmIds = make_shared<NumMwmIds>();
-  auto stash = make_shared<TrafficStash>(trafficCache, numMwmIds);
+  auto numMwmIds = std::make_shared<NumMwmIds>();
+  auto stash = std::make_shared<TrafficStash>(trafficCache, numMwmIds);
   return CreateEstimatorForCar(stash);
 }
 

--- a/generator/generator_tests_support/routing_helpers.hpp
+++ b/generator/generator_tests_support/routing_helpers.hpp
@@ -31,8 +31,6 @@ class TestGeometryLoader : public GeometryLoader
 {
 public:
   // GeometryLoader overrides:
-  ~TestGeometryLoader() override = default;
-
   void Load(uint32_t featureId, routing::RoadGeometry & road) override;
 
   void AddRoad(uint32_t featureId, bool oneWay, float speed,

--- a/generator/generator_tests_support/routing_helpers.hpp
+++ b/generator/generator_tests_support/routing_helpers.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
+#include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/joint.hpp"
+
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace generator
 {
@@ -15,3 +24,34 @@ namespace generator
 void ReEncodeOsmIdsToFeatureIdsMapping(std::string const & mappingContent,
                                        std::string const & outputFilePath);
 }  // namespace generator
+
+namespace routing
+{
+class TestGeometryLoader : public GeometryLoader
+{
+public:
+  // GeometryLoader overrides:
+  ~TestGeometryLoader() override = default;
+
+  void Load(uint32_t featureId, routing::RoadGeometry & road) override;
+
+  void AddRoad(uint32_t featureId, bool oneWay, float speed,
+               routing::RoadGeometry::Points const & points);
+
+  void SetPassThroughAllowed(uint32_t featureId, bool passThroughAllowed);
+
+private:
+  std::unordered_map<uint32_t, RoadGeometry> m_roads;
+};
+
+std::shared_ptr<routing::EdgeEstimator> CreateEstimatorForCar(
+    traffic::TrafficCache const & trafficCache);
+std::shared_ptr<routing::EdgeEstimator> CreateEstimatorForCar(std::shared_ptr<TrafficStash> trafficStash);
+
+Joint MakeJoint(std::vector<routing::RoadPoint> const & points);
+
+std::unique_ptr<IndexGraph> BuildIndexGraph(std::unique_ptr<TestGeometryLoader> geometryLoader,
+                                            std::shared_ptr<EdgeEstimator> estimator,
+                                            std::vector<Joint> const & joints);
+}  // namespace routing
+

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -617,9 +617,10 @@ int GeneratorToolMain(int argc, char ** argv)
       string const roadAccessFilename =
           genInfo.GetIntermediateFileName(ROAD_ACCESS_FILENAME);
 
-      routing::BuildRoadRestrictions(datFile, restrictionsFilename, osmToFeatureFilename);
-      routing::BuildRoadAccessInfo(datFile, roadAccessFilename, osmToFeatureFilename);
       routing::BuildRoutingIndex(datFile, country, *countryParentGetter);
+      routing::BuildRoadRestrictions(path, datFile, country, restrictionsFilename, osmToFeatureFilename,
+                                     *countryParentGetter);
+      routing::BuildRoadAccessInfo(datFile, roadAccessFilename, osmToFeatureFilename);
     }
 
     if (FLAGS_make_city_roads)

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -203,6 +203,7 @@ public:
   IntermediateDataReader(std::shared_ptr<PointStorageReaderInterface> nodes,
                          feature::GenerateInfo & info);
 
+  // TODO |GetNode()|, |lat|, |lon| is used as y, x in real.
   bool GetNode(Key id, double & lat, double & lon) const { return m_nodes->GetPoint(id, lat, lon); }
   bool GetWay(Key id, WayElement & e) { return m_ways.Read(id, e); }
   void LoadIndex();

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -203,7 +203,7 @@ public:
   IntermediateDataReader(std::shared_ptr<PointStorageReaderInterface> nodes,
                          feature::GenerateInfo & info);
 
-  // TODO |GetNode()|, |lat|, |lon| is used as y, x in real.
+  // TODO |GetNode()|, |lat|, |lon| are used as y, x in real.
   bool GetNode(Key id, double & lat, double & lon) const { return m_nodes->GetPoint(id, lat, lon); }
   bool GetWay(Key id, WayElement & e) { return m_ways.Read(id, e); }
   void LoadIndex();

--- a/generator/restaurants_info/CMakeLists.txt
+++ b/generator/restaurants_info/CMakeLists.txt
@@ -17,6 +17,7 @@ omim_link_libraries(
   generator
   search
   routing
+  traffic
   routing_common
   editor
   indexer

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "boost/optional.hpp"
+
 namespace
 {
 using namespace routing;
@@ -46,17 +48,13 @@ namespace routing
 {
 m2::PointD constexpr RestrictionCollector::kNoCoords;
 
-bool RestrictionCollector::PrepareOsmIdToFeatureId(string const & osmIdsToFeatureIdPath)
+RestrictionCollector::RestrictionCollector(string const & osmIdsToFeatureIdPath,
+                                           std::unique_ptr<IndexGraph> && graph)
+  : m_indexGraph(std::move(graph))
 {
-  if (!ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdPath, m_osmIdToFeatureId))
-  {
-    LOG(LWARNING, ("An error happened while parsing feature id to osm ids mapping from file:",
-                   osmIdsToFeatureIdPath));
-    m_osmIdToFeatureId.clear();
-    return false;
-  }
-
-  return true;
+  CHECK(ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdPath, m_osmIdToFeatureId),
+        ("An error happened while parsing feature id to "
+         "osm ids mapping from file:", osmIdsToFeatureIdPath));
 }
 
 bool RestrictionCollector::Process(std::string const & restrictionPath)

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -48,7 +48,7 @@ namespace routing
 {
 m2::PointD constexpr RestrictionCollector::kNoCoords;
 
-RestrictionCollector::RestrictionCollector(string const & osmIdsToFeatureIdPath,
+RestrictionCollector::RestrictionCollector(std::string const & osmIdsToFeatureIdPath,
                                            std::unique_ptr<IndexGraph> && graph)
   : m_indexGraph(std::move(graph))
 {
@@ -259,8 +259,6 @@ void FromString(std::string const & str, RestrictionWriter::ViaType & type)
 
 void FromString(std::string const & str, double & number)
 {
-  std::stringstream ss;
-  ss << str;
-  ss >> number;
+  CHECK(strings::to_double(str.c_str(), number), ());
 }
 }  // namespace routing

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -94,7 +94,7 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
       return false;
 
     Restriction::Type restrictionType;
-    auto viaType = RestrictionWriter::ViaType::Max;
+    auto viaType = RestrictionWriter::ViaType::Count;
     FromString(*iter, restrictionType);
     ++iter;
 
@@ -120,7 +120,7 @@ bool RestrictionCollector::ParseRestrictions(string const & path)
     if (viaType == RestrictionWriter::ViaType::Node)
       CHECK_EQUAL(osmIds.size(), 2, ("Only |from| and |to| osmId."));
 
-    CHECK_NOT_EQUAL(viaType, RestrictionWriter::ViaType::Max, ());
+    CHECK_NOT_EQUAL(viaType, RestrictionWriter::ViaType::Count, ());
     AddRestriction(coords, restrictionType, osmIds);
   }
   return true;

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -20,16 +20,14 @@
 
 namespace routing
 {
+class TestRestrictionCollector;
 /// This class collects all relations with type restriction and save feature ids of
 /// their road feature in text file for using later.
 class RestrictionCollector
 {
 public:
-  RestrictionCollector() = default;
-
-  bool PrepareOsmIdToFeatureId(std::string const & osmIdsToFeatureIdPath);
-
-  void SetIndexGraphForTest(std::unique_ptr<IndexGraph> graph) { m_indexGraph = std::move(graph); }
+  RestrictionCollector(string const & osmIdsToFeatureIdPath,
+                       std::unique_ptr<IndexGraph> && graph);
 
   bool Process(std::string const & restrictionPath);
 
@@ -39,13 +37,10 @@ public:
   std::vector<Restriction> const & GetRestrictions() const { return m_restrictions; }
 
 private:
+  friend class TestRestrictionCollector;
+
   static m2::PointD constexpr kNoCoords =
       m2::PointD(std::numeric_limits<double>::max(), std::numeric_limits<double>::max());
-
-  friend void UnitTest_RestrictionTest_ValidCase();
-  friend void UnitTest_RestrictionTest_InvalidCase();
-  friend void UnitTest_RestrictionTest_InvalidCase_NoSuchFeature();
-  friend void UnitTest_RestrictionTest_InvalidCase_FeaturesNotIntersecting();
 
   /// \brief Parses comma separated text file with line in following format:
   /// In case of restriction, that consists of "way(from)" -> "node(via)" -> "way(to)"

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -4,6 +4,9 @@
 
 #include "routing/index_graph_loader.hpp"
 
+#include "routing_common/car_model.cpp"
+#include "routing_common/vehicle_model.hpp"
+
 #include "platform/country_file.hpp"
 #include "platform/local_country_file.hpp"
 
@@ -60,10 +63,8 @@ CreateRestrictionCollectorAndParse(
   std::unique_ptr<IndexGraph> graph
     = CreateIndexGraph(targetPath, mwmPath, country, countryParentNameGetterFn);
 
-  auto restrictionCollector = std::make_unique<RestrictionCollector>();
-  if (!restrictionCollector->PrepareOsmIdToFeatureId(osmIdsToFeatureIdsPath))
-    return {};
-
+  auto restrictionCollector =
+      std::make_unique<RestrictionCollector>(osmIdsToFeatureIdsPath, std::move(graph));
 
   if (!restrictionCollector->Process(restrictionPath))
     return {};

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -28,6 +28,7 @@
 namespace
 {
 using namespace routing;
+
 std::unique_ptr<IndexGraph>
 CreateIndexGraph(std::string const & targetPath,
                  std::string const & mwmPath,

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -33,7 +34,7 @@ CreateIndexGraph(std::string const & targetPath,
                  std::string const & country,
                  CountryParentNameGetterFn const & countryParentNameGetterFn)
 {
-  shared_ptr<VehicleModelInterface> vehicleModel =
+  std::shared_ptr<VehicleModelInterface> vehicleModel =
       CarModelFactory(countryParentNameGetterFn).GetVehicleModelForCountry(country);
 
   MwmValue mwmValue(
@@ -60,8 +61,8 @@ CreateRestrictionCollectorAndParse(
   LOG(LDEBUG, ("BuildRoadRestrictions(", targetPath, ", ", restrictionPath, ", ",
                                          osmIdsToFeatureIdsPath, ");"));
 
-  std::unique_ptr<IndexGraph> graph
-    = CreateIndexGraph(targetPath, mwmPath, country, countryParentNameGetterFn);
+  std::unique_ptr<IndexGraph> graph =
+      CreateIndexGraph(targetPath, mwmPath, country, countryParentNameGetterFn);
 
   auto restrictionCollector =
       std::make_unique<RestrictionCollector>(osmIdsToFeatureIdsPath, std::move(graph));

--- a/generator/restriction_generator.hpp
+++ b/generator/restriction_generator.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
+#include "generator/restriction_collector.hpp"
+#include "generator/routing_index_generator.hpp"
+
+#include <memory>
 #include <string>
 
 namespace routing
 {
+std::unique_ptr<RestrictionCollector>
+CreateRestrictionCollectorAndParse(
+    std::string const & targetPath, std::string const & mwmPath, std::string const & country,
+    std::string const & restrictionPath, std::string const & osmIdsToFeatureIdsPath,
+    CountryParentNameGetterFn const & countryParentNameGetterFn);
+
+void SerializeRestrictions(RestrictionCollector const & restrictionCollector,
+                           std::string const & mwmPath);
 // This function is the generator tool's interface to building the mwm
 // section which contains road restrictions. (See https://wiki.openstreetmap.org/wiki/Restriction)
 // As long as the restrictions are built later than the road features themselves
@@ -29,6 +41,10 @@ namespace routing
 /// \param osmIdsToFeatureIdsPath a binary file with mapping form osm ids to feature ids.
 /// One osm id is mapped to one feature id. The file should be saved with the help of
 /// OsmID2FeatureID class or using a similar way.
-bool BuildRoadRestrictions(std::string const & mwmPath, std::string const & restrictionPath,
-                           std::string const & osmIdsToFeatureIdsPath);
+bool BuildRoadRestrictions(std::string const & targetPath,
+                           std::string const & mwmPath,
+                           std::string const & country,
+                           std::string const & restrictionPath,
+                           std::string const & osmIdsToFeatureIdsPath,
+                           CountryParentNameGetterFn const & countryParentNameGetterFn);
 }  // namespace routing

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -201,7 +201,7 @@ std::string DebugPrint(RestrictionWriter::ViaType const & type)
   {
   case RestrictionWriter::ViaType::Node: return RestrictionWriter::kNodeString;
   case RestrictionWriter::ViaType::Way: return RestrictionWriter::kWayString;
-  case RestrictionWriter::ViaType::Max: CHECK(false, ());
+  case RestrictionWriter::ViaType::Max: UNREACHABLE();
   }
   UNREACHABLE();
 }

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -201,7 +201,7 @@ std::string DebugPrint(RestrictionWriter::ViaType const & type)
   {
   case RestrictionWriter::ViaType::Node: return RestrictionWriter::kNodeString;
   case RestrictionWriter::ViaType::Way: return RestrictionWriter::kWayString;
-  case RestrictionWriter::ViaType::Max: UNREACHABLE();
+  case RestrictionWriter::ViaType::Count: UNREACHABLE();
   }
   UNREACHABLE();
 }

--- a/generator/restriction_writer.hpp
+++ b/generator/restriction_writer.hpp
@@ -19,7 +19,7 @@ public:
     Node,
     Way,
 
-    Max,
+    Count,
   };
 
   static std::string const kNodeString;
@@ -28,8 +28,11 @@ public:
   RestrictionWriter(std::string const & fullPath,
                     generator::cache::IntermediateDataReader const & cache);
 
+  // generator::CollectorInterface overrides:
+  // @{
   void CollectRelation(RelationElement const & relationElement) override;
   void Save() override {}
+  // @}
 
   static ViaType ConvertFromString(std::string const & str);
 

--- a/generator/restriction_writer.hpp
+++ b/generator/restriction_writer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "generator/collector_interface.hpp"
+#include "generator/intermediate_data.hpp"
 
 #include <fstream>
 #include <string>
@@ -12,20 +13,32 @@ namespace routing
 class RestrictionWriter : public generator::CollectorInterface
 {
 public:
-  RestrictionWriter(std::string const & fullPath);
-  // CollectorRelationsInterface overrides:
-  /// \brief Writes |relationElement| to |m_stream| if |relationElement| is a supported restriction.
-  /// See restriction_generator.hpp for the description of the format.
-  /// \note For the time being only line-point-line restrictions are processed. The other
-  /// restrictions are ignored.
-  // @TODO(bykoianko) It's necessary to process all kind of restrictions.
+
+  enum class ViaType
+  {
+    Node,
+    Way,
+  };
+
+  static std::string const kNodeString;
+  static std::string const kWayString;
+
+  RestrictionWriter(std::string const & fullPath,
+                    generator::cache::IntermediateDataReader const & cache);
+
   void CollectRelation(RelationElement const & relationElement) override;
   void Save() override {}
+
+  static ViaType ConvertFromString(std::string const & str);
 
 private:
   void Open(std::string const & fullPath);
   bool IsOpened() const;
 
   std::ofstream m_stream;
+  generator::cache::IntermediateDataReader const & m_cache;
 };
+
+std::string DebugPrint(RestrictionWriter::ViaType const & type);
 }  // namespace routing
+

--- a/generator/restriction_writer.hpp
+++ b/generator/restriction_writer.hpp
@@ -18,6 +18,8 @@ public:
   {
     Node,
     Way,
+
+    Max,
   };
 
   static std::string const kNodeString;

--- a/generator/srtm_coverage_checker/CMakeLists.txt
+++ b/generator/srtm_coverage_checker/CMakeLists.txt
@@ -16,6 +16,7 @@ omim_link_libraries(
   ${PROJECT_NAME}
   generator
   routing
+  traffic
   routing_common
   indexer
   platform

--- a/generator/translator_country.cpp
+++ b/generator/translator_country.cpp
@@ -85,7 +85,7 @@ TranslatorCountry::TranslatorCountry(std::shared_ptr<EmitterInterface> emitter, 
 
   // These are the four collector that collect additional information for the future building of routing section.
   AddCollector(std::make_shared<MaxspeedsCollector>(info.GetIntermediateFileName(MAXSPEEDS_FILENAME)));
-  AddCollector(std::make_shared<routing::RestrictionWriter>(info.GetIntermediateFileName(RESTRICTIONS_FILENAME)));
+  AddCollector(std::make_shared<routing::RestrictionWriter>(info.GetIntermediateFileName(RESTRICTIONS_FILENAME), cache));
   AddCollector(std::make_shared<routing::RoadAccessWriter>(info.GetIntermediateFileName(ROAD_ACCESS_FILENAME)));
   AddCollector(std::make_shared<routing::CameraCollector>(info.GetIntermediateFileName(CAMERAS_TO_WAYS_FILENAME)));
 

--- a/geometry/point2d.hpp
+++ b/geometry/point2d.hpp
@@ -22,12 +22,12 @@ public:
 
   T x, y;
 
-  Point() : x(T()), y(T()) {}
+  constexpr Point() : x(T()), y(T()) {}
 
-  Point(T x_, T y_) : x(x_), y(y_) {}
+  constexpr Point(T x_, T y_) : x(x_), y(y_) {}
 
   template <typename U>
-  explicit Point(Point<U> const & u) : x(u.x), y(u.y)
+  explicit constexpr Point(Point<U> const & u) : x(u.x), y(u.y)
   {
   }
 

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -66,6 +66,7 @@ omim_link_libraries(
   opening_hours
   oauthcpp
   pugixml
+  traffic
   ${LIBZ}
 )
 

--- a/map/map_integration_tests/CMakeLists.txt
+++ b/map/map_integration_tests/CMakeLists.txt
@@ -36,6 +36,7 @@ omim_link_libraries(
   pugixml
   opening_hours
   icu
+  traffic
   ${Qt5Network_LIBRARIES}
   ${LIBZ}
 )

--- a/openlr/openlr_tests/CMakeLists.txt
+++ b/openlr/openlr_tests/CMakeLists.txt
@@ -32,6 +32,7 @@ omim_link_libraries(
   succinct
   protobuf
   icu
+  traffic
   ${Qt5Core_LIBRARIES}
   ${LIBZ}
 )

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <vector>
 
 namespace routing
@@ -13,11 +14,29 @@ public:
   using Edge = EdgeType;
   using Weight = WeightType;
 
+  using Parents = std::map<Vertex, Vertex>;
+
   virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) = 0;
 
   virtual void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
   virtual void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
 
+  virtual void SetAStarParents(bool forward, Parents & parents);
+  virtual bool AreWavesConnectible(Parents & forwardParents, Vertex const & commonVertex,
+                                   Parents & backwardParents);
+
   virtual ~AStarGraph() = default;
 };
+
+template <typename VertexType, typename EdgeType, typename WeightType>
+void AStarGraph<VertexType, EdgeType, WeightType>::SetAStarParents(bool /* forward */,
+                                                                   std::map<Vertex, Vertex> & /* parents */) {}
+
+template <typename VertexType, typename EdgeType, typename WeightType>
+bool AStarGraph<VertexType, EdgeType, WeightType>::AreWavesConnectible(AStarGraph::Parents & /* forwardParents */,
+                                                                       Vertex const & /* commonVertex */,
+                                                                       AStarGraph::Parents & /* backwardParents */)
+{
+  return true;
+}
 }  // namespace routing

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/routing_helpers.hpp"
 
+#include "traffic/speed_groups.hpp"
 #include "traffic/traffic_info.hpp"
 
 #include "indexer/feature_altitude.hpp"

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -129,7 +129,7 @@ IndexGraph::GetJointEdgeByLastPoint(Segment const & parent, Segment const & firs
   vector<JointEdge> edges;
   vector<RouteWeight> parentWeights;
   map<JointSegment, JointSegment> emptyParents;
-  ReconstructJointSegment({}, parent, possibleChilds, lastPoints,
+  ReconstructJointSegment({} /* parentJoint */, parent, possibleChilds, lastPoints,
                           isOutgoing, edges, parentWeights, emptyParents);
 
   CHECK_LESS_OR_EQUAL(edges.size(), 1, ());

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -163,10 +163,10 @@ void IndexGraph::SetRestrictions(RestrictionVec && restrictions)
   {
     ASSERT(!restriction.empty(), ());
     auto & forward = m_restrictionsForward[restriction.back()];
-    forward.emplace_back(restriction.begin(), std::prev(restriction.end()));
-    std::reverse(forward.back().begin(), forward.back().end());
+    forward.emplace_back(restriction.begin(), prev(restriction.end()));
+    reverse(forward.back().begin(), forward.back().end());
 
-    m_restrictionsBackward[restriction.front()].emplace_back(std::next(restriction.begin()), restriction.end());
+    m_restrictionsBackward[restriction.front()].emplace_back(next(restriction.begin()), restriction.end());
   }
 
   LOG(LDEBUG, ("Restrictions are loaded in:", timer.ElapsedNano() / 1e6, "ms"));

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -19,6 +19,9 @@
 #include <utility>
 #include <vector>
 
+#include <map>
+#include <memory>
+
 #include <boost/optional.hpp>
 
 namespace routing

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <memory>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/routing/joint_segment.cpp
+++ b/routing/joint_segment.cpp
@@ -8,7 +8,7 @@
 
 namespace routing
 {
-bool IsRealSegment(Segment const & segment)
+bool IsRealSegmentSimple(Segment const & segment)
 {
   return segment.GetFeatureId() != FakeFeatureIds::kIndexGraphStarterId;
 }
@@ -17,7 +17,7 @@ JointSegment::JointSegment(Segment const & from, Segment const & to)
 {
   // Can not check segment for fake or not with segment.IsRealSegment(), because all segments
   // have got fake m_numMwmId during mwm generation.
-  CHECK(IsRealSegment(from) && IsRealSegment(to),
+  CHECK(IsRealSegmentSimple(from) && IsRealSegmentSimple(to),
         ("Segments of joints can not be fake. Only through ToFake() method."));
 
   CHECK_EQUAL(from.GetMwmId(), to.GetMwmId(), ("Different mwmIds in segments for JointSegment"));

--- a/routing/joint_segment.hpp
+++ b/routing/joint_segment.hpp
@@ -20,10 +20,10 @@ public:
   JointSegment() = default;
   JointSegment(Segment const & from, Segment const & to);
 
-  uint32_t & GetFeatureId() { return m_featureId; }
+  void SetFeatureId(uint32_t id) { m_featureId = id; }
   uint32_t GetFeatureId() const { return m_featureId; }
   NumMwmId GetMwmId() const { return m_numMwmId; }
-  NumMwmId & GetMwmId() { return m_numMwmId; }
+  void SetMwmId(NumMwmId id) { m_numMwmId = id; }
   uint32_t GetStartSegmentId() const { return m_startSegmentId; }
   uint32_t GetEndSegmentId() const { return m_endSegmentId; }
   uint32_t GetSegmentId(bool start) const { return start ? m_startSegmentId : m_endSegmentId; }
@@ -31,6 +31,7 @@ public:
 
   void ToFake(uint32_t fakeId);
   bool IsFake() const;
+  bool IsRealSegment() const { return !IsFake(); }
 
   Segment GetSegment(bool start) const
   {

--- a/routing/restriction_loader.cpp
+++ b/routing/restriction_loader.cpp
@@ -49,7 +49,8 @@ RestrictionLoader::RestrictionLoader(MwmValue const & mwmValue, IndexGraph const
 
   try
   {
-    m_reader = make_unique<FilesContainerR::TReader>(mwmValue.m_cont.GetReader(RESTRICTIONS_FILE_TAG));
+    m_reader =
+        std::make_unique<FilesContainerR::TReader>(mwmValue.m_cont.GetReader(RESTRICTIONS_FILE_TAG));
     ReaderSource<FilesContainerR::TReader> src(*m_reader);
     m_header.Deserialize(src);
 

--- a/routing/restriction_loader.hpp
+++ b/routing/restriction_loader.hpp
@@ -17,8 +17,8 @@ class RestrictionLoader
 public:
   explicit RestrictionLoader(MwmValue const & mwmValue, IndexGraph const & graph);
 
-  bool HasRestrictions() const { return !m_restrictions.empty(); }
-  RestrictionVec && StealRestrictions() { return move(m_restrictions); }
+  bool HasRestrictions() const;
+  RestrictionVec && StealRestrictions();
 
 private:
   std::unique_ptr<FilesContainerR::TReader> m_reader;
@@ -28,6 +28,6 @@ private:
 };
 
 void ConvertRestrictionsOnlyToNoAndSort(IndexGraph const & graph,
-                                        RestrictionVec const & restrictionsOnly,
+                                        RestrictionVec & restrictionsOnly,
                                         RestrictionVec & restrictionsNo);
 }  // namespace routing

--- a/routing/restrictions_serialization.cpp
+++ b/routing/restrictions_serialization.cpp
@@ -15,12 +15,6 @@ namespace routing
 // static
 uint32_t const Restriction::kInvalidFeatureId = numeric_limits<uint32_t>::max();
 
-bool Restriction::IsValid() const
-{
-  return !m_featureIds.empty() &&
-         find(begin(m_featureIds), end(m_featureIds), kInvalidFeatureId) == end(m_featureIds);
-}
-
 bool Restriction::operator==(Restriction const & restriction) const
 {
   return m_featureIds == restriction.m_featureIds && m_type == restriction.m_type;
@@ -33,7 +27,7 @@ bool Restriction::operator<(Restriction const & restriction) const
   return m_featureIds < restriction.m_featureIds;
 }
 
-string ToString(Restriction::Type const & type)
+string DebugPrint(Restriction::Type const & type)
 {
   switch (type)
   {
@@ -43,13 +37,17 @@ string ToString(Restriction::Type const & type)
   return "Unknown";
 }
 
-string DebugPrint(Restriction::Type const & type) { return ToString(type); }
-
 string DebugPrint(Restriction const & restriction)
 {
   ostringstream out;
-  out << "m_featureIds:[" << ::DebugPrint(restriction.m_featureIds)
-      << "] m_type:" << DebugPrint(restriction.m_type) << " ";
+  out << "[" << DebugPrint(restriction.m_type) << "]: {";
+  for (size_t i = 0; i < restriction.m_featureIds.size(); ++i)
+  {
+    out << restriction.m_featureIds[i];
+    if (i + 1 != restriction.m_featureIds.size())
+      out << ", ";
+  }
+  out << "}";
   return out.str();
 }
 }  // namespace routing

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -1,6 +1,6 @@
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
-#include "routing/routing_tests/index_graph_tools.hpp"
+#include "routing_common/index_graph_tools.hpp"
 
 #include "testing/testing.hpp"
 

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -1,6 +1,6 @@
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
-#include "routing_common/index_graph_tools.hpp"
+#include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "testing/testing.hpp"
 

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -63,6 +63,7 @@ omim_link_libraries(
   succinct
   stats_client
   icu
+  generator_tests_support
 
   ${LIBZ}
 )

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -6,7 +6,7 @@
 #include "routing/index_graph_starter.hpp"
 #include "routing/routing_session.hpp"
 
-#include "routing/routing_tests/index_graph_tools.hpp"
+#include "routing_common/index_graph_tools.hpp"
 
 #include "traffic/traffic_info.hpp"
 

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -6,7 +6,7 @@
 #include "routing/index_graph_starter.hpp"
 #include "routing/routing_session.hpp"
 
-#include "routing_common/index_graph_tools.hpp"
+#include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "traffic/traffic_info.hpp"
 

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests_support/routing_helpers.hpp"
+
 #include "routing/fake_ending.hpp"
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -1,6 +1,6 @@
 #include "testing/testing.hpp"
 
-#include "generator/generator_tests/routing_tools.hpp"
+#include "generator/generator_tests_support/routing_helpers.hpp"
 
 #include "routing/routing_tests/index_graph_tools.hpp"
 
@@ -31,7 +31,7 @@ using namespace std;
 //                  |
 // 2 *              *
 //    ↖          ↗   ↖
-//      F2      F3      F4
+//      F2     F3     F4
 //        ↖  ↗           ↖
 // 1        *               *
 //        ↗  ↖
@@ -91,7 +91,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
 {
   Init(BuildXYGraph());
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {1 /* feature from */, 3 /* feature to */}}};
+    {1 /* feature from */, 3 /* feature to */}
+  };
   RestrictionVec restrictionsNo;
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -108,7 +109,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
 {
   Init(BuildXYGraph());
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}}};
+    {3 /* feature from */, 5 /* feature to */}
+  };
   RestrictionVec restrictionsNo;
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -126,8 +128,9 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
 {
   Init(BuildXYGraph());
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {1 /* feature from */, 3 /* feature to */}},
-      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}}};
+    {1 /* feature from */, 3 /* feature to */},
+    {3 /* feature from */, 5 /* feature to */}
+  };
   RestrictionVec restrictionsNo;
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -146,11 +149,11 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
   Init(BuildXYGraph());
 
   RestrictionVec restrictionsNo = {
-    {Restriction::Type::No, {1 /* feature from */, 2 /* feature to */}}
+    {1 /* feature from */, 2 /* feature to */}
   };
 
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}}
+    {3 /* feature from */, 5 /* feature to */}
   };
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -169,10 +172,10 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
 {
   Init(BuildXYGraph());
   RestrictionVec restrictionsNo = {
-    {Restriction::Type::No, {1 /* feature from */, 3 /* feature to */}}
+    {1 /* feature from */, 3 /* feature to */}
   };
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {3 /* feature from */, 5 /* feature to */}}
+    {3 /* feature from */, 5 /* feature to */}
   };
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -252,7 +255,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildXXGraph()
 //             F4       F5
 //           ↗             ↘
 // 1        *                *
-//           ↖               ↓
+//           ↖               ↑
 //             F2            F3
 //               ↖           ↓ <-- Finish
 // 0 *              *--F1--->*
@@ -312,8 +315,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
   Init(BuildXXGraph());
   RestrictionVec restrictionsNo;
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {1 /* feature from */, 3 /* feature to */}},
-      {Restriction::Type::Only, {3 /* feature from */, 6 /* feature to */}}
+    {1 /* feature from */, 3 /* feature to */},
+    {3 /* feature from */, 6 /* feature to */}
   };
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
                                      restrictionsNo);
@@ -329,15 +332,16 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
 UNIT_CLASS_TEST(RestrictionTest, XXGraph_RestrictionF1F3No)
 {
   Init(BuildXXGraph());
-  RestrictionVec restrictions = {
-      {Restriction::Type::No, {1 /* feature from */, 3 /* feature to */}}};
+  RestrictionVec restrictionsNo = {
+    {1 /* feature from */, 3 /* feature to */}
+  };
   vector<m2::PointD> const expectedGeom = {
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
 
   TestRestrictions(
       expectedGeom, Algorithm::Result::OK,
       MakeFakeEnding(9 /* featureId */, 0 /* segmentIdx */, m2::PointD(2, -1), *m_graph),
-      MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictions), *this);
+      MakeFakeEnding(6, 0, m2::PointD(3, 3), *m_graph), move(restrictionsNo), *this);
 }
 
 // Cumulative case. Route through XX graph with four restricitons of different types applying
@@ -346,13 +350,13 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
 {
   Init(BuildXXGraph());
   RestrictionVec restrictionsNo = {
-    {Restriction::Type::No, {1 /* feature from */, 3 /* feature to */}}
+    {1 /* feature from */, 3 /* feature to */}
   };
 
   RestrictionVec restrictionsOnly = {
-      {Restriction::Type::Only, {4 /* feature from */, 6 /* feature to */}},
-      {Restriction::Type::Only, {7 /* feature from */, 8 /* feature to */}},
-      {Restriction::Type::Only, {8 /* feature from */, 4 /* feature to */}}
+    {4 /* feature from */, 6 /* feature to */},
+    {7 /* feature from */, 8 /* feature to */},
+    {8 /* feature from */, 4 /* feature to */}
   };
 
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
@@ -380,7 +384,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_CheckOnlyRestriction)
   };
 
   RestrictionVec restrictionsOnly = {
-    {Restriction::Type::Only, {0 /* feature from */, 2 /* feature to */}},
+    {0 /* feature from */, 2 /* feature to */},
   };
   RestrictionVec restrictionsNo;
   ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests/routing_tools.hpp"
+
 #include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "routing/fake_ending.hpp"

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -12,9 +12,8 @@
 #include "routing/routing_helpers.hpp"
 #include "routing/vehicle_mask.hpp"
 
-#include "routing/routing_tests/index_graph_tools.hpp"
-
 #include "routing_common/car_model.hpp"
+#include "routing_common/index_graph_tools.hpp"
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "routing/routing_tests/index_graph_tools.hpp"
+
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_graph.hpp"
 
@@ -13,7 +15,6 @@
 #include "routing/vehicle_mask.hpp"
 
 #include "routing_common/car_model.hpp"
-#include "routing_common/index_graph_tools.hpp"
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -321,7 +321,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                                   estimator);
+                                              estimator);
 }
 
 unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -2,6 +2,8 @@
 
 #include "testing/testing.hpp"
 
+#include "testing/testing.hpp"
+
 #include "routing/geometry.hpp"
 
 #include "routing/base/routing_result.hpp"
@@ -13,6 +15,8 @@
 
 #include <unordered_map>
 
+using namespace std;
+
 namespace routing_test
 {
 using namespace routing;
@@ -20,33 +24,6 @@ using namespace routing;
 namespace
 {
 double constexpr kEpsilon = 1e-6;
-
-class WorldGraphForAStar : public AStarGraph<Segment, SegmentEdge, RouteWeight>
-{
-public:
-
-  explicit WorldGraphForAStar(WorldGraph & graph) : m_graph(graph) {}
-
-  Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
-  {
-    return m_graph.HeuristicCostEstimate(from, to);
-  }
-
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
-  {
-    m_graph.GetOutgoingEdgesList(v, edges);
-  }
-
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
-  {
-    m_graph.GetIngoingEdgesList(v, edges);
-  }
-
-  ~WorldGraphForAStar() override = default;
-
-private:
-  WorldGraph & m_graph;
-};
 
 template <typename Graph>
 Graph & GetGraph(unordered_map<NumMwmId, unique_ptr<Graph>> const & graphs, NumMwmId mwmId)
@@ -197,7 +174,7 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
 
   AlgorithmForWorldGraph algorithm;
 
-  routing_test::WorldGraphForAStar graphForAStar(*worldGraph);
+  WorldGraphForAStar graphForAStar(*worldGraph);
 
   AlgorithmForWorldGraph::ParamsForTests params(graphForAStar, startSegment, finishSegment,
                                                 nullptr /* prevRoute */,
@@ -324,7 +301,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator);
+                                                   estimator);
 }
 
 unique_ptr<IndexGraph> BuildIndexGraph(unique_ptr<TestGeometryLoader> geometryLoader,
@@ -341,11 +318,12 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
                                                     vector<Joint> const & joints)
 {
   auto graph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
+  
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator);
+                                                   estimator);
 }
 
 unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -1,6 +1,4 @@
-#include "routing_common/index_graph_tools.hpp"
-
-#include "testing/testing.hpp"
+#include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "testing/testing.hpp"
 
@@ -8,7 +6,7 @@
 
 #include "routing/base/routing_result.hpp"
 
-#include "routing_common/car_model.hpp"
+#include "testing/testing.hpp"
 
 #include "base/assert.hpp"
 #include "base/math.hpp"

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -233,11 +233,11 @@ private:
 };
 
 std::unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(std::unique_ptr<TestGeometryLoader> loader,
-                                                    std::shared_ptr<EdgeEstimator> estimator,
-                                                    std::vector<Joint> const & joints);
+                                                         std::shared_ptr<EdgeEstimator> estimator,
+                                                         std::vector<Joint> const & joints);
 std::unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(std::unique_ptr<ZeroGeometryLoader> loader,
-                                                    std::shared_ptr<EdgeEstimator> estimator,
-                                                    std::vector<Joint> const & joints);
+                                                         std::shared_ptr<EdgeEstimator> estimator,
+                                                         std::vector<Joint> const & joints);
 
 AStarAlgorithm<Segment, SegmentEdge, RouteWeight>::Result CalculateRoute(
     IndexGraphStarter & starter, std::vector<Segment> & roadPoints, double & timeSec);

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "generator/generator_tests/routing_tools.hpp"
+#include "generator/generator_tests_support/routing_helpers.hpp"
 
 #include "routing/edge_estimator.hpp"
 #include "routing/fake_ending.hpp"

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -53,6 +53,7 @@ public:
   using Weight = AStarGraph::Weight;
 
   explicit WorldGraphForAStar(WorldGraph & graph) : m_graph(graph) {}
+  ~WorldGraphForAStar() override = default;
 
   Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
   {
@@ -68,8 +69,6 @@ public:
   {
     m_graph.GetIngoingEdgesList(v, edges);
   }
-
-  ~WorldGraphForAStar() override = default;
 
 private:
   WorldGraph & m_graph;

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -16,6 +16,7 @@
 
 namespace routing_test
 {
+using namespace std;
 using namespace routing;
 
 //                             Finish

--- a/routing/routing_tests/restriction_test.cpp
+++ b/routing/routing_tests/restriction_test.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests/routing_tools.hpp"
+
 #include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "routing/fake_ending.hpp"

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -2,7 +2,8 @@
 
 #include "routing/road_access.hpp"
 #include "routing/road_access_serialization.hpp"
-#include "routing/routing_tests/index_graph_tools.hpp"
+
+#include "routing_common/index_graph_tools.hpp"
 
 #include "coding/reader.hpp"
 #include "coding/writer.hpp"

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -3,7 +3,7 @@
 #include "routing/road_access.hpp"
 #include "routing/road_access_serialization.hpp"
 
-#include "routing_common/index_graph_tools.hpp"
+#include "routing/routing_tests/index_graph_tools.hpp"
 
 #include "coding/reader.hpp"
 #include "coding/writer.hpp"

--- a/routing/segment.hpp
+++ b/routing/segment.hpp
@@ -31,8 +31,10 @@ public:
   {
   }
 
+  Segment const & GetSegment(bool /* start */) const { return *this; }
   NumMwmId GetMwmId() const { return m_mwmId; }
   uint32_t GetFeatureId() const { return m_featureId; }
+  void SetFeatureId(uint32_t id) { m_featureId = id; }
   uint32_t GetSegmentIdx() const { return m_segmentIdx; }
   bool IsForward() const { return m_forward; }
 
@@ -59,6 +61,8 @@ public:
 
     return m_forward < seg.m_forward;
   }
+
+  uint32_t GetStartSegmentId() const { return 0; }
 
   bool operator==(Segment const & seg) const
   {

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -16,6 +16,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include <functional>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -29,40 +31,64 @@ public:
                           std::shared_ptr<EdgeEstimator> estimator);
 
   // WorldGraph overrides:
+  // @{
   ~SingleVehicleWorldGraph() override = default;
 
   void GetEdgeList(Segment const & segment, bool isOutgoing,
                    std::vector<SegmentEdge> & edges) override;
 
-  void GetEdgeList(Segment const & parent, bool isOutgoing,
+  void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,
                    std::vector<JointEdge> & jointEdges, std::vector<RouteWeight> & parentWeights) override;
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
+
   Junction const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
+
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;
   bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) override;
   void ClearCachedGraphs() override { m_loader->Clear(); }
+
   void SetMode(WorldGraphMode mode) override { m_mode = mode; }
   WorldGraphMode GetMode() const override { return m_mode; }
+
   void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
   void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) override;
+
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
   RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
   double CalcSegmentETA(Segment const & segment) override;
+
   std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
 
+  void SetRoutingOptions(RoutingOptions routingOptions) override { m_avoidRoutingOptions = routingOptions; }
   /// \returns true if feature, associated with segment satisfies users conditions.
   bool IsRoutingOptionsGood(Segment const & segment) override;
   RoutingOptions GetRoutingOptions(Segment const & segment) override;
-  void SetRoutingOptions(RoutingOptions routingOptions) override { m_avoidRoutingOptions = routingOptions; }
 
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
   std::vector<RouteSegment::SpeedCamera> GetSpeedCamInfo(Segment const & segment) override;
+
+  IndexGraph & GetIndexGraph(NumMwmId numMwmId) override
+  {
+    return m_loader->GetIndexGraph(numMwmId);
+  }
+
+  void SetAStarParents(bool forward, ParentSegments & parents) override;
+  void SetAStarParents(bool forward, ParentJoints & parents) override;
+
+  bool AreWavesConnectible(ParentSegments & forwardParents, Segment const & commonVertex,
+                           ParentSegments & backwardParents,
+                           std::function<uint32_t(Segment const &)> && fakeFeatureConverter) override;
+  bool AreWavesConnectible(ParentJoints & forwardParents, JointSegment const & commonVertex,
+                           ParentJoints & backwardParents,
+                           std::function<uint32_t(JointSegment const &)> && fakeFeatureConverter) override;
+  // @}
 
   // This method should be used for tests only
   IndexGraph & GetIndexGraphForTests(NumMwmId numMwmId)
@@ -70,12 +96,17 @@ public:
     return m_loader->GetIndexGraph(numMwmId);
   }
 
-  IndexGraph & GetIndexGraph(NumMwmId numMwmId) override
-  {
-    return m_loader->GetIndexGraph(numMwmId);
-  }
-
 private:
+  /// \brief Get parents' featureIds of |commonVertex| from forward AStar wave and join them with
+  ///        parents' featureIds from backward wave.
+  /// \return The result chain of fetureIds are used to find restrictions on it and understand whether
+  ///         waves are connectable or not.
+  template <typename VertexType>
+  bool AreWavesConnectibleImpl(std::map<VertexType, VertexType> const & forwardParents,
+                               VertexType const & commonVertex,
+                               std::map<VertexType, VertexType> const & backwardParents,
+                               std::function<uint32_t(VertexType const &)> && fakeFeatureConverter);
+
   // Retrieves the same |jointEdges|, but into others mwms.
   // If they are cross mwm edges, of course.
   void CheckAndProcessTransitFeatures(Segment const & parent,
@@ -92,5 +123,17 @@ private:
   std::shared_ptr<EdgeEstimator> m_estimator;
   RoutingOptions m_avoidRoutingOptions = RoutingOptions();
   WorldGraphMode m_mode = WorldGraphMode::NoLeaps;
+
+  template <typename Vertex>
+  struct AStarParents
+  {
+    using ParentType = std::map<Vertex, Vertex>;
+    static ParentType kEmpty;
+    ParentType * forward = &kEmpty;
+    ParentType * backward = &kEmpty;
+  };
+
+  AStarParents<Segment> m_parentsForSegments;
+  AStarParents<JointSegment> m_parentsForJoints;
 };
 }  // namespace routing

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -24,7 +24,8 @@ TransitWorldGraph::TransitWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
   CHECK(m_estimator, ());
 }
 
-void TransitWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
+void TransitWorldGraph::GetEdgeList(JointSegment const & parentJoint,
+                                    Segment const & segment, bool isOutgoing,
                                     std::vector<JointEdge> & edges,
                                     std::vector<RouteWeight> & parentWeights)
 {

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -61,7 +61,8 @@ public:
   double CalcSegmentETA(Segment const & segment) override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing,
+  void GetEdgeList(JointSegment const & parentJoint,
+                   Segment const & segment, bool isOutgoing,
                    std::vector<JointEdge> & edges,
                    std::vector<RouteWeight> & parentWeights) override;
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -1,5 +1,7 @@
 #include "routing/world_graph.hpp"
 
+#include <map>
+
 namespace routing
 {
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges)
@@ -49,6 +51,23 @@ bool WorldGraph::IsRoutingOptionsGood(Segment const & /* segment */)
 std::vector<RouteSegment::SpeedCamera> WorldGraph::GetSpeedCamInfo(Segment const & segment)
 {
   return {};
+}
+
+void WorldGraph::SetAStarParents(bool forward, std::map<Segment, Segment> & parents) {}
+void WorldGraph::SetAStarParents(bool forward, std::map<JointSegment, JointSegment> & parents) {}
+
+bool WorldGraph::AreWavesConnectible(ParentSegments & forwardParents, Segment const & commonVertex,
+                                     ParentSegments & backwardParents,
+                                     std::function<uint32_t(Segment const &)> && fakeFeatureConverter)
+{
+  return true;
+}
+
+bool WorldGraph::AreWavesConnectible(ParentJoints & forwardParents, JointSegment const & commonVertex,
+                                     ParentJoints & backwardParents,
+                                     std::function<uint32_t(JointSegment const &)> && fakeFeatureConverter)
+{
+  return true;
 }
 
 void WorldGraph::SetRoutingOptions(RoutingOptions /* routingOption */) {}

--- a/search/search_integration_tests/CMakeLists.txt
+++ b/search/search_integration_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ omim_link_libraries(
   pugixml
   opening_hours
   icu
+  traffic
   ${Qt5Network_LIBRARIES}
   ${LIBZ}
 )

--- a/storage/storage_tests/CMakeLists.txt
+++ b/storage/storage_tests/CMakeLists.txt
@@ -28,12 +28,12 @@ omim_link_libraries(
   drape_frontend
   shaders
   map
-  traffic
   storage
   drape
   generator
   search
   routing
+  traffic
   routing_common
   ugc
   kml

--- a/ugc/ugc_tests/CMakeLists.txt
+++ b/ugc/ugc_tests/CMakeLists.txt
@@ -51,6 +51,7 @@ omim_link_libraries(
   succinct
   opening_hours
   oauthcpp
+  traffic
   ${LIBZ}
 )
 link_qt5_core(${PROJECT_NAME})


### PR DESCRIPTION
## Stage 1. Preprocess data.

1) generator/restriction_writer.cpp
2) generator/restriction_writer.hpp
3) generator/relation_tags.cpp
4) generator/translator_planet.cpp

Это одна из начальных стадий, когда к нам приходит чистый Osm Relation, и записываем информацию о 
restrictions в `restriction.csv`. Здесь я изменил формат csv - теперь мы поддерживаем restrictions 
у которых есть way в качестве via, а в случае с restriction вида |way1| -> |node| -> |way2| мы запоминаем
координаты |node|, чтобы в последствии удалить те restriction, у которых way1 и way2 не пересекаются в |node|.

## Stage 2. Process data.

1) generator/restriction_collector.cpp
2) generator/restriction_collector.hpp
3) generator/generator_tool/generator_tool.cpp
4) geometry/point2d.hpp
5) generator/restriction_generator.cpp
6) generator/restriction_generator.hpp

Тут мы считываем строчки из `restriction.csv`. Добавил тут проверку пересечения feature, которые учавствуют в 
restrions. Поэтому теперь вначале делается `BuildRoutingIndex()` (`generator_tool.cpp`), а потом `BuildRoadRestrictions()`.

Для restriction вида |way1| -> |node| -> |way2|, просто проверяем, что |way1| и |way2| пересекаются в |node|.
Для restriction вида |way1| -> |way2| -> ... -> |wayN|, проверяем, что |way1| и |way2| имеют общие Joint, ... , |wayN-1| и |wayN| имеют общие Joint.

## Stage 3. Generator tests.

1) generator/generator_tests/restriction_collector_test.cpp
2) generator/generator_tests/restriction_test.cpp
3) routing_common/CMakeLists.txt
4) routing/routing_tests/CMakeLists.txt
5) routing/routing_tests/index_graph_test.cpp
6) routing/routing_tests/index_graph_tools.cpp
7) routing/routing_tests/index_graph_tools.hpp
8) routing/routing_tests/road_access_test.cpp
9) routing/routing_tests/applying_traffic_test.cpp
10) routing/routing_integration_tests/routing_test_tools.cpp

Я тут переписал тесты, какие-то удалил (бесполезные). В тестах добавился созданный руками IndexGraph 
(в комментах есть ascii-картинка). Для того, чтобы использовать штуки для IndexGraph пришлось перенести
`index_graph_tools.hpp`, `index_graph_tools.cpp` из `routing_tests` в `routing_common`
так как там уже реализованы некоторые ф-ии, а `routing_tests` является executable, а не library и линковать
с `generator_tests` не получилось.

В тестах проверяется добавляение restrictions в пустую mwm, сравнивается с ожидаемым результатом.
Проверяется, что не добавляются фичи, с некорректными featureId, а также те, которые не пересекаются.

## Stage 4. Restrictions deserialization from mwm to routing data structure.

1) routing/restriction_loader.hpp
2) routing/restriction_loader.cpp
3) routing/restrictions_serialization.cpp
4) routing/restrictions_serialization.hpp
5) routing/index_graph.cpp (IndexGraph::SetRestrictions)

Тут происходит десериализация из mwm. Как было раньше: мы доставали restrictions, конвертировали все Only в No
и после чего добавляли в std::vector<Restriction> у IndexGraph набор restrictions. Далее делали бинпоиск по этому
вектору при построении маршрутов. Как будет сейчас:

![image](https://user-images.githubusercontent.com/17534533/55571972-45e0d800-570f-11e9-9426-0ad47aede3ce.png)

## Stage 5. Using restriction in routing

1) routing/index_graph.hpp
2) routing/joint_segment.cpp
3) routing/joint_segment.hpp
4) routing/segment.hpp
5) routing/base/astar_algorithm.hpp
6) routing/base/astar_graph.hpp
7) routing/index_graph_starter_joints.hpp
8) routing/single_vehicle_world_graph.cpp
9) routing/single_vehicle_world_graph.hpp
10) routing/transit_world_graph.cpp
11) routing/transit_world_graph.hpp
12) routing/world_graph.cpp
13) routing/world_graph.hpp
14) routing/index_graph_starter.hpp
15) generator/routing_index_generator.cpp

Как мы теперь их используем в `index_graph.hpp` есть ф-ия `template <typename Parent> bool IsRestricted(...)`
Она принимает:
1) Parent const & parent - чтобы селектить предков по 4)
2) parentFeatureId - так как одного предка мы знаем (откуда мы пришли), то передаем его featureId сразу
3) currentFeatureId - текущая фича, чтобы заселектить restrictions, которые относятся к ней
4) std::map<Parent, Parent> & parents - предки из A*

Именно эта ф-ия в конечном итоге проверяет запреты, использую предков из A*.
Как она вызывается:


0) В мастере уже PR, который делает graph абстрактным классом в A*.
1) A* при создании BidirectionalStepContext вызывает graph.SetAStarParents(forward, parent)
2) Последнее, в свою очередь, пробрасывается до WorldGraph (а именно до SingleVehicleWorldGraph)
   где уже и сохраняются raw pointers на std::map из A*.
3) Вызов GetEdgeList имеет следующую цепочку: A* -> IndexGraphStarterJoints -> IndexGraphStarter
                                                 -> WorldGraph -> (тут и передаются parents, которые мы сохранили) IndexGraph

## Stage 6. Routing unit tests.

1) routing/routing_tests/cumulative_restriction_test.cpp
2) routing/routing_tests/restriction_test.cpp

Тут добавил unit tests на многозвенные restrictions.

## Results
![image](https://user-images.githubusercontent.com/17534533/55077896-e3059600-50a9-11e9-8a41-5901b47918f0.png)
![image](https://user-images.githubusercontent.com/17534533/55078065-498ab400-50aa-11e9-9098-8ce068a8c997.png)
![image](https://user-images.githubusercontent.com/17534533/55078289-ddf51680-50aa-11e9-9530-8da1adb82e2c.png)
![image](https://user-images.githubusercontent.com/17534533/55083835-34ffe900-50b5-11e9-8396-de587c957213.png)
![image](https://user-images.githubusercontent.com/17534533/55216904-23325900-520f-11e9-80c1-68cacf41fcb5.png)
![image](https://user-images.githubusercontent.com/17534533/55217187-f03c9500-520f-11e9-8ba6-19b31bcaa5e0.png)
![image](https://user-images.githubusercontent.com/17534533/55227286-1a01b600-5228-11e9-84f0-e5a0b36ec8a7.png)
![image](https://user-images.githubusercontent.com/17534533/55318218-eb2f4e00-547a-11e9-8d3b-489f532fd2ef.png)
Был разговор о том, что osrm не поддерживает restrictions, в больше чем одним way, proof:
![image](https://user-images.githubusercontent.com/17534533/56085962-543c9b80-5e55-11e9-8157-2c054e2811c1.png)

![image](https://user-images.githubusercontent.com/17534533/55318576-c1c2f200-547b-11e9-96ff-646d78af02d8.png)
