### PR TITLE
[track analyzer] Tabling. Column number and column order fix.

### DIFF
--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -262,7 +262,7 @@ public:
         << m_totalTime << ","
         << CalcSpeedKMpH(m_totalDistance, m_totalTime) << ",";
 
-    for (size_t i = 1; i < m_crossroads.size(); ++i)
+    for (size_t i = 0; i < m_crossroads.size(); ++i)
     {
       out << m_crossroads[i];
       if (i != m_crossroads.size() - 1)

--- a/track_analyzing/track_analyzer/utils.cpp
+++ b/track_analyzing/track_analyzer/utils.cpp
@@ -235,9 +235,9 @@ void ParseTracks(string const & logFile, shared_ptr<NumMwmIds> const & numMwmIds
 
 void WriteCsvTableHeader(basic_ostream<char> & stream)
 {
-  stream << "user,mwm,hw type,surface type,maxspeed km/h,is city road,is one way,is day,lat lon,distance,time,"
-            "mean speed km/h,turn from smaller to bigger,turn from bigger to smaller,from link,to link,"
-            "intersection with big,intersection with small,intersection with link\n";
+  stream << "user,mwm,hw type,surface type,maxspeed km/h,is city road,is one way,is day,lat lon,"
+            "distance,time,mean speed km/h,turn from smaller to bigger,turn from bigger to smaller,"
+            "intersection with big\n";
 }
 
 void LogNameToCountMapping(string const & keyName, string const & descr,


### PR DESCRIPTION
Тестирование PR https://github.com/mapsme/omim/pull/12574 выявило в нем серьезные ошибки. Данные ошибки произошли в процессе упрощения кода после изменений. Т.о. результаты описанные в описании https://github.com/mapsme/omim/pull/12574 в силе.

Ошибки следующие.

SpeedInfo::GetSummary() заполняет записи в csv для каждого значения в `enum class IsCrossroadChecker::Type` начиная с 1го, а не нулевого. Т.к. начинались значения с `IsCrossroadChecker::Type::None`.

Во-первых, учитывая изменения в `IsCrossroadChecker::Type`(https://github.com/mapsme/omim/pull/12574/files#diff-87fdcfaa7d7525bb928d09027a24055b) нужно записывать, начиная с 0.

Во-вторых, учитывая изменения в том же файле, необходимо изменить и список колонок в csv.

На базе данного PR я запустил тесты. Тесты прошли успешно.

@mesozoic-drones @gmoryes PTAL
