### PR TITLE
Fixing routing integration and quality test. Getting ready that DataSource::RegisterMap() may return not Success.

### DIFF
--- a/routing/routing_integration_tests/road_graph_tests.cpp
+++ b/routing/routing_integration_tests/road_graph_tests.cpp
@@ -34,10 +34,7 @@ UNIT_TEST(FakeEdgesCombinatorialExplosion)
 
   FrozenDataSource dataSource;
   for (auto const & file : localFiles)
-  {
-    auto const result = dataSource.Register(file);
-    TEST_EQUAL(result.second, MwmSet::RegResult::Success, ());
-  }
+    dataSource.Register(file);
 
   FeaturesRoadGraph graph(dataSource, IRoadGraph::Mode::ObeyOnewayTag,
                           make_shared<CarModelFactory>(CountryParentNameGetterFn()));

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -28,6 +28,7 @@
 #include "geometry/latlon.hpp"
 
 #include "base/math.hpp"
+#include "base/stl_helpers.hpp"
 
 #include "private.h"
 
@@ -71,14 +72,8 @@ shared_ptr<model::FeaturesFetcher> CreateFeaturesFetcher(vector<LocalCountryFile
   featuresFetcher->InitClassificator();
 
   for (LocalCountryFile const & localFile : localFiles)
-  {
-    auto p = featuresFetcher->RegisterMap(localFile);
-    if (p.second != MwmSet::RegResult::Success)
-    {
-      ASSERT(false, ("Can't register", localFile));
-      return nullptr;
-    }
-  }
+    featuresFetcher->RegisterMap(localFile);
+
   return featuresFetcher;
 }
 
@@ -110,7 +105,10 @@ unique_ptr<IndexRouter> CreateVehicleRouter(DataSource & dataSource,
   {
     auto const & countryFile = f.GetCountryFile();
     auto const mwmId = dataSource.GetMwmIdByCountryFile(countryFile);
-    CHECK(mwmId.IsAlive(), ());
+
+    if (!mwmId.IsAlive())
+      continue;
+
     if (countryParentGetter->GetStorageForTesting().IsLeaf(countryFile.GetName()))
       numMwmIds->RegisterFile(countryFile);
   }

--- a/routing/routing_quality/utils.cpp
+++ b/routing/routing_quality/utils.cpp
@@ -83,7 +83,9 @@ private:
       UNUSED_VALUE(m_dataSource.RegisterMap(localFile));
       auto const & countryFile = localFile.GetCountryFile();
       auto const mwmId = m_dataSource.GetMwmIdByCountryFile(countryFile);
-      CHECK(mwmId.IsAlive(), ());
+
+      if (!mwmId.IsAlive())
+        continue;
 
       // Only maps from countries.txt should be used for tests.
       if (m_cpg->GetStorageForTesting().IsLeaf(countryFile.GetName()))


### PR DESCRIPTION
В конце прошлой недели `DataSource::RegisterMap(localFile);` стала возвращать ошибку регистрации для WorldCoasts_obsolete.mwm и других устаревших файлов. Данный PR готовит routing integration tests и routing quality tests к тому, что `DataSource::RegisterMap(localFile);` может вернуть что-то отличное от успеха. В этом случае mwm для которых это происходит не используются.

@gmoryes @tatiana-yan PTAL