### PR TITLE
[coding][generator] Store alt_name and old_name from osm.

### DIFF
--- a/coding/string_utf8_multilang.cpp
+++ b/coding/string_utf8_multilang.cpp
@@ -104,6 +104,9 @@ StringUtf8Multilang::Languages const & StringUtf8Multilang::GetSupportedLanguage
   // Asserts for generic class constants.
   ASSERT_EQUAL(kLanguages[kDefaultCode].m_code, string("default"), ());
   ASSERT_EQUAL(kLanguages[kInternationalCode].m_code, string("int_name"), ());
+  ASSERT_EQUAL(kLanguages[kAltNameCode].m_code, string("alt_name"), ());
+  ASSERT_EQUAL(kLanguages[kOldNameCode].m_code, string("old_name"), ());
+  ASSERT_EQUAL(kLanguages[kEnglishCode].m_code, string("en"), ());
   static StringUtf8Multilang::Languages languages;
   if (languages.empty())
   {

--- a/coding/string_utf8_multilang.cpp
+++ b/coding/string_utf8_multilang.cpp
@@ -207,6 +207,25 @@ void StringUtf8Multilang::AddString(int8_t lang, string const & utf8s)
   m_s.insert(m_s.end(), utf8s.begin(), utf8s.end());
 }
 
+void StringUtf8Multilang::RemoveString(int8_t lang)
+{
+  size_t i = 0;
+  size_t const sz = m_s.size();
+
+  while (i < sz)
+  {
+    size_t const next = GetNextIndex(i);
+
+    if ((m_s[i] & 0x3F) == lang)
+    {
+      m_s.erase(i, next - i);
+      return;
+    }
+
+    i = next;
+  }
+}
+
 bool StringUtf8Multilang::GetString(int8_t lang, string & utf8s) const
 {
   if (!IsSupportedLangCode(lang))

--- a/coding/string_utf8_multilang.cpp
+++ b/coding/string_utf8_multilang.cpp
@@ -68,9 +68,9 @@ array<StringUtf8Multilang::Lang, StringUtf8Multilang::kMaxSupportedLanguages> co
      {"vi", "Tiếng Việt", ""},
      {"tr", "Türkçe", ""},
      {"bg", "Български", "Bulgarian-Latin/BGN"},
-     {StringUtf8Multilang::kReservedLang /* eo */, "", ""},
+     {"alt_name", "Alternative name", "Any-Latin"},  // Was "eo" before December 2018.
      {"lt", "Lietuvių", ""},
-     {StringUtf8Multilang::kReservedLang /* la */, "", ""},
+     {"old_name", "Old/Previous name", "Any-Latin"},  // Was "la" before December 2018.
      {"kk", "Қазақ", "Kazakh-Latin/BGN"},
      {StringUtf8Multilang::kReservedLang /* gsw */, "", ""},
      {"et", "Eesti", ""},

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -86,6 +86,8 @@ public:
   static int8_t constexpr kDefaultCode = 0;
   static int8_t constexpr kEnglishCode = 1;
   static int8_t constexpr kInternationalCode = 7;
+  static int8_t constexpr kAltNameCode = 53;
+  static int8_t constexpr kOldNameCode = 55;
   /// How many languages we support on indexing stage. See full list in cpp file.
   /// TODO(AlexZ): Review and replace invalid languages by valid ones.
   static int8_t constexpr kMaxSupportedLanguages = 64;

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -120,6 +120,14 @@ public:
       AddString(l, utf8s);
   }
 
+  void RemoveString(int8_t lang);
+  void RemoveString(std::string const & lang)
+  {
+    int8_t const l = GetLangIndex(lang);
+    if (l >= 0)
+      RemoveString(l);
+  }
+
   // Calls |fn| for each pair of |lang| and |utf8s| stored in this multilang string.
   template <typename Fn>
   void ForEach(Fn && fn) const

--- a/editor/xml_feature.cpp
+++ b/editor/xml_feature.cpp
@@ -92,6 +92,13 @@ char const * const XMLFeature::kDefaultLang =
     StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode);
 char const * const XMLFeature::kIntlLang =
     StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kInternationalCode);
