### PR TITLE
[categories][search][strings] Fix simplified Chinese wine shop translation.

### DIFF
--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -2332,7 +2332,7 @@
 	<string name="type.shop.tyres">轮胎店</string>
 	<string name="type.shop.variety_store">杂货店</string>
 	<string name="type.shop.video">商店</string>
-	<string name="type.shop.wine">酒店</string>
+	<string name="type.shop.wine">贩酒处</string>
 	<string name="type.sport.athletics">田径</string>
 	<string name="type.sport.basketball">篮球</string>
 	<string name="type.sport.equestrian">马术运动</string>

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -7229,7 +7229,7 @@ th:ร้านขายไวน์
 tr:Caviste
 uk:Винна крамниця
 vi:Rượu|Cửa hàng rượu
-zh-Hans:酒店
+zh-Hans:贩酒处
 zh-Hant:販酒處
 el:Οινοπωλείο
 sk:Vinotéka

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -259,8 +259,8 @@ th:โรงแรม
 tr:Otel
 uk:Готель
 vi:Khách sạn
-zh-Hans:旅店
-zh-Hant:飯店
+zh-Hans:旅店|酒店
+zh-Hant:飯店|酒店
 el:Ξενοδοχείο
 he:מלון
 sk:Hotel
@@ -4869,7 +4869,7 @@ th:โมเทล
 tr:motel
 uk:мотель
 zh-Hans:2宾馆|汽车旅馆|旅店
-zh-Hant:1飯店|1汽車旅館|旅館|住宿|賓館|酒店|招待所
+zh-Hant:1飯店|1汽車旅館|旅館|住宿|賓館|招待所
 el:μοτέλ
 sk:ubytovňa|motel
 sw:Hoteli
@@ -4902,7 +4902,7 @@ tr:Misafir evi|pansiyon
 uk:Гостинний дім|готель|хостел|постояльний двір
 vi:Nhà khách
 zh-Hans:1招待所์|์旅馆์|์旅社|旅店
-zh-Hant:1賓館|旅館|飯店|酒店|旅舍|住宿|招待所
+zh-Hant:1賓館|旅館|飯店|旅舍|住宿|招待所
 el:Ξενώνας|ξενοδοχείο|ξενώνας
 sk:Penzión|hostel|ubytovňa
 sw:Gesti

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -17643,7 +17643,7 @@
     tr = Caviste
     uk = Винна крамниця
     vi = Rượu
-    zh-Hans = 酒店
+    zh-Hans = 贩酒处
     zh-Hant = 販酒處
     el = Οινοπωλείο
     sk = Vinotéka

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -4886,7 +4886,7 @@
 
 "type.shop.video" = "商店";
 
-"type.shop.wine" = "酒店";
+"type.shop.wine" = "贩酒处";
 
 "type.sponsored" = "sponsored";
 


### PR DESCRIPTION
酒店, которое использовалось раньше, чаще употребляется в значении "отель", а мы при вводе 酒店 показывали алкомаркеты.

酒店 судя по всему употребляется в значении отель как в traditional так и в simplified, в частности на всех наших букинговских кнопках, вотс нью, пушах и т.п. как для zh-Hans так и для zh-Hant используется 酒店.