### PR TITLE
[routing] Bidirectional LeapsOnly mode

### DIFF
--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -150,10 +150,23 @@ public:
   {
     auto const & transition = GetTransition(segment);
     CHECK_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
-    for (size_t exitIdx = 0; exitIdx < m_exits.size(); ++exitIdx)
+    auto const enterIdx = transition.m_enterIdx;
+    for (uint32_t exitIdx = 0; exitIdx < static_cast<uint32_t>(m_exits.size()); ++exitIdx)
     {
-      auto const weight = GetWeight(base::asserted_cast<size_t>(transition.m_enterIdx), exitIdx);
+      auto const weight = GetWeight(enterIdx, exitIdx);
       AddEdge(m_exits[exitIdx], weight, edges);
+    }
+  }
+
+  void GetIngoingEdgeList(Segment const & segment, std::vector<SegmentEdge> & edges) const
+  {
+    auto const & transition = GetTransition(segment);
+    CHECK_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
+    auto const exitIdx = transition.m_exitIdx;
+    for (uint32_t enterIdx = 0; enterIdx < static_cast<uint32_t>(m_enters.size()); ++enterIdx)
+    {
+      auto const weight = GetWeight(enterIdx, exitIdx);
+      AddEdge(m_enters[enterIdx], weight, edges);
     }
   }
 

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -151,7 +151,7 @@ public:
     auto const & transition = GetTransition(segment);
     CHECK_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
     auto const enterIdx = transition.m_enterIdx;
