### PR TITLE
[Routing] Do not match bearing to the route (pedestrian mode)

### DIFF
--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -511,12 +511,14 @@ void DrapeEngine::StopLocationFollow()
                                   MessagePriority::Normal);
 }
 
-void DrapeEngine::FollowRoute(int preferredZoomLevel, int preferredZoomLevel3d, bool enableAutoZoom)
+void DrapeEngine::FollowRoute(int preferredZoomLevel, int preferredZoomLevel3d, bool enableAutoZoom,
+                              bool isArrowGlued)
 {
-  m_threadCommutator->PostMessage(ThreadsCommutator::RenderThread,
-                                  make_unique_dp<FollowRouteMessage>(preferredZoomLevel,
-                                                                     preferredZoomLevel3d, enableAutoZoom),
-                                  MessagePriority::Normal);
+  m_threadCommutator->PostMessage(
+      ThreadsCommutator::RenderThread,
+      make_unique_dp<FollowRouteMessage>(preferredZoomLevel, preferredZoomLevel3d, enableAutoZoom,
+                                         isArrowGlued),
+      MessagePriority::Normal);
 }
 
 void DrapeEngine::SetModelViewListener(ModelViewChangedHandler && fn)

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -178,7 +178,8 @@ public:
   
   dp::DrapeID AddSubroute(SubrouteConstPtr subroute);
   void RemoveSubroute(dp::DrapeID subrouteId, bool deactivateFollowing);
-  void FollowRoute(int preferredZoomLevel, int preferredZoomLevel3d, bool enableAutoZoom);
+  void FollowRoute(int preferredZoomLevel, int preferredZoomLevel3d, bool enableAutoZoom,
+                   bool isArrowGlued);
   void DeactivateRouteFollowing();
   void SetSubrouteVisibility(dp::DrapeID subrouteId, bool isVisible);
   dp::DrapeID AddRoutePreviewSegment(m2::PointD const & startPt, m2::PointD const & finishPt);

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -559,7 +559,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       {
         FollowRoute(m_pendingFollowRoute->m_preferredZoomLevel,
                     m_pendingFollowRoute->m_preferredZoomLevelIn3d,
-                    m_pendingFollowRoute->m_enableAutoZoom);
+                    m_pendingFollowRoute->m_enableAutoZoom, m_pendingFollowRoute->m_isArrowGlued);
         m_pendingFollowRoute.reset();
       }
       break;
@@ -633,13 +633,14 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       // receive FollowRoute message before FlushSubroute message, so we need to postpone its processing.
       if (m_routeRenderer->GetSubroutes().empty())
       {
-        m_pendingFollowRoute = std::make_unique<FollowRouteData>(msg->GetPreferredZoomLevel(),
-                                                                 msg->GetPreferredZoomLevelIn3d(),
-                                                                 msg->EnableAutoZoom());
+        m_pendingFollowRoute = std::make_unique<FollowRouteData>(
+            msg->GetPreferredZoomLevel(), msg->GetPreferredZoomLevelIn3d(), msg->EnableAutoZoom(),
+            msg->IsArrowGlued());
         break;
       }
 
-      FollowRoute(msg->GetPreferredZoomLevel(), msg->GetPreferredZoomLevelIn3d(), msg->EnableAutoZoom());
+      FollowRoute(msg->GetPreferredZoomLevel(), msg->GetPreferredZoomLevelIn3d(),
+                  msg->EnableAutoZoom(), msg->IsArrowGlued());
       break;
     }
 
@@ -1113,11 +1114,11 @@ void FrontendRenderer::UpdateContextDependentResources()
 }
 
 void FrontendRenderer::FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d,
-                                   bool enableAutoZoom)
+                                   bool enableAutoZoom, bool isArrowGlued)
 {
   m_myPositionController->ActivateRouting(
       !m_enablePerspectiveInNavigation ? preferredZoomLevel : preferredZoomLevelIn3d,
-      enableAutoZoom);
+      enableAutoZoom, isArrowGlued);
 
   if (m_enablePerspectiveInNavigation)
     AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -254,7 +254,9 @@ private:
   using TRenderGroupRemovePredicate = std::function<bool(drape_ptr<RenderGroup> const &)>;
   void RemoveRenderGroupsLater(TRenderGroupRemovePredicate const & predicate);
 
-  void FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom);
+  void FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
+                   bool isArrowGlued);
+
   bool CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData);
 
   void InvalidateRect(m2::RectD const & gRect);
