### PR TITLE
[routing] [generator] UTurn Restrictions

### DIFF
--- a/generator/generator_tests/restriction_test.cpp
+++ b/generator/generator_tests/restriction_test.cpp
@@ -17,6 +17,7 @@
 
 #include "coding/file_container.hpp"
 
+#include "base/assert.hpp"
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
 
@@ -45,12 +46,56 @@ string const kTestMwm = "test";
 string const kRestrictionFileName = "restrictions_in_osm_ids.csv";
 string const kOsmIdsToFeatureIdsName = "osm_ids_to_feature_ids" OSM2FEATURE_FILE_EXTENSION;
 
+struct RestrictionUTurnForTests
+{
+  RestrictionUTurnForTests(Restriction::Type type, uint32_t featureId, bool viaIsFirstPoint)
+    : m_type(type),
+      m_featureId(featureId),
+      m_viaIsFirstPoint(viaIsFirstPoint)
+  {
+    CHECK(m_type == Restriction::Type::NoUTurn || m_type == Restriction::Type::OnlyUTurn, ());
+  }
+
+  bool operator==(RestrictionUTurnForTests const & rhs) const
+  {
+    return m_type == rhs.m_type && m_featureId == rhs.m_featureId &&
+           m_viaIsFirstPoint == rhs.m_viaIsFirstPoint;
+  }
+
+  bool operator<(RestrictionUTurnForTests const & rhs) const
+  {
+    if (m_type != rhs.m_type)
+      return m_type < rhs.m_type;
+
+    if (m_featureId != rhs.m_featureId)
+      return m_featureId < rhs.m_featureId;
+
+    return m_viaIsFirstPoint < rhs.m_viaIsFirstPoint;
+  }
+
+  Restriction::Type m_type;
+  uint32_t m_featureId;
+  bool m_viaIsFirstPoint;
+};
+
+string DebugPrint(RestrictionUTurnForTests const & r)
+{
+  ostringstream ss;
+  ss << "[" << DebugPrint(r.m_type) << "]: "
+     << "feature: " << r.m_featureId << ", "
+     << "isFirstPoint: " << r.m_viaIsFirstPoint;
+
+  return ss.str();
+}
+
 void BuildEmptyMwm(LocalCountryFile & country)
 {
   generator::tests_support::TestMwmBuilder builder(country, feature::DataHeader::country);
 }
 
-void LoadRestrictions(string const & mwmFilePath, vector<Restriction> & restrictions)
+void LoadRestrictions(string const & mwmFilePath, 
+                      vector<Restriction> & restrictions, 
+                      vector<RestrictionUTurnForTests> & restrictionsUTurn)
 {
   FilesContainerR const cont(mwmFilePath);
   if (!cont.IsExist(RESTRICTIONS_FILE_TAG))
@@ -65,13 +110,22 @@ void LoadRestrictions(string const & mwmFilePath, vector<Restriction> & restrict
 
     RestrictionVec restrictionsNo;
     RestrictionVec restrictionsOnly;
-    RestrictionSerializer::Deserialize(header, restrictionsNo, restrictionsOnly, src);
+    vector<RestrictionUTurn> restrictionsNoUTurn;
+    vector<RestrictionUTurn> restrictionsOnlyUTurn;
+    RestrictionSerializer::Deserialize(header, restrictionsNo, restrictionsOnly,
+                                       restrictionsNoUTurn, restrictionsOnlyUTurn, src);
 
     for (auto const & r : restrictionsNo)
       restrictions.emplace_back(Restriction::Type::No, vector<uint32_t>(r.begin(), r.end()));
 
     for (auto const & r : restrictionsOnly)
       restrictions.emplace_back(Restriction::Type::Only, vector<uint32_t>(r.begin(), r.end()));
+
+    for (auto const & r : restrictionsNoUTurn)
+      restrictionsUTurn.emplace_back(Restriction::Type::NoUTurn, r.m_featureId, r.m_viaIsFirstPoint);
+
+    for (auto const & r : restrictionsOnlyUTurn)
+      restrictionsUTurn.emplace_back(Restriction::Type::OnlyUTurn, r.m_featureId, r.m_viaIsFirstPoint);
   }
   catch (Reader::OpenException const & e)
   {
@@ -86,7 +140,8 @@ void LoadRestrictions(string const & mwmFilePath, vector<Restriction> & restrict
 void TestRestrictionBuilding(string const & restrictionPath,  
                              string const & osmIdsToFeatureIdContent,
                              unique_ptr<IndexGraph> graph,
-                             vector<Restriction> & expected)
+                             vector<Restriction> & expectedNotUTurn,
+                             vector<RestrictionUTurnForTests> & expectedUTurn)
 {
   Platform & platform = GetPlatform();
   string const writableDir = platform.WritableDir();
@@ -123,12 +178,17 @@ void TestRestrictionBuilding(string const & restrictionPath,
 
   // Reading from mwm section and testing restrictions.
   vector<Restriction> restrictionsFromMwm;
-  LoadRestrictions(mwmFullPath, restrictionsFromMwm);
+  vector<RestrictionUTurnForTests> restrictionsUTurnFromMwm;
+  LoadRestrictions(mwmFullPath, restrictionsFromMwm, restrictionsUTurnFromMwm);
 
   sort(restrictionsFromMwm.begin(), restrictionsFromMwm.end());
-  sort(expected.begin(), expected.end());
+  sort(restrictionsUTurnFromMwm.begin(), restrictionsUTurnFromMwm.end());
 
-  TEST_EQUAL(restrictionsFromMwm, expected, ());
+  sort(expectedNotUTurn.begin(), expectedNotUTurn.end());
+  sort(expectedUTurn.begin(), expectedUTurn.end());
+
+  TEST_EQUAL(restrictionsFromMwm, expectedNotUTurn, ());
+  TEST_EQUAL(restrictionsUTurnFromMwm, expectedUTurn, ());
 }
 
 // 2                 *
@@ -138,7 +198,7 @@ void TestRestrictionBuilding(string const & restrictionPath,
 // 1         *                 *<- F3 ->*-> F8 -> *-> F10 -> *
 //            ↖                         ↑       ↗
 //              F6                      F2   F9
-//         Start   ↖                    ↑  ↗
+//         Start   ↘                    ↑  ↗
 // 0         *-> F7 ->*-> F0 ->*-> F1 ->*
 //          -1        0        1        2         3          4
 //
@@ -158,7 +218,7 @@ pair<unique_ptr<IndexGraph>, string> BuildTwoCubeGraph()
                   RoadGeometry::Points({{0.0, 2.0}, {1.0, 1.0}}));
   loader->AddRoad(5 /* feature id */, true /* one way */, 1.0 /* speed */,
                   RoadGeometry::Points({{-1.0, 1.0}, {0.0, 2.0}}));
-  loader->AddRoad(6 /* feature id */, true /* one way */, 1.0 /* speed */,
+  loader->AddRoad(6 /* feature id */, false /* one way */, 1.0 /* speed */,
                   RoadGeometry::Points({{0.0, 0.0}, {-1.0, 1.0}}));
   loader->AddRoad(7 /* feature id */, true /* one way */, 1.0 /* speed */,
                   RoadGeometry::Points({{-1.0, 0.0}, {0.0, 0.0}}));
@@ -211,12 +271,13 @@ UNIT_TEST(RestrictionGenerationTest_1)
       /* Type  ViaType  ViaNodeCoords: x    y   from  to */
       R"(Only, node,                   1.0, 0.0,  0,  1)";
 
-  vector<Restriction> expected = {
+  vector<Restriction> expectedNotUTurn = {
       {Restriction::Type::Only, {0, 1}}
   };
+  vector<RestrictionUTurnForTests> expectedUTurn;
 
   TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
-                          expected);
+                          expectedNotUTurn, expectedUTurn);
 }
 
 UNIT_TEST(RestrictionGenerationTest_2)
@@ -229,12 +290,13 @@ UNIT_TEST(RestrictionGenerationTest_2)
       /* Type  ViaType from  ViaWayId to */
       R"(Only, way,      0,     1     2)";
 
-  vector<Restriction> expected = {
+  vector<Restriction> expectedNotUTurn = {
       {Restriction::Type::Only, {0, 1, 2}}
   };
+  vector<RestrictionUTurnForTests> expectedUTurn;
 
   TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
-                          expected);
+                          expectedNotUTurn, expectedUTurn);
 }
 
 UNIT_TEST(RestrictionGenerationTest_3)
