### PR TITLE
[routing] Comment test and add another.

### DIFF
--- a/routing/routing_quality/routing_quality_tests/passby_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/passby_roads_tests.cpp
@@ -110,12 +110,14 @@ UNIT_TEST(RoutingQuality_SlovenijaLjubljana)
        ());
 }
 
-UNIT_TEST(RoutingQuality_FrancePoitiers)
-{
-  TEST(CheckCarRoute({46.63612, 0.35762} /* start */, {46.49, 0.36787} /* finish */,
-                     {{{46.58706, 0.39232}}} /* reference point */),
-       ());
-}
+
+// TODO: Uncomment this test when correct city boundaries or crossroads will be ready.
+//UNIT_TEST(RoutingQuality_FrancePoitiers)
+//{
+//  TEST(CheckCarRoute({46.63612, 0.35762} /* start */, {46.49, 0.36787} /* finish */,
+//                     {{{46.58706, 0.39232}}} /* reference point */),
+//       ());
+//}
 
 UNIT_TEST(RoutingQuality_FranceLoudun)
 {
@@ -136,5 +138,13 @@ UNIT_TEST(RoutingQuality_BelgiumBrussel)
   TEST(CheckCarRoute({50.88374, 4.2195} /* start */, {50.91494, 4.38122} /* finish */,
                      {{{50.91727, 4.36858}}} /* reference point */),
        ());
+}
+
+UNIT_TEST(RoutingQuality_SouthernDenmarkPastUnclassified)
+{
+  TEST(CheckCarRoute({55.44681, 10.29} /* start */, {55.45877, 10.26456} /* finish */,
+                     {{{55.45505, 10.26972}}} /* reference point */),
+       ());
+
 }
 }  // namespace


### PR DESCRIPTION
Из за понижения скорости на unclassified дорогах мы стали проходить закомменченый тест таким образом:
<img width="1792" alt="Снимок экрана 2019-05-16 в 18 25 23" src="https://user-images.githubusercontent.com/6297856/57912404-df64e300-7892-11e9-96e1-4b2e7d3a2c3c.png">
До этого проходили вот так:
<img width="1748" alt="Снимок экрана 2019-05-16 в 18 38 38" src="https://user-images.githubusercontent.com/6297856/57912399-dd9b1f80-7892-11e9-9190-c870ef1371a1.png">
выделеный участок дороги - это unclassified (как видно, довольно длинный и в целом не удивительно, что тест не прошел)
для сравнения гугл кладет через unclassified (по гугл картам я посмотрел, дорога действительно похожа на unclassified)
<img width="1436" alt="Снимок экрана 2019-05-16 в 18 12 58" src="https://user-images.githubusercontent.com/6297856/57912409-e0961000-7892-11e9-8ca7-222aca5623d8.png">
кажется, что когда будут починены границы городов + сделаны перекрестки - этот тест снова должен работать. 
повышать обратно скорость unclassified дорог неправильно, тк по документации osm'a они должны быть ниже tertiary.

так же добавил тест с ситуацией, которую чинил Владимир @bykoianko, а именно движение по secondary дороге без съезда на unclassified. 