### PR TITLE
[search_integration_tests] Remove some CategoriesTest exceptions.

### DIFF
--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -148,19 +148,15 @@ UNIT_CLASS_TEST(SmokeTest, DeepCategoryTest)
 UNIT_CLASS_TEST(SmokeTest, CategoriesTest)
 {
   // todo(@t.yan): fix some or delete category.
-  vector<vector<string>> const invisibleAsPointTags = {{"amenity", "driving_school"},
-                                                       {"military", "bunker"},
-                                                       {"waterway", "canal"},
+  vector<vector<string>> const invisibleAsPointTags = {{"waterway", "canal"},
                                                        {"waterway", "river"},
                                                        {"waterway", "riverbank"},
                                                        {"waterway", "stream"},
                                                        {"landuse", "basin"},
                                                        {"place", "county"},
                                                        {"place", "islet"},
-                                                       {"power", "pole"},
                                                        {"highway", "footway"},
                                                        {"highway", "cycleway"},
-                                                       {"highway", "ford"}, // MAPSME-10683
                                                        {"highway", "living_street"},
                                                        {"highway", "motorway"},
                                                        {"highway", "motorway_link"},
@@ -183,7 +179,6 @@ UNIT_CLASS_TEST(SmokeTest, CategoriesTest)
                                                        {"highway", "trunk"},
                                                        {"highway", "trunk_link"},
                                                        {"highway", "unclassified"},
-                                                       {"man_made", "surveillance"},
                                                        {"man_made", "tower"},
                                                        {"man_made", "water_tower"},
                                                        {"man_made", "water_well"},


### PR DESCRIPTION
highway ford добавили в стили, 
amenity driving_school судя по этому тесту и по другим теперь считается отображаемым (стилей я не вижу, но drules вижу; судя по всему, у нас где-то есть стиль для amenity=*)
остальное удалили из категорий когда была чистка типов, которые в categories лежали чисто ради переводов