@@ -244,17 +306,18 @@ UNIT_TEST(RestrictionGenerationTest_3)
   tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
 
   string const restrictionPath =
-      /* Type  ViaType ViaNodeCoords: x    y   from  to */
-      R"(Only, node,                  0.0, 0.0,  7,   6
+      /* Type  ViaType ViaNodeCoords: x    y   from  via to */
+      R"(Only, node,                  0.0, 0.0,  7,      6
          No,   way,                              2,   8, 10)";
 
-  vector<Restriction> expected = {
+  vector<Restriction> expectedNotUTurn = {
       {Restriction::Type::Only, {7, 6}},
       {Restriction::Type::No,   {2, 8, 10}}
   };
+  vector<RestrictionUTurnForTests> expectedUTurn;
 
   TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
-                          expected);
+                          expectedNotUTurn, expectedUTurn);
 }
 
 UNIT_TEST(RestrictionGenerationTest_BadConnection_1)
@@ -265,17 +328,18 @@ UNIT_TEST(RestrictionGenerationTest_BadConnection_1)
 
   // Here features 7 and 6 don't connect at (2.0, 0.0)
   string const restrictionPath =
-      /* Type  ViaType ViaNodeCoords: x    y   from  to */
-      R"(Only, node,                  2.0, 0.0,  7,   6
+      /* Type  ViaType ViaNodeCoords: x    y   from  via to */
+      R"(Only, node,                  2.0, 0.0,  7,      6
          No,   way,                              2,   8, 10)";
 
   // So we don't expect first restriction here.
-  vector<Restriction> expected = {
+  vector<Restriction> expectedNotUTurn = {
       {Restriction::Type::No,   {2, 8, 10}}
   };
+  vector<RestrictionUTurnForTests> expectedUTurn;
 
   TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
-                          expected);
+                          expectedNotUTurn, expectedUTurn);
 }
 
 UNIT_TEST(RestrictionGenerationTest_BadConnection_2)
@@ -286,16 +350,90 @@ UNIT_TEST(RestrictionGenerationTest_BadConnection_2)
 
   // Here features 0, 1 and 3 don't have common joints (namely 1 and 3).
   string const restrictionPath =
-      /* Type  ViaType ViaNodeCoords: x    y   from  to */
-      R"(Only, node,                  0.0, 0.0,  7,   6
+      /* Type  ViaType ViaNodeCoords: x    y   from  via to */
+      R"(Only, node,                  0.0, 0.0,  7,      6
          No,   way,                              0,   1, 3)";
 
   // So we don't expect second restriction here.
-  vector<Restriction> expected = {
+  vector<Restriction> expectedNotUTurn = {
       {Restriction::Type::Only,   {7, 6}}
+  };
+  vector<RestrictionUTurnForTests> expectedUTurn;
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expectedNotUTurn, expectedUTurn);
+}
+
+UNIT_TEST(RestrictionGenerationTest_WithUTurn_1)
+{
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  string const restrictionPath =
+    /* Type     ViaType ViaNodeCoords: x    y   from  to */
+    R"(NoUTurn,   node,                2.0, 1.0,  3,   3
+       OnlyUTurn, node,                0.0, 0.0,  6,   6)";
+
+  // So we don't expect second restriction here.
+  vector<Restriction> expectedNotUTurn;
+  vector<RestrictionUTurnForTests> expectedUTurn = {
+    {Restriction::Type::NoUTurn, 3 /* featureId */, false /* viaIsFirstPoint */},
+    {Restriction::Type::OnlyUTurn, 6 /* featureId */, true /* viaIsFirstPoint */}
   };
 
   TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
-                          expected);
+                          expectedNotUTurn, expectedUTurn);
+}
+
+UNIT_TEST(RestrictionGenerationTest_WithUTurn_2)
+{
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  // First two are not UTurn restrictions, but still correct restriction.
+  // We should just convert them.
+  string const restrictionPath =
+      /* Type     ViaType ViaNodeCoords: x    y   from via to */
+      R"(NoUTurn,   node,                2.0, 1.0,  2,     8
+         NoUTurn,    way,                           2, 8,  10
+         OnlyUTurn,  way,                           6, 5,  4
+         OnlyUTurn, node,               -1.0, 1.0,  6,     6)";
+
+  // So we don't expect second restriction here.
+  vector<Restriction> expectedNotUTurn = {
+      {Restriction::Type::No, {2, 8}},
+      {Restriction::Type::No, {2, 8, 10}},
+      {Restriction::Type::Only, {6, 5, 4}}
+  };
+
+  vector<RestrictionUTurnForTests> expectedUTurn = {
+      {Restriction::Type::OnlyUTurn, 6 /* featureId */, false /* viaIsFirstPoint */}
+  };
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expectedNotUTurn, expectedUTurn);
+}
+
+UNIT_TEST(RestrictionGenerationTest_WithUTurn_BadConnection_1)
+{
+  string osmIdsToFeatureIdsContent;
+  unique_ptr<IndexGraph> indexGraph;
+  tie(indexGraph, osmIdsToFeatureIdsContent) = BuildTwoCubeGraph();
+
+  string const restrictionPath =
+      /* Type     ViaType ViaNodeCoords: x     y   from  via  to */
+      R"(NoUTurn,   node,                20.0, 11.0,  2,      8
+         OnlyUTurn,  way,                             6,   2, 4
+         OnlyUTurn, node,               -10.0, 10.0,  6,      6
+         NoUTurn,   node,               -10.0, 10.0,  6,      6)";
+
+  // So we don't expect second restriction here.
+  vector<Restriction> expectedNotUTurn;
+  vector<RestrictionUTurnForTests> expectedUTurn;
+
+  TestRestrictionBuilding(restrictionPath, osmIdsToFeatureIdsContent, move(indexGraph),
+                          expectedNotUTurn, expectedUTurn);
 }
 }  // namespace

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -362,7 +362,7 @@ void FromString(std::string const & str, Restriction::Type & type)
   }
 
   CHECK(false,
-        ("Invalid line:", str, "expected:", kNo, "or", kOnly, "or", kNoUTurn, "or", kOnlyUTurnrouting));
+        ("Invalid line:", str, "expected:", kNo, "or", kOnly, "or", kNoUTurn, "or", kOnlyUTurn));
   UNREACHABLE();
 }
 

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -362,7 +362,7 @@ void FromString(std::string const & str, Restriction::Type & type)
   }
 
   CHECK(false,
-        ("Invalid line:", str, "expected:", kNo, "or", kOnly, "or", kNoUTurn, "or", kOnlyUTurnrouting/restrictions_serialization.hpp));
+        ("Invalid line:", str, "expected:", kNo, "or", kOnly, "or", kNoUTurn, "or", kOnlyUTurnrouting));
   UNREACHABLE();
 }
 

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -20,6 +20,7 @@
 #include "defines.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
