### PR TITLE
[search] Fix postcodes format for postcodes search index.

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -281,10 +281,21 @@ void GetUKPostcodes(string const & filename, storage::CountryId const & countryI
     if (find(countries.begin(), countries.end(), countryId) == countries.end())
       continue;
 
+    // UK postcodes formats are: aana naa, ana naa, an naa, ann naa, aan naa, aann naa.
+
+    auto postcode = fields[kPostcodeIndex];
+    // Do not index outer postcodes.
+    if (postcode.size() < 5)
+      continue;
+
+    // Space is skipped in dataset for |aana naa| and |aann naa| to make it fit 7 symbols in csv.
+    // Let's fix it here.
+    if (postcode.find(' ') == string::npos)
+      postcode.insert(static_cast<size_t>(postcode.size() - 3), " ");
+
     CHECK_EQUAL(valueMapping.size(), index, ());
     valueMapping.push_back(p);
-    keyValuePairs.emplace_back(search::NormalizeAndSimplifyString(fields[kPostcodeIndex]),
-                               Value(index));
+    keyValuePairs.emplace_back(search::NormalizeAndSimplifyString(postcode), Value(index));
     ++index;
   }
 }

--- a/search/search_integration_tests/postcode_points_tests.cpp
+++ b/search/search_integration_tests/postcode_points_tests.cpp
@@ -46,9 +46,14 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
   auto const postcodesRelativePath = base::JoinPath(writableDir, testFile);
 
   ScopedFile const osmScopedFile(testFile,
-                                 "aa11 0, 1.0, 1.0\n"
-                                 "aa11 1, 2.0, 2.0\n"
-                                 "aa11 2, 3.0, 3.0\n");
+                                 "aa11 0bb, 1.0, 1.0\n"
+                                 "aa11 1bb, 2.0, 2.0\n"
+                                 // Missing space. Postcode should be converted to |aa11 2bb|
+                                 // for index.
+                                 "aa112bb, 3.0, 3.0\n"
+                                 // Put here some wrong location to make sure outer postcode
+                                 // will be skipped in index and calculated from inners.
+                                 "aa11, 100.0, 1.0\n");
 
   auto infoGetter = std::make_shared<storage::CountryInfoGetterForTesting>();
   infoGetter->AddCountry(storage::CountryDef(
@@ -67,21 +72,21 @@ UNIT_CLASS_TEST(PostcodePointsTest, Smoke)
   PostcodePoints p(*value);
   {
     vector<m2::PointD> points;
-    p.Get(NormalizeAndSimplifyString("aa11 0"), points);
+    p.Get(NormalizeAndSimplifyString("aa11 0bb"), points);
     TEST_EQUAL(points.size(), 1, ());
     TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(1.0, 1.0), kMwmPointAccuracy),
          ());
   }
   {
     vector<m2::PointD> points;
-    p.Get(NormalizeAndSimplifyString("aa11 1"), points);
+    p.Get(NormalizeAndSimplifyString("aa11 1bb"), points);
     TEST_EQUAL(points.size(), 1, ());
     TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(2.0, 2.0), kMwmPointAccuracy),
          ());
   }
   {
     vector<m2::PointD> points;
-    p.Get(NormalizeAndSimplifyString("aa11 2"), points);
+    p.Get(NormalizeAndSimplifyString("aa11 2bb"), points);
     TEST_EQUAL(points.size(), 1, ());
     TEST(base::AlmostEqualAbs(points[0], MercatorBounds::FromLatLon(3.0, 3.0), kMwmPointAccuracy),
          ());
@@ -161,26 +166,26 @@ UNIT_CLASS_TEST(PostcodePointsTest, SearchStreetWithPostcode)
       "XX6 7KL, 4.0, 6.0\n"
       "YY8 9MN, 6.0, 4.0\n"
       // Some dummy postcodes to make postcode radius approximation not too big.
-      "CC1 001, 5.0, 5.0\n"
-      "CC1 002, 5.0, 5.0\n"
-      "CC1 003, 5.0, 5.0\n"
-      "CC1 004, 5.0, 5.0\n"
-      "CC1 005, 5.0, 5.0\n"
-      "CC1 006, 5.0, 5.0\n"
-      "CC1 007, 5.0, 5.0\n"
-      "CC1 008, 5.0, 5.0\n"
-      "CC1 009, 5.0, 5.0\n"
-      "CC1 010, 5.0, 5.0\n"
-      "CC1 011, 5.0, 5.0\n"
-      "CC1 012, 5.0, 5.0\n"
-      "CC1 013, 5.0, 5.0\n"
-      "CC1 014, 5.0, 5.0\n"
-      "CC1 015, 5.0, 5.0\n"
-      "CC1 016, 5.0, 5.0\n"
-      "CC1 017, 5.0, 5.0\n"
-      "CC1 018, 5.0, 5.0\n"
-      "CC1 019, 5.0, 5.0\n"
-      "CC1 020, 5.0, 5.0\n");
+      "CC1 0AA, 5.0, 5.0\n"
+      "CC1 0AB, 5.0, 5.0\n"
+      "CC1 0AC, 5.0, 5.0\n"
+      "CC1 0AD, 5.0, 5.0\n"
+      "CC1 0AE, 5.0, 5.0\n"
+      "CC1 0AF, 5.0, 5.0\n"
+      "CC1 0AG, 5.0, 5.0\n"
+      "CC1 0AH, 5.0, 5.0\n"
+      "CC1 0AI, 5.0, 5.0\n"
+      "CC1 0AJ, 5.0, 5.0\n"
+      "CC1 0AK, 5.0, 5.0\n"
+      "CC1 0AL, 5.0, 5.0\n"
+      "CC1 0AM, 5.0, 5.0\n"
+      "CC1 0AN, 5.0, 5.0\n"
+      "CC1 0AO, 5.0, 5.0\n"
+      "CC1 0AP, 5.0, 5.0\n"
+      "CC1 0AQ, 5.0, 5.0\n"
+      "CC1 0AR, 5.0, 5.0\n"
+      "CC1 0AS, 5.0, 5.0\n"
+      "CC1 0AT, 5.0, 5.0\n");
 
   auto const rect =
       m2::RectD(MercatorBounds::FromLatLon(3.99, 3.99), MercatorBounds::FromLatLon(6.01, 6.01));


### PR DESCRIPTION
Разобралась с форматом посткодов, есть возможность однозначано восстановить посткод в формате "outer inner" из данных датасета, потому что inner всегда 3 символа naa.