### PR TITLE
[Android] Fix for arrow rotation in not-default screen orientation.

### DIFF
--- a/android/src/com/mapswithme/util/LocationUtils.java
+++ b/android/src/com/mapswithme/util/LocationUtils.java
@@ -35,6 +35,8 @@ public class LocationUtils
     double correction = 0;
     switch (displayOrientation)
     {
+    case Surface.ROTATION_0:
+      return angle;
     case Surface.ROTATION_90:
       correction = Math.PI / 2.0;
       break;
@@ -46,11 +48,7 @@ public class LocationUtils
       break;
     }
 
-    // negative values (like -1.0) should remain negative (indicates that no direction available)
-    if (angle >= 0.0)
-      angle = correctAngle(angle, correction);
-
-    return angle;
+    return correctAngle(angle, correction);
   }
 
   public static double correctAngle(double angle, double correction)


### PR DESCRIPTION
[MAPSME-13879](https://jira.mail.ru/browse/MAPSME-13879)

Старый  баг, существует ориентировочно с 2014 года (но так как стрелку трогала я, понятно, на кого пало подозрение =).

Заключается в резком повороте стрелки местоположения пользователя при "не-дефолтном" повороте экрана. Для большинства девайсов - это альбомная ориентация, но могут быть исключения (когда альбомная ориентация принята за дефолтную, а не портретная). 

**Воспроизводится** в том числе на 9.6 и ранее: нужно попробовать описать 360 градусов девайсом в альбомной ориентации по горизонтальной оси (условно положить на стол и покрутить). Будет видно, что стрелка срывается в не соответствующее действительности направление.

**Причина:** мы делаем поправку на поворот девайса (прибавляем pi/2, pi, 3p/2) только если угол поворота от сенсора пришел не отрицательный. Но от сенсора может прийти отрицательный угол, и это **не означает** его невалидность.





