### PR TITLE
[Routing] Tune pedestrian and bicycle "climb" penalty.

### DIFF
--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -59,4 +59,12 @@ private:
   double const m_maxWeightSpeedMpS;
   SpeedKMpH const m_offroadSpeedKMpH;
 };
+
+double GetPedestrianClimbPenalty(EdgeEstimator::Purpose purpose, double tangent,
+                                 geometry::Altitude altitudeM);
+double GetBicycleClimbPenalty(EdgeEstimator::Purpose purpose, double tangent,
+                              geometry::Altitude altitudeM);
+double GetCarClimbPenalty(EdgeEstimator::Purpose /* purpose */, double /* tangent */,
+                          geometry::Altitude /* altitude */);
+
 }  // namespace routing

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 347.4, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 301.8, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.
@@ -148,7 +148,7 @@ UNIT_TEST(SpainTenerifeAdejeVilaflor)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents(VehicleType::Bicycle),
       mercator::FromLatLon(28.11984, -16.72592), {0.0, 0.0},
-      mercator::FromLatLon(28.15865, -16.63704), 18019.6 /* expectedTimeSeconds */);
+      mercator::FromLatLon(28.15865, -16.63704), 10787.6 /* expectedTimeSeconds */);
 }
 
 // Test on riding down from Vilaflor (altitude 1400 meters) to Adeje (sea level).
@@ -157,5 +157,5 @@ UNIT_TEST(SpainTenerifeVilaflorAdeje)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents(VehicleType::Bicycle),
       mercator::FromLatLon(28.15865, -16.63704), {0.0, 0.0},
-      mercator::FromLatLon(28.11984, -16.72592), 8868.36 /* expectedTimeSeconds */);
+      mercator::FromLatLon(28.11984, -16.72592), 7979.9 /* expectedTimeSeconds */);
 }

--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -60,9 +60,10 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
-  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnLeft);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 
 UNIT_TEST(RussiaMoscowSalameiNerisNoUTurnBicycleWayTurnTest)

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -269,7 +269,7 @@ UNIT_TEST(CzechPragueHiltonToKarlovMost)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(50.0933, 14.4397), {0., 0.},
-      mercator::FromLatLon(50.0864, 14.4124), 2398.);
+      mercator::FromLatLon(50.0864, 14.4124), 2568.8);
 }
 
 UNIT_TEST(CzechPragueHiltonToNicholasChurch)
@@ -285,7 +285,7 @@ UNIT_TEST(CzechPragueHiltonToKvetniceViewpoint)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(50.0933, 14.4397), {0., 0.},
-      mercator::FromLatLon(50.0806, 14.3973), 4335.);
+      mercator::FromLatLon(50.0806, 14.3973), 4805.1);
 }
 
 UNIT_TEST(RussiaSaintPetersburgMoyka93ToAlexanderColumn)
@@ -524,7 +524,7 @@ UNIT_TEST(RussiaElbrusPriut11)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(43.35254, 42.43788), {0., 0.},
-      mercator::FromLatLon(43.31475, 42.46035), 5998.61 /* expectedTimeSeconds */);
+      mercator::FromLatLon(43.31475, 42.46035), 13708.4 /* expectedTimeSeconds */);
 }
 
 // Test on going straight forward on primary road.

--- a/routing/routing_integration_tests/transit_route_test.cpp
+++ b/routing/routing_integration_tests/transit_route_test.cpp
@@ -44,7 +44,7 @@ UNIT_TEST(Transit_Moscow_NoSubwayTest)
                                   mercator::FromLatLon(55.73470, 37.62617));
   TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
 
-  integration::TestRouteLength(*routeResult.first, 612.664);
+  integration::TestRouteLength(*routeResult.first, 588.9);
 
   CHECK(routeResult.first, ());
   integration::CheckSubwayAbsent(*routeResult.first);

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
   coding_test.cpp
   cross_mwm_connector_test.cpp
   cumulative_restriction_test.cpp
+  edge_estimator_tests.cpp
   fake_graph_test.cpp
   followed_polyline_test.cpp
   index_graph_test.cpp

