### PR TITLE
[search] Decrease name rank for features matched by alt/old name.

### DIFF
--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -257,11 +257,11 @@ double RankingInfo::GetLinearModelRank() const
     result += kType[m_type];
     if (Model::IsPoi(m_type))
       result += kResultType[base::Underlying(m_resultType)];
-    result += kNameScore[nameScore];
-    result += kErrorsMade * GetErrorsMadePerToken();
-    result += kMatchedFraction * m_matchedFraction;
     result += (m_allTokensUsed ? 1 : 0) * kAllTokensUsed;
     result += (m_exactCountryOrCapital ? 1 : 0) * kExactCountryOrCapital;
+    auto const nameRank = kNameScore[nameScore] + kErrorsMade * GetErrorsMadePerToken() +
+                          kMatchedFraction * m_matchedFraction;
+    result += (m_isAltOrOldName ? 0.7 : 1.0) * nameRank;
   }
   else
   {


### PR DESCRIPTION
Пока не смогла посмотреть как это выглядит на наших размеченных данных, т.к. текущие карты не содержат alt_name в строках и в поисковом индексе.

Можно или после сборки данных посмотреть и при необходимости внести правки или дождаться сборки данных (по идее это будет после создания ветки release-102 уже в ветке).