### PR TITLE
[coding][map][tracking] Track reporting for all route types.

### DIFF
--- a/coding/coding_tests/traffic_test.cpp
+++ b/coding/coding_tests/traffic_test.cpp
@@ -1,9 +1,12 @@
 #include "testing/testing.hpp"
 
+#include "routing/router.hpp"
+
+#include "traffic/speed_groups.hpp"
+
 #include "coding/traffic.hpp"
 
 #include "geometry/mercator.hpp"
-#include "geometry/point2d.hpp"
 
 #include "base/logging.hpp"
 #include "base/math.hpp"
@@ -65,7 +68,10 @@ void Test(vector<TrafficGPSEncoder::DataPoint> & points)
 UNIT_TEST(Traffic_Serialization_Smoke)
 {
   vector<TrafficGPSEncoder::DataPoint> data = {
-      {0, ms::LatLon(0.0, 1.0), 1}, {0, ms::LatLon(0.0, 2.0), 2},
+      {0, ms::LatLon(0.0, 1.0), static_cast<uint8_t>(traffic::SpeedGroup::G1),
+       static_cast<uint8_t>(routing::RouterType::Vehicle)},
+      {0, ms::LatLon(0.0, 2.0), static_cast<uint8_t>(traffic::SpeedGroup::G2),
+       static_cast<uint8_t>(routing::RouterType::Vehicle)},
   };
   Test(data);
 }
@@ -79,7 +85,10 @@ UNIT_TEST(Traffic_Serialization_EmptyPath)
 UNIT_TEST(Traffic_Serialization_StraightLine100m)
 {
   vector<TrafficGPSEncoder::DataPoint> path = {
-      {0, ms::LatLon(0.0, 0.0), 1}, {0, ms::LatLon(0.0, 1e-3), 2},
+      {0, ms::LatLon(0.0, 0.0), static_cast<uint8_t>(traffic::SpeedGroup::G1),
+       static_cast<uint8_t>(routing::RouterType::Bicycle)},
+      {0, ms::LatLon(0.0, 1e-3), static_cast<uint8_t>(traffic::SpeedGroup::G2),
+       static_cast<uint8_t>(routing::RouterType::Bicycle)},
   };
   Test(path);
 }
@@ -87,7 +96,10 @@ UNIT_TEST(Traffic_Serialization_StraightLine100m)
 UNIT_TEST(Traffic_Serialization_StraightLine50Km)
 {
   vector<TrafficGPSEncoder::DataPoint> path = {
-      {0, ms::LatLon(0.0, 0.0), 1}, {0, ms::LatLon(0.0, 0.5), 2},
+      {0, ms::LatLon(0.0, 0.0), static_cast<uint8_t>(traffic::SpeedGroup::G1),
+       static_cast<uint8_t>(routing::RouterType::Pedestrian)},
+      {0, ms::LatLon(0.0, 0.5), static_cast<uint8_t>(traffic::SpeedGroup::G2),
+       static_cast<uint8_t>(routing::RouterType::Pedestrian)},
   };
   Test(path);
 }
@@ -99,7 +111,9 @@ UNIT_TEST(Traffic_Serialization_Zigzag500m)
   {
     double const x = i * 1e-3;
     double const y = i % 2 == 0 ? 0 : 1e-3;
-    path.emplace_back(TrafficGPSEncoder::DataPoint(0, ms::LatLon(y, x), 3));
+    path.emplace_back(TrafficGPSEncoder::DataPoint(
+        0, ms::LatLon(y, x), static_cast<uint8_t>(traffic::SpeedGroup::G3),
+        static_cast<uint8_t>(routing::RouterType::Vehicle)));
   }
   Test(path);
 }
@@ -111,7 +125,9 @@ UNIT_TEST(Traffic_Serialization_Zigzag10Km)
   {
     double const x = i * 1e-2;
     double const y = i % 2 == 0 ? 0 : 1e-2;
-    path.emplace_back(TrafficGPSEncoder::DataPoint(0, ms::LatLon(y, x), 0));
+    path.emplace_back(TrafficGPSEncoder::DataPoint(
+        0, ms::LatLon(y, x), static_cast<uint8_t>(traffic::SpeedGroup::G0),
+        static_cast<uint8_t>(routing::RouterType::Vehicle)));
   }
   Test(path);
 }
