### PR TITLE
Improved dependency description.

### DIFF
--- a/3party/bsdiff-courgette/CMakeLists.txt
+++ b/3party/bsdiff-courgette/CMakeLists.txt
@@ -2,8 +2,6 @@ project(bsdiff)
 
 add_clang_compile_options("-Wno-shorten-64-to-32")
 
-include_directories(bsdiff divsufsort)
-
 set(
   SRC
   bsdiff/bsdiff.h
@@ -17,4 +15,13 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  bsdiff
+  divsufsort
+  .
+)
+
 omim_add_test_subdirectory(bsdiff/bsdiff_tests)

--- a/3party/bsdiff-courgette/bsdiff/bsdiff_tests/CMakeLists.txt
+++ b/3party/bsdiff-courgette/bsdiff/bsdiff_tests/CMakeLists.txt
@@ -7,6 +7,10 @@ set(
 
 omim_add_test(${PROJECT_NAME} ${SRC})
 
+include_directories(
+  ${OMIM_ROOT}/3party
+)
+
 omim_link_libraries(
   ${PROJECT_NAME}
   bsdiff

--- a/3party/bsdiff-courgette/bsdiff/bsdiff_tests/bsdiff_search_tests.cpp
+++ b/3party/bsdiff-courgette/bsdiff/bsdiff_tests/bsdiff_search_tests.cpp
@@ -1,7 +1,5 @@
 #include "testing/testing.hpp"
 
-#include "base/macros.hpp"
-
 #include <cstring>
 #include <string>
 #include <vector>

--- a/3party/expat/CMakeLists.txt
+++ b/3party/expat/CMakeLists.txt
@@ -23,3 +23,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  lib
+)

--- a/3party/freetype/CMakeLists.txt
+++ b/3party/freetype/CMakeLists.txt
@@ -14,8 +14,6 @@ add_gcc_compile_options(
   "-Wno-unused-function"
 )
 
-include_directories(include)
-
 set(
   SRC
   src/autofit/afangles.c
@@ -123,3 +121,15 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  include
+)
+
+# 3party libraries or external dependencies
+target_link_libraries(
+  ${PROJECT_NAME}
+  ${LIBZ}
+)

--- a/3party/gflags/CMakeLists.txt
+++ b/3party/gflags/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(gflags)
 
-include_directories(src)
-
 set(
   SRC
   src/config.h
@@ -13,3 +11,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME} BEFORE
+  PUBLIC
+  src
+)

--- a/3party/gflags/CMakeLists.txt
+++ b/3party/gflags/CMakeLists.txt
@@ -13,7 +13,7 @@ set(
 add_library(${PROJECT_NAME} ${SRC})
 
 target_include_directories(
-  ${PROJECT_NAME} BEFORE
+  ${PROJECT_NAME}
   PUBLIC
   src
 )

--- a/3party/glm/glm/CMakeLists.txt
+++ b/3party/glm/glm/CMakeLists.txt
@@ -28,8 +28,6 @@ source_group("GTX Files" FILES ${GTX_SOURCE})
 source_group("GTX Files" FILES ${GTX_INLINE})
 source_group("GTX Files" FILES ${GTX_HEADER})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
-
 if(GLM_TEST_ENABLE)
 	add_executable(${NAME} ${ROOT_TEXT}
 		${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
@@ -38,5 +36,11 @@ if(GLM_TEST_ENABLE)
 		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER})
 endif(GLM_TEST_ENABLE)
 
-#add_library(glm STATIC glm.cpp)
+add_library(glm STATIC detail/glm.cpp)
 #add_library(glm_shared SHARED glm.cpp)
+
+target_include_directories(
+  glm
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
+)

--- a/3party/gmock/CMakeLists.txt
+++ b/3party/gmock/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(gmock)
 
-include_directories(. gtest gtest/include include)
-
 set(
   SRC
   gtest/src/gtest-all.cc
@@ -37,3 +35,12 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  . 
+  gtest 
+  gtest/include 
+  include
+)

--- a/3party/icu/CMakeLists.txt
+++ b/3party/icu/CMakeLists.txt
@@ -1,22 +1,10 @@
 project(icu)
 
-add_definitions(
-  -DU_CHARSET_IS_UTF8=1
-  -DU_STATIC_IMPLEMENTATION
-  -DU_COMMON_IMPLEMENTATION
-  -DU_I18N_IMPLEMENTATION
-  -DU_NO_DEFAULT_INCLUDE_UTF_HEADERS
-  -DU_DISABLE_RENAMING
-  -DU_ENABLE_DYLOAD=0
-)
-
 add_clang_compile_options("-Wno-deprecated-declarations")
 add_clang_compile_options("-Wno-enum-compare")
 add_gcc_compile_options("-Wno-deprecated-declarations")
 
 set(CMAKE_PREFIX_PATH ./)
-
-include_directories(common i18n common/unicode ./)
 
 set(
   SRC
@@ -818,3 +806,22 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_compile_definitions(
+  ${PROJECT_NAME}
+  PUBLIC
+  -DU_HAVE_STD_STRING=1
+  -DU_STATIC_IMPLEMENTATION
+  -DU_COMMON_IMPLEMENTATION
+  -DU_I18N_IMPLEMENTATION
+  -DU_NO_DEFAULT_INCLUDE_UTF_HEADERS
+  -DU_DISABLE_RENAMING
+  -DU_ENABLE_DYLOAD=0
+)
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  common
+  i18n
+)

--- a/3party/jansson/CMakeLists.txt
+++ b/3party/jansson/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(jansson)
 
-include_directories(src ../../)
-
 set(
   SRC
   jansson_handle.cpp
@@ -30,3 +28,11 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  ../../
+  ../../3party
+  src
+)

--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "jansson_handle.hpp"
-
 #include "base/exception.hpp"
 #include "base/string_utils.hpp"
 
@@ -12,6 +10,7 @@
 
 #include <boost/optional.hpp>
 
+#include "3party/jansson/jansson_handle.hpp"
 #include "3party/jansson/src/jansson.h"
 
 namespace base

--- a/3party/liboauthcpp/CMakeLists.txt
+++ b/3party/liboauthcpp/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(oauthcpp)
 
-include_directories(include src)
-
 add_clang_compile_options("-Wno-shorten-64-to-32")
 
 set(
@@ -15,3 +13,10 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  include
+  src
+)

--- a/3party/libtess2/CMakeLists.txt
+++ b/3party/libtess2/CMakeLists.txt
@@ -22,3 +22,10 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  Include
+)
+

--- a/3party/minizip/CMakeLists.txt
+++ b/3party/minizip/CMakeLists.txt
@@ -16,3 +16,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  .
+)

--- a/3party/open-location-code/CMakeLists.txt
+++ b/3party/open-location-code/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(openlocationcode)
 
-include_directories(src ../../)
-
 set(
   SRC
   codearea.cc
@@ -11,3 +9,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  .
+)

--- a/3party/opening_hours/CMakeLists.txt
+++ b/3party/opening_hours/CMakeLists.txt
@@ -35,7 +35,13 @@ set(
   rules_evaluation.cpp
 )
 
-add_library(opening_hours ${SRC})
+add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  .
+)
 
 omim_add_test_subdirectory(opening_hours_tests)
 omim_add_test_subdirectory(opening_hours_integration_tests)

--- a/3party/protobuf/CMakeLists.txt
+++ b/3party/protobuf/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(protobuf)
 
-include_directories(. protobuf/src ../../)
-
 if (NOT PLATFORM_WIN)
   add_definitions(-DHAVE_PTHREAD)
 endif ()
@@ -36,3 +34,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  protobuf/src
+)

--- a/3party/pugixml/CMakeLists.txt
+++ b/3party/pugixml/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(pugixml)
 
-include_directories(src)
-
 set(
   SRC
   src/pugiconfig.hpp
@@ -11,3 +9,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  src
+)

--- a/3party/stb_image/CMakeLists.txt
+++ b/3party/stb_image/CMakeLists.txt
@@ -7,3 +7,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  .
+)

--- a/3party/succinct/CMakeLists.txt
+++ b/3party/succinct/CMakeLists.txt
@@ -2,8 +2,6 @@ project(succinct)
 
 add_definitions(-DLTC_NO_ROLC)
 
-include_directories(src/headers)
-
 add_clang_compile_options(
   "-Wno-unused-local-typedef"
   "-Wno-unused-private-field"
@@ -39,3 +37,9 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  src/headers
+)

--- a/3party/vulkan_wrapper/CMakeLists.txt
+++ b/3party/vulkan_wrapper/CMakeLists.txt
@@ -5,8 +5,6 @@ add_gcc_compile_options("-Wno-deprecated-declarations")
 
 set(CMAKE_PREFIX_PATH ./)
 
-include_directories(../Vulkan-Headers/include)
-
 set(
   SRC
   vulkan_wrapper.cpp
@@ -14,3 +12,10 @@ set(
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  ../Vulkan-Headers/include
+  .
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ include_directories(
   ${CMAKE_HOME_DIRECTORY}
   ${Qt5Core_INCLUDE_DIRS}
   ${Qt5Network_INCLUDE_DIRS}
+  ${OMIM_ROOT}/3party
+  ${OMIM_ROOT}/3party/utfcpp/source/utf8
+  ${OMIM_ROOT}/3party/Alohalytics/src
 )
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
@@ -255,17 +258,18 @@ add_subdirectory(3party/bsdiff-courgette)
 add_subdirectory(3party/expat)
 add_subdirectory(3party/freetype)
 add_subdirectory(3party/gflags)
+add_subdirectory(3party/glm)
 add_subdirectory(3party/icu)
 add_subdirectory(3party/jansson)
 add_subdirectory(3party/liboauthcpp)
 add_subdirectory(3party/minizip)
+add_subdirectory(3party/open-location-code)
 add_subdirectory(3party/opening_hours)
 add_subdirectory(3party/protobuf)
 add_subdirectory(3party/pugixml)
 add_subdirectory(3party/sdf_image)
 add_subdirectory(3party/stb_image)
 add_subdirectory(3party/succinct)
-add_subdirectory(3party/open-location-code)
 add_subdirectory(3party/vulkan_wrapper)
 
 if (PLATFORM_DESKTOP)

--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -3,18 +3,6 @@ cmake_minimum_required(VERSION 3.2)
 project(mapswithme C CXX)
 
 include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-  ${OMIM_ROOT}/3party/boost
-  ${OMIM_ROOT}/3party/protobuf/protobuf/src
-  ${OMIM_ROOT}/3party/glm
-  ${OMIM_ROOT}/3party/succinct
-  ${OMIM_ROOT}/3party/agg
-  ${OMIM_ROOT}/3party/icu/common
-  ${OMIM_ROOT}/3party/icu/i18n
-  ${OMIM_ROOT}/3party/stb_image
-  ${OMIM_ROOT}/3party/sdf_image
-  ${OMIM_ROOT}/3party/Vulkan-Headers/include
-  ${OMIM_ROOT}/3party/vulkan_wrapper
   ${OMIM_ROOT}/android/jni
 )
 
@@ -101,53 +89,33 @@ set(
 omim_add_library(mapswithme SHARED ${SRC})
 
 target_link_libraries(
-  mapswithme
-  # Android libs
+  ${PROJECT_NAME}
+  base
+  coding
+  drape
+  drape_frontend
+  editor
+  geometry
+  indexer
+  local_ads
+  map
+  metrics
+  partners_api
+  platform
+  routing
+  search
+  storage
+)
+
+# 3party libraries or external dependencies
+target_link_libraries(
+  ${PROJECT_NAME}
+  opening_hours
+   # Android libs
   log
   android
   EGL
   GLESv2
   atomic
   z
-  # MapsWithMe libs
-  map
-  tracking
-  routing
-  traffic
-  routing_common
-  transit
-  drape_frontend
-  shaders
-  search
-  storage
-  descriptions
-  ugc
-  drape
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  partners_api
-  local_ads
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  opening_hours
-  pugixml
-  oauthcpp
-  expat
-  freetype
-  minizip
-  jansson
-  protobuf
-  stats_client
-  succinct
-  stb_image
-  sdf_image
-  icu
-  agg
-  vulkan_wrapper
 )

--- a/android/jni/com/mapswithme/maps/editor/OpeningHours.cpp
+++ b/android/jni/com/mapswithme/maps/editor/OpeningHours.cpp
@@ -11,7 +11,7 @@
 #include <set>
 #include <vector>
 
-#include "3party/opening_hours/opening_hours.hpp"
+#include <opening_hours/opening_hours.hpp>
 
 namespace
 {

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -108,4 +108,7 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+# Also depends on:
+#   3party/utfcpp
+
 omim_add_test_subdirectory(base_tests)

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -53,4 +53,8 @@ set(
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})
-omim_link_libraries(${PROJECT_NAME} base)
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+)

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <type_traits>
 
-#include "3party/utfcpp/source/utf8/unchecked.h"
+#include <utfcpp/source/utf8/unchecked.h>
 
 /// All methods work with strings in utf-8 format
 namespace strings

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -52,14 +52,6 @@ function(omim_add_executable executable)
   endif()
 endfunction()
 
-function(omim_add_library library)
-  add_library(${library} ${ARGN})
-  add_dependencies(${library} BuildVersion)
-  if (USE_PCH)
-    add_precompiled_headers_to_target(${library} ${OMIM_PCH_TARGET_NAME})
-  endif()
-endfunction()
-
 function(omim_add_test executable)
   if (NOT SKIP_TESTS)
     omim_add_executable(
@@ -67,6 +59,30 @@ function(omim_add_test executable)
       ${ARGN}
       ${OMIM_ROOT}/testing/testingmain.cpp
      )
+  endif()
+
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${executable}
+    ${Qt5Gui_LIBRARIES}
+    ${Qt5Widgets_LIBRARIES}
+  )
+
+  link_qt5_core(${executable})
+  if (PLATFORM_LINUX)
+    # 3party libraries or external dependencies
+    omim_link_libraries(
+      ${executable}
+      ${CMAKE_DL_LIBS}
+    )
+  endif()
+endfunction()
+
+function(omim_add_library library)
+  add_library(${library} ${ARGN})
+  add_dependencies(${library} BuildVersion)
+  if (USE_PCH)
+    add_precompiled_headers_to_target(${library} ${OMIM_PCH_TARGET_NAME})
   endif()
 endfunction()
 
@@ -86,25 +102,9 @@ function(omim_add_pybindings_subdirectory subdir)
   endif()
 endfunction()
 
-function(omim_link_platform_deps target)
-  if ("${ARGN}" MATCHES "platform")
-    if (PLATFORM_MAC)
-      target_link_libraries(
-        ${target}
-        "-framework CFNetwork"
-        "-framework Foundation"
-        "-framework IOKit"
-        "-framework SystemConfiguration"
-        "-framework Security"
-      )
-    endif()
-  endif()
-endfunction()
-
 function(omim_link_libraries target)
   if (TARGET ${target})
     target_link_libraries(${target} ${ARGN} ${CMAKE_THREAD_LIBS_INIT})
-    omim_link_platform_deps(${target} ${ARGN})
   else()
     message("~> Skipping linking the libraries to the target ${target} as it"
             " does not exist")

--- a/coding/CMakeLists.txt
+++ b/coding/CMakeLists.txt
@@ -2,16 +2,8 @@ project(coding)
 
 add_definitions(-DU_DISABLE_RENAMING)
 
