### PR TITLE
[indexer][generator] Create FeatureBuilderParams with members used for mwm generation only.

### DIFF
--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -98,16 +98,13 @@ void BookingDataset::BuildObject(Object const & hotel,
   metadata.Set(Metadata::FMD_STARS, strings::to_string(hotel.m_stars));
   metadata.Set(Metadata::FMD_PRICE_RATE, strings::to_string(hotel.m_priceCategory));
 
-  auto & params = fb.GetParams();
-  // params.AddAddress(hotel.address);
-  // TODO(mgsergio): addr:full ???
-
   if (!hotel.m_street.empty())
     fb.AddStreet(hotel.m_street);
 
   if (!hotel.m_houseNumber.empty())
     fb.AddHouseNumber(hotel.m_houseNumber);
 
+  auto & params = fb.GetParams();
   if (!hotel.m_translations.empty())
   {
     // TODO(mgsergio): Move parsing to the hotel costruction stage.

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -365,17 +365,6 @@ bool FeatureBuilder::IsExactEq(FeatureBuilder const & fb) const
       m_coastCell == fb.m_coastCell;
 }
 
-void FeatureBuilder::SerializeBase(Buffer & data, serial::GeometryCodingParams const & params,
-                                   bool saveAddInfo) const
-{
-  PushBackByteSink<Buffer> sink(data);
-
-  m_params.Write(sink, saveAddInfo);
-
-  if (m_params.GetGeomType() == GeomType::Point)
-    serial::SavePoint(sink, m_center, params);
-}
-
 void FeatureBuilder::SerializeForIntermediate(Buffer & data) const
 {
   CHECK(IsValid(), (*this));
@@ -384,11 +373,14 @@ void FeatureBuilder::SerializeForIntermediate(Buffer & data) const
 
   serial::GeometryCodingParams cp;
 
-  SerializeBase(data, cp, true /* store additional info from FeatureParams */);
-
   PushBackByteSink<Buffer> sink(data);
+  m_params.Write(sink);
 
-  if (m_params.GetGeomType() != GeomType::Point)
+  if (m_params.GetGeomType() == GeomType::Point)
+  {
+    serial::SavePoint(sink, m_center, cp);
+  }
+  else
   {
     WriteVarUint(sink, static_cast<uint32_t>(m_polygons.size()));
 
@@ -478,7 +470,7 @@ void FeatureBuilder::SerializeAccuratelyForIntermediate(Buffer & data) const
 
   data.clear();
   PushBackByteSink<Buffer> sink(data);
-  m_params.Write(sink, true /* store additional info from FeatureParams */);
+  m_params.Write(sink);
   if (IsPoint())
   {
     WritePOD(sink, m_center);
@@ -675,10 +667,14 @@ void FeatureBuilder::SerializeForMwm(SupportingData & data,
 {
   data.m_buffer.clear();
 
-  // header data serialization
-  SerializeBase(data.m_buffer, params, false /* don't store additional info from FeatureParams*/);
-
   PushBackByteSink<Buffer> sink(data.m_buffer);
+  FeatureParams(m_params).Write(sink);
+
+  if (m_params.GetGeomType() == GeomType::Point)
+  {
+    serial::SavePoint(sink, m_center, params);
+    return;
+  }
 
   uint8_t const ptsCount = base::asserted_cast<uint8_t>(data.m_innerPts.size());
   uint8_t trgCount = base::asserted_cast<uint8_t>(data.m_innerTrg.size());

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -153,10 +153,10 @@ public:
   void AddStreet(std::string const & streetName);
   void AddPostcode(std::string const & postcode);
   bool AddName(std::string const & lang, std::string const & name);
-  void SetParams(FeatureParams const & params) { m_params.SetParams(params); }
+  void SetParams(FeatureBuilderParams const & params) { m_params.SetParams(params); }
 
-  FeatureParams const & GetParams() const { return m_params; }
-  FeatureParams & GetParams() { return m_params; }
+  FeatureBuilderParams const & GetParams() const { return m_params; }
+  FeatureBuilderParams & GetParams() { return m_params; }
   std::string GetName(int8_t lang = StringUtf8Multilang::kDefaultCode) const;
   StringUtf8Multilang const & GetMultilangName() const { return m_params.name; }
   uint8_t GetRank() const { return m_params.rank; }
@@ -178,9 +178,6 @@ public:
 
   // Serialization.
   bool PreSerialize();
-  void SerializeBase(Buffer & data, serial::GeometryCodingParams const & params,
-                     bool saveAddInfo) const;
-
   bool PreSerializeAndRemoveUselessNamesForIntermediate();
   void SerializeForIntermediate(Buffer & data) const;
   void SerializeBorderForIntermediate(serial::GeometryCodingParams const & params,
@@ -237,7 +234,7 @@ protected:
   Geometry m_polygons;  // Check HEADER_IS_AREA
   m2::RectD m_limitRect;
   std::vector<base::GeoObjectId> m_osmIds;
-  FeatureParams m_params;
+  FeatureBuilderParams m_params;
   /// Not used in GEOM_POINTs
   int64_t m_coastCell;
 };

--- a/generator/feature_maker.cpp
+++ b/generator/feature_maker.cpp
@@ -18,14 +18,14 @@ std::shared_ptr<FeatureMakerBase> FeatureMakerSimple::Clone() const
   return std::make_shared<FeatureMakerSimple>();
 }
 
-void FeatureMakerSimple::ParseParams(FeatureParams & params, OsmElement & p) const
+void FeatureMakerSimple::ParseParams(FeatureBuilderParams & params, OsmElement & p) const
 {
   ftype::GetNameAndType(&p, params, [] (uint32_t type) {
     return classif().IsTypeValid(type);
   });
 }
 
-bool FeatureMakerSimple::BuildFromNode(OsmElement & p, FeatureParams const & params)
+bool FeatureMakerSimple::BuildFromNode(OsmElement & p, FeatureBuilderParams const & params)
 {
   FeatureBuilder fb;
   fb.SetCenter(mercator::FromLatLon(p.m_lat, p.m_lon));
@@ -35,7 +35,7 @@ bool FeatureMakerSimple::BuildFromNode(OsmElement & p, FeatureParams const & par
   return true;
 }
 
-bool FeatureMakerSimple::BuildFromWay(OsmElement & p, FeatureParams const & params)
+bool FeatureMakerSimple::BuildFromWay(OsmElement & p, FeatureBuilderParams const & params)
 {
   auto const & nodes = p.Nodes();
   if (nodes.size() < 2)
@@ -56,13 +56,13 @@ bool FeatureMakerSimple::BuildFromWay(OsmElement & p, FeatureParams const & para
   if (fb.IsGeometryClosed())
     fb.SetArea();
   else
-    fb.SetLinear(params.m_reverseGeometry);
+    fb.SetLinear(params.GetReversedGeometry());
 
   m_queue.push(std::move(fb));
   return true;
 }
 
-bool FeatureMakerSimple::BuildFromRelation(OsmElement & p, FeatureParams const & params)
+bool FeatureMakerSimple::BuildFromRelation(OsmElement & p, FeatureBuilderParams const & params)
 {
   HolesRelation helper(m_cache);
   helper.Build(&p);
@@ -97,7 +97,7 @@ std::shared_ptr<FeatureMakerBase> FeatureMaker::Clone() const
   return std::make_shared<FeatureMaker>();
 }
 
-void FeatureMaker::ParseParams(FeatureParams & params, OsmElement & p) const
+void FeatureMaker::ParseParams(FeatureBuilderParams & params, OsmElement & p) const
 {
   ftype::GetNameAndType(&p, params);
 }

--- a/generator/feature_maker.hpp
+++ b/generator/feature_maker.hpp
@@ -21,13 +21,13 @@ public:
 
 protected:
   // FeatureMaker overrides:
-  void ParseParams(FeatureParams & params, OsmElement & element) const override;
+  void ParseParams(FeatureBuilderParams & params, OsmElement & element) const override;
 
 private:
   // FeatureMaker overrides:
-  bool BuildFromNode(OsmElement & element, FeatureParams const & params) override;
-  bool BuildFromWay(OsmElement & element, FeatureParams const & params) override;
-  bool BuildFromRelation(OsmElement & element, FeatureParams const & params) override;
+  bool BuildFromNode(OsmElement & element, FeatureBuilderParams const & params) override;
+  bool BuildFromWay(OsmElement & element, FeatureBuilderParams const & params) override;
+  bool BuildFromRelation(OsmElement & element, FeatureBuilderParams const & params) override;
 };
 
 // The difference between class FeatureMakerSimple and class FeatureMaker is that
@@ -42,6 +42,6 @@ public:
 
 private:
   // FeatureMaker overrides:
-  void ParseParams(FeatureParams & params, OsmElement & element) const override;
+  void ParseParams(FeatureBuilderParams & params, OsmElement & element) const override;
 };
 }  // namespace generator

--- a/generator/feature_maker_base.cpp
+++ b/generator/feature_maker_base.cpp
@@ -27,7 +27,7 @@ bool FeatureMakerBase::Add(OsmElement & element)
 {
   ASSERT(m_cache, ());
 
-  FeatureParams params;
+  FeatureBuilderParams params;
   ParseParams(params, element);
   switch (element.m_type)
   {
@@ -81,7 +81,7 @@ void TransformToLine(FeatureBuilder & feature)
     return;
 
   CHECK(feature.IsArea(), (feature));
-  feature.SetLinear(feature.GetParams().m_reverseGeometry);
+  feature.SetLinear(feature.GetParams().GetReversedGeometry());
 }
 
 FeatureBuilder MakePoint(FeatureBuilder const & feature)

--- a/generator/feature_maker_base.hpp
+++ b/generator/feature_maker_base.hpp
@@ -31,11 +31,11 @@ public:
   bool Empty() const;
 
 protected:
-  virtual bool BuildFromNode(OsmElement & element, FeatureParams const & params) = 0;
-  virtual bool BuildFromWay(OsmElement & element, FeatureParams const & params) = 0;
-  virtual bool BuildFromRelation(OsmElement & element, FeatureParams const & params) = 0;
+  virtual bool BuildFromNode(OsmElement & element, FeatureBuilderParams const & params) = 0;
+  virtual bool BuildFromWay(OsmElement & element, FeatureBuilderParams const & params) = 0;
+  virtual bool BuildFromRelation(OsmElement & element, FeatureBuilderParams const & params) = 0;
 
-  virtual void ParseParams(FeatureParams & params, OsmElement & element) const  = 0;
+  virtual void ParseParams(FeatureBuilderParams & params, OsmElement & element) const = 0;
 
   std::shared_ptr<cache::IntermediateDataReaderInterface> m_cache;
   std::queue<feature::FeatureBuilder> m_queue;

--- a/generator/feature_processing_layers.cpp
+++ b/generator/feature_processing_layers.cpp
@@ -169,7 +169,7 @@ void RepresentationLayer::Handle(FeatureBuilder & fb)
   }
 }
 
-void RepresentationLayer::HandleArea(FeatureBuilder & fb, FeatureParams const & params)
+void RepresentationLayer::HandleArea(FeatureBuilder & fb, FeatureBuilderParams const & params)
 {
   if (CanBeArea(params))
   {

--- a/generator/feature_processing_layers.hpp
+++ b/generator/feature_processing_layers.hpp
@@ -101,7 +101,7 @@ private:
   static bool CanBePoint(FeatureParams const & params);
   static bool CanBeLine(FeatureParams const & params);
 
-  void HandleArea(feature::FeatureBuilder & fb, FeatureParams const & params);
+  void HandleArea(feature::FeatureBuilder & fb, FeatureBuilderParams const & params);
 };
 
 // Responsibility of class PrepareFeatureLayer is the removal of unused types and names,

--- a/generator/generator_tests/descriptions_section_builder_tests.cpp
+++ b/generator/generator_tests/descriptions_section_builder_tests.cpp
@@ -293,7 +293,7 @@ private:
 
   static Feature MakeFeature(std::string const & url)
   {
-    FeatureParams params;
+    FeatureBuilderParams params;
     MetadataTagProcessor p(params);
     feature::Metadata & md = params.GetMetadata();
     p("wikipedia", url);

--- a/generator/generator_tests/feature_builder_test.cpp
+++ b/generator/generator_tests/feature_builder_test.cpp
@@ -23,7 +23,7 @@ using namespace tests;
 UNIT_CLASS_TEST(TestWithClassificator, FBuilder_ManyTypes)
 {
   FeatureBuilder fb1;
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr1[][1] = {
     { "building" },
@@ -67,7 +67,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_ManyTypes)
 UNIT_CLASS_TEST(TestWithClassificator, FBuilder_LineTypes)
 {
   FeatureBuilder fb1;
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr2[][2] = {
     { "railway", "rail" },
@@ -103,7 +103,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_LineTypes)
 UNIT_CLASS_TEST(TestWithClassificator, FBuilder_Waterfall)
 {
   FeatureBuilder fb1;
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr[][2] = {{"waterway", "waterfall"}};
   AddTypes(params, arr);
@@ -170,7 +170,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FVisibility_RemoveUselessTypes)
 
 UNIT_CLASS_TEST(TestWithClassificator, FBuilder_RemoveUselessNames)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr3[][3] = { { "boundary", "administrative", "2" } };
   AddTypes(params, arr3);
@@ -199,22 +199,16 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_RemoveUselessNames)
   TEST(fb1.IsValid(), (fb1));
 }
 
-UNIT_CLASS_TEST(TestWithClassificator, FeatureParams_Parsing)
+UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilderParams_Parsing)
 {
   {
-    FeatureParams params;
+    FeatureBuilderParams params;
     params.AddStreet("Embarcadero\nstreet");
     TEST_EQUAL(params.GetStreet(), "Embarcadero street", ());
   }
 
   {
-    FeatureParams params;
-    params.AddAddress("165 \t\t Dolliver Street");
-    TEST_EQUAL(params.GetStreet(), "Dolliver Street", ());
-  }
-
-  {
-    FeatureParams params;
+    FeatureBuilderParams params;
 
     params.MakeZero();
     TEST(params.AddHouseNumber("123"), ());
@@ -233,7 +227,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FeatureParams_Parsing)
 UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeLocalityObjectForBuildingPoint)
 {
   FeatureBuilder fb;
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr1[][1] = {
     { "building" },
@@ -265,7 +259,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeLocalityObjectFor
 UNIT_TEST(FeatureBuilder_SerializeAccuratelyForIntermediate)
 {
   FeatureBuilder fb1;
-  FeatureParams params;
+  FeatureBuilderParams params;
 
   char const * arr2[][2] = {
     { "railway", "rail" },

--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -13,7 +13,7 @@ using feature::Metadata;
 
 UNIT_TEST(Metadata_ValidateAndFormat_stars)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();
 
@@ -78,7 +78,7 @@ UNIT_CLASS_TEST(TestWithClassificator, Metadata_ValidateAndFormat_operator)
   uint32_t const type_atm = classif().GetTypeByPath({ "amenity", "atm" });
   uint32_t const type_fuel = classif().GetTypeByPath({ "amenity", "fuel" });
 
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();
 
@@ -105,7 +105,7 @@ UNIT_CLASS_TEST(TestWithClassificator, Metadata_ValidateAndFormat_operator)
 
 UNIT_TEST(Metadata_ValidateAndFormat_height)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();
 
@@ -138,7 +138,7 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
 {
   char const * kWikiKey = "wikipedia";
 
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();
 
@@ -203,7 +203,7 @@ UNIT_TEST(Metadata_ValidateAndFormat_wikipedia)
 
 UNIT_CLASS_TEST(TestWithClassificator, Metadata_ValidateAndFormat_duration)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   params.AddType(classif().GetTypeByPath({"route", "ferry"}));
   MetadataTagProcessor p(params);
   Metadata & md = params.GetMetadata();

--- a/generator/generator_tests/osm2meta_test.cpp
+++ b/generator/generator_tests/osm2meta_test.cpp
@@ -4,7 +4,7 @@
 
 UNIT_TEST(ValidateAndFormat_cuisine_test)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessorImpl tagProc(params);
   TEST_EQUAL(tagProc.ValidateAndFormat_cuisine(" ,ABC, CDE;   FgH,   "), "abc;cde;fgh", ());
   TEST_EQUAL(tagProc.ValidateAndFormat_cuisine(";;;ABc,   cef,,,"), "abc;cef", ());
@@ -17,7 +17,7 @@ UNIT_TEST(ValidateAndFormat_cuisine_test)
 
 UNIT_TEST(ValidateAndFormat_ele)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessorImpl tagProc(params);
   TEST_EQUAL(tagProc.ValidateAndFormat_ele(""), "", ());
   TEST_EQUAL(tagProc.ValidateAndFormat_ele("not a number"), "", ());
@@ -43,7 +43,7 @@ UNIT_TEST(ValidateAndFormat_ele)
 
 UNIT_TEST(ValidateAndFormat_building_levels)
 {
-  FeatureParams params;
+  FeatureBuilderParams params;
   MetadataTagProcessorImpl tp(params);
   TEST_EQUAL(tp.ValidateAndFormat_building_levels("４"), "4", ());
   TEST_EQUAL(tp.ValidateAndFormat_building_levels("４floors"), "4", ());

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -35,7 +35,7 @@ namespace
     OsmElement e;
     FillXmlElement(arr, count, &e);
 
-    FeatureParams params;
+    FeatureBuilderParams params;
     ftype::GetNameAndType(&e, params);
 
     DumpTypes(params.m_types);
@@ -50,7 +50,7 @@ namespace
     e.AddTag("smoothness", smoothness);
     e.AddTag("surface:grade", grade);
 
-    FeatureParams params;
+    FeatureBuilderParams params;
     ftype::GetNameAndType(&e, params);
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
@@ -62,14 +62,16 @@ namespace
       if (rtype.substr(0, 9) == "psurface-")
         psurface = rtype.substr(9);
     }
-    TEST(params.IsTypeExist(GetType({"psurface", value})), ("Surface:", surface, "Smoothness:", smoothness, "Grade:", grade, "Expected:", value, "Got:", psurface));
+    TEST(params.IsTypeExist(GetType({"psurface", value})),
+         ("Surface:", surface, "Smoothness:", smoothness, "Grade:", grade, "Expected:", value,
+          "Got:", psurface));
   }
 
-FeatureParams GetFeatureParams(char const * arr[][2], size_t count)
+  FeatureBuilderParams GetFeatureBuilderParams(char const * arr[][2], size_t count)
   {
     OsmElement e;
     FillXmlElement(arr, count, &e);
-    FeatureParams params;
+    FeatureBuilderParams params;
 
     ftype::GetNameAndType(&e, params);
     return params;
@@ -85,7 +87,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_SkipDummy)
     { "ref", "E51" }
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST_EQUAL(params.m_types[0], GetType(arr[1]), ());
@@ -136,7 +138,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Combined)
     { "name", "Гимназия 15" }
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType(arr[3])), ());
@@ -161,7 +163,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Address)
     { "uir_adr:ADRESA_KOD", "21717036" }
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"building", "address"})), ());
@@ -183,7 +185,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_PlaceState)
     { "ref", "CA" }
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "state", "USA"})), ());
@@ -232,7 +234,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_AlabamaRiver)
   FillXmlElement(arr2, ARRAY_SIZE(arr2), &e);
   FillXmlElement(arr3, ARRAY_SIZE(arr3), &e);
 
