### PR TITLE
[generator] Ignore some barriers without access for car routing

### DIFF
--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -13,6 +13,7 @@
 #include "coding/file_container.hpp"
 #include "coding/file_writer.hpp"
 
+#include "base/assert.hpp"
 #include "base/geo_object_id.hpp"
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
@@ -67,7 +68,7 @@ TagMapping const kCarBarriersTagMapping = {
     {OsmElement::Tag("barrier", "cycle_barrier"), RoadAccess::Type::No},
     {OsmElement::Tag("barrier", "gate"), RoadAccess::Type::Private},
     {OsmElement::Tag("barrier", "lift_gate"), RoadAccess::Type::Private},
-// TODO (@gmoryes) add this type
+// TODO (@gmoryes) The types below should be added.
 //  {OsmElement::Tag("barrier", "chain"), RoadAccess::Type::No},
 //  {OsmElement::Tag("barrier", "swing_gate"), RoadAccess::Type::Private}
 };
@@ -93,6 +94,7 @@ TagMapping const kBicycleTagMapping = {
 TagMapping const kBicycleBarriersTagMapping = {
     {OsmElement::Tag("barrier", "cycle_barrier"), RoadAccess::Type::No},
     {OsmElement::Tag("barrier", "gate"), RoadAccess::Type::Private},
+    {OsmElement::Tag("barrier", "kissing_gate"), RoadAccess::Type::Private},
 };
 
 // Allow everything to keep transit section empty. We'll use pedestrian section for
@@ -295,7 +297,7 @@ void RoadAccessTagProcessor::Process(OsmElement const & elem, ofstream & oss)
 
     RoadAccess::Type roadAccessType;
     bool hasCarAccessTag;
-    std::tie(roadAccessType, hasCarAccessTag) = it->second;
+    tie(roadAccessType, hasCarAccessTag) = it->second;
 
     if (m_vehicleType == VehicleType::Car && ShouldIgnorePrivateAccess(elem, hasCarAccessTag))
       return;
@@ -311,7 +313,7 @@ bool RoadAccessTagProcessor::HasCarAccessTag(OsmElement const & osmElement) cons
   CHECK_EQUAL(m_vehicleType, VehicleType::Car, ("HasCarAccessTag() works only for Car."));
   CHECK_EQUAL(osmElement.type, OsmElement::EntityType::Node, ());
 
-  static std::vector<TagMapping const *> const kAccessTagsWithoutBarrier = {
+  static vector<TagMapping const *> const kAccessTagsWithoutBarrier = {
       &kMotorCarTagMapping, &kMotorVehicleTagMapping, &kVehicleTagMapping,
       &kDefaultTagMapping
   };
@@ -337,7 +339,7 @@ bool RoadAccessTagProcessor::ShouldIgnorePrivateAccess(OsmElement const & osmEle
   if (hasCarAccessTag)
     return false;
 
-  static std::set<OsmElement::Tag> const kHighwaysWhereIgnoresPrivateAccess = {
+  static set<OsmElement::Tag> const kHighwaysWhereIgnoresPrivateAccess = {
       {OsmElement::Tag("highway", "motorway")},
       {OsmElement::Tag("highway", "motorway_link")},
       {OsmElement::Tag("highway", "primary")},
@@ -371,7 +373,7 @@ RoadAccess::Type RoadAccessTagProcessor::GetAccessType(OsmElement const & elem) 
 }
 
 // RoadAccessWriter ------------------------------------------------------------
-RoadAccessWriter::RoadAccessWriter(std::string const & filePath)
+RoadAccessWriter::RoadAccessWriter(string const & filePath)
 {
   for (size_t i = 0; i < static_cast<size_t>(VehicleType::Count); ++i)
     m_tagProcessors.emplace_back(static_cast<VehicleType>(i));

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -14,7 +14,6 @@
 #include <ostream>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
 
 struct OsmElement;
@@ -35,19 +34,22 @@ public:
   void Process(OsmElement const & elem, std::ofstream & oss);
 
 private:
-  bool HasCarAccessTag(OsmElement const & osmElement) const;
-  bool ShouldIgnorePrivateAccess(OsmElement const & osmElement, bool hasAccessTag) const;
+  bool ShouldIgnoreBarrierWithoutAccess(OsmElement const & osmElement) const;
   RoadAccess::Type GetAccessType(OsmElement const & elem) const;
 
   VehicleType m_vehicleType;
+
+  std::vector<TagMapping const *> m_barrierMappings;
+
   // Order of tag mappings in m_tagMappings is from more to less specific.
   // e.g. for car: motorcar, motorvehicle, vehicle, general access tags.
-  std::vector<TagMapping const *> m_tagMappings;
+  std::vector<TagMapping const *> m_accessMappings;
 
-  // Tag mapping for barriers.
-  // Key is barrier node osm id.
-  // Value is accessType and bool - element car access tag.
-  std::map<uint64_t, std::pair<RoadAccess::Type, bool>> m_barriers;
+  // We decided to ignore some barriers without access on some type of highways
+  // because we almost always do not need to add penalty for passes through such nodes.
+  std::set<OsmElement::Tag> const * m_hwIgnoreBarriersWithoutAccess;
+
+  std::map<uint64_t, RoadAccess::Type> m_barriers;
 };
 
 class RoadAccessWriter : public generator::CollectorInterface

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -12,7 +12,9 @@
 #include <fstream>
 #include <map>
 #include <ostream>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct OsmElement;
@@ -41,8 +43,11 @@ private:
   // Order of tag mappings in m_tagMappings is from more to less specific.
   // e.g. for car: motorcar, motorvehicle, vehicle, general access tags.
   std::vector<TagMapping const *> m_tagMappings;
-  // Tag mapping for barriers. Key is barrier node osm id.
-  std::map<uint64_t, std::pair<RoadAccess::Type, bool /* has access tag */>> m_barriers;
+
+  // Tag mapping for barriers.
+  // Key is barrier node osm id.
+  // Value is accessType and bool - element car access tag.
+  std::map<uint64_t, std::pair<RoadAccess::Type, bool>> m_barriers;
 };
 
 class RoadAccessWriter : public generator::CollectorInterface

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -33,6 +33,8 @@ public:
   void Process(OsmElement const & elem, std::ofstream & oss);
 
 private:
+  bool HasCarAccessTag(OsmElement const & osmElement) const;
+  bool ShouldIgnorePrivateAccess(OsmElement const & osmElement, bool hasAccessTag) const;
   RoadAccess::Type GetAccessType(OsmElement const & elem) const;
 
   VehicleType m_vehicleType;
@@ -40,7 +42,7 @@ private:
   // e.g. for car: motorcar, motorvehicle, vehicle, general access tags.
   std::vector<TagMapping const *> m_tagMappings;
   // Tag mapping for barriers. Key is barrier node osm id.
-  std::map<uint64_t, RoadAccess::Type> m_barriers;
+  std::map<uint64_t, std::pair<RoadAccess::Type, bool /* has access tag */>> m_barriers;
 };
 
 class RoadAccessWriter : public generator::CollectorInterface


### PR DESCRIPTION
Иногда на дорогах встречаются внезапно шлагбаумы, которые мешают роутеру, также в попытках запрещать ехать через дворы мы начинаем творить странные вещи на всяких границах/переходах на платную дорогу, так как там стоит barrier=lift_gate и подобные

Данный PR не рассматривает барьеры для машин без access, если эти барьеры стоят на следующих типах дорог:
```cpp
static std::set<OsmElement::Tag> const kHighwaysWhereIgnoredPrivateAccess = {
      {OsmElement::Tag("highway", "motorway")},
      {OsmElement::Tag("highway", "trunk")},
      {OsmElement::Tag("highway", "primary")},
      {OsmElement::Tag("highway", "secondary")},
      {OsmElement::Tag("highway", "tertiary")},
      {OsmElement::Tag("highway", "motorway_link")},
      {OsmElement::Tag("highway", "trunk_link")},
      {OsmElement::Tag("highway", "primary_link")},
      {OsmElement::Tag("highway", "secondary_link")},
      {OsmElement::Tag("highway", "tertiary_link")}
  };
```

Дороги были выбраны из соображения следующего мини исследования: https://jira.mail.ru/browse/MAPSME-10286