@@ -344,15 +346,18 @@ private:
 
   struct FollowRouteData
   {
-    FollowRouteData(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom)
+    FollowRouteData(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
+                    bool isArrowGlued)
       : m_preferredZoomLevel(preferredZoomLevel)
       , m_preferredZoomLevelIn3d(preferredZoomLevelIn3d)
       , m_enableAutoZoom(enableAutoZoom)
+      , m_isArrowGlued(isArrowGlued)
     {}
 
     int m_preferredZoomLevel;
     int m_preferredZoomLevelIn3d;
     bool m_enableAutoZoom;
+    bool m_isArrowGlued;
   };
 
   std::unique_ptr<FollowRouteData> m_pendingFollowRoute;

--- a/drape_frontend/message_subclasses.hpp
+++ b/drape_frontend/message_subclasses.hpp
@@ -756,10 +756,12 @@ public:
 class FollowRouteMessage : public Message
 {
 public:
-  FollowRouteMessage(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom)
+  FollowRouteMessage(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
+                     bool isArrowGlued)
     : m_preferredZoomLevel(preferredZoomLevel)
     , m_preferredZoomLevelIn3d(preferredZoomLevelIn3d)
     , m_enableAutoZoom(enableAutoZoom)
+    , m_isArrowGlued(isArrowGlued)
   {}
 
   Type GetType() const override { return Type::FollowRoute; }
@@ -767,11 +769,13 @@ public:
   int GetPreferredZoomLevel() const { return m_preferredZoomLevel; }
   int GetPreferredZoomLevelIn3d() const { return m_preferredZoomLevelIn3d; }
   bool EnableAutoZoom() const { return m_enableAutoZoom; }
+  bool IsArrowGlued() const { return m_isArrowGlued; }
 
 private:
   int const m_preferredZoomLevel;
   int const m_preferredZoomLevelIn3d;
   bool const m_enableAutoZoom;
+  bool const m_isArrowGlued;
 };
 
 class SwitchMapStyleMessage : public BaseBlockingMessage

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -422,7 +422,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
     m_autoScale2d = m_autoScale3d = kUnknownAutoZoom;
   }
 
-  if (!m_isCompassAvailable)
+  if (!m_isCompassAvailable || m_isArrowGluedInRouting)
   {
     bool const hasBearing = info.HasBearing();
     if ((isNavigable && hasBearing) ||
@@ -573,7 +573,7 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
   double const oldAzimut = GetDrawableAzimut();
   m_isCompassAvailable = true;
 
-  if (IsInRouting() && m_isArrowGluedInRouting && m_mode == location::FollowAndRotate)
+  if (IsInRouting() && m_isArrowGluedInRouting)
     return;
 
   SetDirection(info.m_bearing);

--- a/drape_frontend/my_position_controller.hpp
+++ b/drape_frontend/my_position_controller.hpp
@@ -105,7 +105,7 @@ public:
                       drape_ptr<MyPosition> && shape);
   void ResetRenderShape();
 
-  void ActivateRouting(int zoomLevel, bool enableAutoZoom);
+  void ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued);
   void DeactivateRouting();
 
   void EnablePerspectiveInRouting(bool enablePerspective);
@@ -167,7 +167,8 @@ private:
   location::TMyPositionModeChanged m_modeChangeCallback;
   Hints m_hints;
 
-  bool m_isInRouting;
+  bool m_isInRouting = false;
+  bool m_isArrowGluedInRouting = false;
 
   bool m_needBlockAnimation;
   bool m_wasRotationInScaling;
@@ -187,7 +188,6 @@ private:
   double m_autoScale2d;
   double m_autoScale3d;
 
-  base::Timer m_lastGPSBearing;
   base::Timer m_pendingTimer;
   bool m_pendingStarted = true;
   base::Timer m_routingNotFollowTimer;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3794,8 +3794,10 @@ void Framework::OnRouteFollow(routing::RouterType type)
     m_trafficManager.SetEnabled(false /* enabled */);
     SaveTrafficEnabled(false /* enabled */);
   }
-
-  m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom);
+  // TODO. We need to sync two enums VehicleType and RouterType to be able to pass
+  // GetRoutingSettings(type).m_matchRoute to the FollowRoute() instead of |isPedestrianRoute|.
+  // |isArrowGlued| parameter fully corresponds to |m_matchRoute| in RoutingSettings.
+  m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom, !isPedestrianRoute /* isArrowGlued */);
 }
 
 // RoutingManager::Delegate

--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -2,19 +2,22 @@
 
 #include "routing/routing_helpers.hpp"
 
