### PR TITLE
[indexer][generaror] Add postcodes section.

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -29,6 +29,7 @@
 #define SEARCH_INDEX_FILE_TAG "sdx"
 #define SEARCH_ADDRESS_FILE_TAG "addr"
 #define POSTCODE_POINTS_FILE_TAG "postcode_points"
+#define POSTCODES_FILE_TAG "postcodes"
 #define CITIES_BOUNDARIES_FILE_TAG "cities_boundaries"
 #define FEATURE_TO_OSM_FILE_TAG "feature_to_osm"
 #define HEADER_FILE_TAG "header"
@@ -47,8 +48,8 @@
 #define REGION_INFO_FILE_TAG "rgninfo"
 #define METALINES_FILE_TAG "metalines"
 #define CAMERAS_INFO_FILE_TAG "speedcams"
-// Temporary addresses section that is used in search index generation.
-#define SEARCH_TOKENS_FILE_TAG "addrtags"
+// Temporary addresses section that is used in search index and postcodes generation.
+#define TEMP_ADDR_FILE_TAG "addrtags"
 #define TRAFFIC_KEYS_FILE_TAG "traffic"
 #define TRANSIT_CROSS_MWM_FILE_TAG "transit_cross_mwm"
 #define TRANSIT_FILE_TAG "transit"

--- a/defines.hpp
+++ b/defines.hpp
@@ -49,7 +49,7 @@
 #define METALINES_FILE_TAG "metalines"
 #define CAMERAS_INFO_FILE_TAG "speedcams"
 // Temporary addresses section that is used in search index and postcodes generation.
-#define TEMP_ADDR_FILE_TAG "addrtags"
+#define TEMP_ADDR_FILE_TAG "tempaddr"
 #define TRAFFIC_KEYS_FILE_TAG "traffic"
 #define TRANSIT_CROSS_MWM_FILE_TAG "transit_cross_mwm"
 #define TRANSIT_FILE_TAG "transit"

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -142,6 +142,8 @@ set(
   platform_helpers.hpp
   popular_places_section_builder.cpp
   popular_places_section_builder.hpp
+  postcodes_section_builder.cpp
+  postcodes_section_builder.hpp
   processor_booking.hpp
   processor_coastline.cpp
   processor_coastline.hpp

--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -65,7 +65,7 @@ public:
 
     m_helperFile.resize(FILES_COUNT);
     m_helperFile[METADATA] = make_unique<TmpFile>(fName + METADATA_FILE_TAG);
-    m_helperFile[SEARCH_TOKENS] = make_unique<TmpFile>(fName + SEARCH_TOKENS_FILE_TAG);
+    m_helperFile[TEMP_ADDR] = make_unique<TmpFile>(fName + TEMP_ADDR_FILE_TAG);
   }
 
   ~FeaturesCollector2()
@@ -126,7 +126,7 @@ public:
     }
 
     finalizeFn(move(m_helperFile[METADATA]), METADATA_FILE_TAG);
-    finalizeFn(move(m_helperFile[SEARCH_TOKENS]), SEARCH_TOKENS_FILE_TAG);
+    finalizeFn(move(m_helperFile[TEMP_ADDR]), TEMP_ADDR_FILE_TAG);
 
     m_writer.Finish();
 
@@ -225,7 +225,7 @@ public:
 
       featureId = WriteFeatureBase(buffer.m_buffer, fb);
 
