### PR TITLE
[generator][search] Use postcodes section for search index build.

### DIFF
--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -6,6 +6,7 @@
 #include "generator/feature_generator.hpp"
 #include "generator/feature_sorter.hpp"
 #include "generator/generator_tests_support/test_feature.hpp"
+#include "generator/postcodes_section_builder.hpp"
 #include "generator/search_index_builder.hpp"
 
 #include "indexer/city_boundary.hpp"
@@ -147,6 +148,8 @@ void TestMwmBuilder::Finish()
   CHECK(BuildOffsetsTable(path), ("Can't build feature offsets table."));
 
   CHECK(indexer::BuildIndexFromDataFile(path, path), ("Can't build geometry index."));
+
+  CHECK(BuildPostcodesSection(path), ("Can't build postcodes section."));
 
   CHECK(indexer::BuildSearchIndexFromDataFile(m_file.GetDirectory(), m_file.GetCountryName(),
                                               true /* forceRebuild */, 1 /* threadsCount */),


### PR DESCRIPTION
реквест поверх
https://github.com/mapsme/omim/pull/12170

Чтобы можно было добавить в секцию с посткодами дополнительные данные и они автоматически проиндексировались в поиске, нужно использовать для построения поискового индекса данные оттуда (а не полученные напрямую из промежуточного файла). Механизм получения посткодов из секции с посткодами -- FeatureType::GetPostcode().