### PR TITLE
[geometry] Move Junction and TAltitude to geometry.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -36,6 +36,7 @@
 
 #include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "indexer/feature_altitude.hpp"
 
@@ -1382,7 +1383,7 @@ Java_com_mapswithme_maps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv *
   ::Framework * fr = frm();
   ASSERT(fr, ());
 
-  feature::TAltitudes altitudes;
+  geometry::TAltitudes altitudes;
   vector<double> routePointDistanceM;
   if (!fr->GetRoutingManager().GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
   {

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -48,7 +48,7 @@ public:
   explicit SrtmGetter(std::string const & srtmDir) : m_srtmManager(srtmDir) {}
 
   // AltitudeGetter overrides:
-  feature::TAltitude GetAltitude(m2::PointD const & p) override
+  geometry::TAltitude GetAltitude(m2::PointD const & p) override
   {
     return m_srtmManager.GetHeight(mercator::ToLatLon(p));
   }
@@ -75,7 +75,7 @@ public:
   using TFeatureAltitudes = std::vector<FeatureAltitude>;
 
   explicit Processor(AltitudeGetter & altitudeGetter)
-    : m_altitudeGetter(altitudeGetter), m_minAltitude(kInvalidAltitude)
+    : m_altitudeGetter(altitudeGetter), m_minAltitude(geometry::kInvalidAltitude)
   {
   }
 
@@ -86,7 +86,7 @@ public:
     return m_altitudeAvailabilityBuilder;
   }
 
-  TAltitude GetMinAltitude() const { return m_minAltitude; }
+  geometry::TAltitude GetMinAltitude() const { return m_minAltitude; }
 
   void operator()(FeatureType & f, uint32_t const & id)
   {
@@ -108,18 +108,18 @@ public:
     if (pointsCount == 0)
       return;
 
-    TAltitudes altitudes;
-    TAltitude minFeatureAltitude = kInvalidAltitude;
+    geometry::TAltitudes altitudes;
+    geometry::TAltitude minFeatureAltitude = geometry::kInvalidAltitude;
     for (size_t i = 0; i < pointsCount; ++i)
     {
-      TAltitude const a = m_altitudeGetter.GetAltitude(f.GetPoint(i));
-      if (a == kInvalidAltitude)
+      geometry::TAltitude const a = m_altitudeGetter.GetAltitude(f.GetPoint(i));
+      if (a == geometry::kInvalidAltitude)
       {
         // One invalid point invalidates the whole feature.
         return;
       }
 
-      if (minFeatureAltitude == kInvalidAltitude)
+      if (minFeatureAltitude == geometry::kInvalidAltitude)
         minFeatureAltitude = a;
       else
         minFeatureAltitude = std::min(minFeatureAltitude, a);
@@ -130,7 +130,7 @@ public:
     hasAltitude = true;
     m_featureAltitudes.emplace_back(id, Altitudes(std::move(altitudes)));
 
-    if (m_minAltitude == kInvalidAltitude)
+    if (m_minAltitude == geometry::kInvalidAltitude)
       m_minAltitude = minFeatureAltitude;
     else
       m_minAltitude = std::min(minFeatureAltitude, m_minAltitude);
@@ -148,7 +148,7 @@ private:
   AltitudeGetter & m_altitudeGetter;
   TFeatureAltitudes m_featureAltitudes;
   succinct::bit_vector_builder m_altitudeAvailabilityBuilder;
-  TAltitude m_minAltitude;
+  geometry::TAltitude m_minAltitude;
 };
 }  // namespace
 

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "indexer/feature_altitude.hpp"
 
@@ -11,7 +12,7 @@ namespace routing
 class AltitudeGetter
 {
 public:
-  virtual feature::TAltitude GetAltitude(m2::PointD const & p) = 0;
+  virtual geometry::TAltitude GetAltitude(m2::PointD const & p) = 0;
 };
 
 /// \brief Adds altitude section to mwm. It has the following format:

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -13,6 +13,7 @@
 #include "indexer/feature_processor.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "platform/country_file.hpp"
 #include "platform/platform.hpp"
@@ -55,10 +56,10 @@ std::string const kTestMwm = "test";
 
 struct Point3D
 {
-  Point3D(int32_t x, int32_t y, TAltitude a) : m_point(x, y), m_altitude(a) {}
+  Point3D(int32_t x, int32_t y, geometry::TAltitude a) : m_point(x, y), m_altitude(a) {}
 
   m2::PointI m_point;
-  TAltitude m_altitude;
+  geometry::TAltitude m_altitude;
 };
 
 using TPoint3DList = std::vector<Point3D>;
@@ -71,7 +72,7 @@ TPoint3DList const kRoad4 = {{-10, 1, -1}, {-20, 6, -100}, {-20, -11, -110}};
 class MockAltitudeGetter : public AltitudeGetter
 {
 public:
-  using TMockAltitudes = std::map<m2::PointI, TAltitude>;
+  using TMockAltitudes = std::map<m2::PointI, geometry::TAltitude>;
 
   explicit MockAltitudeGetter(std::vector<TPoint3DList> const & roads)
   {
@@ -92,12 +93,12 @@ public:
   }
 
   // AltitudeGetter overrides:
-  TAltitude GetAltitude(m2::PointD const & p) override
+  geometry::TAltitude GetAltitude(m2::PointD const & p) override
   {
     m2::PointI const rounded(static_cast<int32_t>(round(p.x)), static_cast<int32_t>(round(p.y)));
     auto const it = m_altitudes.find(rounded);
     if (it == m_altitudes.end())
-      return kInvalidAltitude;
+      return geometry::kInvalidAltitude;
 
     return it->second;
   }
@@ -110,9 +111,9 @@ private:
 class MockNoAltitudeGetter : public AltitudeGetter
 {
 public:
-  TAltitude GetAltitude(m2::PointD const &) override
+  geometry::TAltitude GetAltitude(m2::PointD const &) override
   {
-    return kInvalidAltitude;
+    return geometry::kInvalidAltitude;
   }
 };
 
@@ -142,7 +143,7 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
   auto processor = [&expectedAltitudes, &loader](FeatureType & f, uint32_t const & id) {
     f.ParseGeometry(FeatureType::BEST_GEOMETRY);
     size_t const pointsCount = f.GetPointsCount();
-    TAltitudes const altitudes = loader.GetAltitudes(id, pointsCount);
+    geometry::TAltitudes const altitudes = loader.GetAltitudes(id, pointsCount);
 
     if (!routing::IsRoad(feature::TypesHolder(f)))
     {
@@ -154,8 +155,10 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
 
     for (size_t i = 0; i < pointsCount; ++i)
     {
-      TAltitude const fromGetter = expectedAltitudes.GetAltitude(f.GetPoint(i));
-      TAltitude const expected = (fromGetter == kInvalidAltitude ? kDefaultAltitudeMeters : fromGetter);
+      geometry::TAltitude const fromGetter = expectedAltitudes.GetAltitude(f.GetPoint(i));
+      geometry::TAltitude const expected =
+          (fromGetter == geometry::kInvalidAltitude ? geometry::kDefaultAltitudeMeters
+                                                    : fromGetter);
       TEST_EQUAL(expected, altitudes[i], ("A wrong altitude"));
     }
   };

--- a/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
+++ b/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
@@ -9,6 +9,7 @@
 #include "indexer/feature_processor.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "platform/country_file.hpp"
 #include "platform/local_country_file.hpp"
@@ -80,7 +81,7 @@ int main(int argc, char * argv[])
       for (size_t i = 0; i < ft.GetPointsCount(); ++i)
       {
         auto const height = manager.GetHeight(mercator::ToLatLon(ft.GetPoint(i)));
-        if (height != feature::kInvalidAltitude)
+        if (height != geometry::kInvalidAltitude)
           good++;
       }
     });

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -84,10 +84,10 @@ void SrtmTile::Init(std::string const & dir, ms::LatLon const & coord)
   m_valid = true;
 }
 
-feature::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
+geometry::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
 {
   if (!IsValid())
-    return feature::kInvalidAltitude;
+    return geometry::kInvalidAltitude;
 
   double ln = coord.m_lon - static_cast<int>(coord.m_lon);
   if (ln < 0)
@@ -103,7 +103,7 @@ feature::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
   size_t const ix = row * (kArcSecondsInDegree + 1) + col;
 
   if (ix >= Size())
-    return feature::kInvalidAltitude;
+    return geometry::kInvalidAltitude;
   return ReverseByteOrder(Data()[ix]);
 }
 
@@ -145,7 +145,7 @@ void SrtmTile::Invalidate()
 
 // SrtmTileManager ---------------------------------------------------------------------------------
 SrtmTileManager::SrtmTileManager(std::string const & dir) : m_dir(dir) {}
-feature::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
+geometry::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 {
   std::string const base = SrtmTile::GetBase(coord);
   auto it = m_tiles.find(base);

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -4,6 +4,8 @@
 
 #include "indexer/feature_altitude.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/macros.hpp"
 
 #include <cstdint>
@@ -22,17 +24,17 @@ public:
 
   inline bool IsValid() const { return m_valid; }
   // Returns height in meters at |coord| or kInvalidAltitude.
-  feature::TAltitude GetHeight(ms::LatLon const & coord);
+  geometry::TAltitude GetHeight(ms::LatLon const & coord);
 
   static std::string GetBase(ms::LatLon coord);
 
 private:
-  inline feature::TAltitude const * Data() const
+  inline geometry::TAltitude const * Data() const
   {
-    return reinterpret_cast<feature::TAltitude const *>(m_data.data());
+    return reinterpret_cast<geometry::TAltitude const *>(m_data.data());
   };
 
-  inline size_t Size() const { return m_data.size() / sizeof(feature::TAltitude); }
+  inline size_t Size() const { return m_data.size() / sizeof(geometry::TAltitude); }
   void Invalidate();
 
   std::string m_data;
@@ -46,7 +48,7 @@ class SrtmTileManager
 public:
   SrtmTileManager(std::string const & dir);
 
-  feature::TAltitude GetHeight(ms::LatLon const & coord);
+  geometry::TAltitude GetHeight(ms::LatLon const & coord);
 
 private:
   std::string m_dir;

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -43,6 +43,8 @@ set(
   parametrized_segment.hpp
   point2d.hpp
   point3d.hpp
+  point_with_altitude.cpp
+  point_with_altitude.hpp
   polygon.hpp
   polyline2d.hpp
   rect2d.hpp

--- a/geometry/point_with_altitude.cpp
+++ b/geometry/point_with_altitude.cpp
@@ -1,0 +1,24 @@
+#include "geometry/point_with_altitude.hpp"
+
+#include <sstream>
+
+namespace geometry
+{
+PointWithAltitude::PointWithAltitude()
+  : m_point(m2::PointD::Zero()), m_altitude(kDefaultAltitudeMeters)
+{
+}
+
+PointWithAltitude::PointWithAltitude(m2::PointD const & point, TAltitude altitude)
+  : m_point(point), m_altitude(altitude)
+{
+}
+
+std::string DebugPrint(PointWithAltitude const & r)
+{
+  std::ostringstream ss;
+  ss << "PointWithAltitude{point:" << DebugPrint(r.m_point) << ", altitude:" << r.GetAltitude()
+     << "}";
+  return ss.str();
+}
+}  // namespace geometry

--- a/geometry/point_with_altitude.hpp
+++ b/geometry/point_with_altitude.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "geometry/point2d.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace geometry
+{
+using TAltitude = int16_t;
+using TAltitudes = std::vector<TAltitude>;
+
+TAltitude constexpr kInvalidAltitude = std::numeric_limits<TAltitude>::min();
+TAltitude constexpr kDefaultAltitudeMeters = 0;
+
+double constexpr kPointsEqualEpsilon = 1e-6;
+
+class PointWithAltitude
+{
+public:
+  PointWithAltitude();
+  PointWithAltitude(m2::PointD const & point, TAltitude altitude);
+  PointWithAltitude(PointWithAltitude const &) = default;
+  PointWithAltitude & operator=(PointWithAltitude const &) = default;
+
+  bool operator==(PointWithAltitude const & r) const { return m_point == r.m_point; }
+  bool operator!=(PointWithAltitude const & r) const { return !(*this == r); }
+  bool operator<(PointWithAltitude const & r) const { return m_point < r.m_point; }
+
+  m2::PointD const & GetPoint() const { return m_point; }
+  TAltitude GetAltitude() const { return m_altitude; }
+
+private:
+  friend std::string DebugPrint(PointWithAltitude const & r);
+
+  m2::PointD m_point;
+  TAltitude m_altitude;
+};
+
+std::string DebugPrint(PointWithAltitude const & r);
+
+inline PointWithAltitude MakePointWithAltitudeForTesting(m2::PointD const & point)
+{
+  return PointWithAltitude(point, kDefaultAltitudeMeters);
+}
+
+inline bool AlmostEqualAbs(PointWithAltitude const & lhs, PointWithAltitude const & rhs)
+{
+  return base::AlmostEqualAbs(lhs.GetPoint(), rhs.GetPoint(), kPointsEqualEpsilon);
+}
+}  // namespace geometry

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -68,15 +68,18 @@ AltitudeLoader::AltitudeLoader(DataSource const & dataSource, MwmSet::MwmId cons
 
 bool AltitudeLoader::HasAltitudes() const
 {
-  return m_reader != nullptr && m_header.m_minAltitude != kInvalidAltitude;
+  return m_reader != nullptr && m_header.m_minAltitude != geometry::kInvalidAltitude;
 }
 
-TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t pointCount)
+geometry::TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t pointCount)
 {
   if (!HasAltitudes())
   {
     // The version of mwm is less than version::Format::v8 or there's no altitude section in mwm.
-    return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, kDefaultAltitudeMeters))).first->second;
+    return m_cache
+        .insert(make_pair(featureId,
+                          geometry::TAltitudes(pointCount, geometry::kDefaultAltitudeMeters)))
+        .first->second;
   }
 
   auto const it = m_cache.find(featureId);
@@ -85,7 +88,8 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
 
   if (!m_altitudeAvailability[featureId])
   {
-    return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, m_header.m_minAltitude)))
+    return m_cache
+        .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
         .first->second;
   }
 
@@ -105,14 +109,17 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
     bool const isDeserialized = altitudes.Deserialize(m_header.m_minAltitude, pointCount,
                                                       m_countryFileName, featureId,  src);
 
-    bool const allValid = isDeserialized
-        && none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
-                   [](TAltitude a) { return a == kInvalidAltitude; });
+    bool const allValid =
+        isDeserialized &&
+        none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
+                [](geometry::TAltitude a) { return a == geometry::kInvalidAltitude; });
     if (!allValid)
     {
       LOG(LERROR, ("Only a part point of a feature has a valid altitdue. Altitudes: ", altitudes.m_altitudes,
                    ". Feature Id", featureId, "of", m_countryFileName));
-      return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, m_header.m_minAltitude))).first->second;
+      return m_cache
+          .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
+          .first->second;
     }
 
     return m_cache.insert(make_pair(featureId, move(altitudes.m_altitudes))).first->second;
@@ -120,7 +127,9 @@ TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t point
   catch (Reader::OpenException const & e)
   {
     LOG(LERROR, ("Feature Id", featureId, "of", m_countryFileName, ". Error while getting altitude data:", e.Msg()));
-    return m_cache.insert(make_pair(featureId, TAltitudes(pointCount, m_header.m_minAltitude))).first->second;
+    return m_cache
+        .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
+        .first->second;
   }
 }
 }  // namespace feature

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -4,6 +4,8 @@
 
 #include "coding/memory_region.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,7 +29,7 @@ public:
 
   /// \returns altitude of feature with |featureId|. All items of the returned vector are valid
   /// or the returned vector is empty.
-  TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
+  geometry::TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
 
   bool HasAltitudes() const;
 
@@ -41,7 +43,7 @@ private:
   succinct::elias_fano m_featureTable;
 
   std::unique_ptr<FilesContainerR::TReader> m_reader;
-  std::map<uint32_t, TAltitudes> m_cache;
+  std::map<uint32_t, geometry::TAltitudes> m_cache;
   AltitudeHeader m_header;
   std::string m_countryFileName;
   MwmSet::MwmHandle m_handle;

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -547,7 +547,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
     return;
 
   auto routePointDistanceM = std::make_shared<std::vector<double>>(std::vector<double>());
-  auto altitudes = std::make_shared<feature::TAltitudes>(feature::TAltitudes());
+  auto altitudes = std::make_shared<geometry::TAltitudes>(geometry::TAltitudes());
   if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*routePointDistanceM, *altitudes))
     return;
 

