### PR TITLE
[generator:regions] Fix Moscow administrative regions affiliation

### DIFF
--- a/generator/generator_tests/regions_tests.cpp
+++ b/generator/generator_tests/regions_tests.cpp
@@ -542,6 +542,48 @@ UNIT_TEST(RegionsBuilderTest_GenerateRusCitySuburb)
        ());
 }
 
+UNIT_TEST(RegionsBuilderTest_GenerateRusMoscowSubregion)
+{
+  Tag const admin{"admin_level"};
+  Tag const place{"place"};
+  Tag const name{"name"};
+  TagValue const ba{"boundary", "administrative"};
+
+  auto regions = GenerateTestRegions({
+      {1, {name = u8"Россия", admin = "2", ba}, {{0, 0}, {50, 50}}},
+      {2, {name = u8"Центральный федеральный округ", admin = "3", ba}, {{10, 10}, {20, 20}}},
+      {3, {name = u8"Москва", admin = "4", ba}, {{12, 12}, {16, 16}}},
+
+      {4, {name = u8"Западный административный округ", admin = "5", ba}, {{12, 12}, {13, 13}}},
+      {4, {name = u8"Западный административный округ", admin = "5", ba}, {{13, 13}, {15, 14}}},
+      {5, {name = u8"Северный административный округ", admin = "5", ba}, {{13, 14}, {15, 15}}},
+      {6, {name = u8"Троицкий административный округ", admin = "5", ba}, {{15, 15}, {16, 16}}},
+
+      {7, {name = u8"Москва", place = "city"}, {{12, 12}, {13, 13}}},
+      {7, {name = u8"Москва", place = "city"}, {{13, 13}, {15, 15}}},
+  });
+
+  TEST(HasName(regions, u8"Россия, region: Москва"), ());
+  TEST(HasName(regions,
+               u8"Россия, region: Москва, locality: Москва"),
+       ());
+  TEST(!HasName(regions,
+                u8"Россия, region: Москва, subregion: Западный административный округ, "
+                u8"locality: Москва"),
+       ());
+  TEST(HasName(regions,
+               u8"Россия, region: Москва, locality: Москва, "
+               u8"subregion: Западный административный округ"),
+       ());
+  TEST(HasName(regions,
+               u8"Россия, region: Москва, locality: Москва, "
+               u8"subregion: Северный административный округ"),
+       ());
+  TEST(HasName(regions,
+               u8"Россия, region: Москва, subregion: Троицкий административный округ"),
+       ());
+}
+
 UNIT_TEST(RegionsBuilderTest_GenerateRusMoscowSuburb)
 {
   Tag const admin{"admin_level"};

--- a/generator/regions/specs/russia.inl
+++ b/generator/regions/specs/russia.inl
@@ -23,6 +23,9 @@ public:
   // CountrySpecifier overrides:
   void AdjustRegionsLevel(Node::PtrList & outers) override;
 
+  int RelateByWeight(LevelRegion const & lhs, LevelRegion const & rhs) const override;
+  static bool IsFederalCity(LevelRegion const & region);
+
 private:
   // CountrySpecifier overrides:
   PlaceLevel GetSpecificCountryLevel(Region const & region) const override;
@@ -151,6 +154,34 @@ void RussiaSpecifier::MarkAllSuburbsToSublocalities(Node::Ptr & tree)
 
   for (auto & subtree : tree->GetChildren())
     MarkAllSuburbsToSublocalities(subtree);
+}
+
+int RussiaSpecifier::RelateByWeight(LevelRegion const & lhs, LevelRegion const & rhs) const
+{
+  if (PlaceLevel::Locality == lhs.GetLevel() && IsFederalCity(lhs))
+  {
+    auto rhsAdminLevel = rhs.GetAdminLevel();
+    if (rhsAdminLevel == AdminLevel::Five || rhsAdminLevel == AdminLevel::Eight)
+      return 1;
+  }
+
+  if (PlaceLevel::Locality == rhs.GetLevel() && IsFederalCity(rhs))
+  {
+    auto lhsAdminLevel = lhs.GetAdminLevel();
+    if (lhsAdminLevel == AdminLevel::Five || lhsAdminLevel == AdminLevel::Eight)
+      return -1;
+  }
+
+  return CountrySpecifier::RelateByWeight(lhs, rhs);
+}
+
+bool RussiaSpecifier::IsFederalCity(LevelRegion const & region)
+{
+  if (region.GetPlaceType() != PlaceType::City)
+    return false;
+
+  auto && name = region.GetName();
+  return name == u8"Москва" || name == u8"Санкт-Петербург" || name == u8"Севастополь";
 }
 
 PlaceLevel RussiaSpecifier::GetSpecificCountryLevel(Region const & region) const


### PR DESCRIPTION
Если геометрия округов и районов Москвы/Санкт-Петербурга/Севастополя эквивалентны геометрии regons place=city, то включать их внутрь этих городов.