### PR TITLE
[geocoder] Optimize memory: name dictionary for address parts

### DIFF
--- a/geocoder/CMakeLists.txt
+++ b/geocoder/CMakeLists.txt
@@ -12,6 +12,8 @@ set(
   hierarchy_reader.hpp
   index.cpp
   index.hpp
+  name_dictionary.cpp
+  name_dictionary.hpp
   result.cpp
   result.hpp
   types.cpp

--- a/geocoder/geocoder_cli/geocoder_cli.cpp
+++ b/geocoder/geocoder_cli/geocoder_cli.cpp
@@ -24,13 +24,28 @@ void PrintResults(Hierarchy const & hierarchy, vector<Result> const & results)
   if (results.empty())
     return;
   cout << "Top results:" << endl;
+
+  auto const & dictionary = hierarchy.GetNormalizedNameDictionary();
   for (size_t i = 0; i < results.size(); ++i)
   {
     if (FLAGS_top >= 0 && static_cast<int32_t>(i) >= FLAGS_top)
       break;
     cout << "  " << DebugPrint(results[i]);
     if (auto const && e = hierarchy.GetEntryForOsmId(results[i].m_osmId))
-      cout << " " << DebugPrint(e->m_address);
+    {
+      cout << " [";
+      auto const * delimiter = "";
+      for (size_t i = 0; i < static_cast<size_t>(Type::Count); ++i)
+      {
+        if (e->m_normalizedAddress[i])
+        {
+          auto type = static_cast<Type>(i);
+          cout << delimiter << ToString(type) << ": " << e->GetNormalizedName(type, dictionary);
+          delimiter = ", ";
+        }
+      }
+      cout << "]";
+    }
     cout << endl;
   }
 }

--- a/geocoder/geocoder_cli/geocoder_cli.cpp
+++ b/geocoder/geocoder_cli/geocoder_cli.cpp
@@ -37,7 +37,7 @@ void PrintResults(Hierarchy const & hierarchy, vector<Result> const & results)
       auto const * delimiter = "";
       for (size_t i = 0; i < static_cast<size_t>(Type::Count); ++i)
       {
-        if (e->m_normalizedAddress[i])
+        if (e->m_normalizedAddress[i] != NameDictionary::kUnspecifiedPosition)
         {
           auto type = static_cast<Type>(i);
           cout << delimiter << ToString(type) << ": " << e->GetNormalizedName(type, dictionary);

--- a/geocoder/geocoder_tests/geocoder_tests.cpp
+++ b/geocoder/geocoder_tests/geocoder_tests.cpp
@@ -29,13 +29,6 @@ C00000000004B279 {"type": "Feature", "geometry": {"type": "Point", "coordinates"
 C0000000001C4CA7 {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-78.7260117405499, 21.74300205]}, "properties": {"locales": {"default": {"name": "Ciego de Ávila", "address": {"region": "Ciego de Ávila", "country": "Cuba"}}}, "rank": 4}}
 C00000000059D6B5 {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-78.9263054493181, 22.08185765]}, "properties": {"locales": {"default": {"name": "Florencia", "address": {"subregion": "Florencia", "region": "Ciego de Ávila", "country": "Cuba"}}}, "rank": 6}}
 )#";
-
-geocoder::Tokens Split(string const & s)
-{
-  geocoder::Tokens result;
-  search::NormalizeAndTokenizeAsUtf8(s, result);
-  return result;
-}
 }  // namespace
 
 namespace geocoder
