### PR TITLE
[routing] Fix for crash in debug mode in A* UpdateProgress.

### DIFF
--- a/routing/base/astar_progress.cpp
+++ b/routing/base/astar_progress.cpp
@@ -101,7 +101,10 @@ double AStarProgress::UpdateProgress(ms::LatLon const & current, ms::LatLon cons
   double const newProgress = UpdateProgressImpl(m_subProgresses.begin(), current, end) * 100.0;
   m_lastPercentValue = std::max(m_lastPercentValue, newProgress);
 
-  ASSERT_LESS_OR_EQUAL(m_lastPercentValue, kMaxPercent, ());
+  ASSERT(m_lastPercentValue < kMaxPercent ||
+             base::AlmostEqualAbs(m_lastPercentValue, kMaxPercent, 1e-5 /* eps */),
+         (m_lastPercentValue, kMaxPercent));
+
   m_lastPercentValue = std::min(m_lastPercentValue, kMaxPercent);
   return m_lastPercentValue;
 }


### PR DESCRIPTION
Во время работы routes_builder_tool в дебаге периодически срабатывает assert:

```
LOG TID(1) INFO      19.7545 routes_builder_tool/utils.cpp:140 BuildRoutes() Progress: 4 %
TID(2) ASSERT FAILED
base/astar_progress.cpp:104
CHECK(m_lastPercentValue <= kMaxPercent) 99 99
Assertion failed: (false), function UpdateProgress, file /Users/o.khlopkova/forked/omim/routing/base/astar_progress.cpp, line 104.
```

Это происходит, когда в `ASSERT_LESS_OR_EQUAL(m_lastPercentValue, kMaxPercent, ());` в `routing/base/astar_progress.cpp` некорректно сравниваются числа с плавающей точкой, которые не могут быть представлены точно. Например m_lastPercentValue=99.000000082 и kMaxPercent=99.000000000.


