### PR TITLE
[routing] pass weight to the vertex from A* to graph

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -205,11 +205,13 @@ public:
     m_graph.GetEdgeList(child, isOutgoing, true /* useRoutingOptions */, edges);
   }
 
-  void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,
-                   vector<JointEdge> & edges, vector<RouteWeight> & parentWeights) const
+  void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & vertexData,
+                   Segment const & parent, bool isOutgoing, vector<JointEdge> & edges,
+                   vector<RouteWeight> & parentWeights) const
   {
     CHECK(m_AStarParents, ());
-    return m_graph.GetEdgeList(parentJoint, parent, isOutgoing, edges, parentWeights, *m_AStarParents);
+    return m_graph.GetEdgeList(vertexData.m_vertex, parent, isOutgoing, edges, parentWeights,
+                               *m_AStarParents);
   }
 
   bool IsJoint(Segment const & segment, bool fromStart) const

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
   base/astar_algorithm.hpp
   base/astar_progress.cpp
   base/astar_progress.hpp
+  base/astar_vertex_data.hpp
   base/astar_weight.hpp
   base/bfs.hpp
   base/followed_polyline.cpp

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/base/astar_weight.hpp"
+#include "routing/base/astar_vertex_data.hpp"
 
 #include <map>
 #include <vector>
@@ -21,8 +22,10 @@ public:
 
   virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) = 0;
 
-  virtual void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
-  virtual void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) = 0;
+  virtual void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                                    std::vector<Edge> & edges) = 0;
+  virtual void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                                   std::vector<Edge> & edges) = 0;
 
   virtual void SetAStarParents(bool forward, Parents & parents);
   virtual void DropAStarParents();

--- a/routing/base/astar_vertex_data.hpp
+++ b/routing/base/astar_vertex_data.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace routing::astar
+{
+template <typename Vertex, typename Weight>
+struct VertexData
+{
+  VertexData() = default;
+  VertexData(Vertex const & vertex, Weight const & realDistance)
+    : m_vertex(vertex), m_realDistance(realDistance)
+  {
+  }
+
+  Vertex m_vertex;
+  Weight m_realDistance;
+};
+}  // namespace routing

--- a/routing/base/bfs.hpp
+++ b/routing/base/bfs.hpp
@@ -59,10 +59,7 @@ void BFS<Graph>::Run(Vertex const & start, bool isOutgoing,
     Vertex const current = queue.front();
     queue.pop();
 
-    if (isOutgoing)
-      m_graph.GetOutgoingEdgesList(current, edges);
-    else
-      m_graph.GetIngoingEdgesList(current, edges);
+    m_graph.GetEdgesList(current, isOutgoing, edges);
 
     for (auto const & edge : edges)
     {

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -63,21 +63,42 @@ bool IndexGraph::IsJointOrEnd(Segment const & segment, bool fromStart)
   return pointId + 1 == pointsNumber;
 }
 
-void IndexGraph::GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                             vector<SegmentEdge> & edges, Parents<Segment> const & parents)
+void IndexGraph::GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData,
+                             bool isOutgoing, bool useRoutingOptions, vector<SegmentEdge> & edges,
+                             Parents<Segment> const & parents)
 {
+  GetEdgeListImpl(vertexData, isOutgoing, useRoutingOptions, true /* useAccessConditional */, edges,
+                  parents);
+}
+
+void IndexGraph::GetEdgeList(Segment const & segment,
+                             bool isOutgoing, bool useRoutingOptions, vector<SegmentEdge> & edges,
+                             Parents<Segment> const & parents)
+{
+  GetEdgeListImpl({segment, Weight(0.0)} /* vertexData */, isOutgoing, useRoutingOptions,
+                  false /* useAccessConditional */, edges, parents);
+}
+
+void IndexGraph::GetEdgeListImpl(astar::VertexData<Segment, RouteWeight> const & vertexData,
+                                 bool isOutgoing, bool useRoutingOptions, bool useAccessConditional,
+                                 std::vector<SegmentEdge> & edges, Parents<Segment> const & parents)
+{
+  auto const & segment = vertexData.m_vertex;
+
   RoadPoint const roadPoint = segment.GetRoadPoint(isOutgoing);
   Joint::Id const jointId = m_roadIndex.GetJointId(roadPoint);
 
   if (jointId != Joint::kInvalidId)
   {
     m_jointIndex.ForEachPoint(jointId, [&](RoadPoint const & rp) {
-      GetNeighboringEdges(segment, rp, isOutgoing, useRoutingOptions, edges, parents);
+      GetNeighboringEdges(vertexData, rp, isOutgoing, useRoutingOptions, edges, parents,
+                          useAccessConditional);
     });
   }
   else
   {
-    GetNeighboringEdges(segment, roadPoint, isOutgoing, useRoutingOptions, edges, parents);
+    GetNeighboringEdges(vertexData, roadPoint, isOutgoing, useRoutingOptions, edges, parents,
+                        useAccessConditional);
   }
 }
 
