### PR TITLE
[transit][routing] Experimental transit in runtime.

### DIFF
--- a/drape_frontend/transit_scheme_builder.cpp
+++ b/drape_frontend/transit_scheme_builder.cpp
@@ -381,7 +381,8 @@ void TransitSchemeBuilder::CollectLines(TransitDisplayInfo const & transitDispla
   for (auto const & pair : linesLengths)
   {
     auto const lineId = pair.second;
-    scheme.m_lines[lineId] = LineParams(transitDisplayInfo.m_linesSubway.at(lineId).GetColor(), depth);
+    scheme.m_lines[lineId] =
+        LineParams(transitDisplayInfo.m_linesSubway.at(lineId).GetColor(), depth);
     depth += kDepthPerLine;
   }
 }
@@ -453,10 +454,10 @@ void TransitSchemeBuilder::AddShape(TransitDisplayInfo const & transitDisplayInf
                                     MwmSchemeData & scheme)
 {
   auto const stop1It = transitDisplayInfo.m_stopsSubway.find(stop1Id);
-  ASSERT(stop1It != transitDisplayInfo.m_stopsSubway.end(), ());
+  ASSERT(stop1It != transitDisplayInfo.m_stopsSubway.end(), (stop1Id));
 
   auto const stop2It = transitDisplayInfo.m_stopsSubway.find(stop2Id);
-  ASSERT(stop2It != transitDisplayInfo.m_stopsSubway.end(), ());
+  ASSERT(stop2It != transitDisplayInfo.m_stopsSubway.end(), (stop2Id));
 
   auto const transfer1Id = stop1It->second.GetTransferId();
   auto const transfer2Id = stop2It->second.GetTransferId();
@@ -476,8 +477,6 @@ void TransitSchemeBuilder::AddShape(TransitDisplayInfo const & transitDisplayInf
 
   if (it == transitDisplayInfo.m_shapesSubway.end())
     return;
-
-  ASSERT(it != transitDisplayInfo.m_shapesSubway.end(), ());
 
   auto const itScheme = scheme.m_shapes.find(shapeId);
   if (itScheme == scheme.m_shapes.end())

--- a/iphone/Maps/Core/Routing/MWMRouterTransitStepInfo.mm
+++ b/iphone/Maps/Core/Routing/MWMRouterTransitStepInfo.mm
@@ -15,6 +15,13 @@ MWMRouterTransitType convertType(TransitType type)
   case TransitType::LightRail: return MWMRouterTransitTypeLightRail;
   case TransitType::Monorail: return MWMRouterTransitTypeMonorail;
   }
+
+  // This is temporary solution for compiling iOS project after adding new
+  // TransitType values. When these values will be approved we'll add them
+  // above in switch(type) and remove this line.
+  // TODO(o.khlopkova) Replace this return with more cases when transit
+  // types are ready.
+  return MWMRouterTransitTypePedestrian;
 }
 
 UIColor * convertColor(uint32_t colorARGB)

--- a/map/transit/transit_display.hpp
+++ b/map/transit/transit_display.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-enum class TransitType: uint32_t
+enum class TransitType : uint32_t
 {
   // Do not change the order!
   IntermediatePoint,
@@ -23,7 +23,17 @@ enum class TransitType: uint32_t
   Subway,
   Train,
   LightRail,
-  Monorail
+  Monorail,
+
+  Tram,
+  Bus,
+  Ferry,
+  CableTram,
+  AerialLift,
+  Funicular,
+  Trolleybus,
+  AirService,
+  WaterService
 };
 
 extern std::map<TransitType, std::string> const kTransitSymbols;
@@ -100,6 +110,29 @@ struct TransitMarkInfo
   FeatureID m_featureId;
 };
 
+struct SubrouteParams
+{
+  df::ColorConstant m_lastColor;
+  m2::PointD m_lastDir;
+  ::transit::TransitId m_lastLineId = ::transit::kInvalidTransitId;
+  df::SubrouteMarker m_marker;
+  TransitMarkInfo m_transitMarkInfo;
+  TransitType m_transitType = TransitType::Pedestrian;
+  double m_prevDistance = 0.0;
+  double m_prevTime = 0.0;
+  bool m_pendingEntrance = false;
+};
+
+struct SubrouteSegmentParams
+{
+  SubrouteSegmentParams(routing::TransitInfo const & transitInfo) : m_transitInfo(transitInfo) {}
+  int m_time = 0;
+  double m_distance = 0.0;
+  routing::TransitInfo m_transitInfo;
+  TransitDisplayInfo m_displayInfo;
+  MwmSet::MwmId m_mwmId;
+};
+
 class TransitRouteDisplay
 {
 public:
@@ -116,6 +149,17 @@ public:
   TransitRouteInfo const & GetRouteInfo();
 
 private:
+  void AddEdgeSubwayForSubroute(routing::RouteSegment const & segment, df::Subroute & subroute,
+                                SubrouteParams & sp, SubrouteSegmentParams & ssp);
+  void AddEdgePTForSubroute(routing::RouteSegment const & segment, df::Subroute & subroute,
+                            SubrouteParams & sp, SubrouteSegmentParams & ssp);
+
+  void AddGateSubwayForSubroute(routing::RouteSegment const & segment, df::Subroute & subroute,
+                                SubrouteParams & sp, SubrouteSegmentParams & ssp);
+
+  void AddGatePTForSubroute(routing::RouteSegment const & segment, df::Subroute & subroute,
+                            SubrouteParams & sp, SubrouteSegmentParams & ssp);
+
   void CollectTransitDisplayInfo(std::vector<routing::RouteSegment> const & segments,
                                  TransitDisplayInfos & transitDisplayInfos);
   TransitMark * CreateMark(m2::PointD const & pt, FeatureID const & fid);

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -124,7 +124,7 @@ void ReadTransitTask::Do()
   }
   else
   {
-    UNREACHABLE();
+    CHECK(false, (transitHeaderVersion));
   }
 
   vector<FeatureID> features;
@@ -178,7 +178,7 @@ void ReadTransitTask::FillLinesAndRoutes(::transit::experimental::TransitData co
                                         return route.GetId() == routeId;
                                       });
 
-    CHECK(itRoute != routes.end(), ());
+    CHECK(itRoute != routes.end(), (line));
 
     if (m_loadSubset)
     {

--- a/map/transit/transit_reader.hpp
+++ b/map/transit/transit_reader.hpp
@@ -4,6 +4,7 @@
 
 #include "drape_frontend/drape_engine_safe_ptr.hpp"
 
+#include "transit/experimental/transit_data.hpp"
 #include "transit/transit_display_info.hpp"
 
 #include "indexer/data_source.hpp"
@@ -67,6 +68,8 @@ private:
       }
     }
   };
