### PR TITLE
[search] [bookmarks] Implemented Attach/Detach listeners in search.

### DIFF
--- a/map/bookmarks_search_params.hpp
+++ b/map/bookmarks_search_params.hpp
@@ -25,7 +25,7 @@ struct BookmarksSearchParams
   using OnResults = std::function<void(Results const & results, Status status)>;
 
   std::string m_query;
-  kml::MarkGroupId m_categoryId = kml::kInvalidMarkGroupId;
+  kml::MarkGroupId m_groupId = kml::kInvalidMarkGroupId;
   OnStarted m_onStarted;
   OnResults m_onResults;
 };

--- a/map/map_tests/search_api_tests.cpp
+++ b/map/map_tests/search_api_tests.cpp
@@ -146,6 +146,7 @@ UNIT_CLASS_TEST(SearchAPITest, BookmarksSearch)
   kml::SetDefaultStr(data.m_description, "Clean place with a reasonable price");
   marks.emplace_back(2, data);
   m_api.OnBookmarksCreated(marks);
+  m_api.OnViewportChanged(m2::RectD(-1, -1, 1, 1));
 
   auto runTest = [&](string const & query, kml::MarkGroupId const & groupId,
                      vector<kml::MarkId> const & expected) {
@@ -162,7 +163,6 @@ UNIT_CLASS_TEST(SearchAPITest, BookmarksSearch)
     };
     params.m_groupId = groupId;
 
-    m_api.OnViewportChanged(m2::RectD(-1, -1, 1, 1));
     m_api.SearchInBookmarks(params);
 
     auto const ids = future.get();

--- a/map/search_api.cpp
+++ b/map/search_api.cpp
@@ -19,6 +19,7 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/checked_cast.hpp"
 #include "base/scope_guard.hpp"
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
@@ -59,9 +60,9 @@ bookmarks::Id KmlMarkIdToSearchBookmarkId(kml::MarkId id)
   static_assert(is_unsigned<kml::MarkId>::value, "");
   static_assert(is_unsigned<bookmarks::Id>::value, "");
 
-  static_assert(sizeof(bookmarks::Id) >= sizeof(kml::MarkId), "");
+  static_assert(sizeof(bookmarks::Id) == sizeof(kml::MarkId), "");
 
-  return static_cast<bookmarks::Id>(id);
+  return base::asserted_cast<bookmarks::Id>(id);
 }
 
 bookmarks::GroupId KmlGroupIdToSearchGroupId(kml::MarkGroupId id)
@@ -77,7 +78,7 @@ bookmarks::GroupId KmlGroupIdToSearchGroupId(kml::MarkGroupId id)
   if (id == kml::kInvalidMarkGroupId)
     return bookmarks::kInvalidGroupId;
 
-  return static_cast<bookmarks::GroupId>(id);
+  return base::asserted_cast<bookmarks::GroupId>(id);
 }
 
 kml::MarkId SearchBookmarkIdToKmlMarkId(bookmarks::Id id) { return static_cast<kml::MarkId>(id); }
@@ -410,7 +411,7 @@ void SearchAPI::OnBookmarksDeleted(vector<kml::MarkId> const & marks)
   m_engine.OnBookmarksDeleted(data);
 }
 