--- a/routing/routing_tests/edge_estimator_tests.cpp
+++ b/routing/routing_tests/edge_estimator_tests.cpp
@@ -1,0 +1,79 @@
+#include "testing/testing.hpp"
+
+#include "routing/edge_estimator.hpp"
+
+#include "geometry/point_with_altitude.hpp"
+
+#include <cmath>
+
+namespace
+{
+using namespace routing;
+
+double const kTan = 0.1;
+geometry::Altitude const kAlt = 100.0;
+auto const kPurposes = {EdgeEstimator::Purpose::Weight, EdgeEstimator::Purpose::ETA};
+constexpr double kAccuracyEps = 1e-5;
+
+// Climb penalty on plain surface (tangent = 0) must be 1.0 for ETA and Weight estimations.
+UNIT_TEST(ClimbPenalty_ZeroTangent)
+{
+  double const zeroTangent = 0.0;
+
+  for (auto const & purpose : kPurposes)
+  {
+    TEST_EQUAL(GetCarClimbPenalty(purpose, zeroTangent, kAlt), 1.0, ());
+    TEST_EQUAL(GetBicycleClimbPenalty(purpose, zeroTangent, kAlt), 1.0, ());
+    TEST_EQUAL(GetPedestrianClimbPenalty(purpose, zeroTangent, kAlt), 1.0, ());
+  }
+}
+
+// Descent penalty for pedestrians and bicycles must be less then the ascent penalty.
+UNIT_TEST(ClimbPenalty_DescentLessThenAscent)
+{
+  for (auto const & purpose : kPurposes)
+  {
+    double const ascPenaltyPedestrian = GetPedestrianClimbPenalty(purpose, kTan, kAlt);
+    double const descPenaltyPedestrian = GetPedestrianClimbPenalty(purpose, -kTan, kAlt);
+    TEST_LESS(descPenaltyPedestrian, ascPenaltyPedestrian, ());
+
+    double const ascPenaltyBicycle = GetBicycleClimbPenalty(purpose, kTan, kAlt);
+    double const descPenaltyBicycle = GetBicycleClimbPenalty(purpose, -kTan, kAlt);
+    TEST_LESS(descPenaltyBicycle, ascPenaltyBicycle, ());
+  }
+}
+
+// Descent penalty for cars must be equal to the ascent penalty.
+UNIT_TEST(ClimbPenalty_DescentEqualsAscent)
+{
+  for (auto const & purpose : kPurposes)
+  {
+    double const ascPenaltyCar = GetCarClimbPenalty(purpose, kTan, kAlt);
+    double const descPenaltyCar = GetCarClimbPenalty(purpose, -kTan, kAlt);
+    TEST_EQUAL(ascPenaltyCar, 1.0, ());
+    TEST_EQUAL(descPenaltyCar, 1.0, ());
+  }
+}
+
+// Climb penalty high above the sea level (higher then 2.5 km) should be very significant.
+UNIT_TEST(ClimbPenalty_HighAboveSeaLevel)
+{
+  for (auto const & purpose : kPurposes)
+  {
+    double const penalty2500 = GetPedestrianClimbPenalty(purpose, kTan, 2500);
+    double const penalty4000 = GetPedestrianClimbPenalty(purpose, kTan, 4000);
+    double const penalty5500 = GetPedestrianClimbPenalty(purpose, kTan, 5500);
+    double const penalty7000 = GetPedestrianClimbPenalty(purpose, kTan, 7000);
+
+    TEST_GREATER_OR_EQUAL(penalty2500, 2.0, ());
+    TEST_GREATER_OR_EQUAL(penalty4000, penalty2500 + 1.0, ());
+    TEST_GREATER_OR_EQUAL(penalty5500, penalty4000 + 1.0, ());
+    TEST_GREATER_OR_EQUAL(penalty7000, penalty5500 + 1.0, ());
+
+    double const penalty2500Bicyclce = GetBicycleClimbPenalty(purpose, kTan, 2500);
+
+    TEST_GREATER_OR_EQUAL(penalty2500Bicyclce, 6.0, ());
+    TEST_ALMOST_EQUAL_ABS(GetCarClimbPenalty(purpose, kTan, 2500), 1.0, kAccuracyEps, ());
+  }
+}
+}  // namespace


