### PR TITLE
[indexer] builder fix

### DIFF
--- a/indexer/feature_decl.hpp
+++ b/indexer/feature_decl.hpp
@@ -7,7 +7,7 @@
 
 namespace feature
 {
-enum class GeomType
+enum class GeomType : int8_t
 {
   Undefined = -1,
   Point = 0,


### PR DESCRIPTION
Фикс падения в генераторе индекс-файла: чтение одного байта, а не 4х в LocalityObject::Deserialize()