### PR TITLE
[routing] Correct processing that a osm id of a road may correspond to several road feature ids for speed cameras case.

### DIFF
--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -24,7 +24,7 @@ CamerasInfoCollector::CamerasInfoCollector(std::string const & dataFilePath,
                                            std::string const & camerasInfoPath,
                                            std::string const & osmIdsToFeatureIdsPath)
 {
-  std::map<base::GeoObjectId, std::vector<uint32_t>> osmIdToFeatureIds;
+  routing::OsmIdToFeatureIds osmIdToFeatureIds;
   if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
   {
     LOG(LCRITICAL, ("An error happened while parsing feature id to osm ids mapping from file:",
@@ -97,8 +97,7 @@ void CamerasInfoCollector::Serialize(FileWriter & writer) const
 }
 
 bool CamerasInfoCollector::ParseIntermediateInfo(
-    std::string const & camerasInfoPath,
-    std::map<base::GeoObjectId, std::vector<uint32_t>> const & osmIdToFeatureIds)
+    std::string const & camerasInfoPath, routing::OsmIdToFeatureIds const & osmIdToFeatureIds)
 {
   FileReader reader(camerasInfoPath);
   ReaderSource<FileReader> src(reader);

--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -24,14 +24,14 @@ CamerasInfoCollector::CamerasInfoCollector(std::string const & dataFilePath,
                                            std::string const & camerasInfoPath,
                                            std::string const & osmIdsToFeatureIdsPath)
 {
-  std::map<base::GeoObjectId, uint32_t> osmIdToFeatureId;
-  if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureId))
+  std::map<base::GeoObjectId, std::vector<uint32_t>> osmIdToFeatureIds;
+  if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
   {
     LOG(LCRITICAL, ("An error happened while parsing feature id to osm ids mapping from file:",
                     osmIdsToFeatureIdsPath));
   }
 
-  if (!ParseIntermediateInfo(camerasInfoPath, osmIdToFeatureId))
+  if (!ParseIntermediateInfo(camerasInfoPath, osmIdToFeatureIds))
     LOG(LCRITICAL, ("Unable to parse intermediate file(", camerasInfoPath, ") about cameras info"));
 
   platform::LocalCountryFile file = platform::LocalCountryFile::MakeTemporary(dataFilePath);
@@ -96,8 +96,9 @@ void CamerasInfoCollector::Serialize(FileWriter & writer) const
     camera.Serialize(writer, prevFeatureId);
 }
 
-bool CamerasInfoCollector::ParseIntermediateInfo(std::string const & camerasInfoPath,
-                                                 std::map<base::GeoObjectId, uint32_t> const & osmIdToFeatureId)
+bool CamerasInfoCollector::ParseIntermediateInfo(
+    std::string const & camerasInfoPath,
+    std::map<base::GeoObjectId, std::vector<uint32_t>> const & osmIdToFeatureIds)
 {
   FileReader reader(camerasInfoPath);
   ReaderSource<FileReader> src(reader);
@@ -144,9 +145,14 @@ bool CamerasInfoCollector::ParseIntermediateInfo(std::string const & camerasInfo
     {
       ReadPrimitiveFromSource(src, wayOsmId);
 
-      auto const it = osmIdToFeatureId.find(base::MakeOsmWay(wayOsmId));
-      if (it != osmIdToFeatureId.cend())
-        ways.emplace_back(it->second /* featureId */, 0 /* segmentId */, 0 /* coef */);
+      auto const it = osmIdToFeatureIds.find(base::MakeOsmWay(wayOsmId));
+      if (it != osmIdToFeatureIds.cend())
+      {
+        auto const & featureIdsVec = it->second;
+        // Note. One |wayOsmId| may correspond several feature ids.
+        for (auto const featureId : featureIdsVec)
+          ways.emplace_back(featureId, 0 /* segmentId */, 0 /* coef */);
+      }
     }
 
     auto const speed = base::asserted_cast<uint8_t>(maxSpeedKmPH);
@@ -282,10 +288,6 @@ std::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindMys
 
     ft.ForEachPoint(findPoint, scales::GetUpperScale());
 
-//    CHECK(found, ("Cannot find camera point at the feature:", wayFeatureId,
-//                  "; camera center:", mercator::ToLatLon(m_data.m_center)));
-    // @TODO(bykoianko) The invariant above is valid. But as a fast fix, let's remove
-    // all the cameras in case of no feature ends matches.
     if (!found)
     {
       cannotFindMyself = true;
@@ -308,8 +310,14 @@ std::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindMys
 
   if (cannotFindMyself)
   {
-    LOG(LWARNING, ("Cannot find camera point at the feature:", wayFeatureId,
-                   "; camera center:", mercator::ToLatLon(m_data.m_center)));
+    // Note. Speed camera with coords |m_data.m_center| is not located at any point of |wayFeatureId|.
+    // It may happens if osm feature corresponds to |wayFeatureId| is split by a mini_roundabout
+    // or turning_loop. There are two cases:
+    // * |m_data.m_center| is located at a point of another part of the whole osm feature. In
+    //   that case it will be found on another call of FindMyself() method.
+    // * |m_data.m_center| coincides with point of mini_roundabout or turning_loop. It means
+    //   there on feature point which coincides with speed camera (|m_data.m_center|).
+    //   These camera (notification) will be lost.
     return {};
   }
 

--- a/generator/camera_info_collector.hpp
+++ b/generator/camera_info_collector.hpp
@@ -80,8 +80,9 @@ private:
   inline static double constexpr kMaxDistFromCameraToClosestSegmentMeters = 20.0;
   inline static double constexpr kSearchCameraRadiusMeters = 10.0;
 
-  bool ParseIntermediateInfo(std::string const & camerasInfoPath,
-                             std::map<base::GeoObjectId, uint32_t> const & osmIdToFeatureId);
+  bool ParseIntermediateInfo(
+      std::string const & camerasInfoPath,
+      std::map<base::GeoObjectId, std::vector<uint32_t>> const & osmIdToFeatureIds);
 
   std::vector<Camera> m_cameras;
 };

--- a/generator/camera_info_collector.hpp
+++ b/generator/camera_info_collector.hpp
@@ -80,9 +80,8 @@ private:
   inline static double constexpr kMaxDistFromCameraToClosestSegmentMeters = 20.0;
   inline static double constexpr kSearchCameraRadiusMeters = 10.0;
 
-  bool ParseIntermediateInfo(
-      std::string const & camerasInfoPath,
-      std::map<base::GeoObjectId, std::vector<uint32_t>> const & osmIdToFeatureIds);
+  bool ParseIntermediateInfo(std::string const & camerasInfoPath,
+                             routing::OsmIdToFeatureIds const & osmIdToFeatureIds);
 
   std::vector<Camera> m_cameras;
 };

--- a/generator/metalines_builder.cpp
+++ b/generator/metalines_builder.cpp
@@ -225,7 +225,7 @@ void MetalinesBuilder::MergeInto(MetalinesBuilder & collector) const
 bool WriteMetalinesSection(std::string const & mwmPath, std::string const & metalinesPath,
                            std::string const & osmIdsToFeatureIdsPath)
 {
-  std::map<base::GeoObjectId, std::vector<uint32_t>> osmIdToFeatureIds;
+  routing::OsmIdToFeatureIds osmIdToFeatureIds;
   if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
     return false;
 

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -314,7 +314,7 @@ bool RestrictionCollector::AddRestriction(m2::PointD const & coords,
     auto const result = m_osmIdToFeatureIds.find(osmIds[i]);
     if (result == m_osmIdToFeatureIds.cend())
     {
-      // It could happens near mwm border when one of a restriction lines is not included in mwm
+      // It happens near mwm border when one of a restriction lines is not included in mwm
       // but the restriction is included.
       return false;
     }

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "generator/restriction_writer.hpp"
+#include "generator/routing_helpers.hpp"
 #include "generator/routing_index_generator.hpp"
 
 #include "routing/index_graph.hpp"
@@ -91,7 +92,7 @@ private:
                       std::vector<base::GeoObjectId> const & osmIds);
 
   std::vector<Restriction> m_restrictions;
-  std::map<base::GeoObjectId, std::vector<uint32_t>> m_osmIdToFeatureIds;
+  OsmIdToFeatureIds m_osmIdToFeatureIds;
 
   std::unique_ptr<IndexGraph> m_indexGraph;
 

--- a/generator/restriction_collector.hpp
+++ b/generator/restriction_collector.hpp
@@ -91,7 +91,7 @@ private:
                       std::vector<base::GeoObjectId> const & osmIds);
 
   std::vector<Restriction> m_restrictions;
-  std::map<base::GeoObjectId, uint32_t> m_osmIdToFeatureId;
+  std::map<base::GeoObjectId, std::vector<uint32_t>> m_osmIdToFeatureIds;
 
   std::unique_ptr<IndexGraph> m_indexGraph;
 

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -162,8 +162,7 @@ set<OsmElement::Tag> const kHighwaysWhereIgnoreBarriersWithoutAccess = {
     {OsmElement::Tag("highway", "trunk_link")}
 };
 
-bool ParseRoadAccess(string const & roadAccessPath,
-                     map<base::GeoObjectId, vector<uint32_t>> const & osmIdToFeatureIds,
+bool ParseRoadAccess(string const & roadAccessPath, OsmIdToFeatureIds const & osmIdToFeatureIds,
                      RoadAccessCollector::RoadAccessByVehicleType & roadAccessByVehicleType)
 {
   ifstream stream(roadAccessPath);
@@ -264,8 +263,7 @@ bool ParseRoadAccess(string const & roadAccessPath,
 }
 
 void ParseRoadAccessConditional(
-    string const & roadAccessPath,
-    map<base::GeoObjectId, vector<uint32_t>> const & osmIdToFeatureIds,
+    string const & roadAccessPath, OsmIdToFeatureIds const & osmIdToFeatureIds,
     RoadAccessCollector::RoadAccessByVehicleType & roadAccessByVehicleType)
 {
   ifstream stream(roadAccessPath);
@@ -648,7 +646,7 @@ void RoadAccessWriter::MergeInto(RoadAccessWriter & collector) const
 RoadAccessCollector::RoadAccessCollector(string const & dataFilePath, string const & roadAccessPath,
                                          string const & osmIdsToFeatureIdsPath)
 {
-  map<base::GeoObjectId, vector<uint32_t>> osmIdToFeatureIds;
+  OsmIdToFeatureIds osmIdToFeatureIds;
   if (!ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
   {
     LOG(LWARNING, ("An error happened while parsing feature id to osm ids mapping from file:",

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -27,19 +27,18 @@ bool ForEachRoadFromFile(string const & filename, ToDo && toDo)
 namespace routing
 {
 void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
-                  map<base::GeoObjectId, uint32_t> & osmIdToFeatureId)
+                  map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds)
 {
-  // Failing to insert here usually means that two features were created
-  // from one osm id, for example an area and its boundary.
-  osmIdToFeatureId.emplace(osmId, featureId);
+  osmIdToFeatureIds[osmId].push_back(featureId);
 }
 
-bool ParseRoadsOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
-                                       map<base::GeoObjectId, uint32_t> & osmIdToFeatureId)
+bool ParseRoadsOsmIdToFeatureIdMapping(
+    string const & osmIdsToFeatureIdPath,
+    map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds)
 {
   return ForEachRoadFromFile(osmIdsToFeatureIdPath,
                              [&](uint32_t featureId, base::GeoObjectId osmId) {
-                               AddFeatureId(osmId, featureId, osmIdToFeatureId);
+                               AddFeatureId(osmId, featureId, osmIdToFeatureIds);
                              });
 }
 

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -27,14 +27,13 @@ bool ForEachRoadFromFile(string const & filename, ToDo && toDo)
 namespace routing
 {
 void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
-                  map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds)
+                  OsmIdToFeatureIds & osmIdToFeatureIds)
 {
   osmIdToFeatureIds[osmId].push_back(featureId);
 }
 
-bool ParseRoadsOsmIdToFeatureIdMapping(
-    string const & osmIdsToFeatureIdPath,
-    map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds)
+bool ParseRoadsOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
+                                       OsmIdToFeatureIds & osmIdToFeatureIds)
 {
   return ForEachRoadFromFile(osmIdsToFeatureIdPath,
                              [&](uint32_t featureId, base::GeoObjectId osmId) {

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -9,6 +9,8 @@
 
 namespace routing
 {
+using OsmIdToFeatureIds = std::map<base::GeoObjectId, std::vector<uint32_t>>;
+
 // Adds |featureId| and corresponding |osmId| to |osmIdToFeatureId|.
 // Note. In general, one |featureId| may correspond to several osm ids.
 // Or on the contrary one osm id may correspond to several feature ids. It may happens for example
@@ -16,7 +18,7 @@ namespace routing
 // As for road features a road |osmId| may correspond to several feature ids if
 // the |osmId| is split by a mini_roundabout or a turning_loop.
 void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
-                  std::map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds);
+                  OsmIdToFeatureIds & osmIdToFeatureIds);
 
 // Parses comma separated text file with line in following format:
 // <feature id>, <osm id 1 corresponding feature id>, <osm id 2 corresponding feature id>, and so
@@ -26,9 +28,8 @@ void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
 // 138000, 5170209, 5143342,
 // 138001, 5170228,
 // 137999, 5170197,
-bool ParseRoadsOsmIdToFeatureIdMapping(
-    std::string const & osmIdsToFeatureIdPath,
-    std::map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds);
+bool ParseRoadsOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
+                                       OsmIdToFeatureIds & osmIdToFeatureIds);
 bool ParseRoadsFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
                                        std::map<uint32_t, base::GeoObjectId> & featureIdToOsmId);
 }  // namespace routing

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -5,24 +5,30 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace routing
 {
-// Adds feature id and corresponding |osmId| to |osmIdToFeatureId|.
+// Adds |featureId| and corresponding |osmId| to |osmIdToFeatureId|.
 // Note. In general, one |featureId| may correspond to several osm ids.
-// But for a road feature |featureId| corresponds to exactly one osm id.
+// Or on the contrary one osm id may correspond to several feature ids. It may happens for example
+// when an area and its boundary may correspond to the same osm id.
+// As for road features a road |osmId| may correspond to several feature ids if
+// the |osmId| is split by a mini_roundabout or a turning_loop.
 void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
-                  std::map<base::GeoObjectId, uint32_t> & osmIdToFeatureId);
+                  std::map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds);
 
 // Parses comma separated text file with line in following format:
 // <feature id>, <osm id 1 corresponding feature id>, <osm id 2 corresponding feature id>, and so
-// on
+// on. It may contain several line with the same feature ids.
 // For example:
 // 137999, 5170186,
 // 138000, 5170209, 5143342,
 // 138001, 5170228,
-bool ParseRoadsOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
-                                       std::map<base::GeoObjectId, uint32_t> & osmIdToFeatureId);
+// 137999, 5170197,
+bool ParseRoadsOsmIdToFeatureIdMapping(
+    std::string const & osmIdsToFeatureIdPath,
+    std::map<base::GeoObjectId, std::vector<uint32_t>> & osmIdToFeatureIds);
 bool ParseRoadsFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
                                        std::map<uint32_t, base::GeoObjectId> & featureIdToOsmId);
 }  // namespace routing

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -471,4 +471,17 @@ UNIT_TEST(SpeedCameraNotification_NeverMode_1)
     }
   }
 }
