### PR TITLE
[routing] Support hwtag-nocar hwtag-yescar.

### DIFF
--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -65,12 +65,14 @@ namespace
     TEST(params.IsTypeExist(GetType({"psurface", value})), ("Surface:", surface, "Smoothness:", smoothness, "Grade:", grade, "Expected:", value, "Got:", psurface));
   }
 
-  void GetFeatureParams(char const * arr[][2], size_t count, FeatureParams & params)
+FeatureParams GetFeatureParams(char const * arr[][2], size_t count)
   {
     OsmElement e;
     FillXmlElement(arr, count, &e);
+    FeatureParams params;
 
     ftype::GetNameAndType(&e, params);
+    return params;
   }
 }  // namespace
 
@@ -83,8 +85,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_SkipDummy)
     { "ref", "E51" }
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST_EQUAL(params.m_types[0], GetType(arr[1]), ());
@@ -135,8 +136,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Combined)
     { "name", "Гимназия 15" }
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType(arr[3])), ());
@@ -161,8 +161,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Address)
     { "uir_adr:ADRESA_KOD", "21717036" }
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"building", "address"})), ());
@@ -184,8 +183,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_PlaceState)
     { "ref", "CA" }
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "state", "USA"})), ());
@@ -286,8 +284,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "yes" }
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"amenity", "atm"})), ());
@@ -301,8 +298,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "no" }
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), ());
@@ -318,8 +314,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "6"})), ());
@@ -332,8 +327,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -348,8 +342,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), ());
@@ -365,8 +358,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Route)
       { "ref", "I 95" }
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -383,8 +375,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "2" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "motorway", "bridge"})), ());
@@ -398,8 +389,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "-1" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "trunk", "tunnel"})), ());
@@ -412,8 +402,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "bridge", "yes" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "secondary", "bridge"})), ());
@@ -426,8 +415,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "tunnel", "yes" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "primary", "tunnel"})), ());
@@ -439,8 +427,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "highway", "living_street" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -456,8 +443,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Amenity)
       { "fuel", "wood" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -478,8 +464,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
       { "oneway", "true" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -496,8 +481,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"oneway:bicycle", "no"},
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 6, (params));
     TEST(params.IsTypeExist(GetType(arr[1])), ());
@@ -513,8 +497,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"foot", "yes"}, {"cycleway", "lane"}, {"highway", "primary"},
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType(arr[2])), ());
@@ -554,8 +537,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Ferry)
     { "route", "ferry" },
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 3, (params));
 
@@ -584,8 +566,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"highway", "secondary"},
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(!params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -598,8 +579,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"motorcar", "yes"},
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(!params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -612,8 +592,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"motor_vehicle", "no"},
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -630,8 +609,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Boundary)
     { "boundary", "administrative" },
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType({"boundary", "administrative", "2"})), ());
@@ -652,8 +630,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Dibrugarh)
     { "website", "http://www.hotelvishal.in" },
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), (params));
@@ -673,8 +650,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "subway" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "moscow"})), (params));
@@ -689,8 +665,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "route", "subway" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "newyork"})), (params));
@@ -706,8 +681,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "station", "light_rail" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "light_rail"})), (params));
@@ -725,8 +699,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "monorail" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "monorail"})), (params));
@@ -741,8 +714,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "railway", "station" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "london"})), (params));
@@ -756,8 +728,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "building", "hospital" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -769,8 +740,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "amenity", "hospital" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -825,8 +795,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Moscow)
       { "wikipedia", "ru:Москва" },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), (params));
@@ -847,8 +816,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Translations)
     { "population", "2243833" }
   };
 
-  FeatureParams params;
-  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -870,8 +838,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Cuisine)
       { "cuisine", "indian ; steak,coffee  shop " },
     };
 
