### PR TITLE
[search] Filter street predictions

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -521,7 +521,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
 
   // MatchAroundPivot() should always be matched in mwms
   // intersecting with position and viewport.
-  auto processCountry = [&](MwmType const & mwmType, unique_ptr<MwmContext> context, bool updatePreranker) {
+  auto processCountry = [&](unique_ptr<MwmContext> context, bool updatePreranker) {
     ASSERT(context, ());
     m_context = move(context);
 
@@ -562,16 +562,20 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
 
     if (m_params.IsCategorialRequest())
     {
-      MatchCategories(ctx, mwmType.m_viewportIntersected /* aroundPivot */);
+      auto const mwmType = m_context->GetType();
+      CHECK(mwmType, ());
+      MatchCategories(ctx, mwmType->m_viewportIntersected /* aroundPivot */);
     }
     else
     {
-      MatchRegions(ctx, mwmType, Region::TYPE_COUNTRY);
+      MatchRegions(ctx, Region::TYPE_COUNTRY);
 
-      if (mwmType.m_viewportIntersected || mwmType.m_containsUserPosition ||
+      auto const mwmType = m_context->GetType();
+      CHECK(mwmType, ());
+      if (mwmType->m_viewportIntersected || mwmType->m_containsUserPosition ||
           m_preRanker.NumSentResults() == 0)
       {
-        MatchAroundPivot(ctx, mwmType);
+        MatchAroundPivot(ctx);
       }
     }
 
@@ -812,7 +816,7 @@ void Geocoder::ForEachCountry(ExtendedMwmInfos const & extendedInfos, Fn && fn)
       continue;
     bool const updatePreranker = i + 1 >= extendedInfos.m_firstBatchSize;
     auto const & mwmType = extendedInfos.m_infos[i].m_type;
-    if (fn(mwmType, make_unique<MwmContext>(move(handle)), updatePreranker) ==
+    if (fn(make_unique<MwmContext>(move(handle), mwmType), updatePreranker) ==
         base::ControlFlow::Break)
     {
       break;
@@ -851,7 +855,7 @@ void Geocoder::MatchCategories(BaseContext & ctx, bool aroundPivot)
   features.ForEach(emit);
 }
 
-void Geocoder::MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type type)
+void Geocoder::MatchRegions(BaseContext & ctx, Region::Type type)
 {
   TRACE(MatchRegions);
 
@@ -860,12 +864,12 @@ void Geocoder::MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type typ
   case Region::TYPE_STATE:
     // Tries to skip state matching and go to cities matching.
     // Then, performs states matching.
-    MatchCities(ctx, mwmType);
+    MatchCities(ctx);
     break;
   case Region::TYPE_COUNTRY:
     // Tries to skip country matching and go to states matching.
     // Then, performs countries matching.
-    MatchRegions(ctx, mwmType, Region::TYPE_STATE);
+    MatchRegions(ctx, Region::TYPE_STATE);
     break;
   case Region::TYPE_COUNT: ASSERT(false, ("Invalid region type.")); return;
   }
@@ -926,15 +930,15 @@ void Geocoder::MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type typ
 
       switch (type)
       {
-      case Region::TYPE_STATE: MatchCities(ctx, mwmType); break;
-      case Region::TYPE_COUNTRY: MatchRegions(ctx, mwmType, Region::TYPE_STATE); break;
+      case Region::TYPE_STATE: MatchCities(ctx); break;
+      case Region::TYPE_COUNTRY: MatchRegions(ctx, Region::TYPE_STATE); break;
       case Region::TYPE_COUNT: ASSERT(false, ("Invalid region type.")); break;
       }
     }
   }
 }
 
-void Geocoder::MatchCities(BaseContext & ctx, MwmType mwmType)
+void Geocoder::MatchCities(BaseContext & ctx)
 {
   TRACE(MatchCities);
 
@@ -990,7 +994,7 @@ void Geocoder::MatchCities(BaseContext & ctx, MwmType mwmType)
   }
 }
 
