### PR TITLE
[transit] Split feeds by borders polygons.

### DIFF
--- a/transit/world_feed/CMakeLists.txt
+++ b/transit/world_feed/CMakeLists.txt
@@ -15,6 +15,7 @@ omim_add_library(${PROJECT_NAME} ${SRC})
 
 omim_link_libraries(
     ${PROJECT_NAME}
+    generator
     drape_frontend
     shaders
     routing

--- a/transit/world_feed/gtfs_converter/gtfs_converter.cpp
+++ b/transit/world_feed/gtfs_converter/gtfs_converter.cpp
@@ -1,3 +1,5 @@
+#include "generator/affiliation.hpp"
+
 #include "transit/world_feed/color_picker.hpp"
 #include "transit/world_feed/world_feed.hpp"
 
@@ -198,6 +200,9 @@ int main(int argc, char ** argv)
   GetPlatform().SetResourceDir(FLAGS_path_resources);
   transit::ColorPicker colorPicker;
 
+  feature::CountriesFilesAffiliation mwmMatcher(GetPlatform().ResourcesDir(),
+                                                false /* haveBordersForWholeWorld */);
+
   for (size_t i = 0; i < gtfsFeeds.size(); ++i)
   {
     base::Timer feedTimer;
@@ -231,7 +236,7 @@ int main(int argc, char ** argv)
       continue;
     }
 
-    transit::WorldFeed globalFeed(generator, colorPicker);
+    transit::WorldFeed globalFeed(generator, colorPicker, mwmMatcher);
 
     if (!globalFeed.SetFeed(std::move(feed)))
     {

--- a/transit/world_feed/world_feed_integration_tests/CMakeLists.txt
+++ b/transit/world_feed/world_feed_integration_tests/CMakeLists.txt
@@ -10,4 +10,5 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 omim_link_libraries(
   ${PROJECT_NAME}
   world_feed
+  generator
 )

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -1,5 +1,7 @@
 #include "testing/testing.hpp"
 
+#include "generator/affiliation.hpp"
+
 #include "transit/world_feed/world_feed.hpp"
 
 #include "platform/platform.hpp"
@@ -26,7 +28,9 @@ namespace transit
 class WorldFeedIntegrationTests
 {
 public:
-  WorldFeedIntegrationTests() : m_globalFeed(m_generator, m_colorPicker)
+  WorldFeedIntegrationTests()
+    : m_mwmMatcher(GetTestingOptions().m_resourcePath, false /* haveBordersForWholeWorld */)
+    , m_globalFeed(m_generator, m_colorPicker, m_mwmMatcher)
   {
     auto const & options = GetTestingOptions();
 
@@ -91,6 +95,7 @@ private:
   std::string m_testPath;
   IdGenerator m_generator;
   transit::ColorPicker m_colorPicker;
+  feature::CountriesFilesAffiliation m_mwmMatcher;
   WorldFeed m_globalFeed;
 };
 


### PR DESCRIPTION
Разбиение json'ов общественного транспорта по регионам до этапа генератора. Теперь для каждой mwm в директории с названием mwm формируется свой набор файлов (networks.transit.json, routes.transit.json, stops.transit.json, etc). Получается иерархия:
```
~/jsons_for_generator
|______Argentina_Buenos Aires_North
...............|______networks.transit.json, routes.transit.json, ...
|______Belgium_Antwerp
...............|______networks.transit.json, routes.transit.json, ...
```

Правила отнесения сущности к mwm соответствуют правилам, действующим сейчас для метро, которые определены в `GraphData::ClipGraph(vector<m2::RegionD> const & borders)`.