### PR TITLE
[indexer] Get rid of MwmValueBase

### DIFF
--- a/indexer/data_source.cpp
+++ b/indexer/data_source.cpp
@@ -178,7 +178,7 @@ unique_ptr<MwmInfo> DataSource::CreateInfo(platform::LocalCountryFile const & lo
   return unique_ptr<MwmInfo>(move(info));
 }
 
-unique_ptr<MwmSet::MwmValueBase> DataSource::CreateValue(MwmInfo & info) const
+unique_ptr<MwmValue> DataSource::CreateValue(MwmInfo & info) const
 {
   // Create a section with rank table if it does not exist.
   platform::LocalCountryFile const & localFile = info.GetLocalFile();
@@ -188,7 +188,7 @@ unique_ptr<MwmSet::MwmValueBase> DataSource::CreateValue(MwmInfo & info) const
 
   p->SetTable(dynamic_cast<MwmInfoEx &>(info));
   ASSERT(p->GetHeader().IsMWMSuitable(), ());
-  return unique_ptr<MwmSet::MwmValueBase>(move(p));
+  return unique_ptr<MwmValue>(move(p));
 }
 
 pair<MwmSet::MwmId, MwmSet::RegResult> DataSource::RegisterMap(LocalCountryFile const & localFile)

--- a/indexer/data_source.hpp
+++ b/indexer/data_source.hpp
@@ -71,7 +71,7 @@ protected:
 
   /// MwmSet overrides:
   std::unique_ptr<MwmInfo> CreateInfo(platform::LocalCountryFile const & localFile) const override;
-  std::unique_ptr<MwmValueBase> CreateValue(MwmInfo & info) const override;
+  std::unique_ptr<MwmValue> CreateValue(MwmInfo & info) const override;
 
 private:
   friend class FeaturesLoaderGuard;

--- a/indexer/indexer_tests/mwm_set_test.cpp
+++ b/indexer/indexer_tests/mwm_set_test.cpp
@@ -1,6 +1,8 @@
 #include "testing/testing.hpp"
 
-#include "test_mwm_set.hpp"
+#include "platform/platform_tests_support/scoped_mwm.cpp"
+
+#include "indexer/indexer_tests/test_mwm_set.hpp"
 
 #include "indexer/mwm_set.hpp"
 
@@ -13,6 +15,7 @@ using namespace std;
 using platform::CountryFile;
 using platform::LocalCountryFile;
 using tests::TestMwmSet;
+using namespace platform::tests_support;
 
 using MwmsInfo = unordered_map<string, shared_ptr<MwmInfo>>;
 
@@ -40,6 +43,13 @@ UNIT_TEST(MwmSetSmokeTest)
 {
   TestMwmSet mwmSet;
   MwmsInfo mwmsInfo;
+
+  ScopedMwm mwm0("0.mwm");
+  ScopedMwm mwm1("1.mwm");
+  ScopedMwm mwm2("2.mwm");
+  ScopedMwm mwm3("3.mwm");
+  ScopedMwm mwm4("4.mwm");
+  ScopedMwm mwm5("5.mwm");
 
   UNUSED_VALUE(mwmSet.Register(LocalCountryFile::MakeForTesting("0")));
   UNUSED_VALUE(mwmSet.Register(LocalCountryFile::MakeForTesting("1")));
@@ -106,6 +116,8 @@ UNIT_TEST(MwmSetSmokeTest)
 
 UNIT_TEST(MwmSetIdTest)
 {
+  ScopedMwm mwm3("3.mwm");
+
   TestMwmSet mwmSet;
   TEST_EQUAL(MwmSet::RegResult::Success,
              mwmSet.Register(LocalCountryFile::MakeForTesting("3")).second, ());
@@ -129,6 +141,7 @@ UNIT_TEST(MwmSetIdTest)
 
 UNIT_TEST(MwmSetLockAndIdTest)
 {
+  ScopedMwm mwm4("4.mwm");
   TestMwmSet mwmSet;
   MwmSet::MwmId id;
 

--- a/indexer/indexer_tests/test_mwm_set.hpp
+++ b/indexer/indexer_tests/test_mwm_set.hpp
@@ -31,9 +31,9 @@ protected:
     return info;
   }
 
-  std::unique_ptr<MwmValueBase> CreateValue(MwmInfo &) const override
+  std::unique_ptr<MwmValue> CreateValue(MwmInfo & info) const override
   {
-    return std::make_unique<MwmValueBase>();
+    return std::make_unique<MwmValue>(info.GetLocalFile());
   }
   //@}
 };

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -49,9 +49,9 @@ private:
     info->m_version.SetFormat(version::Format::lastFormat);
     return info;
   }
-  unique_ptr<MwmValueBase> CreateValue(MwmInfo &) const override
+  unique_ptr<MwmValue> CreateValue(MwmInfo & info) const override
   {
-    return make_unique<MwmValueBase>();
+    return make_unique<MwmValue>(info.GetLocalFile());
   }
   //@}
 

--- a/traffic/traffic_tests/traffic_info_test.cpp
+++ b/traffic/traffic_tests/traffic_info_test.cpp
@@ -33,9 +33,9 @@ protected:
     return info;
   }
 
-  unique_ptr<MwmValueBase> CreateValue(MwmInfo &) const override
+  unique_ptr<MwmValue> CreateValue(MwmInfo & info) const override
   {
-    return make_unique<MwmValueBase>();
+    return make_unique<MwmValue>(info.GetLocalFile());
   }
 };
 }  // namespace


### PR DESCRIPTION
после этого PR избавлюсь от шаблонности в:
```cpp
handle.GetValue<MwmSet::MwmValue>();
```