### PR TITLE
[release-96][routing] Continue navigating along a previous route in case of route rebuilding error.

### DIFF
--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -42,30 +42,32 @@ enum class RouterResultCode
 
 enum class SessionState
 {
-  RoutingNotActive,
-  RouteBuilding,     // we requested a route and wait when it will be builded
-  RouteNotReady,     // routing was not build
-  RouteNotStarted,   // route is builded but the user isn't on it
-  OnRoute,           // user follows the route
-  RouteNeedRebuild,  // user left the route
-  RouteFinished,     // destination point is reached but the session isn't closed
-  RouteNoFollowing,  // route is built but following mode has been disabled
-  RouteRebuilding,   // we requested a route rebuild and wait when it will be rebuilded
+  RoutingNotActive,   // No valid route: no route after application launching or the route was removed.
+  RouteBuilding,      // We requested a route and wait when it will be built. User may be following
+                      // the previous route.
+  RouteBuildingError, // The route was not built because of an error.
+  RouteNotStarted,    // Route is built but the user isn't on it.
+  OnRoute,            // User follows the route.
+  RouteNeedRebuild,   // User left the route.
+  RouteFinished,      // Destination point is reached but the session isn't closed.
+  RouteNoFollowing,   // Route is built but following mode has been disabled.
+  RouteRebuilding,    // We requested a route rebuild and wait when it will be rebuilt.
+                      // User may following the previous route.
 };
 
 /*
  * RoutingNotActive -> RouteBuilding    // start route building
- * RouteBuilding -> RouteNotReady       // waiting for route in case of building a new route
+ * RouteBuilding -> RouteBuildingError       // route was built with an error
  * RouteBuilding -> RouteNotStarted     // route is built in case of building a new route
- * RouteRebuilding -> RouteNotReady     // waiting for route in case of rebuilding
+ * RouteRebuilding -> RouteBuildingError     // waiting for route in case of rebuilding
  * RouteRebuilding -> RouteNotStarted   // route is built in case of rebuilding
  * RouteNotStarted -> OnRoute           // user started following the route
  * RouteNotStarted -> RouteNeedRebuild  // user doesn't like the route.
  * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
- * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position.
+ * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position
  * OnRoute -> RouteFinished             // user reached the end of route
- * RouteNeedRebuild -> RouteNotReady    // start rebuild route
- * RouteFinished -> RouteNotReady       // start new route
+ * OnRoute -> RouteBuilding             // while moving along a route user makes a new route
+ * RouteNeedRebuild -> RouteRebuilding  // start rebuild route
  */
 
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -45,7 +45,7 @@ enum class SessionState
   NoValidRoute,       // No valid route: no route after application launching or the route was removed.
   RouteBuilding,      // We requested a route and wait when it will be built. User may be following
                       // the previous route.
-  RouteBuildingError, // The route was not built because of an error.
+  RouteBuildingError, // @TODO The state should be removed. The route was not built because of an error.
   RouteNotStarted,    // Route is built but the user isn't on it.
   OnRoute,            // User follows the route.
   RouteNeedRebuild,   // User left the route.