@@ -81,28 +82,46 @@ CreateRestrictionCollectorAndParse(
   return restrictionCollector;
 }
 
-void SerializeRestrictions(RestrictionCollector const & restrictionCollector,
+void SerializeRestrictions(RestrictionCollector & restrictionCollector,
                            std::string const & mwmPath)
 {
-  auto const & restrictions = restrictionCollector.GetRestrictions();
-
-  auto const firstOnlyIt =
-      std::lower_bound(restrictions.cbegin(), restrictions.cend(),
-                       Restriction(Restriction::Type::Only, {} /* links */),
-                       base::LessBy(&Restriction::m_type));
+  std::vector<Restriction> restrictions = restrictionCollector.StealRestrictions();
+  CHECK(std::is_sorted(restrictions.cbegin(), restrictions.cend()), ());
 
   RestrictionHeader header;
-  header.m_noRestrictionCount = base::checked_cast<uint32_t>(std::distance(restrictions.cbegin(), firstOnlyIt));
-  header.m_onlyRestrictionCount = base::checked_cast<uint32_t>(restrictions.size() - header.m_noRestrictionCount);
 
-  LOG(LINFO, ("Header info. There are", header.m_noRestrictionCount, "restrictions of type No and",
-              header.m_onlyRestrictionCount, "restrictions of type Only"));
+  auto prevTypeEndIt = restrictions.cbegin();
+  for (size_t i = 1; i <= RestrictionHeader::kRestrictionTypes.size(); ++i)
+  {
+    decltype(restrictions.cbegin()) firstNextType;
+    if (i != RestrictionHeader::kRestrictionTypes.size())
+    {
+      firstNextType =
+          std::lower_bound(restrictions.cbegin(), restrictions.cend(),
+                           Restriction(RestrictionHeader::kRestrictionTypes[i], {} /* links */),
+                           base::LessBy(&Restriction::m_type));
+    }
+    else
+    {
+      firstNextType = restrictions.cend();
+    }
+
+    CHECK_GREATER_OR_EQUAL(i, 1, ("Unexpected overflow."));
+    auto const prevType = RestrictionHeader::kRestrictionTypes[i - 1];
+    header.SetNumberOf(prevType, 
+                       base::checked_cast<uint32_t>(std::distance(prevTypeEndIt, firstNextType)));
+
+    prevTypeEndIt = firstNextType;
+  }
+
+  LOG(LINFO, ("Routing restriction info:", header));
 
   FilesContainerW cont(mwmPath, FileWriter::OP_WRITE_EXISTING);
   FileWriter w = cont.GetWriter(RESTRICTIONS_FILE_TAG);
   header.Serialize(w);
 
-  RestrictionSerializer::Serialize(header, restrictions.cbegin(), restrictions.cend(), w);
+  base::SortUnique(restrictions);
+  RestrictionSerializer::Serialize(header, restrictions.begin(), restrictions.end(), w);
 }
 
 bool BuildRoadRestrictions(std::string const & targetPath,
@@ -112,7 +131,7 @@ bool BuildRoadRestrictions(std::string const & targetPath,
                            std::string const & osmIdsToFeatureIdsPath,
                            CountryParentNameGetterFn const & countryParentNameGetterFn)
 {
-  auto const collector =
+  auto collector =
       CreateRestrictionCollectorAndParse(targetPath, mwmPath, country, restrictionPath,
                                          osmIdsToFeatureIdsPath, countryParentNameGetterFn);
 

--- a/generator/restriction_generator.hpp
+++ b/generator/restriction_generator.hpp
@@ -14,7 +14,7 @@ CreateRestrictionCollectorAndParse(
     std::string const & restrictionPath, std::string const & osmIdsToFeatureIdsPath,
     CountryParentNameGetterFn const & countryParentNameGetterFn);
 
-void SerializeRestrictions(RestrictionCollector const & restrictionCollector,
+void SerializeRestrictions(RestrictionCollector & restrictionCollector,
                            std::string const & mwmPath);
 // This function is the generator tool's interface to building the mwm
 // section which contains road restrictions. (See https://wiki.openstreetmap.org/wiki/Restriction)

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -74,6 +74,7 @@ public:
   void Import(std::vector<Joint> const & joints);
 
   void SetRestrictions(RestrictionVec && restrictions);
+  void SetUTurnRestrictions(std::vector<RestrictionUTurn> && noUTurnRestrictions);
   void SetRoadAccess(RoadAccess && roadAccess);
 
   void PushFromSerializer(Joint::Id jointId, RoadPoint const & rp)
@@ -137,8 +138,23 @@ private:
   std::shared_ptr<EdgeEstimator> m_estimator;
   RoadIndex m_roadIndex;
   JointIndex m_jointIndex;
+
   Restrictions m_restrictionsForward;
   Restrictions m_restrictionsBackward;
+
+  // u_turn can be in both sides of feature.
+  struct UTurnEnding
+  {
+    bool m_atTheBegin = false;
+    bool m_atTheEnd = false;
+  };
+  // Stored featureId and it's UTurnEnding, which shows where is
+  // u_turn restriction is placed - at the beginning or at the ending of feature.
+  //
+  // If m_noUTurnRestrictions.count(featureId) == 0, that means, that there are no any
+  // no_u_turn restriction at the feature with id = featureId.
+  std::unordered_map<uint32_t, UTurnEnding> m_noUTurnRestrictions;
+
   RoadAccess m_roadAccess;
   RoutingOptions m_avoidRoutingOptions;
 };

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -256,7 +256,10 @@ void DeserializeIndexGraph(MwmValue const & mwmValue, VehicleType vehicleType, I
   IndexGraphSerializer::Deserialize(graph, src, GetVehicleMask(vehicleType));
   RestrictionLoader restrictionLoader(mwmValue, graph);
   if (restrictionLoader.HasRestrictions())
+  {
     graph.SetRestrictions(restrictionLoader.StealRestrictions());
+    graph.SetUTurnRestrictions(restrictionLoader.StealNoUTurnRestrictions());
+  }
 
   RoadAccess roadAccess;
   if (ReadRoadAccessFromMwm(mwmValue, vehicleType, roadAccess))

--- a/routing/restriction_loader.hpp
+++ b/routing/restriction_loader.hpp
@@ -15,19 +15,25 @@ namespace routing
 class RestrictionLoader
 {
 public:
-  explicit RestrictionLoader(MwmValue const & mwmValue, IndexGraph const & graph);
+  explicit RestrictionLoader(MwmValue const & mwmValue, IndexGraph & graph);
 
   bool HasRestrictions() const;
   RestrictionVec && StealRestrictions();
+  std::vector<RestrictionUTurn> && StealNoUTurnRestrictions();
 
 private:
   std::unique_ptr<FilesContainerR::TReader> m_reader;
   RestrictionHeader m_header;
   RestrictionVec m_restrictions;
+  std::vector<RestrictionUTurn> m_noUTurnRestrictions;
   std::string const m_countryFileName;
 };
 
-void ConvertRestrictionsOnlyToNoAndSort(IndexGraph const & graph,
-                                        RestrictionVec const & restrictionsOnly,
-                                        RestrictionVec & restrictionsNo);
+void ConvertRestrictionsOnlyToNo(IndexGraph const & graph,
+                                 RestrictionVec const & restrictionsOnly,
+                                 RestrictionVec & restrictionsNo);
+
+void ConvertRestrictionsOnlyUTurnToNo(IndexGraph & graph,
+                                      std::vector<RestrictionUTurn> const & restrictionsOnlyUTurn,
+                                      RestrictionVec & restrictionsNo);
 }  // namespace routing

--- a/routing/restrictions_serialization.hpp
+++ b/routing/restrictions_serialization.hpp
@@ -13,8 +13,10 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -35,8 +37,12 @@ struct Restriction
   /// * driving along the restriction is prohibited (No)
   enum class Type
   {
-    No,    // Going according such restriction is prohibited.
-    Only,  // Only going according such restriction is permitted
+    No,        // Going according such restriction is prohibited.
+    Only,      // Only going according such restriction is permitted.
+
+    NoUTurn,   // Making U-turn from a feature to the same one according
+               // to such restriction is prohibited.
+    OnlyUTurn  // Only U-turn is permitted at the feature.
   };
 
   Restriction(Type type, std::vector<uint32_t> const & links) : m_featureIds(links), m_type(type) {}
@@ -48,14 +54,27 @@ struct Restriction
   Type m_type;
 };
 
-// Each std::vector<uint32_t> contains feature ids of a restriction of type only or no.
+bool IsUTurnType(Restriction::Type type);
+
+// Each std::vector<uint32_t> contains feature ids of a restriction of |Restriction::Type|.
 using RestrictionVec = std::vector<std::vector<uint32_t>>;
 
-std::string DebugPrint(Restriction::Type const & type);
-std::string DebugPrint(Restriction const & restriction);
+struct RestrictionUTurn
+{
+  RestrictionUTurn(uint32_t featureId, bool viaIsFirstPoint) :
+    m_featureId(featureId), m_viaIsFirstPoint(viaIsFirstPoint) {}
+
+  uint32_t m_featureId;
+  bool m_viaIsFirstPoint;
+};
 
 struct RestrictionHeader
 {
+  // In 1.0 version additional data about U-turns was added to the section. 21.05.2019
+  static uint16_t constexpr kLatestVersion = 1;
+
+  static std::vector<Restriction::Type> const kRestrictionTypes;
+
   RestrictionHeader() { Reset(); }
 
   template <class Sink>
@@ -63,8 +82,12 @@ struct RestrictionHeader
   {
     WriteToSink(sink, m_version);
     WriteToSink(sink, m_reserved);
-    WriteToSink(sink, m_noRestrictionCount);
-    WriteToSink(sink, m_onlyRestrictionCount);
+
+    for (auto const type : kRestrictionTypes)
+      CHECK_NOT_EQUAL(m_restrictionCount.count(type), 0, ());
+
+    for (auto const type : kRestrictionTypes)
+      WriteToSink(sink, m_restrictionCount.at(type));
   }
 
   template <class Source>
@@ -72,46 +95,74 @@ struct RestrictionHeader
   {
     m_version = ReadPrimitiveFromSource<uint16_t>(src);
     m_reserved = ReadPrimitiveFromSource<uint16_t>(src);
-    m_noRestrictionCount = ReadPrimitiveFromSource<uint32_t>(src);
-    m_onlyRestrictionCount = ReadPrimitiveFromSource<uint32_t>(src);
+    m_restrictionCount[Restriction::Type::No] = ReadPrimitiveFromSource<uint32_t>(src);
+    m_restrictionCount[Restriction::Type::Only] = ReadPrimitiveFromSource<uint32_t>(src);
+
+    // TODO Version 1 was implemented at 21.05.2019.
+    //  Supporting version 0 for backward compatibility should be removed later.
+    switch (m_version)
+    {
+    case 0:
+    {
+      m_restrictionCount[Restriction::Type::NoUTurn] = 0;
+      m_restrictionCount[Restriction::Type::OnlyUTurn] = 0;
+      break;
+    }
+    case 1:
+    {
+      m_restrictionCount[Restriction::Type::NoUTurn] = ReadPrimitiveFromSource<uint32_t>(src);
+      m_restrictionCount[Restriction::Type::OnlyUTurn] = ReadPrimitiveFromSource<uint32_t>(src);
+      break;
+    }
+    default:
+      CHECK(false, ("Wrong restrictions version in header:", m_version));
+    }
   }
 
-  void Reset()
-  {
-    m_version = 0;
-    m_reserved = 0;
-    m_noRestrictionCount = 0;
-    m_onlyRestrictionCount = 0;
-  }
+  void Reset();
+
+  uint32_t GetNumberOf(Restriction::Type type) const;
+  void SetNumberOf(Restriction::Type type, uint32_t size);
 
   uint16_t m_version;
   uint16_t m_reserved;
-  uint32_t m_noRestrictionCount;
-  uint32_t m_onlyRestrictionCount;
+  std::unordered_map<Restriction::Type, uint32_t> m_restrictionCount;
 };
-
-static_assert(sizeof(RestrictionHeader) == 12, "Wrong header size of routing section.");
 
 class RestrictionSerializer
 {
 public:
+  static uint32_t constexpr kUTurnAtTheBeginMask = 1U << 31;
+
   template <class Sink>
   static void Serialize(RestrictionHeader const & header,
-                        std::vector<Restriction>::const_iterator begin,
-                        std::vector<Restriction>::const_iterator end, Sink & sink)
+                        std::vector<Restriction>::iterator begin,
+                        std::vector<Restriction>::iterator end, Sink & sink)
   {
-    auto const firstOnlyIt = begin + header.m_noRestrictionCount;
-    SerializeSingleType(begin, firstOnlyIt, sink);
-    SerializeSingleType(firstOnlyIt, end, sink);
+    auto const firstOnlyIt = begin + header.GetNumberOf(Restriction::Type::No);
+    auto const firstNoUTurnIt = firstOnlyIt + header.GetNumberOf(Restriction::Type::Only);
+    auto const firstOnlyUTurnIt = firstNoUTurnIt + header.GetNumberOf(Restriction::Type::NoUTurn);
+
+    SerializeNotUTurn(begin, firstOnlyIt, sink);
+    SerializeNotUTurn(firstOnlyIt, firstNoUTurnIt, sink);
+
+    SerializeUTurn(firstNoUTurnIt, firstOnlyUTurnIt, sink);
+    SerializeUTurn(firstOnlyUTurnIt, end, sink);
   }
 
   template <class Source>
   static void Deserialize(RestrictionHeader const & header,
                           RestrictionVec & restrictionsNo,
-                          RestrictionVec & restrictionsOnly, Source & src)
+                          RestrictionVec & restrictionsOnly,
+                          std::vector<RestrictionUTurn> & restrictionsNoUTurn,
+                          std::vector<RestrictionUTurn> & restrictionsOnlyUTurn,
+                          Source & src)
   {
-    DeserializeSingleType(header.m_noRestrictionCount, restrictionsNo, src);
-    DeserializeSingleType(header.m_onlyRestrictionCount, restrictionsOnly, src);
+    DeserializeNotUTurn(header, header.GetNumberOf(Restriction::Type::No), restrictionsNo, src);
+    DeserializeNotUTurn(header, header.GetNumberOf(Restriction::Type::Only), restrictionsOnly, src);
+
+    DeserializeUTurn(header.GetNumberOf(Restriction::Type::NoUTurn), restrictionsNoUTurn, src);
+    DeserializeUTurn(header.GetNumberOf(Restriction::Type::OnlyUTurn), restrictionsOnlyUTurn, src);
   }
 
 private:
@@ -122,14 +173,16 @@ private:
   /// \param end is an iterator to the element after the last element to serialize.
   /// \note All restrictions should have the same type.
   template <class Sink>
-  static void SerializeSingleType(std::vector<Restriction>::const_iterator begin,
-                                  std::vector<Restriction>::const_iterator end, Sink & sink)
+  static void SerializeNotUTurn(std::vector<Restriction>::const_iterator begin,
+                                std::vector<Restriction>::const_iterator end, Sink & sink)
   {
     if (begin == end)
       return;
 
     CHECK(std::is_sorted(begin, end), ());
     Restriction::Type const type = begin->m_type;
+
+    CHECK(!IsUTurnType(type), ("UTurn restrictions must be processed by another function."));
 
     uint32_t prevFirstLinkFeatureId = 0;
     BitWriter<FileWriter> bits(sink);
@@ -138,8 +191,8 @@ private:
       CHECK_EQUAL(type, begin->m_type, ());
 
       Restriction const & restriction = *begin;
-      CHECK_LESS(1, restriction.m_featureIds.size(),
-                 ("No sense in zero or one link restrictions."));
+      CHECK_GREATER_OR_EQUAL(restriction.m_featureIds.size(), 2,
+                             ("No sense in zero or one link restrictions."));
 
       coding::DeltaCoder::Encode(
           bits, restriction.m_featureIds.size() - 1 /* number of link is two or more */);
@@ -159,7 +212,8 @@ private:
   }
 
   template <class Source>
-  static bool DeserializeSingleType(uint32_t count, RestrictionVec & restrictions, Source & src)
+  static bool DeserializeNotUTurn(RestrictionHeader const & header,
+                                  uint32_t count, RestrictionVec & result, Source & src)
   {
     uint32_t prevFirstLinkFeatureId = 0;
     BitReader<Source> bits(src);
@@ -172,7 +226,7 @@ private:
         return false;
       }
       auto const numLinks =
-          static_cast<size_t>(biasedLinkNumber + 1); /* number of link is two or more */
+          static_cast<size_t>(biasedLinkNumber + 1 /* number of link is two or more */);
 
       std::vector<uint32_t> restriction(numLinks);
       auto const biasedFirstFeatureId = coding::DeltaCoder::Decode(bits);
@@ -198,10 +252,97 @@ private:
       }
 
       prevFirstLinkFeatureId = restriction[0];