-      fb.GetAddressData().Serialize(*(m_helperFile[SEARCH_TOKENS]));
+      fb.GetAddressData().Serialize(*(m_helperFile[TEMP_ADDR]));
 
       if (!fb.GetMetadata().Empty())
       {
@@ -260,7 +260,7 @@ private:
   enum
   {
     METADATA = 0,
-    SEARCH_TOKENS = 1,
+    TEMP_ADDR = 1,
     FILES_COUNT = 2
   };
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -17,6 +17,7 @@
 #include "generator/osm_source.hpp"
 #include "generator/platform_helpers.hpp"
 #include "generator/popular_places_section_builder.hpp"
+#include "generator/postcodes_section_builder.hpp"
 #include "generator/processor_factory.hpp"
 #include "generator/ratings_section_builder.hpp"
 #include "generator/raw_generator.hpp"
@@ -342,6 +343,9 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
       LOG(LINFO, ("Generating offsets table for", datFile));
       if (!feature::BuildOffsetsTable(datFile))
         continue;
+
+      if (!BuildPostcodesSection(datFile))
+        LOG(LCRITICAL, ("Error generating postcodes section."));
 
       if (mapType == MapType::Country)
       {

--- a/generator/postcodes_section_builder.cpp
+++ b/generator/postcodes_section_builder.cpp
@@ -1,0 +1,58 @@
+#include "generator/postcodes_section_builder.hpp"
+
+#include "generator/gen_mwm_info.hpp"
+
+#include "indexer/feature_meta.hpp"
+#include "indexer/feature_processor.hpp"
+#include "indexer/postcodes.hpp"
+
+#include "platform/platform.hpp"
+
+#include "coding/files_container.hpp"
+#include "coding/reader.hpp"
+
+#include "base/checked_cast.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include "defines.hpp"
+
+namespace generator
+{
+bool BuildPostcodesSection(std::string const & mwmFile)
+{
+  LOG(LINFO, ("Building the Postcodes section"));
+
+  FilesContainerR container(GetPlatform().GetReader(mwmFile, "f"));
+  ReaderSource<ModelReaderPtr> src(container.GetReader(TEMP_ADDR_FILE_TAG));
+  std::vector<feature::AddressData> addrs;
+  while (src.Size() > 0)
+  {
+    addrs.push_back({});
+    addrs.back().Deserialize(src);
+  }
+
+  auto const featuresCount = base::checked_cast<uint32_t>(addrs.size());
+
+  indexer::PostcodesBuilder builder;
+  bool havePostcodes = false;
+  feature::ForEachFromDat(mwmFile, [&](FeatureType const & f, uint32_t featureId) {
+    CHECK_LESS(featureId, featuresCount, ());
+    auto const postcode = addrs[featureId].Get(feature::AddressData::Type::Postcode);
+    if (postcode.empty())
+      return;
+
+    havePostcodes = true;
+    builder.Put(featureId, postcode);
+  });
+
+  if (!havePostcodes)
+    return true;
+
+  FilesContainerW writeContainer(mwmFile, FileWriter::OP_WRITE_EXISTING);
+  auto writer = writeContainer.GetWriter(POSTCODES_FILE_TAG);
+  builder.Freeze(*writer);
+  return true;
+}
+}  // namespace generator

--- a/generator/postcodes_section_builder.hpp
+++ b/generator/postcodes_section_builder.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+
+namespace generator
+{
+bool BuildPostcodesSection(std::string const & mwmFile);
+}  // namespace generator

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -447,7 +447,7 @@ void AddFeatureNameIndexPairs(FeaturesVectorTest const & features,
 
 void ReadAddressData(FilesContainerR & container, vector<feature::AddressData> & addrs)
 {
-  ReaderSource<ModelReaderPtr> src(container.GetReader(SEARCH_TOKENS_FILE_TAG));
+  ReaderSource<ModelReaderPtr> src(container.GetReader(TEMP_ADDR_FILE_TAG));
   while (src.Size() > 0)
   {
     addrs.push_back({});
@@ -635,7 +635,7 @@ bool BuildSearchIndexFromDataFile(string const & filename, bool forceRebuild, ui
       // todo(@m) Is it possible to make it work?
       {
         FilesContainerW writeContainer(readContainer.GetFileName(), FileWriter::OP_WRITE_EXISTING);
-        writeContainer.DeleteSection(SEARCH_TOKENS_FILE_TAG);
+        writeContainer.DeleteSection(TEMP_ADDR_FILE_TAG);
       }
 
       // Separate scopes because FilesContainerW cannot write two sections at once.

--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -100,6 +100,8 @@ set(
   map_style_reader.hpp
   mwm_set.cpp
   mwm_set.hpp
+  postcodes.cpp
+  postcodes.hpp
   postcodes_matcher.cpp   # it's in indexer due to editor which is in indexer and depends on postcodes_marcher
   postcodes_matcher.hpp    # it's in indexer due to editor which is in indexer and depends on postcodes_marcher
   rank_table.cpp

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   interval_index_test.cpp
   mwm_set_test.cpp
   postcodes_matcher_tests.cpp
+  postcodes_tests.cpp
   rank_table_test.cpp
   scale_index_reading_tests.cpp
   scales_test.cpp

--- a/indexer/indexer_tests/postcodes_tests.cpp
+++ b/indexer/indexer_tests/postcodes_tests.cpp
@@ -1,0 +1,53 @@
+#include "testing/testing.hpp"
+
+#include "indexer/postcodes.hpp"
+
+#include "coding/reader.hpp"
+#include "coding/writer.hpp"
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+using namespace indexer;
+using namespace std;
+
+using Buffer = vector<uint8_t>;
+
+UNIT_TEST(Postcodes_Smoke)
+{
+  map<uint32_t, string> const features = {
+      {1, "127001"}, {5, "aa1 1aa"}, {10, "123"}, {20, "aaa 1111"}};
+
+  Buffer buffer;
+  {
+    PostcodesBuilder builder;
+
+    for (auto const & feature : features)
+      builder.Put(feature.first, feature.second);
+
+    MemWriter<Buffer> writer(buffer);
+    builder.Freeze(writer);
+  }
+
+  {
+    MemReader reader(buffer.data(), buffer.size());
+    auto postcodes = Postcodes::Load(reader);
+    TEST(postcodes.get(), ());
+
+    string actual;
+    for (uint32_t i = 0; i < 100; ++i)
+    {
+      auto const it = features.find(i);
+      if (it != features.end())
+      {
+        TEST(postcodes->Get(i, actual), ());
+        TEST_EQUAL(actual, it->second, ());
+      }
+      else
+      {
+        TEST(!postcodes->Get(i, actual), ());
+      }
+    }
+  }
+}

--- a/indexer/postcodes.cpp
+++ b/indexer/postcodes.cpp
@@ -1,0 +1,138 @@
+#include "indexer/postcodes.hpp"
+
+#include "coding/varint.hpp"
+
+#include "base/assert.hpp"
+#include "base/checked_cast.hpp"
+
+#include <type_traits>
+
+using namespace std;
+
+namespace indexer
+{
+void Postcodes::Header::Read(Reader & reader)
+{
+  static_assert(is_same<underlying_type_t<Version>, uint8_t>::value, "");
+  NonOwningReaderSource source(reader);
+  m_version = static_cast<Version>(ReadPrimitiveFromSource<uint8_t>(source));
+  CHECK_EQUAL(base::Underlying(m_version), base::Underlying(Version::V0), ());
+  m_stringsOffset = ReadPrimitiveFromSource<uint32_t>(source);
+  m_stringsSize = ReadPrimitiveFromSource<uint32_t>(source);
+  m_postcodesMapOffset = ReadPrimitiveFromSource<uint32_t>(source);
+  m_postcodesMapSize = ReadPrimitiveFromSource<uint32_t>(source);
+}
+
+bool Postcodes::Get(uint32_t id, std::string & postcode)
+{
+  uint32_t postcodeId;
+  if (!m_map->Get(id, postcodeId))
+    return false;
+
+  CHECK_LESS_OR_EQUAL(postcodeId, m_strings.GetNumStrings(), ());
+  postcode = m_strings.ExtractString(*m_stringsSubreader, postcodeId);
+  return true;
+}
+
+// static
+unique_ptr<Postcodes> Postcodes::Load(Reader & reader)
+{
+  auto postcodes = make_unique<Postcodes>();
+  postcodes->m_version = Version::V0;
+
+  Header header;
+  header.Read(reader);
+
+  postcodes->m_stringsSubreader =
+      reader.CreateSubReader(header.m_stringsOffset, header.m_stringsSize);
+  if (!postcodes->m_stringsSubreader)
+    return {};
+  postcodes->m_strings.InitializeIfNeeded(*postcodes->m_stringsSubreader);
+
+  postcodes->m_mapSubreader =
+      reader.CreateSubReader(header.m_postcodesMapOffset, header.m_postcodesMapSize);
+  if (!postcodes->m_mapSubreader)
+    return {};
+
+  // Decodes block encoded by writeBlockCallback from PostcodesBuilder::Freeze.
+  auto const readBlockCallback = [&](NonOwningReaderSource & source, uint32_t blockSize,
+                                     vector<uint32_t> & values) {
+    values.resize(blockSize);
+    for (size_t i = 0; i < blockSize && source.Size() > 0; ++i)
+      values[i] = ReadVarUint<uint32_t>(source);
+  };
+
+  postcodes->m_map = Map::Load(*postcodes->m_mapSubreader, readBlockCallback);
+  if (!postcodes->m_map)
+    return {};
+
+  return postcodes;
+}
+
+// PostcodesBuilder -----------------------------------------------------------------------------
+void PostcodesBuilder::Put(uint32_t featureId, std::string const & postcode)
+{
+  uint32_t postcodeId = 0;
+  auto const it = m_postcodeToId.find(postcode);
+  if (it != m_postcodeToId.end())
+  {
+    postcodeId = it->second;
+    CHECK_LESS_OR_EQUAL(postcodeId, m_postcodeToId.size(), ());
+    CHECK_EQUAL(m_idToPostcode.count(postcodeId), 1, ());
+  }
+  else
+  {
+    postcodeId = base::asserted_cast<uint32_t>(m_postcodeToId.size());
+    m_postcodeToId[postcode] = postcodeId;
+    CHECK_EQUAL(m_idToPostcode.count(postcodeId), 0, ());
+    m_idToPostcode[postcodeId] = postcode;
+    CHECK_EQUAL(m_idToPostcode.size(), m_postcodeToId.size(), ());
+  }
+  m_builder.Put(featureId, postcodeId);
+}
+
+void PostcodesBuilder::Freeze(Writer & writer) const
+{
+  size_t startOffset = writer.Pos();
+  CHECK(coding::IsAlign8(startOffset), ());
+
+  Postcodes::Header header;
+  header.Serialize(writer);
+
+  uint64_t bytesWritten = writer.Pos();
+  coding::WritePadding(writer, bytesWritten);
+
+  header.m_stringsOffset = base::asserted_cast<uint32_t>(writer.Pos() - startOffset);
+  {
+    coding::BlockedTextStorageWriter<decltype(writer)> stringsWriter(writer, 1000 /* blockSize */);
+    for (size_t i = 0; i < m_idToPostcode.size(); ++i)
+    {
+      auto const it = m_idToPostcode.find(base::asserted_cast<uint32_t>(i));
+      CHECK(it != m_idToPostcode.end(), ());
+      stringsWriter.Append(it->second);
+    }
+    // stringsWriter destructor writes strings section index right after strings.
+  }
+
+  header.m_stringsSize =
+      base::asserted_cast<uint32_t>(writer.Pos() - header.m_stringsOffset - startOffset);
+  bytesWritten = writer.Pos();
+  coding::WritePadding(writer, bytesWritten);
+
+  header.m_postcodesMapOffset = base::asserted_cast<uint32_t>(writer.Pos() - startOffset);
+
+  auto const writeBlockCallback = [](auto & w, auto begin, auto end) {
+    for (auto it = begin; it != end; ++it)
+      WriteVarUint(w, *it);
+  };
+  m_builder.Freeze(writer, writeBlockCallback);
+
+  header.m_postcodesMapSize =
+      base::asserted_cast<uint32_t>(writer.Pos() - header.m_postcodesMapOffset - startOffset);
+
+  auto const endOffset = writer.Pos();
+  writer.Seek(startOffset);
+  header.Serialize(writer);
+  writer.Seek(endOffset);
+}
+}  // namespace indexer

--- a/indexer/postcodes.hpp
+++ b/indexer/postcodes.hpp
@@ -49,9 +49,9 @@ public:
 
   static std::unique_ptr<Postcodes> Load(Reader & reader);
 
-  // Tries to get |postcode| of the feature identified by |id|.  Returns
-  // false if table does not have entry for the feature.
-  WARN_UNUSED_RESULT bool Get(uint32_t id, std::string & postcode);
+  // Tries to get |postcode| of the feature with id |featureId|. Returns false if table
+  // does not have entry for the feature.
+  WARN_UNUSED_RESULT bool Get(uint32_t featureId, std::string & postcode);
 
 private:
   using Map = MapUint32ToValue<uint32_t>;

--- a/indexer/postcodes.hpp
+++ b/indexer/postcodes.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "coding/map_uint32_to_val.hpp"
+#include "coding/reader.hpp"
+#include "coding/text_storage.hpp"
+#include "coding/write_to_sink.hpp"
+#include "coding/writer.hpp"
+
+#include "base/stl_helpers.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace indexer
+{
+class Postcodes
+{
+public:
+  enum class Version : uint8_t
+  {
+    V0 = 0,
+    Latest = V0
+  };
+
+  struct Header
+  {
+    template <typename Sink>
+    void Serialize(Sink & sink) const
+    {
+      CHECK_EQUAL(base::Underlying(m_version), base::Underlying(Version::V0), ());
+      WriteToSink(sink, static_cast<uint8_t>(m_version));
+      WriteToSink(sink, m_stringsOffset);
+      WriteToSink(sink, m_stringsSize);
+      WriteToSink(sink, m_postcodesMapOffset);
+      WriteToSink(sink, m_postcodesMapSize);
+    }
+
+    void Read(Reader & reader);
+
+    Version m_version = Version::Latest;
+    // All offsets are relative to the start of the section (offset of header is zero).
+    uint32_t m_stringsOffset = 0;
+    uint32_t m_stringsSize = 0;
+    uint32_t m_postcodesMapOffset = 0;
+    uint32_t m_postcodesMapSize = 0;
+  };
+
+  static std::unique_ptr<Postcodes> Load(Reader & reader);
+
+  // Tries to get |postcode| of the feature identified by |id|.  Returns
+  // false if table does not have entry for the feature.
+  WARN_UNUSED_RESULT bool Get(uint32_t id, std::string & postcode);
+
+private:
+  using Map = MapUint32ToValue<uint32_t>;
+
+  std::unique_ptr<Reader> m_stringsSubreader;
+  coding::BlockedTextStorageReader m_strings;
+  std::unique_ptr<Map> m_map;
+  std::unique_ptr<Reader> m_mapSubreader;
+  Version m_version = Version::Latest;
+};
+
+class PostcodesBuilder
+{
+public:
+  void Put(uint32_t featureId, std::string const & postcode);
+  void Freeze(Writer & writer) const;
+
+private:
+  std::unordered_map<std::string, uint32_t> m_postcodeToId;
+  std::unordered_map<uint32_t, std::string> m_idToPostcode;
+  MapUint32ToValueBuilder<uint32_t> m_builder;
+};
+}  // namespace indexer

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		4088CE2121AE993F00E2702A /* brands_holder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4088CE1F21AE993F00E2702A /* brands_holder.cpp */; };
 		4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */; };
 		4099F64A1FC7142A002A7B05 /* fake_feature_ids.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */; };
+		409EE3E3237E9AA700EA31A4 /* postcodes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 409EE3E1237E9AA700EA31A4 /* postcodes.hpp */; };
+		409EE3E4237E9AA700EA31A4 /* postcodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 409EE3E2237E9AA700EA31A4 /* postcodes.cpp */; };
+		40BC58CA237EACDF006B2C4E /* postcodes_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */; };
 		40C3C091205BF9F400CED188 /* bounds.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C3C090205BF9F400CED188 /* bounds.hpp */; };
 		40DF582D2174979200E4E0FC /* classificator_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40DF582C2174979200E4E0FC /* classificator_tests.cpp */; };
 		456B3FB41EDEEB65009B3D1F /* scales_patch.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */; };