-  FeatureParams params;
+  FeatureBuilderParams params;
   ftype::GetNameAndType(&e, params);
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
@@ -259,7 +261,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
     TagReplacer tagReplacer(GetPlatform().ResourcesDir() + REPLACED_TAGS_FILE);
     tagReplacer.Process(e);
 
-    FeatureParams params;
+    FeatureBuilderParams params;
     ftype::GetNameAndType(&e, params);
 
     char const * arrT1[] = { "building" };
@@ -287,7 +289,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "yes" }
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"amenity", "atm"})), ());
@@ -301,7 +303,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Synonyms)
       { "atm", "no" }
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), ());
@@ -317,7 +319,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "6"})), ());
@@ -330,7 +332,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -345,7 +347,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Capital)
       { "place", "city" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), ());
@@ -361,7 +363,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Route)
       { "ref", "I 95" }
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -378,7 +380,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "2" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "motorway", "bridge"})), ());
@@ -392,7 +394,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "layer", "-1" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "trunk", "tunnel"})), ());
@@ -405,7 +407,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "bridge", "yes" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "secondary", "bridge"})), ());
@@ -418,7 +420,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "tunnel", "yes" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"highway", "primary", "tunnel"})), ());
@@ -430,7 +432,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Layer)
       { "highway", "living_street" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -446,7 +448,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Amenity)
       { "fuel", "wood" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -467,7 +469,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
       { "oneway", "true" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType(arr[0])), ());
