### PR TITLE
[pygen] Fix pygen build under OS X.

### DIFF
--- a/generator/pygen/CMakeLists.txt
+++ b/generator/pygen/CMakeLists.txt
@@ -44,6 +44,7 @@ omim_link_libraries(
   sqlite3
   ${CMAKE_DL_LIBS}
   ${LIBZ}
+  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
 )
 


### PR DESCRIPTION
иначе на макоси вот так:

```
[100%] Linking CXX shared module ../../pygen.so
Undefined symbols for architecture x86_64:
  "_PyArg_ParseTupleAndKeywords", referenced from:
      boost::python::property_init(_object*, _object*, _object*) in libboost_python37.a(class.o)
  "_PyBaseObject_Type", referenced from:
      boost::python::objects::class_type() in libboost_python37.a(class.o)
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
  "_PyBool_FromLong", referenced from:
      boost::python::objects::class_base::enable_pickling_(bool) in libboost_python37.a(class.o)
  "_PyBool_Type", referenced from:
      boost::python::converter::(anonymous namespace)::bool_rvalue_from_python::get_pytype() in libboost_python37.a(builtin_converters.o)
  "_PyBytes_AsString", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::python::converter::(anonymous namespace)::string_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyBytes_Size", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::python::converter::(anonymous namespace)::string_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyCFunction_NewEx", referenced from:
      boost::python::objects::class_base::def_no_init() in libboost_python37.a(class.o)
  "_PyCFunction_Type", referenced from:
      boost::python::objects::function_get_class(_object*, void*) in libboost_python37.a(function.o)
  "_PyCallable_Check", referenced from:
      boost::python::objects::class_base::make_method_static(char const*) in libboost_python37.a(class.o)
  "_PyComplex_ImagAsDouble", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<long double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyComplex_RealAsDouble", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<long double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyComplex_Type", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::complex_rvalue_from_python::get_pytype() in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<long double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<long double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      ...
  "_PyDict_Clear", referenced from:
      boost::python::detail::dict_base::clear() in libboost_python37.a(dict.o)
  "_PyDict_Copy", referenced from:
      boost::python::detail::dict_base::copy() in libboost_python37.a(dict.o)
  "_PyDict_GetItem", referenced from:
      boost::python::detail::dict_base::get(boost::python::api::object const&) const in libboost_python37.a(dict.o)
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
  "_PyDict_Items", referenced from:
      boost::python::detail::dict_base::items() const in libboost_python37.a(dict.o)
  "_PyDict_Keys", referenced from:
      boost::python::detail::dict_base::keys() const in libboost_python37.a(dict.o)
  "_PyDict_New", referenced from:
      boost::python::objects::instance_get_dict(_object*, void*) in libboost_python37.a(class.o)
      boost::python::detail::dict_base::dict_base() in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::dict_base() in libboost_python37.a(dict.o)
  "_PyDict_Size", referenced from:
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
  "_PyDict_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<boost::python::dict const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::dict_base::call(boost::python::api::object const&) in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::dict_base(boost::python::api::object const&) in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::dict_base(boost::python::api::object const&) in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::clear() in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::copy() in libboost_python37.a(dict.o)
      boost::python::detail::dict_base::get(boost::python::api::object const&) const in libboost_python37.a(dict.o)
      ...
  "_PyDict_Update", referenced from:
      boost::python::detail::dict_base::update(boost::python::api::object const&) in libboost_python37.a(dict.o)
  "_PyDict_Values", referenced from:
      boost::python::detail::dict_base::values() const in libboost_python37.a(dict.o)
  "_PyErr_Clear", referenced from:
      boost::python::objects::instance_new(_typeobject*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::api::getattr(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::getattr(boost::python::api::object const&, char const*, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
  "_PyErr_ExceptionMatches", referenced from:
      boost::python::api::getattr(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::getattr(boost::python::api::object const&, char const*, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
  "_PyErr_Format", referenced from:
      boost::python::objects::class_base::make_method_static(char const*) in libboost_python37.a(class.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
      boost::python::pytype_check(_typeobject*, _object*) in libboost_python37.a(from_python.o)
      boost::python::converter::registration::get_class_object() const in libboost_python37.a(registry.o)
  "_PyErr_NewException", referenced from:
      boost::python::objects::function::argument_error(_object*, _object*) const in libboost_python37.a(function.o)
  "_PyErr_NoMemory", referenced from:
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
  "_PyErr_Occurred", referenced from:
      boost::python::detail::list_base::insert(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::objects::function::signature(bool) const in libboost_python37.a(function.o)
      boost::python::objects::enum_base::export_values() in libboost_python37.a(enum.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<signed char, boost::python::converter::(anonymous namespace)::signed_int_rvalue_from_python<signed char> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned char, boost::python::converter::(anonymous namespace)::unsigned_int_rvalue_from_python<unsigned char> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<short, boost::python::converter::(anonymous namespace)::signed_int_rvalue_from_python<short> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      ...
  "_PyErr_SetNone", referenced from:
      (anonymous namespace)::MwmIter::Next() in pygen.cpp.o
  "_PyErr_SetObject", referenced from:
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      boost::python::objects::function::argument_error(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::converter::rvalue_from_python_stage2(_object*, boost::python::converter::rvalue_from_python_stage1_data&, boost::python::converter::registration const&) in libboost_python37.a(from_python.o)
      boost::python::converter::(anonymous namespace)::throw_no_lvalue_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
      boost::python::converter::(anonymous namespace)::lvalue_result_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
      boost::python::converter::registration::to_python(void const volatile*) const in libboost_python37.a(registry.o)
      boost::python::(anonymous namespace)::instance_reduce(boost::python::api::object) in libboost_python37.a(pickle_support.o)
      ...
  "_PyErr_SetString", referenced from:
      _no_init in libboost_python37.a(class.o)
      boost::python::static_data_descr_set(_object*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
      boost::python::detail::pure_virtual_called() in libboost_python37.a(function.o)
      boost::python::objects::function_get_module(_object*, void*) in libboost_python37.a(function.o)
      boost::python::(anonymous namespace)::instance_reduce(boost::python::api::object) in libboost_python37.a(pickle_support.o)
  "_PyErr_WarnEx", referenced from:
      boost::python::converter::registry::insert(_object* (*)(void const*), boost::python::type_info, _typeobject const* (*)()) in libboost_python37.a(registry.o)
  "_PyEval_CallFunction", referenced from:
      boost::python::detail::returnable<boost::python::api::object>::type boost::python::call<boost::python::api::object, char const*, boost::python::handle<_object>, boost::python::dict>(_object*, char const* const&, boost::python::handle<_object> const&, boost::python::dict const&, boost::type<boost::python::api::object>*) in libboost_python37.a(class.o)
      boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::attribute_policies> >::operator()() const in libboost_python37.a(dict.o)
      boost::python::detail::dependent<boost::python::api::object, boost::python::api::object>::type boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::const_attribute_policies> >::operator()<boost::python::api::object>(boost::python::api::object const&) const in libboost_python37.a(dict.o)
      boost::python::detail::dependent<boost::python::api::object, boost::python::api::object>::type boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::const_attribute_policies> >::operator()<boost::python::api::object, boost::python::api::object>(boost::python::api::object const&, boost::python::api::object const&) const in libboost_python37.a(dict.o)
      boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::const_attribute_policies> >::operator()() const in libboost_python37.a(dict.o)
      boost::python::detail::dependent<boost::python::api::object, boost::python::api::object>::type boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::attribute_policies> >::operator()<boost::python::api::object>(boost::python::api::object const&) const in libboost_python37.a(dict.o)
      boost::python::detail::dependent<boost::python::api::object, boost::python::api::object>::type boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::attribute_policies> >::operator()<boost::python::api::object, boost::python::api::object>(boost::python::api::object const&, boost::python::api::object const&) const in libboost_python37.a(dict.o)
      ...
  "_PyExc_AttributeError", referenced from:
      boost::python::static_data_descr_set(_object*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::api::getattr(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::getattr(boost::python::api::object const&, char const*, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::objects::function_get_module(_object*, void*) in libboost_python37.a(function.o)
  "_PyExc_IndexError", referenced from:
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
  "_PyExc_OverflowError", referenced from:
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
  "_PyExc_ReferenceError", referenced from:
      boost::python::converter::(anonymous namespace)::lvalue_result_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
  "_PyExc_RuntimeError", referenced from:
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      _no_init in libboost_python37.a(class.o)
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
      boost::python::detail::pure_virtual_called() in libboost_python37.a(function.o)
      boost::python::(anonymous namespace)::instance_reduce(boost::python::api::object) in libboost_python37.a(pickle_support.o)
  "_PyExc_StopIteration", referenced from:
      (anonymous namespace)::MwmIter::Next() in pygen.cpp.o
  "_PyExc_TypeError", referenced from:
      boost::python::objects::class_base::make_method_static(char const*) in libboost_python37.a(class.o)
      boost::python::objects::function::argument_error(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::converter::rvalue_from_python_stage2(_object*, boost::python::converter::rvalue_from_python_stage1_data&, boost::python::converter::registration const&) in libboost_python37.a(from_python.o)
      boost::python::converter::(anonymous namespace)::throw_no_lvalue_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
      boost::python::pytype_check(_typeobject*, _object*) in libboost_python37.a(from_python.o)
      boost::python::converter::registration::get_class_object() const in libboost_python37.a(registry.o)
      boost::python::converter::registration::to_python(void const volatile*) const in libboost_python37.a(registry.o)
      ...
  "_PyExc_ValueError", referenced from:
      boost::python::handle_exception_impl(boost::function0<void>) in libboost_python37.a(errors.o)
  "_PyFloat_FromDouble", referenced from:
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::python::detail::member<double, m2::Point<double> >, boost::python::return_value_policy<boost::python::return_by_value, boost::python::default_call_policies>, boost::mpl::vector2<double&, m2::Point<double>&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<double (m2::Rect<double>::*)() const, boost::python::default_call_policies, boost::mpl::vector2<double, m2::Rect<double>&> > >::operator()(_object*, _object*) in pygen.cpp.o
  "_PyFloat_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<double&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<double const&> >::get_pytype() in pygen.cpp.o
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<float, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::float_rvalue_from_python::get_pytype() in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<double, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<long double, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      ...
  "_PyList_Append", referenced from:
      boost::python::detail::list_base::append(boost::python::api::object const&) in libboost_python37.a(list.o)
  "_PyList_Insert", referenced from:
      boost::python::detail::list_base::insert(long, boost::python::api::object const&) in libboost_python37.a(list.o)
  "_PyList_New", referenced from:
      boost::python::detail::list_base::list_base() in libboost_python37.a(list.o)
      boost::python::detail::list_base::list_base() in libboost_python37.a(list.o)
  "_PyList_Reverse", referenced from:
      boost::python::detail::list_base::reverse() in libboost_python37.a(list.o)
  "_PyList_Sort", referenced from:
      boost::python::detail::list_base::sort() in libboost_python37.a(list.o)
  "_PyList_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<boost::python::list const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::list_base::call(boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::list_base(boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::list_base(boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::append(boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::insert(long, boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::reverse() in libboost_python37.a(list.o)
      ...
  "_PyLong_AsLong", referenced from:
      boost::python::enum_<feature::Metadata::EType>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in pygen.cpp.o
      boost::python::enum_<feature::GeomType>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in pygen.cpp.o
      boost::python::enum_<feature::DataHeader::MapType>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in pygen.cpp.o
      boost::python::enum_<version::Format>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in pygen.cpp.o
      boost::python::objects::enum_repr(_object*) in libboost_python37.a(enum.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<signed char, boost::python::converter::(anonymous namespace)::signed_int_rvalue_from_python<signed char> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<short, boost::python::converter::(anonymous namespace)::signed_int_rvalue_from_python<short> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      ...
  "_PyLong_AsLongLong", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<long long, boost::python::converter::(anonymous namespace)::long_long_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyLong_AsSsize_t", referenced from:
      boost::python::objects::instance_new(_typeobject*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::detail::list_base::index(boost::python::api::object const&) const in libboost_python37.a(list.o)
      boost::python::detail::list_base::insert(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(list.o)
      boost::python::detail::list_base::count(boost::python::api::object const&) const in libboost_python37.a(list.o)
  "_PyLong_AsUnsignedLong", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned char, boost::python::converter::(anonymous namespace)::unsigned_int_rvalue_from_python<unsigned char> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned short, boost::python::converter::(anonymous namespace)::unsigned_int_rvalue_from_python<unsigned short> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned int, boost::python::converter::(anonymous namespace)::unsigned_int_rvalue_from_python<unsigned int> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned long, boost::python::converter::(anonymous namespace)::unsigned_int_rvalue_from_python<unsigned long> >::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyLong_AsUnsignedLongLong", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<unsigned long long, boost::python::converter::(anonymous namespace)::unsigned_long_long_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyLong_FromLong", referenced from:
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<signed char ((anonymous namespace)::FeatureTypeWrapper::*)(), boost::python::default_call_policies, boost::mpl::vector2<signed char, (anonymous namespace)::FeatureTypeWrapper&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::detail::list_base::pop(long) in libboost_python37.a(list.o)
      boost::python::detail::returnable<boost::python::api::object>::type boost::python::call<boost::python::api::object, long, boost::python::api::object>(_object*, long const&, boost::python::api::object const&, boost::type<boost::python::api::object>*) in libboost_python37.a(list.o)
      boost::python::objects::enum_base::add_value(char const*, long) in libboost_python37.a(enum.o)
      boost::python::api::proxy<boost::python::api::item_policies> boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::item_policies> >::operator[]<int>(int const&) in libboost_python37.a(enum.o)
      boost::python::api::object boost::python::dict::get<long, boost::python::api::object>(long const&, boost::python::api::object const&) const in libboost_python37.a(enum.o)
      boost::python::detail::returnable<boost::python::api::object>::type boost::python::call<boost::python::api::object, long>(_object*, long const&, boost::type<boost::python::api::object>*) in libboost_python37.a(enum.o)
      ...
  "_PyLong_FromUnsignedLong", referenced from:
      void boost::python::list::append<unsigned int>(unsigned int const&) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned int (version::MwmVersion::*)() const, boost::python::default_call_policies, boost::mpl::vector2<unsigned int, version::MwmVersion&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned int ((anonymous namespace)::FeatureTypeWrapper::*)() const, boost::python::default_call_policies, boost::mpl::vector2<unsigned int, (anonymous namespace)::FeatureTypeWrapper&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned char ((anonymous namespace)::FeatureTypeWrapper::*)(), boost::python::default_call_policies, boost::mpl::vector2<unsigned char, (anonymous namespace)::FeatureTypeWrapper&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned long ((anonymous namespace)::Mwm::*)() const, boost::python::default_call_policies, boost::mpl::vector2<unsigned long, (anonymous namespace)::Mwm&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::class_base::set_instance_size(unsigned long) in libboost_python37.a(class.o)
      boost::python::objects::function::signature(bool) const in libboost_python37.a(function.o)
      ...
  "_PyLong_FromUnsignedLongLong", referenced from:
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::python::detail::member<unsigned long long, FilesContainerBase::TagInfo>, boost::python::return_value_policy<boost::python::return_by_value, boost::python::default_call_policies>, boost::mpl::vector2<unsigned long long&, FilesContainerBase::TagInfo&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned long long (version::MwmVersion::*)() const, boost::python::default_call_policies, boost::mpl::vector2<unsigned long long, version::MwmVersion&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<unsigned long long ((anonymous namespace)::FeatureTypeWrapper::*)(), boost::python::default_call_policies, boost::mpl::vector2<unsigned long long, (anonymous namespace)::FeatureTypeWrapper&> > >::operator()(_object*, _object*) in pygen.cpp.o
  "_PyLong_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<unsigned long long&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<unsigned long long const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<unsigned int const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<unsigned char const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<signed char const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<unsigned long const&> >::get_pytype() in pygen.cpp.o
      boost::python::objects::enum_base::enum_base(char const*, _object* (*)(void const*), void* (*)(_object*), void (*)(_object*, boost::python::converter::rvalue_from_python_stage1_data*), boost::python::type_info, char const*) in libboost_python37.a(enum.o)
      ...
  "_PyMem_Free", referenced from:
      boost::python::instance_holder::deallocate(_object*, void*) in libboost_python37.a(class.o)
      boost::python::objects::instance_dealloc(_object*) in libboost_python37.a(class.o)
  "_PyMem_Malloc", referenced from:
      boost::python::instance_holder::allocate(_object*, unsigned long, unsigned long) in libboost_python37.a(class.o)
  "_PyMethod_New", referenced from:
      boost::python::objects::function_descr_get(_object*, _object*, _object*) in libboost_python37.a(function.o)
  "_PyModule_Create2", referenced from:
      boost::python::detail::init_module(PyModuleDef&, void (*)()) in libboost_python37.a(module.o)
  "_PyModule_Type", referenced from:
      boost::python::objects::module_prefix() in libboost_python37.a(class.o)
  "_PyNumber_Add", referenced from:
      boost::python::api::operator+(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_And", referenced from:
      boost::python::api::operator&(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_FloorDivide", referenced from:
      boost::python::api::operator/(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceAdd", referenced from:
      boost::python::api::operator+=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceAnd", referenced from:
      boost::python::api::operator&=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceFloorDivide", referenced from:
      boost::python::api::operator/=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceLshift", referenced from:
      boost::python::api::operator<<=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceMultiply", referenced from:
      boost::python::api::operator*=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceOr", referenced from:
      boost::python::api::operator|=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceRemainder", referenced from:
      boost::python::api::operator%=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceRshift", referenced from:
      boost::python::api::operator>>=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceSubtract", referenced from:
      boost::python::api::operator-=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_InPlaceXor", referenced from:
      boost::python::api::operator^=(boost::python::api::object&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Lshift", referenced from:
      boost::python::api::operator<<(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Multiply", referenced from:
      boost::python::api::operator*(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Or", referenced from:
      boost::python::api::operator|(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Remainder", referenced from:
      boost::python::api::operator%(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Rshift", referenced from:
      boost::python::api::operator>>(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Subtract", referenced from:
      boost::python::api::operator-(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyNumber_Xor", referenced from:
      boost::python::api::operator^(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyObject_Call", referenced from:
      boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::attribute_policies> >::operator()(boost::python::detail::args_proxy const&, boost::python::detail::kwds_proxy const&) const in libboost_python37.a(list.o)
  "_PyObject_CallFunction", referenced from:
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::static_data_descr_get(_object*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::static_data_descr_set(_object*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::detail::dict_base::call(boost::python::api::object const&) in libboost_python37.a(dict.o)
      ...
  "_PyObject_CallMethod", referenced from:
      boost::python::detail::str_base::capitalize() const in libboost_python37.a(str.o)
      boost::python::detail::str_base::center(boost::python::api::object const&) const in libboost_python37.a(str.o)
      boost::python::detail::str_base::expandtabs() const in libboost_python37.a(str.o)
      boost::python::detail::str_base::expandtabs(boost::python::api::object const&) const in libboost_python37.a(str.o)
      boost::python::detail::str_base::join(boost::python::api::object const&) const in libboost_python37.a(str.o)
      boost::python::detail::str_base::ljust(boost::python::api::object const&) const in libboost_python37.a(str.o)
      boost::python::detail::str_base::lower() const in libboost_python37.a(str.o)
      ...
  "_PyObject_ClearWeakRefs", referenced from:
      boost::python::objects::instance_dealloc(_object*) in libboost_python37.a(class.o)
  "_PyObject_DelItem", referenced from:
      boost::python::api::delitem(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::setslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::delslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&) in libboost_python37.a(object_protocol.o)
  "_PyObject_GetAttr", referenced from:
      boost::python::api::getattr(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::getattr(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
  "_PyObject_GetAttrString", referenced from:
      boost::python::objects::instance_new(_typeobject*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::api::getattr(boost::python::api::object const&, char const*) in libboost_python37.a(object_protocol.o)
      boost::python::api::getattr(boost::python::api::object const&, char const*, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
      boost::python::objects::enum_repr(_object*) in libboost_python37.a(enum.o)
  "_PyObject_GetItem", referenced from:
      boost::python::api::getitem(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::getslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&) in libboost_python37.a(object_protocol.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
  "_PyObject_IsInstance", referenced from:
      boost::python::enum_<feature::Metadata::EType>::convertible_from_python(_object*) in pygen.cpp.o
      boost::python::enum_<feature::GeomType>::convertible_from_python(_object*) in pygen.cpp.o
      boost::python::enum_<feature::DataHeader::MapType>::convertible_from_python(_object*) in pygen.cpp.o
      boost::python::enum_<version::Format>::convertible_from_python(_object*) in pygen.cpp.o
      boost::python::objects::module_prefix() in libboost_python37.a(class.o)
      boost::python::class_setattro(_object*, _object*, _object*) in libboost_python37.a(class.o)
      boost::python::pytype_check(_typeobject*, _object*) in libboost_python37.a(from_python.o)
      ...
  "_PyObject_IsTrue", referenced from:
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      boost::python::objects::function::signature(bool) const in libboost_python37.a(function.o)
      boost::python::objects::function::add_overload(boost::python::handle<boost::python::objects::function> const&) in libboost_python37.a(function.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
      boost::python::objects::function_get_doc(_object*, void*) in libboost_python37.a(function.o)
      boost::python::objects::enum_base::enum_base(char const*, _object* (*)(void const*), void* (*)(_object*), void (*)(_object*, boost::python::converter::rvalue_from_python_stage1_data*), boost::python::type_info, char const*) in libboost_python37.a(enum.o)
      boost::python::objects::enum_base::to_python(_typeobject*, long) in libboost_python37.a(enum.o)
      ...
  "_PyObject_RichCompare", referenced from:
      boost::python::api::operator>(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
      boost::python::api::operator>=(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
      boost::python::api::operator<(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
      boost::python::api::operator<=(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
      boost::python::api::operator==(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
      boost::python::api::operator!=(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_operators.o)
  "_PyObject_SetAttr", referenced from:
      boost::python::api::setattr(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::delattr(boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
  "_PyObject_SetAttrString", referenced from:
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::setattr(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::def_no_init() in libboost_python37.a(class.o)
      boost::python::objects::class_base::enable_pickling_(bool) in libboost_python37.a(class.o)
      ...
  "_PyObject_SetItem", referenced from:
      boost::python::api::setitem(boost::python::api::object const&, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::setslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
  "_PyObject_Size", referenced from:
      boost::python::objects::function::signature(bool) const in libboost_python37.a(function.o)
      boost::python::objects::enum_base::export_values() in libboost_python37.a(enum.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::basic_string<wchar_t, std::__1::char_traits<wchar_t>, std::__1::allocator<wchar_t> >, boost::python::converter::(anonymous namespace)::wstring_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::(anonymous namespace)::instance_reduce(boost::python::api::object) in libboost_python37.a(pickle_support.o)
      boost::python::objects::function_doc_signature_generator::parameter_string(boost::python::objects::py_function const&, unsigned long, boost::python::api::object, bool) in libboost_python37.a(function_doc_signature.o)
      boost::python::objects::function_doc_signature_generator::pretty_signature(boost::python::objects::function const*, unsigned long, bool) in libboost_python37.a(function_doc_signature.o)
      boost::python::objects::function_doc_signature_generator::function_doc_signatures(boost::python::objects::function const*) in libboost_python37.a(function_doc_signature.o)
      ...
  "_PyProperty_Type", referenced from:
      boost::python::objects::static_data() in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_property(char const*, boost::python::api::object const&, boost::python::api::object const&, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::class_setattro(_object*, _object*, _object*) in libboost_python37.a(class.o)
  "_PySlice_New", referenced from:
      boost::python::api::getslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::setslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&, boost::python::api::object const&) in libboost_python37.a(object_protocol.o)
      boost::python::api::delslice(boost::python::api::object const&, boost::python::handle<_object> const&, boost::python::handle<_object> const&) in libboost_python37.a(object_protocol.o)
  "_PyStaticMethod_New", referenced from:
      boost::python::objects::class_base::make_method_static(char const*) in libboost_python37.a(class.o)
  "_PyStaticMethod_Type", referenced from:
      boost::python::objects::function::add_to_namespace(boost::python::api::object const&, char const*, boost::python::api::object const&, char const*) in libboost_python37.a(function.o)
  "_PyTuple_GetItem", referenced from:
      boost::python::objects::function::argument_error(_object*, _object*) const in libboost_python37.a(function.o)
  "_PyTuple_New", referenced from:
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      boost::python::objects::function::function(boost::python::objects::py_function const&, boost::python::detail::keyword const*, unsigned int) in libboost_python37.a(function.o)
      boost::python::tuple boost::python::make_tuple<char const*, boost::python::handle<_object> >(char const* const&, boost::python::handle<_object> const&) in libboost_python37.a(function.o)
      boost::python::tuple boost::python::make_tuple<char const*>(char const* const&) in libboost_python37.a(function.o)
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::tuple boost::python::make_tuple<boost::python::api::object, boost::python::str, char const*>(boost::python::api::object const&, boost::python::str const&, char const* const&) in libboost_python37.a(function.o)
      boost::python::tuple boost::python::make_tuple<boost::python::api::object, boost::python::str>(boost::python::api::object const&, boost::python::str const&) in libboost_python37.a(function.o)
      ...
  "_PyTuple_Size", referenced from:
      boost::python::objects::function::call(_object*, _object*) const in libboost_python37.a(function.o)
      boost::python::objects::function::argument_error(_object*, _object*) const in libboost_python37.a(function.o)
  "_PyTuple_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<boost::python::tuple const&> >::get_pytype() in libboost_python37.a(pickle_support.o)
      boost::python::detail::tuple_base::call(boost::python::api::object const&) in libboost_python37.a(tuple.o)
      boost::python::detail::tuple_base::tuple_base(boost::python::api::object const&) in libboost_python37.a(tuple.o)
      boost::python::detail::tuple_base::tuple_base(boost::python::api::object const&) in libboost_python37.a(tuple.o)
      __GLOBAL__sub_I_tuple.cpp in libboost_python37.a(tuple.o)
  "_PyType_GenericAlloc", referenced from:
      boost::python::objects::class_type_object in libboost_python37.a(class.o)
  "_PyType_IsSubtype", referenced from:
      boost::python::objects::find_instance_impl(_object*, boost::python::type_info, bool) in libboost_python37.a(class.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<float, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<double, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<long double, boost::python::converter::(anonymous namespace)::float_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<float>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::complex<double>, boost::python::converter::(anonymous namespace)::complex_rvalue_from_python>::convertible(_object*) in libboost_python37.a(builtin_converters.o)
      ...
  "_PyType_Ready", referenced from:
      boost::python::objects::static_data() in libboost_python37.a(class.o)
      boost::python::objects::class_metatype() in libboost_python37.a(class.o)
      boost::python::objects::class_type() in libboost_python37.a(class.o)
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::class_setattro(_object*, _object*, _object*) in libboost_python37.a(class.o)
      ...
  "_PyType_Type", referenced from:
      boost::python::objects::static_data() in libboost_python37.a(class.o)
      boost::python::objects::class_metatype() in libboost_python37.a(class.o)
      boost::python::objects::class_type() in libboost_python37.a(class.o)
      boost::python::objects::class_base::class_base(char const*, unsigned long, boost::python::type_info const*, char const*) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::objects::class_base::add_static_property(char const*, boost::python::api::object const&, boost::python::api::object const&) in libboost_python37.a(class.o)
      boost::python::class_setattro(_object*, _object*, _object*) in libboost_python37.a(class.o)
      ...
  "_PyUnicode_AsUTF8", referenced from:
      boost::python::converter::(anonymous namespace)::convert_to_cstring(_object*) in libboost_python37.a(builtin_converters.o)
  "_PyUnicode_AsUTF8String", referenced from:
      boost::python::converter::(anonymous namespace)::py_unicode_as_string_unaryfunc in libboost_python37.a(builtin_converters.o)
  "_PyUnicode_AsWideChar", referenced from:
      boost::python::converter::(anonymous namespace)::slot_rvalue_from_python<std::__1::basic_string<wchar_t, std::__1::char_traits<wchar_t>, std::__1::allocator<wchar_t> >, boost::python::converter::(anonymous namespace)::wstring_rvalue_from_python>::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) in libboost_python37.a(builtin_converters.o)
  "_PyUnicode_FromEncodedObject", referenced from:
      _encode_string_unaryfunc in libboost_python37.a(builtin_converters.o)
  "_PyUnicode_FromFormat", referenced from:
      boost::python::objects::enum_repr(_object*) in libboost_python37.a(enum.o)
      boost::python::converter::rvalue_from_python_stage2(_object*, boost::python::converter::rvalue_from_python_stage1_data&, boost::python::converter::registration const&) in libboost_python37.a(from_python.o)
      boost::python::converter::(anonymous namespace)::throw_no_lvalue_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
      boost::python::converter::(anonymous namespace)::lvalue_result_from_python(_object*, boost::python::converter::registration const&, char const*) in libboost_python37.a(from_python.o)
      boost::python::converter::registration::to_python(void const volatile*) const in libboost_python37.a(registry.o)
  "_PyUnicode_FromString", referenced from:
      boost::python::converter::do_return_to_python(char const*) in libboost_python37.a(builtin_converters.o)
      boost::python::detail::str_base::str_base() in libboost_python37.a(str.o)
      boost::python::detail::str_base::str_base() in libboost_python37.a(str.o)
      boost::python::detail::str_base::str_base(char const*) in libboost_python37.a(str.o)
      boost::python::detail::str_base::str_base(char const*) in libboost_python37.a(str.o)
  "_PyUnicode_FromStringAndSize", referenced from:
      (anonymous namespace)::Mwm::GetSectionsInfo() const in pygen.cpp.o
      boost::python::api::proxy<boost::python::api::item_policies> const& boost::python::api::proxy<boost::python::api::item_policies>::operator=<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const in pygen.cpp.o
      boost::python::detail::caller_arity<1u>::impl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (*)(m2::Point<double> const&), boost::python::default_call_policies, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, m2::Point<double> const&> >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::detail::caller_arity<1u>::impl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (*)(m2::Triangle<double> const&), boost::python::default_call_policies, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, m2::Triangle<double> const&> >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::detail::caller_arity<1u>::impl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (*)(m2::Rect<double> const&), boost::python::default_call_policies, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, m2::Rect<double> const&> >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::python::detail::member<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, FilesContainerBase::TagInfo>, boost::python::return_value_policy<boost::python::return_by_value, boost::python::default_call_policies>, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, FilesContainerBase::TagInfo&> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::detail::caller_arity<1u>::impl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (*)(FilesContainerBase::TagInfo const&), boost::python::default_call_policies, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, FilesContainerBase::TagInfo const&> >::operator()(_object*, _object*) in pygen.cpp.o
      ...
  "_PyUnicode_InternFromString", referenced from:
      boost::python::objects::function_get_name(_object*, void*) in libboost_python37.a(function.o)
  "_PyUnicode_Type", referenced from:
      boost::python::detail::converter_target_type<boost::python::to_python_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> >::get_pytype() in pygen.cpp.o
      boost::python::detail::converter_target_type<boost::python::to_python_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&> >::get_pytype() in pygen.cpp.o
      boost::python::converter::wrap_pytype<&(PyUnicode_Type)>::get_pytype() in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::wstring_rvalue_from_python::get_pytype() in libboost_python37.a(builtin_converters.o)
      boost::python::converter::(anonymous namespace)::string_rvalue_from_python::get_pytype() in libboost_python37.a(builtin_converters.o)
      boost::python::detail::str_base::call(boost::python::api::object const&) in libboost_python37.a(str.o)
      boost::python::detail::str_base::str_base(boost::python::api::object const&) in libboost_python37.a(str.o)
      ...
  "__PyType_Lookup", referenced from:
      boost::python::class_setattro(_object*, _object*, _object*) in libboost_python37.a(class.o)
  "__Py_NoneStruct", referenced from:
      init_module_pygen() in pygen.cpp.o
      boost::python::converter::shared_ptr_from_python<(anonymous namespace)::GeometryNamespace, boost::shared_ptr>::convertible(_object*) in pygen.cpp.o
      boost::python::converter::shared_ptr_from_python<(anonymous namespace)::GeometryNamespace, std::__1::shared_ptr>::convertible(_object*) in pygen.cpp.o
      boost::python::converter::as_to_python_function<(anonymous namespace)::GeometryNamespace, boost::python::objects::class_cref_wrapper<(anonymous namespace)::GeometryNamespace, boost::python::objects::make_instance<(anonymous namespace)::GeometryNamespace, boost::python::objects::value_holder<(anonymous namespace)::GeometryNamespace> > > >::convert(void const*) in pygen.cpp.o
      boost::python::objects::caller_py_function_impl<boost::python::detail::caller<void (*)(_object*), boost::python::default_call_policies, boost::mpl::vector2<void, _object*> > >::operator()(_object*, _object*) in pygen.cpp.o
      boost::python::converter::shared_ptr_from_python<m2::Point<double>, boost::shared_ptr>::convertible(_object*) in pygen.cpp.o
      boost::python::converter::shared_ptr_from_python<m2::Point<double>, std::__1::shared_ptr>::convertible(_object*) in pygen.cpp.o
      ...
  "__Py_NotImplementedStruct", referenced from:
      boost::python::objects::(anonymous namespace)::not_implemented(_object*, _object*) in libboost_python37.a(function.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [pygen.so] Error 1
make[2]: *** [generator/pygen/CMakeFiles/pygen.dir/all] Error 2
make[1]: *** [generator/pygen/CMakeFiles/pygen.dir/rule] Error 2
make: *** [pygen] Error 2
error: command 'make' failed with exit status 2
```