### PR TITLE
[routing] Fix crash in LeapsPostprocessor

### DIFF
--- a/routing/leaps_postprocessor.cpp
+++ b/routing/leaps_postprocessor.cpp
@@ -215,7 +215,8 @@ bool LeapsPostProcessor::PathInterval::GreaterByWeight::operator()(PathInterval 
 
 bool LeapsPostProcessor::PathInterval::operator<(PathInterval const & rhs) const
 {
-  CHECK(m_left > rhs.m_right || m_right < rhs.m_left,
+  CHECK(m_left > rhs.m_right || m_right < rhs.m_left ||
+        m_left == rhs.m_left && m_right == rhs.m_right,
         ("Intervals shouldn't intersect.", *this, rhs));
 
   return m_right < rhs.m_left;

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -549,4 +549,14 @@ namespace
         vehicleComponents, MercatorBounds::FromLatLon(55.93885, 37.40588), {0.0, 0.0},
         MercatorBounds::FromLatLon(55.93706, 37.45339), 10270.2);
   }
+
+  UNIT_TEST(NoCrash_RioGrandeCosmopolis)
+  {
+    TRouteResult route =
+        integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                    MercatorBounds::FromLatLon(-32.17641, -52.16350), {0., 0.},
+                                    MercatorBounds::FromLatLon(-22.64374, -47.19720));
+
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
+  }
 }  // namespace


### PR DESCRIPTION
Crash about comparison of equals elements during std::sort