### PR TITLE
[search] Match street synonyms with misprints.

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -203,10 +203,9 @@ struct FeatureNameInserter
 
     if (m_hasStreetType)
     {
-      search::StreetTokensFilter filter([&](strings::UniString const & token, size_t /* tag */)
-                                        {
-                                          AddToken(lang, token);
-                                        });
+      search::StreetTokensFilter filter(
+          [&](strings::UniString const & token, size_t /* tag */) { AddToken(lang, token); },
+          false /* withMisprints */);
       for (auto const & token : tokens)
         filter.Put(token, false /* isPrefix */, 0 /* tag */);
 

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -103,8 +103,9 @@ class StreetTokensFilter
 public:
   using Callback = std::function<void(strings::UniString const & token, size_t tag)>;
 
-  template <typename TC>
-  explicit StreetTokensFilter(TC && callback) : m_callback(std::forward<TC>(callback))
+  template <typename C>
+  StreetTokensFilter(C && callback, bool withMisprints)
+    : m_callback(std::forward<C>(callback)), m_withMisprints(withMisprints)
   {
   }
 
@@ -125,5 +126,6 @@ private:
   size_t m_numSynonyms = 0;
 
   Callback m_callback;
+  bool m_withMisprints = false;
 };
 }  // namespace search


### PR DESCRIPTION
Добавление опечаточника замедляет StreetsMatcher, но относительно общего времени поиска это не критично.
Раньше StreetsMatcher::Go отнимал примерно 0.1% от общего времени поиска, теперь примерно 0.5%.