### PR TITLE
[search] Keep better result in PreRanker::Filter and RemoveDuplicatingLinear.

### DIFF
--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -71,6 +71,10 @@ PreRankerResult::PreRankerResult(FeatureID const & id, PreRankingInfo const & in
   : m_id(id), m_info(info), m_provenance(provenance)
 {
   ASSERT(m_id.IsValid(), ());
+
+  m_matchedTokensNumber = 0;
+  for (auto const & r : m_info.m_tokenRange)
+    m_matchedTokensNumber += r.Size();
 }
 
 // static
@@ -99,6 +103,12 @@ bool PreRankerResult::LessByExactMatch(PreRankerResult const & lhs, PreRankerRes
   auto const rhsScore = rhs.m_info.m_exactMatch && rhs.m_info.m_allTokensUsed;
   if (lhsScore != rhsScore)
     return lhsScore;
+
+  if (lhs.GetInnermostTokensNumber() != rhs.GetInnermostTokensNumber())
+    return lhs.GetInnermostTokensNumber() > rhs.GetInnermostTokensNumber();
+
+  if (lhs.GetMatchedTokensNumber() != rhs.GetMatchedTokensNumber())
+    return lhs.GetMatchedTokensNumber() > rhs.GetMatchedTokensNumber();
 
   return LessDistance(lhs, rhs);
 }

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -55,12 +55,16 @@ public:
   PreRankingInfo & GetInfo() { return m_info; }
   PreRankingInfo const & GetInfo() const { return m_info; }
   std::vector<ResultTracer::Branch> const & GetProvenance() const { return m_provenance; }
+  size_t GetInnermostTokensNumber() const { return m_info.InnermostTokenRange().Size(); }
+  size_t GetMatchedTokensNumber() const { return m_matchedTokensNumber; }
 
 private:
   friend class RankerResult;
 
   FeatureID m_id;
   PreRankingInfo m_info;
+
+  size_t m_matchedTokensNumber = 0;
 
   // The call path in the Geocoder that leads to this result.
   std::vector<ResultTracer::Branch> m_provenance;

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -9,6 +9,8 @@
 
 #include "indexer/feature_data.hpp"
 
+#include "geometry/point2d.hpp"
+
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -52,11 +54,20 @@ public:
   uint8_t GetRank() const { return m_info.m_rank; }
   uint8_t GetPopularity() const { return m_info.m_popularity; }
   std::pair<uint8_t, float> GetRating() const { return m_info.m_rating; }
-  PreRankingInfo & GetInfo() { return m_info; }
   PreRankingInfo const & GetInfo() const { return m_info; }
   std::vector<ResultTracer::Branch> const & GetProvenance() const { return m_provenance; }
   size_t GetInnermostTokensNumber() const { return m_info.InnermostTokenRange().Size(); }
   size_t GetMatchedTokensNumber() const { return m_matchedTokensNumber; }
+
+  void SetRank(uint8_t rank) { m_info.m_rank = rank; }
+  void SetPopularity(uint8_t popularity) { m_info.m_popularity = popularity; }
+  void SetRating(std::pair<uint8_t, float> const & rating) { m_info.m_rating = rating; }
+  void SetDistanceToPivot(double distance) { m_info.m_distanceToPivot = distance; }
+  void SetCenter(m2::PointD const & center)
+  {
+    m_info.m_center = center;
+    m_info.m_centerLoaded = true;
+  }
 
 private:
   friend class RankerResult;

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -148,11 +148,13 @@ void PreRanker::Filter(bool viewportSearch)
     if (lhs.GetId() != rhs.GetId())
       return lhs.GetId() < rhs.GetId();
 
-    auto const & linfo = lhs.GetInfo();
-    auto const & rinfo = rhs.GetInfo();
-    if (linfo.GetNumTokens() != rinfo.GetNumTokens())
-      return linfo.GetNumTokens() > rinfo.GetNumTokens();
-    return linfo.InnermostTokenRange().Begin() < rinfo.InnermostTokenRange().Begin();
+    if (lhs.GetInnermostTokensNumber() != rhs.GetInnermostTokensNumber())
+      return lhs.GetInnermostTokensNumber() > rhs.GetInnermostTokensNumber();
+
+    if (lhs.GetMatchedTokensNumber() != rhs.GetMatchedTokensNumber())
+      return lhs.GetMatchedTokensNumber() > rhs.GetMatchedTokensNumber();
+
+    return lhs.GetInfo().InnermostTokenRange().Begin() < rhs.GetInfo().InnermostTokenRange().Begin();
   };
 
   sort(m_results.begin(), m_results.end(), comparePreRankerResults);

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -86,7 +86,6 @@ void PreRanker::FillMissingFieldsInPreResults()
 
   ForEach([&](PreRankerResult & r) {
     FeatureID const & id = r.GetId();
-    PreRankingInfo & info = r.GetInfo();
     if (id.m_mwmId != mwmId)
     {
       mwmId = id.m_mwmId;
@@ -109,17 +108,15 @@ void PreRanker::FillMissingFieldsInPreResults()
         ratings = make_unique<DummyRankTable>();
     }
 
-    info.m_rank = ranks->Get(id.m_index);
-    info.m_popularity = popularityRanks->Get(id.m_index);
-    info.m_rating = ugc::UGC::UnpackRating(ratings->Get(id.m_index));
+    r.SetRank(ranks->Get(id.m_index));
+    r.SetPopularity(popularityRanks->Get(id.m_index));
+    r.SetRating(ugc::UGC::UnpackRating(ratings->Get(id.m_index)));
 
     m2::PointD center;
     if (centers && centers->Get(id.m_index, center))
     {
-      info.m_distanceToPivot =
-          MercatorBounds::DistanceOnEarth(m_params.m_accuratePivotCenter, center);
-      info.m_center = center;
-      info.m_centerLoaded = true;
+      r.SetDistanceToPivot(MercatorBounds::DistanceOnEarth(m_params.m_accuratePivotCenter, center));
+      r.SetCenter(center);
     }
     else
     {
@@ -128,7 +125,7 @@ void PreRanker::FillMissingFieldsInPreResults()
         m_pivotFeatures.SetPosition(m_params.m_accuratePivotCenter, m_params.m_scale);
         pivotFeaturesInitialized = true;
       }
-      info.m_distanceToPivot = m_pivotFeatures.GetDistanceToFeatureMeters(id);
+      r.SetDistanceToPivot(m_pivotFeatures.GetDistanceToFeatureMeters(id));
     }
   });
 }

