### PR TITLE
[strings] Fixed typo in DE

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -986,7 +986,7 @@
 	<!-- When there are no available taxis nearby -->
 	<string name="taxi_not_found">Es konnte kein Taxi in der Nähe gefunden werden</string>
 	<!-- When there are no available taxi providers nearby -->
-	<string name="taxi_no_providers">Taxi ist hie nicht verfügbar</string>
+	<string name="taxi_no_providers">Taxi ist hier nicht verfügbar</string>
 	<string name="install_app">Installieren</string>
 	<!-- `Filter` is a noun here -->
 	<string name="booking_filters">Filter</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22086,7 +22086,7 @@
     nl = Taxi hier niet beschikbaar
     fi = Taksi ei ole saatavilla täällä
     fr = Taxi pas disponible ici
-    de = Taxi ist hie nicht verfügbar
+    de = Taxi ist hier nicht verfügbar
     hu = Itt nincs taxi
     id = Taksi tidak tersedia di sini
     it = Taxi non disponibile qui

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1673,7 +1673,7 @@
 "taxi_not_found" = "Es konnte kein Taxi in der Nähe gefunden werden";
 
 /* When there are no available taxi providers nearby */
-"taxi_no_providers" = "Taxi ist hie nicht verfügbar";
+"taxi_no_providers" = "Taxi ist hier nicht verfügbar";
 
 "install_app" = "Installieren";
 


### PR DESCRIPTION
Hello,
I noticed that the German version of maps.me has a typo if Taxi is not available for the chosen route. It says "Taxi ist hie nicht verfügbar." But is has to be "Taxi ist hier nicht verfügbar.". It really annoys me that is way I write you. Can you change it?