### PR TITLE
[data] Handle cycleway=opposite_lane.

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -39,6 +39,7 @@ office=notary : office=lawyer
 office=administrative : office=government
 
 amenity=monastery : amenity=place_of_worship
+cycleway=opposite_lane : oneway:bicycle=no
 
 power = transformer : power = substation
 


### PR DESCRIPTION
[MAPSME-14244](https://jira.mail.ru/browse/MAPSME-14244)

Судя по маппингу в ОСМ, ситуаций, когда присутствует тег cycleway=opposite_lane, но при этом есть другие теги, говорящие, что по другим полосам велосипедам проезд запрещен ("oneway:bicycle"="yes"), всего 28 штук. И большинство из них некорректны. Поэтому предлагаю присутствие тега cycleway=opposite_lane считать возможностью велосипеда ехать в обе стороны.

Например:
[OSM way](https://www.openstreetmap.org/way/440561496)
<img width="884" alt="image" src="https://user-images.githubusercontent.com/54934129/88650123-1ce91100-d0d1-11ea-87f3-c320dd44c80d.png">

До реквеста мы не ведем "против движения": 
<img width="400" alt="Screenshot 2020-07-27 at 15 31 57" src="https://user-images.githubusercontent.com/54934129/88676074-53845300-d0f4-11ea-9ff1-f7dc8ae7e306.png">

После реквеста ведем в обе стороны:
<img width="400" alt="Screenshot 2020-07-27 at 18 39 03" src="https://user-images.githubusercontent.com/54934129/88676276-8dedf000-d0f4-11ea-8962-422764175e5d.png">
