### PR TITLE
[routing] Fix matching to fake segments

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1168,8 +1168,9 @@ void RoutingManager::MatchLocationToRoute(location::GpsInfo & location,
 
 location::RouteMatchingInfo RoutingManager::GetRouteMatchingInfo(location::GpsInfo & info)
 {
-  location::RouteMatchingInfo routeMatchingInfo;
   CheckLocationForRouting(info);
+
+  location::RouteMatchingInfo routeMatchingInfo;
   MatchLocationToRoute(info, routeMatchingInfo);
   return routeMatchingInfo;
 }

--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -137,7 +137,7 @@ Iter FollowedPolyline::GetBestMatchingProjection(m2::RectD const & posRect) cons
 {
   CHECK_EQUAL(m_segProj.size() + 1, m_poly.GetSize(), ());
   // At first trying to find a projection to two closest route segments of route which is close
-  // enough to |posRect| center. If |m_current| is right before intermediate point we can get |closestIter|
+  // enough to |posRect| center. If |m_current| is right before intermediate point we can get |iter|
   // right after intermediate point (in next subroute).
   size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
   auto const iter = GetClosestMatchingProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);

--- a/routing/base/followed_polyline.hpp
+++ b/routing/base/followed_polyline.hpp
@@ -59,39 +59,26 @@ public:
 
   struct Iter
   {
-    m2::PointD m_pt;
-    size_t m_ind;
-
     static size_t constexpr kInvalidIndex = std::numeric_limits<size_t>::max();
 
+    Iter() = default;
     Iter(m2::PointD pt, size_t ind) : m_pt(pt), m_ind(ind) {}
-    Iter() : m_ind(kInvalidIndex) {}
+
     bool IsValid() const { return m_ind != kInvalidIndex; }
+
+    m2::PointD m_pt;
+    size_t m_ind = kInvalidIndex;
   };
 
-  struct UpdatedProjection
-  {
-    // Iterator to the projection point.
-    Iter m_iter;
-    // True if nearest point is on an unmatched segment.
-    bool m_closerToUnmatching;
-  };
-
-  struct UpdatedProjectionInfo
-  {
-    bool m_updatedProjection;
-    bool m_closerToUnmatching;
-  };
-
-  const Iter GetCurrentIter() const { return m_current; }
+  Iter GetCurrentIter() const { return m_current; }
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
 
   /// \brief Sets indexes of all unmatching segments on route.
-  void SetUnmatchingSegmentIndexes(std::vector<size_t> && unmatchingSegmentIndexes);
+  void SetFakeSegmentIndexes(std::vector<size_t> && fakeSegmentIndexes);
 
   /// \brief Updates projection to the closest matched segment if it's possible.
-  UpdatedProjectionInfo UpdateMatchingProjection(m2::RectD const & posRect);
+  bool UpdateMatchingProjection(m2::RectD const & posRect);
 
   Iter UpdateProjection(m2::RectD const & posRect);
 
@@ -134,8 +121,10 @@ public:
     return res;
   }
 
-UpdatedProjection GetClosestMatchingProjectionInInterval(m2::RectD const & posRect,
-                                                        size_t startIdx, size_t endIdx) const;
+  Iter GetClosestMatchingProjectionInInterval(m2::RectD const & posRect, size_t startIdx,
+                                              size_t endIdx) const;
+
+  bool IsFakeSegment(size_t index) const;
 
 private:
   /// \returns iterator to the best projection of center of |posRect| to the |m_poly|.
@@ -145,13 +134,13 @@ private:
   template <typename DistanceFn>
   Iter GetBestProjection(m2::RectD const & posRect, DistanceFn const & distFn) const;
 
-  UpdatedProjection GetBestMatchingProjection(m2::RectD const & posRect) const;
+  Iter GetBestMatchingProjection(m2::RectD const & posRect) const;
 
   void Update();
 
   m2::PolylineD m_poly;
   /// Indexes of all unmatching segments on route.
-  std::vector<size_t> m_unmatchingSegmentIndexes;
+  std::vector<size_t> m_fakeSegmentIndexes;
 
   /// Iterator with the current position. Position sets with UpdateProjection methods.
   Iter m_current;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -247,16 +247,16 @@ void Route::SetFakeSegmentsOnPolyline()
       fakeSegmentIndexes.push_back(i);
   }
 
