### PR TITLE
[routing] rid of m2::PointD in routing

### DIFF
--- a/base/buffer_vector.hpp
+++ b/base/buffer_vector.hpp
@@ -22,6 +22,7 @@ template <class T, size_t N> class buffer_vector
 {
 private:
   enum { USE_DYNAMIC = N + 1 };
+  // TODO (@gmoryes) consider std::aligned_storage
   T m_static[N];
   size_t m_size;
   std::vector<T> m_dynamic;

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -162,7 +162,7 @@ bool RestrictionCollector::FeatureHasPointWithCoords(uint32_t featureId,
   for (uint32_t i = 0; i < pointsCount; ++i)
   {
     static double constexpr kEps = 1e-5;
-    if (base::AlmostEqualAbs(roadGeometry.GetPoint(i), coords, kEps))
+    if (base::AlmostEqualAbs(mercator::FromLatLon(roadGeometry.GetPoint(i)), coords, kEps))
       return true;
   }
 
@@ -257,8 +257,10 @@ bool RestrictionCollector::CheckAndProcessUTurn(Restriction::Type & restrictionT
     // According to the wiki: via must be at the end or at the beginning of feature.
     // https://wiki.openstreetmap.org/wiki/Relation:restriction
     static auto constexpr kEps = 1e-5;
-    bool const viaIsFirstNode = base::AlmostEqualAbs(coords, road.GetPoint(0), kEps);
-    bool const viaIsLastNode = base::AlmostEqualAbs(coords, road.GetPoint(n - 1), kEps);
+    bool const viaIsFirstNode =
+        base::AlmostEqualAbs(coords, mercator::FromLatLon(road.GetPoint(0)), kEps);
+    bool const viaIsLastNode =
+        base::AlmostEqualAbs(coords, mercator::FromLatLon(road.GetPoint(n - 1)), kEps);
 
     if (viaIsFirstNode)
     {

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -168,7 +168,7 @@ public:
   Segment GetStartSegment() const { return m_start; }
   Segment GetFinishSegment() const { return {}; }
   bool ConvertToReal(Segment const & /* segment */) const { return false; }
-  RouteWeight HeuristicCostEstimate(Segment const & /* from */, m2::PointD const & /* to */)
+  RouteWeight HeuristicCostEstimate(Segment const & /* from */, ms::LatLon const & /* to */)
   {
     CHECK(false, ("This method exists only for compatibility with IndexGraphStarterJoints"));
     return GetAStarWeightZero<RouteWeight>();
@@ -195,7 +195,7 @@ public:
   RouteWeight GetAStarWeightEpsilon() { return RouteWeight(0.0); }
   // @}
 
-  m2::PointD const & GetPoint(Segment const & s, bool forward)
+  ms::LatLon const & GetPoint(Segment const & s, bool forward)
   {
     return m_graph.GetPoint(s, forward);
   }

--- a/geometry/latlon.cpp
+++ b/geometry/latlon.cpp
@@ -1,6 +1,7 @@
 #include "latlon.hpp"
 
 #include <sstream>
+#include <tuple>
 
 namespace ms
 {
@@ -14,7 +15,12 @@ double const LatLon::kMaxLon = 180.0;
 // So if you want to change the value you should change the code of processing the statistics.
 LatLon const LatLon::kInvalidValue = LatLon(-180.0, -180.0);
 
-bool LatLon::operator==(ms::LatLon const & p) const { return m_lat == p.m_lat && m_lon == p.m_lon; }
+bool LatLon::operator==(ms::LatLon const & rhs) const { return m_lat == rhs.m_lat && m_lon == rhs.m_lon; }
+
+bool LatLon::operator<(ms::LatLon const & rhs) const
+{
+  return std::tie(m_lat, m_lon) < std::tie(rhs.m_lat, rhs.m_lon);
+}
 
 bool LatLon::EqualDxDy(LatLon const & p, double eps) const
 {
@@ -29,3 +35,12 @@ std::string DebugPrint(LatLon const & t)
   return out.str();
 }
 }  // namespace ms
+
+namespace base
+{
+bool AlmostEqualAbs(ms::LatLon const & ll1, ms::LatLon const & ll2, double const & eps)
+{
+  return base::AlmostEqualAbs(ll1.m_lat, ll2.m_lat, eps) &&
+         base::AlmostEqualAbs(ll1.m_lon, ll2.m_lon, eps);
+}
+}  // namespace base

--- a/geometry/latlon.hpp
+++ b/geometry/latlon.hpp
@@ -24,7 +24,8 @@ public:
 
   static LatLon Zero() { return LatLon(0.0, 0.0); }
 
-  bool operator==(ms::LatLon const & p) const;
+  bool operator==(ms::LatLon const & rhs) const;
+  bool operator<(ms::LatLon const & rhs) const;
 
   bool EqualDxDy(LatLon const & p, double eps) const;
 
@@ -36,3 +37,8 @@ public:
 
 std::string DebugPrint(LatLon const & t);
 }  // namespace ms
+
+namespace base
+{
+bool AlmostEqualAbs(ms::LatLon const & ll1, ms::LatLon const & ll2, double const & eps);
+}  // namespace base

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -70,6 +70,8 @@ set(
   joint_segment.cpp
   joint_segment.hpp
   junction_visitor.hpp
+  latlon_with_altitude.cpp
+  latlon_with_altitude.hpp
   leaps_graph.cpp
   leaps_graph.hpp
   leaps_postprocessor.cpp

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -148,7 +148,7 @@ void AsyncRouter::RouterDelegateProxy::OnProgress(float progress)
   }
 }
 
-void AsyncRouter::RouterDelegateProxy::OnPointCheck(m2::PointD const & pt)
+void AsyncRouter::RouterDelegateProxy::OnPointCheck(ms::LatLon const & pt)
 {
 #ifdef SHOW_ROUTE_DEBUG_MARKS
   PointCheckCallback onPointCheck = nullptr;
@@ -161,7 +161,7 @@ void AsyncRouter::RouterDelegateProxy::OnPointCheck(m2::PointD const & pt)
       return;
 
     onPointCheck = m_onPointCheck;
-    point = pt;
+    point = mercator::FromLatLon(pt);
   }
 
   GetPlatform().RunTask(Platform::Thread::Gui, [onPointCheck, point]() { onPointCheck(point); });

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -87,7 +87,7 @@ private:
 
   private:
     void OnProgress(float progress);
-    void OnPointCheck(m2::PointD const & pt);
+    void OnPointCheck(ms::LatLon const & pt);
 
     std::mutex m_guard;
     ReadyCallbackOwnership const m_onReadyOwnership;

--- a/routing/base/astar_progress.hpp
+++ b/routing/base/astar_progress.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "geometry/point2d.hpp"
+#include "geometry/latlon.hpp"
 
 #include <list>
 
@@ -9,11 +9,11 @@ namespace routing
 class AStarSubProgress
 {
 public:
-  AStarSubProgress(m2::PointD const & start, m2::PointD const & finish, double contributionCoef);
+  AStarSubProgress(ms::LatLon const & start, ms::LatLon const & finish, double contributionCoef);
 
   explicit AStarSubProgress(double contributionCoef);
 
-  double UpdateProgress(m2::PointD const & current, m2::PointD const & finish);
+  double UpdateProgress(ms::LatLon const & current, ms::LatLon const & finish);
   /// \brief Some |AStarSubProgress| could have their own subProgresses (next item in
   /// AStarProgress::m_subProgresses after current), in order to return true progress
   /// back to the upper level of subProgresses, we should do progress backpropagation of
@@ -30,8 +30,8 @@ private:
   double m_forwardDistance = 0.0;
   double m_backwardDistance = 0.0;
 
-  m2::PointD m_startPoint;
-  m2::PointD m_finishPoint;
+  ms::LatLon m_startPoint;
+  ms::LatLon m_finishPoint;
 };
 
 class AStarProgress
@@ -46,13 +46,13 @@ public:
   void PushAndDropLastSubProgress();
   void DropLastSubProgress();
   void AppendSubProgress(AStarSubProgress const & subProgress);
-  double UpdateProgress(m2::PointD const & current, m2::PointD const & end);
+  double UpdateProgress(ms::LatLon const & current, ms::LatLon const & end);
 
 private:
   using ListItem = std::list<AStarSubProgress>::iterator;
 
-  double UpdateProgressImpl(ListItem subProgress, m2::PointD const & current,
-                            m2::PointD const & end);
+  double UpdateProgressImpl(ListItem subProgress, ms::LatLon const & current,
+                            ms::LatLon const & end);
 
   // This value is in range: [0, 1].
   double m_lastPercentValue = 0.0;

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -30,17 +30,17 @@ public:
   EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH);
   virtual ~EdgeEstimator() = default;
 
-  double CalcHeuristic(m2::PointD const & from, m2::PointD const & to) const;
+  double CalcHeuristic(ms::LatLon const & from, ms::LatLon const & to) const;
   // Estimates time in seconds it takes to go from point |from| to point |to| along a leap (fake)
   // edge |from|-|to| using real features.
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
   // (|from|, |to|) in road graph.
   // Note 2. The result of the method should be less or equal to CalcHeuristic(|from|, |to|).
   // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
-  double CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const;
+  double CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const;
 
   // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake edge.
-  double CalcOffroad(m2::PointD const & from, m2::PointD const & to, Purpose purpose) const;
+  double CalcOffroad(ms::LatLon const & from, ms::LatLon const & to, Purpose purpose) const;
 
   virtual double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road,
                                    Purpose purpose) const = 0;

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/segment.hpp"
 
+#include "geometry/latlon.hpp"
 #include "geometry/point2d.hpp"
-#include "geometry/point_with_altitude.hpp"
 
 #include <vector>
 
@@ -17,9 +18,9 @@ class WorldGraph;
 struct Projection final
 {
   Projection(Segment const & segment, bool isOneWay,
-             geometry::PointWithAltitude const & segmentFront,
-             geometry::PointWithAltitude const & segmentBack,
-             geometry::PointWithAltitude const & junction)
+             LatLonWithAltitude const & segmentFront,
+             LatLonWithAltitude const & segmentBack,
+             LatLonWithAltitude const & junction)
     : m_segment(segment)
     , m_isOneWay(isOneWay)
     , m_segmentFront(segmentFront)
@@ -30,14 +31,14 @@ struct Projection final
 
   Segment m_segment;
   bool m_isOneWay = false;
-  geometry::PointWithAltitude m_segmentFront;
-  geometry::PointWithAltitude m_segmentBack;
-  geometry::PointWithAltitude m_junction;
+  LatLonWithAltitude m_segmentFront;
+  LatLonWithAltitude m_segmentBack;
+  LatLonWithAltitude m_junction;
 };
 
 struct FakeEnding final
 {
-  geometry::PointWithAltitude m_originJunction;
+  LatLonWithAltitude m_originJunction;
   std::vector<Projection> m_projections;
 };
 

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/road_graph.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
 
