### PR TITLE
[routing] Fixed duplicate names in absent list.

### DIFF
--- a/android/jni/com/mapswithme/core/jni_helper.cpp
+++ b/android/jni/com/mapswithme/core/jni_helper.cpp
@@ -167,15 +167,6 @@ jstring ToJavaString(JNIEnv * env, char const * s)
   return env->NewStringUTF(s);
 }
 
-jobjectArray ToJavaStringArray(JNIEnv * env, std::vector<std::string> const & src)
-{
-  return ToJavaArray(env, GetStringClass(env), src,
-                     [](JNIEnv * env, std::string const & item)
-                     {
-                       return ToJavaString(env, item.c_str());
-                     });
-}
-
 jclass GetStringClass(JNIEnv * env)
 {
   return env->FindClass(GetStringClassName());

--- a/android/jni/com/mapswithme/core/jni_helper.hpp
+++ b/android/jni/com/mapswithme/core/jni_helper.hpp
@@ -96,7 +96,15 @@ jobjectArray ToJavaArray(JNIEnv * env, jclass clazz, TContainer const & src, TTo
                      std::forward<TToJavaFn>(toJavaFn));
 }
 
-jobjectArray ToJavaStringArray(JNIEnv * env, std::vector<std::string> const & src);
+template <typename Cont>
+jobjectArray ToJavaStringArray(JNIEnv * env, Cont const & src)
+{
+  return ToJavaArray(env, GetStringClass(env), src,
+                     [](JNIEnv * env, std::string const & item)
+                     {
+                       return ToJavaString(env, item.c_str());
+                     });
+}
 
 void DumpDalvikReferenceTables();
 

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -17,6 +17,7 @@
 #include "partners_api/mopub_ads.hpp"
 #include "partners_api/megafon_countries.hpp"
 
+#include "storage/storage_defines.hpp"
 #include "storage/storage_helpers.hpp"
 
 #include "drape_frontend/user_event_stream.hpp"
@@ -855,7 +856,7 @@ void Framework::OnPowerSchemeChanged(power_management::Scheme const actualScheme
 extern "C"
 {
 void CallRoutingListener(shared_ptr<jobject> listener, int errorCode,
-                         vector<storage::CountryId> const & absentMaps)
+                         storage::CountriesSet const & absentMaps)
 {
   JNIEnv * env = jni::GetEnv();
   jmethodID const method = jni::GetMethodID(env, *listener, "onRoutingEvent", "(I[Ljava/lang/String;)V");
@@ -1432,8 +1433,8 @@ Java_com_mapswithme_maps_Framework_nativeSetRoutingListener(JNIEnv * env, jclass
   CHECK(g_framework, ("Framework isn't created yet!"));
   auto rf = jni::make_global_ref(listener);
   frm()->GetRoutingManager().SetRouteBuildingListener(
-      [rf](routing::RouterResultCode e, storage::CountriesVec const & v) {
-        CallRoutingListener(rf, static_cast<int>(e), v);
+      [rf](routing::RouterResultCode e, storage::CountriesSet const & countries) {
+        CallRoutingListener(rf, static_cast<int>(e), countries);
       });
 }
 

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController+CPP.h
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController+CPP.h
@@ -4,11 +4,12 @@
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "storage/storage.hpp"
+#include "storage/storage_defines.hpp"
 
 @interface MWMAlertViewController (CPP)
 
 - (void)presentAlert:(routing::RouterResultCode)type;
-- (void)presentDownloaderAlertWithCountries:(storage::CountriesVec const &)countries
+- (void)presentDownloaderAlertWithCountries:(storage::CountriesSet const &)countries
                                        code:(routing::RouterResultCode)code
                                 cancelBlock:(nonnull MWMVoidBlock)cancelBlock
                               downloadBlock:(nonnull MWMDownloadBlock)downloadBlock

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
@@ -102,7 +102,7 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
   [self displayAlert:[MWMAlert routingMigrationAlertWithOkBlock:okBlock]];
 }
 
-- (void)presentDownloaderAlertWithCountries:(storage::CountriesVec const &)countries
+- (void)presentDownloaderAlertWithCountries:(storage::CountriesSet const &)countries
                                        code:(routing::RouterResultCode)code
                                 cancelBlock:(MWMVoidBlock)cancelBlock
                               downloadBlock:(MWMDownloadBlock)downloadBlock

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert+CPP.h
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert+CPP.h
@@ -3,13 +3,14 @@
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "storage/storage.hpp"
+#include "storage/storage_defines.hpp"
 
 using MWMDownloadBlock = void (^)(storage::CountriesVec const &, MWMVoidBlock);
 
 @interface MWMAlert (CPP)
 
 + (MWMAlert *)alert:(routing::RouterResultCode)type;
-+ (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::CountriesVec const &)countries
++ (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::CountriesSet const &)countries
                                             code:(routing::RouterResultCode)code
                                      cancelBlock:(MWMVoidBlock)cancelBlock
                                    downloadBlock:(MWMDownloadBlock)downloadBlock

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -50,7 +50,7 @@
   return [MWMDefaultAlert routingMigrationAlertWithOkBlock:okBlock];
 }
 
-+ (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::CountriesVec const &)countries
++ (MWMAlert *)downloaderAlertWithAbsentCountries:(storage::CountriesSet const &)countries
                                             code:(routing::RouterResultCode)code
                                      cancelBlock:(MWMVoidBlock)cancelBlock
                                    downloadBlock:(MWMDownloadBlock)downloadBlock

--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.h
@@ -2,9 +2,11 @@
 
 #include "routing/routing_callbacks.hpp"
 
+#include "storage/storage_defines.hpp"
+
 @interface MWMDownloadTransitMapAlert : MWMAlert
 
-+ (instancetype)downloaderAlertWithMaps:(storage::CountriesVec const &)countries
++ (instancetype)downloaderAlertWithMaps:(storage::CountriesSet const &)countries
                                    code:(routing::RouterResultCode)code
                             cancelBlock:(MWMVoidBlock)cancelBlock
                           downloadBlock:(MWMDownloadBlock)downloadBlock

--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
@@ -56,7 +56,7 @@ CGFloat const kAnimationDuration = .05;
   storage::CountriesVec m_countries;
 }
 
