### PR TITLE
[iOS] remove references to undocumented API

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksVC.mm
+++ b/iphone/Maps/Bookmarks/BookmarksVC.mm
@@ -553,14 +553,16 @@ using namespace std;
 }
 
 - (void)showSpinner:(BOOL)show {
-  UITextField *textField = [self.searchBar valueForKey:@"searchField"];
-  if (!show) {
-    textField.leftView = self.searchIcon;
-    [self.spinner stopAnimating];
-  } else {
-    self.spinner.bounds = textField.leftView.bounds;
-    textField.leftView = self.spinner;
-    [self.spinner startAnimating];
+  if (@available(iOS 13, *)) {
+    UITextField *textField = self.searchBar.searchTextField;
+    if (!show) {
+      textField.leftView = self.searchIcon;
+      [self.spinner stopAnimating];
+    } else {
+      self.spinner.bounds = textField.leftView.bounds;
+      textField.leftView = self.spinner;
+      [self.spinner startAnimating];
+    }
   }
 }
 
@@ -569,7 +571,6 @@ using namespace std;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 

--- a/iphone/Maps/Categories/UIKitCategories.mm
+++ b/iphone/Maps/Categories/UIKitCategories.mm
@@ -240,22 +240,6 @@
 
 @end
 
-@implementation UITextField (Refresh)
-
-- (void)mwm_refreshUI
-{
-  [super mwm_refreshUI];
-  UIColor * oppositeText = self.textColor.opposite;
-  UILabel * placeholder = [self valueForKey:@"_placeholderLabel"];
-  UIColor * oppositePlaceholder = placeholder.textColor.opposite;
-  if (oppositeText)
-    self.textColor = oppositeText;
-  if (oppositePlaceholder)
-    placeholder.textColor = oppositePlaceholder;
-}
-
-@end
-
 @implementation UIImageView (Refresh)
 
 - (void)mwm_refreshUI

--- a/iphone/Maps/Classes/Components/MWMMailViewController.mm
+++ b/iphone/Maps/Classes/Components/MWMMailViewController.mm
@@ -11,7 +11,6 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 

--- a/iphone/Maps/Classes/Components/MWMNavigationController.m
+++ b/iphone/Maps/Classes/Components/MWMNavigationController.m
@@ -12,7 +12,6 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 

--- a/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-            <string>HelveticaNeue-Medium</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -56,7 +48,6 @@
                                         <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular14"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="bookmark_set_name"/>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="white"/>
                                     </userDefinedRuntimeAttributes>
                                     <connections>
@@ -135,7 +126,7 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QQD-2O-DHw" userLabel="vDivider">
-                            <rect key="frame" x="139" y="127.5" width="1" height="44"/>
+                            <rect key="frame" x="139.5" y="127.5" width="1" height="44"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.12" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="1" id="Lhw-ff-5Vq"/>

--- a/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-            <string>HelveticaNeue-Medium</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="bh1-8l-voy" customClass="MWMPlaceDoesntExistAlert" propertyAccessControl="all">
+        <view contentMode="scaleToFill" id="bh1-8l-voy" customClass="MWMPlaceDoesntExistAlert">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -71,7 +63,6 @@
                                         <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular14"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_comment_hint"/>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="white"/>
                                     </userDefinedRuntimeAttributes>
                                 </textField>
@@ -147,7 +138,7 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tyn-yU-dk3" userLabel="vDivider">
-                            <rect key="frame" x="139" y="122" width="1" height="44"/>
+                            <rect key="frame" x="139.5" y="122" width="1" height="44"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.12" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="1" id="Bva-2f-zNE"/>

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
@@ -91,8 +91,6 @@ extern NSString * const kAlohalyticsTapEventKey;
                                          isDirectionViewUnderStatusBar ||
                                          isMenuViewUnderStatusBar || isAddPlaceUnderStatusBar;
 
-  setStatusBarBackgroundColor(isSomethingUnderStatusBar ? UIColor.clearColor
-                                                        : [UIColor statusBarBackground]);
   return isSomethingUnderStatusBar || isNightMode ? UIStatusBarStyleLightContent
                                                   : UIStatusBarStyleDefault;
 }

--- a/iphone/Maps/Common/MWMCommon.h
+++ b/iphone/Maps/Common/MWMCommon.h
@@ -51,11 +51,3 @@ static inline CGFloat statusBarHeight()
   CGSize const statusBarSize = UIApplication.sharedApplication.statusBarFrame.size;
   return MIN(statusBarSize.height, statusBarSize.width);
 }
