### PR TITLE
[Drape-frontend] Handle arrow direction in routing at low speed.

### DIFF
--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -422,11 +422,15 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
     m_autoScale2d = m_autoScale3d = kUnknownAutoZoom;
   }
 
-  if (!m_isCompassAvailable || m_isArrowGluedInRouting)
+  // Sets direction based on GPS if compass is not available or the direction must be glued to the
+  // route (route-corrected angle is set only in OnLocationUpdate(): in OnCompassUpdate() the angle
+  // always has the original value.
+  if ((!m_isCompassAvailable || m_isArrowGluedInRouting) && info.HasBearing())
   {
-    bool const hasBearing = info.HasBearing();
-    if ((isNavigable && hasBearing) ||
-        (!isNavigable && hasBearing && info.HasSpeed() && info.m_speedMpS > kMinSpeedThresholdMps))
+    // Sets direction if in routing, or moving with |m_speedMpS| speed, or there is no signal from
+    // the compass sensor.
+    if (isNavigable || (info.HasSpeed() && info.m_speedMpS > kMinSpeedThresholdMps) ||
+        !m_isCompassAvailable)
     {
       SetDirection(base::DegToRad(info.m_bearing));
     }


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13111
https://jira.mail.ru/browse/MAPSME-13110

После мержа #12344 появились 2 **проблемы:**
1) Если начать ведение по вело/авто маршруту на нулевой скорости, то пока скорость не возрастет, стрелка направления **не будет матчиться** на маршрут, а будет показывать изначальный угол девайса до перехода в режим ведения.

<img width="219" alt="image" src="https://user-images.githubusercontent.com/54934129/74032892-14d3d280-49c6-11ea-8084-e1a273a54a26.png">

2) На одной из моделей самсунга при запуске приложения вместо стрелки местоположения отображается точка.

<img width="219" alt="image" src="https://user-images.githubusercontent.com/54934129/74033217-bce99b80-49c6-11ea-9a16-fdc609c86529.png">


**Причина:** в PR #12344 реализована логика поворота стрелки либо на основании данных компаса, либо GPS. Иначе ее колбасит между значениями от двух разных сенсоров. При этом не скорректировано условие отрисовывать направление по GNSS, даже если скорость околонулевая.

**Решение:** изменить условие отрисовки поворота стрелки в методе OnLocationUpdate(), который обрабатывает данные GNSS.
