### PR TITLE
[platform] Correct threads finishing. Previous implementation was wro…

### DIFF
--- a/base/thread_pool_delayed.cpp
+++ b/base/thread_pool_delayed.cpp
@@ -157,7 +157,7 @@ void ThreadPool::ShutdownAndJoin()
   m_threads.clear();
 }
 
-bool ThreadPool::IsShoutedDown()
+bool ThreadPool::IsShutDown()
 {
   lock_guard<mutex> lk(m_mu);
   return m_shutdown;

--- a/base/thread_pool_delayed.cpp
+++ b/base/thread_pool_delayed.cpp
@@ -156,6 +156,12 @@ void ThreadPool::ShutdownAndJoin()
   }
   m_threads.clear();
 }
+
+bool ThreadPool::IsShoutedDown()
+{
+  lock_guard<mutex> lk(m_mu);
+  return m_shutdown;
+}
 }  // namespace delayed
 }  // namespace thread_pool
 }  // namespace base

--- a/base/thread_pool_delayed.hpp
+++ b/base/thread_pool_delayed.hpp
@@ -69,6 +69,7 @@ public:
 
   // Sends a signal to the thread to shut down and waits for completion.
   void ShutdownAndJoin();
+  bool IsShoutedDown();
 
   static TimePoint Now() { return Clock::now(); }
 

--- a/base/thread_pool_delayed.hpp
+++ b/base/thread_pool_delayed.hpp
@@ -69,7 +69,7 @@ public:
 
   // Sends a signal to the thread to shut down and waits for completion.
   void ShutdownAndJoin();
-  bool IsShoutedDown();
+  bool IsShutDown();
 
   static TimePoint Now() { return Clock::now(); }
 

--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -329,21 +329,23 @@ unsigned Platform::CpuCores() const
 void Platform::ShutdownThreads()
 {
   ASSERT(m_networkThread && m_fileThread && m_backgroundThread, ());
+  ASSERT(!m_networkThread->IsShoutedDown(), ());
+  ASSERT(!m_fileThread->IsShoutedDown(), ());
+  ASSERT(!m_backgroundThread->IsShoutedDown(), ());
 
   m_batteryTracker.UnsubscribeAll();
 
   m_networkThread->ShutdownAndJoin();
   m_fileThread->ShutdownAndJoin();
   m_backgroundThread->ShutdownAndJoin();
-
-  m_networkThread.reset();
-  m_fileThread.reset();
-  m_backgroundThread.reset();
 }
 
 void Platform::RunThreads()
 {
-  ASSERT(!m_networkThread && !m_fileThread && !m_backgroundThread, ());
+  ASSERT(!m_networkThread || (m_networkThread && m_networkThread->IsShoutedDown()), ());
+  ASSERT(!m_fileThread || (m_fileThread && m_fileThread->IsShoutedDown()), ());
+  ASSERT(!m_backgroundThread || (m_backgroundThread && m_backgroundThread->IsShoutedDown()), ());
+
   m_networkThread = make_unique<base::thread_pool::delayed::ThreadPool>();
   m_fileThread = make_unique<base::thread_pool::delayed::ThreadPool>();
   m_backgroundThread = make_unique<base::thread_pool::delayed::ThreadPool>();

--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -329,9 +329,9 @@ unsigned Platform::CpuCores() const
 void Platform::ShutdownThreads()
 {
   ASSERT(m_networkThread && m_fileThread && m_backgroundThread, ());
-  ASSERT(!m_networkThread->IsShoutedDown(), ());
-  ASSERT(!m_fileThread->IsShoutedDown(), ());
-  ASSERT(!m_backgroundThread->IsShoutedDown(), ());
+  ASSERT(!m_networkThread->IsShutDown(), ());
+  ASSERT(!m_fileThread->IsShutDown(), ());
+  ASSERT(!m_backgroundThread->IsShutDown(), ());
 
   m_batteryTracker.UnsubscribeAll();
 
@@ -342,9 +342,9 @@ void Platform::ShutdownThreads()
 
 void Platform::RunThreads()
 {
-  ASSERT(!m_networkThread || (m_networkThread && m_networkThread->IsShoutedDown()), ());
-  ASSERT(!m_fileThread || (m_fileThread && m_fileThread->IsShoutedDown()), ());
-  ASSERT(!m_backgroundThread || (m_backgroundThread && m_backgroundThread->IsShoutedDown()), ());
+  ASSERT(!m_networkThread || (m_networkThread && m_networkThread->IsShutDown()), ());
+  ASSERT(!m_fileThread || (m_fileThread && m_fileThread->IsShutDown()), ());
+  ASSERT(!m_backgroundThread || (m_backgroundThread && m_backgroundThread->IsShutDown()), ());
 
   m_networkThread = make_unique<base::thread_pool::delayed::ThreadPool>();
   m_fileThread = make_unique<base::thread_pool::delayed::ThreadPool>();

--- a/platform/platform_tests/platform_test.cpp
+++ b/platform/platform_tests/platform_test.cpp
@@ -286,3 +286,26 @@ UNIT_TEST(MkDirRecursively)
 
   CHECK(Platform::RmDirRecursively(workPath), ());
 }
+
+UNIT_TEST(Platform_ThreadRunner)
+{
+  {
+    Platform::ThreadRunner m_runner;
+
+    bool called = false;
+    GetPlatform().RunTask(Platform::Thread::File, [&called]
+    {
+      called = true;
+      testing::Notify();
+    });
+    testing::Wait();
+
+    TEST(called, ());
+  }
+
+  GetPlatform().RunTask(Platform::Thread::File, []
+  {
+    TEST(false, ("The task must not be posted when thread runner is dead. "
+                 "But app must not be crashed. It is normal behaviour during destruction"));
+  });
+}


### PR DESCRIPTION
…ng because of it was not support task posting from one async thread to another one.