### PR TITLE
[search] Fill cuisines for search result.

### DIFF
--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -4,9 +4,10 @@
 #include "indexer/feature.hpp"
 #include "indexer/feature_data.hpp"
 #include "indexer/feature_visibility.hpp"
+#include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 
-#include "geometry/point2d.hpp"
+#include "platform/localization.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
 #include "coding/transliteration.hpp"
@@ -372,5 +373,33 @@ vector<int8_t> GetDescriptionLangPriority(RegionData const & regionData, int8_t 
 {
   bool const preferDefault = IsNativeLang(regionData, deviceLang);
   return MakePrimaryNamePriorityList(deviceLang, preferDefault);
+}
+
+vector<string> GetCuisines(TypesHolder const & types)
+{
+  vector<string> cuisines;
+  auto const & isCuisine = ftypes::IsCuisineChecker::Instance();
+  for (auto const t : types)
+  {
+    if (!isCuisine(t))
+      continue;
+    auto const cuisine = classif().GetFullObjectNamePath(t);
+    CHECK_EQUAL(cuisine.size(), 2, (cuisine));
+    cuisines.push_back(cuisine[1]);
+  }
+  return cuisines;
+}
+
+vector<string> GetLocalizedCuisines(TypesHolder const & types)
+{
+  vector<string> localized;
+  auto const & isCuisine = ftypes::IsCuisineChecker::Instance();
+  for (auto const t : types)
+  {
+    if (!isCuisine(t))
+      continue;
+    localized.push_back(platform::GetLocalizedTypeName(classif().GetReadableObjectName(t)));
+  }
+  return localized;
 }
 } // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -77,4 +77,10 @@ namespace feature
   /// - international language code;
   /// - english language code;
   std::vector<int8_t> GetDescriptionLangPriority(RegionData const & regionData, int8_t const deviceLang);
+
+  // Returns vector of cuisines readable names from classificator.
+  std::vector<std::string> GetCuisines(TypesHolder const & types);
+
+  // Returns vector of cuisines names localized by platform.
+  std::vector<std::string> GetLocalizedCuisines(TypesHolder const & types);
 }  // namespace feature

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -2,6 +2,7 @@
 
 #include "indexer/feature.hpp"
 #include "indexer/feature_algo.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/ftypes_matcher.hpp"
 
 #include "platform/localization.hpp"
@@ -168,32 +169,11 @@ Internet MapObject::GetInternet() const
   return Internet::Unknown;
 }
 
-vector<string> MapObject::GetCuisines() const
-{
-  vector<string> cuisines;
-  auto const & isCuisine = ftypes::IsCuisineChecker::Instance();
-  for (auto const t : m_types)
-  {
-    if (!isCuisine(t))
-      continue;
-    auto const cuisine = classif().GetFullObjectNamePath(t);
-    CHECK_EQUAL(cuisine.size(), 2, (cuisine));
-    cuisines.push_back(cuisine[1]);
-  }
-  return cuisines;
-}
+vector<string> MapObject::GetCuisines() const { return feature::GetCuisines(m_types); }
 
 vector<string> MapObject::GetLocalizedCuisines() const
 {
-  vector<string> localized;
-  auto const & isCuisine = ftypes::IsCuisineChecker::Instance();
-  for (auto const t : m_types)
-  {
-    if (!isCuisine(t))
-      continue;
-    localized.push_back(platform::GetLocalizedTypeName(classif().GetReadableObjectName(t)));
-  }
-  return localized;
+  return feature::GetLocalizedCuisines(m_types);
 }
 
 string MapObject::FormatCuisines() const { return strings::JoinStrings(GetLocalizedCuisines(), " • "); }

