### PR TITLE
[routing] Add junction visitor

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -69,6 +69,7 @@ set(
   joint_index.hpp
   joint_segment.cpp
   joint_segment.hpp
+  junction_visitor.hpp
   leaps_postprocessor.cpp
   leaps_postprocessor.hpp
   loaded_path_segment.hpp

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <queue>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -557,7 +557,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
     JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
     RoutingResult<JointSegment, RouteWeight> routingResult;
 
-    using Visitor = JunctionVisitor<JointSegment, JointsStarter>;
+    using Visitor = JunctionVisitor<JointsStarter>;
     Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);
 
     using Vertex = JointsStarter::Vertex;
@@ -591,7 +591,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
       progress->AppendSubProgress(leapsProgress);
     }
 
-    using Visitor = JunctionVisitor<Segment, IndexGraphStarter>;
+    using Visitor = JunctionVisitor<IndexGraphStarter>;
     auto const visitPeriod =
         mode == WorldGraphMode::LeapsOnly ? kVisitPeriodForLeaps : kVisitPeriod;
     Visitor visitor(starter, delegate, visitPeriod, progress);
@@ -677,7 +677,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
                            EdgeEstimator::Purpose::Weight));
   }
 
-  using Visitor = JunctionVisitor<Segment, IndexGraphStarter>;
+  using Visitor = JunctionVisitor<IndexGraphStarter>;
   Visitor visitor(starter, delegate, kVisitPeriod);
 
   using Vertex = IndexGraphStarter::Vertex;
@@ -996,8 +996,8 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
     return RouterResultCode::NoError;
   }
 
+  CHECK(progress, ());
   SCOPE_GUARD(progressGuard, [&progress]() {
-    CHECK(progress, ());
     progress->PushAndDropLastSubProgress();
   });
 
@@ -1092,7 +1092,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
         progress->DropLastSubProgress();
     });
 
-    using Visitor = JunctionVisitor<JointSegment, JointsStarter>;
+    using Visitor = JunctionVisitor<JointsStarter>;
     Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);
 
     AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -543,6 +543,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
                                                 IndexGraphStarter & starter,
                                                 vector<Segment> & subroute)
 {
+  CHECK(progress, ());
   subroute.clear();
 
   SetupAlgorithmMode(starter);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -543,7 +543,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
                                                 IndexGraphStarter & starter,
                                                 vector<Segment> & subroute)
 {
-  CHECK(progress, ());
+  CHECK(progress, (checkpoints));
   subroute.clear();
 
   SetupAlgorithmMode(starter);
@@ -997,6 +997,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
   }
 
   SCOPE_GUARD(progressGuard, [&progress]() {
+    CHECK(progress, ());
     progress->PushAndDropLastSubProgress();
   });
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -99,7 +99,8 @@ private:
                                     m2::PointD const & startDirection,
                                     RouterDelegate const & delegate, Route & route);
   RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
-                                     RouterDelegate const & delegate, AStarProgress & progress,
+                                     RouterDelegate const & delegate,
+                                     std::shared_ptr<AStarProgress> const & progress,
                                      IndexGraphStarter & graph, std::vector<Segment> & subroute);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints,
@@ -150,7 +151,8 @@ private:
   // ProcessLeaps replaces each leap with calculated route through mwm.
   RouterResultCode ProcessLeapsJoints(std::vector<Segment> const & input,
                                       RouterDelegate const & delegate, WorldGraphMode prevMode,
-                                      IndexGraphStarter & starter, AStarProgress & progress,
+                                      IndexGraphStarter & starter,
+                                      std::shared_ptr<AStarProgress> const & progress,
                                       std::vector<Segment> & output);
   RouterResultCode RedressRoute(std::vector<Segment> const & segments,
                                 base::Cancellable const & cancellable, IndexGraphStarter & starter,
@@ -179,9 +181,9 @@ private:
     UNREACHABLE();
   }
 
