### PR TITLE
[routing] Drop speed cameras notifications flags, fix crash in ASSERT

### DIFF
--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -338,7 +338,55 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_7)
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());
     }
+  }
+}
 
+// Mode: Always/Auto
+// ____Notification___|___beep____|_____Impact camera zone_____|
+// ----------------^  |  - We are here. Exceed speed limit.
+//                    |    In case Always/Auto mode we should hear voice notification.
+// -----------------^ |  - Then we are here. Exceed speed limit.
+//                    |    But it's soon to make beep signal.
+// ---------------------^ - Than we are here. Exceed speed limit.
+//                          We should here beep signal.
+UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_8)
+{
+  vector<SpeedCameraManagerMode> modes = {SpeedCameraManagerMode::Auto, SpeedCameraManagerMode::Always};
+  for (auto const mode : modes)
+  {
+    RoutingSession routingSession;
+    InitRoutingSession({55.678536, 37.531112} /* from */,
+                       {55.671112, 37.520202} /* to   */,
+                       routingSession,
+                       mode);
+
+    {
+      double const speedKmPH = 180.0;
+      ChangePosition({55.67840, 37.53090}, speedKmPH, routingSession);
+      TEST(!CheckVoiceNotification(routingSession), ());
+      TEST(!CheckBeepSignal(routingSession), ());
+    }
+    {
+      double const speedKmPH = 180.0;
+      ChangePosition({55.67810, 37.53050}, speedKmPH, routingSession);
+      TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
+      TEST(CheckVoiceNotification(routingSession), ());
+      TEST(!CheckBeepSignal(routingSession), ());
+    }
+    {
+      double const speedKmPH = 180.0;
+      ChangePosition({55.67810, 37.53050}, speedKmPH, routingSession);
+      TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
+      TEST(!CheckVoiceNotification(routingSession), ());
+      TEST(!CheckBeepSignal(routingSession), ());
+    }
+    {
+      double const speedKmPH = 180.0;
+      ChangePosition({55.67790, 37.53020}, speedKmPH, routingSession);
+      TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
+      TEST(!CheckVoiceNotification(routingSession), ());
+      TEST(CheckBeepSignal(routingSession), ());
+    }
   }
 }
 

--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -97,9 +97,10 @@ void SpeedCameraManager::GenerateNotifications(std::vector<std::string> & notifi
   if (VoiceSignalAvailable())
   {
     notifications.emplace_back(m_notificationManager.GenerateSpeedCameraText());
-    m_makeVoiceSignal = false;
     ++m_voiceSignalCounter;
   }
+
+  m_makeVoiceSignal = false;
 }
 
 bool SpeedCameraManager::ShouldPlayBeepSignal()
@@ -116,6 +117,7 @@ bool SpeedCameraManager::ShouldPlayBeepSignal()
     return true;
   }
 
+  m_makeBeepSignal = false;
   return false;
 }
 
@@ -360,7 +362,7 @@ void SpeedCameraManager::SendNotificationStat(double passedDistanceMeters, doubl
 
   auto const distToCameraMeters = camera.m_distFromBeginMeters - passedDistanceMeters;
 
-  ASSERT(m_makeBeepSignal != m_makeVoiceSignal, ("In each moment of time only one flag should be up."));
+  CHECK(m_makeBeepSignal != m_makeVoiceSignal, ("In each moment of time only one flag should be up."));
   alohalytics::TStringMap params = {{"type", m_makeBeepSignal ? "beep" : "voice"},
                                     {"distance", strings::to_string(distToCameraMeters)},
                                     {"speed", strings::to_string(measurement_utils::MpsToKmph(speedMpS))}};


### PR DESCRIPTION
как происходил креш:
ехать по дороге: `m_voiceSignalCounter = 0, m_makeVoiceSignal = false`
1) попасть в зону нотификации голосом 
2) превысить скорость (`m_makeVoiceSignal = true`)
3) произнести уведомление (`m_voiceSignalCounter = 1`, `m_makeVoiceSignal = false`)
4) продолжать превышать  (`m_makeVoiceSignal = true`)
5) несмотря на `m_makeVoiceSignal` мы не произенесем еще одно уведомление, так как m_voiceSignalCounter > 1
6) попасть в зону Beed Signal
7) превышать (`m_makeBeepSignal = true`) => **CRASH**

проблема в том, что если счетчик сигналов какого-то типа больше 1, то уведомление мы не делаем, но и флаг не сбрасываем, из-за этого может упасть в ASSERT

добавил интеграционный тест, который крэшится на мастере (воспроизводит эту проблему выше)