### PR TITLE
[qt] Screenshoter accepts viewport center points and zoom or rects

### DIFF
--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -622,7 +622,8 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
     {
       ref_ptr<NotifyGraphicsReadyMessage> msg = message;
       m_commutator->PostMessage(ThreadsCommutator::RenderThread,
-                                make_unique_dp<NotifyGraphicsReadyMessage>(msg->GetCallback()),
+                                make_unique_dp<NotifyGraphicsReadyMessage>(msg->GetCallback(),
+                                                                           msg->NeedInvalidate()),
                                 MessagePriority::Normal);
       break;
     }

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -525,10 +525,10 @@ void DrapeEngine::SetModelViewListener(ModelViewChangedHandler && fn)
 }
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_LINUX)
-void DrapeEngine::NotifyGraphicsReady(GraphicsReadyHandler const & fn)
+void DrapeEngine::NotifyGraphicsReady(GraphicsReadyHandler const & fn, bool needInvalidate)
 {
   m_threadCommutator->PostMessage(ThreadsCommutator::ResourceUploadThread,
-                                  make_unique_dp<NotifyGraphicsReadyMessage>(fn),
+                                  make_unique_dp<NotifyGraphicsReadyMessage>(fn, needInvalidate),
                                   MessagePriority::Normal);
 }
 #endif

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -145,7 +145,7 @@ public:
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_LINUX)
   using GraphicsReadyHandler = FrontendRenderer::GraphicsReadyHandler;
-  void NotifyGraphicsReady(GraphicsReadyHandler const & fn);
+  void NotifyGraphicsReady(GraphicsReadyHandler const & fn, bool needInvalidate);
 #endif
 
   void ClearUserMarksGroup(kml::MarkGroupId groupId);

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1054,7 +1054,12 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       {
         m_graphicsStage = GraphicsStage::WaitReady;
         if (m_notFinishedTiles.empty())
-          InvalidateRect(m_userEventStream.GetCurrentScreen().ClipRect());
+        {
+          if (msg->NeedInvalidate())
+            InvalidateRect(m_userEventStream.GetCurrentScreen().ClipRect());
+          else
+            m_graphicsStage = GraphicsStage::WaitRendering;
+        }
       }
       break;
     }

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -1014,15 +1014,18 @@ class NotifyGraphicsReadyMessage : public Message
 public:
   using GraphicsReadyCallback = std::function<void()>;
 
-  explicit NotifyGraphicsReadyMessage(GraphicsReadyCallback const & callback)
-    : m_callback(callback)
+  explicit NotifyGraphicsReadyMessage(GraphicsReadyCallback const & callback, bool needInvalidate)
+    : m_needInvalidate(needInvalidate)
+    , m_callback(callback)
   {}
 
   Type GetType() const override { return Type::NotifyGraphicsReady; }
 
+  bool NeedInvalidate() const { return m_needInvalidate; }
   GraphicsReadyCallback GetCallback() { return m_callback; }
 
 private:
+  bool m_needInvalidate;
   GraphicsReadyCallback m_callback;
 };
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1251,10 +1251,10 @@ void Framework::SetViewportListener(TViewportChangedFn const & fn)
 }
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_LINUX)
-void Framework::NotifyGraphicsReady(TGraphicsReadyFn const & fn)
+void Framework::NotifyGraphicsReady(TGraphicsReadyFn const & fn, bool needInvalidate)
 {
   if (m_drapeEngine != nullptr)
-    m_drapeEngine->NotifyGraphicsReady(fn);
+    m_drapeEngine->NotifyGraphicsReady(fn, needInvalidate);
 }
 #endif
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -627,7 +627,7 @@ public:
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_LINUX)
   using TGraphicsReadyFn = df::DrapeEngine::GraphicsReadyHandler;
-  void NotifyGraphicsReady(TGraphicsReadyFn const & fn);
+  void NotifyGraphicsReady(TGraphicsReadyFn const & fn, bool needInvalidate);
 #endif
 
   void StopLocationFollow();

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -472,13 +472,6 @@ void DrawWidget::keyReleaseEvent(QKeyEvent * e)
     m_emulatingLocation = false;
 }
 
