### PR TITLE
[transit] Fix color-picking of 'text' color variations.

### DIFF
--- a/transit/world_feed/color_picker.hpp
+++ b/transit/world_feed/color_picker.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "drape_frontend/color_constants.hpp"
+
+#include <map>
 #include <string>
 #include <unordered_map>
 
@@ -13,5 +16,6 @@ public:
 
 private:
   std::unordered_map<std::string, std::string> m_colorsToNames;
+  std::map<std::string, dp::Color> m_drapeClearColors;
 };
 }  // namespace transit

--- a/transit/world_feed/world_feed_tests/world_feed_tests.cpp
+++ b/transit/world_feed/world_feed_tests/world_feed_tests.cpp
@@ -1,7 +1,10 @@
 #include "testing/testing.hpp"
 
+#include "transit/world_feed/color_picker.hpp"
 #include "transit/world_feed/date_time_helpers.hpp"
 #include "transit/world_feed/feed_helpers.hpp"
+
+#include "platform/platform.hpp"
 
 #include "base/assert.hpp"
 
@@ -308,5 +311,23 @@ UNIT_TEST(Transit_GTFS_ProjectStopToLine_NearCircle)
   TestPlanFact(12, false, PrepareNearestPointOnTrack(point_D, 10 /* startIndex */, shape));
   TestPlanFact(14, true, PrepareNearestPointOnTrack(point_E, 12 /* startIndex */, shape));
   TestPlanFact(20, true, PrepareNearestPointOnTrack(point_F, 14 /* startIndex */, shape));
+}
+
+UNIT_TEST(Transit_ColorPicker)
+{
+  auto const & options = GetTestingOptions();
+  GetPlatform().SetResourceDir(options.m_resourcePath);
+
+  ColorPicker colorPicker;
+  
+  // We check that we don't match with the 'text' colors subset. This is the color of transit
+  // text lime_light and we expect not to pick it.
+  TEST_EQUAL(colorPicker.GetNearestColor("827717"), "lime_dark", ());
+
+  // We check the default color for invalid input.
+  TEST_EQUAL(colorPicker.GetNearestColor("94141230"), "default", ());
+
+  // We check that we really find nearest colors. This input is really close to pink light.
+  TEST_EQUAL(colorPicker.GetNearestColor("d18aa2"), "pink_light", ());
 }
 }  // namespace

--- a/transit/world_feed/world_feed_tests/world_feed_tests.cpp
+++ b/transit/world_feed/world_feed_tests/world_feed_tests.cpp
@@ -319,7 +319,7 @@ UNIT_TEST(Transit_ColorPicker)
   GetPlatform().SetResourceDir(options.m_resourcePath);
 
   ColorPicker colorPicker;
-  
+
   // We check that we don't match with the 'text' colors subset. This is the color of transit
   // text lime_light and we expect not to pick it.
   TEST_EQUAL(colorPicker.GetNearestColor("827717"), "lime_dark", ());


### PR DESCRIPTION
Было замечено, что в классе ColorPicker для подбора цветов маршрутов из мапсмишной цветовой гаммы не обрабатывается случай цветов для текста, а не для фона. Такие цвета в своем названии содержат специальную подстроку.

Это поведение исправлено, на него добавлен юнит-тест.

Транзитные цвета подгружаются drape-frontend'ом из файла `data/transit_colors.txt`. Пример записи в этом файле:

```json
    "purple_light": {
      "clear": "CE93D8",
      "night": "684A6D",
      "text": "4A148C",
      "text_night": "684A6D"
    },
```

Для цвета `purple_light` мы должны использовать только `clear`-значение, а `text` - нет. Хотя drape-frontend  и добавляет его в контейнер clear.