### PR TITLE
[search_quality] aloha_to_samples_tool: add mode to save all events from aloha as samples.

### DIFF
--- a/openlr/helpers.cpp
+++ b/openlr/helpers.cpp
@@ -67,7 +67,9 @@ optional<Score> GetFrcScore(Graph::Edge const & e, FunctionalRoadClass functiona
     if (hwClass == ftypes::HighwayClass::LivingStreet || hwClass == ftypes::HighwayClass::Service)
       return optional<Score>(kMaxScoreForFrc);
 
-    return hwClass == ftypes::HighwayClass::Tertiary ? optional<Score>(0) : nullopt;
+    return (hwClass == ftypes::HighwayClass::Tertiary || hwClass == ftypes::HighwayClass::Secondary)
+               ? optional<Score>(0)
+               : nullopt;
 
   case FunctionalRoadClass::FRC5:
   case FunctionalRoadClass::FRC6:

--- a/search/search_quality/aloha_to_samples_tool/aloha_to_samples_tool.cpp
+++ b/search/search_quality/aloha_to_samples_tool/aloha_to_samples_tool.cpp
@@ -36,6 +36,9 @@ DEFINE_string(categorial, "all",
               "Allowed values: 'all' - save all requests; 'only' - save only categorial requests; "
               "'no' - save all but categorial requests.");
 DEFINE_string(locales, "", "Comma separated locales to filter samples.");
+DEFINE_string(mode, "clicked",
+              "Allowed values: 'all' - save all searchEmitResultAndCoords event as samples; "
+              "'clicked' - save only samples wits corresponding searchShowResult event, add results to samples.");
 
 struct EmitInfo
 {
@@ -165,7 +168,7 @@ optional<Sample::Result> ParseResultWithCoords(string const & str)
   return res;
 }
 
-optional<Sample> MakeSample(EmitInfo const & info, size_t relevantPos)
+optional<Sample> MakeSample(EmitInfo const & info, optional<size_t> relevantPos)
 {
   Sample sample;
   sample.m_query = MakeUniString(info.m_query);
@@ -173,6 +176,9 @@ optional<Sample> MakeSample(EmitInfo const & info, size_t relevantPos)
   sample.m_pos = info.m_pos;
   sample.m_viewport = info.m_viewport;
   sample.m_results.reserve(info.m_results.size());
+  if (!relevantPos)
+    return sample;
+
   for (size_t i = 0; i < info.m_results.size(); ++i)
   {
     auto res = ParseResultWithCoords(info.m_results[i]);
@@ -186,6 +192,17 @@ optional<Sample> MakeSample(EmitInfo const & info, size_t relevantPos)
   return sample;
 }
 
+void PrintSample(EmitInfo const & info, optional<size_t> relevantPos)
+{
+  auto const sample = MakeSample(info, relevantPos);
+  if (!sample)
+    return;
+
+  string json;
+  Sample::SerializeToJSONLines({*sample}, json);
+  cout << json;
+}
+
 int main(int argc, char * argv[])
 {
   google::SetUsageMessage("This tool converts events from Alohalytics to search samples.");
@@ -195,6 +212,12 @@ int main(int argc, char * argv[])
   {
     LOG(LINFO, ("Invalid categorial filter mode:", FLAGS_categorial,
                 "allowed walues are: 'all', 'only', 'no'."));
+    return EXIT_FAILURE;
+  }
+
+  if (FLAGS_mode != "all" && FLAGS_mode != "clicked")
+  {
+    LOG(LINFO, ("Invalid mode:", FLAGS_mode, "allowed walues are: 'all', 'clicked'."));
     return EXIT_FAILURE;
   }
 
@@ -246,6 +269,9 @@ int main(int argc, char * argv[])
     {
       info = ParseEmitResultsAndCoords(kpe->pairs);
       newUser = false;
+
+      if (FLAGS_mode == "all")
+        PrintSample(*info, {});
     }
     else if (kpe->key == "searchShowResult" && !newUser)
     {
@@ -267,12 +293,7 @@ int main(int argc, char * argv[])
       if (!resultMatches)
         continue;
 
-      if (auto const sample = MakeSample(*info, result->m_pos))
-      {
-        string json;
-        Sample::SerializeToJSONLines({*sample}, json);
-        cout << json;
-      }
+      PrintSample(*info, result->m_pos);
     }
   }
   return EXIT_SUCCESS;

--- a/search/types_skipper.cpp
+++ b/search/types_skipper.cpp
@@ -16,13 +16,14 @@ TypesSkipper::TypesSkipper()
 {
   Classificator const & c = classif();
 
-  for (auto const & e : (StringIL[]){{"building"}, {"highway"}, {"landuse"}, {"natural"},
-                                     {"office"}, {"waterway"}, {"area:highway"}})
+  StringIL const typesLengthOne[] = {{"building"}, {"highway"}, {"landuse"}, {"natural"},
+                                     {"office"}, {"waterway"}, {"area:highway"}};
+  for (auto const & e : typesLengthOne)
   {
     m_skipIfEmptyName[0].push_back(c.GetTypeByPath(e));
   }
 
-  for (auto const & e : (StringIL[]){{"man_made", "chimney"},
+  StringIL const typesLengthTwo[] = {{"man_made", "chimney"},
                                      {"place", "country"},
                                      {"place", "state"},
                                      {"place", "county"},
@@ -31,10 +32,12 @@ TypesSkipper::TypesSkipper()
                                      {"place", "town"},
                                      {"place", "suburb"},
                                      {"place", "neighbourhood"},
-                                     {"place", "square"}})
+                                     {"place", "square"}};
+  for (auto const & e : typesLengthTwo)
   {
     m_skipIfEmptyName[1].push_back(c.GetTypeByPath(e));
   }
+
   m_skipAlways[1].push_back(c.GetTypeByPath({"sponsored", "partner18"}));
   m_skipAlways[1].push_back(c.GetTypeByPath({"sponsored", "partner19"}));
   m_skipAlways[0].push_back(c.GetTypeByPath({"isoline"}));

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -1,13 +1,108 @@
 project(shaders)
 
-execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} ${OMIM_ROOT}/shaders/gl_shaders_preprocessor.py
-  ${OMIM_ROOT}/shaders/GL
-  shader_index.txt
-  programs.hpp
-  shaders_lib.glsl
-  ${OMIM_ROOT}/shaders
-  gl_shaders
+add_library(${PROJECT_NAME})
+
+set(
+  shader_files
+    GL/area.vsh.glsl
+    GL/area3d.vsh.glsl
+    GL/area3d_outline.vsh.glsl
+    GL/arrow3d.fsh.glsl
+    GL/arrow3d.vsh.glsl
+    GL/arrow3d_outline.fsh.glsl
+    GL/arrow3d_shadow.fsh.glsl
+    GL/arrow3d_shadow.vsh.glsl
+    GL/circle.fsh.glsl
+    GL/circle.vsh.glsl
+    GL/circle_point.fsh.glsl
+    GL/circle_point.vsh.glsl
+    GL/colored_symbol.fsh.glsl
+    GL/colored_symbol.vsh.glsl
+    GL/colored_symbol_billboard.vsh.glsl
+    GL/dashed_line.fsh.glsl
+    GL/dashed_line.vsh.glsl
+    GL/debug_rect.fsh.glsl
+    GL/debug_rect.vsh.glsl
+    GL/hatching_area.fsh.glsl
+    GL/hatching_area.vsh.glsl
+    GL/line.fsh.glsl
+    GL/line.vsh.glsl
+    GL/masked_texturing.fsh.glsl
+    GL/masked_texturing.vsh.glsl
+    GL/masked_texturing_billboard.vsh.glsl
+    GL/my_position.vsh.glsl
+    GL/path_symbol.vsh.glsl
+    GL/position_accuracy3d.vsh.glsl
+    GL/route.fsh.glsl
+    GL/route.vsh.glsl
+    GL/route_arrow.fsh.glsl
+    GL/route_arrow.vsh.glsl
+    GL/route_dash.fsh.glsl
+    GL/route_marker.fsh.glsl
+    GL/route_marker.vsh.glsl
+    GL/ruler.vsh.glsl
+    GL/screen_quad.vsh.glsl
+    GL/selection_line.fsh.glsl
+    GL/selection_line.vsh.glsl
+    GL/shaders_lib.glsl
+    GL/smaa_blending_weight.fsh.glsl
+    GL/smaa_blending_weight.vsh.glsl
+    GL/smaa_edges.fsh.glsl
+    GL/smaa_edges.vsh.glsl
+    GL/smaa_final.fsh.glsl
+    GL/smaa_final.vsh.glsl
+    GL/solid_color.fsh.glsl
+    GL/text.fsh.glsl
+    GL/text.vsh.glsl
+    GL/text_billboard.vsh.glsl
+    GL/text_fixed.fsh.glsl
+    GL/text_outlined.vsh.glsl
+    GL/text_outlined_billboard.vsh.glsl
+    GL/text_outlined_gui.vsh.glsl
+    GL/texturing.fsh.glsl
+    GL/texturing.vsh.glsl
+    GL/texturing3d.fsh.glsl
+    GL/texturing_billboard.vsh.glsl
+    GL/texturing_gui.vsh.glsl
+    GL/traffic.fsh.glsl
+    GL/traffic.vsh.glsl
+    GL/traffic_circle.fsh.glsl
+    GL/traffic_circle.vsh.glsl
+    GL/traffic_line.fsh.glsl
+    GL/traffic_line.vsh.glsl
+    GL/transit.fsh.glsl
+    GL/transit.vsh.glsl
+    GL/transit_circle.fsh.glsl
+    GL/transit_circle.vsh.glsl
+    GL/transit_marker.fsh.glsl
+    GL/transit_marker.vsh.glsl
+    GL/user_mark.fsh.glsl
+    GL/user_mark.vsh.glsl
+    GL/user_mark_billboard.vsh.glsl
+)
+set_source_files_properties(${shader_files} PROPERTIES HEADER_FILE_ONLY TRUE)
+
+add_custom_command(
+  WORKING_DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+  DEPENDS
+    gl_shaders_preprocessor.py
+    ${shader_files}
+    GL/shader_index.txt
+    programs.hpp
+  COMMAND
+    ${PYTHON_EXECUTABLE}
+    ARGS
+      gl_shaders_preprocessor.py
+      GL/
+      shader_index.txt
+      programs.hpp
+      shaders_lib.glsl
+      ./
+      gl_shaders
+  OUTPUT
+    ${CMAKE_CURRENT_SOURCE_DIR}/gl_shaders.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gl_shaders.hpp
 )
 
 include_directories(
@@ -17,120 +112,40 @@ include_directories(
   ${OMIM_ROOT}/3party/vulkan_wrapper
 )
 
-set(
-  SRC
-  gl_program_info.hpp
-  gl_program_params.cpp
-  gl_program_params.hpp
-  gl_program_pool.cpp
-  gl_program_pool.hpp
-  gl_shaders.cpp
-  gl_shaders.hpp
-  program_manager.cpp
-  program_manager.hpp
-  program_params.cpp
-  program_params.hpp
-  program_pool.hpp
-  programs.hpp
-  vulkan_program_params.cpp
-  vulkan_program_params.hpp
-  vulkan_program_pool.cpp
-  vulkan_program_pool.hpp
+target_sources(
+  ${PROJECT_NAME}
+  PRIVATE
+    ${shader_files}
+    gl_program_info.hpp
+    gl_program_params.cpp
+    gl_program_params.hpp
+    gl_program_pool.cpp
+    gl_program_pool.hpp
+    gl_shaders.cpp
+    gl_shaders.hpp
+    program_manager.cpp
+    program_manager.hpp
+    program_params.cpp
+    program_params.hpp
+    program_pool.hpp
+    programs.hpp
+    vulkan_program_params.cpp
+    vulkan_program_params.hpp
+    vulkan_program_pool.cpp
+    vulkan_program_pool.hpp
 )
 
 if (PLATFORM_IPHONE)
-append(
-  SRC
-  metal_program_params.hpp
-  metal_program_params.mm
-  metal_program_pool.hpp
-  metal_program_pool.mm
-  metal/debug_rect.metal
-  program_manager_metal.mm
-)
+  target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+      metal/debug_rect.metal
+      metal_program_params.hpp
+      metal_program_params.mm
+      metal_program_pool.hpp
+      metal_program_pool.mm
+      program_manager_metal.mm
+  )
 endif()
-
-add_library(${PROJECT_NAME} ${SRC})
-
-set(
-  GL_SHADERS_SRC
-  GL/area.vsh.glsl
-  GL/area3d.vsh.glsl
-  GL/area3d_outline.vsh.glsl
-  GL/arrow3d.fsh.glsl
-  GL/arrow3d.vsh.glsl
-  GL/arrow3d_outline.fsh.glsl
-  GL/arrow3d_shadow.fsh.glsl
-  GL/arrow3d_shadow.vsh.glsl
-  GL/circle.fsh.glsl
-  GL/circle.vsh.glsl
-  GL/circle_point.fsh.glsl
-  GL/circle_point.vsh.glsl
-  GL/colored_symbol.fsh.glsl
-  GL/colored_symbol.vsh.glsl
-  GL/colored_symbol_billboard.vsh.glsl
-  GL/dashed_line.fsh.glsl
-  GL/dashed_line.vsh.glsl
-  GL/debug_rect.fsh.glsl
-  GL/debug_rect.vsh.glsl
-  GL/hatching_area.fsh.glsl
-  GL/hatching_area.vsh.glsl
-  GL/line.fsh.glsl
-  GL/line.vsh.glsl
-  GL/masked_texturing.fsh.glsl
-  GL/masked_texturing.vsh.glsl
-  GL/masked_texturing_billboard.vsh.glsl
-  GL/my_position.vsh.glsl
-  GL/path_symbol.vsh.glsl
-  GL/position_accuracy3d.vsh.glsl
-  GL/route.fsh.glsl
-  GL/route.vsh.glsl
-  GL/route_arrow.fsh.glsl
-  GL/route_arrow.vsh.glsl
-  GL/route_dash.fsh.glsl
-  GL/route_marker.fsh.glsl
-  GL/route_marker.vsh.glsl
-  GL/ruler.vsh.glsl
-  GL/selection_line.fsh.glsl
-  GL/selection_line.vsh.glsl
-  GL/screen_quad.vsh.glsl
-  GL/shader_index.txt
-  GL/shaders_lib.glsl
-  GL/smaa_blending_weight.fsh.glsl
-  GL/smaa_blending_weight.vsh.glsl
-  GL/smaa_edges.fsh.glsl
-  GL/smaa_edges.vsh.glsl
-  GL/smaa_final.fsh.glsl
-  GL/smaa_final.vsh.glsl
-  GL/solid_color.fsh.glsl
-  GL/text.fsh.glsl
-  GL/text.vsh.glsl
-  GL/text_billboard.vsh.glsl
-  GL/text_fixed.fsh.glsl
-  GL/text_outlined.vsh.glsl
-  GL/text_outlined_billboard.vsh.glsl
-  GL/text_outlined_gui.vsh.glsl
-  GL/texturing.fsh.glsl
-  GL/texturing.vsh.glsl
-  GL/texturing3d.fsh.glsl
-  GL/texturing_billboard.vsh.glsl
-  GL/texturing_gui.vsh.glsl
-  GL/traffic.fsh.glsl
-  GL/traffic.vsh.glsl
-  GL/traffic_circle.fsh.glsl
-  GL/traffic_circle.vsh.glsl
-  GL/traffic_line.fsh.glsl
-  GL/traffic_line.vsh.glsl
-  GL/transit.fsh.glsl
-  GL/transit.vsh.glsl
-  GL/transit_circle.fsh.glsl
-  GL/transit_circle.vsh.glsl
-  GL/transit_marker.fsh.glsl
-  GL/transit_marker.vsh.glsl
-  GL/user_mark.fsh.glsl
-  GL/user_mark.vsh.glsl
-  GL/user_mark_billboard.vsh.glsl
-)
-add_custom_target(gl_shaders_sources SOURCES ${GL_SHADERS_SRC})
 
 omim_add_test_subdirectory(shaders_tests)


### PR DESCRIPTION
так удобнее разбирать не кликнутые запросы из алохи, но т.к. на выходе много всего не склеено лучше по умолчанию оставить старый режим.