### PR TITLE
[generator] Add 4wd_only to replaced_tags.

### DIFF
--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -479,6 +479,8 @@ string DetermineSurface(OsmElement * p)
       surface_grade = tag.m_value;
     else if (tag.m_key == "highway")
       isHighway = true;
+    else if (tag.m_key == "4wd_only" && (tag.m_value == "yes" || tag.m_value == "recommended"))
+      return "unpaved_bad";
   }
 
   if (!isHighway || (surface.empty() && smoothness.empty()))


### PR DESCRIPTION
There is about 14.3k of tags **4wd_only** with values "yes" or "recommended". This tag marks roads only suitable for 4WD-only vehicles. [Ticket MAPSME-12152.](https://jira.mail.ru/browse/MAPSME-12152)

The purpose of this PR is to mark such roads as `unpaved_bad` thus to pessimize the routes on `4wd_only` roads.

[Road](https://www.openstreetmap.org/way/52106287#map=14/60.2530/18.5741) marked with `4wd_only` in OSM on our map before PR:
<img width="607" alt="Screenshot 2019-10-16 at 10 49 14" src="https://user-images.githubusercontent.com/54934129/66903970-02471f00-f00c-11e9-9060-1e84856fbc39.png">

After PR:
<img width="722" alt="Screenshot 2019-10-16 at 11 50 31" src="https://user-images.githubusercontent.com/54934129/66904030-1e4ac080-f00c-11e9-9262-ae063f4ff104.png">