### PR TITLE
[search] LocalityScorer: prefer localities from matched regions.

### DIFF
--- a/search/locality_scorer.hpp
+++ b/search/locality_scorer.hpp
@@ -33,6 +33,7 @@ public:
     virtual void GetNames(uint32_t featureId, std::vector<std::string> & names) const = 0;
     virtual uint8_t GetRank(uint32_t featureId) const = 0;
     virtual std::optional<m2::PointD> GetCenter(uint32_t featureId) = 0;
+    virtual bool BelongsToMatchedRegion(m2::PointD const & p) const = 0;
   };
 
   LocalityScorer(QueryParams const & params, m2::PointD const & pivot, Delegate & delegate);
@@ -56,6 +57,7 @@ private:
     double m_similarity = 0.0;
     uint8_t m_rank = 0;
     double m_distanceToPivot = std::numeric_limits<double>::max();
+    bool m_belongsToMatchedRegion = false;
   };
 
   friend std::string DebugPrint(ExLocality const & locality);
@@ -72,12 +74,12 @@ private:
   void LeaveTopByExactMatchNormAndRank(size_t limitUniqueIds, std::vector<ExLocality> & els) const;
 
   // Leaves at most |limit| unique best localities by similarity and matched tokens range size. For
-  // elements with the same similarity and matched range size selects the closest one (by distance to
-  // pivot), rest of elements are sorted by rank.
+  // elements with the same similarity and matched range size prefers localities from already
+  // matched regions, then the closest one (by distance to pivot), rest of elements are sorted by
+  // rank.
   void LeaveTopBySimilarityAndOther(size_t limit, std::vector<ExLocality> & els) const;
 
   void GetDocVecs(uint32_t localityId, std::vector<DocVec> & dvs) const;
-  double GetDistanceToPivot(uint32_t localityId);
   double GetSimilarity(QueryVec & qv, IdfMap & docIdfs, std::vector<DocVec> & dvs) const;
 
   QueryParams const & m_params;


### PR DESCRIPTION
Реквест поверх https://github.com/mapsme/omim/pull/12982

Предлагается предпочитать localities из уже заматченых регионов.

На размеченной выборке нету отличий ни в количестве результатов ни в скорости работы.
По профайлеру вижу что в FillLocalitiesTable проводим на 20% больше времени, но это всё равно в районе 0.03% от времени поиска.

Теперь работают запросы типа Springfield Tennessee, San Francisco Columbia, San Antonio  Venezuela и т.п.
Правда, есть ещё такой не работающий юз-кейс:
<img width="663" alt="Screenshot 2020-04-23 at 18 19 27" src="https://user-images.githubusercontent.com/9213190/80121207-ab12a000-8594-11ea-90ee-ba49ab867cd6.png">
<img width="663" alt="Screenshot 2020-04-23 at 18 19 38" src="https://user-images.githubusercontent.com/9213190/80121217-aea62700-8594-11ea-9a01-490a84514ec1.png">
<img width="663" alt="Screenshot 2020-04-23 at 18 19 45" src="https://user-images.githubusercontent.com/9213190/80121220-af3ebd80-8594-11ea-9462-e7caeccb4650.png">


Актуально в основном для штатов для нескольких названий городов которых в стране больше 10 штук (они там любители 88 городов назвать Washington).
Как вариант, можно различать сматчилось ли только state/country или оба. Либо пока забить.