### PR TITLE
[generator] Serialize experimental transit cross-mwm section.

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -543,12 +543,13 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
       if (FLAGS_make_transit_cross_mwm_experimental)
       {
-        // TODO(o.khlopkova): Implement BuildTransitCrossMwmSection().
-        LOG(LINFO, ("Make cross mwm for experimental transit."));
+        routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter,
+                                             true /* experimentalTransit */);
       }
       else if (FLAGS_make_transit_cross_mwm)
       {
-        routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter);
+        routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter,
+                                             false /* experimentalTransit */);
       }
     }
 

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -24,5 +24,6 @@ void BuildRoutingCrossMwmSection(std::string const & path, std::string const & m
 /// \note Before a call of this method TRANSIT_FILE_TAG should be built.
 void BuildTransitCrossMwmSection(std::string const & path, std::string const & mwmFile,
                                  std::string const & country,
-                                 CountryParentNameGetterFn const & countryParentNameGetterFn);
+                                 CountryParentNameGetterFn const & countryParentNameGetterFn,
+                                 bool experimentalTransit = false);
 }  // namespace routing


### PR DESCRIPTION
Реквест для сериализации кросс-мвм секции для экспериментального транзита. Сводится к тому, что по экспериментальному флагу вместо объекта  типа `routing::transit::GraphData` сериализуется объект `transit::experimental::TransitData`.