--- a/map/chart_generator.cpp
+++ b/map/chart_generator.cpp
@@ -107,7 +107,7 @@ void ReflectChartData(vector<double> & chartData)
 }
 
 bool NormalizeChartData(vector<double> const & distanceDataM,
-                        feature::TAltitudes const & altitudeDataM, size_t resultPointCount,
+                        geometry::TAltitudes const & altitudeDataM, size_t resultPointCount,
                         vector<double> & uniformAltitudeDataM)
 {
   double constexpr kEpsilon = 1e-6;
@@ -272,7 +272,7 @@ bool GenerateChartByPoints(uint32_t width, uint32_t height, vector<m2::PointD> c
 }
 
 bool GenerateChart(uint32_t width, uint32_t height, vector<double> const & distanceDataM,
-                   feature::TAltitudes const & altitudeDataM, MapStyle mapStyle,
+                   geometry::TAltitudes const & altitudeDataM, MapStyle mapStyle,
                    vector<uint8_t> & frameBuffer)
 {
   if (distanceDataM.size() != altitudeDataM.size())

--- a/map/chart_generator.hpp
+++ b/map/chart_generator.hpp
@@ -4,6 +4,7 @@
 #include "indexer/map_style.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -21,7 +22,7 @@ void ReflectChartData(std::vector<double> & chartData);
 /// |resultPointCount| points. |distanceDataM| and |altitudeDataM| form a curve of route altitude.
 /// This method is used to generalize and evenly distribute points of the chart.
 bool NormalizeChartData(std::vector<double> const & distanceDataM,
-                        feature::TAltitudes const & altitudeDataM, size_t resultPointCount,
+                        geometry::TAltitudes const & altitudeDataM, size_t resultPointCount,
                         std::vector<double> & uniformAltitudeDataM);
 
 /// \brief fills |yAxisDataPxl|. |yAxisDataPxl| is formed to pevent displaying
@@ -47,6 +48,6 @@ bool GenerateChartByPoints(uint32_t width, uint32_t height,
                            std::vector<uint8_t> & frameBuffer);
 
 bool GenerateChart(uint32_t width, uint32_t height, std::vector<double> const & distanceDataM,
-                   feature::TAltitudes const & altitudeDataM, MapStyle mapStyle,
+                   geometry::TAltitudes const & altitudeDataM, MapStyle mapStyle,
                    std::vector<uint8_t> & frameBuffer);
 }  // namespace maps

--- a/map/map_tests/chart_generator_tests.cpp
+++ b/map/map_tests/chart_generator_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "map/chart_generator.hpp"
 
+#include "geometry/point_with_altitude.hpp"
 #include "base/math.hpp"
 
 #include <cstdint>
@@ -77,7 +78,7 @@ UNIT_TEST(ReflectChartData_Test)
 UNIT_TEST(NormalizeChartData_SmokeTest)
 {
   vector<double> const distanceDataM = {0.0, 0.0, 0.0};
-  feature::TAltitudes const altitudeDataM = {0, 0, 0};
+  geometry::TAltitudes const altitudeDataM = {0, 0, 0};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 2 /* resultPointCount */, uniformAltitudeDataM),
@@ -90,7 +91,7 @@ UNIT_TEST(NormalizeChartData_SmokeTest)
 UNIT_TEST(NormalizeChartData_NoResultPointTest)
 {
   vector<double> const distanceDataM = {0.0, 0.0, 0.0};
-  feature::TAltitudes const altitudeDataM = {0, 0, 0};
+  geometry::TAltitudes const altitudeDataM = {0, 0, 0};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 0 /* resultPointCount */, uniformAltitudeDataM),
@@ -102,7 +103,7 @@ UNIT_TEST(NormalizeChartData_NoResultPointTest)
 UNIT_TEST(NormalizeChartData_NoPointTest)
 {
   vector<double> const distanceDataM = {};
-  feature::TAltitudes const altitudeDataM = {};
+  geometry::TAltitudes const altitudeDataM = {};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 2 /* resultPointCount */, uniformAltitudeDataM),
@@ -114,7 +115,7 @@ UNIT_TEST(NormalizeChartData_NoPointTest)
 UNIT_TEST(NormalizeChartData_Test)
 {
   vector<double> const distanceDataM = {0.0, 2.0, 4.0, 6.0};
-  feature::TAltitudes const altitudeDataM = {-9, 0, 9, 18};
+  geometry::TAltitudes const altitudeDataM = {-9, 0, 9, 18};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 10 /* resultPointCount */, uniformAltitudeDataM),
@@ -201,7 +202,7 @@ UNIT_TEST(GenerateChart_NoPointsTest)
 {
   size_t constexpr width = 50;
   vector<double> const distanceDataM = {};
-  feature::TAltitudes const & altitudeDataM = {};
+  geometry::TAltitudes const & altitudeDataM = {};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -216,7 +217,7 @@ UNIT_TEST(GenerateChart_OnePointTest)
   size_t constexpr width = 50;
   size_t constexpr height = 50;
   vector<double> const distanceDataM = {0.0};
-  feature::TAltitudes const & altitudeDataM = {0};
+  geometry::TAltitudes const & altitudeDataM = {0};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, height, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -233,7 +234,7 @@ UNIT_TEST(GenerateChart_EmptyRectTest)
 {
   size_t constexpr width = 0;
   vector<double> const distanceDataM = {};
-  feature::TAltitudes const & altitudeDataM = {};
+  geometry::TAltitudes const & altitudeDataM = {};
   vector<uint8_t> frameBuffer;
 
   TEST(!maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -246,7 +247,7 @@ UNIT_TEST(GenerateChart_Test)
 {
   size_t constexpr width = 50;
   vector<double> const distanceDataM = {0.0, 100.0};
-  feature::TAltitudes const & altitudeDataM = {0, 1000};
+  geometry::TAltitudes const & altitudeDataM = {0, 1000};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1198,7 +1198,7 @@ bool RoutingManager::HasRouteAltitude() const
 }
 
 bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & routePointDistanceM,
-                                                    feature::TAltitudes & altitudes) const
+                                                    geometry::TAltitudes & altitudes) const
 {
   if (!m_routingSession.GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
     return false;
@@ -1208,7 +1208,7 @@ bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & routePointD
 }
 
 bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
-                                                feature::TAltitudes const & altitudes,
+                                                geometry::TAltitudes const & altitudes,
                                                 vector<double> const & routePointDistanceM,
                                                 vector<uint8_t> & imageRGBAData,
                                                 int32_t & minRouteAltitude,
@@ -1224,8 +1224,8 @@ bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
     return false;
 
   auto const minMaxIt = minmax_element(altitudes.cbegin(), altitudes.cend());
-  feature::TAltitude const minRouteAltitudeM = *minMaxIt.first;
-  feature::TAltitude const maxRouteAltitudeM = *minMaxIt.second;
+  geometry::TAltitude const minRouteAltitudeM = *minMaxIt.first;
+  geometry::TAltitude const maxRouteAltitudeM = *minMaxIt.second;
 
   if (!settings::Get(settings::kMeasurementUnits, altitudeUnits))
     altitudeUnits = measurement_utils::Units::Metric;

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -21,6 +21,7 @@
 #include "tracking/reporter.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/thread_checker.hpp"
 
@@ -263,7 +264,7 @@ public:
   /// \brief Fills altitude of current route points and distance in meters form the beginning
   /// of the route point based on the route in RoutingSession.
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routePointDistanceM,
-                                      feature::TAltitudes & altitudes) const;
+                                      geometry::TAltitudes & altitudes) const;
 
   /// \brief Generates 4 bytes per point image (RGBA) and put the data to |imageRGBAData|.
   /// \param width is width of chart shall be generated in pixels.
@@ -280,7 +281,7 @@ public:
   /// \note If HasRouteAltitude() method returns true, GenerateRouteAltitudeChart(...)
   /// could return false if route was deleted or rebuilt between the calls.
   bool GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
-                                  feature::TAltitudes const & altitudes,
+                                  geometry::TAltitudes const & altitudes,
                                   std::vector<double> const & routePointDistanceM,
                                   std::vector<uint8_t> & imageRGBAData, int32_t & minRouteAltitude,
                                   int32_t & maxRouteAltitude,

--- a/openlr/candidate_paths_getter.cpp
+++ b/openlr/candidate_paths_getter.cpp
@@ -10,6 +10,7 @@
 #include "platform/location.hpp"
 
 #include "geometry/angles.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <algorithm>
 #include <iterator>
@@ -46,11 +47,11 @@ Graph::Edge CandidatePathsGetter::Link::GetStartEdge() const
   return start->m_edge;
 }
 
-bool CandidatePathsGetter::Link::IsJunctionInPath(routing::Junction const & j) const
+bool CandidatePathsGetter::Link::IsPointOnPath(geometry::PointWithAltitude const & point) const
 {
   for (auto * l = this; l; l = l->m_parent.get())
   {
-    if (l->m_edge.GetEndJunction() == j)
+    if (l->m_edge.GetEndJunction() == point)
     {
       LOG(LDEBUG, ("A loop detected, skipping..."));
       return true;
@@ -104,9 +105,9 @@ void CandidatePathsGetter::GetStartLines(vector<m2::PointD> const & points, bool
   for (auto const & pc : points)
   {
     if (!isLastPoint)
-      m_graph.GetOutgoingEdges(Junction(pc, 0 /* altitude */), edges);
+      m_graph.GetOutgoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), edges);
     else
-      m_graph.GetIngoingEdges(Junction(pc, 0 /* altitude */), edges);
+      m_graph.GetIngoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), edges);
   }
 
   // Same edges may start on different points if those points are close enough.
@@ -165,7 +166,7 @@ void CandidatePathsGetter::GetAllSuitablePaths(Graph::EdgeVector const & startLi
 
       // TODO(mgsergio): Should we check form of way as well?
 
-      if (u->IsJunctionInPath(e.GetEndJunction()))
+      if (u->IsPointOnPath(e.GetEndJunction()))
         continue;
 
       auto const p = make_shared<Link>(u, e, u->m_distanceM + currentEdgeLen);

--- a/openlr/candidate_paths_getter.hpp
+++ b/openlr/candidate_paths_getter.hpp
@@ -47,7 +47,7 @@ private:
     {
     }
 
-    bool IsJunctionInPath(routing::Junction const & j) const;
+    bool IsPointOnPath(geometry::PointWithAltitude const & point) const;
 
     Graph::Edge GetStartEdge() const;
 

--- a/openlr/candidate_points_getter.cpp
+++ b/openlr/candidate_points_getter.cpp
@@ -6,6 +6,8 @@
 
 #include "storage/country_info_getter.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/stl_helpers.hpp"
 
 #include <algorithm>
@@ -56,7 +58,7 @@ void CandidatePointsGetter::EnrichWithProjectionPoints(m2::PointD const & p,
 {
   m_graph.ResetFakes();
 
-  std::vector<std::pair<Graph::Edge, Junction>> vicinities;
+  std::vector<std::pair<Graph::Edge, geometry::PointWithAltitude>> vicinities;
   m_graph.FindClosestEdges(p, static_cast<uint32_t>(m_maxProjectionCandidates), vicinities);
   for (auto const & v : vicinities)
   {

--- a/openlr/decoded_path.cpp
+++ b/openlr/decoded_path.cpp
@@ -137,8 +137,8 @@ void PathFromXML(pugi::xml_node const & node, DataSource const & dataSource, Pat
 
     p.push_back(Edge::MakeReal(
         fid, isForward, segmentId,
-        routing::Junction(mercator::FromLatLon(start), feature::kDefaultAltitudeMeters),
-        routing::Junction(mercator::FromLatLon(end), feature::kDefaultAltitudeMeters)));
+        geometry::PointWithAltitude(mercator::FromLatLon(start), geometry::kDefaultAltitudeMeters),
+        geometry::PointWithAltitude(mercator::FromLatLon(end), geometry::kDefaultAltitudeMeters)));
   }
 }
 

--- a/openlr/graph.cpp
+++ b/openlr/graph.cpp
@@ -1,6 +1,7 @@
 #include "openlr/graph.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <map>
 #include <memory>
@@ -14,9 +15,10 @@ namespace openlr
 {
 namespace
 {
-using EdgeGetter = void (IRoadGraph::*)(Junction const &, RoadGraphBase::EdgeVector &) const;
+using EdgeGetter = void (IRoadGraph::*)(geometry::PointWithAltitude const &,
+                                        RoadGraphBase::EdgeVector &) const;
 
-void GetRegularEdges(Junction const & junction, IRoadGraph const & graph,
+void GetRegularEdges(geometry::PointWithAltitude const & junction, IRoadGraph const & graph,
                      EdgeGetter const edgeGetter,
                      map<openlr::Graph::Junction, Graph::EdgeVector> & cache,
                      Graph::EdgeVector & edges)

--- a/openlr/graph.hpp
+++ b/openlr/graph.hpp
@@ -26,14 +26,14 @@ class Graph
 public:
   using Edge = routing::Edge;
   using EdgeVector = routing::FeaturesRoadGraph::EdgeVector;
-  using Junction = routing::Junction;
+  using Junction = geometry::PointWithAltitude;
 
   Graph(DataSource const & dataSource, std::shared_ptr<routing::CarModelFactory> carModelFactory);
 
   // Appends edges such as that edge.GetStartJunction() == junction to the |edges|.
-  void GetOutgoingEdges(routing::Junction const & junction, EdgeVector & edges);
+  void GetOutgoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges);
   // Appends edges such as that edge.GetEndJunction() == junction to the |edges|.
-  void GetIngoingEdges(routing::Junction const & junction, EdgeVector & edges);
+  void GetIngoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges);
 
   // Appends edges such as that edge.GetStartJunction() == junction and edge.IsFake() == false
   // to the |edges|.

--- a/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
@@ -202,9 +202,8 @@ public:
   std::vector<m2::PointD> GetReachablePoints(m2::PointD const & p) const override
   {
     routing::FeaturesRoadGraph::EdgeVector edges;
-    m_roadGraph.GetOutgoingEdges(
-        routing::Junction(p, feature::kDefaultAltitudeMeters),
-        edges);
+    m_roadGraph.GetOutgoingEdges(geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters),
+                                 edges);
 
     std::vector<m2::PointD> points;
     for (auto const & e : edges)

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.cpp
@@ -394,10 +394,10 @@ void TrafficMode::CommitPath()
     std::tie(prevFid, prevSegId) = prevPoint.GetPoint();
     std::tie(fid, segId) = point.GetPoint();
 
-    path.push_back(Edge::MakeReal(fid, prevSegId < segId /* forward */,
-                                  base::checked_cast<uint32_t>(prevSegId),
-                                  routing::Junction(prevPoint.GetCoordinate(), 0 /* altitude */),
-                                  routing::Junction(point.GetCoordinate(), 0 /* altitude */)));
+    path.push_back(Edge::MakeReal(
+        fid, prevSegId < segId /* forward */, base::checked_cast<uint32_t>(prevSegId),
+        geometry::PointWithAltitude(prevPoint.GetCoordinate(), 0 /* altitude */),
+        geometry::PointWithAltitude(point.GetCoordinate(), 0 /* altitude */)));
   }
 
   m_currentSegment->SetGoldenPath(path);

--- a/openlr/openlr_tests/decoded_path_test.cpp
+++ b/openlr/openlr_tests/decoded_path_test.cpp
@@ -46,9 +46,9 @@ double RoughUpToFive(double d)
 
 m2::PointD RoughPoint(m2::PointD const & p) { return {RoughUpToFive(p.x), RoughUpToFive(p.y)}; }
 
-routing::Junction RoughJunction(routing::Junction const & j)
+geometry::PointWithAltitude RoughJunction(geometry::PointWithAltitude const & j)
 {
-  return routing::Junction(RoughPoint(j.GetPoint()), j.GetAltitude());
+  return geometry::PointWithAltitude(RoughPoint(j.GetPoint()), j.GetAltitude());
 }
 
 routing::Edge RoughEdgeJunctions(routing::Edge const & e)
@@ -106,7 +106,8 @@ openlr::Path MakePath(FeatureType const & road, bool const forward)
     path.push_back(routing::Edge::MakeReal(
         road.GetID(), forward,
         base::checked_cast<uint32_t>(current - static_cast<size_t>(!forward)) /* segId */,
-        routing::Junction(from, 0 /* altitude */), routing::Junction(to, 0 /* altitude */)));
+        geometry::PointWithAltitude(from, 0 /* altitude */),
+        geometry::PointWithAltitude(to, 0 /* altitude */)));
   }
 
   RoughJunctionsInPath(path);

--- a/openlr/router.hpp
+++ b/openlr/router.hpp
@@ -73,8 +73,9 @@ private:
     };
 
     Vertex() = default;
-    Vertex(routing::Junction const & junction, routing::Junction const & stageStart,
-           double stageStartDistance, size_t stage, bool bearingChecked);
+    Vertex(geometry::PointWithAltitude const & junction,
+           geometry::PointWithAltitude const & stageStart, double stageStartDistance, size_t stage,
+           bool bearingChecked);
 
     bool operator<(Vertex const & rhs) const;
     bool operator==(Vertex const & rhs) const;
@@ -82,8 +83,8 @@ private:
 
     m2::PointD GetPoint() const { return m_junction.GetPoint(); }
 
-    routing::Junction m_junction;
-    routing::Junction m_stageStart;
+    geometry::PointWithAltitude m_junction;
+    geometry::PointWithAltitude m_stageStart;
     double m_stageStartDistance = 0.0;
     size_t m_stage = 0;
     bool m_bearingChecked = false;
@@ -137,7 +138,7 @@ private:
   using Links = std::map<Vertex, std::pair<Vertex, Edge>>;
 
   using RoadGraphEdgesGetter = void (routing::IRoadGraph::*)(
-      routing::Junction const & junction, routing::IRoadGraph::EdgeVector & edges) const;
+      geometry::PointWithAltitude const & junction, routing::IRoadGraph::EdgeVector & edges) const;
 
   bool Init(std::vector<WayPoint> const & points, double positiveOffsetM, double negativeOffsetM);
   bool FindPath(std::vector<routing::Edge> & path);
@@ -172,11 +173,13 @@ private:
   template <typename Fn>
   void ForEachEdge(Vertex const & u, bool outgoing, FunctionalRoadClass restriction, Fn && fn);
 
-  void GetOutgoingEdges(routing::Junction const & u, routing::IRoadGraph::EdgeVector & edges);
-  void GetIngoingEdges(routing::Junction const & u, routing::IRoadGraph::EdgeVector & edges);
-  void GetEdges(routing::Junction const & u, RoadGraphEdgesGetter getRegular,
+  void GetOutgoingEdges(geometry::PointWithAltitude const & u,
+                        routing::IRoadGraph::EdgeVector & edges);
+  void GetIngoingEdges(geometry::PointWithAltitude const & u,
+                       routing::IRoadGraph::EdgeVector & edges);
+  void GetEdges(geometry::PointWithAltitude const & u, RoadGraphEdgesGetter getRegular,
                 RoadGraphEdgesGetter getFake,
-                std::map<routing::Junction, routing::IRoadGraph::EdgeVector> & cache,
+                std::map<geometry::PointWithAltitude, routing::IRoadGraph::EdgeVector> & cache,
                 routing::IRoadGraph::EdgeVector & edges);
 
   template <typename Fn>
@@ -211,15 +214,15 @@ private:
   void FindSingleEdgeApproximation(std::vector<Edge> const & edges, std::vector<routing::Edge> & path);
 
   routing::FeaturesRoadGraph & m_graph;
-  std::map<routing::Junction, routing::IRoadGraph::EdgeVector> m_outgoingCache;
-  std::map<routing::Junction, routing::IRoadGraph::EdgeVector> m_ingoingCache;
+  std::map<geometry::PointWithAltitude, routing::IRoadGraph::EdgeVector> m_outgoingCache;
+  std::map<geometry::PointWithAltitude, routing::IRoadGraph::EdgeVector> m_ingoingCache;
   RoadInfoGetter & m_roadInfoGetter;
 
   std::vector<WayPoint> m_points;
   double m_positiveOffsetM;
   double m_negativeOffsetM;
   std::vector<std::vector<m2::PointD>> m_pivots;
-  routing::Junction m_sourceJunction;
-  routing::Junction m_targetJunction;
+  geometry::PointWithAltitude m_sourceJunction;
+  geometry::PointWithAltitude m_targetJunction;
 };
 }  // namespace openlr

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -10,6 +10,7 @@
 
 #include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/logging.hpp"
 #include "base/stl_helpers.hpp"
@@ -66,7 +67,7 @@ Graph::Edge ScoreCandidatePathsGetter::Link::GetStartEdge() const
   return start->m_edge;
 }
 