-include_directories(
-  ${OMIM_ROOT}/coding
-  ${OMIM_ROOT}/3party/expat
-  ${OMIM_ROOT}/3party/icu/common
-  ${OMIM_ROOT}/3party/icu/i18n
-)
-
 set(
   SRC
-  ${OMIM_ROOT}/3party/expat/expat_impl.h
   base64.cpp
   base64.hpp
   bit_streams.hpp
@@ -99,5 +91,23 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  geometry
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  expat
+  icu
+  jansson
+  minizip
+  oauthcpp
+  succinct
+  ${LIBZ}
+)
 
 omim_add_test_subdirectory(coding_tests)

--- a/coding/coding_tests/CMakeLists.txt
+++ b/coding/coding_tests/CMakeLists.txt
@@ -51,15 +51,18 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
-  platform
-  coding
   base
+  coding
   geometry
-  jansson
-  minizip
-  succinct
-  stats_client
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
+  platform
+  platform_tests_support
 )
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  succinct
+)
+
+# Also depends on:
+#   3party/utfcpp

--- a/coding/coding_tests/string_utf8_multilang_tests.cpp
+++ b/coding/coding_tests/string_utf8_multilang_tests.cpp
@@ -4,7 +4,7 @@
 
 #include "base/control_flow.hpp"
 
-#include "3party/utfcpp/source/utf8.h"
+#include <utfcpp/source/utf8.h>
 
 #include <cstddef>
 #include <string>

--- a/coding/coding_tests/succinct_mapper_test.cpp
+++ b/coding/coding_tests/succinct_mapper_test.cpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "3party/succinct/mapper.hpp"
+#include <succinct/mapper.hpp>
 
 using namespace coding;
 

--- a/coding/internal/xmlparser.hpp
+++ b/coding/internal/xmlparser.hpp
@@ -11,7 +11,7 @@
 #include <string>
 
 #define XML_STATIC
-#include "3party/expat/expat_impl.h"
+#include <expat/expat_impl.h>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/coding/map_uint32_to_val.hpp
+++ b/coding/map_uint32_to_val.hpp
@@ -18,8 +18,8 @@
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
-#include "3party/succinct/elias_fano.hpp"
-#include "3party/succinct/rs_bit_vector.hpp"
+#include <succinct/elias_fano.hpp>
+#include <succinct/rs_bit_vector.hpp>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/coding/serdes_json.hpp
+++ b/coding/serdes_json.hpp
@@ -6,7 +6,7 @@
 #include "base/exception.hpp"
 #include "base/scope_guard.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <array>
 #include <chrono>

--- a/coding/sha1.cpp
+++ b/coding/sha1.cpp
@@ -7,8 +7,8 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 
-#include "3party/liboauthcpp/src/SHA1.h"
-#include "3party/liboauthcpp/src/base64.h"
+#include <liboauthcpp/src/SHA1.h>
+#include <liboauthcpp/src/base64.h>
 
 #include <algorithm>
 #include <vector>

--- a/coding/simple_dense_coding.hpp
+++ b/coding/simple_dense_coding.hpp
@@ -8,7 +8,7 @@
   #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
  
-#include "3party/succinct/elias_fano_compressed_list.hpp"
+#include <succinct/elias_fano_compressed_list.hpp>
  
 #if defined(__clang__)
   #pragma clang diagnostic pop

--- a/coding/succinct_mapper.hpp
+++ b/coding/succinct_mapper.hpp
@@ -12,8 +12,8 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 
-#include "3party/succinct/mappable_vector.hpp"
-#include "3party/succinct/mapper.hpp"
+#include <succinct/mappable_vector.hpp>
+#include <succinct/mapper.hpp>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/coding/transliteration.cpp
+++ b/coding/transliteration.cpp
@@ -5,11 +5,11 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/icu/common/unicode/uclean.h"
-#include "3party/icu/common/unicode/unistr.h"
-#include "3party/icu/common/unicode/utypes.h"
-#include "3party/icu/i18n/unicode/translit.h"
-#include "3party/icu/i18n/unicode/utrans.h"
+#include <icu/common/unicode/uclean.h>
+#include <icu/common/unicode/unistr.h>
+#include <icu/common/unicode/utypes.h>
+#include <icu/i18n/unicode/translit.h>
+#include <icu/i18n/unicode/utrans.h>
 
 #include <cstring>
 #include <mutex>

--- a/coding/zip_creator.cpp
+++ b/coding/zip_creator.cpp
@@ -14,7 +14,7 @@
 #include <ctime>
 #include <vector>
 
-#include "3party/minizip/zip.h"
+#include <minizip/zip.h>
 
 using namespace std;
 

--- a/coding/zip_reader.cpp
+++ b/coding/zip_reader.cpp
@@ -5,7 +5,7 @@
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
 
-#include "3party/minizip/unzip.h"
+#include <minizip/unzip.h>
 
 using namespace std;
 

--- a/descriptions/CMakeLists.txt
+++ b/descriptions/CMakeLists.txt
@@ -10,4 +10,12 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  indexer
+)
+
 omim_add_test_subdirectory(descriptions_tests)

--- a/descriptions/descriptions_tests/CMakeLists.txt
+++ b/descriptions/descriptions_tests/CMakeLists.txt
@@ -9,14 +9,6 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  descriptions
-  indexer
-  platform
   coding
-  base
-  jansson
-  stats_client
-  ${LIBZ}
+  descriptions
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/drape/CMakeLists.txt
+++ b/drape/CMakeLists.txt
@@ -4,15 +4,6 @@ get_filename_component(DRAPE_ROOT ${PROJECT_SOURCE_DIR} ABSOLUTE)
 
 add_definitions(-DU_DISABLE_RENAMING)
 
-include_directories(
-  ${OMIM_ROOT}/3party/freetype/include
-  ${OMIM_ROOT}/3party/glm
-  ${OMIM_ROOT}/3party/icu/common
-  ${OMIM_ROOT}/3party/icu/i18n
-  ${OMIM_ROOT}/3party/Vulkan-Headers/include
-  ${OMIM_ROOT}/3party/vulkan_wrapper
-)
-
 set(
   DRAPE_COMMON_SRC
   ${DRAPE_ROOT}/attribute_buffer_mutator.cpp
@@ -176,5 +167,37 @@ append(
 )
 
 omim_add_library(${PROJECT_NAME} ${DRAPE_COMMON_SRC} ${SRC} ${VULKAN_SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  freetype
+  glm
+  icu
+  sdf_image
+  stats_client
+  stb_image
+  vulkan_wrapper
+)
+
+link_opengl(${PROJECT_NAME})
+
+if (PLATFORM_MAC)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    "-framework Foundation"
+    "-framework QuartzCore"
+  )
+endif()
 
 omim_add_test_subdirectory(drape_tests)

--- a/drape/bidi.cpp
+++ b/drape/bidi.cpp
@@ -2,9 +2,10 @@
 
 #include "base/logging.hpp"
 
-#include "3party/icu/common/unicode/ubidi.h"
-#include "3party/icu/common/unicode/unistr.h"
-#include "3party/icu/common/unicode/ushape.h"
+#include "icu/common/unicode/utypes.h"
+#include "icu/common/unicode/ubidi.h"
+#include "icu/common/unicode/unistr.h"
+#include "icu/common/unicode/ushape.h"
 
 namespace bidi
 {

--- a/drape/drape_tests/CMakeLists.txt
+++ b/drape/drape_tests/CMakeLists.txt
@@ -5,12 +5,6 @@ add_definitions(
   -DGTEST_DONT_DEFINE_TEST
 )
 
-include_directories(
-  ${OMIM_ROOT}/3party/gmock/include
-  ${OMIM_ROOT}/3party/gmock/gtest/include
-  ${OMIM_ROOT}/3party/freetype/include
-)
-
 set(
   SRC
   attribute_provides_tests.cpp
@@ -43,38 +37,28 @@ omim_add_executable(${PROJECT_NAME} ${DRAPE_COMMON_SRC} ${VULKAN_SRC} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  qt_tstfrm
+  base
+  drape
   indexer
   platform
-  coding
-  geometry
-  base
-  icu
-  expat
-  stats_client
-  freetype
-  gmock
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Gui_LIBRARIES}
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
+  qt_tstfrm
 )
 
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gmock
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+)
+
+link_opengl(${PROJECT_NAME})
 link_qt5_core(${PROJECT_NAME})
 
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    "-framework CoreLocation"
-  )
-endif()
-
 if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
   omim_link_libraries(
     ${PROJECT_NAME}
-    dl
+    ${CMAKE_DL_LIBS}
   )
 endif()

--- a/drape/gl_includes.hpp
+++ b/drape/gl_includes.hpp
@@ -14,7 +14,7 @@
   #include "std/windows.hpp"
   #define GL_GLEXT_PROTOTYPES
   #include <GL/gl.h>
-  #include "3party/GL/glext.h"
+  #include <GL/glext.h>
 #elif defined(OMIM_OS_ANDROID)
   #define GL_GLEXT_PROTOTYPES
   #include <GLES2/gl2.h>

--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -1,5 +1,4 @@
 #include "drape/glyph_manager.hpp"
-#include "3party/sdf_image/sdf_image.h"
 
 #include "platform/platform.hpp"
 
@@ -18,6 +17,7 @@
 #include <utility>
 
 #include <ft2build.h>
+#include <sdf_image/sdf_image.h>
 #include FT_TYPES_H
 #include FT_SYSTEM_H
 #include FT_FREETYPE_H

--- a/drape/static_texture.cpp
+++ b/drape/static_texture.cpp
@@ -9,14 +9,14 @@
 
 #include "base/string_utils.hpp"
 
-#ifdef DEBUG
-#include "3party/glm/glm/gtx/bit.hpp"
-#endif
-#include "3party/stb_image/stb_image.h"
-
 #include <functional>
 #include <limits>
 #include <vector>