-      restrictions.emplace_back(std::move(restriction));
+
+      // TODO 1.0 version added at 21.05.2019, we should remove supporting 0.0v sometimes.
+      //  In 1.0 version there are no two-way restrictions with same featureIds.
+      //  Because such restrictions become Restriction::Type::NoUTurn,
+      //                                   Restriction::Type::OnlyUTurn.
+      if (header.m_version != 0 && restriction.size() == 2)
+        CHECK_NOT_EQUAL(restriction.front(), restriction.back(), ());
+
+      result.emplace_back(std::move(restriction));
+    }
+
+    return true;
+  }
+
+  /// \brief Serializes a range of restrictions form |begin| to |end| to |sink|.
+  /// \param begin is an iterator to the first item to serialize.
+  /// \param end is an iterator to the element after the last element to serialize.
+  /// \note All restrictions should have the same type.
+  template <class Sink>
+  static void SerializeUTurn(std::vector<Restriction>::iterator begin,
+                             std::vector<Restriction>::iterator end, Sink & sink)
+  {
+    if (begin == end)
+      return;
+
+    CHECK(std::is_sorted(begin, end), ());
+
+    Restriction::Type const type = begin->m_type;
+
+    CHECK(IsUTurnType(type), ("Not UTurn restrictions must be processed by another function."));
+
+    auto const savedBegin = begin;
+    for (; begin != end; ++begin)
+    {
+      CHECK_EQUAL(type, begin->m_type, ());
+      CHECK_EQUAL(begin->m_featureIds.size(), 1,
+                  ("UTurn restrictions must consists of 1 feature."));
+
+      auto featureId = static_cast<int32_t>(begin->m_featureIds.back());
+      featureId = bits::ZigZagEncode(featureId);
+      begin->m_featureIds.back() = static_cast<uint32_t>(featureId);
+    }
+
+    begin = savedBegin;
+    std::sort(begin, end);
+
+    uint32_t prevFeatureId = 0;
+    for (; begin != end; ++begin)
+    {
+      Restriction const & restriction = *begin;
+      auto const currentFeatureId = restriction.m_featureIds.back();
+
+      CHECK_LESS(prevFeatureId, currentFeatureId, ());
+      WriteVarUint(sink, currentFeatureId - prevFeatureId);
+
+      prevFeatureId = currentFeatureId;
+    }
+  }
+
+  template <class Source>
+  static bool DeserializeUTurn(uint32_t count,
+                               std::vector<RestrictionUTurn> & result,
+                               Source & src)
+  {
+    uint32_t prevFeatureId = 0;
+    BitReader<Source> bits(src);
+    for (size_t i = 0; i < count; ++i)
+    {
+      uint32_t currentFeatureId = 0;
+      auto const biasedFirstFeatureId = ReadVarUint<uint32_t>(src);
+      if (biasedFirstFeatureId == 0)
+      {
+        LOG(LERROR, ("Decoded first link restriction feature id delta is zero."));
+        return false;
+      }
+
+      currentFeatureId = prevFeatureId + biasedFirstFeatureId;
+      prevFeatureId = currentFeatureId;
+
+      auto featureIdAfterZigZag = bits::ZigZagDecode(currentFeatureId);
+
+      bool const viaNodeIsFirstFeturePoint = featureIdAfterZigZag & kUTurnAtTheBeginMask;
+      featureIdAfterZigZag ^= featureIdAfterZigZag & kUTurnAtTheBeginMask;
+      result.emplace_back(featureIdAfterZigZag, viaNodeIsFirstFeturePoint);
     }
 
     return true;
   }
 };
