### PR TITLE
[routing] Fix for SIGSEGV crash in FeaturesRoadGraph::RoadInfoCache.

### DIFF
--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -107,6 +107,7 @@ void FeaturesRoadGraph::CrossCountryVehicleModel::Clear()
 
 IRoadGraph::RoadInfo & FeaturesRoadGraph::RoadInfoCache::Find(FeatureID const & featureId, bool & found)
 {
+  std::lock_guard lock(m_mutexCache);
   auto res = m_cache.emplace(featureId.m_mwmId, TMwmFeatureCache());
   if (res.second)
     res.first->second.Init(kPowOfTwoForFeatureCacheSize);
@@ -115,8 +116,10 @@ IRoadGraph::RoadInfo & FeaturesRoadGraph::RoadInfoCache::Find(FeatureID const & 
 
 void FeaturesRoadGraph::RoadInfoCache::Clear()
 {
+  std::lock_guard lock(m_mutexCache);
   m_cache.clear();
 }
+
 FeaturesRoadGraph::FeaturesRoadGraph(DataSource const & dataSource, IRoadGraph::Mode mode,
                                      shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory)
   : m_dataSource(dataSource), m_mode(mode), m_vehicleModel(vehicleModelFactory)

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -129,7 +129,6 @@ private:
 
   DataSource const & m_dataSource;
   IRoadGraph::Mode const m_mode;
-
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable std::map<MwmSet::MwmId, Value> m_mwmLocks;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -64,6 +65,8 @@ private:
 
   private:
     using TMwmFeatureCache = base::Cache<uint32_t, RoadInfo>;
+
+    std::mutex m_mutexCache;
     std::map<MwmSet::MwmId, TMwmFeatureCache> m_cache;
   };
 
@@ -126,6 +129,7 @@ private:
 
   DataSource const & m_dataSource;
   IRoadGraph::Mode const m_mode;
+
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable std::map<MwmSet::MwmId, Value> m_mwmLocks;


### PR DESCRIPTION
Как в среднем выглядит верхушка стека креша:

`base::Cache<unsigned int, routing::IRoadGraph::RoadInfo>::Find
routing::FeaturesRoadGraph::GetCachedRoadInfo
DataSource::ForEachInRect
routing::FeaturesRoadGraph::FindClosestEdges
routing::IndexRouter::FindClosestProjectionToRoad
routing::RoutingSession::MatchLocationToRoadGraph`

[Креш в firebase](https://console.firebase.google.com/u/1/project/mapsmestats/crashlytics/app/android:com.mapswithme.maps.pro/issues/5409b42e33e4cd568a309f6343d0d0b6?time=last-seven-days&sessionId=5ea0181c037b00016a5f1e42c1dc2c9c_DNE_0_v2)

Ловим segmentation fault при обращении к не инициализированному кешу в методе `FeaturesRoadGraph::RoadInfoCache::Find`:
`return res.first->second.Find(featureId.m_index, found);`

**Причина:** race condition. Обращения к FeaturesRoadGraph::RoadInfoCache происходят из двух потоков - потока роутнига (в режиме построения маршрута) и UI-потока (в режиме ведения). Хотя этот race condition существует уже давно, проявляться крешами он стал только в последней версии, потому что в ней из потока роутинга участилось обращение к кешу через `m_roadGraph.FindClosestEdges().`

<img width="1316" alt="Screenshot 2020-04-23 at 11 06 47" src="https://user-images.githubusercontent.com/54934129/80082348-eb562c00-855c-11ea-9e79-1b429035c4b5.png">

<img width="1249" alt="Screenshot 2020-04-23 at 11 14 27" src="https://user-images.githubusercontent.com/54934129/80082384-f7da8480-855c-11ea-86bc-df11d1346d3b.png">


**Лечение:** в качестве быстрого фикса кеш обложен мьютексом. На перспективу планируем переделать поток роутинга на очередь сообщений.
