### PR TITLE
[generator] Fixed generation.

### DIFF
--- a/generator/collector_routing_city_boundaries.cpp
+++ b/generator/collector_routing_city_boundaries.cpp
@@ -134,7 +134,7 @@ void RoutingCityBoundariesCollector::Collect(OsmElement const & osmElement)
 
   while (m_featureMakerSimple.GetNextFeature(feature))
   {
-    if (feature.GetParams().IsValid())
+    if (feature.IsValid())
       Process(feature, osmElementCopy);
   }
 }

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -218,7 +218,7 @@ bool FeatureBuilder::RemoveInvalidTypes()
 
 TypesHolder FeatureBuilder::GetTypesHolder() const
 {
-  Check(*this);
+  CHECK(IsValid(), (*this));
 
   TypesHolder holder(m_params.GetGeomType());
   for (auto const t : m_params.m_types)
@@ -380,7 +380,7 @@ void FeatureBuilder::SerializeBase(Buffer & data, serial::GeometryCodingParams c
 
 void FeatureBuilder::SerializeForIntermediate(Buffer & data) const
 {
-  Check(*this);
+  CHECK(IsValid(), (*this));
 
   data.clear();
 
@@ -471,12 +471,13 @@ void FeatureBuilder::DeserializeFromIntermediate(Buffer & data)
 
   rw::ReadVectorOfPOD(source, m_osmIds);
 
-  Check(*this);
+  CHECK(IsValid(), (*this));
 }
 
 void FeatureBuilder::SerializeAccuratelyForIntermediate(Buffer & data) const
 {
-  Check(*this);
+  CHECK(IsValid(), (*this));
+
   data.clear();
   PushBackByteSink<Buffer> sink(data);
   m_params.Write(sink, true /* store additional info from FeatureParams */);
@@ -531,7 +532,8 @@ void FeatureBuilder::DeserializeAccuratelyFromIntermediate(Buffer & data)
   }
 
   rw::ReadVectorOfPOD(source, m_osmIds);
-  Check(*this);
+
+  CHECK(IsValid(), (*this));
 }
 
 void FeatureBuilder::AddOsmId(base::GeoObjectId id) { m_osmIds.push_back(id); }
@@ -749,19 +751,24 @@ void FeatureBuilder::SerializeForMwm(SupportingData & data,
   }
 }
 
-// Functions
-void Check(FeatureBuilder const fb)
+bool FeatureBuilder::IsValid() const
 {
-  CHECK(fb.GetParams().CheckValid(), (fb));
+  if (!GetParams().IsValid())
+    return false;
 
-  if (fb.IsLine())
-    CHECK(fb.GetOuterGeometry().size() >= 2, (fb));
+  if (IsLine() && GetOuterGeometry().size() < 2)
+    return false;
 
-  if (fb.IsArea())
+  if (IsArea())
   {
-    for (auto const & points : fb.GetGeometry())
-      CHECK(points.size() >= 3, (fb));
+    for (auto const & points : GetGeometry())
+    {
+      if (points.size() < 3)
+        return false;
+    }
   }
+
+  return true;
 }
 
 string DebugPrint(FeatureBuilder const & fb)

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -88,8 +88,6 @@ bool FeatureBuilder::IsGeometryClosed() const
 
 m2::PointD FeatureBuilder::GetGeometryCenter() const
 {
-  //TODO(vng): Check requirements in this assert
-  //ASSERT ( IsGeometryClosed(), () );
   m2::PointD ret(0.0, 0.0);
 
   PointSeq const & poly = GetOuterGeometry();

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -51,6 +51,8 @@ public:
   // coordinates is used.
   bool IsExactEq(FeatureBuilder const & fb) const;
 
+  bool IsValid() const;
+
   // To work with geometry.
   void AddPoint(m2::PointD const & p);
   void SetHoles(Geometry const & holes);
@@ -240,7 +242,6 @@ protected:
   int64_t m_coastCell;
 };
 
