### PR TITLE
Fix build with GCC 10

### DIFF
--- a/coding/move_to_front.hpp
+++ b/coding/move_to_front.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <cstddef>
 
 namespace coding
 {

--- a/coding/move_to_front.hpp
+++ b/coding/move_to_front.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <cstddef>
 
 namespace coding
 {


### PR DESCRIPTION
I am try to build generator_tool with GCC 10 (coming soon with Fedora 32) and has error:
```
In file included from /home/vascom/mapsme/omim/coding/move_to_front.cpp:1:
/home/vascom/mapsme/omim/coding/move_to_front.hpp:12:10: ошибка: «size_t» не является именем типа
   12 |   static size_t constexpr kNumBytes = static_cast<size_t>(std::numeric_limits<uint8_t>::max()) + 1;
      |          ^~~~~~
/home/vascom/mapsme/omim/coding/move_to_front.hpp:6:1: замечание: «size_t» is defined in header «<cstddef>»; did you forget to «#include <cstddef>»?
    5 | #include <limits>
  +++ |+#include <cstddef>
    6 |
```
With this fix generator_tool built successfully.