### PR TITLE
[generator] PlaceProcessor: do not use PlaceProcessor for unnamed places.

### DIFF
--- a/generator/place_processor.cpp
+++ b/generator/place_processor.cpp
@@ -120,6 +120,9 @@ namespace generator
 {
 bool NeedProcessPlace(feature::FeatureBuilder const & fb)
 {
+  if (fb.GetMultilangName().IsEmpty())
+    return false;
+
   auto const & islandChecker = ftypes::IsIslandChecker::Instance();
   auto const & localityChecker = ftypes::IsLocalityChecker::Instance();
   return islandChecker(fb.GetTypes()) || localityChecker.GetType(GetPlaceType(fb)) != ftypes::LocalityType::None;


### PR DESCRIPTION
У безымянных объектов имена совпадают, но взаимно вытеснять их не надо