### PR TITLE
[Routing] Fake graph stress testing.

### DIFF
--- a/routing/fake_graph.hpp
+++ b/routing/fake_graph.hpp
@@ -26,8 +26,8 @@ public:
   // outgoing edges, fills segment to vertex mapping. Fills real to fake and fake to real
   // mapping if isPartOfReal is true.
   void AddVertex(SegmentType const & existentSegment, SegmentType const & newSegment,
-                 VertexType const & newVertex, bool isOutgoing, bool isPartOfReal,
-                 SegmentType const & real)
+                 VertexType const & newVertex, bool isOutgoing, bool isPartOfReal = false,
+                 SegmentType const & real = SegmentType())
   {
     AddStandaloneVertex(newSegment, newVertex);
     auto const & segmentFrom = isOutgoing ? existentSegment : newSegment;

--- a/routing/routing_benchmarks/CMakeLists.txt
+++ b/routing/routing_benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   ../routing_integration_tests/routing_test_tools.hpp
   bicycle_routing_tests.cpp
   car_routing_tests.cpp
+  fake_graph_tests.cpp
   helpers.cpp
   helpers.hpp
   pedestrian_routing_tests.cpp

--- a/routing/routing_benchmarks/fake_graph_tests.cpp
+++ b/routing/routing_benchmarks/fake_graph_tests.cpp
@@ -1,0 +1,98 @@
+#include "testing/testing.hpp"
+
+#include "routing/fake_graph.hpp"
+#include "routing/segment.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/timer.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+using namespace routing;
+using namespace std;
+
+namespace
+{
+NumMwmId constexpr kDummyMwmId = 20;
+
+// Finds Segments in graph for measuring total search time.
+void FindNodesTest(FakeGraph<Segment, m2::PointD> const & graph, uint32_t maxIndex,
+                   uint32_t iterCount)
+{
+  for (uint32_t i = 1; i < iterCount; ++i)
+  {
+    uint32_t const id = i < maxIndex ? i : i % maxIndex + 1;
+    auto volatile res = graph.GetVertex({kDummyMwmId, id, id, true /* forward */});
+  }
+}
+
+// Builds fake graph in the shape of the "square seed".
+FakeGraph<Segment, m2::PointD> ConstructSieveGraph(uint32_t startSegmentIndex,
+                                                   uint32_t sideOfSquarePoints,
+                                                   m2::PointD const & leftLowerPoint)
+{
+  CHECK_GREATER(sideOfSquarePoints, 1, ());
+  FakeGraph<Segment, m2::PointD> fakeGraph;
+  auto curId = startSegmentIndex;
+  auto const maxSegmentIndex = startSegmentIndex + sideOfSquarePoints;
+  bool isFirstRow = true;
+
+  for (auto i = startSegmentIndex; i < maxSegmentIndex; ++i)
+  {
+    bool isFirstCol = true;
+    for (auto j = startSegmentIndex; j < maxSegmentIndex; ++j, ++curId)
+    {
+      Segment cur(kDummyMwmId, curId, curId, true /* forward */);
+      m2::PointD const coord(leftLowerPoint.x + i, leftLowerPoint.y + j);
+      if (isFirstCol)
+      {
+        fakeGraph.AddStandaloneVertex(cur, coord);
+        isFirstCol = false;
+      }
+      else
+      {
+        auto const prevId = curId - 1;
+        Segment prev(kDummyMwmId, prevId, prevId, true /* forward */);
+        fakeGraph.AddVertex(prev, cur, coord, true /* isOutgoing */);
+        fakeGraph.AddConnection(cur, prev);
+      }
+      if (!isFirstRow)
+      {
+        Segment lower(kDummyMwmId, curId - sideOfSquarePoints, curId - sideOfSquarePoints, true /* forward */);
+        fakeGraph.AddConnection(cur, lower);
+        fakeGraph.AddConnection(lower, cur);
+      }
+    }
+    isFirstRow = false;
+  }
+
+  return fakeGraph;
+}
+
+// Builds fake graph and calculates the performance of insert/find operations.
+UNIT_TEST(HugeFakeGraphTest)
+{
+  for (auto sideOfSquare : {5, 10, 32, 60, 100, 250, 500, 750, 1000})
+  {
+    base::HighResTimer timerStart;
+
+    auto const fakeGraph = ConstructSieveGraph(1, sideOfSquare, {1.0, 1.0});
+
+    auto const totalSize = sideOfSquare * sideOfSquare;
+    CHECK_EQUAL(fakeGraph.GetSize(), totalSize, ());
+
+    auto const intermediatePoint = timerStart.ElapsedMillis();
+
+    uint32_t constexpr iterCount = 10000;  // Count of cycles for averaging the result time.
+    FindNodesTest(fakeGraph, totalSize, iterCount);
+
+    LOG(LINFO, (totalSize, "nodes in fake graph. Construction duration:", intermediatePoint, "ms.",
+                iterCount, "iterations of search duration:",
+                timerStart.ElapsedMillis() - intermediatePoint, "ms."));
+  }
+}
+}  // namespace

--- a/routing/routing_tests/fake_graph_test.cpp
+++ b/routing/routing_tests/fake_graph_test.cpp
@@ -36,7 +36,7 @@ ConstructFakeGraph(uint32_t numerationStart, uint32_t numFake, uint32_t numReal)
   for (uint32_t prevNumber = numerationStart; prevNumber + 1 < numerationStart + numFake + numReal;
        ++prevNumber)
   {
-    bool const newIsReal = prevNumber + 1 < numerationStart + numFake ? false : true;
+    bool const newIsReal = prevNumber + 1 < numerationStart + numFake;
     int32_t const prevSegment = prevNumber;
     int32_t const newSegment = prevNumber + 1;
     auto const newVertex = m2::PointD(prevNumber + 1, prevNumber + 1);


### PR DESCRIPTION
The goal of this PR is to check for any bottlenecks in our FakeGraph implementation for future use in case of really large fake graphs.

Below is the comparison of the std::map and std::unordered_map FakeGraph implementations. 

The tables represent the time of 100 000 searches in the graph and  the duration of graph building (average values for 5 loops).

**std::map as the core containter in FakeGraph, SegmentType = int32_t (just for baseline)**

| Count of nodes | DEBUG Duration of graph building, ms | DEBUG Duration of searching, ms | RELEASE Duration of graph building, ms | RELEASE Duration of searching, ms |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 25  | 0   | 27 |  0  |  0  |
| 100  | 1  | 29  |  0   |  0   |
| 1 024  | 12  | 37 |  1   |  1 |
| 10 k  | 170  | 62  |   20  | 1  |
| 250 k  | 4 687  | 50  |   680 | 1 |
| 1 mln  | 21 900  | 53  |  3 081  |  2  |

**std::map as the core containter in FakeGraph, SegmentType = Segment**

| Count of nodes | DEBUG Duration of graph building, ms | DEBUG Duration of searching, ms | RELEASE Duration of graph building, ms | RELEASE Duration of searching, ms |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 25  | 0  | 2 |  0 |  0 |
| 100  | 1 | 3  |  0  |  0  |
| 1 024  |  14 | 3 |  1  |  1 |
| 10 k  | 175  | 4  |  18 | 1  |
| 250 k  | 5 676 | 5 |  552 |  1 |
| 1 mln  | 28 193  | 5 |  2 492  |  2  |

**std::unordered_map as the core containter in FakeGraph, SegmentType = Segment**

| Count of nodes | DEBUG Duration of graph building, ms (+reserve()) | DEBUG Duration of searching, ms | RELEASE Duration of graph building, ms | RELEASE Duration of searching, ms |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 25  | 0  (0) | 3 |  0 (0)  |  0 |
| 100  | 1  (0) | 3  |  0 (0) |   0  |
| 1 024  | 8 (8) | 2 |  2  (1) |  0 |
| 10 k  | 92  (97) | 4  |   28 (19)  | 0  |
| 250 k  | 2 857 (2 603) | 6 |   1 303 (628) | 1 |
| 1 mln  | 11 032 (10 113)  | 6 |  4 078  (2 523) |  1  |