### PR TITLE
[c++] fix warnings from clang 11.0

### DIFF
--- a/map/traffic_manager.hpp
+++ b/map/traffic_manager.hpp
@@ -58,7 +58,6 @@ public:
 
   TrafficManager(GetMwmsByRectFn const & getMwmsByRectFn, size_t maxCacheSizeBytes,
                  traffic::TrafficObserver & observer);
-  TrafficManager(TrafficManager && /* trafficManager */) = default;
   ~TrafficManager();
 
   void Teardown();
@@ -89,7 +88,7 @@ private:
   struct CacheEntry
   {
     CacheEntry();
-    CacheEntry(std::chrono::time_point<std::chrono::steady_clock> const & requestTime);
+    explicit CacheEntry(std::chrono::time_point<std::chrono::steady_clock> const & requestTime);
 
     bool m_isLoaded;
     size_t m_dataSize;

--- a/routing/segmented_route.hpp
+++ b/routing/segmented_route.hpp
@@ -22,9 +22,9 @@ public:
     m2::PointD const & GetPoint() const { return m_point; }
 
   private:
-    Segment const m_segment;
+    Segment m_segment;
     // The front point of segment
-    m2::PointD const m_point = m2::PointD::Zero();
+    m2::PointD m_point = m2::PointD::Zero();
   };
 
   SegmentedRoute(m2::PointD const & start, m2::PointD const & finish,

--- a/search/locality_scorer.hpp
+++ b/search/locality_scorer.hpp
@@ -42,7 +42,6 @@ public:
 private:
   struct ExLocality
   {
-    ExLocality() = default;
     ExLocality(Locality const & locality, double queryNorm, uint8_t rank);
 
     uint32_t GetId() const { return m_locality.m_featureId; }


### PR DESCRIPTION
В новом clang подъехали варнинги на тему того, что написал `SomeClass() = default`, в то время как, какое-нибудь поле не может быть создано по дефолту, из-за этого дефолтный конструктор на самом деле удален неявно получается