--- a/search/pre_ranking_info.hpp
+++ b/search/pre_ranking_info.hpp
@@ -31,8 +31,6 @@ struct PreRankingInfo
     return m_tokenRange[m_type];
   }
 
-  size_t GetNumTokens() const { return InnermostTokenRange().Size(); }
-
   // An abstract distance from the feature to the pivot.  Measurement
   // units do not matter here.
   double m_distanceToPivot = 0;

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -183,7 +183,7 @@ void RemoveDuplicatingLinear(vector<RankerResult> & results)
       return t1 < t2;
 
     // After unique, the better feature should be kept.
-    return r1.GetDistance() < r2.GetDistance();
+    return r1.GetLinearModelRank() > r2.GetLinearModelRank();
   };
 
   auto equalCmp = [](RankerResult const & r1, RankerResult const & r2) -> bool {


### PR DESCRIPTION
Мы можем получить одну и ту же фичу несколькими способами, например в запросе "город улица дом", если в данных нету дома мы можем получить улицу по пути "город-улица", а можем получить заматчив только улицу.
В этом случае единственное отличие между PreRankerResult-ами будет TokenRange-ах, разумнее выбирать тот результат, у которого больше заматченых ранжей.

При прореживании улиц тоже разумно выбирать лучшую с точки зрения ранка, а не просто по расстоянию. Функция расчета ранка не дорогая -- у нас уже посчитаны все опечатки и т.п., вызвана будет только для линейных фичей с одинаковым именем, это не должно сказаться на производительности.