### PR TITLE
[android] Adjusted zoom in elevation chart, i.e. disabled pinch zoom…

### DIFF
--- a/android/src/com/mapswithme/maps/ChartController.java
+++ b/android/src/com/mapswithme/maps/ChartController.java
@@ -25,7 +25,6 @@ import com.mapswithme.maps.bookmarks.data.ElevationInfo;
 import com.mapswithme.maps.widget.placepage.AxisValueFormatter;
 import com.mapswithme.maps.widget.placepage.CurrentLocationMarkerView;
 import com.mapswithme.maps.widget.placepage.FloatingMarkerView;
-import com.mapswithme.util.StringUtils;
 import com.mapswithme.util.ThemeUtils;
 import com.mapswithme.util.Utils;
 
@@ -178,8 +177,8 @@ public class ChartController implements OnChartValueSelectedListener, Initializa
     mChart.setData(data);
     mChart.animateX(CHART_ANIMATION_DURATION);
 
-    mMinAltitude.setText(StringUtils.nativeFormatDistance(info.getMinAltitude()));
-    mMaxAltitude.setText(StringUtils.nativeFormatDistance(info.getMaxAltitude()));
+    mMinAltitude.setText(Framework.nativeFormatAltitude(info.getMinAltitude()));
+    mMaxAltitude.setText(Framework.nativeFormatAltitude(info.getMaxAltitude()));
 
     highlightActivePointManually();
   }

--- a/android/src/com/mapswithme/maps/ChartController.java
+++ b/android/src/com/mapswithme/maps/ChartController.java
@@ -8,7 +8,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.Legend;
 import com.github.mikephil.charting.components.MarkerView;
@@ -44,6 +43,7 @@ public class ChartController implements OnChartValueSelectedListener, Initializa
   private static final int CHART_X_LABEL_COUNT = 6;
   private static final int CHART_ANIMATION_DURATION = 1500;
   private static final int CHART_FILL_ALPHA = (int) (0.12 * 255);
+  private static final int CHART_AXIS_GRANULARITY = 100;
   private static final float CUBIC_INTENSITY = 0.2f;
   private static final int CURRENT_POSITION_OUT_OF_TRACK = -1;
 
@@ -93,9 +93,8 @@ public class ChartController implements OnChartValueSelectedListener, Initializa
     mChart.setTouchEnabled(true);
     mChart.setOnChartValueSelectedListener(this);
     mChart.setDrawGridBackground(false);
-    mChart.setDragEnabled(true);
-    mChart.setScaleEnabled(true);
-    mChart.setPinchZoom(true);
+    mChart.setScaleXEnabled(true);
+    mChart.setScaleYEnabled(false);
     mChart.setExtraTopOffset(0);
     int sideOffset = resources.getDimensionPixelSize(R.dimen.margin_base);
     int topOffset = 0;