-#include "geometry/point2d.hpp"
-#include "geometry/point_with_altitude.hpp"
+#include "geometry/latlon.hpp"
 
 #include "base/visitor.hpp"
 
@@ -25,8 +25,8 @@ public:
     PartOfReal,
   };
 
-  FakeVertex(NumMwmId numMwmId, geometry::PointWithAltitude const & from,
-             geometry::PointWithAltitude const & to, Type type)
+  FakeVertex(NumMwmId numMwmId, LatLonWithAltitude const & from,
+             LatLonWithAltitude const & to, Type type)
     : m_numMwmId(numMwmId), m_from(from), m_to(to), m_type(type)
   {
   }
@@ -41,14 +41,14 @@ public:
 
   bool operator<(FakeVertex const & rhs) const
   {
-    return std::tie(m_numMwmId, m_from, m_to, m_type) <
-           std::tie(rhs.m_numMwmId, rhs.m_from, rhs.m_to, rhs.m_type);
+    return std::tie(m_type, m_from, m_to, m_numMwmId) <
+           std::tie(rhs.m_type, rhs.m_from, rhs.m_to,rhs.m_numMwmId);
   }
 
-  geometry::PointWithAltitude const & GetJunctionFrom() const { return m_from; }
-  m2::PointD const & GetPointFrom() const { return m_from.GetPoint(); }
-  geometry::PointWithAltitude const & GetJunctionTo() const { return m_to; }
-  m2::PointD const & GetPointTo() const { return m_to.GetPoint(); }
+  LatLonWithAltitude const & GetJunctionFrom() const { return m_from; }
+  ms::LatLon const & GetPointFrom() const { return m_from.GetLatLon(); }
+  LatLonWithAltitude const & GetJunctionTo() const { return m_to; }
+  ms::LatLon const & GetPointTo() const { return m_to.GetLatLon(); }
   Type GetType() const { return m_type; }
 
   DECLARE_VISITOR(visitor(m_numMwmId, "m_numMwmId"), visitor(m_from, "m_from"),
@@ -59,8 +59,8 @@ private:
   // Note. It's important to know which mwm contains the FakeVertex if it is located
   // near an mwm borders along road features which are duplicated.
   NumMwmId m_numMwmId = kFakeNumMwmId;
-  geometry::PointWithAltitude m_from;
-  geometry::PointWithAltitude m_to;
+  LatLonWithAltitude m_from;
+  LatLonWithAltitude m_to;
   Type m_type = Type::PureFake;
 };
 

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/city_roads.hpp"
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/maxspeeds.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/road_point.hpp"
@@ -11,8 +12,7 @@
 
 #include "indexer/feature_altitude.hpp"
 
