### PR TITLE
[data] Remove CountriesNamesTest exceptions after MAPSME-10611 fix.

### DIFF
--- a/map/map_tests/countries_names_tests.cpp
+++ b/map/map_tests/countries_names_tests.cpp
@@ -53,10 +53,6 @@ UNIT_TEST(CountriesNamesTest)
                                    "Transnistria",
                                    "Nagorno-Karabakh Republic",
                                    "Republic of Artsakh",
-                                   // MAPSME-10611
-                                   "Mayorca Residencial",
-                                   "Magnolias Residencial",
-                                   "Residencial Magnolias",
                                    };
 
   auto const features = cache.Get(mwmContext);


### PR DESCRIPTION
После исправления MAPSME-10611  и мержа новых данных в мастер неправильно собранные из осм страны пропали, можно удалить исключения из теста.