### PR TITLE
[routing] Reducing offroad speed for car routing while route building and not to take into account it for ETA.

### DIFF
--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -119,7 +119,7 @@ double EdgeEstimator::CalcLeapWeight(m2::PointD const & from, m2::PointD const &
   return TimeBetweenSec(from, to, m_maxWeightSpeedMpS / 2.0);
 }
 
-double EdgeEstimator::CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const
+double EdgeEstimator::CalcOffroad(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const
 {
   return TimeBetweenSec(from, to,
                         KMPH2MPS(purpose == Purpose::Weight ? m_offroadSpeedKMpH.m_weight

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -102,7 +102,9 @@ EdgeEstimator::EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroa
   CHECK_GREATER(m_offroadSpeedKMpH.m_weight, 0.0, ());
   CHECK_GREATER(m_offroadSpeedKMpH.m_eta, 0.0, ());
   CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KMPH2MPS(m_offroadSpeedKMpH.m_weight), ());
-  CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KMPH2MPS(m_offroadSpeedKMpH.m_eta), ());
+
+  if (m_offroadSpeedKMpH.m_eta != kUndefinedSpeed)
+    CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KMPH2MPS(m_offroadSpeedKMpH.m_eta), ());
 }
 
 double EdgeEstimator::CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const
@@ -119,11 +121,15 @@ double EdgeEstimator::CalcLeapWeight(m2::PointD const & from, m2::PointD const &
   return TimeBetweenSec(from, to, m_maxWeightSpeedMpS / 2.0);
 }
 
-double EdgeEstimator::CalcOffroad(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const
+double EdgeEstimator::CalcOffroad(m2::PointD const & from, m2::PointD const & to,
+                                  Purpose purpose) const
 {
-  return TimeBetweenSec(from, to,
-                        KMPH2MPS(purpose == Purpose::Weight ? m_offroadSpeedKMpH.m_weight
-                                                            : m_offroadSpeedKMpH.m_eta));
+  auto const offroadSpeedKMpH = purpose == Purpose::Weight ? m_offroadSpeedKMpH.m_weight
+                                                            : m_offroadSpeedKMpH.m_eta;
+  if (offroadSpeedKMpH == kUndefinedSpeed)
+    return 0.0;
+
+  return TimeBetweenSec(from, to, KMPH2MPS(offroadSpeedKMpH));
 }
 
 // PedestrianEstimator -----------------------------------------------------------------------------

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -103,7 +103,7 @@ EdgeEstimator::EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroa
   CHECK_GREATER(m_offroadSpeedKMpH.m_eta, 0.0, ());
   CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KMPH2MPS(m_offroadSpeedKMpH.m_weight), ());
 
-  if (m_offroadSpeedKMpH.m_eta != kUndefinedSpeed)
+  if (m_offroadSpeedKMpH.m_eta != kNotUsed)
     CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KMPH2MPS(m_offroadSpeedKMpH.m_eta), ());
 }
 
@@ -126,7 +126,7 @@ double EdgeEstimator::CalcOffroad(m2::PointD const & from, m2::PointD const & to
 {
   auto const offroadSpeedKMpH = purpose == Purpose::Weight ? m_offroadSpeedKMpH.m_weight
                                                             : m_offroadSpeedKMpH.m_eta;
-  if (offroadSpeedKMpH == kUndefinedSpeed)
+  if (offroadSpeedKMpH == kNotUsed)
     return 0.0;
 
   return TimeBetweenSec(from, to, KMPH2MPS(offroadSpeedKMpH));

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -40,7 +40,7 @@ public:
   double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const;
 
   // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake edge.
-  double CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const;
+  double CalcOffroad(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const;
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road,
                                    Purpose purpose) const = 0;

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -27,7 +27,7 @@ public:
     ETA
   };
 
-  EdgeEstimator(double maxWeightSpeedKMpH, double offroadSpeedKMpH);
+  EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH);
   virtual ~EdgeEstimator() = default;
 
   double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const;
@@ -39,17 +39,16 @@ public:
   // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
   double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const;
 
-  // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake
-  // edge.
-  double CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const;
+  // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake edge.
+  double CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const;
 
-  virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road) const = 0;
-  virtual double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const = 0;
+  virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road,
+                                   Purpose purpose) const = 0;
   virtual double GetUTurnPenalty(Purpose purpose) const = 0;
   virtual double GetFerryLandingPenalty(Purpose purpose) const = 0;
 
   static std::shared_ptr<EdgeEstimator> Create(VehicleType vehicleType, double maxWeighSpeedKMpH,
-                                               double offroadSpeedKMpH,
+                                               SpeedKMpH const & offroadSpeedKMpH,
                                                std::shared_ptr<TrafficStash>);
 
   static std::shared_ptr<EdgeEstimator> Create(VehicleType vehicleType,
@@ -58,6 +57,6 @@ public:
 
 private:
   double const m_maxWeightSpeedMpS;
-  double const m_offroadSpeedMpS;
+  SpeedKMpH const m_offroadSpeedKMpH;
 };
 }  // namespace routing

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -61,7 +61,7 @@ HighwayType FeaturesRoadGraph::CrossCountryVehicleModel::GetHighwayType(FeatureT
   return GetVehicleModel(f.GetID())->GetHighwayType(f);
 }
 
