### PR TITLE
[routing] Improve A* progress in UI for LeapsOnly mode

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -10,6 +10,8 @@ set(
   async_router.cpp
   async_router.hpp
   base/astar_algorithm.hpp
+  base/astar_progress.cpp
+  base/astar_progress.hpp
   base/astar_weight.hpp
   base/followed_polyline.cpp
   base/followed_polyline.hpp

--- a/routing/base/astar_progress.cpp
+++ b/routing/base/astar_progress.cpp
@@ -1,0 +1,107 @@
+#include "routing/base/astar_progress.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/assert.hpp"
+#include "base/math.hpp"
+
+#include <algorithm>
+#include <iterator>
+
+namespace routing
+{
+// AStarSubProgress ----------------------------------------------------------------------
+
+AStarSubProgress::AStarSubProgress(m2::PointD const & start, m2::PointD const & finish,
+                                   double contributionCoef)
+  : m_contributionCoef(contributionCoef), m_startPoint(start), m_finishPoint(finish)
+{
+  ASSERT_GREATER(m_contributionCoef, 0.0, ());
+
+  m_fullDistance = MercatorBounds::DistanceOnEarth(start, finish);
+  m_forwardDistance = m_fullDistance;
+  m_backwardDistance = m_fullDistance;
+}
+
+AStarSubProgress::AStarSubProgress(double contributionCoef)
+    : m_contributionCoef(contributionCoef)
+{
+  ASSERT_NOT_EQUAL(m_contributionCoef, 0.0, ());
+}
+
+double AStarSubProgress::UpdateProgress(m2::PointD const & current, m2::PointD const & finish)
+{
+  ASSERT_NOT_EQUAL(m_fullDistance, 0.0, ());
+
+  double const dist = MercatorBounds::DistanceOnEarth(current, finish);
+  double & toUpdate = finish == m_finishPoint ? m_forwardDistance : m_backwardDistance;
+
+  toUpdate = std::min(toUpdate, dist);
+
+  double part = 2.0 - (m_forwardDistance + m_backwardDistance) / m_fullDistance;
+  part = base::clamp(part, 0.0, 1.0);
+  double const newProgress =  m_contributionCoef * part;
+
+  m_currentProgress = std::max(newProgress, m_currentProgress);
+
+  return m_currentProgress;
+}
+
+double AStarSubProgress::UpdateProgress(double subSubProgressValue)
+{
+  return m_currentProgress + m_contributionCoef * subSubProgressValue;
+}
+
+void AStarSubProgress::Flush(double progress)
+{
+  m_currentProgress += m_contributionCoef * progress;
+}
+
+double AStarSubProgress::GetMaxContribution() const { return m_contributionCoef; }
+
+// AStarProgress -------------------------------------------------------------------------
+
+AStarProgress::AStarProgress()
+{
+  m_subProgresses.emplace_back(AStarSubProgress(1.0));
+}
+
+AStarProgress::~AStarProgress()
+{
+  CHECK(std::next(m_subProgresses.begin()) == m_subProgresses.end(), ());
+}
+
+void AStarProgress::AppendSubProgress(AStarSubProgress const & subProgress)
+{
+  m_subProgresses.emplace_back(subProgress);
+}
+
+void AStarProgress::EraseLastSubProgress()
+{
+  ASSERT(m_subProgresses.begin() != m_subProgresses.end(), ());
+  ASSERT(m_subProgresses.begin() != std::prev(m_subProgresses.end()), ());
+
+  auto prevLast = std::prev(std::prev(m_subProgresses.end()));
+  prevLast->Flush(m_subProgresses.back().GetMaxContribution());
+
+  CHECK(!m_subProgresses.empty(), ());
+  auto const last = std::prev(m_subProgresses.end());
+  m_subProgresses.erase(last);
+}
+
+double AStarProgress::UpdateProgress(m2::PointD const & current, m2::PointD const & end)
+{
+  return UpdateProgressImpl(m_subProgresses.begin(), current, end) * 100.0;
+}
+
+double AStarProgress::GetLastPercent() const { return m_lastValue * 100.0; }
+
+double AStarProgress::UpdateProgressImpl(ListItem subProgress, m2::PointD const & current,
+                                         m2::PointD const & end)
+{
+  if (std::next(subProgress) != m_subProgresses.end())
+    return subProgress->UpdateProgress(UpdateProgressImpl(std::next(subProgress), current, end));
+
+  return subProgress->UpdateProgress(current, end);
+}
+}  // namespace routing

--- a/routing/base/astar_progress.hpp
+++ b/routing/base/astar_progress.hpp
@@ -1,66 +1,129 @@
 #pragma once
 
+#include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
-#include "geometry/mercator.hpp"
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+
+#include <iterator>
+#include <list>
 
 namespace routing
 {
-class AStarProgress
+class AStarSubProgress
 {
 public:
-  AStarProgress(float startValue, float stopValue)
-      : m_startValue(startValue), m_stopValue(stopValue) {}
-
-  void Initialize(m2::PointD const & startPoint, m2::PointD const & finalPoint)
+  AStarSubProgress(m2::PointD const & start, m2::PointD const & finish, double contributionCoef)
+    : m_contributionCoef(contributionCoef), m_startPoint(start), m_finalPoint(finish)
   {
-    m_startPoint = startPoint;
-    m_finalPoint = finalPoint;
-    m_initialDistance = MercatorBounds::DistanceOnEarth(startPoint, finalPoint);
-    m_forwardDistance = m_initialDistance;
-    m_backwardDistance = m_initialDistance;
-    m_lastValue = m_startValue;
+    ASSERT_NOT_EQUAL(m_contributionCoef, 0.0, ());
+
+    m_fullDistance = MercatorBounds::DistanceOnEarth(start, finish);
+    m_forwardDistance = m_fullDistance;
+    m_backwardDistance = m_fullDistance;
   }
 
-  float GetProgressForDirectedAlgo(m2::PointD const & point)
+  explicit AStarSubProgress(double contributionCoef)
+      : m_contributionCoef(contributionCoef)
   {
-    return CheckConstraints(
-        1.0 - MercatorBounds::DistanceOnEarth(point, m_finalPoint) / m_initialDistance);
+    ASSERT_NOT_EQUAL(m_contributionCoef, 0.0, ());
   }
 
-  float GetProgressForBidirectedAlgo(m2::PointD const & point, m2::PointD const & target)
+  double UpdateProgress(m2::PointD const & current, m2::PointD const & end)
   {
-    if (target == m_finalPoint)
-      m_forwardDistance = MercatorBounds::DistanceOnEarth(point, target);
-    else if (target == m_startPoint)
-      m_backwardDistance = MercatorBounds::DistanceOnEarth(point, target);
-    else
-      ASSERT(false, ());
-    return CheckConstraints(2.0 - (m_forwardDistance + m_backwardDistance) / m_initialDistance);
+    ASSERT_NOT_EQUAL(m_fullDistance, 0.0, ());
+
+    double dist = MercatorBounds::DistanceOnEarth(current, end);
+    double & toUpdate = end == m_finalPoint ? m_forwardDistance : m_backwardDistance;
+
+    toUpdate = std::min(toUpdate, dist);
+
+    double part = 2.0 - (m_forwardDistance + m_backwardDistance) / m_fullDistance;
+    part = base::clamp(part, 0.0, 1.0);
+    double newProgress =  m_contributionCoef * part;
+
+    m_currentProgress = std::max(newProgress, m_currentProgress);
+
+    return m_currentProgress;
   }
 
-  float GetLastValue() const { return m_lastValue; }
+  double UpdateProgress(double subSubProgressValue)
+  {
+    return m_currentProgress + m_contributionCoef * subSubProgressValue;
+  }
+
+  void Flush(double progress)
+  {
+    m_currentProgress += m_contributionCoef * progress;
+  }
+
+  double GetMaxContribution() const { return m_contributionCoef; }
 
 private:
-  float CheckConstraints(float const & roadPart)
-  {
-    float mappedValue = m_startValue + (m_stopValue - m_startValue) * roadPart;
-    mappedValue = base::clamp(mappedValue, m_startValue, m_stopValue);
-    if (mappedValue > m_lastValue)
-      m_lastValue = mappedValue;
-    return m_lastValue;
-  }
 
-  float m_forwardDistance;
-  float m_backwardDistance;
-  float m_initialDistance;
-  float m_lastValue;
+  double m_currentProgress = 0.0;
+
+  double m_contributionCoef = 0.0;
+
+  double m_fullDistance = 0.0;
+
+  double m_forwardDistance = 0.0;
+  double m_backwardDistance = 0.0;
 
   m2::PointD m_startPoint;
   m2::PointD m_finalPoint;
-
-  float const m_startValue;
-  float const m_stopValue;
 };
 
+class AStarProgress
+{
+public:
+
+  AStarProgress()
+  {
+    m_subProgresses.emplace_back(AStarSubProgress(1.0));
+  }
+
+  void AppendSubProgress(AStarSubProgress const & subProgress)
+  {
+    m_subProgresses.emplace_back(subProgress);
+  }
+
+  void EraseLastSubProgress()
+  {
+    ASSERT(m_subProgresses.begin() != m_subProgresses.end(), ());
+    ASSERT(m_subProgresses.begin() != std::prev(m_subProgresses.end()), ());
+
+    auto prevLast = std::prev(std::prev(m_subProgresses.end()));
+    prevLast->Flush(m_subProgresses.back().GetMaxContribution());
+
+    CHECK(!m_subProgresses.empty(), ());
+    auto last = std::prev(m_subProgresses.end());
+    m_subProgresses.erase(last);
+  }
+
+  double UpdateProgress(m2::PointD const & current, m2::PointD const & end)
+  {
+    return UpdateProgressImpl(m_subProgresses.begin(), current, end) * 100.0;
+  }
+
+  double GetLastValue() const { return m_lastValue * 100.0; }
+
+private:
+
+  using ListItem = std::list<AStarSubProgress>::iterator;
+
+  double UpdateProgressImpl(ListItem subProgress, m2::PointD const & current,
+                            m2::PointD const & end)
+  {
+    if (std::next(subProgress) != m_subProgresses.end())
+      return subProgress->UpdateProgress(UpdateProgressImpl(std::next(subProgress), current, end));
+
+    return subProgress->UpdateProgress(current, end);
+  }
+
+  double m_lastValue = 0.0;
+
+  std::list<AStarSubProgress> m_subProgresses;
+};
 }  //  namespace routing

--- a/routing/base/astar_progress.hpp
+++ b/routing/base/astar_progress.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
-#include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
-#include "base/assert.hpp"
-#include "base/logging.hpp"
-
-#include <iterator>
 #include <list>
 
 namespace routing
@@ -14,114 +9,49 @@ namespace routing
 class AStarSubProgress
 {
 public:
-  AStarSubProgress(m2::PointD const & start, m2::PointD const & finish, double contributionCoef)
-    : m_contributionCoef(contributionCoef), m_startPoint(start), m_finalPoint(finish)
-  {
-    ASSERT_NOT_EQUAL(m_contributionCoef, 0.0, ());
+  AStarSubProgress(m2::PointD const & start, m2::PointD const & finish, double contributionCoef);
 
-    m_fullDistance = MercatorBounds::DistanceOnEarth(start, finish);
-    m_forwardDistance = m_fullDistance;
-    m_backwardDistance = m_fullDistance;
-  }
+  explicit AStarSubProgress(double contributionCoef);
 
-  explicit AStarSubProgress(double contributionCoef)
-      : m_contributionCoef(contributionCoef)
-  {
-    ASSERT_NOT_EQUAL(m_contributionCoef, 0.0, ());
-  }
+  double UpdateProgress(m2::PointD const & current, m2::PointD const & finish);
+  /// \brief Some |AStarSubProgress| could have their own subProgresses (next item in
+  /// AStarProgress::m_subProgresses after current), in order to return true progress
+  /// back to the upper level of subProgresses, we should do progress backpropagation of
+  /// subProgress of current subProgress - |subSubProgressValue|
+  double UpdateProgress(double subSubProgressValue);
 
-  double UpdateProgress(m2::PointD const & current, m2::PointD const & end)
-  {
-    ASSERT_NOT_EQUAL(m_fullDistance, 0.0, ());
-
-    double dist = MercatorBounds::DistanceOnEarth(current, end);
-    double & toUpdate = end == m_finalPoint ? m_forwardDistance : m_backwardDistance;
-
-    toUpdate = std::min(toUpdate, dist);
-
-    double part = 2.0 - (m_forwardDistance + m_backwardDistance) / m_fullDistance;
-    part = base::clamp(part, 0.0, 1.0);
-    double newProgress =  m_contributionCoef * part;
-
-    m_currentProgress = std::max(newProgress, m_currentProgress);
-
-    return m_currentProgress;
-  }
-
-  double UpdateProgress(double subSubProgressValue)
-  {
-    return m_currentProgress + m_contributionCoef * subSubProgressValue;
-  }
-
-  void Flush(double progress)
-  {
-    m_currentProgress += m_contributionCoef * progress;
-  }
-
-  double GetMaxContribution() const { return m_contributionCoef; }
+  void Flush(double progress);
+  double GetMaxContribution() const;
 
 private:
-
   double m_currentProgress = 0.0;
-
   double m_contributionCoef = 0.0;
-
   double m_fullDistance = 0.0;
-
   double m_forwardDistance = 0.0;
   double m_backwardDistance = 0.0;
 
   m2::PointD m_startPoint;
-  m2::PointD m_finalPoint;
+  m2::PointD m_finishPoint;
 };
 
 class AStarProgress
 {
 public:
+  AStarProgress();
+  ~AStarProgress();
 
-  AStarProgress()
-  {
-    m_subProgresses.emplace_back(AStarSubProgress(1.0));
-  }
-
-  void AppendSubProgress(AStarSubProgress const & subProgress)
-  {
-    m_subProgresses.emplace_back(subProgress);
-  }
-
-  void EraseLastSubProgress()
-  {
-    ASSERT(m_subProgresses.begin() != m_subProgresses.end(), ());
-    ASSERT(m_subProgresses.begin() != std::prev(m_subProgresses.end()), ());
-
-    auto prevLast = std::prev(std::prev(m_subProgresses.end()));
-    prevLast->Flush(m_subProgresses.back().GetMaxContribution());
-
-    CHECK(!m_subProgresses.empty(), ());
-    auto last = std::prev(m_subProgresses.end());
-    m_subProgresses.erase(last);
-  }
-
-  double UpdateProgress(m2::PointD const & current, m2::PointD const & end)
-  {
-    return UpdateProgressImpl(m_subProgresses.begin(), current, end) * 100.0;
-  }
-
-  double GetLastValue() const { return m_lastValue * 100.0; }
+  double GetLastPercent() const;
+  void EraseLastSubProgress();
+  void AppendSubProgress(AStarSubProgress const & subProgress);
+  double UpdateProgress(m2::PointD const & current, m2::PointD const & end);
 
 private:
-
   using ListItem = std::list<AStarSubProgress>::iterator;
 
   double UpdateProgressImpl(ListItem subProgress, m2::PointD const & current,
-                            m2::PointD const & end)
-  {
-    if (std::next(subProgress) != m_subProgresses.end())
-      return subProgress->UpdateProgress(UpdateProgressImpl(std::next(subProgress), current, end));
+                            m2::PointD const & end);
 
-    return subProgress->UpdateProgress(current, end);
-  }
-
+  // This value is in range: [0, 1].
   double m_lastValue = 0.0;
 
   std::list<AStarSubProgress> m_subProgresses;

--- a/routing/checkpoints.cpp
+++ b/routing/checkpoints.cpp
@@ -44,7 +44,7 @@ void Checkpoints::PassNextPoint()
   CHECK(!IsFinished(), ());
   ++m_passedIdx;
 }
