### PR TITLE
[tracking] Renamed headers for ArchivalReporter.

### DIFF
--- a/tracking/archival_manager.cpp
+++ b/tracking/archival_manager.cpp
@@ -124,8 +124,8 @@ void ArchivalManager::CreateUploadTask(std::string const & filePath)
   platform::HttpPayload payload;
   payload.m_url = m_url;
   payload.m_filePath = filePath;
-  payload.m_headers = {{"TrackInfo", base::GetNameFromFullPathWithoutExt(filePath)},
-                       {"Aloha", GetPlatform().UniqueIdHash()},
+  payload.m_headers = {{"X-Mapsme-TrackInfo", base::GetNameFromFullPathWithoutExt(filePath)},
+                       {"X-Mapsme-Device-Id", GetPlatform().UniqueIdHash()},
                        {"User-Agent", GetPlatform().GetAppUserAgent()}};
   platform::HttpUploaderBackground uploader(payload);
   uploader.Upload();


### PR DESCRIPTION
Для единообразия добавлен префикс X-Mapsme для хедеров TrackInfo, Aloha.