-void SearchAPI::OnBookmarksAttached(std::vector<BookmarkGroupInfo> const & groupInfos)
+void SearchAPI::OnBookmarksAttached(vector<BookmarkGroupInfo> const & groupInfos)
 {
   for (auto const & info : groupInfos)
   {
@@ -420,7 +421,7 @@ void SearchAPI::OnBookmarksAttached(std::vector<BookmarkGroupInfo> const & group
   }
 }
 
-void SearchAPI::OnBookmarksDetached(std::vector<BookmarkGroupInfo> const & groupInfos)
+void SearchAPI::OnBookmarksDetached(vector<BookmarkGroupInfo> const & groupInfos)
 {
   for (auto const & info : groupInfos)
   {

--- a/map/search_api.hpp
+++ b/map/search_api.hpp
@@ -147,8 +147,8 @@ public:
   void OnBookmarksCreated(std::vector<BookmarkInfo> const & marks);
   void OnBookmarksUpdated(std::vector<BookmarkInfo> const & marks);
   void OnBookmarksDeleted(std::vector<kml::MarkId> const & marks);
-  void OnBookmarksAttached(std::vector<BookmarkGroupInfo> const & marks);
-  void OnBookmarksDetached(std::vector<BookmarkGroupInfo> const & marks);
+  void OnBookmarksAttached(std::vector<BookmarkGroupInfo> const & groupInfos);
+  void OnBookmarksDetached(std::vector<BookmarkGroupInfo> const & groupInfos);
 
 private:
   struct SearchIntent

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
   bookmarks/processor.cpp
   bookmarks/processor.hpp
   bookmarks/results.hpp
+  bookmarks/types.cpp
   bookmarks/types.hpp
   cancel_exception.hpp
   categories_cache.cpp

--- a/search/bookmarks/data.hpp
+++ b/search/bookmarks/data.hpp
@@ -26,6 +26,7 @@ struct Data
 
   Data(kml::BookmarkData const & bookmarkData)
     : m_name(kml::GetDefaultStr(bookmarkData.m_name))
+    // todo(@m) Do not add descriptions to index in Version 0.
     , m_description(kml::GetDefaultStr(bookmarkData.m_description))
   {
   }

--- a/search/bookmarks/processor.cpp
+++ b/search/bookmarks/processor.cpp
@@ -120,12 +120,14 @@ void Processor::DetachFromGroup(Id const & id, GroupId const & group)
   {
     LOG(LWARNING, ("Tried to detach bookmark", id, "from group", group,
                    "but it does not belong to any group"));
+    return;
   }
 
   if (it->second != group)
   {
     LOG(LWARNING, ("Tried to detach bookmark", id, "from group", group,
                    "but it only belongs to group", it->second));
+    return;
   }
   m_idToGroup.erase(it);
 }

--- a/search/bookmarks/processor.hpp
+++ b/search/bookmarks/processor.hpp
@@ -33,13 +33,22 @@ class Processor : public IdfMap::Delegate
 public:
   using Index = search_base::MemSearchIndex<Id>;
 
+  struct Params : public QueryParams
+  {
+    // If valid, only show results with bookmarks attached to |m_groupId|.
+    GroupId m_groupId = kInvalidGroupId;
+  };
+
   Processor(Emitter & emitter, base::Cancellable const & cancellable);
   ~Processor() override = default;
 
   void Add(Id const & id, Doc const & doc);
   void Erase(Id const & id);
 
-  void Search(QueryParams const & params) const;
+  void AttachToGroup(Id const & id, GroupId const & group);
+  void DetachFromGroup(Id const & id, GroupId const & group);
+
+  void Search(Params const & params) const;
 
   // IdfMap::Delegate overrides:
   uint64_t GetNumDocs(strings::UniString const & token, bool isPrefix) const override;
@@ -68,6 +77,11 @@ private:
 
   Index m_index;
   std::unordered_map<Id, DocVec> m_docs;
+
+  // Currently a bookmark can belong to at most one group
+  // but in the future it is possible for a single bookmark to be
+  // attached to multiple groups.
+  std::unordered_map<Id, GroupId> m_idToGroup;
 };
 }  // namespace bookmarks
 }  // namespace search

--- a/search/bookmarks/types.cpp
+++ b/search/bookmarks/types.cpp
@@ -1,0 +1,9 @@
+#include "search/bookmarks/types.hpp"
+
+namespace search
+{
+namespace bookmarks
+{
+GroupId const kInvalidGroupId = std::numeric_limits<GroupId>::max();
+}  // namespace bookmarks
+}  // namespace search

--- a/search/bookmarks/types.hpp
+++ b/search/bookmarks/types.hpp
@@ -14,6 +14,6 @@ using Id = uint64_t;
 using GroupId = uint64_t;
 using Doc = Data;
 
