### PR TITLE
[search] Optimize postcodes index.

### DIFF
--- a/geometry/mercator.cpp
+++ b/geometry/mercator.cpp
@@ -56,3 +56,19 @@ double MercatorBounds::AreaOnEarth(m2::RectD const & rect)
   return MercatorBounds::AreaOnEarth(rect.LeftTop(), rect.LeftBottom(), rect.RightBottom()) +
          MercatorBounds::AreaOnEarth(rect.LeftTop(), rect.RightTop(), rect.RightBottom());
 }
+
+m2::PointD MercatorBounds::UKCoordsToXY(double eastingM, double northingM)
+{
+  // The map projection used on Ordnance Survey Great Britain maps is known as the National Grid.
+  // It's UTM-like coordinate system.
+  // The Transverse Mercator eastings and northings axes are given a ‘false origin’ just south west
+  // of the Scilly Isles to ensure that all coordinates in Britain are positive. The false origin is
+  // 400 km west and 100 km north of the ‘true origin’ on the central meridian at 49°N 2°W (OSGB36)
+  // and approx. 49°N 2°0′5″ W (WGS 84). For further details see:
+  //   https://www.ordnancesurvey.co.uk/documents/resources/guide-coordinate-systems-great-britain.pdf
+  //   https://en.wikipedia.org/wiki/Ordnance_Survey_National_Grid
+  auto static kNationalGridOriginX = MercatorBounds::LonToX(-7.5571597);
+  auto static kNationalGridOriginY = MercatorBounds::LatToY(49.7668072);
+
+  return GetSmPoint({kNationalGridOriginX, kNationalGridOriginY}, eastingM, northingM);
+}

--- a/geometry/mercator.hpp
+++ b/geometry/mercator.hpp
@@ -120,4 +120,7 @@ struct MercatorBounds
   static double AreaOnEarth(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   /// Calculates area on Earth in m².
   static double AreaOnEarth(m2::RectD const & mercatorRect);
+
+  // Converts UK easting and northing measured from UK National Grid origin to mercator.
+  static m2::PointD UKCoordsToXY(double eastingM, double northingM);
 };

--- a/search/postcode_points.hpp
+++ b/search/postcode_points.hpp
@@ -57,9 +57,12 @@ public:
   void Get(strings::UniString const & postcode, std::vector<m2::PointD> & points) const;
 
 private:
+  void Get(strings::UniString const & postcode, bool recursive,
+           std::vector<m2::PointD> & points) const;
+
   Header m_header;
   std::unique_ptr<CentersTable> m_points;
-  std::unique_ptr<trie::Iterator<ValueList<Uint64IndexValue>>> m_root;
+  std::unique_ptr<trie::Iterator<SingleUint64Value>> m_root;
   std::unique_ptr<Reader> m_trieSubReader;
   std::unique_ptr<Reader> m_pointsSubReader;
 };

--- a/search/search_integration_tests/postcode_points_tests.cpp
+++ b/search/search_integration_tests/postcode_points_tests.cpp
@@ -46,14 +46,16 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
   auto const postcodesRelativePath = base::JoinPath(writableDir, testFile);
 
   // <outward>,<inward>,<easting>,<northing>,<WGS84 lat>,<WGS84 long>,<2+6 NGR>,<grid>,<sources>
-  ScopedFile const osmScopedFile(testFile,
-                                 "aa11, 0, dummy, dummy, 0.0, 0.0, dummy, dummy, dummy\n"
-                                 "aa11, 1, dummy, dummy, 0.1, 0.1, dummy, dummy, dummy\n"
-                                 "aa11, 2, dummy, dummy, 0.2, 0.2, dummy, dummy, dummy\n");
+  ScopedFile const osmScopedFile(
+      testFile,
+      "aa11 0, dummy, 1000, 1000, dummy, dummy, dummy, dummy, dummy, dummy\n"
+      "aa11 1, dummy, 2000, 2000, dummy, dummy, dummy, dummy, dummy, dummy\n"
+      "aa11 2, dummy, 3000, 3000, dummy, dummy, dummy, dummy, dummy, dummy\n");
 
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
   infoGetter->AddCountry(
-      storage::CountryDef(countryName, m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0))));
+      storage::CountryDef(countryName, m2::RectD(MercatorBounds::UKCoordsToXY(999, 999),
+                                                 MercatorBounds::UKCoordsToXY(30001, 30001))));
 
   auto const id = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
     builder.SetPostcodesData(postcodesRelativePath, infoGetter);
