### PR TITLE
[search] Separate localities caches.

### DIFF
--- a/generator/collector_city_area.cpp
+++ b/generator/collector_city_area.cpp
@@ -31,7 +31,8 @@ std::shared_ptr<CollectorInterface> CityAreaCollector::Clone(
 
 void CityAreaCollector::CollectFeature(FeatureBuilder const & feature, OsmElement const &)
 {
-  if (!(feature.IsArea() && ftypes::IsCityTownOrVillage(feature.GetTypes())))
+  auto const & isCityTownOrVillage = ftypes::IsCityTownOrVillageChecker::Instance();
+  if (!(feature.IsArea() && isCityTownOrVillage(feature.GetTypes())))
     return;
 
   auto copy = feature;

--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -426,7 +426,8 @@ private:
       if (poiChecker(fb.GetTypes()))
         ++actual.m_poi;
 
-      if (ftypes::IsCityTownOrVillage(fb.GetTypes()))
+      auto const & isCityTownOrVillage = ftypes::IsCityTownOrVillageChecker::Instance();
+      if (isCityTownOrVillage(fb.GetTypes()))
         ++actual.m_cityTownOrVillage;
 
       auto static const & bookingChecker = ftypes::IsBookingHotelChecker::Instance();

--- a/generator/generator_tests_support/test_mwm_builder.cpp
+++ b/generator/generator_tests_support/test_mwm_builder.cpp
@@ -87,7 +87,8 @@ bool TestMwmBuilder::Add(FeatureBuilder & fb)
 {
   CHECK(m_collector, ("It's not possible to add features after call to Finish()."));
 
-  if (ftypes::IsCityTownOrVillage(fb.GetTypes()) && fb.GetGeomType() == GeomType::Area)
+  auto const & isCityTownOrVillage = ftypes::IsCityTownOrVillageChecker::Instance();
+  if (isCityTownOrVillage(fb.GetTypes()) && fb.GetGeomType() == GeomType::Area)
   {
     auto const & metadata = fb.GetMetadata();
     uint64_t testId;

--- a/generator/place_processor.cpp
+++ b/generator/place_processor.cpp
@@ -159,12 +159,13 @@ void PlaceProcessor::FillTable(FeaturePlaces::const_iterator start, FeaturePlace
 {
   CHECK(m_boundariesTable, ());
   base::GeoObjectId lastId;
+  auto const & isCityTownOrVillage = ftypes::IsCityTownOrVillageChecker::Instance();
   for (auto outerIt = start; outerIt != end; ++outerIt)
   {
     auto const & fbs = outerIt->GetFbs();
     for (auto const & fb : fbs)
     {
-      if (!(fb.IsArea() && ftypes::IsCityTownOrVillage(fb.GetTypes())))
+      if (!(fb.IsArea() && isCityTownOrVillage(fb.GetTypes())))
         continue;
 
       auto const id = fb.GetLastOsmId();

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -713,6 +713,32 @@ LocalityType IsLocalityChecker::GetType(FeatureType & f) const
   return GetType(types);
 }
 
+IsCountryChecker::IsCountryChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"place", "country"}));
+}
+
+IsStateChecker::IsStateChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"place", "state"}));
+}
+
+IsCityTownOrVillageChecker::IsCityTownOrVillageChecker()
+{
+  vector<pair<string, string>> const types = {
+    {"place", "city"},
+    {"place", "town"},
+    {"place", "village"},
+    {"place", "hamlet"}
+  };
+
+  Classificator const & c = classif();
+  for (auto const & t : types)
+    m_types.push_back(c.GetTypeByPath({t.first, t.second}));
+}
+
 uint64_t GetPopulation(FeatureType & ft)
 {
   uint64_t population = ft.GetPopulation();

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -430,15 +430,27 @@ public:
   DECLARE_CHECKER_INSTANCE(IsLocalityChecker);
 };
 
