### PR TITLE
[Platform][Android][iOS] Upload file in background.

### DIFF
--- a/android/jni/com/mapswithme/util/HttpUploader.cpp
+++ b/android/jni/com/mapswithme/util/HttpUploader.cpp
@@ -48,18 +48,19 @@ HttpUploader::Result HttpUploader::Upload() const
                             "[Lcom/mapswithme/util/KeyValue;"
                             "[Lcom/mapswithme/util/KeyValue;"
                             "Ljava/lang/String;Ljava/lang/String;Z)V");
-
-  jni::ScopedLocalRef<jstring> const method(env, jni::ToJavaString(env, m_method));
-  jni::ScopedLocalRef<jstring> const url(env, jni::ToJavaString(env, m_url));
-  jni::ScopedLocalRef<jobjectArray> const params(env, jni::ToKeyValueArray(env, m_params));
-  jni::ScopedLocalRef<jobjectArray> const headers(env, jni::ToKeyValueArray(env, m_headers));
-  jni::ScopedLocalRef<jstring> const fileKey(env, jni::ToJavaString(env, m_fileKey));
-  jni::ScopedLocalRef<jstring> const filePath(env, jni::ToJavaString(env, m_filePath));
+  HttpPayload const payload = GetPayload();
+  jni::ScopedLocalRef<jstring> const method(env, jni::ToJavaString(env, payload.m_method));
+  jni::ScopedLocalRef<jstring> const url(env, jni::ToJavaString(env, payload.m_url));
+  jni::ScopedLocalRef<jobjectArray> const params(env, jni::ToKeyValueArray(env, payload.m_params));
+  jni::ScopedLocalRef<jobjectArray> const headers(env,
+                                                  jni::ToKeyValueArray(env, payload.m_headers));
+  jni::ScopedLocalRef<jstring> const fileKey(env, jni::ToJavaString(env, payload.m_fileKey));
+  jni::ScopedLocalRef<jstring> const filePath(env, jni::ToJavaString(env, payload.m_filePath));
 
   jni::ScopedLocalRef<jobject> const httpUploaderObject(
       env, env->NewObject(g_httpUploaderClazz, httpUploaderConstructor, method.get(), url.get(),
                           params.get(), headers.get(), fileKey.get(), filePath.get(),
-                          static_cast<jboolean>(m_needClientAuth)));
+                          static_cast<jboolean>(payload.m_needClientAuth)));
 
   static jmethodID const uploadId = jni::GetMethodID(env, httpUploaderObject, "upload",
                                                      "()Lcom/mapswithme/util/HttpUploader$Result;");

--- a/map/cloud.cpp
+++ b/map/cloud.cpp
@@ -5,13 +5,14 @@
 #include "coding/internal/file_data.hpp"
 #include "coding/sha1.hpp"
 
-#include "platform/network_policy.hpp"
 #include "platform/http_client.hpp"
+#include "platform/http_payload.hpp"
+#include "platform/http_uploader.hpp"
+#include "platform/network_policy.hpp"
 #include "platform/platform.hpp"
 #include "platform/preferred_languages.hpp"
 #include "platform/remote_file.hpp"
 #include "platform/settings.hpp"
-#include "platform/http_uploader.hpp"
 
 #include "base/assert.hpp"
 #include "base/file_name_utils.hpp"
