### PR TITLE
[generator] Fix comment, move unused static kInvalidFeatureId to derived class.

### DIFF
--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -25,10 +25,7 @@ public:
   static uint64_t GetCurrentPosition();
   std::string const & GetFilePath() const { return m_dataFile.GetName(); }
   /// \brief Serializes |f|.
-  /// \returns Feature id of serialized feature if |f| is serialized after the call
-  /// and |kInvalidFeatureId| if not.
-  /// \note See implementation operator() in derived class for cases when |f| cannot be
-  /// serialized.
+  /// \returns Feature id of serialized feature.
   virtual uint32_t Collect(FeatureBuilder const & f);
   virtual uint32_t Collect(FeatureBuilder & f)
   {
@@ -37,8 +34,6 @@ public:
   virtual void Finish() {}
 
 protected:
-  static uint32_t constexpr kInvalidFeatureId = std::numeric_limits<uint32_t>::max();
-
   /// \return Feature offset in the file, which is used as an ID later
   uint32_t WriteFeatureBase(std::vector<char> const & bytes, FeatureBuilder const & fb);
   void Flush();

--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -52,6 +52,8 @@ namespace feature
 class FeaturesCollector2 : public FeaturesCollector
 {
 public:
+  static uint32_t constexpr kInvalidFeatureId = std::numeric_limits<uint32_t>::max();
+
   FeaturesCollector2(string const & filename, DataHeader const & header,
                      RegionData const & regionData, uint32_t versionDate)
     : FeaturesCollector(filename + FEATURES_FILE_TAG)


### PR DESCRIPTION
Collect в FeaturesCollector никогда не возвращает kInvalidFeatureId. Если что-то пошло не так, то этого вызова просто не будет.

kInvalidFeatureId используется только в классе-наследнике.