### PR TITLE
[coding] Support multiple transliterators for lang_code. Support hiragana-latin transliteration.

### DIFF
--- a/coding/string_utf8_multilang.cpp
+++ b/coding/string_utf8_multilang.cpp
@@ -15,70 +15,70 @@ namespace
 // Note that it's not feasible to increase languages number here due to current encoding (6 bit to
 // store language code).
 array<StringUtf8Multilang::Lang, StringUtf8Multilang::kMaxSupportedLanguages> const kLanguages = {
-    {{"default", "Native for each country", "Any-Latin"},
-     {"en", "English", ""},
-     {"ja", "日本語", ""},
-     {"fr", "Français", ""},
-     {"ko_rm", "Korean (Romanized)", "Korean-Latin/BGN"},
-     {"ar", "العربية", "Any-Latin"},
-     {"de", "Deutsch", ""},
-     {"int_name", "International (Latin)", "Any-Latin"},
-     {"ru", "Русский", "Russian-Latin/BGN"},
-     {"sv", "Svenska", ""},
-     {"zh", "中文", "Any-Latin"},
-     {"fi", "Suomi", ""},
-     {"be", "Беларуская", "Belarusian-Latin/BGN"},
-     {"ka", "ქართული", "Georgian-Latin"},
-     {"ko", "한국어", "Hangul-Latin/BGN"},
-     {"he", "עברית", "Hebrew-Latin"},
-     {"nl", "Nederlands", ""},
-     {"ga", "Gaeilge", ""},
-     {"ja_rm", "Japanese (Romanized)", "Any-Latin"},
-     {"el", "Ελληνικά", "Greek-Latin"},
-     {"it", "Italiano", ""},
-     {"es", "Español", ""},
-     {"zh_pinyin", "Chinese (Pinyin)", "Any-Latin"},
-     {"th", "ไทย", ""},  // Thai-Latin
-     {"cy", "Cymraeg", ""},
-     {"sr", "Српски", "Serbian-Latin/BGN"},
-     {"uk", "Українська", "Ukrainian-Latin/BGN"},
-     {"ca", "Català", ""},
-     {"hu", "Magyar", ""},
-     {StringUtf8Multilang::kReservedLang /* hsb */, "", ""},
-     {"eu", "Euskara", ""},
-     {"fa", "فارسی", "Any-Latin"},
-     {StringUtf8Multilang::kReservedLang /* br */, "", ""},
-     {"pl", "Polski", ""},
-     {"hy", "Հայերէն", "Armenian-Latin"},
-     {StringUtf8Multilang::kReservedLang /* kn */, "", ""},
-     {"sl", "Slovenščina", ""},
-     {"ro", "Română", ""},
-     {"sq", "Shqip", ""},
-     {"am", "አማርኛ", "Amharic-Latin/BGN"},
-     {"no", "Norsk", ""},  // Was "fy" before December 2018.
-     {"cs", "Čeština", ""},
-     {"id", "Bahasa Indonesia", ""},  // Was "gd" before December 2018.
-     {"sk", "Slovenčina", ""},
-     {"af", "Afrikaans", ""},
-     {"ja_kana", "日本語(カタカナ)", "Katakana-Latin"},
-     {StringUtf8Multilang::kReservedLang /* lb */, "", ""},
-     {"pt", "Português", ""},
-     {"hr", "Hrvatski", ""},
-     {"da", "Dansk", ""},  // Was "fur" before December 2018.
-     {"vi", "Tiếng Việt", ""},
-     {"tr", "Türkçe", ""},
-     {"bg", "Български", "Bulgarian-Latin/BGN"},
-     {"alt_name", "Alternative name", "Any-Latin"},  // Was "eo" before December 2018.
-     {"lt", "Lietuvių", ""},
-     {"old_name", "Old/Previous name", "Any-Latin"},  // Was "la" before December 2018.
-     {"kk", "Қазақ", "Kazakh-Latin/BGN"},
-     {StringUtf8Multilang::kReservedLang /* gsw */, "", ""},
-     {"et", "Eesti", ""},
-     {"ku", "Kurdish", "Any-Latin"},
-     {"mn", "Mongolian", "Mongolian-Latin/BGN"},
-     {"mk", "Македонски", "Macedonian-Latin/BGN"},
-     {"lv", "Latviešu", ""},
-     {"hi", "हिन्दी", "Any-Latin"}}};
+    {{"default", "Native for each country", {"Any-Latin"}},
+     {"en", "English", {}},
+     {"ja", "日本語", {}},
+     {"fr", "Français", {}},
+     {"ko_rm", "Korean (Romanized)", {"Korean-Latin/BGN"}},
+     {"ar", "العربية", {"Any-Latin"}},
+     {"de", "Deutsch", {}},
+     {"int_name", "International (Latin)", {"Any-Latin"}},
+     {"ru", "Русский", {"Russian-Latin/BGN"}},
+     {"sv", "Svenska", {}},
+     {"zh", "中文", {"Any-Latin"}},
+     {"fi", "Suomi", {}},
+     {"be", "Беларуская", {"Belarusian-Latin/BGN"}},
+     {"ka", "ქართული", {"Georgian-Latin"}},
+     {"ko", "한국어", {"Hangul-Latin/BGN"}},
+     {"he", "עברית", {"Hebrew-Latin"}},
+     {"nl", "Nederlands", {}},
+     {"ga", "Gaeilge", {}},
+     {"ja_rm", "Japanese (Romanized)", {"Any-Latin"}},
+     {"el", "Ελληνικά", {"Greek-Latin"}},
+     {"it", "Italiano", {}},
+     {"es", "Español", {}},
+     {"zh_pinyin", "Chinese (Pinyin)", {"Any-Latin"}},
+     {"th", "ไทย", {}},  // Thai-Latin
+     {"cy", "Cymraeg", {}},
+     {"sr", "Српски", {"Serbian-Latin/BGN"}},
+     {"uk", "Українська", {"Ukrainian-Latin/BGN"}},
+     {"ca", "Català", {}},
+     {"hu", "Magyar", {}},
+     {StringUtf8Multilang::kReservedLang /* hsb */, "", {}},
+     {"eu", "Euskara", {}},
+     {"fa", "فارسی", {"Any-Latin"}},
+     {StringUtf8Multilang::kReservedLang /* br */, "", {}},
+     {"pl", "Polski", {}},
+     {"hy", "Հայերէն", {"Armenian-Latin"}},
+     {StringUtf8Multilang::kReservedLang /* kn */, "", {}},
+     {"sl", "Slovenščina", {}},
+     {"ro", "Română", {}},
+     {"sq", "Shqip", {}},
+     {"am", "አማርኛ", {"Amharic-Latin/BGN"}},
+     {"no", "Norsk", {}},  // Was "fy" before December 2018.
+     {"cs", "Čeština", {}},
+     {"id", "Bahasa Indonesia", {}},  // Was "gd" before December 2018.
+     {"sk", "Slovenčina", {}},
+     {"af", "Afrikaans", {}},
+     {"ja_kana", "日本語(カタカナ)", {"Katakana-Latin", "Hiragana-Latin"}},
+     {StringUtf8Multilang::kReservedLang /* lb */, "", {}},
+     {"pt", "Português", {}},
+     {"hr", "Hrvatski", {}},
+     {"da", "Dansk", {}},  // Was "fur" before December 2018.
+     {"vi", "Tiếng Việt", {}},
+     {"tr", "Türkçe", {}},
+     {"bg", "Български", {"Bulgarian-Latin/BGN"}},
+     {"alt_name", "Alternative name", {"Any-Latin"}},  // Was "eo" before December 2018.
+     {"lt", "Lietuvių", {}},
+     {"old_name", "Old/Previous name", {"Any-Latin"}},  // Was "la" before December 2018.
+     {"kk", "Қазақ", {"Kazakh-Latin/BGN"}},
+     {StringUtf8Multilang::kReservedLang /* gsw */, "", {}},
+     {"et", "Eesti", {}},
+     {"ku", "Kurdish", {"Any-Latin"}},
+     {"mn", "Mongolian", {"Mongolian-Latin/BGN"}},
+     {"mk", "Македонски", {"Macedonian-Latin/BGN"}},
+     {"lv", "Latviešu", {}},
+     {"hi", "हिन्दी", {"Any-Latin"}}}};
 
 static_assert(
     kLanguages.size() == StringUtf8Multilang::kMaxSupportedLanguages,
@@ -137,7 +137,7 @@ char const * StringUtf8Multilang::GetLangByCode(int8_t langCode)
   if (!IsSupportedLangCode(langCode))
     return "";
 
-  return kLanguages[langCode].m_code;
+  return kLanguages[langCode].m_code.c_str();
 }
 
 // static
