### PR TITLE
[routing] Fixing mistakenly corrected routing integration test.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 345.25, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 334.7, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.


### PR DESCRIPTION
В коммите: 5b87ef63bf061ad23ac6735bffed0e8f1981610f (https://github.com/mapsme/omim/pull/11274) был ошибочно исправлен тест NetherlandsAmsterdamBicycleYes. Теперь возвращаем исправление обратно.

@gmoryes PTAL