### PR TITLE
[generator] Handle mini-roundabouts in the middle of the road.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -127,20 +127,20 @@ CountryFeaturesCounters constexpr kWorldCounters(945 /* fbs */, 364406 /* geomet
                                                  0 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthAucklandCounters(
-    1812099 /* fbs */, 12196602 /* geometryPoints */, 1007482 /* point */, 205502 /* line */,
-    599115 /* area */, 212466 /* poi */, 521 /* cityTownOrVillage */, 3557 /* bookingHotels */);
+    1812231 /* fbs */, 12196602 /* geometryPoints */, 1007482 /* point */, 205634 /* line */,
+    599115 /* area */, 212598 /* poi */, 521 /* cityTownOrVillage */, 3557 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kNorthWellingtonCounters(
-    797745 /* fbs */, 7771644 /* geometryPoints */, 460522 /* point */, 86947 /* line */,
-    250276 /* area */, 95829 /* poi */, 297 /* cityTownOrVillage */, 1062 /* bookingHotels */);
+    797809 /* fbs */, 7771643 /* geometryPoints */, 460522 /* point */, 87011 /* line */,
+    250276 /* area */, 95893 /* poi */, 297 /* cityTownOrVillage */, 1062 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthCanterburyCounters(
-    637194 /* fbs */, 6984528 /* geometryPoints */, 397947 /* point */, 81661 /* line */,
-    157586 /* area */, 89630 /* poi */, 331 /* cityTownOrVillage */, 2085 /* bookingHotels */);
+    637228 /* fbs */, 6984528 /* geometryPoints */, 397947 /* point */, 81695 /* line */,
+    157586 /* area */, 89664 /* poi */, 331 /* cityTownOrVillage */, 2085 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthSouthlandCounters(
-    340612 /* fbs */, 5342351 /* geometryPoints */, 185986 /* point */, 40100 /* line */,
-    114526 /* area */, 40650 /* poi */, 297 /* cityTownOrVillage */, 1621 /* bookingHotels */);
+    340629 /* fbs */, 5342351 /* geometryPoints */, 185986 /* point */, 40117 /* line */,
+    114526 /* area */, 40667 /* poi */, 297 /* cityTownOrVillage */, 1621 /* bookingHotels */);
 
 CountryFeaturesCounters constexpr kSouthSouthlandMixedNodesCounters(
     2 /* fbs */, 2 /* geometryPoints */, 2 /* point */, 0 /* line */, 0 /* area */, 0 /* poi */,

--- a/generator/generator_tests/mini_roundabout_tests.cpp
+++ b/generator/generator_tests/mini_roundabout_tests.cpp
@@ -97,7 +97,7 @@ UNIT_TEST(TrimSegment_Vertical)
   m2::PointD const a(2.0, -1.0);
   m2::PointD const b(2.0, 3.0);
   double const dist = 1.0;
-  m2::PointD const point = TrimSegment(a, b, dist);
+  m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
   m2::PointD const pointPlan(2.0, 2.0);
   TEST(AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
 }
@@ -107,7 +107,7 @@ UNIT_TEST(TrimSegment_VerticalNegative)
   m2::PointD const a(-3.0, -5.0);
   m2::PointD const b(-3.0, 6.0);
   double const dist = 4.0;
-  m2::PointD const point = TrimSegment(a, b, dist);
+  m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
   m2::PointD const pointPlan(-3.0, 2.0);
   TEST(AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
 }
@@ -117,7 +117,7 @@ UNIT_TEST(TrimSegment_ExceptionalCase)
   m2::PointD const a(1.0, 2.0);
   m2::PointD const b(2.0, 3.0);
   double const dist = 10.0;
-  m2::PointD const point = TrimSegment(a, b, dist);
+  m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
   TEST(AlmostEqualAbs(point, a, kMwmPointAccuracy), ());
 }
 
@@ -170,7 +170,8 @@ UNIT_TEST(TrimSegment_Radius3)
   m2::PointD const pointRoundabout(15.0, 17.0);
   double const r = 3.0;
 
-  m2::PointD const nextPointOnRoad = TrimSegment(pointOnRoad, pointRoundabout, r);
+  m2::PointD const nextPointOnRoad = GetPointAtDistFromTarget(
+      pointOnRoad /* source */, pointRoundabout /* target */, r /* dist */);
   double const dist = DistanceOnPlain(nextPointOnRoad, pointRoundabout);
   TestRunCmpNumbers(dist, r);
 }
@@ -209,7 +210,8 @@ UNIT_TEST(Manage_MiniRoundabout_1Road)
                               kMwmPointAccuracy),
          ());
 
