### PR TITLE
Mapsme 13288 update ndk via buildgradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,9 +8,10 @@ buildscript {
   }
 
   dependencies {
-    // Don't update Gradle plugin until Fabric plugin supports it correctly,
-    // i.e. when OOM problem during native symbols upload is fixed.
-    classpath 'com.android.tools.build:gradle:3.4.1'
+    classpath 'com.android.tools.build:gradle:3.5.2'
+    // Don't update Fabric plugin until they fix OOM problem during native symbols upload.
+    // The latest version 1.31.2 https://docs.fabric.io/android/changelog.html#october-15-2019
+    // still consists OOM issue.
     classpath 'io.fabric.tools:gradle:1.27.0'
   }
 }
@@ -119,6 +120,7 @@ project.ext.appId = 'com.mapswithme.maps.pro'
 
 crashlytics {
   enableNdk true
+  androidNdkLibsOut "./build/intermediates/stripped_native_libs"
 }
 
 configurations.all {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -172,6 +172,7 @@ configurations.all {
 }
 
 android {
+  ndkVersion = "21.0.6113669"
   dataBinding {
     enabled = true
   }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 21 16:53:35 MSK 2019
+#Fri Feb 28 11:02:45 MSK 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Updated NDK version to 21 via build.gradle. Build will failed if the specified NDK is not found. Now it's the last stable version - 21. 

Important note: ndk.dir in local.properties must be point on ndk of same version as build.gradle ndk version or deleted from local.properties.