### PR TITLE
[elevation] Check has_elevation_profile is set to make track interactive

### DIFF
--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -52,6 +52,7 @@ std::string GetBookmarkIconType(kml::BookmarkIcon const & icon)
 }
 
 std::string const kCustomImageProperty = "CustomImage";
+std::string const kHasElevationProfileProperty = "has_elevation_profile";
 }  // namespace
 
 Bookmark::Bookmark(m2::PointD const & ptOrg)
@@ -352,6 +353,12 @@ std::string BookmarkCategory::GetName() const
 bool BookmarkCategory::IsCategoryFromCatalog() const
 {
   return FromCatalog(m_data, m_serverId);
+}
+
+bool BookmarkCategory::HasElevationProfile() const
+{
+  auto const it = m_data.m_properties.find(kHasElevationProfileProperty);
+  return (it != m_data.m_properties.end()) && (it->second != "0");
 }
 
 std::string BookmarkCategory::GetCatalogDeeplink() const

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -96,6 +96,7 @@ public:
   std::string const & GetServerId() const { return m_serverId; }
 
   bool IsCategoryFromCatalog() const;
+  bool HasElevationProfile() const;
   std::string GetCatalogDeeplink() const;
   std::string GetCatalogPublicLink() const;
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2857,7 +2857,7 @@ void BookmarkManager::CreateCategories(KMLDataCollection && dataCollection, bool
     }
     for (auto & trackData : fileData.m_tracksData)
     {
-      auto track = std::make_unique<Track>(std::move(trackData), group->IsCategoryFromCatalog());
+      auto track = std::make_unique<Track>(std::move(trackData), group->HasElevationProfile());
       auto * t = AddTrack(std::move(track));
       t->Attach(groupId);
       group->AttachTrack(t->GetId());


### PR DESCRIPTION
Признак интерактивности для трека - это наличие has_elevation_profile!="0" в kml.

https://jira.mail.ru/browse/MAPSME-13495