### PR TITLE
[search] Allow misprints while determing NameScore for ranking.

### DIFF
--- a/base/base_tests/levenshtein_dfa_test.cpp
+++ b/base/base_tests/levenshtein_dfa_test.cpp
@@ -290,7 +290,6 @@ UNIT_TEST(LevenshteinDFA_PrefixDFASmoke)
     {
       for (auto const & query : queries)
       {
-        LOG(LINFO, (source, query));
         PrefixDFAModifier<LevenshteinDFA> dfa(LevenshteinDFA(source, 2 /* maxErrors */));
         auto it = dfa.Begin();
         for (auto const c : query)

--- a/base/dfa_helpers.hpp
+++ b/base/dfa_helpers.hpp
@@ -62,6 +62,7 @@ public:
     bool Accepts() const { return m_accepts; }
     bool Rejects() const { return !Accepts() && m_it.Rejects(); }
     size_t ErrorsMade() const { return m_it.ErrorsMade(); }
+    size_t PrefixErrorsMade() const { return m_it.PrefixErrorsMade(); }
 
   private:
     friend class PrefixDFAModifier;

--- a/base/levenshtein_dfa.cpp
+++ b/base/levenshtein_dfa.cpp
@@ -237,6 +237,7 @@ LevenshteinDFA::LevenshteinDFA(UniString const & s, size_t prefixSize,
     m_transitions.emplace_back(m_alphabet.size());
     m_accepting.push_back(false);
     m_errorsMade.push_back(ErrorsMade(state));
+    m_prefixErrorsMade.push_back(PrefixErrorsMade(state));
   };
 
   pushState(MakeStart(), kStartingState);
@@ -348,6 +349,14 @@ size_t LevenshteinDFA::ErrorsMade(State const & s) const
     auto const errorsLeft = p.m_errorsLeft - (m_size - p.m_offset);
     errorsMade = std::min(errorsMade, m_maxErrors - errorsLeft);
   }
+  return errorsMade;
+}
+
+size_t LevenshteinDFA::PrefixErrorsMade(State const & s) const
+{
+  size_t errorsMade = m_maxErrors;
+  for (auto const & p : s.m_positions)
+    errorsMade = std::min(errorsMade, m_maxErrors - p.m_errorsLeft);
   return errorsMade;
 }
 

--- a/base/levenshtein_dfa.hpp
+++ b/base/levenshtein_dfa.hpp
@@ -82,6 +82,7 @@ public:
     bool Rejects() const { return m_dfa.IsRejecting(m_s); }
 
     size_t ErrorsMade() const { return m_dfa.ErrorsMade(m_s); }
+    size_t PrefixErrorsMade() const { return m_dfa.PrefixErrorsMade(m_s); }
 
   private:
     friend class LevenshteinDFA;
@@ -126,6 +127,10 @@ private:
   size_t ErrorsMade(State const & s) const;
   size_t ErrorsMade(size_t s) const { return m_errorsMade[s]; }
 
+  // Returns minimum number of errors already made. This number cannot decrease.
+  size_t PrefixErrorsMade(State const & s) const;
+  size_t PrefixErrorsMade(size_t s) const { return m_prefixErrorsMade[s]; }
+
   size_t Move(size_t s, UniChar c) const;
 
   size_t const m_size;
@@ -136,6 +141,7 @@ private:
   std::vector<std::vector<size_t>> m_transitions;
   std::vector<bool> m_accepting;
   std::vector<size_t> m_errorsMade;
+  std::vector<size_t> m_prefixErrorsMade;
 };
 
 std::string DebugPrint(LevenshteinDFA::Position const & p);

--- a/base/uni_string_dfa.hpp
+++ b/base/uni_string_dfa.hpp
@@ -19,6 +19,7 @@ public:
     bool Accepts() const { return !Rejects() && m_pos == m_s.size(); }
     bool Rejects() const { return m_rejected; }
     size_t ErrorsMade() const { return 0; }
