### PR TITLE
[routing][release-92] Preventing crossing valid roads by fake edges.

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -193,7 +193,7 @@ public:
 
   void GetEdgesList(Segment const & child, bool isOutgoing, vector<SegmentEdge> & edges)
   {
-    m_graph.GetEdgeList(child, isOutgoing, edges);
+    m_graph.GetEdgeList(child, isOutgoing, true /* useRoutingOptions */, edges);
   }
 
   void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,

--- a/openlr/graph.cpp
+++ b/openlr/graph.cpp
@@ -68,7 +68,7 @@ void Graph::FindClosestEdges(m2::PointD const & point, uint32_t const count,
 {
   m_graph.FindClosestEdges(
       MercatorBounds::RectByCenterXYAndSizeInMeters(point, FeaturesRoadGraph::kClosestEdgesRadiusM),
-      count, nullptr /* isGoodFeature */, vicinities);
+      count, vicinities);
 }
 
 void Graph::AddIngoingFakeEdge(Edge const & e)

--- a/openlr/openlr_stat/CMakeLists.txt
+++ b/openlr/openlr_stat/CMakeLists.txt
@@ -11,6 +11,7 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 omim_link_libraries(${PROJECT_NAME}
   openlr
   routing
+  traffic
   routing_common
   storage
   editor

--- a/openlr/router.cpp
+++ b/openlr/router.cpp
@@ -176,7 +176,7 @@ bool Router::Init(std::vector<WayPoint> const & points, double positiveOffsetM,
     m_graph.FindClosestEdges(
         MercatorBounds::RectByCenterXYAndSizeInMeters(
             m_points[i].m_point, routing::FeaturesRoadGraph::kClosestEdgesRadiusM),
-        kMaxRoadCandidates, nullptr /* isGoodFeature */, vicinity);
+        kMaxRoadCandidates, vicinity);
     for (auto const & v : vicinity)
     {
       auto const & e = v.first;
@@ -197,7 +197,7 @@ bool Router::Init(std::vector<WayPoint> const & points, double positiveOffsetM,
     m_graph.FindClosestEdges(
         MercatorBounds::RectByCenterXYAndSizeInMeters(
             m_sourceJunction.GetPoint(), routing::FeaturesRoadGraph::kClosestEdgesRadiusM),
-        kMaxRoadCandidates, nullptr /* isGoodFeature */, sourceVicinity);
+        kMaxRoadCandidates, sourceVicinity);
     m_graph.AddFakeEdges(m_sourceJunction, sourceVicinity);
   }
 
@@ -207,7 +207,7 @@ bool Router::Init(std::vector<WayPoint> const & points, double positiveOffsetM,
     m_graph.FindClosestEdges(
         MercatorBounds::RectByCenterXYAndSizeInMeters(
             m_targetJunction.GetPoint(), routing::FeaturesRoadGraph::kClosestEdgesRadiusM),
-        kMaxRoadCandidates, nullptr /* isGoodFeature */, targetVicinity);
+        kMaxRoadCandidates, targetVicinity);
     m_graph.AddFakeEdges(m_targetJunction, targetVicinity);
   }
 
