### PR TITLE
[search] Keep type of mwm from first batch (ViewportIntersect/UserPosition/MatchedCity).

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -566,7 +566,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
 
     if (m_params.IsCategorialRequest())
     {
-      MatchCategories(ctx, mwmType.IsFirstBatchMwm(inViewport));
+      MatchCategories(ctx, mwmType.m_viewportIntersect /* aroundPivot */);
     }
     else
     {

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -572,7 +572,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
     {
       MatchRegions(ctx, Region::TYPE_COUNTRY);
 
-      if (mwmType.IsFirstBatchMwm(inViewport) || m_preRanker.NumSentResults() == 0)
+      if (mwmType.m_viewportIntersect || mwmType.m_userPosition || m_preRanker.NumSentResults() == 0)
       {
         MatchAroundPivot(ctx);
       }

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -461,10 +461,10 @@ Geocoder::MwmInfosWithType Geocoder::OrderCountries(bool inViewport,
 
   auto const getMwmType = [&](auto const & info) {
     MwmType mwmType;
-    mwmType.m_viewportIntersect = m_params.m_pivot.IsIntersect(info->m_bordersRect);
-    mwmType.m_userPosition = m_params.m_position &&
-                             info->m_bordersRect.IsPointInside(*m_params.m_position);
-    mwmType.m_matchedCity = mwmsWithCities.count(info->GetCountryName()) != 0;
+    mwmType.m_viewportIntersected = m_params.m_pivot.IsIntersect(info->m_bordersRect);
+    mwmType.m_containsUserPosition =
+        m_params.m_position && info->m_bordersRect.IsPointInside(*m_params.m_position);
+    mwmType.m_containsMatchedCity = mwmsWithCities.count(info->GetCountryName()) != 0;
     return mwmType;
   };
 
@@ -566,13 +566,14 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
 
     if (m_params.IsCategorialRequest())
     {
-      MatchCategories(ctx, mwmType.m_viewportIntersect /* aroundPivot */);
+      MatchCategories(ctx, mwmType.m_viewportIntersected /* aroundPivot */);
     }
     else
     {
       MatchRegions(ctx, Region::TYPE_COUNTRY);
 
-      if (mwmType.m_viewportIntersect || mwmType.m_userPosition || m_preRanker.NumSentResults() == 0)
+      if (mwmType.m_viewportIntersected || mwmType.m_containsUserPosition ||
+          m_preRanker.NumSentResults() == 0)
       {
         MatchAroundPivot(ctx);
       }

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -138,13 +138,13 @@ private:
   {
     bool IsFirstBatchMwm(bool inViewport) const {
       if (inViewport)
-        return m_viewportIntersect;
-      return m_viewportIntersect || m_userPosition || m_matchedCity;
+        return m_viewportIntersected;
+      return m_viewportIntersected || m_containsUserPosition || m_containsMatchedCity;
     }
 
-    bool m_viewportIntersect = false;
-    bool m_userPosition = false;
-    bool m_matchedCity = false;
+    bool m_viewportIntersected = false;
+    bool m_containsUserPosition = false;
+    bool m_containsMatchedCity = false;
   };
 
   struct MwmInfosWithType
@@ -285,11 +285,13 @@ private:
                                              Model::Type & type);
 
   // Reorders maps in a way that prefix consists of "best" maps to search and suffix consists of all
-  // other maps ordered by minimum distance from pivot. Returns number of maps in prefix.
+  // other maps ordered by minimum distance from pivot. Returns MwmInfosWithType structure which
+  // consists of vector of mwms with MwmType information and number of "best" maps to search.
   // For viewport mode prefix consists of maps intersecting with pivot ordered by distance from pivot
   // center.
-  // For non-viewport search mode prefix consists of maps intersecting with pivot, map with user location
-  // and maps with cities matched to the query, sorting prefers mwms that contain the user's position.
+  // For non-viewport search mode prefix consists of maps intersecting with pivot, map with user
+  // location and maps with cities matched to the query, sorting prefers mwms that contain the
+  // user's position.
   MwmInfosWithType OrderCountries(bool inViewport,
                                   std::vector<std::shared_ptr<MwmInfo>> const & infos);
 

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -134,6 +134,26 @@ private:
     Count
   };
 
+  struct MwmType
+  {
+    bool IsFirstBatchMwm(bool inViewport) const {
+      if (inViewport)
+        return m_viewportIntersect;
+      return m_viewportIntersect || m_userPosition || m_matchedCity;
+    }
+
+    bool m_viewportIntersect = false;
+    bool m_userPosition = false;
+    bool m_matchedCity = false;
+  };
+
+  struct MwmInfosWithType
+  {
+    using MwmInfoWithType = std::pair<std::shared_ptr<MwmInfo>, MwmType>;
+    std::vector<MwmInfoWithType> m_infos;
+    size_t m_firstBatchSize = 0;
+  };
+
   struct Postcodes
   {
     void Clear()
@@ -160,7 +180,7 @@ private:
   // Sets search query params for categorial search.
   void SetParamsForCategorialSearch(Params const & params);
 
-  void GoImpl(std::vector<std::shared_ptr<MwmInfo>> & infos, bool inViewport);
+  void GoImpl(std::vector<std::shared_ptr<MwmInfo>> const & infos, bool inViewport);
 
   template <typename Locality>
   using TokenToLocalities = std::map<TokenRange, std::vector<Locality>>;
@@ -183,7 +203,7 @@ private:
   bool CityHasPostcode(BaseContext const & ctx) const;
 
   template <typename Fn>
-  void ForEachCountry(std::vector<std::shared_ptr<MwmInfo>> const & infos, Fn && fn);
+  void ForEachCountry(MwmInfosWithType const & infos, Fn && fn);
 
   // Throws CancelException if cancelled.
   void BailIfCancelled() { ::search::BailIfCancelled(m_cancellable); }
@@ -270,7 +290,8 @@ private:
   // center.
   // For non-viewport search mode prefix consists of maps intersecting with pivot, map with user location
   // and maps with cities matched to the query, sorting prefers mwms that contain the user's position.
-  size_t OrderCountries(bool inViewport, std::vector<std::shared_ptr<MwmInfo>> & infos);
+  MwmInfosWithType OrderCountries(bool inViewport,
+                                  std::vector<std::shared_ptr<MwmInfo>> const & infos);
 
   DataSource const & m_dataSource;
   storage::CountryInfoGetter const & m_infoGetter;


### PR DESCRIPTION
OrderCountries сильно усложнилась с момента своего появления (появились mwm с my_position и с городами, соотвествующими запросу). Информации о количестве mwm в первой порции выдачи уже не хватает чтобы с этим всем корректно работать.

Мне реквест нужен чтобы дальше фильтровать какие улицы рассматривать в CreateStreetsLayerAndMatchLowerLayers, но думаю что он полезен независимо от этого:
- если OrderCountries дальше будет усложняться лучше понимать как mwm попадают в первую порцию выдачи (и возможно как-то сортировать их внутри первой порции кроме расстояния от вьюпорта)
- уже сейчас реквест исправляет вызов
https://github.com/mapsme/omim/blob/e03990ef9cf39e4af859e6162e5698f32760655b/search/geocoder.cpp#L566
 судя по коду функции нужно передавать в качестве aroundPivot true только для вьюпорта, а не для всего первого батча.