### PR TITLE
[routing] Decreasing speed for unclassified roads to tertiary speed.

### DIFF
--- a/routing_common/car_model_coefs_default.hpp
+++ b/routing_common/car_model_coefs_default.hpp
@@ -91,7 +91,7 @@ HighwayBasedMeanSpeeds const kGlobalHighwayBasedMeanSpeeds = {
   {HighwayType::HighwayTertiary, InOutCitySpeedKMpH({45.50, 38.86} /* in city */, {50.50, 44.14} /* out city */)},
   {HighwayType::HighwayTertiaryLink, InOutCitySpeedKMpH({40.95, 34.97} /* in city */, {45.45, 39.73} /* out city */)},
   {HighwayType::HighwayResidential, InOutCitySpeedKMpH({20.00, 20.00} /* in city */, {25.00, 25.00} /* out city */)},
-  {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH({45.50, 38.86} /* in city */, {50.50, 44.14} /* out city */)},
+  {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH({30.00, 30.00} /* in city */, {40.00, 40.00} /* out city */)},
   {HighwayType::HighwayService, InOutCitySpeedKMpH({15.00, 15.00} /* in city */, {15.00, 15.00} /* out city */)},
   {HighwayType::HighwayLivingStreet, InOutCitySpeedKMpH({10.00, 10.00} /* in city */, {10.00, 10.00} /* out city */)},
   {HighwayType::HighwayRoad, InOutCitySpeedKMpH({10.00, 10.00} /* in city */, {10.00, 10.00} /* out city */)},

--- a/routing_common/car_model_coefs_default.hpp
+++ b/routing_common/car_model_coefs_default.hpp
@@ -91,7 +91,7 @@ HighwayBasedMeanSpeeds const kGlobalHighwayBasedMeanSpeeds = {
   {HighwayType::HighwayTertiary, InOutCitySpeedKMpH({45.50, 38.86} /* in city */, {50.50, 44.14} /* out city */)},
   {HighwayType::HighwayTertiaryLink, InOutCitySpeedKMpH({40.95, 34.97} /* in city */, {45.45, 39.73} /* out city */)},
   {HighwayType::HighwayResidential, InOutCitySpeedKMpH({20.00, 20.00} /* in city */, {25.00, 25.00} /* out city */)},
-  {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH({51.30, 51.30} /* in city */, {66.00, 66.00} /* out city */)},
+  {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH({45.50, 38.86} /* in city */, {50.50, 44.14} /* out city */)},
   {HighwayType::HighwayService, InOutCitySpeedKMpH({15.00, 15.00} /* in city */, {15.00, 15.00} /* out city */)},
   {HighwayType::HighwayLivingStreet, InOutCitySpeedKMpH({10.00, 10.00} /* in city */, {10.00, 10.00} /* out city */)},
   {HighwayType::HighwayRoad, InOutCitySpeedKMpH({10.00, 10.00} /* in city */, {10.00, 10.00} /* out city */)},


### PR DESCRIPTION
Идея в том, что после вычисления скоростей для ряда классов дорог, для дорог unclassified они остались не изменными. Как следствие стали примерно, как у primary. Что давало ошибки вроде такой: 
![image](https://user-images.githubusercontent.com/1768114/57291044-5813b480-70c7-11e9-80f4-fe88d174bb50.png)

Этот PR делает скорости для дорог unclassified более соответствующими действительности. Позже они будут посчитаны точно.

@vmihaylenko @gmoryes PTAL