### PR TITLE
[routing] Adding logs in case wrong version (wrong header) of access conditional section.

### DIFF
--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -104,7 +104,7 @@ void LoadRoadAccess(string const & mwmFilePath, VehicleType vehicleType, RoadAcc
     FilesContainerR::TReader const reader = cont.GetReader(ROAD_ACCESS_FILE_TAG);
     ReaderSource<FilesContainerR::TReader> src(reader);
 
-    RoadAccessSerializer::Deserialize(src, vehicleType, roadAccess);
+    RoadAccessSerializer::Deserialize(src, vehicleType, roadAccess, mwmFilePath);
   }
   catch (Reader::OpenException const & e)
   {

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -11,6 +11,8 @@
 
 #include "indexer/data_source.hpp"
 
+#include "platform/country_defines.hpp"
+
 #include "coding/files_container.hpp"
 
 #include "base/assert.hpp"
@@ -230,7 +232,8 @@ bool ReadRoadAccessFromMwm(MwmValue const & mwmValue, VehicleType vehicleType,
     auto const reader = mwmValue.m_cont.GetReader(ROAD_ACCESS_FILE_TAG);
     ReaderSource<FilesContainerR::TReader> src(reader);
 
-    RoadAccessSerializer::Deserialize(src, vehicleType, roadAccess);
+    RoadAccessSerializer::Deserialize(src, vehicleType, roadAccess,
+                                      mwmValue.m_file.GetPath(MapFileType::Map));
   }
   catch (Reader::OpenException const & e)
   {

--- a/routing/routing_tests/road_access_test.cpp
+++ b/routing/routing_tests/road_access_test.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "3party/opening_hours/opening_hours.hpp"
@@ -139,7 +140,7 @@ public:
 
     MemReader memReader(m_buffer.data(), m_buffer.size());
     ReaderSource<MemReader> src(memReader);
-    RoadAccessSerializer::Deserialize(src, vehicleType, deserializedRoadAccess);
+    RoadAccessSerializer::Deserialize(src, vehicleType, deserializedRoadAccess, string("unknown"));
     TEST_EQUAL(answer, deserializedRoadAccess, ());
   }
 


### PR DESCRIPTION
При тесте версии 10.0.2 случился креш у одного клиента:
https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/839fceb4c295a1831f6aefbb193ba68f/sessions/latest

Ставка на то, что одна из карт скаченных в 17 или 18 года повреждена или не совместимой версии. Тем не менее добавлены логи, чтоб в след раз, если такой креш появиться получить больше информации.

@mesozoic-drones PTAL