### PR TITLE
[generator:regions] Generate features with build geometry

### DIFF
--- a/generator/generator_tests/regions_tests.cpp
+++ b/generator/generator_tests/regions_tests.cpp
@@ -185,7 +185,7 @@ UNIT_TEST(RegionsBuilderTest_GetCountryNames)
   auto const filename = MakeCollectorData();
   RegionInfo collector(filename);
   RegionsBuilder builder(MakeTestDataSet1(collector));
-  auto const countryNames = builder.GetCountryNames();
+  auto const & countryNames = builder.GetCountryNames();
   TEST_EQUAL(countryNames.size(), 2, ());
   TEST(std::count(std::begin(countryNames), std::end(countryNames), "Country_1"), ());
   TEST(std::count(std::begin(countryNames), std::end(countryNames), "Country_2"), ());
@@ -196,7 +196,7 @@ UNIT_TEST(RegionsBuilderTest_GetCountries)
   auto const filename = MakeCollectorData();
   RegionInfo collector(filename);
   RegionsBuilder builder(MakeTestDataSet1(collector));
-  auto const countries = builder.GetCountries();
+  auto const & countries = builder.GetCountriesOuters();
   TEST_EQUAL(countries.size(), 3, ());
   TEST_EQUAL(std::count_if(std::begin(countries), std::end(countries),
                            [](const Region & r) {return r.GetName() == "Country_1"; }), 1, ());
@@ -210,11 +210,14 @@ UNIT_TEST(RegionsBuilderTest_GetCountryTrees)
   RegionInfo collector(filename);
   std::vector<std::string> bankOfNames;
   RegionsBuilder builder(MakeTestDataSet1(collector));
-  builder.ForEachNormalizedCountry([&](std::string const & name, Node::Ptr const & tree) {
-    ForEachLevelPath(tree, [&](NodePath const & path) {
-      StringJoinPolicy stringifier;
-      bankOfNames.push_back(stringifier.ToString(path));
-    });
+  builder.ForEachCountry([&](std::string const & name, Node::PtrList const & outers) {
+    for (auto const & tree : outers)
+    {
+      ForEachLevelPath(tree, [&](NodePath const & path) {
+        StringJoinPolicy stringifier;
+        bankOfNames.push_back(stringifier.ToString(path));
+      });
+    }
   });
 
   TEST(NameExists(bankOfNames, "Country_2"), ());

--- a/generator/place_node.hpp
+++ b/generator/place_node.hpp
@@ -32,12 +32,6 @@ public:
   Data & GetData() { return m_data; }
   Data const & GetData() const { return m_data; }
 
-  void ShrinkToFitChildren()
-  {
-    if (m_children.capacity() != m_children.size())
-      PtrList(m_children).swap(m_children);
-  }
-
 private:
   Data m_data;
   PtrList m_children;

--- a/generator/popularity.hpp
+++ b/generator/popularity.hpp
@@ -53,7 +53,6 @@ public:
   bool Contains(PopularityGeomPlace const & smaller) const;
   bool Contains(m2::PointD const & point) const;
   feature::FeatureBuilder const & GetFeature() const { return m_feature; }
-  void DeletePolygon() { m_polygon = nullptr; }
   double GetArea() const { return m_area; }
   base::GeoObjectId GetId() const { return m_id; }
 

--- a/generator/regions/node.hpp
+++ b/generator/regions/node.hpp
@@ -29,17 +29,10 @@ void ForEachLevelPath(Node::Ptr const & tree, Fn && fn)
     ForEachLevelPath(subtree, fn);
 }
 
-size_t TreeSize(Node::Ptr node);
+size_t TreeSize(Node::Ptr const & node);
 
-size_t MaxDepth(Node::Ptr node);
+size_t MaxDepth(Node::Ptr const & node);
 
 void DebugPrintTree(Node::Ptr const & tree, std::ostream & stream = std::cout);
-
-// This function merges two trees if the roots have the same ids.
-Node::Ptr MergeTree(Node::Ptr l, Node::Ptr r);
-
-// This function corrects the tree. It traverses the whole node and unites children with
-// the same ids.
-void NormalizeTree(Node::Ptr tree);
 }  // namespace regions
 }  // namespace generator

