### PR TITLE
[indexer][search] Set default population for Country and State to avoid zero rank.

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -710,15 +710,12 @@ uint64_t GetPopulation(FeatureType & ft)
   {
     switch (IsLocalityChecker::Instance().GetType(ft))
     {
-    case LocalityType::City:
-    case LocalityType::Town:
-      population = 10000;
-      break;
-    case LocalityType::Village:
-      population = 100;
-      break;
-    default:
-      population = 0;
+    case LocalityType::Country: population = 500000; break;
+    case LocalityType::State: population = 100000; break;
+    case LocalityType::City: population = 50000; break;
+    case LocalityType::Town: population = 10000; break;
+    case LocalityType::Village: population = 100; break;
+    default: population = 0;
     }
   }
 


### PR DESCRIPTION
Значения выбраны консервативно, т.к. наиболее важные объекты лучше замаплены и с большей вероятностью имеют заполенный population.

Согласно https://wiki.openstreetmap.org/wiki/Tag:place%3Dcity
`
As of mid 2019, 63% of place=city have a population=* tag, of which the median value is 130,000, and 95% of place=city have a population=* value over 20,000. However, 13% have a population=* value between 20,000 and 50,000.
`
поэтому 50 000 кажется нормальным консервативным выбором.
Для state выбор тоже консервативный. Для стран -- сейчас в osm есть только 3 страны без population: Монако, Джибути и Шри-Ланка. Население очень разное, но страна -- в любом случае значимый объект, кажется неправильным что мы деревням ранг поднимаем, а странам -- нет.