### PR TITLE
[routing] Removing RoutingQuality_NoLoop_MoscowToKazan because it gives two edges with the same weight.

### DIFF
--- a/routing/routing_quality/routing_quality_tests/leaps_postprocessing_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/leaps_postprocessing_tests.cpp
@@ -13,13 +13,6 @@ using namespace std;
 
 namespace
 {
-UNIT_TEST(RoutingQuality_NoLoop_MoscowToKazan)
-{
-  TEST(!CheckCarRoute({55.63113, 37.63054} /* start */, {55.67914, 52.37389} /* finish */,
-                      {{{55.80643, 37.83981}}} /* reference point */),
-       ());
-}
-
 UNIT_TEST(RoutingQuality_NoLoop_Canada)
 {
   TEST(!CheckCarRoute({53.53540, -113.50798} /* start */, {69.44402, -133.03189} /* finish */,


### PR DESCRIPTION
Я решил удалить этот тест и вместо него поставить тикет:
https://jira.mail.ru/browse/MAPSME-13865. 

Кратко причины:
- этот тест попадает воспроизводит ошибку на особом случае, в котором я разобрался и эта ошибка не должна исправляться `LeapsPostProcessor`;
- на `LeapsPostProcessor` имеется еще 12 тестов, т.е. проверка достаточна;

Причины детально:
При меж mwm-ом роутинге иногда возникает ситуация, при которой старт и два выхода из mwm соединяется дугами одного веса и оба выхода находятся в одной точке. Например, если из Москвы нужно выехать по Шоссе Энтузиастов, то при меж mwm-ом роутинге, старт будет соединен с этим выходом двумя дугами одинакового веса. Вес одинаковый, поскольку эти дуги приходят в одну точку.
![image](https://user-images.githubusercontent.com/1768114/82217443-18f78080-9923-11ea-83df-86f754e24bc7.png)

Т.е. вес дуги от сегмента старта (где бы он не находился в Москве) и до переходных сегментов 3190 и 17786 одинаков. Но маршруты проходящие через эти сегменты будут принципиально различаться. Через сегмент 3190 не будет давать петлю при движении с юга Москвы, но через 17786 будет. Поскольку, чтоб проехать по одностороннему сегменту 17786 нужно заезжать по МКАД с севера. Как следствие, при выборе сегмента 17786 получается примерно такая петля на маршруте:
![image](https://user-images.githubusercontent.com/1768114/82217600-50fec380-9923-11ea-81d6-82d8687cb4cb.png)

Хуже того. Маршрут может идти иногда через 17786, а иногда через 3190. Поскольку это маршруты одинакового веса. В данный момент, на Мак идет через сегмент 3190, а на Linux через 17786.

Я удаляю данные тест, поскольку этот случай не может исправить сейчас `LeapsPostProcessor` (https://github.com/mapsme/omim/pull/11091). Петля в этом случае, не имеет общих сегментов, а проходит по разным дорогам. А вместо него ставлю тикет: https://jira.mail.ru/browse/MAPSME-13865

@mesozoic-drones PTAL