-bool ScoreCandidatePathsGetter::Link::IsJunctionInPath(Junction const & j) const
+bool ScoreCandidatePathsGetter::Link::IsJunctionInPath(geometry::PointWithAltitude const & j) const
 {
   for (auto * l = this; l; l = l->m_parent.get())
   {

--- a/openlr/score_candidate_paths_getter.hpp
+++ b/openlr/score_candidate_paths_getter.hpp
@@ -47,7 +47,7 @@ private:
       CHECK(!edge.IsFake(), ("Edge should not be fake:", edge));
     }
 
-    bool IsJunctionInPath(routing::Junction const & j) const;
+    bool IsJunctionInPath(geometry::PointWithAltitude const & j) const;
 
     Graph::Edge GetStartEdge() const;
 

--- a/openlr/score_candidate_points_getter.cpp
+++ b/openlr/score_candidate_points_getter.cpp
@@ -11,6 +11,7 @@
 #include "indexer/scales.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/assert.hpp"
 #include "base/stl_helpers.hpp"
@@ -55,9 +56,9 @@ void ScoreCandidatePointsGetter::GetJunctionPointCandidates(m2::PointD const & p
   {
     Graph::EdgeVector edges;
     if (!isLastPoint)
-      m_graph.GetOutgoingEdges(Junction(pc.m_point, 0 /* altitude */), edges);
+      m_graph.GetOutgoingEdges(geometry::PointWithAltitude(pc.m_point, 0 /* altitude */), edges);
     else
-      m_graph.GetIngoingEdges(Junction(pc.m_point, 0 /* altitude */), edges);
+      m_graph.GetIngoingEdges(geometry::PointWithAltitude(pc.m_point, 0 /* altitude */), edges);
 
     for (auto const & e : edges)
       edgeCandidates.emplace_back(pc.m_score, e);
@@ -69,7 +70,7 @@ void ScoreCandidatePointsGetter::EnrichWithProjectionPoints(m2::PointD const & p
 {
   m_graph.ResetFakes();
 
-  std::vector<std::pair<Graph::Edge, Junction>> vicinities;
+  std::vector<std::pair<Graph::Edge, geometry::PointWithAltitude>> vicinities;
   m_graph.FindClosestEdges(p, static_cast<uint32_t>(m_maxProjectionCandidates), vicinities);
   for (auto const & v : vicinities)
   {
@@ -89,10 +90,10 @@ void ScoreCandidatePointsGetter::EnrichWithProjectionPoints(m2::PointD const & p
 bool ScoreCandidatePointsGetter::IsJunction(m2::PointD const & p)
 {
   Graph::EdgeVector outgoing;
-  m_graph.GetRegularOutgoingEdges(Junction(p, 0 /* altitude */), outgoing);
+  m_graph.GetRegularOutgoingEdges(geometry::PointWithAltitude(p, 0 /* altitude */), outgoing);
 
   Graph::EdgeVector ingoing;
-  m_graph.GetRegularIngoingEdges(Junction(p, 0 /* altitude */), ingoing);
+  m_graph.GetRegularIngoingEdges(geometry::PointWithAltitude(p, 0 /* altitude */), ingoing);
 
   // Note. At mwm borders the size of |ids| may be bigger than two in case of straight
   // road because of road feature duplication at borders.

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -75,13 +75,13 @@ public:
 
   double GetPathLength() const override { return m_routeLength; }
 
-  Junction GetStartPoint() const override
+  geometry::PointWithAltitude GetStartPoint() const override
   {
     CHECK(!m_routeEdges.empty(), ());
     return m_routeEdges.front().GetStartJunction();
   }
 
-  Junction GetEndPoint() const override
+  geometry::PointWithAltitude GetEndPoint() const override
   {
     CHECK(!m_routeEdges.empty(), ());
     return m_routeEdges.back().GetEndJunction();
@@ -165,10 +165,12 @@ BicycleDirectionsEngine::BicycleDirectionsEngine(DataSource const & dataSource,
   CHECK(m_numMwmIds, ());
 }
 
-bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph, vector<Junction> const & path,
+bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph,
+                                       vector<geometry::PointWithAltitude> const & path,
                                        base::Cancellable const & cancellable, Route::TTurns & turns,
                                        Route::TStreets & streetNames,
-                                       vector<Junction> & routeGeometry, vector<Segment> & segments)
+                                       vector<geometry::PointWithAltitude> & routeGeometry,
+                                       vector<Segment> & segments)
 {
   CHECK(m_numMwmIds, ());
 
@@ -297,7 +299,8 @@ void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
     sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(), base::LessBy(&TurnCandidate::m_angle));
 }
 
-void BicycleDirectionsEngine::GetEdges(IndexRoadGraph const & graph, Junction const & currJunction,
+void BicycleDirectionsEngine::GetEdges(IndexRoadGraph const & graph,
+                                       geometry::PointWithAltitude const & currJunction,
                                        bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
                                        IRoadGraph::EdgeVector & ingoing)
 {
@@ -310,7 +313,7 @@ void BicycleDirectionsEngine::GetEdges(IndexRoadGraph const & graph, Junction co
 }
 
 void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
-    IndexRoadGraph const & graph, vector<Junction> const & path,
+    IndexRoadGraph const & graph, vector<geometry::PointWithAltitude> const & path,
     IRoadGraph::EdgeVector const & routeEdges, base::Cancellable const & cancellable)
 {
   size_t const pathSize = path.size();
@@ -320,15 +323,15 @@ void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
   auto constexpr kInvalidSegId = numeric_limits<uint32_t>::max();
   // |startSegId| is a value to keep start segment id of a new instance of LoadedPathSegment.
   uint32_t startSegId = kInvalidSegId;
-  vector<Junction> prevJunctions;
+  vector<geometry::PointWithAltitude> prevJunctions;
   vector<Segment> prevSegments;
   for (size_t i = 1; i < pathSize; ++i)
   {
     if (cancellable.IsCancelled())
       return;
 
-    Junction const & prevJunction = path[i - 1];
-    Junction const & currJunction = path[i];
+    geometry::PointWithAltitude const & prevJunction = path[i - 1];
+    geometry::PointWithAltitude const & currJunction = path[i];
 
     IRoadGraph::EdgeVector outgoingEdges;
     IRoadGraph::EdgeVector ingoingEdges;

--- a/routing/bicycle_directions.hpp
+++ b/routing/bicycle_directions.hpp
@@ -10,6 +10,8 @@
 
 #include "indexer/data_source.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <map>
 #include <memory>
 #include <vector>
@@ -33,9 +35,10 @@ public:
   BicycleDirectionsEngine(DataSource const & dataSource, std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  bool Generate(IndexRoadGraph const & graph, std::vector<Junction> const & path,
+  bool Generate(IndexRoadGraph const & graph, std::vector<geometry::PointWithAltitude> const & path,
                 base::Cancellable const & cancellable, Route::TTurns & turns,
-                Route::TStreets & streetNames, std::vector<Junction> & routeGeometry,
+                Route::TStreets & streetNames,
+                std::vector<geometry::PointWithAltitude> & routeGeometry,
                 std::vector<Segment> & segments) override;
   void Clear() override;
 
@@ -49,11 +52,11 @@ private:
   /// \brief The method gathers sequence of segments according to IsJoint() method
   /// and fills |m_adjacentEdges| and |m_pathSegments|.
   void FillPathSegmentsAndAdjacentEdgesMap(IndexRoadGraph const & graph,
-                                           std::vector<Junction> const & path,
+                                           std::vector<geometry::PointWithAltitude> const & path,
                                            IRoadGraph::EdgeVector const & routeEdges,
                                            base::Cancellable const & cancellable);
 
-  void GetEdges(IndexRoadGraph const & graph, Junction const & currJunction,
+  void GetEdges(IndexRoadGraph const & graph, geometry::PointWithAltitude const & currJunction,
                 bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
                 IRoadGraph::EdgeVector & ingoing);
 

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -7,6 +7,8 @@
 
 #include "traffic/traffic_info.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/cancellable.hpp"
 
 #include <vector>
@@ -23,9 +25,11 @@ public:
   /// \brief Generates all args which are passed by reference.
   /// \param path is points of the route. It should not be empty.
   /// \returns true if fields passed by reference are filled correctly and false otherwise.
-  virtual bool Generate(IndexRoadGraph const & graph, std::vector<Junction> const & path,
+  virtual bool Generate(IndexRoadGraph const & graph,
+                        std::vector<geometry::PointWithAltitude> const & path,
                         base::Cancellable const & cancellable, Route::TTurns & turns,
-                        Route::TStreets & streetNames, std::vector<Junction> & routeGeometry,
+                        Route::TStreets & streetNames,
+                        std::vector<geometry::PointWithAltitude> & routeGeometry,
                         std::vector<Segment> & segments) = 0;
   virtual void Clear() = 0;
 };

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -15,8 +15,9 @@ using namespace std;
 
 namespace
 {
-Junction CalcProjectionToSegment(Junction const & begin, Junction const & end,
-                                 m2::PointD const & point)
+geometry::PointWithAltitude CalcProjectionToSegment(geometry::PointWithAltitude const & begin,
+                                                    geometry::PointWithAltitude const & end,
+                                                    m2::PointD const & point)
 {
   m2::ParametrizedSegment<m2::PointD> segment(begin.GetPoint(), end.GetPoint());
 
@@ -25,12 +26,12 @@ Junction CalcProjectionToSegment(Junction const & begin, Junction const & end,
 
   double constexpr kEpsMeters = 2.0;
   if (base::AlmostEqualAbs(distBeginToEnd, 0.0, kEpsMeters))
-    return Junction(projectedPoint, begin.GetAltitude());
+    return geometry::PointWithAltitude(projectedPoint, begin.GetAltitude());
 
   auto const distBeginToProjection = mercator::DistanceOnEarth(begin.GetPoint(), projectedPoint);
   auto const altitude = begin.GetAltitude() + (end.GetAltitude() - begin.GetAltitude()) *
                                                   distBeginToProjection / distBeginToEnd;
-  return Junction(projectedPoint, altitude);
+  return geometry::PointWithAltitude(projectedPoint, altitude);
 }
 }  // namespace
 
@@ -57,7 +58,8 @@ FakeEnding MakeFakeEnding(vector<Segment> const & segments, m2::PointD const & p
     averageAltitude = (i * averageAltitude + projectedJunction.GetAltitude()) / (i + 1);
   }
 
-  ending.m_originJunction = Junction(point, static_cast<feature::TAltitude>(averageAltitude));
+  ending.m_originJunction =
+      geometry::PointWithAltitude(point, static_cast<geometry::TAltitude>(averageAltitude));
   return ending;
 }
 
@@ -70,7 +72,7 @@ FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, Ind
   auto const & projectedJunction = CalcProjectionToSegment(backJunction, frontJunction, point);
 
   FakeEnding ending;
-  ending.m_originJunction = Junction(point, projectedJunction.GetAltitude());
+  ending.m_originJunction = geometry::PointWithAltitude(point, projectedJunction.GetAltitude());
   ending.m_projections.emplace_back(segment, oneWay, frontJunction, backJunction,
                                     projectedJunction);
   return ending;

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -4,6 +4,7 @@
 #include "routing/segment.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <vector>
 
@@ -15,8 +16,10 @@ class WorldGraph;
 
 struct Projection final
 {
-  Projection(Segment const & segment, bool isOneWay, Junction const & segmentFront,
-             Junction const & segmentBack, Junction const & junction)
+  Projection(Segment const & segment, bool isOneWay,
+             geometry::PointWithAltitude const & segmentFront,
+             geometry::PointWithAltitude const & segmentBack,
+             geometry::PointWithAltitude const & junction)
     : m_segment(segment)
     , m_isOneWay(isOneWay)
     , m_segmentFront(segmentFront)
@@ -27,14 +30,14 @@ struct Projection final
 
   Segment m_segment;
   bool m_isOneWay = false;
-  Junction m_segmentFront;
-  Junction m_segmentBack;
-  Junction m_junction;
+  geometry::PointWithAltitude m_segmentFront;
+  geometry::PointWithAltitude m_segmentBack;
+  geometry::PointWithAltitude m_junction;
 };
 
 struct FakeEnding final
 {
-  Junction m_originJunction;
+  geometry::PointWithAltitude m_originJunction;
   std::vector<Projection> m_projections;
 };
 

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -5,6 +5,7 @@
 #include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/visitor.hpp"
 
@@ -24,7 +25,8 @@ public:
     PartOfReal,
   };
 
-  FakeVertex(NumMwmId numMwmId, Junction const & from, Junction const & to, Type type)
+  FakeVertex(NumMwmId numMwmId, geometry::PointWithAltitude const & from,
+             geometry::PointWithAltitude const & to, Type type)
     : m_numMwmId(numMwmId), m_from(from), m_to(to), m_type(type)
   {
   }
@@ -43,9 +45,9 @@ public:
            std::tie(rhs.m_numMwmId, rhs.m_from, rhs.m_to, rhs.m_type);
   }
 
-  Junction const & GetJunctionFrom() const { return m_from; }
+  geometry::PointWithAltitude const & GetJunctionFrom() const { return m_from; }
   m2::PointD const & GetPointFrom() const { return m_from.GetPoint(); }
-  Junction const & GetJunctionTo() const { return m_to; }
+  geometry::PointWithAltitude const & GetJunctionTo() const { return m_to; }
   m2::PointD const & GetPointTo() const { return m_to.GetPoint(); }
   Type GetType() const { return m_type; }
 
@@ -57,8 +59,8 @@ private:
   // Note. It's important to know which mwm contains the FakeVertex if it is located
   // near an mwm borders along road features which are duplicated.
   NumMwmId m_numMwmId = kFakeNumMwmId;
-  Junction m_from;
-  Junction m_to;
+  geometry::PointWithAltitude m_from;
+  geometry::PointWithAltitude m_to;
   Type m_type = Type::PureFake;
 };
 

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -175,8 +175,9 @@ void FeaturesRoadGraph::ForEachFeatureClosestToCross(m2::PointD const & cross,
   m_dataSource.ForEachInRect(featuresLoader, rect, GetStreetReadScale());
 }
 
-void FeaturesRoadGraph::FindClosestEdges(m2::RectD const & rect, uint32_t count,
-                                         vector<pair<Edge, Junction>> & vicinities) const
+void FeaturesRoadGraph::FindClosestEdges(
+    m2::RectD const & rect, uint32_t count,
+    vector<pair<Edge, geometry::PointWithAltitude>> & vicinities) const
 {
   NearestEdgeFinder finder(rect.Center(), nullptr /* IsEdgeProjGood */);
 
@@ -234,7 +235,8 @@ void FeaturesRoadGraph::GetFeatureTypes(FeatureID const & featureId, feature::Ty
   types = feature::TypesHolder(*ft);
 }
 
-void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const
+void FeaturesRoadGraph::GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                                         feature::TypesHolder & types) const
 {
   types = feature::TypesHolder();
 
@@ -247,7 +249,7 @@ void FeaturesRoadGraph::GetJunctionTypes(Junction const & junction, feature::Typ
     if (ft.GetGeomType() != feature::GeomType::Point)
       return;
 
-    if (!base::AlmostEqualAbs(ft.GetCenter(), cross, routing::kPointsEqualEpsilon))
+    if (!base::AlmostEqualAbs(ft.GetCenter(), cross, geometry::kPointsEqualEpsilon))
       return;
 
     feature::TypesHolder typesHolder(ft);
@@ -274,7 +276,7 @@ void FeaturesRoadGraph::ClearState()
 
 bool FeaturesRoadGraph::IsRoad(FeatureType & ft) const { return m_vehicleModel.IsRoad(ft); }
 
-IRoadGraph::JunctionVec FeaturesRoadGraph::GetRoadGeom(FeatureType & ft) const
+IRoadGraph::PointWithAltitudeVec FeaturesRoadGraph::GetRoadGeom(FeatureType & ft) const
 {
   FeatureID const & featureId = ft.GetID();
   IRoadGraph::RoadInfo const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
@@ -302,7 +304,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
   size_t const pointsCount = ft.GetPointsCount();
 
-  feature::TAltitudes altitudes;
+  geometry::TAltitudes altitudes;
   if (value.m_altitudeLoader)
   {
     altitudes = value.m_altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount());
@@ -310,7 +312,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   else
   {
     ASSERT(false, ());
-    altitudes = feature::TAltitudes(ft.GetPointsCount(), feature::kDefaultAltitudeMeters);
+    altitudes = geometry::TAltitudes(ft.GetPointsCount(), geometry::kDefaultAltitudeMeters);
   }
 
   CHECK_EQUAL(altitudes.size(), pointsCount,
@@ -319,7 +321,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
 
   ri.m_junctions.resize(pointsCount);
   for (size_t i = 0; i < pointsCount; ++i)
-    ri.m_junctions[i] = Junction(ft.GetPoint(i), altitudes[i]);
+    ri.m_junctions[i] = geometry::PointWithAltitude(ft.GetPoint(i), altitudes[i]);
 }
 
 IRoadGraph::RoadInfo const & FeaturesRoadGraph::GetCachedRoadInfo(FeatureID const & featureId,

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -11,6 +11,7 @@
 #include "indexer/mwm_set.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/cache.hpp"
 
@@ -80,17 +81,19 @@ public:
   double GetMaxSpeedKMpH() const override;
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgesLoader) const override;
-  void FindClosestEdges(m2::RectD const & rect, uint32_t count,
-                        std::vector<std::pair<Edge, Junction>> & vicinities) const override;
+  void FindClosestEdges(
+      m2::RectD const & rect, uint32_t count,
+      std::vector<std::pair<Edge, geometry::PointWithAltitude>> & vicinities) const override;
   std::vector<IRoadGraph::FullRoadInfo>
   FindRoads(m2::RectD const & rect, IsGoodFeatureFn const & isGoodFeature) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
-  void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const override;
+  void GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                        feature::TypesHolder & types) const override;
   IRoadGraph::Mode GetMode() const override;
   void ClearState() override;
 
   bool IsRoad(FeatureType & ft) const;
-  IRoadGraph::JunctionVec GetRoadGeom(FeatureType & ft) const;
+  IRoadGraph::PointWithAltitudeVec GetRoadGeom(FeatureType & ft) const;
 
 private:
   friend class CrossFeaturesLoader;

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -100,7 +100,7 @@ void GeometryLoaderImpl::Load(uint32_t featureId, RoadGeometry & road)
 
   feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
 
-  feature::TAltitudes const * altitudes = nullptr;
+  geometry::TAltitudes const * altitudes = nullptr;
   if (m_loadAltitudes)
     altitudes = &(m_altitudeLoader.GetAltitudes(featureId, feature->GetPointsCount()));
 
@@ -176,11 +176,12 @@ RoadGeometry::RoadGeometry(bool oneWay, double weightSpeedKMpH, double etaSpeedK
 
   m_junctions.reserve(points.size());
   for (auto const & point : points)
-    m_junctions.emplace_back(point, feature::kDefaultAltitudeMeters);
+    m_junctions.emplace_back(point, geometry::kDefaultAltitudeMeters);
 }
 
 void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType & feature,
-                        feature::TAltitudes const * altitudes, bool inCity, Maxspeed const & maxspeed)
+                        geometry::TAltitudes const * altitudes, bool inCity,
+                        Maxspeed const & maxspeed)
 {
   CHECK(altitudes == nullptr || altitudes->size() == feature.GetPointsCount(), ());
 
@@ -204,7 +205,7 @@ void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType 
   for (size_t i = 0; i < feature.GetPointsCount(); ++i)
   {
     m_junctions.emplace_back(feature.GetPoint(i),
-                             altitudes ? (*altitudes)[i] : feature::kDefaultAltitudeMeters);
+                             altitudes ? (*altitudes)[i] : geometry::kDefaultAltitudeMeters);
   }
 
   if (m_routingOptions.Has(RoutingOptions::Road::Ferry))

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -12,6 +12,7 @@
 #include "indexer/feature_altitude.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/buffer_vector.hpp"
 #include "base/fifo_cache.hpp"
@@ -35,14 +36,14 @@ public:
   RoadGeometry(bool oneWay, double weightSpeedKMpH, double etaSpeedKMpH, Points const & points);
 
   void Load(VehicleModelInterface const & vehicleModel, FeatureType & feature,
-            feature::TAltitudes const * altitudes, bool inCity, Maxspeed const & maxspeed);
+            geometry::TAltitudes const * altitudes, bool inCity, Maxspeed const & maxspeed);
 
   bool IsOneWay() const { return m_isOneWay; }
   SpeedKMpH const & GetSpeed(bool forward) const;
   HighwayType GetHighwayType() const { return *m_highwayType; }
   bool IsPassThroughAllowed() const { return m_isPassThroughAllowed; }
 
-  Junction const & GetJunction(uint32_t junctionId) const
+  geometry::PointWithAltitude const & GetJunction(uint32_t junctionId) const
   {
     ASSERT_LESS(junctionId, m_junctions.size(), ());
     return m_junctions[junctionId];
@@ -80,7 +81,7 @@ private:
 
   double GetRoadLengthM() const;
 
-  buffer_vector<Junction, 32> m_junctions;
+  buffer_vector<geometry::PointWithAltitude, 32> m_junctions;
   SpeedKMpH m_forwardSpeed;
   SpeedKMpH m_backwardSpeed;
   boost::optional<HighwayType> m_highwayType;

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -81,13 +81,13 @@ void IndexGraphStarter::Append(FakeEdgesContainer const & container)
   m_startToFinishDistanceM = mercator::DistanceOnEarth(startPoint, finishPoint);
 }
 
-Junction const & IndexGraphStarter::GetStartJunction() const
+geometry::PointWithAltitude const & IndexGraphStarter::GetStartJunction() const
 {
   auto const & startSegment = GetStartSegment();
   return m_fake.GetVertex(startSegment).GetJunctionFrom();
 }
 
-Junction const & IndexGraphStarter::GetFinishJunction() const
+geometry::PointWithAltitude const & IndexGraphStarter::GetFinishJunction() const
 {
   auto const & finishSegment = GetFinishSegment();
   return m_fake.GetVertex(finishSegment).GetJunctionTo();
@@ -101,7 +101,8 @@ bool IndexGraphStarter::ConvertToReal(Segment & segment) const
   return m_fake.FindReal(Segment(segment), segment);
 }
 
-Junction const & IndexGraphStarter::GetJunction(Segment const & segment, bool front) const
+geometry::PointWithAltitude const & IndexGraphStarter::GetJunction(Segment const & segment,
+                                                                   bool front) const
 {
   if (!IsFakeSegment(segment))
     return m_graph.GetJunction(segment, front);
@@ -110,8 +111,8 @@ Junction const & IndexGraphStarter::GetJunction(Segment const & segment, bool fr
   return front ? vertex.GetJunctionTo() : vertex.GetJunctionFrom();
 }
 
-Junction const & IndexGraphStarter::GetRouteJunction(vector<Segment> const & segments,
-                                                     size_t pointIndex) const
+geometry::PointWithAltitude const & IndexGraphStarter::GetRouteJunction(
+    vector<Segment> const & segments, size_t pointIndex) const
 {
   CHECK(!segments.empty(), ());
   CHECK_LESS_OR_EQUAL(
@@ -296,7 +297,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
 {
   Segment const dummy = Segment();
 
-  map<Segment, Junction> otherSegments;
+  map<Segment, geometry::PointWithAltitude> otherSegments;
   for (auto const & p : otherEnding.m_projections)
   {
     otherSegments[p.m_segment] = p.m_junction;

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -16,6 +16,8 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -54,16 +56,17 @@ public:
 
   WorldGraph & GetGraph() const { return m_graph; }
   WorldGraphMode GetMode() const { return m_graph.GetMode(); }
-  Junction const & GetStartJunction() const;
-  Junction const & GetFinishJunction() const;
+  geometry::PointWithAltitude const & GetStartJunction() const;
+  geometry::PointWithAltitude const & GetFinishJunction() const;
   Segment GetStartSegment() const { return GetFakeSegment(m_start.m_id); }
   Segment GetFinishSegment() const { return GetFakeSegment(m_finish.m_id); }
   // If segment is real returns true and does not modify segment.
   // If segment is part of real converts it to real and returns true.
   // Otherwise returns false and does not modify segment.
   bool ConvertToReal(Segment & segment) const;
-  Junction const & GetJunction(Segment const & segment, bool front) const;
-  Junction const & GetRouteJunction(std::vector<Segment> const & route, size_t pointIndex) const;
+  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) const;
+  geometry::PointWithAltitude const & GetRouteJunction(std::vector<Segment> const & route,
+                                                       size_t pointIndex) const;
   m2::PointD const & GetPoint(Segment const & segment, bool front) const;
 
   bool IsRoutingOptionsGood(Segment const & segment) const;

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -12,7 +12,8 @@ using namespace std;
 namespace routing
 {
 IndexRoadGraph::IndexRoadGraph(shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarter & starter,
-                               vector<Segment> const & segments, vector<Junction> const & junctions,
+                               vector<Segment> const & segments,
+                               vector<geometry::PointWithAltitude> const & junctions,
                                DataSource & dataSource)
   : m_dataSource(dataSource), m_numMwmIds(numMwmIds), m_starter(starter), m_segments(segments)
 {
@@ -22,7 +23,7 @@ IndexRoadGraph::IndexRoadGraph(shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarte
 
   for (size_t i = 0; i < junctions.size(); ++i)
   {
-    Junction const & junction = junctions[i];
+    geometry::PointWithAltitude const & junction = junctions[i];
     if (i > 0)
       m_endToSegment[junction].push_back(segments[i - 1]);
     if (i < segments.size())
@@ -30,12 +31,14 @@ IndexRoadGraph::IndexRoadGraph(shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarte
   }
 }
 
-void IndexRoadGraph::GetOutgoingEdges(Junction const & junction, EdgeVector & edges) const
+void IndexRoadGraph::GetOutgoingEdges(geometry::PointWithAltitude const & junction,
+                                      EdgeVector & edges) const
 {
   GetEdges(junction, true, edges);
 }
 
-void IndexRoadGraph::GetIngoingEdges(Junction const & junction, EdgeVector & edges) const
+void IndexRoadGraph::GetIngoingEdges(geometry::PointWithAltitude const & junction,
+                                     EdgeVector & edges) const
 {
   GetEdges(junction, false, edges);
 }
@@ -71,7 +74,8 @@ void IndexRoadGraph::GetEdgeTypes(Edge const & edge, feature::TypesHolder & type
   types = feature::TypesHolder(*ft);
 }
 
-void IndexRoadGraph::GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const
+void IndexRoadGraph::GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                                      feature::TypesHolder & types) const
 {
   // TODO: implement method to support PedestrianDirection::LiftGate, PedestrianDirection::Gate
   types = feature::TypesHolder();
@@ -118,7 +122,8 @@ void IndexRoadGraph::GetRouteSegments(std::vector<Segment> & segments) const
   segments = m_segments;
 }
 
-void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, EdgeVector & edges) const
+void IndexRoadGraph::GetEdges(geometry::PointWithAltitude const & junction, bool isOutgoing,
+                              EdgeVector & edges) const
 {
   edges.clear();
 
@@ -147,7 +152,7 @@ void IndexRoadGraph::GetEdges(Junction const & junction, bool isOutgoing, EdgeVe
   }
 }
 
-vector<Segment> const & IndexRoadGraph::GetSegments(Junction const & junction,
+vector<Segment> const & IndexRoadGraph::GetSegments(geometry::PointWithAltitude const & junction,
                                                     bool isOutgoing) const
 {
   auto const & junctionToSegment = isOutgoing ? m_endToSegment : m_beginToSegment;

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -8,6 +8,8 @@
 
 #include "indexer/data_source.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <map>
 #include <memory>
 #include <vector>
@@ -18,28 +20,33 @@ class IndexRoadGraph : public RoadGraphBase
 {
 public:
   IndexRoadGraph(std::shared_ptr<NumMwmIds> numMwmIds, IndexGraphStarter & starter,
-                 std::vector<Segment> const & segments, std::vector<Junction> const & junctions,
+                 std::vector<Segment> const & segments,
+                 std::vector<geometry::PointWithAltitude> const & junctions,
                  DataSource & dataSource);
 
   // IRoadGraphBase overrides:
-  virtual void GetOutgoingEdges(Junction const & junction, EdgeVector & edges) const override;
-  virtual void GetIngoingEdges(Junction const & junction, EdgeVector & edges) const override;
+  virtual void GetOutgoingEdges(geometry::PointWithAltitude const & junction,
+                                EdgeVector & edges) const override;
+  virtual void GetIngoingEdges(geometry::PointWithAltitude const & junction,
+                               EdgeVector & edges) const override;
   virtual double GetMaxSpeedKMpH() const override;
   virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const override;
-  virtual void GetJunctionTypes(Junction const & junction,
+  virtual void GetJunctionTypes(geometry::PointWithAltitude const & junction,
                                 feature::TypesHolder & types) const override;
   virtual void GetRouteEdges(EdgeVector & edges) const override;
   virtual void GetRouteSegments(std::vector<Segment> & segments) const override;
 
 private:
-  void GetEdges(Junction const & junction, bool isOutgoing, EdgeVector & edges) const;
-  std::vector<Segment> const & GetSegments(Junction const & junction, bool isOutgoing) const;
+  void GetEdges(geometry::PointWithAltitude const & junction, bool isOutgoing,
+                EdgeVector & edges) const;
+  std::vector<Segment> const & GetSegments(geometry::PointWithAltitude const & junction,
+                                           bool isOutgoing) const;
 
   DataSource & m_dataSource;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   IndexGraphStarter & m_starter;
   std::vector<Segment> m_segments;
-  std::map<Junction, std::vector<Segment>> m_beginToSegment;
-  std::map<Junction, std::vector<Segment>> m_endToSegment;
+  std::map<geometry::PointWithAltitude, std::vector<Segment>> m_beginToSegment;
+  std::map<geometry::PointWithAltitude, std::vector<Segment>> m_endToSegment;
 };
 }  // namespace routing

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -25,6 +25,7 @@
 #include "platform/country_file.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/rect2d.hpp"
 #include "geometry/tree4d.hpp"
 
@@ -116,21 +117,23 @@ private:
 
   /// \returns true if a segment (|point|, |edgeProjection.second|) crosses one of segments
   /// in |fences| except for a one which has the same geometry with |edgeProjection.first|.
-  bool IsFencedOff(m2::PointD const & point, std::pair<Edge, Junction> const & edgeProjection,
+  bool IsFencedOff(m2::PointD const & point,
+                   std::pair<Edge, geometry::PointWithAltitude> const & edgeProjection,
                    std::vector<IRoadGraph::FullRoadInfo> const & fences) const;
 
-  void RoadsToNearestEdges(m2::PointD const & point,
-                           std::vector<IRoadGraph::FullRoadInfo> const & roads,
-                           IsEdgeProjGood const & isGood,
-                           std::vector<std::pair<Edge, Junction>> & edgeProj) const;
+  void RoadsToNearestEdges(
+      m2::PointD const & point, std::vector<IRoadGraph::FullRoadInfo> const & roads,
+      IsEdgeProjGood const & isGood,
+      std::vector<std::pair<Edge, geometry::PointWithAltitude>> & edgeProj) const;
 
   Segment GetSegmentByEdge(Edge const & edge) const;
 
   /// \brief Fills |closestCodirectionalEdge| with a codirectional edge which is closet to
   /// |point| and returns true if there's any. If not returns false.
-  bool FindClosestCodirectionalEdge(m2::PointD const & point, m2::PointD const & direction,
-                                    std::vector<std::pair<Edge, Junction>> const & candidates,
-                                    Edge & closestCodirectionalEdge) const;
+  bool FindClosestCodirectionalEdge(
+      m2::PointD const & point, m2::PointD const & direction,
+      std::vector<std::pair<Edge, geometry::PointWithAltitude>> const & candidates,
+      Edge & closestCodirectionalEdge) const;
 
   /// \brief Finds the best segments (edges) which may be considered as starts or finishes
   /// of the route. According to current implementation the closest to |point| segment which

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -10,6 +10,8 @@
 
 #include "indexer/ftypes_matcher.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/buffer_vector.hpp"
 
 #include <string>
@@ -24,7 +26,7 @@ namespace routing
  */
 struct LoadedPathSegment
 {
-  std::vector<Junction> m_path;
+  std::vector<geometry::PointWithAltitude> m_path;
   std::vector<turns::SingleLaneInfo> m_lanes;
   std::string m_name;
   double m_weight = 0.0; /*!< Time in seconds to pass the segment. */

--- a/routing/nearest_edge_finder.hpp
+++ b/routing/nearest_edge_finder.hpp
@@ -4,11 +4,12 @@
 
 #include "routing_common/vehicle_model.hpp"
 
-#include "geometry/point2d.hpp"
-
 #include "indexer/feature_altitude.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/mwm_set.hpp"
+
+#include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <functional>
 #include <cstdint>
@@ -19,7 +20,7 @@
 
 namespace routing
 {
-using IsEdgeProjGood = std::function<bool(std::pair<Edge, Junction> const&)>;
+using IsEdgeProjGood = std::function<bool(std::pair<Edge, geometry::PointWithAltitude> const &)>;
 
 /// Helper functor class to filter nearest roads to the given starting point.
 /// Class returns pairs of outgoing edge and projection point on the edge
@@ -32,8 +33,8 @@ public:
 
   void AddInformationSource(IRoadGraph::FullRoadInfo const & roadInfo);
 
-
-  void MakeResult(std::vector<std::pair<Edge, Junction>> & res, size_t maxCountFeatures);
+  void MakeResult(std::vector<std::pair<Edge, geometry::PointWithAltitude>> & res,
+                  size_t maxCountFeatures);
 
 private:
   struct Candidate
@@ -42,17 +43,17 @@ private:
 
     double m_squaredDist = std::numeric_limits<double>::max();
     uint32_t m_segId = kInvalidSegmentId;
-    Junction m_segStart;
-    Junction m_segEnd;
-    Junction m_projPoint;
+    geometry::PointWithAltitude m_segStart;
+    geometry::PointWithAltitude m_segEnd;
+    geometry::PointWithAltitude m_projPoint;
     FeatureID m_fid;
     bool m_bidirectional = true;
   };
 
   void AddResIf(Candidate const & candidate, bool forward, size_t maxCountFeatures,
-                std::vector<std::pair<Edge, Junction>> & res) const;
+                std::vector<std::pair<Edge, geometry::PointWithAltitude>> & res) const;
   void CandidateToResult(Candidate const & candidate, size_t maxCountFeatures,
-                         std::vector<std::pair<Edge, Junction>> & res) const;
+                         std::vector<std::pair<Edge, geometry::PointWithAltitude>> & res) const;
 
   m2::PointD const m_point;
   std::vector<Candidate> m_candidates;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -40,10 +40,10 @@ PedestrianDirectionsEngine::PedestrianDirectionsEngine(shared_ptr<NumMwmIds> num
 }
 
 bool PedestrianDirectionsEngine::Generate(IndexRoadGraph const & graph,
-                                          vector<Junction> const & path,
+                                          vector<geometry::PointWithAltitude> const & path,
                                           base::Cancellable const & cancellable,
                                           Route::TTurns & turns, Route::TStreets & streetNames,
-                                          vector<Junction> & routeGeometry,
+                                          vector<geometry::PointWithAltitude> & routeGeometry,
                                           vector<Segment> & segments)
 {
   turns.clear();

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -4,6 +4,8 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <memory>
 #include <vector>
 
@@ -16,9 +18,10 @@ public:
   PedestrianDirectionsEngine(std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
-  bool Generate(IndexRoadGraph const & graph, std::vector<Junction> const & path,
+  bool Generate(IndexRoadGraph const & graph, std::vector<geometry::PointWithAltitude> const & path,
                 base::Cancellable const & cancellable, Route::TTurns & turns,
-                Route::TStreets & streetNames, std::vector<Junction> & routeGeometry,
+                Route::TStreets & streetNames,
+                std::vector<geometry::PointWithAltitude> & routeGeometry,
                 std::vector<Segment> & segments) override;
   void Clear() override {}
 

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -9,6 +9,7 @@
 #include "indexer/feature_data.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/rect2d.hpp"
 
 #include "base/string_utils.hpp"
@@ -23,42 +24,6 @@
 namespace routing
 {
 using IsGoodFeatureFn = std::function<bool(FeatureID const &)>;
-
-double constexpr kPointsEqualEpsilon = 1e-6;
-
-/// The Junction class represents a node description on a road network graph
-class Junction
-{
-public:
-  Junction();
-  Junction(m2::PointD const & point, feature::TAltitude altitude);
-  Junction(Junction const &) = default;
-  Junction & operator=(Junction const &) = default;
-
-  inline bool operator==(Junction const & r) const { return m_point == r.m_point; }
-  inline bool operator!=(Junction const & r) const { return !(*this == r); }
-  inline bool operator<(Junction const & r) const { return m_point < r.m_point; }
-
-  inline m2::PointD const & GetPoint() const { return m_point; }
-  inline feature::TAltitude GetAltitude() const { return m_altitude; }
-
-private:
-  friend std::string DebugPrint(Junction const & r);
-
-  // Point of the junction
-  m2::PointD m_point;
-  feature::TAltitude m_altitude;
-};
-
-inline Junction MakeJunctionForTesting(m2::PointD const & point)
-{
-  return Junction(point, feature::kDefaultAltitudeMeters);
-}
-
-inline bool AlmostEqualAbs(Junction const & lhs, Junction const & rhs)
-{
-  return base::AlmostEqualAbs(lhs.GetPoint(), rhs.GetPoint(), kPointsEqualEpsilon);
-}
 
 /// The Edge class represents an edge description on a road network graph
 class Edge
@@ -76,21 +41,24 @@ public:
   Edge & operator=(Edge const &) = default;
 
   static Edge MakeReal(FeatureID const & featureId, bool forward, uint32_t segId,
-                       Junction const & startJunction, Junction const & endJunction);
+                       geometry::PointWithAltitude const & startJunction,
+                       geometry::PointWithAltitude const & endJunction);
   static Edge MakeFakeWithRealPart(FeatureID const & featureId, uint32_t fakeSegmentId,
                                    bool forward, uint32_t segId,
-                                   Junction const & startJunction, Junction const & endJunction);
-  static Edge MakeFake(Junction const & startJunction, Junction const & endJunction);
-  static Edge MakeFake(Junction const & startJunction, Junction const & endJunction,
-                       Edge const & prototype);
+                                   geometry::PointWithAltitude const & startJunction,
+                                   geometry::PointWithAltitude const & endJunction);
+  static Edge MakeFake(geometry::PointWithAltitude const & startJunction,
+                       geometry::PointWithAltitude const & endJunction);
+  static Edge MakeFake(geometry::PointWithAltitude const & startJunction,
+                       geometry::PointWithAltitude const & endJunction, Edge const & prototype);
 
   inline FeatureID GetFeatureId() const { return m_featureId; }
   inline bool IsForward() const { return m_forward; }
   inline uint32_t GetSegId() const { return m_segId; }
   inline uint32_t GetFakeSegmentId() const { return m_fakeSegmentId; }
 
-  inline Junction const & GetStartJunction() const { return m_startJunction; }
-  inline Junction const & GetEndJunction() const { return m_endJunction; }
+  inline geometry::PointWithAltitude const & GetStartJunction() const { return m_startJunction; }
+  inline geometry::PointWithAltitude const & GetEndJunction() const { return m_endJunction; }
 
   inline m2::PointD const & GetStartPoint() const { return m_startJunction.GetPoint(); }
   inline m2::PointD const & GetEndPoint() const { return m_endJunction.GetPoint(); }
@@ -112,9 +80,9 @@ public:
   bool operator<(Edge const & r) const;
 
 private:
-  Edge(Type type, FeatureID const & featureId, uint32_t fakeSegmentId,
-       bool forward, uint32_t segId, Junction const & startJunction,
-       Junction const & endJunction);
+  Edge(Type type, FeatureID const & featureId, uint32_t fakeSegmentId, bool forward, uint32_t segId,
+       geometry::PointWithAltitude const & startJunction,
+       geometry::PointWithAltitude const & endJunction);
 
   friend std::string DebugPrint(Edge const & r);
 
@@ -129,11 +97,11 @@ private:
   // Ordinal number of the segment on the road.
   uint32_t m_segId = 0;
 
-  // Start junction of the segment on the road.
-  Junction m_startJunction;
+  // Start point of the segment on the road.
+  geometry::PointWithAltitude m_startJunction;
 
-  // End junction of the segment on the road.
-  Junction m_endJunction;
+  // End point of the segment on the road.
+  geometry::PointWithAltitude m_endJunction;
 
   // Note. If |m_forward| == true index of |m_startJunction| point at the feature |m_featureId|
   // is less than index |m_endJunction|.
@@ -151,10 +119,12 @@ public:
   using EdgeVector = std::vector<Edge>;
 
   /// Finds all nearest outgoing edges, that route to the junction.
-  virtual void GetOutgoingEdges(Junction const & junction, EdgeVector & edges) const = 0;
+  virtual void GetOutgoingEdges(geometry::PointWithAltitude const & junction,
+                                EdgeVector & edges) const = 0;
 
   /// Finds all nearest ingoing edges, that route to the junction.
-  virtual void GetIngoingEdges(Junction const & junction, EdgeVector & edges) const = 0;
+  virtual void GetIngoingEdges(geometry::PointWithAltitude const & junction,
+                               EdgeVector & edges) const = 0;
 
   /// Returns max speed in KM/H
   virtual double GetMaxSpeedKMpH() const = 0;
@@ -163,7 +133,8 @@ public:
   virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const = 0;
 
   /// @return Types for specified junction
-  virtual void GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const = 0;
+  virtual void GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                                feature::TypesHolder & types) const = 0;
 
   virtual void GetRouteEdges(EdgeVector & routeEdges) const;
   virtual void GetRouteSegments(std::vector<Segment> & segments) const;
@@ -173,10 +144,10 @@ class IRoadGraph : public RoadGraphBase
 {
 public:
   // CheckGraphConnectivity() types aliases:
-  using Vertex = Junction;
+  using Vertex = geometry::PointWithAltitude;
   using Edge = routing::Edge;
   using Weight = double;
-  using JunctionVec = buffer_vector<Junction, 32>;
+  using PointWithAltitudeVec = buffer_vector<geometry::PointWithAltitude, 32>;
 
   enum class Mode
   {
@@ -190,11 +161,12 @@ public:
   {
     RoadInfo();
     RoadInfo(RoadInfo && ri);
-    RoadInfo(bool bidirectional, double speedKMPH, std::initializer_list<Junction> const & points);
+    RoadInfo(bool bidirectional, double speedKMPH,
+             std::initializer_list<geometry::PointWithAltitude> const & points);
     RoadInfo(RoadInfo const &) = default;
     RoadInfo & operator=(RoadInfo const &) = default;
 
-    JunctionVec m_junctions;
+    PointWithAltitudeVec m_junctions;
     double m_speedKMPH;
     bool m_bidirectional;
   };
@@ -215,30 +187,32 @@ public:
   class ICrossEdgesLoader
   {
   public:
-    ICrossEdgesLoader(Junction const & cross, IRoadGraph::Mode mode, EdgeVector & edges)
+    ICrossEdgesLoader(geometry::PointWithAltitude const & cross, IRoadGraph::Mode mode,
+                      EdgeVector & edges)
       : m_cross(cross), m_mode(mode), m_edges(edges)
     {
     }
 
     virtual ~ICrossEdgesLoader() = default;
 
-    void operator()(FeatureID const & featureId, JunctionVec const & junctions,
+    void operator()(FeatureID const & featureId, PointWithAltitudeVec const & junctions,
                     bool bidirectional)
     {
       LoadEdges(featureId, junctions, bidirectional);
     }
 
   private:
-    virtual void LoadEdges(FeatureID const & featureId, JunctionVec const & junctions,
+    virtual void LoadEdges(FeatureID const & featureId, PointWithAltitudeVec const & junctions,
                            bool bidirectional) = 0;
 
   protected:
     template <typename TFn>
-    void ForEachEdge(JunctionVec const & junctions, TFn && fn)
+    void ForEachEdge(PointWithAltitudeVec const & junctions, TFn && fn)
     {
       for (size_t i = 0; i < junctions.size(); ++i)
       {
-        if (!base::AlmostEqualAbs(m_cross.GetPoint(), junctions[i].GetPoint(), kPointsEqualEpsilon))
+        if (!base::AlmostEqualAbs(m_cross.GetPoint(), junctions[i].GetPoint(),
+                                  geometry::kPointsEqualEpsilon))
           continue;
 
         if (i + 1 < junctions.size())
@@ -258,7 +232,7 @@ public:
       }
     }
 
-    Junction const m_cross;
+    geometry::PointWithAltitude const m_cross;
     IRoadGraph::Mode const m_mode;
     EdgeVector & m_edges;
   };
@@ -266,44 +240,48 @@ public:
   class CrossOutgoingLoader : public ICrossEdgesLoader
   {
   public:
-    CrossOutgoingLoader(Junction const & cross, IRoadGraph::Mode mode, EdgeVector & edges)
+    CrossOutgoingLoader(geometry::PointWithAltitude const & cross, IRoadGraph::Mode mode,
+                        EdgeVector & edges)
       : ICrossEdgesLoader(cross, mode, edges)
     {
     }
 
   private:
     // ICrossEdgesLoader overrides:
-    void LoadEdges(FeatureID const & featureId, JunctionVec const & junctions,
+    void LoadEdges(FeatureID const & featureId, PointWithAltitudeVec const & junctions,
                    bool bidirectional) override;
   };
 
   class CrossIngoingLoader : public ICrossEdgesLoader
   {
   public:
-    CrossIngoingLoader(Junction const & cross, IRoadGraph::Mode mode, EdgeVector & edges)
+    CrossIngoingLoader(geometry::PointWithAltitude const & cross, IRoadGraph::Mode mode,
+                       EdgeVector & edges)
       : ICrossEdgesLoader(cross, mode, edges)
     {
     }
 
   private:
     // ICrossEdgesLoader overrides:
-    void LoadEdges(FeatureID const & featureId, JunctionVec const & junctions,
+    void LoadEdges(FeatureID const & featureId, PointWithAltitudeVec const & junctions,
                    bool bidirectional) override;
   };
 
   virtual ~IRoadGraph() = default;
 
-  void GetOutgoingEdges(Junction const & junction, EdgeVector & edges) const override;
+  void GetOutgoingEdges(geometry::PointWithAltitude const & junction,
+                        EdgeVector & edges) const override;
 
-  void GetIngoingEdges(Junction const & junction, EdgeVector & edges) const override;
+  void GetIngoingEdges(geometry::PointWithAltitude const & junction,
+                       EdgeVector & edges) const override;
 
   /// Removes all fake turns and vertices from the graph.
   void ResetFakes();
 
   /// Adds fake edges from fake position rp to real vicinity
   /// positions.
-  void AddFakeEdges(Junction const & junction,
-                    std::vector<std::pair<Edge, Junction>> const & vicinities);
+  void AddFakeEdges(geometry::PointWithAltitude const & junction,
+                    std::vector<std::pair<Edge, geometry::PointWithAltitude>> const & vicinities);
   void AddOutgoingFakeEdge(Edge const & e);
   void AddIngoingFakeEdge(Edge const & e);
 
@@ -323,8 +301,9 @@ public:
   /// Finds the closest edges to the center of |rect|.
   /// @return Array of pairs of Edge and projection point on the Edge. If there is no the closest edges
   /// then returns empty array.
-  virtual void FindClosestEdges(m2::RectD const & rect, uint32_t count,
-                                std::vector<std::pair<Edge, Junction>> & vicinities) const {};
+  virtual void FindClosestEdges(
+      m2::RectD const & rect, uint32_t count,
+      std::vector<std::pair<Edge, geometry::PointWithAltitude>> & vicinities) const {};
 
   /// \returns Vector of pairs FeatureID and corresponding RoadInfo for road features
   /// lying in |rect|.
@@ -344,16 +323,19 @@ public:
   virtual void ClearState() {}
 
   /// \brief Finds all outgoing regular (non-fake) edges for junction.
-  void GetRegularOutgoingEdges(Junction const & junction, EdgeVector & edges) const;
+  void GetRegularOutgoingEdges(geometry::PointWithAltitude const & junction,
+                               EdgeVector & edges) const;
   /// \brief Finds all ingoing regular (non-fake) edges for junction.
-  void GetRegularIngoingEdges(Junction const & junction, EdgeVector & edges) const;
+  void GetRegularIngoingEdges(geometry::PointWithAltitude const & junction,
+                              EdgeVector & edges) const;
   /// \brief Finds all outgoing fake edges for junction.
-  void GetFakeOutgoingEdges(Junction const & junction, EdgeVector & edges) const;
+  void GetFakeOutgoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges) const;
   /// \brief Finds all ingoing fake edges for junction.
-  void GetFakeIngoingEdges(Junction const & junction, EdgeVector & edges) const;
+  void GetFakeIngoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges) const;
 
 private:
-  void AddEdge(Junction const & j, Edge const & e, std::map<Junction, EdgeVector> & edges);
+  void AddEdge(geometry::PointWithAltitude const & j, Edge const & e,
+               std::map<geometry::PointWithAltitude, EdgeVector> & edges);
 
   template <typename Fn>
   void ForEachFakeEdge(Fn && fn)
@@ -373,8 +355,8 @@ private:
 
   /// \note |m_fakeIngoingEdges| and |m_fakeOutgoingEdges| map junctions to sorted vectors.
   /// Items to these maps should be inserted with AddEdge() method only.
-  std::map<Junction, EdgeVector> m_fakeIngoingEdges;
-  std::map<Junction, EdgeVector> m_fakeOutgoingEdges;
+  std::map<geometry::PointWithAltitude, EdgeVector> m_fakeIngoingEdges;
+  std::map<geometry::PointWithAltitude, EdgeVector> m_fakeOutgoingEdges;
 };
 
 std::string DebugPrint(IRoadGraph::Mode mode);
@@ -382,7 +364,7 @@ std::string DebugPrint(IRoadGraph::Mode mode);
 IRoadGraph::RoadInfo MakeRoadInfoForTesting(bool bidirectional, double speedKMPH,
                                             std::initializer_list<m2::PointD> const & points);
 
-inline void JunctionsToPoints(std::vector<Junction> const & junctions,
+inline void JunctionsToPoints(std::vector<geometry::PointWithAltitude> const & junctions,
                               std::vector<m2::PointD> & points)
 {
   points.resize(junctions.size());
@@ -390,8 +372,8 @@ inline void JunctionsToPoints(std::vector<Junction> const & junctions,
     points[i] = junctions[i].GetPoint();
 }
 
-inline void JunctionsToAltitudes(std::vector<Junction> const & junctions,
-                                 feature::TAltitudes & altitudes)
+inline void JunctionsToAltitudes(std::vector<geometry::PointWithAltitude> const & junctions,
+                                 geometry::TAltitudes & altitudes)
 {
   altitudes.resize(junctions.size());
   for (size_t i = 0; i < junctions.size(); ++i)

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -345,7 +345,7 @@ void Route::SetSubrouteUid(size_t segmentIdx, SubrouteUid subrouteUid)
   m_subrouteUid = subrouteUid;
 }
 
-void Route::GetAltitudes(feature::TAltitudes & altitudes) const
+void Route::GetAltitudes(geometry::TAltitudes & altitudes) const
 {
   altitudes.clear();
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -15,6 +15,7 @@
 
 #include "platform/country_file.hpp"
 
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/polyline2d.hpp"
 
 #include "base/assert.hpp"
@@ -65,9 +66,10 @@ public:
     uint8_t m_maxSpeedKmPH = 0;
   };
 
-  RouteSegment(Segment const & segment, turns::TurnItem const & turn, Junction const & junction,
-               std::string const & street, double distFromBeginningMeters,
-               double distFromBeginningMerc, double timeFromBeginningS, traffic::SpeedGroup traffic,
+  RouteSegment(Segment const & segment, turns::TurnItem const & turn,
+               geometry::PointWithAltitude const & junction, std::string const & street,
+               double distFromBeginningMeters, double distFromBeginningMerc,
+               double timeFromBeginningS, traffic::SpeedGroup traffic,
                std::unique_ptr<TransitInfo> transitInfo)
     : m_segment(segment)
     , m_turn(turn)
@@ -88,7 +90,7 @@ public:
 
   Segment const & GetSegment() const { return m_segment; }
   Segment & GetSegment() { return m_segment; }
-  Junction const & GetJunction() const { return m_junction; }
+  geometry::PointWithAltitude const & GetJunction() const { return m_junction; }
   std::string const & GetStreet() const { return m_street; }
   traffic::SpeedGroup GetTraffic() const { return m_traffic; }
   turns::TurnItem const & GetTurn() const { return m_turn; }
@@ -114,7 +116,7 @@ private:
   turns::TurnItem m_turn;
 
   /// The furthest point of the segment from the beginning of the route along the route.
-  Junction m_junction;
+  geometry::PointWithAltitude m_junction;
 
   /// Street name of |m_segment| if any. Otherwise |m_street| is empty.
   std::string m_street;
@@ -155,7 +157,8 @@ public:
   public:
     SubrouteAttrs() = default;
 
-    SubrouteAttrs(Junction const & start, Junction const & finish, size_t beginSegmentIdx,
+    SubrouteAttrs(geometry::PointWithAltitude const & start,
+                  geometry::PointWithAltitude const & finish, size_t beginSegmentIdx,
                   size_t endSegmentIdx)
       : m_start(start)
       , m_finish(finish)
@@ -173,8 +176,8 @@ public:
     {
     }
 
-    Junction const & GetStart() const { return m_start; }
-    Junction const & GetFinish() const { return m_finish; }
+    geometry::PointWithAltitude const & GetStart() const { return m_start; }
+    geometry::PointWithAltitude const & GetFinish() const { return m_finish; }
 
     size_t GetBeginSegmentIdx() const { return m_beginSegmentIdx; }
     size_t GetEndSegmentIdx() const { return m_endSegmentIdx; }
@@ -182,9 +185,8 @@ public:
     size_t GetSize() const { return m_endSegmentIdx - m_beginSegmentIdx; }
 
   private:
-
-    Junction m_start;
-    Junction m_finish;
+    geometry::PointWithAltitude m_start;
+    geometry::PointWithAltitude m_finish;
 
     // Index of the first subroute segment in the whole route.
     size_t m_beginSegmentIdx = 0;
@@ -261,7 +263,7 @@ public:
     m_haveAltitudes = true;
     for (auto const & s : m_routeSegments)
     {
-      if (s.GetJunction().GetAltitude() == feature::kInvalidAltitude)
+      if (s.GetJunction().GetAltitude() == geometry::kInvalidAltitude)
       {
         m_haveAltitudes = false;
         return;
@@ -377,7 +379,7 @@ public:
   /// after the route is removed.
   void SetSubrouteUid(size_t segmentIdx, SubrouteUid subrouteUid);
 
-  void GetAltitudes(feature::TAltitudes & altitudes) const;
+  void GetAltitudes(geometry::TAltitudes & altitudes) const;
   bool HaveAltitudes() const { return m_haveAltitudes; }
   traffic::SpeedGroup GetTraffic(size_t segmentIdx) const;
 

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -17,6 +17,7 @@
 
 #include "geometry/mercator.hpp"
 #include "geometry/polyline2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/logging.hpp"
 #include "base/math.hpp"
@@ -105,11 +106,11 @@ void RoutingTest::TestRouters(m2::PointD const & startPos, m2::PointD const & fi
 
 void RoutingTest::TestTwoPointsOnFeature(m2::PointD const & startPos, m2::PointD const & finalPos)
 {
-  vector<pair<routing::Edge, routing::Junction>> startEdges;
+  vector<pair<routing::Edge, geometry::PointWithAltitude>> startEdges;
   GetNearestEdges(startPos, startEdges);
   TEST(!startEdges.empty(), ());
 
-  vector<pair<routing::Edge, routing::Junction>> finalEdges;
+  vector<pair<routing::Edge, geometry::PointWithAltitude>> finalEdges;
   GetNearestEdges(finalPos, finalEdges);
   TEST(!finalEdges.empty(), ());
 
@@ -137,7 +138,7 @@ unique_ptr<routing::IRouter> RoutingTest::CreateRouter(string const & name)
 }
 
 void RoutingTest::GetNearestEdges(m2::PointD const & pt,
-                                  vector<pair<routing::Edge, routing::Junction>> & edges)
+                                  vector<pair<routing::Edge, geometry::PointWithAltitude>> & edges)
 {
   routing::FeaturesRoadGraph graph(m_dataSource, m_mode, CreateModelFactory());
   graph.FindClosestEdges(mercator::RectByCenterXYAndSizeInMeters(
@@ -159,8 +160,8 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
   TEST(route.IsValid(), ());
   m2::PolylineD const & poly = route.GetPoly();
   TEST_GREATER(poly.GetSize(), 0, ());
-  TEST(base::AlmostEqualAbs(poly.Front(), startPos, routing::kPointsEqualEpsilon), ());
-  TEST(base::AlmostEqualAbs(poly.Back(), finalPos, routing::kPointsEqualEpsilon), ());
+  TEST(base::AlmostEqualAbs(poly.Front(), startPos, geometry::kPointsEqualEpsilon), ());
+  TEST(base::AlmostEqualAbs(poly.Back(), finalPos, geometry::kPointsEqualEpsilon), ());
   LOG(LINFO, ("Route polyline size:", route.GetPoly().GetSize()));
   LOG(LINFO, ("Route distance, meters:", route.GetTotalDistanceMeters()));
   LOG(LINFO, ("Elapsed, seconds:", elapsedSec));

--- a/routing/routing_benchmarks/helpers.hpp
+++ b/routing/routing_benchmarks/helpers.hpp
@@ -42,7 +42,7 @@ protected:
 
   std::unique_ptr<routing::IRouter> CreateRouter(std::string const & name);
   void GetNearestEdges(m2::PointD const & pt,
-                       std::vector<std::pair<routing::Edge, routing::Junction>> & edges);
+                       std::vector<std::pair<routing::Edge, geometry::PointWithAltitude>> & edges);
 
   routing::IRoadGraph::Mode const m_mode;
   routing::VehicleType m_type;

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -17,7 +17,8 @@ namespace routing
 using namespace std;
 using namespace traffic;
 
-void FillSegmentInfo(vector<Segment> const & segments, vector<Junction> const & junctions,
+void FillSegmentInfo(vector<Segment> const & segments,
+                     vector<geometry::PointWithAltitude> const & junctions,
                      Route::TTurns const & turns, Route::TStreets const & streets,
                      Route::TTimes const & times, shared_ptr<TrafficStash> const & trafficStash,
                      vector<RouteSegment> & routeSegment)
@@ -98,8 +99,9 @@ void FillSegmentInfo(vector<Segment> const & segments, vector<Junction> const & 
 
 void ReconstructRoute(IDirectionsEngine & engine, IndexRoadGraph const & graph,
                       shared_ptr<TrafficStash> const & trafficStash,
-                      base::Cancellable const & cancellable, vector<Junction> const & path,
-                      Route::TTimes && times, Route & route)
+                      base::Cancellable const & cancellable,
+                      vector<geometry::PointWithAltitude> const & path, Route::TTimes && times,
+                      Route & route)
 {
   if (path.empty())
   {
@@ -110,7 +112,7 @@ void ReconstructRoute(IDirectionsEngine & engine, IndexRoadGraph const & graph,
   CHECK_EQUAL(path.size(), times.size(), ());
 
   Route::TTurns turnsDir;
-  vector<Junction> junctions;
+  vector<geometry::PointWithAltitude> junctions;
   Route::TStreets streetNames;
   vector<Segment> segments;
 
@@ -180,7 +182,7 @@ bool SegmentCrossesRect(m2::Segment2D const & segment, m2::RectD const & rect)
   return isSideIntersected;
 }
 
-bool RectCoversPolyline(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect)
+bool RectCoversPolyline(IRoadGraph::PointWithAltitudeVec const & junctions, m2::RectD const & rect)
 {
   if (junctions.empty())
     return false;

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -13,6 +13,7 @@
 #include "routing_common/car_model.hpp"
 #include "routing_common/pedestrian_model.hpp"
 
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/rect2d.hpp"
 #include "geometry/segment2d.hpp"
 
@@ -47,15 +48,18 @@ bool IsRoad(Types const & types)
          IsBicycleRoad(types);
 }
 
-void FillSegmentInfo(std::vector<Segment> const & segments, std::vector<Junction> const & junctions,
+void FillSegmentInfo(std::vector<Segment> const & segments,
+                     std::vector<geometry::PointWithAltitude> const & junctions,
                      Route::TTurns const & turns, Route::TStreets const & streets,
-                     Route::TTimes const & times, std::shared_ptr<TrafficStash> const & trafficStash,
+                     Route::TTimes const & times,
+                     std::shared_ptr<TrafficStash> const & trafficStash,
                      std::vector<RouteSegment> & routeSegment);
 
 void ReconstructRoute(IDirectionsEngine & engine, IndexRoadGraph const & graph,
                       std::shared_ptr<TrafficStash> const & trafficStash,
-                      base::Cancellable const & cancellable, std::vector<Junction> const & path,
-                      Route::TTimes && times, Route & route);
+                      base::Cancellable const & cancellable,
+                      std::vector<geometry::PointWithAltitude> const & path, Route::TTimes && times,
+                      Route & route);
 
 /// \brief Converts |edge| to |segment|.
 /// \returns Segment() if mwm of |edge| is not alive.
@@ -65,7 +69,7 @@ Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge);
 bool SegmentCrossesRect(m2::Segment2D const & segment, m2::RectD const & rect);
 
 // \returns true if any part of polyline |junctions| lay in |rect| and false otherwise.
-bool RectCoversPolyline(IRoadGraph::JunctionVec const & junctions, m2::RectD const & rect);
+bool RectCoversPolyline(IRoadGraph::PointWithAltitudeVec const & junctions, m2::RectD const & rect);
 
 /// \brief Checks is edge connected with world graph. Function does BFS while it finds some number
 /// of edges,

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -13,6 +13,7 @@
 #include "routing/routing_helpers.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "platform/local_country_file.hpp"
 
@@ -42,8 +43,9 @@ LocalCountryFile GetLocalCountryFileByCountryId(CountryFile const & country)
   return {};
 }
 
-void TestAltitudeOfAllMwmFeatures(string const & countryId, TAltitude const altitudeLowerBoundMeters,
-                                  TAltitude const altitudeUpperBoundMeters)
+void TestAltitudeOfAllMwmFeatures(string const & countryId,
+                                  geometry::TAltitude const altitudeLowerBoundMeters,
+                                  geometry::TAltitude const altitudeUpperBoundMeters)
 {
   FrozenDataSource dataSource;
 
@@ -67,7 +69,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId, TAltitude const alti
     if (pointsCount == 0)
       return;
 
-    TAltitudes altitudes = altitudeLoader->GetAltitudes(id, pointsCount);
+    geometry::TAltitudes altitudes = altitudeLoader->GetAltitudes(id, pointsCount);
     TEST(!altitudes.empty(),
          ("Empty altitude vector. MWM:", countryId, ", feature id:", id, ", altitudes:", altitudes));
 

--- a/routing/routing_integration_tests/road_graph_tests.cpp
+++ b/routing/routing_integration_tests/road_graph_tests.cpp
@@ -16,6 +16,8 @@
 
 #include "routing/routing_integration_tests/routing_test_tools.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -40,9 +42,9 @@ UNIT_TEST(FakeEdgesCombinatorialExplosion)
 
   FeaturesRoadGraph graph(dataSource, IRoadGraph::Mode::ObeyOnewayTag,
                           std::make_shared<CarModelFactory>(CountryParentNameGetterFn()));
-  Junction const j(m2::PointD(mercator::FromLatLon(50.73208, -1.21279)),
-                   feature::kDefaultAltitudeMeters);
-  std::vector<std::pair<routing::Edge, routing::Junction>> sourceVicinity;
+  geometry::PointWithAltitude const j(m2::PointD(mercator::FromLatLon(50.73208, -1.21279)),
+                                      geometry::kDefaultAltitudeMeters);
+  std::vector<std::pair<routing::Edge, geometry::PointWithAltitude>> sourceVicinity;
   graph.FindClosestEdges(mercator::RectByCenterXYAndSizeInMeters(
                              j.GetPoint(), FeaturesRoadGraph::kClosestEdgesRadiusM),
                          20 /* count */, sourceVicinity);

--- a/routing/routing_result_graph.hpp
+++ b/routing/routing_result_graph.hpp
@@ -4,6 +4,8 @@
 #include "routing/road_graph.hpp"
 #include "routing/turn_candidate.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <cstddef>
 
 namespace routing
@@ -26,8 +28,8 @@ public:
   virtual void GetPossibleTurns(SegmentRange const & segmentRange, m2::PointD const & junctionPoint,
                                 size_t & ingoingCount, TurnCandidates & outgoingTurns) const = 0;
   virtual double GetPathLength() const = 0;
-  virtual Junction GetStartPoint() const = 0;
-  virtual Junction GetEndPoint() const = 0;
+  virtual geometry::PointWithAltitude GetStartPoint() const = 0;
+  virtual geometry::PointWithAltitude GetEndPoint() const = 0;
 
   virtual ~IRoutingResult() = default;
 };

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -718,7 +718,7 @@ bool RoutingSession::IsRouteValid() const
 }
 
 bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDistanceM,
-                                                    feature::TAltitudes & routeAltitudesM) const
+                                                    geometry::TAltitudes & routeAltitudesM) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(m_route, ());
@@ -727,7 +727,7 @@ bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDis
     return false;
 
   routeSegDistanceM = m_route->GetSegDistanceMeters();
-  feature::TAltitudes altitudes;
+  geometry::TAltitudes altitudes;
   m_route->GetAltitudes(routeAltitudesM);
   return true;
 }

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -20,6 +20,7 @@
 #include "platform/measurement_utils.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/polyline2d.hpp"
 
 #include "base/thread_checker.hpp"
@@ -94,7 +95,7 @@ public:
   /// route altitude information to |routeSegDistanceM| and |routeAltitudes|.
   /// \returns true if there is valid route information. If the route is not valid returns false.
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
-                                      feature::TAltitudes & routeAltitudesM) const;
+                                      geometry::TAltitudes & routeAltitudesM) const;
 
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   void GetRouteFollowingInfo(FollowingInfo & info) const;

--- a/routing/routing_tests/astar_router_test.cpp
+++ b/routing/routing_tests/astar_router_test.cpp
@@ -12,6 +12,7 @@
 #include "indexer/feature_altitude.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/logging.hpp"
 #include "base/macros.hpp"
@@ -24,15 +25,16 @@ using namespace std;
 
 namespace
 {
-void TestAStarRouterMock(Junction const & startPos, Junction const & finalPos,
-                         vector<Junction> const & expected)
+void TestAStarRouterMock(geometry::PointWithAltitude const & startPos,
+                         geometry::PointWithAltitude const & finalPos,
+                         vector<geometry::PointWithAltitude> const & expected)
 {
   classificator::Load();
 
   RoadGraphMockSource graph;
   InitRoadGraphMockSourceWithTest2(graph);
 
-  RoutingResult<Junction, double /* Weight */> result;
+  RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
   TestAStarBidirectionalAlgo algorithm;
   TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, result), ());
@@ -55,27 +57,37 @@ void AddRoad(RoadGraphMockSource & graph, initializer_list<m2::PointD> const & p
 
 UNIT_TEST(AStarRouter_Graph2_Simple1)
 {
-  Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
-  Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 55));
+  geometry::PointWithAltitude const startPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0));
+  geometry::PointWithAltitude const finalPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 55));
 
-  vector<Junction> const expected = {
-      MakeJunctionForTesting(m2::PointD(0, 0)),   MakeJunctionForTesting(m2::PointD(5, 10)),
-      MakeJunctionForTesting(m2::PointD(5, 40)),  MakeJunctionForTesting(m2::PointD(18, 55)),
-      MakeJunctionForTesting(m2::PointD(39, 55)), MakeJunctionForTesting(m2::PointD(80, 55))};
+  vector<geometry::PointWithAltitude> const expected = {
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 10)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 40)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(18, 55)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(39, 55)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 55))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
 
 UNIT_TEST(AStarRouter_Graph2_Simple2)
 {
-  Junction const startPos = MakeJunctionForTesting(m2::PointD(80, 55));
-  Junction const finalPos = MakeJunctionForTesting(m2::PointD(80, 0));
+  geometry::PointWithAltitude const startPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 55));
+  geometry::PointWithAltitude const finalPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 0));
 
-  vector<Junction> const expected = {
-      MakeJunctionForTesting(m2::PointD(80, 55)), MakeJunctionForTesting(m2::PointD(39, 55)),
-      MakeJunctionForTesting(m2::PointD(37, 30)), MakeJunctionForTesting(m2::PointD(70, 30)),
-      MakeJunctionForTesting(m2::PointD(70, 10)), MakeJunctionForTesting(m2::PointD(70, 0)),
-      MakeJunctionForTesting(m2::PointD(80, 0))};
+  vector<geometry::PointWithAltitude> const expected = {
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 55)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(39, 55)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(37, 30)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 30)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 10)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 0)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 0))};
 
   TestAStarRouterMock(startPos, finalPos, expected);
 }
@@ -92,14 +104,18 @@ UNIT_TEST(AStarRouter_SimpleGraph_RouteIsFound)
   AddRoad(graph, {m2::PointD(0, 60), m2::PointD(0, 30)}); // feature 4
   AddRoad(graph, {m2::PointD(0, 30), m2::PointD(0, 0)}); // feature 5
 
-  Junction const startPos = MakeJunctionForTesting(m2::PointD(0, 0));
-  Junction const finalPos = MakeJunctionForTesting(m2::PointD(40, 100));
+  geometry::PointWithAltitude const startPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0));
+  geometry::PointWithAltitude const finalPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(40, 100));
 
-  vector<Junction> const expected = {
-      MakeJunctionForTesting(m2::PointD(0, 0)), MakeJunctionForTesting(m2::PointD(0, 30)),
-      MakeJunctionForTesting(m2::PointD(0, 60)), MakeJunctionForTesting(m2::PointD(40, 100))};
+  vector<geometry::PointWithAltitude> const expected = {
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 30)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 60)),
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(40, 100))};
 
