### PR TITLE
[python][generator] Fix for transit_path_experimental.

### DIFF
--- a/tools/python/maps_generator/generator/env.py
+++ b/tools/python/maps_generator/generator/env.py
@@ -214,8 +214,10 @@ class PathProvider:
 
     @property
     def transit_path_experimental(self) -> AnyStr:
-        return os.path.join(
-            self.intermediate_data_path, "transit_from_gtfs"
+        return (
+            os.path.join(self.intermediate_data_path, "transit_from_gtfs")
+            if settings.TRANSIT_URL
+            else ""
         )
 
     @property


### PR DESCRIPTION
Фикс ошибки: на `Stage Mwm` generator_tool всегда запускается с проброшенным параметром `--transit_path_experimental`. Нужно, чтобы он запускался с этим параметром только если заполнен путь к  json'ам с общественным транспортом в конфиге: `TRANSIT_URL`.