-void Geocoder::MatchAroundPivot(BaseContext & ctx, MwmType mwmType)
+void Geocoder::MatchAroundPivot(BaseContext & ctx)
 {
   TRACE(MatchAroundPivot);
 
@@ -999,10 +1003,12 @@ void Geocoder::MatchAroundPivot(BaseContext & ctx, MwmType mwmType)
   ViewportFilter filter(features, m_preRanker.Limit() /* threshold */);
 
   vector<m2::PointD> centers = {m_params.m_pivot.Center()};
-  if (mwmType.m_containsUserPosition)
+  auto const mwmType = m_context->GetType();
+  CHECK(mwmType, ());
+  if (mwmType->m_containsUserPosition)
   {
     CHECK(m_params.m_position, ());
-    if (mwmType.m_viewportIntersected)
+    if (mwmType->m_viewportIntersected)
       centers.push_back(*m_params.m_position);
     else
       centers = {*m_params.m_position};

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1170,8 +1170,16 @@ void Geocoder::CreateStreetsLayerAndMatchLowerLayers(BaseContext & ctx,
 
   vector<uint32_t> sortedFeatures;
   sortedFeatures.reserve(base::checked_cast<size_t>(prediction.m_features.PopCount()));
-  prediction.m_features.ForEach([&sortedFeatures](uint64_t bit) {
-    sortedFeatures.push_back(base::asserted_cast<uint32_t>(bit));
+  prediction.m_features.ForEach([&](uint64_t bit) {
+    auto const fid = base::asserted_cast<uint32_t>(bit);
+    m2::PointD streetCenter;
+    if (m_context->GetCenter(fid, streetCenter) &&
+        any_of(centers.begin(), centers.end(), [&](auto const & center) {
+          return mercator::DistanceOnEarth(center, streetCenter) <= m_params.m_streetSearchRadiusM;
+        }))
+    {
+      sortedFeatures.push_back(base::asserted_cast<uint32_t>(bit));
+    }
   });
   layer.m_sortedFeatures = &sortedFeatures;
 

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -566,12 +566,12 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
     }
     else
     {
-      MatchRegions(ctx, Region::TYPE_COUNTRY);
+      MatchRegions(ctx, mwmType, Region::TYPE_COUNTRY);
 
       if (mwmType.m_viewportIntersected || mwmType.m_containsUserPosition ||
           m_preRanker.NumSentResults() == 0)
       {
-        MatchAroundPivot(ctx);
+        MatchAroundPivot(ctx, mwmType);
       }
     }
 
@@ -851,7 +851,7 @@ void Geocoder::MatchCategories(BaseContext & ctx, bool aroundPivot)
   features.ForEach(emit);
 }
 
-void Geocoder::MatchRegions(BaseContext & ctx, Region::Type type)
+void Geocoder::MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type type)
 {
   TRACE(MatchRegions);
 
@@ -860,12 +860,12 @@ void Geocoder::MatchRegions(BaseContext & ctx, Region::Type type)
   case Region::TYPE_STATE:
     // Tries to skip state matching and go to cities matching.
     // Then, performs states matching.
-    MatchCities(ctx);
+    MatchCities(ctx, mwmType);
     break;
   case Region::TYPE_COUNTRY:
     // Tries to skip country matching and go to states matching.
     // Then, performs countries matching.
-    MatchRegions(ctx, Region::TYPE_STATE);
+    MatchRegions(ctx, mwmType, Region::TYPE_STATE);
     break;
   case Region::TYPE_COUNT: ASSERT(false, ("Invalid region type.")); return;
   }
@@ -926,15 +926,15 @@ void Geocoder::MatchRegions(BaseContext & ctx, Region::Type type)
 
       switch (type)
       {
-      case Region::TYPE_STATE: MatchCities(ctx); break;
-      case Region::TYPE_COUNTRY: MatchRegions(ctx, Region::TYPE_STATE); break;
+      case Region::TYPE_STATE: MatchCities(ctx, mwmType); break;
+      case Region::TYPE_COUNTRY: MatchRegions(ctx, mwmType, Region::TYPE_STATE); break;
       case Region::TYPE_COUNT: ASSERT(false, ("Invalid region type.")); break;
       }
     }
   }
 }
 
