### PR TITLE
[omim] Regexp for includes order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,8 +21,344 @@ IndentCaseLabels: false
 NamespaceIndentation: None
 PointerAlignment: Middle
 SortIncludes: true
-IncludeBlocks: Preserve
 Standard: Cpp11
+IncludeBlocks: Regroup
+IncludeCategories:
+# Tests --------------------------------------------------------------------------------------------
+  - Regex:           '^"track_analyzing/track_analyzing_tests/'
+    Priority:        4740
+
+  - Regex:           '^"generator/generator_integration_tests/'
+    Priority:        4750
+  - Regex:           '^"generator/generator_tests/'
+    Priority:        4751
+  - Regex:           '^"generator/mwm_diff_tests/'
+    Priority:        4752
+
+  - Regex:           '^"map/style_tests/'
+    Priority:        4760
+  - Regex:           '^"map/mwm_tests/'
+    Priority:        4761
+  - Regex:           '^"map/map_tests/'
+    Priority:        4762
+  - Regex:           '^"map/map_integration_tests/'
+    Priority:        4763
+
+  - Regex:           '^"openlr/openlr_tests/'
+    Priority:        4770
+
+  - Regex:           '^"local_ads/local_ads_tests/'
+    Priority:        4780
+
+  - Regex:           '^"descriptions/descriptions_tests/'
+    Priority:        4790
+
+  - Regex:           '^"metrics/metrics_tests/'
+    Priority:        4800
+
+  - Regex:           '^"ugc/ugc_tests'
+    Priority:        4810
+
+  - Regex:           '^"search/search_integration_tests/'
+    Priority:        4820
+  - Regex:           '^"search/search_tests/'
+    Priority:        4821
+  - Regex:           '^"search/search_quality/search_quality_tests/'
+    Priority:        4822
+
+  - Regex:           '^"drape_frontend/drape_frontend_tests/'
+    Priority:        4830
+
+  - Regex:           '^"routing/routing_tests/'
+    Priority:        4840
+  - Regex:           '^"routing/routing_integration_tests/'
+    Priority:        4841
+  - Regex:           '^"routing/routing_quality/routing_quality_tests/'
+    Priority:        4842
+  - Regex:           '^"routing/routing_consistency_tests/'
+    Priority:        4843
+  - Regex:           '^"routing/routing_benchmarks/'
+    Priority:        4844
+
+  - Regex:           '^"kml/kml_tests'
+    Priority:        4850
+
+  - Regex:           '^"tracking/tracking_tests/'
+    Priority:        4860
+
+  - Regex:           '^"partners_api/partners_api_tests/'
+    Priority:        4870
+
+  - Regex:           '^"traffic/traffic_tests/'
+    Priority:        4880
+
+  - Regex:           '^"storage/storage_tests/'
+    Priority:        4890
+  - Regex:           '^"storage/storage_integration_tests/'
+    Priority:        4891
+
+  - Regex:           '^"editor/editor_tests/'
+    Priority:        4900
+  - Regex:           '^"editor/osm_auth_tests/'
+    Priority:        4910
+
+  - Regex:           '^"drape/drape_tests/'
+    Priority:        4920
+
+  - Regex:           '^"transit/transit_tests'
+    Priority:        4930
+
+  - Regex:           '^"routing_common/routing_common_tests/'
+    Priority:        4940
+
+  - Regex:           '^"indexer/indexer_tests/'
+    Priority:        4950
+
+  - Regex:           '^"platform/platform_tests/'
+    Priority:        4960
+
+  - Regex:           '^"coding/coding_tests/'
+    Priority:        4970
+
+  - Regex:           '^"geometry/geometry_tests/'
+    Priority:        4980
+
+  - Regex:           '^"base/base_tests/'
+    Priority:        4990
+
+  - Regex:           '^"testing/'
+    Priority:        5000
+
+# Binaries (tools) ---------------------------------------------------------------------------------
+
+  - Regex:           '^"openlr/openlr_match_quality/openlr_assessment_tool/'
+    Priority:        18908
+  - Regex:           '^"search/search_quality/assessment_tool/'
+    Priority:        18909
+  - Regex:           '^"qt/'
+    Priority:        18910
+
+  - Regex:           '^"track_analyzing/track_analyzer/'
+    Priority:        19000
+
+  - Regex:           '^"feature_list/'
+    Priority:        19100
+
+  - Regex:           '^"generator/booking_quality_check/'
+    Priority:        19206
+  - Regex:           '^"generator/complex_generator/'
+    Priority:        19207
+  - Regex:           '^"generator/feature_segments_checker/'
+    Priority:        19208
+  - Regex:           '^"generator/srtm_coverage_checker/'
+    Priority:        19209
+  - Regex:           '^"generator/generator_tool/'
+    Priority:        19210
+
+  - Regex:           '^"map/extrapolation_benchmark/'
+    Priority:        19309
+  - Regex:           '^"map/benchmark_tool/'
+    Priority:        19310
+
+  - Regex:           '^"openlr/openlr_stat/'
+    Priority:        19400
+
+  - Regex:           '^"mapshot/'
+    Priority:        19500
+
+  - Regex:           '^"search/search_quality/booking_dataset_generator/'
+    Priority:        19707
+  - Regex:           '^"search/search_quality/features_collector_tool/'
+    Priority:        19708
+  - Regex:           '^"search/search_quality/samples_generation_tool/'
+    Priority:        19709
+  - Regex:           '^"search/search_quality/search_quality_tool/'
+    Priority:        19710
+
+  - Regex:           '^"track_generator/'
+    Priority:        19800
+
+  - Regex:           '^"routing/routing_quality/routing_quality_tool/'
+    Priority:        19909
+  - Regex:           '^"routing/routes_builder/routes_builder_tool/'
+    Priority:        19910
+
+  - Regex:           '^"skin_generator/'
+    Priority:        20000
+
+# Libraries ----------------------------------------------------------------------------------------
+
+  - Regex:           '^"track_analyzing/'
+    Priority:        46800
+
+  - Regex:           '^"generator/mwm_diff/pymwm_diff/'
+    Priority:        46907
+  - Regex:           '^"generator/mwm_diff/'
+    Priority:        46908
+  - Regex:           '^"generator/generator_tests_support/'
+    Priority:        46909
+  - Regex:           '^"generator/'
+    Priority:        46910
+
+  - Regex:           '^"map/'
+    Priority:        47000
+
+  - Regex:           '^"openlr/'
+    Priority:        47100
+
+  - Regex:           '^"local_ads/pylocal_ads/'
+    Priority:        47209
+  - Regex:           '^"local_ads/'
+    Priority:        47210
+
+  - Regex:           '^"descriptions/'
+    Priority:        47300
+
+  - Regex:           '^"search/search_quality/'
+    Priority:        47407
+  - Regex:           '^"search/search_tests_support/'
+    Priority:        47408
+  - Regex:           '^"search/pysearch/'
+    Priority:        47409
+  - Regex:           '^"search/'
+    Priority:        47410
+
+  - Regex:           '^"ugc/'
+    Priority:        47500
+
+  - Regex:           '^"track_generator/pytrack_generator/'
+    Priority:        47600
+
+  - Regex:           '^"routing/routing_quality/api/'
+    Priority:        47707
+  - Regex:           '^"routing/routing_quality/'
+    Priority:        47708
+  - Regex:           '^"routing/routes_builder/'
+    Priority:        47709
+  - Regex:           '^"routing/'
+    Priority:        47710
+
+  - Regex:           '^"tracking/pytracking/'
+    Priority:        47809
+  - Regex:           '^"tracking/'
+    Priority:        47810
+
+  - Regex:           '^"partners_api/'
+    Priority:        47900
+
+  - Regex:           '^"metrics/metrics_tests_support/'
+    Priority:        48009
+  - Regex:           '^"metrics/'
+    Priority:        48010
+
+  - Regex:           '^"traffic/pytraffic/'
+    Priority:        48109
+  - Regex:           '^"traffic/'
+    Priority:        48110
+
+  - Regex:           '^"storage/'
+    Priority:        48200
+
+  - Regex:           '^"editor/editor_tests_support/'
+    Priority:        48309
+  - Regex:           '^"editor/'
+    Priority:        48310
+
+  - Regex:           '^"software_renderer/'
+    Priority:        48400
+
+  - Regex:           '^"drape_frontend/'
+    Priority:        48500
+
+  - Regex:           '^"shaders/'
+    Priority:        48600
+
+  - Regex:           '^"drape/'
+    Priority:        48700
+
+  - Regex:           '^"qt_tstfrm/'
+    Priority:        48800
+
+  - Regex:           '^"kml/pykmlib/'
+    Priority:        48909
+  - Regex:           '^"kml/'
+    Priority:        48910
+
+  - Regex:           '^"transit/'
+    Priority:        49000
+
+  - Regex:           '^"routing_common/'
+    Priority:        49100
+
+  - Regex:           '^"indexer/'
+    Priority:        49200
+
+  - Regex:           '^"web_api/'
+    Priority:        49300
+
+  - Regex:           '^"platform/platform_tests_support/'
+    Priority:        49409
+  - Regex:           '^"platform/'
+    Priority:        49410
+
+  - Regex:           '^"coding/'
+    Priority:        49500
+
+  - Regex:           '^"geometry/'
+    Priority:        49600
+  
+  - Regex:           '^"base/'
+    Priority:        49700
+
+  - Regex:           '^"pyhelpers/'
+    Priority:        49800
+
+  - Regex:           '^"com/mapswithme/util/'
+    Priority:        49840
+
+  - Regex:           '^"com/mapswithme/maps/'
+    Priority:        49850
+
+  - Regex:           '^"com/mapswithme/platform/'
+    Priority:        49860
+
+  - Regex:           '^"com/mapswithme/opengl/'
+    Priority:        49870
+
+  - Regex:           '^"com/mapswithme/vulkan/'
+    Priority:        49880
+
+  - Regex:           '^"com/mapswithme/core/'
+    Priority:        49890
+
+  - Regex:           '^"private\.h"$'
+    Priority:        49900
+
+  - Regex:           '^"std/'
+    Priority:        50000
+
+  - Regex:           '^"defines\.hpp"$'
+    Priority:        50100
+
+  - Regex:           '^<Qt.*>$'
+    Priority:        50140
+
+  - Regex:           '^<jni.h>$'
+    Priority:        50180
+
+  - Regex:           '^<.*>$'
+    Priority:        50200
+
+  - Regex:           '^"(3party/boost|boost)/'
+    Priority:        50300
+  - Regex:           '^<boost'
+    Priority:        50300
+
+  - Regex:           '^"3party/.*'
+    Priority:        50400
+
+  - Regex:           '^"build_version\.hpp"$'
+    Priority:        99999
 
 ---
 Language: Java


### PR DESCRIPTION
Предлагается настроить сортировку include через clang-format. Он по регулярным выражениям и приоритетам, сам умеет собирать в группы и расставлять их в правильном порядке. Приоритеты выставлял согласно текущим зависимостям (чем **больше** приоритет, тем **ниже** include). Все регулярные выражения в файле идут в порядке от меньшего приоритета, к большему.

Каждое регулярное выражение описывает тест/библиотеку/бинарь. При данной схеме
```cpp
#include "some_library.hpp"

#include "some_library/base/some_base.hpp"
```
превратится (потому что `some_library/base` не является библиотекой/тестом/бинарем) в: 
```cpp
#include "some_library.hpp"
#include "some_library/base/some_base.hpp"
```

Чтобы их разделить, нужно отдельно указать регулярное выражение для `some_library/base` и указать приоритет выше, чем у `some_library`.

Поскольку какие-то тесты (`base_tests` например) не зависят ни от чего, а какие-то (`routing_integration_tests` например) могут зависеть даже от `map`, то предлагается все тесты просто всегда выносить вверх, с логикой, что "тесты" могут потенциально зависеть от чего угодно и не хочется каждый раз думать - куда их поставить.