### PR TITLE
[routing] Fixing the last routing integration test for maps 200402.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -134,12 +134,13 @@ UNIT_TEST(SwedenStockholmBicyclePastFerry)
       mercator::FromLatLon(59.32967, 18.075), 46163.7);
 }
 
+// Test on cross mwm bicycle routing.
 UNIT_TEST(CrossMwmKaliningradRegionToLiepaja)
 {
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Bicycle),
-      mercator::FromLatLon(55.15414, 20.85378), {0., 0.},
-      mercator::FromLatLon(56.51119, 21.01847), 192000);
+      mercator::FromLatLon(54.63519, 21.80749), {0., 0.},
+      mercator::FromLatLon(56.51119, 21.01847), 295241);
 }
 
 // Test on riding up from Adeje (sea level) to Vilaflor (altitude 1400 meters).


### PR DESCRIPTION
Тест CrossMwmKaliningradRegionToLiepaja на меж mwm-й велосипедный routing. Однако карта была отредактирована месяц назад и на велосипедном пути (https://www.openstreetmap.org/way/615386881) был поставлен barrier=gate (https://www.openstreetmap.org/node/7257314716). Это привело к тому, что маршрут стал строиться в объезд, через Калининград. Я перенес старт, чтоб попрежнему тестировался меж mwm-й велосипедный роутинг.

![image](https://user-images.githubusercontent.com/1768114/78793482-25e79280-79bb-11ea-9ecb-6f8e1fe28c1f.png)

@mesozoic-drones PTAL