### PR TITLE
[track analyzing] Fixing case when a package with DataPoints is corrupted.

### DIFF
--- a/track_analyzing/log_parser.cpp
+++ b/track_analyzing/log_parser.cpp
@@ -27,9 +27,19 @@ vector<DataPoint> ReadDataPoints(string const & data)
 {
   string const decoded = FromHex(data);
   vector<DataPoint> points;
-  MemReader memReader(decoded.data(), decoded.size());
-  ReaderSource<MemReader> src(memReader);
-  coding::TrafficGPSEncoder::DeserializeDataPoints(1 /* version */, src, points);
+  MemReaderWithExceptions memReader(decoded.data(), decoded.size());
+  ReaderSource<MemReaderWithExceptions> src(memReader);
+
+  try
+  {
+    coding::TrafficGPSEncoder::DeserializeDataPoints(1 /* version */, src, points);
+  }
+  catch (Reader::SizeException const & e)
+  {
+    points.clear();
+    LOG(LERROR, ("DataPoint is corrupted. data:", data));
+    LOG(LINFO, ("Continue reading..."));
+  }
   return points;
 }
 

--- a/track_analyzing/log_parser.cpp
+++ b/track_analyzing/log_parser.cpp
@@ -7,6 +7,7 @@
 #include "platform/platform.hpp"
 
 #include "coding/hex.hpp"
+#include "coding/traffic.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -32,7 +33,8 @@ vector<DataPoint> ReadDataPoints(string const & data)
 
   try
   {
-    coding::TrafficGPSEncoder::DeserializeDataPoints(1 /* version */, src, points);
+    coding::TrafficGPSEncoder::DeserializeDataPoints(coding::TrafficGPSEncoder::kLatestVersion, src,
+                                                     points);
   }
   catch (Reader::SizeException const & e)
   {


### PR DESCRIPTION
При обработке очень большого числа DataPoints в одном случае пакет с бинарными данными о точке оказался поврежден. А именно метод `coding::TrafficGPSEncoder::DeserializeDataPoints(...)` получил пакет размером 244 байта. Первые 112 байт представляли реальные данные. А остальные мусор. Далее происходило присвоение отрицательного значения uint64_t (в DeserializeDataPointsV1()). Далее в цикле `while (src.Size() > 0)` (в DeserializeDataPointsV1()) происходило переполнение.

Причиной появления поврежденного пакета могли быть:
- hardware ошибка при сохранении;
- software ошибка при сохранении;
- коллизия чек суммы в в TCP/IP;

Данный PR делает обработку данного случая. Использован MemReaderWithExceptions, который запускает исключение в случае присвоение uint64_t отрицательного значения.

Я специально не добавил тест на этот случай. Если я это сделаю, что данный тест будет падать в debug режиме при таком варианте кода. С другой стороны, он будет просто тестировать MemReaderWithExceptions. Как вариант можем рассмотреть  в случае исключения не крешить дебаг версию, и сделать тест.

@mesozoic-drones @vicpopov PTAL