### PR TITLE
[generator] Osm2meta minor refactoring.

### DIFF
--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -1,10 +1,13 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 #include "generator/osm2meta.hpp"
 
-#include "indexer/classificator_loader.hpp"
+#include "indexer/classificator.hpp"
 
 #include "base/logging.hpp"
+
+using namespace generator::tests_support;
 
 using feature::Metadata;
 
@@ -70,12 +73,10 @@ UNIT_TEST(Metadata_ValidateAndFormat_stars)
 
 }
 
-UNIT_TEST(Metadata_ValidateAndFormat_operator)
+UNIT_CLASS_TEST(TestWithClassificator, Metadata_ValidateAndFormat_operator)
 {
-  classificator::Load();
-  Classificator const & c = classif();
-  uint32_t const type_atm = c.GetTypeByPath({ "amenity", "atm" });
-  uint32_t const type_fuel = c.GetTypeByPath({ "amenity", "fuel" });
+  uint32_t const type_atm = classif().GetTypeByPath({ "amenity", "atm" });
+  uint32_t const type_fuel = classif().GetTypeByPath({ "amenity", "fuel" });
 
   FeatureParams params;
   MetadataTagProcessor p(params);
@@ -200,7 +201,7 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
 // Look at: https://wiki.openstreetmap.org/wiki/Key:duration for details
 // about "duration" format.
 
-UNIT_TEST(Metadata_ValidateAndFormat_duration)
+UNIT_CLASS_TEST(TestWithClassificator, Metadata_ValidateAndFormat_duration)
 {
   FeatureParams params;
   params.AddType(classif().GetTypeByPath({"route", "ferry"}));

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -4,6 +4,8 @@
 
 #include "routing/routing_helpers.hpp"
 
+#include "indexer/ftypes_matcher.hpp"
+
 #include "coding/url_encode.hpp"
 
 #include "base/logging.hpp"
@@ -289,6 +291,9 @@ string MetadataTagProcessorImpl::ValidateAndFormat_airport_iata(string const & v
 
 string MetadataTagProcessorImpl::ValidateAndFormat_duration(string const & v) const
 {
+  if (!ftypes::IsFerryChecker::Instance()(m_params.m_types))
+    return {};
+
   auto const format = [](double hours) -> string {
     if (base::AlmostEqualAbs(hours, 0.0, 1e-5))
       return {};

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "indexer/feature_data.hpp"
-#include "indexer/classificator.hpp"
-#include "indexer/ftypes_matcher.hpp"
 
 #include <string>
 
@@ -97,14 +95,7 @@ public:
     case Metadata::FMD_BANNER_URL: valid = ValidateAndFormat_url(v); break;
     case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
     case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
-    case Metadata::FMD_DURATION:
-    {
-      static uint32_t const kFerryType = classif().GetTypeByPath({"route", "ferry"});
-      if (m_params.FindType(kFerryType, 2 /* level */) != ftype::GetEmptyValue())
-        valid = ValidateAndFormat_duration(v);
-
-      break;
-    }
+    case Metadata::FMD_DURATION: valid = ValidateAndFormat_duration(v); break;
     // Metadata types we do not get from OSM.
     case Metadata::FMD_SPONSORED_ID:
     case Metadata::FMD_PRICE_RATE:

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -626,6 +626,12 @@ IsMotorwayJunctionChecker::IsMotorwayJunctionChecker()
   m_types.push_back(c.GetTypeByPath({"highway", "motorway_junction"}));
 }
 
+IsFerryChecker::IsFerryChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"route", "ferry"}));
+}
+
 IsLocalityChecker::IsLocalityChecker()
 {
   Classificator const & c = classif();

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -375,6 +375,13 @@ public:
   DECLARE_CHECKER_INSTANCE(IsMotorwayJunctionChecker);
 };
 
+class IsFerryChecker : public BaseChecker
+{
+  IsFerryChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsFerryChecker);
+};
+
 /// Type of locality (do not change values and order - they have detalization order)
 /// Country < State < City < ...
 enum class LocalityType


### PR DESCRIPTION
Детали о том когда заполнять или не заполнять значения для всех остальных типов убраны в ValidateAndFormat, например:

```C++
string MetadataTagProcessorImpl::ValidateAndFormat_operator(string const & v) const
{
  auto const & isATM = ftypes::IsATMChecker::Instance();
  auto const & isFuelStation = ftypes::IsFuelStationChecker::Instance();

  if (!(isATM(m_params.m_types) || isFuelStation(m_params.m_types)))
    return string();

  return v;
}
```