-template <typename Types>
-bool IsCityTownOrVillage(Types const & types)
+
+class IsCountryChecker : public BaseChecker
 {
-  feature::TypesHolder h;
-  for (auto const t : types)
-    h.Add(t);
-  auto const type = IsLocalityChecker::Instance().GetType(h);
-  return type == LocalityType ::City || type == LocalityType ::Town || type == LocalityType ::Village;
-}
+  IsCountryChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsCountryChecker);
+};
+
+class IsStateChecker : public BaseChecker
+{
+  IsStateChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsStateChecker);
+};
+
+class IsCityTownOrVillageChecker : public BaseChecker
+{
+  IsCityTownOrVillageChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsCityTownOrVillageChecker);
+};
 
 /// @name Get city radius and population.
 /// @param r Radius in meters.

--- a/search/categories_cache.cpp
+++ b/search/categories_cache.cpp
@@ -72,9 +72,21 @@ VillagesCache::VillagesCache(base::Cancellable const & cancellable)
 {
 }
 
-// LocalitiesCache ----------------------------------------------------------------------------------
-LocalitiesCache::LocalitiesCache(base::Cancellable const & cancellable)
-  : CategoriesCache(ftypes::IsLocalityChecker::Instance(), cancellable)
+// CountriesCache ----------------------------------------------------------------------------------
+CountriesCache::CountriesCache(base::Cancellable const & cancellable)
+  : CategoriesCache(ftypes::IsCountryChecker::Instance(), cancellable)
+{
+}
+
+// StatesCache -------------------------------------------------------------------------------------
+StatesCache::StatesCache(base::Cancellable const & cancellable)
+  : CategoriesCache(ftypes::IsStateChecker::Instance(), cancellable)
+{
+}
+
+// CitiesTownsOrVillagesCache ----------------------------------------------------------------------
+CitiesTownsOrVillagesCache::CitiesTownsOrVillagesCache(base::Cancellable const & cancellable)
+  : CategoriesCache(ftypes::IsCityTownOrVillageChecker::Instance(), cancellable)
 {
 }
 

--- a/search/categories_cache.hpp
+++ b/search/categories_cache.hpp
@@ -64,10 +64,24 @@ public:
   VillagesCache(base::Cancellable const & cancellable);
 };
 
-class LocalitiesCache : public CategoriesCache
+class CountriesCache : public CategoriesCache
 {
 public:
-  LocalitiesCache(base::Cancellable const & cancellable);
+  CountriesCache(base::Cancellable const & cancellable);
+};
+
+class StatesCache : public CategoriesCache
+{
+public:
+  StatesCache(base::Cancellable const & cancellable);
+};
+
+// Used for cities/towns/villages from world. Currently we do not have villages in World.mwm but
+// it may be good to put some important villages to it: mountain/beach resorts.
+class CitiesTownsOrVillagesCache : public CategoriesCache
+{
+public:
+  CitiesTownsOrVillagesCache(base::Cancellable const & cancellable);
 };
 
 class HotelsCache : public CategoriesCache

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -96,9 +96,20 @@ public:
     double m_villageSearchRadiusM = 0.0;
   };
 
+  struct LocalitiesCaches
+  {
+    LocalitiesCaches(base::Cancellable const & cancellable);
+    void Clear();
+
+    CountriesCache m_countries;
+    StatesCache m_states;
+    CitiesTownsOrVillagesCache m_citiesTownsOrVillages;
+    VillagesCache m_villages;
+  };
+
   Geocoder(DataSource const & dataSource, storage::CountryInfoGetter const & infoGetter,
            CategoriesHolder const & categories, CitiesBoundariesTable const & citiesBoundaries,
-           PreRanker & preRanker, VillagesCache & villagesCache, LocalitiesCache & localitiesCache,
+           PreRanker & preRanker, LocalitiesCaches & localitiesCaches,
            base::Cancellable const & cancellable);
   ~Geocoder();
 
