### PR TITLE
[cherry-pick][iOS] fix a bug in which the app crashes on the device at startup.

### DIFF
--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -308,7 +308,6 @@
 		34F742321E0834F400AC1FD6 /* UIViewController+Navigation.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F742301E0834F400AC1FD6 /* UIViewController+Navigation.m */; };
 		34FE5A6F1F18F30F00BCA729 /* TrafficButtonArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FE5A6D1F18F30F00BCA729 /* TrafficButtonArea.swift */; };
 		39CDE69123E1B6C8007CDA58 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39CDE69023E1B6C8007CDA58 /* libge0.a */; };
-		3D0BBC1E23F434E400A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC1D23F434E400A50354 /* libminizip.dylib */; };
 		3D0D2F7623D858BF00945C8D /* IsolinesTutorialBlur.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3D0D2F7523D858BF00945C8D /* IsolinesTutorialBlur.xib */; };
 		3D15ACEE2155117000F725D5 /* MWMObjectsCategorySelectorDataSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3D15ACED2155117000F725D5 /* MWMObjectsCategorySelectorDataSource.mm */; };
 		3D1958EB213804B6009A83EC /* libmetrics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D1958EA213804B6009A83EC /* libmetrics.a */; };
@@ -372,6 +371,8 @@
 		4738A8E7239FC513007C0F43 /* AdBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4738A8E6239FC513007C0F43 /* AdBannerView.swift */; };
 		4738A8E9239FC526007C0F43 /* AdBannerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4738A8E8239FC526007C0F43 /* AdBannerView.xib */; };
 		473CBF9B2164DD470059BD54 /* SettingsTableViewSelectableProgressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473CBF9A2164DD470059BD54 /* SettingsTableViewSelectableProgressCell.swift */; };
+		4740184323F5BDE800A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184123F5BDD300A93C81 /* minizip.framework */; };
+		4740184423F5BDE900A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184123F5BDD300A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		474AC76C2139E4F2002F9BF9 /* RemoveAdsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474AC76A2139E4F2002F9BF9 /* RemoveAdsViewController.swift */; };
 		474AC76D2139E4F2002F9BF9 /* RemoveAdsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 474AC76B2139E4F2002F9BF9 /* RemoveAdsViewController.xib */; };
 		474C9F5A213FF75800369009 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 474C9F59213FF75800369009 /* StoreKit.framework */; };
@@ -863,6 +864,20 @@
 		F6FE3C3C1CC5106500A73196 /* MWMPlaceDoesntExistAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6FE3C3A1CC5106500A73196 /* MWMPlaceDoesntExistAlert.xib */; };
 		F6FEA82E1C58F108007223CC /* MWMButton.m in Sources */ = {isa = PBXBuildFile; fileRef = F6FEA82C1C58E89B007223CC /* MWMButton.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4740184523F5BDE900A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740184423F5BDE900A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0B07BBB5C2EFC6F60EF51BC8 /* Pods-MAPS.ME.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MAPS.ME.debug.xcconfig"; path = "Target Support Files/Pods-MAPS.ME/Pods-MAPS.ME.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1367,7 +1382,6 @@
 		34FE4C441BCC013500066718 /* MWMMapWidgets.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MWMMapWidgets.mm; sourceTree = "<group>"; };
 		34FE5A6D1F18F30F00BCA729 /* TrafficButtonArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrafficButtonArea.swift; sourceTree = "<group>"; };
 		39CDE69023E1B6C8007CDA58 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC1D23F434E400A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0D2F7523D858BF00945C8D /* IsolinesTutorialBlur.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IsolinesTutorialBlur.xib; sourceTree = "<group>"; };
 		3D15ACED2155117000F725D5 /* MWMObjectsCategorySelectorDataSource.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MWMObjectsCategorySelectorDataSource.mm; sourceTree = "<group>"; };
 		3D15ACEF2155118800F725D5 /* MWMObjectsCategorySelectorDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMObjectsCategorySelectorDataSource.h; sourceTree = "<group>"; };
@@ -1447,6 +1461,7 @@
 		4738A8E6239FC513007C0F43 /* AdBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdBannerView.swift; sourceTree = "<group>"; };
 		4738A8E8239FC526007C0F43 /* AdBannerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AdBannerView.xib; sourceTree = "<group>"; };
 		473CBF9A2164DD470059BD54 /* SettingsTableViewSelectableProgressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewSelectableProgressCell.swift; sourceTree = "<group>"; };
+		4740184123F5BDD300A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		474902D8224A54EC008D71E0 /* MWMRoutingOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMRoutingOptions.h; sourceTree = "<group>"; };
 		474902D9224A54EC008D71E0 /* MWMRoutingOptions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MWMRoutingOptions.mm; sourceTree = "<group>"; };
 		474AC76A2139E4F2002F9BF9 /* RemoveAdsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAdsViewController.swift; sourceTree = "<group>"; };
@@ -1580,7 +1595,6 @@
 		6741AAAE1BF356B9002C974C /* libindexer.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libindexer.a; path = "../../../omim-xcode-build/Debug/libindexer.a"; sourceTree = "<group>"; };
 		6741AAAF1BF356B9002C974C /* libjansson.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libjansson.a; path = "../../../omim-xcode-build/Debug/libjansson.a"; sourceTree = "<group>"; };
 		6741AAB11BF356B9002C974C /* libmap.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmap.a; path = "../../../omim-xcode-build/Debug/libmap.a"; sourceTree = "<group>"; };
-		6741AAB21BF356B9002C974C /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		6741AAB31BF356B9002C974C /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		6741AAB41BF356B9002C974C /* libosrm.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libosrm.a; path = "../../../omim-xcode-build/Debug/libosrm.a"; sourceTree = "<group>"; };
 		6741AAB51BF356B9002C974C /* libplatform.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libplatform.a; path = "../../../omim-xcode-build/Debug/libplatform.a"; sourceTree = "<group>"; };
@@ -2118,7 +2132,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC1E23F434E400A50354 /* libminizip.dylib in Frameworks */,
 				39CDE69123E1B6C8007CDA58 /* libge0.a in Frameworks */,
 				47A65CAD2350044800DCD85F /* CoreApi.framework in Frameworks */,
 				4577B28121F2066A00864FAC /* libvulkan_wrapper.a in Frameworks */,
@@ -2154,6 +2167,7 @@
 				3446C6771DDCA9A200146687 /* libtraffic.a in Frameworks */,
 				34201E0C1DC0E33100D24118 /* libtracking.a in Frameworks */,
 				341F09841C20138100F18AC5 /* libpugixml.a in Frameworks */,
+				4740184323F5BDE800A93C81 /* minizip.framework in Frameworks */,
 				3411387D1C15AE73002E3B3E /* libeditor.a in Frameworks */,
 				6741AABD1BF356BA002C974C /* libagg.a in Frameworks */,
 				6741AABE1BF356BA002C974C /* libalohalitics.a in Frameworks */,
@@ -2299,8 +2313,8 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC1D23F434E400A50354 /* libminizip.dylib */,
 				39CDE69023E1B6C8007CDA58 /* libge0.a */,
+				4740184123F5BDD300A93C81 /* minizip.framework */,
 				450B5C822355F50200E9019E /* libweb_api.a */,
 				47A65CAC2350044800DCD85F /* CoreApi.framework */,
 				4577B28021F2066A00864FAC /* libvulkan_wrapper.a */,
@@ -2335,7 +2349,6 @@
 				6741AAAF1BF356B9002C974C /* libjansson.a */,
 				45FFD65C1E965EBE00DB854E /* liblocal_ads.a */,
 				6741AAB11BF356B9002C974C /* libmap.a */,
-				6741AAB21BF356B9002C974C /* libminizip.a */,
 				340DC82B1C4E72C700EAA2CC /* liboauthcpp.a */,
 				6741AAB31BF356B9002C974C /* libopening_hours.a */,
 				6741AAB41BF356B9002C974C /* libosrm.a */,
@@ -4806,6 +4819,7 @@
 				6741AA311BF340DE002C974C /* Frameworks */,
 				34F7422E1E08328300AC1FD6 /* Crashlytics */,
 				AED76F73852BBAF00EEF9E66 /* [CP] Embed Pods Frameworks */,
+				4740184523F5BDE900A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/xcode/coding/coding.xcodeproj/project.pbxproj
+++ b/xcode/coding/coding.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		39F376D2207D32AA0058E8E0 /* test_polylines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39F376CA207D329F0058E8E0 /* test_polylines.cpp */; };
 		39F376D3207D32AD0058E8E0 /* geometry_serialization_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39F376CC207D329F0058E8E0 /* geometry_serialization_test.cpp */; };
 		39F376D4207D32B10058E8E0 /* geometry_coding_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39F376CB207D329F0058E8E0 /* geometry_coding_test.cpp */; };
-		3D0BBC2023F4352C00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC1F23F4352C00A50354 /* libminizip.dylib */; };
 		3D489BC01D3D21A00052AA38 /* succinct_mapper_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BBA1D3D217E0052AA38 /* succinct_mapper_test.cpp */; };
 		3D489BC11D3D21A40052AA38 /* simple_dense_coding_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BB91D3D217E0052AA38 /* simple_dense_coding_test.cpp */; };
 		3D489BC21D3D21AA0052AA38 /* fixed_bits_ddvector_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BB81D3D217E0052AA38 /* fixed_bits_ddvector_test.cpp */; };
@@ -74,6 +73,8 @@
 		4563B063205909290057556D /* sha1.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4563B060205909280057556D /* sha1.hpp */; };
 		45C108BA1E9CFF8E000FE1F6 /* libgeometry.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45C108B91E9CFF8E000FE1F6 /* libgeometry.a */; };
 		56DAC3642399206A000BC50D /* test_polylines.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56DAC3632399206A000BC50D /* test_polylines.hpp */; };
+		4740184823F5BE0800A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184623F5BE0200A93C81 /* minizip.framework */; };
+		4740184923F5BE0800A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184623F5BE0200A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		670BAACB1D0B0C1E000302DA /* huffman.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 394917221BAC3C2F002A8C4F /* huffman.cpp */; };
 		670D04BD1B0BA92D0013A7AC /* expat_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 670D04B31B0BA9050013A7AC /* expat_impl.h */; };
 		670D04BE1B0BA92D0013A7AC /* file64_api.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 670D04B41B0BA9050013A7AC /* file64_api.hpp */; };
