### PR TITLE
[routing] Renaming BicycleDirectionsEngine to CarDirectionsEngine.

### DIFF
--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -18,8 +18,8 @@ set(
   base/followed_polyline.cpp
   base/followed_polyline.hpp
   base/routing_result.hpp
-  bicycle_directions.cpp
-  bicycle_directions.hpp
+  car_directions.cpp
+  car_directions.hpp
   checkpoint_predictor.cpp
   checkpoint_predictor.hpp
   checkpoints.cpp

--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -1,4 +1,4 @@
-#include "routing/bicycle_directions.hpp"
+#include "routing/car_directions.hpp"
 
 #include "routing/road_point.hpp"
 #include "routing/router_delegate.hpp"
@@ -36,7 +36,7 @@ class RoutingResult : public IRoutingResult
 {
 public:
   RoutingResult(IRoadGraph::EdgeVector const & routeEdges,
-                BicycleDirectionsEngine::AdjacentEdgesMap const & adjacentEdges,
+                CarDirectionsEngine::AdjacentEdgesMap const & adjacentEdges,
                 TUnpackedPathSegments const & pathSegments)
     : m_routeEdges(routeEdges)
     , m_adjacentEdges(adjacentEdges)
@@ -89,7 +89,7 @@ public:
 
 private:
   IRoadGraph::EdgeVector const & m_routeEdges;
-  BicycleDirectionsEngine::AdjacentEdgesMap const & m_adjacentEdges;
+  CarDirectionsEngine::AdjacentEdgesMap const & m_adjacentEdges;
   TUnpackedPathSegments const & m_pathSegments;
   double m_routeLength;
 };
@@ -150,27 +150,27 @@ bool IsJoint(IRoadGraph::EdgeVector const & ingoingEdges,
 
 namespace routing
 {
-// BicycleDirectionsEngine::AdjacentEdges ---------------------------------------------------------
-bool BicycleDirectionsEngine::AdjacentEdges::IsAlmostEqual(AdjacentEdges const & rhs) const
+// CarDirectionsEngine::AdjacentEdges ---------------------------------------------------------
+bool CarDirectionsEngine::AdjacentEdges::IsAlmostEqual(AdjacentEdges const & rhs) const
 {
   return m_outgoingTurns.IsAlmostEqual(rhs.m_outgoingTurns) &&
          m_ingoingTurnsCount == rhs.m_ingoingTurnsCount;
 }
 
-// BicycleDirectionsEngine ------------------------------------------------------------------------
-BicycleDirectionsEngine::BicycleDirectionsEngine(DataSource const & dataSource,
-                                                 shared_ptr<NumMwmIds> numMwmIds)
+// CarDirectionsEngine ------------------------------------------------------------------------
+CarDirectionsEngine::CarDirectionsEngine(DataSource const & dataSource,
+                                         shared_ptr<NumMwmIds> numMwmIds)
   : m_dataSource(dataSource), m_numMwmIds(numMwmIds)
 {
   CHECK(m_numMwmIds, ());
 }
 
-bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph,
-                                       vector<geometry::PointWithAltitude> const & path,
-                                       base::Cancellable const & cancellable, Route::TTurns & turns,
-                                       Route::TStreets & streetNames,
-                                       vector<geometry::PointWithAltitude> & routeGeometry,
-                                       vector<Segment> & segments)
+bool CarDirectionsEngine::Generate(IndexRoadGraph const & graph,
+                                   vector<geometry::PointWithAltitude> const & path,
+                                   base::Cancellable const & cancellable, Route::TTurns & turns,
+                                   Route::TStreets & streetNames,
+                                   vector<geometry::PointWithAltitude> & routeGeometry,
+                                   vector<Segment> & segments)
 {
   CHECK(m_numMwmIds, ());
 
@@ -212,21 +212,21 @@ bool BicycleDirectionsEngine::Generate(IndexRoadGraph const & graph,
   return true;
 }
 
-void BicycleDirectionsEngine::Clear()
+void CarDirectionsEngine::Clear()
 {
   m_adjacentEdges.clear();
   m_pathSegments.clear();
   m_loader.reset();
 }
 
-FeaturesLoaderGuard & BicycleDirectionsEngine::GetLoader(MwmSet::MwmId const & id)
+FeaturesLoaderGuard & CarDirectionsEngine::GetLoader(MwmSet::MwmId const & id)
 {
   if (!m_loader || id != m_loader->GetId())
     m_loader = make_unique<FeaturesLoaderGuard>(m_dataSource, id);
   return *m_loader;
 }
 
-void BicycleDirectionsEngine::LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment)
+void CarDirectionsEngine::LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment)
 {
   if (!featureId.IsValid())
     return;
@@ -245,7 +245,7 @@ void BicycleDirectionsEngine::LoadPathAttributes(FeatureID const & featureId, Lo
   pathSegment.m_onRoundabout = ftypes::IsRoundAboutChecker::Instance()(*ft);
 }
 
-void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
+void CarDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
     IRoadGraph::EdgeVector const & outgoingEdges, Edge const & inEdge, uint32_t startSegId,
     uint32_t endSegId, SegmentRange & segmentRange, TurnCandidates & outgoingTurns)
 {
@@ -303,10 +303,10 @@ void BicycleDirectionsEngine::GetSegmentRangeAndAdjacentEdges(
     sort(outgoingTurns.candidates.begin(), outgoingTurns.candidates.end(), base::LessBy(&TurnCandidate::m_angle));
 }
 
-void BicycleDirectionsEngine::GetEdges(IndexRoadGraph const & graph,
-                                       geometry::PointWithAltitude const & currJunction,
-                                       bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
-                                       IRoadGraph::EdgeVector & ingoing)
+void CarDirectionsEngine::GetEdges(IndexRoadGraph const & graph,
+                                   geometry::PointWithAltitude const & currJunction,
+                                   bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
+                                   IRoadGraph::EdgeVector & ingoing)
 {
   // Note. If |currJunction| is a finish the outgoing edges
   // from finish are not important for turn generation.
@@ -316,7 +316,7 @@ void BicycleDirectionsEngine::GetEdges(IndexRoadGraph const & graph,
   graph.GetIngoingEdges(currJunction, ingoing);
 }
 
-void BicycleDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
+void CarDirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
     IndexRoadGraph const & graph, vector<geometry::PointWithAltitude> const & path,
     IRoadGraph::EdgeVector const & routeEdges, base::Cancellable const & cancellable)
 {

--- a/routing/car_directions.hpp
+++ b/routing/car_directions.hpp
@@ -18,7 +18,7 @@
 
 namespace routing
 {
-class BicycleDirectionsEngine : public IDirectionsEngine
+class CarDirectionsEngine : public IDirectionsEngine
 {
 public:
   struct AdjacentEdges
@@ -32,7 +32,7 @@ public:
 
   using AdjacentEdgesMap = std::map<SegmentRange, AdjacentEdges>;
 
-  BicycleDirectionsEngine(DataSource const & dataSource, std::shared_ptr<NumMwmIds> numMwmIds);
+  CarDirectionsEngine(DataSource const & dataSource, std::shared_ptr<NumMwmIds> numMwmIds);
 
   // IDirectionsEngine override:
   bool Generate(IndexRoadGraph const & graph, std::vector<geometry::PointWithAltitude> const & path,

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -3,7 +3,7 @@
 #include "routing/base/astar_progress.hpp"
 #include "routing/base/bfs.hpp"
 
-#include "routing/bicycle_directions.hpp"
+#include "routing/car_directions.hpp"
 #include "routing/fake_ending.hpp"
 #include "routing/index_graph.hpp"
 #include "routing/index_graph_loader.hpp"
@@ -126,7 +126,7 @@ unique_ptr<IDirectionsEngine> CreateDirectionsEngine(VehicleType vehicleType,
   case VehicleType::Bicycle:
   // @TODO Bicycle turn generation engine is used now. It's ok for the time being.
   // But later a special car turn generation engine should be implemented.
-  case VehicleType::Car: return make_unique<BicycleDirectionsEngine>(dataSource, numMwmIds);
+  case VehicleType::Car: return make_unique<CarDirectionsEngine>(dataSource, numMwmIds);
   case VehicleType::Count:
     CHECK(false, ("Can't create DirectionsEngine for", vehicleType));
     return nullptr;

--- a/routing/routing_benchmarks/bicycle_routing_tests.cpp
+++ b/routing/routing_benchmarks/bicycle_routing_tests.cpp
@@ -2,7 +2,7 @@
 
 #include "routing/routing_benchmarks/helpers.hpp"
 
-#include "routing/bicycle_directions.hpp"
+#include "routing/car_directions.hpp"
 #include "routing/road_graph.hpp"
 
 #include "routing_common/bicycle_model.hpp"
@@ -32,7 +32,7 @@ protected:
   std::unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
       std::shared_ptr<routing::NumMwmIds> numMwmIds) override
   {
-    return std::make_unique<routing::BicycleDirectionsEngine>(m_dataSource, numMwmIds);
+    return std::make_unique<routing::CarDirectionsEngine>(m_dataSource, numMwmIds);
   }
 
   std::unique_ptr<routing::VehicleModelFactoryInterface> CreateModelFactory() override

--- a/routing/routing_benchmarks/car_routing_tests.cpp
+++ b/routing/routing_benchmarks/car_routing_tests.cpp
@@ -2,7 +2,7 @@
 
 #include "routing/routing_benchmarks/helpers.hpp"
 
-#include "routing/bicycle_directions.hpp"
+#include "routing/car_directions.hpp"
 #include "routing/road_graph.hpp"
 
 #include "routing_common/car_model.hpp"
@@ -42,7 +42,7 @@ protected:
   std::unique_ptr<routing::IDirectionsEngine> CreateDirectionsEngine(
       std::shared_ptr<routing::NumMwmIds> numMwmIds) override
   {
-    return std::make_unique<routing::BicycleDirectionsEngine>(m_dataSource, numMwmIds);
+    return std::make_unique<routing::CarDirectionsEngine>(m_dataSource, numMwmIds);
   }
 
   std::unique_ptr<routing::VehicleModelFactoryInterface> CreateModelFactory() override

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -55,7 +55,7 @@ private:
   // Fake edges in IndexGraph is identified by instances of Segment
   // with Segment::m_mwmId == kFakeNumMwmId. So instead of |m_featureId| field in this class
   // number mwm id field and feature id (uint32_t) should be used and |m_start| and |m_end|
-  // should be removed. To do that classes IndexRoadGraph, BicycleDirectionsEngine,
+  // should be removed. To do that classes IndexRoadGraph, CarDirectionsEngine,
   // PedestrianDirectionsEngine and other should be significant refactored.
   m2::PointD m_start;          // Coordinates of start of last Edge in SegmentRange.
   m2::PointD m_end;            // Coordinates of end of SegmentRange.

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -114,8 +114,6 @@
 		56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */; };
 		56099E2A1CC7C97D00A7772A /* routing_result_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E261CC7C97D00A7772A /* routing_result_graph.hpp */; };
 		56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E271CC7C97D00A7772A /* turn_candidate.hpp */; };
-		56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56099E301CC9247E00A7772A /* bicycle_directions.cpp */; };
-		56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56099E311CC9247E00A7772A /* bicycle_directions.hpp */; };
 		560A273B233BB18900B20E8F /* following_info.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 560A273A233BB18900B20E8F /* following_info.hpp */; };
 		5610731B221ABF96008447B2 /* speed_camera_prohibition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */; };
 		5610731C221ABF96008447B2 /* speed_camera_prohibition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */; };
