### PR TITLE
[generator] Remove features size check. We already check it when we write features section.

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -73,13 +73,6 @@ public:
     m_addrFile = make_unique<FileWriter>(filename + TEMP_ADDR_FILENAME);
   }
 
-  ~FeaturesCollector2()
-  {
-    // Check file size.
-    auto const unused = CheckedFilePosCast(m_dataFile);
-    UNUSED_VALUE(unused);
-  }
-
   void Finish()
   {
     // write version information


### PR DESCRIPTION
Мы пишем оффсеты для секции features, резмер оффсетов должен помещаться в uint32, поэтому размер секции features не должен превышать 4Гб.

Проверка на это делалась именно в деструкторе FeaturesCollector2, а не FeaturesCollector (хотя только FeaturesCollector пишет m_dataFile), т.к. в FeaturesCollector нет таких ограничений на размер файла -- он пишет и FinalFeatures и MwmTmp, размер MwmTmp не ограничен 4 Гб.

Но в FeaturesCollector2 мы теперь проверяем размер секции features сразу после записи секции, вот тут:

https://github.com/mapsme/omim/blob/61dfcea7b61cf8ec0b1a10c24488ec05c47c2b39/generator/feature_sorter.cpp#L125

поэтому проверка в деструкторе больше не нужна.