### PR TITLE
[routing] Changed IndexRouter::AreMwmsNear

### DIFF
--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -153,7 +153,7 @@ private:
                                 RouterDelegate const & delegate, IndexGraphStarter & starter,
                                 Route & route) const;
 
-  bool AreMwmsNear(std::set<NumMwmId> const & mwmIds) const;
+  bool AreMwmsNear(IndexGraphStarter const & starter) const;
   bool DoesTransitSectionExist(NumMwmId numMwmId) const;
 
   RouterResultCode ConvertTransitResult(std::set<NumMwmId> const & mwmIds,

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -559,4 +559,14 @@ namespace
 
     TEST_EQUAL(route.second, RouterResultCode::NoError, ());
   }
+
+  UNIT_TEST(AreMwmsNear_HelsinkiPiter)
+  {
+    TRouteResult route =
+        integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                    MercatorBounds::FromLatLon(60.87083, 26.53612), {0., 0.},
+                                    MercatorBounds::FromLatLon(60.95360, 28.53979));
+
+    TEST_EQUAL(route.second, RouterResultCode::NoError, ());
+  }
 }  // namespace


### PR DESCRIPTION
In previous version start and finish could have only one
mwm related to them, but after adding several fake
segments, start and finish could be linked with
different mwms, because of that AreMwmsNear returns
false when start or finish placed near mwm's border.
Because of that LeapsOnly is chosen instead of
Joints mode.