-void Check(FeatureBuilder const fb);
 std::string DebugPrint(FeatureBuilder const & fb);
 
 // SerializationPolicy serialization and deserialization.

--- a/generator/feature_maker_base.cpp
+++ b/generator/feature_maker_base.cpp
@@ -73,10 +73,11 @@ void TransformToPoint(FeatureBuilder & feature)
 
 void TransformToLine(FeatureBuilder & feature)
 {
-  if (feature.IsArea() || feature.IsLine())
-    feature.SetLinear(feature.GetParams().m_reverseGeometry);
-  else
-    CHECK(false, (feature));
+  if (feature.IsLine())
+    return;
+
+  CHECK(feature.IsArea(), (feature));
+  feature.SetLinear(feature.GetParams().m_reverseGeometry);
 }
 
 FeatureBuilder MakePoint(FeatureBuilder const & feature)

--- a/generator/feature_maker_base.cpp
+++ b/generator/feature_maker_base.cpp
@@ -58,9 +58,11 @@ bool FeatureMakerBase::GetNextFeature(FeatureBuilder & feature)
   return true;
 }
 
-void TransformAreaToPoint(FeatureBuilder & feature)
+void TransformToPoint(FeatureBuilder & feature)
 {
-  CHECK(feature.IsArea(), ());
+  if (!feature.IsArea() && !feature.IsLine())
+    return;
+
   auto const center = feature.GetGeometryCenter();
   feature.ResetGeometry();
   feature.SetCenter(center);
@@ -69,23 +71,25 @@ void TransformAreaToPoint(FeatureBuilder & feature)
     params.SetGeomTypePointEx();
 }
 
-void TransformAreaToLine(FeatureBuilder & feature)
+void TransformToLine(FeatureBuilder & feature)
 {
-  CHECK(feature.IsArea(), ());
-  feature.SetLinear(feature.GetParams().m_reverseGeometry);
+  if (feature.IsArea() || feature.IsLine())
+    feature.SetLinear(feature.GetParams().m_reverseGeometry);
+  else
+    CHECK(false, (feature));
 }
 
-FeatureBuilder MakePointFromArea(FeatureBuilder const & feature)
+FeatureBuilder MakePoint(FeatureBuilder const & feature)
 {
   FeatureBuilder tmp(feature);
-  TransformAreaToPoint(tmp);
+  TransformToPoint(tmp);
   return tmp;
 }
 
-FeatureBuilder MakeLineFromArea(FeatureBuilder const & feature)
+FeatureBuilder MakeLine(FeatureBuilder const & feature)
 {
   FeatureBuilder tmp(feature);
-  TransformAreaToLine(tmp);
+  TransformToLine(tmp);
   return tmp;
 }
 }  // namespace generator

--- a/generator/feature_maker_base.hpp
+++ b/generator/feature_maker_base.hpp
@@ -40,9 +40,9 @@ protected:
   std::queue<feature::FeatureBuilder> m_queue;
 };
 
-void TransformAreaToPoint(feature::FeatureBuilder & feature);
-void TransformAreaToLine(feature::FeatureBuilder & feature);
+void TransformToPoint(feature::FeatureBuilder & feature);
+void TransformToLine(feature::FeatureBuilder & feature);
 
-feature::FeatureBuilder MakePointFromArea(feature::FeatureBuilder const & feature);
-feature::FeatureBuilder MakeLineFromArea(feature::FeatureBuilder const & feature);
+feature::FeatureBuilder MakePoint(feature::FeatureBuilder const & feature);
+feature::FeatureBuilder MakeLine(feature::FeatureBuilder const & feature);
 }  // namespace generator

--- a/generator/feature_processing_layers.cpp
+++ b/generator/feature_processing_layers.cpp
@@ -136,7 +136,7 @@ void RepresentationLayer::Handle(FeatureBuilder & fb)
       HandleArea(fb, params);
       if (CanBeLine(params))
       {
-        auto featureLine = MakeLineFromArea(fb);
+        auto featureLine = MakeLine(fb);
         LayerBase::Handle(featureLine);
       }
       break;
