### PR TITLE
[drape] [android] [vulkan] sporadic crash on layer switching

### DIFF
--- a/drape/drape_tests/testing_graphics_context.hpp
+++ b/drape/drape_tests/testing_graphics_context.hpp
@@ -12,6 +12,7 @@ public:
   void Present() override {}
   void MakeCurrent() override {}
   void SetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override {}
+  void ForgetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override {}
   void ApplyFramebuffer(std::string const & framebufferLabel) override {}
 
   void Init(dp::ApiVersion apiVersion) override {}

--- a/drape/graphics_context.hpp
+++ b/drape/graphics_context.hpp
@@ -58,6 +58,7 @@ public:
   virtual void DoneCurrent() {}
   // The value 'nullptr' means default(system) framebuffer.
   virtual void SetFramebuffer(ref_ptr<BaseFramebuffer> framebuffer) = 0;
+  virtual void ForgetFramebuffer(ref_ptr<BaseFramebuffer> framebuffer) = 0;
   virtual void ApplyFramebuffer(std::string const & framebufferLabel) = 0;
   // w, h - pixel size of render target (logical size * visual scale).
   virtual void Resize(int /* w */, int /* h */) {}

--- a/drape/metal/metal_base_context.hpp
+++ b/drape/metal/metal_base_context.hpp
@@ -34,6 +34,7 @@ public:
   bool Validate() override { return true; }
   void Resize(int w, int h) override;
   void SetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override;
+  void ForgetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override {}
   void ApplyFramebuffer(std::string const & framebufferLabel) override;
   void Init(ApiVersion apiVersion) override;
   ApiVersion GetApiVersion() const override;

--- a/drape/oglcontext.hpp
+++ b/drape/oglcontext.hpp
@@ -11,6 +11,7 @@ public:
   ApiVersion GetApiVersion() const override;
   std::string GetRendererName() const override;
   std::string GetRendererVersion() const override;
+  void ForgetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override {}
   void ApplyFramebuffer(std::string const & framebufferLabel) override {}
 
   void DebugSynchronizeWithCPU() override;

--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -314,6 +314,14 @@ void VulkanBaseContext::SetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer)
   m_currentFramebuffer = framebuffer;
 }
 
+void VulkanBaseContext::ForgetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer)
+{
+  if (m_framebuffersData.count(framebuffer) == 0)
+    return;
+  vkDeviceWaitIdle(m_device);
+  DestroyRenderPassAndFramebuffer(framebuffer);
+}
+
 void VulkanBaseContext::ApplyFramebuffer(std::string const & framebufferLabel)
 {
   vkCmdSetStencilReference(m_renderingCommandBuffers[m_inflightFrameIndex], VK_STENCIL_FRONT_AND_BACK,
@@ -860,7 +868,7 @@ void VulkanBaseContext::DestroyRenderPassAndFramebuffers()
 
 void VulkanBaseContext::DestroyRenderPassAndFramebuffer(ref_ptr<BaseFramebuffer> framebuffer)
 {
-  auto const & fbData = m_framebuffersData[m_currentFramebuffer];
+  auto const & fbData = m_framebuffersData[framebuffer];
   if (m_pipeline && fbData.m_renderPass != VK_NULL_HANDLE)
     m_pipeline->ResetCache(m_device, fbData.m_renderPass);
 

--- a/drape/vulkan/vulkan_base_context.hpp
+++ b/drape/vulkan/vulkan_base_context.hpp
@@ -47,6 +47,7 @@ public:
   bool Validate() override { return true; }
   void Resize(int w, int h) override;
   void SetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override;
+  void ForgetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer) override;
   void ApplyFramebuffer(std::string const & framebufferLabel) override;
   void Init(ApiVersion apiVersion) override;
   void SetPresentAvailable(bool available) override;

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -885,7 +885,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 #ifndef OMIM_OS_IPHONE_SIMULATOR
       CHECK(m_context != nullptr, ());
       m_postprocessRenderer->SetEffectEnabled(m_context, PostprocessRenderer::Effect::Antialiasing,
-                                              msg->IsEnabled() ? true : m_isAntialiasingEnabled);
+                                              msg->IsEnabled() || m_isAntialiasingEnabled);
 #endif
       if (!msg->IsEnabled())
         m_transitSchemeRenderer->ClearContextDependentResources(make_ref(m_overlayTree));

--- a/drape_frontend/postprocess_renderer.cpp
+++ b/drape_frontend/postprocess_renderer.cpp
@@ -430,6 +430,10 @@ void PostprocessRenderer::UpdateFramebuffers(ref_ptr<dp::GraphicsContext> contex
   }
   else
   {
+    context->ForgetFramebuffer(make_ref(m_edgesFramebuffer));
+    context->ForgetFramebuffer(make_ref(m_blendingWeightFramebuffer));
+    context->ForgetFramebuffer(make_ref(m_smaaFramebuffer));
+
     m_edgesFramebuffer.reset();
     m_blendingWeightFramebuffer.reset();
     m_smaaFramebuffer.reset();


### PR DESCRIPTION
При хаотичном быстром переключении слоёв крэш случается в драйвере вулкана при [этом](https://github.com/mapsme/omim/blob/e8a5c821e4b010b65ef3898e91b0203a3362c59f/drape/vulkan/vulkan_base_context.cpp#L462) вызове.
`VulkanBaseContext` хранит ресурсы, ассоциированные с фрэймбуфером, в `m_framebuffersData`, который имеет тип `std::map<ref_ptr<BaseFramebuffer>, FramebufferData>`. Фреймбуферы для разлиных нужд создаются в `drape_frontend/postprocess_renderer.cpp`. Например, [здесь](https://github.com/mapsme/omim/blob/e8a5c821e4b010b65ef3898e91b0203a3362c59f/drape_frontend/postprocess_renderer.cpp#L417-L436) создаётся три фреймбуфера для SMAA. Для разных слоёв антиалиасинг включается или выключается (для энергоэффективности). В общем случае объекты типа `dp::Framebuffer` пересоздаются (удаляются и создаются), например, при переключении слоёв. Аллокатор иногда может создавать новый объект по тому же адресу, по которому был создан (и недавно удалён) какой-то объект ранее. Т.к. ключ в маппинге `m_framebuffersData` является просто адресом объекта, то в некоторый момент времени `VulkanBaseContext::ApplyFramebuffer` получает совершенно новый объект фреймбуфера со старым адресом и ресурсы, ассоциированные с этим адресом объекта, полученные из `m_framebuffersData` по ключу - адресу объекта фреймбуфера, оказываются невалидными для нового объекта. Для решения этой проблемы необходимо вручную удалять значение из маппинга при удалении соответствующего объекта ключа.
Кроме спорадических крэшей, описанная выше проблема должна была приводить со временем к накоплению неосвобождённых дескрипторов ресурсов, ассоциированных с удалёнными фреймбуферами и хранящихся в `m_framebuffersData`.

https://jira.mail.ru/browse/MAPSME-13706