### PR TITLE
[track_analyzing] Adding balance_csv and some other commands to track analyzer.

### DIFF
--- a/track_analyzing/track_analyzer/CMakeLists.txt
+++ b/track_analyzing/track_analyzer/CMakeLists.txt
@@ -4,8 +4,8 @@ include_directories(${OMIM_ROOT}/3party/gflags/src)
 
 set(
   SRC
-  balance_csv_impl.cpp
-  balance_csv_impl.hpp
+  cmd_balance_csv.cpp
+  cmd_balance_csv.hpp
   cmd_cpp_track.cpp
   cmd_gpx.cpp
   cmd_match.cpp

--- a/track_analyzing/track_analyzer/cmd_balance_csv.hpp
+++ b/track_analyzing/track_analyzer/cmd_balance_csv.hpp
@@ -20,42 +20,6 @@ using MwmToDataPointFraction = std::map<std::string, double>;
 
 size_t constexpr kMwmNameCsvColumn = 1;
 
-/// \brief Fills a map |mwmToDataPoints| mwm to DataPoints number according to |tableCsvStream| and
-/// fills |matchedDataPoints| with all the content of |tableCsvStream|.
-void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDataPoints,
-               std::vector<TableRow> & table);
-
-/// \brief Removing every mwm from |checkedMap| and |additionalMap| if it has
-/// |ignoreDataPointsNumber| data points or less in |checkedMap|.
-void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
-                          uint64_t ignoreDataPointNumber);
-
-/// \returns mapping from mwm to fraction of data points contained in the mwm.
-MwmToDataPointFraction GetMwmToDataPointFraction(MwmToDataPoints const & numberMapping);
-
-/// \returns mapping mwm to matched data points fulfilling two conditions:
-/// *  number of data points in the returned mapping is less than or equal to
-///    number of data points in |matchedDataPoints| for every mwm
-/// * distribution defined by |distributionFraction| is kept
-MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
-    MwmToDataPoints const & matchedDataPoints,
-    MwmToDataPointFraction const & distributionFractions);
-
-/// \returns mapping with number of matched data points for every mwm to correspond to |distribution|.
-MwmToDataPoints BalancedDataPointNumber(MwmToDataPoints && distribution,
-                                        MwmToDataPoints && matchedDataPoints,
-                                        uint64_t ignoreDataPointsNumber);
-
-/// \breif Leaves in |table| only number of items according to |balancedDataPointNumbers|.
-/// \note |table| may have a significant size. It may be several tens millions records.
-void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, std::vector<TableRow> & table);
-
-/// \brief Fills |balancedTable| with TableRow(s) according to the distribution set in
-/// |distributionCsvStream|.
-void BalanceDataPoints(std::basic_istream<char> & distributionCsvStream,
-                       std::basic_istream<char> & tableCsvStream, uint64_t ignoreDataPointsNumber,
-                       std::vector<TableRow> & balancedTable);
-
 template <typename MapCont>
 typename MapCont::mapped_type ValueSum(MapCont const & mapCont)
 {
@@ -79,4 +43,46 @@ bool AreKeysEqual(Map1 const & map1, Map2 const & map2)
   }
   return true;
 }
