### PR TITLE
[platform][mwm_traits] Adjust kLastVersionWithPlainEliasFanoMap for centers table.

### DIFF
--- a/platform/mwm_traits.cpp
+++ b/platform/mwm_traits.cpp
@@ -31,7 +31,7 @@ MwmTraits::CentersTableFormat MwmTraits::GetCentersTableFormat() const
   if (GetFormat() < version::Format::v9)
     return CentersTableFormat::PlainEliasFanoMap;
 
-  uint32_t constexpr kLastVersionWithPlainEliasFanoMap = 190923;
+  uint32_t constexpr kLastVersionWithPlainEliasFanoMap = 191019;
   if (GetVersion() <= kLastVersionWithPlainEliasFanoMap)
     return CentersTableFormat::PlainEliasFanoMap;
 


### PR DESCRIPTION
В мастере изменился формат centers table, но мы продолжаем выпускать минорки из релизной ветки, поэтому для совместимости с релизными картами нужно апдейтить константу (только для минорок 9.4, в релизной ветке 9.5 будет уже новый код).