### PR TITLE
[search][map] Allow to set different vertical and horizontal distance between search results.

### DIFF
--- a/geometry/geometry_tests/nearby_points_sweeper_test.cpp
+++ b/geometry/geometry_tests/nearby_points_sweeper_test.cpp
@@ -84,34 +84,13 @@ UNIT_TEST(NearbyPointsSweeper_Smoke)
 
     TEST_EQUAL(expected, actual, ());
   }
-}
-
-UNIT_TEST(NearbyPointsSweeper_CornerCases)
-{
-  uint8_t const priority = 0;
-  vector<PointD> const points = {PointD(0, 0),     PointD(0, 0), PointD(1, 0),
-                                 PointD(0, 1),     PointD(1, 1), PointD(1, 0),
-                                 PointD(0.5, 0.5), PointD(0, 1)};
 
   {
-    // In accordance with the specification, all points must be left
-    // as is when epsilon is negative.
-    NearbyPointsSweeper sweeper(-1.0);
+    uint8_t const priority = 0;
+    vector<PointD> const points = {PointD(0, 0),     PointD(0, 0), PointD(1, 0),
+                                   PointD(0, 1),     PointD(1, 1), PointD(1, 0),
+                                   PointD(0.5, 0.5), PointD(0, 1)};
 
-    TIndexSet expected;
-    for (size_t i = 0; i < points.size(); ++i)
-    {
-      sweeper.Add(points[i].x, points[i].y, i, priority);
-      expected.insert(i);
-    }
-
-    TIndexSet actual;
-    sweeper.Sweep(base::MakeInsertFunctor(actual));
-
-    TEST_EQUAL(expected, actual, ());
-  }
-
-  {
     NearbyPointsSweeper sweeper(10.0);
     for (size_t i = 0; i < points.size(); ++i)
       sweeper.Add(points[i].x, points[i].y, i, priority);

--- a/geometry/nearby_points_sweeper.cpp
+++ b/geometry/nearby_points_sweeper.cpp
@@ -26,13 +26,22 @@ bool NearbyPointsSweeper::Event::operator<(Event const & rhs) const
 }
 
 // NearbyPointsSweeper -----------------------------------------------------------------------------
-NearbyPointsSweeper::NearbyPointsSweeper(double eps) : m_eps(eps), m_heps(std::max(eps * 0.5, 0.0))
+NearbyPointsSweeper::NearbyPointsSweeper(double eps) : m_xEps(eps), m_yEps(eps)
 {
+  CHECK_GREATER_OR_EQUAL(m_xEps, 0.0, ());
+  CHECK_GREATER_OR_EQUAL(m_yEps, 0.0, ());
+}
+
+NearbyPointsSweeper::NearbyPointsSweeper(double xEps, double yEps) : m_xEps(xEps), m_yEps(yEps)
+{
+  CHECK_GREATER_OR_EQUAL(m_xEps, 0.0, ());
+  CHECK_GREATER_OR_EQUAL(m_yEps, 0.0, ());
 }
 
 void NearbyPointsSweeper::Add(double x, double y, size_t index, uint8_t priority)
 {
-  m_events.emplace_back(Event::TYPE_SEGMENT_START, y - m_heps, x, index, priority);
-  m_events.emplace_back(Event::TYPE_SEGMENT_END, y + m_heps, x, index, priority);
+  auto const yEpsHalf = 0.5 * m_yEps;
+  m_events.emplace_back(Event::TYPE_SEGMENT_START, y - yEpsHalf, x, index, priority);
+  m_events.emplace_back(Event::TYPE_SEGMENT_END, y + yEpsHalf, x, index, priority);
 }
 }  // namespace m2

