### PR TITLE
[android] Fixed endless progress of the cross promo gallery when ther…

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1246,12 +1246,12 @@ public class PlacePageView extends NestedScrollView
 
   private void processSponsored(@NonNull NetworkPolicy policy)
   {
+    boolean hasPromoGallery = mSponsored != null && mSponsored.getType() == Sponsored.TYPE_PROMO_CATALOG;
+    toggleCatalogPromoGallery(hasPromoGallery);
+
     if (mSponsored == null || mMapObject == null)
       return;
 
-    boolean hasPromoGallery = mSponsored.getType() == Sponsored.TYPE_PROMO_CATALOG;
-    toggleCatalogPromoGallery(hasPromoGallery);
-    
     if (hasPromoGallery && policy.canUseNetwork())
     {
       Promo.INSTANCE.nativeRequestCityGallery(policy, mMapObject.getLat(), mMapObject.getLon(),


### PR DESCRIPTION
…e are no promo objects in the current city, which is associated with the MapObject
https://jira.mail.ru/browse/MAPSME-11445