### PR TITLE
 [routing] Making passing through living_street and service roads for bicycle in Russia.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -85,14 +85,32 @@ UNIT_TEST(RussiaMoscowKashirskoe16ToCapLongRoute)
       MercatorBounds::FromLatLon(55.68927, 37.70356), 7075.0);
 }
 
-// No pass through service road in Russia
-UNIT_TEST(RussiaMoscowNoServicePassThrough)
+// Passing through living_street and service are allowed in Russia
+UNIT_TEST(RussiaMoscowServicePassThrough1)
 {
   TRouteResult route =
         integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Bicycle),
                                     MercatorBounds::FromLatLon(55.66230, 37.63214), {0., 0.},
                                     MercatorBounds::FromLatLon(55.68895, 37.70286));
-  TEST_EQUAL(route.second, RouterResultCode::RouteNotFound, ());
+  TEST_EQUAL(route.second, RouterResultCode::NoError, ());
+}
+
+UNIT_TEST(RussiaMoscowServicePassThrough2)
+{
+  TRouteResult route =
+      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Bicycle),
+                                  MercatorBounds::FromLatLon(55.69038, 37.70015), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.69123, 37.6953));
+  TEST_EQUAL(route.second, RouterResultCode::NoError, ());
+}
+
+UNIT_TEST(RussiaMoscowServicePassThrough3)
+{
+  TRouteResult route =
+      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Bicycle),
+                                  MercatorBounds::FromLatLon(55.79649, 37.53738), {0., 0.},
+                                  MercatorBounds::FromLatLon(55.79618, 37.54071));
+  TEST_EQUAL(route.second, RouterResultCode::NoError, ());
 }
 
 // TODO: This test doesn't pass because routing::RouteWeight::operator<

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -117,12 +117,12 @@ UNIT_TEST(RussiaMoscowTatishchevaOnewayCarRoadTurnTest)
 
   integration::TestTurnCount(route, 4 /* expectedTurnCount */);
 
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnRight);
 
-  integration::TestRouteLength(route, 675.0);
+  integration::TestRouteLength(route, 333.0);
 }
 
 UNIT_TEST(RussiaMoscowSvobodiOnewayBicycleWayTurnTest)

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -168,6 +168,29 @@ VehicleModel::LimitsInitList const kBicycleOptionsBridlewayAllowed = {
     {{"highway", "steps"}, true},
     {{"highway", "platform"}, true}};
 
+// Same as defaults except pedestrian and footway are allowed
+VehicleModel::LimitsInitList const kBicycleOptionsPedestrianFootwayAllowed = {
+    {{"highway", "trunk"}, true},
+    {{"highway", "trunk_link"}, true},
+    {{"highway", "primary"}, true},
+    {{"highway", "primary_link"}, true},
+    {{"highway", "secondary"}, true},
+    {{"highway", "secondary_link"}, true},
+    {{"highway", "tertiary"}, true},
+    {{"highway", "tertiary_link"}, true},
+    {{"highway", "service"}, true},
+    {{"highway", "unclassified"}, true},
+    {{"highway", "road"}, true},
+    {{"highway", "track"}, true},
+    {{"highway", "path"}, true},
+    {{"highway", "cycleway"}, true},
+    {{"highway", "residential"}, true},
+    {{"highway", "living_street"}, true},
+    {{"highway", "steps"}, true},
+    {{"highway", "pedestrian"}, true},
+    {{"highway", "footway"}, true},
+    {{"highway", "platform"}, true}};
+
 // Australia
 VehicleModel::LimitsInitList const kBicycleOptionsAustralia = kBicycleOptionsAll;
 
@@ -191,28 +214,7 @@ VehicleModel::LimitsInitList const kBicycleOptionsAustria = {
     {{"highway", "platform"}, true}};
 
 // Belarus