-void Geocoder::MatchCities(BaseContext & ctx)
+void Geocoder::MatchCities(BaseContext & ctx, MwmType mwmType)
 {
   TRACE(MatchCities);
 
@@ -980,7 +980,7 @@ void Geocoder::MatchCities(BaseContext & ctx)
       LocalityFilter filter(cityFeatures);
 
       size_t const numEmitted = ctx.m_numEmitted;
-      LimitedSearch(ctx, filter);
+      LimitedSearch(ctx, filter, {city.m_rect.Center()});
       if (numEmitted == ctx.m_numEmitted)
       {
         TRACE(Relaxed);
@@ -990,17 +990,29 @@ void Geocoder::MatchCities(BaseContext & ctx)
   }
 }
 
-void Geocoder::MatchAroundPivot(BaseContext & ctx)
+void Geocoder::MatchAroundPivot(BaseContext & ctx, MwmType mwmType)
 {
   TRACE(MatchAroundPivot);
 
   CBV features;
   features.SetFull();
   ViewportFilter filter(features, m_preRanker.Limit() /* threshold */);
-  LimitedSearch(ctx, filter);
+
+  vector<m2::PointD> centers = {m_params.m_pivot.Center()};
+  if (mwmType.m_containsUserPosition)
+  {
+    CHECK(m_params.m_position, ());
+    if (mwmType.m_viewportIntersected)
+      centers.push_back(*m_params.m_position);
+    else
+      centers = {*m_params.m_position};
+  }
+
+  LimitedSearch(ctx, filter, centers);
 }
 
-void Geocoder::LimitedSearch(BaseContext & ctx, FeaturesFilter const & filter)
+void Geocoder::LimitedSearch(BaseContext & ctx, FeaturesFilter const & filter,
+                             vector<m2::PointD> const & centers)
 {
   m_filter = &filter;
   SCOPE_GUARD(resetFilter, [&]() { m_filter = nullptr; });
@@ -1013,8 +1025,8 @@ void Geocoder::LimitedSearch(BaseContext & ctx, FeaturesFilter const & filter)
 
   MatchUnclassified(ctx, 0 /* curToken */);
 
-  auto const search = [this, &ctx]() {
-    GreedilyMatchStreets(ctx);
+  auto const search = [this, &ctx, &centers]() {
+    GreedilyMatchStreets(ctx, centers);
     MatchPOIsAndBuildings(ctx, 0 /* curToken */);
   };
 
@@ -1090,7 +1102,7 @@ void Geocoder::WithPostcodes(BaseContext & ctx, Fn && fn)
   }
 }
 
-void Geocoder::GreedilyMatchStreets(BaseContext & ctx)
+void Geocoder::GreedilyMatchStreets(BaseContext & ctx, vector<m2::PointD> const & centers)
 {
   TRACE(GreedilyMatchStreets);
 
@@ -1099,12 +1111,13 @@ void Geocoder::GreedilyMatchStreets(BaseContext & ctx)
   StreetsMatcher::Go(ctx, ctx.m_streets, *m_filter, m_params, predictions);
 
   for (auto const & prediction : predictions)
-    CreateStreetsLayerAndMatchLowerLayers(ctx, prediction);
+    CreateStreetsLayerAndMatchLowerLayers(ctx, prediction, centers);
 
-  GreedilyMatchStreetsWithSuburbs(ctx);
+  GreedilyMatchStreetsWithSuburbs(ctx, centers);
 }
 
