### PR TITLE
[generator:geo_objects] Fix features filter: ignore lines

### DIFF
--- a/generator/geo_objects/geo_objects_filter.cpp
+++ b/generator/geo_objects/geo_objects_filter.cpp
@@ -19,7 +19,10 @@ bool GeoObjectsFilter::IsAccepted(FeatureBuilder const & feature)
 {
   if (!feature.GetParams().IsValid())
     return false;
-  
+
+  if (feature.IsLine())
+    return false;
+
   return IsBuilding(feature) || HasHouse(feature) || IsPoi(feature);
 }
 


### PR DESCRIPTION
Фикс фильтра фичей geo_objects: возвращён игнор линий, который был раньше. Линии добавлялись для streets, которые теперь генерируется отдельным запуском.