### PR TITLE
[routing] penalty for ferries

### DIFF
--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -4,12 +4,7 @@
 
 #include "indexer/classificator_loader.hpp"
 
-#include "coding/writer.hpp"
-#include "coding/reader.hpp"
-
 #include "base/logging.hpp"
-
-#include "std/target_os.hpp"
 
 using feature::Metadata;
 
@@ -202,9 +197,13 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
 #undef WIKIHOST
 }
 
+// Look at: https://wiki.openstreetmap.org/wiki/Key:duration for details
+// about "duration" format.
+
 UNIT_TEST(Metadata_ValidateAndFormat_duration)
 {
   FeatureParams params;
+  params.AddType(classif().GetTypeByPath({"route", "ferry"}));
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();
 
@@ -222,10 +221,14 @@ UNIT_TEST(Metadata_ValidateAndFormat_duration)
     }
   };
 
+  // "10" - 10 minutes ~ 0.16667 hours
   test("10", "0.16667");
+  // 10:00 - 10 hours
   test("10:00", "10");
   test("QWE", "");
+  // 1:1:1 - 1 hour + 1 minute + 1 second
   test("1:1:1", "1.0169");
+  // 10 hours and 30 minutes
   test("10:30", "10.5");
   test("30", "0.5");
   test("60", "1");
@@ -243,17 +246,24 @@ UNIT_TEST(Metadata_ValidateAndFormat_duration)
   test("5:00 hours", "");
   test("12 min", "");
 
+  // means 20 seconds
   test("PT20S", "0.0055556");
+  // means 7 minutes
   test("PT7M", "0.11667");
+  // means 10 minutes and 40 seconds
   test("PT10M40S", "0.17778");
   test("PT50M", "0.83333");
+  // means 2 hours
   test("PT2H", "2");
+  // means 7 hours and 50 minutes
   test("PT7H50M", "7.8333");
   test("PT60M", "1");
   test("PT15M", "0.25");
 
+  // means 1000 years, but we don't support such duration.
   test("PT1000Y", "");
   test("PTPT", "");
+  // means 4 day, but we don't support such duration.
   test("P4D", "");
   test("PT50:20", "");
 }

--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -201,3 +201,59 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
 
 #undef WIKIHOST
 }
+
+UNIT_TEST(Metadata_ValidateAndFormat_duration)
+{
+  FeatureParams params;
+  MetadataTagProcessor p(params);
+  Metadata & md = params.GetMetadata();
+
+  auto const test = [&](std::string const & osm, std::string const & expected) {
+    p("duration", osm);
+
+    if (expected.empty())
+    {
+      TEST(md.Empty(), ());
+    }
+    else
+    {
+      TEST_EQUAL(md.Get(Metadata::FMD_DURATION), expected, ());
+      md.Drop(Metadata::FMD_DURATION);
+    }
+  };
+
+  test("10", "0.16667");
+  test("10:00", "10");
+  test("QWE", "");
+  test("1:1:1", "1.0169");
+  test("10:30", "10.5");
+  test("30", "0.5");
+  test("60", "1");
+  test("120", "2");
+  test("35:10", "35.167");
+
+  test("35::10", "");
+  test("", "");
+  test("0", "");
+  test("asd", "");
+  test("10 minutes", "");
+  test("01:15 h", "");
+  test("08:00;07:00;06:30", "");
+  test("3-4 minutes", "");
+  test("5:00 hours", "");
+  test("12 min", "");
+
+  test("PT20S", "0.0055556");
+  test("PT7M", "0.11667");
+  test("PT10M40S", "0.17778");
+  test("PT50M", "0.83333");
+  test("PT2H", "2");
+  test("PT7H50M", "7.8333");
+  test("PT60M", "1");
+  test("PT15M", "0.25");
+
+  test("PT1000Y", "");
+  test("PTPT", "");
+  test("P4D", "");
+  test("PT50:20", "");
+}

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -11,7 +11,6 @@
 #include "base/string_utils.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdlib>

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -34,6 +34,7 @@ struct MetadataTagProcessorImpl
   std::string ValidateAndFormat_denomination(std::string const & v) const;
   std::string ValidateAndFormat_wikipedia(std::string v) const;
   std::string ValidateAndFormat_airport_iata(std::string const & v) const;