-
-static inline void setStatusBarBackgroundColor(UIColor * color)
-{
-  UIView * statusBar =
-      [UIApplication.sharedApplication valueForKeyPath:@"statusBarWindow.statusBar"];
-  if ([statusBar respondsToSelector:@selector(setBackgroundColor:)])
-    statusBar.backgroundColor = color;
-}

--- a/iphone/Maps/UI/Downloader/MWMBaseMapDownloaderViewController.mm
+++ b/iphone/Maps/UI/Downloader/MWMBaseMapDownloaderViewController.mm
@@ -712,7 +712,6 @@ using namespace storage;
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 

--- a/iphone/Maps/UI/EditBookmark/MWMBookmarkTitleCell.xib
+++ b/iphone/Maps/UI/EditBookmark/MWMBookmarkTitleCell.xib
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="oz5-CE-QZ8" customClass="MWMBookmarkTitleCell" propertyAccessControl="all">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="oz5-CE-QZ8" customClass="MWMBookmarkTitleCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oz5-CE-QZ8" id="v5X-p8-TtT">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ykx-ep-qjo">
@@ -26,7 +24,6 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular17"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="placepage_bookmark_name_hint"/>
-                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="delegate" destination="oz5-CE-QZ8" id="xG2-C9-gMT"/>

--- a/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
@@ -1,26 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="hfo-cP-AGX" customClass="MWMEditorAdditionalNameTableViewCell" propertyAccessControl="all">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="hfo-cP-AGX" customClass="MWMEditorAdditionalNameTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hfo-cP-AGX" id="JQH-ks-NoC">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="zh-classical" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="efb-nS-cjm">
@@ -39,7 +32,7 @@
                         </userDefinedRuntimeAttributes>
                     </label>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="499" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="9BY-PA-dlA">
-                        <rect key="frame" x="100" y="16.5" width="204" height="11"/>
+                        <rect key="frame" x="100" y="16" width="204" height="12"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                         <textInputTraits key="textInputTraits"/>
@@ -48,14 +41,13 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_edit_place_name_hint"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="validatorName" value="MWMInputValidator"/>
-                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="delegate" destination="hfo-cP-AGX" id="jkD-0x-Ods"/>
                         </connections>
                     </textField>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="252" translatesAutoresizingMaskIntoConstraints="NO" id="SZa-Bj-se1">
-                        <rect key="frame" x="60" y="31.5" width="252" height="0.0"/>
+                        <rect key="frame" x="60" y="32" width="252" height="0.0"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="999" id="CPF-uE-pzx"/>

--- a/iphone/Maps/UI/Editor/Cells/MWMEditorTextTableViewCell.xib
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorTextTableViewCell.xib
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="MWMEditorTextTableViewCell" propertyAccessControl="all">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="MWMEditorTextTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="58.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5uK-5Q-cg0">
@@ -45,14 +37,13 @@
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular17"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
-                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="delegate" destination="KGk-i7-Jjw" id="GO4-EB-MG9"/>
                         </connections>
                     </textField>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="252" translatesAutoresizingMaskIntoConstraints="NO" id="Lht-i1-s0H">
-                        <rect key="frame" x="60" y="32" width="252" height="14"/>
+                        <rect key="frame" x="60" y="32" width="252" height="15"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="250" id="2X4-TJ-v2V"/>

--- a/iphone/Maps/UI/Editor/Cuisine/MWMCuisineEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/Cuisine/MWMCuisineEditorViewController.mm
@@ -50,7 +50,6 @@ vector<string> SliceKeys(vector<pair<string, string>> const & v)
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 
@@ -140,9 +139,6 @@ vector<string> SliceKeys(vector<pair<string, string>> const & v)
   self.isSearch = NO;
   self.searchBar.backgroundImage = [UIImage imageWithColor:[UIColor primary]];
   self.searchBar.placeholder = L(@"search");
-  UITextField * textFiled = [self.searchBar valueForKey:@"searchField"];
-  UILabel * placeholder = [textFiled valueForKey:@"_placeholderLabel"];
-  placeholder.textColor = [UIColor blackHintText];
 }
 
 - (void)configData

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -65,7 +65,6 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  setStatusBarBackgroundColor(UIColor.clearColor);
   return UIStatusBarStyleLightContent;
 }
 
@@ -74,9 +73,6 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 {
   self.searchBar.backgroundImage = [UIImage imageWithColor:[UIColor primary]];
   self.searchBar.placeholder = L(@"search");
-  UITextField * textFiled = [self.searchBar valueForKey:@"searchField"];
-  UILabel * placeholder = [textFiled valueForKey:@"_placeholderLabel"];
-  placeholder.textColor = [UIColor blackHintText];
 }
 
 - (void)onDone

