### PR TITLE
[routing] Renaming methods: ForEachRoadFromFile to ForEachWayFromFile, ParseRoadsOsmIdToFeatureIdMapping to ParseWaysOsmIdToFeatureIdMapping and ParseRoadsFeatureIdToOsmIdMapping to ParseWaysFeatureIdToOsmIdMapping.

### DIFF
--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -25,7 +25,7 @@ CamerasInfoCollector::CamerasInfoCollector(std::string const & dataFilePath,
                                            std::string const & osmIdsToFeatureIdsPath)
 {
   routing::OsmIdToFeatureIds osmIdToFeatureIds;
-  if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
+  if (!routing::ParseWaysOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
   {
     LOG(LCRITICAL, ("An error happened while parsing feature id to osm ids mapping from file:",
                     osmIdsToFeatureIdsPath));

--- a/generator/maxspeeds_builder.cpp
+++ b/generator/maxspeeds_builder.cpp
@@ -186,7 +186,7 @@ void BuildMaxspeedsSection(string const & dataPath, string const & osmToFeatureP
   LOG(LINFO, ("BuildMaxspeedsSection(", dataPath, ",", osmToFeaturePath, ",", maxspeedsFilename, ")"));
 
   map<uint32_t, base::GeoObjectId> featureIdToOsmId;
-  CHECK(ParseRoadsFeatureIdToOsmIdMapping(osmToFeaturePath, featureIdToOsmId), ());
+  CHECK(ParseWaysFeatureIdToOsmIdMapping(osmToFeaturePath, featureIdToOsmId), ());
   BuildMaxspeedsSection(dataPath, featureIdToOsmId, maxspeedsFilename);
 }
 }  // namespace routing

--- a/generator/metalines_builder.cpp
+++ b/generator/metalines_builder.cpp
@@ -226,7 +226,7 @@ bool WriteMetalinesSection(std::string const & mwmPath, std::string const & meta
                            std::string const & osmIdsToFeatureIdsPath)
 {
   routing::OsmIdToFeatureIds osmIdToFeatureIds;
-  if (!routing::ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
+  if (!routing::ParseWaysOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
     return false;
 
   FileReader reader(metalinesPath);

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -52,7 +52,7 @@ RestrictionCollector::RestrictionCollector(std::string const & osmIdsToFeatureId
                                            std::unique_ptr<IndexGraph> && graph)
   : m_indexGraph(std::move(graph))
 {
-  CHECK(ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdPath, m_osmIdToFeatureIds),
+  CHECK(ParseWaysOsmIdToFeatureIdMapping(osmIdsToFeatureIdPath, m_osmIdToFeatureIds),
         ("An error happened while parsing feature id to "
          "osm ids mapping from file:", osmIdsToFeatureIdPath));
 }

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -647,7 +647,7 @@ RoadAccessCollector::RoadAccessCollector(string const & dataFilePath, string con
                                          string const & osmIdsToFeatureIdsPath)
 {
   OsmIdToFeatureIds osmIdToFeatureIds;
-  if (!ParseRoadsOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
+  if (!ParseWaysOsmIdToFeatureIdMapping(osmIdsToFeatureIdsPath, osmIdToFeatureIds))
   {
     LOG(LWARNING, ("An error happened while parsing feature id to osm ids mapping from file:",
                    osmIdsToFeatureIdsPath));

--- a/generator/routing_helpers.cpp
+++ b/generator/routing_helpers.cpp
@@ -13,7 +13,7 @@ using std::string;
 namespace
 {
 template <class ToDo>
-bool ForEachRoadFromFile(string const & filename, ToDo && toDo)
+bool ForEachWayFromFile(string const & filename, ToDo && toDo)
 {
   return generator::ForEachOsmId2FeatureId(
       filename, [&](auto const & compositeOsmId, auto featureId) {
@@ -32,22 +32,22 @@ void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
   osmIdToFeatureIds[osmId].push_back(featureId);
 }
 
-bool ParseRoadsOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
-                                       OsmIdToFeatureIds & osmIdToFeatureIds)
+bool ParseWaysOsmIdToFeatureIdMapping(string const & osmIdsToFeatureIdPath,
+                                      OsmIdToFeatureIds & osmIdToFeatureIds)
 {
-  return ForEachRoadFromFile(osmIdsToFeatureIdPath,
+  return ForEachWayFromFile(osmIdsToFeatureIdPath,
                              [&](uint32_t featureId, base::GeoObjectId osmId) {
                                AddFeatureId(osmId, featureId, osmIdToFeatureIds);
                              });
 }
 
-bool ParseRoadsFeatureIdToOsmIdMapping(string const & osmIdsToFeatureIdPath,
-                                       map<uint32_t, base::GeoObjectId> & featureIdToOsmId)
+bool ParseWaysFeatureIdToOsmIdMapping(string const & osmIdsToFeatureIdPath,
+                                      map<uint32_t, base::GeoObjectId> & featureIdToOsmId)
 {
   featureIdToOsmId.clear();
   bool idsAreOk = true;
 
-  bool const readSuccess = ForEachRoadFromFile(
+  bool const readSuccess = ForEachWayFromFile(
       osmIdsToFeatureIdPath, [&](uint32_t featureId, base::GeoObjectId const & osmId) {
         auto const emplaced = featureIdToOsmId.emplace(featureId, osmId);
         if (emplaced.second)

--- a/generator/routing_helpers.hpp
+++ b/generator/routing_helpers.hpp
@@ -11,7 +11,7 @@ namespace routing
 {
 using OsmIdToFeatureIds = std::map<base::GeoObjectId, std::vector<uint32_t>>;
 
-// Adds |featureId| and corresponding |osmId| to |osmIdToFeatureId|.
+// Adds |featureId| and corresponding |osmId| to |osmIdToFeatureIds|.
 // Note. In general, one |featureId| may correspond to several osm ids.
 // Or on the contrary one osm id may correspond to several feature ids. It may happens for example
 // when an area and its boundary may correspond to the same osm id.
@@ -28,8 +28,12 @@ void AddFeatureId(base::GeoObjectId osmId, uint32_t featureId,
 // 138000, 5170209, 5143342,
 // 138001, 5170228,
 // 137999, 5170197,
-bool ParseRoadsOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
-                                       OsmIdToFeatureIds & osmIdToFeatureIds);
-bool ParseRoadsFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
-                                       std::map<uint32_t, base::GeoObjectId> & featureIdToOsmId);
+//
+// Note. These methods fill |osmIdToFeatureIds| and |featureIdToOsmId| with features of
+// type base::GeoObjectId::Type::ObsoleteOsmWay. This type contains all the roads
+// and besides that other linear objects like streams and fences.
+bool ParseWaysOsmIdToFeatureIdMapping(std::string const & osmIdsToFeatureIdPath,
+                                      OsmIdToFeatureIds & osmIdToFeatureIds);
+bool ParseWaysFeatureIdToOsmIdMapping(std::string const & osmIdsToFeatureIdPath,
+                                      std::map<uint32_t, base::GeoObjectId> & featureIdToOsmId);
 }  // namespace routing

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -263,7 +263,7 @@ void CalcCrossMwmTransitions(
 {
   VehicleMaskBuilder const maskMaker(country, countryParentNameGetterFn);
   map<uint32_t, base::GeoObjectId> featureIdToOsmId;
-  CHECK(ParseRoadsFeatureIdToOsmIdMapping(mappingFile, featureIdToOsmId),
+  CHECK(ParseWaysFeatureIdToOsmIdMapping(mappingFile, featureIdToOsmId),
         ("Can't parse feature id to osm id mapping. File:", mappingFile));
 
   auto const & path = base::JoinPath(intermediateDir, CROSS_MWM_OSM_WAYS_DIR, country);


### PR DESCRIPTION
Переименовал методы:
ForEachRoadFromFile(...) -> ForEachWayFromFile(...)
ParseRoadsOsmIdToFeatureIdMapping(...) -> ParseWaysOsmIdToFeatureIdMapping(...)
ParseRoadsFeatureIdToOsmIdMapping(...) -> ParseWaysFeatureIdToOsmIdMapping(...)

что более точно отражает, то что они делают.
По результатам договоренностей в https://github.com/mapsme/omim/pull/12959

@tatiana-yan @mesozoic-drones PTAL