### PR TITLE
[generator:geo_objects] Refactoring: class RegionsDecoder

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -91,8 +91,12 @@ set(SRC
   geometry_holder.hpp
   geo_objects/geo_objects.cpp
   geo_objects/geo_objects.hpp
+  geo_objects/geo_object_info_getter.cpp
+  geo_objects/geo_object_info_getter.hpp
   geo_objects/key_value_storage.cpp
   geo_objects/key_value_storage.hpp
+  geo_objects/region_info_getter.cpp
+  geo_objects/region_info_getter.hpp
   holes.cpp
   holes.hpp
   intermediate_data.cpp

--- a/generator/geo_objects/geo_object_info_getter.cpp
+++ b/generator/geo_objects/geo_object_info_getter.cpp
@@ -1,0 +1,22 @@
+#include "generator/geo_objects/geo_object_info_getter.hpp"
+
+#include <utility>
+
+namespace generator
+{
+namespace geo_objects
+{
+GeoObjectInfoGetter::GeoObjectInfoGetter(indexer::GeoObjectsIndex<IndexReader> && index,
+                                         KeyValueStorage && kvStorage)
+    : m_index{std::move(index)}, m_storage{std::move(kvStorage)}
+{ }
+
+std::vector<base::GeoObjectId> GeoObjectInfoGetter::SearchObjectsInIndex(m2::PointD const & point) const
+{
+  std::vector<base::GeoObjectId> ids;
+  auto const emplace = [&ids] (base::GeoObjectId const & osmId) { ids.emplace_back(osmId); };
+  m_index.ForEachAtPoint(emplace, point);
+  return ids;
+}
+}  // namespace geo_objects
+}  // namespace generator

--- a/generator/geo_objects/geo_object_info_getter.hpp
+++ b/generator/geo_objects/geo_object_info_getter.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "generator/geo_objects/key_value_storage.hpp"
+
+#include "indexer/locality_index.hpp"
+
+#include "coding/reader.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/geo_object_id.hpp"
+
+#include <utility>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include "3party/jansson/myjansson.hpp"
+
+namespace generator
+{
+namespace geo_objects
+{
+class GeoObjectInfoGetter
+{
+public:
+  using IndexReader = ReaderPtr<Reader>;
+
+  GeoObjectInfoGetter(indexer::GeoObjectsIndex<IndexReader> && index, KeyValueStorage && kvStorage);
+
+  template <typename Predicate>
+  boost::optional<base::Json> Find(m2::PointD const & point, Predicate && pred) const;
+
+private:
+  std::vector<base::GeoObjectId> SearchObjectsInIndex(m2::PointD const & point) const;
+
+  indexer::GeoObjectsIndex<IndexReader> m_index;
+  KeyValueStorage m_storage;
+};
+
+template <typename Predicate>
+boost::optional<base::Json> GeoObjectInfoGetter::Find(m2::PointD const & point, Predicate && pred) const
+{
+  auto const ids = SearchObjectsInIndex(point);
+  for (auto const & id : ids)
+  {
+    auto const object = m_storage.Find(id.GetEncodedId());
+    if (!object)
+      continue;
+
+    if (pred(*object))
+      return object;
+  }
+
+  return {};
+}
+}  // namespace geo_objects
+}  // namespace generator

--- a/generator/geo_objects/geo_objects.hpp
+++ b/generator/geo_objects/geo_objects.hpp
@@ -11,7 +11,7 @@ namespace geo_objects
 // In this step, we need key-value pairs for the regions and the index for the regions.
 // Then we build an index for houses. And then we finish building key-value pairs for poi using
 // this index for houses.
-bool GenerateGeoObjects(std::string const & pathInRegionsIndx,
+bool GenerateGeoObjects(std::string const & pathInRegionsIndex,
                         std::string const & pathInRegionsKv,
                         std::string const & pathInGeoObjectsTmpMwm,
                         std::string const & pathOutIdsWithoutAddress,

--- a/generator/geo_objects/key_value_storage.cpp
+++ b/generator/geo_objects/key_value_storage.cpp
@@ -1,13 +1,21 @@
 #include "generator/geo_objects/key_value_storage.hpp"
 
+#include "coding/reader.hpp"
+
+#include "base/exception.hpp"
 #include "base/logging.hpp"
 
 namespace generator
 {
 namespace geo_objects
 {
-KeyValueStorage::KeyValueStorage(std::istream & stream, std::function<bool(KeyValue const &)> const & pred)
+KeyValueStorage::KeyValueStorage(std::string const & path,
+                                 std::function<bool(KeyValue const &)> const & pred)
 {
+  std::fstream stream{path};
+  if (!stream)
+    MYTHROW(Reader::OpenException, ("Failed to open file", path));
+
   std::string line;
   std::streamoff lineNumber = 0;
   while (std::getline(stream, line))

--- a/generator/geo_objects/key_value_storage.hpp
+++ b/generator/geo_objects/key_value_storage.hpp
@@ -20,8 +20,14 @@ using KeyValue = std::pair<uint64_t, base::Json>;
 class KeyValueStorage
 {
 public:
-  explicit KeyValueStorage(std::istream & stream,
+  explicit KeyValueStorage(std::string const & kvPath,
                            std::function<bool(KeyValue const &)> const & pred = DefaultPred);
+
+  KeyValueStorage(KeyValueStorage &&) = default;
+  KeyValueStorage & operator=(KeyValueStorage &&) = default;
+
+  KeyValueStorage(KeyValueStorage const &) = delete;
+  KeyValueStorage & operator=(KeyValueStorage const &) = delete;
 
   boost::optional<base::Json> Find(uint64_t key) const;
   size_t Size() const;

--- a/generator/geo_objects/region_info_getter.cpp
+++ b/generator/geo_objects/region_info_getter.cpp
@@ -1,0 +1,76 @@
+#include "generator/geo_objects/region_info_getter.hpp"
+
+#include "coding/mmap_reader.hpp"
+
+#include "base/logging.hpp"
+
+namespace generator
+{
+namespace geo_objects
+{
+RegionInfoGetter::RegionInfoGetter(std::string const & indexPath, std::string const & kvPath)
+    : m_index{indexer::ReadIndex<indexer::RegionsIndexBox<IndexReader>, MmapReader>(indexPath)}
+    , m_storage(kvPath)
+{ }
+
+boost::optional<KeyValue> RegionInfoGetter::FindDeepest(m2::PointD const & point) const
+{
+  auto const ids = SearchObjectsInIndex(point);
+  return GetDeepest(ids);
+}
+
+std::vector<base::GeoObjectId> RegionInfoGetter::SearchObjectsInIndex(m2::PointD const & point) const
+{
+  std::vector<base::GeoObjectId> ids;
+  auto const emplace = [&ids] (base::GeoObjectId const & osmId) { ids.emplace_back(osmId); };
+  m_index.ForEachAtPoint(emplace, point);
+  return ids;
+}
+
+boost::optional<KeyValue> RegionInfoGetter::GetDeepest(std::vector<base::GeoObjectId> const & ids) const
+{
+  boost::optional<KeyValue> deepest;
+  int deepestRank = 0;
+  for (auto const & id : ids)
+  {
+    base::Json temp;
+    auto const res = m_storage.Find(id.GetEncodedId());
+    if (!res)
+    {
+      LOG(LWARNING, ("Id not found in region key-value storage:", id));
+      continue;
+    }
+
+    temp = *res;
+    if (!json_is_object(temp.get()))
+    {
+      LOG(LWARNING, ("Value is not a json object in region key-value storage:", id));
+      continue;
+    }
+
+    int tempRank = GetRank(temp);
+    if (!deepest || deepestRank < tempRank)
+    {
+      deepestRank = tempRank;
+      deepest = KeyValue(static_cast<int64_t>(id.GetEncodedId()), temp);
+    }
+  }
+
+  return deepest;
+}
+
+int RegionInfoGetter::GetRank(base::Json const & json) const
+{
+  json_t * properties = nullptr;
+  FromJSONObject(json.get(), "properties", properties);
+  int rank;
+  FromJSONObject(properties, "rank", rank);
+  return rank;
+}
+
+KeyValueStorage const & RegionInfoGetter::GetStorage() const noexcept
+{
+  return m_storage;
+}
+}  // namespace geo_objects
+}  // namespace generator

--- a/generator/geo_objects/region_info_getter.hpp
+++ b/generator/geo_objects/region_info_getter.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "generator/geo_objects/key_value_storage.hpp"
+
+#include "indexer/locality_index.hpp"
+
+#include "coding/reader.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/geo_object_id.hpp"
+
+#include <string>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include "3party/jansson/myjansson.hpp"
+
+namespace generator
+{
+namespace geo_objects
+{
+class RegionInfoGetter
+{
+public:
+  RegionInfoGetter(std::string const & indexPath, std::string const & kvPath);
+
+  boost::optional<KeyValue> FindDeepest(m2::PointD const & point) const;
+  KeyValueStorage const & GetStorage() const noexcept;
+
+private:
+  using IndexReader = ReaderPtr<Reader>;
+
+  std::vector<base::GeoObjectId> SearchObjectsInIndex(m2::PointD const & point) const;
+  boost::optional<KeyValue> GetDeepest(std::vector<base::GeoObjectId> const & ids) const;
+  int GetRank(base::Json const & json) const;
+
+  indexer::RegionsIndex<IndexReader> m_index;
+  KeyValueStorage m_storage;
+};
+}  // namespace geo_objects
+}  // namespace generator

--- a/indexer/locality_index.hpp
+++ b/indexer/locality_index.hpp
@@ -40,6 +40,11 @@ public:
     m_intervalIndex = std::make_unique<IntervalIndex<Reader, uint64_t>>(reader);
   }
 
+  void ForEachAtPoint(ProcessObject const & processObject, m2::PointD const & point) const
+  {
+    ForEachInRect(processObject, m2::RectD(point, point));
+  }
+
   void ForEachInRect(ProcessObject const & processObject, m2::RectD const & rect) const
   {
     covering::CoveringGetter cov(rect, covering::CoveringMode::ViewportWithLowLevels);


### PR DESCRIPTION
Рефакторинг для фикса проверки границы региона и для повторного использования в генерации улиц.

Перенёс код обратного поиска региона и строения в классы RegionsDecoder и GeoObjectsDecoder.
KeyValueStorage принимает путь, вместо потока.
