### PR TITLE
[3party] Cherry-pick: Added sumbodule just_gtfs for parsing GTFS feeds.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,7 @@
   url = https://github.com/boostorg/boost.git
   branch = boost-1.68.0
   ignore = dirty
+[submodule "3party/just_gtfs"]
+  path = 3party/just_gtfs
+  url = https://github.com/mapsme/just_gtfs.git
+  branch = for-usage-as-submodule


### PR DESCRIPTION
Cherry-pick: #13024

Зачем делать чери-пик добавления сабмодуля: на дженкинсе запускается git submodule update. Для сабмодулей, в которых что-то обновилось, она не подтягивает изменения. Сабмодуль just_gtfs, в котором периодически обновляется код, подтягивается устаревший, и сборка ломается. А с опцией --remote все нормально работает. 
Но @ToshUxanoff  не может ее полноценно добавить (только для этого сабмодуля), пока в release-100 отсутствует этот сабмодуль.

Описание опции --remote:
If you track branches in your submodules, you can update them via the --remote parameter of the git submodule update command. This pulls in new commits into the main repository and its submodules.