### PR TITLE
Creating crossmwm section without asking current time.

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -16,6 +16,7 @@
 #include "routing/index_graph_serialization.hpp"
 #include "routing/index_graph_starter_joints.hpp"
 #include "routing/joint_segment.hpp"
+#include "routing/road_access.hpp"
 #include "routing/vehicle_mask.hpp"
 
 #include "routing_common/bicycle_model.hpp"
@@ -440,6 +441,13 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
     Segment const & enter = connector.GetEnter(i);
 
     using Algorithm = AStarAlgorithm<JointSegment, JointEdge, RouteWeight>;
+
+    graph.SetCurrentTimeGetter([]() {
+      CHECK(false, ("IndexGraph::m_currentTimeGetter() or RoadAccess::m_currentTimeGetter() is "
+                    "called but should not be called."));
+      return static_cast<time_t>(0);
+    });
+    graph.SetRoadAccess(RoadAccess());
 
     Algorithm astar;
     IndexGraphWrapper indexGraphWrapper(graph, enter);

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -505,8 +505,9 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
           uint32_t const lastPoint = exit.GetPointId(true /* front */);
 
           static map<JointSegment, JointSegment> kEmptyParents;
-          auto optionalEdge =  graph.GetJointEdgeByLastPoint(parentSegment, firstChild,
-                                                             true /* isOutgoing */, lastPoint);
+          auto optionalEdge =
+              graph.GetJointEdgeByLastPoint(parentSegment, firstChild, true /* isOutgoing */,
+                                            false /* useAccessConditional */, lastPoint);
 
           if (!optionalEdge)
             continue;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -65,6 +65,7 @@ public:
 
   std::optional<JointEdge> GetJointEdgeByLastPoint(Segment const & parent,
                                                    Segment const & firstChild, bool isOutgoing,
+                                                   bool useAccessConditional,
                                                    uint32_t lastPoint);
 
   Joint::Id GetJointId(RoadPoint const & rp) const { return m_roadIndex.GetJointId(rp); }
@@ -129,9 +130,10 @@ public:
 
   bool IsUTurnAndRestricted(Segment const & parent, Segment const & child, bool isOutgoing) const;
 
-  RouteWeight CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool isOutgoing,
-                                  Segment const & from, Segment const & to,
-                                  std::optional<RouteWeight const> const & prevWeight = std::nullopt);
+  RouteWeight CalculateEdgeWeight(
+      EdgeEstimator::Purpose purpose, bool isOutgoing, bool useAccessConditional,
+      Segment const & from, Segment const & to,
+      std::optional<RouteWeight const> const & prevWeight = std::nullopt);
 
   template <typename T>
   void SetCurrentTimeGetter(T && t) { m_currentTimeGetter = std::forward<T>(t); }
@@ -151,8 +153,8 @@ private:
                            std::vector<SegmentEdge> & edges, Parents<Segment> const & parents,
                            bool useAccessConditional);
   void GetNeighboringEdge(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
-                          Segment const & to, bool isOutgoing, std::vector<SegmentEdge> & edges,
-                          Parents<Segment> const & parents, bool useAccessConditional);
+                          Segment const & to, bool isOutgoing, bool useAccessConditional,
+                          std::vector<SegmentEdge> & edges, Parents<Segment> const & parents);
 
   struct PenaltyData
   {
@@ -171,7 +173,7 @@ private:
   /// will be at |u|. This time is based on start time of route building and weight of calculated
   /// path until |u|.
   RouteWeight GetPenalties(EdgeEstimator::Purpose purpose, Segment const & u, Segment const & v,
-                           std::optional<RouteWeight> const & prevWeight);
+                           std::optional<RouteWeight> const & prevWeight, bool useAccessConditional);
 
   void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
                                        bool isOutgoing, std::vector<Segment> & children);
@@ -181,6 +183,7 @@ private:
                                std::vector<Segment> const & firstChildren,
                                std::vector<uint32_t> const & lastPointIds,
                                bool isOutgoing,
+                               bool useAccessConditional,
                                std::vector<JointEdge> & jointEdges,
                                std::vector<RouteWeight> & parentWeights,
                                Parents<JointSegment> const & parents);

--- a/routing/road_access.cpp
+++ b/routing/road_access.cpp
@@ -33,10 +33,6 @@ void PrintKV(ostringstream & oss, KV const & kvs, size_t maxKVToShow)
 namespace routing
 {
 // RoadAccess --------------------------------------------------------------------------------------
-// @TODO(bykoinako) It's a fast fix for release. The idea behind it is to remember the time of
-// creation RoadAccess instance and return it instread of getting time when m_currentTimeGetter() is
-// called. But it's not understadbale now why m_currentTimeGetter() is called when
-// cross_mwm section is built.
 RoadAccess::RoadAccess() : m_currentTimeGetter([time = GetCurrentTimestamp()]() { return time; }) {}
 
 pair<RoadAccess::Type, RoadAccess::Confidence> RoadAccess::GetAccess(

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -118,7 +118,7 @@ private:
   void CheckAndProcessTransitFeatures(Segment const & parent,
                                       std::vector<JointEdge> & jointEdges,
                                       std::vector<RouteWeight> & parentWeights,
-                                      bool isOutgoing);
+                                      bool isOutgoing, bool useAccessConditional);
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
 

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -157,7 +157,8 @@ double TransitWorldGraph::CalculateETA(Segment const & from, Segment const & to)
 
   auto & indexGraph = m_indexLoader->GetIndexGraph(from.GetMwmId());
   return indexGraph
-      .CalculateEdgeWeight(EdgeEstimator::Purpose::ETA, true /* isOutgoing */, from, to)
+      .CalculateEdgeWeight(EdgeEstimator::Purpose::ETA, true /* isOutgoing */,
+                           false /* useAccessConditional */, from, to)
       .GetWeight();
 }
 


### PR DESCRIPTION
В методе IndexGraph::GetEdgeListImpl() есть параметр useAccessConditional. Ранее он был прокинут не везде, и часть фунциональности при вызове `IndexGraph::GetEdgeListImpl(..useAccessConditional = false..)` вызывалась с `useAccessConditional = true`. Это происходило при сборке cross_mwm секции. Например, при этом метод `ReconstructJointSegment()` всегда вызывался так, что access:conditional были учтитны.

Это приводило к тому, что во время сборки карты вызывалась ф-ция получения времени на каждой вершине.

Данный PR исправляет эту ошибку. Более того, он делает еще одну вещь. В случае если во время сборки секции cross_mwm будет вызвана ф-ция получения времени генератор упадет по чеку.

@mesozoic-drones @maksimandrianov @PTAL