@@ -74,6 +67,8 @@ UNIT_TEST(Geocoder_Hierarchy)
 {
   ScopedFile const regionsJsonFile("regions.jsonl", kRegionsData);
   Geocoder geocoder(regionsJsonFile.GetFullPath());
+  auto const & hierarchy = geocoder.GetHierarchy();
+  auto const & dictionary = hierarchy.GetNormalizedNameDictionary();
 
   vector<Hierarchy::Entry> entries;
   geocoder.GetIndex().ForEachDocId({("florencia")}, [&](Index::DocId const & docId) {
@@ -81,9 +76,9 @@ UNIT_TEST(Geocoder_Hierarchy)
   });
 
   TEST_EQUAL(entries.size(), 1, ());
-  TEST_EQUAL(entries[0].m_address[static_cast<size_t>(Type::Country)], Split("cuba"), ());
-  TEST_EQUAL(entries[0].m_address[static_cast<size_t>(Type::Region)], Split("ciego de avila"), ());
-  TEST_EQUAL(entries[0].m_address[static_cast<size_t>(Type::Subregion)], Split("florencia"), ());
+  TEST_EQUAL(entries[0].GetNormalizedName(Type::Country, dictionary), "cuba", ());
+  TEST_EQUAL(entries[0].GetNormalizedName(Type::Region, dictionary), "ciego de avila", ());
+  TEST_EQUAL(entries[0].GetNormalizedName(Type::Subregion, dictionary), "florencia", ());
 }
 
 UNIT_TEST(Geocoder_OnlyBuildings)

--- a/geocoder/hierarchy.hpp
+++ b/geocoder/hierarchy.hpp
@@ -60,10 +60,10 @@ public:
   struct Entry
   {
     bool DeserializeFromJSON(std::string const & jsonStr,
-                             NameDictionaryMaker & normalizedNameDictionaryMaker,
+                             NameDictionaryBuilder & normalizedNameDictionaryBuilder,
                              ParsingStats & stats);
     bool DeserializeFromJSONImpl(json_t * const root, std::string const & jsonStr,
-                                 NameDictionaryMaker & normalizedNameDictionaryMaker,
+                                 NameDictionaryBuilder & normalizedNameDictionaryBuilder,
                                  ParsingStats & stats);
 
     std::string const & GetNormalizedName(Type type,

--- a/geocoder/hierarchy_reader.cpp
+++ b/geocoder/hierarchy_reader.cpp
@@ -61,7 +61,7 @@ Hierarchy HierarchyReader::Read(unsigned int readersCount)
   LOG(LINFO, ("Reading entries..."));
 
   vector<Entry> entries;
-  NameDictionaryMaker nameDictionaryMaker;
+  NameDictionaryBuilder nameDictionaryBuilder;
   ParsingStats stats{};
 
   base::thread_pool::computational::ThreadPool threadPool{readersCount};
@@ -86,7 +86,7 @@ Hierarchy HierarchyReader::Read(unsigned int readersCount)
         if (auto & position = entry.m_normalizedAddress[i])
         {
           auto const & name = taskNameDictionary.Get(position);
-          position = nameDictionaryMaker.Add(name);
+          position = nameDictionaryBuilder.Add(name);
         }
       }
     }
@@ -118,7 +118,7 @@ Hierarchy HierarchyReader::Read(unsigned int readersCount)
       ("Entries whose names do not match their most specific addresses:", stats.m_mismatchedNames));
   LOG(LINFO, ("(End of stats.)"));
 
