### PR TITLE
[docs] Adding problem solving to building pybindings documentation.

### DIFF
--- a/docs/building_pybindings.txt
+++ b/docs/building_pybindings.txt
@@ -95,11 +95,21 @@ Run tests:
 
 Problems and solutions
 ----------------------
-1. Building binding on MacOS Catalina 10.15.5.
-   If you try to build one of the bindings on MacOS Catalina with Apple clang version 11.0.3 you'll see the error that the flag fcoalesce-templates is not supported. The workaround is to remove this flag from 3party/boost/tools/build/src/tools/darwin.jam and 3party/boost/tools/build/src/tools/darwin.py
+1. Building bindings on MacOS Catalina 10.15.5.
+   If you try to build one of the bindings on MacOS Catalina with Apple clang
+   version 11.0.3 you'll see the error that the flag fcoalesce-templates is not
+   supported. The workaround is to remove this flag from
+   3party/boost/tools/build/src/tools/darwin.jam and
+   3party/boost/tools/build/src/tools/darwin.py
 
-2. If there is a build errors while Boost.Python building the C++ headers are not seen. For example,  fatal error: 'cstddef' file not found. Some flags should be added while building bindings. For example, instead launching:
-  $ python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release
+2. You may get build errors that standard C++ headers can't be found while
+   building of Boost.Python. For example, fatal error: 'cstddef' file not found.
+   In that case the following flags should be set to correct values:
+   MACOSX_DEPLOYMENT_TARGET, CC, CXX, CFLAGS. For example, instead of launching:
 
-should be launched:
-  $ MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release
+    $ python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release
+
+   should be launched:
+
+    $ MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ CFLAGS='-stdlib=libc++'
+      python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release

--- a/docs/building_pybindings.txt
+++ b/docs/building_pybindings.txt
@@ -92,3 +92,14 @@ Run tests:
   MWM_RESOURCES_DIR=data \
   MWM_WRITABLE_DIR=data \
   search/pysearch/run_search_engine.py
+
+Problems and solutions
+----------------------
+1. Building binding on MacOS Catalina 10.15.5.
+   If you try to build one of the bindings on MacOS Catalina with Apple clang version 11.0.3 you'll see the error that the flag fcoalesce-templates is not supported. The workaround is to remove this flag from 3party/boost/tools/build/src/tools/darwin.jam and 3party/boost/tools/build/src/tools/darwin.py
+
+2. If there is a build errors while Boost.Python building the C++ headers are not seen. For example,  fatal error: 'cstddef' file not found. Some flags should be added while building bindings. For example, instead launching:
+  $ python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release
+
+should be launched:
+  $ MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' python3.7 kml/pykmlib/setup.py build --omim-builddir=kml/pykmlib/cmake-build-release


### PR DESCRIPTION
Мы с @tatiana-yan вчера потратили некоторое время на сборку pybindings на MacOS 10.15.5 (Catalina) и решили пару проблем при сборке. Чтоб эти решения не потерялись, я добавил их в документацию по сборке bybindings.

@tatiana-yan @vicpopov PTAL