### PR TITLE
[coding] [map] Refactored url's ForEachParam.

### DIFF
--- a/coding/coding_tests/url_tests.cpp
+++ b/coding/coding_tests/url_tests.cpp
@@ -35,13 +35,12 @@ public:
   }
 
 private:
-  bool AddTestValue(url::Param const & param)
+  void AddTestValue(url::Param const & param)
   {
     TEST(!m_keyValuePairs.empty(), ("Failed for url = ", m_url, "Passed KV = ", param));
     TEST_EQUAL(m_keyValuePairs.front().first, param.m_name, ());
     TEST_EQUAL(m_keyValuePairs.front().second, param.m_value, ());
     m_keyValuePairs.pop();
-    return true;
   }
 
   string m_url;

--- a/coding/url.cpp
+++ b/coding/url.cpp
@@ -224,19 +224,10 @@ bool Url::Parse(std::string const & url)
   return true;
 }
 
-bool Url::ForEachParam(Callback const & callback) const
+void Url::ForEachParam(Callback const & callback) const
 {
-  // todo(@m) Looks strange but old code worked this way.
-  if (m_params.empty())
-    return false;
-
   for (auto const & param : m_params)
-  {
-    if (!callback(param))
-      return false;
-  }
-
-  return true;
+    callback(param);
 }
 
 string Make(string const & baseUrl, Params const & params)

--- a/coding/url.hpp
+++ b/coding/url.hpp
@@ -26,14 +26,14 @@ using Params = std::vector<Param>;
 class Url
 {
 public:
-  using Callback = std::function<bool(Param const & param)>;
+  using Callback = std::function<void(Param const & param)>;
 
   explicit Url(std::string const & url);
 
   std::string const & GetScheme() const { return m_scheme; }
   std::string const & GetPath() const { return m_path; }
   bool IsValid() const { return !m_scheme.empty(); }
-  bool ForEachParam(Callback const & callback) const;
+  void ForEachParam(Callback const & callback) const;
 
 private:
   bool Parse(std::string const & url);

--- a/map/map_tests/mwm_url_tests.cpp
+++ b/map/map_tests/mwm_url_tests.cpp
@@ -39,9 +39,11 @@ class ApiTest
 {
 public:
   explicit ApiTest(string const & urlString)
-    : m_fm(kFrameworkParams)
+    : m_framework(kFrameworkParams)
   {
-    m_m = &m_fm.GetBookmarkManager();
+    df::VisualParams::Init(1.0, 1024);
+
+    m_m = &m_framework.GetBookmarkManager();
     m_api.SetBookmarkManager(m_m);
 
     auto const res = m_api.SetUrlAndParse(urlString);
@@ -103,7 +105,7 @@ private:
   }
 
 private:
-  Framework m_fm;
+  Framework m_framework;
   ParsedMapApi m_api;
   m2::RectD m_viewportRect;
   BookmarkManager * m_m;
@@ -118,7 +120,7 @@ bool IsValid(Framework & fm, string const & urlString)
 
   return api.IsValid();
 }
-}
+}  // namespace
 
 UNIT_TEST(MapApiSmoke)
 {

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "coding/url.hpp"
+
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
@@ -102,13 +104,13 @@ public:
   Subscription const & GetSubscription() const { return m_subscription; }
 private:
   ParsingResult Parse(url::Url const & url);
-  bool AddKeyValue(std::string const & key, std::string const & value, std::vector<ApiPoint> & points);
-  bool RouteKeyValue(std::string const & key, std::string const & value, std::vector<std::string> & pattern);
-  bool SearchKeyValue(std::string const & key, std::string const & value, SearchRequest & request) const;
-  bool LeadKeyValue(std::string const & key, std::string const & value, lead::CampaignDescription & description) const;
-  bool CatalogKeyValue(std::string const & key, std::string const & value, Catalog & item) const;
-  bool CatalogPathKeyValue(std::string const & key, std::string const & value, CatalogPath & item) const;
-  bool SubscriptionKeyValue(std::string const & key, std::string const & value, Subscription & item) const;
+  void ParseMapParam(url::Param const & param, std::vector<ApiPoint> & points, bool & correctOrder);
+  void ParseRouteParam(url::Param const & param, std::vector<std::string> & pattern);
+  void ParseSearchParam(url::Param const & param, SearchRequest & request) const;
+  void ParseLeadParam(url::Param const & param, lead::CampaignDescription & description) const;
+  void ParseCatalogParam(url::Param const & param, Catalog & item) const;
+  void ParseCatalogPathParam(url::Param const & param, CatalogPath & item) const;
+  void ParseSubscriptionParam(url::Param const & param, Subscription & item) const;
 
   BookmarkManager * m_bmManager = nullptr;
   std::vector<RoutePoint> m_routePoints;


### PR DESCRIPTION
The bool value in the old version served two purposes
at once: it was used both to control the execution flow
and to indicate the parsing result. As such, the return
value of true meant "the needed key was found and the
callback returned true when executed with the corresponding value"
and the return value of false meant "either the needed key
was not found or the callback returned false even though the
key was present". This is too loaded semantically and is
a false optimization (since the parsed url params need to be stored
in a vector of pairs by the time of this call, early exit won't help much).