### PR TITLE
[generator] [routing] Fix points accuracy

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -102,6 +102,7 @@
 #define CAMERAS_TO_WAYS_FILENAME "cameras_to_ways.bin"
 #define MAXSPEEDS_FILENAME "maxspeeds.csv"
 #define CITIES_AREAS_TMP_FILENAME "cities_areas" DATA_FILE_EXTENSION_TMP
+#define CROSS_MWM_OSM_WAYS_DIR "cross_mwm_osm_ways"
 
 #define TRAFFIC_FILE_EXTENSION ".traffic"
 

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -49,6 +49,8 @@ set(
   collector_interface.hpp
   collector_tag.cpp
   collector_tag.hpp
+  cross_mwm_osm_ways_collector.cpp
+  cross_mwm_osm_ways_collector.hpp
   descriptions_section_builder.cpp
   descriptions_section_builder.hpp
   dumper.cpp

--- a/generator/affiliation.cpp
+++ b/generator/affiliation.cpp
@@ -4,6 +4,7 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/assert.hpp"
 #include "base/thread_pool_computational.hpp"
 
 #include <cmath>
@@ -53,6 +54,21 @@ std::vector<std::string> CountriesFilesAffiliation::GetAffiliations(FeatureBuild
   }
 
   return countries;
+}
+
+std::vector<bool>
+CountriesFilesAffiliation::GetFeaturePointsEntries(std::string const & mwmName,
+                                                   FeatureBuilder const & fb) const
+{
+  std::vector<bool> entries;
+  entries.reserve(fb.GetPointsCount());
+  auto const & polygon = m_countries.GetRegionByName(mwmName);
+  fb.ForAnyGeometryPoint([&entries, &polygon](auto const & point) {
+    entries.emplace_back(polygon.Contains(point));
+    return false;
+  });
+
+  return entries;
 }
 
 bool CountriesFilesAffiliation::HasRegionByName(std::string const & name) const
@@ -232,5 +248,12 @@ std::vector<std::string> SingleAffiliation::GetAffiliations(FeatureBuilder const
 bool SingleAffiliation::HasRegionByName(std::string const & name) const
 {
   return name == m_filename;
+}
+
+std::vector<bool>
+SingleAffiliation::GetFeaturePointsEntries(std::string const & mwmName,
+                                           FeatureBuilder const & fb) const
+{
+  UNREACHABLE();
 }
 }  // namespace feature

--- a/generator/affiliation.hpp
+++ b/generator/affiliation.hpp
@@ -20,6 +20,8 @@ public:
   // The method will return the names of the buckets to which the fb belongs.
   virtual std::vector<std::string> GetAffiliations(FeatureBuilder const & fb) const = 0;
   virtual bool HasRegionByName(std::string const & name) const = 0;
+  virtual std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
+                                                    FeatureBuilder const & fb) const = 0;
 };
 
 class CountriesFilesAffiliation : public AffiliationInterface
@@ -30,6 +32,8 @@ public:
   // AffiliationInterface overrides:
   std::vector<std::string> GetAffiliations(FeatureBuilder const & fb) const override;
   bool HasRegionByName(std::string const & name) const override;
+  std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
+                                            FeatureBuilder const & fb) const override;
 
 protected:
   borders::CountriesContainer const & m_countries;
@@ -60,11 +64,13 @@ private:
 class SingleAffiliation : public AffiliationInterface
 {
 public:
-  SingleAffiliation(std::string const & filename);
+  explicit SingleAffiliation(std::string const & filename);
 
   // AffiliationInterface overrides:
   std::vector<std::string> GetAffiliations(FeatureBuilder const &) const override;
   bool HasRegionByName(std::string const & name) const override;
+  std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
+                                            FeatureBuilder const & fb) const override;
 
 private:
   std::string m_filename;

--- a/generator/affiliation.hpp
+++ b/generator/affiliation.hpp
@@ -19,9 +19,9 @@ public:
 
   // The method will return the names of the buckets to which the fb belongs.
   virtual std::vector<std::string> GetAffiliations(FeatureBuilder const & fb) const = 0;
+  virtual std::vector<std::string> GetAffiliations(m2::PointD const & point) const = 0;
   virtual bool HasRegionByName(std::string const & name) const = 0;
-  virtual std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
-                                                    FeatureBuilder const & fb) const = 0;
+
 };
 
 class CountriesFilesAffiliation : public AffiliationInterface
