### PR TITLE
[search] NormalizeAndSimplifyString: replace sequence of spaces with single one.

### DIFF
--- a/indexer/indexer_tests/search_string_utils_test.cpp
+++ b/indexer/indexer_tests/search_string_utils_test.cpp
@@ -92,6 +92,7 @@ UNIT_TEST(NormalizeAndSimplifyStringWithOurTambourines)
                         "aaaaaooooeeeeiduuuuyaadeoou",  // Vietnamese
                         "ăâț", "aat",                   // Romanian
                         "Триу́мф-Пала́с", "триумф-палас", // Russian accent
+                        "  a   b  c d ", " a b c d ",   // Multiple spaces
                        };
 
   for (size_t i = 0; i < ARRAY_SIZE(arr); i += 2)
@@ -257,9 +258,9 @@ UNIT_TEST(StreetTokensFilter)
 
 UNIT_TEST(NormalizeAndSimplifyString_Numero)
 {
-  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона №51"), "зона  51", ());
-  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона № 51"), "зона   51", ());
-  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area #51"), "area  51", ());
-  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area # "), "area   ", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона №51"), "зона 51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Зона № 51"), "зона 51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area #51"), "area 51", ());
+  TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area # "), "area ", ());
   TEST_EQUAL(NormalizeAndSimplifyStringUtf8("Area #One"), "area #one", ());
 }

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -141,6 +141,10 @@ UniString NormalizeAndSimplifyString(string const & s)
 
   RemoveNumeroSigns(uniString);
 
+  // Replace sequence of spaces with single one.
+  auto const spacesChecker = [](UniChar lhs, UniChar rhs) { return (lhs == rhs) && (lhs == ' '); };
+  uniString.erase(unique(uniString.begin(), uniString.end(), spacesChecker), uniString.end());
+
   return uniString;
 
   /// @todo Restore this logic to distinguish и-й in future.


### PR DESCRIPTION
Полезно если нужно проиндексировать и искать что-то с пробелами (например индексы).
Можно сделать отдельной функцией, но не вижу причин почему не делать сразу в NormalizeAndSimplifyString.