### PR TITLE
[search][coding] Normalize ja kana.

### DIFF
--- a/base/buffer_vector.hpp
+++ b/base/buffer_vector.hpp
@@ -237,8 +237,10 @@ public:
   //@}
 
   T const * begin() const { return data(); }
+  T const * cbegin() const { return data(); }
   T       * begin()       { return data(); }
   T const * end() const { return data() + size(); }
+  T const * cend() const { return data() + size(); }
   T       * end()       { return data() + size(); }
   //@}
 

--- a/coding/transliteration.cpp
+++ b/coding/transliteration.cpp
@@ -81,6 +81,7 @@ void Transliteration::SetMode(Transliteration::Mode mode)
 
 bool Transliteration::Transliterate(std::string transliteratorId, UnicodeString & ustr) const
 {
+  CHECK(m_inited, ());
   CHECK(!transliteratorId.empty(), (transliteratorId));
 
   auto it = m_transliterators.find(transliteratorId);
@@ -127,9 +128,10 @@ bool Transliteration::Transliterate(std::string transliteratorId, UnicodeString 
   return true;
 }
 
-bool Transliteration::Transliterate(std::string const & str, std::string transliteratorId,
-                                    std::string & out) const
+bool Transliteration::TransliterateForce(std::string const & str, std::string const & transliteratorId,
+                                         std::string & out) const
 {
+  CHECK(m_inited, ());
   UnicodeString ustr(str.c_str());
   auto const res = Transliterate(transliteratorId, ustr);
   if (res)
@@ -140,6 +142,7 @@ bool Transliteration::Transliterate(std::string const & str, std::string transli
 bool Transliteration::Transliterate(std::string const & str, int8_t langCode,
                                     std::string & out) const
 {
+  CHECK(m_inited, ());
   if (m_mode != Mode::Enabled)
     return false;
 
@@ -152,11 +155,7 @@ bool Transliteration::Transliterate(std::string const & str, int8_t langCode,
 
   UnicodeString ustr(str.c_str());
   for (auto transliteratorId : transliteratorsIds)
-  {
-    if (!Transliterate(transliteratorId, ustr))
-      continue;
-
-  }
+    Transliterate(transliteratorId, ustr);
 
   if (ustr.isEmpty())
     return false;

--- a/coding/transliteration.hpp
+++ b/coding/transliteration.hpp
@@ -4,7 +4,13 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
+
+namespace icu
+{
+class UnicodeString;
+}  // namespace icu
 
 class Transliteration
 {
@@ -22,13 +28,19 @@ public:
   void Init(std::string const & icuDataDir);
 
   void SetMode(Mode mode);
+  bool Transliterate(std::string const & str, std::string transliteratorId,
+                     std::string & out) const;
   bool Transliterate(std::string const & str, int8_t langCode, std::string & out) const;
 
 private:
+  struct TransliteratorInfo;
+
   Transliteration();
 
-  std::atomic<Mode> m_mode;
+  bool Transliterate(std::string transliteratorId, icu::UnicodeString & ustr) const;
 
-  struct TransliteratorInfo;
+  std::mutex m_initializationMutex;
+  std::atomic<bool> m_inited;
+  std::atomic<Mode> m_mode;
   std::map<std::string, std::unique_ptr<TransliteratorInfo>> m_transliterators;
 };

--- a/coding/transliteration.hpp
+++ b/coding/transliteration.hpp
@@ -28,9 +28,13 @@ public:
   void Init(std::string const & icuDataDir);
 
   void SetMode(Mode mode);
-  bool Transliterate(std::string const & str, std::string transliteratorId,
-                     std::string & out) const;
+  // Transliterates |str| with transliterators set for |langCode| in StringUtf8Multilang
+  // if mode is set to Enabled.
   bool Transliterate(std::string const & str, int8_t langCode, std::string & out) const;
+
+  // Transliterates |str| with |transliteratorId|, ignores mode.
+  bool TransliterateForce(std::string const & str, std::string const & transliteratorId,
+                          std::string & out) const;
 
 private:
   struct TransliteratorInfo;

--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -128,6 +128,8 @@ set(
   string_slice.hpp
   succinct_trie_builder.hpp
   succinct_trie_reader.hpp
+  transliteration_loader.cpp
+  transliteration_loader.hpp
   tree_structure.hpp
   trie.hpp
   trie_builder.hpp

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -70,7 +70,7 @@ void TransliterateHiraganaToKatakana(UniString & s)
 
   InitTransliterationInstanceWithDefaultDirs();
   string out;
-  if (Transliteration::Instance().Transliterate(strings::ToUtf8(s), "Hiragana-Katakana", out))
+  if (Transliteration::Instance().TransliterateForce(strings::ToUtf8(s), "Hiragana-Katakana", out))
     s = MakeUniString(out);
 }
 }  // namespace

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -64,6 +64,10 @@ void RemoveNumeroSigns(UniString & s)
 
 void TransliterateHiraganaToKatakana(UniString & s)
 {
+  // Transliteration is heavy. Check we have any hiragana symbol before transliteration.
+  if (!base::AnyOf(s, [](UniChar c){ return c >= 0x3041 && c<= 0x309F; }))
+    return;
+
   InitTransliterationInstanceWithDefaultDirs();
   string out;
   if (Transliteration::Instance().Transliterate(strings::ToUtf8(s), "Hiragana-Katakana", out))

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -1,6 +1,9 @@
 #include "indexer/search_string_utils.hpp"
 
 #include "indexer/string_set.hpp"
+#include "indexer/transliteration_loader.hpp"
+
+#include "coding/transliteration.hpp"
 
 #include "coding/transliteration.hpp"
 
@@ -57,6 +60,14 @@ void RemoveNumeroSigns(UniString & s)
 
     i = j;
   }
+}
+
+void TransliterateHiraganaToKatakana(UniString & s)
+{
+  InitTransliterationInstanceWithDefaultDirs();
+  string out;
+  if (Transliteration::Instance().Transliterate(strings::ToUtf8(s), "Hiragana-Katakana", out))
+    s = MakeUniString(out);
 }
 }  // namespace
 
@@ -134,6 +145,7 @@ UniString NormalizeAndSimplifyString(string const & s)
 
   MakeLowerCaseInplace(uniString);
   NormalizeInplace(uniString);
+  TransliterateHiraganaToKatakana(uniString);
 
   // Remove accents that can appear after NFKD normalization.
   uniString.erase_if([](UniChar const & c) {

--- a/indexer/transliteration_loader.cpp
+++ b/indexer/transliteration_loader.cpp
@@ -1,0 +1,34 @@
+#include "indexer/transliteration_loader.hpp"
+
+#include "platform/platform.hpp"
+
+#include "coding/transliteration.hpp"
+#include "coding/zip_reader.hpp"
+
+#include "base/exception.hpp"
+#include "base/logging.hpp"
+
+#include <string>
+
+void InitTransliterationInstanceWithDefaultDirs()
+{
+#if defined(OMIM_OS_ANDROID)
+  char const kICUDataFile[] = "icudt57l.dat";
+  if (!GetPlatform().IsFileExistsByFullPath(GetPlatform().WritableDir() + kICUDataFile))
+  {
+    try
+    {
+      ZipFileReader::UnzipFile(GetPlatform().ResourcesDir(), std::string("assets/") + kICUDataFile,
+                               GetPlatform().WritableDir() + kICUDataFile);
+    }
+    catch (RootException const & e)
+    {
+      LOG(LWARNING,
+          ("Can't get transliteration data file \"", kICUDataFile, "\", reason:", e.Msg()));
+    }
+  }
+  Transliteration::Instance().Init(GetPlatform().WritableDir());
+#else
+  Transliteration::Instance().Init(GetPlatform().ResourcesDir());
+#endif
+}

--- a/indexer/transliteration_loader.hpp
+++ b/indexer/transliteration_loader.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void InitTransliterationInstanceWithDefaultDirs();

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -67,6 +67,7 @@
 #include "indexer/ftypes_sponsored.hpp"
 #include "indexer/map_style_reader.hpp"
 #include "indexer/scales.hpp"
+#include "indexer/transliteration_loader.hpp"
 
 #include "metrics/eye.hpp"
 
@@ -150,10 +151,6 @@ char const kLargeFontsSize[] = "LargeFontsSize";
 char const kTranslitMode[] = "TransliterationMode";
 char const kPreferredGraphicsAPI[] = "PreferredGraphicsAPI";
 char const kShowDebugInfo[] = "DebugInfo";
-
-#if defined(OMIM_OS_ANDROID)
-char const kICUDataFile[] = "icudt57l.dat";
-#endif
 
 auto constexpr kLargeFontsScaleFactor = 1.6;
 auto constexpr kGuidesEnabledInBackgroundMaxHours = 8;
@@ -1587,24 +1584,7 @@ void Framework::InitDiscoveryManager()
 
 void Framework::InitTransliteration()
 {
-#if defined(OMIM_OS_ANDROID)
-  if (!GetPlatform().IsFileExistsByFullPath(GetPlatform().WritableDir() + kICUDataFile))
-  {
-    try
-    {
-      ZipFileReader::UnzipFile(GetPlatform().ResourcesDir(),
-                               string("assets/") + kICUDataFile,
-                               GetPlatform().WritableDir() + kICUDataFile);
-    }
-    catch (RootException const & e)
-    {
-      LOG(LWARNING, ("Can't get transliteration data file \"", kICUDataFile, "\", reason:", e.Msg()));
-    }
-  }
-  Transliteration::Instance().Init(GetPlatform().WritableDir());
-#else
-  Transliteration::Instance().Init(GetPlatform().ResourcesDir());
-#endif
+  InitTransliterationInstanceWithDefaultDirs();
 
   if (!LoadTransliteration())
     Transliteration::Instance().SetMode(Transliteration::Mode::Disabled);

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -3078,5 +3078,25 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_IsAltOrOldName)
   checkIsAltOrOldName("Питер проспект Пролетарской Победы Ростикс", true);
   checkIsAltOrOldName("Ленинград проспект Пролетарской Победы Ростикс", true);
 }
+
+UNIT_CLASS_TEST(ProcessorTest, JaKanaNormalizationTest)
+{
+  string const countryName = "Wonderland";
+
+  TestPOI poiHiragana(m2::PointD(0.0, 0.0), "とうきょうと", "default");
+  TestPOI poiKatakana(m2::PointD(1.0, 1.0), "トウキョウト", "default");
+
+  auto countryId = BuildCountry(countryName, [&](TestMwmBuilder & builder) {
+    builder.Add(poiHiragana);
+    builder.Add(poiKatakana);
+  });
+
+  SetViewport(m2::RectD(m2::PointD(0.0, 0.0), m2::PointD(1.0, 1.0)));
+  {
+    Rules rules = {ExactMatch(countryId, poiHiragana), ExactMatch(countryId, poiKatakana)};
+    TEST(ResultsMatch("とうきょうと", rules), ());
+    TEST(ResultsMatch("トウキョウト", rules), ());
+  }
+}
 }  // namespace
 }  // namespace search

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		3D928F671D50F9FE001670E0 /* data_source_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D928F651D50F9FE001670E0 /* data_source_helpers.cpp */; };
 		3D928F681D50F9FE001670E0 /* data_source_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D928F661D50F9FE001670E0 /* data_source_helpers.hpp */; };
 		40009062201F5CB000963E18 /* cell_value_pair.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4000905D201F5CAF00963E18 /* cell_value_pair.hpp */; };
