### PR TITLE
[routing] Routing quality tests fix for 190830.

### DIFF
--- a/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
@@ -18,7 +18,7 @@ UNIT_TEST(RoutingQuality_RussiaMoscowTushino)
 UNIT_TEST(RoutingQuality_TurkeyIzmirArea)
 {
   TEST(CheckCarRoute({38.80146, 26.97696} /* start */, {39.0837, 26.90977} /* finish */,
-                     {{{39.08146, 27.11798}}} /* reference track */),
+                     {{{39.08124, 27.11829}}} /* reference track */),
        ());
 }
 
@@ -60,7 +60,7 @@ UNIT_TEST(RoutingQuality_IranSouth)
 UNIT_TEST(RoutingQuality_EindhovenNetherlands)
 {
   TEST(CheckCarRoute({50.91974, 5.33535} /* start */, {51.92532, 5.49066} /* finish */,
-                     {{{51.42016, 5.42881}, {51.44316, 5.42723}, {51.50230, 5.47485}}} /* reference track */),
+                     {{{51.42016, 5.42881}, {51.44316, 5.42723}}} /* reference track */),
        ());
 }
 
@@ -81,7 +81,7 @@ UNIT_TEST(RoutingQuality_CigilTurkey)
 UNIT_TEST(RoutingQuality_KatowicePoland)
 {
   TEST(CheckCarRoute({50.37282, 18.75667} /* start */, {50.83499, 19.14612} /* finish */,
-                     {{{50.422229, 19.04746}, {50.48831, 19.21423}}} /* reference track */),
+                     {{{50.422229, 19.04746}}} /* reference track */),
        ());
 }
 


### PR DESCRIPTION
После обновления карт - поправлены 3 теста.

**RoutingQuality_TurkeyIzmirArea**
Около месяца назад подвинули дорогу проходящую около reference point. https://www.openstreetmap.org/way/319972296#map=15/39.0670/27.1086
Точку тоже надо подвинуть.
![image](https://user-images.githubusercontent.com/1768114/64246486-8ab6a800-cf15-11e9-9a07-65a3ab431108.png)

**RoutingQuality_EindhovenNetherlands**
Предпочитаем highway=motorway дороге highway=primary, что кажется вполне логичным.
![image](https://user-images.githubusercontent.com/1768114/64246878-5099d600-cf16-11e9-94a9-4f11c23b2116.png)

**RoutingQuality_KatowicePoland**
Ведем по магистрали с ограничением в 130 вместо магистрали с ограничением 120, что кажется нормально.
![image](https://user-images.githubusercontent.com/1768114/64247118-d74eb300-cf16-11e9-9a06-1277835e8ccc.png)

@gmoryes PTAL


