### PR TITLE
[android] Back url support for deeplink

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BookmarksListFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarksListFragment.java
@@ -4,14 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
-import androidx.annotation.CallSuper;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -19,8 +12,15 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.crashlytics.android.Crashlytics;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapswithme.maps.MwmActivity;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.base.BaseMwmRecyclerFragment;
@@ -43,6 +43,7 @@ import com.mapswithme.maps.widget.placepage.EditBookmarkFragment;
 import com.mapswithme.maps.widget.placepage.Sponsored;
 import com.mapswithme.maps.widget.recycler.ItemDecoratorFactory;
 import com.mapswithme.util.BottomSheetHelper;
+import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.sharing.ShareOption;
 import com.mapswithme.util.sharing.SharingHelper;
@@ -99,7 +100,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   public void onCreate(@Nullable Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-    Crashlytics.log("onCreate");
+    CrashlyticsUtils.log(Log.INFO, TAG, "onCreate");
     BookmarkCategory category = getCategoryOrThrow();
     mCategoryDataSource = new CategoryDataSource(category);
     mCatalogListener = new CatalogListenerDecorator(this);
@@ -134,7 +135,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
   {
     super.onViewCreated(view, savedInstanceState);
-    Crashlytics.log("onViewCreated");
+    CrashlyticsUtils.log(Log.INFO, TAG, "onViewCreated");
     configureAdapter();
     configureFab(view);
 
@@ -155,7 +156,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   public void onStart()
   {
     super.onStart();
-    Crashlytics.log("onStart");
+    CrashlyticsUtils.log(Log.INFO, TAG, "onStart");
     SearchEngine.INSTANCE.addBookmarkListener(this);
     BookmarkManager.INSTANCE.addSortingListener(this);
     BookmarkManager.INSTANCE.addSharingListener(this);
@@ -166,7 +167,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   public void onResume()
   {
     super.onResume();
-    Crashlytics.log("onResume");
+    CrashlyticsUtils.log(Log.INFO, TAG, "onResume");
     BookmarkListAdapter adapter = getAdapter();
     adapter.notifyDataSetChanged();
     updateSorting();
@@ -178,14 +179,14 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   public void onPause()
   {
     super.onPause();
-    Crashlytics.log("onPause");
+    CrashlyticsUtils.log(Log.INFO, TAG,"onPause");
   }
 
   @Override
   public void onStop()
   {
     super.onStop();
-    Crashlytics.log("onStop");
+    CrashlyticsUtils.log(Log.INFO, TAG, "onStop");
     SearchEngine.INSTANCE.removeBookmarkListener(this);
     BookmarkManager.INSTANCE.removeSortingListener(this);
     BookmarkManager.INSTANCE.removeSharingListener(this);

--- a/android/src/com/mapswithme/maps/intent/BackUrlMapTaskWrapper.java
+++ b/android/src/com/mapswithme/maps/intent/BackUrlMapTaskWrapper.java
@@ -1,0 +1,49 @@
+package com.mapswithme.maps.intent;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import com.mapswithme.maps.MwmActivity;
+
+public class BackUrlMapTaskWrapper implements MapTask
+{
+  private static final String BACK_URL_PARAMETER = "back_url";
+  private static final long serialVersionUID = 5078514919824594790L;
+  @NonNull
+  private final MapTask mMapTask;
+  @NonNull
+  private final String mUrl;
+
+  private BackUrlMapTaskWrapper(@NonNull MapTask mapTask, @NonNull String url)
+  {
+    mMapTask = mapTask;
+    mUrl = url;
+  }
+
+  @Override
+  public boolean run(@NonNull MwmActivity target)
+  {
+    final boolean success = mMapTask.run(target);
+
+    Uri uri = Uri.parse(mUrl);
+    String backUrl = uri.getQueryParameter(BACK_URL_PARAMETER);
+    if (TextUtils.isEmpty(backUrl))
+      return success;
+
+    Intent intent = target.getIntent();
+    if (intent == null)
+      return success;
+
+    intent.putExtra(MwmActivity.EXTRA_BACK_URL, backUrl);
+
+    return success;
+  }
+
+  @NonNull
+  static MapTask wrap(@NonNull MapTask task, @NonNull String url)
+  {
+    return new BackUrlMapTaskWrapper(task, url);
+  }
+}

--- a/android/src/com/mapswithme/maps/intent/BackUrlMapTaskWrapper.java
+++ b/android/src/com/mapswithme/maps/intent/BackUrlMapTaskWrapper.java
@@ -27,13 +27,13 @@ public class BackUrlMapTaskWrapper implements MapTask
   {
     final boolean success = mMapTask.run(target);
 
+    final Intent intent = target.getIntent();
+    if (intent == null)
+      return success;
+
     Uri uri = Uri.parse(mUrl);
     String backUrl = uri.getQueryParameter(BACK_URL_PARAMETER);
     if (TextUtils.isEmpty(backUrl))
-      return success;
-
-    Intent intent = target.getIntent();
-    if (intent == null)
       return success;
 
     intent.putExtra(MwmActivity.EXTRA_BACK_URL, backUrl);

--- a/android/src/com/mapswithme/maps/intent/Factory.java
+++ b/android/src/com/mapswithme/maps/intent/Factory.java
@@ -3,12 +3,12 @@ package com.mapswithme.maps.intent;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
-import android.text.TextUtils;
-
 import com.crashlytics.android.Crashlytics;
 import com.mapswithme.maps.DownloadResourcesLegacyActivity;
 import com.mapswithme.maps.Framework;
@@ -188,7 +188,7 @@ public class Factory
     @Override
     MapTask createMapTask(@NonNull String uri)
     {
-      return new OpenUrlTask(uri);
+      return BackUrlMapTaskWrapper.wrap(new OpenUrlTask(uri), uri);
     }
   }
 
@@ -406,7 +406,7 @@ public class Factory
       Uri coreUri = uri.buildUpon()
                        .scheme(SCHEME_CORE)
                        .authority("").build();
-      return new OpenUrlTask(coreUri.toString());
+      return BackUrlMapTaskWrapper.wrap(new OpenUrlTask(coreUri.toString()), url);
     }
 
     @Nullable

--- a/android/src/com/mapswithme/maps/intent/Factory.java
+++ b/android/src/com/mapswithme/maps/intent/Factory.java
@@ -4,12 +4,12 @@ import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
-import com.crashlytics.android.Crashlytics;
 import com.mapswithme.maps.DownloadResourcesLegacyActivity;
 import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.MapFragment;
@@ -36,6 +36,7 @@ import com.mapswithme.maps.ugc.EditParams;
 import com.mapswithme.maps.ugc.UGC;
 import com.mapswithme.maps.ugc.UGCEditorActivity;
 import com.mapswithme.util.Constants;
+import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.StorageUtils;
 import com.mapswithme.util.UTM;
 import com.mapswithme.util.Utils;
@@ -169,7 +170,7 @@ public class Factory
       String msg = this.getClass().getSimpleName() + ": incoming intent uri: " + uri;
       LOGGER.i(this.getClass().getSimpleName(), msg);
       org.alohalytics.Statistics.logEvent(msg);
-      Crashlytics.log(msg);
+      CrashlyticsUtils.log(Log.INFO, getClass().getSimpleName(), msg);
       return createMapTask(uri);
     }
 

--- a/android/src/com/mapswithme/maps/scheduling/ConnectivityJobScheduler.java
+++ b/android/src/com/mapswithme/maps/scheduling/ConnectivityJobScheduler.java
@@ -6,9 +6,8 @@ import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
 import android.os.Build;
-import androidx.annotation.NonNull;
 
-import com.crashlytics.android.Crashlytics;
+import androidx.annotation.NonNull;
 import com.firebase.jobdispatcher.Constraint;
 import com.firebase.jobdispatcher.FirebaseJobDispatcher;
 import com.firebase.jobdispatcher.GooglePlayDriver;
@@ -18,6 +17,7 @@ import com.firebase.jobdispatcher.Trigger;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.mapswithme.maps.MwmApplication;
+import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.Utils;
 
 import java.util.Objects;
@@ -127,7 +127,7 @@ public class ConnectivityJobScheduler implements ConnectivityListener
     {
       IllegalStateException exception = new IllegalStateException("Play services doesn't exist on" +
                                                                   " the device");
-      Crashlytics.logException(exception);
+      CrashlyticsUtils.logException(exception);
     }
 
     @Override

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -14,14 +14,6 @@ import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.provider.Settings;
-import androidx.annotation.DimenRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.fragment.app.Fragment;
-import androidx.core.app.NavUtils;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -31,6 +23,14 @@ import android.view.View;
 import android.view.Window;
 import android.widget.Toast;
 
+import androidx.annotation.DimenRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.NavUtils;
+import androidx.fragment.app.Fragment;
 import com.mapswithme.maps.BuildConfig;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.R;
@@ -243,6 +243,29 @@ public class Utils
       CrashlyticsUtils.logException(e);
       intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       context.startActivity(intent);
+    }
+  }
+
+  public static boolean openUri(@NonNull Context context, @NonNull Uri uri)
+  {
+    final Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setData(uri);
+    try
+    {
+      context.startActivity(intent);
+      return true;
+    }
+    catch (ActivityNotFoundException e)
+    {
+      CrashlyticsUtils.logException(e);
+      return false;
+    }
+    catch (AndroidRuntimeException e)
+    {
+      CrashlyticsUtils.logException(e);
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      context.startActivity(intent);
+      return false;
     }
   }
 

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -324,7 +324,10 @@ bool ParsedMapApi::RouteKeyValue(string const & key, string const & value, vecto
 {
   using namespace route;
 
-  if (pattern.empty() || key != pattern.front())
+  if (pattern.empty())
+    return true;
+
+  if (key != pattern.front())
     return false;
 
   if (key == kSourceLatLon || key == kDestLatLon)


### PR DESCRIPTION
Added support for correct handling of back url parameter in a deeplink. It allows to come back to an external app which MAPSME is called from. Technically, coming back means that 'KeyEvent.KEYCODE_ESCAPE' is encountered. 

For example, going to this link https://dlink.maps.me/route?sll=55.800800,37.532754&saddr=PointA&dll=55.760158,37.618756&daddr=PointB&type=vehicle&back_url=wunderlinq://bla-bla-bla our app stores the back url in memory. And if the user taps on the hardware escape button then MAPSE will fire intent with back url data to lead the user back to the external app.

@kconger please take a look at this PR and if you have any questions let me know. I've implemented  only Android part as you see. To make the same for IOS please communicate with @beloal . Also If your requirements to this feature are not implemented completely as you wanted please let me know as well.