### PR TITLE
[search] Use pre-converted dataset for UK postcodes.

### DIFF
--- a/geometry/mercator.cpp
+++ b/geometry/mercator.cpp
@@ -56,19 +56,3 @@ double MercatorBounds::AreaOnEarth(m2::RectD const & rect)
   return MercatorBounds::AreaOnEarth(rect.LeftTop(), rect.LeftBottom(), rect.RightBottom()) +
          MercatorBounds::AreaOnEarth(rect.LeftTop(), rect.RightTop(), rect.RightBottom());
 }
-
-m2::PointD MercatorBounds::UKCoordsToXY(double eastingM, double northingM)
-{
-  // The map projection used on Ordnance Survey Great Britain maps is known as the National Grid.
-  // It's UTM-like coordinate system.
-  // The Transverse Mercator eastings and northings axes are given a ‘false origin’ just south west
-  // of the Scilly Isles to ensure that all coordinates in Britain are positive. The false origin is
-  // 400 km west and 100 km north of the ‘true origin’ on the central meridian at 49°N 2°W (OSGB36)
-  // and approx. 49°N 2°0′5″ W (WGS 84). For further details see:
-  //   https://www.ordnancesurvey.co.uk/documents/resources/guide-coordinate-systems-great-britain.pdf
-  //   https://en.wikipedia.org/wiki/Ordnance_Survey_National_Grid
-  auto static kNationalGridOriginX = MercatorBounds::LonToX(-7.5571597);
-  auto static kNationalGridOriginY = MercatorBounds::LatToY(49.7668072);
-
-  return GetSmPoint({kNationalGridOriginX, kNationalGridOriginY}, eastingM, northingM);
-}

--- a/geometry/mercator.hpp
+++ b/geometry/mercator.hpp
@@ -120,7 +120,4 @@ struct MercatorBounds
   static double AreaOnEarth(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   /// Calculates area on Earth in m².
   static double AreaOnEarth(m2::RectD const & mercatorRect);
-
-  // Converts UK easting and northing measured from UK National Grid origin to mercator.
-  static m2::PointD UKCoordsToXY(double eastingM, double northingM);
 };

--- a/search/search_integration_tests/postcode_points_tests.cpp
+++ b/search/search_integration_tests/postcode_points_tests.cpp
@@ -45,16 +45,15 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
   string const testFile = "postcodes.csv";
   auto const postcodesRelativePath = base::JoinPath(writableDir, testFile);
 
-  ScopedFile const osmScopedFile(
-      testFile,
-      "aa11 0, dummy, 1000, 1000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "aa11 1, dummy, 2000, 2000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "aa11 2, dummy, 3000, 3000, dummy, dummy, dummy, dummy, dummy, dummy\n");
+  ScopedFile const osmScopedFile(testFile,
+                                 "aa11 0, 1.0, 1.0\n"
+                                 "aa11 1, 2.0, 2.0\n"
+                                 "aa11 2, 3.0, 3.0\n");
 
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
-  infoGetter->AddCountry(
-      storage::CountryDef(countryName, m2::RectD(MercatorBounds::UKCoordsToXY(999, 999),
-                                                 MercatorBounds::UKCoordsToXY(30001, 30001))));
+  infoGetter->AddCountry(storage::CountryDef(
+      countryName,
+      m2::RectD(MercatorBounds::FromLatLon(0.99, 0.99), MercatorBounds::FromLatLon(3.01, 3.01))));
 
   auto const id = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
     builder.SetPostcodesData(postcodesRelativePath, infoGetter);
@@ -70,24 +69,21 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 0"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(1000, 1000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(1.0, 1.0), kMwmPointAccuracy),
          ());
   }
   {
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 1"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(2000, 2000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(2.0, 2.0), kMwmPointAccuracy),
          ());
   }
   {
     vector<m2::PointD> points;
     p.Get(NormalizeAndSimplifyString("aa11 2"), points);
     TEST_EQUAL(points.size(), 1, ());
-    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(3000, 3000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(3.0, 3.0), kMwmPointAccuracy),
          ());
   }
   {
@@ -95,14 +91,11 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
     p.Get(NormalizeAndSimplifyString("aa11"), points);
     TEST_EQUAL(points.size(), 3, ());
     sort(points.begin(), points.end());
-    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::UKCoordsToXY(1000, 1000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(1.0, 1.0), kMwmPointAccuracy),
          ());
