### PR TITLE
[routing] Split logic of different routings modes into different methods

### DIFF
--- a/base/timer.cpp
+++ b/base/timer.cpp
@@ -3,6 +3,7 @@
 #include "base/assert.hpp"
 #include "base/get_time.hpp"
 #include "base/gmtime.hpp"
+#include "base/logging.hpp"
 #include "base/macros.hpp"
 #include "base/timegm.hpp"
 
@@ -207,5 +208,34 @@ uint64_t TimeTToSecondsSinceEpoch(time_t time)
 {
   auto const tpoint = std::chrono::system_clock::from_time_t(time);
   return std::chrono::duration_cast<std::chrono::seconds>(tpoint.time_since_epoch()).count();
+}
+
+ScopedTimerWithLog::ScopedTimerWithLog(std::string const & timerName, Measure measure)
+  : m_name(timerName), m_measure(measure)
+{
+}
+
+ScopedTimerWithLog::~ScopedTimerWithLog()
+{
+  double time = 0.0;
+  std::string suffix;
+  switch (m_measure)
+  {
+  case Measure::MilliSeconds:
+  {
+    time = m_timer.ElapsedMillis();
+    suffix = "ms";
+    break;
+  }
+  case Measure::Seconds:
+  {
+    time = m_timer.ElapsedSeconds();
+    suffix = "s";
+    break;
+  }
+  default: UNREACHABLE();
+  }
+
+  LOG(LINFO, (m_name, "time:", time, suffix));
 }
 }  // namespace base

--- a/base/timer.cpp
+++ b/base/timer.cpp
@@ -217,25 +217,19 @@ ScopedTimerWithLog::ScopedTimerWithLog(std::string const & timerName, Measure me
 
 ScopedTimerWithLog::~ScopedTimerWithLog()
 {
-  double time = 0.0;
-  std::string suffix;
   switch (m_measure)
   {
   case Measure::MilliSeconds:
   {
-    time = m_timer.ElapsedMillis();
-    suffix = "ms";
+    LOG(LINFO, (m_name, "time:", m_timer.ElapsedMillis(), "ms"));
     break;
   }
   case Measure::Seconds:
   {
-    time = m_timer.ElapsedSeconds();
-    suffix = "s";
+    LOG(LINFO, (m_name, "time:", m_timer.ElapsedSeconds(), "s"));
     break;
   }
-  default: UNREACHABLE();
   }
-
-  LOG(LINFO, (m_name, "time:", time, suffix));
+  UNREACHABLE();
 }
 }  // namespace base

--- a/base/timer.hpp
+++ b/base/timer.hpp
@@ -74,6 +74,25 @@ public:
   double ElapsedSeconds() const;
 };
 
+class ScopedTimerWithLog
+{
+public:
+  enum class Measure
+  {
+    MilliSeconds,
+    Seconds,
+  };
+
+  explicit ScopedTimerWithLog(std::string const & timerName,
+                              Measure measure = Measure::MilliSeconds);
+  ~ScopedTimerWithLog();
+
+private:
+  std::string m_name;
+  Measure m_measure;
+  HighResTimer m_timer;
+};
+
 time_t SecondsSinceEpochToTimeT(uint64_t secondsSinceEpoch);
 uint64_t TimeTToSecondsSinceEpoch(time_t time);
 }  // namespace base

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -549,91 +549,120 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
   SetupAlgorithmMode(starter);
   LOG(LINFO, ("Routing in mode:", starter.GetGraph().GetMode()));
 
-  base::HighResTimer timer;
+  base::ScopedTimerWithLog timer("Route build");
   WorldGraphMode const mode = starter.GetGraph().GetMode();