-double FeaturesRoadGraph::CrossCountryVehicleModel::GetOffroadSpeed() const
+SpeedKMpH FeaturesRoadGraph::CrossCountryVehicleModel::GetOffroadSpeed() const
 {
   return m_offroadSpeedKMpH;
 }

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -61,7 +61,7 @@ HighwayType FeaturesRoadGraph::CrossCountryVehicleModel::GetHighwayType(FeatureT
   return GetVehicleModel(f.GetID())->GetHighwayType(f);
 }
 
-SpeedKMpH FeaturesRoadGraph::CrossCountryVehicleModel::GetOffroadSpeed() const
+SpeedKMpH const & FeaturesRoadGraph::CrossCountryVehicleModel::GetOffroadSpeed() const
 {
   return m_offroadSpeedKMpH;
 }

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -37,7 +37,7 @@ private:
     SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
     HighwayType GetHighwayType(FeatureType & f) const override;
     double GetMaxWeightSpeed() const override { return m_maxSpeed; };
-    double GetOffroadSpeed() const override;
+    SpeedKMpH GetOffroadSpeed() const override;
     bool IsOneWay(FeatureType & f) const override;
     bool IsRoad(FeatureType & f) const override;
     bool IsPassThroughAllowed(FeatureType & f) const override;
@@ -49,7 +49,7 @@ private:
 
     std::shared_ptr<VehicleModelFactoryInterface> const m_vehicleModelFactory;
     double const m_maxSpeed;
-    double const m_offroadSpeedKMpH;
+    SpeedKMpH const m_offroadSpeedKMpH;
 
     mutable std::map<MwmSet::MwmId, std::shared_ptr<VehicleModelInterface>> m_cache;
   };

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -37,7 +37,7 @@ private:
     SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
     HighwayType GetHighwayType(FeatureType & f) const override;
     double GetMaxWeightSpeed() const override { return m_maxSpeed; };
-    SpeedKMpH GetOffroadSpeed() const override;
+    SpeedKMpH const & GetOffroadSpeed() const override;
     bool IsOneWay(FeatureType & f) const override;
     bool IsRoad(FeatureType & f) const override;
     bool IsPassThroughAllowed(FeatureType & f) const override;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -461,11 +461,15 @@ RouteWeight IndexGraph::CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool
     switch (purpose)
     {
     case EdgeEstimator::Purpose::Weight:
+    {
       return RouteWeight(
           m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::Weight));
+    }
     case EdgeEstimator::Purpose::ETA:
+    {
       return RouteWeight(
           m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::ETA));
+    }
     }
     UNREACHABLE();
   };

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -204,12 +204,6 @@ void IndexGraph::SetUTurnRestrictions(vector<RestrictionUTurn> && noUTurnRestric
 
 void IndexGraph::SetRoadAccess(RoadAccess && roadAccess) { m_roadAccess = move(roadAccess); }
 
-RouteWeight IndexGraph::CalcSegmentWeight(Segment const & segment)
-{
-  return RouteWeight(
-      m_estimator->CalcSegmentWeight(segment, m_geometry->GetRoad(segment.GetFeatureId())));
-}
-
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
                                      bool useRoutingOptions, vector<SegmentEdge> & edges,
                                      map<Segment, Segment> & parents)
@@ -466,8 +460,12 @@ RouteWeight IndexGraph::CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool
     auto const & road = m_geometry->GetRoad(segment.GetFeatureId());
     switch (purpose)
     {
-    case EdgeEstimator::Purpose::Weight: return RouteWeight(m_estimator->CalcSegmentWeight(segment, road));
-    case EdgeEstimator::Purpose::ETA: return RouteWeight(m_estimator->CalcSegmentETA(segment, road));
+    case EdgeEstimator::Purpose::Weight:
+      return RouteWeight(
+          m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::Weight));
+    case EdgeEstimator::Purpose::ETA:
+      return RouteWeight(
+          m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::ETA));
     }
     UNREACHABLE();
   };

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -458,20 +458,7 @@ RouteWeight IndexGraph::CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool
   auto const getWeight = [this, isOutgoing, &to, &from, purpose]() {
     auto const & segment = isOutgoing ? to : from;
     auto const & road = m_geometry->GetRoad(segment.GetFeatureId());
-    switch (purpose)
-    {
-    case EdgeEstimator::Purpose::Weight:
-    {
-      return RouteWeight(
-          m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::Weight));
-    }
-    case EdgeEstimator::Purpose::ETA:
-    {
-      return RouteWeight(
-          m_estimator->CalcSegmentWeight(segment, road, EdgeEstimator::Purpose::ETA));
-    }
-    }
-    UNREACHABLE();
+    return RouteWeight(m_estimator->CalcSegmentWeight(segment, road, purpose));
   };
 
   auto const & weight = getWeight();

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -121,9 +121,6 @@ public:
                                   Segment const & from, Segment const & to);
 
 private:
-
-  RouteWeight CalcSegmentWeight(Segment const & segment);
-
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
                            bool useRoutingOptions, std::vector<SegmentEdge> & edges,
                            std::map<Segment, Segment> & parents);

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -134,7 +134,7 @@ public:
     return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */), to);
   }
 