-  RoutingResult<Junction, double /* Weight */> result;
+  RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
   TestAStarBidirectionalAlgo algorithm;
   TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
              algorithm.CalculateRoute(graph, startPos, finalPos, result), ());
@@ -117,34 +133,42 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
 
   // Roads in the first connected component.
   vector<IRoadGraph::RoadInfo> const roadInfo_1 = {
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(10, 10)),
-                            MakeJunctionForTesting(m2::PointD(90, 10))}),  // feature 0
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(90, 10)),
-                            MakeJunctionForTesting(m2::PointD(90, 90))}),  // feature 1
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(90, 90)),
-                            MakeJunctionForTesting(m2::PointD(10, 90))}),  // feature 2
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(10, 90)),
-                            MakeJunctionForTesting(m2::PointD(10, 10))}),  // feature 3
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 10)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(90, 10))}),  // feature 0
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(90, 10)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(90, 90))}),  // feature 1
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(90, 90)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 90))}),  // feature 2
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 90)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 10))}),  // feature 3
   };
 
   // Roads in the second connected component.
   vector<IRoadGraph::RoadInfo> const roadInfo_2 = {
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(30, 30)),
-                            MakeJunctionForTesting(m2::PointD(70, 30))}),  // feature 4
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(70, 30)),
-                            MakeJunctionForTesting(m2::PointD(70, 70))}),  // feature 5
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(70, 70)),
-                            MakeJunctionForTesting(m2::PointD(30, 70))}),  // feature 6
-      IRoadGraph::RoadInfo(true /* bidir */, speedKMpH,
-                           {MakeJunctionForTesting(m2::PointD(30, 70)),
-                            MakeJunctionForTesting(m2::PointD(30, 30))}),  // feature 7
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(30, 30)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 30))}),  // feature 4
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 30)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 70))}),  // feature 5
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 70)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(30, 70))}),  // feature 6
+      IRoadGraph::RoadInfo(
+          true /* bidir */, speedKMpH,
+          {geometry::MakePointWithAltitudeForTesting(m2::PointD(30, 70)),
+           geometry::MakePointWithAltitudeForTesting(m2::PointD(30, 30))}),  // feature 7
   };
 
   for (auto const & ri : roadInfo_1)
