### PR TITLE
[routing] Fix for SIGSEGV crash in FeaturesRoadGraph::RoadInfoCache.

### DIFF
--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -107,6 +107,7 @@ void FeaturesRoadGraph::CrossCountryVehicleModel::Clear()
 
 IRoadGraph::RoadInfo & FeaturesRoadGraph::RoadInfoCache::Find(FeatureID const & featureId, bool & found)
 {
+  std::lock_guard lock(m_mutexCache);
   auto res = m_cache.emplace(featureId.m_mwmId, TMwmFeatureCache());
   if (res.second)
     res.first->second.Init(kPowOfTwoForFeatureCacheSize);
@@ -115,8 +116,10 @@ IRoadGraph::RoadInfo & FeaturesRoadGraph::RoadInfoCache::Find(FeatureID const & 
 
 void FeaturesRoadGraph::RoadInfoCache::Clear()
 {
+  std::lock_guard lock(m_mutexCache);
   m_cache.clear();
 }
+
 FeaturesRoadGraph::FeaturesRoadGraph(DataSource const & dataSource, IRoadGraph::Mode mode,
                                      shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory)
   : m_dataSource(dataSource), m_mode(mode), m_vehicleModel(vehicleModelFactory)

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -129,7 +129,6 @@ private:
 
   DataSource const & m_dataSource;
   IRoadGraph::Mode const m_mode;
-
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable std::map<MwmSet::MwmId, Value> m_mwmLocks;

--- a/routing/features_road_graph.hpp
+++ b/routing/features_road_graph.hpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -64,6 +65,8 @@ private:
 
   private:
     using TMwmFeatureCache = base::Cache<uint32_t, RoadInfo>;
+
+    std::mutex m_mutexCache;
     std::map<MwmSet::MwmId, TMwmFeatureCache> m_cache;
   };
 
@@ -126,6 +129,7 @@ private:
 
   DataSource const & m_dataSource;
   IRoadGraph::Mode const m_mode;
+
   mutable RoadInfoCache m_cache;
   mutable CrossCountryVehicleModel m_vehicleModel;
   mutable std::map<MwmSet::MwmId, Value> m_mwmLocks;


### PR DESCRIPTION
Cherry-pick for #12993 from release-100.