### PR TITLE
[indexer] Removed the UPDATE event type from MwmSet.

### DIFF
--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -302,6 +302,11 @@ void Editor::ClearAllLocalEdits()
   Invalidate();
 }
 
+void Editor::OnMapRegistered(platform::LocalCountryFile const & localFile)
+{
+  LoadEdits();
+}
+
 void Editor::OnMapDeregistered(platform::LocalCountryFile const & localFile)
 {
   // Can be called on non-main-thread in case of simultaneous uploading process.

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -122,12 +122,8 @@ public:
   /// Resets editor to initial state: no any edits or created/deleted features.
   void ClearAllLocalEdits();
 
-  void OnMapUpdated(platform::LocalCountryFile const &,
-                    platform::LocalCountryFile const &) override
-  {
-    LoadEdits();
-  }
-
+  // MwmSet::Observer overrides:
+  void OnMapRegistered(platform::LocalCountryFile const & localFile) override;
   void OnMapDeregistered(platform::LocalCountryFile const & localFile) override;
 
   using FeatureIndexFunctor = std::function<void(uint32_t)>;

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -124,7 +124,6 @@ public:
 
   // MwmSet::Observer overrides:
   void OnMapRegistered(platform::LocalCountryFile const & localFile) override;
-  void OnMapDeregistered(platform::LocalCountryFile const & localFile) override;
 
   using FeatureIndexFunctor = std::function<void(uint32_t)>;
   void ForEachCreatedFeature(MwmSet::MwmId const & id, FeatureIndexFunctor const & f,

--- a/indexer/indexer_tests/data_source_test.cpp
+++ b/indexer/indexer_tests/data_source_test.cpp
@@ -38,12 +38,6 @@ public:
     AddEvent(m_expected, MwmSet::Event::TYPE_REGISTERED, localFile);
   }
 
-  void ExpectUpdated(platform::LocalCountryFile const & newFile,
-                     platform::LocalCountryFile const & oldFile)
-  {
-    AddEvent(m_expected, MwmSet::Event::TYPE_UPDATED, newFile, oldFile);
-  }
-
   void ExpectDeregistered(platform::LocalCountryFile const & localFile)
   {
     AddEvent(m_expected, MwmSet::Event::TYPE_DEREGISTERED, localFile);
@@ -67,12 +61,6 @@ public:
   void OnMapRegistered(platform::LocalCountryFile const & localFile) override
   {
     AddEvent(m_actual, MwmSet::Event::TYPE_REGISTERED, localFile);
-  }
-
-  void OnMapUpdated(platform::LocalCountryFile const & newFile,
-                    platform::LocalCountryFile const & oldFile) override
-  {
-    AddEvent(m_actual, MwmSet::Event::TYPE_UPDATED, newFile, oldFile);
   }
 
   void OnMapDeregistered(platform::LocalCountryFile const & localFile) override
@@ -107,7 +95,7 @@ UNIT_CLASS_TEST(DataSourceTest, StatusNotifications)
   CountryFile const country("minsk-pass");
 
   // These two classes point to the same file, but will be considered
-  // by Index as distinct files because versions are artificially set
+  // by DataSource as distinct files because versions are artificially set
   // to different numbers.
   LocalCountryFile const file1(mapsDir, country, 1 /* version */);
   LocalCountryFile const file2(mapsDir, country, 2 /* version */);
@@ -147,7 +135,8 @@ UNIT_CLASS_TEST(DataSourceTest, StatusNotifications)
     TEST(id2.IsAlive(), ());
     TEST_NOT_EQUAL(id1, id2, ());
 
-    ExpectUpdated(file2, file1);
+    ExpectDeregistered(file1);
+    ExpectRegistered(file2);
     TEST(CheckExpectations(), ());
   }
 

--- a/indexer/mwm_set.hpp
+++ b/indexer/mwm_set.hpp
@@ -184,7 +184,6 @@ public:
     {
       TYPE_REGISTERED,
       TYPE_DEREGISTERED,
-      TYPE_UPDATED,
     };
 
     Event() = default;
@@ -248,18 +247,11 @@ public:
   public:
     virtual ~Observer() = default;
 
-    // Called when a map is registered for a first time and can be
-    // used.
-    virtual void OnMapRegistered(platform::LocalCountryFile const & /*localFile*/) {}
-
-    // Called when a map is updated to a newer version. Feel free to
-    // treat it as combined OnMapRegistered(newFile) +
-    // OnMapDeregistered(oldFile).
-    virtual void OnMapUpdated(platform::LocalCountryFile const & /*newFile*/,
-                              platform::LocalCountryFile const & /*oldFile*/) {}
+    // Called when a map is registered for the first time and can be used.
+    virtual void OnMapRegistered(platform::LocalCountryFile const & /* localFile */) {}
 
     // Called when a map is deregistered and can no longer be used.
-    virtual void OnMapDeregistered(platform::LocalCountryFile const & /*localFile*/) {}
+    virtual void OnMapDeregistered(platform::LocalCountryFile const & /* localFile */) {}
   };
 
   /// Registers a new map.

