### PR TITLE
[routing] Extended fake feature interval for transit.

### DIFF
--- a/routing/fake_feature_ids.cpp
+++ b/routing/fake_feature_ids.cpp
@@ -5,6 +5,8 @@ namespace routing
 // static
 uint32_t constexpr FakeFeatureIds::kIndexGraphStarterId;
 // static
+uint32_t constexpr FakeFeatureIds::k28BitsOffset;
+// static
 uint32_t constexpr FakeFeatureIds::k24BitsOffset;
 // static
 uint32_t constexpr FakeFeatureIds::kTransitGraphFeaturesStart;

--- a/routing/fake_feature_ids.hpp
+++ b/routing/fake_feature_ids.hpp
@@ -24,9 +24,10 @@ struct FakeFeatureIds
   // It's important that |kGuidesGraphFeaturesStart| is greater than maximum number of real road
   // feature id. Also transit and guides fake feature id should not overlap with real feature id
   // and editor feature ids.
+  static uint32_t constexpr k28BitsOffset = 0xfffffff;
   static uint32_t constexpr k24BitsOffset = 0xffffff;
   static uint32_t constexpr kTransitGraphFeaturesStart =
-      std::numeric_limits<uint32_t>::max() - k24BitsOffset;
+      std::numeric_limits<uint32_t>::max() - k28BitsOffset;
   static uint32_t constexpr kGuidesGraphFeaturesStart = kTransitGraphFeaturesStart - k24BitsOffset;
 };
 


### PR DESCRIPTION
Мы хотим добавить в секцию transit данные из GTFS фидов. В качестве id берем FakeFeatureId из интервала IsTransitFeature(), а это всего 15 млн (15 728 640). Для хранения не только метро, но и GTFS, этого мало. PR увеличивает это значение до 260 млн (267 386 880). На OSM фичи при этом остается 4 009 754 624 айдишников, то есть фичи OSM не пострадают.

| Интервал  | До PR | После PR |
| ------------- | ------------- | ------------- |
| kIndexGraphStartedId  | 4 294 967 295  | 4 294 967 295  |
| kEditorCreatedFeaturesStart  | 4 293 918 720  | 4 293 918 720  |
| kTransitGraphFeaturesStart  | 4 278 190 080  | **4 026 531 840**  |
| kGuidesGraphFeaturesStart  | 4 261 412 865  | **4 009 754 625**  |
| OSM ids start | 0  | 0  |