+
+std::string DebugPrint(Restriction::Type const & type);
+std::string DebugPrint(Restriction const & restriction);
+std::string DebugPrint(RestrictionHeader const & restrictionHeader);
 }  // namespace routing

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -1010,3 +1010,37 @@ UNIT_TEST(RussiaMoscowLeninskyProsp2Test)
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
 }
+
+/*
+UNIT_TEST(RussiaMoscow_OnlyUTurnTest_1)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                  MercatorBounds::FromLatLon(55.90382, 37.40219), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(55.90278, 37.40354));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestRouteLength(route, 3854.44);
+}
+
+UNIT_TEST(RussiaMoscow_OnlyUTurnTest_1_WithDirection)
+{
+  auto const startDir = MercatorBounds::FromLatLon(55.90423, 37.40176);
+  auto const endDir = MercatorBounds::FromLatLon(55.90218, 37.40433);
+  auto const direction = endDir - startDir;
+
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                  MercatorBounds::FromLatLon(55.90382, 37.40219), direction,
+                                  MercatorBounds::FromLatLon(55.90278, 37.40354));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::UTurnLeft);
+}
+*/

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -36,6 +36,8 @@ set(
   turns_generator_test.cpp
   turns_sound_test.cpp
   turns_tts_text_tests.cpp
+  uturn_restriction_tests.cpp
+  world_graph_builder.cpp
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -94,8 +94,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
     {1 /* feature from */, 3 /* feature to */}
   };
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
@@ -104,7 +104,7 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF1F3Only)
       MakeFakeEnding(5, 0, m2::PointD(2, 3), *m_graph), move(restrictionsNo), *this);
 }
 
