### PR TITLE
 [std][routing] Use new include style for routing 

### DIFF
--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -32,6 +32,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace dp
@@ -58,7 +59,7 @@ public:
            double vs,
            double fontsScaleFactor,
            gui::TWidgetsInitInfo && info,
-           pair<location::EMyPositionMode, bool> const & initialMyPositionMode,
+           std::pair<location::EMyPositionMode, bool> const & initialMyPositionMode,
            location::TMyPositionModeChanged && myPositionModeChanged,
            bool allow3dBuildings,
            bool trafficEnabled,
@@ -100,7 +101,7 @@ public:
     double m_vs;
     double m_fontsScaleFactor;
     gui::TWidgetsInitInfo m_info;
-    pair<location::EMyPositionMode, bool> m_initialMyPositionMode;
+    std::pair<location::EMyPositionMode, bool> m_initialMyPositionMode;
     location::TMyPositionModeChanged m_myPositionModeChanged;
     bool m_allow3dBuildings;
     bool m_trafficEnabled;

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -14,7 +14,9 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 
-#include "std/limits.hpp"
+#include <limits>
+
+using namespace std;
 
 namespace routing
 {

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -14,11 +14,10 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <boost/optional.hpp>
 
@@ -35,11 +34,11 @@ public:
   using Weight = RouteWeight;
 
   IndexGraph() = default;
-  IndexGraph(shared_ptr<Geometry> geometry, shared_ptr<EdgeEstimator> estimator,
+  IndexGraph(std::shared_ptr<Geometry> geometry, std::shared_ptr<EdgeEstimator> estimator,
              RoutingOptions routingOptions = RoutingOptions());
 
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
-  void GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
+  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
   void GetEdgeList(Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
                    std::vector<RouteWeight> & parentWeights);
@@ -63,14 +62,14 @@ public:
   uint32_t GetNumPoints() const { return m_jointIndex.GetNumPoints(); }
 
   void Build(uint32_t numJoints);
-  void Import(vector<Joint> const & joints);
+  void Import(std::vector<Joint> const & joints);
 
   void SetRestrictions(RestrictionVec && restrictions);
   void SetRoadAccess(RoadAccess && roadAccess);
 
   // Interface for AStarAlgorithm:
-  void GetOutgoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
-  void GetIngoingEdgesList(Segment const & segment, vector<SegmentEdge> & edges);
+  void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges);
+  void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges);
 
   void PushFromSerializer(Joint::Id jointId, RoadPoint const & rp)
   {
@@ -80,7 +79,7 @@ public:
   template <typename F>
   void ForEachRoad(F && f) const
   {
-    m_roadIndex.ForEachRoad(forward<F>(f));
+    m_roadIndex.ForEachRoad(std::forward<F>(f));
   }
 
   template <typename F>
@@ -103,9 +102,9 @@ public:
 
 private:
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
-                           vector<SegmentEdge> & edges);
+                           std::vector<SegmentEdge> & edges);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
-                          vector<SegmentEdge> & edges);
+                          std::vector<SegmentEdge> & edges);
   RouteWeight GetPenalties(Segment const & u, Segment const & v);
 
   void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, std::vector<Segment> & children);
@@ -114,8 +113,8 @@ private:
                                bool isOutgoing, std::vector<JointEdge> & jointEdges,
                                std::vector<RouteWeight> & parentWeights);
 
-  shared_ptr<Geometry> m_geometry;
-  shared_ptr<EdgeEstimator> m_estimator;
+  std::shared_ptr<Geometry> m_geometry;
+  std::shared_ptr<EdgeEstimator> m_estimator;
   RoadIndex m_roadIndex;
   JointIndex m_jointIndex;
   RestrictionVec m_restrictions;

--- a/routing/joint.hpp
+++ b/routing/joint.hpp
@@ -4,9 +4,9 @@
 
 #include "base/buffer_vector.hpp"
 
-#include "std/cstdint.hpp"
-#include "std/limits.hpp"
-#include "std/string.hpp"
+#include <cstdint>
+#include <limits>
+#include <string>
 
 namespace routing
 {
@@ -16,7 +16,7 @@ class Joint final
 {
 public:
   using Id = uint32_t;
-  static Id constexpr kInvalidId = numeric_limits<Id>::max();
+  static Id constexpr kInvalidId = std::numeric_limits<Id>::max();
 
   void AddPoint(RoadPoint const & rp) { m_points.emplace_back(rp); }
 
@@ -28,5 +28,5 @@ private:
   buffer_vector<RoadPoint, 2> m_points;
 };
 
-string DebugPrint(Joint const & joint);
+std::string DebugPrint(Joint const & joint);
 }  // namespace routing

