### PR TITLE
[routing] Fixing routing integration tests for map 190727.

### DIFF
--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -61,11 +61,9 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
-  integration::TestTurnCount(route, 4 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest)


### PR DESCRIPTION
После обнолвения карт c 190719 до 190727 в ветке release-92 сломался один интеграционый тест: RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest

Сейчас маршрут и маневры вполне соответствуют карте.

@gmoryes PTAL

![image](https://user-images.githubusercontent.com/1768114/62448614-f23fd300-b770-11e9-9604-89d6e8f1c2b2.png)
