### PR TITLE
[generator] Parse multiple aerodrome types. 

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -1007,7 +1007,7 @@ place|city|capital|11;[place=city][capital=11],[place=city][capital?][admin_leve
 hwtag|yesfoot;1007;
 public_transport|platform;1008;
 deprecated|deprecated;1009;x
-aeroway|aerodrome|international;[aeroway=aerodrome][aerodrome=international];;name;int_name;1010;
+aeroway|aerodrome|international;[aeroway=aerodrome][aerodrome=international],[aeroway=aerodrome][aerodrome:type=international];;name;int_name;1010;
 railway|station|light_rail;[railway=station][station=light_rail],[railway=station][transport=light_rail];;name;int_name;1011;
 railway|station|monorail;[railway=station][station=monorail],[railway=station][transport=monorail];;name;int_name;1012;
 railway|station|subway|london;[railway=station][transport=subway][city=london],[railway=station][station=subway][city=london];;name;int_name;1013;

--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -50,8 +50,6 @@ diet:vegan=yes : cuisine=vegan
 diet:vegan=only : cuisine=vegan
 diet=vegan : cuisine=vegan
 
-aerodrome:type=international : aerodrome=international
-
 amenity=parking_entrance : amenity=parking
 
 historic=cannon : historic=memorial

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -937,6 +937,19 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_DoNotMergeTags)
   }
 }
 
+UNIT_CLASS_TEST(TestWithClassificator, OsmType_AerodromeType)
+{
+  Tags const tags = {
+      {"aeroway", "aerodrome"},
+      {"aerodrome:type", "international ; public"},
+  };
+
+  auto const params = GetFeatureBuilderParams(tags);
+
+  TEST_EQUAL(params.m_types.size(), 1, (params));
+  TEST(params.IsTypeExist(GetType({"aeroway", "aerodrome", "international"})), (params));
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, OsmType_SimpleTypesSmoke)
 {
   Tags const simpleTypes = {

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -580,6 +580,25 @@ void PreprocessElement(OsmElement * p)
     }
   }
 
+  string const kAerodromeTypeKey = "aerodrome:type";
+  auto aerodromeTypes = p->GetTag(kAerodromeTypeKey);
+  if (!aerodromeTypes.empty())
+  {
+    strings::MakeLowerCaseInplace(aerodromeTypes);
+    bool first = true;
+    for (auto type : strings::Tokenize(aerodromeTypes, ",;"))
+    {
+      strings::Trim(type, " ");
+
+      if (first)
+        p->UpdateTag(kAerodromeTypeKey, [&type](auto & value) { value = type; });
+      else
+        p->AddTag(kAerodromeTypeKey, type);
+
+      first = false;
+    }
+  }
+
   // We replace a value of 'place' with a value of 'de: place' because most people regard
   // places names as 'de: place' defines it.
   // TODO(@m.andrianov): A better solution for the future is writing this rule in replaced_tags.txt


### PR DESCRIPTION
В osm начали мапить несколько типов одновременно в ключе `aerodrome:type`
https://taginfo.openstreetmap.org/keys/aerodrome:type#values

`international;public` 56 штук

в статье не написано что так можно https://wiki.openstreetmap.org/wiki/Key:aerodrome:type?uselang=en-GB
но думаю надо это поддерживать.