### PR TITLE
[omim] Add -DUSE_HEAPPROF=ON option to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ if (USE_PPROF)
   add_definitions(-DUSE_PPROF)
 endif()
 
+if (USE_HEAPPROF)
+  message("Heap Profiler is enabled")
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Set environment variables

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -52,6 +52,18 @@ function(omim_add_executable executable)
       target_link_libraries(${executable} "-lprofiler")
     endif()
   endif()
+
+  if (USE_HEAPPROF)
+    if (PLATFORM_MAC)
+      message(
+        WARNING
+        "Trying to use -ltcmalloc on MacOS, make sure that you installed it (https://github.com/gperftools/gperftools)."
+      )
+    else()
+      target_link_libraries(${executable} "-ltcmalloc")
+    endif()
+  endif()
+
   if (USE_PCH)
     add_precompiled_headers_to_target(${executable} ${OMIM_PCH_TARGET_NAME})
   endif()


### PR DESCRIPTION
# Instruction for MacOs
```sh
git clone https://github.com/gperftools/gperftools
cd gperftools
./autogen.sh
./configure
sudo make -j8 install
```
Here dylib: `/usr/local/lib/libtcmalloc.dylib`

After that just:
```sh
cmake .. -DUSE_HEAPPROF=ON
```