### PR TITLE
[routing] Fixing unspecified cases and code refactoring

### DIFF
--- a/routing/routing_quality/routing_quality_tool/error_type_counter.cpp
+++ b/routing/routing_quality/routing_quality_tool/error_type_counter.cpp
@@ -14,8 +14,8 @@ void ErrorTypeCounter::PushError(api::ResultCode code)
   routing::RouterResultCode routingCode = routing::RouterResultCode::InternalError;
   switch (code)
   {
-  case api::ResultCode::ResponseOK: routingCode = routing::RouterResultCode::NoError;
-  case api::ResultCode::Error: routingCode = routing::RouterResultCode::RouteNotFound;
+  case api::ResultCode::ResponseOK: routingCode = routing::RouterResultCode::NoError; break;
+  case api::ResultCode::Error: routingCode = routing::RouterResultCode::RouteNotFound; break;
   }
   CHECK_NOT_EQUAL(routingCode, routing::RouterResultCode::InternalError,
                   ("Wrong value of api::ResultCode:", static_cast<int>(code)));

--- a/routing/routing_quality/routing_quality_tool/error_type_counter.cpp
+++ b/routing/routing_quality/routing_quality_tool/error_type_counter.cpp
@@ -1,5 +1,7 @@
 #include "routing/routing_quality/routing_quality_tool/error_type_counter.hpp"
 
