### PR TITLE
[openlr] Parsing and using openlr segment with coordinates tag.

### DIFF
--- a/openlr/helpers.cpp
+++ b/openlr/helpers.cpp
@@ -98,7 +98,7 @@ m2::PointD BearingPointsSelector::GetStartPoint(Graph::Edge const & e) const
   return m_isLastPoint ? e.GetEndPoint() : e.GetStartPoint();
 }
 
-m2::PointD BearingPointsSelector::GetEndPoint(Graph::Edge const & e, double distanceM)
+m2::PointD BearingPointsSelector::GetEndPoint(Graph::Edge const & e, double distanceM) const
 {
   if (distanceM < m_bearDistM && m_bearDistM <= distanceM + EdgeLength(e))
   {

--- a/openlr/helpers.hpp
+++ b/openlr/helpers.hpp
@@ -21,7 +21,7 @@ public:
   BearingPointsSelector(uint32_t bearDistM, bool isLastPoint);
 
   m2::PointD GetStartPoint(Graph::Edge const & e) const;
-  m2::PointD GetEndPoint(Graph::Edge const & e, double distanceM);
+  m2::PointD GetEndPoint(Graph::Edge const & e, double distanceM) const;
 
 private:
   double m_bearDistM;

--- a/openlr/openlr_decoder.cpp
+++ b/openlr/openlr_decoder.cpp
@@ -401,12 +401,12 @@ public:
                                             m_dataSource, m_graph);
     ScoreCandidatePathsGetter pathsGetter(pointsGetter, m_graph, m_infoGetter, stat);
 
-    if (!pathsGetter.GetLineCandidatesForPoints(points, segment.m_status, lineCandidates))
+    if (!pathsGetter.GetLineCandidatesForPoints(points, segment.m_source, lineCandidates))
       return false;
 
     vector<Graph::EdgeVector> resultPath;
     ScorePathsConnector connector(m_graph, m_infoGetter, stat);
-    if (!connector.FindBestPath(points, lineCandidates, segment.m_status, resultPath))
+    if (!connector.FindBestPath(points, lineCandidates, segment.m_source, resultPath))
     {
       LOG(LINFO, ("Connections not found:", segment.m_segmentId));
       auto const mercatorPoints = segment.GetMercatorPoints();

--- a/openlr/openlr_decoder.cpp
+++ b/openlr/openlr_decoder.cpp
@@ -401,14 +401,17 @@ public:
                                             m_dataSource, m_graph);
     ScoreCandidatePathsGetter pathsGetter(pointsGetter, m_graph, m_infoGetter, stat);
 
-    if (!pathsGetter.GetLineCandidatesForPoints(points, lineCandidates))
+    if (!pathsGetter.GetLineCandidatesForPoints(points, segment.m_status, lineCandidates))
       return false;
 
     vector<Graph::EdgeVector> resultPath;
     ScorePathsConnector connector(m_graph, m_infoGetter, stat);
-    if (!connector.FindBestPath(points, lineCandidates, resultPath))
+    if (!connector.FindBestPath(points, lineCandidates, segment.m_status, resultPath))
     {
       LOG(LINFO, ("Connections not found:", segment.m_segmentId));
+      auto const mercatorPoints = segment.GetMercatorPoints();
+      for (auto const & mercatorPoint : mercatorPoints)
+        LOG(LINFO, (MercatorBounds::ToLatLon(mercatorPoint)));
       return false;
     }
 

--- a/openlr/openlr_model.cpp
+++ b/openlr/openlr_model.cpp
@@ -2,6 +2,8 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/assert.hpp"
+
 using namespace std;
 
 namespace openlr
@@ -23,5 +25,16 @@ vector<LocationReferencePoint> const & LinearSegment::GetLRPs() const
 vector<LocationReferencePoint> & LinearSegment::GetLRPs()
 {
   return m_locationReference.m_points;
+}
+
+string DebugPrint(LinearSegmentSource source)
+{
+  switch (source)
+  {
+  case LinearSegmentSource::NotValid: return "NotValid";
+  case LinearSegmentSource::FromLocationReferenceTag: return "FromLocationReferenceTag";
+  case LinearSegmentSource::FormCoordinatesTag: return "FormCoordinatesTag";
+  }
+  UNREACHABLE();
 }
 }  // namespace openlr

