### PR TITLE
[drape] [Vulkan] [Android] Update whole palette texture at once

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -196,18 +196,16 @@ bool Framework::CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi
   // Vulkan is supported only since Android 8.0, because some Android devices with Android 7.x
   // have fatal driver issue, which can lead to process termination and whole OS destabilization.
   int constexpr kMinSdkVersionForVulkan = 26;
-  // Ban Vulkan temporarily for Android 10.0 because of unfixed rendering artifacts.
-  int constexpr kMaxSdkVersionForVulkan = 28;
   int const sdkVersion = GetAndroidSdkVersion();
   auto const vulkanForbidden = sdkVersion < kMinSdkVersionForVulkan ||
-                               sdkVersion > kMaxSdkVersionForVulkan ||
                                dp::SupportManager::Instance().IsVulkanForbidden();
   if (vulkanForbidden)
     LOG(LWARNING, ("Vulkan API is forbidden on this device."));
 
   if (m_work.LoadPreferredGraphicsAPI() == dp::ApiVersion::Vulkan && !vulkanForbidden)
   {
-    m_vulkanContextFactory = make_unique_dp<AndroidVulkanContextFactory>(appVersionCode);
+    m_vulkanContextFactory =
+        make_unique_dp<AndroidVulkanContextFactory>(appVersionCode, sdkVersion);
     if (!CastFactory(m_vulkanContextFactory)->IsVulkanSupported())
     {
       LOG(LWARNING, ("Vulkan API is not supported."));

--- a/android/jni/com/mapswithme/vulkan/android_vulkan_context_factory.hpp
+++ b/android/jni/com/mapswithme/vulkan/android_vulkan_context_factory.hpp
@@ -19,7 +19,7 @@ namespace android
 class AndroidVulkanContextFactory : public dp::GraphicsContextFactory
 {
 public:
-  explicit AndroidVulkanContextFactory(int appVersionCode);
+  explicit AndroidVulkanContextFactory(int appVersionCode, int sdkVersion);
   ~AndroidVulkanContextFactory();
 
   bool IsVulkanSupported() const;

--- a/drape/graphics_context.hpp
+++ b/drape/graphics_context.hpp
@@ -71,6 +71,7 @@ public:
   virtual ApiVersion GetApiVersion() const = 0;
   virtual std::string GetRendererName() const = 0;
   virtual std::string GetRendererVersion() const = 0;
+  virtual bool HasPartialTextureUpdates() const { return true; }
 
   virtual void DebugSynchronizeWithCPU() {}
   virtual void PushDebugLabel(std::string const & label) = 0;

--- a/drape/support_manager.hpp
+++ b/drape/support_manager.hpp
@@ -41,8 +41,12 @@ public:
   bool IsVulkanForbidden() const;
   bool IsVulkanForbidden(std::string const & deviceName,
                          Version apiVersion, Version driverVersion) const;
+  bool IsVulkanTexturePartialUpdateBuggy(int sdkVersion, std::string const & deviceName,
+                                         Version apiVersion, Version driverVersion) const;
 
 private:
+  struct Configuration;
+
   SupportManager() = default;
 
   std::string m_rendererName;

--- a/drape/texture_of_colors.hpp
+++ b/drape/texture_of_colors.hpp
@@ -49,6 +49,7 @@ private:
 
   TPalette m_palette;
   TPalette m_predefinedPalette;
+  buffer_vector<PendingColor, 16> m_nodes;
   buffer_vector<PendingColor, 16> m_pendingNodes;
   m2::PointU m_textureSize;
   m2::PointU m_cursor;

--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -53,12 +53,14 @@ VulkanBaseContext::VulkanBaseContext(VkInstance vulkanInstance, VkPhysicalDevice
                                      VkPhysicalDeviceProperties const & gpuProperties,
                                      VkDevice device, uint32_t renderingQueueFamilyIndex,
                                      ref_ptr<VulkanObjectManager> objectManager,
-                                     drape_ptr<VulkanPipeline> && pipeline)
+                                     drape_ptr<VulkanPipeline> && pipeline,
+                                     bool hasPartialTextureUpdates)
   : m_vulkanInstance(vulkanInstance)
   , m_gpu(gpu)
   , m_gpuProperties(gpuProperties)
   , m_device(device)
   , m_renderingQueueFamilyIndex(renderingQueueFamilyIndex)
+  , m_hasPartialTextureUpdates(hasPartialTextureUpdates)
   , m_objectManager(std::move(objectManager))
   , m_pipeline(std::move(pipeline))
   , m_presentAvailable(true)
@@ -100,6 +102,8 @@ std::string VulkanBaseContext::GetRendererVersion() const
      << VK_VERSION_PATCH(m_gpuProperties.driverVersion);
   return ss.str();
 }
+
+bool VulkanBaseContext::HasPartialTextureUpdates() const { return m_hasPartialTextureUpdates; }
 
 void VulkanBaseContext::Init(ApiVersion apiVersion)
 {

--- a/drape/vulkan/vulkan_base_context.hpp
+++ b/drape/vulkan/vulkan_base_context.hpp
@@ -31,10 +31,9 @@ class VulkanBaseContext : public dp::GraphicsContext
 {
 public:
   VulkanBaseContext(VkInstance vulkanInstance, VkPhysicalDevice gpu,
-                    VkPhysicalDeviceProperties const & gpuProperties,
-                    VkDevice device, uint32_t renderingQueueFamilyIndex,
-                    ref_ptr<VulkanObjectManager> objectManager,
-                    drape_ptr<VulkanPipeline> && pipeline);
+                    VkPhysicalDeviceProperties const & gpuProperties, VkDevice device,
+                    uint32_t renderingQueueFamilyIndex, ref_ptr<VulkanObjectManager> objectManager,
+                    drape_ptr<VulkanPipeline> && pipeline, bool hasPartialTextureUpdates);
   ~VulkanBaseContext() override;
 
   using ContextHandler = std::function<void(uint32_t inflightFrameIndex)>;
@@ -54,6 +53,7 @@ public:
   ApiVersion GetApiVersion() const override { return dp::ApiVersion::Vulkan; }
   std::string GetRendererName() const override;
   std::string GetRendererVersion() const override;
+  bool HasPartialTextureUpdates() const override;
 
   void DebugSynchronizeWithCPU() override {}
   void PushDebugLabel(std::string const & label) override {}
@@ -167,6 +167,7 @@ protected:
   VkPhysicalDeviceProperties const m_gpuProperties;
   VkDevice const m_device;
   uint32_t const m_renderingQueueFamilyIndex;
+  bool const m_hasPartialTextureUpdates;
 
   VkQueue m_queue = {};
   VkCommandPool m_commandPool = {};

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -80,7 +80,6 @@ set(
     GL/user_mark.vsh.glsl
     GL/user_mark_billboard.vsh.glsl
 )
-set_source_files_properties(${shader_files} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 add_custom_command(
   WORKING_DIRECTORY
@@ -104,6 +103,8 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/gl_shaders.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl_shaders.hpp
 )
+
+source_group("Shader Index" FILES GL/shader_index.txt)
 
 include_directories(
   ${OMIM_ROOT}/3party/glm
@@ -129,6 +130,7 @@ target_sources(
     program_params.hpp
     program_pool.hpp
     programs.hpp
+    GL/shader_index.txt
     vulkan_program_params.cpp
     vulkan_program_params.hpp
     vulkan_program_pool.cpp


### PR DESCRIPTION
На Android 10 и Mali-G76 обновление региона текстуры приводит к тому, что все старые данные текстуры затираются. Затираются прозрачным чёрным цветом, что в результате даёт такие артефакты, как невидимые глифы и др.
Пример draw call-а наименования улицы, который выглядит как состоящий из одной только (белой) обводки:
![palette](https://user-images.githubusercontent.com/896175/86598777-10343a00-bfb7-11ea-8964-52d8789d94b0.png)
здесь в текстуре палитры сине-зелёная точка (поставлена мной) над зелёной четвёркой пикселей указывает на текстурные координаты (0.9219, 0.3594). Как видно первая часть текстуры палитры полностью пустая и заполнена прозрачным чёрным цветом (или очищена).
В [шейдер](https://github.com/mapsme/omim/blob/9556ebaa46532643b0970dfba9604a40649fbbd9/shaders/GL/text_outlined.vsh.glsl) для этого draw call-а передаются текстурные координаты основного цвета текста (0.92188, 0.35938), которые указывают на ту же четвёрку пикселей 2x2 в палитре (на её центр), что и координаты, приведённые выше:
![uniforms](https://user-images.githubusercontent.com/896175/86599414-10810500-bfb8-11ea-832a-b6c35243f71d.png)
По этим координатам находится значение (0, 0, 0, 0), что является ошибочным.

Workaround состоит в том, что для проблемных платформ хранятся все регионы цветов, когда-либо записанные в палитру. На таких платформах вместо дополнения текстуры палитры регионами с новыми цветами производится полная перезапись прямоугольного региона текстуры палитры, охватывающего все новые и уже инициализированные пиксели (+добивается последняя строка прозрачными чёрными пикселями, чтобы логика сформировала единственный `vkCmdCopyBufferToImage`).
На данный момент есть высокая степень уверенности, что это баг, т.к. проверка всех переходов состояний текстур (`VkImageView`) говорит о том, что все нужные барьеры в коде присутствуют и выполняются. Debug validation layers также не сообщают ни о каких неверных состояниях ресурсов.

https://jira.mail.ru/browse/MAPSME-12632