### PR TITLE
[search] Forbid poi-building parse.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1427,6 +1427,7 @@ bool Geocoder::IsLayerSequenceSane(vector<FeaturesLayer> const & layers) const
   uint32_t mask = 0;
   size_t buildingIndex = layers.size();
   size_t streetIndex = layers.size();
+  size_t poiIndex = layers.size();
 
   // Following loop returns false iff there are two different layers
   // of the same search type.
@@ -1445,10 +1446,13 @@ bool Geocoder::IsLayerSequenceSane(vector<FeaturesLayer> const & layers) const
       buildingIndex = i;
     else if (layer.m_type == Model::TYPE_STREET)
       streetIndex = i;
+    else if (layer.m_type == Model::TYPE_POI)
+      poiIndex = i;
   }
 
   bool const hasBuildings = buildingIndex != layers.size();
   bool const hasStreets = streetIndex != layers.size();
+  bool const hasPois = poiIndex != layers.size();
 
   // Checks that building and street layers are neighbours.
   if (hasBuildings && hasStreets)
@@ -1457,6 +1461,10 @@ bool Geocoder::IsLayerSequenceSane(vector<FeaturesLayer> const & layers) const
     auto const & streets = layers[streetIndex];
     if (!buildings.m_tokenRange.AdjacentTo(streets.m_tokenRange))
       return false;
+  }
+  if (hasBuildings && hasPois && !hasStreets)
+  {
+    return false;
   }
 
   return true;

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -1511,9 +1511,9 @@ UNIT_CLASS_TEST(ProcessorTest, PathsThroughLayers)
     TEST(ResultsMatch("computing street statistical learning cafe ", {rulePoi}), ());
     TEST(ResultsMatch("computing street 0 cafe ", {rulePoi}), ());
 
-    // POI-BUILDING
-    TEST(ResultsMatch("statistical learning cafe ", {rulePoi}), ());
-    TEST(ResultsMatch("0 cafe ", {rulePoi}), ());
+    // POI-BUILDING is not supported
+    TEST(ResultsMatch("statistical learning cafe ", {}), ());
+    TEST(ResultsMatch("0 cafe ", {}), ());
 
     // POI-STREET
     TEST(ResultsMatch("computing street cafe ", {rulePoi}), ());


### PR DESCRIPTION
Предлагаю не поддерживать разбор `poi - building` без улицы.

Есть два вариант такого разбора: `poi - номер дома` и `poi - название дома`.

Про `poi - номер дома` вроде понятно что разбор странный и сложно придумать сценарий в котором это нужно.

Про `poi - название дома`  менее однозначно.
Например можно искать "МГУ столовая", "Пушкинский музей сувениры", "мэйл ру старбакс" и т.п. Но в данном случае разбор `poi - название дома` всё равно не будет применён, т.к. если у фичи кроме типа building есть ещё значимые типы (`amenity-*`, `tourism-*`, `office-*` и т.п.), то фича не будет считаться домом, а будет считаться poi (разбора `poi - poi` у нас сейчас нет, можно о нём подумать).
Я посмотрела в данных на фичи, которые будут считаться домом с именем (для этого нужно чтобы у них 1) был тип дома, 2) не было типа poi, 3) был housenumber, 4) было имя). Такие фичи есть (в Москве около 4 тысяч штук), но всё что я отсмотрела -- примеры плохого мапинга. Например вписывают "автомойка" или "кафе" в название и не добавляют тип, вписывают название больницы в имя и не добавляют тип и т.п. Не похоже что есть необходимость поддерживать poi внутри таких фичей.

Поэтому предлагаю от такого разбора отказаться.

По тестам -- нашлось на 1 витальный результат больше, в семпле 141 "19 школ" успели найти 19-ю школу. Без фикса видимо много времени тратилось на то чтобы во всех 19-х домах из мвм поискать poi с именем "школ" или типом школа.