### PR TITLE
[generator] maps_generator --without_countries option

### DIFF
--- a/tools/python/maps_generator/README.md
+++ b/tools/python/maps_generator/README.md
@@ -123,6 +123,11 @@ optional arguments:
                         break, for which maps will be built. The names of the
                         regions can be seen in omim/data/borders. It is
                         necessary to set names without any extension.
+
+  --without_countries COUNTRIES
+                        Syntax the same with --countries. List of regions
+                        which you want to exclude from building.
+
   --skip SKIP           List of stages, separated by a comma or a semicolon,
                         for which building will be skipped. Available skip
                         stages: download_external,
@@ -217,4 +222,10 @@ PLANET_MD5_URL: https://download.geofabrik.de/russia/central-fed-district-latest
 3. Run
 ```sh
 python$ python3.6 -m maps_generator --countries="Russia_Moscow" --skip="coastline"
+```
+
+#### Generate all possible mwms from .osm.pbf file
+If you cut some area (with http://geojson.io and osmium tool for example) and you don't want to think what mwms got into this .osm.pbf file, you just:
+```sh
+python$ python3.6 -m maps_generator --skip="coastline" --without_countries="World*"
 ```


### PR DESCRIPTION
Проблема такая:
1) есть .osm.pbf file
2) хочу сгенерить все mwm, которые попали в этот файл
3) не хочу никаких World/Coast и чего-то еще

пишу:
```sh
python3 -m maps_generator --countries="*" --skip="coastline"
```
на что получаю, что нельзя скипать `coastline`, если генеришь `World*`
А генерю `World*` я из-за `--countries="*"`

Короче новая опция позволяет исключать страны из генерации, работает так же как и `--countries`

Например, если хочется собрать европу, но без Германии и Англии, то можно написать:
```sh
# with europe-latest.osm.pbf
python3 -m maps_generator --countries="*" --skip="coastline" --without_countries="World*, UK*, Germany*"
```