+
+#ifdef DEBUG
+#include <glm/gtx/bit.hpp>
+#endif
+#include <stb_image/stb_image.h>
 
 namespace dp
 {

--- a/drape/support_manager.cpp
+++ b/drape/support_manager.cpp
@@ -6,13 +6,13 @@
 
 #include "base/logging.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-
 #include "std/target_os.hpp"
 
 #include <algorithm>
 #include <string>
 #include <vector>
+
+#include <Alohalytics/src/alohalytics.h>
 
 namespace dp
 {

--- a/drape/symbols_texture.cpp
+++ b/drape/symbols_texture.cpp
@@ -1,5 +1,4 @@
 #include "drape/symbols_texture.hpp"
-#include "3party/stb_image/stb_image.h"
 
 #include "indexer/map_style_reader.hpp"
 
@@ -11,8 +10,10 @@
 #include "base/string_utils.hpp"
 
 #ifdef DEBUG
-#include "3party/glm/glm/gtx/bit.hpp"
+#include <glm/gtx/bit.hpp>
 #endif
+
+#include <stb_image/stb_image.h>
 
 #include <functional>
 #include <utility>

--- a/drape/texture.cpp
+++ b/drape/texture.cpp
@@ -6,7 +6,7 @@
 
 #include "base/math.hpp"
 
-#include "3party/glm/glm/gtx/bit.hpp"
+#include <glm/gtx/bit.hpp>
 
 namespace dp
 {

--- a/drape_frontend/CMakeLists.txt
+++ b/drape_frontend/CMakeLists.txt
@@ -1,14 +1,5 @@
 project(drape_frontend)
 
-include_directories(
-  .
-  ${OMIM_ROOT}/3party/protobuf/protobuf/src
-  ${OMIM_ROOT}/3party/expat/lib
-  ${OMIM_ROOT}/3party/freetype/include
-  ${OMIM_ROOT}/3party/jansson/src
-  ${OMIM_ROOT}/3party/glm
-)
-
 set(
   SRC
   animation/animation.cpp
@@ -220,5 +211,21 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  drape
+  editor
+  geometry
+  indexer
+  kml
+  platform
+  shaders
+  storage
+  traffic
+  transit
+)
 
 omim_add_test_subdirectory(drape_frontend_tests)

--- a/drape_frontend/color_constants.cpp
+++ b/drape_frontend/color_constants.cpp
@@ -11,10 +11,10 @@
 #include "base/assert.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
-
 #include <fstream>
 #include <map>
+
+#include <jansson/myjansson.hpp>
 
 using namespace std;
 

--- a/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -10,38 +10,11 @@ set(
 
 omim_add_test(${PROJECT_NAME} ${SRC})
 
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    ${Qt5Widgets_LIBRARIES}
-  )
-endif()
-
 omim_link_libraries(
   ${PROJECT_NAME}
-  drape_frontend
-  drape
-  platform
-  indexer
-  geometry
-  coding
   base
-  expat
-  stats_client
-  freetype
-  stb_image
-  sdf_image
-  icu
-  vulkan_wrapper
-  ${LIBZ}
+  drape
+  drape_frontend
+  geometry
+  shaders
 )
-
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})

--- a/drape_frontend/drape_measurer.cpp
+++ b/drape_frontend/drape_measurer.cpp
@@ -4,9 +4,9 @@
 
 #include "geometry/mercator.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-
 #include <iomanip>
+
+#include <Alohalytics/src/alohalytics.h>
 
 namespace df
 {

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -13,13 +13,13 @@
 
 #include "base/math.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-
 #include <algorithm>
 #include <chrono>
 #include <string>
 #include <vector>
 #include <utility>
+
+#include <Alohalytics/src/alohalytics.h>
 
 namespace df
 {

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -40,6 +40,23 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  opening_hours
+  pugixml
+  stats_client
+)
+
 omim_add_test_subdirectory(editor_tests)
 omim_add_test_subdirectory(editor_tests_support)
 omim_add_test_subdirectory(osm_auth_tests)

--- a/editor/config_loader.cpp
+++ b/editor/config_loader.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <iterator>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 using namespace std;
 

--- a/editor/editor_config.hpp
+++ b/editor/editor_config.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 class Reader;
 

--- a/editor/editor_notes.cpp
+++ b/editor/editor_notes.cpp
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <future>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_storage.hpp
+++ b/editor/editor_storage.hpp
@@ -2,7 +2,7 @@
 
 #include <mutex>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace editor
 {

--- a/editor/editor_tests/CMakeLists.txt
+++ b/editor/editor_tests/CMakeLists.txt
@@ -20,31 +20,22 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  editor_tests_support
-  platform_tests_support
-  generator_tests_support
-  generator
-  routing
-  routing_common
-  search
-  editor
-  indexer
-  storage
-  platform
-  geometry
-  coding
   base
-  stats_client
-  opening_hours
+  editor
+  editor_tests_support
+  generator
+  generator_tests_support
+  geometry
+  indexer
+  map
+  platform
+  platform_tests_support
+  search
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   pugixml
-  tess2
-  jansson
-  succinct
-  icu
-  protobuf
-  oauthcpp
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
-  ${Qt5Widgets_LIBRARIES}
 )

--- a/editor/editor_tests/config_loader_test.cpp
+++ b/editor/editor_tests/config_loader_test.cpp
@@ -7,7 +7,7 @@
 
 #include "base/atomic_shared_ptr.hpp"
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/feature_matcher_test.cpp
+++ b/editor/editor_tests/feature_matcher_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/match_by_geometry_test.cpp
+++ b/editor/editor_tests/match_by_geometry_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/xml_feature_test.cpp
+++ b/editor/editor_tests/xml_feature_test.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 using namespace editor;
 

--- a/editor/editor_tests_support/CMakeLists.txt
+++ b/editor/editor_tests_support/CMakeLists.txt
@@ -7,3 +7,10 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  editor
+  indexer
+)

--- a/editor/new_feature_categories.cpp
+++ b/editor/new_feature_categories.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 namespace osm
 {

--- a/editor/opening_hours_ui.hpp
+++ b/editor/opening_hours_ui.hpp
@@ -3,7 +3,7 @@
 #include <set>
 #include <vector>
 
-#include "3party/opening_hours/opening_hours.hpp"
+#include <opening_hours/opening_hours.hpp>
 
 namespace editor
 {

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -13,7 +13,7 @@
 
 #include "private.h"
 
-#include "3party/liboauthcpp/include/liboauthcpp/liboauthcpp.h"
+#include <liboauthcpp/liboauthcpp.h>
 
 using namespace std;
 

--- a/editor/osm_auth_tests/CMakeLists.txt
+++ b/editor/osm_auth_tests/CMakeLists.txt
@@ -10,19 +10,13 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  editor
-  indexer
-  platform
-  platform_tests_support
-  geometry
-  coding
   base
+  editor
+  geometry
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   pugixml
-  protobuf
-  jansson
-  icu
-  oauthcpp
-  stats_client
-  ${LIBZ}
-  ${Qt5Widgets_LIBRARIES}
 )

--- a/editor/osm_auth_tests/server_api_test.cpp
+++ b/editor/osm_auth_tests/server_api_test.cpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <string>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 using osm::ServerApi06;
 using osm::OsmOAuth;

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -39,9 +39,9 @@
 #include <array>
 #include <sstream>
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/opening_hours/opening_hours.hpp"
-#include "3party/pugixml/src/pugixml.hpp"
+#include <Alohalytics/src/alohalytics.h>
+#include <opening_hours/opening_hours.hpp>
+#include <pugixml/src/pugixml.hpp>
 
 using namespace std;
 

--- a/editor/server_api.cpp
+++ b/editor/server_api.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <sstream>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/ui2oh.cpp
+++ b/editor/ui2oh.cpp
@@ -6,7 +6,7 @@
 #include <set>
 #include <string>
 
-#include "3party/opening_hours/opening_hours.hpp"
+#include <opening_hours/opening_hours.hpp>
 
 namespace
 {

--- a/editor/user_stats.cpp
+++ b/editor/user_stats.cpp
@@ -10,7 +10,7 @@
 #include "base/thread.hpp"
 #include "base/timer.hpp"
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace
 {

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace osm
 {

--- a/feature_list/CMakeLists.txt
+++ b/feature_list/CMakeLists.txt
@@ -1,42 +1,17 @@
 project(feature_list_generator)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(SRC feature_list.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
   generator
-  routing
-  traffic
-  routing_common
-  search_quality
-  search_tests_support
-  search
-  storage
-  kml
-  editor
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  agg
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  succinct
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  search
+  search_quality
+  storage
 )
-
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(generator)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   affiliation.cpp
@@ -227,6 +222,33 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  descriptions
+  geometry
+  indexer
+  platform
+  routing
+  routing_common
+  search
+  storage
+  traffic
+  transit
+  ugc
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+  sqlite3
+  succinct
+  tess2
+  ${CMAKE_DL_LIBS}
+)
 
 omim_add_test_subdirectory(generator_tests_support)
 omim_add_test_subdirectory(generator_tests)

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -32,9 +32,9 @@
 #include <utility>
 #include <vector>
 
-#include "3party/succinct/elias_fano.hpp"
-#include "3party/succinct/mapper.hpp"
-#include "3party/succinct/rs_bit_vector.hpp"
+#include <succinct/elias_fano.hpp>
+#include <succinct/mapper.hpp>
+#include <succinct/rs_bit_vector.hpp>
 
 using namespace feature;
 

--- a/generator/booking_quality_check/CMakeLists.txt
+++ b/generator/booking_quality_check/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(booking_quality_check)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   booking_quality_check.cpp
@@ -14,29 +9,19 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator
-  search
-  routing
-  traffic
-  routing_common
-  editor
-  indexer
-  geometry
-  platform
-  coding
   base
-  expat
-  gflags
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  succinct
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  coding
+  generator
+  geometry
+  indexer
+  map
+  platform
+  search
+  storage
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/generator/booking_quality_check/booking_addr_match.cpp
+++ b/generator/booking_quality_check/booking_addr_match.cpp
@@ -31,7 +31,7 @@
 #include <memory>
 #include <numeric>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace generator;
 using namespace storage;

--- a/generator/booking_quality_check/booking_quality_check.cpp
+++ b/generator/booking_quality_check/booking_quality_check.cpp
@@ -27,7 +27,7 @@
 #include <numeric>
 #include <random>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 #include "boost/range/adaptor/map.hpp"
 #include "boost/range/algorithm/copy.hpp"

--- a/generator/brands_loader.cpp
+++ b/generator/brands_loader.cpp
@@ -8,7 +8,7 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <algorithm>
 #include <cstdint>

--- a/generator/complex_generator/CMakeLists.txt
+++ b/generator/complex_generator/CMakeLists.txt
@@ -1,47 +1,20 @@
 project(complex_generator)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(SRC complex_generator.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator
-  routing
-  traffic
-  routing_common
-  descriptions
-  transit
-  ugc
-  search
-  storage
-  editor
-  indexer
-  mwm_diff
-  platform
-  geometry
-  coding
   base
-  opening_hours
-  freetype
-  expat
-  icu
-  jansson
-  protobuf
-  bsdiff
-  stats_client
-  minizip
-  succinct
-  pugixml
-  tess2
-  gflags
-  oauthcpp
-  sqlite3
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  coding
+  generator
+  indexer
+  platform
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/generator/complex_generator/complex_generator.cpp
+++ b/generator/complex_generator/complex_generator.cpp
@@ -42,7 +42,7 @@
 #include "build_version.hpp"
 #include "defines.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(node_storage, "map",
               "Type of storage for intermediate points representation. Available: raw, map, mem.");

--- a/generator/extract_addr/CMakeLists.txt
+++ b/generator/extract_addr/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(extract_addr)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   extract_addr.cpp
@@ -13,28 +9,15 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator
-  search
-  routing
-  traffic
-  routing_common
-  indexer
-  editor
-  geometry
-  platform
-  coding
   base
-  minizip
-  jansson
-  pugixml
-  stats_client
-  opening_hours
-  succinct
-  oauthcpp
-  expat
-  protobuf
-  icu
-  ${LIBZ}
+  generator
+  geometry
+  indexer
+  platform
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)

--- a/generator/extract_addr/extract_addr.cpp
+++ b/generator/extract_addr/extract_addr.cpp
@@ -11,7 +11,7 @@
 
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/generator/feature_segments_checker/CMakeLists.txt
+++ b/generator/feature_segments_checker/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(feature_segments_checker)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   feature_segments_checker.cpp
@@ -14,23 +9,16 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
   generator
-  routing
-  traffic
-  routing_common
+  geometry
   indexer
   platform
-  geometry
-  coding
-  base
-  gflags
-  icu
-  jansson
-  minizip
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
+  routing_common
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -26,7 +26,7 @@
 #include <set>
 #include <string>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace std;
 

--- a/generator/filter_elements.hpp
+++ b/generator/filter_elements.hpp
@@ -43,7 +43,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace generator
 {

--- a/generator/generator_integration_tests/CMakeLists.txt
+++ b/generator/generator_integration_tests/CMakeLists.txt
@@ -11,54 +11,9 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator_tests_support
-  platform_tests_support
+  base
+  coding
   generator
-  drape_frontend
-  shaders
-  map
-  routing
-  search
-  storage
-  drape
-  traffic
-  routing_common
-  descriptions
-  transit
-  kml
-  editor
   indexer
   platform
-  geometry
-  coding
-  base
-  freetype
-  expat
-  icu
-  agg
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  pugixml
-  tess2
-  gflags
-  oauthcpp
-  opening_hours
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  # TODO(syershov): Use FindPackage.
-  sqlite3
-  ${LIBZ}
 )
-
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_qt5_core(${PROJECT_NAME})

--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -51,45 +51,17 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator_tests_support
-  platform_tests_support
-  generator
-  routing
-  search
-  storage
-  traffic
-  routing_common
+  base
+  coding
   descriptions
-  transit
-  editor
+  generator
+  generator_tests_support
+  geometry
   indexer
   platform
-  geometry
-  coding
-  base
-  expat
-  icu
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  pugixml
-  tess2
-  gflags
-  oauthcpp
-  opening_hours
+  platform_tests_support
+  routing
+  routing_common
   ugc
-  # TODO(syershov): Use FindPackage.
-  sqlite3
-  ${LIBZ}
 )
 
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_qt5_core(${PROJECT_NAME})

--- a/generator/generator_tests_support/CMakeLists.txt
+++ b/generator/generator_tests_support/CMakeLists.txt
@@ -15,3 +15,17 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  editor
+  generator
+  geometry
+  indexer
+  platform
+  routing
+  routing_common
+  storage
+)

--- a/generator/generator_tool/CMakeLists.txt
+++ b/generator/generator_tool/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(generator_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(SRC generator_tool.cpp)
 
 if (BUILD_DESIGNER)
@@ -12,40 +10,17 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator
-  routing
-  traffic
-  routing_common
-  descriptions
-  transit
-  ugc
-  search
-  storage
-  editor
-  indexer
-  mwm_diff
-  platform
-  geometry
-  coding
   base
-  opening_hours
-  freetype
-  expat
-  icu
-  jansson
-  protobuf
-  bsdiff
-  stats_client
-  minizip
-  succinct
-  pugixml
-  tess2
-  gflags
-  oauthcpp
-  sqlite3
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  coding
+  generator
+  indexer
+  platform
+  routing
+  storage
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -67,7 +67,7 @@
 #include "build_version.hpp"
 #include "defines.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace std;
 

--- a/generator/mwm_diff/CMakeLists.txt
+++ b/generator/mwm_diff/CMakeLists.txt
@@ -8,5 +8,17 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  bsdiff
+)
+
 omim_add_pybindings_subdirectory(pymwm_diff)
 omim_add_test_subdirectory(mwm_diff_tests)

--- a/generator/mwm_diff/diff.cpp
+++ b/generator/mwm_diff/diff.cpp
@@ -17,7 +17,7 @@
 #include <iterator>
 #include <vector>
 
-#include "3party/bsdiff-courgette/bsdiff/bsdiff.h"
+#include <bsdiff/bsdiff.h>
 
 using namespace std;
 

--- a/generator/mwm_diff/mwm_diff_tests/CMakeLists.txt
+++ b/generator/mwm_diff/mwm_diff_tests/CMakeLists.txt
@@ -9,13 +9,8 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  mwm_diff
-  bsdiff
-  platform
-  coding
   base
-  stats_client
-  ${LIBZ}
+  coding
+  generator
+  platform
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/generator/promo_catalog_cities.hpp
+++ b/generator/promo_catalog_cities.hpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <unordered_set>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace promo
 {

--- a/generator/region_meta.cpp
+++ b/generator/region_meta.cpp
@@ -4,7 +4,7 @@
 
 #include "platform/platform.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <cstdint>
 #include <vector>

--- a/generator/srtm_coverage_checker/CMakeLists.txt
+++ b/generator/srtm_coverage_checker/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(srtm_coverage_checker)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   srtm_coverage_checker.cpp
@@ -14,23 +9,16 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
   generator
-  routing
-  traffic
-  routing_common
+  geometry
   indexer
   platform
-  geometry
-  coding
-  base
-  gflags
-  icu
-  jansson
-  minizip
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
+  routing
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
+++ b/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
@@ -1,5 +1,7 @@
 #include "generator/srtm_parser.hpp"
 
+#include "generator/srtm_parser.hpp"
+
 #include "routing/routing_helpers.hpp"
 
 #include "indexer/classificator_loader.hpp"
@@ -22,7 +24,7 @@
 #include <limits>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(srtm_path, "", "Path to directory with SRTM files");
 DEFINE_string(mwm_path, "", "Path to mwm files (writable dir)");

--- a/generator/tesselator.cpp
+++ b/generator/tesselator.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <queue>
 
-#include "3party/libtess2/Include/tesselator.h"
+#include <libtess2/Include/tesselator.h>
 
 namespace tesselator
 {

--- a/generator/transit_generator.cpp
+++ b/generator/transit_generator.cpp
@@ -34,7 +34,7 @@
 
 #include "defines.hpp"
 
-#include "3party/jansson/src/jansson.h"
+#include <jansson/myjansson.hpp>
 
 using namespace generator;
 using namespace platform;

--- a/generator/ugc_translator.cpp
+++ b/generator/ugc_translator.cpp
@@ -10,7 +10,7 @@
 
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace generator
 {

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -62,4 +62,13 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+)
+
+# Also depends on:
+#   3party/robust
+#   3party/kdtree++
+
 omim_add_test_subdirectory(geometry_tests)

--- a/geometry/geometry_tests/CMakeLists.txt
+++ b/geometry/geometry_tests/CMakeLists.txt
@@ -42,4 +42,8 @@ set(
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})
-omim_link_libraries(${PROJECT_NAME} geometry base)
+
+omim_link_libraries(${PROJECT_NAME}
+  base
+  geometry
+)

--- a/geometry/region2d/boost_concept.hpp
+++ b/geometry/region2d/boost_concept.hpp
@@ -6,12 +6,12 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#include "3party/boost/boost/polygon/detail/polygon_sort_adaptor.hpp"
-#include "3party/boost/boost/polygon/polygon.hpp"
+#include <boost/polygon/detail/polygon_sort_adaptor.hpp>
+#include <boost/polygon/polygon.hpp>
 #pragma clang diagnostic pop
 #else
-#include "3party/boost/boost/polygon/detail/polygon_sort_adaptor.hpp"
-#include "3party/boost/boost/polygon/polygon.hpp"
+#include <boost/polygon/detail/polygon_sort_adaptor.hpp>
+#include <boost/polygon/polygon.hpp>
 #endif
 
 #include <vector>

--- a/geometry/robust_orientation.cpp
+++ b/geometry/robust_orientation.cpp
@@ -8,10 +8,10 @@ extern "C" {
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wconditional-uninitialized"
-#include "3party/robust/predicates.c"
+#include <robust/predicates.c>
 #pragma clang diagnostic pop
 #else
-#include "3party/robust/predicates.c"
+#include <robust/predicates.c>
 #endif
 }
 

--- a/geometry/tree4d.hpp
+++ b/geometry/tree4d.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "3party/kdtree++/kdtree.hpp"
+#include <kdtree++/kdtree.hpp>
 
 namespace m4
 {

--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(indexer)
 
-include_directories(${OMIM_ROOT}/3party/protobuf/protobuf/src)
-
 set(
   SRC
   altitude_loader.cpp
@@ -137,5 +135,24 @@ set(
 file(COPY ${OTHER_FILES} DESTINATION ${CMAKE_BINARY_DIR})
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  platform
+  search
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  protobuf
+  succinct
+)
+
+# Also depends on:
+#   3party/utfcpp
 
 omim_add_test_subdirectory(indexer_tests)

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -13,7 +13,7 @@
 
 #include <algorithm>
 
-#include "3party/succinct/mapper.hpp"
+#include <succinct/mapper.hpp>
 
 using namespace std;
 

--- a/indexer/centers_table.cpp
+++ b/indexer/centers_table.cpp
@@ -19,8 +19,8 @@
 
 #include <unordered_map>
 
-#include "3party/succinct/elias_fano.hpp"
-#include "3party/succinct/rs_bit_vector.hpp"
+#include <succinct/elias_fano.hpp>
+#include <succinct/rs_bit_vector.hpp>
 
 using namespace std;
 

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -124,7 +124,7 @@ public:
   }
 
   template <typename Functor>
-  void ForEachTriangleEx(Functor && f, int scale) const
+  void ForEachTriangleEx(Functor && f, int scale)
   {
     f.StartPrimitive(m_triangles.size());
     ForEachTriangle(std::forward<Functor>(f), scale);

--- a/indexer/features_offsets_table.hpp
+++ b/indexer/features_offsets_table.hpp
@@ -15,8 +15,8 @@
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
-#include "3party/succinct/elias_fano.hpp"
-#include "3party/succinct/mapper.hpp"
+#include <succinct/elias_fano.hpp>
+#include <succinct/mapper.hpp>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -42,32 +42,11 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator_tests_support
-  search_tests_support
-  platform_tests_support
-  generator
-  search
-  routing
-  routing_common
-  indexer
-  storage
-  editor
-  platform
-  coding
-  geometry
   base
-  stats_client
-  icu
-  jansson
-  tess2
-  protobuf
-  succinct
-  opening_hours
-  oauthcpp
-  pugixml
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  coding
+  generator
+  generator_tests_support
+  geometry
+  indexer
+  platform
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -6,12 +6,12 @@
 #include "base/macros.hpp"
 #include "base/mem_trie.hpp"
 
-#include "3party/utfcpp/source/utf8/unchecked.h"
-
 #include <algorithm>
 #include <memory>
 #include <queue>
 #include <vector>
+
+#include <utfcpp/source/utf8/unchecked.h>
 
 using namespace std;
 using namespace strings;

--- a/iphone/Maps/Common/Statistics/Statistics.mm
+++ b/iphone/Maps/Common/Statistics/Statistics.mm
@@ -3,7 +3,7 @@
 #import "MWMCustomFacebookEvents.h"
 #import "MWMSettings.h"
 
-#import "3party/Alohalytics/src/alohalytics.h"
+#import <Alohalytics/src/alohalytics.h>
 #import "3party/Alohalytics/src/alohalytics_objc.h"
 #import "Flurry.h"
 #import <MyTrackerSDK/MRMyTracker.h>

--- a/kml/CMakeLists.txt
+++ b/kml/CMakeLists.txt
@@ -16,5 +16,14 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+)
+
 omim_add_pybindings_subdirectory(pykmlib)
 omim_add_test_subdirectory(kml_tests)

--- a/kml/kml_tests/CMakeLists.txt
+++ b/kml/kml_tests/CMakeLists.txt
@@ -10,20 +10,8 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  kml
-  indexer
-  editor
-  platform
-  coding
-  geometry
   base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  pugixml
-  expat
-  stats_client
-  ${LIBZ}
+  coding
+  indexer
+  kml
 )
-link_qt5_core(${PROJECT_NAME})

--- a/local_ads/CMakeLists.txt
+++ b/local_ads/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(local_ads)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   campaign.hpp
@@ -21,6 +17,16 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  indexer
+  platform
+  routing
+  storage
+)
 
 omim_add_pybindings_subdirectory(pylocal_ads)
 omim_add_test_subdirectory(local_ads_tests)

--- a/local_ads/local_ads_tests/CMakeLists.txt
+++ b/local_ads/local_ads_tests/CMakeLists.txt
@@ -11,16 +11,8 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  local_ads
-  platform_tests_support
-  platform
-  coding
-  geometry
   base
-  jansson
-  oauthcpp
-  stats_client
-  ${LIBZ}
+  local_ads
+  platform
+  platform_tests_support
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/local_ads/statistics.cpp
+++ b/local_ads/statistics.cpp
@@ -21,7 +21,7 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <functional>
 #include <memory>

--- a/map/CMakeLists.txt
+++ b/map/CMakeLists.txt
@@ -1,12 +1,5 @@
 project(map)
 
-include_directories(
-  ${OMIM_ROOT}/3party/protobuf/protobuf/src
-  ${OMIM_ROOT}/3party/freetype/include
-  ${OMIM_ROOT}/3party/jansson/src
-  ${OMIM_ROOT}/3party/glm
-)
-
 set(
   SRC
   ../api/src/c/api-client.c
@@ -141,6 +134,39 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  descriptions
+  drape
+  drape_frontend
+  editor
+  geometry
+  indexer
+  kml
+  local_ads
+  metrics
+  partners_api
+  platform
+  routing
+  routing_common
+  search
+  storage
+  tracking
+  traffic
+  ugc
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  opening_hours
+  jansson
+  agg
+  stats_client
+)
 
 omim_add_test_subdirectory(map_integration_tests)
 omim_add_test_subdirectory(map_tests)

--- a/map/benchmark_tool/CMakeLists.txt
+++ b/map/benchmark_tool/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(benchmark_tool)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   api.cpp
@@ -17,25 +12,14 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  editor
-  indexer
-  metrics
-  geometry
-  platform
-  coding
   base
-  gflags
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  succinct
-  ${LIBZ}
+  indexer
+  map
+  platform
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/map/benchmark_tool/main.cpp
+++ b/map/benchmark_tool/main.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace std;
 

--- a/map/benchmark_tools.cpp
+++ b/map/benchmark_tools.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace
 {

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -43,7 +43,7 @@
 #include <sstream>
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace std::placeholders;
 

--- a/map/chart_generator.cpp
+++ b/map/chart_generator.cpp
@@ -5,14 +5,14 @@
 
 #include <algorithm>
 
-#include "3party/agg/agg_conv_curve.h"
-#include "3party/agg/agg_conv_stroke.h"
-#include "3party/agg/agg_path_storage.h"
-#include "3party/agg/agg_pixfmt_rgba.h"
-#include "3party/agg/agg_rasterizer_scanline_aa.h"
-#include "3party/agg/agg_renderer_primitives.h"
-#include "3party/agg/agg_renderer_scanline.h"
-#include "3party/agg/agg_scanline_p.h"
+#include <agg/agg_conv_curve.h>
+#include <agg/agg_conv_stroke.h>
+#include <agg/agg_path_storage.h>
+#include <agg/agg_pixfmt_rgba.h>
+#include <agg/agg_rasterizer_scanline_aa.h>
+#include <agg/agg_renderer_primitives.h>
+#include <agg/agg_renderer_scanline.h>
+#include <agg/agg_scanline_p.h>
 
 using namespace std;
 

--- a/map/cloud.cpp
+++ b/map/cloud.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <sstream>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 #include "private.h"
 

--- a/map/extrapolation_benchmark/CMakeLists.txt
+++ b/map/extrapolation_benchmark/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(extrapolation_benchmark)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   extrapolation_benchmark.cpp
@@ -14,16 +9,15 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  routing
-  metrics
-  platform
-  geometry
-  coding
   base
-  stats_client
-  gflags
-  ${LIBZ}
+  geometry
+  map
+  platform
+  routing
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/map/extrapolation_benchmark/extrapolation_benchmark.cpp
+++ b/map/extrapolation_benchmark/extrapolation_benchmark.cpp
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
-#include "3party/gflags/src/gflags/gflags_declare.h"
+#include <gflags/gflags.h>
+#include <gflags/gflags_declare.h>
 
 // This tool is written to estimate quality of location extrapolation. To launch the benchmark
 // you need tracks in csv file with the format described below. To generate the csv file

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -15,8 +15,6 @@
 #include "map/utils.hpp"
 #include "map/viewport_search_params.hpp"
 
-#include "generator/borders.hpp"
-
 #include "routing/city_roads.hpp"
 #include "routing/index_router.hpp"
 #include "routing/online_absent_fetcher.hpp"
@@ -112,7 +110,7 @@
 #include "defines.hpp"
 #include "private.h"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace location;
 using namespace notifications;

--- a/map/map_integration_tests/CMakeLists.txt
+++ b/map/map_integration_tests/CMakeLists.txt
@@ -9,37 +9,10 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  search_tests_support
+  base
   editor_tests_support
   generator_tests_support
-  generator
-  routing
-  routing_common
+  map
   search
-  storage
-  stats_client
-  editor
-  indexer
-  metrics
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
-  tess2
-  protobuf
-  jansson
-  succinct
-  pugixml
-  opening_hours
-  icu
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
+  search_tests_support
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/map/map_tests/CMakeLists.txt
+++ b/map/map_tests/CMakeLists.txt
@@ -34,65 +34,20 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
-  metrics_tests_support
-  search_tests_support
-  editor_tests_support
-  generator_tests_support
-  generator
-  map
-  drape_frontend
-  shaders
-  drape
-  routing
-  traffic
-  transit
-  tracking
-  routing_common
-  search
-  storage
-  metrics
-  mwm_diff
-  bsdiff
-  descriptions
-  ugc
-  partners_api
-  local_ads
-  kml
-  editor
-  indexer
-  platform
-  geometry
-  coding
   base
-
-  agg
-  expat
-  freetype
-  icu
-  jansson
-  minizip
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  sdf_image
-  stb_image
-  succinct
-  tess2
-  stats_client
-  vulkan_wrapper
-  ${Qt5Widgets_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
+  coding
+  drape_frontend
+  generator
+  generator_tests_support
+  geometry
+  indexer
+  map
+  metrics
+  metrics_tests_support
+  partners_api
+  platform
+  platform_tests_support
+  search
+  search_tests_support
+  storage
 )
-
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})

