### PR TITLE
[routing][release-92] Adding num mwm id to FakeVertex to distinguish FakeVertex near mww borders.

### DIFF
--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -48,7 +48,6 @@ public:
            ("Segment", from, "does not exist in fake graph."));
     ASSERT(m_segmentToVertex.find(to) != m_segmentToVertex.end(),
            ("Segment", to, "does not exist in fake graph."));
-
     m_outgoing[from].insert(to);
     m_ingoing[to].insert(from);
   }

--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -48,6 +48,7 @@ public:
            ("Segment", from, "does not exist in fake graph."));
     ASSERT(m_segmentToVertex.find(to) != m_segmentToVertex.end(),
            ("Segment", to, "does not exist in fake graph."));
+
     m_outgoing[from].insert(to);
     m_ingoing[to].insert(from);
   }

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -2,6 +2,8 @@
 
 #include "routing/road_graph.hpp"
 
+#include "routing_common/num_mwm_id.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "base/visitor.hpp"
@@ -21,8 +23,8 @@ public:
     PartOfReal,
   };
 
-  FakeVertex(Junction const & from, Junction const & to, Type type)
-    : m_from(from), m_to(to), m_type(type)
+  FakeVertex(NumMwmId numMwmId, Junction const & from, Junction const & to, Type type)
+    : m_numMwmId(numMwmId), m_from(from), m_to(to), m_type(type)
   {
   }
 