@@ -31,9 +31,9 @@ public:
 
   // AffiliationInterface overrides:
   std::vector<std::string> GetAffiliations(FeatureBuilder const & fb) const override;
+  std::vector<std::string> GetAffiliations(m2::PointD const & point) const override;
+
   bool HasRegionByName(std::string const & name) const override;
-  std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
-                                            FeatureBuilder const & fb) const override;
 
 protected:
   borders::CountriesContainer const & m_countries;
@@ -69,8 +69,7 @@ public:
   // AffiliationInterface overrides:
   std::vector<std::string> GetAffiliations(FeatureBuilder const &) const override;
   bool HasRegionByName(std::string const & name) const override;
-  std::vector<bool> GetFeaturePointsEntries(std::string const & mwmName,
-                                            FeatureBuilder const & fb) const override;
+  std::vector<std::string> GetAffiliations(m2::PointD const & point) const override;
 
 private:
   std::string m_filename;

--- a/generator/collector_interface.hpp
+++ b/generator/collector_interface.hpp
@@ -39,6 +39,7 @@ class CollectorCollection;
 class CollectorTag;
 class MaxspeedsCollector;
 class CityAreaCollector;
+class CrossMwmOsmWaysCollector;
 namespace cache
 {
 class IntermediateDataReader;
@@ -77,6 +78,7 @@ public:
   virtual void MergeInto(feature::MetalinesBuilder &) const { FailIfMethodUnsupported(); }
   virtual void MergeInto(regions::CollectorRegionInfo &) const { FailIfMethodUnsupported(); }
   virtual void MergeInto(CollectorCollection &) const { FailIfMethodUnsupported(); }
+  virtual void MergeInto(CrossMwmOsmWaysCollector &) const { FailIfMethodUnsupported(); }
 
   std::string GetTmpFilename() const { return m_filename + "." + std::to_string(m_id); }
   std::string const & GetFilename() const { return m_filename; }

--- a/generator/cross_mwm_osm_ways_collector.hpp
+++ b/generator/cross_mwm_osm_ways_collector.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "generator/affiliation.hpp"
+#include "generator/collector_interface.hpp"
+#include "generator/generate_info.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <set>
+
+namespace generator
+{
+class CrossMwmOsmWaysCollector : public generator::CollectorInterface
+{
+public:
+  explicit CrossMwmOsmWaysCollector(feature::GenerateInfo const & info);
+
+  explicit CrossMwmOsmWaysCollector(std::string intermediateDir,
+                                    std::shared_ptr<feature::CountriesFilesAffiliation> affiliation);
+
+  struct Info
+  {
+    struct SegmentInfo
+    {
+      SegmentInfo() = default;
+      SegmentInfo(uint32_t id, bool forwardIsEnter)
+          : m_segmentId(id), m_forwardIsEnter(forwardIsEnter) {}
+
+      uint32_t m_segmentId = 0;
+      bool m_forwardIsEnter = false;
+    };
+
+    bool operator<(Info const & rhs) const;
+
+    Info(uint64_t osmId, std::vector<SegmentInfo> crossMwmSegments)
+        : m_osmId(osmId), m_crossMwmSegments(std::move(crossMwmSegments)) {}
+
+    explicit Info(uint64_t osmId) : m_osmId(osmId) {}
+
+    static void Dump(Info const & info, std::ofstream & output);
+    static std::set<Info> LoadFromFileToSet(std::string const & path);
+
+    uint64_t m_osmId;
+    std::vector<SegmentInfo> m_crossMwmSegments;
+  };
+
+  // generator::CollectorInterface overrides:
+  // @{
+  std::shared_ptr<CollectorInterface>
+  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const override;
+
+  void CollectFeature(feature::FeatureBuilder const & fb, OsmElement const & element) override;
+  void Save() override;
+
+  void Merge(generator::CollectorInterface const & collector) override;
+  void MergeInto(CrossMwmOsmWaysCollector & collector) const override;
+  // @}
+
+private:
+  std::string m_intermediateDir;
+  std::map<std::string, std::vector<Info>> m_mwmToCrossMwmOsmIds;
+  std::shared_ptr<feature::CountriesFilesAffiliation> m_affiliation;
+};
+}  // namespace generator

--- a/generator/cross_mwm_osm_ways_collector.hpp
+++ b/generator/cross_mwm_osm_ways_collector.hpp
@@ -9,18 +9,14 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 
 namespace generator
 {
 class CrossMwmOsmWaysCollector : public generator::CollectorInterface
 {
 public:
-  explicit CrossMwmOsmWaysCollector(feature::GenerateInfo const & info);
-
-  explicit CrossMwmOsmWaysCollector(std::string intermediateDir,
-                                    std::shared_ptr<feature::CountriesFilesAffiliation> affiliation);
-
-  struct Info
+  struct CrossMwmInfo
   {
     struct SegmentInfo
     {
@@ -32,19 +28,24 @@ public:
       bool m_forwardIsEnter = false;
     };
 
-    bool operator<(Info const & rhs) const;
-
-    Info(uint64_t osmId, std::vector<SegmentInfo> crossMwmSegments)
+    explicit CrossMwmInfo(uint64_t osmId) : m_osmId(osmId) {}
+    CrossMwmInfo(uint64_t osmId, std::vector<SegmentInfo> crossMwmSegments)
         : m_osmId(osmId), m_crossMwmSegments(std::move(crossMwmSegments)) {}
 
-    explicit Info(uint64_t osmId) : m_osmId(osmId) {}
+    bool operator<(CrossMwmInfo const & rhs) const;
 
-    static void Dump(Info const & info, std::ofstream & output);
-    static std::set<Info> LoadFromFileToSet(std::string const & path);
+    static void Dump(CrossMwmInfo const & info, std::ofstream & output);
+    static std::set<CrossMwmInfo> LoadFromFileToSet(std::string const & path);
 
     uint64_t m_osmId;
     std::vector<SegmentInfo> m_crossMwmSegments;
   };
+
+  CrossMwmOsmWaysCollector(std::string intermediateDir,
+                           std::string const & targetDir,
+                           bool haveBordersForWholeWorld);
+  CrossMwmOsmWaysCollector(std::string intermediateDir,
+                           std::shared_ptr<feature::CountriesFilesAffiliation> affiliation);
 
   // generator::CollectorInterface overrides:
   // @{
@@ -60,7 +61,7 @@ public:
 
 private:
   std::string m_intermediateDir;
-  std::map<std::string, std::vector<Info>> m_mwmToCrossMwmOsmIds;
+  std::map<std::string, std::vector<CrossMwmInfo>> m_mwmToCrossMwmOsmIds;
   std::shared_ptr<feature::CountriesFilesAffiliation> m_affiliation;
 };
 }  // namespace generator

--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
   collector_city_area_tests.cpp
   common.cpp
   common.hpp
+  cross_mwm_osm_ways_collector_tests.cpp
   descriptions_section_builder_tests.cpp
   feature_builder_test.cpp
   feature_merger_test.cpp

--- a/generator/generator_tests/cross_mwm_osm_ways_collector_tests.cpp
+++ b/generator/generator_tests/cross_mwm_osm_ways_collector_tests.cpp
@@ -1,0 +1,174 @@
+#include "testing/testing.hpp"
+
+#include "generator/generator_tests/common.hpp"
+
+#include "generator/collector_collection.hpp"
+#include "generator/collector_tag.hpp"
+#include "generator/cross_mwm_osm_ways_collector.hpp"
+
+#include "platform/platform.hpp"
+
+#include "indexer/classificator_loader.cpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/assert.hpp"
+#include "base/macros.hpp"
+#include "base/scope_guard.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace generator;
+using namespace generator_tests;
+
+namespace
+{
+std::string const kTmpDirName = "cross_mwm_ways";
+
+std::vector<std::string> const kHighwayUnclassifiedPath = {"highway", "unclassified"};
+std::vector<std::pair<std::string, std::string>> const kHighwayUnclassified = {
+    {"highway", "unclassified"}};
+
+std::string const kOsmWayIdOne = std::to_string(base::MakeOsmWay(1).GetEncodedId());
+std::string const kOsmWayIdTwo = std::to_string(base::MakeOsmWay(2).GetEncodedId());
+
+class CrossMwmWayCollectorTest
+{
+public:
+  CrossMwmWayCollectorTest()
+  {
+    classificator::Load();
+    m_targetDir = GetPlatform().WritableDir();
+
+    auto const & intermediateDir = base::JoinPath(m_targetDir, kTmpDirName);
+    UNUSED_VALUE(Platform::MkDir(intermediateDir));
+    m_intermediateDir = intermediateDir;
+  }
+
+  ~CrossMwmWayCollectorTest() { Platform::RmDirRecursively(m_intermediateDir); }
+
+  std::shared_ptr<CollectorCollection> InitCollection()
+  {
+    auto collection = std::make_shared<CollectorCollection>();
+    collection->Append(std::make_shared<CrossMwmOsmWaysCollector>(
+        m_intermediateDir, m_targetDir, true /* haveBordersForWholeWorld */));
+    return collection;
+  }
+
+  void Checker()
+  {
+    std::vector<std::string> answersForRomaniaNorth_West = {
+        /* osmId crossMwmSegmentsNumber [crossMwmSegmentsIds forwardIsEnter]+ */
+        kOsmWayIdOne + " 1 1 0 ", kOsmWayIdTwo + " 1 0 0 "};
+
+    std::vector<std::string> answersForHungary_Northern_Great_Plain = {
+        /* osmId crossMwmSegmentsNumber [crossMwmSegmentsIds forwardIsEnter]+ */
+        kOsmWayIdOne + " 1 1 1 ", kOsmWayIdTwo + " 1 0 1 "};
+
+    auto const & pathToRomania =
+        base::JoinPath(m_intermediateDir, CROSS_MWM_OSM_WAYS_DIR, "Romania_North_West");
+    auto const & pathToHungary =
+        base::JoinPath(m_intermediateDir, CROSS_MWM_OSM_WAYS_DIR, "Hungary_Northern Great Plain");
+
+    Check(pathToRomania, std::move(answersForRomaniaNorth_West));
+    Check(pathToHungary, std::move(answersForHungary_Northern_Great_Plain));
+  }
+
+private:
+  static void Check(std::string const & filename, std::vector<std::string> && answers)
+  {
+    std::ifstream stream;
+    stream.exceptions(std::ios::badbit);
+    stream.open(filename);
+    size_t pos = 0;
+    std::string line;
+    while (std::getline(stream, line))
+    {
+      TEST_EQUAL(line, answers[pos], ());
+      pos++;
+    }
+    TEST_EQUAL(pos, answers.size(), ());
+  }
+
+  std::string m_intermediateDir;
+  std::string m_targetDir;
+};
+
+feature::FeatureBuilder CreateFeatureBuilderFromOsmWay(uint64_t osmId,
+                                                       std::vector<m2::PointD> && points)
+{
+  feature::FeatureBuilder fb;
+  fb.AddOsmId(base::MakeOsmWay(osmId));
+  fb.SetLinear();
+  for (auto const & point : points)
+    fb.AddPoint(point);
+
+  fb.AddType(classif().GetTypeByPath(kHighwayUnclassifiedPath));
+  return fb;
+}
+
+void AddOsmWayByPoints(uint64_t osmId, std::vector<m2::PointD> && points,
+                       std::shared_ptr<CollectorInterface> const & collection)
+{
+  auto const & featureBuilder = CreateFeatureBuilderFromOsmWay(osmId, std::move(points));
+  collection->CollectFeature(
+      featureBuilder, MakeOsmElement(osmId, kHighwayUnclassified, OsmElement::EntityType::Way));
+}
+
+void AppendFirstWayFromRomaniaToHungary(std::shared_ptr<CollectorInterface> const & collection)
+{
+  {
+    // In "Romania_North_West", Out of "Hungary_Northern Great Plain"
+    auto const & a = MercatorBounds::FromLatLon({47.48897, 22.22737});
+    // In "Romania_North_West", Out of "Hungary_Northern Great Plain"
+    auto const & b = MercatorBounds::FromLatLon({47.52341, 22.24097});
+    // Out of "Romania_North_West", in "Hungary_Northern Great Plain"
+    auto const & c = MercatorBounds::FromLatLon({47.63462, 22.04041});
+    AddOsmWayByPoints(1 /* osmId */, {a, b, c} /* points */, collection);
+  }
+}
+
+void AppendSecondWayFromRomaniaToHungary(std::shared_ptr<CollectorInterface> const & collection)
+{
+  {
+    // In "Romania_North_West", Out of "Hungary_Northern Great Plain"
+    auto const & a = MercatorBounds::FromLatLon({47.36594, 22.16958});
+    // Out of "Romania_North_West", in "Hungary_Northern Great Plain"
+    auto const & b = MercatorBounds::FromLatLon({47.49356, 21.77018});
+    AddOsmWayByPoints(2 /* osmId */, {a, b} /* points */, collection);
+  }
+}
+
+UNIT_CLASS_TEST(CrossMwmWayCollectorTest, OneCollectorTest)
+{
+  auto collection1 = InitCollection();
+
+  AppendFirstWayFromRomaniaToHungary(collection1);
+  AppendSecondWayFromRomaniaToHungary(collection1);
+
+  collection1->Save();
+
+  Checker();
+}
+
+UNIT_CLASS_TEST(CrossMwmWayCollectorTest, TwoCollectorTest)
+{
+  auto collection1 = InitCollection();
+  AppendFirstWayFromRomaniaToHungary(collection1);
+
+  auto collection2 = collection1->Clone();
+  AppendSecondWayFromRomaniaToHungary(collection2);
+
+  collection1->Finish();
+  collection2->Finish();
+  collection1->Merge(*collection2);
+  collection1->Save();
+
+  Checker();
+}
+}  // namespace

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -483,8 +483,8 @@ int GeneratorToolMain(int argc, char ** argv)
 
       if (FLAGS_make_cross_mwm)
       {
-        routing::BuildRoutingCrossMwmSection(path, datFile, country, *countryParentGetter,
-                                             osmToFeatureFilename,
+        routing::BuildRoutingCrossMwmSection(path, datFile, country, genInfo.m_intermediateDir,
+                                             *countryParentGetter, osmToFeatureFilename,
                                              FLAGS_disable_cross_mwm_progress);
       }
 

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -264,7 +264,7 @@ void CalcCrossMwmTransitions(
 
   auto const & path = base::JoinPath(intermediateDir, CROSS_MWM_OSM_WAYS_DIR, country);
   auto const crossMwmOsmIdWays =
-      generator::CrossMwmOsmWaysCollector::Info::LoadFromFileToSet(path);
+      generator::CrossMwmOsmWaysCollector::CrossMwmInfo::LoadFromFileToSet(path);
 
   ForEachFromDat(mwmFile, [&](FeatureType & f, uint32_t featureId) {
     VehicleMask const roadMask = maskMaker.CalcRoadMask(f);
@@ -276,18 +276,16 @@ void CalcCrossMwmTransitions(
     auto const osmId = it->second;
     CHECK(osmId.GetType() == base::GeoObjectId::Type::ObsoleteOsmWay, ());
 
-    auto const it =
-        crossMwmOsmIdWays.find(generator::CrossMwmOsmWaysCollector::Info(osmId.GetEncodedId()));
+    auto const crossMwmWayInfoIt =
+        crossMwmOsmIdWays.find(generator::CrossMwmOsmWaysCollector::CrossMwmInfo(osmId.GetEncodedId()));
 
-    if (it != crossMwmOsmIdWays.cend())
+    if (crossMwmWayInfoIt != crossMwmOsmIdWays.cend())
     {
       f.ParseGeometry(FeatureType::BEST_GEOMETRY);
-      if (f.GetPointsCount() == 0)
-        return;
 
       VehicleMask const oneWayMask = maskMaker.CalcOneWayMask(f);
 
-      auto const & crossMwmWayInfo = *it;
+      auto const & crossMwmWayInfo = *crossMwmWayInfoIt;
       for (auto const & segmentInfo : crossMwmWayInfo.m_crossMwmSegments)
       {
         uint32_t const segmentId = segmentInfo.m_segmentId;

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -16,7 +16,7 @@ bool BuildRoutingIndex(std::string const & filename, std::string const & country
 /// * all features and feature geometry should be generated
 /// * city_roads section should be generated
 void BuildRoutingCrossMwmSection(std::string const & path, std::string const & mwmFile,
-                                 std::string const & country,
+                                 std::string const & country, std::string const & intermediateDir,
                                  CountryParentNameGetterFn const & countryParentNameGetterFn,
                                  std::string const & osmToFeatureFile,
                                  bool disableCrossMwmProgress);

--- a/generator/translator_country.cpp
+++ b/generator/translator_country.cpp
@@ -98,11 +98,11 @@ TranslatorCountry::TranslatorCountry(std::shared_ptr<FeatureProcessorInterface> 
   collectors->Append(std::make_shared<routing::RestrictionWriter>(info.GetIntermediateFileName(RESTRICTIONS_FILENAME), cache->GetCache()));
   collectors->Append(std::make_shared<routing::RoadAccessWriter>(info.GetIntermediateFileName(ROAD_ACCESS_FILENAME)));
   collectors->Append(std::make_shared<routing::CameraCollector>(info.GetIntermediateFileName(CAMERAS_TO_WAYS_FILENAME)));
+  collectors->Append(std::make_shared<CrossMwmOsmWaysCollector>(info.m_intermediateDir, info.m_targetDir, info.m_haveBordersForWholeWorld));
   if (info.m_genAddresses)
     collectors->Append(std::make_shared<CollectorAddresses>(info.GetAddressesFileName()));
   if (!info.m_idToWikidataFilename.empty())
     collectors->Append(std::make_shared<CollectorTag>(info.m_idToWikidataFilename, "wikidata" /* tagKey */, WikiDataValidator));
-  collectors->Append(std::make_shared<CrossMwmOsmWaysCollector>(info));
   SetCollector(collectors);
 }
 

--- a/generator/translator_country.cpp
+++ b/generator/translator_country.cpp
@@ -6,6 +6,7 @@
 #include "generator/collector_collection.hpp"
 #include "generator/collector_interface.hpp"
 #include "generator/collector_tag.hpp"
+#include "generator/cross_mwm_osm_ways_collector.hpp"
 #include "generator/feature_maker.hpp"
 #include "generator/filter_collection.hpp"
 #include "generator/filter_elements.hpp"
@@ -101,6 +102,7 @@ TranslatorCountry::TranslatorCountry(std::shared_ptr<FeatureProcessorInterface> 
     collectors->Append(std::make_shared<CollectorAddresses>(info.GetAddressesFileName()));
   if (!info.m_idToWikidataFilename.empty())
     collectors->Append(std::make_shared<CollectorTag>(info.m_idToWikidataFilename, "wikidata" /* tagKey */, WikiDataValidator));
+  collectors->Append(std::make_shared<CrossMwmOsmWaysCollector>(info));
   SetCollector(collectors);
 }
 

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -91,7 +91,7 @@ public:
     template <class Sink>
     void Serialize(uint32_t bitsPerCrossMwmId, uint8_t bitsPerMask, Sink & sink) const
     {
-      // TODO (@gmoryes)
+      // TODO (@gmoryes):
       //  We do not use back and front point of segment in code, so we just write
       //  zero to this 128 bits. Need to remove this data from mwm section.
       WriteVarUint<uint64_t>(sink, 0);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -557,7 +557,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
       starter.GetGraph().SetMode(WorldGraphMode::Joints);
       break;
     case VehicleType::Transit:
-      starter.GetGraph().SetMode(WorldGraphMode::Joints);
+      starter.GetGraph().SetMode(WorldGraphMode::NoLeaps);
       break;
     case VehicleType::Car:
       starter.GetGraph().SetMode(AreMwmsNear(starter) ? WorldGraphMode::Joints

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -557,7 +557,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
       starter.GetGraph().SetMode(WorldGraphMode::Joints);
       break;
     case VehicleType::Transit:
-      starter.GetGraph().SetMode(WorldGraphMode::NoLeaps);
+      starter.GetGraph().SetMode(WorldGraphMode::Joints);
       break;
     case VehicleType::Car:
       starter.GetGraph().SetMode(AreMwmsNear(starter) ? WorldGraphMode::Joints

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -99,7 +99,6 @@ void SingleVehicleWorldGraph::GetEdgeList(Segment const & segment, bool isOutgoi
 
   if (m_mode != WorldGraphMode::SingleMwm && m_crossMwmGraph && m_crossMwmGraph->IsTransition(segment, isOutgoing))
     GetTwins(segment, isOutgoing, useRoutingOptions, edges);
-
 }
 
 void SingleVehicleWorldGraph::GetEdgeList(JointSegment const & parentJoint,


### PR DESCRIPTION
Смотреть после этого: https://github.com/mapsme/omim/pull/11624

На этапе раскидывания фичей по mwm мы используем геометрию более высокой точности, после чего, на этапе роутинга, используем геометрию из mwm (там меньше точности)

Из-за этого получалось так, при генерации одна и та же точка вначале принадлежала mwm, а потом нет, из-за этого случился баг на границе:

![image](https://user-images.githubusercontent.com/17534533/64270938-14319e80-cf45-11e9-8384-ccc137eda3ba.png)

В качестве решения: теперь на этапе раскидывания фичей, мы запоминаем переходные фичи и записываем их в файл соответствующей mwm'ки, а на этапе роутинга вычитываем из файла

после PR все лечится:
![image](https://user-images.githubusercontent.com/17534533/64271058-55c24980-cf45-11e9-848c-45acd2d3dacb.png)
