### PR TITLE
[openlr] Fixing openlr matcher.

### DIFF
--- a/openlr/candidate_paths_getter.cpp
+++ b/openlr/candidate_paths_getter.cpp
@@ -117,7 +117,8 @@ void CandidatePathsGetter::GetStartLines(vector<m2::PointD> const & points, bool
 void CandidatePathsGetter::GetAllSuitablePaths(Graph::EdgeVector const & startLines,
                                                bool isLastPoint, double bearDistM,
                                                FunctionalRoadClass functionalRoadClass,
-                                               FormOfWay formOfWay, vector<LinkPtr> & allPaths)
+                                               FormOfWay formOfWay, double distanceToNextPointM,
+                                               vector<LinkPtr> & allPaths)
 {
   queue<LinkPtr> q;
 
@@ -277,7 +278,7 @@ void CandidatePathsGetter::GetLineCandidates(openlr::LocationReferencePoint cons
 
   vector<LinkPtr> allPaths;
   GetAllSuitablePaths(startLines, isLastPoint, bearDistM, p.m_functionalRoadClass, p.m_formOfWay,
-                      allPaths);
+                      distanceToNextPointM, allPaths);
   GetBestCandidatePaths(allPaths, isLastPoint, p.m_bearing, bearDistM, startPoint, candidates);
   LOG(LDEBUG, (candidates.size(), "candidate paths found for point (LatLon)", p.m_latLon));
 }

--- a/openlr/candidate_paths_getter.hpp
+++ b/openlr/candidate_paths_getter.hpp
@@ -105,9 +105,9 @@ private:
   void GetStartLines(std::vector<m2::PointD> const & points, bool const isLastPoint,
                      Graph::EdgeVector & edges);
 