-GroupId constexpr kInvalidGroupId = std::numeric_limits<GroupId>::max();
+extern GroupId const kInvalidGroupId;
 }  // namespace bookmarks
 }  // namespace search

--- a/search/bookmarks/types.hpp
+++ b/search/bookmarks/types.hpp
@@ -3,12 +3,17 @@
 #include "search/bookmarks/data.hpp"
 
 #include <cstdint>
+#include <limits>
 
 namespace search
 {
 namespace bookmarks
 {
+// todo(@m) s/Id/DocId/g ?
 using Id = uint64_t;
+using GroupId = uint64_t;
 using Doc = Data;
+
+GroupId constexpr kInvalidGroupId = std::numeric_limits<GroupId>::max();
 }  // namespace bookmarks
 }  // namespace search

--- a/search/engine.cpp
+++ b/search/engine.cpp
@@ -176,19 +176,19 @@ void Engine::OnBookmarksDeleted(vector<bookmarks::Id> const & marks)
               [marks](Processor & processor) { processor.OnBookmarksDeleted(marks); });
 }
 
-void Engine::OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+void Engine::OnBookmarksAttachedToGroup(bookmarks::GroupId const & groupId,
                                         vector<bookmarks::Id> const & marks)
 {
-  PostMessage(Message::TYPE_BROADCAST, [group, marks](Processor & processor) {
-    processor.OnBookmarksAttachedToGroup(group, marks);
+  PostMessage(Message::TYPE_BROADCAST, [groupId, marks](Processor & processor) {
+    processor.OnBookmarksAttachedToGroup(groupId, marks);
   });
 }
 
-void Engine::OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+void Engine::OnBookmarksDetachedFromGroup(bookmarks::GroupId const & groupId,
                                           vector<bookmarks::Id> const & marks)
 {
-  PostMessage(Message::TYPE_BROADCAST, [group, marks](Processor & processor) {
-    processor.OnBookmarksDetachedFromGroup(group, marks);
+  PostMessage(Message::TYPE_BROADCAST, [groupId, marks](Processor & processor) {
+    processor.OnBookmarksDetachedFromGroup(groupId, marks);
   });
 }
 

--- a/search/engine.cpp
+++ b/search/engine.cpp
@@ -176,6 +176,22 @@ void Engine::OnBookmarksDeleted(vector<bookmarks::Id> const & marks)
               [marks](Processor & processor) { processor.OnBookmarksDeleted(marks); });
 }
 
+void Engine::OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+                                        vector<bookmarks::Id> const & marks)
+{
+  PostMessage(Message::TYPE_BROADCAST, [group, marks](Processor & processor) {
+    processor.OnBookmarksAttachedToGroup(group, marks);
+  });
+}
+
+void Engine::OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+                                          vector<bookmarks::Id> const & marks)
+{
+  PostMessage(Message::TYPE_BROADCAST, [group, marks](Processor & processor) {
+    processor.OnBookmarksDetachedFromGroup(group, marks);
+  });
+}
+
 void Engine::MainLoop(Context & context)
 {
   while (true)

--- a/search/engine.hpp
+++ b/search/engine.hpp
@@ -111,9 +111,9 @@ public:
   void OnBookmarksCreated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksUpdated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksDeleted(std::vector<bookmarks::Id> const & marks);
-  void OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+  void OnBookmarksAttachedToGroup(bookmarks::GroupId const & groupId,
                                   std::vector<bookmarks::Id> const & marks);
-  void OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+  void OnBookmarksDetachedFromGroup(bookmarks::GroupId const & groupId,
                                     std::vector<bookmarks::Id> const & marks);
 
 private:

--- a/search/engine.hpp
+++ b/search/engine.hpp
@@ -111,6 +111,10 @@ public:
   void OnBookmarksCreated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksUpdated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksDeleted(std::vector<bookmarks::Id> const & marks);
+  void OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+                                  std::vector<bookmarks::Id> const & marks);
+  void OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+                                    std::vector<bookmarks::Id> const & marks);
 
 private:
   struct Message

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -345,18 +345,18 @@ void Processor::OnBookmarksDeleted(vector<bookmarks::Id> const & marks)
     m_bookmarksProcessor.Erase(id);
 }
 