-    for (uint32_t exitIdx = 0; exitIdx < static_cast<uint32_t>(m_exits.size()); ++exitIdx)
+    for (size_t exitIdx = 0; exitIdx < m_exits.size(); ++exitIdx)
     {
       auto const weight = GetWeight(enterIdx, exitIdx);
       AddEdge(m_exits[exitIdx], weight, edges);
@@ -163,7 +163,7 @@ public:
     auto const & transition = GetTransition(segment);
     CHECK_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
     auto const exitIdx = transition.m_exitIdx;
-    for (uint32_t enterIdx = 0; enterIdx < static_cast<uint32_t>(m_enters.size()); ++enterIdx)
+    for (size_t enterIdx = 0; enterIdx < m_enters.size(); ++enterIdx)
     {
       auto const weight = GetWeight(enterIdx, exitIdx);
       AddEdge(m_enters[enterIdx], weight, edges);

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -1,19 +1,16 @@
 #include "routing/cross_mwm_graph.hpp"
+
 #include "routing/routing_exceptions.hpp"
 #include "routing/transit_graph.hpp"
 
 #include "indexer/data_source.hpp"
 #include "indexer/scales.hpp"
 
-#include "geometry/mercator.hpp"
-
 #include "base/assert.hpp"
-#include "base/math.hpp"
 #include "base/stl_helpers.hpp"
 
 #include "defines.hpp"
 
-#include <algorithm>
 #include <numeric>
 #include <utility>
 
@@ -91,7 +88,7 @@ void CrossMwmGraph::DeserializeTransitTransitions(vector<NumMwmId> const & mwmId
 
 void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
 {
-  CHECK(IsTransition(s, isOutgoing),
+  ASSERT(IsTransition(s, isOutgoing),
         ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
   // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.
   // |twins| is not filled for such cases. For details please see a note in
@@ -131,21 +128,44 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
     CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
 }
 
-void CrossMwmGraph::GetOutgoingEdgeList(Segment const & s, vector<SegmentEdge> & edges)
+void CrossMwmGraph::GetOutgoingEdgeList(Segment const & enter, vector<SegmentEdge> & edges)
 {
-  CHECK(IsTransition(s, false /* isEnter */),
-        ("The segment is not a transition segment. IsTransition(", s, ", false) returns false."));
-  edges.clear();
+  ASSERT(
+      IsTransition(enter, false /* isEnter */),
+      ("The segment is not a transition segment. IsTransition(", enter, ", false) returns false."));
 
-  if (TransitGraph::IsTransitSegment(s))
+  // Is not supported yet.
+  /*
+  if (TransitGraph::IsTransitSegment(enter))
   {
-    if (TransitCrossMwmSectionExists(s.GetMwmId()))
-      m_crossMwmTransitGraph.GetOutgoingEdgeList(s, edges);
+    if (TransitCrossMwmSectionExists(enter.GetMwmId()))
+      m_crossMwmTransitGraph.GetOutgoingEdgeList(enter, edges);
     return;
   }
+  */
 
-  if (CrossMwmSectionExists(s.GetMwmId()))
-    m_crossMwmIndexGraph.GetOutgoingEdgeList(s, edges);
+  if (CrossMwmSectionExists(enter.GetMwmId()))
+    m_crossMwmIndexGraph.GetOutgoingEdgeList(enter, edges);
+}
+
+void CrossMwmGraph::GetIngoingEdgeList(Segment const & exit, vector<SegmentEdge> & edges)
+{
+  ASSERT(
+    IsTransition(exit, true /* isEnter */),
+    ("The segment is not a transition segment. IsTransition(", exit, ", true) returns false."));
+
+  // Is not supported yet.
+  /*
+  if (TransitGraph::IsTransitSegment(enter))
+  {
+    if (TransitCrossMwmSectionExists(enter.GetMwmId()))
+      m_crossMwmTransitGraph.GetIngoingEdgeList(enter, edges);
+    return;
+  }
+  */
+
+  if (CrossMwmSectionExists(exit.GetMwmId()))
+    m_crossMwmIndexGraph.GetIngoingEdgeList(exit, edges);
 }
 
 void CrossMwmGraph::Clear()

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -89,6 +89,8 @@ public:
   /// to calculate |segment| weight.
   void GetOutgoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges);
 
+  void GetIngoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges);
+
   void Clear();
 
   // \returns transitions for mwm with id |numMwmId| for CrossMwmIndexGraph.

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -152,6 +152,12 @@ public:
     c.GetOutgoingEdgeList(s, edges);
   }
 
+  void GetIngoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges)
+  {
+    CrossMwmConnector<CrossMwmId> const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
+    c.GetIngoingEdgeList(s, edges);
+  }
+
   void Clear() { m_connectors.clear(); }
 
   bool InCache(NumMwmId numMwmId) const { return m_connectors.count(numMwmId) != 0; }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -644,8 +644,9 @@ RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(
   Visitor visitor(leapsGraph, delegate, kVisitPeriodForLeaps, progress);
 
   AStarAlgorithm<Vertex, Edge, Weight>::Params<Visitor, AStarLengthChecker> params(
-      leapsGraph, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
-      delegate.GetCancellable(), move(visitor), AStarLengthChecker(starter));
+      leapsGraph, leapsGraph.GetStartSegment(), leapsGraph.GetFinishSegment(),
+      nullptr /* prevRoute */, delegate.GetCancellable(), move(visitor),
+      AStarLengthChecker(starter));
 
   RoutingResult<Vertex, Weight> routingResult;
   RouterResultCode const result =
@@ -667,7 +668,7 @@ RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(
   LeapsPostProcessor leapsPostProcessor(subrouteWithoutPostprocessing, starter);
   subroute = leapsPostProcessor.GetProcessedPath();
 
-  return leapsResult;
+  return RouterResultCode::NoError;
 }
 
 RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -206,11 +206,6 @@ private:
       RoutingResult<Vertex, Weight> & routingResult, WorldGraphMode mode) const
   {
     AStarAlgorithm<Vertex, Edge, Weight> algorithm;
-    if (mode == WorldGraphMode::LeapsOnly)
-    {
-      return ConvertTransitResult(mwmIds,
-                                  ConvertResult<Vertex, Edge, Weight>(algorithm.FindPath(params, routingResult)));
-    }
     return ConvertTransitResult(
         mwmIds, ConvertResult<Vertex, Edge, Weight>(algorithm.FindPathBidirectional(params, routingResult)));
   }

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -75,9 +75,8 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
   {
     // Connect start to all exits (|isEnter| == false).
     auto const & exits = m_starter.GetGraph().GetTransitions(mwmId, false /* isEnter */);
-    for (uint32_t exitId = 0; exitId < static_cast<uint32_t>(exits.size()); ++exitId)
+    for (auto const & exit : exits)
     {
-      auto const & exit = exits[exitId];
       auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint);
 
@@ -94,9 +93,8 @@ void LeapsGraph::GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
   {
     // Connect finish to all enters (|isEnter| == true).
     auto const & enters = m_starter.GetGraph().GetTransitions(mwmId, true /* isEnter */);
-    for (uint32_t enterId = 0; enterId < static_cast<uint32_t>(enters.size()); ++enterId)
+    for (auto const & enter : enters)
     {
-      auto const & enter = enters[enterId];
       auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint);
 

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -2,52 +2,53 @@
 
 #include "routing_common/num_mwm_id.hpp"
 
+#include "base/assert.hpp"
+
 #include <set>
 
 namespace routing
 {
-LeapsGraph::LeapsGraph(IndexGraphStarter & starter) : m_starter(starter) {}
+LeapsGraph::LeapsGraph(IndexGraphStarter & starter) : m_starter(starter)
+{
+  m_startPoint = m_starter.GetPoint(m_starter.GetStartSegment(), true /* front */);
+  m_finishPoint = m_starter.GetPoint(m_starter.GetFinishSegment(), true /* front */);
+  m_startSegment = m_starter.GetStartSegment();
+  m_finishSegment = m_starter.GetFinishSegment();
+}
 
-void LeapsGraph::GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetOutgoingEdgesList(Segment const & segment,
+                                      std::vector<SegmentEdge> & edges)
 {
   GetEdgesList(segment, true /* isOutgoing */, edges);
 }
 
-void LeapsGraph::GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetIngoingEdgesList(Segment const & segment,
+                                     std::vector<SegmentEdge> & edges)
 {
   GetEdgesList(segment, false /* isOutgoing */, edges);
 }
 
 RouteWeight LeapsGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
 {
-  return m_starter.HeuristicCostEstimate(from, to);
+  ASSERT(to == m_startSegment || to == m_finishSegment, ());
+  bool const toFinish = to == m_finishSegment;
+  auto const & toPoint = toFinish ? m_finishPoint : m_startPoint;
+  return m_starter.HeuristicCostEstimate(from, toPoint);
 }
 
 void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
                               std::vector<SegmentEdge> & edges)
 {
-  // Ingoing edges listing are not supported in LeapsOnly mode because we do not have enough
-  // information to calculate |segment| weight. See https://jira.mail.ru/browse/MAPSME-5743 for
-  // details.
-  CHECK(isOutgoing, ("Ingoing edges listing are not supported in LeapsOnly mode."));
-
   edges.clear();
 
-  if (segment.IsRealSegment() && !m_starter.IsRoutingOptionsGood(segment))
-    return;
+  if (segment == m_startSegment)
+    return GetEdgesListFromStart(segment, isOutgoing, edges);
 
-  if (segment == m_starter.GetStartSegment())
-  {
-    GetEdgesListForStart(segment, isOutgoing, edges);
-    return;
-  }
+  if (segment == m_finishSegment)
+    return GetEdgesListToFinish(segment, isOutgoing, edges);
 
-  // An edge from finish mwm enter to finish.
-  if (m_starter.GetFinishEnding().OverlapsWithMwm(segment.GetMwmId()))
-  {
-    GetEdgesListForFinish(segment, isOutgoing, edges);
+  if (!m_starter.IsRoutingOptionsGood(segment))
     return;
-  }
 
   auto & crossMwmGraph = m_starter.GetGraph().GetCrossMwmGraph();
   if (crossMwmGraph.IsTransition(segment, isOutgoing))
@@ -56,45 +57,67 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
     m_starter.GetGraph().GetTwinsInner(segment, isOutgoing, twins);
     for (auto const & twin : twins)
       edges.emplace_back(twin, RouteWeight(0.0));
+
+    return;
   }
-  else
-  {
+
+  if (isOutgoing)
     crossMwmGraph.GetOutgoingEdgeList(segment, edges);
-  }
+  else
+    crossMwmGraph.GetIngoingEdgeList(segment, edges);
 }
 
-void LeapsGraph::GetEdgesListForStart(Segment const & segment, bool isOutgoing,
-                                      std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
+                                       std::vector<SegmentEdge> & edges)
 {
-  auto const & segmentPoint = GetPoint(segment, true /* front */);
-  std::set<NumMwmId> seen;
+  CHECK(isOutgoing, ());
   for (auto const mwmId : m_starter.GetStartEnding().m_mwmIds)
   {
-    if (seen.insert(mwmId).second)
+    // Connect start to all exits (|isEnter| == false).
+    auto const & exits = m_starter.GetGraph().GetTransitions(mwmId, false /* isEnter */);
+    for (uint32_t exitId = 0; exitId < static_cast<uint32_t>(exits.size()); ++exitId)
     {
-      // Connect start to all exits (|isEnter| == false).
-      for (auto const & transition : m_starter.GetGraph().GetTransitions(mwmId, false /* isEnter */))
-      {
-        auto const & transitionFrontPoint = GetPoint(transition, true /* front */);
-        auto const weight = m_starter.GetGraph().CalcLeapWeight(segmentPoint, transitionFrontPoint);
-        edges.emplace_back(transition, weight);
-      }
+      auto const & exit = exits[exitId];
+      auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */);
+      auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint);
+
+      edges.emplace_back(exit, weight);
     }
   }
 }
 