@@ -178,7 +178,7 @@ void RepresentationLayer::HandleArea(FeatureBuilder & fb, FeatureParams const & 
   }
   else if (CanBePoint(params))
   {
-    auto featurePoint = MakePointFromArea(fb);
+    auto featurePoint = MakePoint(fb);
     LayerBase::Handle(featurePoint);
   }
 }

--- a/generator/final_processor_intermediate_mwm.cpp
+++ b/generator/final_processor_intermediate_mwm.cpp
@@ -361,8 +361,10 @@ void CountryFinalProcessor::ProcessBooking()
           }
           else
           {
-            dataset.PreprocessMatchedOsmObject(
-                id, fb, [&](FeatureBuilder & newFeature) { writer.Write(newFeature); });
+            dataset.PreprocessMatchedOsmObject(id, fb, [&](FeatureBuilder & newFeature) {
+              if (newFeature.PreSerialize())
+                writer.Write(newFeature);
+            });
           }
         }
       });

--- a/generator/generator_tests/feature_builder_test.cpp
+++ b/generator/generator_tests/feature_builder_test.cpp
@@ -50,7 +50,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_ManyTypes)
   fb1.SetCenter(m2::PointD(0, 0));
 
   TEST(fb1.RemoveInvalidTypes(), ());
-  Check(fb1);
+  TEST(fb1.IsValid(), (fb1));
 
   FeatureBuilder::Buffer buffer;
   TEST(fb1.PreSerializeAndRemoveUselessNamesForIntermediate(), ());
@@ -59,7 +59,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_ManyTypes)
   FeatureBuilder fb2;
   fb2.DeserializeFromIntermediate(buffer);
 
-  Check(fb2);
+  TEST(fb2.IsValid(), (fb2));
   TEST_EQUAL(fb1, fb2, ());
   TEST_EQUAL(fb2.GetTypesCount(), 6, ());
 }
@@ -86,7 +86,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_LineTypes)
   fb1.SetLinear();
 
   TEST(fb1.RemoveInvalidTypes(), ());
-  Check(fb1);
+  TEST(fb1.IsValid(), (fb1));
 
   FeatureBuilder::Buffer buffer;
   TEST(fb1.PreSerializeAndRemoveUselessNamesForIntermediate(), ());
@@ -95,7 +95,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_LineTypes)
   FeatureBuilder fb2;
   fb2.DeserializeFromIntermediate(buffer);
 
-  Check(fb2);
+  TEST(fb2.IsValid(), (fb2));
   TEST_EQUAL(fb1, fb2, ());
   TEST_EQUAL(fb2.GetTypesCount(), 5, ());
 }
@@ -113,7 +113,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_Waterfall)
   fb1.SetCenter(m2::PointD(1, 1));
 
   TEST(fb1.RemoveInvalidTypes(), ());
-  Check(fb1);
+  TEST(fb1.IsValid(), (fb1));
 
   FeatureBuilder::Buffer buffer;
   TEST(fb1.PreSerializeAndRemoveUselessNamesForIntermediate(), ());
@@ -122,7 +122,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_Waterfall)
   FeatureBuilder fb2;
   fb2.DeserializeFromIntermediate(buffer);
 
-  Check(fb2);
+  TEST(fb2.IsValid(), (fb2));
   TEST_EQUAL(fb1, fb2, ());
   TEST_EQUAL(fb2.GetTypesCount(), 1, ());;
 }
@@ -196,7 +196,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_RemoveUselessNames)
   TEST(fb1.GetName(0).empty(), ());
   TEST(fb1.GetName(8).empty(), ());
 
-  Check(fb1);
+  TEST(fb1.IsValid(), (fb1));
 }
 
 UNIT_CLASS_TEST(TestWithClassificator, FeatureParams_Parsing)
@@ -250,7 +250,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeLocalityObjectFor
   fb.SetCenter(m2::PointD(10.1, 15.8));
 
   TEST(fb.RemoveInvalidTypes(), ());