@@ -122,9 +143,29 @@ void IndexGraph::GetLastPointsForJoint(vector<Segment> const & children,
   }
 }
 
-void IndexGraph::GetEdgeList(JointSegment const & parentJoint,
-                             Segment const & parent, bool isOutgoing, vector<JointEdge> & edges,
-                             vector<RouteWeight> & parentWeights, Parents<JointSegment> & parents)
+void IndexGraph::GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
+                             Segment const & parent, bool isOutgoing,
+                             std::vector<JointEdge> & edges,
+                             std::vector<RouteWeight> & parentWeights,
+                             Parents<JointSegment> & parents)
+{
+  GetEdgeListImpl(parentVertexData, parent, isOutgoing, true /* useAccessConditional */, edges,
+                  parentWeights, parents);
+}
+
+void IndexGraph::GetEdgeList(JointSegment const & parentJoint, Segment const & parent,
+                             bool isOutgoing, std::vector<JointEdge> & edges,
+                             std::vector<RouteWeight> & parentWeights,
+                             Parents<JointSegment> & parents)
+{
+  GetEdgeListImpl({parentJoint, Weight(0.0)}, parent, isOutgoing, false /* useAccessConditional */, edges,
+                  parentWeights, parents);
+}
+
+void IndexGraph::GetEdgeListImpl(
+    astar::VertexData<JointSegment, RouteWeight> const & parentVertexData, Segment const & parent,
+    bool isOutgoing, bool useAccessConditional, vector<JointEdge> & edges,
+    vector<RouteWeight> & parentWeights, Parents<JointSegment> & parents)
 {
   vector<Segment> possibleChildren;
   GetSegmentCandidateForJoint(parent, isOutgoing, possibleChildren);
@@ -132,7 +173,7 @@ void IndexGraph::GetEdgeList(JointSegment const & parentJoint,
   vector<uint32_t> lastPoints;
   GetLastPointsForJoint(possibleChildren, isOutgoing, lastPoints);
 
-  ReconstructJointSegment(parentJoint, parent, possibleChildren, lastPoints,
+  ReconstructJointSegment(parentVertexData, parent, possibleChildren, lastPoints,
                           isOutgoing, edges, parentWeights, parents);
 }
 
@@ -146,7 +187,7 @@ optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
   vector<JointEdge> edges;
   vector<RouteWeight> parentWeights;
   Parents<JointSegment> emptyParents;
-  ReconstructJointSegment({} /* parentJoint */, parent, possibleChildren, lastPoints,
+  ReconstructJointSegment({} /* parentVertexData */, parent, possibleChildren, lastPoints,
                           isOutgoing, edges, parentWeights, emptyParents);
 
   CHECK_LESS_OR_EQUAL(edges.size(), 1, ());
@@ -201,9 +242,10 @@ void IndexGraph::SetUTurnRestrictions(vector<RestrictionUTurn> && noUTurnRestric
 
 void IndexGraph::SetRoadAccess(RoadAccess && roadAccess) { m_roadAccess = move(roadAccess); }
 
-void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
-                                     bool useRoutingOptions, vector<SegmentEdge> & edges,
-                                     Parents<Segment> const & parents)
+void IndexGraph::GetNeighboringEdges(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
+                                     RoadPoint const & rp, bool isOutgoing, bool useRoutingOptions,
+                                     vector<SegmentEdge> & edges, Parents<Segment> const & parents,
+                                     bool useAccessConditional)
 {
   RoadGeometry const & road = m_geometry->GetRoad(rp.GetFeatureId());
 
@@ -214,19 +256,20 @@ void IndexGraph::GetNeighboringEdges(Segment const & from, RoadPoint const & rp,
     return;
 
   bool const bidirectional = !road.IsOneWay();
-
+  auto const & from = fromVertexData.m_vertex;
   if ((isOutgoing || bidirectional) && rp.GetPointId() + 1 < road.GetPointsCount())
   {
-    GetNeighboringEdge(from,
+    GetNeighboringEdge(fromVertexData,
                        Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId(), isOutgoing),
-                       isOutgoing, edges, parents);
+                       isOutgoing, edges, parents, useAccessConditional);
   }
 
   if ((!isOutgoing || bidirectional) && rp.GetPointId() > 0)
   {
     GetNeighboringEdge(
-        from, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing),
-        isOutgoing, edges, parents);
+        fromVertexData,
+        Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing), isOutgoing,
+        edges, parents, useAccessConditional);
   }
 }
 
