### PR TITLE
track_analyzer] Moving to uint64_t DataPoints number.

### DIFF
--- a/track_analyzing/track_analyzer/balance_csv_impl.cpp
+++ b/track_analyzing/track_analyzer/balance_csv_impl.cpp
@@ -36,7 +36,7 @@ void FillTable(basic_istream<char> & tableCsvStream, MwmToDataPoints & matchedDa
 }
 
 void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
-                          uint32_t ignoreDataPointNumber)
+                          uint64_t ignoreDataPointNumber)
 {
   CHECK(AreKeysEqual(additionalMap, checkedMap),
         ("Mwms in |checkedMap| and in |additionalMap| should have the same set of keys."));
@@ -59,7 +59,7 @@ void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additi
 MwmToDataPointFraction GetMwmToDataPointFraction(MwmToDataPoints const & numberMapping)
 {
   CHECK(!numberMapping.empty(), ());
-  uint32_t const totalDataPointNumber = ValueSum(numberMapping);
+  uint64_t const totalDataPointNumber = ValueSum(numberMapping);
 
   MwmToDataPointFraction fractionMapping;
   for (auto const & kv : numberMapping)
@@ -81,7 +81,7 @@ MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
 
   double maxRatio = 0.0;
   double maxRationDistributionFraction = 0.0;
-  uint32_t maxRationMatchedDataPointNumber = 0;
+  uint64_t maxRationMatchedDataPointNumber = 0;
   // First, let's find such mwm that all |matchedDataPoints| of it may be used and
   // the distribution set in |distributionFractions| will be kept. It's an mwm
   // on which the maximum of ratio
@@ -112,7 +112,7 @@ MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
   // fraction of data point in the distribution for this mwm (less or equal 1.0) it's possible to
   // calculate the total matched points number which may be used to keep the distribution.
   auto const totalMatchedPointNumberToKeepDistribution =
-      static_cast<uint32_t>(maxRationMatchedDataPointNumber / maxRationDistributionFraction);
+      static_cast<uint64_t>(maxRationMatchedDataPointNumber / maxRationDistributionFraction);
   CHECK_LESS_OR_EQUAL(totalMatchedPointNumberToKeepDistribution, ValueSum(matchedDataPoints), ());
 
   // Having total maximum matched point number which let to keep the distribution
@@ -125,7 +125,7 @@ MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
     auto const & mwm = kv.first;
     auto const fraction = kv.second;
     auto const matchedDataPointsToKeepDistributionForMwm =
-        static_cast<uint32_t>(fraction * totalMatchedPointNumberToKeepDistribution);
+        static_cast<uint64_t>(fraction * totalMatchedPointNumberToKeepDistribution);
     matchedDataPointsToKeepDistribution.emplace(mwm, matchedDataPointsToKeepDistributionForMwm);
 
     if (matchedDataPointsToKeepDistributionForMwm == 0)
@@ -141,7 +141,7 @@ MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
 
 MwmToDataPoints BalancedDataPointNumber(MwmToDataPoints && distribution,
                                         MwmToDataPoints && matchedDataPoints,
-                                        uint32_t ignoreDataPointsNumber)
+                                        uint64_t ignoreDataPointsNumber)
 {
   // Removing every mwm from |distribution| and |matchedDataPoints| if it has
   // |ignoreDataPointsNumber| data points or less in |matchedDataPoints|.
@@ -202,19 +202,19 @@ void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, vector<TableR
 }
 
 void BalanceDataPoints(basic_istream<char> & distributionCsvStream,
-                       basic_istream<char> & tableCsvStream, uint32_t ignoreDataPointsNumber,
+                       basic_istream<char> & tableCsvStream, uint64_t ignoreDataPointsNumber,
                        vector<TableRow> & balancedTable)
 {
   LOG(LINFO, ("Balancing data points..."));
   // Filling a map mwm to DataPoints number according to distribution csv file.
   MwmToDataPoints distribution;
   MappingFromCsv(distributionCsvStream, distribution);
-  uint32_t const totalDistributionDataPointsNumber = ValueSum(distribution);
+  uint64_t const totalDistributionDataPointsNumber = ValueSum(distribution);
 
   balancedTable.clear();
   MwmToDataPoints matchedDataPoints;
   FillTable(tableCsvStream, matchedDataPoints, balancedTable);
-  uint32_t const totalMatchedDataPointsNumber = ValueSum(matchedDataPoints);
+  uint64_t const totalMatchedDataPointsNumber = ValueSum(matchedDataPoints);
 
   if (matchedDataPoints.empty())
   {
@@ -236,7 +236,7 @@ void BalanceDataPoints(basic_istream<char> & distributionCsvStream,
   // Calculating how many points should have every mwm to keep the |distribution|.
   MwmToDataPoints const balancedDataPointNumber =
       BalancedDataPointNumber(move(distribution), move(matchedDataPoints), ignoreDataPointsNumber);
-  uint32_t const totalBalancedDataPointsNumber = ValueSum(balancedDataPointNumber);
+  uint64_t const totalBalancedDataPointsNumber = ValueSum(balancedDataPointNumber);
 
   // |balancedTable| is filled now with all the items from |tableCsvStream|.
   // Removing some items form |tableCsvStream| (if it's necessary) to correspond to

--- a/track_analyzing/track_analyzer/balance_csv_impl.hpp
+++ b/track_analyzing/track_analyzer/balance_csv_impl.hpp
@@ -28,7 +28,7 @@ void FillTable(std::basic_istream<char> & tableCsvStream, MwmToDataPoints & matc
 /// \brief Removing every mwm from |checkedMap| and |additionalMap| if it has
 /// |ignoreDataPointsNumber| data points or less in |checkedMap|.
 void RemoveKeysSmallValue(MwmToDataPoints & checkedMap, MwmToDataPoints & additionalMap,
-                          uint32_t ignoreDataPointNumber);
+                          uint64_t ignoreDataPointNumber);
 
 /// \returns mapping from mwm to fraction of data points contained in the mwm.
 MwmToDataPointFraction GetMwmToDataPointFraction(MwmToDataPoints const & numberMapping);
@@ -44,7 +44,7 @@ MwmToDataPoints CalcsMatchedDataPointsToKeepDistribution(
 /// \returns mapping with number of matched data points for every mwm to correspond to |distribution|.
 MwmToDataPoints BalancedDataPointNumber(MwmToDataPoints && distribution,
                                         MwmToDataPoints && matchedDataPoints,
-                                        uint32_t ignoreDataPointsNumber);
+                                        uint64_t ignoreDataPointsNumber);
 
 /// \breif Leaves in |table| only number of items according to |balancedDataPointNumbers|.
 /// \note |table| may have a significant size. It may be several tens millions records.
@@ -53,7 +53,7 @@ void FilterTable(MwmToDataPoints const & balancedDataPointNumbers, std::vector<T
 /// \brief Fills |balancedTable| with TableRow(s) according to the distribution set in
 /// |distributionCsvStream|.
 void BalanceDataPoints(std::basic_istream<char> & distributionCsvStream,
-                       std::basic_istream<char> & tableCsvStream, uint32_t ignoreDataPointsNumber,
+                       std::basic_istream<char> & tableCsvStream, uint64_t ignoreDataPointsNumber,
                        std::vector<TableRow> & balancedTable);
 
 template <typename MapCont>

--- a/track_analyzing/track_analyzer/utils.cpp
+++ b/track_analyzing/track_analyzer/utils.cpp
@@ -98,7 +98,7 @@ void Stats::AddTracksStats(MwmToTracks const & mwmToTracks, NumMwmIds const & nu
   for (auto const & kv : mwmToTracks)
   {
     auto const & userToTrack = kv.second;
-    uint32_t dataPointNum = 0;
+    uint64_t dataPointNum = 0;
     for (auto const & userTrack : userToTrack)
       dataPointNum += userTrack.second.size();
 
@@ -111,7 +111,7 @@ void Stats::AddTracksStats(MwmToTracks const & mwmToTracks, NumMwmIds const & nu
 }
 
 void Stats::AddDataPoints(string const & mwmName, string const & countryName,
-                          uint32_t dataPointNum)
+                          uint64_t dataPointNum)
 {
   m_mwmToTotalDataPoints[mwmName] += dataPointNum;
   m_countryToTotalDataPoints[countryName] += dataPointNum;
@@ -142,7 +142,7 @@ void MappingToCsv(string const & keyName, Stats::NameToCountMapping const & mapp
   struct KeyValue
   {
     string m_key;
-    uint32_t m_value = 0;
+    uint64_t m_value = 0;
   };
 
   if (mapping.empty())
@@ -163,7 +163,7 @@ void MappingToCsv(string const & keyName, Stats::NameToCountMapping const & mapp
   sort(keyValues.begin(), keyValues.end(),
        [](KeyValue const & a, KeyValue const & b) { return a.m_value > b.m_value; });
 
-  uint32_t allValues = 0;
+  uint64_t allValues = 0;
   for (auto const & kv : keyValues)
     allValues += kv.m_value;
 
@@ -189,7 +189,7 @@ void MappingFromCsv(basic_istream<char> & ss, Stats::NameToCountMapping & mappin
     auto const & key = row[0];
     uint64_t value = 0;
     CHECK(strings::to_uint64(row[1], value), ());
-    auto const it = mapping.insert(make_pair(key, base::checked_cast<uint32_t>(value)));
+    auto const it = mapping.insert(make_pair(key, value));
     CHECK(it.second, ());
   }
 }

--- a/track_analyzing/track_analyzer/utils.hpp
+++ b/track_analyzing/track_analyzer/utils.hpp
@@ -19,7 +19,7 @@ class Stats
 public:
   friend std::string DebugPrint(Stats const & s);
 
-  using NameToCountMapping = std::map<std::string, uint32_t>;
+  using NameToCountMapping = std::map<std::string, uint64_t>;
 
   Stats() = default;
   Stats(NameToCountMapping const & mwmToTotalDataPoints,
@@ -34,7 +34,7 @@ public:
 
   /// \brief Adds |dataPointNum| to |m_mwmToTotalDataPoints| and |m_countryToTotalDataPoints|.
   void AddDataPoints(std::string const & mwmName, std::string const & countryName,
-                     uint32_t dataPointNum);
+                     uint64_t dataPointNum);
 
   /// \brief Saves csv file with numbers of DataPoints for each mwm to |csvPath|.
   /// If |csvPath| is empty it does nothing.

--- a/track_analyzing/track_analyzing_tests/balance_tests.cpp
+++ b/track_analyzing/track_analyzing_tests/balance_tests.cpp
@@ -197,6 +197,26 @@ UNIT_TEST(BalancedDataPointNumberTest)
   }
 }
 
+UNIT_TEST(BalancedDataPointNumberUint64Test)
+{
+  MwmToDataPoints distribution = {{"Russia_Moscow", 6'000'000'000'000 /* data points */},
+                                  {"San Marino", 3'000'000'000'000 /* data points */},
+                                  {"Slovakia", 1'000'000'000'000 /* data points */}};
+  MwmToDataPoints matchedDataPoints = {{"Russia_Moscow", 500'000'000'000 /* data points */},
+                                       {"San Marino", 300'000'000'000 /* data points */},
+                                       {"Slovakia", 10'000'000'000 /* data points */}};
+  {
+    auto distr = distribution;
+    auto matched = matchedDataPoints;
+    auto const balancedDataPointNumber =
+        BalancedDataPointNumber(move(distr), move(matched), 7'000'000'000 /* ignoreDataPointsNumber */);
+    MwmToDataPoints expectedBalancedDataPointNumber = {{"Russia_Moscow", 60'000'000'000 /* data points */},
+                                                       {"San Marino", 30'000'000'000 /* data points */},
+                                                       {"Slovakia", 10'000'000'000 /* data points */}};
+    TEST_EQUAL(balancedDataPointNumber, expectedBalancedDataPointNumber, ());
+  }
+}
+
 UNIT_TEST(FilterTableTest)
 {
   std::stringstream ss;

--- a/track_analyzing/track_analyzing_tests/statistics_tests.cpp
+++ b/track_analyzing/track_analyzing_tests/statistics_tests.cpp
@@ -125,6 +125,19 @@ Belarus_Minsk Region,2
   }
 }
 
+UNIT_TEST(MappingToCsvUint64Test)
+{
+  Stats::NameToCountMapping const mapping = {{"Belarus_Minsk Region", 5'000'000'000},
+                                             {"Uzbekistan", 15'000'000'000}};
+  std::stringstream ss;
+  MappingToCsv("mwm", mapping, true /* printPercentage */, ss);
+  std::string const expected = R"(mwm,number,percent
+Uzbekistan,15000000000,75
+Belarus_Minsk Region,5000000000,25
+)";
+  TEST_EQUAL(ss.str(), expected, ());
+}
+
 UNIT_TEST(SerializationToCsvTest)
 {
   Stats::NameToCountMapping const mapping1 = {{"Belarus_Minsk Region", 2},
@@ -151,5 +164,13 @@ UNIT_TEST(SerializationToCsvWithZeroValueTest)
   MappingFromCsv(ss, readMapping);
 
   TEST_EQUAL(readMapping, expected, (ss.str()));
+}
+
+UNIT_TEST(SerializationToCsvUint64Test)
+{
+  Stats::NameToCountMapping const mapping = {{"Belarus_Minsk Region", 20'000'000'000},
+                                             {"Uzbekistan", 5},
+                                             {"Russia_Moscow", 7'000'000'000}};
+  TestSerializationToCsv(mapping);
 }
 }  // namespace


### PR DESCRIPTION
Кол-во точек в треках за 2 месяца превышает 2G. При обработке больших объемов треков всплыла ошибка связанная с тем, что uint32_t стало не хватать. Данный PR заменяет uint32_t на unit64_t. И добавляет тесты на это изменение.

@mesozoic-drones @gmoryes PTAL