### PR TITLE
Road warnings displacement.

### DIFF
--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -862,7 +862,6 @@ drape_ptr<UserMarkRenderParams> DrapeEngine::GenerateMarkRenderInfo(UserPointMar
   renderInfo->m_minZoom = mark->GetMinZoom();
   renderInfo->m_minTitleZoom = mark->GetMinTitleZoom();
   renderInfo->m_isVisible = mark->IsVisible();
-  renderInfo->m_alwaysVisibleMinZoom = mark->GetAlwaysVisibleMinZoom();
   renderInfo->m_pivot = mark->GetPivot();
   renderInfo->m_pixelOffset = mark->GetPixelOffset();
   renderInfo->m_titleDecl = mark->GetTitleDecl();

--- a/drape_frontend/user_mark_shapes.cpp
+++ b/drape_frontend/user_mark_shapes.cpp
@@ -362,7 +362,7 @@ void CacheUserMarks(ref_ptr<dp::GraphicsContext> context, TileKey const & tileKe
       continue;
 
     UserMarkRenderParams & renderInfo = *it->second;
-    if (!renderInfo.m_isVisible && renderInfo.m_alwaysVisibleMinZoom > tileKey.m_zoomLevel)
+    if (!renderInfo.m_isVisible)
       continue;
 
     m2::PointD const tileCenter = tileKey.GetGlobalRect().Center();

--- a/drape_frontend/user_mark_shapes.hpp
+++ b/drape_frontend/user_mark_shapes.hpp
@@ -39,7 +39,6 @@ struct UserMarkRenderParams
   bool m_hasCreationAnimation = false;
   bool m_justCreated = false;
   bool m_isVisible = true;
-  int m_alwaysVisibleMinZoom = std::numeric_limits<int>::max();
   FeatureID m_featureId;
   bool m_isMarkAboveText = false;
 };

--- a/drape_frontend/user_marks_provider.hpp
+++ b/drape_frontend/user_marks_provider.hpp
@@ -65,7 +65,6 @@ public:
   virtual float GetDepth() const = 0;
   virtual DepthLayer GetDepthLayer() const = 0;
   virtual bool IsVisible() const = 0;
-  virtual int GetAlwaysVisibleMinZoom() const = 0;
   virtual drape_ptr<TitlesInfo> GetTitleDecl() const = 0;
   virtual drape_ptr<SymbolNameZoomInfo> GetSymbolNames() const = 0;
   virtual drape_ptr<SymbolNameZoomInfo> GetBadgeNames() const = 0;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2303,8 +2303,6 @@ void Framework::ActivateMapSelection(bool needAnimation, df::SelectionShape::ESe
   SetDisplacementMode(DisplacementModeManager::SLOT_MAP_SELECTION,
                       ftypes::IsHotelChecker::Instance()(info.GetTypes()) /* show */);
 
-  m_routingManager.UpdateRouteMarksVisibility(info.IsRoadType() ? info.GetRoadType() : RoadWarningMarkType::Count);
-
   if (m_activateMapSelectionFn)
     m_activateMapSelectionFn(info);
   else
@@ -2318,8 +2316,6 @@ void Framework::DeactivateMapSelection(bool notifyUI)
 
   if (notifyUI && m_deactivateMapSelectionFn)
     m_deactivateMapSelectionFn(!somethingWasAlreadySelected);
-
-  m_routingManager.UpdateRouteMarksVisibility(RoadWarningMarkType::Count);
 
   if (somethingWasAlreadySelected && m_drapeEngine != nullptr)
     m_drapeEngine->DeselectObject();
@@ -2545,12 +2541,7 @@ UserMark const * Framework::FindUserMarkInTapPosition(df::TapInfo const & tapInf
         return tapInfo.GetRoutingPointSearchRect(m_currentModelView);
       return tapInfo.GetDefaultSearchRect(m_currentModelView);
     },
-    [this](UserMark::Type type)
-    {
-      if (type == UserMark::Type::ROAD_WARNING)
-        return GetDrawScale() < RoadWarningMark::kAlwaysVisibleMinZoom;
-      return false;
-    });
+    [](UserMark::Type type) { return false; });
   return mark;
 }
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2392,6 +2392,9 @@ void Framework::OnTapEvent(TapEvent const & tapEvent)
           kv["partner"] = info.GetPartnerName();
       }
 