-#include "geometry/point2d.hpp"
-#include "geometry/point_with_altitude.hpp"
+#include "geometry/latlon.hpp"
 
 #include "base/buffer_vector.hpp"
 #include "base/fifo_cache.hpp"
@@ -43,13 +43,13 @@ public:
   HighwayType GetHighwayType() const { return *m_highwayType; }
   bool IsPassThroughAllowed() const { return m_isPassThroughAllowed; }
 
-  geometry::PointWithAltitude const & GetJunction(uint32_t junctionId) const
+  LatLonWithAltitude const & GetJunction(uint32_t junctionId) const
   {
     ASSERT_LESS(junctionId, m_junctions.size(), ());
     return m_junctions[junctionId];
   }
 
-  m2::PointD const & GetPoint(uint32_t pointId) const { return GetJunction(pointId).GetPoint(); }
+  ms::LatLon const & GetPoint(uint32_t pointId) const { return GetJunction(pointId).GetLatLon(); }
 
   uint32_t GetPointsCount() const { return static_cast<uint32_t>(m_junctions.size()); }
 
@@ -81,7 +81,7 @@ private:
 
   double GetRoadLengthM() const;
 
-  buffer_vector<geometry::PointWithAltitude, 32> m_junctions;
+  buffer_vector<LatLonWithAltitude, 32> m_junctions;
   SpeedKMpH m_forwardSpeed;
   SpeedKMpH m_backwardSpeed;
   boost::optional<HighwayType> m_highwayType;
@@ -142,7 +142,7 @@ public:
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.
-  m2::PointD const & GetPoint(RoadPoint const & rp)
+  ms::LatLon const & GetPoint(RoadPoint const & rp)
   {
     return GetRoad(rp.GetFeatureId()).GetPoint(rp.GetPointId());
   }

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -134,7 +134,6 @@ void IndexGraph::GetEdgeList(JointSegment const & parentJoint,
   vector<uint32_t> lastPoints;
   GetLastPointsForJoint(possibleChildren, isOutgoing, lastPoints);
 
-
   ReconstructJointSegment(parentJoint, parent, possibleChildren, lastPoints,
                           isOutgoing, edges, parentWeights, parents);
 }
@@ -377,8 +376,8 @@ void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bo
   if (m_roadAccess.GetPointType(rp) == RoadAccess::Type::No)
     return;
 
-  RouteWeight weight = CalculateEdgeWeight(EdgeEstimator::Purpose::Weight, isOutgoing, from, to);
-  edges.emplace_back(to, std::move(weight));
+  auto const weight = CalculateEdgeWeight(EdgeEstimator::Purpose::Weight, isOutgoing, from, to);
+  edges.emplace_back(to, weight);
 }
 
 IndexGraph::PenaltyData IndexGraph::GetRoadPenaltyData(Segment const & segment)

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -101,7 +101,7 @@ public:
                              std::vector<uint32_t> & lastPoints);
 
   WorldGraphMode GetMode() const;
-  m2::PointD const & GetPoint(Segment const & segment, bool front)
+  ms::LatLon const & GetPoint(Segment const & segment, bool front)
   {
     return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
   }

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -9,14 +9,13 @@
 #include "routing/fake_vertex.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/joint.hpp"
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/route_point.hpp"
 #include "routing/route_weight.hpp"
 #include "routing/segment.hpp"
 #include "routing/world_graph.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
-
-#include "geometry/point_with_altitude.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -56,18 +55,18 @@ public:
 
   WorldGraph & GetGraph() const { return m_graph; }
   WorldGraphMode GetMode() const { return m_graph.GetMode(); }