@@ -123,7 +139,9 @@ UNIT_TEST(Traffic_Serialization_Zigzag100Km)
   {
     double const x = i * 1e-1;
     double const y = i % 2 == 0 ? 0 : 1e-1;
-    path.emplace_back(TrafficGPSEncoder::DataPoint(0, ms::LatLon(y, x), 0));
+    path.emplace_back(TrafficGPSEncoder::DataPoint(
+        0, ms::LatLon(y, x), static_cast<uint8_t>(traffic::SpeedGroup::G0),
+        static_cast<uint8_t>(routing::RouterType::Vehicle)));
   }
   Test(path);
 }
@@ -138,7 +156,9 @@ UNIT_TEST(Traffic_Serialization_Circle20KmRadius)
     double const radius = 0.25;
     double const x = radius * cos(alpha);
     double const y = radius * sin(alpha);
-    path.emplace_back(TrafficGPSEncoder::DataPoint(0, ms::LatLon(y, x), 0));
+    path.emplace_back(TrafficGPSEncoder::DataPoint(
+        0, ms::LatLon(y, x), static_cast<uint8_t>(traffic::SpeedGroup::G0),
+        static_cast<uint8_t>(routing::RouterType::Vehicle)));
   }
   Test(path);
 }
@@ -146,7 +166,10 @@ UNIT_TEST(Traffic_Serialization_Circle20KmRadius)
 UNIT_TEST(Traffic_Serialization_ExtremeLatLon)
 {
   vector<TrafficGPSEncoder::DataPoint> path = {
-      {0, ms::LatLon(-90, -180), 0}, {0, ms::LatLon(90, 180), 0},
+      {0, ms::LatLon(-90, -180), static_cast<uint8_t>(traffic::SpeedGroup::G0),
+       static_cast<uint8_t>(routing::RouterType::Vehicle)},
+      {0, ms::LatLon(90, 180), static_cast<uint8_t>(traffic::SpeedGroup::G0),
+       static_cast<uint8_t>(routing::RouterType::Vehicle)},
   };
   Test(path);
 }

--- a/coding/traffic.cpp
+++ b/coding/traffic.cpp
@@ -5,7 +5,7 @@
 namespace coding
 {
 // static
-uint32_t const TrafficGPSEncoder::kLatestVersion = 1;
+uint32_t const TrafficGPSEncoder::kLatestVersion = 2;
 uint32_t const TrafficGPSEncoder::kCoordBits = 30;
 double const TrafficGPSEncoder::kMinDeltaLat = ms::LatLon::kMinLat - ms::LatLon::kMaxLat;
 double const TrafficGPSEncoder::kMaxDeltaLat = ms::LatLon::kMaxLat - ms::LatLon::kMinLat;

--- a/coding/traffic.hpp
+++ b/coding/traffic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "routing/router.hpp"
+
 #include "coding/point_coding.hpp"
 #include "coding/reader.hpp"
 #include "coding/varint.hpp"
@@ -30,7 +32,15 @@ public:
     DataPoint() = default;
 
     DataPoint(uint64_t timestamp, ms::LatLon latLon, uint8_t traffic)
-      : m_timestamp(timestamp), m_latLon(latLon), m_traffic(traffic)
+      : m_timestamp(timestamp)
+      , m_latLon(latLon)
+      , m_traffic(traffic)
+      , m_trackType(static_cast<uint8_t>(routing::RouterType::Vehicle))
+    {
+    }
+
+    DataPoint(uint64_t timestamp, ms::LatLon latLon, uint8_t traffic, uint8_t trackType)
+      : m_timestamp(timestamp), m_latLon(latLon), m_traffic(traffic), m_trackType(trackType)
     {
     }
     // Uint64 should be enough for all our use cases.
@@ -41,10 +51,13 @@ public:
     // so as not to introduce a cyclic dependency.
     // This field was added in Version 1 (and was the only addition).
     uint8_t m_traffic = 0;
+    // A pod type instead of the enum class routing::RouterType.
+    // This field was added in Version 2 (and was the only addition).
+    uint8_t m_trackType = 0;
 
     bool operator==(DataPoint const & p) const
     {
-      return m_timestamp == p.m_timestamp && m_latLon == p.m_latLon;
+      return m_timestamp == p.m_timestamp && m_latLon == p.m_latLon && m_trackType == p.m_trackType;
     }
   };
 
