### PR TITLE
[omim] add 3party/boost to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ tizen/*/.*
 3party/osrm/osrm-backend/util/fingerprint_impl.hpp
 3party/osrm/osrm-backend/util/git_sha.cpp
 3party/osrm/osrm-backend/build/
+3party/boost/
 
 tizen/*/crash-info/*
 .idea/*


### PR DESCRIPTION
У меня на маке происходит следующее (после обновления буста):
![image](https://user-images.githubusercontent.com/17534533/59261777-c3acec80-8c46-11e9-907f-d1e8063e292b.png)
а на mapsme4 так:
![image](https://user-images.githubusercontent.com/17534533/59261846-daebda00-8c46-11e9-9e64-9fee523e3c13.png)

кажется, надо добавить 3party/boost в .gitignore