@@ -161,11 +185,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is no any route between points in different connected components.
   for (size_t i = 0; i < roadInfo_1.size(); ++i)
   {
-    Junction const startPos = roadInfo_1[i].m_junctions[0];
+    geometry::PointWithAltitude const startPos = roadInfo_1[i].m_junctions[0];
     for (size_t j = 0; j < roadInfo_2.size(); ++j)
     {
-      Junction const finalPos = roadInfo_2[j].m_junctions[0];
-      RoutingResult<Junction, double /* Weight */> result;
+      geometry::PointWithAltitude const finalPos = roadInfo_2[j].m_junctions[0];
+      RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::NoPath,
                  algorithm.CalculateRoute(graph, startPos, finalPos, result), ());
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::NoPath,
@@ -176,11 +200,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is route between points in the first connected component.
   for (size_t i = 0; i < roadInfo_1.size(); ++i)
   {
-    Junction const startPos = roadInfo_1[i].m_junctions[0];
+    geometry::PointWithAltitude const startPos = roadInfo_1[i].m_junctions[0];
     for (size_t j = i + 1; j < roadInfo_1.size(); ++j)
     {
-      Junction const finalPos = roadInfo_1[j].m_junctions[0];
-      RoutingResult<Junction, double /* Weight */> result;
+      geometry::PointWithAltitude const finalPos = roadInfo_1[j].m_junctions[0];
+      RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, result), ());
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
@@ -191,11 +215,11 @@ UNIT_TEST(AStarRouter_SimpleGraph_RoutesInConnectedComponents)
   // Check if there is route between points in the second connected component.
   for (size_t i = 0; i < roadInfo_2.size(); ++i)
   {
-    Junction const startPos = roadInfo_2[i].m_junctions[0];
+    geometry::PointWithAltitude const startPos = roadInfo_2[i].m_junctions[0];
     for (size_t j = i + 1; j < roadInfo_2.size(); ++j)
     {
-      Junction const finalPos = roadInfo_2[j].m_junctions[0];
-      RoutingResult<Junction, double /* Weight */> result;
+      geometry::PointWithAltitude const finalPos = roadInfo_2[j].m_junctions[0];
+      RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
                  algorithm.CalculateRoute(graph, startPos, finalPos, result), ());
       TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
@@ -222,20 +246,23 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad1)
   // path2 = 8/3 = 2.666(6)
   // path3 = 1/5 + 8/4 + 1/5 = 2.4
 
-  RoutingResult<Junction, double /* Weight */> result;
+  RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
   TestAStarBidirectionalAlgo algorithm;
   TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
-             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
-                                      MakeJunctionForTesting(m2::PointD(10, 2)), result),
+             algorithm.CalculateRoute(
+                 graph, geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                 geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2)), result),
              ());
