### PR TITLE
[storage][data] Add country name synonyms to countries.txt

### DIFF
--- a/data/countries.txt
+++ b/data/countries.txt
@@ -244,6 +244,10 @@
     "Caribisch Nederland", 
     "Nederland", 
     "Venezuela"
+   ],
+   "country_name_synonyms": [
+     "Aruba",
+     "Curacao"
    ]
   }, 
   {
@@ -360,6 +364,9 @@
     "Anguilla", 
     "France", 
     "Nederland"
+   ],
+   "country_name_synonyms": [
+     "Sint Maarten"
    ]
   }, 
   {
@@ -998,6 +1005,9 @@
   }, 
   {
    "id": "Belarus", 
+   "country_name_synonyms": [
+     "Belaruś"
+   ],
    "g": [
     {
      "id": "Belarus_Vitebsk Region", 
@@ -2606,6 +2616,9 @@
    ], 
    "affiliations": [
     "Cabo Verde"
+   ],
+   "country_name_synonyms": [
+     "Cabo Verde"
    ]
   }, 
   {
@@ -2787,10 +2800,16 @@
     "Pointe-Noire", 
     "Pool", 
     "Sangha"
+   ],
+   "country_name_synonyms": [
+     "Republic of the Congo"
    ]
   }, 
   {
    "id": "Congo-Kinshasa", 
+   "country_name_synonyms": [
+     "Democratic Republic of the Congo"
+   ],
    "g": [
     {
      "id": "Congo-Kinshasa_West", 
@@ -2940,6 +2959,9 @@
   }, 
   {
    "id": "Czech Republic", 
+   "country_name_synonyms": [
+     "Czechia"
+   ],
    "g": [
     {
      "id": "Czech_Praha", 
@@ -3146,6 +3168,10 @@
     "Vall\u00e9e du Bandama", 
     "Woroba", 
     "Yamoussoukro"
+   ],
+   "country_name_synonyms": [
+     "Côte d'Ivoire",
+     "Ivory Coast"
    ]
   }, 
   {
@@ -7011,6 +7037,9 @@
       "Lazio", 
       "Palmarola", 
       "Ventotene"
+     ],
+     "country_name_synonyms": [
+       "Vatican City"
      ]
     }, 
     {
@@ -8347,6 +8376,9 @@
    ], 
    "affiliations": [
     "Lesotho"
+   ],
+   "country_name_synonyms": [
+     "Lesotho"
    ]
   }, 
   {
@@ -8613,6 +8645,9 @@
     "\u0408\u0443\u0433\u043e\u0438\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d", 
     "\u041f\u0435\u043b\u0430\u0433\u043e\u043d\u0438\u0441\u043a\u0438 \u0420\u0435\u0433\u0438\u043e\u043d", 
     "\u0421\u0435\u0432\u0435\u0440\u043e\u0438\u0441\u0442\u043e\u0447\u0435\u043d \u0420\u0435\u0433\u0438\u043e\u043d"
+   ],
+   "country_name_synonyms": [
+     "North Macedonia"
    ]
   }, 
   {
@@ -9722,6 +9757,9 @@
   }, 
   {
    "id": "People's Republic of China", 
+   "country_name_synonyms": [
+     "China"
+   ],
    "g": [
     {
      "id": "China_Anhui", 
@@ -9782,6 +9820,9 @@
       "\u4e2d\u56fd", 
       "\u5e7f\u4e1c\u7701", 
       "\u6d77\u5357\u7701"
+     ],
+     "country_name_synonyms": [
+      "Hong Kong"
      ]
     }, 
     {
@@ -10339,6 +10380,9 @@
    ], 
    "affiliations": [
     "Pitcairn Islands"
+   ],
+   "country_name_synonyms": [
+     "Pitcairn"
    ]
   }, 
   {
@@ -10659,6 +10703,9 @@
    ], 
    "affiliations": [
     "Republika e Kosov\u00ebs"
+   ],
+   "country_name_synonyms": [
+     "Kosovo"
    ]
   }, 
   {
@@ -12054,6 +12101,10 @@
     "AS", 
     "S\u0101moa", 
     "United States of America"
+   ],
+   "country_name_synonyms": [
+     "American Samoa",
+     "Sāmoa"
    ]
   }, 
   {
@@ -12479,6 +12530,9 @@
    "affiliations": [
     "Freezland Rock", 
     "South Georgia and South Sandwich Islands"
+   ],
+   "country_name_synonyms": [
+     "South Georgia and South Sandwich Islands"
    ]
   }, 
   {
@@ -12855,6 +12909,9 @@
       "Area C"
      ]
     }
