### PR TITLE
[generator:streets] Highway tracing: detect street's regions

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -193,6 +193,8 @@ set(SRC
   statistics.hpp
   streets/street_geometry.cpp
   streets/street_geometry.hpp
+  streets/street_regions_tracing.cpp
+  streets/street_regions_tracing.hpp
   streets/streets.cpp
   streets/streets.hpp
   streets/streets_builder.cpp

--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(
   sponsored_storage_tests.cpp
   srtm_parser_test.cpp
   street_geometry_tests.cpp
+  street_regions_tracing_tests.cpp
   tag_admixer_test.cpp
   tesselator_test.cpp
   triangles_tree_coding_test.cpp

--- a/generator/generator_tests/street_regions_tracing_tests.cpp
+++ b/generator/generator_tests/street_regions_tracing_tests.cpp
@@ -1,0 +1,64 @@
+#include "testing/testing.hpp"
+
+#include "generator/streets/street_regions_tracing.hpp"
+
+#include "base/geo_object_id.hpp"
+
+using namespace generator::streets;
+using generator::KeyValue;
+
+UNIT_TEST(StreetRegionTracingTest_StreetInOneRegion)
+{
+  auto regionGetter = [] (auto &&) { return KeyValue{1, {}}; };
+  auto && tracing = StreetRegionsTracing{{{0.0, 0.0}, {1.0, 1.0}}, regionGetter};
+  auto && segments = tracing.StealPathSegments();
+
+  TEST_EQUAL(segments.size(), 1, ());
+  TEST_EQUAL(segments.front().m_region.first, 1, ());
+}
+
+UNIT_TEST(StreetRegionTracingTest_OutgoingStreet)
+{
+  auto regionGetter = [] (auto && point) {
+    if (point.x < 0.001)
+      return KeyValue{1, {}};
+    return KeyValue{2, {}};
+  };
+  auto && tracing = StreetRegionsTracing{{{0.0, 0.0}, {1.0, 0.0}}, regionGetter};
+  auto && segments = tracing.StealPathSegments();
+
+  TEST_EQUAL(segments.size(), 2, ());
+  TEST_EQUAL(segments.front().m_region.first, 1, ());
+  TEST_EQUAL(segments.back().m_region.first, 2, ());
+}
+
+UNIT_TEST(StreetRegionTracingTest_IncomingStreet)
+{
+  auto regionGetter = [] (auto && point) {
+    if (point.x < 0.999)
+      return KeyValue{1, {}};
+    return KeyValue{2, {}};
+  };
+  auto && tracing = StreetRegionsTracing{{{0.0, 0.0}, {1.0, 0.0}}, regionGetter};
+  auto && segments = tracing.StealPathSegments();
+
+  TEST_EQUAL(segments.size(), 2, ());
+  TEST_EQUAL(segments.front().m_region.first, 1, ());
+  TEST_EQUAL(segments.back().m_region.first, 2, ());
+}
+
+UNIT_TEST(StreetRegionTracingTest_StreetWithTransitRegion)
+{
+  auto regionGetter = [] (auto && point) {
+    if (0.5 <= point.x && point.x <= 0.501)
+      return KeyValue{2, {}};
+    return KeyValue{1, {}};
+  };
+  auto && tracing = StreetRegionsTracing{{{0.0, 0.0}, {1.0, 0.0}}, regionGetter};
+  auto && segments = tracing.StealPathSegments();
+
+  TEST_EQUAL(segments.size(), 3, ());
+  TEST_EQUAL(segments[0].m_region.first, 1, ());
+  TEST_EQUAL(segments[1].m_region.first, 2, ());
+  TEST_EQUAL(segments[2].m_region.first, 1, ());
+}

--- a/generator/streets/street_regions_tracing.cpp
+++ b/generator/streets/street_regions_tracing.cpp
@@ -1,0 +1,193 @@
+#include "generator/streets/street_regions_tracing.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include <algorithm>
+#include <iterator>
+
+#include <boost/optional.hpp>
+
+namespace generator
+{
+namespace streets
+{
+constexpr m2::Meter const StreetRegionsTracing::kRegionCheckStepDistance;
+constexpr m2::Meter const StreetRegionsTracing::kRegionBoundarySearchStepDistance;
+
+StreetRegionsTracing::StreetRegionsTracing(Path const & path,
+                                           StreetRegionInfoGetter const & streetRegionInfoGetter)
+  : m_path{path}, m_streetRegionInfoGetter{streetRegionInfoGetter}
+{
+  CHECK_GREATER_OR_EQUAL(m_path.size(), 2, ());
+
+  m_currentPoint = m_path.front();
+  m_nextPathPoint = std::next(m_path.begin());
+
+  m_currentRegion = m_streetRegionInfoGetter(m_currentPoint);
+  if (m_currentRegion)
+    StartNewSegment();
+
+  Trace();
+}
+
+StreetRegionsTracing::PathSegments && StreetRegionsTracing::StealPathSegments()
+{
+  return std::move(m_pathSegments);
+}
+
+void StreetRegionsTracing::Trace()
+{
+  while (m_nextPathPoint != m_path.end())
+  {
+    if (!TraceToNextCheckPointInCurrentRegion())
+      TraceUpToNextRegion();
+  }
+
+  if (m_currentRegion)
+    ReleaseCurrentSegment();
+}
+
+bool StreetRegionsTracing::TraceToNextCheckPointInCurrentRegion()
+{
+  Meter distanceToCheckPoint{};
+  auto newNextPathPoint = m_nextPathPoint;
+  auto checkPoint = FollowToNextPoint(m_currentPoint, kRegionCheckStepDistance, m_nextPathPoint,
+                                      distanceToCheckPoint, newNextPathPoint);
+
+  auto checkPointRegion = m_streetRegionInfoGetter(checkPoint);
+  if (!IsSameRegion(checkPointRegion))
+    return false;
+
+  AdvanceTo(checkPoint, distanceToCheckPoint, newNextPathPoint);
+  return true;
+}
+
+void StreetRegionsTracing::TraceUpToNextRegion()
+{
+  while (m_nextPathPoint != m_path.end())
+  {
+    Meter distanceToNextPoint{};
+    auto newNextPathPoint = m_nextPathPoint;
+    auto nextPoint = FollowToNextPoint(m_currentPoint, kRegionBoundarySearchStepDistance, m_nextPathPoint,
+                                       distanceToNextPoint, newNextPathPoint);
+
+    auto nextPointRegion = m_streetRegionInfoGetter(nextPoint);
+    if (!IsSameRegion(nextPointRegion))
+    {
+      AdvanceToBoundary(nextPointRegion, nextPoint, distanceToNextPoint, newNextPathPoint);
+      return;
+    }
+
+    AdvanceTo(nextPoint, distanceToNextPoint, newNextPathPoint);
+  }
+}
+
+void StreetRegionsTracing::AdvanceToBoundary(boost::optional<KeyValue> const & newRegion,
+    m2::PointD const newRegionPoint, Meter distance, Path::const_iterator nextPathPoint)
+{
+  if (m_currentRegion)
+    CloseCurrentSegment(newRegionPoint, distance, nextPathPoint);
+
+  m_currentRegion = newRegion;
+  if (m_currentRegion)
+    StartNewSegment();
+
+  AdvanceTo(newRegionPoint, distance, nextPathPoint);
+}
+
+void StreetRegionsTracing::AdvanceTo(m2::PointD const toPoint, Meter distance,
+                                     Path::const_iterator nextPathPoint)
+{
+  CHECK(0.0 <= distance || m_nextPathPoint != nextPathPoint, ());
+
+  if (m_currentRegion)
+  {
+    CHECK(!m_pathSegments.empty(), ());
+    auto & currentSegment = m_pathSegments.back();
+    std::copy(m_nextPathPoint, nextPathPoint, std::back_inserter(currentSegment.m_path));
+    currentSegment.m_pathLengthMeters += distance;
+  }
+
+  m_currentPoint = toPoint;
+  m_nextPathPoint = nextPathPoint;
+}
+
+void StreetRegionsTracing::StartNewSegment()
+{
+  CHECK(m_currentRegion, ());
+  m_pathSegments.push_back({*m_currentRegion, {m_currentPoint}, 0.0 /* m_pathLengthMeters */});
+}
+
+void StreetRegionsTracing::CloseCurrentSegment(m2::PointD const endPoint, Meter distance,
+                                               Path::const_iterator pathEndPoint)
+{
+  CHECK(0.0 <= distance || m_nextPathPoint != pathEndPoint, ());
+
+  CHECK(!m_pathSegments.empty(), ());
+  auto & currentSegment = m_pathSegments.back();
+
+  std::copy(m_nextPathPoint, pathEndPoint, std::back_inserter(currentSegment.m_path));
+  if (currentSegment.m_path.back() != endPoint)
+    currentSegment.m_path.push_back(endPoint);
+
+  currentSegment.m_pathLengthMeters += distance;
+
+  ReleaseCurrentSegment();
+}
+
+void StreetRegionsTracing::ReleaseCurrentSegment()
+{
+  CHECK(!m_pathSegments.empty(), ());
+  auto & currentSegment = m_pathSegments.back();
+
+  CHECK_GREATER_OR_EQUAL(currentSegment.m_path.size(), 2, ());
+
+  constexpr auto kSegmentLengthMin = 1.0_m;
+  if (m_pathSegments.back().m_pathLengthMeters < kSegmentLengthMin)
+    m_pathSegments.pop_back();
+}
+
+m2::PointD StreetRegionsTracing::FollowToNextPoint(m2::PointD const & startPoint, Meter stepDistance,
+    Path::const_iterator nextPathPoint, Meter & distance, Path::const_iterator & newNextPathPoint) const
+{
+  auto point = startPoint;
+  distance = 0.0_m;
+  newNextPathPoint = nextPathPoint;
+  for (; newNextPathPoint != m_path.end(); ++newNextPathPoint)
+  {
+    auto nextPoint = *newNextPathPoint;
+    auto distanceToNextPoint = Meter{MercatorBounds::DistanceOnEarth(point, nextPoint)};
+    CHECK_LESS(distance, stepDistance, ());
+    auto restDistance = stepDistance - distance;
+
+    constexpr auto kDistancePrecision = 2.0_m;
+    if (std::fabs(restDistance - distanceToNextPoint) <= kDistancePrecision)
+    {
+      ++newNextPathPoint;
+      distance += distanceToNextPoint;
+      return nextPoint;
+    }
+
+    if (restDistance < distanceToNextPoint)
+    {
+      point += (nextPoint - point) * restDistance / distanceToNextPoint;
+      distance = stepDistance;
+      return point;
+    }
+
+    point = nextPoint;
+    distance += distanceToNextPoint;
+  }
+
+  return point;
+}
+
+bool StreetRegionsTracing::IsSameRegion(boost::optional<KeyValue> const & region) const
+{
+  if (m_currentRegion && region)
+    return m_currentRegion->first == region->first;
+
+  return !m_currentRegion && !region;
+}
+}  // namespace streets
+}  // namespace generator

--- a/generator/streets/street_regions_tracing.hpp
+++ b/generator/streets/street_regions_tracing.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "generator/key_value_storage.hpp"
+
+#include "geometry/meter.hpp"
+#include "geometry/point2d.hpp"
+
+#include <functional>
+#include <vector>
+
+namespace generator
+{
+namespace streets
+{
+using m2::literals::operator"" _m;
+
+class StreetRegionsTracing final
+{
+public:
+  using Meter = m2::Meter;
+  using StreetRegionInfoGetter = std::function<boost::optional<KeyValue>(m2::PointD const & pathPoint)>;
+  using Path = std::vector<m2::PointD>;
+
+  constexpr static auto const kRegionCheckStepDistance = 100.0_m;
+  constexpr static auto const kRegionBoundarySearchStepDistance = 10.0_m;
+
+  struct Segment
+  {
+    KeyValue m_region;
+    Path m_path;
+    Meter m_pathLengthMeters;
+  };
+
+  using PathSegments = std::vector<Segment>;
+
+  StreetRegionsTracing(Path const & path, StreetRegionInfoGetter const & streetRegionInfoGetter);
+
+  PathSegments && StealPathSegments();
+
+private:
+  void Trace();
+  bool TraceToNextCheckPointInCurrentRegion();
+  void TraceUpToNextRegion();
+  void AdvanceTo(m2::PointD const toPoint, Meter distance, Path::const_iterator nextPathPoint);
+  void AdvanceToBoundary(boost::optional<KeyValue> const & newRegion, m2::PointD const newRegionPoint,
+                         Meter distance, Path::const_iterator nextPathPoint);
+  void StartNewSegment();
+  void CloseCurrentSegment(m2::PointD const endPoint, Meter distance, Path::const_iterator pathEndPoint);
+  void ReleaseCurrentSegment();
+  m2::PointD FollowToNextPoint(m2::PointD const & startPoint, Meter stepDistance,
+      Path::const_iterator nextPathPoint, Meter & distance, Path::const_iterator & newNextPathPoint) const;
+  bool IsSameRegion(boost::optional<KeyValue> const & region) const;
+
+  Path const & m_path;
+  StreetRegionInfoGetter const & m_streetRegionInfoGetter;
+  m2::PointD m_currentPoint;
+  Path::const_iterator m_nextPathPoint;
+  boost::optional<KeyValue> m_currentRegion;
+  PathSegments m_pathSegments;
+};
+}  // namespace streets
+}  // namesapce generator

--- a/generator/streets/streets_builder.hpp
+++ b/generator/streets/streets_builder.hpp
@@ -46,12 +46,12 @@ private:
                            RegionStreets const & streets);
 
   void AddStreet(feature::FeatureBuilder & fb);
+  void AddStreetHighway(feature::FeatureBuilder & fb);
+  void AddStreetArea(feature::FeatureBuilder & fb);
+  void AddStreetPoint(feature::FeatureBuilder & fb);
   void AddStreetBinding(std::string && streetName, feature::FeatureBuilder & fb);
-  boost::optional<KeyValue> FindStreetRegionOwner(feature::FeatureBuilder & fb);
   boost::optional<KeyValue> FindStreetRegionOwner(m2::PointD const & point, bool needLocality = false);
-  void InsertStreet(KeyValue const & region, feature::FeatureBuilder & fb);
-  void InsertStreetBinding(KeyValue const & region, std::string && streetName,
-      feature::FeatureBuilder & fb);
+  StreetGeometry & InsertStreet(uint64_t regionId, std::string && streetName);
   std::unique_ptr<char, JSONFreeDeleter> MakeStreetValue(
       uint64_t regionId, JsonValue const & regionObject, std::string const & streetName,
       m2::RectD const & bbox, m2::PointD const & pinPoint);

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -29,6 +29,7 @@ set(
   line2d.hpp
   mercator.cpp
   mercator.hpp
+  meter.hpp
   nearby_points_sweeper.cpp
   nearby_points_sweeper.hpp
   packer.cpp

--- a/geometry/meter.hpp
+++ b/geometry/meter.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace m2
+{
+using Meter = double;
+
+inline namespace literals
+{
+inline constexpr auto operator"" _m(long double value) noexcept -> Meter
+{
+  return {static_cast<double>(value)};
+}
+
+inline constexpr auto operator"" _km(long double value) noexcept -> Meter
+{
+  return {static_cast<double>(value * 1000.0)};
+}
+}  // namespace literals
+}  // namespace m2


### PR DESCRIPTION
Добавление улицы во все регионы, через которые она проходит.

В OSM улица (highway=... node) может проходить через несколько регионов (regions). Например, начинаться в населённом пункте, а заканчиваться в области, или проходить по области сквозь населенные пункты.

В мастере принадлежность улицы региону определяется по первой точке. В этом PR определяются все сегменты дороги, где каждый сегмент принадлежит одному region (сегмент от/до границы region). Сегменты строятся трассировкой вдоль пути: каждые 100 метров проверяется принадлежность региону и с шагом 10 метров для поиска границы между регионами.

В комментариях с TODO представлен код, который нужно вернуть после попадания в мастер геометрии улицы PR #10836