### PR TITLE
[generator]Json locale format

### DIFF
--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -77,17 +77,18 @@ json_t * GetJSONOptionalField(json_t * root, std::string const & field);
 json_t * GetJSONOptionalField(json_t * root, char const * field);
 json_t const * GetJSONOptionalField(json_t const * root, char const * field);
 
-template <class First, class... Paths>
-inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, First path, Paths... paths)
+template <class First>
+inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, First && path)
 {
-  json_t const * newRoot = GetJSONObligatoryFieldByPath(root, path);
-  return GetJSONObligatoryFieldByPath(newRoot, paths...);
+  return GetJSONObligatoryField(root, std::forward<First>(path));
 }
 
-template <>
-inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, char const * path)
+template <class First, class... Paths>
+inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, First && path,
+                                                   Paths &&... paths)
 {
-  return GetJSONObligatoryField(root, path);
+  json_t const * newRoot = GetJSONObligatoryFieldByPath(root, std::forward<First>(path));
+  return GetJSONObligatoryFieldByPath(newRoot, std::forward<Paths>(paths)...);
 }
 
 bool JSONIsNull(json_t const * root);

--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -76,6 +76,20 @@ json_t const * GetJSONObligatoryField(json_t const * root, char const * field);
 json_t * GetJSONOptionalField(json_t * root, std::string const & field);
 json_t * GetJSONOptionalField(json_t * root, char const * field);
 json_t const * GetJSONOptionalField(json_t const * root, char const * field);
