### PR TITLE
[RELEASE ONLY] Fastfix GetCurrentTimestamp(). For crossmwm section fast build.

### DIFF
--- a/routing/road_access.cpp
+++ b/routing/road_access.cpp
@@ -33,9 +33,7 @@ void PrintKV(ostringstream & oss, KV const & kvs, size_t maxKVToShow)
 namespace routing
 {
 // RoadAccess --------------------------------------------------------------------------------------
-RoadAccess::RoadAccess() : m_currentTimeGetter([](){ return GetCurrentTimestamp(); })
-{
-}
+RoadAccess::RoadAccess() : m_currentTimeGetter([time = GetCurrentTimestamp()]() { return time; }) {}
 
 pair<RoadAccess::Type, RoadAccess::Confidence> RoadAccess::GetAccess(
     uint32_t featureId, RouteWeight const & weightToFeature) const

--- a/routing/road_access.cpp
+++ b/routing/road_access.cpp
@@ -33,6 +33,10 @@ void PrintKV(ostringstream & oss, KV const & kvs, size_t maxKVToShow)
 namespace routing
 {
 // RoadAccess --------------------------------------------------------------------------------------
+// @TODO(bykoinako) It's a fast fix for release. The idea behind it is to remember the time of
+// creation RoadAccess instance and return it instread of getting time when m_currentTimeGetter() is
+// called. But it's not understadbale now why m_currentTimeGetter() is called when
+// cross_mwm section is built.
 RoadAccess::RoadAccess() : m_currentTimeGetter([time = GetCurrentTimestamp()]() { return time; }) {}
 
 pair<RoadAccess::Type, RoadAccess::Confidence> RoadAccess::GetAccess(


### PR DESCRIPTION
Данный PR содержит 2 исправления, которые позволят не задерживать сборку карты:

1. Данное исправление может позволить собрать быстро секцию cross_mwm. Однако это ни финальный фиск. Поскольку пока не ясно, почему вообще при сборке crossmwm-ой секции вызывается RoadAccess::m_currentTimeGetter::operator().

2. В редких ситуациях сохраненная speedcam не находится в точке сочленения сегментов фичи, хотя судя по коду, должна. 

Это случается в:
US_Minnesota_Minneapolis
UK_England_East of England_Essex
Russia_Kabardino-Balkaria
Italy_Piemont_Torino
UK_England_South East_Oxford
Italy_Trentino-Alto Adige Sudtirol
New Zealand North_Auckland
UK_England_East Midlands
Uzbekistan
UK_England_South East_Brighton

В данном PR такие камеры выкидываются, а лог записывается информация о тех камерах, что выкинуты.