@@ -165,6 +166,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		4740180E23F5BB5800A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740184923F5BE0800A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -184,7 +196,6 @@
 		394917221BAC3C2F002A8C4F /* huffman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = huffman.cpp; sourceTree = "<group>"; };
 		394917231BAC3C2F002A8C4F /* huffman.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = huffman.hpp; sourceTree = "<group>"; };
 		394917271BAC3CAC002A8C4F /* libbase.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbase.a; path = "../../../omim-xcode-build/Debug/libbase.a"; sourceTree = "<group>"; };
-		394917281BAC3CAC002A8C4F /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		394917291BAC3CAC002A8C4F /* libsuccinct.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsuccinct.a; path = "../../../omim-xcode-build/Debug/libsuccinct.a"; sourceTree = "<group>"; };
 		3949172F1BAC3CC9002A8C4F /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		3954E00D233500E90007FDE4 /* files_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = files_container.hpp; sourceTree = "<group>"; };
@@ -221,7 +232,6 @@
 		39F376CA207D329F0058E8E0 /* test_polylines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_polylines.cpp; sourceTree = "<group>"; };
 		39F376CB207D329F0058E8E0 /* geometry_coding_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = geometry_coding_test.cpp; sourceTree = "<group>"; };
 		39F376CC207D329F0058E8E0 /* geometry_serialization_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = geometry_serialization_test.cpp; sourceTree = "<group>"; };
-		3D0BBC1F23F4352C00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D489BB51D3D21510052AA38 /* libplatform.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libplatform.a; path = "../../../omim-xcode-build/Debug/libplatform.a"; sourceTree = "<group>"; };
 		3D489BB71D3D217E0052AA38 /* elias_coder_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = elias_coder_test.cpp; sourceTree = "<group>"; };
 		3D489BB81D3D217E0052AA38 /* fixed_bits_ddvector_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fixed_bits_ddvector_test.cpp; sourceTree = "<group>"; };
@@ -239,6 +249,7 @@
 		4563B060205909280057556D /* sha1.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = sha1.hpp; sourceTree = "<group>"; };
 		45C108B91E9CFF8E000FE1F6 /* libgeometry.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgeometry.a; path = "/Users/r.kuznetsov/Dev/Projects/omim/xcode/geometry/../../../omim-build/xcode/Debug/libgeometry.a"; sourceTree = "<absolute>"; };
 		56DAC3632399206A000BC50D /* test_polylines.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = test_polylines.hpp; sourceTree = "<group>"; };
+		4740184623F5BE0200A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		670D04B31B0BA9050013A7AC /* expat_impl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = expat_impl.h; sourceTree = "<group>"; };
 		670D04B41B0BA9050013A7AC /* file64_api.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = file64_api.hpp; sourceTree = "<group>"; };
 		670D04B51B0BA9050013A7AC /* file_data.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = file_data.cpp; sourceTree = "<group>"; };
@@ -328,10 +339,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2023F4352C00A50354 /* libminizip.dylib in Frameworks */,
 				39C2288323E1EF1C00251321 /* Security.framework in Frameworks */,
 				39C2288123E1EF1700251321 /* CoreLocation.framework in Frameworks */,
 				39C2287F23E1EF0000251321 /* libjansson.a in Frameworks */,
+				4740184823F5BE0800A93C81 /* minizip.framework in Frameworks */,
 				F65AFA381F18C7A500979A50 /* libplatform.a in Frameworks */,
 				F65AFA361F18B8AB00979A50 /* libplatform_tests_support.a in Frameworks */,
 				45C108BA1E9CFF8E000FE1F6 /* libgeometry.a in Frameworks */,
@@ -357,11 +368,11 @@
 		3496AB6C1DC1F53500C5DDBA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC1F23F4352C00A50354 /* libminizip.dylib */,
 				39C2288223E1EF1C00251321 /* Security.framework */,
 				39C2288023E1EF1700251321 /* CoreLocation.framework */,
 				39C2287E23E1EF0000251321 /* libjansson.a */,
 				D57BDA1C2396A48400505BE6 /* liboauthcpp.a */,
+				4740184623F5BE0200A93C81 /* minizip.framework */,
 				F65AFA371F18C7A500979A50 /* libplatform.a */,
 				F65AFA351F18B8AB00979A50 /* libplatform_tests_support.a */,
 				45C108B91E9CFF8E000FE1F6 /* libgeometry.a */,
@@ -557,7 +568,6 @@
 				3D489BB51D3D21510052AA38 /* libplatform.a */,
 				3949172F1BAC3CC9002A8C4F /* libz.tbd */,
 				394917271BAC3CAC002A8C4F /* libbase.a */,
-				394917281BAC3CAC002A8C4F /* libminizip.a */,
 				394917291BAC3CAC002A8C4F /* libsuccinct.a */,
 			);
 			name = libs;
@@ -645,6 +655,7 @@
 				3949168B1BAC3A5F002A8C4F /* Sources */,
 				3949168C1BAC3A5F002A8C4F /* Frameworks */,
 				3949168D1BAC3A5F002A8C4F /* CopyFiles */,
+				4740180E23F5BB5800A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -800,6 +811,8 @@
 		394916941BAC3A5F002A8C4F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				INFOPLIST_FILE = "$(OMIM_ROOT)/iphone/Maps/MAPSME.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.coding_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -808,6 +821,8 @@
 		394916951BAC3A5F002A8C4F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				INFOPLIST_FILE = "$(OMIM_ROOT)/iphone/Maps/MAPSME.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.coding_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -897,6 +912,8 @@
 		A8E541421F9FBD6B00A1B8FA /* Production Full */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				INFOPLIST_FILE = "$(OMIM_ROOT)/iphone/Maps/MAPSME.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.coding_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/xcode/generator_tool/generator_tool.xcodeproj/project.pbxproj
+++ b/xcode/generator_tool/generator_tool.xcodeproj/project.pbxproj
@@ -33,13 +33,16 @@
 		397057C022CB57F9001A55CA /* cities_ids_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397057BD22CB57F8001A55CA /* cities_ids_tests.cpp */; };
 		39B9681E23E1AC3700D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9681D23E1AC3700D3B8E3 /* libge0.a */; };
 		39C4345222CE13F00002AEE3 /* booking_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39C4345122CE13F00002AEE3 /* booking_tests.cpp */; };
-		3D0BBC2223F435B900A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2123F435B900A50354 /* libminizip.dylib */; };
-		3D0BBC2423F52ED500A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2323F52ED500A50354 /* libminizip.dylib */; };
-		3D0BBC2623F52EE900A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2523F52EE900A50354 /* libminizip.dylib */; };
 		401E3189225C988500DE7EB8 /* libdescriptions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 401E3188225C988500DE7EB8 /* libdescriptions.a */; };
 		4491F494213D6B470011834F /* speed_cameras_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4491F490213D46380011834F /* speed_cameras_test.cpp */; };
 		4491F496213D6B8E0011834F /* osm2meta_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 677E2A0B1CAAC7CB001DC42A /* osm2meta_test.cpp */; };
 		4491F497213D6BA00011834F /* tag_admixer_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 677E2A0C1CAAC7CB001DC42A /* tag_admixer_test.cpp */; };
+		4740184B23F5BE1B00A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184A23F5BE1B00A93C81 /* minizip.framework */; };
+		4740184C23F5BE1C00A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184A23F5BE1B00A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4740184E23F5BE3900A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184D23F5BE3900A93C81 /* minizip.framework */; };
+		4740184F23F5BE3A00A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740184D23F5BE3900A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4740185123F5BE6500A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185023F5BE6500A93C81 /* minizip.framework */; };
+		4740185223F5BE6600A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185023F5BE6500A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		562147271F6AA36A002D2214 /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 562147261F6AA36A002D2214 /* libbsdiff.a */; };
 		562147291F6AA37E002D2214 /* libmwm_diff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 562147281F6AA37E002D2214 /* libmwm_diff.a */; };
 		562D42941FD8460500A995F3 /* libugc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 562D42951FD8460500A995F3 /* libugc.a */; };
@@ -190,6 +193,39 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		4740181723F5BB9F00A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740185223F5BE6600A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4740181A23F5BBA500A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740184F23F5BE3A00A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4740181D23F5BBAA00A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740184C23F5BE1C00A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6726C2311A4C2BBD005EEA39 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -247,11 +283,11 @@
 		397057BD22CB57F8001A55CA /* cities_ids_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cities_ids_tests.cpp; sourceTree = "<group>"; };
 		39B9681D23E1AC3700D3B8E3 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		39C4345122CE13F00002AEE3 /* booking_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = booking_tests.cpp; sourceTree = "<group>"; };
-		3D0BBC2123F435B900A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2323F52ED500A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2523F52EE900A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		401E3188225C988500DE7EB8 /* libdescriptions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libdescriptions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4491F490213D46380011834F /* speed_cameras_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_cameras_test.cpp; sourceTree = "<group>"; };
+		4740184A23F5BE1B00A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4740184D23F5BE3900A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4740185023F5BE6500A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		562147261F6AA36A002D2214 /* libbsdiff.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbsdiff.a; path = ../bsdiff/build/Debug/libbsdiff.a; sourceTree = "<group>"; };
 		562147281F6AA37E002D2214 /* libmwm_diff.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmwm_diff.a; path = "../../../../Library/Developer/Xcode/DerivedData/omim-gsfdicnjgjjbizhdmwedavcucpok/Build/Products/Debug/libmwm_diff.a"; sourceTree = "<group>"; };
 		562D42951FD8460500A995F3 /* libugc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libugc.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -298,7 +334,6 @@
 		671ED3BE20D4098100D4317E /* sponsored_storage_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sponsored_storage_tests.cpp; sourceTree = "<group>"; };
 		671ED3C620D40A2000D4317E /* libplatform_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libplatform_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		671ED3C820D40A3E00D4317E /* libgenerator_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgenerator_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		671ED3CA20D40A8C00D4317E /* libminizip.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		671F58B71B86109B0032311E /* intermediate_data_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = intermediate_data_test.cpp; sourceTree = "<group>"; };
 		6726C1E51A4C28D5005EEA39 /* coasts_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coasts_test.cpp; sourceTree = "<group>"; };
 		6726C1E61A4C28D5005EEA39 /* feature_builder_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = feature_builder_test.cpp; sourceTree = "<group>"; };
@@ -343,7 +378,6 @@
 		679624B71D11775300AE4E3C /* libdrape_frontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdrape_frontend.a; path = "../../../omim-xcode-build/Debug/libdrape_frontend.a"; sourceTree = "<group>"; };
 		679624B81D11775300AE4E3C /* libdrape.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdrape.a; path = "../../../omim-xcode-build/Debug/libdrape.a"; sourceTree = "<group>"; };
 		679624B91D11775300AE4E3C /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = "../../../omim-xcode-build/Debug/libfreetype.a"; sourceTree = "<group>"; };
-		679624BC1D11775300AE4E3C /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		679624BD1D11775300AE4E3C /* libplatform_tests_support.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libplatform_tests_support.a; path = "../../../omim-xcode-build/Debug/libplatform_tests_support.a"; sourceTree = "<group>"; };
 		679624BE1D11775300AE4E3C /* libsdf_image.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsdf_image.a; path = "../../../omim-xcode-build/Debug/libsdf_image.a"; sourceTree = "<group>"; };
 		679624BF1D11775300AE4E3C /* libstb_image.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libstb_image.a; path = "../../../omim-xcode-build/Debug/libstb_image.a"; sourceTree = "<group>"; };
@@ -362,11 +396,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2423F52ED500A50354 /* libminizip.dylib in Frameworks */,
 				56DAC360239915E9000BC50D /* libstorage.a in Frameworks */,
 				671C2D8B22AFE2F7008B2B8B /* libdescriptions.a in Frameworks */,
 				671C2D8922AFE250008B2B8B /* libtraffic.a in Frameworks */,
 				677E2A0A1CAAC771001DC42A /* libz.tbd in Frameworks */,
