### PR TITLE
[generator:regions] Add Russsia administrative devisions

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -168,6 +168,8 @@ set(SRC
   regions/regions_builder.hpp
   regions/regions_fixer.cpp
   regions/regions_fixer.hpp
+  regions/specs/rus.cpp
+  regions/specs/rus.hpp
   restriction_collector.cpp
   restriction_collector.hpp
   restriction_generator.cpp

--- a/generator/generator_tests/region_info_collector_tests.cpp
+++ b/generator/generator_tests/region_info_collector_tests.cpp
@@ -41,9 +41,9 @@ UNIT_TEST(RegionInfoCollector_Collect)
 {
   auto const filename = GetFileName();
   CollectorRegionInfo regionInfoCollector(filename);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementCity);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementCountry);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementEmpty);
+  regionInfoCollector.Collect(kOsmElementCity);
+  regionInfoCollector.Collect(kOsmElementCountry);
+  regionInfoCollector.Collect(kOsmElementEmpty);
   regionInfoCollector.Save();
 
   RegionInfo regionInfo(filename);
@@ -86,7 +86,7 @@ UNIT_TEST(RegionInfoCollector_Get)
 {
   auto const filename = GetFileName();
   CollectorRegionInfo regionInfoCollector(filename);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementCity);
+  regionInfoCollector.Collect(kOsmElementCity);
   regionInfoCollector.Save();
 
   RegionInfo regionInfo(filename);
@@ -100,8 +100,8 @@ UNIT_TEST(RegionInfoCollector_Exists)
 {
   auto const filename = GetFileName();
   CollectorRegionInfo regionInfoCollector(filename);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementCity);
-  regionInfoCollector.CollectFeature(kEmptyFeature, kOsmElementCountry);
+  regionInfoCollector.Collect(kOsmElementCity);
+  regionInfoCollector.Collect(kOsmElementCountry);
   regionInfoCollector.Save();
 
   RegionInfo regionInfo(filename);

--- a/generator/regions/collector_region_info.cpp
+++ b/generator/regions/collector_region_info.cpp
@@ -69,7 +69,7 @@ char const * GetLabel(PlaceLevel level)
 
 CollectorRegionInfo::CollectorRegionInfo(std::string const & filename) : m_filename(filename) {}
 
