### PR TITLE
[search] Avoid double pois search for mwm with matched cities.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -585,7 +585,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
       auto const mwmType = m_context->GetType();
       CHECK(mwmType, ());
       if (mwmType->m_viewportIntersected || mwmType->m_containsUserPosition ||
-          m_preRanker.NumSentResults() == 0)
+          m_preRanker.Size() == 0)
       {
         MatchAroundPivot(ctx);
       }


### PR DESCRIPTION
Сейчас мы вызываем для mwm с MatchedCities MatchAroundPivot (т.к. они в первой порции выдачи, для них NumSentResults нулевой). Это приводит к тому что токен названия города, который должен был "израсходоваться" на название города используется для матчинга имён пои. Например при локейшене и вьюпорте в москве получаем такие результаты:

![Screenshot_20200402_142921_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78246006-1b2b8a00-74f1-11ea-8654-c33a642a3182.jpg)
![Screenshot_20200402_143455_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78245950-018a4280-74f1-11ea-802d-2a7337ac4067.jpg)
![Screenshot_20200402_143502_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78245957-03540600-74f1-11ea-9f94-7b15b60f7870.jpg)
![Screenshot_20200402_143514_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/78245960-051dc980-74f1-11ea-9d99-5821ad39c909.jpg)

Матчить токен "минск" на poi из mwm  с минском не надо.
На остальные случаи этот фикс не влияет, т.к. для mwm не из первой порции выдачи 
`m_preRanker.NumSentResults() ==0 ` и `m_preRanker().Size() == 0` эквивалентны, а остальные типы mwm из первой выдачи (вьюпорт и локация пользователя) перечислены явно.

На размеченной выборке кол-во витальных не уменьшилось, при этом стало меньше мусора.
После фикса поиск с тем же вьюпортом и gps в Москве:
![Screenshot_20200402_143428_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/78246282-94c37800-74f1-11ea-89ac-b2eaee503cca.jpg)