+
+template <class First, class... Paths>
+inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, First path, Paths... paths)
+{
+  json_t const * newRoot = GetJSONObligatoryFieldByPath(root, path);
+  return GetJSONObligatoryFieldByPath(newRoot, paths...);
+}
+
+template <>
+inline json_t const * GetJSONObligatoryFieldByPath(json_t const * root, char const * path)
+{
+  return GetJSONObligatoryField(root, path);
+}
+
 bool JSONIsNull(json_t const * root);
 }  // namespace base
 

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -64,14 +64,6 @@ void ReadString(TSource & src, std::string & s)
 class StringUtf8Multilang
 {
 public:
-  struct Hash
-  {
-    std::size_t operator()(StringUtf8Multilang const & s) const noexcept
-    {
-      return std::hash<std::string>{}(s.m_s);
-    }
-  };
-
   struct Lang
   {
     /// OSM language code (e.g. for name:en it's "en" part).

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -63,6 +64,14 @@ void ReadString(TSource & src, std::string & s)
 class StringUtf8Multilang
 {
 public:
+  struct Hash
+  {
+    std::size_t operator()(StringUtf8Multilang const & s) const noexcept
+    {
+      return std::hash<std::string>{}(s.m_s);
+    }
+  };
+
   struct Lang
   {
     /// OSM language code (e.g. for name:en it's "en" part).

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -150,6 +150,7 @@ public:
   FeatureParams const & GetParams() const { return m_params; }
   FeatureParams & GetParams() { return m_params; }
   std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
+  StringUtf8Multilang GetMultilangName() const { return m_params.name; }
   uint8_t GetRank() const { return m_params.rank; }
   bool FormatFullAddress(std::string & res) const;
   AddressData const & GetAddressData() const { return m_params.GetAddressData(); }
@@ -175,7 +176,8 @@ public:
 
   bool PreSerializeAndRemoveUselessNamesForIntermediate();
   void SerializeForIntermediate(Buffer & data) const;
-  void SerializeBorderForIntermediate(serial::GeometryCodingParams const & params, Buffer & data) const;
+  void SerializeBorderForIntermediate(serial::GeometryCodingParams const & params,
+                                      Buffer & data) const;
   void DeserializeFromIntermediate(Buffer & data);
 
   bool PreSerializeAndRemoveUselessNamesForMwm(SupportingData const & data);
@@ -201,13 +203,13 @@ public:
   void SetCoastCell(int64_t iCell) { m_coastCell = iCell; }
   bool IsCoastCell() const { return (m_coastCell != -1); }
 
- protected:
+protected:
   template <class ToDo>
   class ToDoWrapper
   {
   public:
     ToDoWrapper(ToDo && toDo) : m_toDo(std::forward<ToDo>(toDo)) {}
-    bool operator() (m2::PointD const & p) { return m_toDo(p); }
+    bool operator()(m2::PointD const & p) { return m_toDo(p); }
     void EndRegion() {}
 
   private:
@@ -218,9 +220,9 @@ public:
   // - point in point-feature
   // - origin point of text [future] in line-feature
   // - origin point of text or symbol in area-feature
-  m2::PointD m_center;    // Check  HEADER_HAS_POINT
+  m2::PointD m_center;  // Check  HEADER_HAS_POINT
   // List of geometry polygons.
-  Geometry m_polygons; // Check HEADER_IS_AREA
+  Geometry m_polygons;  // Check HEADER_IS_AREA
   m2::RectD m_limitRect;
   std::vector<base::GeoObjectId> m_osmIds;
   FeatureParams m_params;
@@ -264,7 +266,7 @@ void ForEachFromDatRawFormat(std::string const & filename, ToDo && toDo)
 /// Parallel process features in .dat file.
 template <class ToDo>
 void ForEachParallelFromDatRawFormat(size_t threadsCount, std::string const & filename,
-    ToDo && toDo)
+                                     ToDo && toDo)
 {
   CHECK_GREATER_OR_EQUAL(threadsCount, 1, ());
   if (threadsCount == 1)

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -150,7 +150,7 @@ public:
   FeatureParams const & GetParams() const { return m_params; }
   FeatureParams & GetParams() { return m_params; }
   std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
-  StringUtf8Multilang GetMultilangName() const { return m_params.name; }
+  StringUtf8Multilang const & GetMultilangName() const { return m_params.name; }
   uint8_t GetRank() const { return m_params.rank; }
   bool FormatFullAddress(std::string & res) const;
   AddressData const & GetAddressData() const { return m_params.GetAddressData(); }

--- a/generator/generator_tests/translation_test.cpp
+++ b/generator/generator_tests/translation_test.cpp
@@ -15,8 +15,7 @@ using namespace generator;
 // Transliteration tests ---------------------------------------------------------------------------
 using Translations = std::vector<std::pair<std::string, std::string>>;
 bool TestTransliteration(Translations const & translations,
-                         std::string const & expectedTransliteration,
-                         std::string const & lang)
+                         std::string const & expectedTransliteration, std::string const & lang)
 {
   StringUtf8Multilang name;
   for (auto const & langAndTranslation : translations)

--- a/generator/generator_tests/translation_test.cpp
+++ b/generator/generator_tests/translation_test.cpp
@@ -51,8 +51,8 @@ UNIT_TEST(Transliteration)
       {"sr", "Мичиген"},       {"ta", "மிச்சிகன்"},    {"th", "รัฐมิชิแกน"},   {"tl", "Misigan"},
       {"uk", "Мічиган"},       {"yi", "מישיגן"},     {"zh", "密歇根州"}};
 
-  TEST(TestTransliteration(scotlandTranslations, "Shotlandiya", "en"), ());
+  TEST(TestTransliteration(scotlandTranslations, "Scotland", "en"), ());
   TEST(TestTransliteration(michiganTranslations, "Michigan", "en"), ());
-  TEST(TestTransliteration(scotlandTranslations, "Shotlandiya", "ru"), ());
-  TEST(TestTransliteration(michiganTranslations, "Michigan", "ru"), ());
+  TEST(TestTransliteration(scotlandTranslations, "Шотландия", "ru"), ());
+  TEST(TestTransliteration(michiganTranslations, "Мичиган", "ru"), ());
 }

--- a/generator/geo_objects/geo_objects.cpp
+++ b/generator/geo_objects/geo_objects.cpp
@@ -101,7 +101,8 @@ base::JSONPtr MakeGeoObjectValueWithoutAddress(FeatureBuilder const & fb, JsonVa
 {
   auto jsonWithAddress = json.MakeDeepCopyJson();
   auto properties = json_object_get(jsonWithAddress.get(), "properties");
-  ToJSONObject(*properties, "name", fb.GetName());
+  Localizator localizator(*properties);
+  localizator.AddLocale("name", Localizator::EasyObjectWithTranslation(fb.GetMultilangName()));
   UpdateCoordinates(fb.GetKeyPoint(), jsonWithAddress);
   return jsonWithAddress;
 }

--- a/generator/geo_objects/geo_objects.cpp
+++ b/generator/geo_objects/geo_objects.cpp
@@ -46,8 +46,9 @@ using IndexReader = ReaderPtr<Reader>;
 
 bool HouseHasAddress(JsonValue const & json)
 {
-  auto && properties = base::GetJSONObligatoryField(json, "properties");
-  auto && address = base::GetJSONObligatoryField(properties, "address");
+  auto && address =
+      base::GetJSONObligatoryFieldByPath(json, "properties", "locales", "default", "address");
+
   auto && building = base::GetJSONOptionalField(address, "building");
   return building && !base::JSONIsNull(building);
 }
@@ -154,9 +155,8 @@ void FilterAddresslessByCountryAndRepackMwm(std::string const & pathInGeoObjects
     if (!regionKeyValue)
       return;
 
-    auto && properties = base::GetJSONObligatoryField(*regionKeyValue->second, "properties");
-    auto && address = base::GetJSONObligatoryField(properties, "address");
-    auto && country = base::GetJSONObligatoryField(address, "country");
+    auto && country = base::GetJSONObligatoryFieldByPath(
+        *regionKeyValue->second, "properties", "locales", "default", "address", "country");
     auto countryName = FromJSON<std::string>(country);
     auto pos = includeCountries.find(countryName);
     if (pos != std::string::npos)

--- a/generator/regions/region.cpp
+++ b/generator/regions/region.cpp
@@ -60,13 +60,11 @@ Region::Region(PlacePoint const & place)
 
 std::string Region::GetTranslatedOrTransliteratedName(LanguageCode languageCode) const
 {
-  if (m_placeLabel)
-  {
-    std::string const & name = m_placeLabel->GetTranslatedOrTransliteratedName(languageCode);
-    if (!name.empty())
-      return name;
-  }
-  return RegionWithName::GetTranslatedOrTransliteratedName(languageCode);
+  if (!m_placeLabel)
+    return RegionWithName::GetTranslatedOrTransliteratedName(languageCode);
+
+  std::string const & name = m_placeLabel->GetTranslatedOrTransliteratedName(languageCode);
+  return name.empty() ? RegionWithName::GetTranslatedOrTransliteratedName(languageCode) : name;
 }
 
 std::string Region::GetName(int8_t lang) const

--- a/generator/regions/region.cpp
+++ b/generator/regions/region.cpp
@@ -61,8 +61,11 @@ Region::Region(PlacePoint const & place)
 std::string Region::GetTranslatedOrTransliteratedName(LanguageCode languageCode) const
 {
   if (m_placeLabel)
-    return m_placeLabel->GetTranslatedOrTransliteratedName(languageCode);
-
+  {
+    std::string const & name = m_placeLabel->GetTranslatedOrTransliteratedName(languageCode);
+    if (!name.empty())
+      return name;
+  }
   return RegionWithName::GetTranslatedOrTransliteratedName(languageCode);
 }
 

--- a/generator/regions/regions.cpp
+++ b/generator/regions/regions.cpp
@@ -189,7 +189,7 @@ private:
 
     LOG(LINFO, ("Country regions of", *country, "has built:", countryRegionsCount, "total regions.",
                 countryObjectCount, "objects."));
-  }  //
+  }
 
   std::tuple<RegionsBuilder::Regions, PlacePointsMap> ReadDatasetFromTmpMwm(
       std::string const & tmpMwmFilename, RegionInfo & collector)

--- a/generator/regions/regions.cpp
+++ b/generator/regions/regions.cpp
@@ -102,7 +102,9 @@ private:
     ToJSONArray(*coordinates, center.m_lat);
     ToJSONObject(*geometry, "coordinates", coordinates);
 
-    Localizator localizator;
+    auto properties = base::NewJSONObject();
+
+    Localizator localizator(*properties);
     boost::optional<std::string> dref;
 
     for (auto const & p : path)
@@ -128,12 +130,7 @@ private:
     }
 
     localizator.AddLocale("name", main);
-
-    auto properties = base::NewJSONObject();
-    auto locales = localizator.BuildLocales();
-
     ToJSONObject(*properties, "rank", main.GetRank());
-    ToJSONObject(*properties, "locales", locales);
 
     if (dref)
       ToJSONObject(*properties, "dref", *dref);

--- a/generator/streets/streets_builder.cpp
+++ b/generator/streets/streets_builder.cpp
@@ -138,8 +138,8 @@ boost::optional<KeyValue> StreetsBuilder::FindStreetRegionOwner(m2::PointD const
                                                                 bool needLocality)
 {
   auto const isStreetAdministrator = [needLocality](KeyValue const & region) {
-    auto const && properties = base::GetJSONObligatoryField(*region.second, "properties");
-    auto const && address = base::GetJSONObligatoryField(properties, "address");
+    auto && address = base::GetJSONObligatoryFieldByPath(*region.second, "properties", "locales",
+                                                         "default", "address");
 
     if (base::GetJSONOptionalField(address, "suburb"))
       return false;
@@ -166,9 +166,9 @@ base::JSONPtr StreetsBuilder::MakeStreetValue(uint64_t regionId, JsonValue const
                                               m2::RectD const & bbox, m2::PointD const & pinPoint)
 {
   auto streetObject = base::NewJSONObject();
+  auto && regionAddress = base::GetJSONObligatoryFieldByPath(regionObject, "properties", "locales",
+                                                             "default", "address");
 
-  auto const && regionProperties = base::GetJSONObligatoryField(regionObject, "properties");
-  auto const && regionAddress = base::GetJSONObligatoryField(regionProperties, "address");
   auto address = base::JSONPtr{json_deep_copy(const_cast<json_t *>(regionAddress))};
   ToJSONObject(*address, "street", streetName);
 

--- a/generator/streets/streets_builder.hpp
+++ b/generator/streets/streets_builder.hpp
@@ -41,8 +41,12 @@ public:
   static bool IsStreet(feature::FeatureBuilder const & fb);
 
 private:
-  using RegionStreets =
-      std::unordered_map<StringUtf8Multilang, StreetGeometry, StringUtf8Multilang::Hash>;
+  struct Street
+  {
+    StringUtf8Multilang m_name;
+    StreetGeometry m_geometry;
+  };
+  using RegionStreets = std::unordered_map<std::string, Street>;
 
   void SaveRegionStreetsKv(std::ostream & streamStreetsKv, uint64_t regionId,
                            RegionStreets const & streets);
@@ -51,10 +55,12 @@ private:
   void AddStreetHighway(feature::FeatureBuilder & fb);
   void AddStreetArea(feature::FeatureBuilder & fb);
   void AddStreetPoint(feature::FeatureBuilder & fb);
-  void AddStreetBinding(StringUtf8Multilang && streetName, feature::FeatureBuilder & fb);
+  void AddStreetBinding(std::string && streetName, feature::FeatureBuilder & fb,
+                        StringUtf8Multilang && multiLangName);
   boost::optional<KeyValue> FindStreetRegionOwner(m2::PointD const & point,
                                                   bool needLocality = false);
-  StreetGeometry & InsertStreet(uint64_t regionId, StringUtf8Multilang && streetName);
+  Street & InsertStreet(uint64_t regionId, std::string && streetName,
+                        StringUtf8Multilang && multilangName);
   base::JSONPtr MakeStreetValue(uint64_t regionId, JsonValue const & regionObject,
                                 const StringUtf8Multilang & streetName, m2::RectD const & bbox,
                                 m2::PointD const & pinPoint);

--- a/generator/streets/streets_builder.hpp
+++ b/generator/streets/streets_builder.hpp
@@ -56,11 +56,11 @@ private:
   void AddStreetArea(feature::FeatureBuilder & fb);
   void AddStreetPoint(feature::FeatureBuilder & fb);
   void AddStreetBinding(std::string && streetName, feature::FeatureBuilder & fb,
-                        StringUtf8Multilang && multiLangName);
+                        StringUtf8Multilang const & multiLangName);
   boost::optional<KeyValue> FindStreetRegionOwner(m2::PointD const & point,
                                                   bool needLocality = false);
   Street & InsertStreet(uint64_t regionId, std::string && streetName,
-                        StringUtf8Multilang && multilangName);
+                        StringUtf8Multilang const & multilangName);
   base::JSONPtr MakeStreetValue(uint64_t regionId, JsonValue const & regionObject,
                                 const StringUtf8Multilang & streetName, m2::RectD const & bbox,
                                 m2::PointD const & pinPoint);

--- a/generator/streets/streets_builder.hpp
+++ b/generator/streets/streets_builder.hpp
@@ -41,7 +41,8 @@ public:
   static bool IsStreet(feature::FeatureBuilder const & fb);
 
 private:
-  using RegionStreets = std::unordered_map<std::string, StreetGeometry>;
+  using RegionStreets =
+      std::unordered_map<StringUtf8Multilang, StreetGeometry, StringUtf8Multilang::Hash>;
 
   void SaveRegionStreetsKv(std::ostream & streamStreetsKv, uint64_t regionId,
                            RegionStreets const & streets);
@@ -50,12 +51,12 @@ private:
   void AddStreetHighway(feature::FeatureBuilder & fb);
   void AddStreetArea(feature::FeatureBuilder & fb);
   void AddStreetPoint(feature::FeatureBuilder & fb);
-  void AddStreetBinding(std::string && streetName, feature::FeatureBuilder & fb);
+  void AddStreetBinding(StringUtf8Multilang && streetName, feature::FeatureBuilder & fb);
   boost::optional<KeyValue> FindStreetRegionOwner(m2::PointD const & point,
                                                   bool needLocality = false);
-  StreetGeometry & InsertStreet(uint64_t regionId, std::string && streetName);
+  StreetGeometry & InsertStreet(uint64_t regionId, StringUtf8Multilang && streetName);
   base::JSONPtr MakeStreetValue(uint64_t regionId, JsonValue const & regionObject,
-                                std::string const & streetName, m2::RectD const & bbox,
+                                const StringUtf8Multilang & streetName, m2::RectD const & bbox,
                                 m2::PointD const & pinPoint);
   base::GeoObjectId NextOsmSurrogateId();
 

--- a/generator/translation.cpp
+++ b/generator/translation.cpp
@@ -37,7 +37,8 @@ std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
     return s;
 
   auto const fn = [&s](int8_t code, std::string const & name) {
-    if (strings::IsASCIIString(name)) {
+    if (strings::IsASCIIString(name))
+    {
       s = name;
       return base::ControlFlow::Break;
     }

--- a/generator/translation.cpp
+++ b/generator/translation.cpp
@@ -28,6 +28,9 @@ std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
   if (!s.empty())
     return s;
 
+  if (languageCode != StringUtf8Multilang::kEnglishCode)
+    return std::string();
+
   s = GetName(name, StringUtf8Multilang::kInternationalCode);
   if (!s.empty() && strings::IsASCIIString(s))
     return s;

--- a/generator/translation.cpp
+++ b/generator/translation.cpp
@@ -13,8 +13,8 @@ namespace
 using Languages = std::vector<std::string>;
 
 const std::unordered_map<generator::LanguageCode, Languages> kPreferredLanguagesForTransliterate = {
-    {StringUtf8Multilang::GetLangIndex("ru"), {"en" /*English*/, "ru" /*Русский*/}},
-    {StringUtf8Multilang::GetLangIndex("en"), {"en" /*English*/, "ru" /*Русский*/}}};
+    {StringUtf8Multilang::GetLangIndex("ru"), {"ru", "uk", "be"}},
+    {StringUtf8Multilang::GetLangIndex("en"), {"en", "da", "es", "fr"}}};
 
 Languages kLocalelanguages = {"en", "ru"};
 }  // namespace
@@ -32,7 +32,16 @@ std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
   if (!s.empty() && strings::IsASCIIString(s))
     return s;
 
+  s = GetName(name, StringUtf8Multilang::kDefaultCode);
+  if (!s.empty() && strings::IsASCIIString(s))
+    return s;
+
   auto const fn = [&s](int8_t code, std::string const & name) {
+    if (strings::IsASCIIString(name)) {
+      s = name;
+      return base::ControlFlow::Break;
+    }
+
     if (code != StringUtf8Multilang::kDefaultCode &&
         Transliteration::Instance().Transliterate(name, code, s) && strings::IsASCIIString(s))
     {

--- a/generator/translation.cpp
+++ b/generator/translation.cpp
@@ -25,7 +25,7 @@ std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
                                               LanguageCode languageCode)
 {
   std::string s = GetName(name, languageCode);
-  if (!s.empty() && strings::IsASCIIString(s))
+  if (!s.empty())
     return s;
 
   s = GetName(name, StringUtf8Multilang::kInternationalCode);

--- a/generator/translation.hpp
+++ b/generator/translation.hpp
@@ -19,7 +19,7 @@ inline std::string GetName(StringUtf8Multilang const & name, LanguageCode lang)
 }
 
 /// This function will take the following steps:
-/// 1. Return the |languageCode| name if it exists and is ASCII.
+/// 1. Return the |languageCode| name if it exists.
 /// 2. Try to get International name
 /// 3. Return transliteration trying to use kPreferredLanguagesForTransliterate
 /// first, then any, if it succeeds.
@@ -30,47 +30,88 @@ std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
 class Localizator
 {
 public:
-  struct LabelAndTranslition
+  template <class Object>
+  void AddLocale(std::string const & label, Object objectWithName,
+                 std::string const & level = std::string())
   {
-    std::string m_label;
-    std::string m_translation;
-  };
+    AddLocale(DefaultLocaleName(), level, objectWithName.GetName(), label);
 
-  template <class Fn>
-  void AddLocale(Fn && translator)
-  {
     auto const & languages = LocaleLanguages();
-    for (auto const & language : languages)
+    for (std::string const & language : languages)
     {
-      m_localesWithLanguages.emplace_back(LocaleWithLanguage{base::NewJSONObject(), language});
-      std::string label;
-      std::string translation;
-      LabelAndTranslition labelAndTranslation{translator(language)};
-      ToJSONObject(*m_localesWithLanguages.back().m_locale, labelAndTranslation.m_label,
-                   labelAndTranslation.m_translation);
+      std::string const & translation = objectWithName.GetTranslatedOrTransliteratedName(
+          StringUtf8Multilang::GetLangIndex(language));
+
+      if (translation.empty())
+        continue;
+
+      AddLocale(language, level, translation, label);
     }
+  }
+
+  template <class Verboser>
+  void AddVerbose(Verboser && verboser, std::string const & level)
+  {
+    json_t & locale = GetLocale(DefaultLocaleName());
+    json_t & node = GetLevel(level, locale);
+    verboser(node);
   }
 
   base::JSONPtr BuildLocales()
   {
     auto locales = base::NewJSONObject();
-    for (auto & localeWithLanguage : m_localesWithLanguages)
-      ToJSONObject(*locales, localeWithLanguage.m_language, localeWithLanguage.m_locale);
+    for (auto & localeWithLanguage : m_localesByLanguages)
+      ToJSONObject(*locales, localeWithLanguage.first, *localeWithLanguage.second);
 
-    m_localesWithLanguages.clear();
+    m_localesByLanguages.clear();
     return locales;
   }
 
 private:
-  struct LocaleWithLanguage
+  void AddLocale(std::string const & language, std::string const & level, std::string const & name,
+                 std::string const & label)
   {
-    base::JSONPtr m_locale;
-    std::string m_language;
-  };
-  using LocalesWithLanguages = std::vector<LocaleWithLanguage>;
+    json_t & locale = GetLocale(language);
 
+    if (!level.empty())
+    {
+      json_t & levelNode = GetLevel(level, locale);
+      ToJSONObject(levelNode, label, name);
+    }
+    else
+    {
+      ToJSONObject(locale, label, name);
+    }
+  }
+  static std::string const & DefaultLocaleName()
+  {
+    static std::string const kDefaultLocaleName = "default";
+    return kDefaultLocaleName;
+  }
+
+  json_t & GetLocale(std::string const & language)
+  {
+    if (m_localesByLanguages.find(language) == m_localesByLanguages.end())
+      m_localesByLanguages[language] = json_object();
+
+    return *m_localesByLanguages.at(language);
+  }
+
+  static json_t & GetLevel(std::string const & level, json_t & locale)
+  {
+    json_t * levelNode = base::GetJSONOptionalField(&locale, level);
+
+    if (!levelNode)
+    {
+      levelNode = json_object();
+      ToJSONObject(locale, level, *levelNode);
+    }
+
+    return *levelNode;
+  }
   std::vector<std::string> const & LocaleLanguages() const;
 
-  LocalesWithLanguages m_localesWithLanguages;
+  using LocalesByLanguages = std::map<std::string, json_t *>;
+  LocalesByLanguages m_localesByLanguages;
 };
 }  // namespace generator

--- a/generator/translation.hpp
+++ b/generator/translation.hpp
@@ -95,6 +95,7 @@ private:
       ToJSONObject(locale, label, name);
     }
   }
