### PR TITLE
[search] Do not require POI to have a postcode if the city has.

### DIFF
--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -178,6 +178,8 @@ private:
 
   void FillVillageLocalities(BaseContext const & ctx);
 
+  bool CityHasPostcode(BaseContext const & ctx) const;
+
   template <typename Fn>
   void ForEachCountry(std::vector<std::shared_ptr<MwmInfo>> const & infos, Fn && fn);
 
@@ -240,7 +242,7 @@ private:
   void EmitResult(BaseContext & ctx, Region const & region, TokenRange const & tokenRange,
                   bool allTokensUsed, bool exactMatch);
   void EmitResult(BaseContext & ctx, City const & city, TokenRange const & tokenRange,
-                  bool allTokensUsed, bool exactMatch);
+                  bool allTokensUsed);
 
   // Tries to match unclassified objects from lower layers, like
   // parks, forests, lakes, rivers, etc. This method finds all

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -2220,11 +2220,13 @@ UNIT_CLASS_TEST(ProcessorTest, VillagePostcodes)
       "Rue des Serpents", "en");
 
   TestBuilding building4(m2::PointD(0.0, 0.00001), "", "4", street.GetName("en"), "en");
+  TestPOI poi(m2::PointD(0.0, -0.00001), "Carrefour", "en");
 
   auto countryId = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
     builder.Add(marckolsheim);
     builder.Add(street);
     builder.Add(building4);
+    builder.Add(poi);
   });
 
   SetViewport(m2::RectD(-1, -1, 1, 1));
@@ -2234,7 +2236,12 @@ UNIT_CLASS_TEST(ProcessorTest, VillagePostcodes)
     TEST(ResultsMatch("Rue des Serpents 4 Marckolsheim 67390 ", rules), ());
   }
   {
-    Rules rules{ExactMatch(countryId, street), ExactMatch(countryId, marckolsheim)};
+    Rules rules{ExactMatch(countryId, poi), ExactMatch(countryId, street)};
+    // Test that we do not require the poi to have a postcode if the village has.
+    TEST(ResultsMatch("Carrefour Rue des Serpents Marckolsheim 67390 ", rules), ());
+  }
+  {
+    Rules rules{ExactMatch(countryId, street)};
     // Test that we do not require the street to have a postcode if the village has.
     TEST(ResultsMatch("Rue des Serpents Marckolsheim 67390 ", rules), ());
   }


### PR DESCRIPTION
немногим ранее добавляла игнорирование требования посткода для дома, если он уже указан для всего населенного пункта

теперь добавляю то же самое для poi 

также в WithPostcodes добавлен эмит города, если после нахождения посткода в запросе все токены использованы (поддержка запросов вида "Юрьево 127001")