+
+/// \brief Fills a map |mwmToDataPoints| mwm to DataPoints number according to |tableCsvStream| and
+/// fills |matchedDataPoints| with all the content of |tableCsvStream|.
+void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDataPoints,
+               std::vector<TableRow> & table);
+
+/// \brief Removing every mwm from |checkedMap| and |additionalMap| if it has
+/// |ignoreDataPointsNumber| data points or less in |checkedMap|.
+void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
+                          uint64_t ignoreDataPointNumber);
+
+/// \returns mapping from mwm to fraction of data points contained in the mwm.
+MwmToDataPointFraction GetMwmToDataPointFraction(MwmToDataPoints const & numberMapping);
+
+/// \returns mapping mwm to matched data points fulfilling two conditions:
+/// *  number of data points in the returned mapping is less than or equal to
+///    number of data points in |matchedDataPoints| for every mwm
+/// * distribution defined by |distributionFraction| is kept
+MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
+    MwmToDataPoints const & matchedDataPoints,
+    MwmToDataPointFraction const & distributionFractions);
+
+/// \returns mapping with number of matched data points for every mwm to correspond to |distribution|.
+MwmToDataPoints BalancedDataPointNumber(MwmToDataPoints && matchedDataPoints,
+                                        MwmToDataPoints && distribution,
+                                        uint64_t ignoreDataPointsNumber);
+
+/// \breif Leaves in |table| only number of items according to |balancedDataPointNumbers|.
+/// \note |table| may have a significant size. It may be several tens millions records.
+void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, std::vector<TableRow> & table);
+
+/// \brief Fills |balancedTable| with TableRow(s) according to the distribution set in
+/// |distributionCsvStream|.
+void BalanceDataPoints(std::basic_istream<char> & tableCsvStream,
+                       std::basic_istream<char> & distributionCsvStream,
+                       uint64_t ignoreDataPointsNumber, std::vector<TableRow> & balancedTable);
+
+/// \brief Removes some data point for every mwm from |csvPath| to correspond distribution
+/// set in |distributionPath|. If an mwm in |csvPath| contains data points less of equal to
+/// |ignoreDataPointsNumber| than the mwm will not be taken into acount while balancing.
+void CmdBalanceCsv(std::string const & csvPath, std::string const & distributionPath,
+                   uint64_t ignoreDataPointsNumber);
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/cmd_balance_csv.hpp
+++ b/track_analyzing/track_analyzer/cmd_balance_csv.hpp
@@ -2,6 +2,8 @@
 
 #include "track_analyzing/track_analyzer/utils.hpp"
 
+#include "base/logging.hpp"
+
 #include <cstdint>
 #include <map>
 #include <sstream>
@@ -34,14 +36,19 @@ template<typename Map1, typename Map2>
 bool AreKeysEqual(Map1 const & map1, Map2 const & map2)
 {
   if (map1.size() != map2.size())
-    return false;
-
-  for (auto const & kv : map1)
   {
-    if (map2.count(kv.first) == 0)
-      return false;
+    LOG(LINFO,
+        ("AreKeysEqual() returns false. map1.size():", map1.size(), "map2.size()", map2.size()));
+    return false;
   }
-  return true;
+
+  return std::equal(map1.begin(), map1.end(), map2.begin(), [](auto const & kv1, auto const & kv2) {
+    if (kv1.first == kv2.first)
+      return true;
+
+    LOG(LINFO, ("Keys:", kv1.first, "and", kv2.first, "are not equal."));
+    return false;
+  });
 }
 
 /// \brief Fills a map |mwmToDataPoints| mwm to DataPoints number according to |tableCsvStream| and

