### PR TITLE
[core] Return current states from isolines, traffic and transit manag…

### DIFF
--- a/map/isolines_manager.cpp
+++ b/map/isolines_manager.cpp
@@ -21,6 +21,11 @@ IsolinesManager::IsolinesManager(DataSource & dataSource, GetMwmsByRectFn const 
   CHECK(m_getMwmsByRectFn != nullptr, ());
 }
 
+IsolinesManager::IsolinesState IsolinesManager::GetState() const
+{
+  return m_state;
+}
+
 void IsolinesManager::SetStateListener(IsolinesStateChangedFn const & onStateChangedFn)
 {
   m_onStateChangedFn = onStateChangedFn;

--- a/map/isolines_manager.hpp
+++ b/map/isolines_manager.hpp
@@ -33,7 +33,9 @@ public:
 
   IsolinesManager(DataSource & dataSource, GetMwmsByRectFn const & getMwmsByRectFn);
 
+  IsolinesState GetState() const;
   void SetStateListener(IsolinesStateChangedFn const & onStateChangedFn);
+
   void SetDrapeEngine(ref_ptr<df::DrapeEngine> engine);
 
   void SetEnabled(bool enabled);

--- a/map/traffic_manager.cpp
+++ b/map/traffic_manager.cpp
@@ -79,12 +79,14 @@ void TrafficManager::Teardown()
   m_thread.join();
 }
 
+TrafficManager::TrafficState TrafficManager::GetState() const
+{
+  return m_state;
+}
+
 void TrafficManager::SetStateListener(TrafficStateChangedFn const & onStateChangedFn)
 {
-  GetPlatform().RunTask(Platform::Thread::Gui, [this, onStateChangedFn]()
-  {
-    m_onStateChangedFn = onStateChangedFn;
-  });
+  m_onStateChangedFn = onStateChangedFn;
 }
 
 void TrafficManager::SetEnabled(bool enabled)

--- a/map/traffic_manager.hpp
+++ b/map/traffic_manager.hpp
@@ -62,7 +62,9 @@ public:
 
   void Teardown();
 
+  TrafficState GetState() const;
   void SetStateListener(TrafficStateChangedFn const & onStateChangedFn);
+
   void SetDrapeEngine(ref_ptr<df::DrapeEngine> engine);
   void SetCurrentDataVersion(int64_t dataVersion);
 

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -411,6 +411,11 @@ void TransitReadManager::OnTaskCompleted(threads::IRoutine * task)
     m_event.notify_all();
 }
 
+TransitReadManager::TransitSchemeState TransitReadManager::GetState() const
+{
+  return m_state;
+}
+
 void TransitReadManager::SetStateListener(TransitStateChangedFn const & onStateChangedFn)
 {
   m_onStateChangedFn = onStateChangedFn;

--- a/map/transit/transit_reader.hpp
+++ b/map/transit/transit_reader.hpp
@@ -99,6 +99,8 @@ public:
   void Stop();
 
   void SetDrapeEngine(ref_ptr<df::DrapeEngine> engine);
+
+  TransitSchemeState GetState() const;
   void SetStateListener(TransitStateChangedFn const & onStateChangedFn);
 
   bool GetTransitDisplayInfo(TransitDisplayInfos & transitDisplayInfos);


### PR DESCRIPTION
…ers.

Сейчас менеджеры IsolinesManager, TransitReadManager и TrafficManager включаются внутри класса Framework согласно настройкам, хранящимся в settings.ini. IsolinesManager и TrafficManager включаются в конструкторе Framework, а TransitReadManager внутри Framework::CreateDrapeEngine.

Возможны ситуации, когда платформы подписываются на изменение статусов позже, чем статус поменялся. В этом случае платформам может не прийти текущий статус. 

В iOS состояние кнопки слоев сейчас зависит только от переключения статусов в колбеке, поэтому пропущенные вызовы приводили к невалидному состоянию кнопки. В Android проверяются настройки settings.ini через методы 
bool Framework::LoadTrafficEnabled();
bool Framework::LoadTransitSchemeEnabled();
bool Framework::LoadIsolinesEnabled();
Поэтому состояние кнопки включен/выключен всегда правильное, но может быть пропущен показ тоста.

Я добавила методы, возвращающие текущий статус менеджеров. После подписки на уведомления имеет смысл спросить текущий статус менеджера и выполнить логику по переходу в этот статус.

Мы обсудили с @beloal, что вызывать колбек с текущим статусом сразу синхронно в момент подписки не будет работать как минимум на iOS, поэтому это отдельные методы.