### PR TITLE
[Android] Refactoring of north direction handling.

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -149,11 +149,6 @@ void Framework::OnCompassUpdated(location::CompassInfo const & info, bool forceR
   }
 }
 
-void Framework::UpdateCompassSensor(int ind, float * arr)
-{
-  m_sensors[ind].Next(arr);
-}
-
 void Framework::MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive)
 {
   if (m_myPositionModeSignal)

--- a/android/jni/com/mapswithme/maps/Framework.hpp
+++ b/android/jni/com/mapswithme/maps/Framework.hpp
@@ -92,7 +92,6 @@ namespace android
     void OnLocationError(int/* == location::TLocationStatus*/ newStatus);
     void OnLocationUpdated(location::GpsInfo const & info);
     void OnCompassUpdated(location::CompassInfo const & info, bool forceRedraw);
-    void UpdateCompassSensor(int ind, float * arr);
 
     bool CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi, bool firstLaunch,
                            bool launchByDeepLink, int appVersionCode);

--- a/android/jni/com/mapswithme/maps/LocationHelper.cpp
+++ b/android/jni/com/mapswithme/maps/LocationHelper.cpp
@@ -42,20 +42,4 @@ extern "C"
       g_framework->OnLocationUpdated(info);
     GpsTracker::Instance().OnLocationUpdated(info);
   }
-
-  JNIEXPORT jfloatArray JNICALL
-  Java_com_mapswithme_maps_location_LocationHelper_nativeUpdateCompassSensor(JNIEnv * env, jclass clazz, jint ind, jfloatArray arr)
-  {
-    int const kCoordsCount = 3;
-
-    // Extract coords
-    jfloat coords[kCoordsCount];
-    env->GetFloatArrayRegion(arr, 0, kCoordsCount, coords);
-    g_framework->UpdateCompassSensor(ind, coords);
-
-    // Put coords back to java result array
-    jfloatArray ret = (jfloatArray)env->NewFloatArray(kCoordsCount);
-    env->SetFloatArrayRegion(ret, 0, kCoordsCount, coords);
-    return ret;
-  }
 }

--- a/android/jni/com/mapswithme/maps/MapFragment.cpp
+++ b/android/jni/com/mapswithme/maps/MapFragment.cpp
@@ -26,10 +26,10 @@ extern "C"
 using namespace storage;
 
 JNIEXPORT void JNICALL
-Java_com_mapswithme_maps_MapFragment_nativeCompassUpdated(JNIEnv * env, jclass clazz, jdouble magneticNorth, jdouble trueNorth, jboolean forceRedraw)
+Java_com_mapswithme_maps_MapFragment_nativeCompassUpdated(JNIEnv * env, jclass clazz, jdouble north, jboolean forceRedraw)
 {
   location::CompassInfo info;
-  info.m_bearing = (trueNorth >= 0.0) ? trueNorth : magneticNorth;
+  info.m_bearing = north;
 
   g_framework->OnCompassUpdated(info, forceRedraw);
 }

--- a/android/src/com/mapswithme/maps/MapFragment.java
+++ b/android/src/com/mapswithme/maps/MapFragment.java
@@ -379,7 +379,7 @@ public class MapFragment extends BaseMwmFragment
     return mSurfaceCreated;
   }
 
-  static native void nativeCompassUpdated(double magneticNorth, double trueNorth, boolean forceRedraw);
+  static native void nativeCompassUpdated(double north, boolean forceRedraw);
   static native void nativeScalePlus();
   static native void nativeScaleMinus();
   public static native boolean nativeShowMapForUrl(String url);

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1704,7 +1704,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     CompassData compass = LocationHelper.INSTANCE.getCompassData();
     if (compass != null)
-      MapFragment.nativeCompassUpdated(compass.getMagneticNorth(), compass.getTrueNorth(), true);
+      MapFragment.nativeCompassUpdated(compass.getNorth(), true);
   }
 
   private void adjustBottomWidgets(int offsetY)
@@ -2207,7 +2207,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onCompassUpdated(@NonNull CompassData compass)
   {
-    MapFragment.nativeCompassUpdated(compass.getMagneticNorth(), compass.getTrueNorth(), false);
+    MapFragment.nativeCompassUpdated(compass.getNorth(), false);
     mNavigationController.updateNorth(compass.getNorth());
   }
 

--- a/android/src/com/mapswithme/maps/location/CompassData.java
+++ b/android/src/com/mapswithme/maps/location/CompassData.java
@@ -8,30 +8,16 @@ import com.mapswithme.util.LocationUtils;
 
 public final class CompassData
 {
-  private double mMagneticNorth;
-  private double mTrueNorth;
   private double mNorth;
 
-  public void update(double magneticNorth, double trueNorth)
+  public void update(double north)
   {
     Activity top = MwmApplication.backgroundTracker().getTopActivity();
     if (top == null)
       return;
 
     int rotation = top.getWindowManager().getDefaultDisplay().getRotation();
-    mMagneticNorth = LocationUtils.correctCompassAngle(rotation, magneticNorth);
-    mTrueNorth = LocationUtils.correctCompassAngle(rotation, trueNorth);
-    mNorth = ((mTrueNorth >= 0.0) ? mTrueNorth : mMagneticNorth);
-  }
-
-  public double getMagneticNorth()
-  {
-    return mMagneticNorth;
-  }
-
-  public double getTrueNorth()
-  {
-    return mTrueNorth;
+    mNorth = LocationUtils.correctCompassAngle(rotation, north);
   }
 
   public double getNorth()

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -73,12 +73,12 @@ public enum LocationHelper
     }
 
     @Override
