### PR TITLE
[search] Pass hotels refused by booking filter.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1661,9 +1661,6 @@ void Geocoder::EmitResult(BaseContext & ctx, MwmSet::MwmId const & mwmId, uint32
   if (matchedFraction <= 0.1)
     return;
 
-  if (ctx.m_hotelsFilter && !ctx.m_hotelsFilter->Matches(id))
-    return;
-
   if (ctx.m_cuisineFilter && !ctx.m_cuisineFilter->Matches(id))
     return;
 
@@ -1676,6 +1673,10 @@ void Geocoder::EmitResult(BaseContext & ctx, MwmSet::MwmId const & mwmId, uint32
   // distant from the pivot when there are enough results close to the
   // pivot.
   PreRankingInfo info(type, tokenRange);
+
+  if (ctx.m_hotelsFilter && !ctx.m_hotelsFilter->Matches(id))
+    info.m_refusedByFilter = true;
+
   for (auto const & layer : ctx.m_layers)
     info.m_tokenRanges[layer.m_type] = layer.m_tokenRange;
 

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -41,7 +41,10 @@ void SweepNearbyResults(double xEps, double yEps, set<FeatureID> const & prevEmi
     uint8_t const popularity = results[i].GetInfo().m_popularity;
     uint8_t const prevCount = prevEmit.count(results[i].GetId()) ? 1 : 0;
     uint8_t const exactMatch = results[i].GetInfo().m_exactMatch ? 1 : 0;
-    uint8_t const priority = max({rank, prevCount, popularity, exactMatch});
+    // We prefer result which passed the filter even if it has lower rank / popularity / prevCount /
+    // exactMatch.
+    uint8_t const filterPassed = results[i].GetInfo().m_refusedByFilter ? 0 : 2;
+    uint8_t const priority = max({rank, prevCount, popularity, exactMatch}) + filterPassed;
     sweeper.Add(p.x, p.y, i, priority);
   }
 

--- a/search/pre_ranking_info.hpp
+++ b/search/pre_ranking_info.hpp
@@ -62,6 +62,9 @@ struct PreRankingInfo
   // Popularity rank of the feature.
   uint8_t m_popularity = 0;
 
+  // We may want to show results which did not pass filter.
+  bool m_refusedByFilter = false;
+
   // Confidence and UGC rating.
   // Confidence: 0 - no information
   //             1 - based on few reviews

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -363,6 +363,7 @@ class RankerResultMaker
     info.m_exactMatch = preInfo.m_exactMatch;
     info.m_categorialRequest = m_params.IsCategorialRequest();
     info.m_tokenRanges = preInfo.m_tokenRanges;
+    info.m_refusedByFilter = preInfo.m_refusedByFilter;
 
     // We do not compare result name and request for categorial requests but we prefer named
     // features.

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -28,6 +28,7 @@ double constexpr kCategoriesDistanceToPivot = -0.6874177;
 double constexpr kCategoriesRank = 1.0000000;
 double constexpr kCategoriesRating = 0.0500000;
 double constexpr kCategoriesFalseCats = -1.0000000;
+double constexpr kCategoriesRefusedByFilter = -1.0000000;
 
 double constexpr kDistanceToPivot = -0.2123693;
 double constexpr kRank = 0.1065355;
@@ -38,6 +39,7 @@ double constexpr kErrorsMade = -0.0391331;
 double constexpr kMatchedFraction = 0.1876736;
 double constexpr kAllTokensUsed = 0.0478513;
 double constexpr kExactCountryOrCapital = 0.1247733;
+double constexpr kRefusedByFilter = -1.0000000;
 double constexpr kNameScore[NameScore::NAME_SCORE_COUNT] = {
   0.0085962 /* Zero */,
   -0.0099698 /* Substring */,
@@ -73,6 +75,8 @@ static_assert(kRank >= 0, "");
 static_assert(kPopularity >= 0, "");
 static_assert(kErrorsMade <= 0, "");
 static_assert(kExactCountryOrCapital >= 0, "");
+static_assert(kCategoriesRefusedByFilter < 0, "");
+static_assert(kRefusedByFilter < 0, "");
 
 double TransformDistance(double distance)
 {
@@ -199,6 +203,7 @@ string DebugPrint(RankingInfo const & info)
   os << ", m_exactCountryOrCapital:" << info.m_exactCountryOrCapital;
   os << ", m_categorialRequest:" << info.m_categorialRequest;
   os << ", m_hasName:" << info.m_hasName;
+  os << ", m_refusedByFilter:" << info.m_refusedByFilter;
   os << "]";
   return os.str();
 }
@@ -262,6 +267,7 @@ double RankingInfo::GetLinearModelRank() const
     auto const nameRank = kNameScore[nameScore] + kErrorsMade * GetErrorsMadePerToken() +
                           kMatchedFraction * m_matchedFraction;
     result += (m_isAltOrOldName ? 0.7 : 1.0) * nameRank;
+    result += (m_refusedByFilter ? 1 : 0) * kRefusedByFilter;
   }
   else
   {
@@ -271,6 +277,7 @@ double RankingInfo::GetLinearModelRank() const
     result += kCategoriesRating * rating;
     result += kCategoriesFalseCats * kFalseCats;
     result += m_hasName * kHasName;
+    result += (m_refusedByFilter ? 1 : 0) * kCategoriesRefusedByFilter;
   }
   return result;
 }

--- a/search/ranking_info.hpp
+++ b/search/ranking_info.hpp
@@ -113,6 +113,9 @@ struct RankingInfo
 
   // True iff the feature has a name.
   bool m_hasName = false;
+
+  // We may want to show results which did not pass filter.
+  bool m_refusedByFilter = false;
 };
 
 ResultType GetResultType(feature::TypesHolder const & th);

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -103,6 +103,7 @@ public:
     return m_details.m_hotelApproximatePricing;
   }
   bool IsHotel() const { return m_details.m_isHotel; }