--- a/track_analyzing/track_analyzer/cmd_match.cpp
+++ b/track_analyzing/track_analyzer/cmd_match.cpp
@@ -165,6 +165,8 @@ void UnzipAndMatch(Iter begin, Iter end, string const & trackExt, Stats & stats)
 
 void CmdMatchDir(string const & logDir, string const & trackExt, string const & inputDistribution)
 {
+  LOG(LINFO,
+      ("Matching dir:", logDir, ". Input distribution will be saved to:", inputDistribution));
   Platform::EFileType fileType = Platform::FILE_TYPE_UNKNOWN;
   Platform::EError const result = Platform::GetFileType(logDir, fileType);
 

--- a/track_analyzing/track_analyzer/cmd_match.cpp
+++ b/track_analyzing/track_analyzer/cmd_match.cpp
@@ -94,11 +94,11 @@ void MatchTracks(MwmToTracks const & mwmToTracks, storage::Storage const & stora
 namespace track_analyzing
 {
 void CmdMatch(string const & logFile, string const & trackFile,
-              shared_ptr<NumMwmIds> const & numMwmIds, Storage const & storage, Stats & stat)
+              shared_ptr<NumMwmIds> const & numMwmIds, Storage const & storage, Stats & stats)
 {
   MwmToTracks mwmToTracks;
   ParseTracks(logFile, numMwmIds, mwmToTracks);
-  stat.AddTracksStats(mwmToTracks, *numMwmIds, storage);
+  stats.AddTracksStats(mwmToTracks, *numMwmIds, storage);
 
   MwmToMatchedTracks mwmToMatchedTracks;
   MatchTracks(mwmToTracks, storage, *numMwmIds, mwmToMatchedTracks);
@@ -109,17 +109,17 @@ void CmdMatch(string const & logFile, string const & trackFile,
   LOG(LINFO, ("Matched tracks were saved to", trackFile));
 }
 
-void CmdMatch(string const & logFile, string const & trackFile)
+void CmdMatch(string const & logFile, string const & trackFile, string const & inputDistribution)
 {
   LOG(LINFO, ("Matching", logFile));
   Storage storage;
   storage.RegisterAllLocalMaps(false /* enableDiffs */);
   shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
 
-  Stats stat;
-  CmdMatch(logFile, trackFile, numMwmIds, storage, stat);
+  Stats stats;
+  CmdMatch(logFile, trackFile, numMwmIds, storage, stats);
   LOG(LINFO, ("DataPoint distribution by mwms and countries."));
-  LOG(LINFO, (stat));
+  LOG(LINFO, (stats));
 }
 
 void UnzipAndMatch(Iter begin, Iter end, string const & trackExt, Stats & stats)
@@ -163,7 +163,7 @@ void UnzipAndMatch(Iter begin, Iter end, string const & trackExt, Stats & stats)
   }
 }
 
-void CmdMatchDir(string const & logDir, string const & trackExt)
+void CmdMatchDir(string const & logDir, string const & trackExt, string const & inputDistribution)
 {
   Platform::EFileType fileType = Platform::FILE_TYPE_UNKNOWN;
   Platform::EError const result = Platform::GetFileType(logDir, fileType);

--- a/track_analyzing/track_analyzer/cmd_match.cpp
+++ b/track_analyzing/track_analyzer/cmd_match.cpp
@@ -118,8 +118,8 @@ void CmdMatch(string const & logFile, string const & trackFile, string const & i
 
   Stats stats;
   CmdMatch(logFile, trackFile, numMwmIds, storage, stats);
-  LOG(LINFO, ("DataPoint distribution by mwms and countries."));
-  LOG(LINFO, (stats));
+  stats.SaveMwmDistributionToCsv(inputDistribution);
+  stats.LogCountries();
 }
 
 void UnzipAndMatch(Iter begin, Iter end, string const & trackExt, Stats & stats)
@@ -218,7 +218,7 @@ void CmdMatchDir(string const & logDir, string const & trackExt, string const & 
   for (auto const & s : stats)
     statSum.Add(s);
 
-  LOG(LINFO, ("DataPoint distribution by mwms and countries."));
-  LOG(LINFO, (statSum));
+  statSum.SaveMwmDistributionToCsv(inputDistribution);
+  statSum.LogCountries();
 }
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/cmd_match.cpp
+++ b/track_analyzing/track_analyzer/cmd_match.cpp
@@ -119,7 +119,7 @@ void CmdMatch(string const & logFile, string const & trackFile, string const & i
   Stats stats;
   CmdMatch(logFile, trackFile, numMwmIds, storage, stats);
   stats.SaveMwmDistributionToCsv(inputDistribution);
-  stats.LogCountries();
+  stats.Log();
 }
 
 void UnzipAndMatch(Iter begin, Iter end, string const & trackExt, Stats & stats)
@@ -219,6 +219,6 @@ void CmdMatchDir(string const & logDir, string const & trackExt, string const & 
     statSum.Add(s);
 
   statSum.SaveMwmDistributionToCsv(inputDistribution);
-  statSum.LogCountries();
+  statSum.Log();
 }
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -315,7 +315,7 @@ public:
       if (!it.first.IsValid())
         continue;
 
-      out << user << "," << countryName << "," << it.first.GetSummary() << ","
+      out << user << "," << mwmName << "," << it.first.GetSummary() << ","
           << it.second.GetSummary() << '\n';
 
       stats.AddDataPoints(mwmName, countryName, it.second.GetDataPointsNumber());

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -386,9 +386,7 @@ namespace track_analyzing
 void CmdTagsTable(string const & filepath, string const & trackExtension, StringFilter mwmFilter,
                   StringFilter userFilter)
 {
-  cout << "user,mwm,hw type,surface type,maxspeed km/h,is city road,is one way,is day,lat lon,distance,time,"
-          "mean speed km/h,turn from smaller to bigger,turn from bigger to smaller,from link,to link,"
-          "intersection with big,intersection with small,intersection with link\n";
+  WriteCsvTableHeader(cout);
 
   storage::Storage storage;
   storage.RegisterAllLocalMaps(false /* enableDiffs */);

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -476,8 +476,6 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
   ForEachTrackFile(filepath, trackExtension, numMwmIds, processTrack);
 
-  LOG(LINFO,
-      ("DataPoint distribution by mwms and countries and match and table commands."));
-  LOG(LINFO, (stats));
+  stats.Log();
 }
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/track_analyzer.cpp
+++ b/track_analyzing/track_analyzer/track_analyzer.cpp
@@ -37,7 +37,9 @@ DEFINE_string_ext(cmd, "",
                   "tracks - prints track statistics\n"
                   "track - prints info about single track\n"
                   "cpptrack - prints track coords to insert them to cpp code\n"
-                  "table - prints csv table based on matched tracks\n"
+                  "table - prints csv table based on matched tracks to stdout\n"
+                  "balance_csv - prints csv table based on csv table set in \"in\" param "
+                  "with a distribution set according to input_distribution param.\n"
                   "gpx - convert raw logs into gpx files\n");
 DEFINE_string_ext(in, "", "input log file name");
 DEFINE_string(out, "", "output track file name");
@@ -45,6 +47,15 @@ DEFINE_string_ext(output_dir, "", "output dir for gpx files");
 DEFINE_string_ext(mwm, "", "short mwm name");
 DEFINE_string_ext(user, "", "user id");
 DEFINE_int32(track, -1, "track index");
+DEFINE_string(
+    input_distribution, "",
+    "path to input data point distribution file. It's a csv file with data point count for "
+    "some mwms. Usage:\n"
+    "- It may be used with match and match_dir command. If so it's a path to save file with "
+    "data point distribution by mwm. If it's empty no file is saved.\n"
+    "- It may be used with table command. If so it's a path of a file with distribution which "
+    "will be used for normalization (balancing) the result of the command."
+    "If it's empty no distribution will be used.");
 
 DEFINE_string(track_extension, ".track", "track files extension");
 DEFINE_bool(no_world_logs, false, "don't print world summary logs");
@@ -81,9 +92,9 @@ namespace track_analyzing
 void CmdCppTrack(string const & trackFile, string const & mwmName, string const & user,
                  size_t trackIdx);
 // Match raw gps logs to tracks.
-void CmdMatch(string const & logFile, string const & trackFile);
+void CmdMatch(string const & logFile, string const & trackFile, string const & inputDistribution);
 // The same as match but applies for the directory with raw logs.
-void CmdMatchDir(string const & logDir, string const & trackExt);
+void CmdMatchDir(string const & logDir, string const & trackExt, string const & inputDistribution);
 // Parse |logFile| and save tracks (mwm name, aloha id, lats, lons, timestamps in seconds in csv).
 void CmdUnmatchedTracks(string const & logFile, string const & trackFileCsv);
 // Print aggregated tracks to csv table.
@@ -112,12 +123,12 @@ int main(int argc, char ** argv)
     if (cmd == "match")
     {
       string const & logFile = Checked_in();
-      CmdMatch(logFile, FLAGS_out.empty() ? logFile + ".track" : FLAGS_out);
+      CmdMatch(logFile, FLAGS_out.empty() ? logFile + ".track" : FLAGS_out, FLAGS_input_distribution);
     }
     else if (cmd == "match_dir")
     {
       string const & logDir = Checked_in();
-      CmdMatchDir(logDir, FLAGS_track_extension);
+      CmdMatchDir(logDir, FLAGS_track_extension, FLAGS_input_distribution);
     }
     else if (cmd == "unmatched_tracks")
     {

--- a/track_analyzing/track_analyzer/track_analyzer.cpp
+++ b/track_analyzing/track_analyzer/track_analyzer.cpp
@@ -58,12 +58,12 @@ DEFINE_string(
     "- It may be used with match and match_dir command. If so it's a path to save file with "
     "data point distribution by mwm. If it's empty no file is saved.\n"
     "- It may be used with balance_csv command. If so it's a path of a file with distribution which "
-    "will be used for normalization (balancing) the result of the command."
-    "If it's empty no distribution will be used.");
+    "will be used for normalization (balancing) the result of the command. It should not be empty.");
 DEFINE_uint64(
-    ignore_datapoints_number, 500,
-    "if the number of datapoints or less is contained in an mwm after matching and tabling the mwm "
-    "will not used for balancing. This param should be used with balance_csv command.");
+    ignore_datapoints_number, 100,
+    "The number of datapoints in an mwm to exclude the mwm from balancing process. If this number "
+    "of datapoints or less number is in an mwm after matching and tabling, the mwm will not used "
+    "for balancing. This param should be used with balance_csv command.");
 
 DEFINE_string(track_extension, ".track", "track files extension");
 DEFINE_bool(no_world_logs, false, "don't print world summary logs");

--- a/track_analyzing/track_analyzer/utils.cpp
+++ b/track_analyzing/track_analyzer/utils.cpp
@@ -104,9 +104,7 @@ void Stats::AddTracksStats(MwmToTracks const & mwmToTracks, NumMwmIds const & nu
 
     NumMwmId const numMwmId = kv.first;
     auto const mwmName = numMwmIds.GetFile(numMwmId).GetName();
-    auto const countryName = storage.GetTopmostParentFor(mwmName);
-    // Note. In case of disputed mwms |countryName| will be empty.
-    AddDataPoints(mwmName, countryName, dataPointNum);
+    AddDataPoints(mwmName, storage, dataPointNum);
   }
 }
 