--- a/map/booking_availability_filter.cpp
+++ b/map/booking_availability_filter.cpp
@@ -147,7 +147,7 @@ void PrepareData(DataSource const & dataSource, search::Results const & results,
 
   for (auto const & r : results)
   {
-    if (!r.m_metadata.m_isSponsoredHotel || r.GetResultType() != search::Result::Type::Feature)
+    if (!r.m_details.m_isSponsoredHotel || r.GetResultType() != search::Result::Type::Feature)
       continue;
 
     features.push_back(r.GetFeatureID());
@@ -320,7 +320,7 @@ void AvailabilityFilter::GetFeaturesFromCache(search::Results const & results,
 
   for (auto const & r : results)
   {
-    if (!r.m_metadata.m_isSponsoredHotel || r.GetResultType() != search::Result::Type::Feature)
+    if (!r.m_details.m_isSponsoredHotel || r.GetResultType() != search::Result::Type::Feature)
       continue;
 
     features.push_back(r.GetFeatureID());

--- a/map/discovery/discovery_search.cpp
+++ b/map/discovery/discovery_search.cpp
@@ -27,10 +27,11 @@ search::Result MakeResultFromFeatureType(FeatureType & ft)
   feature::TypesHolder holder(ft);
   holder.SortBySpec();
 
-  search::Result::Metadata metadata;
-  search::ProcessMetadata(ft, metadata);
+  search::Result::Details details;
+  search::FillDetails(ft, details);
 
-  return {ft.GetID(), feature::GetCenter(ft), name, "", holder.GetBestType(), metadata};
+  return {ft.GetID(),       feature::GetCenter(ft), name,
+          "" /* address */, holder.GetBestType(),   details};
 }
 
 class GreaterRating
@@ -38,7 +39,7 @@ class GreaterRating
 public:
   bool operator()(search::Result const & lhs, search::Result const & rhs) const
   {
-    return lhs.m_metadata.m_hotelRating > rhs.m_metadata.m_hotelRating;
+    return lhs.m_details.m_hotelRating > rhs.m_details.m_hotelRating;
   }
 };
 }  // namespace

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1778,11 +1778,11 @@ void Framework::FillSearchResultsMarks(search::Results::ConstIter begin,
 
     mark->SetMatchedName(r.GetString());
 
-    if (r.m_metadata.m_isSponsoredHotel)
+    if (r.m_details.m_isSponsoredHotel)
     {
       mark->SetBookingType(isFeature && m_localAdsManager.HasVisualization(r.GetFeatureID()) /* hasLocalAds */);
-      mark->SetRating(r.m_metadata.m_hotelRating);
-      mark->SetPricing(r.m_metadata.m_hotelPricing);
+      mark->SetRating(r.m_details.m_hotelRating);
+      mark->SetPricing(r.m_details.m_hotelPricing);
     }
     else if (isFeature)
     {
@@ -3172,9 +3172,9 @@ bool Framework::ParseEditorDebugCommand(search::SearchParams const & params)
       string name;
       ft->GetReadableName(name);
       feature::TypesHolder const types(*ft);
-      search::Result::Metadata smd;
+      search::Result::Details details;
       results.AddResultNoChecks(search::Result(fid, feature::GetCenter(*ft), name, edit.second,
-                                               types.GetBestType(), smd));
+                                               types.GetBestType(), details));
     }
     params.m_onResults(results);
 

