### PR TITLE
[Strings] Fix typo in NL translation 

### DIFF
--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -1518,7 +1518,7 @@
 	<string name="driving_options_title">Omweginstellingen</string>
 	<string name="driving_options_subheader">Vermijden op elke route</string>
 	<string name="avoid_tolls">Tolwegen</string>
-	<string name="avoid_unpaved">Aardewegen</string>
+	<string name="avoid_unpaved">Aarden wegen</string>
 	<string name="avoid_ferry">Ferries</string>
 	<string name="avoid_motorways">Hoofdverkeerswegen</string>
 	<string name="unable_to_calc_alert_title">Kan route niet opbouwen</string>
@@ -1530,7 +1530,7 @@
 	<string name="ferry_crossing">Ferry</string>
 	<string name="operated_by">Gecontroleerd door \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Tolwegen vermijden</string>
-	<string name="avoid_unpaved_roads_placepage">Aardewegen vermijden</string>
+	<string name="avoid_unpaved_roads_placepage">Aarden wegen vermijden</string>
 	<string name="avoid_ferry_crossing_placepage">Ferries vermijden</string>
 	<string name="cached_guides_placeholder_subtitle">Klare reisgids op MAPS.ME bevatten geselecteerde plaatsen met foto\'s en beschrijvingen die op de kaart worden weergegeven en offline beschikbaar zijn.</string>
 	<string name="guides_catalogue_title">Reisgidscatalogus</string>
@@ -1551,7 +1551,7 @@
 	<string name="whats_new_auto_update_bydeeplink_message">Heerladt de kaarten op actuele informatie over objecten te krijgen!</string>
 	<string name="whats_new_auto_update_and_proceed_button_size">Bijwerken (%s) en verder gaan</string>
 	<string name="whatsnew_toll_unpaved_title">Bouw routen met inachtneming van alle soorten wegen</string>
-	<string name="whatsnew_toll_unpaved_message">Kies omwegen via tolwegen, aardewegen en ferries</string>
+	<string name="whatsnew_toll_unpaved_message">Kies omwegen via tolwegen, aarden wegen en ferries</string>
 	<string name="whatsnew_new_catalogue_title">Bijgewerkte cataloguspagina\'s</string>
 	<string name="whatsnew_new_catalogue_message">We hebben gedetailleerde informatie over partnerhandleidingen toegevoegd, zodat de routekeuze gemakkelijk en handig is</string>
 	<string name="purchase_please_wait_toast">Verlaat het scherm niet, alstublieft, voordat het aankoopproces is voltooid</string>
@@ -1616,7 +1616,7 @@
 	<string name="whatsnew_carnavi_fixes_for_android_title">Navigatie update</string>
 	<string name="whatsnew_carnavi_fixes_for_android_message">We hebben de aanleg van routes naar punten ver van de weggen verbeterd</string>
 	<string name="avoid_unpaved_carplay_1">Geen aardew.</string>
-	<string name="avoid_unpaved_carplay_2">Geen aardewegen</string>
+	<string name="avoid_unpaved_carplay_2">Geen aarden wegen</string>
 	<string name="avoid_ferry_carplay_1">Geen ferry\'s</string>
 	<string name="avoid_ferry_carplay_2">Geen ferry\'s</string>
 	<string name="avoid_tolls_carplay_1">Zonder tol</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -38840,7 +38840,7 @@
     ar = طرق غير ممهدة
     cs = Nezpevněná silnice
     da = Grusveje
-    nl = Aardewegen
+    nl = Aarden wegen
     fi = Päällystämättömät tiet
     fr = Routes non revêtues
     de = Erdwege
@@ -39248,7 +39248,7 @@
     ar = تجنب الطرق الغير ممهدة
     cs = Vyhnout se nezpevněným silnicím
     da = Undgå grusveje
-    nl = Aardewegen vermijden
+    nl = Aarden wegen vermijden
     fi = Vältä maanteitä
     fr = Éviter les routes non revêtues
     de = Erdwege vermeiden
@@ -39892,7 +39892,7 @@
     ar = حدد الطرق التي تحتوي: نقط تحصيل رسوم، طرق غير ممهدة، تفاطعات العبارات
     cs = Vyberte si objížďky podle zpoplatněných silnic, prašných silnic a přejezdů trajektů
     da = Vælg omveje for at undgå vejbaner, grusveje og færgeoverfarter
-    nl = Kies omwegen via tolwegen, aardewegen en ferries
+    nl = Kies omwegen via tolwegen, aarden wegen en ferries
     fi = Valitse kiertoreitit maksullisten teiden, päällystämättömien teiden ja lauttojen ohi
     fr = Choisissez des itinéraires de détour par péage, routes non revêtues et passages d'un cours d'eau
     de = Wählen Sie die Umwege durch Mautstraßen, Erdwege und Fährstellen
@@ -42108,7 +42108,7 @@
     ar = تجنب غير الممهد
     cs = Vyhnout se nezp
     da = Undgå grus
-    nl = Geen aardewegen
+    nl = Geen aarden wegen
     fi = Vain päällyste
     fr = Route de terre
     de = Ohne Landstr.

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -2740,7 +2740,7 @@
 
 "avoid_tolls" = "Tolwegen";
 
-"avoid_unpaved" = "Aardewegen";
+"avoid_unpaved" = "Aarden wegen";
 
 "avoid_ferry" = "Ferries";
 
@@ -2764,7 +2764,7 @@
 
 "avoid_toll_roads_placepage" = "Tolwegen vermijden";
 
-"avoid_unpaved_roads_placepage" = "Aardewegen vermijden";
+"avoid_unpaved_roads_placepage" = "Aarden wegen vermijden";
 
 "avoid_ferry_crossing_placepage" = "Ferries vermijden";
 
@@ -2798,7 +2798,7 @@
 
 "whatsnew_toll_unpaved_title" = "Bouw routen met inachtneming van alle soorten wegen";
 
-"whatsnew_toll_unpaved_message" = "Kies omwegen via tolwegen, aardewegen en ferries";
+"whatsnew_toll_unpaved_message" = "Kies omwegen via tolwegen, aarden wegen en ferries";
 
 "whatsnew_new_catalogue_title" = "Bijgewerkte cataloguspagina's";
 
@@ -2932,7 +2932,7 @@
 
 "avoid_unpaved_carplay_1" = "Geen aardew.";
 
-"avoid_unpaved_carplay_2" = "Geen aardewegen";
+"avoid_unpaved_carplay_2" = "Geen aarden wegen";
 
 "avoid_ferry_carplay_1" = "Geen ferry's";
 


### PR DESCRIPTION
"User: Earthways ON-OFF.

In correct Dutch it is "Aarden wegen".
With a ".... n" so and apart.
Everything of matter is written with a "n" (wooden chair, iron spoon, linen dress, earthen wall etc.)

Me: If I understand correctly, the word "Aardewegen’" should be corrected to Aarden wegen, is it correct?

User: Yes, that's right 😀" 

I've contacted user so that he can confirm all the changes in the context. User replied: "Thank you for your action. Has been adjusted correctly".