### PR TITLE
[android] Fixed geo-pushes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   implementation 'com.facebook.android:audience-network-sdk:4.28.2'
   implementation 'com.google.code.gson:gson:2.6.1'
   implementation 'com.pushwoosh:pushwoosh:5.17.0'
+  implementation 'com.pushwoosh:pushwoosh-location:5.17.0'
   implementation 'com.pushwoosh:pushwoosh-gcm:5.12.1'
   implementation 'com.my.tracker:mytracker-sdk:1.5.3'
   implementation ('com.my.target:mytarget-sdk:5.2.2') {

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -20,6 +20,7 @@ import com.mapswithme.util.PermissionsUtils;
 import com.mapswithme.util.Utils;
 import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
+import com.mapswithme.util.statistics.PushwooshHelper;
 
 public enum LocationHelper
 {
@@ -528,6 +529,7 @@ public enum LocationHelper
 
     if (mLocationProvider.isActive())
     {
+      PushwooshHelper.startLocationTracking();
       if (!mInFirstRun && getMyPositionMode() == LocationState.NOT_FOLLOW_NO_POSITION)
         switchToNextMode();
     }
@@ -553,6 +555,7 @@ public enum LocationHelper
     //noinspection ConstantConditions
     mLocationProvider.stop();
     mSensorHelper.stop();
+    PushwooshHelper.stopLocationTracking();
   }
 
   /**

--- a/android/src/com/mapswithme/util/statistics/PushwooshHelper.java
+++ b/android/src/com/mapswithme/util/statistics/PushwooshHelper.java
@@ -8,6 +8,7 @@ import com.mapswithme.util.log.LoggerFactory;
 import com.pushwoosh.Pushwoosh;
 import com.pushwoosh.exception.PushwooshException;
 import com.pushwoosh.function.Result;
+import com.pushwoosh.location.PushwooshLocation;
 import com.pushwoosh.tags.TagsBundle;
 
 import java.util.Arrays;
@@ -47,6 +48,16 @@ public final class PushwooshHelper
   private void onSuccess(@NonNull Result<Void, PushwooshException> result)
   {
     /* Do nothing by default */
+  }
+
+  public static void startLocationTracking()
+  {
+    PushwooshLocation.startLocationTracking();
+  }
+
+  public static void stopLocationTracking()
+  {
+    PushwooshLocation.stopLocationTracking();
   }
 
   public static native void nativeProcessFirstLaunch();


### PR DESCRIPTION
После обновления PW с версии 5.9 до 5.17, скорее всего сломались гуопуши. PW в версии 5.10 вынес поддержку геопушей в отдельную библиотеку. Кроме того, теперь надо явно вызывать start/stop location tracking.
В данном PR это и делается.
Ссылка на доку PW: https://pushwoosh.gitbook.io/platform-docs/pushwoosh-sdk/android-push-notifications/customizing-android-sdk-5.0#geozones-push-notification