@@ -291,6 +294,9 @@
 		4088CE1F21AE993F00E2702A /* brands_holder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = brands_holder.cpp; sourceTree = "<group>"; };
 		4099F6471FC71429002A7B05 /* fake_feature_ids.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_feature_ids.cpp; sourceTree = "<group>"; };
 		4099F6481FC7142A002A7B05 /* fake_feature_ids.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_feature_ids.hpp; sourceTree = "<group>"; };
+		409EE3E1237E9AA700EA31A4 /* postcodes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = postcodes.hpp; sourceTree = "<group>"; };
+		409EE3E2237E9AA700EA31A4 /* postcodes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = postcodes.cpp; sourceTree = "<group>"; };
+		40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = postcodes_tests.cpp; sourceTree = "<group>"; };
 		40C3C090205BF9F400CED188 /* bounds.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bounds.hpp; sourceTree = "<group>"; };
 		40DF582C2174979200E4E0FC /* classificator_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = classificator_tests.cpp; sourceTree = "<group>"; };
 		456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scales_patch.hpp; sourceTree = "<group>"; };
@@ -555,6 +561,7 @@
 		670C60F81AB0657700C38A8C /* indexer_tests */ = {
 			isa = PBXGroup;
 			children = (
+				40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */,
 				391C0C8522BD255E003DC252 /* feature_to_osm_tests.cpp */,
 				406970A121AEF2F10024DDB2 /* brands_tests.cpp */,
 				40C3C090205BF9F400CED188 /* bounds.hpp */,
@@ -622,6 +629,8 @@
 		6753409C1A3F53CB00A0A8C3 /* indexer */ = {
 			isa = PBXGroup;
 			children = (
+				409EE3E2237E9AA700EA31A4 /* postcodes.cpp */,
+				409EE3E1237E9AA700EA31A4 /* postcodes.hpp */,
 				40662D2F236059BF006A124D /* tree_node.hpp */,
 				391C0C8122BD2551003DC252 /* feature_to_osm.cpp */,
 				391C0C8222BD2551003DC252 /* feature_to_osm.hpp */,
@@ -810,6 +819,7 @@
 				670BAACA1D0B0BBB000302DA /* string_slice.hpp in Headers */,
 				6753413F1A3F540F00A0A8C3 /* scale_index.hpp in Headers */,
 				6753410E1A3F540F00A0A8C3 /* drawing_rules.hpp in Headers */,
+				409EE3E3237E9AA700EA31A4 /* postcodes.hpp in Headers */,
 				670C615C1AB0691900C38A8C /* features_offsets_table.hpp in Headers */,
 				6758AED41BB4413000C26E27 /* drules_selector.hpp in Headers */,
 				6753412F1A3F540F00A0A8C3 /* index_builder.hpp in Headers */,
@@ -997,10 +1007,12 @@
 				6753410D1A3F540F00A0A8C3 /* drawing_rules.cpp in Sources */,
 				675341301A3F540F00A0A8C3 /* data_source.cpp in Sources */,
 				34664CF61D49FEC1003D7096 /* centers_table.cpp in Sources */,
+				40BC58CA237EACDF006B2C4E /* postcodes_tests.cpp in Sources */,
 				3D12E3D72111B4BE0015A9A9 /* caching_rank_table_loader.cpp in Sources */,
 				6753414D1A3F540F00A0A8C3 /* types_mapping.cpp in Sources */,
 				34583BC71C88552100F94664 /* cuisines.cpp in Sources */,
 				3D452AFA1EE6D9F5009EAB9B /* wheelchair_tests.cpp in Sources */,
+				409EE3E4237E9AA700EA31A4 /* postcodes.cpp in Sources */,
 				675341121A3F540F00A0A8C3 /* feature_algo.cpp in Sources */,
 				675341211A3F540F00A0A8C3 /* feature_utils.cpp in Sources */,
 				4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */,


### PR DESCRIPTION
Сейчас почтовые индексы хранятся в метадате не экономично (как строки с большим количеством дублирования, в среднем один индекс дублируется 60 раз на mwm).
В этом реквесте новая секция для индексов, которая хранит их более сжатым образом. Удаление из метадаты и переход на использование новой секции будет отдельным реквестом, чтобы было проще смотреть.

До создания релизной ветки 9.5 мержить не стоит