### PR TITLE
[routing] Match location only to real segments

### DIFF
--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -156,26 +156,6 @@ FollowedPolyline::UpdatedProjectionInfo FollowedPolyline::UpdateMatchedProjectio
   return UpdatedProjectionInfo{res.iter.IsValid(), res.closerToUnmatched};
 }
 
-Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
-                                                    double predictDistance)
-{
-  ASSERT(m_current.IsValid(), ());
-  ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
-
-  if (predictDistance <= 0.0)
-    return UpdateProjection(posRect);
-
-  Iter res;
-  res = GetBestProjection(posRect, [&](Iter const & it)
-  {
-    return fabs(GetDistanceM(m_current, it) - predictDistance);
-  });
-
-  if (res.IsValid())
-    m_current = res;
-  return res;
-}
-
 Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect)
 {
   ASSERT(m_current.IsValid(), ());

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -253,7 +253,7 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchedProjectio
     if (dp >= minDistUnmatched && dp >= minDist)
       continue;
 
-    if (std::binary_search(m_unmatchedSegmentIndexes.begin(), m_unmatchedSegmentIndexes.end(), it.m_ind))
+    if (!std::binary_search(m_unmatchedSegmentIndexes.begin(), m_unmatchedSegmentIndexes.end(), it.m_ind))
     {
       if (minDist > dp) // overwrite best match for matched segment
       {

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -136,8 +136,8 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetBestMatchedProjection(m
   // right after intermediate point (in next subroute).
   size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
   auto res = GetClosestMatchedProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);
-  if (res.iter.IsValid())
-    return UpdatedProjection{res.iter, res.closerToUnmatched};
+  if (res.m_iter.IsValid() || res.m_closerToUnmatched)
+    return UpdatedProjection{res.m_iter, res.m_closerToUnmatched};
 
   // If a projection to the 3 closest route segments is not found tries to find projection to other route
   // segments of current subroute.
@@ -151,9 +151,9 @@ FollowedPolyline::UpdatedProjectionInfo FollowedPolyline::UpdateMatchedProjectio
 
   auto res = GetBestMatchedProjection(posRect);
 
-  if (res.iter.IsValid())
-    m_current = res.iter;
-  return UpdatedProjectionInfo{res.iter.IsValid(), res.closerToUnmatched};
+  if (res.m_iter.IsValid())
+    m_current = res.m_iter;
+  return UpdatedProjectionInfo{res.m_iter.IsValid(), res.m_closerToUnmatched};
 }
 
 Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect)
@@ -246,6 +246,6 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchedProjectio
         minDistUnmatched = dp;
     }
   }
-  return UpdatedProjection{nearestIter /* Iter */, minDistUnmatched < minDist /* closerToUnmatched */};
+  return UpdatedProjection{nearestIter /* m_iter */, minDistUnmatched < minDist /* m_closerToUnmatched */};
 }
 }  //  namespace routing

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -135,7 +135,7 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetBestMatchedProjection(m
   // enough to |posRect| center. If |m_current| is right before intermediate point we can get |closestIter|
   // right after intermediate point (in next subroute).
   size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
-  auto res = GetClosestMatchedProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);
+  auto const res = GetClosestMatchedProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);
   if (res.m_iter.IsValid() || res.m_closerToUnmatched)
     return UpdatedProjection{res.m_iter, res.m_closerToUnmatched};
 
@@ -246,6 +246,6 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchedProjectio
         minDistUnmatched = dp;
     }
   }
-  return UpdatedProjection{nearestIter /* m_iter */, minDistUnmatched < minDist /* m_closerToUnmatched */};
+  return UpdatedProjection{nearestIter, minDistUnmatched < minDist /* m_closerToUnmatched */};
 }
 }  //  namespace routing

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -149,7 +149,7 @@ FollowedPolyline::UpdatedProjectionInfo FollowedPolyline::UpdateMatchedProjectio
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
 
-  m2::PointD const currPos = posRect.Center();
+  m2::PointD const & currPos = posRect.Center();
   auto res = GetBestMatchedProjection(posRect);
 
   if (res.iter.IsValid())

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -128,9 +128,7 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
   return GetClosestProjectionInInterval(posRect, distFn, hoppingBorderIdx, m_nextCheckpointIndex);
 }
 
-  template <class DistanceFn>
-  pair<Iter, bool> FollowedPolyline::GetBestMatchedProjection(m2::RectD const & posRect,
-                                                                   DistanceFn const & distFn) const
+  pair<Iter, bool> FollowedPolyline::GetBestMatchedProjection(m2::RectD const & posRect) const
   {
     CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
     // At first trying to find a projection to two closest route segments of route which is close
@@ -139,14 +137,13 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
     size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
     Iter closestIter;
     bool nearestIsFake = false;
-    tie(closestIter, nearestIsFake) = GetClosestMatchedProjectionInInterval(posRect, distFn, m_current.m_ind,
-                                                                                 hoppingBorderIdx);
+    tie(closestIter, nearestIsFake) = GetClosestMatchedProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);
     if (closestIter.IsValid())
       return make_pair(closestIter, nearestIsFake);
 
     // If a projection to the 3 closest route segments is not found tries to find projection to other route
     // segments of current subroute.
-    return GetClosestMatchedProjectionInInterval(posRect, distFn, hoppingBorderIdx, m_nextCheckpointIndex);
+    return GetClosestMatchedProjectionInInterval(posRect, hoppingBorderIdx, m_nextCheckpointIndex);
   }
 
 pair<bool, bool> FollowedPolyline::UpdateMatchedProjection(m2::RectD const & posRect)
