### PR TITLE
Mapsme 12371 update pushwoosh

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ dependencies {
   implementation 'com.facebook.android:facebook-android-sdk:4.40.0'
   implementation 'com.facebook.android:audience-network-sdk:4.28.2'
   implementation 'com.google.code.gson:gson:2.6.1'
-  implementation 'com.pushwoosh:pushwoosh:5.19.1'
+  implementation 'com.pushwoosh:pushwoosh:5.19.6'
   implementation 'com.pushwoosh:pushwoosh-gcm:5.12.1'
   implementation 'com.my.tracker:mytracker-sdk:1.5.3'
   implementation ('com.my.target:mytarget-sdk:5.2.2') {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,8 +2,8 @@ propMinSdkVersion=15
 propTargetSdkVersion=28
 propCompileSdkVersion=28
 propBuildToolsVersion=27.0.3
-propVersionCode=946
-propVersionName=9.4.6
+propVersionCode=947
+propVersionName=9.4.7
 propDebugNdkFlags=V=1 NDK_DEBUG=1 DEBUG=1
 propReleaseNdkFlags=V=1 NDK_DEBUG=0 PRODUCTION=1
 propSupportLibraryVersion=27.1.1

--- a/android/src/com/mapswithme/maps/scheduling/JobServiceDelegate.java
+++ b/android/src/com/mapswithme/maps/scheduling/JobServiceDelegate.java
@@ -18,7 +18,7 @@ class JobServiceDelegate
 
   boolean onStartJob()
   {
-    ConnectionState.Type type = ConnectionState.requestCurrentType();
+    ConnectionState.Type type = ConnectionState.requestCurrentType(mApp);
     if (type == ConnectionState.Type.WIFI)
       NotificationService.startOnConnectivityChanged(mApp);
 

--- a/android/src/com/mapswithme/util/ConnectionState.java
+++ b/android/src/com/mapswithme/util/ConnectionState.java
@@ -1,5 +1,6 @@
 package com.mapswithme.util;
 
+import android.app.Application;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -44,17 +45,50 @@ public class ConnectionState
     }
   }
 
+  /**
+   * Use the {@link #isNetworkConnected(Context, int)} method instead.
+   */
+  @Deprecated
   private static boolean isNetworkConnected(int networkType)
   {
     final NetworkInfo info = getActiveNetwork();
     return info != null && info.getType() == networkType && info.isConnected();
   }
 
-  public static
-  @Nullable
-  NetworkInfo getActiveNetwork()
+  private static boolean isNetworkConnected(@NonNull Context context, int networkType)
   {
-    return ((ConnectivityManager) MwmApplication.get().getSystemService(Context.CONNECTIVITY_SERVICE)).getActiveNetworkInfo();
+    final NetworkInfo info = getActiveNetwork(context);
+    return info != null && info.getType() == networkType && info.isConnected();
+  }
+
+  /**
+   * Use the {@link #getActiveNetwork(Context)} method instead.
+   */
+  @Nullable
+  @Deprecated
+  public static NetworkInfo getActiveNetwork()
+  {
+    Application context = MwmApplication.get();
+    if (context == null)
+      return null;
+
+    ConnectivityManager manager =
+        ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    if (manager == null)
+      return null;
+
+    return manager.getActiveNetworkInfo();
+  }
+
+  @Nullable
+  public static NetworkInfo getActiveNetwork(@NonNull Context context)
+  {
+    ConnectivityManager manager =
+        ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+    if (manager == null)
+      return null;
+
+    return manager.getActiveNetworkInfo();
   }
 
   public static boolean isMobileConnected()
@@ -125,12 +159,27 @@ public class ConnectionState
     return requestCurrentType().getNativeRepresentation();
   }
 
+  /**
+   * Use the {@link #requestCurrentType(Context)} method instead.
+   */
   @NonNull
+  @Deprecated
   public static Type requestCurrentType()
   {
     for (ConnectionState.Type each : ConnectionState.Type.values())
     {
       if (isNetworkConnected(each.getPlatformRepresentation()))
+        return each;
+    }
+    return NONE;
+  }
+
+  @NonNull
+  public static Type requestCurrentType(@NonNull Context context)
+  {
+    for (ConnectionState.Type each : ConnectionState.Type.values())
+    {
+      if (isNetworkConnected(context, each.getPlatformRepresentation()))
         return each;
     }
     return NONE;


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-12371 Обновил пушвуш сдк. Пофиксил NPE, который в топе в Google developer console:

```
java.lang.RuntimeException: 
  at android.app.job.JobServiceEngine$JobHandler.handleMessage (JobServiceEngine.java:112)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:180)
  at android.app.ActivityThread.main (ActivityThread.java:6944)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:240)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:835)
Caused by: java.lang.NullPointerException: 
  at com.mapswithme.util.ConnectionState.getActiveNetwork (ConnectionState.java:57)
  at com.mapswithme.util.ConnectionState.isNetworkConnected (ConnectionState.java:49)
  at com.mapswithme.util.ConnectionState.requestCurrentType (ConnectionState.java:133)
  at com.mapswithme.maps.scheduling.JobServiceDelegate.onStartJob (JobServiceDelegate.java:21)
  at com.mapswithme.maps.scheduling.NativeJobService.onStartJob (NativeJobService.java:33)
  at android.app.job.JobService$1.onStartJob (JobService.java:71)
  at android.app.job.JobServiceEngine$JobHandler.handleMessage (JobServiceEngine.java:108)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:180)
  at android.app.ActivityThread.main (ActivityThread.java:6944)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:240)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:835)
```