### PR TITLE
cherry-pick [partners_api] booking method is removed because it is unused on our …

### DIFF
--- a/partners_api/booking_api.cpp
+++ b/partners_api/booking_api.cpp
@@ -59,11 +59,6 @@ bool RunSimpleHttpRequest(bool const needAuth, string const & url, string & resu
   return request.RunHttpRequest(result);
 }
 
-std::string FormatTime(system_clock::time_point p)
-{
-  return partners_api::FormatTime(p, "%Y-%m-%d");
-}
-
 string MakeUrlForTesting(string const & func, url::Params const & params, string const & divider)
 {
   ASSERT(!g_BookingUrlForTesting.empty(), ());
@@ -90,11 +85,6 @@ string MakeApiUrlImpl(string const & baseUrl, string const & func, url::Params c
     return MakeUrlForTesting(func, params, divider);
 
   return url::Make(baseUrl + divider + func, params);
-}
-
-string MakeApiUrlV1(string const & func, url::Params const & params)
-{
-  return MakeApiUrlImpl(kBookingApiBaseUrlV1, func, params, ".");
 }
 
 string MakeApiUrlV2(string const & func, url::Params const & params)
@@ -405,18 +395,6 @@ string MakeLabel(string const & labelSource)
 
 namespace booking
 {
-// static
-bool RawApi::GetHotelAvailability(string const & hotelId, string const & currency, string & result)
-{
-  system_clock::time_point p = system_clock::from_time_t(time(nullptr));
-
-  string url = MakeApiUrlV1("getHotelAvailability", {{"hotel_ids", hotelId},
-                                                     {"currency_code", currency},
-                                                     {"arrival_date", FormatTime(p)},
-                                                     {"departure_date", FormatTime(p + hours(24))}});
-  return RunSimpleHttpRequest(true, url, result);
-}
-
 // static
 bool RawApi::GetExtendedInfo(string const & hotelId, string const & lang, string & result)
 {

--- a/partners_api/booking_api.hpp
+++ b/partners_api/booking_api.hpp
@@ -111,8 +111,6 @@ struct Blocks
 class RawApi
 {
 public:
-  // Booking Api v1 methods:
-  static bool GetHotelAvailability(std::string const & hotelId, std::string const & currency, std::string & result);
   static bool GetExtendedInfo(std::string const & hotelId, std::string const & lang, std::string & result);
   // Booking Api v2 methods:
   static bool HotelAvailability(AvailabilityParams const & params, std::string & result);

--- a/partners_api/partners_api_tests/booking_tests.cpp
+++ b/partners_api/partners_api_tests/booking_tests.cpp
@@ -27,14 +27,6 @@ public:
   }
 };
 
-UNIT_TEST(Booking_GetHotelAvailability)
-{
-  std::string const kHotelId = "98251";  // Booking hotel id for testing.
-  std::string result;
-  TEST(RawApi::GetHotelAvailability(kHotelId, "", result), ());
-  TEST(!result.empty(), ());
-}
-
 UNIT_TEST(Booking_GetExtendedInfo)
 {
   std::string const kHotelId = "0";  // Internal hotel id for testing.
@@ -46,7 +38,7 @@ UNIT_TEST(Booking_GetExtendedInfo)
 UNIT_TEST(Booking_HotelAvailability)
 {
   AvailabilityParams params;
-  params.m_hotelIds = {"98251"};
+  params.m_hotelIds = {"98251"}; // booking hotel id for testing
   params.m_rooms = {{2, AvailabilityParams::Room::kNoChildren}};
   params.m_checkin = std::chrono::system_clock::now() + std::chrono::hours(24);
   params.m_checkout = std::chrono::system_clock::now() + std::chrono::hours(24 * 7);


### PR DESCRIPTION
…side and no longer supported on booking side.

cherry pick of https://github.com/mapsme/omim/pull/12955