### PR TITLE
Dangling reference fixing.

### DIFF
--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -23,7 +23,8 @@ void ReEncodeOsmIdsToFeatureIdsMapping(std::string const & mappingContent, std::
   gen::Accumulator<std::pair<base::GeoObjectId, uint32_t>> osmIdsToFeatureIds;
   for (; lineIter; ++lineIter)
   {
-    strings::SimpleTokenizer idIter(*lineIter, ", \t" /* id delimiters */);
+    auto const & line = *lineIter;
+    strings::SimpleTokenizer idIter(line, ", \t" /* id delimiters */);
     uint64_t osmId = 0;
     TEST(idIter, ());
     TEST(strings::to_uint64(*idIter, osmId), ("Cannot convert to uint64_t:", *idIter));


### PR DESCRIPTION
Причина проблемы в том, что `*lineIter` возвращает строку. А в c-tor SimpleTokenizer сохранялись ссылки на этот временный объект. Об этом говорят и комментарии к c-tor SimpleTokenizer : 
```c++
  // *NOTE* |s| must be not temporary!
  TokenizeIterator(std::string const & s, DelimFn const & delimFn)
    : m_start(s.begin()), m_end(s.begin()), m_finish(s.end()), m_delimFn(delimFn)
  {
    Move();
  }

  // *NOTE* |s| must be not temporary!
  TokenizeIterator(UniString const & s, DelimFn const & delimFn)
    : m_start(s.begin()), m_end(s.begin()), m_finish(s.end()), m_delimFn(delimFn)
  {
    Move();
  }
```. 

`auto const & line = *lineIter;` продливает время жизни строки.

```c++
2019-07-17 14:08:43.837904+0300 generator_tests[78080:2524775] =================================================================
2019-07-17 14:08:43.838238+0300 generator_tests[78080:2524775] ==78080==ERROR: AddressSanitizer: stack-use-after-scope on address 0x000114899381 at pc 0x000108dc0b85 bp 0x7ffee6e4af20 sp 0x7ffee6e4af18
2019-07-17 14:08:43.838255+0300 generator_tests[78080:2524775] READ of size 1 at 0x000114899381 thread T0
2019-07-17 14:08:43.838264+0300 generator_tests[78080:2524775] pc_0x108dc0b84###func_std::__1::char_traits<char>::assign(char&, char const&)###file___string###line_208###obj_(generator_tests:x86_64+0x10000cb84)
2019-07-17 14:08:43.838278+0300 generator_tests[78080:2524775] pc_0x108fd84d2###func_std::__1::enable_if<__is_forward_iterator<std::__1::__wrap_iter<char const*> >::value, void>::type std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__init<std::__1::__wrap_iter<char const*> >(std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>)###file_string###line_2051###obj_(generator_tests:x86_64+0x1002244d2)
2019-07-17 14:08:43.838375+0300 generator_tests[78080:2524775] pc_0x108fd5871###func_strings::TokenizeIterator<strings::SimpleDelimiter, utf8::unchecked::iterator<std::__1::__wrap_iter<char const*> >, false>::operator*() const###file_string_utils.hpp###line_155###obj_(generator_tests:x86_64+0x100221871)
2019-07-17 14:08:43.838399+0300 generator_tests[78080:2524775] pc_0x10915b363###func_generator::ReEncodeOsmIdsToFeatureIdsMapping(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)###file_routing_helpers.cpp###line_30###obj_(generator_tests:x86_64+0x1003a7363)
2019-07-17 14:08:43.838414+0300 generator_tests[78080:2524775] pc_0x109053570###func_routing::TestRestrictionCollector::TestRestrictionCollector()###file_restriction_collector_test.cpp###line_117###obj_(generator_tests:x86_64+0x10029f570)
2019-07-17 14:08:43.838423+0300 generator_tests[78080:2524775] pc_0x10905051e###func_routing::UnitTest_TestRestrictionCollector_ValidCase()###file_restriction_collector_test.cpp###line_190###obj_(generator_tests:x86_64+0x10029c51e)
2019-07-17 14:08:43.838436+0300 generator_tests[78080:2524775] pc_0x10912c9e3###func_main###file_testingmain.cpp###line_244###obj_(generator_tests:x86_64+0x1003789e3)
2019-07-17 14:08:43.838447+0300 generator_tests[78080:2524775] pc_0x7fff7f1d43d4###func_start###file_<null>###line_-421226272###obj_(libdyld.dylib:x86_64+0x163d4)
2019-07-17 14:08:43.838454+0300 generator_tests[78080:2524775] 
2019-07-17 14:08:43.838461+0300 generator_tests[78080:2524775] Address 0x000114899381 is located in stack of thread T0 at offset 897 in frame
2019-07-17 14:08:43.838471+0300 generator_tests[78080:2524775] pc_0x10915acaf###func_generator::ReEncodeOsmIdsToFeatureIdsMapping(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)###file_routing_helpers.cpp###line_20###obj_(generator_tests:x86_64+0x1003a6caf)
2019-07-17 14:08:43.838479+0300 generator_tests[78080:2524775] 
```