### PR TITLE
[routing] Add benchmark modes for routing tools

### DIFF
--- a/routing/routes_builder/routes_builder.cpp
+++ b/routing/routes_builder/routes_builder.cpp
@@ -298,8 +298,7 @@ RoutesBuilder::Processor::operator()(Params const & params)
   CHECK(m_dataSource, ());
 
   double timeSum = 0;
-  size_t numberOfBuilds = params.m_benchmarkMode ? 3 : 1;
-  for (size_t i = 0; i < numberOfBuilds; ++i)
+  for (size_t i = 0; i < params.m_lounchesNumber; ++i)
   {
     m_delegate->SetTimeout(params.m_timeoutSeconds);
     base::Timer timer;
@@ -315,7 +314,7 @@ RoutesBuilder::Processor::operator()(Params const & params)
   Result result;
   result.m_params.m_checkpoints = params.m_checkpoints;
   result.m_code = resultCode;
-  result.m_buildTimeSeconds = timeSum / static_cast<double>(numberOfBuilds);
+  result.m_buildTimeSeconds = timeSum / static_cast<double>(params.m_lounchesNumber);
 
   RoutesBuilder::Route routeResult;
   routeResult.m_distance = route.GetTotalDistanceMeters();

--- a/routing/routes_builder/routes_builder.cpp
+++ b/routing/routes_builder/routes_builder.cpp
@@ -90,8 +90,7 @@ RoutesBuilder & RoutesBuilder::GetSimpleRoutesBuilder()
   static RoutesBuilder routesBuilder(1 /* threadsNumber */);
   return routesBuilder;
 }
-RoutesBuilder::RoutesBuilder(size_t threadsNumber)
-    : m_threadPool(threadsNumber)
+RoutesBuilder::RoutesBuilder(size_t threadsNumber) : m_threadPool(threadsNumber)
 {
   CHECK_GREATER(threadsNumber, 0, ());
   LOG(LINFO, ("Threads number:", threadsNumber));
@@ -297,7 +296,7 @@ RoutesBuilder::Processor::operator()(Params const & params)
 
   CHECK(m_dataSource, ());
 
-  double timeSum = 0;
+  double timeSum = 0.0;
   for (size_t i = 0; i < params.m_launchesNumber; ++i)
   {
     m_delegate->SetTimeout(params.m_timeoutSeconds);

--- a/routing/routes_builder/routes_builder.cpp
+++ b/routing/routes_builder/routes_builder.cpp
@@ -298,7 +298,7 @@ RoutesBuilder::Processor::operator()(Params const & params)
   CHECK(m_dataSource, ());
 
   double timeSum = 0;
-  for (size_t i = 0; i < params.m_lounchesNumber; ++i)
+  for (size_t i = 0; i < params.m_launchesNumber; ++i)
   {
     m_delegate->SetTimeout(params.m_timeoutSeconds);
     base::Timer timer;
@@ -314,7 +314,7 @@ RoutesBuilder::Processor::operator()(Params const & params)
   Result result;
   result.m_params.m_checkpoints = params.m_checkpoints;
   result.m_code = resultCode;
-  result.m_buildTimeSeconds = timeSum / static_cast<double>(params.m_lounchesNumber);
+  result.m_buildTimeSeconds = timeSum / static_cast<double>(params.m_launchesNumber);
 
   RoutesBuilder::Route routeResult;
   routeResult.m_distance = route.GetTotalDistanceMeters();

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -62,7 +62,7 @@ public:
     VehicleType m_type = VehicleType::Car;
     Checkpoints m_checkpoints;
     uint32_t m_timeoutSeconds = RouterDelegate::kNoTimeout;
-    uint32_t m_lounchesNumber = 1;
+    uint32_t m_launchesNumber = 1;
   };
 
   struct Route

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -62,7 +62,7 @@ public:
     VehicleType m_type = VehicleType::Car;
     Checkpoints m_checkpoints;
     uint32_t m_timeoutSeconds = RouterDelegate::kNoTimeout;
-    bool m_benchmarkMode = false;
+    uint32_t m_lounchesNumber = 1;
   };
 
   struct Route

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -62,6 +62,7 @@ public:
     VehicleType m_type = VehicleType::Car;
     Checkpoints m_checkpoints;
     uint32_t m_timeoutSeconds = RouterDelegate::kNoTimeout;
+    bool m_benchmarkMode = false;
   };
 
   struct Route
@@ -92,6 +93,7 @@ public:
     RouterResultCode m_code = RouterResultCode::RouteNotFound;
     Params m_params;
     std::vector<Route> m_routes;
