### PR TITLE
[routing] Accumulating position to calculate a better end user direction.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1015,6 +1015,7 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
   m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, rect, true /* applyRotation */,
                          -1 /* zoom */, true /* isAnim */, true /* useVisibleViewport */);
 
+  m_routingSession.ClearPositionAccumulator();
   m_routingSession.SetUserCurrentPosition(routePoints.front().m_position);
 
   vector<m2::PointD> points;
@@ -1027,6 +1028,8 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
 
 void RoutingManager::SetUserCurrentPosition(m2::PointD const & position)
 {
+  // @TODO(bykoianko) PositionAccumulator should be filled even if there's no route.
+  // That means IsRoutingActive() returns false.
   if (IsRoutingActive())
     m_routingSession.SetUserCurrentPosition(position);
 

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1028,8 +1028,8 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
 
 void RoutingManager::SetUserCurrentPosition(m2::PointD const & position)
 {
-  // @TODO(bykoianko) PositionAccumulator should be filled even if there's no route.
-  // That means IsRoutingActive() returns false.
+  m_routingSession.PushPositionAccumulator(position);
+
   if (IsRoutingActive())
     m_routingSession.SetUserCurrentPosition(position);
 

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -83,6 +83,8 @@ set(
   online_cross_fetcher.hpp
   pedestrian_directions.cpp
   pedestrian_directions.hpp
+  position_accumulator.cpp
+  position_accumulator.hpp
   restriction_loader.cpp
   restriction_loader.hpp
   restrictions_serialization.cpp

--- a/routing/position_accumulator.cpp
+++ b/routing/position_accumulator.cpp
@@ -1,0 +1,88 @@
+#include "routing/position_accumulator.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/assert.hpp"
+
+#include <algorithm>
+
+double constexpr PositionAccumulator::kMinTrackLengthM;
+double constexpr PositionAccumulator::kMinGoodSegmentLengthM;
+double constexpr PositionAccumulator::kMaxGoodSegmentLengthM;
+double constexpr PositionAccumulator::kMinValidSegmentLengthM;
+double constexpr PositionAccumulator::kMaxValidSegmentLengthM;
+
+void PositionAccumulator::PushNextPoint(m2::PointD const & point)
+{
+  double const lenM =
+      m_points.empty() ? 0.0 : MercatorBounds::DistanceOnEarth(point, m_points.back());
+
+  // Only the last segment is used if it has a good length.
+  if (lenM >= kMinGoodSegmentLengthM && lenM <= kMaxGoodSegmentLengthM)
+  {
+    m_points.erase(m_points.begin(), m_points.end() - 1);
+    m_trackLengthM = lenM;
+    m_points.push_back(point);
+    CHECK_EQUAL(m_points.size(), 2, ());
+    return;
+  }
+
+  // If the last segment is too long it tells nothing about an end user direction.
+  // And the history is not actual.
+  if (lenM > kMaxValidSegmentLengthM)
+  {
+    Clear();
+    return;
+  }
+
+  // If the last segment is too short it means an end user stays we there's no information
+  // about it's direction. If m_points.empty() == true it means |point| is the first point.
+  if (!m_points.empty() && lenM < kMinValidSegmentLengthM)
+    return;
+
+  // If |m_points| is empty |point| should be added any way.
+  // If the size of |m_points| is 1 and |lenM| is valid |point| should be added.
+  if (m_points.size() < 2)
+  {
+    CHECK_EQUAL(m_trackLengthM, 0.0, ());
+    m_trackLengthM = lenM;
+    m_points.push_back(point);
+    return;
+  }
+
+  // If after adding |point| to |m_points| and removing the farthest point the segment length
+  // is less than |kMinTrackLengthM| we just adding |point|.
+  double farthestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
+  if (m_trackLengthM + lenM - farthestSegmentLenM <= kMinTrackLengthM)
+  {
+    m_trackLengthM += lenM;
+    m_points.push_back(point);
+    return;
+  }
+
+  // Removing the farthest point if length of the track |m_points[1]|, ..., |m_points.back()|, |point|
+  // is more than |kMinTrackLengthM|.
+  while (m_trackLengthM + lenM - farthestSegmentLenM > kMinTrackLengthM && m_points.size() > 2)
+  {
+    m_trackLengthM -= farthestSegmentLenM;
+    m_points.pop_front();
+    farthestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
+  }
+  m_trackLengthM += lenM;
+  m_points.push_back(point);
+  // @TODO(bykoianko) Error in |m_trackLengthM| may be accumulated.
+}
+
+void PositionAccumulator::PositionAccumulator::Clear()
+{
+  m_points.clear();
+  m_trackLengthM = 0.0;
+}
+
+m2::PointD PositionAccumulator::PositionAccumulator::GetDirection() const
+{
+  if (m_points.size() <= 1)
+    return m2::PointD::Zero();
+
+  return m_points.back() - m_points.front();
+}

--- a/routing/position_accumulator.cpp
+++ b/routing/position_accumulator.cpp
@@ -6,9 +6,9 @@
 
 #include <algorithm>
 
+namespace routing
+{
 double constexpr PositionAccumulator::kMinTrackLengthM;
-double constexpr PositionAccumulator::kMinGoodSegmentLengthM;
-double constexpr PositionAccumulator::kMaxGoodSegmentLengthM;
 double constexpr PositionAccumulator::kMinValidSegmentLengthM;
 double constexpr PositionAccumulator::kMaxValidSegmentLengthM;
 
@@ -17,21 +17,12 @@ void PositionAccumulator::PushNextPoint(m2::PointD const & point)
   double const lenM =
       m_points.empty() ? 0.0 : MercatorBounds::DistanceOnEarth(point, m_points.back());
 
-  // Only the last segment is used if it has a good length.
-  if (lenM >= kMinGoodSegmentLengthM && lenM <= kMaxGoodSegmentLengthM)
-  {
-    m_points.erase(m_points.begin(), m_points.end() - 1);
-    m_trackLengthM = lenM;
-    m_points.push_back(point);
-    CHECK_EQUAL(m_points.size(), 2, ());
-    return;
-  }
-
   // If the last segment is too long it tells nothing about an end user direction.
   // And the history is not actual.
   if (lenM > kMaxValidSegmentLengthM)
   {
     Clear();
+    m_points.push_back(point);
     return;
   }
 
@@ -52,8 +43,8 @@ void PositionAccumulator::PushNextPoint(m2::PointD const & point)
 
   // If after adding |point| to |m_points| and removing the farthest point the segment length
   // is less than |kMinTrackLengthM| we just adding |point|.
-  double farthestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
-  if (m_trackLengthM + lenM - farthestSegmentLenM <= kMinTrackLengthM)
+  double oldestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
+  if (m_trackLengthM + lenM - oldestSegmentLenM <= kMinTrackLengthM)
   {
     m_trackLengthM += lenM;
     m_points.push_back(point);
@@ -62,27 +53,28 @@ void PositionAccumulator::PushNextPoint(m2::PointD const & point)
 
   // Removing the farthest point if length of the track |m_points[1]|, ..., |m_points.back()|, |point|
   // is more than |kMinTrackLengthM|.
-  while (m_trackLengthM + lenM - farthestSegmentLenM > kMinTrackLengthM && m_points.size() > 2)
+  while (m_trackLengthM + lenM - oldestSegmentLenM > kMinTrackLengthM && m_points.size() > 2)
   {
-    m_trackLengthM -= farthestSegmentLenM;
+    m_trackLengthM -= oldestSegmentLenM;
     m_points.pop_front();
-    farthestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
+    oldestSegmentLenM = MercatorBounds::DistanceOnEarth(m_points[1], m_points[0]);
   }
+
   m_trackLengthM += lenM;
   m_points.push_back(point);
-  // @TODO(bykoianko) Error in |m_trackLengthM| may be accumulated.
 }
 
-void PositionAccumulator::PositionAccumulator::Clear()
+void PositionAccumulator::Clear()
 {
   m_points.clear();
   m_trackLengthM = 0.0;
 }
 
-m2::PointD PositionAccumulator::PositionAccumulator::GetDirection() const
+m2::PointD PositionAccumulator::GetDirection() const
 {
   if (m_points.size() <= 1)
     return m2::PointD::Zero();
 
   return m_points.back() - m_points.front();
 }
+}  // routing

--- a/routing/position_accumulator.hpp
+++ b/routing/position_accumulator.hpp
@@ -16,13 +16,12 @@ public:
   // the length of the all track will be more than |kMinTrackLengthM|.
   static double constexpr kMinTrackLengthM = 70.0;
 
-  // All segments which are shorter than
+  // All segments which are shorter than |kMinValidSegmentLengthM| are not added to the track.
   static double constexpr kMinValidSegmentLengthM = 10.0;
-  // are not added to the track.
 
-  // If a segment is longer then
+  // If a segment is longer then |kMaxValidSegmentLengthM|
+  // all the content of |m_points| is removed and the current point is added to track.
   static double constexpr kMaxValidSegmentLengthM = 80.0;
-  // all the content of |m_points| is removed the current point is added to track.
 
   void PushNextPoint(m2::PointD const & point);
   void Clear();

--- a/routing/position_accumulator.hpp
+++ b/routing/position_accumulator.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "geometry/point2d.hpp"
+
+#include <queue>
+
+/// \brief This class accumulates a track of some number of last gps positions.
+/// The track is used to calculate the direction of an end user.
+class PositionAccumulator
+{
+public:
+  // Several last gps positions are accumulating in |PositionAccumulator::m_points|.
+  // The last positions may be removed from |PositionAccumulator::m_points| in several cases.
+  // 1. If after the removing the last point the length of the track will be more than |kMinTrackLengthM|.
+  static double constexpr kMinTrackLengthM = 70.0;
+  // 2. All points from |m_points| except for |m_points.back()| if the distance between
+  // |m_points.back()| and next point (|point|) is more than
+  static double constexpr kMinGoodSegmentLengthM = 9.0;
+  // and more than
+  static double constexpr kMaxGoodSegmentLengthM = 80.0;
+  // Than means that only last segment is used to get the direction
+  // |PositionAccumulator::GetDirection()| if a driver goes quick enough.
+
+  // All segments which are shorter than
+  static double constexpr kMinValidSegmentLengthM = 1.0;
+  // and longer than
+  static double constexpr kMaxValidSegmentLengthM = kMaxGoodSegmentLengthM;
+  // should be removed.
+
+  void PushNextPoint(m2::PointD const & point);
+  void Clear();
+
+  /// \returns direction or {0.0, 0.0} if |m_points| is empty or contains only one item.
+  m2::PointD GetDirection() const;
+
+  // Getters for testing this class.
+  std::deque<m2::PointD> const & GetPointsForTesting() const { return m_points; }
+  double GetTrackLengthMForTesting() const { return m_trackLengthM; }
+
+private:
+  // There's the current position at the end. At the beginning there's the last position of the track.
+  // The distance between them is more or equal than |kMinTrackLengthM| if there're enough points in
+  // |m_points|.
+  std::deque<m2::PointD> m_points;
+  double m_trackLengthM = 0.0;
+};

--- a/routing/position_accumulator.hpp
+++ b/routing/position_accumulator.hpp
@@ -4,28 +4,25 @@
 
 #include <queue>
 
+namespace routing
+{
 /// \brief This class accumulates a track of some number of last gps positions.
 /// The track is used to calculate the direction of an end user.
 class PositionAccumulator
 {
 public:
   // Several last gps positions are accumulating in |PositionAccumulator::m_points|.
-  // The last positions may be removed from |PositionAccumulator::m_points| in several cases.
-  // 1. If after the removing the last point the length of the track will be more than |kMinTrackLengthM|.
+  // The last position (the last point from |m_points|) may be removed if after the removing it
+  // the length of the all track will be more than |kMinTrackLengthM|.
   static double constexpr kMinTrackLengthM = 70.0;
-  // 2. All points from |m_points| except for |m_points.back()| if the distance between
-  // |m_points.back()| and next point (|point|) is more than
-  static double constexpr kMinGoodSegmentLengthM = 9.0;
-  // and more than
-  static double constexpr kMaxGoodSegmentLengthM = 80.0;
-  // Than means that only last segment is used to get the direction
-  // |PositionAccumulator::GetDirection()| if a driver goes quick enough.
 
   // All segments which are shorter than
-  static double constexpr kMinValidSegmentLengthM = 1.0;
-  // and longer than
-  static double constexpr kMaxValidSegmentLengthM = kMaxGoodSegmentLengthM;
-  // should be removed.
+  static double constexpr kMinValidSegmentLengthM = 10.0;
+  // are not added to the track.
+
+  // If a segment is longer then
+  static double constexpr kMaxValidSegmentLengthM = 80.0;
+  // all the content of |m_points| is removed the current point is added to track.
 
   void PushNextPoint(m2::PointD const & point);
   void Clear();
@@ -44,3 +41,4 @@ private:
   std::deque<m2::PointD> m_points;
   double m_trackLengthM = 0.0;
 };
+}  // routing

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -610,8 +610,19 @@ void RoutingSession::SetUserCurrentPosition(m2::PointD const & position)
 
   m_userCurrentPosition = position;
   m_userCurrentPositionValid = true;
+}
+
+void RoutingSession::PushPositionAccumulator(m2::PointD const & position)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_positionAccumulator.PushNextPoint(position);
+}
+void RoutingSession::ClearPositionAccumulator()
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+
+  m_positionAccumulator.Clear();
 }
 
 void RoutingSession::EnableTurnNotifications(bool enable)

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/async_router.hpp"
+#include "routing/position_accumulator.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
@@ -105,6 +106,10 @@ public:
 
   void SetUserCurrentPosition(m2::PointD const & position);
 
