### PR TITLE
Track balancer implementation.

### DIFF
--- a/track_analyzing/track_analyzer/CMakeLists.txt
+++ b/track_analyzing/track_analyzer/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(${OMIM_ROOT}/3party/gflags/src)
 
 set(
   SRC
+  balance_csv_impl.cpp
+  balance_csv_impl.hpp
   cmd_cpp_track.cpp
   cmd_gpx.cpp
   cmd_match.cpp

--- a/track_analyzing/track_analyzer/balance_csv_impl.cpp
+++ b/track_analyzing/track_analyzer/balance_csv_impl.cpp
@@ -1,0 +1,230 @@
+#include "track_analyzing/track_analyzer/balance_csv_impl.hpp"
+
+#include "track_analyzing/track_analyzer/utils.hpp"
+
+#include "coding/csv_reader.hpp"
+
+#include "base/math.hpp"
+
+#include <algorithm>
+#include <random>
+#include <utility>
+
+namespace
+{
+double constexpr kSumFractionEps = 1e-5;
+}  // namespace
+
+namespace track_analyzing
+{
+using namespace std;
+
+void FillTable(basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDataPoints,
+               vector<TableRow> & table)
+{
+  for (auto const & row : coding::CSVRunner(
+      coding::CSVReader(tableCsvStream, true /* hasHeader */, ',' /* delimiter */)))
+  {
+    CHECK_EQUAL(row.size(), 19 /* number fields in table csv */, (row));
+    auto const & mwmName = row[kMwmNameCsvColumn];
+    matchedDataPoints[mwmName] += 1;
+    table.push_back(row);
+  }
+}
+
+void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
+                          uint32_t ignoreDataPointNumber)
+{
+  CHECK(AreKeysEqual(additionalMap, checkedMap),
+        ("Mwms in |checkedMap| and in |additionalMap| should have the same set of keys."));
+
+  for (auto it = checkedMap.begin() ; it != checkedMap.end();)
+  {
+    auto const dataPointNumberAfterMatching = it->second;
+    if (dataPointNumberAfterMatching > ignoreDataPointNumber)
+    {
+      ++it;
+      continue;
+    }
+
+    auto const & mwmName = it->first;
+    additionalMap.erase(mwmName);
+    it = checkedMap.erase(it);
+  }
+}
+
+void FillsMwmToDataPointFraction(MwmToDataPoints const & numberMapping, MwmToDataPointFraction & fractionMapping)
+{
+  CHECK(!numberMapping.empty(), ());
+  uint32_t const totalDataPointNumber = ValueSum(numberMapping);
+
+  fractionMapping.clear();
+  for (auto const & kv : numberMapping)
+    fractionMapping.emplace(kv.first, static_cast<double>(kv.second) / totalDataPointNumber);
+}
+
+void CalcsMatchedDataPointsToKeepDistribution(MwmToDataPoints const & matchedDataPoints,
+                                              MwmToDataPointFraction const & distributionFractions,
+                                              MwmToDataPoints & matchedDataPointsToKeepDistribution)
+{
+  CHECK(!matchedDataPoints.empty(), ());
+  CHECK(AreKeysEqual(matchedDataPoints, distributionFractions),
+        ("Mwms in |matchedDataPoints| and in |distributionFractions| should have the same set of keys."));
+  CHECK(base::AlmostEqualAbs(ValueSum(distributionFractions), 1.0, kSumFractionEps),
+        (ValueSum(distributionFractions)));
+
+  matchedDataPointsToKeepDistribution.clear();
+
+  MwmToDataPointFraction matchedFractions;
+  FillsMwmToDataPointFraction(matchedDataPoints, matchedFractions);
+
+  double maxRatio = 0.0;
+  double maxRationDistributionFraction = 0.0;
+  uint32_t maxRationMatchedDataPointNumber = 0;
+  // First, let's find such mwm that all |matchedDataPoints| of it may be used and
+  // the distribution set in |distributionFractions| will be kept. It's an mwm
+  // on which the maximum of ratio
+  // (percent of data points in the distribution) / (percent of matched data points)
+  // is reached.
+  for (auto const & kv : matchedDataPoints)
+  {
+    auto const & mwmName = kv.first;
+    auto const matchedDataPointNumber = kv.second;
+    auto const it = distributionFractions.find(mwmName);
+    CHECK(it != distributionFractions.cend(), (mwmName));
+    auto const distributionFraction = it->second;
+    double const matchedFraction = matchedFractions[mwmName];
+
+    double const ratio = distributionFraction / matchedFraction;
+    if (ratio > maxRatio)
+    {
+      maxRatio = ratio;
+      maxRationDistributionFraction = distributionFraction;
+      maxRationMatchedDataPointNumber = matchedDataPointNumber;
+    }
+  }
+  CHECK_GREATER_OR_EQUAL(maxRatio, 1.0, ());
+
+  // Having data points number in mwm on which the maximum is reached and
+  // fraction of data point in the distribution for this mwm (less or equal 1.0) it's possible to
+  // calculate the total matched points number which may be used to keep the distribution.
+  auto const totalMatchedPointNumberToKeepDistribution =
+      static_cast<uint32_t>(maxRationMatchedDataPointNumber / maxRationDistributionFraction);
+  CHECK_LESS_OR_EQUAL(totalMatchedPointNumberToKeepDistribution, ValueSum(matchedDataPoints), ());
+
+  // Having total maximum matched point number which let to keep the distribution
+  // and which fraction for each mwm should be used to correspond to the distribution
+  // it's possible to find matched data point number which may be used for each mwm
+  // to fulfil the distribution.
+  for (auto const & kv : distributionFractions)
+  {
+    auto const fraction = kv.second;
+    matchedDataPointsToKeepDistribution.emplace(
+        kv.first, static_cast<uint32_t>(fraction * totalMatchedPointNumberToKeepDistribution));
+  }
+}
+
+void BalanceDataPointNumber(MwmToDataPoints && distribution,
+                            MwmToDataPoints && matchedDataPoints, uint32_t ignoreDataPointsNumber,
+                            MwmToDataPoints & balancedDataPointNumber)
+{
+  // Removing every mwm from |distribution| and |matchedDataPoints| if it has
+  // |ignoreDataPointsNumber| data points or less in |matchedDataPoints|.
+  RemoveKeysSmallValue(matchedDataPoints, distribution, ignoreDataPointsNumber);
+
+  // Calculating how much percent data points in each mwm of |distribution|.
+  MwmToDataPointFraction distributionFraction;
+  FillsMwmToDataPointFraction(distribution, distributionFraction);
+
+  CHECK(AreKeysEqual(distribution, matchedDataPoints),
+        ("Mwms in |checkedMap| and in |additionalMap| should have the same set of keys."));
+  // The distribution defined in |distribution| and the distribution after matching
+  // may be different. (They are most likely different.) So to keep the distribution
+  // defined in |distribution| after matching only a part of matched data points
+  // should be used.
+  // Filling |balancedDataPointNumber| with information about how many data points
+  // form |distributionCsvStream| should be used for every mwm.
+  CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
+                                           balancedDataPointNumber);
+}
+
+void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, vector<TableRow> & table)
+{
+  map<string, vector<size_t>> tableIdx;
+  for (size_t idx = 0; idx < table.size(); ++idx)
+  {
+    auto const & row = table[idx];
+    tableIdx[row[kMwmNameCsvColumn]].push_back(idx);
+  }
+
+  // Shuffling data point indexes and reducing the size of index vector for each mwm according to
+  // |balancedDataPointNumbers|.
+  random_device rd;
+  mt19937 g(rd());
+  for (auto & kv : tableIdx)
+  {
+    auto const & mwmName = kv.first;
+    auto & mwmRecordsIndices = kv.second;
+    auto it = balancedDataPointNumbers.find(mwmName);
+    if (it == balancedDataPointNumbers.end())
+    {
+      mwmRecordsIndices.resize(0); // No indices.
+      continue;
+    }
+
+    auto const balancedDataPointNumber = it->second;
+    CHECK_LESS_OR_EQUAL(balancedDataPointNumber, mwmRecordsIndices.size(), (mwmName));
+    shuffle(mwmRecordsIndices.begin(), mwmRecordsIndices.end(), g);
+    mwmRecordsIndices.resize(balancedDataPointNumber);
+  }
+
+  // Refilling |table| with part of its items to corresponds |balancedDataPointNumbers| distribution.
+  vector<TableRow> balancedTable;
+  for (auto const & kv : tableIdx)
+  {
+    for (auto const idx : kv.second)
+      balancedTable.emplace_back(move(table[idx]));
+  }
+  table = move(balancedTable);
+}
+
+void BalanceDataPoints(basic_istream<char> & distributionCsvStream,
+                       basic_istream<char> & tableCsvStream, uint32_t ignoreDataPointsNumber,
+                       vector<TableRow> & balancedTable)
+{
+  // Filling a map mwm to DataPoints number according to distribution csv file.
+  MwmToDataPoints distribution;
+  MappingFromCsv(distributionCsvStream, distribution);
+
+  balancedTable.clear();
+  MwmToDataPoints matchedDataPoints;
+  FillTable(tableCsvStream, matchedDataPoints, balancedTable);
+
+  if (matchedDataPoints.empty())
+  {
+    CHECK(balancedTable.empty(), ());
+    return;
+  }
+
+  // Removing every mwm from |distribution| if there is no such mwm in |matchedDataPoints|.
+  for (auto it = distribution.begin(); it != distribution.end();)
+  {
+    if (matchedDataPoints.count(it->first) == 0)
+      it = distribution.erase(it);
+    else
+      ++it;
+  }
+  CHECK(AreKeysEqual(distribution, matchedDataPoints),
+        ("Mwms in |distribution| and in |matchedDataPoints| should have the same set of keys."));
+
+  // Calculating how many points should have every mwm to keep the |distribution|.
+  MwmToDataPoints balancedDataPointNumber;
+  BalanceDataPointNumber(move(distribution), move(matchedDataPoints), ignoreDataPointsNumber,
+                         balancedDataPointNumber);
+
+  // |balancedTable| is filled now with all the items from |tableCsvStream|.
+  // Removing some items form |tableCsvStream| (if it's necessary) to correspond to
+  // the distribution.
+  FilterTable(balancedDataPointNumber, balancedTable);
+}
+}  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/balance_csv_impl.hpp
+++ b/track_analyzing/track_analyzer/balance_csv_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "track_analyzing/track_analyzer/utils.hpp"
 
 #include <cstdint>
