### PR TITLE
[bookmarks] Fixed requesting symbol sizes on start. Fixed processing …

### DIFF
--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -761,6 +761,13 @@ private:
   std::vector<std::string> GetAllPaidCategoriesIds() const;
 
   kml::MarkId GetTrackSelectionMarkId(kml::TrackId trackId) const;
+  int GetTrackSelectionMarkMinZoom(kml::TrackId trackId) const;
+  void DeleteTrackSelectionMark(kml::TrackId trackId);
+  void SetTrackInfoMark(kml::TrackId trackId, m2::PointD const & pt);
+  void ResetTrackInfoMark(kml::TrackId trackId);
+
+  void UpdateTrackMarks();
+  void RequestSymbolSizes();
 
   ThreadChecker m_threadChecker;
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2723,6 +2723,8 @@ BookmarkManager::TrackSelectionInfo Framework::FindTrackInTapPosition(
   auto const & bm = GetBookmarkManager();
   if (buildInfo.m_trackId != kml::kInvalidTrackId)
   {
+    if (bm.GetTrack(buildInfo.m_trackId) == nullptr)
+      return {};
     auto const selection = bm.GetTrackSelectionInfo(buildInfo.m_trackId);
     CHECK_NOT_EQUAL(selection.m_trackId, kml::kInvalidTrackId, ());
     return selection;


### PR DESCRIPTION
…of a track deleting.

* На Andoid исправлен креш на старте при обращении к VisualParams до их инициализации в DrapeEngine.
* Доработки по обработке удаления трека.