### PR TITLE
feature_list_generator build fix.

### DIFF
--- a/editor/editor_tests/CMakeLists.txt
+++ b/editor/editor_tests/CMakeLists.txt
@@ -44,6 +44,7 @@ omim_link_libraries(
   protobuf
   oauthcpp
   traffic
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
   ${Qt5Widgets_LIBRARIES}
 )

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -23,7 +23,6 @@ omim_link_libraries(
   mwm_diff
   bsdiff
   geometry
-  generator
   coding
   base
   agg

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -8,6 +8,9 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  generator
+  routing
+  traffic
   routing_common
   search_quality
   search_tests_support
@@ -32,6 +35,7 @@ omim_link_libraries(
   pugixml
   stats_client
   succinct
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
 )
 

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -8,8 +8,6 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  traffic
   routing_common
   search_quality
   search_tests_support

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -10,6 +10,7 @@ omim_link_libraries(
   ${PROJECT_NAME}
   map
   traffic
+  routing_common
   search_quality
   search_tests_support
   search

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -13,7 +13,6 @@ omim_link_libraries(
   search_tests_support
   search
   storage
-  ugc
   kml
   editor
   indexer

--- a/generator/booking_quality_check/CMakeLists.txt
+++ b/generator/booking_quality_check/CMakeLists.txt
@@ -35,6 +35,7 @@ omim_link_libraries(
   pugixml
   stats_client
   succinct
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
 )
 

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -66,6 +66,7 @@ omim_link_libraries(
   oauthcpp
   pugixml
   traffic
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
 )
 

--- a/map/map_integration_tests/CMakeLists.txt
+++ b/map/map_integration_tests/CMakeLists.txt
@@ -37,6 +37,7 @@ omim_link_libraries(
   opening_hours
   icu
   traffic
+  ${CMAKE_DL_LIBS}
   ${Qt5Network_LIBRARIES}
   ${LIBZ}
 )

--- a/openlr/openlr_tests/CMakeLists.txt
+++ b/openlr/openlr_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ omim_link_libraries(
   protobuf
   icu
   traffic
+  ${CMAKE_DL_LIBS}
   ${Qt5Core_LIBRARIES}
   ${LIBZ}
 )

--- a/search/search_integration_tests/CMakeLists.txt
+++ b/search/search_integration_tests/CMakeLists.txt
@@ -45,6 +45,7 @@ omim_link_libraries(
   opening_hours
   icu
   traffic
+  ${CMAKE_DL_LIBS}
   ${Qt5Network_LIBRARIES}
   ${LIBZ}
 )

--- a/ugc/ugc_tests/CMakeLists.txt
+++ b/ugc/ugc_tests/CMakeLists.txt
@@ -52,6 +52,7 @@ omim_link_libraries(
   opening_hours
   oauthcpp
   traffic
+  ${CMAKE_DL_LIBS}
   ${LIBZ}
 )
 link_qt5_core(${PROJECT_NAME})


### PR DESCRIPTION
Поправлена сборка. Была ошибка:
```
libgenerator.a(restriction_generator.cpp.o)
      vtable for routing::CarModelFactory in libgenerator.a(restriction_generator.cpp.o)
  "typeinfo for routing::VehicleModel", referenced from:
      typeinfo for routing::CarModel in libgenerator.a(restriction_generator.cpp.o)
  "typeinfo for routing::VehicleModelFactory", referenced from:
      typeinfo for routing::CarModelFactory in libgenerator.a(restriction_generator.cpp.o)
  "vtable for routing::VehicleModel", referenced from:
      routing::VehicleModel::~VehicleModel() in libgenerator.a(restriction_generator.cpp.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for routing::VehicleModelFactory", referenced from:
      routing::VehicleModelFactory::~VehicleModelFactory() in libgenerator.a(restriction_generator.cpp.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [feature_list_generator] Error 1
make[1]: *** [feature_list/CMakeFiles/feature_list_generator.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```
@gmoryes @tatiana-yan PTAL