### PR TITLE
[routing] Fixing routing quality test RoutingQuality_IranSouth.

### DIFF
--- a/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
@@ -53,7 +53,8 @@ UNIT_TEST(RoutingQuality_USAOklahoma)
 UNIT_TEST(RoutingQuality_IranSouth)
 {
   TEST(CheckCarRoute({32.45088, 51.76419} /* start */, {32.97067, 51.50399} /* finish */,
-                     {{{32.67021, 51.64323}, {32.68752, 51.63387}}} /* reference track */),
+                     {{{32.67021, 51.64323}, {32.68752, 51.63387}},
+                      {{32.67021, 51.64323}, {32.7501, 51.64661}}} /* reference track */),
        ());
 }
 


### PR DESCRIPTION
Данная группа outing quality tests на то, чтоб маршруты прокладывались по большим дорогам. В случае этого теста возможны 2 варианта:
Более короткий путь по прямому highway=trunk, как это было в картах 190910:
![image](https://user-images.githubusercontent.com/1768114/70147601-ab79cf80-16b5-11ea-9ae4-f5d1d6ae844b.png)

И более длинный путь, по highway=motorway (с большим maxspeed), как это стало на картах 191124:
![image](https://user-images.githubusercontent.com/1768114/70147674-d19f6f80-16b5-11ea-8555-0839fb005cac.png)

Учитывая, что от релиза к релизу карт эти 2 маршрута иногда меняются, и что оба они представляются корректными я задаю 2 варианта, как возможные.

@gmoryes @mesozoic-drones PTAL