--- a/routing/online_absent_fetcher.cpp
+++ b/routing/online_absent_fetcher.cpp
@@ -8,9 +8,9 @@
 
 #include "base/stl_helpers.hpp"
 
-#include "std/vector.hpp"
-
 #include "private.h"
+
+using namespace std;
 
 using platform::CountryFile;
 using platform::LocalCountryFile;

--- a/routing/online_cross_fetcher.cpp
+++ b/routing/online_cross_fetcher.cpp
@@ -10,6 +10,8 @@
 
 #include "geometry/mercator.hpp"
 
+using namespace std;
+
 namespace
 {
 inline string LatLonToURLArgs(ms::LatLon const & point)

--- a/routing/online_cross_fetcher.hpp
+++ b/routing/online_cross_fetcher.hpp
@@ -10,8 +10,8 @@
 
 #include "base/thread.hpp"
 
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <string>
+#include <vector>
 
 namespace routing
 {
@@ -22,21 +22,21 @@ namespace routing
 /// \param finalPoint Coordinates of a finish point.
 /// \return URL for OSRM MAPS.ME server request.
 /// \see MapsMePlugin.hpp for REST protocol.
-string GenerateOnlineRequest(string const & serverURL, ms::LatLon const & startPoint,
+string GenerateOnlineRequest(std::string const & serverURL, ms::LatLon const & startPoint,
                              ms::LatLon const & finalPoint);
 
 /// \brief ParseResponse MAPS.ME OSRM server response parser.
 /// \param serverResponse Server response data.
 /// \param outPoints Mwm map points.
 /// \return true if there are some maps in a server's response.
-bool ParseResponse(string const & serverResponse, vector<m2::PointD> & outPoints);
+bool ParseResponse(std::string const & serverResponse, std::vector<m2::PointD> & outPoints);
 
 class OnlineCrossFetcher : public threads::IRoutine
 {
 public:
   /// \brief OnlineCrossFetcher helper class to make request to online OSRM server
   ///        and get mwm names list
-  OnlineCrossFetcher(TCountryFileFn const & countryFileFn, string const & serverURL,
+  OnlineCrossFetcher(TCountryFileFn const & countryFileFn, std::string const & serverURL,
                      Checkpoints const & checkpoints);
 
   /// Overrides threads::IRoutine processing procedure. Calls online OSRM server and parses response.
@@ -44,12 +44,12 @@ public:
 
   /// \brief GetMwmPoints returns mwm representation points list.
   /// \return Mwm points to build route from startPt to finishPt. Empty list if there were errors.
-  vector<m2::PointD> const & GetMwmPoints() { return m_mwmPoints; }
+  std::vector<m2::PointD> const & GetMwmPoints() { return m_mwmPoints; }
 
 private:
   TCountryFileFn const m_countryFileFn;
-  string const m_serverURL;
+  std::string const m_serverURL;
   Checkpoints const m_checkpoints;
-  vector<m2::PointD> m_mwmPoints;
+  std::vector<m2::PointD> m_mwmPoints;
 };
 }

--- a/routing/restriction_loader.cpp
+++ b/routing/restriction_loader.cpp
@@ -7,6 +7,10 @@
 
 #include "base/stl_helpers.hpp"
 
+#include <vector>
+
+using namespace std;
+
 namespace
 {
 using namespace routing;

--- a/routing/restriction_loader.hpp
+++ b/routing/restriction_loader.hpp
@@ -5,8 +5,8 @@
 
 #include "coding/file_container.hpp"
 
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
+#include <memory>
+#include <string>
 
 class MwmValue;
 
@@ -21,10 +21,10 @@ public:
   RestrictionVec && StealRestrictions() { return move(m_restrictions); }
 
 private:
-  unique_ptr<FilesContainerR::TReader> m_reader;
+  std::unique_ptr<FilesContainerR::TReader> m_reader;
   RestrictionHeader m_header;
   RestrictionVec m_restrictions;
-  string const m_countryFileName;
+  std::string const m_countryFileName;
 };
 
 void ConvertRestrictionsOnlyToNoAndSort(IndexGraph const & graph,

--- a/routing/restrictions_serialization.cpp
+++ b/routing/restrictions_serialization.cpp
@@ -1,6 +1,8 @@
 #include "routing/restrictions_serialization.hpp"
 
-#include "std/sstream.hpp"
+#include <sstream>
+
+using namespace std;
 
 namespace
 {

--- a/routing/routing_benchmarks/bicycle_routing_tests.cpp
+++ b/routing/routing_benchmarks/bicycle_routing_tests.cpp
@@ -9,14 +9,14 @@
 
 #include "geometry/mercator.hpp"
 
-#include "std/set.hpp"
-#include "std/string.hpp"
+#include <set>
+#include <string>
 
 namespace
 {
 // Test preconditions: files from the kMapFiles set with '.mwm'
 // extension must be placed in omim/data folder.
-set<string> const kMapFiles = {"Russia_Moscow"};
+std::set<std::string> const kMapFiles = {"Russia_Moscow"};
 
 class BicycleTest : public RoutingTest
 {

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -18,14 +18,16 @@
 
 #include "base/math.hpp"
 
-#include "std/string.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/utility.hpp"
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {
 using namespace feature;
 using namespace platform;
+using namespace std;
 
 LocalCountryFile GetLocalCountryFileByCountryId(CountryFile const & country)
 {

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -4,7 +4,7 @@
 #include "routing/road_graph.hpp"
 #include "routing/turn_candidate.hpp"
 
-#include "std/vector.hpp"
+#include <cstddef>
 
 namespace routing
 {

--- a/routing/routing_tests/applying_traffic_test.cpp
+++ b/routing/routing_tests/applying_traffic_test.cpp
@@ -18,14 +18,14 @@
 
 #include "routing/base/astar_algorithm.hpp"
 
-#include "std/shared_ptr.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/vector.hpp"
+#include <memory>
+#include <vector>
 
 namespace
 {
 using namespace routing;
 using namespace routing_test;
+using namespace std;
 using namespace traffic;
 
 // @TODO(bykoianko) When PR with applying restricions is merged BuildXXGraph()

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -4,14 +4,14 @@
 #include "routing/base/astar_graph.hpp"
 #include "routing/base/routing_result.hpp"
 
-#include "std/map.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <map>
+#include <utility>
+#include <vector>
 
 namespace routing_test
 {
-
-using namespace  routing;
+using namespace routing;
+using namespace std;
 
 struct Edge
 {

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -27,14 +27,13 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/cstdint.hpp"
-#include "std/map.hpp"
-#include "std/shared_ptr.hpp"
-#include "std/unique_ptr.hpp"
-#include "std/unordered_map.hpp"
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace routing_test
 {
@@ -47,15 +46,15 @@ NumMwmId constexpr kTestNumMwmId = 777;
 struct RestrictionTest
 {
   RestrictionTest() { classificator::Load(); }
-  void Init(unique_ptr<SingleVehicleWorldGraph> graph) { m_graph = move(graph); }
+  void Init(std::unique_ptr<SingleVehicleWorldGraph> graph) { m_graph = std::move(graph); }
   void SetStarter(FakeEnding const & start, FakeEnding const & finish);
   void SetRestrictions(RestrictionVec && restrictions)
   {
-    m_graph->GetIndexGraphForTests(kTestNumMwmId).SetRestrictions(move(restrictions));
+    m_graph->GetIndexGraphForTests(kTestNumMwmId).SetRestrictions(std::move(restrictions));
   }
 
-  unique_ptr<SingleVehicleWorldGraph> m_graph;
-  unique_ptr<IndexGraphStarter> m_starter;
+  std::unique_ptr<SingleVehicleWorldGraph> m_graph;
+  std::unique_ptr<IndexGraphStarter> m_starter;
 };
 
 class TestGeometryLoader final : public routing::GeometryLoader
@@ -72,7 +71,7 @@ public:
   void SetPassThroughAllowed(uint32_t featureId, bool passThroughAllowed);
 
 private:
-  unordered_map<uint32_t, routing::RoadGeometry> m_roads;
+  std::unordered_map<uint32_t, routing::RoadGeometry> m_roads;
 };
 
 class ZeroGeometryLoader final : public routing::GeometryLoader
@@ -99,10 +98,10 @@ public:
 
   void Clear() override;
 
-  void AddGraph(NumMwmId mwmId, unique_ptr<IndexGraph> graph);
+  void AddGraph(NumMwmId mwmId, std::unique_ptr<IndexGraph> graph);
 
 private:
-  unordered_map<NumMwmId, unique_ptr<IndexGraph>> m_graphs;
+  std::unordered_map<NumMwmId, std::unique_ptr<IndexGraph>> m_graphs;
 };
 
 class TestTransitGraphLoader : public TransitGraphLoader
@@ -114,10 +113,10 @@ public:
   TransitGraph & GetTransitGraph(NumMwmId mwmId, IndexGraph & indexGraph) override;
   void Clear() override;
 
-  void AddGraph(NumMwmId mwmId, unique_ptr<TransitGraph> graph);
+  void AddGraph(NumMwmId mwmId, std::unique_ptr<TransitGraph> graph);
 
 private:
-  unordered_map<NumMwmId, unique_ptr<TransitGraph>> m_graphs;
+  std::unordered_map<NumMwmId, std::unique_ptr<TransitGraph>> m_graphs;
 };
 
 // An estimator that uses the information from the supported |segmentWeights| map
@@ -129,7 +128,7 @@ class WeightedEdgeEstimator final : public EdgeEstimator
 public:
   // maxSpeedKMpH doesn't matter, but should be greater then any road speed in all tests.
   // offroadSpeedKMpH doesn't matter, but should be > 0 and <= maxSpeedKMpH.
-  explicit WeightedEdgeEstimator(map<Segment, double> const & segmentWeights)
+  explicit WeightedEdgeEstimator(std::map<Segment, double> const & segmentWeights)
     : EdgeEstimator(1e10 /* maxSpeedKMpH */, 1.0 /* offroadSpeedKMpH */)
     , m_segmentWeights(segmentWeights)
   {
@@ -143,7 +142,7 @@ public:
   double GetUTurnPenalty() const override;
 
 private:
-  map<Segment, double> m_segmentWeights;
+  std::map<Segment, double> m_segmentWeights;
 };
 
 // A simple class to test graph algorithms for the index graph
@@ -153,7 +152,7 @@ class TestIndexGraphTopology final
 {
 public:
   using Vertex = uint32_t;
-  using Edge = pair<Vertex, Vertex>;
+  using Edge = std::pair<Vertex, Vertex>;
 
   // Creates an empty graph on |numVertices| vertices.
   TestIndexGraphTopology(uint32_t numVertices);
@@ -170,7 +169,8 @@ public:
   void SetVertexAccess(Vertex v, RoadAccess::Type type);
 
   // Finds a path between the start and finish vertices. Returns true iff a path exists.
-  bool FindPath(Vertex start, Vertex finish, double & pathWeight, vector<Edge> & pathEdges) const;
+  bool FindPath(Vertex start, Vertex finish, double & pathWeight,
+                std::vector<Edge> & pathEdges) const;
 
 private:
   struct EdgeRequest
@@ -196,53 +196,54 @@ private:
   struct Builder
   {
     Builder(uint32_t numVertices) : m_numVertices(numVertices) {}
-    unique_ptr<SingleVehicleWorldGraph> PrepareIndexGraph();
+    std::unique_ptr<SingleVehicleWorldGraph> PrepareIndexGraph();
     void BuildJoints();
-    void BuildGraphFromRequests(vector<EdgeRequest> const & requests);
+    void BuildGraphFromRequests(std::vector<EdgeRequest> const & requests);
     void BuildSegmentFromEdge(EdgeRequest const & request);
 
     uint32_t const m_numVertices;
-    map<Edge, double> m_edgeWeights;
-    map<Segment, double> m_segmentWeights;
-    map<Segment, Edge> m_segmentToEdge;
-    map<Vertex, vector<Segment>> m_outgoingSegments;
-    map<Vertex, vector<Segment>> m_ingoingSegments;
-    vector<Joint> m_joints;
+    std::map<Edge, double> m_edgeWeights;
+    std::map<Segment, double> m_segmentWeights;
+    std::map<Segment, Edge> m_segmentToEdge;
+    std::map<Vertex, std::vector<Segment>> m_outgoingSegments;
+    std::map<Vertex, std::vector<Segment>> m_ingoingSegments;
+    std::vector<Joint> m_joints;
     RoadAccess m_roadAccess;
   };
 
-  void AddDirectedEdge(vector<EdgeRequest> & edgeRequests, Vertex from, Vertex to,
+  void AddDirectedEdge(std::vector<EdgeRequest> & edgeRequests, Vertex from, Vertex to,
                        double weight) const;
 
   uint32_t const m_numVertices;
-  vector<EdgeRequest> m_edgeRequests;
+  std::vector<EdgeRequest> m_edgeRequests;
 };
 
-unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> loader,
-                                                    shared_ptr<EdgeEstimator> estimator,
-                                                    vector<Joint> const & joints);
-unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoader> loader,
-                                                    shared_ptr<EdgeEstimator> estimator,
-                                                    vector<Joint> const & joints);
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(std::unique_ptr<TestGeometryLoader> loader,
+                                                    std::shared_ptr<EdgeEstimator> estimator,
+                                                    std::vector<Joint> const & joints);
+unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(std::unique_ptr<ZeroGeometryLoader> loader,
+                                                    std::shared_ptr<EdgeEstimator> estimator,
+                                                    std::vector<Joint> const & joints);
 
-routing::Joint MakeJoint(vector<routing::RoadPoint> const & points);
+routing::Joint MakeJoint(std::vector<routing::RoadPoint> const & points);
 
 shared_ptr<routing::EdgeEstimator> CreateEstimatorForCar(
     traffic::TrafficCache const & trafficCache);
-shared_ptr<routing::EdgeEstimator> CreateEstimatorForCar(shared_ptr<TrafficStash> trafficStash);
+shared_ptr<routing::EdgeEstimator> CreateEstimatorForCar(
+    std::shared_ptr<TrafficStash> trafficStash);
 
 AStarAlgorithm<Segment, SegmentEdge, RouteWeight>::Result CalculateRoute(
-    IndexGraphStarter & starter, vector<Segment> & roadPoints, double & timeSec);
+    IndexGraphStarter & starter, std::vector<Segment> & roadPoints, double & timeSec);
 
 void TestRouteGeometry(
     IndexGraphStarter & starter,
     AStarAlgorithm<Segment, SegmentEdge, RouteWeight>::Result expectedRouteResult,
-    vector<m2::PointD> const & expectedRouteGeom);
+    std::vector<m2::PointD> const & expectedRouteGeom);
 
 /// \brief Applies |restrictions| to graph in |restrictionTest| and
 /// tests the resulting route.
 /// \note restrictionTest should have a valid |restrictionTest.m_graph|.
-void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,
+void TestRestrictions(std::vector<m2::PointD> const & expectedRouteGeom,
                       AStarAlgorithm<Segment, SegmentEdge, RouteWeight>::Result expectedRouteResult,
                       FakeEnding const & start, FakeEnding const & finish,
                       RestrictionVec && restrictions, RestrictionTest & restrictionTest);
@@ -255,7 +256,7 @@ void TestRestrictions(vector<m2::PointD> const & expectedRouteGeom,
 void TestTopologyGraph(TestIndexGraphTopology const & graph, TestIndexGraphTopology::Vertex from,
                        TestIndexGraphTopology::Vertex to, bool expectedPathFound,
                        double const expectedWeight,
-                       vector<TestIndexGraphTopology::Edge> const & expectedEdges);
+                       std::vector<TestIndexGraphTopology::Edge> const & expectedEdges);
 
 // Creates FakeEnding projected to |Segment(kTestNumMwmId, featureId, segmentIdx, true /* forward
 // */)|.

--- a/routing/routing_tests/online_cross_fetcher_test.cpp
+++ b/routing/routing_tests/online_cross_fetcher_test.cpp
@@ -5,11 +5,12 @@
 
 #include "geometry/point2d.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <algorithm>
+#include <string>
+#include <vector>
 
 using namespace routing;
+using namespace std;
 
 namespace
 {

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -8,8 +8,8 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/shared_ptr.hpp"
+#include <algorithm>
+#include <memory>
 
 using namespace routing;
 using namespace std;

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -3,13 +3,14 @@
 #include "routing/road_graph.hpp"
 #include "routing/routing_tests/road_graph_builder.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/utility.hpp"
+#include <algorithm>
+#include <utility>
 
 namespace routing_test
 {
 
 using namespace routing;
+using namespace std;
 
 UNIT_TEST(RoadGraph_NearestEdges)
 {

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -11,12 +11,13 @@
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
-#include "std/set.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <set>
+#include <string>
+#include <vector>
 
 using namespace routing;
 using namespace routing::turns;
+using namespace std;
 
 namespace
 {

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -13,11 +13,12 @@
 
 #include "base/macros.hpp"
 
-#include "std/cmath.hpp"
-#include "std/string.hpp"
-#include "std/vector.hpp"
+#include <cmath>
+#include <string>
+#include <vector>
 
 using namespace routing;
+using namespace std;
 using namespace turns;
 
 namespace

--- a/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/routing/routing_tests/turns_tts_text_tests.cpp
@@ -3,13 +3,14 @@
 #include "routing/turns_sound_settings.hpp"
 #include "routing/turns_tts_text.hpp"
 
-#include "std/cstring.hpp"
-#include "std/string.hpp"
+#include <cstring>
+#include <string>
 
 namespace
 {
 using namespace routing::turns;
 using namespace routing::turns::sound;
+using namespace std;
 
 bool PairDistEquals(PairDist const & lhs, PairDist const & rhs)
 {

--- a/routing/turns_sound_settings.hpp
+++ b/routing/turns_sound_settings.hpp
@@ -4,8 +4,9 @@
 
 #include "platform/measurement_utils.hpp"
 
-#include "std/utility.hpp"
-#include "std/vector.hpp"
+#include <cstdint>
+#include <utility>
+#include <vector>
 
 namespace routing
 {
@@ -47,14 +48,15 @@ class Settings
 
   /// \brief m_distancesToPronounce is a list of distances in m_lengthUnits
   ///  which are ready to be pronounced.
-  vector<uint32_t> m_soundedDistancesUnits;
+  std::vector<uint32_t> m_soundedDistancesUnits;
   measurement_utils::Units m_lengthUnits;
 
   // This constructor is for testing only.
   Settings(uint32_t notificationTimeSeconds, uint32_t minNotificationDistanceUnits,
            uint32_t maxNotificationDistanceUnits, uint32_t startBeforeSeconds,
            uint32_t minStartBeforeMeters, uint32_t maxStartBeforeMeters,
-           uint32_t minDistToSayNotificationMeters, vector<uint32_t> const & soundedDistancesUnits,
+           uint32_t minDistToSayNotificationMeters,
+           std::vector<uint32_t> const & soundedDistancesUnits,
            measurement_utils::Units lengthUnits)
     : m_timeSeconds(notificationTimeSeconds)
     , m_minDistanceUnits(minNotificationDistanceUnits)
@@ -85,7 +87,7 @@ public:
 
   void SetState(uint32_t notificationTimeSeconds, uint32_t minNotificationDistanceUnits,
                 uint32_t maxNotificationDistanceUnits,
-                vector<uint32_t> const & soundedDistancesUnits,
+                std::vector<uint32_t> const & soundedDistancesUnits,
                 measurement_utils::Units lengthUnits);
 
   /// \brief IsValid checks if Settings data is consistent.
@@ -156,8 +158,8 @@ struct Notification
 
 string DebugPrint(Notification const & turnGeom);
 
-using PairDist = pair<uint32_t, char const *>;
-using VecPairDist = vector<PairDist>;
+using PairDist = std::pair<uint32_t, char const *>;
+using VecPairDist = std::vector<PairDist>;
 
 /// @return a reference to a vector of pairs of a distance in meters and a text id.
 /// All the distances are translated in supported languages and can be pronounced.
@@ -177,9 +179,9 @@ VecPairDist const & GetAllSoundedDistFeet();
 // to convert from vector<pair<uint32_t, char const *>> to vector<uint32_t>.
 
 /// @return distance in meters which are used for turn sound generation.
-vector<uint32_t> const & GetSoundedDistMeters();
+std::vector<uint32_t> const & GetSoundedDistMeters();
 /// @return distance in feet which are used for turn sound generation.
-vector<uint32_t> const & GetSoundedDistFeet();
+std::vector<uint32_t> const & GetSoundedDistFeet();
 
 }  // namespace sound
 }  // namespace turns

--- a/routing/turns_tts_text.cpp
+++ b/routing/turns_tts_text.cpp
@@ -3,10 +3,12 @@
 
 #include "base/string_utils.hpp"
 
-#include "std/algorithm.hpp"
-#include "std/iterator.hpp"
-#include "std/string.hpp"
-#include "std/utility.hpp"
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <utility>
+
+using namespace std;
 
 namespace
 {


### PR DESCRIPTION
drape engine сломался потому что он заинклюжен после роутинга в map/user_mark_layer.cpp и других местах, раньше туда попадали инклюды и using из роутинга