@@ -60,7 +73,7 @@ public:
     {
     case 0: return SerializeDataPointsV0(writer, points);
     case 1: return SerializeDataPointsV1(writer, points);
-
+    case 2: return SerializeDataPointsV2(writer, points);
     default: ASSERT(false, ("Unexpected serializer version:", version)); break;
     }
     return 0;
@@ -74,7 +87,7 @@ public:
     {
     case 0: return DeserializeDataPointsV0(src, result);
     case 1: return DeserializeDataPointsV1(src, result);
-
+    case 2: return DeserializeDataPointsV2(src, result);
     default: ASSERT(false, ("Unexpected serializer version:", version)); break;
     }
   }
@@ -158,6 +171,50 @@ private:
     return static_cast<size_t>(writer.Pos() - startPos);
   }
 
+  template <typename Writer, typename Collection>
+  static size_t SerializeDataPointsV2(Writer & writer, Collection const & points)
+  {
+    auto const startPos = writer.Pos();
+    if (!points.empty())
+    {
+      uint64_t const firstTimestamp = points[0].m_timestamp;
+      uint32_t const firstLat = DoubleToUint32(points[0].m_latLon.m_lat, ms::LatLon::kMinLat,
+                                               ms::LatLon::kMaxLat, kCoordBits);
+      uint32_t const firstLon = DoubleToUint32(points[0].m_latLon.m_lon, ms::LatLon::kMinLon,
+                                               ms::LatLon::kMaxLon, kCoordBits);
+      uint32_t const traffic = points[0].m_traffic;
+      uint32_t const trackType = points[0].m_trackType;
+      WriteVarUint(writer, firstTimestamp);
+      WriteVarUint(writer, firstLat);
+      WriteVarUint(writer, firstLon);
+      WriteVarUint(writer, traffic);
+      WriteVarUint(writer, trackType);
+    }
+
+    for (size_t i = 1; i < points.size(); ++i)
+    {
+      ASSERT_LESS_OR_EQUAL(points[i - 1].m_timestamp, points[i].m_timestamp, ());
+
+      uint64_t const deltaTimestamp = points[i].m_timestamp - points[i - 1].m_timestamp;
+      uint32_t deltaLat = DoubleToUint32(points[i].m_latLon.m_lat - points[i - 1].m_latLon.m_lat,
+                                         kMinDeltaLat, kMaxDeltaLat, kCoordBits);
+      uint32_t deltaLon = DoubleToUint32(points[i].m_latLon.m_lon - points[i - 1].m_latLon.m_lon,
+                                         kMinDeltaLon, kMaxDeltaLon, kCoordBits);
+
+      uint32_t const traffic = points[i - 1].m_traffic;
+      uint32_t const trackType = points[i].m_trackType;
+      WriteVarUint(writer, deltaTimestamp);
+      WriteVarUint(writer, deltaLat);
+      WriteVarUint(writer, deltaLon);
+      WriteVarUint(writer, traffic);
+      WriteVarUint(writer, trackType);
+    }
+
+    ASSERT_LESS_OR_EQUAL(writer.Pos() - startPos, std::numeric_limits<size_t>::max(),
+                         ("Too much data."));
+    return static_cast<size_t>(writer.Pos() - startPos);
+  }
+
   template <typename Source, typename Collection>
   static void DeserializeDataPointsV0(Source & src, Collection & result)
   {
@@ -222,6 +279,44 @@ private:
             Uint32ToDouble(ReadVarUint<uint32_t>(src), kMinDeltaLon, kMaxDeltaLon, kCoordBits);
         traffic = base::asserted_cast<uint8_t>(ReadVarUint<uint32_t>(src));
         result.emplace_back(lastTimestamp, ms::LatLon(lastLat, lastLon), traffic);
+      }
+    }
+  }
+
+  template <typename Source, typename Collection>
+  static void DeserializeDataPointsV2(Source & src, Collection & result)
+  {
+    bool first = true;
+    uint64_t lastTimestamp = 0;
+    double lastLat = 0.0;
+    double lastLon = 0.0;
+    uint8_t traffic = 0;
+    uint8_t trackType = 0;
+
+    while (src.Size() > 0)
+    {
+      if (first)
+      {
+        lastTimestamp = ReadVarUint<uint64_t>(src);
+        lastLat = Uint32ToDouble(ReadVarUint<uint32_t>(src), ms::LatLon::kMinLat,
+                                 ms::LatLon::kMaxLat, kCoordBits);
+        lastLon = Uint32ToDouble(ReadVarUint<uint32_t>(src), ms::LatLon::kMinLon,
+                                 ms::LatLon::kMaxLon, kCoordBits);
+        traffic = base::asserted_cast<uint8_t>(ReadVarUint<uint32_t>(src));
+        trackType = base::asserted_cast<uint8_t>(ReadVarUint<uint32_t>(src));
+        result.emplace_back(lastTimestamp, ms::LatLon(lastLat, lastLon), traffic, trackType);
+        first = false;
+      }
+      else
+      {
+        lastTimestamp += ReadVarUint<uint64_t>(src);
+        lastLat +=
+            Uint32ToDouble(ReadVarUint<uint32_t>(src), kMinDeltaLat, kMaxDeltaLat, kCoordBits);
+        lastLon +=
+            Uint32ToDouble(ReadVarUint<uint32_t>(src), kMinDeltaLon, kMaxDeltaLon, kCoordBits);
+        traffic = base::asserted_cast<uint8_t>(ReadVarUint<uint32_t>(src));
+        trackType = base::asserted_cast<uint8_t>(ReadVarUint<uint32_t>(src));
+        result.emplace_back(lastTimestamp, ms::LatLon(lastLat, lastLon), traffic, trackType);
       }
     }
   }

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1250,8 +1250,11 @@ bool RoutingManager::IsTrackingReporterEnabled() const
   if (!pm.IsFacilityEnabled(power_management::Facility::GpsTrackingForTraffic))
     return false;
 