@@ -115,6 +113,14 @@ void Stats::AddDataPoints(string const & mwmName, string const & countryName,
 {
   m_mwmToTotalDataPoints[mwmName] += dataPointNum;
   m_countryToTotalDataPoints[countryName] += dataPointNum;
+}
+
+void Stats::AddDataPoints(std::string const & mwmName, storage::Storage const & storage,
+                          uint32_t dataPointNum)
+{
+  auto const countryName = storage.GetTopmostParentFor(mwmName);
+  // Note. In case of disputed mwms |countryName| will be empty.
+  AddDataPoints(mwmName, countryName, dataPointNum);
 }
 
 void Stats::SaveMwmDistributionToCsv(string const & csvPath) const
@@ -126,18 +132,10 @@ void Stats::SaveMwmDistributionToCsv(string const & csvPath) const
   MappingToCsv("mwm", m_mwmToTotalDataPoints, false /* printPercentage */, ss);
 }
 
-void Stats::LogMwms() const
+void Stats::Log() const
 {
-  ostringstream ss;
-  PrintMap("mwm", "Mwm to total data points number:", m_mwmToTotalDataPoints, ss);
-  LOG(LINFO, (ss.str()));
-}
-
-void Stats::LogCountries() const
-{
-  ostringstream ss;
-  PrintMap("country", "Country name to data points number:", m_countryToTotalDataPoints, ss);
-  LOG(LINFO, (ss.str()));
+  LogMwms();
+  LogCountries();
 }
 
 Stats::NameToCountMapping const & Stats::GetMwmToTotalDataPointsForTesting() const
