### PR TITLE
[routing] Fixing routing integration tests for map 200607.

### DIFF
--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -59,7 +59,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
         mercator::FromLatLon(55.97310, 37.41460), {0., 0.},
-        mercator::FromLatLon(55.75100, 37.61790), 39899.2);
+        mercator::FromLatLon(55.75100, 37.61790), 33763.7);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -355,34 +355,34 @@ UNIT_TEST(SpeedCameraNotification_AutoAlwaysMode_8)
   for (auto const mode : modes)
   {
     RoutingSession routingSession;
-    InitRoutingSession({55.678536, 37.531112} /* from */,
-                       {55.671112, 37.520202} /* to   */,
+    InitRoutingSession({55.67547, 37.52662} /* from */,
+                       {55.67052, 37.51893}   /* to   */,
                        routingSession,
                        mode);
 
     {
       double const speedKmPH = 180.0;
-      ChangePosition({55.67840, 37.53090}, speedKmPH, routingSession);
+      ChangePosition({55.67533, 37.5264}, speedKmPH, routingSession);
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
     {
       double const speedKmPH = 180.0;
-      ChangePosition({55.67810, 37.53050}, speedKmPH, routingSession);
+      ChangePosition({55.67515, 37.52577}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
       TEST(CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
     {
       double const speedKmPH = 180.0;
-      ChangePosition({55.67810, 37.53050}, speedKmPH, routingSession);
+      ChangePosition({55.67515, 37.52577}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::VoiceNotificationZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(!CheckBeepSignal(routingSession), ());
     }
     {
       double const speedKmPH = 180.0;
-      ChangePosition({55.67790, 37.53020}, speedKmPH, routingSession);
+      ChangePosition({55.67505, 37.52542}, speedKmPH, routingSession);
       TEST_EQUAL(CheckZone(routingSession, speedKmPH), SpeedCameraManager::Interval::BeepSignalZone, ());
       TEST(!CheckVoiceNotification(routingSession), ());
       TEST(CheckBeepSignal(routingSession), ());


### PR DESCRIPTION
После обновления карты до 200607 сломалось 2 routing integration tests.

MoscowToSVOAirport
Изменились пути подъезда к аэропорту
![image](https://user-images.githubusercontent.com/1768114/85425618-115e7380-b582-11ea-8fcd-d59be103fe08.png)


SpeedCameraNotification_AutoAlwaysMode_8
Удалили камеру скорости. Я сделал тест с привязкой к другой камере.
Было:
![image](https://user-images.githubusercontent.com/1768114/85425712-2fc46f00-b582-11ea-8bee-a2d3597589a8.png)

Стало:
![image](https://user-images.githubusercontent.com/1768114/85425739-3c48c780-b582-11ea-89cf-1fd7869e5a16.png)

@mesozoic-drones PTAL
