### PR TITLE
[generator] Added handler for exceptions and errors.

### DIFF
--- a/generator/generator_tool/CMakeLists.txt
+++ b/generator/generator_tool/CMakeLists.txt
@@ -43,6 +43,7 @@ omim_link_libraries(
   gflags
   oauthcpp
   sqlite3
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
 )
 


### PR DESCRIPTION
Данный реквест печает стектрейс при возникновении исключительной ситуации. (exception, CHECK, ASSERT..)
Это помогает быстро понять, где произошла проблема.
Так же теперь нет необходимости писать дублирующий код:
```
try 
{
// some code
}
catch(std::exception const & e)
{
LOG(LCRITICAL, (..., e.what()));
}
```
плюс к этому, платформы тоже умеют печатать стектрейс

реализуется с помощью header only boost

Пример вывода на linux при указании неверного пути файла(удобно читать с конца):
```
Core exception: File types.txt doesn't exist in the scope wrf Have been looking in:
 /
/home/andrianov/Projects/omim/dataf/
/home/andrianov/Projects/omim/dataf/
 0# ErrorHandler() in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
 1# 0x0000563866247474 in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
 2# 0x0000563866247491 in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
 3# 0x00007FB8B4D50F20 in /lib/x86_64-linux-gnu/libc.so.6
 4# gsignal in /lib/x86_64-linux-gnu/libc.so.6
 5# abort in /lib/x86_64-linux-gnu/libc.so.6
 6# 0x00007FB8B57455BF in /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 7# 0x00007FB8B574BA41 in /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 8# 0x00007FB8B574BC74 in /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 9# Platform::ReadPathForFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) const in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
10# Platform::GetReader(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
11# classificator::Load() in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
12# GeneratorToolMain(int, char**) in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
13# main in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
14# __libc_start_main in /lib/x86_64-linux-gnu/libc.so.6
15# _start in /home/andrianov/Projects/build-omim_copy-Desktop_Qt_5_10_1_GCC_64bit-Debug/generator_tool
```