### PR TITLE
[generator] Fixes for hierarchy

### DIFF
--- a/generator/gen_mwm_info.cpp
+++ b/generator/gen_mwm_info.cpp
@@ -41,15 +41,15 @@ void OsmID2FeatureID::AddIds(CompositeId const & osmId, uint32_t featureId)
   m_data.emplace_back(osmId, featureId);
 }
 
-boost::optional<uint32_t> OsmID2FeatureID::GetFeatureId(CompositeId const & id) const
+std::vector<uint32_t> OsmID2FeatureID::GetFeatureIds(CompositeId const & id) const
 {
-  auto const it = std::lower_bound(std::cbegin(m_data), std::cend(m_data), id,
-                                   [](auto const & l, auto const & r) { return l.first < r; });
-  if (it == std::cend(m_data) || it->first != id)
-    return {};
+  std::vector<uint32_t> ids;
+  auto it = std::lower_bound(std::cbegin(m_data), std::cend(m_data), id,
+                             [](auto const & l, auto const & r) { return l.first < r; });
+  while (it != std::cend(m_data) && it->first == id)
+    ids.emplace_back((it++)->second);
 
-  CHECK_NOT_EQUAL(std::next(it)->first, id, (id));
-  return it->second;
+  return ids;
 }
 
 std::vector<uint32_t> OsmID2FeatureID::GetFeatureIds(base::GeoObjectId mainId) const

--- a/generator/gen_mwm_info.hpp
+++ b/generator/gen_mwm_info.hpp
@@ -37,7 +37,7 @@ public:
   bool ReadFromFile(std::string const & filename);
 
   void AddIds(CompositeId const & osmId, uint32_t featureId);
-  boost::optional<uint32_t> GetFeatureId(CompositeId const & id) const;
+  std::vector<uint32_t> GetFeatureIds(CompositeId const & id) const;
   std::vector<uint32_t> GetFeatureIds(base::GeoObjectId mainId) const;
 
   Version GetVersion() const;

--- a/generator/generator_tests/gen_mwm_info_tests.cpp
+++ b/generator/generator_tests/gen_mwm_info_tests.cpp
@@ -57,10 +57,28 @@ UNIT_TEST(OsmID2FeatureID_GetFeatureId)
     };
     TEST_EQUAL(mapping.GetFeatureIds(kCid1.m_additionalId), answer, ());
   }
-  TEST_EQUAL(*mapping.GetFeatureId(kCid1), kId1, ());
-  TEST_EQUAL(*mapping.GetFeatureId(kCid2), kId2, ());
-  TEST_EQUAL(*mapping.GetFeatureId(kCid3), kId3, ());
-  TEST(!mapping.GetFeatureId(generator::CompositeId(base::GeoObjectId())), ());
+  {
+    std::vector<uint32_t> const answer{
+        kId1,
+    };
+    TEST_EQUAL(mapping.GetFeatureIds(kCid1), answer, ());
+  }
+  {
+    std::vector<uint32_t> const answer{
+        kId2
+    };
+    TEST_EQUAL(mapping.GetFeatureIds(kCid3), answer, ());
+  }
+  {
+    std::vector<uint32_t> const answer{
+        kId3,
+    };
+    TEST_EQUAL(mapping.GetFeatureIds(kCid3), answer, ());
+  }
+  {
+    std::vector<uint32_t> const answer;
+    TEST_EQUAL(mapping.GetFeatureIds(generator::CompositeId(base::GeoObjectId())), answer, ());
+  }
 }
 
 UNIT_TEST(OsmID2FeatureID_ReadWrite)

--- a/generator/hierarchy.hpp
+++ b/generator/hierarchy.hpp
@@ -62,7 +62,6 @@ public:
   bool IsPoint() const { return m_isPoint; }
 
   bool Contains(HierarchyPlace const & smaller) const;
-  bool IsEqualGeometry(HierarchyPlace const & other) const;
 
 private:
   bool Contains(m2::PointD const & point) const;


### PR DESCRIPTION
Когда генерил иерахию для популярити столкнулся с некоторыми пролбемами:

[generator] Fixes cyclic connections. 
Испправляет циклические связи, раньше две геометрии проврялись на строгую вложенность, теперь дупоскается погрешность, из за этого проверки IsEqualGeometry теперь недостаточно.

[generator] Fixed GetFeatureId(CompositeId const & id).
Для элемента с одним CompositeId может найтись несколько фичей, самый простой пример: для замкнутого way который мы хотим нарисовать залитым и с обводкой, придется добавить две фичи с типами Area и Line