### PR TITLE
[omim] Replaced boost::optional with std::optional.

### DIFF
--- a/3party/jansson/myjansson.hpp
+++ b/3party/jansson/myjansson.hpp
@@ -7,10 +7,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "3party/jansson/src/jansson.h"
 
@@ -163,13 +162,13 @@ void FromJSONObject(json_t * root, std::string const & field, T & result)
 }
 
 template <typename T>
-boost::optional<T> FromJSONObjectOptional(json_t const * root, char const * field)
+std::optional<T> FromJSONObjectOptional(json_t const * root, char const * field)
 {
   auto * json = base::GetJSONOptionalField(root, field);
   if (!json)
     return {};
 
-  boost::optional<T> result{T{}};
+  std::optional<T> result{T{}};
   FromJSON(json, *result);
   return result;
 }

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -2000,7 +2000,7 @@ Java_com_mapswithme_maps_Framework_nativeHasMegafonCategoryBanner(JNIEnv * env, 
   if (!position)
     return static_cast<jboolean>(false);
 
-  auto const latLon = mercator::ToLatLon(position.get());
+  auto const latLon = mercator::ToLatLon(*position);
   return static_cast<jboolean>(ads::HasMegafonCategoryBanner(frm()->GetStorage(),
                                                              frm()->GetTopmostCountries(latLon),
                                                              languages::GetCurrentNorm()));
@@ -2111,7 +2111,9 @@ Java_com_mapswithme_maps_Framework_nativeGetCurrentTipIndex(JNIEnv * env, jclass
 {
   auto const & tipsApi = frm()->GetTipsApi();
   auto const tip = tipsApi.GetTip();
-  return tip.is_initialized() ? static_cast<jint>(tip.get()) : kUndefinedTip;
+  if (!tip)
+    return kUndefinedTip;
+  return static_cast<jint>(*tip);
 }
 
 JNIEXPORT void JNICALL

--- a/android/jni/com/mapswithme/maps/LightFramework.cpp
+++ b/android/jni/com/mapswithme/maps/LightFramework.cpp
@@ -101,7 +101,7 @@ Java_com_mapswithme_maps_LightFramework_nativeGetNotification(JNIEnv * env, jcla
   if (!notification)
     return nullptr;
 
-  auto const & n = notification.get();
+  auto const & n = *notification;
   // Type::UgcReview is only supported.
   CHECK_EQUAL(n.GetType(), notifications::NotificationCandidate::Type::UgcReview, ());
 

--- a/android/jni/com/mapswithme/maps/UserMarkHelper.cpp
+++ b/android/jni/com/mapswithme/maps/UserMarkHelper.cpp
@@ -62,9 +62,8 @@ jobject CreateHotelType(JNIEnv * env, place_page::Info const & info)
   static jmethodID const hotelTypeCtorId =
     jni::GetConstructorID(env, hotelTypeClass, "(ILjava/lang/String;)V");
 
-  auto const tag = ftypes::IsHotelChecker::GetHotelTypeTag(info.GetHotelType().get());
-  return env->NewObject(hotelTypeClass, hotelTypeCtorId,
-                        static_cast<jint>(info.GetHotelType().get()),
+  auto const tag = ftypes::IsHotelChecker::GetHotelTypeTag(*info.GetHotelType());
+  return env->NewObject(hotelTypeClass, hotelTypeCtorId, static_cast<jint>(*info.GetHotelType()),
                         jni::ToJavaString(env, tag));
 }
 
@@ -148,7 +147,7 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info)
   jni::TScopedLocalRef hotelType(env, CreateHotelType(env, info));
   jni::TScopedLocalRef popularity(env, CreatePopularity(env, info));
 
-  int priceRate = info.GetRawApproximatePricing().get_value_or(kPriceRateUndefined);
+  int priceRate = info.GetRawApproximatePricing().value_or(kPriceRateUndefined);
 
   if (info.IsBookmark())
   {

--- a/base/cancellable.hpp
+++ b/base/cancellable.hpp
@@ -3,9 +3,8 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 namespace base
 {
@@ -51,7 +50,7 @@ private:
 
   mutable Status m_status = Status::Active;
 
-  boost::optional<std::chrono::steady_clock::time_point> m_deadline;
+  std::optional<std::chrono::steady_clock::time_point> m_deadline;
 };
 
 std::string DebugPrint(Cancellable::Status status);

--- a/coding/csv_reader.cpp
+++ b/coding/csv_reader.cpp
@@ -46,7 +46,7 @@ CSVReader::Rows CSVReader::ReadAll()
   return file;
 }
 
-boost::optional<CSVReader::Row> CSVReader::ReadRow()
+std::optional<CSVReader::Row> CSVReader::ReadRow()
 {
   auto const line = m_reader->ReadLine();
   if (!line)
@@ -62,15 +62,15 @@ size_t CSVReader::GetCurrentLineNumber() const { return m_currentLine; }
 
 CSVReader::IstreamWrapper::IstreamWrapper(std::istream & stream) : m_stream(stream) {}
 
-boost::optional<std::string> CSVReader::IstreamWrapper::ReadLine()
+std::optional<std::string> CSVReader::IstreamWrapper::ReadLine()
 {
   std::string line;
-  return std::getline(m_stream, line) ? line : boost::optional<std::string>();
+  return std::getline(m_stream, line) ? line : std::optional<std::string>();
 }
 
 CSVReader::ReaderWrapper::ReaderWrapper(Reader const & reader) : m_reader(reader) {}
 
-boost::optional<std::string> CSVReader::ReaderWrapper::ReadLine()
+std::optional<std::string> CSVReader::ReaderWrapper::ReadLine()
 {
   std::vector<char> line;
   char ch = '\0';
@@ -98,7 +98,7 @@ CSVReader::DefaultReader::DefaultReader(std::string const & filename)
   m_stream.exceptions(std::ios::badbit);
 }
 
-boost::optional<std::string> CSVReader::DefaultReader::ReadLine()
+std::optional<std::string> CSVReader::DefaultReader::ReadLine()
 {
   return IstreamWrapper(m_stream).ReadLine();
 }

--- a/coding/csv_reader.hpp
+++ b/coding/csv_reader.hpp
@@ -4,11 +4,10 @@
 
 #include <fstream>
 #include <functional>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace coding
 {
@@ -26,7 +25,7 @@ public:
   char GetDelimiter() const;
 
   Row const & GetHeader() const;
-  boost::optional<Row> ReadRow();
+  std::optional<Row> ReadRow();
   Rows ReadAll();
 
   template <typename Fn>
@@ -45,7 +44,7 @@ private:
   public:
     virtual ~ReaderInterface() = default;
 
-    virtual boost::optional<std::string> ReadLine() = 0;
+    virtual std::optional<std::string> ReadLine() = 0;
   };
 
   class IstreamWrapper : public ReaderInterface
@@ -54,7 +53,7 @@ private:
     explicit IstreamWrapper(std::istream & stream);
 
     // ReaderInterface overrides:
-    boost::optional<std::string> ReadLine() override;
+    std::optional<std::string> ReadLine() override;
 
   private:
     std::istream & m_stream;
@@ -66,7 +65,7 @@ private:
     explicit ReaderWrapper(Reader const & reader);
 
     // ReaderInterface overrides:
-    boost::optional<std::string> ReadLine() override;
+    std::optional<std::string> ReadLine() override;
 
   private:
     size_t m_pos = 0;
@@ -79,7 +78,7 @@ private:
     explicit DefaultReader(std::string const & filename);
 
     // ReaderInterface overrides:
-    boost::optional<std::string> ReadLine() override;
+    std::optional<std::string> ReadLine() override;
 
   private:
     std::ifstream m_stream;
@@ -114,7 +113,7 @@ public:
 
   private:
     CSVReader & m_reader;
-    boost::optional<CSVReader::Row> m_current;
+    std::optional<CSVReader::Row> m_current;
   };
 
   // Warning: It reads first line.

--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -348,7 +348,7 @@ void VulkanBaseContext::ApplyFramebuffer(std::string const & framebufferLabel)
 
     if (m_currentFramebuffer == nullptr)
     {
-      colorFormat = m_surfaceFormat.get().format;
+      colorFormat = m_surfaceFormat->format;
       depthFormat = VulkanFormatUnpacker::Unpack(TextureFormat::Depth);
 
       fbData.m_packedAttachmentOperations = packedAttachmentOperations;
@@ -766,19 +766,19 @@ ref_ptr<VulkanStagingBuffer> VulkanBaseContext::GetDefaultStagingBuffer() const
   
 void VulkanBaseContext::RecreateSwapchain()
 {
-  CHECK(m_surface.is_initialized(), ());
-  CHECK(m_surfaceFormat.is_initialized(), ());
+  CHECK(m_surface.has_value(), ());
+  CHECK(m_surfaceFormat.has_value(), ());
 
   DestroySwapchain();
 
   VkSwapchainCreateInfoKHR swapchainCI = {};
   swapchainCI.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
   swapchainCI.pNext = nullptr;
-  swapchainCI.surface = m_surface.get();
+  swapchainCI.surface = *m_surface;
   swapchainCI.minImageCount = std::min(m_surfaceCapabilities.minImageCount + 1,
                                        m_surfaceCapabilities.maxImageCount);
-  swapchainCI.imageFormat = m_surfaceFormat.get().format;
-  swapchainCI.imageColorSpace = m_surfaceFormat.get().colorSpace;
+  swapchainCI.imageFormat = m_surfaceFormat->format;
+  swapchainCI.imageColorSpace = m_surfaceFormat->colorSpace;
   swapchainCI.imageExtent = m_surfaceCapabilities.currentExtent;
 
   swapchainCI.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -819,7 +819,7 @@ void VulkanBaseContext::RecreateSwapchain()
     swapchainImageViewCI.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     swapchainImageViewCI.image = m_swapchainImages[i];
     swapchainImageViewCI.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    swapchainImageViewCI.format = m_surfaceFormat.get().format;
+    swapchainImageViewCI.format = m_surfaceFormat->format;
     swapchainImageViewCI.components = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
                                        VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
     swapchainImageViewCI.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/drape/vulkan/vulkan_base_context.hpp
+++ b/drape/vulkan/vulkan_base_context.hpp
@@ -15,13 +15,12 @@
 #include <vulkan_wrapper.h>
 #include <vulkan/vulkan.h>
 
-#include <boost/optional.hpp>
-
 #include <array>
 #include <atomic>
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace dp
@@ -184,10 +183,10 @@ protected:
 
   ref_ptr<VulkanObjectManager> m_objectManager;
   drape_ptr<VulkanPipeline> m_pipeline;
-  boost::optional<VkSurfaceKHR> m_surface;
+  std::optional<VkSurfaceKHR> m_surface;
 
   VkSurfaceCapabilitiesKHR m_surfaceCapabilities;
-  boost::optional<VkSurfaceFormatKHR> m_surfaceFormat;
+  std::optional<VkSurfaceFormatKHR> m_surfaceFormat;
 
   VkSwapchainKHR m_swapchain = {};
   std::vector<VkImageView> m_swapchainImageViews;

--- a/drape/vulkan/vulkan_memory_manager.cpp
+++ b/drape/vulkan/vulkan_memory_manager.cpp
@@ -30,8 +30,9 @@ std::array<uint32_t, VulkanMemoryManager::kResourcesCount> const kDesiredSizeInB
   100 * 1024 * 1024,                     // Image
 }};
 
-VkMemoryPropertyFlags GetMemoryPropertyFlags(VulkanMemoryManager::ResourceType resourceType,
-                                             boost::optional<VkMemoryPropertyFlags> & fallbackTypeBits)
+VkMemoryPropertyFlags GetMemoryPropertyFlags(
+    VulkanMemoryManager::ResourceType resourceType,
+    std::optional<VkMemoryPropertyFlags> & fallbackTypeBits)
 {
   switch (resourceType)
   {
@@ -93,8 +94,8 @@ VulkanMemoryManager::~VulkanMemoryManager()
   ASSERT_EQUAL(m_totalAllocationCounter, 0, ());
 }
 
-boost::optional<uint32_t> VulkanMemoryManager::GetMemoryTypeIndex(uint32_t typeBits,
-                                                                  VkMemoryPropertyFlags properties) const
+std::optional<uint32_t> VulkanMemoryManager::GetMemoryTypeIndex(
+    uint32_t typeBits, VkMemoryPropertyFlags properties) const
 {
   for (uint32_t i = 0; i < m_memoryProperties.memoryTypeCount; i++)
   {
@@ -189,12 +190,12 @@ VulkanMemoryManager::AllocationPtr VulkanMemoryManager::Allocate(ResourceType re
   }
 
   // Looking for memory index by memory properties.
-  boost::optional<VkMemoryPropertyFlags> fallbackFlags;
+  std::optional<VkMemoryPropertyFlags> fallbackFlags;
   auto flags = GetMemoryPropertyFlags(resourceType, fallbackFlags);
   auto memoryTypeIndex = GetMemoryTypeIndex(memReqs.memoryTypeBits, flags);
   if (!memoryTypeIndex && fallbackFlags)
   {
-    flags = fallbackFlags.value();
+    flags = *fallbackFlags;
     memoryTypeIndex = GetMemoryTypeIndex(memReqs.memoryTypeBits, flags);
   }
 
@@ -209,7 +210,7 @@ VulkanMemoryManager::AllocationPtr VulkanMemoryManager::Allocate(ResourceType re
   memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
   memAllocInfo.pNext = nullptr;
   memAllocInfo.allocationSize = blockSize;
-  memAllocInfo.memoryTypeIndex = memoryTypeIndex.value();
+  memAllocInfo.memoryTypeIndex = *memoryTypeIndex;
   IncrementTotalAllocationsCount();
   CHECK_VK_CALL(vkAllocateMemory(m_device, &memAllocInfo, nullptr, &memory));
   m_sizes[static_cast<size_t>(resourceType)] += blockSize;

--- a/drape/vulkan/vulkan_memory_manager.hpp
+++ b/drape/vulkan/vulkan_memory_manager.hpp
@@ -5,14 +5,13 @@
 #include <vulkan_wrapper.h>
 #include <vulkan/vulkan.h>
 
-#include <boost/optional.hpp>
-
 #include <array>
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <vector>
+#include <optional>
 #include <unordered_map>
+#include <vector>
 
 namespace dp
 {
@@ -81,8 +80,8 @@ public:
   VkPhysicalDeviceLimits const & GetDeviceLimits() const;
 
 private:
-  boost::optional<uint32_t> GetMemoryTypeIndex(uint32_t typeBits,
-                                               VkMemoryPropertyFlags properties) const;
+  std::optional<uint32_t> GetMemoryTypeIndex(uint32_t typeBits,
+                                             VkMemoryPropertyFlags properties) const;
   void IncrementTotalAllocationsCount();
   void DecrementTotalAllocationsCount();
 

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1320,10 +1320,11 @@ void FrontendRenderer::ProcessSelection(ref_ptr<SelectObjectMessage> msg)
   if (msg->IsDismiss())
   {
     m_selectionShape->Hide();
-    if (!m_myPositionController->IsModeChangeViewport() && m_selectionTrackInfo.is_initialized())
+    if (!m_myPositionController->IsModeChangeViewport() && m_selectionTrackInfo.has_value())
     {
-      AddUserEvent(make_unique_dp<SetAnyRectEvent>(m_selectionTrackInfo.get().m_startRect, true /* isAnim */,
-                                                   false /* fitInViewport */, false /* useVisibleViewport */));
+      AddUserEvent(make_unique_dp<SetAnyRectEvent>(m_selectionTrackInfo->m_startRect,
+                                                   true /* isAnim */, false /* fitInViewport */,
+                                                   false /* useVisibleViewport */));
     }
     m_selectionTrackInfo.reset();
   }
@@ -2117,7 +2118,7 @@ bool FrontendRenderer::OnNewVisibleViewport(m2::RectD const & oldViewport, m2::R
 
   gOffset = m2::PointD(0, 0);
   if (m_myPositionController->IsModeChangeViewport() || m_selectionShape == nullptr ||
-      oldViewport == newViewport || !m_selectionTrackInfo.is_initialized())
+      oldViewport == newViewport || !m_selectionTrackInfo.has_value())
   {
     return false;
   }
@@ -2170,34 +2171,34 @@ bool FrontendRenderer::OnNewVisibleViewport(m2::RectD const & oldViewport, m2::R
 
   m2::PointD pOffset(0.0, 0.0);
   if ((oldViewport.IsIntersect(targetRect) && !newViewport.IsRectInside(rect)) ||
-      (newViewport.IsRectInside(rect) && m_selectionTrackInfo.get().m_snapSides != m2::PointI::Zero()))
+      (newViewport.IsRectInside(rect) && m_selectionTrackInfo->m_snapSides != m2::PointI::Zero()))
   {
     // In case the rect of the selection is [partly] hidden, scroll the map to keep it visible.
     // In case the rect of the selection is visible after the map scrolling,
     // try to rollback part of that scrolling to return the map to its original position.
-    if (rect.minX() < newViewport.minX() || m_selectionTrackInfo.get().m_snapSides.x < 0)
+    if (rect.minX() < newViewport.minX() || m_selectionTrackInfo->m_snapSides.x < 0)
     {
-      pOffset.x = std::max(m_selectionTrackInfo.get().m_startPos.x - pos.x, newViewport.minX() - rect.minX());
-      m_selectionTrackInfo.get().m_snapSides.x = -1;
+      pOffset.x = std::max(m_selectionTrackInfo->m_startPos.x - pos.x, newViewport.minX() - rect.minX());
+      m_selectionTrackInfo->m_snapSides.x = -1;
     }
-    else if (rect.maxX() > newViewport.maxX() || m_selectionTrackInfo.get().m_snapSides.x > 0)
+    else if (rect.maxX() > newViewport.maxX() || m_selectionTrackInfo->m_snapSides.x > 0)
     {
-      pOffset.x = std::min(m_selectionTrackInfo.get().m_startPos.x - pos.x, newViewport.maxX() - rect.maxX());
-      m_selectionTrackInfo.get().m_snapSides.x = 1;
+      pOffset.x = std::min(m_selectionTrackInfo->m_startPos.x - pos.x, newViewport.maxX() - rect.maxX());
+      m_selectionTrackInfo->m_snapSides.x = 1;
     }
 
-    if (rect.minY() < newViewport.minY() || m_selectionTrackInfo.get().m_snapSides.y < 0)
+    if (rect.minY() < newViewport.minY() || m_selectionTrackInfo->m_snapSides.y < 0)
     {
-      pOffset.y = std::max(m_selectionTrackInfo.get().m_startPos.y - pos.y, newViewport.minY() - rect.minY());
-      m_selectionTrackInfo.get().m_snapSides.y = -1;
+      pOffset.y = std::max(m_selectionTrackInfo->m_startPos.y - pos.y, newViewport.minY() - rect.minY());
+      m_selectionTrackInfo->m_snapSides.y = -1;
     }
-    else if (rect.maxY() > newViewport.maxY() || m_selectionTrackInfo.get().m_snapSides.y > 0)
+    else if (rect.maxY() > newViewport.maxY() || m_selectionTrackInfo->m_snapSides.y > 0)
     {
-      pOffset.y = std::min(m_selectionTrackInfo.get().m_startPos.y - pos.y, newViewport.maxY() - rect.maxY());
-      m_selectionTrackInfo.get().m_snapSides.y = 1;
+      pOffset.y = std::min(m_selectionTrackInfo->m_startPos.y - pos.y, newViewport.maxY() - rect.maxY());
+      m_selectionTrackInfo->m_snapSides.y = 1;
     }
   }
-  
+
   double const ptZ = m_selectionShape->GetPositionZ();
   gOffset = screen.PtoG(screen.P3dtoP(pos + pOffset, ptZ)) - screen.PtoG(screen.P3dtoP(pos, ptZ));
   return true;

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -37,10 +37,9 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_set>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace dp
 {
@@ -302,7 +301,7 @@ private:
     m2::PointD m_startPos;
     m2::PointI m_snapSides = m2::PointI::Zero();
   };
-  boost::optional<SelectionTrackInfo> m_selectionTrackInfo;
+  std::optional<SelectionTrackInfo> m_selectionTrackInfo;
 
   drape_ptr<RouteRenderer> m_routeRenderer;
   drape_ptr<TrafficRenderer> m_trafficRenderer;

--- a/editor/edits_migration.cpp
+++ b/editor/edits_migration.cpp
@@ -10,7 +10,7 @@
 
 #include "base/logging.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace editor
 {
@@ -51,7 +51,7 @@ FeatureID MigrateWayOrRelatonFeatureIndex(
     FeatureStatus const /* Unused for now (we don't create/delete area features)*/,
     GenerateIDFn const & /*Unused for the same reason*/)
 {
-  boost::optional<FeatureID> fid;
+  std::optional<FeatureID> fid;
   auto bestScore = 0.6;  // initial score is used as a threshold.
   auto geometry = xml.GetGeometry();
   auto count = 0;
@@ -99,7 +99,7 @@ FeatureID MigrateWayOrRelatonFeatureIndex(
     MYTHROW(MigrationError,
             ("None of returned ways suffice. Possibly, the feature has been deleted."));
   }
-  return fid.get();
+  return *fid;
 }
 
 FeatureID MigrateFeatureIndex(osm::Editor::ForEachFeaturesNearByFn & forEach,

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -501,7 +501,7 @@ void Editor::ForEachCreatedFeature(MwmSet::MwmId const & id, FeatureIndexFunctor
   }
 }
 
-boost::optional<osm::EditableMapObject> Editor::GetEditedFeature(FeatureID const & fid) const
+optional<osm::EditableMapObject> Editor::GetEditedFeature(FeatureID const & fid) const
 {
   auto const features = m_features.Get();
   auto const * featureInfo = GetFeatureTypeInfo(*features, fid.m_mwmId, fid.m_index);

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -24,11 +24,10 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace editor
 {
@@ -140,7 +139,7 @@ public:
   void DeleteFeature(FeatureID const & fid);
 
   /// @returns empty object if feature wasn't edited.
-  boost::optional<osm::EditableMapObject> GetEditedFeature(FeatureID const & fid) const;
+  std::optional<osm::EditableMapObject> GetEditedFeature(FeatureID const & fid) const;
 
   /// @returns false if feature wasn't edited.
   /// @param outFeatureStreet is valid only if true was returned.

--- a/generator/affiliation.cpp
+++ b/generator/affiliation.cpp
@@ -117,7 +117,8 @@ std::vector<std::string> CountriesFilesIndexAffiliation::GetAffiliations(Feature
   return oneCountry ? std::vector<std::string>{*oneCountry} : GetHonestAffiliations(fb);
 }
 
-boost::optional<std::string> CountriesFilesIndexAffiliation::IsOneCountryForBbox(FeatureBuilder const & fb) const
+std::optional<std::string> CountriesFilesIndexAffiliation::IsOneCountryForBbox(
+    FeatureBuilder const & fb) const
 {
   borders::CountryPolygons const * country = nullptr;
   std::vector<Value> values;
@@ -134,7 +135,7 @@ boost::optional<std::string> CountriesFilesIndexAffiliation::IsOneCountryForBbox
         return {};
     }
   }
-  return country ? country->GetName() : boost::optional<std::string>{};
+  return country ? country->GetName() : std::optional<std::string>{};
 }
 
 std::vector<std::string> CountriesFilesIndexAffiliation::GetHonestAffiliations(FeatureBuilder const & fb) const

--- a/generator/affiliation.hpp
+++ b/generator/affiliation.hpp
@@ -4,11 +4,11 @@
 #include "generator/cells_merger.hpp"
 #include "generator/feature_builder.hpp"
 
+#include <optional>
 #include <string>
 #include <vector>
 
 #include <boost/geometry/index/rtree.hpp>
-#include <boost/optional.hpp>
 
 namespace feature
 {
@@ -55,7 +55,7 @@ public:
 private:
   static Box MakeBox(m2::RectD const & rect);
   std::shared_ptr<Tree> BuildIndex(std::vector<m2::RectD> const & net);
-  boost::optional<std::string> IsOneCountryForBbox(FeatureBuilder const & fb) const;
+  std::optional<std::string> IsOneCountryForBbox(FeatureBuilder const & fb) const;
   std::vector<std::string> GetHonestAffiliations(FeatureBuilder const & fb) const;
 
   std::shared_ptr<Tree> m_index;

--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -256,8 +256,8 @@ void CamerasInfoCollector::Camera::FindClosestSegmentWithGeometryIndex(FrozenDat
     m_data.m_ways.emplace_back(bestFeatureId, bestSegmentId, bestCoef);
 }
 
-boost::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindMyself(
-  uint32_t wayFeatureId, FrozenDataSource const & dataSource, MwmSet::MwmId const & mwmId) const
+std::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindMyself(
+    uint32_t wayFeatureId, FrozenDataSource const & dataSource, MwmSet::MwmId const & mwmId) const
 {
   double coef = 0.0;
   bool isRoad = true;
@@ -299,7 +299,7 @@ boost::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindM
   dataSource.ReadFeature(readFeature, featureID);
 
   if (isRoad)
-    return boost::optional<std::pair<double, uint32_t>>({coef, result});
+    return std::optional<std::pair<double, uint32_t>>({coef, result});
 
   return {};
 }

--- a/generator/camera_info_collector.hpp
+++ b/generator/camera_info_collector.hpp
@@ -22,11 +22,10 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "boost/optional.hpp"
 
 namespace generator
 {
@@ -69,8 +68,9 @@ private:
     // Returns empty object, if current feature - |wayId| is not the car road.
     // Otherwise returns id of segment from feature with id - |wayId|, which starts (or ends) at camera's
     // center and coefficient - where it placed at the segment: 0.0 (or 1.0).
-    boost::optional<std::pair<double, uint32_t>> FindMyself(
-      uint32_t wayFeatureId, FrozenDataSource const & dataSource, MwmSet::MwmId const & mwmId) const;
+    std::optional<std::pair<double, uint32_t>> FindMyself(uint32_t wayFeatureId,
+                                                          FrozenDataSource const & dataSource,
+                                                          MwmSet::MwmId const & mwmId) const;
 
     void Serialize(FileWriter & writer, uint32_t & prevFeatureId) const;
 

--- a/generator/cells_merger.cpp
+++ b/generator/cells_merger.cpp
@@ -157,7 +157,7 @@ m2::PointI CellsMerger::FindBigSquare(m2::PointI const & xy, m2::PointI const & 
   }
 }
 
-boost::optional<m2::PointI> CellsMerger::FindDirection(m2::PointI const & startXy) const
+std::optional<m2::PointI> CellsMerger::FindDirection(m2::PointI const & startXy) const
 {
   std::array<std::pair<size_t, m2::PointI>, 4> directionsWithWeight;
   std::array<m2::PointI, 4> const directions{{{1, 1}, {-1, 1}, {1, -1}, {-1, -1}}};
@@ -171,7 +171,7 @@ boost::optional<m2::PointI> CellsMerger::FindDirection(m2::PointI const & startX
                  });
   auto const direction =
       std::max_element(std::cbegin(directionsWithWeight), std::cend(directionsWithWeight))->second;
-  return Has(startXy + direction) ? direction : boost::optional<m2::PointI>{};
+  return Has(startXy + direction) ? direction : std::optional<m2::PointI>{};
 }
 
 void CellsMerger::Remove(m2::PointI const & minXy, m2::PointI const & maxXy)
@@ -189,7 +189,7 @@ bool CellsMerger::Has(int32_t x, int32_t y) const { return m_matrix.count({x, y}
 
 bool CellsMerger::Has(const m2::PointI & xy) const { return Has(xy.x, xy.y); }
 
-boost::optional<m2::PointI> CellsMerger::FindMax() const
+std::optional<m2::PointI> CellsMerger::FindMax() const
 {
   m2::PointI max;
   size_t sum = 0;
@@ -202,7 +202,7 @@ boost::optional<m2::PointI> CellsMerger::FindMax() const
       max = pair.first;
     }
   }
-  return sum != 0 ? max : boost::optional<m2::PointI>{};
+  return sum != 0 ? max : std::optional<m2::PointI>{};
 }
 
 m2::RectD CellsMerger::Union(m2::PointI const & startXy)

--- a/generator/cells_merger.hpp
+++ b/generator/cells_merger.hpp
@@ -6,10 +6,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace generator
 {
@@ -63,8 +62,8 @@ private:
                              CellWrapper const & defaultValue = CellWrapper::kEmpty) const;
 
   void CalcSum();
-  boost::optional<m2::PointI> FindMax() const;
-  boost::optional<m2::PointI> FindDirection(m2::PointI const & startXy) const;
+  std::optional<m2::PointI> FindMax() const;
+  std::optional<m2::PointI> FindDirection(m2::PointI const & startXy) const;
   m2::PointI FindBigSquare(m2::PointI const & xy, m2::PointI const & direction) const;
   m2::RectD Union(m2::PointI const & startXy);
   void Remove(m2::PointI const & minXy, m2::PointI const & maxXy);

--- a/generator/collector_camera.cpp
+++ b/generator/collector_camera.cpp
@@ -35,7 +35,7 @@ namespace routing
 {
 size_t const CameraProcessor::kMaxSpeedSpeedStringLength = 32;
 
-boost::optional<double> GetMaxSpeedKmPH(std::string const & maxSpeedString)
+std::optional<double> GetMaxSpeedKmPH(std::string const & maxSpeedString)
 {
   routing::SpeedInUnits speed;
   if (!generator::ParseMaxspeedTag(maxSpeedString, speed) || !speed.IsNumeric())

--- a/generator/collector_camera.hpp
+++ b/generator/collector_camera.hpp
@@ -5,14 +5,13 @@
 #include "coding/file_writer.hpp"
 
 #include <cstdint>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace generator_tests
 {
@@ -43,7 +42,7 @@ namespace routing
 ///                         "130 kmh" - means 130 km per hour.
 /// See https://wiki.openstreetmap.org/wiki/Key:maxspeed
 /// for more details about input string.
-boost::optional<double> GetMaxSpeedKmPH(std::string const & maxSpeedString);
+std::optional<double> GetMaxSpeedKmPH(std::string const & maxSpeedString);
 
 class CameraProcessor
 {

--- a/generator/collector_routing_city_boundaries.cpp
+++ b/generator/collector_routing_city_boundaries.cpp
@@ -24,7 +24,7 @@ using namespace feature::serialization_policy;
 
 namespace
 {
-boost::optional<uint64_t> GetPlaceNodeFromMembers(OsmElement const & element)
+std::optional<uint64_t> GetPlaceNodeFromMembers(OsmElement const & element)
 {
   uint64_t adminCentreRef = 0;
   uint64_t labelRef = 0;

--- a/generator/descriptions_section_builder.cpp
+++ b/generator/descriptions_section_builder.cpp
@@ -52,7 +52,7 @@ WikidataHelper::WikidataHelper(std::string const & mwmPath, std::string const & 
   }
 }
 
-boost::optional<std::string> WikidataHelper::GetWikidataId(uint32_t featureId) const
+std::optional<std::string> WikidataHelper::GetWikidataId(uint32_t featureId) const
 {
   auto const itFeatureIdToOsmId = m_featureIdToOsmId.find(featureId);
   if (itFeatureIdToOsmId == std::end(m_featureIdToOsmId))
@@ -60,8 +60,8 @@ boost::optional<std::string> WikidataHelper::GetWikidataId(uint32_t featureId) c
 
   auto const osmId = itFeatureIdToOsmId->second;
   auto const itOsmIdToWikidataId = m_osmIdToWikidataId.find(osmId);
-  return itOsmIdToWikidataId == std::end(m_osmIdToWikidataId) ?
-        boost::optional<std::string>() : itOsmIdToWikidataId->second;
+  return itOsmIdToWikidataId == std::end(m_osmIdToWikidataId) ? std::optional<std::string>()
+                                                              : itOsmIdToWikidataId->second;
 }
 
 std::string DescriptionsCollectionBuilderStat::LangStatisticsToString() const
@@ -127,8 +127,8 @@ size_t DescriptionsCollectionBuilder::FillStringFromFile(std::string const & ful
   return contentSize;
 }
 
-boost::optional<size_t> DescriptionsCollectionBuilder::FindPageAndFill(std::string path,
-                                                                       StringUtf8Multilang & str)
+std::optional<size_t> DescriptionsCollectionBuilder::FindPageAndFill(std::string path,
+                                                                     StringUtf8Multilang & str)
 {
   if (!IsValidDir(path))
   {

--- a/generator/descriptions_section_builder.hpp
+++ b/generator/descriptions_section_builder.hpp
@@ -21,11 +21,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
-
-#include <boost/optional.hpp>
 
 namespace generator_tests
 {
@@ -40,7 +39,7 @@ public:
   WikidataHelper() = default;
   explicit WikidataHelper(std::string const & mwmPath, std::string const & idToWikidataPath);
 
-  boost::optional<std::string> GetWikidataId(uint32_t featureId) const;
+  std::optional<std::string> GetWikidataId(uint32_t featureId) const;
 
 private:
   std::string m_mwmPath;
@@ -158,7 +157,7 @@ public:
 private:
   static size_t FillStringFromFile(std::string const & fullPath, int8_t code,
                                    StringUtf8Multilang & str);
-  boost::optional<size_t> FindPageAndFill(std::string wikipediaUrl, StringUtf8Multilang & str);
+  std::optional<size_t> FindPageAndFill(std::string wikipediaUrl, StringUtf8Multilang & str);
   size_t GetFeatureDescription(std::string const & wikiUrl, uint32_t featureId,
                                descriptions::FeatureDescription & description);
 

--- a/generator/gen_mwm_info.hpp
+++ b/generator/gen_mwm_info.hpp
@@ -17,8 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 namespace generator
 {
 CompositeId MakeCompositeId(feature::FeatureBuilder const & fb);

--- a/generator/hierarchy.cpp
+++ b/generator/hierarchy.cpp
@@ -167,7 +167,7 @@ HierarchyEntryEnricher::HierarchyEntryEnricher(std::string const & osm2FtIdsPath
   CHECK(m_osm2FtIds.ReadFromFile(osm2FtIdsPath), (osm2FtIdsPath));
 }
 
-boost::optional<m2::PointD> HierarchyEntryEnricher::GetFeatureCenter(CompositeId const & id) const
+std::optional<m2::PointD> HierarchyEntryEnricher::GetFeatureCenter(CompositeId const & id) const
 {
   auto const optIds = m_osm2FtIds.GetFeatureIds(id);
   if (optIds.empty())

--- a/generator/hierarchy.hpp
+++ b/generator/hierarchy.hpp
@@ -26,13 +26,13 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <boost/geometry.hpp>
-#include <boost/optional.hpp>
 
 namespace generator
 {
@@ -101,7 +101,7 @@ class HierarchyEntryEnricher
 public:
   HierarchyEntryEnricher(std::string const & osm2FtIdsPath, std::string const & countryFullPath);
 
-  boost::optional<m2::PointD> GetFeatureCenter(CompositeId const & id) const;
+  std::optional<m2::PointD> GetFeatureCenter(CompositeId const & id) const;
 
 private:
   OsmID2FeatureID m_osm2FtIds;

--- a/generator/hierarchy_entry.hpp
+++ b/generator/hierarchy_entry.hpp
@@ -13,16 +13,15 @@
 #include "coding/csv_reader.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 namespace generator
 {
 struct HierarchyEntry
 {
   CompositeId m_id;
-  boost::optional<CompositeId> m_parentId;
+  std::optional<CompositeId> m_parentId;
   size_t m_depth = 0;
   std::string m_name;
   storage::CountryId m_country;

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -16,11 +16,10 @@
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
+#include <optional>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
-
-#include "boost/optional.hpp"
 
 using namespace std;
 
@@ -299,7 +298,7 @@ string MetadataTagProcessorImpl::ValidateAndFormat_duration(string const & v) co
     return ss.str();
   };
 
-  auto const readNumber = [&v](size_t & pos) -> boost::optional<uint32_t> {
+  auto const readNumber = [&v](size_t & pos) -> optional<uint32_t> {
     uint32_t number = 0;
     size_t const startPos = pos;
     while (pos < v.size() && isdigit(v[pos]))
@@ -315,7 +314,7 @@ string MetadataTagProcessorImpl::ValidateAndFormat_duration(string const & v) co
     return {number};
   };
 
-  auto const convert = [](char type, uint32_t number) -> boost::optional<double> {
+  auto const convert = [](char type, uint32_t number) -> optional<double> {
     switch (type)
     {
     case 'H': return number;
@@ -331,7 +330,7 @@ string MetadataTagProcessorImpl::ValidateAndFormat_duration(string const & v) co
 
   double hours = 0.0;
   size_t pos = 0;
-  boost::optional<uint32_t> op;
+  optional<uint32_t> op;
 
   if (strings::StartsWith(v, "PT"))
   {

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -21,8 +21,6 @@
 #include <sstream>
 #include <unordered_set>
 
-#include "boost/optional.hpp"
-
 namespace
 {
 using namespace routing;

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -27,7 +27,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "defines.hpp"
 
@@ -364,10 +364,10 @@ RoadAccess::Type RoadAccessTagProcessor::GetAccessType(OsmElement const & elem) 
     {
       auto const accessType = GetAccessTypeFromMapping(elem, tagMapping);
       if (accessType != RoadAccess::Type::Count)
-        return boost::optional<RoadAccess::Type>(accessType);
+        return optional<RoadAccess::Type>(accessType);
     }
 
-    return boost::optional<RoadAccess::Type>();
+    return optional<RoadAccess::Type>();
   };
 
   if (auto op = getType(m_accessMappings))

--- a/indexer/ftraits.hpp
+++ b/indexer/ftraits.hpp
@@ -13,11 +13,10 @@
 #include <array>
 #include <cstdint>
 #include <initializer_list>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
-
-#include <boost/optional.hpp>
 
 namespace ftraits
 {
@@ -25,22 +24,22 @@ template <typename Base, typename Value>
 class TraitsBase
 {
 public:
-  static boost::optional<Value> GetValue(feature::TypesHolder const & types)
+  static std::optional<Value> GetValue(feature::TypesHolder const & types)
   {
     auto const & instance = Instance();
     auto const it = Find(types);
     if (!instance.m_matcher.IsValid(it))
-      return boost::none;
+      return std::nullopt;
 
     return it->second;
   }
 
-  static boost::optional<uint32_t> GetType(feature::TypesHolder const & types)
+  static std::optional<uint32_t> GetType(feature::TypesHolder const & types)
   {
     auto const & instance = Instance();
     auto const it = Find(types);
     if (!instance.m_matcher.IsValid(it))
-      return boost::none;
+      return std::nullopt;
 
     return it->first;
   }

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -104,7 +104,7 @@ string DebugPrint(HighwayClass const cls)
   return out.str();
 }
 
-std::string DebugPrint(LocalityType const localityType)
+string DebugPrint(LocalityType const localityType)
 {
   switch (localityType)
   {
@@ -545,7 +545,7 @@ uint32_t IsCoastlineChecker::GetCoastlineType() const
   return m_types[0];
 }
 
-boost::optional<IsHotelChecker::Type> IsHotelChecker::GetHotelType(FeatureType & ft) const
+optional<IsHotelChecker::Type> IsHotelChecker::GetHotelType(FeatureType & ft) const
 {
   feature::TypesHolder types(ft);
   buffer_vector<uint32_t, feature::kMaxTypesCount> sortedTypes(types.begin(), types.end());

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -10,13 +10,12 @@
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <optional>
 #include <set>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace feature { class TypesHolder; }
 class FeatureType;
@@ -299,7 +298,7 @@ public:
 
   unsigned GetHotelTypesMask(FeatureType & ft) const;
 
-  boost::optional<Type> GetHotelType(FeatureType & ft) const;
+  std::optional<Type> GetHotelType(FeatureType & ft) const;
 
   DECLARE_CHECKER_INSTANCE(IsHotelChecker);
 private:

--- a/indexer/shared_load_info.cpp
+++ b/indexer/shared_load_info.cpp
@@ -42,7 +42,7 @@ SharedLoadInfo::Reader SharedLoadInfo::GetTrianglesReader(int ind) const
   return m_cont.GetReader(GetTagForIndex(TRIANGLE_FILE_TAG, ind));
 }
 
-boost::optional<SharedLoadInfo::Reader> SharedLoadInfo::GetPostcodesReader() const
+std::optional<SharedLoadInfo::Reader> SharedLoadInfo::GetPostcodesReader() const
 {
   if (!m_cont.IsExist(POSTCODES_FILE_TAG))
     return {};

--- a/indexer/shared_load_info.hpp
+++ b/indexer/shared_load_info.hpp
@@ -7,7 +7,7 @@
 
 #include "base/macros.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace feature
 {
@@ -26,7 +26,7 @@ public:
   Reader GetAltitudeReader() const;
   Reader GetGeometryReader(int ind) const;
   Reader GetTrianglesReader(int ind) const;
-  boost::optional<Reader> GetPostcodesReader() const;
+  std::optional<Reader> GetPostcodesReader() const;
 
   version::Format GetMWMFormat() const { return m_header.GetFormat(); }
 

--- a/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.mm
@@ -32,8 +32,8 @@
 
   if (GetPlatform().ConnectionStatus() == Platform::EConnectionType::CONNECTION_NONE)
     return NO;
-  
-  auto const latLon = mercator::ToLatLon(position.get());
+
+  auto const latLon = mercator::ToLatLon(*position);
   return ads::HasMegafonCategoryBanner(f.GetStorage(), f.GetTopmostCountries(latLon),
                                        languages::GetCurrentNorm());
 }

--- a/iphone/Maps/Core/Notifications/LocalNotificationManager.mm
+++ b/iphone/Maps/Core/Notifications/LocalNotificationManager.mm
@@ -49,7 +49,7 @@ static NSString * const kLastUGCNotificationDate = @"LastUGCNotificationDate";
 
   if (notificationCandidate)
   {
-    auto const notification = notificationCandidate.get();
+    auto const notification = *notificationCandidate;
     if (notification.GetType() == notifications::NotificationCandidate::Type::UgcReview)
     {
       CoreNotificationWrapper * w = [[CoreNotificationWrapper alloc] initWithNotificationCandidate:notification];

--- a/iphone/Maps/UI/PlacePage/MWMPlacePageData.h
+++ b/iphone/Maps/UI/PlacePage/MWMPlacePageData.h
@@ -10,9 +10,8 @@
 
 #include "platform/network_policy.hpp"
 
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 @class MWMPlacePageData;
 @class MWMUGCReviewVM;
@@ -203,8 +202,8 @@ typedef void (^RefreshPromoCallbackBlock)(NSIndexSet *insertedSections);
 - (NSURL *)URLToAllReviews;
 - (NSArray<MWMGalleryItemModel *> *)photos;
 
-- (boost::optional<int>)hotelRawApproximatePricing;
-- (boost::optional<ftypes::IsHotelChecker::Type>)hotelType;
+- (std::optional<int>)hotelRawApproximatePricing;
+- (std::optional<ftypes::IsHotelChecker::Type>)hotelType;
 
 // Partners
 - (NSString *)partnerName;

--- a/iphone/Maps/UI/PlacePage/MWMPlacePageData.mm
+++ b/iphone/Maps/UI/PlacePage/MWMPlacePageData.mm
@@ -637,13 +637,11 @@ NSString * const kUserDefaultsLatLonAsDMSKey = @"UserDefaultsLatLonAsDMS";
   return _photos;
 }
 
-- (boost::optional<int>)hotelRawApproximatePricing
-{
+- (std::optional<int>)hotelRawApproximatePricing {
   return [self getRawData].GetRawApproximatePricing();
 }
 
-- (boost::optional<ftypes::IsHotelChecker::Type>)hotelType
-{
+- (std::optional<ftypes::IsHotelChecker::Type>)hotelType {
   return [self getRawData].GetHotelType();
 }
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1198,7 +1198,7 @@ void BookmarkManager::SortByTime(std::vector<SortBookmarkData> const & bookmarks
 
   auto const currentTime = std::chrono::system_clock::now();
 
-  boost::optional<SortedByTimeBlockType> lastBlockType;
+  std::optional<SortedByTimeBlockType> lastBlockType;
   SortedBlock currentBlock;
   for (auto mark : sortedMarks)
   {
@@ -1208,17 +1208,17 @@ void BookmarkManager::SortByTime(std::vector<SortBookmarkData> const & bookmarks
 
     if (!lastBlockType)
     {
-      lastBlockType.reset(currentBlockType);
+      lastBlockType = currentBlockType;
       currentBlock.m_blockName = GetSortedByTimeBlockName(currentBlockType);
     }
 
-    if (currentBlockType != lastBlockType.get())
+    if (currentBlockType != *lastBlockType)
     {
       sortedBlocks.push_back(currentBlock);
       currentBlock = SortedBlock();
       currentBlock.m_blockName = GetSortedByTimeBlockName(currentBlockType);
     }
-    lastBlockType.reset(currentBlockType);
+    lastBlockType = currentBlockType;
     currentBlock.m_markIds.push_back(mark->m_id);
   }
   if (!currentBlock.m_markIds.empty())
@@ -1897,7 +1897,7 @@ void BookmarkManager::LoadBookmarkRoutine(std::string const & filePath, bool isT
     auto const savePath = GetKMLPath(filePath);
     if (savePath)
     {
-      auto fileSavePath = savePath.get();
+      auto fileSavePath = *savePath;
       auto kmlData = LoadKmlFile(fileSavePath, KmlFileType::Text);
       if (m_needTeardown)
         return;
@@ -2005,7 +2005,7 @@ void BookmarkManager::NotifyAboutFile(bool success, std::string const & filePath
   });
 }
 
-boost::optional<std::string> BookmarkManager::GetKMLPath(std::string const & filePath)
+std::optional<std::string> BookmarkManager::GetKMLPath(std::string const & filePath)
 {
   std::string const fileExt = GetFileExt(filePath);
   std::string fileSavePath;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -25,10 +25,9 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace search
 {
@@ -624,7 +623,7 @@ private:
 
   void NotifyAboutStartAsyncLoading();
   void NotifyAboutFinishAsyncLoading(KMLDataCollectionPtr && collection);
-  boost::optional<std::string> GetKMLPath(std::string const & filePath);
+  std::optional<std::string> GetKMLPath(std::string const & filePath);
   void NotifyAboutFile(bool success, std::string const & filePath, bool isTemporaryFile);
   void LoadBookmarkRoutine(std::string const & filePath, bool isTemporaryFile);
   

--- a/map/everywhere_search_params.hpp
+++ b/map/everywhere_search_params.hpp
@@ -9,10 +9,9 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace search
 {
@@ -25,7 +24,7 @@ struct EverywhereSearchParams
   std::string m_inputLocale;
   std::shared_ptr<hotels_filter::Rule> m_hotelsFilter;
   booking::filter::Tasks m_bookingFilterTasks;
-  boost::optional<std::chrono::steady_clock::duration> m_timeout;
+  std::optional<std::chrono::steady_clock::duration> m_timeout;
 
   OnResults m_onResults;
 };

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -448,7 +448,7 @@ Framework::Framework(FrameworkParams const & params)
   {
     auto const userPos = GetCurrentPosition();
     if (userPos)
-      OnRouteStartBuild(m_featuresFetcher.GetDataSource(), points, userPos.get());
+      OnRouteStartBuild(m_featuresFetcher.GetDataSource(), points, *userPos);
   });
 
   InitCityFinder();
@@ -2351,16 +2351,16 @@ void Framework::SetPlacePageListeners(PlacePageEvent::OnOpen const & onOpen,
 place_page::Info const & Framework::GetCurrentPlacePageInfo() const
 {
   CHECK(IsPlacePageOpened(), ());
-  return m_currentPlacePageInfo.get();
+  return *m_currentPlacePageInfo;
 }
 
 place_page::Info & Framework::GetCurrentPlacePageInfo()
 {
   CHECK(IsPlacePageOpened(), ());
-  return m_currentPlacePageInfo.get();
+  return *m_currentPlacePageInfo;
 }
 
-void Framework::ActivateMapSelection(boost::optional<place_page::Info> const & info)
+void Framework::ActivateMapSelection(std::optional<place_page::Info> const & info)
 {
   if (!info)
     return;
@@ -2523,7 +2523,8 @@ FeatureID Framework::FindBuildingAtPoint(m2::PointD const & mercator) const
   return featureId;
 }
 
-boost::optional<place_page::Info> Framework::BuildPlacePageInfo(place_page::BuildInfo const & buildInfo)
+std::optional<place_page::Info> Framework::BuildPlacePageInfo(
+    place_page::BuildInfo const & buildInfo)
 {
   place_page::Info outInfo;
   if (m_drapeEngine == nullptr)
@@ -2628,7 +2629,8 @@ boost::optional<place_page::Info> Framework::BuildPlacePageInfo(place_page::Buil
   return {};
 }
 
-void Framework::UpdatePlacePageInfoForCurrentSelection(boost::optional<place_page::BuildInfo> const & overrideInfo)
+void Framework::UpdatePlacePageInfoForCurrentSelection(
+    std::optional<place_page::BuildInfo> const & overrideInfo)
 {
   if (!m_currentPlacePageInfo)
     return;
@@ -3723,7 +3725,7 @@ void Framework::ClearViewportSearchResults()
   GetBookmarkManager().GetEditSession().ClearGroup(UserMark::Type::SEARCH);
 }
 
-boost::optional<m2::PointD> Framework::GetCurrentPosition() const
+std::optional<m2::PointD> Framework::GetCurrentPosition() const
 {
   auto const & myPosMark = GetBookmarkManager().MyPositionMark();
   if (!myPosMark.HasPosition())

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -91,11 +91,10 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace osm
 {
@@ -381,19 +380,20 @@ public:
                                  booking::filter::Types types) override;
   void ClearViewportSearchResults() override;
   // PositionProvider, SearchApi::Delegate and TipsApi::Delegate override.
-  boost::optional<m2::PointD> GetCurrentPosition() const override;
+  std::optional<m2::PointD> GetCurrentPosition() const override;
   bool ParseSearchQueryCommand(search::SearchParams const & params) override;
   search::ProductInfo GetProductInfo(search::Result const & result) const override;
   double GetMinDistanceBetweenResults() const override;
 
 private:
-  void ActivateMapSelection(boost::optional<place_page::Info> const & info);
+  void ActivateMapSelection(std::optional<place_page::Info> const & info);
   void InvalidateUserMarks();
 
 public:
   void DeactivateMapSelection(bool notifyUI);
   /// Used to "refresh" UI in some cases (e.g. feature editing).
-  void UpdatePlacePageInfoForCurrentSelection(boost::optional<place_page::BuildInfo> const & overrideInfo = {});
+  void UpdatePlacePageInfoForCurrentSelection(
+      std::optional<place_page::BuildInfo> const & overrideInfo = {});
 
   struct PlacePageEvent
   {
@@ -434,10 +434,10 @@ public:
                     std::vector<FeatureID> const & features);
 
 private:
-  boost::optional<place_page::Info> m_currentPlacePageInfo;
+  std::optional<place_page::Info> m_currentPlacePageInfo;
 
   void OnTapEvent(place_page::BuildInfo const & buildInfo);
-  boost::optional<place_page::Info> BuildPlacePageInfo(place_page::BuildInfo const & buildInfo);
+  std::optional<place_page::Info> BuildPlacePageInfo(place_page::BuildInfo const & buildInfo);
   UserMark const * FindUserMarkInTapPosition(place_page::BuildInfo const & buildInfo) const;
   FeatureID FindBuildingAtPoint(m2::PointD const & mercator) const;
 

--- a/map/framework_light.hpp
+++ b/map/framework_light.hpp
@@ -18,8 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 namespace lightweight
 {
 struct LightFrameworkTest;

--- a/map/map_tests/notification_tests.cpp
+++ b/map/map_tests/notification_tests.cpp
@@ -166,11 +166,11 @@ UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckRouteToInSam
 
   auto result = notificationManager.GetNotification();
 
-  TEST(result.is_initialized(), ());
-  TEST_EQUAL(result.get().GetType(), NotificationCandidate::Type::UgcReview, ());
+  TEST(result.has_value(), ());
+  TEST_EQUAL(result->GetType(), NotificationCandidate::Type::UgcReview, ());
 
   result = notificationManager.GetNotification();
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 }
 
 UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckUgcNotSavedTrigger)
@@ -206,18 +206,18 @@ UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckUgcNotSavedT
 
   auto result = notificationManager.GetNotification();
 
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 
   auto & candidate = notificationManager.GetEditableQueue().m_candidates[0];
   NotificationManagerForTesting::SetCreatedTime(candidate, Clock::now() - hours(25));
 
   result = notificationManager.GetNotification();
 
-  TEST(result.is_initialized(), ());
-  TEST_EQUAL(result.get().GetType(), NotificationCandidate::Type::UgcReview, ());
+  TEST(result.has_value(), ());
+  TEST_EQUAL(result->GetType(), NotificationCandidate::Type::UgcReview, ());
 
   result = notificationManager.GetNotification();
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 
   {
     eye::MapObject::Event event;
@@ -238,7 +238,7 @@ UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckUgcNotSavedT
   }
 
   result = notificationManager.GetNotification();
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 }
 
 UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckPlannedTripTrigger)
@@ -285,17 +285,17 @@ UNIT_CLASS_TEST(ScopedNotificationsQueue, Notifications_UgcRateCheckPlannedTripT
 
   auto result = notificationManager.GetNotification();
 
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 
   auto & candidate = notificationManager.GetEditableQueue().m_candidates[0];
   NotificationManagerForTesting::SetCreatedTime(candidate, Clock::now() - hours(25));
 
   result = notificationManager.GetNotification();
 
-  TEST(result.is_initialized(), ());
-  TEST_EQUAL(result.get().GetType(), NotificationCandidate::Type::UgcReview, ());
+  TEST(result.has_value(), ());
+  TEST_EQUAL(result->GetType(), NotificationCandidate::Type::UgcReview, ());
 
   result = notificationManager.GetNotification();
-  TEST(!result.is_initialized(), ());
+  TEST(!result.has_value(), ());
 }
 }  // namespace

--- a/map/map_tests/tips_tests.cpp
+++ b/map/map_tests/tips_tests.cpp
@@ -10,9 +10,8 @@
 #include "base/timer.hpp"
 
 #include <algorithm>
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 using namespace eye;
 
@@ -27,10 +26,7 @@ public:
   }
 
   // TipsApi::Delegate overrides:
-  boost::optional<m2::PointD> GetCurrentPosition() const override
-  {
-    return {};
-  }
+  std::optional<m2::PointD> GetCurrentPosition() const override { return {}; }
 
   bool IsCountryLoaded(m2::PointD const & pt) const override { return false; }
 
@@ -52,9 +48,9 @@ void MakeLastShownTipAvailableByTime()
   EyeForTesting::SetInfo(editableInfo);
 }
 
-boost::optional<eye::Tip::Type> GetTipForTesting(TipsApi::Duration showAnyTipPeriod,
-                                                 TipsApi::Duration showSameTipPeriod,
-                                                 TipsApiDelegate const & delegate)
+std::optional<eye::Tip::Type> GetTipForTesting(TipsApi::Duration showAnyTipPeriod,
+                                               TipsApi::Duration showSameTipPeriod,
+                                               TipsApiDelegate const & delegate)
 {
   // Do not use additional conditions for testing.
   TipsApi::Conditions conditions =
@@ -71,7 +67,7 @@ boost::optional<eye::Tip::Type> GetTipForTesting(TipsApi::Duration showAnyTipPer
   return TipsApi::GetTipForTesting(showAnyTipPeriod, showSameTipPeriod, delegate, conditions);
 }
 
-boost::optional<eye::Tip::Type> GetTipForTesting()
+std::optional<eye::Tip::Type> GetTipForTesting()
 {
   return GetTipForTesting(TipsApi::GetShowAnyTipPeriod(), TipsApi::GetShowSameTipPeriod(), {});
 }
@@ -81,8 +77,8 @@ void ShowTipWithClickCountTest(Tip::Event eventType, size_t maxClickCount)
   std::vector<Tip::Type> usedTips;
   auto previousTip = GetTipForTesting();
 
-  TEST(previousTip.is_initialized(), ());
-  TEST_NOT_EQUAL(previousTip.get(), Tip::Type::Count, ());
+  TEST(previousTip.has_value(), ());
+  TEST_NOT_EQUAL(*previousTip, Tip::Type::Count, ());
 
   auto const totalTipsCount = static_cast<size_t>(Tip::Type::Count);
 
@@ -90,44 +86,44 @@ void ShowTipWithClickCountTest(Tip::Event eventType, size_t maxClickCount)
   {
     auto tip = GetTipForTesting();
 
-    TEST(tip.is_initialized(), ());
-    TEST_NOT_EQUAL(tip.get(), Tip::Type::Count, ());
+    TEST(tip.has_value(), ());
+    TEST_NOT_EQUAL(*tip, Tip::Type::Count, ());
 
-    EyeForTesting::AppendTip(tip.get(), eventType);
+    EyeForTesting::AppendTip(*tip, eventType);
 
-    boost::optional<Tip::Type> secondTip;
+    std::optional<Tip::Type> secondTip;
     for (size_t j = 1; j < maxClickCount; ++j)
     {
       MakeLastShownTipAvailableByTime();
 
       secondTip = GetTipForTesting();
-      TEST(secondTip.is_initialized(), ());
+      TEST(secondTip.has_value(), ());
 
-      EyeForTesting::AppendTip(tip.get(), eventType);
+      EyeForTesting::AppendTip(*tip, eventType);
     }
 
     MakeLastShownTipAvailableByTime();
 
     secondTip = GetTipForTesting();
-    TEST(!secondTip.is_initialized() || secondTip.get() != tip.get(), ());
+    TEST(!secondTip.has_value() || *secondTip != *tip, ());
   }
 
   auto emptyTip = GetTipForTesting();
-  TEST(!emptyTip.is_initialized(), ());
+  TEST(!emptyTip.has_value(), ());
 }
 
 UNIT_CLASS_TEST(ScopedEyeForTesting, ShowAnyTipPeriod_Test)
 {
   auto firstTip = GetTipForTesting();
 
-  TEST(firstTip.is_initialized(), ());
-  TEST_NOT_EQUAL(firstTip.get(), Tip::Type::Count, ());
+  TEST(firstTip.has_value(), ());
+  TEST_NOT_EQUAL(*firstTip, Tip::Type::Count, ());
 
-  EyeForTesting::AppendTip(firstTip.get(), Tip::Event::GotitClicked);
+  EyeForTesting::AppendTip(*firstTip, Tip::Event::GotitClicked);
 
   auto secondTip = GetTipForTesting();
 
-  TEST(!secondTip.is_initialized(), ());
+  TEST(!secondTip.has_value(), ());
 }
 
 UNIT_CLASS_TEST(ScopedEyeForTesting, ShowFirstTip_Test)
@@ -135,8 +131,8 @@ UNIT_CLASS_TEST(ScopedEyeForTesting, ShowFirstTip_Test)
   std::vector<Tip::Type> usedTips;
   auto previousTip = GetTipForTesting();
 
-  TEST(previousTip.is_initialized(), ());
-  TEST_NOT_EQUAL(previousTip.get(), Tip::Type::Count, ());
+  TEST(previousTip.has_value(), ());
+  TEST_NOT_EQUAL(*previousTip, Tip::Type::Count, ());
 
   auto const totalTipsCount = static_cast<size_t>(Tip::Type::Count);
 
@@ -144,24 +140,24 @@ UNIT_CLASS_TEST(ScopedEyeForTesting, ShowFirstTip_Test)
   {
     auto tip = GetTipForTesting({}, TipsApi::GetShowSameTipPeriod(), {});
 
-    TEST(tip.is_initialized(), ());
-    TEST_NOT_EQUAL(tip.get(), Tip::Type::Count, ());
+    TEST(tip.has_value(), ());
+    TEST_NOT_EQUAL(*tip, Tip::Type::Count, ());
 
-    auto const it = std::find(usedTips.cbegin(), usedTips.cend(), tip.get());
+    auto const it = std::find(usedTips.cbegin(), usedTips.cend(), *tip);
     TEST(it == usedTips.cend(), ());
 
     if (i % 2 == 0)
-      EyeForTesting::AppendTip(tip.get(), Tip::Event::ActionClicked);
+      EyeForTesting::AppendTip(*tip, Tip::Event::ActionClicked);
     else
-      EyeForTesting::AppendTip(tip.get(), Tip::Event::GotitClicked);
+      EyeForTesting::AppendTip(*tip, Tip::Event::GotitClicked);
 
-    TEST(!GetTipForTesting().is_initialized(), ());
+    TEST(!GetTipForTesting().has_value(), ());
 
-    usedTips.emplace_back(tip.get());
+    usedTips.emplace_back(*tip);
   }
 
   auto emptyTip = GetTipForTesting();
-  TEST(!emptyTip.is_initialized(), ());
+  TEST(!emptyTip.has_value(), ());
 }
 
 UNIT_CLASS_TEST(ScopedEyeForTesting, ShowTipAndActionClicked_Test)
@@ -179,9 +175,9 @@ UNIT_CLASS_TEST(ScopedEyeForTesting, ShowTipAfterWarmStart)
   TipsApiDelegate d;
   d.SetLastBackgroundTime(base::Timer::LocalTime());
   auto tip = GetTipForTesting({}, TipsApi::GetShowSameTipPeriod(), d);
-  TEST(!tip.is_initialized(), ());
+  TEST(!tip.has_value(), ());
   d.SetLastBackgroundTime(base::Timer::LocalTime() - TipsApi::ShowTipAfterCollapsingPeriod().count());
   tip = GetTipForTesting({}, TipsApi::GetShowSameTipPeriod(), d);
-  TEST(tip.is_initialized(), ());
+  TEST(tip.has_value(), ());
 }
 }  // namespace

--- a/map/notifications/notification_manager.hpp
+++ b/map/notifications/notification_manager.hpp
@@ -8,13 +8,12 @@
 
 #include <ctime>
 #include <memory>
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 namespace notifications
 {
-using Notification = boost::optional<NotificationCandidate>;
+using Notification = std::optional<NotificationCandidate>;
 class NotificationManager : public eye::Subscriber
 {
 public:

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -305,7 +305,7 @@ std::string Info::GetApproximatePricing() const
   return result;
 }
 
-boost::optional<int> Info::GetRawApproximatePricing() const
+std::optional<int> Info::GetRawApproximatePricing() const
 {
   if (!IsSponsored())
     return {};

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -27,11 +27,10 @@
 #include "defines.hpp"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace ads
 {
@@ -178,7 +177,7 @@ public:
   float GetRatingRawValue() const;
   /// @returns string with |kPricingSymbol| signs or empty std::string if it isn't booking object
   std::string GetApproximatePricing() const;
-  boost::optional<int> GetRawApproximatePricing() const;
+  std::optional<int> GetRawApproximatePricing() const;
 
   /// UI setters
   void SetCustomName(std::string const & name);
@@ -294,7 +293,7 @@ public:
   void SetMercator(m2::PointD const & mercator) { m_mercator = mercator; }
   std::vector<std::string> GetRawTypes() const { return m_types.ToObjectNames(); }
 
-  boost::optional<ftypes::IsHotelChecker::Type> GetHotelType() const { return m_hotelType; }
+  std::optional<ftypes::IsHotelChecker::Type> GetHotelType() const { return m_hotelType; }
 
   void SetPopularity(uint8_t popularity) { m_popularity = popularity; }
   uint8_t GetPopularity() const { return m_popularity; }
@@ -394,7 +393,7 @@ private:
 
   feature::TypesHolder m_sortedTypes;
 
-  boost::optional<ftypes::IsHotelChecker::Type> m_hotelType;
+  std::optional<ftypes::IsHotelChecker::Type> m_hotelType;
 
   uint8_t m_popularity = 0;
 

--- a/map/position_provider.hpp
+++ b/map/position_provider.hpp
@@ -2,12 +2,12 @@
 
 #include "geometry/point2d.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 class PositionProvider
 {
 public:
   virtual ~PositionProvider() = default;
 
-  virtual boost::optional<m2::PointD> GetCurrentPosition() const = 0;
+  virtual std::optional<m2::PointD> GetCurrentPosition() const = 0;
 };

--- a/map/search_api.hpp
+++ b/map/search_api.hpp
@@ -21,12 +21,11 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class DataSource;
 
@@ -71,7 +70,7 @@ public:
 
     virtual void ClearViewportSearchResults() {}
 
-    virtual boost::optional<m2::PointD> GetCurrentPosition() const { return {}; };
+    virtual std::optional<m2::PointD> GetCurrentPosition() const { return {}; };
 
     virtual bool ParseSearchQueryCommand(search::SearchParams const & /* params */)
     {

--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -186,8 +186,8 @@ m2::PointD GetSize(SearchMarkType searchMarkType, bool hasLocalAds, bool isRated
   if (!SearchMarks::HaveSizes())
     return {};
 
-  auto const pixelSize =
-      SearchMarks::GetSize(GetSymbol(searchMarkType, hasLocalAds, isRated)).get_value_or({});
+  auto const pixelSize = SearchMarks::GetSize(GetSymbol(searchMarkType, hasLocalAds, isRated))
+                             .value_or(m2::PointD::Zero());
   double const pixelToMercator = modelView.GetScale();
   return {pixelToMercator * pixelSize.x, pixelToMercator * pixelSize.y};
 }
@@ -355,7 +355,7 @@ drape_ptr<df::UserPointMark::SymbolOffsets> SearchMarkPoint::GetSymbolOffsets() 
     return nullptr;
 
   auto const name = GetSymbolName();
-  auto const iconSz = SearchMarks::GetSize(name).get_value_or({});
+  auto const iconSz = SearchMarks::GetSize(name).value_or(m2::PointD::Zero());
 
   float horizontalOffset = 0.0f;
   if (SMT(m_type) != SearchMarkType::Booking && m_hasLocalAds)
@@ -366,7 +366,7 @@ drape_ptr<df::UserPointMark::SymbolOffsets> SearchMarkPoint::GetSymbolOffsets() 
   SymbolOffsets offsets(scales::UPPER_STYLE_SCALE);
   for (size_t i = 0; i < offsets.size(); i++)
   {
-    auto const badgeSz = SearchMarks::GetSize(badgeName).get_value_or({});
+    auto const badgeSz = SearchMarks::GetSize(badgeName).value_or(m2::PointD::Zero());
     offsets[i] = {(0.5f + horizontalOffset) * static_cast<float>(badgeSz.x - iconSz.x), 0.0};
   }
 
@@ -413,7 +413,7 @@ drape_ptr<df::UserPointMark::TitlesInfo> SearchMarkPoint::GetTitleDecl() const
     if (!sz)
       return nullptr;
     auto constexpr kShadowOffset = 4.0;
-    auto const centerOffset = -0.5 * sz.get().y - kShadowOffset;
+    auto const centerOffset = -0.5 * sz->y - kShadowOffset;
     titleDecl.m_primaryOffset.y =
         static_cast<float>(centerOffset / df::VisualParams::Instance().GetVisualScale()) -
         0.5f * titleDecl.m_primaryTextFont.m_size;
@@ -590,7 +590,7 @@ double SearchMarks::GetMaxDimension(ScreenBase const & modelView) const
 }
 
 // static
-boost::optional<m2::PointD> SearchMarks::GetSize(std::string const & symbolName)
+std::optional<m2::PointD> SearchMarks::GetSize(std::string const & symbolName)
 {
   auto const it = m_searchMarksSizes.find(symbolName);
   if (it == m_searchMarksSizes.end())

--- a/map/search_mark.hpp
+++ b/map/search_mark.hpp
@@ -9,11 +9,10 @@
 #include "geometry/point2d.hpp"
 #include "geometry/screenbase.hpp"
 
-#include <boost/optional.hpp>
-
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -94,7 +93,7 @@ public:
   void SetSales(std::vector<FeatureID> const & features, bool hasSale);
 
   static bool HaveSizes() { return !m_searchMarksSizes.empty(); };
-  static boost::optional<m2::PointD> GetSize(std::string const & symbolName);
+  static std::optional<m2::PointD> GetSize(std::string const & symbolName);
 
 private:
   void FilterAndProcessMarks(std::vector<FeatureID> const & features,

--- a/map/tips_api.cpp
+++ b/map/tips_api.cpp
@@ -34,10 +34,10 @@ size_t ToIndex(T type)
   return static_cast<size_t>(type);
 }
 
-boost::optional<eye::Tip::Type> GetTipImpl(TipsApi::Duration showAnyTipPeriod,
-                                           TipsApi::Duration showSameTipPeriod,
-                                           TipsApi::Delegate const & delegate,
-                                           TipsApi::Conditions const & conditions)
+std::optional<eye::Tip::Type> GetTipImpl(TipsApi::Duration showAnyTipPeriod,
+                                         TipsApi::Duration showSameTipPeriod,
+                                         TipsApi::Delegate const & delegate,
+                                         TipsApi::Conditions const & conditions)
 {
   auto const lastBackgroundTime = delegate.GetLastBackgroundTime();
   if (lastBackgroundTime != 0.0)
@@ -159,10 +159,10 @@ TipsApi::TipsApi(Delegate const & delegate)
       }
 
       auto const pos = m_delegate.GetCurrentPosition();
-      if (!pos.is_initialized())
+      if (!pos)
         return false;
 
-      return m_delegate.IsCountryLoaded(pos.get());
+      return m_delegate.IsCountryLoaded(*pos);
     },
     // Condition for Tips::Type::PublicTransport type.
     [this] (eye::Info const & info)
@@ -179,24 +179,24 @@ TipsApi::TipsApi(Delegate const & delegate)
       }
 
       auto const pos = m_delegate.GetCurrentPosition();
-      if (!pos.is_initialized())
+      if (!pos)
         return false;
 
-      return m_delegate.HaveTransit(pos.get());
+      return m_delegate.HaveTransit(*pos);
     }
   }};
 }
 
-boost::optional<eye::Tip::Type> TipsApi::GetTip() const
+std::optional<eye::Tip::Type> TipsApi::GetTip() const
 {
   return GetTipImpl(GetShowAnyTipPeriod(), GetShowSameTipPeriod(), m_delegate, m_conditions);
 }
 
 // static
-boost::optional<eye::Tip::Type> TipsApi::GetTipForTesting(Duration showAnyTipPeriod,
-                                                          Duration showSameTipPeriod,
-                                                          TipsApi::Delegate const & delegate,
-                                                          Conditions const & triggers)
+std::optional<eye::Tip::Type> TipsApi::GetTipForTesting(Duration showAnyTipPeriod,
+                                                        Duration showSameTipPeriod,
+                                                        TipsApi::Delegate const & delegate,
+                                                        Conditions const & triggers)
 {
   return GetTipImpl(showAnyTipPeriod, showSameTipPeriod, delegate, triggers);
 }

--- a/map/tips_api.hpp
+++ b/map/tips_api.hpp
@@ -5,12 +5,11 @@
 #include "geometry/point2d.hpp"
 
 #include <array>
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 class TipsApi
 {
@@ -24,7 +23,7 @@ public:
   public:
     virtual ~Delegate() = default;
 
-    virtual boost::optional<m2::PointD> GetCurrentPosition() const = 0;
+    virtual std::optional<m2::PointD> GetCurrentPosition() const = 0;
     virtual bool IsCountryLoaded(m2::PointD const & pt) const = 0;
     virtual bool HaveTransit(m2::PointD const & pt) const = 0;
     virtual double GetLastBackgroundTime() const = 0;
@@ -38,12 +37,12 @@ public:
 
   explicit TipsApi(Delegate const & delegate);
 
-  boost::optional<eye::Tip::Type> GetTip() const;
+  std::optional<eye::Tip::Type> GetTip() const;
 
-  static boost::optional<eye::Tip::Type> GetTipForTesting(Duration showAnyTipPeriod,
-                                                          Duration showSameTipPeriod,
-                                                          TipsApi::Delegate const & delegate,
-                                                          Conditions const & triggers);
+  static std::optional<eye::Tip::Type> GetTipForTesting(Duration showAnyTipPeriod,
+                                                        Duration showSameTipPeriod,
+                                                        TipsApi::Delegate const & delegate,
+                                                        Conditions const & triggers);
 
 private:
   Delegate const & m_delegate;

--- a/map/utils.cpp
+++ b/map/utils.cpp
@@ -56,7 +56,7 @@ eye::MapObject MakeEyeMapObject(FeatureType & ft)
 }
 
 void RegisterEyeEventIfPossible(eye::MapObject::Event::Type const type,
-                                boost::optional<m2::PointD> const & userPos,
+                                std::optional<m2::PointD> const & userPos,
                                 place_page::Info const & info)
 {
   if (!userPos)

--- a/map/utils.hpp
+++ b/map/utils.hpp
@@ -2,7 +2,7 @@
 
 #include "metrics/eye_info.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace place_page
 {
@@ -17,6 +17,6 @@ eye::MapObject MakeEyeMapObject(place_page::Info const & info);
 eye::MapObject MakeEyeMapObject(FeatureType & ft);
 
 void RegisterEyeEventIfPossible(eye::MapObject::Event::Type const type,
-                                boost::optional<m2::PointD> const & userPos,
+                                std::optional<m2::PointD> const & userPos,
                                 place_page::Info const & info);
 }  // namespace utils

--- a/map/viewport_search_params.hpp
+++ b/map/viewport_search_params.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace search
@@ -21,7 +22,7 @@ struct ViewportSearchParams
   std::string m_inputLocale;
   std::shared_ptr<hotels_filter::Rule> m_hotelsFilter;
   booking::filter::Tasks m_bookingFilterTasks;
-  boost::optional<std::chrono::steady_clock::duration> m_timeout;
+  std::optional<std::chrono::steady_clock::duration> m_timeout;
 
   OnStarted m_onStarted;
   OnCompleted m_onCompleted;

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -6,9 +6,8 @@
 #include "base/logging.hpp"
 
 #include <cstring>
+#include <optional>
 #include <type_traits>
-
-#include "boost/optional.hpp"
 
 #include "3party/pugixml/src/pugixml.hpp"
 
@@ -27,9 +26,9 @@ bool IntegerFromXML(pugi::xml_node const & node, Value & value)
   return true;
 }
 
-boost::optional<double> DoubleFromXML(pugi::xml_node const & node)
+std::optional<double> DoubleFromXML(pugi::xml_node const & node)
 {
-  return node ? node.text().as_double() : boost::optional<double>();
+  return node ? node.text().as_double() : std::optional<double>();
 }
 
 bool GetLatLon(pugi::xml_node const & node, int32_t & lat, int32_t & lon)
@@ -112,12 +111,12 @@ bool FirstCoordinateFromXML(pugi::xml_node const & node, ms::LatLon & latLon)
   return true;
 }
 
-boost::optional<ms::LatLon> LatLonFormXML(pugi::xml_node const & node)
+std::optional<ms::LatLon> LatLonFormXML(pugi::xml_node const & node)
 {
   auto const lat = DoubleFromXML(node.child("latitude"));
   auto const lon = DoubleFromXML(node.child("longitude"));
 
-  return lat && lon ? ms::LatLon(lat.get(), lon.get()) : ms::LatLon::Zero();
+  return lat && lon ? ms::LatLon(*lat, *lon) : ms::LatLon::Zero();
 }
 
 bool CoordinateFromXML(pugi::xml_node const & node, ms::LatLon const & prevCoord,
@@ -294,10 +293,10 @@ bool CoordinatesFromXML(pugi::xml_node const & coordsNode, openlr::LinearLocatio
     return false;
   }
 
-  LOG(LINFO, ("from:", latLonStart.get(), "to:", latLonEnd.get()));
+  LOG(LINFO, ("from:", *latLonStart, "to:", *latLonEnd));
   locRef.m_points.resize(2);
-  locRef.m_points[0].m_latLon = latLonStart.get();
-  locRef.m_points[1].m_latLon = latLonEnd.get();
+  locRef.m_points[0].m_latLon = *latLonStart;
+  locRef.m_points[1].m_latLon = *latLonEnd;
   return true;
 }
 }  // namespace

--- a/platform/local_country_file.cpp
+++ b/platform/local_country_file.cpp
@@ -67,7 +67,7 @@ uint64_t LocalCountryFile::GetSize(MapFileType type) const
   if (!m_files[base::Underlying(type)].has_value())
     return 0;
 
-  return m_files[base::Underlying(type)].get();
+  return *m_files[base::Underlying(type)];
 }
 
 bool LocalCountryFile::HasFiles() const
@@ -137,9 +137,8 @@ string DebugPrint(LocalCountryFile const & file)
   {
     if (mapFile)
     {
-      filesStream << (fileAdded ? ", " : "") << mapFile.get();
-      if (!fileAdded)
-        fileAdded = true;
+      filesStream << (fileAdded ? ", " : "") << *mapFile;
+      fileAdded = true;
     }
   }
   filesStream << "]";

--- a/platform/local_country_file.hpp
+++ b/platform/local_country_file.hpp
@@ -7,10 +7,9 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace platform
 {
@@ -98,7 +97,7 @@ private:
   CountryFile m_countryFile;
   int64_t m_version;
 
-  using File = boost::optional<uint64_t>;
+  using File = std::optional<uint64_t>;
   std::array<File, base::Underlying(MapFileType::Count)> m_files = {};
 };
 

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -19,9 +19,8 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
-
-#include "boost/optional.hpp"
 
 #include <QtWidgets/QRubberBand>
 
@@ -146,7 +145,7 @@ public:
 
 private:
   void ProcessSelectionMode();
-  boost::optional<SelectionMode> m_currentSelectionMode;
+  std::optional<SelectionMode> m_currentSelectionMode;
   RouteMarkType m_routePointAddMode = RouteMarkType::Finish;
 
   std::unique_ptr<Screenshoter> m_screenshoter;

--- a/qt/routing_settings_dialog.cpp
+++ b/qt/routing_settings_dialog.cpp
@@ -47,7 +47,7 @@ void RoutingSettings::ResetSettings()
 }
 
 // static
-boost::optional<ms::LatLon> RoutingSettings::GetCoordsFromString(std::string const & input)
+std::optional<ms::LatLon> RoutingSettings::GetCoordsFromString(std::string const & input)
 {
   ms::LatLon coords{};
   strings::SimpleTokenizer iter(input, kDelim);
@@ -66,7 +66,7 @@ boost::optional<ms::LatLon> RoutingSettings::GetCoordsFromString(std::string con
 }
 
 // static
-boost::optional<ms::LatLon> RoutingSettings::GetCoords(bool start)
+std::optional<ms::LatLon> RoutingSettings::GetCoords(bool start)
 {
   std::string input;
   settings::TryGet(start ? kStartCoordsCachedSettings : kFinishCoordsCachedSettings, input);

--- a/qt/routing_settings_dialog.hpp
+++ b/qt/routing_settings_dialog.hpp
@@ -9,9 +9,8 @@
 #include <QtWidgets/QFormLayout>
 #include <QtWidgets/QLineEdit>
 
+#include <optional>
 #include <string>
-
-#include "boost/optional.hpp"
 
 class Framework;
 
@@ -21,7 +20,7 @@ class RoutingSettings : public QDialog
 {
 public:
   static bool IsCacheEnabled();
-  static boost::optional<ms::LatLon> GetCoords(bool start);
+  static std::optional<ms::LatLon> GetCoords(bool start);
   static void LoadSettings(Framework & framework);
   static void ResetSettings();
 
@@ -35,7 +34,7 @@ private:
   static std::string const kFinishCoordsCachedSettings;
   static std::string const kRouterTypeCachedSettings;
 
-  static boost::optional<ms::LatLon> GetCoordsFromString(std::string const & input);
+  static std::optional<ms::LatLon> GetCoordsFromString(std::string const & input);
 
   void AddLineEdit(std::string const & title, QLineEdit * lineEdit);
   void AddCheckBox();

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -280,7 +280,7 @@ namespace qt
     m_framework.SearchInDownloader(params);
   }
 
-  void UpdateDialog::FillTree(boost::optional<Filter> const & filter, uint64_t timestamp)
+  void UpdateDialog::FillTree(optional<Filter> const & filter, uint64_t timestamp)
   {
     CHECK_THREAD_CHECKER(m_threadChecker, ());
 
@@ -303,7 +303,7 @@ namespace qt
   }
 
   void UpdateDialog::FillTreeImpl(QTreeWidgetItem * parent, CountryId const & countryId,
-                                  boost::optional<Filter> const & filter)
+                                  optional<Filter> const & filter)
   {
     CountriesVec children;
     GetStorage().GetChildren(countryId, children);

--- a/qt/update_dialog.hpp
+++ b/qt/update_dialog.hpp
@@ -5,12 +5,11 @@
 #include "base/thread_checker.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDialog>
@@ -56,9 +55,9 @@ namespace qt
 
     // Adds only those countries present in |filter|.
     // Calls whose timestamp is not the latest are discarded.
-    void FillTree(boost::optional<Filter> const & filter, uint64_t timestamp);
+    void FillTree(std::optional<Filter> const & filter, uint64_t timestamp);
     void FillTreeImpl(QTreeWidgetItem * parent, storage::CountryId const & countryId,
-                      boost::optional<Filter> const & filter);
+                      std::optional<Filter> const & filter);
 
     void UpdateRowWithCountryInfo(storage::CountryId const & countryId);
     void UpdateRowWithCountryInfo(QTreeWidgetItem * item, storage::CountryId const & countryId);

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -19,9 +19,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 class DataSource;
 
@@ -84,7 +83,7 @@ private:
   buffer_vector<LatLonWithAltitude, 32> m_junctions;
   SpeedKMpH m_forwardSpeed;
   SpeedKMpH m_backwardSpeed;
-  boost::optional<HighwayType> m_highwayType;
+  std::optional<HighwayType> m_highwayType;
   bool m_isOneWay = false;
   bool m_valid = false;
   bool m_isPassThroughAllowed = false;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -138,9 +138,9 @@ void IndexGraph::GetEdgeList(JointSegment const & parentJoint,
                           isOutgoing, edges, parentWeights, parents);
 }
 
-boost::optional<JointEdge>
-IndexGraph::GetJointEdgeByLastPoint(Segment const & parent, Segment const & firstChild,
-                                    bool isOutgoing, uint32_t lastPoint)
+optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
+                                                        Segment const & firstChild, bool isOutgoing,
+                                                        uint32_t lastPoint)
 {
   vector<Segment> const possibleChilds = {firstChild};
   vector<uint32_t> const lastPoints = {lastPoint};

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -17,11 +17,10 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace routing
 {
@@ -53,8 +52,9 @@ public:
                    Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
                    std::vector<RouteWeight> & parentWeights, std::map<JointSegment, JointSegment> & parents);
 
-  boost::optional<JointEdge> GetJointEdgeByLastPoint(Segment const & parent, Segment const & firstChild,
-                                                     bool isOutgoing, uint32_t lastPoint);
+  std::optional<JointEdge> GetJointEdgeByLastPoint(Segment const & parent,
+                                                   Segment const & firstChild, bool isOutgoing,
+                                                   uint32_t lastPoint);
 
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
 

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -15,11 +15,10 @@
 #include <algorithm>
 #include <limits>
 #include <map>
+#include <optional>
 #include <queue>
 #include <set>
 #include <vector>
-
-#include "boost/optional.hpp"
 
 namespace routing
 {
@@ -152,9 +151,8 @@ private:
                                   std::vector<JointEdge> & edges,
                                   std::vector<Weight> & parentWeights);
 
-  boost::optional<Segment> GetParentSegment(JointSegment const & vertex,
-                                            bool isOutgoing,
-                                            std::vector<JointEdge> & edges);
+  std::optional<Segment> GetParentSegment(JointSegment const & vertex, bool isOutgoing,
+                                          std::vector<JointEdge> & edges);
 
   /// \brief Makes BFS from |startSegment| in direction |fromStart| and find the closest segments
   /// which end RoadPoints are joints. Thus we build fake joint segments graph.
@@ -384,11 +382,10 @@ Segment const & IndexGraphStarterJoints<Graph>::GetSegmentOfFakeJoint(JointSegme
 }
 
 template <typename Graph>
-boost::optional<Segment> IndexGraphStarterJoints<Graph>::GetParentSegment(JointSegment const & vertex,
-                                                                          bool isOutgoing,
-                                                                          std::vector<JointEdge> & edges)
+std::optional<Segment> IndexGraphStarterJoints<Graph>::GetParentSegment(
+    JointSegment const & vertex, bool isOutgoing, std::vector<JointEdge> & edges)
 {
-  boost::optional<Segment> parentSegment;
+  std::optional<Segment> parentSegment;
   bool const opposite = !isOutgoing;
   if (vertex.IsFake())
   {
@@ -462,7 +459,7 @@ bool IndexGraphStarterJoints<Graph>::FillEdgesAndParentsWeights(JointSegment con
     if (!optional)
       return false;
 
-    Segment const & parentSegment = optional.value();
+    Segment const & parentSegment = *optional;
     m_graph.GetEdgeList(vertex, parentSegment, isOutgoing, edges, parentWeights);
 
     firstFakeId = edges.size();

--- a/routing/routes_builder/routes_builder_tool/utils.cpp
+++ b/routing/routes_builder/routes_builder_tool/utils.cpp
@@ -21,10 +21,9 @@
 #include <chrono>
 #include <future>
 #include <iostream>
+#include <optional>
 #include <thread>
 #include <tuple>
-
-#include "boost/optional.hpp"
 
 using namespace routing_quality;
 
@@ -145,7 +144,7 @@ void BuildRoutes(std::string const & routesPath,
   }
 }
 
-boost::optional<std::tuple<ms::LatLon, ms::LatLon, int32_t>> ParseApiLine(std::ifstream & input)
+std::optional<std::tuple<ms::LatLon, ms::LatLon, int32_t>> ParseApiLine(std::ifstream & input)
 {
   std::string line;
   if (!std::getline(input, line))

--- a/routing/routing_options.cpp
+++ b/routing/routing_options.cpp
@@ -86,11 +86,11 @@ RoutingOptionsClassifier::RoutingOptionsClassifier()
   }
 }
 
-boost::optional<RoutingOptions::Road> RoutingOptionsClassifier::Get(uint32_t type) const
+optional<RoutingOptions::Road> RoutingOptionsClassifier::Get(uint32_t type) const
 {
   auto const it = m_data.find(type);
   if (it == m_data.cend())
-    return boost::none;
+    return {};
 
   return it->second;
 }

--- a/routing/routing_options.hpp
+++ b/routing/routing_options.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <set>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-
-#include "boost/optional.hpp"
 
 namespace routing
 {
@@ -50,7 +49,7 @@ class RoutingOptionsClassifier
 public:
   RoutingOptionsClassifier();
 
-  boost::optional<RoutingOptions::Road> Get(uint32_t type) const;
+  std::optional<RoutingOptions::Road> Get(uint32_t type) const;
   static RoutingOptionsClassifier const & Instance();
 
 private:

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -4,7 +4,6 @@
 #include <utility>
 
 #include "base/assert.hpp"
-#include "boost/optional.hpp"
 
 namespace routing
 {

--- a/routing_common/vehicle_model.cpp
+++ b/routing_common/vehicle_model.cpp
@@ -12,8 +12,6 @@
 #include <algorithm>
 #include <sstream>
 
-#include <boost/optional.hpp>
-
 using namespace routing;
 using namespace std;
 
@@ -117,7 +115,7 @@ SpeedKMpH VehicleModel::GetSpeed(FeatureType & f, SpeedParams const & speedParam
 HighwayType VehicleModel::GetHighwayType(FeatureType & f) const
 {
   feature::TypesHolder const types(f);
-  boost::optional<HighwayType> ret;
+  optional<HighwayType> ret;
   for (auto const t : types)
   {
     ret = GetHighwayType(t);
@@ -136,9 +134,9 @@ double VehicleModel::GetMaxWeightSpeed() const
   return max(m_maxModelSpeed.m_inCity.m_weight, m_maxModelSpeed.m_outCity.m_weight);
 }
 
-boost::optional<HighwayType> VehicleModel::GetHighwayType(uint32_t type) const
+optional<HighwayType> VehicleModel::GetHighwayType(uint32_t type) const
 {
-  boost::optional<HighwayType> hwType;
+  optional<HighwayType> hwType;
   type = ftypes::BaseChecker::PrepareToMatch(type, 2);
   auto const it = m_roadTypes.find(type);
   if (it != m_roadTypes.cend())
@@ -161,7 +159,8 @@ void VehicleModel::GetSurfaceFactor(uint32_t type, SpeedFactor & factor) const
   CHECK_GREATER(factor.m_eta, 0.0, ());
 }
 
-void VehicleModel::GetAdditionalRoadSpeed(uint32_t type, bool isCityRoad, boost::optional<SpeedKMpH> & speed) const
+void VehicleModel::GetAdditionalRoadSpeed(uint32_t type, bool isCityRoad,
+                                          optional<SpeedKMpH> & speed) const
 {
   auto const it = FindAdditionalRoadType(type);
   if (it == m_addRoadTypes.cend())
@@ -258,9 +257,9 @@ SpeedKMpH VehicleModel::GetTypeSpeed(feature::TypesHolder const & types,
                                      SpeedParams const & speedParams) const
 {
   bool const isCityRoad = speedParams.m_inCity;
-  boost::optional<HighwayType> hwType;
+  optional<HighwayType> hwType;
   SpeedFactor surfaceFactor;
-  boost::optional<SpeedKMpH> additionalRoadSpeed;
+  optional<SpeedKMpH> additionalRoadSpeed;
   for (uint32_t t : types)
   {
     if (!hwType)

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -10,13 +10,12 @@
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class Classificator;
 class FeatureType;
@@ -397,9 +396,10 @@ private:
     SpeedFactor m_factor;
   };
 
-  boost::optional<HighwayType> GetHighwayType(uint32_t type) const;
+  std::optional<HighwayType> GetHighwayType(uint32_t type) const;
   void GetSurfaceFactor(uint32_t type, SpeedFactor & factor) const;
-  void GetAdditionalRoadSpeed(uint32_t type, bool isCityRoad, boost::optional<SpeedKMpH> & speed) const;
+  void GetAdditionalRoadSpeed(uint32_t type, bool isCityRoad,
+                              std::optional<SpeedKMpH> & speed) const;
 
   SpeedKMpH GetSpeedOnFeatureWithoutMaxspeed(HighwayType const & type,
                                              SpeedParams const & speedParams) const;

--- a/search/doc_vec.cpp
+++ b/search/doc_vec.cpp
@@ -49,7 +49,7 @@ double SqrL2(IdfMap & idfs, vector<TokenFrequencyPair> const & tfs)
 
 // Computes squared L2 norm of vector of tokens + prefix token.
 double SqrL2(IdfMap & idfs, vector<TokenFrequencyPair> const & tfs,
-             boost::optional<strings::UniString> const & prefix)
+             optional<strings::UniString> const & prefix)
 {
   auto result = SqrL2(idfs, tfs);
   if (prefix)

--- a/search/doc_vec.hpp
+++ b/search/doc_vec.hpp
@@ -9,11 +9,10 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
-
-#include <boost/optional.hpp>
 
 namespace search
 {
@@ -104,7 +103,7 @@ public:
     friend class QueryVec;
 
     std::vector<strings::UniString> m_tokens;
-    boost::optional<strings::UniString> m_prefix;
+    std::optional<strings::UniString> m_prefix;
   };
 
   explicit QueryVec(IdfMap & idfs) : m_idfs(&idfs) {}
@@ -134,6 +133,6 @@ private:
 
   IdfMap * m_idfs;
   std::vector<TokenFrequencyPair> m_tfs;
-  boost::optional<strings::UniString> m_prefix;
+  std::optional<strings::UniString> m_prefix;
 };
 }  // namespace search

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -261,7 +261,7 @@ double GetDistanceMeters(m2::PointD const & pivot, m2::RectD const & rect)
 
 struct KeyedMwmInfo
 {
-  KeyedMwmInfo(shared_ptr<MwmInfo> const & info, boost::optional<m2::PointD> const & position,
+  KeyedMwmInfo(shared_ptr<MwmInfo> const & info, optional<m2::PointD> const & position,
                m2::RectD const & pivot, bool inViewport)
     : m_info(info)
   {

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -44,10 +44,9 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class CategoriesHolder;
 class DataSource;
@@ -87,7 +86,7 @@ public:
   {
     Mode m_mode = Mode::Everywhere;
     m2::RectD m_pivot;
-    boost::optional<m2::PointD> m_position;
+    std::optional<m2::PointD> m_position;
     Locales m_categoryLocales;
     std::shared_ptr<hotels_filter::Rule> m_hotelsFilter;
     std::vector<uint32_t> m_cuisineTypes;

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -11,12 +11,11 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <random>
 #include <set>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class DataSource;
 
@@ -41,7 +40,7 @@ public:
     // compute the distance from a feature to the pivot.
     m2::PointD m_accuratePivotCenter;
 
-    boost::optional<m2::PointD> m_position;
+    std::optional<m2::PointD> m_position;
     m2::RectD m_viewport;
 
     int m_scale = 0;

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -27,11 +27,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class FeatureType;
 class CategoriesHolder;
@@ -138,7 +137,7 @@ protected:
   std::vector<uint32_t> m_cuisineTypes;
 
   m2::RectD m_viewport;
-  boost::optional<m2::PointD> m_position;
+  std::optional<m2::PointD> m_position;
 
   bool m_lastUpdate = false;
 

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -24,8 +24,7 @@
 
 #include <algorithm>
 #include <memory>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 using namespace std;
 
@@ -480,7 +479,7 @@ public:
   {
   }
 
-  boost::optional<RankerResult> operator()(PreRankerResult const & preRankerResult)
+  optional<RankerResult> operator()(PreRankerResult const & preRankerResult)
   {
     m2::PointD center;
     string name;

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -85,10 +85,10 @@ string Join(string const & s, Args &&... args)
 ReverseGeocoder::ReverseGeocoder(DataSource const & dataSource) : m_dataSource(dataSource) {}
 
 // static
-boost::optional<uint32_t> ReverseGeocoder::GetMatchedStreetIndex(string const & keyName,
-                                                                 vector<Street> const & streets)
+optional<uint32_t> ReverseGeocoder::GetMatchedStreetIndex(string const & keyName,
+                                                          vector<Street> const & streets)
 {
-  auto matchStreet = [&](bool ignoreStreetSynonyms) -> boost::optional<uint32_t> {
+  auto matchStreet = [&](bool ignoreStreetSynonyms) -> optional<uint32_t> {
     // Find the exact match or the best match in kSimilarityTresholdPercent limit.
     uint32_t result;
     size_t minPercent = kSimilarityThresholdPercent + 1;

--- a/search/reverse_geocoder.hpp
+++ b/search/reverse_geocoder.hpp
@@ -12,11 +12,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class FeatureType;
 class DataSource;
@@ -118,8 +117,8 @@ public:
 
   /// Returns a feature id of street from |streets| whose name best matches |keyName|
   /// or empty value if the match was not found.
-  static boost::optional<uint32_t> GetMatchedStreetIndex(std::string const & keyName,
-                                                         std::vector<Street> const & streets);
+  static std::optional<uint32_t> GetMatchedStreetIndex(std::string const & keyName,
+                                                       std::vector<Street> const & streets);
 
   /// @return Sorted by distance streets vector for the specified MwmId.
   /// Parameter |includeSquaresAndSuburbs| needed for backward compatibility:

--- a/search/search_params.hpp
+++ b/search/search_params.hpp
@@ -12,9 +12,8 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 namespace search
 {
@@ -64,7 +63,7 @@ struct SearchParams
   std::string m_query;
   std::string m_inputLocale;
 
-  boost::optional<m2::PointD> m_position;
+  std::optional<m2::PointD> m_position;
   m2::RectD m_viewport;
 
   size_t m_batchSize = kDefaultBatchSizeEverywhere;

--- a/search/search_quality/aloha_to_samples_tool/aloha_to_samples_tool.cpp
+++ b/search/search_quality/aloha_to_samples_tool/aloha_to_samples_tool.cpp
@@ -16,11 +16,10 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "3party/gflags/src/gflags/gflags.h"
 
@@ -78,7 +77,7 @@ bool IsCategorialRequest(string query, uint8_t locale)
   return isCategorialRequest;
 }
 
-boost::optional<EmitInfo> ParseEmitResultsAndCoords(map<string, string> const & kpePairs)
+optional<EmitInfo> ParseEmitResultsAndCoords(map<string, string> const & kpePairs)
 {
   EmitInfo info;
   try
@@ -117,7 +116,7 @@ boost::optional<EmitInfo> ParseEmitResultsAndCoords(map<string, string> const & 
   return info;
 }
 
-boost::optional<ResultInfo> ParseShowResult(map<string, string> const & kpePairs)
+optional<ResultInfo> ParseShowResult(map<string, string> const & kpePairs)
 {
   ResultInfo info;
   try
@@ -134,7 +133,7 @@ boost::optional<ResultInfo> ParseShowResult(map<string, string> const & kpePairs
   return info;
 }
 
-boost::optional<Sample::Result> ParseResultWithCoords(string const & str)
+optional<Sample::Result> ParseResultWithCoords(string const & str)
 {
   auto const tokens = Tokenize(str, "|");
   // No coords.
@@ -162,7 +161,7 @@ boost::optional<Sample::Result> ParseResultWithCoords(string const & str)
   return res;
 }
 
-boost::optional<Sample> MakeSample(EmitInfo const & info, size_t relevantPos)
+optional<Sample> MakeSample(EmitInfo const & info, size_t relevantPos)
 {
   Sample sample;
   sample.m_query = MakeUniString(info.m_query);
@@ -197,10 +196,10 @@ int main(int argc, char * argv[])
 
   classificator::Load();
 
-  cereal::BinaryInputArchive ar(std::cin);
+  cereal::BinaryInputArchive ar(cin);
   unique_ptr<AlohalyticsBaseEvent> ptr;
   bool newUser = true;
-  boost::optional<EmitInfo> info;
+  optional<EmitInfo> info;
 
   while (true)
   {

--- a/search/search_quality/assessment_tool/edits.cpp
+++ b/search/search_quality/assessment_tool/edits.cpp
@@ -50,7 +50,7 @@ bool ResultsEdits::Editor::Set(Relevance relevance)
   return m_parent.SetRelevance(m_index, relevance);
 }
 
-boost::optional<ResultsEdits::Relevance> const & ResultsEdits::Editor::Get() const
+optional<ResultsEdits::Relevance> const & ResultsEdits::Editor::Get() const
 {
   return m_parent.Get(m_index).m_currRelevance;
 }
@@ -75,7 +75,7 @@ void ResultsEdits::Apply()
   });
 }
 
-void ResultsEdits::Reset(vector<boost::optional<ResultsEdits::Relevance>> const & relevances)
+void ResultsEdits::Reset(vector<optional<ResultsEdits::Relevance>> const & relevances)
 {
   WithObserver(Update::MakeAll(), [this, &relevances]() {
     m_entries.resize(relevances.size());
@@ -170,9 +170,9 @@ ResultsEdits::Entry const & ResultsEdits::GetEntry(size_t index) const
   return m_entries[index];
 }
 
-vector<boost::optional<ResultsEdits::Relevance>> ResultsEdits::GetRelevances() const
+vector<optional<ResultsEdits::Relevance>> ResultsEdits::GetRelevances() const
 {
-  vector<boost::optional<ResultsEdits::Relevance>> relevances(m_entries.size());
+  vector<optional<ResultsEdits::Relevance>> relevances(m_entries.size());
   for (size_t i = 0; i < m_entries.size(); ++i)
     relevances[i] = m_entries[i].m_currRelevance;
   return relevances;

--- a/search/search_quality/assessment_tool/edits.hpp
+++ b/search/search_quality/assessment_tool/edits.hpp
@@ -7,10 +7,9 @@
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <type_traits>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 struct SampleEdits
 {
@@ -44,13 +43,13 @@ public:
     };
 
     Entry() = default;
-    Entry(boost::optional<Relevance> relevance, Type type)
+    Entry(std::optional<Relevance> relevance, Type type)
       : m_currRelevance(relevance), m_origRelevance(relevance), m_type(type)
     {
     }
 
-    boost::optional<Relevance> m_currRelevance = {};
-    boost::optional<Relevance> m_origRelevance = {};
+    std::optional<Relevance> m_currRelevance = {};
+    std::optional<Relevance> m_origRelevance = {};
     bool m_deleted = false;
     Type m_type = Type::Loaded;
   };
@@ -91,7 +90,7 @@ public:
     // Sets relevance to |relevance|. Returns true iff |relevance|
     // differs from the original one.
     bool Set(Relevance relevance);
-    boost::optional<Relevance> const & Get() const;
+    std::optional<Relevance> const & Get() const;
     bool HasChanges() const;
     Entry::Type GetType() const;
 
@@ -103,7 +102,7 @@ public:
   explicit ResultsEdits(OnUpdate onUpdate) : m_onUpdate(onUpdate) {}
 
   void Apply();
-  void Reset(std::vector<boost::optional<Relevance>> const & relevances);
+  void Reset(std::vector<std::optional<Relevance>> const & relevances);
 
   // Sets relevance at |index| to |relevance|. Returns true iff
   // |relevance| differs from the original one.
@@ -125,7 +124,7 @@ public:
   Entry & GetEntry(size_t index);
   Entry const & GetEntry(size_t index) const;
   size_t NumEntries() const { return m_entries.size(); }
-  std::vector<boost::optional<Relevance>> GetRelevances() const;
+  std::vector<std::optional<Relevance>> GetRelevances() const;
 
   Entry const & Get(size_t index) const;
 

--- a/search/search_quality/assessment_tool/main_model.hpp
+++ b/search/search_quality/assessment_tool/main_model.hpp
@@ -16,8 +16,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 class Framework;
 class DataSource;
 

--- a/search/search_quality/assessment_tool/main_view.cpp
+++ b/search/search_quality/assessment_tool/main_view.cpp
@@ -113,8 +113,7 @@ void MainView::OnSearchCompleted()
 }
 
 void MainView::ShowSample(size_t sampleIndex, search::Sample const & sample,
-                          boost::optional<m2::PointD> const & position, bool isUseless,
-                          bool hasEdits)
+                          std::optional<m2::PointD> const & position, bool isUseless, bool hasEdits)
 {
   m_sampleLocale = sample.m_locale;
 

--- a/search/search_quality/assessment_tool/main_view.hpp
+++ b/search/search_quality/assessment_tool/main_view.hpp
@@ -33,7 +33,7 @@ public:
   void OnSearchStarted() override;
   void OnSearchCompleted() override;
   void ShowSample(size_t sampleIndex, search::Sample const & sample,
-                  boost::optional<m2::PointD> const & position, bool isUseless,
+                  std::optional<m2::PointD> const & position, bool isUseless,
                   bool hasEdits) override;
 
   void AddFoundResults(search::Results::ConstIter begin, search::Results::ConstIter end) override;

--- a/search/search_quality/assessment_tool/sample_view.cpp
+++ b/search/search_quality/assessment_tool/sample_view.cpp
@@ -179,7 +179,7 @@ SampleView::SampleView(QWidget * parent, Framework & framework)
 }
 
 void SampleView::SetContents(search::Sample const & sample,
-                             boost::optional<m2::PointD> const & position)
+                             std::optional<m2::PointD> const & position)
 {
   if (!sample.m_query.empty())
   {
@@ -348,7 +348,7 @@ void SampleView::Clear()
 
   ClearAllResults();
   HideUserPosition();
-  m_position = boost::none;
+  m_position = std::nullopt;
   OnSearchCompleted();
 }
 

--- a/search/search_quality/assessment_tool/sample_view.hpp
+++ b/search/search_quality/assessment_tool/sample_view.hpp
@@ -8,7 +8,7 @@
 
 #include "kml/type_utils.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QtCore/QMargins>
 #include <QtWidgets/QWidget>
@@ -29,7 +29,7 @@ public:
 
   SampleView(QWidget * parent, Framework & framework);
 
-  void SetContents(search::Sample const & sample, boost::optional<m2::PointD> const & position);
+  void SetContents(search::Sample const & sample, std::optional<m2::PointD> const & position);
   void OnSearchStarted();
   void OnSearchCompleted();
 
@@ -99,5 +99,5 @@ private:
 
   kml::MarkId m_positionMarkId = kml::kInvalidMarkId;
 
-  boost::optional<m2::PointD> m_position;
+  std::optional<m2::PointD> m_position;
 };

--- a/search/search_quality/assessment_tool/search_request_runner.cpp
+++ b/search/search_quality/assessment_tool/search_request_runner.cpp
@@ -92,7 +92,7 @@ void SearchRequestRunner::RunRequest(size_t index, bool background, size_t times
   sample.FillSearchParams(params);
   params.m_timeout = search::SearchParams::kDefaultDesktopTimeout;
   params.m_onResults = [=](search::Results const & results) {
-    vector<boost::optional<ResultsEdits::Relevance>> relevances;
+    vector<optional<ResultsEdits::Relevance>> relevances;
     vector<size_t> goldenMatching;
     vector<size_t> actualMatching;
 
@@ -147,7 +147,7 @@ void SearchRequestRunner::RunRequest(size_t index, bool background, size_t times
           context.m_actualMatching = actualMatching;
 
           {
-            vector<boost::optional<ResultsEdits::Relevance>> relevances;
+            vector<optional<ResultsEdits::Relevance>> relevances;
 
             auto & nonFound = context.m_nonFoundResults;
             CHECK(nonFound.empty(), ());

--- a/search/search_quality/assessment_tool/view.hpp
+++ b/search/search_quality/assessment_tool/view.hpp
@@ -9,10 +9,9 @@
 #include "geometry/rect2d.hpp"
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class ResultsEdits;
 class Model;
@@ -34,7 +33,7 @@ public:
   virtual void OnSearchStarted() = 0;
   virtual void OnSearchCompleted() = 0;
   virtual void ShowSample(size_t index, search::Sample const & sample,
-                          boost::optional<m2::PointD> const & position, bool isUseless,
+                          std::optional<m2::PointD> const & position, bool isUseless,
                           bool hasEdits) = 0;
 
   virtual void AddFoundResults(search::Results::ConstIter begin,

--- a/search/search_quality/helpers_json.cpp
+++ b/search/search_quality/helpers_json.cpp
@@ -58,12 +58,12 @@ void FromJSONObject(json_t * root, string const & field, PointD & point)
   FromJSONObject(root, field.c_str(), point);
 }
 
-void FromJSONObjectOptional(json_t * root, char const * field, boost::optional<PointD> & point)
+void FromJSONObjectOptional(json_t * root, char const * field, optional<PointD> & point)
 {
   json_t * p = base::GetJSONOptionalField(root, field);
   if (!p || base::JSONIsNull(p))
   {
-    point = boost::none;
+    point = nullopt;
     return;
   }
 
@@ -80,7 +80,7 @@ void ToJSONObject(json_t & root, char const * field, PointD const & point)
   json_object_set_new(&root, field, json.release());
 }
 
-void FromJSONObjectOptional(json_t * root, string const & field, boost::optional<PointD> & point)
+void FromJSONObjectOptional(json_t * root, string const & field, optional<PointD> & point)
 {
   FromJSONObjectOptional(root, field.c_str(), point);
 }
@@ -90,7 +90,7 @@ void ToJSONObject(json_t & root, string const & field, PointD const & point)
   ToJSONObject(root, field.c_str(), point);
 }
 
-void ToJSONObject(json_t & root, char const * field, boost::optional<PointD> const & point)
+void ToJSONObject(json_t & root, char const * field, optional<PointD> const & point)
 {
   if (point)
     ToJSONObject(root, field, *point);
@@ -98,7 +98,7 @@ void ToJSONObject(json_t & root, char const * field, boost::optional<PointD> con
     ToJSONObject(root, field, base::NewJSONNull());
 }
 
-void ToJSONObject(json_t & root, string const & field, boost::optional<PointD> const & point)
+void ToJSONObject(json_t & root, string const & field, optional<PointD> const & point)
 {
   ToJSONObject(root, field.c_str(), point);
 }

--- a/search/search_quality/helpers_json.hpp
+++ b/search/search_quality/helpers_json.hpp
@@ -3,9 +3,8 @@
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
+#include <optional>
 #include <string>
-
-#include <boost/optional.hpp>
 
 #include "3party/jansson/myjansson.hpp"
 
@@ -17,13 +16,13 @@ void FromJSONObject(json_t * root, std::string const & field, RectD & rect);
 void ToJSONObject(json_t & root, std::string const & field, RectD const & rect);
 
 void FromJSONObject(json_t * root, char const * field, PointD & point);
-void FromJSONObjectOptional(json_t * root, char const * field, boost::optional<PointD> & point);
+void FromJSONObjectOptional(json_t * root, char const * field, std::optional<PointD> & point);
 void FromJSONObject(json_t * root, std::string const & field, PointD & point);
 void FromJSONObjectOptional(json_t * root, std::string const & field,
-                            boost::optional<PointD> & point);
+                            std::optional<PointD> & point);
 
 void ToJSONObject(json_t & root, char const * field, PointD const & point);
 void ToJSONObject(json_t & root, std::string const & field, PointD const & point);
-void ToJSONObject(json_t & root, char const * field, boost::optional<PointD> const & point);
-void ToJSONObject(json_t & root, std::string const & field, boost::optional<PointD> const & point);
+void ToJSONObject(json_t & root, char const * field, std::optional<PointD> const & point);
+void ToJSONObject(json_t & root, std::string const & field, std::optional<PointD> const & point);
 }  // namespace m2

--- a/search/search_quality/sample.hpp
+++ b/search/search_quality/sample.hpp
@@ -7,10 +7,9 @@
 
 #include "3party/jansson/myjansson.hpp"
 
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class FeatureType;
 
@@ -72,7 +71,7 @@ struct Sample
 
   strings::UniString m_query;
   std::string m_locale;
-  boost::optional<m2::PointD> m_pos;
+  std::optional<m2::PointD> m_pos;
   m2::RectD m_viewport = m2::RectD(0, 0, 0, 0);
   std::vector<Result> m_results;
   std::vector<strings::UniString> m_relatedQueries;

--- a/search/search_quality/samples_generation_tool/samples_generation_tool.cpp
+++ b/search/search_quality/samples_generation_tool/samples_generation_tool.cpp
@@ -297,7 +297,7 @@ string GetLocalizedCafeType(unordered_map<uint32_t, StringUtf8Multilang> const &
   return translation;
 }
 
-boost::optional<Sample> GenerateRequest(
+optional<Sample> GenerateRequest(
     FeatureType & ft, search::ReverseGeocoder const & coder,
     unordered_map<uint32_t, StringUtf8Multilang> const & typesTranslations,
     vector<int8_t> const & mwmLangCodes, RequestType requestType)

--- a/search/search_quality/search_quality_tests/sample_test.cpp
+++ b/search/search_quality/search_quality_tests/sample_test.cpp
@@ -55,7 +55,7 @@ void SampleTest::Init()
 
   m_tula.m_query = strings::MakeUniString("tula");
   m_tula.m_locale = "en";
-  m_tula.m_pos = boost::none;
+  m_tula.m_pos = nullopt;
   m_tula.m_viewport = {37.5064, 67.0476, 37.7799, 67.304};
 }
 }  // namespace

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -21,12 +21,11 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace storage
 {
@@ -200,7 +199,7 @@ private:
   // calls to the diff manager's ApplyDiff are coordinated from the storage thread.
   base::Cancellable m_diffsCancellable;
 
-  boost::optional<CountryId> m_latestDiffRequest;
+  std::optional<CountryId> m_latestDiffRequest;
 
   // Since the diff manager runs on a different thread, the result
   // of diff application may return "Ok" when in fact the diff was

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -51,8 +51,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include "defines.hpp"
 
 using namespace routing;

--- a/tracking/archival_manager.cpp
+++ b/tracking/archival_manager.cpp
@@ -59,18 +59,18 @@ ArchivalManager::ArchivalManager(uint32_t version, std::string const & url)
 {
 }
 
-boost::optional<FileWriter> ArchivalManager::GetFileWriter(
+std::optional<FileWriter> ArchivalManager::GetFileWriter(
     routing::RouterType const & trackType) const
 {
   std::string const fileName =
       archival_file::GetArchiveFilename(m_version, GetTimestamp(), trackType);
   try
   {
-    return boost::optional<FileWriter>(base::JoinPath(m_tracksDir, fileName));
+    return std::optional<FileWriter>(base::JoinPath(m_tracksDir, fileName));
   }
   catch (std::exception const & e)
   {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/tracking/archival_manager.hpp
+++ b/tracking/archival_manager.hpp
@@ -9,11 +9,10 @@
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "boost/optional.hpp"
 
 namespace tracking
 {
@@ -47,7 +46,7 @@ private:
   std::chrono::seconds ReadTimestamp(std::string const & filePath);
   void WriteTimestamp(std::string const & filePath);
 
-  boost::optional<FileWriter> GetFileWriter(routing::RouterType const & trackType) const;
+  std::optional<FileWriter> GetFileWriter(routing::RouterType const & trackType) const;
 
   std::vector<std::string> GetFilesOrderedByCreation(std::string const & extension) const;
   bool CreateTracksDir() const;
@@ -73,6 +72,6 @@ void ArchivalManager::Dump(T & archive, routing::RouterType const & trackType, b
     return;
 
   if (auto dst = GetFileWriter(trackType))
-    archive.Write(dst.get());
+    archive.Write(*dst);
 }
 }  // namespace tracking

--- a/ugc/storage.cpp
+++ b/ugc/storage.cpp
@@ -25,12 +25,11 @@
 
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <utility>
 
 #include "3party/Alohalytics/src/alohalytics.h"
 #include "3party/jansson/myjansson.hpp"
-
-#include <boost/optional/optional.hpp>
 
 using namespace std;
 using namespace ugc;
@@ -340,7 +339,7 @@ void Storage::Load()
   if (m_indexes.empty())
     return;
 
-  boost::optional<IndexVersion> version;
+  optional<IndexVersion> version;
   for (auto const & i : m_indexes)
   {
     if (i.m_deleted)

--- a/web_api/request_headers.cpp
+++ b/web_api/request_headers.cpp
@@ -32,7 +32,7 @@ platform::HttpClient::Headers GetCatalogHeaders(HeadersParams const & params)
   if (params.m_currentPosition)
   {
     std::ostringstream latLonStream;
-    auto const latLon = mercator::ToLatLon(params.m_currentPosition.get());
+    auto const latLon = mercator::ToLatLon(*params.m_currentPosition);
     latLonStream << std::fixed << std::setprecision(3) << latLon.m_lat << "," << latLon.m_lon;
     result.emplace(kLatLonHeader, latLonStream.str());
   }

--- a/web_api/request_headers.hpp
+++ b/web_api/request_headers.hpp
@@ -6,16 +6,15 @@
 
 #include "base/geo_object_id.hpp"
 
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace web_api
 {
 class HeadersParams
 {
 public:
-  boost::optional<m2::PointD> m_currentPosition;
+  std::optional<m2::PointD> m_currentPosition;
   std::vector<base::GeoObjectId> m_countryGeoIds;
   std::vector<base::GeoObjectId> m_cityGeoIds;
 };


### PR DESCRIPTION
Since C++17, optional is part of the C++ Standard Library.