### PR TITLE
[search] [bookmarks] Enabled indexing in the CurrentOrig locale.

### DIFF
--- a/search/bookmarks/data.cpp
+++ b/search/bookmarks/data.cpp
@@ -12,8 +12,8 @@ string DebugPrint(Data const & data)
 {
   ostringstream os;
   os << "Data [";
-  os << "name: " << data.m_name << ", ";
-  os << "description: " << data.m_description << "]";
+  os << "names: " << ::DebugPrint(data.GetNames()) << ", ";
+  os << "description: " << data.GetDescription() << "]";
   return os.str();
 }
 }  // namespace bookmarks

--- a/search/bookmarks/data.hpp
+++ b/search/bookmarks/data.hpp
@@ -6,22 +6,25 @@
 
 #include "coding/string_utf8_multilang.hpp"
 
+#include "platform/preferred_languages.hpp"
+
 #include "base/string_utils.hpp"
 
 #include <string>
+#include <vector>
 
 namespace search
 {
 namespace bookmarks
 {
 // TODO (@m, @y): add more features for a bookmark here, i.e. address, center.
-struct Data
+class Data
 {
+public:
   Data() = default;
 
   Data(kml::BookmarkData const & bookmarkData)
-    : m_name(kml::GetDefaultStr(bookmarkData.m_name))
-    , m_customName(kml::GetDefaultStr(bookmarkData.m_customName))
+    : m_names(ExtractIndexableNames(bookmarkData))
     , m_description(kml::GetDefaultStr(bookmarkData.m_description))
   {
   }
@@ -30,11 +33,14 @@ struct Data
   void ForEachNameToken(Fn && fn) const
   {
     auto withDefaultLang = [&](strings::UniString const & token) {
+      // Note that the Default Language here is not the same as in the kml library.
+      // Bookmark search by locale is not supported so every name is stored
+      // in the default branch of the search trie.
       fn(StringUtf8Multilang::kDefaultCode, token);
     };
 
-    ForEachNormalizedToken(m_name, withDefaultLang);
-    ForEachNormalizedToken(m_customName, withDefaultLang);
+    for (auto const & name : m_names)
+      ForEachNormalizedToken(name, withDefaultLang);
   }
 
   template <typename Fn>
@@ -47,8 +53,31 @@ struct Data
     ForEachNormalizedToken(m_description, withDefaultLang);
   }
 
-  std::string m_name;
-  std::string m_customName;
+  std::vector<std::string> const & GetNames() const { return m_names; }
+  std::string const & GetDescription() const { return m_description; }
+
+private:
+  std::vector<std::string> ExtractIndexableNames(kml::BookmarkData const & bookmarkData)
+  {
+    // Same as GetPreferredBookmarkName from the map library. Duplicated here to avoid dependency.
+    auto name0 = kml::GetPreferredBookmarkName(bookmarkData, languages::GetCurrentOrig());
+    auto name1 = kml::GetPreferredBookmarkStr(bookmarkData.m_name, languages::GetCurrentOrig());
+    // Normalization is postponed. It is unlikely but we may still need original strings later.
+    // Trimming seems harmless, though.
+    strings::Trim(name0);
+    strings::Trim(name1);
+    if (name0 == name1)
+      return {name0};
+    return {name0, name1};
+  }
+
+  // Names and custom names in all the locales that we are interested in.
+  // The locale set is fixed at startup and the relevant names are provided
+  // by the kml library. In case the user switches the device locale while
+  // running the app, the UI will adapt; however the search will not, and the
+  // bookmarks will not be reindexed. We consider this situation to be improbable
+  // enough to justify not storing redundant names here.
+  std::vector<std::string> m_names;
   std::string m_description;
 };
 

--- a/search/search_tests/CMakeLists.txt
+++ b/search/search_tests/CMakeLists.txt
@@ -36,6 +36,7 @@ omim_link_libraries(
   search_tests_support
   generator_tests_support
   platform_tests_support
+  kml
   search
   editor
   indexer


### PR DESCRIPTION
Note that bookmark's custom name is still being indexed when it differs
from bookmark's name. This in fact has been the intended behaviour
all along.