### PR TITLE
[geocoder] Fixed feature name in localized region address.

### DIFF
--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -357,6 +357,7 @@ string ReverseGeocoder::GetLocalizedRegionAddress(RegionAddress const & addr,
     {
       vector<string> nameParts;
       nameGetter.GetLocalizedFullName(countryName, nameParts);
+      nameParts.insert(nameParts.begin(), addrStr);
       nameParts.erase(unique(nameParts.begin(), nameParts.end()), nameParts.end());
       addrStr = strings::JoinStrings(nameParts, ", ");
     }


### PR DESCRIPTION
При локализации адреса имя топонима вычитывалось, но использовалось не всегда.