### PR TITLE
[search] Remove wrong MaxErrors calculation from ranking

### DIFF
--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -57,16 +57,21 @@ void RemoveNumeroSigns(UniString & s)
 }
 }  // namespace
 
+size_t GetMaxErrorsForTokenLength(size_t length)
+{
+  if (length < 4)
+    return 0;
+  if (length < 8)
+    return 1;
+  return 2;
+}
+
 size_t GetMaxErrorsForToken(strings::UniString const & token)
 {
   bool const digitsOnly = all_of(token.begin(), token.end(), ::isdigit);
   if (digitsOnly)
     return 0;
-  if (token.size() < 4)
-    return 0;
-  if (token.size() < 8)
-    return 1;
-  return 2;
+  return GetMaxErrorsForTokenLength(token.size());
 }
 
 strings::LevenshteinDFA BuildLevenshteinDFA(strings::UniString const & s)

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -13,6 +13,7 @@
 
 namespace search
 {
+size_t GetMaxErrorsForTokenLength(size_t length);
 size_t GetMaxErrorsForToken(strings::UniString const & token);
 
 strings::LevenshteinDFA BuildLevenshteinDFA(strings::UniString const & s);

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -33,15 +33,6 @@ namespace search
 {
 namespace
 {
-size_t GetMaxNumberOfErrors(Geocoder::Params const & params)
-{
-  size_t result = 0;
-  for (size_t i = 0; i < params.GetNumTokens(); ++i)
-    result += GetMaxErrorsForToken(params.GetToken(i).GetOriginal());
-
-  return result;
-}
-
 template <typename Slice>
 void UpdateNameScores(string const & name, Slice const & slice, NameScores & bestScores)
 {
@@ -420,7 +411,7 @@ class RankerResultMaker
 
       info.m_nameScore = nameScore;
       info.m_errorsMade = errorsMade;
-      info.m_maxErrorsMade = GetMaxNumberOfErrors(m_params);
+      info.m_numTokens = m_params.GetNumTokens();
       info.m_matchedFraction =
           totalLength == 0 ? 1.0
                            : static_cast<double>(matchedLength) / static_cast<double>(totalLength);

--- a/search/ranking_info.hpp
+++ b/search/ranking_info.hpp
@@ -26,7 +26,7 @@ struct RankingInfo
   // correspond to important features.
   double GetLinearModelRank() const;
 
-  double GetErrorsMade() const;
+  double GetErrorsMadePerToken() const;
 
   // Distance from the feature to the pivot point.
   double m_distanceToPivot = kMaxDistMeters;
@@ -45,8 +45,8 @@ struct RankingInfo
 
   // Number of misprints.
   ErrorsMade m_errorsMade;
-  // Maximal number of allowed misprints for query.
-  size_t m_maxErrorsMade;
+  // Query tokens number.
+  size_t m_numTokens;
 
   // Fraction of characters from original query matched to feature.
   double m_matchedFraction = 0.0;


### PR DESCRIPTION
Неправильно считался MaxErrors, т.к. мачинг происходит(автомат строится) по токенам из фичей. Токены из фичей могут быть длиннее токенов из запроса, получается что MaxErrors это количество токенов умноженное на максимальное количество опечаток в токене.