-  if (m_currentRouterType != RouterType::Vehicle)
+  if (m_currentRouterType != RouterType::Vehicle && m_currentRouterType != RouterType::Bicycle &&
+      m_currentRouterType != RouterType::Pedestrian)
+  {
     return false;
+  }
 
   if (!m_routingSession.IsFollowing())
     return false;
@@ -1476,7 +1479,10 @@ void RoutingManager::OnExtrapolatedLocationUpdate(location::GpsInfo const & info
                          routeMatchingInfo);
 
   if (IsTrackingReporterEnabled())
-    m_trackingReporter.AddLocation(gpsInfo, m_routingSession.MatchTraffic(routeMatchingInfo));
+  {
+    m_trackingReporter.AddLocation(gpsInfo, m_routingSession.MatchTraffic(routeMatchingInfo),
+                                   m_currentRouterType);
+  }
 }
 
 void RoutingManager::DeleteSavedRoutePoints()

--- a/pyhelpers/pair.hpp
+++ b/pyhelpers/pair.hpp
@@ -15,7 +15,7 @@ struct pair_to_tuple
 {
   static PyObject * convert(std::pair<T1, T2> const & p)
   {
-    return incref(std::make_tuple(p.first, p.second).ptr());
+    return incref(boost::python::make_tuple(p.first, p.second).ptr());
   }
   
   static PyTypeObject const * get_pytype() { return &PyTuple_Type; }
@@ -24,6 +24,6 @@ struct pair_to_tuple
 template <typename T1, typename T2>
 struct pair_to_python_converter
 {
-  pair_to_python_converter() { to_python_converter<pair<T1, T2>, pair_to_tuple<T1, T2>, true>(); }
+  pair_to_python_converter() { to_python_converter<std::pair<T1, T2>, pair_to_tuple<T1, T2>, true>(); }
 };
 }  // namespace

