### PR TITLE
[generator][storage] Convert place=province to place=state for Japan, South Korea and Turkey.

### DIFF
--- a/generator/booking_quality_check/CMakeLists.txt
+++ b/generator/booking_quality_check/CMakeLists.txt
@@ -19,6 +19,7 @@ omim_link_libraries(
   routing
   traffic
   routing_common
+  storage
   editor
   indexer
   geometry

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -626,15 +626,20 @@ void PreprocessElement(OsmElement * p)
   CHECK(infoGetter, ());
   auto static const countryTree = storage::LoadCountriesFromFile(COUNTRIES_FILE);
   CHECK(countryTree, ());
-  std::set<storage::CountryId> provinceToStateCountries = {"Japan", "South Korea", "Turkey"};
   p->UpdateTag("place", [&](string & value) {
     if (value != "province")
       return;
 
+    std::array<storage::CountryId, 3> const provinceToStateCountries = {"Japan", "South Korea",
+                                                                        "Turkey"};
     auto const pt = mercator::FromLatLon(p->m_lat, p->m_lon);
     auto const countryId = infoGetter->GetRegionCountryId(pt);
-    if (provinceToStateCountries.count(storage::GetTopmostParentFor(*countryTree, countryId)) > 0)
+    auto const country = storage::GetTopmostParentFor(*countryTree, countryId);
+    if (base::FindIf(provinceToStateCountries, [&](auto const & c) { return c == country; }) !=
+        provinceToStateCountries.end())
+    {
       value = "state";
+    }
   });
 }
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -17,6 +17,8 @@ set(
   country_parent_getter.hpp
   country_tree.cpp
   country_tree.hpp
+  country_tree_helpers.cpp
+  country_tree_helpers.hpp
   diff_scheme/apply_diff.cpp
   diff_scheme/apply_diff.hpp
   diff_scheme/diffs_data_source.cpp

--- a/storage/country_tree_helpers.cpp
+++ b/storage/country_tree_helpers.cpp
@@ -3,6 +3,7 @@
 #include "base/logging.hpp"
 
 #include <vector>
+#include <utility>
 
 namespace storage
 {
@@ -50,6 +51,6 @@ std::optional<CountryTree> LoadCountriesFromFile(std::string const & path)
   if (res == -1)
     return {};
 
-  return countries;
+  return std::optional<CountryTree>(std::move(countries));
 }
 }  // namespace storage

