### PR TITLE
[base] ExceptionCatcher. Prevent returning reference on a local temporary object.

### DIFF
--- a/base/base_tests/exception_tests.cpp
+++ b/base/base_tests/exception_tests.cpp
@@ -157,7 +157,7 @@ UNIT_TEST(ExceptionCatcher_FunctionsReturnVoid)
   ExceptionCatcher("Function returns void.", exception, FuncThrowsNumberVoid);
 }
 
-UNIT_TEST(ExceptionCatcher_PreventReturningRefOnLocaleTemporaryObj)
+UNIT_TEST(ExceptionCatcher_PreventReturningRefOnLocalTemporaryObj)
 {
   std::string const str = "A string";
   auto const returnedStr = ReturnsByRef(str);

--- a/base/base_tests/exception_tests.cpp
+++ b/base/base_tests/exception_tests.cpp
@@ -3,6 +3,7 @@
 #include "base/exception.hpp"
 
 #include <exception>
+#include <string>
 
 namespace
 {
@@ -21,6 +22,14 @@ void FuncDoesNotThrowVoid(int) noexcept { return; }
 void FuncThrowsRootExceptionVoid(int) { throw RootException("RootException", "RootException"); }
 void FuncThrowsExceptionVoid() { throw std::exception(); }
 void FuncThrowsNumberVoid() { throw 1; };
+
+std::string const & ReturnsByRef(std::string const & str)
+{
+  bool exception = true;
+  return ExceptionCatcher(
+      "ReturnsByRef().", exception,
+      [](std::string const & str) -> std::string const & { return str; }, str);
+}
 
 UNIT_TEST(ExceptionCatcher_FunctionsWithoutArgs)
 {
@@ -146,5 +155,12 @@ UNIT_TEST(ExceptionCatcher_FunctionsReturnVoid)
   ExceptionCatcher("Function returns void.", exception, FuncThrowsRootExceptionVoid, 7);
   ExceptionCatcher("Function returns void.", exception, FuncThrowsExceptionVoid);
   ExceptionCatcher("Function returns void.", exception, FuncThrowsNumberVoid);
+}
+
+UNIT_TEST(ExceptionCatcher_PreventReturningRefOnLocaleTemporaryObj)
+{
+  std::string const str = "A string";
+  auto const returnedStr = ReturnsByRef(str);
+  TEST_EQUAL(str, returnedStr, ());
 }
 }  // namespace

--- a/base/exception.hpp
+++ b/base/exception.hpp
@@ -25,8 +25,9 @@ private:
 };
 
 template <typename Fn, typename... Args>
-std::result_of_t<Fn && (Args && ...)> ExceptionCatcher(
-    std::string const & comment, bool & exceptionWasThrown, Fn && fn, Args &&... args) noexcept
+std::result_of_t<Fn && (Args && ...)> ExceptionCatcher(std::string const & comment,
+                                                       bool & exceptionWasThrown, Fn && fn,
+                                                       Args &&... args) noexcept
 {
   try
   {
@@ -47,7 +48,12 @@ std::result_of_t<Fn && (Args && ...)> ExceptionCatcher(
   }
 
   exceptionWasThrown = true;
-  return std::result_of_t<Fn && (Args && ...)>();
+  using ReturnType = std::decay_t<std::result_of_t<Fn && (Args && ...)>>;
+  if constexpr (!std::is_same_v<void, ReturnType>)
+  {
+    static const ReturnType defaultResult = {};
+    return defaultResult;
+  }
 }
 
 #define DECLARE_EXCEPTION(exception_name, base_exception) \


### PR DESCRIPTION
В ExceptionCatcher был один не приятный момент.

Предположим, что ф-ция `fn` возвращает значение по константой ссылке, например, предварительно его где-то отыскав (https://github.com/mapsme/omim/blob/ee133396e229eb7a3a9943060f78a83fab684f43/kml/pykmlib/bindings.cpp#L55).

Предположим, что нам нужно обернуть ее в ExceptionCatcher. Но в случае исключения ExceptionCatcher возвращает значение сгенерированное конструктором по умолчанию. Т.е. код `return std::result_of_t<Fn && (Args && ...)>();` становится не компилируемым.

Предлагаю следующее решение проблемы.

@mpimenov @mesozoic-drones PTAL