### PR TITLE
[generator][tests] Rename tests to allow single test selection with --filter.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -462,12 +462,12 @@ UNIT_CLASS_TEST(FeatureIntegrationTests, BuildCoasts)
   FeatureIntegrationTests::BuildCoasts();
 }
 
-UNIT_CLASS_TEST(FeatureIntegrationTests, BuildWorld)
+UNIT_CLASS_TEST(FeatureIntegrationTests, BuildWorldMultithread)
 {
   FeatureIntegrationTests::BuildWorld();
 }
 
-UNIT_CLASS_TEST(FeatureIntegrationTests, BuildCountries)
+UNIT_CLASS_TEST(FeatureIntegrationTests, BuildCountriesMultithread)
 {
   FeatureIntegrationTests::BuildCountries();
 }
@@ -482,7 +482,7 @@ UNIT_CLASS_TEST(FeatureIntegrationTests, CheckMixedTagsAndNodes)
   FeatureIntegrationTests::CheckMixedTagsAndNodes();
 }
 
-UNIT_CLASS_TEST(FeatureIntegrationTests, CheckGeneratedData)
+UNIT_CLASS_TEST(FeatureIntegrationTests, CheckGeneratedDataMultithread)
 {
   FeatureIntegrationTests::CheckGeneratedData();
 }


### PR DESCRIPTION
Cейчас `generator_integration_tests --filter=BuildCountries ` запускает три теста: BuildCountries, BuildCountriesWithComplex и BuildCountriesOneThread. Это не всегда удобно, иногда хочется запустить только 1 самый быстрый тест.