--- a/map/mwm_tests/CMakeLists.txt
+++ b/map/mwm_tests/CMakeLists.txt
@@ -8,39 +8,12 @@ set(
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})
+
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  search
-  storage
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  geometry
-  coding
   base
-  opening_hours
-  freetype
-  icu
-  agg
-  expat
-  oauthcpp
-  protobuf
-  jansson
-  succinct
-  pugixml
-  stats_client
-  ${LIBZ}
+  geometry
+  indexer
+  map
+  platform
 )
-
-link_qt5_core(${PROJECT_NAME})
-link_opengl(${PROJECT_NAME})
-
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    "-framework QuartzCore"
-  )
-endif()

--- a/map/osm_opening_hours.hpp
+++ b/map/osm_opening_hours.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "3party/opening_hours/opening_hours.hpp"
-
 #include "base/assert.hpp"
 
 #include <chrono>
 #include <ctime>
 #include <string>
+
+#include <opening_hours/opening_hours.hpp>
 
 namespace osm
 {

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -39,8 +39,8 @@
 #include "base/scope_guard.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/jansson/myjansson.hpp"
+#include <Alohalytics/src/alohalytics.h>
+#include <jansson/myjansson.hpp>
 
 #include <iomanip>
 #include <ios>

--- a/map/style_tests/CMakeLists.txt
+++ b/map/style_tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(style_tests)
 
-include_directories(${OMIM_ROOT}/3party/protobuf/protobuf/src)
-
 set(
   SRC
   classificator_tests.cpp
@@ -9,7 +7,6 @@ set(
   helpers.hpp
   style_symbols_consistency_test.cpp
 )
-
 
 if (BUILD_DESIGNER)
   set(SRC MACOSX_BUNDLE ${SRC})
@@ -19,18 +16,9 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  indexer
-  platform
-  geometry
-  coding
   base
-  expat
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
+  coding
+  indexer
+  map
+  platform
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/map/traffic_manager.cpp
+++ b/map/traffic_manager.cpp
@@ -12,7 +12,7 @@
 
 #include "platform/platform.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace std::chrono;
 

--- a/map/user.cpp
+++ b/map/user.cpp
@@ -26,8 +26,8 @@
 
 #include "private.h"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/jansson/myjansson.hpp"
+#include <Alohalytics/src/alohalytics.h>
+#include <jansson/myjansson.hpp>
 
 namespace
 {

--- a/mapshot/CMakeLists.txt
+++ b/mapshot/CMakeLists.txt
@@ -1,11 +1,5 @@
 project(mapshot_tool)
 
-include_directories(
-  .
-  ${OMIM_ROOT}/3party/glm
-  ${OMIM_ROOT}/3party/gflags/src
-)
-
 set(
   SRC
   mapshot.cpp
@@ -15,53 +9,15 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
+  drape_frontend
+  geometry
   map
   software_renderer
-  drape_frontend
-  shaders
-  routing
-  search
-  storage
-  tracking
-  traffic
-  routing_common
-  ugc
-  drape
-  partners_api
-  local_ads
-  kml
-  indexer
-  platform
-  editor
-  geometry
-  coding
-  base
-  freetype
-  expat
-  gflags
-  icu
-  agg
-  jansson
-  protobuf
-  osrm
-  stats_client
-  minizip
-  succinct
-  pugixml
-  oauthcpp
-  opening_hours
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  ${LIBZ}
 )
 
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/mapshot/mapshot.cpp
+++ b/mapshot/mapshot.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <string>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 #pragma mark Define options
 //----------------------------------------------------------------------------------------
@@ -131,7 +131,7 @@ void DrawFrame(Framework & framework,
 
   int const upperScale = scales::GetUpperScale();
 
-  framework.GetIndex().ForEachInRect([&doDraw](FeatureType & ft) { doDraw(ft); }, selectRect, min(upperScale, drawScale));
+  framework.GetDataSource().ForEachInRect([&doDraw](FeatureType & ft) { doDraw(ft); }, selectRect, std::min(upperScale, drawScale));
 
   cpuDrawer->Flush();
   //cpuDrawer->DrawMyPosition(screen.GtoP(center));

--- a/metrics/CMakeLists.txt
+++ b/metrics/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(metrics)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(
   SRC
   eye.cpp
@@ -14,6 +12,20 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)
 
 omim_add_test_subdirectory(metrics_tests)
 omim_add_test_subdirectory(metrics_tests_support)

--- a/metrics/metrics_tests/CMakeLists.txt
+++ b/metrics/metrics_tests/CMakeLists.txt
@@ -8,14 +8,7 @@ set(
 omim_add_test(${PROJECT_NAME} ${SRC})
 omim_link_libraries(
   ${PROJECT_NAME}
-  metrics_tests_support
-  metrics
-  platform
   coding
-  geometry
-  base
-  stats_client
-  jansson
-  ${LIBZ})
-
-link_qt5_core(${PROJECT_NAME})
+  metrics
+  metrics_tests_support
+)

--- a/metrics/metrics_tests_support/CMakeLists.txt
+++ b/metrics/metrics_tests_support/CMakeLists.txt
@@ -7,3 +7,11 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  metrics
+  platform
+)

--- a/openlr/CMakeLists.txt
+++ b/openlr/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(openlr)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   cache_line_size.hpp
@@ -41,6 +37,19 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  geometry
+  indexer
+  platform
+  routing
+  routing_common
+  storage
+)
+
 add_subdirectory(openlr_match_quality)
 add_subdirectory(openlr_stat)
+
 omim_add_test_subdirectory(openlr_tests)

--- a/openlr/decoded_path.hpp
+++ b/openlr/decoded_path.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 class DataSource;
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/CMakeLists.txt
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/CMakeLists.txt
@@ -3,12 +3,6 @@ project(openlr_assessment_tool)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/glm
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(
   SRC
   main.cpp
@@ -32,64 +26,35 @@ omim_add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  qt_common
-  map
-  drape_frontend
-  shaders
-  routing
-  search_quality
-  search
-  storage
-  tracking
-  traffic
-  routing_common
-  transit
-  descriptions
-  ugc
-  drape
-  partners_api
-  local_ads
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  expat
-  freetype
-  icu
-  agg
-  gflags
-  jansson
-  minizip
-  oauthcpp
-  opening_hours
+  drape_frontend
+  geometry
+  indexer
+  map
   openlr
-  protobuf
-  pugixml
-  sdf_image
-  stats_client
-  stb_image
-  succinct
-  vulkan_wrapper
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
+  platform
+  qt_common
+  routing
+  routing_common
+  storage
 )
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+  ${Qt5Widgets_LIBRARIES}
+)
+
+link_opengl(${PROJECT_NAME})
+link_qt5_core(${PROJECT_NAME})
 
 if (PLATFORM_LINUX)
   omim_link_libraries(
     ${PROJECT_NAME}
-    dl
+    ${CMAKE_DL_LIBS}
   )
 endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
 
 if (PLATFORM_MAC)
   set_target_properties(

--- a/openlr/openlr_match_quality/openlr_assessment_tool/main.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/main.cpp
@@ -2,7 +2,7 @@
 
 #include "openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 #include <cstdio>
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
@@ -3,7 +3,7 @@
 #include "openlr/decoded_path.hpp"
 #include "openlr/openlr_model.hpp"
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 namespace openlr
 {

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
@@ -8,7 +8,7 @@
 #include "base/assert.hpp"
 #include "base/scope_guard.hpp"
 
-#include "3party/pugixml/src/utils.hpp"
+#include <pugixml/src/utils.hpp>
 
 #include <QItemSelection>
 #include <QMessageBox>

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
@@ -11,7 +11,7 @@
 
 #include "base/exception.hpp"
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -10,7 +10,7 @@
 
 #include "boost/optional.hpp"
 
-#include "3party/pugixml/src/pugixml.hpp"
+#include <pugixml/src/pugixml.hpp>
 
 using namespace std;
 

--- a/openlr/openlr_stat/CMakeLists.txt
+++ b/openlr/openlr_stat/CMakeLists.txt
@@ -1,37 +1,25 @@
 project(openlr_stat)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   openlr_stat.cpp
 )
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
-omim_link_libraries(${PROJECT_NAME}
-  openlr
-  routing
-  traffic
-  routing_common
-  storage
-  editor
-  indexer
-  mwm_diff
-  platform
-  geometry
-  coding
+
+omim_link_libraries(
+  ${PROJECT_NAME}
   base
-  gflags
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  bsdiff
-  pugixml
-  stats_client
-  ${Qt5Core_LIBRARIES}
-  ${LIBZ}
+  indexer
+  openlr
+  platform
+  routing
+  storage
 )
 
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+  pugixml
+)

--- a/openlr/openlr_stat/openlr_stat.cpp
+++ b/openlr/openlr_stat/openlr_stat.cpp
@@ -27,8 +27,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
-#include "3party/pugixml/src/pugixml.hpp"
+#include <gflags/gflags.h>
+#include <pugixml/src/pugixml.hpp>
 
 DEFINE_string(input, "", "Path to OpenLR file.");
 DEFINE_string(spark_output, "", "Path to output file in spark-oriented format");

--- a/openlr/openlr_tests/CMakeLists.txt
+++ b/openlr/openlr_tests/CMakeLists.txt
@@ -9,32 +9,11 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
+  generator
+  indexer
+  openlr
+  platform
   platform_tests_support
   generator_tests_support
-  platform_tests_support
-  generator
-  routing
-  search
-  storage
-  openlr
-  editor
-  indexer
-  routing_common
-  platform
-  coding
-  geometry
-  base
-  jansson
-  tess2
-  oauthcpp
-  opening_hours
-  pugixml
-  stats_client
-  succinct
-  protobuf
-  icu
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${Qt5Core_LIBRARIES}
-  ${LIBZ}
 )

--- a/openlr/openlr_tests/decoded_path_test.cpp
+++ b/openlr/openlr_tests/decoded_path_test.cpp
@@ -22,8 +22,8 @@
 #include <sstream>
 #include <vector>
 
-#include "3party/pugixml/src/pugixml.hpp"
-#include "3party/pugixml/src/utils.hpp"
+#include <pugixml/src/pugixml.hpp>
+#include <pugixml/src/utils.hpp>
 
 using namespace generator::tests_support;
 using namespace platform::tests_support;

--- a/partners_api/CMakeLists.txt
+++ b/partners_api/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(partners_api)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(
   SRC
   ads_base.cpp
@@ -62,5 +60,22 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  metrics
+  platform
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)
 
 omim_add_test_subdirectory(partners_api_tests)

--- a/partners_api/booking_api.cpp
+++ b/partners_api/booking_api.cpp
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <utility>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/partners_api/locals_api.cpp
+++ b/partners_api/locals_api.cpp
@@ -12,7 +12,7 @@
 
 #include "defines.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/partners_api/maxim_api.cpp
+++ b/partners_api/maxim_api.cpp
@@ -13,7 +13,7 @@
 #include <limits>
 #include <sstream>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/partners_api/partners_api_tests/CMakeLists.txt
+++ b/partners_api/partners_api_tests/CMakeLists.txt
@@ -24,29 +24,19 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
+  base
+  geometry
+  indexer
+  metrics
   metrics_tests_support
   partners_api
-  metrics
-  storage
-  indexer
   platform
-  editor
-  mwm_diff
-  bsdiff
-  geometry 
-  coding
-  base
-  jansson
-  stats_client
-  pugixml
-  protobuf
-  oauthcpp
-  opening_hours
-  icu
-  ${LIBZ}
-  ${Qt5Widgets_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
+  platform_tests_support
+  platform_tests_support
 )
 
-link_qt5_core(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)

--- a/partners_api/partners_api_tests/uber_tests.cpp
+++ b/partners_api/partners_api_tests/uber_tests.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 using namespace std;
 using namespace taxi;

--- a/partners_api/promo_api.cpp
+++ b/partners_api/promo_api.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <utility>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 using namespace base;
 

--- a/partners_api/rutaxi_api.cpp
+++ b/partners_api/rutaxi_api.cpp
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <utility>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/partners_api/uber_api.cpp
+++ b/partners_api/uber_api.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <utility>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/partners_api/yandex_api.cpp
+++ b/partners_api/yandex_api.cpp
@@ -14,7 +14,7 @@
 #include <limits>
 #include <sstream>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(platform)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src ${OMIM_ROOT}/platform)
-
 set(CMAKE_AUTOMOC ON)
 
 set(
@@ -151,12 +149,46 @@ add_subdirectory(platform_tests_support)
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+  stats_client
+)
+
+link_qt5_core(${PROJECT_NAME})
+
 if (APPLE)
   target_compile_options(${PROJECT_NAME} PUBLIC "-fobjc-arc")
 endif()
 
 if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+
   link_qt5_network(${PROJECT_NAME})
+elseif (PLATFORM_MAC)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    "-framework CFNetwork"
+    "-framework CoreFoundation"
+    "-framework CoreLocation"
+    "-framework Foundation"
+    "-framework IOKit"
+    "-framework Security"
+    "-framework SystemConfiguration"
+  )
 endif()
 
 omim_add_test_subdirectory(platform_tests)

