### PR TITLE
[routing] Fix crash in routing in IndexGraph::IsRestricted

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -172,6 +172,7 @@ public:
     CHECK(false, ("This method exists only for compatibility with IndexGraphStarterJoints"));
     return GetAStarWeightZero<RouteWeight>();
   }
+
   bool AreWavesConnectible(map<JointSegment, JointSegment> const & /* forwardParents */,
                            JointSegment const & /* commonVertex */,
                            map<JointSegment, JointSegment> const & /* backwardParents */,
@@ -179,16 +180,21 @@ public:
   {
     return true;
   }
+
+  void SetAStarParents(bool /* forward */, map<JointSegment, JointSegment> & parents)
+  {
+    m_AStarParents = &parents;
+  }
+
+  void DropAStarParents()
+  {
+    m_AStarParents = nullptr;
+  }
   // @}
 
   m2::PointD const & GetPoint(Segment const & s, bool forward)
   {
     return m_graph.GetPoint(s, forward);
-  }
-
-  void SetAStarParents(bool /* forward */, map<JointSegment, JointSegment> & parents)
-  {
-    m_AStarParents = &parents;
   }
 
   void GetEdgesList(Segment const & child, bool isOutgoing, vector<SegmentEdge> & edges)
@@ -473,8 +479,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
     Algorithm astar;
     IndexGraphWrapper indexGraphWrapper(graph, enter);
     DijkstraWrapperJoints wrapper(indexGraphWrapper, enter);
-    AStarAlgorithm<JointSegment, JointEdge, RouteWeight>::Context context;
-    indexGraphWrapper.SetAStarParents(true /* forward */, context.GetParents());
+    AStarAlgorithm<JointSegment, JointEdge, RouteWeight>::Context context(wrapper);
     unordered_map<uint32_t, vector<JointSegment>> visitedVertexes;
     astar.PropagateWave(wrapper, wrapper.GetStartJoint(),
                         [&](JointSegment const & vertex)

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -22,6 +22,7 @@ public:
   virtual void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
 
   virtual void SetAStarParents(bool forward, Parents & parents);
+  virtual void DropAStarParents();
   virtual bool AreWavesConnectible(Parents & forwardParents, Vertex const & commonVertex,
                                    Parents & backwardParents);
 
@@ -31,6 +32,9 @@ public:
 template <typename VertexType, typename EdgeType, typename WeightType>
 void AStarGraph<VertexType, EdgeType, WeightType>::SetAStarParents(bool /* forward */,
                                                                    std::map<Vertex, Vertex> & /* parents */) {}
+
+template <typename VertexType, typename EdgeType, typename WeightType>
+void AStarGraph<VertexType, EdgeType, WeightType>::DropAStarParents() {}
 
 template <typename VertexType, typename EdgeType, typename WeightType>
 bool AStarGraph<VertexType, EdgeType, WeightType>::AreWavesConnectible(AStarGraph::Parents & /* forwardParents */,

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -117,6 +117,11 @@ public:
     m_graph.SetAStarParents(forward, parents);
   }
 
+  void DropAStarParents() override
+  {
+    m_graph.DropAStarParents();
+  }
+
   bool AreWavesConnectible(std::map<Vertex, Vertex> & forwardParents, Vertex const & commonVertex,
                            std::map<Vertex, Vertex> & backwardParents) override
   {

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -60,6 +60,11 @@ public:
     m_graph.SetAStarParents(forward, parents);
   }
 
+  void DropAStarParents() override
+  {
+    m_graph.DropAStarParents();
+  }
+
   bool AreWavesConnectible(std::map<Vertex, Vertex> & forwardParents, Vertex const & commonVertex,
                           std::map<Vertex, Vertex> & backwardParents) override
   {

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -251,6 +251,15 @@ void SingleVehicleWorldGraph::SetAStarParents(bool forward, map<JointSegment, Jo
     m_parentsForJoints.backward = &parents;
 }
 
+void SingleVehicleWorldGraph::DropAStarParents()
+{
+  m_parentsForJoints.backward = &AStarParents<JointSegment>::kEmpty;
+  m_parentsForJoints.forward = &AStarParents<JointSegment>::kEmpty;
+
+  m_parentsForSegments.backward = &AStarParents<Segment>::kEmpty;
+  m_parentsForSegments.forward = &AStarParents<Segment>::kEmpty;
+}
+
 template <typename VertexType>
 NumMwmId GetCommonMwmInChain(vector<VertexType> const & chain)
 {

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -81,6 +81,7 @@ public:
 
   void SetAStarParents(bool forward, ParentSegments & parents) override;
   void SetAStarParents(bool forward, ParentJoints & parents) override;
+  void DropAStarParents() override;
 
   bool AreWavesConnectible(ParentSegments & forwardParents, Segment const & commonVertex,
                            ParentSegments & backwardParents,

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -56,6 +56,7 @@ std::vector<RouteSegment::SpeedCamera> WorldGraph::GetSpeedCamInfo(Segment const
 
 void WorldGraph::SetAStarParents(bool forward, std::map<Segment, Segment> & parents) {}
 void WorldGraph::SetAStarParents(bool forward, std::map<JointSegment, JointSegment> & parents) {}
+void WorldGraph::DropAStarParents() {}
 
 bool WorldGraph::AreWavesConnectible(ParentSegments & forwardParents, Segment const & commonVertex,
                                      ParentSegments & backwardParents,

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -93,6 +93,7 @@ public:
 
   virtual void SetAStarParents(bool forward, ParentSegments & parents);
   virtual void SetAStarParents(bool forward, ParentJoints & parents);
+  virtual void DropAStarParents();
 
   virtual bool AreWavesConnectible(ParentSegments & forwardParents, Segment const & commonVertex,
                                   ParentSegments & backwardParents,


### PR DESCRIPTION
Added DropAStarParents method for AStarGraph, because after
AStarAlgorithm ended, IndexGraph still links with AStar's
parents which are have been already deallocated.