@@ -56,18 +56,20 @@ enum class SessionState
 };
 
 /*
- * NoValidRoute -> RouteBuilding    // start route building
- * RouteBuilding -> RouteBuildingError       // route was built with an error
- * RouteBuilding -> RouteNotStarted     // route is built in case of building a new route
- * RouteRebuilding -> RouteBuildingError     // waiting for route in case of rebuilding
- * RouteRebuilding -> RouteNotStarted   // route is built in case of rebuilding
- * RouteNotStarted -> OnRoute           // user started following the route
- * RouteNotStarted -> RouteNeedRebuild  // user doesn't like the route.
- * OnRoute -> RouteNeedRebuild          // user moves away from route - need to rebuild
- * OnRoute -> RouteNoFollowing          // following mode was disabled. Router doesn't track position
- * OnRoute -> RouteFinished             // user reached the end of route
- * OnRoute -> RouteBuilding             // while moving along a route user makes a new route
- * RouteNeedRebuild -> RouteRebuilding  // start rebuild route
+ * NoValidRoute -> RouteBuilding         // start route building
+ * RouteBuilding -> RouteBuildingError   // route was built with an error
+ * RouteBuilding -> RouteNotStarted      // route is built in case of building a new route
+ * RouteRebuilding -> RouteBuildingError // waiting for route in case of rebuilding
+ * RouteRebuilding -> RouteNotStarted    // route is built in case of rebuilding
+ * RouteNotStarted -> OnRoute            // user started following the route
+ * RouteNotStarted -> RouteNeedRebuild   // user doesn't like the route.
+ * OnRoute -> RouteNeedRebuild           // user moves away from route - need to rebuild
+ * RouteNeedRebuild -> RouteRebuilding   // the route is in process of rebuilding or
+ *                                       // while rebuilding an error happens
+ * RouteRebuilding -> OnRoute            // following along route after rebuilding
+ * OnRoute -> RouteNoFollowing           // following mode was disabled. Router doesn't track position
+ * OnRoute -> RouteFinished              // user reached the end of route
+ * OnRoute -> RouteBuilding              // while moving along a route user makes a new route
  */
 
 using CheckpointCallback = std::function<void(size_t passedCheckpointIdx)>;

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -42,7 +42,7 @@ enum class RouterResultCode
 
 enum class SessionState
 {
-  RoutingNotActive,   // No valid route: no route after application launching or the route was removed.
+  NoValidRoute,       // No valid route: no route after application launching or the route was removed.
   RouteBuilding,      // We requested a route and wait when it will be built. User may be following
                       // the previous route.
   RouteBuildingError, // The route was not built because of an error.
@@ -56,7 +56,7 @@ enum class SessionState
 };
 
 /*
- * RoutingNotActive -> RouteBuilding    // start route building
+ * NoValidRoute -> RouteBuilding    // start route building
  * RouteBuilding -> RouteBuildingError       // route was built with an error
  * RouteBuilding -> RouteNotStarted     // route is built in case of building a new route
  * RouteRebuilding -> RouteBuildingError     // waiting for route in case of rebuilding

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -181,8 +181,8 @@ private:
   };
 
   void AssignRoute(std::shared_ptr<Route> route, RouterResultCode e);
-  /// RemoveRoute removes m_route and resets route attributes (m_state, m_lastDistance, m_moveAwayCounter).
-  void RemoveRoute();
+  /// RemoveRoute() removes m_route and resets route attributes (m_state, m_lastDistance, m_moveAwayCounter).
+  void RemoveRoute(bool changeStateToNoValidRoute);
   void RebuildRouteOnTrafficUpdate();
 
   double GetCompletionPercent() const;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -181,8 +181,8 @@ private:
   };
 
   void AssignRoute(std::shared_ptr<Route> route, RouterResultCode e);
-  /// RemoveRoute() removes m_route and resets route attributes (m_state, m_lastDistance, m_moveAwayCounter).
-  void RemoveRoute(bool changeStateToNoValidRoute);
+  /// RemoveRoute() removes m_route and resets route attributes (m_lastDistance, m_moveAwayCounter).
+  void RemoveRoute();
   void RebuildRouteOnTrafficUpdate();
 
   double GetCompletionPercent() const;

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -19,12 +19,22 @@
 #include <string>
 #include <vector>
 
-namespace routing
+namespace
 {
+using namespace routing;
 using namespace std;
 
 using chrono::seconds;
 using chrono::steady_clock;
+
+vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 2.}, {0., 3.}, {0., 4.}};
+vector<Segment> const kTestSegments({{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}});
+Route::TTurns const kTestTurns = {turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
+Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(2, 10),
+                                Route::TTimeItem(3, 15)});
+auto const kRouteBuildingMaxDuration = seconds(30);
+
+void FillSubroutesInfo(Route & route);
 
 // Simple router. It returns route given to him on creation.
 class DummyRouter : public IRouter
@@ -52,14 +62,34 @@ public:
   }
 };
 
-static vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 2.}, {0., 3.}, {0., 4.}};
-static vector<Segment> const kTestSegments({{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}});
-static Route::TTurns const kTestTurns = {
-    turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
-static Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(2, 10),
-                                       Route::TTimeItem(3, 15)});
+// Router which every next call of CalculateRoute() method return different return codes.
+class ReturnCodesRouter : public IRouter
+{
+public:
+  ReturnCodesRouter(initializer_list<RouterResultCode> const & returnCodes,
+                    vector<m2::PointD> const & route)
+    : m_returnCodes(returnCodes), m_route(route)
+  {
+  }
 
-static auto kRouteBuildingMaxDuration = seconds(30);
+  // IRouter overrides:
+  string GetName() const override { return "return codes router"; }
+  void ClearState() override {}
+  RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */,
+                                  m2::PointD const & /* startDirection */, bool /* adjust */,
+                                  RouterDelegate const & /* delegate */, Route & route) override
+  {
+    TEST_LESS(m_returnCodesIdx, m_returnCodes.size(), ());
+    route = Route(GetName(), m_route.begin(), m_route.end(), 0 /* route id */);
+    FillSubroutesInfo(route);
+    return m_returnCodes[m_returnCodesIdx++];
+  }
+
+private:
+  vector<RouterResultCode> m_returnCodes;
+  vector<m2::PointD> m_route;
+  size_t m_returnCodesIdx = 0;
+};
 
 class TimedSignal
 {
@@ -96,12 +126,34 @@ public:
   SessionStateTest(initializer_list<SessionState> expectedStates, RoutingSession & routingSession)
     : m_expectedStates(expectedStates), m_session(routingSession)
   {
-    m_session.SetChangeSessionStateCallback([this](SessionState previous, SessionState current) {
-      TestChangeSessionStateCallbackCall(previous, current);
+    for (size_t i = 1; i < expectedStates.size(); ++i)
+    {
+      // Note. Change session state callback is called only if the state is change.
+      if (m_expectedStates[i - 1] != m_expectedStates[i])
+        ++m_expectedNumberOfStateChanging;
+    }
+
+    TimedSignal timedSignal;
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, &timedSignal]() {
+      m_session.SetChangeSessionStateCallback([this](SessionState previous, SessionState current) {
+        TestChangeSessionStateCallbackCall(previous, current);
+      });
+      timedSignal.Signal();
     });
+    TEST(timedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Callback is not set."));
   }
 
-  ~SessionStateTest() { m_session.SetChangeSessionStateCallback(nullptr); }
+  ~SessionStateTest()
+  {
+    TEST_EQUAL(m_numberOfTestCalls, m_expectedNumberOfStateChanging,
+               ("Wrong number of calls of SetState() callback.", m_expectedStates));
+    TimedSignal timedSignal;
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, &timedSignal]() {
+      m_session.SetChangeSessionStateCallback(nullptr);
+      timedSignal.Signal();
+    });
+    TEST(timedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Callback is not set."));
+  }
 
 private:
   void TestChangeSessionStateCallbackCall(SessionState previous, SessionState current)
@@ -116,6 +168,7 @@ private:
 
   size_t m_numberOfTestCalls = 0;
   vector<SessionState> const m_expectedStates;
+  size_t m_expectedNumberOfStateChanging = 0;
   RoutingSession & m_session;
 };
 
