### PR TITLE
[generator] Recount coefs for GetRadiusByPopulationForRouting 

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -734,9 +734,9 @@ double GetRadiusByPopulationForRouting(uint64_t p, LocalityType localityType)
 {
   switch (localityType)
   {
-  case LocalityType::City: return pow(static_cast<double>(p), 1.0 / 2.6) * 50;
-  case LocalityType::Town: return pow(static_cast<double>(p), 1.0 / 4.4) * 210.0;
-  case LocalityType::Village: return pow(static_cast<double>(p), 1.0 / 15.3) * 730.0;
+  case LocalityType::City: return pow(static_cast<double>(p), 1.0 / 2.5) * 34.0;
+  case LocalityType::Town: return pow(static_cast<double>(p), 1.0 / 6.8) * 354.0;
+  case LocalityType::Village: return pow(static_cast<double>(p), 1.0 / 15.1) * 610.0;
   default: UNREACHABLE();
   }
 }


### PR DESCRIPTION
https://confluence.mail.ru/pages/viewpage.action?pageId=287950469#id-%D0%98%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5admin_centre-formula_after_boost

Что произошло: формула вычисления площади поменялась на boost::area(...)
А коэффициенты последние считались для ф-ии, которая работала не так хорошо