### PR TITLE
[transit] Squeeze experimental transit section.

### DIFF
--- a/transit/experimental/transit_types_experimental.hpp
+++ b/transit/experimental/transit_types_experimental.hpp
@@ -225,6 +225,7 @@ private:
   ShapeLink m_shapeLink;
   Translations m_title;
   IdList m_stopIds;
+  // Join lines with identical shape, route and stops but different m_intervals and m_serviceDays:
   std::vector<LineInterval> m_intervals;
   osmoh::OpeningHours m_serviceDays;
 };
@@ -265,7 +266,9 @@ private:
   // enter the gate. The segments may be invalid because of map date. If so there's no pedestrian
   // segment which can be used to reach the stop.
   std::vector<SingleMwmSegment> m_bestPedestrianSegments;
+  // Replace Translations with std::string:
   Translations m_title;
+  // Replace osmoh::OpeningHours with something new:
   TimeTable m_timetable;
   m2::PointD m_point;
   IdList m_transferIds;


### PR DESCRIPTION
@bykoianko @maksimandrianov **План ревью:** 1) обсуждаем дескрипшен 2) после того, как всем все будет ок, добавляю реализацию.

**Проблема:** экспериментальная транзитная секция занимает многовато места. В среднем случае 3-5Мб (это еще норм, но можно лучше), в худшем - удваивает размер mwm.

**Что уже сделано для ужатия секции:**
- айди всех gtfs сущностей (кроме ребер) теперь находятся не в интервале транзитных фич, а начинаются с нуля. Они полностью оторваны от других айди в рантайме мапсми, поэтому могут принимать любые значения. Это сделано в реквесте #13448. Айди ребер расчитываются генератором и от этого изменения не пострадают. Это поможет сэкономить места в секции, но совсем немного.

**Предложения для бОльшего ужатия:**

1.  **ГОТОВО** Только около 6 - 7% фидов содержат переводы на другие языки. Часть из этих переводов выполнена с отклонениями от спецификациями и правильно распарсить ее не получается. Поэтому для хранения наименований (название остановки, маршрута, оператора и тд) предлагаю отказаться от хранения строк в мапе с ключом - языком и значением - наименованием. В подавляющем большинстве случаев язык один, и мапа сосотоит из одного элемента `"default"="some text"`. Если исходить из того, что фид представлен в дефолтном для мвм языке, то достаточно хранить просто строку. Если мы начнем активно генерить переводы сами, то будем их хранить в дополнительном опциональном поле. 
2.  **ГОТОВО** Для хранения расписаний и времени прибытия/отправления с остановки был выбран `osmoh::OpeningHours`. Причина: он уже используется у нас в `access conditional`. Но он объективно очень долго (де)сериализуется строка <---> класс и занимает много места в секции (потому что сохраняется как строка). Предлагаю написать новый нормальный класс, заточенный на хранение расписаний. Еще два важных недостатка osmoh::OpeningHours - он не умеет хранить точку времени (НЕ интервал); не умеет работать с секундами. А нам обе этих вещи нужны для расписания остановок: в каких-то фидах время прибытия и отправления с остановки одинаковы (точка времени, не интервал), в каких-то - отличаются секунд на 20-40. 
3.  **ГОТОВО** За отдельную линию мы считаем линии с различными m_intervals и m_serviceDays. Даже если остановки, полилиния и маршрут совпадают. Предлагаю склеивать такие линии в одну с сохранением вложенности "в какие serviceDays какие ходят m_intervals".