### PR TITLE
[routing] Build routes using not only OSM but also guides tracks.

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -8,18 +8,19 @@
 
 #include "routing/following_info.hpp"
 #include "routing/route.hpp"
+#include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "routing/routing_session.hpp"
 #include "routing/speed_camera_manager.hpp"
+
+#include "tracking/archival_reporter.hpp"
+#include "tracking/reporter.hpp"
 
 #include "storage/storage_defines.hpp"
 
 #include "drape_frontend/drape_engine_safe_ptr.hpp"
 
 #include "drape/pointers.hpp"
-
-#include "tracking/archival_reporter.hpp"
-#include "tracking/reporter.hpp"
 
 #include "geometry/point2d.hpp"
 #include "geometry/point_with_altitude.hpp"
@@ -140,6 +141,7 @@ public:
   bool IsOnRoute() const { return m_routingSession.IsOnRoute(); }
   bool IsRoutingFollowing() const { return m_routingSession.IsFollowing(); }
   bool IsRouteValid() const { return m_routingSession.IsRouteValid(); }
+  routing::GuidesTracks GetGuidesTracks() const;
   void BuildRoute(uint32_t timeoutSec = routing::RouterDelegate::kNoTimeout);
   void SetUserCurrentPosition(m2::PointD const & position);
   void ResetRoutingSession() { m_routingSession.Reset(); }

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -51,6 +51,10 @@ set(
   following_info.hpp
   geometry.cpp
   geometry.hpp
+  guides_connections.cpp
+  guides_connections.hpp
+  guides_graph.cpp
+  guides_graph.hpp
   index_graph.cpp
   index_graph.hpp
   index_graph_loader.cpp

--- a/routing/async_router.hpp
+++ b/routing/async_router.hpp
@@ -55,6 +55,7 @@ public:
                       ProgressCallback const & progressCallback,
                       uint32_t timeoutSec = RouterDelegate::kNoTimeout);
 
+  void SetGuidesTracks(GuidesTracks && guides);
   /// Interrupt routing and clear buffers
   void ClearState();
 
@@ -116,6 +117,8 @@ private:
   /// Current request parameters
   bool m_clearState = false;
   Checkpoints m_checkpoints;
+  GuidesTracks m_guides;
+
   m2::PointD m_startDirection = m2::PointD::Zero();
   bool m_adjustToPrevRoute = false;
   std::shared_ptr<RouterDelegateProxy> m_delegateProxy;

--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -1,5 +1,6 @@
 #include "routing/car_directions.hpp"
 
+#include "routing/fake_feature_ids.hpp"
 #include "routing/road_point.hpp"
 #include "routing/router_delegate.hpp"
 #include "routing/routing_exceptions.hpp"
@@ -13,7 +14,6 @@
 #include "routing_common/car_model.hpp"
 
 #include "indexer/ftypes_matcher.hpp"
-#include "indexer/scales.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
 
