### PR TITLE
[Android] Pedestrian routing: change chaotic arrow to next turn.

### DIFF
--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -221,19 +221,12 @@ public class NavigationController implements TrafficManager.TrafficCallback, Vie
 
   private void updatePedestrian(RoutingInfo info)
   {
-    Location next = info.pedestrianNextDirection;
-    Location location = LocationHelper.INSTANCE.getSavedLocation();
-    DistanceAndAzimut da = Framework.nativeGetDistanceAndAzimuthFromLatLon(next.getLatitude(), next.getLongitude(),
-                                                                           location.getLatitude(), location.getLongitude(),
-                                                                           mNorth);
-    String[] splitDistance = da.getDistance().split(" ");
+    info.carDirection.setTurnDrawable(mNextTurnImage);
     mNextTurnDistance.setText(Utils.formatUnitsText(mFrame.getContext(),
-                                                    R.dimen.text_size_nav_number,
-                                                    R.dimen.text_size_nav_dimension,
-                                                    splitDistance[0],
-                                                    splitDistance[1]));
-    if (info.pedestrianTurnDirection != null)
-      RoutingInfo.PedestrianTurnDirection.setTurnDrawable(mNextTurnImage, da);
+            R.dimen.text_size_nav_number,
+            R.dimen.text_size_nav_dimension,
+            info.distToTurn,
+            info.turnUnits));
   }
 
   public void updateNorth(double north)

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -20,8 +20,6 @@ UIImage * image(routing::turns::CarDirection t, bool isNextTurn)
 {
   if (![MWMLocationManager lastLocation])
     return nil;
-  if ([MWMRouter type] == MWMRouterTypePedestrian)
-    return [UIImage imageNamed:@"ic_direction"];
 
   using namespace routing::turns;
   NSString * imageName;


### PR DESCRIPTION
Замена стрелки (азимут по направлению) на "следующий маневр" для режима пешей навигации.

Причина: стрелка хаотичная; непонятно, на что она указывает. Сбивает с толку.
PR: заменить "следующим маневром" по аналогии с авто-роутингом.

Было:
![image](https://user-images.githubusercontent.com/54934129/70795363-b537bd00-1db0-11ea-85a7-7e180460fbc0.png)

Стало:
![image](https://user-images.githubusercontent.com/54934129/70795415-ce406e00-1db0-11ea-9913-0148fb72b614.png)