+   ],
+   "country_name_synonyms": [
+     "Palestinian Territories"
    ]
   }, 
   {
@@ -12963,6 +13020,9 @@
     "Sifundza seManzini", 
     "Sifundza seShiselweni", 
     "Swatini"
+   ],
+   "country_name_synonyms": [
+     "Eswatini"
    ]
   }, 
   {
@@ -13425,6 +13485,9 @@
    "affiliations": [
     "Ciego de \u00c1vila", 
     "The Bahamas"
+   ],
+   "country_name_synonyms": [
+     "Bahamas"
    ]
   }, 
   {
@@ -15204,6 +15267,9 @@
       "Northern Mariana Islands", 
       "MP", 
       "United States of America"
+     ],
+     "country_name_synonyms": [
+      "Guam"
      ]
     }, 
     {

--- a/data/countries_synonyms.csv
+++ b/data/countries_synonyms.csv
@@ -1,0 +1,24 @@
+Samoa	American Samoa
+Samoa	Sāmoa
+People's Republic of China	China
+Pitcairn Islands	Pitcairn
+South Georgia and the South Sandwich Islands	South Georgia and South Sandwich Islands
+The Bahamas	Bahamas
+Belarus	Belaruś
+Kingdom of Lesotho	Lesotho
+Swaziland	Eswatini
+Congo-Brazzaville	Republic of the Congo
+Congo-Kinshasa	Democratic Republic of the Congo
+Caribisch Nederland	Aruba
+Caribisch Nederland	Curacao
+Saint Martin	Sint Maarten
+Cape Verde	Cabo Verde
+Cote dIvoire	Côte d'Ivoire
+Cote dIvoire	Ivory Coast
+Palestine Region	Palestinian Territories
+Italy_Lazio	Vatican City
+Republic of Kosovo	Kosovo
+China_Guangdong	Hong Kong
+US_Guam	Guam
+Macedonia	North Macedonia
+Czech Republic	Czechia

--- a/map/map_tests/countries_names_tests.cpp
+++ b/map/map_tests/countries_names_tests.cpp
@@ -32,6 +32,7 @@ UNIT_TEST(CountriesNamesTest)
 {
   Framework f(FrameworkParams(false /* m_enableLocalAds */, false /* m_enableDiffs */));
   auto & storage = f.GetStorage();
+  auto const & synonyms = storage.GetCountryNameSynonyms();
 
   auto handle = search::FindWorld(f.GetDataSource());
   TEST(handle.IsAlive(), ());
@@ -48,32 +49,9 @@ UNIT_TEST(CountriesNamesTest)
                                       StringUtf8Multilang::kDefaultCode,
                                       StringUtf8Multilang::kInternationalCode};
 
-  // todo: (@t.yan) fix names for countries which have separate mwms.
-  set<string> const kIgnoreList = {"China",
-                                   "American Samoa",
-                                   "Sāmoa",
-                                   "Pitcairn",
-                                   "South Georgia and South Sandwich Islands",
-                                   "Lesotho",
-                                   "Eswatini",
-                                   "Republic of the Congo",
-                                   "Democratic Republic of the Congo",
-                                   "Aruba",
-                                   "Sint Maarten",
-                                   "Bahamas",
-                                   "Cabo Verde",
-                                   "Ivory Coast",
-                                   "Palestinian Territories",
-                                   "Turkish Republic Of Northern Cyprus",
-                                   "Nagorno-Karabakh Republic",
-                                   "Vatican City",
-                                   "North Macedonia",
-                                   "Kosovo",
-                                   "Czechia",
+  set<string> const kIgnoreList = {"Turkish Republic Of Northern Cyprus",
                                    "Transnistria",
-                                   "Republic of Belarus",
-                                   "Hong Kong",
-                                   "Guam",
+                                   "Nagorno-Karabakh Republic",
                                    // MAPSME-10611
                                    "Mayorca Residencial",
                                    "Magnolias Residencial"};
@@ -92,7 +70,10 @@ UNIT_TEST(CountriesNamesTest)
                   string name;
                   if (!ft->GetName(langIndex, name))
                     return false;
-                  return storage.IsNode(name) || kIgnoreList.count(name) != 0;
+                  auto const it = synonyms.find(name);
+                  if (it == synonyms.end())
+                    return storage.IsNode(name) || kIgnoreList.count(name) != 0;
+                  return storage.IsNode(it->second);
                 }),
          ("Cannot find countries.txt record for country feature:",
           ft->DebugString(FeatureType::BEST_GEOMETRY)));

