### PR TITLE
[partners_api] Remove not existing type from partners_api.

### DIFF
--- a/partners_api/mopub_ads.cpp
+++ b/partners_api/mopub_ads.cpp
@@ -69,8 +69,6 @@ Mopub::Mopub()
                {"amenity", "bureau_de_change"}},
               kNonTourismPlacementId);
 
-  AppendEntry({{"sponsored", "banner"}}, kSponsoredBannerPlacementId);
-
   for (auto const & p : GetPartners())
   {
     auto const & placementId = p.GetBannerPlacementId();

--- a/partners_api/partners_api_tests/ads_engine_tests.cpp
+++ b/partners_api/partners_api_tests/ads_engine_tests.cpp
@@ -136,23 +136,6 @@ UNIT_TEST(AdsEngine_Smoke)
     auto result = engine.GetBanners(holder, {"Russian Federation"}, "ru");
     TEST(result.empty(), ());
   }
-  ads::Google google;
-  {
-    feature::TypesHolder holder;
-    holder.Assign(c.GetTypeByPath({"sponsored", "banner"}));
-    TEST(engine.HasBanner(holder, {"Russian Federation"}, "ru"), ());
-    auto result = engine.GetBanners(holder, {"Russian Federation"}, "ru");
-    TEST(!result.empty(), ());
-    CheckIds(result, {"2bab47102d38485996788ab9b602ce2c"});
-  }
-  {
-    feature::TypesHolder holder;
-    holder.Assign(c.GetTypeByPath({"sponsored", "banner"}));
-    TEST(engine.HasBanner(holder, {"United States"}, "en"), ());
-    auto result = engine.GetBanners(holder, {"United States"}, "en");
-    TEST(!result.empty(), ());
-    CheckIds(result, {"2bab47102d38485996788ab9b602ce2c"});
-  }
   ads::Facebook facebook;
   {
     TEST(engine.HasSearchBanner(), ());

--- a/partners_api/rb_ads.cpp
+++ b/partners_api/rb_ads.cpp
@@ -84,8 +84,6 @@ Rb::Rb()
 
   AppendEntry({{"building"}}, kBuildingPlacementId);
 
-  AppendExcludedTypes({{"sponsored", "banner"}});
-
   AppendSupportedCountries(kSupportedCountries);
   AppendSupportedUserLanguages(kSupportedLanguages);
 }


### PR DESCRIPTION
После того как были задеприкейчены неиспользуемые типы

```
sponsored|banner|lamoda_ru;1140;
sponsored|banner|lamoda_ua;1141;
sponsored|banner|deliveryclub;1142;
sponsored|banner|tutu;1143;
sponsored|banner|geerbest_uk;1144;
sponsored|banner|rentalcars;1145;
sponsored|banner|viator;1146;
sponsored|banner|geerbest_de;1147;
sponsored|banner|geerbest_fr;1148;
sponsored|banner|raileurope;1149;
```

сломались тесты partners_api.
Причина такая: хоть типы действительно не использовались, в рантайме мог существовать тип sponsored-banner (такого типа нет, но если есть тип a-b-c-d, то в классификаторе в рантайме существуют и a и a-b и a-b-c). Этот тип использовался в partners_api.