@@ -484,7 +486,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"oneway:bicycle", "no"},
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 6, (params));
     TEST(params.IsTypeExist(GetType(arr[1])), ());
@@ -500,7 +502,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
         {"foot", "yes"}, {"cycleway", "lane"}, {"highway", "primary"},
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType(arr[2])), ());
@@ -540,7 +542,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Ferry)
     { "route", "ferry" },
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 3, (params));
 
@@ -569,7 +571,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"highway", "secondary"},
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(!params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -582,7 +584,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"motorcar", "yes"},
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(!params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -595,7 +597,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_YesCarNoCar)
         {"motor_vehicle", "no"},
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(carModel.GetNoCarTypeForTesting()), ());
@@ -612,7 +614,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Boundary)
     { "boundary", "administrative" },
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 2, (params));
   TEST(params.IsTypeExist(GetType({"boundary", "administrative", "2"})), ());
@@ -633,7 +635,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Dibrugarh)
     { "website", "http://www.hotelvishal.in" },
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), (params));
@@ -653,7 +655,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "subway" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "moscow"})), (params));
@@ -668,7 +670,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "route", "subway" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "newyork"})), (params));
@@ -684,7 +686,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "station", "light_rail" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "light_rail"})), (params));
@@ -702,7 +704,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "transport", "monorail" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "monorail"})), (params));
@@ -717,7 +719,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Subway)
       { "railway", "station" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"railway", "station", "subway", "london"})), (params));
