### PR TITLE
[search] Fix clang 11.0.3 crash.

### DIFF
--- a/search/types_skipper.cpp
+++ b/search/types_skipper.cpp
@@ -16,13 +16,14 @@ TypesSkipper::TypesSkipper()
 {
   Classificator const & c = classif();
 
-  for (auto const & e : (StringIL[]){{"building"}, {"highway"}, {"landuse"}, {"natural"},
-                                     {"office"}, {"waterway"}, {"area:highway"}})
+  StringIL const typesLengthOne[] = {{"building"}, {"highway"}, {"landuse"}, {"natural"},
+                                     {"office"}, {"waterway"}, {"area:highway"}};
+  for (auto const & e : typesLengthOne)
   {
     m_skipIfEmptyName[0].push_back(c.GetTypeByPath(e));
   }
 
-  for (auto const & e : (StringIL[]){{"man_made", "chimney"},
+  StringIL const typesLengthTwo[] = {{"man_made", "chimney"},
                                      {"place", "country"},
                                      {"place", "state"},
                                      {"place", "county"},
@@ -31,10 +32,12 @@ TypesSkipper::TypesSkipper()
                                      {"place", "town"},
                                      {"place", "suburb"},
                                      {"place", "neighbourhood"},
-                                     {"place", "square"}})
+                                     {"place", "square"}};
+  for (auto const & e : typesLengthTwo)
   {
     m_skipIfEmptyName[1].push_back(c.GetTypeByPath(e));
   }
+
   m_skipAlways[1].push_back(c.GetTypeByPath({"sponsored", "partner18"}));
   m_skipAlways[1].push_back(c.GetTypeByPath({"sponsored", "partner19"}));
   m_skipAlways[0].push_back(c.GetTypeByPath({"isoline"}));


### PR DESCRIPTION
Исправление креша на Clang 11.0.3.

https://en.cppreference.com/w/cpp/language/range-for

Temporary range expression
If range_expression returns a temporary, its lifetime is extended until the end of the loop, as indicated by binding to the forwarding reference __range, but beware that the lifetime of any temporary within range_expression is not extended.

У нас массив инициалайзер листов, гарантируется что массив доживёт до конца времени работы цикла. Вряд ли под beware that the lifetime of any temporary within range_expression is not extended. имеется в виду что массив будет жить а элементы его умрут (это странно, по идее речь должна идти о более сложных конструкциях).

С компиляторами отличными от Clang 11.0.3 работало.