### PR TITLE
[generator_integration_tests] Print all changed counters before fail on TEST macros.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -74,7 +74,40 @@ struct CountryFeaturesCounters
            m_poi == rhs.m_poi && m_cityTownOrVillage == rhs.m_cityTownOrVillage &&
            m_bookingHotels == rhs.m_bookingHotels;
   }
+
+  bool operator!=(CountryFeaturesCounters const & rhs) const { return !(*this == rhs); }
 };
+
+struct CountryFeatureResults
+{
+  CountryFeatureResults() = default;
+  CountryFeatureResults(CountryFeaturesCounters actual, CountryFeaturesCounters expected)
+    : m_actual(actual), m_expected(expected)
+  {
+  }
+
+  CountryFeaturesCounters m_actual;
+  CountryFeaturesCounters m_expected;
+};
+
+void TestAndLogCountryFeatures(std::map<std::string, CountryFeatureResults> const & results)
+{
+  for (auto const & result : results)
+  {
+    if (result.second.m_actual != result.second.m_expected)
+    {
+      LOG(LINFO, ("Unexpectad result for", result.first, "actual:", result.second.m_actual,
+                  "expected:", result.second.m_expected,
+                  "the difference is:", result.second.m_actual - result.second.m_expected));
+    }
+  }
+
+  for (auto const & result : results)
+  {
+    TEST_EQUAL(result.second.m_actual, result.second.m_expected,
+               (result.first, "difference:", result.second.m_actual - result.second.m_expected));
+  }
+}
 
 std::string DebugPrint(CountryFeaturesCounters const & cnt)
 {
@@ -198,7 +231,8 @@ public:
 
     TEST(Platform::IsFileExistsByFullPath(world), ());
 
-    TestCountry(world, kWorldCounters);
+    auto const actual = GetCountersForCountry(world);
+    TEST_EQUAL(actual, kWorldCounters, ("kWorldCounters difference:", actual - kWorldCounters));
   }
 
   void BuildCountries()
@@ -220,10 +254,16 @@ public:
     rawGenerator.GenerateCountries();
     TEST(rawGenerator.Execute(), ());
 
-    TestCountry(northAuckland, kNorthAucklandCounters);
-    TestCountry(northWellington, kNorthWellingtonCounters);
-    TestCountry(southCanterbury, kSouthCanterburyCounters);
-    TestCountry(southSouthland, kSouthSouthlandCounters);
+    std::map<std::string, CountryFeatureResults> results;
+    results["kNorthAucklandCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northAuckland), kNorthAucklandCounters);
+    results["kNorthWellingtonCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northWellington), kNorthWellingtonCounters);
+    results["kSouthCanterburyCounters"] =
+        CountryFeatureResults(GetCountersForCountry(southCanterbury), kSouthCanterburyCounters);
+    results["kSouthSouthlandCounters"] =
+        CountryFeatureResults(GetCountersForCountry(southSouthland), kSouthSouthlandCounters);
+    TestAndLogCountryFeatures(results);
   }
 
   void BuildCountriesWithComplex()
@@ -246,10 +286,20 @@ public:
     rawGenerator.GenerateCountries();
     TEST(rawGenerator.Execute(), ());
 
-    TestCountry(northAuckland, kNorthAucklandCounters + kNorthAucklandComplexFeaturesCounters);
-    TestCountry(northWellington, kNorthWellingtonCounters + kNorthWellingtonComplexFeaturesCounters);
-    TestCountry(southCanterbury, kSouthCanterburyCounters + kSouthCanterburyComplexFeaturesCounters);
-    TestCountry(southSouthland, kSouthSouthlandCounters + kSouthSouthlandComplexFeaturesCounters);
+    std::map<std::string, CountryFeatureResults> results;
+    results["kNorthAucklandCounters + kNorthAucklandComplexFeaturesCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northAuckland),
+                              kNorthAucklandCounters + kNorthAucklandComplexFeaturesCounters);
+    results["kNorthWellingtonCounters + kNorthWellingtonComplexFeaturesCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northWellington),
+                              kNorthWellingtonCounters + kNorthWellingtonComplexFeaturesCounters);
+    results["kSouthCanterburyCounters + kSouthCanterburyComplexFeaturesCounters"] =
+        CountryFeatureResults(GetCountersForCountry(southCanterbury),
+                              kSouthCanterburyCounters + kSouthCanterburyComplexFeaturesCounters);
+    results["kSouthSouthlandCounters + kSouthSouthlandComplexFeaturesCounters"] =
+        CountryFeatureResults(GetCountersForCountry(southSouthland),
+                              kSouthSouthlandCounters + kSouthSouthlandComplexFeaturesCounters);
+    TestAndLogCountryFeatures(results);
   }
 
   void CheckMixedTagsAndNodes()
@@ -274,22 +324,28 @@ public:
     rawGenerator.GenerateWorld(true /* needMixTags */);
     TEST(rawGenerator.Execute(), ());
 
-    TestCountry(northAuckland, kNorthAucklandCounters);
-    TestCountry(northWellington, kNorthWellingtonCounters);
-    TestCountry(southCanterbury, kSouthCanterburyCounters);
-
     size_t partner1CntReal = 0;
 
