### PR TITLE
[DNM][ios][booking] use single deep link when booking.com app is installed

### DIFF
--- a/iphone/Maps/UI/PlacePage/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/MWMPlacePageManager.mm
@@ -488,6 +488,20 @@ void RegisterEventIfPossible(eye::MapObject::Event::Type const type, place_page:
   [self.ownerViewController openFullPlaceDescriptionWithHtml:htmlString];
 }
 
+- (void)openPartnerWithStatisticLog:(NSString *)eventName proposedUrl:(NSURL *)proposedUrl
+{
+  auto data = self.data;
+  if (!data)
+    return;
+  
+  logSponsoredEvent(data, eventName);
+  
+  NSURL * url = data.isPartnerAppInstalled ? data.deepLink : proposedUrl;
+  NSAssert(url, @"Sponsored url can't be nil!");
+  
+  [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+}
+
 - (void)book
 {
   auto data = self.data;
@@ -507,12 +521,8 @@ void RegisterEventIfPossible(eye::MapObject::Event::Type const type, place_page:
     NSAssert(false, @"Invalid book case!");
     return;
   }
-  logSponsoredEvent(data, eventName);
   
-  NSURL * url = data.isPartnerAppInstalled ? data.deepLink : data.sponsoredURL;
-  NSAssert(url, @"Sponsored url can't be nil!");
-  
-  [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+  [self openPartnerWithStatisticLog:eventName proposedUrl:data.sponsoredURL];
 }
 
 - (void)openDescriptionUrl
@@ -520,10 +530,9 @@ void RegisterEventIfPossible(eye::MapObject::Event::Type const type, place_page:
   auto data = self.data;
   if (!data)
     return;
-  
-  logSponsoredEvent(data, kStatPlacePageHotelDetails);
-  [UIApplication.sharedApplication openURL:data.sponsoredDescriptionURL
-                                   options:@{} completionHandler:nil];
+ 
+ [self openPartnerWithStatisticLog:kStatPlacePageHotelDetails
+                       proposedUrl:data.sponsoredDescriptionURL];
 }
 
 - (void)openMoreUrl
@@ -532,9 +541,8 @@ void RegisterEventIfPossible(eye::MapObject::Event::Type const type, place_page:
   if (!data)
     return;
   
-  logSponsoredEvent(data, kStatPlacePageHotelMore);
-  [UIApplication.sharedApplication openURL:data.sponsoredMoreURL
-                                   options:@{} completionHandler:nil];
+  [self openPartnerWithStatisticLog:kStatPlacePageHotelMore
+                        proposedUrl:data.sponsoredMoreURL];
 }
 
 - (void)openReviewUrl
@@ -543,9 +551,8 @@ void RegisterEventIfPossible(eye::MapObject::Event::Type const type, place_page:
   if (!data)
     return;
   
-  logSponsoredEvent(data, kStatPlacePageHotelReviews);
-  [UIApplication.sharedApplication openURL:data.sponsoredReviewURL
-                                   options:@{} completionHandler:nil];
+  [self openPartnerWithStatisticLog:kStatPlacePageHotelReviews
+                        proposedUrl:data.sponsoredReviewURL];
 }
 
 - (void)searchBookingHotels


### PR DESCRIPTION
В прошлом pr https://github.com/mapsme/omim/pull/10720 изменил поведение - сделал, чтоб открывались ссылки, соответствующие кнопкам. Оказалось, что под IOS, в октябре 2018 решили всегда открывать диплинки, когда приложение booking установлено. А под андройд другое поведение. Пока единое решение не выработано. Возвращаю измененное поведение.