### PR TITLE
[generator] Refactored Polygonizer.

### DIFF
--- a/3party/kdtree++/kdtree.hpp
+++ b/3party/kdtree++/kdtree.hpp
@@ -400,6 +400,13 @@ namespace KDTree
           _M_for_each(_M_get_root(), 0, toDo);
       }
 
+      template <class ToDo> bool any_of(ToDo toDo) const
+      {
+        if (_M_get_root())
+          return _M_any_of(_M_get_root(), 0, toDo);
+        return false;
+      }
+
       // compares via equality
       // if you are looking for a particular item in the tree,
       // and (for example) it has an ID that is checked via an == comparison
@@ -656,6 +663,21 @@ namespace KDTree
 
         if (_S_right(N) && toDo.ScanRight(L, _S_value(N)))
           _M_for_each(_S_right(N), L+1, toDo);
+      }
+
+      template <class ToDo>
+      bool _M_any_of(_Link_const_type N, size_type const L, ToDo toDo) const
+      {
+        if (toDo.Do(_S_value(N)))
+          return true;
+
+        if (_S_left(N) && toDo.ScanLeft(L, _S_value(N)))
+          return _M_any_of(_S_left(N), L+1, toDo);
+
+        if (_S_right(N) && toDo.ScanRight(L, _S_value(N)))
+          return _M_any_of(_S_right(N), L+1, toDo);
+
+        return false;
       }
 
 

--- a/3party/kdtree++/kdtree.hpp
+++ b/3party/kdtree++/kdtree.hpp
@@ -400,10 +400,10 @@ namespace KDTree
           _M_for_each(_M_get_root(), 0, toDo);
       }
 
-      template <class ToDo> bool any_of(ToDo toDo) const
+      template <class ToDo> bool for_any(ToDo toDo) const
       {
         if (_M_get_root())
-          return _M_any_of(_M_get_root(), 0, toDo);
+          return _M_for_any(_M_get_root(), 0, toDo);
         return false;
       }
 
@@ -666,16 +666,16 @@ namespace KDTree
       }
 
       template <class ToDo>
-      bool _M_any_of(_Link_const_type N, size_type const L, ToDo toDo) const
+      bool _M_for_any(_Link_const_type N, size_type const L, ToDo toDo) const
       {
-        if (toDo.Do(_S_value(N)))
+        if (toDo.DoIfIntersects(_S_value(N)))
           return true;
 
         if (_S_left(N) && toDo.ScanLeft(L, _S_value(N)))
-          return _M_any_of(_S_left(N), L+1, toDo);
+          return _M_for_any(_S_left(N), L+1, toDo);
 
         if (_S_right(N) && toDo.ScanRight(L, _S_value(N)))
-          return _M_any_of(_S_right(N), L+1, toDo);
+          return _M_for_any(_S_right(N), L+1, toDo);
 
         return false;
       }