-  RouteWeight CalcSegmentWeight(Segment const & segment) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
   double CalculateETA(Segment const & from, Segment const & to) const;
   double CalculateETAWithoutPenalty(Segment const & segment) const;
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -92,7 +92,7 @@ double CalcMaxSpeed(NumMwmIds const & numMwmIds,
   return maxSpeed;
 }
 
-SpeedKMpH CalcOffroadSpeed(VehicleModelFactoryInterface const & vehicleModelFactory)
+SpeedKMpH const & CalcOffroadSpeed(VehicleModelFactoryInterface const & vehicleModelFactory)
 {
   return vehicleModelFactory.GetVehicleModel()->GetOffroadSpeed();
 }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -92,7 +92,7 @@ double CalcMaxSpeed(NumMwmIds const & numMwmIds,
   return maxSpeed;
 }
 
-double CalcOffroadSpeed(VehicleModelFactoryInterface const & vehicleModelFactory)
+SpeedKMpH CalcOffroadSpeed(VehicleModelFactoryInterface const & vehicleModelFactory)
 {
   return vehicleModelFactory.GetVehicleModel()->GetOffroadSpeed();
 }
@@ -724,7 +724,8 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   for (size_t i = lastSubroute.GetBeginSegmentIdx(); i < lastSubroute.GetEndSegmentIdx(); ++i)
   {
     auto const & step = steps[i];
-    prevEdges.emplace_back(step.GetSegment(), starter.CalcSegmentWeight(step.GetSegment()));
+    prevEdges.emplace_back(step.GetSegment(), starter.CalcSegmentWeight(step.GetSegment(),
+                           EdgeEstimator::Purpose::Weight));
   }
 
   uint32_t visitCount = 0;

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 345.25, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 347.4, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -59,7 +59,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
         MercatorBounds::FromLatLon(55.97310, 37.41460), {0., 0.},
-        MercatorBounds::FromLatLon(55.75100, 37.61790), 33717.0);
+        MercatorBounds::FromLatLon(55.75100, 37.61790), 39899.2);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.
@@ -323,7 +323,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 1000.65);
+    integration::TestRouteTime(route, 967.0);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
@@ -405,7 +405,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 19859.3);
+    integration::TestRouteTime(route, 19645.0);
   }
 
   // Test on roads with tag route=shuttle_train
@@ -547,7 +547,7 @@ namespace
 
     integration::CalculateRouteAndTestRouteLength(
         vehicleComponents, MercatorBounds::FromLatLon(55.93885, 37.40588), {0.0, 0.0},
-        MercatorBounds::FromLatLon(55.93706, 37.45339), 10627.5);
+        MercatorBounds::FromLatLon(55.93706, 37.45339), 9168.15);
   }
 
   UNIT_TEST(NoCrash_RioGrandeCosmopolis)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -405,7 +405,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 19645.0);
+    integration::TestRouteTime(route, 19621.8);
   }
 
   // Test on roads with tag route=shuttle_train

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -569,4 +569,23 @@ namespace
 
     TEST_EQUAL(route.second, RouterResultCode::NoError, ());
   }
+
+  // Test RussiaShorterFakeEdges1 and RussiaShorterFakeEdges2 are on reducing
+  // |kSpeedOffroadKMpH| for car routing. This lets us make
+  // fake edges shorter that prevent crossing lakes, forests and so on.
+  UNIT_TEST(RussiaBlackLakeShorterFakeEdges1)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents(VehicleType::Car),
+        MercatorBounds::FromLatLon(55.62466, 39.71385), {0., 0.},
+        MercatorBounds::FromLatLon(55.63114, 39.70979), 1469.54);
+  }
+
+  UNIT_TEST(RussiaShorterFakeEdges2)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents(VehicleType::Car),
+        MercatorBounds::FromLatLon(55.31103, 38.80954), {0., 0.},
+        MercatorBounds::FromLatLon(55.31155, 38.8217), 2489.8);
+  }
 }  // namespace

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -323,7 +323,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 979.4);
+    integration::TestRouteTime(route, 1000.65);
   }
 
   UNIT_TEST(RussiaMoscowLenigradskiy39GeroevPanfilovtsev22SubrouteTest)
@@ -405,7 +405,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 19621.8);
+    integration::TestRouteTime(route, 19859.3);
   }
 
   // Test on roads with tag route=shuttle_train
@@ -433,7 +433,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 6445.17);
+    integration::TestRouteTime(route, 6470.68);
   }
 
   // Test on removing speed cameras from the route for maps from Jan 2019,
@@ -547,7 +547,7 @@ namespace
 
     integration::CalculateRouteAndTestRouteLength(
         vehicleComponents, MercatorBounds::FromLatLon(55.93885, 37.40588), {0.0, 0.0},
-        MercatorBounds::FromLatLon(55.93706, 37.45339), 10270.2);
+        MercatorBounds::FromLatLon(55.93706, 37.45339), 10627.5);
   }
 
   UNIT_TEST(NoCrash_RioGrandeCosmopolis)

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -545,9 +545,9 @@ UNIT_TEST(FakeEndingAStarInvariant)
   auto const finish = MakeFakeEnding(0, 0, m2::PointD(2.0, 1.0), *worldGraph);
 
   auto const expectedWeight =