+
+  void FillLinesAndRoutes(::transit::experimental::TransitData const & transitData);
 
   DataSource & m_dataSource;
   TReadFeaturesFn m_readFeaturesFn;

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -2,11 +2,11 @@
 
 #include "testing/testing.hpp"
 
-#include "routing/geometry.hpp"
-
 #include "routing/base/routing_result.hpp"
-
+#include "routing/geometry.hpp"
 #include "routing/routing_helpers.hpp"
+
+#include "transit/transit_version.hpp"
 
 #include "base/assert.hpp"
 #include "base/math.hpp"
@@ -453,8 +453,9 @@ unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geo
   auto indexGraph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
   indexGraph->Import(joints);
 
-  auto transitGraph = make_unique<TransitGraph>(kTestNumMwmId, estimator);
-  TransitGraph::GateEndings gateEndings;
+  auto transitGraph =
+      make_unique<TransitGraph>(::transit::TransitVersion::OnlySubway, kTestNumMwmId, estimator);
+  TransitGraph::Endings gateEndings;
   MakeGateEndings(transitData.GetGates(), kTestNumMwmId, *indexGraph, gateEndings);
   transitGraph->Fill(transitData, gateEndings);
 

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -12,6 +12,9 @@ namespace routing
 namespace
 {
 using namespace std;
+// TODO(o.khlopkova) Replace this constant with implementation of intervals calculation on the
+// gtfs converter step.
+size_t constexpr kDefaultIntervalS = 60 * 60;  // 1 hour.
 
 Segment GetReverseSegment(Segment const & segment)
 {
@@ -40,10 +43,13 @@ bool TransitGraph::IsTransitSegment(Segment const & segment)
   return IsTransitFeature(segment.GetFeatureId());
 }
 
-TransitGraph::TransitGraph(NumMwmId numMwmId, shared_ptr<EdgeEstimator> estimator)
-  : m_mwmId(numMwmId), m_estimator(estimator)
+TransitGraph::TransitGraph(::transit::TransitVersion transitVersion, NumMwmId numMwmId,
+                           shared_ptr<EdgeEstimator> estimator)
+  : m_transitVersion(transitVersion), m_mwmId(numMwmId), m_estimator(estimator)
 {
 }
+
+::transit::TransitVersion TransitGraph::GetTransitVersion() const { return m_transitVersion; }
 
 LatLonWithAltitude const & TransitGraph::GetJunction(Segment const & segment,
                                                               bool front) const
@@ -57,18 +63,48 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment,
                                             EdgeEstimator::Purpose purpose) const
 {
   CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
-  if (IsGate(segment))
-  {
-    auto const weight = GetGate(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */, 0 /* numAccessChanges */,
-                       0 /* numAccessConditionalPenalties */, weight /* transitTime */);
-  }
 
-  if (IsEdge(segment))
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
   {
-    auto const weight = GetEdge(segment).GetWeight();
-    return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */, 0 /* numAccessChanges */,
-                       0 /* numAccessConditionalPenalties */, weight /* transitTime */);
+    if (IsGate(segment))
+    {
+      auto const weight = GetGate(segment).GetWeight();
+      return RouteWeight(weight, 0 /* numPassThroughChanges */,
+                         0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                         weight /* transitTime */);
+    }
+
+    if (IsEdge(segment))
+    {
+      auto const weight = GetEdge(segment).GetWeight();
+      return RouteWeight(weight, 0 /* numPassThroughChanges */,
+                         0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                         weight /* transitTime */);
+    }
+  }
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+  {
+    if (IsGate(segment))
+    {
+      // TODO (o.khlopkova) Manage different weights for different stops linked to the gate.
+      auto const weight = kDefaultIntervalS;
+      return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */,
+                         0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                         weight /* transitTime */);
+    }
+
+    if (IsEdge(segment))
+    {
+      auto weight = GetEdgePT(segment).GetWeight();
+      CHECK_NOT_EQUAL(weight, 0, (segment));
+      return RouteWeight(weight /* weight */, 0 /* numPassThroughChanges */,
+                         0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                         weight /* transitTime */);
+    }
+  }
+  else
+  {
+    UNREACHABLE();
   }
 
   return RouteWeight(
@@ -78,30 +114,67 @@ RouteWeight TransitGraph::CalcSegmentWeight(Segment const & segment,
 
 RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const & to) const
 {
-  // We need to wait transport and apply additional penalty only if we change to transit::Edge.
-  if (!IsEdge(to))
-    return GetAStarWeightZero<RouteWeight>();
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
+  {
+    // We need to wait transport and apply additional penalty only if we change to transit::Edge.
+    if (!IsEdge(to))
+      return GetAStarWeightZero<RouteWeight>();
 
-  auto const & edgeTo = GetEdge(to);
+    auto const & edgeTo = GetEdge(to);
 
-  // We are changing to transfer and do not need to apply extra penalty here. We'll do it while
-  // changing from transfer.
-  if (edgeTo.GetTransfer())
-    return GetAStarWeightZero<RouteWeight>();
+    // We are changing to transfer and do not need to apply extra penalty here. We'll do it while
+    // changing from transfer.
+    if (edgeTo.GetTransfer())
+      return GetAStarWeightZero<RouteWeight>();
 
-  auto const lineIdTo = edgeTo.GetLineId();
+    auto const lineIdTo = edgeTo.GetLineId();
 
-  if (IsEdge(from) && GetEdge(from).GetLineId() == lineIdTo)
-    return GetAStarWeightZero<RouteWeight>();
+    if (IsEdge(from) && GetEdge(from).GetLineId() == lineIdTo)
+      return GetAStarWeightZero<RouteWeight>();
 
-  // We need to apply extra penalty when:
-  // 1. |from| is gate, |to| is edge
-  // 2. |from| is transfer, |to| is edge
-  // 3. |from| is edge, |to| is edge from another line directly connected to |from|.
-  auto const it = m_transferPenalties.find(lineIdTo);
-  CHECK(it != m_transferPenalties.cend(), ("Segment", to, "belongs to unknown line:", lineIdTo));
-  return RouteWeight(it->second /* weight */, 0 /* nonPassThrougCross */, 0 /* numAccessChanges */,
-                     0 /* numAccessConditionalPenalties */, it->second /* transitTime */);
+    // We need to apply extra penalty when:
+    // 1. |from| is gate, |to| is edge
+    // 2. |from| is transfer, |to| is edge
+    // 3. |from| is edge, |to| is edge from another line directly connected to |from|.
+    auto const it = m_transferPenalties.find(lineIdTo);
+    CHECK(it != m_transferPenalties.cend(), ("Segment", to, "belongs to unknown line:", lineIdTo));
+    return RouteWeight(it->second /* weight */, 0 /* nonPassThrougCross */,
+                       0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                       it->second /* transitTime */);
+  }
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+  {
+    // We need to wait transport and apply additional penalty only if we change to transit::Edge.
+    if (!IsEdge(to))
+      return GetAStarWeightZero<RouteWeight>();
+
+    auto const & edgeTo = GetEdgePT(to);
+
+    // We are changing to transfer and do not need to apply extra penalty here. We'll do it while
+    // changing from transfer.
+    if (edgeTo.IsTransfer())
+      return GetAStarWeightZero<RouteWeight>();
+
+    auto const lineIdTo = edgeTo.GetLineId();
+
+    if (IsEdge(from) && GetEdgePT(from).GetLineId() == lineIdTo)
+      return GetAStarWeightZero<RouteWeight>();
+
+    // We need to apply extra penalty when:
+    // 1. |from| is gate, |to| is edge
+    // 2. |from| is transfer, |to| is edge
+    // 3. |from| is edge, |to| is edge from another line directly connected to |from|.
+    auto const it = m_transferPenaltiesPT.find(lineIdTo);
+    CHECK(it != m_transferPenaltiesPT.end(), ("Segment", to, "belongs to unknown line:", lineIdTo));
+    CHECK(!it->second.empty(), ());
+    size_t const headwayS = it->second.front().m_headwayS;
+
+    return RouteWeight(static_cast<double>(headwayS) /* weight */, 0 /* nonPassThroughCross */,
+                       0 /* numAccessChanges */, 0 /* numAccessConditionalPenalties */,
+                       headwayS /* transitTime */);
+  }
+
+  UNREACHABLE();
 }
 
 void TransitGraph::GetTransitEdges(Segment const & segment, bool isOutgoing,
@@ -127,8 +200,92 @@ bool TransitGraph::FindReal(Segment const & fake, Segment & real) const
   return m_fake.FindReal(fake, real);
 }
 
-void TransitGraph::Fill(transit::GraphData const & transitData, GateEndings const & gateEndings)
+void TransitGraph::Fill(::transit::experimental::TransitData const & transitData,
+                        Endings const & stopEndings, Endings const & gateEndings)
 {
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+
+  for (auto const & line : transitData.GetLines())
+  {
+    m_transferPenaltiesPT[line.GetId()].reserve(line.GetIntervals().size());
+
+    for (auto const & interval : line.GetIntervals())
+    {
+      m_transferPenaltiesPT[line.GetId()].emplace_back(interval.m_headwayS / 2,
+                                                       interval.m_timeIntervals);
+    }
+
+    // TODO(o.khlopkova) Decide what to do with lines with empty intervals.
+    if (m_transferPenaltiesPT[line.GetId()].empty())
+    {
+      m_transferPenaltiesPT[line.GetId()].emplace_back(kDefaultIntervalS / 2,
+                                                       osmoh::OpeningHours("24/7"));
+    }
+  }
+
+  map<transit::StopId, LatLonWithAltitude> stopCoords;
+
+  for (auto const & stop : transitData.GetStops())
+  {
+    stopCoords[stop.GetId()] =
+        LatLonWithAltitude(mercator::ToLatLon(stop.GetPoint()), geometry::kDefaultAltitudeMeters);
+  }
+
+  StopToSegmentsMap stopToBack;
+  StopToSegmentsMap stopToFront;
+  StopToSegmentsMap outgoing;
+  StopToSegmentsMap ingoing;
+
+  // It's important to add transit edges first to ensure fake segment id for particular edge is edge
+  // order in mwm. We use edge fake segments in cross-mwm section and they should be stable.
+  auto const & edges = transitData.GetEdges();
+  CHECK_EQUAL(m_fake.GetSize(), 0, ());
+  for (size_t i = 0; i < edges.size(); ++i)
+  {
+    auto const & edge = edges[i];
+    CHECK_NOT_EQUAL(edge.GetWeight(), transit::kInvalidWeight, ("Edge should have valid weight."));
+    auto const edgeSegment = AddEdge(edge, stopCoords, stopToBack, stopToFront);
+    // Checks fake feature ids have consecutive numeration starting from
+    // FakeFeatureIds::kTransitGraphFeaturesStart.
+    CHECK_EQUAL(edgeSegment.GetFeatureId(), i + FakeFeatureIds::kTransitGraphFeaturesStart, ());
+    outgoing[edge.GetStop1Id()].insert(edgeSegment);
+    ingoing[edge.GetStop2Id()].insert(edgeSegment);
+  }
+  CHECK_EQUAL(m_fake.GetSize(), edges.size(), ());
+
+  for (auto const & gate : transitData.GetGates())
+  {
+    CHECK(!gate.GetStopsWithWeight().empty(), ("Gate should have valid weight."));
+
+    // Gate ending may have empty projections vector. It means gate is not connected to roads.
+    auto const it = gateEndings.find(gate.GetOsmId());
+    if (it != gateEndings.end())
+    {
+      if (gate.IsEntrance())
+        AddGate(gate, it->second, stopCoords, true /* isEnter */, stopToBack, stopToFront);
+      if (gate.IsExit())
+        AddGate(gate, it->second, stopCoords, false /* isEnter */, stopToBack, stopToFront);
+    }
+  }
+
+  for (auto const & stop : transitData.GetStops())
+  {
+    // Stop ending may have empty projections vector. It means stop is not connected to roads.
+    auto const it = stopEndings.find(stop.GetId());
+    if (it != stopEndings.end())
+    {
+      AddStop(stop, it->second, stopCoords, stopToBack, stopToFront);
+    }
+  }
+
+  AddConnections(outgoing, stopToBack, stopToFront, true /* isOutgoing */);
+  AddConnections(ingoing, stopToBack, stopToFront, false /* isOutgoing */);
+}
+
+void TransitGraph::Fill(transit::GraphData const & transitData, Endings const & gateEndings)
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   // Line has information about transit interval.
   // We assume arrival time has uniform distribution with min value |0| and max value |line.GetInterval()|.
   // Expected value of time to wait transport for particular line is |line.GetInterval() / 2|.
@@ -183,12 +340,20 @@ void TransitGraph::Fill(transit::GraphData const & transitData, GateEndings cons
 
 bool TransitGraph::IsGate(Segment const & segment) const
 {
-  return m_segmentToGate.count(segment) > 0;
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
+    return m_segmentToGate.count(segment) > 0;
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+    return m_segmentToGatePT.count(segment) > 0;
+  UNREACHABLE();
 }
 
 bool TransitGraph::IsEdge(Segment const & segment) const
 {
-  return m_segmentToEdge.count(segment) > 0;
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
+    return m_segmentToEdge.count(segment) > 0;
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+    return m_segmentToEdgePT.count(segment) > 0;
+  UNREACHABLE();
 }
 
 transit::Gate const & TransitGraph::GetGate(Segment const & segment) const
@@ -198,10 +363,26 @@ transit::Gate const & TransitGraph::GetGate(Segment const & segment) const
   return it->second;
 }
 
+::transit::experimental::Gate const & TransitGraph::GetGatePT(Segment const & segment) const
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+  auto const it = m_segmentToGatePT.find(segment);
+  CHECK(it != m_segmentToGatePT.cend(), ("Unknown transit segment."));
+  return it->second;
+}
+
 transit::Edge const & TransitGraph::GetEdge(Segment const & segment) const
 {
   auto const it = m_segmentToEdge.find(segment);
   CHECK(it != m_segmentToEdge.cend(), ("Unknown transit segment."));
+  return it->second;
+}
+
+::transit::experimental::Edge const & TransitGraph::GetEdgePT(Segment const & segment) const
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+  auto const it = m_segmentToEdgePT.find(segment);
+  CHECK(it != m_segmentToEdgePT.cend(), ("Unknown transit segment", segment));
   return it->second;
 }
 