@@ -927,15 +928,18 @@ Cloud::RequestResult Cloud::ExecuteUploading(UploadingResponseData const & respo
   int code = 0;
   for (size_t i = 0; i < urls.size(); ++i)
   {
-    platform::HttpUploader request;
-    request.SetUrl(urls[i]);
-    request.SetMethod(responseData.m_method);
+    platform::HttpPayload payload;
+    payload.m_url = urls[i];
+    payload.m_method = responseData.m_method;
+
     for (auto const & f : responseData.m_fields)
     {
       ASSERT_EQUAL(f.size(), 2, ());
-      request.SetParam(f[0], f[1]);
+      payload.m_params[f[0]] = f[1];
     }
-    request.SetFilePath(filePath);
+    payload.m_filePath = filePath;
+
+    platform::HttpUploader request(payload);
 
     auto const result = request.Upload();
     code = result.m_httpCode;

--- a/map/user.cpp
+++ b/map/user.cpp
@@ -1,6 +1,7 @@
 #include "map/user.hpp"
 
 #include "platform/http_client.hpp"
+#include "platform/http_payload.hpp"
 #include "platform/http_uploader.hpp"
 #include "platform/platform.hpp"
 #include "platform/preferred_languages.hpp"
@@ -641,13 +642,13 @@ void User::BindUser(CompleteUserBindingHandler && completionHandler)
                             [this, url, filePath, completionHandler = std::move(completionHandler)]()
       {
         SCOPE_GUARD(tmpFileGuard, std::bind(&base::DeleteFileX, std::cref(filePath)));
-        platform::HttpUploader request;
-        request.SetUrl(url);
-        request.SetNeedClientAuth(true);
-        request.SetHeaders({{"Authorization", BuildAuthorizationToken(m_accessToken)},
-                            {"User-Agent", GetPlatform().GetAppUserAgent()}});
-        request.SetFilePath(filePath);
-
+        platform::HttpPayload payload;
+        payload.m_url = url;
+        payload.m_needClientAuth = true;
+        payload.m_headers = {{"Authorization", BuildAuthorizationToken(m_accessToken)},
+                             {"User-Agent", GetPlatform().GetAppUserAgent()}};
+        payload.m_filePath = filePath;
+        platform::HttpUploader request(payload);
         auto const result = request.Upload();
         if (result.m_httpCode >= 200 && result.m_httpCode < 300)
         {

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -22,10 +22,13 @@ set(
   gui_thread.hpp
   http_client.cpp
   http_client.hpp
+  http_payload.cpp
+  http_payload.hpp
   http_request.cpp
   http_request.hpp
   http_thread_callback.hpp
   http_uploader.hpp
+  http_uploader_background.hpp
   http_user_agent.cpp
   http_user_agent.hpp
   local_country_file.cpp

--- a/platform/http_payload.cpp
+++ b/platform/http_payload.cpp
@@ -1,0 +1,6 @@
+#include "platform/http_payload.hpp"
+
+namespace platform
+{
+HttpPayload::HttpPayload() : m_method("POST"), m_fileKey("file"), m_needClientAuth(false) {}
+}  // namespace platform

--- a/platform/http_payload.hpp
+++ b/platform/http_payload.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace platform
+{
+struct HttpPayload
+{
+  HttpPayload();
+
+  std::string m_method;
+  std::string m_url;
+  std::map<std::string, std::string> m_params;
+  std::map<std::string, std::string> m_headers;
+  std::string m_fileKey;
+  std::string m_filePath;
+  bool m_needClientAuth;
+};
+}  // namespace platform

--- a/platform/http_uploader.hpp
+++ b/platform/http_uploader.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "platform/http_payload.hpp"
+
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -16,24 +18,12 @@ public:
     std::string m_description;
   };
 
-  void SetMethod(std::string const & method) { m_method = method; }
-  void SetUrl(std::string const & url) { m_url = url; }
-  void SetParams(std::map<std::string, std::string> const & params) { m_params = params; }
-  void SetParam(std::string const & key, std::string const & value) { m_params[key] = value; }
-  void SetHeaders(std::map<std::string, std::string> const & headers) { m_headers = headers; }
-  void SetFileKey(std::string const & fileKey) { m_fileKey = fileKey; }
-  void SetFilePath(std::string const & filePath) { m_filePath = filePath; }
-  void SetNeedClientAuth(bool needClientAuth) { m_needClientAuth = needClientAuth; }
-
+  HttpUploader() = delete;
+  explicit HttpUploader(HttpPayload const & payload) : m_payload(payload) {}
+  HttpPayload const & GetPayload() const { return m_payload; }
   Result Upload() const;
 
 private:
-  std::string m_method = "POST";
-  std::string m_url;
-  std::map<std::string, std::string> m_params;
-  std::map<std::string, std::string> m_headers;
-  std::string m_fileKey = "file";
-  std::string m_filePath;
-  bool m_needClientAuth = false;
+  HttpPayload const m_payload;
 };
 }  // namespace platform

--- a/platform/http_uploader_apple.mm
+++ b/platform/http_uploader_apple.mm
@@ -201,12 +201,12 @@ HttpUploader::Result HttpUploader::Upload() const
   };
 
   auto uploadTask = [[MultipartUploadTask alloc] init];
-  uploadTask.method = @(m_method.c_str());
-  uploadTask.urlString = @(m_url.c_str());
-  uploadTask.fileKey = @(m_fileKey.c_str());
-  uploadTask.filePath = @(m_filePath.c_str());
-  uploadTask.params = mapTransform(m_params);
-  uploadTask.headers = mapTransform(m_headers);
+  uploadTask.method = @(m_payload.m_method.c_str());
+  uploadTask.urlString = @(m_payload.m_url.c_str());
+  uploadTask.fileKey = @(m_payload.m_fileKey.c_str());
+  uploadTask.filePath = @(m_payload.m_filePath.c_str());
+  uploadTask.params = mapTransform(m_payload.m_params);
+  uploadTask.headers = mapTransform(m_payload.m_headers);
   [uploadTask uploadWithCompletion:[resultPtr, waiterPtr](NSInteger httpCode, NSString * description) {
     resultPtr->m_httpCode = static_cast<int32_t>(httpCode);
     resultPtr->m_description = description.UTF8String;

--- a/platform/http_uploader_background.hpp
+++ b/platform/http_uploader_background.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "platform/http_payload.hpp"
+
+namespace platform
+{
+class HttpUploaderBackground
+{
+public:
+  HttpUploaderBackground() = delete;
+  explicit HttpUploaderBackground(HttpPayload const & payload) : m_payload(payload) {}
+  HttpPayload const & GetPayload() const { return m_payload; }
+
+  // TODO add platform-specific implementation
+  void Upload() const {}
+
+private:
+  HttpPayload m_payload;
+};
+}  // namespace platform

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -117,6 +117,9 @@
 		67AB92EA1B7B3E9100AB5194 /* get_text_by_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67AB92E81B7B3E9100AB5194 /* get_text_by_id.cpp */; };
 		67AB92EB1B7B3E9100AB5194 /* get_text_by_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 67AB92E91B7B3E9100AB5194 /* get_text_by_id.hpp */; };
 		67B30B2A2084B7D8008AEBFD /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67B30B292084B7D7008AEBFD /* CoreLocation.framework */; };