@@ -157,9 +154,7 @@ pair<bool, bool> FollowedPolyline::UpdateMatchedProjection(m2::RectD const & pos
   Iter iter;
   bool nearestIsFake = false;
   m2::PointD const currPos = posRect.Center();
-  tie(iter, nearestIsFake) = GetBestMatchedProjection(posRect, [&](Iter const & it) {
-    return MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
-  });
+  tie(iter, nearestIsFake) = GetBestMatchedProjection(posRect);
 
   if (iter.IsValid())
     m_current = iter;

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -1,5 +1,7 @@
 #include "followed_polyline.hpp"
 
+#include "base/assert.hpp"
+
 #include <algorithm>
 #include <limits>
 
@@ -113,7 +115,7 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
 {
   CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
   // At first trying to find a projection to two closest route segments of route which is close
-  // enough to |posRect| center. If m_current is right before intermediate point we can get closestIter
+  // enough to |posRect| center. If |m_current| is right before intermediate point we can get |closestIter|
   // right after intermediate point (in next subroute).
   size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 2);
   Iter const closestIter =
@@ -127,27 +129,27 @@ Iter FollowedPolyline::GetBestProjection(m2::RectD const & posRect,
 }
 
   template <class DistanceFn>
-  std::pair<Iter, bool> FollowedPolyline::GetBestMatchedProjection(m2::RectD const & posRect,
+  pair<Iter, bool> FollowedPolyline::GetBestMatchedProjection(m2::RectD const & posRect,
                                                                    DistanceFn const & distFn) const
   {
     CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
     // At first trying to find a projection to two closest route segments of route which is close
-    // enough to |posRect| center. If m_current is right before intermediate point we can get closestIter
+    // enough to |posRect| center. If |m_current| is right before intermediate point we can get |closestIter|
     // right after intermediate point (in next subroute).
     size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
     Iter closestIter;
     bool nearestIsFake = false;
-    std::tie(closestIter, nearestIsFake) = GetClosestMatchedProjectionInInterval(posRect, distFn, m_current.m_ind,
+    tie(closestIter, nearestIsFake) = GetClosestMatchedProjectionInInterval(posRect, distFn, m_current.m_ind,
                                                                                  hoppingBorderIdx);
     if (closestIter.IsValid())
-      return std::make_pair(closestIter, nearestIsFake);
+      return make_pair(closestIter, nearestIsFake);
 
     // If a projection to the 3 closest route segments is not found tries to find projection to other route
     // segments of current subroute.
     return GetClosestMatchedProjectionInInterval(posRect, distFn, hoppingBorderIdx, m_nextCheckpointIndex);
   }
 
-std::pair<bool, bool> FollowedPolyline::UpdateMatchedProjection(m2::RectD const & posRect)
+pair<bool, bool> FollowedPolyline::UpdateMatchedProjection(m2::RectD const & posRect)
 {
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
@@ -155,13 +157,13 @@ std::pair<bool, bool> FollowedPolyline::UpdateMatchedProjection(m2::RectD const 
   Iter iter;
   bool nearestIsFake = false;
   m2::PointD const currPos = posRect.Center();
-  std::tie(iter, nearestIsFake) = GetBestMatchedProjection(posRect, [&](Iter const &it) {
+  tie(iter, nearestIsFake) = GetBestMatchedProjection(posRect, [&](Iter const & it) {
     return MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
   });
 
   if (iter.IsValid())
     m_current = iter;
-  return std::make_pair(iter.IsValid(), nearestIsFake);
+  return make_pair(iter.IsValid(), nearestIsFake);
 }
 
 Iter FollowedPolyline::UpdateProjectionByPrediction(m2::RectD const & posRect,
@@ -201,9 +203,10 @@ Iter FollowedPolyline::UpdateProjection(m2::RectD const & posRect)
   return res;
 }
 
-void FollowedPolyline::SetUnmatchedSegmentIndexes(std::vector<size_t> const & unmatchedSegmentIndexes)
+void FollowedPolyline::SetUnmatchedSegmentIndexes(vector<size_t> && unmatchedSegmentIndexes)
 {
-  m_unmatchedSegmentIndexes = unmatchedSegmentIndexes;
+  ASSERT(is_sorted(unmatchedSegmentIndexes.cbegin(), unmatchedSegmentIndexes.cend()), ());
+  m_unmatchedSegmentIndexes = move(unmatchedSegmentIndexes);
 }
 
 double FollowedPolyline::GetDistFromCurPointToRoutePointMerc() const

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -149,7 +149,7 @@ FollowedPolyline::UpdatedProjectionInfo FollowedPolyline::UpdateMatchedProjectio
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
 
-  auto res = GetBestMatchedProjection(posRect);
+  auto const res = GetBestMatchedProjection(posRect);
 
   if (res.m_iter.IsValid())
     m_current = res.m_iter;

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -234,7 +234,7 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchingProjecti
 
     if (!std::binary_search(m_unmatchingSegmentIndexes.begin(), m_unmatchingSegmentIndexes.end(), it.m_ind))
     {
-      if (minDist > dp) // overwrite best match for matched segment
+      if (minDist > dp) // Overwrites the best matching for matched segment.
       {
         minDist = dp;
         nearestIter = it;

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -149,7 +149,6 @@ FollowedPolyline::UpdatedProjectionInfo FollowedPolyline::UpdateMatchedProjectio
   ASSERT(m_current.IsValid(), ());
   ASSERT_LESS(m_current.m_ind, m_poly.GetSize() - 1, ());
 
-  m2::PointD const & currPos = posRect.Center();
   auto res = GetBestMatchedProjection(posRect);
 
   if (res.iter.IsValid())
@@ -267,6 +266,6 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchedProjectio
         minDistUnmatched = dp;
     }
   }
-  return UpdatedProjection{nearestIter, minDistUnmatched < minDist};
+  return UpdatedProjection{nearestIter /* Iter */, minDistUnmatched < minDist /* closerToUnmatched */};
 }
 }  //  namespace routing

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -218,11 +218,11 @@ FollowedPolyline::UpdatedProjection FollowedPolyline::GetClosestMatchingProjecti
   double minDist = std::numeric_limits<double>::max();
   double minDistUnmatching = minDist;
 
-  m2::PointD const & currPos = posRect.Center();
+  m2::PointD const currPos = posRect.Center();
 
   for (size_t i = startIdx; i < endIdx; ++i)
   {
-    m2::PointD const & pt = m_segProj[i].ClosestPointTo(currPos);
+    m2::PointD const pt = m_segProj[i].ClosestPointTo(currPos);
 
     if (!posRect.IsPointInside(pt))
       continue;

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -74,24 +74,24 @@ public:
     // Iterator to the projection point.
     Iter m_iter;
     // True if nearest point is on an unmatched segment.
-    bool m_closerToUnmatched;
+    bool m_closerToUnmatching;
   };
 
   struct UpdatedProjectionInfo
   {
     bool m_updatedProjection;
-    bool m_closerToUnmatched;
+    bool m_closerToUnmatching;
   };
 
   const Iter GetCurrentIter() const { return m_current; }
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
 
-  /// \brief Sets indexes of all unmatched segments on route.
-  void SetUnmatchedSegmentIndexes(std::vector<size_t> && unmatchedSegmentIndexes);
+  /// \brief Sets indexes of all unmatching segments on route.
+  void SetUnmatchingSegmentIndexes(std::vector<size_t> && unmatchingSegmentIndexes);
 
   /// \brief Updates projection to the closest matched segment if it's possible.
-  UpdatedProjectionInfo UpdateMatchedProjection(m2::RectD const & posRect);
+  UpdatedProjectionInfo UpdateMatchingProjection(m2::RectD const & posRect);
 
   Iter UpdateProjection(m2::RectD const & posRect);
 
@@ -134,7 +134,7 @@ public:
     return res;
   }
 
-UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
+UpdatedProjection GetClosestMatchingProjectionInInterval(m2::RectD const & posRect,
                                                         size_t startIdx, size_t endIdx) const;
 
 private:
@@ -145,13 +145,13 @@ private:
   template <typename DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
-  UpdatedProjection GetBestMatchedProjection(m2::RectD const & posRect) const;
+  UpdatedProjection GetBestMatchingProjection(m2::RectD const & posRect) const;
 
   void Update();
 
   m2::PolylineD m_poly;
-  /// Indexes of all unmatched segments on route.
-  std::vector<size_t> m_unmatchedSegmentIndexes;
+  /// Indexes of all unmatching segments on route.
+  std::vector<size_t> m_unmatchingSegmentIndexes;
 
   /// Iterator with the current position. Position sets with UpdateProjection methods.
   Iter m_current;

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -138,8 +138,8 @@ public:
     return res;
   }
 
-  UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
-                                                              size_t startIdx, size_t endIdx) const;
+UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
+                                                            size_t startIdx, size_t endIdx) const;
 
 private:
   /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -93,7 +93,7 @@ public:
   void SetUnmatchedSegmentIndexes(std::vector<size_t> && unmatchedSegmentIndexes);
 
   /// \brief Updates projection to the closest matched segment if it's possible.