@@ -14,13 +15,13 @@ using MwmToDataPoints = Stats::NameToCountMapping;
 // Csv table row.
 using TableRow = std::vector<std::string>;
 // Mwm to data points percent in the mwm mapping. It's assumed that the sum of the values
-// should be equal to 100.0 percents.
+// should be equal to 100.0 percent.
 using MwmToDataPointFraction = std::map<std::string, double>;
 
 size_t constexpr kMwmNameCsvColumn = 1;
 
 /// \brief Fills a map |mwmToDataPoints| mwm to DataPoints number according to |tableCsvStream| and
-/// fills |table| with all the content of |tableCsv|.
+/// fills |matchedDataPoints| with all the content of |tableCsvStream|.
 void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDataPoints,
                std::vector<TableRow> & table);
 
@@ -29,24 +30,21 @@ void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matc
 void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
                           uint32_t ignoreDataPointNumber);
 
-/// \brief Fills |fractionMapping|. It is the mapping from mwm to fraction of data points contained
-/// in the mwm.
-void FillsMwmToDataPointFraction(MwmToDataPoints const & numberMapping,
-                                 MwmToDataPointFraction & fractionMapping);
+/// \returns mapping from mwm to fraction of data points contained in the mwm.
+MwmToDataPointFraction GetMwmToDataPointFraction(MwmToDataPoints const & numberMapping);
 