+				4740184E23F5BE3900A93C81 /* minizip.framework in Frameworks */,
 				671ED3C920D40A3E00D4317E /* libgenerator_tests_support.a in Frameworks */,
 				671ED3C720D40A2000D4317E /* libplatform_tests_support.a in Frameworks */,
 				56EE14CF1FE803FE0036F20C /* libtransit.a in Frameworks */,
@@ -431,7 +465,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2223F435B900A50354 /* libminizip.dylib in Frameworks */,
 				39B9681E23E1AC3700D3B8E3 /* libge0.a in Frameworks */,
 				401E3189225C988500DE7EB8 /* libdescriptions.a in Frameworks */,
 				56EE14CD1FE803EA0036F20C /* libtransit.a in Frameworks */,
@@ -457,6 +490,7 @@
 				67BC92C51D17FD5800A4A378 /* libstb_image.a in Frameworks */,
 				677E2A191CAACCB3001DC42A /* libz.tbd in Frameworks */,
 				6719DD5F1B95AB570018166F /* libtess2.a in Frameworks */,
+				4740185123F5BE6500A93C81 /* minizip.framework in Frameworks */,
 				670F887A1CE4CA9C003F68BA /* libopening_hours.a in Frameworks */,
 				674A28F21B1C8119001A525C /* libsuccinct.a in Frameworks */,
 				674A28F01B1C8104001A525C /* libsearch.a in Frameworks */,
@@ -481,7 +515,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2623F52EE900A50354 /* libminizip.dylib in Frameworks */,
 				679624CF1D11779700AE4E3C /* OpenGL.framework in Frameworks */,
 				679624CD1D11775F00AE4E3C /* libagg.a in Frameworks */,
 				679624CB1D11775F00AE4E3C /* librouting.a in Frameworks */,
@@ -493,6 +526,7 @@
 				679624C91D11775300AE4E3C /* libstb_image.a in Frameworks */,
 				679624B51D11773A00AE4E3C /* libmap.a in Frameworks */,
 				6796249F1D1013AD00AE4E3C /* libsearch_tests_support.a in Frameworks */,
+				4740184B23F5BE1B00A93C81 /* minizip.framework in Frameworks */,
 				6796247E1D10130A00AE4E3C /* libz.tbd in Frameworks */,
 				6796247D1D1012F500AE4E3C /* libopening_hours.a in Frameworks */,
 				6796247B1D1012F500AE4E3C /* libprotobuf.a in Frameworks */,
@@ -520,15 +554,14 @@
 		34F558551DBF3CD800A4FC11 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2523F52EE900A50354 /* libminizip.dylib */,
-				3D0BBC2323F52ED500A50354 /* libminizip.dylib */,
-				3D0BBC2123F435B900A50354 /* libminizip.dylib */,
 				39B9681D23E1AC3700D3B8E3 /* libge0.a */,
 				56DAC35F239915E9000BC50D /* libstorage.a */,
+				4740185023F5BE6500A93C81 /* minizip.framework */,
+				4740184D23F5BE3900A93C81 /* minizip.framework */,
+				4740184A23F5BE1B00A93C81 /* minizip.framework */,
 				671C2D8A22AFE2F7008B2B8B /* libdescriptions.a */,
 				671C2D8822AFE250008B2B8B /* libtraffic.a */,
 				401E3188225C988500DE7EB8 /* libdescriptions.a */,
-				671ED3CA20D40A8C00D4317E /* libminizip.a */,
 				671ED3C820D40A3E00D4317E /* libgenerator_tests_support.a */,
 				671ED3C620D40A2000D4317E /* libplatform_tests_support.a */,
 				56EE14D01FE803FE0036F20C /* libtransit.a */,
@@ -666,7 +699,6 @@
 				679624B71D11775300AE4E3C /* libdrape_frontend.a */,
 				679624B81D11775300AE4E3C /* libdrape.a */,
 				679624B91D11775300AE4E3C /* libfreetype.a */,
-				679624BC1D11775300AE4E3C /* libminizip.a */,
 				679624BD1D11775300AE4E3C /* libplatform_tests_support.a */,
 				679624BE1D11775300AE4E3C /* libsdf_image.a */,
 				679624BF1D11775300AE4E3C /* libstb_image.a */,
@@ -710,6 +742,7 @@
 				6726C21D1A4C2BBD005EEA39 /* Sources */,
 				6726C21F1A4C2BBD005EEA39 /* Frameworks */,
 				6726C2311A4C2BBD005EEA39 /* CopyFiles */,
+				4740181A23F5BBA500A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -744,6 +777,7 @@
 				675341541A3F54D800A0A8C3 /* Sources */,
 				675341551A3F54D800A0A8C3 /* Frameworks */,
 				675341561A3F54D800A0A8C3 /* CopyFiles */,
+				4740181723F5BB9F00A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -761,6 +795,7 @@
 				679624591D100F2500AE4E3C /* Sources */,
 				6796245A1D100F2500AE4E3C /* Frameworks */,
 				6796245B1D100F2500AE4E3C /* CopyFiles */,
+				4740181D23F5BBAA00A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/xcode/map/map.xcodeproj/project.pbxproj
+++ b/xcode/map/map.xcodeproj/project.pbxproj
@@ -26,7 +26,15 @@
 		39E3C60423312BA800FB0C37 /* features_fetcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39E3C60223312BA800FB0C37 /* features_fetcher.cpp */; };
 		3D0AEAFC1FBB0FF400AD042B /* libgenerator_tests_support.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0AEAFF1FBB0FF400AD042B /* libgenerator_tests_support.a */; };
 		3D0AEAFE1FBB0FF400AD042B /* libsearch_tests_support.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0AEB011FBB0FF400AD042B /* libsearch_tests_support.a */; };
-		3D0BBC2823F52FA500A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2723F52FA500A50354 /* libminizip.dylib */; };
+		3D0BBAE523F3EEEF00A50354 /* libweb_api.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAE423F3EEEF00A50354 /* libweb_api.a */; };
+		3D0BBAE723F3EF2700A50354 /* libvulkan_wrapper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAE623F3EF2700A50354 /* libvulkan_wrapper.a */; };
+		3D0BBAE923F3EF4B00A50354 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAE823F3EF4B00A50354 /* CoreLocation.framework */; };
+		3D0BBAEB23F3EF9D00A50354 /* libdescriptions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAEA23F3EF9D00A50354 /* libdescriptions.a */; };
+		3D0BBAED23F3EFBC00A50354 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAEC23F3EFBC00A50354 /* Security.framework */; };
+		3D0BBB9A23F3FCF700A50354 /* libweb_api.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBB9923F3FCF700A50354 /* libweb_api.a */; };
+		3D0BBB9C23F3FDAE00A50354 /* libtraffic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBB9B23F3FDAE00A50354 /* libtraffic.a */; };
+		3D0BBBA623F40F5600A50354 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAE823F3EF4B00A50354 /* CoreLocation.framework */; };
+		3D0BBBA723F40F6500A50354 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBAEC23F3EFBC00A50354 /* Security.framework */; };
 		3D0D2F7323D854AA00945C8D /* tips_api_delegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D0D2F7123D854AA00945C8D /* tips_api_delegate.cpp */; };
 		3D0D2F7423D854AA00945C8D /* tips_api_delegate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D0D2F7223D854AA00945C8D /* tips_api_delegate.hpp */; };
 		3D1775A42317E2FD00F8889C /* promo_catalog_poi_checker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D1775A22317E2FD00F8889C /* promo_catalog_poi_checker.hpp */; };
@@ -135,6 +143,8 @@
 		45F6EE9E1FB1C77600019892 /* mwm_tree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 45F6EE9B1FB1C77500019892 /* mwm_tree.hpp */; };
 		45F6EE9F1FB1C77600019892 /* search_api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45F6EE9C1FB1C77500019892 /* search_api.cpp */; };
 		470015E4234246AE00EBF03D /* bookmark_catalog.hpp in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4564FA80209497A60043CCFB /* bookmark_catalog.hpp */; };
+		4740185423F5BE8A00A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185323F5BE8A00A93C81 /* minizip.framework */; };
+		4740185523F5BE8B00A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185323F5BE8A00A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		475BD61B211C5FDC00E298C6 /* libshaders.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 475BD61A211C5FDC00E298C6 /* libshaders.a */; };
 		47A9D82220A19E9E00E4671B /* libopen_location_code.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 47A9D82120A19E9E00E4671B /* libopen_location_code.a */; };
 		47A9D82420A19EC300E4671B /* libkml.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 47A9D82320A19EC300E4671B /* libkml.a */; };
@@ -261,6 +271,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4740182223F5BBC900A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740185523F5BE8B00A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		674A29DD1B26FD1C001A525C /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,7 +316,14 @@
 		3D0AEAFF1FBB0FF400AD042B /* libgenerator_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgenerator_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0AEB001FBB0FF400AD042B /* libindexer_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libindexer_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0AEB011FBB0FF400AD042B /* libsearch_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libsearch_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2723F52FA500A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBAE423F3EEEF00A50354 /* libweb_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libweb_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBAE623F3EF2700A50354 /* libvulkan_wrapper.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libvulkan_wrapper.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBAE823F3EF4B00A50354 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		3D0BBAEA23F3EF9D00A50354 /* libdescriptions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libdescriptions.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBAEC23F3EFBC00A50354 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		3D0BBB9723F3F45F00A50354 /* libindexer_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libindexer_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBB9923F3FCF700A50354 /* libweb_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libweb_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBB9B23F3FDAE00A50354 /* libtraffic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtraffic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0D2F7123D854AA00945C8D /* tips_api_delegate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tips_api_delegate.cpp; sourceTree = "<group>"; };
 		3D0D2F7223D854AA00945C8D /* tips_api_delegate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tips_api_delegate.hpp; sourceTree = "<group>"; };
 		3D1775A22317E2FD00F8889C /* promo_catalog_poi_checker.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = promo_catalog_poi_checker.hpp; sourceTree = "<group>"; };
@@ -404,6 +432,7 @@
 		45F6EE9A1FB1C77500019892 /* search_api.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = search_api.hpp; sourceTree = "<group>"; };
 		45F6EE9B1FB1C77500019892 /* mwm_tree.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mwm_tree.hpp; sourceTree = "<group>"; };
 		45F6EE9C1FB1C77500019892 /* search_api.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = search_api.cpp; sourceTree = "<group>"; };
+		4740185323F5BE8A00A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		475BD61A211C5FDC00E298C6 /* libshaders.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libshaders.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		47A9D82120A19E9E00E4671B /* libopen_location_code.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libopen_location_code.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		47A9D82320A19EC300E4671B /* libkml.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libkml.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -485,7 +514,6 @@
 		679624A51D1017C200AE4E3C /* mwm_set_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mwm_set_test.cpp; sourceTree = "<group>"; };
 		67F183741BD5041700AB1840 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		67F1837D1BD5049500AB1840 /* libagg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libagg.a; path = "../../../omim-xcode-build/Debug/libagg.a"; sourceTree = "<group>"; };
-		67F1837F1BD5049500AB1840 /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		67F183801BD5049500AB1840 /* libtess2.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtess2.a; path = "../../../omim-xcode-build/Debug/libtess2.a"; sourceTree = "<group>"; };
 		67F183851BD504ED00AB1840 /* libsystem_configuration.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsystem_configuration.tbd; path = usr/lib/system/libsystem_configuration.tbd; sourceTree = SDKROOT; };
 		67F183871BD5050900AB1840 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -575,12 +603,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2823F52FA500A50354 /* libminizip.dylib in Frameworks */,
 				39B9682423E1AC7400D3B8E3 /* libge0.a in Frameworks */,
 				56DAC37423992505000BC50D /* Security.framework in Frameworks */,
 				56DAC37223992491000BC50D /* libweb_api.a in Frameworks */,
 				56DAC3702399248B000BC50D /* libdescriptions.a in Frameworks */,
 				56DAC36E23992467000BC50D /* libvulkan_wrapper.a in Frameworks */,