-  UpdatedProjectionInfo  UpdateMatchedProjection(m2::RectD const & posRect);
+  UpdatedProjectionInfo UpdateMatchedProjection(m2::RectD const & posRect);
 
   Iter UpdateProjection(m2::RectD const & posRect);
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -80,7 +80,7 @@ public:
   struct UpdatedProjectionInfo
   {
     bool updatedProjection;
-    bool closerToFake;
+    bool closerToUnmatched;
   };
 
   const Iter GetCurrentIter() const { return m_current; }

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -72,15 +72,15 @@ public:
   struct UpdatedProjection
   {
     // Iterator to the projection point.
-    Iter iter;
+    Iter m_iter;
     // True if nearest point is on an unmatched segment.
-    bool closerToUnmatched;
+    bool m_closerToUnmatched;
   };
 
   struct UpdatedProjectionInfo
   {
-    bool updatedProjection;
-    bool closerToUnmatched;
+    bool m_updatedProjection;
+    bool m_closerToUnmatched;
   };
 
   const Iter GetCurrentIter() const { return m_current; }
@@ -115,11 +115,9 @@ public:
     Iter res;
     double minDist = std::numeric_limits<double>::max();
 
-    m2::PointD const & currPos = posRect.Center();
-
     for (size_t i = startIdx; i < endIdx; ++i)
     {
-      m2::PointD const & pt = m_segProj[i].ClosestPointTo(currPos);
+      m2::PointD const & pt = m_segProj[i].ClosestPointTo(posRect.Center());
 
       if (!posRect.IsPointInside(pt))
         continue;

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <limits>
-#include <utility>
 #include <vector>
 
 namespace routing
@@ -70,6 +69,20 @@ public:
     bool IsValid() const { return m_ind != kInvalidIndex; }
   };
 
+  struct UpdatedProjection
+  {
+    // Iterator to the projection point.
+    Iter iter;
+    // True if nearest point is on an unmatched segment.
+    bool closerToUnmatched;
+  };
+
+  struct UpdatedProjectionInfo
+  {
+    bool updatedProjection;
+    bool closerToFake;
+  };
+
   const Iter GetCurrentIter() const { return m_current; }
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
@@ -79,8 +92,8 @@ public:
   /// \brief Sets indexes of all unmatched segments on route.
   void SetUnmatchedSegmentIndexes(std::vector<size_t> && unmatchedSegmentIndexes);
 
