### PR TITLE
[base] All kinds of exceptions catcher.

### DIFF
--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(
   condition_test.cpp
   containers_test.cpp
   control_flow_tests.cpp
+  exception_tests.cpp
   fifo_cache_test.cpp
   file_name_utils_tests.cpp
   geo_object_id_tests.cpp

--- a/base/base_tests/exception_tests.cpp
+++ b/base/base_tests/exception_tests.cpp
@@ -1,0 +1,47 @@
+#include "testing/testing.hpp"
+
+#include "base/exception.hpp"
+
+#include <exception>
+
+namespace
+{
+int FuncDoesNotThrow() noexcept { return 1; }
+int FuncThrowsRootException() { throw RootException("RootException", "RootException"); }
+int FuncThrowsException() { throw std::exception(); }
+int FuncThrowsNumber() { throw 1; };
+
+int FuncDoesNotThrowArg(int) noexcept { return 1; }
+int FuncThrowsRootExceptionArg(int) { throw RootException("RootException", "RootException"); }
+int FuncThrowsExceptionArg(int) { throw std::exception(); }
+int FuncThrowsNumberArg(int) { throw 1; };
+
+UNIT_TEST(ExceptionCatcher_FunctionsWithoutArgs)
+{
+  ExceptionCatcher("ExceptionCatcher_Smoke", FuncDoesNotThrow);
+  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsRootException);
+  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsException);
+  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsNumber);
+}
+
+UNIT_TEST(ExceptionCatcher_Functions)
+{
+  ExceptionCatcher("ExceptionCatcher", FuncDoesNotThrowArg, 7);
+  ExceptionCatcher("ExceptionCatcher", FuncThrowsRootExceptionArg, 7);
+  ExceptionCatcher("ExceptionCatcher", FuncThrowsExceptionArg, 7);
+  ExceptionCatcher("ExceptionCatcher", FuncThrowsNumberArg, 7);
+}
+
+UNIT_TEST(ExceptionCatcher_Lambdas)
+{
+  ExceptionCatcher(
+      "ExceptionCatcher", [](int) { return 1; }, 7);
+  ExceptionCatcher(
+      "ExceptionCatcher", [](int) -> int { throw RootException("RootException", "RootException"); },
+      7);
+  ExceptionCatcher(
+      "ExceptionCatcher", [](int) -> int { throw std::exception(); }, 7);
+  ExceptionCatcher(
+      "ExceptionCatcher", [](int) -> int { throw 1; }, 7);
+}
+}  // namespace

--- a/base/base_tests/exception_tests.cpp
+++ b/base/base_tests/exception_tests.cpp
@@ -9,6 +9,7 @@ namespace
 int FuncDoesNotThrow() noexcept { return 1; }
 int FuncThrowsRootException() { throw RootException("RootException", "RootException"); }
 int FuncThrowsException() { throw std::exception(); }
+int FuncThrowsRuntimeError() { throw std::runtime_error("runtime_error"); }
 int FuncThrowsNumber() { throw 1; };
 
 int FuncDoesNotThrowArg(int) noexcept { return 1; }
@@ -18,30 +19,30 @@ int FuncThrowsNumberArg(int) { throw 1; };
 
 UNIT_TEST(ExceptionCatcher_FunctionsWithoutArgs)
 {
-  ExceptionCatcher("ExceptionCatcher_Smoke", FuncDoesNotThrow);
-  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsRootException);
-  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsException);
-  ExceptionCatcher("ExceptionCatcher_Smoke", FuncThrowsNumber);
+  ExceptionCatcher("Function without arg.", FuncDoesNotThrow);
+  ExceptionCatcher("Function without arg.", FuncThrowsRootException);
+  ExceptionCatcher("Function without arg.", FuncThrowsException);
+  ExceptionCatcher("Function without arg.", FuncThrowsRuntimeError);
+  ExceptionCatcher("Function without arg.", FuncThrowsNumber);
 }
 
 UNIT_TEST(ExceptionCatcher_Functions)
 {
-  ExceptionCatcher("ExceptionCatcher", FuncDoesNotThrowArg, 7);
-  ExceptionCatcher("ExceptionCatcher", FuncThrowsRootExceptionArg, 7);
-  ExceptionCatcher("ExceptionCatcher", FuncThrowsExceptionArg, 7);
-  ExceptionCatcher("ExceptionCatcher", FuncThrowsNumberArg, 7);
+  ExceptionCatcher("Function with arg.", FuncDoesNotThrowArg, 7);
+  ExceptionCatcher("Function with arg.", FuncThrowsRootExceptionArg, 7);
+  ExceptionCatcher("Function with arg.", FuncThrowsExceptionArg, 7);
+  ExceptionCatcher("Function with arg.", FuncThrowsNumberArg, 7);
 }
 
 UNIT_TEST(ExceptionCatcher_Lambdas)
 {
   ExceptionCatcher(
-      "ExceptionCatcher", [](int) { return 1; }, 7);
+      "Lambda", [](int) { return 1; }, 7);
   ExceptionCatcher(
-      "ExceptionCatcher", [](int) -> int { throw RootException("RootException", "RootException"); },
-      7);
+      "Lambda", [](int) -> int { throw RootException("RootException", "RootException"); }, 7);
   ExceptionCatcher(
-      "ExceptionCatcher", [](int) -> int { throw std::exception(); }, 7);
+      "Lambda", [](int) -> int { throw std::exception(); }, 7);
   ExceptionCatcher(
-      "ExceptionCatcher", [](int) -> int { throw 1; }, 7);
+      "Lambda", [](int) -> int { throw 1; }, 7);
 }
 }  // namespace

--- a/base/exception.hpp
+++ b/base/exception.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base/internal/message.hpp"
+#include "base/logging.hpp"
 #include "base/macros.hpp"
 
 #include <exception>
@@ -22,6 +23,29 @@ private:
   std::string m_whatWithAscii;
   std::string m_msg;
 };
+
+template <typename Fn, typename... Args>
+std::result_of_t<Fn && (Args && ...)> ExceptionCatcher(std::string const & comment, Fn && fn,
+                                                       Args &&... args) noexcept
+{
+  try
+  {
+    return std::forward<Fn>(fn)(std::forward<Args>(args)...);
+  }
+  catch (RootException const & ex)
+  {
+    LOG(LWARNING, ("RootException.", comment, ex.Msg(), ex.what()));
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LWARNING, ("std::exception.", comment, ex.what()));
+  }
+  catch (...)
+  {
+    LOG(LWARNING, ("Unknown exception.", comment));
+  }
+  return {};
+}
 
 #define DECLARE_EXCEPTION(exception_name, base_exception) \
   class exception_name : public base_exception \


### PR DESCRIPTION
Иногда возникает необходимость перехватить все исключения и не дать им выйти за пределы вызова.
Я планирую использовать данную ф-цию далее в kml/pykmlib/bindings.cpp, что при не правильном вводе наш сервер не падал и в других подобных местах.

@mesozoic-drones @mpimenov PTAL