### PR TITLE
[routing] Routing integration tests fixing.

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -63,7 +63,6 @@ public:
     m_map[c.GetTypeByPath({"highway", "cycleway"})] = ftypes::HighwayClass::Pedestrian;
     m_map[c.GetTypeByPath({"highway", "path"})] = ftypes::HighwayClass::Pedestrian;
     m_map[c.GetTypeByPath({"highway", "construction"})] = ftypes::HighwayClass::Pedestrian;
-
   }
 
   ftypes::HighwayClass Get(uint32_t t) const

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -62,6 +62,8 @@ public:
     m_map[c.GetTypeByPath({"highway", "steps"})] = ftypes::HighwayClass::Pedestrian;
     m_map[c.GetTypeByPath({"highway", "cycleway"})] = ftypes::HighwayClass::Pedestrian;
     m_map[c.GetTypeByPath({"highway", "path"})] = ftypes::HighwayClass::Pedestrian;
+    m_map[c.GetTypeByPath({"highway", "construction"})] = ftypes::HighwayClass::Pedestrian;
+
   }
 
   ftypes::HighwayClass Get(uint32_t t) const

--- a/routing/bicycle_directions.cpp
+++ b/routing/bicycle_directions.cpp
@@ -266,8 +266,12 @@ void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
       continue;
 
     auto const highwayClass = ftypes::GetHighwayClass(feature::TypesHolder(*ft));
-    ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Error, ());
-    ASSERT_NOT_EQUAL(highwayClass, ftypes::HighwayClass::Undefined, ());
+    ASSERT_NOT_EQUAL(
+        highwayClass, ftypes::HighwayClass::Error,
+        (mercator::ToLatLon(edge.GetStartPoint()), mercator::ToLatLon(edge.GetEndPoint())));
+    ASSERT_NOT_EQUAL(
+        highwayClass, ftypes::HighwayClass::Undefined,
+        (mercator::ToLatLon(edge.GetStartPoint()), mercator::ToLatLon(edge.GetEndPoint())));
 
     bool const isLink = ftypes::IsLinkChecker::Instance()(*ft);
 

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -376,12 +376,13 @@ UNIT_TEST(USANewYorkEmpireStateBuildingToUnitedNations)
       mercator::FromLatLon(40.75047, -73.96759), 2265.);
 }
 
+// Test on walking around a ford on an mwm border.
 UNIT_TEST(CrossMwmRussiaPStaiToBelarusDrazdy)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(55.014, 30.95552), {0., 0.},
-      mercator::FromLatLon(55.01437, 30.8858), 4834.5);
+      mercator::FromLatLon(55.01437, 30.8858), 12137.3);
 }
 
 UNIT_TEST(RussiaZgradPanfilovskyUndergroundCrossing)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -419,7 +419,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 6470.68);
+    integration::TestRouteTime(route, 6348.78);
   }
 
   // Test on removing speed cameras from the route for maps from Jan 2019,

--- a/routing/routing_integration_tests/transit_route_test.cpp
+++ b/routing/routing_integration_tests/transit_route_test.cpp
@@ -69,7 +69,7 @@ UNIT_TEST(Transit_Piter_TooLongPedestrian)
   TRouteResult routeResult =
       integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Transit),
                                   mercator::FromLatLon(59.90511, 30.31425), {0.0, 0.0},
-                                  mercator::FromLatLon(59.80677, 30.44749));
+                                  mercator::FromLatLon(59.78014, 30.50036));
 
   TEST_EQUAL(routeResult.second, RouterResultCode::TransitRouteNotFoundTooLongPedestrian, ());
 }
@@ -124,7 +124,7 @@ UNIT_TEST(Transit_London_DeptfordBridgeToCyprus)
 
   TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
 
-  integration::TestRouteLength(*routeResult.first, 12293.4);
+  integration::TestRouteLength(*routeResult.first, 12758.9);
 
   CHECK(routeResult.first, ());
   integration::CheckSubwayExistence(*routeResult.first);


### PR DESCRIPTION
**SwedenStockholmBicyclePastFerry**
Срабатывал ASSERT в debug режиме на тесте SwedenStockholmBicyclePastFerry. В релизе тест проходил. Причина была в том, что к маршруту примыкала фича highway-construction. Это возможный кейс. Такие "дороги" (фичи) сейчас поступают к генератору маневров. А он хочет получить у них HighwayClass. Добавил такие фичи в HighwayClass.
![image](https://user-images.githubusercontent.com/1768114/69877575-a8f13180-12d3-11ea-9c20-0f1c1f8ac49a.png)
![image](https://user-images.githubusercontent.com/1768114/69877711-fb325280-12d3-11ea-923f-4b75f66fbbd1.png)

**Transit_London_DeptfordBridgeToCyprus**
Незначительно изменилась длина маршрута.
Стало:
![image](https://user-images.githubusercontent.com/1768114/69877807-3e8cc100-12d4-11ea-8b5d-dd54cd0cc15a.png)

**Transit_Piter_TooLongPedestrian**
В карте 191019 станция Шушары была. 
![image](https://user-images.githubusercontent.com/1768114/69877910-77c53100-12d4-11ea-8769-65fbd7cde2ea.png)
Но у нее был сломан выход. 
![image](https://user-images.githubusercontent.com/1768114/69877927-81e72f80-12d4-11ea-9df0-b47b911e0d4b.png)

На 191124 вход починился и пешеходная часть маршрута стала не большой. Маршрут стал прокладываться.
![image](https://user-images.githubusercontent.com/1768114/69877970-9fb49480-12d4-11ea-81c4-2b5a6f47286b.png)

Чтоб тест отвечал своему названию, отдаляем точку финиша от станции метро Шушары еще сильнее. Теперь тест говорит, что пешеходная часть слишком длинная, как и должно быть.

**TolyattiFeatureThatCrossSeveralMwmsTest**
Незначительное изменение ETA маршрута.
Было:
![image](https://user-images.githubusercontent.com/1768114/69878061-e1453f80-12d4-11ea-8d74-b2ff35442f3b.png)
Стало:
![image](https://user-images.githubusercontent.com/1768114/69878079-eefac500-12d4-11ea-9cb0-4181f4b91487.png)

**CrossMwmRussiaPStaiToBelarusDrazdy**
Ранее не было брода на данном маршруте. Теперь он появился и маршрут пошел в обход брода. Я оставил этот тест. Сейчас он проверяет не только пересечение границ mwm пешеходами, но и проверяет, что мы обходим брод.
Было:
![image](https://user-images.githubusercontent.com/1768114/69961516-18a62d00-151d-11ea-8d4b-8e5e43484779.png)
Стало:
![image](https://user-images.githubusercontent.com/1768114/69961535-2065d180-151d-11ea-92de-580b70b115aa.png)

Тест CrossMwmRussiaPStaiToBelarusDrazdy поднял проблему, которая может воспроизводится при старте или финише около границы, при условии что фича пересекающая границу mwm пересечена бродом или другим запретительным объектом. Сейчас чиню данный случай на master.

@gmoryes @mesozoic-drones PTAL
