### PR TITLE
[search] Pass |exactMatch| to PreRanker, Ranker. Take |exactMatch| into account in LocalityScorer.

### DIFF
--- a/base/dfa_helpers.hpp
+++ b/base/dfa_helpers.hpp
@@ -16,8 +16,41 @@ public:
   public:
     Iterator & Move(strings::UniChar c)
     {
-      if (Accepts() || Rejects())
+      if (Rejects())
         return *this;
+
+      if (Accepts())
+      {
+        auto currentIt = m_it;
+        currentIt.Move(c);
+
+        // While moving m_it, errors number decreases while matching unmatched symbols:
+        // source:  a b c d e f
+        // query:   a b c d e f
+        // errors:  5 4 3 2 1 0
+        //
+        // After a misprinted symbol errors number remains the same:
+        // source:  a b c d e f
+        // query:   a b z d e f
+        // errors:  5 4 3 3 2 1
+        //
+        // source:  a b c d e f
+        // query:   a b d c e f
+        // errors:  5 4 3 3 2 1
+        //
+        // source:  a b c d e f
+        // query:   a b d e f
+        // errors:  5 4 3 3 2
+        //
+        // source:  a b c d e f
+        // query:   a b c z d e f
+        // errors:  5 4 3 3 3 2 1
+        //
+        // Errors number cannot decrease after it has increased once.
+
+        if (currentIt.ErrorsMade() > ErrorsMade())
+          return *this;
+      }
 
       m_it.Move(c);
       if (m_it.Accepts())

--- a/search/categories_cache.cpp
+++ b/search/categories_cache.cpp
@@ -52,7 +52,7 @@ CBV CategoriesCache::Load(MwmContext const & context) const
   });
 
   Retrieval retrieval(context, m_cancellable);
-  return CBV(retrieval.RetrieveAddressFeatures(request).m_features);
+  return retrieval.RetrieveAddressFeatures(request).m_features;
 }
 
 // StreetsCache ------------------------------------------------------------------------------------

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -225,11 +225,11 @@ private:
   // Forms result and feeds it to |m_preRanker|.
   void EmitResult(BaseContext & ctx, MwmSet::MwmId const & mwmId, uint32_t ftId, Model::Type type,
                   TokenRange const & tokenRange, IntersectionResult const * geoParts,
-                  bool allTokensUsed);
+                  bool allTokensUsed, bool exactMatch);
   void EmitResult(BaseContext & ctx, Region const & region, TokenRange const & tokenRange,
-                  bool allTokensUsed);
+                  bool allTokensUsed, bool exactMatch);
   void EmitResult(BaseContext & ctx, City const & city, TokenRange const & tokenRange,
-                  bool allTokensUsed);
+                  bool allTokensUsed, bool exactMatch);
 
   // Tries to match unclassified objects from lower layers, like
   // parks, forests, lakes, rivers, etc. This method finds all

--- a/search/geocoder_context.hpp
+++ b/search/geocoder_context.hpp
@@ -6,6 +6,7 @@
 #include "search/geocoder_locality.hpp"
 #include "search/hotels_filter.hpp"
 #include "search/model.hpp"
+#include "search/retrieval.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -55,7 +56,7 @@ struct BaseContext
 
   // List of bit-vectors of features, where i-th element of the list
   // corresponds to the i-th token in the search query.
-  std::vector<CBV> m_features;
+  std::vector<Retrieval::ExtendedFeatures> m_features;
   CBV m_villages;
   CBV m_streets;
 

--- a/search/geocoder_locality.hpp
+++ b/search/geocoder_locality.hpp
@@ -21,8 +21,12 @@ class IdfMap;
 struct Locality
 {
   Locality(MwmSet::MwmId const & countryId, uint32_t featureId, TokenRange const & tokenRange,
-           QueryVec const & queryVec)
-    : m_countryId(countryId), m_featureId(featureId), m_tokenRange(tokenRange), m_queryVec(queryVec)
+           QueryVec const & queryVec, bool exactMatch)
+    : m_countryId(countryId)
+    , m_featureId(featureId)
+    , m_tokenRange(tokenRange)
+    , m_queryVec(queryVec)
+    , m_exactMatch(exactMatch)
   {
   }
 
@@ -32,6 +36,7 @@ struct Locality
   uint32_t m_featureId = 0;
   TokenRange m_tokenRange;
   QueryVec m_queryVec;