@@ -229,6 +410,8 @@ void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending
                            bool isEnter, StopToSegmentsMap & stopToBack,
                            StopToSegmentsMap & stopToFront)
 {
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   Segment const dummy = Segment();
   for (auto const & projection : ending.m_projections)
   {
@@ -279,10 +462,130 @@ void TransitGraph::AddGate(transit::Gate const & gate, FakeEnding const & ending
   }
 }
 
+void TransitGraph::AddGate(::transit::experimental::Gate const & gate, FakeEnding const & ending,
+                           std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
+                           bool isEnter, StopToSegmentsMap & stopToBack,
+                           StopToSegmentsMap & stopToFront)
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+
+  Segment const dummy = Segment();
+  for (auto const & projection : ending.m_projections)
+  {
+    // Add projection edges
+    auto const projectionSegment = GetNewTransitSegment();
+    FakeVertex projectionVertex(
+        projection.m_segment.GetMwmId(), isEnter ? projection.m_junction : ending.m_originJunction,
+        isEnter ? ending.m_originJunction : projection.m_junction, FakeVertex::Type::PureFake);
+    m_fake.AddStandaloneVertex(projectionSegment, projectionVertex);
+
+    // Add fake parts of real
+    FakeVertex forwardPartOfReal(
+        projection.m_segment.GetMwmId(), isEnter ? projection.m_segmentBack : projection.m_junction,
+        isEnter ? projection.m_junction : projection.m_segmentFront, FakeVertex::Type::PartOfReal);
+    auto const fakeForwardSegment = GetNewTransitSegment();
+    m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
+                     !isEnter /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
+
+    if (!projection.m_isOneWay)
+    {
+      FakeVertex backwardPartOfReal(projection.m_segment.GetMwmId(),
+                                    isEnter ? projection.m_segmentFront : projection.m_junction,
+                                    isEnter ? projection.m_junction : projection.m_segmentBack,
+                                    FakeVertex::Type::PartOfReal);
+      auto const fakeBackwardSegment = GetNewTransitSegment();
+      m_fake.AddVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
+                       !isEnter /* isOutgoing */, true /* isPartOfReal */,
+                       GetReverseSegment(projection.m_segment));
+    }
+
+    // Connect gate to stops
+    for (auto const & timeFromGateToStop : gate.GetStopsWithWeight())
+    {
+      auto const stopId = timeFromGateToStop.m_stopId;
+      auto const gateSegment = GetNewTransitSegment();
+      auto const stopIt = stopCoords.find(stopId);
+      CHECK(stopIt != stopCoords.end(), ("Stop", stopId, "does not exist."));
+      FakeVertex gateVertex(
+          projection.m_segment.GetMwmId(), isEnter ? ending.m_originJunction : stopIt->second,
+          isEnter ? stopIt->second : ending.m_originJunction, FakeVertex::Type::PureFake);
+      m_fake.AddVertex(projectionSegment, gateSegment, gateVertex, isEnter /* isOutgoing */,
+                       false /* isPartOfReal */, dummy /* realSegment */);
+      m_segmentToGatePT[gateSegment] = gate;
+      if (isEnter)
+        stopToFront[stopId].insert(gateSegment);
+      else
+        stopToBack[stopId].insert(gateSegment);
+    }
+  }
+}
+
+void TransitGraph::AddStop(::transit::experimental::Stop const & stop, FakeEnding const & ending,
+                           std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
+                           StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront)
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+
+  Segment const dummy = Segment();
+  for (bool isEnter : {true, false})
+  {
+    for (auto const & projection : ending.m_projections)
+    {
+      // Add projection edges
+      auto const projectionSegment = GetNewTransitSegment();
+      FakeVertex projectionVertex(projection.m_segment.GetMwmId(),
+                                  isEnter ? projection.m_junction : ending.m_originJunction,
+                                  isEnter ? ending.m_originJunction : projection.m_junction,
+                                  FakeVertex::Type::PureFake);
+      m_fake.AddStandaloneVertex(projectionSegment, projectionVertex);
+
+      // Add fake parts of real
+      FakeVertex forwardPartOfReal(projection.m_segment.GetMwmId(),
+                                   isEnter ? projection.m_segmentBack : projection.m_junction,
+                                   isEnter ? projection.m_junction : projection.m_segmentFront,
+                                   FakeVertex::Type::PartOfReal);
+      auto const fakeForwardSegment = GetNewTransitSegment();
+      m_fake.AddVertex(projectionSegment, fakeForwardSegment, forwardPartOfReal,
+                       !isEnter /* isOutgoing */, true /* isPartOfReal */, projection.m_segment);
+
+      if (!projection.m_isOneWay)
+      {
+        FakeVertex backwardPartOfReal(projection.m_segment.GetMwmId(),
+                                      isEnter ? projection.m_segmentFront : projection.m_junction,
+                                      isEnter ? projection.m_junction : projection.m_segmentBack,
+                                      FakeVertex::Type::PartOfReal);
+        auto const fakeBackwardSegment = GetNewTransitSegment();
+        m_fake.AddVertex(projectionSegment, fakeBackwardSegment, backwardPartOfReal,
+                         !isEnter /* isOutgoing */, true /* isPartOfReal */,
+                         GetReverseSegment(projection.m_segment));
+      }
+
+      // Connect stop to graph.
+
+      auto const stopId = stop.GetId();
+      auto const stopSegment = GetNewTransitSegment();
+      auto const stopIt = stopCoords.find(stopId);
+      CHECK(stopIt != stopCoords.end(), ("Stop", stopId, "does not exist."));
+      FakeVertex stopVertex(
+          projection.m_segment.GetMwmId(), isEnter ? ending.m_originJunction : stopIt->second,
+          isEnter ? stopIt->second : ending.m_originJunction, FakeVertex::Type::PureFake);
+      m_fake.AddVertex(projectionSegment, stopSegment, stopVertex, isEnter /* isOutgoing */,
+                       false /* isPartOfReal */, dummy /* realSegment */);
+      m_segmentToStopPT[stopSegment] = stop;
+      if (isEnter)
+        stopToFront[stopId].insert(stopSegment);
+      else
+        stopToBack[stopId].insert(stopSegment);
+    }
+  }
+}
+
 Segment TransitGraph::AddEdge(transit::Edge const & edge,
                               map<transit::StopId, LatLonWithAltitude> const & stopCoords,
                               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront)
 {
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   auto const edgeSegment = GetNewTransitSegment();
   auto const stopFromId = edge.GetStop1Id();
   auto const stopToId = edge.GetStop2Id();
@@ -290,6 +593,24 @@ Segment TransitGraph::AddEdge(transit::Edge const & edge,
                         GetStopJunction(stopCoords, stopToId), FakeVertex::Type::PureFake);
   m_fake.AddStandaloneVertex(edgeSegment, edgeVertex);
   m_segmentToEdge[edgeSegment] = edge;
+  stopToBack[stopFromId].insert(edgeSegment);
+  stopToFront[stopToId].insert(edgeSegment);
+  return edgeSegment;
+}
+
+Segment TransitGraph::AddEdge(::transit::experimental::Edge const & edge,
+                              std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
+                              StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront)
+{
+  CHECK_EQUAL(m_transitVersion, ::transit::TransitVersion::AllPublicTransport, ());
+
+  auto const edgeSegment = GetNewTransitSegment();
+  auto const stopFromId = edge.GetStop1Id();
+  auto const stopToId = edge.GetStop2Id();
+  FakeVertex edgeVertex(m_mwmId, GetStopJunction(stopCoords, stopFromId),
+                        GetStopJunction(stopCoords, stopToId), FakeVertex::Type::PureFake);
+  m_fake.AddStandaloneVertex(edgeSegment, edgeVertex);
+  m_segmentToEdgePT[edgeSegment] = edge;
   stopToBack[stopFromId].insert(edgeSegment);
   stopToFront[stopToId].insert(edgeSegment);
   return edgeSegment;
@@ -316,8 +637,8 @@ void TransitGraph::AddConnections(StopToSegmentsMap const & connections,
   }
 }
 
