### PR TITLE
[routing] Refactor RouterDelegate

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1245,7 +1245,7 @@ Java_com_mapswithme_maps_Framework_nativeCloseRouting(JNIEnv * env, jclass)
 JNIEXPORT void JNICALL
 Java_com_mapswithme_maps_Framework_nativeBuildRoute(JNIEnv * env, jclass)
 {
-  frm()->GetRoutingManager().BuildRoute(0 /* timeoutSec */);
+  frm()->GetRoutingManager().BuildRoute();
 }
 
 JNIEXPORT void JNICALL

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -144,7 +144,7 @@
   auto const pointsCount = points.size();
   
   if (pointsCount > 1) {
-    self.rm.BuildRoute(0 /* timeoutSec */);
+    self.rm.BuildRoute();
   } else {
     if (errorPtr) {
       if (pointsCount == 0) {

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -427,7 +427,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
     self.type = routerType(rm.GetBestRouter(points.front().m_position, points.back().m_position));
 
   [[MWMMapViewControlsManager manager] onRouteRebuild];
-  rm.BuildRoute(0 /* timeoutSec */);
+  rm.BuildRoute();
 }
 
 + (void)start

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -137,7 +137,7 @@ public:
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRoutingFollowing() const { return m_routingSession.IsFollowing(); }
   bool IsRouteValid() const { return m_routingSession.IsRouteValid(); }
-  void BuildRoute(uint32_t timeoutSec);
+  void BuildRoute(uint32_t timeoutSec = routing::RouterDelegate::kNoTimeout);
   void SetUserCurrentPosition(m2::PointD const & position);
   void ResetRoutingSession() { m_routingSession.Reset(); }
   // FollowRoute has a bug where the router follows the route even if the method hads't been called.

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -223,7 +223,7 @@ void DrawWidget::initializeGL()
   m_framework.GetRoutingManager().LoadRoutePoints([this](bool success)
   {
     if (success)
-      m_framework.GetRoutingManager().BuildRoute(0 /* timeoutSec */);
+      m_framework.GetRoutingManager().BuildRoute();
   });
 
   if (m_screenshotMode)
@@ -586,7 +586,7 @@ void DrawWidget::SubmitRoutingPoint(m2::PointD const & pt)
   routingManager.AddRoutePoint(std::move(point));
 
   if (routingManager.GetRoutePoints().size() >= 2)
-    routingManager.BuildRoute(0 /* timeoutSec */);
+    routingManager.BuildRoute();
 }
 
 void DrawWidget::SubmitBookmark(m2::PointD const & pt)
@@ -648,7 +648,7 @@ void DrawWidget::OnRouteRecommendation(RoutingManager::Recommendation recommenda
     routingManager.AddRoutePoint(std::move(startPoint));
 
     if (routingManager.GetRoutePoints().size() >= 2)
-      routingManager.BuildRoute(0 /* timeoutSec */);
+      routingManager.BuildRoute();
   }
 }
 

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -53,7 +53,7 @@ public:
                       NeedMoreMapsCallback const & needMoreMapsCallback,
                       RemoveRouteCallback const & removeRouteCallback,
                       ProgressCallback const & progressCallback,
-                      uint32_t timeoutSec);
+                      uint32_t timeoutSec = RouterDelegate::kNoTimeout);
 
   /// Interrupt routing and clear buffers
   void ClearState();

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -178,7 +178,7 @@ bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph, vector<Junc
   streetNames.clear();
   routeGeometry.clear();
   segments.clear();
-  
+
   size_t const pathSize = path.size();
   // Note. According to Route::IsValid() method route of zero or one point is invalid.
   if (pathSize <= 1)
@@ -199,9 +199,8 @@ bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph, vector<Junc
     return false;
 
   ::RoutingResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
-  RouterDelegate delegate;
-
-  MakeTurnAnnotation(resultGraph, *m_numMwmIds, delegate, routeGeometry, turns, streetNames, segments);
+  MakeTurnAnnotation(resultGraph, *m_numMwmIds, cancellable, routeGeometry, turns, streetNames,
+                     segments);
   CHECK_EQUAL(routeGeometry.size(), pathSize, ());
   // In case of bicycle routing |m_pathSegments| may have an empty
   // |LoadedPathSegment::m_segments| fields. In that case |segments| is empty

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -497,7 +497,7 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
 
   // TODO (@gmoryes) https://jira.mail.ru/browse/MAPSME-10694
   //  We should do RedressRoute for each subroute separately.
