### PR TITLE
[Routing] Archival reporter integration test.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -314,10 +314,7 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
   , m_delegate(delegate)
   , m_trackingReporter(platform::CreateSocket(), TRACKING_REALTIME_HOST, TRACKING_REALTIME_PORT,
                        tracking::Reporter::kPushDelayMs)
-// TODO (o.khlopkova) remove ifdef when all platforms are ready.
-#if !defined(OMIM_OS_IPHONE)
   , m_trackingReporterArchive(TRACKING_HISTORICAL_HOST)
-#endif
   , m_extrapolator(
         [this](location::GpsInfo const & gpsInfo) { this->OnExtrapolatedLocationUpdate(gpsInfo); })
 {
@@ -486,8 +483,6 @@ void RoutingManager::OnLocationUpdate(location::GpsInfo const & info)
 {
   m_extrapolator.OnLocationUpdate(info);
 
-  //TODO (o.khlopkova) remove ifdef when all platforms are ready.
-#if !defined(OMIM_OS_IPHONE)
   if (IsTrackingReporterArchiveEnabled())
   {
      location::GpsInfo gpsInfo(info);
@@ -495,7 +490,6 @@ void RoutingManager::OnLocationUpdate(location::GpsInfo const & info)
      m_trackingReporterArchive.Insert(m_currentRouterType, info,
                                     m_routingSession.MatchTraffic(routeMatchingInfo));
   }
-#endif
 }
 
 RouterType RoutingManager::GetBestRouter(m2::PointD const & startPoint,
@@ -1146,10 +1140,7 @@ void RoutingManager::CallRouteBuilded(RouterResultCode code,
 
 void RoutingManager::ConfigureArchivalReporter(tracking::ArchivingSettings const & settings)
 {
-  // TODO (o.khlopkova) remove ifdef when all platforms are ready.
-#if !defined(OMIM_OS_IPHONE)
   m_trackingReporterArchive.SetArchivalManagerSettings(settings);
-#endif
 }
 
 void RoutingManager::CallRouteBuildStart(std::vector<RouteMarkData> const & points)

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -370,10 +370,8 @@ private:
   routing::RoutingSession m_routingSession;
   Delegate & m_delegate;
   tracking::Reporter m_trackingReporter;
-  // TODO(o.khlopkova) remove ifdef when all platforms are ready.
-#if !defined(OMIM_OS_IPHONE)
   tracking::ArchivalReporter m_trackingReporterArchive;
-#endif
+
   BookmarkManager * m_bmManager = nullptr;
   extrapolation::Extrapolator m_extrapolator;
 

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -7,8 +7,16 @@
 
 project(routing_integration_tests)
 
+include_directories(
+        ${OMIM_ROOT}/3party/freetype/include
+        ${OMIM_ROOT}/3party/glm
+        ${OMIM_ROOT}/3party/jansson/src
+        ${OMIM_ROOT}/3party/protobuf/protobuf/src
+)
+
 set(
   SRC
+  archival_reporter_tests.cpp
   bicycle_route_test.cpp
   bicycle_turn_test.cpp
   get_altitude_test.cpp
@@ -31,7 +39,11 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 omim_link_libraries(
   ${PROJECT_NAME}
   editor_tests_support
+  generator
   map
+  tracking
+  drape_frontend
+  shaders
   routing
   search
   storage
@@ -39,25 +51,49 @@ omim_link_libraries(
   traffic
   routing_common
   transit
+  descriptions
+  ugc
+  drape
+  partners_api
+  web_api
+  local_ads
+  platform_tests_support
   kml
   editor
   indexer
+  metrics
   platform
   oauthcpp
   geometry
   coding
   base
+  gflags
   jansson
   protobuf
   bsdiff
   succinct
   stats_client
+  minizip
   pugixml
   opening_hours
+  expat
+  freetype
   icu
+  sdf_image
+  stb_image
+  vulkan_wrapper
   agg
   ${LIBZ}
+  ${Qt5Widgets_LIBRARIES}
 )
 
+if (PLATFORM_LINUX)
+  omim_link_libraries(
+    ${PROJECT_NAME}
+    dl
+  )
+endif()
+
+link_opengl(${PROJECT_NAME})
 link_qt5_core(${PROJECT_NAME})
 link_qt5_network(${PROJECT_NAME})

--- a/routing/routing_integration_tests/archival_reporter_tests.cpp
+++ b/routing/routing_integration_tests/archival_reporter_tests.cpp
@@ -1,0 +1,174 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "map/framework.hpp"
+#include "map/routing_manager.hpp"
+
+#include "platform/platform.hpp"
+
+#include "coding/file_writer.hpp"
+
+#include "base/assert.hpp"
+#include "base/file_name_utils.hpp"
+
+#include "defines.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace
+{
+void UpdateLocationForArchiving(location::GpsInfo & point) { point.m_timestamp += 3; }
+
+size_t GetFilesCount(std::string const & path,
+                     std::string const & extension = ARCHIVE_TRACKS_FILE_EXTENSION)
+{
+  Platform::FilesList files;
+  Platform::GetFilesByExt(path, extension, files);
+  return files.size();
+}
+
+void FillArchive(RoutingManager & manager, size_t count)
+{
+  location::GpsInfo point;
+  point.m_horizontalAccuracy = 10.0;
+
+  for (size_t i = 0; i < count; ++i)
+  {
+    UpdateLocationForArchiving(point);
+    manager.OnLocationUpdate(point);
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+}
+
+void CreateEmptyFile(std::string const & path, std::string const & fileName)
+{
+  FileWriter fw(base::JoinPath(path, fileName));
+}
+
+void TestFilesExistence(size_t newestIndex, size_t fileCount, std::string const & fileExtension,
+                        std::string const & dir)
+{
+  CHECK_GREATER(newestIndex, fileCount, ());
+  for (size_t i = newestIndex; i > newestIndex - fileCount; --i)
+  {
+    TEST(Platform::IsFileExistsByFullPath(base::JoinPath(dir, std::to_string(i) + fileExtension)),
+         ());
+  }
+}
+
+TRouteResult GetRouteResult()
+{
+  return integration::CalculateRoute(integration::GetVehicleComponents(routing::VehicleType::Car),
+                                     mercator::FromLatLon(55.76100, 37.58000), m2::PointD::Zero(),
+                                     mercator::FromLatLon(55.75718, 37.63156));
+}
+
+size_t GetInitialTimestamp()
+{
+  auto const now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+}
+
+class TestArchivalReporter
+{
+public:
+  TestArchivalReporter()
+    : m_framework(m_frameworkParams)
+    , m_manager(m_framework.GetRoutingManager())
+    , m_session(m_manager.RoutingSession())
+    , m_routeResult(GetRouteResult())
+    , m_route(*m_routeResult.first)
+    , m_tracksDir(tracking::GetTracksDirectory())
+  {
+    RouterResultCode const result = m_routeResult.second;
+    TEST_EQUAL(result, RouterResultCode::NoError, ());
+
+    m_manager.SetRouter(routing::RouterType::Vehicle);
+    m_session.SetState(routing::SessionState::OnRoute);
+    m_session.EnableFollowMode();
+
+    m_session.SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
+    m_session.AssignRouteForTesting(std::make_shared<Route>(m_route), m_routeResult.second);
+  }
+
+  ~TestArchivalReporter() { Platform::RmDirRecursively(m_tracksDir); }
+
+protected:
+  FrameworkParams m_frameworkParams;
+  Framework m_framework;
+  RoutingManager & m_manager;
+  routing::RoutingSession & m_session;
+  TRouteResult m_routeResult;
+  Route & m_route;
+  std::string m_tracksDir;
+};
+
+// Ordinary ArchivalReporter pipeline: periodically dump files.
+UNIT_CLASS_TEST(TestArchivalReporter, StraightPipeline)
+{
+  TEST_EQUAL(GetFilesCount(m_tracksDir), 0, ());
+  for (size_t iter = 1; iter < 4; ++iter)
+  {
+    FillArchive(m_manager, tracking::kItemsForDump);
+    TEST_EQUAL(GetFilesCount(m_tracksDir), iter, ());
+  }
+}
+
+// Startup of ArchivalReporter: if there are too many files they need to be removed.
+UNIT_TEST(TestArchivalReporter_DeleteOldData)
+{
+  tracking::ArchivingSettings const settings;
+  std::string const tracksDir = tracking::GetTracksDirectory();
+  CHECK(Platform::MkDirChecked(tracksDir), ());
+  size_t const maxFilesCount = std::max(settings.m_maxFilesToSave, settings.m_maxArchivesToSave);
+  size_t const tsStart = GetInitialTimestamp();
+  size_t newestFileIndex = maxFilesCount * 2;
+
+  // Create files before the AchivalReporter initialization.
+  for (size_t i = 0, ts = tsStart; i <= newestFileIndex; ++i, ++ts)
+  {
+    auto const name = std::to_string(ts);
+    CreateEmptyFile(tracksDir, name + ARCHIVE_TRACKS_FILE_EXTENSION);
+    CreateEmptyFile(tracksDir, name + ARCHIVE_TRACKS_ZIPPED_FILE_EXTENSION);
+    TEST_EQUAL(GetFilesCount(tracksDir, ARCHIVE_TRACKS_FILE_EXTENSION), i + 1, ());
+    TEST_EQUAL(GetFilesCount(tracksDir, ARCHIVE_TRACKS_ZIPPED_FILE_EXTENSION), i + 1, ());
+  }
+
+  // Create the ArchivalReporter instance. It will remove the oldest files on startup.
+  TestArchivalReporter testReporter;
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  // Check that the files count equals to the maximum count.
+  TEST_EQUAL(GetFilesCount(tracksDir, ARCHIVE_TRACKS_FILE_EXTENSION), settings.m_maxFilesToSave,
+             ());
+  TEST_EQUAL(GetFilesCount(tracksDir, ARCHIVE_TRACKS_ZIPPED_FILE_EXTENSION),
+             settings.m_maxArchivesToSave, ());
+  // Check that the oldest files are removed and the newest ones are not.
+  newestFileIndex += tsStart;
+  TestFilesExistence(newestFileIndex, settings.m_maxFilesToSave, ARCHIVE_TRACKS_FILE_EXTENSION,
+                     tracksDir);
+  TestFilesExistence(newestFileIndex, settings.m_maxArchivesToSave,
+                     ARCHIVE_TRACKS_ZIPPED_FILE_EXTENSION, tracksDir);
+}
+
+// ArchivalReporter pipeline with no dumping.
+// Checks behaviour if there is no free space on device.
+UNIT_CLASS_TEST(TestArchivalReporter, FreeSpaceOnDisk)
+{
+  tracking::ArchivingSettings settings;
+  settings.m_minFreeSpaceOnDiskBytes = std::numeric_limits<size_t>::max();
+  m_manager.ConfigureArchivalReporter(settings);
+
+  TEST_EQUAL(GetFilesCount(m_tracksDir), 0, ());
+  for (size_t iter = 1; iter < 4; ++iter)
+  {
+    FillArchive(m_manager, tracking::kItemsForDump);
+    TEST_EQUAL(GetFilesCount(m_tracksDir), 0, ());
+  }
+}
+}  // namespace

--- a/tracking/archival_manager.cpp
+++ b/tracking/archival_manager.cpp
@@ -24,11 +24,6 @@ std::chrono::seconds GetTimestamp()
   return std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
 }
 
-std::string GetTracksDirectory()
-{
-  return base::JoinPath(GetPlatform().WritableDir(), kTracksArchive);
-}
-
 std::string GetTimestampFile(std::string const & tracksDir)
 {
   return base::JoinPath(tracksDir, kFileTimestampName);
@@ -37,6 +32,11 @@ std::string GetTimestampFile(std::string const & tracksDir)
 
 namespace tracking
 {
+std::string GetTracksDirectory()
+{
+  return base::JoinPath(GetPlatform().WritableDir(), kTracksArchive);
+}
+
 ArchivalManager::ArchivalManager(std::string const & url)
   : m_url(url)
   , m_tracksDir(GetTracksDirectory())

--- a/tracking/archival_manager.hpp
+++ b/tracking/archival_manager.hpp
@@ -26,6 +26,9 @@ struct ArchivingSettings
   uint32_t m_version = 1;
 };
 
+/// \returns path to the directory with the tracks.
+std::string GetTracksDirectory();
+
 class ArchivalManager
 {
 public:

--- a/tracking/archival_reporter.cpp
+++ b/tracking/archival_reporter.cpp
@@ -10,16 +10,6 @@
 namespace
 {
 double constexpr kRequiredHorizontalAccuracyM = 15.0;
-
-double constexpr kMinDelaySecondsCar = 1.0;
-double constexpr kMinDelaySecondsBicycle = 2.0;
-double constexpr kMinDelaySecondsPedestrian = 3.0;
-
-double constexpr kMinDelaySeconds =
-    std::min(kMinDelaySecondsCar, std::min(kMinDelaySecondsBicycle, kMinDelaySecondsPedestrian));
-
-// Number of items for at least 20 minutes.
-auto constexpr kItemsForDump = static_cast<size_t>(20.0 * 60.0 / kMinDelaySeconds);
 }  // namespace
 
 namespace tracking

--- a/tracking/archival_reporter.hpp
+++ b/tracking/archival_reporter.hpp
@@ -19,6 +19,16 @@
 
 namespace tracking
 {
+double constexpr kMinDelaySecondsCar = 1.0;
+double constexpr kMinDelaySecondsBicycle = 2.0;
+double constexpr kMinDelaySecondsPedestrian = 3.0;
+
+double constexpr kMinDelaySeconds =
+    std::min(kMinDelaySecondsCar, std::min(kMinDelaySecondsBicycle, kMinDelaySecondsPedestrian));
+
+// Number of items for at least 20 minutes.
+auto constexpr kItemsForDump = static_cast<size_t>(20.0 * 60.0 / kMinDelaySeconds);
+
 // Archive template instances.
 using Archive = BasicArchive<Packet>;
 using ArchiveCar = BasicArchive<PacketCar>;


### PR DESCRIPTION
Интеграционные тесты archival reporter.
**Почему они в роутинге, а не в tracking?** Потому что в routing_integration_tests находятся routing_test_tools, которые собираются в исполняемый файл, а не либу. Правильнее добавить интеграционный тест в роутинг, чем отдельно собирать routing_test_tools в либу и линковать из tracking.

**Откуда много новых зависимостей в CMakeLists?** Они нужны для framework, который используется для получения ссылки на адекватно настроенный routing manager, который в свою очередь запускает archival reporter.

