### PR TITLE
[openlr] Setting US locale to be able to parse double independently from locale.

### DIFF
--- a/openlr/openlr_stat/openlr_stat.cpp
+++ b/openlr/openlr_stat/openlr_stat.cpp
@@ -19,6 +19,7 @@
 #include "base/stl_helpers.hpp"
 
 #include <algorithm>
+#include <clocale>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -271,6 +272,7 @@ int main(int argc, char * argv[])
     exit(-1);
   }
 
+  std::setlocale(LC_ALL, "en_US.UTF-8");
   auto const segments = LoadSegments(document);
 
   std::vector<DecodedPath> paths(segments.size());


### PR DESCRIPTION
Для разбора xml с геометрией мы используем `.omim/3party/pugixml/`. В нем, для получения double используется метод strtod(...). Он конвертирует строчку в double. Данный метод зависит от локали. Например, у меня запущенный из консоли и из CLion openlr_stat давал разные результаты. При запуске из консоли стоит русская локаль. И strtod("42.648735046386697434", 0) возвращал 42, поскольку в русской локале разделитель запятая.

@mesozoic-drones PTAL