--- a/map/features_fetcher.cpp
+++ b/map/features_fetcher.cpp
@@ -78,17 +78,8 @@ m2::RectD FeaturesFetcher::GetWorldRect() const
   return m_rect;
 }
 
-void FeaturesFetcher::OnMapUpdated(platform::LocalCountryFile const & newFile,
-                                   platform::LocalCountryFile const & oldFile)
-{
-  if (m_onMapDeregistered)
-    m_onMapDeregistered(oldFile);
-}
-
 void FeaturesFetcher::OnMapDeregistered(platform::LocalCountryFile const & localFile)
 {
   if (m_onMapDeregistered)
-  {
     m_onMapDeregistered(localFile);
-  }
 }

--- a/map/features_fetcher.hpp
+++ b/map/features_fetcher.hpp
@@ -75,8 +75,6 @@ public:
   m2::RectD GetWorldRect() const;
 
   // MwmSet::Observer overrides:
-  void OnMapUpdated(platform::LocalCountryFile const & newFile,
-                    platform::LocalCountryFile const & oldFile) override;
   void OnMapDeregistered(platform::LocalCountryFile const & localFile) override;
 
 private:

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -720,13 +720,13 @@ bool Framework::OnCountryFileDelete(storage::CountryId const & countryId,
 
 void Framework::OnMapDeregistered(platform::LocalCountryFile const & localFile)
 {
-  m_localAdsManager.OnMwmDeregistered(localFile);
-  m_transitManager.OnMwmDeregistered(localFile);
-  m_trafficManager.OnMwmDeregistered(localFile);
-  m_popularityLoader.OnMwmDeregistered(localFile);
-
   auto action = [this, localFile]
   {
+    m_localAdsManager.OnMwmDeregistered(localFile);
+    m_transitManager.OnMwmDeregistered(localFile);
+    m_trafficManager.OnMwmDeregistered(localFile);
+    m_popularityLoader.OnMwmDeregistered(localFile);
+
     m_storage.DeleteCustomCountryVersion(localFile);
   };
 

--- a/storage/diff_scheme/diff_manager.cpp
+++ b/storage/diff_scheme/diff_manager.cpp
@@ -95,7 +95,7 @@ void Manager::ApplyDiff(ApplyDiffParams && p, base::Cancellable const & cancella
         result = DiffApplicationResult::Failed;
       }
 
-      base::DeleteFileX(diffApplyingInProgressPath);
+      Platform::RemoveFileIfExists(diffApplyingInProgressPath);
 
       if (result != DiffApplicationResult::Ok)
         Platform::RemoveFileIfExists(newMwmPath);


### PR DESCRIPTION
Fixes a couple of crashes related to map updates.

When an activity such as processing a search request or building a route was being performed during an update, there used to be a possibility of the map file to be deleted by an OnMapUpdated call even if its corresponding MwmValue had been properly locked.