--- a/storage/country_tree_helpers.cpp
+++ b/storage/country_tree_helpers.cpp
@@ -13,7 +13,7 @@ CountryId GetTopmostParentFor(CountryTree const & countries, CountryId const & c
   countries.Find(countryId, nodes);
   if (nodes.empty())
   {
-    LOG(LWARNING, ("CountryId =", countryId, "not found in m_countries."));
+    LOG(LWARNING, ("CountryId =", countryId, "not found in countries."));
     return {};
   }
 

--- a/storage/country_tree_helpers.cpp
+++ b/storage/country_tree_helpers.cpp
@@ -1,0 +1,55 @@
+#include "storage/country_tree_helpers.hpp"
+
+#include "base/logging.hpp"
+
+#include <vector>
+
+namespace storage
+{
+CountryId GetTopmostParentFor(CountryTree const & countries, CountryId const & countryId)
+{
+  std::vector<CountryTree::Node const *> nodes;
+  countries.Find(countryId, nodes);
+  if (nodes.empty())
+  {
+    LOG(LWARNING, ("CountryId =", countryId, "not found in m_countries."));
+    return {};
+  }
+
+  if (nodes.size() > 1)
+  {
+    // Disputed territory. Has multiple parents.
+    return countryId;
+  }
+
+  auto result = nodes[0];
+
+  if (!result->HasParent())
+    return result->Value().Name();
+
+  auto parent = &(result->Parent());
+  while (parent->HasParent())
+  {
+    result = parent;
+    parent = &(result->Parent());
+  }
+
+  return result->Value().Name();
+}
+
+std::optional<CountryTree> LoadCountriesFromFile(std::string const & path)
+{
+  Affiliations affiliations;
+  CountryNameSynonyms countryNameSynonyms;
+  MwmTopCityGeoIds mwmTopCityGeoIds;
+  MwmTopCountryGeoIds mwmTopCountryGeoIds;
+  CountryTree countries;
+  auto const res = LoadCountriesFromFile(path, countries, affiliations, countryNameSynonyms,
+                                         mwmTopCityGeoIds, mwmTopCountryGeoIds);
+
+  if (res == -1)
+    return {};
+
+  return countries;
+}
+}  // namespace storage

--- a/storage/country_tree_helpers.cpp
+++ b/storage/country_tree_helpers.cpp
@@ -20,7 +20,14 @@ CountryId GetTopmostParentFor(CountryTree const & countries, CountryId const & c
   if (nodes.size() > 1)
   {
     // Disputed territory. Has multiple parents.
-    return countryId;
+    CHECK(nodes[0]->HasParent(), ());
+    auto const parentId = nodes[0]->Parent().Value().Name();
+    for (size_t i = 1; i < nodes.size(); ++i)
+    {
+      if (nodes[i]->Parent().Value().Name() != parentId)
+        return countryId;
+    }
+    return GetTopmostParentFor(countries, parentId);
   }
 
   auto result = nodes[0];

--- a/storage/country_tree_helpers.hpp
+++ b/storage/country_tree_helpers.hpp
@@ -12,6 +12,6 @@ namespace storage
 std::optional<CountryTree> LoadCountriesFromFile(std::string const & path);
 
 // Returns topmost country id prior root id or |countryId| itself, if it's already a topmost node or
-// it's a disputed territory.
+// disputed territory id if |countryId| is a disputed territory or belongs to disputed territory.
 CountryId GetTopmostParentFor(CountryTree const & countries, CountryId const & countryId);
 }  // namespace storage

--- a/storage/country_tree_helpers.hpp
+++ b/storage/country_tree_helpers.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "storage/country_tree.hpp"
+#include "storage/storage_defines.hpp"
+
+#include <optional>
+#include <string>
+
+namespace storage
+{
+// Loads CountryTree only, without affiliations/synonyms/catalogIds.
+std::optional<CountryTree> LoadCountriesFromFile(std::string const & path);
+
+// Returns topmost country id prior root id or |countryId| itself, if it's already a topmost node or
+// it's a disputed territory.
+CountryId GetTopmostParentFor(CountryTree const & countries, CountryId const & countryId);
+}  // namespace storage

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -1,11 +1,10 @@
 #include "storage/storage.hpp"
 
+#include "storage/country_tree_helpers.hpp"
 #include "storage/diff_scheme/apply_diff.hpp"
 #include "storage/diff_scheme/diff_scheme_loader.hpp"
 #include "storage/http_map_files_downloader.hpp"
 #include "storage/storage_helpers.hpp"
-
-#include "defines.hpp"
 
 #include "platform/local_country_file_utils.hpp"
 #include "platform/marketing_service.hpp"
@@ -24,11 +23,12 @@
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 
+#include "defines.hpp"
+
 #include <algorithm>
 #include <chrono>
-#include <sstream>
-
 #include <limits>
+#include <sstream>
 
 #include "3party/Alohalytics/src/alohalytics.h"
 
@@ -1787,16 +1787,7 @@ CountryId const Storage::GetParentIdFor(CountryId const & countryId) const
 
 CountryId const Storage::GetTopmostParentFor(CountryId const & countryId) const
 {
-  auto const rootId = GetRootId();
-  auto result = countryId;
-  auto parent = GetParentIdFor(result);
-  while (!parent.empty() && parent != rootId)
-  {
-    result = move(parent);
-    parent = GetParentIdFor(result);
-  }
-
-  return result;
+  return ::storage::GetTopmostParentFor(m_countries, countryId);
 }
 
 MwmSize Storage::GetRemoteSize(CountryFile const & file) const

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -368,7 +368,8 @@ public:
                           size_t level = 0) const;
 
   /// \brief Returns topmost country id prior root id or |countryId| itself, if it's already
-  /// a topmost node or it's a disputed territory.
+  /// a topmost node or disputed territory id if |countryId| is a disputed territory or belongs to
+  /// disputed territory.
   CountryId const GetTopmostParentFor(CountryId const & countryId) const;
   /// \brief Returns parent id for node if node has single parent. Otherwise (if node is disputed
   /// territory and has multiple parents or does not exist) returns empty CountryId

--- a/storage/storage_tests/storage_tests.cpp
+++ b/storage/storage_tests/storage_tests.cpp
@@ -1384,6 +1384,17 @@ UNIT_TEST(StorageTest_GetTopmostNodesFor)
   TEST_EQUAL(path[1], "Palestine Region", (path));
 }
 
+UNIT_TEST(StorageTest_GetTopmostParentFor)
+{
+  Storage storage;
+
+  TEST_EQUAL(storage.GetTopmostParentFor("France_Auvergne_Allier"), "France", ());
+  TEST_EQUAL(storage.GetTopmostParentFor("France_Auvergne"), "France", ());
+  TEST_EQUAL(storage.GetTopmostParentFor("Belgium"), "Belgium", ());
+  TEST_EQUAL(storage.GetTopmostParentFor("Jerusalem"), "Jerusalem", ());
+  TEST_EQUAL(storage.GetTopmostParentFor("US_California_LA"), "United States of America", ());
+}
+
 UNIT_TEST(StorageTest_GetTopmostNodesForWithLevel)
 {
   Storage storage;

--- a/xcode/storage/storage.xcodeproj/project.pbxproj
+++ b/xcode/storage/storage.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		402873422295A91F0036AA1C /* country_tree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4028733F2295A91E0036AA1C /* country_tree.hpp */; };
 		402873432295A91F0036AA1C /* country_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 402873402295A91F0036AA1C /* country_tree.cpp */; };
 		402873442295A91F0036AA1C /* downloader_search_params.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 402873412295A91F0036AA1C /* downloader_search_params.hpp */; };