-    FeatureParams params;
-    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
+    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType({"cuisine", "indian"})), (params));

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -83,11 +83,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_SkipDummy)
     { "ref", "E51" }
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST_EQUAL(params.m_types[0], GetType(arr[1]), ());
@@ -138,11 +135,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Combined)
     { "name", "Гимназия 15" }
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType(arr[3])), ());
@@ -167,11 +161,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Address)
     { "uir_adr:ADRESA_KOD", "21717036" }
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"building", "address"})), ());
@@ -193,11 +184,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_PlaceState)
     { "ref", "CA" }
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "state", "USA"})), ());
@@ -271,7 +259,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
 
     TagReplacer tagReplacer(GetPlatform().ResourcesDir() + REPLACED_TAGS_FILE);
     tagReplacer(e);
-    
+
     FeatureParams params;
     ftype::GetNameAndType(&e, params);
 
@@ -298,11 +286,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "yes" }
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"amenity", "atm"})), ());
@@ -316,11 +301,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "no" }
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), ());
@@ -336,11 +318,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "6"})), ());
@@ -353,11 +332,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -372,11 +348,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), ());
@@ -392,11 +365,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Route)
       { "ref", "I 95" }
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -413,11 +383,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "2" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "motorway", "bridge"})), ());
@@ -431,11 +398,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "-1" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "trunk", "tunnel"})), ());
@@ -448,11 +412,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "bridge", "yes" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "secondary", "bridge"})), ());
@@ -465,11 +426,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "tunnel", "yes" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "primary", "tunnel"})), ());
@@ -481,11 +439,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "highway", "living_street" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -501,11 +456,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Amenity)
       { "fuel", "wood" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -526,11 +478,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
       { "oneway", "true" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -547,11 +496,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"oneway:bicycle", "no"},
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 6, (params));
     TEST(params.IsTypeExist(GetType(arr[1])), ());
@@ -567,11 +513,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"foot", "yes"}, {"cycleway", "lane"}, {"highway", "primary"},
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType(arr[2])), ());
@@ -611,11 +554,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Ferry)
     { "route", "ferry" },
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 3, (params));
 
@@ -653,7 +593,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
   }
 
   {
-    char const* arr[][2] = {
+    char const * arr[][2] = {
         {"highway", "cycleway"},
         {"motorcar", "yes"},
     };
@@ -690,11 +630,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Boundary)
     { "boundary", "administrative" },
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType({"boundary", "administrative", "2"})), ());
@@ -715,11 +652,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Dibrugarh)
     { "website", "http://www.hotelvishal.in" },
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), (params));
@@ -739,11 +673,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "subway" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "moscow"})), (params));
@@ -758,11 +689,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "route", "subway" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "newyork"})), (params));
@@ -778,11 +706,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "station", "light_rail" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "light_rail"})), (params));
@@ -800,11 +725,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "monorail" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "monorail"})), (params));
@@ -819,11 +741,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "railway", "station" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "london"})), (params));
@@ -837,11 +756,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "building", "hospital" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -853,11 +769,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "amenity", "hospital" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -912,11 +825,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Moscow)
       { "wikipedia", "ru:Москва" },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), (params));
@@ -937,11 +847,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Translations)
     { "population", "2243833" }
   };
 
-  OsmElement e;
-  FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
   FeatureParams params;
-  ftype::GetNameAndType(&e, params);
+  GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -963,11 +870,8 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Cuisine)
       { "cuisine", "indian ; steak,coffee  shop " },
     };
 
-    OsmElement e;
-    FillXmlElement(arr, ARRAY_SIZE(arr), &e);
-
     FeatureParams params;
-    ftype::GetNameAndType(&e, params);
+    GetFeatureParams(arr, ARRAY_SIZE(arr), params);
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType({"cuisine", "indian"})), (params));

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -471,4 +471,27 @@ namespace
       MercatorBounds::FromLatLon(55.991845, 37.215312), 799.0);
   }
 */