-// Route through XY graph with one restriciton (type only) from F3 to F5.
+// Route through XY graph with one restriction (type only) from F3 to F5.
 UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
 {
   Init(BuildXYGraph());
@@ -112,8 +112,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5Only)
     {3 /* feature from */, 5 /* feature to */}
   };
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
@@ -132,8 +132,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyF1F3Only)
     {3 /* feature from */, 5 /* feature to */}
   };
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
@@ -155,8 +155,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_PermutationsF3F5OnlyAndF0F2No)
   RestrictionVec restrictionsOnly = {
     {3 /* feature from */, 5 /* feature to */}
   };
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, 0 /* y */}, {1, 1}, {2, 2}, {2, 3}};
   TestRestrictions(
@@ -177,8 +177,8 @@ UNIT_CLASS_TEST(RestrictionTest, XYGraph_RestrictionF3F5OnlyAndF1F3No)
   RestrictionVec restrictionsOnly = {
     {3 /* feature from */, 5 /* feature to */}
   };
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   TestRestrictions(
       {} /* expectedGeom */, Algorithm::Result::NoPath,
@@ -318,8 +318,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3OnlyAndF3F6Only)
     {1 /* feature from */, 3 /* feature to */},
     {3 /* feature from */, 6 /* feature to */}
   };
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   vector<m2::PointD> const expectedGeom = {{2 /* x */, -1 /* y */}, {2, 0}, {1, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
@@ -359,8 +359,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_PermutationsF1F3NoF7F8OnlyF8F4OnlyF4F6O
     {8 /* feature from */, 4 /* feature to */}
   };
 
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
   vector<m2::PointD> const expectedGeom = {
       {2 /* x */, -1 /* y */}, {2, 0}, {3, 0}, {3, 1}, {2, 2}, {3, 3}};
   TestRestrictions(
@@ -387,8 +387,8 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_CheckOnlyRestriction)
     {0 /* feature from */, 2 /* feature to */},
   };
   RestrictionVec restrictionsNo;
-  ConvertRestrictionsOnlyToNoAndSort(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
-                                     restrictionsNo);
+  ConvertRestrictionsOnlyToNo(m_graph->GetIndexGraphForTests(kTestNumMwmId), restrictionsOnly,
+                              restrictionsNo);
 
   // Check that without restrictions we can find path better.
   test({start, {2, 0}, {1, 1}, {2, 2}, {3, 1}, finish, finish}, move(restrictionsNo));

