### PR TITLE
[search] Continue MatchAroundPivot untill result with all tokens used found.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -585,7 +585,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
       auto const mwmType = m_context->GetType();
       CHECK(mwmType, ());
       if (mwmType->m_viewportIntersected || mwmType->m_containsUserPosition ||
-          !m_preRanker.HaveFullResult())
+          !m_preRanker.HaveFullyMatchedResult())
       {
         MatchAroundPivot(ctx);
       }

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -585,7 +585,7 @@ void Geocoder::GoImpl(vector<shared_ptr<MwmInfo>> const & infos, bool inViewport
       auto const mwmType = m_context->GetType();
       CHECK(mwmType, ());
       if (mwmType->m_viewportIntersected || mwmType->m_containsUserPosition ||
-          m_preRanker.Size() == 0)
+          !m_preRanker.HaveFullResult())
       {
         MatchAroundPivot(ctx);
       }

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -73,7 +73,7 @@ public:
 
     m_results.emplace_back(std::forward<Args>(args)...);
     if (m_results.back().GetInfo().m_allTokensUsed)
-      m_haveFullResult = true;
+      m_haveFullyMatchedResult = true;
   }
 
   // Computes missing fields for all pre-results.
@@ -88,7 +88,7 @@ public:
   size_t Size() const { return m_results.size(); }
   size_t BatchSize() const { return m_params.m_batchSize; }
   size_t NumSentResults() const { return m_numSentResults; }
-  bool HaveFullResult() const { return m_haveFullResult; }
+  bool HaveFullyMatchedResult() const { return m_haveFullyMatchedResult; }
   size_t Limit() const { return m_params.m_limit; }
 
   template <typename Fn>
@@ -113,7 +113,8 @@ private:
   // Amount of results sent up the pipeline.
   size_t m_numSentResults = 0;
 
-  bool m_haveFullResult = false;
+  // True iff there is at least one result with all tokens used (not relaxed).
+  bool m_haveFullyMatchedResult = false;
 
   // Cache of nested rects used to estimate distance from a feature to the pivot.
   NestedRectsCache m_pivotFeatures;

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -72,6 +72,8 @@ public:
       return;
 
     m_results.emplace_back(std::forward<Args>(args)...);
+    if (m_results.back().GetInfo().m_allTokensUsed)
+      m_haveFullResult = true;
   }
 
   // Computes missing fields for all pre-results.
@@ -86,6 +88,7 @@ public:
   size_t Size() const { return m_results.size(); }
   size_t BatchSize() const { return m_params.m_batchSize; }
   size_t NumSentResults() const { return m_numSentResults; }
+  bool HaveFullResult() const { return m_haveFullResult; }
   size_t Limit() const { return m_params.m_limit; }
 
   template <typename Fn>
@@ -109,6 +112,8 @@ private:
 
   // Amount of results sent up the pipeline.
   size_t m_numSentResults = 0;
+
+  bool m_haveFullResult = false;
 
   // Cache of nested rects used to estimate distance from a feature to the pivot.
   NestedRectsCache m_pivotFeatures;

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -2793,7 +2793,7 @@ UNIT_CLASS_TEST(ProcessorTest, MatchedFraction)
   }
 }
 
-UNIT_CLASS_TEST(ProcessorTest, AvoidMathcAroundPivotInMwmWithCity)
+UNIT_CLASS_TEST(ProcessorTest, AvoidMatchAroundPivotInMwmWithCity)
 {
   string const minskCountryName = "Minsk";
 


### PR DESCRIPTION
ошибалась вчера тут https://github.com/mapsme/omim/pull/12858

когда утверждала что 

> для mwm не из первой порции выдачи
`m_preRanker.NumSentResults() ==0` и `m_preRanker().Size() == 0` эквивалентны

если все результаты relaxed это неверно. Поправила + добавила тест.