### PR TITLE
[routing] Route rebuilding fix.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1118,8 +1118,8 @@ void RoutingManager::CheckLocationForRouting(location::GpsInfo const & info)
     m_routingSession.RebuildRoute(
         mercator::FromLatLon(info.m_latitude, info.m_longitude),
         [this](Route const & route, RouterResultCode code) { OnRebuildRouteReady(route, code); },
-        nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, 0 /* timeoutSec */,
-        SessionState::RouteRebuilding, true /* adjustToPrevRoute */);
+        nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */,
+        RouterDelegate::kNoTimeout, SessionState::RouteRebuilding, true /* adjustToPrevRoute */);
   }
 }
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -182,7 +182,7 @@ void RoutingSession::RebuildRouteOnTrafficUpdate()
   }
 
   RebuildRoute(startPoint, m_rebuildReadyCallback, nullptr /* needMoreMapsCallback */,
-               nullptr /* removeRouteCallback */, 0 /* timeoutSec */,
+               nullptr /* removeRouteCallback */, RouterDelegate::kNoTimeout,
                SessionState::RouteRebuilding, false /* adjustToPrevRoute */);
 }
 


### PR DESCRIPTION
После переезда RouterDelegate на новый base::Cancellable (https://github.com/mapsme/omim/pull/11978) в 2 местах в качестве отсутствия timeout-та остался 0. А должен был появиться RouterDelegate::kNoTimeout.

Одна из этих ошибок приводила к прекращению перепрокладки маршрута после ухода с него (https://jira.mail.ru/browse/MAPSME-12826). А другая, к прекращению перепрокладки после загрузки пробок (https://jira.mail.ru/browse/MAPSME-12827). Этот PR так же исправляет баг: (https://jira.mail.ru/browse/MAPSME-12739)

Это происходило, поскольку после вызовова `RouterDelegate::SetTimeout(0 /* timeoutSec */)`, `Cancellable::m_status` принимал значение `Status::DeadlineExceeded`. Что в свою очередь приводило к тому, что метод `Cancellable::IsCancelled()` вызываемый в `FindPathBidirectional(...)` возвращал true и перепрокладка (прокладка после загрузки пробок) маршрутов закачивалась.

@gmoryes PTAL