### PR TITLE
[ios] Fix ios build after StringUtf8Multilang::Lang changes.

### DIFF
--- a/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.mm
+++ b/iphone/Maps/UI/Editor/AdditionalNames/MWMEditorAdditionalNamesTableViewController.mm
@@ -66,8 +66,8 @@ additionalSkipLanguageCodes:(std::vector<NSInteger>)additionalSkipLanguageCodes
   MWMTableViewCell * cell = [tableView dequeueReusableCellWithIdentifier:@"ListCellIdentifier"];
   NSInteger const index = indexPath.row;
   StringUtf8Multilang::Lang const & language = m_languages[index];
-  cell.textLabel.text = @(language.m_name);
-  cell.detailTextLabel.text = @(language.m_code);
+  cell.textLabel.text = @(language.m_name.c_str());
+  cell.detailTextLabel.text = @(language.m_code.c_str());
 
   int8_t const languageIndex = StringUtf8Multilang::GetLangIndex(language.m_code);
   cell.accessoryType = UITableViewCellAccessoryNone;


### PR DESCRIPTION
в структуре char* стал string, а в коде ios не поменяла