### PR TITLE
[routing][map build fix] ShouldSkipYear(...) functions returns a wrong value.

### DIFF
--- a/routing/opening_hours_serdes.cpp
+++ b/routing/opening_hours_serdes.cpp
@@ -53,7 +53,7 @@ bool ShouldSkipYear(osmoh::MonthdayRange const & range, uint16_t currentYear)
 {
   auto const hasYear = range.GetStart().HasYear() && range.GetEnd().HasYear();
   if (!hasYear)
-    return true;
+    return false;
 
   return ShouldSkipYear(range.GetStart().GetYear(), range.GetEnd().GetYear(), currentYear);
 }

--- a/routing/opening_hours_serdes.cpp
+++ b/routing/opening_hours_serdes.cpp
@@ -35,12 +35,18 @@ osmoh::RuleSequence GetTwentyFourHourRule()
   return result;
 }
 
+bool ShouldSkipYear(uint16_t startYear, uint16_t endYear, uint16_t currentYear)
+{
+  if (startYear > endYear)
+    return true; // Wrong data. |startYear| is later than |endYear|.
+
+  // returns true if |startYear| and |endYear| are too old and false otherwise.
+  return endYear < currentYear;
+}
+
 bool ShouldSkipYear(osmoh::YearRange const & range, uint16_t currentYear)
 {
-  if (range.GetStart() > range.GetEnd())
-    return true;
-  
-  return range.GetStart() < currentYear && range.GetEnd() < currentYear;
+  return ShouldSkipYear(range.GetStart(), range.GetEnd(), currentYear);
 }
 
 bool ShouldSkipYear(osmoh::MonthdayRange const & range, uint16_t currentYear)
@@ -48,13 +54,8 @@ bool ShouldSkipYear(osmoh::MonthdayRange const & range, uint16_t currentYear)
   auto const hasYear = range.GetStart().HasYear() && range.GetEnd().HasYear();
   if (!hasYear)
     return true;
-  
-  auto const startYear = range.GetStart().GetYear();
-  auto const endYear = range.GetEnd().GetYear();
-  if (startYear > endYear)
-    return true;
 
-  return hasYear && startYear < currentYear && endYear < currentYear;
+  return ShouldSkipYear(range.GetStart().GetYear(), range.GetEnd().GetYear(), currentYear);
 }
 
 bool UselessModifier(osmoh::RuleSequence const & rule)

--- a/routing/opening_hours_serdes.cpp
+++ b/routing/opening_hours_serdes.cpp
@@ -38,7 +38,7 @@ osmoh::RuleSequence GetTwentyFourHourRule()
 bool ShouldSkipYear(osmoh::YearRange const & range, uint16_t currentYear)
 {
   if (range.GetStart() > range.GetEnd())
-    return false;
+    return true;
   
   return range.GetStart() < currentYear && range.GetEnd() < currentYear;
 }
@@ -47,12 +47,12 @@ bool ShouldSkipYear(osmoh::MonthdayRange const & range, uint16_t currentYear)
 {
   auto const hasYear = range.GetStart().HasYear() && range.GetEnd().HasYear();
   if (!hasYear)
-    return false;
+    return true;
   
   auto const startYear = range.GetStart().GetYear();
   auto const endYear = range.GetEnd().GetYear();
   if (startYear > endYear)
-    return false;
+    return true;
 
   return hasYear && startYear < currentYear && endYear < currentYear;
 }

--- a/routing/routing_tests/opening_hours_serdes_tests.cpp
+++ b/routing/routing_tests/opening_hours_serdes_tests.cpp
@@ -183,6 +183,16 @@ UNIT_CLASS_TEST(BitReaderWriter, OpeningHoursSerDes_EnableTests_2)
   TEST(Serialize("2019 Nov 30 - 2090 Mar 31"), ());
 }
 
+// Test on serialization ranges where start is later than end.
+// It is wrong but still possible data.
+UNIT_CLASS_TEST(BitReaderWriter, OpeningHoursSerDes_CannotSerialize)
+{
+  Enable(OpeningHoursSerDes::Header::Bits::Year);
+  Enable(OpeningHoursSerDes::Header::Bits::Month);
+  TEST(!Serialize("2020 - 2019"), ());
+  TEST(!Serialize("2020 May 20 - 2018 Nov 30"), ());
+}
+
 UNIT_CLASS_TEST(BitReaderWriter, OpeningHoursSerDes_YearOnly)
 {
   Enable(OpeningHoursSerDes::Header::Bits::Year);


### PR DESCRIPTION
В время сборки карты происходила сериализация opening hours для дорог. При этом инвариант был нарушен. Это и выявлял чек:
`CHECK(start <= end && end >= m_currentYear, (start, end, m_currentYear));` в 
методе `OpeningHoursSerDes::CheckYearRange(...)`. 

Он данные чек проверяет, что если и начало и конец ограничения были до даты сборки, то на более раннем этапе данные ограничения должны быть выкинуты.

Действительно, в начале метода  `OpeningHoursSerDes::SerializeImpl(...)` вызывается `DecomposeOh(...)`, в котором есть код, который отвечает за выкидывание таких ограничений. А в конце метода `OpeningHoursSerDes::SerializeImpl(...)` через цепочку вызовов, вызывается выше указанный чек.

Проблема была в том, что в коде ответственном за удаление старых ограничений в `DecomposeOh(...)` true и false были перепутаны. Т.е. методы `ShouldSkipYear(...)` возвращали, что устаревшие ограничения выкидывать не нужно.

@tatiana-yan @mesozoic-drones @maksimandrianov  PTAL