--- a/geometry/nearby_points_sweeper.hpp
+++ b/geometry/nearby_points_sweeper.hpp
@@ -15,16 +15,18 @@ namespace m2
 {
 // This class can be used to greedily sweep points on a plane that are
 // too close to each other.  Two points are considered to be "too
-// close" when Manhattan distance between them is less than or equal
-// to some preselected epsilon. Note, the result is not the largest
-// subset of points that can be selected, but it can be computed quite
-// fast and gives satisfactory results.
+// close" when distance along axes between them is less than or equal
+// to some preselected epsilon. Different epsilons can be used for different axes.
+// Note, the result is not the largest subset of points that can be selected,
+// but it can be computed quite fast and gives satisfactory results.
 //
 // *NOTE* The class is NOT thread-safe.
 class NearbyPointsSweeper
 {
 public:
   explicit NearbyPointsSweeper(double eps);
+
+  NearbyPointsSweeper(double xEps, double yEps);
 
   // Adds a new point (|x|, |y|) on the plane. |index| is used to
   // identify individual points, and will be reported for survived
@@ -69,7 +71,7 @@ public:
           }
 
           double const x = it->m_x;
-          if (fabs(x - event.m_x) <= m_eps)
+          if (fabs(x - event.m_x) <= m_xEps)
           {
             if (it->m_priority >= event.m_priority)
             {
@@ -80,7 +82,7 @@ public:
             it = line.erase(it);
           }
 
-          if (x + m_eps < event.m_x)
+          if (x + m_xEps < event.m_x)
             break;
 
           if (it == line.begin())
@@ -151,7 +153,7 @@ private:
   };
 
   std::vector<Event> m_events;
-  double const m_eps;
-  double const m_heps;
+  double const m_xEps;
+  double const m_yEps;
 };
 }  // namespace m2

--- a/map/map_integration_tests/interactive_search_test.cpp
+++ b/map/map_integration_tests/interactive_search_test.cpp
@@ -160,7 +160,8 @@ UNIT_CLASS_TEST(InteractiveSearchTest, NearbyFeaturesInViewport)
   params.m_inputLocale = "en";
   params.m_viewport = m2::RectD(m2::PointD(-0.5, -0.5), m2::PointD(0.5, 0.5));
   params.m_mode = Mode::Viewport;
-  params.m_minDistanceOnMapBetweenResults = kEps * 0.9;
+  params.m_minDistanceOnMapBetweenResultsX = kEps * 0.9;
+  params.m_minDistanceOnMapBetweenResultsY = kEps * 0.9;
   params.m_suggestsEnabled = false;
 
   {
@@ -173,7 +174,8 @@ UNIT_CLASS_TEST(InteractiveSearchTest, NearbyFeaturesInViewport)
          ());
   }
 