+
   static std::string const & DefaultLocaleName()
   {
     static std::string const kDefaultLocaleName = "default";

--- a/generator/translation.hpp
+++ b/generator/translation.hpp
@@ -113,6 +113,7 @@ private:
   }
 
   std::vector<std::string> const & LocaleLanguages() const;
+
   json_t & m_node;
 };
 }  // namespace generator

--- a/generator/translation.hpp
+++ b/generator/translation.hpp
@@ -20,6 +20,7 @@ inline std::string GetName(StringUtf8Multilang const & name, LanguageCode lang)
 
 /// This function will take the following steps:
 /// 1. Return the |languageCode| name if it exists.
+/// 1.1 Next steps only for english locale
 /// 2. Try to get international name.
 /// 3. Try to check if default name is ASCII and return it if succeeds.
 /// 4. Return transliteration trying to use kPreferredLanguagesForTransliterate

--- a/generator/translation.hpp
+++ b/generator/translation.hpp
@@ -20,10 +20,11 @@ inline std::string GetName(StringUtf8Multilang const & name, LanguageCode lang)
 
 /// This function will take the following steps:
 /// 1. Return the |languageCode| name if it exists.
-/// 2. Try to get International name
-/// 3. Return transliteration trying to use kPreferredLanguagesForTransliterate
+/// 2. Try to get international name.
+/// 3. Try to check if default name is ASCII and return it if succeeds.
+/// 4. Return transliteration trying to use kPreferredLanguagesForTransliterate
 /// first, then any, if it succeeds.
-/// 3. Otherwise, return empty string.
+/// 5. Otherwise, return empty string.
 std::string GetTranslatedOrTransliteratedName(StringUtf8Multilang const & name,
                                               LanguageCode languageCode);
 


### PR DESCRIPTION
Меняем формат jsonl файликов
Словарь address уезжает в locales, получается что-то вроде

``
{
  "locales": {
    "default": {
      "address": {
        "country": "Bahamas"
      },
      "name": "Bahamas"
    },
    "en": {
      "address": {
        "country": "Bahamas"
      },
      "name": "Bahamas"
    },
    "ru": {
      "address": {
        "country": "Багамы"
      },
      "name": "Багамы"
    }
  },
  "rank": 1,
  "dref": null,
  "code": "BS"
}
``

Усложняем логику перевода имени.