@@ -146,16 +146,17 @@ char const * StringUtf8Multilang::GetLangNameByCode(int8_t langCode)
   if (!IsSupportedLangCode(langCode))
     return "";
 
-  return kLanguages[langCode].m_name;
+  return kLanguages[langCode].m_name.c_str();
 }
 
 // static
-char const * StringUtf8Multilang::GetTransliteratorIdByCode(int8_t langCode)
+vector<string> const & StringUtf8Multilang::GetTransliteratorsIdsByCode(int8_t langCode)
 {
+  static const vector<string> empty;
   if (!IsSupportedLangCode(langCode))
-    return "";
+    return empty;
 
-  return kLanguages[langCode].m_transliteratorId;
+  return kLanguages[langCode].m_transliteratorsIds;
 }
 
 size_t StringUtf8Multilang::GetNextIndex(size_t i) const

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace utils
 {
@@ -67,11 +68,11 @@ public:
   struct Lang
   {
     /// OSM language code (e.g. for name:en it's "en" part).
-    char const * m_code;
+    std::string m_code;
     /// Native language name.
-    char const * m_name;
-    /// Transliterator to latin id.
-    char const * m_transliteratorId;
+    std::string m_name;
+    /// Transliterators to latin ids.
+    std::vector<std::string> m_transliteratorsIds;
   };
 
   struct Position
@@ -107,8 +108,8 @@ public:
   static char const * GetLangByCode(int8_t langCode);
   /// @returns empty string if langCode is invalid.
   static char const * GetLangNameByCode(int8_t langCode);
-  /// @returns empty string if langCode is invalid.
-  static char const * GetTransliteratorIdByCode(int8_t langCode);
+  /// @returns empty vector if langCode is invalid.
+  static std::vector<std::string> const & GetTransliteratorsIdsByCode(int8_t langCode);
 
   inline bool operator==(StringUtf8Multilang const & rhs) const { return m_s == rhs.m_s; }
   inline bool operator!=(StringUtf8Multilang const & rhs) const { return !(*this == rhs); }

--- a/coding/transliteration.cpp
+++ b/coding/transliteration.cpp
@@ -82,14 +82,13 @@ bool Transliteration::Transliterate(std::string const & str, int8_t langCode, st
   UnicodeString ustr(str.c_str());
   for (auto transliteratorId : transliteratorsIds)
   {
-    if (transliteratorId.empty())
-      return false;
+    CHECK(!transliteratorId.empty(), (transliteratorId));
 
     auto it = m_transliterators.find(transliteratorId);
     if (it == m_transliterators.end())
     {
       LOG(LWARNING, ("Transliteration failed, unknown transliterator \"", transliteratorId, "\""));
-      return false;
+      continue;
     }
 
     if (!it->second->m_initialized)
@@ -119,7 +118,7 @@ bool Transliteration::Transliterate(std::string const & str, int8_t langCode, st
     }
 
     if (it->second->m_transliterator == nullptr)
-      return false;
+      continue;
 
     it->second->m_transliterator->transliterate(ustr);
 

--- a/editor/xml_feature.cpp
+++ b/editor/xml_feature.cpp
@@ -88,17 +88,6 @@ void ValidateElement(pugi::xml_node const & nodeOrWay)
 
 namespace editor
 {
-char const * const XMLFeature::kDefaultLang =
-    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode);
-char const * const XMLFeature::kIntlLang =
-    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kInternationalCode);
-char const * const XMLFeature::kAltLang =
-    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kAltNameCode);
-char const * const XMLFeature::kOldLang =
-    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kOldNameCode);
-char const * const XMLFeature::kIntlName = XMLFeature::kIntlLang;
-char const * const XMLFeature::kAltName = XMLFeature::kAltLang;
-char const * const XMLFeature::kOldName = XMLFeature::kOldLang;
 
 XMLFeature::XMLFeature(Type const type)
 {
@@ -244,6 +233,10 @@ vector<m2::PointD> XMLFeature::GetGeometry() const
 
 string XMLFeature::GetName(string const & lang) const
 {
+  ASSERT_EQUAL(kDefaultLang, StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode), ());
+  ASSERT_EQUAL(kIntlLang, StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kInternationalCode), ());
+  ASSERT_EQUAL(kAltLang, StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kAltNameCode), ());
+  ASSERT_EQUAL(kOldLang, StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kOldNameCode), ());
   if (lang == kIntlLang)
     return GetTagValue(kIntlName);
   if (lang == kAltLang)

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -32,13 +32,13 @@ class XMLFeature
 {
   static constexpr char const * kDefaultName = "name";
   static constexpr char const * kLocalName = "name:";
-  static char const * const kIntlName;
-  static char const * const kAltName;
-  static char const * const kOldName;
-  static char const * const kDefaultLang;
-  static char const * const kIntlLang;
-  static char const * const kAltLang;
-  static char const * const kOldLang;
+  static constexpr char const * kIntlName = "int_name";
+  static constexpr char const * kAltName = "alt_name";
+  static constexpr char const * kOldName = "old_name";
+  static constexpr char const * kDefaultLang = "default";
+  static constexpr char const * kIntlLang = kIntlName;
+  static constexpr char const * kAltLang = kAltName;
+  static constexpr char const * kOldLang = kOldName;
 
 public:
   // Used in point to string serialization.

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -31,11 +31,6 @@ int8_t GetIndex(string const & lang)
   return StrUtf8::GetLangIndex(lang);
 }
 
