### PR TITLE
[transit] Remove 'number' field from experimental transit line.

### DIFF
--- a/transit/experimental/transit_data.cpp
+++ b/transit/experimental/transit_data.cpp
@@ -302,9 +302,6 @@ void Read(base::Json const & obj, std::vector<Line> & lines)
   ShapeLink const shapeLink = GetShapeLinkFromJson(obj.get());
   Translations const title = GetTranslationsFromJson(obj.get(), "title");
 
-  // TODO (o.khlopkova) add "number" to gtfs converter pipeline
-  // and fill number with GetTranslationsFromJson(obj.get(), "number").
-  Translations const number;
   IdList const stopIds = GetStopIdsFromJson(obj.get());
 
   std::vector<LineInterval> const intervals = GetIntervalsFromJson(obj.get());
@@ -313,7 +310,7 @@ void Read(base::Json const & obj, std::vector<Line> & lines)
   FromJSONObject(obj.get(), "service_days", serviceDaysStr);
   osmoh::OpeningHours const serviceDays(serviceDaysStr);
 
-  lines.emplace_back(id, routeId, shapeLink, title, number, stopIds, intervals, serviceDays);
+  lines.emplace_back(id, routeId, shapeLink, title, stopIds, intervals, serviceDays);
 }
 
 void Read(base::Json const & obj, std::vector<Stop> & stops, OsmIdToFeatureIdsMap const & mapping)

--- a/transit/experimental/transit_types_experimental.cpp
+++ b/transit/experimental/transit_types_experimental.cpp
@@ -136,13 +136,12 @@ TransitId Route::GetNetworkId() const { return m_networkId; }
 
 // Line --------------------------------------------------------------------------------------------
 Line::Line(TransitId id, TransitId routeId, ShapeLink shapeLink, Translations const & title,
-           Translations const & number, IdList stopIds, std::vector<LineInterval> const & intervals,
+           IdList stopIds, std::vector<LineInterval> const & intervals,
            osmoh::OpeningHours const & serviceDays)
   : m_id(id)
   , m_routeId(routeId)
   , m_shapeLink(shapeLink)
   , m_title(title)
-  , m_number(number)
   , m_stopIds(stopIds)
   , m_intervals(intervals)
   , m_serviceDays(serviceDays)
@@ -160,10 +159,6 @@ bool Line::IsValid() const
 }
 
 TransitId Line::GetId() const { return m_id; }
-
-std::string Line::GetNumber() const { return GetTranslation(m_number); }
-
-Translations const & Line::GetNumbers() const { return m_number; }
 
 std::string Line::GetTitle() const { return GetTranslation(m_title); }
 

--- a/transit/experimental/transit_types_experimental.hpp
+++ b/transit/experimental/transit_types_experimental.hpp
@@ -199,7 +199,7 @@ class Line
 public:
   Line() = default;
   Line(TransitId id, TransitId routeId, ShapeLink shapeLink, Translations const & title,
-       Translations const & number, IdList stopIds, std::vector<LineInterval> const & intervals,
+       IdList stopIds, std::vector<LineInterval> const & intervals,
        osmoh::OpeningHours const & serviceDays);
 
   bool operator<(Line const & rhs) const;
@@ -208,8 +208,6 @@ public:
   bool IsValid() const;
 
   TransitId GetId() const;
-  std::string GetNumber() const;
-  Translations const & GetNumbers() const;
   std::string GetTitle() const;
   Translations const & GetTitles() const;
   TransitId GetRouteId() const;
@@ -222,14 +220,12 @@ private:
   DECLARE_TRANSIT_TYPES_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Line, visitor(m_id, "id"), visitor(m_routeId, "route_id"),
                                   visitor(m_shapeLink, "shape_link"), visitor(m_title, "title"),
-                                  visitor(m_number, "number"), visitor(m_stopIds, "stop_ids"),
-                                  visitor(m_intervals, "intervals"),
+                                  visitor(m_stopIds, "stop_ids"), visitor(m_intervals, "intervals"),
                                   visitor(m_serviceDays, "service_days"))
   TransitId m_id = kInvalidTransitId;
   TransitId m_routeId = kInvalidTransitId;
   ShapeLink m_shapeLink;
   Translations m_title;
