### PR TITLE
[track analyzing] Improving tabling. 

### DIFF
--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -444,14 +444,18 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           // Splitting track with points where MoveType is changed.
           while (end != track.end() && pointToMoveType.GetMoveType(*end) == moveType)
           {
-            IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()), info);
+            IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()),
+                                                info);
             prev = end;
             ++end;
           }
 
           // If it's not the end of the track than it could be a crossroad.
           if (end != track.end())
-            IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()), info);
+          {
+            IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()),
+                                                info);
+          }
 
           aggregator.Add(move(moveType), info, subtrackBegin, end, geometry);
           subtrackBegin = end;

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -435,8 +435,8 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           continue;
 
         MoveTypeAggregator aggregator;
-        IsCrossroadChecker::CrossroadInfo info{};
-        info.fill(0);
+        // Initializing with base::Underlying(IsCrossroadChecker::Type::None) that means with 0.
+        IsCrossroadChecker::CrossroadInfo info = {};
         for (auto subtrackBegin = track.begin(); subtrackBegin != track.end();)
         {
           auto moveType = pointToMoveType.GetMoveType(*subtrackBegin);
@@ -451,8 +451,7 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           }
 
           // If it's not the end of the track than it could be a crossroad.
-          IsCrossroadChecker::CrossroadInfo crossroad{};
-          crossroad.fill(0);
+          IsCrossroadChecker::CrossroadInfo crossroad = {};
           if (end != track.end())
           {
             crossroad = checker(prev->GetSegment(), end->GetSegment());
@@ -461,7 +460,6 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
           aggregator.Add(move(moveType), info, subtrackBegin, end, geometry);
           subtrackBegin = end;
-//          info = {};
           info.fill(0);
         }
 

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -436,6 +436,7 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
         MoveTypeAggregator aggregator;
         IsCrossroadChecker::CrossroadInfo info{};
