### PR TITLE
[transit] Fix for android build error on master.

### DIFF
--- a/transit/CMakeLists.txt
+++ b/transit/CMakeLists.txt
@@ -17,4 +17,7 @@ set(
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 omim_add_test_subdirectory(transit_tests)
-add_subdirectory(world_feed)
+
+if (PLATFORM_DESKTOP)
+    add_subdirectory(world_feed)
+endif()

--- a/transit/world_feed/CMakeLists.txt
+++ b/transit/world_feed/CMakeLists.txt
@@ -53,21 +53,27 @@ omim_link_libraries(
     stb_image
     sdf_image
     vulkan_wrapper
-    ${Qt5Widgets_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
     ${LIBZ}
 )
 
-if (PLATFORM_LINUX)
+if (PLATFORM_MAC)
     omim_link_libraries(
-            ${PROJECT_NAME}
-            dl
+       ${PROJECT_NAME}
+       ${Qt5Widgets_LIBRARIES}
     )
 endif()
 
+if (PLATFORM_LINUX)
+    omim_link_libraries(
+       ${PROJECT_NAME}
+       dl
+    )
+endif()
+
+
 link_opengl(${PROJECT_NAME})
 link_qt5_core(${PROJECT_NAME})
-link_qt5_network(${PROJECT_NAME})
 
 omim_add_test_subdirectory(world_feed_tests)
+
 add_subdirectory(gtfs_converter)


### PR DESCRIPTION
По аналогии с генератором, benchmark_tool, routes_builder и другими тулзами, которые запускаются на сервер-сайд: world_feed не нужно собирать под платформы. Для этого добавлен` if (PLATFORM_DESKTOP)`.