### PR TITLE
[ios] Remove unused method.

### DIFF
--- a/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.m
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.m
@@ -39,8 +39,6 @@ static CGFloat const kErrorLabelHeight = 16;
   [self processValidation];
 }
 
-- (IBAction)changeLanguageTap { [self.delegate editAdditionalNameLanguage:self.code]; }
-
 - (void)processValidation
 {
   if (self.isValid)


### PR DESCRIPTION
При добавлении метод был привязан к экшену в xib:

https://github.com/mapsme/omim/commit/c360e8fb91d2478f6bc6f8ad9265494b1553172e 

но в 2016 году его из xib удалили:
https://github.com/mapsme/omim/pull/4485

насколько я поняла, сначала была реализована более примитивная поддержка языков в редакторе, частью которой был этот метод, потом переписали на более "продвинутую" и в процессе был убран контрол к которому был привязан метод, а метод не удалили.