@@ -500,7 +500,7 @@ void Router::ForEachNonFakeClosestEdge(Vertex const & u, FunctionalRoadClass con
   m_graph.FindClosestEdges(
       MercatorBounds::RectByCenterXYAndSizeInMeters(
           u.m_junction.GetPoint(), routing::FeaturesRoadGraph::kClosestEdgesRadiusM),
-      kMaxRoadCandidates, nullptr /* isGoodFeature */, vicinity);
+      kMaxRoadCandidates, vicinity);
 
   for (auto const & p : vicinity)
   {

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -212,10 +212,10 @@ vector<IRoadGraph::FullRoadInfo> FeaturesRoadGraph::FindRoads(
     // DataSource::ForEachInRect() gives not ony features inside |rect| but some other features
     // which lie close to the rect. Removes all the features which don't cross |rect|.
     auto const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
-    if (!PolylineInRect(roadInfo.m_junctions, rect))
+    if (!RectCoversPolyline(roadInfo.m_junctions, rect))
       return;
 
-    roads.emplace_back(featureId, roadInfo, true /* m_isRoadAccordingToModel */);
+    roads.emplace_back(featureId, roadInfo);
   };
 
   m_dataSource.ForEachInRect(f, rect, GetStreetReadScale());

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -199,10 +199,10 @@ void FeaturesRoadGraph::FindClosestEdges(m2::RectD const & rect, uint32_t count,
   finder.MakeResult(vicinities, count);
 }
 
-vector<pair<FeatureID, IRoadGraph::RoadInfo>> FeaturesRoadGraph::FindRoads(
+vector<IRoadGraph::FullRoadInfo> FeaturesRoadGraph::FindRoads(
     m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const
 {
-  vector<pair<FeatureID, IRoadGraph::RoadInfo>> roads;
+  vector<IRoadGraph::FullRoadInfo> roads;
   auto const f = [&roads, &isGoodFeature, this](FeatureType & ft) {
     if (!m_vehicleModel.IsRoad(ft))
       return;
@@ -211,7 +211,8 @@ vector<pair<FeatureID, IRoadGraph::RoadInfo>> FeaturesRoadGraph::FindRoads(
     if (isGoodFeature && !isGoodFeature(featureId))
       return;
 
-    roads.emplace_back(featureId, GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH));
+    roads.emplace_back(featureId, GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH),
+                       true /* m_isRoadAccordingToModel */);
   };
 
   m_dataSource.ForEachInRect(f, rect, GetStreetReadScale());

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -189,7 +189,7 @@ void FeaturesRoadGraph::FindClosestEdges(m2::RectD const & rect, uint32_t count,
     IRoadGraph::RoadInfo const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
     CHECK_EQUAL(roadInfo.m_speedKMPH, kInvalidSpeedKMPH, ());
 
-    finder.AddInformationSource(featureId, roadInfo.m_junctions, roadInfo.m_bidirectional);
+    finder.AddInformationSource(IRoadGraph::FullRoadInfo(featureId, roadInfo));
   };
 
   m_dataSource.ForEachInRect(f, rect, GetStreetReadScale());
@@ -197,8 +197,8 @@ void FeaturesRoadGraph::FindClosestEdges(m2::RectD const & rect, uint32_t count,
   finder.MakeResult(vicinities, count);
 }
 
-vector<IRoadGraph::FullRoadInfo> FeaturesRoadGraph::FindRoads(
-    m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const
+vector<IRoadGraph::FullRoadInfo>
+FeaturesRoadGraph::FindRoads(m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const
 {
   vector<IRoadGraph::FullRoadInfo> roads;
   auto const f = [&roads, &isGoodFeature, &rect, this](FeatureType & ft) {
@@ -209,7 +209,7 @@ vector<IRoadGraph::FullRoadInfo> FeaturesRoadGraph::FindRoads(
     if (isGoodFeature && !isGoodFeature(featureId))
       return;
 
-    // DataSource::ForEachInRect() gives not ony features inside |rect| but some other features
+    // DataSource::ForEachInRect() gives not only features inside |rect| but some other features
     // which lie close to the rect. Removes all the features which don't cross |rect|.
     auto const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
     if (!RectCoversPolyline(roadInfo.m_junctions, rect))

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -80,8 +80,8 @@ public:
   double GetMaxSpeedKMpH() const override;
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgesLoader) const override;
-  void FindClosestEdges(m2::RectD const & rect, uint32_t count, IsGoodFeatureFn const & isGoodFeature,
-                        std::vector<std::pair<Edge, Junction>> & vicinities) const override;
+  void FindClosestEdges(m2::RectD const & rect, uint32_t count,
+      std::vector<std::pair<Edge, Junction>> & vicinities) const override;
   std::vector<IRoadGraph::FullRoadInfo> FindRoads(
       m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
@@ -132,5 +132,4 @@ private:
 // with start point s such as that |s - p| < d, and edge is considered outgouing from p.
 // Symmetrically for ingoing edges.
 double GetRoadCrossingRadiusMeters();
-
 }  // namespace routing

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -82,7 +82,7 @@ public:
                                     ICrossEdgesLoader & edgesLoader) const override;
   void FindClosestEdges(m2::RectD const & rect, uint32_t count, IsGoodFeatureFn const & isGoodFeature,
                         std::vector<std::pair<Edge, Junction>> & vicinities) const override;
-  std::vector<std::pair<FeatureID, RoadInfo>> FindRoads(
+  std::vector<IRoadGraph::FullRoadInfo> FindRoads(
       m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -82,8 +82,8 @@ public:
                                     ICrossEdgesLoader & edgesLoader) const override;
   void FindClosestEdges(m2::RectD const & rect, uint32_t count,
                         std::vector<std::pair<Edge, Junction>> & vicinities) const override;
-  std::vector<IRoadGraph::FullRoadInfo> FindRoads(
-      m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
+  std::vector<IRoadGraph::FullRoadInfo>
+  FindRoads(m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
   void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
   IRoadGraph::Mode GetMode() const override;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -81,7 +81,7 @@ public:
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgesLoader) const override;
   void FindClosestEdges(m2::RectD const & rect, uint32_t count,
-      std::vector<std::pair<Edge, Junction>> & vicinities) const override;
+                        std::vector<std::pair<Edge, Junction>> & vicinities) const override;
   std::vector<IRoadGraph::FullRoadInfo> FindRoads(
       m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -261,14 +261,7 @@ void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutg
   Joint::Id const jointId = m_roadIndex.GetJointId(roadPoint);
 
   if (jointId == Joint::kInvalidId)
-  {
-    if (IsJointOrEnd(parent, isOutgoing))
-    {
-      // It's not a joint but a loose end of a feature.
-      GetSegmentCandidateForRoadPoint(roadPoint, parent.GetMwmId(), isOutgoing, children);
-    }
     return;
-  }
 
   m_jointIndex.ForEachPoint(jointId, [&](RoadPoint const & rp) {
     GetSegmentCandidateForRoadPoint(rp, parent.GetMwmId(), isOutgoing, children);

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -60,8 +60,8 @@ bool IndexGraph::IsJointOrEnd(Segment const & segment, bool fromStart)
   return pointId + 1 == pointsNumber;
 }
 
-void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges,
-                             map<Segment, Segment> & parents)
+void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                             vector<SegmentEdge> & edges, map<Segment, Segment> & parents)
 {
   RoadPoint const roadPoint = segment.GetRoadPoint(isOutgoing);
   Joint::Id const jointId = m_roadIndex.GetJointId(roadPoint);
@@ -69,12 +69,12 @@ void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, vector<Se
   if (jointId != Joint::kInvalidId)
   {
     m_jointIndex.ForEachPoint(jointId, [&](RoadPoint const & rp) {
-      GetNeighboringEdges(segment, rp, isOutgoing, edges, parents);
+      GetNeighboringEdges(segment, rp, isOutgoing, useRoutingOptions, edges, parents);
     });
   }
   else
   {
-    GetNeighboringEdges(segment, roadPoint, isOutgoing, edges, parents);
+    GetNeighboringEdges(segment, roadPoint, isOutgoing, useRoutingOptions, edges, parents);
   }
 }
 
@@ -206,14 +206,15 @@ RouteWeight IndexGraph::CalcSegmentWeight(Segment const & segment)
 }
 
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
-                                     vector<SegmentEdge> & edges, map<Segment, Segment> & parents)
+                                     bool useRoutingOptions, vector<SegmentEdge> & edges,
+                                     map<Segment, Segment> & parents)
 {
   RoadGeometry const & road = m_geometry->GetRoad(rp.GetFeatureId());
 
   if (!road.IsValid())
     return;
 
-  if (!road.SuitableForOptions(m_avoidRoutingOptions))
+  if (useRoutingOptions && !road.SuitableForOptions(m_avoidRoutingOptions))
     return;
 
   bool const bidirectional = !road.IsOneWay();

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -241,8 +241,6 @@ void IndexGraph::GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId 
   if (!road.IsValid())
     return;
 
-  // Note. Flag |useRoutingOptions| is not passed to this place because it's true
-  // for all cases in current code. So if below should be checked anyway.
   if (!road.SuitableForOptions(m_avoidRoutingOptions))
     return;
 

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -249,6 +249,8 @@ void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutg
     if (!road.IsValid())
       return;
 
+    // Note. Flag |useRoutingOptions| is not passed to this place because it's true
+    // for all cases in current code. So if below should be checked anyway.
     if (!road.SuitableForOptions(m_avoidRoutingOptions))
       return;
 

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -127,6 +127,8 @@ private:
                           std::vector<SegmentEdge> & edges, std::map<Segment, Segment> & parents);
   RouteWeight GetPenalties(Segment const & u, Segment const & v);
 
+  void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
+                                       bool isOutgoing, std::vector<Segment> & children);
   void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, std::vector<Segment> & children);
   void ReconstructJointSegment(JointSegment const & parentJoint,
                                Segment const & parent,

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -45,7 +45,8 @@ public:
 
   static std::map<Segment, Segment> kEmptyParentsSegments;
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
-  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                   std::vector<SegmentEdge> & edges,
                    std::map<Segment, Segment> & parents = kEmptyParentsSegments);
 
   void GetEdgeList(JointSegment const & parentJoint,
@@ -120,7 +121,8 @@ private:
   RouteWeight CalcSegmentWeight(Segment const & segment);
 
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
-                           std::vector<SegmentEdge> & edges, std::map<Segment, Segment> & parents);
+                           bool useRoutingOptions, std::vector<SegmentEdge> & edges,
+                           std::map<Segment, Segment> & parents);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                           std::vector<SegmentEdge> & edges, std::map<Segment, Segment> & parents);
   RouteWeight GetPenalties(Segment const & u, Segment const & v);

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -216,7 +216,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
       return;
     }
 
-    m_graph.GetEdgeList(segment, isOutgoing, edges);
+    m_graph.GetEdgeList(segment, isOutgoing, true /* useRoutingOptions */, edges);
     return;
   }
 
@@ -228,7 +228,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
       bool const haveSameFront = GetJunction(segment, true /* front */) == GetJunction(real, true);
       bool const haveSameBack = GetJunction(segment, false /* front */) == GetJunction(real, false);
       if ((isOutgoing && haveSameFront) || (!isOutgoing && haveSameBack))
-        m_graph.GetEdgeList(real, isOutgoing, edges);
+        m_graph.GetEdgeList(real, isOutgoing, true /* useRoutingOptions */, edges);
     }
 
     for (auto const & s : m_fake.GetEdges(segment, isOutgoing))