@@ -231,6 +231,9 @@ void CarDirectionsEngine::LoadPathAttributes(FeatureID const & featureId, Loaded
   if (!featureId.IsValid())
     return;
 
+  if (FakeFeatureIds::IsGuidesFeature(featureId.m_index))
+    return;
+
   auto ft = GetLoader(featureId.m_mwmId).GetFeatureByIndex(featureId.m_index);
   if (!ft)
     return;
@@ -263,6 +266,9 @@ void CarDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
       continue;
 
     auto const & outFeatureId = edge.GetFeatureId();
+    if (FakeFeatureIds::IsGuidesFeature(outFeatureId.m_index))
+      continue;
+
     auto ft = GetLoader(outFeatureId.m_mwmId).GetFeatureByIndex(outFeatureId.m_index);
     if (!ft)
       continue;

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -141,6 +141,8 @@ double EdgeEstimator::CalcLeapWeight(ms::LatLon const & from, ms::LatLon const &
   return TimeBetweenSec(from, to, m_maxWeightSpeedMpS / 2.0);
 }
 
+double EdgeEstimator::GetMaxWeightSpeedMpS() const { return m_maxWeightSpeedMpS; }
+
 double EdgeEstimator::CalcOffroad(ms::LatLon const & from, ms::LatLon const & to,
                                   Purpose purpose) const
 {

--- a/routing/edge_estimator.hpp
+++ b/routing/edge_estimator.hpp
@@ -39,6 +39,8 @@ public:
   // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
   double CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const;
 
+  double GetMaxWeightSpeedMpS() const;
+
   // Estimates time in seconds it takes to go from point |from| to point |to| along direct fake edge.
   double CalcOffroad(ms::LatLon const & from, ms::LatLon const & to, Purpose purpose) const;
 

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -9,6 +9,7 @@
 
 #include "base/math.hpp"
 
+#include <tuple>
 #include <utility>
 
 using namespace routing;
@@ -43,6 +44,13 @@ LatLonWithAltitude CalcProjectionToSegment(LatLonWithAltitude const & begin,
 
 namespace routing
 {
+bool Projection::operator==(const Projection & other) const
+{
+  return tie(m_segment, m_isOneWay, m_segmentFront, m_segmentBack, m_junction) ==
+         tie(other.m_segment, other.m_isOneWay, other.m_segmentFront, other.m_segmentBack,
+             other.m_junction);
+}
+
 FakeEnding MakeFakeEnding(vector<Segment> const & segments, m2::PointD const & point,
                           WorldGraph & graph)
 {

--- a/routing/fake_ending.hpp
+++ b/routing/fake_ending.hpp
@@ -28,6 +28,7 @@ struct Projection final
     , m_junction(junction)
   {
   }
+  bool operator==(Projection const & other) const;
 
   Segment m_segment;
   bool m_isOneWay = false;

--- a/routing/fake_feature_ids.cpp
+++ b/routing/fake_feature_ids.cpp
@@ -8,4 +8,6 @@ uint32_t constexpr FakeFeatureIds::kIndexGraphStarterId;
 uint32_t constexpr FakeFeatureIds::k24BitsOffset;
 // static
 uint32_t constexpr FakeFeatureIds::kTransitGraphFeaturesStart;
+// static
+uint32_t constexpr FakeFeatureIds::kGuidesGraphFeaturesStart;
 }  // namespace routing

--- a/routing/fake_feature_ids.hpp
+++ b/routing/fake_feature_ids.hpp
@@ -15,20 +15,36 @@ struct FakeFeatureIds
            !feature::FakeFeatureIds::IsEditorCreatedFeature(id);
   }
 
+  static bool IsGuidesFeature(uint32_t id)
+  {
+    return id >= kGuidesGraphFeaturesStart && id < kTransitGraphFeaturesStart;
+  }
+
   static uint32_t constexpr kIndexGraphStarterId = std::numeric_limits<uint32_t>::max();
-  // It's important that |kTransitGraphFeaturesStart| is greater than maximum number of real road
-  // feature id. Also transit fake feature id should not overlap with real feature id and editor
-  // feature ids.
+  // It's important that |kGuidesGraphFeaturesStart| is greater than maximum number of real road
+  // feature id. Also transit and guides fake feature id should not overlap with real feature id
+  // and editor feature ids.
   static uint32_t constexpr k24BitsOffset = 0xffffff;
   static uint32_t constexpr kTransitGraphFeaturesStart =
       std::numeric_limits<uint32_t>::max() - k24BitsOffset;
+  static uint32_t constexpr kGuidesGraphFeaturesStart = kTransitGraphFeaturesStart - k24BitsOffset;
 };
 
 static_assert(feature::FakeFeatureIds::kEditorCreatedFeaturesStart >
-                      FakeFeatureIds::kTransitGraphFeaturesStart &&
-                  feature::FakeFeatureIds::kEditorCreatedFeaturesStart -
-                          FakeFeatureIds::kTransitGraphFeaturesStart >=
-                      FakeFeatureIds::k24BitsOffset - feature::FakeFeatureIds::k20BitsOffset,
+                  FakeFeatureIds::kTransitGraphFeaturesStart,
+              "routing::FakeFeatureIds::kTransitGraphFeaturesStart or "
+              "feature::FakeFeatureIds::kEditorCreatedFeaturesStart was changed. "
+              "Interval for transit fake features may be too small.");
+
+static_assert(FakeFeatureIds::kTransitGraphFeaturesStart >
+                  FakeFeatureIds::kGuidesGraphFeaturesStart,
+              "routing::FakeFeatureIds::kTransitGraphFeaturesStart or "
+              "feature::FakeFeatureIds::kGuidesGraphFeaturesStart was changed. "
+              "Interval for guides fake features may be too small.");
+
+static_assert(feature::FakeFeatureIds::kEditorCreatedFeaturesStart -
+                      FakeFeatureIds::kTransitGraphFeaturesStart >=
+                  FakeFeatureIds::k24BitsOffset - feature::FakeFeatureIds::k20BitsOffset,
               "routing::FakeFeatureIds::kTransitGraphFeaturesStart or "
               "feature::FakeFeatureIds::kEditorCreatedFeaturesStart was changed. "
               "Interval for transit fake features may be too small.");

--- a/routing/guides_connections.cpp
+++ b/routing/guides_connections.cpp
@@ -1,0 +1,303 @@
+#include "routing/guides_connections.hpp"
+
+#include "routing/fake_feature_ids.hpp"
+
+namespace
+{
+// We consider only really close points to be attached to the track.
+double constexpr kMaxDistToTrackPointM = 50.0;
+
+// For points further from track then |kEqDistToTrackPointM| we try to attach them to the OSM
+// graph.
+double constexpr kEqDistToTrackPointM = 20.0;
+
+// It the checkpoint is further from the guides track than |kMaxDistToTrackForSkippingM|, we skip
+// this track completely. For time optimization purposes only.
+double constexpr kMaxDistToTrackForSkippingM = 100'000.0;
+}  // namespace
+
+namespace routing
+{
+CheckpointTrackProj::CheckpointTrackProj(kml::MarkGroupId guideId, size_t trackIdx,
+                                         size_t trackPointIdx,
+                                         geometry::PointWithAltitude const & projectedPoint,
+                                         double distToProjectedPointM)
+  : m_guideId(guideId)
+  , m_trackIdx(trackIdx)
+  , m_trackPointIdx(trackPointIdx)
+  , m_projectedPoint(projectedPoint)
+  , m_distToProjectedPointM(distToProjectedPointM)
+{
+}
+
+std::pair<geometry::PointWithAltitude, double> GetProjectionAndDistOnSegment(
+    m2::PointD const & point, geometry::PointWithAltitude const & startPath,
+    geometry::PointWithAltitude const & endPath)
+{
+  m2::PointD const projection =
+      m2::ParametrizedSegment<m2::PointD>(startPath.GetPoint(), endPath.GetPoint())
+          .ClosestPointTo(point);
+  double const distM = mercator::DistanceOnEarth(projection, point);
+  return std::make_pair(geometry::PointWithAltitude(projection, 0 /* altitude */), distM);
+}
+
+bool GuidesConnections::IsActive() const { return !m_allTracks.empty(); }
+
+std::vector<ConnectionToOsm> GuidesConnections::GetOsmConnections(size_t checkpointIdx) const
+{
+  auto it = m_connectionsToOsm.find(checkpointIdx);
+  if (it == m_connectionsToOsm.end())
+    return {};
+  return it->second;
+}
+
+void GuidesConnections::UpdateOsmConnections(size_t checkpointIdx,
+                                             std::vector<ConnectionToOsm> const & links)
+{
+  auto const it = m_connectionsToOsm.find(checkpointIdx);
+  CHECK(it != m_connectionsToOsm.cend(), (checkpointIdx));
+  it->second = links;
+}
+
+GuidesConnections::GuidesConnections(GuidesTracks const & guides) : m_allTracks(guides) {}
+
+void GuidesConnections::PullCheckpointsToTracks(std::vector<m2::PointD> const & checkpoints)
+{
+  for (size_t checkpointIdx = 0; checkpointIdx < checkpoints.size(); ++checkpointIdx)
+  {
+    for (auto const & [guideId, tracks] : m_allTracks)
+    {
+      for (size_t trackIdx = 0; trackIdx < tracks.size(); ++trackIdx)
+      {
+        CHECK(!tracks[trackIdx].empty(), (trackIdx));
+        for (size_t pointIdx = 0; pointIdx < tracks[trackIdx].size() - 1; ++pointIdx)
+        {
+          auto const [checkpointProj, distM] =
+              GetProjectionAndDistOnSegment(checkpoints[checkpointIdx], tracks[trackIdx][pointIdx],
+                                            tracks[trackIdx][pointIdx + 1]);
+
+          // Skip too far track.
+          if (distM > kMaxDistToTrackForSkippingM)
+            break;
+
+          // We consider only really close points to be attached to the track.
+          if (distM > kMaxDistToTrackPointM)
+            continue;
+
+          CheckpointTrackProj const curProj(guideId, trackIdx, pointIdx, checkpointProj, distM);
+          auto const [it, inserted] = m_checkpointsOnTracks.emplace(checkpointIdx, curProj);
+
+          if (!inserted && it->second.m_distToProjectedPointM > distM)
+            it->second = curProj;
+        }
+      }
+    }
+  }
+}
+
+void GuidesConnections::AddTerminalGuidePoint(size_t checkpointIdx, size_t neighbourIdx,
+                                              m2::PointD const & curPoint)
+{
+  auto const it = m_checkpointsOnTracks.find(neighbourIdx);
+  CHECK(it != m_checkpointsOnTracks.cend(), (neighbourIdx));
+
+  auto const & neighbour = it->second;
+  auto const guideId = neighbour.m_guideId;
+  auto const trackIdx = neighbour.m_trackIdx;
+  auto const & track = m_allTracks[guideId][trackIdx];
+
+  CHECK_GREATER(
+      track.size(), 1,
+      ("checkpointIdx:", checkpointIdx, "neighbourIdx:", neighbourIdx, "trackIdx:", trackIdx));
+
+  // Connect start checkpoint to the starting point of the track.
+  if (checkpointIdx == 0)
+  {
+    double const distToStartM = mercator::DistanceOnEarth(curPoint, track.front().GetPoint());
+    m_checkpointsOnTracks[checkpointIdx] = CheckpointTrackProj(
+        guideId, trackIdx, 0 /* trackPointIdx */, track.front() /* proj */, distToStartM);
+
+    return;
+  }
+
+  // Connect finish checkpoint to the finish point of the track.
+  double const distToSFinishM = mercator::DistanceOnEarth(curPoint, track.back().GetPoint());
+  m_checkpointsOnTracks[checkpointIdx] =
+      CheckpointTrackProj(guideId, trackIdx, track.size() - 2 /* trackPointIdx */,
+                          track.back() /* proj */, distToSFinishM);
+}
+
+bool GuidesConnections::IsCheckpointAttached(size_t checkpointIdx) const
+{
+  return m_checkpointsOnTracks.find(checkpointIdx) != m_checkpointsOnTracks.end();
+}
+
+std::vector<size_t> GetNeighbourIntermediatePoints(size_t checkpointIdx, size_t checkpointsCount)
+{
+  CHECK_GREATER(checkpointsCount, 2, (checkpointsCount));
+  std::vector<size_t> neighbours;
+  // We add left intermediate point:
+  if (checkpointIdx > 1)
+    neighbours.push_back(checkpointIdx - 1);
+  // We add right intermediate point:
+  if (checkpointIdx < checkpointsCount - 2)
+    neighbours.push_back(checkpointIdx + 1);
+  return neighbours;
+}
+
+bool GuidesConnections::FitsForDirectLinkToGuide(size_t checkpointIdx,
+                                                 size_t checkpointsCount) const
+{
+  auto it = m_checkpointsOnTracks.find(checkpointIdx);
+  CHECK(it != m_checkpointsOnTracks.end(), (checkpointIdx));
+  bool const checkpointIsFar = it->second.m_distToProjectedPointM > kEqDistToTrackPointM;
+  if (checkpointIsFar)
+    return false;
+
+  // If checkpoint lies on the track but its neighbour intermediate checkpoint does not, we should
+  // connect this checkpoint to the OSM graph.
+  if (checkpointsCount <= 2)
+    return true;
+
+  for (auto const neighbourIdx : GetNeighbourIntermediatePoints(checkpointIdx, checkpointsCount))
+  {
+    if (m_checkpointsOnTracks.find(neighbourIdx) == m_checkpointsOnTracks.end())
+      return false;
+  }
+
+  return true;
+}
+
+void GuidesConnections::PullAdditionalCheckpointsToTracks(
+    std::vector<m2::PointD> const & checkpoints)
+{
+  for (size_t i : {size_t(0), checkpoints.size() - 1})
+  {
+    // Skip already connected to the tracks checkpoints.
+    if (IsCheckpointAttached(i))
+      continue;
+
+    // Neighbour point of this terminal point should be on the track.
+    size_t neighbourIdx = i == 0 ? i + 1 : i - 1;
+
+    if (!IsCheckpointAttached(neighbourIdx))
+      continue;
+
+    AddTerminalGuidePoint(i, neighbourIdx, checkpoints[i]);
+  }
+}
+
+bool GuidesConnections::IsAttached() const { return !m_checkpointsFakeEndings.empty(); }
+
+FakeEnding GuidesConnections::GetFakeEnding(size_t checkpointIdx) const
+{
+  if (IsAttached())
+  {
+    auto it = m_checkpointsFakeEndings.find(checkpointIdx);
+    if (it != m_checkpointsFakeEndings.end())
+      return it->second;
+  }
+  return FakeEnding();
+}
+
+GuidesGraph const & GuidesConnections::GetGuidesGraph() const { return m_graph; }
+
+void GuidesConnections::OverwriteFakeEnding(size_t checkpointIdx, FakeEnding const & newFakeEnding)
+{
+  m_checkpointsFakeEndings[checkpointIdx] = newFakeEnding;
+}
+
+// static
+void GuidesConnections::ExtendFakeEndingProjections(FakeEnding const & srcFakeEnding,
+                                                    FakeEnding & dstFakeEnding)
+{
+  dstFakeEnding.m_originJunction = srcFakeEnding.m_originJunction;
+
+  for (auto const & proj : srcFakeEnding.m_projections)
+  {
+    if (std::find(dstFakeEnding.m_projections.begin(), dstFakeEnding.m_projections.end(), proj) ==
+        dstFakeEnding.m_projections.end())
+    {
+      dstFakeEnding.m_projections.push_back(proj);
+    }
+  }
+}
+
+NumMwmId GuidesConnections::GetMwmId() const { return m_graph.GetMwmId(); }
+
+void GuidesConnections::SetGuidesGraphParams(NumMwmId mwmId, double maxSpeed)
+{
+  m_graph = GuidesGraph(maxSpeed, mwmId);
+}
+
+void GuidesConnections::ConnectToGuidesGraph(std::vector<m2::PointD> const & checkpoints)
+{
+  PullCheckpointsToTracks(checkpoints);
+
+  PullAdditionalCheckpointsToTracks(checkpoints);
+
+  std::map<std::pair<kml::MarkGroupId, size_t>, Segment> addedTracks;
+
+  for (auto const & [checkpointIdx, proj] : m_checkpointsOnTracks)
+  {
+    auto const & checkpoint = checkpoints[checkpointIdx];
+    auto const & checkpointProj = proj.m_projectedPoint;
+
+    Segment segmentOnTrack;
+    auto const [it, insertedSegment] =
+        addedTracks.emplace(std::make_pair(proj.m_guideId, proj.m_trackIdx), segmentOnTrack);
+    if (insertedSegment)
+    {
+      CHECK(!m_allTracks[proj.m_guideId][proj.m_trackIdx].empty(),
+            ("checkpointIdx:", checkpointIdx, "guideId:", proj.m_guideId,
+             "trackIdx:", proj.m_trackIdx));
+
+      segmentOnTrack =
+          m_graph.AddTrack(m_allTracks[proj.m_guideId][proj.m_trackIdx], proj.m_trackPointIdx);
+      it->second = segmentOnTrack;
+    }
+    else
+    {
+      segmentOnTrack = m_graph.FindSegment(it->second, proj.m_trackPointIdx);
+    }
+    FakeEnding const newEnding = m_graph.MakeFakeEnding(segmentOnTrack, checkpoint, checkpointProj);
+    auto const [itEnding, inserted] = m_checkpointsFakeEndings.emplace(checkpointIdx, newEnding);
+
+    CHECK(inserted, (checkpointIdx));
+    bool const fitsForOsmLink = !FitsForDirectLinkToGuide(checkpointIdx, checkpoints.size());
+
+    if (fitsForOsmLink)
+      AddConnectionToOsm(checkpointIdx, segmentOnTrack, checkpointProj);
+
+    // Connect to OSM start and finish points of the track.
+    auto const & firstPointOnTrack = m_allTracks[proj.m_guideId][proj.m_trackIdx][0];
+    if (!(fitsForOsmLink && firstPointOnTrack == checkpointProj))
+    {
+      auto const & firstSegmentOnTrack = m_graph.FindSegment(segmentOnTrack, 0);
+      AddConnectionToOsm(checkpointIdx, firstSegmentOnTrack, firstPointOnTrack);
+    }
+
+    auto const & lastPointIdx = m_allTracks[proj.m_guideId][proj.m_trackIdx].size() - 1;
+    auto const & lastPointOnTrack = m_allTracks[proj.m_guideId][proj.m_trackIdx][lastPointIdx];
+    if (!(fitsForOsmLink && lastPointOnTrack == checkpointProj))
+    {
+      auto const & lastSegmentOnTrack = m_graph.FindSegment(segmentOnTrack, lastPointIdx - 1);
+      AddConnectionToOsm(checkpointIdx, lastSegmentOnTrack, lastPointOnTrack);
+    }
+  }
+}
+
+void GuidesConnections::AddConnectionToOsm(size_t checkpointIdx, Segment const & real,
+                                           geometry::PointWithAltitude const & loop)
+{
+  LatLonWithAltitude const loopPoint(mercator::ToLatLon(loop.GetPoint()), loop.GetAltitude());
+
+  ConnectionToOsm link;
+  link.m_loopVertex = FakeVertex(kFakeNumMwmId, loopPoint, loopPoint, FakeVertex::Type::PureFake);
+  link.m_realSegment = real;
+  link.m_projectedPoint = loop;
+  std::tie(link.m_realFrom, link.m_realTo) = m_graph.GetFromTo(real);
+
+  m_connectionsToOsm[checkpointIdx].push_back(link);
+}
+}  // namespace routing

--- a/routing/guides_connections.hpp
+++ b/routing/guides_connections.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "routing/edge_estimator.hpp"
+#include "routing/fake_ending.hpp"
+#include "routing/fake_vertex.hpp"
+#include "routing/guides_graph.hpp"
+#include "routing/router.hpp"
+#include "routing/segment.hpp"
+
+#include "kml/type_utils.hpp"
+
+#include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
+
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace routing
+{
+// Information needed to attach guide track to the OSM segments via fake edges.
+struct ConnectionToOsm
+{
+  // Fake ending connecting |m_projectedPoint| on the tracks segment |m_realSegment| to OSM.
+  FakeEnding m_fakeEnding;
+  // Loop vertex for |m_projectedPoint|.
+  FakeVertex m_loopVertex;
+  // Segment on the track to which the |m_loopVertex| should be attached via |m_partsOfReal|.
+  Segment m_realSegment;
+  // Terminal points of |m_realSegment|.
+  LatLonWithAltitude m_realFrom;
+  LatLonWithAltitude m_realTo;
+  // Vertexes and corresponding PartOfReal segments connecting |m_loopVertex| and |m_realSegment|.
+  std::vector<std::pair<FakeVertex, Segment>> m_partsOfReal;
+  // Projection of the checkpoint to the track.
+  geometry::PointWithAltitude m_projectedPoint;
+};
+
+// Information about checkpoint projection to the nearest guides track.
+struct CheckpointTrackProj
+{
+  CheckpointTrackProj() = default;
+  CheckpointTrackProj(kml::MarkGroupId guideId, size_t trackIdx, size_t trackPointIdx,
+                      geometry::PointWithAltitude const & projectedPoint,
+                      double distToProjectedPointM);
+  // Guide id.
+  kml::MarkGroupId m_guideId = 0;
+  // Index of the track belonging to |m_guideId|.
+  size_t m_trackIdx = 0;
+  // Index of the nearest segment 'from' or 'to' point on the track to the checkpoint.
+  size_t m_trackPointIdx = 0;
+  // Projection of the checkpoint to the track.
+  geometry::PointWithAltitude m_projectedPoint;
+  // Distance between the checkpoint and |m_projectedPoint|
+  double m_distToProjectedPointM = 0;
+};
+
+using Projections = std::map<size_t, CheckpointTrackProj>;
+using IterProjections = Projections::iterator;
+
+// Prepares guides tracks for attaching to the roads graph.
+class GuidesConnections
+{
+public:
+  GuidesConnections() = default;
+  GuidesConnections(GuidesTracks const & guides);
+
+  // Sets mwm id and speed values for guides graph.
+  void SetGuidesGraphParams(NumMwmId mwmId, double maxSpeed);
+
+  // Finds closest guides tracks for checkpoints, fills guides graph.
+  void ConnectToGuidesGraph(std::vector<m2::PointD> const & checkpoints);
+
+  // Overwrites osm connections for checkpoint by its index |checkpointIdx|.
+  void UpdateOsmConnections(size_t checkpointIdx, std::vector<ConnectionToOsm> const & links);
+
+  // Set |newFakeEnding| for checkpoint.
+  void OverwriteFakeEnding(size_t checkpointIdx, FakeEnding const & newFakeEnding);
+
+  // Merge existing |srcFakeEnding| with |dstFakeEnding|.
+  static void ExtendFakeEndingProjections(FakeEnding const & srcFakeEnding,
+                                          FakeEnding & dstFakeEnding);
+
+  // Returns guides graph |m_graph| for index graph starter.
+  GuidesGraph const & GetGuidesGraph() const;
+
+  // Returns all connections to the OSM graph relevant to checkpoint with |checkpointIdx| index.
+  std::vector<ConnectionToOsm> GetOsmConnections(size_t checkpointIdx) const;
+
+  // Checks if checkpoint is close enough to some track.
+  bool FitsForDirectLinkToGuide(size_t checkpointIdx, size_t checkpointsCount) const;
+
+  // Checks if checkpoint is considered to be attached to some track.
+  bool IsCheckpointAttached(size_t checkpointIdx) const;
+
+  // Checks if GuidesConnections instance is active.
+  bool IsActive() const;
+
+  // Checks if some guides tracks in GuidesConnections instance are attached to the checkpoints.
+  bool IsAttached() const;
+
+  // Returns mwm id linked to all tracks in the guides graph.
+  NumMwmId GetMwmId() const;
+
+  // Returns fake ending associated with checkpoint by its index |checkpointIdx|.
+  FakeEnding GetFakeEnding(size_t checkpointIdx) const;
+
+private:
+  // Fills |ConnectionToOsm| for checkpoints for its further attachment to the roads graph.
+  void AddConnectionToOsm(size_t checkpointIdx, Segment const & real,
+                          geometry::PointWithAltitude const & loop);
+
+  // Attaches checkpoints to the nearest guides tracks if possible.
+  void PullCheckpointsToTracks(std::vector<m2::PointD> const & checkpoints);
+
+  // Attaches terminal point on the track to the terminal checkpoint: start to start;
+  // finish - to finish.
+  void AddTerminalGuidePoint(size_t checkpointIdx, size_t neighbourIdx,
+                             m2::PointD const & curPoint);
+
+  // Attaches neighbour terminal checkpoints for those which are already attached.
+  void PullAdditionalCheckpointsToTracks(std::vector<m2::PointD> const & checkpoints);
+
+  GuidesTracks m_allTracks;
+  Projections m_checkpointsOnTracks;
+
+  // Maps with checkpoint indexes as keys.
+  std::map<size_t, FakeEnding> m_checkpointsFakeEndings;
+  std::map<size_t, std::vector<ConnectionToOsm>> m_connectionsToOsm;
+
+  GuidesGraph m_graph;
+};
+}  // namespace routing

--- a/routing/guides_graph.cpp
+++ b/routing/guides_graph.cpp
@@ -1,0 +1,158 @@
+#include "routing/guides_graph.hpp"
+
+#include "routing/fake_feature_ids.hpp"
+
+#include "geometry/distance_on_sphere.hpp"
+#include "geometry/mercator.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <tuple>
+
+namespace
+{
+double constexpr kZeroAltitude = 0.0;
+}  // namespace
+
+namespace routing
+{
+bool GuideSegmentCompare::operator()(Segment const & lhs, Segment const & rhs) const
+{
+  if (lhs.GetFeatureId() != rhs.GetFeatureId())
+    return lhs.GetFeatureId() < rhs.GetFeatureId();
+
+  return lhs.GetSegmentIdx() < rhs.GetSegmentIdx();
+}
+
+GuidesGraph::GuidesGraph(double maxSpeedMpS, NumMwmId mwmId)
+  : m_maxSpeedMpS(maxSpeedMpS)
+  , m_mwmId(mwmId)
+  , m_curGuidesFeatrueId(FakeFeatureIds::kGuidesGraphFeaturesStart)
+{
+  CHECK_NOT_EQUAL(m_maxSpeedMpS, 0.0, ());
+}
+
+double GuidesGraph::CalcSegmentTimeS(LatLonWithAltitude const & point1,
+                                     LatLonWithAltitude const & point2) const
+{
+  double const distM = ms::DistanceOnEarth(point1.GetLatLon(), point2.GetLatLon());
+  double const weight = distM / m_maxSpeedMpS;
+  return weight;
+}
+
+void GuidesGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
+                              std::vector<SegmentEdge> & edges,
+                              RouteWeight const & prevWeight) const
+{
+  auto const it = m_segments.find(segment);
+  CHECK(it != m_segments.end(), (segment));
+  auto const & segmentOnTrack = it->first;
+
+  IterOnTrack itOnTrack;
+
+  if (segment.IsForward() == isOutgoing)
+  {
+    Segment nextSegment(segmentOnTrack.GetMwmId(), segmentOnTrack.GetFeatureId(),
+                        segmentOnTrack.GetSegmentIdx() + 1, segmentOnTrack.IsForward());
+    itOnTrack = m_segments.find(nextSegment);
+    if (itOnTrack == m_segments.end())
+      return;
+  }
+  else
+  {
+    if (it->first.GetSegmentIdx() == 0)
+      return;
+
+    Segment prevSegment(segmentOnTrack.GetMwmId(), segmentOnTrack.GetFeatureId(),
+                        segmentOnTrack.GetSegmentIdx() - 1, segmentOnTrack.IsForward());
+    itOnTrack = m_segments.find(prevSegment);
+    CHECK(itOnTrack != m_segments.end(), (segment));
+  }
+  auto const & neighbour = itOnTrack->first;
+  Segment const resSegment(neighbour.GetMwmId(), neighbour.GetFeatureId(),
+                           neighbour.GetSegmentIdx(), segment.IsForward());
+
+  auto const weight = isOutgoing ? RouteWeight(itOnTrack->second.m_weight) : prevWeight;
+  edges.emplace_back(resSegment, weight);
+}
+
+LatLonWithAltitude const & GuidesGraph::GetJunction(Segment const & segment, bool front) const
+{
+  auto const it = m_segments.find(segment);
+  CHECK(it != m_segments.end(), (segment));
+  return segment.IsForward() == front ? it->second.m_pointLast : it->second.m_pointFirst;
+}
+
+NumMwmId GuidesGraph::GetMwmId() const { return m_mwmId; }
+
+Segment GuidesGraph::AddTrack(std::vector<geometry::PointWithAltitude> const & guideTrack,
+                              size_t requiredSegmentIdx)
+{
+  uint32_t segmentIdx = 0;
+  Segment segment;
+
+  for (size_t i = 0; i < guideTrack.size() - 1; ++i)
+  {
+    GuideSegmentData data;
+    Segment curSegment(m_mwmId, m_curGuidesFeatrueId, segmentIdx++, true /* forward */);
+    if (i == requiredSegmentIdx)
+      segment = curSegment;
+
+    data.m_pointFirst = LatLonWithAltitude(mercator::ToLatLon(guideTrack[i].GetPoint()),
+                                           guideTrack[i].GetAltitude());
+    data.m_pointLast = LatLonWithAltitude(mercator::ToLatLon(guideTrack[i + 1].GetPoint()),
+                                          guideTrack[i + 1].GetAltitude());
+
+    data.m_weight = CalcSegmentTimeS(data.m_pointFirst, data.m_pointLast);
+
+    auto const [it, inserted] = m_segments.emplace(curSegment, data);
+    CHECK(inserted, (curSegment));
+  }
+  ++m_curGuidesFeatrueId;
+  return segment;
+}
+
+Segment GuidesGraph::FindSegment(Segment const & segment, size_t segmentIdx) const
+{
+  auto const it = m_segments.find(segment);
+  CHECK(it != m_segments.end(), (segment, segmentIdx));
+  Segment segmentOnTrack(it->first.GetMwmId(), it->first.GetFeatureId(),
+                         static_cast<uint32_t>(segmentIdx), it->first.IsForward());
+
+  auto const itByIndex = m_segments.find(segmentOnTrack);
+  CHECK(itByIndex != m_segments.end(), (segment, segmentIdx));
+  return itByIndex->first;
+}
+
+RouteWeight GuidesGraph::CalcSegmentWeight(Segment const & segment) const
+{
+  auto const it = m_segments.find(segment);
+  CHECK(it != m_segments.end(), (segment));
+
+  return RouteWeight(it->second.m_weight);
+}
+
+FakeEnding GuidesGraph::MakeFakeEnding(Segment const & segment, m2::PointD const & point,
+                                       geometry::PointWithAltitude const & projection) const
+{
+  auto const & frontJunction = GetJunction(segment, true /* front */);
+  auto const & backJunction = GetJunction(segment, false /* front */);
+
+  FakeEnding ending;
+  ending.m_projections.emplace_back(segment, false /* isOneWay */, frontJunction, backJunction,
+                                    LatLonWithAltitude(mercator::ToLatLon(projection.GetPoint()),
+                                                       projection.GetAltitude()) /* junction */);
+
+  ending.m_originJunction =
+      LatLonWithAltitude(mercator::ToLatLon(point), static_cast<geometry::Altitude>(kZeroAltitude));
+  return ending;
+}
+
+std::pair<LatLonWithAltitude, LatLonWithAltitude> GuidesGraph::GetFromTo(
+    Segment const & segment) const
+{
+  auto const & from = GetJunction(segment, false /* front */);
+  auto const & to = GetJunction(segment, true /* front */);
+  return std::make_pair(from, to);
+}
+}  // namespace routing

--- a/routing/guides_graph.hpp
+++ b/routing/guides_graph.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "routing/fake_ending.hpp"
+#include "routing/latlon_with_altitude.hpp"
+#include "routing/segment.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace routing
+{
+// Segment of the track in the guides graph.
+struct GuideSegmentData
+{
+  LatLonWithAltitude m_pointFirst;
+  LatLonWithAltitude m_pointLast;
+  double m_weight = 0.0;
+};
+
+// Custom comparison optimized for Guides segments: they all have the same |m_mwmId| and
+// |m_forward| is always true.
+struct GuideSegmentCompare
+{
+  bool operator()(Segment const & lhs, Segment const & rhs) const;
+};
+
+using GuideSegments = std::map<Segment, GuideSegmentData, GuideSegmentCompare>;
+using IterOnTrack = GuideSegments::const_iterator;
+
+// Graph used in IndexGraphStarter for building routes through the guides tracks.
+class GuidesGraph
+{
+public:
+  GuidesGraph() = default;
+  explicit GuidesGraph(double maxSpeedMpS, NumMwmId mwmId);
+
+  Segment AddTrack(std::vector<geometry::PointWithAltitude> const & guideTrack,
+                   size_t requiredSegmentIdx);
+
+  FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
+                            geometry::PointWithAltitude const & projection) const;
+
+  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges,
+                   RouteWeight const & prevWeight) const;
+  routing::LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment) const;
+  Segment FindSegment(Segment const & segment, size_t segmentIdx) const;
+
+  // Returns back and front points of the segment. Segment belongs to one of the guides tracks.
+  std::pair<LatLonWithAltitude, LatLonWithAltitude> GetFromTo(Segment const & segment) const;
+
+  NumMwmId GetMwmId() const;
+
+private:
+  double CalcSegmentTimeS(LatLonWithAltitude const & point1,
+                          LatLonWithAltitude const & point2) const;
+
+  GuideSegments m_segments;
+  double m_maxSpeedMpS = 0.0;
+  NumMwmId m_mwmId = 0;
+  uint32_t m_curGuidesFeatrueId = 0;
+};
+}  // namespace routing

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -67,10 +67,16 @@ IndexGraphStarter::IndexGraphStarter(FakeEnding const & startEnding,
                                      bool strictForward, WorldGraph & graph)
   : m_graph(graph)
 {
-  m_start.m_id = fakeNumerationStart;
-  AddStart(startEnding, finishEnding, strictForward, fakeNumerationStart);
-  m_finish.m_id = fakeNumerationStart;
-  AddFinish(finishEnding, startEnding, fakeNumerationStart);
+  m_fakeNumerationStart = fakeNumerationStart;
+
+  m_start.m_id = m_fakeNumerationStart;
+  AddStart(startEnding, finishEnding, strictForward);
+  m_finish.m_id = m_fakeNumerationStart;
+  AddFinish(finishEnding, startEnding);
+
+  m_otherEndings.push_back(startEnding);
+  m_otherEndings.push_back(finishEnding);
+
   auto const startPoint = GetPoint(GetStartSegment(), false /* front */);
   auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */);
   m_startToFinishDistanceM = ms::DistanceOnEarth(startPoint, finishPoint);