--- a/generator/emitter_coastline.cpp
+++ b/generator/emitter_coastline.cpp
@@ -47,7 +47,7 @@ bool EmitterCoastline::Finish()
   m_generator->GetFeatures(features);
   for (auto & feature : features)
   {
-    collector(feature);
+    collector.Collect(feature);
 
     ++totalFeatures;
     totalPoints += feature.GetPointsCount();

--- a/generator/emitter_simple.cpp
+++ b/generator/emitter_simple.cpp
@@ -11,7 +11,7 @@ EmitterSimple::EmitterSimple(feature::GenerateInfo const & info) :
 
 void EmitterSimple::GetNames(std::vector<std::string> & names) const
 {
-  names = m_regionGenerator->Parent().Names();
+  names = m_regionGenerator->Parent().GetNames();
 }
 
 void EmitterSimple::Process(FeatureBuilder1 & fb)

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -163,28 +163,28 @@ public:
   //@}
 
   template <class ToDo>
-  bool AnyOfGeometryPointEx(ToDo && toDo) const
+  bool ForAnyGeometryPointEx(ToDo && toDo) const
   {
     if (m_params.GetGeomType() == feature::GeomType::Point)
       return toDo(m_center);
-    else
+
+    for (PointSeq const & points : m_polygons)
     {
-      for (PointSeq const & points : m_polygons)
+      for (auto const & pt : points)
       {
-        for (auto const & pt : points)
-          if (toDo(pt))
-            return true;
-        toDo.EndRegion();
+        if (toDo(pt))
+          return true;
       }
-      return false;
+      toDo.EndRegion();
     }
+    return false;
   }
 
   template <class ToDo>
-  bool AnyOfGeometryPoint(ToDo && toDo) const
+  bool ForAnyGeometryPoint(ToDo && toDo) const
   {
     ToDoWrapper<ToDo> wrapper(std::forward<ToDo>(toDo));
-    return AnyOfGeometryPointEx(std::move(wrapper));
+    return ForAnyGeometryPointEx(std::move(wrapper));
   }
 
   bool PreSerialize();

--- a/generator/feature_generator.cpp
+++ b/generator/feature_generator.cpp
@@ -92,7 +92,7 @@ uint32_t FeaturesCollector::WriteFeatureBase(std::vector<char> const & bytes, Fe
   return m_featureID++;
 }
 
-uint32_t FeaturesCollector::operator()(FeatureBuilder1 const & fb)
+uint32_t FeaturesCollector::Collect(FeatureBuilder1 const & fb)
 {
   FeatureBuilder1::Buffer bytes;
   fb.Serialize(bytes);
@@ -112,9 +112,9 @@ FeaturesAndRawGeometryCollector::~FeaturesAndRawGeometryCollector()
   LOG(LINFO, ("Write", m_rawGeometryCounter, "geometries into", m_rawGeometryFileStream.GetName()));
 }
 
-uint32_t FeaturesAndRawGeometryCollector::operator()(FeatureBuilder1 const & fb)
+uint32_t FeaturesAndRawGeometryCollector::Collect(FeatureBuilder1 const & fb)
 {
-  uint32_t const featureId = FeaturesCollector::operator()(fb);
+  uint32_t const featureId = FeaturesCollector::Collect(fb);
   FeatureBuilder1::Geometry const & geom = fb.GetGeometry();
   if (geom.empty())
     return featureId;

--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -29,10 +29,10 @@ public:
   /// and |kInvalidFeatureId| if not.
   /// \note See implementation operator() in derived class for cases when |f| cannot be
   /// serialized.
-  virtual uint32_t operator()(FeatureBuilder1 const & f);
-  virtual uint32_t operator()(FeatureBuilder1 & f)
+  virtual uint32_t Collect(FeatureBuilder1 const & f);
+  virtual uint32_t Collect(FeatureBuilder1 & f)
   {
-    return (*this)(const_cast<FeatureBuilder1 const &>(f));
+    return Collect(const_cast<FeatureBuilder1 const &>(f));
   }
   virtual void Finish() {}
 
@@ -65,7 +65,7 @@ public:
                                   std::string const & rawGeometryFileName);
   ~FeaturesAndRawGeometryCollector() override;
 
-  uint32_t operator()(FeatureBuilder1 const & f) override;
+  uint32_t Collect(FeatureBuilder1 const & f) override;
 };
 
 uint32_t CheckedFilePosCast(FileWriter const & f);

--- a/generator/feature_processing_layers.cpp
+++ b/generator/feature_processing_layers.cpp
@@ -336,8 +336,8 @@ EmitCoastsLayer::~EmitCoastsLayer()
     m_countryMapper->Map(fb);
     emitter.Finish();
 
-    fb.AddName("default", emitter.m_currentNames);
-    (*m_collector)(fb);
+    fb.AddName("default", emitter.GetCurrentNames());
+    m_collector->Collect(fb);
   });
 }
 
@@ -369,7 +369,7 @@ CountryMapper::Polygonizer & CountryMapper::Parent()
 
 std::vector<std::string> const & CountryMapper::GetNames() const
 {
-  return m_countries->Parent().Names();
+  return m_countries->Parent().GetNames();
 }
 
 WorldMapper::WorldMapper(std::string const & worldFilename, std::string const & rawGeometryFilename,

--- a/generator/generator_tests/coasts_test.cpp
+++ b/generator/generator_tests/coasts_test.cpp
@@ -99,7 +99,7 @@ public:
   void operator()(FeatureBuilder1 const & fb1, uint64_t)
   {
     if (HasID(fb1))
-      m_collector(fb1);
+      m_collector.Collect(fb1);
   }
 
 private:

--- a/generator/generator_tests/popularity_builder_tests.cpp
+++ b/generator/generator_tests/popularity_builder_tests.cpp
@@ -242,7 +242,7 @@ public:
     {
       feature::FeaturesCollector collector(filename);
       for (auto const & feature : m_testSet)
-        collector(feature);
+        collector.Collect(feature);
     }
 
     PopularityBuilder builder(filename);

--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -104,7 +104,7 @@ bool TestMwmBuilder::Add(FeatureBuilder1 & fb)
     return false;
   }
 
