### PR TITLE
[generator] Fixed affiliations.

### DIFF
--- a/generator/affiliation.cpp
+++ b/generator/affiliation.cpp
@@ -28,7 +28,7 @@ std::vector<std::string> CountriesFilesAffiliation::GetAffiliations(FeatureBuild
 {
   std::vector<std::string> countries;
   std::vector<std::reference_wrapper<borders::CountryPolygons const>> countriesContainer;
-  m_countryPolygonsTree.ForEachPolygonInRect(fb.GetLimitRect(), [&](auto const & countryPolygons) {
+  m_countryPolygonsTree.ForEachCountryInRect(fb.GetLimitRect(), [&](auto const & countryPolygons) {
     countriesContainer.emplace_back(countryPolygons);
   });
 
@@ -59,7 +59,7 @@ CountriesFilesAffiliation::GetAffiliations(m2::PointD const & point) const
 {
   std::vector<std::string> countries;
   std::vector<std::reference_wrapper<borders::CountryPolygons const>> countriesContainer;
-  m_countryPolygonsTree.ForEachPolygonInRect(m2::RectD(point, point), [&](auto const & countryPolygons) {
+  m_countryPolygonsTree.ForEachCountryInRect(m2::RectD(point, point), [&](auto const & countryPolygons) {
     countriesContainer.emplace_back(countryPolygons);
   });
 
@@ -188,7 +188,7 @@ CountriesFilesIndexAffiliation::BuildIndex(const std::vector<m2::RectD> & net)
     {
       pool.SubmitWork([&, rect]() {
         std::vector<std::reference_wrapper<borders::CountryPolygons const>> countries;
-        m_countryPolygonsTree.ForEachPolygonInRect(rect, [&](auto const & country) {
+        m_countryPolygonsTree.ForEachCountryInRect(rect, [&](auto const & country) {
           countries.emplace_back(country);
         });
         if (m_haveBordersForWholeWorld && countries.size() == 1)

--- a/generator/borders.hpp
+++ b/generator/borders.hpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -107,9 +108,13 @@ public:
   size_t GetSize() const { return m_countryPolygonsMap.size(); }
 
   template <typename ToDo>
-  void ForEachPolygonInRect(m2::RectD const & rect, ToDo && toDo) const
+  void ForEachCountryInRect(m2::RectD const & rect, ToDo && toDo) const
   {
-    m_regionsTree.ForEachInRect(rect, std::forward<ToDo>(toDo));
+    std::unordered_set<CountryPolygons const *> uniq;
+    m_regionsTree.ForEachInRect(rect, [&](auto const & countryPolygons) {
+      if (uniq.emplace(&countryPolygons.get()).second)
+        toDo(countryPolygons);
+    });
   }
 
   bool HasRegionByName(std::string const & name) const


### PR DESCRIPTION
Пояснение фикса:
Баг был когда страна представлялась несколькими многоугольниками + когда точка попадала в пересечение их bbox' ов.
Т.е метод GetAffiliations мог возвращать страны, которые могли дублироваться. 
Это приводило к ряду неприятных последтсвий: от дублирования фичей в мвмке до неправильного подсчета кросс мвмных переходов.

https://github.com/mapsme/omim/pull/12389