### PR TITLE
[generator:geo_objects] Generate surrogate streets for KV by POI

### DIFF
--- a/generator/geo_objects/streets_builder.hpp
+++ b/generator/geo_objects/streets_builder.hpp
@@ -9,12 +9,13 @@
 
 #include "geometry/point2d.hpp"
 
+#include "base/geo_object_id.hpp"
+
 #include <memory>
 #include <ostream>
 #include <stdint.h>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 #include <boost/optional.hpp>
 
@@ -33,13 +34,25 @@ public:
   static bool IsStreet(FeatureBuilder1 const & fb);
 
 private:
+  using RegionStreets = std::unordered_map<std::string, base::GeoObjectId>;
+
+  void SaveStreetGeoObjects(std::ostream & streamGeoObjectsKv);
+  void SaveRegionStreetGeoObjects(std::ostream & streamGeoObjectsKv, uint64_t regionId,
+                                  RegionStreets const & streets);
+
+  void AddStreet(FeatureBuilder1 & fb);
+  void AddStreetBinding(std::string && streetName, FeatureBuilder1 & fb);
   boost::optional<KeyValue> FindStreetRegionOwner(FeatureBuilder1 & fb);
   boost::optional<KeyValue> FindStreetRegionOwner(m2::PointD const & point);
-  bool InsertStreet(KeyValue const & region, FeatureBuilder1 & fb);
-  std::unique_ptr<char, JSONFreeDeleter> MakeStreetValue(FeatureBuilder1 const & fb, KeyValue const & region);
+  bool InsertStreet(KeyValue const & region, std::string && streetName, base::GeoObjectId id);
+  bool InsertSurrogateStreet(KeyValue const & region, std::string && streetName);
+  std::unique_ptr<char, JSONFreeDeleter> MakeStreetValue(uint64_t regionId, base::Json const regionObject,
+                                                         std::string const & streetName);
+  base::GeoObjectId NextOsmSurrogateId();
 
-  std::unordered_map<uint64_t, std::unordered_set<std::string>> m_regionsStreets;
+  std::unordered_map<uint64_t, RegionStreets> m_regions;
   RegionInfoGetter const & m_regionInfoGetter;
+  uint64_t m_osmSurrogateCounter{0};
 };
 }  // namespace geo_objects
 }  // namespace generator


### PR DESCRIPTION
Генерация улиц для прямого геокодера и по POI. Ранее это делалось скриптом genin/gen_streets.py (см. [Генератор индексов для геокодера](https://confluence.mail.ru/pages/viewpage.action?pageId=150642306))