### PR TITLE
Fix German translation for dog park

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -1962,7 +1962,7 @@
 	<string name="type.landuse.landfill">Müllhalde</string>
 	<string name="type.landuse.railway">Eisenbahnanlagen</string>
 	<string name="type.landuse.reservoir">Wasserfläche</string>
-	<string name="type.leisure.dog_park">Platz für Hundesauflauf</string>
+	<string name="type.leisure.dog_park">Hundeauslauffläche</string>
 	<string name="type.leisure.dog_park.tennis">Hundezone</string>
 	<string name="type.leisure.fitness_centre">Fitnessstudio</string>
 	<string name="type.leisure.fitness_station">Fitnessstation</string>

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -11046,7 +11046,7 @@
     nl = Plaats voor hondenuitlaten
     fi = Koirien ulkoilupaikka
     fr = Places autorisés pour promener les chiens
-    de = Platz für Hundesauflauf
+    de = Hundeauslauffläche
     hu = Kutyás terület
     id = Area untuk anjing
     it = Area sgambamento cani

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -3875,7 +3875,7 @@
 
 "type.leisure.common" = "leisure-common";
 
-"type.leisure.dog_park" = "Platz für Hundesauflauf";
+"type.leisure.dog_park" = "Hundeauslauffläche";
 
 "type.leisure.dog_park.tennis" = "Hundezone";
 


### PR DESCRIPTION
Fix German translation for dog park:
"Hundeauflauf" is actually something to eat containing dog meat :(
