### PR TITLE
[taxi] zurich is removed from freenow.

### DIFF
--- a/data/taxi_places/freenow.json
+++ b/data/taxi_places/freenow.json
@@ -172,12 +172,6 @@
       }, 
       {
         "cities": [
-          "Zurich"
-        ], 
-        "id": "Switzerland"
-      }, 
-      {
-        "cities": [
           "Barcelona", 
           "Madrid", 
           "Seville", 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13265