--- a/track_generator/pytrack_generator/bindings.cpp
+++ b/track_generator/pytrack_generator/bindings.cpp
@@ -1,6 +1,6 @@
 #include "routing/route.hpp"
 #include "routing/routing_callbacks.hpp"
-#include "routing/routing_quality/utils.hpp"
+#include "routing/routing_quality/routing_quality_tool/utils.hpp"
 
 #include "platform/platform.hpp"
 

--- a/tracking/protocol.cpp
+++ b/tracking/protocol.cpp
@@ -23,6 +23,7 @@ vector<uint8_t> CreateDataPacketImpl(Container const & points,
   {
   case tracking::Protocol::PacketType::DataV0: version = 0; break;
   case tracking::Protocol::PacketType::DataV1: version = 1; break;
+  case tracking::Protocol::PacketType::DataV2: version = 2; break;
   case tracking::Protocol::PacketType::AuthV0: ASSERT(false, ("Not a DATA packet.")); break;
   }
 
@@ -92,7 +93,8 @@ string Protocol::DecodeAuthPacket(Protocol::PacketType type, vector<uint8_t> con
   {
   case Protocol::PacketType::AuthV0: return string(begin(data), end(data));
   case Protocol::PacketType::DataV0:
-  case Protocol::PacketType::DataV1: ASSERT(false, ("Not an AUTH packet.")); break;
+  case Protocol::PacketType::DataV1:
+  case Protocol::PacketType::DataV2: ASSERT(false, ("Not an AUTH packet.")); break;
   }
   return string();
 }
@@ -110,6 +112,9 @@ Protocol::DataElementsVec Protocol::DecodeDataPacket(PacketType type, vector<uin
     break;
   case Protocol::PacketType::DataV1:
     Encoder::DeserializeDataPoints(1 /* version */, src, points);
+    break;
+  case Protocol::PacketType::DataV2:
+    Encoder::DeserializeDataPoints(2 /* version */, src, points);
     break;
   case Protocol::PacketType::AuthV0: ASSERT(false, ("Not a DATA packet.")); break;
   }
@@ -138,6 +143,7 @@ string DebugPrint(Protocol::PacketType type)
   case Protocol::PacketType::AuthV0: return "AuthV0";
   case Protocol::PacketType::DataV0: return "DataV0";
   case Protocol::PacketType::DataV1: return "DataV1";
+  case Protocol::PacketType::DataV2: return "DataV2";
   }
   stringstream ss;
   ss << "Unknown(" << static_cast<uint32_t>(type) << ")";

--- a/tracking/protocol.hpp
+++ b/tracking/protocol.hpp
@@ -35,9 +35,10 @@ public:
     AuthV0 = 0x81,
     DataV0 = 0x82,
     DataV1 = 0x92,
+    DataV2 = 0x93,
 
     CurrentAuth = AuthV0,
-    CurrentData = DataV1
+    CurrentData = DataV2
   };
 
   static std::vector<uint8_t> CreateHeader(PacketType type, uint32_t payloadSize);

--- a/tracking/pytracking/bindings.cpp
+++ b/tracking/pytracking/bindings.cpp
@@ -19,7 +19,7 @@ BOOST_PYTHON_MODULE(pytracking)
 
   // Register the to-python converters.
   pair_to_python_converter<Protocol::PacketType, size_t>();
-  to_python_converter<vector<uint8_t>, vector_uint8t_to_str>();
+  to_python_converter<std::vector<uint8_t>, vector_uint8t_to_str>();
   vector_uint8t_from_python_str();
 
   class_<Protocol::DataElementsVec>("DataElementsVec")
@@ -33,19 +33,21 @@ BOOST_PYTHON_MODULE(pytracking)
       .def(init<uint64_t, ms::LatLon const &, uint8_t>())
       .def_readwrite("timestamp", &coding::TrafficGPSEncoder::DataPoint::m_timestamp)
       .def_readwrite("coords", &coding::TrafficGPSEncoder::DataPoint::m_latLon)
