### PR TITLE
[indexer] Do not reuse FeaturesVector buffer for different features. Store buffer inside FeatureType.

### DIFF
--- a/coding/coding_tests/var_record_reader_test.cpp
+++ b/coding/coding_tests/var_record_reader_test.cpp
@@ -19,14 +19,14 @@ namespace
 {
   struct SaveForEachParams
   {
-    explicit SaveForEachParams(vector<pair<uint64_t, string> > & data) : m_Data(data) {}
+    explicit SaveForEachParams(vector<pair<uint64_t, string>> & data) : m_data(data) {}
 
     void operator()(uint64_t pos, vector<char> && data) const
     {
-      m_Data.emplace_back(pos, string(data.begin(), data.end()));
+      m_data.emplace_back(pos, string(data.begin(), data.end()));
     }
 
-    vector<pair<uint64_t, string> > & m_Data;
+    vector<pair<uint64_t, string>> & m_data;
   };
 
 }

--- a/coding/var_record_reader.hpp
+++ b/coding/var_record_reader.hpp
@@ -11,77 +11,40 @@
 #include <string>
 #include <vector>
 
-inline uint32_t VarRecordSizeReaderVarint(ArrayByteSource & source)
-{
-  return ReadVarUint<uint32_t>(source);
-}
-
-inline uint32_t VarRecordSizeReaderFixed(ArrayByteSource & source)
-{
-  return ReadPrimitiveFromSource<uint32_t>(source);
-}
-
-// Efficiently reads records, encoded as [VarUint size] [Data] .. [VarUint size] [Data].
-// If size of a record is less than expectedRecordSize, exactly 1 Reader.Read() call is made,
-// otherwise exactly 2 Reader.Read() calls are made.
-// Second template parameter is strategy for reading record size,
-// either &VarRecordSizeReaderVarint or &VarRecordSizeReaderFixed.
-template <class ReaderT, uint32_t (*VarRecordSizeReaderFn)(ArrayByteSource &)>
+// Reads records, encoded as [VarUint size] [Data] .. [VarUint size] [Data].
+template <class ReaderT>
 class VarRecordReader
 {
 public:
-  VarRecordReader(ReaderT const & reader, uint32_t expectedRecordSize)
-  : m_Reader(reader), m_ReaderSize(reader.Size()), m_ExpectedRecordSize(expectedRecordSize)
+  VarRecordReader(ReaderT const & reader) : m_reader(reader), m_readerSize(reader.Size()) {}
+
+  std::vector<char> ReadRecord(uint64_t const pos) const
   {
-    ASSERT_GREATER_OR_EQUAL(expectedRecordSize, 4, ());
+    ASSERT_LESS(pos, m_readerSize, ());
+    ReaderSource source(m_reader);
+    source.Skip(pos);
+    uint32_t const recordSize = ReadVarUint<uint32_t>(source);
+    std::vector<char> buffer(recordSize);
+    source.Read(buffer.data(), recordSize);
+    return buffer;
   }
 
-  uint64_t ReadRecord(uint64_t const pos, std::vector<char> & buffer, uint32_t & recordOffset,
-                      uint32_t & actualSize) const
-  {
-    ASSERT_LESS(pos, m_ReaderSize, ());
-    uint32_t const initialSize = static_cast<uint32_t>(
-        std::min(static_cast<uint64_t>(m_ExpectedRecordSize), m_ReaderSize - pos));
-
-    if (buffer.size() < initialSize)
-      buffer.resize(initialSize);
-
-    m_Reader.Read(pos, &buffer[0], initialSize);
-    ArrayByteSource source(&buffer[0]);
-    uint32_t const recordSize = VarRecordSizeReaderFn(source);
-    uint32_t const recordSizeSize = static_cast<uint32_t>(source.PtrC() - &buffer[0]);
-    uint32_t const fullSize = recordSize + recordSizeSize;
-    ASSERT_LESS_OR_EQUAL(pos + fullSize, m_ReaderSize, ());
-    if (buffer.size() < fullSize)
-      buffer.resize(fullSize);
-    if (initialSize < fullSize)
-      m_Reader.Read(pos + initialSize, &buffer[initialSize], fullSize - initialSize);
-
-    recordOffset = recordSizeSize;
-    actualSize = fullSize;
-    return pos + fullSize;
-  }
-
-  template <typename F>
-  void ForEachRecord(F const & f) const
+  void ForEachRecord(std::function<void(uint32_t, std::vector<char> &&)> const & f) const
   {
     uint64_t pos = 0;
-    std::vector<char> buffer;
-    while (pos < m_ReaderSize)
+    ReaderSource source(m_reader);
+    while (pos < m_readerSize)
     {
-      uint32_t offset = 0, size = 0;
-      uint64_t nextPos = ReadRecord(pos, buffer, offset, size);
-      // uint64_t -> uint32_t : assume that feature dat file not more than 4Gb
-      f(static_cast<uint32_t>(pos), &buffer[offset], static_cast<uint32_t>(size - offset));
-      pos = nextPos;
+      uint32_t const recordSize = ReadVarUint<uint32_t>(source);
+      std::vector<char> buffer(recordSize);
+      source.Read(buffer.data(), recordSize);
+      f(static_cast<uint32_t>(pos), std::move(buffer));
+      pos = source.Pos();
     }
     ASSERT_EQUAL(pos, m_ReaderSize, ());
   }
 
-  bool IsEqual(std::string const & fName) const { return m_Reader.IsEqual(fName); }
-
 protected:
-  ReaderT m_Reader;
-  uint64_t m_ReaderSize;
-  uint32_t m_ExpectedRecordSize; // Expected size of a record.
+  ReaderT m_reader;
+  uint64_t m_readerSize;
 };

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -109,13 +109,13 @@ int GetScaleIndex(SharedLoadInfo const & loadInfo, int scale,
   return -1;
 }
 