-double Checkpoints::GetPathLength() const
+double Checkpoints::GetSummaryLengthBetweenPointsMeters() const
 {
   double dist = 0.0;
   for (size_t i = 1; i < m_points.size(); ++i)

--- a/routing/checkpoints.cpp
+++ b/routing/checkpoints.cpp
@@ -44,6 +44,14 @@ void Checkpoints::PassNextPoint()
   CHECK(!IsFinished(), ());
   ++m_passedIdx;
 }
+double Checkpoints::GetPathLength() const
+{
+  double dist = 0.0;
+  for (size_t i = 1; i < m_points.size(); ++i)
+    dist += MercatorBounds::DistanceOnEarth(m_points[i - 1], m_points[i]);
+
+  return dist;
+}
 
 std::string DebugPrint(Checkpoints const & checkpoints)
 {

--- a/routing/checkpoints.hpp
+++ b/routing/checkpoints.hpp
@@ -28,7 +28,7 @@ public:
   size_t GetNumSubroutes() const { return m_points.size() - 1; }
   bool IsFinished() const { return m_passedIdx >= GetNumSubroutes(); }
 
-  double GetPathLength() const;
+  double GetSummaryLengthBetweenPointsMeters() const;
 
   void PassNextPoint();
 

--- a/routing/checkpoints.hpp
+++ b/routing/checkpoints.hpp
@@ -28,6 +28,8 @@ public:
   size_t GetNumSubroutes() const { return m_points.size() - 1; }
   bool IsFinished() const { return m_passedIdx >= GetNumSubroutes(); }
 
+  double GetPathLength() const;
+
   void PassNextPoint();
 
 private:

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -394,7 +394,7 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
   PushPassedSubroutes(checkpoints, subroutes);
   unique_ptr<IndexGraphStarter> starter;
   AStarProgress progress;
-  double const checkpointsLength = checkpoints.GetPathLength();
+  double const checkpointsLength = checkpoints.GetSummaryLengthBetweenPointsMeters();
 
   for (size_t i = checkpoints.GetPassedIdx(); i < checkpoints.GetNumSubroutes(); ++i)
   {
@@ -539,7 +539,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
     RoutingResult<JointSegment, RouteWeight> routingResult;
 
     uint32_t visitCount = 0;
-    auto lastValue = progress.GetLastValue();
+    auto lastValue = progress.GetLastPercent();
     auto const onVisitJunctionJoints = [&](JointSegment const & from, JointSegment const & to)
     {
       ++visitCount;
@@ -580,7 +580,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
     using Weight = IndexGraphStarter::Weight;
 
     uint32_t visitCount = 0;
-    auto lastValue = progress.GetLastValue();
+    auto lastValue = progress.GetLastPercent();
     if (mode == WorldGraphMode::LeapsOnly)
     {
       AStarSubProgress leapsProgress(checkpoints.GetPoint(subrouteIdx),
@@ -908,17 +908,16 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
     using Edge = IndexGraphStarterJoints<IndexGraphStarter>::Edge;
     using Weight = IndexGraphStarterJoints<IndexGraphStarter>::Weight;
 
-    double contribCoef = static_cast<double>(end - start + 1) /
-                         static_cast<double>(input.size());
-    auto startPoint = starter.GetPoint(input[start], true /* front */);
-    auto endPoint = starter.GetPoint(input[end], true /* front */);
+    auto const contribCoef = static_cast<double>(end - start + 1) / (input.size());
+    auto const startPoint = starter.GetPoint(input[start], true /* front */);
+    auto const endPoint = starter.GetPoint(input[end], true /* front */);
     progress.AppendSubProgress({startPoint, endPoint, contribCoef});
     SCOPE_GUARD(progressGuard, [&progress]() {
       progress.EraseLastSubProgress();
     });
 
     uint32_t visitCount = 0;
-    auto lastValue = progress.GetLastValue();
+    auto lastValue = progress.GetLastPercent();
     auto const onVisitJunctionJoints = [&](JointSegment const & from, JointSegment const & to)
     {
       ++visitCount;
@@ -966,7 +965,6 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
       prevStart = start;
       return true;
     }
-
 
     LOG(LINFO, ("Can not find path",
       "from:",

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/base/astar_algorithm.hpp"
+#include "routing/base/astar_progress.hpp"
 #include "routing/base/routing_result.hpp"
 
 #include "routing/cross_mwm_graph.hpp"
@@ -24,6 +25,8 @@
 #include "platform/country_file.hpp"
 
 #include "geometry/tree4d.hpp"
+
+#include "base/astar_progress.hpp"
 
 #include <functional>
 #include <memory>
@@ -86,8 +89,8 @@ private:
                                     m2::PointD const & startDirection,
                                     RouterDelegate const & delegate, Route & route);
   RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
-                                     RouterDelegate const & delegate, IndexGraphStarter & graph,
-                                     std::vector<Segment> & subroute);
+                                     RouterDelegate const & delegate, AStarProgress & progress,
+                                     IndexGraphStarter & graph, std::vector<Segment> & subroute);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints,
                                m2::PointD const & startDirection,
@@ -112,7 +115,7 @@ private:
   // ProcessLeaps replaces each leap with calculated route through mwm.
   RouterResultCode ProcessLeapsJoints(vector<Segment> const & input, RouterDelegate const & delegate,
                                       WorldGraphMode prevMode, IndexGraphStarter & starter,
-                                      vector<Segment> & output);
+                                      AStarProgress & progress, vector<Segment> & output);
   RouterResultCode RedressRoute(std::vector<Segment> const & segments,
                                 RouterDelegate const & delegate, IndexGraphStarter & starter,
                                 Route & route) const;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -26,8 +26,6 @@
 
 #include "geometry/tree4d.hpp"
 
-#include "base/astar_progress.hpp"
-
 #include <functional>
 #include <memory>
 #include <set>

--- a/routing/routing_tests/astar_progress_test.cpp
+++ b/routing/routing_tests/astar_progress_test.cpp
@@ -12,12 +12,12 @@ UNIT_TEST(DirectedAStarProgressCheck)
   m2::PointD finish = m2::PointD(0, 3);
   m2::PointD middle = m2::PointD(0, 2);
 
-  AStarProgress progress(0, 100);
-  progress.Initialize(start, finish);
-  TEST_LESS(progress.GetProgressForDirectedAlgo(start), 0.1f, ());
-  TEST_LESS(progress.GetProgressForDirectedAlgo(middle), 50.5f, ());
-  TEST_GREATER(progress.GetProgressForDirectedAlgo(middle), 49.5f, ());
-  TEST_GREATER(progress.GetProgressForDirectedAlgo(finish), 99.9f, ());
+  AStarProgress progress;
+  progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
+  TEST_LESS(progress.UpdateProgress(start, finish), 0.1f, ());
+  TEST_LESS(progress.UpdateProgress(middle, finish), 50.5f, ());
+  TEST_GREATER(progress.UpdateProgress(middle, finish), 49.5f, ());
+  TEST_GREATER(progress.UpdateProgress(finish, finish), 99.9f, ());
 }
 
 UNIT_TEST(DirectedAStarDegradationCheck)
@@ -26,14 +26,14 @@ UNIT_TEST(DirectedAStarDegradationCheck)
   m2::PointD finish = m2::PointD(0, 3);
   m2::PointD middle = m2::PointD(0, 2);
 
-  AStarProgress progress(0, 100);
-  progress.Initialize(start, finish);
-  auto value1 = progress.GetProgressForDirectedAlgo(middle);
-  auto value2 = progress.GetProgressForDirectedAlgo(start);
+  AStarProgress progress;
+  progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
+  auto value1 = progress.UpdateProgress(middle, finish);
+  auto value2 = progress.UpdateProgress(start, finish);
   TEST_LESS_OR_EQUAL(value1, value2, ());
 
-  progress.Initialize(start, finish);
-  auto value3 = progress.GetProgressForDirectedAlgo(start);
+  progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
+  auto value3 = progress.UpdateProgress(start, finish);
   TEST_GREATER_OR_EQUAL(value1, value3, ());
 }
 
@@ -44,25 +44,11 @@ UNIT_TEST(RangeCheckTest)
   m2::PointD preStart = m2::PointD(0, 0);
   m2::PointD postFinish = m2::PointD(0, 6);
 
-  AStarProgress progress(0, 100);
-  progress.Initialize(start, finish);
-  TEST_EQUAL(progress.GetProgressForDirectedAlgo(preStart), 0.0, ());
-  TEST_EQUAL(progress.GetProgressForDirectedAlgo(postFinish), 0.0, ());
-  TEST_EQUAL(progress.GetProgressForDirectedAlgo(finish), 100.0, ());
-}
-
-UNIT_TEST(DirectedAStarProgressCheckAtShiftedInterval)
-{
-  m2::PointD start = m2::PointD(0, 1);
-  m2::PointD finish = m2::PointD(0, 3);
-  m2::PointD middle = m2::PointD(0, 2);
-
-  AStarProgress progress(50, 250);
-  progress.Initialize(start, finish);
-  TEST_LESS(progress.GetProgressForDirectedAlgo(start), 50.1f, ());
-  TEST_LESS(progress.GetProgressForDirectedAlgo(middle), 150.5f, ());
-  TEST_GREATER(progress.GetProgressForDirectedAlgo(middle), 145.5f, ());
-  TEST_GREATER(progress.GetProgressForDirectedAlgo(finish), 245.9f, ());
+  AStarProgress progress;
+  progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
+  TEST_EQUAL(progress.UpdateProgress(preStart, finish), 0.0, ());
+  TEST_EQUAL(progress.UpdateProgress(postFinish, finish), 0.0, ());
+  TEST_EQUAL(progress.UpdateProgress(finish, finish), 100.0, ());
 }
 
 UNIT_TEST(BidirectedAStarProgressCheck)