--- a/platform/get_text_by_id.cpp
+++ b/platform/get_text_by_id.cpp
@@ -5,7 +5,7 @@
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "std/target_os.hpp"
 

--- a/platform/http_request.cpp
+++ b/platform/http_request.cpp
@@ -19,7 +19,7 @@
 
 #include "defines.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace std;
 

--- a/platform/platform_tests/CMakeLists.txt
+++ b/platform/platform_tests/CMakeLists.txt
@@ -21,28 +21,24 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
-  platform
-  coding
   base
-  jansson
-  minizip
-  oauthcpp
-  stats_client
-  ${LIBZ}
+  coding
+  platform
+  platform_tests_support
 )
 
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    ${Qt5Widgets_LIBRARIES}
-    "-framework QuartzCore"
-  )
-endif()
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)
 
-if (PLATFORM_WIN OR PLATFORM_LINUX)
+link_qt5_core(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
   omim_link_libraries(
     ${PROJECT_NAME}
-    ${Qt5Widgets_LIBRARIES}
+    ${CMAKE_DL_LIBS}
   )
 endif()

--- a/platform/platform_tests/jansson_test.cpp
+++ b/platform/platform_tests/jansson_test.cpp
@@ -1,6 +1,6 @@
 #include "testing/testing.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 UNIT_TEST(Jansson_Smoke)
 {

--- a/platform/platform_tests_support/CMakeLists.txt
+++ b/platform/platform_tests_support/CMakeLists.txt
@@ -16,3 +16,11 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  indexer
+  platform
+)

--- a/platform/servers_list.cpp
+++ b/platform/servers_list.cpp
@@ -6,7 +6,7 @@
 #include "base/logging.hpp"
 #include "base/assert.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace downloader
 {

--- a/platform/wifi_location_service.cpp
+++ b/platform/wifi_location_service.cpp
@@ -8,7 +8,7 @@
 #include <functional>
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -7,12 +7,6 @@ QT5_ADD_RESOURCES(RES_SOURCES res/resources.qrc)
 
 set_property(SOURCE qrc_resources.cpp PROPERTY SKIP_AUTOGEN ON)
 
-include_directories(
-  ${OMIM_ROOT}/3party/glm
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   about.cpp
@@ -66,64 +60,42 @@ omim_add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${RES_SOURCES} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  qt_common
-  map
+  base
+  coding
+  drape
   drape_frontend
-  shaders
+  editor
   generator
+  geometry
+  indexer
+  kml
+  map
+  platform
+  qt_common
   routing
   search
   storage
-  mwm_diff
-  bsdiff
-  tracking
-  traffic
-  routing_common
-  transit
-  descriptions
-  ugc
-  drape
-  partners_api
-  local_ads
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  geometry
-  coding
-  base
-  freetype
-  expat
-  gflags
-  icu
-  agg
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  pugixml
-  oauthcpp
-  opening_hours
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  ${Qt5Gui_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
 )
 
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+  jansson
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+)
 
 link_opengl(${PROJECT_NAME})
 link_qt5_core(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+endif()
 
 if (BUILD_DESIGNER)
   set(BUNDLE_NAME "MAPS.ME.Designer")
@@ -220,15 +192,6 @@ elseif(PLATFORM_LINUX)
 endif()
 
 if (PLATFORM_MAC)
-  target_link_libraries(
-    ${PROJECT_NAME}
-    "-framework Foundation"
-    "-framework CoreLocation"
-    "-framework CoreWLAN"
-    "-framework SystemConfiguration"
-    "-framework CFNetwork"
-  )
-
   if (NOT APP_VERSION)
     set(BUNDLE_VERSION "UNKNOWN")
   else()

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -18,8 +18,8 @@
 #include <cstdlib>
 #include <sstream>
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/gflags/src/gflags/gflags.h"
+#include <Alohalytics/src/alohalytics.h>
+#include <gflags/gflags.h>
 
 #include <QtCore/QDir>
 #include <QtWidgets/QMessageBox>

--- a/qt/qt_common/CMakeLists.txt
+++ b/qt/qt_common/CMakeLists.txt
@@ -4,10 +4,6 @@ QT5_ADD_RESOURCES(RESOURCES res/resources_common.qrc)
 
 set_property(SOURCE qrc_resources_common.cpp PROPERTY SKIP_AUTOGEN ON)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   helpers.cpp
@@ -27,3 +23,34 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC} ${RESOURCES})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  drape
+  drape_frontend
+  geometry
+  indexer
+  kml
+  map
+  platform
+  search
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+)
+
+link_opengl(${PROJECT_NAME})
+link_qt5_core(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+endif()

--- a/qt_tstfrm/CMakeLists.txt
+++ b/qt_tstfrm/CMakeLists.txt
@@ -7,3 +7,26 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+)
+
+link_opengl(${PROJECT_NAME})
+link_qt5_core(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+endif()

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(routing)
 
-include_directories(
-  .
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   async_router.cpp
@@ -159,6 +154,26 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+  routing_common
+  traffic
+  transit
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+  stats_client
+  succinct
+)
 
 if (PLATFORM_DESKTOP)
   add_subdirectory(routing_quality)

--- a/routing/city_roads.hpp
+++ b/routing/city_roads.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 
-#include "3party/succinct/elias_fano.hpp"
+#include <succinct/elias_fano.hpp>
 
 class DataSource;
 

--- a/routing/maxspeeds.hpp
+++ b/routing/maxspeeds.hpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <vector>
 
-#include "3party/succinct/elias_fano.hpp"
+#include <succinct/elias_fano.hpp>
 
 class DataSource;
 

--- a/routing/maxspeeds_serialization.hpp
+++ b/routing/maxspeeds_serialization.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 
-#include "3party/succinct/elias_fano.hpp"
+#include <succinct/elias_fano.hpp>
 
 namespace routing
 {

--- a/routing/online_cross_fetcher.cpp
+++ b/routing/online_cross_fetcher.cpp
@@ -6,7 +6,7 @@
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include "geometry/mercator.hpp"
 

--- a/routing/routes_builder/CMakeLists.txt
+++ b/routing/routes_builder/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(routes_builder)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   data_source_storage.cpp
@@ -12,7 +10,17 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
-add_subdirectory(routes_builder_tool)
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+  routing
+  routing_common
+  storage
+  traffic
+)
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+add_subdirectory(routes_builder_tool)

--- a/routing/routes_builder/routes_builder_tool/CMakeLists.txt
+++ b/routing/routes_builder/routes_builder_tool/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(routes_builder_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   routes_builder_tool.cpp
@@ -13,28 +11,17 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  routes_builder
-  routing_api
-  routing
-  traffic
-  routing_common
-  transit
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  gflags
-  ${LIBZ}
+  geometry
+  platform
+  routes_builder
+  routing
+  routing_api
+  routing_quality
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_uint64(threads, 0,
               "The number of threads. std::thread::hardware_concurrency() is used by default.");

--- a/routing/routes_builder/routes_builder_tool/utils.cpp
+++ b/routing/routes_builder/routes_builder_tool/utils.cpp
@@ -25,7 +25,7 @@
 #include <thread>
 #include <tuple>
 
-#include "boost/optional.hpp"
+#include <boost/optional.hpp>
 
 using namespace routing_quality;
 

--- a/routing/routing_benchmarks/CMakeLists.txt
+++ b/routing/routing_benchmarks/CMakeLists.txt
@@ -15,34 +15,14 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  routing
-  traffic
-  routing_common
-  transit
-  search
-  storage
-  mwm_diff
-  traffic
-  kml
-  editor
-  indexer
-  platform
-  oauthcpp
-  opening_hours
-  geometry
-  coding
   base
-  jansson
-  protobuf
-  bsdiff
-  stats_client
-  succinct
-  pugixml
-  icu
-  agg
-  ${LIBZ}
+  geometry
+  indexer
+  map
+  platform
+  routing
+  routing_common
+  storage
+  traffic
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -5,8 +5,7 @@
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/features_road_graph.hpp"
 #include "routing/router_delegate.hpp"
-
-#include "routing_integration_tests/routing_test_tools.hpp"
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
 
 #include "indexer/classificator_loader.hpp"
 #include "indexer/mwm_set.hpp"

--- a/routing/routing_consistency_tests/CMakeLists.txt
+++ b/routing/routing_consistency_tests/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 project(routing_consistency_tests)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   ../routing_integration_tests/routing_test_tools.cpp
@@ -16,36 +14,16 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
+  generator
+  geometry
   map
   routing
-  traffic
-  routing_common
-  transit
-  search
   storage
-  mwm_diff
-  kml
-  editor
-  indexer
-  platform
-  geometry
-  oauthcpp
-  opening_hours
-  coding
-  base
-  jansson
-  protobuf
-  bsdiff
-  succinct
-  stats_client
-  generator
-  gflags
-  pugixml
-  icu
-  agg
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/routing/routing_consistency_tests/routing_consistency_tests.cpp
+++ b/routing/routing_consistency_tests/routing_consistency_tests.cpp
@@ -16,7 +16,7 @@
 #include <map>
 #include <string>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace routing;
 using namespace std;

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -29,34 +29,12 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  editor_tests_support
-  map
-  routing
-  search
-  storage
-  mwm_diff
-  traffic
-  routing_common
-  transit
-  kml
-  editor
-  indexer
-  platform
-  oauthcpp
-  geometry
-  coding
   base
-  jansson
-  protobuf
-  bsdiff
-  succinct
-  stats_client
-  pugixml
-  opening_hours
-  icu
-  agg
-  ${LIBZ}
+  geometry
+  indexer
+  map
+  platform
+  routing
+  routing_common
+  storage
 )
-
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_quality/CMakeLists.txt
+++ b/routing/routing_quality/CMakeLists.txt
@@ -10,31 +10,13 @@ omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
+  base
+  geometry
   routes_builder
   routing
-  traffic
-  routing_common
-  transit
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
 )
 
 add_subdirectory(api)
 add_subdirectory(routing_quality_tool)
 
 omim_add_test_subdirectory(routing_quality_tests)