-  /// \brief Updates projection to the closest real segment if it's possible.
-  std::pair<bool, bool>  UpdateMatchedProjection(m2::RectD const & posRect);
+  /// \brief Updates projection to the closest matched segment if it's possible.
+  UpdatedProjectionInfo  UpdateMatchedProjection(m2::RectD const & posRect);
 
   Iter UpdateProjection(m2::RectD const & posRect);
 
@@ -125,8 +138,7 @@ public:
     return res;
   }
 
-  /// \returns pair of iterator (projection point) and bool (true if nearest point is on an unmatched segment).
-  std::pair<Iter, bool> GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
+  UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
                                                               size_t startIdx, size_t endIdx) const
   {
     CHECK_LESS_OR_EQUAL(endIdx, m_segProj.size(), ());
@@ -163,7 +175,7 @@ public:
           minDistUnmatched = dp;
       }
     }
-    return std::make_pair(nearestIter, minDistUnmatched < minDist);
+    return UpdatedProjection{nearestIter, minDistUnmatched < minDist};
   }
 
 private:
@@ -174,7 +186,7 @@ private:
   template <typename DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
-  std::pair<Iter, bool> GetBestMatchedProjection(m2::RectD const & posRect) const;
+  UpdatedProjection GetBestMatchedProjection(m2::RectD const & posRect) const;
 
   void Update();
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -139,44 +139,7 @@ public:
   }
 
   UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
-                                                              size_t startIdx, size_t endIdx) const
-  {
-    CHECK_LESS_OR_EQUAL(endIdx, m_segProj.size(), ());
-    CHECK_LESS_OR_EQUAL(startIdx, endIdx, ());
-    Iter nearestIter;
-    double minDist = std::numeric_limits<double>::max();
-    double minDistUnmatched = minDist;
-
-    m2::PointD const & currPos = posRect.Center();
-
-    for (size_t i = startIdx; i < endIdx; ++i)
-    {
-      m2::PointD const & pt = m_segProj[i].ClosestPointTo(currPos);
-
-      if (!posRect.IsPointInside(pt))
-        continue;
-
-      Iter it(pt, i);
-      double const dp = MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
-      if (dp >= minDistUnmatched && dp >= minDist)
-        continue;
-
-      if (std::binary_search(m_unmatchedSegmentIndexes.begin(), m_unmatchedSegmentIndexes.end(), it.m_ind))
-      {
-        if (minDist > dp) // overwrite best match for matched segment
-        {
-          minDist = dp;
-          nearestIter = it;
-        }
-      }
-      else
-      {
-        if (minDistUnmatched > dp)
-          minDistUnmatched = dp;
-      }
-    }
-    return UpdatedProjection{nearestIter, minDistUnmatched < minDist};
-  }
+                                                              size_t startIdx, size_t endIdx) const;
 
 private:
   /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -135,7 +135,7 @@ public:
   }
 
 UpdatedProjection GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
-                                                            size_t startIdx, size_t endIdx) const;
+                                                        size_t startIdx, size_t endIdx) const;
 
 private:
   /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -87,8 +87,6 @@ public:
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
 
-  Iter UpdateProjectionByPrediction(m2::RectD const & posRect, double predictDistance);
-
   /// \brief Sets indexes of all unmatched segments on route.
   void SetUnmatchedSegmentIndexes(std::vector<size_t> && unmatchedSegmentIndexes);
 

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -126,8 +126,7 @@ public:
   }
 
   /// \returns pair of iterator (projection point) and bool (true if nearest point is on an unmatched segment).
-  template <typename DistanceFn>
-  std::pair<Iter, bool> GetClosestMatchedProjectionInInterval(m2::RectD const & posRect, DistanceFn const & distFn,
+  std::pair<Iter, bool> GetClosestMatchedProjectionInInterval(m2::RectD const & posRect,
                                                               size_t startIdx, size_t endIdx) const
   {
     CHECK_LESS_OR_EQUAL(endIdx, m_segProj.size(), ());
@@ -146,7 +145,7 @@ public:
         continue;
 
       Iter it(pt, i);
-      double const dp = distFn(it);
+      double const dp = MercatorBounds::DistanceOnEarth(it.m_pt, currPos);
       if (dp >= minDistUnmatched && dp >= minDist)
         continue;
 
@@ -160,7 +159,7 @@ public:
       }
       else
       {
-        if (minDistUnmatched > dp) // overwrite best match for unmatched segment
+        if (minDistUnmatched > dp)
           minDistUnmatched = dp;
       }
     }
@@ -175,9 +174,7 @@ private:
   template <typename DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
-  template <class DistanceFn>
-  std::pair<Iter, bool> GetBestMatchedProjection(m2::RectD const & posRect,
-                                                 DistanceFn const & distFn) const;
+  std::pair<Iter, bool> GetBestMatchedProjection(m2::RectD const & posRect) const;
 
   void Update();
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1352,6 +1352,7 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
     if (!segment.IsRealSegment())
       starter.ConvertToReal(segment);
   }