+    size_t PrefixErrorsMade() const { return 0; }
 
   private:
     friend class UniStringDFA;

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -33,7 +33,7 @@ namespace search
 {
 namespace
 {
-size_t GetMaxNumberOfErros(Geocoder::Params const & params)
+size_t GetMaxNumberOfErrors(Geocoder::Params const & params)
 {
   size_t result = 0;
   for (size_t i = 0; i < params.GetNumTokens(); ++i)
@@ -50,16 +50,14 @@ struct NameScoresEx : public NameScores
 template <typename Slice>
 void UpdateNameScores(string const & name, Slice const & slice, NameScores & bestScores)
 {
-  auto const newScores = GetNameScores(name, slice);
-  bestScores = NameScores::BestScores(newScores, bestScores);
+  bestScores.UpdateIfBetter(GetNameScores(name, slice););
 }
 
 template <typename Slice>
 void UpdateNameScores(vector<strings::UniString> const & tokens, Slice const & slice,
                       NameScores & bestScores)
 {
-  auto const newScores = GetNameScores(tokens, slice);
-  bestScores = NameScores::BestScores(newScores, bestScores);
+  bestScores.UpdateIfBetter(GetNameScores(tokens, slice));
 }
 
 // This function assumes that at most one token in |streetTokens| ends with "strasse".
@@ -415,7 +413,7 @@ class RankerResultMaker
 
       info.m_nameScore = nameScore;
       info.m_errorsMade = errorsMade;
-      info.m_maxErrorsMade = GetMaxNumberOfErros(m_params);
+      info.m_maxErrorsMade = GetMaxNumberOfErrors(m_params);
       info.m_matchedFraction =
           totalLength == 0 ? 1.0
                            : static_cast<double>(matchedLength) / static_cast<double>(totalLength);

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -33,26 +33,33 @@ namespace search
 {
 namespace
 {
-struct NameScores
+size_t GetMaxNumberOfErros(Geocoder::Params const & params)
 {
-  NameScore m_nameScore = NAME_SCORE_ZERO;
-  ErrorsMade m_errorsMade;
+  size_t result = 0;
+  for (size_t i = 0; i < params.GetNumTokens(); ++i)
+    result += GetMaxErrorsForToken(params.GetToken(i).GetOriginal());
+
+  return result;
+}
+
+struct NameScoresEx : public NameScores
+{
   size_t m_matchedLength = 0;
 };
 
 template <typename Slice>
 void UpdateNameScores(string const & name, Slice const & slice, NameScores & bestScores)
 {
-  bestScores.m_nameScore = max(bestScores.m_nameScore, GetNameScore(name, slice));
-  bestScores.m_errorsMade = ErrorsMade::Min(bestScores.m_errorsMade, GetErrorsMade(name, slice));
+  auto const newScores = GetNameScores(name, slice);
+  bestScores = NameScores::BestScores(newScores, bestScores);
 }
 
 template <typename Slice>
 void UpdateNameScores(vector<strings::UniString> const & tokens, Slice const & slice,
                       NameScores & bestScores)
 {
-  bestScores.m_nameScore = max(bestScores.m_nameScore, GetNameScore(tokens, slice));
-  bestScores.m_errorsMade = ErrorsMade::Min(bestScores.m_errorsMade, GetErrorsMade(tokens, slice));
+  auto const newScores = GetNameScores(tokens, slice);
+  bestScores = NameScores::BestScores(newScores, bestScores);
 }
 
 // This function assumes that at most one token in |streetTokens| ends with "strasse".
@@ -86,10 +93,10 @@ bool ModifyStrasse(vector<strings::UniString> & streetTokens)
   return false;
 }
 
-NameScores GetNameScores(FeatureType & ft, Geocoder::Params const & params,
-                         TokenRange const & range, Model::Type type)
+NameScoresEx GetNameScores(FeatureType & ft, Geocoder::Params const & params,
+                           TokenRange const & range, Model::Type type)
 {
-  NameScores bestScores;
+  NameScoresEx bestScores;
 
   TokenSlice const slice(params, range);
   TokenSliceNoCategories const sliceNoCategories(params, range);
@@ -408,6 +415,7 @@ class RankerResultMaker
 
       info.m_nameScore = nameScore;
       info.m_errorsMade = errorsMade;
+      info.m_maxErrorsMade = GetMaxNumberOfErros(m_params);
       info.m_matchedFraction =
           totalLength == 0 ? 1.0
                            : static_cast<double>(matchedLength) / static_cast<double>(totalLength);

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -42,11 +42,6 @@ size_t GetMaxNumberOfErrors(Geocoder::Params const & params)
   return result;
 }
 
-struct NameScoresEx : public NameScores
-{
-  size_t m_matchedLength = 0;
-};
-
 template <typename Slice>
 void UpdateNameScores(string const & name, Slice const & slice, NameScores & bestScores)
 {
@@ -91,18 +86,19 @@ bool ModifyStrasse(vector<strings::UniString> & streetTokens)
   return false;
 }
 
-NameScoresEx GetNameScores(FeatureType & ft, Geocoder::Params const & params,
-                           TokenRange const & range, Model::Type type)
+pair<NameScores, size_t> GetNameScores(FeatureType & ft, Geocoder::Params const & params,
+                                       TokenRange const & range, Model::Type type)
 {
-  NameScoresEx bestScores;
+  NameScores bestScores;
 
   TokenSlice const slice(params, range);
   TokenSliceNoCategories const sliceNoCategories(params, range);
 
+  size_t matchedLength = 0;
   if (type != Model::Type::TYPE_COUNT)
   {
     for (size_t i = 0; i < slice.Size(); ++i)
-      bestScores.m_matchedLength += slice.Get(i).GetOriginal().size();
+      matchedLength += slice.Get(i).GetOriginal().size();
   }
 
   for (auto const lang : params.GetLangs())
@@ -146,15 +142,15 @@ NameScoresEx GetNameScores(FeatureType & ft, Geocoder::Params const & params,
     });
   }
 
-  return bestScores;
+  return make_pair(bestScores, matchedLength);
 }
 
 pair<ErrorsMade, size_t> MatchTokenRange(FeatureType & ft, Geocoder::Params const & params,
                                          TokenRange const & range, Model::Type type)
 {
-  auto const nameScores = GetNameScores(ft, params, range, type);
-  auto errorsMade = nameScores.m_errorsMade;
-  auto matchedLength = nameScores.m_matchedLength;
+  auto const scores = GetNameScores(ft, params, range, type);
+  auto errorsMade = scores.first.m_errorsMade;
+  auto matchedLength = scores.second;
   if (errorsMade.IsValid())
     return make_pair(errorsMade, matchedLength);
 
@@ -370,12 +366,11 @@ class RankerResultMaker
     }
     else
     {
-      auto const nameScores =
-          GetNameScores(ft, m_params, preInfo.InnermostTokenRange(), info.m_type);
+      auto const scores = GetNameScores(ft, m_params, preInfo.InnermostTokenRange(), info.m_type);
 
-      auto nameScore = nameScores.m_nameScore;
-      auto errorsMade = nameScores.m_errorsMade;
-      auto matchedLength = nameScores.m_matchedLength;
+      auto nameScore = scores.first.m_nameScore;
+      auto errorsMade = scores.first.m_errorsMade;
+      auto matchedLength = scores.second;
 
       if (info.m_type != Model::TYPE_STREET &&
           preInfo.m_geoParts.m_street != IntersectionResult::kInvalidId)
@@ -386,11 +381,11 @@ class RankerResultMaker
         {
           auto const type = Model::TYPE_STREET;
           auto const & range = preInfo.m_tokenRange[type];
-          auto const nameScores = GetNameScores(*street, m_params, range, type);
+          auto const streetScores = GetNameScores(*street, m_params, range, type);
 
-          nameScore = min(nameScore, nameScores.m_nameScore);
-          errorsMade += nameScores.m_errorsMade;
-          matchedLength += nameScores.m_matchedLength;
+          nameScore = min(nameScore, streetScores.first.m_nameScore);
+          errorsMade += streetScores.first.m_errorsMade;
+          matchedLength += streetScores.second;
         }
       }
 

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -14,32 +14,32 @@ namespace
 {
 // See search/search_quality/scoring_model.py for details.  In short,
 // these coeffs correspond to coeffs in a linear model.
-double constexpr kDistanceToPivot = -0.4639722;
+double constexpr kDistanceToPivot = -0.8175524;
 double constexpr kRank = 1.0000000;
 // todo: (@t.yan) Adjust.
 double constexpr kPopularity = 0.0500000;
 // todo: (@t.yan) Adjust.
 double constexpr kRating = 0.0500000;
-double constexpr kFalseCats = -1.0000000;
-double constexpr kErrorsMade = -0.0221024;
-double constexpr kMatchedFraction = 0.3817912;
-double constexpr kAllTokensUsed = 0.6343994;
+double constexpr kFalseCats = -0.3745520;
+double constexpr kErrorsMade = -0.1090870;
+double constexpr kMatchedFraction = 0.7859737;
+double constexpr kAllTokensUsed = 1.0000000;
 double constexpr kHasName = 0.5;
 double constexpr kNameScore[NameScore::NAME_SCORE_COUNT] = {
-  -0.2330337 /* Zero */,
-  0.0413221 /* Substring */,
-  0.0578796 /* Prefix */,
-  0.1338319 /* Full Match */
+  -0.1752510 /* Zero */,
+  0.0309111 /* Substring */,
+  0.0127291 /* Prefix */,
+  0.1316108 /* Full Match */
 };
 double constexpr kType[Model::TYPE_COUNT] = {
-  -0.1252380 /* POI */,
-  -0.1252380 /* Building */,
-  -0.1197951 /* Street */,
-  -0.1371600 /* Unclassified */,
-  -0.0394436 /* Village */,
-  0.1370968 /* City */,
-  -0.0810345 /* State */,
-  0.3655743 /* Country */
+  -0.1554708 /* POI */,
+  -0.1554708 /* Building */,
+  -0.1052415 /* Street */,
+  -0.1650949 /* Unclassified */,
+  -0.1556262 /* Village */,
+  0.1771632 /* City */,
+  0.0604687 /* State */,
+  0.3438015 /* Country */
 };
 
 // Coeffs sanity checks.
@@ -102,6 +102,7 @@ string DebugPrint(RankingInfo const & info)
      << "]";
   os << ", m_nameScore:" << DebugPrint(info.m_nameScore);
   os << ", m_errorsMade:" << DebugPrint(info.m_errorsMade);
+  os << ", m_maxErrorsMade:" << info.m_maxErrorsMade;
   os << ", m_matchedFraction:" << info.m_matchedFraction;
   os << ", m_type:" << DebugPrint(info.m_type);
   os << ", m_pureCats:" << info.m_pureCats;
@@ -175,8 +176,14 @@ double RankingInfo::GetLinearModelRank() const
   return result;
 }
 
-size_t RankingInfo::GetErrorsMade() const
+double RankingInfo::GetErrorsMade() const
 {
-  return m_errorsMade.IsValid() ? m_errorsMade.m_errorsMade : 0;
+  if (!m_errorsMade.IsValid())
+    return 1.0;
+
+  if (m_maxErrorsMade == 0)
+    return 0.0;
+
+  return static_cast<double>(m_errorsMade.m_errorsMade) / static_cast<double>(m_maxErrorsMade);
 }
 }  // namespace search

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -184,6 +184,7 @@ double RankingInfo::GetErrorsMade() const
   if (m_maxErrorsMade == 0)
     return 0.0;
 
+  CHECK_GREATER_OR_EQUAL(m_maxErrorsMade, m_errorsMade.m_errorsMade, ());
   return static_cast<double>(m_errorsMade.m_errorsMade) / static_cast<double>(m_maxErrorsMade);
 }
 }  // namespace search