@@ -731,7 +733,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "building", "hospital" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -743,7 +745,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hospital)
       { "amenity", "hospital" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
     TEST(params.IsTypeExist(GetType({"building"})), (params));
@@ -765,7 +767,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Entrance)
     TagReplacer tagReplacer(GetPlatform().ResourcesDir() + REPLACED_TAGS_FILE);
     tagReplacer.Process(e);
 
-    FeatureParams params;
+    FeatureBuilderParams params;
     ftype::GetNameAndType(&e, params);
 
     TEST_EQUAL(params.m_types.size(), 2, (params));
@@ -798,7 +800,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Moscow)
       { "wikipedia", "ru:Москва" },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 1, (params));
     TEST(params.IsTypeExist(GetType({"place", "city", "capital", "2"})), (params));
@@ -819,7 +821,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Translations)
     { "population", "2243833" }
   };
 
-  FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+  auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
   TEST_EQUAL(params.m_types.size(), 1, (params));
   TEST(params.IsTypeExist(GetType({"place", "city"})), ());
@@ -841,7 +843,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Cuisine)
       { "cuisine", "indian ; steak,coffee  shop " },
     };
 
-    FeatureParams const params = GetFeatureParams(arr, ARRAY_SIZE(arr));
+    auto const params = GetFeatureBuilderParams(arr, ARRAY_SIZE(arr));
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
     TEST(params.IsTypeExist(GetType({"cuisine", "indian"})), (params));