+  route.SetFakeSegmentsOnPolyline();
 
   vector<platform::CountryFile> speedCamProhibited;
   FillSpeedCamProhibitedMwms(segments, speedCamProhibited);

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -255,7 +255,7 @@ Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & inf
   m2::RectD const rect = MercatorBounds::MetersToXY(
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-  auto resUpdate = m_poly.UpdateMatchedProjection(rect);
+  auto const resUpdate = m_poly.UpdateMatchedProjection(rect);
   return MovedIteratorInfo{resUpdate.m_updatedProjection, resUpdate.m_closerToUnmatched};
 }
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -240,13 +240,13 @@ void Route::GetCurrentDirectionPoint(m2::PointD & pt) const
 
 void Route::SetFakeSegmentsOnPolyline()
 {
-  vector<size_t> fakeSegmentIndexes{};
-  auto const & routeSegments = GetRouteSegments();
-  for (size_t i = 0; i < routeSegments.size(); ++i)
+  vector<size_t> fakeSegmentIndexes;
+  for (size_t i = 0; i < m_routeSegments.size(); ++i)
   {
-    if (!routeSegments[i].GetSegment().IsRealSegment())
+    if (!m_routeSegments[i].GetSegment().IsRealSegment())
       fakeSegmentIndexes.push_back(i);
   }
+
   m_poly.SetUnmatchedSegmentIndexes(move(fakeSegmentIndexes));
 }
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -256,7 +256,7 @@ Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & inf
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
   auto resUpdate = m_poly.UpdateMatchedProjection(rect);
-  return MovedIteratorInfo{resUpdate.updatedProjection, resUpdate.closerToUnmatched};
+  return MovedIteratorInfo{resUpdate.m_updatedProjection, resUpdate.m_closerToUnmatched};
 }
 
 double Route::GetPolySegAngle(size_t ind) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -238,28 +238,19 @@ void Route::GetCurrentDirectionPoint(m2::PointD & pt) const
   m_poly.GetCurrentDirectionPoint(pt, kOnEndToleranceM);
 }
 
-bool Route::MoveIterator(location::GpsInfo const & info)
-{
-  m2::RectD const rect = MercatorBounds::MetersToXY(
-        info.m_longitude, info.m_latitude,
-        max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-  FollowedPolyline::Iter const res = m_poly.UpdateProjectionByPrediction(rect, -1.0 /* predictDistance */);
-  return res.IsValid();
-}
-
 void Route::SetFakeSegmentsOnPolyline()
 {
-  std::vector<size_t> fakeSegmentIndexes{};
-  auto const & segs = GetRouteSegments();
-  for(size_t i = 0; i < segs.size(); ++i)
+  vector<size_t> fakeSegmentIndexes{};
+  auto const & routeSegments = GetRouteSegments();
+  for (size_t i = 0; i < routeSegments.size(); ++i)
   {
-    if(!segs[i].GetSegment().IsRealSegment())
+    if (!routeSegments[i].GetSegment().IsRealSegment())
       fakeSegmentIndexes.push_back(i);
   }
-  m_poly.SetUnmatchedSegmentIndexes(fakeSegmentIndexes);
+  m_poly.SetUnmatchedSegmentIndexes(move(fakeSegmentIndexes));
 }
 
-std::pair<bool, bool> Route::MoveIteratorToReal(location::GpsInfo const & info)
+pair<bool, bool> Route::MoveIteratorToReal(location::GpsInfo const & info)
 {
   m2::RectD const rect = MercatorBounds::MetersToXY(
       info.m_longitude, info.m_latitude,
@@ -405,7 +396,7 @@ bool Route::CrossMwmsPartlyProhibitedForSpeedCams() const
   return !m_speedCamPartlyProhibitedMwms.empty();
 }
 
-std::vector<platform::CountryFile> const & Route::GetMwmsPartlyProhibitedForSpeedCams() const
+vector<platform::CountryFile> const & Route::GetMwmsPartlyProhibitedForSpeedCams() const
 {
   return m_speedCamPartlyProhibitedMwms;
 }

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -250,13 +250,13 @@ void Route::SetFakeSegmentsOnPolyline()
   m_poly.SetUnmatchedSegmentIndexes(move(fakeSegmentIndexes));
 }
 
-pair<bool, bool> Route::MoveIteratorToReal(location::GpsInfo const & info)
+Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & info)
 {
   m2::RectD const rect = MercatorBounds::MetersToXY(
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-
-  return m_poly.UpdateMatchedProjection(rect);
+  auto resUpdate = m_poly.UpdateMatchedProjection(rect);
+  return MovedIteratorInfo{resUpdate.updatedProjection, resUpdate.closerToFake};
 }
 
 double Route::GetPolySegAngle(size_t ind) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -256,7 +256,7 @@ Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & inf
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
   auto resUpdate = m_poly.UpdateMatchedProjection(rect);
-  return MovedIteratorInfo{resUpdate.updatedProjection, resUpdate.closerToFake};
+  return MovedIteratorInfo{resUpdate.updatedProjection, resUpdate.closerToUnmatched};
 }
 
 double Route::GetPolySegAngle(size_t ind) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -247,7 +247,7 @@ void Route::SetFakeSegmentsOnPolyline()
       fakeSegmentIndexes.push_back(i);
   }
 
-  m_poly.SetUnmatchedSegmentIndexes(move(fakeSegmentIndexes));
+  m_poly.SetUnmatchingSegmentIndexes(move(fakeSegmentIndexes));
 }
 
 Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & info)
@@ -255,8 +255,8 @@ Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & inf
   m2::RectD const rect = MercatorBounds::MetersToXY(
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-  auto const resUpdate = m_poly.UpdateMatchedProjection(rect);
-  return MovedIteratorInfo{resUpdate.m_updatedProjection, resUpdate.m_closerToUnmatched};
+  auto const resUpdate = m_poly.UpdateMatchingProjection(rect);
+  return MovedIteratorInfo{resUpdate.m_updatedProjection, resUpdate.m_closerToUnmatching};
 }
 
 double Route::GetPolySegAngle(size_t ind) const

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -247,6 +247,27 @@ bool Route::MoveIterator(location::GpsInfo const & info)
   return res.IsValid();
 }
 
