### PR TITLE
[transit] Validate edge weight in gtfs_converter.

### DIFF
--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -57,6 +57,7 @@ struct TimeFromGateToStop
 
   DECLARE_VISITOR_AND_DEBUG_PRINT(TimeFromGateToStop, visitor(m_stopId, "stopId"),
                                   visitor(m_timeSeconds, "timeSeconds"))
+
   TransitId m_stopId = kInvalidTransitId;
   size_t m_timeSeconds = 0;
 };

--- a/transit/world_feed/feed_helpers.hpp
+++ b/transit/world_feed/feed_helpers.hpp
@@ -2,6 +2,7 @@
 
 #include "geometry/point2d.hpp"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,7 +26,9 @@ ProjectionToShape ProjectStopOnTrack(m2::PointD const & stopPoint, m2::PointD co
 /// \returns index of the nearest track point to the |point| and flag if it was inserted to the
 /// shape. If this index doesn't match already existent points, the stop projection is inserted to
 /// the |polyline| and the flag is set to true.
-std::pair<size_t, bool> PrepareNearestPointOnTrack(m2::PointD const & point, size_t startIndex,
+std::pair<size_t, bool> PrepareNearestPointOnTrack(m2::PointD const & point,
+                                                   std::optional<m2::PointD> const & prevPoint,
+                                                   size_t startIndex,
                                                    std::vector<m2::PointD> & polyline);
 
 /// \returns true if we should not skip routes with this GTFS |routeType|.
@@ -40,4 +43,32 @@ std::string ToStringExtendedType(gtfs::RouteType const & routeType);
 /// \return stop times for trip with |tripId|.
 gtfs::StopTimes GetStopTimesForTrip(gtfs::StopTimes const & allStopTimes,
                                     std::string const & tripId);
+
+// Delete item from the |container| by its key.
+template <class C, class K>
+void DeleteIfExists(C & container, K const & key)
+{
+  auto it = container.find(key);
+  if (it != container.end())
+    container.erase(it);
+}
+
+template <class K>
+void DeleteIfExists(std::vector<K> & container, K const & key)
+{
+  auto it = std::find(container.begin(), container.end(), key);
+  if (it != container.end())
+    container.erase(it);
+}
+
+// Delete items by keys in |keysForDel| from the |container|.
+template <class C, class S>
+void DeleteAllEntriesByIds(C & container, S const & keysForDel)
+{
+  for (auto const & key : keysForDel)
+    DeleteIfExists(container, key);
+}
+
+inline double KmphToMps(double kmph) { return kmph * 1'000.0 / (60.0 * 60.0); }
+inline double MpsToKmph(double mps) { return mps / 1'000.0 * 60.0 * 60.0; }
 }  // namespace transit

--- a/transit/world_feed/gtfs_converter/gtfs_converter.cpp
+++ b/transit/world_feed/gtfs_converter/gtfs_converter.cpp
@@ -238,7 +238,6 @@ bool ConvertFeeds(transit::IdGenerator & generator, transit::ColorPicker & color
 
   LOG(LINFO, ("Corrupted feeds paths:", invalidFeeds));
   LOG(LINFO, ("Corrupted feeds:", invalidFeeds.size(), "/", feedsTotal));
-  LOG(LINFO, ("Bad stop sequences:", transit::WorldFeed::GetCorruptedStopSequenceCount()));
   LOG(LINFO, ("Feeds with no shapes:", feedsWithNoShapesCount, "/", feedsTotal));
   LOG(LINFO, ("Feeds parsed but not dumped:", feedsNotDumpedCount, "/", feedsTotal));
   LOG(LINFO, ("Total dumped feeds:", feedsDumped, "/", feedsTotal));

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -81,13 +81,13 @@ public:
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 21, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 87, ());
     // All trips have unique service_id so each line corresponds to some trip.
-    TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 981, ());
-    TEST_EQUAL(m_globalFeed.m_stops.m_data.size(), 1021, ());
+    TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 980, ());
+    TEST_EQUAL(m_globalFeed.m_stops.m_data.size(), 1008, ());
     // 64 shapes contained in other shapes should be skipped.
     TEST_EQUAL(m_globalFeed.m_shapes.m_data.size(), 329, ());
     TEST_EQUAL(m_globalFeed.m_gates.m_data.size(), 0, ());
     TEST_EQUAL(m_globalFeed.m_transfers.m_data.size(), 0, ());
-    TEST_EQUAL(m_globalFeed.m_edges.m_data.size(), 10091, ());
+    TEST_EQUAL(m_globalFeed.m_edges.m_data.size(), 10079, ());
     TEST_EQUAL(m_globalFeed.m_edgesTransfers.m_data.size(), 0, ());
   }
 


### PR DESCRIPTION
Класс `WorldFeed` нужен, чтобы конвертировать фиды из формата GTFS и сохранять в специального вида line-by-line json.  Этот класс используется тулзой `gtfs_converter`. Сохраненные с ее помощью json'ы затем отдаются генератору  карт (`generator_tool`) для заполнения новой версии транзитной секции. Более подробное описание WorldFeed есть в реквесте по его добавлению: #12946 

В этом реквесте в `WorldFeed` внесены улучшения:
- Добавлена валидация весов ребер (`edges`), соединяющих остановки в граф для роутинга. В GTFS может попадаться оторванное от нашего пространства-времени расписание, а также удивительные координаты остановок. Например, время в пути между двумя автобусными остановками, разнесенными на 60км, может составлять 40 секунд. Линии маршрута с такими аномалиями мы не сохраняем в json. И если в маршруте присутствуют только аномальные линии, удаляем и его. Аналогично поступаем с операторами (network).
- В связи с более жесткой валидацией ребер скорректирован алгоритм проецирования остановок на полилинию маршрута.
- Нам не нужно, чтобы айдишники всех сущностей транзита были в интервале `FakeFeatureIds::IsTransitFeature()`. В этом интервале должны быть только айди ребер, а они заполняются на этапе `generator_tool`. Поэтому минимальное значение айди сброшено в 0.
- Совсем мелкие фиксы типа "на сколько элементов в векторе делать reserve" и опечаток.