### PR DESCRIPTION
[MAPSME-12329](https://jira.mail.ru/browse/MAPSME-12329)
[MAPSME-11406](https://jira.mail.ru/browse/MAPSME-11406)

PR решает несколько задач:
- Мы одинаково пессимизируем время на маршруте и для расчета веса ребра в A*, и для расчета ETA, который показываем пользователю. **Решение:** теперь для этих двух целей используются разные формулы.
- Мы завышаем ETA для пеших и вело-маршрутов (баг репорты, тикеты, наблюдения на знакомых маршрутах, сравнение ETA с роутингом конкурентов, сравнение с ETA треков от партнера). **Решение:** на данных поставщика хайкинг и вело-треков обучена модель, и в формуле оценки ETA по углу наклона используются ее коэффициенты. 
- Для пеших маршрутов мы выбираем слишком крутые маршруты, даже если доступны более пологие, но немного более длинные. **Решение:** для оценки весов ребер A* используются другие коэффициенты, отличные от полученных из модели. Принцип, по которому они выбирались: последовательно увеличивались коэффициенты от модели, пока маршруты тестовой выборки не стали удовлетворять условиям [MAPSME-12329](https://jira.mail.ru/browse/MAPSME-12329).

На тестовой выборке хайкинг-маршрутов (650 лучших треков) ошибка составляет:
Mean error = 5.3%. Median 9.2. Dispersion 19.9. Была -16.3% (время пессимизировалось).

На тестовой выборке вело-маршрутов  (1038 лучших треков) ошибка составляет:
Mean error = 9.4%. Median 10.1. Dispersion 22.0. Была -14.5% (то есть время пессимизировалось).

Примеры пеших и вело-маршрутов до (скрины из release 9.5) и после PR.

До | После| Комментарий
--- | ---| ---
 <img width="300" src="https://user-images.githubusercontent.com/54934129/73076718-b3910700-3ecf-11ea-91ba-f2231a573f89.jpeg">| <img width="300" src="https://user-images.githubusercontent.com/54934129/73077378-1afb8680-3ed1-11ea-98fa-d6bcde944ccd.jpeg"> | Москва, Воробьевы горы. Сокращено ETA. 2ГИС оценивает время как 8 минут. ETA 17 min -> 10 min. 
<img width="300" src="https://user-images.githubusercontent.com/54934129/73076818-f226c180-3ecf-11ea-89a5-50b23a08e08d.jpeg"> | <img width="300" src="https://user-images.githubusercontent.com/54934129/73080175-7714d980-3ed6-11ea-909d-cad20876d24f.jpeg"> | Выполнено пожелание из тикета MAPSME-12329: ведем по более пологому маршруту. ETA 4h 56 min -> 3h 21 min. 8.1 km -> 7.3 km.
<img width="300" src="https://user-images.githubusercontent.com/54934129/73076837-fc48c000-3ecf-11ea-8c2d-d9941d5f0c1d.jpeg"> |  <img width="300" src="https://user-images.githubusercontent.com/54934129/73080199-8136d800-3ed6-11ea-870a-d9943c4c10e3.jpeg"> | Снижен ETA по тикету MAPSME-11406. Гугл оценивает время как 1ч 11 минут, ОСМ -   1ч 43 минут. ETA 6h 36 min -> 4h 4 min.
<img width="300" src="https://user-images.githubusercontent.com/54934129/73165603-2c2cd900-4105-11ea-858c-16fc6451bb16.jpeg"> | <img width="300" src="https://user-images.githubusercontent.com/54934129/73165589-2636f800-4105-11ea-8be3-6d3e916dd429.jpeg"> | Спуск возле Эльбруса. 5.2 км, более точная оценка ETA: при разнице высот в 1.55 км время стало 3 ч 48 м вместо 1 ч 39 м.
<img width="300" src="https://user-images.githubusercontent.com/54934129/73076860-0b2f7280-3ed0-11ea-97ae-2b049a50aeed.jpeg"> | <img width="300" src="https://user-images.githubusercontent.com/54934129/73080229-8a27a980-3ed6-11ea-87d4-f2972a00c426.jpeg"> | Более адекватный ETA для проверенного вело-маршрута: ETA 29 min -> 24 min.
<img width="300" src="https://user-images.githubusercontent.com/54934129/73166028-123fc600-4106-11ea-9ed5-4cbef6bfb7ef.jpg"> | <img width="300" src="https://user-images.githubusercontent.com/54934129/73166004-094ef480-4106-11ea-9705-8a1c668da032.jpg"> | Более адекватный ETA для проверенного пешего маршрута: ETA 1 h 17 min -> 1 h 7 min.
