-  m_poly.SetUnmatchingSegmentIndexes(move(fakeSegmentIndexes));
+  m_poly.SetFakeSegmentIndexes(move(fakeSegmentIndexes));
 }
 
-Route::MovedIteratorInfo Route::MoveIteratorToReal(location::GpsInfo const & info)
+bool Route::MoveIterator(location::GpsInfo const & info)
 {
   m2::RectD const rect = mercator::MetersToXY(
       info.m_longitude, info.m_latitude,
       max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-  auto const resUpdate = m_poly.UpdateMatchingProjection(rect);
-  return MovedIteratorInfo{resUpdate.m_updatedProjection, resUpdate.m_closerToUnmatching};
+
+  return m_poly.UpdateMatchingProjection(rect);
 }
 
 double Route::GetPolySegAngle(size_t ind) const
@@ -285,17 +285,20 @@ void Route::MatchLocationToRoute(location::GpsInfo & location, location::RouteMa
   if (m_poly.IsValid())
   {
     auto const & iter = m_poly.GetCurrentIter();
-    m2::PointD const locationMerc = mercator::FromLatLon(location.m_latitude, location.m_longitude);
-    double const distFromRouteM = mercator::DistanceOnEarth(iter.m_pt, locationMerc);
-    if (distFromRouteM < m_routingSettings.m_matchingThresholdM)
+
+    auto const locationMerc = mercator::FromLatLon(location.m_latitude, location.m_longitude);
+    auto const distFromRouteM = mercator::DistanceOnEarth(iter.m_pt, locationMerc);
+
+    if (!m_poly.IsFakeSegment(iter.m_ind) &&
+        distFromRouteM < m_routingSettings.m_matchingThresholdM)
     {
       location.m_latitude = mercator::YToLat(iter.m_pt.y);
       location.m_longitude = mercator::XToLon(iter.m_pt.x);
       if (m_routingSettings.m_matchRoute)
         location.m_bearing = location::AngleToBearing(GetPolySegAngle(iter.m_ind));
-
-      routeMatchingInfo.Set(iter.m_pt, iter.m_ind, GetMercatorDistanceFromBegin());
     }
+
+    routeMatchingInfo.Set(iter.m_pt, iter.m_ind, GetMercatorDistanceFromBegin());
   }
 }
 

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -195,14 +195,6 @@ public:
     size_t m_endSegmentIdx = 0;
   };
 
-  struct MovedIteratorInfo
-  {
-    // Indicator of setting the iterator to one of real segments.
-    bool m_movedIterator;
-    // Indicator of the presence of the fake segment which is the nearest to the given point.
-    bool m_closerToFake;
-  };
-
   /// \brief For every subroute some attributes are kept in the following structure.
   struct SubrouteSettings final
   {
@@ -334,7 +326,7 @@ public:
 
   void GetCurrentDirectionPoint(m2::PointD & pt) const;
   
-  MovedIteratorInfo MoveIteratorToReal(location::GpsInfo const & info);
+  bool MoveIterator(location::GpsInfo const & info);
 
   void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 

--- a/routing/routing_integration_tests/street_names_test.cpp
+++ b/routing/routing_integration_tests/street_names_test.cpp
@@ -17,7 +17,7 @@ void MoveRoute(Route & route, ms::LatLon const & coords)
   info.m_verticalAccuracy = 0.01;
   info.m_longitude = coords.m_lon;
   info.m_latitude = coords.m_lat;
-  route.MoveIteratorToReal(info);
+  route.MoveIterator(info);
 }
 
 UNIT_TEST(RussiaTulskayaToPaveletskayaStreetNamesTest)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -284,9 +284,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
 
-  auto const iteratorAction = m_route->MoveIteratorToReal(info);
-
-  if (iteratorAction.m_movedIterator)
+  if (m_route->MoveIterator(info))
   {
     m_moveAwayCounter = 0;
     m_lastDistance = 0.0;
@@ -306,7 +304,6 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     else
     {
       SetState(SessionState::OnRoute);
-
       m_speedCameraManager.OnLocationPositionChanged(info);
     }
 
@@ -316,7 +313,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     return m_state;
   }
 
