### PR TITLE
[bookmarks] Changes tracker refactoring.

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/BookmarkManager.java
@@ -193,6 +193,13 @@ public enum BookmarkManager
   // Called from JNI.
   @SuppressWarnings("unused")
   @MainThread
+  public void onBookmarksChanged()
+  {
+    // TODO: Implement.
+  }
+
+  @SuppressWarnings("unused")
+  @MainThread
   public void onBookmarksLoadingStarted()
   {
     for (BookmarksLoadingListener listener : mListeners)

--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -291,7 +291,7 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
       m_userMarkGenerator->SetRemovedUserMarks(msg->AcceptRemovedIds());
       m_userMarkGenerator->SetUserMarks(msg->AcceptMarkRenderParams());
       m_userMarkGenerator->SetUserLines(msg->AcceptLineRenderParams());
-      m_userMarkGenerator->SetCreatedUserMarks(msg->AcceptCreatedIds());
+      m_userMarkGenerator->SetJustCreatedUserMarks(msg->AcceptJustCreatedIds());
       break;
     }
 

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -243,8 +243,9 @@ void DrapeEngine::InvalidateUserMarks()
 
 void DrapeEngine::UpdateUserMarks(UserMarksProvider * provider, bool firstTime)
 {
-  auto const dirtyGroupIds = firstTime ? provider->GetAllGroupIds() : provider->GetDirtyGroupIds();
-  if (dirtyGroupIds.empty())
+  auto const updatedGroupIds = firstTime ? provider->GetAllGroupIds()
+                                         : provider->GetUpdatedGroupIds();
+  if (updatedGroupIds.empty())
     return;
 
   auto marksRenderCollection = make_unique_dp<UserMarksRenderCollection>();
@@ -254,7 +255,7 @@ void DrapeEngine::UpdateUserMarks(UserMarksProvider * provider, bool firstTime)
 
   if (!firstTime)
   {
-    kml::MarkGroupId lastGroupId = *dirtyGroupIds.begin();
+    kml::MarkGroupId lastGroupId = *updatedGroupIds.begin();
     bool visibilityChanged = provider->IsGroupVisibilityChanged(lastGroupId);
     bool groupIsVisible = provider->IsGroupVisible(lastGroupId);
 
@@ -264,8 +265,6 @@ void DrapeEngine::UpdateUserMarks(UserMarksProvider * provider, bool firstTime)
       kml::MarkIdCollection *idCollection)
     {
       auto const *mark = provider->GetUserPointMark(markId);
-      if (!mark->IsDirty())
-        return;
       auto const groupId = mark->GetGroupId();
       if (groupId != lastGroupId)
       {
@@ -297,7 +296,7 @@ void DrapeEngine::UpdateUserMarks(UserMarksProvider * provider, bool firstTime)
   }
 
   std::map<kml::MarkGroupId, drape_ptr<IDCollections>> dirtyMarkIds;
-  for (auto groupId : dirtyGroupIds)
+  for (auto groupId : updatedGroupIds)
   {
     auto & idCollection = *(dirtyMarkIds.emplace(groupId, make_unique_dp<IDCollections>()).first->second);
     bool const visibilityChanged = provider->IsGroupVisibilityChanged(groupId);

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -241,11 +241,11 @@ private:
 class UpdateUserMarksMessage : public Message
 {
 public:
-  UpdateUserMarksMessage(drape_ptr<IDCollections> && createdIds,
+  UpdateUserMarksMessage(drape_ptr<IDCollections> && justCreatedIds,
                          drape_ptr<IDCollections> && removedIds,
                          drape_ptr<UserMarksRenderCollection> && marksRenderParams,
                          drape_ptr<UserLinesRenderCollection> && linesRenderParams)
-    : m_createdIds(std::move(createdIds))
+    : m_justCreatedIds(std::move(justCreatedIds))
     , m_removedIds(std::move(removedIds))
     , m_marksRenderParams(std::move(marksRenderParams))
     , m_linesRenderParams(std::move(linesRenderParams))
@@ -256,10 +256,10 @@ public:
   drape_ptr<UserMarksRenderCollection> AcceptMarkRenderParams() { return std::move(m_marksRenderParams); }
   drape_ptr<UserLinesRenderCollection> AcceptLineRenderParams() { return std::move(m_linesRenderParams); }
   drape_ptr<IDCollections> AcceptRemovedIds() { return std::move(m_removedIds); }
-  drape_ptr<IDCollections> AcceptCreatedIds() { return std::move(m_createdIds); }
+  drape_ptr<IDCollections> AcceptJustCreatedIds() { return std::move(m_justCreatedIds); }
 
 private:
-  drape_ptr<IDCollections> m_createdIds;
+  drape_ptr<IDCollections> m_justCreatedIds;
   drape_ptr<IDCollections> m_removedIds;
   drape_ptr<UserMarksRenderCollection> m_marksRenderParams;
   drape_ptr<UserLinesRenderCollection> m_linesRenderParams;

--- a/drape_frontend/user_mark_generator.cpp
+++ b/drape_frontend/user_mark_generator.cpp
@@ -43,7 +43,7 @@ void UserMarkGenerator::SetRemovedUserMarks(drape_ptr<IDCollections> && ids)
     m_lines.erase(id);
 }
 
-void UserMarkGenerator::SetCreatedUserMarks(drape_ptr<IDCollections> && ids)
+void UserMarkGenerator::SetJustCreatedUserMarks(drape_ptr<IDCollections> && ids)
 {
   if (ids == nullptr)
     return;

--- a/drape_frontend/user_mark_generator.hpp
+++ b/drape_frontend/user_mark_generator.hpp
@@ -26,7 +26,7 @@ public:
   void SetUserMarks(drape_ptr<UserMarksRenderCollection> && marks);
   void SetUserLines(drape_ptr<UserLinesRenderCollection> && lines);
   void SetRemovedUserMarks(drape_ptr<IDCollections> && ids);
-  void SetCreatedUserMarks(drape_ptr<IDCollections> && ids);
+  void SetJustCreatedUserMarks(drape_ptr<IDCollections> && ids);
 
   void SetGroup(kml::MarkGroupId groupId, drape_ptr<IDCollections> && ids);
   void RemoveGroup(kml::MarkGroupId groupId);

--- a/drape_frontend/user_marks_provider.hpp
+++ b/drape_frontend/user_marks_provider.hpp
@@ -114,7 +114,7 @@ class UserMarksProvider
 {
 public:
   virtual ~UserMarksProvider() = default;
-  virtual kml::GroupIdSet const & GetDirtyGroupIds() const = 0;
+  virtual kml::GroupIdSet const & GetUpdatedGroupIds() const = 0;
   virtual kml::GroupIdSet const & GetRemovedGroupIds() const = 0;
   virtual kml::GroupIdSet GetAllGroupIds() const = 0;
   virtual bool IsGroupVisible(kml::MarkGroupId groupId) const = 0;

--- a/drape_frontend/user_marks_provider.hpp
+++ b/drape_frontend/user_marks_provider.hpp
@@ -97,6 +97,7 @@ public:
   virtual void ResetChanges() const = 0;
 
   virtual kml::TrackId GetId() const { return m_id; }
+  virtual kml::MarkGroupId GetGroupId() const = 0;
 
   virtual int GetMinZoom() const = 0;
   virtual DepthLayer GetDepthLayer() const = 0;
@@ -117,13 +118,15 @@ public:
   virtual kml::GroupIdSet const & GetUpdatedGroupIds() const = 0;
   virtual kml::GroupIdSet const & GetRemovedGroupIds() const = 0;
   virtual kml::GroupIdSet GetAllGroupIds() const = 0;
+  virtual kml::GroupIdSet const & GetBecameVisibleGroupIds() const = 0;
+  virtual kml::GroupIdSet const & GetBecameInvisibleGroupIds() const = 0;
   virtual bool IsGroupVisible(kml::MarkGroupId groupId) const = 0;
-  virtual bool IsGroupVisibilityChanged(kml::MarkGroupId groupId) const = 0;
   virtual kml::MarkIdSet const & GetGroupPointIds(kml::MarkGroupId groupId) const = 0;
   virtual kml::TrackIdSet const & GetGroupLineIds(kml::MarkGroupId groupId) const = 0;
   virtual kml::MarkIdSet const & GetCreatedMarkIds() const = 0;
   virtual kml::MarkIdSet const & GetRemovedMarkIds() const = 0;
   virtual kml::MarkIdSet const & GetUpdatedMarkIds() const = 0;
+  virtual kml::TrackIdSet const & GetCreatedLineIds() const = 0;
   virtual kml::TrackIdSet const & GetRemovedLineIds() const = 0;
   /// Never store UserPointMark reference.
   virtual UserPointMark const * GetUserPointMark(kml::MarkId markId) const = 0;

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -3452,7 +3452,7 @@ void BookmarkManager::MarksChangesTracker::OnUpdateGroup(kml::MarkGroupId groupI
   m_updatedGroups.insert(groupId);
 }
 
-void BookmarkManager::MarksChangesTracker::OnBecameVisibleGroup(kml::MarkGroupId groupId)
+void BookmarkManager::MarksChangesTracker::OnBecomeVisibleGroup(kml::MarkGroupId groupId)
 {
   auto const it = m_becameInvisibleGroups.find(groupId);
   if (it != m_becameInvisibleGroups.end())
@@ -3461,7 +3461,7 @@ void BookmarkManager::MarksChangesTracker::OnBecameVisibleGroup(kml::MarkGroupId
     m_becameVisibleGroups.insert(groupId);
 }
 
-void BookmarkManager::MarksChangesTracker::OnBecameInvisibleGroup(kml::MarkGroupId groupId)
+void BookmarkManager::MarksChangesTracker::OnBecomeInvisibleGroup(kml::MarkGroupId groupId)
 {
   auto const it = m_becameVisibleGroups.find(groupId);
   if (it != m_becameVisibleGroups.end())
@@ -3564,10 +3564,10 @@ void BookmarkManager::MarksChangesTracker::AddChanges(MarksChangesTracker const 
     OnUpdateGroup(groupId);
 
   for (auto const groupId : changes.m_becameVisibleGroups)
-    OnBecameVisibleGroup(groupId);
+    OnBecomeVisibleGroup(groupId);
 
   for (auto const groupId : changes.m_becameInvisibleGroups)
-    OnBecameInvisibleGroup(groupId);
+    OnBecomeInvisibleGroup(groupId);
 
   for (auto const groupId : changes.m_removedGroups)
     OnDeleteGroup(groupId);

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -495,8 +495,8 @@ private:
 
   private:
     void OnUpdateGroup(kml::MarkGroupId groupId);
-    void OnBecameVisibleGroup(kml::MarkGroupId groupId);
-    void OnBecameInvisibleGroup(kml::MarkGroupId groupId);
+    void OnBecomeVisibleGroup(kml::MarkGroupId groupId);
+    void OnBecomeInvisibleGroup(kml::MarkGroupId groupId);
 
     void InsertBookmark(kml::MarkId markId, kml::MarkGroupId catId,
                         GroupMarkIdSet & setToInsert, GroupMarkIdSet & setToErase);

--- a/map/track.hpp
+++ b/map/track.hpp
@@ -12,6 +12,8 @@ class Track : public df::UserLineMark
 public:
   explicit Track(kml::TrackData && data);
 
+  kml::MarkGroupId GetGroupId() const override { return m_groupID; }
+
   bool IsDirty() const override { return m_isDirty; }
   void ResetChanges() const override { m_isDirty = false; }
 
@@ -28,8 +30,6 @@ public:
   float GetWidth(size_t layerIndex) const override;
   float GetDepth(size_t layerIndex) const override;
   std::vector<m2::PointD> const & GetPoints() const override;
-
-  kml::MarkGroupId GetGroupId() const { return m_groupID; }
 
   void Attach(kml::MarkGroupId groupId);
   void Detach();


### PR DESCRIPTION
В рамках задачи по оптимизации UI на Андроиде потребовалось кеширование категорий букмарок. Для инвалидации этого кеша в PR добавлен callback, уведомляющий о наличии изменений в букмарках.
Выполнен рефакторинг системы отслеживания изменений букмарок: установка паузы на отправку "тяжелых" уведомлений в поисковый движок и Drape не мешает отправке уведомлений о наличии изменений.