### PR TITLE
Added short names for AU and NZ 

### DIFF
--- a/data/synonyms.txt
+++ b/data/synonyms.txt
@@ -72,3 +72,32 @@ Yukon: YT
 Китай: КНР
 People's Republic of China: China, PRC
 China: PRC
+
+Australia: AU
+New South Wales: NSW
+Queensland: QLD
+South Australia: SA
+Tasmania: TAS
+Victoria: VIC
+Western Australia: WA
+Australian Capital Territory: ACT
+Jervis Bay Territory: JBT
+Northern Territory: NT
+
+New Zealand: NZ
+Auckland: AUK
+Bay of Plenty: BOP
+Canterbury: CAN
+Gisborne: GIS
+Hawke's Bay: HKB
+Marlborough: MBH
+Manawatu-Wanganui: MWT
+Nelson: NSN	
+Northland: NTL
+Otago: OTA
+Southland: STL	
+Taranaki: TKI	
+Waikato: WKO		
+Wellington: WGN	
+West Coast: WTC	
+Chatham Islands: CIT


### PR DESCRIPTION
Short names according to ISO:

1. https://en.wikipedia.org/wiki/ISO_3166-2:AU

2. https://en.wikipedia.org/wiki/ISO_3166-2:NZ

All names are present in OSM at the moment. I use Chatham Islands instead Chatham Islands Territory as the name is not present in OSM yet.