-uint32_t CalcOffset(ArrayByteSource const & source, const char * start)
+uint32_t CalcOffset(ArrayByteSource const & source, char const * start)
 {
   ASSERT_GREATER_OR_EQUAL(source.PtrC(), start, ());
-  return static_cast<uint32_t>(source.PtrC() - start);
+  return static_cast<uint32_t>(distance(start, source.PtrC()));
 }
 
-uint8_t Header(FeatureType::Buffer const & data) { return static_cast<uint8_t>(data[0]); }
+uint8_t Header(vector<char> const & data) { return static_cast<uint8_t>(data[0]); }
 
 void ReadOffsets(SharedLoadInfo const & loadInfo, ArrayByteSource & src, uint8_t mask,
                  FeatureType::GeometryOffsets & offsets)
@@ -181,17 +181,11 @@ uint8_t ReadByte(TSource & src)
 }
 }  // namespace
 
-FeatureType::FeatureType(SharedLoadInfo const * loadInfo, Buffer && buffer) : m_data(buffer)
+FeatureType::FeatureType(SharedLoadInfo const * loadInfo, vector<char> && buffer)
+  : m_data(buffer), m_loadInfo(loadInfo)
 {
-  CHECK(loadInfo, ());
-  m_loadInfo = loadInfo;
+  CHECK(m_loadInfo, ());
   m_header = Header(m_data);
-
-  m_offsets.Reset();
-  m_ptsSimpMask = 0;
-  m_limitRect.MakeEmpty();
-  m_parsed.Reset();
-  m_innerStats.MakeZero();
 }
 
 FeatureType::FeatureType(osm::MapObject const & emo)

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -31,10 +31,9 @@ class MapObject;
 class FeatureType
 {
 public:
-  using Buffer = std::vector<char>;
   using GeometryOffsets = buffer_vector<uint32_t, feature::DataHeader::kMaxScalesCount>;
 
-  FeatureType(feature::SharedLoadInfo const * loadInfo, Buffer && buffer);
+  FeatureType(feature::SharedLoadInfo const * loadInfo, std::vector<char> && buffer);
   FeatureType(osm::MapObject const & emo);
 
   feature::GeomType GetGeomType() const;
@@ -244,7 +243,7 @@ private:
 
   // Non-owning pointer to shared load info. SharedLoadInfo created once per FeaturesVector.
   feature::SharedLoadInfo const * m_loadInfo = nullptr;
-  Buffer m_data;
+  std::vector<char> m_data;
 
   ParsedFlags m_parsed;
   Offsets m_offsets;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -31,10 +31,10 @@ class MapObject;
 class FeatureType
 {
 public:
-  using Buffer = char const *;
+  using Buffer = std::vector<char>;
   using GeometryOffsets = buffer_vector<uint32_t, feature::DataHeader::kMaxScalesCount>;
 
-  FeatureType(feature::SharedLoadInfo const * loadInfo, Buffer buffer);
+  FeatureType(feature::SharedLoadInfo const * loadInfo, Buffer && buffer);
   FeatureType(osm::MapObject const & emo);
 
   feature::GeomType GetGeomType() const;
@@ -244,8 +244,7 @@ private:
 
   // Non-owning pointer to shared load info. SharedLoadInfo created once per FeaturesVector.
   feature::SharedLoadInfo const * m_loadInfo = nullptr;
-  // Raw pointer to data buffer.
-  Buffer m_data = nullptr;
+  Buffer m_data;
 
   ParsedFlags m_parsed;
   Offsets m_offsets;

--- a/indexer/features_vector.cpp
+++ b/indexer/features_vector.cpp
@@ -7,10 +7,8 @@
 
 std::unique_ptr<FeatureType> FeaturesVector::GetByIndex(uint32_t index) const
 {
-  uint32_t offset = 0, size = 0;
   auto const ftOffset = m_table ? m_table->GetFeatureOffset(index) : index;
-  m_recordReader.ReadRecord(ftOffset, m_buffer, offset, size);
-  return std::make_unique<FeatureType>(&m_loadInfo, &m_buffer[offset]);
+  return std::make_unique<FeatureType>(&m_loadInfo, m_recordReader.ReadRecord(ftOffset));
 }
 
 size_t FeaturesVector::GetNumFeatures() const

--- a/indexer/features_vector.hpp
+++ b/indexer/features_vector.hpp
@@ -54,7 +54,6 @@ private:
 
   feature::SharedLoadInfo m_loadInfo;
   VarRecordReader<FilesContainerR::TReader> m_recordReader;
-  mutable std::vector<char> m_buffer;
   feature::FeaturesOffsetsTable const * m_table;
 };
 

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -27,7 +27,7 @@ set(
   postcodes_matcher_tests.cpp
   postcodes_tests.cpp
   rank_table_test.cpp
-  read_features_test.cpp
+  read_features_tests.cpp
   scale_index_reading_tests.cpp
   scales_test.cpp
   search_string_utils_test.cpp

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   postcodes_matcher_tests.cpp
   postcodes_tests.cpp
   rank_table_test.cpp
+  read_features_test.cpp
   scale_index_reading_tests.cpp
   scales_test.cpp
   search_string_utils_test.cpp

--- a/indexer/indexer_tests/read_features_test.cpp
+++ b/indexer/indexer_tests/read_features_test.cpp
@@ -1,0 +1,38 @@
+#include "testing/testing.hpp"
+
+#include "indexer/classificator_loader.hpp"
+#include "indexer/data_source.hpp"
+
+#include "platform/local_country_file.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+using namespace std;
+
+UNIT_TEST(ReadFeatures_Smoke)
+{
+  classificator::Load();
+
+  FrozenDataSource dataSource;
+  dataSource.RegisterMap(platform::LocalCountryFile::MakeForTesting("minsk-pass"));
+
+  vector<shared_ptr<MwmInfo>> infos;
+  dataSource.GetMwmsInfo(infos);
+  CHECK_EQUAL(infos.size(), 1, ());
+
+  auto handle = dataSource.GetMwmHandleById(MwmSet::MwmId(infos[0]));
+
+  FeaturesLoaderGuard const guard(dataSource, handle.GetId());
+  LOG(LINFO, (guard.GetNumFeatures()));
+  for (uint32_t i = 0; i < guard.GetNumFeatures() - 1; ++i)
+  {
+    LOG(LINFO, ("Trying", i, i + 1));
+    auto ft1 = guard.GetFeatureByIndex(i);
+    auto ft2 = guard.GetFeatureByIndex(i + 1);
+
+    ft2->ForEachType([](auto const t) {});
+    ft1->ForEachType([](auto const t) {});
+  }
+}

--- a/indexer/indexer_tests/read_features_tests.cpp
+++ b/indexer/indexer_tests/read_features_tests.cpp
@@ -26,13 +26,13 @@ UNIT_TEST(ReadFeatures_Smoke)
 
   FeaturesLoaderGuard const guard(dataSource, handle.GetId());
   LOG(LINFO, (guard.GetNumFeatures()));
-  for (uint32_t i = 0; i < guard.GetNumFeatures() - 1; ++i)
+  for (uint32_t i = 0; i + 1 < guard.GetNumFeatures(); ++i)
   {
     LOG(LINFO, ("Trying", i, i + 1));
     auto ft1 = guard.GetFeatureByIndex(i);
     auto ft2 = guard.GetFeatureByIndex(i + 1);
 
-    ft2->ForEachType([](auto const t) {});
-    ft1->ForEachType([](auto const t) {});
+    ft2->ForEachType([](auto const /* t */) {});
+    ft1->ForEachType([](auto const /* t */) {});
   }
 }

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		3D928F681D50F9FE001670E0 /* data_source_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D928F661D50F9FE001670E0 /* data_source_helpers.hpp */; };
 		40009062201F5CB000963E18 /* cell_value_pair.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4000905D201F5CAF00963E18 /* cell_value_pair.hpp */; };
 		40662D32236059BF006A124D /* tree_node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40662D2F236059BF006A124D /* tree_node.hpp */; };
