### PR TITLE
[search] Move UpdateResults from PreRanker::Finish to Geocoder::GoImpl to avoid uncaught CancelException.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -570,6 +570,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> & infos, bool inViewport)
 
   // Iterates through all alive mwms and performs geocoding.
   ForEachCountry(infos, processCountry);
+  m_preRanker.UpdateResults(true /* lastUpdate */);
 }
 
 void Geocoder::InitBaseContext(BaseContext & ctx)

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -68,9 +68,6 @@ void PreRanker::Init(Params const & params)
 
 void PreRanker::Finish(bool cancelled)
 {
-  if (!cancelled)
-    UpdateResults(true /* lastUpdate */);
-
   m_ranker.Finish(cancelled);
 }
 

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -511,7 +511,7 @@ void Ranker::Init(Params const & params, Geocoder::Params const & geocoderParams
 
 void Ranker::Finish(bool cancelled)
 {
-  // The results have been updated by PreRanker.
+  // The results should be updated by Geocoder before Finish call.
   m_emitter.Finish(cancelled);
 }
 


### PR DESCRIPTION
отдельный вопрос -- надо ли инициализировать геокодер/преранкер/ранкер и вызывать m_geocoder.Finish в процессоре при поиске по букмаркам