+				3D0BBAED23F3EFBC00A50354 /* Security.framework in Frameworks */,
+				3D0BBAEB23F3EF9D00A50354 /* libdescriptions.a in Frameworks */,
+				3D0BBAE923F3EF4B00A50354 /* CoreLocation.framework in Frameworks */,
+				3D0BBAE723F3EF2700A50354 /* libvulkan_wrapper.a in Frameworks */,
+				3D0BBAE523F3EEEF00A50354 /* libweb_api.a in Frameworks */,
 				3DD122BB2135708900EDFB53 /* libmetrics_tests_support.a in Frameworks */,
 				3DD122BD2135708900EDFB53 /* libmetrics.a in Frameworks */,
 				475BD61B211C5FDC00E298C6 /* libshaders.a in Frameworks */,
@@ -621,6 +653,7 @@
 				674A2A1B1B26FE62001A525C /* libindexer.a in Frameworks */,
 				674A2A1C1B26FE62001A525C /* libjansson.a in Frameworks */,
 				674A2A1D1B26FE62001A525C /* libopening_hours.a in Frameworks */,
+				4740185423F5BE8A00A93C81 /* minizip.framework in Frameworks */,
 				674A2A1E1B26FE62001A525C /* libosrm.a in Frameworks */,
 				674A2A1F1B26FE62001A525C /* libplatform.a in Frameworks */,
 				674A2A201B26FE62001A525C /* libprotobuf.a in Frameworks */,
@@ -644,13 +677,21 @@
 		34DDA17E1DBE5DF40088A609 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2723F52FA500A50354 /* libminizip.dylib */,
 				39B9682323E1AC7400D3B8E3 /* libge0.a */,
 				56DAC37523992556000BC50D /* libtraffic.a */,
 				56DAC37323992504000BC50D /* Security.framework */,
 				56DAC37123992491000BC50D /* libweb_api.a */,
 				56DAC36F2399248B000BC50D /* libdescriptions.a */,
 				56DAC36D23992467000BC50D /* libvulkan_wrapper.a */,
+				4740185323F5BE8A00A93C81 /* minizip.framework */,
+				3D0BBB9B23F3FDAE00A50354 /* libtraffic.a */,
+				3D0BBB9923F3FCF700A50354 /* libweb_api.a */,
+				3D0BBB9723F3F45F00A50354 /* libindexer_tests_support.a */,
+				3D0BBAEC23F3EFBC00A50354 /* Security.framework */,
+				3D0BBAEA23F3EF9D00A50354 /* libdescriptions.a */,
+				3D0BBAE823F3EF4B00A50354 /* CoreLocation.framework */,
+				3D0BBAE623F3EF2700A50354 /* libvulkan_wrapper.a */,
+				3D0BBAE423F3EEEF00A50354 /* libweb_api.a */,
 				3DD122BA2135708900EDFB53 /* libmetrics_tests_support.a */,
 				3DD122BC2135708900EDFB53 /* libmetrics.a */,
 				3D4F457D21354F720005E765 /* libeye_tests_support.a */,
@@ -791,7 +832,6 @@
 				67F183871BD5050900AB1840 /* SystemConfiguration.framework */,
 				67F183851BD504ED00AB1840 /* libsystem_configuration.tbd */,
 				67F1837D1BD5049500AB1840 /* libagg.a */,
-				67F1837F1BD5049500AB1840 /* libminizip.a */,
 				67F183801BD5049500AB1840 /* libtess2.a */,
 				67F183741BD5041700AB1840 /* libz.tbd */,
 				674A2A321B26FFE9001A525C /* OpenGL.framework */,
@@ -1100,6 +1140,7 @@
 				674A29DB1B26FD1C001A525C /* Sources */,
 				674A29DC1B26FD1C001A525C /* Frameworks */,
 				674A29DD1B26FD1C001A525C /* CopyFiles */,
+				4740182223F5BBC900A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1322,6 +1363,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.map_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1335,6 +1377,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.map_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1435,6 +1478,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.map_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/xcode/mapshot/mapshot.xcodeproj/project.pbxproj
+++ b/xcode/mapshot/mapshot.xcodeproj/project.pbxproj
@@ -13,9 +13,12 @@
 		346B76D71DC1ED5D00C7C87E /* liboauthcpp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 346B76D61DC1ED5D00C7C87E /* liboauthcpp.a */; };
 		346B76D91DC1ED7A00C7C87E /* libtracking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 346B76D81DC1ED7A00C7C87E /* libtracking.a */; };
 		39B9682823E1AC9900D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9682723E1AC9900D3B8E3 /* libge0.a */; };
-		3D0BBC2A23F52FEB00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2923F52FEB00A50354 /* libminizip.dylib */; };
+		3D0BBBA323F3FF4600A50354 /* libprotobuf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBBA223F3FF4600A50354 /* libprotobuf.a */; };
+		3D0BBBA523F3FF6700A50354 /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBBA423F3FF6700A50354 /* libfreetype.a */; };
 		453FEE221F35E87B005C1BB4 /* libsoftware_renderer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 453FEE211F35E87B005C1BB4 /* libsoftware_renderer.a */; };
 		453FEE241F35E8C1005C1BB4 /* libagg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 453FEE231F35E8C1005C1BB4 /* libagg.a */; };
+		4740185723F5BEA000A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185623F5BEA000A93C81 /* minizip.framework */; };
+		4740185823F5BEA000A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185623F5BEA000A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		675D213D1BFB717400717E4F /* mapshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675D213C1BFB717400717E4F /* mapshot.cpp */; };
 		675D21411BFB76B000717E4F /* libbase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675D213E1BFB76B000717E4F /* libbase.a */; };
 		675D21431BFB76B000717E4F /* libmap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675D21401BFB76B000717E4F /* libmap.a */; };
@@ -48,6 +51,17 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		4740182723F5BBE500A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740185823F5BEA000A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		675D212F1BFB6F3D00717E4F /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -68,9 +82,11 @@
 		3475E0DF1DBF57AC004C7E69 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		3475E0E01DBF57AC004C7E69 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
 		39B9682723E1AC9900D3B8E3 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2923F52FEB00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBBA223F3FF4600A50354 /* libprotobuf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libprotobuf.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBBA423F3FF6700A50354 /* libfreetype.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libfreetype.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		453FEE211F35E87B005C1BB4 /* libsoftware_renderer.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsoftware_renderer.a; path = ../software_renderer/build/Debug/libsoftware_renderer.a; sourceTree = "<group>"; };
 		453FEE231F35E8C1005C1BB4 /* libagg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libagg.a; path = ../agg/build/Release/libagg.a; sourceTree = "<group>"; };
+		4740185623F5BEA000A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		675D21311BFB6F3D00717E4F /* mapshot */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = mapshot; sourceTree = BUILT_PRODUCTS_DIR; };
 		675D213C1BFB717400717E4F /* mapshot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mapshot.cpp; sourceTree = "<group>"; };
 		675D213E1BFB76B000717E4F /* libbase.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbase.a; path = "../../../omim-xcode-build/Debug/libbase.a"; sourceTree = "<group>"; };
@@ -95,7 +111,6 @@
 		675D21751BFB828900717E4F /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		675D21771BFB829000717E4F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		675D217A1BFB84BA00717E4F /* libgeometry.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgeometry.a; path = "../../../omim-xcode-build/Debug/libgeometry.a"; sourceTree = "<group>"; };
-		675D217B1BFB84BA00717E4F /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		675D217C1BFB84BA00717E4F /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		675D21811BFB85E800717E4F /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		675D21831BFB86F400717E4F /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
@@ -109,8 +124,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2A23F52FEB00A50354 /* libminizip.dylib in Frameworks */,
 				39B9682823E1AC9900D3B8E3 /* libge0.a in Frameworks */,
+				3D0BBBA523F3FF6700A50354 /* libfreetype.a in Frameworks */,
+				3D0BBBA323F3FF4600A50354 /* libprotobuf.a in Frameworks */,
 				453FEE241F35E8C1005C1BB4 /* libagg.a in Frameworks */,
 				453FEE221F35E87B005C1BB4 /* libsoftware_renderer.a in Frameworks */,
 				346B76D91DC1ED7A00C7C87E /* libtracking.a in Frameworks */,
@@ -144,6 +160,7 @@
 				675D21621BFB779A00717E4F /* libsearch.a in Frameworks */,
 				675D21631BFB779A00717E4F /* libstorage.a in Frameworks */,
 				675D21641BFB779A00717E4F /* libsuccinct.a in Frameworks */,
+				4740185723F5BEA000A93C81 /* minizip.framework in Frameworks */,
 				675D21411BFB76B000717E4F /* libbase.a in Frameworks */,
 				675D21431BFB76B000717E4F /* libmap.a in Frameworks */,
 			);
@@ -155,8 +172,10 @@
 		346B76CF1DC1ED0B00C7C87E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2923F52FEB00A50354 /* libminizip.dylib */,
 				39B9682723E1AC9900D3B8E3 /* libge0.a */,
+				4740185623F5BEA000A93C81 /* minizip.framework */,
+				3D0BBBA423F3FF6700A50354 /* libfreetype.a */,
+				3D0BBBA223F3FF4600A50354 /* libprotobuf.a */,
 				453FEE231F35E8C1005C1BB4 /* libagg.a */,
 				453FEE211F35E87B005C1BB4 /* libsoftware_renderer.a */,
 				346B76D81DC1ED7A00C7C87E /* libtracking.a */,
@@ -206,7 +225,6 @@
 				675D21831BFB86F400717E4F /* IOKit.framework */,
 				675D21811BFB85E800717E4F /* libz.tbd */,
 				675D217A1BFB84BA00717E4F /* libgeometry.a */,
-				675D217B1BFB84BA00717E4F /* libminizip.a */,
 				675D217C1BFB84BA00717E4F /* libopening_hours.a */,
 				675D21771BFB829000717E4F /* Cocoa.framework */,
 				675D21751BFB828900717E4F /* CoreFoundation.framework */,
