### PR TITLE
[generator] Fix CanBeLine and CanBePoint rules for feature emission.

### DIFF
--- a/generator/feature_processing_layers.cpp
+++ b/generator/feature_processing_layers.cpp
@@ -98,6 +98,12 @@ void RepresentationLayer::Handle(FeatureBuilder & fb)
     case feature::GeomType::Area:
     {
       HandleArea(fb, params);
+      // CanBeLine ignores exceptional types from TypeAlwaysExists / IsUsefulNondrawableType.
+      // Areal object with types amenity=restaurant + wifi=yes + cuisine=* should be added as areal object with
+      // these types and no extra linear/point objects.
+      // We need extra line object only for case when object has type which is drawable like line:
+      // amenity=playground + barrier=fence shold be added as areal object with amenity=playground + linear object
+      // with barrier=fence.
       if (CanBeLine(params))
       {
         auto featureLine = MakeLine(fb);
@@ -142,6 +148,7 @@ void RepresentationLayer::HandleArea(FeatureBuilder & fb, FeatureBuilderParams c
   }
   else if (CanBePoint(params))
   {
+    // CanBePoint ignores exceptional types from TypeAlwaysExists / IsUsefulNondrawableType.
     auto featurePoint = MakePoint(fb);
     LayerBase::Handle(featurePoint);
   }
@@ -156,13 +163,13 @@ bool RepresentationLayer::CanBeArea(FeatureParams const & params)
 // static
 bool RepresentationLayer::CanBePoint(FeatureParams const & params)
 {
-  return feature::HasUsefulType(params.m_types, feature::GeomType::Point);
+  return feature::IsDrawableLike(params.m_types, feature::GeomType::Point);
 }
 
 // static
 bool RepresentationLayer::CanBeLine(FeatureParams const & params)
 {
-  return feature::HasUsefulType(params.m_types, feature::GeomType::Line);
+  return feature::IsDrawableLike(params.m_types, feature::GeomType::Line);
 }
 
 void PrepareFeatureLayer::Handle(FeatureBuilder & fb)

--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -92,19 +92,19 @@ CountryFeaturesCounters constexpr kWorldCounters(945 /* fbs */, 364406 /* geomet
                                                  0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthAucklandCounters(
-    1812220 /* fbs */, 12197554 /* geometryPoints */, 1007483 /* point */, 205623 /* line */,
+    1811973 /* fbs */, 12194857 /* geometryPoints */, 1007481 /* point */, 205378 /* line */,
     599114 /* area */, 212342 /* poi */, 521 /* cityTownOrVillage */, 3557 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthWellingtonCounters(
-    797963 /* fbs */, 7773454 /* geometryPoints */, 460516 /* point */, 87172 /* line */,
+    797725 /* fbs */, 7771489 /* geometryPoints */, 460514 /* point */, 86936 /* line */,
     250275 /* area */, 95819 /* poi */, 297 /* cityTownOrVillage */, 1062 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthCanterburyCounters(
-    637282 /* fbs */, 6985227 /* geometryPoints */, 397939 /* point */, 81755 /* line */,
+    637089 /* fbs */, 6983208 /* geometryPoints */, 397934 /* point */, 81567 /* line */,
     157588 /* area */, 89534 /* poi */, 331 /* cityTownOrVillage */, 2085 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthSouthlandCounters(
-    340647 /* fbs */, 5342833 /* geometryPoints */, 185980 /* point */, 40141 /* line */,
+    340601 /* fbs */, 5342296 /* geometryPoints */, 185978 /* point */, 40097 /* line */,
     114526 /* area */, 40647 /* poi */, 297 /* cityTownOrVillage */, 1621 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthSouthlandMixedNodesCounters(
@@ -112,15 +112,15 @@ CountryFeaturesCounters constexpr kSouthSouthlandMixedNodesCounters(
     0 /* cityTownOrVillage */, 0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthAucklandComplexFeaturesCounters(
-    283 /* fbs */, 16014 /* geometryPoints */, 0 /* point */, 247 /* line */, 36 /* area */,
+    288 /* fbs */, 16119 /* geometryPoints */, 0 /* point */, 252 /* line */, 36 /* area */,
     0 /* poi */, 0 /* cityTownOrVillage */, 0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthWellingtonComplexFeaturesCounters(
-    253 /* fbs */, 18422 /* geometryPoints */, 0 /* point */, 243 /* line */, 10 /* area */,
+    254 /* fbs */, 18434 /* geometryPoints */, 0 /* point */, 244 /* line */, 10 /* area */,
     0 /* poi */, 0 /* cityTownOrVillage */, 0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthCanterburyComplexFeaturesCounters(
-    1035 /* fbs */, 73795 /* geometryPoints */, 0 /* point */, 1014 /* line */, 21 /* area */,
+    1037 /* fbs */, 73854 /* geometryPoints */, 0 /* point */, 1016 /* line */, 21 /* area */,
     0 /* poi */, 0 /* cityTownOrVillage */, 0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthSouthlandComplexFeaturesCounters(


### PR DESCRIPTION
Сейчас при добавлении фичи в качестве Area для неё проверяется `feature::IsDrawableLike(params.m_types, feature::GeomType::Area);`, что означает что фича либо имеет тип который "всегда отображается" такой как wifi и complex_entry либо действительно отображается как area.

При добавлении как Line и Point проверяется HasUsefulType, который также приводит к добавлению фичи если у неё есть типы cuisine, wheelchair и т.п.

По плану мы не должны добавлять в карту такие типы, если нет "полезных", то есть не должно существовать объектов с типами только cuisine, wheelchair и т.п. без отображаемых типов.

После исправления меняются generator integration tests, т.к. из карт исчезают эти лишние линии и точки с типами только cuisine, wheelchair и т.п.
дифф с фичами которые исчезли:
[git_diff.txt](https://github.com/mapsme/omim/files/4059749/git_diff.txt)

Также изменились константы в тесте комплексов, т.к. для площадных объектов, являющихся комплексами, нужен соответсвующий линейный объект
раньше для театров/университетов/музеев с типом wheelchair=* создавался линейный объект с таким типом (что не правильно), теперь соответсвующий объект создается при генерации комплексов с типом complex_entry.
Список новых complex_entry:
[git_diff_complex.txt](https://github.com/mapsme/omim/files/4059748/git_diff_complex.txt)
Кликабельные примеры:
https://www.openstreetmap.org/way/23894173
https://www.openstreetmap.org/way/23906678
https://www.openstreetmap.org/way/51949995
https://www.openstreetmap.org/way/66211908