-  auto redressResult = RedressRoute(segments, delegate, *starter, route);
+  auto redressResult = RedressRoute(segments, delegate.GetCancellable(), *starter, route);
   if (redressResult != RouterResultCode::NoError)
     return redressResult;
 
@@ -605,7 +605,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
 
     AStarAlgorithm<Vertex, Edge, Weight>::Params params(
       jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(), nullptr /* prevRoute */,
-      delegate, onVisitJunctionJoints, checkLength);
+      delegate.GetCancellable(), onVisitJunctionJoints, checkLength);
 
     set<NumMwmId> const mwmIds = starter.GetMwms();
     RouterResultCode const result = FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, mode);
@@ -650,7 +650,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
     RoutingResult<Segment, RouteWeight> routingResult;
     AStarAlgorithm<Vertex, Edge, Weight>::Params params(
       starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
-      delegate, onVisitJunction, checkLength);
+      delegate.GetCancellable(), onVisitJunction, checkLength);
 
     set<NumMwmId> const mwmIds = starter.GetMwms();
     RouterResultCode const result = FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, mode);
@@ -748,8 +748,9 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 
   AStarAlgorithm<Vertex, Edge, Weight> algorithm;
   AStarAlgorithm<Vertex, Edge, Weight>::Params params(starter, starter.GetStartSegment(),
-                                                      {} /* finalVertex */, &prevEdges, delegate,
-                                                      onVisitJunction, checkLength);
+                                                      {} /* finalVertex */, &prevEdges,
+                                                      delegate.GetCancellable(), onVisitJunction,
+                                                      checkLength);
   RoutingResult<Segment, RouteWeight> result;
   auto const resultCode =
       ConvertResult<Vertex, Edge, Weight>(algorithm.AdjustRoute(params, result));
@@ -783,7 +784,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   route.SetCurrentSubrouteIdx(checkpoints.GetPassedIdx());
   route.SetSubroteAttrs(move(subroutes));
 
-  auto const redressResult = RedressRoute(result.m_path, delegate, starter, route);
+  auto const redressResult = RedressRoute(result.m_path, delegate.GetCancellable(), starter, route);
   if (redressResult != RouterResultCode::NoError)
     return redressResult;
 
@@ -1176,8 +1177,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
 
     AStarAlgorithm<Vertex, Edge, Weight>::Params params(
       jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(),
-      nullptr /* prevRoute */, delegate,
-      onVisitJunctionJoints, checkLength);
+      nullptr /* prevRoute */, delegate.GetCancellable(), onVisitJunctionJoints, checkLength);
 
     resultCode = FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, mode);
     return resultCode;
@@ -1295,7 +1295,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
 }
 
 RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
-                                           RouterDelegate const & delegate,
+                                           base::Cancellable const & cancellable,
                                            IndexGraphStarter & starter, Route & route) const
 {
   CHECK(!segments.empty(), ());
@@ -1326,8 +1326,8 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   }
 
   CHECK(m_directionsEngine, ());
-  ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, delegate, junctions, move(times),
-                   route);
+  ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, cancellable, junctions,
+                   move(times), route);
 
   CHECK(m_numMwmIds, ());
   auto & worldGraph = starter.GetGraph();
@@ -1358,7 +1358,7 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   FillSpeedCamProhibitedMwms(segments, speedCamProhibited);
   route.SetMwmsPartlyProhibitedForSpeedCams(move(speedCamProhibited));
 
-  if (delegate.IsCancelled())
+  if (cancellable.IsCancelled())
     return RouterResultCode::Cancelled;
 
   if (!route.IsValid())

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -153,7 +153,7 @@ private:
                                       IndexGraphStarter & starter, AStarProgress & progress,
                                       std::vector<Segment> & output);
   RouterResultCode RedressRoute(std::vector<Segment> const & segments,
-                                RouterDelegate const & delegate, IndexGraphStarter & starter,
+                                base::Cancellable const & cancellable, IndexGraphStarter & starter,
                                 Route & route) const;
 
   bool AreMwmsNear(IndexGraphStarter const & starter) const;

--- a/routing/router_delegate.cpp
+++ b/routing/router_delegate.cpp
@@ -1,17 +1,31 @@
 #include "routing/router_delegate.hpp"
 
