### PR TITLE
[vulkan] rearrange locations of attributes for outlined gui text MAPSME-13322

### DIFF
--- a/drape_frontend/gui/gui_text.cpp
+++ b/drape_frontend/gui/gui_text.cpp
@@ -93,11 +93,11 @@ dp::BindingInfo const & StaticLabel::Vertex::GetBindingInfo()
 
     FillPositionDecl(info->GetBindingDecl(0), stride, offset);
     offset += sizeof(glsl::vec3);
-    FillNormalDecl(info->GetBindingDecl(1), stride, offset);
+    FillColorDecl(info->GetBindingDecl(1), stride, offset);
     offset += sizeof(glsl::vec2);
-    FillColorDecl(info->GetBindingDecl(2), stride, offset);
+    FillOutlineDecl(info->GetBindingDecl(2), stride, offset);
     offset += sizeof(glsl::vec2);
-    FillOutlineDecl(info->GetBindingDecl(3), stride, offset);
+    FillNormalDecl(info->GetBindingDecl(3), stride, offset);
     offset += sizeof(glsl::vec2);
     FillMaskDecl(info->GetBindingDecl(4), stride, offset);
     ASSERT_EQUAL(offset + sizeof(glsl::vec2), stride, ());
@@ -192,7 +192,7 @@ void StaticLabel::CacheStaticText(std::string const & text, char const * delim,
       glsl::vec3 position = glsl::vec3(0.0, 0.0, depth);
 
       for (size_t v = 0; v < normals.size(); ++v)
-        rb.push_back(Vertex(position, pen + normals[v], colorTex, outlineTex, maskTex[v]));
+        rb.push_back(Vertex(position, colorTex, outlineTex, pen + normals[v], maskTex[v]));
 
       float const advance = glyph.GetAdvanceX() * textRatio;
       prevLineHeight = std::max(prevLineHeight, offsets.y + glyph.GetPixelHeight() * textRatio);

--- a/drape_frontend/gui/gui_text.hpp
+++ b/drape_frontend/gui/gui_text.hpp
@@ -26,21 +26,21 @@ public:
   struct Vertex
   {
     Vertex() = default;
-    Vertex(glsl::vec3 const & pos, glsl::vec2 const & normal, glsl::vec2 const & color,
-           glsl::vec2 const & outline, glsl::vec2 const & mask)
+    Vertex(glsl::vec3 const & pos, glsl::vec2 const & color, glsl::vec2 const & outline,
+           glsl::vec2 const & normal, glsl::vec2 const & mask)
       : m_position(pos)
-      , m_normal(normal)
       , m_colorTexCoord(color)
       , m_outlineColorTexCoord(outline)
+      , m_normal(normal)
       , m_maskTexCoord(mask)
     {}
 
     static dp::BindingInfo const & GetBindingInfo();
 
     glsl::vec3 m_position;
-    glsl::vec2 m_normal;
     glsl::vec2 m_colorTexCoord;
     glsl::vec2 m_outlineColorTexCoord;
+    glsl::vec2 m_normal;
     glsl::vec2 m_maskTexCoord;
   };
 


### PR DESCRIPTION
[Порядок](https://github.com/mapsme/omim/blob/0979af18e4494769fd635e9eec626b87c5dd3587/drape_frontend/gui/gui_text.cpp#L94-L103) `dp::BindingDecl` атрибутов в `dp::BindingInfo` должен совпадать с [порядком деклараций](https://github.com/mapsme/omim/blob/0979af18e4494769fd635e9eec626b87c5dd3587/shaders/GL/text_outlined_gui.vsh.glsl#L1-L5) в шейдере, т.к. во вулкановском графическом пайплайне порядок перечесления локаций [жёстко задан](https://github.com/mapsme/omim/blob/0979af18e4494769fd635e9eec626b87c5dd3587/drape/vulkan/vulkan_pipeline.cpp#L355) порядком следования биндингов буфферов аттрибутов вершин (всегда сначала static, затем dynamic, если есть) и номерами деклараций (аргументом `dp::BindingInfo::GetBindingDecl`).

@darina PTAL

https://jira.mail.ru/browse/MAPSME-13322