@@ -86,7 +92,10 @@ void IndexGraphStarter::Append(FakeEdgesContainer const & container)
   auto const startPoint = GetPoint(GetStartSegment(), false /* front */);
   auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */);
   m_startToFinishDistanceM = ms::DistanceOnEarth(startPoint, finishPoint);
+  m_fakeNumerationStart += container.m_fake.GetSize();
 }
+
+void IndexGraphStarter::SetGuides(GuidesGraph const & guides) { m_guides = guides; }
 
 LatLonWithAltitude const & IndexGraphStarter::GetStartJunction() const
 {
@@ -110,6 +119,9 @@ bool IndexGraphStarter::ConvertToReal(Segment & segment) const
 
 LatLonWithAltitude const & IndexGraphStarter::GetJunction(Segment const & segment, bool front) const
 {
+  if (IsGuidesSegment(segment))
+    return m_guides.GetJunction(segment, front);
+
   if (!IsFakeSegment(segment))
     return m_graph.GetJunction(segment, front);
 
@@ -192,6 +204,11 @@ void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & v
   CHECK_NOT_EQUAL(m_graph.GetMode(), WorldGraphMode::LeapsOnly, ());
 
   auto const & segment = vertexData.m_vertex;
+  // Weight used only when isOutgoing = false for passing to m_guides and placing to |edges|.
+  RouteWeight ingoingSegmentWeight;
+  if (!isOutgoing)
+    ingoingSegmentWeight = CalcSegmentWeight(segment, EdgeEstimator::Purpose::Weight);
+
   if (IsFakeSegment(segment))
   {
     Segment real;
@@ -201,14 +218,28 @@ void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & v
       bool const haveSameBack = GetJunction(segment, false /* front */) == GetJunction(real, false);
       if ((isOutgoing && haveSameFront) || (!isOutgoing && haveSameBack))
       {
-        astar::VertexData const replacedFakeSegment(real, vertexData.m_realDistance);
-        m_graph.GetEdgeList(replacedFakeSegment, isOutgoing, true /* useRoutingOptions */,
-                            useAccessConditional, edges);
+        if (IsGuidesSegment(real))
+        {
+          m_guides.GetEdgeList(real, isOutgoing, edges, ingoingSegmentWeight);
+        }
+        else
+        {
+          astar::VertexData const replacedFakeSegment(real, vertexData.m_realDistance);
+          m_graph.GetEdgeList(replacedFakeSegment, isOutgoing, true /* useRoutingOptions */,
+                              useAccessConditional, edges);
+        }
       }
     }
 
     for (auto const & s : m_fake.GetEdges(segment, isOutgoing))
-      edges.emplace_back(s, CalcSegmentWeight(isOutgoing ? s : segment, EdgeEstimator::Purpose::Weight));
+    {
+      edges.emplace_back(s, isOutgoing ? CalcSegmentWeight(s, EdgeEstimator::Purpose::Weight)
+                                       : ingoingSegmentWeight);
+    }
+  }
+  else if (IsGuidesSegment(segment))
+  {
+    m_guides.GetEdgeList(segment, isOutgoing, edges, ingoingSegmentWeight);
   }
   else
   {
@@ -219,13 +250,24 @@ void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & v
   AddFakeEdges(segment, isOutgoing, edges);
 }
 
+RouteWeight IndexGraphStarter::CalcGuidesSegmentWeight(Segment const & segment,
+                                                       EdgeEstimator::Purpose purpose) const
+{
+  if (purpose == EdgeEstimator::Purpose::Weight)
+    return m_guides.CalcSegmentWeight(segment);
+
+  auto [from, to] = m_guides.GetFromTo(segment);
+  return m_graph.CalcOffroadWeight(from.GetLatLon(), to.GetLatLon(), purpose);
+}
+
 RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment,
                                                  EdgeEstimator::Purpose purpose) const
 {
+  if (IsGuidesSegment(segment))
+    return CalcGuidesSegmentWeight(segment, purpose);
+
   if (!IsFakeSegment(segment))
-  {
     return m_graph.CalcSegmentWeight(segment, purpose);
-  }
 
   auto const & vertex = m_fake.GetVertex(segment);
   Segment real;
@@ -239,10 +281,13 @@ RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment,
     // it's necessary to return a instance of the structure |RouteWeight| with zero wight.
     // Theoretically it may be differ from |RouteWeight(0)| because some road access block
     // may be kept in it and it is up to |RouteWeight| to know how to multiply by zero.
-    if (fullLen == 0.0)
-      return 0.0 * m_graph.CalcSegmentWeight(real, purpose);
 
-    return (partLen / fullLen) * m_graph.CalcSegmentWeight(real, purpose);
+    Weight const weight = IsGuidesSegment(real) ? CalcGuidesSegmentWeight(real, purpose)
+                                                : m_graph.CalcSegmentWeight(real, purpose);
+    if (fullLen == 0.0)
+      return 0.0 * weight;
+
+    return (partLen / fullLen) * weight;
   }
 
   return m_graph.CalcOffroadWeight(vertex.GetPointFrom(), vertex.GetPointTo(), purpose);