--- a/search/ranking_info.hpp
+++ b/search/ranking_info.hpp
@@ -26,7 +26,7 @@ struct RankingInfo
   // correspond to important features.
   double GetLinearModelRank() const;
 
-  size_t GetErrorsMade() const;
+  double GetErrorsMade() const;
 
   // Distance from the feature to the pivot point.
   double m_distanceToPivot = kMaxDistMeters;
@@ -43,8 +43,10 @@ struct RankingInfo
   // Score for the feature's name.
   NameScore m_nameScore = NAME_SCORE_ZERO;
 
-  // Number of typos.
+  // Number of misprints.
   ErrorsMade m_errorsMade;
+  // Maximal number of allowed misprints for query.
+  size_t m_maxErrorsMade;
 
   // Fraction of characters from original query matched to feature.
   double m_matchedFraction = 0.0;

--- a/search/ranking_utils.cpp
+++ b/search/ranking_utils.cpp
@@ -27,18 +27,6 @@ struct TokenInfo
 };
 }  // namespace
 
-// static
-NameScores NameScores::BestScores(NameScores const & lhs, NameScores const & rhs)
-{
-  if (lhs.m_nameScore != rhs.m_nameScore)
-    return lhs.m_nameScore > rhs.m_nameScore ? lhs : rhs;
-
-  NameScores result = lhs;
-  result.m_errorsMade = ErrorsMade::Min(lhs.m_errorsMade, rhs.m_errorsMade);
-
-  return result;
-}
-
 // CategoriesInfo ----------------------------------------------------------------------------------
 CategoriesInfo::CategoriesInfo(feature::TypesHolder const & holder, TokenSlice const & tokens,
                                Locales const & locales, CategoriesHolder const & categories)
