### PR TITLE
[search] Remove cllon from street synonyms.

### DIFF
--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -268,7 +268,7 @@ public:
       "allee", "al", "brücke", "br", "chaussee", "gasse", "gr", "pfad", "straße", "str", "weg", "platz",
 
       // Español - Spanish
-      "avenida", "avd", "avda", "bulevar", "bulev", "calle", "calleja", "cllja", "callejón", "callej", "cjon", "cllon", "callejuela", "cjla", "callizo", "cllzo", "calzada", "czada", "costera", "coste", "plza", "pza", "plazoleta", "pzta", "plazuela", "plzla", "tránsito", "trans", "transversal", "trval", "trasera", "tras", "travesía", "trva",
+      "avenida", "avd", "avda", "bulevar", "bulev", "calle", "calleja", "cllja", "callejón", "callej", "cjon", "callejuela", "cjla", "callizo", "cllzo", "calzada", "czada", "costera", "coste", "plza", "pza", "plazoleta", "pzta", "plazuela", "plzla", "tránsito", "trans", "transversal", "trval", "trasera", "tras", "travesía", "trva",
 
       // Français - French
       "rue", "avenue", "carré", "cercle", "route", "boulevard", "drive", "autoroute", "lane", "chemin",


### PR DESCRIPTION
1. Поиск в интернете на испанских сайтах не указывает на то, что это часто употребимый синоним для улицы.
2. Я посмотрела имена всех фичей в 15 произвольных испаноговорящих mwm (Испания, Аргентина, Чили, Боливия), нашла там суммарно ровно 0 фичей с cllon в имени.
3. Расстояние всего в 1 букву от Colón (Колумб), имя которого часто встречается в топонимах, поэтому cllon может быть значимым токеном, а мы его сейчас часто игнорируем.