@@ -236,7 +236,7 @@ void IndexGraphStarter::GetEdgesList(Segment const & segment, bool isOutgoing,
   }
   else
   {
-    m_graph.GetEdgeList(segment, isOutgoing, edges);
+    m_graph.GetEdgeList(segment, isOutgoing, true /* useRoutingOptions */, edges);
   }
 
   AddFakeEdges(segment, isOutgoing, edges);

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -599,7 +599,7 @@ std::vector<JointEdge> IndexGraphStarterJoints<Graph>::FindFirstJoints(Segment c
     // or it's the real one and its end (RoadPoint) is |Joint|.
     if (((!IsRealSegment(segment) && m_graph.ConvertToReal(segment) &&
           isEndOfSegment(beforeConvert, segment, fromStart)) || IsRealSegment(beforeConvert)) &&
-        IsJointOrEnd(segment, fromStart))
+        IsJoint(segment, fromStart))
     {
       addFake(segment, beforeConvert);
       continue;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -11,7 +11,6 @@
 #include "routing/index_graph_starter.hpp"
 #include "routing/index_road_graph.hpp"
 #include "routing/leaps_postprocessor.hpp"
-#include "routing/nearest_edge_finder.hpp"
 #include "routing/pedestrian_directions.hpp"
 #include "routing/restriction_loader.hpp"
 #include "routing/route.hpp"
@@ -197,13 +196,32 @@ bool IsTheSameSegments(m2::PointD const & seg1From, m2::PointD const & seg1To,
   return (seg1From == seg2From && seg1To == seg2To) || (seg1From == seg2To && seg1To == seg2From);
 }
 
-bool IsDeadEnd(Segment const & segment, bool isOutgoing, WorldGraph & worldGraph,
-               set<Segment> & visitedSegments)
+bool IsDeadEnd(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+               WorldGraph & worldGraph, set<Segment> & visitedSegments)
 {
   // Maximum size (in Segment) of an island in road graph which may be found by the method.
   size_t constexpr kDeadEndTestLimit = 250;
 
-  return !CheckGraphConnectivity(segment, isOutgoing, kDeadEndTestLimit, worldGraph, visitedSegments);
+  return !CheckGraphConnectivity(segment, isOutgoing, useRoutingOptions, kDeadEndTestLimit,
+                                 worldGraph, visitedSegments);
+}
+
+bool IsDeadEndCached(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                     WorldGraph & worldGraph, set<Segment> & deadEnds)
+{
+  if (deadEnds.count(segment) != 0)
+    return true;
+
+  set<Segment> visitedSegments;
+  if (IsDeadEnd(segment, isOutgoing, useRoutingOptions, worldGraph, visitedSegments))
+  {
+    auto const beginIt = std::make_move_iterator(visitedSegments.begin());
+    auto const endIt = std::make_move_iterator(visitedSegments.end());
+    deadEnds.insert(beginIt, endIt);
+    return true;
+  }
+
+  return false;
 }
 }  // namespace
 
@@ -820,17 +838,8 @@ void IndexRouter::EraseIfDeadEnd(WorldGraph & worldGraph,
     // all segments of the feature is considered as dead ends.
     auto const segment = GetSegmentByEdge(Edge::MakeReal(r.m_featureId, true /* forward */, 0 /* segment id */,
                                                          r.m_roadInfo.m_junctions[0], r.m_roadInfo.m_junctions[1]));
-    if (deadEnds.count(segment) != 0)
-      return true;
-
-    set<Segment> visitedSegments;
-    if (!IsDeadEnd(segment, true /* isOutgoing */, worldGraph, visitedSegments))
-      return false;
-
-    auto const beginIt = std::make_move_iterator(visitedSegments.begin());
-    auto const endIt = std::make_move_iterator(visitedSegments.end());
-    deadEnds.insert(beginIt, endIt);
-    return true;
+    return IsDeadEndCached(segment, true /* isOutgoing */, false /* useRoutingOptions */, worldGraph,
+                           deadEnds);
   });
 }
 
@@ -871,10 +880,11 @@ bool IndexRouter::IsFencedOff(m2::PointD const & point, pair<Edge, Junction> con
 }
 
 void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