+  void ClearPositionAccumulator() { m_positionAccumulator.Clear(); }
+
+  void ActivateAdditionalFeatures() {}
+
   /// Disable following mode on GPS updates. Following mode is disabled only for the current route.
   /// If a route is rebuilt you must call DisableFollowMode again.
   /// Returns true if following was disabled, false if a route is not ready for the following yet.
@@ -188,23 +193,21 @@ private:
   bool m_isFollowing;
   Checkpoints m_checkpoints;
 
-
   /// Current position metrics to check for RouteNeedRebuild state.
   double m_lastDistance = 0.0;
   int m_moveAwayCounter = 0;
   m2::PointD m_lastGoodPosition;
-  // |m_currentDirection| is a vector from the position before last good position to last good position.
-  m2::PointD m_currentDirection;
+
   m2::PointD m_userCurrentPosition;
-  m2::PointD m_userFormerPosition;
   bool m_userCurrentPositionValid = false;
-  bool m_userFormerPositionValid = false;
 
   // Sound turn notification parameters.
   turns::sound::NotificationManager m_turnNotificationsMgr;
 
   SpeedCameraManager m_speedCameraManager;
   RoutingSettings m_routingSettings;
+
+  PositionAccumulator m_positionAccumulator;
 
   ReadyCallback m_buildReadyCallback;
   ReadyCallback m_rebuildReadyCallback;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -106,7 +106,8 @@ public:
 
   void SetUserCurrentPosition(m2::PointD const & position);
 