-      .def_readwrite("traffic", &coding::TrafficGPSEncoder::DataPoint::m_traffic);
+      .def_readwrite("traffic", &coding::TrafficGPSEncoder::DataPoint::m_traffic)
+      .def_readwrite("trackType", &coding::TrafficGPSEncoder::DataPoint::m_trackType);
 
   enum_<Protocol::PacketType>("PacketType")
       .value("AuthV0", Protocol::PacketType::AuthV0)
       .value("DataV0", Protocol::PacketType::DataV0)
       .value("DataV1", Protocol::PacketType::DataV1)
+      .value("DataV2", Protocol::PacketType::DataV2)
       .value("CurrentAuth", Protocol::PacketType::CurrentAuth)
       .value("CurrentData", Protocol::PacketType::CurrentData);
 
-  vector<uint8_t> (*CreateDataPacket1)(Protocol::DataElementsCirc const &,
+  std::vector<uint8_t> (*CreateDataPacket1)(Protocol::DataElementsCirc const &,
                                        tracking::Protocol::PacketType) =
       &Protocol::CreateDataPacket;
-  vector<uint8_t> (*CreateDataPacket2)(Protocol::DataElementsVec const &,
+  std::vector<uint8_t> (*CreateDataPacket2)(Protocol::DataElementsVec const &,
                                        tracking::Protocol::PacketType) =
       &Protocol::CreateDataPacket;
 

--- a/tracking/reporter.cpp
+++ b/tracking/reporter.cpp
@@ -4,12 +4,10 @@
 #include "platform/platform.hpp"
 #include "platform/socket.hpp"
 
-#include "3party/Alohalytics/src/alohalytics.h"
-
 #include "base/logging.hpp"
 #include "base/timer.hpp"
 
-#include "std/target_os.hpp"
+#include "3party/Alohalytics/src/alohalytics.h"
 
 #include <cmath>
 
@@ -54,7 +52,8 @@ Reporter::~Reporter()
   m_thread.join();
 }
 
-void Reporter::AddLocation(location::GpsInfo const & info, traffic::SpeedGroup traffic)
+void Reporter::AddLocation(location::GpsInfo const & info, traffic::SpeedGroup traffic,
+                           routing::RouterType routerType)
 {
   lock_guard<mutex> lg(m_mutex);
 
@@ -80,7 +79,8 @@ void Reporter::AddLocation(location::GpsInfo const & info, traffic::SpeedGroup t
   m_lastGpsTime = info.m_timestamp;
   m_input.push_back(
       DataPoint(info.m_timestamp, ms::LatLon(info.m_latitude, info.m_longitude),
-                static_cast<std::underlying_type<traffic::SpeedGroup>::type>(traffic)));
+                static_cast<std::underlying_type<traffic::SpeedGroup>::type>(traffic),
+                static_cast<std::underlying_type<routing::RouterType>::type>(routerType)));
 }
 
 void Reporter::Run()

--- a/tracking/reporter.hpp
+++ b/tracking/reporter.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "routing/router.hpp"
+
 #include "tracking/connection.hpp"
 
 #include "traffic/speed_groups.hpp"
@@ -40,7 +42,8 @@ public:
            std::chrono::milliseconds pushDelay);
   ~Reporter();
 
-  void AddLocation(location::GpsInfo const & info, traffic::SpeedGroup traffic);
+  void AddLocation(location::GpsInfo const & info, traffic::SpeedGroup traffic,
+                   routing::RouterType routerType);
 
   void SetAllowSendingPoints(bool allow) { m_allowSendingPoints = allow; }
 