@@ -72,10 +58,10 @@ UNIT_TEST(BidirectedAStarProgressCheck)
   m2::PointD fWave = m2::PointD(0, 1);
   m2::PointD bWave = m2::PointD(0, 3);
 
-  AStarProgress progress(0.0f, 100.0f);
-  progress.Initialize(start, finish);
-  progress.GetProgressForBidirectedAlgo(fWave, finish);
-  float result = progress.GetProgressForBidirectedAlgo(bWave, start);
+  AStarProgress progress;
+  progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
+  progress.UpdateProgress(fWave, finish);
+  float result = progress.UpdateProgress(bWave, start);
   TEST_GREATER(result, 49.5, ());
   TEST_LESS(result, 50.5, ());
 }

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		4408A63D21F1E7F0008171B8 /* index_graph_starter_joints.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */; };
 		4408A63E21F1E7F0008171B8 /* joint_segment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4408A63A21F1E7F0008171B8 /* joint_segment.cpp */; };
 		44183280222D45BB00C70BD9 /* routing_options_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4418327F222D45BB00C70BD9 /* routing_options_tests.cpp */; };
+		44A95C71225F6A4F00C22F4F /* astar_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44A95C6F225F6A4F00C22F4F /* astar_graph.hpp */; };
+		44A95C72225F6A4F00C22F4F /* astar_progress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44A95C70225F6A4F00C22F4F /* astar_progress.cpp */; };
 		44AE4A12214FBB8E006321F5 /* speed_camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44AE4A10214FBB8D006321F5 /* speed_camera.cpp */; };
 		44AE4A13214FBB8E006321F5 /* speed_camera.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44AE4A11214FBB8D006321F5 /* speed_camera.hpp */; };
 		44C56C0A22296498006C2A1D /* routing_options.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44C56C0822296498006C2A1D /* routing_options.hpp */; };
