### PR TITLE
[mapcss] Fix mapcss-mapping for complex entry.

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -1328,4 +1328,4 @@ amenity|parking_space|underground;[amenity=parking_space][parking=underground];;
 amenity|parking_space|private;[amenity=parking_space][access=private];;name;int_name;1328;
 amenity|parking_space|permissive;[amenity=parking_space][access=permissive];;name;int_name;1329;
 landuse|churchyard;1330;
-complex_entry;1331;
+complex_entry;[complex_entry];;name;int_name;1331;


### PR DESCRIPTION
По формату короткую запись можно использовать для типов, которые превращаются в теги методом замены `|` на `=` и все наши парсилки на это расчитывают. Для типов длины 1 используется длинная запись.

https://github.com/mapsme/kothic/blob/master/src/libkomwm.py#L141