@@ -257,6 +302,22 @@ double IndexGraphStarter::CalculateETA(Segment const & from, Segment const & to)
   if (IsFakeSegment(from))
     return CalculateETAWithoutPenalty(to);
 
+  if (IsGuidesSegment(from) || IsGuidesSegment(to))
+  {
+    double res = 0.0;
+    if (IsGuidesSegment(from))
+      res += CalcGuidesSegmentWeight(from, EdgeEstimator::Purpose::ETA).GetWeight();
+    else
+      res += CalculateETAWithoutPenalty(from);
+
+    if (IsGuidesSegment(to))
+      res += CalcGuidesSegmentWeight(to, EdgeEstimator::Purpose::ETA).GetWeight();
+    else
+      res += CalculateETAWithoutPenalty(to);
+
+    return res;
+  }
+
   return m_graph.CalculateETA(from, to);
 }
 
@@ -265,11 +326,107 @@ double IndexGraphStarter::CalculateETAWithoutPenalty(Segment const & segment) co
   if (IsFakeSegment(segment))
     return CalcSegmentWeight(segment, EdgeEstimator::Purpose::ETA).GetWeight();
 
+  if (IsGuidesSegment(segment))
+    return CalcGuidesSegmentWeight(segment, EdgeEstimator::Purpose::ETA).GetWeight();
+
   return m_graph.CalculateETAWithoutPenalty(segment);
 }
 
+void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding)
+{
+  Segment const dummy = Segment();
+
+  map<Segment, vector<LatLonWithAltitude>> otherSegments;
+  for (auto const & ending : m_otherEndings)
+  {
+    for (auto const & p : ending.m_projections)
+    {
+      otherSegments[p.m_segment].push_back(p.m_junction);
+      // We use |otherEnding| to generate proper fake edges in case both endings have projections
+      // to the same segment. Direction of p.m_segment does not matter.
+      otherSegments[GetReverseSegment(p.m_segment)].push_back(p.m_junction);
+    }
+  }
+
+  // Add pure fake vertex
+  auto const fakeSegment = GetFakeSegmentAndIncr();
+  FakeVertex fakeVertex(kFakeNumMwmId, thisEnding.m_originJunction, thisEnding.m_originJunction,
+                        FakeVertex::Type::PureFake);
+  m_fake.AddStandaloneVertex(fakeSegment, fakeVertex);
+  for (bool isStart : {true, false})
+  {
+    for (auto const & projection : thisEnding.m_projections)
+    {
+      // Add projection edges
+      auto const projectionSegment = GetFakeSegmentAndIncr();
+      FakeVertex projectionVertex(projection.m_segment.GetMwmId(),
+                                  isStart ? thisEnding.m_originJunction : projection.m_junction,
+                                  isStart ? projection.m_junction : thisEnding.m_originJunction,
+                                  FakeVertex::Type::PureFake);
+      m_fake.AddVertex(fakeSegment, projectionSegment, projectionVertex, isStart /* isOutgoing */,
+                       false /* isPartOfReal */, dummy /* realSegment */);
+
+      // Add fake parts of real
+      auto frontJunction = projection.m_segmentFront;
+      auto backJunction = projection.m_segmentBack;
+
+      // Check whether we have projections to same real segment from both endings.
+      auto const it = otherSegments.find(projection.m_segment);
+      if (it != otherSegments.end())
+      {
+        LatLonWithAltitude otherJunction = it->second[0];
+        double distBackToOther =
+            ms::DistanceOnEarth(backJunction.GetLatLon(), otherJunction.GetLatLon());
+        for (auto const & coord : it->second)
+        {
+          double curDist = ms::DistanceOnEarth(backJunction.GetLatLon(), coord.GetLatLon());
+          if (curDist < distBackToOther)
+          {
+            distBackToOther = curDist;
+            otherJunction = coord;
+          }
+        }
+
+        auto const distBackToThis =
+            ms::DistanceOnEarth(backJunction.GetLatLon(), projection.m_junction.GetLatLon());
+
+        if (distBackToThis < distBackToOther)
+          frontJunction = otherJunction;
+        else if (distBackToOther < distBackToThis)
+          backJunction = otherJunction;
+        else
+          frontJunction = backJunction = otherJunction;
+      }
+
+      FakeVertex forwardPartOfReal(
+          projection.m_segment.GetMwmId(), isStart ? projection.m_junction : backJunction,
+          isStart ? frontJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
+      Segment fakeForwardSegment;
+      if (!m_fake.FindSegment(forwardPartOfReal, fakeForwardSegment))
+        fakeForwardSegment = GetFakeSegmentAndIncr();
+      m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
+                       isStart /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
+
+      if (!projection.m_isOneWay)
+      {
+        auto const backwardSegment = GetReverseSegment(projection.m_segment);
+        FakeVertex backwardPartOfReal(
+            backwardSegment.GetMwmId(), isStart ? projection.m_junction : frontJunction,
+            isStart ? backJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
+        Segment fakeBackwardSegment;
+        if (!m_fake.FindSegment(backwardPartOfReal, fakeBackwardSegment))
+          fakeBackwardSegment = GetFakeSegmentAndIncr();
+        m_fake.AddVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
+                         isStart /* isOutgoing */, true /* isPartOfReal */, backwardSegment);
+      }
+    }
+  }
+
+  m_otherEndings.push_back(thisEnding);
+}
+
 void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding const & otherEnding,
-                                  bool isStart, bool strictForward, uint32_t & fakeNumerationStart)
+                                  bool isStart, bool strictForward)
 {
   Segment const dummy = Segment();
 
@@ -283,7 +440,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
   }
 
   // Add pure fake vertex