-
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_quality/api/CMakeLists.txt
+++ b/routing/routing_quality/api/CMakeLists.txt
@@ -17,22 +17,10 @@ omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  routing
-  traffic
-  routing_common
-  transit
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
+  coding
+  geometry
+  platform
+  routing
+  routing_quality
 )

--- a/routing/routing_quality/routing_quality_tests/CMakeLists.txt
+++ b/routing/routing_quality/routing_quality_tests/CMakeLists.txt
@@ -15,27 +15,6 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  routes_builder
-  routing_quality
   routing
-  traffic
-  routing_common
-  transit
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  ${LIBZ}
+  routing_quality
 )
-
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_quality/routing_quality_tool/CMakeLists.txt
+++ b/routing/routing_quality/routing_quality_tool/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(routing_quality_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   routing_quality_tool.cpp
@@ -13,32 +11,19 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  routing_quality
-  routing_api
-  routes_builder
-  generator
-  routing
-  platform
-  traffic
-  routing_common
-  transit
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  kml
-  geometry
-  coding
   base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  gflags
-  ${LIBZ}
+  coding
+  geometry
+  kml
+  platform
+  routes_builder
+  routing
+  routing_api
+  routing_quality
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/routing/routing_quality/routing_quality_tool/routing_quality_tool.cpp
+++ b/routing/routing_quality/routing_quality_tool/routing_quality_tool.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(mapsme_old_results, "", "Path to directory with previous mapsme router results.");
 DEFINE_string(mapsme_results, "", "Path to directory with mapsme router results.");

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -13,7 +13,7 @@
 
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace location;
 using namespace std;

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -45,31 +45,16 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  map
-  routing
-  platform_tests_support
-  traffic
-  routing_common
-  transit
-  kml
-  descriptions
+  base
+  coding
+  generator
+  generator_tests_support
+  geometry
   indexer
   platform
-  geometry
-  coding
-  base
-  agg
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  succinct
-  stats_client
-  icu
-  generator_tests_support
-
-  ${LIBZ}
+  platform_tests_support
+  routing
+  routing_common
+  traffic
+  transit
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -2,7 +2,7 @@
 
 #include "routing/speed_camera.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 #include <cmath>
 

--- a/routing_common/CMakeLists.txt
+++ b/routing_common/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(routing_common)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   bicycle_model.cpp
@@ -21,4 +17,18 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  indexer
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)
+
 omim_add_test_subdirectory(routing_common_tests)

--- a/routing_common/routing_common_tests/CMakeLists.txt
+++ b/routing_common/routing_common_tests/CMakeLists.txt
@@ -10,22 +10,8 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  indexer
-  editor
-  routing_common
-  platform
-  geometry
-  coding
   base
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  succinct
-  ${LIBZ}
+  indexer
+  platform
+  routing_common
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -171,6 +171,27 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  editor
+  geometry
+  indexer
+  kml
+  platform
+  storage
+  ugc
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  opening_hours
+  openlocationcode
+  stats_client
+)
+
 if (PLATFORM_DESKTOP)
   add_subdirectory(search_quality)
   add_subdirectory(search_tests_support)
@@ -179,7 +200,3 @@ omim_add_pybindings_subdirectory(pysearch)
 omim_add_test_subdirectory(search_tests)
 omim_add_test_subdirectory(search_integration_tests)
 
-target_link_libraries(
-  ${PROJECT_NAME}
-  openlocationcode
-)

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -53,8 +53,8 @@
 
 #include <algorithm>
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/open-location-code/openlocationcode.h"
+#include <Alohalytics/src/alohalytics.h>
+#include <open-location-code/openlocationcode.h>
 
 using namespace std;
 

--- a/search/search_integration_tests/CMakeLists.txt
+++ b/search/search_integration_tests/CMakeLists.txt
@@ -18,36 +18,17 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_tests_support
-  editor_tests_support
-  generator_tests_support
-  platform_tests_support
-  generator
-  routing
-  routing_common
-  search
-  storage
-  stats_client
+  base
+  coding
   editor
+  generator
+  generator_tests_support
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
-  tess2
-  protobuf
-  jansson
-  succinct
-  pugixml
-  opening_hours
-  icu
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
+  platform_tests_support
+  search
+  search_tests_support
+  storage
 )
 
-link_qt5_core(${PROJECT_NAME})

--- a/search/search_quality/CMakeLists.txt
+++ b/search/search_quality/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(search_quality)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(SRC
   helpers.cpp
   helpers.hpp
@@ -14,6 +12,24 @@ set(SRC
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+  platform
+  search
+  search_tests_support
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)
 
 if (NOT SKIP_DESKTOP)
   add_subdirectory(assessment_tool)

--- a/search/search_quality/assessment_tool/CMakeLists.txt
+++ b/search/search_quality/assessment_tool/CMakeLists.txt
@@ -3,9 +3,6 @@ project(assessment_tool)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-include_directories(${OMIM_ROOT}/3party/glm)
-
 set(
   SRC
   assessment_tool.cpp
@@ -39,65 +36,36 @@ omim_add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  qt_common
-  map
-  drape_frontend
-  shaders
-  routing
-  search_quality
-  search_tests_support
-  search
-  storage
-  tracking
-  traffic
-  routing_common
-  transit
-  descriptions
-  ugc
-  drape
-  partners_api
-  local_ads
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  expat
-  freetype
-  icu
-  agg
-  gflags
-  jansson
-  minizip
-  oauthcpp
-  opening_hours
-  openlr
-  protobuf
-  pugixml
-  sdf_image
-  stats_client
-  stb_image
-  succinct
-  vulkan_wrapper
-  ${Qt5Widgets_LIBRARIES}
-  ${LIBZ}
+  coding
+  geometry
+  indexer
+  kml
+  map
+  platform
+  qt_common
+  search
+  search_quality
 )
 
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+)
 
 link_opengl(${PROJECT_NAME})
 link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  # 3party libraries or external dependencies
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+endif()
 
 if (PLATFORM_MAC)
   set_target_properties(

--- a/search/search_quality/assessment_tool/assessment_tool.cpp
+++ b/search/search_quality/assessment_tool/assessment_tool.cpp
@@ -9,7 +9,7 @@
 
 #include <QtWidgets/QApplication>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(resources_path, "", "Path to resources directory");
 DEFINE_string(data_path, "", "Path to data directory");

--- a/search/search_quality/booking_dataset_generator/CMakeLists.txt
+++ b/search/search_quality/booking_dataset_generator/CMakeLists.txt
@@ -1,36 +1,22 @@
 project(booking_dataset_generator)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(SRC booking_dataset_generator.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_quality
-  search_tests_support
-  search
-  storage
-  editor
+  base
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
+  search
+  search_quality
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   gflags
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  opening_hours
-  pugixml
-  icu
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
 )

--- a/search/search_quality/booking_dataset_generator/booking_dataset_generator.cpp
+++ b/search/search_quality/booking_dataset_generator/booking_dataset_generator.cpp
@@ -33,7 +33,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 #include "defines.hpp"
 

--- a/search/search_quality/features_collector_tool/CMakeLists.txt
+++ b/search/search_quality/features_collector_tool/CMakeLists.txt
@@ -1,36 +1,23 @@
 project(features_collector_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(SRC features_collector_tool.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_quality
-  search_tests_support
-  search
-  storage
-  editor
+  base
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
+  search
+  search_quality
+  search_tests_support
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   gflags
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  opening_hours
-  pugixml
-  icu
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
 )

--- a/search/search_quality/features_collector_tool/features_collector_tool.cpp
+++ b/search/search_quality/features_collector_tool/features_collector_tool.cpp
@@ -34,7 +34,7 @@
 
 #include "defines.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace search::search_quality;
 using namespace search::tests_support;

--- a/search/search_quality/helpers.cpp
+++ b/search/search_quality/helpers.cpp
@@ -30,7 +30,7 @@
 
 #include "defines.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 using namespace std;
 

--- a/search/search_quality/helpers_json.hpp
+++ b/search/search_quality/helpers_json.hpp
@@ -7,7 +7,7 @@
 
 #include <boost/optional.hpp>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 namespace m2
 {

--- a/search/search_quality/sample.hpp
+++ b/search/search_quality/sample.hpp
@@ -5,7 +5,7 @@
 
 #include "base/string_utils.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <string>
 #include <vector>

--- a/search/search_quality/samples_generation_tool/CMakeLists.txt
+++ b/search/search_quality/samples_generation_tool/CMakeLists.txt
@@ -1,36 +1,21 @@
 project(samples_generation_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(SRC samples_generation_tool.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_quality
-  search_tests_support
-  search
-  storage
-  editor
+  base
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
+  search
+  search_quality
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   gflags
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  opening_hours
-  pugixml
-  icu
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
 )

--- a/search/search_quality/samples_generation_tool/samples_generation_tool.cpp
+++ b/search/search_quality/samples_generation_tool/samples_generation_tool.cpp
@@ -33,7 +33,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace search::search_quality;
 using namespace search;

--- a/search/search_quality/search_quality_tests/CMakeLists.txt
+++ b/search/search_quality/search_quality_tests/CMakeLists.txt
@@ -1,29 +1,12 @@
 project(search_quality_tests)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(SRC sample_test.cpp)
 
 omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_quality
-  search
-  indexer
-  editor
-  platform
-  coding
-  geometry
   base
-  icu
-  jansson
-  protobuf
-  oauthcpp
-  opening_hours
-  pugixml
-  stats_client
-  ${LIBZ}
+  search
+  search_quality
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/search/search_quality/search_quality_tool/CMakeLists.txt
+++ b/search/search_quality/search_quality_tool/CMakeLists.txt
@@ -1,37 +1,23 @@
 project(search_quality_tool)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(SRC search_quality_tool.cpp)
 
 omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_quality
-  search_tests_support
-  search
-  storage
-  editor
+  base
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  oauthcpp
+  search
+  search_quality
+  search_tests_support
+  storage
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   gflags
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  opening_hours
-  pugixml
-  icu
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
 )

--- a/search/search_quality/search_quality_tool/search_quality_tool.cpp
+++ b/search/search_quality/search_quality_tool/search_quality_tool.cpp
@@ -47,7 +47,7 @@
 
 #include "defines.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 using namespace search::search_quality;
 using namespace search::tests_support;

--- a/search/search_tests/CMakeLists.txt
+++ b/search/search_tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(search_tests)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(
   SRC
   algos_tests.cpp
@@ -33,27 +31,13 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  search_tests_support
-  generator_tests_support
-  platform_tests_support
-  kml
-  search
-  editor
-  indexer
-  storage
-  platform
-  geometry
-  coding
   base
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  succinct
-  icu
-  ${LIBZ}
+  coding
+  generator
+  generator_tests_support
+  geometry
+  indexer
+  platform
+  platform_tests_support
+  search
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/search/search_tests_support/CMakeLists.txt
+++ b/search/search_tests_support/CMakeLists.txt
@@ -14,3 +14,16 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  editor
+  editor_tests_support
+  generator
+  geometry
+  indexer
+  platform
+  search
+  storage
+)

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -10,13 +10,6 @@ execute_process(
   gl_shaders
 )
 
-include_directories(
-  ${OMIM_ROOT}/3party/glm
-  ${OMIM_ROOT}/3party/jansson/src
-  ${OMIM_ROOT}/3party/Vulkan-Headers/include
-  ${OMIM_ROOT}/3party/vulkan_wrapper
-)
-
 set(
   SRC
   gl_program_info.hpp
@@ -131,6 +124,15 @@ set(
   GL/user_mark.vsh.glsl
   GL/user_mark_billboard.vsh.glsl
 )
+
 add_custom_target(gl_shaders_sources SOURCES ${GL_SHADERS_SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  drape
+  platform
+)
 
 omim_add_test_subdirectory(shaders_tests)

--- a/shaders/shaders_tests/CMakeLists.txt
+++ b/shaders/shaders_tests/CMakeLists.txt
@@ -18,41 +18,20 @@ set(
 
 omim_add_test(${PROJECT_NAME} ${SRC})
 
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    ${Qt5Widgets_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Gui_LIBRARIES}
-  )
-endif()
-
 omim_link_libraries(
   ${PROJECT_NAME}
-  qt_tstfrm
-  shaders
+  base
   drape
   platform
-  indexer
-  geometry
-  coding
-  base
-  expat
-  stats_client
-  freetype
-  stb_image
-  sdf_image
-  icu
-  vulkan_wrapper
-  ${LIBZ}
+  qt_tstfrm
+  shaders
 )
+
+link_qt5_core(${PROJECT_NAME})
 
 if (PLATFORM_LINUX)
   omim_link_libraries(
     ${PROJECT_NAME}
-    dl
+    ${CMAKE_DL_LIBS}
   )
 endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})

--- a/skin_generator/CMakeLists.txt
+++ b/skin_generator/CMakeLists.txt
@@ -1,11 +1,5 @@
 project(skin_generator_tool)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-  ${OMIM_ROOT}/3party/freetype/include
-  ${Boost_INCLUDE_DIRS}
-)
-
 set(
   SRC
   generator.cpp
@@ -21,15 +15,26 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  geometry
-  coding
   base
-  freetype
-  gflags
-  Boost::boost
-  ${Qt5Gui_LIBRARIES}
-  ${Qt5Widgets_LIBRARIES}
-  ${Qt5Xml_LIBRARIES}
-  ${Qt5Svg_LIBRARIES}
-  ${LIBZ}
+  coding
+  geometry
 )
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Svg_LIBRARIES}
+  ${Qt5Xml_LIBRARIES}
+)
+
+link_opengl(${PROJECT_NAME})
+link_qt5_core(${PROJECT_NAME})
+
+if (PLATFORM_LINUX)
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    ${CMAKE_DL_LIBS}
+  )
+endif()

--- a/skin_generator/main.cpp
+++ b/skin_generator/main.cpp
@@ -11,7 +11,7 @@
 #include <QtXml/QXmlSimpleReader>
 #include <QtXml/QXmlInputSource>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(fontFileName, "../../data/01_dejavusans.ttf", "path to TrueType font file");
 DEFINE_string(symbolsFile, "../../data/results.unicode", "file with 2bytes symbols for which the skin should be generated");