+#include "base/assert.hpp"
+
 namespace routing
 {
 // RoutingSettings ---------------------------------------------------------------------------------
 RoutingSettings::RoutingSettings(bool useDirectionForRouteBuilding, bool matchRoute,
                                  bool soundDirection, double matchingThresholdM,
-                                 bool keepPedestrianInfo, bool showTurnAfterNext,
+                                 bool showTurnAfterNext,
                                  double minSpeedForRouteRebuildMpS, double finishToleranceM)
+
   : m_useDirectionForRouteBuilding(useDirectionForRouteBuilding)
   , m_matchRoute(matchRoute)
   , m_soundDirection(soundDirection)
   , m_matchingThresholdM(matchingThresholdM)
-  , m_keepPedestrianInfo(keepPedestrianInfo)
   , m_showTurnAfterNext(showTurnAfterNext)
+  , m_minSpeedForRouteRebuildMpS(minSpeedForRouteRebuildMpS)
   , m_finishToleranceM(finishToleranceM)
 {
 }
@@ -25,10 +28,9 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
   {
   case VehicleType::Pedestrian:
     return {false /* useDirectionForRouteBuilding */,
-            true /* m_matchRoute */,
+            false /* m_matchRoute */,
             false /* m_soundDirection */,
             20.0 /* m_matchingThresholdM */,
-            true /* m_keepPedestrianInfo */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
             20.0 /* m_finishToleranceM */};
@@ -37,7 +39,6 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             true /* m_matchRoute */,
             false /* m_soundDirection */,
             40.0 /* m_matchingThresholdM */,
-            true /* m_keepPedestrianInfo */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
             20.0 /* m_finishToleranceM */};
@@ -46,7 +47,6 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             true /* m_matchRoute */,
             true /* m_soundDirection */,
             30.0 /* m_matchingThresholdM */,
-            false /* m_keepPedestrianInfo */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
             20.0 /* m_finishToleranceM */};
@@ -55,7 +55,6 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             true /* m_matchRoute */,
             true /* m_soundDirection */,
             50.0 /* m_matchingThresholdM */,
-            false /* m_keepPedestrianInfo */,
             true /* m_showTurnAfterNext */,
             routing::KMPH2MPS(3.0) /* m_minSpeedForRouteRebuildMpS */,
             50.0 /* m_finishToleranceM */};

--- a/routing/routing_settings.hpp
+++ b/routing/routing_settings.hpp
@@ -2,11 +2,8 @@
 
 #include "routing/vehicle_mask.hpp"
 
-#include "base/assert.hpp"
-
 namespace routing
 {
-
 /// \brief The RoutingSettings struct is intended to collect all the settings of
 /// following along the route.
 /// For example, route matching properties, rerouting properties and so on.
@@ -16,8 +13,9 @@ struct RoutingSettings
 
 private:
   RoutingSettings(bool useDirectionForRouteBuilding, bool matchRoute, bool soundDirection,
-                  double matchingThresholdM, bool keepPedestrianInfo, bool showTurnAfterNext,
+                  double matchingThresholdM, bool showTurnAfterNext,
                   double minSpeedForRouteRebuildMpS, double finishToleranceM);
+
 
 public:
   /// \brief We accumulate several positions to calculate current direction.
@@ -37,10 +35,6 @@ public:
   /// m_matchingThresholdM to the route than the current position is moved to
   /// the closest point to the route.
   double m_matchingThresholdM;
-
-  /// \brief m_keepPedestrianInfo flag for keeping in memory additional information for pedestrian
-  /// routing.
-  bool m_keepPedestrianInfo;
 
   /// \brief if m_showTurnAfterNext is equal to true end users see a notification
   /// about the turn after the next in some cases.


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-12781

When the user enters the navigation mode for pedestrians, the location arrow is "glued" to the route. It does not point to the real direction. It is very disorienting. For pedestrians we need to untie the direction of the arrow from the route.

This PR:
- Passes new flag from `Framework` to `MyPositionController` - `isArrowGluedInRouting`. It is set to `true` for car, bicycle and transit modes and is set to `false` for pedestrian mode.
- Activates GNSS bearing only if compass is not available on device. It prevents random arrow movements when angle values are switched between compass and GNSS. So the GNSS angle value becomes the reserve option: the precise direction can not be obtained from the GNSS device sensors. [Android documentation:](https://developer.android.com/reference/android/location/Location.html#getBearingAccuracyDegrees()) 
> We define bearing accuracy at 68% confidence. 
> ...
> For example, if getBearing() returns 60, and getBearingAccuracyDegrees() returns 10, then there is a 68% probability of the true bearing being between 50 and 70 degrees.
- Changes epsilon for AlmostCurrentAzimut(): the old value is 1e-5. 
0.00001 rad = 0.00057°
This value is too precise, the new value 1e-3 fits as well and results in in fewer redraws.
0.001 rad = 0.057°
- Sets match to route to `false` for pedestrians in `routing_settings.cpp`.
- Removes an unused parameter `m_keepPedestrianInfo`.