+  std::string ValidateAndFormat_duration(std::string const & v) const;
 
 protected:
   FeatureParams & m_params;
@@ -96,6 +97,7 @@ public:
     case Metadata::FMD_BANNER_URL: valid = ValidateAndFormat_url(v); break;
     case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
     case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
+    case Metadata::FMD_DURATION: valid = ValidateAndFormat_duration(v); break;
     // Metadata types we do not get from OSM.
     case Metadata::FMD_SPONSORED_ID:
     case Metadata::FMD_PRICE_RATE:

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -97,7 +97,14 @@ public:
     case Metadata::FMD_BANNER_URL: valid = ValidateAndFormat_url(v); break;
     case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
     case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
-    case Metadata::FMD_DURATION: valid = ValidateAndFormat_duration(v); break;
+    case Metadata::FMD_DURATION:
+    {
+      static uint32_t const kFerryType = classif().GetTypeByPath({"route", "ferry"});
+      if (m_params.FindType(kFerryType, 2 /* level */) != ftype::GetEmptyValue())
+        valid = ValidateAndFormat_duration(v);
+
+      break;
+    }
     // Metadata types we do not get from OSM.
     case Metadata::FMD_SPONSORED_ID:
     case Metadata::FMD_PRICE_RATE:

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -94,6 +94,8 @@ bool Metadata::TypeFromString(string const & k, Metadata::EType & outType)
     outType = Metadata::FMD_LEVEL;
   else if (k == "iata")
     outType = Metadata::FMD_AIRPORT_IATA;
+  else if (k == "duration")
+    outType = Metadata::FMD_DURATION;
   else
     return false;
 
@@ -193,6 +195,7 @@ string ToString(Metadata::EType type)
   case Metadata::FMD_LEVEL: return "level";
   case Metadata::FMD_AIRPORT_IATA: return "iata";
   case Metadata::FMD_BRAND: return "brand";
+  case Metadata::FMD_DURATION: return "duration";
   case Metadata::FMD_COUNT: CHECK(false, ("FMD_COUNT can not be used as a type."));
   };
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -133,6 +133,10 @@ public:
     FMD_LEVEL = 28,
     FMD_AIRPORT_IATA = 29,
     FMD_BRAND = 30,
+    // Duration of routes by ferries and other rare means of transportation.
+    // The number of ferries having the duration key in OSM is low so we
+    // store the parsed tag value in Metadata instead of building a separate section for it.
+    // See https://wiki.openstreetmap.org/wiki/Key:duration
     FMD_DURATION = 31,
     FMD_COUNT
   };

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -133,6 +133,7 @@ public:
     FMD_LEVEL = 28,
     FMD_AIRPORT_IATA = 29,
     FMD_BRAND = 30,
+    FMD_DURATION = 31,
     FMD_COUNT
   };
 

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -167,6 +167,7 @@ std::vector<Props> MetadataToProps(std::vector<T> const & metadata)
     case Metadata::FMD_BANNER_URL:
     case Metadata::FMD_AIRPORT_IATA:
     case Metadata::FMD_BRAND:
+    case Metadata::FMD_DURATION:
     case Metadata::FMD_COUNT:
       break;
       // Please add new cases when compiler issues an "unhandled switch case" warning here.

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -138,8 +138,8 @@ public:
   {
     switch (purpose)
     {
-    case Purpose::Weight: return 20 * 60;  // seconds
-    case Purpose::ETA: return 8 * 60;  // seconds
+    case Purpose::Weight: return 20.0 * 60.0;  // seconds
+    case Purpose::ETA: return 8.0 * 60.0;  // seconds
     }
     UNREACHABLE();
   }

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -21,6 +21,12 @@ namespace routing
 class EdgeEstimator
 {
 public:
+  enum class Purpose
+  {
+    Weight,
+    ETA
+  };
+
   EdgeEstimator(double maxWeightSpeedKMpH, double offroadSpeedKMpH);
   virtual ~EdgeEstimator() = default;
 
@@ -39,7 +45,8 @@ public:
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
   virtual double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const = 0;
-  virtual double GetUTurnPenalty() const = 0;
+  virtual double GetUTurnPenalty(Purpose purpose) const = 0;
+  virtual double GetFerryLandingPenalty(Purpose purpose) const = 0;
 
   static std::shared_ptr<EdgeEstimator> Create(VehicleType vehicleType, double maxWeighSpeedKMpH,
                                                double offroadSpeedKMpH,

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -77,6 +77,9 @@ public:
   RoutingOptions GetRoutingOptions() const { return m_routingOptions; }
 
 private:
+
+  double GetRoadLengthM() const;
+
   buffer_vector<Junction, 32> m_junctions;
   SpeedKMpH m_forwardSpeed;
   SpeedKMpH m_backwardSpeed;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -116,6 +116,10 @@ public:
                     std::map<Parent, Parent> & parents) const;
 
   bool IsUTurnAndRestricted(Segment const & parent, Segment const & child, bool isOutgoing) const;
+
+  RouteWeight CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool isOutgoing,
+                                  Segment const & from, Segment const & to);
+
 private:
 
   RouteWeight CalcSegmentWeight(Segment const & segment);
