### PR TITLE
[Android Strings TTS] new order for languages plus sk and sv

### DIFF
--- a/android/res/values/strings-tts.xml
+++ b/android/res/values/strings-tts.xml
@@ -18,61 +18,65 @@
                 translatable="false">
     <item>en</item>
     <item>ru</item>
-    <item>es</item>
-    <item>de</item>
-    <item>fr</item>
-    <item>zh-TW:zh-Hant</item>
-    <item>zh-CN:zh-Hans</item>
-    <item>pt</item>
-    <item>th</item>
-    <item>tr</item>
-    <item>ar</item>
     <item>cs</item>
     <item>da</item>
-    <item>el</item>
-    <item>fi</item>
-    <item>hi</item>
-    <item>hu</item>
+    <item>de</item>
+    <item>es</item>
+    <item>fr</item>
     <item>id</item>
     <item>it</item>
-    <item>ja</item>
-    <item>ko</item>
+    <item>hu</item>
     <item>nl</item>
     <item>pl</item>
+    <item>pt</item>
     <item>ro</item>
-    <item>fa</item>
-    <item>uk</item>
+    <item>sk</item>
+    <item>fi</item>
+    <item>sv</item>
     <item>vi</item>
+    <item>tr</item>
+    <item>el</item>
+    <item>uk</item>
+    <item>ar</item>
+    <item>fa</item>
+    <item>hi</item>
+    <item>ja</item>
+    <item>ko</item>
+    <item>th</item>
+    <item>zh-TW:zh-Hant</item>
+    <item>zh-CN:zh-Hans</item> 
   </string-array>
 
   <string-array name="tts_language_names"
                 translatable="false">
     <item>English</item>
     <item>Русский</item>
-    <item>Español</item>
-    <item>Deutsch</item>
-    <item>Français</item>
-    <item>中文繁體</item>
-    <item>中文简体</item>
-    <item>Português</item>
-    <item>ภาษาไทย</item>
-    <item>Türkçe</item>
-    <item>العربية</item>
     <item>Čeština</item>
     <item>Dansk</item>
-    <item>Ελληνικά</item>
-    <item>Suomi</item>
-    <item>हिंदी</item>
-    <item>Magyar</item>
+    <item>Deutsch</item>
+    <item>Español</item>
+    <item>Français</item>
     <item>Indonesia</item>
     <item>Italiano</item>
-    <item>日本語</item>
-    <item>한국어</item>
+    <item>Magyar</item>
     <item>Nederlands</item>
     <item>Polski</item>
+    <item>Português</item>
     <item>Română</item>
-    <item>فارسی</item>
-    <item>Українська</item>
+    <item>Slovenčina</item>
+    <item>Suomi</item>
+    <item>Svenska</item>
     <item>Tiếng Việt</item>
+    <item>Türkçe</item>
+    <item>Ελληνικά</item>
+    <item>Українська</item>
+    <item>العربية</item>
+    <item>فارسی</item>
+    <item>हिंदी</item>
+    <item>日本語</item>
+    <item>한국어</item>
+    <item>ภาษาไทย</item>
+    <item>中文繁體</item>
+    <item>中文简体</item>
   </string-array>
 </resources>


### PR DESCRIPTION
New trendy and simple order for languages plus sk and sv cause now Google TTS supports them