### PR TITLE
[Generator tests] Fixed tests after fords removal.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -321,7 +321,7 @@ public:
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);
-    TestGeneratedFile(roadAccess, 1966468 /* fileSize */);
+    TestGeneratedFile(roadAccess, 1914255 /* fileSize */);
     TestGeneratedFile(m_genInfo.m_citiesBoundariesFilename, 87 /* fileSize */);
   }
 


### PR DESCRIPTION
#12473
[MAPSME-12984](https://jira.mail.ru/browse/MAPSME-12984)

Был убран Access::No для бродов, и этот PR - починка тестов генератора.