-void MakeGateEndings(vector<transit::Gate> const & gates, NumMwmId mwmId,
-                     IndexGraph & indexGraph, TransitGraph::GateEndings & gateEndings)
+void MakeGateEndings(vector<transit::Gate> const & gates, NumMwmId mwmId, IndexGraph & indexGraph,
+                     TransitGraph::Endings & gateEndings)
 {
   for (auto const & gate : gates)
   {
@@ -328,6 +649,34 @@ void MakeGateEndings(vector<transit::Gate> const & gates, NumMwmId mwmId,
     Segment const real(mwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
                        gateSegment.GetForward());
     gateEndings.emplace(gate.GetOsmId(), MakeFakeEnding({real}, gate.GetPoint(), indexGraph));
+  }
+}
+
+void MakeGateEndings(std::vector<::transit::experimental::Gate> const & gates, NumMwmId mwmId,
+                     IndexGraph & indexGraph, TransitGraph::Endings & gateEndings)
+{
+  for (auto const & gate : gates)
+  {
+    for (auto const & gateSegment : gate.GetBestPedestrianSegments())
+    {
+      Segment const real(mwmId, gateSegment.GetFeatureId(), gateSegment.GetSegmentIdx(),
+                         gateSegment.IsForward());
+      gateEndings.emplace(gate.GetOsmId(), MakeFakeEnding(real, gate.GetPoint(), indexGraph));
+    }
+  }
+}
+
+void MakeStopEndings(std::vector<::transit::experimental::Stop> const & stops, NumMwmId mwmId,
+                     IndexGraph & indexGraph, TransitGraph::Endings & stopEndings)
+{
+  for (auto const & stop : stops)
+  {
+    for (auto const & stopSegment : stop.GetBestPedestrianSegments())
+    {
+      Segment const real(mwmId, stopSegment.GetFeatureId(), stopSegment.GetSegmentIdx(),
+                         stopSegment.IsForward());
+      stopEndings.emplace(stop.GetId(), MakeFakeEnding(real, stop.GetPoint(), indexGraph));
+    }
   }
 }
 }  // namespace routing

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -9,8 +9,11 @@
 #include "routing/route_weight.hpp"
 #include "routing/segment.hpp"
 
