### PR TITLE
[defines] Rename POSTCODE_POINTS_FILE_TAG to postcode_points.

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -28,7 +28,7 @@
 #define INDEX_FILE_TAG "idx"
 #define SEARCH_INDEX_FILE_TAG "sdx"
 #define SEARCH_ADDRESS_FILE_TAG "addr"
-#define POSTCODE_POINTS_FILE_TAG "postcodes"
+#define POSTCODE_POINTS_FILE_TAG "postcode_points"
 #define CITIES_BOUNDARIES_FILE_TAG "cities_boundaries"
 #define FEATURE_TO_OSM_FILE_TAG "feature_to_osm"
 #define HEADER_FILE_TAG "header"


### PR DESCRIPTION
Планируется вынести FMD_POSTCODES в отдельную секцию и логично будет назвать ее postcodes, поэтому переименовываю POSTCODE_POINTS_FILE_TAG в postcode_points.
Ещё не было ни одной "боевой" генерации данных с postcodes, поэтому это переименование сейчас ни на что не повлияет.