### PR TITLE
[iOS] Fixed view port after recovering a trip on the carplay

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -401,9 +401,12 @@ extension CarPlayService: CPMapTemplateDelegate {
     guard let info = routeChoice.userInfo as? RouteInfo,
       let estimates = createEstimates(routeInfo: info) else {
       applyUndefinedEstimates(template: mapTemplate, trip: trip)
+      router?.rebuildRoute()
       return
     }
     mapTemplate.updateEstimates(estimates, for: trip)
+    routeChoice.userInfo = nil
+    router?.rebuildRoute()
   }
 }
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-11563
Поговорила с Дашей. Вьюпорт настраивается до построения маршрута и, после того как маршрут построен, изменение вьюпорта не приводит к перепозиционированию. Так что после переноса маршрута на карплей, приходится перестраивать маршрут с новым вьюпортом.