+void Route::SetFakeSegmentsOnPolyline()
+{
+  std::vector<size_t> fakeSegmentIndexes{};
+  auto const & segs = GetRouteSegments();
+  for(size_t i = 0; i < segs.size(); ++i)
+  {
+    if(!segs[i].GetSegment().IsRealSegment())
+      fakeSegmentIndexes.push_back(i);
+  }
+  m_poly.SetUnmatchedSegmentIndexes(fakeSegmentIndexes);
+}
+
+std::pair<bool, bool> Route::MoveIteratorToReal(location::GpsInfo const & info)
+{
+  m2::RectD const rect = MercatorBounds::MetersToXY(
+      info.m_longitude, info.m_latitude,
+      max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
+
+  return m_poly.UpdateMatchedProjection(rect);
+}
+
 double Route::GetPolySegAngle(size_t ind) const
 {
   size_t const polySz = m_poly.GetPolyline().GetSize();

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace location
@@ -194,9 +195,9 @@ public:
 
   struct MovedIteratorInfo
   {
-    // Indicator of setting the iterator to one of real segments
+    // Indicator of setting the iterator to one of real segments.
     bool m_movedIterator;
-    // Indicator of the presence of the fake segment which is the nearest to the given point
+    // Indicator of the presence of the fake segment which is the nearest to the given point.
     bool m_closerToFake;
   };
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -256,7 +256,7 @@ public:
       if (s.GetJunction().GetAltitude() == feature::kInvalidAltitude)
       {
         m_haveAltitudes = false;
-        return;
+        break;
       }
     }
   }
@@ -327,6 +327,10 @@ public:
   /// @return true  If position was updated successfully (projection within gps error radius).
   bool MoveIterator(location::GpsInfo const & info);
 
+  /// @return pair of vals: first = true if position was updated successfully to real segment,
+  /// second = true if position is closer to the fake segment
+  std::pair<bool, bool> MoveIteratorToReal(location::GpsInfo const & info);
+
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 
   /// Add country name if we have no country filename to make route
@@ -392,7 +396,9 @@ public:
 
 private:
   friend std::string DebugPrint(Route const & r);
-
+public:
+  void SetFakeSegmentsOnPolyline();
+private:
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurn(size_t segIdx, turns::TurnItem & turn) const;
   size_t ConvertPointIdxToSegmentIdx(size_t pointIdx) const;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -256,7 +256,7 @@ public:
       if (s.GetJunction().GetAltitude() == feature::kInvalidAltitude)
       {
         m_haveAltitudes = false;
-        break;
+        return;
       }
     }
   }
@@ -324,10 +324,7 @@ public:
 
   void GetCurrentDirectionPoint(m2::PointD & pt) const;
 
-  /// @return true  If position was updated successfully (projection within gps error radius).
-  bool MoveIterator(location::GpsInfo const & info);
-
-  /// @return pair of vals: first = true if position was updated successfully to real segment,
+  /// \returns pair of vals: first = true if position was updated successfully to real segment,
   /// second = true if position is closer to the fake segment
   std::pair<bool, bool> MoveIteratorToReal(location::GpsInfo const & info);
 
@@ -396,8 +393,10 @@ public:
 
 private:
   friend std::string DebugPrint(Route const & r);
+
 public:
   void SetFakeSegmentsOnPolyline();
+
 private:
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurn(size_t segIdx, turns::TurnItem & turn) const;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -24,7 +24,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace location
@@ -193,6 +192,14 @@ public:
     size_t m_endSegmentIdx = 0;
   };
 
+  struct MovedIteratorInfo
+  {
+    // Indicator of setting the iterator to one of real segments
+    bool movedIterator;
+    // Indicator of the presence of the fake segment which is the nearest to the given point
+    bool closerToFake;
+  };
+
   /// \brief For every subroute some attributes are kept in the following structure.
   struct SubrouteSettings final
   {
@@ -326,7 +333,7 @@ public:
 
   /// \returns pair of vals: first = true if position was updated successfully to real segment,
   /// second = true if position is closer to the fake segment
-  std::pair<bool, bool> MoveIteratorToReal(location::GpsInfo const & info);
+  MovedIteratorInfo MoveIteratorToReal(location::GpsInfo const & info);
 
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -398,13 +398,11 @@ public:
   /// about speed cameras.
   std::vector<platform::CountryFile> const & GetMwmsPartlyProhibitedForSpeedCams() const;
 
-private:
-  friend std::string DebugPrint(Route const & r);
-
-public:
   void SetFakeSegmentsOnPolyline();
 
 private:
+  friend std::string DebugPrint(Route const & r);
+
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurn(size_t segIdx, turns::TurnItem & turn) const;
   size_t ConvertPointIdxToSegmentIdx(size_t pointIdx) const;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -330,9 +330,7 @@ public:
   bool GetNextTurns(std::vector<turns::TurnItemDist> & turns) const;
 
   void GetCurrentDirectionPoint(m2::PointD & pt) const;
-
-  /// \returns pair of vals: first = true if position was updated successfully to real segment,
-  /// second = true if position is closer to the fake segment
+  
   MovedIteratorInfo MoveIteratorToReal(location::GpsInfo const & info);
 
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -195,9 +195,9 @@ public:
   struct MovedIteratorInfo
   {
     // Indicator of setting the iterator to one of real segments
-    bool movedIterator;
+    bool m_movedIterator;
     // Indicator of the presence of the fake segment which is the nearest to the given point
-    bool closerToFake;
+    bool m_closerToFake;
   };
 
   /// \brief For every subroute some attributes are kept in the following structure.

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -320,25 +320,15 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
       TEST(!CheckBeepSignal(routingSession), ());
     }
 