--- a/iphone/Maps/UI/Editor/Street/MWMStreetEditorEditTableViewCell.xib
+++ b/iphone/Maps/UI/Editor/Street/MWMStreetEditorEditTableViewCell.xib
@@ -1,26 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KGk-i7-Jjw" customClass="MWMStreetEditorEditTableViewCell" propertyAccessControl="all">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KGk-i7-Jjw" customClass="MWMStreetEditorEditTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="8Pj-WT-J59">
@@ -35,7 +28,6 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="validatorName" value="MWMInputValidator"/>
                             <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="add_street"/>
-                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="delegate" destination="KGk-i7-Jjw" id="r4r-Wy-T2m"/>
@@ -58,6 +50,7 @@
             <connections>
                 <outlet property="textField" destination="8Pj-WT-J59" id="lqN-IV-C5E"/>
             </connections>
+            <point key="canvasLocation" x="139" y="154"/>
         </tableViewCell>
     </objects>
 </document>

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Content/BookmarkCell/MWMBookmarkCell.xib
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Content/BookmarkCell/MWMBookmarkCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="240"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="45K-kk-B2o" id="wdW-iu-3p9">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="239.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="240"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Fsd-1g-BiQ">
@@ -39,7 +36,7 @@
                         </connections>
                     </textView>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gradient_light" translatesAutoresizingMaskIntoConstraints="NO" id="nxK-lC-JqY">
-                        <rect key="frame" x="24" y="137" width="272" height="24"/>
+                        <rect key="frame" x="16" y="137.5" width="288" height="24"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="24" id="lxX-KK-ccK"/>
                         </constraints>
@@ -48,7 +45,7 @@
                         </userDefinedRuntimeAttributes>
                     </imageView>
                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZiC-VG-fs0">
-                        <rect key="frame" x="0.0" y="161" width="320" height="33"/>
+                        <rect key="frame" x="0.0" y="161.5" width="320" height="33"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="33" id="I3z-10-2aB"/>
                         </constraints>
@@ -67,7 +64,7 @@
                         </connections>
                     </button>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="separator_image" translatesAutoresizingMaskIntoConstraints="NO" id="ZHb-qS-nFh">
-                        <rect key="frame" x="16" y="194" width="304" height="1"/>
+                        <rect key="frame" x="16" y="194.5" width="304" height="1"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Nie-DF-2Ki"/>
                         </constraints>
@@ -76,7 +73,7 @@
                         </userDefinedRuntimeAttributes>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fKp-HW-1bX">
-                        <rect key="frame" x="0.0" y="195" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="195.5" width="320" height="44"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="44" id="GrP-Iw-EEG"/>
                         </constraints>
@@ -96,7 +93,7 @@
                         </connections>
                     </button>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Xqf-Fb-Ojj">
-                        <rect key="frame" x="142" y="199" width="36" height="36"/>
+                        <rect key="frame" x="142" y="199.5" width="36" height="36"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="36" id="gj2-Tn-x6I"/>
                             <constraint firstAttribute="height" constant="36" id="rzU-50-2nS"/>
@@ -106,15 +103,15 @@
                 <constraints>
                     <constraint firstItem="Xqf-Fb-Ojj" firstAttribute="centerX" secondItem="fKp-HW-1bX" secondAttribute="centerX" id="3SE-at-on8"/>
                     <constraint firstItem="fKp-HW-1bX" firstAttribute="top" secondItem="ZHb-qS-nFh" secondAttribute="bottom" id="5GI-iV-NcW"/>
-                    <constraint firstItem="nxK-lC-JqY" firstAttribute="leading" secondItem="wdW-iu-3p9" secondAttribute="leadingMargin" constant="8" id="7aJ-6Q-edO"/>
                     <constraint firstItem="Xqf-Fb-Ojj" firstAttribute="centerY" secondItem="fKp-HW-1bX" secondAttribute="centerY" id="Bjg-lo-TFI"/>
                     <constraint firstAttribute="bottom" secondItem="fKp-HW-1bX" secondAttribute="bottom" constant="0.5" id="Lni-kV-hFB"/>
                     <constraint firstItem="ZHb-qS-nFh" firstAttribute="leading" secondItem="wdW-iu-3p9" secondAttribute="leading" constant="16" id="MNZ-uJ-rat"/>