-  void GetAllSuitablePaths(Graph::EdgeVector const & startLines, bool isLastPoint,
-                           double bearDistM, FunctionalRoadClass  functionalRoadClass,
-                           FormOfWay formOfWay, std::vector<LinkPtr> & allPaths);
+  void GetAllSuitablePaths(Graph::EdgeVector const & startLines, bool isLastPoint, double bearDistM,
+                           FunctionalRoadClass functionalRoadClass, FormOfWay formOfWay,
+                           double distanceToNextPointM, std::vector<LinkPtr> & allPaths);
 
   void GetBestCandidatePaths(std::vector<LinkPtr> const & allPaths, bool const isLastPoint,
                              uint32_t const requiredBearing, double const bearDistM,

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -171,8 +171,8 @@ void ScoreCandidatePathsGetter::GetAllSuitablePaths(ScoreEdgeVec const & startLi
     auto const & currentEdge = u->m_edge;
     auto const currentEdgeLen = EdgeLength(currentEdge);
 
-    // The path from the start of the segment of to the finish to the segment should be
-    // much shorter then the distance of connection of openlr segment.
+    // The path from the start of the openlr segment to the finish to the openlr segment should be
+    // much shorter then the distance of any connection of openlr segment.
     // This condition should be checked because otherwise in rare case |q| may be overfilled.
     if (u->m_distanceM > distanceToNextPointM)
       continue;

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -71,7 +71,7 @@ bool ScoreCandidatePathsGetter::Link::IsJunctionInPath(geometry::PointWithAltitu
 {
   for (auto * l = this; l; l = l->m_parent.get())
   {
-    if (l->m_edge.GetEndJunction() == j)
+    if (l->m_edge.GetEndJunction().GetPoint() == j.GetPoint())
     {
       LOG(LDEBUG, ("A loop detected, skipping..."));
       return true;

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -5,7 +5,6 @@
 #include "openlr/score_candidate_points_getter.hpp"
 
 #include "routing/road_graph.hpp"
-#include "base/stl_helpers.hpp"
 
 #include "platform/location.hpp"
 
@@ -141,6 +140,7 @@ void ScoreCandidatePathsGetter::GetAllSuitablePaths(ScoreEdgeVec const & startLi
                                                     double bearDistM,
                                                     FunctionalRoadClass functionalRoadClass,
                                                     FormOfWay formOfWay,
+                                                    double distanceToNextPointM,
                                                     vector<shared_ptr<Link>> & allPaths)
 {
   CHECK_NOT_EQUAL(source, LinearSegmentSource::NotValid, ());
@@ -170,6 +170,12 @@ void ScoreCandidatePathsGetter::GetAllSuitablePaths(ScoreEdgeVec const & startLi
 
     auto const & currentEdge = u->m_edge;
     auto const currentEdgeLen = EdgeLength(currentEdge);
+
+    // The path from the start of the segment of to the finish to the segment should be
+    // much shorter then the distance of connection of openlr segment.
+    // This condition should be checked because otherwise in rare case |q| may be overfilled.
+    if (u->m_distanceM > distanceToNextPointM)
+      continue;
 
     if (u->m_distanceM + currentEdgeLen >= bearDistM)
     {
@@ -302,7 +308,7 @@ void ScoreCandidatePathsGetter::GetLineCandidates(openlr::LocationReferencePoint
 
   vector<shared_ptr<Link>> allPaths;
   GetAllSuitablePaths(startLines, source, isLastPoint, bearDistM, p.m_functionalRoadClass,
-                      p.m_formOfWay, allPaths);
+                      p.m_formOfWay, distanceToNextPointM, allPaths);
 
   GetBestCandidatePaths(allPaths, source, isLastPoint, p.m_bearing, bearDistM, startPoint,
                         candidates);

--- a/openlr/score_candidate_paths_getter.hpp
+++ b/openlr/score_candidate_paths_getter.hpp
@@ -100,6 +100,7 @@ private:
   void GetAllSuitablePaths(ScoreEdgeVec const & startLines, LinearSegmentSource source,
                            bool isLastPoint, double bearDistM,
                            FunctionalRoadClass functionalRoadClass, FormOfWay formOfWay,
+                           double distanceToNextPointM,
                            std::vector<std::shared_ptr<Link>> & allPaths);
 
   void GetBestCandidatePaths(std::vector<std::shared_ptr<Link>> const & allPaths,


### PR DESCRIPTION
Новый мачер с новой геометрией в некоторых ситуациях не привязывал корректно. Проблема была в том, что дороги были много кратно продублированы и это давало комбинаторный рост кол-ва вариантов, и потребляемой памяти. И соответственно останавливало мачинг. Чтоб это поправить я добавил фильтр: EdgeSortUniqueByStartAndEndPoints(), который выкидывает дубликаты.

Кроме того, сделал еще 2 улучшения.
- При поиске, коротких путей, как отойти от старта и подойти к финишу в GetAllSuitablePaths() сделал, чтоб не было пройдено слишком много вершин. `Проверка: if (u->m_distanceM > distanceToNextPointM)`;
- Сравнение тоже с высотой не всегда срабатывало. Т.к. в ряде ситуаций, не всегда, высоты в них была равно 0. (Подробнее https://github.com/mapsme/omim/pull/13288) Поэтому сделал проверку: `if (l->m_edge.GetEndJunction().GetPoint() == j.GetPoint())`;

Качество мачинга ухудшилось, но пределах погрешности:
Было:
Нью-Йорк: mean: 0.9770, std: 0.1091
Лондон: mean: 0.9667, std: 0.1521
Сан-Марино: mean: _0.9596_, std: _0.1651_
Москва: mean: mean: 0.9417, std: 0.2163
В среднем: mean: _0.96125_

Стало:
Нью-Йорк: mean: 0.9770, std: 0.1091
Лондон: mean: 0.9667, std: 0.1521
Сан-Марино: mean: _0.9535_, std: _0.1681_
Москва: mean: mean: 0.9417, std: 0.2163
В среднем: mean: _0,959725_

@mesozoic-drones @maksimandrianov PTAL