@@ -105,7 +93,7 @@ ErrorsMade GetPrefixErrorsMade(QueryParams::Token const & token, strings::UniStr
     auto it = dfa.Begin();
     strings::DFAMove(it, s.begin(), s.end());
     if (!it.Rejects())
-      errorsMade = ErrorsMade::Min(errorsMade, ErrorsMade(it.ErrorsMade()));
+      errorsMade = ErrorsMade::Min(errorsMade, ErrorsMade(it.PrefixErrorsMade()));
   });
 
   return errorsMade;
@@ -146,5 +134,12 @@ string DebugPrint(NameScore score)
   case NAME_SCORE_COUNT: return "Count";
   }
   return "Unknown";
+}
+
+string DebugPrint(NameScores scores)
+{
+  ostringstream os;
+  os << "[ " << DebugPrint(scores.m_nameScore) << ", " << DebugPrint(scores.m_errorsMade) << " ]";
+  return os.str();
 }
 }  // namespace search

--- a/search/ranking_utils.hpp
+++ b/search/ranking_utils.hpp
@@ -93,19 +93,15 @@ struct ErrorsMade
   size_t m_errorsMade = kInfiniteErrors;
 };
 
-string DebugPrint(ErrorsMade const & errorsMade);
+std::string DebugPrint(ErrorsMade const & errorsMade);
 
 namespace impl
 {
-bool FullMatch(QueryParams::Token const & token, strings::UniString const & text);
-
-bool PrefixMatch(QueryParams::Token const & token, strings::UniString const & text);
-
 // Returns the minimum number of errors needed to match |text| with
 // any of the |tokens|.  If it's not possible in accordance with
 // GetMaxErrorsForToken(|text|), returns kInfiniteErrors.
-ErrorsMade GetMinErrorsMade(std::vector<strings::UniString> const & tokens,
-                            strings::UniString const & text);
+ErrorsMade GetErrorsMade(QueryParams::Token const & token, strings::UniString const & text);
+ErrorsMade GetPrefixErrorsMade(QueryParams::Token const & token, strings::UniString const & text);
 }  // namespace impl
 
 // The order and numeric values are important here.  Please, check all