-      estimator->CalcOffroadWeight({1.0, 1.0}, {1.0, 0.0}) +
+      estimator->CalcOffroadWeight({1.0, 1.0}, {1.0, 0.0}, EdgeEstimator::Purpose::Weight) +
       MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / KMPH2MPS(1.0) +
-      estimator->CalcOffroadWeight({2.0, 0.0}, {2.0, 1.0});
+      estimator->CalcOffroadWeight({2.0, 0.0}, {2.0, 1.0}, EdgeEstimator::Purpose::Weight);
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *worldGraph);
 }
 

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -545,9 +545,9 @@ UNIT_TEST(FakeEndingAStarInvariant)
   auto const finish = MakeFakeEnding(0, 0, m2::PointD(2.0, 1.0), *worldGraph);
 
   auto const expectedWeight =
-      estimator->CalcOffroadWeight({1.0, 1.0}, {1.0, 0.0}, EdgeEstimator::Purpose::Weight) +
+      estimator->CalcOffroad({1.0, 1.0}, {1.0, 0.0}, EdgeEstimator::Purpose::Weight) +
       MercatorBounds::DistanceOnEarth({1.0, 0.0}, {2.0, 0.0}) / KMPH2MPS(1.0) +
-      estimator->CalcOffroadWeight({2.0, 0.0}, {2.0, 1.0}, EdgeEstimator::Purpose::Weight);
+          estimator->CalcOffroad({2.0, 0.0}, {2.0, 1.0}, EdgeEstimator::Purpose::Weight);
   TestRoute(start, finish, expectedRoute.size(), &expectedRoute, expectedWeight, *worldGraph);
 }
 

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -139,7 +139,8 @@ void TestTransitGraphLoader::AddGraph(NumMwmId mwmId, unique_ptr<TransitGraph> g
 
 // WeightedEdgeEstimator --------------------------------------------------------------
 double WeightedEdgeEstimator::CalcSegmentWeight(Segment const & segment,
-                                                RoadGeometry const & /* road */) const
+                                                RoadGeometry const & /* road */,
+                                                EdgeEstimator::Purpose /* purpose */) const
 {
   auto const it = m_segmentWeights.find(segment);
   CHECK(it != m_segmentWeights.cend(), ());

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -171,8 +171,9 @@ public:
   // EdgeEstimator overrides:
   ~WeightedEdgeEstimator() override = default;
 
-  double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */) const override;
-  double CalcSegmentETA(Segment const & segment, RoadGeometry const & road) const override { return 0.0; }
+  double CalcSegmentWeight(Segment const & segment, RoadGeometry const & /* road */,
+                           EdgeEstimator::Purpose purpose) const override;
+
   double GetUTurnPenalty(Purpose purpose) const override;
   double GetFerryLandingPenalty(Purpose purpose) const override;
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -174,10 +174,11 @@ RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(m2::PointD const & fr
   return RouteWeight(m_estimator->CalcHeuristic(from, to));
 }
 
-RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment)
+RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment,
+                                                       EdgeEstimator::Purpose purpose)
 {
   return RouteWeight(m_estimator->CalcSegmentWeight(
-      segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())));
+      segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()), purpose));
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(m2::PointD const & from,
@@ -187,9 +188,10 @@ RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(m2::PointD const & from,
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
-                                                       m2::PointD const & to) const
+                                                       m2::PointD const & to,
+                                                       EdgeEstimator::Purpose purpose) const
 {
-  return RouteWeight(m_estimator->CalcOffroadWeight(from, to));
+  return RouteWeight(m_estimator->CalcOffroadWeight(from, to, purpose));
 }
 
 double SingleVehicleWorldGraph::CalculateETA(Segment const & from, Segment const & to)
@@ -203,8 +205,9 @@ double SingleVehicleWorldGraph::CalculateETA(Segment const & from, Segment const
 
 double SingleVehicleWorldGraph::CalculateETAWithoutPenalty(Segment const & segment)
 {
-  return m_estimator->CalcSegmentETA(segment,
-                                     GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()));
+  return m_estimator->CalcSegmentWeight(segment,
+                                        GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()),
+                                        EdgeEstimator::Purpose::ETA);
 }
 
 vector<Segment> const & SingleVehicleWorldGraph::GetTransitions(NumMwmId numMwmId, bool isEnter)

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -191,7 +191,7 @@ RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
                                                        m2::PointD const & to,
                                                        EdgeEstimator::Purpose purpose) const
 {
-  return RouteWeight(m_estimator->CalcOffroadWeight(from, to, purpose));
+  return RouteWeight(m_estimator->CalcOffroad(from, to, purpose));
 }
 
 double SingleVehicleWorldGraph::CalculateETA(Segment const & from, Segment const & to)

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -59,9 +59,10 @@ public:
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) override;
 
-  RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
   RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+                                EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;
   double CalculateETAWithoutPenalty(Segment const & segment) override;
 

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -50,7 +50,8 @@ Junction const & TransitGraph::GetJunction(Segment const & segment, bool front) 
   return front ? vertex.GetJunctionTo() : vertex.GetJunctionFrom();
 }
 
-RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment) const
+RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment,
+                                            EdgeEstimator::Purpose purpose) const
 {
   CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
   if (IsGate(segment))
@@ -69,7 +70,7 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment) const
 
   return RouteWeight(
       m_estimator->CalcOffroadWeight(GetJunction(segment, false /* front */).GetPoint(),
-                                     GetJunction(segment, true /* front */).GetPoint()));
+                                     GetJunction(segment, true /* front */).GetPoint(), purpose));
 }
 
 RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const & to) const
