### PR TITLE
[routing] May be fix enormous memory usage in routes_builder_tool

### DIFF
--- a/routing/routes_builder/routes_builder.cpp
+++ b/routing/routes_builder/routes_builder.cpp
@@ -291,6 +291,8 @@ RoutesBuilder::Processor::operator()(Params const & params)
   RouterResultCode resultCode;
   routing::Route route("" /* router */, 0 /* routeId */);
 
+  m_delegate->SetTimeout(params.m_timeoutSeconds);
+
   CHECK(m_dataSource, ());
   resultCode =
       m_router->CalculateRoute(params.m_checkpoints,

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -60,6 +60,7 @@ public:
 
     VehicleType m_type = VehicleType::Car;
     Checkpoints m_checkpoints;
+    uint32_t m_timeoutSeconds = 0;
   };
 
   struct Route

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -32,7 +32,10 @@ DEFINE_string(resources_path, "", "Resources path.");
 DEFINE_string(api_name, "", "Api name, current options: mapbox,google");
 DEFINE_string(api_token, "", "Token for chosen api.");
 
-DEFINE_int64(start_from, 0, "The line number from which the tool should start reading.");
+DEFINE_uint64(start_from, 0, "The line number from which the tool should start reading.");
+
+DEFINE_int32(timeout, 10 * 60, "Timeout in seconds for each route building. "
+                               "0 means without timeout (default: 10 minutes).");
 
 using namespace routing;
 using namespace routes_builder;
@@ -61,6 +64,8 @@ int Main(int argc, char ** argv)
   google::SetUsageMessage("This tool provides routes building for them further analyze.");
   google::ParseCommandLineFlags(&argc, &argv, true);
 
+  CHECK_GREATER_OR_EQUAL(FLAGS_timeout, 0, ("Timeout should be greater than zero."));
+
   CHECK(!FLAGS_routes_file.empty(),
         ("\n\n\t--routes_file is required.",
          "\n\nType --help for usage."));
@@ -86,9 +91,8 @@ int Main(int argc, char ** argv)
   else
     CHECK_EQUAL(Platform::MkDir(FLAGS_dump_path), Platform::EError::ERR_OK,());
 
-  std::vector<RoutesBuilder::Result> results;
   if (IsLocalBuild())
-    results = BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads);
+    BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout);
 
   if (IsApiBuild())
   {

--- a/routing/routes_builder/routes_builder_tool/utils.hpp
+++ b/routing/routes_builder/routes_builder_tool/utils.hpp
@@ -13,10 +13,11 @@ namespace routing
 {
 namespace routes_builder
 {
-std::vector<RoutesBuilder::Result> BuildRoutes(std::string const & routesPath,
-                                               std::string const & dumpPath,
-                                               int64_t startFrom,
-                                               uint64_t threadsNumber);
+void BuildRoutes(std::string const & routesPath,
+                 std::string const & dumpPath,
+                 uint64_t startFrom,
+                 uint64_t threadsNumber,
+                 uint32_t timeoutPerRouteSeconds);
 
 void BuildRoutesWithApi(std::unique_ptr<routing_quality::api::RoutingApi> routingApi,
                         std::string const & routesPath,


### PR DESCRIPTION
Проблемы:
1) Зачем-то я написал так, что все результаты сохраняются в 
```cpp
std::vector<RoutesBuilder::Result>
```
(ф-ия BuildRoutes возвращала вектор, который потом никак не используется), из-за этого (теоретически) постоянно росло потребление памяти. В этом векторе самое тяжелое - это хранится вся геометрия маршрута (все его точки).
2) Существует N маршрутов, на которых тулза прям застревала, посмотрел на них руками, все они примерно об одном и том же (о Египте). Там landuse-military и стоит border-control (в осме стоит vehicle_motor=no):
![image](https://user-images.githubusercontent.com/17534533/67512290-25736d80-f6a1-11e9-90cd-ee88dae7c66c.png)
И на остальных путях что-то подобное
В итоге получалась такая картина:
![image](https://user-images.githubusercontent.com/17534533/67512415-73887100-f6a1-11e9-9a5f-0559a48059e0.png)
Красными стрелочками я примерно обозначил старт и финиш.
Такая картина получается на desktop, если подождать какое-то время, конца построения я естественно не дожидался. Построение этого маршрута на сервере заняло примерно 1 час и 30 минут

Когда такие ситуации приводили к плохим последствиям: когда одновременно разные треды запустят эти плохие таски, тогда эти треды будут пытаться обойти весь мир, как итог - огромное потребление памяти. Решение - сделаем регулируемый таймаут, по умолчанию 10 минут. При этом при построении, тулза будет говорить о тасках, для которых построение заняло больше таймаута, чтобы выкинуть такие маршруты из выборки.

При этом утверждается, что все маршруты из выборки - были построены на телефоне, такое условие как раз решало подобные проблемы с потреблением памяти при обходе мира. Теория о том - почему же так вышло сейчас, заключается в том, что маршруты были собраны за 2018 год, изменение node barrier-control произошло год назад. То есть возможно у нас и дальше будет происходить такие ситуации, когда с актуальными данными старые маршруты перестают нормально строиться.