@@ -125,7 +129,15 @@ private:
                            std::map<Segment, Segment> & parents);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
                           std::vector<SegmentEdge> & edges, std::map<Segment, Segment> & parents);
-  RouteWeight GetPenalties(Segment const & u, Segment const & v);
+
+  struct PenaltyData
+  {
+    bool m_passThroughAllowed = false;
+    bool m_isFerry = false;
+  };
+
+  PenaltyData GetRoadPenaltyData(Segment const & segment);
+  RouteWeight GetPenalties(EdgeEstimator::Purpose purpose, Segment const & u, Segment const & v);
 
   void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
                                        bool isOutgoing, std::vector<Segment> & children);

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -132,8 +132,12 @@ private:
 
   struct PenaltyData
   {
-    bool m_passThroughAllowed = false;
-    bool m_isFerry = false;
+    PenaltyData(bool passThroughAllowed, bool isFerry)
+      : m_passThroughAllowed(passThroughAllowed),
+        m_isFerry(isFerry) {}
+
+    bool m_passThroughAllowed;
+    bool m_isFerry;
   };
 
   PenaltyData GetRoadPenaltyData(Segment const & segment);

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -270,13 +270,24 @@ RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment) const
   return m_graph.CalcOffroadWeight(vertex.GetPointFrom(), vertex.GetPointTo());
 }
 
-double IndexGraphStarter::CalcSegmentETA(Segment const & segment) const
+double IndexGraphStarter::CalculateETA(Segment const & from, Segment const & to) const
 {
   // We don't distinguish fake segment weight and fake segment transit time.
+  if (IsFakeSegment(to))
+    return CalcSegmentWeight(to).GetWeight();
+
+  if (IsFakeSegment(from))
+    return CalculateETAWithoutPenalty(to);
+
+  return m_graph.CalculateETA(from, to);
+}
+
+double IndexGraphStarter::CalculateETAWithoutPenalty(Segment const & segment) const
+{
   if (IsFakeSegment(segment))
     return CalcSegmentWeight(segment).GetWeight();
 
-  return m_graph.CalcSegmentETA(segment);
+  return m_graph.CalculateETAWithoutPenalty(segment);
 }
 
 void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding const & otherEnding,

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -135,7 +135,8 @@ public:
   }
 
   RouteWeight CalcSegmentWeight(Segment const & segment) const;
-  double CalcSegmentETA(Segment const & segment) const;
+  double CalculateETA(Segment const & from, Segment const & to) const;
+  double CalculateETAWithoutPenalty(Segment const & segment) const;
 
   // For compatibility with IndexGraphStarterJoints
   // @{

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1313,11 +1313,13 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   double time = 0.0;
   times.emplace_back(static_cast<uint32_t>(0), 0.0);
 
-  for (size_t i = 0; i + 1 < numPoints; ++i)
+  for (size_t i = 0; i < segments.size() - 1; ++i)
   {
-    time += starter.CalcSegmentETA(segments[i]);
+    time += starter.CalculateETA(segments[i], segments[i + 1]);
     times.emplace_back(static_cast<uint32_t>(i + 1), time);
   }
+
+  times.emplace_back(static_cast<uint32_t>(segments.size()), time);
 
   CHECK(m_directionsEngine, ());
   ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, junctions, move(times),