+		402AD2E424A200F600DE5CB1 /* country_tree_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 402AD2E224A200F600DE5CB1 /* country_tree_helpers.hpp */; };
+		402AD2E524A200F600DE5CB1 /* country_tree_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 402AD2E324A200F600DE5CB1 /* country_tree_helpers.cpp */; };
 		4740186123F5BF0C00A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186023F5BF0C00A93C81 /* minizip.framework */; };
 		4740186223F5BF0C00A93C81 /* minizip.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186023F5BF0C00A93C81 /* minizip.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4740186423F5BF1800A93C81 /* minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4740186323F5BF1800A93C81 /* minizip.framework */; };
@@ -255,6 +257,8 @@
 		4028733F2295A91E0036AA1C /* country_tree.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = country_tree.hpp; sourceTree = "<group>"; };
 		402873402295A91F0036AA1C /* country_tree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = country_tree.cpp; sourceTree = "<group>"; };
 		402873412295A91F0036AA1C /* downloader_search_params.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = downloader_search_params.hpp; sourceTree = "<group>"; };
+		402AD2E224A200F600DE5CB1 /* country_tree_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = country_tree_helpers.hpp; sourceTree = "<group>"; };
+		402AD2E324A200F600DE5CB1 /* country_tree_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = country_tree_helpers.cpp; sourceTree = "<group>"; };
 		4069AD9F21495A5A005EB75C /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = categories_cuisines.txt; sourceTree = "<group>"; };
 		4740186023F5BF0C00A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4740186323F5BF1800A93C81 /* minizip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = minizip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -614,6 +618,8 @@
 		675342E21A3F59EF00A0A8C3 /* storage */ = {
 			isa = PBXGroup;
 			children = (
+				402AD2E324A200F600DE5CB1 /* country_tree_helpers.cpp */,
+				402AD2E224A200F600DE5CB1 /* country_tree_helpers.hpp */,
 				56DAC38323992819000BC50D /* queued_country.cpp */,
 				56DAC38423992819000BC50D /* queued_country.hpp */,
 				3DF528E02386B966000ED0D5 /* apply_diff.cpp */,
@@ -699,6 +705,7 @@
 				674125201B4C05FA00A3E828 /* map_files_downloader.hpp in Headers */,
 				56D8CB9A1CAC17A80003F420 /* test_defines.hpp in Headers */,
 				F68CC5C01F38B967007527C7 /* diff_types.hpp in Headers */,
+				402AD2E424A200F600DE5CB1 /* country_tree_helpers.hpp in Headers */,
 				401ECED51F56C50900DFDF76 /* country_parent_getter.hpp in Headers */,
 				3DF528E22386B966000ED0D5 /* diffs_data_source.hpp in Headers */,
 				34C9BCFD1C6CCF85000DC38D /* country_name_getter.hpp in Headers */,
@@ -898,6 +905,7 @@
 				674125231B4C05FA00A3E828 /* storage_defines.cpp in Sources */,
 				3DCD414920D80C1B00143533 /* lightweight_matching_tests.cpp in Sources */,
 				67BE1DC51CD2180D00572709 /* downloading_policy.cpp in Sources */,
+				402AD2E524A200F600DE5CB1 /* country_tree_helpers.cpp in Sources */,
 				402873432295A91F0036AA1C /* country_tree.cpp in Sources */,
 				F6BC312C2034366100F677FE /* pinger.cpp in Sources */,
 				34C9BCFC1C6CCF85000DC38D /* country_name_getter.cpp in Sources */,


### PR DESCRIPTION
В осме есть тег place=province (https://wiki.openstreetmap.org/wiki/Tag:place%3Dprovince), который значит то же самое что place=state, но там где не штаты, а провинции. При этом там где провинции (в Канаде, Франции и т.п.) все всё равно используют place=state, так что зачем province нужен не вполне понятно.
Но в Японии, Турции и Южной Корее административные единицы верхнего уровня (префектуры/иль/провинции) мапят через province, поэтому надо обрабатывать place=province.

Но просто так приравнять его к state нельзя, т.к. в Испании, Италии и ещё нескольких странах примерно 5% административных единиц с уровнем admin_level=6 (следующая ступень деления после state) замаплены как place=province.

Поэтому предлагается конвертить province в state в зависимости от  того в какой мы стране.

Использовать GetTopmostParent напрямую из Storage нельзя т.к. Storage хочет быть созданным и умереть на главном потоке мобильного приложения, поэтому вынесла реализацию метода из Storage.