### PR TITLE
[transit] Versioning for transit section.

### DIFF
--- a/routing/transit_graph_loader.cpp
+++ b/routing/transit_graph_loader.cpp
@@ -6,6 +6,7 @@
 #include "transit/transit_graph_data.hpp"
 #include "transit/transit_serdes.hpp"
 #include "transit/transit_types.hpp"
+#include "transit/transit_version.hpp"
 
 #include "indexer/data_source.hpp"
 #include "indexer/mwm_set.hpp"

--- a/transit/CMakeLists.txt
+++ b/transit/CMakeLists.txt
@@ -17,6 +17,8 @@ set(
   transit_serdes.hpp
   transit_types.cpp
   transit_types.hpp
+  transit_version.cpp
+  transit_version.hpp
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC})

--- a/transit/experimental/transit_data.cpp
+++ b/transit/experimental/transit_data.cpp
@@ -2,6 +2,7 @@
 
 #include "transit/transit_entities.hpp"
 #include "transit/transit_serdes.hpp"
+#include "transit/transit_version.hpp"
 
 #include "base/assert.hpp"
 #include "base/file_name_utils.hpp"
@@ -437,7 +438,7 @@ void TransitData::Serialize(Writer & writer)
   routing::transit::Serializer<Writer> serializer(writer);
   routing::transit::FixedSizeSerializer<Writer> fixedSizeSerializer(writer);
   m_header = TransitHeader();
-  m_header.m_version = kExperimentalTransitVersion;
+  m_header.m_version = static_cast<uint16_t>(TransitVersion::AllPublicTransport);
   fixedSizeSerializer(m_header);
 
   m_header.m_stopsOffset = base::checked_cast<uint32_t>(writer.Pos() - startOffset);