--- a/search/downloader_search_callback.cpp
+++ b/search/downloader_search_callback.cpp
@@ -20,6 +20,7 @@ namespace
 bool GetGroupCountryIdFromFeature(storage::Storage const & storage, FeatureType & ft,
                                   std::string & name)
 {
+  auto const & synonyms = storage.GetCountryNameSynonyms();
   int8_t const langIndices[] = {StringUtf8Multilang::kEnglishCode,
                                 StringUtf8Multilang::kDefaultCode,
                                 StringUtf8Multilang::kInternationalCode};
@@ -30,6 +31,13 @@ bool GetGroupCountryIdFromFeature(storage::Storage const & storage, FeatureType 
       continue;
     if (storage.IsInnerNode(name))
       return true;
+    auto const it = synonyms.find(name);
+    if (it == synonyms.end())
+      continue;
+    if (!storage.IsInnerNode(it->second))
+      continue;
+    name = it->second;
+    return true;
   }
   return false;
 }

--- a/search/region_info_getter.cpp
+++ b/search/region_info_getter.cpp
@@ -43,7 +43,8 @@ void GetPathToRoot(storage::CountryId const & id, storage::CountryTree const & c
 void RegionInfoGetter::LoadCountriesTree()
 {
   storage::Affiliations affiliations;
-  storage::LoadCountriesFromFile(COUNTRIES_FILE, m_countries, affiliations);
+  storage::CountryNameSynonyms countryNameSynonyms;
+  storage::LoadCountriesFromFile(COUNTRIES_FILE, m_countries, affiliations, countryNameSynonyms);
 }
 
 void RegionInfoGetter::SetLocale(string const & locale)

--- a/search/search_quality/features_collector_tool/features_collector_tool.cpp
+++ b/search/search_quality/features_collector_tool/features_collector_tool.cpp
@@ -108,7 +108,8 @@ int main(int argc, char * argv[])
   InitDataSource(dataSource, "" /* mwmListPath */);
 
   storage::Affiliations affiliations;
-  InitAffiliations(affiliations);
+  storage::CountryNameSynonyms countryNameSynonyms;
+  InitStorageData(affiliations, countryNameSynonyms);
 
   auto engine = InitSearchEngine(dataSource, affiliations, "en" /* locale */, 1 /* numThreads */);
 

--- a/search/search_quality/helpers.cpp
+++ b/search/search_quality/helpers.cpp
@@ -175,12 +175,14 @@ void InitDataSource(FrozenDataSource & dataSource, string const & mwmListPath)
   LOG(LINFO, ());
 }
 