@@ -272,7 +315,7 @@ void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutg
 /// \param |parentWeights| - see |IndexGraphStarterJoints::GetEdgeList| method about this argument.
 ///                          Shortly - in case of |isOutgoing| == false, method saves here the weights
 ///                                   from parent to firstChildren.
-void IndexGraph::ReconstructJointSegment(JointSegment const & parentJoint,
+void IndexGraph::ReconstructJointSegment(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                                          Segment const & parent,
                                          vector<Segment> const & firstChildren,
                                          vector<uint32_t> const & lastPointIds,
@@ -283,6 +326,7 @@ void IndexGraph::ReconstructJointSegment(JointSegment const & parentJoint,
 {
   CHECK_EQUAL(firstChildren.size(), lastPointIds.size(), ());
 
+  auto const & parentJoint = parentVertexData.m_vertex;
   for (size_t i = 0; i < firstChildren.size(); ++i)
   {
     auto const & firstChild = firstChildren[i];
@@ -358,14 +402,21 @@ void IndexGraph::ReconstructJointSegment(JointSegment const & parentJoint,
   }
 }
 
-void IndexGraph::GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
-                                    vector<SegmentEdge> & edges, Parents<Segment> const & parents)
+void IndexGraph::GetNeighboringEdge(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
+                                    Segment const & to, bool isOutgoing,
+                                    vector<SegmentEdge> & edges, Parents<Segment> const & parents,
+                                    bool useAccessConditional)
 {
+  auto const & from = fromVertexData.m_vertex;
+
   if (IsUTurn(from, to) && IsUTurnAndRestricted(from, to, isOutgoing))
     return;
 
   if (IsRestricted(from, from.GetFeatureId(), to.GetFeatureId(), isOutgoing, parents))
     return;
+
+  // TODO (@gmoryes) use access conditional here.
+  UNUSED_VALUE(useAccessConditional);
 
   if (m_roadAccess.GetAccess(to.GetFeatureId()) == RoadAccess::Type::No)
     return;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "routing/base/astar_algorithm.hpp"
+#include "routing/base/astar_graph.hpp"
+#include "routing/base/astar_vertex_data.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
 #include "routing/joint.hpp"
@@ -11,9 +14,6 @@
 #include "routing/road_point.hpp"
 #include "routing/routing_options.hpp"
 #include "routing/segment.hpp"
-
-#include "routing/base/astar_algorithm.hpp"
-#include "routing/base/astar_graph.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -50,13 +50,19 @@ public:
 
   inline static Parents<Segment> kEmptyParentsSegments = {};
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
+  void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
+                   bool useRoutingOptions, std::vector<SegmentEdge> & edges,
+                   Parents<Segment> const & parents = kEmptyParentsSegments);
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                    std::vector<SegmentEdge> & edges,
                    Parents<Segment> const & parents = kEmptyParentsSegments);
 
-  void GetEdgeList(JointSegment const & parentJoint,
+  void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                    Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
                    std::vector<RouteWeight> & parentWeights, Parents<JointSegment> & parents);
+  void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,
+                   std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights,
+                   Parents<JointSegment> & parents);
 
   std::optional<JointEdge> GetJointEdgeByLastPoint(Segment const & parent,
                                                    Segment const & firstChild, bool isOutgoing,
@@ -127,11 +133,22 @@ public:
                                   Segment const & from, Segment const & to);
 
 private:
-  void GetNeighboringEdges(Segment const & from, RoadPoint const & rp, bool isOutgoing,
-                           bool useRoutingOptions, std::vector<SegmentEdge> & edges,
-                           Parents<Segment> const & parents);
-  void GetNeighboringEdge(Segment const & from, Segment const & to, bool isOutgoing,
-                          std::vector<SegmentEdge> & edges, Parents<Segment> const & parents);
+  void GetEdgeListImpl(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
+                       bool useRoutingOptions, bool useAccessConditional,
+                       std::vector<SegmentEdge> & edges, Parents<Segment> const & parents);
+
+  void GetEdgeListImpl(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
+                       Segment const & parent, bool isOutgoing, bool useAccessConditional,
+                       std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights,
+                       Parents<JointSegment> & parents);
+
+  void GetNeighboringEdges(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
+                           RoadPoint const & rp, bool isOutgoing, bool useRoutingOptions,
+                           std::vector<SegmentEdge> & edges, Parents<Segment> const & parents,
+                           bool useAccessConditional);
+  void GetNeighboringEdge(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
+                          Segment const & to, bool isOutgoing, std::vector<SegmentEdge> & edges,
+                          Parents<Segment> const & parents, bool useAccessConditional);
 
   struct PenaltyData
   {
@@ -149,7 +166,7 @@ private:
   void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
                                        bool isOutgoing, std::vector<Segment> & children);
   void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, std::vector<Segment> & children);