+#include "base/assert.hpp"
+
 namespace routing_quality::routing_quality_tool
 {
 void ErrorTypeCounter::PushError(routing::RouterResultCode code)
@@ -9,13 +11,14 @@ void ErrorTypeCounter::PushError(routing::RouterResultCode code)
 
 void ErrorTypeCounter::PushError(api::ResultCode code)
 {
-  routing::RouterResultCode routingCode;
+  routing::RouterResultCode routingCode = routing::RouterResultCode::InternalError;
   switch (code)
   {
   case api::ResultCode::ResponseOK: routingCode = routing::RouterResultCode::NoError;
   case api::ResultCode::Error: routingCode = routing::RouterResultCode::RouteNotFound;
   }
-  routingCode = routing::RouterResultCode::InternalError;
+  CHECK_NOT_EQUAL(routingCode, routing::RouterResultCode::InternalError,
+                  ("Wrong value of api::ResultCode:", static_cast<int>(code)));
   PushError(routingCode);
 }
 

--- a/routing/routing_tests/turns_sound_test.cpp
+++ b/routing/routing_tests/turns_sound_test.cpp
@@ -94,22 +94,16 @@ UNIT_TEST(TurnNotificationSettingsNotValidTest)
 
 UNIT_TEST(TurnsSoundMetersTest)
 {
-  NotificationManager notificationManager(5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */,
-                                          100 /* maxStartBeforeMeters */,
-                                          100 /* minDistToSayNotificationMeters */);
-  notificationManager.Enable(true);
-  notificationManager.SetLengthUnits(measurement_utils::Units::Metric);
   string const engShortJson =
       "\
       {\
       \"in_600_meters\":\"In 600 meters.\",\
       \"make_a_right_turn\":\"Make a right turn.\"\
       }";
-  notificationManager.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  notificationManager.m_settings.ForTestingSetNotificationTimeSecond(20);
-
-  notificationManager.Reset();
-  notificationManager.SetSpeedMetersPerSecond(30.);
+  auto notificationManager = NotificationManager::CreateNotificationManagerForTesting(
+      5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */, 100 /* maxStartBeforeMeters */,
+      100 /* minDistToSayNotificationMeters */, measurement_utils::Units::Metric, engShortJson,
+      20 /* notificationTimeSecond */, 30.0 /* speedMeterPerSecond */);
 
   vector<TurnItemDist> turns = {{{5 /* idx */, CarDirection::TurnRight}, 1000.}};
   vector<string> turnNotifications;
@@ -192,11 +186,6 @@ UNIT_TEST(TurnsSoundMetersTest)
 // So the first notification of the second turn shall be skipped.
 UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
 {
-  NotificationManager notificationManager(5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */,
-                                          100 /* maxStartBeforeMeters */,
-                                          100 /* minDistToSayNotificationMeters */);
-  notificationManager.Enable(true);
-  notificationManager.SetLengthUnits(measurement_utils::Units::Metric);
   string const engShortJson =
       "\
       {\
@@ -204,11 +193,10 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
       \"make_a_sharp_right_turn\":\"Make a sharp right turn.\",\
       \"enter_the_roundabout\":\"Enter the roundabout.\"\
       }";
-  notificationManager.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  notificationManager.m_settings.ForTestingSetNotificationTimeSecond(20);
-
-  notificationManager.Reset();
-  notificationManager.SetSpeedMetersPerSecond(35.);
+  auto notificationManager = NotificationManager::CreateNotificationManagerForTesting(
+      5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */, 100 /* maxStartBeforeMeters */,
+      100 /* minDistToSayNotificationMeters */, measurement_utils::Units::Metric, engShortJson,
+      20 /* notificationTimeSecond */, 35.0 /* speedMeterPerSecond */);
 
   vector<TurnItemDist> turns = {{{5 /* idx */, CarDirection::TurnSharpRight}, 800.}};
   vector<string> turnNotifications;
@@ -269,22 +257,16 @@ UNIT_TEST(TurnsSoundMetersTwoTurnsTest)
 
 UNIT_TEST(TurnsSoundFeetTest)
 {
-  NotificationManager notificationManager(5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */,
-                                          100 /* maxStartBeforeMeters */,
-                                          100 /* minDistToSayNotificationMeters */);
-  notificationManager.Enable(true);
-  notificationManager.SetLengthUnits(measurement_utils::Units::Imperial);
   string const engShortJson =
       "\
       {\
       \"in_2000_feet\":\"In 2000 feet.\",\
       \"enter_the_roundabout\":\"Enter the roundabout.\"\
       }";
-  notificationManager.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  notificationManager.m_settings.ForTestingSetNotificationTimeSecond(20);
-
-  notificationManager.Reset();
-  notificationManager.SetSpeedMetersPerSecond(30.);
+  auto notificationManager = NotificationManager::CreateNotificationManagerForTesting(
+      5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */, 100 /* maxStartBeforeMeters */,
+      100 /* minDistToSayNotificationMeters */, measurement_utils::Units::Imperial, engShortJson,
+      20 /* notificationTimeSecond */, 30.0 /* speedMeterPerSecond */);
 
   vector<TurnItemDist> turns = {{{7 /* idx */, CarDirection::EnterRoundAbout,
                                   3 /* exitNum */}, 1000.}};
@@ -352,11 +334,6 @@ UNIT_TEST(TurnsSoundFeetTest)
 
 UNIT_TEST(TurnsSoundComposedTurnTest)
 {
-  NotificationManager notificationManager(5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */,
-                                          100 /* maxStartBeforeMeters */,
-                                          100 /* minDistToSayNotificationMeters */);
-  notificationManager.Enable(true);
-  notificationManager.SetLengthUnits(measurement_utils::Units::Metric);
   string const engShortJson =
       "\
       {\
@@ -366,11 +343,11 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
       \"then\":\"Then.\",\
       \"you_have_reached_the_destination\":\"You have reached the destination.\"\
       }";
-  notificationManager.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  notificationManager.m_settings.ForTestingSetNotificationTimeSecond(30);
+  auto notificationManager = NotificationManager::CreateNotificationManagerForTesting(
+      5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */, 100 /* maxStartBeforeMeters */,
+      100 /* minDistToSayNotificationMeters */, measurement_utils::Units::Metric, engShortJson,
+      30.0 /* notificationTimeSecond */, 20.0 /* speedMeterPerSecond */);
 
-  notificationManager.Reset();
-  notificationManager.SetSpeedMetersPerSecond(20.);
   vector<string> turnNotifications;
 
   // Starting nearing the first turn.
@@ -429,11 +406,6 @@ UNIT_TEST(TurnsSoundComposedTurnTest)
 
 UNIT_TEST(TurnsSoundRoundaboutTurnTest)
 {
-  NotificationManager notificationManager(5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */,
-                                          100 /* maxStartBeforeMeters */,
-                                          100 /* minDistToSayNotificationMeters */);
-  notificationManager.Enable(true);
-  notificationManager.SetLengthUnits(measurement_utils::Units::Metric);
   string const engShortJson =
       "\
       {\
@@ -445,11 +417,11 @@ UNIT_TEST(TurnsSoundRoundaboutTurnTest)
       \"in_600_meters\":\"In 600 meters.\",\
       \"then\":\"Then.\"\
       }";
-  notificationManager.m_getTtsText.ForTestingSetLocaleWithJson(engShortJson, "en");
-  notificationManager.m_settings.ForTestingSetNotificationTimeSecond(30);
+  auto notificationManager = NotificationManager::CreateNotificationManagerForTesting(
+      5 /* startBeforeSeconds */, 10 /* minStartBeforeMeters */, 100 /* maxStartBeforeMeters */,
+      100 /* minDistToSayNotificationMeters */, measurement_utils::Units::Metric, engShortJson,
+      30 /* notificationTimeSecond */, 20.0 /* speedMeterPerSecond */);
 
-  notificationManager.Reset();
-  notificationManager.SetSpeedMetersPerSecond(20.);
   vector<string> turnNotifications;
 
   // Starting nearing the first turn.

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -36,14 +36,15 @@ namespace turns
 namespace sound
 {
 NotificationManager::NotificationManager()
-    : m_enabled(false)
-    , m_speedMetersPerSecond(0.0)
-    , m_settings(8 /* m_startBeforeSeconds */, 35 /* m_minStartBeforeMeters */,
-                 150 /* m_maxStartBeforeMeters */, 170 /* m_minDistToSayNotificationMeters */)
-    , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
-    , m_turnNotificationWithThen(false)
-    , m_nextTurnIndex(0)
-    , m_secondTurnNotification(CarDirection::None)
+  : m_enabled(false)
+  , m_speedMetersPerSecond(0.0)
+  , m_settings(8 /* m_startBeforeSeconds */, 35 /* m_minStartBeforeMeters */,
+               150 /* m_maxStartBeforeMeters */, 170 /* m_minDistToSayNotificationMeters */)
+  , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
+  , m_turnNotificationWithThen(false)
+  , m_nextTurnIndex(0)
+  , m_secondTurnNotification(CarDirection::None)
+  , m_secondTurnNotificationIndex(0)
 {
 }
 

--- a/routing/turns_notification_manager.hpp
+++ b/routing/turns_notification_manager.hpp
@@ -22,118 +22,23 @@ enum class PronouncedNotification
 {
   Nothing,
   First,
-  Second /** The second notification just before the turn was pronounced. */
+  Second, /** The second notification just before the turn was pronounced. */
 };
 
-std::string DebugPrint(PronouncedNotification const notificationProgress);
+std::string DebugPrint(PronouncedNotification notificationProgress);
 
 /// \brief The TurnsSound class is responsible for all route turn sound notifications functionality.
 /// To be able to generate turn sound notification the class needs to have correct Settings
 /// and relevant speed.
 class NotificationManager
 {
-  friend void UnitTest_TurnsSoundMetersTest();
-  friend void UnitTest_TurnsSoundMetersTwoTurnsTest();
-  friend void UnitTest_TurnsSoundFeetTest();
-  friend void UnitTest_TurnsSoundComposedTurnTest();
-  friend void UnitTest_TurnsSoundRoundaboutTurnTest();
-
-  /// \brief The private constructor is used only for testing.
-  NotificationManager(uint32_t startBeforeSeconds, uint32_t minStartBeforeMeters,
-                      uint32_t maxStartBeforeMeters, uint32_t minDistToSayNotificationMeters)
-    : m_enabled(false)
-    , m_speedMetersPerSecond(0.)
-    , m_settings(startBeforeSeconds, minStartBeforeMeters, maxStartBeforeMeters,
-                 minDistToSayNotificationMeters)
-    , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
-    , m_turnNotificationWithThen(false)
-    , m_nextTurnIndex(0)
-    , m_secondTurnNotification(CarDirection::None)
-  {
-  }
-
-  /// m_enabled == true when tts is turned on.
-  /// Important! Clients (iOS/Android) implies that m_enabled is false by default.
-  bool m_enabled;
-
-  /// In m_speedMetersPerSecond is intended for some speed which will be used for
-  /// convertion a distance in seconds to distance in meters. It could be a current
-  /// an end user speed or an average speed for last several seconds.
-  /// @TODO(vbykoianko) It's better to use an average speed
-  /// for last several seconds instead of the current speed here.
-  double m_speedMetersPerSecond;
-
-  Settings m_settings;
-
-  /// m_nextTurnNotificationProgress keeps a status which is being changing while
-  /// an end user is coming to the closest (the next) turn along the route.
-  /// When an end user is far from the next turn
-  /// m_nextTurnNotificationProgress == Nothing.
-  /// After the first turn notification has been pronounced
-  /// m_nextTurnNotificationProgress == First.
-  /// After the second notification has been pronounced
-  /// m_nextTurnNotificationProgress == Second.
-  PronouncedNotification m_nextTurnNotificationProgress;
-
-  /// The flag is set to true if notification about the second turn was pronounced.
-  /// It could happen in expressions like "Turn right. Then turn left."
-  /// This flag is used to pass the information if second turn notification was pronounced
-  /// between two calls of GenerateTurnNotifications() method.
-  bool m_turnNotificationWithThen;
-
-  uint32_t m_nextTurnIndex;
-
-  /// getTtsText is a convector form turn notification information and locale to
-  /// notification string.
-  GetTtsText m_getTtsText;
-
-  /// if m_secondTurnNotification == true it's time to display the second turn notification
-  /// visual informer, and false otherwise.
-  /// m_secondTurnNotification is a direction of the turn after the closest one
-  /// if an end user shall be informed about it. If not, m_secondTurnNotification ==
-  /// TurnDirection::NoTurn
-  CarDirection m_secondTurnNotification;
-
-  /// m_secondTurnNotificationIndex is an index of the closest turn on the route polyline
-  /// where m_secondTurnNotification was set to true last time for a turn.
-  /// If the closest turn is changed m_secondTurnNotification is set to 0.
-  /// \note 0 is a valid index. But in this context it could be considered as invalid
-  /// because if firstTurnIndex == 0 that means we're at very beginning of the route
-  /// and we're about to making a turn. In that case it's no use to inform a user about
-  /// the turn after the next one.
-  uint32_t m_secondTurnNotificationIndex;
-
-  std::string GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
-                               CarDirection turnDir, measurement_utils::Units lengthUnits) const;
-
-  /// Generates turn sound notification for the nearest to the current position turn.
-  std::string GenerateFirstTurnSound(TurnItem const & turn, double distanceToTurnMeters);
-
-  /// Changes the state of the class to emulate that first turn notification is pronounced
-  /// without pronunciation.
-  void FastForwardFirstTurnNotification();
-
-  /// \param turns contains information about the next turns staring from closest turn.
-  /// That means turns[0] is the closest turn (if available).
-  /// @return the second closest turn or TurnDirection::NoTurn.
-  /// \note If GenerateSecondTurnNotification returns a value different form TurnDirection::NoTurn
-  /// for a turn once it will return the same value until the turn is changed.
-  /// \note This method works independent from m_enabled value.
-  /// So it works when the class enable and disable.
-  CarDirection GenerateSecondTurnNotification(std::vector<TurnItemDist> const & turns);
-
 public:
-  NotificationManager()
-    : m_enabled(false)
-    , m_speedMetersPerSecond(0.)
-    , m_settings(8 /* m_startBeforeSeconds */, 35 /* m_minStartBeforeMeters */,
-                 150 /* m_maxStartBeforeMeters */, 170 /* m_minDistToSayNotificationMeters */)
-    , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
-    , m_turnNotificationWithThen(false)
-    , m_nextTurnIndex(0)
-    , m_secondTurnNotification(CarDirection::None)
-  {
-  }
+  NotificationManager();
+
+  static NotificationManager CreateNotificationManagerForTesting(
+      uint32_t startBeforeSeconds, uint32_t minStartBeforeMeters, uint32_t maxStartBeforeMeters,
+      uint32_t minDistToSayNotificationMeters, measurement_utils::Units lengthUnits,
+      std::string const & engShortJson, uint32_t notificationTimeSecond, double speedMeterPerSecond);
 
   bool IsEnabled() const { return m_enabled; }
   void Enable(bool enable);
@@ -181,6 +86,77 @@ public:
   /// \note This method works independent from m_enabled value.
   /// So it works when the class enable and disable.
   CarDirection GetSecondTurnNotification() const { return m_secondTurnNotification; }
+
+private:
+  std::string GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
+                               CarDirection turnDir, measurement_utils::Units lengthUnits) const;
+
+  /// Generates turn sound notification for the nearest to the current position turn.
+  std::string GenerateFirstTurnSound(TurnItem const & turn, double distanceToTurnMeters);
+
+  /// Changes the state of the class to emulate that first turn notification is pronounced
+  /// without pronunciation.
+  void FastForwardFirstTurnNotification();
+
+  /// \param turns contains information about the next turns staring from closest turn.
+  /// That means turns[0] is the closest turn (if available).
+  /// @return the second closest turn or TurnDirection::NoTurn.
+  /// \note If GenerateSecondTurnNotification returns a value different form TurnDirection::NoTurn
+  /// for a turn once it will return the same value until the turn is changed.
+  /// \note This method works independent from m_enabled value.
+  /// So it works when the class enable and disable.
+  CarDirection GenerateSecondTurnNotification(std::vector<TurnItemDist> const & turns);
+
+  /// m_enabled == true when tts is turned on.
+  /// Important! Clients (iOS/Android) implies that m_enabled is false by default.
+  bool m_enabled;
+
+  /// In m_speedMetersPerSecond is intended for some speed which will be used for
+  /// conversion a distance in seconds to distance in meters. It could be a current
+  /// an end user speed or an average speed for last several seconds.
+  /// @TODO(bykoianko) It's better to use an average speed
+  /// for last several seconds instead of the current speed here.
+  double m_speedMetersPerSecond;
+
+  Settings m_settings;
+
+  /// m_nextTurnNotificationProgress keeps a status which is being changing while
+  /// an end user is coming to the closest (the next) turn along the route.
+  /// When an end user is far from the next turn
+  /// m_nextTurnNotificationProgress == Nothing.
+  /// After the first turn notification has been pronounced
+  /// m_nextTurnNotificationProgress == First.
+  /// After the second notification has been pronounced
+  /// m_nextTurnNotificationProgress == Second.
+  PronouncedNotification m_nextTurnNotificationProgress;
+
+  /// The flag is set to true if notification about the second turn was pronounced.
+  /// It could happen in expressions like "Turn right. Then turn left."
+  /// This flag is used to pass the information if second turn notification was pronounced
+  /// between two calls of GenerateTurnNotifications() method.
+  bool m_turnNotificationWithThen;
+
+  uint32_t m_nextTurnIndex;
+
+  /// getTtsText is a convector form turn notification information and locale to
+  /// notification string.
+  GetTtsText m_getTtsText;
+
+  /// if m_secondTurnNotification == true it's time to display the second turn notification
+  /// visual informer, and false otherwise.
+  /// m_secondTurnNotification is a direction of the turn after the closest one
+  /// if an end user shall be informed about it. If not, m_secondTurnNotification ==
+  /// TurnDirection::NoTurn
+  CarDirection m_secondTurnNotification;
+
+  /// m_secondTurnNotificationIndex is an index of the closest turn on the route polyline
+  /// where m_secondTurnNotification was set to true last time for a turn.
+  /// If the closest turn is changed m_secondTurnNotification is set to 0.
+  /// \note 0 is a valid index. But in this context it could be considered as invalid
+  /// because if firstTurnIndex == 0 that means we're at very beginning of the route
+  /// and we're about to making a turn. In that case it's no use to inform a user about
+  /// the turn after the next one.
+  uint32_t m_secondTurnNotificationIndex;
 };
 }  // namespace sound
 }  // namespace turns


### PR DESCRIPTION
Смотреть имеет смысл по комитам.
1. Поправил переинициализированную переменную;
2. Упростил код;
3. Определил неспецифицированную переменную;

@mesozoic-drones @mpimenov PTAL