+    double m_buildTimeSeconds;
   };
 
   Result ProcessTask(Params const & params);

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -93,7 +93,7 @@ public:
     RouterResultCode m_code = RouterResultCode::RouteNotFound;
     Params m_params;
     std::vector<Route> m_routes;
-    double m_buildTimeSeconds;
+    double m_buildTimeSeconds = 0.0;
   };
 
   Result ProcessTask(Params const & params);

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -103,7 +103,7 @@ int Main(int argc, char ** argv)
     if (launchesNumber > 1)
     {
       LOG(LINFO,
-          ("Benchmark mode is activated. Each route will be build", launchesNumber, "times."));
+          ("Benchmark mode is activated. Each route will be built", launchesNumber, "times."));
     }
 
     BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout,

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -38,7 +38,8 @@ DEFINE_int32(timeout, 10 * 60, "Timeout in seconds for each route building. "
                                "0 means without timeout (default: 10 minutes).");
 
 DEFINE_bool(verbose, false, "Verbose logging (default: false)");
-DEFINE_bool(benchmark, false, "Builds each route 3 times and averages the time building.");
+
+DEFINE_int32(lounches_number, 1, "Number of lounches of routes buildings. Needs for benchmarking (default: 1)");
 
 using namespace routing;
 using namespace routes_builder;
@@ -89,6 +90,8 @@ int Main(int argc, char ** argv)
         ("\n\n\t--dump_path is empty. It makes no sense to run this tool. No result will be saved.",
          "\n\nType --help for usage."));
 
+  CHECK_GREATER_OR_EQUAL(FLAGS_lounches_number, 1, ());
+
   if (Platform::IsFileExistsByFullPath(FLAGS_dump_path))
     CheckDirExistence(FLAGS_dump_path);
   else
@@ -96,10 +99,15 @@ int Main(int argc, char ** argv)
 
   if (IsLocalBuild())
   {
-    if (FLAGS_benchmark)
-      LOG(LINFO, ("Benchmark mode is activated. Each route will build 3 times."));
+    auto const lunchesNumber = static_cast<uint32_t>(FLAGS_lounches_number);
+    if (lunchesNumber > 1)
+    {
+      LOG(LINFO,
+          ("Benchmark mode is activated. Each route will be build", lunchesNumber, " times."));
+    }
+
     BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout,
-                FLAGS_verbose, FLAGS_benchmark);
+                FLAGS_verbose, lunchesNumber);
   }
 
   if (IsApiBuild())

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -39,7 +39,7 @@ DEFINE_int32(timeout, 10 * 60, "Timeout in seconds for each route building. "
 
 DEFINE_bool(verbose, false, "Verbose logging (default: false)");
 
-DEFINE_int32(lounches_number, 1, "Number of lounches of routes buildings. Needs for benchmarking (default: 1)");
+DEFINE_int32(launches_number, 1, "Number of launches of routes buildings. Needs for benchmarking (default: 1)");
 
 using namespace routing;
 using namespace routes_builder;
@@ -90,7 +90,7 @@ int Main(int argc, char ** argv)
         ("\n\n\t--dump_path is empty. It makes no sense to run this tool. No result will be saved.",
          "\n\nType --help for usage."));
 
-  CHECK_GREATER_OR_EQUAL(FLAGS_lounches_number, 1, ());
+  CHECK_GREATER_OR_EQUAL(FLAGS_launches_number, 1, ());
 
   if (Platform::IsFileExistsByFullPath(FLAGS_dump_path))
     CheckDirExistence(FLAGS_dump_path);
@@ -99,15 +99,15 @@ int Main(int argc, char ** argv)
 
   if (IsLocalBuild())
   {
-    auto const lunchesNumber = static_cast<uint32_t>(FLAGS_lounches_number);
-    if (lunchesNumber > 1)
+    auto const launchesNumber = static_cast<uint32_t>(FLAGS_launches_number);
+    if (launchesNumber > 1)
     {
       LOG(LINFO,
-          ("Benchmark mode is activated. Each route will be build", lunchesNumber, " times."));
+          ("Benchmark mode is activated. Each route will be build", launchesNumber, "times."));
     }
 
     BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout,
-                FLAGS_verbose, lunchesNumber);
+                FLAGS_verbose, launchesNumber);
   }
 
   if (IsApiBuild())

--- a/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
+++ b/routing/routes_builder/routes_builder_tool/routes_builder_tool.cpp
@@ -38,6 +38,7 @@ DEFINE_int32(timeout, 10 * 60, "Timeout in seconds for each route building. "
                                "0 means without timeout (default: 10 minutes).");
 
 DEFINE_bool(verbose, false, "Verbose logging (default: false)");