-  geometry::PointWithAltitude const & GetStartJunction() const;
-  geometry::PointWithAltitude const & GetFinishJunction() const;
+  LatLonWithAltitude const & GetStartJunction() const;
+  LatLonWithAltitude const & GetFinishJunction() const;
   Segment GetStartSegment() const { return GetFakeSegment(m_start.m_id); }
   Segment GetFinishSegment() const { return GetFakeSegment(m_finish.m_id); }
   // If segment is real returns true and does not modify segment.
   // If segment is part of real converts it to real and returns true.
   // Otherwise returns false and does not modify segment.
   bool ConvertToReal(Segment & segment) const;
-  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) const;
-  geometry::PointWithAltitude const & GetRouteJunction(std::vector<Segment> const & route,
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
+  LatLonWithAltitude const & GetRouteJunction(std::vector<Segment> const & route,
                                                        size_t pointIndex) const;
-  m2::PointD const & GetPoint(Segment const & segment, bool front) const;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front) const;
 
   bool IsRoutingOptionsGood(Segment const & segment) const;
   RoutingOptions GetRoutingOptions(Segment const & segment) const;
@@ -134,7 +133,7 @@ public:
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
-  RouteWeight HeuristicCostEstimate(Vertex const & from, m2::PointD const & to) const
+  RouteWeight HeuristicCostEstimate(Vertex const & from, ms::LatLon const & to) const
   {
     return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */), to);
   }

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -7,7 +7,8 @@
 #include "routing/joint_segment.hpp"
 #include "routing/segment.hpp"
 
-#include "geometry/point2d.hpp"
+#include "geometry/distance_on_sphere.hpp"
+#include "geometry/latlon.hpp"
 
 #include "base/assert.hpp"
 
@@ -36,7 +37,7 @@ public:
 
   void Init(Segment const & startSegment, Segment const & endSegment);
 
-  m2::PointD const & GetPoint(JointSegment const & jointSegment, bool start);
+  ms::LatLon const & GetPoint(JointSegment const & jointSegment, bool start);
   JointSegment const & GetStartJoint() const { return m_startJoint; }
   JointSegment const & GetFinishJoint() const { return m_endJoint; }
 
@@ -181,8 +182,8 @@ private:
   Segment m_startSegment;
   Segment m_endSegment;
 
-  m2::PointD m_startPoint;
-  m2::PointD m_endPoint;
+  ms::LatLon m_startPoint;
+  ms::LatLon m_endPoint;
 
   // See comments in |GetEdgeList()| about |m_savedWeight|.
   std::map<JointSegment, Weight> m_savedWeight;
@@ -232,7 +233,7 @@ IndexGraphStarterJoints<Graph>::IndexGraphStarterJoints(Graph & graph,
 
   m_endSegment = Segment();
   m_endJoint = JointSegment();
-  m_endPoint = m2::PointD::Zero();
+  m_endPoint = ms::LatLon();
 
   m_init = true;
 }
@@ -302,7 +303,7 @@ RouteWeight IndexGraphStarterJoints<Graph>::HeuristicCostEstimate(JointSegment c
 }
 
 template <typename Graph>
-m2::PointD const &
+ms::LatLon const &
 IndexGraphStarterJoints<Graph>::GetPoint(JointSegment const & jointSegment, bool start)
 {
   Segment segment = jointSegment.IsFake() ? m_fakeJointSegments[jointSegment].GetSegment(start)

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -33,14 +33,14 @@ public:
     if (m_visitCounter % m_visitPeriod != 0)
       return;
 
-    m2::PointD const & pointFrom = m_graph.GetPoint(from, true /* front */);
+    auto const & pointFrom = m_graph.GetPoint(from, true /* front */);
     m_delegate.OnPointCheck(pointFrom);
 
     auto progress = m_progress.lock();
     if (!progress)
       return;
 
-    m2::PointD const & pointTo = m_graph.GetPoint(to, true /* front */);
+    auto const & pointTo = m_graph.GetPoint(to, true /* front */);
     auto const currentPercent = progress->UpdateProgress(pointFrom, pointTo);
     if (currentPercent - m_lastProgressPercent > kProgressInterval)
     {

--- a/routing/latlon_with_altitude.cpp
+++ b/routing/latlon_with_altitude.cpp
@@ -1,0 +1,32 @@
+#include "routing/latlon_with_altitude.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include <sstream>
+#include <utility>
+
+namespace routing
+{
+std::string DebugPrint(LatLonWithAltitude const & latLonWithAltitude)
+{
+  std::stringstream ss;
+  ss << "LatLonWithAltitude(" << DebugPrint(latLonWithAltitude.GetLatLon()) << ", "
+     << latLonWithAltitude.GetAltitude() << ")";
+  return ss.str();
+}
+
+bool LatLonWithAltitude::operator<(LatLonWithAltitude const & rhs) const
+{
+  return m_latlon < rhs.m_latlon;
+}
+
+bool LatLonWithAltitude::operator==(LatLonWithAltitude const & rhs) const
+{
+  return m_latlon == rhs.m_latlon;
+}
+
+geometry::PointWithAltitude LatLonWithAltitude::ToPointWithAltitude() const
+{
+  return geometry::PointWithAltitude(mercator::FromLatLon(m_latlon), m_altitude);
+}
+}  // namespace routing

--- a/routing/latlon_with_altitude.hpp
+++ b/routing/latlon_with_altitude.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "geometry/latlon.hpp"
+#include "geometry/point_with_altitude.hpp"
+
+#include <string>
+
+namespace routing
+{
+class LatLonWithAltitude
+{
+public:
+  LatLonWithAltitude() = default;
+  LatLonWithAltitude(ms::LatLon const & latlon, geometry::Altitude altitude)
+    : m_latlon(latlon), m_altitude(altitude)
+  {
+  }
+
+  bool operator==(LatLonWithAltitude const & rhs) const;
+  bool operator<(LatLonWithAltitude const & rhs) const;
+
+  ms::LatLon const & GetLatLon() const { return m_latlon; }
+  geometry::Altitude GetAltitude() const { return m_altitude; }
+
+  geometry::PointWithAltitude ToPointWithAltitude() const;
+
+private:
+  ms::LatLon m_latlon;
+  geometry::Altitude m_altitude = geometry::kDefaultAltitudeMeters;
+};
+
+std::string DebugPrint(LatLonWithAltitude const & latLonWithAltitude);
+}  // namespace routing

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -107,7 +107,7 @@ void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<Segme
   }
 }
 
