### PR TITLE
add selection of recycling types into OSM editor

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -34,6 +34,45 @@
         <!-- A list of values is hard-coded, so string in this case. -->
         <value type="string" many="yes" />
       </field>
+      <field name="recycling_type">
+        <tag k="recycling_type" />
+        <value type="list"/>
+          <option value="container" />
+          <option value="centre" />
+        </value>
+      </field>
+      <field name="recycling_batteries">
+        <tag k="recycling:batteries" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_cans">
+        <tag k="recycling:cans" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_clothes">
+        <tag k="recycling:clothes" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_glass_bottles">
+        <tag k="recycling:glass_bottles" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_paper">
+        <tag k="recycling:paper" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_plastic_bottles">
+        <tag k="recycling:plastic_bottles" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_scrap_metal">
+        <tag k="recycling:scrap_metal" />
+        <value type="boolean" />
+      </field>
+      <field name="recycling_small_appliances">
+        <tag k="recycling:small_appliances" />
+        <value type="boolean" />
+      </field>
       <field name="opening_hours">
         <tag k="opening_hours" />
       </field>
@@ -307,6 +346,15 @@
         <include field="internet" />
       </type>
       <type id="amenity-recycling">
+        <include field="recycling_type" />
+        <include field="recycling_batteries" />
+        <include field="recycling_cans" />
+        <include field="recycling_clothes" />
+        <include field="recycling_glass_bottles" />
+        <include field="recycling_paper" />
+        <include field="recycling_plastic_bottles" />
+        <include field="recycling_scrap_metal" />
+        <include field="recycling_small_appliances" />
         <include field="name" />
         <include field="operator" />
         <include field="website" />


### PR DESCRIPTION
First of all, thank you for completing implementation of recycling types view. I got it on my phone and it is working!

Я показал эту функцию московским активистам, выступающим за раздельный сбор мусора (и его уменьшение в целом), и оказалось что MAPS.ME может служить заменой заброшенному сайту https://recyclemap.ru/

Единственный запрос от них - это возможность добавлять recycling-контейнеры прямо из MAPS.ME

Для этого я добавил самые распространённые типы собираемого вторсырья ( из https://wiki.openstreetmap.org/wiki/Tag:amenity%3Drecycling ). Я не тестировал свои изменения, надеюсь они будут работать из коробки и вам не придётся ничего дорабатывать.