--- a/routing/leaps_postprocessor.cpp
+++ b/routing/leaps_postprocessor.cpp
@@ -103,7 +103,7 @@ void LeapsPostProcessor::Init()
   for (size_t i = 1; i < m_path.size(); ++i)
   {
     auto const & segment = m_path[i];
-    m_prefixSumETA[i] = m_prefixSumETA[i - 1] + m_starter.CalcSegmentETA(segment);
+    m_prefixSumETA[i] = m_prefixSumETA[i - 1] + m_starter.CalculateETAWithoutPenalty(segment);
 
     CHECK_EQUAL(m_segmentToIndex.count(segment), 0, ());
     m_segmentToIndex[segment] = i;
@@ -146,7 +146,7 @@ auto LeapsPostProcessor::CalculateIntervalsToRelax() -> std::set<PathInterval, P
   {
     std::map<Segment, SegmentData> segmentsData;
     auto const & segment = m_path[right];
-    segmentsData.emplace(segment, SegmentData(0, m_starter.CalcSegmentETA(segment)));
+    segmentsData.emplace(segment, SegmentData(0, m_starter.CalculateETAWithoutPenalty(segment)));
 
     FillIngoingPaths(segment, segmentsData);
 
@@ -192,7 +192,7 @@ void LeapsPostProcessor::FillIngoingPaths(
 
               auto & current = segmentsData[state.m_vertex];
               current.m_summaryETA =
-                  parent.m_summaryETA + m_starter.CalcSegmentETA(state.m_vertex);
+                  parent.m_summaryETA + m_starter.CalculateETAWithoutPenalty(state.m_vertex);
 
               current.m_steps = parent.m_steps + 1;
 

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -131,7 +131,7 @@ UNIT_TEST(SwedenStockholmBicyclePastFerry)
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents(VehicleType::Bicycle),
       MercatorBounds::FromLatLon(59.4725, 18.51355), {0.0, 0.0},
-      MercatorBounds::FromLatLon(59.32967, 18.075), 66161.2);
+      MercatorBounds::FromLatLon(59.32967, 18.075), 46163.7);
 }
 
 UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -494,7 +494,7 @@ UNIT_TEST(NetherlandsAmsterdamPedestrianPastFerry)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       MercatorBounds::FromLatLon(52.38075, 4.89938), {0.0, 0.0},
-      MercatorBounds::FromLatLon(52.40194, 4.89038), 3580.0);
+      MercatorBounds::FromLatLon(52.40194, 4.89038), 2553.18);
 }
 
 // Test on building pedestrian route past ferry.

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -203,7 +203,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
         MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
-        MercatorBounds::FromLatLon(50.93227, 1.82725), 64753.0);
+        MercatorBounds::FromLatLon(50.93227, 1.82725), 72153.8);
   }
 
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)

--- a/routing/routing_integration_tests/transit_route_test.cpp
+++ b/routing/routing_integration_tests/transit_route_test.cpp
@@ -8,7 +8,7 @@ using namespace routing;
 
 namespace
 {
-UNIT_TEST(Moscow_CenterToKotelniki_CrossMwm)
+UNIT_TEST(Transit_Moscow_CenterToKotelniki_CrossMwm)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -22,7 +22,7 @@ UNIT_TEST(Moscow_CenterToKotelniki_CrossMwm)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(Moscow_DubrovkaToTrtykovskya)
+UNIT_TEST(Transit_Moscow_DubrovkaToTrtykovskya)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -36,7 +36,7 @@ UNIT_TEST(Moscow_DubrovkaToTrtykovskya)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(Moscow_NoSubwayTest)
+UNIT_TEST(Transit_Moscow_NoSubwayTest)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -50,7 +50,7 @@ UNIT_TEST(Moscow_NoSubwayTest)
   integration::CheckSubwayAbsent(*routeResult.first);
 }
 
-UNIT_TEST(Piter_FrunzenskyaToPlochadVosstaniya)
+UNIT_TEST(Transit_Piter_FrunzenskyaToPlochadVosstaniya)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -64,7 +64,7 @@ UNIT_TEST(Piter_FrunzenskyaToPlochadVosstaniya)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(Piter_TooLongPedestrian)
+UNIT_TEST(Transit_Piter_TooLongPedestrian)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -74,7 +74,7 @@ UNIT_TEST(Piter_TooLongPedestrian)
   TEST_EQUAL(routeResult.second, RouterResultCode::TransitRouteNotFoundTooLongPedestrian, ());
 }
 