-void Processor::OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+void Processor::OnBookmarksAttachedToGroup(bookmarks::GroupId const & groupId,
                                            vector<bookmarks::Id> const & marks)
 {
   for (auto const & id : marks)
-    m_bookmarksProcessor.AttachToGroup(id, group);
+    m_bookmarksProcessor.AttachToGroup(id, groupId);
 }
 
-void Processor::OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+void Processor::OnBookmarksDetachedFromGroup(bookmarks::GroupId const & groupId,
                                              vector<bookmarks::Id> const & marks)
 {
   for (auto const & id : marks)
-    m_bookmarksProcessor.DetachFromGroup(id, group);
+    m_bookmarksProcessor.DetachFromGroup(id, groupId);
 }
 
 Locales Processor::GetCategoryLocales() const

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -345,6 +345,20 @@ void Processor::OnBookmarksDeleted(vector<bookmarks::Id> const & marks)
     m_bookmarksProcessor.Erase(id);
 }
 
+void Processor::OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+                                           vector<bookmarks::Id> const & marks)
+{
+  for (auto const & id : marks)
+    m_bookmarksProcessor.AttachToGroup(id, group);
+}
+
+void Processor::OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+                                             vector<bookmarks::Id> const & marks)
+{
+  for (auto const & id : marks)
+    m_bookmarksProcessor.DetachFromGroup(id, group);
+}
+
 Locales Processor::GetCategoryLocales() const
 {
   static int8_t const enLocaleCode = CategoriesHolder::MapLocaleToInteger("en");
@@ -428,7 +442,7 @@ void Processor::Search(SearchParams const & params)
         m_geocoder.GoEverywhere();
       }
       break;
-    case Mode::Bookmarks: SearchBookmarks(); break;
+    case Mode::Bookmarks: SearchBookmarks(params.m_bookmarksGroupId); break;
     case Mode::Count: ASSERT(false, ("Invalid mode")); break;
     }
   }
@@ -484,10 +498,11 @@ void Processor::SearchPlusCode()
   m_emitter.Emit();
 }
 
-void Processor::SearchBookmarks() const
+void Processor::SearchBookmarks(bookmarks::GroupId const & groupId) const
 {
-  QueryParams params;
+  bookmarks::Processor::Params params;
   InitParams(params);
+  params.m_groupId = groupId;
   m_bookmarksProcessor.Search(params);
 }
 

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -78,7 +78,7 @@ public:
   // Tries to parse a plus code from |m_query| and generate a (lat, lon) result.
   void SearchPlusCode();
 
-  void SearchBookmarks() const;
+  void SearchBookmarks(bookmarks::GroupId const & groupId) const;
 
   void InitParams(QueryParams & params) const;
 
@@ -97,6 +97,10 @@ public:
   void OnBookmarksCreated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksUpdated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksDeleted(std::vector<bookmarks::Id> const & marks);
+  void OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+                                  std::vector<bookmarks::Id> const & marks);
+  void OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+                                    std::vector<bookmarks::Id> const & marks);
 
 protected:
   Locales GetCategoryLocales() const;

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -97,9 +97,9 @@ public:
   void OnBookmarksCreated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksUpdated(std::vector<std::pair<bookmarks::Id, bookmarks::Doc>> const & marks);
   void OnBookmarksDeleted(std::vector<bookmarks::Id> const & marks);