-  if (mode == WorldGraphMode::Joints)
+  switch (mode)
   {
-    using JointsStarter = IndexGraphStarterJoints<IndexGraphStarter>;
-    JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
-    RoutingResult<JointSegment, RouteWeight> routingResult;
-
-    using Visitor = JunctionVisitor<JointsStarter>;
-    Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);
-
-    using Vertex = JointsStarter::Vertex;
-    using Edge = JointsStarter::Edge;
-    using Weight = JointsStarter::Weight;
-
-    AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
-        jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(),
-        nullptr /* prevRoute */, delegate.GetCancellable(), move(visitor),
-        AStarLengthChecker(starter));
-
-    set<NumMwmId> const mwmIds = starter.GetMwms();
-    RouterResultCode const result =
-        FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, mode);
-    if (result != RouterResultCode::NoError)
-      return result;
-
-    subroute = ProcessJoints(routingResult.m_path, jointStarter);
+  case WorldGraphMode::Joints:
+    return CalculateSubrouteJointsMode(starter, delegate, progress, subroute);
+  case WorldGraphMode::NoLeaps:
+    return CalculateSubrouteNoLeapsMode(starter, delegate, progress, subroute);
+  case WorldGraphMode::LeapsOnly:
+    return CalculateSubrouteLeapsOnlyMode(checkpoints, subrouteIdx, starter, delegate, progress,
+                                          subroute);
+  default: CHECK(false, ("Wrong WorldGraphMode here:", mode));
   }
-  else
-  {
-    using Vertex = IndexGraphStarter::Vertex;
-    using Edge = IndexGraphStarter::Edge;
-    using Weight = IndexGraphStarter::Weight;
+  UNREACHABLE();
+}
 
-    if (mode == WorldGraphMode::LeapsOnly)
-    {
-      AStarSubProgress leapsProgress(checkpoints.GetPoint(subrouteIdx),
-                                     checkpoints.GetPoint(subrouteIdx + 1),
-                                     kLeapsStageContribution);
-      progress->AppendSubProgress(leapsProgress);
-    }
+RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
+    IndexGraphStarter & starter, RouterDelegate const & delegate,
+    std::shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
+{
+  using JointsStarter = IndexGraphStarterJoints<IndexGraphStarter>;
+  JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
 
-    using Visitor = JunctionVisitor<IndexGraphStarter>;
-    auto const visitPeriod =
-        mode == WorldGraphMode::LeapsOnly ? kVisitPeriodForLeaps : kVisitPeriod;
-    Visitor visitor(starter, delegate, visitPeriod, progress);
+  using Visitor = JunctionVisitor<JointsStarter>;
+  Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);
 
-    RoutingResult<Segment, RouteWeight> routingResult;
-    AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
-        starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
-        delegate.GetCancellable(), move(visitor), AStarLengthChecker(starter));
+  using Vertex = JointsStarter::Vertex;
+  using Edge = JointsStarter::Edge;
+  using Weight = JointsStarter::Weight;
 
-    set<NumMwmId> const mwmIds = starter.GetMwms();
-    RouterResultCode const result =
-        FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, mode);
+  AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
+      jointStarter, jointStarter.GetStartJoint(), jointStarter.GetFinishJoint(),
+      nullptr /* prevRoute */, delegate.GetCancellable(), move(visitor),
+      AStarLengthChecker(starter));
 
-    if (mode == WorldGraphMode::LeapsOnly)
-      progress->PushAndDropLastSubProgress();
+  RoutingResult<Vertex, Weight> routingResult;
+  RouterResultCode const result =
+      FindPath<Vertex, Edge, Weight>(params, {} /* mwmIds */, routingResult, WorldGraphMode::Joints);
 
-    if (result != RouterResultCode::NoError)
-      return result;
+  if (result != RouterResultCode::NoError)
+    return result;
 
-    vector<Segment> subrouteWithoutPostprocessing;
-    RouterResultCode const leapsResult =
-        ProcessLeapsJoints(routingResult.m_path, delegate, starter.GetGraph().GetMode(), starter,
-                           progress, subrouteWithoutPostprocessing);
+  subroute = ProcessJoints(routingResult.m_path, jointStarter);
+  return result;
+}
 