-  template <typename Vertex, typename Edge, typename Weight>
+  template <typename Vertex, typename Edge, typename Weight, typename AStarParams>
   RouterResultCode FindPath(
-      typename AStarAlgorithm<Vertex, Edge, Weight>::Params & params, std::set<NumMwmId> const & mwmIds,
+      AStarParams & params, std::set<NumMwmId> const & mwmIds,
       RoutingResult<Vertex, Weight> & routingResult, WorldGraphMode mode) const
   {
     AStarAlgorithm<Vertex, Edge, Weight> algorithm;

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "routing/base/astar_progress.hpp"
+
+#include "routing/router_delegate.hpp"
+
+#include <cstdint>
+#include <memory>
+
+namespace routing
+{
+double constexpr kProgressInterval = 0.5;
+
+template <typename Vertex, typename Graph>
+class JunctionVisitor
+{
+public:
+  explicit JunctionVisitor(Graph & graph, RouterDelegate const & delegate, uint32_t visitPeriod,
+                           std::shared_ptr<AStarProgress> const & progress = nullptr)
+    : m_graph(graph), m_delegate(delegate), m_visitPeriod(visitPeriod), m_progress(progress)
+  {
+    if (progress)
+      m_lastProgressPercent = progress->GetLastPercent();
+  }
+
+  void operator()(Vertex const & from, Vertex const & to)
+  {
+    ++m_visitCounter;
+    if (m_visitCounter % m_visitPeriod != 0)
+      return;
+
+    m2::PointD const & pointFrom = m_graph.GetPoint(from, true /* front */);
+    m_delegate.OnPointCheck(pointFrom);
+
+    auto progress = m_progress.lock();
+    if (!progress)
+      return;
+
+    m2::PointD const & pointTo = m_graph.GetPoint(to, true /* front */);
+    auto const currentPercent = progress->UpdateProgress(pointFrom, pointTo);
+    if (currentPercent - m_lastProgressPercent > kProgressInterval)
+    {
+      m_lastProgressPercent = currentPercent;
+      m_delegate.OnProgress(currentPercent);
+    }
+  }
+
+private:
+  Graph & m_graph;
+  RouterDelegate const & m_delegate;
+  uint32_t m_visitCounter = 0;
+  uint32_t m_visitPeriod;
+  std::weak_ptr<AStarProgress> m_progress;
+  double m_lastProgressPercent = 0.0;
+};
+}  // namespace routing

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -13,12 +13,14 @@ namespace routing
 {
 double constexpr kProgressInterval = 0.5;
 
-template <typename Vertex, typename Graph>
+template <typename Graph>
 class JunctionVisitor
 {
 public:
-  explicit JunctionVisitor(Graph & graph, RouterDelegate const & delegate, uint32_t visitPeriod,
-                           std::shared_ptr<AStarProgress> const & progress = nullptr)
+  using Vertex = typename Graph::Vertex;
+
+  JunctionVisitor(Graph & graph, RouterDelegate const & delegate, uint32_t visitPeriod,
+                  std::shared_ptr<AStarProgress> const & progress = nullptr)
     : m_graph(graph), m_delegate(delegate), m_visitPeriod(visitPeriod), m_progress(progress)
   {
     if (progress)

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -4,6 +4,8 @@
 
 #include "routing/router_delegate.hpp"
 
+#include "geometry/point2d.hpp"
+
 #include <cstdint>
 #include <memory>
 

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -205,4 +205,24 @@ bool RectCoversPolyline(IRoadGraph::JunctionVec const & junctions, m2::RectD con
 
   return false;
 }
+
+// AStarLengthChecker ------------------------------------------------------------------------------
+
+AStarLengthChecker::AStarLengthChecker(IndexGraphStarter & starter) : m_starter(starter) {}
+
+bool AStarLengthChecker::operator()(RouteWeight const & weight) const
+{
+  return m_starter.CheckLength(weight);
+}
+
+// AdjustLengthChecker -----------------------------------------------------------------------------
+
+AdjustLengthChecker::AdjustLengthChecker(IndexGraphStarter & starter) : m_starter(starter) {}
+
+bool AdjustLengthChecker::operator()(RouteWeight const & weight) const
+{
+  // Limit of adjust in seconds.
+  double constexpr kAdjustLimitSec = 5 * 60;
+  return weight <= RouteWeight(kAdjustLimitSec) && m_starter.CheckLength(weight);
+}
 }  // namespace routing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -4,6 +4,7 @@
 #include "routing/index_road_graph.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route.hpp"
+#include "routing/route_weight.hpp"
 #include "routing/traffic_stash.hpp"
 
 #include "traffic/traffic_info.hpp"
@@ -104,6 +105,8 @@ bool CheckGraphConnectivity(typename Graph::Vertex const & start, bool isOutgoin
 
   return marked.size() >= limit;
 }
+
+class IndexGraphStarter;
 
 struct AStarLengthChecker
 {

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -104,4 +104,18 @@ bool CheckGraphConnectivity(typename Graph::Vertex const & start, bool isOutgoin
 
   return marked.size() >= limit;
 }
+
+struct AStarLengthChecker
+{
+  explicit AStarLengthChecker(IndexGraphStarter & starter);
+  bool operator()(RouteWeight const & weight) const;
+  IndexGraphStarter & m_starter;
+};
+
+struct AdjustLengthChecker
+{
+  explicit AdjustLengthChecker(IndexGraphStarter & starter);
+  bool operator()(RouteWeight const & weight) const;
+  IndexGraphStarter & m_starter;
+};
 }  // namespace routing

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -121,7 +121,7 @@ UNIT_TEST(AdjustRouteNoPath)
   auto checkLength = [](double weight) { return weight <= 1.0; };
   Algorithm algo;
   Algorithm::ParamsForTests<decltype(checkLength)> params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                                    move(checkLength));
+                                     move(checkLength));
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -22,8 +22,8 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 {
   Algorithm algo;
 
-  Algorithm::ParamsForTests params(graph, 0u /* startVertex */, 4u /* finishVertex */,
-                                    nullptr /* prevRoute */, {} /* checkLengthCallback */);
+  Algorithm::ParamsForTests<> params(graph, 0u /* startVertex */, 4u /* finishVertex */,
+                                     nullptr /* prevRoute */);
 
   RoutingResult<unsigned /* Vertex */, double /* Weight */> actualRoute;
   TEST_EQUAL(Algorithm::Result::OK, algo.FindPath(params, actualRoute), ());
@@ -63,10 +63,12 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   graph.AddEdge(2, 4, 10);
   graph.AddEdge(3, 4, 3);
 
+  auto checkLength = [](double weight) { return weight < 23; };
   Algorithm algo;
-  Algorithm::ParamsForTests params(graph, 0u /* startVertex */, 4u /* finishVertex */,
-                                    nullptr /* prevRoute */,
-                                    [](double weight) { return weight < 23; });
+  Algorithm::ParamsForTests<decltype(checkLength)> params(
+      graph, 0u /* startVertex */, 4u /* finishVertex */, nullptr /* prevRoute */,
+      move(checkLength));
+
   RoutingResult<unsigned /* Vertex */, double /* Weight */> routingResult;
   Algorithm::Result result = algo.FindPath(params, routingResult);
   // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
@@ -92,9 +94,11 @@ UNIT_TEST(AdjustRoute)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
+  auto checkLength = [](double weight) { return weight <= 1.0; };
   Algorithm algo;
-  Algorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                                    [](double weight) { return weight <= 1.0; });
+  Algorithm::ParamsForTests<decltype(checkLength)> params(
+      graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute, move(checkLength));
+
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 
@@ -114,9 +118,10 @@ UNIT_TEST(AdjustRouteNoPath)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
+  auto checkLength = [](double weight) { return weight <= 1.0; };
   Algorithm algo;
-  Algorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                                    [](double weight) { return weight <= 1.0; });
+  Algorithm::ParamsForTests<decltype(checkLength)> params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
+                                    move(checkLength));
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 
@@ -136,9 +141,11 @@ UNIT_TEST(AdjustRouteOutOfLimit)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
+  auto checkLength = [](double weight) { return weight <= 1.0; };
   Algorithm algo;
