### PR TITLE
[routing] Fixed integration tests.

### DIFF
--- a/routing/routing_integration_tests/transit_route_test.cpp
+++ b/routing/routing_integration_tests/transit_route_test.cpp
@@ -130,7 +130,7 @@ UNIT_TEST(London_DeptfordBridgeToCyprus)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(Vashington_FoggyToShaw)
+UNIT_TEST(Washington_FoggyToShaw)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -139,7 +139,7 @@ UNIT_TEST(Vashington_FoggyToShaw)
 
   TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
 
-  integration::TestRouteLength(*routeResult.first, 6318.54);
+  integration::TestRouteLength(*routeResult.first, 6180.54);
 
   CHECK(routeResult.first, ());
   integration::CheckSubwayExistence(*routeResult.first);


### PR DESCRIPTION
На старых данных был маршрут длиной 6320м и строился он всегда таким образом:
<img width="1792" alt="было 6320м" src="https://user-images.githubusercontent.com/6297856/60676833-912e9200-9e88-11e9-8295-3f96026bc56b.png">

На новых данных маршрут каждый раз разный:
6185м
<img width="1792" alt="стало, 6185м, 2237с" src="https://user-images.githubusercontent.com/6297856/60676892-b7543200-9e88-11e9-9d42-628580e5a28d.png">
6184м
<img width="1792" alt="стало, 6184м, 2236с" src="https://user-images.githubusercontent.com/6297856/60676962-e4a0e000-9e88-11e9-8c4b-e74811e5d8cb.png">

бывают еще другие варианты, все примерно одинаковой длины
такая ситуация из за того, что станция foggy пренадлежит 3м параллельным веткам: оранжевой, серой и синей. станция shaw-howard пренадлежит желтой и зеленой ветке. 
https://www.wmata.com/schedules/maps/upload/2019-System-Map.pdf