@@ -148,6 +146,22 @@ Stats::NameToCountMapping const & Stats::GetMwmToTotalDataPointsForTesting() con
 Stats::NameToCountMapping const & Stats::GetCountryToTotalDataPointsForTesting() const
 {
   return m_countryToTotalDataPoints;
+}
+
+void Stats::LogMwms() const
+{
+  ostringstream ss;
+  LOG(LINFO, ("\n"));
+  PrintMap("mwm", "Mwm to total data points number:", m_mwmToTotalDataPoints, ss);
+  LOG(LINFO, (ss.str()));
+}
+
+void Stats::LogCountries() const
+{
+  ostringstream ss;
+  LOG(LINFO, ("\n"));
+  PrintMap("country", "Country name to data points number:", m_countryToTotalDataPoints, ss);
+  LOG(LINFO, (ss.str()));
 }
 
 void MappingToCsv(string const & keyName, Stats::NameToCountMapping const & mapping,

--- a/track_analyzing/track_analyzer/utils.cpp
+++ b/track_analyzing/track_analyzer/utils.cpp
@@ -117,13 +117,27 @@ void Stats::AddDataPoints(string const & mwmName, string const & countryName,
   m_countryToTotalDataPoints[countryName] += dataPointNum;
 }
 
-void Stats::SaveMwmDistributionToCsv(string const & csvPath)
+void Stats::SaveMwmDistributionToCsv(string const & csvPath) const
 {
   if (csvPath.empty())
     return;
 
   ostringstream ss(csvPath);
   MappingToCsv("mwm", m_mwmToTotalDataPoints, false /* printPercentage */, ss);
+}
+
+void Stats::LogMwms() const
+{
+  ostringstream ss;
+  PrintMap("mwm", "Mwm to total data points number:", m_mwmToTotalDataPoints, ss);
+  LOG(LINFO, (ss.str()));
+}
+
+void Stats::LogCountries() const
+{
+  ostringstream ss;
+  PrintMap("country", "Country name to data points number:", m_countryToTotalDataPoints, ss);
+  LOG(LINFO, (ss.str()));
 }
 
 Stats::NameToCountMapping const & Stats::GetMwmToTotalDataPointsForTesting() const
@@ -205,6 +219,13 @@ void ParseTracks(string const & logFile, shared_ptr<NumMwmIds> const & numMwmIds
   LOG(LINFO, ("Parsing", logFile));
   LogParser parser(numMwmIds, move(mwmTree), dataDir);
   parser.Parse(logFile, mwmToTracks);
+}
+
+void WriteCsvTableHeader(basic_ostream<char> & stream)
+{
+  stream << "user,mwm,hw type,surface type,maxspeed km/h,is city road,is one way,is day,lat lon,distance,time,"
+            "mean speed km/h,turn from smaller to bigger,turn from bigger to smaller,from link,to link,"
+            "intersection with big,intersection with small,intersection with link\n";
 }
 
 string DebugPrint(Stats const & s)

--- a/track_analyzing/track_analyzer/utils.hpp
+++ b/track_analyzing/track_analyzer/utils.hpp
@@ -37,17 +37,22 @@ public:
   void AddDataPoints(std::string const & mwmName, std::string const & countryName,
                      uint64_t dataPointNum);
 
+  void AddDataPoints(std::string const & mwmName, storage::Storage const & storage,
+                     uint32_t dataPointNum);
+
   /// \brief Saves csv file with numbers of DataPoints for each mwm to |csvPath|.
   /// If |csvPath| is empty it does nothing.
   void SaveMwmDistributionToCsv(std::string const & csvPath) const;
 
-  void LogMwms() const;
-  void LogCountries() const;
+  void Log() const;
 
   NameToCountMapping const & GetMwmToTotalDataPointsForTesting() const;
   NameToCountMapping const & GetCountryToTotalDataPointsForTesting() const;
 
 private:
+  void LogMwms() const;
+  void LogCountries() const;
+
   /// \note These fields may present mapping from territory name to either DataPoints
   /// or MatchedTrackPoint count.
   NameToCountMapping m_mwmToTotalDataPoints;

--- a/track_analyzing/track_analyzer/utils.hpp
+++ b/track_analyzing/track_analyzer/utils.hpp
@@ -38,7 +38,7 @@ public:
                      uint64_t dataPointNum);
 
   void AddDataPoints(std::string const & mwmName, storage::Storage const & storage,
-                     uint32_t dataPointNum);
+                     uint64_t dataPointNum);
 
   /// \brief Saves csv file with numbers of DataPoints for each mwm to |csvPath|.
   /// If |csvPath| is empty it does nothing.