-  void ClearPositionAccumulator() { m_positionAccumulator.Clear(); }
+  void PushPositionAccumulator(m2::PointD const & position);
+  void ClearPositionAccumulator();
 
   void ActivateAdditionalFeatures() {}
 

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
   maxspeeds_tests.cpp
   nearest_edge_finder_tests.cpp
   online_cross_fetcher_test.cpp
+  position_accumulator_tests.cpp
   restriction_test.cpp
   road_access_test.cpp
   road_graph_builder.cpp

--- a/routing/routing_tests/position_accumulator_tests.cpp
+++ b/routing/routing_tests/position_accumulator_tests.cpp
@@ -1,0 +1,100 @@
+#include "testing/testing.hpp"
+
+#include "routing/position_accumulator.hpp"
+
+#include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
+
+#include "base/math.hpp"
+
+namespace
+{
+double constexpr kEps = 1e-10;
+double constexpr kEpsMeters = 0.1;
+
+class PositionAccumulatorTest
+{
+public:
+  void PushNextPoint(m2::PointD const & point) { m_positionAccumulator.PushNextPoint(point); }
+  void Clear() { m_positionAccumulator.Clear(); }
+  m2::PointD GetDirection() const { return m_positionAccumulator.GetDirection(); }
+
+  std::deque<m2::PointD> const & GetPoints() const
+  {
+    return m_positionAccumulator.GetPointsForTesting();
+  }
+
+  double GetTrackLengthM() const { return m_positionAccumulator.GetTrackLengthMForTesting(); }
+
+private:
+  PositionAccumulator m_positionAccumulator;
+};
+
+UNIT_CLASS_TEST(PositionAccumulatorTest, Smoke)
+{
+  PushNextPoint({0.0, 0.0});
+  PushNextPoint({0.00001, 0.0});
+  TEST_EQUAL(GetPoints().size(), 2, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.00001, 0.0), kEps), ());
+  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 1.11, kEpsMeters), (GetTrackLengthM()));
+}
+
+// Test on using good segments.
+UNIT_CLASS_TEST(PositionAccumulatorTest, LastGoodSegment)
+{
+  double constexpr kStepShortButValid = 0.00001;
+
+  for (signed i = -10; i <= 0; ++i)
+    PushNextPoint({kStepShortButValid * i, 0.0});
+  TEST_EQUAL(GetPoints().size(), 11, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(10 * kStepShortButValid, 0.0), kEps),
+       (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 11.13, kEpsMeters), (GetTrackLengthM()));
+
+  double constexpr kStepGood = 0.0001;
+  for (size_t i = 0; i < 10; ++i)
+    PushNextPoint({kStepGood * i, 0.0});
+
+  TEST_EQUAL(GetPoints().size(), 2, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStepGood, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 11.13, kEpsMeters), (GetTrackLengthM()));
+  TEST(m2::AlmostEqualAbs({kStepGood * 8, 0.0}, GetPoints()[0], kEps), ());
+  TEST(m2::AlmostEqualAbs({kStepGood * 9, 0.0}, GetPoints()[1], kEps), ());
+}
+
+// Test on removing too outdated elements from the position accumulator.
+// Adding short but still valid segments.
+UNIT_CLASS_TEST(PositionAccumulatorTest, RemovingOutdated)
+{
+  double constexpr kStep = 0.00001;
+  for (size_t i = 0; i < 100; ++i)
+    PushNextPoint({kStep * i, 0.0});
+
+  TEST_EQUAL(GetPoints().size(), 64, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStep * 63, 0.0), kEps), (GetDirection()));
+
+  for (size_t i = 36; i < 100; ++i)
+  {
+    TEST(m2::AlmostEqualAbs({kStep * i, 0.0}, GetPoints()[i - 36], kEps),
+         (m2::PointD(kStep * i, 0.0), GetPoints()[i - 36], i));
+  }
+}
+
+// Test on adding segments longer than |PositionAccumulator::kMaxValidSegmentLengthM|
+// and shorter than |PositionAccumulator::kMinValidSegmentLengthM|.
+UNIT_CLASS_TEST(PositionAccumulatorTest, LongSegment)
+{
+  PushNextPoint({0.0, 0.0});
+  PushNextPoint({0.001, 0.0}); // Longer than |MaxValidSegmentLengthM|.
+  TEST(GetPoints().empty(), ());
+  PushNextPoint({0.001001, 0.0}); // Shorter than |kMinValidSegmentLengthM|, but the first one.
+  PushNextPoint({0.00102, 0.0});
+  PushNextPoint({0.00103, 0.0});
+  PushNextPoint({0.001031, 0.0}); // Shorter than |kMinValidSegmentLengthM|, so it's ignored.
+  TEST_EQUAL(GetPoints().size(), 3, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.000029, 0.0), kEps), (GetDirection()));
+  PushNextPoint({0.00201, 0.0}); // Longer than |PositionAccumulator::kMaxValidSegmentLengthM|.
+  TEST_EQUAL(GetPoints().size(), 0, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0, 0.0), kEps), (GetDirection()));
+}
+}  // namespace

