### PR TITLE
[routing] Using method for getting the closest segment in EraseIfDeadEnd().

### DIFF
--- a/geometry/geometry_tests/polyline_tests.cpp
+++ b/geometry/geometry_tests/polyline_tests.cpp
@@ -15,7 +15,7 @@ double constexpr kEps = 1e-5;
 void TestClosest(std::vector<m2::PointD> const & points, m2::PointD const & point,
                  double expectedSquaredDist, uint32_t expectedIndex)
 {
-  auto const closestByPoints = m2::CalcMinSquaredDistance(points, point);
+  auto const closestByPoints = m2::CalcMinSquaredDistance(points.begin(), points.end(), point);
   TEST_ALMOST_EQUAL_ABS(closestByPoints.first, expectedSquaredDist, kEps, ());
   TEST_EQUAL(closestByPoints.second, expectedIndex, ());
 

--- a/geometry/geometry_tests/polyline_tests.cpp
+++ b/geometry/geometry_tests/polyline_tests.cpp
@@ -6,16 +6,23 @@
 
 #include "base/math.hpp"
 
+#include <vector>
+
 namespace
 {
 double constexpr kEps = 1e-5;
 
-void TestClosest(m2::PolylineD const & poly, m2::PointD const & point, double expectedSquaredDist,
-                 uint32_t expectedIndex)
+void TestClosest(std::vector<m2::PointD> const & points, m2::PointD const & point,
+                 double expectedSquaredDist, uint32_t expectedIndex)
 {
-  auto const closest = poly.CalcMinSquaredDistance(m2::PointD(point));
-  TEST_ALMOST_EQUAL_ABS(closest.first, expectedSquaredDist, kEps, ());
-  TEST_EQUAL(closest.second, expectedIndex, ());
+  auto const closestByPoints = m2::CalcMinSquaredDistance(points, point);
+  TEST_ALMOST_EQUAL_ABS(closestByPoints.first, expectedSquaredDist, kEps, ());
+  TEST_EQUAL(closestByPoints.second, expectedIndex, ());
+
+  m2::PolylineD const poly(points);
+  auto const closestByPoly = poly.CalcMinSquaredDistance(m2::PointD(point));
+  TEST_ALMOST_EQUAL_ABS(closestByPoly.first, expectedSquaredDist, kEps, ());
+  TEST_EQUAL(closestByPoly.second, expectedIndex, ());
 }
 
 UNIT_TEST(Rect_PolylineSmokeTest)
@@ -37,8 +44,8 @@ UNIT_TEST(Rect_PolylineMinDistanceTest)
   // 1 |              |
   //   |              |
   //   0----1----2----3
-  m2::PolylineD const poly = {{0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0},
-                              {2.0, 0.0}, {3.0, 0.0}, {3.0, 1.0}};
+  std::vector<m2::PointD> const poly = {{0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0},
+                                        {2.0, 0.0}, {3.0, 0.0}, {3.0, 1.0}};
 
   TestClosest(poly, m2::PointD(0.0, 1.0), 0.0 /* expectedSquaredDist */, 0 /* expectedIndex */);
   TestClosest(poly, m2::PointD(0.0, 0.0), 0.0 /* expectedSquaredDist */, 0 /* expectedIndex */);

--- a/geometry/point_with_altitude.hpp
+++ b/geometry/point_with_altitude.hpp
@@ -41,6 +41,10 @@ private:
 
 std::string DebugPrint(PointWithAltitude const & r);
 
+template <typename T>
+m2::Point<T> GetPoint(m2::Point<T> const & point) { return point; }
+m2::PointD GetPoint(PointWithAltitude const pwa) { return pwa.GetPoint(); }
+
 inline PointWithAltitude MakePointWithAltitudeForTesting(m2::PointD const & point)
 {
   return PointWithAltitude(point, kDefaultAltitudeMeters);

--- a/geometry/point_with_altitude.hpp
+++ b/geometry/point_with_altitude.hpp
@@ -43,7 +43,7 @@ std::string DebugPrint(PointWithAltitude const & r);
 
 template <typename T>
 m2::Point<T> GetPoint(m2::Point<T> const & point) { return point; }
-m2::PointD GetPoint(PointWithAltitude const pwa) { return pwa.GetPoint(); }
+inline m2::PointD GetPoint(PointWithAltitude const & pwa) { return pwa.GetPoint(); }
 
 inline PointWithAltitude MakePointWithAltitudeForTesting(m2::PointD const & point)
 {

--- a/geometry/polyline2d.hpp
+++ b/geometry/polyline2d.hpp
@@ -19,17 +19,17 @@
 namespace m2
 {
 /// \returns a pair of minimum squared distance from |point| to the closest segment and
-/// a zero-based closest segment index in |points|.
-template <typename T>
-std::pair<double, uint32_t> CalcMinSquaredDistance(std::vector<Point<T>> const & points,
-                                                   Point<T> const & point)
+/// a zero-based closest segment index in points in range [|beginIt|, |endIt|).
+template <typename It, typename T>
+std::pair<double, uint32_t> CalcMinSquaredDistance(It beginIt, It endIt,
+                                                   m2::Point<T> const & point)
 {
-  CHECK_GREATER(points.size(), 1, ());
+  CHECK_GREATER(std::distance(beginIt, endIt), 1, ());
   auto squaredClosestSegDist = std::numeric_limits<double>::max();
 
-  auto i = points.begin();
-  auto closestSeg = points.begin();
-  for (auto j = i + 1; j != points.end(); ++i, ++j)
+  auto i = beginIt;
+  auto closestSeg = beginIt;
+  for (auto j = i + 1; j != endIt; ++i, ++j)
   {
     m2::ParametrizedSegment<m2::Point<T>> seg(geometry::GetPoint(*i), geometry::GetPoint(*j));
     auto const squaredSegDist = seg.SquaredDistanceToPoint(point);
@@ -41,7 +41,7 @@ std::pair<double, uint32_t> CalcMinSquaredDistance(std::vector<Point<T>> const &
   }
 
   return std::make_pair(squaredClosestSegDist,
-                        static_cast<uint32_t>(std::distance(points.begin(), closestSeg)));
+                        static_cast<uint32_t>(std::distance(beginIt, closestSeg)));
 }
 
 template <typename T>
@@ -94,7 +94,7 @@ public:
 
   std::pair<double, uint32_t> CalcMinSquaredDistance(m2::Point<T> const & point) const
   {
-    return m2::CalcMinSquaredDistance(m_points, point);
+    return m2::CalcMinSquaredDistance(m_points.begin(), m_points.end(), point);
   }
 
   Rect<T> GetLimitRect() const

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -77,9 +77,9 @@ public:
               traffic::TrafficCache const & trafficCache, DataSource & dataSource);
 
   std::unique_ptr<WorldGraph> MakeSingleMwmWorldGraph();
-  bool FindBestSegments(m2::PointD const & point, m2::PointD const & direction, bool isOutgoing,
+  bool FindBestSegments(m2::PointD const & checkpoint, m2::PointD const & direction, bool isOutgoing,
                         WorldGraph & worldGraph, std::vector<Segment> & bestSegments);
-  bool FindBestEdges(m2::PointD const & point,
+  bool FindBestEdges(m2::PointD const & checkpoint,
                      platform::CountryFile const & pointCountryFile,
                      m2::PointD const & direction, bool isOutgoing,
                      double closestEdgesRadiusM, WorldGraph & worldGraph,
@@ -126,9 +126,9 @@ private:
 
   /// \brief Removes all roads from |roads| which goes to dead ends and all road which
   /// is not good according to |worldGraph|. For car routing there are roads with hwtag nocar as well.
-  /// \param point which is used to look for the closest segment in a road. The closest segment
+  /// \param checkpoint which is used to look for the closest segment in a road. The closest segment
   /// is used then to check if it's a dead end.
-  void EraseIfDeadEnd(WorldGraph & worldGraph, m2::PointD const & point,
+  void EraseIfDeadEnd(WorldGraph & worldGraph, m2::PointD const & checkpoint,
                       std::vector<IRoadGraph::FullRoadInfo> & roads) const;
 
   /// \returns true if a segment (|point|, |edgeProjection.second|) crosses one of segments
@@ -152,17 +152,17 @@ private:
       Edge & closestCodirectionalEdge) const;
 
   /// \brief Finds the best segments (edges) which may be considered as starts or finishes
-  /// of the route. According to current implementation the closest to |point| segment which
+  /// of the route. According to current implementation the closest to |checkpoint| segment which
   /// is almost codirectianal to |direction| is the best.
   /// If there's no an almost codirectional segment in the neighbourhood then all not dead end
   /// candidates which may be reached without crossing road graph will be added to |bestSegments|.
-  /// \param isOutgoing == true if |point| is considered as the start of the route.
-  /// isOutgoing == false if |point| is considered as the finish of the route.
+  /// \param isOutgoing == true if |checkpoint| is considered as the start of the route.
+  /// isOutgoing == false if |checkpoint| is considered as the finish of the route.
   /// \param bestSegmentIsAlmostCodirectional is filled with true if |bestSegment| is chosen
   /// because |direction| and direction of |bestSegment| are almost equal and with false otherwise.
   /// \return true if the best segment is found and false otherwise.
   /// \note Candidates in |bestSegments| are sorted from better to worse.
-  bool FindBestSegments(m2::PointD const & point, m2::PointD const & direction, bool isOutgoing,
+  bool FindBestSegments(m2::PointD const & checkpoint, m2::PointD const & direction, bool isOutgoing,
                         WorldGraph & worldGraph, std::vector<Segment> & bestSegments,
                         bool & bestSegmentIsAlmostCodirectional) const;
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -125,8 +125,10 @@ private:
   std::unique_ptr<WorldGraph> MakeWorldGraph();
 
   /// \brief Removes all roads from |roads| which goes to dead ends and all road which
-  /// is not good according to |worldGraph|. For car routing it's roads with hwtag nocar.
-  void EraseIfDeadEnd(WorldGraph & worldGraph,
+  /// is not good according to |worldGraph|. For car routing there are roads with hwtag nocar as well.
+  /// \param point which is used to look for the closest segment in a road. The closest segment
+  /// is used then to check if it's a dead end.
+  void EraseIfDeadEnd(WorldGraph & worldGraph, m2::PointD const & point,
                       std::vector<IRoadGraph::FullRoadInfo> & roads) const;
 
   /// \returns true if a segment (|point|, |edgeProjection.second|) crosses one of segments

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -534,3 +534,12 @@ UNIT_TEST(BudvaPrimaryRoad)
       mercator::FromLatLon(42.2884527, 18.8456794), {0., 0.},
       mercator::FromLatLon(42.2880575, 18.8492896), 368.85);
 }
+
+// Test on start and finish route which lies on a feature crossed by a mwm border and a ford.
+UNIT_TEST(RussiaSmolenskAriaFeatureCrossingBorderWithFord)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents(VehicleType::Pedestrian),
+      mercator::FromLatLon(55.01727, 30.91566), {0., 0.},
+      mercator::FromLatLon(55.01867, 30.91285), 298.6);
+}


### PR DESCRIPTION
В данном PR обобщен метод CalcMinSquaredDistance(), чтоб его можно было использовать и с vector<m2::PointD> и с buffer_vector<PointWithAltitude>.

Затем он использован в EraseIfDeadEnd(), чтоб начинать поиск не с первого сегмента фичи, а с ближайшего сегмента. Эвристика с поиском с первого сегмента фичи использовалась ранее и оказалась не работоспособной при старте маршрута с фичи, которая пересекает границу mwm, так же прерывается бродом или подобным препятствием.

RussiaSmolenskAriaFeatureCrossingBorderWithFord
![image](https://user-images.githubusercontent.com/1768114/70039830-99bbfd80-15cb-11ea-87a7-3e747cc5cba9.png)

@gmoryes @mesozoic-drones PTAL