@@ -380,6 +382,8 @@
 		4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_starter_joints.hpp; sourceTree = "<group>"; };
 		4408A63A21F1E7F0008171B8 /* joint_segment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = joint_segment.cpp; sourceTree = "<group>"; };
 		4418327F222D45BB00C70BD9 /* routing_options_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_options_tests.cpp; sourceTree = "<group>"; };
+		44A95C6F225F6A4F00C22F4F /* astar_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = astar_graph.hpp; path = base/astar_graph.hpp; sourceTree = "<group>"; };
+		44A95C70225F6A4F00C22F4F /* astar_progress.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = astar_progress.cpp; path = base/astar_progress.cpp; sourceTree = "<group>"; };
 		44AE4A10214FBB8D006321F5 /* speed_camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera.cpp; sourceTree = "<group>"; };
 		44AE4A11214FBB8D006321F5 /* speed_camera.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera.hpp; sourceTree = "<group>"; };
 		44C56C0822296498006C2A1D /* routing_options.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_options.hpp; sourceTree = "<group>"; };
@@ -821,11 +825,12 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				44A95C6F225F6A4F00C22F4F /* astar_graph.hpp */,
+				44A95C70225F6A4F00C22F4F /* astar_progress.cpp */,
 				44C56C0922296498006C2A1D /* routing_options.cpp */,
 				44C56C0822296498006C2A1D /* routing_options.hpp */,
 				5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */,
 				56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */,