-m2::PointD const & LeapsGraph::GetPoint(Segment const & segment, bool front)
+ms::LatLon const & LeapsGraph::GetPoint(Segment const & segment, bool front) const
 {
   return m_starter.GetPoint(segment, front);
 }

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -6,7 +6,7 @@
 #include "routing/route_weight.hpp"
 #include "routing/segment.hpp"
 
-#include "geometry/point2d.hpp"
+#include "geometry/latlon.hpp"
 
 #include <vector>
 
@@ -25,9 +25,9 @@ public:
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
-  m2::PointD const & GetPoint(Segment const & segment, bool front);
   Segment const & GetStartSegment() const;
   Segment const & GetFinishSegment() const;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front) const;
 
 private:
   void GetEdgesList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
@@ -35,8 +35,8 @@ private:
   void GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges);
   void GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges);
 
-  m2::PointD m_startPoint;
-  m2::PointD m_finishPoint;
+  ms::LatLon m_startPoint;
+  ms::LatLon m_finishPoint;
 
   Segment m_startSegment;
   Segment m_finishSegment;

--- a/routing/router_delegate.cpp
+++ b/routing/router_delegate.cpp
@@ -7,7 +7,7 @@ namespace routing
 namespace
 {
 void DefaultProgressFn(float /* progress */) {}
-void DefaultPointFn(m2::PointD const & /* point */) {}
+void DefaultPointFn(ms::LatLon const & /* point */) {}
 }  //  namespace
 
 RouterDelegate::RouterDelegate()
@@ -22,7 +22,7 @@ void RouterDelegate::OnProgress(float progress) const
     m_progressCallback(progress);
 }
 
-void RouterDelegate::OnPointCheck(m2::PointD const & point) const
+void RouterDelegate::OnPointCheck(ms::LatLon const & point) const
 {
   if (!m_cancellable.IsCancelled())
     m_pointCallback(point);

--- a/routing/router_delegate.hpp
+++ b/routing/router_delegate.hpp
@@ -1,7 +1,8 @@
 #pragma once
+
 #include "routing/routing_callbacks.hpp"
 
-#include "geometry/point2d.hpp"
+#include "geometry/latlon.hpp"
 
 #include "base/cancellable.hpp"
 #include "base/timer.hpp"
@@ -19,7 +20,7 @@ public:
 
   /// Set routing progress. Waits current progress status from 0 to 100.
   void OnProgress(float progress) const;
-  void OnPointCheck(m2::PointD const & point) const;
+  void OnPointCheck(ms::LatLon const & point) const;
 
   void SetProgressCallback(ProgressCallback const & progressCallback);
   void SetPointCheckCallback(PointCheckCallback const & pointCallback);

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "geometry/latlon.hpp"
 #include "geometry/point2d.hpp"
 
 #include "base/assert.hpp"
@@ -70,7 +71,7 @@ enum class SessionState
 
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;
 using NeedMoreMapsCallback = std::function<void(uint64_t, std::set<std::string> const &)>;
-using PointCheckCallback = std::function<void(m2::PointD const &)>;
+using PointCheckCallback = std::function<void(ms::LatLon const &)>;
 using ProgressCallback = std::function<void(float)>;
 using ReadyCallback = std::function<void(Route const &, RouterResultCode)>;
 using ReadyCallbackOwnership = std::function<void(std::shared_ptr<Route>, RouterResultCode)>;

--- a/routing/routing_tests/astar_progress_test.cpp
+++ b/routing/routing_tests/astar_progress_test.cpp
@@ -8,9 +8,9 @@ using namespace routing;
 
 UNIT_TEST(DirectedAStarProgressCheck)
 {
-  m2::PointD start = m2::PointD(0, 1);
-  m2::PointD finish = m2::PointD(0, 3);
-  m2::PointD middle = m2::PointD(0, 2);
+  ms::LatLon start = ms::LatLon(0.0, 1.0);
+  ms::LatLon finish = ms::LatLon(0.0, 3.0);
+  ms::LatLon middle = ms::LatLon(0.0, 2.0);
 
   AStarProgress progress;
   progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
@@ -28,9 +28,9 @@ UNIT_TEST(DirectedAStarProgressCheck)
 
 UNIT_TEST(DirectedAStarDegradationCheck)
 {
-  m2::PointD start = m2::PointD(0, 1);
-  m2::PointD finish = m2::PointD(0, 3);
-  m2::PointD middle = m2::PointD(0, 2);
+  ms::LatLon start = ms::LatLon(0.0, 1.0);
+  ms::LatLon finish = ms::LatLon(0.0, 3.0);
+  ms::LatLon middle = ms::LatLon(0.0, 2.0);
 
   AStarProgress progressFirst;
   progressFirst.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
@@ -49,10 +49,10 @@ UNIT_TEST(DirectedAStarDegradationCheck)
 
 UNIT_TEST(RangeCheckTest)
 {
-  m2::PointD start = m2::PointD(0, 1);
-  m2::PointD finish = m2::PointD(0, 3);
-  m2::PointD preStart = m2::PointD(0, 0);
-  m2::PointD postFinish = m2::PointD(0, 6);
+  ms::LatLon start = ms::LatLon(0.0, 1.0);
+  ms::LatLon finish = ms::LatLon(0.0, 3.0);
+  ms::LatLon preStart = ms::LatLon(0.0, 0.0);
+  ms::LatLon postFinish = ms::LatLon(0.0, 6.0);
 
   AStarProgress progress;
   progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});
@@ -65,10 +65,10 @@ UNIT_TEST(RangeCheckTest)
 
 UNIT_TEST(BidirectedAStarProgressCheck)
 {
-  m2::PointD start = m2::PointD(0, 0);
-  m2::PointD finish = m2::PointD(0, 4);
-  m2::PointD fWave = m2::PointD(0, 1);
-  m2::PointD bWave = m2::PointD(0, 3);
+  ms::LatLon start = ms::LatLon(0.0, 0.0);
+  ms::LatLon finish = ms::LatLon(0.0, 4.0);
+  ms::LatLon fWave = ms::LatLon(0.0, 1.0);
+  ms::LatLon bWave = ms::LatLon(0.0, 3.0);
 
   AStarProgress progress;
   progress.AppendSubProgress({start, finish, 1.0 /* contributionCoef */});

--- a/routing/routing_tests/cumulative_restriction_test.cpp
+++ b/routing/routing_tests/cumulative_restriction_test.cpp
@@ -391,7 +391,7 @@ UNIT_CLASS_TEST(RestrictionTest, XXGraph_CheckOnlyRestriction)
                               restrictionsNo);
 
   // Check that without restrictions we can find path better.
-  test({start, {2, 0}, {1, 1}, {2, 2}, {3, 1}, finish, finish}, move(restrictionsNo));
-  test({start, {2, 0}, {3, 0}, finish, finish}, RestrictionVec());
+  test({start, {2, 0}, {1, 1}, {2, 2}, {3, 1}, finish}, move(restrictionsNo));
+  test({start, {2, 0}, {3, 0}, finish}, RestrictionVec());
 }
 }  // namespace

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -57,7 +57,8 @@ public:
   // @{
   Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
   {
-    return m_graph->HeuristicCostEstimate(from, to);
+    return m_graph->HeuristicCostEstimate(m_graph->GetPoint(from, true /* front */),
+                                          m_graph->GetPoint(to, true /* front */));
   }
 
   void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -109,16 +109,16 @@ void SingleVehicleWorldGraph::GetEdgeList(JointSegment const & parentJoint,
     CheckAndProcessTransitFeatures(parent, jointEdges, parentWeights, isOutgoing);
 }
 
