### PR TITLE
[search] [assessment-tool] Changed the display of the user's position.

### DIFF
--- a/search/search_quality/assessment_tool/sample_view.hpp
+++ b/search/search_quality/assessment_tool/sample_view.hpp
@@ -6,6 +6,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include "kml/type_utils.hpp"
+
 #include <boost/optional.hpp>
 
 #include <QtCore/QMargins>
@@ -89,6 +91,8 @@ private:
 
   QMargins m_rightAreaMargins;
   QMargins m_defaultMargins;
+
+  kml::MarkId m_positionMarkId = kml::kInvalidMarkId;
 
   boost::optional<m2::PointD> m_position;
 };


### PR DESCRIPTION
We used to call Framework's methods (OnLocationUpdate/OnLocationError)
here but they come bundled with an unremovable heuristic that keeps the
old position for some time when the position is lost.
This resulted in sometimes showing wrong positions for the samples that
do not have position info (the search params worked correctly
and were not using the old pos).