### PR TITLE
[strings] Auto generated additional strings for iOS.

### DIFF
--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ مسار";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s مكان";
+
+"routes_card_routes_tag" = "برنامج الرحلة";
+
+"routes_card_set_tag" = "أماكن مميزة";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ cesta";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s míst";
+
+"routes_card_routes_tag" = "Itinerář";
+
+"routes_card_set_tag" = "Doporučená místa";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ rute";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s steder";
+
+"routes_card_routes_tag" = "Rejseplan";
+
+"routes_card_set_tag" = "Fremhævede steder";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ Wanderweg";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s Orte";
+
+"routes_card_routes_tag" = "Route";
+
+"routes_card_set_tag" = "Selektion der Plätze";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ δρόμος";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s τοποθεσιών";
+
+"routes_card_routes_tag" = "Διαδρομή";
+
+"routes_card_set_tag" = "Προτεινόμενα μέρη";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ track";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s places";
+
+"routes_card_routes_tag" = "Itinerary";
+
+"routes_card_set_tag" = "Featured places";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ track";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s places";
+
+"routes_card_routes_tag" = "Itinerary";
+
+"routes_card_set_tag" = "Featured places";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ pista";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s lugares";
+
+"routes_card_routes_tag" = "Itinerario";
+
+"routes_card_set_tag" = "Lugares destacados";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ مسیر";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s مکان ها";
+
+"routes_card_routes_tag" = "مسیر سفر";
+
+"routes_card_set_tag" = "مکان های ویژه";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ reitti";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s paikoista";
+
+"routes_card_routes_tag" = "Reitti";
+
+"routes_card_set_tag" = "Esitellyt paikat";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ itinéraire";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s places";
+
+"routes_card_routes_tag" = "Itinéraire";
+
+"routes_card_set_tag" = "Sélection de sièges";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ útvonal";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s hely";
+
+"routes_card_routes_tag" = "Útiterv";
+
+"routes_card_set_tag" = "Kiemelt helyek";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ lintasan";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s tempat";
+
+"routes_card_routes_tag" = "Rencana perjalanan";
+
+"routes_card_set_tag" = "Tempat pilihan";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ sentieri";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s posti";
+
+"routes_card_routes_tag" = "Percorso";
+
+"routes_card_set_tag" = "Selezione dei luoghi";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+トラック";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s個の場所";
+
+"routes_card_routes_tag" = "経路";
+
+"routes_card_set_tag" = "主要な場所";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ 경로";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s 장소";
+
+"routes_card_routes_tag" = "일정표";
+
+"routes_card_set_tag" = "주요 장소";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ spor";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s steder";
+
+"routes_card_routes_tag" = "Ruten";
+
+"routes_card_set_tag" = "Kompilasjon av steder";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ route";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s plaatsen";
+
+"routes_card_routes_tag" = "Route";
+
+"routes_card_set_tag" = "Aanbevolen plaatsen";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ trasa";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s miejsc";
+
+"routes_card_routes_tag" = "Trasa";
+
+"routes_card_set_tag" = "Polecane miejsca";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ trilha";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s locais";
+
+"routes_card_routes_tag" = "Percurso";
+
+"routes_card_set_tag" = "Lugares em destaque";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ track";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s locuri";
+
+"routes_card_routes_tag" = "Traseu";
+
+"routes_card_set_tag" = "Locuri atractive";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ трек";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s мест";
+
+"routes_card_routes_tag" = "Маршрут";
+
+"routes_card_set_tag" = "Подборка мест";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ trasu";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s miest";
+
+"routes_card_routes_tag" = "Itinerár";
+
+"routes_card_set_tag" = "Odporúčané miesta";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ bana";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s platser";
+
+"routes_card_routes_tag" = "Resväg";
+
+"routes_card_set_tag" = "Utvalda platser";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ เส้นทาง";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s สถานที่";
+
+"routes_card_routes_tag" = "แผนการเดินทาง";
+
+"routes_card_set_tag" = "สถานที่แนะนำ";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ rota";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s yer";
+
+"routes_card_routes_tag" = "Yol";
+
+"routes_card_set_tag" = "Öne çıkan yerler";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ трек";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s місць";
+
+"routes_card_routes_tag" = "Маршрут";
+
+"routes_card_set_tag" = "Добірка місць";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+ tuyến đường";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s địa điểm";
+
+"routes_card_routes_tag" = "Tuyến";
+
+"routes_card_set_tag" = "Địa điểm nổi bật";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+路线";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s位置";
+
+"routes_card_routes_tag" = "路线";
+
+"routes_card_set_tag" = "特色景点";
+
 
 /**********  Partners  **********/
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -3304,6 +3304,16 @@
 
 "routes_card_plus_track" = "+路線";
 
+"routes_card_city" = "City";
+
+"routes_card_outdoor" = "Outdoor";
+
+"routes_card_number_of_points" = "%s位置";
+
+"routes_card_routes_tag" = "路線";
+
+"routes_card_set_tag" = "特色景點";
+
 
 /**********  Partners  **********/
 


### PR DESCRIPTION
У нас в strings.txt имеются фразы:

[routes_card_city],  [routes_card_outdoor] с переводом только на английский.
[routes_card_number_of_points], [routes_card_routes_tag], [routes_card_set_tag] с переводами на множество языков.

Если запустить: ./tools/unix/generate_localizations.sh видно, что для iOS для этих тагов ничего не сгенерировано. В данном PR я делаю это.

@beloal PTAL