### PR TITLE
[generator] Some rework of ClustersFinder.

### DIFF
--- a/generator/generator_tests/cluster_finder_tests.cpp
+++ b/generator/generator_tests/cluster_finder_tests.cpp
@@ -65,13 +65,7 @@ auto const getRadiusMFunction = [](NamedPoint const & p) {
 };
 
 auto const isSameFunction = [](NamedPoint const & left, NamedPoint const & right) {
-  if (left.m_name != right.m_name)
-    return false;
-
-  if (left.m_type != right.m_type)
-    return false;
-
-  return MercatorBounds::DistanceOnEarth(left.m_point, right.m_point)  < getRadiusMFunction(left);
+  return left.m_name == right.m_name && left.m_type == right.m_type;
 };
 
 void Sort(std::vector<std::vector<NamedPoint>> & data)
@@ -94,16 +88,6 @@ void Test(std::vector<std::vector<NamedPoint>> & result, std::vector<std::vector
   Sort(result);
   Sort(expected);
   TEST_EQUAL(result, expected, ());
-}
-
-template <typename T, template<typename, typename> class Container, typename Alloc = std::allocator<T>>
-std::vector<std::vector<T>> GetClusters(
-    Container<T, Alloc> && container,
-    typename ClustersFinder<T, Container, Alloc>::RadiusFunc const & radiusFunc,
-    typename ClustersFinder<T, Container, Alloc>::IsSameFunc const & isSameFunc)
-{
-  return ClustersFinder<T, Container, Alloc>(std::forward<Container<T, Alloc>>(container),
-                                             radiusFunc, isSameFunc).Find();
 }
 
 UNIT_TEST(ClustersFinder_Empty)

--- a/generator/place_processor.cpp
+++ b/generator/place_processor.cpp
@@ -66,16 +66,7 @@ bool IsTheSamePlace(T const & left, T const & right)
   auto const & localityChecker = ftypes::IsLocalityChecker::Instance();
   auto const localityL = localityChecker.GetType(GetPlaceType(left));
   auto const localityR = localityChecker.GetType(GetPlaceType(right));
-  if (localityL != localityR)
-    return false;
-
-  auto const & rectL = left.GetLimitRect();
-  auto const & rectR = right.GetLimitRect();
-  if (rectL.IsIntersect(rectR))
-    return true;
-
-  auto const dist = MercatorBounds::DistanceOnEarth(left.GetKeyPoint(), right.GetKeyPoint());
-  return dist <= GetRadiusM(localityL);
+  return localityL == localityR;
 }
 
 std::vector<std::vector<FeaturePlace>> FindClusters(std::vector<FeaturePlace> && places)
@@ -85,9 +76,7 @@ std::vector<std::vector<FeaturePlace>> FindClusters(std::vector<FeaturePlace> &&
     auto const locality = localityChecker.GetType(GetPlaceType(fp.GetFb()));
     return GetRadiusM(locality);
   };
-  ClustersFinder<FeaturePlace, std::vector> finder(std::move(places), func,
-                                                   IsTheSamePlace<FeaturePlace>);
-  return finder.Find();
+  return GetClusters(std::move(places), func, IsTheSamePlace<FeaturePlace>);
 }
 }  // namespace
 

--- a/generator/place_processor.hpp
+++ b/generator/place_processor.hpp
@@ -68,7 +68,7 @@ private:
       queue.pop();
       auto const queryBbox = GetBboxFor(current);
       m_tree.ForEachInRect(queryBbox, [&](auto const & candidate) {
-        if (unviewed.count(candidate) == 0 || !m_isSameFunc(*current, *candidate))
+        if (unviewed.count(candidate) == 0 || !m_isSameFunc(*it, *candidate))
           return;
 
         unviewed.erase(candidate);
@@ -96,6 +96,16 @@ private:
   IsSameFunc m_isSameFunc;
   m4::Tree<ConstIterator, TraitsDef> m_tree;
 };
+
+template <typename T, template<typename, typename> class Container, typename Alloc = std::allocator<T>>
+std::vector<std::vector<T>> GetClusters(
+    Container<T, Alloc> && container,
+    typename ClustersFinder<T, Container, Alloc>::RadiusFunc const & radiusFunc,
+    typename ClustersFinder<T, Container, Alloc>::IsSameFunc const & isSameFunc)
+{
+  return ClustersFinder<T, Container, Alloc>(std::forward<Container<T, Alloc>>(container),
+                                             radiusFunc, isSameFunc).Find();
+}
 
 bool NeedProcessPlace(feature::FeatureBuilder const & fb);
 


### PR DESCRIPTION
Это очень важное улучшение!
Вот кейс когда старый код бы работал плохо:
m_isSameFunc пророверяет имена, и если расстояние <= 1, то считет имена равными.
```
obj1(Имя1) obj2(Имя11) obj3(Имя111)
```
В старой реализации это бы отнеслось к одному кластеру

m_isSameFunc не должна делать проверку на близость, за это отвечает квадродерево