@@ -70,6 +70,9 @@ void ParseTracks(std::string const & logFile, std::shared_ptr<routing::NumMwmIds
                  MwmToTracks & mwmToTracks);
 
 void WriteCsvTableHeader(std::basic_ostream<char> & stream);
+
+void LogNameToCountMapping(std::string const & keyName, std::string const & descr,
+                           Stats::NameToCountMapping const & mapping);
 
 std::string DebugPrint(Stats const & s);
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzer/utils.hpp
+++ b/track_analyzing/track_analyzer/utils.hpp
@@ -7,6 +7,7 @@
 #include "track_analyzing/track.hpp"
 
 #include <cstdint>
+#include <istream>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -38,7 +39,10 @@ public:
 
   /// \brief Saves csv file with numbers of DataPoints for each mwm to |csvPath|.
   /// If |csvPath| is empty it does nothing.
-  void SaveMwmDistributionToCsv(std::string const & csvPath);
+  void SaveMwmDistributionToCsv(std::string const & csvPath) const;
+
+  void LogMwms() const;
+  void LogCountries() const;
 
   NameToCountMapping const & GetMwmToTotalDataPointsForTesting() const;
   NameToCountMapping const & GetCountryToTotalDataPointsForTesting() const;
@@ -59,6 +63,8 @@ void MappingFromCsv(std::basic_istream<char> & ss, Stats::NameToCountMapping & m
 /// \brief Parses tracks from |logFile| and fills |mwmToTracks|.
 void ParseTracks(std::string const & logFile, std::shared_ptr<routing::NumMwmIds> const & numMwmIds,
                  MwmToTracks & mwmToTracks);
+
+void WriteCsvTableHeader(std::basic_ostream<char> & stream);
 
 std::string DebugPrint(Stats const & s);
 }  // namespace track_analyzing

