### PR TITLE
[search][indexer] Use different radius for different suburb types.

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -294,9 +294,45 @@ IsSquareChecker::IsSquareChecker()
 IsSuburbChecker::IsSuburbChecker()
 {
   Classificator const & c = classif();
-  m_types.push_back(c.GetTypeByPath({"landuse", "residential"}));
-  m_types.push_back(c.GetTypeByPath({"place", "neighbourhood"}));
-  m_types.push_back(c.GetTypeByPath({"place", "suburb"}));
+  auto const residentialType = c.GetTypeByPath({"landuse", "residential"});
+  auto const neighbourhoodType = c.GetTypeByPath({"place", "neighbourhood"});
+  auto const suburbType = c.GetTypeByPath({"place", "suburb"});
+  m_types.push_back(residentialType);
+  m_types.push_back(neighbourhoodType);
+  m_types.push_back(suburbType);
+  CHECK(m_types[static_cast<size_t>(SuburbType::Residential)] == residentialType, ());
+  CHECK(m_types[static_cast<size_t>(SuburbType::Neighbourhood)] == neighbourhoodType, ());
+  CHECK(m_types[static_cast<size_t>(SuburbType::Suburb)] == suburbType, ());
+}
+
+SuburbType IsSuburbChecker::GetType(uint32_t t) const
+{
+  ftype::TruncValue(t, 2);
+
+  for (size_t i = 0; i < m_types.size(); ++i)
+  {
+    if (m_types[i] == t)
+      return static_cast<SuburbType>(i);
+  }
+
+  return SuburbType::None;
+}
+
+SuburbType IsSuburbChecker::GetType(feature::TypesHolder const & types) const
+{
+  for (uint32_t t : types)
+  {
+    auto const type = GetType(t);
+    if (type != SuburbType::None)
+      return type;
+  }
+  return SuburbType::None;
+}
+
+SuburbType IsSuburbChecker::GetType(FeatureType & f) const
+{
+  feature::TypesHolder types(f);
+  return GetType(types);
 }
 
 IsWayChecker::IsWayChecker()

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -320,12 +320,17 @@ SuburbType IsSuburbChecker::GetType(uint32_t t) const
 
 SuburbType IsSuburbChecker::GetType(feature::TypesHolder const & types) const
 {
+  auto smallestType = SuburbType::Count;
   for (uint32_t t : types)
   {
     auto const type = GetType(t);
-    if (type != SuburbType::None)
-      return type;
+    if (type != SuburbType::None && type < smallestType)
+      smallestType = type;
   }
+
+  if (smallestType != SuburbType::Count)
+    return smallestType;
+
   return SuburbType::None;
 }
 

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -136,11 +136,32 @@ public:
   DECLARE_CHECKER_INSTANCE(IsSquareChecker);
 };
 
+/// Type of locality (do not change values and order - they have detalization order)
+/// Suburb > Neighbourhood > Residential
+enum class SuburbType
+{
+  None = -1,
+  Residential = 0,
+  Neighbourhood,
+  Suburb,
+  Count
+};
+
+static_assert(base::Underlying(SuburbType::Residential) <
+                  base::Underlying(SuburbType::Neighbourhood),
+              "");
+static_assert(base::Underlying(SuburbType::Neighbourhood) < base::Underlying(SuburbType::Suburb),
+              "");
+
 class IsSuburbChecker : public BaseChecker
 {
   IsSuburbChecker();
 
 public:
+  SuburbType GetType(uint32_t t) const;
+  SuburbType GetType(feature::TypesHolder const & types) const;
+  SuburbType GetType(FeatureType & f) const;
+
   DECLARE_CHECKER_INSTANCE(IsSuburbChecker);
 };
 

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -136,8 +136,9 @@ public:
   DECLARE_CHECKER_INSTANCE(IsSquareChecker);
 };
 
-/// Type of locality (do not change values and order - they have detalization order)
-/// Suburb > Neighbourhood > Residential
+// Type of suburb.
+// Do not change values and order - they are in the order of decreasing specificity.
+// Suburb > Neighbourhood > Residential
 enum class SuburbType
 {
   None = -1,


### PR DESCRIPTION
У нас сейчас suburb это и район города ("аэропорт", "бутырский" и т.п.) и всякие микрорайоны/жк кторые гораздо меньше и замапаны через landuse=residential/place=neighbourhood. Для последних использование радиуса 2 км приводит к нерелевантным результатам которые для ранкера выглядят хорошо.

Радиусы были получены методом прикладывания "линейки" к выдаче overpass для соответсвующего типа.