-/// \brief Fills mapping |matchedDataPointsToKeepDistribution| fulfilling two conditions:
-/// *  number of data points in |matchedDataPointsToKeepDistribution| is less or equal
+/// \returns mapping mwm to matched data points fulfilling two conditions:
+/// *  number of data points in the returned mapping is less than or equal to
 ///    number of data points in |matchedDataPoints| for every mwm
 /// * distribution defined by |distributionFraction| is kept
-void CalcsMatchedDataPointsToKeepDistribution(MwmToDataPoints const & matchedDataPoints,
-                                              MwmToDataPointFraction const & distributionFractions,
-                                              MwmToDataPoints & matchedDataPointsToKeepDistribution);
+MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
+    MwmToDataPoints const & matchedDataPoints,
+    MwmToDataPointFraction const & distributionFractions);
 
-/// \brief Fills |balancedDataPointNumber| with number of matched data points for every mwm
-/// to correspond to |distribution|.
-void BalanceDataPointNumber(MwmToDataPoints && distribution,
-                            MwmToDataPoints && matchedDataPoints, uint32_t ignoreDataPointsNumber,
-                            MwmToDataPoints & balancedDataPointNumber);
+/// \returns mapping with number of matched data points for every mwm to correspond to |distribution|.
+MwmToDataPoints BalancedDataPointNumber(MwmToDataPoints && distribution,
+                                        MwmToDataPoints && matchedDataPoints,
+                                        uint32_t ignoreDataPointsNumber);
 
 /// \breif Leaves in |table| only number of items according to |balancedDataPointNumbers|.
 /// \note |table| may have a significant size. It may be several tens millions records.

