### PR TITLE
[generator:regions] Add place label nodes

### DIFF
--- a/generator/regions/collector_region_info.hpp
+++ b/generator/regions/collector_region_info.hpp
@@ -103,6 +103,7 @@ struct RegionData
   base::GeoObjectId m_osmId;
   AdminLevel m_adminLevel = AdminLevel::Unknown;
   PlaceType m_place = PlaceType::Unknown;
+  base::GeoObjectId m_labelOsmId;
 };
 
 using MapRegionData = std::unordered_map<base::GeoObjectId, RegionData>;

--- a/generator/regions/region.cpp
+++ b/generator/regions/region.cpp
@@ -50,10 +50,61 @@ Region::Region(PlacePoint const & place)
   , RegionWithData(place.GetRegionData())
   , m_polygon(std::make_shared<BoostPolygon>())
 {
+  CHECK_NOT_EQUAL(place.GetPlaceType(), PlaceType::Unknown, ());
+
   auto const radius = GetRadiusByPlaceType(place.GetPlaceType());
   *m_polygon = MakePolygonWithRadius(place.GetPosition(), radius);
   boost::geometry::envelope(*m_polygon, m_rect);
   m_area = boost::geometry::area(*m_polygon);
+}
+
+std::string Region::GetEnglishOrTransliteratedName() const
+{
+  if (m_placeLabel)
+    return m_placeLabel->GetEnglishOrTransliteratedName();
+
+  return RegionWithName::GetEnglishOrTransliteratedName();
+}
+
+std::string Region::GetName(int8_t lang) const
+{
+  if (m_placeLabel)
+    return m_placeLabel->GetName();
+
+  return RegionWithName::GetName();
+}
+
+base::GeoObjectId Region::GetId() const
+{
+  if (m_placeLabel)
+    return m_placeLabel->GetId();
+
+  return RegionWithData::GetId();
+}
+
+PlaceType Region::GetPlaceType() const
+{
+  if (m_placeLabel)
+    return m_placeLabel->GetPlaceType();
+
+  return RegionWithData::GetPlaceType();
+}
+
+boost::optional<std::string> Region::GetIsoCode() const
+{
+  if (m_placeLabel)
+  {
+    if (auto && isoCode = m_placeLabel->GetIsoCode())
+      return isoCode;
+  }
+
+  return RegionWithData::GetIsoCode();
+}
+
+void Region::SetLabel(PlacePoint const & place)
+{
+  CHECK(!m_placeLabel, ());
+  m_placeLabel = place;
 }
 
 // static
@@ -127,6 +178,9 @@ bool Region::ContainsRect(Region const & smaller) const
 
 BoostPoint Region::GetCenter() const
 {
+  if (m_placeLabel)
+    return m_placeLabel->GetPosition();
+
   BoostPoint p;
   boost::geometry::centroid(m_rect, p);
   return p;

--- a/generator/regions/region.hpp
+++ b/generator/regions/region.hpp
@@ -2,6 +2,7 @@
 
 #include "generator/feature_builder.hpp"
 #include "generator/regions/region_base.hpp"
+#include "generator/regions/place_point.hpp"
 
 #include <memory>
 
@@ -16,16 +17,26 @@ class RegionDataProxy;
 
 namespace regions
 {
-class PlacePoint;
-
 // This is a helper class that is needed to represent the region.
 // With this view, further processing is simplified.
-class Region : public RegionWithName, public RegionWithData
+class Region : protected RegionWithName, protected RegionWithData
 {
 public:
   explicit Region(feature::FeatureBuilder const & fb, RegionDataProxy const & rd);
   // Build a region and its boundary based on the heuristic.
   explicit Region(PlacePoint const & place);
+
+  // See RegionWithName::GetEnglishOrTransliteratedName().
+  std::string GetEnglishOrTransliteratedName() const;
+  std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
+
+  base::GeoObjectId GetId() const;
+  using RegionWithData::GetAdminLevel;
+  PlaceType GetPlaceType() const;
+  boost::optional<std::string> GetIsoCode() const;
+
+  using RegionWithData::GetLabelOsmId;
+  void SetLabel(PlacePoint const & place);
 
   bool Contains(Region const & smaller) const;
   bool ContainsRect(Region const & smaller) const;
@@ -44,6 +55,7 @@ public:
 private:
   void FillPolygon(feature::FeatureBuilder const & fb);
 
+  boost::optional<PlacePoint> m_placeLabel;
   std::shared_ptr<BoostPolygon> m_polygon;
   BoostRect m_rect;
   double m_area;

--- a/generator/regions/region_base.cpp
+++ b/generator/regions/region_base.cpp
@@ -63,5 +63,10 @@ boost::optional<std::string> RegionWithData::GetIsoCode() const
 {
   return m_regionData.GetIsoCodeAlpha2();
 }
+
+boost::optional<base::GeoObjectId> RegionWithData::GetLabelOsmId() const
+{
+  return m_regionData.GetLabelOsmId();
+}
 }  // namespace regions
 }  // namespace generator

--- a/generator/regions/region_base.hpp
+++ b/generator/regions/region_base.hpp
@@ -50,6 +50,8 @@ public:
   base::GeoObjectId GetId() const;
   boost::optional<std::string> GetIsoCode() const;
 
+  boost::optional<base::GeoObjectId> GetLabelOsmId() const;
+
   AdminLevel GetAdminLevel() const { return m_regionData.GetAdminLevel(); }
   PlaceType GetPlaceType() const { return m_regionData.GetPlaceType(); }
 

--- a/generator/regions/region_info.cpp
+++ b/generator/regions/region_info.cpp
@@ -115,6 +115,16 @@ PlaceType BaseRegionDataProxy<T>::GetPlaceType() const
 }
 
 template <typename T>