-  TEST_EQUAL(
-      result.m_path,
-      vector<Junction>(
-          {MakeJunctionForTesting(m2::PointD(2, 2)), MakeJunctionForTesting(m2::PointD(2, 3)),
-           MakeJunctionForTesting(m2::PointD(4, 3)), MakeJunctionForTesting(m2::PointD(6, 3)),
-           MakeJunctionForTesting(m2::PointD(8, 3)), MakeJunctionForTesting(m2::PointD(10, 3)),
-           MakeJunctionForTesting(m2::PointD(10, 2))}),
-      ());
+  TEST_EQUAL(result.m_path,
+             vector<geometry::PointWithAltitude>(
+                 {geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 3)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(4, 3)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(6, 3)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(8, 3)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 3)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2))}),
+             ());
   TEST(base::AlmostEqualAbs(result.m_distance, 800451., 1.), ("Distance error:", result.m_distance));
 }
 
@@ -256,16 +283,18 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad2)
   // path2 = 8/4.1 = 1.95
   // path3 = 1/5 + 8/4.4 + 1/5 = 2.2
 
-  RoutingResult<Junction, double /* Weight */> result;
+  RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
   TestAStarBidirectionalAlgo algorithm;
   TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
-             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
-                                      MakeJunctionForTesting(m2::PointD(10, 2)), result),
+             algorithm.CalculateRoute(
+                 graph, geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                 geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2)), result),
              ());
   TEST_EQUAL(result.m_path,
-             vector<Junction>({MakeJunctionForTesting(m2::PointD(2, 2)),
-                               MakeJunctionForTesting(m2::PointD(6, 2)),
-                               MakeJunctionForTesting(m2::PointD(10, 2))}),
+             vector<geometry::PointWithAltitude>(
+                 {geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(6, 2)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2))}),
              ());
   TEST(base::AlmostEqualAbs(result.m_distance, 781458., 1.), ("Distance error:", result.m_distance));
 }
@@ -287,17 +316,19 @@ UNIT_TEST(AStarRouter_SimpleGraph_PickTheFasterRoad3)
   // path2 = 8/3.9 = 2.05
   // path3 = 1/5 + 8/4.9 + 1/5 = 2.03
 
-  RoutingResult<Junction, double /* Weight */> result;
+  RoutingResult<geometry::PointWithAltitude, double /* Weight */> result;
   TestAStarBidirectionalAlgo algorithm;
   TEST_EQUAL(TestAStarBidirectionalAlgo::Result::OK,
-             algorithm.CalculateRoute(graph, MakeJunctionForTesting(m2::PointD(2, 2)),
-                                      MakeJunctionForTesting(m2::PointD(10, 2)), result),
+             algorithm.CalculateRoute(
+                 graph, geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                 geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2)), result),
              ());
-  TEST_EQUAL(
-      result.m_path,
-      vector<Junction>(
-          {MakeJunctionForTesting(m2::PointD(2, 2)), MakeJunctionForTesting(m2::PointD(2, 1)),
-           MakeJunctionForTesting(m2::PointD(10, 1)), MakeJunctionForTesting(m2::PointD(10, 2))}),
-      ());
+  TEST_EQUAL(result.m_path,
+             vector<geometry::PointWithAltitude>(
+                 {geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 2)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 1)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 1)),
+                  geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 2))}),
+             ());
   TEST(base::AlmostEqualAbs(result.m_distance, 814412., 1.), ("Distance error:", result.m_distance));
 }

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -18,6 +18,7 @@
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "coding/reader.hpp"
 #include "coding/writer.hpp"
@@ -747,10 +748,10 @@ UNIT_TEST(IndexGraph_OnlyTopology_3)
 // Test that a codirectional edge is always better than others.
 UNIT_TEST(BestEdgeComparator_OneCodirectionalEdge)
 {
-  Edge const edge1 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
-                                    MakeJunctionForTesting({-0.002, 0.002}));
-  Edge const edge2 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
-                                    MakeJunctionForTesting({0.002, 0.0}));
+  Edge const edge1 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({-0.002, 0.002}));
+  Edge const edge2 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({0.002, 0.0}));
   IndexRouter::BestEdgeComparator bestEdgeComparator(m2::PointD(0.0, 0.0), m2::PointD(0.0, 0.001));
 
   TEST_EQUAL(bestEdgeComparator.Compare(edge1, edge2), -1, ());
@@ -771,10 +772,10 @@ UNIT_TEST(BestEdgeComparator_OneCodirectionalEdge)
 // Test that if there are two codirectional edges the closest one to |point| is better.
 UNIT_TEST(BestEdgeComparator_TwoCodirectionalEdges)
 {
-  Edge const edge1 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
-                                    MakeJunctionForTesting({-0.002, 0.004}));
-  Edge const edge2 = Edge::MakeFake(MakeJunctionForTesting({0.0, 0.0}),
-                                    MakeJunctionForTesting({0.0, 0.002}));
+  Edge const edge1 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({-0.002, 0.004}));
+  Edge const edge2 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({0.0, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({0.0, 0.002}));
   IndexRouter::BestEdgeComparator bestEdgeComparator(m2::PointD(0.0, 0.0), m2::PointD(0.0, 0.001));
 
   TEST_EQUAL(bestEdgeComparator.Compare(edge1, edge2), 1, ());
@@ -790,10 +791,10 @@ UNIT_TEST(BestEdgeComparator_TwoCodirectionalEdges)
 // Test that if two edges are not codirectional the closet one to |point| is better.
 UNIT_TEST(BestEdgeComparator_TwoNotCodirectionalEdges)
 {
-  Edge const edge1 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.002}),
-                                    MakeJunctionForTesting({0.002, 0.002}));
-  Edge const edge2 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
-                                    MakeJunctionForTesting({0.002, 0.0}));
+  Edge const edge1 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.002}),
+                                    geometry::MakePointWithAltitudeForTesting({0.002, 0.002}));
+  Edge const edge2 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({0.002, 0.0}));
   IndexRouter::BestEdgeComparator bestEdgeComparator(m2::PointD(0.0, 0.0), m2::PointD(0.0, 0.001));
 
   TEST_EQUAL(bestEdgeComparator.Compare(edge1, edge2), 1, ());
