### PR TITLE
[map] Fix azimuth disappearance for PP.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1860,19 +1860,16 @@ bool Framework::GetDistanceAndAzimut(m2::PointD const & point,
   // Distance may be less than 1.0
   UNUSED_VALUE(measurement_utils::FormatDistance(d, distance));
 
-  if (north >= 0.0)
-  {
-    // We calculate azimut even when distance is very short (d ~ 0),
-    // because return value has 2 states (near me or far from me).
+  // We calculate azimuth even when distance is very short (d ~ 0),
+  // because return value has 2 states (near me or far from me).
 
-    azimut = ang::Azimuth(mercator::FromLatLon(lat, lon), point, north);
+  azimut = ang::Azimuth(mercator::FromLatLon(lat, lon), point, north);
 
-    double const pi2 = 2.0*math::pi;
-    if (azimut < 0.0)
-      azimut += pi2;
-    else if (azimut > pi2)
-      azimut -= pi2;
-  }
+  double const pi2 = 2.0*math::pi;
+  if (azimut < 0.0)
+    azimut += pi2;
+  else if (azimut > pi2)
+    azimut -= pi2;
 
   // This constant and return value is using for arrow/flag choice.
   return (d < 25000.0);


### PR DESCRIPTION
[MAPSME-13851](https://jira.mail.ru/browse/MAPSME-13851)

В 10.0.3 пропала синяя стрелка направления движения, которая отображается в PP, если определилось местоположение. Стрелка появляется, если немного подвигать телефон.

**Причина бага:** метод `GetDistanceAndAzimut()` фреймворка рассчитывал азимут только если ему приходил не отрицательный угол от компаса. Нет азимута -> нет стрелки.

Но угол от компаса может быть отрицательным. Причина очень похожа на причину этого бага: #13121
Причем баг #13121 воспроизводится на более старых версиях приложения (что ожидаемо), а этот - только на новой. Возможно, на более ранних версиях приложения он не воспроизводился настолько регулярно, потому что показания от чистого магнитометра, которые мы использовали, дают большой разброс и даже в случае отрицательного значения периодически (то есть много раз за секунду) генерится положительное. Сейчас мы используем fused сенсор, и такого разброса нет.