-geometry::PointWithAltitude const & SingleVehicleWorldGraph::GetJunction(Segment const & segment,
+LatLonWithAltitude const & SingleVehicleWorldGraph::GetJunction(Segment const & segment,
                                                                          bool front)
 {
   return GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId())
          .GetJunction(segment.GetPointId(front));
 }
 
-m2::PointD const & SingleVehicleWorldGraph::GetPoint(Segment const & segment, bool front)
+ms::LatLon const & SingleVehicleWorldGraph::GetPoint(Segment const & segment, bool front)
 {
-  return GetJunction(segment, front).GetPoint();
+  return GetJunction(segment, front).GetLatLon();
 }
 
 bool SingleVehicleWorldGraph::IsOneWay(NumMwmId mwmId, uint32_t featureId)
@@ -131,22 +131,12 @@ bool SingleVehicleWorldGraph::IsPassThroughAllowed(NumMwmId mwmId, uint32_t feat
   return GetRoadGeometry(mwmId, featureId).IsPassThroughAllowed();
 }
 
-RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
-{
-  return HeuristicCostEstimate(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
-}
-
-
-RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(Segment const & from, m2::PointD const & to)
-{
-  return HeuristicCostEstimate(GetPoint(from, true /* front */), to);
-}
-
-RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(m2::PointD const & from,
-                                                           m2::PointD const & to)
+RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(ms::LatLon const & from,
+                                                           ms::LatLon const & to)
 {
   return RouteWeight(m_estimator->CalcHeuristic(from, to));
 }
+
 
 RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment,
                                                        EdgeEstimator::Purpose purpose)
@@ -155,14 +145,14 @@ RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment,
       segment, GetRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()), purpose));
 }
 
-RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(m2::PointD const & from,
-                                                    m2::PointD const & to) const
+RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(ms::LatLon const & from,
+                                                    ms::LatLon const & to) const
 {
   return RouteWeight(m_estimator->CalcLeapWeight(from, to));
 }
 
-RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(m2::PointD const & from,
-                                                       m2::PointD const & to,
+RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(ms::LatLon const & from,
+                                                       ms::LatLon const & to,
                                                        EdgeEstimator::Purpose purpose) const
 {
   return RouteWeight(m_estimator->CalcOffroad(from, to, purpose));

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -43,8 +43,8 @@ public:
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
 
-  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) override;
-  m2::PointD const & GetPoint(Segment const & segment, bool front) override;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) override;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front) override;
 
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;
   bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) override;
@@ -53,13 +53,11 @@ public:
   void SetMode(WorldGraphMode mode) override { m_mode = mode; }
   WorldGraphMode GetMode() const override { return m_mode; }
 
-  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
-  RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
-  RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) override;
+  RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
 
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
-  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
+  RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;
   double CalculateETAWithoutPenalty(Segment const & segment) override;

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -4,6 +4,7 @@
 #include "routing/fake_ending.hpp"
 #include "routing/fake_graph.hpp"
 #include "routing/fake_vertex.hpp"
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route_weight.hpp"
 #include "routing/segment.hpp"
@@ -12,8 +13,6 @@
 #include "transit/transit_types.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
-
-#include "geometry/point_with_altitude.hpp"
 
 #include <cstdint>
 #include <map>
