### PR TITLE
[Routing] Match location to the road graph when it is not matched to the route.

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1154,7 +1154,10 @@ void RoutingManager::MatchLocationToRoute(location::GpsInfo & location,
   if (!IsRoutingActive())
     return;
 
-  m_routingSession.MatchLocationToRoute(location, routeMatchingInfo);
+  bool const matchedToRoute = m_routingSession.MatchLocationToRoute(location, routeMatchingInfo);
+
+  if (!matchedToRoute && m_currentRouterType == RouterType::Vehicle)
+    m_routingSession.MatchLocationToRoadGraph(location);
 }
 
 location::RouteMatchingInfo RoutingManager::GetRouteMatchingInfo(location::GpsInfo & info)

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1149,7 +1149,7 @@ void RoutingManager::CallRouteBuildStart(std::vector<RouteMarkData> const & poin
 }
 
 void RoutingManager::MatchLocationToRoute(location::GpsInfo & location,
-                                          location::RouteMatchingInfo & routeMatchingInfo) const
+                                          location::RouteMatchingInfo & routeMatchingInfo)
 {
   if (!IsRoutingActive())
     return;

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -338,7 +338,7 @@ private:
   bool IsTrackingReporterEnabled() const;
   bool IsTrackingReporterArchiveEnabled() const;
   void MatchLocationToRoute(location::GpsInfo & info,
-                            location::RouteMatchingInfo & routeMatchingInfo) const;
+                            location::RouteMatchingInfo & routeMatchingInfo);
   location::RouteMatchingInfo GetRouteMatchingInfo(location::GpsInfo & info);
   uint32_t GenerateRoutePointsTransactionId() const;
 

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -337,6 +337,8 @@ private:
 
   bool IsTrackingReporterEnabled() const;
   bool IsTrackingReporterArchiveEnabled() const;
+  /// \returns false if the location could not be matched to the route and should be matched to the
+  /// road graph. Otherwise returns true.
   void MatchLocationToRoute(location::GpsInfo & info,
                             location::RouteMatchingInfo & routeMatchingInfo);
   location::RouteMatchingInfo GetRouteMatchingInfo(location::GpsInfo & info);

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -129,6 +129,13 @@ void AsyncRouter::RouterDelegateProxy::Cancel()
   m_delegate.Cancel();
 }
 
+bool AsyncRouter::FindClosestProjectionToRoad(m2::PointD const & point,
+                                              m2::PointD const & direction, double radius,
+                                              EdgeProj & proj)
+{
+  return m_router->FindClosestProjectionToRoad(point, direction, radius, proj);
+}
+
 void AsyncRouter::RouterDelegateProxy::OnProgress(float progress)
 {
   ProgressCallback onProgress = nullptr;

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -37,8 +37,8 @@ public:
   /// @param fetcher pointer to a online fetcher
   void SetRouter(std::unique_ptr<IRouter> && router, std::unique_ptr<IOnlineFetcher> && fetcher);
 
-  /// Main method to calulate new route from startPt to finalPt with start direction
-  /// Processed result will be passed to callback. Callback will called at GUI thread.
+  /// Main method to calculate new route from startPt to finalPt with start direction
+  /// Processed result will be passed to callback. Callback will be called at the GUI thread.
   ///
   /// @param checkpoints start, finish and intermadiate points
   /// @param direction start direction for routers with high cost of the turnarounds
@@ -57,6 +57,9 @@ public:
 
   /// Interrupt routing and clear buffers
   void ClearState();
+
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                   double radius, EdgeProj & proj);
 
 private:
   /// Worker thread function

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -336,7 +336,7 @@ bool IndexRouter::FindClosestProjectionToRoad(m2::PointD const & point,
   auto const rect = mercator::RectByCenterXYAndSizeInMeters(point, radius);
   std::vector<std::pair<Edge, geometry::PointWithAltitude>> candidates;
 
-  uint32_t const count = direction.IsAlmostZero() ? 1 : 3;
+  uint32_t const count = direction.IsAlmostZero() ? 1 : 4;
   m_roadGraph.FindClosestEdges(rect, count, candidates);
 
   if (candidates.empty())

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -93,6 +93,9 @@ public:
                                   bool adjustToPrevRoute, RouterDelegate const & delegate,
                                   Route & route) override;
 
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                   double radius, EdgeProj & proj) override;
+
   VehicleType GetVehicleType() const { return m_vehicleType; }
 
 private:
@@ -144,7 +147,7 @@ private:
 
   Segment GetSegmentByEdge(Edge const & edge) const;
 