--- a/routing/routing_tests/uturn_restriction_tests.cpp
+++ b/routing/routing_tests/uturn_restriction_tests.cpp
@@ -1,0 +1,140 @@
+#include "testing/testing.hpp"
+
+#include "routing/restriction_loader.hpp"
+
+#include "routing/routing_tests/index_graph_tools.hpp"
+#include "routing/routing_tests/world_graph_builder.hpp"
+
+namespace routing_test
+{
+using namespace routing;
+
+using Algorithm = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
+UNIT_CLASS_TEST(NoUTurnRestrictionTest, CheckNoUTurn_1)
+{
+  Init(BuildCrossGraph());
+
+  Segment const start(kTestNumMwmId, 3 /* fId */, 0 /* segId */, true /* forward */);
+  Segment const finish(kTestNumMwmId, 7 /* fId */, 0 /* segId */, true /* forward */);
+
+  std::vector<m2::PointD> const expectedGeom = {
+      {3.0, 0.0}, {2.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeom);
+
+  std::vector<RestrictionUTurn> noUTurnRestrictions = {
+      {3 /* featureId */, false /* viaIsFirstPoint */}
+  };
+
+  SetNoUTurnRestrictions(std::move(noUTurnRestrictions));
+  TestRouteGeom(start, finish, Algorithm::Result::NoPath, {} /* expectedGeom */);
+}
+
+UNIT_CLASS_TEST(NoUTurnRestrictionTest, CheckNoUTurn_2)
+{
+  Init(BuildCrossGraph());
+
+  Segment const start(kTestNumMwmId, 2 /* fId */, 0 /* segId */, true /* forward */);
+  Segment const finish(kTestNumMwmId, 7 /* fId */, 0 /* segId */, true /* forward */);
+
+  std::vector<m2::PointD> const expectedGeom = {
+      {2.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeom);
+
+  std::vector<RestrictionUTurn> noUTurnRestrictions = {
+      {2 /* featureId */, false /* viaIsFirstPoint */}
+  };
+
+  std::vector<m2::PointD> const expectedGeomAfterRestriction = {
+      {2.0, 0.0}, {3.0, 0.0}, {2.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}
+  };
+
+  SetNoUTurnRestrictions(std::move(noUTurnRestrictions));
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeomAfterRestriction);
+}
+
+UNIT_CLASS_TEST(NoUTurnRestrictionTest, CheckNoUTurn_3)
+{
+  Init(BuildCrossGraph());
+
+  Segment const start(kTestNumMwmId, 2 /* fId */, 0 /* segId */, false /* forward */);
+  Segment const finish(kTestNumMwmId, 3 /* fId */, 0 /* segId */, true /* forward */);
+
+  std::vector<m2::PointD> const expectedGeom = {
+      {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeom);
+
+  std::vector<RestrictionUTurn> noUTurnRestrictions = {
+      {2 /* featureId */, true /* viaIsFirstPoint */}
+  };
+
+  std::vector<m2::PointD> const expectedGeomAfterRestriction = {
+      {1.0, 0.0}, {1.0, -1.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}
+  };
+
+  SetNoUTurnRestrictions(std::move(noUTurnRestrictions));
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeomAfterRestriction);
+}
+
+UNIT_CLASS_TEST(NoUTurnRestrictionTest, CheckOnlyUTurn_1)
+{
+  Init(BuildCrossGraph());
+
+  Segment const start(kTestNumMwmId, 2 /* fId */, 0 /* segId */, true /* forward */);
+  Segment const finish(kTestNumMwmId, 3 /* fId */, 0 /* segId */, true /* forward */);
+
+  std::vector<m2::PointD> const expectedGeom = {
+      {2.0, 0.0}, {3.0, 0.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeom);
+
+  std::vector<RestrictionUTurn> onlyUTurnRestrictions = {
+      {2 /* featureId */, false /* viaIsFirstPoint */}
+  };
+
+  RestrictionVec restrictionsNo;
+
+  auto & indexGraph = m_graph->GetWorldGraph().GetIndexGraph(kTestNumMwmId);
+  ConvertRestrictionsOnlyUTurnToNo(indexGraph, onlyUTurnRestrictions, restrictionsNo);
+  SetRestrictions(std::move(restrictionsNo));
+
+  TestRouteGeom(start, finish, Algorithm::Result::NoPath, {} /* expectedGeom */);
+}
+
+UNIT_CLASS_TEST(NoUTurnRestrictionTest, CheckOnlyUTurn_2)
+{
+  Init(BuildTestGraph());
+
+  Segment const start(kTestNumMwmId, 0 /* fId */, 0 /* segId */, false /* forward */);
+  Segment const finish(kTestNumMwmId, 5 /* fId */, 0 /* segId */, true /* forward */);
+
+  std::vector<m2::PointD> const expectedGeom = {
+      {0.0, 1.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 2.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeom);
+
+  std::vector<RestrictionUTurn> onlyUTurnRestrictions = {
+      {1 /* featureId */, false /* viaIsFirstPoint */}
+  };
+
+  RestrictionVec restrictionsNo;
+
+  auto & indexGraph = m_graph->GetWorldGraph().GetIndexGraph(kTestNumMwmId);
+  ConvertRestrictionsOnlyUTurnToNo(indexGraph, onlyUTurnRestrictions, restrictionsNo);
+  SetRestrictions(std::move(restrictionsNo));
+
+  std::vector<m2::PointD> const expectedGeomAfterRestriction = {
+      {0.0, 1.0}, {-1.0, 1.0}, {-1.0, 2.0}, {0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}
+  };
+
+  TestRouteGeom(start, finish, Algorithm::Result::OK, expectedGeomAfterRestriction);
+}
+}  // namespace routing_test

--- a/routing/routing_tests/world_graph_builder.cpp
+++ b/routing/routing_tests/world_graph_builder.cpp
@@ -1,0 +1,110 @@
+#include "routing/routing_tests/world_graph_builder.hpp"
+
+#include "generator/generator_tests_support/routing_helpers.hpp"
+
+#include "routing/routing_tests/index_graph_tools.hpp"
+
+#include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/joint.hpp"
+#include "routing/single_vehicle_world_graph.hpp"
+
+#include "traffic/traffic_cache.hpp"
+
+#include <vector>
+#include <utility>
+
+namespace routing_test
+{
+using namespace routing;
+
+//                             Finish
+//                               *
+//                               ^
+//                               |
+//                               F7
+//                               |
+//                               *
+//                               ^
+//                               |
+//                               F6
+//                               |
+// Start * -- F0 --> * -- F1 --> * <-- F2 --> * <-- F3 --> *
+//                              | ^
+//                              | |
+//                             F4 F5
+//                              | |
+//                              ⌄ |
+//                               *
+std::unique_ptr<SingleVehicleWorldGraph> BuildCrossGraph()
+{
+  std::unique_ptr<TestGeometryLoader> loader = std::make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{-1.0, 0.0}, {0.0, 0.0}}));
+  loader->AddRoad(1 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {1.0, 0.0}}));
+  loader->AddRoad(2 /* featureId */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.9999, 0.0}}));
+  loader->AddRoad(3 /* featureId */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.9999, 0.0}, {3.0, 0.0}}));
+  loader->AddRoad(4 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, -1.0}}));
+  loader->AddRoad(5 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, -1.0}, {1.0, 0.0}}));
+  loader->AddRoad(6 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {1.0, 1.0}}));
+  loader->AddRoad(7 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {1.0, 2.0}}));
+
+  std::vector<Joint> const joints = {
+    MakeJoint({{0, 1}, {1, 0}}), MakeJoint({{1, 1}, {2, 0}, {4, 0}, {5, 1}, {6, 0}}),
+    MakeJoint({{2, 1}, {3, 0}}), MakeJoint({{4, 1}, {5, 0}}), MakeJoint({{6, 1}, {7, 0}})};
+
+  traffic::TrafficCache const trafficCache;
+  std::shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
+
+  return BuildWorldGraph(move(loader), estimator, joints);
+}
+
+//
+// 2    * -- F2 --> * -- F2 --> * -- F2 --> * -- F5 --> *
+//      ↑                                 ↗
+//      F2                            F3
+//      ↑                          ↗
+// 1    * <-- F0 --> * <-- F1 --> *
+//                                 ↘
+//                                    F4
+//                                        ↘
+// 0                                        *
+//
+//     -1           0            1          2           3
+//
+std::unique_ptr<SingleVehicleWorldGraph> BuildTestGraph()
+{
+  std::unique_ptr<TestGeometryLoader> loader = std::make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 1.0}, {-1.0, 1.0}}));
+  loader->AddRoad(1 /* featureId */, false /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 1.0}, {1.0, 1.0}}));
+  loader->AddRoad(2 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{-1.0, 1.0}, {-1.0, 2.0}, {0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}}));
+  loader->AddRoad(3 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 1.0}, {2.0, 2.0}}));
+  loader->AddRoad(4 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{1.0, 0.0}, {2.0, 0.0}}));
+  loader->AddRoad(5 /* featureId */, true /* oneWay */, 1.0 /* speed */,
+                  RoadGeometry::Points({{2.0, 2.0}, {3.0, 2.0}}));
+
+  std::vector<Joint> const joints = {
+      MakeJoint({{1, 0}, {0, 0}}),           // (0, 1)
+      MakeJoint({{0, 1}, {2, 0}}),           // (-1, 1)
+      MakeJoint({{3, 1}, {2, 4}, {5, 0}}),   // (2, 2)
+      MakeJoint({{1, 1}, {3, 0}, {4, 0}})};  // (1, 1)
+
+  traffic::TrafficCache const trafficCache;
+  std::shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
+
+  return BuildWorldGraph(std::move(loader), estimator, joints);
+}
+}  // namespace routing_test
+