@@ -35,7 +34,7 @@ public:
 
   TransitGraph(NumMwmId numMwmId, std::shared_ptr<EdgeEstimator> estimator);
 
-  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) const;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
   void GetTransitEdges(Segment const & segment, bool isOutgoing,
@@ -59,12 +58,12 @@ private:
   // Adds gate to fake graph. Also adds gate to temporary stopToBack, stopToFront maps used while
   // TransitGraph::Fill.
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
-               std::map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
+               std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
                bool isEnter, StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
   // Adds transit edge to fake graph, returns corresponding transit segment. Also adds gate to
   // temporary stopToBack, stopToFront maps used while TransitGraph::Fill.
   Segment AddEdge(transit::Edge const & edge,
-                  std::map<transit::StopId, geometry::PointWithAltitude> const & stopCoords,
+                  std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
                   StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
   // Adds connections to fake graph.
   void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -72,8 +72,7 @@ void TransitWorldGraph::GetEdgeList(JointSegment const & parentJoint,
   CHECK(false, ("TransitWorldGraph does not support Joints mode."));
 }
 
-geometry::PointWithAltitude const & TransitWorldGraph::GetJunction(Segment const & segment,
-                                                                   bool front)
+LatLonWithAltitude const & TransitWorldGraph::GetJunction(Segment const & segment, bool front)
 {
   if (TransitGraph::IsTransitSegment(segment))
     return GetTransitGraph(segment.GetMwmId()).GetJunction(segment, front);
@@ -82,9 +81,9 @@ geometry::PointWithAltitude const & TransitWorldGraph::GetJunction(Segment const
       .GetJunction(segment.GetPointId(front));
 }
 
-m2::PointD const & TransitWorldGraph::GetPoint(Segment const & segment, bool front)
+ms::LatLon const & TransitWorldGraph::GetPoint(Segment const & segment, bool front)
 {
-  return GetJunction(segment, front).GetPoint();
+  return GetJunction(segment, front).GetLatLon();
 }
 
 bool TransitWorldGraph::IsOneWay(NumMwmId mwmId, uint32_t featureId)
@@ -107,17 +106,7 @@ void TransitWorldGraph::ClearCachedGraphs()
   m_transitLoader->Clear();
 }
 
-RouteWeight TransitWorldGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
-{
-  return HeuristicCostEstimate(GetPoint(from, true /* front */), GetPoint(to, true /* front */));
-}
-
-RouteWeight TransitWorldGraph::HeuristicCostEstimate(Segment const & from, m2::PointD const & to)
-{
-  return HeuristicCostEstimate(GetPoint(from, true /* front */), to);
-}
-
-RouteWeight TransitWorldGraph::HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to)
+RouteWeight TransitWorldGraph::HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to)
 {
   return RouteWeight(m_estimator->CalcHeuristic(from, to));
 }
@@ -135,13 +124,13 @@ RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment,
       segment, GetRealRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()), purpose));
 }
 
-RouteWeight TransitWorldGraph::CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const
+RouteWeight TransitWorldGraph::CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const
 {
   return RouteWeight(m_estimator->CalcLeapWeight(from, to));
 }
 
-RouteWeight TransitWorldGraph::CalcOffroadWeight(m2::PointD const & from,
-                                                 m2::PointD const & to,
+RouteWeight TransitWorldGraph::CalcOffroadWeight(ms::LatLon const & from,
+                                                 ms::LatLon const & to,
                                                  EdgeEstimator::Purpose purpose) const
 {
   return RouteWeight(m_estimator->CalcOffroad(from, to, purpose));

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -15,8 +15,7 @@
 
 #include "transit/transit_types.hpp"
 
-#include "geometry/point2d.hpp"
-#include "geometry/point_with_altitude.hpp"
+#include "geometry/latlon.hpp"
 
 #include <memory>
 #include <vector>
@@ -47,8 +46,8 @@ public:
     return weight.GetWeight() - weight.GetTransitTime() <=
            MaxPedestrianTimeSec(startToFinishDistanceM);
   }
-  geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) override;
-  m2::PointD const & GetPoint(Segment const & segment, bool front) override;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) override;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front) override;
   // All transit features are oneway.
   bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;
   // All transit features are allowed for through passage.
@@ -56,12 +55,12 @@ public:
   void ClearCachedGraphs() override;
   void SetMode(WorldGraphMode mode) override { m_mode = mode; }
   WorldGraphMode GetMode() const override { return m_mode; }
-  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
-  RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) override;
-  RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) override;
+
+  RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
+
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
-  RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const override;
-  RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
+  RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;
   double CalculateETAWithoutPenalty(Segment const & segment) override;

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -5,6 +5,7 @@
 #include "routing/geometry.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/joint_segment.hpp"
+#include "routing/latlon_with_altitude.hpp"
 #include "routing/road_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/routing_options.hpp"
@@ -52,8 +53,8 @@ public:
   // start to finish of the route.
   virtual bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const = 0;
 
-  virtual geometry::PointWithAltitude const & GetJunction(Segment const & segment, bool front) = 0;
-  virtual m2::PointD const & GetPoint(Segment const & segment, bool front) = 0;
+  virtual LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) = 0;
+  virtual ms::LatLon const & GetPoint(Segment const & segment, bool front) = 0;
   virtual bool IsOneWay(NumMwmId mwmId, uint32_t featureId) = 0;
 
   // Checks whether feature is allowed for through passage.
@@ -64,16 +65,14 @@ public:
   virtual void SetMode(WorldGraphMode mode) = 0;
   virtual WorldGraphMode GetMode() const = 0;
 