-                                      vector<IRoadGraph::FullRoadInfo> const & roads,
-                                      uint32_t count, vector<pair<Edge, Junction>> & edgeProj) const
+                                      vector<IRoadGraph::FullRoadInfo> const & roads, uint32_t count,
+                                      IsEdgeProjGood const & IsGood,
+                                      vector<pair<Edge, Junction>> & edgeProj) const
 {
-  NearestEdgeFinder finder(point);
+  NearestEdgeFinder finder(point, IsGood);
   for (auto const & r : roads)
     finder.AddInformationSource(r.m_featureId, r.m_roadInfo.m_junctions, r.m_roadInfo.m_bidirectional);
 
@@ -925,14 +935,14 @@ bool IndexRouter::FindBestSegments(m2::PointD const & point, m2::PointD const & 
   auto const file = platform::CountryFile(m_countryFileFn(point));
 
   vector<Edge> bestEdges;
-  if (!FindBestEdges(point, file, direction, isOutgoing, 20.0 /* closestEdgesRadiusM */,
+  if (!FindBestEdges(point, file, direction, isOutgoing, 40.0 /* closestEdgesRadiusM */,
                      worldGraph, bestEdges, bestSegmentIsAlmostCodirectional))
   {
-    if (!FindBestEdges(point, file, direction, isOutgoing, 300.0 /* closestEdgesRadiusM */,
+    if (!FindBestEdges(point, file, direction, isOutgoing, 500.0 /* closestEdgesRadiusM */,
                        worldGraph, bestEdges, bestSegmentIsAlmostCodirectional) &&
                        bestEdges.size() < kMaxRoadCandidates)
     {
-      if (!FindBestEdges(point, file, direction, isOutgoing, 1500.0 /* closestEdgesRadiusM */,
+      if (!FindBestEdges(point, file, direction, isOutgoing, 2000.0 /* closestEdgesRadiusM */,
                          worldGraph, bestEdges, bestSegmentIsAlmostCodirectional))
       {
         return false;
@@ -983,17 +993,22 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
         point.SquaredLength(rhs.m_roadInfo.m_junctions[0].GetPoint());
   });
 
+  set<Segment> deadEnds;
+  auto const IsGood = [&, this](pair<Edge, Junction> const & edgeProj){
+    auto const segment = GetSegmentByEdge(edgeProj.first);
+    if (IsDeadEndCached(segment, isOutgoing, true /* useRoutingOptions */,  worldGraph, deadEnds))
+      return false;
+
+    // Removing all candidates which are fenced off by the road graph from |point|.
+    // It's better to perform this step after |candidates| are found:
+    // * by performance reasons
+    // * the closest edge(s) is not separated from |point| by other edges.
+    return !IsFencedOff(point, edgeProj, closestRoads);
+  };
+
   // Getting |kMaxRoadCandidates| closest edges from |closestRoads|.
   vector<pair<Edge, Junction>> candidates;
-  RoadsToNearestEdges(point, closestRoads, kMaxRoadCandidates, candidates);
-
-  // Removing all candidates which are fenced off by the road graph from |point|.
-  // It's better to perform this step after |candidates| are found:
-  // * by performance reasons
-  // * the closest edge(s) is not separated from |point| by other edges.
-  base::EraseIf(candidates, [&point, &closestRoads, this](pair<Edge, Junction> const & candidate) {
-    return IsFencedOff(point, candidate, closestRoads);
-  });
+  RoadsToNearestEdges(point, closestRoads, kMaxRoadCandidates, IsGood, candidates);
 
   if (candidates.empty())
     return false;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -807,21 +807,19 @@ unique_ptr<WorldGraph> IndexRouter::MakeWorldGraph()
 }
 
 void IndexRouter::EraseIfDeadEnd(WorldGraph & worldGraph,
-                                 vector<pair<FeatureID, IRoadGraph::RoadInfo>> & roads) const
+                                 vector<IRoadGraph::FullRoadInfo> & roads) const
 {
   // |deadEnds| cache is necessary to minimize number of calls a time consumption IsDeadEnd() method.
   set<Segment> deadEnds;
-  base::EraseIf(roads, [&deadEnds, &worldGraph, this](pair<FeatureID, IRoadGraph::RoadInfo> const & r) {
-    auto const & featureId = r.first;
-    auto const & road = r.second;
-    CHECK_GREATER_OR_EQUAL(road.m_junctions.size(), 2, ());
+  base::EraseIf(roads, [&deadEnds, &worldGraph, this](IRoadGraph::FullRoadInfo const & r) {
+    CHECK_GREATER_OR_EQUAL(r.m_roadInfo.m_junctions.size(), 2, ());
 
     // Note. Checking if an edge goes to a dead end is a time consumption process.
     // So the number of checked edges should be minimized as possible.
     // Below a heuristic is used. If a first segment of a feature is forward direction is a dead end
     // all segments of the feature is considered as dead ends.
-    auto const segment = GetSegmentByEdge(Edge::MakeReal(featureId, true /* forward */, 0 /* segment id */,
-                                                         road.m_junctions[0], road.m_junctions[1]));
+    auto const segment = GetSegmentByEdge(Edge::MakeReal(r.m_featureId, true /* forward */, 0 /* segment id */,
+                                                         r.m_roadInfo.m_junctions[0], r.m_roadInfo.m_junctions[1]));
     if (deadEnds.count(segment) != 0)
       return true;
 
@@ -837,14 +835,14 @@ void IndexRouter::EraseIfDeadEnd(WorldGraph & worldGraph,
 }
 
 bool IndexRouter::IsFencedOff(m2::PointD const & point, pair<Edge, Junction> const & edgeProjection,
-                              vector<pair<FeatureID, IRoadGraph::RoadInfo>> const & fences) const
+                              vector<IRoadGraph::FullRoadInfo> const & fences) const
 {
   auto const & edge = edgeProjection.first;
   auto const & projPoint = edgeProjection.second.GetPoint();
 
   for (auto const & fence : fences)
   {
-    auto const & featureGeom = fence.second.m_junctions;
+    auto const & featureGeom = fence.m_roadInfo.m_junctions;
     for (size_t i = 1; i < featureGeom.size(); ++i)
     {
       auto const & fencePointFrom = featureGeom[i - 1];
@@ -873,16 +871,12 @@ bool IndexRouter::IsFencedOff(m2::PointD const & point, pair<Edge, Junction> con
 }
 
 void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
-                                      vector<pair<FeatureID, IRoadGraph::RoadInfo>> const & roads,
+                                      vector<IRoadGraph::FullRoadInfo> const & roads,
                                       uint32_t count, vector<pair<Edge, Junction>> & edgeProj) const
 {
   NearestEdgeFinder finder(point);
   for (auto const & r : roads)
-  {
-    auto const & fid = r.first;
-    auto const & roadInfo = r.second;
-    finder.AddInformationSource(fid, roadInfo.m_junctions, roadInfo.m_bidirectional);
-  }
+    finder.AddInformationSource(r.m_featureId, r.m_roadInfo.m_junctions, r.m_roadInfo.m_bidirectional);
 
   finder.MakeResult(edgeProj, count);
 }
@@ -982,12 +976,11 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
   // a feature to a |point| the more chances that it crosses the segment
   // |point|, projections of |point| on feature edges. It confirmed with benchmarks.
   sort(closestRoads.begin(), closestRoads.end(),
-       [&point](pair<FeatureID, IRoadGraph::RoadInfo> const & lhs,
-          pair<FeatureID, IRoadGraph::RoadInfo> const & rhs) {
-    CHECK(!lhs.second.m_junctions.empty(), ());
+       [&point](IRoadGraph::FullRoadInfo const & lhs, IRoadGraph::FullRoadInfo const & rhs) {
+    CHECK(!lhs.m_roadInfo.m_junctions.empty(), ());
     return
-        point.SquaredLength(lhs.second.m_junctions[0].GetPoint()) <
-        point.SquaredLength(rhs.second.m_junctions[0].GetPoint());
+        point.SquaredLength(lhs.m_roadInfo.m_junctions[0].GetPoint()) <
+        point.SquaredLength(rhs.m_roadInfo.m_junctions[0].GetPoint());
   });
 
   // Getting |kMaxRoadCandidates| closest edges from |closestRoads|.

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -881,10 +881,10 @@ bool IndexRouter::IsFencedOff(m2::PointD const & point, pair<Edge, Junction> con
 
 void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
                                       vector<IRoadGraph::FullRoadInfo> const & roads, uint32_t count,
-                                      IsEdgeProjGood const & IsGood,
+                                      IsEdgeProjGood const & isGood,
                                       vector<pair<Edge, Junction>> & edgeProj) const
 {
-  NearestEdgeFinder finder(point, IsGood);
+  NearestEdgeFinder finder(point, isGood);
   for (auto const & r : roads)
     finder.AddInformationSource(r.m_featureId, r.m_roadInfo.m_junctions, r.m_roadInfo.m_bidirectional);
 
@@ -977,9 +977,10 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
   auto closestRoads = m_roadGraph.FindRoads(rect, isGoodFeature);
 
   // Removing all dead ends from |closestRoads|. Then some candidates will be taken from |closestRoads|.
-  // It's necessary to call for all |closestRoads| before IsFencedOff(). If to remove all fenced off
-  // by other features from |point| candidates at first, only dead ends candidates may be left.
-  // And then the dead end candidates will be removed as well as dead ends.
+  // It's necessary to remove all dead ends for all |closestRoads| before IsFencedOff().
+  // If to remove all fenced off by other features from |point| candidates at first,
+  // only dead ends candidates may be left. And then the dead end candidates will be removed
+  // as well as dead ends. It often happens near airports.
   EraseIfDeadEnd(worldGraph, closestRoads);
 
   // Sorting from the closest features to the further ones. The idea is the closer
@@ -993,22 +994,29 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
         point.SquaredLength(rhs.m_roadInfo.m_junctions[0].GetPoint());
   });
 
+  // Note about necessity of removing dead ends twice.
+  // At first, only real dead ends and roads which are not correct according to |worldGraph|
+  // are removed in EraseIfDeadEnd() function. It's necessary to prepare correct road network
+  // (|closestRoads|) which will be used in IsFencedOff() method later and |closestRoads|
+  // should contain all roads independently of routing options to prevent crossing roads
+  // which are switched off in RoutingOptions.
+  // Then in |IsDeadEndCached(..., true /* useRoutingOptions */, ...)| below we ignore
+  // candidates if it's a dead end taking into acount routing options. We ignore candidates as well
+  // if they don't match RoutingOptions.
   set<Segment> deadEnds;
-  auto const IsGood = [&, this](pair<Edge, Junction> const & edgeProj){
+  auto const isGood = [&, this](pair<Edge, Junction> const & edgeProj){
     auto const segment = GetSegmentByEdge(edgeProj.first);
     if (IsDeadEndCached(segment, isOutgoing, true /* useRoutingOptions */,  worldGraph, deadEnds))
       return false;
 
-    // Removing all candidates which are fenced off by the road graph from |point|.
-    // It's better to perform this step after |candidates| are found:
-    // * by performance reasons
-    // * the closest edge(s) is not separated from |point| by other edges.
+    // Removing all candidates which are fenced off by the road graph (|closestRoads|) from |point|.
     return !IsFencedOff(point, edgeProj, closestRoads);
   };
 
-  // Getting |kMaxRoadCandidates| closest edges from |closestRoads|.
+  // Getting |kMaxRoadCandidates| closest edges from |closestRoads| if they are correct
+  // according to isGood() function.
   vector<pair<Edge, Junction>> candidates;
-  RoadsToNearestEdges(point, closestRoads, kMaxRoadCandidates, IsGood, candidates);
+  RoadsToNearestEdges(point, closestRoads, kMaxRoadCandidates, isGood, candidates);
 
   if (candidates.empty())
     return false;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -829,15 +829,17 @@ void IndexRouter::EraseIfDeadEnd(WorldGraph & worldGraph,
 {
   // |deadEnds| cache is necessary to minimize number of calls a time consumption IsDeadEnd() method.
   set<Segment> deadEnds;
-  base::EraseIf(roads, [&deadEnds, &worldGraph, this](IRoadGraph::FullRoadInfo const & r) {
-    CHECK_GREATER_OR_EQUAL(r.m_roadInfo.m_junctions.size(), 2, ());
+  base::EraseIf(roads, [&deadEnds, &worldGraph, this](auto const & fullRoadInfo) {
+    CHECK_GREATER_OR_EQUAL(fullRoadInfo.m_roadInfo.m_junctions.size(), 2, ());
 
     // Note. Checking if an edge goes to a dead end is a time consumption process.
     // So the number of checked edges should be minimized as possible.
     // Below a heuristic is used. If a first segment of a feature is forward direction is a dead end
     // all segments of the feature is considered as dead ends.
-    auto const segment = GetSegmentByEdge(Edge::MakeReal(r.m_featureId, true /* forward */, 0 /* segment id */,
-                                                         r.m_roadInfo.m_junctions[0], r.m_roadInfo.m_junctions[1]));
+    auto const segment = GetSegmentByEdge(Edge::MakeReal(fullRoadInfo.m_featureId, true /* forward */,
+                                                         0 /* segment id */,
+                                                         fullRoadInfo.m_roadInfo.m_junctions[0],
+                                                         fullRoadInfo.m_roadInfo.m_junctions[1]));
     return IsDeadEndCached(segment, true /* isOutgoing */, false /* useRoutingOptions */, worldGraph,
                            deadEnds);
   });
@@ -885,8 +887,8 @@ void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
                                       vector<pair<Edge, Junction>> & edgeProj) const
 {
   NearestEdgeFinder finder(point, isGood);
-  for (auto const & r : roads)
-    finder.AddInformationSource(r.m_featureId, r.m_roadInfo.m_junctions, r.m_roadInfo.m_bidirectional);
+  for (auto const & road : roads)
+    finder.AddInformationSource(road);
 
   finder.MakeResult(edgeProj, count);
 }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1006,7 +1006,7 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
   // candidates if it's a dead end taking into acount routing options. We ignore candidates as well
   // if they don't match RoutingOptions.
   set<Segment> deadEnds;
-  auto const isGood = [&, this](pair<Edge, Junction> const & edgeProj){
+  auto const isGood = [&](pair<Edge, Junction> const & edgeProj){
     auto const segment = GetSegmentByEdge(edgeProj.first);
     if (IsDeadEndCached(segment, isOutgoing, true /* useRoutingOptions */,  worldGraph, deadEnds))
       return false;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -882,7 +882,7 @@ bool IndexRouter::IsFencedOff(m2::PointD const & point, pair<Edge, Junction> con
 }
 
 void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
-                                      vector<IRoadGraph::FullRoadInfo> const & roads, uint32_t count,
+                                      vector<IRoadGraph::FullRoadInfo> const & roads,
                                       IsEdgeProjGood const & isGood,
                                       vector<pair<Edge, Junction>> & edgeProj) const
 {
@@ -890,7 +890,7 @@ void IndexRouter::RoadsToNearestEdges(m2::PointD const & point,
   for (auto const & road : roads)
     finder.AddInformationSource(road);
 
-  finder.MakeResult(edgeProj, count);
+  finder.MakeResult(edgeProj, kMaxRoadCandidates);
 }
 
 Segment IndexRouter::GetSegmentByEdge(Edge const & edge) const
@@ -1015,10 +1015,9 @@ bool IndexRouter::FindBestEdges(m2::PointD const & point,
     return !IsFencedOff(point, edgeProj, closestRoads);
   };
 
-  // Getting |kMaxRoadCandidates| closest edges from |closestRoads| if they are correct
-  // according to isGood() function.
+  // Getting closest edges from |closestRoads| if they are correct according to isGood() function.
   vector<pair<Edge, Junction>> candidates;
-  RoadsToNearestEdges(point, closestRoads, kMaxRoadCandidates, isGood, candidates);
+  RoadsToNearestEdges(point, closestRoads, isGood, candidates);
 
   if (candidates.empty())
     return false;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -106,7 +106,8 @@ private:
 
   std::unique_ptr<WorldGraph> MakeWorldGraph();
 
-  /// \brief Removes all roads from |roads| which goes to dead ends.
+  /// \brief Removes all roads from |roads| which goes to dead ends and all road which
+  /// is not good according to |worldGraph|. For car routing it's roads with hwtag nocar.
   void EraseIfDeadEnd(WorldGraph & worldGraph,
                       std::vector<IRoadGraph::FullRoadInfo> & roads) const;
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -11,6 +11,7 @@
 #include "routing/features_road_graph.hpp"
 #include "routing/index_graph_starter_joints.hpp"
 #include "routing/joint.hpp"
+#include "routing/nearest_edge_finder.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "routing/segment.hpp"
@@ -115,8 +116,9 @@ private:
                    std::vector<IRoadGraph::FullRoadInfo> const & fences) const;
 
   void RoadsToNearestEdges(m2::PointD const & point,
-                           std::vector<IRoadGraph::FullRoadInfo> const & roads,
-                           uint32_t count, std::vector<std::pair<Edge, Junction>> & edgeProj) const;
+                           std::vector<IRoadGraph::FullRoadInfo> const & roads, uint32_t count,
+                           IsEdgeProjGood const & isGood,
+                           std::vector<std::pair<Edge, Junction>> & edgeProj) const;
 
   Segment GetSegmentByEdge(Edge const & edge) const;
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -107,15 +107,15 @@ private:
 
   /// \brief Removes all roads from |roads| which goes to dead ends.
   void EraseIfDeadEnd(WorldGraph & worldGraph,
-                      std::vector<std::pair<FeatureID, IRoadGraph::RoadInfo>> & roads) const;
+                      std::vector<IRoadGraph::FullRoadInfo> & roads) const;
 
   /// \returns true if a segment (|point|, |edgeProjection.second|) crosses one of segments
   /// in |fences| except for a one which has the same geometry with |edgeProjection.first|.
   bool IsFencedOff(m2::PointD const & point, std::pair<Edge, Junction> const & edgeProjection,
-                   std::vector<std::pair<FeatureID, IRoadGraph::RoadInfo>> const & fences) const;
+                   std::vector<IRoadGraph::FullRoadInfo> const & fences) const;
 
   void RoadsToNearestEdges(m2::PointD const & point,
-                           std::vector<std::pair<FeatureID, IRoadGraph::RoadInfo>> const & roads,
+                           std::vector<IRoadGraph::FullRoadInfo> const & roads,
                            uint32_t count, std::vector<std::pair<Edge, Junction>> & edgeProj) const;
 
   Segment GetSegmentByEdge(Edge const & edge) const;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -117,7 +117,7 @@ private:
                    std::vector<IRoadGraph::FullRoadInfo> const & fences) const;
 
   void RoadsToNearestEdges(m2::PointD const & point,
-                           std::vector<IRoadGraph::FullRoadInfo> const & roads, uint32_t count,
+                           std::vector<IRoadGraph::FullRoadInfo> const & roads,
                            IsEdgeProjGood const & isGood,
                            std::vector<std::pair<Edge, Junction>> & edgeProj) const;
 

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -113,7 +113,9 @@ void NearestEdgeFinder::AddResIf(Candidate const & candidate, bool forward, size
   if (res.size() >= maxCountFeatures)
     return;
 
-  auto const & edge = Edge::MakeReal(candidate.m_fid, forward, candidate.m_segId, candidate.m_segStart, candidate.m_segEnd);
+  Junction const & start = forward ? candidate.m_segStart : candidate.m_segEnd;
+  Junction const & end = forward ? candidate.m_segEnd : candidate.m_segStart;
+  auto const & edge = Edge::MakeReal(candidate.m_fid, forward, candidate.m_segId, start,end);
   auto const & edgeProj = make_pair(edge, candidate.m_projPoint);
   if (m_isEdgeProjGood && !m_isEdgeProjGood(edgeProj))
     return;

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -62,7 +62,7 @@ void NearestEdgeFinder::AddInformationSource(IRoadGraph::FullRoadInfo const & ro
   else
   {
     double const distFromStartM = MercatorBounds::DistanceOnEarth(segStart.GetPoint(), closestPoint);
-    ASSERT_LESS_OR_EQUAL(distFromStartM, segLenM, (featureId));
+    ASSERT_LESS_OR_EQUAL(distFromStartM, segLenM, (roadInfo.m_featureId));
     projPointAlt =
         startAlt + static_cast<feature::TAltitude>((endAlt - startAlt) * distFromStartM / segLenM);
   }

--- a/routing/nearest_edge_finder.hpp
+++ b/routing/nearest_edge_finder.hpp
@@ -25,6 +25,17 @@ using IsEdgeProjGood = std::function<bool(std::pair<Edge, Junction> const&)>;
 /// Class returns pairs of outgoing edge and projection point on the edge
 class NearestEdgeFinder
 {
+public:
+  NearestEdgeFinder(m2::PointD const & point, IsEdgeProjGood const & isEdgeProjGood);
+
+  inline bool HasCandidates() const { return !m_candidates.empty(); }
+
+  void AddInformationSource(FeatureID const & featureId, IRoadGraph::JunctionVec const & junctions,
+                            bool bidirectional);
+
+  void MakeResult(std::vector<std::pair<Edge, Junction>> & res, size_t maxCountFeatures);
+
+private:
   struct Candidate
   {
     static auto constexpr kInvalidSegmentId = std::numeric_limits<uint32_t>::max();
@@ -38,26 +49,15 @@ class NearestEdgeFinder
     bool m_bidirectional = true;
   };
 
-  m2::PointD const m_point;
-  std::vector<Candidate> m_candidates;
-  IsEdgeProjGood m_isEdgeProjGood;
-
-public:
-  explicit NearestEdgeFinder(m2::PointD const & point, IsEdgeProjGood const & isEdgeProjGood);
-
-  inline bool HasCandidates() const { return !m_candidates.empty(); }
-
-  void AddInformationSource(FeatureID const & featureId, IRoadGraph::JunctionVec const & junctions,
-                            bool bidirectional);
-
-  void MakeResult(std::vector<std::pair<Edge, Junction>> & res, size_t maxCountFeatures);
-
-private:
   void AddResIf(FeatureID const & featureId, bool forward, uint32_t segId,
                 Junction const & startJunction, Junction const & endJunction,
                 Junction const & projPoint, size_t maxCountFeatures,
                 std::vector<std::pair<Edge, Junction>> & res) const;
   void CandidateToResult(Candidate const & candidate, size_t maxCountFeatures,
                          std::vector<std::pair<Edge, Junction>> & res) const;
+
+  m2::PointD const m_point;
+  std::vector<Candidate> m_candidates;
+  IsEdgeProjGood m_isEdgeProjGood;
 };
 }  // namespace routing

--- a/routing/nearest_edge_finder.hpp
+++ b/routing/nearest_edge_finder.hpp
@@ -10,6 +10,7 @@
 #include "indexer/feature_decl.hpp"
 #include "indexer/mwm_set.hpp"
 
+#include <functional>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -18,6 +19,7 @@
 
 namespace routing
 {
+using IsEdgeProjGood = std::function<bool(std::pair<Edge, Junction> const&)>;
 
 /// Helper functor class to filter nearest roads to the given starting point.
 /// Class returns pairs of outgoing edge and projection point on the edge
@@ -38,9 +40,10 @@ class NearestEdgeFinder
 
   m2::PointD const m_point;
   std::vector<Candidate> m_candidates;
+  IsEdgeProjGood m_isEdgeProjGood;
 
 public:
-  explicit NearestEdgeFinder(m2::PointD const & point);
+  explicit NearestEdgeFinder(m2::PointD const & point, IsEdgeProjGood const & isEdgeProjGood);
 
   inline bool HasCandidates() const { return !m_candidates.empty(); }
 
@@ -50,6 +53,10 @@ public:
   void MakeResult(std::vector<std::pair<Edge, Junction>> & res, size_t maxCountFeatures);
 
 private:
+  void AddResIf(FeatureID const & featureId, bool forward, uint32_t segId,
+                Junction const & startJunction, Junction const & endJunction,
+                Junction const & projPoint, size_t maxCountFeatures,
+                std::vector<std::pair<Edge, Junction>> & res) const;
   void CandidateToResult(Candidate const & candidate, size_t maxCountFeatures,
                          std::vector<std::pair<Edge, Junction>> & res) const;
 };

--- a/routing/nearest_edge_finder.hpp
+++ b/routing/nearest_edge_finder.hpp
@@ -30,8 +30,8 @@ public:
 
   inline bool HasCandidates() const { return !m_candidates.empty(); }
 
-  void AddInformationSource(FeatureID const & featureId, IRoadGraph::JunctionVec const & junctions,
-                            bool bidirectional);
+  void AddInformationSource(IRoadGraph::FullRoadInfo const & roadInfo);
+
 
   void MakeResult(std::vector<std::pair<Edge, Junction>> & res, size_t maxCountFeatures);
 
@@ -49,9 +49,7 @@ private:
     bool m_bidirectional = true;
   };
 
-  void AddResIf(FeatureID const & featureId, bool forward, uint32_t segId,
-                Junction const & startJunction, Junction const & endJunction,
-                Junction const & projPoint, size_t maxCountFeatures,
+  void AddResIf(Candidate const & candidate, bool forward, size_t maxCountFeatures,
                 std::vector<std::pair<Edge, Junction>> & res) const;
   void CandidateToResult(Candidate const & candidate, size_t maxCountFeatures,
                          std::vector<std::pair<Edge, Junction>> & res) const;

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -198,6 +198,21 @@ public:
     bool m_bidirectional;
   };
 
+  struct FullRoadInfo
+  {
+    FullRoadInfo(FeatureID const & featureId, RoadInfo const & roadInfo,
+                 bool isRoadAccordingToModel)
+      : m_featureId(featureId)
+      , m_roadInfo(roadInfo)
+      , m_isRoadAccordingToModel(isRoadAccordingToModel)
+    {
+    }
+
+    FeatureID m_featureId;
+    RoadInfo m_roadInfo;
+    bool m_isRoadAccordingToModel;
+  };
+
   /// This class is responsible for loading edges in a cross.
   class ICrossEdgesLoader
   {
@@ -318,7 +333,7 @@ public:
   /// lying in |rect|.
   /// \note |RoadInfo::m_speedKMPH| is set to |kInvalidSpeedKMPH|.
   /// \note Some roads returned by this method my lie outside |rect| but close to it.
-  virtual std::vector<std::pair<FeatureID, RoadInfo>> FindRoads(
+  virtual std::vector<FullRoadInfo> FindRoads(
       m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const { return {}; }
 
   /// @return Types for the specified feature

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -200,17 +200,14 @@ public:
 
   struct FullRoadInfo
   {
-    FullRoadInfo(FeatureID const & featureId, RoadInfo const & roadInfo,
-                 bool isRoadAccordingToModel)
+    FullRoadInfo(FeatureID const & featureId, RoadInfo const & roadInfo)
       : m_featureId(featureId)
       , m_roadInfo(roadInfo)
-      , m_isRoadAccordingToModel(isRoadAccordingToModel)
     {
     }
 
     FeatureID m_featureId;
     RoadInfo m_roadInfo;
-    bool m_isRoadAccordingToModel;
   };
 
   /// This class is responsible for loading edges in a cross.

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -326,13 +326,11 @@ public:
   /// @return Array of pairs of Edge and projection point on the Edge. If there is no the closest edges
   /// then returns empty array.
   virtual void FindClosestEdges(m2::RectD const & rect, uint32_t count,
-                                IsGoodFeatureFn const & isGoodFeature,
                                 std::vector<std::pair<Edge, Junction>> & vicinities) const {};
 
-  /// \returns Vector of pairs FeatureID and corresponing RoadInfo for road features
+  /// \returns Vector of pairs FeatureID and corresponding RoadInfo for road features
   /// lying in |rect|.
   /// \note |RoadInfo::m_speedKMPH| is set to |kInvalidSpeedKMPH|.
-  /// \note Some roads returned by this method my lie outside |rect| but close to it.
   virtual std::vector<FullRoadInfo> FindRoads(
       m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const { return {}; }
 

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -142,7 +142,7 @@ void RoutingTest::GetNearestEdges(m2::PointD const & pt,
   routing::FeaturesRoadGraph graph(m_dataSource, m_mode, CreateModelFactory());
   graph.FindClosestEdges(MercatorBounds::RectByCenterXYAndSizeInMeters(
                              pt, routing::FeaturesRoadGraph::kClosestEdgesRadiusM),
-                         1 /* count */, nullptr /* isGoodFeature */, edges);
+                         1 /* count */, edges);
 }
 
 void TestRouter(routing::IRouter & router, m2::PointD const & startPos,

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -4,6 +4,9 @@
 
 #include "traffic/traffic_info.hpp"
 
+#include "geometry/parametrized_segment.hpp"
+#include "geometry/point2d.hpp"
+
 #include "base/stl_helpers.hpp"
 
 #include <algorithm>
@@ -159,5 +162,24 @@ Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge)
       numMwmIds.GetId(edge.GetFeatureId().m_mwmId.GetInfo()->GetLocalFile().GetCountryFile());
 
   return Segment(numMwmId, edge.GetFeatureId().m_index, edge.GetSegId(), edge.IsForward());
+}
+
+bool PolylineInRect(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect)
+{
+  if (junctions.empty())
+    return false;
+
+  if (junctions.size() == 1)
+    return rect.IsPointInside(junctions.front().GetPoint());
+
+  auto const & center = rect.Center();
+  for (size_t i = 1; i < junctions.size(); ++i)
+  {
+    m2::ParametrizedSegment<m2::PointD> segProj(junctions[i - 1].GetPoint(), junctions[i].GetPoint());
+    m2::PointD const & proj = segProj.ClosestPointTo(center);
+    if (rect.IsPointInside(proj))
+      return true;
+  }
+  return false;
 }
 }  // namespace routing

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -187,9 +187,9 @@ bool RectCoversPolyline(IRoadGraph::JunctionVec const & junctions, m2::RectD con
   if (junctions.size() == 1)
     return rect.IsPointInside(junctions.front().GetPoint());
 
-  for (auto const & j : junctions)
+  for (auto const & junction : junctions)
   {
-    if (rect.IsPointInside(j.GetPoint()))
+    if (rect.IsPointInside(junction.GetPoint()))
       return true;
   }
 

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -61,8 +61,9 @@ bool PolylineInRect(IRoadGraph::JunctionVec const & junctions, m2::RectD const &
 /// if graph ends before this number is reached then junction is assumed as not connected to the
 /// world graph.
 template <typename Graph>
-bool CheckGraphConnectivity(typename Graph::Vertex const & start, bool isOutgoing, size_t limit,
-                            Graph & graph, std::set<typename Graph::Vertex> & marked)
+bool CheckGraphConnectivity(typename Graph::Vertex const & start, bool isOutgoing,
+                            bool useRoutingOptions, size_t limit, Graph & graph,
+                            std::set<typename Graph::Vertex> & marked)
 {
   std::queue<typename Graph::Vertex> q;
   q.push(start);
@@ -79,7 +80,7 @@ bool CheckGraphConnectivity(typename Graph::Vertex const & start, bool isOutgoin
 
     // Note. If |isOutgoing| == true outgoing edges are looked for.
     // If |isOutgoing| == false it's the finish. So ingoing edges are looked for.
-    graph.GetEdgeList(u, isOutgoing, edges);
+    graph.GetEdgeList(u, isOutgoing, useRoutingOptions, edges);
     for (auto const & edge : edges)
     {
       auto const & v = edge.GetTarget();

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -13,6 +13,7 @@
 #include "routing_common/pedestrian_model.hpp"
 
 #include "geometry/rect2d.hpp"
+#include "geometry/segment2d.hpp"
 
 #include "base/cancellable.hpp"
 
@@ -53,8 +54,11 @@ void ReconstructRoute(IDirectionsEngine & engine, IndexRoadGraph const & graph,
 /// \returns Segment() if mwm of |edge| is not alive.
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
 
-// @returns true if any part of polyline |junctions| lay in |rect| and false otherwise.
-bool PolylineInRect(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect);
+/// \returns true if |segment| crosses any side of |rect|.
+bool SegmentCrossesRect(m2::Segment2D const & segment, m2::RectD const & rect);
+
+// \returns true if any part of polyline |junctions| lay in |rect| and false otherwise.
+bool RectCoversPolyline(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -2,6 +2,7 @@
 
 #include "routing/directions_engine.hpp"
 #include "routing/index_road_graph.hpp"
+#include "routing/road_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/traffic_stash.hpp"
 
@@ -10,6 +11,8 @@
 #include "routing_common/bicycle_model.hpp"
 #include "routing_common/car_model.hpp"
 #include "routing_common/pedestrian_model.hpp"
+
+#include "geometry/rect2d.hpp"
 
 #include "base/cancellable.hpp"
 
@@ -49,6 +52,9 @@ void ReconstructRoute(IDirectionsEngine & engine, IndexRoadGraph const & graph,
 /// \brief Converts |edge| to |segment|.
 /// \returns Segment() if mwm of |edge| is not alive.
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
+
+// @returns true if any part of polyline |junctions| lay in |rect| and false otherwise.
+bool PolylineInRect(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,

--- a/routing/routing_integration_tests/road_graph_tests.cpp
+++ b/routing/routing_integration_tests/road_graph_tests.cpp
@@ -45,7 +45,7 @@ UNIT_TEST(FakeEdgesCombinatorialExplosion)
   std::vector<std::pair<routing::Edge, routing::Junction>> sourceVicinity;
   graph.FindClosestEdges(MercatorBounds::RectByCenterXYAndSizeInMeters(
                              j.GetPoint(), FeaturesRoadGraph::kClosestEdgesRadiusM),
-                         20 /* count */, {} /* ignoredFeatures */, sourceVicinity);
+                         20 /* count */, sourceVicinity);
   // In case of the combinatorial explosion mentioned above all the memory was consumed for
   // FeaturesRoadGraph::m_fakeIngoingEdges and FeaturesRoadGraph::m_fakeOutgoingEdges fields.
   graph.AddFakeEdges(j, sourceVicinity);

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -19,8 +19,6 @@ namespace
   public:
     RoutingOptionSetter(RoutingOptions::Road road)
     {
-      m_formerRoutingOptions.LoadCarOptionsFromSettings();
-
       RoutingOptions routingOptions;
       routingOptions.Add(road);
       RoutingOptions::SaveCarOptionsToSettings(routingOptions);
@@ -32,7 +30,7 @@ namespace
     }
 
   private:
-    RoutingOptions m_formerRoutingOptions;
+    RoutingOptions m_formerRoutingOptions = RoutingOptions::LoadCarOptionsFromSettings();
   };
 
 

--- a/routing/routing_integration_tests/small_routes.cpp
+++ b/routing/routing_integration_tests/small_routes.cpp
@@ -138,7 +138,8 @@ UNIT_TEST(SmallRoutes_JustNoError)
         integration::CalculateRoute(integration::GetVehicleComponents(type),
                                     MercatorBounds::FromLatLon(start), {0., 0.},
                                     MercatorBounds::FromLatLon(finish));
-    TEST_EQUAL(result.second, RouterResultCode::NoError, ());
+    TEST_EQUAL(result.second, RouterResultCode::NoError,
+               (std::get<0>(route), std::get<1>(route), std::get<2>(route)));
   }
 
   number = 0;

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -84,7 +84,7 @@ void TestEdges(IndexGraph & graph, Segment const & segment, vector<Segment> cons
          ());
 
   vector<SegmentEdge> edges;
-  graph.GetEdgeList(segment, isOutgoing, edges);
+  graph.GetEdgeList(segment, isOutgoing, true /* useRoutingOptions */, edges);
 
   vector<Segment> targets;
   for (SegmentEdge const & edge : edges)

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -18,7 +18,7 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
   unique_ptr<RoadGraphMockSource> graph(new RoadGraphMockSource());
   InitRoadGraphMockSourceWithTest1(*graph);
 
-  NearestEdgeFinder finder(point);
+  NearestEdgeFinder finder(point, nullptr /* isEdgeProjGood */);
   for (size_t i = 0; i < graph->GetRoadCount(); ++i)
   {
     FeatureID const featureId = MakeTestFeatureID(base::checked_cast<uint32_t>(i));

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/routing_tests/road_graph_builder.hpp"
 
+#include "routing/road_graph.hpp"
 #include "routing/nearest_edge_finder.hpp"
 
 #include "routing_common/maxspeed_conversion.hpp"
@@ -24,7 +25,7 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
     FeatureID const featureId = MakeTestFeatureID(base::checked_cast<uint32_t>(i));
     auto const & roadInfo =
         graph->GetRoadInfo(featureId, {true /* forward */, false /* in city */, Maxspeed()});
-    finder.AddInformationSource(featureId, roadInfo.m_junctions, roadInfo.m_bidirectional);
+    finder.AddInformationSource(IRoadGraph::FullRoadInfo(featureId, roadInfo));
   }
 
   vector<pair<Edge, Junction>> result;

--- a/routing/routing_tests/routing_helpers_tests.cpp
+++ b/routing/routing_tests/routing_helpers_tests.cpp
@@ -69,25 +69,25 @@ UNIT_TEST(FillSegmentInfoTest)
 UNIT_TEST(PolylineInRectTest)
 {
   // Empty polyline.
-  TEST(!PolylineInRect({}, m2::RectD()), ());
-  TEST(!PolylineInRect({}, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+  TEST(!RectCoversPolyline({}, m2::RectD()), ());
+  TEST(!RectCoversPolyline({}, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
 
   // One point polyline outside the rect.
   {
     auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(3.0, 3.0), 0 /* altitude */}});
-    TEST(!PolylineInRect(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+    TEST(!RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // One point polyline inside the rect.
   {
     auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(1.0, 1.0), 0 /* altitude */}});
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // One point polyline on the rect border.
   {
     auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(0.0, 0.0), 0 /* altitude */}});
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // Two point polyline touching the rect border.
@@ -96,16 +96,24 @@ UNIT_TEST(PolylineInRectTest)
         {m2::PointD(-1.0, -1.0), 0 /* altitude */},
         {m2::PointD(0.0, 0.0), 0 /* altitude */},
     });
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
-  // Crossing rect.
+  // Crossing rect by a segment but no polyline points inside the rect.
   {
     auto const junctions = IRoadGraph::JunctionVec({
         {m2::PointD(-1.0, -1.0), 0 /* altitude */},
         {m2::PointD(5.0, 5.0), 0 /* altitude */},
     });
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
+  }
+
+  {
+    auto const junctions = IRoadGraph::JunctionVec({
+        {m2::PointD(0.0, 1.0), 0 /* altitude */},
+        {m2::PointD(100.0, 2.0), 0 /* altitude */},
+    });
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 100.0, 1.0)), ());
   }
 
   // Crossing a rect very close to a corner.
@@ -114,7 +122,7 @@ UNIT_TEST(PolylineInRectTest)
         {m2::PointD(-1.0, 0.0), 0 /* altitude */},
         {m2::PointD(1.0, 1.9), 0 /* altitude */},
     });
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 1.0, 1.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 1.0, 1.0)), ());
   }
 
   // Three point polyline crossing the rect.
@@ -124,7 +132,7 @@ UNIT_TEST(PolylineInRectTest)
         {m2::PointD(1.0, 0.01), 0 /* altitude */},
         {m2::PointD(2.0, -1.0), 0 /* altitude */},
     });
-    TEST(PolylineInRect(junctions, m2::RectD(0.0, 0.0, 1.0, 1.0)), ());
+    TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 1.0, 1.0)), ());
   }
 }
 }  // namespace routing_test

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -34,7 +34,7 @@ public:
   // @{
   ~SingleVehicleWorldGraph() override = default;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                    std::vector<SegmentEdge> & edges) override;
 
   void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -202,7 +202,7 @@ void TransitWorldGraph::AddRealEdges(Segment const & segment, bool isOutgoing,
                                      bool useRoutingOptions, vector<SegmentEdge> & edges)
 {
   auto & indexGraph = GetIndexGraph(segment.GetMwmId());
-  indexGraph.GetEdgeList(segment, isOutgoing, true /* useRoutingOptions */, edges);
+  indexGraph.GetEdgeList(segment, isOutgoing, useRoutingOptions, edges);
   GetTwins(segment, isOutgoing, useRoutingOptions, edges);
 }
 

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -34,8 +34,13 @@ public:
   // WorldGraph overrides:
   ~TransitWorldGraph() override = default;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing,
+  void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                    std::vector<SegmentEdge> & edges) override;
+  void GetEdgeList(JointSegment const & parentJoint,
+                   Segment const & segment, bool isOutgoing,
+                   std::vector<JointEdge> & edges,
+                   std::vector<RouteWeight> & parentWeights) override;
+
   bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const override
   {
     return weight.GetWeight() - weight.GetTransitTime() <=
@@ -61,11 +66,6 @@ public:
   double CalcSegmentETA(Segment const & segment) override;
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
-  void GetEdgeList(JointSegment const & parentJoint,
-                   Segment const & segment, bool isOutgoing,
-                   std::vector<JointEdge> & edges,
-                   std::vector<RouteWeight> & parentWeights) override;
-
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) override
   {
     return m_indexLoader->GetIndexGraph(numMwmId);
@@ -83,7 +83,8 @@ private:
   }
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
-  void AddRealEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges);
+  void AddRealEdges(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                    vector<SegmentEdge> & edges);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,7 +4,8 @@
 
 namespace routing
 {
-void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges)
+void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                          std::vector<SegmentEdge> & edges)
 {
   std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);