-  Check(fb);
+  TEST(fb.IsValid(), (fb));
 
   feature::DataHeader header;
   header.SetGeometryCodingParams(serial::GeometryCodingParams());
@@ -286,7 +286,7 @@ UNIT_TEST(FeatureBuilder_SerializeAccuratelyForIntermediate)
   fb1.SetLinear();
 
   TEST(fb1.RemoveInvalidTypes(), ());
-  Check(fb1);
+  TEST(fb1.IsValid(), (fb1));
 
   FeatureBuilder::Buffer buffer;
   TEST(fb1.PreSerializeAndRemoveUselessNamesForIntermediate(), ());
@@ -295,6 +295,6 @@ UNIT_TEST(FeatureBuilder_SerializeAccuratelyForIntermediate)
   FeatureBuilder fb2;
   fb2.DeserializeAccuratelyFromIntermediate(buffer);
 
-  Check(fb2);
+  TEST(fb2.IsValid(), (fb2));
   TEST(fb1.IsExactEq(fb2), ());
 }

--- a/generator/generator_tests/place_processor_tests.cpp
+++ b/generator/generator_tests/place_processor_tests.cpp
@@ -173,7 +173,7 @@ UNIT_CLASS_TEST(TestPlaceProcessor, OnePlaceAreaTest)
   pp.Add(kArea);
 
   std::vector<generator::PlaceProcessor::PlaceWithIds> r{
-      {generator::MakePointFromArea(kArea), {kArea.GetMostGenericOsmId()}}};
+      {generator::MakePoint(kArea), {kArea.GetMostGenericOsmId()}}};
   Test(pp.ProcessPlaces(), r);
   TEST(TestTable(*table, {{{kArea.GetMostGenericOsmId()}, 1 /* cluster size */}}), ());
 }
@@ -210,7 +210,7 @@ UNIT_CLASS_TEST(TestPlaceProcessor, SameNamesButDifferentPlacesTest)
 
   std::vector<generator::PlaceProcessor::PlaceWithIds> r{
       {point, {point.GetMostGenericOsmId()}},
-      {generator::MakePointFromArea(kArea), {kArea.GetMostGenericOsmId()}}};
+      {generator::MakePoint(kArea), {kArea.GetMostGenericOsmId()}}};
   Test(pp.ProcessPlaces(), r);
   TEST(TestTable(*table, {{{kArea.GetMostGenericOsmId()}, 1 /* cluster size */}}), ());
 }

--- a/generator/place_processor.cpp
+++ b/generator/place_processor.cpp
@@ -197,7 +197,7 @@ std::vector<PlaceProcessor::PlaceWithIds> PlaceProcessor::ProcessPlaces()
       if (bestFb.IsArea() && localityChecker.GetType(GetPlaceType(bestFb)) != ftypes::LocalityType::None)
       {
         LOG(LWARNING, (bestFb, "is transforming to point."));
-        TransformAreaToPoint(bestFb);
+        TransformToPoint(bestFb);
       }
       std::vector<base::GeoObjectId> ids;
       ids.reserve(cluster.size());

--- a/generator/world_map_generator.hpp
+++ b/generator/world_map_generator.hpp
@@ -298,7 +298,7 @@ public:
       // because we do not need geometry for invisible features (just search index and placepage
       // data) and want to avoid size checks applied to areas.
       if (originalFeature.GetGeomType() != feature::GeomType::Point)
-        generator::TransformAreaToPoint(originalFeature);
+        generator::TransformToPoint(originalFeature);
 
       m_worldBucket.PushSure(originalFeature);
       return;

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -222,10 +222,7 @@ bool FeatureParamsBase::operator == (FeatureParamsBase const & rhs) const
 
 bool FeatureParamsBase::IsValid() const
 {
-   if (layer <= LAYER_LOW || layer >= LAYER_HIGH)
-     return false;
-
-   return true;
+  return layer > LAYER_LOW && layer < LAYER_HIGH;
 }
 
 string FeatureParamsBase::DebugString() const