--- a/routing/routing_tests/position_accumulator_tests.cpp
+++ b/routing/routing_tests/position_accumulator_tests.cpp
@@ -9,92 +9,79 @@
 
 namespace
 {
+using namespace routing;
+
 double constexpr kEps = 1e-10;
 double constexpr kEpsMeters = 0.1;
 
-class PositionAccumulatorTest
-{
-public:
-  void PushNextPoint(m2::PointD const & point) { m_positionAccumulator.PushNextPoint(point); }
-  void Clear() { m_positionAccumulator.Clear(); }
-  m2::PointD GetDirection() const { return m_positionAccumulator.GetDirection(); }
-
-  std::deque<m2::PointD> const & GetPoints() const
-  {
-    return m_positionAccumulator.GetPointsForTesting();
-  }
-
-  double GetTrackLengthM() const { return m_positionAccumulator.GetTrackLengthMForTesting(); }
-
-private:
-  PositionAccumulator m_positionAccumulator;
-};
-
-UNIT_CLASS_TEST(PositionAccumulatorTest, Smoke)
+UNIT_CLASS_TEST(PositionAccumulator, Smoke)
 {
   PushNextPoint({0.0, 0.0});
-  PushNextPoint({0.00001, 0.0});
-  TEST_EQUAL(GetPoints().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.00001, 0.0), kEps), ());
-  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 1.11, kEpsMeters), (GetTrackLengthM()));
+  PushNextPoint({0.00002, 0.0});
+  TEST_EQUAL(GetPointsForTesting().size(), 2, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.00002, 0.0), kEps), ());
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 2.22, kEpsMeters),
+       (GetTrackLengthMForTesting()));
 }
 
 // Test on using good segments.
