### PR TITLE
[search] Set RankingInfo::m_hasName to true for features with brand or operator.

### DIFF
--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -313,10 +313,20 @@ class RankerResultMaker
     info.m_allTokensUsed = preInfo.m_allTokensUsed;
     info.m_exactMatch = preInfo.m_exactMatch;
     info.m_categorialRequest = m_params.IsCategorialRequest();
-    info.m_hasName = ft.HasName();
 
-    // We do not compare result name and request for categorial requests.
-    if (!m_params.IsCategorialRequest())
+    // We do not compare result name and request for categorial requests but we prefer named
+    // features.
+    if (m_params.IsCategorialRequest())
+    {
+      info.m_hasName = ft.HasName();
+      if (!info.m_hasName)
+      {
+        auto const & meta = ft.GetMetadata();
+        info.m_hasName =
+            meta.Has(feature::Metadata::FMD_OPERATOR) || meta.Has(feature::Metadata::FMD_BRAND);
+      }
+    }
+    else
     {
       auto const nameScores =
           GetNameScores(ft, m_params, preInfo.InnermostTokenRange(), info.m_type);


### PR DESCRIPTION
Для некоторых объектов (азс, банкомат) обычно название указывается в operator. Имя при этом пустое, но азс/банкомат по сути не noname. С брендами аналогично.

m_hasName используется только для категорийных запросов, поэтому, раз мы начали читать метадату, занесла под `if (m_params.IsCategorialRequest())`.