### PR TITLE
[generator] Fix regions index generation: ignore features types

### DIFF
--- a/generator/feature_helpers.cpp
+++ b/generator/feature_helpers.cpp
@@ -2,8 +2,6 @@
 
 #include "generator/feature_builder.hpp"
 
-#include "indexer/feature_visibility.hpp"
-
 #include "coding/point_coding.hpp"
 
 #include "base/stl_helpers.hpp"
@@ -14,6 +12,14 @@ using namespace std;
 
 namespace feature
 {
+CalculateMidPoints::CalculateMidPoints()
+  : CalculateMidPoints(static_cast<int (*)(TypesHolder const & types, m2::RectD limitRect)>(GetMinDrawableScale))
+{ }
+
+CalculateMidPoints::CalculateMidPoints(MinDrawableScalePolicy const & minDrawableScalePolicy)
+  : m_minDrawableScalePolicy{minDrawableScalePolicy}
+{ }
+
 void CalculateMidPoints::operator()(FeatureBuilder1 const & ft, uint64_t pos)
 {
   // Reset state.
@@ -25,7 +31,7 @@ void CalculateMidPoints::operator()(FeatureBuilder1 const & ft, uint64_t pos)
   m_midLoc = m_midLoc / m_locCount;
 
   uint64_t const pointAsInt64 = PointToInt64Obsolete(m_midLoc, m_coordBits);
-  int const minScale = feature::GetMinDrawableScale(ft.GetTypesHolder(), ft.GetLimitRect());
+  int const minScale = m_minDrawableScalePolicy(ft.GetTypesHolder(), ft.GetLimitRect());
 
   /// May be invisible if it's small area object with [0-9] scales.
   /// @todo Probably, we need to keep that objects if 9 scale (as we do in 17 scale).

--- a/generator/feature_helpers.hpp
+++ b/generator/feature_helpers.hpp
@@ -6,6 +6,8 @@
 #include "geometry/point2d.hpp"
 #include "geometry/simplification.hpp"
 
+#include "indexer/feature_data.hpp"
+#include "indexer/feature_visibility.hpp"
 #include "indexer/scales.hpp"
 
 #include "base/assert.hpp"
@@ -13,6 +15,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <utility>
 #include <vector>
@@ -25,8 +28,10 @@ class CalculateMidPoints
 {
 public:
   using CellAndOffset = std::pair<uint64_t, uint64_t>;
+  using MinDrawableScalePolicy = std::function<int(TypesHolder const & types, m2::RectD limitRect)>;
 
-  CalculateMidPoints() = default;
+  CalculateMidPoints();
+  CalculateMidPoints(MinDrawableScalePolicy const & minDrawableScalePolicy);
 
   void operator()(FeatureBuilder1 const & ft, uint64_t pos);
   bool operator()(m2::PointD const & p);
@@ -42,6 +47,7 @@ private:
   size_t m_locCount = 0;
   size_t m_allCount = 0;
   uint8_t m_coordBits = serial::GeometryCodingParams().GetCoordBits();
+  MinDrawableScalePolicy m_minDrawableScalePolicy;
   std::vector<CellAndOffset> m_vec;
 };
 

--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -400,8 +400,23 @@ int GetMinDrawableScale(TypesHolder const & types, m2::RectD limitRect)
   int const upBound = scales::GetUpperStyleScale();
 
   for (int level = 0; level <= upBound; ++level)
+  {
     if (IsDrawableForIndex(types, limitRect, level))
       return level;
+  }
+
+  return -1;
+}
+
+int GetMinDrawableScaleGeometryOnly(TypesHolder const & types, m2::RectD limitRect)
+{
+  int const upBound = scales::GetUpperStyleScale();
+
+  for (int level = 0; level <= upBound; ++level)
+  {
+    if (IsDrawableForIndexGeometryOnly(types, limitRect, level))
+      return level;
+  }
 
   return -1;
 }
@@ -411,8 +426,10 @@ int GetMinDrawableScaleClassifOnly(TypesHolder const & types)
   int const upBound = scales::GetUpperStyleScale();
 
   for (int level = 0; level <= upBound; ++level)
+  {
     if (IsDrawableForIndexClassifOnly(types, level))
       return level;
+  }
 
   return -1;
 }

--- a/indexer/feature_visibility.hpp
+++ b/indexer/feature_visibility.hpp
@@ -42,6 +42,7 @@ namespace feature
 
   int GetMinDrawableScale(FeatureType & ft);
   int GetMinDrawableScale(TypesHolder const & types, m2::RectD limitRect);
+  int GetMinDrawableScaleGeometryOnly(TypesHolder const & types, m2::RectD limitRect);
   int GetMinDrawableScaleClassifOnly(TypesHolder const & types);
 
   /// @return [-1, -1] if range is not drawable


### PR DESCRIPTION
Игнорировать тип фичи для регионов B2B при построении индекса, что бы, например, генерировать район города по relation с adim_level и вхождением его в населённый пункт. Сам генератор фич регионов будет строить дерево регионов из нужных типов фич.