### PR TITLE
[generator] Block fords before access tags parsing.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -321,7 +321,7 @@ public:
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);
-    TestGeneratedFile(roadAccess, 1969045 /* fileSize */);
+    TestGeneratedFile(roadAccess, 1970528 /* fileSize */);
     TestGeneratedFile(m_genInfo.m_citiesBoundariesFilename, 87 /* fileSize */);
   }
 

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -111,13 +111,16 @@ TagMapping const kBicycleBarriersTagMapping = {
 // Empty mapping leads to default RoadAccess::Type::Yes access type for all roads.
 TagMapping const kTransitTagMapping = {};
 
+TagMapping const kForbiddenRoadsTagMapping = {
+  {OsmElement::Tag("highway", "ford"), RoadAccess::Type::No}
+};
+
 TagMapping const kDefaultTagMapping = {
   {OsmElement::Tag("access", "yes"), RoadAccess::Type::Yes},
   {OsmElement::Tag("access", "permissive"), RoadAccess::Type::Yes},
   {OsmElement::Tag("access", "no"), RoadAccess::Type::No},
   {OsmElement::Tag("access", "private"), RoadAccess::Type::Private},
   {OsmElement::Tag("access", "destination"), RoadAccess::Type::Destination},
-  {OsmElement::Tag("highway", "ford"), RoadAccess::Type::No}
 };
 
 set<OsmElement::Tag> const kHighwaysWhereIgnorePrivateAccessForCar = {
@@ -260,6 +263,7 @@ RoadAccessTagProcessor::RoadAccessTagProcessor(VehicleType vehicleType)
   switch (vehicleType)
   {
   case VehicleType::Car:
+    m_accessMappings.push_back(&kForbiddenRoadsTagMapping);
     m_accessMappings.push_back(&kMotorCarTagMapping);
     m_accessMappings.push_back(&kMotorVehicleTagMapping);
     m_accessMappings.push_back(&kVehicleTagMapping);
@@ -268,11 +272,13 @@ RoadAccessTagProcessor::RoadAccessTagProcessor(VehicleType vehicleType)
     m_hwIgnoreBarriersWithoutAccess = &kHighwaysWhereIgnorePrivateAccessForCar;
     break;
   case VehicleType::Pedestrian:
+    m_accessMappings.push_back(&kForbiddenRoadsTagMapping);
     m_accessMappings.push_back(&kPedestrianTagMapping);
     m_accessMappings.push_back(&kDefaultTagMapping);
     m_hwIgnoreBarriersWithoutAccess = &kHighwaysWhereIgnorePrivateAccessEmpty;
     break;
   case VehicleType::Bicycle:
+    m_accessMappings.push_back(&kForbiddenRoadsTagMapping);
     m_accessMappings.push_back(&kBicycleTagMapping);
     m_accessMappings.push_back(&kVehicleTagMapping);
     m_accessMappings.push_back(&kDefaultTagMapping);


### PR DESCRIPTION
Сейчас если у фичи есть тег ford и есть тег access, то результирующий access зависит от того в каком они порядке: какой первый тег в осм элементе, тот и "победил".
Например: https://www.openstreetmap.org/way/226176257#map=19/-43.20916/171.71059

Меняю предпочтения: если есть дорожный тип, который мы запрещаем, то не важно какой access.

diff road_access.csv в интеграционных тестах генератора:
```diff
> Car No 381672999 0
> Bicycle No 381672999 0
> Pedestrian No 381672999 0
< Car Private 381672999 0
< Bicycle Private 381672999 0
< Pedestrian Private 381672999 0
> Car No 551873851 0
> Bicycle No 551873851 0
> Pedestrian No 551873851 0
< Car Private 551873851 0
< Bicycle Private 551873851 0
< Pedestrian Private 551873851 0
> Bicycle No 193660923 0
> Bicycle No 218327604 0
> Bicycle No 226176256 0
> Bicycle No 226176257 0
> Bicycle No 226176366 0
> Bicycle No 226211967 0
> Bicycle No 226212603 0
> Bicycle No 243875632 0
> Bicycle No 285860659 0
> Bicycle No 312184310 0
> Bicycle No 317751997 14
> Bicycle No 317751997 24
> Bicycle No 365417583 0
> Bicycle No 396815087 0
> Bicycle No 414749699 0
> Bicycle No 414749702 0
> Bicycle No 449149844 0
> Bicycle No 619975669 0
> Bicycle No 678266153 0
> Car No 144670404 0
> Car No 317751997 14
> Car No 317751997 24
> Car No 323729574 0
> Car No 414749699 0
> Car No 449149844 0
> Car No 619975669 0
> Car No 678266153 0
> Pedestrian No 155711646 13
> Pedestrian No 169231465 0
> Pedestrian No 218327604 0
> Pedestrian No 218479521 0
> Pedestrian No 226176256 0
> Pedestrian No 226176258 0
> Pedestrian No 226176366 0
> Pedestrian No 243875632 0
> Pedestrian No 261051811 2
> Pedestrian No 274175063 0
> Pedestrian No 274176948 0
> Pedestrian No 285860659 0
> Pedestrian No 289824393 0
> Pedestrian No 289824412 0
> Pedestrian No 289824423 0
> Pedestrian No 289824552 0
> Pedestrian No 317751996 119
> Pedestrian No 317751996 146
> Pedestrian No 317751996 153
> Pedestrian No 317751996 169
> Pedestrian No 317751997 14
> Pedestrian No 317751997 24
> Pedestrian No 365417583 0
> Pedestrian No 414749699 0
> Pedestrian No 414749702 0
> Pedestrian No 449149844 0
> Pedestrian No 529279926 0
> Pedestrian No 539136321 0
> Pedestrian No 593293904 0
> Pedestrian No 657356766 0
> Pedestrian No 677202228 0
> Pedestrian No 677202232 0
> Pedestrian No 677351253 0
> Pedestrian No 678266153 0
> Pedestrian No 85552951 0
```