### PR TITLE
[search][map][ios][android] Show road shields in place page and search results description.

### DIFF
--- a/android/jni/com/mapswithme/maps/SearchEngine.cpp
+++ b/android/jni/com/mapswithme/maps/SearchEngine.cpp
@@ -345,6 +345,7 @@ jobject ToJavaResult(Result & result, search::ProductInfo const & productInfo, b
   jni::TScopedLocalRef cuisine(env, jni::ToJavaString(env, result.GetCuisine()));
   jni::TScopedLocalRef brand(env, jni::ToJavaString(env, result.GetBrand()));
   jni::TScopedLocalRef airportIata(env, jni::ToJavaString(env, result.GetAirportIata()));
+  jni::TScopedLocalRef roadShields(env, jni::ToJavaString(env, result.GetRoadShields()));
   jni::TScopedLocalRef pricing(env, jni::ToJavaString(env, result.GetHotelApproximatePricing()));
 
 
@@ -356,7 +357,7 @@ jobject ToJavaResult(Result & result, search::ProductInfo const & productInfo, b
   jni::TScopedLocalRef desc(env, env->NewObject(g_descriptionClass, g_descriptionConstructor,
                                                 featureId.get(), featureType.get(), address.get(),
                                                 dist.get(), cuisine.get(), brand.get(), airportIata.get(),
-                                                pricing.get(), rating,
+                                                roadShields.get(), pricing.get(), rating,
                                                 result.GetStarsCount(),
                                                 static_cast<jint>(result.IsOpenNow()),
                                                 static_cast<jboolean>(popularityHasHigherPriority)));
@@ -655,7 +656,7 @@ extern "C"
                                                      "(Lcom/mapswithme/maps/bookmarks/data/FeatureId;"
                                                      "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
                                                      "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
-                                                     "Ljava/lang/String;FIIZ)V");
+                                                     "Ljava/lang/String;Ljava/lang/String;FIIZ)V");
 
     g_popularityClass = jni::GetGlobalClassRef(env, "com/mapswithme/maps/search/Popularity");
     g_popularityConstructor = jni::GetConstructorID(env, g_popularityClass, "(I)V");

--- a/android/src/com/mapswithme/maps/search/SearchAdapter.java
+++ b/android/src/com/mapswithme/maps/search/SearchAdapter.java
@@ -234,6 +234,10 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
       {
         tail.append(" • " + result.description.airportIata);
       }
+      else if (!TextUtils.isEmpty(result.description.roadShields))
+      {
+        tail.append(" • " + result.description.roadShields);
+      }
       else
       {
         if (!TextUtils.isEmpty(result.description.brand))

--- a/android/src/com/mapswithme/maps/search/SearchResult.java
+++ b/android/src/com/mapswithme/maps/search/SearchResult.java
@@ -31,6 +31,7 @@ public class SearchResult implements PopularityProvider
     public final String cuisine;
     public final String brand;
     public final String airportIata;
+    public final String roadShields;
     public final String pricing;
     public final float rating;
     public final int stars;
@@ -38,7 +39,7 @@ public class SearchResult implements PopularityProvider
     public final boolean hasPopularityHigherPriority;
 
     public Description(FeatureId featureId, String featureType, String region, String distance,
-                       String cuisine, String brand, String airportIata, String pricing,
+                       String cuisine, String brand, String airportIata, String roadShields, String pricing,
                        float rating, int stars, int openNow, boolean hasPopularityHigherPriority)
     {
       this.featureId = featureId;
@@ -48,6 +49,7 @@ public class SearchResult implements PopularityProvider
       this.cuisine = cuisine;
       this.brand = brand;
       this.airportIata = airportIata;
+      this.roadShields = roadShields;
       this.pricing = pricing;
       this.rating = rating;
       this.stars = stars;

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -18,7 +18,6 @@
 #include "indexer/features_vector.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/postcodes_matcher.hpp"
-#include "indexer/road_shields_parser.hpp"
 #include "indexer/search_delimiters.hpp"
 #include "indexer/search_string_utils.hpp"
 #include "indexer/trie_builder.hpp"
@@ -323,11 +322,10 @@ public:
       return;
 
     // Road number.
-    if (hasStreetType && !f.GetRoadNumber().empty())
+    if (hasStreetType)
     {
-      auto const shields = ftypes::GetRoadShields(f);
-      for (auto const & shield : shields)
-        inserter(StringUtf8Multilang::kDefaultCode, shield.m_name);
+      for (auto const & shield : feature::GetRoadShieldsNames(f.GetRoadNumber()))
+        inserter(StringUtf8Multilang::kDefaultCode, shield);
     }
 
     if (ftypes::IsAirportChecker::Instance()(types))

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -5,6 +5,7 @@
 #include "indexer/feature_data.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
+#include "indexer/road_shields_parser.hpp"
 #include "indexer/scales.hpp"
 
 #include "platform/localization.hpp"
@@ -401,5 +402,14 @@ vector<string> GetLocalizedCuisines(TypesHolder const & types)
     localized.push_back(platform::GetLocalizedTypeName(classif().GetReadableObjectName(t)));
   }
   return localized;
+}
+
+vector<string> GetRoadShieldsNames(string const & rawRoadNumber)
+{
+  vector<string> names;
+  for (auto const & shield : ftypes::GetRoadShields(rawRoadNumber))
+    names.push_back(shield.m_name);
+
+  return names;
 }
 } // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -83,4 +83,7 @@ namespace feature
 
   // Returns vector of cuisines names localized by platform.
   std::vector<std::string> GetLocalizedCuisines(TypesHolder const & types);
