### PR TITLE
[routing] Crash fix for reading zero version of section roadaccess.

### DIFF
--- a/routing/road_access_serialization.cpp
+++ b/routing/road_access_serialization.cpp
@@ -8,6 +8,7 @@ std::string DebugPrint(RoadAccessSerializer::Header const & header)
 {
   switch (header)
   {
+  case RoadAccessSerializer::Header::TheFirstVersionRoadAccess: return "TheFirstVersionRoadAccess";
   case RoadAccessSerializer::Header::WithoutAccessConditional: return "WithoutAccessConditional";
   case RoadAccessSerializer::Header::WithAccessConditional: return "WithAccessConditional";
   }

--- a/routing/road_access_serialization.hpp
+++ b/routing/road_access_serialization.hpp
@@ -43,8 +43,9 @@ public:
 
   enum class Header
   {
-    WithoutAccessConditional = 1,
-    WithAccessConditional = 2
+    TheFirstVersionRoadAccess = 0, // Version of section roadaccess in 2017.
+    WithoutAccessConditional = 1,  // Section roadaccess before conditional was implemented.
+    WithAccessConditional = 2      // Section roadaccess with conditional.
   };
 
   RoadAccessSerializer() = delete;
@@ -67,6 +68,8 @@ public:
     CHECK_LESS_OR_EQUAL(header, kLatestVersion, ());
     switch (header)
     {
+    case Header::TheFirstVersionRoadAccess:
+      break; // Version of 2017. Unsupported.
     case Header::WithoutAccessConditional:
     {
       DeserializeAccess(src, vehicleType, roadAccess);


### PR DESCRIPTION
Crash fix: https://fabric.io/mapsme/android/apps/com.mapswithme.maps.pro/issues/839fceb4c295a1831f6aefbb193ba68f?time=last-ninety-days

Теперь мы снова прокладываем маршруты по картам 170728 и более поздним.

@mesozoic-drones @tatiana-yan PTAL