### PR TITLE
[routing] Remove useless code

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -191,6 +191,8 @@ public:
   {
     m_AStarParents = nullptr;
   }
+
+  RouteWeight GetAStarWeightEpsilon() { return RouteWeight(0.0); }
   // @}
 
   m2::PointD const & GetPoint(Segment const & s, bool forward)

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "routing/base/astar_weight.hpp"
+
 #include <map>
 #include <vector>
 
@@ -26,6 +28,8 @@ public:
   virtual bool AreWavesConnectible(Parents & forwardParents, Vertex const & commonVertex,
                                    Parents & backwardParents);
 
+  virtual Weight GetAStarWeightEpsilon();
+
   virtual ~AStarGraph() = default;
 };
 
@@ -42,5 +46,11 @@ bool AStarGraph<VertexType, EdgeType, WeightType>::AreWavesConnectible(AStarGrap
                                                                        AStarGraph::Parents & /* backwardParents */)
 {
   return true;
+}
+
+template <typename VertexType, typename EdgeType, typename WeightType>
+WeightType AStarGraph<VertexType, EdgeType, WeightType>::GetAStarWeightEpsilon()
+{
+  return routing::GetAStarWeightEpsilon<WeightType>();
 }
 }  // namespace routing

--- a/routing/base/astar_weight.hpp
+++ b/routing/base/astar_weight.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "base/assert.hpp"
+
 #include <limits>
 
 namespace routing
@@ -15,7 +17,10 @@ constexpr double GetAStarWeightZero<double>()
 
 // Precision of comparison weights.
 template <typename Weight>
-constexpr Weight GetAStarWeightEpsilon();
+constexpr Weight GetAStarWeightEpsilon()
+{
+  UNREACHABLE();
+}
 
 template <>
 constexpr double GetAStarWeightEpsilon<double>()

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -4,6 +4,8 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
+#include "coding/point_coding.hpp"
+
 #include "geometry/mercator.hpp"
 
 #include <algorithm>
@@ -431,5 +433,16 @@ bool IndexGraphStarter::StartPassThroughAllowed()
 bool IndexGraphStarter::FinishPassThroughAllowed()
 {
   return EndingPassThroughAllowed(m_finish);
+}
+
+RouteWeight IndexGraphStarter::GetAStarWeightEpsilon()
+{
+  // Epsilon for double calculations.
+  auto constexpr kEps = RouteWeight(1e-6);
+  // We store points with |kMwmPointAccuracy|. In case of cross mwm routing we couldn't
+  // distinguish the point geometry changing in |kMwmPointAccuracy| radius of the same segments from
+  // mwms with different versions. So let's use such epsilon to maintain the A* invariant.
+  return kEps +
+         m_graph.HeuristicCostEstimate(m2::PointD(0.0, 0.0), m2::PointD(kMwmPointAccuracy, 0.0));
 }
 }  // namespace routing

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -130,6 +130,8 @@ public:
   {
     return m_graph.AreWavesConnectible(forwardParents, commonVertex, backwardParents, nullptr);
   }
+
+  RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
   RouteWeight HeuristicCostEstimate(Vertex const & from, m2::PointD const & to) const

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -85,6 +85,8 @@ public:
     return m_graph.AreWavesConnectible(forwardParents, commonVertex, backwardParents,
                                        std::move(converter));
   }
+
+  RouteWeight GetAStarWeightEpsilon() override { return m_graph.GetAStarWeightEpsilon(); }
   // @}
 
   WorldGraphMode GetMode() const { return m_graph.GetMode(); }

--- a/routing/route_weight.hpp
+++ b/routing/route_weight.hpp
@@ -113,12 +113,4 @@ constexpr RouteWeight GetAStarWeightZero<RouteWeight>()
   return RouteWeight(0.0 /* weight */, 0 /* numPassThroughChanges */, 0 /* numAccessChanges */,
                      0.0 /* transitTime */);
 }
-
-template <>
-constexpr RouteWeight GetAStarWeightEpsilon<RouteWeight>()
-{
-  return RouteWeight(GetAStarWeightEpsilon<double>(), 0 /* numPassThroughChanges */,
-                     0 /* numAccessChanges */, 0.0 /* transitTime */);
-}
-
 }  // namespace routing

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -73,6 +73,8 @@ public:
   {
     m_graph->GetIngoingEdgesList(v, edges);
   }
+
+  RouteWeight GetAStarWeightEpsilon() override { return RouteWeight(0.0); }
   // @}
 
   WorldGraph & GetWorldGraph() { return *m_graph; }

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -18,15 +18,9 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRout
     // We need both enter to mwm and exit from mwm in LeapsOnly mode to reconstruct leap.
     // That's why we need to duplicate twin segment here and than remove duplicate
     // while processing leaps.
-    m2::PointD const & from = GetPoint(segment, isOutgoing /* front */);
     for (Segment const & twin : twins)
-    {
-      m2::PointD const & to = GetPoint(twin, isOutgoing /* front */);
-      // Weight is usually zero because twins correspond the same feature
-      // in different mwms. But if we have mwms with different versions and a feature
-      // was moved in one of them the weight is greater than zero.
-      edges.emplace_back(twin, HeuristicCostEstimate(from, to));
-    }
+      edges.emplace_back(twin, RouteWeight(0.0));
+
     return;
   }
 


### PR DESCRIPTION
ф-ия routing/cross_mwm_index_graph.hpp:GetTwinsByCrossMwmId
проверяет, что геометрии twin'ов - одинаковые, поэтому этот код бесполезен, потому что:
1) никогда не исполняется
2) был еще до того, как добавилась проверка на геометрию и не гарантирует корректную работу в случае разных геометрий