### PR TITLE
[routing] Fix crash in FeaturesRoadGraph::FindClosestEdges().

### DIFF
--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -183,7 +183,7 @@ void FeaturesRoadGraph::FindClosestEdges(
 {
   NearestEdgeFinder finder(rect.Center(), nullptr /* IsEdgeProjGood */);
 
-  auto const f = [&finder, &rect, this](FeatureType & ft)
+  auto const f = [&finder, this](FeatureType & ft)
   {
     if (!m_vehicleModel.IsRoad(ft))
       return;
@@ -191,10 +191,6 @@ void FeaturesRoadGraph::FindClosestEdges(
     FeatureID const & featureId = ft.GetID();
 
     IRoadGraph::RoadInfo const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
-    CHECK_EQUAL(roadInfo.m_speedKMPH, kInvalidSpeedKMPH,
-                (mercator::ToLatLon(rect.Center()), featureId, roadInfo.m_speedKMPH,
-                 roadInfo.m_bidirectional, roadInfo.m_junctions));
-
     finder.AddInformationSource(IRoadGraph::FullRoadInfo(featureId, roadInfo));
   };
 

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -183,7 +183,7 @@ void FeaturesRoadGraph::FindClosestEdges(
 {
   NearestEdgeFinder finder(rect.Center(), nullptr /* IsEdgeProjGood */);
 
-  auto const f = [&finder, this](FeatureType & ft)
+  auto const f = [&finder, &rect, this](FeatureType & ft)
   {
     if (!m_vehicleModel.IsRoad(ft))
       return;
@@ -191,7 +191,9 @@ void FeaturesRoadGraph::FindClosestEdges(
     FeatureID const & featureId = ft.GetID();
 
     IRoadGraph::RoadInfo const & roadInfo = GetCachedRoadInfo(featureId, ft, kInvalidSpeedKMPH);
-    CHECK_EQUAL(roadInfo.m_speedKMPH, kInvalidSpeedKMPH, ());
+    CHECK_EQUAL(roadInfo.m_speedKMPH, kInvalidSpeedKMPH,
+                (mercator::ToLatLon(rect.Center()), featureId, roadInfo.m_speedKMPH,
+                 roadInfo.m_bidirectional, roadInfo.m_junctions));
 
     finder.AddInformationSource(IRoadGraph::FullRoadInfo(featureId, roadInfo));
   };
@@ -296,12 +298,13 @@ double FeaturesRoadGraph::GetSpeedKMpHFromFt(FeatureType & ft, SpeedParams const
 void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType & ft,
                                         double speedKMpH, RoadInfo & ri) const
 {
+  ri.m_speedKMPH = speedKMpH;
+
   Value const & value = LockMwm(featureId.m_mwmId);
   if (!value.IsAlive())
     return;
 
   ri.m_bidirectional = !IsOneWay(ft);
-  ri.m_speedKMPH = speedKMpH;
 
   ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
   size_t const pointsCount = ft.GetPointsCount();


### PR DESCRIPTION
По крешу: https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/c33bd1776ddb3311feeb4b47acfe9f75/sessions/latest

- Внес изменение, которое может приводить к срабатыванию данного CHECK
Если передать в FeaturesRoadGraph::ExtractRoadInfo() `featureId`, у которой featureId.m_mwmId.IsAlive() возвращает false, то скорость будет равна 0 и чек сработает.

- Вывел больше информации в случае срабатывания CHECK

@mesozoic-drones @tatiana-yan PTAL