+      if (info.IsRoadType())
+        kv["road_warning"] = DebugPrint(info.GetRoadType());
+
       // Older version of statistics used "$GetUserMark" event.
       alohalytics::Stats::Instance().LogEvent("$SelectMapObject", kv,
                                               alohalytics::Location::FromLatLon(ll.lat, ll.lon));

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -362,6 +362,7 @@ void Info::SetRoadType(FeatureType & ft, RoadWarningMarkType type, std::string c
       m_uiTitle = localizedType;
     else
       subtitle.push_back(localizedType);
+    subtitle.push_back(distance);
   }
   else if (type == RoadWarningMarkType::Dirty)
   {

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -590,7 +590,6 @@ void RoutingManager::CreateRoadWarningMarks(RoadWarningsCollection && roadWarnin
         auto const & routeInfo = typeInfo.second[i];
         auto mark = es.CreateUserMark<RoadWarningMark>(routeInfo.m_startPoint);
         mark->SetIndex(static_cast<uint32_t>(i));
-        mark->SetIsVisible(i == 0);
         mark->SetRoadWarningType(type);
         mark->SetFeatureId(routeInfo.m_featureId);
         std::string distanceStr;
@@ -1494,19 +1493,4 @@ void RoutingManager::SetSubroutesVisibility(bool visible)
 bool RoutingManager::IsSpeedLimitExceeded() const
 {
   return m_routingSession.IsSpeedLimitExceeded();
-}
-
-void RoutingManager::UpdateRouteMarksVisibility(RoadWarningMarkType selectedType)
-{
-  auto const markIds = m_bmManager->GetUserMarkIds(UserMark::Type::ROAD_WARNING);
-  if (markIds.empty())
-    return;
-
-  auto es = m_bmManager->GetEditSession();
-  for (auto id : markIds)
-  {
-    auto mark = es.GetMarkForEdit<RoadWarningMark>(id);
-    auto const isVisible = mark->GetIndex() == 0 || selectedType == mark->GetRoadWarningType();
-    mark->SetIsVisible(isVisible);
-  }
 }

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -286,8 +286,6 @@ public:
   /// \brief It deletes file with saved route points if it exists.
   void DeleteSavedRoutePoints();
 
-  void UpdateRouteMarksVisibility(RoadWarningMarkType selectedType);
-
   void UpdatePreviewMode();
   void CancelPreviewMode();
 

--- a/map/routing_mark.cpp
+++ b/map/routing_mark.cpp
@@ -621,16 +621,25 @@ RoadWarningMark::RoadWarningMark(m2::PointD const & ptOrg)
   : UserMark(ptOrg, Type::ROAD_WARNING)
 {}
 
+uint16_t RoadWarningMark::GetPriority() const
+{
+  if (m_index == 0)
+  {
+    switch (m_type)
+    {
+    case RoadWarningMarkType::Toll: return static_cast<uint16_t>(Priority::RoadWarningFirstToll);
+    case RoadWarningMarkType::Ferry: return static_cast<uint16_t>(Priority::RoadWarningFirstFerry);
+    case RoadWarningMarkType::Dirty: return static_cast<uint16_t>(Priority::RoadWarningFirstDirty);
+    case RoadWarningMarkType::Count: CHECK(false, ()); break;
+    }
+  }
+  return static_cast<uint16_t>(Priority::RoadWarning);
+}
+
 void RoadWarningMark::SetIndex(uint32_t index)
 {
   SetDirty();
   m_index = index;
-}
-
-void RoadWarningMark::SetIsVisible(bool isVisible)
-{
-  SetDirty();
-  m_isVisible = isVisible;
 }
 
 void RoadWarningMark::SetRoadWarningType(RoadWarningMarkType type)
@@ -664,13 +673,6 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RoadWarningMark::GetSymbolNames
   auto symbol = make_unique_dp<SymbolNameZoomInfo>();
   symbol->insert(std::make_pair(1 /* zoomLevel */, symbolName));
   return symbol;
-}
-
-drape_ptr<df::UserPointMark::ColoredSymbolZoomInfo> RoadWarningMark::GetColoredSymbols() const
-{
-  auto coloredSymbol = make_unique_dp<ColoredSymbolZoomInfo>();
-  coloredSymbol->m_isSymbolStub = true;
-  return coloredSymbol;
 }
 
 // static

--- a/map/routing_mark.hpp
+++ b/map/routing_mark.hpp
@@ -207,20 +207,16 @@ enum class RoadWarningMarkType : uint8_t
 class RoadWarningMark : public UserMark
 {
 public:
-  static int constexpr kAlwaysVisibleMinZoom = 13;
-
   explicit RoadWarningMark(m2::PointD const & ptOrg);
 
+  bool SymbolIsPOI() const override { return true; }
   dp::Anchor GetAnchor() const override { return dp::Anchor::Bottom; }
   df::DepthLayer GetDepthLayer() const override { return df::DepthLayer::RoutingBottomMarkLayer; }
-  uint16_t GetPriority() const override { return static_cast<uint16_t>(Priority::RoadWarning); }
+  uint16_t GetPriority() const override;
   df::SpecialDisplacement GetDisplacement() const override { return df::SpecialDisplacement::SpecialModeUserMark; }
 
   void SetIndex(uint32_t index);
   uint32_t GetIndex() const override { return m_index; }
-
-  void SetIsVisible(bool isVisible);
-  bool IsVisible() const override { return m_isVisible; }
 
   void SetRoadWarningType(RoadWarningMarkType type);
   RoadWarningMarkType GetRoadWarningType() const { return m_type; }
@@ -233,10 +229,6 @@ public:
 
   drape_ptr<SymbolNameZoomInfo> GetSymbolNames() const override;
 
-  drape_ptr<ColoredSymbolZoomInfo> GetColoredSymbols() const override;
-
-  int GetAlwaysVisibleMinZoom() const override { return kAlwaysVisibleMinZoom; }
-
   static std::string GetLocalizedRoadWarningType(RoadWarningMarkType type);
 
 private:
@@ -244,7 +236,6 @@ private:
   FeatureID m_featureId;
   uint32_t m_index = 0;
   std::string m_distance;
-  bool m_isVisible = true;
 };
 
 std::string DebugPrint(RoadWarningMarkType type);

--- a/map/user_mark.hpp
+++ b/map/user_mark.hpp
@@ -31,6 +31,9 @@ public:
     TransitKeyStop,
     SpeedCamera,
     RoadWarning,
+    RoadWarningFirstFerry,
+    RoadWarningFirstDirty,
+    RoadWarningFirstToll,
   };
 
   enum Type : uint32_t
@@ -62,7 +65,6 @@ public:
   bool IsDirty() const override { return m_isDirty; }
   void ResetChanges() const override { m_isDirty = false; }
   bool IsVisible() const override { return true; }
-  int GetAlwaysVisibleMinZoom() const override { return std::numeric_limits<int>::max(); }
   m2::PointD const & GetPivot() const override;
   m2::PointD GetPixelOffset() const override { return {}; }
   dp::Anchor GetAnchor() const override { return dp::Center; }


### PR DESCRIPTION
Изменена логика отображения предупреждений, теперь все метки видны и вытесняются между собой.
Приоритет вытеснения:
* первая метка платной дороги
* первая метка грунтовой дороги
* первая метка паромной переправы
* остальные метки