+#include "transit/experimental/transit_data.hpp"
+#include "transit/experimental/transit_types_experimental.hpp"
 #include "transit/transit_graph_data.hpp"
 #include "transit/transit_types.hpp"
+#include "transit/transit_version.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
 
@@ -27,12 +30,17 @@ class IndexGraph;
 class TransitGraph final
 {
 public:
-  using GateEndings = std::map<transit::OsmId, FakeEnding>;
+  // Fake endings for gates (in subway transit version) or for gates and stops (in public transport
+  // version.
+  using Endings = std::map<transit::OsmId, FakeEnding>;
 
   static bool IsTransitFeature(uint32_t featureId);
   static bool IsTransitSegment(Segment const & segment);
 
-  TransitGraph(NumMwmId numMwmId, std::shared_ptr<EdgeEstimator> estimator);
+  TransitGraph(::transit::TransitVersion transitVersion, NumMwmId numMwmId,
+               std::shared_ptr<EdgeEstimator> estimator);
+
+  ::transit::TransitVersion GetTransitVersion() const;
 
   LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
@@ -42,12 +50,16 @@ public:
   std::set<Segment> const & GetFake(Segment const & real) const;
   bool FindReal(Segment const & fake, Segment & real) const;
 
-  void Fill(transit::GraphData const & transitData, GateEndings const & gateEndings);
+  void Fill(::transit::experimental::TransitData const & transitData, Endings const & stopEndings,
+            Endings const & gateEndings);
+  void Fill(transit::GraphData const & transitData, Endings const & gateEndings);
 
   bool IsGate(Segment const & segment) const;
   bool IsEdge(Segment const & segment) const;
   transit::Gate const & GetGate(Segment const & segment) const;
+  ::transit::experimental::Gate const & GetGatePT(Segment const & segment) const;
   transit::Edge const & GetEdge(Segment const & segment) const;
+  ::transit::experimental::Edge const & GetEdgePT(Segment const & segment) const;
 
 private:
   using StopToSegmentsMap = std::map<transit::StopId, std::set<Segment>>;
@@ -60,23 +72,52 @@ private:
   void AddGate(transit::Gate const & gate, FakeEnding const & ending,
                std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
                bool isEnter, StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+
+  void AddGate(::transit::experimental::Gate const & gate, FakeEnding const & ending,
+               std::map<transit::StopId, LatLonWithAltitude> const & stopCoords, bool isEnter,
+               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+
+  void AddStop(::transit::experimental::Stop const & stop, FakeEnding const & ending,
+               std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
+               StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+
   // Adds transit edge to fake graph, returns corresponding transit segment. Also adds gate to
   // temporary stopToBack, stopToFront maps used while TransitGraph::Fill.
   Segment AddEdge(transit::Edge const & edge,
                   std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
                   StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+
+  Segment AddEdge(::transit::experimental::Edge const & edge,
+                  std::map<transit::StopId, LatLonWithAltitude> const & stopCoords,
+                  StopToSegmentsMap & stopToBack, StopToSegmentsMap & stopToFront);
+
   // Adds connections to fake graph.
   void AddConnections(StopToSegmentsMap const & connections, StopToSegmentsMap const & stopToBack,
                       StopToSegmentsMap const & stopToFront, bool isOutgoing);
 
+  ::transit::TransitVersion const m_transitVersion;
   NumMwmId const m_mwmId = kFakeNumMwmId;
   std::shared_ptr<EdgeEstimator> m_estimator;
   FakeGraph m_fake;
+
+  // Fields for working with OnlySubway version of transit.
   std::map<Segment, transit::Edge> m_segmentToEdge;
   std::map<Segment, transit::Gate> m_segmentToGate;
   std::map<transit::LineId, double> m_transferPenalties;
+
+  // Fields for working with Public transport version of transit.
+  std::map<Segment, ::transit::experimental::Edge> m_segmentToEdgePT;
+  std::map<Segment, ::transit::experimental::Gate> m_segmentToGatePT;
+  std::map<Segment, ::transit::experimental::Stop> m_segmentToStopPT;
+  std::map<::transit::TransitId, std::vector<::transit::LineInterval>> m_transferPenaltiesPT;
 };
 
 void MakeGateEndings(std::vector<transit::Gate> const & gates, NumMwmId mwmId,
-                     IndexGraph & indexGraph, TransitGraph::GateEndings & gateEndings);
+                     IndexGraph & indexGraph, TransitGraph::Endings & gateEndings);
+
+void MakeGateEndings(std::vector<::transit::experimental::Gate> const & gates, NumMwmId mwmId,
+                     IndexGraph & indexGraph, TransitGraph::Endings & gateEndings);
+
+void MakeStopEndings(std::vector<::transit::experimental::Stop> const & stops, NumMwmId mwmId,
+                     IndexGraph & indexGraph, TransitGraph::Endings & gateEndings);
 }  // namespace routing

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -101,9 +101,9 @@ private:
   FakeGraph m_fake;
 
   // Fields for working with OnlySubway version of transit.
-  std::map<Segment, transit::Edge> m_segmentToEdge;
-  std::map<Segment, transit::Gate> m_segmentToGate;
-  std::map<transit::LineId, double> m_transferPenalties;
+  std::map<Segment, transit::Edge> m_segmentToEdgeSubway;
+  std::map<Segment, transit::Gate> m_segmentToGateSubway;
+  std::map<transit::LineId, double> m_transferPenaltiesSubway;
 
   // Fields for working with Public transport version of transit.
   std::map<Segment, ::transit::experimental::Edge> m_segmentToEdgePT;

--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -128,13 +128,15 @@ unique_ptr<TransitGraph> TransitGraphLoaderImpl::CreateTransitGraph(NumMwmId num
       return graph;
     }
 
-    UNREACHABLE();
+    CHECK(false, (transitHeaderVersion));
   }
   catch (Reader::OpenException const & e)
   {
     LOG(LERROR, ("Error while reading", TRANSIT_FILE_TAG, "section.", e.Msg()));
     throw;
   }
+
+  UNREACHABLE();
 }
 
 // static

