### PR TITLE
[search] Add alt/old name in braces when search result is matched by alt/old name.

### DIFF
--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -756,6 +756,7 @@ void Ranker::MakeRankerResults(Geocoder::Params const & geocoderParams,
 
 void Ranker::GetBestMatchName(FeatureType & f, string & name) const
 {
+  int8_t bestLang;
   KeywordLangMatcher::Score bestScore;
   auto updateScore = [&](int8_t lang, string const & s, bool force) {
     // Ignore name for categorial requests.
@@ -764,6 +765,7 @@ void Ranker::GetBestMatchName(FeatureType & f, string & name) const
     {
       bestScore = score;
       name = s;
+      bestLang = lang;
     }
   };
 
@@ -780,6 +782,14 @@ void Ranker::GetBestMatchName(FeatureType & f, string & name) const
     }
   };
   UNUSED_VALUE(f.ForEachName(bestNameFinder));
+
+  if (bestLang == StringUtf8Multilang::kAltNameCode ||
+      bestLang == StringUtf8Multilang::kOldNameCode)
+  {
+    string readableName;
+    f.GetReadableName(readableName);
+    name = readableName + " (" + name + ")";
+  }
 }
 
 void Ranker::MatchForSuggestions(strings::UniString const & token, int8_t locale,

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -756,7 +756,7 @@ void Ranker::MakeRankerResults(Geocoder::Params const & geocoderParams,
 
 void Ranker::GetBestMatchName(FeatureType & f, string & name) const
 {
-  int8_t bestLang;
+  int8_t bestLang = StringUtf8Multilang::kUnsupportedLanguageCode;
   KeywordLangMatcher::Score bestScore;
   auto updateScore = [&](int8_t lang, string const & s, bool force) {
     // Ignore name for categorial requests.
@@ -788,7 +788,9 @@ void Ranker::GetBestMatchName(FeatureType & f, string & name) const
   {
     string readableName;
     f.GetReadableName(readableName);
-    name = readableName + " (" + name + ")";
+    // Do nothing if alt/old name is the only name we have.
+    if (readableName != name)
+      name = readableName + " (" + name + ")";
   }
 }
 


### PR DESCRIPTION
Отображение alt_name/old_name  в скобочках если по нему заматчилось.

Показала Ксюше, она одобрила.

Выглядит так:
https://www.openstreetmap.org/node/4027027525 
![Screenshot_20200708_155447_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/87014077-41d61c80-c1d4-11ea-80d9-90545210b4a4.jpg)

С альтернативными направлениями письма тоже ок:
https://www.openstreetmap.org/way/35201362
![Screenshot_20200708_205831_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/87014083-44d10d00-c1d4-11ea-9c43-bbda76c1d106.jpg)


https://www.openstreetmap.org/node/2506247280
![Screenshot_20200708_210244_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/87014094-48fd2a80-c1d4-11ea-8d9c-e2d38e4e0c0e.jpg)


https://www.openstreetmap.org/way/35201362
![Screenshot_20200708_211027_com mapswithme maps pro beta](https://user-images.githubusercontent.com/9213190/87014107-4dc1de80-c1d4-11ea-880c-ae733ea54619.jpg)