@@ -243,6 +261,7 @@
 				675D212D1BFB6F3D00717E4F /* Sources */,
 				675D212E1BFB6F3D00717E4F /* Frameworks */,
 				675D212F1BFB6F3D00717E4F /* CopyFiles */,
+				4740182723F5BBE500A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/xcode/minizip/minizip.xcodeproj/project.pbxproj
+++ b/xcode/minizip/minizip.xcodeproj/project.pbxproj
@@ -7,15 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		39E0FA6023EDB52400001124 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 39E0FA5F23EDB52400001124 /* libz.tbd */; };
-		39E0FA6523EDB80E00001124 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 39E0FA6323EDB80E00001124 /* ioapi.h */; };
-		39E0FA6623EDB80E00001124 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 39E0FA6423EDB80E00001124 /* ioapi.c */; };
-		3D40DEBB23EB5E0100A0153A /* minizip.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D40DEA223EB5E0100A0153A /* minizip.hpp */; };
-		3D40DECA23EB5E0100A0153A /* minizip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DEBA23EB5E0100A0153A /* minizip.cpp */; };
-		3D40DECD23EC069300A0153A /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DECB23EC069300A0153A /* zip.c */; };
-		3D40DECE23EC069300A0153A /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D40DECC23EC069300A0153A /* zip.h */; };
-		3D40DED123EC071400A0153A /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DECF23EC071400A0153A /* unzip.c */; };
-		3D40DED223EC071400A0153A /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D40DED023EC071400A0153A /* unzip.h */; };
+		474017FF23F5B2E100A93C81 /* minizip.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D40DEA223EB5E0100A0153A /* minizip.hpp */; };
+		4740180023F5B2E500A93C81 /* minizip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DEBA23EB5E0100A0153A /* minizip.cpp */; };
+		4740180123F5B2E900A93C81 /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DECB23EC069300A0153A /* zip.c */; };
+		4740180223F5B2EC00A93C81 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D40DECF23EC071400A0153A /* unzip.c */; };
+		4740180323F5B2EE00A93C81 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 39E0FA6423EDB80E00001124 /* ioapi.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,15 +27,15 @@
 		3D40DECC23EC069300A0153A /* zip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = zip.h; path = src/zip.h; sourceTree = "<group>"; };
 		3D40DECF23EC071400A0153A /* unzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = unzip.c; path = src/unzip.c; sourceTree = "<group>"; };
 		3D40DED023EC071400A0153A /* unzip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = unzip.h; path = src/unzip.h; sourceTree = "<group>"; };
-		671F590C1B87568D0032311E /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		474017F623F5B2CE00A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		474017F923F5B2CE00A93C81 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		671F59091B87568D0032311E /* Frameworks */ = {
+		474017F323F5B2CE00A93C81 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				39E0FA6023EDB52400001124 /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,12 +51,21 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		474017F723F5B2CE00A93C81 /* minizip_framework */ = {
+			isa = PBXGroup;
+			children = (
+				474017F923F5B2CE00A93C81 /* Info.plist */,
+			);
+			path = minizip_framework;
+			sourceTree = "<group>";
+		};
 		671F59031B87568D0032311E = {
 			isa = PBXGroup;
 			children = (
 				34EBB47C1DBF525A005BE9B8 /* common-debug.xcconfig */,
 				34EBB47D1DBF525A005BE9B8 /* common-release.xcconfig */,
 				671F59131B8756990032311E /* minizip */,
+				474017F723F5B2CE00A93C81 /* minizip_framework */,
 				671F590D1B87568D0032311E /* Products */,
 				39E0FA5E23EDB52400001124 /* Frameworks */,
 			);
@@ -69,7 +74,7 @@
 		671F590D1B87568D0032311E /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				671F590C1B87568D0032311E /* libminizip.dylib */,
+				474017F623F5B2CE00A93C81 /* minizip.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -93,36 +98,34 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		671F590A1B87568D0032311E /* Headers */ = {
+		474017F123F5B2CE00A93C81 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D40DED223EC071400A0153A /* unzip.h in Headers */,
-				3D40DECE23EC069300A0153A /* zip.h in Headers */,
-				3D40DEBB23EB5E0100A0153A /* minizip.hpp in Headers */,
-				39E0FA6523EDB80E00001124 /* ioapi.h in Headers */,
+				474017FF23F5B2E100A93C81 /* minizip.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		671F590B1B87568D0032311E /* minizip */ = {
+		474017F523F5B2CE00A93C81 /* minizip */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 671F59101B87568D0032311E /* Build configuration list for PBXNativeTarget "minizip" */;
+			buildConfigurationList = 474017FE23F5B2CE00A93C81 /* Build configuration list for PBXNativeTarget "minizip" */;
 			buildPhases = (
-				671F59081B87568D0032311E /* Sources */,
-				671F59091B87568D0032311E /* Frameworks */,
-				671F590A1B87568D0032311E /* Headers */,
+				474017F123F5B2CE00A93C81 /* Headers */,
+				474017F223F5B2CE00A93C81 /* Sources */,
+				474017F323F5B2CE00A93C81 /* Frameworks */,
+				474017F423F5B2CE00A93C81 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = minizip;
-			productName = minizip;
-			productReference = 671F590C1B87568D0032311E /* libminizip.dylib */;
-			productType = "com.apple.product-type.library.static";
+			productName = minizip_ios;
+			productReference = 474017F623F5B2CE00A93C81 /* minizip.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -130,11 +133,14 @@
 		671F59041B87568D0032311E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				DefaultBuildSystemTypeForWorkspace = Latest;
 				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = maps.me;
 				TargetAttributes = {
-					671F590B1B87568D0032311E = {
-						CreatedOnToolsVersion = 6.4;
+					474017F523F5B2CE00A93C81 = {
+						CreatedOnToolsVersion = 11.3;
+						DevelopmentTeam = 8L2P6RXNG7;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -151,26 +157,246 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				671F590B1B87568D0032311E /* minizip */,
+				474017F523F5B2CE00A93C81 /* minizip */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		474017F423F5B2CE00A93C81 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
-		671F59081B87568D0032311E /* Sources */ = {
+		474017F223F5B2CE00A93C81 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D40DED123EC071400A0153A /* unzip.c in Sources */,
-				3D40DECA23EB5E0100A0153A /* minizip.cpp in Sources */,
-				39E0FA6623EDB80E00001124 /* ioapi.c in Sources */,
-				3D40DECD23EC069300A0153A /* zip.c in Sources */,
+				4740180223F5B2EC00A93C81 /* unzip.c in Sources */,
+				4740180023F5B2E500A93C81 /* minizip.cpp in Sources */,
+				4740180323F5B2EE00A93C81 /* ioapi.c in Sources */,
+				4740180123F5B2E900A93C81 /* zip.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		474017FB23F5B2CE00A93C81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 8L2P6RXNG7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = minizip_framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapswithme.minizip-ios";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		474017FC23F5B2CE00A93C81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 8L2P6RXNG7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = minizip_framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapswithme.minizip-ios";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		474017FD23F5B2CE00A93C81 /* Production Full */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 8L2P6RXNG7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = minizip_framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapswithme.minizip-ios";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Production Full";
+		};
 		671F590E1B87568D0032311E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 34EBB47C1DBF525A005BE9B8 /* common-debug.xcconfig */;
@@ -195,28 +421,6 @@
 			};
 			name = Release;
 		};
-		671F59111B87568D0032311E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				EXECUTABLE_EXTENSION = dylib;
-				EXECUTABLE_PREFIX = lib;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				MACH_O_TYPE = mh_dylib;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		671F59121B87568D0032311E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				EXECUTABLE_EXTENSION = dylib;
-				EXECUTABLE_PREFIX = lib;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				MACH_O_TYPE = mh_dylib;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
 		A8E541211F9FBCFE00A1B8FA /* Production Full */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 34EBB47D1DBF525A005BE9B8 /* common-release.xcconfig */;
@@ -229,36 +433,25 @@
 			};
 			name = "Production Full";
 		};
-		A8E541221F9FBCFE00A1B8FA /* Production Full */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				EXECUTABLE_EXTENSION = dylib;
-				EXECUTABLE_PREFIX = lib;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				MACH_O_TYPE = mh_dylib;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = "Production Full";
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		474017FE23F5B2CE00A93C81 /* Build configuration list for PBXNativeTarget "minizip" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				474017FB23F5B2CE00A93C81 /* Debug */,
+				474017FC23F5B2CE00A93C81 /* Release */,
+				474017FD23F5B2CE00A93C81 /* Production Full */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		671F59071B87568D0032311E /* Build configuration list for PBXProject "minizip" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				671F590E1B87568D0032311E /* Debug */,
 				671F590F1B87568D0032311E /* Release */,
 				A8E541211F9FBCFE00A1B8FA /* Production Full */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		671F59101B87568D0032311E /* Build configuration list for PBXNativeTarget "minizip" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				671F59111B87568D0032311E /* Debug */,
-				671F59121B87568D0032311E /* Release */,
-				A8E541221F9FBCFE00A1B8FA /* Production Full */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/xcode/minizip/minizip_framework/Info.plist
+++ b/xcode/minizip/minizip_framework/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -106,7 +106,6 @@
 		678338A11C6DE5BA00FD6263 /* libbase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675341311C58C786002CF0D9 /* libbase.a */; };
 		678338A21C6DE5BA00FD6263 /* libcoding.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675341321C58C786002CF0D9 /* libcoding.a */; };
 		678338A31C6DE5BA00FD6263 /* libjansson.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675341331C58C786002CF0D9 /* libjansson.a */; };
-		678338A41C6DE5BA00FD6263 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675341341C58C786002CF0D9 /* libminizip.a */; };
 		678338A61C6DE5BA00FD6263 /* libindexer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6753412F1C58C70C002CF0D9 /* libindexer.a */; };
 		678338A71C6DE5E300FD6263 /* libplatform_tests_support.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675340E91C58C496002CF0D9 /* libplatform_tests_support.a */; };
 		678338A81C6DE5E300FD6263 /* libplatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 675343781A3F5CF500A0A8C3 /* libplatform.a */; };
@@ -210,7 +209,6 @@
 		675341311C58C786002CF0D9 /* libbase.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbase.a; path = "../../../omim-xcode-build/Debug/libbase.a"; sourceTree = "<group>"; };
 		675341321C58C786002CF0D9 /* libcoding.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoding.a; path = "../../../omim-xcode-build/Debug/libcoding.a"; sourceTree = "<group>"; };
 		675341331C58C786002CF0D9 /* libjansson.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libjansson.a; path = "../../../omim-xcode-build/Debug/libjansson.a"; sourceTree = "<group>"; };
-		675341341C58C786002CF0D9 /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		6753413B1C58C79C002CF0D9 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		675343781A3F5CF500A0A8C3 /* libplatform.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libplatform.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		675343861A3F5D5900A0A8C3 /* apple_location_service.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = apple_location_service.mm; sourceTree = "<group>"; };
@@ -291,7 +289,6 @@
 				678338A71C6DE5E300FD6263 /* libplatform_tests_support.a in Frameworks */,
 				678338A81C6DE5E300FD6263 /* libplatform.a in Frameworks */,
 				678338A21C6DE5BA00FD6263 /* libcoding.a in Frameworks */,