-    TEST(base::AlmostEqualAbs(points[1], MercatorBounds::UKCoordsToXY(2000, 2000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[1], MercatorBounds::FromLatLon(2.0, 2.0), kMwmPointAccuracy),
          ());
-    TEST(base::AlmostEqualAbs(points[2], MercatorBounds::UKCoordsToXY(3000, 3000),
-                              kMwmPointAccuracy),
+    TEST(base::AlmostEqualAbs(points[2], MercatorBounds::FromLatLon(3.0, 3.0), kMwmPointAccuracy),
          ());
   }
 }
@@ -116,15 +109,15 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchPostcode)
   string const testFile = "postcodes.csv";
   auto const postcodesRelativePath = base::JoinPath(writableDir, testFile);
 
-  ScopedFile const osmScopedFile(
-      testFile,
-      "BA6 7JP, dummy, 4000, 4000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "BA6 8JP, dummy, 6000, 6000, dummy, dummy, dummy, dummy, dummy, dummy\n");
+  // Use the same latitude for easier center calculation.
+  ScopedFile const osmScopedFile(testFile,
+                                 "BA6 7JP, 5.0, 4.0\n"
+                                 "BA6 8JP, 5.0, 6.0\n");
 
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
-  infoGetter->AddCountry(
-      storage::CountryDef(countryName, m2::RectD(MercatorBounds::UKCoordsToXY(3000, 3000),
-                                                 MercatorBounds::UKCoordsToXY(7000, 7000))));
+  infoGetter->AddCountry(storage::CountryDef(
+      countryName,
+      m2::RectD(MercatorBounds::FromLatLon(3.0, 3.0), MercatorBounds::FromLatLon(7.0, 7.0))));
 
   auto const id = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
     builder.SetPostcodesData(postcodesRelativePath, infoGetter);
@@ -143,13 +136,13 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchPostcode)
     TEST(base::AlmostEqualAbs(expected, actual, kMwmPointAccuracy), ());
   };
 
-  test("BA6 7JP", MercatorBounds::UKCoordsToXY(4000, 4000));
-  test("BA6 7JP ", MercatorBounds::UKCoordsToXY(4000, 4000));
-  test("BA6 8JP", MercatorBounds::UKCoordsToXY(6000, 6000));
-  test("BA6 8JP ", MercatorBounds::UKCoordsToXY(6000, 6000));
+  test("BA6 7JP", MercatorBounds::FromLatLon(5.0, 4.0));
+  test("BA6 7JP ", MercatorBounds::FromLatLon(5.0, 4.0));
+  test("BA6 8JP", MercatorBounds::FromLatLon(5.0, 6.0));
+  test("BA6 8JP ", MercatorBounds::FromLatLon(5.0, 6.0));
   // Search should return center of all inward codes for outward query.
-  test("BA6", MercatorBounds::UKCoordsToXY(5000, 5000));
-  test("BA6 ", MercatorBounds::UKCoordsToXY(5000, 5000));
+  test("BA6", MercatorBounds::FromLatLon(5.0, 5.0));
+  test("BA6 ", MercatorBounds::FromLatLon(5.0, 5.0));
 }
 
 UNIT_CLASS_TEST(PostcodePointsTest, SearchStreetWithPostcode)
@@ -163,54 +156,54 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchStreetWithPostcode)
 
   ScopedFile const osmScopedFile(
       testFile,
-      "AA5 6KL, dummy, 4000, 4000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "BB7 8MN, dummy, 6000, 6000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "XX6 7KL, dummy, 4000, 6000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "YY8 9MN, dummy, 6000, 4000, dummy, dummy, dummy, dummy, dummy, dummy\n"
+      "AA5 6KL, 4.0, 4.0\n"
+      "BB7 8MN, 6.0, 6.0\n"
+      "XX6 7KL, 4.0, 6.0\n"
+      "YY8 9MN, 6.0, 4.0\n"
       // Some dummy postcodes to make postcode radius approximation not too big.
-      "CC1 001, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 002, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 003, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 004, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 005, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 006, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 007, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 008, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 009, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 010, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 011, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 012, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 013, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 014, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 015, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 016, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 017, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 018, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 019, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n"
-      "CC1 020, dummy, 5000, 5000, dummy, dummy, dummy, dummy, dummy, dummy\n");
+      "CC1 001, 5.0, 5.0\n"
+      "CC1 002, 5.0, 5.0\n"
+      "CC1 003, 5.0, 5.0\n"
+      "CC1 004, 5.0, 5.0\n"
+      "CC1 005, 5.0, 5.0\n"
+      "CC1 006, 5.0, 5.0\n"
+      "CC1 007, 5.0, 5.0\n"
+      "CC1 008, 5.0, 5.0\n"
+      "CC1 009, 5.0, 5.0\n"
+      "CC1 010, 5.0, 5.0\n"
+      "CC1 011, 5.0, 5.0\n"
+      "CC1 012, 5.0, 5.0\n"
+      "CC1 013, 5.0, 5.0\n"
+      "CC1 014, 5.0, 5.0\n"
+      "CC1 015, 5.0, 5.0\n"
+      "CC1 016, 5.0, 5.0\n"
+      "CC1 017, 5.0, 5.0\n"
+      "CC1 018, 5.0, 5.0\n"
+      "CC1 019, 5.0, 5.0\n"
+      "CC1 020, 5.0, 5.0\n");
 
   auto const rect =
