### PR TITLE
[search] Add forgotten dependency.

### DIFF
--- a/search/search_quality/aloha_to_samples_tool/CMakeLists.txt
+++ b/search/search_quality/aloha_to_samples_tool/CMakeLists.txt
@@ -14,6 +14,7 @@ omim_link_libraries(
   storage
   editor
   indexer
+  ge0
   platform
   mwm_diff
   bsdiff

--- a/search/search_quality/search_quality_tests/CMakeLists.txt
+++ b/search/search_quality/search_quality_tests/CMakeLists.txt
@@ -12,6 +12,7 @@ omim_link_libraries(
   search
   indexer
   editor
+  ge0
   platform
   coding
   geometry

--- a/search/search_tests/CMakeLists.txt
+++ b/search/search_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ omim_link_libraries(
   editor
   indexer
   storage
+  ge0
   platform
   geometry
   coding


### PR DESCRIPTION
на некоторых линуксах бинари не линкуются

ещё вроде бы можно было бы вписать ge0 в ./search/CMakeLists.txt рядом с openlocationcode и удалить из cmakelist для всех бинарей, но почему-то мы так не делаем с остальными библиотеками