### PR TITLE
[generator:streets] Fix Line::Concatenate

### DIFF
--- a/generator/streets/street_geometry.hpp
+++ b/generator/streets/street_geometry.hpp
@@ -68,8 +68,11 @@ private:
 
   struct Line
   {
+    static constexpr double kCoordEqualityEps = 1e-5;
+
     // Try to append |line| to front or to back of |this| line.
-    bool Concatenate(Line && line);
+    bool Concatenate(Line && other);
+    void Reverse();
     // The function does not check addition of line segment to ring line.
     // Line configuration depends on addition sequences.
     // |segment| will not modify if the function returns false.


### PR DESCRIPTION
Фикс HighwayGeometry::Line::Concatenate для колец и развилок, когда две ломанные частично склеивается. Например, склейка [p4, p2] и [p1, p2] [p2, p3] может дать две непустые ломанные [p4, p2] [p2, p1] и [p2, p3] (сперва склейка [p4, p2] и [p1, p2] по p2, и не возможность склеить [p2, p3] с [p4, p2] [p2, p1]). Ожидается, что, либо вся линия добавится в другую, любо они не изменяются.