-				678338A41C6DE5BA00FD6263 /* libminizip.a in Frameworks */,
 				678338A11C6DE5BA00FD6263 /* libbase.a in Frameworks */,
 				678338A61C6DE5BA00FD6263 /* libindexer.a in Frameworks */,
 				678338A31C6DE5BA00FD6263 /* libjansson.a in Frameworks */,
@@ -357,7 +354,6 @@
 				675341311C58C786002CF0D9 /* libbase.a */,
 				675341321C58C786002CF0D9 /* libcoding.a */,
 				675341331C58C786002CF0D9 /* libjansson.a */,
-				675341341C58C786002CF0D9 /* libminizip.a */,
 				6753412F1C58C70C002CF0D9 /* libindexer.a */,
 			);
 			name = libs;

--- a/xcode/qtMapsMe/qtMapsMe.xcodeproj/project.pbxproj
+++ b/xcode/qtMapsMe/qtMapsMe.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		34FFD30F1E9CEF490010AD12 /* map_widget.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 34FFD2F21E9CEEA20010AD12 /* map_widget.hpp */; };
 		34FFD3101E9CEF490010AD12 /* resources_common.qrc in Sources */ = {isa = PBXBuildFile; fileRef = 34FFD2FD1E9CEEA20010AD12 /* resources_common.qrc */; };
 		39B9682623E1AC8800D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9682523E1AC8800D3B8E3 /* libge0.a */; };
-		3D0BBC2C23F5302900A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2B23F5302900A50354 /* libminizip.dylib */; };
 		4415CD992271B1A200AA3A19 /* routing_settings_dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4415CD952271B1A200AA3A19 /* routing_settings_dialog.cpp */; };
 		4415CD9A2271B1A200AA3A19 /* screenshoter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4415CD962271B1A200AA3A19 /* screenshoter.cpp */; };
 		450703071E9E6C7100E8C029 /* local_ads_symbols.txt in Resources */ = {isa = PBXBuildFile; fileRef = 450703061E9E6C7100E8C029 /* local_ads_symbols.txt */; };
@@ -56,6 +55,8 @@
 		45B5B5A51CA422EE00D93E36 /* resources-xhdpi_dark in Resources */ = {isa = PBXBuildFile; fileRef = 45B5B5A01CA422EE00D93E36 /* resources-xhdpi_dark */; };
 		45B5B5A61CA422EE00D93E36 /* resources-xxhdpi_dark in Resources */ = {isa = PBXBuildFile; fileRef = 45B5B5A11CA422EE00D93E36 /* resources-xxhdpi_dark */; };
 		45D7ADA4210B519300160DE3 /* bookmark_dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45D7ADA2210B519300160DE3 /* bookmark_dialog.cpp */; };
+		4740186723F5BF3900A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186623F5BF3900A93C81 /* minizip.framework */; };
+		4740186823F5BF3900A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186623F5BF3900A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		670D05931B0CBD320013A7AC /* about.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 6753456D1A404CB200A0A8C3 /* about.hpp */; };
 		670D05941B0CBD320013A7AC /* info_dialog.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 675345731A404CB200A0A8C3 /* info_dialog.hpp */; };
 		670D05951B0CBD320013A7AC /* preferences_dialog.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 675345781A404CB200A0A8C3 /* preferences_dialog.hpp */; };
@@ -185,6 +186,17 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		4740184023F5BC8E00A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740186823F5BF3900A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6729A5B81A692C7D007D5872 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -251,7 +263,6 @@
 		34FFD30B1E9CEF010010AD12 /* libicu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libicu.a; path = "/Users/igrechuhin/Repo/omim/xcode/icu/../../../omim-build/xcode/Debug/libicu.a"; sourceTree = "<absolute>"; };
 		34FFD30C1E9CEF010010AD12 /* liblocal_ads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblocal_ads.a; path = "/Users/igrechuhin/Repo/omim/xcode/local_ads/../../../omim-build/xcode/Debug/liblocal_ads.a"; sourceTree = "<absolute>"; };
 		39B9682523E1AC8800D3B8E3 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2B23F5302900A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		4415CD952271B1A200AA3A19 /* routing_settings_dialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_settings_dialog.cpp; sourceTree = "<group>"; };
 		4415CD962271B1A200AA3A19 /* screenshoter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = screenshoter.cpp; sourceTree = "<group>"; };
 		4415CD972271B1A200AA3A19 /* routing_settings_dialog.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_settings_dialog.hpp; sourceTree = "<group>"; };
@@ -287,6 +298,7 @@
 		45B5B5A11CA422EE00D93E36 /* resources-xxhdpi_dark */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "resources-xxhdpi_dark"; sourceTree = "<group>"; };
 		45D7ADA2210B519300160DE3 /* bookmark_dialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bookmark_dialog.cpp; sourceTree = "<group>"; };
 		45D7ADA3210B519300160DE3 /* bookmark_dialog.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bookmark_dialog.hpp; sourceTree = "<group>"; };
+		4740186623F5BF3900A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		671182F41C80E09A00CB8177 /* colors.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = colors.txt; sourceTree = "<group>"; };
 		671182F51C80E09A00CB8177 /* patterns.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = patterns.txt; sourceTree = "<group>"; };
 		6714E5DE1BD13F67008AB603 /* drules_proto_clear.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = drules_proto_clear.bin; sourceTree = "<group>"; };
@@ -296,7 +308,6 @@
 		671E78E41E6A4E1A00B2859B /* librouting_common.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = librouting_common.a; path = "/Users/darkserj/mapsme/omim/xcode/routing_common/../../../omim-build/xcode/Debug/librouting_common.a"; sourceTree = "<absolute>"; };
 		671E79211E6A508600B2859B /* libopenlr.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopenlr.a; path = "/Users/darkserj/mapsme/omim/xcode/openlr/../../../omim-build/xcode/Debug/libopenlr.a"; sourceTree = "<absolute>"; };
 		671F59011B8755FE0032311E /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
-		671F592F1B8759460032311E /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		672292B01DE307DC005BA3A7 /* libtraffic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtraffic.a; path = "../../../omim-build/xcode/Debug/libtraffic.a"; sourceTree = "<group>"; };
 		6729A5B91A693013007D5872 /* categories.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = categories.txt; sourceTree = "<group>"; };
 		6729A5BA1A693013007D5872 /* classificator.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = classificator.txt; sourceTree = "<group>"; };
@@ -381,7 +392,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2C23F5302900A50354 /* libminizip.dylib in Frameworks */,
 				39B9682623E1AC8800D3B8E3 /* libge0.a in Frameworks */,
 				675B562020D15BEF00A521D2 /* libkml.a in Frameworks */,
 				675B561E20D15BC300A521D2 /* libopen_location_code.a in Frameworks */,
@@ -429,6 +439,7 @@
 				67534C421A4097D000A0A8C3 /* OpenGL.framework in Frameworks */,
 				675345A81A40535E00A0A8C3 /* Cocoa.framework in Frameworks */,
 				675345A61A40534F00A0A8C3 /* CoreFoundation.framework in Frameworks */,
+				4740186723F5BF3900A93C81 /* minizip.framework in Frameworks */,
 				675345A41A40534500A0A8C3 /* IOKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -439,8 +450,8 @@
 		3475E0DC1DBF5772004C7E69 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2B23F5302900A50354 /* libminizip.dylib */,
 				39B9682523E1AC8800D3B8E3 /* libge0.a */,
+				4740186623F5BF3900A93C81 /* minizip.framework */,
 				675B561F20D15BEF00A521D2 /* libkml.a */,
 				675B561D20D15BC300A521D2 /* libopen_location_code.a */,
 				34EF6F8120246E0B00838CBC /* libtransit.a */,
@@ -457,7 +468,6 @@
 				674A7E341C0DB727003D48E1 /* libsdf_image.a */,
 				674A7E351C0DB727003D48E1 /* libstb_image.a */,
 				67E8DC911BBC1D3F0053C5BA /* libagg.a */,
-				671F592F1B8759460032311E /* libminizip.a */,
 				671F59011B8755FE0032311E /* libz.dylib */,
 				674A29901B26F0AE001A525C /* libalohalitics.a */,
 				674A29931B26F0AE001A525C /* libbase.a */,
@@ -682,6 +692,7 @@
 				675345471A404C6100A0A8C3 /* Resources */,
 				6729A5B81A692C7D007D5872 /* CopyFiles */,
 				34EF6F84202471B500838CBC /* Copy frameworks */,
+				4740184023F5BC8E00A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 				671E78E11E6A45BD00B2859B /* PBXBuildRule */,
@@ -897,6 +908,7 @@
 				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "mail.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -919,6 +931,7 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "mail.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		349D1CE01E3F589900A878FD /* restrictions_serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 349D1CDE1E3F589900A878FD /* restrictions_serialization.cpp */; };
 		349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 349D1CDF1E3F589900A878FD /* restrictions_serialization.hpp */; };
 		39B9682A23E1ACB300D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9682923E1ACB300D3B8E3 /* libge0.a */; };
-		3D0BBC2E23F5306A00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2D23F5306A00A50354 /* libminizip.dylib */; };
 		40576F761F791360000B593B /* fake_graph_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40576F751F791360000B593B /* fake_graph_test.cpp */; };
 		40576F781F7A788B000B593B /* fake_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40576F771F7A788B000B593B /* fake_vertex.hpp */; };
 		405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 405F48DB1F6AD01C005BA81A /* routing_result.hpp */; };
@@ -109,6 +108,8 @@
 		44F45B282136B069001B1618 /* speed_cameras_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44F45B272136B069001B1618 /* speed_cameras_tests.cpp */; };
 		44F4EDC723A78C2E005254C4 /* latlon_with_altitude.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44F4EDC523A78C2D005254C4 /* latlon_with_altitude.cpp */; };
 		44F4EDC823A78C2E005254C4 /* latlon_with_altitude.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 44F4EDC623A78C2E005254C4 /* latlon_with_altitude.hpp */; };