-      m2::RectD(MercatorBounds::UKCoordsToXY(3990, 3990), MercatorBounds::UKCoordsToXY(6010, 6010));
+      m2::RectD(MercatorBounds::FromLatLon(3.99, 3.99), MercatorBounds::FromLatLon(6.01, 6.01));
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
   infoGetter->AddCountry(storage::CountryDef(countryName, rect));
 
-  TestStreet streetA(vector<m2::PointD>{MercatorBounds::UKCoordsToXY(3990, 3990),
-                                        MercatorBounds::UKCoordsToXY(4010, 4010)},
+  TestStreet streetA(vector<m2::PointD>{MercatorBounds::FromLatLon(3.99, 3.99),
+                                        MercatorBounds::FromLatLon(4.01, 4.01)},
                      "Garden street", "en");
-  TestPOI houseA(MercatorBounds::UKCoordsToXY(4000, 4000), "", "en");
+  TestPOI houseA(MercatorBounds::FromLatLon(4.0, 4.0), "", "en");
   houseA.SetHouseNumber("1");
   houseA.SetStreetName(streetA.GetName("en"));
-  TestStreet streetB(vector<m2::PointD>{MercatorBounds::UKCoordsToXY(5990, 5990),
-                                        MercatorBounds::UKCoordsToXY(6010, 6010)},
+  TestStreet streetB(vector<m2::PointD>{MercatorBounds::FromLatLon(5.99, 5.99),
+                                        MercatorBounds::FromLatLon(6.01, 6.01)},
                      "Garden street", "en");
-  TestPOI houseB(MercatorBounds::UKCoordsToXY(6000, 6000), "", "en");
+  TestPOI houseB(MercatorBounds::FromLatLon(6.0, 6.0), "", "en");
   houseB.SetHouseNumber("1");
   houseB.SetStreetName(streetB.GetName("en"));
-  TestStreet streetX(vector<m2::PointD>{MercatorBounds::UKCoordsToXY(3990, 5990),
-                                        MercatorBounds::UKCoordsToXY(4010, 6010)},
+  TestStreet streetX(vector<m2::PointD>{MercatorBounds::FromLatLon(3.99, 5.99),
+                                        MercatorBounds::FromLatLon(4.01, 6.01)},
                      "Main street", "en");
-  TestStreet streetY(vector<m2::PointD>{MercatorBounds::UKCoordsToXY(5990, 3990),
-                                        MercatorBounds::UKCoordsToXY(6010, 4010)},
+  TestStreet streetY(vector<m2::PointD>{MercatorBounds::FromLatLon(5.99, 3.99),
+                                        MercatorBounds::FromLatLon(6.01, 4.01)},
                      "Main street", "en");
 
   auto const id = BuildCountry(countryName, [&](TestMwmBuilder & builder) {


### PR DESCRIPTION
Конвертация координат оказалась не так проста -- метры меряются не по поверхности земли, а по собственному варианту проекции меркатора. Не вижу смысла тащить её в проект, предлагаю конвертировать датасет перед использованием, код конвертации тривиальный:

```
import csv
from OSGridConverter import grid2latlong
from OSGridConverter import OSGridReference

with open('~/data/uk_postcodes_grid', newline='') as old:
  old_reader = csv.reader(old)
  for row in old_reader:
    postcode = row[0]
    g = OSGridReference(int(row[2]),int(row[3]))
    ll = g.toLatLong(tag='WGS84')
    print(postcode+","+ll.__str__()) 
```