### PR TITLE
[routing] Changed IndexRouter::AreMwmsNear

### DIFF
--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -542,8 +542,8 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
       starter.GetGraph().SetMode(WorldGraphMode::NoLeaps);
       break;
     case VehicleType::Car:
-      starter.GetGraph().SetMode(AreMwmsNear(starter.GetMwms()) ? WorldGraphMode::Joints
-                                                                : WorldGraphMode::LeapsOnly);
+      starter.GetGraph().SetMode(AreMwmsNear(starter) ? WorldGraphMode::Joints
+                                                      : WorldGraphMode::LeapsOnly);
       break;
     case VehicleType::Count:
       CHECK(false, ("Unknown vehicle type:", m_vehicleType));
@@ -1347,17 +1347,23 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   return RouterResultCode::NoError;
 }
 
-bool IndexRouter::AreMwmsNear(set<NumMwmId> const & mwmIds) const
+bool IndexRouter::AreMwmsNear(IndexGraphStarter const & starter) const
 {
-  for (auto const & outerId : mwmIds)
+  auto const & startMwmIds = starter.GetStartMwms();
+  auto const & finishMwmIds = starter.GetFinishMwms();
+  for (auto const startMwmId : startMwmIds)
   {
-    m2::RectD const rect = m_countryRectFn(m_numMwmIds->GetFile(outerId).GetName());
+    m2::RectD const & rect = m_countryRectFn(m_numMwmIds->GetFile(startMwmId).GetName());
     size_t found = 0;
-    m_numMwmTree->ForEachInRect(rect, [&](NumMwmId id) { found += mwmIds.count(id); });
-    if (found != mwmIds.size())
-      return false;
+    m_numMwmTree->ForEachInRect(rect,
+                                [&finishMwmIds, &found](NumMwmId id) {
+                                  found += finishMwmIds.count(id);
+                                });
+    if (found != 0)
+      return true;
   }
-  return true;
+
+  return false;
 }
 
 bool IndexRouter::DoesTransitSectionExist(NumMwmId numMwmId) const

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -150,7 +150,7 @@ private:
                                 RouterDelegate const & delegate, IndexGraphStarter & starter,
                                 Route & route) const;
 
-  bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
+  bool AreMwmsNear(IndexGraphStarter const & starter) const;
   bool DoesTransitSectionExist(NumMwmId numMwmId) const;
 
   RouterResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,


### PR DESCRIPTION
In previous version start and finish could have only one
mwm related to them, but after adding several fake
segments, start and finish could be linked with
different mwms, because of that AreMwmsNear returns
false when start or finish placed near mwm's border.
Because of that LeapsOnly is chosen instead of
Joints mode.