### PR TITLE
[geocoder] Relax number matching for streets

### DIFF
--- a/base/stl_helpers.hpp
+++ b/base/stl_helpers.hpp
@@ -299,6 +299,23 @@ bool IsSortedAndUnique(Iter beg, Iter end)
   return IsSortedAndUnique(beg, end, std::less<typename std::iterator_traits<Iter>::value_type>());
 }
 
+// See std::includes() C++20.
+template <typename Iter1, typename Iter2>
+bool Includes(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2)
+{
+  assert(std::is_sorted(first1, last1));
+  assert(std::is_sorted(first2, last2));
+
+  for (; first2 != last2; ++first1)
+  {
+    if (first1 == last1 || *first2 < *first1)
+      return false;
+    if (!(*first1 < *first2))
+      ++first2;
+  }
+  return true;
+}
+
 struct DeleteFunctor
 {
   template <typename T>


### PR DESCRIPTION
Фикс кейса из таска MAPSB2B-65: не находится улица по запросу `Россия, Город Москва, Улица Тверская-Ямская 1-я`.

Причина в том, что для улиц с номерами (которые могут считаться номерами домов) все токены должны быть размечены. В данном примере не размечен токен `Город`.
В этом PR ослабил условие необходимой разметки всех токенов, на обязательное наличие номера в адресе.

Оценка качества и скорости до:
```
Processed rows                        	10000	54.826211
full_matched                          	7853	78.53
```

Оценка качества и скорости после:
```
Processed rows                        	10000	54.133313
full_matched                          	7864	78.64
```