+		4740185A23F5BEE500A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185923F5BEE500A93C81 /* minizip.framework */; };
+		4740185B23F5BEE600A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185923F5BEE500A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
@@ -319,6 +320,20 @@
 		F6C3A1B621AC298F0060EEC8 /* speed_camera_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6C3A1B421AC298F0060EEC8 /* speed_camera_manager.cpp */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		4740185C23F5BEE600A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740185B23F5BEE600A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		0C08AA321DF83223004195DD /* index_graph_serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_graph_serialization.cpp; sourceTree = "<group>"; };
 		0C08AA331DF83223004195DD /* index_graph_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_graph_serialization.hpp; sourceTree = "<group>"; };
@@ -371,7 +386,6 @@
 		34F558351DBF2A2600A4FC11 /* common-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-debug.xcconfig"; path = "../common-debug.xcconfig"; sourceTree = "<group>"; };
 		34F558361DBF2A2600A4FC11 /* common-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
 		39B9682923E1ACB300D3B8E3 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2D23F5306A00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		40576F751F791360000B593B /* fake_graph_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_graph_test.cpp; sourceTree = "<group>"; };
 		40576F771F7A788B000B593B /* fake_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fake_vertex.hpp; sourceTree = "<group>"; };
 		405F48DB1F6AD01C005BA81A /* routing_result.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result.hpp; sourceTree = "<group>"; };
@@ -424,6 +438,7 @@
 		44F45B272136B069001B1618 /* speed_cameras_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_cameras_tests.cpp; sourceTree = "<group>"; };
 		44F4EDC523A78C2D005254C4 /* latlon_with_altitude.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = latlon_with_altitude.cpp; sourceTree = "<group>"; };
 		44F4EDC623A78C2E005254C4 /* latlon_with_altitude.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = latlon_with_altitude.hpp; sourceTree = "<group>"; };
+		4740185923F5BEE500A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
@@ -567,7 +582,6 @@
 		67BD35DA1C69F198003AA26F /* libexpat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexpat.a; path = "../../../omim-xcode-build/Debug/libexpat.a"; sourceTree = "<group>"; };
 		67BD35DB1C69F198003AA26F /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = "../../../omim-xcode-build/Debug/libfreetype.a"; sourceTree = "<group>"; };
 		67BD35DE1C69F198003AA26F /* libmap.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmap.a; path = "../../../omim-xcode-build/Debug/libmap.a"; sourceTree = "<group>"; };
-		67BD35DF1C69F198003AA26F /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		67BD35E01C69F198003AA26F /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		67BD35E11C69F198003AA26F /* libsdf_image.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsdf_image.a; path = "../../../omim-xcode-build/Debug/libsdf_image.a"; sourceTree = "<group>"; };
 		67BD35E21C69F198003AA26F /* libstb_image.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libstb_image.a; path = "../../../omim-xcode-build/Debug/libstb_image.a"; sourceTree = "<group>"; };
@@ -652,11 +666,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC2E23F5306A00A50354 /* libminizip.dylib in Frameworks */,
 				39B9682A23E1ACB300D3B8E3 /* libge0.a in Frameworks */,
 				56EE14DB1FE812FC0036F20C /* libtransit.a in Frameworks */,
 				567E9F811F5853370064CB96 /* libtraffic.a in Frameworks */,
 				567E9F7F1F58530D0064CB96 /* librouting_common.a in Frameworks */,
+				4740185A23F5BEE500A93C81 /* minizip.framework in Frameworks */,
 				567E9F7D1F5852C00064CB96 /* libicu.a in Frameworks */,
 				67BD35E31C69F198003AA26F /* libagg.a in Frameworks */,
 				67BD35E51C69F198003AA26F /* libdrape_frontend.a in Frameworks */,
@@ -694,8 +708,8 @@
 		56F0D7611D896DAF00045886 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2D23F5306A00A50354 /* libminizip.dylib */,
 				39B9682923E1ACB300D3B8E3 /* libge0.a */,
+				4740185923F5BEE500A93C81 /* minizip.framework */,
 				56EE14DC1FE812FC0036F20C /* libtransit.a */,
 				567E9F801F5853370064CB96 /* libtraffic.a */,
 				408B55BF1FD953F100F4E78B /* libbsdiff.a */,
@@ -780,7 +794,6 @@
 				67BD35DA1C69F198003AA26F /* libexpat.a */,
 				67BD35DB1C69F198003AA26F /* libfreetype.a */,
 				67BD35DE1C69F198003AA26F /* libmap.a */,
-				67BD35DF1C69F198003AA26F /* libminizip.a */,
 				67BD35E01C69F198003AA26F /* libopening_hours.a */,
 				67BD35E11C69F198003AA26F /* libsdf_image.a */,
 				67BD35E21C69F198003AA26F /* libstb_image.a */,
@@ -1204,6 +1217,7 @@
 				67BD35911C69F03E003AA26F /* Sources */,
 				67BD35921C69F03E003AA26F /* Frameworks */,
 				67BD35931C69F03E003AA26F /* Resources */,
+				4740185C23F5BEE600A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1552,6 +1566,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)_common/build/Debug",
@@ -1566,6 +1581,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)_common/build/Debug",
@@ -1614,6 +1630,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)_common/build/Debug",

--- a/xcode/search/search.xcodeproj/project.pbxproj
+++ b/xcode/search/search.xcodeproj/project.pbxproj
@@ -161,7 +161,8 @@
 		39BBC1401F9FD683009D1687 /* point_rect_matcher_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC13F1F9FD683009D1687 /* point_rect_matcher_tests.cpp */; };
 		39BBC1421F9FD68C009D1687 /* highlighting_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BBC1411F9FD68C009D1687 /* highlighting_tests.cpp */; };
 		3D0AEB021FBB102C00AD042B /* libgenerator_tests_support.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0AEB041FBB102C00AD042B /* libgenerator_tests_support.a */; };
-		3D0BBC3023F5309F00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC2F23F5309F00A50354 /* libminizip.dylib */; };
+		3D0BBB9F23F3FDE100A50354 /* helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D0BBB9D23F3FDE100A50354 /* helpers.hpp */; };
+		3D0BBBA023F3FDE100A50354 /* helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D0BBB9E23F3FDE100A50354 /* helpers.cpp */; };
 		3DA5722B20C1956D007BDE27 /* integration_tests_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DA5722920C1956D007BDE27 /* integration_tests_helpers.hpp */; };
 		3DFEBF761EF2D55800317D5C /* city_finder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DFEBF751EF2D55800317D5C /* city_finder.hpp */; };
 		405DB10720FF472300EE3824 /* utils_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405DB10620FF472300EE3824 /* utils_test.cpp */; };
@@ -182,6 +183,8 @@
 		45A008521FE9088400D77690 /* doc_vec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45A0084E1FE9088300D77690 /* doc_vec.cpp */; };
 		45A008531FE9088400D77690 /* idf_map.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 45A0084F1FE9088300D77690 /* idf_map.hpp */; };
 		45A008541FE9088400D77690 /* idf_map.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45A008501FE9088300D77690 /* idf_map.cpp */; };
+		4740185E23F5BEF900A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185D23F5BEF900A93C81 /* minizip.framework */; };
+		4740185F23F5BEF900A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740185D23F5BEF900A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		56D5456E1C74A48C00E3719C /* mode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56D5456C1C74A48C00E3719C /* mode.cpp */; };
 		56D5456F1C74A48C00E3719C /* mode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56D5456D1C74A48C00E3719C /* mode.hpp */; };
 		56DAC34123991253000BC50D /* helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56DAC33F23991253000BC50D /* helpers.hpp */; };
@@ -298,6 +301,17 @@
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 1;
+		};
+		4740183123F5BC2E00A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740185F23F5BEF900A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		671C620A1AE9225100076BD0 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -427,7 +441,6 @@
 		39B2B96B1FB4631400AB85A1 /* libbsdiff.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbsdiff.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		39B2B96D1FB4633200AB85A1 /* libtess2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtess2.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		39B2B9751FB4687500AB85A1 /* libgflags.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgflags.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		39B2B9841FB469ED00AB85A1 /* libminizip.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		39BBC1391F9FD65C009D1687 /* highlighting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = highlighting.cpp; sourceTree = "<group>"; };
 		39BBC13A1F9FD65C009D1687 /* highlighting.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = highlighting.hpp; sourceTree = "<group>"; };
 		39BBC13D1F9FD679009D1687 /* segment_tree_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = segment_tree_tests.cpp; sourceTree = "<group>"; };
@@ -435,7 +448,8 @@
 		39BBC1411F9FD68C009D1687 /* highlighting_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = highlighting_tests.cpp; sourceTree = "<group>"; };
 		3D0AEB041FBB102C00AD042B /* libgenerator_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgenerator_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0AEB051FBB102C00AD042B /* libindexer_tests_support.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libindexer_tests_support.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC2F23F5309F00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0BBB9D23F3FDE100A50354 /* helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = helpers.hpp; sourceTree = "<group>"; };
+		3D0BBB9E23F3FDE100A50354 /* helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = helpers.cpp; sourceTree = "<group>"; };
 		3DA5722820C1956D007BDE27 /* integration_tests_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = integration_tests_helpers.cpp; sourceTree = "<group>"; };
 		3DA5722920C1956D007BDE27 /* integration_tests_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = integration_tests_helpers.hpp; sourceTree = "<group>"; };
 		3DFEBF751EF2D55800317D5C /* city_finder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = city_finder.hpp; sourceTree = "<group>"; };
@@ -457,6 +471,7 @@
 		45A0084E1FE9088300D77690 /* doc_vec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = doc_vec.cpp; sourceTree = "<group>"; };
 		45A0084F1FE9088300D77690 /* idf_map.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = idf_map.hpp; sourceTree = "<group>"; };
 		45A008501FE9088300D77690 /* idf_map.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = idf_map.cpp; sourceTree = "<group>"; };
+		4740185D23F5BEF900A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56D5456C1C74A48C00E3719C /* mode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mode.cpp; sourceTree = "<group>"; };
 		56D5456D1C74A48C00E3719C /* mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mode.hpp; sourceTree = "<group>"; };
 		56DAC33F23991253000BC50D /* helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = helpers.hpp; sourceTree = "<group>"; };
@@ -573,7 +588,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC3023F5309F00A50354 /* libminizip.dylib in Frameworks */,
 				6715565720BF1019002BA3B4 /* libeditor_tests_support.a in Frameworks */,
 				6715565920BF1019002BA3B4 /* libopen_location_code.a in Frameworks */,
 				39AEF86C1FB45E1600943FC9 /* libz.tbd in Frameworks */,
@@ -600,6 +614,7 @@
 				39B2B9641FB462B100AB85A1 /* librouting_common.a in Frameworks */,
 				39B2B9621FB4629A00AB85A1 /* librouting.a in Frameworks */,
 				39B2B9601FB4627600AB85A1 /* libgenerator.a in Frameworks */,
+				4740185E23F5BEF900A93C81 /* minizip.framework in Frameworks */,
 				39AEF87C1FB45E1600943FC9 /* libsearch_tests_support.a in Frameworks */,
 				39B2B95C1FB4624800AB85A1 /* libgenerator_tests_support.a in Frameworks */,
 			);
@@ -678,16 +693,15 @@
 		34F558391DBF2E0E00A4FC11 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC2F23F5309F00A50354 /* libminizip.dylib */,
 				56DAC34523991309000BC50D /* libkml.a */,
 				56DAC34323991301000BC50D /* libplatform_tests_support.a */,
+				4740185D23F5BEF900A93C81 /* minizip.framework */,
 				67935E7320D14D06002996B0 /* CoreLocation.framework */,
 				6715565620BF1019002BA3B4 /* libeditor_tests_support.a */,
 				6715565820BF1019002BA3B4 /* libopen_location_code.a */,
 				1D4E79A92076190D006B7856 /* libopen_location_code.a */,
 				3D0AEB041FBB102C00AD042B /* libgenerator_tests_support.a */,
 				3D0AEB051FBB102C00AD042B /* libindexer_tests_support.a */,