-void Geocoder::GreedilyMatchStreetsWithSuburbs(BaseContext & ctx)
+void Geocoder::GreedilyMatchStreetsWithSuburbs(BaseContext & ctx,
+                                               vector<m2::PointD> const & centers)
 {
   TRACE(GreedilyMatchStreetsWithSuburbs);
   vector<StreetsMatcher::Prediction> suburbs;
@@ -1138,13 +1151,14 @@ void Geocoder::GreedilyMatchStreetsWithSuburbs(BaseContext & ctx)
       StreetsMatcher::Go(ctx, suburbStreets, *m_filter, m_params, predictions);
 
       for (auto const & prediction : predictions)
-        CreateStreetsLayerAndMatchLowerLayers(ctx, prediction);
+        CreateStreetsLayerAndMatchLowerLayers(ctx, prediction, centers);
     });
   }
 }
 
 void Geocoder::CreateStreetsLayerAndMatchLowerLayers(BaseContext & ctx,
-                                                     StreetsMatcher::Prediction const & prediction)
+                                                     StreetsMatcher::Prediction const & prediction,
+                                                     vector<m2::PointD> const & centers)
 {
   auto & layers = ctx.m_layers;
 

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -92,6 +92,7 @@ public:
     std::vector<uint32_t> m_cuisineTypes;
     std::vector<uint32_t> m_preferredTypes;
     std::shared_ptr<Tracer> m_tracer;
+    double m_streetSearchRadiusM = 0.0;
   };
 
   Geocoder(DataSource const & dataSource, storage::CountryInfoGetter const & infoGetter,

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -135,19 +135,6 @@ private:
     Count
   };
 
-  struct MwmType
-  {
-    bool IsFirstBatchMwm(bool inViewport) const {
-      if (inViewport)
-        return m_viewportIntersected;
-      return m_viewportIntersected || m_containsUserPosition || m_containsMatchedCity;
-    }
-
-    bool m_viewportIntersected = false;
-    bool m_containsUserPosition = false;
-    bool m_containsMatchedCity = false;
-  };
-
   struct ExtendedMwmInfos
   {
     struct ExtendedMwmInfo
@@ -155,7 +142,7 @@ private:
       bool operator<(ExtendedMwmInfo const & rhs) const;
 
       std::shared_ptr<MwmInfo> m_info;
-      MwmType m_type;
+      MwmContext::MwmType m_type;
       double m_similarity;
       double m_distance;
     };
@@ -223,17 +210,17 @@ private:
 
   // Tries to find all countries and states in a search query and then
   // performs matching of cities in found maps.
-  void MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type type);
+  void MatchRegions(BaseContext & ctx, Region::Type type);
 
   // Tries to find all cities in a search query and then performs
   // matching of streets in found cities.
-  void MatchCities(BaseContext & ctx, MwmType mwmType);
+  void MatchCities(BaseContext & ctx);
 
   // Tries to do geocoding without localities, ie. find POIs,
   // BUILDINGs and STREETs without knowledge about country, state,
   // city or village. If during the geocoding too many features are
   // retrieved, viewport is used to throw away excess features.
-  void MatchAroundPivot(BaseContext & ctx, MwmType mwmType);
+  void MatchAroundPivot(BaseContext & ctx);
 
   // Tries to do geocoding in a limited scope, assuming that knowledge
   // about high-level features, like cities or countries, is

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -222,34 +222,36 @@ private:
 
   // Tries to find all countries and states in a search query and then
   // performs matching of cities in found maps.
-  void MatchRegions(BaseContext & ctx, Region::Type type);
+  void MatchRegions(BaseContext & ctx, MwmType mwmType, Region::Type type);
 
   // Tries to find all cities in a search query and then performs
   // matching of streets in found cities.
-  void MatchCities(BaseContext & ctx);
+  void MatchCities(BaseContext & ctx, MwmType mwmType);
 
   // Tries to do geocoding without localities, ie. find POIs,
   // BUILDINGs and STREETs without knowledge about country, state,
   // city or village. If during the geocoding too many features are
   // retrieved, viewport is used to throw away excess features.