-  (*m_collector)(fb);
+  m_collector->Collect(fb);
   return true;
 }
 

--- a/generator/geo_objects/geo_objects.cpp
+++ b/generator/geo_objects/geo_objects.cpp
@@ -144,7 +144,7 @@ void FilterAddresslessByCountryAndRepackMwm(std::string const & pathInGeoObjects
   {
     if (GeoObjectsFilter::HasHouse(fb))
     {
-      collector(fb);
+      collector.Collect(fb);
       return;
     }
 
@@ -158,7 +158,7 @@ void FilterAddresslessByCountryAndRepackMwm(std::string const & pathInGeoObjects
     auto countryName = FromJSON<std::string>(country);
     auto pos = includeCountries.find(countryName);
     if (pos != std::string::npos)
-      collector(fb);
+      collector.Collect(fb);
   };
   feature::ForEachFromDatRawFormat(pathInGeoObjectsTmpMwm, filteringCollector);
 

--- a/generator/locality_sorter.cpp
+++ b/generator/locality_sorter.cpp
@@ -44,7 +44,7 @@ public:
   }
 
   // FeaturesCollector overrides:
-  uint32_t operator()(FeatureBuilder1 & fb) override
+  uint32_t Collect(FeatureBuilder1 & fb) override
   {
     if (fb.IsArea())
     {
@@ -101,7 +101,7 @@ public:
     m_writer.Finish();
   }
 
-  uint32_t operator()(FeatureBuilder1 & fb1) override
+  uint32_t Collect(FeatureBuilder1 & fb1) override
   {
     auto & fb2 = static_cast<FeatureBuilder2 &>(fb1);
 
@@ -217,7 +217,7 @@ bool GenerateLocalityDataImpl(FeaturesCollector & collector, NeedSerialize const
       ReadFromSourceRawFormat(src, f);
       // Emit object.
       if (needSerialize(f))
-        collector(f);
+        collector.Collect(f);
     }
 
     collector.Finish();

--- a/generator/polygonizer.hpp
+++ b/generator/polygonizer.hpp
@@ -3,220 +3,98 @@
 #include "generator/borders_loader.hpp"
 #include "generator/feature_builder.hpp"
 #include "generator/generate_info.hpp"
-#include "generator/osm_source.hpp"
-
-#include "indexer/feature_visibility.hpp"
-#include "indexer/cell_id.hpp"
 
 #include "geometry/rect2d.hpp"
+#include "geometry/mercator.hpp"
 
-#include "coding/file_writer.hpp"
-
-#include "base/base.hpp"
-#include "base/buffer_vector.hpp"
-#include "base/macros.hpp"
-
+#include <memory>
 #include <string>
-
-#ifndef PARALLEL_POLYGONIZER
-#define PARALLEL_POLYGONIZER 1
-#endif
-
-#if PARALLEL_POLYGONIZER
-#include <QtCore/QSemaphore>
-#include <QtCore/QThreadPool>
-#include <QtCore/QMutex>
-#include <QtCore/QMutexLocker>
-#endif
+#include <vector>
 
 namespace feature
 {
-  // Groups features according to country polygons
-  template <class FeatureOutT>
-  class Polygonizer
+// Groups features according to country polygons
+template <class FeatureOut>
+class Polygonizer
+{
+public:
+  Polygonizer(feature::GenerateInfo const & info)
+    : m_info(info)
   {
-    feature::GenerateInfo const & m_info;
-
-    vector<FeatureOutT*> m_Buckets;
-    vector<std::string> m_Names;
-    borders::CountriesContainer m_countries;
-
-#if PARALLEL_POLYGONIZER
-    QThreadPool m_ThreadPool;
-    QSemaphore m_ThreadPoolSemaphore;
-    QMutex m_EmitFeatureMutex;
-#endif
-
-  public:
-    Polygonizer(feature::GenerateInfo const & info)
-      : m_info(info)
-#if PARALLEL_POLYGONIZER
-      , m_ThreadPoolSemaphore(m_ThreadPool.maxThreadCount() * 8)
-#endif
+    if (info.m_splitByPolygons)
     {
-#if PARALLEL_POLYGONIZER
-      LOG(LINFO, ("Polygonizer thread pool threads:", m_ThreadPool.maxThreadCount()));
-#endif
-
-      if (info.m_splitByPolygons)
-      {
-        CHECK(borders::LoadCountriesList(info.m_targetDir, m_countries),
+      CHECK(borders::LoadCountriesList(info.m_targetDir, m_countries),
             ("Error loading country polygons files"));
-      }
-      else
-      {
-        // Insert fake country polygon equal to whole world to
-        // create only one output file which contains all features
-        m_countries.Add(borders::CountryPolygons(info.m_fileName), MercatorBounds::FullRect());
-      }
     }
-    ~Polygonizer()
+    else
     {
-      Finish();
-      for_each(m_Buckets.begin(), m_Buckets.end(), base::DeleteFunctor());
+      // Insert fake country polygon equal to whole world to
+      // create only one output file which contains all features
+      m_countries.Add(borders::CountryPolygons(info.m_fileName), MercatorBounds::FullRect());
     }
+  }
 
-    struct PointChecker
+  ~Polygonizer()
+  {
+    Finish();
+  }
+
+  void operator()(FeatureBuilder1 & fb)
+  {
+    m_countries.ForEachInRect(fb.GetLimitRect(), [&](auto const & countryPolygons) {
+      auto const need = fb.AnyOfGeometryPoint([&](auto const & point) {
+        auto const & regions = countryPolygons.m_regions;
+        return regions.AnyOfInRect(m2::RectD(point, point), [&](auto const & rgn) {
+          return rgn.Contains(point);
+        });
+        return true;
+      });
+
+      if (need)
+        EmitFeature(countryPolygons, fb);
+    });
+  }
+
+  void Start()
+  {
+    m_currentNames.clear();
+  }
+
+  void Finish()
+  {
+  }
+
+  void EmitFeature(borders::CountryPolygons const & countryPolygons, FeatureBuilder1 const & fb)
+  {
+    if (countryPolygons.m_index == -1)
     {
-      borders::RegionsContainer const & m_regions;
-      bool m_belongs;
-
-      PointChecker(borders::RegionsContainer const & regions)
-        : m_regions(regions), m_belongs(false) {}
-
-      bool operator()(m2::PointD const & pt)
-      {
-        m_regions.ForEachInRect(m2::RectD(pt, pt),
-                                std::bind<void>(std::ref(*this), std::placeholders::_1, std::cref(pt)));
-        return !m_belongs;
-      }
-
-      void operator() (borders::Region const & rgn, borders::Region::Value const & point)
-      {
-        if (!m_belongs)
-          m_belongs = rgn.Contains(point);
-      }
-    };
-
-    class InsertCountriesPtr
-    {
-      typedef buffer_vector<borders::CountryPolygons const *, 32> vec_type;
-      vec_type & m_vec;
-
-    public:
-      InsertCountriesPtr(vec_type & vec) : m_vec(vec) {}
-      void operator() (borders::CountryPolygons const & c)
-      {
-        m_vec.push_back(&c);
-      }
-    };
-
-    void operator()(FeatureBuilder1 & fb)
-    {
-      buffer_vector<borders::CountryPolygons const *, 32> vec;
-      m_countries.ForEachInRect(fb.GetLimitRect(), InsertCountriesPtr(vec));
-
-      switch (vec.size())
-      {
-      case 0:
-        break;
-      case 1:
-        EmitFeature(vec[0], fb);
-        break;
-      default:
-        {
-#if PARALLEL_POLYGONIZER
-          m_ThreadPoolSemaphore.acquire();
-          m_ThreadPool.start(new PolygonizerTask(this, vec, fb));
-#else
-        PolygonizerTask task(this, vec, fb);
-        task.RunBase();
-#endif
-        }
-      }
+      m_Names.push_back(countryPolygons.m_name);
+      m_Buckets.emplace_back(new FeatureOut(m_info.GetTmpFileName(countryPolygons.m_name)));
+      countryPolygons.m_index = static_cast<int>(m_Buckets.size())-1;
     }
 
-    std::string m_currentNames;
+    if (!m_currentNames.empty())
+      m_currentNames += ';';
 
-    void Start()
-    {
-      m_currentNames.clear();
-    }
+    m_currentNames += countryPolygons.m_name;
+    m_Buckets[countryPolygons.m_index]->Collect(fb);
+  }
 
-    void Finish()
-    {
-#if PARALLEL_POLYGONIZER
-      m_ThreadPool.waitForDone();
-#endif
-    }
+  std::vector<std::string> const & GetNames() const
+  {
+    return m_Names;
+  }
 
-    void EmitFeature(borders::CountryPolygons const * country, FeatureBuilder1 const & fb)
-    {
-#if PARALLEL_POLYGONIZER
-      QMutexLocker mutexLocker(&m_EmitFeatureMutex);
-      UNUSED_VALUE(mutexLocker);
-#endif
-      if (country->m_index == -1)
-      {
-        m_Names.push_back(country->m_name);
-        m_Buckets.push_back(new FeatureOutT(m_info.GetTmpFileName(country->m_name)));
-        country->m_index = static_cast<int>(m_Buckets.size())-1;
-      }
+  std::string const & GetCurrentNames() const
+  {
+    return m_currentNames;
+  }
 
-      if (!m_currentNames.empty())
-        m_currentNames += ';';
-      m_currentNames += country->m_name;
-
-      auto & bucket = *(m_Buckets[country->m_index]);
-      bucket(fb);
-    }
-
-    vector<std::string> const & Names() const
-    {
-      return m_Names;
-    }
-
-  private:
-    friend class PolygonizerTask;
-
-    class PolygonizerTask
-#if PARALLEL_POLYGONIZER
-      : public QRunnable
-#endif
-    {
-    public:
-      PolygonizerTask(Polygonizer * pPolygonizer,
-                      buffer_vector<borders::CountryPolygons const *, 32> const & countries,
-                      FeatureBuilder1 const & fb)
-        : m_pPolygonizer(pPolygonizer), m_Countries(countries), m_fb(fb)
-      {
-      }
-
-      void RunBase()
-      {
-        for (size_t i = 0; i < m_Countries.size(); ++i)
-        {
-          PointChecker doCheck(m_Countries[i]->m_regions);
-          m_fb.ForEachGeometryPoint(doCheck);
-
-          if (doCheck.m_belongs)
-            m_pPolygonizer->EmitFeature(m_Countries[i], m_fb);
-        }
-      }
-
-#if PARALLEL_POLYGONIZER
-      void run()
-      {
-        RunBase();
-
-        m_pPolygonizer->m_ThreadPoolSemaphore.release();
-      }
-#endif
-
-    private:
-      Polygonizer * m_pPolygonizer;
-      buffer_vector<borders::CountryPolygons const *, 32> m_Countries;
-      FeatureBuilder1 m_fb;
-    };
-  };
+private:
+  feature::GenerateInfo const & m_info;
+  std::vector<std::unique_ptr<FeatureOut>> m_Buckets;
+  std::vector<std::string> m_Names;
+  borders::CountriesContainer m_countries;
+  std::string m_currentNames;
+};
 }  // namespace feature

--- a/generator/polygonizer.hpp
+++ b/generator/polygonizer.hpp
@@ -13,7 +13,7 @@
 
 namespace feature
 {
-// Groups features according to country polygons
+// Groups features according to country polygons.
 template <class FeatureOut>
 class Polygonizer
 {
@@ -24,12 +24,12 @@ public:
     if (info.m_splitByPolygons)
     {
       CHECK(borders::LoadCountriesList(info.m_targetDir, m_countries),
-            ("Error loading country polygons files"));
+            ("Error loading country polygons files."));
     }
     else
     {
       // Insert fake country polygon equal to whole world to
-      // create only one output file which contains all features
+      // create only one output file which contains all features.
       m_countries.Add(borders::CountryPolygons(info.m_fileName), MercatorBounds::FullRect());
     }
   }
@@ -42,12 +42,11 @@ public:
   void operator()(FeatureBuilder1 & fb)
   {
     m_countries.ForEachInRect(fb.GetLimitRect(), [&](auto const & countryPolygons) {
-      auto const need = fb.AnyOfGeometryPoint([&](auto const & point) {
+      auto const need = fb.ForAnyGeometryPoint([&](auto const & point) {
         auto const & regions = countryPolygons.m_regions;
-        return regions.AnyOfInRect(m2::RectD(point, point), [&](auto const & rgn) {
+        return regions.ForAnyInRect(m2::RectD(point, point), [&](auto const & rgn) {
           return rgn.Contains(point);
         });
-        return true;
       });
 
       if (need)
@@ -68,21 +67,21 @@ public:
   {
     if (countryPolygons.m_index == -1)
     {
-      m_Names.push_back(countryPolygons.m_name);
-      m_Buckets.emplace_back(new FeatureOut(m_info.GetTmpFileName(countryPolygons.m_name)));
-      countryPolygons.m_index = static_cast<int>(m_Buckets.size())-1;
+      m_names.push_back(countryPolygons.m_name);
+      m_buckets.emplace_back(new FeatureOut(m_info.GetTmpFileName(countryPolygons.m_name)));
+      countryPolygons.m_index = static_cast<int>(m_buckets.size()) - 1;
     }
 
     if (!m_currentNames.empty())
       m_currentNames += ';';
 
     m_currentNames += countryPolygons.m_name;
-    m_Buckets[countryPolygons.m_index]->Collect(fb);
+    m_buckets[countryPolygons.m_index]->Collect(fb);
   }
 
   std::vector<std::string> const & GetNames() const
   {
-    return m_Names;
+    return m_names;
   }
 
   std::string const & GetCurrentNames() const
@@ -92,8 +91,8 @@ public:
 
 private:
   feature::GenerateInfo const & m_info;
-  std::vector<std::unique_ptr<FeatureOut>> m_Buckets;
-  std::vector<std::string> m_Names;
+  std::vector<std::unique_ptr<FeatureOut>> m_buckets;
+  std::vector<std::string> m_names;
   borders::CountriesContainer m_countries;
   std::string m_currentNames;
 };

--- a/generator/regions/regions.cpp
+++ b/generator/regions/regions.cpp
@@ -158,7 +158,7 @@ private:
       }
 
       CHECK(fb.IsArea(), ());
-      collector(fb);
+      collector.Collect(fb);
     };
 
     feature::ForEachFromDatRawFormat(m_pathInRegionsTmpMwm, toDo);

--- a/generator/world_map_generator.hpp
+++ b/generator/world_map_generator.hpp
@@ -243,7 +243,7 @@ class WorldMapGenerator
       return (scales::GetUpperWorldScale() >= fb.GetMinFeatureDrawScale());
     }
 
-    void PushSure(FeatureBuilder1 const & fb) { m_output(fb); }
+    void PushSure(FeatureBuilder1 const & fb) { m_output.Collect(fb); }
   };
 
   EmitterImpl m_worldBucket;

--- a/geometry/tree4d.hpp
+++ b/geometry/tree4d.hpp
@@ -107,6 +107,13 @@ class Tree
         m_toDo(v);
     }
 
+    bool Do(Value const & v) const
+    {
+      if (v.IsIntersect(m_rect))
+        return m_toDo(v);
+      return false;
+    }
+
   private:
     m2::RectD const & m_rect;
     ToDo m_toDo;
@@ -221,6 +228,12 @@ public:
     }
 
     return false;
+  }
+
+  template <typename ToDo>
+  bool AnyOfInRect(m2::RectD const & rect, ToDo && toDo) const
+  {
+    return m_tree.any_of(GetFunctor(rect, [&toDo](Value const & v) { return toDo(v.m_val); }));
   }
 
   template <typename ToDo>

--- a/geometry/tree4d.hpp
+++ b/geometry/tree4d.hpp
@@ -107,7 +107,7 @@ class Tree
         m_toDo(v);
     }
 
-    bool Do(Value const & v) const
+    bool DoIfIntersects(Value const & v) const
     {
       if (v.IsIntersect(m_rect))
         return m_toDo(v);
@@ -231,9 +231,9 @@ public:
   }
 
   template <typename ToDo>
-  bool AnyOfInRect(m2::RectD const & rect, ToDo && toDo) const
+  bool ForAnyInRect(m2::RectD const & rect, ToDo && toDo) const
   {
-    return m_tree.any_of(GetFunctor(rect, [&toDo](Value const & v) { return toDo(v.m_val); }));
+    return m_tree.for_any(GetFunctor(rect, [&toDo](Value const & v) { return toDo(v.m_val); }));
   }
 
   template <typename ToDo>


### PR DESCRIPTION
Отрефакторил класс Polygonizer:
Помимо всяких форматирований, было несколько на мой взгляд важных проблем:
1. Помните не получилось пересобрать Италию для продакшн карт, оказывается вся проблема тут https://github.com/mapsme/omim/blob/master/generator/polygonizer.hpp#L119. В этом switch. Не проверялись точные границы региона. В приниципе понятно зачем авторы так сделали. Это будет работать немного быстрее, но невозможно пересобрать какие то mwm ки. Эта возможность очень нужна. Теперь границы проверяются всегда.
2. Потенциальная гонка в этой строке: https://github.com/mapsme/omim/blob/master/generator/polygonizer.hpp#L203, если пройтись глазами по стеку вызово видно, что emit (внутри write) может вызываться для одного и того же региона для разных фичей. Это очень опасно. Удалил распаралелливание и зависимость от Qt в этом месте.
 