@@ -133,6 +186,36 @@ void FillSubroutesInfo(Route & route)
       {Route::SubrouteAttrs(junctions.front(), junctions.back(), 0, kTestSegments.size())}));
 }
 
+void TestMovingByUpdatingLat(SessionStateTest const & sessionState, vector<double> const & lats,
+                             location::GpsInfo const & info, RoutingSession & session)
+{
+  location::GpsInfo uptInfo(info);
+  TimedSignal signal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&session, &signal, &lats, &uptInfo]() {
+    for (auto const lat : lats)
+    {
+      uptInfo.m_latitude = lat;
+      session.OnLocationPositionChanged(uptInfo);
+    }
+
+    signal.Signal();
+  });
+  TEST(signal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
+       ("Along route moving timeout."));
+}
+
+void TestLeavingRoute(RoutingSession & session, location::GpsInfo const & info)
+{
+  vector<double> const latitudes = {0.0,    -0.001, -0.002, -0.003, -0.004, -0.005,
+                                    -0.006, -0.007, -0.008, -0.009, -0.01,  -0.011};
+  SessionStateTest sessionStateTest({SessionState::OnRoute, SessionState::RouteNeedRebuild},
+                                    session);
+  TestMovingByUpdatingLat(sessionStateTest, latitudes, info, session);
+}
+}  // namespace
+
+namespace routing
+{
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteBuilding)
 {
   // Multithreading synchronization note. |counter| and |session| are constructed on the main thread,
@@ -169,7 +252,6 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteBuilding)
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingAway)
 {
   location::GpsInfo info;
-  FrozenDataSource dataSource;
   size_t counter = 0;
 
   TimedSignal alongTimedSignal;
@@ -193,40 +275,40 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
   TEST_EQUAL(counter, 1, ());
 
-  TimedSignal oppositeTimedSignal;
-  GetPlatform().RunTask(Platform::Thread::Gui, [&oppositeTimedSignal, &info, this]() {
-    info.m_horizontalAccuracy = 0.01;
-    info.m_verticalAccuracy = 0.01;
-    info.m_longitude = 0.;
-    info.m_latitude = 1.;
-    SessionState code = SessionState::NoValidRoute;
+  {
+    SessionStateTest sessionStateTest(
+        {SessionState::RouteNotStarted, SessionState::OnRoute, SessionState::RouteBuilding,
+         SessionState::RouteNotStarted},
+        *m_session);
+    TimedSignal oppositeTimedSignal;
+    GetPlatform().RunTask(Platform::Thread::Gui, [&oppositeTimedSignal, &info, this]() {
+      info.m_horizontalAccuracy = 0.01;
+      info.m_verticalAccuracy = 0.01;
+      info.m_longitude = 0.;
+      info.m_latitude = 1.;
+      SessionState code = SessionState::NoValidRoute;
 
-    {
-      SessionStateTest sessionStateTest({SessionState::RouteNotStarted, SessionState::OnRoute},
-                                        *m_session);
-      while (info.m_latitude < kTestRoute.back().y)
       {
-        code = m_session->OnLocationPositionChanged(info);
-        TEST_EQUAL(code, SessionState::OnRoute, ());
-        info.m_latitude += 0.01;
+        while (info.m_latitude < kTestRoute.back().y)
+        {
+          code = m_session->OnLocationPositionChanged(info);
+          TEST_EQUAL(code, SessionState::OnRoute, ());
+          info.m_latitude += 0.01;
+        }
       }
-    }
 
-    // Rebuild route and go in opposite direction. So initiate a route rebuilding flag.
-    m_session->SetRoutingCallbacks(
-        [&oppositeTimedSignal](Route const &, RouterResultCode) { oppositeTimedSignal.Signal(); },
-        nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
-        nullptr /* removeRouteCallback */);
-    {
-      SessionStateTest sessionStateTest(
-          {SessionState::OnRoute, SessionState::RouteBuilding},
-          *m_session);
-
-      m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
-                            RouterDelegate::kNoTimeout);
-    }
-  });
-  TEST(oppositeTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+      // Rebuild route and go in opposite direction. So initiate a route rebuilding flag.
+      m_session->SetRoutingCallbacks(
+          [&oppositeTimedSignal](Route const &, RouterResultCode) { oppositeTimedSignal.Signal(); },
+          nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
+          nullptr /* removeRouteCallback */);
+      {
+        m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+                              RouterDelegate::kNoTimeout);
+      }
+    });
+    TEST(oppositeTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+  }
 
   // Going away from route to set rebuilding flag.
   TimedSignal checkTimedSignal;
@@ -252,7 +334,6 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingToRoute)
 {
   location::GpsInfo info;
-  FrozenDataSource dataSource;
   size_t counter = 0;
 
   TimedSignal alongTimedSignal;
@@ -276,33 +357,34 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingT
   TEST_EQUAL(counter, 1, ());
 
   // Going starting far from the route and moving to the route but rebuild flag still is set.
-  TimedSignal checkTimedSignalAway;
-  GetPlatform().RunTask(Platform::Thread::Gui, [&checkTimedSignalAway, &info, this]() {
-    info.m_longitude = 0.0;
-    info.m_latitude = 0.0;
-    info.m_speedMpS = routing::KMPH2MPS(60);
-    SessionState code = SessionState::NoValidRoute;
-    {
-      SessionStateTest sessionStateTest(
-          {SessionState::RouteNotStarted, SessionState::RouteNeedRebuild},
-          *m_session);
-      for (size_t i = 0; i < 8; ++i)
+  {
+    SessionStateTest sessionStateTest(
+        {SessionState::RouteNotStarted, SessionState::RouteNeedRebuild},
+        *m_session);
+    TimedSignal checkTimedSignalAway;
+    GetPlatform().RunTask(Platform::Thread::Gui, [&checkTimedSignalAway, &info, this]() {
+      info.m_longitude = 0.0;
+      info.m_latitude = 0.0;
+      info.m_speedMpS = routing::KMPH2MPS(60);
+      SessionState code = SessionState::NoValidRoute;
       {
-        code = m_session->OnLocationPositionChanged(info);
-        info.m_latitude += 0.1;
+        for (size_t i = 0; i < 8; ++i)
+        {
+          code = m_session->OnLocationPositionChanged(info);
+          info.m_latitude += 0.1;
+        }
       }
-    }
-    TEST_EQUAL(code, SessionState::RouteNeedRebuild, ());
-    checkTimedSignalAway.Signal();
-  });
-  TEST(checkTimedSignalAway.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
-       ("Route was not rebuilt."));
+      TEST_EQUAL(code, SessionState::RouteNeedRebuild, ());
+      checkTimedSignalAway.Signal();
+    });
+    TEST(checkTimedSignalAway.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
+         ("Route was not rebuilt."));
+  }
 }
 
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersistence)
 {
   location::GpsInfo info;
-  FrozenDataSource dataSource;
   size_t counter = 0;
 
   TimedSignal alongTimedSignal;
@@ -389,7 +471,6 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
 
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest)
 {
-  FrozenDataSource dataSource;
   TimedSignal alongTimedSignal;
   GetPlatform().RunTask(Platform::Thread::Gui, [&alongTimedSignal, this]() {
     InitRoutingSession();
@@ -450,5 +531,90 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest
   });
   TEST(checkTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
        ("Route checking timeout."));
+}
+
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
+{
+  vector<m2::PointD> const kRoute = {{0.0, 0.001}, {0.0, 0.002}, {0.0, 0.003}, {0.0, 0.004}};
+  // Creation RoutingSession.
+  TimedSignal createTimedSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [this, &kRoute, &createTimedSignal]() {
+    InitRoutingSession();
+    unique_ptr<ReturnCodesRouter> router = make_unique<ReturnCodesRouter>(initializer_list<
+        RouterResultCode>{RouterResultCode::NoError, RouterResultCode::InternalError}, kRoute);
+    m_session->SetRouter(move(router), nullptr);
+    createTimedSignal.Signal();
+  });
+  TEST(createTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
+       ("RouteSession was not created."));
+
+  // Building a route.
+  {
+    SessionStateTest sessionStateTest(
+        {SessionState::NoValidRoute, SessionState::RouteBuilding, SessionState::RouteNotStarted},
+        *m_session);
+    TimedSignal buildTimedSignal;
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, &kRoute, &buildTimedSignal]() {
+      m_session->SetRoutingCallbacks(
+          [&buildTimedSignal](Route const &, RouterResultCode) { buildTimedSignal.Signal(); },
+          nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
+          nullptr /* removeRouteCallback */);
+
+      m_session->BuildRoute(Checkpoints(kRoute.front(), kRoute.back()),
+                            RouterDelegate::kNoTimeout);
+    });
+    TEST(buildTimedSignal
+             .WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+  }
+
+  location::GpsInfo info;
+  info.m_horizontalAccuracy = 5.0; // meters
+  info.m_verticalAccuracy = 5.0; // meters
+  info.m_longitude = 0.0;
+
+  // Moving along route.
+  {
+    SessionStateTest sessionStateTest({SessionState::RouteNotStarted, SessionState::OnRoute},
+                                      *m_session);
+    vector<double> const latitudes = {0.001, 0.0015, 0.002};
+    TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
+  }
+
+  // Leaving the route until switching to |SessionState::RouteNeedRebuild| state.
+  TestLeavingRoute(*m_session, info);
+
+  // Continue moving along the route.
+  {
+    SessionStateTest sessionStateTest({SessionState::RouteNeedRebuild, SessionState::OnRoute},
+                                      *m_session);
+    vector<double> const latitudes = {0.002, 0.0025, 0.003};
+    TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
+  }
+
+  // Leaving the route until switching to |SessionState::RouteRebuilding| state.
+  TestLeavingRoute(*m_session, info);
+  {
+    SessionStateTest sessionStateTest(
+        {SessionState::RouteNeedRebuild, SessionState::RouteRebuilding,
+         SessionState::RouteNotStarted
+         },
+        *m_session);
+    TimedSignal signal;
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, &signal]() {
+      m_session->SetState(SessionState::RouteRebuilding);
+      m_session->SetState(SessionState::RouteNotStarted);
+      signal.Signal();
+    });
+    TEST(signal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
+         ("State was not set."));
+  }
+
+  // Continue moving along the route again.
+  {
+    SessionStateTest sessionStateTest({SessionState::RouteNotStarted, SessionState::OnRoute},
+                                      *m_session);
+    vector<double> const latitudes = {0.003, 0.0035, 0.004};
+    TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
+  }
 }
 }  // namespace routing

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -219,7 +219,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
         nullptr /* removeRouteCallback */);
     {
       SessionStateTest sessionStateTest(
-          {SessionState::OnRoute, SessionState::RoutingNotActive, SessionState::RouteBuilding},
+          {SessionState::OnRoute, SessionState::RouteBuilding},
           *m_session);
 
       m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -580,7 +580,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
     TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
   }
 