-    TestCountry(southSouthland, kSouthSouthlandCounters + kSouthSouthlandMixedNodesCounters,
-                [&](auto const & fb) {
-                  static auto const partner1 = classif().GetTypeByPath({"sponsored", "partner1"});
-                  if (fb.HasType(partner1))
-                    ++partner1CntReal;
-                });
+    std::map<std::string, CountryFeatureResults> results;
+    results["kNorthAucklandCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northAuckland), kNorthAucklandCounters);
+    results["kNorthWellingtonCounters"] =
+        CountryFeatureResults(GetCountersForCountry(northWellington), kNorthWellingtonCounters);
+    results["kSouthCanterburyCounters"] =
+        CountryFeatureResults(GetCountersForCountry(southCanterbury), kSouthCanterburyCounters);
+    results["kSouthSouthlandCounters + kSouthSouthlandMixedNodesCounters"] = CountryFeatureResults(
+        GetCountersForCountry(
+            southSouthland,
+            [&](auto const & fb) {
+              static auto const partner1 = classif().GetTypeByPath({"sponsored", "partner1"});
+              if (fb.HasType(partner1))
+                ++partner1CntReal;
+            }),
+        kSouthSouthlandCounters + kSouthSouthlandMixedNodesCounters);
+    results["kWorldCounters"] = CountryFeatureResults(GetCountersForCountry(world), kWorldCounters);
 
+    TestAndLogCountryFeatures(results);
     TEST_EQUAL(partner1CntReal, 4, ());
-
-    TestCountry(world, kWorldCounters);
   }
 
   void CheckGeneratedData()
@@ -344,10 +400,9 @@ public:
   }
 
 private:
-  void TestCountry(
-      std::string const & path, CountryFeaturesCounters const & expected,
-      std::function<void(feature::FeatureBuilder const &)> const & fn =
-          [](feature::FeatureBuilder const &) {})
+  CountryFeaturesCounters GetCountersForCountry(
+      std::string const & path, std::function<void(feature::FeatureBuilder const &)> const & fn =
+                                    [](feature::FeatureBuilder const &) {})
   {
     CHECK(Platform::IsFileExistsByFullPath(path), ());
     auto const fbs = feature::ReadAllDatRawFormat(path);
@@ -377,7 +432,7 @@ private:
       fn(fb);
     }
 
-    TEST_EQUAL(actual, expected, ("The difference is:", actual - expected));
+    return actual;
   }
 
   void TestGeneratedFile(std::string const & path, size_t fileSize)


### PR DESCRIPTION
Сейчас при запуске generator_integration_tests если в тестах countries что-то пофейлилось, то мы падаем на 1-й ошибке и остальные не видим -- это не удобно надо или несколько раз править и перезапускать или менять TEST на LOG.

В реквесте функция сначала пишет все фейлы, а потом только падает на TEST. 
Пример вывода:
```
Final processing is finished.
Unexpectad result for kNorthAucklandCounters actual: CountryFeaturesCount(fbs = 1812099, geometryPoints = 12196602, point = 1007482, line = 205502, area = 599115, poi = 212466, cityTownOrVillage = 521, bookingHotels = 3557) expected: CountryFeaturesCount(fbs = 1811974, geometryPoints = 12194844, point = 1007482, line = 205377, area = 599115, poi = 212341, cityTownOrVillage = 521, bookingHotels = 3557) the difference is: CountryFeaturesCount(fbs = 125, geometryPoints = 1758, point = 0, line = 125, area = 0, poi = 125, cityTownOrVillage = 0, bookingHotels = 0)
Unexpectad result for kNorthWellingtonCounters actual: CountryFeaturesCount(fbs = 797745, geometryPoints = 7771644, point = 460522, line = 86947, area = 250276, poi = 95829, cityTownOrVillage = 297, bookingHotels = 1062) expected: CountryFeaturesCount(fbs = 797735, geometryPoints = 7771504, point = 460522, line = 86937, area = 250276, poi = 95819, cityTownOrVillage = 297, bookingHotels = 1062) the difference is: CountryFeaturesCount(fbs = 10, geometryPoints = 140, point = 0, line = 10, area = 0, poi = 10, cityTownOrVillage = 0, bookingHotels = 0)
Unexpectad result for kSouthCanterburyCounters actual: CountryFeaturesCount(fbs = 637194, geometryPoints = 6984528, point = 397947, line = 81661, area = 157586, poi = 89630, cityTownOrVillage = 331, bookingHotels = 2085) expected: CountryFeaturesCount(fbs = 637099, geometryPoints = 6983176, point = 397947, line = 81566, area = 157586, poi = 89535, cityTownOrVillage = 331, bookingHotels = 2085) the difference is: CountryFeaturesCount(fbs = 95, geometryPoints = 1352, point = 0, line = 95, area = 0, poi = 95, cityTownOrVillage = 0, bookingHotels = 0)
Unexpectad result for kSouthSouthlandCounters actual: CountryFeaturesCount(fbs = 340612, geometryPoints = 5342351, point = 185986, line = 40100, area = 114526, poi = 40650, cityTownOrVillage = 297, bookingHotels = 1621) expected: CountryFeaturesCount(fbs = 340609, geometryPoints = 5342304, point = 185986, line = 40097, area = 114526, poi = 40647, cityTownOrVillage = 297, bookingHotels = 1621) the difference is: CountryFeaturesCount(fbs = 3, geometryPoints = 47, point = 0, line = 3, area = 0, poi = 3, cityTownOrVillage = 0, bookingHotels = 0)
FAILED
generator_integration_tests/features_tests.cpp:113 TEST(result.second.m_actual == result.second.m_expected) CountryFeaturesCount(fbs = 1812099, geometryPoints = 12196602, point = 1007482, line = 205502, area = 599115, poi = 212466, cityTownOrVillage = 521, bookingHotels = 3557) CountryFeaturesCount(fbs = 1811974, geometryPoints = 12194844, point = 1007482, line = 205377, area = 599115, poi = 212341, cityTownOrVillage = 521, bookingHotels = 3557) kNorthAucklandCounters difference: CountryFeaturesCount(fbs = 125, geometryPoints = 1758, point = 0, line = 125, area = 0, poi = 125, cityTownOrVillage = 0, bookingHotels = 0)
Test took 160766 ms
```