### PR TITLE
[maps_generator] Pass parameter make_transit_cross_mwm_experimental.

### DIFF
--- a/tools/python/maps_generator/generator/gen_tool.py
+++ b/tools/python/maps_generator/generator/gen_tool.py
@@ -41,6 +41,7 @@ class GenTool:
         "make_cross_mwm": bool,
         "make_routing_index": bool,
         "make_transit_cross_mwm": bool,
+        "make_transit_cross_mwm_experimental": bool,
         "preprocess": bool,
         "split_by_polygons": bool,
         "type_statistics": bool,

--- a/tools/python/maps_generator/generator/steps.py
+++ b/tools/python/maps_generator/generator/steps.py
@@ -316,6 +316,7 @@ def step_routing_transit(env: Env, country: AnyStr, **kwargs):
         transit_path=env.paths.transit_path,
         transit_path_experimental=env.paths.transit_path_experimental,
         make_transit_cross_mwm=True,
+        make_transit_cross_mwm_experimental=env.paths.transit_path_experimental,
         output=country,
         **kwargs,
     )


### PR DESCRIPTION
Прокидывание второго (и последнего) параметра в generator_tool для сборки экспериментальной транзитной секции. Он уже есть в generator_tool, PR добавляет его в питон.