-  /// \brief Fills |closestCodirectionalEdge| with a codirectional edge which is closet to
+  /// \brief Fills |closestCodirectionalEdge| with a codirectional edge which is closest to
   /// |point| and returns true if there's any. If not returns false.
   bool FindClosestCodirectionalEdge(
       m2::PointD const & point, m2::PointD const & direction,

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -251,6 +251,7 @@ public:
 
   std::vector<RouteSegment> & GetRouteSegments() { return m_routeSegments; }
   std::vector<RouteSegment> const & GetRouteSegments() const { return m_routeSegments; }
+  RoutingSettings const & GetCurrentRoutingSettings() const { return m_routingSettings; }
 
   void SetCurrentSubrouteIdx(size_t currentSubrouteIdx) { m_currentSubrouteIdx = currentSubrouteIdx; }
 
@@ -314,7 +315,10 @@ public:
   
   bool MoveIterator(location::GpsInfo const & info);
 
-  void MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
+  /// \brief Finds projection of |location| to the nearest route and sets |routeMatchingInfo|
+  /// fields accordingly.
+  bool MatchLocationToRoute(location::GpsInfo & location,
+                            location::RouteMatchingInfo & routeMatchingInfo) const;
 
   /// Add country name if we have no country filename to make route
   void AddAbsentCountry(std::string const & name);

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -22,6 +22,12 @@ using CountryParentNameGetterFn = std::function<std::string(std::string const &)
 
 class Route;
 
+struct EdgeProj
+{
+  Edge m_edge;
+  m2::PointD m_point;
+};
+
 /// Routing engine type.
 enum class RouterType
 {
@@ -64,6 +70,9 @@ public:
   virtual RouterResultCode CalculateRoute(Checkpoints const & checkpoints,
                                           m2::PointD const & startDirection, bool adjust,
                                           RouterDelegate const & delegate, Route & route) = 0;
+
+  virtual bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                           double radius, EdgeProj & proj) = 0;
 };
 
 }  // namespace routing

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -550,24 +550,20 @@ void RoutingSession::MatchLocationToRoadGraph(location::GpsInfo & location)
   m_proj = proj;
 }
 
-void RoutingSession::MatchLocationToRoute(location::GpsInfo & location,
+bool RoutingSession::MatchLocationToRoute(location::GpsInfo & location,
                                           location::RouteMatchingInfo & routeMatchingInfo)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   if (!IsOnRoute())
-    return;
+    return true;
 
   ASSERT(m_route, ());
 
   bool const matchedToRoute = m_route->MatchLocationToRoute(location, routeMatchingInfo);
   if (matchedToRoute)
-  {
     m_projectedToRoadGraph = false;
-    return;
-  }
 
-  // Could not match location to the route. Let's try to match to the road graph.
-  MatchLocationToRoadGraph(location);
+  return matchedToRoute;
 }
 
 traffic::SpeedGroup RoutingSession::MatchTraffic(

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -100,7 +100,8 @@ public:
   void GetRouteFollowingInfo(FollowingInfo & info) const;
 
   void MatchLocationToRoute(location::GpsInfo & location,
-                            location::RouteMatchingInfo & routeMatchingInfo) const;
+                            location::RouteMatchingInfo & routeMatchingInfo);
+  void MatchLocationToRoadGraph(location::GpsInfo & location);
   // Get traffic speed for the current route position.
   // Returns SpeedGroup::Unknown if any trouble happens: position doesn't match with route or something else.
   traffic::SpeedGroup MatchTraffic(location::RouteMatchingInfo const & routeMatchingInfo) const;
@@ -194,6 +195,9 @@ private:
   SessionState m_state;
   bool m_isFollowing;
   Checkpoints m_checkpoints;
+
+  EdgeProj m_proj;
+  bool m_projectedToRoadGraph = false;
 
   /// Current position metrics to check for RouteNeedRebuild state.
   double m_lastDistance = 0.0;

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -99,7 +99,7 @@ public:
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   void GetRouteFollowingInfo(FollowingInfo & info) const;
 
-  void MatchLocationToRoute(location::GpsInfo & location,
+  bool MatchLocationToRoute(location::GpsInfo & location,
                             location::RouteMatchingInfo & routeMatchingInfo);
   void MatchLocationToRoadGraph(location::GpsInfo & location);
   // Get traffic speed for the current route position.

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -48,6 +48,12 @@ public:
 
     return m_result;
   }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                   double radius, EdgeProj & proj) override
+  {
+    return false;
+  }
 };
 
 class DummyFetcher : public IOnlineFetcher

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -61,6 +61,12 @@ public:
     route = m_route;
     return m_code;
   }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                   double radius, EdgeProj & proj) override
+  {
+    return false;
+  }
 };
 
 // Router which every next call of CalculateRoute() method return different return codes.
@@ -84,6 +90,12 @@ public:
     route = Route(GetName(), m_route.begin(), m_route.end(), 0 /* route id */);
     FillSubroutesInfo(route);
     return m_returnCodes[m_returnCodesIdx++];
+  }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
+                                   double radius, EdgeProj & proj) override
+  {
+    return false;
   }
 
 private:


### PR DESCRIPTION
[MAPSME-13093](https://jira.mail.ru/browse/MAPSME-13093)

**Cars only.** When the route is built, the user's location is projected on the route if it fits in the corridor of 50 meters.

For cases when **the user's location does not fall into the corridor,** it should be projected to the nearest road of the road graph that corresponds to current vehicle type.

Example of location and bearing matching to the road graph:

<img width="375" alt="Screenshot 2020-02-05 at 11 51 17" src="https://user-images.githubusercontent.com/54934129/73825896-e01d1b00-480d-11ea-9bc2-29335e4f638e.png">



