### PR TITLE
buildsystem: explicitly disable skipping of desktop build

### DIFF
--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -61,6 +61,9 @@ while getopts ":cdrstagjp:" opt; do
   esac
 done
 
+[ -z "$OPT_SKIP_DESKTOP" ] &&
+CMAKE_CONFIG="${CMAKE_CONFIG:-} -DSKIP_DESKTOP=OFF"
+
 [ -n "$OPT_DESIGNER" -a -n "$OPT_SKIP_DESKTOP" ] &&
 echo "Can't skip desktop and build designer tool simultaneously" &&
 exit 2


### PR DESCRIPTION
to override value in CMakeCache.txt