### PR TITLE
[android] Use GetEditableProperties instead of GetEditableFields for editor details block.

### DIFF
--- a/android/jni/com/mapswithme/maps/editor/Editor.cpp
+++ b/android/jni/com/mapswithme/maps/editor/Editor.cpp
@@ -261,14 +261,14 @@ Java_com_mapswithme_maps_editor_Editor_nativeShouldShowAddBusiness(JNIEnv *, jcl
 }
 
 JNIEXPORT jintArray JNICALL
-Java_com_mapswithme_maps_editor_Editor_nativeGetEditableFields(JNIEnv * env, jclass clazz)
+Java_com_mapswithme_maps_editor_Editor_nativeGetEditableProperties(JNIEnv * env, jclass clazz)
 {
-  auto const & editable = g_editableMapObject.GetEditableFields();
+  auto const & editable = g_editableMapObject.GetEditableProperties();
   size_t const size = editable.size();
   jintArray jEditableFields = env->NewIntArray(static_cast<jsize>(size));
   jint * arr = env->GetIntArrayElements(jEditableFields, 0);
   for (size_t i = 0; i < size; ++i)
-    arr[i] = editable[i];
+    arr[i] = base::Underlying(editable[i]);
   env->ReleaseIntArrayElements(jEditableFields, arr, 0);
 
   return jEditableFields;

--- a/android/res/layout/fragment_editor.xml
+++ b/android/res/layout/fragment_editor.xml
@@ -158,7 +158,7 @@
     </androidx.cardview.widget.CardView>
 
     <androidx.cardview.widget.CardView
-      android:id="@+id/cv__metadata"
+      android:id="@+id/cv__details"
       style="@style/MwmWidget.Editor.CardView">
 
       <LinearLayout

--- a/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
@@ -31,31 +31,20 @@ public class MapObject implements Parcelable, PopularityProvider, ShareableInfoP
   // Order must correspond indexer/map_object.hpp
   public enum OsmProps
   {
-    OpeningHours(0),
-    Phone(1),
-    Fax(2),
-    Website(3),
-    Email(4),
-    Cuisine(5),
-    Stars(6),
-    Operator(7),
-    Elevation(8),
-    Internet(9),
-    Wikipedia(10),
-    Flats(11),
-    BuildingLevels(12),
-    Level(13);
-    private final int mType;
-
-    OsmProps(int type)
-    {
-      mType = type;
-    }
-
-    public int toInt()
-    {
-      return mType;
-    }
+    OpeningHours,
+    Phone,
+    Fax,
+    Website,
+    Email,
+    Cuisine,
+    Stars,
+    Operator,
+    Elevation,
+    Internet,
+    Wikipedia,
+    Flats,
+    BuildingLevels,
+    Level;
   }
 
   @Retention(RetentionPolicy.SOURCE)

--- a/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/MapObject.java
@@ -28,6 +28,36 @@ import java.util.List;
 // separate them. Simple getters from jni place_page::Info and osm::EditableFeature should be enough.
 public class MapObject implements Parcelable, PopularityProvider, ShareableInfoProvider
 {
+  // Order must correspond indexer/map_object.hpp
+  public enum OsmProps
+  {
+    OpeningHours(0),
+    Phone(1),
+    Fax(2),
+    Website(3),
+    Email(4),
+    Cuisine(5),
+    Stars(6),
+    Operator(7),
+    Elevation(8),
+    Internet(9),
+    Wikipedia(10),
+    Flats(11),
+    BuildingLevels(12),
+    Level(13);
+    private final int mType;
+
+    OsmProps(int type)
+    {
+      mType = type;
+    }
+
+    public int toInt()
+    {
+      return mType;
+    }
+  }
+
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({ POI, API_POINT, BOOKMARK, MY_POSITION, SEARCH })
   public @interface MapObjectType

--- a/android/src/com/mapswithme/maps/editor/Editor.java
+++ b/android/src/com/mapswithme/maps/editor/Editor.java
@@ -63,7 +63,7 @@ public final class Editor
   public static native boolean nativeShouldShowAddPlace();
   public static native boolean nativeShouldShowAddBusiness();
   @NonNull
-  public static native int[] nativeGetEditableFields();
+  public static native int[] nativeGetEditableProperties();
 
   public static native String nativeGetCategory();
   public static native String nativeGetOpeningHours();

--- a/android/src/com/mapswithme/maps/editor/EditorFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorFragment.java
@@ -27,7 +27,7 @@ import android.widget.TextView;
 import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.base.BaseMwmFragment;
-import com.mapswithme.maps.bookmarks.data.Metadata.MetadataType;
+import com.mapswithme.maps.bookmarks.data.MapObject.OsmProps;
 import com.mapswithme.maps.dialog.EditTextDialogFragment;
 import com.mapswithme.maps.editor.data.LocalizedName;
 import com.mapswithme.maps.editor.data.LocalizedStreet;
@@ -49,7 +49,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   private TextView mCategory;
   private View mCardName;
   private View mCardAddress;
-  private View mCardMetadata;
+  private View mCardDetails;
 
   private RecyclerView mNamesView;
 
@@ -114,7 +114,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   private TextView mOpeningHours;
   private View mEditOpeningHours;
   private EditText mDescription;
-  private final SparseArray<View> mMetaBlocks = new SparseArray<>(7);
+  private final SparseArray<View> mDetailsBlocks = new SparseArray<>(7);
   private TextView mReset;
 
   private EditorHostFragment mParent;
@@ -312,27 +312,27 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     UiUtils.showIf(Editor.nativeIsAddressEditable(), mCardAddress);
     UiUtils.showIf(Editor.nativeIsBuilding() && !Editor.nativeIsPointType(), mBlockLevels);
 
-    final int[] editableMeta = Editor.nativeGetEditableFields();
-    if (editableMeta.length == 0)
+    final int[] editableDetails = Editor.nativeGetEditableProperties();
+    if (editableDetails.length == 0)
     {
-      UiUtils.hide(mCardMetadata);
+      UiUtils.hide(mCardDetails);
       return;
     }
 
-    for (int i = 0; i < mMetaBlocks.size(); i++)
-      UiUtils.hide(mMetaBlocks.valueAt(i));
+    for (int i = 0; i < mDetailsBlocks.size(); i++)
+      UiUtils.hide(mDetailsBlocks.valueAt(i));
 
-    boolean anyEditableMeta = false;
-    for (int type : editableMeta)
+    boolean anyEditableDetails = false;
+    for (int type : editableDetails)
     {
-      final View metaBlock = mMetaBlocks.get(type);
-      if (metaBlock == null)
+      final View detailsBlock = mDetailsBlocks.get(type);
+      if (detailsBlock == null)
         continue;
 
-      anyEditableMeta = true;
-      UiUtils.show(metaBlock);
+      anyEditableDetails = true;
+      UiUtils.show(detailsBlock);
     }
-    UiUtils.showIf(anyEditableMeta, mCardMetadata);
+    UiUtils.showIf(anyEditableDetails, mCardDetails);
   }
 
   private void refreshOpeningTime()
@@ -412,7 +412,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mCategory = (TextView) categoryBlock.findViewById(R.id.name);
     mCardName = view.findViewById(R.id.cv__name);
     mCardAddress = view.findViewById(R.id.cv__address);
-    mCardMetadata = view.findViewById(R.id.cv__metadata);
+    mCardDetails = view.findViewById(R.id.cv__details);
     initNamesView(view);
 
     // Address
@@ -463,13 +463,13 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mReset = (TextView) view.findViewById(R.id.reset);
     mReset.setOnClickListener(this);
 
-    mMetaBlocks.append(MetadataType.FMD_OPEN_HOURS.toInt(), blockOpeningHours);
-    mMetaBlocks.append(MetadataType.FMD_PHONE_NUMBER.toInt(), blockPhone);
-    mMetaBlocks.append(MetadataType.FMD_WEBSITE.toInt(), blockWeb);
-    mMetaBlocks.append(MetadataType.FMD_EMAIL.toInt(), blockEmail);
-    mMetaBlocks.append(MetadataType.FMD_CUISINE.toInt(), blockCuisine);
-    mMetaBlocks.append(MetadataType.FMD_OPERATOR.toInt(), blockOperator);
-    mMetaBlocks.append(MetadataType.FMD_INTERNET.toInt(), blockWifi);
+    mDetailsBlocks.append(OsmProps.OpeningHours.toInt(), blockOpeningHours);
+    mDetailsBlocks.append(OsmProps.Phone.toInt(), blockPhone);
+    mDetailsBlocks.append(OsmProps.Website.toInt(), blockWeb);
+    mDetailsBlocks.append(OsmProps.Email.toInt(), blockEmail);
+    mDetailsBlocks.append(OsmProps.Cuisine.toInt(), blockCuisine);
+    mDetailsBlocks.append(OsmProps.Operator.toInt(), blockOperator);
+    mDetailsBlocks.append(OsmProps.Internet.toInt(), blockWifi);
   }
 
   private static EditText findInput(View blockWithInput)