+        info.fill(0);
         for (auto subtrackBegin = track.begin(); subtrackBegin != track.end();)
         {
           auto moveType = pointToMoveType.GetMoveType(*subtrackBegin);
@@ -451,6 +452,7 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
           // If it's not the end of the track than it could be a crossroad.
           IsCrossroadChecker::CrossroadInfo crossroad{};
+          crossroad.fill(0);
           if (end != track.end())
           {
             crossroad = checker(prev->GetSegment(), end->GetSegment());
@@ -459,7 +461,8 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
 
           aggregator.Add(move(moveType), info, subtrackBegin, end, geometry);
           subtrackBegin = end;
-          info = {};
+//          info = {};
+          info.fill(0);
         }
 
         auto const summary = aggregator.GetSummary(user, mwmName, countryName, stats);

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -435,7 +435,6 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           continue;
 
         MoveTypeAggregator aggregator;
-        // Initializing with base::Underlying(IsCrossroadChecker::Type::None) that means with 0.
         IsCrossroadChecker::CrossroadInfo info = {};
         for (auto subtrackBegin = track.begin(); subtrackBegin != track.end();)
         {
@@ -451,12 +450,8 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
           }
 
           // If it's not the end of the track than it could be a crossroad.
-          IsCrossroadChecker::CrossroadInfo crossroad = {};
           if (end != track.end())
-          {
-            crossroad = checker(prev->GetSegment(), end->GetSegment());
-            IsCrossroadChecker::MergeCrossroads(crossroad, info);
-          }
+            IsCrossroadChecker::MergeCrossroads(checker(prev->GetSegment(), end->GetSegment()), info);
 
           aggregator.Add(move(moveType), info, subtrackBegin, end, geometry);
           subtrackBegin = end;

--- a/track_analyzing/track_analyzer/crossroad_checker.cpp
+++ b/track_analyzing/track_analyzer/crossroad_checker.cpp
@@ -77,10 +77,7 @@ namespace routing
 {
 IsCrossroadChecker::CrossroadInfo IsCrossroadChecker::operator()(Segment const & current, Segment const & next) const
 {
-  IsCrossroadChecker::CrossroadInfo ret{};
-  ret.fill(0);
-//  if (current == next)
-//    return ret;
+  IsCrossroadChecker::CrossroadInfo ret = {};
 
   auto const currentSegmentFeatureId = current.GetFeatureId();
   auto const currentSegmentHwType = m_geometry.GetRoad(currentSegmentFeatureId).GetHighwayType();
@@ -93,19 +90,19 @@ IsCrossroadChecker::CrossroadInfo IsCrossroadChecker::operator()(Segment const &
 
   bool const isCurrentLink = IsHighwayLink(currentSegmentHwType);
   bool const isNextLink = IsHighwayLink(nextSegmentHwType);
-  bool const currentIsBig = IsBigHighway(currentSegmentHwType);
-  bool const nextIsBig = IsBigHighway(nextSegmentHwType);
+  bool const isCurrentBig = IsBigHighway(currentSegmentHwType);
+  bool const isNextBig = IsBigHighway(nextSegmentHwType);
 
   if (currentSegmentFeatureId != nextSegmentFeatureId && currentSegmentHwType != nextSegmentHwType)
   {
     // Changing highway type.
-    if (isCurrentLink && !isNextLink && nextIsBig)
+    if (isCurrentLink && !isNextLink && isNextBig)
     {
       ++ret[base::Underlying(Type::TurnFromSmallerToBigger)];
       return ret;
     }
 
-    if (!isCurrentLink && isNextLink && currentIsBig)
+    if (!isCurrentLink && isNextLink && isCurrentBig)
     {
       ++ret[base::Underlying(Type::TurnFromBiggerToSmaller)];
       return ret;
@@ -114,12 +111,12 @@ IsCrossroadChecker::CrossroadInfo IsCrossroadChecker::operator()(Segment const &
     // It's move without links.
     if (!isCurrentLink && !isNextLink)
     {
-      if (currentIsBig && !nextIsBig)
+      if (isCurrentBig && !isNextBig)
       {
         ++ret[base::Underlying(Type::TurnFromBiggerToSmaller)];
         return ret;
       }
-      else if (!currentIsBig && nextIsBig)
+      else if (!isCurrentBig && isNextBig)
       {
         ++ret[base::Underlying(Type::TurnFromSmallerToBigger)];
         return ret;

--- a/track_analyzing/track_analyzer/crossroad_checker.cpp
+++ b/track_analyzing/track_analyzer/crossroad_checker.cpp
@@ -105,7 +105,7 @@ IsCrossroadChecker::Type IsCrossroadChecker::operator()(Segment const & current,
     {
       if (isCurrentBig && !isNextBig)
         return Type::TurnFromBiggerToSmaller;
-      else if (!isCurrentBig && isNextBig)
+      if (!isCurrentBig && isNextBig)
         return Type::TurnFromSmallerToBigger;
     }
   }

--- a/track_analyzing/track_analyzer/crossroad_checker.hpp
+++ b/track_analyzing/track_analyzer/crossroad_checker.hpp
@@ -7,6 +7,7 @@
 #include "base/stl_helpers.hpp"
 
 #include <array>
+#include <string>
 
 namespace routing
 {
@@ -15,14 +16,9 @@ class IsCrossroadChecker
 public:
   enum class Type
   {
-    None,
     TurnFromSmallerToBigger,
     TurnFromBiggerToSmaller,
-    FromLink,
-    ToLink,
     IntersectionWithBig,
-    IntersectionWithSmall,
-    IntersectionWithLink,
     Count
   };
 
@@ -31,12 +27,16 @@ public:
   IsCrossroadChecker(IndexGraph & indexGraph, Geometry & geometry) : m_indexGraph(indexGraph), m_geometry(geometry) {}
   /// \brief Compares two segments by their highway type to find if there was a crossroad between them.
   /// Check if current segment is a joint to find and find all intersections with other roads.
-  CrossroadInfo operator()(Segment const & current, Segment const & next) const;
+  Type operator()(Segment const & current, Segment const & next) const;
 
-  static void MergeCrossroads(CrossroadInfo const & from, CrossroadInfo & to);
+  static void MergeCrossroads(Type from, CrossroadInfo & to);
+  static void MergeCrossroads(IsCrossroadChecker::CrossroadInfo const & from,
+                              IsCrossroadChecker::CrossroadInfo & to);
 
 private:
   IndexGraph & m_indexGraph;
   Geometry & m_geometry;
 };
+
+std::string DebugPrint(IsCrossroadChecker::Type type);
 }  // namespace routing


### PR DESCRIPTION
Цель данного PR улучшить разбиение по трекам, чтоб уменьшить среднюю ошибку.

Ключевое изменение, это изменение в IsCrossroadChecker::operator(). Мы стали по другому считать перекрестки и определять их типы.

1. При переходе трека с сегмента на сегмент может быть не более одного перекрестка. Это отражает измененная сигнатура `IsCrossroadChecker::operator()`. Теперь возвращается только одно значение, а не массив.

2. Ранее перекрестки типов: FromLink, ToLink, IntersectionWithSmall, IntersectionWithLink считались, но не учитываются при расчете ETA, то теперь многие из них учитываются и попадают в одну категорий, которые остались. Например, FromLink это обычно выезд на б_о_льшую дорогу. Соответственно теперь относится к категории TurnFromSmallerToBigger.

Почему это изменение делает лучше? Ниже сравнение.

Обучение на данных за месяц, + 20% для проверки. Используются фичи (TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig) во всех сочетаниях.

Сравниваем:
(1) Текущий мастер. В нем генерируются все типы перекрестков (TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig, FromLink, ToLink, IntersectionWithSmall, IntersectionWithLink), а используются только TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig, в разных сочетаниях
(2) новый вариант, когда генерируются TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig и используются в разных сочетаниях.

В настоящий момент, для генерации релизного ETA, в мастере считаются все 7 вариантов перекрестков, а используются для генерации только 3 TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig.

**В городе (старая разбивка, как в мастере/новая разбивка, как в PR)**
**TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig**:  11.179018033769754/ 9.3755281199636631
**TurnFromSmallerToBigger, TurnFromBiggerToSmaller**:  11.451159791569088/ 9.421512233007757
**TurnFromBiggerToSmaller, IntersectionWithBig**: 11.170416493690368/ 9.3739685430708537
**TurnFromSmallerToBigger, IntersectionWithBig**:  11.366937614363563/ 9.4284493605286457
**TurnFromSmallerToBigger**:  11.519632391959163/ 9.4716448265419011
**TurnFromBiggerToSmaller**:  11.449715851490758/ 9.4209127015877243
**IntersectionWithBig**:  11.193175307332083/ 9.4279256885092675
: 11.538027039860868/  9.47164482641322

**За городом (старая разбивка/новая разбивка)**
**TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig**: 6.9933332489377502/ 6.353997259116686
**TurnFromSmallerToBigger, TurnFromBiggerToSmaller**:  7.0636120873200907/ 6.3613844351314235
**TurnFromBiggerToSmaller, IntersectionWithBig**: 6.9975827321087616/ 6.3698773507596709
**TurnFromSmallerToBigger, IntersectionWithBig**:  7.0494720219212388/ 6.4282398161974701
**TurnFromSmallerToBigger**:  7.1203807297427781/ 6.4236884929695144
**TurnFromBiggerToSmaller**:  7.0574798607387939/ 6.3609618668418655
**IntersectionWithBig**:  7.0488217930011148/ 6.4277602734500805
: 7.1193195192194549/ 6.4236884926093056

Далее, в python коде, по результатам этого теста планируется использовать все 3 фичи (TurnFromSmallerToBigger, TurnFromBiggerToSmaller, IntersectionWithBig) для генерации факторов. Поскольку за городом и в городе ошибка существенно уменьшается.

За городом по средней ошибке выигрываем 1.8% (в итоге 9.37%), в городе выигрываем 0.65% (в итоге 6.35%)

@gmoryes @mesozoic-drones PTAL