-  void ReconstructJointSegment(JointSegment const & parentJoint,
+  void ReconstructJointSegment(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                                Segment const & parent,
                                std::vector<Segment> const & firstChildren,
                                std::vector<uint32_t> const & lastPointIds,

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -138,6 +138,7 @@ void IndexRoadGraph::GetEdges(geometry::PointWithAltitude const & junction, bool
   {
     tmpEdges.clear();
     m_starter.GetEdgesList(segment, isOutgoing, tmpEdges);
+
     segmentEdges.insert(segmentEdges.end(), tmpEdges.begin(), tmpEdges.end());
   }
 

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -16,16 +16,16 @@ LeapsGraph::LeapsGraph(IndexGraphStarter & starter) : m_starter(starter)
   m_finishSegment = m_starter.GetFinishSegment();
 }
 
-void LeapsGraph::GetOutgoingEdgesList(Segment const & segment,
+void LeapsGraph::GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                                       std::vector<SegmentEdge> & edges)
 {
-  GetEdgesList(segment, true /* isOutgoing */, edges);
+  GetEdgesList(vertexData.m_vertex, true /* isOutgoing */, edges);
 }
 
-void LeapsGraph::GetIngoingEdgesList(Segment const & segment,
+void LeapsGraph::GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                                      std::vector<SegmentEdge> & edges)
 {
-  GetEdgesList(segment, false /* isOutgoing */, edges);
+  GetEdgesList(vertexData.m_vertex, false /* isOutgoing */, edges);
 }
 
 RouteWeight LeapsGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/base/astar_graph.hpp"
+#include "routing/base/astar_vertex_data.hpp"
 
 #include "routing/index_graph_starter.hpp"
 #include "routing/route_weight.hpp"
@@ -19,8 +20,10 @@ public:
 
   // AStarGraph overrides:
   // @{
-  void GetOutgoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
-  void GetIngoingEdgesList(Segment const & segment, std::vector<SegmentEdge> & edges) override;
+  void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                            std::vector<SegmentEdge> & edges) override;
+  void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                           std::vector<SegmentEdge> & edges) override;
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight GetAStarWeightEpsilon() override;
   // @}

--- a/routing/routes_builder/routes_builder_tool/CMakeLists.txt
+++ b/routing/routes_builder/routes_builder_tool/CMakeLists.txt
@@ -31,6 +31,7 @@ omim_link_libraries(
   jansson
   oauthcpp
   protobuf
+  opening_hours
   stats_client
   succinct
   gflags

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -226,7 +226,8 @@ bool CheckGraphConnectivity(Segment const & start, bool isOutgoing, bool useRout
 
     // Note. If |isOutgoing| == true outgoing edges are looked for.
     // If |isOutgoing| == false it's the finish. So ingoing edges are looked for.
-    graph.GetEdgeList(u, isOutgoing, useRoutingOptions, edges);
+    graph.GetEdgeList({u, RouteWeight(0.0)}, isOutgoing, useRoutingOptions,
+                      false /* useAccessConditional */, edges);
     for (auto const & edge : edges)
     {
       auto const & v = edge.GetTarget();

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -61,16 +61,20 @@ public:
                                           m_graph->GetPoint(to, true /* front */));
   }
 
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
+  void GetOutgoingEdgesList(astar::VertexData<Vertex, RouteWeight> const & vertexData,
+                            std::vector<Edge> & edges) override
   {
     edges.clear();
-    m_graph->GetEdgeList(v, true /* isOutgoing */, true /* useRoutingOptions */, edges);
+    m_graph->GetEdgeList(vertexData.m_vertex, true /* isOutgoing */, true /* useRoutingOptions */,
+                         edges);
   }
 
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & edges) override
+  void GetIngoingEdgesList(astar::VertexData<Vertex, RouteWeight> const & vertexData,
+                           std::vector<Edge> & edges) override
   {
     edges.clear();
-    m_graph->GetEdgeList(v, false /* isOutgoing */, true /* useRoutingOptions */, edges);
+    m_graph->GetEdgeList(vertexData.m_vertex, false /* isOutgoing */, true /* useRoutingOptions */,
+                         edges);
   }
 
   RouteWeight GetAStarWeightEpsilon() override { return RouteWeight(0.0); }

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -27,14 +27,22 @@ size_t UndirectedGraph::GetNodesNumber() const
   return m_adjs.size();
 }
 