-UNIT_CLASS_TEST(PositionAccumulatorTest, LastGoodSegment)
+UNIT_CLASS_TEST(PositionAccumulator, LastGoodSegment)
 {
-  double constexpr kStepShortButValid = 0.00001;
+  double constexpr kStepShortButValid = 0.00002;
 
   for (signed i = -10; i <= 0; ++i)
     PushNextPoint({kStepShortButValid * i, 0.0});
-  TEST_EQUAL(GetPoints().size(), 11, ());
+  TEST_EQUAL(GetPointsForTesting().size(), 11, ());
   TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(10 * kStepShortButValid, 0.0), kEps),
        (GetDirection()));
-  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 11.13, kEpsMeters), (GetTrackLengthM()));
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 22.26, kEpsMeters),
+       (GetTrackLengthMForTesting()));
 
   double constexpr kStepGood = 0.0001;
   for (size_t i = 0; i < 10; ++i)
     PushNextPoint({kStepGood * i, 0.0});
 
-  TEST_EQUAL(GetPoints().size(), 2, ());
+  TEST_EQUAL(GetPointsForTesting().size(), 2, ());
   TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStepGood, 0.0), kEps), (GetDirection()));
-  TEST(base::AlmostEqualAbs(GetTrackLengthM(), 11.13, kEpsMeters), (GetTrackLengthM()));
-  TEST(m2::AlmostEqualAbs({kStepGood * 8, 0.0}, GetPoints()[0], kEps), ());
-  TEST(m2::AlmostEqualAbs({kStepGood * 9, 0.0}, GetPoints()[1], kEps), ());
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 11.13, kEpsMeters),
+       (GetTrackLengthMForTesting()));
+  TEST(m2::AlmostEqualAbs({kStepGood * 8, 0.0}, GetPointsForTesting()[0], kEps), ());
+  TEST(m2::AlmostEqualAbs({kStepGood * 9, 0.0}, GetPointsForTesting()[1], kEps), ());
 }
 
 // Test on removing too outdated elements from the position accumulator.
 // Adding short but still valid segments.
-UNIT_CLASS_TEST(PositionAccumulatorTest, RemovingOutdated)
+UNIT_CLASS_TEST(PositionAccumulator, RemovingOutdated)
 {
-  double constexpr kStep = 0.00001;
+  double constexpr kStep = 0.00002;
   for (size_t i = 0; i < 100; ++i)
     PushNextPoint({kStep * i, 0.0});
 
-  TEST_EQUAL(GetPoints().size(), 64, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStep * 63, 0.0), kEps), (GetDirection()));
+  TEST_EQUAL(GetPointsForTesting().size(), 33, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStep * 32, 0.0), kEps), (GetDirection()));
 
