### PR TITLE
[map] Fix PowerManager tests when config dir is not the same with wri…

### DIFF
--- a/map/map_tests/power_manager_tests.cpp
+++ b/map/map_tests/power_manager_tests.cpp
@@ -3,7 +3,11 @@
 #include "map/power_management/power_manager.hpp"
 #include "map/power_management/power_management_schemas.hpp"
 
-#include "platform/platform_tests_support/scoped_file.hpp"
+#include "platform//platform.hpp"
+
+#include "coding/file_writer.hpp"
+
+#include "base/scope_guard.hpp"
 
 #include <functional>
 #include <vector>
@@ -12,8 +16,6 @@ using namespace power_management;
 
 namespace
 {
-using namespace platform::tests_support;
-
 struct SubscriberForTesting : public PowerManager::Subscriber
 {
 public:
@@ -65,7 +67,8 @@ void TestAllFacilitiesEnabledExcept(PowerManager const & manager,
 
 UNIT_TEST(PowerManager_SetFacility)
 {
-  ScopedFile sf("power_manager_config", ScopedFile::Mode::DoNotCreate);
+  auto const configPath = PowerManager::GetConfigPath();
+  SCOPE_GUARD(deleteFileGuard, bind(&FileWriter::DeleteFileX, std::cref(configPath)));
   PowerManager manager;
   SubscriberForTesting subscriber;
 
@@ -98,7 +101,8 @@ UNIT_TEST(PowerManager_SetFacility)
 
 UNIT_TEST(PowerManager_SetScheme)
 {
-  ScopedFile sf("power_manager_config", ScopedFile::Mode::DoNotCreate);
+  auto const configPath = PowerManager::GetConfigPath();
+  SCOPE_GUARD(deleteFileGuard, bind(&FileWriter::DeleteFileX, std::cref(configPath)));
   Platform::ThreadRunner m_runner;
   PowerManager manager;
   SubscriberForTesting subscriber;
@@ -183,7 +187,8 @@ UNIT_TEST(PowerManager_SetScheme)
 
 UNIT_TEST(PowerManager_OnBatteryLevelChanged)
 {
-  ScopedFile sf("power_manager_config", ScopedFile::Mode::DoNotCreate);
+  auto const configPath = PowerManager::GetConfigPath();
+  SCOPE_GUARD(deleteFileGuard, bind(&FileWriter::DeleteFileX, std::cref(configPath)));
   Platform::ThreadRunner m_runner;
   PowerManager manager;
   SubscriberForTesting subscriber;

--- a/map/power_management/power_manager.hpp
+++ b/map/power_management/power_manager.hpp
@@ -25,6 +25,8 @@ public:
     virtual void OnPowerSchemeChanged(Scheme const actualScheme) {}
   };
 
+  static std::string GetConfigPath();
+
   void Load();
   // Set some facility state manually, it turns current scheme to Scheme::None.
   void SetFacility(Facility const facility, bool enabled);


### PR DESCRIPTION
…table dir (linux).

@milchakov FYI: на линуксе эти тесты работали в релизе, но не работали в дебаге (там ассерт в деструкторе ScopedFile, который падает если файл не существует).
То что при неправильном пути к файлу тесты в релизе проходили -- это ок?