--- a/track_analyzing/track_analyzer/balance_csv_impl.hpp
+++ b/track_analyzing/track_analyzer/balance_csv_impl.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include "track_analyzing/track_analyzer/utils.hpp"
+
+#include <cstdint>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace track_analyzing
+{
+// Mwm to data points number in the mwm mapping.
+using MwmToDataPoints = Stats::NameToCountMapping;
+// Csv table row.
+using TableRow = std::vector<std::string>;
+// Mwm to data points percent in the mwm mapping. It's assumed that the sum of the values
+// should be equal to 100.0 percents.
+using MwmToDataPointFraction = std::map<std::string, double>;
+
+size_t constexpr kMwmNameCsvColumn = 1;
+
+/// \brief Fills a map |mwmToDataPoints| mwm to DataPoints number according to |tableCsvStream| and
+/// fills |table| with all the content of |tableCsv|.
+void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDataPoints,
+               std::vector<TableRow> & table);
+
+/// \brief Removing every mwm from |checkedMap| and |additionalMap| if it has
+/// |ignoreDataPointsNumber| data points or less in |checkedMap|.
+void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
+                          uint32_t ignoreDataPointNumber);
+
+/// \brief Fills |fractionMapping|. It is the mapping from mwm to fraction of data points contained
+/// in the mwm.
+void FillsMwmToDataPointFraction(MwmToDataPoints const & numberMapping,
+                                 MwmToDataPointFraction & fractionMapping);
+
+/// \brief Fills mapping |matchedDataPointsToKeepDistribution| fulfilling two conditions:
+/// *  number of data points in |matchedDataPointsToKeepDistribution| is less or equal
+///    number of data points in |matchedDataPoints| for every mwm
+/// * distribution defined by |distributionFraction| is kept
+void CalcsMatchedDataPointsToKeepDistribution(MwmToDataPoints const & matchedDataPoints,
+                                              MwmToDataPointFraction const & distributionFractions,
+                                              MwmToDataPoints & matchedDataPointsToKeepDistribution);
+
+/// \brief Fills |balancedDataPointNumber| with number of matched data points for every mwm
+/// to correspond to |distribution|.
+void BalanceDataPointNumber(MwmToDataPoints && distribution,
+                            MwmToDataPoints && matchedDataPoints, uint32_t ignoreDataPointsNumber,
+                            MwmToDataPoints & balancedDataPointNumber);
+
+/// \breif Leaves in |table| only number of items according to |balancedDataPointNumbers|.
+/// \note |table| may have a significant size. It may be several tens millions records.
+void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, std::vector<TableRow> & table);
+
+/// \brief Fills |balancedTable| with TableRow(s) according to the distribution set in
+/// |distributionCsvStream|.
+void BalanceDataPoints(std::basic_istream<char> & distributionCsvStream,
+                       std::basic_istream<char> & tableCsvStream, uint32_t ignoreDataPointsNumber,
+                       std::vector<TableRow> & balancedTable);
+
+template <typename MapCont>
+typename MapCont::mapped_type ValueSum(MapCont const & mapCont)
+{
+  typename MapCont::mapped_type valueSum = typename MapCont::mapped_type();
+  for (auto const & kv : mapCont)
+    valueSum += kv.second;
+  return valueSum;
+}
+
+/// \returns true if |map1| and |map2| have the same key and false otherwise.
+template<typename Map1, typename Map2>
+bool AreKeysEqual(Map1 const & map1, Map2 const & map2)
+{
+  if (map1.size() != map2.size())
+    return false;
+
+  for (auto const & kv : map1)
+  {
+    if (map2.count(kv.first) == 0)
+      return false;
+  }
+  return true;
+}
+}  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/cmd_match.cpp
+++ b/track_analyzing/track_analyzer/cmd_match.cpp
@@ -98,7 +98,7 @@ void CmdMatch(string const & logFile, string const & trackFile,
 {
   MwmToTracks mwmToTracks;
   ParseTracks(logFile, numMwmIds, mwmToTracks);
-  AddStat(mwmToTracks, *numMwmIds, storage, stat);
+  stat.AddTracksStats(mwmToTracks, *numMwmIds, storage);
 
   MwmToMatchedTracks mwmToMatchedTracks;
   MatchTracks(mwmToTracks, storage, *numMwmIds, mwmToMatchedTracks);

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -320,8 +320,7 @@ public:
       out << user << "," << countryName << "," << it.first.GetSummary() << ","
           << it.second.GetSummary() << '\n';
 
-      stats.m_mwmToTotalDataPoints[mwmName] += it.second.GetDataPointsNumber();
-      stats.m_countryToTotalDataPoints[countryName] += it.second.GetDataPointsNumber();
+      stats.AddDataPoints(mwmName, countryName, it.second.GetDataPointsNumber());
     }
 
     return out.str();

--- a/track_analyzing/track_analyzer/utils.hpp
+++ b/track_analyzing/track_analyzer/utils.hpp
@@ -9,31 +9,56 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
-#include <track_analyzing/track.hpp>
 
 namespace track_analyzing
 {
-struct Stats
+class Stats
 {
+public:
+  friend std::string DebugPrint(Stats const & s);
+
   using NameToCountMapping = std::map<std::string, uint32_t>;
 
-  void Add(Stats const & stats);
-  bool operator==(Stats const & stats) const;
+  Stats() = default;
+  Stats(NameToCountMapping const & mwmToTotalDataPoints,
+        NameToCountMapping const & countryToTotalDataPoint);
 
+  bool operator==(Stats const & stats) const;
+  void Add(Stats const & stats);
+
+  /// \brief Adds some stats according to |mwmToTracks|.
+  void AddTracksStats(MwmToTracks const & mwmToTracks, routing::NumMwmIds const & numMwmIds,
+                      storage::Storage const & storage);
+
+  /// \brief Adds |dataPointNum| to |m_mwmToTotalDataPoints| and |m_countryToTotalDataPoints|.
+  void AddDataPoints(std::string const & mwmName, std::string const & countryName,
+                     uint32_t dataPointNum);
+
+  /// \brief Saves csv file with numbers of DataPoints for each mwm to |csvPath|.
+  /// If |csvPath| is empty it does nothing.
+  void SaveMwmDistributionToCsv(std::string const & csvPath);
+
+  NameToCountMapping const & GetMwmToTotalDataPointsForTesting() const;
+  NameToCountMapping const & GetCountryToTotalDataPointsForTesting() const;
+
+private:
   /// \note These fields may present mapping from territory name to either DataPoints
   /// or MatchedTrackPoint count.
   NameToCountMapping m_mwmToTotalDataPoints;
   NameToCountMapping m_countryToTotalDataPoints;
 };
 
+/// \brief Saves |mapping| as csv to |ss|.
+void MappingToCsv(std::string const & keyName, Stats::NameToCountMapping const & mapping,
+                  bool printPercentage, std::basic_ostream<char> & ss);
+/// \breif Fills |mapping| according to csv in |ss|. Csv header is skipped.
+void MappingFromCsv(std::basic_istream<char> & ss, Stats::NameToCountMapping & mapping);
+
 /// \brief Parses tracks from |logFile| and fills |mwmToTracks|.
 void ParseTracks(std::string const & logFile, std::shared_ptr<routing::NumMwmIds> const & numMwmIds,
                  MwmToTracks & mwmToTracks);
-
-/// \brief Fills |stat| according to |mwmToTracks|.
-void AddStat(MwmToTracks const & mwmToTracks, routing::NumMwmIds const & numMwmIds,
-             storage::Storage const & storage, Stats & stats);
 
 std::string DebugPrint(Stats const & s);
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzing_tests/CMakeLists.txt
+++ b/track_analyzing/track_analyzing_tests/CMakeLists.txt
@@ -2,8 +2,11 @@ project(track_analyzing_tests)
 
 set(
   SRC
+  ../track_analyzer/balance_csv_impl.cpp
+  ../track_analyzer/balance_csv_impl.hpp
   ../track_analyzer/utils.cpp
   ../track_analyzer/utils.hpp
+  balance_tests.cpp
   statistics_tests.cpp
 )
 

--- a/track_analyzing/track_analyzing_tests/balance_tests.cpp
+++ b/track_analyzing/track_analyzing_tests/balance_tests.cpp
@@ -103,29 +103,18 @@ UNIT_TEST(RemoveKeysSmallValueTest)
   TEST_EQUAL(additionalMap, expectedAdditionalMap, ());
 }
 
-UNIT_TEST(FillsMwmToDataPointFractionTest)
+UNIT_TEST(GetMwmToDataPointFractionTest)
 {
   MwmToDataPoints const numberMapping = {{"Russia_Moscow", 100 /* data points */},
                                          {"San Marino", 50 /* data points */},
                                          {"Slovakia", 50 /* data points */}};
-  MwmToDataPointFraction fractionMapping;
-  FillsMwmToDataPointFraction(numberMapping, fractionMapping);
+  auto const fractionMapping = GetMwmToDataPointFraction(numberMapping);
 
   MwmToDataPointFraction expectedFractionMapping{{"Russia_Moscow", 0.5 /* fraction */},
                                                  {"San Marino", 0.25 /* fraction */},
                                                  {"Slovakia", 0.25 /* fraction */}};
   TEST_EQUAL(fractionMapping, expectedFractionMapping, ());
 }
-
-//UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionEmptyTest)
-//{
-//  MwmToDataPoints const matchedDataPoints;
-//  MwmToDataPointFraction const distributionFraction;
-//  MwmToDataPoints matchedDataPointsToKeepDistribution;
-//  CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
-//                                           matchedDataPointsToKeepDistribution);
-//  TEST(matchedDataPointsToKeepDistribution.empty(), ());
-//}
 
 UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionTest)
 {
@@ -139,9 +128,8 @@ UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionTest)
     MwmToDataPoints expected = {{"Russia_Moscow", 400 /* data points */},
                                 {"San Marino", 50 /* data points */},
                                 {"Slovakia", 50 /* data points */}};