-  for (size_t i = 36; i < 100; ++i)
+  for (size_t i = 67; i < 100; ++i)
   {
-    TEST(m2::AlmostEqualAbs({kStep * i, 0.0}, GetPoints()[i - 36], kEps),
-         (m2::PointD(kStep * i, 0.0), GetPoints()[i - 36], i));
+    TEST(m2::AlmostEqualAbs({kStep * i, 0.0}, GetPointsForTesting()[i - 67], kEps),
+         (m2::PointD(kStep * i, 0.0), GetPointsForTesting()[i - 67], i));
   }
 }
 
 // Test on adding segments longer than |PositionAccumulator::kMaxValidSegmentLengthM|
 // and shorter than |PositionAccumulator::kMinValidSegmentLengthM|.
-UNIT_CLASS_TEST(PositionAccumulatorTest, LongSegment)
+UNIT_CLASS_TEST(PositionAccumulator, LongSegment)
 {
   PushNextPoint({0.0, 0.0});
   PushNextPoint({0.001, 0.0}); // Longer than |MaxValidSegmentLengthM|.
-  TEST(GetPoints().empty(), ());
+  TEST(GetPointsForTesting().empty(), ());
   PushNextPoint({0.001001, 0.0}); // Shorter than |kMinValidSegmentLengthM|, but the first one.
   PushNextPoint({0.00102, 0.0});
-  PushNextPoint({0.00103, 0.0});
-  PushNextPoint({0.001031, 0.0}); // Shorter than |kMinValidSegmentLengthM|, so it's ignored.
-  TEST_EQUAL(GetPoints().size(), 3, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.000029, 0.0), kEps), (GetDirection()));
+  PushNextPoint({0.00104, 0.0});
+  PushNextPoint({0.001041, 0.0}); // Shorter than |kMinValidSegmentLengthM|, so it's ignored.
+  TEST_EQUAL(GetPointsForTesting().size(), 3, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.000039, 0.0), kEps), (GetDirection()));
   PushNextPoint({0.00201, 0.0}); // Longer than |PositionAccumulator::kMaxValidSegmentLengthM|.
-  TEST_EQUAL(GetPoints().size(), 0, ());
+  TEST_EQUAL(GetPointsForTesting().size(), 0, ());
   TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0, 0.0), kEps), (GetDirection()));
 }
 }  // namespace

--- a/routing/routing_tests/position_accumulator_tests.cpp
+++ b/routing/routing_tests/position_accumulator_tests.cpp
@@ -17,36 +17,38 @@ double constexpr kEpsMeters = 0.1;
 UNIT_CLASS_TEST(PositionAccumulator, Smoke)
 {
   PushNextPoint({0.0, 0.0});
-  PushNextPoint({0.00002, 0.0});
+  PushNextPoint({0.00005, 0.0});
+  PushNextPoint({0.0001, 0.0});
   TEST_EQUAL(GetPointsForTesting().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.00002, 0.0), kEps), ());
-  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 2.22, kEpsMeters),
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0001, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 11.13, kEpsMeters),
        (GetTrackLengthMForTesting()));
 }
 
-// Test on using good segments.
-UNIT_CLASS_TEST(PositionAccumulator, LastGoodSegment)
+UNIT_CLASS_TEST(PositionAccumulator, GoodSegment)
 {
-  double constexpr kStepShortButValid = 0.00002;
+  double constexpr kStepShortButValid = 0.00001;
 
-  for (signed i = -10; i <= 0; ++i)
+  // The distance from points with i = -15 to point with i = -6 is a little more then
+  // |PositionAccumulator::kMinValidSegmentLengthM| meters. But the distance from
+  // point with i = -4 to point with i = 0 is less then |PositionAccumulator::kMinValidSegmentLengthM|.
+  // So the direction is calculated based on two points.
+  for (signed i = -15; i <= 0; ++i)
     PushNextPoint({kStepShortButValid * i, 0.0});
-  TEST_EQUAL(GetPointsForTesting().size(), 11, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(10 * kStepShortButValid, 0.0), kEps),
+  TEST_EQUAL(GetPointsForTesting().size(), 2, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(9 * kStepShortButValid, 0.0), kEps),
        (GetDirection()));
-  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 22.26, kEpsMeters),
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 10.02, kEpsMeters),
        (GetTrackLengthMForTesting()));
 
   double constexpr kStepGood = 0.0001;
   for (size_t i = 0; i < 10; ++i)
     PushNextPoint({kStepGood * i, 0.0});
 
-  TEST_EQUAL(GetPointsForTesting().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStepGood, 0.0), kEps), (GetDirection()));
-  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 11.13, kEpsMeters),
+  TEST_EQUAL(GetPointsForTesting().size(), 8, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 77.92, kEpsMeters),
        (GetTrackLengthMForTesting()));