@@ -120,6 +116,14 @@ enum NameScore
   NAME_SCORE_COUNT
 };
 
+struct NameScores
+{
+  static NameScores BestScores(NameScores const & lhs, NameScores const & rhs);
+
+  NameScore m_nameScore = NAME_SCORE_ZERO;
+  ErrorsMade m_errorsMade;
+};
+
 // Returns true when |s| is a stop-word and may be removed from a query.
 bool IsStopWord(strings::UniString const & s);
 
@@ -127,78 +131,66 @@ bool IsStopWord(strings::UniString const & s);
 void PrepareStringForMatching(std::string const & name, std::vector<strings::UniString> & tokens);
 
 template <typename Slice>
-NameScore GetNameScore(std::string const & name, Slice const & slice)
+NameScores GetNameScores(std::vector<strings::UniString> const & tokens, Slice const & slice)
 {
   if (slice.Empty())
-    return NAME_SCORE_ZERO;
-
-  std::vector<strings::UniString> tokens;
-  SplitUniString(NormalizeAndSimplifyString(name), base::MakeBackInsertFunctor(tokens), Delimiters());
-  return GetNameScore(tokens, slice);
-}
-
-template <typename Slice>
-NameScore GetNameScore(std::vector<strings::UniString> const & tokens, Slice const & slice)
-{
-  if (slice.Empty())
-    return NAME_SCORE_ZERO;
+    return {};
 
   size_t const n = tokens.size();
   size_t const m = slice.Size();
 
   bool const lastTokenIsPrefix = slice.IsPrefix(m - 1);
 
-  NameScore score = NAME_SCORE_ZERO;
+  NameScores scores;
   for (size_t offset = 0; offset + m <= n; ++offset)
   {
+    ErrorsMade totalErrorsMade;
     bool match = true;
     for (size_t i = 0; i < m - 1 && match; ++i)
-      match = match && impl::FullMatch(slice.Get(i), tokens[offset + i]);
+    {
+      auto errorsMade = impl::GetErrorsMade(slice.Get(i), tokens[offset + i]);
+      match = match && errorsMade.IsValid();
+      totalErrorsMade += errorsMade;
+    }
+
     if (!match)
       continue;
 
-    bool const fullMatch = impl::FullMatch(slice.Get(m - 1), tokens[offset + m - 1]);
-    bool const prefixMatch =
-        lastTokenIsPrefix && impl::PrefixMatch(slice.Get(m - 1), tokens[offset + m - 1]);
-    if (!fullMatch && !prefixMatch)
+    auto const prefixErrorsMade =
+        impl::GetPrefixErrorsMade(slice.Get(m - 1), tokens[offset + m - 1]);
+    auto const fullErrorsMade = impl::GetErrorsMade(slice.Get(m - 1), tokens[offset + m - 1]);
+    if (!fullErrorsMade.IsValid() && !(prefixErrorsMade.IsValid() && lastTokenIsPrefix))
       continue;
 
-    if (m == n && fullMatch)
-      return NAME_SCORE_FULL_MATCH;
+    if (m == n && fullErrorsMade.IsValid())
+    {
+      scores.m_nameScore = NAME_SCORE_FULL_MATCH;
+      scores.m_errorsMade = totalErrorsMade + fullErrorsMade;
+      return scores;
+    }
 
     if (offset == 0)
-      score = std::max(score, NAME_SCORE_PREFIX);
-
-    score = std::max(score, NAME_SCORE_SUBSTRING);
+    {
+      scores.m_nameScore = std::max(scores.m_nameScore, NAME_SCORE_PREFIX);
+      scores.m_errorsMade = totalErrorsMade + prefixErrorsMade;
+    }
+    else
+    {
+      scores.m_nameScore = std::max(scores.m_nameScore, NAME_SCORE_SUBSTRING);
+      scores.m_errorsMade = totalErrorsMade + prefixErrorsMade;
+    }
   }
-  return score;
-}
-
-string DebugPrint(NameScore score);
-
-// Returns total number of errors that were made during matching
-// feature |tokens| by a query - query tokens are in |slice|.
-template <typename Slice>
-ErrorsMade GetErrorsMade(std::vector<strings::UniString> const & tokens, Slice const & slice)
-{
-  ErrorsMade totalErrorsMade;
-
-  for (size_t i = 0; i < slice.Size(); ++i)
-  {
-    ErrorsMade errorsMade;
-    slice.Get(i).ForEachSynonym([&](strings::UniString const & s) {
-      errorsMade = ErrorsMade::Min(errorsMade, impl::GetMinErrorsMade(tokens, s));
-    });
-
-    totalErrorsMade += errorsMade;
-  }
-
-  return totalErrorsMade;
+  return scores;
 }
 
 template <typename Slice>