-unordered_map<int8_t, vector<int8_t>> const kSimilarToDeviceLanguages =
-{
-  {GetIndex("be"), {GetIndex("ru")}}
-};
-
 void GetMwmLangName(feature::RegionData const & regionData, StringUtf8Multilang const & src, string & out)
 {
   vector<int8_t> mwmLangCodes;
@@ -101,6 +96,11 @@ bool GetBestName(StringUtf8Multilang const & src, vector<int8_t> const & priorit
 
 vector<int8_t> GetSimilarToDeviceLanguages(int8_t deviceLang)
 {  
+  static unordered_map<int8_t, vector<int8_t>> const kSimilarToDeviceLanguages =
+  {
+    {GetIndex("be"), {GetIndex("ru")}}
+  };
+
   auto const it = kSimilarToDeviceLanguages.find(deviceLang);
   if (it != kSimilarToDeviceLanguages.cend())
     return it->second;

--- a/map/map_tests/transliteration_test.cpp
+++ b/map/map_tests/transliteration_test.cpp
@@ -38,6 +38,8 @@ UNIT_TEST(Transliteration_CompareSamples)
   TestTransliteration(translit, "hy", "Հայերէն", "Hayeren");
   TestTransliteration(translit, "am", "አማርኛ", "amarinya");
   TestTransliteration(translit, "ja_kana", "カタカナ", "katakana");
+  TestTransliteration(translit, "ja_kana", "ひらがな", "hiragana");
+  TestTransliteration(translit, "ja_kana", "カタカナ ひらがな", "katakana hiragana");
   TestTransliteration(translit, "bg", "Български", "Bulgarski");
   TestTransliteration(translit, "kk", "Қазақ", "Qazaq");
   TestTransliteration(translit, "mn", "Монгол хэл", "Mongol hel");


### PR DESCRIPTION
ja_kana это имя на слоговой азбуке. Но у японцев две слоговых азбуки (катакана и хирагана) и ja_kana это любая из них. У нас поддерживалась только транслитерация катакана.

Вижу несколько вариантов как это можно исправить:
- в coding/transliteration делать костыль для ja_kana
- поддержать несколько транслитераторов и применить один из них (выбрать тот после которого на выходе будет больше латиницы)
- поддержать несколько транслитераторов и последовательно применить все

мне показалось что последний вариант лучше, сделала его.