--- a/generator/opentable_dataset.cpp
+++ b/generator/opentable_dataset.cpp
@@ -57,9 +57,6 @@ void OpentableDataset::PreprocessMatchedOsmObject(ObjectId const matchedObjId, F
   metadata.Set(Metadata::FMD_SPONSORED_ID, strings::to_string(restaurant.m_id.Get()));
 
   FeatureParams & params = fb.GetParams();
-  // params.AddAddress(restaurant.address);
-  // TODO(mgsergio): addr:full ???
-
   params.AddName(StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode),
                  restaurant.m_name);
 

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -6,10 +6,7 @@
 
 struct MetadataTagProcessorImpl
 {
-  MetadataTagProcessorImpl(FeatureParams &params)
-  : m_params(params)
-  {
-  }
+  MetadataTagProcessorImpl(FeatureBuilderParams & params) : m_params(params) {}
 
   std::string ValidateAndFormat_maxspeed(std::string const & v) const;
   std::string ValidateAndFormat_stars(std::string const & v) const;
@@ -34,7 +31,7 @@ struct MetadataTagProcessorImpl
   std::string ValidateAndFormat_duration(std::string const & v) const;
 
 protected:
-  FeatureParams & m_params;
+  FeatureBuilderParams & m_params;
 };
 
 class MetadataTagProcessor : private MetadataTagProcessorImpl