--- a/software_renderer/CMakeLists.txt
+++ b/software_renderer/CMakeLists.txt
@@ -1,13 +1,5 @@
 project(software_renderer)
 
-include_directories(
-  .
-  ${OMIM_ROOT}/3party/protobuf/protobuf/src
-  ${OMIM_ROOT}/3party/expat/lib
-  ${OMIM_ROOT}/3party/freetype/include
-  ${OMIM_ROOT}/3party/glm
-)
-
 set(
   SRC
   area_info.hpp
@@ -41,3 +33,21 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  drape
+  drape_frontend
+  geometry
+  indexer
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  agg
+  stb_image
+)

--- a/software_renderer/cpu_drawer.hpp
+++ b/software_renderer/cpu_drawer.hpp
@@ -212,7 +212,7 @@ private:
   std::map<FeatureID, FeatureStyler> m_stylers;
   std::map<FeatureID, AreaInfo> m_areasGeometry;
   std::map<FeatureID, PathInfo> m_pathGeometry;
-  std::map<FeatureID, string> m_roadNames;
+  std::map<FeatureID, std::string> m_roadNames;
   dp::FontDecl m_roadNumberFont;
 
   double m_visualScale;

--- a/software_renderer/feature_processor.cpp
+++ b/software_renderer/feature_processor.cpp
@@ -43,7 +43,7 @@ FeatureProcessor::FeatureProcessor(ref_ptr<CPUDrawer> drawer,
 //  ASSERT_GREATER(m_zoom, scales::GetUpperWorldScale(), ());
 }
 
