### PR TITLE
[routing] Crashfix in case traffic jam has been downloaded while the first route building.

### DIFF
--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -280,7 +280,11 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   }
 
   CHECK(m_route, (m_state));
-  CHECK(m_route->IsValid(), (m_state));
+  // Note. The route may not be valid here. It happens in case when while the first route
+  // build is cancelled because of traffic jam were downloaded. After that route rebuilding
+  // happens. While the rebuilding may be called OnLocationPositionChanged(...)
+  if (!m_route->IsValid())
+    return m_state;
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
 


### PR DESCRIPTION
Данный PR исправляет следующую ситуацию.

1. Программа загрузилась;
2. Маршрут прокладывается и в процессе прокладки маршрута загрузились пробки;
В этом случае, в процессе прокладки (SessionState::RouteBuilding) вызывается RoutingSession::RebuildRouteOnTrafficUpdate(), который в свою очередь отменяет прокладку маршрута (m_router->ClearState();). Вызывается callback `delegateProxy->OnRemoveRoute(RouterResultCode::Cancelled)`, который не меняется state (SessionState::RouteBuilding). 

Затем из RoutingSession::RebuildRouteOnTrafficUpdate() вызывается   `RebuildRoute(...., SessionState::RouteRebuilding, ...);`, который меняет state на SessionState::RouteRebuilding.

Далее мы крешимся, если в процессе этой перепрокладки после загрузки пробок вызывается OnLocationPositionChanged() мы падали на чеке.

Данный PR исправляет креши со следующим кол стерком в firebase:
```c++
3
libmapswithme.so
routing_manager.cpp - Line 1115
RoutingManager::CheckLocationForRouting(location::GpsInfo const&) + 1115
4
libmapswithme.so
routing_manager.cpp - Line 1149
RoutingManager::GetRouteMatchingInfo(location::GpsInfo&) + 1149
5
libmapswithme.so
functional - Line 1923
std::__ndk1::function<void ()>::operator()() const + 1923
```

https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/5cd3af74f8b88c29636ca064/sessions/latest

https://jira.mail.ru/browse/MAPSME-13319

@gmoryes @mesozoic-drones PTAL