### PR TITLE
[routing] Fixing routing integration tests for 200402.

### DIFF
--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -285,7 +285,7 @@ UNIT_TEST(CzechPragueHiltonToKvetniceViewpoint)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(50.0933, 14.4397), {0., 0.},
-      mercator::FromLatLon(50.0806, 14.3973), 4805.1);
+      mercator::FromLatLon(50.0806, 14.3973), 4448.6);
 }
 
 UNIT_TEST(RussiaSaintPetersburgMoyka93ToAlexanderColumn)

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -407,7 +407,7 @@ namespace
 
     CHECK(routeResult.first, ());
     Route const & route = *routeResult.first;
-    integration::TestRouteTime(route, 6529.2);
+    integration::TestRouteTime(route, 6349.9);
   }
 
   UNIT_TEST(TolyattiFeatureThatCrossSeveralMwmsTest)


### PR DESCRIPTION
Поправил 2 из 3 routing integration tests. Отавшийся тест - отдельная тема. Похоже мы не прокладывали и не прокладываем маршруты через bicycle=designated, но должны. Буду разбираться отдельно. Это не кажется новой проблемой поскольку дорогу, на которой воспроизводится ошибка, отредактировали месяц назад.

Остальные два - просто изменения в картах. 

CzechPragueHiltonToKvetniceViewpoint
![image](https://user-images.githubusercontent.com/1768114/78781272-9afd9c80-79a8-11ea-8117-54d39b6a4dee.png)

GermanyShuttleTrainTest
![image](https://user-images.githubusercontent.com/1768114/78781292-a4870480-79a8-11ea-846c-4482363066e4.png)

@mesozoic-drones PTAL
