### PR TITLE
[generator:geo_objects] Optimize RSS usage: json objects limit

### DIFF
--- a/generator/geo_objects/geo_objects.cpp
+++ b/generator/geo_objects/geo_objects.cpp
@@ -191,15 +191,12 @@ void BuildGeoObjectsWithAddresses(KeyValueStorage & geoObjectsKv,
     auto json = KeyValueStorage::JsonString{json_dumps(jsonValue.get(),
         JSON_REAL_PRECISION(regions::JsonPolicy::kDefaultPrecision) | JSON_COMPACT)};
 
-    if (!GeoObjectsFilter::HasHouse(fb))
-      jsonValue.reset();  // no cache JSON model
-
     std::lock_guard<std::mutex> lock(updateMutex);
-    geoObjectsKv.Insert(id, std::move(json), std::move(jsonValue));
+    geoObjectsKv.Insert(id, std::move(json));  // no cache JSON model
   };
 
   ForEachParallelFromDatRawFormat(threadsCount, pathInGeoObjectsTmpMwm, concurrentTransformer);
-  LOG(LINFO, ("Added ", geoObjectsKv.Size(), "geo objects with addresses."));
+  LOG(LINFO, ("Added", geoObjectsKv.Size(), "geo objects with addresses."));
 }
 
 void BuildGeoObjectsWithoutAddresses(KeyValueStorage & geoObjectsKv,
@@ -265,7 +262,7 @@ bool GenerateGeoObjects(std::string const & pathInRegionsIndex,
                                          pathInGeoObjectsTmpMwm);
 
   Platform().RemoveFileIfExists(pathOutGeoObjectsKv);
-  KeyValueStorage geoObjectsKv(pathOutGeoObjectsKv, 10'000'000);
+  KeyValueStorage geoObjectsKv(pathOutGeoObjectsKv, 0 /* cacheValuesCountLimit */);
   BuildGeoObjectsWithAddresses(geoObjectsKv, regionInfoGetter, pathInGeoObjectsTmpMwm,
                                verbose, threadsCount);
   LOG(LINFO, ("Geo objects with addresses were built."));

--- a/generator/key_value_storage.cpp
+++ b/generator/key_value_storage.cpp
@@ -25,7 +25,7 @@ KeyValueStorage::KeyValueStorage(std::string const & path, size_t cacheValuesCou
 
     uint64_t key;
     auto value = std::string{};
-    if (!ParseKeyValueLine(line, key, value, lineNumber))
+    if (!ParseKeyValueLine(line, lineNumber, key, value))
       continue;
 
     json_error_t jsonError;
@@ -49,8 +49,8 @@ KeyValueStorage::KeyValueStorage(std::string const & path, size_t cacheValuesCou
 }
 
 // static
-bool KeyValueStorage::ParseKeyValueLine(std::string const & line, uint64_t & key,
-    std::string & value, std::streamoff lineNumber)
+bool KeyValueStorage::ParseKeyValueLine(std::string const & line, std::streamoff lineNumber,
+    uint64_t & key, std::string & value)
 {
   auto const pos = line.find(" ");
   if (pos == std::string::npos)

--- a/generator/key_value_storage.hpp
+++ b/generator/key_value_storage.hpp
@@ -59,8 +59,8 @@ private:
   using Value = boost::variant<std::shared_ptr<JsonValue>, JsonString>;
 
   static bool DefaultPred(KeyValue const &) { return true; }
-  static bool ParseKeyValueLine(std::string const & line, uint64_t & key, std::string & value,
-                                std::streamoff lineNumber);
+  static bool ParseKeyValueLine(std::string const & line, std::streamoff lineNumber,
+                                uint64_t & key, std::string & value);
   JsonString CopyJsonString(std::string const & value) const;
 
   std::fstream m_storage;

--- a/generator/key_value_storage.hpp
+++ b/generator/key_value_storage.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include <boost/optional.hpp>
+#include <boost/variant.hpp>
 
 #include "3party/jansson/myjansson.hpp"
 
@@ -41,7 +42,7 @@ class KeyValueStorage
 public:
   using JsonString = std::unique_ptr<char, JSONFreeDeleter>;
 
-  explicit KeyValueStorage(std::string const & kvPath,
+  explicit KeyValueStorage(std::string const & kvPath, size_t cacheValuesCountLimit,
                            std::function<bool(KeyValue const &)> const & pred = DefaultPred);
 
   KeyValueStorage(KeyValueStorage &&) = default;
@@ -50,15 +51,20 @@ public:
   KeyValueStorage(KeyValueStorage const &) = delete;
   KeyValueStorage & operator=(KeyValueStorage const &) = delete;
 
-  void Insert(uint64_t key, JsonString && valueJson, base::JSONPtr && value);
+  void Insert(uint64_t key, JsonString && valueJson, base::JSONPtr && value = {});
   std::shared_ptr<JsonValue> Find(uint64_t key) const;
   size_t Size() const;
 
 private:
+  using Value = boost::variant<std::shared_ptr<JsonValue>, JsonString>;
+
   static bool DefaultPred(KeyValue const &) { return true; }
-  static bool ParseKeyValueLine(std::string const & line, KeyValue & res, std::streamoff lineNumber);
+  static bool ParseKeyValueLine(std::string const & line, uint64_t & key, std::string & value,
+                                std::streamoff lineNumber);
+  JsonString CopyJsonString(std::string const & value) const;
 
   std::fstream m_storage;
-  std::unordered_map<uint64_t, std::shared_ptr<JsonValue>> m_values;
+  std::unordered_map<uint64_t, Value> m_values;
+  size_t m_cacheValuesCountLimit;
 };
 }  // namespace generator

--- a/generator/regions/region_info_getter.cpp
+++ b/generator/regions/region_info_getter.cpp
@@ -10,7 +10,7 @@ namespace regions
 {
 RegionInfoGetter::RegionInfoGetter(std::string const & indexPath, std::string const & kvPath)
     : m_index{indexer::ReadIndex<indexer::RegionsIndexBox<IndexReader>, MmapReader>(indexPath)}
-    , m_storage(kvPath)
+    , m_storage(kvPath, 1'000'000)
 {
   m_borders.Deserialize(indexPath);
 }


### PR DESCRIPTION
Оптимизация по памяти. Сейчас генератор для geo_objects не помещается в 256 Gb: слишком много занимают десериализованные json объекты строений в KeyValueStorage.
В этом PR KeyValueStorage хранит только заданное кол-во (первых) десер. json объектов, а остальные - в виде json, строки. Когда требуется json для объекта, то он десер. на лету и после обработки уничтожается. Т.к. обработка происходит в неск. потоках и десериализация происходит в них же, то скорость генерация осталось на том же уровне (при большом кол-ве потоков).