### PR TITLE
[openlr] Using secondary roads for FRC4.

### DIFF
--- a/openlr/helpers.cpp
+++ b/openlr/helpers.cpp
@@ -67,7 +67,9 @@ optional<Score> GetFrcScore(Graph::Edge const & e, FunctionalRoadClass functiona
     if (hwClass == ftypes::HighwayClass::LivingStreet || hwClass == ftypes::HighwayClass::Service)
       return optional<Score>(kMaxScoreForFrc);
 
-    return hwClass == ftypes::HighwayClass::Tertiary ? optional<Score>(0) : nullopt;
+    return (hwClass == ftypes::HighwayClass::Tertiary || hwClass == ftypes::HighwayClass::Secondary)
+               ? optional<Score>(0)
+               : nullopt;
 
   case FunctionalRoadClass::FRC5:
   case FunctionalRoadClass::FRC6:


### PR DESCRIPTION
В процессе разметки выяснилось, что появились дуги с FRC4, которые должны мачится на highway secondary в osm. Этот PR отражает это изменение.

@mesozoic-drones 