### PR TITLE
[search] Use alt_name/old_name.

### DIFF
--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -66,6 +66,12 @@ TestFeature::TestFeature(m2::PointD const & center, string const & name, string 
   Init();
 }
 
+TestFeature::TestFeature(m2::PointD const & center, StringUtf8Multilang const & name)
+  : m_id(GenUniqueId()), m_center(center), m_type(Type::Point), m_names(name)
+{
+  Init();
+}
+
 TestFeature::TestFeature(vector<m2::PointD> const & boundary, string const & name,
                          string const & lang)
   : m_id(GenUniqueId()), m_boundary(boundary), m_type(Type::Area)
@@ -179,6 +185,11 @@ string TestState::ToDebugString() const
 TestCity::TestCity(m2::PointD const & center, string const & name, string const & lang,
                    uint8_t rank)
   : TestFeature(center, name, lang), m_rank(rank)
+{
+}
+
+TestCity::TestCity(m2::PointD const & center, StringUtf8Multilang const & name, uint8_t rank)
+  : TestFeature(center, name), m_rank(rank)
 {
 }
 

--- a/generator/generator_tests_support/test_feature.hpp
+++ b/generator/generator_tests_support/test_feature.hpp
@@ -66,6 +66,7 @@ protected:
   TestFeature(std::string const & name, std::string const & lang);
   TestFeature(StringUtf8Multilang const & name);
   TestFeature(m2::PointD const & center, std::string const & name, std::string const & lang);
+  TestFeature(m2::PointD const & center, StringUtf8Multilang const & name);
   TestFeature(std::vector<m2::PointD> const & boundary, std::string const & name,
               std::string const & lang);
 
@@ -106,6 +107,7 @@ class TestCity : public TestFeature
 public:
   TestCity(m2::PointD const & center, std::string const & name, std::string const & lang,
            uint8_t rank);
+  TestCity(m2::PointD const & center, StringUtf8Multilang const & name, uint8_t rank);
   TestCity(std::vector<m2::PointD> const & boundary, std::string const & name,
            std::string const & lang, uint8_t rank);
 

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -77,6 +77,7 @@ enum LanguageTier
   LANGUAGE_TIER_INPUT,
   LANGUAGE_TIER_EN_AND_INTERNATIONAL,
   LANGUAGE_TIER_DEFAULT,
+  LANGUAGE_TIER_ALT_AND_OLD,
   LANGUAGE_TIER_COUNT
 };
 
@@ -177,6 +178,9 @@ Processor::Processor(DataSource const & dataSource, CategoriesHolder const & cat
       {StringUtf8Multilang::kInternationalCode, StringUtf8Multilang::kEnglishCode});
   m_keywordsScorer.SetLanguages(LanguageTier::LANGUAGE_TIER_DEFAULT,
                                 {StringUtf8Multilang::kDefaultCode});
+  m_keywordsScorer.SetLanguages(
+      LanguageTier::LANGUAGE_TIER_ALT_AND_OLD,
+      {StringUtf8Multilang::kAltNameCode, StringUtf8Multilang::kOldNameCode});
 
   SetPreferredLocale("en");
 }

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -188,6 +188,7 @@ string DebugPrint(RankingInfo const & info)
      << "]";
   os << ", m_nameScore:" << DebugPrint(info.m_nameScore);
   os << ", m_errorsMade:" << DebugPrint(info.m_errorsMade);
+  os << ", m_isAltOrOldName: " << info.m_isAltOrOldName;
   os << ", m_numTokens:" << info.m_numTokens;
   os << ", m_matchedFraction:" << info.m_matchedFraction;
   os << ", m_type:" << DebugPrint(info.m_type);

--- a/search/ranking_info.hpp
+++ b/search/ranking_info.hpp
@@ -68,6 +68,9 @@ struct RankingInfo
   // Number of misprints.
   ErrorsMade m_errorsMade;
 
+  // alt_name or old_name is used.
+  bool m_isAltOrOldName = false;
+
   // Query tokens number.
   size_t m_numTokens = 0;
 

--- a/search/ranking_utils.cpp
+++ b/search/ranking_utils.cpp
@@ -139,7 +139,8 @@ string DebugPrint(NameScore score)
 string DebugPrint(NameScores scores)
 {
   ostringstream os;
-  os << "[ " << DebugPrint(scores.m_nameScore) << ", " << DebugPrint(scores.m_errorsMade) << " ]";
+  os << "[ " << DebugPrint(scores.m_nameScore) << ", " << DebugPrint(scores.m_errorsMade) << ", "
+     << scores.m_isAltOrOldName << " ]";
   return os.str();
 }
 }  // namespace search

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -2978,5 +2978,25 @@ UNIT_CLASS_TEST(ProcessorTest, SimilarLanguage)
   // ko is in language list if query locale is ko.
   testLanguage("ko", "지유가오카", true);
 }
+
+UNIT_CLASS_TEST(ProcessorTest, AltAndOldName)
+{
+  string const countryName = "Wonderland";
+
+  TestMultilingualPOI poi(m2::PointD(0.0, 0.0), "default",
+                          {{"en", "english"}, {"alt_name", "alternative"}, {"old_name", "old"}});
+
+  auto wonderlandId =
+      BuildCountry(countryName, [&](TestMwmBuilder & builder) { builder.Add(poi); });
+
+  SetViewport(m2::RectD(-1, -1, 1, 1));
+  {
+    Rules rules{ExactMatch(wonderlandId, poi)};
+    TEST(ResultsMatch("default", rules), ());
+    TEST(ResultsMatch("english", rules), ());
+    TEST(ResultsMatch("alternative", rules), ());
+    TEST(ResultsMatch("old", rules), ());
+  }
+}
 }  // namespace
 }  // namespace search

--- a/search/search_tests/ranking_tests.cpp
+++ b/search/search_tests/ranking_tests.cpp
@@ -40,7 +40,7 @@ NameScores GetScore(string const & name, string const & query, TokenRange const 
     params.InitNoPrefix(tokens.begin(), tokens.end());
   }
 
-  return GetNameScores(name, TokenSlice(params, tokenRange));
+  return GetNameScores(name, StringUtf8Multilang::kDefaultCode, TokenSlice(params, tokenRange));
 }
 
 UNIT_TEST(NameTest_Smoke)
@@ -49,7 +49,8 @@ UNIT_TEST(NameTest_Smoke)
                        NameScore nameScore, size_t errorsMade) {
     TEST_EQUAL(
         GetScore(name, query, tokenRange),
-        NameScores(nameScore, nameScore == NAME_SCORE_ZERO ? ErrorsMade() : ErrorsMade(errorsMade)),
+        NameScores(nameScore, nameScore == NAME_SCORE_ZERO ? ErrorsMade() : ErrorsMade(errorsMade),
+                   false /* isAltOrOldNAme */),
         (name, query, tokenRange));
   };
 


### PR DESCRIPTION
Сделала использование в поиске и протаскивание в ranking_info. Осталось сделать какое-то понижение в ранжировании для alt_name и old_name . Варианты: уменьшать компоненты ранжирования полученные из имени на коэффициент или прибавлять отрицательный коэффициент).

Отдельный реквест по другому отображению результатов: https://github.com/mapsme/omim/pull/13389 Пока остался открытым вопрос как отображать если старое имя было использовано не для конечного результата, а для города/района/улицы. Т.к. мы вообще не показываем пользователю какие токены и на что заматчились, полное совпадение/не полное и т.п., то возможно никак.