### PR TITLE
[data][indexer][generator][python] Rename dat section to features.

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -25,7 +25,8 @@
 #define ID2REL_EXT ".id2rel"
 
 #define CENTERS_FILE_TAG "centers"
-#define DATA_FILE_TAG "dat"
+#define FEATURES_FILE_TAG_V1_V9 "dat"
+#define FEATURES_FILE_TAG "features"
 #define GEOMETRY_FILE_TAG "geom"
 #define TRIANGLE_FILE_TAG "trg"
 #define INDEX_FILE_TAG "idx"

--- a/generator/altitude_generator.cpp
+++ b/generator/altitude_generator.cpp
@@ -160,7 +160,7 @@ void BuildRoadAltitudes(std::string const & mwmPath, AltitudeGetter & altitudeGe
   {
     // Preparing altitude information.
     Processor processor(altitudeGetter);
-    feature::ForEachFromDat(mwmPath, processor);
+    feature::ForEachFeature(mwmPath, processor);
 
     if (!processor.HasAltitudeInfo())
     {

--- a/generator/city_roads_generator.cpp
+++ b/generator/city_roads_generator.cpp
@@ -62,7 +62,7 @@ vector<uint32_t> CalcRoadFeatureIds(string const & dataPath, string const & boun
   CitiesBoundariesChecker const checker(citiesBoundaries);
 
   vector<uint32_t> cityRoadFeatureIds;
-  ForEachFromDat(dataPath, [&cityRoadFeatureIds, &checker](FeatureType & ft, uint32_t fid) {
+  ForEachFeature(dataPath, [&cityRoadFeatureIds, &checker](FeatureType & ft, uint32_t fid) {
     bool const needToProcess =
         routing::IsCarRoad(TypesHolder(ft)) || routing::IsBicycleRoad(TypesHolder(ft));
     if (!needToProcess)

--- a/generator/descriptions_section_builder.hpp
+++ b/generator/descriptions_section_builder.hpp
@@ -49,11 +49,11 @@ private:
 };
 
 template <class T>
-struct ForEachFromDatAdapt
+struct ForEachFeatureAdapt
 {
   void operator()(std::string const & str, T && fn) const
   {
-    feature::ForEachFromDat(str, std::forward<T>(fn));
+    feature::ForEachFeature(str, std::forward<T>(fn));
   }
 };
 
@@ -103,7 +103,7 @@ public:
                                 std::string const & idToWikidataPath);
   DescriptionsCollectionBuilder(std::string const & wikipediaDir, std::string const & mwmFile);
 
-  template <typename Ft, template <typename> class ForEachFromDatAdapter>
+  template <typename Ft, template <typename> class ForEachFeatureAdapter>
   descriptions::DescriptionsCollection MakeDescriptions()
   {
     descriptions::DescriptionsCollection descriptionList;
@@ -145,7 +145,7 @@ public:
       m_stat.IncPage();
       descriptionList.emplace_back(std::move(description));
     };
-    ForEachFromDatAdapter<decltype(fn)> adapter;
+    ForEachFeatureAdapter<decltype(fn)> adapter;
     adapter(m_mwmFile, std::move(fn));
     return descriptionList;
   }
@@ -167,7 +167,7 @@ private:
   std::string m_mwmFile;
 };
 
-template <typename Ft, template <typename> class ForEachFromDatAdapter = ForEachFromDatAdapt>
+template <typename Ft, template <typename> class ForEachFeatureAdapter = ForEachFeatureAdapt>
 struct DescriptionsSectionBuilder
 {
   static void Build(std::string const & wikipediaDir, std::string const & mwmFile,
@@ -186,7 +186,7 @@ struct DescriptionsSectionBuilder
 private:
   static void Build(std::string const & mwmFile, DescriptionsCollectionBuilder & builder)
   {
-    auto descriptionList = builder.MakeDescriptions<Ft, ForEachFromDatAdapter>();
+    auto descriptionList = builder.MakeDescriptions<Ft, ForEachFeatureAdapter>();
     auto const & stat = builder.GetStat();
     auto const size = stat.GetTotalSize();
     LOG(LINFO, ("Added", stat.GetNumberOfWikipediaUrls(), "pages from wikipedia urls for", mwmFile));

--- a/generator/dumper.cpp
+++ b/generator/dumper.cpp
@@ -99,7 +99,7 @@ namespace feature
   void DumpTypes(string const & fPath)
   {
     TypesCollector doClass;
-    feature::ForEachFromDat(fPath, doClass);
+    feature::ForEachFeature(fPath, doClass);
 
     typedef pair<vector<uint32_t>, size_t> stats_elem_type;
     typedef vector<stats_elem_type> vec_to_sort;
@@ -185,7 +185,7 @@ namespace feature
   void DumpPrefixes(string const & fPath)
   {
     PrefixesCollector doClass;
-    feature::ForEachFromDat(fPath, doClass);
+    feature::ForEachFeature(fPath, doClass);
     for (TokensContainerT::iterator it = doClass.m_stats.begin();
          it != doClass.m_stats.end(); ++it)
     {
@@ -225,7 +225,7 @@ namespace feature
         cout << name << endl;
     };
 
-    feature::ForEachFromDat(fPath, [&](FeatureType & f, uint32_t)
+    feature::ForEachFeature(fPath, [&](FeatureType & f, uint32_t)
                             {
                               f.ForEachName(printName);
                             });

--- a/generator/feature_builder.hpp
+++ b/generator/feature_builder.hpp
@@ -285,9 +285,9 @@ void ReadFromSourceRawFormat(Source & src, FeatureBuilder & fb)
   SerializationPolicy::Deserialize(fb, buffer);
 }
 
-// Process features in .dat file.
+// Process features in features file.
 template <class SerializationPolicy = serialization_policy::MinSize, class ToDo>
-void ForEachFromDatRawFormat(std::string const & filename, ToDo && toDo)
+void ForEachFeatureRawFormat(std::string const & filename, ToDo && toDo)
 {
   FileReader reader(filename);
   ReaderSource<FileReader> src(reader);
@@ -304,14 +304,14 @@ void ForEachFromDatRawFormat(std::string const & filename, ToDo && toDo)
   }
 }
 
-/// Parallel process features in .dat file.
+/// Parallel process features in features file.
 template <class SerializationPolicy = serialization_policy::MinSize, class ToDo>
 void ForEachParallelFromDatRawFormat(size_t threadsCount, std::string const & filename,
                                      ToDo && toDo)
 {
   CHECK_GREATER_OR_EQUAL(threadsCount, 1, ());
   if (threadsCount == 1)
-    return ForEachFromDatRawFormat(filename, std::forward<ToDo>(toDo));
+    return ForEachFeatureRawFormat(filename, std::forward<ToDo>(toDo));
 
   FileReader reader(filename);
   ReaderSource<FileReader> src(reader);
@@ -350,7 +350,7 @@ template <class SerializationPolicy = serialization_policy::MinSize>
 std::vector<FeatureBuilder> ReadAllDatRawFormat(std::string const & fileName)
 {
   std::vector<FeatureBuilder> fbs;
-  ForEachFromDatRawFormat<SerializationPolicy>(fileName, [&](auto && fb, auto const &) {
+  ForEachFeatureRawFormat<SerializationPolicy>(fileName, [&](auto && fb, auto const &) {
     fbs.emplace_back(std::move(fb));
   });
   return fbs;

--- a/generator/feature_generator.cpp
+++ b/generator/feature_generator.cpp
@@ -26,9 +26,10 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 namespace feature
 {
-
 FeaturesCollector::FeaturesCollector(std::string const & fName, FileWriter::Op op)
-  : m_datFile(fName, op), m_writeBuffer(kBufferSize) {}
+  : m_dataFile(fName, op), m_writeBuffer(kBufferSize)
+{
+}
 
 FeaturesCollector::~FeaturesCollector()
 {
@@ -54,14 +55,14 @@ std::pair<char[ValueSizeT], uint8_t> PackValue(ValueT v)
 
 void FeaturesCollector::FlushBuffer()
 {
-  m_datFile.Write(m_writeBuffer.data(), m_writePosition);
+  m_dataFile.Write(m_writeBuffer.data(), m_writePosition);
   m_writePosition = 0;
 }
 
 void FeaturesCollector::Flush()
 {
   FlushBuffer();
-  m_datFile.Flush();
+  m_dataFile.Flush();
 }
 
 void FeaturesCollector::Write(char const * src, size_t size)

--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -13,7 +13,7 @@ namespace feature
 {
 class FeatureBuilder;
 
-// Writes features to dat file.
+// Writes features to file.
 class FeaturesCollector
 {
 public:

--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -23,7 +23,7 @@ public:
   virtual ~FeaturesCollector();
 
   static uint64_t GetCurrentPosition();
-  std::string const & GetFilePath() const { return m_datFile.GetName(); }
+  std::string const & GetFilePath() const { return m_dataFile.GetName(); }
   /// \brief Serializes |f|.
   /// \returns Feature id of serialized feature if |f| is serialized after the call
   /// and |kInvalidFeatureId| if not.
@@ -43,7 +43,7 @@ protected:
   uint32_t WriteFeatureBase(std::vector<char> const & bytes, FeatureBuilder const & fb);
   void Flush();
 
-  FileWriter m_datFile;
+  FileWriter m_dataFile;
   m2::RectD m_bounds;
 
 private:

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -334,7 +334,7 @@ int main(int argc, char ** argv)
   generator::SrtmTileManager manager(FLAGS_srtm_dir_path);
 
   Processor processor(manager);
-  ForEachFromDat(FLAGS_mwm_file_path, processor);
+  ForEachFeature(FLAGS_mwm_file_path, processor);
 
   PrintCont(processor.m_altitudeDiffs, "Altitude difference between start and end of features.",
             " feature(s) with altitude difference ", " meter(s)");

--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -54,7 +54,7 @@ class FeaturesCollector2 : public FeaturesCollector
 public:
   FeaturesCollector2(string const & filename, DataHeader const & header,
                      RegionData const & regionData, uint32_t versionDate)
-    : FeaturesCollector(filename + DATA_FILE_TAG)
+    : FeaturesCollector(filename + FEATURES_FILE_TAG)
     , m_filename(filename)
     , m_header(header)
     , m_regionData(regionData)
@@ -107,7 +107,7 @@ public:
 
     {
       FilesContainerW writer(m_filename, FileWriter::OP_WRITE_EXISTING);
-      auto w = writer.GetWriter(DATA_FILE_TAG);
+      auto w = writer.GetWriter(FEATURES_FILE_TAG);
 
       size_t const startOffset = w->Pos();
       CHECK(coding::IsAlign8(startOffset), ());
@@ -341,7 +341,7 @@ bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & na
 
   // Store cellIds for middle points.
   CalculateMidPoints midPoints;
-  ForEachFromDatRawFormat(srcFilePath, [&midPoints](FeatureBuilder const & fb, uint64_t pos) {
+  ForEachFeatureRawFormat(srcFilePath, [&midPoints](FeatureBuilder const & fb, uint64_t pos) {
     midPoints(fb, pos);
   });
 
@@ -373,9 +373,9 @@ bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & na
     // Transform features from raw format to optimized format.
     try
     {
-      // FeaturesCollector2 will create temprory file `datFilePath + DATA_FILE_TAG`.
+      // FeaturesCollector2 will create temporary file `datFilePath + FEATURES_FILE_TAG`.
       // We cannot remove it in ~FeaturesCollector2(), we need to remove it in SCOPE_GUARD.
-      SCOPE_GUARD(_, [&](){ Platform::RemoveFileIfExists(datFilePath + DATA_FILE_TAG); });
+      SCOPE_GUARD(_, [&](){ Platform::RemoveFileIfExists(datFilePath + FEATURES_FILE_TAG); });
       FeaturesCollector2 collector(datFilePath, header, regionData, info.m_versionDate);
 
       for (auto const & point : midPoints.GetVector())

--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -74,7 +74,7 @@ public:
   ~FeaturesCollector2()
   {
     // Check file size.
-    auto const unused = CheckedFilePosCast(m_datFile);
+    auto const unused = CheckedFilePosCast(m_dataFile);
     UNUSED_VALUE(unused);
   }
 
@@ -119,7 +119,7 @@ public:
       coding::WritePadding(*w, bytesWritten);
 
       header.m_featuresOffset = base::asserted_cast<uint32_t>(w->Pos() - startOffset);
-      ReaderSource<ModelReaderPtr> src(make_unique<FileReader>(m_datFile.GetName()));
+      ReaderSource<ModelReaderPtr> src(make_unique<FileReader>(m_dataFile.GetName()));
       rw::ReadAndWrite(src, *w);
       header.m_featuresSize =
           base::asserted_cast<uint32_t>(w->Pos() - header.m_featuresOffset - startOffset);
@@ -337,7 +337,7 @@ bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & na
                            feature::DataHeader::MapType mapType)
 {
   string const srcFilePath = info.GetTmpFileName(name);
-  string const datFilePath = info.GetTargetFileName(name);
+  string const dataFilePath = info.GetTargetFileName(name);
 
   // Store cellIds for middle points.
   CalculateMidPoints midPoints;
@@ -373,10 +373,10 @@ bool GenerateFinalFeatures(feature::GenerateInfo const & info, string const & na
     // Transform features from raw format to optimized format.
     try
     {
-      // FeaturesCollector2 will create temporary file `datFilePath + FEATURES_FILE_TAG`.
+      // FeaturesCollector2 will create temporary file `dataFilePath + FEATURES_FILE_TAG`.
       // We cannot remove it in ~FeaturesCollector2(), we need to remove it in SCOPE_GUARD.
-      SCOPE_GUARD(_, [&](){ Platform::RemoveFileIfExists(datFilePath + FEATURES_FILE_TAG); });
-      FeaturesCollector2 collector(datFilePath, header, regionData, info.m_versionDate);
+      SCOPE_GUARD(_, [&]() { Platform::RemoveFileIfExists(dataFilePath + FEATURES_FILE_TAG); });
+      FeaturesCollector2 collector(dataFilePath, header, regionData, info.m_versionDate);
 
       for (auto const & point : midPoints.GetVector())
       {

--- a/generator/feature_sorter.hpp
+++ b/generator/feature_sorter.hpp
@@ -8,7 +8,7 @@
 
 namespace feature
 {
-/// Final generation of data from input feature-dat-file.
+/// Final generation of data from input feature-file.
 /// @param path - path to folder with countries;
 /// @param name - name of generated country;
 bool GenerateFinalFeatures(feature::GenerateInfo const & info, std::string const & name,

--- a/generator/final_processor_utils.hpp
+++ b/generator/final_processor_utils.hpp
@@ -30,7 +30,7 @@ public:
 
   explicit PlaceHelper(std::string const & filename) : PlaceHelper()
   {
-    feature::ForEachFromDatRawFormat<feature::serialization_policy::MaxAccuracy>(
+    feature::ForEachFeatureRawFormat<feature::serialization_policy::MaxAccuracy>(
         filename, [&](auto const & fb, auto const &) { m_processor.Add(fb); });
   }
 

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -159,7 +159,7 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
       TEST_EQUAL(expected, altitudes[i], ("A wrong altitude"));
     }
   };
-  feature::ForEachFromDat(mwmPath, processor);
+  feature::ForEachFeature(mwmPath, processor);
 }
 
 void TestAltitudesBuilding(std::vector<TPoint3DList> const & roads, bool hasAltitudeExpected,

--- a/generator/generator_tests/cities_ids_tests.cpp
+++ b/generator/generator_tests/cities_ids_tests.cpp
@@ -111,7 +111,7 @@ UNIT_CLASS_TEST(CitiesIdsTest, BuildCitiesIds)
       TEST_EQUAL(originalMapping[index], gid.GetSerialId(), ());
     };
 
-    feature::ForEachFromDat(worldMwmPath, test);
+    feature::ForEachFeature(worldMwmPath, test);
 
     TEST_EQUAL(numFeatures, 3, ());
     TEST_EQUAL(numLocalities, 2, ());

--- a/generator/generator_tests/coasts_test.cpp
+++ b/generator/generator_tests/coasts_test.cpp
@@ -205,6 +205,6 @@ UNIT_TEST(WorldCoasts_CheckBounds)
 
   //DoPrintCoasts doProcess(vID);
   DoCopyCoasts doProcess("/Users/alena/omim/omim/data/WorldCoasts.mwm.tmp", vID);
-  ForEachFromDatRawFormat("/Users/alena/omim/omim-indexer-tmp/WorldCoasts.mwm.tmp", doProcess);
+  ForEachFeatureRawFormat("/Users/alena/omim/omim-indexer-tmp/WorldCoasts.mwm.tmp", doProcess);
 }
 */

--- a/generator/generator_tests/descriptions_section_builder_tests.cpp
+++ b/generator/generator_tests/descriptions_section_builder_tests.cpp
@@ -98,7 +98,7 @@ public:
   void MakeDescriptions() const
   {
     DescriptionsCollectionBuilder b(m_wikiDir, kMwmFile);
-    auto const descriptionList = b.MakeDescriptions<Feature, ForEachFromDatMockAdapt>();
+    auto const descriptionList = b.MakeDescriptions<Feature, ForEachFeatureMockAdapt>();
     auto const  & stat = b.GetStat();
     TEST_EQUAL(GetTestDataPages(), descriptionList.size(), ());
     TEST_EQUAL(GetTestDataPages(), stat.GetNumberOfPages(), ());
@@ -188,7 +188,7 @@ public:
     using namespace platform::tests_support;
     auto const testMwm = kMwmFile + DATA_FILE_EXTENSION;
     ScopedMwm testScopedMwm(testMwm);
-    DescriptionsSectionBuilder<Feature, ForEachFromDatMockAdapt>::Build(m_wikiDir,
+    DescriptionsSectionBuilder<Feature, ForEachFeatureMockAdapt>::Build(m_wikiDir,
                                                                         testScopedMwm.GetFullPath());
     FilesContainerR container(testScopedMwm.GetFullPath());
     TEST(container.IsExist(DESCRIPTIONS_FILE_TAG), ());
@@ -214,7 +214,7 @@ public:
 
 private:
   template <class ToDo>
-  static void ForEachFromDatMock(std::string const &, ToDo && toDo)
+  static void ForEachFeatureMock(std::string const &, ToDo && toDo)
   {
     for (size_t i = 0; i < kWikiData.size(); ++i)
     {
@@ -224,11 +224,11 @@ private:
   }
 
   template <class T>
-  struct ForEachFromDatMockAdapt
+  struct ForEachFeatureMockAdapt
   {
     void operator()(std::string const & str, T && fn) const
     {
-      ForEachFromDatMock(str, std::forward<T>(fn));
+      ForEachFeatureMock(str, std::forward<T>(fn));
     }
   };
 

--- a/generator/generator_tests/maxspeeds_tests.cpp
+++ b/generator/generator_tests/maxspeeds_tests.cpp
@@ -122,7 +122,7 @@ void TestMaxspeedsSection(Features const & roads, string const & maxspeedsCsvCon
     // Comparing maxspeed from csv and maxspeed from mwm section.
     TEST_EQUAL(maxspeedCsv, maxspeedMwm, ());
   };
-  feature::ForEachFromDat(testMwmFullPath, processor);
+  feature::ForEachFeature(testMwmFullPath, processor);
 }
 
 // Note. ParseMaxspeeds() is not tested in TestMaxspeedsSection() because it's used twice there.

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -330,7 +330,7 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
     }
   }
 
-  // Enumerate over all dat files that were created.
+  // Enumerate over all features files that were created.
   size_t const count = genInfo.m_bucketNames.size();
   for (size_t i = 0; i < count; ++i)
   {

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -318,14 +318,14 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
   if (!FLAGS_dump_wikipedia_urls.empty())
   {
     auto const tmpPath = base::JoinPath(genInfo.m_intermediateDir, "tmp");
-    auto const datFiles = platform_helpers::GetFullDataTmpFilePaths(tmpPath);
+    auto const dataFiles = platform_helpers::GetFullDataTmpFilePaths(tmpPath);
 
-    WikiUrlDumper wikiUrlDumper(FLAGS_dump_wikipedia_urls, datFiles);
+    WikiUrlDumper wikiUrlDumper(FLAGS_dump_wikipedia_urls, dataFiles);
     wikiUrlDumper.Dump(threadsCount);
 
     if (!FLAGS_idToWikidata.empty())
     {
-      WikiDataFilter wikiDataFilter(FLAGS_idToWikidata, datFiles);
+      WikiDataFilter wikiDataFilter(FLAGS_idToWikidata, dataFiles);
       wikiDataFilter.Filter(threadsCount);
     }
   }
@@ -335,7 +335,7 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
   for (size_t i = 0; i < count; ++i)
   {
     string const & country = genInfo.m_bucketNames[i];
-    string const datFile = base::JoinPath(path, country + DATA_FILE_EXTENSION);
+    string const dataFile = base::JoinPath(path, country + DATA_FILE_EXTENSION);
     string const osmToFeatureFilename =
         genInfo.GetTargetFileName(country) + OSM2FEATURE_FILE_EXTENSION;
 
@@ -355,8 +355,8 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
       if (!feature::GenerateFinalFeatures(genInfo, country, mapType))
         continue;
 
-      LOG(LINFO, ("Generating offsets table for", datFile));
-      if (!feature::BuildOffsetsTable(datFile))
+      LOG(LINFO, ("Generating offsets table for", dataFile));
+      if (!feature::BuildOffsetsTable(dataFile))
         continue;
 
       auto const boundaryPostcodesFilename =
@@ -369,22 +369,22 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
         string const metalinesFilename = genInfo.GetIntermediateFileName(METALINES_FILENAME);
 
         LOG(LINFO, ("Processing metalines from", metalinesFilename));
-        if (!feature::WriteMetalinesSection(datFile, metalinesFilename, osmToFeatureFilename))
+        if (!feature::WriteMetalinesSection(dataFile, metalinesFilename, osmToFeatureFilename))
           LOG(LCRITICAL, ("Error generating metalines section."));
       }
     }
 
     if (FLAGS_generate_index)
     {
-      LOG(LINFO, ("Generating index for", datFile));
+      LOG(LINFO, ("Generating index for", dataFile));
 
-      if (!indexer::BuildIndexFromDataFile(datFile, FLAGS_intermediate_data_path + country))
+      if (!indexer::BuildIndexFromDataFile(dataFile, FLAGS_intermediate_data_path + country))
         LOG(LCRITICAL, ("Error generating index."));
     }
 
     if (FLAGS_generate_search_index)
     {
-      LOG(LINFO, ("Generating search index for", datFile));
+      LOG(LINFO, ("Generating search index for", dataFile));
 
       /// @todo Make threads count according to environment (single mwm build or planet build).
       if (!indexer::BuildSearchIndexFromDataFile(path, country, true /* forceRebuild */,
@@ -421,35 +421,35 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
           LOG(LCRITICAL, ("Error generating postcodes section for", country));
       }
 
-      LOG(LINFO, ("Generating rank table for", datFile));
-      if (!search::SearchRankTableBuilder::CreateIfNotExists(datFile))
+      LOG(LINFO, ("Generating rank table for", dataFile));
+      if (!search::SearchRankTableBuilder::CreateIfNotExists(dataFile))
         LOG(LCRITICAL, ("Error generating rank table."));
 
-      LOG(LINFO, ("Generating centers table for", datFile));
-      if (!indexer::BuildCentersTableFromDataFile(datFile, true /* forceRebuild */))
+      LOG(LINFO, ("Generating centers table for", dataFile));
+      if (!indexer::BuildCentersTableFromDataFile(dataFile, true /* forceRebuild */))
         LOG(LCRITICAL, ("Error generating centers table."));
     }
 
     if (FLAGS_generate_cities_boundaries)
     {
       CHECK(!FLAGS_cities_boundaries_data.empty(), ());
-      LOG(LINFO, ("Generating cities boundaries for", datFile));
+      LOG(LINFO, ("Generating cities boundaries for", dataFile));
       generator::OsmIdToBoundariesTable table;
       if (!generator::DeserializeBoundariesTable(FLAGS_cities_boundaries_data, table))
         LOG(LCRITICAL, ("Error deserializing boundaries table"));
-      if (!generator::BuildCitiesBoundaries(datFile, osmToFeatureFilename, table))
+      if (!generator::BuildCitiesBoundaries(dataFile, osmToFeatureFilename, table))
         LOG(LCRITICAL, ("Error generating cities boundaries."));
     }
 
     if (FLAGS_generate_cities_ids)
     {
-      LOG(LINFO, ("Generating cities ids for", datFile));
-      if (!generator::BuildCitiesIds(datFile, osmToFeatureFilename))
+      LOG(LINFO, ("Generating cities ids for", dataFile));
+      if (!generator::BuildCitiesIds(dataFile, osmToFeatureFilename))
         LOG(LCRITICAL, ("Error generating cities ids."));
     }
 
     if (!FLAGS_srtm_path.empty())
-      routing::BuildRoadAltitudes(datFile, FLAGS_srtm_path);
+      routing::BuildRoadAltitudes(dataFile, FLAGS_srtm_path);
 
     if (!FLAGS_transit_path.empty())
       routing::transit::BuildTransit(path, country, osmToFeatureFilename, FLAGS_transit_path);
@@ -465,7 +465,7 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
       {
         string const camerasFilename = genInfo.GetIntermediateFileName(CAMERAS_TO_WAYS_FILENAME);
 
-        BuildCamerasInfo(datFile, camerasFilename, osmToFeatureFilename);
+        BuildCamerasInfo(dataFile, camerasFilename, osmToFeatureFilename);
       }
     }
 
@@ -483,27 +483,27 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
       string const restrictionsFilename = genInfo.GetIntermediateFileName(RESTRICTIONS_FILENAME);
       string const roadAccessFilename = genInfo.GetIntermediateFileName(ROAD_ACCESS_FILENAME);
 
-      routing::BuildRoutingIndex(datFile, country, *countryParentGetter);
-      routing::BuildRoadRestrictions(path, datFile, country, restrictionsFilename,
+      routing::BuildRoutingIndex(dataFile, country, *countryParentGetter);
+      routing::BuildRoadRestrictions(path, dataFile, country, restrictionsFilename,
                                      osmToFeatureFilename, *countryParentGetter);
-      routing::BuildRoadAccessInfo(datFile, roadAccessFilename, osmToFeatureFilename);
+      routing::BuildRoadAccessInfo(dataFile, roadAccessFilename, osmToFeatureFilename);
     }
 
     if (FLAGS_make_city_roads)
     {
       CHECK(!FLAGS_cities_boundaries_data.empty(), ());
-      LOG(LINFO, ("Generating cities boundaries roads for", datFile));
+      LOG(LINFO, ("Generating cities boundaries roads for", dataFile));
       auto const boundariesPath =
           genInfo.GetIntermediateFileName(ROUTING_CITY_BOUNDARIES_DUMP_FILENAME);
-      if (!routing::BuildCityRoads(datFile, boundariesPath))
+      if (!routing::BuildCityRoads(dataFile, boundariesPath))
         LOG(LCRITICAL, ("Generating city roads error."));
     }
 
     if (FLAGS_generate_maxspeed)
     {
-      LOG(LINFO, ("Generating maxspeeds section for", datFile));
+      LOG(LINFO, ("Generating maxspeeds section for", dataFile));
       string const maxspeedsFilename = genInfo.GetIntermediateFileName(MAXSPEEDS_FILENAME);
-      routing::BuildMaxspeedsSection(datFile, osmToFeatureFilename, maxspeedsFilename);
+      routing::BuildMaxspeedsSection(dataFile, osmToFeatureFilename, maxspeedsFilename);
     }
 
     if (FLAGS_make_cross_mwm || FLAGS_make_transit_cross_mwm)
@@ -519,39 +519,39 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
       if (FLAGS_make_cross_mwm)
       {
-        routing::BuildRoutingCrossMwmSection(path, datFile, country, genInfo.m_intermediateDir,
+        routing::BuildRoutingCrossMwmSection(path, dataFile, country, genInfo.m_intermediateDir,
                                              *countryParentGetter, osmToFeatureFilename,
                                              FLAGS_disable_cross_mwm_progress);
       }
 
       if (FLAGS_make_transit_cross_mwm)
-        routing::BuildTransitCrossMwmSection(path, datFile, country, *countryParentGetter);
+        routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter);
     }
 
     if (!FLAGS_ugc_data.empty())
     {
-      if (!BuildUgcMwmSection(FLAGS_ugc_data, datFile, osmToFeatureFilename))
+      if (!BuildUgcMwmSection(FLAGS_ugc_data, dataFile, osmToFeatureFilename))
         LOG(LCRITICAL, ("Error generating UGC mwm section."));
 
-      if (!BuildRatingsMwmSection(FLAGS_ugc_data, datFile, osmToFeatureFilename))
+      if (!BuildRatingsMwmSection(FLAGS_ugc_data, dataFile, osmToFeatureFilename))
         LOG(LCRITICAL, ("Error generating ratings mwm section."));
     }
 
     if (!FLAGS_wikipedia_pages.empty())
     {
       if (!FLAGS_idToWikidata.empty())
-        BuildDescriptionsSection(FLAGS_wikipedia_pages, datFile, FLAGS_idToWikidata);
+        BuildDescriptionsSection(FLAGS_wikipedia_pages, dataFile, FLAGS_idToWikidata);
       else
-        BuildDescriptionsSection(FLAGS_wikipedia_pages, datFile);
+        BuildDescriptionsSection(FLAGS_wikipedia_pages, dataFile);
     }
 
     // This section must be built with the same isolines file as had been used at the features stage.
     if (FLAGS_generate_isolines_info)
-      BuildIsolinesInfoSection(FLAGS_isolines_path, country, datFile);
+      BuildIsolinesInfoSection(FLAGS_isolines_path, country, dataFile);
 
     if (FLAGS_generate_popular_places)
     {
-      if (!BuildPopularPlacesMwmSection(genInfo.m_popularPlacesFilename, datFile,
+      if (!BuildPopularPlacesMwmSection(genInfo.m_popularPlacesFilename, dataFile,
                                         osmToFeatureFilename))
       {
         LOG(LCRITICAL, ("Error generating popular places mwm section."));
@@ -560,54 +560,53 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
     if (FLAGS_generate_traffic_keys)
     {
-      if (!traffic::GenerateTrafficKeysFromDataFile(datFile))
+      if (!traffic::GenerateTrafficKeysFromDataFile(dataFile))
         LOG(LCRITICAL, ("Error generating traffic keys."));
     }
   }
 
-  string const datFile = base::JoinPath(path, FLAGS_output + DATA_FILE_EXTENSION);
+  string const dataFile = base::JoinPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
   if (FLAGS_calc_statistics)
   {
-    LOG(LINFO, ("Calculating statistics for", datFile));
-
+    LOG(LINFO, ("Calculating statistics for", dataFile));
 
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
-    stats::FileContainerStatistic(file, datFile);
-    stats::FileContainerStatistic(file, datFile + ROUTING_FILE_EXTENSION);
+    stats::FileContainerStatistic(file, dataFile);
+    stats::FileContainerStatistic(file, dataFile + ROUTING_FILE_EXTENSION);
 
     stats::MapInfo info;
-    stats::CalcStatistic(datFile, info);
+    stats::CalcStatistic(dataFile, info);
     stats::PrintStatistic(file, info);
   }
 
   if (FLAGS_type_statistics)
   {
-    LOG(LINFO, ("Calculating type statistics for", datFile));
+    LOG(LINFO, ("Calculating type statistics for", dataFile));
 
     stats::MapInfo info;
-    stats::CalcStatistic(datFile, info);
+    stats::CalcStatistic(dataFile, info);
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
     stats::PrintTypeStatistic(file, info);
   }
 
   if (FLAGS_dump_types)
-    feature::DumpTypes(datFile);
+    feature::DumpTypes(dataFile);
 
   if (FLAGS_dump_prefixes)
-    feature::DumpPrefixes(datFile);
+    feature::DumpPrefixes(dataFile);
 
   if (FLAGS_dump_search_tokens)
-    feature::DumpSearchTokens(datFile, 100 /* maxTokensToShow */);
+    feature::DumpSearchTokens(dataFile, 100 /* maxTokensToShow */);
 
   if (FLAGS_dump_feature_names != "")
-    feature::DumpFeatureNames(datFile, FLAGS_dump_feature_names);
+    feature::DumpFeatureNames(dataFile, FLAGS_dump_feature_names);
 
   if (FLAGS_unpack_mwm)
-    UnpackMwm(datFile);
+    UnpackMwm(dataFile);
 
   if (!FLAGS_delete_section.empty())
-    DeleteSection(datFile, FLAGS_delete_section);
+    DeleteSection(dataFile, FLAGS_delete_section);
 
   if (FLAGS_generate_packed_borders)
     borders::GeneratePackedBorders(path);
@@ -616,7 +615,7 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
     borders::UnpackBorders(path, FLAGS_unpack_borders);
 
   if (FLAGS_check_mwm)
-    check_model::ReadFeatures(datFile);
+    check_model::ReadFeatures(dataFile);
 
   return EXIT_SUCCESS;
 });

--- a/generator/maxspeeds_builder.cpp
+++ b/generator/maxspeeds_builder.cpp
@@ -79,7 +79,7 @@ MaxspeedsMwmCollector::MaxspeedsMwmCollector(
   OsmIdToMaxspeed osmIdToMaxspeed;
   CHECK(ParseMaxspeeds(maxspeedCsvPath, osmIdToMaxspeed), (maxspeedCsvPath));
 
-  ForEachFromDat(dataPath, [&](FeatureType & ft, uint32_t fid) {
+  ForEachFeature(dataPath, [&](FeatureType & ft, uint32_t fid) {
     if (!routing::IsCarRoad(TypesHolder(ft)))
       return;
 

--- a/generator/popular_places_section_builder.cpp
+++ b/generator/popular_places_section_builder.cpp
@@ -80,7 +80,7 @@ bool BuildPopularPlacesMwmSection(std::string const & srcFilename, std::string c
   bool popularPlaceFound = false;
 
   std::vector<PopularityIndex> content;
-  feature::ForEachFromDat(mwmFile, [&](FeatureType const & f, uint32_t featureId)
+  feature::ForEachFeature(mwmFile, [&](FeatureType const & f, uint32_t featureId)
   {
     ASSERT_EQUAL(content.size(), featureId, ());
 

--- a/generator/postcodes_section_builder.cpp
+++ b/generator/postcodes_section_builder.cpp
@@ -70,7 +70,7 @@ bool BuildPostcodesSection(std::string const & path, std::string const & country
   size_t postcodesFromAddr = 0;
   size_t postcodesFromBoundaries = 0;
   auto const mwmFile = base::JoinPath(path, country + DATA_FILE_EXTENSION);
-  feature::ForEachFromDat(mwmFile, [&](FeatureType & f, uint32_t featureId) {
+  feature::ForEachFeature(mwmFile, [&](FeatureType & f, uint32_t featureId) {
     CHECK_LESS(featureId, featuresCount, ());
     auto const postcode = addrs[featureId].Get(feature::AddressData::Type::Postcode);
     if (!postcode.empty())

--- a/generator/ratings_section_builder.cpp
+++ b/generator/ratings_section_builder.cpp
@@ -33,7 +33,7 @@ bool BuildRatingsMwmSection(std::string const & srcDbFilename, std::string const
   bool haveUgc = false;
   uint8_t constexpr kNoRating = 0;
 
-  feature::ForEachFromDat(mwmFile, [&](FeatureType & f, uint32_t featureId) {
+  feature::ForEachFeature(mwmFile, [&](FeatureType & f, uint32_t featureId) {
     ugc::UGC ugc;
     auto const it = featureToOsmId.find(featureId);
     // Non-OSM features (coastlines, sponsored objects) are not used.

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -117,7 +117,7 @@ public:
 
   void ProcessAllFeatures(string const & filename)
   {
-    feature::ForEachFromDat(filename, bind(&Processor::ProcessFeature, this, _1, _2));
+    feature::ForEachFeature(filename, bind(&Processor::ProcessFeature, this, _1, _2));
   }
 
   void BuildGraph(IndexGraph & graph) const
@@ -270,7 +270,7 @@ void CalcCrossMwmTransitions(
   auto const crossMwmOsmIdWays =
       generator::CrossMwmOsmWaysCollector::CrossMwmInfo::LoadFromFileToSet(path);
 
-  ForEachFromDat(mwmFile, [&](FeatureType & f, uint32_t featureId) {
+  ForEachFeature(mwmFile, [&](FeatureType & f, uint32_t featureId) {
     VehicleMask const roadMask = maskMaker.CalcRoadMask(f);
     if (roadMask == 0)
       return;

--- a/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
+++ b/generator/srtm_coverage_checker/srtm_coverage_checker.cpp
@@ -71,7 +71,7 @@ int main(int argc, char * argv[])
 
     size_t all = 0;
     size_t good = 0;
-    ForEachFromDat(path, [&](FeatureType & ft, uint32_t fid) {
+    ForEachFeature(path, [&](FeatureType & ft, uint32_t fid) {
       if (!IsRoad(TypesHolder(ft)))
         return;
 

--- a/generator/statistics.cpp
+++ b/generator/statistics.cpp
@@ -110,7 +110,7 @@ namespace stats
   void CalcStatistic(std::string const & fPath, MapInfo & info)
   {
     AccumulateStatistic doProcess(info);
-    feature::ForEachFromDat(fPath, doProcess);
+    feature::ForEachFeature(fPath, doProcess);
   }
 
   void PrintInfo(std::ostream & os, std::string const & prefix, GeneralInfo const & info, bool measurements)

--- a/generator/ugc_section_builder.cpp
+++ b/generator/ugc_section_builder.cpp
@@ -32,7 +32,7 @@ bool BuildUgcMwmSection(std::string const & srcDbFilename, std::string const & m
 
   std::vector<IndexUGC> content;
 
-  feature::ForEachFromDat(mwmFile, [&](FeatureType & f, uint32_t featureId) {
+  feature::ForEachFeature(mwmFile, [&](FeatureType & f, uint32_t featureId) {
     auto const it = featureToOsmId.find(featureId);
     // Non-OSM features (coastlines, sponsored objects) are not used.
     if (it == featureToOsmId.cend())

--- a/generator/utils.cpp
+++ b/generator/utils.cpp
@@ -116,7 +116,7 @@ bool ParseFeatureIdToTestIdMapping(std::string const & path,
                                    std::unordered_map<uint32_t, uint64_t> & mapping)
 {
   bool success = true;
-  feature::ForEachFromDat(path, [&](FeatureType & feature, uint32_t fid) {
+  feature::ForEachFeature(path, [&](FeatureType & feature, uint32_t fid) {
     auto const & metatada = feature.GetMetadata();
     auto const testIdStr = metatada.Get(feature::Metadata::FMD_TEST_ID);
     uint64_t testId;

--- a/generator/wiki_url_dumper.cpp
+++ b/generator/wiki_url_dumper.cpp
@@ -56,7 +56,7 @@ void WikiUrlDumper::Dump(size_t cpuCount) const
 void WikiUrlDumper::DumpOne(std::string const & path, std::ostream & stream)
 {
   auto const & needWikiUrl = ftypes::AttractionsChecker::Instance();
-  feature::ForEachFromDatRawFormat(path, [&](FeatureBuilder const & feature, uint64_t /* pos */) {
+  feature::ForEachFeatureRawFormat(path, [&](FeatureBuilder const & feature, uint64_t /* pos */) {
     if (!needWikiUrl(feature.GetTypesHolder()))
       return;
 
@@ -89,7 +89,7 @@ void WikiDataFilter::FilterOne(std::string const & path, std::map<base::GeoObjec
                                std::ostream & stream)
 {
   auto const & needWikiUrl = ftypes::AttractionsChecker::Instance();
-  feature::ForEachFromDatRawFormat(path, [&](FeatureBuilder const & feature, uint64_t /* pos */) {
+  feature::ForEachFeatureRawFormat(path, [&](FeatureBuilder const & feature, uint64_t /* pos */) {
     if (!needWikiUrl(feature.GetTypesHolder()))
       return;
 

--- a/generator/wiki_url_dumper.hpp
+++ b/generator/wiki_url_dumper.hpp
@@ -12,7 +12,7 @@ namespace generator
 class WikiUrlDumper
 {
 public:
-  explicit WikiUrlDumper(std::string const & path, std::vector<std::string> const & datFiles);
+  explicit WikiUrlDumper(std::string const & path, std::vector<std::string> const & dataFiles);
 
   static void DumpOne(std::string const & path, std::ostream & stream);
 

--- a/indexer/feature_processor.hpp
+++ b/indexer/feature_processor.hpp
@@ -12,15 +12,15 @@
 namespace feature
 {
 template <class ToDo>
-void ForEachFromDat(ModelReaderPtr reader, ToDo && toDo)
+void ForEachFeature(ModelReaderPtr reader, ToDo && toDo)
 {
   FeaturesVectorTest features((FilesContainerR(reader)));
   features.GetVector().ForEach(std::forward<ToDo>(toDo));
 }
 
 template <class ToDo>
-void ForEachFromDat(std::string const & fPath, ToDo && toDo)
+void ForEachFeature(std::string const & fPath, ToDo && toDo)
 {
-  ForEachFromDat(std::make_unique<FileReader>(fPath), std::forward<ToDo>(toDo));
+  ForEachFeature(std::make_unique<FileReader>(fPath), std::forward<ToDo>(toDo));
 }
 }  // namespace feature

--- a/indexer/features_offsets_table.cpp
+++ b/indexer/features_offsets_table.cpp
@@ -129,7 +129,7 @@ namespace feature
       string const destPath = filePath + ".offsets";
       SCOPE_GUARD(fileDeleter, bind(FileWriter::DeleteFileX, destPath));
 
-      FilesContainerR::TReader reader = FilesContainerR(filePath).GetReader(DATA_FILE_TAG);
+      FilesContainerR::TReader reader = FilesContainerR(filePath).GetReader(FEATURES_FILE_TAG);
 
       DatSectionHeader header;
       header.Read(*reader.GetPtr());

--- a/indexer/index_builder.cpp
+++ b/indexer/index_builder.cpp
@@ -8,32 +8,32 @@
 
 namespace indexer
 {
-  bool BuildIndexFromDataFile(std::string const & dataFile, std::string const & tmpFile)
+bool BuildIndexFromDataFile(std::string const & dataFile, std::string const & tmpFile)
+{
+  try
   {
-    try
+    std::string const idxFileName(tmpFile + GEOM_INDEX_TMP_EXT);
     {
-      std::string const idxFileName(tmpFile + GEOM_INDEX_TMP_EXT);
-      {
-        FeaturesVectorTest features(dataFile);
-        FileWriter writer(idxFileName);
+      FeaturesVectorTest features(dataFile);
+      FileWriter writer(idxFileName);
 
-        BuildIndex(features.GetHeader(), features.GetVector(), writer, tmpFile);
-      }
-
-      FilesContainerW(dataFile, FileWriter::OP_WRITE_EXISTING).Write(idxFileName, INDEX_FILE_TAG);
-      FileWriter::DeleteFileX(idxFileName);
-    }
-    catch (Reader::Exception const & e)
-    {
-      LOG(LERROR, ("Error while reading file: ", e.Msg()));
-      return false;
-    }
-    catch (Writer::Exception const & e)
-    {
-      LOG(LERROR, ("Error writing index file: ", e.Msg()));
-      return false;
+      BuildIndex(features.GetHeader(), features.GetVector(), writer, tmpFile);
     }
 
-    return true;
+    FilesContainerW(dataFile, FileWriter::OP_WRITE_EXISTING).Write(idxFileName, INDEX_FILE_TAG);
+    FileWriter::DeleteFileX(idxFileName);
   }
+  catch (Reader::Exception const & e)
+  {
+    LOG(LERROR, ("Error while reading file: ", e.Msg()));
+    return false;
+  }
+  catch (Writer::Exception const & e)
+  {
+    LOG(LERROR, ("Error writing index file: ", e.Msg()));
+    return false;
+  }
+
+  return true;
+}
 }  // namespace indexer

--- a/indexer/index_builder.cpp
+++ b/indexer/index_builder.cpp
@@ -8,19 +8,19 @@
 
 namespace indexer
 {
-  bool BuildIndexFromDataFile(std::string const & datFile, std::string const & tmpFile)
+  bool BuildIndexFromDataFile(std::string const & dataFile, std::string const & tmpFile)
   {
     try
     {
       std::string const idxFileName(tmpFile + GEOM_INDEX_TMP_EXT);
       {
-        FeaturesVectorTest features(datFile);
+        FeaturesVectorTest features(dataFile);
         FileWriter writer(idxFileName);
 
         BuildIndex(features.GetHeader(), features.GetVector(), writer, tmpFile);
       }
 
-      FilesContainerW(datFile, FileWriter::OP_WRITE_EXISTING).Write(idxFileName, INDEX_FILE_TAG);
+      FilesContainerW(dataFile, FileWriter::OP_WRITE_EXISTING).Write(idxFileName, INDEX_FILE_TAG);
       FileWriter::DeleteFileX(idxFileName);
     }
     catch (Reader::Exception const & e)

--- a/indexer/index_builder.hpp
+++ b/indexer/index_builder.hpp
@@ -22,5 +22,5 @@ void BuildIndex(feature::DataHeader const & header, TFeaturesVector const & feat
   }
 
   // doesn't throw exceptions
-  bool BuildIndexFromDataFile(std::string const & datFile, std::string const & tmpFile);
+  bool BuildIndexFromDataFile(std::string const & dataFile, std::string const & tmpFile);
 }  // namespace indexer

--- a/indexer/indexer_tests/features_offsets_table_test.cpp
+++ b/indexer/indexer_tests/features_offsets_table_test.cpp
@@ -79,7 +79,8 @@ namespace feature
     FileWriter::DeleteFileX(indexFile);
 
     FeaturesOffsetsTable::Builder builder;
-    FeaturesVector::ForEachOffset(baseContainer.GetReader(DATA_FILE_TAG), [&builder](uint32_t offset)
+    // minsk-pass.mwm has old format and old FEATURES_FILE_TAG name.
+    FeaturesVector::ForEachOffset(baseContainer.GetReader(FEATURES_FILE_TAG_V1_V9), [&builder](uint32_t offset)
     {
       builder.PushOffset(offset);
     });

--- a/indexer/shared_load_info.cpp
+++ b/indexer/shared_load_info.cpp
@@ -14,7 +14,9 @@ SharedLoadInfo::SharedLoadInfo(FilesContainerR const & cont, DataHeader const & 
 
 SharedLoadInfo::Reader SharedLoadInfo::GetDataReader() const
 {
-  return m_cont.GetReader(DATA_FILE_TAG);
+  if (GetMWMFormat() < version::Format::v10)
+    return m_cont.GetReader(FEATURES_FILE_TAG_V1_V9);
+  return m_cont.GetReader(FEATURES_FILE_TAG);
 }
 
 SharedLoadInfo::Reader SharedLoadInfo::GetMetadataReader() const

--- a/map/mwm_tests/mwm_foreach_test.cpp
+++ b/map/mwm_tests/mwm_foreach_test.cpp
@@ -278,7 +278,7 @@ public:
 //     }
 //     {
 //       AccumulatorEtalon acc(r, scale, v2);
-//       feature::ForEachFromDat(reader, acc);
+//       feature::ForEachFeature(reader, acc);
 //       sort(v2.begin(), v2.end(), FeatureIDCmp());
 //     }
 
@@ -289,7 +289,7 @@ public:
 //       if (errInd != emptyInd)
 //       {
 //         FindOffset doFind(scale, v2[errInd]);
-//         feature::ForEachFromDat(reader, doFind);
+//         feature::ForEachFeature(reader, doFind);
 //       }
 
 //       TEST(false, ("Failed for rect:", r, "; Scale level:", scale, "; Etalon size:", v2.size(), "; Index size:", v1.size()));

--- a/platform/mwm_version.hpp
+++ b/platform/mwm_version.hpp
@@ -24,8 +24,9 @@ enum class Format
   v8,      // February 2016 (long strings in metadata; store seconds since epoch in MwmVersion).
            // December 2016 (index graph section was added in version 161206, between v8 and v9).
   v9,      // April 2017 (OSRM sections are deleted and replaced by cross mwm section).
-  v10,     // April 2020 (compressed metadata index, addr section with header, sdx section with
-           // header, dat section with header).
+  v10,     // April 2020 (dat section renamed to features, compressed metadata index, addr section with
+           // header, sdx section with header, dat section renamed to features, features section with
+           // header).
   lastFormat = v10
 };
 

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -60,7 +60,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId,
   unique_ptr<AltitudeLoader> altitudeLoader =
       make_unique<AltitudeLoader>(dataSource, regResult.first /* mwmId */);
 
-  ForEachFromDat(country.GetPath(MapFileType::Map), [&](FeatureType & f, uint32_t const & id) {
+  ForEachFeature(country.GetPath(MapFileType::Map), [&](FeatureType & f, uint32_t const & id) {
     if (!routing::IsRoad(TypesHolder(f)))
       return;
 

--- a/tools/python/mwm/exceptions.py
+++ b/tools/python/mwm/exceptions.py
@@ -2,5 +2,5 @@ class MwmError(Exception):
     pass
 
 
-class DatSectionParseError(MwmError):
+class FeaturesSectionParseError(MwmError):
     pass

--- a/traffic/traffic_info.cpp
+++ b/traffic/traffic_info.cpp
@@ -184,7 +184,7 @@ SpeedGroup TrafficInfo::GetSpeedGroup(RoadSegmentId const & id) const
 void TrafficInfo::ExtractTrafficKeys(string const & mwmPath, vector<RoadSegmentId> & result)
 {
   result.clear();
-  feature::ForEachFromDat(mwmPath, [&](FeatureType & ft, uint32_t const fid) {
+  feature::ForEachFeature(mwmPath, [&](FeatureType & ft, uint32_t const fid) {
     if (!routing::CarModel::AllLimitsInstance().IsRoad(ft))
       return;
 


### PR DESCRIPTION
Увеличение версии mwm -- хороший повод чтобы переименовать dat в features, тем более формат секции тоже поменялся.

ForEachFeature кажется гораздо лучше отражает суть чем ForEachFromDat.