+  bool IsRefusedByFilter() const { return m_info.m_refusedByFilter; }
 
   osm::YesNoUnknown IsOpenNow() const { return m_details.m_isOpenNow; }
   int GetStarsCount() const { return m_details.m_stars; }

--- a/search/search_tests_support/helpers.cpp
+++ b/search/search_tests_support/helpers.cpp
@@ -78,6 +78,13 @@ size_t SearchTest::GetResultsNumber(string const & query, string const & locale)
   return request.Results().size();
 }
 
+unique_ptr<tests_support::TestSearchRequest> SearchTest::MakeRequest(SearchParams params)
+{
+  auto request = make_unique<tests_support::TestSearchRequest>(m_engine, params);
+  request->Run();
+  return request;
+}
+
 unique_ptr<tests_support::TestSearchRequest> SearchTest::MakeRequest(
     string const & query, string const & locale /* = "en" */)
 {

--- a/search/search_tests_support/helpers.hpp
+++ b/search/search_tests_support/helpers.hpp
@@ -47,6 +47,8 @@ public:
 
   size_t GetResultsNumber(std::string const & query, std::string const & locale);
 
+  std::unique_ptr<tests_support::TestSearchRequest> MakeRequest(SearchParams params);
+
   std::unique_ptr<tests_support::TestSearchRequest> MakeRequest(std::string const & query,
                                                                 std::string const & locale = "en");
 


### PR DESCRIPTION
https://confluence.mail.ru/pages/viewpage.action?pageId=99977256&focusedCommentId=481822067#Booking.comFilters&SearchImprovements-comment-481822067

Отели, которые не прошли фильтр требуется пропускать через поиск (отдавая при этом предпочтения прошедшим фильтр отелям), чтобы в случае когда мало отелей прошло фильтр мы могли показать хотя бы не прошедшие + информацию почему они не прошли.
Сейчас у нас это частично реализовано -- мы сначала применяем оффлайн фильтры, потом прореживаем/ранжируем, потом применяем к результатам онлайн фильтр и показываем по-разному те отели которые прошли и не прошли фильтр.
Но разное поведение при непрохождении онлайн и оффлайн фильтров странно, нужно одинаковое.