### PR TITLE
[generator] PlaceProcessor: tune IsWorsePlace function, fix GetLimitRect behaviour.

### DIFF
--- a/generator/place_processor.hpp
+++ b/generator/place_processor.hpp
@@ -28,15 +28,20 @@ public:
   void Append(feature::FeatureBuilder const & fb);
   feature::FeatureBuilder const & GetFb() const;
   FeaturesBuilders const & GetFbs() const;
-  m2::RectD const & GetLimitRect() const;
+
+  // Returns limit rect around all stored feature builders.
+  m2::RectD const & GetAllFbsLimitRect() const;
+
+  // Methods return values for best stored feature builder.
   base::GeoObjectId GetMostGenericOsmId() const;
   uint8_t GetRank() const;
   std::string GetName() const;
   StringUtf8Multilang const & GetMultilangName() const;
   bool IsPoint() const;
+  m2::RectD const & GetLimitRect() const;
 
 private:
-  m2::RectD m_limitRect;
+  m2::RectD m_allFbsLimitRect;
   FeaturesBuilders m_fbs;
   size_t m_bestIndex;
 };


### PR DESCRIPTION
По GetLimitRect: она использовалась в 2 местах -- для квадродерева, там нужны все fb из FeaturePlace и в IsWorsePlace, где мы должны сравнивать только "лучшие" fb (т.к. потом берём только лучший). Поэтому функции надо разделить, иначе мы получали в IsWorsePlace точки ненулевой площади.

По тюнингу функции выбора place:
собрала у себя Онтарио, отсмотрела вручную все изменения в выборе фичей для place.
Всего изменения в 34 объектах в Онтарио.
Основная масса -- при прочих равных мы раньше предпочитали Relation (т.к. одним из факторов отбора была площадь, то если у нас есть relation сконверченный в точку и в нём node, то брался limit rect вокруг этих двух объектов и его площадь), теперь при прочих равных или даже если Node немного хуже (например меньше population) берём Node. На мой взгляд это лучше, т.к. Node с большей долей вероятности действительно будет городом, а не районом/муниципалететом и т.п. и у него адекватнее расположена точка. Примеры таких изменившихся объектов:
раньше выбирали
https://www.openstreetmap.org/relation/7473982
и
https://www.openstreetmap.org/relation/6501874

Теперь выбираем:
https://www.openstreetmap.org/node/766219035
и
https://www.openstreetmap.org/node/107365748

они как минимум гораздо лучше расположены, лучше будут работать при поиске самого города, при поиске в объектов в городе, карта адекватнее выглядит и т.п.
было:
<img width="1013" alt="Screenshot 2020-05-29 at 11 12 34" src="https://user-images.githubusercontent.com/9213190/83237935-53241600-a19e-11ea-83bd-0f644c003538.png">
стало:
<img width="1013" alt="Screenshot 2020-05-29 at 11 14 01" src="https://user-images.githubusercontent.com/9213190/83237949-5919f700-a19e-11ea-8d90-dd97f6b02f88.png">


было:
<img width="969" alt="Screenshot 2020-05-29 at 11 16 46" src="https://user-images.githubusercontent.com/9213190/83237995-6d5df400-a19e-11ea-9c71-924496ea1fb8.png">
стало:
<img width="969" alt="Screenshot 2020-05-29 at 11 16 07" src="https://user-images.githubusercontent.com/9213190/83237984-69ca6d00-a19e-11ea-94a5-a22f28987e4e.png">

Всего в двух объектах  отличалось что-то кроме ранга(population):
https://www.openstreetmap.org/relation/7106000
https://www.openstreetmap.org/node/61097209

в relation больше population, но в node больше языков, раньше выбирали relation, теперь выбираем node. Расположение принципиально не изменилось, но добавились языки.

Ну и Оттава, раньше выбор делался в пользу relation т.к. там больше population: https://www.openstreetmap.org/relation/4136816
теперь выбираем node, т.к. node в общем случае лучше (лучше расположен и т.п.) и ещё там больше языков -- 30 в node против 2 в relation https://www.openstreetmap.org/node/18886011

было place-city-capital-6 без звёздочки для столицы государства посреди реки (причем ещё временами не в той провинции -- https://jira.mail.ru/browse/MAPSME-12261) с перводами только на дефолтный и корейский
<img width="370" alt="Screenshot 2020-05-29 at 11 18 31" src="https://user-images.githubusercontent.com/9213190/83238195-c3cb3280-a19e-11ea-9088-0d8871fac95f.png">

стало на place-city-capital-2 со звездочкой для столицы государства на ottawa city hall с переводами на 30 языков
<img width="692" alt="Screenshot 2020-05-29 at 11 26 39" src="https://user-images.githubusercontent.com/9213190/83238585-4fdd5a00-a19f-11ea-87fa-c29fc6709f6a.png">


Сейчас собираю на сервере world, хочу в полуавтоматическом режиме проверить что поменяется при выборе других городов и, если будут не только улучшения но и ухудшения, то потюнить коэффициенты (в этом же реквесте или в отдельном).