+
+  // Test that fake segments are not built from start to roads with hwtag=nocar for car routing.
+  UNIT_TEST(SpainBilbaoAirportNoCarTest)
+  {
+    TRouteResult routeResult =
+        integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                    MercatorBounds::FromLatLon(43.29969, -2.91312), {0., 0.},
+                                    MercatorBounds::FromLatLon(43.29904, -2.9108));
+    TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
+
+    CHECK(routeResult.first, ());
+    Route const & route = *(routeResult.first);
+    std::vector<RouteSegment> const & routeSegments = route.GetRouteSegments();
+    TEST_GREATER(routeSegments.size(), 2, ());
+
+    // Note. routeSegments[0] is a start segment(point). routeSegments[1] is a fake segment
+    // which goes from the route start to a segment of the road graph.
+    // routeSegments[1].GetDistFromBeginningMeters() is the length of the first fake segment.
+    // Start point is located near a road with hwtag=no.
+    // So if routeSegments[1].GetDistFromBeginningMeters() is long enough the segment
+    // with hwtag=no is no used.
+    TEST_GREATER(routeSegments[1].GetDistFromBeginningMeters(), 20.0, ());
+  }
 }  // namespace

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -413,8 +413,8 @@ void BicycleModel::Init()
 {
   initializer_list<char const *> hwtagYesBicycle = {"hwtag", "yesbicycle"};
 
-  m_yesBicycleType = classif().GetTypeByPath(hwtagYesBicycle);
   m_noBicycleType = classif().GetTypeByPath({"hwtag", "nobicycle"});
+  m_yesBicycleType = classif().GetTypeByPath(hwtagYesBicycle);
   m_bidirBicycleType = classif().GetTypeByPath({"hwtag", "bidir_bicycle"});
 
   vector<AdditionalRoadTags> const additionalTags = {

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -2,6 +2,7 @@
 #include "routing_common/car_model_coefs.hpp"
 
 #include "indexer/classificator.hpp"
+#include "indexer/feature.hpp"
 
 #include "base/macros.hpp"
 
@@ -199,20 +200,34 @@ CarModel::CarModel()
   : VehicleModel(classif(), kCarOptionsDefault, kCarSurface,
                  {kGlobalHighwayBasedMeanSpeeds, kGlobalHighwayBasedFactors})
 {
-  InitAdditionalRoadTypes();
+  Init();
 }
 
 CarModel::CarModel(VehicleModel::LimitsInitList const & roadLimits, HighwayBasedInfo const & info)
   : VehicleModel(classif(), roadLimits, kCarSurface, info)
 {
-  InitAdditionalRoadTypes();
+  Init();
 }
 
 double CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
-void CarModel::InitAdditionalRoadTypes()
+void CarModel::Init()
 {
+  m_noCarType = classif().GetTypeByPath({"hwtag", "nocar"});
+  m_yesCarType = classif().GetTypeByPath({"hwtag", "yescar"});
+
   SetAdditionalRoadTypes(classif(), kAdditionalTags);
+}
+
+VehicleModelInterface::RoadAvailability CarModel::GetRoadAvailability(feature::TypesHolder const & types) const
+{
+  if (types.Has(m_yesCarType))
+    return RoadAvailability::Available;
+
+  if (types.Has(m_noCarType))
+    return RoadAvailability::NotAvailable;
+
+  return RoadAvailability::Unknown;
 }
 
 // static

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -21,8 +21,14 @@ public:
   static std::vector<AdditionalRoadTags> const & GetAdditionalTags();
   static VehicleModel::SurfaceInitList const & GetSurfaces();
 
+protected:
+  RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;
+
 private:
-  void InitAdditionalRoadTypes();
+  void Init();
+
+  uint32_t m_noCarType = 0;
+  uint32_t m_yesCarType = 0;
 };
 
 class CarModelFactory : public VehicleModelFactory

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -21,6 +21,9 @@ public:
   static std::vector<AdditionalRoadTags> const & GetAdditionalTags();
   static VehicleModel::SurfaceInitList const & GetSurfaces();
 
+  uint32_t GetNoCarTypeForTesting() const { return m_noCarType; }
+  uint32_t GetYesCarTypeForTesting() const { return m_yesCarType; }
+
 protected:
   RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const override;
 


### PR DESCRIPTION
В car_model у нас фичи с тагом hwtag-nocar рассматривались как дороги. Этот PR делает поддержку hwtag-nocar, hwtag-yescar как в вело и пешей модели.

@gmoryes PTAL