@@ -809,8 +810,8 @@ UNIT_TEST(BestEdgeComparator_TwoNotCodirectionalEdges)
 UNIT_TEST(BestEdgeComparator_TwoEdgesOfOneFeature)
 {
   // Please see a note in class Edge definition about start and end point of Edge.
-  Edge const edge1 = Edge::MakeFake(MakeJunctionForTesting({-0.002, 0.0}),
-                                    MakeJunctionForTesting({0.002, 0.0}));
+  Edge const edge1 = Edge::MakeFake(geometry::MakePointWithAltitudeForTesting({-0.002, 0.0}),
+                                    geometry::MakePointWithAltitudeForTesting({0.002, 0.0}));
   Edge const edge2 = edge1.GetReverseEdge();
 
   IndexRouter::BestEdgeComparator bestEdgeComparator(m2::PointD(0.0, 0.001), m2::PointD(0.001, 0.0));

--- a/routing/routing_tests/nearest_edge_finder_tests.cpp
+++ b/routing/routing_tests/nearest_edge_finder_tests.cpp
@@ -7,6 +7,8 @@
 
 #include "routing_common/maxspeed_conversion.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/checked_cast.hpp"
 
 using namespace routing;
@@ -14,7 +16,7 @@ using namespace routing_test;
 using namespace std;
 
 void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
-                        vector<pair<Edge, Junction>> const & expected)
+                        vector<pair<Edge, geometry::PointWithAltitude>> const & expected)
 {
   unique_ptr<RoadGraphMockSource> graph(new RoadGraphMockSource());
   InitRoadGraphMockSourceWithTest1(*graph);
@@ -28,7 +30,7 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
     finder.AddInformationSource(IRoadGraph::FullRoadInfo(featureId, roadInfo));
   }
 
-  vector<pair<Edge, Junction>> result;
+  vector<pair<Edge, geometry::PointWithAltitude>> result;
   TEST(finder.HasCandidates(), ());
   finder.MakeResult(result, candidatesCount);
 
@@ -37,34 +39,34 @@ void TestNearestOnMock1(m2::PointD const & point, size_t const candidatesCount,
 
 UNIT_TEST(StarterPosAtBorder_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected = {
+  vector<pair<Edge, geometry::PointWithAltitude>> const expected = {
       make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 0,
-                               MakeJunctionForTesting(m2::PointD(0, 0)),
-                               MakeJunctionForTesting(m2::PointD(5, 0))),
-                MakeJunctionForTesting(m2::PointD(0, 0)))};
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 0))),
+                geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)))};
   TestNearestOnMock1(m2::PointD(0, 0), 1, expected);
 }
 
 UNIT_TEST(MiddleEdgeTest_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected = {
+  vector<pair<Edge, geometry::PointWithAltitude>> const expected = {
       make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 0,
-                               MakeJunctionForTesting(m2::PointD(0, 0)),
-                               MakeJunctionForTesting(m2::PointD(5, 0))),
-                MakeJunctionForTesting(m2::PointD(3, 0)))};
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 0))),
+                geometry::MakePointWithAltitudeForTesting(m2::PointD(3, 0)))};
   TestNearestOnMock1(m2::PointD(3, 3), 1, expected);
 }
 
 UNIT_TEST(MiddleSegmentTest_Mock1Graph)
 {
-  vector<pair<Edge, Junction>> const expected = {
+  vector<pair<Edge, geometry::PointWithAltitude>> const expected = {
       make_pair(Edge::MakeReal(MakeTestFeatureID(0), true /* forward */, 2,
-                               MakeJunctionForTesting(m2::PointD(10, 0)),
-                               MakeJunctionForTesting(m2::PointD(15, 0))),
-                MakeJunctionForTesting(m2::PointD(12.5, 0))),
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0)),
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(15, 0))),
+                geometry::MakePointWithAltitudeForTesting(m2::PointD(12.5, 0))),
       make_pair(Edge::MakeReal(MakeTestFeatureID(0), false /* forward */, 2,
-                               MakeJunctionForTesting(m2::PointD(15, 0)),
-                               MakeJunctionForTesting(m2::PointD(10, 0))),
-                MakeJunctionForTesting(m2::PointD(12.5, 0)))};
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(15, 0)),
+                               geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0))),
+                geometry::MakePointWithAltitudeForTesting(m2::PointD(12.5, 0)))};
   TestNearestOnMock1(m2::PointD(12.5, 2.5), 2, expected);
 }

--- a/routing/routing_tests/road_graph_builder.cpp
+++ b/routing/routing_tests/road_graph_builder.cpp
@@ -4,6 +4,8 @@
 
 #include "indexer/mwm_set.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include "base/checked_cast.hpp"
 #include "base/logging.hpp"
 #include "base/macros.hpp"
@@ -101,7 +103,8 @@ void RoadGraphMockSource::GetFeatureTypes(FeatureID const & featureId, feature::
   UNUSED_VALUE(types);
 }
 
-void RoadGraphMockSource::GetJunctionTypes(Junction const & junction, feature::TypesHolder & types) const
+void RoadGraphMockSource::GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                                           feature::TypesHolder & types) const
 {
   UNUSED_VALUE(junction);
   UNUSED_VALUE(types);
@@ -123,34 +126,34 @@ void InitRoadGraphMockSourceWithTest1(RoadGraphMockSource & src)
   IRoadGraph::RoadInfo ri0;
   ri0.m_bidirectional = true;
   ri0.m_speedKMPH = kMaxSpeedKMpH;
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(15, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(20, 0)));
 
   IRoadGraph::RoadInfo ri1;
   ri1.m_bidirectional = true;
   ri1.m_speedKMPH = kMaxSpeedKMpH;
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, -10)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, -5)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 5)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, -10)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, -5)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 5)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 10)));
 
   IRoadGraph::RoadInfo ri2;
   ri2.m_bidirectional = true;
   ri2.m_speedKMPH = kMaxSpeedKMpH;
-  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, -5)));
-  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 0)));
+  ri2.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(15, -5)));
+  ri2.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(15, 0)));
 
   IRoadGraph::RoadInfo ri3;
   ri3.m_bidirectional = true;
   ri3.m_speedKMPH = kMaxSpeedKMpH;
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 5)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(15, 5)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(20, 0)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(20, 0)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(25, 5)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(15, 5)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(20, 0)));
 
   src.AddRoad(move(ri0));
   src.AddRoad(move(ri1));
@@ -163,72 +166,72 @@ void InitRoadGraphMockSourceWithTest2(RoadGraphMockSource & graph)
   IRoadGraph::RoadInfo ri0;
   ri0.m_bidirectional = true;
   ri0.m_speedKMPH = kMaxSpeedKMpH;
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(35, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 0)));
-  ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(25, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(35, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 0)));
+  ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 0)));
 
   IRoadGraph::RoadInfo ri1;
   ri1.m_bidirectional = true;
   ri1.m_speedKMPH = kMaxSpeedKMpH;
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 10)));
-  ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 10)));
+  ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 40)));
 
   IRoadGraph::RoadInfo ri2;
   ri2.m_bidirectional = true;
   ri2.m_speedKMPH = kMaxSpeedKMpH;
-  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(12, 25)));
-  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
-  ri2.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 0)));
+  ri2.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(12, 25)));
+  ri2.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 10)));
+  ri2.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 0)));
 
   IRoadGraph::RoadInfo ri3;
   ri3.m_bidirectional = true;
   ri3.m_speedKMPH = kMaxSpeedKMpH;
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 10)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(10, 10)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 10)));
-  ri3.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 10)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 10)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(10, 10)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 10)));
+  ri3.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 10)));
 
   IRoadGraph::RoadInfo ri4;
   ri4.m_bidirectional = true;
   ri4.m_speedKMPH = kMaxSpeedKMpH;
-  ri4.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(25, 0)));
-  ri4.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(27, 25)));
+  ri4.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(25, 0)));
+  ri4.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(27, 25)));
 
   IRoadGraph::RoadInfo ri5;
   ri5.m_bidirectional = true;
   ri5.m_speedKMPH = kMaxSpeedKMpH;
-  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(35, 0)));
-  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(37, 30)));
-  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 30)));
-  ri5.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 30)));
+  ri5.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(35, 0)));
+  ri5.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(37, 30)));
+  ri5.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 30)));
+  ri5.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 30)));
 
   IRoadGraph::RoadInfo ri6;
   ri6.m_bidirectional = true;
   ri6.m_speedKMPH = kMaxSpeedKMpH;
-  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 0)));
-  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 10)));
-  ri6.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(70, 30)));
+  ri6.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 0)));
+  ri6.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 10)));
+  ri6.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(70, 30)));
 
   IRoadGraph::RoadInfo ri7;
   ri7.m_bidirectional = true;
   ri7.m_speedKMPH = kMaxSpeedKMpH;
-  ri7.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(39, 55)));
-  ri7.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(80, 55)));
+  ri7.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(39, 55)));
+  ri7.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(80, 55)));
 
   IRoadGraph::RoadInfo ri8;
   ri8.m_bidirectional = true;
   ri8.m_speedKMPH = kMaxSpeedKMpH;
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(18, 55)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(39, 55)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(37, 30)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(27, 25)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(12, 25)));
-  ri8.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(5, 40)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 40)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(18, 55)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(39, 55)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(37, 30)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(27, 25)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(12, 25)));
+  ri8.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(5, 40)));
 
   graph.AddRoad(move(ri0));
   graph.AddRoad(move(ri1));

--- a/routing/routing_tests/road_graph_builder.hpp
+++ b/routing/routing_tests/road_graph_builder.hpp
@@ -26,7 +26,8 @@ public:
   void ForEachFeatureClosestToCross(m2::PointD const & cross,
                                     ICrossEdgesLoader & edgeLoader) const override;
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const override;
-  void GetJunctionTypes(routing::Junction const & junction, feature::TypesHolder & types) const override;
+  void GetJunctionTypes(geometry::PointWithAltitude const & junction,
+                        feature::TypesHolder & types) const override;
   routing::IRoadGraph::Mode GetMode() const override;
 
 private:

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -3,6 +3,8 @@
 #include "routing/road_graph.hpp"
 #include "routing/routing_tests/road_graph_builder.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <algorithm>
 #include <utility>
 
@@ -33,20 +35,20 @@ UNIT_TEST(RoadGraph_NearestEdges)
   RoadGraphMockSource graph;
   {
     IRoadGraph::RoadInfo ri0;
-    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(-2, 0)));
-    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(-1, 0)));
-    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
-    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(1, 0)));
-    ri0.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(2, 0)));
+    ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(-2, 0)));
+    ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(-1, 0)));
+    ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)));
+    ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(1, 0)));
+    ri0.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(2, 0)));
     ri0.m_speedKMPH = 5;
     ri0.m_bidirectional = true;
 
     IRoadGraph::RoadInfo ri1;
-    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, -2)));
-    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, -1)));
-    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 0)));
-    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 1)));
-    ri1.m_junctions.push_back(MakeJunctionForTesting(m2::PointD(0, 2)));
+    ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, -2)));
+    ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, -1)));
+    ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)));
+    ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 1)));
+    ri1.m_junctions.push_back(geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 2)));
     ri1.m_speedKMPH = 5;
     ri1.m_bidirectional = true;
 
@@ -55,39 +57,40 @@ UNIT_TEST(RoadGraph_NearestEdges)
   }
 
   // We are standing at x junction.
-  Junction const crossPos = MakeJunctionForTesting(m2::PointD(0, 0));
+  geometry::PointWithAltitude const crossPos =
+      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0));
 
   // Expected outgoing edges.
   IRoadGraph::EdgeVector expectedOutgoing = {
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, 0)),
-                     MakeJunctionForTesting(m2::PointD(-1, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(-1, 0))),
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, true /* forward */, 2 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, 0)),
-                     MakeJunctionForTesting(m2::PointD(1, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(1, 0))),
       Edge::MakeReal(MakeTestFeatureID(1) /* second road */, false /* forward */, 1 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, 0)),
-                     MakeJunctionForTesting(m2::PointD(0, -1))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, -1))),
       Edge::MakeReal(MakeTestFeatureID(1) /* second road */, true /* forward */, 2 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, 0)),
-                     MakeJunctionForTesting(m2::PointD(0, 1))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 1))),
   };
   sort(expectedOutgoing.begin(), expectedOutgoing.end());
 
   // Expected ingoing edges.
   IRoadGraph::EdgeVector expectedIngoing = {
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(-1, 0)),
-                     MakeJunctionForTesting(m2::PointD(0, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(-1, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0))),
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, false /* forward */, 2 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(1, 0)),
-                     MakeJunctionForTesting(m2::PointD(0, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(1, 0)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0))),
       Edge::MakeReal(MakeTestFeatureID(1) /* second road */, true /* forward */, 1 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, -1)),
-                     MakeJunctionForTesting(m2::PointD(0, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, -1)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0))),
       Edge::MakeReal(MakeTestFeatureID(1) /* second road */, false /* forward */, 2 /* segId */,
-                     MakeJunctionForTesting(m2::PointD(0, 1)),
-                     MakeJunctionForTesting(m2::PointD(0, 0))),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 1)),
+                     geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0))),
   };
   sort(expectedIngoing.begin(), expectedIngoing.end());
 

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -10,6 +10,7 @@
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <set>
 #include <string>