-bool FeatureProcessor::operator()(FeatureType const & f)
+bool FeatureProcessor::operator()(FeatureType & f)
 {
   FeatureData data;
   data.m_id = f.GetID();
@@ -63,7 +63,7 @@ bool FeatureProcessor::operator()(FeatureType const & f)
 
   switch (data.m_styler.m_geometryType)
   {
-  case feature::GEOM_POINT:
+  case base::Underlying(feature::GeomType::Point):
   {
     typedef one_point functor_t;
 
@@ -82,7 +82,7 @@ bool FeatureProcessor::operator()(FeatureType const & f)
     break;
   }
 
-  case feature::GEOM_AREA:
+  case base::Underlying(feature::GeomType::Area):
   {
     typedef filter_screenpts_adapter<area_tess_points> functor_t;
 
@@ -106,8 +106,7 @@ bool FeatureProcessor::operator()(FeatureType const & f)
     if (!data.m_styler.m_hasLineStyles)
       break;
   }
-
-  case feature::GEOM_LINE:
+  case base::Underlying(feature::GeomType::Line):
     {
       if (data.m_styler.m_hasPathText)
       {

--- a/software_renderer/feature_processor.hpp
+++ b/software_renderer/feature_processor.hpp
@@ -42,7 +42,7 @@ public:
                    ScreenBase const & convertor,
                    int zoomLevel);
 
-  bool operator()(FeatureType const & f);
+  bool operator()(FeatureType & f);
 
 private:
   ref_ptr<CPUDrawer> m_drawer;

--- a/software_renderer/feature_styler.hpp
+++ b/software_renderer/feature_styler.hpp
@@ -32,7 +32,7 @@ struct DrawRule
 struct FeatureStyler
 {
   FeatureStyler() = default;
-  FeatureStyler(FeatureType const & f,
+  FeatureStyler(FeatureType & f,
                 int const zoom,
                 double const visualScale,
                 GlyphCache * glyphCache,
@@ -50,9 +50,9 @@ struct FeatureStyler
 
   double m_visualScale;
 
-  string m_primaryText;
-  string m_secondaryText;
-  string m_refText;
+  std::string m_primaryText;
+  std::string m_secondaryText;
+  std::string m_refText;
 
   typedef buffer_vector<double, 16> ClipIntervalsT;
   ClipIntervalsT m_intervals;
@@ -70,7 +70,7 @@ struct FeatureStyler
 
   bool IsEmpty() const;
 
-  string const GetPathName() const;
+  std::string const GetPathName() const;
 
   bool FilterTextSize(drule::BaseRule const * pRule) const;
 

--- a/software_renderer/frame_image.hpp
+++ b/software_renderer/frame_image.hpp
@@ -19,7 +19,7 @@ struct FrameImage
   // image data.
   // TopLeft-to-RightBottom order
   // Format - png
-  vector<uint8_t> m_data;
+  std::vector<uint8_t> m_data;
   uint32_t m_width = 0;       // pixel width of image
   uint32_t m_height = 0;      // pixel height of image
   uint32_t m_stride = 0;      // row stride in bytes

--- a/software_renderer/geometry_processors.cpp
+++ b/software_renderer/geometry_processors.cpp
@@ -1,11 +1,13 @@
 #include "software_renderer/geometry_processors.hpp"
 
+#include "base/logging.hpp"
+
 #include <functional>
 
 namespace software_renderer
 {
 base_screen::base_screen(params const & p)
-  : base(p)
+  : gp_base(p)
 {
   m_convertor->GtoP(*p.m_rect, m_rect);
 }
@@ -52,7 +54,7 @@ void get_path_intervals::operator()(m2::PointD const & pt)
       }
       else
       {
-        if (base::AlmostEqualULPs(m_intervals->back(), clipStart))
+        if (::base::AlmostEqualULPs(m_intervals->back(), clipStart))
           m_intervals->back() = clipEnd;
         else
         {
@@ -109,7 +111,7 @@ void cut_path_intervals::operator()(m2::PointD const & pt)
         push_point(m_prev + dir * (end - m_length));
 #ifdef DEBUG
         double const len = m_points.back().GetLength();
-        ASSERT_LESS_OR_EQUAL ( fabs(len - (end - start)), 1.0E-4, (len, end - start) );
+        ASSERT_LESS_OR_EQUAL ( std::fabs(len - (end - start)), 1.0E-4, (len, end - start) );
 #endif
       }
     }

--- a/software_renderer/geometry_processors.hpp
+++ b/software_renderer/geometry_processors.hpp
@@ -25,7 +25,7 @@ namespace software_renderer
 /// - convert_point - convert point to screen coordinates;\n
 /// - m_rect - clip rect;\n
 
-struct base
+struct gp_base
 {
   struct params
   {
@@ -34,7 +34,7 @@ struct base
     {}
   };
 
-  explicit base(params const & p)
+  explicit gp_base(params const & p)
     : m_convertor(p.m_convertor)
   {
   }
@@ -48,7 +48,7 @@ struct base
 };
 
 /// in global coordinates
-struct base_global : public base
+struct base_global : public gp_base
 {
   m2::RectD const * m_rect;
 
@@ -57,24 +57,24 @@ struct base_global : public base
     return g2p(pt);
   }
 
-  struct params : base::params
+  struct params : gp_base::params
   {
     m2::RectD const * m_rect;
     params() : m_rect(0){}
   };
 
   explicit base_global(params const & p)
-    : base(p), m_rect(p.m_rect)
+    : gp_base(p), m_rect(p.m_rect)
   {
   }
 };
 
 /// in screen coordinates
-struct base_screen : public base
+struct base_screen : public gp_base
 {
   m2::RectD m_rect;
 
-  struct params : base::params
+  struct params : gp_base::params
   {
     m2::RectD const * m_rect;
     params() : m_rect(0)

--- a/software_renderer/glyph_cache.cpp
+++ b/software_renderer/glyph_cache.cpp
@@ -66,7 +66,7 @@ void GlyphCache::addFonts(std::vector<std::string> const & fontNames)
   m_impl->addFonts(fontNames);
 }
 
-pair<Font*, int> GlyphCache::getCharIDX(GlyphKey const & key)
+std::pair<Font*, int> GlyphCache::getCharIDX(GlyphKey const & key)
 {
   return m_impl->getCharIDX(key);
 }
@@ -76,7 +76,7 @@ GlyphMetrics const GlyphCache::getGlyphMetrics(GlyphKey const & key)
   return m_impl->getGlyphMetrics(key);
 }
 
-shared_ptr<GlyphBitmap> const GlyphCache::getGlyphBitmap(GlyphKey const & key)
+std::shared_ptr<GlyphBitmap> const GlyphCache::getGlyphBitmap(GlyphKey const & key)
 {
   return m_impl->getGlyphBitmap(key);
 }

--- a/software_renderer/glyph_cache_impl.cpp
+++ b/software_renderer/glyph_cache_impl.cpp
@@ -412,7 +412,7 @@ GlyphCacheImpl::~GlyphCacheImpl()
   }
 }
 
-int GlyphCacheImpl::getCharIDX(shared_ptr<Font> const & font, strings::UniChar symbolCode)
+int GlyphCacheImpl::getCharIDX(std::shared_ptr<Font> const & font, strings::UniChar symbolCode)
 {
   if (m_isDebugging)
     return 0;
@@ -471,7 +471,7 @@ std::pair<Font*, int> const GlyphCacheImpl::getCharIDX(GlyphKey const & key)
 
 GlyphMetrics const GlyphCacheImpl::getGlyphMetrics(GlyphKey const & key)
 {
-  pair<Font*, int> charIDX = getCharIDX(key);
+  std::pair<Font*, int> charIDX = getCharIDX(key);
 
   FTC_ScalerRec fontScaler =
   {
@@ -582,7 +582,7 @@ std::shared_ptr<GlyphBitmap> const GlyphCacheImpl::getGlyphBitmap(GlyphKey const
 
   FTC_Node_Unref(node, m_manager);
 
-  return shared_ptr<GlyphBitmap>(bitmap);
+  return std::shared_ptr<GlyphBitmap>(bitmap);
 }
 
 FT_Error GlyphCacheImpl::RequestFace(FTC_FaceID faceID, FT_Library library, FT_Pointer /*requestData*/, FT_Face * face)

--- a/software_renderer/pen_info.hpp
+++ b/software_renderer/pen_info.hpp
@@ -59,10 +59,10 @@ struct PenInfo
       else
       {
         // hack for Samsung GT-S5570 (GPU floor()'s texture pattern width)
-        m_w = max(m_w, 1.0);
+        m_w = std::max(m_w, 1.0);
 
         buffer_vector<double, 4> tmpV;
-        std::copy(pattern, pattern + patternSize, back_inserter(tmpV));
+        std::copy(pattern, pattern + patternSize, std::back_inserter(tmpV));
 
         if (tmpV.size() % 2)
           tmpV.push_back(0);
@@ -110,7 +110,7 @@ struct PenInfo
             curLen += tmpV[i++];
         }
 
-        int periods = max(int((256 - 4) / length), 1);
+        int periods = std::max(int((256 - 4) / length), 1);
         m_pat.reserve(periods * vec.size());
         for (int i = 0; i < periods; ++i)
           std::copy(vec.begin(), vec.end(), std::back_inserter(m_pat));

--- a/software_renderer/proto_to_styles.cpp
+++ b/software_renderer/proto_to_styles.cpp
@@ -97,7 +97,7 @@ void ConvertStyle(SymbolRuleProto const * pSrc, IconInfo & dest)
 void ConvertStyle(CaptionDefProto const * pSrc, double scale, dp::FontDecl & dest, m2::PointD & offset)
 {
   // fonts smaller than 8px look "jumpy" on LDPI devices
-  uint8_t const h = max(8, static_cast<int>(pSrc->height() * scale));
+  uint8_t const h = std::max(8, static_cast<int>(pSrc->height() * scale));
 
   offset = m2::PointD(0, 0);
   if (pSrc->offset_x() != 0)
@@ -114,7 +114,7 @@ void ConvertStyle(CaptionDefProto const * pSrc, double scale, dp::FontDecl & des
 void ConvertStyle(ShieldRuleProto const * pSrc, double scale, dp::FontDecl & dest)
 {
   // fonts smaller than 8px look "jumpy" on LDPI devices
-  uint8_t const h = max(8, static_cast<int>(pSrc->height() * scale));
+  uint8_t const h = std::max(8, static_cast<int>(pSrc->height() * scale));
 
   dest = dp::FontDecl(ConvertColor(pSrc->color()), h);
 

--- a/software_renderer/software_renderer.cpp
+++ b/software_renderer/software_renderer.cpp
@@ -14,18 +14,18 @@
 
 #include "base/logging.hpp"
 
-#include "3party/agg/agg_bounding_rect.h"
-#include "3party/agg/agg_conv_contour.h"
-#include "3party/agg/agg_conv_curve.h"
-#include "3party/agg/agg_conv_dash.h"
-#include "3party/agg/agg_conv_stroke.h"
-#include "3party/agg/agg_ellipse.h"
-#include "3party/agg/agg_path_storage.h"
-#include "3party/agg/agg_rasterizer_scanline_aa.h"
-#include "3party/agg/agg_scanline_p.h"
-#include "3party/agg/agg_vcgen_dash.cpp"
-#include "3party/agg/agg_vcgen_stroke.cpp"
-#include "3party/stb_image/stb_image_write.h"
+#include <agg/agg_bounding_rect.h>
+#include <agg/agg_conv_contour.h>
+#include <agg/agg_conv_curve.h>
+#include <agg/agg_conv_dash.h>
+#include <agg/agg_conv_stroke.h>
+#include <agg/agg_ellipse.h>
+#include <agg/agg_path_storage.h>
+#include <agg/agg_rasterizer_scanline_aa.h>
+#include <agg/agg_scanline_p.h>
+#include <agg/agg_vcgen_dash.cpp>
+#include <agg/agg_vcgen_stroke.cpp>
+#include <stb_image/stb_image_write.h>
 
 using namespace std;
 

--- a/software_renderer/software_renderer.hpp
+++ b/software_renderer/software_renderer.hpp
@@ -16,11 +16,11 @@
 
 #include "base/string_utils.hpp"
 
-#include "3party/agg/agg_rendering_buffer.h"
-#include "3party/agg/agg_pixfmt_rgba.h"
-#include "3party/agg/agg_renderer_scanline.h"
-#include "3party/agg/agg_renderer_primitives.h"
-#include "3party/agg/agg_path_storage.h"
+#include <agg/agg_rendering_buffer.h>
+#include <agg/agg_pixfmt_rgba.h>
+#include <agg/agg_renderer_scanline.h>
+#include <agg/agg_renderer_primitives.h>
+#include <agg/agg_path_storage.h>
 
 #include <cstdint>
 #include <map>
@@ -114,7 +114,7 @@ public:
 
 private:
   std::unique_ptr<GlyphCache> m_glyphCache;
-  std::map<string, m2::RectU> m_symbolsIndex;
+  std::map<std::string, m2::RectU> m_symbolsIndex;
   std::vector<uint8_t> m_symbolsSkin;
   uint32_t m_skinWidth, m_skinHeight;
 

--- a/software_renderer/text_engine.cpp
+++ b/software_renderer/text_engine.cpp
@@ -426,7 +426,7 @@ FT_Glyph face::glyph(unsigned int code, unsigned int prev_code, ml::point_d * ke
 
 ml::face & text_engine::get_face(size_t font_key, std::string const & name, size_t size)
 {
-  pair<size_t, size_t> key(font_key, size);
+  std::pair<size_t, size_t> key(font_key, size);
   face_cache_type::iterator entry = m_cache.find(key);
   if (entry == m_cache.end())
   {

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(stats_client)
 
-include_directories(${OMIM_ROOT} ${OMIM_ROOT}/3party/Alohalytics/src)
-
 set(
   SRC
   ${OMIM_ROOT}/3party/Alohalytics/src/cpp/alohalytics.cc
@@ -45,6 +43,11 @@ elseif(${PLATFORM_ANDROID})
 endif()
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  ${LIBZ}
+)
 
 if (${PLATFORM_IPHONE} OR ${PLATFORM_MAC})
   target_compile_options(${PROJECT_NAME} PUBLIC "-fobjc-arc")

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(storage)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(
   SRC
   country.hpp
@@ -46,6 +44,23 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  geometry
+  mwm_diff
+  platform
+  routing_common
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+  stats_client
+)
 
 omim_add_test_subdirectory(storage_tests)
 omim_add_test_subdirectory(storage_integration_tests)

--- a/storage/country_info_getter.cpp
+++ b/storage/country_info_getter.cpp
@@ -19,7 +19,7 @@
 #include <limits>
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 namespace storage
 {

--- a/storage/country_tree.cpp
+++ b/storage/country_tree.cpp
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <utility>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 using namespace std;
 using platform::CountryFile;

--- a/storage/diff_scheme/diff_manager.cpp
+++ b/storage/diff_scheme/diff_manager.cpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 namespace
 {

--- a/storage/diff_scheme/diff_scheme_loader.cpp
+++ b/storage/diff_scheme/diff_scheme_loader.cpp
@@ -11,8 +11,8 @@
 #include <unordered_map>
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/jansson/myjansson.hpp"
+#include <Alohalytics/src/alohalytics.h>
+#include <jansson/myjansson.hpp>
 
 #include "private.h"
 

--- a/storage/pinger.cpp
+++ b/storage/pinger.cpp
@@ -8,7 +8,7 @@
 #include "base/stl_helpers.hpp"
 #include "base/thread_pool_delayed.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 #include <sstream>
 #include <utility>

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -28,7 +28,7 @@
 
 #include <limits>
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace downloader;
 using namespace generator::mwm_diff;

--- a/storage/storage_integration_tests/CMakeLists.txt
+++ b/storage/storage_integration_tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 project(storage_integration_tests)
 
-include_directories(${OMIM_ROOT}/3party/glm)
 add_definitions("-DOMIM_UNIT_TEST_WITH_QT_EVENT_LOOP")
 
 set(
@@ -20,58 +19,11 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
-  map
-  drape_frontend
-  shaders
-  routing
-  routing_common
-  transit
-  search
-  storage
-  tracking
-  traffic
-  descriptions
-  ugc
-  drape
-  partners_api
-  local_ads
-  kml
-  editor
-  indexer
-  metrics
-  platform
-  opening_hours
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  freetype
-  expat
-  icu
-  agg
-  jansson
-  protobuf
-  stats_client
-  minizip
-  succinct
-  pugixml
-  oauthcpp
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  ${Qt5Widgets_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
+  coding
+  geometry
+  map
+  platform
+  platform_tests_support
+  storage
 )
-
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_opengl(${PROJECT_NAME})
-link_qt5_core(${PROJECT_NAME})

--- a/storage/storage_tests/CMakeLists.txt
+++ b/storage/storage_tests/CMakeLists.txt
@@ -22,54 +22,13 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  platform_tests_support
-  generator_tests_support
-  drape_frontend
-  shaders
-  map
-  storage
-  drape
-  generator
-  search
-  routing
-  traffic
-  routing_common
-  ugc
-  kml
-  editor
-  indexer
-  oauthcpp
-  platform
-  opening_hours
-  mwm_diff
-  bsdiff
-  geometry
-  coding
   base
-  freetype
-  expat
-  icu
-  agg
-  jansson
-  tess2
-  protobuf
-  stats_client
-  minizip
-  succinct
-  pugixml
-  stb_image
-  sdf_image
-  vulkan_wrapper
-  ${Qt5Widgets_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${LIBZ}
+  coding
+  generator
+  generator_tests_support
+  geometry
+  indexer
+  platform
+  platform_tests_support
+  storage
 )
-
-if (PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    dl
-  )
-endif()
-
-link_qt5_core(${PROJECT_NAME})

--- a/track_analyzing/CMakeLists.txt
+++ b/track_analyzing/CMakeLists.txt
@@ -15,4 +15,18 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  generator
+  geometry
+  indexer
+  platform
+  routing
+  routing_common
+  storage
+)
+
 add_subdirectory(track_analyzer)

--- a/track_analyzing/track_analyzer/CMakeLists.txt
+++ b/track_analyzing/track_analyzer/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(track_analyzer)
 
-include_directories(${OMIM_ROOT}/3party/gflags/src)
-
 set(
   SRC
   cmd_cpp_track.cpp
@@ -22,27 +20,20 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  track_analyzing
-  generator
-  routing
-  traffic
-  routing_common
-  storage
+  base
+  coding
+  geometry
   indexer
   platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  icu
-  jansson
-  oauthcpp
-  protobuf
-  stats_client
-  gflags
-  ${LIBZ}
+  routing
+  routing_common
+  storage
+  track_analyzing
+  traffic
 )
 
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  gflags
+)

--- a/track_analyzing/track_analyzer/track_analyzer.cpp
+++ b/track_analyzing/track_analyzer/track_analyzer.cpp
@@ -5,7 +5,7 @@
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 #include <string>
 

--- a/track_generator/CMakeLists.txt
+++ b/track_generator/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(track_generator_tool)
 
-include_directories(
-  ${OMIM_ROOT}/3party/gflags/src
-)
-
 set(
   SRC
   track_generator_tool.cpp
@@ -15,29 +11,18 @@ omim_add_executable(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  routing_quality
+  base
+  coding
+  kml
+  platform
   routes_builder
   routing
-  routing_common
-  kml
-  storage
-  indexer
-  platform
-  mwm_diff
-  bsdiff
-  geometry
-  coding
-  base
-  icu
-  expat
-  oauthcpp
-  protobuf
-  stats_client
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
   gflags
-  ${LIBZ}
 )
 
 omim_add_pybindings_subdirectory(pytrack_generator)
-
-link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})

--- a/track_generator/track_generator_tool.cpp
+++ b/track_generator/track_generator_tool.cpp
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "3party/gflags/src/gflags/gflags.h"
+#include <gflags/gflags.h>
 
 DEFINE_string(inputDir, "", "Path to kmls.");
 

--- a/tracking/CMakeLists.txt
+++ b/tracking/CMakeLists.txt
@@ -12,5 +12,19 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  platform
+  traffic
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  stats_client
+)
+
 omim_add_pybindings_subdirectory(pytracking)
 omim_add_test_subdirectory(tracking_tests)

--- a/tracking/connection.cpp
+++ b/tracking/connection.cpp
@@ -5,7 +5,7 @@
 #include "platform/platform.hpp"
 #include "platform/socket.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 namespace
 {

--- a/tracking/reporter.cpp
+++ b/tracking/reporter.cpp
@@ -4,7 +4,7 @@
 #include "platform/platform.hpp"
 #include "platform/socket.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 #include "base/logging.hpp"
 #include "base/timer.hpp"

--- a/tracking/tracking_tests/CMakeLists.txt
+++ b/tracking/tracking_tests/CMakeLists.txt
@@ -10,13 +10,9 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  tracking
+  base
+  coding
   platform
   platform_tests_support
-  coding
-  base
-  geometry
-  stats_client
-  ${LIBZ}
-  ${Qt5Widgets_LIBRARIES}
+  tracking
 )

--- a/traffic/CMakeLists.txt
+++ b/traffic/CMakeLists.txt
@@ -12,5 +12,20 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  indexer
+  platform
+  routing_common
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  stats_client
+)
+
 omim_add_pybindings_subdirectory(pytraffic)
 omim_add_test_subdirectory(traffic_tests)

--- a/traffic/traffic_info.cpp
+++ b/traffic/traffic_info.cpp
@@ -31,7 +31,7 @@
 #include "defines.hpp"
 #include "private.h"
 
-#include "3party/Alohalytics/src/alohalytics.h"
+#include <Alohalytics/src/alohalytics.h>
 
 using namespace std;
 

--- a/traffic/traffic_tests/CMakeLists.txt
+++ b/traffic/traffic_tests/CMakeLists.txt
@@ -2,8 +2,6 @@ project(traffic_tests)
 
 add_definitions(-DOMIM_UNIT_TEST_WITH_QT_EVENT_LOOP)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 set(
   SRC
   traffic_info_test.cpp
@@ -13,37 +11,9 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  traffic
-  routing_common
   indexer
-  editor
-  platform_tests_support
   platform
-  coding
-  geometry
-  base
-  icu
-  jansson
-  oauthcpp
-  opening_hours
-  protobuf
-  pugixml
-  stats_client
-  ${LIBZ}
+  platform_tests_support
+  traffic
 )
 
-if (PLATFORM_MAC)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    ${Qt5Widgets_LIBRARIES}
-  )
-endif()
-
-if (PLATFORM_WIN OR PLATFORM_LINUX)
-  omim_link_libraries(
-    ${PROJECT_NAME}
-    ${Qt5Network_LIBRARIES}
-  )
-endif()
-
-link_qt5_core(${PROJECT_NAME})

--- a/transit/CMakeLists.txt
+++ b/transit/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(transit)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-)
-
 set(
   SRC
   transit_display_info.hpp
@@ -16,4 +12,17 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(${PROJECT_NAME}
+  base
+  coding
+  geometry
+  indexer
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(${PROJECT_NAME}
+  jansson
+)
+
 omim_add_test_subdirectory(transit_tests)

--- a/transit/transit_graph_data.hpp
+++ b/transit/transit_graph_data.hpp
@@ -12,7 +12,7 @@
 #include "base/geo_object_id.hpp"
 #include "base/visitor.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <cstdint>
 #include <cstring>

--- a/transit/transit_tests/CMakeLists.txt
+++ b/transit/transit_tests/CMakeLists.txt
@@ -12,15 +12,7 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  indexer
-  transit
-  platform
-  coding
-  geometry
   base
-  jansson
-  stats_client
-  ${LIBZ}
+  coding
+  transit
 )
-
-link_qt5_core(${PROJECT_NAME})

--- a/ugc/CMakeLists.txt
+++ b/ugc/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(ugc)
 
-include_directories(
-  ${OMIM_ROOT}/3party/jansson/src
-  ${OMIM_ROOT}/Alohalytics/src
-)
-
 set(
   SRC
   api.cpp
@@ -28,4 +23,22 @@ set(
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})
+
+omim_link_libraries(
+  ${PROJECT_NAME}
+  base
+  coding
+  editor
+  geometry
+  indexer
+  platform
+)
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+  stats_client
+)
+
 omim_add_test_subdirectory(ugc_tests)

--- a/ugc/serdes_json.hpp
+++ b/ugc/serdes_json.hpp
@@ -4,7 +4,7 @@
 
 #include "base/exception.hpp"
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 #include <cstdint>
 #include <cstdlib>

--- a/ugc/storage.cpp
+++ b/ugc/storage.cpp
@@ -27,8 +27,8 @@
 #include <map>
 #include <utility>
 
-#include "3party/Alohalytics/src/alohalytics.h"
-#include "3party/jansson/myjansson.hpp"
+#include <Alohalytics/src/alohalytics.h>
+#include <jansson/myjansson.hpp>
 
 #include <boost/optional/optional.hpp>
 

--- a/ugc/ugc_tests/CMakeLists.txt
+++ b/ugc/ugc_tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(ugc_tests)
 
-include_directories(${OMIM_ROOT}/3party/jansson/src)
-
 option(UGC_MIGRATION "Build migration file for ugc" OFF)
 
 set(
@@ -28,31 +26,18 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  generator_tests_support
-  generator
-  search
-  routing
-  routing_common
-  ugc
-  editor
-  indexer
-  storage
-  platform
-  platform_tests_support
-  coding
-  geometry
   base
-  icu
-  jansson
-  stats_client
-  pugixml
-  tess2
-  protobuf
-  succinct
-  opening_hours
-  oauthcpp
-  traffic
-  ${CMAKE_DL_LIBS}
-  ${LIBZ}
+  coding
+  generator
+  generator_tests_support
+  indexer
+  platform
+  storage
+  ugc
 )
-link_qt5_core(${PROJECT_NAME})
+
+# 3party libraries or external dependencies
+omim_link_libraries(
+  ${PROJECT_NAME}
+  jansson
+)

--- a/ugc/ugc_tests/storage_tests.cpp
+++ b/ugc/ugc_tests/storage_tests.cpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/jansson/myjansson.hpp"
+#include <jansson/myjansson.hpp>
 
 using namespace std;
 using namespace generator::tests_support;


### PR DESCRIPTION
Сейчас у нас в проекте используется такая схема зависимостей: для библиотек зависимости не указываются, для бинарей перечисляются все зависимости. При такой непрозрачной схеме и внушительных размерах нашего проекта(много библиотек и бинарей) возникают следующие проблемы: 1. Непонимание что от чего зависит (из-за этого у нас периодически ломаются сборки при линковке). 2. Дублирование кода в CMakeLists.txt.

Предлагается следующая схема: зависимости всегда у любой цели(бинарь или либа) указываются по подключаемым хедерам.

Открывая CMakeLists.txt будет сразу видно непосредственно от чего зависит библиотека. Не нужно будет указывать во всех бинарях зависимости protobuf, zlib, Qt и т.д. Видно по дифу реквеста, что строк стало меньше.


Зачем изменения в CMakeLists.txt в 3party?

Если мы откроем почти любой CMakeLists.txt, то можем увидеть строки наподобие таких. Пример взят из coding:
```
include_directories(
	${OMIM_ROOT}/coding
	${OMIM_ROOT}/3party/expat
	${OMIM_ROOT}/3party/icu/common
	${OMIM_ROOT}/3party/icu/i18n
)
```

Это снова дублирование.

Решить эту проблему можно дописав CMakeLists.txt у библиотек в 3party. Например для icu:

```
target_include_directories(
${PROJECT_NAME}
	PUBLIC
	common
	i18n
)
```

Зачем изменения в коде?

Дело в том, что в проекте половина includов из 3party записывается в "", а другая в <>.
А еще было забавно, что во многих консольных утилитах(и не только) в CMakeLists.txt прописана строка:
```
include_directories(${OMIM_ROOT}/3party/gflags/src)
```
а в cpp используется
```
#include "3party/gflags/src/gflags/gflags.h"
```

Зачем нужен include_directories если не использовать #include "gflags/gflags.h"? Не понятно. Обычно либо include_directories + относительный инлюд, либо просто абсолютный инлюд.

Я выбрал <>, так как уже для boost и некоторых других либ, не помню точно, но такие точно есть в drape и может где-то еще используются <> и короткая форма записи.

<> и короткая форма записи мне показалась лучше по эстетической причине. И писать меньше:
```
#include <gflags/gflags.h>
```
vs
```
#include "3party/gflags/src/gflags/gflags.h"
```

Префикс 3party имеет преимущество: можно грепать. Но и при предложенном варианте  можно грепать, потому что имя библиотеки есть в инклюде. Нельзя будет грепнуть по 3party, но можно по имени библиотеки.

Еще прикрепляю png и svg картинку(в архиве) графа зависимостей для либ. Все бинари исключены, что бы можно было хоть что-то разобрать.
![graph](https://user-images.githubusercontent.com/12376740/66625291-501eea00-ebfc-11e9-81d5-d466d2a7fc15.png)
[graph.svg.gz](https://github.com/mapsme/omim/files/3715672/graph.svg.gz)

 (Если открыть в редакторе svg, например https://www.janvas.com, то можно подсветить ребра при наведении курсора).