-    // Intermediate Move for correct calculating of passedDistance.
-    {
-      double const speedKmPH = 40.0;
-      ChangePosition({55.76559, 37.59016}, speedKmPH, routingSession);
-      TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
-      TEST(!CheckVoiceNotification(routingSession), ());
-      TEST(!CheckBeepSignal(routingSession), ());
-    }
-
-    // No exceed speed limit in beep zone, but we did VoiceNotification earlier,
+    // No exceed speed limit in beep zone, we did no VoiceNotification,
     // so now we make BeedSignal.
     {
       double const speedKmPH = 40.0;
-      ChangePosition({55.76527, 37.58970}, speedKmPH, routingSession);
+      ChangePosition({55.76559, 37.59016}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());
     }
-
   }
 }
 

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -333,7 +333,7 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
     // so now we make BeedSignal.
     {
       double const speedKmPH = 40.0;
-      ChangePosition({55.765732, 37.590305}, speedKmPH, routingSession);
+      ChangePosition({55.76573, 37.59030}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -323,7 +323,7 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
     // Intermediate Move for correct calculating of passedDistance.
     {
       double const speedKmPH = 20.0;
-      ChangePosition({ 55.76559, 37.59016}, speedKmPH, routingSession);
+      ChangePosition({55.76559, 37.59016}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
@@ -333,7 +333,7 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
     // so now we make BeedSignal.
     {
       double const speedKmPH = 40.0;
-      ChangePosition({ 55.765732, 37.590305}, speedKmPH, routingSession);
+      ChangePosition({55.765732, 37.590305}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -320,15 +320,25 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
       TEST(!CheckBeepSignal(routingSession), ());
     }
 
-    // No exceed speed limit in beep zone, we did no VoiceNotification,
+    // Intermediate Move for correct calculating of passedDistance.
+    {
+      double const speedKmPH = 20.0;
+      ChangePosition({ 55.76559, 37.59016}, speedKmPH, routingSession);
+      TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
+      TEST(!CheckVoiceNotification(routingSession), ());
+      TEST(!CheckBeepSignal(routingSession), ());
+    }
+
+    // No exceed speed limit in beep zone, but we did VoiceNotification earlier,
     // so now we make BeedSignal.
     {
       double const speedKmPH = 40.0;
-      ChangePosition({55.76559, 37.59016}, speedKmPH, routingSession);
+      ChangePosition({ 55.765732, 37.590305}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());
     }
+
   }
 }
 

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -17,7 +17,7 @@ void MoveRoute(Route & route, ms::LatLon const & coords)
   info.m_verticalAccuracy = 0.01;
   info.m_longitude = coords.m_lon;
   info.m_latitude = coords.m_lat;
-  route.MoveIterator(info);
+  route.MoveIteratorToReal(info);
 }
 
 UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -15,7 +15,6 @@
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
-#include <tuple>
 
 using namespace location;
 using namespace std;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -291,11 +291,10 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   ASSERT(m_route->IsValid(), ());
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
-  bool movedIterator = false;
-  bool closerToFake = false;
-  std::tie(movedIterator, closerToFake) = m_route->MoveIteratorToReal(info);
 
-  if (movedIterator)
+  auto iteratorAction = m_route->MoveIteratorToReal(info);
+
+  if (iteratorAction.movedIterator)
   {
     m_moveAwayCounter = 0;
     m_lastDistance = 0.0;
@@ -325,7 +324,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     return m_state;
   }
 
-  if(!closerToFake)
+  if(!iteratorAction.closerToFake)
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -15,7 +15,6 @@
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
-
 using namespace location;
 using namespace std;
 using namespace traffic;
@@ -291,7 +290,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
 
-  auto iteratorAction = m_route->MoveIteratorToReal(info);
+  auto const iteratorAction = m_route->MoveIteratorToReal(info);
 
   if (iteratorAction.m_movedIterator)
   {
@@ -323,7 +322,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     return m_state;
   }
 
-  if(!iteratorAction.m_closerToFake)
+  if (!iteratorAction.m_closerToFake)
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -293,7 +293,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
   auto iteratorAction = m_route->MoveIteratorToReal(info);
 
-  if (iteratorAction.movedIterator)
+  if (iteratorAction.m_movedIterator)
   {
     m_moveAwayCounter = 0;
     m_lastDistance = 0.0;
@@ -323,7 +323,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     return m_state;
   }
 
-  if(!iteratorAction.closerToFake)
+  if(!iteratorAction.m_closerToFake)
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -15,6 +15,8 @@
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
+#include <tuple>
+
 using namespace location;
 using namespace std;
 using namespace traffic;
@@ -289,7 +291,8 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   ASSERT(m_route->IsValid(), ());
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
-  bool movedIterator, closerToFake;
+  bool movedIterator = false;
+  bool closerToFake = false;
   std::tie(movedIterator, closerToFake) = m_route->MoveIteratorToReal(info);
 
   if (movedIterator)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -290,7 +290,6 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
   bool movedIterator, closerToFake;
-  m_route->SetFakeSegmentsOnPolyline();
   std::tie(movedIterator, closerToFake) = m_route->MoveIteratorToReal(info);
 
   if (movedIterator)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -289,8 +289,11 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   ASSERT(m_route->IsValid(), ());
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
+  bool movedIterator, closerToFake;
+  m_route->SetFakeSegmentsOnPolyline();
+  std::tie(movedIterator, closerToFake) = m_route->MoveIteratorToReal(info);
 
-  if (m_route->MoveIterator(info))
+  if (movedIterator)
   {
     m_moveAwayCounter = 0;
     m_lastDistance = 0.0;
@@ -316,8 +319,11 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
     if (m_userCurrentPositionValid)
       m_lastGoodPosition = m_userCurrentPosition;
+
+    return m_state;
   }
-  else
+
+  if(!closerToFake)
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).

--- a/routing/routing_tests/followed_polyline_test.cpp
+++ b/routing/routing_tests/followed_polyline_test.cpp
@@ -68,23 +68,6 @@ UNIT_TEST(FollowedPolylineFollowingTestByProjection)
   TEST_EQUAL(polyline.GetCurrentIter().m_pt, m2::PointD(5, 0), ());
 }
 