+DEFINE_bool(benchmark, false, "Builds each route 3 times and averages the time building.");
 
 using namespace routing;
 using namespace routes_builder;
@@ -95,8 +96,10 @@ int Main(int argc, char ** argv)
 
   if (IsLocalBuild())
   {
-    BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout, 
-                FLAGS_verbose);
+    if (FLAGS_benchmark)
+      LOG(LINFO, ("Benchmark mode is activated. Each route will build 3 times."));
+    BuildRoutes(FLAGS_routes_file, FLAGS_dump_path, FLAGS_start_from, FLAGS_threads, FLAGS_timeout,
+                FLAGS_verbose, FLAGS_benchmark);
   }
 
   if (IsApiBuild())

--- a/routing/routes_builder/routes_builder_tool/utils.cpp
+++ b/routing/routes_builder/routes_builder_tool/utils.cpp
@@ -54,7 +54,7 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
                  bool verbose,
-                 bool benchmarkMode)
+                 uint32_t lunchesNumber)
 {
   CHECK(Platform::IsFileExistsByFullPath(routesPath), ("Can not find file:", routesPath));
   CHECK(!dumpPath.empty(), ("Empty dumpPath."));
@@ -77,7 +77,7 @@ void BuildRoutes(std::string const & routesPath,
     RoutesBuilder::Params params;
     params.m_type = VehicleType::Car;
     params.m_timeoutSeconds = timeoutPerRouteSeconds;
-    params.m_benchmarkMode = benchmarkMode;
+    params.m_lounchesNumber = lunchesNumber;
 
     base::ScopedLogLevelChanger changer(verbose ? base::LogLevel::LINFO : base::LogLevel::LERROR);
     ms::LatLon start;

--- a/routing/routes_builder/routes_builder_tool/utils.cpp
+++ b/routing/routes_builder/routes_builder_tool/utils.cpp
@@ -54,7 +54,7 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
                  bool verbose,
-                 uint32_t lunchesNumber)
+                 uint32_t launchesNumber)
 {
   CHECK(Platform::IsFileExistsByFullPath(routesPath), ("Can not find file:", routesPath));
   CHECK(!dumpPath.empty(), ("Empty dumpPath."));
@@ -77,7 +77,7 @@ void BuildRoutes(std::string const & routesPath,
     RoutesBuilder::Params params;
     params.m_type = VehicleType::Car;
     params.m_timeoutSeconds = timeoutPerRouteSeconds;
-    params.m_lounchesNumber = lunchesNumber;
+    params.m_launchesNumber = launchesNumber;
 
     base::ScopedLogLevelChanger changer(verbose ? base::LogLevel::LINFO : base::LogLevel::LERROR);
     ms::LatLon start;

--- a/routing/routes_builder/routes_builder_tool/utils.cpp
+++ b/routing/routes_builder/routes_builder_tool/utils.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <fstream>
 #include <future>
 #include <iostream>
 #include <thread>
@@ -54,7 +53,8 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t startFrom,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
-                 bool verbose)
+                 bool verbose,
+                 bool benchmarkMode)
 {
   CHECK(Platform::IsFileExistsByFullPath(routesPath), ("Can not find file:", routesPath));
   CHECK(!dumpPath.empty(), ("Empty dumpPath."));
@@ -77,6 +77,7 @@ void BuildRoutes(std::string const & routesPath,
     RoutesBuilder::Params params;
     params.m_type = VehicleType::Car;
     params.m_timeoutSeconds = timeoutPerRouteSeconds;
+    params.m_benchmarkMode = benchmarkMode;
 
     base::ScopedLogLevelChanger changer(verbose ? base::LogLevel::LINFO : base::LogLevel::LERROR);
     ms::LatLon start;
@@ -98,6 +99,7 @@ void BuildRoutes(std::string const & routesPath,
     }
 
     LOG_FORCE(LINFO, ("Created:", tasks.size(), "tasks"));
+    base::Timer timer;
     for (size_t i = 0; i < tasks.size(); ++i)
     {
       size_t shiftIndex = i + startFrom;
@@ -122,6 +124,7 @@ void BuildRoutes(std::string const & routesPath,
         LOG_FORCE(LINFO, ("Progress:", lastPercent, "%"));
       }
     }
+    LOG_FORCE(LINFO, ("BuildRoutes() took:", timer.ElapsedSeconds(), "seconds."));
   }
 }
 