+#include <chrono>
+
 namespace routing
 {
 namespace
 {
 void DefaultProgressFn(float /* progress */) {}
 void DefaultPointFn(m2::PointD const & /* point */) {}
-} //  namespace
+}  //  namespace
 
 RouterDelegate::RouterDelegate()
 {
   m_progressCallback = DefaultProgressFn;
   m_pointCallback = DefaultPointFn;
+}
+
+void RouterDelegate::OnProgress(float progress) const
+{
+  if (!m_cancellable.IsCancelled())
+    m_progressCallback(progress);
+}
+
+void RouterDelegate::OnPointCheck(m2::PointD const & point) const
+{
+  if (!m_cancellable.IsCancelled())
+    m_pointCallback(point);
 }
 
 void RouterDelegate::SetProgressCallback(ProgressCallback const & progressCallback)
@@ -24,46 +38,12 @@ void RouterDelegate::SetPointCheckCallback(PointCheckCallback const & pointCallb
   m_pointCallback = pointCallback ? pointCallback : DefaultPointFn;
 }
 
-void RouterDelegate::OnProgress(float progress) const
+void RouterDelegate::SetTimeout(uint32_t timeoutSec)
 {
-  std::lock_guard<std::mutex> l(m_guard);
-  if (!IsCancelled())
-    m_progressCallback(progress);
-}
+  if (timeoutSec == kNoTimeout)
+    return;
 
-void RouterDelegate::Reset()
-{
-  std::lock_guard<std::mutex> l(m_guard);
-  TimeoutCancellable::Reset();
-}
-
-void RouterDelegate::OnPointCheck(m2::PointD const & point) const
-{
-  std::lock_guard<std::mutex> l(m_guard);
-  if (!IsCancelled())
-    m_pointCallback(point);
-}
-
-TimeoutCancellable::TimeoutCancellable() : m_timeoutSec(0)
-{
-}
-
-bool TimeoutCancellable::IsCancelled() const
-{
-  if (m_timeoutSec && m_timer.ElapsedSeconds() > m_timeoutSec)
-    return true;
-  return Cancellable::IsCancelled();
-}
-
-void TimeoutCancellable::Reset()
-{
-  m_timeoutSec = 0;
-  Cancellable::Reset();
-}
-
-void TimeoutCancellable::SetTimeout(uint32_t timeoutSec)
-{
-  m_timeoutSec = timeoutSec;
-  m_timer.Reset();
+  std::chrono::steady_clock::duration const timeout = std::chrono::seconds(timeoutSec);
+  m_cancellable.SetDeadline(std::chrono::steady_clock::now() + timeout);
 }
 }  //  namespace routing

--- a/routing/router_delegate.hpp
+++ b/routing/router_delegate.hpp
@@ -10,26 +10,11 @@
 
 namespace routing
 {
-class TimeoutCancellable : public base::Cancellable
+class RouterDelegate
 {
 public:
-  TimeoutCancellable();
+  static auto constexpr kNoTimeout = std::numeric_limits<uint32_t>::max();
 
-  /// Sets timeout before cancellation. 0 means an infinite timeout.
-  void SetTimeout(uint32_t timeoutSec);
-
-  // Cancellable overrides:
-  bool IsCancelled() const override;
-  void Reset() override;
-
-private:
-  base::Timer m_timer;
-  uint32_t m_timeoutSec;
-};
-
-class RouterDelegate : public TimeoutCancellable
-{
-public:
   RouterDelegate();
 
   /// Set routing progress. Waits current progress status from 0 to 100.
@@ -39,11 +24,17 @@ public:
   void SetProgressCallback(ProgressCallback const & progressCallback);
   void SetPointCheckCallback(PointCheckCallback const & pointCallback);
 
-  void Reset() override;
+  void SetTimeout(uint32_t timeoutSec);
+
+  base::Cancellable const & GetCancellable() const { return m_cancellable; }
+  void Reset() { return m_cancellable.Reset(); }
+  void Cancel() { return m_cancellable.Cancel(); }
+  bool IsCancelled() const { return m_cancellable.IsCancelled(); }
 
 private:
-  mutable std::mutex m_guard;
   ProgressCallback m_progressCallback;
   PointCheckCallback m_pointCallback;
+
+  base::Cancellable m_cancellable;
 };
 } //  namespace routing

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -4,6 +4,7 @@
 
 #include "routing/checkpoints.hpp"
 #include "routing/index_router.hpp"
+#include "routing/router_delegate.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "routing/segment.hpp"
 #include "routing/vehicle_mask.hpp"
@@ -60,7 +61,7 @@ public:
 
     VehicleType m_type = VehicleType::Car;
     Checkpoints m_checkpoints;