+
+// Test on case when a feature is split by a mini_roundabout or by a turning_loop and
+// contains a speed camera. The thing is to pass this test it's necessary to process
+// fake road feature ids correctly while speed cameras generation process.
+UNIT_TEST(SpeedCameraNotification_CameraOnMiniRoundabout)
+{
+  RoutingSession routingSession;
+  InitRoutingSession({41.201998, 69.109587} /* from */, {41.200358, 69.107051} /* to   */,
+                     routingSession, SpeedCameraManagerMode::Never);
+  double const speedKmPH = 100.0;
+  ChangePosition({41.201998, 69.109587}, speedKmPH, routingSession);
+  TEST(!NoCameraFound(routingSession), ());
+}
 }  // namespace


### PR DESCRIPTION
После корректной поддержки highway=mini_roundabout и highway=turning_loop дорожные фичи стали разбиваться на несколько частей. Т.е. одному osm id теперь может соответствовать несколько дорожных фичь. Более того, возможно, что точка которая ранее принадлежала дорожной фиче, теперь не принадлежит ни какой дорожной фичи. Точки в которых находятся mini_roundabout и turning_loop теперь не принадлежат дорожной сети. Вокруг них круг.

Данный PR начинает серию PR-во по корректной обработке указанной выше ситуации. Он реализует 
1. базовую функциональность по прокидыванию вектора с feature ids для каждого osm id;
2. полностью обрабатывает случай с камерами скорости. Теперь, если камера скорости попадает на разбитую на части фичу, она будет корректно обрабатываться. Если ли же камера скорости окажется в самой точке mini_roundabout или turning_loop оповещения о ней не будет;
3. добавляет один routing integration test на случай, когда osm feature id с камерой разбито  mini_round about.

За ним последуют PR полностью обрабатывающие:
generator/metalines_builder.cpp
generator/restriction_collector.cpp
generator/road_access_generator.cpp

@mesozoic-drones @tatiana-yan PTAL