-  params.m_minDistanceOnMapBetweenResults = kEps * 1.1;
+  params.m_minDistanceOnMapBetweenResultsX = kEps * 1.1;
+  params.m_minDistanceOnMapBetweenResultsY = kEps * 1.1;
 
   {
     TestSearchRequest request(m_engine, params);

--- a/map/search_api.cpp
+++ b/map/search_api.cpp
@@ -486,7 +486,9 @@ bool SearchAPI::Search(SearchParams const & params, bool forceSearch)
   // search request.
   CancelQuery(intent.m_handle);
 
-  intent.m_params.m_minDistanceOnMapBetweenResults = m_delegate.GetMinDistanceBetweenResults();
+  intent.m_params.m_minDistanceOnMapBetweenResultsX = m_delegate.GetMinDistanceBetweenResults();
+  intent.m_params.m_minDistanceOnMapBetweenResultsY =
+      intent.m_params.m_minDistanceOnMapBetweenResultsX;
 
   Search(intent);
 

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -30,9 +30,10 @@ namespace search
 {
 namespace
 {
-void SweepNearbyResults(double eps, set<FeatureID> const & prevEmit, vector<PreRankerResult> & results)
+void SweepNearbyResults(double xEps, double yEps, set<FeatureID> const & prevEmit,
+                        vector<PreRankerResult> & results)
 {
-  m2::NearbyPointsSweeper sweeper(eps);
+  m2::NearbyPointsSweeper sweeper(xEps, yEps);
   for (size_t i = 0; i < results.size(); ++i)
   {
     auto const & p = results[i].GetInfo().m_center;
@@ -282,7 +283,8 @@ void PreRanker::FilterForViewportSearch()
     return result.GetMatchedTokensNumber() + 1 < m_params.m_numQueryTokens;
   });
 
-  SweepNearbyResults(m_params.m_minDistanceOnMapBetweenResults, m_prevEmit, m_results);
+  SweepNearbyResults(m_params.m_minDistanceOnMapBetweenResultsX,
+                     m_params.m_minDistanceOnMapBetweenResultsY, m_prevEmit, m_results);
 
   size_t const n = m_results.size();
 

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -30,7 +30,8 @@ public:
   {
     // Minimal distance between search results in mercators, needed for
     // filtering of viewport search results.
-    double m_minDistanceOnMapBetweenResults = 0.0;
+    double m_minDistanceOnMapBetweenResultsX = 0.0;
+    double m_minDistanceOnMapBetweenResultsY = 0.0;
 
     // This is different from geocoder's pivot because pivot is
     // usually a rectangle created by radius and center and, due to

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -743,7 +743,10 @@ void Processor::InitPreRanker(Geocoder::Params const & geocoderParams,
   PreRanker::Params params;
 
   if (viewportSearch)
-    params.m_minDistanceOnMapBetweenResults = searchParams.m_minDistanceOnMapBetweenResults;
+  {
+    params.m_minDistanceOnMapBetweenResultsX = searchParams.m_minDistanceOnMapBetweenResultsX;
+    params.m_minDistanceOnMapBetweenResultsY = searchParams.m_minDistanceOnMapBetweenResultsY;
+  }
 
   params.m_viewport = GetViewport();
   params.m_accuratePivotCenter = GetPivotPoint(viewportSearch);

--- a/search/search_integration_tests/search_edited_features_test.cpp
+++ b/search/search_integration_tests/search_edited_features_test.cpp
@@ -168,9 +168,10 @@ UNIT_CLASS_TEST(SearchEditedFeaturesTest, ViewportFilter)
     params.m_inputLocale = "en";
     params.m_viewport = m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0));
     params.m_mode = Mode::Viewport;
-    params.m_minDistanceOnMapBetweenResults = 0.02;
+    params.m_minDistanceOnMapBetweenResultsX = 0.02;
+    params.m_minDistanceOnMapBetweenResultsY = 0.02;
 
-    // m_minDistanceOnMapBetweenResults is 0.02, distance between results is 0.01.
+    // Min distance on map between results is 0.02, distance between results is 0.01.
     // The second result must be filtered out.
     Rules const rulesViewport = {ExactMatch(countryId, restaurant)};
 
@@ -185,9 +186,10 @@ UNIT_CLASS_TEST(SearchEditedFeaturesTest, ViewportFilter)
     params.m_inputLocale = "en";
     params.m_viewport = m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0));
     params.m_mode = Mode::Viewport;
-    params.m_minDistanceOnMapBetweenResults = 0.005;
+    params.m_minDistanceOnMapBetweenResultsX = 0.005;
+    params.m_minDistanceOnMapBetweenResultsY = 0.005;
 
-    // m_minDistanceOnMapBetweenResults is 0.005, distance between results is 0.01.
+    // Min distance on map between results is 0.005, distance between results is 0.01.
     // Filter should keep both results.
     Rules const rulesViewport = {ExactMatch(countryId, restaurant), ExactMatch(countryId, cafe)};
 
@@ -203,7 +205,8 @@ UNIT_CLASS_TEST(SearchEditedFeaturesTest, ViewportFilter)
     params.m_inputLocale = "en";
     params.m_viewport = m2::RectD(m2::PointD(-1.0, -1.0), m2::PointD(1.0, 1.0));
     params.m_mode = Mode::Everywhere;
-    params.m_minDistanceOnMapBetweenResults = 0.02;
+    params.m_minDistanceOnMapBetweenResultsX = 0.02;
+    params.m_minDistanceOnMapBetweenResultsY = 0.02;
 
     // No viewport filter for everywhere search mode.
     Rules const rulesEverywhere = {ExactMatch(countryId, restaurant), ExactMatch(countryId, cafe)};

--- a/search/search_params.hpp
+++ b/search/search_params.hpp
@@ -73,7 +73,8 @@ struct SearchParams
 
   // Minimal distance between search results in mercators, needed for
   // pre-ranking of viewport search results.
-  double m_minDistanceOnMapBetweenResults = 0.0;
+  double m_minDistanceOnMapBetweenResultsX = 0.0;
+  double m_minDistanceOnMapBetweenResultsY = 0.0;
 
   // Street search radius from pivot or matched city center for everywhere search mode.
   double m_streetSearchRadiusM = kDefaultStreetSearchRadiusM;


### PR DESCRIPTION
Сейчас у нас расстояния между результатами по вертикали и по горизонтали жестко связаны. В ближайшее время планируется добавить большие плашки с ценами на отели, для этого лучше развязать расстояния, чтобы иметь возможность по вертикали оставить старые, а по горизонтали при необходимости увеличить.