### PR TITLE
[routing] Fixing routing integration tests after map update to 190830.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -203,7 +203,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
         MercatorBounds::FromLatLon(51.09276, 1.11369), {0., 0.},
-        MercatorBounds::FromLatLon(50.93227, 1.82725), 72153.8);
+        MercatorBounds::FromLatLon(50.93227, 1.82725), 64755.6);
   }
 
   UNIT_TEST(RussiaMoscowStartAtTwowayFeatureTest)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -381,7 +381,7 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::ExitHighwayToLeft);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
 }
 
 // Test case: a route goes in Moscow from Varshavskoe shosse (from the city center direction)


### PR DESCRIPTION
После обновления карт (190830) поправил routing integration tests.

==================================
EnglandToFranceRouteLeMansTest
В предыдущей версии карт прокладывали авто маршрут через Ламанш по парому. Теперь по туннелю.
![image](https://user-images.githubusercontent.com/1768114/64326463-afbd2080-cfd2-11e9-8cfc-7fd72b826eda.png)
![image](https://user-images.githubusercontent.com/1768114/64326474-b481d480-cfd2-11e9-92df-d7a78918bd93.png)

==================================
ThailandPhuketNearPrabarameeRoad
20 дней назад дорога, по которой покидаем магистраль потеряла таг link. И поэтому мы вместо ExitHighwayToLeft генерируем TurnSlightLeft. https://www.openstreetmap.org/way/632274299#map=18/7.91015/98.36795
![image](https://user-images.githubusercontent.com/1768114/64326728-29eda500-cfd3-11e9-92cc-a8278330a66d.png)

@gmoryes PTAL

