### PR TITLE
[indexer][generator] Remove FeatureBuilderParams::GetStreet(), FeatureBuilder::AddHouseNumber, FeatureBuilder::AddStreet, FeatureBuilder::AddPostcode.

### DIFF
--- a/generator/booking_dataset.cpp
+++ b/generator/booking_dataset.cpp
@@ -98,13 +98,13 @@ void BookingDataset::BuildObject(Object const & hotel,
   metadata.Set(Metadata::FMD_STARS, strings::to_string(hotel.m_stars));
   metadata.Set(Metadata::FMD_PRICE_RATE, strings::to_string(hotel.m_priceCategory));
 
+  auto & params = fb.GetParams();
   if (!hotel.m_street.empty())
-    fb.AddStreet(hotel.m_street);
+    params.AddStreet(hotel.m_street);
 
   if (!hotel.m_houseNumber.empty())
-    fb.AddHouseNumber(hotel.m_houseNumber);
+    params.AddHouseNumber(hotel.m_houseNumber);
 
-  auto & params = fb.GetParams();
   if (!hotel.m_translations.empty())
   {
     // TODO(mgsergio): Move parsing to the hotel costruction stage.

--- a/generator/booking_quality_check/booking_quality_check.cpp
+++ b/generator/booking_quality_check/booking_quality_check.cpp
@@ -56,20 +56,7 @@ string PrintBuilder(FeatureBuilder const & fb)
   s << "Id: " << DebugPrint(fb.GetMostGenericOsmId()) << '\t'
     << "Name: " << fb.GetName(StringUtf8Multilang::kDefaultCode) << '\t';
 
-  auto const & params = fb.GetParams();
-  auto const street = params.GetStreet();
-  auto const house = params.house.Get();
-
-  string address = street;
-  if (!house.empty())
-  {
-    if (!street.empty())
-      address += ", ";
-    address += house;
-  }
-
-  if (!address.empty())
-    s << "Address: " << address << '\t';
+  s << "Params: " << DebugPrint(fb.GetParams()) << '\t';
 
   auto const center = mercator::ToLatLon(fb.GetKeyPoint());
   s << "lat: " << center.m_lat << " lon: " << center.m_lon << '\t';

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -124,18 +124,6 @@ void FeatureBuilder::SetRank(uint8_t rank)
   m_params.rank = rank;
 }
 
-void FeatureBuilder::AddHouseNumber(string const & houseNumber)
-{
-  m_params.AddHouseNumber(houseNumber);
-}
-
-void FeatureBuilder::AddStreet(string const & streetName) { m_params.AddStreet(streetName); }
-
-void FeatureBuilder::AddPostcode(string const & postcode)
-{
-  m_params.AddPostcode(postcode);
-}
-
 void FeatureBuilder::AddPoint(m2::PointD const & p)
 {
   m_polygons.front().push_back(p);

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -149,9 +149,6 @@ public:
 
   // To work with additional information.
   void SetRank(uint8_t rank);
-  void AddHouseNumber(std::string const & houseNumber);
-  void AddStreet(std::string const & streetName);
-  void AddPostcode(std::string const & postcode);
   bool AddName(std::string const & lang, std::string const & name);
   void SetParams(FeatureBuilderParams const & params) { m_params.SetParams(params); }
 

--- a/generator/generator_tests/feature_builder_test.cpp
+++ b/generator/generator_tests/feature_builder_test.cpp
@@ -201,27 +201,19 @@ UNIT_CLASS_TEST(TestWithClassificator, FBuilder_RemoveUselessNames)
 
 UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilderParams_Parsing)
 {
-  {
-    FeatureBuilderParams params;
-    params.AddStreet("Embarcadero\nstreet");
-    TEST_EQUAL(params.GetStreet(), "Embarcadero street", ());
-  }
+  FeatureBuilderParams params;
 
-  {
-    FeatureBuilderParams params;
+  params.MakeZero();
+  TEST(params.AddHouseNumber("123"), ());
+  TEST_EQUAL(params.house.Get(), "123", ());
 
-    params.MakeZero();
-    TEST(params.AddHouseNumber("123"), ());
-    TEST_EQUAL(params.house.Get(), "123", ());
+  params.MakeZero();
+  TEST(params.AddHouseNumber("0000123"), ());
+  TEST_EQUAL(params.house.Get(), "123", ());
 
-    params.MakeZero();
-    TEST(params.AddHouseNumber("0000123"), ());
-    TEST_EQUAL(params.house.Get(), "123", ());
-
-    params.MakeZero();
-    TEST(params.AddHouseNumber("000000"), ());
-    TEST_EQUAL(params.house.Get(), "0", ());
-  }
+  params.MakeZero();
+  TEST(params.AddHouseNumber("000000"), ());
+  TEST_EQUAL(params.house.Get(), "0", ());
 }
 
 UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeLocalityObjectForBuildingPoint)

