### PR TITLE
[generator] Fix generator integration tests

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -321,7 +321,7 @@ public:
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);
-    TestGeneratedFile(roadAccess, 1970528 /* fileSize */);
+    TestGeneratedFile(roadAccess, 1966468 /* fileSize */);
     TestGeneratedFile(m_genInfo.m_citiesBoundariesFilename, 87 /* fileSize */);
   }
 

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -299,7 +299,7 @@ void RoadAccessTagProcessor::Process(OsmElement const & elem)
     for (auto const tagMapping : mapping)
     {
       auto const accessType = GetAccessTypeFromMapping(elem, tagMapping);
-      if (accessType != RoadAccess::Type::Count && accessType != RoadAccess::Type::Yes)
+      if (accessType != RoadAccess::Type::Count)
         return optional<RoadAccess::Type>(accessType);
     }
 
@@ -308,6 +308,9 @@ void RoadAccessTagProcessor::Process(OsmElement const & elem)
 
   if (auto op = getAccessType(m_accessMappings))
   {
+    if (*op == RoadAccess::Type::Yes)
+      return;
+
     switch (elem.m_type)
     {
     case OsmElement::EntityType::Node: m_barriersWithAccessTag.emplace(elem.m_id, *op); return;


### PR DESCRIPTION
Tests were broken after ignoring barriers on some highways

I see two types of disappearing accesses:
1) Because of  "ignoring barriers on some highways"
2) Because there are lots of ways with tag barrier=gate or something else, for example this: https://www.openstreetmap.org/way/97663995

The 2) is good for us, because such ways anyway break road graph and we will just store less info about way-accesses

Also there was a bug. If elem has "foot=yes" and "access=no", we will skip "yes" tag and apply only "no", so now we prefer "yes" tags if they exist