### PR TITLE
[routing] Removing SessionState::RouteBuildingError state and IsRouteNotReady() methods.

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -132,7 +132,6 @@ public:
   bool IsRouteBuilt() const { return m_routingSession.IsBuilt(); }
   bool IsRouteBuilding() const { return m_routingSession.IsBuilding(); }
   bool IsRouteRebuildingOnly() const { return m_routingSession.IsRebuildingOnly(); }
-  bool IsRouteNotReady() const { return m_routingSession.IsNotReady(); }
   bool IsRouteFinished() const { return m_routingSession.IsFinished(); }
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRoutingFollowing() const { return m_routingSession.IsFollowing(); }

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -45,7 +45,6 @@ enum class SessionState
   NoValidRoute,       // No valid route: no route after application launching or the route was removed.
   RouteBuilding,      // We requested a route and wait when it will be built. User may be following
                       // the previous route.
-  RouteBuildingError, // @TODO The state should be removed. The route was not built because of an error.
   RouteNotStarted,    // Route is built but the user isn't on it.
   OnRoute,            // User follows the route.
   RouteNeedRebuild,   // User left the route.
@@ -57,9 +56,7 @@ enum class SessionState
 
 /*
  * NoValidRoute -> RouteBuilding         // start route building
- * RouteBuilding -> RouteBuildingError   // route was built with an error
  * RouteBuilding -> RouteNotStarted      // route is built in case of building a new route
- * RouteRebuilding -> RouteBuildingError // waiting for route in case of rebuilding
  * RouteRebuilding -> RouteNotStarted    // route is built in case of rebuilding
  * RouteNotStarted -> OnRoute            // user started following the route
  * RouteNotStarted -> RouteNeedRebuild   // user doesn't like the route.

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -161,7 +161,6 @@ void RoutingSession::RebuildRouteOnTrafficUpdate()
     switch (m_state)
     {
     case SessionState::NoValidRoute:
-    case SessionState::RouteBuildingError:
     case SessionState::RouteFinished: return;
 
     case SessionState::RouteBuilding:
@@ -221,12 +220,6 @@ bool RoutingSession::IsRebuildingOnly() const
   return m_state == SessionState::RouteRebuilding;
 }
 
-bool RoutingSession::IsNotReady() const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  return m_state == SessionState::RouteBuildingError;
-}
-
 bool RoutingSession::IsFinished() const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -281,8 +274,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   ASSERT(m_router, ());
 
   if (m_state == SessionState::RouteFinished || m_state == SessionState::RouteBuilding ||
-      m_state == SessionState::RouteBuildingError || m_state == SessionState::RouteNoFollowing ||
-      m_state == SessionState::NoValidRoute)
+      m_state == SessionState::RouteNoFollowing || m_state == SessionState::NoValidRoute)
   {
     return m_state;
   }
@@ -785,7 +777,6 @@ string DebugPrint(SessionState state)
   {
   case SessionState::NoValidRoute: return "NoValidRoute";
   case SessionState::RouteBuilding: return "RouteBuilding";
-  case SessionState::RouteBuildingError: return "RouteBuildingError";
   case SessionState::RouteNotStarted: return "RouteNotStarted";
   case SessionState::OnRoute: return "OnRoute";
   case SessionState::RouteNeedRebuild: return "RouteNeedRebuild";

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -75,7 +75,6 @@ public:
   bool IsBuilding() const;
   bool IsBuildingOnly() const;
   bool IsRebuildingOnly() const;
-  bool IsNotReady() const;
   bool IsFinished() const;
   bool IsNoFollowing() const;
   bool IsOnRoute() const;


### PR DESCRIPTION
cherry-pick: https://github.com/mapsme/omim/pull/12467
Думаю, что и в ветке лучше убрать не корректно работающий метод. Чтоб не воспользовались по ошибке.

@mesozoic-drones PTAL