--- a/track_analyzing/track_analyzing_tests/CMakeLists.txt
+++ b/track_analyzing/track_analyzing_tests/CMakeLists.txt
@@ -2,8 +2,8 @@ project(track_analyzing_tests)
 
 set(
   SRC
-  ../track_analyzer/balance_csv_impl.cpp
-  ../track_analyzer/balance_csv_impl.hpp
+  ../track_analyzer/cmd_balance_csv.cpp
+  ../track_analyzer/cmd_balance_csv.hpp
   ../track_analyzer/utils.cpp
   ../track_analyzer/utils.hpp
   balance_tests.cpp

--- a/track_analyzing/track_analyzing_tests/balance_tests.cpp
+++ b/track_analyzing/track_analyzing_tests/balance_tests.cpp
@@ -1,6 +1,6 @@
 #include "testing/testing.hpp"
 
-#include "track_analyzing/track_analyzer/balance_csv_impl.hpp"
+#include "track_analyzing/track_analyzer/cmd_balance_csv.hpp"
 
 #include <algorithm>
 #include <sstream>
@@ -161,7 +161,7 @@ UNIT_TEST(BalancedDataPointNumberTheSameTest)
     auto distr = distribution;
     auto matched = matchedDataPoints;
     auto const balancedDataPointNumber =
-        BalancedDataPointNumber(move(distr), move(matched), 0 /* ignoreDataPointsNumber */);
+        BalancedDataPointNumber(move(matched), move(distr), 0 /* ignoreDataPointsNumber */);
     TEST_EQUAL(balancedDataPointNumber, matchedDataPoints, ());
   }
 
@@ -171,7 +171,7 @@ UNIT_TEST(BalancedDataPointNumberTheSameTest)
     auto distr = distribution;
     auto matched = matchedDataPoints;
     auto const balancedDataPointNumber =
-        BalancedDataPointNumber(move(distr), move(matched), 7 /* ignoreDataPointsNumber */);
+        BalancedDataPointNumber(move(matched), move(distr), 7 /* ignoreDataPointsNumber */);
     MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 10 /* data points */}};
     TEST_EQUAL(balancedDataPointNumber, expectedBalancedDataPointNumber, ());
   }
@@ -189,7 +189,7 @@ UNIT_TEST(BalancedDataPointNumberTest)
     auto distr = distribution;
     auto matched = matchedDataPoints;
     auto const balancedDataPointNumber =
-        BalancedDataPointNumber(move(distr), move(matched), 7 /* ignoreDataPointsNumber */);
+        BalancedDataPointNumber(move(matched), move(distr), 7 /* ignoreDataPointsNumber */);
     MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 60 /* data points */},
                                                        {"San Marino", 30 /* data points */},
                                                        {"Slovakia", 10 /* data points */}};
@@ -209,7 +209,7 @@ UNIT_TEST(BalancedDataPointNumberUint64Test)
     auto distr = distribution;
     auto matched = matchedDataPoints;
     auto const balancedDataPointNumber =
-        BalancedDataPointNumber(move(distr), move(matched), 7'000'000'000 /* ignoreDataPointsNumber */);
+        BalancedDataPointNumber(move(matched), move(distr), 7'000'000'000 /* ignoreDataPointsNumber */);
     MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 60'000'000'000 /* data points */},
                                                        {"San Marino", 30'000'000'000 /* data points */},
                                                        {"Slovakia", 10'000'000'000 /* data points */}};


### PR DESCRIPTION
Добавлены команды и параметры для балансировки треков в track analyzer.

Появилась команда: balance_csv  для балансировки треков
Добавлены параметры: input_distribution, ignore_datapoints_number.

Пример использования track_analyzer для балансировки:
`./track_analyzer -cmd=balance_csv -in=./train.csv -input_distribution=./distribution.csv -ignore_datapoints_number=100 > ./balanced_train.csv`

@mesozoic-drones @gmoryes PTAL