-  void MatchAroundPivot(BaseContext & ctx);
+  void MatchAroundPivot(BaseContext & ctx, MwmType mwmType);
 
   // Tries to do geocoding in a limited scope, assuming that knowledge
   // about high-level features, like cities or countries, is
   // incorporated into |filter|.
-  void LimitedSearch(BaseContext & ctx, FeaturesFilter const & filter);
+  void LimitedSearch(BaseContext & ctx, FeaturesFilter const & filter,
+                     std::vector<m2::PointD> const & centers);
 
   template <typename Fn>
   void WithPostcodes(BaseContext & ctx, Fn && fn);
 
   // Tries to match some adjacent tokens in the query as streets and
   // then performs geocoding in street vicinities.
-  void GreedilyMatchStreets(BaseContext & ctx);
+  void GreedilyMatchStreets(BaseContext & ctx, std::vector<m2::PointD> const & centers);
   // Matches suburbs and streets inside suburbs like |GreedilyMatchStreets|.
-  void GreedilyMatchStreetsWithSuburbs(BaseContext & ctx);
+  void GreedilyMatchStreetsWithSuburbs(BaseContext & ctx, std::vector<m2::PointD> const & centers);
 
   void CreateStreetsLayerAndMatchLowerLayers(BaseContext & ctx,
-                                             StreetsMatcher::Prediction const & prediction);
+                                             StreetsMatcher::Prediction const & prediction,
+                                             std::vector<m2::PointD> const & centers);
 
   // Tries to find all paths in a search tree, where each edge is
   // marked with some substring of the query tokens. These paths are

--- a/search/mwm_context.cpp
+++ b/search/mwm_context.cpp
@@ -23,6 +23,17 @@ MwmContext::MwmContext(MwmSet::MwmHandle handle)
 {
 }
 