@@ -108,7 +109,8 @@ void TransitGraph::GetTransitEdges(Segment const & segment, bool isOutgoing,
   {
     auto const & from = isOutgoing ? segment : s;
     auto const & to = isOutgoing ? s : segment;
-    edges.emplace_back(s, CalcSegmentWeight(to) + GetTransferPenalty(from, to));
+    edges.emplace_back(
+        s, CalcSegmentWeight(to, EdgeEstimator::Purpose::Weight) + GetTransferPenalty(from, to));
   }
 }
 

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -69,8 +69,8 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment,
   }
 
   return RouteWeight(
-      m_estimator->CalcOffroadWeight(GetJunction(segment, false /* front */).GetPoint(),
-                                     GetJunction(segment, true /* front */).GetPoint(), purpose));
+      m_estimator->CalcOffroad(GetJunction(segment, false /* front */).GetPoint(),
+                               GetJunction(segment, true /* front */).GetPoint(), purpose));
 }
 
 RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const & to) const

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -34,7 +34,7 @@ public:
   TransitGraph(NumMwmId numMwmId, std::shared_ptr<EdgeEstimator> estimator);
 
   Junction const & GetJunction(Segment const & segment, bool front) const;
-  RouteWeight CalcSegmentWeight(Segment const & segment) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
   void GetTransitEdges(Segment const & segment, bool isOutgoing,
                        std::vector<SegmentEdge> & edges) const;

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -155,7 +155,7 @@ RouteWeight TransitWorldGraph::CalcOffroadWeight(m2::PointD const & from,
                                                  m2::PointD const & to,
                                                  EdgeEstimator::Purpose purpose) const
 {
-  return RouteWeight(m_estimator->CalcOffroadWeight(from, to, purpose));
+  return RouteWeight(m_estimator->CalcOffroad(from, to, purpose));
 }
 
 double TransitWorldGraph::CalculateETA(Segment const & from, Segment const & to)

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -60,9 +60,10 @@ public:
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
   RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) override;
-  RouteWeight CalcSegmentWeight(Segment const & segment) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
   RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const override;
+  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+                                EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;
   double CalculateETAWithoutPenalty(Segment const & segment) override;
 

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/joint_segment.hpp"
@@ -73,11 +74,13 @@ public:
   virtual RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) = 0;
   virtual RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) = 0;
 
-  virtual RouteWeight CalcSegmentWeight(Segment const & segment) = 0;
+  virtual RouteWeight CalcSegmentWeight(Segment const & segment,
+                                        EdgeEstimator::Purpose purpose) = 0;
 
   virtual RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
 
-  virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
+  virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+                                        EdgeEstimator::Purpose purpose) const = 0;
 
   virtual double CalculateETA(Segment const & from, Segment const & to) = 0;
   virtual double CalculateETAWithoutPenalty(Segment const & segment) = 0;

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -57,7 +57,7 @@ HighwayBasedMeanSpeeds const kDefaultSpeeds = {
     {HighwayType::RouteFerry, InOutCitySpeedKMpH(SpeedKMpH(3.0, 20.0))},
 };
 
-double constexpr kSpeedOffroadKMpH = 3.0;
+SpeedKMpH constexpr kSpeedOffroadKMpH = {3.0 /* weight */, 3.0 /* eta */};
 
 // Default
 VehicleModel::LimitsInitList const kBicycleOptionsDefault = {
@@ -456,9 +456,9 @@ bool BicycleModel::IsOneWay(FeatureType & f) const
   return VehicleModel::IsOneWay(f);
 }
 
-double BicycleModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH BicycleModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
-// If one of feature types will be disabled for bicycles, features of this type will be simplyfied
+// If one of feature types will be disabled for bicycles, features of this type will be simplified
 // in generator. Look FeatureBuilder1::IsRoad() for more details.
 // static
 BicycleModel const & BicycleModel::AllLimitsInstance()

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -456,7 +456,7 @@ bool BicycleModel::IsOneWay(FeatureType & f) const
   return VehicleModel::IsOneWay(f);
 }
 
-SpeedKMpH BicycleModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH const & BicycleModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 // If one of feature types will be disabled for bicycles, features of this type will be simplified
 // in generator. Look FeatureBuilder1::IsRoad() for more details.

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -14,7 +14,7 @@ public:
   /// VehicleModelInterface overrides:
   SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType & f) const override;
-  double GetOffroadSpeed() const override;
+  SpeedKMpH GetOffroadSpeed() const override;
 
   static BicycleModel const & AllLimitsInstance();
 

--- a/routing_common/bicycle_model.hpp
+++ b/routing_common/bicycle_model.hpp
@@ -14,7 +14,7 @@ public:
   /// VehicleModelInterface overrides:
   SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType & f) const override;
-  SpeedKMpH GetOffroadSpeed() const override;
+  SpeedKMpH const & GetOffroadSpeed() const override;
 
   static BicycleModel const & AllLimitsInstance();
 

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -63,7 +63,7 @@ std::array<char const *, 41> constexpr kCountries = {"Australia",
                                                      "United States of America",
                                                      "Venezuela"};
 