--- a/openlr/openlr_model.cpp
+++ b/openlr/openlr_model.cpp
@@ -33,7 +33,7 @@ string DebugPrint(LinearSegmentSource source)
   {
   case LinearSegmentSource::NotValid: return "NotValid";
   case LinearSegmentSource::FromLocationReferenceTag: return "FromLocationReferenceTag";
-  case LinearSegmentSource::FormCoordinatesTag: return "FormCoordinatesTag";
+  case LinearSegmentSource::FromCoordinatesTag: return "FromCoordinatesTag";
   }
   UNREACHABLE();
 }

--- a/openlr/openlr_model.hpp
+++ b/openlr/openlr_model.hpp
@@ -65,7 +65,7 @@ enum class LinearSegmentSource
 {
   NotValid,
   FromLocationReferenceTag,
-  FormCoordinatesTag,
+  FromCoordinatesTag,
 };
 
 struct LocationReferencePoint
@@ -110,7 +110,7 @@ struct LinearSegment
   std::vector<LocationReferencePoint> const & GetLRPs() const;
   std::vector<LocationReferencePoint> & GetLRPs();
 
-  LinearSegmentSource m_status = LinearSegmentSource::NotValid;
+  LinearSegmentSource m_source = LinearSegmentSource::NotValid;
   // TODO(mgsergio): Think of using openlr::PartnerSegmentId
   uint32_t m_segmentId = kInvalidSegmentId;
   // TODO(mgsergio): Make sure that one segment cannot contain

--- a/openlr/openlr_model.hpp
+++ b/openlr/openlr_model.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace openlr
@@ -58,6 +59,15 @@ enum class FunctionalRoadClass
   NotAValue
 };
 
+// LinearSegment structure may be filled from olr:locationReference xml tag,
+// from coordinates tag or not valid.
+enum class LinearSegmentSource
+{
+  NotValid,
+  FromLocationReferenceTag,
+  FormCoordinatesTag,
+};
+
 struct LocationReferencePoint
 {
   // Coordinates of the point of interest.
@@ -100,6 +110,7 @@ struct LinearSegment
   std::vector<LocationReferencePoint> const & GetLRPs() const;
   std::vector<LocationReferencePoint> & GetLRPs();
 
+  LinearSegmentSource m_status = LinearSegmentSource::NotValid;
   // TODO(mgsergio): Think of using openlr::PartnerSegmentId
   uint32_t m_segmentId = kInvalidSegmentId;
   // TODO(mgsergio): Make sure that one segment cannot contain
@@ -108,4 +119,6 @@ struct LinearSegment
   uint32_t m_segmentLengthMeters = 0;
   // uint32_t m_segmentRefSpeed;  Always null in partners data. (No docs found).
 };
+
+std::string DebugPrint(LinearSegmentSource source);
 }  // namespace openlr

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -70,16 +70,11 @@ pugi::xml_node GetCoordinates(pugi::xml_node const & node)
 
 bool IsLocationReferenceTag(pugi::xml_node const & node)
 {
-//  if (node.select_node(".//olr:locationReference").node())
-//    return false;
-//  return node.select_node("coordinates").node();
   return node.select_node(".//olr:locationReference").node();
 }
 
 bool IsCoordinatesTag(pugi::xml_node const & node)
 {
-//  if (node.select_node(".//olr:locationReference").node())
-//    return false;
   return node.select_node("coordinates").node();
 }
 
@@ -296,8 +291,6 @@ bool CoordinatesFromXML(pugi::xml_node const & coordsNode, openlr::LinearLocatio
     return false;
   }
 