+		4043C0B924ACBA3300545FD8 /* transliteration_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4043C0B724ACBA3200545FD8 /* transliteration_loader.cpp */; };
+		4043C0BA24ACBA3300545FD8 /* transliteration_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4043C0B824ACBA3300545FD8 /* transliteration_loader.hpp */; };
 		40662D32236059BF006A124D /* tree_node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40662D2F236059BF006A124D /* tree_node.hpp */; };
 		4067554C242BB04800EB8F8B /* read_features_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4067554B242BB04800EB8F8B /* read_features_tests.cpp */; };
 		406970A221AEF2F20024DDB2 /* brands_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 406970A121AEF2F10024DDB2 /* brands_tests.cpp */; };
@@ -76,9 +78,9 @@
 		409EE3E4237E9AA700EA31A4 /* postcodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 409EE3E2237E9AA700EA31A4 /* postcodes.cpp */; };
 		40BC58CA237EACDF006B2C4E /* postcodes_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */; };
 		40C3C091205BF9F400CED188 /* bounds.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C3C090205BF9F400CED188 /* bounds.hpp */; };
+		40D62CEF23F2E8BE009A20F5 /* dat_section_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40D62CEE23F2E8BE009A20F5 /* dat_section_header.hpp */; };
 		40DB152D23F2AC9400E49602 /* meta_idx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40DB152B23F2AC9400E49602 /* meta_idx.cpp */; };
 		40DB152E23F2AC9400E49602 /* meta_idx.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40DB152C23F2AC9400E49602 /* meta_idx.hpp */; };