@@ -399,6 +396,7 @@ void FeatureParams::SetGeomTypePointEx()
 
 feature::GeomType FeatureParams::GetGeomType() const
 {
+  CHECK(IsValid(), ());
   switch (m_geomType)
   {
   case HeaderGeomType::Line: return GeomType::Line;
@@ -409,6 +407,7 @@ feature::GeomType FeatureParams::GetGeomType() const
 
 HeaderGeomType FeatureParams::GetHeaderGeomType() const
 {
+  CHECK(IsValid(), ());
   return m_geomType;
 }
 

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -220,9 +220,11 @@ bool FeatureParamsBase::operator == (FeatureParamsBase const & rhs) const
           layer == rhs.layer && rank == rhs.rank);
 }
 
-bool FeatureParamsBase::CheckValid() const
+bool FeatureParamsBase::IsValid() const
 {
-   CHECK(layer > LAYER_LOW && layer < LAYER_HIGH, ());
+   if (layer <= LAYER_LOW || layer >= LAYER_HIGH)
+     return false;
+
    return true;
 }
 
@@ -397,7 +399,6 @@ void FeatureParams::SetGeomTypePointEx()
 
 feature::GeomType FeatureParams::GetGeomType() const
 {
-  CheckValid();
   switch (m_geomType)
   {
   case HeaderGeomType::Line: return GeomType::Line;
@@ -408,7 +409,6 @@ feature::GeomType FeatureParams::GetGeomType() const
 
 HeaderGeomType FeatureParams::GetHeaderGeomType() const
 {
-  CheckValid();
   return m_geomType;
 }
 
@@ -552,11 +552,12 @@ uint32_t FeatureParams::FindType(uint32_t comp, uint8_t level) const
   return ftype::GetEmptyValue();
 }
 
-bool FeatureParams::CheckValid() const
+bool FeatureParams::IsValid() const
 {
-  CHECK(!m_types.empty() && m_types.size() <= kMaxTypesCount, ());
+  if (m_types.empty() || m_types.size() > kMaxTypesCount)
+    return false;
 
-  return FeatureParamsBase::CheckValid();
+  return FeatureParamsBase::IsValid();
 }
 
 uint8_t FeatureParams::GetHeader() const

--- a/indexer/feature_data.hpp
+++ b/indexer/feature_data.hpp
@@ -145,7 +145,7 @@ struct FeatureParamsBase
 
   bool operator == (FeatureParamsBase const & rhs) const;
 
-  bool CheckValid() const;
+  bool IsValid() const;
   std::string DebugString() const;
 
   /// @return true if feature doesn't have any drawable strings (names, houses, etc).
@@ -258,7 +258,6 @@ public:
     m_reverseGeometry = rhs.m_reverseGeometry;
   }
 
-  bool IsValid() const { return !m_types.empty(); }
   void SetGeomType(feature::GeomType t);
   void SetGeomTypePointEx();
   feature::GeomType GetGeomType() const;
@@ -284,7 +283,7 @@ public:
   /// Find type that matches "comp" with "level" in classificator hierarchy.
   uint32_t FindType(uint32_t comp, uint8_t level) const;
 
-  bool CheckValid() const;
+  bool IsValid() const;
 
   uint8_t GetHeader() const;
 


### PR DESCRIPTION
Текущая сборка карт упала несколько раз, думаю что входные данные поменялись и это привело к падениям генератора.

вот фиксы :
1. [generator] Check -> IsValid: added more logging. Функция  Check вызывала падение, из за этого очень сложно было понять какой именно элемент вызвал ошибку, сейчас просто вернет бул, там где важно что бы фб была валидной есть CECK(fb.IsValid(), (fb));

2 .[generator] Fixed booking processing. Фикс падения при обработке букинга, с элемента удалился тэг отеля, а других типов у объекта не было, это вызвало падение.

3. [generator] Fixed wrong feature builder transformations. Changed functions for feature builder transformation. Изменены функции трансформации, после падения генрации world