+
+  // Returns names of feature road shields. Applicable for road features.
+  std::vector<std::string> GetRoadShieldsNames(std::string const & rawRoadNumber);
 }  // namespace feature

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -75,6 +75,7 @@ void MapObject::SetFromFeatureType(FeatureType & ft)
   m_types = feature::TypesHolder(ft);
   m_metadata = ft.GetMetadata();
   m_houseNumber = ft.GetHouseNumber();
+  m_roadNumber = ft.GetRoadNumber();
   m_postcode = ft.GetPostcode();
   m_featureID = ft.GetID();
   m_geomType = ft.GetGeomType();
@@ -177,6 +178,16 @@ vector<string> MapObject::GetLocalizedCuisines() const
 }
 
 string MapObject::FormatCuisines() const { return strings::JoinStrings(GetLocalizedCuisines(), " • "); }
+
+vector<string> MapObject::GetRoadShields() const
+{
+  return feature::GetRoadShieldsNames(m_roadNumber);
+}
+
+string MapObject::FormatRoadShields() const
+{
+  return strings::JoinStrings(GetRoadShields(), " • ");
+}
 
 string MapObject::GetOpeningHours() const
 {

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -22,6 +22,7 @@ constexpr char const * kWlan = "wlan";
 constexpr char const * kWired = "wired";
 constexpr char const * kYes = "yes";
 constexpr char const * kNo = "no";
+constexpr char const * kFieldsSeparator = " • ";
 
 void SetInetIfNeeded(FeatureType & ft, feature::Metadata & metadata)
 {
@@ -177,7 +178,10 @@ vector<string> MapObject::GetLocalizedCuisines() const
   return feature::GetLocalizedCuisines(m_types);
 }
 
-string MapObject::FormatCuisines() const { return strings::JoinStrings(GetLocalizedCuisines(), " • "); }
+string MapObject::FormatCuisines() const
+{
+  return strings::JoinStrings(GetLocalizedCuisines(), kFieldsSeparator);
+}
 
 vector<string> MapObject::GetRoadShields() const
 {
@@ -186,7 +190,7 @@ vector<string> MapObject::GetRoadShields() const
 
 string MapObject::FormatRoadShields() const
 {
-  return strings::JoinStrings(GetRoadShields(), " • ");
+  return strings::JoinStrings(GetRoadShields(), kFieldsSeparator);
 }
 
 string MapObject::GetOpeningHours() const

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -85,6 +85,8 @@ public:
   std::vector<std::string> GetLocalizedCuisines() const;
   /// @returns translated and formatted cuisines.
   std::string FormatCuisines() const;
+  std::vector<std::string> GetRoadShields() const;
+  std::string FormatRoadShields() const;
   std::string GetOpeningHours() const;
   std::string GetOperator() const;
   int GetStars() const;
@@ -120,6 +122,7 @@ protected:
 
   StringUtf8Multilang m_name;
   std::string m_houseNumber;
+  std::string m_roadNumber;
   std::string m_postcode;
   feature::TypesHolder m_types;
   feature::Metadata m_metadata;

--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -538,12 +538,8 @@ std::set<RoadShield> GetRoadShields(FeatureType & f)
   // Find out country name.
   std::string mwmName = f.GetID().GetMwmName();
 
-  // |mwmName| may be empty when GetRoadShields is called from generator.
-  if (mwmName == FeatureID::kInvalidFileName)
-  {
-    return SimpleRoadShieldParser(roadNumber, SimpleRoadShieldParser::ShieldTypes())
-        .GetRoadShields();
-  }
+  ASSERT_NOT_EQUAL(mwmName, FeatureID::kInvalidFileName,
+                   ("Use GetRoadShields(rawRoadNumber) for unknown mwms."));
 
   auto const underlinePos = mwmName.find('_');
   if (underlinePos != std::string::npos)

--- a/indexer/road_shields_parser.cpp
+++ b/indexer/road_shields_parser.cpp
@@ -581,6 +581,15 @@ std::set<RoadShield> GetRoadShields(FeatureType & f)
   return SimpleRoadShieldParser(roadNumber, SimpleRoadShieldParser::ShieldTypes()).GetRoadShields();
 }
 
+std::set<RoadShield> GetRoadShields(std::string const & rawRoadNumber)
+{
+  if (rawRoadNumber.empty())
+    return {};
+
+  return SimpleRoadShieldParser(rawRoadNumber, SimpleRoadShieldParser::ShieldTypes())
+      .GetRoadShields();
+}
+
 std::string DebugPrint(RoadShieldType shieldType)
 {
   using ftypes::RoadShieldType;

--- a/indexer/road_shields_parser.hpp
+++ b/indexer/road_shields_parser.hpp
@@ -52,7 +52,12 @@ struct RoadShield
   }
 };
 