--- a/transit/experimental/transit_types_experimental.hpp
+++ b/transit/experimental/transit_types_experimental.hpp
@@ -40,8 +40,6 @@ namespace transit
 {
 namespace experimental
 {
-constexpr uint16_t kExperimentalTransitVersion = 2;
-
 #define DECLARE_TRANSIT_TYPES_FRIENDS                 \
   template <class Sink>                               \
   friend class routing::transit::Serializer;          \

--- a/transit/transit_tests/transit_test.cpp
+++ b/transit/transit_tests/transit_test.cpp
@@ -2,6 +2,7 @@
 
 #include "transit/transit_serdes.hpp"
 #include "transit/transit_types.hpp"
+#include "transit/transit_version.hpp"
 
 #include "coding/reader.hpp"
 #include "coding/writer.hpp"
@@ -18,6 +19,8 @@ namespace routing
 {
 namespace transit
 {
+auto constexpr kTransitHeaderVersion = static_cast<uint16_t>(::transit::TransitVersion::OnlySubway);
+
 template<class S, class D, class Obj>
 void TestCommonSerialization(Obj const & obj)
 {
@@ -51,10 +54,10 @@ void TestSerialization(Obj const & obj)
 
 UNIT_TEST(Transit_HeaderRewriting)
 {
-  TransitHeader const bigHeader(1 /* version */, 500 /* stopsOffset */, 1000 /* gatesOffset */,
-                                200000 /* edgesOffset */, 300000 /* transfersOffset */,
-                                400000 /* linesOffset */, 5000000 /* shapesOffset */,
-                                6000000 /* networksOffset */, 700000000 /* endOffset */);
+  TransitHeader const bigHeader(
+      kTransitHeaderVersion /* version */, 500 /* stopsOffset */, 1000 /* gatesOffset */,
+      200000 /* edgesOffset */, 300000 /* transfersOffset */, 400000 /* linesOffset */,
+      5000000 /* shapesOffset */, 6000000 /* networksOffset */, 700000000 /* endOffset */);
 
   TransitHeader header;
   vector<uint8_t> buffer;
@@ -103,9 +106,10 @@ UNIT_TEST(Transit_HeaderSerialization)
     TEST(header.IsValid(), (header));
   }
   {
-    TransitHeader header(1 /* version */, 500 /* stopsOffset */, 1000 /* gatesOffset */,
-                         2000 /* edgesOffset */, 3000 /* transfersOffset */, 4000 /* linesOffset */,
-                         5000 /* shapesOffset */, 6000 /* networksOffset */, 7000 /* endOffset */);
+    TransitHeader header(kTransitHeaderVersion /* version */, 500 /* stopsOffset */,
+                         1000 /* gatesOffset */, 2000 /* edgesOffset */, 3000 /* transfersOffset */,
+                         4000 /* linesOffset */, 5000 /* shapesOffset */, 6000 /* networksOffset */,
+                         7000 /* endOffset */);
     TestSerialization(header);
     TEST(header.IsValid(), (header));
   }
@@ -118,17 +122,17 @@ UNIT_TEST(Transit_TransitHeaderValidity)
     TEST(header.IsValid(), (header));
   }
   {
-    TransitHeader const header(1 /* version */, 40 /* stopsOffset */, 44 /* gatesOffset */,
-                               48 /* edgesOffset */, 52 /* transfersOffset */,
-                               56 /* linesOffset */, 60 /* shapesOffset */,
-                               64 /* networksOffset */, 68 /* endOffset */);
+    TransitHeader const header(kTransitHeaderVersion /* version */, 40 /* stopsOffset */,
+                               44 /* gatesOffset */, 48 /* edgesOffset */, 52 /* transfersOffset */,
+                               56 /* linesOffset */, 60 /* shapesOffset */, 64 /* networksOffset */,
+                               68 /* endOffset */);
     TEST(header.IsValid(), (header));
   }
   {
-    TransitHeader const header(1 /* version */, 44 /* stopsOffset */, 40 /* gatesOffset */,
-                               48 /* edgesOffset */, 52 /* transfersOffset */,
-                               56 /* linesOffset */, 60 /* shapesOffset */,
-                               64 /* networksOffset */, 68 /* endOffset */);
+    TransitHeader const header(kTransitHeaderVersion /* version */, 44 /* stopsOffset */,
+                               40 /* gatesOffset */, 48 /* edgesOffset */, 52 /* transfersOffset */,
+                               56 /* linesOffset */, 60 /* shapesOffset */, 64 /* networksOffset */,
+                               68 /* endOffset */);
     TEST(!header.IsValid(), (header));
   }
 }

--- a/transit/transit_types.cpp
+++ b/transit/transit_types.cpp
@@ -1,6 +1,7 @@
 #include "transit/transit_types.hpp"
 
 #include "transit/transit_serdes.hpp"
+#include "transit/transit_version.hpp"
 
 #include "base/string_utils.hpp"
 
@@ -32,7 +33,7 @@ TransitHeader::TransitHeader(uint16_t version, uint32_t stopsOffset, uint32_t ga
 
 void TransitHeader::Reset()
 {
-  m_version = 0;
+  m_version = static_cast<uint16_t>(::transit::TransitVersion::OnlySubway);
   m_reserve = 0;
   m_stopsOffset = 0;
   m_gatesOffset = 0;

--- a/transit/transit_version.cpp
+++ b/transit/transit_version.cpp
@@ -1,0 +1,29 @@
+#include "transit/transit_version.hpp"
+
+#include "base/logging.hpp"
+
+#include <cstdint>
+#include <exception>
+#include <limits>
+
+namespace transit
+{
+TransitVersion GetVersion(Reader & reader)
+{
+  try
+  {
+    NonOwningReaderSource src(reader);
+    uint16_t headerVersion = std::numeric_limits<uint16_t>::max();
+    ReadPrimitiveFromSource(src, headerVersion);
+    CHECK_LESS(headerVersion, static_cast<uint16_t>(TransitVersion::Counter),
+               ("Invalid transit header version."));
+
+    return static_cast<TransitVersion>(headerVersion);
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LERROR, ("Error reading header version from transit mwm section.", ex.what()));
+    throw;
+  }
+}
+}  // namespace transit

--- a/transit/transit_version.hpp
+++ b/transit/transit_version.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "coding/reader.hpp"
+
+namespace transit
+{
+enum class TransitVersion
+{
+  OnlySubway = 0,
+  AllPublicTransport = 1,
+  Counter = 2
+};
+
+// Reads version from header in the transit mwm section and returns it.
+TransitVersion GetVersion(Reader & reader);
+}  // namespace transit

--- a/transit/transit_version.hpp
+++ b/transit/transit_version.hpp
@@ -2,6 +2,10 @@
 
 #include "coding/reader.hpp"
 
+#include "base/assert.hpp"
+
+#include <string>
+
 namespace transit
 {
 enum class TransitVersion
@@ -13,4 +17,15 @@ enum class TransitVersion
 
 // Reads version from header in the transit mwm section and returns it.
 TransitVersion GetVersion(Reader & reader);
+
+inline std::string DebugPrint(TransitVersion version)
+{
+  switch (version)
+  {
+  case TransitVersion::OnlySubway: return "OnlySubway";
+  case TransitVersion::AllPublicTransport: return "AllPublicTransport";
+  case TransitVersion::Counter: return "Counter";
+  }
+  UNREACHABLE();
+}
 }  // namespace transit


### PR DESCRIPTION
- Добавлена функция, которая читает поле версии транзитного хедера и возвращает версию. 
- В тестах старой транизтной версии и в ее продовой записи расходился номер: в mwm мы пишем 0, в тестах почему-то 1. Это исправлено.