--- a/map/map_tests/booking_filter_test.cpp
+++ b/map/map_tests/booking_filter_test.cpp
@@ -104,9 +104,9 @@ UNIT_CLASS_TEST(TestMwmEnvironment, BookingFilter_AvailabilitySmoke)
   search::Results expectedResults;
   m_dataSource.ForEachInRect(
       [&results, &expectedResults](FeatureType & ft) {
-        search::Result::Metadata metadata;
-        metadata.m_isSponsoredHotel = true;
-        search::Result result(ft.GetID(), ft.GetCenter(), "", "", 0, metadata);
+        search::Result::Details details;
+        details.m_isSponsoredHotel = true;
+        search::Result result(ft.GetID(), ft.GetCenter(), "", "", 0, details);
         auto copy = result;
         results.AddResult(std::move(result));
         expectedResults.AddResult(std::move(copy));
@@ -177,11 +177,11 @@ UNIT_CLASS_TEST(TestMwmEnvironment, BookingFilter_ProcessorSmoke)
   search::Results expectedAvailableWithDeals;
   m_dataSource.ForEachInRect(
     [&](FeatureType & ft) {
-      search::Result::Metadata metadata;
-      metadata.m_isSponsoredHotel = true;
+      search::Result::Details details;
+      details.m_isSponsoredHotel = true;
       std::string name;
       ft.GetName(StringUtf8Multilang::kDefaultCode, name);
-      search::Result result(ft.GetID(), ft.GetCenter(), name, "", 0, metadata);
+      search::Result result(ft.GetID(), ft.GetCenter(), name, "", 0, details);
       InsertResult(result, results);
 
       auto const sponsoredId = ft.GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
@@ -300,9 +300,9 @@ UNIT_CLASS_TEST(TestMwmEnvironment, BookingFilter_ApplyFilterOntoWithFeatureIds)
   std::vector<FeatureID> expectedFeatureIds;
   m_dataSource.ForEachInRect(
     [&results, &allFeatureIds, &expectedFeatureIds, &kHotelIds](FeatureType & ft) {
-      search::Result::Metadata metadata;
-      metadata.m_isSponsoredHotel = true;
-      search::Result result(ft.GetID(), ft.GetCenter(), "", "", 0, metadata);
+      search::Result::Details details;
+      details.m_isSponsoredHotel = true;
+      search::Result result(ft.GetID(), ft.GetCenter(), "", "", 0, details);
       auto copy = result;
       results.AddResult(std::move(result));
 

--- a/search/hotels_classifier.cpp
+++ b/search/hotels_classifier.cpp
@@ -16,8 +16,8 @@ bool HotelsClassifier::IsHotelResults(Results const & results)
 
 void HotelsClassifier::Add(Result const & result)
 {
-  if (result.m_metadata.m_isHotel)
-   ++m_numHotels;
+  if (result.m_details.m_isHotel)
+    ++m_numHotels;
 
   ++m_numResults;
 }

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -278,6 +278,9 @@ void FillDetails(FeatureType & ft, Result::Details & details)
     details.m_hotelApproximatePricing = pricingStr;
   }
 
+  auto const cuisines = feature::GetLocalizedCuisines(feature::TypesHolder(ft));
+  details.m_cuisine = strings::JoinStrings(cuisines, " • ");
+
   details.m_isInitialized = true;
 }
 

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -121,7 +121,7 @@ public:
   m2::PointD GetCenter() const { return m_region.m_point; }
   double GetDistance() const { return m_distance; }
   feature::GeomType GetGeomType() const { return m_geomType; }
-  Result::Metadata GetMetadata() const { return m_metadata; }
+  Result::Details GetDetails() const { return m_details; }
 
   double GetDistanceToPivot() const { return m_info.m_distanceToPivot; }
   double GetLinearModelRank() const { return m_info.GetLinearModelRank(); }
@@ -161,13 +161,13 @@ private:
   Type m_resultType;
   RankingInfo m_info;
   feature::GeomType m_geomType;
-  Result::Metadata m_metadata;
+  Result::Details m_details;
 
   // The call path in the Geocoder that leads to this result.
   std::vector<ResultTracer::Branch> m_provenance;
 };
 
-void ProcessMetadata(FeatureType & ft, Result::Metadata & meta);
+void FillDetails(FeatureType & ft, Result::Details & meta);
 
 std::string DebugPrint(RankerResult const & r);
 }  // namespace search

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -585,7 +585,7 @@ Result Ranker::MakeResult(RankerResult const & rankerResult, bool needAddress,
     case RankerResult::Type::Building:
     {
       auto const type = rankerResult.GetBestType(m_params.m_preferredTypes);
-      return Result(r.GetID(), r.GetCenter(), name, address, type, r.GetMetadata());
+      return Result(r.GetID(), r.GetCenter(), name, address, type, r.GetDetails());
     }
     case RankerResult::Type::LatLon: return Result(r.GetCenter(), name, address);
     case RankerResult::Type::Postcode: return Result(r.GetCenter(), name);

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -15,14 +15,14 @@ namespace search
 {
 // Result ------------------------------------------------------------------------------------------
 Result::Result(FeatureID const & id, m2::PointD const & pt, string const & str,
-               string const & address, uint32_t featureType, Metadata const & meta)
+               string const & address, uint32_t featureType, Details const & details)
   : m_resultType(Type::Feature)
   , m_id(id)
   , m_center(pt)
   , m_str(str)
   , m_address(address)
   , m_featureType(featureType)
-  , m_metadata(meta)
+  , m_details(details)
 {
 }
 

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -41,8 +41,8 @@ public:
     Postcode
   };
 
-  // Metadata for search results. Considered valid if GetResultType() == Type::Feature.
-  struct Metadata
+  // Search results details. Considered valid if GetResultType() == Type::Feature.
+  struct Details
   {
     // Valid only if not empty, used for restaurants.
     std::string m_cuisine;
@@ -72,7 +72,7 @@ public:
 
   // For Type::Feature.
   Result(FeatureID const & id, m2::PointD const & pt, std::string const & str,
-         std::string const & address, uint32_t featureType, Metadata const & meta);
+         std::string const & address, uint32_t featureType, Details const & meta);
 
   // For Type::LatLon.
   Result(m2::PointD const & pt, std::string const & latlon, std::string const & address);
@@ -90,18 +90,18 @@ public:
 
   std::string const & GetString() const { return m_str; }
   std::string const & GetAddress() const { return m_address; }
-  std::string const & GetCuisine() const { return m_metadata.m_cuisine; }
-  std::string const & GetAirportIata() const { return m_metadata.m_airportIata; }
-  std::string const & GetBrand() const { return m_metadata.m_brand; }
-  float GetHotelRating() const { return m_metadata.m_hotelRating; }
+  std::string const & GetCuisine() const { return m_details.m_cuisine; }
+  std::string const & GetAirportIata() const { return m_details.m_airportIata; }
+  std::string const & GetBrand() const { return m_details.m_brand; }
+  float GetHotelRating() const { return m_details.m_hotelRating; }
   std::string const & GetHotelApproximatePricing() const
   {
-    return m_metadata.m_hotelApproximatePricing;
+    return m_details.m_hotelApproximatePricing;
   }
-  bool IsHotel() const { return m_metadata.m_isHotel; }
+  bool IsHotel() const { return m_details.m_isHotel; }
 
-  osm::YesNoUnknown IsOpenNow() const { return m_metadata.m_isOpenNow; }
-  int GetStarsCount() const { return m_metadata.m_stars; }
+  osm::YesNoUnknown IsOpenNow() const { return m_details.m_isOpenNow; }
+  int GetStarsCount() const { return m_details.m_stars; }
 
   bool IsSuggest() const;
   bool HasPoint() const;
@@ -175,7 +175,7 @@ private:
 
 public:
   // Careful when moving: the order of destructors is important.
-  Metadata m_metadata;
+  Details m_details;
 };
 
 std::string DebugPrint(search::Result::Type type);

--- a/search/search_tests/results_tests.cpp
+++ b/search/search_tests/results_tests.cpp
@@ -38,11 +38,11 @@ UNIT_TEST(Results_Sorting)
 UNIT_TEST(Result_PrependCity)
 {
   FeatureID const fid;
-  Result::Metadata const meta;
+  Result::Details const details;
 
   {
     Result r(fid, m2::PointD::Zero(), "" /* str */, "Moscow, Russia" /* address */,
-             0 /* featureType */, meta);
+             0 /* featureType */, details);
 
     r.PrependCity("Moscow");
     TEST_EQUAL(r.GetAddress(), "Moscow, Russia", ());
@@ -50,7 +50,7 @@ UNIT_TEST(Result_PrependCity)
 
   {
     Result r(fid, m2::PointD::Zero(), "улица Михася Лынькова" /* str */,
-             "Минская область, Беларусь" /* address */, 0 /* featureType */, meta);
+             "Минская область, Беларусь" /* address */, 0 /* featureType */, details);
 
     r.PrependCity("Минск");
     TEST_EQUAL(r.GetAddress(), "Минск, Минская область, Беларусь", ());


### PR DESCRIPTION
При переводе отображения типа кухни  с метадаты на типы сломала отображение в subtitle в поисковом результате.
9.6:
![Screenshot_20200401_104825_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78125918-5f982680-741a-11ea-9cdb-f9f1e0cebfd2.jpg)

master:
![Screenshot_20200401_104841_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/78125949-6e7ed900-741a-11ea-9a7d-20b32b6acef1.jpg)

В этом реквесте чиню. С реквестом:
![Screenshot_20200401_123921_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/78126015-89514d80-741a-11ea-9e94-874e444bf695.jpg)

Также считаю нужно переименовать Result::Metadata, т.к. cuisine теперь не metadata и планирую туда положить road shields, которые тоже не metadata. Думаю что cuisine и road shields должны быть в этой структуре, а не отдельными полями и отдельными параметрами конструктора.