-  TEST(m2::AlmostEqualAbs({kStepGood * 8, 0.0}, GetPointsForTesting()[0], kEps), ());
-  TEST(m2::AlmostEqualAbs({kStepGood * 9, 0.0}, GetPointsForTesting()[1], kEps), ());
 }
 
 // Test on removing too outdated elements from the position accumulator.
@@ -57,14 +59,8 @@ UNIT_CLASS_TEST(PositionAccumulator, RemovingOutdated)
   for (size_t i = 0; i < 100; ++i)
     PushNextPoint({kStep * i, 0.0});
 
-  TEST_EQUAL(GetPointsForTesting().size(), 33, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(kStep * 32, 0.0), kEps), (GetDirection()));
-
-  for (size_t i = 67; i < 100; ++i)
-  {
-    TEST(m2::AlmostEqualAbs({kStep * i, 0.0}, GetPointsForTesting()[i - 67], kEps),
-         (m2::PointD(kStep * i, 0.0), GetPointsForTesting()[i - 67], i));
-  }
+  TEST_EQUAL(GetPointsForTesting().size(), 8, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
 }
 
 // Test on adding segments longer than |PositionAccumulator::kMaxValidSegmentLengthM|
@@ -73,15 +69,17 @@ UNIT_CLASS_TEST(PositionAccumulator, LongSegment)
 {
   PushNextPoint({0.0, 0.0});
   PushNextPoint({0.001, 0.0}); // Longer than |MaxValidSegmentLengthM|.
-  TEST(GetPointsForTesting().empty(), ());
-  PushNextPoint({0.001001, 0.0}); // Shorter than |kMinValidSegmentLengthM|, but the first one.
+  TEST_EQUAL(GetPointsForTesting().size(), 1, ());
+  PushNextPoint({0.001001, 0.0}); // Shorter than |kMinValidSegmentLengthM|, so it's ignored.
   PushNextPoint({0.00102, 0.0});
   PushNextPoint({0.00104, 0.0});
-  PushNextPoint({0.001041, 0.0}); // Shorter than |kMinValidSegmentLengthM|, so it's ignored.
-  TEST_EQUAL(GetPointsForTesting().size(), 3, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.000039, 0.0), kEps), (GetDirection()));
+  // The distance from point {0.001, 0.0} to this one is greater then
+  // |PositionAccumulator::kMinValidSegmentLengthM|, so the point is added.
+  PushNextPoint({0.0012, 0.0});
+  TEST_EQUAL(GetPointsForTesting().size(), 2, ());
+  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0002, 0.0), kEps), (GetDirection()));
   PushNextPoint({0.00201, 0.0}); // Longer than |PositionAccumulator::kMaxValidSegmentLengthM|.
-  TEST_EQUAL(GetPointsForTesting().size(), 0, ());
+  TEST_EQUAL(GetPointsForTesting().size(), 1, ());
   TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0, 0.0), kEps), (GetDirection()));
 }
 }  // namespace

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		56CA630A1F619C1000E6681B /* road_graph_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA63061F61206700E6681B /* road_graph_tests.cpp */; };
 		56CBED5522E9CE2600D51AF7 /* position_accumulator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CBED5322E9CE2500D51AF7 /* position_accumulator.hpp */; };
 		56CBED5622E9CE2600D51AF7 /* position_accumulator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CBED5422E9CE2600D51AF7 /* position_accumulator.cpp */; };
+		56CBED5822E9CFB600D51AF7 /* position_accumulator_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CBED5722E9CFB600D51AF7 /* position_accumulator_tests.cpp */; };
 		56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */; };
 		56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */; };
 		56ED7DBD1F69425700B67156 /* turn_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 567E9F741F5850460064CB96 /* turn_test.cpp */; };
@@ -459,6 +460,7 @@
 		56CA63061F61206700E6681B /* road_graph_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_graph_tests.cpp; sourceTree = "<group>"; };
 		56CBED5322E9CE2500D51AF7 /* position_accumulator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = position_accumulator.hpp; sourceTree = "<group>"; };
 		56CBED5422E9CE2600D51AF7 /* position_accumulator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = position_accumulator.cpp; sourceTree = "<group>"; };
+		56CBED5722E9CFB600D51AF7 /* position_accumulator_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = position_accumulator_tests.cpp; sourceTree = "<group>"; };
 		56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_index_graph.hpp; sourceTree = "<group>"; };
 		56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_helpers.hpp; sourceTree = "<group>"; };
 		56EE14DC1FE812FC0036F20C /* libtransit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtransit.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -710,6 +712,7 @@
 		6742ACA01C68A07C009CB89E /* routing_tests */ = {
 			isa = PBXGroup;
 			children = (
+				56CBED5722E9CFB600D51AF7 /* position_accumulator_tests.cpp */,
 				440BE38722AFB31600C548FB /* uturn_restriction_tests.cpp */,
 				440BE38322AFB31100C548FB /* world_graph_builder.cpp */,
 				440BE38422AFB31100C548FB /* world_graph_builder.hpp */,
@@ -1306,6 +1309,7 @@
 				6742AD291C68A9DF009CB89E /* astar_router_test.cpp in Sources */,
 				6742AD371C68A9DF009CB89E /* turns_tts_text_tests.cpp in Sources */,
 				6742AD2C1C68A9DF009CB89E /* followed_polyline_test.cpp in Sources */,
+				56CBED5822E9CFB600D51AF7 /* position_accumulator_tests.cpp in Sources */,
 				6742AD341C68A9DF009CB89E /* routing_session_test.cpp in Sources */,
 				6742AD261C68A9DF009CB89E /* testingmain.cpp in Sources */,
 				6742AD361C68A9DF009CB89E /* turns_sound_test.cpp in Sources */,

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA09E21E30E73B00D05C9A /* restriction_test.cpp */; };
 		56CA09E91E30F19800D05C9A /* libtraffic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56CA09E81E30F19800D05C9A /* libtraffic.a */; };
 		56CA630A1F619C1000E6681B /* road_graph_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CA63061F61206700E6681B /* road_graph_tests.cpp */; };