-+ (instancetype)downloaderAlertWithMaps:(storage::CountriesVec const &)countries
++ (instancetype)downloaderAlertWithMaps:(storage::CountriesSet const &)countries
                                    code:(routing::RouterResultCode)code
                             cancelBlock:(MWMVoidBlock)cancelBlock
                           downloadBlock:(MWMDownloadBlock)downloadBlock
@@ -90,14 +90,14 @@ CGFloat const kAnimationDuration = .05;
   return alert;
 }
 
-+ (instancetype)alertWithCountries:(storage::CountriesVec const &)countries
++ (instancetype)alertWithCountries:(storage::CountriesSet const &)countries
 {
   NSAssert(!countries.empty(), @"countries can not be empty.");
   MWMDownloadTransitMapAlert * alert =
       [NSBundle.mainBundle loadNibNamed:kDownloadTransitMapAlertNibName owner:nil options:nil]
           .firstObject;
 
-  alert->m_countries = countries;
+  alert->m_countries = storage::CountriesVec(countries.begin(), countries.end());
   [alert configure];
   [alert updateCountriesList];
   [MWMFrameworkListener addObserver:alert];

--- a/iphone/Maps/Core/Framework/MWMFrameworkHelper.mm
+++ b/iphone/Maps/Core/Framework/MWMFrameworkHelper.mm
@@ -5,8 +5,9 @@
 
 #include "Framework.h"
 
-#include "base/sunrise_sunset.hpp"
 #include "platform/network_policy_ios.h"
+
+#include "base/sunrise_sunset.hpp"
 
 @implementation MWMFrameworkHelper
 

--- a/iphone/Maps/Core/Framework/MWMFrameworkListener.mm
+++ b/iphone/Maps/Core/Framework/MWMFrameworkListener.mm
@@ -2,6 +2,9 @@
 
 #include "Framework.h"
 
+#include "storage/storage.hpp"
+#include "storage/storage_defines.hpp"
+
 namespace
 {
 using Observer = id<MWMFrameworkObserver>;
@@ -97,7 +100,7 @@ void loopWrappers(Observers * observers, TLoopBlock block)
   Observers * observers = self.routeBuildingObservers;
   auto & rm = GetFramework().GetRoutingManager();
   rm.SetRouteBuildingListener(
-      [observers](RouterResultCode code, CountriesVec const & absentCountries) {
+      [observers](RouterResultCode code, CountriesSet const & absentCountries) {
         loopWrappers(observers, [code, absentCountries](TRouteBuildingObserver observer) {
           [observer processRouteBuilderEvent:code countries:absentCountries];
         });

--- a/iphone/Maps/Core/Framework/MWMFrameworkObservers.h
+++ b/iphone/Maps/Core/Framework/MWMFrameworkObservers.h
@@ -14,7 +14,7 @@ using namespace storage;
 @protocol MWMFrameworkRouteBuilderObserver<MWMFrameworkObserver>
 
 - (void)processRouteBuilderEvent:(routing::RouterResultCode)code
-                       countries:(storage::CountriesVec const &)absentCountries;
+                       countries:(storage::CountriesSet const &)absentCountries;
 
 @optional
 

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -641,7 +641,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
 }
 
 - (void)processRouteBuilderEvent:(routing::RouterResultCode)code
-                       countries:(storage::CountriesVec const &)absentCountries
+                       countries:(storage::CountriesSet const &)absentCountries
 {
   MWMMapViewControlsManager * mapViewControlsManager = [MWMMapViewControlsManager manager];
   switch (code)
@@ -704,7 +704,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
 #pragma mark - Alerts
 
 - (void)presentDownloaderAlert:(routing::RouterResultCode)code
-                     countries:(storage::CountriesVec const &)countries
+                     countries:(storage::CountriesSet const &)countries
 {
   MWMAlertViewController * activeAlertController = [MWMAlertViewController activeAlertController];
   if (platform::migrate::NeedMigrate())

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -289,7 +289,7 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
   m_routingSession.SetRoutingCallbacks(
       [this](Route const & route, RouterResultCode code) { OnBuildRouteReady(route, code); },
       [this](Route const & route, RouterResultCode code) { OnRebuildRouteReady(route, code); },
-      [this](uint64_t routeId, vector<string> const & absentCountries) {
+      [this](uint64_t routeId, storage::CountriesSet const & absentCountries) {
         OnNeedMoreMaps(routeId, absentCountries);
       },
       [this](RouterResultCode code) { OnRemoveRoute(code); });
@@ -378,7 +378,7 @@ void RoutingManager::OnBuildRouteReady(Route const & route, RouterResultCode cod
                            true /* useVisibleViewport */);
   }
 
-  CallRouteBuilded(hasWarnings ? RouterResultCode::HasWarnings : code, storage::CountriesVec());
+  CallRouteBuilded(hasWarnings ? RouterResultCode::HasWarnings : code, storage::CountriesSet());
 }
 
 void RoutingManager::OnRebuildRouteReady(Route const & route, RouterResultCode code)
@@ -389,10 +389,10 @@ void RoutingManager::OnRebuildRouteReady(Route const & route, RouterResultCode c
     return;
 
   auto const hasWarnings = InsertRoute(route);
-  CallRouteBuilded(hasWarnings ? RouterResultCode::HasWarnings : code, storage::CountriesVec());
+  CallRouteBuilded(hasWarnings ? RouterResultCode::HasWarnings : code, storage::CountriesSet());
 }
 
-void RoutingManager::OnNeedMoreMaps(uint64_t routeId, vector<string> const & absentCountries)
+void RoutingManager::OnNeedMoreMaps(uint64_t routeId, storage::CountriesSet const & absentCountries)
 {
   // No need to inform user about maps needed for the route if the method is called
   // when RoutingSession contains a new route.
@@ -407,7 +407,7 @@ void RoutingManager::OnRemoveRoute(routing::RouterResultCode code)
 {
   HidePreviewSegments();
   RemoveRoute(true /* deactivateFollowing */);
-  CallRouteBuilded(code, vector<string>());
+  CallRouteBuilded(code, storage::CountriesSet());
 }
 
 void RoutingManager::OnRoutePointPassed(RouteMarkType type, size_t intermediateIndex)
@@ -935,7 +935,7 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
   auto routePoints = GetRoutePoints();
   if (routePoints.size() < 2)
   {
-    CallRouteBuilded(RouterResultCode::Cancelled, storage::CountriesVec());
+    CallRouteBuilded(RouterResultCode::Cancelled, storage::CountriesSet());
     CloseRouting(false /* remove route points */);
     return;
   }
@@ -949,7 +949,7 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
     auto const & myPosition = m_bmManager->MyPositionMark();
     if (!myPosition.HasPosition())
     {
-      CallRouteBuilded(RouterResultCode::NoCurrentPosition, storage::CountriesVec());
+      CallRouteBuilded(RouterResultCode::NoCurrentPosition, storage::CountriesSet());
       return;
     }
     p.m_position = myPosition.GetPivot();
@@ -963,7 +963,7 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
     {
       if (routePoints[i].m_position.EqualDxDy(routePoints[j].m_position, kEps))
       {
-        CallRouteBuilded(RouterResultCode::Cancelled, storage::CountriesVec());
+        CallRouteBuilded(RouterResultCode::Cancelled, storage::CountriesSet());
         CloseRouting(false /* remove route points */);
         return;
       }
@@ -1066,7 +1066,7 @@ void RoutingManager::CheckLocationForRouting(location::GpsInfo const & info)
 }
 
 void RoutingManager::CallRouteBuilded(RouterResultCode code,
-                                      storage::CountriesVec const & absentCountries)
+                                      storage::CountriesSet const & absentCountries)
 {
   m_routingBuildingCallback(code, absentCountries);
 }

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -101,7 +101,7 @@ public:
   };
 
   using RouteBuildingCallback =
-      std::function<void(routing::RouterResultCode, storage::CountriesVec const &)>;
+      std::function<void(routing::RouterResultCode, storage::CountriesSet const &)>;
 
   using RouteStartBuildCallback = std::function<void(std::vector<RouteMarkData> const & points)>;
 
@@ -219,10 +219,10 @@ public:
 
   void CheckLocationForRouting(location::GpsInfo const & info);
   void CallRouteBuilded(routing::RouterResultCode code,
-                        storage::CountriesVec const & absentCountries);
+                        storage::CountriesSet const & absentCountries);
   void OnBuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
   void OnRebuildRouteReady(routing::Route const & route, routing::RouterResultCode code);
-  void OnNeedMoreMaps(uint64_t routeId, std::vector<std::string> const & absentCountries);
+  void OnNeedMoreMaps(uint64_t routeId, storage::CountriesSet const & absentCountries);
   void OnRemoveRoute(routing::RouterResultCode code);
   void OnRoutePointPassed(RouteMarkType type, size_t intermediateIndex);
   void OnLocationUpdate(location::GpsInfo const & info);

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -11,9 +11,9 @@
 #include "search/result.hpp"
 #include "search/reverse_geocoder.hpp"
 
-#include "storage/storage_defines.hpp"
-
 #include "routing/routing_callbacks.hpp"
+
+#include "storage/storage_defines.hpp"
 
 #include "indexer/editable_map_object.hpp"
 
@@ -50,7 +50,7 @@ DrawWidget::DrawWidget(Framework & framework, bool apiOpenGLES3, std::unique_ptr
       [](bool /* switchFullScreenMode */) {});  // Empty deactivation listener.
 
   m_framework.GetRoutingManager().SetRouteBuildingListener(
-      [](routing::RouterResultCode, storage::CountriesVec const &) {});
+      [](routing::RouterResultCode, storage::CountriesSet const &) {});
 
   m_framework.GetRoutingManager().SetRouteRecommendationListener(
     [this](RoutingManager::Recommendation r)

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -99,7 +99,7 @@ void AsyncRouter::RouterDelegateProxy::OnReady(shared_ptr<Route> route, RouterRe
 }
 
 void AsyncRouter::RouterDelegateProxy::OnNeedMoreMaps(uint64_t routeId,
-                                                      vector<string> const & absentCounties)
+                                                      set<string> const & absentCounties)
 {
   if (!m_onNeedMoreMaps)
     return;
@@ -425,11 +425,11 @@ void AsyncRouter::CalculateRoute()
   bool const needFetchAbsent = (code != RouterResultCode::Cancelled);
 
   // Check online response if we have.
-  vector<string> absent;
+  set<string> absent;
   if (absentFetcher && needFetchAbsent)
     absentFetcher->GetAbsentCountries(absent);
 
-  absent.insert(absent.end(), route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
+  absent.insert(route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
   if (!absent.empty())
     code = RouterResultCode::NeedMoreMaps;
 

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <utility>
 
@@ -78,7 +79,7 @@ private:
                         uint32_t timeoutSec);
 
     void OnReady(std::shared_ptr<Route> route, RouterResultCode resultCode);
-    void OnNeedMoreMaps(uint64_t routeId, vector<std::string> const & absentCounties);
+    void OnNeedMoreMaps(uint64_t routeId, std::set<std::string> const & absentCounties);
     void OnRemoveRoute(RouterResultCode resultCode);
     void Cancel();
 

--- a/routing/online_absent_fetcher.cpp
+++ b/routing/online_absent_fetcher.cpp
@@ -41,7 +41,7 @@ void OnlineAbsentCountriesFetcher::GenerateRequest(Checkpoints const & checkpoin
   m_fetcherThread->Create(move(fetcher));
 }
 
-void OnlineAbsentCountriesFetcher::GetAbsentCountries(vector<string> & countries)
+void OnlineAbsentCountriesFetcher::GetAbsentCountries(set<string> & countries)
 {
   countries.clear();
   // Check whether a request was scheduled to be run on the thread.
@@ -56,11 +56,10 @@ void OnlineAbsentCountriesFetcher::GetAbsentCountries(vector<string> & countries
     if (name.empty() || m_countryLocalFileFn(name))
       continue;
 
-    countries.emplace_back(move(name));
+    countries.emplace(move(name));
   }
 
   m_fetcherThread.reset();
-  base::SortUnique(countries);
 }
 
 bool OnlineAbsentCountriesFetcher::AllPointsInSameMwm(Checkpoints const & checkpoints) const

--- a/routing/online_absent_fetcher.hpp
+++ b/routing/online_absent_fetcher.hpp
@@ -9,8 +9,8 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
-#include <vector>
 
 namespace routing
 {
@@ -21,7 +21,7 @@ class IOnlineFetcher
 public:
   virtual ~IOnlineFetcher() = default;
   virtual void GenerateRequest(Checkpoints const &) = 0;
-  virtual void GetAbsentCountries(std::vector<std::string> & countries) = 0;
+  virtual void GetAbsentCountries(std::set<std::string> & countries) = 0;
 };
 
 /*!
@@ -35,7 +35,7 @@ public:
 
   // IOnlineFetcher overrides:
   void GenerateRequest(Checkpoints const &) override;
-  void GetAbsentCountries(std::vector<std::string> & countries) override;
+  void GetAbsentCountries(std::set<std::string> & countries) override;
 
 private:
   bool AllPointsInSameMwm(Checkpoints const &) const;

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -8,8 +8,8 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
-#include <vector>
 
 namespace routing
 {
@@ -41,7 +41,7 @@ enum class RouterResultCode
 };
 
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
-using NeedMoreMapsCallback = std::function<void(uint64_t, std::vector<std::string> const &)>;
+using NeedMoreMapsCallback = std::function<void(uint64_t, std::set<std::string> const &)>;
 using PointCheckCallback = std::function<void(m2::PointD const &)>;
 using ProgressCallback = std::function<void(float)>;
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -34,6 +34,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <set>
 #include <sys/resource.h>
 
 using namespace routing;
@@ -303,7 +304,7 @@ void TestOnlineFetcher(ms::LatLon const & startPoint, ms::LatLon const & finalPo
   routing::OnlineAbsentCountriesFetcher fetcher(countryFileGetter, localFileChecker);
   fetcher.GenerateRequest(Checkpoints(MercatorBounds::FromLatLon(startPoint),
                                       MercatorBounds::FromLatLon(finalPoint)));
-  vector<string> absent;
+  set<string> absent;
   fetcher.GetAbsentCountries(absent);
   if (expected.size() < 2)
   {

--- a/routing/routing_tests/online_cross_fetcher_test.cpp
+++ b/routing/routing_tests/online_cross_fetcher_test.cpp
@@ -6,6 +6,7 @@
 #include "geometry/point2d.hpp"
 
 #include <algorithm>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -54,7 +55,7 @@ UNIT_TEST(OnlineAbsentFetcherSingleMwmTest)
 {
   OnlineAbsentCountriesFetcher fetcher([](m2::PointD const & p){return "A";}, [](string const &){return false;});
   fetcher.GenerateRequest(Checkpoints({1, 1}, {2, 2}));
-  vector<string> countries;
+  set<string> countries;
   fetcher.GetAbsentCountries(countries);
   TEST(countries.empty(), ());
 }


### PR DESCRIPTION
``` 
  set<string> absent;
  if (absentFetcher && needFetchAbsent)		
    absentFetcher->GetAbsentCountries(absent);

  absent.insert(absent.end(), route->GetAbsentCountries().cbegin(), route->GetAbsentCountries().cend());
```

Проблема была в этом коде. Сначала мы получали countryId от онлайн фетчера, потом из route'a.   Исправил ```vector<string>``` на ```set<string>```, т.к. это, кажется, логичнее.

https://jira.mail.ru/browse/MAPSME-8774
https://jira.mail.ru/browse/MAPSME-6748