-    uint32_t m_timeoutSeconds = 0;
+    uint32_t m_timeoutSeconds = RouterDelegate::kNoTimeout;
   };
 
   struct Route

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -1,4 +1,5 @@
 #include "routing/routing_helpers.hpp"
+
 #include "routing/road_point.hpp"
 #include "routing/segment.hpp"
 

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -121,7 +121,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTest, NeedMoreMapsSignalTest)
   async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,
                        bind(ref(resultCallback), _1, _2) /* readyCallback */,
                        bind(ref(resultCallback), _1, _2) /* needMoreMapsCallback */,
-                       nullptr /* removeRouteCallback */, nullptr /* progressCallback */, 0);
+                       nullptr /* removeRouteCallback */, nullptr /* progressCallback */);
 
   resultCallback.WaitFinish();
 
@@ -143,7 +143,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTest, StandardAsyncFogTest)
   async.SetRouter(move(router), move(fetcher));
   async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,
                        bind(ref(resultCallback), _1, _2), nullptr /* needMoreMapsCallback */,
-                       nullptr /* progressCallback */, nullptr /* removeRouteCallback */, 0);
+                       nullptr /* progressCallback */, nullptr /* removeRouteCallback */);
 
   resultCallback.WaitFinish();
 

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -192,9 +192,10 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
     RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path)
 {
   RoadGraph roadGraph(graph);
-  base::Cancellable const cancellable;
+  base::Cancellable cancellable;
   Algorithm::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */,
-                           cancellable, {} /* onVisitJunctionFn */, {} /* checkLength */);
+                           cancellable, {} /* onVisitJunctionFn */,
+                           {} /* checkLength */);
   Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
   return Convert(res);
 }

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -153,8 +153,10 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteBuilding)
           LOG(LINFO, ("Ready"));
           timedSignal.Signal();
         },
-        nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+        nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
+        nullptr /* removeRouteCallback */);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::kNoTimeout);
   });
 
   // Manual check of the routeBuilding mutex to avoid spurious results.
@@ -185,7 +187,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
   TEST_EQUAL(counter, 1, ());
@@ -219,7 +222,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
           {SessionState::OnRoute, SessionState::RoutingNotActive, SessionState::RouteBuilding},
           *m_session);
 
-      m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+      m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                            RouterDelegate::kNoTimeout);
     }
   });
   TEST(oppositeTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -265,7 +269,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingT
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
   TEST_EQUAL(counter, 1, ());
@@ -314,7 +319,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
 
@@ -342,7 +348,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
         [&oppositeTimedSignal](Route const &, RouterResultCode) { oppositeTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::kNoTimeout);
   });
   TEST(oppositeTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
 
@@ -367,7 +374,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
     m_session->RebuildRoute(
         kTestRoute.front(),
         [&rebuildTimedSignal](Route const &, RouterResultCode) { rebuildTimedSignal.Signal(); },
-        nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, 0,
+        nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, RouterDelegate::kNoTimeout,
         SessionState::RouteBuilding, false /* adjust */);
   });
   TEST(rebuildTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -401,7 +408,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), 0);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                          RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
 

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -569,13 +569,13 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
 }
 
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
-                                    RouterDelegate const & delegate,
+                                    base::Cancellable const & cancellable,
                                     vector<Junction> & junctions, Route::TTurns & turnsDir,
                                     Route::TStreets & streets, vector<Segment> & segments)
 {
   LOG(LDEBUG, ("Shortest th length:", result.GetPathLength()));
 
-  if (delegate.IsCancelled())
+  if (cancellable.IsCancelled())
     return RouterResultCode::Cancelled;
   // Annotate turns.
   size_t skipTurnSegments = 0;

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -94,9 +94,9 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
  * \return routing operation result code.
  */
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
-                                       RouterDelegate const & delegate, std::vector<Junction> & points,
-                                       Route::TTurns & turnsDir, Route::TStreets & streets,
-                                       std::vector<Segment> & segments);
+                                    base::Cancellable const & cancellable,
+                                    std::vector<Junction> & points, Route::TTurns & turnsDir,
+                                    Route::TStreets & streets, std::vector<Segment> & segments);
 
 // Returns the distance in meractor units for the path of points for the range [startPointIndex, endPointIndex].
 double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t endPointIndex,


### PR DESCRIPTION
1) переписал RouterDelegate на новый base::Cancellable (@mpimenov написал логику Deadline там недавно)
2) теперь RouterDelegate не является наследником base::Cancellable, потому что в моей голове это должна быть композиция, а не наследование, так как если это наследник base::Cancellable, то почему у него есть OnProgress() PointCheck() и всякое такое