--- a/routing/transit_info.hpp
+++ b/routing/transit_info.hpp
@@ -106,9 +106,7 @@ public:
   explicit TransitInfo(transit::Gate const & gate)
     : m_transitVersion(::transit::TransitVersion::OnlySubway)
     , m_type(Type::Gate)
-    , m_edgeSubway()
     , m_gateSubway(gate)
-    , m_transferSubway()
   {
   }
 
@@ -123,7 +121,6 @@ public:
     : m_transitVersion(::transit::TransitVersion::OnlySubway)
     , m_type(edge.GetTransfer() ? Type::Transfer : Type::Edge)
     , m_edgeSubway(edge.GetTransfer() ? EdgeSubway() : EdgeSubway(edge))
-    , m_gateSubway()
     , m_transferSubway(edge.GetTransfer() ? TransferSubway(edge) : TransferSubway())
   {
   }
@@ -132,7 +129,6 @@ public:
     : m_transitVersion(::transit::TransitVersion::AllPublicTransport)
     , m_type(edge.IsTransfer() ? Type::Transfer : Type::Edge)
     , m_edgePT(edge.IsTransfer() ? EdgePT() : EdgePT(edge))
-    , m_gatePT()
     , m_transferPT(edge.IsTransfer() ? TransferPT(edge) : TransferPT())
   {
   }

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -195,7 +195,7 @@ unique_ptr<TransitInfo> TransitWorldGraph::GetTransitInfo(Segment const & segmen
   }
   else
   {
-    UNREACHABLE();
+    CHECK(false, (transitGraph.GetTransitVersion()));
   }
 
   // Fake segment between pedestrian feature and gate.

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -177,11 +177,26 @@ unique_ptr<TransitInfo> TransitWorldGraph::GetTransitInfo(Segment const & segmen
     return {};
 
   auto & transitGraph = GetTransitGraph(segment.GetMwmId());
-  if (transitGraph.IsGate(segment))
-    return make_unique<TransitInfo>(transitGraph.GetGate(segment));
+  if (transitGraph.GetTransitVersion() == ::transit::TransitVersion::OnlySubway)
+  {
+    if (transitGraph.IsGate(segment))
+      return make_unique<TransitInfo>(transitGraph.GetGate(segment));
 
-  if (transitGraph.IsEdge(segment))
-    return make_unique<TransitInfo>(transitGraph.GetEdge(segment));
+    if (transitGraph.IsEdge(segment))
+      return make_unique<TransitInfo>(transitGraph.GetEdge(segment));
+  }
+  else if (transitGraph.GetTransitVersion() == ::transit::TransitVersion::AllPublicTransport)
+  {
+    if (transitGraph.IsGate(segment))
+      return make_unique<TransitInfo>(transitGraph.GetGatePT(segment));
+
+    if (transitGraph.IsEdge(segment))
+      return make_unique<TransitInfo>(transitGraph.GetEdgePT(segment));
+  }
+  else
+  {
+    UNREACHABLE();
+  }
 
   // Fake segment between pedestrian feature and gate.
   return {};

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -40,6 +40,7 @@ public:
   void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                    bool useRoutingOptions, bool useAccessConditional,
                    std::vector<SegmentEdge> & edges) override;