+  bool m_exactMatch;
 };
 
 // This struct represents a country or US- or Canadian- state.  It

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 class FeatureType;
-class CategoriesHolder;
 
 namespace storage
 {

--- a/search/locality_scorer.hpp
+++ b/search/locality_scorer.hpp
@@ -59,10 +59,10 @@ private:
   // combination of ranks and number of matched tokens.
   void LeaveTopLocalities(IdfMap & idfs, size_t limit, std::vector<Locality> & localities) const;
 
-  // Selects at most |limitUniqueIds| best features by query norm and
+  // Selects at most |limitUniqueIds| best features by exact match, query norm and
   // rank, and then leaves only localities corresponding to those
   // features in |els|.
-  void LeaveTopByNormAndRank(size_t limitUniqueIds, std::vector<ExLocality> & els) const;
+  void LeaveTopByExactMatchNormAndRank(size_t limitUniqueIds, std::vector<ExLocality> & els) const;
 
   // Leaves at most |limit| unique best localities by similarity to
   // the query and rank.

--- a/search/pre_ranking_info.cpp
+++ b/search/pre_ranking_info.cpp
@@ -8,7 +8,7 @@ std::string DebugPrint(PreRankingInfo const & info)
 {
   std::ostringstream os;
   os << "PreRankingInfo [";
-  os << "m_distanceToPivot:" << info.m_distanceToPivot << ", ";
+  os << "m_distanceToPivot: " << info.m_distanceToPivot << ", ";
   for (size_t i = 0; i < static_cast<size_t>(Model::TYPE_COUNT); ++i)
   {
     if (info.m_tokenRange[i].Empty())
@@ -17,8 +17,10 @@ std::string DebugPrint(PreRankingInfo const & info)
     auto const type = static_cast<Model::Type>(i);
     os << "m_tokenRange[" << DebugPrint(type) << "]:" << DebugPrint(info.m_tokenRange[i]) << ", ";
   }
-  os << "m_rank:" << static_cast<int>(info.m_rank) << ", ";
-  os << "m_popularity:" << static_cast<int>(info.m_popularity) << ", ";
+  os << "m_allTokensUsed: " << info.m_allTokensUsed << ", ";
+  os << "m_exactMatch: " << info.m_exactMatch << ", ";
+  os << "m_rank: " << static_cast<int>(info.m_rank) << ", ";
+  os << "m_popularity: " << static_cast<int>(info.m_popularity) << ", ";
   os << "m_rating: [" << static_cast<int>(info.m_rating.first) << ", "<< info.m_rating.second << "], ";
   os << "m_type:" << info.m_type;
   os << "]";

--- a/search/pre_ranking_info.hpp
+++ b/search/pre_ranking_info.hpp
@@ -54,6 +54,9 @@ struct PreRankingInfo
   // were used when retrieving the feature.
   bool m_allTokensUsed = true;
 
+  // True iff all tokens retrieved from search index were matched without misprints.
+  bool m_exactMatch = true;
+
   // Rank of the feature.
   uint8_t m_rank = 0;
 

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -301,6 +301,7 @@ class RankerResultMaker
     info.m_rating = preInfo.m_rating;
     info.m_type = preInfo.m_type;
     info.m_allTokensUsed = preInfo.m_allTokensUsed;
+    info.m_exactMatch = preInfo.m_exactMatch;
     info.m_categorialRequest = m_params.IsCategorialRequest();
     info.m_hasName = ft.HasName();
 

--- a/search/ranking_info.hpp
+++ b/search/ranking_info.hpp
@@ -50,6 +50,9 @@ struct RankingInfo
   // were used when retrieving the feature.
   bool m_allTokensUsed = true;
 
+  // True iff all tokens retrieved from search index were matched without misprints.
+  bool m_exactMatch = true;
+
   // Search type for the feature.
   Model::Type m_type = Model::TYPE_COUNT;
 

--- a/search/retrieval.hpp
+++ b/search/retrieval.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "search/cbv.hpp"
 #include "search/feature_offset_match.hpp"
 #include "search/query_params.hpp"
 
@@ -10,17 +11,16 @@
 #include "geometry/rect2d.hpp"
 
 #include "base/cancellable.hpp"
+#include "base/checked_cast.hpp"
 #include "base/dfa_helpers.hpp"
 #include "base/levenshtein_dfa.hpp"
 
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <utility>
 
 class MwmValue;
-
-namespace coding
-{
-class CompressedBitVector;
-}
 
 namespace search
 {
@@ -32,10 +32,56 @@ class Retrieval
 public:
   template<typename Value>
   using TrieRoot = trie::Iterator<ValueList<Value>>;
-  using Features = std::unique_ptr<coding::CompressedBitVector>;
+  using Features = search::CBV;
 
   struct ExtendedFeatures
   {
+    ExtendedFeatures() = default;
+    ExtendedFeatures(ExtendedFeatures const &) = default;
+    ExtendedFeatures(ExtendedFeatures &&) = default;
+
+    explicit ExtendedFeatures(Features const & cbv) : m_features(cbv), m_exactMatchingFeatures(cbv)
+    {
+    }
+
+    ExtendedFeatures(Features && features, Features && exactMatchingFeatures)
+      : m_features(std::move(features)), m_exactMatchingFeatures(std::move(exactMatchingFeatures))
+    {
+    }
+
+    ExtendedFeatures & operator=(ExtendedFeatures const &) = default;
+    ExtendedFeatures & operator=(ExtendedFeatures &&) = default;
+
+    ExtendedFeatures Intersect(ExtendedFeatures const & rhs) const
+    {
+      ExtendedFeatures result;
+      result.m_features = m_features.Intersect(rhs.m_features);
+      result.m_exactMatchingFeatures =
+          m_exactMatchingFeatures.Intersect(rhs.m_exactMatchingFeatures);
+      return result;
+    }
+
+    ExtendedFeatures Intersect(Features const & cbv) const
+    {
+      ExtendedFeatures result;
+      result.m_features = m_features.Intersect(cbv);
+      result.m_exactMatchingFeatures = m_exactMatchingFeatures.Intersect(cbv);
+      return result;
+    }
+
+    void SetFull()
+    {
+      m_features.SetFull();
+      m_exactMatchingFeatures.SetFull();
+    }
+
+    void ForEach(std::function<void(uint32_t, bool)> const & f) const
+    {
+      m_features.ForEach([&](uint64_t id) {
+        f(base::asserted_cast<uint32_t>(id), m_exactMatchingFeatures.HasBit(id));
+      });
+    }
+
     Features m_features;
     Features m_exactMatchingFeatures;
   };

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -1915,6 +1915,30 @@ UNIT_CLASS_TEST(ProcessorTest, ExactMatchTest)
     TEST(!results[0].GetRankingInfo().m_exactMatch, ());
     TEST(!results[1].GetRankingInfo().m_exactMatch, ());
   }
+
+  {
+    auto request = MakeRequest("cafe лермонтов");
+    auto const & results = request->Results();
+
+    Rules rules{ExactMatch(wonderlandId, cafe), ExactMatch(wonderlandId, lermontov)};
+    TEST(ResultsMatch(results, rules), ());
+
+    TEST_EQUAL(2, results.size(), ("Unexpected number of retrieved cafes."));
+    TEST(results[0].GetRankingInfo().m_exactMatch, ());
+    TEST(results[1].GetRankingInfo().m_exactMatch, ());
+  }
+
+  {
+    auto request = MakeRequest("cafe лер");
+    auto const & results = request->Results();
+
+    Rules rules{ExactMatch(wonderlandId, cafe), ExactMatch(wonderlandId, lermontov)};
+    TEST(ResultsMatch(results, rules), ());
+
+    TEST_EQUAL(2, results.size(), ("Unexpected number of retrieved cafes."));
+    TEST(results[0].GetRankingInfo().m_exactMatch, ());
+    TEST(results[1].GetRankingInfo().m_exactMatch, ());
+  }
 }
 }  // namespace
 }  // namespace search