@@ -140,6 +138,8 @@
 		567F81952154D6FF0093C25B /* city_roads.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 567F81932154D6FF0093C25B /* city_roads.hpp */; };
 		568194751F03A32400450EC3 /* road_access_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194731F03A32400450EC3 /* road_access_test.cpp */; };
 		568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 568194741F03A32400450EC3 /* routing_helpers_tests.cpp */; };
+		569472412418C8220013CD21 /* car_directions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5694723F2418C8220013CD21 /* car_directions.hpp */; };
+		569472422418C8220013CD21 /* car_directions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 569472402418C8220013CD21 /* car_directions.cpp */; };
 		5694CECB1EBA25F7004576D3 /* road_access_serialization.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5694CEC61EBA25F7004576D3 /* road_access_serialization.hpp */; };
 		5694CECC1EBA25F7004576D3 /* road_access.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5694CEC71EBA25F7004576D3 /* road_access.cpp */; };
 		5694CECD1EBA25F7004576D3 /* road_access.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5694CEC81EBA25F7004576D3 /* road_access.hpp */; };
@@ -443,8 +443,6 @@
 		56099E251CC7C97D00A7772A /* loaded_path_segment.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loaded_path_segment.hpp; sourceTree = "<group>"; };
 		56099E261CC7C97D00A7772A /* routing_result_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_result_graph.hpp; sourceTree = "<group>"; };
 		56099E271CC7C97D00A7772A /* turn_candidate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = turn_candidate.hpp; sourceTree = "<group>"; };
-		56099E301CC9247E00A7772A /* bicycle_directions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bicycle_directions.cpp; sourceTree = "<group>"; };
-		56099E311CC9247E00A7772A /* bicycle_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bicycle_directions.hpp; sourceTree = "<group>"; };
 		560A273A233BB18900B20E8F /* following_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = following_info.hpp; sourceTree = "<group>"; };
 		56107319221ABF96008447B2 /* speed_camera_prohibition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_prohibition.hpp; sourceTree = "<group>"; };
 		5610731A221ABF96008447B2 /* speed_camera_prohibition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speed_camera_prohibition.cpp; sourceTree = "<group>"; };
@@ -473,6 +471,8 @@
 		567F81932154D6FF0093C25B /* city_roads.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = city_roads.hpp; path = ../../routing/city_roads.hpp; sourceTree = "<group>"; };
 		568194731F03A32400450EC3 /* road_access_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access_test.cpp; sourceTree = "<group>"; };
 		568194741F03A32400450EC3 /* routing_helpers_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = routing_helpers_tests.cpp; sourceTree = "<group>"; };
+		5694723F2418C8220013CD21 /* car_directions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = car_directions.hpp; sourceTree = "<group>"; };
+		569472402418C8220013CD21 /* car_directions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = car_directions.cpp; sourceTree = "<group>"; };
 		5694CEC61EBA25F7004576D3 /* road_access_serialization.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_access_serialization.hpp; sourceTree = "<group>"; };
 		5694CEC71EBA25F7004576D3 /* road_access.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = road_access.cpp; sourceTree = "<group>"; };
 		5694CEC81EBA25F7004576D3 /* road_access.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = road_access.hpp; sourceTree = "<group>"; };
@@ -876,14 +876,14 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				569472402418C8220013CD21 /* car_directions.cpp */,
+				5694723F2418C8220013CD21 /* car_directions.hpp */,
 				4432C5B524067E6700C9E445 /* road_access_serialization.cpp */,
 				44A95C6F225F6A4F00C22F4F /* astar_graph.hpp */,
 				44A95C70225F6A4F00C22F4F /* astar_progress.cpp */,
 				674F9BBA1B0A580E00704FFA /* async_router.cpp */,
 				674F9BBB1B0A580E00704FFA /* async_router.hpp */,
 				671F58BA1B874EA20032311E /* base */,
