### PR TITLE
No issue crash in workmanager

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,7 @@ dependencies {
   implementation 'com.android.installreferrer:installreferrer:1.0'
 
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+  implementation 'androidx.work:work-runtime:2.2.0'
   implementation 'com.android.billingclient:billing:1.1'
   implementation 'uk.co.samuelwall:material-tap-target-prompt:2.12.1'
   implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
@@ -154,6 +155,7 @@ configurations.all {
     force 'androidx.arch.core:core-common:2.0.0-rc01'
     force 'androidx.arch.core:core-runtime:2.0.0-rc01'
     force 'androidx.lifecycle:lifecycle-livedata-core:2.0.0-rc01'
+    force 'androidx.work:work-runtime:2.2.0'
     force "org.jetbrains.kotlin:kotlin-stdlib:1.3.31"
     force "com.google.code.gson:gson:2.8.5"
     force "com.google.guava:guava:27.0.1-jre"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,8 +2,8 @@ propMinSdkVersion=21
 propTargetSdkVersion=28
 propCompileSdkVersion=28
 propBuildToolsVersion=27.0.3
-propVersionCode=1014
-propVersionName=10.1.4
+propVersionCode=1015
+propVersionName=10.1.5
 propDebugNdkFlags=V=1 NDK_DEBUG=1 DEBUG=1
 propReleaseNdkFlags=V=1 NDK_DEBUG=0 PRODUCTION=1
 propSupportLibraryVersion=27.1.1


### PR DESCRIPTION
Обновил зависимость для WorkManager'a до 2.2.0 версии, в которой был пофикшен крэш https://developer.android.com/jetpack/androidx/releases/work#2.2.0-rc01 . Сам крэш вот :
Fatal Exception: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.net.conn.CONNECTIVITY_CHANGE flg=0x4000010 bqHint=4 (has extras) } in androidx.work.impl.constraints.trackers.NetworkStateTracker$NetworkStateBroadcastReceiver@7d7eb5e
       at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:988)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:145)
       at android.app.ActivityThread.main(ActivityThread.java:6917)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)

Caused by java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@3602d3a1 rejected from java.util.concurrent.ScheduledThreadPoolExecutor@2b3559c6[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
       at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2011)
       at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:793)
       at java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:298)
       at java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:503)
       at java.util.concurrent.Executors$DelegatedScheduledExecutorService.schedule(Executors.java:644)
       at androidx.work.impl.background.systemalarm.WorkTimer.startTimer(WorkTimer.java:82)
       at androidx.work.impl.background.systemalarm.DelayMetCommandHandler.onAllConstraintsMet(DelayMetCommandHandler.java:100)
       at androidx.work.impl.constraints.WorkConstraintsTracker.onConstraintMet(WorkConstraintsTracker.java:150)
       at androidx.work.impl.constraints.controllers.ConstraintController.updateCallback(ConstraintController.java:134)
       at androidx.work.impl.constraints.controllers.ConstraintController.onConstraintChanged(ConstraintController.java:141)
       at androidx.work.impl.constraints.trackers.ConstraintTracker.setState(ConstraintTracker.java:103)
       at androidx.work.impl.constraints.trackers.NetworkStateTracker$NetworkStateBroadcastReceiver.onReceive(NetworkStateTracker.java:170)
       at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:978)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:145)
       at android.app.ActivityThread.main(ActivityThread.java:6917)
       at java.lang.reflect.Method.invoke(Method.java)

https://console.firebase.google.com/u/1/project/mapsmestats/crashlytics/app/android:com.mapswithme.maps.pro/issues/1b8291542524d0a523d0fec8f635aef0?time=last-seven-days&sessionId=5F1FA954030F00014A753FB7A1502C70_DNE_0_v2