### PR TITLE
[generator] Create IntermediateDataReaderInterface

### DIFF
--- a/generator/collector_camera.cpp
+++ b/generator/collector_camera.cpp
@@ -129,8 +129,8 @@ void CameraProcessor::Merge(CameraProcessor const & cameraProcessor)
 CameraCollector::CameraCollector(std::string const & filename) :
   generator::CollectorInterface(filename), m_processor(GetTmpFilename()) {}
 
-std::shared_ptr<generator::CollectorInterface>
-CameraCollector::Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const &) const
+std::shared_ptr<generator::CollectorInterface> CameraCollector::Clone(
+    std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<CameraCollector>(GetFilename());
 }

--- a/generator/collector_camera.hpp
+++ b/generator/collector_camera.hpp
@@ -22,7 +22,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 }  // namespace generator
 
@@ -91,8 +91,9 @@ public:
   explicit CameraCollector(std::string const & filename);
 
   // generator::CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & = {})
+      const override;
   // We will process all nodes before ways because of o5m format:
   // all nodes are first, then all ways, then all relations.
   void CollectFeature(feature::FeatureBuilder const & feature, OsmElement const & element) override;

--- a/generator/collector_city_area.cpp
+++ b/generator/collector_city_area.cpp
@@ -23,8 +23,8 @@ CityAreaCollector::CityAreaCollector(std::string const & filename)
   : CollectorInterface(filename),
     m_writer(std::make_unique<FeatureBuilderWriter<MaxAccuracy>>(GetTmpFilename())) {}
 
-std::shared_ptr<CollectorInterface>
-CityAreaCollector::Clone(std::shared_ptr<cache::IntermediateDataReader> const &) const
+std::shared_ptr<CollectorInterface> CityAreaCollector::Clone(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<CityAreaCollector>(GetFilename());
 }

--- a/generator/collector_city_area.hpp
+++ b/generator/collector_city_area.hpp
@@ -9,7 +9,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 class CityAreaCollector : public CollectorInterface
@@ -18,8 +18,8 @@ public:
   explicit CityAreaCollector(std::string const & filename);
 
   // CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & = {}) const override;
 
   void CollectFeature(feature::FeatureBuilder const & feature, OsmElement const &) override;
   void Finish() override;

--- a/generator/collector_collection.cpp
+++ b/generator/collector_collection.cpp
@@ -8,8 +8,8 @@ using namespace feature;
 
 namespace generator
 {
-std::shared_ptr<CollectorInterface>
-CollectorCollection::Clone(std::shared_ptr<cache::IntermediateDataReader> const & cache) const
+std::shared_ptr<CollectorInterface> CollectorCollection::Clone(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache) const
 {
   auto p = std::make_shared<CollectorCollection>();
   for (auto const & c : m_collection)

--- a/generator/collector_collection.hpp
+++ b/generator/collector_collection.hpp
@@ -17,7 +17,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 // This class allows you to work with a group of collectors as with one.
@@ -25,8 +25,8 @@ class CollectorCollection : public CollectionBase<std::shared_ptr<CollectorInter
 {
 public:
   // CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & cache = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache = {}) const override;
 
   void Collect(OsmElement const & element) override;
   void CollectRelation(RelationElement const & element) override;

--- a/generator/collector_interface.hpp
+++ b/generator/collector_interface.hpp
@@ -44,7 +44,7 @@ class CrossMwmOsmWaysCollector;
 class RoutingCityBoundariesCollector;
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 namespace regions
 {
@@ -59,8 +59,8 @@ public:
   CollectorInterface(std::string const & filename = {}) : m_id(CreateId()), m_filename(filename) {}
   virtual ~CollectorInterface() { CHECK(Platform::RemoveFileIfExists(GetTmpFilename()), ()); }
 
-  virtual std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const = 0;
+  virtual std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & = {}) const = 0;
 
   virtual void Collect(OsmElement const &) {}
   virtual void CollectRelation(RelationElement const &) {}

--- a/generator/collector_mini_roundabout.cpp
+++ b/generator/collector_mini_roundabout.cpp
@@ -96,7 +96,7 @@ MiniRoundaboutCollector::MiniRoundaboutCollector(std::string const & filename)
 }
 
 std::shared_ptr<generator::CollectorInterface> MiniRoundaboutCollector::Clone(
-    std::shared_ptr<generator::cache::IntermediateDataReader> const &) const
+    std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<MiniRoundaboutCollector>(GetFilename());
 }

--- a/generator/collector_mini_roundabout.hpp
+++ b/generator/collector_mini_roundabout.hpp
@@ -24,7 +24,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 class MiniRoundaboutProcessor
@@ -59,7 +59,8 @@ public:
 
   // CollectorInterface overrides:
   std::shared_ptr<CollectorInterface> Clone(
-      std::shared_ptr<generator::cache::IntermediateDataReader> const & = {}) const override;
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & = {})
+      const override;
 
   void Collect(OsmElement const & element) override;
   void CollectFeature(feature::FeatureBuilder const & feature, OsmElement const & element) override;

