### PR TITLE
[generator] Fix for segmentation fault in cross mwm collector.

### DIFF
--- a/generator/cross_mwm_osm_ways_collector.cpp
+++ b/generator/cross_mwm_osm_ways_collector.cpp
@@ -62,7 +62,13 @@ void CrossMwmOsmWaysCollector::CollectFeature(feature::FeatureBuilder const & fb
     auto const & point = featurePoints[pointNumber];
     auto const & pointAffiliations = m_affiliation->GetAffiliations(point);
     for (auto const & mwmName : pointAffiliations)
-      featurePointsEntriesToMwm[mwmName][pointNumber] = true;
+    {
+      // Skip mwms which are not present in the map: these are GetAffiliations() false positives.
+      auto it = featurePointsEntriesToMwm.find(mwmName);
+      if (it == featurePointsEntriesToMwm.end())
+        continue;
+      it->second[pointNumber] = true;
+    }
 
     // TODO (@gmoryes)
     //  Uncomment this check after: https://github.com/mapsme/omim/pull/10996


### PR DESCRIPTION
Проблема: сборка мира крэшится в `CrossMwmOsmWaysCollector::CollectFeature`:

`Program received signal SIGSEGV, Segmentation fault.`

Верхушка стэка:
```
#0  0x0000000001c76980 in std::_Bit_reference::operator= (this=0x7fed3a72e790, __x=true) at /home/opt/rh/devtoolset-7/root/usr/include/c++/7/bits/stl_bvector.h:87
#1  0x0000000001dfb401 in generator::CrossMwmOsmWaysCollector::CollectFeature (this=0xa25daf0, fb=..., element=...) at /home/o.khlopkova/omim/generator/cross_mwm_osm_ways_collector.cpp:67
```

**Причина:** в цикле в мапу по ключу (имя mwm) в поле-значение (вектор из bool) присвоилось значение по не существующиему индексу  `pointNumber`:

```
for (auto const & mwmName : pointAffiliations)
      featurePointsEntriesToMwm[mwmName][pointNumber] = true;
```

Мапа `featurePointsEntriesToMwm`  заранее  заполняется именами mwm и соотнесенными им векторами. Имена mwm определяются через `m_affiliation->GetAffiliations(fb)`.

Однако же в интересующий цикл имена mwm (`mwmName`) подтягиваются отдельно для каждой точки: `m_affiliation->GetAffiliations(point)`

Для FeatureBuilder [паромного пути,](https://www.openstreetmap.org/way/70108523) соединяющего южную и северную точки Японии, нашлось 3 mwm, а для одной из его точек нашлась еще 1 mwm:
`m_affiliation->GetAffiliations(fb)` вернул 3 имени mwm: Japan_Shikoku Region_Kyoto, Japan_Chubu Region_Fukui, Japan_Hokkaido Region_West.
`m_affiliation->GetAffiliations(point)` вернул еще 2 имя: Japan_Chubu Region_Ishikawa.

**Решение:** так как паромные пути - довольно редкий кейс, и чаще встречается пересечение mwm по суше, нужно сохранять mwm, найденные для точек.

[Паромный путь,](https://www.openstreetmap.org/way/70108523) на котором можно проверить работоспособность  PR:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/54934129/68472372-676bea00-0231-11ea-8035-7723f5a30cec.png">