--- a/tracking/tracking_tests/protocol_test.cpp
+++ b/tracking/tracking_tests/protocol_test.cpp
@@ -36,8 +36,8 @@ UNIT_TEST(Protocol_CreateDataPacket)
 {
   using Container = Protocol::DataElementsCirc;
   Container buffer(5);
-  buffer.push_back(Container::value_type(1, ms::LatLon(10, 10), 1));
-  buffer.push_back(Container::value_type(2, ms::LatLon(15, 15), 2));
+  buffer.push_back(Container::value_type(1, ms::LatLon(10, 10), 1, 0));
+  buffer.push_back(Container::value_type(2, ms::LatLon(15, 15), 2, 0));
 
   auto packetV0 = Protocol::CreateDataPacket(buffer, Protocol::PacketType::DataV0);
   TEST_EQUAL(packetV0.size(), 26, ());
@@ -60,6 +60,17 @@ UNIT_TEST(Protocol_CreateDataPacket)
   TEST_EQUAL(packetV1[4], 1, ());
   TEST_EQUAL(packetV1[5], 227, ());
   TEST_EQUAL(packetV1[6], 241, ());
+
+  auto packetV2 = Protocol::CreateDataPacket(buffer, Protocol::PacketType::DataV2);
+  TEST_EQUAL(packetV2.size(), 30, ());
+  TEST_EQUAL(Protocol::PacketType(packetV2[0]), Protocol::PacketType::DataV2, ());
+  TEST_EQUAL(packetV2[1], 0x00, ());
+  TEST_EQUAL(packetV2[2], 0x00, ());
+  TEST_EQUAL(packetV2[3], 26, ());
+
+  TEST_EQUAL(packetV2[4], 1, ());
+  TEST_EQUAL(packetV2[5], 227, ());
+  TEST_EQUAL(packetV2[6], 241, ());
 }
 
 UNIT_TEST(Protocol_DecodeAuthPacket)
@@ -107,4 +118,5 @@ UNIT_TEST(Protocol_DecodeDataPacket)
 
   DecodeDataPacketVersionTest(points, Protocol::PacketType::DataV0);
   DecodeDataPacketVersionTest(points, Protocol::PacketType::DataV1);
+  DecodeDataPacketVersionTest(points, Protocol::PacketType::DataV2);
 }