+                    <constraint firstItem="nxK-lC-JqY" firstAttribute="trailing" secondItem="Fsd-1g-BiQ" secondAttribute="trailing" id="Nuc-hw-k7g"/>
                     <constraint firstAttribute="trailing" secondItem="Fsd-1g-BiQ" secondAttribute="trailing" constant="16" id="Oli-Wc-XEw"/>
                     <constraint firstItem="Fsd-1g-BiQ" firstAttribute="leading" secondItem="wdW-iu-3p9" secondAttribute="leading" constant="16" id="Sf7-Sm-qjx"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="nxK-lC-JqY" secondAttribute="trailing" constant="8" id="XVC-is-HpN"/>
                     <constraint firstAttribute="trailing" secondItem="ZiC-VG-fs0" secondAttribute="trailing" id="YnE-ZS-uvq"/>
                     <constraint firstItem="Fsd-1g-BiQ" firstAttribute="top" secondItem="wdW-iu-3p9" secondAttribute="top" id="eq7-sX-Xmu"/>
+                    <constraint firstItem="nxK-lC-JqY" firstAttribute="leading" secondItem="Fsd-1g-BiQ" secondAttribute="leading" id="fEH-Mb-jKl"/>
                     <constraint firstItem="ZiC-VG-fs0" firstAttribute="top" secondItem="nxK-lC-JqY" secondAttribute="bottom" id="fzw-Ku-ogi"/>
                     <constraint firstItem="ZHb-qS-nFh" firstAttribute="top" secondItem="ZiC-VG-fs0" secondAttribute="bottom" id="lhB-Bz-I7t"/>
                     <constraint firstItem="ZiC-VG-fs0" firstAttribute="top" secondItem="Fsd-1g-BiQ" secondAttribute="bottom" priority="750" id="ljR-q8-Ogv"/>
@@ -135,7 +132,7 @@
                 <outlet property="textViewHeight" destination="9oh-yS-fXg" id="wSI-K7-3Sn"/>
                 <outlet property="textViewZeroHeight" destination="Fzu-Vb-HiG" id="F1e-1k-Ip3"/>
             </connections>
-            <point key="canvasLocation" x="291" y="429"/>
+            <point key="canvasLocation" x="421.73913043478262" y="287.27678571428572"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/iphone/Maps/UI/Search/MWMSearchView.xib
+++ b/iphone/Maps/UI/Search/MWMSearchView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,7 +43,6 @@
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="white"/>
                         <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="search"/>
-                        <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="textFieldDidEndEditing:" destination="-1" eventType="editingDidEnd" id="1NS-lr-9DA"/>

--- a/iphone/Maps/UI/Storyboard/Authorization.storyboard
+++ b/iphone/Maps/UI/Storyboard/Authorization.storyboard
@@ -1,30 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-        </array>
-    </customFonts>
     <scenes>
         <!--AuthorizationOSM Login View Controller-->
         <scene sceneID="14Y-XP-wqe">
             <objects>
-                <viewController storyboardIdentifier="UIViewController-4R7-Vk-fQr" id="4R7-Vk-fQr" customClass="MWMAuthorizationOSMLoginViewController" propertyAccessControl="all" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UIViewController-4R7-Vk-fQr" id="4R7-Vk-fQr" customClass="MWMAuthorizationOSMLoginViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="S9T-iq-RN6">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2p5-BG-sgS">
-                                <rect key="frame" x="0.0" y="40" width="375" height="88"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="88"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8t7-Lb-1dX" userLabel="Separator #1">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -37,7 +30,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NyD-Tz-Vq4">
-                                        <rect key="frame" x="16" y="1" width="343" height="45"/>
+                                        <rect key="frame" x="16" y="1" width="343" height="44.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress"/>
                                         <userDefinedRuntimeAttributes>
@@ -45,14 +38,13 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular17"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="validatorName" value="MWMInputLoginValidator"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <outlet property="delegate" destination="4R7-Vk-fQr" id="koP-R3-XiP"/>
                                         </connections>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xl1-50-Vih" userLabel="Separator #2">
-                                        <rect key="frame" x="16" y="44" width="359" height="1"/>
+                                        <rect key="frame" x="16" y="43.5" width="359" height="1"/>
                                         <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="vvu-MV-Pff"/>
