### PR TITLE
[search][tests] Fix unstable test: mwm should intersect viewport for MatchAroundPivot.

### DIFF
--- a/search/search_integration_tests/ranker_test.cpp
+++ b/search/search_integration_tests/ranker_test.cpp
@@ -114,7 +114,7 @@ UNIT_CLASS_TEST(RankerTest, PreferCountry)
     builder.Add(cafe);
   });
 
-  SetViewport(m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(0.0, 0.0)));
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 1.0)));
   {
     // Country which exactly matches the query should be preferred even if cafe is much closer to
     // viewport center.


### PR DESCRIPTION
Тест был не стабильным: граница mwm совпадала с границей вьюпорта и пересекает ли mwm вьюпорт зависело от погрешностей.
Чтобы MatchAroundPivot запускался и находил POI (при условии что уже есть найденный результат) нужно чтобы mwm пересекала вьюпорт