### PR TITLE
[bookmarks] Use safe version of saving kml and kmb files.

### DIFF
--- a/coding/internal/file_data.cpp
+++ b/coding/internal/file_data.cpp
@@ -203,6 +203,7 @@ bool WriteToTempAndRenameToFile(string const & dest, function<bool(string const 
   if (!write(tmpFileName))
   {
     LOG(LERROR, ("Can't write to", tmpFileName));
+    DeleteFileX(tmpFileName);
     return false;
   }
   if (!RenameFileX(tmpFileName, dest))

--- a/map/bookmark_catalog.cpp
+++ b/map/bookmark_catalog.cpp
@@ -554,8 +554,9 @@ void BookmarkCatalog::Upload(UploadData uploadData, std::string const & accessTo
 
       // Save KML.
       auto const filePath = base::JoinPath(GetPlatform().TmpDir(), uploadData.m_serverId + kKmlExtension);
-      if (!SaveKmlFile(*fileData, filePath, KmlFileType::Text))
+      if (!SaveKmlFileSafe(*fileData, filePath, KmlFileType::Text))
       {
+        FileWriter::DeleteFileX(filePath);
         if (uploadErrorCallback)
           uploadErrorCallback(UploadResult::InvalidCall, "Could not save the uploading file.");
         return;

--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -339,6 +339,22 @@ bool SaveKmlFile(kml::FileData & kmlData, std::string const & file, KmlFileType 
   return success;
 }
 
+bool SaveKmlFileSafe(kml::FileData & kmlData, std::string const & file, KmlFileType fileType)
+{
+  auto const fileTmp = file + ".tmp";
+  if (SaveKmlFile(kmlData, fileTmp, fileType))
+  {
+    // Only after successful save we replace original file.
+    base::DeleteFileX(file);
+    auto const res = base::RenameFileX(fileTmp, file);
+    if (!res)
+      LOG(LWARNING, ("Renaming of .tmp bookmarks file failed", fileTmp, file));
+    return res;
+  }
+  base::DeleteFileX(fileTmp);
+  return false;
+}
+
 bool SaveKmlData(kml::FileData & kmlData, Writer & writer, KmlFileType fileType)
 {
   try

--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -15,6 +15,7 @@
 
 #include "coding/file_reader.hpp"
 #include "coding/file_writer.hpp"
+#include "coding/internal/file_data.hpp"
 #include "coding/sha1.hpp"
 #include "coding/zip_reader.hpp"
 
@@ -341,18 +342,10 @@ bool SaveKmlFile(kml::FileData & kmlData, std::string const & file, KmlFileType 
 
 bool SaveKmlFileSafe(kml::FileData & kmlData, std::string const & file, KmlFileType fileType)
 {
-  auto const fileTmp = file + ".tmp";
-  if (SaveKmlFile(kmlData, fileTmp, fileType))
+  return base::WriteToTempAndRenameToFile(file, [&kmlData, fileType](std::string const & fileName)
   {
-    // Only after successful save we replace original file.
-    base::DeleteFileX(file);
-    auto const res = base::RenameFileX(fileTmp, file);
-    if (!res)
-      LOG(LWARNING, ("Renaming of .tmp bookmarks file failed", fileTmp, file));
-    return res;
-  }
-  base::DeleteFileX(fileTmp);
-  return false;
+    return SaveKmlFile(kmlData, fileName, fileType);
+  });
 }
 
 bool SaveKmlData(kml::FileData & kmlData, Writer & writer, KmlFileType fileType)

--- a/map/bookmark_helpers.hpp
+++ b/map/bookmark_helpers.hpp
@@ -93,7 +93,7 @@ std::unique_ptr<kml::FileData> LoadKmlFile(std::string const & file, KmlFileType
 std::unique_ptr<kml::FileData> LoadKmzFile(std::string const & file, std::string & kmlHash);
 std::unique_ptr<kml::FileData> LoadKmlData(Reader const & reader, KmlFileType fileType);
 
-bool SaveKmlFile(kml::FileData & kmlData, std::string const & file, KmlFileType fileType);
+bool SaveKmlFileSafe(kml::FileData & kmlData, std::string const & file, KmlFileType fileType);
 bool SaveKmlData(kml::FileData & kmlData, Writer & writer, KmlFileType fileType);
 
 void ResetIds(kml::FileData & kmlData);

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -647,7 +647,7 @@ private:
 
   std::unique_ptr<kml::FileData> CollectBmGroupKMLData(BookmarkCategory const * group) const;
   KMLDataCollectionPtr PrepareToSaveBookmarks(kml::GroupIdCollection const & groupIdCollection);
-  bool SaveKmlFileSafe(kml::FileData & kmlData, std::string const & file);
+  bool SaveKmlFileByExt(kml::FileData & kmlData, std::string const & file);
 
   void OnSynchronizationStarted(Cloud::SynchronizationType type);
   void OnSynchronizationFinished(Cloud::SynchronizationType type, Cloud::SynchronizationResult result,


### PR DESCRIPTION
При сохранении kmb файлов возможны сбои, при которых на диск записывается битая версия файла, что приводит к падениям при последующем чтении на старте. PR заменяет метод сохранения на более безопасную версию через временный файл.

https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5cd8f4c1f8b88c2963c537f3