-void InitAffiliations(storage::Affiliations & affiliations)
+void InitStorageData(storage::Affiliations & affiliations,
+                     storage::CountryNameSynonyms & countryNameSynonyms)
 {
   auto const countriesFile = base::JoinPath(GetPlatform().ResourcesDir(), COUNTRIES_FILE);
 
   storage::CountryTree countries;
-  auto const rv = storage::LoadCountriesFromFile(countriesFile, countries, affiliations);
+  auto const rv =
+      storage::LoadCountriesFromFile(countriesFile, countries, affiliations, countryNameSynonyms);
   CHECK(rv != -1, ("Can't load countries from:", countriesFile));
 }
 

--- a/search/search_quality/helpers.hpp
+++ b/search/search_quality/helpers.hpp
@@ -34,7 +34,8 @@ void InitViewport(std::string viewportName, m2::RectD & viewport);
 
 void InitDataSource(FrozenDataSource & dataSource, std::string const & mwmListPath);
 
-void InitAffiliations(storage::Affiliations & affiliations);
+void InitStorageData(storage::Affiliations & affiliations,
+                     storage::CountryNameSynonyms & countryNameSynonyms);
 
 std::unique_ptr<search::tests_support::TestSearchEngine> InitSearchEngine(
     DataSource & dataSource, storage::Affiliations const & affiliations, std::string const & locale,

--- a/search/search_quality/search_quality_tool/search_quality_tool.cpp
+++ b/search/search_quality/search_quality_tool/search_quality_tool.cpp
@@ -380,7 +380,8 @@ int main(int argc, char * argv[])
   InitDataSource(dataSource, FLAGS_mwm_list_path);
 
   storage::Affiliations affiliations;
-  InitAffiliations(affiliations);
+  storage::CountryNameSynonyms countryNameSynonyms;
+  InitStorageData(affiliations, countryNameSynonyms);
 
   auto engine = InitSearchEngine(dataSource, affiliations, FLAGS_locale, FLAGS_num_threads);
 

--- a/storage/country_tree.hpp
+++ b/storage/country_tree.hpp
@@ -254,9 +254,13 @@ private:
 
 /// @return version of country file or -1 if error was encountered
 int64_t LoadCountriesFromBuffer(std::string const & buffer, CountryTree & countries,
-                                Affiliations & affiliations, OldMwmMapping * mapping = nullptr);
+                                Affiliations & affiliations,
+                                CountryNameSynonyms & countryNameSynonyms,
+                                OldMwmMapping * mapping = nullptr);
 int64_t LoadCountriesFromFile(std::string const & path, CountryTree & countries,
-                              Affiliations & affiliations, OldMwmMapping * mapping = nullptr);
+                              Affiliations & affiliations,
+                              CountryNameSynonyms & countryNameSynonyms,
+                              OldMwmMapping * mapping = nullptr);
 
 void LoadCountryFile2CountryInfo(std::string const & jsonBuffer,
                                  std::map<std::string, CountryInfo> & id2info, bool & isSingleMwm);

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -141,8 +141,8 @@ Storage::Storage(string const & referenceCountriesTxtJsonForTesting,
   , m_downloadMapOnTheMap(nullptr)
   , m_maxMwmSizeBytes(0)
 {
-  m_currentVersion =
-      LoadCountriesFromBuffer(referenceCountriesTxtJsonForTesting, m_countries, m_affiliations);
+  m_currentVersion = LoadCountriesFromBuffer(referenceCountriesTxtJsonForTesting, m_countries,
+                                             m_affiliations, m_countryNameSynonyms);
   CHECK_LESS_OR_EQUAL(0, m_currentVersion, ("Can't load test countries file"));
   CalcMaxMwmSizeBytes();
 }
@@ -762,8 +762,8 @@ void Storage::LoadCountriesFile(string const & pathToCountriesFile, string const
 
   if (m_countries.IsEmpty())
   {
-    m_currentVersion =
-        LoadCountriesFromFile(pathToCountriesFile, m_countries, m_affiliations, mapping);
+    m_currentVersion = LoadCountriesFromFile(pathToCountriesFile, m_countries, m_affiliations,
+                                             m_countryNameSynonyms, mapping);
     LOG_SHORT(LINFO, ("Loaded countries list for version:", m_currentVersion));
     if (m_currentVersion < 0)
       LOG(LERROR, ("Can't load countries file", pathToCountriesFile));

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -263,6 +263,7 @@ private:
   // Once filled |m_affiliations| is not changed.
   // Note. |m_affiliations| is empty in case of countries_obsolete.txt.
   Affiliations m_affiliations;
+  CountryNameSynonyms m_countryNameSynonyms;
 
   MwmSize m_maxMwmSizeBytes;
 
@@ -468,6 +469,8 @@ public:
   bool GetUpdateInfo(CountryId const & countryId, UpdateInfo & updateInfo) const;
 
   Affiliations const & GetAffiliations() const { return m_affiliations; }
+
+  CountryNameSynonyms const & GetCountryNameSynonyms() const { return m_countryNameSynonyms; }
 
   /// \brief Calls |toDo| for each node for subtree with |root|.
   /// For example ForEachInSubtree(GetRootId()) calls |toDo| for every node including

--- a/storage/storage_defines.hpp
+++ b/storage/storage_defines.hpp
@@ -19,8 +19,10 @@ using CountriesSet = std::set<CountryId>;
 using CountriesVec = std::vector<CountryId>;
 using LocalFilePtr = std::shared_ptr<platform::LocalCountryFile>;
 using OldMwmMapping = std::map<CountryId, CountriesSet>;
-/// Map from key affiliation words into MWM IDs (file names).
+/// Map from key affiliation words into CountryIds.
 using Affiliations = std::unordered_map<std::string, std::vector<CountryId>>;
+/// Map from country name synonyms and old names into CountryId.
+using CountryNameSynonyms = std::unordered_map<std::string, CountryId>;
 
 extern const storage::CountryId kInvalidCountryId;
 

--- a/tools/python/maps_generator/generator/env.py
+++ b/tools/python/maps_generator/generator/env.py
@@ -209,6 +209,10 @@ class Env:
         return os.path.join(self.user_resource_path, "borders_vs_osm.csv")
 
     @property
+    def countries_synonyms_path(self):
+        return os.path.join(self.user_resource_path, "countries_synonyms.csv")
+
+    @property
     def counties_txt_path(self):
         return os.path.join(self.mwm_path, "countries.txt")
 

--- a/tools/python/maps_generator/maps_generator.py
+++ b/tools/python/maps_generator/maps_generator.py
@@ -223,6 +223,7 @@ def stage_descriptions(env):
 def stage_countries_txt(env):
     countries = hierarchy_to_countries(env.old_to_new_path,
                                        env.borders_to_osm_path,
+                                       env.country_synonyms_path,
                                        env.hierarchy_path, env.mwm_path,
                                        env.mwm_version)
     with open(env.counties_txt_path, "w") as f:

--- a/tools/python/post_generation/__main__.py
+++ b/tools/python/post_generation/__main__.py
@@ -66,12 +66,15 @@ The post_generation commands are:
                             help="old_vs_new.csv file")
         parser.add_argument("--osm", required=True,
                             help="borders_vs_osm.csv file")
+        parser.add_argument("--countries_synonyms", required=True,
+                            help="countries_synonyms.csv file")
         parser.add_argument("--mwm_version", type=int, required=True,
                             help="Mwm version")
         parser.add_argument("-o", "--output", required=True,
                             help="Output countries.txt file (default is stdout)")
         args = parser.parse_args(sys.argv[2:])
         countries_json = hierarchy_to_countries_(args.old, args.osm,
+                                                 args.countries_synonyms,
                                                  args.hierarchy,
                                                  args.target,
                                                  args.mwm_version)

--- a/tools/python/post_generation/hierarchy_to_countries.py
+++ b/tools/python/post_generation/hierarchy_to_countries.py
@@ -109,9 +109,24 @@ def parse_borders_vs_osm(borders_vs_osm_csv_path):
                 vsosm[m.group(1)] = [m.group(3)]
     return vsosm
 
+def parse_countries_synonyms(countries_synonyms_csv_path):
+    countries_synonyms = {}
+    if not countries_synonyms_csv_path:
+        return countries_synonyms
+
+    with open(countries_synonyms_csv_path) as f:
+        for line in f:
+            m = re.match(r"(.+)\t(.+)", line.strip())
+            assert m
+            if m.group(1) in countries_synonyms:
+                countries_synonyms[m.group(1)].append(m.group(2))
+            else:
+                countries_synonyms[m.group(1)] = [m.group(2)]
+    return countries_synonyms
 
 def hierarchy_to_countries(old_vs_new_csv_path, borders_vs_osm_csv_path,
-                           hierarchy_path, target_path, version):
+                           countries_synonyms_csv_path, hierarchy_path,
+                           target_path, version):
 
     def fill_last(last, stack):
         name = last["id"]
@@ -124,6 +139,7 @@ def hierarchy_to_countries(old_vs_new_csv_path, borders_vs_osm_csv_path,
 
     oldvs = parse_old_vs_new(old_vs_new_csv_path)
     vsosm = parse_borders_vs_osm(borders_vs_osm_csv_path)
+    countries_synonyms = parse_countries_synonyms(countries_synonyms_csv_path)
     stack = [CountryDict(v=version, nameattr="Countries", g=[])]
     last = None
     with open(hierarchy_path) as f:
@@ -151,6 +167,8 @@ def hierarchy_to_countries(old_vs_new_csv_path, borders_vs_osm_csv_path,
                 last["old"] = oldvs[items[0]]
             if items[0] in vsosm:
                 last["affiliations"] = vsosm[items[0]]
+            if items[0] in countries_synonyms:
+                last["country_name_synonyms"] = countries_synonyms[items[0]]
 
     # the last line is always a file
     del last["d"]

--- a/tools/unix/generate_planet.sh
+++ b/tools/unix/generate_planet.sh
@@ -636,7 +636,7 @@ if [ "$MODE" == "resources" ]; then
   putmode "Step 8: Updating resource lists"
   # Update countries list
   $PYTHON36 -m $POST_GENERATION_MODULE hierarchy_to_countries --target "$TARGET" --hierarchy "$DATA_PATH/hierarchy.txt" --mwm_version "$COUNTRIES_VERSION" \
-    --old "$DATA_PATH/old_vs_new.csv" --osm "$DATA_PATH/borders_vs_osm.csv" --output "$TARGET/countries.txt" >> "$PLANET_LOG" 2>&1
+    --old "$DATA_PATH/old_vs_new.csv" --osm "$DATA_PATH/borders_vs_osm.csv" --countries_synonyms "$DATA_PATH/countries_synonyms.csv" --output "$TARGET/countries.txt" >> "$PLANET_LOG" 2>&1
 
   # A quick fix: chmodding to a+rw all generated files
   for file in "$TARGET"/*.mwm*; do


### PR DESCRIPTION
Нам иногда нужно (например при поиске в загрузчике) найти по фиче страны её место в CountryTree.
Сейчас поиск проиходит по CountryId и это не всегда удобно -- CountryId на это не расчитаны и нет возможности их менять для листовых mwm: это потребует миграции данных.
В этом реквесте добавляю в countries.txt новое опциональное поле, которое содержит различные варианты написание имени страны/стран лежащей внутри данного узла CountryTree и будет использоваться для матчинга с фичами.