-double constexpr kSpeedOffroadKMpH = 10.0;
+double constexpr kSpeedOffroadKMpH = 3.0;
 
 VehicleModel::LimitsInitList const kCarOptionsDefault = {
     // {{roadType, roadType}  passThroughAllowed}

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -215,7 +215,7 @@ CarModel::CarModel(VehicleModel::LimitsInitList const & roadLimits, HighwayBased
   Init();
 }
 
-SpeedKMpH CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH const & CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void CarModel::Init()
 {

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -69,7 +69,7 @@ std::array<char const *, 41> constexpr kCountries = {"Australia",
 // a start or finish. On the other hand, while route calculation the fake edges are considered
 // as quite heavy. The idea behind that is to use the closest edge for the start and the finish
 // of the route except for some edge cases.
-SpeedKMpH constexpr kSpeedOffroadKMpH = {0.01 /* weight */, kUndefinedSpeed /* eta */};
+SpeedKMpH constexpr kSpeedOffroadKMpH = {0.01 /* weight */, kNotUsed /* eta */};
 
 VehicleModel::LimitsInitList const kCarOptionsDefault = {
     // {{roadType, roadType}  passThroughAllowed}

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -63,7 +63,7 @@ std::array<char const *, 41> constexpr kCountries = {"Australia",
                                                      "United States of America",
                                                      "Venezuela"};
 
-double constexpr kSpeedOffroadKMpH = 3.0;
+SpeedKMpH constexpr kSpeedOffroadKMpH = {3.0 /* weight */, 3.0 /* eta */};
 
 VehicleModel::LimitsInitList const kCarOptionsDefault = {
     // {{roadType, roadType}  passThroughAllowed}
@@ -209,7 +209,7 @@ CarModel::CarModel(VehicleModel::LimitsInitList const & roadLimits, HighwayBased
   Init();
 }
 
-double CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH CarModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void CarModel::Init()
 {

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -64,12 +64,12 @@ std::array<char const *, 41> constexpr kCountries = {"Australia",
                                                      "Venezuela"};
 
 // |kSpeedOffroadKMpH| is a speed which is used for edges that don't lie on road features.
-// For example for pure fake edges. The speed for building route and the speed for
-// ETA calculation is significant different for cars. The idea behind that is
-// to use the closest edge for the start and the finish of the route except for some edge cases.
-// And when ETA is calculated not to take into account fake edges. It's actual
-// when an airport is a start of finish.
-SpeedKMpH constexpr kSpeedOffroadKMpH = {0.01 /* weight */, 100.0 /* eta */};
+// For example for pure fake edges. In car routing, off road speed for calculation ETA is not used.
+// The weight of such edges is considered as 0 seconds. It's especially actual when an airport is
+// a start or finish. On the other hand, while route calculation the fake edges are considered
+// as quite heavy. The idea behind that is to use the closest edge for the start and the finish
+// of the route except for some edge cases.
+SpeedKMpH constexpr kSpeedOffroadKMpH = {0.01 /* weight */, kUndefinedSpeed /* eta */};
 
 VehicleModel::LimitsInitList const kCarOptionsDefault = {
     // {{roadType, roadType}  passThroughAllowed}

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -63,7 +63,13 @@ std::array<char const *, 41> constexpr kCountries = {"Australia",
                                                      "United States of America",
                                                      "Venezuela"};
 
-SpeedKMpH constexpr kSpeedOffroadKMpH = {3.0 /* weight */, 3.0 /* eta */};
+// |kSpeedOffroadKMpH| is a speed which is used for edges that don't lie on road features.
+// For example for pure fake edges. The speed for building route and the speed for
+// ETA calculation is significant different for cars. The idea behind that is
+// to use the closest edge for the start and the finish of the route except for some edge cases.
+// And when ETA is calculated not to take into account fake edges. It's actual
+// when an airport is a start of finish.
+SpeedKMpH constexpr kSpeedOffroadKMpH = {0.01 /* weight */, 100.0 /* eta */};
 
 VehicleModel::LimitsInitList const kCarOptionsDefault = {
     // {{roadType, roadType}  passThroughAllowed}

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -14,7 +14,7 @@ public:
   CarModel(VehicleModel::LimitsInitList const & roadLimits, HighwayBasedInfo const & info);
 
   // VehicleModelInterface overrides:
-  double GetOffroadSpeed() const override;
+  SpeedKMpH GetOffroadSpeed() const override;
 
   static CarModel const & AllLimitsInstance();
   static LimitsInitList const & GetOptions();

--- a/routing_common/car_model.hpp
+++ b/routing_common/car_model.hpp
@@ -14,7 +14,7 @@ public:
   CarModel(VehicleModel::LimitsInitList const & roadLimits, HighwayBasedInfo const & info);
 
   // VehicleModelInterface overrides:
-  SpeedKMpH GetOffroadSpeed() const override;
+  SpeedKMpH const & GetOffroadSpeed() const override;
 
   static CarModel const & AllLimitsInstance();
   static LimitsInitList const & GetOptions();

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -293,7 +293,7 @@ SpeedKMpH PedestrianModel::GetSpeed(FeatureType & f, SpeedParams const & speedPa
   return VehicleModel::GetSpeedWihtoutMaxspeed(f, speedParams);
 }
 
-SpeedKMpH PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH const & PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void PedestrianModel::Init()
 {

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -57,7 +57,7 @@ HighwayBasedMeanSpeeds const kDefaultSpeeds = {
     {HighwayType::RouteFerry, InOutCitySpeedKMpH(SpeedKMpH(1.0, 20.0))},
 };
 
-double constexpr kSpeedOffroadKMpH = 3.0;
+SpeedKMpH constexpr kSpeedOffroadKMpH = {3.0 /* weight */, 3.0 /* eta */};
 
 // Default
 VehicleModel::LimitsInitList const kPedestrianOptionsDefault = {
@@ -293,7 +293,7 @@ SpeedKMpH PedestrianModel::GetSpeed(FeatureType & f, SpeedParams const & speedPa
   return VehicleModel::GetSpeedWihtoutMaxspeed(f, speedParams);
 }
 
-double PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
+SpeedKMpH PedestrianModel::GetOffroadSpeed() const { return kSpeedOffroadKMpH; }
 
 void PedestrianModel::Init()
 {

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -14,7 +14,7 @@ public:
   /// VehicleModelInterface overrides:
   SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType &) const override { return false; }
-  SpeedKMpH GetOffroadSpeed() const override;
+  SpeedKMpH const & GetOffroadSpeed() const override;
 
   static PedestrianModel const & AllLimitsInstance();
 

--- a/routing_common/pedestrian_model.hpp
+++ b/routing_common/pedestrian_model.hpp
@@ -14,7 +14,7 @@ public:
   /// VehicleModelInterface overrides:
   SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   bool IsOneWay(FeatureType &) const override { return false; }
-  double GetOffroadSpeed() const override;
+  SpeedKMpH GetOffroadSpeed() const override;
 
   static PedestrianModel const & AllLimitsInstance();
 

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -72,7 +72,7 @@ public:
   }
 
   // We are not going to use offroad routing in these tests.
-  double GetOffroadSpeed() const override { return 0.0; }
+  SpeedKMpH GetOffroadSpeed() const override { return {0.0 /* weight */, 0.0 /* eta */}; }
 };
 
 uint32_t GetType(char const * s0, char const * s1 = 0, char const * s2 = 0)

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -72,8 +72,13 @@ public:
   }
 
   // We are not going to use offroad routing in these tests.
-  SpeedKMpH GetOffroadSpeed() const override { return {0.0 /* weight */, 0.0 /* eta */}; }
+  SpeedKMpH const & GetOffroadSpeed() const override { return kDummy; }
+
+private:
+  static SpeedKMpH const kDummy;
 };
+
+SpeedKMpH const TestVehicleModel::kDummy = {0.0 /* weight */, 0.0 /* eta */};
 
 uint32_t GetType(char const * s0, char const * s1 = 0, char const * s2 = 0)
 {

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -24,6 +25,8 @@ namespace feature { class TypesHolder; }
 
 namespace routing
 {
+double constexpr kUndefinedSpeed = std::numeric_limits<double>::max();
+
 struct InOutCityFactor;
 struct InOutCitySpeedKMpH;
 

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -85,7 +85,7 @@ struct SpeedParams
   Maxspeed m_maxspeed;
 };
 
-/// \brief Speeds which are used for edge weight and ETA esimations.
+/// \brief Speeds which are used for edge weight and ETA estimations.
 struct SpeedKMpH
 {
   constexpr SpeedKMpH() = default;
@@ -231,7 +231,7 @@ public:
 
   /// @return Offroad speed in KMpH for vehicle. This speed should be used for non-feature routing
   /// e.g. to connect start point to nearest feature.
-  virtual double GetOffroadSpeed() const = 0;
+  virtual SpeedKMpH GetOffroadSpeed() const = 0;
 
   virtual bool IsOneWay(FeatureType & f) const = 0;
 

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -25,7 +25,7 @@ namespace feature { class TypesHolder; }
 
 namespace routing
 {
-double constexpr kUndefinedSpeed = std::numeric_limits<double>::max();
+double constexpr kNotUsed = std::numeric_limits<double>::max();
 
 struct InOutCityFactor;
 struct InOutCitySpeedKMpH;

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -234,7 +234,7 @@ public:
 
   /// @return Offroad speed in KMpH for vehicle. This speed should be used for non-feature routing
   /// e.g. to connect start point to nearest feature.
-  virtual SpeedKMpH GetOffroadSpeed() const = 0;
+  virtual SpeedKMpH const & GetOffroadSpeed() const = 0;
 
   virtual bool IsOneWay(FeatureType & f) const = 0;
 

--- a/track_analyzing/track_analyzer/cmd_tracks.cpp
+++ b/track_analyzing/track_analyzer/cmd_tracks.cpp
@@ -115,7 +115,8 @@ double EstimateDuration(MatchedTrack const & track, shared_ptr<EdgeEstimator> es
       continue;
 
     segment = point.GetSegment();
-    result += estimator->CalcSegmentWeight(segment, geometry.GetRoad(segment.GetFeatureId()));
+    result += estimator->CalcSegmentWeight(segment, geometry.GetRoad(segment.GetFeatureId()),
+                                           EdgeEstimator::Purpose::ETA);
   }
 
   return result;


### PR DESCRIPTION
Основания для данного PR следующие. Сейчас off road speed для машин 10 км в час. Эта скорость используется, как скорость для дуг соединяющих граф дорог с финишем и стартом. Это очень большая скорость, поскольку файковые дуги всегда выигрывают у реальных дуг с типа highway=track (Мы считаем, что на highway=track скорость 5 км в час) у service (15 км/ч), living_street(10 км/ч), у пирсов (17 км/ч за городом и 10 км/ч в городе), если у них плохое покрытие или они не очень прямые.

Примеры, где возникают проблемы: 
![image](https://user-images.githubusercontent.com/1768114/64255538-3f5ac480-cf2a-11e9-8afe-660bffd990cf.png)

![image](https://user-images.githubusercontent.com/1768114/64259680-2d7d1f80-cf32-11e9-9e5a-b9c9ee0f1dac.png)

В данном PR мы делаем возможность задавать off road speed отдельно для ETA и для прокладки маршрута.
- это решает известные проблемы;
- это серьезно не ломает ни один тест. Т.е. тесты надо подправить, но маршруты хуже в них не стали;
- это позволяет точнее считать ETA особенно в случае длинный файковых дуг. Аэропорты, леса.

Поправлены следующие тесты:
===================================================================
**RussiaMoscowLenigradskiy39GeroevPanfilovtsev22TimeTest**
ETA факовых дуг немного увеличился.
С данным PR
![image](https://user-images.githubusercontent.com/1768114/64312827-46c5b080-cfb2-11e9-9f07-c5221987a762.png)

До данного PR
![image](https://user-images.githubusercontent.com/1768114/64260138-070bb400-cf33-11e9-8951-9008ace7c7bb.png)

===================================================================

**TolyattiFeatureThatCrossSeveralMwmsTest**
С данным PR
ETA факовых дуг немного увеличился.
![image](https://user-images.githubusercontent.com/1768114/64313078-22b69f00-cfb3-11e9-8d62-c54254077890.png)

До данного PR
![image](https://user-images.githubusercontent.com/1768114/64260354-68338780-cf33-11e9-9eb0-46f43b048272.png)

===================================================================

**RussiaMoscowNecessityRectCoversPolylineTest**
С данным PR
ETA факовых дуг немного увеличился, но и длина маршрута чуть чуть возросла. Тем не менее ETA маршрута вырос.
![image](https://user-images.githubusercontent.com/1768114/64313229-b0928a00-cfb3-11e9-99ca-6c8fb0b1224e.png)

До данного PR
![image](https://user-images.githubusercontent.com/1768114/64260494-a466e800-cf33-11e9-92f2-a49df5d3fa97.png)

===================================================================
NetherlandsAmsterdamBicycleYes
Тест NetherlandsAmsterdamBicycleYes поправлен, поскольку сейчас в мастере мы полагаем, что метод CalcSegmentWeight() всегда вызывается для вычисления веса дуг, (Weight but not ETA)(https://github.com/mapsme/omim/blob/master/routing/edge_estimator.cpp:182). Однако в случае колстека ниже, видно, что бывает иначе. Данный PR (коммит 2898eb4bdbcdf53b5dceec6495502862d260cded) исправляет эту ошибку. Следовательно поправлен и тест NetherlandsAmsterdamBicycleYes.

```
double (anonymous namespace)::CalcClimbSegment<double (&)(double, short)>(routing::EdgeEstimator::Purpose, routing::Segment const&, routing::RoadGeometry const&, double (&)(double, short)) edge_estimator.cpp:84
routing::BicycleEstimator::CalcSegmentWeight(routing::Segment const&, routing::RoadGeometry const&) const edge_estimator.cpp:182
routing::SingleVehicleWorldGraph::CalcSegmentWeight(routing::Segment const&) single_vehicle_world_graph.cpp:179
routing::IndexGraphStarter::CalcSegmentWeight(routing::Segment const&) const index_graph_starter.cpp:267
routing::IndexGraphStarter::CalculateETA(routing::Segment const&, routing::Segment const&) const index_graph_starter.cpp:277
routing::IndexRouter::RedressRoute(std::__1::vector<routing::Segment, std::__1::allocator<routing::Segment> > const&, routing::RouterDelegate const&, routing::IndexGraphStarter&, routing::Route&) const index_router.cpp:1323
routing::IndexRouter::DoCalculateRoute(routing::Checkpoints const&, m2::Point<double> const&, routing::RouterDelegate const&, routing::Route&) index_router.cpp:500
```
Вид маршрута не изменился:
![image](https://user-images.githubusercontent.com/1768114/64536060-161ea780-d321-11e9-847c-2ce05d3a0270.png)

===================================================================
На примеры, где маршруты прокладывались не верно (см. выше) добавлены тесты. Теперь прокладываются вот так:
![image](https://user-images.githubusercontent.com/1768114/64316017-429e9080-cfbc-11e9-931d-f8228cd7cfbd.png)
![image](https://user-images.githubusercontent.com/1768114/64316021-47634480-cfbc-11e9-9467-b0c6d36f9742.png)

Т.е. медленные дороги (highway=track и т.п.) чаще выигрывают, и не предлагается слезать от старта по лесу или через озеро.

https://jira.mail.ru/browse/MAPSME-11741

@gmoryes PTAL