-void UndirectedGraph::GetIngoingEdgesList(Vertex const & v, std::vector<SimpleEdge> & adj)
+void UndirectedGraph::GetEdgesList(Vertex const & vertex, bool /* isOutgoing */,
+                                   std::vector<Edge> & adj)
 {
-  GetAdjacencyList(v, adj);
+  GetAdjacencyList(vertex, adj);
 }
 
-void UndirectedGraph::GetOutgoingEdgesList(Vertex const & v, std::vector<SimpleEdge> & adj)
+void UndirectedGraph::GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                                          std::vector<SimpleEdge> & adj)
 {
-  GetAdjacencyList(v, adj);
+  GetEdgesList(vertexData.m_vertex, false /* isOutgoing */, adj);
+}
+
+void UndirectedGraph::GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                                           std::vector<SimpleEdge> & adj)
+{
+  GetEdgesList(vertexData.m_vertex, true /* isOutgoing */, adj);
 }
 
 double UndirectedGraph::HeuristicCostEstimate(Vertex const & v, Vertex const & w)
@@ -56,14 +64,9 @@ void DirectedGraph::AddEdge(Vertex from, Vertex to, Weight w)
   m_ingoing[to].emplace_back(from, w);
 }
 
-void DirectedGraph::GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & adj)
+void DirectedGraph::GetEdgesList(Vertex const & v, bool isOutgoing, std::vector<Edge> & adj)
 {
-  adj = m_ingoing[v];
-}
-
-void DirectedGraph::GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & adj)
-{
-  adj = m_outgoing[v];
+  adj = isOutgoing ? m_outgoing[v] : m_ingoing[v];
 }
 }  // namespace routing_tests
 
@@ -114,8 +117,10 @@ public:
     : m_roadGraph(roadGraph), m_maxSpeedMPS(KMPH2MPS(roadGraph.GetMaxSpeedKMpH()))
   {}
 
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & adj) override
+  void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                            std::vector<Edge> & adj) override
   {
+    auto const & v = vertexData.m_vertex;
     IRoadGraph::EdgeVector edges;
     m_roadGraph.GetOutgoingEdges(v, edges);
 
@@ -132,8 +137,10 @@ public:
     }
   }
 
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & adj) override
+  void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                           std::vector<Edge> & adj) override
   {
+    auto const & v = vertexData.m_vertex;
     IRoadGraph::EdgeVector edges;
     m_roadGraph.GetIngoingEdges(v, edges);
 

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -35,10 +35,14 @@ public:
 
   // AStarGraph overrides
   // @{
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & adj) override;
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & adj) override;
+  void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                           std::vector<Edge> & adj) override;
+  void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
+                            std::vector<Edge> & adj) override;
   double HeuristicCostEstimate(Vertex const & v, Vertex const & w) override;
   // @}
+
+  void GetEdgesList(Vertex const & vertex, bool /* isOutgoing */, std::vector<Edge> & adj);
 
 private:
   void GetAdjacencyList(Vertex v, std::vector<Edge> & adj) const;
@@ -55,8 +59,7 @@ public:
 
   void AddEdge(Vertex from, Vertex to, Weight w);
 
-  void GetIngoingEdgesList(Vertex const & v, std::vector<Edge> & adj);
-  void GetOutgoingEdgesList(Vertex const & v, std::vector<Edge> & adj);
+  void GetEdgesList(Vertex const & v, bool isOutgoing, std::vector<Edge> & adj);
 
 private:
   std::map<uint32_t, std::vector<Edge>> m_outgoing;

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -35,11 +35,16 @@ public:
   // @{
   ~SingleVehicleWorldGraph() override = default;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+  using WorldGraph::GetEdgeList;