-    MwmToDataPoints matchedDataPointsToKeepDistribution;
-    CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
-                                             matchedDataPointsToKeepDistribution);
+    MwmToDataPoints const matchedDataPointsToKeepDistribution =
+        CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction);
     TEST_EQUAL(matchedDataPointsToKeepDistribution, expected, ());
   }
   {
@@ -154,14 +142,13 @@ UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionTest)
     MwmToDataPoints expected = {{"Russia_Moscow", 50 /* data points */},
                                 {"San Marino", 100 /* data points */},
                                 {"Slovakia", 100 /* data points */}};
-    MwmToDataPoints matchedDataPointsToKeepDistribution;
-    CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
-                                             matchedDataPointsToKeepDistribution);
+    MwmToDataPoints const matchedDataPointsToKeepDistribution =
+        CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction);
     TEST_EQUAL(matchedDataPointsToKeepDistribution, expected, ());
   }
 }
 
-UNIT_TEST(BalanceDataPointNumberTheSameTest)
+UNIT_TEST(BalancedDataPointNumberTheSameTest)
 {
   MwmToDataPoints const distribution = {{"Russia_Moscow", 100 /* data points */},
                                         {"San Marino", 50 /* data points */},
@@ -173,9 +160,8 @@ UNIT_TEST(BalanceDataPointNumberTheSameTest)
     // Case when the distribution is not changed. All mwms lose the same percent of data points.
     auto distr = distribution;
     auto matched = matchedDataPoints;
-    MwmToDataPoints balancedDataPointNumber;
-    BalanceDataPointNumber(move(distr), move(matched),
-                           0 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    auto const balancedDataPointNumber =
+        BalancedDataPointNumber(move(distr), move(matched), 0 /* ignoreDataPointsNumber */);
     TEST_EQUAL(balancedDataPointNumber, matchedDataPoints, ());
   }
 
@@ -184,15 +170,14 @@ UNIT_TEST(BalanceDataPointNumberTheSameTest)
     // the same percent of data points. But mwms with small number of points are moved.
     auto distr = distribution;
     auto matched = matchedDataPoints;
-    MwmToDataPoints balancedDataPointNumber;
-    BalanceDataPointNumber(move(distr), move(matched),
-                           7 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    auto const balancedDataPointNumber =
+        BalancedDataPointNumber(move(distr), move(matched), 7 /* ignoreDataPointsNumber */);
     MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 10 /* data points */}};
     TEST_EQUAL(balancedDataPointNumber, expectedBalancedDataPointNumber, ());
   }
 }
 
