### PR TITLE
[generator][routing] Handle ice roads

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -14,6 +14,9 @@ ruins=yes : historic=ruins
 drinkable=yes : amenity=drinking_water
 building=entrance : entrance=yes
 
+ice_road=yes : highway=ice_road
+winter_road=yes : highway=ice_road
+
 natural=marsh : natural=wetland, wetland=marsh
 natural=waterfall : waterway=waterfall
 natural = forest : natural = wood

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -74,6 +74,8 @@ set(
   feature_sorter.cpp
   feature_sorter.hpp
   features_processing_helpers.hpp
+  filter_roads.cpp
+  filter_roads.hpp
   filter_collection.cpp
   filter_collection.hpp
   filter_elements.cpp

--- a/generator/filter_collection.cpp
+++ b/generator/filter_collection.cpp
@@ -1,8 +1,5 @@
 #include "generator/filter_collection.hpp"
 
-#include "generator/feature_builder.hpp"
-#include "generator/osm_element.hpp"
-
 #include <algorithm>
 
 using namespace feature;

--- a/generator/filter_collection.hpp
+++ b/generator/filter_collection.hpp
@@ -3,14 +3,6 @@
 #include "generator/collection_base.hpp"
 #include "generator/filter_interface.hpp"
 
-#include <memory>
-
-struct OsmElement;
-namespace feature
-{
-class FeatureBuilder;
-}  // namespace feature
-
 namespace generator
 {
 // This class allows you to work with a group of filters as with one.

--- a/generator/filter_elements.hpp
+++ b/generator/filter_elements.hpp
@@ -34,12 +34,10 @@
 #pragma once
 
 #include "generator/filter_interface.hpp"
-#include "generator/osm_element.hpp"
 
 #include <cstdint>
 #include <functional>
 #include <list>
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/generator/filter_interface.hpp
+++ b/generator/filter_interface.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <memory>
+#include "generator/feature_builder.hpp"
+#include "generator/osm_element.hpp"
 
-struct OsmElement;
-namespace feature
-{
-class FeatureBuilder;
-}  // namespace feature
+#include <memory>
 
 namespace generator
 {

--- a/generator/filter_planet.cpp
+++ b/generator/filter_planet.cpp
@@ -1,16 +1,5 @@
 #include "generator/filter_planet.hpp"
 
-#include "generator/feature_builder.hpp"
-#include "generator/osm_element.hpp"
-
-#include "indexer/classificator.hpp"
-#include "indexer/feature_visibility.hpp"
-#include "indexer/ftypes_matcher.hpp"
-
-#include "base/assert.hpp"
-
-#include <algorithm>
-
 using namespace feature;
 
 namespace generator

--- a/generator/filter_roads.cpp
+++ b/generator/filter_roads.cpp
@@ -1,0 +1,16 @@
+#include "generator/filter_roads.hpp"
+
+using namespace feature;
+
+namespace generator
+{
+std::shared_ptr<FilterInterface> FilterRoads::Clone() const
+{
+  return std::make_shared<FilterRoads>();
+}
+
+bool FilterRoads::IsAccepted(OsmElement const & element)
+{
+  return !element.HasTag("highway", "ice_road");
+}
+}  // namespace generator

--- a/generator/filter_roads.hpp
+++ b/generator/filter_roads.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "generator/filter_interface.hpp"
+
+namespace generator
+{
+class FilterRoads : public FilterInterface
+{
+public:
+  // FilterInterface overrides:
+  std::shared_ptr<FilterInterface> Clone() const override;
+
+  bool IsAccepted(OsmElement const & element) override;
+};
+}  // namespace generator

--- a/generator/filter_world.cpp
+++ b/generator/filter_world.cpp
@@ -1,6 +1,5 @@
 #include "generator/filter_world.hpp"
 
-#include "indexer/categories_holder.hpp"
 #include "indexer/classificator.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"

--- a/generator/filter_world.hpp
+++ b/generator/filter_world.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "generator/feature_builder.hpp"
 #include "generator/filter_interface.hpp"
 #include "generator/popular_places_section_builder.hpp"
 
-#include <memory>
 #include <string>
 
 namespace generator

--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -204,7 +204,7 @@ public:
     TestGeneratedFile(citiesAreas, 18601 /* fileSize */);
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
-    TestGeneratedFile(restrictions, 273283 /* fileSize */);
+    TestGeneratedFile(restrictions, 371110 /* fileSize */);
     TestGeneratedFile(roadAccess, 1969045 /* fileSize */);
     TestGeneratedFile(m_genInfo.m_citiesBoundariesFilename, 87 /* fileSize */);
   }

--- a/generator/translator.cpp
+++ b/generator/translator.cpp
@@ -42,10 +42,10 @@ void Translator::SetFilter(std::shared_ptr<FilterInterface> const & filter) { m_
 
 void Translator::Emit(OsmElement & element)
 {
+  Preprocess(element);
   if (!m_filter->IsAccepted(element))
     return;
 
-  Preprocess(element);
   m_tagsEnricher(element);
   m_collector->Collect(element);
   m_featureMaker->Add(element);

--- a/generator/translator_country.cpp
+++ b/generator/translator_country.cpp
@@ -11,6 +11,7 @@
 #include "generator/filter_collection.hpp"
 #include "generator/filter_elements.hpp"
 #include "generator/filter_planet.hpp"
+#include "generator/filter_roads.hpp"
 #include "generator/generate_info.hpp"
 #include "generator/intermediate_data.hpp"
 #include "generator/maxspeeds_collector.hpp"
@@ -93,8 +94,9 @@ TranslatorCountry::TranslatorCountry(std::shared_ptr<FeatureProcessorInterface> 
   }
   auto filters = std::make_shared<FilterCollection>();
   filters->Append(std::make_shared<FilterPlanet>());
-  filters->Append(std::make_shared<FilterElements>(
-      base::JoinPath(GetPlatform().ResourcesDir(), SKIPPED_ELEMENTS_FILE)));
+  filters->Append(std::make_shared<FilterRoads>());
+  filters->Append(std::make_shared<FilterElements>(base::JoinPath(GetPlatform().ResourcesDir(),
+      SKIPPED_ELEMENTS_FILE)));
   SetFilter(filters);
 
   auto collectors = std::make_shared<CollectorCollection>();

--- a/generator/translator_world.cpp
+++ b/generator/translator_world.cpp
@@ -5,6 +5,7 @@
 #include "generator/filter_collection.hpp"
 #include "generator/filter_elements.hpp"
 #include "generator/filter_planet.hpp"
+#include "generator/filter_roads.hpp"
 #include "generator/filter_world.hpp"
 #include "generator/generate_info.hpp"
 #include "generator/intermediate_data.hpp"
@@ -37,8 +38,9 @@ TranslatorWorld::TranslatorWorld(std::shared_ptr<FeatureProcessorInterface> cons
   }
   auto filters = std::make_shared<FilterCollection>();
   filters->Append(std::make_shared<FilterPlanet>());
-  filters->Append(std::make_shared<FilterElements>(
-      base::JoinPath(GetPlatform().ResourcesDir(), SKIPPED_ELEMENTS_FILE)));
+  filters->Append(std::make_shared<FilterRoads>());
+  filters->Append(std::make_shared<FilterElements>(base::JoinPath(GetPlatform().ResourcesDir(),
+      SKIPPED_ELEMENTS_FILE)));
   SetFilter(filters);
 }
 


### PR DESCRIPTION
There is a pair of keys in OSM which indicates roads built over land on compacted snow, bare ground or on a floating ice cover: [winter_road](https://taginfo.openstreetmap.org/keys/winter_road#values), [ice_road.](https://taginfo.openstreetmap.org/keys/ice_road#values)

We want to implement functionality (ticket [MAPSME-10786](https://jira.mail.ru/browse/MAPSME-10786)):

- Do not show ice roads on maps (both nodes and ways)
- Handle ice roads in navigation mode: never show routs through ice roads

There is over 15k of ice roads in OSM.

Ice roads example:
<img width="892" alt="Screenshot 2019-09-25 at 19 15 30" src="https://user-images.githubusercontent.com/54934129/65619491-e92cee80-dfc8-11e9-90b0-acf4b853a436.png">