--- a/generator/collector_routing_city_boundaries.cpp
+++ b/generator/collector_routing_city_boundaries.cpp
@@ -142,8 +142,8 @@ RoutingCityBoundariesCollector::LocalityData::Deserialize(ReaderSource<FileReade
 // RoutingCityBoundariesCollector ------------------------------------------------------------------
 
 RoutingCityBoundariesCollector::RoutingCityBoundariesCollector(
-    std::string const & filename, std::string const & dumpFilename, 
-    std::shared_ptr<cache::IntermediateDataReader> const & cache)
+    std::string const & filename, std::string const & dumpFilename,
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
   : CollectorInterface(filename)
   , m_writer(std::make_unique<RoutingCityBoundariesWriter>(GetTmpFilename()))
   , m_cache(cache)
@@ -153,7 +153,7 @@ RoutingCityBoundariesCollector::RoutingCityBoundariesCollector(
 }
 
 std::shared_ptr<CollectorInterface> RoutingCityBoundariesCollector::Clone(
-    std::shared_ptr<cache::IntermediateDataReader> const & cache) const
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache) const
 {
   return std::make_shared<RoutingCityBoundariesCollector>(GetFilename(), m_dumpFilename, 
                                                           cache ? cache : m_cache);

--- a/generator/collector_routing_city_boundaries.hpp
+++ b/generator/collector_routing_city_boundaries.hpp
@@ -16,7 +16,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 class RoutingCityBoundariesWriter;
@@ -40,13 +40,13 @@ public:
     m2::PointD m_position = m2::PointD::Zero();
   };
 
-  RoutingCityBoundariesCollector(std::string const & filename,
-                                 std::string const & dumpFilename,
-                                 std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  RoutingCityBoundariesCollector(
+      std::string const & filename, std::string const & dumpFilename,
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   // CollectorInterface overrides:
   std::shared_ptr<CollectorInterface> Clone(
-      std::shared_ptr<cache::IntermediateDataReader> const & cache = {}) const override;
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache = {}) const override;
 
   void Collect(OsmElement const & osmElement) override;
   void Finish() override;
@@ -60,7 +60,7 @@ public:
 
 private:
   std::unique_ptr<RoutingCityBoundariesWriter> m_writer;
-  std::shared_ptr<cache::IntermediateDataReader> m_cache;
+  std::shared_ptr<cache::IntermediateDataReaderInterface> m_cache;
   FeatureMakerSimple m_featureMakerSimple;
   std::string m_dumpFilename;
 };

--- a/generator/collector_tag.cpp
+++ b/generator/collector_tag.cpp
@@ -23,8 +23,8 @@ CollectorTag::CollectorTag(std::string const & filename, std::string const & tag
   m_stream.open(GetTmpFilename());
 }
 
-std::shared_ptr<CollectorInterface>
-CollectorTag::Clone(std::shared_ptr<cache::IntermediateDataReader> const &) const
+std::shared_ptr<CollectorInterface> CollectorTag::Clone(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<CollectorTag>(GetFilename(), m_tagKey, m_validator);
 }

--- a/generator/collector_tag.hpp
+++ b/generator/collector_tag.hpp
@@ -17,7 +17,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 // CollectorTag class collects validated value of a tag and saves it to file with following
@@ -31,8 +31,8 @@ public:
                         Validator const & validator);
 
   // CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & = {}) const override;
 
   void Collect(OsmElement const & el) override;
   void Finish() override;

