### PR TITLE
[generator] Fixed mini-roundabouts to roads matching.

### DIFF
--- a/generator/generator_tests/mini_roundabout_tests.cpp
+++ b/generator/generator_tests/mini_roundabout_tests.cpp
@@ -213,9 +213,8 @@ UNIT_TEST(Manage_MiniRoundabout_1Road)
   AddPointToCircle(circlePlain, newPointOnRoad);
 
   std::vector<m2::PointD> const circlePlainExpected{
-      {11.50013, 85.06309}, {11.50012, 85.06310}, {11.50011, 85.06310},
-      {11.50010, 85.06309},{11.50010, 85.06306}, {11.50012, 85.06305},
-      {11.50013, 85.06306}};
+      {11.50013, 85.06309}, {11.50012, 85.06310}, {11.50011, 85.06310}, {11.50010, 85.06309},
+      {11.50010, 85.06306}, {11.50012, 85.06305}, {11.50013, 85.06306}};
 
   TestRunCmpPoints(circlePlain, circlePlainExpected, r);
 }
@@ -253,10 +252,9 @@ UNIT_TEST(Manage_MiniRoundabout_4Roads)
                                center, r));
 
   std::vector<m2::PointD> const circlePlainExpected{
-      {-0.47381, 60.67520}, {-0.47383, 60.67521}, {-0.47384, 60.67521},
-      {-0.47385, 60.67520},{-0.47386, 60.67520}, {-0.47385, 60.67518},
-      {-0.47385, 60.67518}, {-0.47383,60.67517}, {-0.47381,60.67518},
-      {-0.47381, 60.67518}};
+      {-0.47381, 60.67520}, {-0.47383, 60.67521}, {-0.47384, 60.67521}, {-0.47385, 60.67520},
+      {-0.47386, 60.67520}, {-0.47385, 60.67518}, {-0.47385, 60.67518}, {-0.47383, 60.67517},
+      {-0.47381, 60.67518}, {-0.47381, 60.67518}};
   TestRunCmpPoints(circlePlain, circlePlainExpected, r);
 }
 
@@ -264,8 +262,7 @@ UNIT_TEST(Manage_MiniRoundabout_EqualPoints)
 {
   auto const miniRoundabout = MiniRoundabout(1, 10.0, 10.0);
 
-  m2::PointD const center =
-      mercator::FromLatLon({miniRoundabout.m_lat, miniRoundabout.m_lon});
+  m2::PointD const center = mercator::FromLatLon({miniRoundabout.m_lat, miniRoundabout.m_lon});
 
   double const r = mercator::MetersToMercator(5.0);
 

--- a/generator/generator_tests/mini_roundabout_tests.cpp
+++ b/generator/generator_tests/mini_roundabout_tests.cpp
@@ -213,8 +213,9 @@ UNIT_TEST(Manage_MiniRoundabout_1Road)
   AddPointToCircle(circlePlain, newPointOnRoad);
 
   std::vector<m2::PointD> const circlePlainExpected{
-      {11.50013, 85.06309}, {11.50012, 85.06310}, {11.50010, 85.06309},
-      {11.50010, 85.06306}, {11.50012, 85.06305}, {11.50013, 85.06306}};
+      {11.50013, 85.06309}, {11.50012, 85.06310}, {11.50011, 85.06310},
+      {11.50010, 85.06309},{11.50010, 85.06306}, {11.50012, 85.06305},
+      {11.50013, 85.06306}};
 
   TestRunCmpPoints(circlePlain, circlePlainExpected, r);
 }
@@ -236,7 +237,7 @@ UNIT_TEST(Manage_MiniRoundabout_4Roads)
   double const r = mercator::MetersToMercator(2.5);
 
   auto circlePlain = PointToPolygon(center, r, 6, 30.0);
-  auto circlePlainBeforeAdd = circlePlain;
+
   AddPointToCircle(circlePlain, TrimSegment(mercator::FromLatLon(stationRoadNode.m_lat,
                                                                        stationRoadNode.m_lon),
                                             center, r));
@@ -251,7 +252,27 @@ UNIT_TEST(Manage_MiniRoundabout_4Roads)
                                                           plaughRoundaboutRightNode.m_lon),
                                center, r));
 
-  // No road points are added to the circle, becouse all of them are too close to the
-  // original circle points.
-  TestRunCmpPoints(circlePlain, circlePlainBeforeAdd, r);
+  std::vector<m2::PointD> const circlePlainExpected{
+      {-0.47381, 60.67520}, {-0.47383, 60.67521}, {-0.47384, 60.67521},
+      {-0.47385, 60.67520},{-0.47386, 60.67520}, {-0.47385, 60.67518},
+      {-0.47385, 60.67518}, {-0.47383,60.67517}, {-0.47381,60.67518},
+      {-0.47381, 60.67518}};
+  TestRunCmpPoints(circlePlain, circlePlainExpected, r);
+}
+
+UNIT_TEST(Manage_MiniRoundabout_EqualPoints)
+{
+  auto const miniRoundabout = MiniRoundabout(1, 10.0, 10.0);
+
+  m2::PointD const center =
+      mercator::FromLatLon({miniRoundabout.m_lat, miniRoundabout.m_lon});
+
+  double const r = mercator::MetersToMercator(5.0);
+
+  auto circlePlain = PointToPolygon(center, r, 12, 30.0);
+  AddPointToCircle(circlePlain, circlePlain[12]);
+  AddPointToCircle(circlePlain, circlePlain[6]);
+  AddPointToCircle(circlePlain, circlePlain[0]);
+  AddPointToCircle(circlePlain, circlePlain[0]);
+  TEST_EQUAL(circlePlain.size(), 16, ());
 }

--- a/generator/mini_roundabout_transformer.cpp
+++ b/generator/mini_roundabout_transformer.cpp
@@ -254,9 +254,6 @@ void AddPointToCircle(std::vector<m2::PointD> & circle, m2::PointD const & point
 
   for (size_t i = 0; i < circle.size(); ++i)
   {
-    if (AlmostEqualAbs(circle[i], point, kMwmPointAccuracy))
-      return;
-
     double const dist = DistanceOnPlain(circle[i], point);
     if (dist < dist1)
     {


### PR DESCRIPTION
Баг: дороги не соединяются с мини-раундэбаутами.
Причина: в некоторых случаях точка не добавлялась в мини-раундэабут, если в нем находилась _почти_ такая же. 
А routing_index_generator соединяет фичи, если точки сопадают:
`PointToInt64Obsolete(f.GetPoint(i), kPointCoordBits);`

Соответственно совпадения для дороги в мини-раундэбауте не находилось, и они не соединялись.
PR это исправляет, дороги прокладываются.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/54934129/70452171-bc608180-1ab7-11ea-91b1-8edd9141fe57.png">
