### PR TITLE
[geocoder] Optimize memory at the start

### DIFF
--- a/geocoder/hierarchy_reader.cpp
+++ b/geocoder/hierarchy_reader.cpp
@@ -71,6 +71,7 @@ Hierarchy HierarchyReader::Read(unsigned int readersCount)
     while (!m_eof && tasks.size() <= 2 * readersCount)
       tasks.emplace_back(threadPool.Submit([&] { return ReadEntries(kReadBlockLineCount); }));
 
+    CHECK(!tasks.empty(), ());
     auto & task = tasks.front();
     auto taskResult = task.get();
     tasks.pop_front();
@@ -192,14 +193,16 @@ HierarchyReader::ParsingResult HierarchyReader::DeserializeEntries(
     entries.push_back(move(entry));
   }
 
-  return {std::move(entries), std::move(stats)};
+  return {move(entries), move(stats)};
 }
 
+// static
 bool HierarchyReader::DeserializeId(string const & str, uint64_t & id)
 {
   return strings::to_uint64(str, id, 16 /* base */);
 }
 
+// static
 string HierarchyReader::SerializeId(uint64_t id)
 {
   stringstream s;

--- a/geocoder/hierarchy_reader.hpp
+++ b/geocoder/hierarchy_reader.hpp
@@ -7,10 +7,10 @@
 
 #include <atomic>
 #include <fstream>
-#include <map>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace geocoder
@@ -30,17 +30,23 @@ public:
   Hierarchy Read(unsigned int readersCount = 1);
 
 private:
-  void ReadEntryMap(std::multimap<base::GeoObjectId, Entry> & entries, ParsingStats & stats);
+  struct ParsingResult
+  {
+    std::vector<Entry> m_entries;
+    ParsingStats m_stats;
+  };
 
-  void DeserializeEntryMap(std::vector<std::string> const & linesBuffer, std::size_t const bufferSize,
-                           std::multimap<base::GeoObjectId, Entry> & entries, ParsingStats & stats);
+  ParsingResult ReadEntries(size_t count);
+  ParsingResult DeserializeEntries(std::vector<std::string> const & linesBuffer,
+                                    std::size_t const bufferSize);
   bool DeserializeId(std::string const & str, uint64_t & id);
+  std::string SerializeId(uint64_t id);
 
-  std::vector<Entry> MergeEntries(std::vector<std::multimap<base::GeoObjectId, Entry>> & entryParts);
   void CheckDuplicateOsmIds(std::vector<Entry> const & entries, ParsingStats & stats);
 
   std::ifstream m_fileStream;
   std::istream & m_in;
+  bool m_eof{false};
   std::mutex m_mutex;
   std::atomic<std::uint64_t> m_totalNumLoaded{0};
 };

--- a/geocoder/hierarchy_reader.hpp
+++ b/geocoder/hierarchy_reader.hpp
@@ -39,8 +39,8 @@ private:
   ParsingResult ReadEntries(size_t count);
   ParsingResult DeserializeEntries(std::vector<std::string> const & linesBuffer,
                                     std::size_t const bufferSize);
-  bool DeserializeId(std::string const & str, uint64_t & id);
-  std::string SerializeId(uint64_t id);
+  static bool DeserializeId(std::string const & str, uint64_t & id);
+  static std::string SerializeId(uint64_t id);
 
   void CheckDuplicateOsmIds(std::vector<Entry> const & entries, ParsingStats & stats);
 


### PR DESCRIPTION
Оптимизация по памяти при старте. Сервис не мог подняться, не помещался в память.

Проблема: для загрузки треб. в два раза больше памяти чем для работы.
Решение: загрузка частями.