--- a/search/search_tests/feature_offset_match_tests.cpp
+++ b/search/search_tests/feature_offset_match_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "indexer/trie.hpp"
 
+#include "base/dfa_helpers.hpp"
 #include "base/mem_trie.hpp"
 #include "base/string_utils.hpp"
 
@@ -21,6 +22,8 @@ using Key = strings::UniString;
 using Value = uint32_t;
 using ValueList = VectorValues<Value>;
 using Trie = MemTrie<Key, ValueList>;
+using DFA = strings::LevenshteinDFA;
+using PrefixDFA = strings::PrefixDFAModifier<DFA>;
 
 UNIT_TEST(MatchInTrieTest)
 {
@@ -35,17 +38,60 @@ UNIT_TEST(MatchInTrieTest)
   map<uint32_t, bool> vals;
   auto saveResult = [&vals](uint32_t v, bool exactMatch) { vals[v] = exactMatch; };
 
-  auto const hotelDFA = strings::LevenshteinDFA("hotel", 1 /* maxErrors */);
+  auto const hotelDFA = DFA("hotel", 1 /* maxErrors */);
   search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, hotelDFA, saveResult);
   TEST(vals.at(1), (vals));
   TEST(vals.at(3), (vals));
   TEST(!vals.at(2), (vals));
 
   vals.clear();
