### PR TITLE
[indexer] Do not reset geometry for features created from MapObjects.

### DIFF
--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -402,6 +402,10 @@ void FeatureType::ParseHeader2()
 
 void FeatureType::ResetGeometry()
 {
+  // Do not reset geometry for features created from MapObjects.
+  if (!m_loadInfo)
+    return;
+
   m_points.clear();
   m_triangles.clear();
 


### PR DESCRIPTION
У нас EditableDataSource возвращает MapObject, из которого дальше создаётся FeatureType.
FeatureType имеет полностью распаршенное состояние с геометрией BEST_GEOMETRY и у него не заполнено m_loadInfo.

В drape_frontend для правильной отрисовки пробок геометрия сбрасывается и затем парсится на масштабе BEST_GEOMETRY. Но у отредактированного объекта после сброса геометрии нет возможности её распарсить заново.

Это может быть линейный объект, у которого отредактировано название. В этом случае у него есть прообраз, на который накладываются правки. Но брать m_loadInfo из прообраза плохо, т.к. m_loadInfo отвечает за загрузку всего в FeatureType и мы не сможем нормально отличать фичу-прообраз от отредактированной.

В этом PR добавляю игнорирование ResetGeometry для фичей, созданных из MapObject.

Альтернативный вариант -- парсить и сохранять для фичей, созданных из MapObject геометрию на всех масштабах.
Плюсы -- будет работать более "честно".
Минусы -- в тех единственных двух местах в мобильном приложении где вызвается ResetGeometry это делается чтобы распарсить потом BEST_GEOMETRY которая у нас уже есть. Получится что мы будем хранить довольно много геометрии просто так на всякий случай, если вдруг кому-то понадобится плохая плохая геометрия для отредактированных объектов.