@@ -30,11 +32,14 @@ public:
 
   bool operator==(FakeVertex const & rhs) const
   {
-    return m_from == rhs.m_from && m_to == rhs.m_to && m_type == rhs.m_type;
+    return m_numMwmId == rhs.m_numMwmId && m_from == rhs.m_from && m_to == rhs.m_to &&
+           m_type == rhs.m_type;
   }
 
   bool operator<(FakeVertex const & rhs) const
   {
+    if (m_numMwmId != rhs.m_numMwmId)
+      return m_numMwmId < rhs.m_numMwmId;
     if (m_from != rhs.m_from)
       return m_from < rhs.m_from;
     if (m_to != rhs.m_to)
@@ -48,10 +53,14 @@ public:
   m2::PointD const & GetPointTo() const { return m_to.GetPoint(); }
   Type GetType() const { return m_type; }
 
-  DECLARE_VISITOR(visitor(m_from, "m_from"), visitor(m_to, "m_to"), visitor(m_type, "m_type"))
+  DECLARE_VISITOR(visitor(m_numMwmId, "m_numMwmId"), visitor(m_from, "m_from"),
+                  visitor(m_to, "m_to"), visitor(m_type, "m_type"))
   DECLARE_DEBUG_PRINT(FakeVertex)
 
 private:
+  // Note. It's important to know which mwm contains the FakeVertex if it is located
+  // near an mwm borders along road features which are duplicated.
+  NumMwmId m_numMwmId = kFakeNumMwmId;
   Junction m_from;
   Junction m_to;
   Type m_type = Type::PureFake;

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -10,6 +10,7 @@
 
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace routing
@@ -32,19 +33,14 @@ public:
 
   bool operator==(FakeVertex const & rhs) const
   {
-    return m_numMwmId == rhs.m_numMwmId && m_from == rhs.m_from && m_to == rhs.m_to &&
-           m_type == rhs.m_type;
+    return std::tie(m_numMwmId, m_from, m_to, m_type) ==
+           std::tie(rhs.m_numMwmId, rhs.m_from, rhs.m_to, rhs.m_type);
   }
 
   bool operator<(FakeVertex const & rhs) const
   {
-    if (m_numMwmId != rhs.m_numMwmId)
-      return m_numMwmId < rhs.m_numMwmId;
-    if (m_from != rhs.m_from)
-      return m_from < rhs.m_from;
-    if (m_to != rhs.m_to)
-      return m_to < rhs.m_to;
-    return m_type < rhs.m_type;
+    return std::tie(m_numMwmId, m_from, m_to, m_type) <
+           std::tie(rhs.m_numMwmId, rhs.m_from, rhs.m_to, rhs.m_type);
   }
 
   Junction const & GetJunctionFrom() const { return m_from; }

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -2,6 +2,8 @@
 
 #include "routing/fake_edges_container.hpp"
 
+#include "routing_common/num_mwm_id.hpp"
+
 #include "geometry/mercator.hpp"
 
 #include <algorithm>
@@ -293,7 +295,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
 
   // Add pure fake vertex
   auto const fakeSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
-  FakeVertex fakeVertex(thisEnding.m_originJunction, thisEnding.m_originJunction,
+  FakeVertex fakeVertex(kFakeNumMwmId, thisEnding.m_originJunction, thisEnding.m_originJunction,
                         FakeVertex::Type::PureFake);
   m_fake.AddStandaloneVertex(fakeSegment, fakeVertex);
   for (auto const & projection : thisEnding.m_projections)
@@ -305,7 +307,8 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
 
     // Add projection edges
     auto const projectionSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
-    FakeVertex projectionVertex(isStart ? thisEnding.m_originJunction : projection.m_junction,
+    FakeVertex projectionVertex(projection.m_segment.GetMwmId(),
+                                isStart ? thisEnding.m_originJunction : projection.m_junction,
                                 isStart ? projection.m_junction : thisEnding.m_originJunction,
                                 FakeVertex::Type::PureFake);
     m_fake.AddVertex(fakeSegment, projectionSegment, projectionVertex, isStart /* isOutgoing */,
@@ -332,9 +335,9 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
         frontJunction = backJunction = otherJunction;
     }
 
-    FakeVertex forwardPartOfReal(isStart ? projection.m_junction : backJunction,
-                                 isStart ? frontJunction : projection.m_junction,
-                                 FakeVertex::Type::PartOfReal);
+    FakeVertex forwardPartOfReal(
+        projection.m_segment.GetMwmId(), isStart ? projection.m_junction : backJunction,
+        isStart ? frontJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
     Segment fakeForwardSegment;
     if (!m_fake.FindSegment(forwardPartOfReal, fakeForwardSegment))
       fakeForwardSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
@@ -344,9 +347,9 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
     if (!strictForward && !projection.m_isOneWay)
     {
       auto const backwardSegment = GetReverseSegment(projection.m_segment);
-      FakeVertex backwardPartOfReal(isStart ? projection.m_junction : frontJunction,
-                                    isStart ? backJunction : projection.m_junction,
-                                    FakeVertex::Type::PartOfReal);
+      FakeVertex backwardPartOfReal(
+          projection.m_segment.GetMwmId(), isStart ? projection.m_junction : frontJunction,
+          isStart ? backJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
       Segment fakeBackwardSegment;
       if (!m_fake.FindSegment(backwardPartOfReal, fakeBackwardSegment))
         fakeBackwardSegment = GetFakeSegmentAndIncr(fakeNumerationStart);

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -348,7 +348,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
     {
       auto const backwardSegment = GetReverseSegment(projection.m_segment);
       FakeVertex backwardPartOfReal(
-          projection.m_segment.GetMwmId(), isStart ? projection.m_junction : frontJunction,
+          backwardSegment.GetMwmId(), isStart ? projection.m_junction : frontJunction,
           isStart ? backJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
       Segment fakeBackwardSegment;
       if (!m_fake.FindSegment(backwardPartOfReal, fakeBackwardSegment))

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -787,22 +787,20 @@ UNIT_TEST(BelorussiaMinskTest)
 }
 
 // Test on building route from a point close to mwm border to a point close to a mwm border.
-// This test stop working because of an error in IndexGraphStarterJoints<Graph>::FindFirstJoints()
-// See https://jira.mail.ru/browse/MAPSME-11065 for details.
-//UNIT_TEST(EnglandLondonExitToLeftTest)
-//{
-//  TRouteResult const routeResult =
-//      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
-//                                  MercatorBounds::FromLatLon(51.603582, 0.266995), {0., 0.},
-//                                  MercatorBounds::FromLatLon(51.606785, 0.264055));
-//
-//  Route const & route = *routeResult.first;
-//  RouterResultCode const result = routeResult.second;
-//
-//  TEST_EQUAL(result, RouterResultCode::NoError, ());
-//  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-//  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToLeft);
-//}
+UNIT_TEST(EnglandLondonExitToLeftTest)
+{
+  TRouteResult const routeResult =
+      integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                  MercatorBounds::FromLatLon(51.603582, 0.266995), {0.0, 0.0},
+                                  MercatorBounds::FromLatLon(51.606785, 0.264055));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToLeft);
+}
 
 // Test on the route from Leninsky prospect to its frontage road and turns generated on the route.
 UNIT_TEST(RussiaMoscowLeninskyProspTest)

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -227,22 +227,23 @@ void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending
   {
     // Add projection edges
     auto const projectionSegment = GetNewTransitSegment();
-    FakeVertex projectionVertex(isEnter ? projection.m_junction : ending.m_originJunction,
-                                isEnter ? ending.m_originJunction : projection.m_junction,
-                                FakeVertex::Type::PureFake);
+    FakeVertex projectionVertex(
+        projection.m_segment.GetMwmId(), isEnter ? projection.m_junction : ending.m_originJunction,
+        isEnter ? ending.m_originJunction : projection.m_junction, FakeVertex::Type::PureFake);
     m_fake.AddStandaloneVertex(projectionSegment, projectionVertex);
 
     // Add fake parts of real
-    FakeVertex forwardPartOfReal(isEnter ? projection.m_segmentBack : projection.m_junction,
-                                 isEnter ? projection.m_junction : projection.m_segmentFront,
-                                 FakeVertex::Type::PartOfReal);
+    FakeVertex forwardPartOfReal(
+        projection.m_segment.GetMwmId(), isEnter ? projection.m_segmentBack : projection.m_junction,
+        isEnter ? projection.m_junction : projection.m_segmentFront, FakeVertex::Type::PartOfReal);
     auto const fakeForwardSegment = GetNewTransitSegment();
     m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
                      !isEnter /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
 
     if (!projection.m_isOneWay)
     {
-      FakeVertex backwardPartOfReal(isEnter ? projection.m_segmentFront : projection.m_junction,
+      FakeVertex backwardPartOfReal(projection.m_segment.GetMwmId(),
+                                    isEnter ? projection.m_segmentFront : projection.m_junction,
                                     isEnter ? projection.m_junction : projection.m_segmentBack,
                                     FakeVertex::Type::PartOfReal);
       auto const fakeBackwardSegment = GetNewTransitSegment();
@@ -257,9 +258,9 @@ void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending
       auto const gateSegment = GetNewTransitSegment();
       auto const stopIt = stopCoords.find(stopId);
       CHECK(stopIt != stopCoords.end(), ("Stop", stopId, "does not exist."));
-      FakeVertex gateVertex(isEnter ? ending.m_originJunction : stopIt->second,
-                            isEnter ? stopIt->second : ending.m_originJunction,
-                            FakeVertex::Type::PureFake);
+      FakeVertex gateVertex(
+          projection.m_segment.GetMwmId(), isEnter ? ending.m_originJunction : stopIt->second,
+          isEnter ? stopIt->second : ending.m_originJunction, FakeVertex::Type::PureFake);
       m_fake.AddVertex(projectionSegment, gateSegment, gateVertex, isEnter /* isOutgoing */,
                        false /* isPartOfReal */, dummy /* realSegment */);
       m_segmentToGate[gateSegment] = gate;
@@ -278,7 +279,7 @@ Segment TransitGraph::AddEdge(transit::Edge const & edge,
   auto const edgeSegment = GetNewTransitSegment();
   auto const stopFromId = edge.GetStop1Id();
   auto const stopToId = edge.GetStop2Id();
-  FakeVertex edgeVertex(GetStopJunction(stopCoords, stopFromId),
+  FakeVertex edgeVertex(m_mwmId, GetStopJunction(stopCoords, stopFromId),
                         GetStopJunction(stopCoords, stopToId), FakeVertex::Type::PureFake);
   m_fake.AddStandaloneVertex(edgeSegment, edgeVertex);
   m_segmentToEdge[edgeSegment] = edge;

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -11,6 +11,8 @@
 #include "transit/transit_graph_data.hpp"
 #include "transit/transit_types.hpp"
 
+#include "routing_common/num_mwm_id.hpp"
+
 #include <cstdint>
 #include <map>
 #include <memory>


### PR DESCRIPTION
cherry-pick to release-92 https://github.com/mapsme/omim/pull/11246

https://jira.mail.ru/browse/MAPSME-11065

@tatiana-yan PTAL