### PR TITLE
[generator:regions] Ignore place=locality

### DIFF
--- a/generator/regions/collector_region_info.cpp
+++ b/generator/regions/collector_region_info.cpp
@@ -27,7 +27,6 @@ PlaceType EncodePlaceType(std::string const & place)
     {"suburb", PlaceType::Suburb},
     {"neighbourhood", PlaceType::Neighbourhood},
     {"hamlet", PlaceType::Hamlet},
-    {"locality", PlaceType::Locality},
     {"isolated_dwelling", PlaceType::IsolatedDwelling}
   };
 

--- a/generator/regions/collector_region_info.hpp
+++ b/generator/regions/collector_region_info.hpp
@@ -50,8 +50,7 @@ enum class PlaceType: uint8_t
   Hamlet = 12,
   Suburb = 13,
   Neighbourhood = 14,
-  Locality = 15,
-  IsolatedDwelling = 16,
+  IsolatedDwelling = 15,
 };
 
 PlaceType EncodePlaceType(std::string const & place);

--- a/generator/regions/region.cpp
+++ b/generator/regions/region.cpp
@@ -73,7 +73,6 @@ double Region::GetRadiusByPlaceType(PlaceType place)
   case PlaceType::Neighbourhood:
   case PlaceType::IsolatedDwelling:
     return 0.0035;
-  case PlaceType::Locality:
   case PlaceType::Unknown:
     UNREACHABLE();
   }
@@ -167,7 +166,7 @@ bool FeatureCityPointToRegion(RegionInfo const & regionInfo, FeatureBuilder1 & f
     return false;
 
   auto const placeType = info.GetPlaceType();
-  if (placeType == PlaceType::Locality || placeType == PlaceType::Unknown)
+  if (placeType == PlaceType::Unknown)
     return false;
 
   auto const radius = Region::GetRadiusByPlaceType(placeType);

--- a/generator/regions/regions_builder.cpp
+++ b/generator/regions/regions_builder.cpp
@@ -167,7 +167,6 @@ PlaceLevel RegionsBuilder::GetLevel(Region const & region)
   case PlaceType::Suburb:
   case PlaceType::Neighbourhood:
     return PlaceLevel::Suburb;
-  case PlaceType::Locality:
   case PlaceType::IsolatedDwelling:
     return PlaceLevel::Sublocality;
   case PlaceType::Unknown:
@@ -202,7 +201,6 @@ size_t RegionsBuilder::GetWeight(Region const & region)
   case PlaceType::Suburb:
   case PlaceType::Neighbourhood:
     return 2;
-  case PlaceType::Locality:
   case PlaceType::IsolatedDwelling:
     return 1;
   case PlaceType::Unknown:

--- a/generator/regions/regions_fixer.cpp
+++ b/generator/regions/regions_fixer.cpp
@@ -84,7 +84,7 @@ private:
   bool NeedCity(const City & city)
   {
     auto const placeType = city.GetPlaceType();
-    return placeType >= PlaceType::City && placeType != PlaceType::Locality;
+    return placeType >= PlaceType::City;
   }
 
   RegionsBuilder::Regions m_regions;


### PR DESCRIPTION
Исключил place=locality для regions. Для b2b эти объекты не интересны.
См. https://wiki.openstreetmap.org/wiki/Tag:place%3Dlocality