### PR TITLE
[routing] Fixing rit and rqt for the map 200514.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -54,12 +54,12 @@ namespace
   {
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
-        mercator::FromLatLon(55.75100, 37.61790), {0., 0.},
-        mercator::FromLatLon(55.97310, 37.41460), 37284.);
+        mercator::FromLatLon(55.75100, 37.61790), {0.0, 0.0},
+        mercator::FromLatLon(55.97310, 37.41460), 37284.0);
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
-        mercator::FromLatLon(55.97310, 37.41460), {0., 0.},
-        mercator::FromLatLon(55.75100, 37.61790), 39899.2);
+        mercator::FromLatLon(55.97310, 37.41460), {0.0, 0.0},
+        mercator::FromLatLon(55.75100, 37.61790), 33763.7);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.

--- a/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/bigger_roads_tests.cpp
@@ -10,7 +10,7 @@ namespace
 // Secondary should be preferred against residential.
 UNIT_TEST(RoutingQuality_RussiaMoscowTushino)
 {
-  TEST(CheckCarRoute({55.84398, 37.45018} /* start */, {55.85489, 37.43784} /* finish */,
+  TEST(CheckCarRoute({55.84367, 37.44724} /* start */, {55.85489, 37.43784} /* finish */,
                      {{{55.84343, 37.43949}}} /* reference track */),
        ());
 }
@@ -107,13 +107,6 @@ UNIT_TEST(RoutingQuality_BerlinkaWarsawPoland)
                      {{{54.24278, 19.66106}, {54.13679, 19.45166},
                        {54.06452, 19.62416}, {53.69769, 19.98204},
                        {53.11194, 20.40002}, {52.62966, 20.38488}}} /* reference track */),
-       ());
-}
-
-UNIT_TEST(RoutingQuality_LenOblBadPaving)
-{
-  TEST(CheckCarRoute({60.23884, 29.71603} /* start */, {60.29083, 29.80333} /* finish */,
-                     {{{60.2510134, 29.790209}}} /* reference track */),
        ());
 }
 

--- a/routing/routing_quality/routing_quality_tests/leaps_postprocessing_tests.cpp
+++ b/routing/routing_quality/routing_quality_tests/leaps_postprocessing_tests.cpp
@@ -13,13 +13,6 @@ using namespace std;
 
 namespace
 {
-UNIT_TEST(RoutingQuality_NoLoop_MoscowToKazan)
-{
-  TEST(!CheckCarRoute({55.63113, 37.63054} /* start */, {55.67914, 52.37389} /* finish */,
-                      {{{55.80643, 37.83981}}} /* reference point */),
-       ());
-}
-
 UNIT_TEST(RoutingQuality_NoLoop_Canada)
 {
   TEST(!CheckCarRoute({53.53540, -113.50798} /* start */, {69.44402, -133.03189} /* finish */,


### PR DESCRIPTION
**Routing integration tests**.
Поправил тест **MoscowToSVOAirport**. Он сломался, т.к. часть дорог на поле Шереметьево было удалено с карты в 200514. Фейковая дуга стала длиннее, а маршрут короче. Это видно из скринов ниже.
![image](https://user-images.githubusercontent.com/1768114/83647922-2157e880-a5be-11ea-8fff-7d9c1c4e8881.png)
![image](https://user-images.githubusercontent.com/1768114/83647941-26b53300-a5be-11ea-85cc-c8ad45fe1c4b.png)
В остально маршрут не изменился.
![image](https://user-images.githubusercontent.com/1768114/83648212-7431a000-a5be-11ea-9fcd-52bdc9dd4aa5.png)
![image](https://user-images.githubusercontent.com/1768114/83648225-785dbd80-a5be-11ea-803c-e45d5a644569.png)

**Routing quality tests.**
**RoutingQuality_RussiaMoscowTushino** из коментания к тесту следует: `// Secondary should be preferred against residential.`. Т.е. тест на то, что мы предпочитаем дороги secondary, даже, если задан maxspeed, как в этом случае. Если обратиться к кармодели, то видно, что в городе, для residential коэф 0.75, а для secondary 0.85 от maxspeed (==60). Т.е. для residential скорость рассматривается, как 0.75 * 60 км/ч == 45 км/ч, а для secondary 0.85 * 60 км/ч = 51 км/ч. В данном тесте мы проверяем, что маршрут должен проходит по дороге secondary длиной 828.2 метра, вместо того, чтоб идти по дороге residential длиной, как кажется на глаз, примерно такой же, но если померить, то получим всего 707.9 метра. (см. скриншоты ниже). Т.е. в пересчете на время, картах 200514 0.7079км / 45км/ч = 0.01573(1) часа (56.63 секунды) по дороге residential. 0.8282км / 51км/ч = 0.01624 часа (58.46 секунды). Т.о. время очень близко и может различаться из-за не больших изменений в карте ввиду того, что residential путь заметно короче. Поправим это, переместив старт, так, чтоб увеличить вес residential пути.
![image](https://user-images.githubusercontent.com/1768114/83653774-ddb4ad00-a5c4-11ea-9f7b-183f27cbf9a4.png)
![image](https://user-images.githubusercontent.com/1768114/83653795-e4432480-a5c4-11ea-9edb-4fef2d5813dd.png)

**RoutingQuality_LenOblBadPaving**. Тест был на то, чтоб предпочитать дорогу с хорошим покрытием, но более длинную. В начале апреля, на карте улучшили покрытие дороги. В 200514 - оно стало хорошим: https://www.openstreetmap.org/way/610213522.  Данный тест, я удаляю. Он не единственный, который проверяет покрытие. Есть еще, например, RoutingQuality_MosOblBadPaving, RoutingQuality_LatviaUnpaved.

Кроме того, черепикнул 70cd36b37f562c0592386bb5dd15cf6449313af0 (https://github.com/mapsme/omim/pull/13102 из мастера). Что проходили все rqt.

@maksimandrianov @mesozoic-drones PTAL