### PR TITLE
[vulkan] Fixed crash in staging buffer

### DIFF
--- a/drape/vulkan/vulkan_object_manager.cpp
+++ b/drape/vulkan/vulkan_object_manager.cpp
@@ -312,6 +312,11 @@ void VulkanObjectManager::CollectObjectsImpl(VulkanObjectArray const & objects)
   m_memoryManager.EndDeallocationSession();
 }
 
+void VulkanObjectManager::DestroyObjectUnsafe(VulkanObject object)
+{
+  CollectObjectsImpl(VulkanObjectArray{object});
+}
+
 uint8_t * VulkanObjectManager::MapUnsafe(VulkanObject object)
 {
   CHECK(!object.m_allocation->m_memoryBlock->m_isBlocked, ());

--- a/drape/vulkan/vulkan_object_manager.hpp
+++ b/drape/vulkan/vulkan_object_manager.hpp
@@ -89,6 +89,9 @@ public:
   void CollectDescriptorSetGroups(uint32_t inflightFrameIndex);
   void CollectObjects(uint32_t inflightFrameIndex);
 
+  // Use unsafe function ONLY if an object has been just created.
+  void DestroyObjectUnsafe(VulkanObject object);
+
   VkDevice GetDevice() const { return m_device; }
   VulkanMemoryManager const & GetMemoryManager() const { return m_memoryManager; };
   VkSampler GetSampler(SamplerKey const & key);

--- a/drape/vulkan/vulkan_staging_buffer.hpp
+++ b/drape/vulkan/vulkan_staging_buffer.hpp
@@ -42,7 +42,7 @@ public:
 
 private:
   ref_ptr<VulkanObjectManager> m_objectManager;
-  uint32_t const m_sizeInBytes;
+  uint32_t m_sizeInBytes;
   VulkanObject m_object;
   uint32_t m_offsetAlignment = 0;
   uint32_t m_sizeAlignment = 0;


### PR DESCRIPTION
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5ccbb191f8b88c2963e4e479?time=last-thirty-days

Неправильный размер передавался в m_objectManager->CreateBuffer. Кроме того, добавил фолбэк для девайсов с нестандартным выравниванием.