-				39B2B9841FB469ED00AB85A1 /* libminizip.a */,
 				39B2B9751FB4687500AB85A1 /* libgflags.a */,
 				39B2B96D1FB4633200AB85A1 /* libtess2.a */,
 				39B2B96B1FB4631400AB85A1 /* libbsdiff.a */,
@@ -1121,6 +1135,7 @@
 				39AEF8621FB45E1600943FC9 /* Sources */,
 				39AEF86B1FB45E1600943FC9 /* Frameworks */,
 				39AEF87D1FB45E1600943FC9 /* CopyFiles */,
+				4740183123F5BC2E00A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1390,6 +1405,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_NAME = search_tests;
 			};
 			name = "Production Full";
@@ -1398,6 +1414,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.search_integration_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1407,6 +1424,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = maps.me.search_integration_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/xcode/storage/storage.xcodeproj/project.pbxproj
+++ b/xcode/storage/storage.xcodeproj/project.pbxproj
@@ -24,8 +24,6 @@
 		3971141E229D89F4003915E5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3971141D229D89F4003915E5 /* Security.framework */; };
 		39B9682223E1AC5F00D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9682123E1AC5F00D3B8E3 /* libge0.a */; };
 		39B9682B23E1AD9F00D3B8E3 /* libge0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B9682123E1AC5F00D3B8E3 /* libge0.a */; };
-		3D0BBC3223F530CC00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC3123F530CC00A50354 /* libminizip.dylib */; };
-		3D0BBC3423F530DB00A50354 /* libminizip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D0BBC3323F530DB00A50354 /* libminizip.dylib */; };
 		3D497EA123292706000FB57D /* map_files_downloader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D497E9E23292706000FB57D /* map_files_downloader.cpp */; };
 		3D497EA223292706000FB57D /* map_files_downloader_with_ping.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D497E9F23292706000FB57D /* map_files_downloader_with_ping.hpp */; };
 		3D497EA323292706000FB57D /* map_files_downloader_with_ping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D497EA023292706000FB57D /* map_files_downloader_with_ping.cpp */; };
@@ -43,6 +41,10 @@
 		402873422295A91F0036AA1C /* country_tree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4028733F2295A91E0036AA1C /* country_tree.hpp */; };
 		402873432295A91F0036AA1C /* country_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 402873402295A91F0036AA1C /* country_tree.cpp */; };
 		402873442295A91F0036AA1C /* downloader_search_params.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 402873412295A91F0036AA1C /* downloader_search_params.hpp */; };
+		4740186123F5BF0C00A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186023F5BF0C00A93C81 /* minizip.framework */; };
+		4740186223F5BF0C00A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186023F5BF0C00A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4740186423F5BF1800A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186323F5BF1800A93C81 /* minizip.framework */; };
+		4740186523F5BF1800A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186323F5BF1800A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5670EAFA1FF1150C002495D8 /* libtransit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5670EAFB1FF1150C002495D8 /* libtransit.a */; };
 		5670EAFC1FF11535002495D8 /* libmwm_diff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5670EAFD1FF11535002495D8 /* libmwm_diff.a */; };
 		5670EAFE1FF11558002495D8 /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5670EAFF1FF11558002495D8 /* libbsdiff.a */; };
@@ -193,6 +195,31 @@
 		F6BC312C2034366100F677FE /* pinger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6BC312A2034366100F677FE /* pinger.cpp */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		4740183623F5BC5200A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740186523F5BF1800A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4740183B23F5BC7100A93C81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4740186223F5BF0C00A93C81 /* minizip.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		3462FDAE1DC1E62F00906FD7 /* libgenerator_tests_support.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgenerator_tests_support.a; path = "../../../omim-build/xcode/Debug/libgenerator_tests_support.a"; sourceTree = "<group>"; };
 		3462FDB01DC1E65B00906FD7 /* libgenerator.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgenerator.a; path = "../../../omim-build/xcode/Debug/libgenerator.a"; sourceTree = "<group>"; };
@@ -211,8 +238,6 @@
 		3971141B229D8983003915E5 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		3971141D229D89F4003915E5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		39B9682123E1AC5F00D3B8E3 /* libge0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libge0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC3123F530CC00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D0BBC3323F530DB00A50354 /* libminizip.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libminizip.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D497E9E23292706000FB57D /* map_files_downloader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = map_files_downloader.cpp; sourceTree = "<group>"; };
 		3D497E9F23292706000FB57D /* map_files_downloader_with_ping.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = map_files_downloader_with_ping.hpp; sourceTree = "<group>"; };
 		3D497EA023292706000FB57D /* map_files_downloader_with_ping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = map_files_downloader_with_ping.cpp; sourceTree = "<group>"; };
@@ -231,6 +256,8 @@
 		402873402295A91F0036AA1C /* country_tree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = country_tree.cpp; sourceTree = "<group>"; };
 		402873412295A91F0036AA1C /* downloader_search_params.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = downloader_search_params.hpp; sourceTree = "<group>"; };
 		4069AD9F21495A5A005EB75C /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = categories_cuisines.txt; sourceTree = "<group>"; };
+		4740186023F5BF0C00A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4740186323F5BF1800A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5670EAFB1FF1150C002495D8 /* libtransit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtransit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5670EAFD1FF11535002495D8 /* libmwm_diff.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libmwm_diff.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5670EAFF1FF11558002495D8 /* libbsdiff.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbsdiff.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -285,7 +312,6 @@
 		674709AF1C6215690093DD1B /* libagg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libagg.a; path = "../../../omim-xcode-build/Debug/libagg.a"; sourceTree = "<group>"; };
 		674709B11C6215690093DD1B /* libeditor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libeditor.a; path = "../../../omim-xcode-build/Debug/libeditor.a"; sourceTree = "<group>"; };
 		674709B21C6215690093DD1B /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = "../../../omim-xcode-build/Debug/libfreetype.a"; sourceTree = "<group>"; };
-		674709B51C6215690093DD1B /* libminizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libminizip.a; path = "../../../omim-xcode-build/Debug/libminizip.a"; sourceTree = "<group>"; };
 		674709B61C6215690093DD1B /* liboauthcpp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liboauthcpp.a; path = "../../../omim-xcode-build/Debug/liboauthcpp.a"; sourceTree = "<group>"; };
 		674709B71C6215690093DD1B /* libopening_hours.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libopening_hours.a; path = "../../../omim-xcode-build/Debug/libopening_hours.a"; sourceTree = "<group>"; };
 		674709B91C6215690093DD1B /* libprotobuf.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libprotobuf.a; path = "../../../omim-xcode-build/Debug/libprotobuf.a"; sourceTree = "<group>"; };
@@ -355,10 +381,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC3423F530DB00A50354 /* libminizip.dylib in Frameworks */,
 				3971141E229D89F4003915E5 /* Security.framework in Frameworks */,
 				3971141C229D8983003915E5 /* CoreLocation.framework in Frameworks */,
 				56EE14E11FE813FC0036F20C /* libbsdiff.a in Frameworks */,
+				4740186423F5BF1800A93C81 /* minizip.framework in Frameworks */,
 				56EE14DF1FE813D00036F20C /* libmwm_diff.a in Frameworks */,
 				F66D569A1EAE36510081E883 /* librouting_common.a in Frameworks */,
 				F66D56981EAE36280081E883 /* libicu.a in Frameworks */,
@@ -399,7 +425,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0BBC3223F530CC00A50354 /* libminizip.dylib in Frameworks */,
 				39B9682223E1AC5F00D3B8E3 /* libge0.a in Frameworks */,
 				56DAC38D23992FB1000BC50D /* Security.framework in Frameworks */,
 				56DAC38C23992F8C000BC50D /* libvulkan_wrapper.a in Frameworks */,
@@ -422,6 +447,7 @@
 				67F90BF21C6A2AAB00CD458E /* libstorage.a in Frameworks */,
 				67F90BEC1C6A2A3000CD458E /* libindexer.a in Frameworks */,
 				67F90BE71C6A2A3000CD458E /* libmap.a in Frameworks */,
+				4740186123F5BF0C00A93C81 /* minizip.framework in Frameworks */,
 				67F90BE31C6A2A3000CD458E /* libdrape_frontend.a in Frameworks */,
 				67F90BD51C6A2A3000CD458E /* libeditor.a in Frameworks */,
 				67F90BDB1C6A2A3000CD458E /* libopening_hours.a in Frameworks */,
@@ -454,12 +480,12 @@
 		34F5584C1DBF327C00A4FC11 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3D0BBC3323F530DB00A50354 /* libminizip.dylib */,
-				3D0BBC3123F530CC00A50354 /* libminizip.dylib */,
 				39B9682123E1AC5F00D3B8E3 /* libge0.a */,
 				56DAC38B23992F8C000BC50D /* libvulkan_wrapper.a */,
 				56DAC38923992F84000BC50D /* libweb_api.a */,
 				56DAC38723992F7F000BC50D /* libdescriptions.a */,
+				4740186323F5BF1800A93C81 /* minizip.framework */,
+				4740186023F5BF0C00A93C81 /* minizip.framework */,
 				3971141D229D89F4003915E5 /* Security.framework */,
 				3971141B229D8983003915E5 /* CoreLocation.framework */,
 				39711419229D7F75003915E5 /* libMopub.a */,
@@ -517,7 +543,6 @@
 				674709AF1C6215690093DD1B /* libagg.a */,
 				674709B11C6215690093DD1B /* libeditor.a */,
 				674709B21C6215690093DD1B /* libfreetype.a */,
-				674709B51C6215690093DD1B /* libminizip.a */,
 				674709B61C6215690093DD1B /* liboauthcpp.a */,
 				674709B71C6215690093DD1B /* libopening_hours.a */,
 				674709B91C6215690093DD1B /* libprotobuf.a */,
@@ -728,6 +753,7 @@
 				67F90B541C6A275B00CD458E /* Sources */,
 				67F90B551C6A275B00CD458E /* Frameworks */,
 				67F90B561C6A275B00CD458E /* Resources */,
+				4740183623F5BC5200A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -745,6 +771,7 @@
 				67F90BB21C6A29F700CD458E /* Sources */,
 				67F90BB31C6A29F700CD458E /* Frameworks */,
 				67F90BB41C6A29F700CD458E /* Resources */,
+				4740183B23F5BC7100A93C81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -963,6 +990,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "storage-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -977,6 +1005,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "storage-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -991,6 +1020,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = storage_integration_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1005,6 +1035,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = storage_integration_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1040,6 +1071,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "storage-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1054,6 +1086,7 @@
 					"OMIM_UNIT_TEST_WITH_QT_EVENT_LOOP=1",
 				);
 				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = storage_integration_tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
It crashed minizip lib was missing. Looks like xcode cant link to custom dylibs, so I changed framework type from .dylib to .framework
https://jira.mail.ru/browse/MAPSME-13161