-    if (leapsResult != RouterResultCode::NoError)
-      return leapsResult;
+RouterResultCode IndexRouter::CalculateSubrouteNoLeapsMode(
+    IndexGraphStarter & starter, RouterDelegate const & delegate,
+    std::shared_ptr<AStarProgress> const & progress, std::vector<Segment> & subroute)
+{
+  using Vertex = IndexGraphStarter::Vertex;
+  using Edge = IndexGraphStarter::Edge;
+  using Weight = IndexGraphStarter::Weight;
 
-    if (mode == WorldGraphMode::LeapsOnly)
-    {
-      LeapsPostProcessor leapsPostProcessor(subrouteWithoutPostprocessing, starter);
-      subroute = leapsPostProcessor.GetProcessedPath();
-    }
-    else
-    {
-      subroute = move(subrouteWithoutPostprocessing);
-    }
-  }
+  using Visitor = JunctionVisitor<IndexGraphStarter>;
+  Visitor visitor(starter, delegate, kVisitPeriod, progress);
 
-  LOG(LINFO, ("Time for routing in mode:", starter.GetGraph().GetMode(), "is",
-              timer.ElapsedNano() / 1e6, "ms"));
+  AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
+      starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
+      delegate.GetCancellable(), move(visitor), AStarLengthChecker(starter));
 
-  return RouterResultCode::NoError;
+  RoutingResult<Vertex, Weight> routingResult;
+  set<NumMwmId> const mwmIds = starter.GetMwms();
+  RouterResultCode const result =
+      FindPath<Vertex, Edge, Weight>(params, mwmIds, routingResult, WorldGraphMode::NoLeaps);
+
+  if (result != RouterResultCode::NoError)
+    return result;
+
+  subroute = move(routingResult.m_path);
+  return result;
+}
+
+RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(
+    Checkpoints const & checkpoints, size_t subrouteIdx, IndexGraphStarter & starter,
+    RouterDelegate const & delegate, std::shared_ptr<AStarProgress> const & progress,
+    std::vector<Segment> & subroute)
+{
+  using Vertex = IndexGraphStarter::Vertex;
+  using Edge = IndexGraphStarter::Edge;
+  using Weight = IndexGraphStarter::Weight;
+
+  AStarSubProgress leapsProgress(checkpoints.GetPoint(subrouteIdx),
+                                 checkpoints.GetPoint(subrouteIdx + 1), kLeapsStageContribution);
+  progress->AppendSubProgress(leapsProgress);
+
+  using Visitor = JunctionVisitor<IndexGraphStarter>;
+  Visitor visitor(starter, delegate, kVisitPeriodForLeaps, progress);
+
+  AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
+      starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
+      delegate.GetCancellable(), move(visitor), AStarLengthChecker(starter));
+
+  RoutingResult<Vertex, Weight> routingResult;
+  RouterResultCode const result =
+      FindPath<Vertex, Edge, Weight>(params, {} /* mwmIds */, routingResult, WorldGraphMode::LeapsOnly);
+
+  progress->PushAndDropLastSubProgress();
+
+  if (result != RouterResultCode::NoError)
+    return result;
+
+  vector<Segment> subrouteWithoutPostprocessing;
+  RouterResultCode const leapsResult =
+      ProcessLeapsJoints(routingResult.m_path, delegate, starter.GetGraph().GetMode(), starter,
+                         progress, subrouteWithoutPostprocessing);
+
+  if (leapsResult != RouterResultCode::NoError)
+    return leapsResult;
+
+  LeapsPostProcessor leapsPostProcessor(subrouteWithoutPostprocessing, starter);
+  subroute = leapsPostProcessor.GetProcessedPath();
+
+  return leapsResult;
 }
 
 RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
