### PR TITLE
[python] Add tags mode for dump_mwm

### DIFF
--- a/tools/python/mwm/__main__.py
+++ b/tools/python/mwm/__main__.py
@@ -48,7 +48,7 @@ The most commonly used mwm commands are:
         parser.add_argument("--path", type=str, required=True,
                             help="Path to mwm.")
         parser.add_argument("--format", type=str, default="meta",
-                            choices=("meta", "features"),
+                            choices=("meta", "features", "tags"),
                             help="Output format.")
         args = parser.parse_args(sys.argv[2:])
         dump_mwm(args.path, args.format)

--- a/tools/python/mwm/dump_mwm.py
+++ b/tools/python/mwm/dump_mwm.py
@@ -10,25 +10,26 @@ def dump_mwm(path, format):
     mwm.read_types(os.path.join(os.path.dirname(sys.argv[0]),
                                 "..", "..", "..", "data", "types.txt"))
     header = mwm.read_header()
-    fts = list(mwm.iter_features())
 
-    if format == "meta":
+    if format == "meta" or format == "tags":
         print("Tags:")
         tvv = sorted([(k, v[0], v[1]) for k, v in mwm.tags.items()], key=lambda x: x[1])
         for tv in tvv:
             print("  {0:<8}: offs {1:9} len {2:8}".format(tv[0], tv[1], tv[2]))
+
+    if format == "meta":
         v = mwm.read_version()
         print("Format: {0}, version: {1}".format(v["fmt"], v["date"].strftime("%Y-%m-%d %H:%M")))
         print("Header: {0}".format(header))
         print("Region Info: {0}".format(mwm.read_region_info()))
         print("Metadata count: {0}".format(len(mwm.read_metadata())))
-        print("Feature count: {0}".format(len(fts)))
+        print("Feature count: {0}".format(len(list(mwm.iter_features()))))
         cross = mwm.read_crossmwm()
         if cross:
             print("Outgoing points: {0}, incoming: {1}".format(len(cross["out"]), len(cross["in"])))
             print("Outgoing regions: {0}".format(set(cross["neighbours"])))
-
     elif format == "features":
+        fts = list(mwm.iter_features())
         print("Features:")
         for ft in fts:
             print(json.dumps(ft, ensure_ascii=False))


### PR DESCRIPTION
После улучшений dump_mwm им стало тяжело пользоваться для получения списка секций -- раньше он сразу печатал список секций и дальше тупил на вызове `mwm.iter_features()` (который если что можно было и прибить), теперь -- сразу тупит на `mwm.iter_features()` и списка секций надо ждать минуту.
В этом реквесте отдельный режим для списка секций без `mwm.iter_features()`.

Было:
```
time python3.7 -m mwm dump_mwm --path ~/data/191124/US_California_LA.mwm --format=meta
Tags:
  version : offs         8 len       10
  header  : offs        24 len       32
  rgninfo : offs        56 len        4
  dat     : offs        64 len 52636046
  geom0   : offs  52636112 len    11814
  trg0    : offs  52647928 len    22882
  geom1   : offs  52670816 len   136091
  trg1    : offs  52806912 len   164977
  geom2   : offs  52971896 len   612787
  trg2    : offs  53584688 len  1156774
  geom3   : offs  54741464 len  2763374
  trg3    : offs  57504840 len 37966356
  metaidx : offs  95471200 len 18345560
  meta    : offs 113816760 len 27767724
  offs    : offs 141584488 len  2834376
  metalines: offs 144418864 len   458591
  idx     : offs 144877456 len  6793104
  sdx     : offs 151670560 len  7741514
  addr    : offs 159412080 len   605806
  ranks   : offs 160017888 len   616360
  centers : offs 160634248 len  8526349
  ugc     : offs 169160600 len     5655
  ratings : offs 169166256 len   616072
  popularity: offs 169782328 len   616120
  altitudes: offs 170398448 len  3263128
  speedcams: offs 173661576 len       52
  routing : offs 173661632 len  2172839
  restrictions: offs 175834472 len    51458
  roadaccess: offs 175885936 len   224977
  city_roads: offs 176110920 len   363168
  maxspeeds: offs 176474088 len    70484
  cross_mwm: offs 176544576 len    79086
  traffic : offs 176623664 len   548507
  transit : offs 177172176 len    48124
  transit_cross_mwm: offs 177220304 len       81
  descriptions: offs 177220392 len   205424
Format: 9, version: 2019-11-24 04:08
Header: {'basePoint': (-118.12025202900358, 33.97408483099726), 'bounds': (-120.93749955995008, 31.952161313469766, -112.49999949708581, 36.59788829190489), 'scales': [10, 12, 14, 17], 'langs': [], 'mapType': 'country'}
Region Info: {'languages': ['en']}
Metadata count: 2293195
Feature count: 3152125

real	1m0.119s
user	0m53.903s
sys	0m5.934s
```

Стало:
```
time python3.7 -m mwm dump_mwm --path ~/data/191124/US_California_LA.mwm --format=tags
Tags:
  version : offs         8 len       10
  header  : offs        24 len       32
  rgninfo : offs        56 len        4
  dat     : offs        64 len 52636046
  geom0   : offs  52636112 len    11814
  trg0    : offs  52647928 len    22882
  geom1   : offs  52670816 len   136091
  trg1    : offs  52806912 len   164977
  geom2   : offs  52971896 len   612787
  trg2    : offs  53584688 len  1156774
  geom3   : offs  54741464 len  2763374
  trg3    : offs  57504840 len 37966356
  metaidx : offs  95471200 len 18345560
  meta    : offs 113816760 len 27767724
  offs    : offs 141584488 len  2834376
  metalines: offs 144418864 len   458591
  idx     : offs 144877456 len  6793104
  sdx     : offs 151670560 len  7741514
  addr    : offs 159412080 len   605806
  ranks   : offs 160017888 len   616360
  centers : offs 160634248 len  8526349
  ugc     : offs 169160600 len     5655
  ratings : offs 169166256 len   616072
  popularity: offs 169782328 len   616120
  altitudes: offs 170398448 len  3263128
  speedcams: offs 173661576 len       52
  routing : offs 173661632 len  2172839
  restrictions: offs 175834472 len    51458
  roadaccess: offs 175885936 len   224977
  city_roads: offs 176110920 len   363168
  maxspeeds: offs 176474088 len    70484
  cross_mwm: offs 176544576 len    79086
  traffic : offs 176623664 len   548507
  transit : offs 177172176 len    48124
  transit_cross_mwm: offs 177220304 len       81
  descriptions: offs 177220392 len   205424

real	0m0.061s
user	0m0.040s
sys	0m0.014s
```