-void LeapsGraph::GetEdgesListForFinish(Segment const & segment, bool isOutgoing,
-                                       std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
+                                      std::vector<SegmentEdge> & edges)
 {
-  auto const & segmentPoint = GetPoint(segment, true /* front */);
-  edges.emplace_back(m_starter.GetFinishSegment(),
-                     m_starter.GetGraph().CalcLeapWeight(
-                         segmentPoint, GetPoint(m_starter.GetFinishSegment(), true /* front */)));
+  CHECK(!isOutgoing, ());
+  for (auto const mwmId : m_starter.GetFinishEnding().m_mwmIds)
+  {
+    // Connect finish to all enters (|isEnter| == true).
+    auto const & enters = m_starter.GetGraph().GetTransitions(mwmId, true /* isEnter */);
+    for (uint32_t enterId = 0; enterId < static_cast<uint32_t>(enters.size()); ++enterId)
+    {
+      auto const & enter = enters[enterId];
+      auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */);
+      auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint);
+
+      edges.emplace_back(enter, weight);
+    }
+  }
 }
 
-m2::PointD const & LeapsGraph::GetPoint(Segment const & segment, bool front) const
+m2::PointD const & LeapsGraph::GetPoint(Segment const & segment, bool front)
 {
   return m_starter.GetPoint(segment, front);
+}
+
+Segment const & LeapsGraph::GetStartSegment() const
+{
+  return m_startSegment;
+}
+
+Segment const & LeapsGraph::GetFinishSegment() const
+{
+  return m_finishSegment;
 }
 
 RouteWeight LeapsGraph::GetAStarWeightEpsilon()

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -42,10 +42,18 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
   edges.clear();
 
   if (segment == m_startSegment)