+		D50B2296238591570056820A /* http_payload.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D50B2293238591570056820A /* http_payload.hpp */; };
+		D50B2297238591570056820A /* http_payload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D50B2294238591570056820A /* http_payload.cpp */; };
+		D5B191CF2386C7E4009CD0D6 /* http_uploader_background.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D5B191CE2386C7E4009CD0D6 /* http_uploader_background.hpp */; };
 		EB60B4DC204C130300E4953B /* network_policy_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB60B4DB204C130300E4953B /* network_policy_ios.mm */; };
 		EB60B4DE204C175700E4953B /* network_policy_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = EB60B4DD204C175700E4953B /* network_policy_ios.h */; };
 		F6DF73581EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */; };
@@ -243,6 +246,9 @@
 		67AB92E81B7B3E9100AB5194 /* get_text_by_id.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = get_text_by_id.cpp; sourceTree = "<group>"; };
 		67AB92E91B7B3E9100AB5194 /* get_text_by_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = get_text_by_id.hpp; sourceTree = "<group>"; };
 		67B30B292084B7D7008AEBFD /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		D50B2293238591570056820A /* http_payload.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = http_payload.hpp; sourceTree = "<group>"; };
+		D50B2294238591570056820A /* http_payload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = http_payload.cpp; sourceTree = "<group>"; };
+		D5B191CE2386C7E4009CD0D6 /* http_uploader_background.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = http_uploader_background.hpp; sourceTree = "<group>"; };
 		EB60B4DB204C130300E4953B /* network_policy_ios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = network_policy_ios.mm; sourceTree = "<group>"; };
 		EB60B4DD204C175700E4953B /* network_policy_ios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_policy_ios.h; sourceTree = "<group>"; };
 		F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_storage_base.cpp; sourceTree = "<group>"; };
@@ -372,6 +378,9 @@
 		6753437A1A3F5CF500A0A8C3 /* platform */ = {
 			isa = PBXGroup;
 			children = (
+				D5B191CE2386C7E4009CD0D6 /* http_uploader_background.hpp */,
+				D50B2294238591570056820A /* http_payload.cpp */,
+				D50B2293238591570056820A /* http_payload.hpp */,
 				3DEE1AE521F7091100054A91 /* battery_tracker.cpp */,
 				3DEE1AE621F7091100054A91 /* battery_tracker.hpp */,
 				333A416E21C3E13B00AF26F6 /* http_session_manager.h */,
@@ -508,6 +517,7 @@
 				675343D41A3F5D5A00A0A8C3 /* settings.hpp in Headers */,
 				675343B51A3F5D5A00A0A8C3 /* constants.hpp in Headers */,
 				34C624BE1DABCCD100510300 /* socket.hpp in Headers */,
+				D50B2296238591570056820A /* http_payload.hpp in Headers */,
 				675343C11A3F5D5A00A0A8C3 /* location_service.hpp in Headers */,
 				67AB92DD1B7B3D7300AB5194 /* mwm_version.hpp in Headers */,
 				34513AFC1DCB37C100471BDA /* marketing_service.hpp in Headers */,
@@ -526,6 +536,7 @@
 				675343CD1A3F5D5A00A0A8C3 /* platform.hpp in Headers */,
 				6741250F1B4C00CC00A3E828 /* local_country_file.hpp in Headers */,
 				3D15ACE2214A707900F725D5 /* localization.hpp in Headers */,
+				D5B191CF2386C7E4009CD0D6 /* http_uploader_background.hpp in Headers */,
 				3DE8B98F1DEC3115000E6083 /* network_policy.hpp in Headers */,
 				675E88A11DB7B0F200F8EBDA /* test_socket.hpp in Headers */,
 				675343CF1A3F5D5A00A0A8C3 /* preferred_languages.hpp in Headers */,
@@ -672,6 +683,7 @@
 				67AB92DC1B7B3D7300AB5194 /* mwm_version.cpp in Sources */,
 				67A2526B1BB40E520063F8A8 /* platform_mac.mm in Sources */,
 				3D15ACE1214A707900F725D5 /* localization.mm in Sources */,
+				D50B2297238591570056820A /* http_payload.cpp in Sources */,
 				6741250A1B4C00CC00A3E828 /* country_file.cpp in Sources */,
 				4564FA7F2094978D0043CCFB /* remote_file.cpp in Sources */,
 				674125081B4C00CC00A3E828 /* country_defines.cpp in Sources */,


### PR DESCRIPTION
- Реализация структуры `HttpPayload`, содержащей поля для отправки данных по HTTP.
- Замена отдельных полей в классе `HttpUpload` на структуру `HttpPayload`, добавление геттеров для полей структуры.
- Класс `HttpBackgroundUploader` с методом-заглушкой `Upload()` и полем `HttpPayload`. Метод `Upload()` **должен быть реализован на платформах** для отправки файла по HTTP по событию подключения wi-fi, в том числе из бэкграунда.