-		40D62CEF23F2E8BE009A20F5 /* dat_section_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40D62CEE23F2E8BE009A20F5 /* dat_section_header.hpp */; };
 		40DF582D2174979200E4E0FC /* classificator_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40DF582C2174979200E4E0FC /* classificator_tests.cpp */; };
 		456B3FB41EDEEB65009B3D1F /* scales_patch.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */; };
 		456E1B181F90E5B7009C32E1 /* cities_boundaries_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */; };
@@ -294,6 +296,8 @@
 		3D928F651D50F9FE001670E0 /* data_source_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = data_source_helpers.cpp; sourceTree = "<group>"; };
 		3D928F661D50F9FE001670E0 /* data_source_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = data_source_helpers.hpp; sourceTree = "<group>"; };
 		4000905D201F5CAF00963E18 /* cell_value_pair.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cell_value_pair.hpp; sourceTree = "<group>"; };
+		4043C0B724ACBA3200545FD8 /* transliteration_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transliteration_loader.cpp; sourceTree = "<group>"; };
+		4043C0B824ACBA3300545FD8 /* transliteration_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transliteration_loader.hpp; sourceTree = "<group>"; };
 		4052928E21496D2B00D821F1 /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = categories_cuisines.txt; path = ../../data/categories_cuisines.txt; sourceTree = "<group>"; };
 		40662D2F236059BF006A124D /* tree_node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = tree_node.hpp; path = complex/tree_node.hpp; sourceTree = "<group>"; };
 		4067554B242BB04800EB8F8B /* read_features_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = read_features_tests.cpp; sourceTree = "<group>"; };
@@ -306,9 +310,9 @@
 		409EE3E2237E9AA700EA31A4 /* postcodes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = postcodes.cpp; sourceTree = "<group>"; };
 		40BC58C9237EACDF006B2C4E /* postcodes_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = postcodes_tests.cpp; sourceTree = "<group>"; };
 		40C3C090205BF9F400CED188 /* bounds.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bounds.hpp; sourceTree = "<group>"; };
+		40D62CEE23F2E8BE009A20F5 /* dat_section_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dat_section_header.hpp; sourceTree = "<group>"; };
 		40DB152B23F2AC9400E49602 /* meta_idx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = meta_idx.cpp; sourceTree = "<group>"; };
 		40DB152C23F2AC9400E49602 /* meta_idx.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = meta_idx.hpp; sourceTree = "<group>"; };
-		40D62CEE23F2E8BE009A20F5 /* dat_section_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dat_section_header.hpp; sourceTree = "<group>"; };
 		40DF582C2174979200E4E0FC /* classificator_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = classificator_tests.cpp; sourceTree = "<group>"; };
 		456B3FB31EDEEB65009B3D1F /* scales_patch.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scales_patch.hpp; sourceTree = "<group>"; };
 		456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cities_boundaries_serdes.hpp; sourceTree = "<group>"; };
@@ -646,6 +650,8 @@
 		6753409C1A3F53CB00A0A8C3 /* indexer */ = {
 			isa = PBXGroup;
 			children = (
+				4043C0B724ACBA3200545FD8 /* transliteration_loader.cpp */,
+				4043C0B824ACBA3300545FD8 /* transliteration_loader.hpp */,
 				40DB152B23F2AC9400E49602 /* meta_idx.cpp */,
 				40DB152C23F2AC9400E49602 /* meta_idx.hpp */,
 				40D62CEE23F2E8BE009A20F5 /* dat_section_header.hpp */,
@@ -819,6 +825,7 @@
 				6726C1D21A49DAAC005EEA39 /* feature_meta.hpp in Headers */,
 				347F337F1C454242009758CC /* trie_builder.hpp in Headers */,
 				34664CF71D49FEC1003D7096 /* centers_table.hpp in Headers */,
+				4043C0BA24ACBA3300545FD8 /* transliteration_loader.hpp in Headers */,
 				6753414C1A3F540F00A0A8C3 /* tree_structure.hpp in Headers */,
 				F6DF5F311CD0FD9A00A87154 /* categories_index.hpp in Headers */,
 				40662D32236059BF006A124D /* tree_node.hpp in Headers */,
@@ -1057,6 +1064,7 @@
 				3D452AFC1EE6D9F5009EAB9B /* centers_table_test.cpp in Sources */,
 				34664CF31D49FEC1003D7096 /* altitude_loader.cpp in Sources */,
 				6726C1D11A49DAAC005EEA39 /* feature_meta.cpp in Sources */,
+				4043C0B924ACBA3300545FD8 /* transliteration_loader.cpp in Sources */,
 				6753411C1A3F540F00A0A8C3 /* shared_load_info.cpp in Sources */,
 				67BC92F41D21476500A4A378 /* string_slice.cpp in Sources */,
 				BBB7060F23E46E0100A7F29A /* isolines_info.cpp in Sources */,


### PR DESCRIPTION
В японии две слоговых азбуки, которые почти соотвествуют друг другу (но имеют разное написание и соответственно разные коды в юникод):
https://ru.wikipedia.org/wiki/%D0%9A%D0%B0%D1%82%D0%B0%D0%BA%D0%B0%D0%BD%D0%B0
https://ru.wikipedia.org/wiki/%D0%A5%D0%B8%D1%80%D0%B0%D0%B3%D0%B0%D0%BD%D0%B0

Нужно уметь искать в случаях если данные в осме не хирагане, а запрос на катакане и наоборот. Предлагается всё приводить к в катакане, т.к. в ней есть несколько символов отсуствующих в хирагане (а для всего что есть в хирагане соотвествующий символ в катакане тоже есть) и т.к. она чаще употребляется в осм (по крайней мере названия городов и стран чаще на ней).

Есть несколько вариантов как это делать: использовать icu который мы используем для транслитерации stringutf8multilang или сделать свой транслитератор. Плюс icu в том что это готовое решение которое к нам встроено, минус в том что оно тяжелее и требует инииализации, чтения конфигов и т.п.

При предпроверке что у нас есть хирагана прежде чем транслитерировать замедлений в работе не наблюдаю, если проверку не делать, то наблюдаю (инициализация categories holder, в которой много вызовов NormalizeAndSimplify становится тяжелой частью поиска наравне с геокодером, ранкером и т.п.).