@@ -57,11 +58,12 @@ void GetTestRouteSegments(vector<m2::PointD> const & routePoints, Route::TTurns 
   {
     routeLengthMeters += mercator::DistanceOnEarth(routePoints[i - 1], routePoints[i]);
     routeLengthMertc += routePoints[i - 1].Length(routePoints[i]);
-    routeSegments.emplace_back(Segment(0 /* mwm id */, static_cast<uint32_t>(i) /* feature id */,
-                                       0 /* seg id */, true /* forward */),
-                               turns[i], Junction(routePoints[i], feature::kInvalidAltitude),
-                               streets[i], routeLengthMeters, routeLengthMertc, times[i],
-                               traffic::SpeedGroup::Unknown, nullptr /* transitInfo */);
+    routeSegments.emplace_back(
+        Segment(0 /* mwm id */, static_cast<uint32_t>(i) /* feature id */, 0 /* seg id */,
+                true /* forward */),
+        turns[i], geometry::PointWithAltitude(routePoints[i], geometry::kInvalidAltitude),
+        streets[i], routeLengthMeters, routeLengthMertc, times[i], traffic::SpeedGroup::Unknown,
+        nullptr /* transitInfo */);
   }
 }
 

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -73,11 +73,12 @@ using namespace std;
 
 namespace
 {
-inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double speedMPS)
+inline double TimeBetweenSec(geometry::PointWithAltitude const & j1,
+                             geometry::PointWithAltitude const & j2, double speedMPS)
 {
   ASSERT(speedMPS > 0.0, ());
-  ASSERT_NOT_EQUAL(j1.GetAltitude(), feature::kInvalidAltitude, ());
-  ASSERT_NOT_EQUAL(j2.GetAltitude(), feature::kInvalidAltitude, ());
+  ASSERT_NOT_EQUAL(j1.GetAltitude(), geometry::kInvalidAltitude, ());
+  ASSERT_NOT_EQUAL(j2.GetAltitude(), geometry::kInvalidAltitude, ());
 
   double const distanceM = mercator::DistanceOnEarth(j1.GetPoint(), j2.GetPoint());
   double const altitudeDiffM =
@@ -89,17 +90,20 @@ inline double TimeBetweenSec(Junction const & j1, Junction const & j2, double sp
 class WeightedEdge
 {
 public:
-  WeightedEdge(Junction const & target, double weight) : target(target), weight(weight) {}
+  WeightedEdge(geometry::PointWithAltitude const & target, double weight)
+    : target(target), weight(weight)
+  {
+  }
 
-  inline Junction const & GetTarget() const { return target; }
+  inline geometry::PointWithAltitude const & GetTarget() const { return target; }
   inline double GetWeight() const { return weight; }
 
 private:
-  Junction const target;
+  geometry::PointWithAltitude const target;
   double const weight;
 };
 
-using Algorithm = AStarAlgorithm<Junction, WeightedEdge, double>;
+using Algorithm = AStarAlgorithm<geometry::PointWithAltitude, WeightedEdge, double>;
 
 /// A wrapper around IRoadGraph, which makes it possible to use IRoadGraph with astar algorithms.
 class RoadGraph : public Algorithm::Graph
@@ -188,7 +192,8 @@ string DebugPrint(TestAStarBidirectionalAlgo::Result const & value)
 
 // *************************** AStar-bidirectional routing algorithm implementation ***********************
 TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
-    IRoadGraph const & graph, Junction const & startPos, Junction const & finalPos,
+    IRoadGraph const & graph, geometry::PointWithAltitude const & startPos,
+    geometry::PointWithAltitude const & finalPos,
     RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path)
 {
   RoadGraph roadGraph(graph);

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -6,6 +6,8 @@
 #include "routing/road_graph.hpp"
 #include "routing/router.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <cstdint>
 #include <map>
 #include <string>
@@ -74,8 +76,8 @@ public:
     Cancelled
   };
 
-  Result CalculateRoute(IRoadGraph const & graph, Junction const & startPos,
-                        Junction const & finalPos,
+  Result CalculateRoute(IRoadGraph const & graph, geometry::PointWithAltitude const & startPos,
+                        geometry::PointWithAltitude const & finalPos,
                         RoutingResult<IRoadGraph::Vertex, IRoadGraph::Weight> & path);
 };
 

--- a/routing/routing_tests/routing_helpers_tests.cpp
+++ b/routing/routing_tests/routing_helpers_tests.cpp
@@ -10,6 +10,7 @@
 #include "indexer/feature_altitude.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/rect2d.hpp"
 
 #include <vector>
@@ -24,9 +25,9 @@ UNIT_TEST(FillSegmentInfoSmokeTest)
 {
   vector<Segment> const segments = {
       {0 /* mwmId */, 1 /* featureId */, 0 /* segmentIdx */, true /* forward */}};
-  vector<Junction> const junctions = {
-      {m2::PointD(0.0 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
-      {m2::PointD(0.1 /* x */, 0.0 /* y */), feature::kInvalidAltitude}};
+  vector<geometry::PointWithAltitude> const junctions = {
+      {m2::PointD(0.0 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
+      {m2::PointD(0.1 /* x */, 0.0 /* y */), geometry::kInvalidAltitude}};
   Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::ReachedYourDestination}};
   Route::TStreets const streets = {};
   Route::TTimes const times = {{0 /* point index */, 0.0 /* time in seconds */}, {1, 1.0}};
@@ -43,10 +44,10 @@ UNIT_TEST(FillSegmentInfoTest)
 {
   vector<Segment> const segments = {
       {0 /* mwmId */, 1 /* featureId */, 0 /* segmentIdx */, true /* forward */}, {0, 2, 0, true}};
-  vector<Junction> const junctions = {
-      {m2::PointD(0.0 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
-      {m2::PointD(0.1 /* x */, 0.0 /* y */), feature::kInvalidAltitude},
-      {m2::PointD(0.2 /* x */, 0.0 /* y */), feature::kInvalidAltitude}};
+  vector<geometry::PointWithAltitude> const junctions = {
+      {m2::PointD(0.0 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
+      {m2::PointD(0.1 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
+      {m2::PointD(0.2 /* x */, 0.0 /* y */), geometry::kInvalidAltitude}};
   Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::TurnRight},
                                     {2 /* point index */, CarDirection::ReachedYourDestination}};
   Route::TStreets const streets = {{0 /* point index */, "zero"}, {1, "first"}, {2, "second"}};
@@ -74,25 +75,28 @@ UNIT_TEST(PolylineInRectTest)
 
   // One point polyline outside the rect.
   {
-    auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(3.0, 3.0), 0 /* altitude */}});
+    auto const junctions =
+        IRoadGraph::PointWithAltitudeVec({{m2::PointD(3.0, 3.0), 0 /* altitude */}});
     TEST(!RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // One point polyline inside the rect.
   {
-    auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(1.0, 1.0), 0 /* altitude */}});
+    auto const junctions =
+        IRoadGraph::PointWithAltitudeVec({{m2::PointD(1.0, 1.0), 0 /* altitude */}});
     TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // One point polyline on the rect border.
   {
-    auto const junctions = IRoadGraph::JunctionVec({{m2::PointD(0.0, 0.0), 0 /* altitude */}});
+    auto const junctions =
+        IRoadGraph::PointWithAltitudeVec({{m2::PointD(0.0, 0.0), 0 /* altitude */}});
     TEST(RectCoversPolyline(junctions, m2::RectD(0.0, 0.0, 2.0, 2.0)), ());
   }
 
   // Two point polyline touching the rect border.
   {
-    auto const junctions = IRoadGraph::JunctionVec({
+    auto const junctions = IRoadGraph::PointWithAltitudeVec({
         {m2::PointD(-1.0, -1.0), 0 /* altitude */},
         {m2::PointD(0.0, 0.0), 0 /* altitude */},
     });
@@ -101,7 +105,7 @@ UNIT_TEST(PolylineInRectTest)
 
   // Crossing rect by a segment but no polyline points inside the rect.
   {
-    auto const junctions = IRoadGraph::JunctionVec({
+    auto const junctions = IRoadGraph::PointWithAltitudeVec({
         {m2::PointD(-1.0, -1.0), 0 /* altitude */},
         {m2::PointD(5.0, 5.0), 0 /* altitude */},
     });
@@ -109,7 +113,7 @@ UNIT_TEST(PolylineInRectTest)
   }
 
   {
-    auto const junctions = IRoadGraph::JunctionVec({
+    auto const junctions = IRoadGraph::PointWithAltitudeVec({
         {m2::PointD(0.0, 1.0), 0 /* altitude */},
         {m2::PointD(100.0, 2.0), 0 /* altitude */},
     });
@@ -118,7 +122,7 @@ UNIT_TEST(PolylineInRectTest)
 
   // Crossing a rect very close to a corner.
   {
-    auto const junctions = IRoadGraph::JunctionVec({
+    auto const junctions = IRoadGraph::PointWithAltitudeVec({
         {m2::PointD(-1.0, 0.0), 0 /* altitude */},
         {m2::PointD(1.0, 1.9), 0 /* altitude */},
     });
@@ -127,7 +131,7 @@ UNIT_TEST(PolylineInRectTest)
 
   // Three point polyline crossing the rect.
   {
-    auto const junctions = IRoadGraph::JunctionVec({
+    auto const junctions = IRoadGraph::PointWithAltitudeVec({
         {m2::PointD(0.0, -1.0), 0 /* altitude */},
         {m2::PointD(1.0, 0.01), 0 /* altitude */},
         {m2::PointD(2.0, -1.0), 0 /* altitude */},

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -9,6 +9,7 @@
 #include "routing/routing_session.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/logging.hpp"
 
@@ -121,9 +122,9 @@ private:
 
 void FillSubroutesInfo(Route & route)
 {
-  vector<Junction> junctions;
+  vector<geometry::PointWithAltitude> junctions;
   for (auto const & point : kTestRoute)
-    junctions.emplace_back(point, feature::kDefaultAltitudeMeters);
+    junctions.emplace_back(point, geometry::kDefaultAltitudeMeters);
 
   vector<RouteSegment> segmentInfo;
   FillSegmentInfo(kTestSegments, junctions, kTestTurns, {}, kTestTimes,

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -10,6 +10,7 @@
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include "base/macros.hpp"
 
@@ -44,16 +45,16 @@ public:
     return 0.0;
   }
 
-  Junction GetStartPoint() const override
+  geometry::PointWithAltitude GetStartPoint() const override
   {
     NOTIMPLEMENTED();
-    return Junction();
+    return geometry::PointWithAltitude();
   }
 
-  Junction GetEndPoint() const override
+  geometry::PointWithAltitude GetEndPoint() const override
   {
     NOTIMPLEMENTED();
-    return Junction();
+    return geometry::PointWithAltitude();
   }
 
 private:
@@ -166,11 +167,11 @@ UNIT_TEST(TestFixupTurns)
   m2::RectD const kSquareNearZero =
       mercator::MetersToXY(kSquareCenterLonLat.x, kSquareCenterLonLat.y, kHalfSquareSideMeters);
   // Removing a turn in case staying on a roundabout.
-  vector<Junction> const pointsMerc1 = {
-    {{ kSquareNearZero.minX(), kSquareNearZero.minY() }, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.minX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.maxX(), kSquareNearZero.minY() }, feature::kDefaultAltitudeMeters},
+  vector<geometry::PointWithAltitude> const pointsMerc1 = {
+      {{kSquareNearZero.minX(), kSquareNearZero.minY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.minX(), kSquareNearZero.maxY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.maxX(), kSquareNearZero.maxY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.maxX(), kSquareNearZero.minY()}, geometry::kDefaultAltitudeMeters},
   };
   // The constructor TurnItem(uint32_t idx, CarDirection t, uint32_t exitNum = 0)
   // is used for initialization of vector<TurnItem> below.
@@ -186,10 +187,10 @@ UNIT_TEST(TestFixupTurns)
   TEST_EQUAL(turnsDir1, expectedTurnDir1, ());
 
   // Merging turns which are close to each other.
-  vector<Junction> const pointsMerc2 = {
-    {{ kSquareNearZero.minX(), kSquareNearZero.minY()}, feature::kDefaultAltitudeMeters},
-    {{ kSquareCenterLonLat.x, kSquareCenterLonLat.y }, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
+  vector<geometry::PointWithAltitude> const pointsMerc2 = {
+      {{kSquareNearZero.minX(), kSquareNearZero.minY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareCenterLonLat.x, kSquareCenterLonLat.y}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.maxX(), kSquareNearZero.maxY()}, geometry::kDefaultAltitudeMeters},
   };
   Route::TTurns turnsDir2 = {{0, CarDirection::GoStraight},
                              {1, CarDirection::TurnLeft},
@@ -201,10 +202,10 @@ UNIT_TEST(TestFixupTurns)
   TEST_EQUAL(turnsDir2, expectedTurnDir2, ());
 
   // No turn is removed.
-  vector<Junction> const pointsMerc3 = {
-    {{ kSquareNearZero.minX(), kSquareNearZero.minY()}, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.minX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
-    {{ kSquareNearZero.maxX(), kSquareNearZero.maxY() }, feature::kDefaultAltitudeMeters},
+  vector<geometry::PointWithAltitude> const pointsMerc3 = {
+      {{kSquareNearZero.minX(), kSquareNearZero.minY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.minX(), kSquareNearZero.maxY()}, geometry::kDefaultAltitudeMeters},
+      {{kSquareNearZero.maxX(), kSquareNearZero.maxY()}, geometry::kDefaultAltitudeMeters},
   };
   Route::TTurns turnsDir3 = {{1, CarDirection::TurnRight},
                              {2, CarDirection::ReachedYourDestination}};

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -121,7 +121,8 @@ void SingleVehicleWorldGraph::GetEdgeList(JointSegment const & parentJoint,
     CheckAndProcessTransitFeatures(parent, jointEdges, parentWeights, isOutgoing);
 }
 
-Junction const & SingleVehicleWorldGraph::GetJunction(Segment const & segment, bool front)
+geometry::PointWithAltitude const & SingleVehicleWorldGraph::GetJunction(Segment const & segment,
+                                                                         bool front)
 {
   return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
          .GetJunction(segment.GetPointId(front));

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -15,6 +15,7 @@
 #include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <functional>
 #include <map>
@@ -42,7 +43,7 @@ public:
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
 
-  Junction const & GetJunction(Segment const & segment, bool front) override;
+  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
 
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -17,8 +17,8 @@ Segment GetReverseSegment(Segment const & segment)
                  !segment.IsForward());
 }
 
-Junction const & GetStopJunction(map<transit::StopId, Junction> const & stopCoords,
-                                 transit::StopId stopId)
+geometry::PointWithAltitude const & GetStopJunction(
+    map<transit::StopId, geometry::PointWithAltitude> const & stopCoords, transit::StopId stopId)
 {
   auto const it = stopCoords.find(stopId);
   CHECK(it != stopCoords.cend(), ("Stop", stopId, "does not exist."));
@@ -43,7 +43,8 @@ TransitGraph::TransitGraph(NumMwmId numMwmId, shared_ptr<EdgeEstimator> estimato
 {
 }
 
-Junction const & TransitGraph::GetJunction(Segment const & segment, bool front) const
+geometry::PointWithAltitude const & TransitGraph::GetJunction(Segment const & segment,
+                                                              bool front) const
 {
   CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
   auto const & vertex = m_fake.GetVertex(segment);
@@ -132,9 +133,10 @@ void TransitGraph::Fill(transit::GraphData const & transitData, GateEndings cons
   for (auto const & line : transitData.GetLines())
     m_transferPenalties[line.GetId()] = line.GetInterval() / 2;
 
-  map<transit::StopId, Junction> stopCoords;
+  map<transit::StopId, geometry::PointWithAltitude> stopCoords;
   for (auto const & stop : transitData.GetStops())
-    stopCoords[stop.GetId()] = Junction(stop.GetPoint(), feature::kDefaultAltitudeMeters);
+    stopCoords[stop.GetId()] =
+        geometry::PointWithAltitude(stop.GetPoint(), geometry::kDefaultAltitudeMeters);
 
   StopToSegmentsMap stopToBack;
   StopToSegmentsMap stopToFront;
@@ -221,8 +223,9 @@ Segment TransitGraph::GetNewTransitSegment() const
 }
 
 void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending,
-                           map<transit::StopId, Junction> const & stopCoords, bool isEnter,
-                           StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront)
+                           map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
+                           bool isEnter, StopToSegmentsMap & stopToBack,
+                           StopToSegmentsMap & stopToFront)
 {
   Segment const dummy = Segment();
   for (auto const & projection : ending.m_projections)
@@ -275,7 +278,7 @@ void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending
 }
 
 Segment TransitGraph::AddEdge(transit::Edge const & edge,
-                              map<transit::StopId, Junction> const & stopCoords,
+                              map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
                               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront)
 {
   auto const edgeSegment = GetNewTransitSegment();

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -13,6 +13,8 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -33,7 +35,7 @@ public:
 
   TransitGraph(NumMwmId numMwmId, std::shared_ptr<EdgeEstimator> estimator);
 
-  Junction const & GetJunction(Segment const & segment, bool front) const;
+  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
   void GetTransitEdges(Segment const & segment, bool isOutgoing,
@@ -57,12 +59,12 @@ private:
   // Adds gate to fake graph. Also adds gate to temporary stopToBack, stopToFront maps used while
   // TransitGraph::Fill.
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
-               std::map<transit::StopId, Junction> const & stopCoords, bool isEnter,
-               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+               std::map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
+               bool isEnter, StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
   // Adds transit edge to fake graph, returns corresponding transit segment. Also adds gate to
   // temporary stopToBack, stopToFront maps used while TransitGraph::Fill.
   Segment AddEdge(transit::Edge const & edge,
-                  std::map<transit::StopId, Junction> const & stopCoords,
+                  std::map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
                   StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
   // Adds connections to fake graph.
   void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -72,7 +72,8 @@ void TransitWorldGraph::GetEdgeList(JointSegment const & parentJoint,
   CHECK(false, ("TransitWorldGraph does not support Joints mode."));
 }
 
-Junction const & TransitWorldGraph::GetJunction(Segment const & segment, bool front)
+geometry::PointWithAltitude const & TransitWorldGraph::GetJunction(Segment const & segment,
+                                                                   bool front)
 {
   if (TransitGraph::IsTransitSegment(segment))
     return GetTransitGraph(segment.GetMwmId()).GetJunction(segment, front);

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -16,6 +16,7 @@
 #include "transit/transit_types.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <memory>
 #include <vector>
@@ -46,7 +47,7 @@ public:
     return weight.GetWeight() - weight.GetTransitTime() <=
            MaxPedestrianTimeSec(startToFinishDistanceM);
   }
-  Junction const & GetJunction(Segment const & segment, bool front) override;
+  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) override;
   m2::PointD const & GetPoint(Segment const & segment, bool front) override;
   // All transit features are oneway.
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -570,8 +570,9 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
 
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
                                     base::Cancellable const & cancellable,
-                                    vector<Junction> & junctions, Route::TTurns & turnsDir,
-                                    Route::TStreets & streets, vector<Segment> & segments)
+                                    vector<geometry::PointWithAltitude> & junctions,
+                                    Route::TTurns & turnsDir, Route::TStreets & streets,
+                                    vector<Segment> & segments)
 {
   LOG(LDEBUG, ("Shortest th length:", result.GetPathLength()));
 
@@ -620,12 +621,13 @@ RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds con
     // Path geometry.
     CHECK_GREATER_OR_EQUAL(loadedSegmentIt->m_path.size(), 2, ());
     // Note. Every LoadedPathSegment in TUnpackedPathSegments contains LoadedPathSegment::m_path
-    // of several Junctions. Last Junction in a LoadedPathSegment::m_path is equal to first junction
-    // in next LoadedPathSegment::m_path in vector TUnpackedPathSegments:
+    // of several Junctions. Last PointWithAltitude in a LoadedPathSegment::m_path is equal to first
+    // junction in next LoadedPathSegment::m_path in vector TUnpackedPathSegments:
     // *---*---*---*---*       *---*           *---*---*---*
     //                 *---*---*   *---*---*---*
-    // To prevent having repetitions in |junctions| list it's necessary to take the first point only from the
-    // first item of |loadedSegments|. The beginning should be ignored for the rest |m_path|.
+    // To prevent having repetitions in |junctions| list it's necessary to take the first point only
+    // from the first item of |loadedSegments|. The beginning should be ignored for the rest
+    // |m_path|.
     junctions.insert(junctions.end(), loadedSegmentIt == loadedSegments.cbegin()
                                           ? loadedSegmentIt->m_path.cbegin()
                                           : loadedSegmentIt->m_path.cbegin() + 1,
@@ -671,7 +673,7 @@ double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t end
   return mercatorDistanceBetweenTurns;
 }
 
-void FixupTurns(vector<Junction> const & junctions, Route::TTurns & turnsDir)
+void FixupTurns(vector<geometry::PointWithAltitude> const & junctions, Route::TTurns & turnsDir)
 {
   double const kMergeDistMeters = 30.0;
   // For turns that are not EnterRoundAbout exitNum is always equal to zero.

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -13,6 +13,8 @@
 
 #include "traffic/traffic_info.hpp"
 
+#include "geometry/point_with_altitude.hpp"
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -95,8 +97,9 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
  */
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
                                     base::Cancellable const & cancellable,
-                                    std::vector<Junction> & points, Route::TTurns & turnsDir,
-                                    Route::TStreets & streets, std::vector<Segment> & segments);
+                                    std::vector<geometry::PointWithAltitude> & points,
+                                    Route::TTurns & turnsDir, Route::TStreets & streets,
+                                    std::vector<Segment> & segments);
 
 // Returns the distance in meractor units for the path of points for the range [startPointIndex, endPointIndex].
 double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t endPointIndex,
@@ -106,7 +109,7 @@ double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t end
  * \brief Selects lanes which are recommended for an end user.
  */
 void SelectRecommendedLanes(Route::TTurns & turnsDir);
-void FixupTurns(std::vector<Junction> const & points, Route::TTurns & turnsDir);
+void FixupTurns(std::vector<geometry::PointWithAltitude> const & points, Route::TTurns & turnsDir);
 inline size_t GetFirstSegmentPointIndex(std::pair<size_t, size_t> const & p) { return p.first; }
 
 CarDirection InvertDirection(CarDirection dir);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -13,6 +13,7 @@
 #include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <functional>
 #include <memory>
@@ -55,7 +56,7 @@ public:
   // start to finish of the route.
   virtual bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const = 0;
 
-  virtual Junction const & GetJunction(Segment const & segment, bool front) = 0;
+  virtual geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) = 0;
   virtual m2::PointD const & GetPoint(Segment const & segment, bool front) = 0;
   virtual bool IsOneWay(NumMwmId mwmId, uint32_t featureId) = 0;
 

--- a/xcode/geometry/geometry.xcodeproj/project.pbxproj
+++ b/xcode/geometry/geometry.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		675344DE1A3F68F900A0A8C3 /* binary_operators.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675344DB1A3F68F900A0A8C3 /* binary_operators.cpp */; };
 		675344DF1A3F68F900A0A8C3 /* binary_operators.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 675344DC1A3F68F900A0A8C3 /* binary_operators.hpp */; };
 		675344E01A3F68F900A0A8C3 /* boost_concept.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 675344DD1A3F68F900A0A8C3 /* boost_concept.hpp */; };
+		D501ACA3238FDC6000B8C08E /* point_with_altitude.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D501ACA1238FDC6000B8C08E /* point_with_altitude.cpp */; };
+		D501ACA4238FDC6000B8C08E /* point_with_altitude.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D501ACA2238FDC6000B8C08E /* point_with_altitude.hpp */; };
 		D53836352366DAF3007E7EDB /* oblate_spheroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D53836332366DAF3007E7EDB /* oblate_spheroid.cpp */; };
 		D53836362366DAF3007E7EDB /* oblate_spheroid.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D53836342366DAF3007E7EDB /* oblate_spheroid.hpp */; };
 		D53836382366DB07007E7EDB /* oblate_spheroid_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D53836372366DB07007E7EDB /* oblate_spheroid_tests.cpp */; };
@@ -218,6 +220,8 @@
 		675344DB1A3F68F900A0A8C3 /* binary_operators.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = binary_operators.cpp; sourceTree = "<group>"; };
 		675344DC1A3F68F900A0A8C3 /* binary_operators.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binary_operators.hpp; sourceTree = "<group>"; };
 		675344DD1A3F68F900A0A8C3 /* boost_concept.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = boost_concept.hpp; sourceTree = "<group>"; };
+		D501ACA1238FDC6000B8C08E /* point_with_altitude.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = point_with_altitude.cpp; sourceTree = "<group>"; };
+		D501ACA2238FDC6000B8C08E /* point_with_altitude.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = point_with_altitude.hpp; sourceTree = "<group>"; };
 		D53836332366DAF3007E7EDB /* oblate_spheroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = oblate_spheroid.cpp; sourceTree = "<group>"; };
 		D53836342366DAF3007E7EDB /* oblate_spheroid.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = oblate_spheroid.hpp; sourceTree = "<group>"; };
 		D53836372366DB07007E7EDB /* oblate_spheroid_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = oblate_spheroid_tests.cpp; sourceTree = "<group>"; };
@@ -328,6 +332,8 @@
 				D53836332366DAF3007E7EDB /* oblate_spheroid.cpp */,
 				D53836342366DAF3007E7EDB /* oblate_spheroid.hpp */,
 				440CF0C0236734820017C2A8 /* area_on_earth.cpp */,
+				D501ACA1238FDC6000B8C08E /* point_with_altitude.cpp */,
+				D501ACA2238FDC6000B8C08E /* point_with_altitude.hpp */,
 				440CF0C1236734820017C2A8 /* area_on_earth.hpp */,
 				56D545681C74A46D00E3719C /* algorithm.cpp */,
 				56D545691C74A46D00E3719C /* algorithm.hpp */,
@@ -444,6 +450,7 @@
 				675344DF1A3F68F900A0A8C3 /* binary_operators.hpp in Headers */,
 				45A2D9C31F7526E6003310A0 /* convex_hull.hpp in Headers */,
 				675344D61A3F687400A0A8C3 /* transformations.hpp in Headers */,
+				D501ACA4238FDC6000B8C08E /* point_with_altitude.hpp in Headers */,
 				39B2B9701FB4680500AB85A1 /* diamond_box.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -587,6 +594,7 @@
 				675344DE1A3F68F900A0A8C3 /* binary_operators.cpp in Sources */,
 				D53836352366DAF3007E7EDB /* oblate_spheroid.cpp in Sources */,
 				56EB1ED01C6B6DF30022D831 /* segment2d.cpp in Sources */,
+				D501ACA3238FDC6000B8C08E /* point_with_altitude.cpp in Sources */,
 				45A2D9C21F7526E6003310A0 /* convex_hull.cpp in Sources */,
 				345C55F51C93140A00B6783F /* clipping.cpp in Sources */,
 			);


### PR DESCRIPTION
We need to draw altitude charts for different types of routes, not only based on our index-graph altitudes from OSRM. To do so first we need to move the `Junction` and `TAltitude` entities to the `geometry` namespace (from `routing` and `feature` respectively).

This PR:
- Moves `Junction class`, `TAltitude using` and its helpers to the new hpp+cpp files in the `geometry` namespace.
- Changes `feature` namespace to `geometry` everywhere it is used for `TAltitude` and its derivatives.
- Renames `Junction` to `PointWithAltitude`.