-VehicleModel::LimitsInitList const kBicycleOptionsBelarus = {
-    // Footway and pedestrian are allowed
-    {{"highway", "trunk"}, true},
-    {{"highway", "trunk_link"}, true},
-    {{"highway", "primary"}, true},
-    {{"highway", "primary_link"}, true},
-    {{"highway", "secondary"}, true},
-    {{"highway", "secondary_link"}, true},
-    {{"highway", "tertiary"}, true},
-    {{"highway", "tertiary_link"}, true},
-    {{"highway", "service"}, true},
-    {{"highway", "unclassified"}, true},
-    {{"highway", "road"}, true},
-    {{"highway", "track"}, true},
-    {{"highway", "path"}, true},
-    {{"highway", "cycleway"}, true},
-    {{"highway", "residential"}, true},
-    {{"highway", "living_street"}, true},
-    {{"highway", "steps"}, true},
-    {{"highway", "pedestrian"}, true},
-    {{"highway", "footway"}, true},
-    {{"highway", "platform"}, true}};
+VehicleModel::LimitsInitList const kBicycleOptionsBelarus = kBicycleOptionsPedestrianFootwayAllowed;
 
 // Belgium
 VehicleModel::LimitsInitList const kBicycleOptionsBelgium = {
@@ -318,7 +320,7 @@ VehicleModel::LimitsInitList const kBicycleOptionsRomania = kBicycleOptionsNoTru
 // https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions
 // passing through service and living_street with a bicycle is prohibited
 // it's allowed according to Russian traffic rules.
-VehicleModel::LimitsInitList const kBicycleOptionsRussia = kBicycleOptionsBelarus;
+VehicleModel::LimitsInitList const kBicycleOptionsRussia = kBicycleOptionsPedestrianFootwayAllowed;
 
 // Slovakia
 VehicleModel::LimitsInitList const kBicycleOptionsSlovakia = kBicycleOptionsNoTrunk;

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -313,29 +313,12 @@ VehicleModel::LimitsInitList const kBicycleOptionsPoland = kBicycleOptionsNoTrun
 VehicleModel::LimitsInitList const kBicycleOptionsRomania = kBicycleOptionsNoTrunk;
 
 // Russian Federation
-VehicleModel::LimitsInitList const kBicycleOptionsRussia = {
-    // Footway and pedestrian are allowed
-    // No pass through service and living_street
-    {{"highway", "trunk"}, true},
-    {{"highway", "trunk_link"}, true},
-    {{"highway", "primary"}, true},
-    {{"highway", "primary_link"}, true},
-    {{"highway", "secondary"}, true},
-    {{"highway", "secondary_link"}, true},
-    {{"highway", "tertiary"}, true},
-    {{"highway", "tertiary_link"}, true},
-    {{"highway", "service"}, false},
-    {{"highway", "unclassified"}, true},
-    {{"highway", "road"}, true},
-    {{"highway", "track"}, true},
-    {{"highway", "path"}, true},
-    {{"highway", "cycleway"}, true},
-    {{"highway", "residential"}, true},
-    {{"highway", "living_street"}, false},
-    {{"highway", "steps"}, true},
-    {{"highway", "pedestrian"}, true},
-    {{"highway", "footway"}, true},
-    {{"highway", "platform"}, true}};
+// Footway and pedestrian are allowed
+// Note. Despite the fact that according to
+// https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions
+// passing through service and living_street with a bicycle is prohibited
+// it's allowed according to Russian traffic rules.
+VehicleModel::LimitsInitList const kBicycleOptionsRussia = kBicycleOptionsBelarus;
 
 // Slovakia
 VehicleModel::LimitsInitList const kBicycleOptionsSlovakia = kBicycleOptionsNoTrunk;
@@ -352,7 +335,7 @@ VehicleModel::LimitsInitList const kBicycleOptionsTurkey = kBicycleOptionsDefaul
 // Ukraine
 VehicleModel::LimitsInitList const kBicycleOptionsUkraine = {
     // No trunk
-    // Footway and perestrian are allowed
+    // Footway and pedestrian are allowed
     // No pass through living_street and service
     {{"highway", "primary"}, true},
     {{"highway", "primary_link"}, true},


### PR DESCRIPTION
Данный PR решает 2 проблемы:

1. исправляет ряд ситуаций, когда вело маршрут не прокладывался, хотя должен:
- теперь возможно проложить маршрут от офис (тест: RussiaMoscowServicePassThrough3)
- https://jira.mail.ru/browse/MAPSME-10521
- маршрут в районе Нагатинской набережной (тест: RussiaMoscowServicePassThrough2)

2. приводит в соответствие прокладку веломаршрутов  в России с правилами ПДД.
Согласно ПДД России велосипед является **транспортным средством**:

> "Велосипед" - **транспортное средство**, кроме инвалидных колясок, которое имеет по крайней мере два колеса и приводится в движение как правило мускульной энергией лиц, находящихся на этом транспортном средстве, в частности при помощи педалей или рукояток, и может также иметь электродвигатель номинальной максимальной мощностью в режиме длительной нагрузки, не превышающей 0,25 кВт, автоматически отключающийся на скорости более 25 км/ч.

Источники: 
https://pddmaster.ru/pdd/pdd-dlya-velosipedistov.html#1
http://www.consultant.ru/document/cons_doc_LAW_2709/5894b193fda5648afe1c1a5e70c028f25cd29099/

Согласно ПДД сквозной проезд через дворы запрещен для **механических транспортных средств**

>17.2. В жилой зоне запрещаются сквозное движение **механических транспортных средств**, учебная езда, стоянка с работающим двигателем, а также стоянка грузовых автомобилей с разрешенной максимальной массой более 3,5 т вне специально выделенных и обозначенных знаками и (или) разметкой мест.

Источники:
http://www.consultant.ru/document/cons_doc_LAW_2709/4a197256b71d80d3468ba394e252f791d3066874/

Т.е. велосипед является **транспортным средством**, но не **механическим транспортным средством** для которого проезд через дворы запрещен согласно 17.2. Механическое транспортное средство имеет другое определение в ПДД: http://www.consultant.ru/document/cons_doc_LAW_2709/5894b193fda5648afe1c1a5e70c028f25cd29099/

Т.о. данные о запрете сквозного проезда сквозь дворы для велосипедов в России, в https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions не верны. Другая страна, где запрещены сквозные проезды сквозь дворы для велосипедов - Украина. Но согласно доступному мне переводы ПДД Украины они там правда запрещены (https://vodiy.ua/ru/pdr/1/ https://vodiy.ua/ru/pdr/26/). Поэтому для Украины оставляю как есть.

Добавлены routing_integration_tests.

RussiaMoscowTatishchevaOnewayCarRoadTurnTest поправлен поскольку было:
![image](https://user-images.githubusercontent.com/1768114/59848444-d4a7dd00-936d-11e9-8590-b7096875f8fe.png)

стало:
![image](https://user-images.githubusercontent.com/1768114/59848370-a88c5c00-936d-11e9-8df9-e4270a7ee536.png)

https://jira.mail.ru/browse/MAPSME-10521
https://jira.mail.ru/browse/MAPSME-2961

@tatiana-yan @gmoryes PTAL