-ErrorsMade GetErrorsMade(std::string const & s, Slice const & slice)
+NameScores GetNameScores(std::string const & name, Slice const & slice)
 {
-  return GetErrorsMade({strings::MakeUniString(s)}, slice);
+  std::vector<strings::UniString> tokens;
+  SplitUniString(NormalizeAndSimplifyString(name), base::MakeBackInsertFunctor(tokens),
+                 Delimiters());
+  return GetNameScores(tokens, slice);
 }
+
+std::string DebugPrint(NameScore score);
 }  // namespace search

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -561,8 +561,9 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
   checkErrors("кафе", ErrorsMade());
 
   checkErrors("Cafe Yesenina", ErrorsMade(0));
-  checkErrors("Cafe Esenina", ErrorsMade(1));
   checkErrors("Cafe Jesenina", ErrorsMade(1));
+  // We allow only Y->{E, J, I, U} misprints for the first letter.
+  checkErrors("Cafe Esenina", ErrorsMade(2));
 
   checkErrors("Островского кафе", ErrorsMade(0));
   checkErrors("Астровского кафе", ErrorsMade(1));
@@ -1897,9 +1898,9 @@ UNIT_CLASS_TEST(ProcessorTest, ExactMatchTest)
     TEST(ResultsMatch(results, rules), ());
 
     TEST_EQUAL(2, results.size(), ("Unexpected number of retrieved cafes."));
