### PR TITLE
[debug] Added command to “search” by feature id

### DIFF
--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -427,6 +427,9 @@ public:
   vector<MwmSet::MwmId> GetMwmsByRect(m2::RectD const & rect, bool rough) const;
   MwmSet::MwmId GetMwmIdByName(string const & name) const;
 
+  // Use only for debug purposes!
+  vector<FeatureID> FindFeaturesByIndex(uint32_t featureIndex) const;
+
   void ReadFeatures(function<void(FeatureType &)> const & reader,
                     vector<FeatureID> const & features);
 


### PR DESCRIPTION
`?fid<space>index<space>` подсвечивает искомую фичу на карте. Сначала ищет по mwm, которые попадают во вьюпорт, потом по всем остальным (затем чтобы было удобнее и не надо было в строке поиска писать имя mwm).
Функцию можно также теоретически переиспользовать для отображения всех mwm, которые содержат фичу с таким индексом. Полезно, когда известен индекс, а mwm нет.

![Desktop](https://habrastorage.org/webt/0k/lj/ss/0kljsso2thz-w7ws3iqhe2dwyag.png)

Еще добавлен лог
LOG TID(1) INFO Feature found: { MwmId [Russia_Moscow, 190329], 30510 } ms::LatLon(55.767733055622471738, 37.658749950369809767)
LOG TID(1) INFO Feature found: { MwmId [World, 190328], 30510 } ms::LatLon(33.08056028396005388, 37.916676749786944356)