-UNIT_TEST(FollowedPolylineFollowingTestByPrediction)
-{
-  m2::PolylineD testPolyline({{0, 0}, {0.003, 0}, {0.003, 1}});
-  FollowedPolyline polyline(testPolyline.Begin(), testPolyline.End());
-  TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
-  polyline.UpdateProjection(MercatorBounds::RectByCenterXYAndSizeInMeters({0, 0}, 2));
-  TEST_EQUAL(polyline.GetCurrentIter().m_ind, 0, ());
-  TEST_EQUAL(polyline.GetCurrentIter().m_pt, m2::PointD(0, 0), ());
-  // Near 0 distances between lons and lats are almost equal.
-  double dist = MercatorBounds::DistanceOnEarth({0, 0}, {0.003, 0}) * 2;
-  polyline.UpdateProjectionByPrediction(
-    MercatorBounds::RectByCenterXYAndSizeInMeters({0.002, 0.003}, 20000), dist);
-  TEST_EQUAL(polyline.GetCurrentIter().m_ind, 1, ());
-  TEST_LESS_OR_EQUAL(MercatorBounds::DistanceOnEarth(polyline.GetCurrentIter().m_pt,
-                                                     m2::PointD(0.003, 0.003)), 0.1, ());
-}
-
 UNIT_TEST(FollowedPolylineDistanceCalculationTest)
 {
   // Test full length case.

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -108,19 +108,19 @@ UNIT_TEST(DistanceToCurrentTurnTest)
                             ());
   TEST_EQUAL(turn, kTestTurns[0], ());
 
-  route.MoveIterator(GetGps(0, 0.5));
+  route.MoveIteratorToReal(GetGps(0, 0.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             MercatorBounds::DistanceOnEarth({0, 0.5}, kTestGeometry[1]), 0.1), ());
   TEST_EQUAL(turn, kTestTurns[0], ());
 
-  route.MoveIterator(GetGps(1, 1.5));
+  route.MoveIteratorToReal(GetGps(1, 1.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             MercatorBounds::DistanceOnEarth({1, 1.5}, kTestGeometry[4]), 0.1), ());
   TEST_EQUAL(turn, kTestTurns[2], ());
 
-  route.MoveIterator(GetGps(1, 2.5));
+  route.MoveIteratorToReal(GetGps(1, 2.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             MercatorBounds::DistanceOnEarth({1, 2.5}, kTestGeometry[4]), 0.1), ());
@@ -144,13 +144,13 @@ UNIT_TEST(NextTurnTest)
   TEST_EQUAL(turn, kTestTurns[0], ());
   TEST_EQUAL(nextTurn, kTestTurns[1], ());
 
-  route.MoveIterator(GetGps(0.5, 1));
+  route.MoveIteratorToReal(GetGps(0.5, 1));
   route.GetCurrentTurn(distance, turn);
   route.GetNextTurn(nextDistance, nextTurn);
   TEST_EQUAL(turn, kTestTurns[1], ());
   TEST_EQUAL(nextTurn, kTestTurns[2], ());
 
-  route.MoveIterator(GetGps(1, 1.5));
+  route.MoveIteratorToReal(GetGps(1, 1.5));
   route.GetCurrentTurn(distance, turn);
   route.GetNextTurn(nextDistance, nextTurn);
   TEST_EQUAL(turn, kTestTurns[2], ());
@@ -181,7 +181,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 0.;
     double const y = 0.5;
-    route.MoveIterator(GetGps(x, y));
+    route.MoveIteratorToReal(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
     double const firstSegLenM = MercatorBounds::DistanceOnEarth({x, y}, kTestGeometry[1]);
@@ -194,7 +194,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 1.;
     double const y = 2.5;
-    route.MoveIterator(GetGps(x, y));
+    route.MoveIteratorToReal(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
     double const firstSegLenM = MercatorBounds::DistanceOnEarth({x, y}, kTestGeometry[4]);
@@ -204,7 +204,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 1.;
     double const y = 3.5;
-    route.MoveIterator(GetGps(x, y));
+    route.MoveIteratorToReal(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
   }
@@ -238,7 +238,7 @@ UNIT_TEST(SelfIntersectedRouteMatchingTest)
                                  location::GpsInfo const & expectedMatchingPos,
                                  size_t expectedIndexInRoute) {
     location::RouteMatchingInfo routeMatchingInfo;
-    route.MoveIterator(pos);
+    route.MoveIteratorToReal(pos);
     location::GpsInfo matchedPos = pos;
     route.MatchLocationToRoute(matchedPos, routeMatchingInfo);
     TEST_LESS(MercatorBounds::DistanceOnEarth(
@@ -307,7 +307,7 @@ UNIT_TEST(RouteNameTest)
   location::GpsInfo info;
   info.m_longitude = 1.0;
   info.m_latitude = 2.0;
-  route.MoveIterator(info);
+  route.MoveIteratorToReal(info);
   route.GetCurrentStreetName(name);
-  TEST_EQUAL(name, "Street3", ());
+  TEST_EQUAL(name, "Street2", ());
 }


### PR DESCRIPTION
MAPSME-11809. Fix of 90-degree camera rotation on re-routing.
Screenshot of buggy behaviour while re-routing:

![routing_bug_screen](https://user-images.githubusercontent.com/54934129/65052555-4eeafc00-d973-11e9-9598-1641446b3d57.jpg)