-				56099E301CC9247E00A7772A /* bicycle_directions.cpp */,
-				56099E311CC9247E00A7772A /* bicycle_directions.hpp */,
 				5670595B1F3AF97F0062672D /* checkpoint_predictor.cpp */,
 				5670595C1F3AF97F0062672D /* checkpoint_predictor.hpp */,
 				0CF709351F05172200D5067E /* checkpoints.cpp */,
@@ -1087,12 +1087,12 @@
 				40655E741F8BA46B0065305E /* fake_feature_ids.hpp in Headers */,
 				6753441C1A3F644F00A0A8C3 /* route.hpp in Headers */,
 				44F4EDC823A78C2E005254C4 /* latlon_with_altitude.hpp in Headers */,
+				569472412418C8220013CD21 /* car_directions.hpp in Headers */,
 				A1616E2C1B6B60AB003F078E /* router_delegate.hpp in Headers */,
 				349D1CE11E3F589900A878FD /* restrictions_serialization.hpp in Headers */,
 				56CC5A371E3884960016AC46 /* cross_mwm_index_graph.hpp in Headers */,
 				67C7D42E1B4EB48F00FE41AA /* turns_sound_settings.hpp in Headers */,
 				560A273B233BB18900B20E8F /* following_info.hpp in Headers */,