@@ -306,8 +317,7 @@ private:
 
   StreetsCache m_streetsCache;
   SuburbsCache m_suburbsCache;
-  VillagesCache & m_villagesCache;
-  LocalitiesCache & m_localitiesCache;
+  LocalitiesCaches & m_localitiesCaches;
   HotelsCache m_hotelsCache;
   FoodCache m_foodCache;
   hotels_filter::HotelsFilter m_hotelsFilter;

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -160,15 +160,14 @@ Processor::Processor(DataSource const & dataSource, CategoriesHolder const & cat
   : m_categories(categories)
   , m_infoGetter(infoGetter)
   , m_dataSource(dataSource)
-  , m_villagesCache(static_cast<base::Cancellable const &>(*this))
-  , m_localitiesCache(static_cast<base::Cancellable const &>(*this))
+  , m_localitiesCaches(static_cast<base::Cancellable const &>(*this))
   , m_citiesBoundaries(m_dataSource)
   , m_keywordsScorer(LanguageTier::LANGUAGE_TIER_COUNT)
   , m_ranker(m_dataSource, m_citiesBoundaries, infoGetter, m_keywordsScorer, m_emitter, categories,
-             suggests, m_villagesCache, static_cast<base::Cancellable const &>(*this))
+             suggests, m_localitiesCaches.m_villages, static_cast<base::Cancellable const &>(*this))
   , m_preRanker(m_dataSource, m_ranker)
   , m_geocoder(m_dataSource, infoGetter, categories, m_citiesBoundaries, m_preRanker,
-               m_villagesCache, m_localitiesCache, static_cast<base::Cancellable const &>(*this))
+               m_localitiesCaches, static_cast<base::Cancellable const &>(*this))
   , m_bookmarksProcessor(m_emitter, static_cast<base::Cancellable const &>(*this))
 {
   // Current and input langs are to be set later.
@@ -794,8 +793,7 @@ void Processor::InitEmitter(SearchParams const & searchParams)
 void Processor::ClearCaches()
 {
   m_geocoder.ClearCaches();
-  m_villagesCache.Clear();
-  m_localitiesCache.Clear();
+  m_localitiesCaches.Clear();
   m_preRanker.ClearCaches();
   m_ranker.ClearCaches();
   m_viewport.MakeEmpty();

--- a/search/processor.hpp
+++ b/search/processor.hpp
@@ -147,8 +147,7 @@ protected:
 
   DataSource const & m_dataSource;
 
-  VillagesCache m_villagesCache;
-  LocalitiesCache m_localitiesCache;
+  Geocoder::LocalitiesCaches m_localitiesCaches;
   CitiesBoundariesTable m_citiesBoundaries;
 
   KeywordLangMatcher m_keywordsScorer;


### PR DESCRIPTION
Разделяю кеши для стран, регионов, городов.
Это нужно для того чтобы в дальнейшем при поиске городов учитывать заматченные страны/регионы и при происке регионов учитывать страны.

В FillLocalitiesTable преобразования не эквивалентные: раньше мы "доставали"  100 locality (всех подряд), а потом пытались из их числа выбрать 5 стран с GeomType::Point, 5 штатов с GeomType::Point и 5 городов с GeomType::Point. 
Теперь достаем по 10 стран-штатов-городов и выбираем среди них все у которых геометрия GeomType::Point.

И у того и у другого варианта свои плюсы и минусы (в старом например могло вообще не оказаться стран в кандидатах, а в новом кандидаты могут оказаться сплошными Area, для старого это тоже было проблемой, но меньшей).

Пока по assesment_tool вижу что изменений в кол-ве релевантных результатов нет, замедления тоже нет. Дальше это место предположительно будет сильно переписано.

В каких случаях может провалиться `ft = m_context->GetFeature(l.m_featureId);` я не поняла, но проверку оставила. При прогоне выборки в assesment_tool такого не было.