### PR TITLE
[transit] Add links from stop to transfer.

### DIFF
--- a/transit/experimental/transit_types_experimental.cpp
+++ b/transit/experimental/transit_types_experimental.cpp
@@ -178,12 +178,13 @@ osmoh::OpeningHours Line::GetServiceDays() const { return m_serviceDays; }
 Stop::Stop() : m_ids(true /* serializeFeatureIdOnly */) {}
 
 Stop::Stop(TransitId id, FeatureId featureId, OsmId osmId, Translations const & title,
-           TimeTable const & timetable, m2::PointD const & point)
+           TimeTable const & timetable, m2::PointD const & point, IdList const & transferIds)
   : m_id(id)
   , m_ids(featureId, osmId, true /* serializeFeatureIdOnly */)
   , m_title(title)
   , m_timetable(timetable)
   , m_point(point)
+  , m_transferIds(transferIds)
 {
 }
 
@@ -221,6 +222,8 @@ std::string Stop::GetTitle() const { return GetTranslation(m_title); }
 TimeTable const & Stop::GetTimeTable() const { return m_timetable; }
 
 m2::PointD const & Stop::GetPoint() const { return m_point; }
+
+IdList const & Stop::GetTransferIds() const { return m_transferIds; }
 
 void Stop::SetBestPedestrianSegments(std::vector<SingleMwmSegment> const & seg)
 {

--- a/transit/experimental/transit_types_experimental.hpp
+++ b/transit/experimental/transit_types_experimental.hpp
@@ -234,7 +234,7 @@ class Stop
 public:
   Stop();
   Stop(TransitId id, FeatureId featureId, OsmId osmId, Translations const & title,
-       TimeTable const & timetable, m2::PointD const & point);
+       TimeTable const & timetable, m2::PointD const & point, IdList const & transferIds);
   explicit Stop(TransitId id);
 
   bool operator<(Stop const & rhs) const;
@@ -251,13 +251,14 @@ public:
   std::string GetTitle() const;
   TimeTable const & GetTimeTable() const;
   m2::PointD const & GetPoint() const;
+  IdList const & GetTransferIds() const;
 
 private:
   DECLARE_TRANSIT_TYPES_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Stop, visitor(m_id, "id"), visitor(m_ids, "id_bundle"),
                                   visitor(m_bestPedestrianSegments, "best_pedestrian_segments"),
                                   visitor(m_title, "title"), visitor(m_timetable, "timetable"),
-                                  visitor(m_point, "point"))
+                                  visitor(m_point, "point"), visitor(m_transferIds, "transfer_ids"))
   TransitId m_id = kInvalidTransitId;
   IdBundle m_ids;
   // |m_bestPedestrianSegments| are segments which can be used for pedestrian routing to leave and
@@ -267,6 +268,7 @@ private:
   Translations m_title;
   TimeTable m_timetable;
   m2::PointD m_point;
+  IdList m_transferIds;
 };
 
 class Gate

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -174,6 +174,10 @@ UNIT_TEST(ReadJson_Stop)
                "line_id":4036591562,
                "arrivals":"15:23-15:23 open"
              }
+           ],
+           "transfer_ids":[
+             4036593809,
+             4036595406
            ]
          })"};
 
@@ -182,7 +186,7 @@ UNIT_TEST(ReadJson_Stop)
            Translations{{"default", "Balfour Rd & Foothill Dr"}},
            TimeTable{{4036591493, osmoh::OpeningHours("13:23-13:23 open")},
                      {4036591562, osmoh::OpeningHours("15:23-15:23 open")}},
-           m2::PointD(-121.74124, 41.04276))};
+           m2::PointD(-121.74124, 41.04276), {4036593809, 4036595406} /* transferIds */)};
 
   std::vector<Stop> stopsFact;
 

--- a/transit/transit_experimental_tests/transit_serdes_tests.cpp
+++ b/transit/transit_experimental_tests/transit_serdes_tests.cpp
@@ -152,10 +152,10 @@ TransitData FillTestTransitData()
                                  {4026636458, osmoh::OpeningHours("05:00-05:00 open")},
                                  {4026636458, osmoh::OpeningHours("05:30-05:30 open")},
                                  {4026952369, osmoh::OpeningHours("15:30-15:30 open")}},
-                       m2::PointD(-58.57196, -36.82596)),
+                       m2::PointD(-58.57196, -36.82596), {} /* transferIds */),
                   Stop(4026990854 /* id */, kInvalidFeatureId /* featureId */,
                        kInvalidOsmId /* osmId */, Translations{{"default", "QUIROGA 1901-1999"}},
-                       TimeTable{}, m2::PointD(-58.57196, -36.82967))};
+                       TimeTable{}, m2::PointD(-58.57196, -36.82967), {} /* transferIds */)};
 
   data.SetStopPedestrianSegments(
       0 /* stopIdx */,

--- a/transit/transit_tests/transit_tools.hpp
+++ b/transit/transit_tests/transit_tools.hpp
@@ -60,9 +60,10 @@ inline bool Equal(Line const & l1, Line const & l2)
 inline bool Equal(Stop const & s1, Stop const & s2)
 {
   return (std::make_tuple(s1.GetId(), s1.GetFeatureId(), s1.GetOsmId(), s1.GetTitle(),
-                          s1.GetTimeTable(), s1.GetBestPedestrianSegments()) ==
+                          s1.GetTimeTable(), s1.GetTransferIds(), s1.GetBestPedestrianSegments()) ==
           std::make_tuple(s2.GetId(), s2.GetFeatureId(), s2.GetOsmId(), s2.GetTitle(),
-                          s2.GetTimeTable(), s2.GetBestPedestrianSegments())) &&
+                          s2.GetTimeTable(), s2.GetTransferIds(),
+                          s2.GetBestPedestrianSegments())) &&
          base::AlmostEqualAbs(s1.GetPoint(), s2.GetPoint(), kPointsEqualEpsilon);
 }
 

--- a/transit/world_feed/subway_converter.cpp
+++ b/transit/world_feed/subway_converter.cpp
@@ -331,6 +331,10 @@ bool SubwayConverter::ConvertTransfers()
   {
     auto const [transferId, transferData] = MakeTransfer(transferSubway);
     m_feed.m_transfers.m_data.emplace(transferId, transferData);
+
+    // All stops are already present in |m_feed| before the |ConvertTransfers()| call.
+    for (auto stopId : transferData.m_stopsIds)
+      LinkTransferIdToStop(m_feed.m_stops.m_data.at(stopId), transferId);
   }
 
   LOG(LINFO, ("Converted", m_feed.m_transfers.m_data.size(),

--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -123,6 +123,9 @@ struct StopData
   // |m_timetable| can be left empty.
   TimeTable m_timetable;
 
+  // Ids of transfer nodes containing this stop.
+  IdList m_transferIds;
+
   uint64_t m_osmId = 0;
 
   // Field not intended for dumping to json:
@@ -427,4 +430,7 @@ auto BuildHash(Values... values)
 
   return hash;
 }
+
+// Inserts |transferId| into the |stop| m_transferIds if it isn't already present there.
+void LinkTransferIdToStop(StopData & stop, TransitId transferId);
 }  // namespace transit


### PR DESCRIPTION
При подготовке реквеста про работу с экспериментальным транзитом в рантайме #13353 всплыло, что я забыла добавить в объект остановки поле "айди пересадок". В этом поле перечисляются пересадки, в которых фигурирует айдишник остановки. 

Данный реквест это исправляет.