### PR TITLE
[generator] Using ref tag if there's one for highway-motorway_junction.

### DIFF
--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -9,6 +9,7 @@
 #include "indexer/feature_algo.hpp"
 #include "indexer/feature_impl.hpp"
 #include "indexer/feature_visibility.hpp"
+#include "indexer/ftypes_matcher.hpp"
 
 #include "coding/bit_streams.hpp"
 #include "coding/byte_stream.hpp"
@@ -246,8 +247,11 @@ bool FeatureBuilder::PreSerialize()
 
     // Store ref's in name field (used in "highway-motorway_junction").
     // Also can be used to save post_box postcodes.
-    if (m_params.name.IsEmpty() && !m_params.ref.empty())
-      m_params.name.AddString(StringUtf8Multilang::kDefaultCode, m_params.ref);
+    if (!m_params.ref.empty())
+    {
+      if (ftypes::IsMotorwayJunctionChecker::Instance()(GetTypes()) || m_params.name.IsEmpty())
+        m_params.name.AddString(StringUtf8Multilang::kDefaultCode, m_params.ref);
+    }
 
     m_params.ref.clear();
     break;

--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -117,8 +117,8 @@ public:
     rawGenerator.GenerateCountries();
     TEST(rawGenerator.Execute(), ());
 
-    TestCountry(northAuckland, 1812066 /* fbsCnt */, 12195243 /* geometryPointsCnt */,
-                1007483 /* pointCnt */, 205469 /* lineCnt */, 599114 /* areaCnt */,
+    TestCountry(northAuckland, 1812060 /* fbsCnt */, 12195237 /* geometryPointsCnt */,
+                1007477 /* pointCnt */, 205469 /* lineCnt */, 599114 /* areaCnt */,
                 212188 /* poiCnt */, 521 /* cityTownOrVillageCnt */, 3557 /* bookingHotelsCnt */);
     TestCountry(northWellington, 797849 /* fbsCnt */, 7772223 /* geometryPointsCnt */,
                 460516 /* pointCnt */, 87058 /* lineCnt */, 250275 /* areaCnt */,
@@ -126,7 +126,7 @@ public:
     TestCountry(southCanterbury, 637239 /* fbsCnt */, 6984529 /* geometryPointsCnt */,
                 397939 /* pointCnt */, 81712 /* lineCnt */, 157588 /* areaCnt */,
                 89491 /* poiCnt */, 331 /* cityTownOrVillageCnt */, 2085 /* bookingHotelsCnt */);
-    TestCountry(southSouthland, 340630 /* fbsCnt */, 5343003 /* geometryPointsCnt */, 185980 /* pointCnt */,
+    TestCountry(southSouthland, 340629 /* fbsCnt */, 5343002 /* geometryPointsCnt */, 185979 /* pointCnt */,
                 40124 /* lineCnt */, 114526 /* areaCnt */, 40630 /* poiCnt */,
                 297 /* cityTownOrVillageCnt */, 1621 /* bookingHotelsCnt */);
   }
@@ -153,8 +153,8 @@ public:
     rawGenerator.GenerateWorld(true /* needMixTags */);
     TEST(rawGenerator.Execute(), ());
 
-    TestCountry(northAuckland, 1812066 /* fbsCnt */, 12195243 /* geometryPointsCnt */,
-                1007483 /* pointCnt */, 205469 /* lineCnt */, 599114 /* areaCnt */,
+    TestCountry(northAuckland, 1812060 /* fbsCnt */, 12195237 /* geometryPointsCnt */,
+                1007477 /* pointCnt */, 205469 /* lineCnt */, 599114 /* areaCnt */,
                 212188 /* poiCnt */, 521 /* cityTownOrVillageCnt */, 3557 /* bookingHotelsCnt */);
     TestCountry(northWellington, 797849 /* fbsCnt */, 7772223 /* geometryPointsCnt */,
                 460516 /* pointCnt */, 87058 /* lineCnt */, 250275 /* areaCnt */,
@@ -163,7 +163,7 @@ public:
                 397939 /* pointCnt */, 81712 /* lineCnt */, 157588 /* areaCnt */,
                 89491 /* poiCnt */, 331 /* cityTownOrVillageCnt */, 2085 /* bookingHotelsCnt */);
     size_t partner1CntReal = 0;
-    TestCountry(southSouthland, 340632 /* fbsCnt */, 5343005 /* geometryPointsCnt */, 185982 /* pointCnt */,
+    TestCountry(southSouthland, 340631 /* fbsCnt */, 5343004 /* geometryPointsCnt */, 185981 /* pointCnt */,
                 40124 /* lineCnt */, 114526 /* areaCnt */, 40630 /* poiCnt */,
                 297 /* cityTownOrVillageCnt */, 1621 /* bookingHotelsCnt */, [&](auto const & fb) {
                   static auto const partner1 = classif().GetTypeByPath({"sponsored", "partner1"});

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -620,6 +620,12 @@ IsPublicTransportStopChecker::IsPublicTransportStopChecker()
   m_types.push_back(classif().GetTypeByPath({"railway", "tram_stop"}));
 }
 
+IsMotorwayJunctionChecker::IsMotorwayJunctionChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"highway", "motorway_junction"}));
+}
+
 IsLocalityChecker::IsLocalityChecker()
 {
   Classificator const & c = classif();

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -368,6 +368,13 @@ public:
   DECLARE_CHECKER_INSTANCE(IsPublicTransportStopChecker);
 };
 
+class IsMotorwayJunctionChecker : public BaseChecker
+{
+  IsMotorwayJunctionChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsMotorwayJunctionChecker);
+};
+
 /// Type of locality (do not change values and order - they have detalization order)
 /// Country < State < City < ...
 enum class LocalityType