+boost::optional<base::GeoObjectId> BaseRegionDataProxy<T>::GetLabelOsmId() const
+{
+  auto const & labelId = GetMapRegionData().at(m_osmId).m_labelOsmId;
+  if (!labelId.GetEncodedId())
+    return {};
+
+  return labelId;
+}
+
+template <typename T>
 boost::optional<std::string> BaseRegionDataProxy<T>::GetIsoCodeAlpha2() const
 {
   auto const & codesMap = GetMapIsoCode();

--- a/generator/regions/region_info.hpp
+++ b/generator/regions/region_info.hpp
@@ -69,6 +69,7 @@ public:
   base::GeoObjectId const & GetOsmId() const;
   AdminLevel GetAdminLevel() const;
   PlaceType GetPlaceType() const;
+  boost::optional<base::GeoObjectId> GetLabelOsmId() const;
 
   boost::optional<std::string> GetIsoCodeAlpha2() const;
   boost::optional<std::string> GetIsoCodeAlpha3() const;

--- a/generator/regions/regions.cpp
+++ b/generator/regions/regions.cpp
@@ -62,10 +62,12 @@ public:
     auto timer = base::Timer{};
     Transliteration::Instance().Init(GetPlatform().ResourcesDir());
 
-    RegionsBuilder::Regions regions = ReadAndFixData();
-    RegionsBuilder builder{std::move(regions), threadsCount};
-    GenerateRegions(builder);
+    RegionsBuilder::Regions regions;
+    PlacePointsMap placePointsMap;
+    std::tie(regions, placePointsMap) = ReadDatasetFromTmpMwm(m_pathInRegionsTmpMwm, m_regionsInfoCollector);
+    RegionsBuilder builder{std::move(regions), std::move(placePointsMap), threadsCount};
 
+    GenerateRegions(builder);
     LOG(LINFO, ("Finish generating regions.", timer.ElapsedSeconds(), "seconds."));
   }
 
@@ -220,16 +222,6 @@ private:
 
     ForEachFromDatRawFormat(tmpMwmFilename, toDo);
     return std::make_tuple(std::move(regions), std::move(placePointsMap));
-  }
-
-  RegionsBuilder::Regions ReadAndFixData()
-  {
-    RegionsBuilder::Regions regions;
-    PlacePointsMap placePointsMap;
-    std::tie(regions, placePointsMap) =
-        ReadDatasetFromTmpMwm(m_pathInRegionsTmpMwm, m_regionsInfoCollector);
-    FixRegionsWithPlacePointApproximation(placePointsMap, regions);
-    return regions;
   }
 
   void RepackTmpMwm()

--- a/generator/regions/regions_builder.hpp
+++ b/generator/regions/regions_builder.hpp
@@ -23,7 +23,8 @@ public:
   using StringsList = std::vector<std::string>;
   using CountryFn = std::function<void(std::string const &, Node::PtrList const &)>;
 
-  explicit RegionsBuilder(Regions && regions, size_t threadsCount = 1);
+  explicit RegionsBuilder(Regions && regions, PlacePointsMap && placePointsMap,
+                          size_t threadsCount = 1);
 
   Regions const & GetCountriesOuters() const;
   StringsList GetCountryNames() const;
@@ -32,6 +33,7 @@ public:
 private:
   static constexpr double kAreaRelativeErrorPercent = 0.1;
 
+  void MoveLabelPlacePoints(PlacePointsMap & placePointsMap, Regions & regions);
   Regions FormRegionsInAreaOrder(Regions && regions);
   Regions ExtractCountriesOuters(Regions & regions);
   Node::PtrList BuildCountryRegionTrees(Regions const & outers,


### PR DESCRIPTION
Насыщение данных: используются label node для регионов для имени, для определения place-типа, центра региона.

Тесты для них пока закомментарены в PR #11073, что бы не дублировать тестовую инфраструктуру регионов.