+  // Dummy method which shouldn't be called.
   void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                    Segment const & segment, bool isOutgoing, bool useAccessConditional,
                    std::vector<JointEdge> & edges,

--- a/transit/transit_display_info.hpp
+++ b/transit/transit_display_info.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "transit/experimental/transit_types_experimental.hpp"
 #include "transit/transit_types.hpp"
+#include "transit/transit_version.hpp"
 
 #include "indexer/feature_decl.hpp"
 
@@ -24,14 +26,31 @@ using TransitShapesInfo = std::map<routing::transit::ShapeId, routing::transit::
 using TransitLinesInfo = std::map<routing::transit::LineId, routing::transit::Line>;
 using TransitNetworksInfo = std::map<routing::transit::NetworkId, routing::transit::Network>;
 
+using TransitStopsInfoPT = std::map<::transit::TransitId, ::transit::experimental::Stop>;
+using TransitTransfersInfoPT = std::map<::transit::TransitId, ::transit::experimental::Transfer>;
+using TransitShapesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Shape>;
+using TransitLinesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Line>;
+using TransitRoutesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Route>;
+using TransitNetworksInfoPT = std::map<::transit::TransitId, ::transit::experimental::Network>;
+
 struct TransitDisplayInfo
 {
-  TransitNetworksInfo m_networks;
-  TransitLinesInfo m_lines;
-  TransitStopsInfo m_stops;
-  TransitTransfersInfo m_transfers;
-  TransitShapesInfo m_shapes;
+  ::transit::TransitVersion m_transitVersion;
+
   TransitFeaturesInfo m_features;
+
+  TransitNetworksInfo m_networksSubway;
+  TransitLinesInfo m_linesSubway;
+  TransitStopsInfo m_stopsSubway;
+  TransitTransfersInfo m_transfersSubway;
+  TransitShapesInfo m_shapesSubway;
+
+  TransitNetworksInfoPT m_networksPT;
+  TransitLinesInfoPT m_linesPT;
+  TransitRoutesInfoPT m_routesPT;
+  TransitStopsInfoPT m_stopsPT;
+  TransitTransfersInfoPT m_transfersPT;
+  TransitShapesInfoPT m_shapesPT;
 };
 
 using TransitDisplayInfos = std::map<MwmSet::MwmId, std::unique_ptr<TransitDisplayInfo>>;

--- a/transit/transit_display_info.hpp
+++ b/transit/transit_display_info.hpp
@@ -20,6 +20,10 @@ struct TransitFeatureInfo
 
 using TransitFeaturesInfo = std::map<FeatureID, TransitFeatureInfo>;
 
+// We have two completely different versions of transit section: the actual one with subway-only
+// info and the experimental one with all public transport (PT) info. So we keep the old data
+// with suffix Subway and the new data with suffix PT. In the future we will remove the subway
+// version (after a year or so of PT usage).
 using TransitStopsInfo = std::map<routing::transit::StopId, routing::transit::Stop>;
 using TransitTransfersInfo = std::map<routing::transit::TransferId, routing::transit::Transfer>;
 using TransitShapesInfo = std::map<routing::transit::ShapeId, routing::transit::Shape>;

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -105,6 +105,12 @@ struct ShapeLink
            std::tie(rhs.m_shapeId, rhs.m_startIndex, rhs.m_endIndex);
   }
 
+  bool operator<(ShapeLink const & rhs) const
+  {
+    return std::tie(m_shapeId, m_startIndex, m_endIndex) <
+           std::tie(rhs.m_shapeId, rhs.m_startIndex, rhs.m_endIndex);
+  }
+
   DECLARE_VISITOR_AND_DEBUG_PRINT(ShapeLink, visitor(m_shapeId, "id"),
                                   visitor(m_startIndex, "startIndex"),
                                   visitor(m_endIndex, "endIndex"))

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 

--- a/transit/transit_version.hpp
+++ b/transit/transit_version.hpp
@@ -5,6 +5,7 @@
 #include "base/assert.hpp"
 
 #include <string>
+#include <type_traits>
 
 namespace transit
 {
@@ -26,6 +27,9 @@ inline std::string DebugPrint(TransitVersion version)
   case TransitVersion::AllPublicTransport: return "AllPublicTransport";
   case TransitVersion::Counter: return "Counter";
   }
+
+  LOG(LERROR,
+      ("Unknown version:", static_cast<std::underlying_type<TransitVersion>::type>(version)));
   UNREACHABLE();
 }
 }  // namespace transit

--- a/xcode/transit/transit.xcodeproj/project.pbxproj
+++ b/xcode/transit/transit.xcodeproj/project.pbxproj
@@ -13,6 +13,14 @@
 		562DDBDF1FE8EA0A0091F566 /* transit_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 562DDBDB1FE8EA0A0091F566 /* transit_serdes.hpp */; };
 		56EE14CB1FE7F2900036F20C /* transit_types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56EE14C91FE7F2900036F20C /* transit_types.cpp */; };
 		56EE14CC1FE7F2900036F20C /* transit_types.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56EE14CA1FE7F2900036F20C /* transit_types.hpp */; };