--- a/generator/osm2type.hpp
+++ b/generator/osm2type.hpp
@@ -11,6 +11,6 @@ struct OsmElement;
 namespace ftype
 {
 /// Get the types, name and layer for feature with the tree of tags.
-void GetNameAndType(OsmElement * p, FeatureParams & params,
+void GetNameAndType(OsmElement * p, FeatureBuilderParams & params,
                     std::function<bool(uint32_t)> filterType = feature::TypeIsUseful);
 }

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -335,45 +335,6 @@ bool FeatureParams::AddHouseNumber(string houseNumber)
   return false;
 }
 
-void FeatureParams::AddStreet(string s)
-{
-  // Replace \n with spaces because we write addresses to txt file.
-  replace(s.begin(), s.end(), '\n', ' ');
-
-  m_addrTags.Add(AddressData::Type::Street, s);
-}
-
-void FeatureParams::AddAddress(string const & s)
-{
-  size_t i = s.find_first_of("\t ");
-  if (i != string::npos)
-  {
-    string const house = s.substr(0, i);
-    if (feature::IsHouseNumber(house))
-    {
-      AddHouseNumber(house);
-      i = s.find_first_not_of("\t ", i);
-    }
-    else
-    {
-      i = 0;
-    }
-  }
-  else
-  {
-    i = 0;
-  }
-
-  AddStreet(s.substr(i));
-}
-
-void FeatureParams::AddPostcode(string const & s)
-{
-  m_addrTags.Add(AddressData::Type::Postcode, s);
-}
-
-string FeatureParams::GetStreet() const { return m_addrTags.Get(AddressData::Type::Street); }
-
 void FeatureParams::SetGeomType(feature::GeomType t)
 {
   switch (t)
@@ -574,6 +535,21 @@ uint32_t FeatureParams::GetTypeForIndex(uint32_t i)
   return classif().GetTypeForIndex(i);
 }
 
