### PR TITLE
[indexer] Remove postcodes from metadata.

### DIFF
--- a/editor/editor_config.cpp
+++ b/editor/editor_config.cpp
@@ -28,7 +28,6 @@ static unordered_map<string, EType> const kNamesToFMD = {
     // {"", feature::Metadata::FMD_TURN_LANES_FORWARD},
     // {"", feature::Metadata::FMD_TURN_LANES_BACKWARD},
     {"email", feature::Metadata::FMD_EMAIL},
-    {"postcode", feature::Metadata::FMD_POSTCODE},
     {"wikipedia", feature::Metadata::FMD_WIKIPEDIA},
     // {"", feature::Metadata::FMD_MAXSPEED},
     {"flats", feature::Metadata::FMD_FLATS},
@@ -127,7 +126,6 @@ bool EditorConfig::GetTypeDescription(vector<string> classificatorTypes,
     {
       outDesc.m_address = isBuilding = true;
       outDesc.m_editableFields.push_back(feature::Metadata::FMD_BUILDING_LEVELS);
-      outDesc.m_editableFields.push_back(feature::Metadata::FMD_POSTCODE);
       classificatorTypes.erase(it);
       break;
     }

--- a/editor/editor_tests/xml_feature_test.cpp
+++ b/editor/editor_tests/xml_feature_test.cpp
@@ -61,6 +61,7 @@ UNIT_TEST(XMLFeature_Setters)
   feature.SetName("int_name", "Gorky Park");
 
   feature.SetHouse("10");
+  feature.SetPostcode("127001");
   feature.SetTagValue("opening_hours", "Mo-Fr 08:15-17:30");
   feature.SetTagValue("amenity", "atm");
 
@@ -74,6 +75,7 @@ UNIT_TEST(XMLFeature_Setters)
   <tag k="name:ru" v="Парк Горького" />
   <tag k="int_name" v="Gorky Park" />
   <tag k="addr:housenumber" v="10" />
+  <tag k="addr:postcode" v="127001" />
   <tag k="opening_hours" v="Mo-Fr 08:15-17:30" />
   <tag k="amenity" v="atm" />
 </node>
@@ -167,6 +169,7 @@ auto const kTestNode = R"(<?xml version="1.0"?>
   <tag k="name:ru" v="Парк Горького" />
   <tag k="int_name" v="Gorky Park" />
   <tag k="addr:housenumber" v="10" />
+  <tag k="addr:postcode" v="127001" />
   <tag k="opening_hours" v="Mo-Fr 08:15-17:30" />
   <tag k="amenity" v="atm" />
 </node>
@@ -186,6 +189,7 @@ UNIT_TEST(XMLFeature_FromXml)
   TEST(!feature.HasKey("FooBarBaz"), ());
 
   TEST_EQUAL(feature.GetHouse(), "10", ());
+  TEST_EQUAL(feature.GetPostcode(), "127001", ());
   TEST_EQUAL(feature.GetCenter(), ms::LatLon(55.7978998, 37.4745280), ());
   TEST_EQUAL(feature.GetName(), "Gorki Park", ());
   TEST_EQUAL(feature.GetName("default"), "Gorki Park", ());
@@ -361,6 +365,7 @@ UNIT_TEST(XMLFeature_FromXMLAndBackToXML)
   <tag k="name:en" v="Gorki Park" />
   <tag k="name:ru" v="Парк Горького" />
   <tag k="addr:housenumber" v="10" />
+  <tag k="addr:postcode" v="127001" />
   </node>
   )";
 

--- a/editor/osm_auth_tests/CMakeLists.txt
+++ b/editor/osm_auth_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ omim_link_libraries(
   icu
   oauthcpp
   stats_client
+  succinct
   ${LIBZ}
   ${Qt5Widgets_LIBRARIES}
 )

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -130,6 +130,9 @@ bool AreObjectsEqualButStreet(osm::EditableMapObject const & lhs,
   if (lhs.GetHouseNumber() != rhs.GetHouseNumber())
     return false;
 
+  if (lhs.GetPostcode() != rhs.GetPostcode())
+    return false;
+
   if (!lhs.GetMetadata().Equals(rhs.GetMetadata()))
     return false;
 

--- a/editor/xml_feature.cpp
+++ b/editor/xml_feature.cpp
@@ -26,6 +26,7 @@ constexpr char const * kUploadTimestamp = "upload_timestamp";
 constexpr char const * kUploadStatus = "upload_status";
 constexpr char const * kUploadError = "upload_error";
 constexpr char const * kHouseNumber = "addr:housenumber";
+constexpr char const * kPostcode = "addr:postcode";
 
 constexpr char const * kUnknownType = "unknown";
 constexpr char const * kNodeType = "node";
@@ -260,6 +261,10 @@ string XMLFeature::GetHouse() const { return GetTagValue(kHouseNumber); }
 
 void XMLFeature::SetHouse(string const & house) { SetTagValue(kHouseNumber, house); }
 
+string XMLFeature::GetPostcode() const { return GetTagValue(kPostcode); }
+
+void XMLFeature::SetPostcode(string const & postcode) { SetTagValue(kPostcode, postcode); }
+
 time_t XMLFeature::GetModificationTime() const
 {
   return base::StringToTimestamp(GetRootNode().attribute(kTimestamp).value());
@@ -393,6 +398,10 @@ void ApplyPatch(XMLFeature const & xml, osm::EditableMapObject & object)
   if (!house.empty())
     object.SetHouseNumber(house);
 
+  auto const postcode = xml.GetPostcode();
+  if (!postcode.empty())
+    object.SetPostcode(postcode);
+
   xml.ForEachTag([&object](string const & k, string const & v) {
     if (!object.UpdateMetadataValue(k, v))
       LOG(LWARNING, ("Patch feature has unknown tags", k, v));
@@ -420,6 +429,10 @@ XMLFeature ToXML(osm::EditableMapObject const & object, bool serializeType)
   string const house = object.GetHouseNumber();
   if (!house.empty())
     toFeature.SetHouse(house);
+
+  auto const postcode = object.GetPostcode();
+  if (!postcode.empty())
+    toFeature.SetPostcode(postcode);
 
   if (serializeType)
   {
@@ -473,6 +486,10 @@ bool FromXML(XMLFeature const & xml, osm::EditableMapObject & object)
   string const house = xml.GetHouse();
   if (!house.empty())
     object.SetHouseNumber(house);
+
+  auto const postcode = xml.GetPostcode();
+  if (!postcode.empty())
+    object.SetPostcode(postcode);
 
   feature::TypesHolder types;
   xml.ForEachTag([&object, &types](string const & k, string const & v) {

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -127,6 +127,9 @@ public:
   std::string GetHouse() const;
   void SetHouse(std::string const & house);
 
+  std::string GetPostcode() const;
+  void SetPostcode(std::string const & postcode);
+
   /// Our and OSM modification time are equal.
   time_t GetModificationTime() const;
   void SetModificationTime(time_t const time);

--- a/generator/feature_segments_checker/CMakeLists.txt
+++ b/generator/feature_segments_checker/CMakeLists.txt
@@ -30,6 +30,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   ${LIBZ}
 )
 

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -143,11 +143,6 @@ string MetadataTagProcessorImpl::ValidateAndFormat_email(string const & v) const
   return v;
 }
 
-string MetadataTagProcessorImpl::ValidateAndFormat_postcode(string const & v) const
-{
-  return v;
-}
-
 string MetadataTagProcessorImpl::ValidateAndFormat_flats(string const & v) const
 {
   return v;

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -23,7 +23,6 @@ struct MetadataTagProcessorImpl
   std::string ValidateAndFormat_turn_lanes_forward(std::string const & v) const;
   std::string ValidateAndFormat_turn_lanes_backward(std::string const & v) const;
   std::string ValidateAndFormat_email(std::string const & v) const;
-  std::string ValidateAndFormat_postcode(std::string const & v) const;
   std::string ValidateAndFormat_flats(std::string const & v) const;
   std::string ValidateAndFormat_internet(std::string v) const;
   std::string ValidateAndFormat_height(std::string const & v) const;
@@ -84,7 +83,6 @@ public:
     case Metadata::FMD_TURN_LANES_FORWARD: valid = ValidateAndFormat_turn_lanes_forward(v); break;
     case Metadata::FMD_TURN_LANES_BACKWARD: valid = ValidateAndFormat_turn_lanes_backward(v); break;
     case Metadata::FMD_EMAIL: valid = ValidateAndFormat_email(v); break;
-    case Metadata::FMD_POSTCODE: valid = ValidateAndFormat_postcode(v); break;
     case Metadata::FMD_WIKIPEDIA: valid = ValidateAndFormat_wikipedia(v); break;
     case Metadata::FMD_FLATS: valid = ValidateAndFormat_flats(v); break;
     case Metadata::FMD_MIN_HEIGHT:  // The same validator as for height.
@@ -96,13 +94,15 @@ public:
     case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
     case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
     case Metadata::FMD_DURATION: valid = ValidateAndFormat_duration(v); break;
+    // Used for old data compatibility only and should not be set:
+    case Metadata::FMD_POSTCODE: CHECK(false, (mdType, "used for compatibility, should not be set."));
     // Metadata types we do not get from OSM.
     case Metadata::FMD_SPONSORED_ID:
     case Metadata::FMD_PRICE_RATE:
     case Metadata::FMD_RATING:
     case Metadata::FMD_BRAND:
     case Metadata::FMD_TEST_ID:
-    case Metadata::FMD_COUNT: CHECK(false, (mdType, "should not be parsed from OSM"));
+    case Metadata::FMD_COUNT: CHECK(false, (mdType, "should not be parsed from OSM."));
     }
     md.Set(mdType, valid);
     return false;

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -870,9 +870,8 @@ void GetNameAndType(OsmElement * p, FeatureParams & params, function<bool(uint32
       {"addr:postcode", "*",
        [&params](string & k, string & v) {
          params.AddPostcode(v);
-         // todo @t.yan: uncomment when we stop to add postcodes to metadata
-         // k.clear();
-         // v.clear();
+         k.clear();
+         v.clear();
       }},
 
       {"population", "*",

--- a/generator/srtm_coverage_checker/CMakeLists.txt
+++ b/generator/srtm_coverage_checker/CMakeLists.txt
@@ -30,6 +30,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   ${LIBZ}
 )
 

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -281,10 +281,7 @@ NamesDataSource EditableMapObject::GetNamesDataSource(StringUtf8Multilang const 
 
 vector<LocalizedStreet> const & EditableMapObject::GetNearbyStreets() const { return m_nearbyStreets; }
 
-string EditableMapObject::GetPostcode() const
-{
-  return m_metadata.Get(feature::Metadata::FMD_POSTCODE);
-}
+string EditableMapObject::GetPostcode() const { return m_postcode; }
 
 string EditableMapObject::GetWikipedia() const
 {
@@ -453,10 +450,7 @@ bool EditableMapObject::UpdateMetadataValue(string const & key, string const & v
   return true;
 }
 
-void EditableMapObject::SetPostcode(string const & postcode)
-{
-  m_metadata.Set(feature::Metadata::FMD_POSTCODE, postcode);
-}
+void EditableMapObject::SetPostcode(string const & postcode) { m_postcode = postcode; }
 
 void EditableMapObject::SetPhone(string const & phone)
 {

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -30,7 +30,7 @@ struct EditableProperties
   }
 
   bool m_name = false;
-  /// If true, enables editing of house number, street address and post code.
+  /// If true, enables editing of house number, street address and postcode.
   bool m_address = false;
   std::vector<feature::Metadata::EType> m_metadata;
   bool IsEditable() const { return m_name || m_address || !m_metadata.empty(); }

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -155,6 +155,8 @@ public:
   uint64_t GetPopulation();
   std::string GetRoadNumber();
 
+  std::string const & GetPostcode();
+
   feature::Metadata & GetMetadata();
 
   /// @name Statistic functions.
@@ -193,8 +195,12 @@ private:
     bool m_points = false;
     bool m_triangles = false;
     bool m_metadata = false;
+    bool m_postcode = false;
 
-    void Reset() { m_types = m_common = m_header2 = m_points = m_triangles = m_metadata = false; }
+    void Reset()
+    {
+      m_types = m_common = m_header2 = m_points = m_triangles = m_metadata = m_postcode = false;
+    }
   };
 
   struct Offsets
@@ -216,6 +222,7 @@ private:
   void ParseCommon();
   void ParseHeader2();
   void ParseMetadata();
+  void ParsePostcode();
   void ParseGeometryAndTriangles(int scale);
 
   uint8_t m_header = 0;
@@ -223,6 +230,7 @@ private:
 
   FeatureID m_id;
   FeatureParamsBase m_params;
+  std::string m_postcode;
 
   m2::PointD m_center;
   m2::RectD m_limitRect;

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -74,8 +74,6 @@ bool Metadata::TypeFromString(string const & k, Metadata::EType & outType)
     outType = Metadata::FMD_TURN_LANES_BACKWARD;
   else if (k == "email" || k == "contact:email")
     outType = Metadata::FMD_EMAIL;
-  else if (k == "addr:postcode")
-    outType = Metadata::FMD_POSTCODE;
   else if (k == "wikipedia")
     outType = Metadata::FMD_WIKIPEDIA;
   else if (k == "addr:flats")

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -120,7 +120,7 @@ public:
     FMD_TURN_LANES_FORWARD = 12,
     FMD_TURN_LANES_BACKWARD = 13,
     FMD_EMAIL = 14,
-    FMD_POSTCODE = 15,
+    FMD_POSTCODE = 15,  // Used for old data compatibility only. Should be empty for new mwms.
     FMD_WIKIPEDIA = 16,
     // FMD_MAXSPEED used to be 17 but now it is stored in a section of its own.
     FMD_FLATS = 18,

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -75,6 +75,7 @@ void MapObject::SetFromFeatureType(FeatureType & ft)
   m_types = feature::TypesHolder(ft);
   m_metadata = ft.GetMetadata();
   m_houseNumber = ft.GetHouseNumber();
+  m_postcode = ft.GetPostcode();
   m_featureID = ft.GetID();
   m_geomType = ft.GetGeomType();
   if (m_geomType == feature::GeomType::Area)
@@ -112,6 +113,8 @@ StringUtf8Multilang const & MapObject::GetNameMultilang() const
 }
 
 string const & MapObject::GetHouseNumber() const { return m_houseNumber; }
+
+string const & MapObject::GetPostcode() const { return m_postcode; }
 
 string MapObject::GetLocalizedType() const
 {

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -68,6 +68,7 @@ public:
   StringUtf8Multilang const & GetNameMultilang() const;
 
   std::string const & GetHouseNumber() const;
+  std::string const & GetPostcode() const;
 
   /// @name Metadata fields.
   //@{
@@ -118,6 +119,7 @@ protected:
 
   StringUtf8Multilang m_name;
   std::string m_houseNumber;
+  std::string m_postcode;
   feature::TypesHolder m_types;
   feature::Metadata m_metadata;
 

--- a/indexer/shared_load_info.cpp
+++ b/indexer/shared_load_info.cpp
@@ -41,4 +41,12 @@ SharedLoadInfo::Reader SharedLoadInfo::GetTrianglesReader(int ind) const
 {
   return m_cont.GetReader(GetTagForIndex(TRIANGLE_FILE_TAG, ind));
 }
+
+boost::optional<SharedLoadInfo::Reader> SharedLoadInfo::GetPostcodesReader() const
+{
+  if (!m_cont.IsExist(POSTCODES_FILE_TAG))
+    return {};
+
+  return m_cont.GetReader(POSTCODES_FILE_TAG);
+}
 }  // namespace feature

--- a/indexer/shared_load_info.hpp
+++ b/indexer/shared_load_info.hpp
@@ -7,6 +7,8 @@
 
 #include "base/macros.hpp"
 
+#include <boost/optional.hpp>
+
 namespace feature
 {
 // This info is created once per FeaturesVector.
@@ -24,6 +26,7 @@ public:
   Reader GetAltitudeReader() const;
   Reader GetGeometryReader(int ind) const;
   Reader GetTrianglesReader(int ind) const;
+  boost::optional<Reader> GetPostcodesReader() const;
 
   version::Format GetMWMFormat() const { return m_header.GetFormat(); }
 

--- a/kml/kml_tests/CMakeLists.txt
+++ b/kml/kml_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ omim_link_libraries(
   pugixml
   expat
   stats_client
+  succinct
   ${LIBZ}
 )
 link_qt5_core(${PROJECT_NAME})

--- a/map/style_tests/CMakeLists.txt
+++ b/map/style_tests/CMakeLists.txt
@@ -30,6 +30,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   ${LIBZ}
 )
 

--- a/openlr/openlr_stat/CMakeLists.txt
+++ b/openlr/openlr_stat/CMakeLists.txt
@@ -30,6 +30,7 @@ omim_link_libraries(${PROJECT_NAME}
   bsdiff
   pugixml
   stats_client
+  succinct
   ${Qt5Core_LIBRARIES}
   ${LIBZ}
 )

--- a/partners_api/partners_api_tests/CMakeLists.txt
+++ b/partners_api/partners_api_tests/CMakeLists.txt
@@ -40,6 +40,7 @@ omim_link_libraries(
   base
   jansson
   stats_client
+  succinct
   pugixml
   protobuf
   oauthcpp

--- a/routing/routes_builder/routes_builder_tool/CMakeLists.txt
+++ b/routing/routes_builder/routes_builder_tool/CMakeLists.txt
@@ -32,6 +32,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   gflags
   ${LIBZ}
 )

--- a/routing/routing_quality/CMakeLists.txt
+++ b/routing/routing_quality/CMakeLists.txt
@@ -28,6 +28,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   ${LIBZ}
 )
 

--- a/search/retrieval.cpp
+++ b/search/retrieval.cpp
@@ -225,7 +225,7 @@ pair<bool, bool> MatchFeatureByNameAndType(EditableMapObject const & emo,
 
 bool MatchFeatureByPostcode(EditableMapObject const & emo, TokenSlice const & slice)
 {
-  string const postcode = emo.GetMetadata().Get(feature::Metadata::FMD_POSTCODE);
+  string const postcode = emo.GetPostcode();
   vector<UniString> tokens;
   NormalizeAndTokenizeString(postcode, tokens, Delimiters());
   if (slice.Size() > tokens.size())

--- a/search/search_quality/search_quality_tests/CMakeLists.txt
+++ b/search/search_quality/search_quality_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ omim_link_libraries(
   opening_hours
   pugixml
   stats_client
+  succinct
   ${LIBZ}
 )
 

--- a/track_analyzing/track_analyzer/CMakeLists.txt
+++ b/track_analyzing/track_analyzer/CMakeLists.txt
@@ -40,6 +40,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   gflags
   ${LIBZ}
 )

--- a/track_analyzing/track_analyzing_tests/CMakeLists.txt
+++ b/track_analyzing/track_analyzing_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   gflags
   ${LIBZ}
 )

--- a/track_generator/CMakeLists.txt
+++ b/track_generator/CMakeLists.txt
@@ -33,6 +33,7 @@ omim_link_libraries(
   oauthcpp
   protobuf
   stats_client
+  succinct
   gflags
   ${LIBZ}
 )

--- a/traffic/traffic_tests/CMakeLists.txt
+++ b/traffic/traffic_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ omim_link_libraries(
   protobuf
   pugixml
   stats_client
+  succinct
   ${LIBZ}
 )
 


### PR DESCRIPTION
Первый коммит оформлен как отдельный реквест: https://github.com/mapsme/omim/pull/12051

Второй -- технический (надеюсь мы когда-нибудь зальём ту половину https://github.com/mapsme/omim/pull/11882 которая про CMake и отревертим это)

Третий коммит содержательный, в нём выключается сохранение индексов в метадату и включается их чтение из новой секции.

В состоянии драфта до создания ветки release-95.