### PR TITLE
[generator:regions] Fix commutative property of RelateByWeight()

### DIFF
--- a/generator/regions/country_specifier.cpp
+++ b/generator/regions/country_specifier.cpp
@@ -102,12 +102,28 @@ int CountrySpecifier::RelateByWeight(LevelRegion const & l, LevelRegion const & 
       return 1;
     }
   }
-  if (lAdminLevel != AdminLevel::Unknown)
-    return 1;
-  if (rAdminLevel != AdminLevel::Unknown)
-    return -1;
+  else
+  {
+    if (lAdminLevel != AdminLevel::Unknown)
+      return 1;
+    else if (rAdminLevel != AdminLevel::Unknown)
+      return -1;
+  }
 
-  return 0;
+  // Let leveled region is derived region.
+  if (lLevel != PlaceLevel::Unknown && rLevel == PlaceLevel::Unknown)
+    return -1;
+  if (rLevel != PlaceLevel::Unknown && lLevel == PlaceLevel::Unknown)
+    return 1;
+
+  // Let place-marked region is derived region.
+  if (lPlaceType != PlaceType::Unknown && rPlaceType == PlaceType::Unknown)
+    return -1;
+  if (rPlaceType != PlaceType::Unknown && lPlaceType == PlaceType::Unknown)
+    return 1;
+
+  CHECK_NOT_EQUAL(l.GetOriginId(), r.GetOriginId(), ());
+  return l.GetOriginId() < r.GetOriginId() ? 1 : -1;
 }
 }  // namespace regions
 }  // namespace generator

--- a/generator/regions/country_specifier.hpp
+++ b/generator/regions/country_specifier.hpp
@@ -16,8 +16,7 @@ public:
   virtual void AdjustRegionsLevel(Node::PtrList & outers);
   PlaceLevel GetLevel(Region const & region) const;
 
-  // Return -1 - |l| is under place of |r|, 0 - undefined relation, 1 - |r| is under place of |l|.
-  // Non-transitive.
+  // Return -1 - |l| is under place of |r|, 1 - |r| is under place of |l|.
   virtual int RelateByWeight(LevelRegion const & l, LevelRegion const & r) const;
   static PlaceLevel GetLevel(PlaceType placeType);
 

--- a/generator/regions/region.cpp
+++ b/generator/regions/region.cpp
@@ -72,6 +72,11 @@ base::GeoObjectId Region::GetId() const
   return RegionWithData::GetId();
 }
 
+base::GeoObjectId Region::GetOriginId() const
+{
+  return RegionWithData::GetId();
+}
+
 PlaceType Region::GetPlaceType() const
 {
   if (m_placeLabel)

--- a/generator/regions/region.hpp
+++ b/generator/regions/region.hpp
@@ -32,6 +32,7 @@ public:
   std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
 
   base::GeoObjectId GetId() const;
+  base::GeoObjectId GetOriginId() const;
   using RegionWithData::GetAdminLevel;
   PlaceType GetPlaceType() const;
   boost::optional<std::string> GetIsoCode() const;

--- a/generator/regions/regions_builder.cpp
+++ b/generator/regions/regions_builder.cpp
@@ -174,6 +174,8 @@ Node::Ptr RegionsBuilder::ChooseParent(std::vector<Node::Ptr> const & nodesInAre
     }
   }
 
+  CHECK(!parent || -1 == CompareAffiliation(region, parent->GetData(), countrySpecifier),
+        (GetRegionNotation(region), GetRegionNotation(parent->GetData())));
   return parent;
 }
 


### PR DESCRIPTION
Фикс: если геометрии двух регионов совпадают, то они должны быть вложены один в другой, а не быть братьями в дереве.
RelateByWeight() возвращает: -1 - левый регион подчинён правому, 1 - правый левому.