+void FeatureBuilderParams::AddStreet(string s)
+{
+  // Replace \n with spaces because we write addresses to txt file.
+  replace(s.begin(), s.end(), '\n', ' ');
+
+  m_addrTags.Add(AddressData::Type::Street, s);
+}
+
+void FeatureBuilderParams::AddPostcode(string const & s)
+{
+  m_addrTags.Add(AddressData::Type::Postcode, s);
+}
+
+string FeatureBuilderParams::GetStreet() const { return m_addrTags.Get(AddressData::Type::Street); }
+
 string DebugPrint(FeatureParams const & p)
 {
   Classificator const & c = classif();
@@ -584,3 +560,5 @@ string DebugPrint(FeatureParams const & p)
 
   return (res + p.DebugString());
 }
+
+string DebugPrint(FeatureBuilderParams const & p) { return DebugPrint(FeatureParams(p)); }

--- a/search/search_integration_tests/generate_tests.cpp
+++ b/search/search_integration_tests/generate_tests.cpp
@@ -36,7 +36,7 @@ public:
     OsmElement e;
     e.AddTag(tag.first, tag.second);
 
-    FeatureParams params;
+    FeatureBuilderParams params;
     ftype::GetNameAndType(&e, params);
     params.AddName("en", "xxx");
 


### PR DESCRIPTION
перенесла поля
```C++
  bool m_reverseGeometry;
  feature::Metadata m_metadata;
  feature::AddressData m_addrTags;
```
которые используются только для генерации из FeatureParams в наследника FeatureBuilderParams.

Удалила метод AddAddress, который не использовался (использование было закомментировано) и имеет плохую реализацию -- он пытается распарсить полный адрес, но при этом поддерживает только формат "дом улица", а в реальных данных типичное содержимое поля "addr:full" это что-то типа "Капотня 2-й квартал, 22" (а в букинге ещё хлеще) -- если решим парсить, то нужно писать другой парсер.

Есть альтернативная реализация -- удалить поля из FeatureParams и перенести их сразу в FeatureBuilder: https://github.com/mapsme/omim/pull/12040/files