@@ -33,7 +34,7 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, std::vector<
   SetMode(WorldGraphMode::SingleMwm);
 
   for (Segment const & twin : twins)
-    GetEdgeList(twin, isOutgoing, edges);
+    GetEdgeList(twin, isOutgoing, useRoutingOptions, edges);
 
   SetMode(prevMode);
 }

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -45,7 +45,7 @@ public:
 
   virtual ~WorldGraph() = default;
 
-  virtual void GetEdgeList(Segment const & segment, bool isOutgoing,
+  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                            std::vector<SegmentEdge> & edges) = 0;
   virtual void GetEdgeList(JointSegment const & vertex, Segment const & segment, bool isOutgoing,
                            std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights) = 0;
@@ -109,7 +109,8 @@ public:
   virtual IndexGraph & GetIndexGraph(NumMwmId numMwmId) = 0;
 
 protected:
-  void GetTwins(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  void GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+                std::vector<SegmentEdge> & edges);
   virtual void GetTwinsInner(Segment const & segment, bool isOutgoing,
                              std::vector<Segment> & twins) = 0;
 };

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -183,7 +183,7 @@ void TrackMatcher::Step::FillCandidates(Step const & previousStep, IndexGraph & 
     m_candidates.emplace_back(segment, DistanceToSegment(segment, m_point, graph));
 
     edges.clear();
-    graph.GetEdgeList(segment, true /* isOutgoing */, edges);
+    graph.GetEdgeList(segment, true /* isOutgoing */, true /* useRoutingOptions */, edges);
 
     for (SegmentEdge const & edge : edges)
     {
@@ -209,7 +209,8 @@ void TrackMatcher::Step::ChooseSegment(Step const & nextStep, IndexGraph & index
   double minDistance = numeric_limits<double>::max();
 
   vector<SegmentEdge> edges;
-  indexGraph.GetEdgeList(nextStep.m_segment, false /* isOutgoing */, edges);
+  indexGraph.GetEdgeList(nextStep.m_segment, false /* isOutgoing */, true /* useRoutingOptions */,
+                         edges);
   edges.emplace_back(nextStep.m_segment, GetAStarWeightZero<RouteWeight>());
 
   for (Candidate const & candidate : m_candidates)


### PR DESCRIPTION
При построении маршрута от старта и к финишу достраиваются файковые дуги. (Было добавлено в https://github.com/mapsme/omim/pull/11038). Эти файковые дуги достраиваются только до дуг дорожного графа, до которых можно добраться по прямой не пересекая других дуг графа. Их этого правила было два исключения:
1. пересекаем дороги не доступные для машин (тропы, другие пути);
2. пересекаем дороги, по которым клиент не хочет ездить: платные, фери и т.п;

Данный PR исключает (2). Например, если пользователь хочет ехать в объезд платных дорог, то мы не предлагаем ему пересекать платную дорогу по прямой.

Осталось:
- добавить интеграционные тесты на эту фичу;
- поправить SmallRoutes_JustNoError (тест 30): построение короткого маршрута, когда старт и финиш проецируется на одну и ту же точку на графе дорог (сейчас не прокладывает)

https://jira.mail.ru/browse/MAPSME-11257

@gmoryes PTAL
