### PR TITLE
[track_analyzer] Preventing taking into account crossroads at end of DataPoints twice.

### DIFF
--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -445,6 +445,7 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           auto moveType = pointToMoveType.GetMoveType(*subtrackBegin);
           auto prev = subtrackBegin;
           auto end = subtrackBegin + 1;
+          // Splitting track with points where MoveType is changed.
           while (end != track.end() && pointToMoveType.GetMoveType(*end) == moveType)
           {
             IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()), info);
@@ -462,7 +463,7 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
           aggregator.Add(move(moveType), info, subtrackBegin, end, geometry);
           subtrackBegin = end;
-          info = move(crossroad);
+          info = {};
         }
 
         auto const summary = aggregator.GetSummary(user, mwmName, countryName, stats);


### PR DESCRIPTION
В ф-ции, которая разбивает трек на составляющие была ошибка. Все перекрестки, которые попадали на точки разбиения трека учитывались дважды. Т.е. если трек разбивался на n частей (n-1) точкой, которая всегда перекресток, то эти (n-1) точка присутствовали дважды. В конце и в начале каждой части.

В строчке 461 данные о таком перекрестке добавлялись в конец части трека (мержились в инфо)

А в строчке 465, в начало.

@gmoryes @mesozoic-drones PTAL