### PR TITLE
[generator] Remove setting postcode to metadata for tests.

### DIFF
--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -134,8 +134,6 @@ void FeatureBuilder::AddStreet(string const & streetName) { m_params.AddStreet(s
 void FeatureBuilder::AddPostcode(string const & postcode)
 {
   m_params.AddPostcode(postcode);
-  // todo @t.yan: remove when we stop to add postcodes to metadata
-  m_params.GetMetadata().Set(Metadata::FMD_POSTCODE, postcode);
 }
 
 void FeatureBuilder::AddPoint(m2::PointD const & p)


### PR DESCRIPTION
Забытая тудушка, метод используется только в тестах -- для настойщей сборки карт устанавливается сразу в параметры в osm2type.
Но тесты не парсят osm, а работают сразу с FeatureBuilder, поэтому нужен метод, который добавляет в FeatureBuilder.