--- a/android/src/com/mapswithme/maps/editor/EditorFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorFragment.java
@@ -463,13 +463,13 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mReset = (TextView) view.findViewById(R.id.reset);
     mReset.setOnClickListener(this);
 
-    mDetailsBlocks.append(OsmProps.OpeningHours.toInt(), blockOpeningHours);
-    mDetailsBlocks.append(OsmProps.Phone.toInt(), blockPhone);
-    mDetailsBlocks.append(OsmProps.Website.toInt(), blockWeb);
-    mDetailsBlocks.append(OsmProps.Email.toInt(), blockEmail);
-    mDetailsBlocks.append(OsmProps.Cuisine.toInt(), blockCuisine);
-    mDetailsBlocks.append(OsmProps.Operator.toInt(), blockOperator);
-    mDetailsBlocks.append(OsmProps.Internet.toInt(), blockWifi);
+    mDetailsBlocks.append(OsmProps.OpeningHours.ordinal(), blockOpeningHours);
+    mDetailsBlocks.append(OsmProps.Phone.ordinal(), blockPhone);
+    mDetailsBlocks.append(OsmProps.Website.ordinal(), blockWeb);
+    mDetailsBlocks.append(OsmProps.Email.ordinal(), blockEmail);
+    mDetailsBlocks.append(OsmProps.Cuisine.ordinal(), blockCuisine);
+    mDetailsBlocks.append(OsmProps.Operator.ordinal(), blockOperator);
+    mDetailsBlocks.append(OsmProps.Internet.ordinal(), blockWifi);
   }
 
   private static EditText findInput(View blockWithInput)

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -31,23 +31,24 @@ enum class Internet
 };
 std::string DebugPrint(Internet internet);
 
-/// Metadata fields in the sorted order, visible to users.
-enum class Props
+// Metadata fields in the sorted order, visible to users.
+// Must correspond MapObject.java
+enum class Props : uint8_t
 {
-  OpeningHours,
-  Phone,
-  Fax,
-  Website,
-  Email,
-  Cuisine,
-  Stars,
-  Operator,
-  Elevation,
-  Internet,
-  Wikipedia,
-  Flats,
-  BuildingLevels,
-  Level
+  OpeningHours = 0,
+  Phone = 1,
+  Fax = 2,
+  Website = 3,
+  Email = 4,
+  Cuisine = 5,
+  Stars = 6,
+  Operator = 7,
+  Elevation = 8,
+  Internet = 9,
+  Wikipedia = 10,
+  Flats = 11,
+  BuildingLevels = 12,
+  Level = 13
 };
 std::string DebugPrint(Props props);
 


### PR DESCRIPTION
Мотивация состоит в том, чтобы отвязать блок details в редакторе от метадаты, т.к. часть этих полей будет выноситься из метадаты и способ хранения данных в mwm не должен влиять на то где именно в редакторе отображается поле.

задача для перевода в тестирование:
https://jira.mail.ru/browse/MAPSME-13097