### PR TITLE
[search] Fix road shields indexing.

### DIFF
--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -18,6 +18,7 @@
 #include "indexer/features_vector.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/postcodes_matcher.hpp"
+#include "indexer/road_shields_parser.hpp"
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
 #include "indexer/trie_builder.hpp"
@@ -40,15 +41,15 @@
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
 
+#include "defines.hpp"
+
 #include <algorithm>
 #include <fstream>
 #include <map>
 #include <mutex>
+#include <thread>
 #include <unordered_map>
 #include <vector>
-#include <thread>
-
-#include "defines.hpp"
 
 using namespace std;
 
@@ -322,8 +323,12 @@ public:
       return;
 
     // Road number.
-    if (hasStreetType && !f.GetParams().ref.empty())
-      inserter(StringUtf8Multilang::kDefaultCode, f.GetParams().ref);
+    if (hasStreetType && !f.GetRoadNumber().empty())
+    {
+      auto const shields = ftypes::GetRoadShields(f);
+      for (auto const & shield : shields)
+        inserter(StringUtf8Multilang::kDefaultCode, shield.m_name);
+    }
 
     if (ftypes::IsAirportChecker::Instance()(types))
     {

--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -537,7 +537,14 @@ std::set<RoadShield> GetRoadShields(FeatureType & f)
 
   // Find out country name.
   std::string mwmName = f.GetID().GetMwmName();
-  ASSERT_NOT_EQUAL(mwmName, FeatureID::kInvalidFileName, ());
+
+  // |mwmName| may be empty when GetRoadShields is called from generator.
+  if (mwmName == FeatureID::kInvalidFileName)
+  {
+    return SimpleRoadShieldParser(roadNumber, SimpleRoadShieldParser::ShieldTypes())
+        .GetRoadShields();
+  }
+
   auto const underlinePos = mwmName.find('_');
   if (underlinePos != std::string::npos)
     mwmName = mwmName.substr(0, underlinePos);

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -15,6 +15,7 @@
 #include "indexer/data_source.hpp"
 #include "indexer/feature_algo.hpp"
 #include "indexer/ftypes_matcher.hpp"
+#include "indexer/road_shields_parser.hpp"
 #include "indexer/search_string_utils.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
@@ -146,9 +147,9 @@ pair<NameScores, size_t> GetNameScores(FeatureType & ft, Geocoder::Params const 
 
   if (type == Model::TYPE_STREET)
   {
-    auto const roadNumber = ft.GetRoadNumber();
-    if (!roadNumber.empty())
-      UpdateNameScores(roadNumber, sliceNoCategories, bestScores);
+    auto const shields = ftypes::GetRoadShields(ft);
+    for (auto const & shield : shields)
+      UpdateNameScores(shield.m_name, sliceNoCategories, bestScores);
   }
 
   return make_pair(bestScores, matchedLength);

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -2375,6 +2375,30 @@ UNIT_CLASS_TEST(ProcessorTest, StreetNumber)
   }
 }
 
+UNIT_CLASS_TEST(ProcessorTest, StreetNumberEnriched)
+{
+  string const countryName = "Wonderland";
+
+  TestStreet street(vector<m2::PointD>{m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0)}, "Нева", "ru");
+  street.SetRoadNumber("M-11;ru:national/M-11");
+
+  auto countryId =
+      BuildCountry(countryName, [&](TestMwmBuilder & builder) { builder.Add(street); });
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 2.0)));
+  {
+    Rules rules = {ExactMatch(countryId, street)};
+    TEST(ResultsMatch("M-11 ", rules), ());
+  }
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 2.0)));
+  {
+    Rules rules = {};
+    TEST(ResultsMatch("ru ", rules), ());
+    TEST(ResultsMatch("national ", rules), ());
+  }
+}
+
 UNIT_CLASS_TEST(ProcessorTest, Postbox)
 {
   string const countryName = "Wonderland";


### PR DESCRIPTION
В некоторых случаях мы дополняем FeatureParams ref информацией о дорожной сети из relation.

В generator/osm2type.cpp мы просто заполняем ref как есть, а в generator/relation_tags.cpp можем дополнить его.

Так, например, для фичи https://www.openstreetmap.org/way/343180292 с ref `М-11` мы берём из relation https://www.openstreetmap.org/relation/1168820, в который она входит, `network=ru:national` и итоговое значение FeatureParams ref для этой фичи получается `M-11;ru:national/M-11`.

Очевидно в поиске не нужно индексировать служебную информацию. У нас уже есть парсер который эту информацию парсит.