### PR TITLE
[ios][editor] Remove conditions which can not be true.

### DIFF
--- a/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.h
+++ b/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.h
@@ -12,7 +12,6 @@
 
 - (void)configWithDelegate:(id<MWMEditorAdditionalNamesProtocol>)delegate
                       name:(StringUtf8Multilang const &)name
-additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes
-      selectedLanguageCode:(NSInteger)selectedLanguageCode;
+additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes;
 
 @end

--- a/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.mm
+++ b/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.mm
@@ -3,7 +3,6 @@
 
 @interface MWMEditorAdditionalNamesTableViewController ()
 
-@property (nonatomic) NSInteger selectedLanguageCode;
 @property (weak, nonatomic) id<MWMEditorAdditionalNamesProtocol> delegate;
 
 @end
@@ -20,12 +19,10 @@
 - (void)configWithDelegate:(id<MWMEditorAdditionalNamesProtocol>)delegate
                       name:(StringUtf8Multilang const &)name
 additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes
-      selectedLanguageCode:(NSInteger)selectedLanguageCode
 {
   self.delegate = delegate;
   m_name = name;
   m_additionalSkipLanguageCodes = additionalSkipLanguageCodes;
-  self.selectedLanguageCode = selectedLanguageCode;
 }
 
 - (void)viewDidLoad
@@ -40,17 +37,12 @@ additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes
   auto const getIndex = [](std::string const & lang) { return StringUtf8Multilang::GetLangIndex(lang); };
   StringUtf8Multilang::Languages const & supportedLanguages = StringUtf8Multilang::GetSupportedLanguages();
   m_languages.clear();
-  if (self.selectedLanguageCode == StringUtf8Multilang::kDefaultCode ||
-      self.selectedLanguageCode == StringUtf8Multilang::kInternationalCode)
-  {
-    return;
-  }
 
   auto constexpr kDefaultCode = StringUtf8Multilang::kDefaultCode;
   for (auto const & language : supportedLanguages)
   {
     auto const langIndex = getIndex(language.m_code);
-    if (self.selectedLanguageCode == NSNotFound && langIndex != kDefaultCode && m_name.HasString(langIndex))
+    if (langIndex != kDefaultCode && m_name.HasString(langIndex))
       continue;
     auto it = std::find(m_additionalSkipLanguageCodes.begin(), m_additionalSkipLanguageCodes.end(), langIndex);
     if (it == m_additionalSkipLanguageCodes.end())
@@ -78,7 +70,7 @@ additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes
   cell.detailTextLabel.text = @(language.m_code);
 
   int8_t const languageIndex = StringUtf8Multilang::GetLangIndex(language.m_code);
-  cell.accessoryType = (languageIndex == self.selectedLanguageCode ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone);
+  cell.accessoryType = UITableViewCellAccessoryNone;
   return cell;
 }
 

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -1067,8 +1067,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellType> const & cells, UIT
     MWMEditorAdditionalNamesTableViewController * dvc = segue.destinationViewController;
     [dvc configWithDelegate:self
                                name:m_mapObject.GetNameMultilang()
-        additionalSkipLanguageCodes:m_newAdditionalLanguages
-               selectedLanguageCode:((NSNumber *)sender).integerValue];
+        additionalSkipLanguageCodes:m_newAdditionalLanguages];
   }
 }
 


### PR DESCRIPTION
Что такое selectedLanguageCode не понятно, сейчас он всегда равен NSIntegerMax и условия типа `languageIndex == self.selectedLanguageCode`, `self.selectedLanguageCode == StringUtf8Multilang::kDefaultCode`, `self.selectedLanguageCode == StringUtf8Multilang::kInternationalCode` не могут выполняться.