+		4067554C242BB04800EB8F8B /* read_features_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4067554B242BB04800EB8F8B /* read_features_tests.cpp */; };
 		406970A221AEF2F20024DDB2 /* brands_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 406970A121AEF2F10024DDB2 /* brands_tests.cpp */; };
 		4088CE2021AE993F00E2702A /* brands_holder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4088CE1E21AE993F00E2702A /* brands_holder.hpp */; };
 		4088CE2121AE993F00E2702A /* brands_holder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4088CE1F21AE993F00E2702A /* brands_holder.cpp */; };
@@ -292,6 +293,7 @@
 		4000905D201F5CAF00963E18 /* cell_value_pair.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cell_value_pair.hpp; sourceTree = "<group>"; };
 		4052928E21496D2B00D821F1 /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = categories_cuisines.txt; path = ../../data/categories_cuisines.txt; sourceTree = "<group>"; };
 		40662D2F236059BF006A124D /* tree_node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = tree_node.hpp; path = complex/tree_node.hpp; sourceTree = "<group>"; };
+		4067554B242BB04800EB8F8B /* read_features_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = read_features_tests.cpp; sourceTree = "<group>"; };
 		406970A121AEF2F10024DDB2 /* brands_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = brands_tests.cpp; sourceTree = "<group>"; };
 		4088CE1E21AE993F00E2702A /* brands_holder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = brands_holder.hpp; sourceTree = "<group>"; };
 		4088CE1F21AE993F00E2702A /* brands_holder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = brands_holder.cpp; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 		670C60F81AB0657700C38A8C /* indexer_tests */ = {
 			isa = PBXGroup;
 			children = (
+				4067554B242BB04800EB8F8B /* read_features_tests.cpp */,
 				40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */,
 				391C0C8522BD255E003DC252 /* feature_to_osm_tests.cpp */,
 				406970A121AEF2F10024DDB2 /* brands_tests.cpp */,
@@ -1049,6 +1052,7 @@
 				675341071A3F540F00A0A8C3 /* data_factory.cpp in Sources */,
 				34583BCB1C88552100F94664 /* map_object.cpp in Sources */,
 				675B562320D25C9800A521D2 /* feature_source.cpp in Sources */,
+				4067554C242BB04800EB8F8B /* read_features_tests.cpp in Sources */,
 				6753412E1A3F540F00A0A8C3 /* index_builder.cpp in Sources */,
 				675341011A3F540F00A0A8C3 /* classificator_loader.cpp in Sources */,
 				456E1B191F90E5B7009C32E1 /* ftypes_sponsored.cpp in Sources */,


### PR DESCRIPTION
Сейчас у нас в FeaturesVector переиспользуется один и тот же буфер для всех фичей. Поэтому такой код как в добавленном тесте ReadFeatures_Smoke приводит к крешам.

Видимо это сделано из соображений производительности -- чтобы было меньше аллокаций и освобождений памяти. Но, как показывают тесты, хранение в каждой фиче её буфера в некоторых случаях работает быстрее, в некоторых -- не сильно хуже. (предполагаю что это происходит потому что сейчас всегда читается минимум 256 байт, хотя на самом деле многие фичи значительно меньше).

Недостатком текущего дизайна также является то, что сложно отслеживать и не допускать использование FeatureType таким образом как это показано в тесте ReadFeatures_Smoke.
Сейчас у нас есть места где чтение фичей происходит "неразрешенным" способом, например в FeaturesLayerMatcher::GetNearbyStreets(FeatureType & feature) feature вычитана из FeaturesVector входящего в MwmContext. И внутри FeaturesLayerMatcher::GetNearbyStreets мы вызываем m_reverseGeocoder.GetNearbyStreets, который тоже читает фичи из этого же FeaturesVector.
Предположительно, с этим связана часть крешей при чтении фичей (порядка 300 крешей в день).


Тесты производительности рендеринга:

На десктопе было:

```
===== Drape statistic report ===== 

 ----- Render statistic report ----- 
 FPS = 572
 Min FPS = 6
 Immediate rendering FPS = 1355
 Immediate rendering min FPS = 6
 Frame render time, ms = 5
 FPS Distribution:
(длинный и не оч информативный лог, убрала чтобы не загромождать, если нужен -- выложу отдельным комментом)
 ----- Render statistic report ----- 


 ----- Tiles read statistic report ----- 
 Tile read time, ms = 32
 Tiles count = 84385
 ----- Tiles read statistic report ----- 


 ----- Generation statistic report ----- 
 Max scene preparing time, ms = 2796
 Shapes total generation time, ms = 497840
 Shapes total count = 142099438, (0.00350346 ms per shape)
 Overlay shapes total generation time, ms = 250643
 Overlay shapes total count = 32361697, (0.00774505 ms per overlay)
 ----- Generation statistic report ----- 


 ===== Drape statistic report =====
```

на десктопе стало:

```
===== Drape statistic report ===== 

 ----- Render statistic report ----- 
 FPS = 662
 Min FPS = 6
 Immediate rendering FPS = 1522
 Immediate rendering min FPS = 6
 Frame render time, ms = 4
 FPS Distribution:
(длинный и не оч информативный лог, убрала чтобы не загромождать, если нужен -- выложу отдельным комментом)
 ----- Render statistic report ----- 


 ----- Tiles read statistic report ----- 
 Tile read time, ms = 27
 Tiles count = 89059
 ----- Tiles read statistic report ----- 


 ----- Generation statistic report ----- 
 Max scene preparing time, ms = 2615
 Shapes total generation time, ms = 433943
 Shapes total count = 151969112, (0.00285547 ms per shape)
 Overlay shapes total generation time, ms = 227946
 Overlay shapes total count = 35581017, (0.00640639 ms per overlay)
 ----- Generation statistic report ----- 


 ===== Drape statistic report =====
```

FPS на 15% вырос, tile read time на 15% уменьшился


на андроиде Huawei P20 Pro было:
```
===== Drape statistic report ===== 
    
    ----- Render statistic report ----- 
     FPS = 59
     Min FPS = 2
     Immediate rendering FPS = 225
     Immediate rendering min FPS = 2
     Frame render time, ms = 18
     FPS Distribution:
       0-10: 0.07629%
       10-20: 0.8392%
       20-30: 2.56%
       30-40: 3.352%
       40-50: 5.043%
       50-60: 30.89%
       60-70: 50.48%
       70-80: 3.318%
       80-90: 1.996%
       90-100: 1.169%
       100-110: 0.2732%
       120-130: 0.001031%
     ----- Render statistic report ----- 
    
    
    ----- Tiles read statistic report ----- 
     Tile read time, ms = 74
     Tiles count = 28338
     ----- Tiles read statistic report ----- 
    
    
    ----- Generation statistic report ----- 
     Max scene preparing time, ms = 1725
     Shapes total generation time, ms = 450438
     Shapes total count = 78207805, (0.0057595 ms per shape)
     Overlay shapes total generation time, ms = 90147
     Overlay shapes total count = 7094266, (0.012707 ms per overlay)
     ----- Generation statistic report ----- 
    
    
    ===== Drape statistic report ===== 
```

на андроиде Huawei P20 Pro стало:
```
***** Report for scenario Test Scenario LA *****
     
    ===== Drape statistic report ===== 
    
    ----- Render statistic report ----- 
     FPS = 59
     Min FPS = 6
     Immediate rendering FPS = 224
     Immediate rendering min FPS = 7
     Frame render time, ms = 18
     FPS Distribution:
       0-10: 0.0768%
       10-20: 0.8209%
       20-30: 2.566%
       30-40: 3.434%
       40-50: 5.025%
       50-60: 27.43%
       60-70: 50%
       70-80: 4.576%
       80-90: 3.521%
       90-100: 2.086%
       100-110: 0.4639%
     ----- Render statistic report ----- 
    
    
     ----- Tiles read statistic report ----- 
     Tile read time, ms = 76
     Tiles count = 28412
     ----- Tiles read statistic report ----- 
    
    
     ----- Generation statistic report ----- 
     Max scene preparing time, ms = 1679
     Shapes total generation time, ms = 452360
     Shapes total count = 77431578, (0.00584206 ms per shape)
     Overlay shapes total generation time, ms = 91373
     Overlay shapes total count = 7031853, (0.0129942 ms per overlay)
     ----- Generation statistic report ----- 
    
    
     ===== Drape statistic report ===== 
```

FPS такой же, min FPS получше, tile read time на 2% больше, при этом Max scene preparing time наоборот чуть меньше -- в целом результаты выглядят похожими.

Визуально на андроиде и на десктопе ничего плохого не наблюдаю, тормозов в поиске не наблюдаю, features_collector не замедлился, судя по профайлерам в поиске вычитка фичей тоже стала чуть быстрее (но разница -- единицы процентов).