### PR TITLE
[search] Do not cache viewport features for MatchAroundPivot.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -947,7 +947,8 @@ void Geocoder::MatchAroundPivot(BaseContext & ctx)
 {
   TRACE(MatchAroundPivot);
 
-  auto const features = RetrieveGeometryFeatures(*m_context, m_params.m_pivot, RECT_ID_PIVOT);
+  CBV features;
+  features.SetFull();
   ViewportFilter filter(features, m_preRanker.Limit() /* threshold */);
   LimitedSearch(ctx, filter);
 }


### PR DESCRIPTION
Отменяю кеширование фичей из вьюпорта при поиске домов и POI.
Причина: оно занимает до 30% времени первого вызова поиска и при этом не приносит видимых улучшений.
Отсмотрела работу поиска на 400 размеченных случайных запросах на русском.
В большинстве случаев все результаты полностью совпадают (включая нерелевантные и мусор).
Для 28 запросов были различия. В большинстве случаев это замена одного мусора/нерелевантных ответов на другой мусор/нерелевантные ответы. Ни в одном из случаев разница не коснулась лучшего ответа. В целом новый вариант тяготеет к нахождению более далёких, но лучше подходящих под запрос ответов.
В одном случае на мой взгляд был потерян один релевантный ответ (но сохранен витальный), в восьми случаях были найдены ранее не найденные релевантные ответы (витальные были и остались найдены) либо мусорные результаты заменены на далёкие, но подходящие под зарос.

Случай в котором ухудшилась работа:
```
{"viewport":{"minx":27.791,"miny":52.501800000000003,"maxx":27.823899999999998,"maxy":52.558100000000003},"query":"chisinau","results":[],"locale":"ru","position":    {"x":27.807400000000001,"y":52.529899999999998},"related_queries":["calarasi"]}
```
тут в обоих случаях был найден кишинёв, но старый код помимо города (витальный ответ) находил также международный аэропорт (релевантный), новый -- нет

Случаи в которых улучшилась работа:
```
{"viewport":{"minx":38.242899999999999,"miny":50.9634,"maxx":38.306100000000001,"maxy":51.0595},"query":"\u043a\u0440\u0430\u0441\u043d\u043e\u0434\u0430","results":[],"locale":"ru","position":null,"related_queries":["\u0438\u043d\u0442\u0435\u0440\u043d\u0430\u0446\u0438\u043e\u043d\u043f"]}
```
по запросу "краснодар" в обоих случаях находится город, но новый код находит также аэропорт и вокзал

```
{"viewport":{"minx":17.215499999999999,"miny":54.6629,"maxx":17.2196,"maxy":54.669899999999998},"query":"munich","results":[],"    locale":"ru","position":{"x":17.217600000000001,"y":54.666499999999999},"related_queries":["vienna"]}
```
по запросу "munich" в обоих случаях находится город, но новый код также находит munich international airport

```
{"viewport":{"minx":51.001300000000001,"miny":58.997500000000002,"maxx":51.610300000000002,"maxy":60.078499999999998},"query":"\u0430\u043a\u0430\u0431\u0443\u043b\u0445\u0430    \u0438\u0440 \u0445\u0430\u043d\u0430 78","results":[],"locale":"ru-RU","position":{"x":57.1942000    00000002,"y":58.326799999999999},"related_queries":["\u0430\u043a\u0442\u0430\u0431\u0443\u043b\u0445\u0430\u0438\u0440 \u0445\u0430\u043d\u0430 78","\u0430\u0430\u0431\u0443\    u043b\u0445\u0430\u0438\u0440 \u0445\u0430\u043d\u0430 78"]}
```
по запросу "абдулхаир хана 78" находится улица абдулхаир хана в близком к вьюпорту городе вместо мусора

```
{"viewport":{"minx":34.723999999999997,"miny":33.820599999999999,"maxx":34.820900000000002,"maxy":33.992800000000003},"query":"\u0436\u0430\u0431\u043e\u0442\u0438\u043d\u0441    \u043a\u0438\u0438 12","results":[],"    locale":"ru-RU","position":{"x":34.772399999999998,"y":33.906700000000001},"related_queries":[]}
```
по запросу "жаботинский 12" находим жаботинский 12 в близком городе вместо мусора в текущем

```
{"viewport":{"minx":61.338900000000002,"miny":66.6083,"maxx":61.347200000000001,"maxy":66.621799999999993},"query":"\u043f\u043e\u0431\u0435\u0434\u044b 133","results":[],"locale":"ru","position":{"x":61.3431,"y":    66.614999999999995},"related_queries":["\u0431\u0430\u043d\u043a\u043e\u043c\u0430\u0442"]}
```
по запросу "победы 133" находим победы 133 в соседнем городе вместо мусора в текущем

```
{"viewport":{"minx":61.527999999999999,"miny":50.296500000000002,"maxx":62.777999999999999,"maxy":52.515300000000003},"query":"\u0430\u0439\u0442\u0435\u043a\u0435 \u0431\u043    8","results":[],"locale":"ru-RU","position":{"x":76.944100000000006,"y":48.0794},"related_queries":["\u0443\u043b\u0438\u0447"]}
```
по запросу "айтеке би" находим далёкие айтеке би вместо близкого мусора

```
{"viewport":{"minx":33.526299999999999,"miny":49.9435,"maxx":33.527999999999999,"maxy":49.946399999999997},"query":"\u043b\u0435\u043d\u0438\u043d\u0430 8","results":[],"locale":"ru-RU","position":{"x":33.527099999999997,"y":49.944899999999997},"related_queries":["\u043f\u0440\u043e\    u0441\u043f\u0435\u043a\u0442 \u043f\u043e\u0431\u0435\u0434\u044b","\u0443\u043b\u0438\u0446\u0430 \u043b\u0435\u043d\u0438\u043d\u0430"]}
```
по запросу "ленина 8" находим ленина 8 в соседних деревнях вметсто мусора рядом

```
{"viewport":{"minx":44.677500000000002,"miny":44.968600000000002,"maxx":44.690899999999999,"maxy":44.992600000000003},"query":"erevan","results":[],"locale":"ru","position":{"x":44.684199999999997,"y":44.980600000000003},"related_queries":[]}
```
по запросу "erevan" в обоих случаях находим ереван, в новом дополнительно находим ереванское шоссе недалеко от вьюпорта