-void DrawWidget::OnViewportChanged(ScreenBase const & screen)
-{
-  TBase::OnViewportChanged(screen);
-  if (m_screenshotMode)
-    m_screenshoter->CheckViewport();
-}
-
 bool DrawWidget::Search(search::EverywhereSearchParams const & params)
 {
   return m_framework.SearchEverywhere(params);

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -100,7 +100,6 @@ protected:
   void mousePressEvent(QMouseEvent * e) override;
   void mouseMoveEvent(QMouseEvent * e) override;
   void mouseReleaseEvent(QMouseEvent * e) override;
-  void OnViewportChanged(ScreenBase const & screen) override;
   //@}
 
   void keyPressEvent(QKeyEvent * e) override;

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -30,12 +30,21 @@ DEFINE_string(data_path, "", "Path to data directory.");
 DEFINE_string(log_abort_level, base::ToString(base::GetDefaultLogAbortLevel()),
               "Log messages severity that causes termination.");
 DEFINE_string(resources_path, "", "Path to resources directory.");
-DEFINE_string(kml_path, "", "Path to a directory with kml files to take screenshots.");
+DEFINE_string(kml_path, "", "Activates screenshot mode. Path to a kml file or a directory "
+              "with kml files to take screenshots.");
+DEFINE_string(points, "", "Activates screenshot mode. Points on the map and zoom level "
+              "[1..18] in format \"lat,lon,zoom[;lat,lon,zoom]\" or path to a file with points in "
+              "the same format. Each point and zoom define a place on the map to take screenshot.");
+DEFINE_string(rects, "", "Activates screenshot mode. Rects on the map in format"
+              "\"lat_leftBottom,lon_leftBottom,lat_rightTop,lon_rightTop"
+              "[;lat_leftBottom,lon_leftBottom,lat_rightTop,lon_rightTop]\" or path to a file with "
+              "rects in the same format. Each rect defines a place on the map to take screenshot.");
 DEFINE_string(dst_path, "", "Path to a directory to save screenshots.");
 DEFINE_string(lang, "", "Device language.");
 DEFINE_int32(width, 0, "Screenshot width.");
 DEFINE_int32(height, 0, "Screenshot height.");
-DEFINE_double(dpi_scale, 0.0, "Screenshot dpi scale.");
+DEFINE_double(dpi_scale, 0.0, "Screenshot dpi scale (mdpi = 1.0, hdpi = 1.5, "
+              "xhdpiScale = 2.0, 6plus = 2.4, xxhdpi = 3.0, xxxhdpi = 3.5).");
 
 using namespace std;
 
@@ -165,10 +174,24 @@ int main(int argc, char * argv[])
     if (!FLAGS_lang.empty())
       (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
 
-    if (!FLAGS_kml_path.empty())
+    if (!FLAGS_kml_path.empty() || !FLAGS_points.empty() || !FLAGS_rects.empty())
     {
       screenshotParams = std::make_unique<qt::ScreenshotParams>();
-      screenshotParams->m_kmlPath = FLAGS_kml_path;
+      if (!FLAGS_kml_path.empty())
+      {
+        screenshotParams->m_kmlPath = FLAGS_kml_path;
+        screenshotParams->m_mode = qt::ScreenshotParams::Mode::KmlFiles;
+      }
+      else if (!FLAGS_points.empty())
+      {
+        screenshotParams->m_points = FLAGS_points;
+        screenshotParams->m_mode = qt::ScreenshotParams::Mode::Points;
+      }
+      else if (!FLAGS_rects.empty())
+      {
+        screenshotParams->m_rects = FLAGS_rects;
+        screenshotParams->m_mode = qt::ScreenshotParams::Mode::Rects;
+      }
       if (!FLAGS_dst_path.empty())
         screenshotParams->m_dstPath = FLAGS_dst_path;
       if (FLAGS_width > 0)

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -170,6 +170,7 @@ int main(int argc, char * argv[])
 
 #if defined(OMIM_OS_MAC)
     apiOpenGLES3 = a.arguments().contains("es3", Qt::CaseInsensitive);
+#endif
 
     if (!FLAGS_lang.empty())
       (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
@@ -201,7 +202,7 @@ int main(int argc, char * argv[])
       if (FLAGS_dpi_scale >= df::VisualParams::kMdpiScale && FLAGS_dpi_scale <= df::VisualParams::kXxxhdpiScale)
         screenshotParams->m_dpiScale = FLAGS_dpi_scale;
     }
-#endif
+
     qt::MainWindow::SetDefaultSurfaceFormat(apiOpenGLES3);
 
     FrameworkParams frameworkParams;

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -177,18 +177,15 @@ MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
 
   m_pDrawWidget = new DrawWidget(framework, apiOpenGLES3, std::move(screenshotParams), this);
 
+  setCentralWidget(m_pDrawWidget);
+
   if (m_screenshotMode)
   {
-    QSizePolicy policy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    setSizePolicy(policy);
     QSize size(static_cast<int>(screenshotParams->m_width), static_cast<int>(screenshotParams->m_height));
-    m_pDrawWidget->resize(size);
     size.setHeight(size.height() + statusBar()->height());
-    setMaximumSize(size);
-    setMinimumSize(size);
+    m_pDrawWidget->setFixedSize(size);
+    setFixedSize(size);
   }
-
-  setCentralWidget(m_pDrawWidget);
 
   QObject::connect(m_pDrawWidget, SIGNAL(BeforeEngineCreation()), this, SLOT(OnBeforeEngineCreation()));
 

--- a/qt/qt_common/map_widget.hpp
+++ b/qt/qt_common/map_widget.hpp
@@ -79,7 +79,7 @@ protected:
   void Build();
   void ShowInfoPopup(QMouseEvent * e, m2::PointD const & pt);
 
-  virtual void OnViewportChanged(ScreenBase const & screen);
+  void OnViewportChanged(ScreenBase const & screen);
 
   // QOpenGLWidget overrides:
   void initializeGL() override;

--- a/qt/screenshoter.cpp
+++ b/qt/screenshoter.cpp
@@ -17,8 +17,8 @@
 #include <QtGui/QPixmap>
 
 #include <chrono>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <sstream>
 
 namespace
@@ -130,14 +130,12 @@ void Screenshoter::Start()
     m_screenshotParams.m_dstPath = base::JoinPath(m_screenshotParams.m_kmlPath, "screenshots");
 
   LOG(LINFO, ("\nScreenshoter parameters:"
-    "\n  mode:", m_screenshotParams.m_mode,
-    "\n  kml_path:", m_screenshotParams.m_kmlPath,
-    "\n  points:", m_screenshotParams.m_points,
-    "\n  rects:", m_screenshotParams.m_rects,
-    "\n  dst_path:", m_screenshotParams.m_dstPath,
-    "\n  width:", m_screenshotParams.m_width,
-    "\n  height:", m_screenshotParams.m_height,
-    "\n  dpi_scale:", m_screenshotParams.m_dpiScale));
+              "\n  mode:",
+              m_screenshotParams.m_mode, "\n  kml_path:", m_screenshotParams.m_kmlPath,
+              "\n  points:", m_screenshotParams.m_points, "\n  rects:", m_screenshotParams.m_rects,
+              "\n  dst_path:", m_screenshotParams.m_dstPath,
+              "\n  width:", m_screenshotParams.m_width, "\n  height:", m_screenshotParams.m_height,
+              "\n  dpi_scale:", m_screenshotParams.m_dpiScale));
 
   if (!Platform::MkDirChecked(m_screenshotParams.m_dstPath))
   {
@@ -221,8 +219,8 @@ void Screenshoter::ProcessNextRect()
 
   std::string const postfix = "_" + languages::GetCurrentNorm();
   std::stringstream ss;
-  ss << "rect_" << std::setfill('0') << std::setw(4) <<
-     m_itemsCount - m_rectsToProcess.size() << postfix;
+  ss << "rect_" << std::setfill('0') << std::setw(4) << m_itemsCount - m_rectsToProcess.size()
+     << postfix;
 
   m_nextScreenshotName = ss.str();
 
@@ -232,8 +230,8 @@ void Screenshoter::ProcessNextRect()
   CHECK(rect.IsValid(), ());
 
   ChangeState(State::WaitPosition);
-  m_framework.ShowRect(rect, -1 /* maxScale */,
-                       false /* animation */, false /* useVisibleViewport */);
+  m_framework.ShowRect(rect, -1 /* maxScale */, false /* animation */,
+                       false /* useVisibleViewport */);
   WaitPosition();
 }
 
@@ -247,8 +245,8 @@ void Screenshoter::ProcessNextPoint()
 
   std::string const postfix = "_" + languages::GetCurrentNorm();
   std::stringstream ss;
-  ss << "point_" << std::setfill('0') << std::setw(4) <<
-     m_itemsCount - m_pointsToProcess.size() << postfix;
+  ss << "point_" << std::setfill('0') << std::setw(4) << m_itemsCount - m_pointsToProcess.size()
+     << postfix;
 
   m_nextScreenshotName = ss.str();
 
@@ -325,18 +323,16 @@ void Screenshoter::OnGraphicsReady()
 
 void Screenshoter::WaitPosition()
 {
-  m_framework.NotifyGraphicsReady([this]()
-    {
-      GetPlatform().RunTask(Platform::Thread::Gui, [this] { OnPositionReady(); });
-    }, false /* needInvalidate */ );
+  m_framework.NotifyGraphicsReady(
+      [this]() { GetPlatform().RunTask(Platform::Thread::Gui, [this] { OnPositionReady(); }); },
+      false /* needInvalidate */);
 }
 
 void Screenshoter::WaitGraphics()
 {
-  m_framework.NotifyGraphicsReady([this]()
-    {
-      GetPlatform().RunTask(Platform::Thread::Gui, [this] { OnGraphicsReady(); });
-    }, true /* needInvalidate */ );
+  m_framework.NotifyGraphicsReady(
+      [this]() { GetPlatform().RunTask(Platform::Thread::Gui, [this] { OnGraphicsReady(); }); },
+      true /* needInvalidate */);
 }
 
 void Screenshoter::SaveScreenshot()
@@ -368,8 +364,8 @@ void Screenshoter::ChangeState(State newState, std::string const & msg)
   if (m_screenshotParams.m_statusChangedFn)
   {
     std::ostringstream ss;
-    ss << "[" << m_itemsCount - GetItemsToProcessCount() << "/" << m_itemsCount << "] file: "
-       << m_nextScreenshotName << " state: " << DebugPrint(newState);
+    ss << "[" << m_itemsCount - GetItemsToProcessCount() << "/" << m_itemsCount
+       << "] file: " << m_nextScreenshotName << " state: " << DebugPrint(newState);
     if (!msg.empty())
       ss << " msg: " << msg;
     LOG(LINFO, (ss.str()));
@@ -402,7 +398,7 @@ bool Screenshoter::PrepareItemsToProcess()
 bool Screenshoter::PrepareKmlFiles()
 {
   if (!Platform::IsDirectory(m_screenshotParams.m_kmlPath) &&
-    !Platform::IsFileExistsByFullPath(m_screenshotParams.m_kmlPath))
+      !Platform::IsFileExistsByFullPath(m_screenshotParams.m_kmlPath))
   {
     ChangeState(State::FileError, "Invalid kml path.");
     return false;

--- a/qt/screenshoter.cpp
+++ b/qt/screenshoter.cpp
@@ -75,7 +75,7 @@ bool ParsePointsStr(std::string const & pointsStr, std::list<std::pair<m2::Point
   int zoom;
   while (tupleIter)
   {
-    if (ParsePoint(*tupleIter, ",", pt, zoom))
+    if (ParsePoint(*tupleIter, ", \t", pt, zoom))
     {
       points.emplace_back(pt, zoom);
     }
@@ -95,7 +95,7 @@ bool ParseRectsStr(std::string const & rectsStr, std::list<m2::RectD> & rects)
   m2::RectD rect;
   while (tupleIter)
   {
-    if (ParseRect(*tupleIter, ",", rect))
+    if (ParseRect(*tupleIter, ", \t", rect))
     {
       rects.push_back(rect);
     }

--- a/qt/screenshoter.hpp
+++ b/qt/screenshoter.hpp
@@ -22,6 +22,16 @@ struct ScreenshotParams
 
   using TStatusChangedFn = std::function<void(std::string const & /* status */, bool finished)>;
 
+  enum class Mode
+  {
+    Points,
+    Rects,
+    KmlFiles
+  };
+
+  Mode m_mode;
+  std::string m_points;
+  std::string m_rects;
   std::string m_kmlPath;
   std::string m_dstPath;
   uint32_t m_width = kDefaultWidth;
@@ -38,7 +48,8 @@ public:
   void Start();
 
   void OnCountryChanged(storage::CountryId countryId);
-  bool CheckViewport();
+
+  void OnPositionReady();
   void OnGraphicsReady();
 
 private:
@@ -51,14 +62,29 @@ private:
     WaitGraphics,
     Ready,
     FileError,
+    ParamsError,
     Done
   };
 
+  void ProcessNextItem();
   void ProcessNextKml();
+  void ProcessNextRect();
+  void ProcessNextPoint();
   void PrepareCountries();
   void SaveScreenshot();
+  void WaitPosition();
   void WaitGraphics();
-  void ChangeState(State newState);
+  void ChangeState(State newState, std::string const & msg = "");
+
+  size_t GetItemsToProcessCount();
+
+  bool PrepareItemsToProcess();
+  bool PrepareKmlFiles();
+  bool PreparePoints();
+  bool PrepareRects();
+
+  bool LoadRects(std::string const & rects);
+  bool LoadPoints(std::string const & points);
 
   friend std::string DebugPrint(State state);
 
@@ -67,11 +93,13 @@ private:
   Framework & m_framework;
   QWidget * m_widget;
   std::list<std::string> m_filesToProcess;
-  size_t m_filesCount = 0;
+  std::list<std::pair<m2::PointD, int>> m_pointsToProcess;
+  std::list<m2::RectD> m_rectsToProcess;
+  size_t m_itemsCount = 0;
   std::set<storage::CountryId> m_countriesToDownload;
   std::string m_nextScreenshotName;
-  m2::RectD m_dataRect;
 };
 
 std::string DebugPrint(Screenshoter::State state);
+std::string DebugPrint(ScreenshotParams::Mode mode);
 }  // namespace qt


### PR DESCRIPTION
…for positioning on the map.

Теперь можно делать скриншоты не только для kml файлов, но и по списку прямоугольников или списку точка+зум.

Десктопную версию приложения можно запустить в режиме скриншотилки одним из параметров командной строки:
**-kml_path** - путь к kml файлу или директории с kml файлами, для которых нужно снять скриншот.
**-rects** - строка в формате "lat_leftBottom,lon_leftBottom,lat_rightTop,lon_rightTop[;lat_leftBottom,lon_leftBottom,lat_rightTop,lon_rightTop] или путь к файлу с прямоугольниками в этом формате, так же в файле вместо ';' можно использовать '\n'
**-points** - строка в формате "lat,lon,zoom[;lat,lon,zoom]" или путь к файлу с точками в этом формате, так же в файле вместо ';' можно использовать '\n'

дополнительные параметры:
-dst_path - путь к директории, куда сохранять скриншоты.
-lang - стока локали (например, "en", "ru")
-width, -height - размер скриншотов в пикселях.
-dpi_scale - масштаб  dpi
     