--- a/indexer/indexer_tests/checker_test.cpp
+++ b/indexer/indexer_tests/checker_test.cpp
@@ -100,6 +100,12 @@ vector<uint32_t> GetBridgeAndTunnelTypes()
   return GetTypes(arr, ARRAY_SIZE(arr));
 }
 
+uint32_t GetMotorwayJunctionType()
+{
+  Classificator const & c = classif();
+  return c.GetTypeByPath({"highway", "motorway_junction"});
+}
+
 vector<uint32_t> GetPoiTypes()
 {
   std::vector<std::string> const types = {
@@ -237,4 +243,12 @@ UNIT_TEST(IsAttractionsChecker)
     TEST(checker(t), ());
 
   TEST(!checker(c.GetTypeByPath({"route", "shuttle_train"})), ());
+}
+
+UNIT_TEST(IsMotorwayJunctionChecker)
+{
+  classificator::Load();
+
+  TEST(ftypes::IsMotorwayJunctionChecker::Instance()(GetMotorwayJunctionType()), ());
+  TEST(!ftypes::IsMotorwayJunctionChecker::Instance()(GetPoiTypes()), ());
 }


### PR DESCRIPTION
У тага точечного highway=motorway_junction есть поля ref и name. Поле ref - надпись, куда поворачивать. Поле name - название города (местности) куда поворачивать. Часто бывает, что в один город (местность) можно повернуть с многих съездов.

С другой стороны в адресах в Европе часто пишут номер съезда (попадает в поле ref). То что это так, я делаю вывод на основании жалоб пользователей время от времени + мой личный опыт (Испания, Франция. Повороты с магистралей).

Около поворота на магистрали на карте лучше подписывать номер поворота (или название поворота), который попадает в таг ref, а не название города. Название города, в удалении от города смотрится вообще не однозначно.

Данный PR влияет на случай, когда highway=motorway_junction, ref=* и name=* заданы одновременно. Приоритет теперь будет иметь ref.

Кроме того. Данный PR делает так, что мы теперь будем использовать таг ref только для highway=motorway_junction. @maksimandrianov это правильно? Оставить его использование для других точечных объектов?

Кол-во тагов: highway=motorway_junction + ref=* - 99K, highway=motorway_junction + name=* - 56K

Было:
![image](https://user-images.githubusercontent.com/1768114/66323081-eb2d7080-e92b-11e9-9bd5-6c5cfdb38ea0.png)

Стало:
![image](https://user-images.githubusercontent.com/1768114/66323096-f1bbe800-e92b-11e9-814b-43622bea54fb.png)

https://jira.mail.ru/browse/MAPSME-12063

@maksimandrianov, @gmoryes  PTAL