+		D55B290A24CACF9E000E2EBE /* transit_display_info.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D55B290524CACF9E000E2EBE /* transit_display_info.hpp */; };
+		D55B290B24CACF9E000E2EBE /* transit_version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D55B290624CACF9E000E2EBE /* transit_version.hpp */; };
+		D55B290C24CACF9E000E2EBE /* transit_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D55B290724CACF9E000E2EBE /* transit_version.cpp */; };
+		D55B290D24CACF9E000E2EBE /* transit_entities.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D55B290924CACF9E000E2EBE /* transit_entities.hpp */; };
+		D56AD1DB24CB02C00057F2E0 /* transit_types_experimental.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D56AD1D724CB02BF0057F2E0 /* transit_types_experimental.hpp */; };
+		D56AD1DC24CB02C00057F2E0 /* transit_data.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D56AD1D824CB02BF0057F2E0 /* transit_data.hpp */; };
+		D56AD1DD24CB02C00057F2E0 /* transit_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D56AD1D924CB02BF0057F2E0 /* transit_data.cpp */; };
+		D56AD1DE24CB02C00057F2E0 /* transit_types_experimental.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D56AD1DA24CB02BF0057F2E0 /* transit_types_experimental.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +33,14 @@
 		56EE14C81FE7F20A0036F20C /* common-release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "common-release.xcconfig"; path = "../common-release.xcconfig"; sourceTree = "<group>"; };
 		56EE14C91FE7F2900036F20C /* transit_types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_types.cpp; sourceTree = "<group>"; };
 		56EE14CA1FE7F2900036F20C /* transit_types.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_types.hpp; sourceTree = "<group>"; };
+		D55B290524CACF9E000E2EBE /* transit_display_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_display_info.hpp; sourceTree = "<group>"; };
+		D55B290624CACF9E000E2EBE /* transit_version.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_version.hpp; sourceTree = "<group>"; };
+		D55B290724CACF9E000E2EBE /* transit_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_version.cpp; sourceTree = "<group>"; };
+		D55B290924CACF9E000E2EBE /* transit_entities.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_entities.hpp; sourceTree = "<group>"; };
+		D56AD1D724CB02BF0057F2E0 /* transit_types_experimental.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_types_experimental.hpp; sourceTree = "<group>"; };
+		D56AD1D824CB02BF0057F2E0 /* transit_data.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_data.hpp; sourceTree = "<group>"; };
+		D56AD1D924CB02BF0057F2E0 /* transit_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_data.cpp; sourceTree = "<group>"; };
+		D56AD1DA24CB02BF0057F2E0 /* transit_types_experimental.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_types_experimental.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +75,11 @@
 		56D7F2F61FE7F0F200D99E62 /* transit */ = {
 			isa = PBXGroup;
 			children = (
+				D56AD1D624CB02BF0057F2E0 /* experimental */,
+				D55B290524CACF9E000E2EBE /* transit_display_info.hpp */,
+				D55B290924CACF9E000E2EBE /* transit_entities.hpp */,
+				D55B290724CACF9E000E2EBE /* transit_version.cpp */,
+				D55B290624CACF9E000E2EBE /* transit_version.hpp */,
 				562DDBD81FE8EA080091F566 /* transit_graph_data.cpp */,
 				562DDBD91FE8EA080091F566 /* transit_graph_data.hpp */,
 				562DDBDB1FE8EA0A0091F566 /* transit_serdes.hpp */,
@@ -70,6 +91,17 @@
 			path = ../../transit;
 			sourceTree = "<group>";
 		};
+		D56AD1D624CB02BF0057F2E0 /* experimental */ = {
+			isa = PBXGroup;
+			children = (
+				D56AD1D724CB02BF0057F2E0 /* transit_types_experimental.hpp */,
+				D56AD1D824CB02BF0057F2E0 /* transit_data.hpp */,
+				D56AD1D924CB02BF0057F2E0 /* transit_data.cpp */,
+				D56AD1DA24CB02BF0057F2E0 /* transit_types_experimental.cpp */,
+			);
+			path = experimental;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -77,8 +109,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D56AD1DC24CB02C00057F2E0 /* transit_data.hpp in Headers */,
+				D55B290D24CACF9E000E2EBE /* transit_entities.hpp in Headers */,
 				56EE14CC1FE7F2900036F20C /* transit_types.hpp in Headers */,
+				D56AD1DB24CB02C00057F2E0 /* transit_types_experimental.hpp in Headers */,
 				562DDBDD1FE8EA0A0091F566 /* transit_graph_data.hpp in Headers */,
+				D55B290A24CACF9E000E2EBE /* transit_display_info.hpp in Headers */,
+				D55B290B24CACF9E000E2EBE /* transit_version.hpp in Headers */,
 				562DDBDF1FE8EA0A0091F566 /* transit_serdes.hpp in Headers */,
 				562DDBDE1FE8EA0A0091F566 /* transit_speed_limits.hpp in Headers */,
 			);
@@ -141,8 +178,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D55B290C24CACF9E000E2EBE /* transit_version.cpp in Sources */,
 				562DDBDC1FE8EA0A0091F566 /* transit_graph_data.cpp in Sources */,
 				56EE14CB1FE7F2900036F20C /* transit_types.cpp in Sources */,
+				D56AD1DD24CB02C00057F2E0 /* transit_data.cpp in Sources */,
+				D56AD1DE24CB02C00057F2E0 /* transit_types_experimental.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Реквест реализует работу с новой версией транзитной секции в рантайме:
-  роутинга,
- отрисовки проложенного маршрута.

@bykoianko @tomilov Реквест удобнее всего смотреть по комитам.

В нем делается следующее: 
- в классы, ответственные за хранение данных из транзитной секции, добавляется поле "версия" и поля в формате новой версии, которые частично или полностью соответствуют старым полям (например, line). Старые поля переименовываются путем добавления суффикса Subway (потому что старая версия транзита - это только метро); новые поля именуются с добавлением суффикса PT (public transport).
- в соответствии с этим отрефакторен код, который с этими классами работает. Он разбивается на две ветки: if (старая версия), if (новая версия).

Для обработки новой версии транзита в рантайме в слое со схемой метро будет отдельный реквест.

В этом реквесте уже прокладываются маршруты в рантайме. Для этого нужны mwm, собранные со включенными экспериментальными параметрами генератора. В них находится транзитная секция в новом формате.

Примеры построенных маршрутов на общественном транспорте. Для наглядности они отрисованы поверх kml, содержащих всю транспортную сеть с остановками.
<img width="890" alt="Screenshot 2020-07-16 at 16 10 45" src="https://user-images.githubusercontent.com/54934129/87675034-871fbe80-c77f-11ea-8624-62b4cd812da6.png">
<img width="724" alt="Screenshot 2020-07-07 at 11 16 32" src="https://user-images.githubusercontent.com/54934129/87675118-a28ac980-c77f-11ea-9a4c-496999db6312.png"><img width="1550" alt="Screenshot 2020-07-16 at 16 13 26" src="https://user-images.githubusercontent.com/54934129/87675013-81c27400-c77f-11ea-9912-6a655057812e.png">






 
