### PR TITLE
[search] Fix locality finder for two close localities.

### DIFF
--- a/search/locality_finder.cpp
+++ b/search/locality_finder.cpp
@@ -167,8 +167,9 @@ void LocalitySelector::operator()(LocalityItem const & item)
   // multivariate Gaussian.
   double const distance = mercator::DistanceOnEarth(item.m_center, m_p);
 
+  // GetPopulationByRadius may return 0.
   double const score =
-      ftypes::GetPopulationByRadius(distance) / static_cast<double>(item.m_population);
+      (ftypes::GetPopulationByRadius(distance) + 1) / static_cast<double>(item.m_population);
 
   if (!inside && m_inside)
     return;


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-11091

Если два населенных пункта находятся на расстоянии меньше 550 метров от результата, то берём тот у которого больше population.
Раньше брали тот который первым попался.

Отдельно можно подумать чтобы для маленького distance учитывать его как-то иначе чем через GetPopulationByRadius