### PR TITLE
[shaders] GLSL compiler timeout increased.

### DIFF
--- a/shaders/shaders_tests/gl_shaders_mobile_compile_test.cpp
+++ b/shaders/shaders_tests/gl_shaders_mobile_compile_test.cpp
@@ -86,7 +86,9 @@ void RunShaderTest(dp::ApiVersion apiVersion, std::string const & shaderName,
   p.start(glslCompiler, args, QIODevice::ReadOnly);
 
   TEST(p.waitForStarted(), ("GLSL compiler not started", glslCompiler));
-  TEST(p.waitForFinished(), ("GLSL compiler not finished in time", glslCompiler));
+
+  int32_t kFinishTimeoutInMs = 60000;
+  TEST(p.waitForFinished(kFinishTimeoutInMs), ("GLSL compiler not finished in time", glslCompiler));
 
   QString result = p.readAllStandardOutput();
   if (!successChecker(result))


### PR DESCRIPTION
На билд сервере иногда не хватает дефолтного тайм-аута в 30000мс.