-  auto const homelDFA = strings::LevenshteinDFA("homel", 1 /* maxErrors */);
+  auto const homelDFA = DFA("homel", 1 /* maxErrors */);
   search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, homelDFA, saveResult);
   TEST(vals.at(2), (vals));
   TEST(!vals.at(1), (vals));
   TEST(!vals.at(3), (vals));
+}
+
+UNIT_TEST(MatchPrefixInTrieTest)
+{
+  Trie trie;
+
+  vector<pair<string, uint32_t>> const data = {{"лермонтовъ", 1}, {"лермонтово", 2}};
+
+  for (auto const & kv : data)
+    trie.Add(strings::MakeUniString(kv.first), kv.second);
+
+  trie::MemTrieIterator<Key, ValueList> const rootIterator(trie.GetRootIterator());
+  map<uint32_t, bool> vals;
+  auto saveResult = [&vals](uint32_t v, bool exactMatch) { vals[v] = exactMatch; };
+
+  {
+    vals.clear();
+    auto const lermontov = PrefixDFA(DFA("лермонтовъ", 2 /* maxErrors */));
+    search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, lermontov, saveResult);
+    TEST(vals.at(1), (vals));
+    TEST(!vals.at(2), (vals));
+  }
+  {
+    vals.clear();
+    auto const lermontovo = PrefixDFA(DFA("лермонтово", 2 /* maxErrors */));
+    search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, lermontovo, saveResult);
+    TEST(vals.at(2), (vals));
+    TEST(!vals.at(1), (vals));
+  }
+  {
+    vals.clear();
+    auto const commonPrexif = PrefixDFA(DFA("лермонтов", 2 /* maxErrors */));
+    search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, commonPrexif, saveResult);
+    TEST(vals.at(2), (vals));
+    TEST(vals.at(1), (vals));
+  }
+  {
+    vals.clear();
+    auto const commonPrexif = PrefixDFA(DFA("лер", 2 /* maxErrors */));
+    search::impl::MatchInTrie(rootIterator, nullptr, 0 /* prefixSize */, commonPrexif, saveResult);
+    TEST(vals.at(2), (vals));
+    TEST(vals.at(1), (vals));
+  }
 }
 }  // namespace

--- a/search/search_tests/locality_scorer_test.cpp
+++ b/search/search_tests/locality_scorer_test.cpp
@@ -93,7 +93,7 @@ public:
       });
 
       base::SortUnique(ids);
-      ctx.m_features.emplace_back(coding::CompressedBitVectorBuilder::FromBitPositions(ids));
+      ctx.m_features.emplace_back(CBV(coding::CompressedBitVectorBuilder::FromBitPositions(ids)));
     }
 
     CBV filter;

--- a/search/streets_matcher.cpp
+++ b/search/streets_matcher.cpp
@@ -126,7 +126,7 @@ void StreetsMatcher::FindStreets(BaseContext const & ctx, FeaturesFilter const &
 
     StreetTokensFilter filter([&](strings::UniString const & /* token */, size_t tag)
                               {
-                                auto buffer = streets.Intersect(ctx.m_features[tag]);
+                                auto buffer = streets.Intersect(ctx.m_features[tag].m_features);
                                 if (tag < curToken)
                                 {
                                   // This is the case for delayed
@@ -134,7 +134,7 @@ void StreetsMatcher::FindStreets(BaseContext const & ctx, FeaturesFilter const &
                                   // |streets| is temporarily in the
                                   // incomplete state.
                                   streets = buffer;
-                                  all = all.Intersect(ctx.m_features[tag]);
+                                  all = all.Intersect(ctx.m_features[tag].m_features);
                                   emptyIntersection = false;
 
                                   incomplete = true;
@@ -149,7 +149,7 @@ void StreetsMatcher::FindStreets(BaseContext const & ctx, FeaturesFilter const &
                                   emit();
 
                                 streets = buffer;
-                                all = all.Intersect(ctx.m_features[tag]);
+                                all = all.Intersect(ctx.m_features[tag].m_features);
                                 emptyIntersection = false;
                                 incomplete = false;
                               });


### PR DESCRIPTION
В этом реквесте признак exactMatch протаскивается в преранкер и ранкер, но пока там не используется.
Используется для предварительного отбора городов/деревень в LocalityScorer.
На размеченной выборке существенной разницы по производительности, профилю времени исполнения функций, результатам нет.