-  auto const fakeSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
+  auto const fakeSegment = GetFakeSegmentAndIncr();
   FakeVertex fakeVertex(kFakeNumMwmId, thisEnding.m_originJunction, thisEnding.m_originJunction,
                         FakeVertex::Type::PureFake);
   m_fake.AddStandaloneVertex(fakeSegment, fakeVertex);
@@ -295,7 +452,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
       m_finish.m_real.insert(projection.m_segment);
 
     // Add projection edges
-    auto const projectionSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
+    auto const projectionSegment = GetFakeSegmentAndIncr();
     FakeVertex projectionVertex(projection.m_segment.GetMwmId(),
                                 isStart ? thisEnding.m_originJunction : projection.m_junction,
                                 isStart ? projection.m_junction : thisEnding.m_originJunction,
@@ -329,7 +486,7 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
         isStart ? frontJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
     Segment fakeForwardSegment;
     if (!m_fake.FindSegment(forwardPartOfReal, fakeForwardSegment))
-      fakeForwardSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
+      fakeForwardSegment = GetFakeSegmentAndIncr();
     m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
                      isStart /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
 
@@ -341,25 +498,30 @@ void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding, FakeEnding cons
           isStart ? backJunction : projection.m_junction, FakeVertex::Type::PartOfReal);
       Segment fakeBackwardSegment;
       if (!m_fake.FindSegment(backwardPartOfReal, fakeBackwardSegment))
-        fakeBackwardSegment = GetFakeSegmentAndIncr(fakeNumerationStart);
+        fakeBackwardSegment = GetFakeSegmentAndIncr();
       m_fake.AddVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
                        isStart /* isOutgoing */, true /* isPartOfReal */, backwardSegment);
     }
   }
 }
 
-void IndexGraphStarter::AddStart(FakeEnding const & startEnding, FakeEnding const & finishEnding,
-                                 bool strictForward, uint32_t & fakeNumerationStart)
+void IndexGraphStarter::ConnectLoopToGuideSegments(
+    FakeVertex const & loop, Segment const & realSegment, LatLonWithAltitude realFrom,
+    LatLonWithAltitude realTo, vector<pair<FakeVertex, Segment>> const & partsOfReal)
 {
-  AddEnding(startEnding, finishEnding, true /* isStart */, strictForward, fakeNumerationStart);
+  m_fake.ConnectLoopToGuideSegments(loop, realSegment, realFrom, realTo, partsOfReal);
+}
+
+void IndexGraphStarter::AddStart(FakeEnding const & startEnding, FakeEnding const & finishEnding,
+                                 bool strictForward)
+{
+  AddEnding(startEnding, finishEnding, true /* isStart */, strictForward);
   m_start.FillMwmIds();
 }
 
-void IndexGraphStarter::AddFinish(FakeEnding const & finishEnding, FakeEnding const & startEnding,
-                                  uint32_t & fakeNumerationStart)
+void IndexGraphStarter::AddFinish(FakeEnding const & finishEnding, FakeEnding const & startEnding)
 {
-  AddEnding(finishEnding, startEnding, false /* isStart */, false /* strictForward */,
-            fakeNumerationStart);
+  AddEnding(finishEnding, startEnding, false /* isStart */, false /* strictForward */);
   m_finish.FillMwmIds();
 }
 
@@ -394,11 +556,11 @@ void IndexGraphStarter::AddFakeEdges(Segment const & segment, bool isOutgoing, v
 
 bool IndexGraphStarter::EndingPassThroughAllowed(Ending const & ending)
 {
-  return any_of(ending.m_real.cbegin(), ending.m_real.cend(),
-                [this](Segment const & s) {
-                  return m_graph.IsPassThroughAllowed(s.GetMwmId(),
-                                                      s.GetFeatureId());
-                });
+  return any_of(ending.m_real.cbegin(), ending.m_real.cend(), [this](Segment const & s) {
+    if (IsGuidesSegment(s))
+      return true;
+    return m_graph.IsPassThroughAllowed(s.GetMwmId(), s.GetFeatureId());
+  });
 }
 
 bool IndexGraphStarter::StartPassThroughAllowed()
@@ -409,6 +571,12 @@ bool IndexGraphStarter::StartPassThroughAllowed()
 bool IndexGraphStarter::FinishPassThroughAllowed()
 {
   return EndingPassThroughAllowed(m_finish);
+}
+
+Segment IndexGraphStarter::GetFakeSegmentAndIncr()
+{
+  CHECK_LESS(m_fakeNumerationStart, numeric_limits<uint32_t>::max(), ());
+  return GetFakeSegment(m_fakeNumerationStart++);
 }
 
 RouteWeight IndexGraphStarter::GetAStarWeightEpsilon()

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -1,5 +1,6 @@
 #include "routing/index_road_graph.hpp"
 
+#include "routing/fake_feature_ids.hpp"
 #include "routing/latlon_with_altitude.hpp"
 #include "routing/routing_exceptions.hpp"
 #include "routing/transit_graph.hpp"
@@ -64,6 +65,12 @@ void IndexRoadGraph::GetEdgeTypes(Edge const & edge, feature::TypesHolder & type
   }
 
   FeatureID const featureId = edge.GetFeatureId();
+  if (FakeFeatureIds::IsGuidesFeature(featureId.m_index))
+  {
+    types = feature::TypesHolder(feature::GeomType::Line);
+    return;
+  }
+
   FeaturesLoaderGuard loader(m_dataSource, featureId.m_mwmId);
   auto ft = loader.GetFeatureByIndex(featureId.m_index);
   if (!ft)

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -515,12 +515,11 @@ void IndexRouter::AddGuidesOsmConnectionsToGraphStarter(size_t checkpointIdxFrom
   auto linksTo = m_guides.GetOsmConnections(checkpointIdxTo);
   for (auto const & link : linksTo)
   {
-    auto it =
-        std::find_if(linksFrom.begin(), linksFrom.end(), [&link](ConnectionToOsm const & cur) {
-          return link.m_fakeEnding.m_originJunction == cur.m_fakeEnding.m_originJunction &&
-                 link.m_fakeEnding.m_projections == cur.m_fakeEnding.m_projections &&
-                 link.m_realSegment == cur.m_realSegment && link.m_realTo == cur.m_realTo;
-        });
+    auto it = find_if(linksFrom.begin(), linksFrom.end(), [&link](ConnectionToOsm const & cur) {
+      return link.m_fakeEnding.m_originJunction == cur.m_fakeEnding.m_originJunction &&
+             link.m_fakeEnding.m_projections == cur.m_fakeEnding.m_projections &&
+             link.m_realSegment == cur.m_realSegment && link.m_realTo == cur.m_realTo;
+    });
 
     if (it == linksFrom.end())
     {

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -1,17 +1,22 @@
 #pragma once
 
-#include "routing/routing_callbacks.hpp"
 #include "routing/checkpoints.hpp"
 #include "routing/route.hpp"
 #include "routing/router_delegate.hpp"
+#include "routing/routing_callbacks.hpp"
+
+#include "kml/type_utils.hpp"
 
 #include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 #include "geometry/rect2d.hpp"
 
 #include "base/cancellable.hpp"
 
 #include <functional>
+#include <map>
 #include <string>
+#include <vector>
 
 namespace routing
 {
@@ -19,6 +24,10 @@ namespace routing
 using TCountryFileFn = std::function<std::string(m2::PointD const &)>;
 using CourntryRectFn = std::function<m2::RectD(std::string const & countryId)>;
 using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
+
+// Guides with integer ids containing multiple tracks. One track consists of its points.
+using GuidesTracks =
+    std::map<kml::MarkGroupId, std::vector<std::vector<geometry::PointWithAltitude>>>;
 
 class Route;
 
@@ -54,6 +63,8 @@ public:
 
   /// Clear all temporary buffers.
   virtual void ClearState() {}
+
+  virtual void SetGuides(GuidesTracks && guides) = 0;
 
   /// Override this function with routing implementation.
   /// It will be called in separate thread and only one function will processed in same time.

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
   bicycle_route_test.cpp
   bicycle_turn_test.cpp
   get_altitude_test.cpp
+  guides_tests.cpp
   online_cross_tests.cpp
   pedestrian_route_test.cpp
   road_graph_tests.cpp

--- a/routing/routing_integration_tests/guides_tests.cpp
+++ b/routing/routing_integration_tests/guides_tests.cpp
@@ -1,0 +1,124 @@
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "testing/testing.hpp"
+
+#include "routing/route.hpp"
+#include "routing/routing_callbacks.hpp"
+
+#include "geometry/latlon.hpp"
+
+#include <algorithm>
+
+using namespace routing;
+
+namespace
+{
+// Test guide track is laid crosswise the OSM road graph. It doesn't match the OSM roads so we
+// can test route length, time and points number and it is enough to guarantee that the route
+// built during the test is the route through the guide which we expect.
+GuidesTracks GetTestGuides()
+{
+  // Guide with single track.
+  GuidesTracks guides;
+  guides[10] = {{{mercator::FromLatLon(48.13999, 11.56873), 10},
+                 {mercator::FromLatLon(48.14096, 11.57246), 10},
+                 {mercator::FromLatLon(48.14487, 11.57259), 10}}};
+  return guides;
+}
+
+void TestGuideRoute(Checkpoints const & checkpoints, double expectedDistM, double expectedTimeS,
+                    size_t expectedPointsCount)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(
+      integration::GetVehicleComponents(VehicleType::Pedestrian), checkpoints, GetTestGuides());
+
+  TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
+
+  integration::TestRouteLength(*routeResult.first, expectedDistM);
+  integration::TestRouteTime(*routeResult.first, expectedTimeS);
+  integration::TestRoutePointsNumber(*routeResult.first, expectedPointsCount);
+}
+
+void ReverseCheckpoints(Checkpoints const & checkpoints)
+{
+  auto points = checkpoints.GetPoints();
+  std::reverse(points.begin(), points.end());
+}
+
+// Start and finish checkpoints are connected to the track via single fake edge.
+UNIT_TEST(Guides_TwoPointsOnTrack)
+{
+  // Checkpoints lie on the track.
+  Checkpoints const checkpoints{mercator::FromLatLon(48.14367, 11.57257),
+                                mercator::FromLatLon(48.13999, 11.56873)};
+
+  double const expectedDistM = 600.8;
+  double const expectedTimeS = 721.0;
+  size_t const expectedPointsCount = 7;
+
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+  ReverseCheckpoints(checkpoints);
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+}
+
+// One checkpoint is connected to the track projection via OSM,
+// other checkpoint is connected to the track projection via single fake edge.
+UNIT_TEST(Guides_TwoPointsOnTrackOneViaOsm)
+{
+  // Start is further from track then |kEqDistToTrackPointM|, but finish is closer.
+  Checkpoints const checkpoints{mercator::FromLatLon(48.13998, 11.56982),
+                                mercator::FromLatLon(48.14448, 11.57259)};
+
+  double const expectedDistM = 702.4;
+  double const expectedTimeS = 821.6;
+  size_t const expectedPointsCount = 11;
+
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+  ReverseCheckpoints(checkpoints);
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+}
+
+// Start checkpoint is far away from the track, finish checkpoint lies in meters from
+// the middle of the track. We build the first part of the route from start to the terminal
+// track point, second part - from the terminal point to the finish.
+UNIT_TEST(Guides_FinishPointOnTrack)
+{
+  Checkpoints const checkpoints{mercator::FromLatLon(48.1394659, 11.575924),
+                                mercator::FromLatLon(48.1407632, 11.5716992)};
+
+  double const expectedDistM = 840.1;
+  double const expectedTimeS = 771.3;
+  size_t const expectedPointsCount = 37;
+
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+}
+
+// Start checkpoint is on the track, finish checkpoint is far away. We build the first part of the
+// route through the track and the second part - through the OSM roads.
+UNIT_TEST(Guides_StartPointOnTrack)
+{
+  Checkpoints const checkpoints{mercator::FromLatLon(48.14168, 11.57244),
+                                mercator::FromLatLon(48.13741, 11.56095)};
+
+  double const expectedDistM = 1272.3;
+  double const expectedTimeS = 1192.0;
+  size_t const expectedPointsCount = 67;
+
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+}
+
+// Start and finish lie on the track; 3 intermediate points are far away from the track.
+UNIT_TEST(Guides_MultipleIntermediatePoints)
+{
+  Checkpoints const checkpoints(
+      {mercator::FromLatLon(48.14403, 11.57259), mercator::FromLatLon(48.14439, 11.57480),
+       mercator::FromLatLon(48.14192, 11.57548), mercator::FromLatLon(48.14106, 11.57279),
+       mercator::FromLatLon(48.14044, 11.57061)});
+
+  double const expectedDistM = 1221.11;
+  double const expectedTimeS = 1096.6;
+  size_t const expectedPointsCount = 67;
+
+  TestGuideRoute(checkpoints, expectedDistM, expectedTimeS, expectedPointsCount);
+}
+}  // namespace

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <set>
 #include <tuple>
+#include <utility>
 
 using namespace routing;
 using namespace routing_test;
@@ -159,6 +160,20 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
   RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
       Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, *route);
   ASSERT(route, ());
+  routerComponents.GetRouter().SetGuides({});
+  return TRouteResult(route, result);
+}
+
+TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
+                            Checkpoints const & checkpoints, GuidesTracks && guides)
+{
+  RouterDelegate delegate;
+  shared_ptr<Route> route = make_shared<Route>("mapsme", 0 /* route id */);
+  routerComponents.GetRouter().SetGuides(move(guides));
+  RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
+      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, *route);
+  ASSERT(route, ());
+  routerComponents.GetRouter().SetGuides({});
   return TRouteResult(route, result);
 }
 

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -109,6 +109,9 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                             m2::PointD const & startPoint, m2::PointD const & startDirection,
                             m2::PointD const & finalPoint);
 
+TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
+                            Checkpoints const & checkpoints, GuidesTracks && guides);
+
 void TestTurnCount(Route const & route, uint32_t expectedTurnCount);
 
 /// Testing route length.

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -80,13 +80,15 @@ void RoutingSession::Init(RoutingStatisticsCallback const & routingStatisticsFn,
   alohalytics::LogEvent("OnRoutingInit", params);
 }
 
-void RoutingSession::BuildRoute(Checkpoints const & checkpoints,
+void RoutingSession::BuildRoute(Checkpoints const & checkpoints, GuidesTracks && guides,
                                 uint32_t timeoutSec)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   CHECK(m_router, ());
   m_checkpoints = checkpoints;
   m_router->ClearState();
+  m_router->SetGuidesTracks(std::move(guides));
+
   m_isFollowing = false;
   m_routingRebuildCount = -1; // -1 for the first rebuild.
 
@@ -115,8 +117,8 @@ void RoutingSession::RebuildRoute(m2::PointD const & startPoint,
   // Use old-style callback construction, because lambda constructs buggy function on Android
   // (callback param isn't captured by value).
   m_router->CalculateRoute(checkpoints, direction, adjustToPrevRoute,
-                           DoReadyCallback(*this, readyCallback),
-                           needMoreMapsCallback, removeRouteCallback, m_progressCallback, timeoutSec);
+                           DoReadyCallback(*this, readyCallback), needMoreMapsCallback,
+                           removeRouteCallback, m_progressCallback, timeoutSec);
 }
 
 m2::PointD RoutingSession::GetStartPoint() const

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -58,8 +58,7 @@ public:
 
   /// @param[in] checkpoints in mercator
   /// @param[in] timeoutSec timeout in seconds, if zero then there is no timeout
-  void BuildRoute(Checkpoints const & checkpoints,
-                  uint32_t timeoutSec);
+  void BuildRoute(Checkpoints const & checkpoints, GuidesTracks && guides, uint32_t timeoutSec);
   void RebuildRoute(m2::PointD const & startPoint, ReadyCallback const & readyCallback,
                     NeedMoreMapsCallback const & needMoreMapsCallback,
                     RemoveRouteCallback const & removeRouteCallback, uint32_t timeoutSec,

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
   edge_estimator_tests.cpp
   fake_graph_test.cpp
   followed_polyline_test.cpp
+  guides_tests.cpp
   index_graph_test.cpp
   index_graph_tools.cpp
   index_graph_tools.hpp

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -36,6 +36,7 @@ public:
   
   // IRouter overrides:
   string GetName() const override { return "Dummy"; }
+  void SetGuides(GuidesTracks && /* guides */) override {}
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
                             bool adjustToPrevRoute, RouterDelegate const & delegate,
                             Route & route) override

--- a/routing/routing_tests/fake_graph_test.cpp
+++ b/routing/routing_tests/fake_graph_test.cpp
@@ -1,6 +1,10 @@
 #include "testing/testing.hpp"
 
+#include "routing/fake_feature_ids.hpp"
 #include "routing/fake_graph.hpp"
+#include "routing/segment.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point2d.hpp"
 
