### PR TITLE
[iOS] Fixed location manager

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.h
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.h
@@ -14,7 +14,7 @@
                              needToRebuild:(BOOL)needToRebuild;
 - (void)presentRoutingDisclaimerAlertWithOkBlock:(nonnull nonnull MWMVoidBlock)block;
 - (void)presentDisabledLocationAlert;
-- (void)presentLocationAlert;
+- (void)presentLocationAlertWithCancelBlock:(MWMVoidBlock)cancelBlock;
 - (void)presentLocationServiceNotSupportedAlert;
 - (void)presentLocationNotFoundAlertWithOkBlock:(nonnull MWMVoidBlock)okBlock;
 - (void)presentNoConnectionAlert;

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
@@ -51,10 +51,10 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
 #pragma mark - Actions
 
 - (void)presentRateAlert { [self displayAlert:[MWMAlert rateAlert]]; }
-- (void)presentLocationAlert
+- (void)presentLocationAlertWithCancelBlock:(MWMVoidBlock)cancelBlock
 {
   if (![MapViewController sharedController].welcomePageController)
-    [self displayAlert:[MWMAlert locationAlert]];
+    [self displayAlert:[MWMAlert locationAlertWithCancelBlock: cancelBlock]];
 }
 - (void)presentPoint2PointAlertWithOkBlock:(nonnull MWMVoidBlock)okBlock
                              needToRebuild:(BOOL)needToRebuild

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.h
@@ -5,7 +5,7 @@
 
 + (MWMAlert *)routingMigrationAlertWithOkBlock:(MWMVoidBlock)okBlock;
 + (MWMAlert *)rateAlert;
-+ (MWMAlert *)locationAlert;
++ (MWMAlert *)locationAlertWithCancelBlock:(MWMVoidBlock)cancelBlock;
 + (MWMAlert *)routingDisclaimerAlertWithOkBlock:(MWMVoidBlock)block;
 + (MWMAlert *)disabledLocationAlert;
 + (MWMAlert *)noWiFiAlertWithOkBlock:(MWMVoidBlock)okBlock andCancelBlock:(MWMVoidBlock)cancelBlock;

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -15,7 +15,10 @@
 @implementation MWMAlert
 
 + (MWMAlert *)rateAlert { return [MWMRateAlert alert]; }
-+ (MWMAlert *)locationAlert { return [MWMLocationAlert alert]; }
++ (MWMAlert *)locationAlertWithCancelBlock:(MWMVoidBlock)cancelBlock {
+  return [MWMLocationAlert alertWithCancelBlock:cancelBlock];
+}
+
 + (MWMAlert *)point2PointAlertWithOkBlock:(MWMVoidBlock)block needToRebuild:(BOOL)needToRebuild
 {
   return [MWMDefaultAlert point2PointAlertWithOkBlock:block needToRebuild:needToRebuild];

--- a/iphone/Maps/Classes/CustomAlert/LocationAlert/MWMLocationAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/LocationAlert/MWMLocationAlert.h
@@ -2,6 +2,6 @@
 
 @interface MWMLocationAlert : MWMAlert
 
-+ (instancetype)alert;
++ (instancetype)alertWithCancelBlock:(MWMVoidBlock)cancelBlock;
 
 @end

--- a/iphone/Maps/Classes/CustomAlert/LocationAlert/MWMLocationAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/LocationAlert/MWMLocationAlert.mm
@@ -9,17 +9,19 @@ static NSString * const kStatisticsEvent = @"Location Alert";
 @interface MWMLocationAlert ()
 
 @property (weak, nonatomic) IBOutlet UIButton * rightButton;
+@property (nullable, nonatomic) MWMVoidBlock cancelBlock;
 
 @end
 
 @implementation MWMLocationAlert
 
-+ (instancetype)alert
++ (instancetype)alertWithCancelBlock:(MWMVoidBlock)cancelBlock
 {
   [Statistics logEvent:kStatisticsEvent withParameters:@{kStatAction : kStatOpen}];
   MWMLocationAlert * alert =
       [NSBundle.mainBundle loadNibNamed:kLocationAlertNibName owner:nil options:nil].firstObject;
   [alert setNeedsCloseAlertAfterEnterBackground];
+  alert.cancelBlock = cancelBlock;
   return alert;
 }
 
@@ -37,7 +39,7 @@ static NSString * const kStatisticsEvent = @"Location Alert";
 - (IBAction)closeTap
 {
   [Statistics logEvent:kStatisticsEvent withParameters:@{kStatAction : kStatClose}];
-  [self close:nil];
+  [self close:self.cancelBlock];
 }
 
 @end

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -282,7 +282,8 @@ NSString * const kHotelFacilitiesSegue = @"Map2FacilitiesSegue";
   self.view.clipsToBounds = YES;
   [MWMKeyboard addObserver:self];
   self.welcomePageController = [MWMWelcomePageController controllerWithParent:self];
-  [self processMyPositionStateModeEvent:MWMMyPositionModePendingPosition];
+  [self processMyPositionStateModeEvent:[MWMLocationManager isLocationProhibited] ?
+                                         MWMMyPositionModeNotFollowNoPosition : MWMMyPositionModePendingPosition];
   if ([MWMNavigationDashboardManager manager].state == MWMNavigationDashboardStateHidden)
     self.controlsManager.menuState = self.controlsManager.menuRestoreState;
 
@@ -582,6 +583,8 @@ NSString * const kHotelFacilitiesSegue = @"Map2FacilitiesSegue";
   case MWMMyPositionModePendingPosition:
       if (self.welcomePageController && [Alohalytics isFirstSession]) { break; }
       [MWMLocationManager start];
+      if (![MWMLocationManager isStarted])
+        [self processMyPositionStateModeEvent: MWMMyPositionModeNotFollowNoPosition];
       break;
   case MWMMyPositionModeNotFollow: break;
   case MWMMyPositionModeFollow:

--- a/iphone/Maps/Core/Location/MWMLocationManager.h
+++ b/iphone/Maps/Core/Location/MWMLocationManager.h
@@ -6,6 +6,7 @@
 
 + (void)start;
 + (void)stop;
++ (BOOL)isStarted;
 
 + (void)addObserver:(id<MWMLocationObserver>)observer;
 + (void)removeObserver:(id<MWMLocationObserver>)observer;
@@ -18,6 +19,8 @@
 
 + (void)applicationDidBecomeActive;
 + (void)applicationWillResignActive;
+
++ (void)enableLocationAlert;
 
 - (instancetype)init __attribute__((unavailable("call +manager instead")));
 - (instancetype)copy __attribute__((unavailable("call +manager instead")));


### PR DESCRIPTION
- Исправлена логика при включении Location Manager. Теперь проверяется, включился ли Location Manager на самом деле. Это должно исправить баг с бесконечной анимацией кнопки на старте при выключенных геосервисах (https://jira.mail.ru/browse/MAPSME-10548);
- Убрана трех-кадровая анимация с кнопок, так как она создавала data race и была незаметна;
- Вместо системного одноразового диалога при выключенных геосервисах показывается наш собственный диалог;
- Добавлено запоминание отказа пользователя от включения геосервисов, чтобы убрать назойливое появление диалога при любом возможном случае