-void CollectorRegionInfo::CollectFeature(const FeatureBuilder &, OsmElement const & el)
+void CollectorRegionInfo::Collect(OsmElement const & el)
 {
   base::GeoObjectId const osmId = GetGeoObjectId(el);
   RegionData regionData;

--- a/generator/regions/collector_region_info.hpp
+++ b/generator/regions/collector_region_info.hpp
@@ -118,7 +118,7 @@ public:
   CollectorRegionInfo(std::string const & filename);
 
   // CollectorInterface overrides:
-  void CollectFeature(feature::FeatureBuilder const &, OsmElement const & el) override;
+  void Collect(OsmElement const & el) override;
   void Save() override;
 
 private:

--- a/generator/regions/country_specifier.cpp
+++ b/generator/regions/country_specifier.cpp
@@ -4,6 +4,9 @@ namespace generator
 {
 namespace regions
 {
+void CountrySpecifier::AdjustRegionsLevel(Node::PtrList & outers)
+{ }
+
 PlaceLevel CountrySpecifier::GetLevel(Region const & region) const
 {
   auto const placeType = region.GetPlaceType();

--- a/generator/regions/country_specifier.hpp
+++ b/generator/regions/country_specifier.hpp
@@ -2,6 +2,7 @@
 
 #include "generator/regions/collector_region_info.hpp"
 #include "generator/regions/level_region.hpp"
+#include "generator/regions/node.hpp"
 #include "generator/regions/region.hpp"
 
 namespace generator
@@ -12,6 +13,8 @@ class CountrySpecifier
 {
 public:
   virtual ~CountrySpecifier() = default;
+
+  virtual void AdjustRegionsLevel(Node::PtrList & outers);
 
   virtual PlaceLevel GetLevel(Region const & region) const;
   // Return -1 - |l| is under place of |r|, 0 - undefined relation, 1 - |r| is under place of |l|.

--- a/generator/regions/regions_builder.cpp
+++ b/generator/regions/regions_builder.cpp
@@ -1,5 +1,7 @@
 #include "generator/regions/regions_builder.hpp"
 
+#include "generator/regions/specs/rus.hpp"
+
 #include "base/assert.hpp"
 #include "base/thread_pool_computational.hpp"
 #include "base/stl_helpers.hpp"
@@ -181,6 +183,8 @@ void RegionsBuilder::ForEachCountry(CountryFn fn)
     std::copy_if(std::begin(countries), std::end(countries), std::back_inserter(outers), pred);
     auto countryTrees = BuildCountryRegionTrees(outers, *countrySpecifier);
 
+    countrySpecifier->AdjustRegionsLevel(countryTrees);
+
     fn(countryName, countryTrees);
   }
 }
@@ -208,6 +212,9 @@ Node::PtrList RegionsBuilder::BuildCountryRegionTrees(Regions const & outers,
 
 std::unique_ptr<CountrySpecifier> RegionsBuilder::GetCountrySpecifier(std::string const & countryName)
 {
+  if (countryName == u8"Россия" || countryName == u8"Российская Федерация" || countryName == u8"РФ")
+    return std::make_unique<specs::RusSpecifier>();
+
   return std::make_unique<CountrySpecifier>();
 }
 }  // namespace regions

--- a/generator/regions/specs/rus.cpp
+++ b/generator/regions/specs/rus.cpp
@@ -1,0 +1,150 @@
+#include "generator/regions/specs/rus.hpp"
+
+#include "base/stl_helpers.hpp"
+
+namespace generator
+{
+namespace regions
+{
+namespace specs
+{
+void RusSpecifier::AdjustRegionsLevel(Node::PtrList & outers)
+{
+  AdjustMoscowAdministrativeDivisions(outers);
+}
+
+void RusSpecifier::AdjustMoscowAdministrativeDivisions(Node::PtrList & outers)
+{
+  for (auto const & tree : outers)
+    AdjustMoscowAdministrativeDivisions(tree);
+
+  if (!m_moscowRegionWasProcessed)
+    LOG(LWARNING, ("Failed to find Moscow region"));
+  if (!m_moscowCityWasProcessed)
+    LOG(LWARNING, ("Failed to find Moscow city"));
+}
+
+void RusSpecifier::AdjustMoscowAdministrativeDivisions(Node::Ptr const & tree)
+{
+  auto const & region = tree->GetData();
+  if (region.GetAdminLevel() == AdminLevel::Four && region.GetName() == u8"Москва")
+  {
+    for (auto & subtree : tree->GetChildren())
+    {
+      MarkMoscowSubregionsByAdministrativeOkrugs(subtree);
+      AdjustMoscowCitySuburbs(subtree);
+    }
+    return;
+  }
+
+  if (region.GetAdminLevel() > AdminLevel::Four)
+    return;
+
+  for (auto & subtree : tree->GetChildren())
+    AdjustMoscowAdministrativeDivisions(subtree);
+}
+
+void RusSpecifier::MarkMoscowSubregionsByAdministrativeOkrugs(Node::Ptr & tree)
+{
+  auto & region = tree->GetData();
+  auto const adminLevel = region.GetAdminLevel();
+  if (adminLevel == AdminLevel::Five)
+  {
+    region.SetLevel(PlaceLevel::Subregion);
+    m_moscowRegionWasProcessed = true;
+    return;
+  }
+
+  if (adminLevel > AdminLevel::Five)
+    return;
+  
+  for (auto & subtree : tree->GetChildren())
+    MarkMoscowSubregionsByAdministrativeOkrugs(subtree);
+}
+
+void RusSpecifier::AdjustMoscowCitySuburbs(Node::Ptr const & tree)
+{
+  auto & region = tree->GetData();
+  if (region.GetPlaceType() == PlaceType::City && region.GetName() == u8"Москва")
+  {
+    for (auto & subtree : tree->GetChildren())
+      MarkMoscowSuburbsByAdministrativeDistrics(subtree);
+    return;
+  }
+
+  if (region.GetLevel() >= PlaceLevel::Locality)
+    return;
+
+  for (auto & subtree : tree->GetChildren())
+    AdjustMoscowCitySuburbs(subtree);
+}
+
+void RusSpecifier::MarkMoscowSuburbsByAdministrativeDistrics(Node::Ptr & tree)
+{
+  auto & region = tree->GetData();
+  if (AdminLevel::Eight == region.GetAdminLevel())
+  {
+    MarkMoscowAdministrativeDistric(tree);
+    return;
+  }
+
+  if (PlaceLevel::Suburb == region.GetLevel())
+    region.SetLevel(PlaceLevel::Sublocality);
+  
+  for (auto & subtree : tree->GetChildren())
+    MarkMoscowSuburbsByAdministrativeDistrics(subtree);
+}
+
+void RusSpecifier::MarkMoscowAdministrativeDistric(Node::Ptr & node)
+{
+  auto & region = node->GetData();
+  region.SetLevel(PlaceLevel::Suburb);
+  m_moscowCityWasProcessed = true;
+
+  for (auto & subtree : node->GetChildren())
+    MarkAllSuburbsToSublocalities(subtree);
+}
+
+void RusSpecifier::MarkAllSuburbsToSublocalities(Node::Ptr & tree)
+{
+  auto & region = tree->GetData();
+  auto const level = region.GetLevel();
+  if (level == PlaceLevel::Locality)  // nested locality
+    return;
+
+  if (level == PlaceLevel::Suburb)
+    region.SetLevel(PlaceLevel::Sublocality);
+  
+  for (auto & subtree : tree->GetChildren())
+    MarkAllSuburbsToSublocalities(subtree);
+}
+
+PlaceLevel RusSpecifier::GetLevel(Region const & region) const
+{
+  auto placeLevel = CountrySpecifier::GetLevel(region.GetPlaceType());
+  if (placeLevel != PlaceLevel::Unknown)
+    return placeLevel;
+
+  return GetRussiaPlaceLevel(region.GetAdminLevel());
+}
+
+// static
+PlaceLevel RusSpecifier::GetRussiaPlaceLevel(AdminLevel adminLevel)
+{
+  switch (adminLevel)
+  {
+  case AdminLevel::Two:
+    return PlaceLevel::Country;
+  case AdminLevel::Four:
+    return PlaceLevel::Region;
+  case AdminLevel::Six:
+    return PlaceLevel::Subregion;
+  default:
+    break;
+  }
+
+  return PlaceLevel::Unknown;
+}
+}  // namespace specs
+}  // namespace regions
+}  // namespace generator

--- a/generator/regions/specs/rus.hpp
+++ b/generator/regions/specs/rus.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "generator/place_node.hpp"
+#include "generator/regions/collector_region_info.hpp"
+#include "generator/regions/country_specifier.hpp"
+#include "generator/regions/region.hpp"
+
+namespace generator
+{
+namespace regions
+{
+namespace specs
+{
+class RusSpecifier final : public CountrySpecifier
+{
+public:
+  // CountrySpecifier overrides:
+  void AdjustRegionsLevel(Node::PtrList & outers) override;
+  PlaceLevel GetLevel(Region const & region) const override;
+
+private:
+  void AdjustMoscowAdministrativeDivisions(Node::PtrList & outers);
+  void AdjustMoscowAdministrativeDivisions(Node::Ptr const & tree);
+  void MarkMoscowSubregionsByAdministrativeOkrugs(Node::Ptr & node);
+
+  void AdjustMoscowCitySuburbs(Node::Ptr const & tree);
+  void MarkMoscowSuburbsByAdministrativeDistrics(Node::Ptr & tree);
+  void MarkMoscowAdministrativeDistric(Node::Ptr & node);
+  void MarkAllSuburbsToSublocalities(Node::Ptr & tree);
+
+  static PlaceLevel GetRussiaPlaceLevel(AdminLevel adminLevel);
+
+  bool m_moscowRegionWasProcessed{false};
+  bool m_moscowCityWasProcessed{false};
+};
+}  // namespace specs
+}  // namespace regions
+}  // namespace generator


### PR DESCRIPTION
Генерация административного деления России по admin_level:
- 4  - region
- 5  - subregion (Москва), suburb (Санкт-Петербург, Севастополь)
- 6 - subregion
- 8 - suburb (Москва), sublocality (Санкт-Петербург, Севастополь)
- 9 - suburb

см.
https://wiki.openstreetmap.org/wiki/RU:Tag:boundary%3Dadministrative
https://wiki.openstreetmap.org/wiki/RU:%D0%9E%D1%88%D0%B8%D0%B1%D0%BA%D0%B8_%D0%B3%D1%80%D0%B0%D0%BD%D0%B8%D1%86