-  // @TODO Default ctor for LatLon.
-
   ms::LatLon latLonStart = ms::LatLon::Zero();
   ms::LatLon latLonEnd = ms::LatLon::Zero();
   if (!LatLonFormXML(coordsNode.child("start"), latLonStart) ||
@@ -325,10 +318,9 @@ bool ParseOpenlr(pugi::xml_document const & document, vector<LinearSegment> & se
     auto const & node = segmentXpathNode.node();
     if (!IsLocationReferenceTag(node) && !IsCoordinatesTag(node))
     {
-//      LOG(LWARNING, ("A segment with <coordinates> instead of <optionLinearLocationReference> "
-//                     "was encountered, skipping..."));
-//      continue;
-      return false;
+      LOG(LWARNING, ("A segment with a strange tag. It is not <coordinates>"
+                     " or <optionLinearLocationReference>, skipping..."));
+      continue;
     }
 
     if (!SegmentFromXML(node, segment))

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -357,7 +357,11 @@ bool SegmentFromXML(pugi::xml_node const & segmentNode, LinearSegment & segment)
   if (IsLocationReferenceTag(segmentNode))
   {
     auto const locRefNode = GetLinearLocationReference(segmentNode);
-    return LinearLocationReferenceFromXML(locRefNode, segment.m_locationReference);
+    auto const result = LinearLocationReferenceFromXML(locRefNode, segment.m_locationReference);
+    if (result)
+      segment.m_status = LinearSegmentSource::FromLocationReferenceTag;
+
+    return result;
   }
 
   CHECK(IsCoordinatesTag(segmentNode), ());
@@ -367,6 +371,7 @@ bool SegmentFromXML(pugi::xml_node const & segmentNode, LinearSegment & segment)
 
   CHECK_EQUAL(segment.m_locationReference.m_points.size(), 2, ());
   segment.m_locationReference.m_points[0].m_distanceToNextPoint = segment.m_segmentLengthMeters;
+  segment.m_status = LinearSegmentSource::FormCoordinatesTag;
   return true;
 }
 }  // namespace openlr

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -351,7 +351,7 @@ bool SegmentFromXML(pugi::xml_node const & segmentNode, LinearSegment & segment)
     auto const locRefNode = GetLinearLocationReference(segmentNode);
     auto const result = LinearLocationReferenceFromXML(locRefNode, segment.m_locationReference);
     if (result)
-      segment.m_status = LinearSegmentSource::FromLocationReferenceTag;
+      segment.m_source = LinearSegmentSource::FromLocationReferenceTag;
 
     return result;
   }
@@ -363,7 +363,7 @@ bool SegmentFromXML(pugi::xml_node const & segmentNode, LinearSegment & segment)
 
   CHECK_EQUAL(segment.m_locationReference.m_points.size(), 2, ());
   segment.m_locationReference.m_points[0].m_distanceToNextPoint = segment.m_segmentLengthMeters;
-  segment.m_status = LinearSegmentSource::FormCoordinatesTag;
+  segment.m_source = LinearSegmentSource::FromCoordinatesTag;
   return true;
 }
 }  // namespace openlr

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -73,9 +73,9 @@ bool GetBearingScore(BearingPointsSelector const & pointsSelector,
     return false;
 
   double constexpr kMaxScoreForBearing = 60.0;
-  double constexpr kAngleDeviationFactor = 4.3;
+  double constexpr kAngleDeviationFactor = 1.0 / 4.3;
   score =
-      static_cast<Score>(kMaxScoreForBearing / (1.0 + angleDeviationDeg / kAngleDeviationFactor));
+      static_cast<Score>(kMaxScoreForBearing / (1.0 + angleDeviationDeg * kAngleDeviationFactor));
 
   return true;
 }