-    TEST(ResultsMatch({results[0]}, {ExactMatch(wonderlandId, cafe)}), ());
-    TEST(results[0].GetRankingInfo().m_exactMatch, ());
-    TEST(!results[1].GetRankingInfo().m_exactMatch, ());
+    TEST(ResultsMatch({results[0]}, {ExactMatch(wonderlandId, lermontov)}), ());
+    TEST(!results[0].GetRankingInfo().m_exactMatch, ());
+    TEST(results[1].GetRankingInfo().m_exactMatch, ());
   }
 
   {

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -556,7 +556,10 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
     TEST_EQUAL(results[0].GetRankingInfo().m_errorsMade, errorsMade, (query));
   };
 
-  checkErrors("кафе лермонтов", ErrorsMade(1));
+  // Prefix match "лермонтов" -> "Лермонтовъ" without errors.
+  checkErrors("кафе лермонтов", ErrorsMade(0));
+  checkErrors("кафе лермнтовъ", ErrorsMade(1));
+  // Full match.
   checkErrors("трактир лермонтов", ErrorsMade(2));
   checkErrors("кафе", ErrorsMade());
 
@@ -572,9 +575,14 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
   checkErrors("пушкенская кафе", ErrorsMade(1));
   checkErrors("пушкинская трактиръ лермонтовъ", ErrorsMade(0));
 