+// Use specific country road shield styles based on mwm feature belongs to.
 std::set<RoadShield> GetRoadShields(FeatureType & f);
+
+// Simple parsing without specific country styles.
+std::set<RoadShield> GetRoadShields(std::string const & rawRoadNumber);
+
 std::string DebugPrint(RoadShieldType shieldType);
 std::string DebugPrint(RoadShield const & shield);
 }  // namespace ftypes

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -74,6 +74,7 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
   NSUInteger const starsCount = result.GetStarsCount();
   NSString * cuisine = @(result.GetCuisine().c_str()).capitalizedString;
   NSString * airportIata = @(result.GetAirportIata().c_str());
+  NSString * roadShields = @(result.GetRoadShields().c_str());
   NSString * brand  = @"";
   if (!result.GetBrand().empty())
     brand = @(platform::GetLocalizedBrandName(result.GetBrand()).c_str());
@@ -82,6 +83,8 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
     [self setInfoRating:starsCount];
   else if (airportIata.length > 0)
     [self setInfoText:airportIata];
+  else if (roadShields.length > 0)
+    [self setInfoText:roadShields];
   else if (brand.length > 0 && cuisine.length > 0)
     [self setInfoText:[NSString stringWithFormat:@"%@ • %@", brand, cuisine]];
   else if (brand.length > 0)

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -118,6 +118,11 @@ std::string Info::FormatSubtitle(bool withType) const
   if (!iata.empty())
     subtitle.push_back(iata);
 
+  // Road numbers/ids.
+  std::string const roadShields = FormatRoadShields();
+  if (!roadShields.empty())
+    subtitle.push_back(roadShields);
+
   // Stars.
   std::string const stars = FormatStars();
   if (!stars.empty())

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -278,11 +278,12 @@ void FillDetails(FeatureType & ft, Result::Details & details)
     details.m_hotelApproximatePricing = pricingStr;
   }
 