-    return GetEdgesListFromStart(segment, isOutgoing, edges);
+  {
+    CHECK(isOutgoing, ("Only forward wave of A* should get edges from start. Backward wave should "
+                       "stop when first time visit the |m_startSegment|."));
+    return GetEdgesListFromStart(segment, edges);
+  }
 
   if (segment == m_finishSegment)
-    return GetEdgesListToFinish(segment, isOutgoing, edges);
+  {
+    CHECK(!isOutgoing, ("Only backward wave of A* should get edges to finish. Forward wave should "
+                        "stop when first time visit the |m_finishSegment|."));
+    return GetEdgesListToFinish(segment, edges);
+  }
 
   if (!m_starter.IsRoutingOptionsGood(segment))
     return;
@@ -67,10 +75,8 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
     crossMwmGraph.GetIngoingEdgeList(segment, edges);
 }
 
-void LeapsGraph::GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
-                                       std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges)
 {
-  CHECK(isOutgoing, ());
   for (auto const mwmId : m_starter.GetStartEnding().m_mwmIds)
   {
     // Connect start to all exits (|isEnter| == false).
@@ -85,10 +91,8 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
   }
 }
 
-void LeapsGraph::GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
-                                      std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges)
 {
-  CHECK(!isOutgoing, ());
   for (auto const mwmId : m_starter.GetFinishEnding().m_mwmIds)
   {
     // Connect finish to all enters (|isEnter| == true).

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -32,10 +32,8 @@ public:
 private:
   void GetEdgesList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
-  void GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
-                             std::vector<SegmentEdge> & edges);
-  void GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
-                             std::vector<SegmentEdge> & edges);
+  void GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges);
+  void GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges);
 
   m2::PointD m_startPoint;
   m2::PointD m_finishPoint;

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -17,7 +17,7 @@ class LeapsGraph : public AStarGraph<Segment, SegmentEdge, RouteWeight>
 public:
   explicit LeapsGraph(IndexGraphStarter & starter);
 
