### PR TITLE
[generator] Optimize EmitterSimple

### DIFF
--- a/generator/emitter_simple.cpp
+++ b/generator/emitter_simple.cpp
@@ -16,7 +16,11 @@ void EmitterSimple::GetNames(std::vector<std::string> & names) const
 
 void EmitterSimple::Process(FeatureBuilder1 & fb)
 {
+  auto & polygonizer = m_regionGenerator->Parent();
+  // Emit each feature independently: clear current country names (see Polygonizer::GetCurrentNames()).
+  polygonizer.Start();
   (*m_regionGenerator)(fb);
+  polygonizer.Finish();
 }
 
 void EmitterPreserialize::Process(FeatureBuilder1 & fb)


### PR DESCRIPTION
Оптимизация regions генератора фичей: не хранить в памяти фейковое имя страны "regions" для каждой обрабатываемой фичи. Сохранение происходит в Polygonizer::EmitFeature (`m_currentNames += countryPolygons.m_name;`)