@@ -12,13 +16,21 @@ using namespace std;
 
 namespace
 {
+Segment GetSegment(uint32_t segmentIdx, bool isReal = false)
+{
+  static NumMwmId constexpr kFakeNumMwmId = std::numeric_limits<NumMwmId>::max();
+  static uint32_t constexpr kFakeFeatureId = FakeFeatureIds::kIndexGraphStarterId;
+  if (isReal)
+    return Segment(0 /* mwmId */, 0 /* featureId */, segmentIdx, true /* isForward */);
+  return Segment(kFakeNumMwmId, kFakeFeatureId, segmentIdx, true /* isForward */);
+}
 // Constructs simple fake graph where vertex (i + 1) is child of vertex (i) with |numFake| fake
 // vertices and |numReal| real vertices. Checks vetex-to-segment, segment-to-vertex, fake-to-real,
 // real-to-fake mappings for each vertex. Checks ingoing and outgoing sets.
-FakeGraph<int32_t /* SegmentType */, m2::PointD /* VertexType */>
+FakeGraph<Segment /* SegmentType */, m2::PointD /* VertexType */>
 ConstructFakeGraph(uint32_t numerationStart, uint32_t numFake, uint32_t numReal)
 {
-  FakeGraph<int32_t, m2::PointD> fakeGraph;
+  FakeGraph<Segment, m2::PointD> fakeGraph;
 
   TEST_EQUAL(fakeGraph.GetSize(), 0, ("Constructed fake graph not empty"));
   if (numFake < 1)
@@ -28,19 +40,19 @@ ConstructFakeGraph(uint32_t numerationStart, uint32_t numFake, uint32_t numReal)
     return fakeGraph;
   }
 
-  int32_t const startSegment = numerationStart;
-  auto const startVertex = m2::PointD(numerationStart, numerationStart);
+  auto const startSegment = GetSegment(numerationStart);
+  m2::PointD const startVertex(numerationStart, numerationStart);
   fakeGraph.AddStandaloneVertex(startSegment, startVertex);
 
   // Add pure fake.
   for (uint32_t prevNumber = numerationStart; prevNumber + 1 < numerationStart + numFake + numReal;
        ++prevNumber)
   {
-    bool const newIsReal = prevNumber + 1 < numerationStart + numFake ? false : true;
-    int32_t const prevSegment = prevNumber;
-    int32_t const newSegment = prevNumber + 1;
-    auto const newVertex = m2::PointD(prevNumber + 1, prevNumber + 1);
-    int32_t const realSegment = -(prevNumber + 1);
+    bool const newIsReal = prevNumber + 1 >= numerationStart + numFake;
+    auto const prevSegment = GetSegment(prevNumber);
+    auto const newSegment = GetSegment(prevNumber + 1);
+    m2::PointD const newVertex(prevNumber + 1, prevNumber + 1);
+    auto const realSegment = GetSegment(prevNumber + 1, true /* isReal */);
 
     fakeGraph.AddVertex(prevSegment, newSegment, newVertex, true /* isOutgoing */,
                         newIsReal /* isPartOfReal */, realSegment);
@@ -48,21 +60,21 @@ ConstructFakeGraph(uint32_t numerationStart, uint32_t numFake, uint32_t numReal)
     // Test segment to vertex mapping.
     TEST_EQUAL(fakeGraph.GetVertex(newSegment), newVertex, ("Wrong segment to vertex mapping."));
     // Test outgoing edge.
-    TEST_EQUAL(fakeGraph.GetEdges(newSegment, false /* isOutgoing */), set<int32_t>{prevSegment},
+    TEST_EQUAL(fakeGraph.GetEdges(newSegment, false /* isOutgoing */), set<Segment>{prevSegment},
                ("Wrong ingoing edges set."));
     // Test ingoing edge.
-    TEST_EQUAL(fakeGraph.GetEdges(prevSegment, true /* isOutgoing */), set<int32_t>{newSegment},
+    TEST_EQUAL(fakeGraph.GetEdges(prevSegment, true /* isOutgoing */), set<Segment>{newSegment},
                ("Wrong ingoing edges set."));
     // Test graph size
     TEST_EQUAL(fakeGraph.GetSize() + numerationStart, prevNumber + 2, ("Wrong fake graph size."));
     // Test fake to real and real to fake mapping.
-    int32_t realFound;
+    Segment realFound;
     if (newIsReal)
     {
       TEST_EQUAL(fakeGraph.FindReal(newSegment, realFound), true,
                  ("Unexpected real segment found."));
       TEST_EQUAL(realSegment, realFound, ("Wrong fake to real mapping."));
-      TEST_EQUAL(fakeGraph.GetFake(realSegment), set<int32_t>{newSegment},
+      TEST_EQUAL(fakeGraph.GetFake(realSegment), set<Segment>{newSegment},
                  ("Unexpected fake segment found."));
     }
     else
@@ -79,7 +91,7 @@ ConstructFakeGraph(uint32_t numerationStart, uint32_t numFake, uint32_t numReal)
 namespace routing
 {
 // Test constructs two fake graphs, performs checks during construction, merges graphs
-// using FakeGraph::Append and checks topology of merged graph.
+// Calls FakeGraph::Append and checks topology of the merged graph.
 UNIT_TEST(FakeGraphTest)
 {
   uint32_t const fake0 = 5;
@@ -99,8 +111,8 @@ UNIT_TEST(FakeGraphTest)
   // Test merged graph.
   for (uint32_t i = 0; i + 1 < fakeGraph0.GetSize(); ++i)
   {
-    int32_t const segmentFrom = i;
-    int32_t const segmentTo = i + 1;
+    auto const segmentFrom = GetSegment(i);
+    auto const segmentTo = GetSegment(i + 1);
 
     TEST_EQUAL(fakeGraph0.GetVertex(segmentFrom), m2::PointD(i, i), ("Wrong segment to vertex mapping."));
     TEST_EQUAL(fakeGraph0.GetVertex(segmentTo), m2::PointD(i + 1, i + 1), ("Wrong segment to vertex mapping."));
@@ -114,10 +126,10 @@ UNIT_TEST(FakeGraphTest)
     }
     else
     {
-      TEST_EQUAL(fakeGraph0.GetEdges(segmentFrom, true /* isOutgoing */), set<int32_t>{segmentTo},
+      TEST_EQUAL(fakeGraph0.GetEdges(segmentFrom, true /* isOutgoing */), set<Segment>{segmentTo},
                  ("Wrong ingoing edges set."));
       TEST_EQUAL(fakeGraph0.GetEdges(segmentTo, false /* isOutgoing */),
-                 set<int32_t>{segmentFrom}, ("Wrong ingoing edges set."));
+                 set<Segment>{segmentFrom}, ("Wrong ingoing edges set."));
     }
   }
 }

--- a/routing/routing_tests/guides_tests.cpp
+++ b/routing/routing_tests/guides_tests.cpp
@@ -1,0 +1,136 @@
+#include "testing/testing.hpp"
+
+#include "routing/guides_connections.hpp"
+
+#include "geometry/mercator.hpp"
+
+namespace
+{
+using namespace routing;
+
+//  10 guide, track 0        10 guide, track 1     11 guide, track 0
+//  4 points                 3 points              3 points
+//
+//                                    X  2         X 2
+//                                   X            X
+//                                   X           X
+//                                  X           X
+//      2  XXXXX 3                  X          X 1
+//        X                        X           X
+//       X                         X           X
+//      X                         X            X
+//     X                          X 1          X
+//  XXX 1                       XX             X 0
+//  0                         XX
+//                          XX
+//                        XX 0
+
+GuidesTracks GetTestGuides()
+{
+  // Two guides. First with 2 tracks, second - with 1 track.
+  GuidesTracks guides;
+  guides[10] = {{{mercator::FromLatLon(48.13999, 11.56873), 5},
+                 {mercator::FromLatLon(48.14096, 11.57246), 5},
+                 {mercator::FromLatLon(48.14487, 11.57259), 6}},
+                {{mercator::FromLatLon(48.14349, 11.56712), 8},
+                 {mercator::FromLatLon(48.14298, 11.56604), 6},
+                 {mercator::FromLatLon(48.14223, 11.56362), 6},
+                 {mercator::FromLatLon(48.14202, 11.56283), 6}}};
+  guides[11] = {{{mercator::FromLatLon(48.14246, 11.57814), 9},
+                 {mercator::FromLatLon(48.14279, 11.57941), 10},
+                 {mercator::FromLatLon(48.14311, 11.58063), 10}}};
+  return guides;
+}
+
+UNIT_TEST(Guides_SafeInit)
+{
+  GuidesConnections guides;
+  TEST(!guides.IsActive(), ());
+  TEST(!guides.IsAttached(), ());
+  TEST(!guides.IsCheckpointAttached(0 /* checkpointIdx */), ());
+}
+
+UNIT_TEST(Guides_InitWithGuides)
+{
+  GuidesConnections guides(GetTestGuides());
+  TEST(guides.IsActive(), ());
+  TEST(!guides.IsAttached(), ());
+}
+
+UNIT_TEST(Guides_TooFarCheckpointsAreNotAttached)
+{
+  GuidesConnections guides(GetTestGuides());
+  TEST(guides.IsActive(), ());
+  TEST(!guides.IsAttached(), ());
+
+  // Checkpoints located further from guides than |kMaxDistToTrackPointM|.
+  std::vector<m2::PointD> const & checkpoints{mercator::FromLatLon(48.13902, 11.57113),
+                                              mercator::FromLatLon(48.14589, 11.56911)};
+
+  guides.ConnectToGuidesGraph(checkpoints);
+  TEST(!guides.IsAttached(), ());
+
+  for (size_t checkpointIdx = 0; checkpointIdx < checkpoints.size(); ++checkpointIdx)
+  {
+    TEST(!guides.IsCheckpointAttached(checkpointIdx), ());
+    TEST(guides.GetOsmConnections(checkpointIdx).empty(), ());
+  }
+}
+
+UNIT_TEST(Guides_FinishAndStartAttached)
+{
+  GuidesConnections guides(GetTestGuides());
+
+  // Start checkpoint should be with fake ending to OSM and finish - with fake ending to the guide
+  // segment.
+  std::vector<m2::PointD> const & checkpoints{mercator::FromLatLon(48.13998, 11.56982),
+                                              mercator::FromLatLon(48.14448, 11.57259)};
+
+  guides.ConnectToGuidesGraph(checkpoints);
+  TEST(guides.IsAttached(), ());
+
+  for (size_t checkpointIdx = 0; checkpointIdx < checkpoints.size(); ++checkpointIdx)
+  {
+    TEST(guides.IsCheckpointAttached(checkpointIdx), ());
+    auto const links = guides.GetOsmConnections(checkpointIdx);
+    TEST(!links.empty(), ());
+
+    bool const isCheckpointNear =
+        guides.FitsForDirectLinkToGuide(checkpointIdx, checkpoints.size());
+    auto const ending = guides.GetFakeEnding(checkpointIdx);
+
+    // Initial projection to guides track.
+    TEST_EQUAL(ending.m_projections.size(), 1, ());
+
+    // Start point is on the track, finish point is on some distance.
+    bool const isStart = checkpointIdx == 0;
+    if (isStart)
+      TEST(!isCheckpointNear, ());
+    else
+      TEST(isCheckpointNear, ());
+  }
+}
+
+UNIT_TEST(Guides_NotAttachIntermediatePoint)
+{
+  GuidesConnections guides(GetTestGuides());
+
+  // Intermediate checkpoints should not be attached to the guides if they are far enough even
+  // if their neighbours are attached.
+  std::vector<m2::PointD> const & checkpoints{mercator::FromLatLon(48.14349, 11.56712),
+                                              mercator::FromLatLon(48.14493, 11.56820),
+                                              mercator::FromLatLon(48.14311, 11.58063)};
+
+  guides.ConnectToGuidesGraph(checkpoints);
+  TEST(guides.IsAttached(), ());
+  for (size_t checkpointIdx = 0; checkpointIdx < checkpoints.size(); ++checkpointIdx)
+  {
+    bool const isAttached = guides.IsCheckpointAttached(checkpointIdx);
+    bool const isIntermediate = checkpointIdx == 1;
+    if (isIntermediate)
+      TEST(!isAttached, ());
+    else
+      TEST(isAttached, ());
+  }
+}
+}  // namespace

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -53,6 +53,8 @@ public:
 
   string GetName() const override { return "dummy"; }
   void ClearState() override {}
+  void SetGuides(GuidesTracks && /* guides */) override {}
+
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */,
                                   m2::PointD const & /* startDirection */, bool /* adjust */,
                                   RouterDelegate const & /* delegate */, Route & route) override
@@ -82,6 +84,8 @@ public:
   // IRouter overrides:
   string GetName() const override { return "return codes router"; }
   void ClearState() override {}
+  void SetGuides(GuidesTracks && /* guides */) override {}
+
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */,
                                   m2::PointD const & /* startDirection */, bool /* adjust */,
                                   RouterDelegate const & /* delegate */, Route & route) override
@@ -251,7 +255,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteBuilding)
         },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::kNoTimeout);
   });
 
@@ -282,7 +286,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -316,7 +320,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
           nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
           nullptr /* removeRouteCallback */);
       {
-        m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+        m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                               RouterDelegate::kNoTimeout);
       }
     });
@@ -363,7 +367,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingT
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -414,7 +418,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -443,7 +447,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
         [&oppositeTimedSignal](Route const &, RouterResultCode) { oppositeTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::kNoTimeout);
   });
   TEST(oppositeTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -502,7 +506,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest
         [&alongTimedSignal](Route const &, RouterResultCode) { alongTimedSignal.Signal(); },
         nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
         nullptr /* removeRouteCallback */);
-    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()),
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), {} /* guides */,
                           RouterDelegate::kNoTimeout);
   });
   TEST(alongTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
@@ -573,7 +577,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
           nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */,
           nullptr /* removeRouteCallback */);
 
-      m_session->BuildRoute(Checkpoints(kRoute.front(), kRoute.back()),
+      m_session->BuildRoute(Checkpoints(kRoute.front(), kRoute.back()), {} /* guides */,
                             RouterDelegate::kNoTimeout);
     });
     TEST(buildTimedSignal

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -316,6 +316,12 @@
 		A1616E2B1B6B60AB003F078E /* router_delegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1616E291B6B60AB003F078E /* router_delegate.cpp */; };
 		A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A1616E2A1B6B60AB003F078E /* router_delegate.hpp */; };
 		A1616E2E1B6B60B3003F078E /* astar_progress.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A1616E2D1B6B60B3003F078E /* astar_progress.hpp */; };
+		D5208C642423681400A9A8B6 /* guides_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D5208C632423681300A9A8B6 /* guides_tests.cpp */; };
+		D526BA79241FC5580076E0B0 /* guides_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D526BA75241FC5580076E0B0 /* guides_graph.cpp */; };
+		D526BA7A241FC5580076E0B0 /* guides_connections.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D526BA76241FC5580076E0B0 /* guides_connections.cpp */; };
+		D526BA7B241FC5580076E0B0 /* guides_connections.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D526BA77241FC5580076E0B0 /* guides_connections.hpp */; };
+		D526BA7C241FC5580076E0B0 /* guides_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D526BA78241FC5580076E0B0 /* guides_graph.hpp */; };
+		D563401F2423816C00FDE20A /* guides_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D563401E2423816C00FDE20A /* guides_tests.cpp */; };
 		F6C3A1B521AC298F0060EEC8 /* speed_camera_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6C3A1B321AC298E0060EEC8 /* speed_camera_manager.hpp */; };
 		F6C3A1B621AC298F0060EEC8 /* speed_camera_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6C3A1B421AC298F0060EEC8 /* speed_camera_manager.cpp */; };
 /* End PBXBuildFile section */
