### PR TITLE
[mapcss] Fix amenity parking backward compatibility.

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -23,7 +23,7 @@ highway|residential|oneway;[highway=residential][oneway?];x;name;int_name;22;hig
 waterway|river;23;
 addr:interpolation|even;[addr:interpolation=even];x;name;int_name;24;hwtag|oneway
 addr:interpolation|odd;[addr:interpolation=odd];x;name;int_name;25;hwtag|private
-amenity|parking;[amenity=parking][access?];;name;int_name;26;
+amenity|parking;26;
 highway|primary;27;
 railway|rail;28;
 highway|service|parking_aisle;[highway=service][service=parking_aisle];;name;int_name;29;


### PR DESCRIPTION
В правилах для типа amenity|parking требуется чтобы ещё был указан access, но сейчас правила игнорируются и amenity|parking получается из фичей amenity=parking независимо от наличия access.
Предлагаю сохранить текущее поведение, тем более access есть только у 22% amenity=parking:

https://taginfo.openstreetmap.org/tags/amenity=parking#combinations

для этого убираю access из селектора. после этого правило можно записать в сокращенном виде.
на автогенеренные файлы это изменение не влияет