-UNIT_TEST(BalanceDataPointNumberTest)
+UNIT_TEST(BalancedDataPointNumberTest)
 {
   MwmToDataPoints distribution = {{"Russia_Moscow", 6000 /* data points */},
                                   {"San Marino", 3000 /* data points */},
@@ -203,9 +188,8 @@ UNIT_TEST(BalanceDataPointNumberTest)
   {
     auto distr = distribution;
     auto matched = matchedDataPoints;
-    MwmToDataPoints balancedDataPointNumber;
-    BalanceDataPointNumber(move(distr), move(matched),
-                           7 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    auto const balancedDataPointNumber =
+        BalancedDataPointNumber(move(distr), move(matched), 7 /* ignoreDataPointsNumber */);
     MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 60 /* data points */},
                                                        {"San Marino", 30 /* data points */},
                                                        {"Slovakia", 10 /* data points */}};

--- a/track_analyzing/track_analyzing_tests/balance_tests.cpp
+++ b/track_analyzing/track_analyzing_tests/balance_tests.cpp
@@ -1,0 +1,259 @@
+#include "testing/testing.hpp"
+
+#include "track_analyzing/track_analyzer/balance_csv_impl.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using namespace std;
+using namespace track_analyzing;
+
+string const csv =  R"(user,mwm,hw type,surface type,maxspeed km/h,is city road,is one way,is day,lat lon,distance,time,mean speed km/h,turn from smaller to bigger,turn from bigger to smaller,from link,to link,intersection with big,intersection with small,intersection with link
+I:D923B4DC-09E0-4B0B-B7F8-153965396B55,New Zealand,highway-trunk,psurface-paved_good,80,0,0,1,-41.4832 173.844,163.984,6,98.3902,0,0,0,0,0,1,0
+I:D923B4DC-09E0-4B0B-B7F8-153965396B55,New Zealand,highway-trunk,psurface-paved_good,80,0,0,1,-41.4831 173.845,2274.59,108,75.8196,0,0,0,0,0,4,0
+A:b6e31294-5c90-4105-9f7b-51a382eabfa0,Poland,highway-primary,psurface-paved_good,50,0,0,0,53.8524 21.3061,1199.34,60,71.9604,0,0,0,0,0,10,0)";
+
+UNIT_TEST(FillTableTestEmpty)
+{
+  std::stringstream ss;
+  std::vector<TableRow> table;
+  MwmToDataPoints matchedDataPoints;
+
+  // Stream without csv header.
+  FillTable(ss, matchedDataPoints, table);
+  TEST(table.empty(), ());
+  TEST(matchedDataPoints.empty(), ());
+
+  // Stream with only csv header.
+  ss << "mwm,number\n";
+  FillTable(ss, matchedDataPoints, table);
+  TEST(table.empty(), ());
+  TEST(matchedDataPoints.empty(), ());
+}
+
+UNIT_TEST(FillTableTest)
+{
+  std::stringstream ss;
+  std::vector<TableRow> table;
+  MwmToDataPoints matchedDataPoints;
+
+  ss << csv;
+  FillTable(ss, matchedDataPoints, table);
+
+  MwmToDataPoints const expectedMatchedDataPoints = {{"New Zealand", 2 /* data points */},
+                                                     {"Poland", 1 /* data points */}};
+  std::vector<TableRow> expectedTable = {
+      {"I:D923B4DC-09E0-4B0B-B7F8-153965396B55", "New Zealand", "highway-trunk",
+       "psurface-paved_good", "80", "0", "0", "1", "-41.4832 173.844", "163.984", "6", "98.3902",
+       "0", "0", "0", "0", "0", "1", "0"},
+      {"I:D923B4DC-09E0-4B0B-B7F8-153965396B55", "New Zealand", "highway-trunk",
+       "psurface-paved_good", "80", "0", "0", "1", "-41.4831 173.845", "2274.59", "108", "75.8196",
+       "0", "0", "0", "0", "0", "4", "0"},
+      {"A:b6e31294-5c90-4105-9f7b-51a382eabfa0", "Poland", "highway-primary", "psurface-paved_good",
+       "50", "0", "0", "0", "53.8524 21.3061", "1199.34", "60", "71.9604", "0", "0", "0", "0", "0",
+       "10", "0"}};
+
+  TEST_EQUAL(matchedDataPoints, expectedMatchedDataPoints, ());
+  TEST_EQUAL(table, expectedTable, ());
+}
+
+UNIT_TEST(AreKeysEqualEmptyMapsTest)
+{
+  TEST(AreKeysEqual(MwmToDataPoints(), MwmToDataPoints()), ());
+}
+
+UNIT_TEST(AreKeysEqualTest)
+{
+  MwmToDataPoints const map1 = {{"Russia_Moscow", 5 /* data points */},
+                                {"San Marino", 7 /* data points */}};
+  MwmToDataPoints map2 = {{"Russia_Moscow", 7 /* data points*/},
+                          {"San Marino", 9 /* data points */}};
+  TEST(AreKeysEqual(map1, map2), ());
+
+  map2["Slovakia"] = 3;
+  TEST(!AreKeysEqual(map1, map2), ());
+}
+
+UNIT_TEST(RemoveKeysSmallValueEmptyTest)
+{
+  MwmToDataPoints checkedMap;
+  MwmToDataPoints additionalMap;
+  RemoveKeysSmallValue(checkedMap, additionalMap, 10 /* ignoreDataPointNumber */);
+  TEST(checkedMap.empty(), (checkedMap.size()));
+  TEST(additionalMap.empty(), (checkedMap.size()));
+}
+
+UNIT_TEST(RemoveKeysSmallValueTest)
+{
+  MwmToDataPoints checkedMap = {{"Russia_Moscow", 3 /* data points */},
+                                {"San Marino", 5 /* data points */}};
+  MwmToDataPoints additionalMap = {{"Russia_Moscow", 7 /* data points*/},
+                                   {"San Marino", 9 /* data points */}};
+  RemoveKeysSmallValue(checkedMap, additionalMap, 4 /* ignoreDataPointNumber */);
+
+  MwmToDataPoints expectedCheckedMap = {{"San Marino", 5 /* data points */}};
+  MwmToDataPoints expectedAdditionalMap = {{"San Marino", 9 /* data points */}};
+
+  TEST_EQUAL(checkedMap, expectedCheckedMap, ());
+  TEST_EQUAL(additionalMap, expectedAdditionalMap, ());
+}
+
+UNIT_TEST(FillsMwmToDataPointFractionTest)
+{
+  MwmToDataPoints const numberMapping = {{"Russia_Moscow", 100 /* data points */},
+                                         {"San Marino", 50 /* data points */},
+                                         {"Slovakia", 50 /* data points */}};
+  MwmToDataPointFraction fractionMapping;
+  FillsMwmToDataPointFraction(numberMapping, fractionMapping);
+
+  MwmToDataPointFraction expectedFractionMapping{{"Russia_Moscow", 0.5 /* fraction */},
+                                                 {"San Marino", 0.25 /* fraction */},
+                                                 {"Slovakia", 0.25 /* fraction */}};
+  TEST_EQUAL(fractionMapping, expectedFractionMapping, ());
+}
+
+//UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionEmptyTest)
+//{
+//  MwmToDataPoints const matchedDataPoints;
+//  MwmToDataPointFraction const distributionFraction;
+//  MwmToDataPoints matchedDataPointsToKeepDistribution;
+//  CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
+//                                           matchedDataPointsToKeepDistribution);
+//  TEST(matchedDataPointsToKeepDistribution.empty(), ());
+//}
+
+UNIT_TEST(CalcsMatchedDataPointsToKeepDistributionTest)
+{
+  {
+    MwmToDataPoints const matchedDataPoints = {{"Russia_Moscow", 400 /* data points */},
+                                               {"San Marino", 400 /* data points */},
+                                               {"Slovakia", 200 /* data points */}};
+    MwmToDataPointFraction const distributionFraction = {{"Russia_Moscow", 0.8 /* data points */},
+                                                         {"San Marino", 0.1 /* data points */},
+                                                         {"Slovakia", 0.1 /* data points */}};
+    MwmToDataPoints expected = {{"Russia_Moscow", 400 /* data points */},
+                                {"San Marino", 50 /* data points */},
+                                {"Slovakia", 50 /* data points */}};
+    MwmToDataPoints matchedDataPointsToKeepDistribution;
+    CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
+                                             matchedDataPointsToKeepDistribution);
+    TEST_EQUAL(matchedDataPointsToKeepDistribution, expected, ());
+  }
+  {
+    MwmToDataPoints const matchedDataPoints = {{"Russia_Moscow", 800 /* data points */},
+                                               {"San Marino", 100 /* data points */},
+                                               {"Slovakia", 100 /* data points */}};
+    MwmToDataPointFraction const distributionFraction = {{"Russia_Moscow", 0.2 /* data points */},
+                                                         {"San Marino", 0.4 /* data points */},
+                                                         {"Slovakia", 0.4 /* data points */}};
+    MwmToDataPoints expected = {{"Russia_Moscow", 50 /* data points */},
+                                {"San Marino", 100 /* data points */},
+                                {"Slovakia", 100 /* data points */}};
+    MwmToDataPoints matchedDataPointsToKeepDistribution;
+    CalcsMatchedDataPointsToKeepDistribution(matchedDataPoints, distributionFraction,
+                                             matchedDataPointsToKeepDistribution);
+    TEST_EQUAL(matchedDataPointsToKeepDistribution, expected, ());
+  }
+}
+
+UNIT_TEST(BalanceDataPointNumberTheSameTest)
+{
+  MwmToDataPoints const distribution = {{"Russia_Moscow", 100 /* data points */},
+                                        {"San Marino", 50 /* data points */},
+                                        {"Slovakia", 50 /* data points */}};
+  MwmToDataPoints const matchedDataPoints = {{"Russia_Moscow", 10 /* data points */},
+                                             {"San Marino", 5 /* data points */},
+                                             {"Slovakia", 5 /* data points */}};
+  {
+    // Case when the distribution is not changed. All mwms lose the same percent of data points.
+    auto distr = distribution;
+    auto matched = matchedDataPoints;
+    MwmToDataPoints balancedDataPointNumber;
+    BalanceDataPointNumber(move(distr), move(matched),
+                           0 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    TEST_EQUAL(balancedDataPointNumber, matchedDataPoints, ());
+  }
+
+  {
+    // Case when the distribution is not changed. All mwms lose
+    // the same percent of data points. But mwms with small number of points are moved.
+    auto distr = distribution;
+    auto matched = matchedDataPoints;
+    MwmToDataPoints balancedDataPointNumber;
+    BalanceDataPointNumber(move(distr), move(matched),
+                           7 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 10 /* data points */}};
+    TEST_EQUAL(balancedDataPointNumber, expectedBalancedDataPointNumber, ());
+  }
+}
+
+UNIT_TEST(BalanceDataPointNumberTest)
+{
+  MwmToDataPoints distribution = {{"Russia_Moscow", 6000 /* data points */},
+                                  {"San Marino", 3000 /* data points */},
+                                  {"Slovakia", 1000 /* data points */}};
+  MwmToDataPoints matchedDataPoints = {{"Russia_Moscow", 500 /* data points */},
+                                       {"San Marino", 300 /* data points */},
+                                       {"Slovakia", 10 /* data points */}};
+  {
+    auto distr = distribution;
+    auto matched = matchedDataPoints;
+    MwmToDataPoints balancedDataPointNumber;
+    BalanceDataPointNumber(move(distr), move(matched),
+                           7 /* ignoreDataPointsNumber */, balancedDataPointNumber);
+    MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 60 /* data points */},
+                                                       {"San Marino", 30 /* data points */},
+                                                       {"Slovakia", 10 /* data points */}};
+    TEST_EQUAL(balancedDataPointNumber, expectedBalancedDataPointNumber, ());
+  }
+}
+
+UNIT_TEST(FilterTableTest)
+{
+  std::stringstream ss;
+  std::vector<TableRow> csvTable;
+  MwmToDataPoints matchedDataPoints;
+
+  ss << csv;
+  FillTable(ss, matchedDataPoints, csvTable);
+
+  auto const calcRecords = [](vector<TableRow> const & t, string const & mwmName) {
+    return count_if(t.cbegin(), t.cend(),
+                    [&mwmName](TableRow const & row) { return row[kMwmNameCsvColumn] == mwmName; });
+  };
+
+  {
+    auto table = csvTable;
+    MwmToDataPoints const balancedDataPointNumbers = {{"New Zealand", 2 /* data points */},
+                                                      {"Poland", 1 /* data points */}};
+    FilterTable(balancedDataPointNumbers, table);
+    TEST_EQUAL(table.size(), 3, ());
+    TEST_EQUAL(calcRecords(table, "New Zealand"), 2, ());
+    TEST_EQUAL(calcRecords(table, "Poland"), 1, ());
+  }
+
+  {
+    auto table = csvTable;
+    MwmToDataPoints const balancedDataPointNumbers = {{"New Zealand", 1 /* data points */},
+                                                      {"Poland", 1 /* data points */}};
+    FilterTable(balancedDataPointNumbers, table);
+    TEST_EQUAL(table.size(), 2, ());
+    TEST_EQUAL(calcRecords(table, "New Zealand"), 1, ());
+    TEST_EQUAL(calcRecords(table, "Poland"), 1, ());
+  }
+
+  {
+    auto table = csvTable;
+    MwmToDataPoints const balancedDataPointNumbers = {{"New Zealand", 2 /* data points */}};
+    FilterTable(balancedDataPointNumbers, table);
+    TEST_EQUAL(table.size(), 2, ());
+    TEST_EQUAL(calcRecords(table, "New Zealand"), 2, ());
+    TEST_EQUAL(calcRecords(table, "Poland"), 0, ());
+  }
+}
+}  // namespace


### PR DESCRIPTION
Распределение треков до и после мачинга сильно различается. Данный PR реализует необходимую функциональность, чтоб уменьшив кол-во смачиних треков сохранить распределение, как до мачинга. Т.е. все изменения для реализации метода:

```c++
void BalanceDataPoints(std::basic_istream<char> & distributionCsvStream,
                       std::basic_istream<char> & tableCsvStream, uint32_t ignoreDataPointsNumber,
                       std::vector<TableRow> & balancedTable);
```
Далее его параметр `balancedTable` будет сохранен в csv и использован вместо csv, которая подается в `tableCsvStream`.

Основные изменения в коммитах "Track balancer implementation." и "Tests on track balancer.". Рекомендую смотреть, начиная с метода BalanceDataPoints(...). И далее в глубину.

@mesozoic-drones @gmoryes PTAL