--- a/tracking/tracking_tests/reporter_test.cpp
+++ b/tracking/tracking_tests/reporter_test.cpp
@@ -33,7 +33,7 @@ void TransferLocation(Reporter & reporter, TestSocket & testSocket, double times
   gpsInfo.m_latitude = latidute;
   gpsInfo.m_longitude = longtitude;
   gpsInfo.m_horizontalAccuracy = 1.0;
-  reporter.AddLocation(gpsInfo, traffic::SpeedGroup::Unknown);
+  reporter.AddLocation(gpsInfo, traffic::SpeedGroup::Unknown, routing::RouterType::Vehicle);
 
   using Packet = tracking::Protocol::PacketType;
   vector<uint8_t> buffer;
@@ -54,6 +54,7 @@ void TransferLocation(Reporter & reporter, TestSocket & testSocket, double times
     }
     case Packet::DataV0:
     case Packet::DataV1:
+    case Packet::DataV2:
     {
       readSize = 0;
       break;

--- a/traffic/pytraffic/bindings.cpp
+++ b/traffic/pytraffic/bindings.cpp
@@ -23,7 +23,6 @@
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-using namespace std;
 
 namespace
 {
@@ -44,9 +43,9 @@ struct SegmentSpeeds
 
 using SegmentMapping = std::map<traffic::TrafficInfo::RoadSegmentId, SegmentSpeeds>;
 
-string SegmentSpeedsRepr(SegmentSpeeds const & v)
+std::string SegmentSpeedsRepr(SegmentSpeeds const & v)
 {
-  ostringstream ss;
+  std::ostringstream ss;
   ss << "SegmentSpeeds("
      << " weighted_speed=" << v.m_weightedSpeed << " weighted_ref_speed=" << v.m_weightedRefSpeed
      << " weight=" << v.m_weight << " )";
@@ -90,21 +89,21 @@ traffic::TrafficInfo::Coloring TransformToSpeedGroups(SegmentMapping const & seg
   return result;
 }
 
-string RoadSegmentIdRepr(traffic::TrafficInfo::RoadSegmentId const & v)
+std::string RoadSegmentIdRepr(traffic::TrafficInfo::RoadSegmentId const & v)
 {
-  ostringstream ss;
+  std::ostringstream ss;
   ss << "RoadSegmentId(" << v.m_fid << ", " << v.m_idx << ", " << int(v.m_dir) << ")";
   return ss.str();
 }
 
-boost::python::list GenerateTrafficKeys(string const & mwmPath)
+boost::python::list GenerateTrafficKeys(std::string const & mwmPath)
 {
-  vector<traffic::TrafficInfo::RoadSegmentId> result;
+  std::vector<traffic::TrafficInfo::RoadSegmentId> result;
   traffic::TrafficInfo::ExtractTrafficKeys(mwmPath, result);
   return std_vector_to_python_list(result);
 }
 
-vector<uint8_t> GenerateTrafficValues(vector<traffic::TrafficInfo::RoadSegmentId> const & keys,
+std::vector<uint8_t> GenerateTrafficValues(std::vector<traffic::TrafficInfo::RoadSegmentId> const & keys,
                                       boost::python::dict const & segmentMappingDict,
                                       uint8_t useTempBlock)
 {
@@ -122,7 +121,7 @@ vector<uint8_t> GenerateTrafficValues(vector<traffic::TrafficInfo::RoadSegmentId
   traffic::TrafficInfo::Coloring coloring;
   traffic::TrafficInfo::CombineColorings(keys, knownColors, coloring);
 
-  vector<traffic::SpeedGroup> values(coloring.size());
+  std::vector<traffic::SpeedGroup> values(coloring.size());
 
   size_t i = 0;
   for (auto const & kv : coloring)
@@ -136,31 +135,31 @@ vector<uint8_t> GenerateTrafficValues(vector<traffic::TrafficInfo::RoadSegmentId
   }
   ASSERT_EQUAL(i, values.size(), ());
 
-  vector<uint8_t> buf;
+  std::vector<uint8_t> buf;
   traffic::TrafficInfo::SerializeTrafficValues(values, buf);
   return buf;
 }
 
-vector<uint8_t> GenerateTrafficValuesFromList(boost::python::list const & keys,
+std::vector<uint8_t> GenerateTrafficValuesFromList(boost::python::list const & keys,
                                               boost::python::dict const & segmentMappingDict)
 {
-  vector<traffic::TrafficInfo::RoadSegmentId> keysVec =
+  std::vector<traffic::TrafficInfo::RoadSegmentId> keysVec =
       python_list_to_std_vector<traffic::TrafficInfo::RoadSegmentId>(keys);
 
   return GenerateTrafficValues(keysVec, segmentMappingDict, 1 /* useTempBlock */);
 }
 
-vector<uint8_t> GenerateTrafficValuesFromBinary(vector<uint8_t> const & keysBlob,
+std::vector<uint8_t> GenerateTrafficValuesFromBinary(std::vector<uint8_t> const & keysBlob,
                                                 boost::python::dict const & segmentMappingDict,
                                                 uint8_t useTempBlock = 1)
 {
-  vector<traffic::TrafficInfo::RoadSegmentId> keys;
+  std::vector<traffic::TrafficInfo::RoadSegmentId> keys;
   traffic::TrafficInfo::DeserializeTrafficKeys(keysBlob, keys);
 
   return GenerateTrafficValues(keys, segmentMappingDict, useTempBlock);
 }
 
-void LoadClassificator(string const & classifPath)
+void LoadClassificator(std::string const & classifPath)
 {
   GetPlatform().SetResourceDir(classifPath);
   classificator::Load();
@@ -173,7 +172,7 @@ BOOST_PYTHON_MODULE(pytraffic)
   scope().attr("__version__") = PYBINDINGS_VERSION;
 
   // Register the to-python converters.
-  to_python_converter<vector<uint8_t>, vector_uint8t_to_str>();
+  to_python_converter<std::vector<uint8_t>, vector_uint8t_to_str>();
   vector_uint8t_from_python_str();
 
   class_<SegmentSpeeds>("SegmentSpeeds", init<double, double, double>())


### PR DESCRIPTION
We need to accumulate statistics not only for car routes but for bicycle and pedestrian routes too. This PR implements:
- enabling  tracking reporting in `routing manager` for  bicycle and pedestrian route types (not only for cars),
- new protocol version for (de)serialisation and sending  this data.