+		56CBED5522E9CE2600D51AF7 /* position_accumulator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CBED5322E9CE2500D51AF7 /* position_accumulator.hpp */; };
+		56CBED5622E9CE2600D51AF7 /* position_accumulator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56CBED5422E9CE2600D51AF7 /* position_accumulator.cpp */; };
 		56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */; };
 		56EA2FD51D8FD8590083F01A /* routing_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */; };
 		56ED7DBD1F69425700B67156 /* turn_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 567E9F741F5850460064CB96 /* turn_test.cpp */; };
@@ -455,6 +457,8 @@
 		56CA09E21E30E73B00D05C9A /* restriction_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = restriction_test.cpp; sourceTree = "<group>"; };
 		56CA09E81E30F19800D05C9A /* libtraffic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtraffic.a; path = "/Users/vladimirbykoyanko/src_github_master/omim/xcode/traffic/../../../omim-build/xcode/Debug/libtraffic.a"; sourceTree = "<absolute>"; };
 		56CA63061F61206700E6681B /* road_graph_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_graph_tests.cpp; sourceTree = "<group>"; };
+		56CBED5322E9CE2500D51AF7 /* position_accumulator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = position_accumulator.hpp; sourceTree = "<group>"; };
+		56CBED5422E9CE2600D51AF7 /* position_accumulator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = position_accumulator.cpp; sourceTree = "<group>"; };
 		56CC5A361E3884960016AC46 /* cross_mwm_index_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_mwm_index_graph.hpp; sourceTree = "<group>"; };
 		56EA2FD41D8FD8590083F01A /* routing_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_helpers.hpp; sourceTree = "<group>"; };
 		56EE14DC1FE812FC0036F20C /* libtransit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtransit.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -845,6 +849,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				56CBED5422E9CE2600D51AF7 /* position_accumulator.cpp */,
+				56CBED5322E9CE2500D51AF7 /* position_accumulator.hpp */,
 				4443DC3522789793000C8E32 /* leaps_postprocessor.cpp */,
 				4443DC3622789793000C8E32 /* leaps_postprocessor.hpp */,
 				44A95C6F225F6A4F00C22F4F /* astar_graph.hpp */,
@@ -1060,6 +1066,7 @@
 				674F9BCD1B0A580E00704FFA /* features_road_graph.hpp in Headers */,
 				40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */,
 				670EE5741B664796001E8064 /* pedestrian_directions.hpp in Headers */,
+				56CBED5522E9CE2600D51AF7 /* position_accumulator.hpp in Headers */,
 				5694CECB1EBA25F7004576D3 /* road_access_serialization.hpp in Headers */,
 				0C08AA371DF8324D004195DD /* vehicle_mask.hpp in Headers */,
 				6753441D1A3F644F00A0A8C3 /* router.hpp in Headers */,
@@ -1352,6 +1359,7 @@
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,
 				5694CECE1EBA25F7004576D3 /* vehicle_mask.cpp in Sources */,
 				0C45D7391F2F75500065C3ED /* routing_settings.cpp in Sources */,
+				56CBED5622E9CE2600D51AF7 /* position_accumulator.cpp in Sources */,
 				0C5FEC691DDE193F0017688C /* road_index.cpp in Sources */,
 				0CF709361F05172200D5067E /* checkpoints.cpp in Sources */,
 				671F58BD1B874EC80032311E /* followed_polyline.cpp in Sources */,


### PR DESCRIPTION
При перепрокладке маршрута сейчас используется направление движения пользователя для лучшего выбора стартового сегмента маршрута. Чтоб вычислить направление используются 2 последние gps координаты.

Это иногда плохо работает. Например, когда клиент останавливается на светофоре и маршрут из-за загрузки пробок перестраивается.

Данный PR сохраняет историю из нескольких последних координат и на базе ряда координат вычисляет направление движения. Если клиент стоит - координаты не добавляются.

@vmihaylenko PTAL