@@ -990,11 +1019,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
                                                  shared_ptr<AStarProgress> const & progress,
                                                  vector<Segment> & output)
 {
-  if (prevMode != WorldGraphMode::LeapsOnly)
-  {
-    output = input;
-    return RouterResultCode::NoError;
-  }
+  CHECK_EQUAL(prevMode, WorldGraphMode::LeapsOnly, ());
 
   CHECK(progress, ());
   SCOPE_GUARD(progressGuard, [&progress]() {

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -214,8 +214,8 @@ bool IsDeadEndCached(Segment const & segment, bool isOutgoing, bool useRoutingOp
   set<Segment> visitedSegments;
   if (IsDeadEnd(segment, isOutgoing, useRoutingOptions, worldGraph, visitedSegments))
   {
-    auto const beginIt = std::make_move_iterator(visitedSegments.begin());
-    auto const endIt = std::make_move_iterator(visitedSegments.end());
+    auto const beginIt = make_move_iterator(visitedSegments.begin());
+    auto const endIt = make_move_iterator(visitedSegments.end());
     deadEnds.insert(beginIt, endIt);
     return true;
   }
@@ -567,7 +567,7 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
 
 RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
     IndexGraphStarter & starter, RouterDelegate const & delegate,
-    std::shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
+    shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
 {
   using JointsStarter = IndexGraphStarterJoints<IndexGraphStarter>;
   JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
@@ -597,7 +597,7 @@ RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
 
 RouterResultCode IndexRouter::CalculateSubrouteNoLeapsMode(
     IndexGraphStarter & starter, RouterDelegate const & delegate,
-    std::shared_ptr<AStarProgress> const & progress, std::vector<Segment> & subroute)
+    shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
 {
   using Vertex = IndexGraphStarter::Vertex;
   using Edge = IndexGraphStarter::Edge;
@@ -619,13 +619,13 @@ RouterResultCode IndexRouter::CalculateSubrouteNoLeapsMode(
     return result;
 
   subroute = move(routingResult.m_path);
-  return result;
+  return RouterResultCode::NoError;
 }
 
 RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(
     Checkpoints const & checkpoints, size_t subrouteIdx, IndexGraphStarter & starter,
-    RouterDelegate const & delegate, std::shared_ptr<AStarProgress> const & progress,
-    std::vector<Segment> & subroute)
+    RouterDelegate const & delegate, shared_ptr<AStarProgress> const & progress,
+    vector<Segment> & subroute)
 {
   using Vertex = IndexGraphStarter::Vertex;
   using Edge = IndexGraphStarter::Edge;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -95,6 +95,20 @@ public:
   VehicleType GetVehicleType() const { return m_vehicleType; }
 
 private:
+  RouterResultCode CalculateSubrouteJointsMode(IndexGraphStarter & starter,
+                                               RouterDelegate const & delegate,
+                                               std::shared_ptr<AStarProgress> const & progress,
+                                               std::vector<Segment> & subroute);
+  RouterResultCode CalculateSubrouteNoLeapsMode(IndexGraphStarter & starter,
+                                                RouterDelegate const & delegate,
+                                                std::shared_ptr<AStarProgress> const & progress,
+                                                std::vector<Segment> & subroute);
+  RouterResultCode CalculateSubrouteLeapsOnlyMode(Checkpoints const & checkpoints,
+                                                  size_t subrouteIdx, IndexGraphStarter & starter,
+                                                  RouterDelegate const & delegate,
+                                                  std::shared_ptr<AStarProgress> const & progress,
+                                                  std::vector<Segment> & subroute);
+
   RouterResultCode DoCalculateRoute(Checkpoints const & checkpoints,
                                     m2::PointD const & startDirection,
                                     RouterDelegate const & delegate, Route & route);


### PR DESCRIPTION
Сейчас ф-ия  `CalculateSubroute` это большая ф-ия с кучей `if (mode == WorldGraphMode::LeapsOnly)`  итд итп, разделил весь код вызовов эти трех режимов в разные методы