-  virtual RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) = 0;
-  virtual RouteWeight HeuristicCostEstimate(m2::PointD const & from, m2::PointD const & to) = 0;
-  virtual RouteWeight HeuristicCostEstimate(Segment const & from, m2::PointD const & to) = 0;
+  virtual RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) = 0;
 
   virtual RouteWeight CalcSegmentWeight(Segment const & segment,
                                         EdgeEstimator::Purpose purpose) = 0;
 
-  virtual RouteWeight CalcLeapWeight(m2::PointD const & from, m2::PointD const & to) const = 0;
+  virtual RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const = 0;
 
-  virtual RouteWeight CalcOffroadWeight(m2::PointD const & from, m2::PointD const & to,
+  virtual RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                         EdgeEstimator::Purpose purpose) const = 0;
 
   virtual double CalculateETA(Segment const & from, Segment const & to) = 0;

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -34,8 +34,9 @@ double DistanceToSegment(m2::PointD const & segmentBegin, m2::PointD const & seg
 
 double DistanceToSegment(Segment const & segment, m2::PointD const & point, IndexGraph & indexGraph)
 {
-  return DistanceToSegment(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(false)),
-                           indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(true)), point);
+  return DistanceToSegment(
+      mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(false))),
+      mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(true))), point);
 }
 
 bool EdgesContain(vector<SegmentEdge> const & edges, Segment const & segment)

--- a/track_analyzing/utils.cpp
+++ b/track_analyzing/utils.cpp
@@ -8,7 +8,7 @@
 
 #include "base/file_name_utils.hpp"
 
-#include "geometry/mercator.hpp"
+#include "geometry/distance_on_sphere.hpp"
 
 #include <cstdint>
 
@@ -30,7 +30,7 @@ double CalcSubtrackLength(MatchedTrack::const_iterator begin, MatchedTrack::cons
     if (segment != prevSegment)
     {
       length +=
-          mercator::DistanceOnEarth(
+          ms::DistanceOnEarth(
           geometry.GetPoint(segment.GetRoadPoint(false /* front */)),
           geometry.GetPoint(segment.GetRoadPoint(true /* front */)));
       prevSegment = segment;

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		44E5574A2136EEC900B01439 /* speed_camera_ser_des.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44E557492136EEC800B01439 /* speed_camera_ser_des.hpp */; };
 		44E5574C2136EED000B01439 /* speed_camera_ser_des.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44E5574B2136EED000B01439 /* speed_camera_ser_des.cpp */; };
 		44F45B282136B069001B1618 /* speed_cameras_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44F45B272136B069001B1618 /* speed_cameras_tests.cpp */; };
+		44F4EDC723A78C2E005254C4 /* latlon_with_altitude.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44F4EDC523A78C2D005254C4 /* latlon_with_altitude.cpp */; };
+		44F4EDC823A78C2E005254C4 /* latlon_with_altitude.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44F4EDC623A78C2E005254C4 /* latlon_with_altitude.hpp */; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
@@ -412,6 +414,8 @@
 		44E557492136EEC800B01439 /* speed_camera_ser_des.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_ser_des.hpp; sourceTree = "<group>"; };
 		44E5574B2136EED000B01439 /* speed_camera_ser_des.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera_ser_des.cpp; sourceTree = "<group>"; };
 		44F45B272136B069001B1618 /* speed_cameras_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_cameras_tests.cpp; sourceTree = "<group>"; };
+		44F4EDC523A78C2D005254C4 /* latlon_with_altitude.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = latlon_with_altitude.cpp; sourceTree = "<group>"; };
+		44F4EDC623A78C2E005254C4 /* latlon_with_altitude.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = latlon_with_altitude.hpp; sourceTree = "<group>"; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
@@ -851,6 +855,8 @@
 			isa = PBXGroup;
 			children = (
 				441CC8C523ACF42C008B9A49 /* segment.cpp */,
+				44F4EDC523A78C2D005254C4 /* latlon_with_altitude.cpp */,
+				44F4EDC623A78C2E005254C4 /* latlon_with_altitude.hpp */,
 				56DAC2C72398F3C8000BC50D /* junction_visitor.hpp */,
 				4433A8EA23993BD700E1350B /* leaps_graph.hpp */,
 				4433A8E823993BD200E1350B /* leaps_graph.cpp */,
@@ -1056,6 +1062,7 @@
 				674F9BD71B0A580E00704FFA /* turns_generator.hpp in Headers */,
 				40655E741F8BA46B0065305E /* fake_feature_ids.hpp in Headers */,
 				6753441C1A3F644F00A0A8C3 /* route.hpp in Headers */,
+				44F4EDC823A78C2E005254C4 /* latlon_with_altitude.hpp in Headers */,
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
 				349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */,
 				56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */,
@@ -1365,6 +1372,7 @@
 				5694CECE1EBA25F7004576D3 /* vehicle_mask.cpp in Sources */,
 				0C45D7391F2F75500065C3ED /* routing_settings.cpp in Sources */,
 				56CBED5622E9CE2600D51AF7 /* position_accumulator.cpp in Sources */,
+				44F4EDC723A78C2E005254C4 /* latlon_with_altitude.cpp in Sources */,
 				0C5FEC691DDE193F0017688C /* road_index.cpp in Sources */,
 				0CF709361F05172200D5067E /* checkpoints.cpp in Sources */,
 				671F58BD1B874EC80032311E /* followed_polyline.cpp in Sources */,


### PR DESCRIPTION
Выборка: равномерно 3000 маршрутов из выборки - 100к
Запуск в 1 поток, каждый маршрут строился по 3 раза, время усреднялось

Среднее время построения уменьшилось на **14.6703%**

# Распределение ускорений
![image](https://user-images.githubusercontent.com/17534533/70981209-c856cf80-20c5-11ea-8836-cbc7d66f28ca.png)
# Ошибки
![image](https://user-images.githubusercontent.com/17534533/70981296-f3412380-20c5-11ea-8db7-4795107897a8.png)