+  string const kFieldsSeparator = " • ";
   auto const cuisines = feature::GetLocalizedCuisines(feature::TypesHolder(ft));
-  details.m_cuisine = strings::JoinStrings(cuisines, " • ");
+  details.m_cuisine = strings::JoinStrings(cuisines, kFieldsSeparator);
 
   auto const roadShields = feature::GetRoadShieldsNames(ft.GetRoadNumber());
-  details.m_roadShields = strings::JoinStrings(roadShields, " • ");
+  details.m_roadShields = strings::JoinStrings(roadShields, kFieldsSeparator);
 
   details.m_isInitialized = true;
 }

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -281,6 +281,9 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   auto const cuisines = feature::GetLocalizedCuisines(feature::TypesHolder(ft));
   details.m_cuisine = strings::JoinStrings(cuisines, " • ");
 
+  auto const roadShields = feature::GetRoadShieldsNames(ft.GetRoadNumber());
+  details.m_roadShields = strings::JoinStrings(roadShields, " • ");
+
   details.m_isInitialized = true;
 }
 

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -14,8 +14,8 @@
 #include "indexer/brands_holder.hpp"
 #include "indexer/data_source.hpp"
 #include "indexer/feature_algo.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/ftypes_matcher.hpp"
-#include "indexer/road_shields_parser.hpp"
 #include "indexer/search_string_utils.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
@@ -147,9 +147,8 @@ pair<NameScores, size_t> GetNameScores(FeatureType & ft, Geocoder::Params const 
 
   if (type == Model::TYPE_STREET)
   {
-    auto const shields = ftypes::GetRoadShields(ft);
-    for (auto const & shield : shields)
-      UpdateNameScores(shield.m_name, sliceNoCategories, bestScores);
+    for (auto const & shield : feature::GetRoadShieldsNames(ft.GetRoadNumber()))
+      UpdateNameScores(shield, sliceNoCategories, bestScores);
   }
 
   return make_pair(bestScores, matchedLength);

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -53,6 +53,9 @@ public:
     // Valid only if not empty, used for brand name.
     std::string m_brand;
 
+    // Valid only if not empty, used for roads.
+    std::string m_roadShields;
+
     // Following fields are used for hotels only.
     int m_hotelPricing = 0;
     std::string m_hotelApproximatePricing;
@@ -93,6 +96,7 @@ public:
   std::string const & GetCuisine() const { return m_details.m_cuisine; }
   std::string const & GetAirportIata() const { return m_details.m_airportIata; }
   std::string const & GetBrand() const { return m_details.m_brand; }
+  std::string const & GetRoadShields() const { return m_details.m_roadShields; }
   float GetHotelRating() const { return m_details.m_hotelRating; }
   std::string const & GetHotelApproximatePricing() const
   {


### PR DESCRIPTION
Добавляю отображение номера дороги в place page и в поисковые результаты.
Согласовано с @kgalushka .

Мы умеем искать по идентификаторам дорог, но при этом не подписываем их ни в выдаче ни в плейспейдже, выглядит странно:
![Screenshot_20200402_113425_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78234248-92f0b900-74df-11ea-9057-74284931c43b.jpg)
![Screenshot_20200402_113438_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78234270-9b48f400-74df-11ea-88b1-2f96cf538fc4.jpg)

не понятна связь между результатом "нева" и запросом "М-11"

В этом реквесте сделано так:
![Screenshot_20200402_113510_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/78234334-b1ef4b00-74df-11ea-92f9-081969af9502.jpg)
![Screenshot_20200402_113518_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/78234362-b9aeef80-74df-11ea-9450-12df1fc02e8a.jpg)

ios:
![image](https://user-images.githubusercontent.com/9213190/78234391-c4698480-74df-11ea-88ce-8cf7a436be42.png)
![image](https://user-images.githubusercontent.com/9213190/78234418-ca5f6580-74df-11ea-84dc-64a3d4c585e6.png)