@@ -257,7 +257,7 @@ void ScoreCandidatePathsGetter::GetBestCandidatePaths(vector<shared_ptr<Link>> c
 
       --traceBackIterationsLeft;
 
-      // Note. No information about bearing if source == LinearSegmentSource::FormCoordinatesTag.
+      // Note. No information about bearing if source == LinearSegmentSource::FromCoordinatesTag.
       Score bearingScore = 0;
       if (source == LinearSegmentSource::FromLocationReferenceTag)
       {

--- a/openlr/score_candidate_paths_getter.hpp
+++ b/openlr/score_candidate_paths_getter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "openlr/helpers.hpp"
 #include "openlr/graph.hpp"
 #include "openlr/openlr_model.hpp"
 #include "openlr/road_info_getter.hpp"
@@ -21,6 +22,12 @@ class ScoreCandidatePointsGetter;
 
 class ScoreCandidatePathsGetter
 {
+  struct Link;
+  friend bool GetBearingScore(BearingPointsSelector const & pointsSelector,
+                              ScoreCandidatePathsGetter::Link const & part,
+                              m2::PointD const & bearStartPoint, uint32_t requiredBearing,
+                              Score & score);
+
 public:
   ScoreCandidatePathsGetter(ScoreCandidatePointsGetter & pointsGetter, Graph & graph,
                             RoadInfoGetter & infoGetter, v2::Stats & stat)
@@ -29,6 +36,7 @@ public:
   }
 
   bool GetLineCandidatesForPoints(std::vector<LocationReferencePoint> const & points,
+                                  LinearSegmentSource source,
                                   std::vector<ScorePathVec> & lineCandidates);
 
 private:
@@ -95,17 +103,19 @@ private:
   /// \brief Fills |allPaths| with paths near start or finish point starting from |startLines|.
   /// To extract a path from |allPaths| a item from |allPaths| should be taken,
   /// then should be taken the member |m_parent| of the item and so on till the beginning.
-  void GetAllSuitablePaths(ScoreEdgeVec const & startLines, bool isLastPoint,
-                           double bearDistM, FunctionalRoadClass  functionalRoadClass,
-                           FormOfWay formOfWay, std::vector<std::shared_ptr<Link>> & allPaths);
+  void GetAllSuitablePaths(ScoreEdgeVec const & startLines, LinearSegmentSource source,
+                           bool isLastPoint, double bearDistM,
+                           FunctionalRoadClass functionalRoadClass, FormOfWay formOfWay,
+                           std::vector<std::shared_ptr<Link>> & allPaths);
 
-  void GetBestCandidatePaths(std::vector<std::shared_ptr<Link>> const & allPaths, bool isLastPoint,
-                             uint32_t requiredBearing, double bearDistM,
-                             m2::PointD const & startPoint, ScorePathVec & candidates);
+  void GetBestCandidatePaths(std::vector<std::shared_ptr<Link>> const & allPaths,
+                             LinearSegmentSource source, bool isLastPoint, uint32_t requiredBearing,
+                             double bearDistM, m2::PointD const & startPoint,
+                             ScorePathVec & candidates);
 
-  void GetLineCandidates(openlr::LocationReferencePoint const & p, bool isLastPoint,
-                         double distanceToNextPointM, ScoreEdgeVec const & edgeCandidates,
-                         ScorePathVec & candidates);
+  void GetLineCandidates(openlr::LocationReferencePoint const & p, LinearSegmentSource source,
+                         bool isLastPoint, double distanceToNextPointM,
+                         ScoreEdgeVec const & edgeCandidates, ScorePathVec & candidates);
 
   ScoreCandidatePointsGetter & m_pointsGetter;
   Graph & m_graph;

--- a/openlr/score_candidate_paths_getter.hpp
+++ b/openlr/score_candidate_paths_getter.hpp
@@ -22,12 +22,6 @@ class ScoreCandidatePointsGetter;
 
 class ScoreCandidatePathsGetter
 {
-  struct Link;
-  friend bool GetBearingScore(BearingPointsSelector const & pointsSelector,
-                              ScoreCandidatePathsGetter::Link const & part,
-                              m2::PointD const & bearStartPoint, uint32_t requiredBearing,
-                              Score & score);
-
 public:
   ScoreCandidatePathsGetter(ScoreCandidatePointsGetter & pointsGetter, Graph & graph,
                             RoadInfoGetter & infoGetter, v2::Stats & stat)
@@ -116,6 +110,10 @@ private:
   void GetLineCandidates(openlr::LocationReferencePoint const & p, LinearSegmentSource source,
                          bool isLastPoint, double distanceToNextPointM,
                          ScoreEdgeVec const & edgeCandidates, ScorePathVec & candidates);
+
+  bool GetBearingScore(BearingPointsSelector const & pointsSelector,
+                       ScoreCandidatePathsGetter::Link const & part,
+                       m2::PointD const & bearStartPoint, uint32_t requiredBearing, Score & score);
 
   ScoreCandidatePointsGetter & m_pointsGetter;
   Graph & m_graph;

--- a/openlr/score_paths_connector.cpp
+++ b/openlr/score_paths_connector.cpp
@@ -188,12 +188,12 @@ bool ScorePathsConnector::FindBestPath(vector<LocationReferencePoint> const & po
         result.cbegin(), result.cend(),
         [](ScorePath const & o1, ScorePath const & o2) { return o1.m_score < o2.m_score; });
 
-    // Note. In case of source == LinearSegmentSource::FormCoordinatesTag there is less
-    // information about a open lr segment so less score is collected.
+    // Note. In case of source == LinearSegmentSource::FromCoordinatesTag there is less
+    // information about a openlr segment so less score is collected.
     Score const kMinValidScore = source == LinearSegmentSource::FromLocationReferenceTag ? 240 : 165;
     if (it->m_score < kMinValidScore)
     {
-      LOG(LINFO, ("The shortest path found but it is no good. The best score:", it->m_score));
+      LOG(LINFO, ("The shortest path found but it is not good. The best score:", it->m_score));
       ++m_stat.m_notEnoughScore;
       return false;
     }

--- a/openlr/score_paths_connector.cpp
+++ b/openlr/score_paths_connector.cpp
@@ -191,6 +191,7 @@ bool ScorePathsConnector::FindBestPath(vector<LocationReferencePoint> const & po
     if (it->m_score < kMinValidScore)
     {
       LOG(LINFO, ("The shortest path found but it is no good. The best score:", it->m_score));
+      ++m_stat.m_notEnoughScore;
       return false;
     }
 

--- a/openlr/score_paths_connector.hpp
+++ b/openlr/score_paths_connector.hpp
@@ -22,14 +22,16 @@ public:
   /// \returns true if the best path is found and false otherwise.
   bool FindBestPath(std::vector<LocationReferencePoint> const & points,
                     std::vector<std::vector<ScorePath>> const & lineCandidates,
+                    LinearSegmentSource source,
                     std::vector<Graph::EdgeVector> & resultPath);
 
 private:
   bool FindShortestPath(Graph::Edge const & from, Graph::Edge const & to,
-                        FunctionalRoadClass lowestFrcToNextPoint, uint32_t maxPathLength,
-                        Graph::EdgeVector & path);
+                        LinearSegmentSource source, FunctionalRoadClass lowestFrcToNextPoint,
+                        uint32_t maxPathLength, Graph::EdgeVector & path);
 
   bool ConnectAdjacentCandidateLines(Graph::EdgeVector const & from, Graph::EdgeVector const & to,
+                                     LinearSegmentSource source,
                                      FunctionalRoadClass lowestFrcToNextPoint,
                                      double distanceToNextPoint, Graph::EdgeVector & resultPath);
 

--- a/openlr/stats.hpp
+++ b/openlr/stats.hpp
@@ -19,6 +19,7 @@ struct alignas(kCacheLineSize) Stats
     m_routesFailed += s.m_routesFailed;
     m_noCandidateFound += s.m_noCandidateFound;
     m_noShortestPathFound += s.m_noShortestPathFound;
+    m_notEnoughScore += s.m_notEnoughScore;
     m_wrongOffsets += s.m_wrongOffsets;
     m_zeroDistToNextPointCount += s.m_zeroDistToNextPointCount;
   }
@@ -29,6 +30,7 @@ struct alignas(kCacheLineSize) Stats
     LOG(LINFO, ("Failed:", m_routesFailed));
     LOG(LINFO, ("No candidate lines:", m_noCandidateFound));
     LOG(LINFO, ("Wrong distance to next point:", m_zeroDistToNextPointCount));
+    LOG(LINFO, ("Not enough score for shortest path:", m_notEnoughScore));
     LOG(LINFO, ("Wrong offsets:", m_wrongOffsets));
     LOG(LINFO, ("No shortest path:", m_noShortestPathFound));
   }
@@ -37,6 +39,7 @@ struct alignas(kCacheLineSize) Stats
   uint32_t m_routesFailed = 0;
   uint32_t m_noCandidateFound = 0;
   uint32_t m_noShortestPathFound = 0;
+  uint32_t m_notEnoughScore = 0;
   uint32_t m_wrongOffsets = 0;
   // Number of zeroed distance-to-next point values in the input.
   uint32_t m_zeroDistToNextPointCount = 0;


### PR DESCRIPTION
В рамках алгоритма 3 по мачингу openlr сегментов теперь используется еще один таг: <coordinates>.

@vmihaylenko @gmoryes PTAL