-UNIT_TEST(Vatikan_NotEnoughGraphDataAtThenEnd)
+UNIT_TEST(Transit_Vatikan_NotEnoughGraphDataAtThenEnd)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -85,7 +85,7 @@ UNIT_TEST(Vatikan_NotEnoughGraphDataAtThenEnd)
   TEST_EQUAL(routeResult.second, RouterResultCode::TransitRouteNotFoundTooLongPedestrian, ());
 }
 
-UNIT_TEST(Vatikan_CorneliaToOttaviano)
+UNIT_TEST(Transit_Vatikan_CorneliaToOttaviano)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -100,7 +100,7 @@ UNIT_TEST(Vatikan_CorneliaToOttaviano)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(London_PoplarToOval)
+UNIT_TEST(Transit_London_PoplarToOval)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -115,7 +115,7 @@ UNIT_TEST(London_PoplarToOval)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(London_DeptfordBridgeToCyprus)
+UNIT_TEST(Transit_London_DeptfordBridgeToCyprus)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -130,7 +130,7 @@ UNIT_TEST(London_DeptfordBridgeToCyprus)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(Washington_FoggyToShaw)
+UNIT_TEST(Transit_Washington_FoggyToShaw)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
@@ -145,7 +145,7 @@ UNIT_TEST(Washington_FoggyToShaw)
   integration::CheckSubwayExistence(*routeResult.first);
 }
 
-UNIT_TEST(NewYork_GrassmereToPleasantPlains)
+UNIT_TEST(Transit_NewYork_GrassmereToPleasantPlains)
 {
   TRouteResult routeResult =
     integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),

--- a/routing/routing_quality/routing_quality_tests/ferry_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/ferry_tests.cpp
@@ -31,7 +31,7 @@ UNIT_TEST(Ferry_RoutingQuality_RussiaFromCrimeaFerry)
 }
 
 // For tests Ferry_RoutingQuality_1 - Ferry_RoutingQuality_15