-  Translations m_number;
   IdList m_stopIds;
   std::vector<LineInterval> m_intervals;
   osmoh::OpeningHours m_serviceDays;

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -137,8 +137,7 @@ UNIT_TEST(ReadJson_Line)
   std::vector<Line> const linesPlan = {
       Line(4036591532 /* id */, 4036591423 /* routeId */,
            ShapeLink(4036591460 /* id */, 415 /* startIndex */, 1691 /* endIndex */),
-           Translations{{"en", "Downtown"}} /* title */,
-           IdList{4036592571, 4036592572, 4036592573},
+           Translations{{"en", "Downtown"}} /* title */, IdList{4036592571, 4036592572, 4036592573},
            std::vector<LineInterval>{LineInterval(
                3600 /* headwayS */,
                osmoh::OpeningHours("06:40-18:40 open") /* timeIntervals */)} /* intervals */,

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -137,7 +137,7 @@ UNIT_TEST(ReadJson_Line)
   std::vector<Line> const linesPlan = {
       Line(4036591532 /* id */, 4036591423 /* routeId */,
            ShapeLink(4036591460 /* id */, 415 /* startIndex */, 1691 /* endIndex */),
-           Translations{{"en", "Downtown"}} /* title */, {} /* number */,
+           Translations{{"en", "Downtown"}} /* title */,
            IdList{4036592571, 4036592572, 4036592573},
            std::vector<LineInterval>{LineInterval(
                3600 /* headwayS */,

--- a/transit/transit_experimental_tests/transit_serdes_tests.cpp
+++ b/transit/transit_experimental_tests/transit_serdes_tests.cpp
@@ -119,7 +119,7 @@ TransitData FillTestTransitData()
   data.m_lines = {
       Line(4036598626 /* id */, 4036206872 /* routeId */,
            ShapeLink(4036591460 /* id */, 0 /* startIndex */, 2690 /* endIndex */),
-           Translations{{"default", "740G"}} /* title */, {} /* number */,
+           Translations{{"default", "740G"}} /* title */,
            IdList{4036592571, 4036592572, 4036592573, 4036592574, 4036592575, 4036592576},
            std::vector<LineInterval>{LineInterval(
                10060 /* headwayS */,
@@ -130,7 +130,7 @@ TransitData FillTestTransitData()
       Line(
           4036598627 /* id */, 4036206872 /* routeId */,
           ShapeLink(4036591461 /* id */, 356 /* startIndex */, 40690 /* endIndex */),
-          {} /* title */, {} /* number */,
+          {} /* title */,
           IdList{4027013783, 4027013784, 4027013785, 4027013786, 4027013787, 4027013788, 4027013789,
                  4027013790, 4027013791, 4027013792, 4027013793, 4027013794, 4027013795, 4027013796,
                  4027013797, 4027013798, 4027013799, 4027013800, 4027013801},

--- a/transit/transit_tests/transit_tools.hpp
+++ b/transit/transit_tests/transit_tools.hpp
@@ -51,12 +51,10 @@ inline bool Equal(Route const & r1, Route const & r2)
 
 inline bool Equal(Line const & l1, Line const & l2)
 {
-  return std::make_tuple(l1.GetId(), l1.GetRouteId(), l1.GetTitles(),
-                         l1.GetStopIds(), l1.GetIntervals(), l1.GetServiceDays(),
-                         l1.GetShapeLink()) ==
-         std::make_tuple(l2.GetId(), l2.GetRouteId(), l2.GetTitles(),
-                         l2.GetStopIds(), l2.GetIntervals(), l2.GetServiceDays(),
-                         l2.GetShapeLink());
+  return std::make_tuple(l1.GetId(), l1.GetRouteId(), l1.GetTitles(), l1.GetStopIds(),
+                         l1.GetIntervals(), l1.GetServiceDays(), l1.GetShapeLink()) ==
+         std::make_tuple(l2.GetId(), l2.GetRouteId(), l2.GetTitles(), l2.GetStopIds(),
+                         l2.GetIntervals(), l2.GetServiceDays(), l2.GetShapeLink());
 }
 
 inline bool Equal(Stop const & s1, Stop const & s2)

--- a/transit/transit_tests/transit_tools.hpp
+++ b/transit/transit_tests/transit_tools.hpp
@@ -51,10 +51,10 @@ inline bool Equal(Route const & r1, Route const & r2)
 
 inline bool Equal(Line const & l1, Line const & l2)
 {
-  return std::make_tuple(l1.GetId(), l1.GetRouteId(), l1.GetTitles(), l1.GetNumbers(),
+  return std::make_tuple(l1.GetId(), l1.GetRouteId(), l1.GetTitles(),
                          l1.GetStopIds(), l1.GetIntervals(), l1.GetServiceDays(),
                          l1.GetShapeLink()) ==
-         std::make_tuple(l2.GetId(), l2.GetRouteId(), l2.GetTitles(), l2.GetNumbers(),
+         std::make_tuple(l2.GetId(), l2.GetRouteId(), l2.GetTitles(),
                          l2.GetStopIds(), l2.GetIntervals(), l2.GetServiceDays(),
                          l2.GetShapeLink());
 }


### PR DESCRIPTION
В процессе работы над новой версией транзита стало понятно, что поле "number" в объектах типа Line не нужно. Речь идет об экспериментальной ветке, текущей реализации работы с общественным транспортом (метро) никак не касается. 

В новой реализации у нас есть сущность route, и значение number из line метро может быть перемещено в title route. У метрошных  line есть 2 поля: number и title. title по смыслу относится к конкретной линии, а number - уже к маршруту целиком и может быть привязан к нескольким линиям. Поэтому по логике вещей это и есть title route.