+char const * const XMLFeature::kAltLang =
+    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kAltNameCode);
+char const * const XMLFeature::kOldLang =
+    StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kOldNameCode);
+char const * const XMLFeature::kIntlName = XMLFeature::kIntlLang;
+char const * const XMLFeature::kAltName = XMLFeature::kAltLang;
+char const * const XMLFeature::kOldName = XMLFeature::kOldLang;
 
 XMLFeature::XMLFeature(Type const type)
 {
@@ -239,6 +246,10 @@ string XMLFeature::GetName(string const & lang) const
 {
   if (lang == kIntlLang)
     return GetTagValue(kIntlName);
+  if (lang == kAltLang)
+    return GetTagValue(kAltName);
+  if (lang == kOldLang)
+    return GetTagValue(kOldName);
   auto const suffix = (lang == kDefaultLang || lang.empty()) ? "" : ":" + lang;
   return GetTagValue(kDefaultName + suffix);
 }
@@ -253,7 +264,17 @@ void XMLFeature::SetName(string const & name) { SetName(kDefaultLang, name); }
 void XMLFeature::SetName(string const & lang, string const & name)
 {
   if (lang == kIntlLang)
+  {
     SetTagValue(kIntlName, name);
+  }
+  else if (lang == kAltLang)
+  {
+    SetTagValue(kAltName, name);
+  }
+  else if (lang == kOldLang)
+  {
+    SetTagValue(kOldName, name);
+  }
   else
   {
     auto const suffix = (lang == kDefaultLang || lang.empty()) ? "" : ":" + lang;

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -31,10 +31,14 @@ DECLARE_EXCEPTION(NoHeader, XMLFeatureError);
 class XMLFeature
 {
   static constexpr char const * kDefaultName = "name";
-  static constexpr char const * kIntlName = "int_name";
   static constexpr char const * kLocalName = "name:";
+  static char const * const kIntlName;
+  static char const * const kAltName;
+  static char const * const kOldName;
   static char const * const kDefaultLang;
   static char const * const kIntlLang;
+  static char const * const kAltLang;
+  static char const * const kOldLang;
 
 public:
   // Used in point to string serialization.

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -10,6 +10,7 @@
 #include "indexer/feature_impl.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
+#include "indexer/search_string_utils.hpp"
 
 #include "coding/bit_streams.hpp"
 #include "coding/byte_stream.hpp"
@@ -299,6 +300,15 @@ void FeatureBuilder::RemoveUselessNames()
       pair<int, int> const range = GetDrawableScaleRangeForRules(types, RULE_ANY_TEXT);
       if (range.first == -1)
         m_params.name.Clear();
+    }
+
+    // We want to skip alt_name which is almost equal to name.
+    std::string altName;
+    std::string name;
+    if (m_params.name.GetString("alt_name", altName) && m_params.name.GetString("default", name) &&
+        search::NormalizeAndSimplifyString(altName) == search::NormalizeAndSimplifyString(name))
+    {
+      m_params.name.RemoveString("alt_name");
     }
   }
 }

--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -378,7 +378,7 @@ public:
     TEST(rawGenerator.Execute(), ());
 
     TestGeneratedFile(cameraToWays, 0 /* fileSize */);
-    TestGeneratedFile(citiesAreas, 18601 /* fileSize */);
+    TestGeneratedFile(citiesAreas, 18705 /* fileSize */);
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -871,6 +871,44 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hotel)
   }
 }
 
+UNIT_CLASS_TEST(TestWithClassificator, OsmType_OldName)
+{
+  {
+    Tags const tags = {
+      {"highway", "residential"},
+      {"name", "Улица Веткина"},
+      {"old_name", "Царская Ветка"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Улица Веткина", ());
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("old_name"), s);
+    TEST_EQUAL(s, "Царская Ветка", ());
+  }
+}
+
+UNIT_CLASS_TEST(TestWithClassificator, OsmType_AltName)
+{
+  {
+    Tags const tags = {
+      {"tourism", "museum"},
+      {"name", "Московский музей современного искусства"},
+      {"alt_name", "MMOMA"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Московский музей современного искусства", ());
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("alt_name"), s);
+    TEST_EQUAL(s, "MMOMA", ());
+  }
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, OsmType_MergeTags)
 {
   {

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -46,8 +46,8 @@ public:
     if (!token)
       return false;
 
-    // Is this an international (latin) name.
-    if (*token == "int_name")
+    // Is this an international (latin) / old / alternative name.
+    if (*token == "int_name" || *token == "old_name" || *token == "alt_name")
     {
       lang = *token;
       return m_savedNames.insert(lang).second;

--- a/generator/osm_element.cpp
+++ b/generator/osm_element.cpp
@@ -59,8 +59,6 @@ void OsmElement::AddTag(char const * key, char const * value)
   SKIP_KEY_BY_PREFIX("whitewater"); // https://wiki.openstreetmap.org/wiki/Whitewater_sports
 
   // In future we can use this tags for improve our search
-  SKIP_KEY_BY_PREFIX("old_name");
-  SKIP_KEY_BY_PREFIX("alt_name");
   SKIP_KEY_BY_PREFIX("nat_name");
   SKIP_KEY_BY_PREFIX("reg_name");
   SKIP_KEY_BY_PREFIX("loc_name");

--- a/generator/relation_tags.cpp
+++ b/generator/relation_tags.cpp
@@ -122,8 +122,11 @@ void RelationTagsWay::Process(RelationElement const & e)
       Base::AddCustomTag({"addr:street", p.second});
 
     // All "name" tags should be skipped.
-    if (strings::StartsWith(p.first, "name") || p.first == "int_name")
+    if (strings::StartsWith(p.first, "name") || p.first == "int_name" || p.first == "old_name" ||
+        p.first == "alt_name")
+    {
       continue;
+    }
 
     if (!isBoundary && p.first == "boundary")
       continue;


### PR DESCRIPTION
cherry-pick  сохранения alt/old name и использования в редакторе (все сохраненные имена мы показываем в редакторе, поэтому перенести только сохранение, но не редактор нельзя).
cherry-pick нужен чтобы имена пораньше попали в данные и была возможность тестировать функции связанные с наличием alt/old name.

Оригинальные реквесты:
https://github.com/mapsme/omim/pull/13229
https://github.com/mapsme/omim/pull/13260
https://github.com/mapsme/omim/pull/13312