@@ -599,6 +605,12 @@
 		A1616E291B6B60AB003F078E /* router_delegate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = router_delegate.cpp; sourceTree = "<group>"; };
 		A1616E2A1B6B60AB003F078E /* router_delegate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = router_delegate.hpp; sourceTree = "<group>"; };
 		A1616E2D1B6B60B3003F078E /* astar_progress.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = astar_progress.hpp; sourceTree = "<group>"; };
+		D5208C632423681300A9A8B6 /* guides_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guides_tests.cpp; sourceTree = "<group>"; };
+		D526BA75241FC5580076E0B0 /* guides_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guides_graph.cpp; sourceTree = "<group>"; };
+		D526BA76241FC5580076E0B0 /* guides_connections.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guides_connections.cpp; sourceTree = "<group>"; };
+		D526BA77241FC5580076E0B0 /* guides_connections.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = guides_connections.hpp; sourceTree = "<group>"; };
+		D526BA78241FC5580076E0B0 /* guides_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = guides_graph.hpp; sourceTree = "<group>"; };
+		D563401E2423816C00FDE20A /* guides_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guides_tests.cpp; sourceTree = "<group>"; };
 		F6C3A1B321AC298E0060EEC8 /* speed_camera_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_manager.hpp; sourceTree = "<group>"; };
 		F6C3A1B421AC298F0060EEC8 /* speed_camera_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera_manager.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -740,6 +752,7 @@
 		6742ACA01C68A07C009CB89E /* routing_tests */ = {
 			isa = PBXGroup;
 			children = (
+				D5208C632423681300A9A8B6 /* guides_tests.cpp */,
 				44B284C323F5A10000A3FBB7 /* opening_hours_serdes_tests.cpp */,
 				56CBED5722E9CFB600D51AF7 /* position_accumulator_tests.cpp */,
 				440BE38722AFB31600C548FB /* uturn_restriction_tests.cpp */,
@@ -876,6 +889,10 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				D526BA76241FC5580076E0B0 /* guides_connections.cpp */,
+				D526BA77241FC5580076E0B0 /* guides_connections.hpp */,
+				D526BA75241FC5580076E0B0 /* guides_graph.cpp */,
+				D526BA78241FC5580076E0B0 /* guides_graph.hpp */,
 				569472402418C8220013CD21 /* car_directions.cpp */,
 				5694723F2418C8220013CD21 /* car_directions.hpp */,
 				4432C5B524067E6700C9E445 /* road_access_serialization.cpp */,
@@ -1034,6 +1051,7 @@
 		67BD35961C69F03E003AA26F /* routing_integration_tests */ = {
 			isa = PBXGroup;
 			children = (
+				D563401E2423816C00FDE20A /* guides_tests.cpp */,
 				56DAC2C32398F348000BC50D /* speed_camera_notifications_tests.cpp */,
 				44D1C41A229C59B8001A3CD2 /* transit_route_test.cpp */,
 				44D1C418229C59A3001A3CD2 /* small_routes.cpp */,
@@ -1069,12 +1087,14 @@
 				0C470E701E0D4EB1005B824D /* segment.hpp in Headers */,
 				A120B3531B4A7C1C002F3808 /* astar_algorithm.hpp in Headers */,
 				0C5FEC5F1DDE192A0017688C /* geometry.hpp in Headers */,
+				D526BA7B241FC5580076E0B0 /* guides_connections.hpp in Headers */,
 				67AB92E71B7B3E6E00AB5194 /* turns_tts_text.hpp in Headers */,
 				56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */,
 				0C5F5D231E798B0400307B98 /* cross_mwm_connector.hpp in Headers */,
 				40F7F3E41F7D246D0082D564 /* single_vehicle_world_graph.hpp in Headers */,
 				56DAC2C82398F3C8000BC50D /* junction_visitor.hpp in Headers */,
 				4408A63D21F1E7F0008171B8 /* index_graph_starter_joints.hpp in Headers */,
+				D526BA7C241FC5580076E0B0 /* guides_graph.hpp in Headers */,
 				5670595E1F3AF97F0062672D /* checkpoint_predictor.hpp in Headers */,
 				6753441F1A3F644F00A0A8C3 /* turns.hpp in Headers */,
 				0C5FEC611DDE192A0017688C /* index_graph.hpp in Headers */,
@@ -1364,6 +1384,7 @@
 				0C090C871E4E276700D52AFD /* world_graph.cpp in Sources */,
 				44C56C0B22296498006C2A1D /* routing_options.cpp in Sources */,
 				0C5F5D201E798B0400307B98 /* cross_mwm_connector_serialization.cpp in Sources */,
+				D526BA7A241FC5580076E0B0 /* guides_connections.cpp in Sources */,
 				56CA09E71E30E73B00D05C9A /* restriction_test.cpp in Sources */,
 				0C5BC9D11E28FD4E0071BFDD /* index_road_graph.cpp in Sources */,
 				0C090C811E4E274000D52AFD /* index_graph_loader.cpp in Sources */,
@@ -1391,6 +1412,7 @@
 				448FD3F3228B1BC500180D90 /* bfs_tests.cpp in Sources */,
 				40858A871F8CEAE60065CFF7 /* fake_feature_ids.cpp in Sources */,
 				40A111CD1F2F6776005E6AD5 /* route_weight.cpp in Sources */,
+				D5208C642423681400A9A8B6 /* guides_tests.cpp in Sources */,
 				4408A63E21F1E7F0008171B8 /* joint_segment.cpp in Sources */,
 				670D049E1B0B4A970013A7AC /* nearest_edge_finder.cpp in Sources */,
 				0C5F5D251E798B3800307B98 /* cross_mwm_connector_test.cpp in Sources */,
@@ -1398,6 +1420,7 @@
 				674F9BD61B0A580E00704FFA /* turns_generator.cpp in Sources */,
 				5694CECE1EBA25F7004576D3 /* vehicle_mask.cpp in Sources */,
 				0C45D7391F2F75500065C3ED /* routing_settings.cpp in Sources */,
+				D563401F2423816C00FDE20A /* guides_tests.cpp in Sources */,
 				56CBED5622E9CE2600D51AF7 /* position_accumulator.cpp in Sources */,
 				44F4EDC723A78C2E005254C4 /* latlon_with_altitude.cpp in Sources */,
 				0C5FEC691DDE193F0017688C /* road_index.cpp in Sources */,
@@ -1411,6 +1434,7 @@
 				674F9BD41B0A580E00704FFA /* road_graph.cpp in Sources */,
 				5631B66B219B125D009F47D4 /* maxspeeds.cpp in Sources */,
 				0C81E1571F0258AA00DC66DF /* segmented_route.cpp in Sources */,
+				D526BA79241FC5580076E0B0 /* guides_graph.cpp in Sources */,
 				56CA09E51E30E73B00D05C9A /* index_graph_tools.cpp in Sources */,
 				0C0DF92A1DE898FF0055A22F /* routing_helpers.cpp in Sources */,
 				67AB92E61B7B3E6E00AB5194 /* turns_tts_text.cpp in Sources */,


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13261

### Цель PR
Если у пользователя скачаны платные или любые партнерские outdoor маршруты (гиды), прокладывать маршрут по ним в приоритете перед графом дорог OSM.

**Наиболее частые сценарии:**
- Точки старта и финиша лежат на трэке гида. В этом случае строим маршрут исключительно по трэку, не переходя на ОСМ. 
Правила: 
1) Точка считается лежащей на трэке, если расстояние от нее до ближайшей проекции на трэк не превышает `kMaxDistToTrackPointM` = 50 м. 
2) При этом если точка находится ближе к трэку, чем `kEqDistToTrackPointM` = 20 м, не имеет смысла пытаться достроить от нее до трэка путь по графу ОСМа: прокладывается обычная фейковая дуга серого цвета. Иначе, если расстояние превышает `kEqDistToTrackPointM`, то от точки до трэка прокладывается путь по ОСМу. Иными словами, если одна из точек, поставленных пользователем, удалена более чем на kEqDistToTrackPointM от тэка (но при этом считается лежащей на трэке), то от нее до ее проекции на трэке прокладываем путь по графу ОСМ. 
3) Для ускорения обработки трэков гидов добавлен параметр `kMaxDistToTrackForSkippingM` = 100 км. При поиске ближайших к точке трэков для каждого трэка рассчитываются расстояния от точек трэка к данной точке. Если любая точка трэка находится от данной точки маршрута далее чем `kMaxDistToTrackForSkippingM`, то такой трэк не рассматривается для соотнесения с этой точкой.

**Пример. Обе точки лежат на трэке:**
<img width="700" alt="Screenshot 2020-03-16 at 13 54 16" src="https://user-images.githubusercontent.com/54934129/76749584-c2888d00-678d-11ea-93e5-49599fa3e3fc.png">
От обеих точек к трэку проведены короткие фейковые дуги, потому что расстояние от них до трэка меньше, чем `kEqDistToTrackPointM`.

**Пример. Одна точка лежит на трэке, другая - "рядом" с ним:** 
<img width="700" alt="Screenshot 2020-03-16 at 13 56 54" src="https://user-images.githubusercontent.com/54934129/76749919-5eb29400-678e-11ea-9f65-27f1e2f20281.png">
Расстояние от старта до трэка больше, чем  `kEqDistToTrackPointM`, поэтому путь до трэка идет по ОСМу. Кажется, не имеет смысла тащить пользователя от этой точки сначала до старта трэка, а затем - до финиша, который он поставил на трэке. Этот крюк может достигать десяти километров.

- Старт возле трэка, финиш - нет. Прокладывать маршрут по трэку от старта до ближайшей терминальной точки трэка, дальше перескакивать на граф ОСМ.
<img width="700" alt="Screenshot 2020-03-16 at 13 57 37" src="https://user-images.githubusercontent.com/54934129/76750185-daacdc00-678e-11ea-9a46-e6882dc7421f.png">

- Старт удален от трэка, финиш - лежит на трэке. Прокладываем маршрут от старта до ближайшей удобной терминальной точки трэка по графу ОСМ, от терминальной точки до финиша - по трэку.
<img width="700" alt="Screenshot 2020-03-16 at 13 57 17" src="https://user-images.githubusercontent.com/54934129/76750134-c49f1b80-678e-11ea-997a-84221be592e1.png">

**Важные замечания.**
- Маршруты получаются не оптимальными по длине и времени. Цель - провести про трэку гида, а не найти оптимальный маршрут.
- Понятия старта и финиша в трэках очень условны. На трэках возможно движение в обе стороны, и не имеет значения, с какого конца начинать движение по трэку. Поэтому при прокладке маршрута от удаленной точки до точки трэка или с трэка до удаленной от него точки выбирается самая удобная терминальная точка трэка (старт или финиш). 
- Промежуточные точки не притягиваются к трэку, если находятся от него дальше, чем `kMaxDistToTrackPointM`. Пользователь явно указал промежуточную точку в стороне от трэка, и притягивание ее к трэку идет в разрез с намерением пользователя. 
- Приоритет трэков гидов достигается за счет двух не связанных между собой факторов: выставления для трэков максимально возможной скорости для данного типа передвижения (вело или пеший); использования только и только трэка и проекции на него, если точки старта и финиша стоят к нему очень близко (на расстоянии  `kEqDistToTrackPointM`). В связи с этим, если одна из точек маршрута удалена от трэка далее чем на `kEqDistToTrackPointM`,  возможны ситуации, когда маршрут по графу ОСМ выиграет у маршрута по трэку: например, в случае, если трэк очень сильно петляет, а рядом проложена прямая дорога. Или если трэк представляет собой петлю. В случае же, если старт и финиш лежат на трэке (`kEqDistToTrackPointM`), маршрут проложится только по трэку.

Пример трэка, в котором нельзя гарантировать, что одна терминальная точка - начало, а другая - конец:
<img width="700" alt="Screenshot 2020-03-16 at 14 14 47" src="https://user-images.githubusercontent.com/54934129/76751594-886cba80-6790-11ea-98a0-a70ac12c78a8.png">
Другой пример:
<img width="300" src="https://user-images.githubusercontent.com/54934129/76756634-23689300-6797-11ea-8f7c-af7f1a2b9f6d.jpeg">



### Реализация
**Новые интервалы фич**
Для роутинга по маршрутам из гидов нужно создавать новые фичи. Для этого добавлен новый интервал id, выделенных специально под гиды.

Какие теперь есть интервалы:
[0,  kGuidesGraphFeaturesStart) - обычные фичи
[kGuidesGraphFeaturesStart, kTransitGraphFeaturesStart) - гиды
[kTransitGraphFeaturesStart, kEditorCreatedFeaturesStart) - транзит
[kEditorCreatedFeaturesStart, uint32_t max] - редактор

uint32_t max                            = 4 294 967 295
kEditorCreatedFeaturesStart = 4 293 918 720
kTransitGraphFeaturesStart   = 4 278 190 080
kGuidesGraphFeaturesStart  = 4 261  412 865 - нижняя граница, до нее - id настоящих фич. 
Остается запас в 4.2 миллиарда. Сейчас в mwm могут присутствовать десятки миллионов фич, так что запас адекватный.

**Прокидывание гидов**
Гиды без изменений пробрасываются из RoutingManager в IndexRouter.
В RoutingManager они формируются 1 раз за 1 прокладку маршрута, при перепрокладке этого не происходит. RoutingSession передает их дальше в AsyncRouter также при первой прокладке маршрута: `m_routingRebuildCount == 0`.