+
+  void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
+                   bool useRoutingOptions, bool useAccessConditional,
                    std::vector<SegmentEdge> & edges) override;
 
-  void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,
-                   std::vector<JointEdge> & jointEdges, std::vector<RouteWeight> & parentWeights) override;
+  void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
+                   Segment const & parent, bool isOutgoing, bool useAccessConditional,
+                   std::vector<JointEdge> & jointEdges,
+                   std::vector<RouteWeight> & parentWeights) override;
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
 

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/base/astar_vertex_data.hpp"
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
@@ -11,9 +12,9 @@
 #include "routing/transit_info.hpp"
 #include "routing/world_graph.hpp"
 
-#include "routing_common/num_mwm_id.hpp"
-
 #include "transit/transit_types.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/latlon.hpp"
 
@@ -34,10 +35,13 @@ public:
   // WorldGraph overrides:
   ~TransitWorldGraph() override = default;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+  using WorldGraph::GetEdgeList;
+
+  void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
+                   bool useRoutingOptions, bool useAccessConditional,
                    std::vector<SegmentEdge> & edges) override;
-  void GetEdgeList(JointSegment const & parentJoint,
-                   Segment const & segment, bool isOutgoing,
+  void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
+                   Segment const & segment, bool isOutgoing, bool useAccessConditional,
                    std::vector<JointEdge> & edges,
                    std::vector<RouteWeight> & parentWeights) override;
 
@@ -84,8 +88,8 @@ private:
   }
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
-  void AddRealEdges(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                    std::vector<SegmentEdge> & edges);
+  void AddRealEdges(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
+                    bool useRoutingOptions, std::vector<SegmentEdge> & edges);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -4,6 +4,13 @@
 
 namespace routing
 {
+void WorldGraph::GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRoutingOptions,
+                             std::vector<SegmentEdge> & edges)
+{
+  GetEdgeList({vertex, RouteWeight(0.0)}, isOutgoing, useRoutingOptions,
+              false /* useAccessConditional */, edges);
+}
+
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                           std::vector<SegmentEdge> & edges)
 {
@@ -16,9 +23,12 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRout
   SetMode(WorldGraphMode::SingleMwm);
 
   for (Segment const & twin : twins)
-    GetEdgeList(twin, isOutgoing, useRoutingOptions, edges);
+  {
+    GetEdgeList({twin, RouteWeight(0.0)}, isOutgoing, useRoutingOptions,
+                false /* useAccessConditional */, edges);
+  }
 
-  SetMode(prevMode);
+      SetMode(prevMode);
 }
 
 RoutingOptions WorldGraph::GetRoutingOptions(Segment const & /* segment */)

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "routing/base/astar_vertex_data.hpp"
 #include "routing/cross_mwm_graph.hpp"
 #include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
@@ -49,12 +50,18 @@ public:
 
   virtual ~WorldGraph() = default;
 
-  virtual void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
+  virtual void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData,
+                           bool isOutgoing, bool useRoutingOptions, bool useAccessConditional,
                            std::vector<SegmentEdge> & edges) = 0;
-  virtual void GetEdgeList(JointSegment const & vertex, Segment const & segment, bool isOutgoing,
-                           std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights) = 0;
+  virtual void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & vertexData,
+                           Segment const & segment, bool isOutgoing, bool useAccessConditional,
+                           std::vector<JointEdge> & edges,
+                           std::vector<RouteWeight> & parentWeights) = 0;
 
-  // Checks whether path length meets restrictions. Restrictions may depend on the distance from
+  void GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRoutingOptions,
+                   std::vector<SegmentEdge> & edges);
+
+      // Checks whether path length meets restrictions. Restrictions may depend on the distance from
   // start to finish of the route.
   virtual bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const = 0;
 


### PR DESCRIPTION
В общем предлагается придерживаться следующей логики:
Если кто-то где-то у кого-то вызывает GetEdgeList(astar::VertexData ... )
то скорее всего этот кто-то понимает, что в vertexData хранится что-то странное и для чего-то наверное нужное, поэтому вызовы ф-ий с vertexData используют access conditional

А если же кто-то где-то у кого-то вызывает GetEdgeList(segment, ...) то скорее всего ему сейчас не очень интересно знание об access conditional и он хочет получить какой-то результат, в таких случаях предлагается не использовать access conditional, хотя бы по той причине, что бы результат работы ф-ий был детерминированным 