-  return Hierarchy{move(entries), nameDictionaryMaker.Release()};
+  return Hierarchy{move(entries), nameDictionaryBuilder.Release()};
 }
 
 void HierarchyReader::CheckDuplicateOsmIds(vector<geocoder::Hierarchy::Entry> const & entries,
@@ -168,7 +168,7 @@ HierarchyReader::ParsingResult HierarchyReader::DeserializeEntries(
 {
   vector<Entry> entries;
   entries.reserve(bufferSize);
-  NameDictionaryMaker nameDictionaryMaker;
+  NameDictionaryBuilder nameDictionaryBuilder;
   ParsingStats stats;
 
   for (size_t i = 0; i < bufferSize; ++i)
@@ -192,7 +192,7 @@ HierarchyReader::ParsingResult HierarchyReader::DeserializeEntries(
     auto const osmId = base::GeoObjectId(encodedId);
     entry.m_osmId = osmId;
 
-    if (!entry.DeserializeFromJSON(json, nameDictionaryMaker, stats))
+    if (!entry.DeserializeFromJSON(json, nameDictionaryBuilder, stats))
       continue;
 
     if (entry.m_type == Type::Count)
@@ -207,7 +207,7 @@ HierarchyReader::ParsingResult HierarchyReader::DeserializeEntries(
     entries.push_back(move(entry));
   }
 
-  return {move(entries), nameDictionaryMaker.Release(), move(stats)};
+  return {move(entries), nameDictionaryBuilder.Release(), move(stats)};
 }
 
 // static

--- a/geocoder/hierarchy_reader.hpp
+++ b/geocoder/hierarchy_reader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geocoder/hierarchy.hpp"
+#include "geocoder/name_dictionary.hpp"
 
 #include "base/exception.hpp"
 #include "base/geo_object_id.hpp"
@@ -33,12 +34,13 @@ private:
   struct ParsingResult
   {
     std::vector<Entry> m_entries;
+    NameDictionary m_nameDictionary;
     ParsingStats m_stats;
   };
 
   ParsingResult ReadEntries(size_t count);
   ParsingResult DeserializeEntries(std::vector<std::string> const & linesBuffer,
-                                    std::size_t const bufferSize);
+                                   std::size_t const bufferSize);
   static bool DeserializeId(std::string const & str, uint64_t & id);
   static std::string SerializeId(uint64_t id);
 

--- a/geocoder/index.cpp
+++ b/geocoder/index.cpp
@@ -150,9 +150,9 @@ void Index::AddHouses(unsigned int loadThreadsCount)
             buildingDoc.m_normalizedAddress[static_cast<size_t>(Type::Locality)];
 
         NameDictionary::Position relation = NameDictionary::kUnspecifiedPosition;
-        if (street)
+        if (street != NameDictionary::kUnspecifiedPosition)
           relation = street;
-        else if (locality)
+        else if (locality != NameDictionary::kUnspecifiedPosition)
           relation = locality;
         else
           continue;
@@ -174,7 +174,7 @@ void Index::AddHouses(unsigned int loadThreadsCount)
 
         if (indexed)
         {
-          auto processedCount = numIndexed.fetch_add(1) + 1;
+          auto const processedCount = numIndexed.fetch_add(1) + 1;
           if (processedCount % kLogBatch == 0)
             LOG(LINFO, ("Indexed", processedCount, "houses"));
         }

--- a/geocoder/index.hpp
+++ b/geocoder/index.hpp
@@ -70,6 +70,7 @@ private:
   void AddHouses(unsigned int loadThreadsCount);
 
   std::vector<Doc> const & m_docs;
+  Hierarchy const & m_hierarchy;
 
   std::unordered_map<std::string, std::vector<DocId>> m_docIdsByTokens;
 

--- a/geocoder/name_dictionary.cpp
+++ b/geocoder/name_dictionary.cpp
@@ -1,0 +1,42 @@
+#include "geocoder/name_dictionary.hpp"
+
+#include "base/assert.hpp"
+
+#include <utility>
+
+namespace geocoder
+{
+// NameDictionary ----------------------------------------------------------------------------------
+std::string const & NameDictionary::Get(Position position) const
+{
+  CHECK_GREATER(position, 0, ());
+  CHECK_LESS_OR_EQUAL(position, m_stock.size(), ());
+  return m_stock[position - 1];
+}
+
+NameDictionary::Position NameDictionary::Add(std::string const & s)
+{
+  CHECK_LESS(m_stock.size(), UINT32_MAX, ());
+  m_stock.push_back(s);
+  return m_stock.size();  // index + 1
+}
+
+// NameDictionaryMaker -----------------------------------------------------------------------------
+NameDictionary::Position NameDictionaryMaker::Add(std::string const & s)
+{
+  auto indexItem = m_index.find(s);
+  if (indexItem != m_index.end())
+    return indexItem->second;
+
+  auto p = m_dictionary.Add(s);
+  auto indexEmplace = m_index.emplace(m_dictionary.Get(p), p);
+  CHECK(indexEmplace.second, ());
+  return p;
+}
+
+NameDictionary NameDictionaryMaker::Release()
+{
+  m_index.clear();
+  return std::move(m_dictionary);
+}
+}  // namespace geocoder

--- a/geocoder/name_dictionary.cpp
+++ b/geocoder/name_dictionary.cpp
@@ -2,6 +2,7 @@
 
 #include "base/assert.hpp"
 
+#include <limits>
 #include <utility>
 
 namespace geocoder
@@ -16,13 +17,13 @@ std::string const & NameDictionary::Get(Position position) const
 
 NameDictionary::Position NameDictionary::Add(std::string const & s)
 {
-  CHECK_LESS(m_stock.size(), UINT32_MAX, ());
+  CHECK_LESS(m_stock.size(), std::numeric_limits<uint32_t>::max(), ());
   m_stock.push_back(s);
   return m_stock.size();  // index + 1
 }
 
-// NameDictionaryMaker -----------------------------------------------------------------------------
-NameDictionary::Position NameDictionaryMaker::Add(std::string const & s)
+// NameDictionaryBuilder -----------------------------------------------------------------------------
+NameDictionary::Position NameDictionaryBuilder::Add(std::string const & s)
 {
   auto indexItem = m_index.find(s);
   if (indexItem != m_index.end())
@@ -34,7 +35,7 @@ NameDictionary::Position NameDictionaryMaker::Add(std::string const & s)
   return p;
 }
 
-NameDictionary NameDictionaryMaker::Release()
+NameDictionary NameDictionaryBuilder::Release()
 {
   m_index.clear();
   return std::move(m_dictionary);

--- a/geocoder/name_dictionary.hpp
+++ b/geocoder/name_dictionary.hpp
@@ -29,12 +29,12 @@ private:
   std::vector<std::string> m_stock;
 };
 
-class NameDictionaryMaker
+class NameDictionaryBuilder
 {
 public:
-  NameDictionaryMaker() = default;
-  NameDictionaryMaker(NameDictionaryMaker const &) = delete;
-  NameDictionaryMaker & operator=(NameDictionaryMaker const &) = delete;
+  NameDictionaryBuilder() = default;
+  NameDictionaryBuilder(NameDictionaryBuilder const &) = delete;
+  NameDictionaryBuilder & operator=(NameDictionaryBuilder const &) = delete;
 
   NameDictionary::Position Add(std::string const & s);
   NameDictionary Release();

--- a/geocoder/name_dictionary.hpp
+++ b/geocoder/name_dictionary.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace geocoder
+{
+class NameDictionary
+{
+public:
+  // Values of Position type: kUnspecifiedPosition or >= 1.
+  using Position = std::uint32_t;
+
+  static constexpr Position kUnspecifiedPosition = 0;
+
+  NameDictionary() = default;
+  NameDictionary(NameDictionary &&) = default;
+  NameDictionary & operator=(NameDictionary &&) = default;
+
+  NameDictionary(NameDictionary const &) = delete;
+  NameDictionary & operator=(NameDictionary const &) = delete;
+
+  std::string const & Get(Position position) const;
+  Position Add(std::string const & s);
+
+private:
+  std::vector<std::string> m_stock;
+};
+
+class NameDictionaryMaker
+{
+public:
+  NameDictionaryMaker() = default;
+  NameDictionaryMaker(NameDictionaryMaker const &) = delete;
+  NameDictionaryMaker & operator=(NameDictionaryMaker const &) = delete;
+
+  NameDictionary::Position Add(std::string const & s);
+  NameDictionary Release();
+
+private:
+  NameDictionary m_dictionary;
+  std::unordered_map<std::string, NameDictionary::Position> m_index;
+};
+}  // namespace geocoder


### PR DESCRIPTION
Оптимизация по памяти: хранить имена полей адресов в словаре и в `Entry` использовать индексы на имя в словаре.
Расходы на память, на примере России: 6.3 GB в тек. версии и 0.9 GB - в этом PR. Скорость загрузки практически не изменилась.