### PR TITLE
[search] StreetTokensFilter: do not emit delayed token for incomplete street synonym.

### DIFF
--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -361,7 +361,9 @@ void StreetTokensFilter::Put(strings::UniString const & token, bool isPrefix, si
       m_delayedTag = tag;
       return;
     }
-    if (m_numSynonyms == 2)
+
+    // Do not emit delayed token for incomplete street synonym.
+    if ((!isPrefix || IsStreetSynonym(token)) && m_numSynonyms == 2)
       EmitToken(m_delayedToken, m_delayedTag);
   }
   EmitToken(token, tag);

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -1940,5 +1940,29 @@ UNIT_CLASS_TEST(ProcessorTest, ExactMatchTest)
     TEST(results[1].GetRankingInfo().m_exactMatch, ());
   }
 }
+
+UNIT_CLASS_TEST(ProcessorTest, StreetSynonymPrefix)
+{
+  string const countryName = "Wonderland";
+
+  // Est is a prefix of "estrada".
+  TestStreet street(vector<m2::PointD>{m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0)},
+                    "Boulevard Maloney Est", "en");
+
+  TestPOI house(m2::PointD(1.0, 1.0), "", "en");
+  house.SetHouseNumber("3");
+  house.SetStreetName(street.GetName("en"));
+
+  auto countryId = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
+    builder.Add(street);
+    builder.Add(house);
+  });
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 2.0)));
+  {
+    Rules rules = {ExactMatch(countryId, house)};
+    TEST(ResultsMatch("3 Boulevard Maloney Est", rules), ());
+  }
+}
 }  // namespace
 }  // namespace search


### PR DESCRIPTION
Предположим что у нас есть фича с названием "улица нахимова", сейчас при построении индекса мы пропустим её через StreetTokensFilter и заиндексируем только за "нахимова".
При этом при поиска по запросу "улица на" мы посчитаем что "на" это префикс от "набережная" и поэтому заэмитим в StreetTokensFilter delayed token "улица", за которым ничего не заиндексировано (т.к. при построении индекса мы этот токен выкинули).
В этом реквесте отменяется эмит отложенного токена для префикса, не являющегося полным синонимом улицы.