### PR TITLE
[routing] Parents const correctness fixing.

### DIFF
--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -64,7 +64,7 @@ bool IndexGraph::IsJointOrEnd(Segment const & segment, bool fromStart)
 }
 
 void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                             vector<SegmentEdge> & edges, Parents<Segment> & parents)
+                             vector<SegmentEdge> & edges, Parents<Segment> const & parents)
 {
   RoadPoint const roadPoint = segment.GetRoadPoint(isOutgoing);
   Joint::Id const jointId = m_roadIndex.GetJointId(roadPoint);
@@ -140,13 +140,13 @@ optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
                                                         Segment const & firstChild, bool isOutgoing,
                                                         uint32_t lastPoint)
 {
-  vector<Segment> const possibleChilds = {firstChild};
+  vector<Segment> const possibleChildren = {firstChild};
   vector<uint32_t> const lastPoints = {lastPoint};
 
   vector<JointEdge> edges;
   vector<RouteWeight> parentWeights;
   Parents<JointSegment> emptyParents;
-  ReconstructJointSegment({} /* parentJoint */, parent, possibleChilds, lastPoints,
+  ReconstructJointSegment({} /* parentJoint */, parent, possibleChildren, lastPoints,
                           isOutgoing, edges, parentWeights, emptyParents);
 
   CHECK_LESS_OR_EQUAL(edges.size(), 1, ());
@@ -203,7 +203,7 @@ void IndexGraph::SetRoadAccess(RoadAccess && roadAccess) { m_roadAccess = move(r
 
 void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
                                      bool useRoutingOptions, vector<SegmentEdge> & edges,
-                                     Parents<Segment> & parents)
+                                     Parents<Segment> const & parents)
 {
   RoadGeometry const & road = m_geometry->GetRoad(rp.GetFeatureId());
 
@@ -266,7 +266,7 @@ void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutg
 
 /// \brief Prolongs segments from |parent| to |firstChildren| directions in order to
 ///        create JointSegments.
-/// \param |firstChildren| - vecotor of neigbouring segments from parent.
+/// \param |firstChildren| - vector of neighbouring segments from parent.
 /// \param |lastPointIds| - vector of the end numbers of road points for |firstChildren|.
 /// \param |jointEdges| - the result vector with JointEdges.
 /// \param |parentWeights| - see |IndexGraphStarterJoints::GetEdgeList| method about this argument.
@@ -279,7 +279,7 @@ void IndexGraph::ReconstructJointSegment(JointSegment const & parentJoint,
                                          bool isOutgoing,
                                          vector<JointEdge> & jointEdges,
                                          vector<RouteWeight> & parentWeights,
-                                         Parents<JointSegment> & parents)
+                                         Parents<JointSegment> const & parents)
 {
   CHECK_EQUAL(firstChildren.size(), lastPointIds.size(), ());
 
@@ -359,7 +359,7 @@ void IndexGraph::ReconstructJointSegment(JointSegment const & parentJoint,
 }
 
 void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
-                                    vector<SegmentEdge> & edges, Parents<Segment> & parents)
+                                    vector<SegmentEdge> & edges, Parents<Segment> const & parents)
 {
   if (IsUTurn(from, to) && IsUTurnAndRestricted(from, to, isOutgoing))
     return;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -52,7 +52,7 @@ public:
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                    std::vector<SegmentEdge> & edges,
-                   Parents<Segment> & parents = kEmptyParentsSegments);
+                   Parents<Segment> const & parents = kEmptyParentsSegments);
 
   void GetEdgeList(JointSegment const & parentJoint,
                    Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
@@ -119,7 +119,7 @@ public:
   bool IsRestricted(ParentVertex const & parent,
                     uint32_t parentFeatureId,
                     uint32_t currentFeatureId, bool isOutgoing,
-                    Parents<ParentVertex> & parents) const;
+                    Parents<ParentVertex> const & parents) const;
 
   bool IsUTurnAndRestricted(Segment const & parent, Segment const & child, bool isOutgoing) const;
 
@@ -129,9 +129,9 @@ public:
 private:
   void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
                            bool useRoutingOptions, std::vector<SegmentEdge> & edges,
-                           Parents<Segment> & parents);
+                           Parents<Segment> const & parents);
   void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
-                          std::vector<SegmentEdge> & edges, Parents<Segment> & parents);
+                          std::vector<SegmentEdge> & edges, Parents<Segment> const & parents);
 
   struct PenaltyData
   {
@@ -156,7 +156,7 @@ private:
                                bool isOutgoing,
                                std::vector<JointEdge> & jointEdges,
                                std::vector<RouteWeight> & parentWeights,
-                               Parents<JointSegment> & parents);
+                               Parents<JointSegment> const & parents);
 
   std::shared_ptr<Geometry> m_geometry;
   std::shared_ptr<EdgeEstimator> m_estimator;
@@ -188,7 +188,7 @@ bool IndexGraph::IsRestricted(ParentVertex const & parent,
                               uint32_t parentFeatureId,
                               uint32_t currentFeatureId,
                               bool isOutgoing,
-                              Parents<ParentVertex> & parents) const
+                              Parents<ParentVertex> const & parents) const
 {
   if (parentFeatureId == currentFeatureId)
     return false;


### PR DESCRIPTION
Передавали параметр `Parents<Segment> const & parents` по ссылке, а не по константой ссылке. Поправил.

@gmoryes @mesozoic-drones PTAL