@@ -125,13 +124,14 @@ public class ChartController implements OnChartValueSelectedListener, Initializa
   {
     XAxis x = mChart.getXAxis();
     x.setLabelCount(CHART_X_LABEL_COUNT, false);
-    x.setAvoidFirstLastClipping(true);
     x.setDrawGridLines(false);
+    x.setGranularity(CHART_AXIS_GRANULARITY);
+    x.setGranularityEnabled(true);
     x.setTextColor(ThemeUtils.getColor(mContext, R.attr.elevationProfileAxisLabelColor));
     x.setPosition(XAxis.XAxisPosition.BOTTOM);
     x.setAxisLineColor(ThemeUtils.getColor(mContext, R.attr.dividerHorizontal));
     x.setAxisLineWidth(mContext.getResources().getDimensionPixelSize(R.dimen.divider_height));
-    ValueFormatter xAxisFormatter = new AxisValueFormatter();
+    ValueFormatter xAxisFormatter = new AxisValueFormatter(mChart);
     x.setValueFormatter(xAxisFormatter);
 
     YAxis y = mChart.getAxisLeft();

--- a/android/src/com/mapswithme/maps/widget/placepage/AxisValueFormatter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/AxisValueFormatter.java
@@ -3,13 +3,13 @@ package com.mapswithme.maps.widget.placepage;
 import androidx.annotation.NonNull;
 import com.github.mikephil.charting.charts.BarLineChartBase;
 import com.github.mikephil.charting.formatter.DefaultValueFormatter;
+import com.mapswithme.maps.Framework;
 import com.mapswithme.util.StringUtils;
 
 public class AxisValueFormatter extends DefaultValueFormatter
 {
-  private static final String DEF_DIMEN = "m";
   private static final int DEF_DIGITS = 1;
-  private static final int DISTANCE_FOR_METER_FORMAT = 1000;
+  private static final int ONE_KM = 1000;
   @NonNull
   private final BarLineChartBase mChart;
 
@@ -22,9 +22,9 @@ public class AxisValueFormatter extends DefaultValueFormatter
   @Override
   public String getFormattedValue(float value)
   {
-    if (mChart.getVisibleXRange() > DISTANCE_FOR_METER_FORMAT)
-      return StringUtils.nativeFormatDistance(value);
+    if (mChart.getVisibleXRange() <= ONE_KM)
+      return Framework.nativeFormatAltitude(value);
 
-    return (int) value + " " + DEF_DIMEN;
+    return StringUtils.nativeFormatDistance(value);
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/AxisValueFormatter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/AxisValueFormatter.java
@@ -1,21 +1,30 @@
 package com.mapswithme.maps.widget.placepage;
 
+import androidx.annotation.NonNull;
+import com.github.mikephil.charting.charts.BarLineChartBase;
 import com.github.mikephil.charting.formatter.DefaultValueFormatter;
 import com.mapswithme.util.StringUtils;
 
 public class AxisValueFormatter extends DefaultValueFormatter
 {
+  private static final String DEF_DIMEN = "m";
   private static final int DEF_DIGITS = 1;
+  private static final int DISTANCE_FOR_METER_FORMAT = 1000;
+  @NonNull
+  private final BarLineChartBase mChart;
 
-
-  public AxisValueFormatter()
+  public AxisValueFormatter(@NonNull BarLineChartBase chart)
   {
     super(DEF_DIGITS);
+    mChart = chart;
   }
 
   @Override
   public String getFormattedValue(float value)
   {
-    return StringUtils.nativeFormatDistance(value);
+    if (mChart.getVisibleXRange() > DISTANCE_FOR_METER_FORMAT)
+      return StringUtils.nativeFormatDistance(value);
+
+    return (int) value + " " + DEF_DIMEN;
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/ElevationProfileViewRenderer.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/ElevationProfileViewRenderer.java
@@ -1,7 +1,5 @@
 package com.mapswithme.maps.widget.placepage;
 
-import android.annotation.SuppressLint;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
@@ -9,6 +7,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mapswithme.maps.ChartController;
+import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.bookmarks.data.ElevationInfo;
 import com.mapswithme.maps.routing.RoutingController;
@@ -57,24 +56,27 @@ public class ElevationProfileViewRenderer implements PlacePageViewRenderer<Place
   @NonNull
   private View mMediumDivider;
 
-  @SuppressLint("SetTextI18n")
   @Override
   public void render(@NonNull PlacePageData data)
   {
     mElevationInfo = (ElevationInfo) data;
     mChartController.setData(mElevationInfo);
-    Resources resources = mTitle.getResources();
-    String meters = " " + resources.getString(R.string.elevation_profile_m);
     mTitle.setText(mElevationInfo.getName());
     setDifficulty(mElevationInfo.getDifficulty());
-    mAscent.setText(mElevationInfo.getAscent() + meters);
-    mDescent.setText(mElevationInfo.getDescent() +  meters);
-    mMaxAltitude.setText(mElevationInfo.getMaxAltitude() + meters);
-    mMinAltitude.setText(mElevationInfo.getMinAltitude() + meters);
+    mAscent.setText(formatDistance(mElevationInfo.getAscent()));
+    mDescent.setText(formatDistance(mElevationInfo.getDescent()));
+    mMaxAltitude.setText(formatDistance(mElevationInfo.getMaxAltitude()));
+    mMinAltitude.setText(formatDistance(mElevationInfo.getMinAltitude()));
     UiUtils.hideIf(mElevationInfo.getDuration() == 0, mTimeContainer);
     mTime.setText(RoutingController.formatRoutingTime(mTitle.getContext(),
                                                       (int) mElevationInfo.getDuration(),
                                                       R.dimen.text_size_body_2));
+  }
+
+  @NonNull
+  private static String formatDistance(int distance)
+  {
+    return Framework.nativeFormatAltitude(distance);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/widget/placepage/FloatingMarkerView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/FloatingMarkerView.java
@@ -12,6 +12,7 @@ import com.github.mikephil.charting.components.MarkerView;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.utils.MPPointF;
+import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.R;
 import com.mapswithme.util.StringUtils;
 
@@ -135,7 +136,7 @@ public class FloatingMarkerView extends MarkerView
   {
     mDistanceTextView.setText(R.string.elevation_profile_distance);
     mDistanceValueView.setText(StringUtils.nativeFormatDistance(entry.getX()));
-    mAltitudeView.setText(StringUtils.nativeFormatDistance(entry.getY()));
+    mAltitudeView.setText(Framework.nativeFormatAltitude(entry.getY()));
   }
 
   private void updateHorizontal(@NonNull Highlight highlight)

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -196,8 +196,8 @@ string FormatAltitude(double altitudeInMeters)
   /// @todo Put string units resources.
   switch (units)
   {
-  case Units::Imperial: ss << MetersToFeet(altitudeInMeters) << "ft"; break;
-  case Units::Metric: ss << altitudeInMeters << "m"; break;
+  case Units::Imperial: ss << MetersToFeet(altitudeInMeters) << " ft"; break;
+  case Units::Metric: ss << altitudeInMeters << " m"; break;
   }
   return ss.str();
 }
@@ -242,8 +242,8 @@ string FormatSpeedUnits(Units units)
 {
   switch (units)
   {
-  case Units::Imperial: return "mph";
-  case Units::Metric: return "km/h";
+  case Units::Imperial: return " mph";
+  case Units::Metric: return " km/h";
   }
   UNREACHABLE();
 }

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -95,33 +95,33 @@ UNIT_TEST(FormatAltitude)
 {
   ScopedSettings guard;
   settings::Set(settings::kMeasurementUnits, Units::Imperial);
-  TEST_EQUAL(FormatAltitude(10000), "32808ft", ());
+  TEST_EQUAL(FormatAltitude(10000), "32808 ft", ());
   settings::Set(settings::kMeasurementUnits, Units::Metric);
-  TEST_EQUAL(FormatAltitude(5), "5m", ());
+  TEST_EQUAL(FormatAltitude(5), "5 m", ());
 }
 
 UNIT_TEST(FormatSpeedWithDeviceUnits)
 {
   {
     ScopedSettings guard(Units::Metric);
-    TEST_EQUAL(FormatSpeedWithDeviceUnits(10), "36km/h", ());
-    TEST_EQUAL(FormatSpeedWithDeviceUnits(1), "3.6km/h", ());
+    TEST_EQUAL(FormatSpeedWithDeviceUnits(10), "36 km/h", ());
+    TEST_EQUAL(FormatSpeedWithDeviceUnits(1), "3.6 km/h", ());
   }
 
   {
     ScopedSettings guard(Units::Imperial);
-    TEST_EQUAL(FormatSpeedWithDeviceUnits(10), "22mph", ());
-    TEST_EQUAL(FormatSpeedWithDeviceUnits(1), "2.2mph", ());
+    TEST_EQUAL(FormatSpeedWithDeviceUnits(10), "22 mph", ());
+    TEST_EQUAL(FormatSpeedWithDeviceUnits(1), "2.2 mph", ());
   }
 }
 
 UNIT_TEST(FormatSpeedWithUnits)
 {
-  TEST_EQUAL(FormatSpeedWithUnits(10, Units::Metric), "36km/h", ());
-  TEST_EQUAL(FormatSpeedWithUnits(1, Units::Metric), "3.6km/h", ());
+  TEST_EQUAL(FormatSpeedWithUnits(10, Units::Metric), "36 km/h", ());
+  TEST_EQUAL(FormatSpeedWithUnits(1, Units::Metric), "3.6 km/h", ());
 
-  TEST_EQUAL(FormatSpeedWithUnits(10, Units::Imperial), "22mph", ());
-  TEST_EQUAL(FormatSpeedWithUnits(1, Units::Imperial), "2.2mph", ());
+  TEST_EQUAL(FormatSpeedWithUnits(10, Units::Imperial), "22 mph", ());
+  TEST_EQUAL(FormatSpeedWithUnits(1, Units::Imperial), "2.2 mph", ());
 }
 
 UNIT_TEST(FormatSpeed)
@@ -135,8 +135,8 @@ UNIT_TEST(FormatSpeed)
 
 UNIT_TEST(FormatSpeedUnits)
 {
-  TEST_EQUAL(FormatSpeedUnits(Units::Metric), "km/h", ());
-  TEST_EQUAL(FormatSpeedUnits(Units::Imperial), "mph", ());
+  TEST_EQUAL(FormatSpeedUnits(Units::Metric), " km/h", ());
+  TEST_EQUAL(FormatSpeedUnits(Units::Imperial), " mph", ());
 }
 
 UNIT_TEST(OSMDistanceToMetersString)


### PR DESCRIPTION
… and left only xaxis scaling

[android] Added displaying meters if x range is lower 1000 meters

https://jira.mail.ru/browse/MAPSME-13475
https://jira.mail.ru/browse/MAPSME-13521

@darina @milchakov просьба посмотреть с++ код, добавил функцию для форматирования дистанции в малые единицы измерения (метры и футы), т.к. все высоты необходимы отображать в малых единицах измерения. @beloal @Polas  возвращаясь к нашему вопросу о форматировании, на стороне андроида нет больше вариантов, кроме как использовать функцию ядра (+ новую, которая в этом реквесте), т.к. у нас нет нормального форматера дистанции в SDK + функция ядра уже читает настройку про км и мили из settings.ini.

Для удобства, все разбито на коммиты модульные.