### PR TITLE
[drape_frontend] Switch between GPS and compass bearing.

### DIFF
--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -26,7 +26,7 @@ namespace df
 namespace
 {
 int const kPositionRoutingOffsetY = 104;
-double const kMinSpeedThresholdMps = 2.8; // 10 km/h
+double const kMinSpeedThresholdMps = 2.8;  // 10 km/h
 double const kGpsBearingLifetimeSec = 5.0;
 double const kMaxPendingLocationTimeSec = 60.0;
 double const kMaxTimeInBackgroundSec = 60.0 * 60;
@@ -578,7 +578,8 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
   double const oldAzimut = GetDrawableAzimut();
   m_isCompassAvailable = true;
 
-  if ((IsInRouting() && m_isArrowGluedInRouting) || m_lastGPSBearing.ElapsedSeconds() < kGpsBearingLifetimeSec)
+  if ((IsInRouting() && m_isArrowGluedInRouting) ||
+      m_lastGPSBearing.ElapsedSeconds() < kGpsBearingLifetimeSec)
     return;
 
   SetDirection(info.m_bearing);

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -148,7 +148,7 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   , m_enableAutoZoomInRouting(params.m_isAutozoomEnabled)
   , m_autoScale2d(GetScreenScale(kDefaultAutoZoom))
   , m_autoScale3d(m_autoScale2d)
-  , m_lastGPSBearing(false)
+  , m_lastGPSBearingTimer(false)
   , m_lastLocationTimestamp(0.0)
   , m_positionRoutingOffsetY(kPositionRoutingOffsetY)
   , m_isDirtyViewport(false)
@@ -434,7 +434,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   if ((!m_isCompassAvailable || glueArrowInRouting || isMovingFast) && info.HasBearing())
   {
     SetDirection(base::DegToRad(info.m_bearing));
-    m_lastGPSBearing.Reset();
+    m_lastGPSBearingTimer.Reset();
   }
 
   if (m_isPositionAssigned && (!AlmostCurrentPosition(oldPos) || !AlmostCurrentAzimut(oldAzimut)))
@@ -578,8 +578,9 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
   double const oldAzimut = GetDrawableAzimut();
   m_isCompassAvailable = true;
 
-  if ((IsInRouting() && m_isArrowGluedInRouting) ||
-      m_lastGPSBearing.ElapsedSeconds() < kGpsBearingLifetimeSec)
+  bool const existsFreshGpsBearing =
+      m_lastGPSBearingTimer.ElapsedSeconds() < kGpsBearingLifetimeSec;
+  if ((IsInRouting() && m_isArrowGluedInRouting) || existsFreshGpsBearing)
     return;
 
   SetDirection(info.m_bearing);

--- a/drape_frontend/my_position_controller.hpp
+++ b/drape_frontend/my_position_controller.hpp
@@ -188,6 +188,7 @@ private:
   double m_autoScale2d;
   double m_autoScale3d;
 
+  base::Timer m_lastGPSBearing;
   base::Timer m_pendingTimer;
   bool m_pendingStarted = true;
   base::Timer m_routingNotFollowTimer;

--- a/drape_frontend/my_position_controller.hpp
+++ b/drape_frontend/my_position_controller.hpp
@@ -188,7 +188,7 @@ private:
   double m_autoScale2d;
   double m_autoScale3d;
 
-  base::Timer m_lastGPSBearing;
+  base::Timer m_lastGPSBearingTimer;
   base::Timer m_pendingTimer;
   bool m_pendingStarted = true;
   base::Timer m_routingNotFollowTimer;


### PR DESCRIPTION
Этот реквест - фикс бага, на который начали жаловаться начиная с 10.3: если использовать мапсми за рулем, но без построенного маршрута и без режима ведения, то стрелку начинает трясти. Не в машине ни мы, ни QA баг не воспроизвели. В машине его отловил Володя. 
https://jira.mail.ru/browse/MAPSME-13797

**Причина бага** - в изменении правил переключения между двумя источниками угла стрелки: GPS и "компас" (на самом деле теперь это связка компас + гироскоп + акселерометр, что дает максимально плавный и точный угол).

**Как было раньше.** До достижения скорости 3.6 км/ч используется угол компаса. После пересечения этого порога - угол GPS. При снижении скорости происходит переключение обратно на компас. При этом если информация об угле от GPS не поступает более 5 секунд, начинает использоваться угол компаса. Минусы: для пешеходов порог в 3.6 пересекается практически постоянно (и дело не только в реальной скорости, но и в погрешностях GPS). Поэтому раз в 5-20 секунд стрелка "дергается" между углом GPS и углом компаса. Из-за таймаута в 5 секунд между переключениями источников перед подергиванием стрелки часто происходит фриз на несколько секунд. Кроме того, на низких скоростях угол GPS значительно менее точный, чем угол компаса. В общем для аутдора смешение двух источников ведет к низкому качеству ориентирования по стрелке.

**Как есть сейчас.** Правила переключения по порогу скорости и таймауту убраны. Для пешехода стрелка стала плавной и предсказуемой. #12344. Но если ориентироваться по ней, находясь за рулем машины, не прокладывая маршрут и не включая режим ведения, то стрелку колбасит. Причина - магнитные девиации из-за присутствия большого количества металлов, проводов и электроники. Это усугубляется тряской машины и положением смартфона под произвольным углом, от чего может складываться впечатление, что стрелка перевернута на 180 градусов. Такая тряска стрелки при вождении машины - большой минус. 

**Фикс.** Решено вернуть порог скорости, но поставить его в 10 км/ч, чтобы он не влиял на юзер экспириенс аутдорщиков. Соответственно возвращается и таймаут переключения между углом GPS и компаса.