@@ -69,28 +71,40 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 0"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], m2::PointD(0.0, 0.0), kMwmPointAccuracy), ());
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(1000, 1000),
+                              kMwmPointAccuracy),
+         ());
   }
   {
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 1"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], m2::PointD(0.1, 0.1), kMwmPointAccuracy), ());
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(2000, 2000),
+                              kMwmPointAccuracy),
+         ());
   }
   {
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 2"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], m2::PointD(0.2, 0.2), kMwmPointAccuracy), ());
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(3000, 3000),
+                              kMwmPointAccuracy),
+         ());
   }
   {
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11"), points);
     TEST_EQUAL(points.size(), 3, ());
     sort(points.begin(), points.end());
-    TEST(base::AlmostEqualAbs(points[0], m2::PointD(0.0, 0.0), kMwmPointAccuracy), ());
-    TEST(base::AlmostEqualAbs(points[1], m2::PointD(0.1, 0.1), kMwmPointAccuracy), ());
-    TEST(base::AlmostEqualAbs(points[2], m2::PointD(0.2, 0.2), kMwmPointAccuracy), ());
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(1000, 1000),
+                              kMwmPointAccuracy),
+         ());
+    TEST(base::AlmostEqualAbs(points[1], MercatorBounds::UKCoordsToXY(2000, 2000),
+                              kMwmPointAccuracy),
+         ());
+    TEST(base::AlmostEqualAbs(points[2], MercatorBounds::UKCoordsToXY(3000, 3000),
+                              kMwmPointAccuracy),
+         ());
   }
 }
 
@@ -104,13 +118,15 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchPostcode)
   auto const postcodesRelativePath = base::JoinPath(writableDir, testFile);
 
   // <outward>,<inward>,<easting>,<northing>,<WGS84 lat>,<WGS84 long>,<2+6 NGR>,<grid>,<sources>
-  ScopedFile const osmScopedFile(testFile,
-                                 "BA6, 7JP, dummy, dummy, 0.4, 0.4, dummy, dummy, dummy\n"
-                                 "BA6, 8JP, dummy, dummy, 0.6, 0.6, dummy, dummy, dummy\n");
+  ScopedFile const osmScopedFile(
+      testFile,
+      "BA6 7JP, dummy, 4000, 4000, dummy, dummy, dummy, dummy, dummy, dummy\n"
+      "BA6 8JP, dummy, 6000, 6000, dummy, dummy, dummy, dummy, dummy, dummy\n");
 
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
   infoGetter->AddCountry(
-      storage::CountryDef(countryName, m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 1.0))));
+      storage::CountryDef(countryName, m2::RectD(MercatorBounds::UKCoordsToXY(3000, 3000),
+                                                 MercatorBounds::UKCoordsToXY(7000, 7000))));
 
   auto const id = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
     builder.SetPostcodesData(postcodesRelativePath, infoGetter);
@@ -129,12 +145,12 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchPostcode)
     TEST(base::AlmostEqualAbs(expected, actual, kMwmPointAccuracy), ());
   };
 
-  test("BA6 7JP", MercatorBounds::FromLatLon(0.4, 0.4));
-  test("BA6 7JP ", MercatorBounds::FromLatLon(0.4, 0.4));
-  test("BA6 8JP", MercatorBounds::FromLatLon(0.6, 0.6));
-  test("BA6 8JP ", MercatorBounds::FromLatLon(0.6, 0.6));
+  test("BA6 7JP", MercatorBounds::UKCoordsToXY(4000, 4000));
+  test("BA6 7JP ", MercatorBounds::UKCoordsToXY(4000, 4000));
+  test("BA6 8JP", MercatorBounds::UKCoordsToXY(6000, 6000));
+  test("BA6 8JP ", MercatorBounds::UKCoordsToXY(6000, 6000));
   // Search should return center of all inward codes for outward query.
-  test("BA6", MercatorBounds::FromLatLon(0.5, 0.5));
-  test("BA6 ", MercatorBounds::FromLatLon(0.5, 0.5));
+  test("BA6", MercatorBounds::UKCoordsToXY(5000, 5000));
+  test("BA6 ", MercatorBounds::UKCoordsToXY(5000, 5000));
 }
 }  // namespace


### PR DESCRIPTION
Предыдущая реализация была хороша для 75к индексов, но оказалась плоха для 1.7м индексов.

Раньше:
- 10к индексов в Лондоне занимали 280кб

Теперь:
- 190к индексов в Лондоне занимают 1.6Мб.

Различия:
- не храним списки для outer индексов, рекурсивно извлекаем их из дерева
- при хранении значений в индексе испльзуем то, что у каждого ключа ровно одно значение, поэтому храним значение как varuint, а не как cbv.

В качестве дальнейших оптимизаций планируется при сохранении centers table использовать знания про limit rect mwm чтобы уменьшить количество битов на точку без потери качества.