### PR TITLE
[coding] Add PointD <-> PointU encoding with limit rect.

### DIFF
--- a/coding/coding_tests/point_coding_tests.cpp
+++ b/coding/coding_tests/point_coding_tests.cpp
@@ -86,20 +86,24 @@ UNIT_TEST(PointDToPointU_WithLimitRect)
 
   for (auto const & origin : limitRectOrigin)
   {
-    for (auto const size : limitRectSize)
+    for (auto const sizeX : limitRectSize)
     {
-      m2::RectD const limitRect(origin.x, origin.y, origin.x + size, origin.y + size);
-      auto distX = uniform_real_distribution<double>(limitRect.minX(), limitRect.maxX());
-      auto distY = uniform_real_distribution<double>(limitRect.minY(), limitRect.maxY());
-      auto const coordBits = GetCoordBits(limitRect, kEps);
-      // All rects in this test are more than 2 times smaller than mercator range.
-      TEST_LESS(coordBits, kCoordBits, (limitRect));
-      for (size_t i = 0; i < pointsPerRect; ++i)
+      for (auto const sizeY : limitRectSize)
       {
-        auto const pt = m2::PointD(distX(rng), distY(rng));
-        auto const pointU = PointDToPointU(pt, coordBits, limitRect);
-        auto const pointD = PointUToPointD(pointU, coordBits, limitRect);
-        TEST(base::AlmostEqualAbs(pt, pointD, kEps), (limitRect, pt, pointD, coordBits, kEps));
+        m2::RectD const limitRect(origin.x, origin.y, origin.x + sizeX, origin.y + sizeY);
+        auto distX = uniform_real_distribution<double>(limitRect.minX(), limitRect.maxX());
+        auto distY = uniform_real_distribution<double>(limitRect.minY(), limitRect.maxY());
+        auto const coordBits = GetCoordBits(limitRect, kEps);
+        TEST_NOT_EQUAL(coordBits, 0, ());
+        // All rects in this test are more than 2 times smaller than mercator range.
+        TEST_LESS(coordBits, kCoordBits, (limitRect));
+        for (size_t i = 0; i < pointsPerRect; ++i)
+        {
+          auto const pt = m2::PointD(distX(rng), distY(rng));
+          auto const pointU = PointDToPointU(pt, coordBits, limitRect);
+          auto const pointD = PointUToPointD(pointU, coordBits, limitRect);
+          TEST(base::AlmostEqualAbs(pt, pointD, kEps), (limitRect, pt, pointD, coordBits, kEps));
+        }
       }
     }
   }

--- a/coding/point_coding.cpp
+++ b/coding/point_coding.cpp
@@ -21,6 +21,7 @@ uint32_t DoubleToUint32(double x, double min, double max, uint8_t coordBits)
 {
   ASSERT_GREATER_OR_EQUAL(coordBits, 1, ());
   ASSERT_LESS_OR_EQUAL(coordBits, 32, ());
+  ASSERT_LESS_OR_EQUAL(min, max, ());
   x = base::Clamp(x, min, max);
   return static_cast<uint32_t>(0.5 + (x - min) / (max - min) * bits::GetFullMask(coordBits));
 }

--- a/coding/point_coding.hpp
+++ b/coding/point_coding.hpp
@@ -44,7 +44,14 @@ m2::PointU PointDToPointU(double x, double y, uint8_t coordBits);
 
 m2::PointU PointDToPointU(m2::PointD const & pt, uint8_t coordBits);
 
+m2::PointU PointDToPointU(m2::PointD const & pt, uint8_t coordBits, m2::RectD const & limitRect);
+
 m2::PointD PointUToPointD(m2::PointU const & p, uint8_t coordBits);
+
+m2::PointD PointUToPointD(m2::PointU const & pt, uint8_t coordBits, m2::RectD const & limitRect);
+
+// Returns coordBits needed to encode point from given rect with given accuracy.
+uint8_t GetCoordBits(m2::RectD const & limitRect, double accuracy);
 
 // All functions below are deprecated and are left
 // only for backward compatibility.

--- a/coding/point_coding.hpp
+++ b/coding/point_coding.hpp
@@ -50,7 +50,8 @@ m2::PointD PointUToPointD(m2::PointU const & p, uint8_t coordBits);
 
 m2::PointD PointUToPointD(m2::PointU const & pt, uint8_t coordBits, m2::RectD const & limitRect);
 
-// Returns coordBits needed to encode point from given rect with given accuracy.
+// Returns coordBits needed to encode point from given rect with given absolute precision.
+// If 32 bits are not enough returns 0. It's caller's responsibility to check it.
 uint8_t GetCoordBits(m2::RectD const & limitRect, double accuracy);
 
 // All functions below are deprecated and are left


### PR DESCRIPTION
новые методы позволяют кодировать точки из заданного прямоугольника и экономить coordBits без потери качества