-// Look to: https://confluence.mail.ru/display/MAPSME/Ferries for more details.
+// Look at: https://confluence.mail.ru/display/MAPSME/Ferries for more details.
 
 UNIT_TEST(Ferry_RoutingQuality_1)
 {

--- a/routing/routing_quality/routing_quality_tests/ferry_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/ferry_tests.cpp
@@ -6,7 +6,7 @@ using namespace routing_quality;
 
 namespace
 {
-UNIT_TEST(RoutingQuality_FinlandBridgeInsteadOfFerry)
+UNIT_TEST(Ferry_RoutingQuality_FinlandBridgeInsteadOfFerry)
 {
   TEST(CheckCarRoute({56.11155, 12.81101} /* start */, {55.59857, 12.3069} /* finish */,
                      {{{55.56602, 12.88537}}} /* reference track */),
@@ -15,7 +15,7 @@ UNIT_TEST(RoutingQuality_FinlandBridgeInsteadOfFerry)
 // TODO: This test doesn't pass because routing::RouteWeight::operator<
 // prefer roads with less number of barriers. It will be more useful to consider
 // barriers only with access=no/private/etc tag.
-//UNIT_TEST(RoutingQuality_RussiaToCrimeaFerry)
+//UNIT_TEST(Ferry_RoutingQuality_RussiaToCrimeaFerry)
 //{
 //  // From Russia to Crimea
 //  TEST(CheckCarRoute({45.34123, 36.67679} /* start */, {45.36479, 36.62194} /* finish */,
@@ -23,10 +23,111 @@ UNIT_TEST(RoutingQuality_FinlandBridgeInsteadOfFerry)
 //       ());
 //}
 
-UNIT_TEST(RoutingQuality_RussiaFromCrimeaFerry)
+UNIT_TEST(Ferry_RoutingQuality_RussiaFromCrimeaFerry)
 {
   TEST(CheckCarRoute({45.36479, 36.62194} /* start */, {45.34123, 36.67679} /* finish */,
                      {{{45.3532, 36.64912}}} /* reference track */),
+       ());
+}
+
+// For tests Ferry_RoutingQuality_1 - Ferry_RoutingQuality_15
+// Look to: https://confluence.mail.ru/display/MAPSME/Ferries for more details.
+
+UNIT_TEST(Ferry_RoutingQuality_1)
+{
+  TEST(CheckCarRoute({67.89425, 13.00747} /* start */, {67.28024, 14.37397} /* finish */,
+                     {{{67.60291, 13.65267}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_2)
+{
+  TEST(CheckCarRoute({51.91347, 5.24265} /* start */, {51.98885, 5.20058} /* finish */,
+                     {{{51.97494, 5.10631}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_3)
+{
+  TEST(CheckCarRoute({50.68323, 7.15683} /* start */, {50.58042, 7.32259} /* finish */,
+                     {{{50.72206, 7.14872}, {50.70747, 7.17801}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_4)
+{
+  TEST(CheckCarRoute({49.37098, 0.84813} /* start */, {49.47950, 0.80918} /* finish */,
+                     {{{49.36829, 0.81359}, {49.41177, 0.79639}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_5)
+{
+  TEST(CheckCarRoute({53.59885, 9.32285} /* start */, {53.93504, 9.48396} /* finish */,
+                     {{{53.55170, 9.89848}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_6)
+{
+  TEST(CheckCarRoute({48.268548, 21.483862} /* start */, {48.24756, 21.54246} /* finish */,
+                     {{{48.32574, 21.56094}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_7)
+{
+  TEST(CheckCarRoute({52.09319, 25.96368} /* start */, {52.02190, 25.98767} /* finish */,
+                     {{{52.08914, 26.13001}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_8)
+{
+  TEST(CheckCarRoute({53.36914, 17.95644} /* start */, {53.46632, 18.01876} /* finish */,
+                     {{{53.31395, 17.98559}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_9)
+{
+  TEST(CheckCarRoute({52.57264, 14.83948} /* start */, {52.74278, 14.95435} /* finish */,
+                     {{{52.65097, 14.99906}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_10)
+{
+  TEST(CheckCarRoute({63.33900, 10.27831} /* start */, {63.33338, 10.22694} /* finish */,
+                     {{{63.32261, 10.26896}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_11)
+{
+  TEST(CheckCarRoute({56.51167, 10.28726} /* start */, {56.57695, 10.11188} /* finish */,
+                     {{{56.44610, 10.26030}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_13)
+{
+  TEST(CheckCarRoute({51.53923, 11.78523} /* start */, {51.62372, 11.86635} /* finish */,
+                     {{{51.50772, 11.94096}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_14)
+{
+  TEST(CheckCarRoute({52.68467, 16.24031} /* start */, {52.74559, 16.27202} /* finish */,
+                     {{{52.71631, 16.37917}}} /* reference track */),
+       ());
+}
+
+UNIT_TEST(Ferry_RoutingQuality_15)
+{
+  TEST(CheckCarRoute({48.29162, 22.21412} /* start */, {48.27409, 22.46155} /* finish */,
+                     {{{48.43306, 22.23317}}} /* reference track */),
        ());
 }
 }  // namespace

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -146,7 +146,8 @@ double WeightedEdgeEstimator::CalcSegmentWeight(Segment const & segment,
   return it->second;
 }
 
-double WeightedEdgeEstimator::GetUTurnPenalty() const { return 0.0; }
+double WeightedEdgeEstimator::GetUTurnPenalty(Purpose purpose) const { return 0.0; }
+double WeightedEdgeEstimator::GetFerryLandingPenalty(Purpose purpose) const { return 0.0; }
 
 // TestIndexGraphTopology --------------------------------------------------------------------------
 TestIndexGraphTopology::TestIndexGraphTopology(uint32_t numVertices) : m_numVertices(numVertices) {}

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -173,7 +173,8 @@ public:
 
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
   double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const override { return 0.0; }
-  double GetUTurnPenalty() const override;
+  double GetUTurnPenalty(Purpose purpose) const override;
+  double GetFerryLandingPenalty(Purpose purpose) const override;
 
 private:
   std::map<Segment, double> m_segmentWeights;

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -192,9 +192,19 @@ RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
   return RouteWeight(m_estimator->CalcOffroadWeight(from, to));
 }
 
-double SingleVehicleWorldGraph::CalcSegmentETA(Segment const & segment)
+double SingleVehicleWorldGraph::CalculateETA(Segment const & from, Segment const & to)
 {
-  return m_estimator->CalcSegmentETA(segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()));
+  if (from.GetMwmId() != to.GetMwmId())
+    return CalculateETAWithoutPenalty(to);
+
+  auto & indexGraph = m_loader->GetIndexGraph(from.GetMwmId());
+  return indexGraph.CalculateEdgeWeight(EdgeEstimator::Purpose::ETA, true /* isOutgoing */, from, to).GetWeight();
+}
+
+double SingleVehicleWorldGraph::CalculateETAWithoutPenalty(Segment const & segment)
+{
+  return m_estimator->CalcSegmentETA(segment,
+                                     GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()));
 }
 
 vector<Segment> const & SingleVehicleWorldGraph::GetTransitions(NumMwmId numMwmId, bool isEnter)

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -62,7 +62,8 @@ public:
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
   RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  double CalcSegmentETA(Segment const & segment) override;
+  double CalculateETA(Segment const & from, Segment const & to) override;
+  double CalculateETAWithoutPenalty(Segment const & segment) override;
 
   std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
 

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -168,7 +168,9 @@ double TransitWorldGraph::CalculateETA(Segment const & from, Segment const & to)
     return m_estimator->CalcSegmentETA(to, GetRealRoadGeometry(to.GetMwmId(), to.GetFeatureId()));
 
   auto & indexGraph = m_indexLoader->GetIndexGraph(from.GetMwmId());
-  return indexGraph.CalculateEdgeWeight(EdgeEstimator::Purpose::ETA, true /* isOutgoing */, from, to).GetWeight();
+  return indexGraph
+      .CalculateEdgeWeight(EdgeEstimator::Purpose::ETA, true /* isOutgoing */, from, to)
+      .GetWeight();
 }
 
 double TransitWorldGraph::CalculateETAWithoutPenalty(Segment const & segment)

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -63,7 +63,9 @@ public:
   RouteWeight CalcSegmentWeight(Segment const & segment) override;
   RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
   RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  double CalcSegmentETA(Segment const & segment) override;
+  double CalculateETA(Segment const & from, Segment const & to) override;
+  double CalculateETAWithoutPenalty(Segment const & segment) override;
+
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) override

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -79,7 +79,8 @@ public:
 
   virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
 
-  virtual double CalcSegmentETA(Segment const & segment) = 0;
+  virtual double CalculateETA(Segment const & from, Segment const & to) = 0;
+  virtual double CalculateETAWithoutPenalty(Segment const & segment) = 0;
 
   /// \returns transitions for mwm with id |numMwmId|.
   virtual std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter);


### PR DESCRIPTION
Надо прочитать: https://confluence.mail.ru/display/MAPSME/Ferries

Изменились 3 интеграционных теста:
1) Bicycle
Тут после подсчета статистики выяснилось, что паромом передвигаться почти всегда быстрее велика, поэтому, даже если несмотря штрафа на посадку, предпочитается паром, то видимо надо на паром

Было: 
![image](https://user-images.githubusercontent.com/17534533/63651826-e5a40e80-c761-11e9-9ea1-31a319b3e62e.png)
Стало: 
![image](https://user-images.githubusercontent.com/17534533/63651829-efc60d00-c761-11e9-81bf-2d3609ba1630.png)

2) Тут предпочитается один паром другому, причем опять же, скорость на пароме всегда больше, чем у пешехода, поэтому это в целом даже логичнее - поехать сразу на пароме до конца
Pedestrian
Было:
![image](https://user-images.githubusercontent.com/17534533/63651857-27cd5000-c762-11e9-8558-3cfd0e6eb5aa.png)
Стало:
![image](https://user-images.githubusercontent.com/17534533/63651858-2dc33100-c762-11e9-99a6-c6a9bdd0fa91.png)

3) Car
Тут вместо посадки на shuttle_train, едем по парому, с shuttle-train надо отдельно что-то делать
Было:
![image](https://user-images.githubusercontent.com/17534533/63651883-7844ad80-c762-11e9-89ea-0dc13ed938b1.png)
Стало:
![image](https://user-images.githubusercontent.com/17534533/63651908-a75b1f00-c762-11e9-8394-d6648479b761.png)