--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -130,8 +130,9 @@ void TestFeature::Serialize(FeatureBuilder & fb) const
       CHECK(fb.AddName(lang, name), ("Can't set feature name:", name, "(", lang, ")"));
     }
   });
+
   if (!m_postcode.empty())
-    fb.AddPostcode(m_postcode);
+    fb.GetParams().AddPostcode(m_postcode);
 }
 
 // TestCountry -------------------------------------------------------------------------------------
@@ -298,10 +299,11 @@ void TestPOI::Serialize(FeatureBuilder & fb) const
   for (auto const & path : m_types)
     fb.AddType(classificator.GetTypeByPath(path));
 
+  auto & params = fb.GetParams();
   if (!m_houseNumber.empty())
-    fb.AddHouseNumber(m_houseNumber);
+    params.AddHouseNumber(m_houseNumber);
   if (!m_streetName.empty())
-    fb.AddStreet(m_streetName);
+    params.AddStreet(m_streetName);
 }
 
 string TestPOI::ToDebugString() const
@@ -383,9 +385,10 @@ void TestBuilding::Serialize(FeatureBuilder & fb) const
 {
   TestFeature::Serialize(fb);
 
-  fb.AddHouseNumber(m_houseNumber);
+  auto & params = fb.GetParams();
+  params.AddHouseNumber(m_houseNumber);
   if (!m_streetName.empty())
-    fb.AddStreet(m_streetName);
+    params.AddStreet(m_streetName);
 
   auto const & classificator = classif();
   fb.AddType(classificator.GetTypeByPath({"building"}));

--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <sstream>
 #include <vector>
 
 using namespace feature;
@@ -548,8 +549,6 @@ void FeatureBuilderParams::AddPostcode(string const & s)
   m_addrTags.Add(AddressData::Type::Postcode, s);
 }
 
-string FeatureBuilderParams::GetStreet() const { return m_addrTags.Get(AddressData::Type::Street); }
-
 string DebugPrint(FeatureParams const & p)
 {
   Classificator const & c = classif();
@@ -561,4 +560,12 @@ string DebugPrint(FeatureParams const & p)
   return (res + p.DebugString());
 }
 
-string DebugPrint(FeatureBuilderParams const & p) { return DebugPrint(FeatureParams(p)); }
+string DebugPrint(FeatureBuilderParams const & p)
+{
+  ostringstream oss;
+  oss << "ReversedGeometry: " << (p.GetReversedGeometry() ? "true" : "false") << "; ";
+  oss << DebugPrint(p.GetMetadata()) << "; ";
+  oss << DebugPrint(p.GetAddressData()) << "; ";
+  oss << DebugPrint(FeatureParams(p));
+  return oss.str();
+}

--- a/indexer/feature_data.hpp
+++ b/indexer/feature_data.hpp
@@ -309,9 +309,6 @@ public:
   void AddStreet(std::string s);
   void AddPostcode(std::string const & s);
 
-  /// Used for generator/booking_quality_check.
-  std::string GetStreet() const;
-
   feature::AddressData const & GetAddressData() const { return m_addrTags; }
   feature::Metadata const & GetMetadata() const { return m_metadata; }
   feature::Metadata & GetMetadata() { return m_metadata; }

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -222,4 +222,13 @@ string DebugPrint(Metadata const & metadata)
   oss << "]";
   return oss.str();
 }
+
+string DebugPrint(feature::AddressData const & addressData)
+{
+  ostringstream oss;
+  oss << "AddressData [";
+  oss << "Street = \"" << addressData.Get(AddressData::Type::Street) << "\"; ";
+  oss << "Postcode = \"" << addressData.Get(AddressData::Type::Postcode) << "\"]";
+  return oss.str();
+}
 }  // namespace feature

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -248,4 +248,5 @@ std::string ToString(feature::Metadata::EType type);
 inline std::string DebugPrint(feature::Metadata::EType type) { return ToString(type); }
 
 std::string DebugPrint(feature::Metadata const & metadata);
+std::string DebugPrint(feature::AddressData const & addressData);
 }  // namespace feature


### PR DESCRIPTION
FeatureBuilderParams::GetStreet() использовалась только для отладочной печати, переделала там отладочную печать.

FeatureBuilder::Add* использовались только в тестах и booking_dataset. Проблема с ними в том, что можно в этот метод добавить логику и в тестах это работать будет, а "на бою" -- нет, так как при сборке карт это всё заполняется напрямую в FeatureBuilderParams (в ParseNameAndType), поэтому более безопасно везде заполнять напрямую в параметрах.