--- a/routing/routing_tests/world_graph_builder.hpp
+++ b/routing/routing_tests/world_graph_builder.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "routing/single_vehicle_world_graph.hpp"
+
+#include <memory>
+
+namespace routing_test
+{
+std::unique_ptr<routing::SingleVehicleWorldGraph> BuildCrossGraph();
+std::unique_ptr<routing::SingleVehicleWorldGraph> BuildTestGraph();
+}  // namespace routing_test
+

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		4408A63C21F1E7F0008171B8 /* joint_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4408A63821F1E7F0008171B8 /* joint_segment.hpp */; };
 		4408A63D21F1E7F0008171B8 /* index_graph_starter_joints.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */; };
 		4408A63E21F1E7F0008171B8 /* joint_segment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4408A63A21F1E7F0008171B8 /* joint_segment.cpp */; };
+		440BE38522AFB31100C548FB /* world_graph_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 440BE38322AFB31100C548FB /* world_graph_builder.cpp */; };
+		440BE38622AFB31100C548FB /* world_graph_builder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 440BE38422AFB31100C548FB /* world_graph_builder.hpp */; };
+		440BE38822AFB31700C548FB /* uturn_restriction_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 440BE38722AFB31600C548FB /* uturn_restriction_tests.cpp */; };
 		44183280222D45BB00C70BD9 /* routing_options_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4418327F222D45BB00C70BD9 /* routing_options_tests.cpp */; };
 		4443DC3722789793000C8E32 /* leaps_postprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4443DC3522789793000C8E32 /* leaps_postprocessor.cpp */; };
 		4443DC3822789793000C8E32 /* leaps_postprocessor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4443DC3622789793000C8E32 /* leaps_postprocessor.hpp */; };
@@ -386,6 +389,9 @@
 		4408A63821F1E7F0008171B8 /* joint_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = joint_segment.hpp; sourceTree = "<group>"; };
 		4408A63921F1E7F0008171B8 /* index_graph_starter_joints.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_starter_joints.hpp; sourceTree = "<group>"; };
 		4408A63A21F1E7F0008171B8 /* joint_segment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = joint_segment.cpp; sourceTree = "<group>"; };
+		440BE38322AFB31100C548FB /* world_graph_builder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = world_graph_builder.cpp; sourceTree = "<group>"; };
+		440BE38422AFB31100C548FB /* world_graph_builder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = world_graph_builder.hpp; sourceTree = "<group>"; };
+		440BE38722AFB31600C548FB /* uturn_restriction_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = uturn_restriction_tests.cpp; sourceTree = "<group>"; };
 		4418327F222D45BB00C70BD9 /* routing_options_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_options_tests.cpp; sourceTree = "<group>"; };
 		4443DC3522789793000C8E32 /* leaps_postprocessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = leaps_postprocessor.cpp; sourceTree = "<group>"; };
 		4443DC3622789793000C8E32 /* leaps_postprocessor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = leaps_postprocessor.hpp; sourceTree = "<group>"; };
@@ -700,6 +706,9 @@
 		6742ACA01C68A07C009CB89E /* routing_tests */ = {
 			isa = PBXGroup;
 			children = (
+				440BE38722AFB31600C548FB /* uturn_restriction_tests.cpp */,
+				440BE38322AFB31100C548FB /* world_graph_builder.cpp */,
+				440BE38422AFB31100C548FB /* world_graph_builder.hpp */,
 				448FD3F2228B1BC500180D90 /* bfs_tests.cpp */,
 				4418327F222D45BB00C70BD9 /* routing_options_tests.cpp */,
 				56A1B7A121A82BCB00246F8C /* maxspeeds_tests.cpp */,
@@ -1084,6 +1093,7 @@
 				0C62BFE61E8ADC3100055A79 /* coding.hpp in Headers */,
 				674F9BD51B0A580E00704FFA /* road_graph.hpp in Headers */,
 				562BDE2020D14860008EFF6F /* routing_callbacks.hpp in Headers */,
+				440BE38622AFB31100C548FB /* world_graph_builder.hpp in Headers */,
 				567F81952154D6FF0093C25B /* city_roads.hpp in Headers */,
 				0C5FEC6B1DDE193F0017688C /* road_point.hpp in Headers */,
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
@@ -1318,6 +1328,7 @@
 				5694CECC1EBA25F7004576D3 /* road_access.cpp in Sources */,
 				44A95C72225F6A4F00C22F4F /* astar_progress.cpp in Sources */,
 				F6C3A1B621AC298F0060EEC8 /* speed_camera_manager.cpp in Sources */,
+				440BE38522AFB31100C548FB /* world_graph_builder.cpp in Sources */,
 				A1616E2B1B6B60AB003F078E /* router_delegate.cpp in Sources */,
 				6741AA9C1BF35331002C974C /* turns_notification_manager.cpp in Sources */,
 				0C0DF9211DE898B70055A22F /* index_graph_starter.cpp in Sources */,
@@ -1374,6 +1385,7 @@
 				5610731C221ABF96008447B2 /* speed_camera_prohibition.cpp in Sources */,
 				56290B87206A3232003892E0 /* routing_algorithm.cpp in Sources */,
 				670EE5751B664796001E8064 /* router.cpp in Sources */,
+				440BE38822AFB31700C548FB /* uturn_restriction_tests.cpp in Sources */,
 				5670595D1F3AF97F0062672D /* checkpoint_predictor.cpp in Sources */,
 				56CA09E31E30E73B00D05C9A /* applying_traffic_test.cpp in Sources */,
 				0C5FEC621DDE192A0017688C /* joint_index.cpp in Sources */,


### PR DESCRIPTION
Смотреть по коммитам

Тут к секции `RESTRICTIONS_FILE_TAG` добавляется новая информация о u_turn
Это либо no_u_turn, либо only_u_turn
В рамках maps.me считается, что такие маневры это только:
с `feature123` -> `feature123` через точку на `feature123`
Все остальное конвертируется в другие соотвествующие типы

Поворот u_turn может совершаться только либо в начале `feature123` либо в концe `feature123`, поэтому храним так:
Выставляем старший бит в `1` если viaIsFirstPoint (разворот в начале) и ничего не ставим, если разворот в конце (и проверяем, что там действительно стоит 0)

Как сериализуем:
У нас получаются положительные и отрицательные числа, мы делаем для них ZigZag encoding => сортируем => delta coding