### PR TITLE
[routing] Fix for speed camera crash.

### DIFF
--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -262,6 +262,9 @@ bool SpeedCameraManager::SetNotificationFlags(double passedDistanceMeters, doubl
     return false;
 
   auto const distToCameraMeters = camera.m_distFromBeginMeters - passedDistanceMeters;
+  // We should reset signal type flags before setting one of them.
+  m_makeBeepSignal = false;
+  m_makeVoiceSignal = false;
 
   Interval interval = SpeedCameraManager::GetIntervalByDistToCam(distToCameraMeters, speedMpS);
   switch (interval)
@@ -362,7 +365,13 @@ void SpeedCameraManager::SendNotificationStat(double passedDistanceMeters, doubl
 
   auto const distToCameraMeters = camera.m_distFromBeginMeters - passedDistanceMeters;
 
-  CHECK(m_makeBeepSignal != m_makeVoiceSignal, ("In each moment of time only one flag should be up."));
+  CHECK(
+      m_makeBeepSignal != m_makeVoiceSignal,
+      ("In each moment of time only one flag should be up.", m_makeVoiceSignal, distToCameraMeters,
+       measurement_utils::MpsToKmph(speedMpS), m_beepSignalCounter, m_voiceSignalCounter,
+       m_hasEnteredTheZone, m_speedLimitExceeded, m_firstNotCheckedSpeedCameraIndex,
+       mercator::ToLatLon(camera.m_position)));
+
   alohalytics::TStringMap params = {{"type", m_makeBeepSignal ? "beep" : "voice"},
                                     {"distance", strings::to_string(distToCameraMeters)},
                                     {"speed", strings::to_string(measurement_utils::MpsToKmph(speedMpS))}};

--- a/routing/speed_camera_manager.hpp
+++ b/routing/speed_camera_manager.hpp
@@ -20,7 +20,7 @@
 
 namespace routing
 {
-// Do not touch the order, it uses in platforms.
+// Do not change the order, it is used by platforms.
 enum class SpeedCameraManagerMode
 {
   Auto,


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13676
Фикс падения
`routing/speed_camera_manager.cpp:365 SendNotificationStat()  CHECK(m_makeBeepSignal != m_makeVoiceSignal) In each moment of time only one flag should be up.`

Следует за #12445.
