### PR TITLE
[generator] Roundabouts should have one direction.

### DIFF
--- a/generator/mini_roundabout_transformer.cpp
+++ b/generator/mini_roundabout_transformer.cpp
@@ -154,6 +154,8 @@ feature::FeatureBuilder CreateFb(std::vector<m2::PointD> const & way, uint64_t i
   fb.AddType(roundaboutType);
   static uint32_t const defaultRoadType = classif().GetTypeByPath({"highway", "tertiary"});
   fb.AddType(roadType == 0 ? defaultRoadType : roadType);
+  static uint32_t const onewayType = classif().GetTypeByPath({"hwtag", "oneway"});
+  fb.AddType(onewayType);
 
   return fb;
 }


### PR DESCRIPTION
Мы добавляем искусственные линии-раундэбауты с центром в точках из ОСМ, помеченных как раундэбауты. Но к ним нужно приклеивать тег oneway по аналогии с обычными way-раундэабутами в generator/osm2type.cpp, line 668:
`{"junction", "roundabout", [&addOneway] { addOneway = true; }},`.

Реквест подготовлен в процессе выяснения причин бага https://jira.mail.ru/browse/MAPSME-13070.