--- a/routing/routes_builder/routes_builder_tool/utils.hpp
+++ b/routing/routes_builder/routes_builder_tool/utils.hpp
@@ -18,7 +18,8 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t startFrom,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
-                 bool verbose);
+                 bool verbose,
+                 bool benchmarkMode);
 
 void BuildRoutesWithApi(std::unique_ptr<routing_quality::api::RoutingApi> routingApi,
                         std::string const & routesPath,

--- a/routing/routes_builder/routes_builder_tool/utils.hpp
+++ b/routing/routes_builder/routes_builder_tool/utils.hpp
@@ -19,7 +19,7 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
                  bool verbose,
-                 bool benchmarkMode);
+                 uint32_t launchNumber);
 
 void BuildRoutesWithApi(std::unique_ptr<routing_quality::api::RoutingApi> routingApi,
                         std::string const & routesPath,

--- a/routing/routes_builder/routes_builder_tool/utils.hpp
+++ b/routing/routes_builder/routes_builder_tool/utils.hpp
@@ -19,7 +19,7 @@ void BuildRoutes(std::string const & routesPath,
                  uint64_t threadsNumber,
                  uint32_t timeoutPerRouteSeconds,
                  bool verbose,
-                 uint32_t launchNumber);
+                 uint32_t launchesNumber);
 
 void BuildRoutesWithApi(std::unique_ptr<routing_quality::api::RoutingApi> routingApi,
                         std::string const & routesPath,

--- a/routing/routing_quality/routing_quality_tool/utils.hpp
+++ b/routing/routing_quality/routing_quality_tool/utils.hpp
@@ -170,7 +170,18 @@ private:
   std::vector<Item> m_routesCounter;
 };
 
-void CreatePythonScriptForDistribution(std::string const & targetDir, std::string const & filename,
-                                       std::vector<Result> const & results);
+void CreatePythonScriptForDistribution(std::string const & pythonScriptPath,
+                                       std::string const & title,
+                                       std::vector<double> const & values);
+
+void CreatePythonGraphByPointsXY(std::string const & pythonScriptPath,
+                                 std::string const & xlabel,
+                                 std::string const & ylabel,
+                                 std::vector<m2::PointD> const & points);
+
+void CreatePythonBarByMap(std::string const & pythonScriptPath,
+                          std::map<std::string, size_t> const & stat,
+                          std::string const & xlabel,
+                          std::string const & ylabel);
 }  // namespace routing_quality_tool
 }  // namespace routing_quality

--- a/routing/routing_quality/routing_quality_tool/utils.hpp
+++ b/routing/routing_quality/routing_quality_tool/utils.hpp
@@ -179,6 +179,8 @@ void CreatePythonGraphByPointsXY(std::string const & pythonScriptPath,
                                  std::string const & ylabel,
                                  std::vector<m2::PointD> const & points);
 
+/// \brief Create python file, that show bar graph, where labels of bars are keys of |stat| and
+/// heights area values of |stat|.
 void CreatePythonBarByMap(std::string const & pythonScriptPath,
                           std::map<std::string, size_t> const & stat,
                           std::string const & xlabel,


### PR DESCRIPTION
Добавляется функционал для бенчмарков, если к routes_builder_tool добавить `--benchmark`, то каждый маршрут построится 3 раза, и сдампится усредненный результат

routing_quality_tool в свою очередь умеет парсить это и выводить всякие статистики через питоновские скрипты:
Пример вывода:
```sh
LOG TID(1) INFO   2.0328e-05 routing_quality_tool/routing_quality_tool.cpp:253 Main() Start loading mapsme results.
LOG TID(1) INFO  0.000492419 routing_quality_tool/utils.hpp:50 LoadResults() Progress: 100 %
LOG TID(1) INFO   0.00464218 routing_quality_tool/routing_quality_tool.cpp:255 Main() Receive: 1 routes from --mapsme_results.
LOG TID(1) INFO   0.00465548 routing_quality_tool/routing_quality_tool.cpp:273 Main() Running in benchmark stat mode.
LOG TID(1) INFO    0.0209546 routing_quality_tool/utils.cpp:250 CreatePythonScriptForDistribution() Run: python ../../tmp/tmp/show_route_time_building_dist.py to look at: Route building time
LOG TID(1) INFO    0.0210361 routing_quality_tool/utils.cpp:293 CreatePythonGraphByPointsXY() Run: python ../../tmp/tmp/show_len_time_graph.py to look at: Building time versus Distance
LOG TID(1) INFO    0.0210623 routing_quality_tool/routing_quality_tool.cpp:199 RunBenchmarkStat() Average route time building: 25.2978 seconds.
LOG TID(1) INFO    0.0210993 routing_quality_tool/utils.cpp:293 CreatePythonGraphByPointsXY() Run: python ../../tmp/tmp/show_time_count_graph.py to look at: Percent of routes builded less than versus Building time
```
Примеры питоновский скриптов: https://confluence.mail.ru/display/MAPSME/MAPS.ME+Router+on+server