-    public void onCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy)
+    public void onCompassUpdated(long time, double north)
     {
       if (mCompassData == null)
         mCompassData = new CompassData();
 
-      mCompassData.update(magneticNorth, trueNorth);
+      mCompassData.update(north);
 
       if (mUiCallback != null)
         mUiCallback.onCompassUpdated(mCompassData);
@@ -251,10 +251,10 @@ public enum LocationHelper
     return mLocationUpdateStoppedByUser;
   }
 
-  void notifyCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy)
+  void notifyCompassUpdated(long time, double north)
   {
     for (LocationListener listener : mListeners)
-      listener.onCompassUpdated(time, magneticNorth, trueNorth, accuracy);
+      listener.onCompassUpdated(time, north);
     mListeners.finishIterate();
   }
 
@@ -661,7 +661,6 @@ public enum LocationHelper
   private static native void nativeOnLocationError(int errorCode);
   private static native void nativeLocationUpdated(long time, double lat, double lon, float accuracy,
                                                    double altitude, float speed, float bearing);
-  static native float[] nativeUpdateCompassSensor(int ind, float[] arr);
 
   public interface UiCallback
   {

--- a/android/src/com/mapswithme/maps/location/LocationListener.java
+++ b/android/src/com/mapswithme/maps/location/LocationListener.java
@@ -10,13 +10,13 @@ public interface LocationListener
     public void onLocationUpdated(Location location) {}
 
     @Override
-    public void onCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy) {}
+    public void onCompassUpdated(long time, double north) {}
 
     @Override
     public void onLocationError(int errorCode) {}
   }
 
   void onLocationUpdated(Location location);
-  void onCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy);
+  void onCompassUpdated(long time, double north);
   void onLocationError(int errorCode);
 }

--- a/android/src/com/mapswithme/maps/location/SensorHelper.java
+++ b/android/src/com/mapswithme/maps/location/SensorHelper.java
@@ -38,8 +38,7 @@ class SensorHelper implements SensorEventListener
       SensorManager.getOrientation(rotMatrix, rotVals);
 
       // rotVals indexes: 0 - yaw, 2 - roll, 1 - pitch.
-      double azimuth = rotVals[0];
-      LocationHelper.INSTANCE.notifyCompassUpdated(event.timestamp, azimuth, azimuth, 1.0);
+      LocationHelper.INSTANCE.notifyCompassUpdated(event.timestamp, rotVals[0]);
     }
   }
 

--- a/android/src/com/mapswithme/maps/widget/placepage/BottomSheetPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BottomSheetPlacePageController.java
@@ -433,14 +433,13 @@ public class BottomSheetPlacePageController implements PlacePageController, Loca
   }
 
   @Override
-  public void onCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy)
+  public void onCompassUpdated(long time, double north)
   {
     @AnchorBottomSheetBehavior.State
     int currentState = mPlacePageBehavior.getState();
     if (isHiddenState(currentState) || isDraggingState(currentState) || isSettlingState(currentState))
       return;
 
-    double north = trueNorth >= 0.0 ? trueNorth : magneticNorth;
     mPlacePage.refreshAzimuth(north);
   }
 

--- a/android/src/com/mapswithme/maps/widget/placepage/DirectionFragment.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/DirectionFragment.java
@@ -132,16 +132,11 @@ public class DirectionFragment extends BaseMwmDialogFragment
   }
 
   @Override
-  public void onCompassUpdated(long time, double magneticNorth, double trueNorth, double accuracy)
+  public void onCompassUpdated(long time, double north)
   {
     final Location last = LocationHelper.INSTANCE.getSavedLocation();
     if (last == null || mMapObject == null)
       return;
-
-    final int rotation = getActivity().getWindowManager().getDefaultDisplay().getRotation();
-    magneticNorth = LocationUtils.correctCompassAngle(rotation, magneticNorth);
-    trueNorth = LocationUtils.correctCompassAngle(rotation, trueNorth);
-    final double north = (trueNorth >= 0.0) ? trueNorth : magneticNorth;
 
     final DistanceAndAzimut da = Framework.nativeGetDistanceAndAzimuthFromLatLon(
         mMapObject.getLat(), mMapObject.getLon(),


### PR DESCRIPTION
1. В связи с переездом на сенсор TYPE_ROTATION_VECTOR теперь не нужно во все методы прокидывать trueNorth и magneticNorth, по которым прикидывается просто "north". Он у нас есть и так. Его и передаем вместо этих двух.
2. Мы не использовали accuracy для компаса. Можно удалить.
3. Удален не использовавшийся метод UpdateCompassSensor в Framework.cpp.