### PR TITLE
[generator] Change feature id to osm id mapping type from uint32_t->vector<GeoObjectId> to uint32_t->GeoObjectId

### DIFF
--- a/generator/cities_boundaries_builder.cpp
+++ b/generator/cities_boundaries_builder.cpp
@@ -39,8 +39,7 @@ namespace generator
 {
 namespace
 {
-bool ParseFeatureIdToTestIdMapping(string const & path,
-                                   unordered_map<uint32_t, vector<uint64_t>> & mapping)
+bool ParseFeatureIdToTestIdMapping(string const & path, unordered_map<uint32_t, uint64_t> & mapping)
 {
   bool success = true;
   feature::ForEachFromDat(path, [&](FeatureType & feature, uint32_t fid) {
@@ -53,7 +52,7 @@ bool ParseFeatureIdToTestIdMapping(string const & path,
       success = false;
       return;
     }
-    mapping[fid].push_back(tid);
+    mapping.emplace(fid, tid);
   });
   return success;
 }
@@ -86,11 +85,8 @@ bool BuildCitiesBoundaries(string const & dataPath, BoundariesTable & table,
     auto it = mapping->find(base::asserted_cast<uint32_t>(fid));
     if (it != mapping->end())
     {
-      for (auto const & id : it->second)
-      {
-        auto const & b = table.Get(id);
-        bs.insert(bs.end(), b.begin(), b.end());
-      }
+      auto const & b = table.Get(it->second);
+      bs.insert(bs.end(), b.begin(), b.end());
     }
 
     all.emplace_back(move(bs));
@@ -107,7 +103,7 @@ bool BuildCitiesBoundaries(string const & dataPath, BoundariesTable & table,
 bool BuildCitiesBoundaries(string const & dataPath, string const & osmToFeaturePath,
                            OsmIdToBoundariesTable & table)
 {
-  using Mapping = unordered_map<uint32_t, vector<base::GeoObjectId>>;
+  using Mapping = unordered_map<uint32_t, base::GeoObjectId>;
 
   return BuildCitiesBoundaries(dataPath, table, [&]() -> unique_ptr<Mapping> {
     Mapping mapping;
@@ -122,7 +118,7 @@ bool BuildCitiesBoundaries(string const & dataPath, string const & osmToFeatureP
 
 bool BuildCitiesBoundariesForTesting(string const & dataPath, TestIdToBoundariesTable & table)
 {
-  using Mapping = unordered_map<uint32_t, vector<uint64_t>>;
+  using Mapping = unordered_map<uint32_t, uint64_t>;
 
   return BuildCitiesBoundaries(dataPath, table, [&]() -> unique_ptr<Mapping> {
     Mapping mapping;

--- a/generator/descriptions_section_builder.cpp
+++ b/generator/descriptions_section_builder.cpp
@@ -55,10 +55,10 @@ WikidataHelper::WikidataHelper(std::string const & mwmPath, std::string const & 
 boost::optional<std::string> WikidataHelper::GetWikidataId(uint32_t featureId) const
 {
   auto const itFeatureIdToOsmId = m_featureIdToOsmId.find(featureId);
-  if (itFeatureIdToOsmId == std::end(m_featureIdToOsmId) || itFeatureIdToOsmId->second.size() == 0)
+  if (itFeatureIdToOsmId == std::end(m_featureIdToOsmId))
     return {};
 
-  auto const osmId = itFeatureIdToOsmId->second[0];
+  auto const osmId = itFeatureIdToOsmId->second;
   auto const itOsmIdToWikidataId = m_osmIdToWikidataId.find(osmId);
   return itOsmIdToWikidataId == std::end(m_osmIdToWikidataId) ?
         boost::optional<std::string>() : itOsmIdToWikidataId->second;

--- a/generator/descriptions_section_builder.hpp
+++ b/generator/descriptions_section_builder.hpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include <boost/optional.hpp>
 
@@ -46,7 +45,7 @@ public:
 private:
   std::string m_mwmPath;
   std::string m_idToWikidataPath;
-  std::unordered_map<uint32_t, std::vector<base::GeoObjectId>> m_featureIdToOsmId;
+  std::unordered_map<uint32_t, base::GeoObjectId> m_featureIdToOsmId;
   std::unordered_map<base::GeoObjectId, std::string> m_osmIdToWikidataId;
 };
 

--- a/generator/popular_places_section_builder.cpp
+++ b/generator/popular_places_section_builder.cpp
@@ -71,7 +71,7 @@ bool BuildPopularPlacesMwmSection(std::string const & srcFilename, std::string c
 
   LOG(LINFO, ("Build Popular Places section"));
 
-  std::unordered_map<uint32_t, std::vector<base::GeoObjectId>> featureIdToOsmId;
+  std::unordered_map<uint32_t, base::GeoObjectId> featureIdToOsmId;
   if (!ParseFeatureIdToOsmIdMapping(osmToFeatureFilename, featureIdToOsmId))
     return false;
 
@@ -88,9 +88,9 @@ bool BuildPopularPlacesMwmSection(std::string const & srcFilename, std::string c
     PopularityIndex rank = 0;
     auto const it = featureIdToOsmId.find(featureId);
     // Non-OSM features (coastlines, sponsored objects) are not used.
-    if (it != featureIdToOsmId.cend() && it->second.size() != 0)
+    if (it != featureIdToOsmId.cend())
     {
-      auto const placesIt = places.find(it->second[0]);
+      auto const placesIt = places.find(it->second);
 
       if (placesIt != places.cend())
       {

--- a/generator/utils.cpp
+++ b/generator/utils.cpp
@@ -7,6 +7,8 @@
 #include "base/assert.hpp"
 #include "base/logging.hpp"
 
+#include <vector>
+
 namespace generator
 {
 // SingleMwmDataSource -----------------------------------------------------------------------------
@@ -26,7 +28,7 @@ SingleMwmDataSource::SingleMwmDataSource(std::string const & mwmPath)
 
 void LoadDataSource(DataSource & dataSource)
 {
-  vector<platform::LocalCountryFile> localFiles;
+  std::vector<platform::LocalCountryFile> localFiles;
 
   Platform & platform = GetPlatform();
   platform::FindAllLocalMapsInDirectoryAndCleanup(platform.WritableDir(), 0 /* version */,
@@ -45,13 +47,11 @@ void LoadDataSource(DataSource & dataSource)
   }
 }
 
-bool ParseFeatureIdToOsmIdMapping(
-    std::string const & path,
-    std::unordered_map<uint32_t, std::vector<base::GeoObjectId>> & mapping)
+bool ParseFeatureIdToOsmIdMapping(std::string const & path,
+                                  std::unordered_map<uint32_t, base::GeoObjectId> & mapping)
 {
-  return ForEachOsmId2FeatureId(path,
-                                [&](base::GeoObjectId const & osmId, uint32_t const featureId) {
-                                  mapping[featureId].push_back(osmId);
-                                });
+  return ForEachOsmId2FeatureId(path, [&](base::GeoObjectId const & osmId, uint32_t const featureId) {
+    CHECK(mapping.emplace(featureId, osmId).second, ("Several osm ids for feature", featureId, "in file", path));
+  });
 }
 }  // namespace generator

--- a/generator/utils.hpp
+++ b/generator/utils.hpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace generator
 {
@@ -63,7 +62,6 @@ bool ForEachOsmId2FeatureId(std::string const & path, ToDo && toDo)
   return true;
 }
 
-bool ParseFeatureIdToOsmIdMapping(
-    std::string const & path,
-    std::unordered_map<uint32_t, std::vector<base::GeoObjectId>> & mapping);
+bool ParseFeatureIdToOsmIdMapping(std::string const & path,
+                                  std::unordered_map<uint32_t, base::GeoObjectId> & mapping);
 }  // namespace generator


### PR DESCRIPTION
Каждой фиче соответствует один osm элемент (обратное не верно).
По построению файлов мэпинга из OsmId в FeatureId это тоже видно:
файл создается в FeaturesCollector2::operator(FeatureBuilder2 & fb) из generator//feature_sorter.cpp
видно, что там для фичи один раз добавляется OsmId, а оператор вызывается для каждой фичи единожды (и создаёт из временной фичи которая берётся из mwm.tmp конечную, которая идёт в итоговую mwm).
Единственным местом где "использовалось" то что GeoObjectId может быть несколько было построение cities_boundaries, они собираются в процессе построения World.mwm с мэпингом OsmId в FeatureId для World.mwm -- распарсила последний, ещё раз убедилась что нет фичей, которым соответствует несколько OsmId.
Собрала из этого реквеста "маленький мир", всё ок.