-  Algorithm::ParamsForTests params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
-                                    [](double weight) { return weight <= 1.0; });
+  Algorithm::ParamsForTests<decltype(checkLength)> params(
+      graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute, move(checkLength));
+
   RoutingResult<unsigned /* Vertex */, double /* Weight */> result;
   auto const code = algo.AdjustRoute(params, result);
 

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -6,7 +6,7 @@
 
 #include "routing/base/routing_result.hpp"
 
-#include "testing/testing.hpp"
+#include "routing/routing_helpers.hpp"
 
 #include "base/assert.hpp"
 #include "base/math.hpp"
@@ -81,9 +81,8 @@ void NoUTurnRestrictionTest::TestRouteGeom(Segment const & start, Segment const 
                                            vector<m2::PointD> const & expectedRouteGeom)
 {
   AlgorithmForWorldGraph algorithm;
-  AlgorithmForWorldGraph::ParamsForTests params(*m_graph, start, finish,
-                                                nullptr /* prevRoute */,
-                                                {} /* checkLengthCallback */);
+  AlgorithmForWorldGraph::ParamsForTests<> params(*m_graph, start, finish,
+                                                  nullptr /* prevRoute */);
 
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
@@ -229,9 +228,8 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
 
   WorldGraphForAStar graphForAStar(move(worldGraph));
 
-  AlgorithmForWorldGraph::ParamsForTests params(graphForAStar, startSegment, finishSegment,
-                                                nullptr /* prevRoute */,
-                                                {} /* checkLengthCallback */);
+  AlgorithmForWorldGraph::ParamsForTests<> params(graphForAStar, startSegment, finishSegment,
+                                                  nullptr /* prevRoute */);
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 
@@ -408,9 +406,9 @@ AlgorithmForWorldGraph::Result CalculateRoute(IndexGraphStarter & starter, vecto
   AlgorithmForWorldGraph algorithm;
   RoutingResult<Segment, RouteWeight> routingResult;
 
-  AlgorithmForWorldGraph::ParamsForTests params(
+  AlgorithmForWorldGraph::ParamsForTests<AStarLengthChecker> params(
       starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
-      [&](RouteWeight const & weight) { return starter.CheckLength(weight); });
+      AStarLengthChecker(starter));
 
   auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
 

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -193,9 +193,9 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
 {
   RoadGraph roadGraph(graph);
   base::Cancellable cancellable;
-  Algorithm::Params params(roadGraph, startPos, finalPos, {} /* prevRoute */,
-                           cancellable, {} /* onVisitJunctionFn */,
-                           {} /* checkLength */);
+  Algorithm::Params<> params(roadGraph, startPos, finalPos, {} /* prevRoute */,
+                             cancellable);
+
   Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
   return Convert(res);
 }


### PR DESCRIPTION
В коде много повторяющихся частей, типа:
```cpp
uint32_t visitCount = 0;
double lastValue = progress.GetLastPercent();
auto const onVisitJunctionJoints = [&](JointSegment const & from, JointSegment const & to)
{
  ++visitCount;
  if (visitCount % kVisitPeriod != 0)
    return;

  m2::PointD const & pointFrom = jointStarter.GetPoint(from, true /* front */);
  m2::PointD const & pointTo = jointStarter.GetPoint(to, true /* front */);
  auto const newValue = progress.UpdateProgress(pointFrom, pointTo);
  if (newValue - lastValue > kProgressInterval)
  {
    lastValue = newValue;
    delegate.OnProgress(newValue);
  }

  delegate.OnPointCheck(pointFrom);
};
```
Вынес эту логику в JunctionVisitor