### PR TITLE
[Geometry] Renamed TAltitude to Altitude.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1383,7 +1383,7 @@ Java_com_mapswithme_maps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv *
   ::Framework * fr = frm();
   ASSERT(fr, ());
 
-  geometry::TAltitudes altitudes;
+  geometry::Altitudes altitudes;
   vector<double> routePointDistanceM;
   if (!fr->GetRoutingManager().GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
   {

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -48,7 +48,7 @@ public:
   explicit SrtmGetter(std::string const & srtmDir) : m_srtmManager(srtmDir) {}
 
   // AltitudeGetter overrides:
-  geometry::TAltitude GetAltitude(m2::PointD const & p) override
+  geometry::Altitude GetAltitude(m2::PointD const & p) override
   {
     return m_srtmManager.GetHeight(mercator::ToLatLon(p));
   }
@@ -86,7 +86,7 @@ public:
     return m_altitudeAvailabilityBuilder;
   }
 
-  geometry::TAltitude GetMinAltitude() const { return m_minAltitude; }
+  geometry::Altitude GetMinAltitude() const { return m_minAltitude; }
 
   void operator()(FeatureType & f, uint32_t const & id)
   {
@@ -108,11 +108,11 @@ public:
     if (pointsCount == 0)
       return;
 
-    geometry::TAltitudes altitudes;
-    geometry::TAltitude minFeatureAltitude = geometry::kInvalidAltitude;
+    geometry::Altitudes altitudes;
+    geometry::Altitude minFeatureAltitude = geometry::kInvalidAltitude;
     for (size_t i = 0; i < pointsCount; ++i)
     {
-      geometry::TAltitude const a = m_altitudeGetter.GetAltitude(f.GetPoint(i));
+      geometry::Altitude const a = m_altitudeGetter.GetAltitude(f.GetPoint(i));
       if (a == geometry::kInvalidAltitude)
       {
         // One invalid point invalidates the whole feature.
@@ -148,7 +148,7 @@ private:
   AltitudeGetter & m_altitudeGetter;
   TFeatureAltitudes m_featureAltitudes;
   succinct::bit_vector_builder m_altitudeAvailabilityBuilder;
-  geometry::TAltitude m_minAltitude;
+  geometry::Altitude m_minAltitude;
 };
 }  // namespace
 

--- a/generator/altitude_generator.hpp
+++ b/generator/altitude_generator.hpp
@@ -12,7 +12,7 @@ namespace routing
 class AltitudeGetter
 {
 public:
-  virtual geometry::TAltitude GetAltitude(m2::PointD const & p) = 0;
+  virtual geometry::Altitude GetAltitude(m2::PointD const & p) = 0;
 };
 
 /// \brief Adds altitude section to mwm. It has the following format:

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -120,7 +120,7 @@ public:
   set<RoughPoint> m_uniqueRoadPoints;
   /// Key is an altitude difference for a feature in meters. If a feature goes up the key is greater then 0.
   /// Value is a number of features.
-  map<geometry::TAltitude, uint32_t> m_altitudeDiffs;
+  map<geometry::Altitude, uint32_t> m_altitudeDiffs;
   /// Key is a length of a feature in meters. Value is a number of features.
   map<uint32_t, uint32_t> m_featureLength;
   /// Key is a length of a feature segment in meters. Value is a segment counter.
@@ -140,11 +140,11 @@ public:
   /// Key is number of meters. It shows altitude deviation of intermediate feature points
   /// from linear model.
   /// Value is a number of features.
-  map<geometry::TAltitude, uint32_t> m_diffFromLinear;
+  map<geometry::Altitude, uint32_t> m_diffFromLinear;
   /// Key is number of meters. It shows altitude deviation of intermediate feature points
   /// from line calculated base on least squares method for all feature points.
   /// Value is a number of features.
-  map<geometry::TAltitude, uint32_t> m_leastSquaresDiff;
+  map<geometry::Altitude, uint32_t> m_leastSquaresDiff;
   /// Number of features for GetBicycleModel().IsRoad(feature) == true.
   uint32_t m_roadCount;
   /// Number of features for empty features with GetBicycleModel().IsRoad(feature).
@@ -153,8 +153,8 @@ public:
   uint32_t m_roadPointCount;
   /// Number of features for GetBicycleModel().IsRoad(feature) != true.
   uint32_t m_notRoadCount;
-  geometry::TAltitude m_minAltitude = geometry::kInvalidAltitude;
-  geometry::TAltitude m_maxAltitude = geometry::kInvalidAltitude;
+  geometry::Altitude m_minAltitude = geometry::kInvalidAltitude;
+  geometry::Altitude m_maxAltitude = geometry::kInvalidAltitude;
 
   explicit Processor(generator::SrtmTileManager & manager)
     : m_srtmManager(manager)
@@ -190,13 +190,13 @@ public:
       m_uniqueRoadPoints.insert(RoughPoint(f.GetPoint(i)));
 
     // Preparing feature altitude and length.
-    geometry::TAltitudes pointAltitudes(numPoints);
+    geometry::Altitudes pointAltitudes(numPoints);
     vector<double> pointDists(numPoints);
     double distFromStartMeters = 0;
     for (uint32_t i = 0; i < numPoints; ++i)
     {
       // Feature segment altitude.
-      geometry::TAltitude altitude = m_srtmManager.GetHeight(mercator::ToLatLon(f.GetPoint(i)));
+      geometry::Altitude altitude = m_srtmManager.GetHeight(mercator::ToLatLon(f.GetPoint(i)));
       pointAltitudes[i] = altitude == geometry::kInvalidAltitude ? 0 : altitude;
       if (i == 0)
       {
@@ -233,8 +233,8 @@ public:
     m_featureLength[static_cast<uint32_t>(realFeatureLengthMeters)]++;
 
     // Feature altitude difference.
-    geometry::TAltitude const startAltitude = pointAltitudes[0];
-    geometry::TAltitude const endAltitude = pointAltitudes[numPoints - 1];
+    geometry::Altitude const startAltitude = pointAltitudes[0];
+    geometry::Altitude const endAltitude = pointAltitudes[numPoints - 1];
     int16_t const altitudeDiff = endAltitude - startAltitude;
     m_altitudeDiffs[altitudeDiff]++;
 
@@ -280,7 +280,7 @@ public:
     for (uint32_t i = 1; i + 1 < numPoints; ++i)
     {
       int32_t const deviation =
-          static_cast<geometry::TAltitude>(GetY(k, startAltitude, pointDists[i])) -
+          static_cast<geometry::Altitude>(GetY(k, startAltitude, pointDists[i])) -
           pointAltitudes[i];
       m_diffFromLinear[deviation]++;
     }
@@ -295,15 +295,15 @@ public:
 
       for (uint32_t i = 0; i < numPoints; ++i)
       {
-        geometry::TAltitude const deviation =
-            static_cast<geometry::TAltitude>(GetY(k, b, pointDists[i])) - pointAltitudes[i];
+        geometry::Altitude const deviation =
+            static_cast<geometry::Altitude>(GetY(k, b, pointDists[i])) - pointAltitudes[i];
         m_leastSquaresDiff[deviation]++;
       }
     }
   }
 };
 
-double CalculateEntropy(map<geometry::TAltitude, uint32_t> const & diffFromLinear)
+double CalculateEntropy(map<geometry::Altitude, uint32_t> const & diffFromLinear)
 {
   uint32_t innerPointCount = 0;
   for (auto const & f : diffFromLinear)

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -56,10 +56,10 @@ std::string const kTestMwm = "test";
 
 struct Point3D
 {
-  Point3D(int32_t x, int32_t y, geometry::TAltitude a) : m_point(x, y), m_altitude(a) {}
+  Point3D(int32_t x, int32_t y, geometry::Altitude a) : m_point(x, y), m_altitude(a) {}
 
   m2::PointI m_point;
-  geometry::TAltitude m_altitude;
+  geometry::Altitude m_altitude;
 };
 
 using TPoint3DList = std::vector<Point3D>;
@@ -72,7 +72,7 @@ TPoint3DList const kRoad4 = {{-10, 1, -1}, {-20, 6, -100}, {-20, -11, -110}};
 class MockAltitudeGetter : public AltitudeGetter
 {
 public:
-  using TMockAltitudes = std::map<m2::PointI, geometry::TAltitude>;
+  using TMockAltitudes = std::map<m2::PointI, geometry::Altitude>;
 
   explicit MockAltitudeGetter(std::vector<TPoint3DList> const & roads)
   {
@@ -93,7 +93,7 @@ public:
   }
 
   // AltitudeGetter overrides:
-  geometry::TAltitude GetAltitude(m2::PointD const & p) override
+  geometry::Altitude GetAltitude(m2::PointD const & p) override
   {
     m2::PointI const rounded(static_cast<int32_t>(round(p.x)), static_cast<int32_t>(round(p.y)));
     auto const it = m_altitudes.find(rounded);
@@ -111,10 +111,7 @@ private:
 class MockNoAltitudeGetter : public AltitudeGetter
 {
 public:
-  geometry::TAltitude GetAltitude(m2::PointD const &) override
-  {
-    return geometry::kInvalidAltitude;
-  }
+  geometry::Altitude GetAltitude(m2::PointD const &) override { return geometry::kInvalidAltitude; }
 };
 
 std::vector<m2::PointD> ExtractPoints(TPoint3DList const & geom3D)
@@ -143,7 +140,7 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
   auto processor = [&expectedAltitudes, &loader](FeatureType & f, uint32_t const & id) {
     f.ParseGeometry(FeatureType::BEST_GEOMETRY);
     size_t const pointsCount = f.GetPointsCount();
-    geometry::TAltitudes const altitudes = loader.GetAltitudes(id, pointsCount);
+    geometry::Altitudes const altitudes = loader.GetAltitudes(id, pointsCount);
 
     if (!routing::IsRoad(feature::TypesHolder(f)))
     {
@@ -155,8 +152,8 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
 
     for (size_t i = 0; i < pointsCount; ++i)
     {
-      geometry::TAltitude const fromGetter = expectedAltitudes.GetAltitude(f.GetPoint(i));
-      geometry::TAltitude const expected =
+      geometry::Altitude const fromGetter = expectedAltitudes.GetAltitude(f.GetPoint(i));
+      geometry::Altitude const expected =
           (fromGetter == geometry::kInvalidAltitude ? geometry::kDefaultAltitudeMeters
                                                     : fromGetter);
       TEST_EQUAL(expected, altitudes[i], ("A wrong altitude"));

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -84,7 +84,7 @@ void SrtmTile::Init(std::string const & dir, ms::LatLon const & coord)
   m_valid = true;
 }
 
-geometry::TAltitude SrtmTile::GetHeight(ms::LatLon const & coord)
+geometry::Altitude SrtmTile::GetHeight(ms::LatLon const & coord)
 {
   if (!IsValid())
     return geometry::kInvalidAltitude;
@@ -145,7 +145,7 @@ void SrtmTile::Invalidate()
 
 // SrtmTileManager ---------------------------------------------------------------------------------
 SrtmTileManager::SrtmTileManager(std::string const & dir) : m_dir(dir) {}
-geometry::TAltitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
+geometry::Altitude SrtmTileManager::GetHeight(ms::LatLon const & coord)
 {
   std::string const base = SrtmTile::GetBase(coord);
   auto it = m_tiles.find(base);

--- a/generator/srtm_parser.hpp
+++ b/generator/srtm_parser.hpp
@@ -24,17 +24,17 @@ public:
 
   inline bool IsValid() const { return m_valid; }
   // Returns height in meters at |coord| or kInvalidAltitude.
-  geometry::TAltitude GetHeight(ms::LatLon const & coord);
+  geometry::Altitude GetHeight(ms::LatLon const & coord);
 
   static std::string GetBase(ms::LatLon coord);
 
 private:
-  inline geometry::TAltitude const * Data() const
+  inline geometry::Altitude const * Data() const
   {
-    return reinterpret_cast<geometry::TAltitude const *>(m_data.data());
+    return reinterpret_cast<geometry::Altitude const *>(m_data.data());
   };
 
-  inline size_t Size() const { return m_data.size() / sizeof(geometry::TAltitude); }
+  inline size_t Size() const { return m_data.size() / sizeof(geometry::Altitude); }
   void Invalidate();
 
   std::string m_data;
@@ -48,7 +48,7 @@ class SrtmTileManager
 public:
   SrtmTileManager(std::string const & dir);
 
-  geometry::TAltitude GetHeight(ms::LatLon const & coord);
+  geometry::Altitude GetHeight(ms::LatLon const & coord);
 
 private:
   std::string m_dir;

--- a/geometry/point_with_altitude.cpp
+++ b/geometry/point_with_altitude.cpp
@@ -9,7 +9,7 @@ PointWithAltitude::PointWithAltitude()
 {
 }
 
-PointWithAltitude::PointWithAltitude(m2::PointD const & point, TAltitude altitude)
+PointWithAltitude::PointWithAltitude(m2::PointD const & point, Altitude altitude)
   : m_point(point), m_altitude(altitude)
 {
 }

--- a/geometry/point_with_altitude.hpp
+++ b/geometry/point_with_altitude.hpp
@@ -9,11 +9,11 @@
 
 namespace geometry
 {
-using TAltitude = int16_t;
-using TAltitudes = std::vector<TAltitude>;
+using Altitude = int16_t;
+using Altitudes = std::vector<Altitude>;
 
-TAltitude constexpr kInvalidAltitude = std::numeric_limits<TAltitude>::min();
-TAltitude constexpr kDefaultAltitudeMeters = 0;
+Altitude constexpr kInvalidAltitude = std::numeric_limits<Altitude>::min();
+Altitude constexpr kDefaultAltitudeMeters = 0;
 
 double constexpr kPointsEqualEpsilon = 1e-6;
 
@@ -21,7 +21,7 @@ class PointWithAltitude
 {
 public:
   PointWithAltitude();
-  PointWithAltitude(m2::PointD const & point, TAltitude altitude);
+  PointWithAltitude(m2::PointD const & point, Altitude altitude);
   PointWithAltitude(PointWithAltitude const &) = default;
   PointWithAltitude & operator=(PointWithAltitude const &) = default;
 
@@ -30,13 +30,13 @@ public:
   bool operator<(PointWithAltitude const & r) const { return m_point < r.m_point; }
 
   m2::PointD const & GetPoint() const { return m_point; }
-  TAltitude GetAltitude() const { return m_altitude; }
+  Altitude GetAltitude() const { return m_altitude; }
 
 private:
   friend std::string DebugPrint(PointWithAltitude const & r);
 
   m2::PointD m_point;
-  TAltitude m_altitude;
+  Altitude m_altitude;
 };
 
 std::string DebugPrint(PointWithAltitude const & r);

--- a/indexer/altitude_loader.cpp
+++ b/indexer/altitude_loader.cpp
@@ -71,14 +71,14 @@ bool AltitudeLoader::HasAltitudes() const
   return m_reader != nullptr && m_header.m_minAltitude != geometry::kInvalidAltitude;
 }
 
-geometry::TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t pointCount)
+geometry::Altitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, size_t pointCount)
 {
   if (!HasAltitudes())
   {
     // The version of mwm is less than version::Format::v8 or there's no altitude section in mwm.
     return m_cache
-        .insert(make_pair(featureId,
-                          geometry::TAltitudes(pointCount, geometry::kDefaultAltitudeMeters)))
+        .insert(
+            make_pair(featureId, geometry::Altitudes(pointCount, geometry::kDefaultAltitudeMeters)))
         .first->second;
   }
 
@@ -89,7 +89,7 @@ geometry::TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, si
   if (!m_altitudeAvailability[featureId])
   {
     return m_cache
-        .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
+        .insert(make_pair(featureId, geometry::Altitudes(pointCount, m_header.m_minAltitude)))
         .first->second;
   }
 
@@ -112,13 +112,13 @@ geometry::TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, si
     bool const allValid =
         isDeserialized &&
         none_of(altitudes.m_altitudes.begin(), altitudes.m_altitudes.end(),
-                [](geometry::TAltitude a) { return a == geometry::kInvalidAltitude; });
+                [](geometry::Altitude a) { return a == geometry::kInvalidAltitude; });
     if (!allValid)
     {
       LOG(LERROR, ("Only a part point of a feature has a valid altitdue. Altitudes: ", altitudes.m_altitudes,
                    ". Feature Id", featureId, "of", m_countryFileName));
       return m_cache
-          .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
+          .insert(make_pair(featureId, geometry::Altitudes(pointCount, m_header.m_minAltitude)))
           .first->second;
     }
 
@@ -128,7 +128,7 @@ geometry::TAltitudes const & AltitudeLoader::GetAltitudes(uint32_t featureId, si
   {
     LOG(LERROR, ("Feature Id", featureId, "of", m_countryFileName, ". Error while getting altitude data:", e.Msg()));
     return m_cache
-        .insert(make_pair(featureId, geometry::TAltitudes(pointCount, m_header.m_minAltitude)))
+        .insert(make_pair(featureId, geometry::Altitudes(pointCount, m_header.m_minAltitude)))
         .first->second;
   }
 }

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -29,7 +29,7 @@ public:
 
   /// \returns altitude of feature with |featureId|. All items of the returned vector are valid
   /// or the returned vector is empty.
-  geometry::TAltitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
+  geometry::Altitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
 
   bool HasAltitudes() const;
 
@@ -43,7 +43,7 @@ private:
   succinct::elias_fano m_featureTable;
 
   std::unique_ptr<FilesContainerR::TReader> m_reader;
-  std::map<uint32_t, geometry::TAltitudes> m_cache;
+  std::map<uint32_t, geometry::Altitudes> m_cache;
   AltitudeHeader m_header;
   std::string m_countryFileName;
   MwmSet::MwmHandle m_handle;

--- a/indexer/feature_altitude.hpp
+++ b/indexer/feature_altitude.hpp
@@ -38,7 +38,7 @@ struct AltitudeHeader
   void Deserialize(TSource & src)
   {
     m_version = ReadPrimitiveFromSource<TAltitudeSectionVersion>(src);
-    m_minAltitude = ReadPrimitiveFromSource<geometry::TAltitude>(src);
+    m_minAltitude = ReadPrimitiveFromSource<geometry::Altitude>(src);
     m_featureTableOffset = ReadPrimitiveFromSource<uint32_t>(src);
     m_altitudesOffset = ReadPrimitiveFromSource<uint32_t>(src);
     m_endOffset = ReadPrimitiveFromSource<uint32_t>(src);
@@ -64,7 +64,7 @@ struct AltitudeHeader
   }
 
   TAltitudeSectionVersion m_version;
-  geometry::TAltitude m_minAltitude;
+  geometry::Altitude m_minAltitude;
   uint32_t m_featureTableOffset;
   uint32_t m_altitudesOffset;
   uint32_t m_endOffset;
@@ -77,15 +77,15 @@ class Altitudes
 public:
   Altitudes() = default;
 
-  explicit Altitudes(geometry::TAltitudes const & altitudes) : m_altitudes(altitudes) {}
+  explicit Altitudes(geometry::Altitudes const & altitudes) : m_altitudes(altitudes) {}
 
   template <class TSink>
-  void Serialize(geometry::TAltitude minAltitude, TSink & sink) const
+  void Serialize(geometry::Altitude minAltitude, TSink & sink) const
   {
     CHECK(!m_altitudes.empty(), ());
 
     BitWriter<TSink> bits(sink);
-    geometry::TAltitude prevAltitude = minAltitude;
+    geometry::Altitude prevAltitude = minAltitude;
     for (auto const altitude : m_altitudes)
     {
       CHECK_LESS_OR_EQUAL(minAltitude, altitude, ("A point altitude is less than min mwm altitude"));
@@ -97,13 +97,13 @@ public:
   }
 
   template <class TSource>
-  bool Deserialize(geometry::TAltitude minAltitude, size_t pointCount,
+  bool Deserialize(geometry::Altitude minAltitude, size_t pointCount,
                    std::string const & countryFileName, uint32_t featureId, TSource & src)
   {
     ASSERT_NOT_EQUAL(pointCount, 0, ());
 
     BitReader<TSource> bits(src);
-    geometry::TAltitude prevAltitude = minAltitude;
+    geometry::Altitude prevAltitude = minAltitude;
     m_altitudes.resize(pointCount);
 
     for (size_t i = 0; i < pointCount; ++i)
@@ -118,7 +118,7 @@ public:
       }
       uint64_t const delta = biasedDelta - 1;
 
-      m_altitudes[i] = static_cast<geometry::TAltitude>(bits::ZigZagDecode(delta) + prevAltitude);
+      m_altitudes[i] = static_cast<geometry::Altitude>(bits::ZigZagDecode(delta) + prevAltitude);
       if (m_altitudes[i] < minAltitude)
       {
         LOG(LERROR, ("A point altitude read from file(", m_altitudes[i],
@@ -136,6 +136,6 @@ public:
   /// * |m_altitudes| is empty. It means there is no altitude information for this feature.
   /// * size of |m_pointAlt| is equal to the number of this feature's points. If so
   ///   all items of |m_altitudes| have valid value.
-  geometry::TAltitudes m_altitudes;
+  geometry::Altitudes m_altitudes;
 };
 }  // namespace feature

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -547,7 +547,7 @@ void logPointEvent(MWMRoutePoint * point, NSString * eventType)
     return;
 
   auto routePointDistanceM = std::make_shared<std::vector<double>>(std::vector<double>());
-  auto altitudes = std::make_shared<geometry::TAltitudes>(geometry::TAltitudes());
+  auto altitudes = std::make_shared<geometry::Altitudes>(geometry::Altitudes());
   if (!GetFramework().GetRoutingManager().GetRouteAltitudesAndDistancesM(*routePointDistanceM, *altitudes))
     return;
 

--- a/map/chart_generator.cpp
+++ b/map/chart_generator.cpp
@@ -107,7 +107,7 @@ void ReflectChartData(vector<double> & chartData)
 }
 
 bool NormalizeChartData(vector<double> const & distanceDataM,
-                        geometry::TAltitudes const & altitudeDataM, size_t resultPointCount,
+                        geometry::Altitudes const & altitudeDataM, size_t resultPointCount,
                         vector<double> & uniformAltitudeDataM)
 {
   double constexpr kEpsilon = 1e-6;
@@ -272,7 +272,7 @@ bool GenerateChartByPoints(uint32_t width, uint32_t height, vector<m2::PointD> c
 }
 
 bool GenerateChart(uint32_t width, uint32_t height, vector<double> const & distanceDataM,
-                   geometry::TAltitudes const & altitudeDataM, MapStyle mapStyle,
+                   geometry::Altitudes const & altitudeDataM, MapStyle mapStyle,
                    vector<uint8_t> & frameBuffer)
 {
   if (distanceDataM.size() != altitudeDataM.size())

--- a/map/chart_generator.hpp
+++ b/map/chart_generator.hpp
@@ -22,7 +22,7 @@ void ReflectChartData(std::vector<double> & chartData);
 /// |resultPointCount| points. |distanceDataM| and |altitudeDataM| form a curve of route altitude.
 /// This method is used to generalize and evenly distribute points of the chart.
 bool NormalizeChartData(std::vector<double> const & distanceDataM,
-                        geometry::TAltitudes const & altitudeDataM, size_t resultPointCount,
+                        geometry::Altitudes const & altitudeDataM, size_t resultPointCount,
                         std::vector<double> & uniformAltitudeDataM);
 
 /// \brief fills |yAxisDataPxl|. |yAxisDataPxl| is formed to pevent displaying
@@ -48,6 +48,6 @@ bool GenerateChartByPoints(uint32_t width, uint32_t height,
                            std::vector<uint8_t> & frameBuffer);
 
 bool GenerateChart(uint32_t width, uint32_t height, std::vector<double> const & distanceDataM,
-                   geometry::TAltitudes const & altitudeDataM, MapStyle mapStyle,
+                   geometry::Altitudes const & altitudeDataM, MapStyle mapStyle,
                    std::vector<uint8_t> & frameBuffer);
 }  // namespace maps

--- a/map/map_tests/chart_generator_tests.cpp
+++ b/map/map_tests/chart_generator_tests.cpp
@@ -78,7 +78,7 @@ UNIT_TEST(ReflectChartData_Test)
 UNIT_TEST(NormalizeChartData_SmokeTest)
 {
   vector<double> const distanceDataM = {0.0, 0.0, 0.0};
-  geometry::TAltitudes const altitudeDataM = {0, 0, 0};
+  geometry::Altitudes const altitudeDataM = {0, 0, 0};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 2 /* resultPointCount */, uniformAltitudeDataM),
@@ -91,7 +91,7 @@ UNIT_TEST(NormalizeChartData_SmokeTest)
 UNIT_TEST(NormalizeChartData_NoResultPointTest)
 {
   vector<double> const distanceDataM = {0.0, 0.0, 0.0};
-  geometry::TAltitudes const altitudeDataM = {0, 0, 0};
+  geometry::Altitudes const altitudeDataM = {0, 0, 0};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 0 /* resultPointCount */, uniformAltitudeDataM),
@@ -103,7 +103,7 @@ UNIT_TEST(NormalizeChartData_NoResultPointTest)
 UNIT_TEST(NormalizeChartData_NoPointTest)
 {
   vector<double> const distanceDataM = {};
-  geometry::TAltitudes const altitudeDataM = {};
+  geometry::Altitudes const altitudeDataM = {};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 2 /* resultPointCount */, uniformAltitudeDataM),
@@ -115,7 +115,7 @@ UNIT_TEST(NormalizeChartData_NoPointTest)
 UNIT_TEST(NormalizeChartData_Test)
 {
   vector<double> const distanceDataM = {0.0, 2.0, 4.0, 6.0};
-  geometry::TAltitudes const altitudeDataM = {-9, 0, 9, 18};
+  geometry::Altitudes const altitudeDataM = {-9, 0, 9, 18};
 
   vector<double> uniformAltitudeDataM;
   TEST(maps::NormalizeChartData(distanceDataM, altitudeDataM, 10 /* resultPointCount */, uniformAltitudeDataM),
@@ -202,7 +202,7 @@ UNIT_TEST(GenerateChart_NoPointsTest)
 {
   size_t constexpr width = 50;
   vector<double> const distanceDataM = {};
-  geometry::TAltitudes const & altitudeDataM = {};
+  geometry::Altitudes const & altitudeDataM = {};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -217,7 +217,7 @@ UNIT_TEST(GenerateChart_OnePointTest)
   size_t constexpr width = 50;
   size_t constexpr height = 50;
   vector<double> const distanceDataM = {0.0};
-  geometry::TAltitudes const & altitudeDataM = {0};
+  geometry::Altitudes const & altitudeDataM = {0};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, height, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -234,7 +234,7 @@ UNIT_TEST(GenerateChart_EmptyRectTest)
 {
   size_t constexpr width = 0;
   vector<double> const distanceDataM = {};
-  geometry::TAltitudes const & altitudeDataM = {};
+  geometry::Altitudes const & altitudeDataM = {};
   vector<uint8_t> frameBuffer;
 
   TEST(!maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,
@@ -247,7 +247,7 @@ UNIT_TEST(GenerateChart_Test)
 {
   size_t constexpr width = 50;
   vector<double> const distanceDataM = {0.0, 100.0};
-  geometry::TAltitudes const & altitudeDataM = {0, 1000};
+  geometry::Altitudes const & altitudeDataM = {0, 1000};
   vector<uint8_t> frameBuffer;
 
   TEST(maps::GenerateChart(width, 50 /* height */, distanceDataM, altitudeDataM, MapStyleDark /* mapStyle */,

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1198,7 +1198,7 @@ bool RoutingManager::HasRouteAltitude() const
 }
 
 bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & routePointDistanceM,
-                                                    geometry::TAltitudes & altitudes) const
+                                                    geometry::Altitudes & altitudes) const
 {
   if (!m_routingSession.GetRouteAltitudesAndDistancesM(routePointDistanceM, altitudes))
     return false;
@@ -1208,7 +1208,7 @@ bool RoutingManager::GetRouteAltitudesAndDistancesM(vector<double> & routePointD
 }
 
 bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
-                                                geometry::TAltitudes const & altitudes,
+                                                geometry::Altitudes const & altitudes,
                                                 vector<double> const & routePointDistanceM,
                                                 vector<uint8_t> & imageRGBAData,
                                                 int32_t & minRouteAltitude,
@@ -1224,8 +1224,8 @@ bool RoutingManager::GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
     return false;
 
   auto const minMaxIt = minmax_element(altitudes.cbegin(), altitudes.cend());
-  geometry::TAltitude const minRouteAltitudeM = *minMaxIt.first;
-  geometry::TAltitude const maxRouteAltitudeM = *minMaxIt.second;
+  geometry::Altitude const minRouteAltitudeM = *minMaxIt.first;
+  geometry::Altitude const maxRouteAltitudeM = *minMaxIt.second;
 
   if (!settings::Get(settings::kMeasurementUnits, altitudeUnits))
     altitudeUnits = measurement_utils::Units::Metric;

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -264,7 +264,7 @@ public:
   /// \brief Fills altitude of current route points and distance in meters form the beginning
   /// of the route point based on the route in RoutingSession.
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routePointDistanceM,
-                                      geometry::TAltitudes & altitudes) const;
+                                      geometry::Altitudes & altitudes) const;
 
   /// \brief Generates 4 bytes per point image (RGBA) and put the data to |imageRGBAData|.
   /// \param width is width of chart shall be generated in pixels.
@@ -281,7 +281,7 @@ public:
   /// \note If HasRouteAltitude() method returns true, GenerateRouteAltitudeChart(...)
   /// could return false if route was deleted or rebuilt between the calls.
   bool GenerateRouteAltitudeChart(uint32_t width, uint32_t height,
-                                  geometry::TAltitudes const & altitudes,
+                                  geometry::Altitudes const & altitudes,
                                   std::vector<double> const & routePointDistanceM,
                                   std::vector<uint8_t> & imageRGBAData, int32_t & minRouteAltitude,
                                   int32_t & maxRouteAltitude,

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -22,7 +22,7 @@ using namespace traffic;
 
 namespace
 {
-geometry::TAltitude constexpr kMountainSicknessAltitudeM = 2500;
+geometry::Altitude constexpr kMountainSicknessAltitudeM = 2500;
 
 double TimeBetweenSec(m2::PointD const & from, m2::PointD const & to, double speedMpS)
 {
@@ -47,7 +47,7 @@ double CalcTrafficFactor(SpeedGroup speedGroup)
   return 1.0 / percentage;
 }
 
-double GetPedestrianClimbPenalty(double tangent, geometry::TAltitude altitudeM)
+double GetPedestrianClimbPenalty(double tangent, geometry::Altitude altitudeM)
 {
   if (tangent <= 0) // Descent
     return 1.0 + 2.0 * (-tangent);
@@ -61,7 +61,7 @@ double GetPedestrianClimbPenalty(double tangent, geometry::TAltitude altitudeM)
   return 1.0 + (10.0 + max(0, altitudeM - kMountainSicknessAltitudeM) * 10.0 / 1500) * tangent;
 }
 
-double GetBicycleClimbPenalty(double tangent, geometry::TAltitude altitudeM)
+double GetBicycleClimbPenalty(double tangent, geometry::Altitude altitudeM)
 {
   if (tangent <= 0) // Descent
     return 1.0;
@@ -73,7 +73,7 @@ double GetBicycleClimbPenalty(double tangent, geometry::TAltitude altitudeM)
   return 1.0 + 50.0 * tangent;
 }
 
-double GetCarClimbPenalty(double /* tangent */, geometry::TAltitude /* altitude */) { return 1.0; }
+double GetCarClimbPenalty(double /* tangent */, geometry::Altitude /* altitude */) { return 1.0; }
 
 template <typename GetClimbPenalty>
 double CalcClimbSegment(EdgeEstimator::Purpose purpose, Segment const & segment,

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -59,7 +59,7 @@ FakeEnding MakeFakeEnding(vector<Segment> const & segments, m2::PointD const & p
   }
 
   ending.m_originJunction =
-      geometry::PointWithAltitude(point, static_cast<geometry::TAltitude>(averageAltitude));
+      geometry::PointWithAltitude(point, static_cast<geometry::Altitude>(averageAltitude));
   return ending;
 }
 

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -304,7 +304,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
   size_t const pointsCount = ft.GetPointsCount();
 
-  geometry::TAltitudes altitudes;
+  geometry::Altitudes altitudes;
   if (value.m_altitudeLoader)
   {
     altitudes = value.m_altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount());
@@ -312,7 +312,7 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   else
   {
     ASSERT(false, ());
-    altitudes = geometry::TAltitudes(ft.GetPointsCount(), geometry::kDefaultAltitudeMeters);
+    altitudes = geometry::Altitudes(ft.GetPointsCount(), geometry::kDefaultAltitudeMeters);
   }
 
   CHECK_EQUAL(altitudes.size(), pointsCount,

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -100,7 +100,7 @@ void GeometryLoaderImpl::Load(uint32_t featureId, RoadGeometry & road)
 
   feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
 
-  geometry::TAltitudes const * altitudes = nullptr;
+  geometry::Altitudes const * altitudes = nullptr;
   if (m_loadAltitudes)
     altitudes = &(m_altitudeLoader.GetAltitudes(featureId, feature->GetPointsCount()));
 
@@ -180,7 +180,7 @@ RoadGeometry::RoadGeometry(bool oneWay, double weightSpeedKMpH, double etaSpeedK
 }
 
 void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType & feature,
-                        geometry::TAltitudes const * altitudes, bool inCity,
+                        geometry::Altitudes const * altitudes, bool inCity,
                         Maxspeed const & maxspeed)
 {
   CHECK(altitudes == nullptr || altitudes->size() == feature.GetPointsCount(), ());

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -36,7 +36,7 @@ public:
   RoadGeometry(bool oneWay, double weightSpeedKMpH, double etaSpeedKMpH, Points const & points);
 
   void Load(VehicleModelInterface const & vehicleModel, FeatureType & feature,
-            geometry::TAltitudes const * altitudes, bool inCity, Maxspeed const & maxspeed);
+            geometry::Altitudes const * altitudes, bool inCity, Maxspeed const & maxspeed);
 
   bool IsOneWay() const { return m_isOneWay; }
   SpeedKMpH const & GetSpeed(bool forward) const;

--- a/routing/nearest_edge_finder.cpp
+++ b/routing/nearest_edge_finder.cpp
@@ -47,14 +47,14 @@ void NearestEdgeFinder::AddInformationSource(IRoadGraph::FullRoadInfo const & ro
   size_t const idx = res.m_segId + 1;
   geometry::PointWithAltitude const & segStart = junctions[idx - 1];
   geometry::PointWithAltitude const & segEnd = junctions[idx];
-  geometry::TAltitude const startAlt = segStart.GetAltitude();
-  geometry::TAltitude const endAlt = segEnd.GetAltitude();
+  geometry::Altitude const startAlt = segStart.GetAltitude();
+  geometry::Altitude const endAlt = segEnd.GetAltitude();
   m2::ParametrizedSegment<m2::PointD> segment(junctions[idx - 1].GetPoint(),
                                               junctions[idx].GetPoint());
   m2::PointD const closestPoint = segment.ClosestPointTo(m_point);
 
   double const segLenM = mercator::DistanceOnEarth(segStart.GetPoint(), segEnd.GetPoint());
-  geometry::TAltitude projPointAlt = geometry::kDefaultAltitudeMeters;
+  geometry::Altitude projPointAlt = geometry::kDefaultAltitudeMeters;
   if (segLenM == 0.0)
   {
     projPointAlt = startAlt;
@@ -64,7 +64,7 @@ void NearestEdgeFinder::AddInformationSource(IRoadGraph::FullRoadInfo const & ro
     double const distFromStartM = mercator::DistanceOnEarth(segStart.GetPoint(), closestPoint);
     ASSERT_LESS_OR_EQUAL(distFromStartM, segLenM, (roadInfo.m_featureId));
     projPointAlt =
-        startAlt + static_cast<geometry::TAltitude>((endAlt - startAlt) * distFromStartM / segLenM);
+        startAlt + static_cast<geometry::Altitude>((endAlt - startAlt) * distFromStartM / segLenM);
   }
 
   res.m_fid = roadInfo.m_featureId;

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -373,7 +373,7 @@ inline void JunctionsToPoints(std::vector<geometry::PointWithAltitude> const & j
 }
 
 inline void JunctionsToAltitudes(std::vector<geometry::PointWithAltitude> const & junctions,
-                                 geometry::TAltitudes & altitudes)
+                                 geometry::Altitudes & altitudes)
 {
   altitudes.resize(junctions.size());
   for (size_t i = 0; i < junctions.size(); ++i)

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -345,7 +345,7 @@ void Route::SetSubrouteUid(size_t segmentIdx, SubrouteUid subrouteUid)
   m_subrouteUid = subrouteUid;
 }
 
-void Route::GetAltitudes(geometry::TAltitudes & altitudes) const
+void Route::GetAltitudes(geometry::Altitudes & altitudes) const
 {
   altitudes.clear();
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -379,7 +379,7 @@ public:
   /// after the route is removed.
   void SetSubrouteUid(size_t segmentIdx, SubrouteUid subrouteUid);
 
-  void GetAltitudes(geometry::TAltitudes & altitudes) const;
+  void GetAltitudes(geometry::Altitudes & altitudes) const;
   bool HaveAltitudes() const { return m_haveAltitudes; }
   traffic::SpeedGroup GetTraffic(size_t segmentIdx) const;
 

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -44,8 +44,8 @@ LocalCountryFile GetLocalCountryFileByCountryId(CountryFile const & country)
 }
 
 void TestAltitudeOfAllMwmFeatures(string const & countryId,
-                                  geometry::TAltitude const altitudeLowerBoundMeters,
-                                  geometry::TAltitude const altitudeUpperBoundMeters)
+                                  geometry::Altitude const altitudeLowerBoundMeters,
+                                  geometry::Altitude const altitudeUpperBoundMeters)
 {
   FrozenDataSource dataSource;
 
@@ -69,7 +69,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId,
     if (pointsCount == 0)
       return;
 
-    geometry::TAltitudes altitudes = altitudeLoader->GetAltitudes(id, pointsCount);
+    geometry::Altitudes altitudes = altitudeLoader->GetAltitudes(id, pointsCount);
     TEST(!altitudes.empty(),
          ("Empty altitude vector. MWM:", countryId, ", feature id:", id, ", altitudes:", altitudes));
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -718,7 +718,7 @@ bool RoutingSession::IsRouteValid() const
 }
 
 bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDistanceM,
-                                                    geometry::TAltitudes & routeAltitudesM) const
+                                                    geometry::Altitudes & routeAltitudesM) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(m_route, ());
@@ -727,7 +727,7 @@ bool RoutingSession::GetRouteAltitudesAndDistancesM(vector<double> & routeSegDis
     return false;
 
   routeSegDistanceM = m_route->GetSegDistanceMeters();
-  geometry::TAltitudes altitudes;
+  geometry::Altitudes altitudes;
   m_route->GetAltitudes(routeAltitudesM);
   return true;
 }

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -95,7 +95,7 @@ public:
   /// route altitude information to |routeSegDistanceM| and |routeAltitudes|.
   /// \returns true if there is valid route information. If the route is not valid returns false.
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
-                                      geometry::TAltitudes & routeAltitudesM) const;
+                                      geometry::Altitudes & routeAltitudesM) const;
 
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   void GetRouteFollowingInfo(FollowingInfo & info) const;


### PR DESCRIPTION
Refactoring of old-style naming of `TAltitude` (TAltitudes)  to `Altitude` (Altitudes).