### PR TITLE
[generator:regions] Approximate settlement only

### DIFF
--- a/generator/regions/regions_fixer.cpp
+++ b/generator/regions/regions_fixer.cpp
@@ -83,8 +83,19 @@ public:
 private:
   bool IsApproximable(PlacePoint const & place)
   {
-    auto const placeType = place.GetPlaceType();
-    return placeType >= PlaceType::City;
+    switch (place.GetPlaceType())
+    {
+    case PlaceType::City:
+    case PlaceType::Town:
+    case PlaceType::Village:
+    case PlaceType::Hamlet:
+    case PlaceType::IsolatedDwelling:
+      return true;
+    default:
+      break;
+    }
+
+    return false;
   }
 
   RegionsBuilder::Regions m_regions;


### PR DESCRIPTION
Круговая аппроксимация только для насел. пункты. Насел. пункты нельзя игнорировать, т.к. jsonl от генератора используется и в прямом геокодере. Районы без границ не страшно потерять, а круговая аппроксимировать ухудшает качество для обратного и прямого геокодеров, как для регионов так и для строений.