### PR TITLE
[generator] Ignore barriers on some highways

### DIFF
--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -190,19 +190,33 @@ UNIT_TEST(RoadAccessWriter_Merge)
                                           OsmElement::EntityType::Way, {10, 11, 12, 13});
   auto const w2 = MakeOsmElementWithNodes(2 /* id */, {{"highway", "service"}} /* tags */,
                                           OsmElement::EntityType::Way, {20, 21, 22, 23});
+  auto const w3 = MakeOsmElementWithNodes(3 /* id */, {{"highway", "motorway"}} /* tags */,
+                                          OsmElement::EntityType::Way, {30, 31, 32, 33});
 
   auto const p1 = generator_tests::MakeOsmElement(11 /* id */, {{"barrier", "lift_gate"}, {"motor_vehicle", "private"}}, OsmElement::EntityType::Node);
   auto const p2 = generator_tests::MakeOsmElement(22 /* id */, {{"barrier", "lift_gate"}, {"motor_vehicle", "private"}}, OsmElement::EntityType::Node);
+  // We should ignore this barrier because it's without access tag and placed on highway-motorway.
+  auto const p3 = generator_tests::MakeOsmElement(32 /* id */, {{"barrier", "lift_gate"}}, OsmElement::EntityType::Node);
 
   auto c1 = make_shared<RoadAccessWriter>(filename);
   auto c2 = c1->Clone();
+  auto c3 = c1->Clone();
+
   c1->CollectFeature(MakeFbForTest(p1), p1);
   c2->CollectFeature(MakeFbForTest(p2), p2);
+  c3->CollectFeature(MakeFbForTest(p3), p3);
+
   c1->CollectFeature(MakeFbForTest(w1), w1);
   c2->CollectFeature(MakeFbForTest(w2), w2);
+  c3->CollectFeature(MakeFbForTest(w3), w3);
+
   c1->Finish();
   c2->Finish();
+  c3->Finish();
+
   c1->Merge(*c2);
+  c1->Merge(*c3);
+
   c1->Save();
 
   ifstream stream;

--- a/generator/road_access_generator.hpp
+++ b/generator/road_access_generator.hpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <sstream>
@@ -45,13 +46,11 @@ public:
 
   void Process(OsmElement const & elem);
   void WriteWayToAccess(std::ostream & stream);
-  void WriteBarrierTags(std::ostream & stream, uint64_t id, std::vector<uint64_t> const & points);
+  void WriteBarrierTags(std::ostream & stream, uint64_t id, std::vector<uint64_t> const & points,
+                        bool ignoreBarrierWithoutAccess);
   void Merge(RoadAccessTagProcessor const & roadAccessTagProcessor);
 
 private:
-  bool ShouldIgnoreBarrierWithoutAccess(OsmElement const & osmElement) const;
-  RoadAccess::Type GetAccessType(OsmElement const & elem) const;
-
   VehicleType m_vehicleType;
 
   std::vector<TagMapping const *> m_barrierMappings;
@@ -62,9 +61,10 @@ private:
 
   // We decided to ignore some barriers without access on some type of highways
   // because we almost always do not need to add penalty for passes through such nodes.
-  std::set<OsmElement::Tag> const * m_hwIgnoreBarriersWithoutAccess;
+  std::optional<std::set<OsmElement::Tag>> m_hwIgnoreBarriersWithoutAccess;
 
-  std::unordered_map<uint64_t, RoadAccess::Type> m_barriers;
+  std::unordered_map<uint64_t, RoadAccess::Type> m_barriersWithoutAccessTag;
+  std::unordered_map<uint64_t, RoadAccess::Type> m_barriersWithAccessTag;
   std::unordered_map<uint64_t, RoadAccess::Type> m_wayToAccess;
 };
 


### PR DESCRIPTION
Идея была в том, чтобы игнорировать `barrier=*` на подмножестве `highway=*`, при условии, что у `barrier=*` нет `access tag`.
Почему-то в коде не проверялось - какой дороге принадлежит точка, из-за этого код по сути не работал