### PR TITLE
[Routing] Fix for followed_polyline.

### DIFF
--- a/routing/base/followed_polyline.cpp
+++ b/routing/base/followed_polyline.cpp
@@ -139,7 +139,8 @@ Iter FollowedPolyline::GetBestMatchingProjection(m2::RectD const & posRect) cons
   // At first trying to find a projection to two closest route segments of route which is close
   // enough to |posRect| center. If |m_current| is right before intermediate point we can get |iter|
   // right after intermediate point (in next subroute).
-  size_t const hoppingBorderIdx = min(m_segProj.size(), m_current.m_ind + 3);
+  size_t const hoppingBorderIdx =
+      min(m_nextCheckpointIndex, min(m_segProj.size(), m_current.m_ind + 3));
   auto const iter = GetClosestMatchingProjectionInInterval(posRect, m_current.m_ind, hoppingBorderIdx);
   if (iter.IsValid())
     return iter;


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13075

Очень старый крэш в режиме ведения по маршруту.
Крэш возникает в редком случае: при движении по маршруту с промежуточной точкой, до которой достроены фейковые сегменты, срабаывавает чек:
`CHECK_LESS_OR_EQUAL(startIdx, endIdx, ());`

Чек срабатывает внутри метода:
```
Iter FollowedPolyline::GetClosestMatchingProjectionInInterval(m2::RectD const & posRect,
                                                              size_t startIdx, size_t endIdx) const
```

То есть `endIdx` оказывается меньше, чем `startIdx`.

**Причина** - отсутствие в вызывающем коде проверки значения hoppingBorderIdx перед вызовом
`GetClosestMatchingProjectionInInterval(posRect, hoppingBorderIdx, m_nextCheckpointIndex);`

Как видно из истории git, такое положение дел было уже очень давно, просто ситуация с попаданием именно в эту ветку кода - крайне редкая.

Пример из тикета с крашрепортом:
<img width="500" alt="Screenshot 2020-01-31 at 16 34 01" src="https://user-images.githubusercontent.com/54934129/73543225-8ac8be80-4447-11ea-8659-37437ce054e5.png">


@gmoryes @bykoianko PTAL