--- a/generator/cross_mwm_osm_ways_collector.cpp
+++ b/generator/cross_mwm_osm_ways_collector.cpp
@@ -32,8 +32,8 @@ CrossMwmOsmWaysCollector::CrossMwmOsmWaysCollector(
 {
 }
 
-std::shared_ptr<CollectorInterface>
-CrossMwmOsmWaysCollector::Clone(std::shared_ptr<cache::IntermediateDataReader> const &) const
+std::shared_ptr<CollectorInterface> CrossMwmOsmWaysCollector::Clone(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<CrossMwmOsmWaysCollector>(m_intermediateDir, m_affiliation);
 }

--- a/generator/cross_mwm_osm_ways_collector.hpp
+++ b/generator/cross_mwm_osm_ways_collector.hpp
@@ -49,8 +49,8 @@ public:
 
   // generator::CollectorInterface overrides:
   // @{
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & = {}) const override;
 
   void CollectFeature(feature::FeatureBuilder const & fb, OsmElement const & element) override;
   void Save() override;

--- a/generator/feature_maker_base.cpp
+++ b/generator/feature_maker_base.cpp
@@ -11,10 +11,14 @@ using namespace feature;
 
 namespace generator
 {
-FeatureMakerBase::FeatureMakerBase(std::shared_ptr<cache::IntermediateDataReader> const & cache)
-  : m_cache(cache) {}
+FeatureMakerBase::FeatureMakerBase(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
+  : m_cache(cache)
+{
+}
 
-void FeatureMakerBase::SetCache(std::shared_ptr<cache::IntermediateDataReader> const & cache)
+void FeatureMakerBase::SetCache(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
 {
   m_cache = cache;
 }

--- a/generator/feature_maker_base.hpp
+++ b/generator/feature_maker_base.hpp
@@ -15,12 +15,13 @@ namespace generator
 class FeatureMakerBase
 {
 public:
-  explicit FeatureMakerBase(std::shared_ptr<cache::IntermediateDataReader> const & cache = {});
+  explicit FeatureMakerBase(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache = {});
   virtual ~FeatureMakerBase() = default;
 
   virtual std::shared_ptr<FeatureMakerBase> Clone() const = 0;
 
-  void SetCache(std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  void SetCache(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   // Reference on element is non const because ftype::GetNameAndType will be call.
   virtual bool Add(OsmElement & element);
@@ -36,7 +37,7 @@ protected:
 
   virtual void ParseParams(FeatureParams & params, OsmElement & element) const  = 0;
 
-  std::shared_ptr<cache::IntermediateDataReader> m_cache;
+  std::shared_ptr<cache::IntermediateDataReaderInterface> m_cache;
   std::queue<feature::FeatureBuilder> m_queue;
 };
 

--- a/generator/holes.cpp
+++ b/generator/holes.cpp
@@ -9,8 +9,9 @@ using namespace feature;
 
 namespace generator
 {
-HolesAccumulator::HolesAccumulator(std::shared_ptr<cache::IntermediateDataReader> const & cache) :
-  m_merger(cache)
+HolesAccumulator::HolesAccumulator(
+    std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
+  : m_merger(cache)
 {
 }
 
@@ -25,9 +26,9 @@ FeatureBuilder::Geometry & HolesAccumulator::GetHoles()
   return m_holes;
 }
 
-HolesProcessor::HolesProcessor(uint64_t id, std::shared_ptr<cache::IntermediateDataReader> const & cache) :
-  m_id(id),
-  m_holes(cache)
+HolesProcessor::HolesProcessor(
+    uint64_t id, std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
+  : m_id(id), m_holes(cache)
 {
 }
 
@@ -53,9 +54,8 @@ void HolesProcessor::operator() (uint64_t id, std::string const & role)
     m_holes(id);
 }
 
-HolesRelation::HolesRelation(std::shared_ptr<cache::IntermediateDataReader> const & cache) :
-  m_holes(cache),
-  m_outer(cache)
+HolesRelation::HolesRelation(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
+  : m_holes(cache), m_outer(cache)
 {
 }
 

--- a/generator/holes.hpp
+++ b/generator/holes.hpp
@@ -13,13 +13,13 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 class HolesAccumulator
 {
 public:
-  explicit HolesAccumulator(std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  explicit HolesAccumulator(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   void operator() (uint64_t id) { m_merger.AddWay(id); }
   feature::FeatureBuilder::Geometry & GetHoles();
@@ -33,7 +33,8 @@ private:
 class HolesProcessor
 {
 public:
-  explicit HolesProcessor(uint64_t id, std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  explicit HolesProcessor(uint64_t id,
+                          std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   /// 1. relations process function
   base::ControlFlow operator() (uint64_t /* id */, RelationElement const & e);
@@ -49,7 +50,7 @@ private:
 class HolesRelation
 {
 public:
-  explicit HolesRelation(std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  explicit HolesRelation(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   void Build(OsmElement const * p);
   feature::FeatureBuilder::Geometry & GetHoles() { return m_holes.GetHoles(); }

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -196,15 +196,28 @@ protected:
   bool m_preload = false;
 };
 
-class IntermediateDataReader
+class IntermediateDataReaderInterface
+{
+public:
+  virtual ~IntermediateDataReaderInterface() = default;
+
+  virtual bool GetNode(Key id, double & lat, double & lon) const = 0;
+  virtual bool GetWay(Key id, WayElement & e) = 0;
+};
+
+class IntermediateDataReader : public IntermediateDataReaderInterface
 {
 public:
   IntermediateDataReader(PointStorageReaderInterface const & nodes,
                          feature::GenerateInfo const & info, bool forceReload = false);
 
+  // IntermediateDataReaderInterface overrides
   // TODO |GetNode()|, |lat|, |lon| are used as y, x in real.
-  bool GetNode(Key id, double & lat, double & lon) const { return m_nodes.GetPoint(id, lat, lon); }
-  bool GetWay(Key id, WayElement & e) { return m_ways.Read(id, e); }
+  bool GetNode(Key id, double & lat, double & lon) const override
+  {
+    return m_nodes.GetPoint(id, lat, lon);
+  }
+  bool GetWay(Key id, WayElement & e) override { return m_ways.Read(id, e); }
 
   template <typename ToDo>
   void ForEachRelationByWay(Key id, ToDo && toDo)

--- a/generator/maxspeeds_collector.cpp
+++ b/generator/maxspeeds_collector.cpp
@@ -44,9 +44,8 @@ MaxspeedsCollector::MaxspeedsCollector(string const & filename)
   m_stream.open(GetTmpFilename());
 }
 
-
-shared_ptr<CollectorInterface>
-MaxspeedsCollector::Clone(shared_ptr<cache::IntermediateDataReader> const &) const
+shared_ptr<CollectorInterface> MaxspeedsCollector::Clone(
+    shared_ptr<cache::IntermediateDataReaderInterface> const &) const
 {
   return make_shared<MaxspeedsCollector>(GetFilename());
 }

--- a/generator/maxspeeds_collector.hpp
+++ b/generator/maxspeeds_collector.hpp
@@ -12,7 +12,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 
 /// \brief Collects all maxspeed tags value and saves them to a csv file.
@@ -25,8 +25,8 @@ public:
   explicit MaxspeedsCollector(std::string const & filename);
 
   // CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<cache::IntermediateDataReaderInterface> const & = {}) const override;
 
   void CollectFeature(feature::FeatureBuilder const &, OsmElement const & p) override;
   void Finish() override;

--- a/generator/metalines_builder.cpp
+++ b/generator/metalines_builder.cpp
@@ -166,8 +166,8 @@ LineStringMerger::OutputData LineStringMerger::OrderData(InputData const & data)
 MetalinesBuilder::MetalinesBuilder(std::string const & filename)
   : generator::CollectorInterface(filename) {}
 
-std::shared_ptr<generator::CollectorInterface>
-MetalinesBuilder::Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const &) const
+std::shared_ptr<generator::CollectorInterface> MetalinesBuilder::Clone(
+    std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const &) const
 {
   return std::make_shared<MetalinesBuilder>(GetFilename());
 }

--- a/generator/metalines_builder.hpp
+++ b/generator/metalines_builder.hpp
@@ -16,7 +16,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 }  // namespace generator
 
@@ -68,8 +68,9 @@ public:
   explicit MetalinesBuilder(std::string const & filename);
 
   // CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & = {})
+      const override;
 
   /// Add a highway segment to the collection of metalines.
   void CollectFeature(FeatureBuilder const & feature, OsmElement const & element) override;

--- a/generator/restriction_writer.cpp
+++ b/generator/restriction_writer.cpp
@@ -95,18 +95,18 @@ namespace routing
 std::string const RestrictionWriter::kNodeString = "node";
 std::string const RestrictionWriter::kWayString = "way";
 
-RestrictionWriter::RestrictionWriter(std::string const & filename,
-                                     std::shared_ptr<generator::cache::IntermediateDataReader> const & cache)
-  : generator::CollectorInterface(filename)
-  , m_cache(cache)
+RestrictionWriter::RestrictionWriter(
+    std::string const & filename,
+    std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & cache)
+  : generator::CollectorInterface(filename), m_cache(cache)
 {
   m_stream.exceptions(std::fstream::failbit | std::fstream::badbit);
   m_stream.open(GetTmpFilename());
   m_stream << std::setprecision(20);
 }
 
-std::shared_ptr<generator::CollectorInterface>
-RestrictionWriter::Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const & cache) const
+std::shared_ptr<generator::CollectorInterface> RestrictionWriter::Clone(
+    std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & cache) const
 { 
   return std::make_shared<RestrictionWriter>(GetFilename(), cache ? cache : m_cache);
 }

--- a/generator/restriction_writer.hpp
+++ b/generator/restriction_writer.hpp
@@ -13,7 +13,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 }  // namespace generator
 
@@ -34,12 +34,14 @@ public:
   static std::string const kNodeString;
   static std::string const kWayString;
 
-  RestrictionWriter(std::string const & filename,
-                    std::shared_ptr<generator::cache::IntermediateDataReader> const & cache);
+  RestrictionWriter(
+      std::string const & filename,
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & cache);
 
   // generator::CollectorInterface overrides:
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const & cache = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & cache = {})
+      const override;
 
   void CollectRelation(RelationElement const & relationElement) override;
   void Finish() override;
@@ -52,7 +54,7 @@ public:
 
 private:
   std::ofstream m_stream;
-  std::shared_ptr<generator::cache::IntermediateDataReader> m_cache;
+  std::shared_ptr<generator::cache::IntermediateDataReaderInterface> m_cache;
 };
 
 std::string DebugPrint(RestrictionWriter::ViaType const & type);

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -398,8 +398,8 @@ RoadAccessWriter::~RoadAccessWriter()
   CHECK(Platform::RemoveFileIfExists(m_waysFilename), ());
 }
 
-shared_ptr<generator::CollectorInterface>
-RoadAccessWriter::Clone(shared_ptr<generator::cache::IntermediateDataReader> const &) const
+shared_ptr<generator::CollectorInterface> RoadAccessWriter::Clone(
+    shared_ptr<generator::cache::IntermediateDataReaderInterface> const &) const
 {
   return make_shared<RoadAccessWriter>(GetFilename());
 }

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -27,7 +27,7 @@ namespace generator
 {
 namespace cache
 {
-class IntermediateDataReader;
+class IntermediateDataReaderInterface;
 }  // namespace cache
 }  // namespace generator
 
@@ -76,8 +76,9 @@ public:
   // CollectorInterface overrides:
   ~RoadAccessWriter() override;
 
-  std::shared_ptr<CollectorInterface>
-  Clone(std::shared_ptr<generator::cache::IntermediateDataReader> const & = {}) const override;
+  std::shared_ptr<CollectorInterface> Clone(
+      std::shared_ptr<generator::cache::IntermediateDataReaderInterface> const & = {})
+      const override;
 
   void CollectFeature(feature::FeatureBuilder const & fb, OsmElement const & elem) override;
   void Finish() override;

--- a/generator/ways_merger.cpp
+++ b/generator/ways_merger.cpp
@@ -2,8 +2,8 @@
 
 namespace generator
 {
-AreaWayMerger::AreaWayMerger(std::shared_ptr<cache::IntermediateDataReader> const & cache) :
-  m_cache(cache)
+AreaWayMerger::AreaWayMerger(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache)
+  : m_cache(cache)
 {
 }
 

--- a/generator/ways_merger.hpp
+++ b/generator/ways_merger.hpp
@@ -20,7 +20,7 @@ class AreaWayMerger
   using WayMapIterator = WayMap::iterator;
 
 public:
-  explicit AreaWayMerger(std::shared_ptr<cache::IntermediateDataReader> const & cache);
+  explicit AreaWayMerger(std::shared_ptr<cache::IntermediateDataReaderInterface> const & cache);
 
   void AddWay(uint64_t id);
 
@@ -76,7 +76,7 @@ public:
   }
 
 private:
-  std::shared_ptr<cache::IntermediateDataReader> m_cache;
+  std::shared_ptr<cache::IntermediateDataReaderInterface> m_cache;
   WayMap m_map;
 };
 }  // namespace generator


### PR DESCRIPTION
Предлагается создать IntermediateDataReaderInterface -- базовый класс для IntermediateDataReader и использовать его в коллекторах.
Это позволит создавать костомные IntermediateDataReader для тестов (например возвращать значения из захардкоженного map). Без этого очень проблематично тестировать функцию `Collector::Collect(OsmElement const & el)`, если она использует cache.