### PR TITLE
[eye] Appending additional counters without any version increasing an…

### DIFF
--- a/metrics/eye_info.hpp
+++ b/metrics/eye_info.hpp
@@ -65,7 +65,7 @@ public:
     std::vector<R> loader;
     visitor(loader, "counters");
     CHECK_LESS_OR_EQUAL(loader.size(), m_counters.size(), ());
-    std::copy_n(loader.cbegin(), m_counters.size(), m_counters.begin());
+    std::copy(loader.cbegin(), loader.cend(), m_counters.begin());
   }
 
   template <typename Visitor>


### PR DESCRIPTION
…d migration is supported.

Решил выбрать этот вариант, хоть он вам и не понравился. 
Ниже опишу причины и соображения.
Предложенные способы решения проблемы:
1. Специальный режим десериализатора который будет десериализовывать массив меньшего размера, чем массив назначения.  
2. Специальный метод десериализатора, который будет десериализовывать массив меньшего размера, чем массив назначения.
3. Специальные визиторы для той структуры данных, для которых нужно необычное поведение.
4. Повысить версию данных и мигрировать.
5. Начать сохранять маппинг ключ-значение.

Первый вариант, на мой взгляд, не подходит потому, что для его реализации потребуется изменить класс, который используется в разных местах и лежит в либе coding. При этом, сейчас этот класс довольно простой и десериализует всегда по одинаковым правилам, а с появлением спец режима поведение будет усложнено.

Второй вариант, на мой взгляд, не подходит потому, что для его реализации тоже потребуется изменить общий класс из либы coding. И при реализации пользователи лишатся возможности десериализовывать опциональные массивы, а также почти полный копипаст обычного метода десериализации массивов.

Третий вариант, на мой взгляд подходит, потому, что не влияет на общие классы, не требует миграции сейчас и в будущем и, при соблюдении правила добавления новых значений перечислений в конец, довольно надежен.

Четвертый вариант довольно надежный, но самый трудозатратный, ведь мигрировать нужно будет при каждом изменении внутренних структур. На мой взгляд он не подходит, потому, что нам часто для Ока требуется добавлять новые метрики, а затрачивать на такую операцию много времени нерационально. При этом, во время сложной операции миграции могут возникать дополнительные ошибки.

Основным плюсом пятого варианта является то, что пары ключ-значение могут сохраняться в любом относительном порядке и любом количестве. На мой взгляд, это хороший вариант, но он не подходит, потому, что усложняет внутренние структуры, увеличивает время сериализации/десериализации, и время доступа к ячейкам. При этом, для его использования, потребуется провести миграцию. Учитывая то, что данные у нас всегда сохраняются автоматически, а порядок определяется расположением значений перечислений, возможность перемешивания пар ключ-значение нам не требуется.