### PR TITLE
[transit] If edge weight is zero, calculate it based on the distance.

### DIFF
--- a/transit/world_feed/feed_helpers.cpp
+++ b/transit/world_feed/feed_helpers.cpp
@@ -117,7 +117,7 @@ std::pair<size_t, bool> PrepareNearestPointOnTrack(m2::PointD const & point, siz
   // We find the most fitting projection of the stop to the polyline. For two different projections
   // with approximately equal distances to the stop the most preferable is the one that is closer
   // to the beginning of the polyline segment.
-  auto const proj =
+  auto proj =
       std::min_element(projections.begin(), projections.end(),
                        [](ProjectionData const & p1, ProjectionData const & p2) {
                          if (CloserToStartAndOnSimilarDistToLine(p1, p2))
@@ -131,6 +131,16 @@ std::pair<size_t, bool> PrepareNearestPointOnTrack(m2::PointD const & point, siz
 
                          return p1.m_distFromPoint < p2.m_distFromPoint;
                        });
+
+  // This case is possible not only for the first stop on the shape. We try to resolve situation
+  // when two stops are projected to the same point on the shape.
+  if (proj->m_indexOnShape == startIndex)
+  {
+    proj = std::min_element(projections.begin(), projections.end(),
+                         [](ProjectionData const & p1, ProjectionData const & p2) {
+                           return p1.m_distFromPoint < p2.m_distFromPoint;
+                         });
+  }
 
   if (proj->m_needsInsertion)
     polyline.insert(polyline.begin() + proj->m_indexOnShape, proj->m_proj);

--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -327,6 +327,8 @@ private:
   void FillTransfers();
   // Fills gates based on GTFS stops.
   void FillGates();
+  // Recalculates 0-weights of edges based on the shape length.
+  bool UpdateEdgeWeights();
 
   bool ProjectStopsToShape(TransitId shapeId, std::vector<m2::PointD> & shape,
                            IdList const & stopIds,


### PR DESCRIPTION
Ребро определяется по двум остановкам и линии, к которой они относятся. Для них в GTFS-файле stop_times.txt указываются arrival_time и departure_time. Как разницу между отправлением от остановки 1 и прибытием на остановку 2 мы рассчитываем вес ребра в секундах. 

Есть нюанс. В ряде случаев эти времена могут быть не заполнены, и мы получаем ребро с нулевым весом. PR делает следующее:
- Если времена не указаны, но заполнен shape_dist_traveled для обеих остановок, мы вычисляем время по нему (t = s / v_avg).
- Если не указан даже shape_dist_traveled (тогда появляются вопросы к авторам фида, но это другая история), мы сами его вычисляем по отрезку shape между двумя остановками.