-  void OnBookmarksAttachedToGroup(bookmarks::GroupId group,
+  void OnBookmarksAttachedToGroup(bookmarks::GroupId const & groupId,
                                   std::vector<bookmarks::Id> const & marks);
-  void OnBookmarksDetachedFromGroup(bookmarks::GroupId group,
+  void OnBookmarksDetachedFromGroup(bookmarks::GroupId const & groupId,
                                     std::vector<bookmarks::Id> const & marks);
 
 protected:

--- a/search/search_params.hpp
+++ b/search/search_params.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "search/bookmarks/types.hpp"
+
 #include "search/hotels_filter.hpp"
 #include "search/mode.hpp"
 
@@ -60,6 +62,8 @@ struct SearchParams
   bool m_needHighlighting = false;
 
   std::shared_ptr<hotels_filter::Rule> m_hotelsFilter;
+
+  bookmarks::GroupId m_bookmarksGroupId = bookmarks::kInvalidGroupId;
 
   std::shared_ptr<Tracer> m_tracer;
 };

--- a/xcode/search/search.xcodeproj/project.pbxproj
+++ b/xcode/search/search.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		34F558451DBF2E7600A4FC11 /* libopening_hours.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558441DBF2E7600A4FC11 /* libopening_hours.a */; };
 		34F558471DBF2E8100A4FC11 /* libsuccinct.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558461DBF2E8100A4FC11 /* libsuccinct.a */; };
 		34F558491DBF2EC700A4FC11 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F558481DBF2EC700A4FC11 /* libz.tbd */; };
+		39066C5622EA03550053E9E1 /* types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39066C5522EA03540053E9E1 /* types.cpp */; };
 		3913DA511F9FCC88004AA681 /* suggest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3913DA501F9FCC88004AA681 /* suggest.cpp */; };
 		392688C320B2D1D600721762 /* bookmarks_processor_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 392688B420B2D1BF00721762 /* bookmarks_processor_tests.cpp */; };
 		392688C420B2D1D600721762 /* mem_search_index_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 392688B520B2D1BF00721762 /* mem_search_index_tests.cpp */; };
@@ -370,6 +371,7 @@
 		34F558441DBF2E7600A4FC11 /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		34F558461DBF2E8100A4FC11 /* libsuccinct.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsuccinct.a; path = "../../../omim-xcode-build/Debug/libsuccinct.a"; sourceTree = "<group>"; };
 		34F558481DBF2EC700A4FC11 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		39066C5522EA03540053E9E1 /* types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = types.cpp; sourceTree = "<group>"; };
 		3913DA501F9FCC88004AA681 /* suggest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = suggest.cpp; sourceTree = "<group>"; };
 		392688B420B2D1BF00721762 /* bookmarks_processor_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bookmarks_processor_tests.cpp; sourceTree = "<group>"; };
 		392688B520B2D1BF00721762 /* mem_search_index_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mem_search_index_tests.cpp; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 		0831F24D200E56100034C365 /* bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				39066C5522EA03540053E9E1 /* types.cpp */,
 				0831F24E200E56100034C365 /* results.hpp */,
 				0831F24F200E56100034C365 /* processor.cpp */,
 				0831F250200E56100034C365 /* data.cpp */,
@@ -1323,6 +1326,7 @@
 				675346E71A40560D00A0A8C3 /* keyword_lang_matcher.cpp in Sources */,
 				0831F258200E56110034C365 /* data.cpp in Sources */,
 				406B98DA229C3EDA0062EBEC /* feature_offset_match_tests.cpp in Sources */,
+				39066C5622EA03550053E9E1 /* types.cpp in Sources */,
 				3453BD5A1DAF91C100380ECB /* hotels_filter.cpp in Sources */,
 				345C8DB31D2D15A50037E3A6 /* streets_matcher.cpp in Sources */,
 				456E1B3E1F9A3C8E009C32E1 /* cities_boundaries_table.cpp in Sources */,


### PR DESCRIPTION
This commit introduces to the general search params the group id
that has no place there. If we decide on decoupling the general map search
and bookmark search, it is to be done in a separate commit.

Note that currently Processor already does a lot of wasteful initialization
(PreRanker, Ranker, keywords, etc.) when preparing to search in bookmarks
so this commit returns the courtesy.