-  // Leaving the route until switching to |SessionState::RouteNeedRebuild| state.
+  // Test 1. Leaving the route and returning to the route when state is |SessionState::RouteNeedRebuil|.
   TestLeavingRoute(*m_session, info);
 
   // Continue moving along the route.
@@ -591,18 +591,16 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
     TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
   }
 
-  // Leaving the route until switching to |SessionState::RouteRebuilding| state.
+  // Test 2. Leaving the route until, can not rebuilding it, and going along an old route.
+  // It happens we the route is left and it's impossible to build a new route.
+  // In this case the navigation is continued based on the former route.
   TestLeavingRoute(*m_session, info);
   {
     SessionStateTest sessionStateTest(
-        {SessionState::RouteNeedRebuild, SessionState::RouteRebuilding,
-         SessionState::RouteNotStarted
-         },
-        *m_session);
+        {SessionState::RouteNeedRebuild, SessionState::RouteRebuilding}, *m_session);
     TimedSignal signal;
     GetPlatform().RunTask(Platform::Thread::Gui, [this, &signal]() {
       m_session->SetState(SessionState::RouteRebuilding);
-      m_session->SetState(SessionState::RouteNotStarted);
       signal.Signal();
     });
     TEST(signal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration),
@@ -611,7 +609,8 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
 
   // Continue moving along the route again.
   {
-    SessionStateTest sessionStateTest({SessionState::RouteNotStarted, SessionState::OnRoute},
+    // Test on state is not changed.
+    SessionStateTest sessionStateTest({SessionState::RouteRebuilding, SessionState::OnRoute},
                                       *m_session);
     vector<double> const latitudes = {0.003, 0.0035, 0.004};
     TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -199,7 +199,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
     info.m_verticalAccuracy = 0.01;
     info.m_longitude = 0.;
     info.m_latitude = 1.;
-    SessionState code = SessionState::RoutingNotActive;
+    SessionState code = SessionState::NoValidRoute;
 
     {
       SessionStateTest sessionStateTest({SessionState::RouteNotStarted, SessionState::OnRoute},
@@ -234,7 +234,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
     info.m_longitude = 0.;
     info.m_latitude = 1.;
     info.m_speedMpS = routing::KMPH2MPS(60);
-    SessionState code = SessionState::RoutingNotActive;
+    SessionState code = SessionState::NoValidRoute;
     for (size_t i = 0; i < 10; ++i)
     {
       code = m_session->OnLocationPositionChanged(info);
@@ -281,7 +281,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingT
     info.m_longitude = 0.0;
     info.m_latitude = 0.0;
     info.m_speedMpS = routing::KMPH2MPS(60);
-    SessionState code = SessionState::RoutingNotActive;
+    SessionState code = SessionState::NoValidRoute;
     {
       SessionStateTest sessionStateTest(
           {SessionState::RouteNotStarted, SessionState::RouteNeedRebuild},
@@ -362,7 +362,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
     info.m_longitude = 0.;
     info.m_latitude = 1.;
     info.m_speedMpS = routing::KMPH2MPS(60);
-    SessionState code = SessionState::RoutingNotActive;
+    SessionState code = SessionState::NoValidRoute;
     for (size_t i = 0; i < 10; ++i)
     {
       code = m_session->OnLocationPositionChanged(info);


### PR DESCRIPTION
Данный PR решает 2 проблемы.

1. Застарелый баг: при использовании Maps.Me иногда ломалась навигация на маршрут. И вплоть до перестроения маршрута не работала. При этом маршрут был отрисован на карте. Причина проблемы была в том, что случай, когда при перестроении маршрута прокладка давала ошибку не был обработан. Это не очень частый случай, но вполне возможный.
![image](https://user-images.githubusercontent.com/1768114/72529425-5ddcaf00-387e-11ea-9399-a32e1dee8ba0.png)
https://jira.mail.ru/browse/MAPSME-12924

2. В момент перепрокладки маршрута терялось притягивание к старому (и отрисованному на карте маршруту) и ориентирование на него.
https://jira.mail.ru/browse/MAPSME-12925

Данный PR решает эти 2 проблемы.

Теперь (1) старый маршрут удаляется, только если есть валидный новый и (2) состояния `SessionState::RouteNeedRebuild` и `SessionState::RouteRebuilding` позволяют ориентироваться на старый маршрут.

@gmoryes @mesozoic-drones PTAL
