### PR TITLE
[drape] Fixed crash in stylist

### DIFF
--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -230,11 +230,17 @@ void CaptionDescription::ProcessZoomLevel(int const zoomLevel)
   }
 
   if (zoomLevel < 5 && m_mainText.size() > 50)
+  {
     m_mainText.clear();
+    m_auxText.clear();
+  }
 }
 
 void CaptionDescription::ProcessMainTextType(drule::text_type_t const & mainTextType)
 {
+  if (m_houseNumber.empty())
+    return;
+
   if (mainTextType == drule::text_type_housenumber)
   {
     m_mainText.swap(m_houseNumber);
@@ -243,8 +249,7 @@ void CaptionDescription::ProcessMainTextType(drule::text_type_t const & mainText
   }
   else if (mainTextType == drule::text_type_name)
   {
-    if (!m_houseNumber.empty() &&
-        (m_mainText.empty() || m_houseNumber.find(m_mainText) != std::string::npos))
+    if (m_mainText.empty() || m_houseNumber.find(m_mainText) != std::string::npos)
     {
       m_houseNumber.swap(m_mainText);
       m_isHouseNumberInMainText = true;


### PR DESCRIPTION
Графический движок запрещает ситуацию, когда у объектов существует secondary text без наличия primary text.
Как воспроизводится крэш. Берем объект, у которого название есть только по-русски, а стиль предполагает наличия номера дома (который оказывается не проставленным). Запускаем приложение на английской локали, название на русском транслитерируется. Транслитерированное название становится primary text, русское - secondary. Номер дома (пустая строка) при применении стиля заменяет primary text (в методе ProcessMainTextType). Оказывается, что primary text - пустой, secondary - не пустой.