-  if (!iteratorAction.m_closerToFake && m_state != SessionState::RouteNeedRebuild && m_state != SessionState::RouteRebuilding)
+  if (m_state != SessionState::RouteNeedRebuild && m_state != SessionState::RouteRebuilding)
   {
     // Distance from the last known projection on route
     // (check if we are moving far from the last known projection).

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -110,19 +110,19 @@ UNIT_TEST(DistanceToCurrentTurnTest)
                             ());
   TEST_EQUAL(turn, kTestTurns[0], ());
 
-  route.MoveIteratorToReal(GetGps(0, 0.5));
+  route.MoveIterator(GetGps(0, 0.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             mercator::DistanceOnEarth({0, 0.5}, kTestGeometry[1]), 0.1), ());
   TEST_EQUAL(turn, kTestTurns[0], ());
 
-  route.MoveIteratorToReal(GetGps(1, 1.5));
+  route.MoveIterator(GetGps(1, 1.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             mercator::DistanceOnEarth({1, 1.5}, kTestGeometry[4]), 0.1), ());
   TEST_EQUAL(turn, kTestTurns[2], ());
 
-  route.MoveIteratorToReal(GetGps(1, 2.5));
+  route.MoveIterator(GetGps(1, 2.5));
   route.GetCurrentTurn(distance, turn);
   TEST(base::AlmostEqualAbs(distance,
                             mercator::DistanceOnEarth({1, 2.5}, kTestGeometry[4]), 0.1), ());
@@ -146,13 +146,13 @@ UNIT_TEST(NextTurnTest)
   TEST_EQUAL(turn, kTestTurns[0], ());
   TEST_EQUAL(nextTurn, kTestTurns[1], ());
 
-  route.MoveIteratorToReal(GetGps(0.5, 1));
+  route.MoveIterator(GetGps(0.5, 1));
   route.GetCurrentTurn(distance, turn);
   route.GetNextTurn(nextDistance, nextTurn);
   TEST_EQUAL(turn, kTestTurns[1], ());
   TEST_EQUAL(nextTurn, kTestTurns[2], ());
 
-  route.MoveIteratorToReal(GetGps(1, 1.5));
+  route.MoveIterator(GetGps(1, 1.5));
   route.GetCurrentTurn(distance, turn);
   route.GetNextTurn(nextDistance, nextTurn);
   TEST_EQUAL(turn, kTestTurns[2], ());
@@ -183,7 +183,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 0.;
     double const y = 0.5;
-    route.MoveIteratorToReal(GetGps(x, y));
+    route.MoveIterator(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
     double const firstSegLenM = mercator::DistanceOnEarth({x, y}, kTestGeometry[1]);
@@ -196,7 +196,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 1.;
     double const y = 2.5;
-    route.MoveIteratorToReal(GetGps(x, y));
+    route.MoveIterator(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
     double const firstSegLenM = mercator::DistanceOnEarth({x, y}, kTestGeometry[4]);
@@ -206,7 +206,7 @@ UNIT_TEST(NextTurnsTest)
   {
     double const x = 1.;
     double const y = 3.5;
-    route.MoveIteratorToReal(GetGps(x, y));
+    route.MoveIterator(GetGps(x, y));
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 1, ());
   }
@@ -240,7 +240,7 @@ UNIT_TEST(SelfIntersectedRouteMatchingTest)
                                  location::GpsInfo const & expectedMatchingPos,
                                  size_t expectedIndexInRoute) {
     location::RouteMatchingInfo routeMatchingInfo;
-    route.MoveIteratorToReal(pos);
+    route.MoveIterator(pos);
     location::GpsInfo matchedPos = pos;
     route.MatchLocationToRoute(matchedPos, routeMatchingInfo);
     TEST_LESS(mercator::DistanceOnEarth(
@@ -309,7 +309,7 @@ UNIT_TEST(RouteNameTest)
   location::GpsInfo info;
   info.m_longitude = 1.0;
   info.m_latitude = 2.0;
-  route.MoveIteratorToReal(info);
+  route.MoveIterator(info);
   route.GetCurrentStreetName(name);
   TEST_EQUAL(name, "Street2", ());
 }


### PR DESCRIPTION
PR исправляет следующую вещь:
1) когда мы матчимся на фейковый сегмент, то мы продолжаем не привызывать стрелку графически, но при этом расстояние при движении вдоль фейкового сегмента - уменьшается
2) если ты сильно отошли от фейкового сегмента, то маршрут будет перестраиваться