--- a/generator/regions/region.hpp
+++ b/generator/regions/region.hpp
@@ -27,17 +27,15 @@ public:
   // Build a region and its boundary based on the heuristic.
   explicit Region(PlacePoint const & place);
 
-  // After calling DeletePolygon, you cannot use Contains, ContainsRect, CalculateOverlapPercentage.
-  void DeletePolygon();
   bool Contains(Region const & smaller) const;
   bool ContainsRect(Region const & smaller) const;
   bool Contains(PlacePoint const & place) const;
   bool Contains(BoostPoint const & point) const;
   double CalculateOverlapPercentage(Region const & other) const;
   BoostPoint GetCenter() const;
-  bool IsCountry() const;
   bool IsLocality() const;
   BoostRect const & GetRect() const { return m_rect; }
+  std::shared_ptr<BoostPolygon> const & GetPolygon() const noexcept { return m_polygon; }
   double GetArea() const { return m_area; }
   // This function uses heuristics and assigns a radius according to the tag place.
   // The radius will be returned in mercator units.
@@ -51,6 +49,6 @@ private:
   double m_area;
 };
 
-bool FeaturePlacePointToRegion(RegionInfo const & regionInfo, feature::FeatureBuilder & feature);
+std::string GetRegionNotation(Region const & region);
 }  // namespace regions
 }  // namespace generator

--- a/generator/regions/regions_builder.hpp
+++ b/generator/regions/regions_builder.hpp
@@ -21,27 +21,27 @@ class RegionsBuilder
 public:
   using Regions = std::vector<Region>;
   using StringsList = std::vector<std::string>;
-  using IdStringList = std::vector<std::pair<base::GeoObjectId, std::string>>;
-  using CountryTrees = std::multimap<std::string, Node::Ptr>;
-  using NormalizedCountryFn = std::function<void(std::string const &, Node::Ptr const &)>;
+  using CountryFn = std::function<void(std::string const &, Node::PtrList const &)>;
 
   explicit RegionsBuilder(Regions && regions, size_t threadsCount = 1);
 
-  Regions const & GetCountries() const;
+  Regions const & GetCountriesOuters() const;
   StringsList GetCountryNames() const;
-  void ForEachNormalizedCountry(NormalizedCountryFn fn);
+  void ForEachCountry(CountryFn fn);
 
   static PlaceLevel GetLevel(Region const & region);
   static size_t GetWeight(Region const & region);
 
 private:
-  static Node::PtrList MakeSelectedRegionsByCountry(Region const & country,
+  Regions FormRegionsInAreaOrder(Regions && regions);
+  Regions ExtractCountriesOuters(Regions & regions);
+  Node::PtrList BuildCountryRegionTrees(Regions const & outers);
+  static Node::Ptr BuildCountryRegionTree(Region const & outer, Regions const & allRegions);
+  static Node::PtrList MakeSelectedRegionsByCountry(Region const & outer,
                                                     Regions const & allRegions);
-  static Node::Ptr BuildCountryRegionTree(Region const & country, Regions const & allRegions);
-  std::vector<Node::Ptr> BuildCountryRegionTrees(RegionsBuilder::Regions const & countries);
 
-  Regions m_countries;
-  Regions m_regions;
+  Regions m_countriesOuters;
+  Regions m_regionsInAreaOrder;
   size_t m_threadsCount;
 };
 }  // namespace regions


### PR DESCRIPTION
Очередная порция изменений отменённого PR #10432.

В данном PR перегенерация фичей регионов с геометрией из дерева иерархии. Это нужно будет, когда place node будут получать границы из административной разметки, и когда будут label точки с границами из relation (которому label точка принадлежит) вместо relation.

Нормализация в дереве, которая была раньше, не используется. Удалил.