-  checkErrors("лермонтовъ чехов", ErrorsMade(1));
+  // Prefix match "чехов" -> "Чеховъ" without errors.
+  checkErrors("лермонтовъ чехов", ErrorsMade(0));
+  checkErrors("лермонтовъ чехов ", ErrorsMade(1));
   checkErrors("лермонтовъ чеховъ", ErrorsMade(0));
-  checkErrors("лермонтов чехов", ErrorsMade(2));
+
+  // Prefix match "чехов" -> "Чеховъ" without errors.
+  checkErrors("лермонтов чехов", ErrorsMade(1));
+  checkErrors("лермонтов чехов ", ErrorsMade(2));
   checkErrors("лермонтов чеховъ", ErrorsMade(1));
 
   checkErrors("лермонтов чеховъ антон павлович", ErrorsMade(3));

--- a/search/search_tests/ranking_tests.cpp
+++ b/search/search_tests/ranking_tests.cpp
@@ -39,7 +39,7 @@ NameScore GetScore(string const & name, string const & query, TokenRange const &
     params.InitNoPrefix(tokens.begin(), tokens.end());
   }
 
-  return GetNameScore(name, TokenSlice(params, tokenRange));
+  return GetNameScores(name, TokenSlice(params, tokenRange)).m_nameScore;
 }
 
 UNIT_TEST(NameTest_Smoke)
@@ -49,11 +49,15 @@ UNIT_TEST(NameTest_Smoke)
   TEST_EQUAL(GetScore("New York", "York", TokenRange(0, 1)), NAME_SCORE_SUBSTRING, ());
   TEST_EQUAL(GetScore("Moscow", "Red Square Mosc", TokenRange(2, 3)), NAME_SCORE_PREFIX, ());
   TEST_EQUAL(GetScore("Moscow", "Red Square Moscow", TokenRange(2, 3)), NAME_SCORE_FULL_MATCH, ());
+  TEST_EQUAL(GetScore("Moscow", "Red Square Moscw", TokenRange(2, 3)), NAME_SCORE_FULL_MATCH, ());
   TEST_EQUAL(GetScore("San Francisco", "Fran", TokenRange(0, 1)), NAME_SCORE_SUBSTRING, ());
   TEST_EQUAL(GetScore("San Francisco", "Fran ", TokenRange(0, 1)), NAME_SCORE_ZERO, ());
   TEST_EQUAL(GetScore("San Francisco", "Sa", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
   TEST_EQUAL(GetScore("San Francisco", "San ", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
-  TEST_EQUAL(GetScore("Лермонтовъ", "Лермонтов", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
+  TEST_EQUAL(GetScore("Лермонтовъ", "Лермон", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
+  TEST_EQUAL(GetScore("Лермонтовъ", "Лермонтов", TokenRange(0, 1)), NAME_SCORE_FULL_MATCH, ());
+  TEST_EQUAL(GetScore("Лермонтовъ", "Лермонтово", TokenRange(0, 1)), NAME_SCORE_FULL_MATCH, ());
+  TEST_EQUAL(GetScore("Лермонтовъ", "Лермнтовъ", TokenRange(0, 1)), NAME_SCORE_FULL_MATCH, ());
   TEST_EQUAL(GetScore("фото на документы", "фото", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
   TEST_EQUAL(GetScore("фотоателье", "фото", TokenRange(0, 1)), NAME_SCORE_PREFIX, ());
 }


### PR DESCRIPTION
При определении NameScore не разрешались ошибки, то есть если в запросе была опечатка, то автоматически токен с опечаткой не матчился и это зачастую приводило к тому, что витальный результат, полностью совпаюащий с запросом с точностью до 1 опечатки, имел NameScore Zero.
Кроме того:
- разбор для NameScore выбирался отдельно от разбора для вычисления количества опечаток
- в случае превышения допустимого количества опечаток считалось что количество опечаток 0.

Также в реквесте новые коэффициенты для модели ранжирования.