### PR TITLE
[generator] Filter metadata.

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -281,6 +281,9 @@ string MetadataTagProcessorImpl::ValidateAndFormat_wikipedia(string v) const
 
 string MetadataTagProcessorImpl::ValidateAndFormat_airport_iata(string const & v) const
 {
+  if (!ftypes::IsAirportChecker::Instance()(m_params.m_types))
+    return {};
+
   if (v.size() != 3)
     return {};
 


### PR DESCRIPTION
Предлагаю не добавлять ele (высота над уровнем моря) в метадату для noname зданий, тем более у нас в следующем релизе будут изолинии.
Тег ele полезен для гор, населенных пунктов и может ещё в каких-то специфических случаях, поэтому пока вместо white list предлагаю black list -- при формировании white list можно что-то упустить.
После этого изменения количество метадаты для US_California_LA уменьшается с 48 до 32 Мб (суммартно meta и metaidx).
Другие "жирные" секции:

```
ele                     2.143.834
height                  2.100.079
turn:lanes                 26.018
turn:lanes:backward        16.870
turn:lanes:forward         16.892
```

height полезна для рендеринга, поэтому её удалить нельзя, предположительно в дальнейшем стоит вынести её из metadata в отдельную секцию.

Также отдальным коммитом добавлена проверка на аэропорт при сохранении в метадату кода аэропорта.