-				4408A63721F1E7F0008171B8 /* index_graph_starter_joints.cpp */,
 				4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */,
 				4408A63A21F1E7F0008171B8 /* joint_segment.cpp */,
 				4408A63821F1E7F0008171B8 /* joint_segment.hpp */,
@@ -1008,6 +1013,7 @@
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
 				40BEC0811F99FFD700E06CA4 /* transit_info.hpp in Headers */,
 				4065EA861F8260010094DEF3 /* transit_graph_loader.hpp in Headers */,
+				44A95C71225F6A4F00C22F4F /* astar_graph.hpp in Headers */,
 				6741AA9D1BF35331002C974C /* turns_notification_manager.hpp in Headers */,
 				5631B66C219B125D009F47D4 /* maxspeeds.hpp in Headers */,
 				674F9BD71B0A580E00704FFA /* turns_generator.hpp in Headers */,
@@ -1172,6 +1178,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1285,7 +1292,6 @@
 			files = (
 				0C5FEC641DDE192A0017688C /* joint.cpp in Sources */,
 				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
-				4408A63B21F1E7F0008171B8 /* index_graph_starter_joints.cpp in Sources */,
 				44C56C0B22296498006C2A1D /* routing_options.cpp in Sources */,
 				0C5F5D201E798B0400307B98 /* cross_mwm_connector_serialization.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
@@ -1294,6 +1300,7 @@
 				349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */,
 				56FEAA6F219E8A610073DF5F /* maxspeeds_serialization.cpp in Sources */,
 				5694CECC1EBA25F7004576D3 /* road_access.cpp in Sources */,
+				44A95C72225F6A4F00C22F4F /* astar_progress.cpp in Sources */,
 				F6C3A1B621AC298F0060EEC8 /* speed_camera_manager.cpp in Sources */,
 				A1616E2B1B6B60AB003F078E /* router_delegate.cpp in Sources */,
 				6741AA9C1BF35331002C974C /* turns_notification_manager.cpp in Sources */,


### PR DESCRIPTION
Что произошло:
Есть класс AStarProgress, он объединяет в себе под-прогрессы (AStarSubProgress). Они образуют список, так как эти подпрогрессы зависят друг от друга, а именно - у каждого подпрогресса есть свой вклад (contributionCoef)

Пример цепочки:
```cpp
// 1.0 - создается по умолчанию
// 0.4 - это участок между промежут. точками (текущий участок составляет 0.4 от всего, например)
// 0.3 - столько отводим для построения в режиме LeapsOnly
subProgress(1.0 /* contributionCoef */) -> subProgress(0.4)-> subProgress(0.3)
```
Что это означает?
Если где-то вызвали:
```cpp
update(current, finish)
```
То новый прогресс считается так:
```cpp
newProgress = 1.0 * (0.4 * (0.3 * progress(current, finish)))
```

Таким образом мы можем строить "зависимости" в стадиях.
Когда мы завершили последнюю текущую стадию (то есть последнюю в цепочке)
Вызываем
```
EraseLastSubProgress();
```
Это аккумулирует в предпоследней ноде макс. прогресс последней ноды и удаляет последнюю ноду, таким образом получится:
```cpp
// 1.0 - создается по умолчанию
// 0.4 - это участок между промежут. точками (текущий участок составляет 0.4 от всего, например)
subProgress(1.0 /* contributionCoef */, sum = 0.4 * 0.3) -> subProgress(0.4, sum = 0.3)
```

То есть как можно видеть в самой первой ноде хранится `0.4 * 0.3 = 0.12`. Теперь после LeapsOnly, добавляем новую ноду, которая будет отвечать за раскрутку Leaps, получим такую цепочку:
 ```cpp
// 1.0 - создается по умолчанию
// 0.4 - это участок между промежут. точками (текущий участок составляет 0.4 от всего, например)
// 0.7 - вклад от раскрутки Leaps в предыдущую ноду
subProgress(1.0 /* contributionCoef */, sum = 0.4 * 0.3) -> subProgress(0.4, sum = 0.3) -> subProgress(0.7, sum = 0)
```

Допустим всего Leaps у нас было 5, тогда каждый Leap вносит 1/5 в 0.7 (раскрутку Leaps)
Допустим мы уже раскрутили 2 Leaps, получаем такую цепочку:
 ```cpp
// 1.0 - создается по умолчанию
// 0.4 - это участок между промежут. точками (текущий участок составляет 0.4 от всего, например)
// 0.7 - вклад от раскрутки Leaps в предыдущую ноду (то есть в 0.4)
// 0.2 - вклад от раскрутки текущего Leap, в 0.7
subProgress(1.0 /* contributionCoef */, sum = 0 + 0.4 * (0.3 + 0.7 * 0.4) = 0.232) -> 
subProgress(0.4, sum = 0.3 + 0.7 * 0.4) -> 
subProgress(0.7, sum = 2 * 0.2 = 0.4) -> 
subProgress(0.2, sum = 0)
```

Получаем, что сейчас итоговый прогресс - 0.232
# Examples
## Before 
https://cloud.mail.ru/public/3KhX/MzvWAXQh9
## After
https://cloud.mail.ru/public/3cso/4pmN9hxGS