-				56099E341CC9247E00A7772A /* bicycle_directions.hpp in Headers */,
 				670EE55E1B6001E7001E8064 /* routing_session.hpp in Headers */,
 				56099E291CC7C97D00A7772A /* loaded_path_segment.hpp in Headers */,
 				56FA20471FBF23A90045DE78 /* cross_mwm_ids.hpp in Headers */,
@@ -1407,7 +1407,6 @@
 				670EE55D1B6001E7001E8064 /* routing_session.cpp in Sources */,
 				56A1B7A221A82BCC00246F8C /* maxspeeds_tests.cpp in Sources */,
 				40C645161F8D167F002E05A0 /* fake_ending.cpp in Sources */,
-				56099E331CC9247E00A7772A /* bicycle_directions.cpp in Sources */,
 				0C08AA341DF83223004195DD /* index_graph_serialization.cpp in Sources */,
 				674F9BD41B0A580E00704FFA /* road_graph.cpp in Sources */,
 				5631B66B219B125D009F47D4 /* maxspeeds.cpp in Sources */,
@@ -1421,6 +1420,7 @@
 				568194751F03A32400450EC3 /* road_access_test.cpp in Sources */,
 				56CA09E41E30E73B00D05C9A /* cumulative_restriction_test.cpp in Sources */,
 				568194761F03A32400450EC3 /* routing_helpers_tests.cpp in Sources */,
+				569472422418C8220013CD21 /* car_directions.cpp in Sources */,
 				44E5574C2136EED000B01439 /* speed_camera_ser_des.cpp in Sources */,
 				4065EA811F824A6C0094DEF3 /* transit_world_graph.cpp in Sources */,
 				0C12ED231E5C822A0080D0F4 /* index_router.cpp in Sources */,


### PR DESCRIPTION
BicycleDirectionsEngine уже много лет является генератором маневров для машин. Переименовал.

@mesozoic-drones PTAL