-  // AStarGraph overridings:
+  // AStarGraph overrides:
   // @{
   void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
   void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
@@ -25,14 +25,23 @@ public:
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
-  m2::PointD const & GetPoint(Segment const & segment, bool front) const;
+  m2::PointD const & GetPoint(Segment const & segment, bool front);
+  Segment const & GetStartSegment() const;
+  Segment const & GetFinishSegment() const;
 
 private:
   void GetEdgesList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
-  void GetEdgesListForStart(Segment const & segment, bool isOutgoing,
-                            std::vector<SegmentEdge> & edges);
-  void GetEdgesListForFinish(Segment const & segment, bool isOutgoing,
+
+  void GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
                              std::vector<SegmentEdge> & edges);
+  void GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
+                             std::vector<SegmentEdge> & edges);
+
+  m2::PointD m_startPoint;
+  m2::PointD m_finishPoint;
+
+  Segment m_startSegment;
+  Segment m_finishSegment;
 
   IndexGraphStarter & m_starter;
 };


### PR DESCRIPTION
На самом деле это результаты двух оптимизаций - хранение стартовой и финишной точки как ms::LatLon, а не m2::PointD + bidirectional LeapsOnly
в этом PR будет пока только второе, первую оптимизацию я выкачу после того, как этот PR помержат

Результаты сравнения прошлой версии с новой на выборке из 100к маршрутов, где были оставлены только маршруты, которые строятся в режиме LeapsOnly (таких оказалось ~18k)

Для всех маршрутов был выбран timeout = 60s.

**Average time: 6.93344s -> 5.62323s (-18.85%)**

# График "сколько процентов маршрутов мы строим за N секунд"
![image](https://user-images.githubusercontent.com/17534533/70543484-7ff65980-1b7b-11ea-8c19-9412a645701f.png)

# Распределение ошибок
Тут ничего интересного, кроме того, что хуже не стало. Часть маршрутов перестала be Cancelled (== timeout), также кол-во маршрутов "RouteNotFound" уменьшилось. Почему - я не стал разбираться, но видимо из-за того же из-за чего ETA не совпадают иногда (об этом ниже)
![image](https://user-images.githubusercontent.com/17534533/70543549-a1574580-1b7b-11ea-9c4f-a0aa12078199.png)

# Распределение "насколько процентов ускорилось/замедлилось"
Как видно, время построения большинства маршрутов ускоряется 
![image](https://user-images.githubusercontent.com/17534533/70543879-34907b00-1b7c-11ea-98e8-5baf25297fe5.png)

# Consistency 
Если поставить проверку на равенство ETA, то неожиданно случаются несовпадения.
Происходит это потому что оценка ребра "Старт -> выход из стартовой mwm" и "Вход в финишную mwm -> Финиш" работает так:
```
distance(A, B) / (maxSpeed / 2.0)
```
Также, раньше при достижении финишной mwm мы сразу строили ребро до финиша и больше ничего не делали. Теперь, так как обратная волна распространяется также из Финиша, мы смотрим на большее кол-во ребер около финишной mwm и поэтому находим более "оптимальный" (учитывая, что мы плохо оцениваем ребро от Старта и до Финиша). Есть небольшое кол-во маршрутов, на которые такое поведение как-то влияет, а именно:
```
из 17903 маршрутов:
17001 (95%) - строится без изменений
902 (5%) - с изменениями
```

# Распределение разниц ETA (old - new), нули выкинуты
Как видно из графика, большинство маршрутов становится короче по ETA. Поэтому такое поведение неконсистентности нам на руку.
![image](https://user-images.githubusercontent.com/17534533/70544731-a0bfae80-1b7d-11ea-8276-9f6bb8c80407.png)