@@ -62,7 +54,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="e51-Qs-t6a">
-                                        <rect key="frame" x="16" y="45" width="343" height="43"/>
+                                        <rect key="frame" x="16" y="44.5" width="343" height="43.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" secureTextEntry="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -70,7 +62,6 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="fontName" value="regular17"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="validatorName" value="MWMInputPasswordValidator"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="colorName" value="blackPrimaryText"/>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="_placeholderLabel.colorName" value="blackHintText"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <outlet property="delegate" destination="4R7-Vk-fQr" id="QBg-oI-jcp"/>
@@ -113,7 +104,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QoF-Wv-nc2">
-                                <rect key="frame" x="16" y="148" width="343" height="44"/>
+                                <rect key="frame" x="16" y="128" width="343" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="g9P-gK-jg8"/>
                                 </constraints>
@@ -139,7 +130,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dOX-WF-oyI">
-                                <rect key="frame" x="16" y="204" width="343" height="44"/>
+                                <rect key="frame" x="16" y="184" width="343" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="SFg-uo-s0U"/>
                                 </constraints>
@@ -157,7 +148,7 @@
                                 </connections>
                             </button>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jMt-5d-INe">
-                                <rect key="frame" x="177.5" y="160" width="20" height="20"/>
+                                <rect key="frame" x="177.5" y="140" width="20" height="20"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="9HJ-T7-PfS"/>
@@ -206,13 +197,13 @@
         <!--Authorization Login View Controller-->
         <scene sceneID="brg-EE-ML1">
             <objects>
-                <viewController storyboardIdentifier="AuthorizationLoginViewController" id="iZ6-Zi-bkZ" customClass="MWMAuthorizationLoginViewController" propertyAccessControl="all" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AuthorizationLoginViewController" id="iZ6-Zi-bkZ" customClass="MWMAuthorizationLoginViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="i64-CY-UO1">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S0n-BM-V4o" userLabel="Auth view">
-                                <rect key="frame" x="20" y="116" width="335" height="249"/>
+                                <rect key="frame" x="20" y="96" width="335" height="248.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tzz-yF-441">
                                         <rect key="frame" x="0.0" y="0.0" width="335" height="40"/>
@@ -342,7 +333,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Don't have OpenStreetMap account?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhm-W1-U8A">
-                                        <rect key="frame" x="0.0" y="180" width="335" height="17"/>
+                                        <rect key="frame" x="0.0" y="180" width="335" height="16.5"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="ntS-Lm-ZFB"/>
                                         </constraints>
@@ -356,7 +347,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </label>
                                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s0p-dL-PG8">
-                                        <rect key="frame" x="0.0" y="205" width="335" height="44"/>
+                                        <rect key="frame" x="0.0" y="204.5" width="335" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="4EG-ux-LH6"/>
                                         </constraints>
@@ -397,7 +388,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qZp-mj-lui" userLabel="Account view">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WGF-rs-oH8" userLabel="Main view">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="212"/>
@@ -420,7 +411,7 @@
                                                 </variation>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VERIFIED CHANGES" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="61G-Rv-3df">
-                                                <rect key="frame" x="119.5" y="146" width="137" height="17"/>
+                                                <rect key="frame" x="119" y="146" width="137" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <color key="textColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -431,7 +422,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last send 12.01.2015" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2UV-ZB-sPO">
-                                                <rect key="frame" x="128.5" y="171" width="119" height="15"/>
+                                                <rect key="frame" x="128" y="171" width="119" height="15"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="0.40000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -533,7 +524,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7m7-zW-Tcq">
-                                        <rect key="frame" x="20" y="607" width="335" height="20"/>
+                                        <rect key="frame" x="20" y="627" width="335" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="Z6L-ma-g9a"/>
                                         </constraints>
@@ -611,20 +602,20 @@
         <!--Authorization Web View Login View Controller-->
         <scene sceneID="FkX-1E-Llw">
             <objects>
-                <viewController storyboardIdentifier="UIViewController-anB-7S-ebY" id="anB-7S-ebY" customClass="MWMAuthorizationWebViewLoginViewController" propertyAccessControl="all" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UIViewController-anB-7S-ebY" id="anB-7S-ebY" customClass="MWMAuthorizationWebViewLoginViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="2u2-L2-Hb3">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iae-5m-9Z1">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="delegate" destination="anB-7S-ebY" id="EDW-sZ-Oem"/>
                                 </connections>
                             </webView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WWh-HK-7a5">
-                                <rect key="frame" x="167.5" y="323.5" width="40" height="40"/>
+                                <rect key="frame" x="167.5" y="313.5" width="40" height="40"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="40" id="4e7-ir-1vf"/>


### PR DESCRIPTION
When built with xCode 11, any usage of private API crashes the app. So I removed it to prevent crashes