-  m2::PointD newPointOnRoad = TrimSegment(nearest, center, r);
+  m2::PointD const newPointOnRoad =
+      GetPointAtDistFromTarget(nearest /* source */, center /* target */, r /* dist */);
   AddPointToCircle(circlePlain, newPointOnRoad);
 
   std::vector<m2::PointD> const circlePlainExpected{
@@ -237,19 +239,22 @@ UNIT_TEST(Manage_MiniRoundabout_4Roads)
 
   auto circlePlain = PointToPolygon(center, r, 6, 30.0);
 
-  AddPointToCircle(circlePlain, TrimSegment(mercator::FromLatLon(stationRoadNode.m_lat,
-                                                                       stationRoadNode.m_lon),
-                                            center, r));
-  AddPointToCircle(circlePlain, TrimSegment(mercator::FromLatLon(plaughRoundaboutNode.m_lat,
-                                                                       plaughRoundaboutNode.m_lon),
-                                            center, r));
-  AddPointToCircle(circlePlain, TrimSegment(mercator::FromLatLon(stationRoadLeftNode.m_lat,
-                                                                       stationRoadLeftNode.m_lon),
-                                            center, r));
+  AddPointToCircle(circlePlain, GetPointAtDistFromTarget(
+                                    mercator::FromLatLon(stationRoadNode.m_lat,
+                                                         stationRoadNode.m_lon) /* source */,
+                                    center /* target */, r /* dist */));
+  AddPointToCircle(circlePlain, GetPointAtDistFromTarget(
+                                    mercator::FromLatLon(plaughRoundaboutNode.m_lat,
+                                                         plaughRoundaboutNode.m_lon) /* source */,
+                                    center /* target */, r /* dist */));
+  AddPointToCircle(circlePlain, GetPointAtDistFromTarget(
+                                    mercator::FromLatLon(stationRoadLeftNode.m_lat,
+                                                         stationRoadLeftNode.m_lon) /* source */,
+                                    center /* target */, r /* dist */));
   AddPointToCircle(circlePlain,
-                   TrimSegment(mercator::FromLatLon(plaughRoundaboutRightNode.m_lat,
-                                                          plaughRoundaboutRightNode.m_lon),
-                               center, r));
+                   GetPointAtDistFromTarget(mercator::FromLatLon(plaughRoundaboutRightNode.m_lat,
+                                                                 plaughRoundaboutRightNode.m_lon),
+                                            center, r));
 
   std::vector<m2::PointD> const circlePlainExpected{
       {-0.47381, 60.67520}, {-0.47383, 60.67521}, {-0.47384, 60.67521}, {-0.47385, 60.67520},

--- a/generator/mini_roundabout_transformer.hpp
+++ b/generator/mini_roundabout_transformer.hpp
@@ -18,6 +18,13 @@
 
 namespace generator
 {
+struct RoundaboutUnit
+{
+  uint64_t m_roadId = 0;
+  m2::PointD m_location;
+  FeatureParams::Types m_roadTypes;
+};
+
 class MiniRoundaboutTransformer
 {
 public:
@@ -36,9 +43,18 @@ private:
   /// \brief Sets |road_type| to |found_type| if it is a more important road type.
   void UpdateRoadType(FeatureParams::Types const & foundTypes, uint32_t & roadType);
 
-  /// \brief Creates new point and add it to |roundabout| circle and to the |road|.
-  bool AddRoundaboutToRoad(m2::PointD const & center, std::vector<m2::PointD> & roundabout,
-                           feature::FeatureBuilder::PointSeq & road);
+  /// \brief Splits |road| in two parts: part before the |roundabout| and after.
+  /// Returns second road to |newRoads| - the artificial one.
+  feature::FeatureBuilder::PointSeq CreateSurrogateRoad(
+      RoundaboutUnit const & roundaboutOnRoad, std::vector<m2::PointD> & roundaboutCircle,
+      feature::FeatureBuilder::PointSeq & road,
+      feature::FeatureBuilder::PointSeq::iterator & itPointUpd);
+
+  /// \brief Creates new point and adds it to |roundabout| circle and to the |road|.
+  bool AddRoundaboutToRoad(RoundaboutUnit const & roundaboutOnRoad,
+                           std::vector<m2::PointD> & roundaboutCircle,
+                           feature::FeatureBuilder::PointSeq & road,
+                           std::vector<feature::FeatureBuilder> & newRoads);
 
   std::vector<MiniRoundaboutInfo> m_roundabouts;
   double const m_radiusMercator = 0.0;
@@ -47,9 +63,10 @@ private:
 /// \brief Calculates Euclidean distance between 2 points on plane.
 double DistanceOnPlain(m2::PointD const & a, m2::PointD const & b);
 
-/// \returns The point that is located on the segment (|segPoint|, |target|) and lies in |r| or less
-/// from |target|.
-m2::PointD TrimSegment(m2::PointD const & segPoint, m2::PointD const & target, double r);
+/// \returns The point that is located on the segment (|source|, |target|) and lies in |dist|
+/// or less from |target|.
+m2::PointD GetPointAtDistFromTarget(m2::PointD const & source, m2::PointD const & target,
+                                    double dist);
 
 /// \brief Creates a regular polygon with |verticesCount| inscribed in a circle with |center| and
 /// |radiusMercator|. The polygon is rotated by an angle |initAngleDeg| CCW.


### PR DESCRIPTION
[MAPSME-13048](https://jira.mail.ru/browse/MAPSME-13048)
Fix for wrong generation of roundabouts from mini-roundabouts.

Example of wrong generation of roundabout above the road:
<img width="500" alt="Screenshot 2020-01-29 at 18 41 58" src="https://user-images.githubusercontent.com/54934129/73440426-4dd6cc00-4362-11ea-933b-11cfbeae2f4c.png">

After fix:
<img width="500" alt="Screenshot 2020-01-30 at 13 15 14" src="https://user-images.githubusercontent.com/54934129/73440599-99897580-4362-11ea-8b3a-99889c14a4b9.png">


Example of road with 2 mini_roundabouts:
https://www.openstreetmap.org/node/1250535302
