### PR TITLE
[generator_integration_tests] Fix CheckGeneratedData tests after adding alt_name to StringUtf8Multilang.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -378,7 +378,7 @@ public:
     TEST(rawGenerator.Execute(), ());
 
     TestGeneratedFile(cameraToWays, 0 /* fileSize */);
-    TestGeneratedFile(citiesAreas, 18601 /* fileSize */);
+    TestGeneratedFile(citiesAreas, 18705 /* fileSize */);
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);


### PR DESCRIPTION
При сохранении промежуточного файла CITIES_AREAS_TMP_FILENAME мы записываем туда фичи, в том числе name, поэтому после того как мы начали сохранять alt_name/old_name/name:da/name:no/name:id которые ранее не сохраняли размер файла поменялся.
Конкретно на тестовые данные повлиял alt_name.

Место где пишутся фичи включая имя:
```C++
void CityAreaCollector::CollectFeature(FeatureBuilder const & feature, OsmElement const &)
{
  auto const & isCityTownOrVillage = ftypes::IsCityTownOrVillageChecker::Instance();
  if (!(feature.IsArea() && isCityTownOrVillage(feature.GetTypes())))
    return;

  auto copy = feature;
  if (copy.PreSerialize())
    m_writer->Write(copy);
}
```