### PR TITLE
[routing] add IsSerializable method

### DIFF
--- a/routing/opening_hours_serdes.cpp
+++ b/routing/opening_hours_serdes.cpp
@@ -1,5 +1,7 @@
 #include "routing/opening_hours_serdes.hpp"
 
+#include "coding/writer.hpp"
+
 #include "base/assert.hpp"
 #include "base/scope_guard.hpp"
 #include "base/stl_helpers.hpp"
@@ -338,5 +340,15 @@ bool OpeningHoursSerDes::IsTwentyFourHourRule(osmoh::RuleSequence const & rule) 
          rule.GetMonths().empty() && rule.GetTimes().size() == 1 &&
          rule.GetTimes().back().GetStart() == kTwentyFourHourStart &&
          rule.GetTimes().back().GetEnd() == kTwentyFourHourEnd;
+}
+
+
+bool OpeningHoursSerDes::IsSerializable(osmoh::OpeningHours const & openingHours)
+{
+  std::vector<uint8_t> buffer;
+  MemWriter memWriter(buffer);
+  BitWriter tmpBitWriter(memWriter);
+
+  return SerializeImpl(tmpBitWriter, openingHours);
 }
 }  // namespace routing


### PR DESCRIPTION
Текущий сериалайзер в случае фейла, оставляет writer в неконсистентном состоянии. Добавил ф-ию IsSerializable, которая сериализует в память и возвращает результат.
Почему я не сериализую вначале в память: потому что чтобы скопировать потом результат, придется делать Flush() на bitWriter, чего делать нельзя (образуются пустоты из нулей).  Ничего умнее сериализации дважды не придумал