### PR TITLE
[generator:regions] Fix capital points affiliation

### DIFF
--- a/generator/generator_tests/regions_tests.cpp
+++ b/generator/generator_tests/regions_tests.cpp
@@ -514,6 +514,28 @@ UNIT_TEST(RegionsBuilderTest_GenerateCityPointRegionByNameMatchingWithCityPostfi
        ());
 }
 
+UNIT_TEST(RegionsBuilderTest_GenerateCapitalPointRegionAndAdminRegionWithSameBoundary)
+{
+  Tag const admin{"admin_level"};
+  Tag const place{"place"};
+  Tag const name{"name"};
+  TagValue const ba{"boundary", "administrative"};
+
+  auto regions = GenerateTestRegions(
+      {
+          {1, {name = u8"Country", admin = "2", ba}, {{0.00, 0.00}, {0.50, 0.50}}},
+          {2, {name = u8"Region", admin = "6", ba}, {{0.10, 0.10}, {0.20, 0.20}}},
+          {3, {name = u8"Washington", admin = "8", ba}, {{0.10, 0.10}, {0.20, 0.20}}},
+          {4, {name = u8"Washington", place = "city", admin = "2"}, {{0.15, 0.15}}},
+      },
+      true /* withGeometry */);
+
+  TEST_EQUAL(regions.size(), 2, (regions));
+  TEST(HasName(regions, u8"Country"), (regions));
+  TEST(HasName(regions, u8"Country, locality: Washington [(0.10, 0.10), (0.20, 0.20)]"),
+       (regions));
+}
+
 // Russia regions tests ----------------------------------------------------------------------------
 UNIT_TEST(RegionsBuilderTest_GenerateRusCitySuburb)
 {

--- a/generator/regions/country_specifier.cpp
+++ b/generator/regions/country_specifier.cpp
@@ -64,11 +64,13 @@ PlaceLevel CountrySpecifier::GetLevel(PlaceType placeType)
 
 int CountrySpecifier::RelateByWeight(LevelRegion const & l, LevelRegion const & r) const
 {
-  if (l.GetLevel() != PlaceLevel::Unknown && r.GetLevel() != PlaceLevel::Unknown)
+  auto const lLevel = l.GetLevel();
+  auto const rLevel = r.GetLevel();
+  if (lLevel != PlaceLevel::Unknown && rLevel != PlaceLevel::Unknown)
   {
-    if (l.GetLevel() > r.GetLevel())
+    if (lLevel > rLevel)
       return -1;
-    if (l.GetLevel() < r.GetLevel())
+    if (lLevel < rLevel)
       return 1;
   }
 
@@ -87,10 +89,18 @@ int CountrySpecifier::RelateByWeight(LevelRegion const & l, LevelRegion const & 
   auto const rAdminLevel = r.GetAdminLevel();
   if (lAdminLevel != AdminLevel::Unknown && rAdminLevel != AdminLevel::Unknown)
   {
-    if (lAdminLevel > rAdminLevel)
+    if (lAdminLevel > rAdminLevel &&
+        // Ignore capital point (admin_level=2).
+        (rAdminLevel != AdminLevel::Two || rLevel == PlaceLevel::Country))
+    {
       return -1;
-    if (lAdminLevel < rAdminLevel)
+    }
+    if (lAdminLevel < rAdminLevel &&
+        // Ignore capital point (admin_level=2).
+        (lAdminLevel != AdminLevel::Two || lLevel == PlaceLevel::Country))
+    {
       return 1;
+    }
   }
   if (lAdminLevel != AdminLevel::Unknown)
     return 1;


### PR DESCRIPTION
Столицы в виде точки имеют admin_level=2 и не должны выигрывать у других admin_level регионов для region/subregion с одинаковой геометрией.