### PR TITLE
[openlr] Comparing edges in A* without altitude.

### DIFF
--- a/openlr/openlr_decoder.cpp
+++ b/openlr/openlr_decoder.cpp
@@ -384,7 +384,7 @@ public:
 
   bool DecodeSegment(LinearSegment const & segment, DecodedPath & path, v2::Stats & stat)
   {
-    LOG(LDEBUG, ("DecodeSegment(...) seg id:", segment.m_segmentId, ", point num:", segment.GetLRPs().size()));
+    LOG(LINFO, ("DecodeSegment(...) seg id:", segment.m_segmentId, ", point num:", segment.GetLRPs().size()));
 
     uint32_t constexpr kMaxJunctionCandidates = 10;
     uint32_t constexpr kMaxProjectionCandidates = 5;
@@ -395,7 +395,7 @@ public:
     CHECK_GREATER(points.size(), 1, ("A segment cannot consist of less than two points"));
     vector<ScorePathVec> lineCandidates;
     lineCandidates.reserve(points.size());
-    LOG(LDEBUG, ("Decoding segment:", segment.m_segmentId, "with", points.size(), "points"));
+    LOG(LINFO, ("Decoding segment:", segment.m_segmentId, "with", points.size(), "points"));
 
     ScoreCandidatePointsGetter pointsGetter(kMaxJunctionCandidates, kMaxProjectionCandidates,
                                             m_dataSource, m_graph);
@@ -431,7 +431,7 @@ public:
       actualRouteDistanceM += EdgeLength(e);
 
     auto const scale = actualRouteDistanceM / requiredRouteDistanceM;
-    LOG(LDEBUG, ("actualRouteDistance:", actualRouteDistanceM,
+    LOG(LINFO, ("actualRouteDistance:", actualRouteDistanceM,
         "requiredRouteDistance:", requiredRouteDistanceM, "scale:", scale));
 
     if (segment.m_locationReference.m_positiveOffsetMeters +

--- a/openlr/score_paths_connector.cpp
+++ b/openlr/score_paths_connector.cpp
@@ -124,9 +124,10 @@ bool ValidatePathByLength(Graph::EdgeVector const & path, double distanceToNextP
 
 bool AreEdgesEqualWithoutAltitude(Graph::Edge const & e1, Graph::Edge const & e2)
 {
-  return e1.GetType() == e2.GetType() && e1.GetFeatureId() == e2.GetFeatureId() &&
-         e1.IsForward() == e2.IsForward() && e1.GetSegId() == e2.GetSegId() &&
-         e1.GetStartPoint() == e2.GetStartPoint() && e1.GetEndPoint() == e2.GetEndPoint();
+  return make_tuple(e1.GetType(), e1.GetFeatureId(), e1.IsForward(), e1.GetSegId(),
+                    e1.GetStartPoint(), e1.GetEndPoint()) ==
+         make_tuple(e2.GetType(), e2.GetFeatureId(), e2.IsForward(), e2.GetSegId(),
+                    e2.GetStartPoint(), e2.GetEndPoint());
 }
 }  // namespace
 

--- a/openlr/score_paths_connector.cpp
+++ b/openlr/score_paths_connector.cpp
@@ -121,6 +121,13 @@ bool ValidatePathByLength(Graph::EdgeVector const & path, double distanceToNextP
 
   return true;
 }
+
+bool AreEdgesEqualWithoutAltitude(Graph::Edge const & e1, Graph::Edge const & e2)
+{
+  return e1.GetType() == e2.GetType() && e1.GetFeatureId() == e2.GetFeatureId() &&
+         e1.IsForward() == e2.IsForward() && e1.GetSegId() == e2.GetSegId() &&
+         e1.GetStartPoint() == e2.GetStartPoint() && e1.GetEndPoint() == e2.GetEndPoint();
+}
 }  // namespace
 
 ScorePathsConnector::ScorePathsConnector(Graph & graph, RoadInfoGetter & infoGetter, v2::Stats & stat)
@@ -254,7 +261,7 @@ bool ScorePathsConnector::FindShortestPath(Graph::Edge const & from, Graph::Edge
     if (stateScore > scores[stateEdge])
       continue;
 
-    if (stateEdge == to)
+    if (AreEdgesEqualWithoutAltitude(stateEdge, to))
     {
       for (auto edge = stateEdge; edge != from; edge = links[edge])
         path.emplace_back(edge);
@@ -322,7 +329,8 @@ bool ScorePathsConnector::ConnectAdjacentCandidateLines(Graph::EdgeVector const 
   resultPath.insert(resultPath.end(), from.cbegin(), prev(from.cend()));
   resultPath.insert(resultPath.end(), shortestPath.cbegin(), shortestPath.cend());
 
-  CHECK_EQUAL(to.front(), shortestPath.back(), ());
+  CHECK(AreEdgesEqualWithoutAltitude(to.front(), shortestPath.back()),
+        (to.front(), shortestPath.back()));
   resultPath.insert(resultPath.end(), next(to.begin()), to.end());
 
   return !resultPath.empty();

--- a/routing/road_graph.hpp
+++ b/routing/road_graph.hpp
@@ -73,6 +73,8 @@ public:
     return GetEndJunction().GetPoint() - GetStartJunction().GetPoint();
   }
 
+  Type GetType() const { return m_type; }
+
   Edge GetReverseEdge() const;
 
   bool SameRoadSegmentAndDirection(Edge const & r) const;


### PR DESCRIPTION
В нынешней реализации openlr мачинга, в A* сравниваются дуги (`Edge`). В дуге содержатся поля типа `PointWithAltitude`. Высота в этом типе берется иногда из `FeaturesRoadGraph` и тогда она корректная, а иногда задается равной 0, если точка получается в результате `DataSource::ForEachInRect(...)`.

Сначала мне показался наиболее чистым вариант, при котором везде используется правильная высота. Но он потребовал достаточно большого и не очень хорошего изменения в коде. Чтоб получить высоту на основании PointD, нужно искать эту точку в кэшах `FeaturesRoadGraph` или загружать еще раз секцию с высотами.

Я решил не делать этого, а вместо этого использовать функцию сравнения `AreEdgesEqualWithoutAltitude(...)`, которая не использует высоты. В действительности, она может даже не сравнивать точки начала и конца дуги. Но пока я оставил сравнение их.

Результаты мачинга на выборке по 20-25 дуг.
До - значит до https://github.com/mapsme/omim/pull/13255 и этого PR.
После - значит с этими двумя PR-ми.

До исправлений на Нью-Йорк 
Base: mean: 0.7098, std: 0.4193
После баг фиксов
New: mean: 0.9693, std: 0.0755

До исправлений на Лондон
Base: mean: 0.8467, std: 0.2980
После баг фиксов
New: mean: 0.8529, std: 0.2863

До исправлений на Сан-Марино
Base: mean: 0.9663, std: 0.0752
После баг фиксов
New: mean: 0.9731, std: 0.0604

@mesozoic-drones PTAL