+MwmContext::MwmContext(MwmSet::MwmHandle handle, MwmType type)
+  : m_handle(std::move(handle))
+  , m_value(*m_handle.GetValue())
+  , m_vector(m_value.m_cont, m_value.GetHeader(), m_value.m_table.get())
+  , m_index(m_value.m_cont.GetReader(INDEX_FILE_TAG), m_value.m_factory)
+  , m_centers(m_value)
+  , m_editableSource(m_handle)
+  , m_type(type)
+{
+}
+
 std::unique_ptr<FeatureType> MwmContext::GetFeature(uint32_t index) const
 {
   std::unique_ptr<FeatureType> ft;

--- a/search/mwm_context.hpp
+++ b/search/mwm_context.hpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -30,11 +31,27 @@ void CoverRect(m2::RectD const & rect, int scale, covering::Intervals & result);
 class MwmContext
 {
 public:
+  struct MwmType
+  {
+    bool IsFirstBatchMwm(bool inViewport) const
+    {
+      if (inViewport)
+        return m_viewportIntersected;
+      return m_viewportIntersected || m_containsUserPosition || m_containsMatchedCity;
+    }
+
+    bool m_viewportIntersected = false;
+    bool m_containsUserPosition = false;
+    bool m_containsMatchedCity = false;
+  };
+
   explicit MwmContext(MwmSet::MwmHandle handle);
+  MwmContext(MwmSet::MwmHandle handle, MwmType type);
 
   MwmSet::MwmId const & GetId() const { return m_handle.GetId(); }
   std::string const & GetName() const { return GetInfo()->GetCountryName(); }
   std::shared_ptr<MwmInfo> const & GetInfo() const { return GetId().GetInfo(); }
+  std::optional<MwmType> const & GetType() const { return m_type; }
 
   template <typename Fn>
   void ForEachIndex(covering::Intervals const & intervals, uint32_t scale, Fn && fn) const
@@ -113,6 +130,7 @@ private:
   ScaleIndex<ModelReaderPtr> m_index;
   LazyCentersTable m_centers;
   EditableFeatureSource m_editableSource;
+  std::optional<MwmType> m_type;
 
   DISALLOW_COPY_AND_MOVE(MwmContext);
 };

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -729,6 +729,7 @@ void Processor::InitGeocoder(Geocoder::Params & geocoderParams, SearchParams con
   geocoderParams.m_cuisineTypes = m_cuisineTypes;
   geocoderParams.m_preferredTypes = m_preferredTypes;
   geocoderParams.m_tracer = searchParams.m_tracer;
+  geocoderParams.m_streetSearchRadiusM = searchParams.m_streetSearchRadiusM;
 
   m_geocoder.SetParams(geocoderParams);
 }

--- a/search/search_params.hpp
+++ b/search/search_params.hpp
@@ -27,6 +27,7 @@ struct SearchParams
   inline static size_t const kDefaultNumResultsEverywhere = 30;
   inline static size_t const kDefaultNumResultsInViewport = 200;
   inline static size_t const kPreResultsCount = 200;
+  inline static double const kDefaultStreetSearchRadiusM = 80000;
   inline static std::chrono::steady_clock::duration const kDefaultTimeout =
       std::chrono::seconds(3);
   inline static std::chrono::steady_clock::duration const kDefaultDesktopTimeout =
@@ -72,6 +73,9 @@ struct SearchParams
   // Minimal distance between search results in mercators, needed for
   // pre-ranking of viewport search results.
   double m_minDistanceOnMapBetweenResults = 0.0;
+
+  // Street search radius from pivot or matched city center for everywhere search mode.
+  double m_streetSearchRadiusM = kDefaultStreetSearchRadiusM;
 
   Mode m_mode = Mode::Everywhere;
 

--- a/search/search_tests_support/helpers.cpp
+++ b/search/search_tests_support/helpers.cpp
@@ -88,6 +88,7 @@ unique_ptr<tests_support::TestSearchRequest> SearchTest::MakeRequest(
   params.m_mode = Mode::Everywhere;
   params.m_needAddress = true;
   params.m_suggestsEnabled = false;
+  params.m_streetSearchRadiusM = tests_support::TestSearchRequest::kDefaultTestStreetSearchRadiusM;
 
   auto request = make_unique<tests_support::TestSearchRequest>(m_engine, params);
   request->Run();

--- a/search/search_tests_support/test_search_request.cpp
+++ b/search/search_tests_support/test_search_request.cpp
@@ -25,6 +25,7 @@ TestSearchRequest::TestSearchRequest(TestSearchEngine & engine, string const & q
   m_params.m_inputLocale = locale;
   m_params.m_viewport = viewport;
   m_params.m_mode = mode;
+  m_params.m_streetSearchRadiusM = kDefaultTestStreetSearchRadiusM;
   SetUpCallbacks();
   SetUpResultParams();
 }
@@ -47,6 +48,7 @@ TestSearchRequest::TestSearchRequest(TestSearchEngine & engine, string const & q
   m_params.m_mode = mode;
   m_params.m_onStarted = onStarted;
   m_params.m_onResults = onResults;
+  m_params.m_streetSearchRadiusM = kDefaultTestStreetSearchRadiusM;
   SetUpResultParams();
 }
 

--- a/search/search_tests_support/test_search_request.hpp
+++ b/search/search_tests_support/test_search_request.hpp
@@ -25,6 +25,8 @@ class TestSearchEngine;
 class TestSearchRequest
 {
 public:
+  inline static double const kDefaultTestStreetSearchRadiusM = 2e7;
+
   TestSearchRequest(TestSearchEngine & engine, std::string const & query,
                     std::string const & locale, Mode mode, m2::RectD const & viewport);
   TestSearchRequest(TestSearchEngine & engine, SearchParams const & params);


### PR DESCRIPTION
Фильтрация улиц по расстоянию от ключевой точки: локации пользователя, центра вьюпорта либо центра города из запроса.

По результатам просмотра размеченной выборки витальных результатов меньше не стало, зато стало меньше мусора + MatchPoiAndBuildings довольно дорогой вызов, их стало меньше, а значит стало больше времени для других разборов.