### PR TITLE
[drape_frontend][transit] Subway layer from experimental transit section.

### DIFF
--- a/drape_frontend/transit_scheme_builder.cpp
+++ b/drape_frontend/transit_scheme_builder.cpp
@@ -9,7 +9,6 @@
 #include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/text_layout.hpp"
 #include "drape_frontend/text_shape.hpp"
-#include "drape_frontend/visual_params.hpp"
 
 #include "shaders/programs.hpp"
 
@@ -19,7 +18,12 @@
 #include "drape/render_bucket.hpp"
 #include "drape/utils/vertex_decl.hpp"
 
+#include "geometry/mercator.hpp"
+
+#include "base/assert.hpp"
 #include "base/string_utils.hpp"
+
+#include <algorithm>
 
 using namespace std;
 
@@ -56,7 +60,10 @@ std::string const kTransitTransferOuterColor = "TransitTransferOuterMarker";
 std::string const kTransitTransferInnerColor = "TransitTransferInnerMarker";
 std::string const kTransitStopInnerColor = "TransitStopInnerMarker";
 
-float const kTransitMarkTextSize = 11.0f;
+float constexpr kTransitMarkTextSize = 11.0f;
+
+static std::unordered_set<std::string> const kSubwayTypes{"subway", "train", "light_rail",
+                                                          "monorail"};
 
 struct TransitStaticVertex
 {
@@ -98,43 +105,10 @@ dp::BindingInfo const & GetTransitStaticBindingInfo()
   return *s_info;
 }
 
-void GenerateLineCaps(ref_ptr<dp::GraphicsContext> context,
-                      std::vector<SchemeSegment> const & segments, glsl::vec4 const & color,
-                      float lineOffset, float halfWidth, float depth, dp::Batcher & batcher)
-{
-  using TV = TransitStaticVertex;
-
-  TGeometryBuffer geometry;
-  geometry.reserve(segments.size() * 3);
-
-  for (auto const & segment : segments)
-  {
-    // Here we use an equilateral triangle to render a circle (incircle of a triangle).
-    static float const kSqrt3 = sqrt(3.0f);
-    auto const offset = lineOffset * segment.m_rightNormal;
-    auto const pivot = glsl::vec3(segment.m_p2, depth);
-
-    auto const n1 = glsl::vec2(-2.0 * halfWidth, -halfWidth);
-    auto const n2 = glsl::vec2(2.0 * halfWidth, -halfWidth);
-    auto const n3 = glsl::vec2(0.0f, (2.0f * kSqrt3 - 1.0f) * halfWidth);
-
-    geometry.emplace_back(pivot, TV::TNormal(-offset, n1), color);
-    geometry.emplace_back(pivot, TV::TNormal(-offset, n2), color);
-    geometry.emplace_back(pivot, TV::TNormal(-offset, n3), color);
-  }
-
-  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
-  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(), make_ref(geometry.data()));
-  auto state = CreateRenderState(gpu::Program::TransitCircle, DepthLayer::TransitSchemeLayer);
-  batcher.InsertTriangleList(context, state, make_ref(&provider));
-}
-
 struct TitleInfo
 {
   TitleInfo() = default;
-  explicit TitleInfo(std::string const & text)
-    : m_text(text)
-  {}
+  explicit TitleInfo(std::string const & text) : m_text(text) {}
 
   std::string m_text;
   size_t m_rowsCount = 0;
@@ -143,7 +117,7 @@ struct TitleInfo
   dp::Anchor m_anchor = dp::Left;
 };
 
-std::vector<TitleInfo> PlaceTitles(StopNodeParams const & stopParams, float textSize,
+std::vector<TitleInfo> PlaceTitles(StopNodeParamsSubway const & stopParams, float textSize,
                                    ref_ptr<dp::TextureManager> textures)
 {
   std::vector<TitleInfo> titles;
@@ -178,7 +152,8 @@ std::vector<TitleInfo> PlaceTitles(StopNodeParams const & stopParams, float text
       summaryRowsCount += layout.GetRowsCount();
     }
 
-    auto const rightRowsCount = summaryRowsCount > 3 ? (summaryRowsCount + 1) / 2 : summaryRowsCount;
+    auto const rightRowsCount =
+        summaryRowsCount > 3 ? (summaryRowsCount + 1) / 2 : summaryRowsCount;
     float rightHeight = 0.0f;
     float leftHeight = 0.0f;
     size_t rowsCount = 0;
@@ -216,26 +191,117 @@ std::vector<TitleInfo> PlaceTitles(StopNodeParams const & stopParams, float text
   return titles;
 }
 
-vector<m2::PointF> GetTransitMarkerSizes(float markerScale, float maxRouteWidth)
+std::vector<TitleInfo> PlaceTitles(StopNodeParamsPT const & stopParams, float textSize,
+                                   ref_ptr<dp::TextureManager> textures)
 {
-  auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
-  vector<m2::PointF> markerSizes;
-  markerSizes.reserve(df::kTransitLinesWidthInPixel.size());
-  for (auto const halfWidth : df::kTransitLinesWidthInPixel)
+  std::vector<TitleInfo> titles;
+  for (auto const & stopInfo : stopParams.m_stopsInfo)
   {
-    float const d = 2.0f * std::min(halfWidth * vs, maxRouteWidth * 0.5f) * markerScale;
-    markerSizes.push_back(m2::PointF(d, d));
+    if (stopInfo.second.m_name.empty())
+      continue;
+    bool isUnique = true;
+    for (auto const & title : titles)
+    {
+      if (title.m_text == stopInfo.second.m_name)
+      {
+        isUnique = false;
+        break;
+      }
+    }
+    if (isUnique)
+      titles.emplace_back(stopInfo.second.m_name);
   }
-  return markerSizes;
+
+  if (titles.size() > 1)
+  {
+    auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
+
+    size_t summaryRowsCount = 0;
+    for (auto & name : titles)
+    {
+      df::StraightTextLayout layout(strings::MakeUniString(name.m_text), textSize,
+                                    false /* isSdf */, textures, dp::Left, false /* forceNoWrap */);
+      name.m_pixelSize = layout.GetPixelSize() + m2::PointF(4.0f * vs, 4.0f * vs);
+      name.m_rowsCount = layout.GetRowsCount();
+      summaryRowsCount += layout.GetRowsCount();
+    }
+
+    auto const rightRowsCount =
+        summaryRowsCount > 3 ? (summaryRowsCount + 1) / 2 : summaryRowsCount;
+    float rightHeight = 0.0f;
+    float leftHeight = 0.0f;
+    size_t rowsCount = 0;
+    size_t rightTitlesCount = 0;
+    for (size_t i = 0; i < titles.size(); ++i)
+    {
+      if (rowsCount < rightRowsCount)
+      {
+        rightHeight += titles[i].m_pixelSize.y;
+        ++rightTitlesCount;
+      }
+      else
+      {
+        leftHeight += titles[i].m_pixelSize.y;
+      }
+      rowsCount += titles[i].m_rowsCount;
+    }
+
+    float currentOffset = -rightHeight / 2.0f;
+    for (size_t i = 0; i < rightTitlesCount; ++i)
+    {
+      titles[i].m_anchor = dp::Left;
+      titles[i].m_offset.y = currentOffset + titles[i].m_pixelSize.y / 2.0f;
+      currentOffset += titles[i].m_pixelSize.y;
+    }
+
+    currentOffset = -leftHeight / 2.0f;
+    for (size_t i = rightTitlesCount; i < titles.size(); ++i)
+    {
+      titles[i].m_anchor = dp::Right;
+      titles[i].m_offset.y = currentOffset + titles[i].m_pixelSize.y / 2.0f;
+      currentOffset += titles[i].m_pixelSize.y;
+    }
+  }
+  return titles;
 }
 
-uint32_t GetRouteId(routing::transit::LineId lineId)
+void GenerateLineCaps(ref_ptr<dp::GraphicsContext> context,
+                      std::vector<SchemeSegment> const & segments, glsl::vec4 const & color,
+                      float lineOffset, float halfWidth, float depth, dp::Batcher & batcher)
 {
-  return static_cast<uint32_t>(lineId >> 4);
+  using TV = TransitStaticVertex;
+
+  TGeometryBuffer geometry;
+  geometry.reserve(segments.size() * 3);
+
+  for (auto const & segment : segments)
+  {
+    // Here we use an equilateral triangle to render a circle (incircle of a triangle).
+    static float const kSqrt3 = sqrt(3.0f);
+    auto const offset = lineOffset * segment.m_rightNormal;
+    auto const pivot = glsl::vec3(segment.m_p2, depth);
+
+    auto const n1 = glsl::vec2(-2.0 * halfWidth, -halfWidth);
+    auto const n2 = glsl::vec2(2.0 * halfWidth, -halfWidth);
+    auto const n3 = glsl::vec2(0.0f, (2.0f * kSqrt3 - 1.0f) * halfWidth);
+
+    geometry.emplace_back(pivot, TV::TNormal(-offset, n1), color);
+    geometry.emplace_back(pivot, TV::TNormal(-offset, n2), color);
+    geometry.emplace_back(pivot, TV::TNormal(-offset, n3), color);
+  }
+
+  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
+  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(),
+                      make_ref(geometry.data()));
+  auto state = CreateRenderState(gpu::Program::TransitCircle, DepthLayer::TransitSchemeLayer);
+  batcher.InsertTriangleList(context, state, make_ref(&provider));
 }
 
-void FillStopParams(TransitDisplayInfo const & transitDisplayInfo, MwmSet::MwmId const & mwmId,
-                    routing::transit::Stop const & stop, StopNodeParams & stopParams)
+uint32_t GetRouteId(routing::transit::LineId lineId) { return static_cast<uint32_t>(lineId >> 4); }
+
+void FillStopParamsSubway(TransitDisplayInfo const & transitDisplayInfo,
+                          MwmSet::MwmId const & mwmId, routing::transit::Stop const & stop,
+                          StopNodeParamsSubway & stopParams)
 {
   FeatureID featureId;
   std::string title;
@@ -249,6 +315,32 @@ void FillStopParams(TransitDisplayInfo const & transitDisplayInfo, MwmSet::MwmId
   for (auto lineId : stop.GetLineIds())
   {
     StopInfo & info = stopParams.m_stopsInfo[GetRouteId(lineId)];
+    info.m_featureId = featureId;
+    info.m_name = title;
+    info.m_lines.insert(lineId);
+  }
+}
+
+void FillStopParamsPT(TransitDisplayInfo const & transitDisplayInfo, MwmSet::MwmId const & mwmId,
+                      ::transit::experimental::Stop const & stop, ::transit::IdSet const & lineIds,
+                      StopNodeParamsPT & stopParams)
+{
+  FeatureID featureId;
+  std::string title;
+
+  if (stop.GetFeatureId() != routing::transit::kInvalidFeatureId)
+  {
+    featureId = FeatureID(mwmId, stop.GetFeatureId());
+    title = transitDisplayInfo.m_features.at(featureId).m_title;
+  }
+
+  stopParams.m_isTransfer = false;
+  stopParams.m_pivot = stop.GetPoint();
+
+  for (auto lineId : lineIds)
+  {
+    ::transit::TransitId const routeId = transitDisplayInfo.m_linesPT.at(lineId).GetRouteId();
+    StopInfo & info = stopParams.m_stopsInfo[routeId];
     info.m_featureId = featureId;
     info.m_name = title;
     info.m_lines.insert(lineId);
@@ -282,26 +374,70 @@ bool FindLongerPath(routing::transit::StopId stop1Id, routing::transit::StopId s
 }
 }  // namespace
 
+std::string TransitSchemeBuilder::MwmSchemeData::GetLineColor(::transit::TransitId lineId) const
+{
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
+  {
+    return m_linesSubway.at(lineId).m_color;
+  }
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+  {
+    return m_linesPT.at(lineId).m_color;
+  }
+  UNREACHABLE();
+}
+
+float TransitSchemeBuilder::MwmSchemeData::GetLineDepth(::transit::TransitId lineId) const
+{
+  if (m_transitVersion == ::transit::TransitVersion::OnlySubway)
+  {
+    return m_linesSubway.at(lineId).m_depth;
+  }
+  else if (m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+  {
+    return m_linesPT.at(lineId).m_depth;
+  }
+  UNREACHABLE();
+}
+
 void TransitSchemeBuilder::UpdateSchemes(ref_ptr<dp::GraphicsContext> context,
                                          TransitDisplayInfos const & transitDisplayInfos,
                                          ref_ptr<dp::TextureManager> textures)
 {
-  for (auto const & mwmInfo : transitDisplayInfos)
+  for (auto const & [mwmId, transitDisplayInfoPtr] : transitDisplayInfos)
   {
-    if (!mwmInfo.second)
+    if (!transitDisplayInfoPtr)
       continue;
 
-    auto const & mwmId = mwmInfo.first;
-    auto const & transitDisplayInfo = *mwmInfo.second.get();
+    auto const & transitDisplayInfo = *transitDisplayInfoPtr.get();
 
     MwmSchemeData & scheme = m_schemes[mwmId];
+    scheme.m_transitVersion = transitDisplayInfo.m_transitVersion;
 
-    CollectStops(transitDisplayInfo, mwmId, scheme);
-    CollectLines(transitDisplayInfo, scheme);
-    CollectShapes(transitDisplayInfo, scheme);
+    if (scheme.m_transitVersion == ::transit::TransitVersion::OnlySubway)
+    {
+      CollectStopsSubway(transitDisplayInfo, mwmId, scheme);
+      CollectLinesSubway(transitDisplayInfo, scheme);
+      CollectShapesSubway(transitDisplayInfo, scheme);
 
-    PrepareScheme(scheme);
-    BuildScheme(context, mwmId, textures);
+      PrepareSchemeSubway(scheme);
+      BuildScheme(context, mwmId, textures);
+    }
+    else if (scheme.m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+    {
+      LinesDataPT const & linesData = CollectLinesPT(transitDisplayInfo, scheme);
+
+      CollectStopsPT(transitDisplayInfo, linesData, mwmId, scheme);
+      CollectShapesPT(transitDisplayInfo, scheme);
+
+      PrepareSchemePT(transitDisplayInfo, scheme);
+      BuildScheme(context, mwmId, textures);
+    }
+    else
+    {
+      LOG(LERROR, (scheme.m_transitVersion));
+      UNREACHABLE();
+    }
   }
 }
 
@@ -328,27 +464,99 @@ void TransitSchemeBuilder::BuildScheme(ref_ptr<dp::GraphicsContext> context,
 {
   if (m_schemes.find(mwmId) == m_schemes.end())
     return;
+
   ++m_recacheId;
   GenerateShapes(context, mwmId);
   GenerateStops(context, mwmId, textures);
 }
 
-void TransitSchemeBuilder::CollectStops(TransitDisplayInfo const & transitDisplayInfo,
-                                        MwmSet::MwmId const & mwmId, MwmSchemeData & scheme)
+void TransitSchemeBuilder::GenerateLinesSubway(MwmSchemeData const & scheme, dp::Batcher & batcher,
+                                               ref_ptr<dp::GraphicsContext> context)
 {
+  for (auto const & shape : scheme.m_shapesSubway)
+  {
+    size_t const linesCount =
+        shape.second.m_forwardLines.size() + shape.second.m_backwardLines.size();
+    float shapeOffset = -static_cast<float>(linesCount / 2) * 2.0f -
+                        1.0f * static_cast<float>(linesCount % 2) + 1.0f;
+    size_t constexpr shapeOffsetIncrement = 2.0f;
+
+    std::vector<std::pair<dp::Color, routing::transit::LineId>> coloredLines;
+
+    for (auto lineId : shape.second.m_forwardLines)
+    {
+      auto const colorName = df::GetTransitColorName(scheme.GetLineColor(lineId));
+      auto const color = GetColorConstant(colorName);
+      coloredLines.emplace_back(color, lineId);
+    }
+
+    for (auto it = shape.second.m_backwardLines.rbegin(); it != shape.second.m_backwardLines.rend();
+         ++it)
+    {
+      auto const colorName = df::GetTransitColorName(scheme.GetLineColor(*it));
+      auto const color = GetColorConstant(colorName);
+      coloredLines.emplace_back(color, *it);
+    }
+
+    for (auto const & coloredLine : coloredLines)
+    {
+      auto const & colorConst = coloredLine.first;
+      auto const & lineId = coloredLine.second;
+      auto const depth = scheme.GetLineDepth(lineId);
+
+      GenerateLine(context, shape.second.m_polyline, scheme.m_pivot, colorConst, shapeOffset,
+                   kTransitLineHalfWidth, depth, batcher);
+
+      shapeOffset += shapeOffsetIncrement;
+    }
+  }
+}
+
+void TransitSchemeBuilder::GenerateLinesPT(MwmSchemeData const & scheme, dp::Batcher & batcher,
+                                           ref_ptr<dp::GraphicsContext> context)
+{
+  for (auto const & [routeId, data] : scheme.m_shapeHierarchyPT)
+  {
+    dp::Color const color = GetColorConstant(df::GetTransitColorName(data.m_color));
+
+    for (auto const & routeData : data.m_routeShapes)
+    {
+      auto const start = ms::LatLon(52.54896573047641084, 13.388990046182382088);
+      auto const end = ms::LatLon(52.549313637305999691, 13.414450707060183277);
+
+      if (base::AlmostEqualAbs(mercator::ToLatLon(routeData.m_polyline.front()), start, 1e-5) &&
+          base::AlmostEqualAbs(mercator::ToLatLon(routeData.m_polyline.back()), end, 1e-5))
+        LOG(LINFO, ("TTT route", routeId, "not inverse", "order", routeData.m_order));
+
+      if (base::AlmostEqualAbs(mercator::ToLatLon(routeData.m_polyline.back()), start, 1e-5) &&
+          base::AlmostEqualAbs(mercator::ToLatLon(routeData.m_polyline.front()), end, 1e-5))
+        LOG(LINFO, ("TTT route", routeId, "inverse", "order", routeData.m_order));
+
+      float const offset = static_cast<float>(routeData.m_order);
+      GenerateLine(context, routeData.m_polyline, scheme.m_pivot, color, offset,
+                   kTransitLineHalfWidth, kBaseLineDepth, batcher);
+    }
+  }
+}
+
+void TransitSchemeBuilder::CollectStopsSubway(TransitDisplayInfo const & transitDisplayInfo,
+                                              MwmSet::MwmId const & mwmId, MwmSchemeData & scheme)
+{
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   for (auto const & stopInfo : transitDisplayInfo.m_stopsSubway)
   {
     routing::transit::Stop const & stop = stopInfo.second;
     if (stop.GetTransferId() != routing::transit::kInvalidTransferId)
       continue;
-    auto & stopNode = scheme.m_stops[stop.GetId()];
-    FillStopParams(transitDisplayInfo, mwmId, stop, stopNode);
+    auto & stopNode = scheme.m_stopsSubway[stop.GetId()];
+    FillStopParamsSubway(transitDisplayInfo, mwmId, stop, stopNode);
   }
 
   for (auto const & stopInfo : transitDisplayInfo.m_transfersSubway)
   {
     routing::transit::Transfer const & transfer = stopInfo.second;
-    auto & stopNode = scheme.m_transfers[transfer.GetId()];
+    auto & stopNode = scheme.m_transfersSubway[transfer.GetId()];
 
     for (auto stopId : transfer.GetStopIds())
     {
@@ -358,15 +566,63 @@ void TransitSchemeBuilder::CollectStops(TransitDisplayInfo const & transitDispla
         continue;
       }
       routing::transit::Stop const & stop = transitDisplayInfo.m_stopsSubway.at(stopId);
-      FillStopParams(transitDisplayInfo, mwmId, stop, stopNode);
+      FillStopParamsSubway(transitDisplayInfo, mwmId, stop, stopNode);
     }
     stopNode.m_isTransfer = true;
     stopNode.m_pivot = transfer.GetPoint();
   }
 }
 
-void TransitSchemeBuilder::CollectLines(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme)
+void TransitSchemeBuilder::CollectStopsPT(TransitDisplayInfo const & transitDisplayInfo,
+                                          LinesDataPT const & linesData,
+                                          MwmSet::MwmId const & mwmId, MwmSchemeData & scheme)
 {
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::AllPublicTransport,
+              ());
+
+  for (auto const & [stopId, lineIds] : linesData.m_stopToLineIds)
+  {
+    ::transit::experimental::Stop const & stop = transitDisplayInfo.m_stopsPT.at(stopId);
+
+    if (!stop.GetTransferIds().empty())
+      continue;
+
+    FillStopParamsPT(transitDisplayInfo, mwmId, stop, lineIds, scheme.m_stopsPT[stopId]);
+
+    scheme.m_stopsPT[stopId].m_isTerminalStop =
+        (linesData.m_terminalStops.find(stopId) != linesData.m_terminalStops.end());
+  }
+
+  for (auto const & transferInfo : transitDisplayInfo.m_transfersPT)
+  {
+    ::transit::experimental::Transfer const & transfer = transferInfo.second;
+    auto & transferNode = scheme.m_transfersPT[transfer.GetId()];
+
+    for (auto stopId : transfer.GetStopIds())
+    {
+      auto itIds = linesData.m_stopToLineIds.find(stopId);
+      if (itIds == linesData.m_stopToLineIds.end())
+        continue;
+
+      auto it = transitDisplayInfo.m_stopsPT.find(stopId);
+      if (it == transitDisplayInfo.m_stopsPT.end())
+        continue;
+
+      ::transit::experimental::Stop const & stop = it->second;
+      FillStopParamsPT(transitDisplayInfo, mwmId, stop, itIds->second, transferNode);
+      transferNode.m_stopsInfo.emplace(stopId, StopInfo());
+    }
+
+    transferNode.m_isTransfer = true;
+    transferNode.m_pivot = transfer.GetPoint();
+  }
+}
+
+void TransitSchemeBuilder::CollectLinesSubway(TransitDisplayInfo const & transitDisplayInfo,
+                                              MwmSchemeData & scheme)
+{
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   std::multimap<size_t, routing::transit::LineId> linesLengths;
   for (auto const & line : transitDisplayInfo.m_linesSubway)
   {
@@ -381,15 +637,51 @@ void TransitSchemeBuilder::CollectLines(TransitDisplayInfo const & transitDispla
   for (auto const & pair : linesLengths)
   {
     auto const lineId = pair.second;
-    scheme.m_lines[lineId] =
+
+    scheme.m_linesSubway[lineId] =
         LineParams(transitDisplayInfo.m_linesSubway.at(lineId).GetColor(), depth);
+
     depth += kDepthPerLine;
   }
 }
 
-void TransitSchemeBuilder::CollectShapes(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme)
+LinesDataPT TransitSchemeBuilder::CollectLinesPT(TransitDisplayInfo const & transitDisplayInfo,
+                                                 MwmSchemeData & scheme)
 {
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::AllPublicTransport,
+              ());
+
+  LinesDataPT linesData;
+
+  for (auto const & [lineId, line] : transitDisplayInfo.m_linesPT)
+  {
+    auto const & lineType = transitDisplayInfo.m_routesPT.at(line.GetRouteId()).GetType();
+
+    // We skip types that are not mentioned for displaying on the layer - buses, ferries, etc.
+    if (kSubwayTypes.find(lineType) == kSubwayTypes.end())
+      continue;
+
+    for (auto stopId : line.GetStopIds())
+      linesData.m_stopToLineIds[stopId].insert(lineId);
+
+    linesData.m_terminalStops.insert(line.GetStopIds().front());
+    linesData.m_terminalStops.insert(line.GetStopIds().back());
+
+    scheme.m_linesPT[lineId] =
+        LineParams(transitDisplayInfo.m_routesPT.at(line.GetRouteId()).GetColor(), kBaseLineDepth);
+    scheme.m_linesPT[lineId].m_stopIds = line.GetStopIds();
+  }
+
+  return linesData;
+}
+
+void TransitSchemeBuilder::CollectShapesSubway(TransitDisplayInfo const & transitDisplayInfo,
+                                               MwmSchemeData & scheme)
+{
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::OnlySubway, ());
+
   std::map<uint32_t, std::vector<routing::transit::LineId>> roads;
+
   for (auto const & line : transitDisplayInfo.m_linesSubway)
   {
     auto const lineId = line.second.GetId();
@@ -411,10 +703,56 @@ void TransitSchemeBuilder::CollectShapes(TransitDisplayInfo const & transitDispl
   }
 }
 
-void TransitSchemeBuilder::FindShapes(routing::transit::StopId stop1Id, routing::transit::StopId stop2Id,
+void TransitSchemeBuilder::CollectShapesPT(TransitDisplayInfo const & transitDisplayInfo,
+                                           MwmSchemeData & scheme)
+{
+  CHECK_EQUAL(transitDisplayInfo.m_transitVersion, ::transit::TransitVersion::AllPublicTransport,
+              ());
+
+  using LineAndShapeLink = std::pair<::transit::TransitId, ::transit::ShapeLink>;
+
+  std::map<::transit::TransitId, std::vector<LineAndShapeLink>> routesToLines;
+
+  for (auto const & [lineId, lineParams] : scheme.m_linesPT)
+  {
+    auto const & line = transitDisplayInfo.m_linesPT.at(lineId);
+    auto const & shapeLink = line.GetShapeLink();
+    ::transit::TransitId routeId = line.GetRouteId();
+    auto const & color = transitDisplayInfo.m_routesPT.at(routeId).GetColor();
+
+    scheme.m_shapeHierarchyPT[routeId].m_color = color;
+    routesToLines[routeId].emplace_back(lineId, shapeLink);
+  }
+
+  for (auto const & [routeId, linesAndLinks] : routesToLines)
+  {
+    auto & route = scheme.m_shapeHierarchyPT[routeId];
+
+    for (auto const & [lineId, shapeLink] : linesAndLinks)
+    {
+      auto const & shape = transitDisplayInfo.m_shapesPT.at(shapeLink.m_shapeId).GetPolyline();
+      auto itMetadata = transitDisplayInfo.m_linesMetadataPT.find(lineId);
+      if (itMetadata == transitDisplayInfo.m_linesMetadataPT.end())
+        continue;
+
+      for (auto const & part : itMetadata->second.GetLineSegmentsOrder())
+      {
+        RouteSegment rs;
+        rs.m_polyline =
+            ::transit::GetPolylinePart(shape, part.m_segment.m_startIdx, part.m_segment.m_endIdx);
+        rs.m_order = part.m_order;
+        route.m_routeShapes.push_back(rs);
+      }
+    }
+  }
+}
+
+void TransitSchemeBuilder::FindShapes(routing::transit::StopId stop1Id,
+                                      routing::transit::StopId stop2Id,
                                       routing::transit::LineId lineId,
                                       std::vector<routing::transit::LineId> const & sameLines,
-                                      TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme)
+                                      TransitDisplayInfo const & transitDisplayInfo,
+                                      MwmSchemeData & scheme)
 {
   bool shapeAdded = false;
 
@@ -478,15 +816,15 @@ void TransitSchemeBuilder::AddShape(TransitDisplayInfo const & transitDisplayInf
   if (it == transitDisplayInfo.m_shapesSubway.end())
     return;
 
-  auto const itScheme = scheme.m_shapes.find(shapeId);
-  if (itScheme == scheme.m_shapes.end())
+  auto const itScheme = scheme.m_shapesSubway.find(shapeId);
+  if (itScheme == scheme.m_shapesSubway.end())
   {
     auto const & polyline = transitDisplayInfo.m_shapesSubway.at(it->first).GetPolyline();
     if (isForward)
-      scheme.m_shapes[shapeId].m_forwardLines.push_back(lineId);
+      scheme.m_shapesSubway[shapeId].m_forwardLines.push_back(lineId);
     else
-      scheme.m_shapes[shapeId].m_backwardLines.push_back(lineId);
-    scheme.m_shapes[shapeId].m_polyline = polyline;
+      scheme.m_shapesSubway[shapeId].m_backwardLines.push_back(lineId);
+    scheme.m_shapesSubway[shapeId].m_polyline = polyline;
   }
   else
   {
@@ -508,17 +846,22 @@ void TransitSchemeBuilder::AddShape(TransitDisplayInfo const & transitDisplayInf
   }
 }
 
-void TransitSchemeBuilder::PrepareScheme(MwmSchemeData & scheme)
+void TransitSchemeBuilder::PrepareSchemeSubway(MwmSchemeData & scheme)
 {
   m2::RectD boundingRect;
-  for (auto const & shape : scheme.m_shapes)
+
+  for (auto const & shape : scheme.m_shapesSubway)
   {
     auto const stop1 = shape.first.GetStop1Id();
     auto const stop2 = shape.first.GetStop2Id();
-    StopNodeParams & params1 = (scheme.m_stops.find(stop1) == scheme.m_stops.end()) ? scheme.m_transfers[stop1]
-                                                                                    : scheme.m_stops[stop1];
-    StopNodeParams & params2 = (scheme.m_stops.find(stop2) == scheme.m_stops.end()) ? scheme.m_transfers[stop2]
-                                                                                    : scheme.m_stops[stop2];
+    StopNodeParamsSubway & params1 =
+        (scheme.m_stopsSubway.find(stop1) == scheme.m_stopsSubway.end())
+            ? scheme.m_transfersSubway[stop1]
+            : scheme.m_stopsSubway[stop1];
+    StopNodeParamsSubway & params2 =
+        (scheme.m_stopsSubway.find(stop2) == scheme.m_stopsSubway.end())
+            ? scheme.m_transfersSubway[stop2]
+            : scheme.m_stopsSubway[stop2];
 
     auto const linesCount = shape.second.m_forwardLines.size() + shape.second.m_backwardLines.size();
 
@@ -536,6 +879,90 @@ void TransitSchemeBuilder::PrepareScheme(MwmSchemeData & scheme)
     for (auto const & pt : shape.second.m_polyline)
       boundingRect.Add(pt);
   }
+
+  scheme.m_pivot = boundingRect.Center();
+}
+
+void TransitSchemeBuilder::PrepareSchemePT(TransitDisplayInfo const & transitDisplayInfo,
+                                           MwmSchemeData & scheme)
+{
+  m2::RectD boundingRect;
+  std::unordered_set<::transit::TransitId> handledStopIds;
+
+  for (auto const & [lineId, lineData] : scheme.m_linesPT)
+  {
+    for (size_t i = 0; i < lineData.m_stopIds.size() - 1; ++i)
+    {
+      ::transit::TransitId stop1Id = lineData.m_stopIds[i];
+      ::transit::TransitId stop2Id = lineData.m_stopIds[i + 1];
+
+      if (!handledStopIds.insert(stop1Id).second && !handledStopIds.insert(stop2Id).second)
+        continue;
+
+      StopNodeParamsPT & params1 = (scheme.m_stopsPT.find(stop1Id) == scheme.m_stopsPT.end())
+                                       ? scheme.m_transfersPT[stop1Id]
+                                       : scheme.m_stopsPT[stop1Id];
+
+      StopNodeParamsPT & params2 = (scheme.m_stopsPT.find(stop2Id) == scheme.m_stopsPT.end())
+                                       ? scheme.m_transfersPT[stop2Id]
+                                       : scheme.m_stopsPT[stop2Id];
+
+      size_t constexpr minLinesCount = 1;
+
+      params1.m_shapeInfo.m_linesCount = std::max(minLinesCount, params1.m_stopsInfo.size());
+      params2.m_shapeInfo.m_linesCount = std::max(minLinesCount, params2.m_stopsInfo.size());
+
+      auto it = transitDisplayInfo.m_edgesPT.find(::transit::EdgeId(stop1Id, stop2Id, lineId));
+
+      if (it == transitDisplayInfo.m_edgesPT.end())
+      {
+        params1.m_shapeInfo.m_direction = (params2.m_pivot - params1.m_pivot).Normalize();
+        params2.m_shapeInfo.m_direction = (params1.m_pivot - params2.m_pivot).Normalize();
+      }
+      else
+      {
+        ::transit::ShapeLink const & shapeLink = it->second.m_shapeLink;
+        auto const & polyline = transitDisplayInfo.m_shapesPT.at(shapeLink.m_shapeId).GetPolyline();
+
+        size_t startIndex = std::min(shapeLink.m_startIndex, shapeLink.m_endIndex);
+        size_t endIndex = std::max(shapeLink.m_startIndex, shapeLink.m_endIndex);
+
+        params1.m_shapeInfo.m_direction =
+            (polyline[startIndex + 1] - polyline[startIndex]).Normalize();
+        params2.m_shapeInfo.m_direction = (polyline[endIndex] - polyline[endIndex - 1]).Normalize();
+
+        if (shapeLink.m_startIndex > shapeLink.m_endIndex)
+          std::swap(params1.m_shapeInfo.m_direction, params2.m_shapeInfo.m_direction);
+
+        for (size_t j = shapeLink.m_startIndex; j <= shapeLink.m_endIndex; ++j)
+          boundingRect.Add(polyline[j]);
+      }
+    }
+  }
+
+  for (auto & [transferId, transferData] : scheme.m_transfersPT)
+  {
+    if (!transferData.m_isTransfer)
+      continue;
+
+    auto const & transfer = transitDisplayInfo.m_transfersPT.at(transferId);
+    std::vector<m2::PointD> pivots;
+
+    for (::transit::TransitId stopId : transfer.GetStopIds())
+    {
+      auto const & stop = transitDisplayInfo.m_stopsPT.at(stopId);
+      pivots.push_back(stop.GetPoint());
+
+      if (pivots.size() == 2)
+        break;
+    }
+
+    CHECK_EQUAL(pivots.size(), 2, ());
+
+    transferData.m_shapeInfo.m_direction = (pivots[1] - pivots[0]).Normalize();
+    transferData.m_shapeInfo.m_linesCount = transfer.GetStopIds().size();
+  }
+
   scheme.m_pivot = boundingRect.Center();
 }
 
@@ -543,7 +970,7 @@ void TransitSchemeBuilder::GenerateShapes(ref_ptr<dp::GraphicsContext> context, 
 {
   MwmSchemeData const & scheme = m_schemes[mwmId];
 
-  uint32_t const kBatchSize = 65000;
+  uint32_t constexpr kBatchSize = 65000;
   dp::Batcher batcher(kBatchSize, kBatchSize);
   batcher.SetBatcherHash(static_cast<uint64_t>(BatcherBucket::Transit));
   {
@@ -557,36 +984,14 @@ void TransitSchemeBuilder::GenerateShapes(ref_ptr<dp::GraphicsContext> context, 
       m_flushRenderDataFn(std::move(renderData));
     });
 
-    for (auto const & shape : scheme.m_shapes)
+    if (scheme.m_transitVersion == ::transit::TransitVersion::OnlySubway)
+      GenerateLinesSubway(scheme, batcher, context);
+    else if (scheme.m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+      GenerateLinesPT(scheme, batcher, context);
+    else
     {
-      auto const linesCount = shape.second.m_forwardLines.size() + shape.second.m_backwardLines.size();
-      auto shapeOffset = -static_cast<float>(linesCount / 2) * 2.0f - 1.0f * static_cast<float>(linesCount % 2) + 1.0f;
-      auto const shapeOffsetIncrement = 2.0f;
-
-      std::vector<std::pair<dp::Color, routing::transit::LineId>> coloredLines;
-      for (auto lineId : shape.second.m_forwardLines)
-      {
-        auto const colorName = df::GetTransitColorName(scheme.m_lines.at(lineId).m_color);
-        auto const color = GetColorConstant(colorName);
-        coloredLines.push_back(std::make_pair(color, lineId));
-      }
-      for (auto it = shape.second.m_backwardLines.rbegin(); it != shape.second.m_backwardLines.rend(); ++it)
-      {
-        auto const colorName = df::GetTransitColorName(scheme.m_lines.at(*it).m_color);
-        auto const color = GetColorConstant(colorName);
-        coloredLines.push_back(std::make_pair(color, *it));
-      }
-
-      for (auto const & coloredLine : coloredLines)
-      {
-        auto const & colorConst = coloredLine.first;
-        auto const & lineId = coloredLine.second;
-        auto const depth = scheme.m_lines.at(lineId).m_depth;
-
-        GenerateLine(context, shape.second.m_polyline, scheme.m_pivot, colorConst, shapeOffset,
-                     kTransitLineHalfWidth, depth, batcher);
-        shapeOffset += shapeOffsetIncrement;
-      }
+      LOG(LERROR, (scheme.m_transitVersion));
+      UNREACHABLE();
     }
   }
 }
@@ -608,86 +1013,190 @@ void TransitSchemeBuilder::GenerateStops(ref_ptr<dp::GraphicsContext> context, M
     m_flushRenderDataFn(std::move(renderData));
   };
 
-  uint32_t const kBatchSize = 5000;
+  uint32_t constexpr kBatchSize = 5000;
   dp::Batcher batcher(kBatchSize, kBatchSize);
+
   batcher.SetBatcherHash(static_cast<uint64_t>(BatcherBucket::Transit));
+  if (scheme.m_transitVersion == ::transit::TransitVersion::OnlySubway)
   {
-    dp::SessionGuard guard(context, batcher, flusher);
-
-    float const kStopScale = 2.5f;
-    float const kTransferScale = 3.0f;
-    std::vector<m2::PointF> const transferMarkerSizes = GetTransitMarkerSizes(kTransferScale, 1000);
-    std::vector<m2::PointF> const stopMarkerSizes = GetTransitMarkerSizes(kStopScale, 1000);
-
-    for (auto const & stop : scheme.m_stops)
-    {
-      GenerateStop(context, stop.second, scheme.m_pivot, scheme.m_lines, batcher);
-      GenerateTitles(context, stop.second, scheme.m_pivot, stopMarkerSizes, textures, batcher);
-    }
-    for (auto const & transfer : scheme.m_transfers)
-    {
-      GenerateTransfer(context, transfer.second, scheme.m_pivot, batcher);
-      GenerateTitles(context, transfer.second, scheme.m_pivot, transferMarkerSizes, textures, batcher);
-    }
+    GenerateLocationsWithTitles(context, textures, batcher, flusher, scheme, scheme.m_stopsSubway,
+                                scheme.m_transfersSubway, scheme.m_linesSubway);
+  }
+  else if (scheme.m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+  {
+    GenerateLocationsWithTitles(context, textures, batcher, flusher, scheme, scheme.m_stopsPT,
+                                scheme.m_transfersPT, scheme.m_linesPT);
+  }
+  else
+  {
+    LOG(LERROR, (scheme.m_transitVersion));
+    UNREACHABLE();
   }
 }
 
-void TransitSchemeBuilder::GenerateTransfer(ref_ptr<dp::GraphicsContext> context,
-                                            StopNodeParams const & params, m2::PointD const & pivot,
-                                            dp::Batcher & batcher)
+void TransitSchemeBuilder::GenerateMarker(ref_ptr<dp::GraphicsContext> context,
+                                          m2::PointD const & pt, m2::PointD widthDir,
+                                          float linesCountWidth, float linesCountHeight,
+                                          float scaleWidth, float scaleHeight, float depth,
+                                          dp::Color const & color, dp::Batcher & batcher)
 {
-  m2::PointD const pt = MapShape::ConvertToLocal(params.m_pivot, pivot, kShapeCoordScalar);
+  using TV = TransitStaticVertex;
 
-  size_t maxLinesCount = 0;
-  m2::PointD dir;
-  for (auto const & shapeInfo : params.m_shapesInfo)
-  {
-    if (shapeInfo.second.m_linesCount > maxLinesCount)
-    {
-      dir = shapeInfo.second.m_direction;
-      maxLinesCount = shapeInfo.second.m_linesCount;
-    }
-  }
+  scaleWidth = (scaleWidth - 1.0f) / linesCountWidth + 1.0f;
+  scaleHeight = (scaleHeight - 1.0f) / linesCountHeight + 1.0f;
 
-  float const kInnerScale = 1.0f;
-  float const kOuterScale = 1.5f;
-  auto const outerColor = GetColorConstant(kTransitTransferOuterColor);
-  auto const innerColor = GetColorConstant(kTransitTransferInnerColor);
+  widthDir.y = -widthDir.y;
+  m2::PointD heightDir = widthDir.Ort();
 
-  float const widthLinesCount = maxLinesCount > 3 ? 1.6f : 1.0f;
-  float const innerScale = maxLinesCount == 1 ? 1.4f : kInnerScale;
-  float const outerScale = maxLinesCount == 1 ? 1.9f : kOuterScale;
+  auto const v1 =
+      -widthDir * scaleWidth * linesCountWidth - heightDir * scaleHeight * linesCountHeight;
+  auto const v2 =
+      widthDir * scaleWidth * linesCountWidth - heightDir * scaleHeight * linesCountHeight;
+  auto const v3 =
+      widthDir * scaleWidth * linesCountWidth + heightDir * scaleHeight * linesCountHeight;
+  auto const v4 =
+      -widthDir * scaleWidth * linesCountWidth + heightDir * scaleHeight * linesCountHeight;
 
-  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, outerScale, outerScale,
-                 kOuterMarkerDepth, outerColor, batcher);
+  glsl::vec3 const pos(pt.x, pt.y, depth);
+  auto const colorVal =
+      glsl::vec4(color.GetRedF(), color.GetGreenF(), color.GetBlueF(), 1.0f /* alpha */);
 
-  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, innerScale, innerScale,
-                 kInnerMarkerDepth, innerColor, batcher);
+  TGeometryBuffer geometry;
+  geometry.reserve(6);
+  geometry.emplace_back(pos, TV::TNormal(v1.x, v1.y, -linesCountWidth, -linesCountHeight),
+                        colorVal);
+  geometry.emplace_back(pos, TV::TNormal(v2.x, v2.y, linesCountWidth, -linesCountHeight), colorVal);
+  geometry.emplace_back(pos, TV::TNormal(v3.x, v3.y, linesCountWidth, linesCountHeight), colorVal);
+  geometry.emplace_back(pos, TV::TNormal(v1.x, v1.y, -linesCountWidth, -linesCountHeight),
+                        colorVal);
+  geometry.emplace_back(pos, TV::TNormal(v3.x, v3.y, linesCountWidth, linesCountHeight), colorVal);
+  geometry.emplace_back(pos, TV::TNormal(v4.x, v4.y, -linesCountWidth, linesCountHeight), colorVal);
+
+  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
+  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(),
+                      make_ref(geometry.data()));
+  auto state = CreateRenderState(gpu::Program::TransitMarker, DepthLayer::TransitSchemeLayer);
+  batcher.InsertTriangleList(context, state, make_ref(&provider));
 }
 
-void TransitSchemeBuilder::GenerateStop(ref_ptr<dp::GraphicsContext> context, StopNodeParams const & params,
-                                        m2::PointD const & pivot, std::map<routing::transit::LineId,
-                                        LineParams> const & lines, dp::Batcher & batcher)
+void TransitSchemeBuilder::GenerateLine(ref_ptr<dp::GraphicsContext> context,
+                                        std::vector<m2::PointD> const & path,
+                                        m2::PointD const & pivot, dp::Color const & colorConst,
+                                        float lineOffset, float halfWidth, float depth,
+                                        dp::Batcher & batcher)
 {
-  bool const severalRoads = params.m_stopsInfo.size() > 1;
+  using TV = TransitStaticVertex;
+
+  TGeometryBuffer geometry;
+  auto const color = glsl::vec4(colorConst.GetRedF(), colorConst.GetGreenF(), colorConst.GetBlueF(),
+                                1.0f /* alpha */);
+  size_t const kAverageSize = path.size() * 6;
+  size_t const kAverageCapSize = 12;
+  geometry.reserve(kAverageSize + kAverageCapSize * 2);
+
+  std::vector<SchemeSegment> segments;
+  segments.reserve(path.size() - 1);
+
+  for (size_t i = 1; i < path.size(); ++i)
+  {
+    if (path[i].EqualDxDy(path[i - 1], 1.0e-5))
+      continue;
+
+    SchemeSegment segment;
+    segment.m_p1 = glsl::ToVec2(MapShape::ConvertToLocal(path[i - 1], pivot, kShapeCoordScalar));
+    segment.m_p2 = glsl::ToVec2(MapShape::ConvertToLocal(path[i], pivot, kShapeCoordScalar));
+    CalculateTangentAndNormals(segment.m_p1, segment.m_p2, segment.m_tangent, segment.m_leftNormal,
+                               segment.m_rightNormal);
+
+    auto const startPivot = glsl::vec3(segment.m_p1, depth);
+    auto const endPivot = glsl::vec3(segment.m_p2, depth);
+    auto const offset = lineOffset * segment.m_rightNormal;
+
+    geometry.emplace_back(startPivot,
+                          TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0),
+                          color);
+    geometry.emplace_back(
+        startPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
+    geometry.emplace_back(
+        endPivot, TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0), color);
+    geometry.emplace_back(
+        endPivot, TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0), color);
+    geometry.emplace_back(
+        startPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
+    geometry.emplace_back(
+        endPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
+
+    segments.emplace_back(std::move(segment));
+  }
+
+  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
+  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(),
+                      make_ref(geometry.data()));
+  auto state = CreateRenderState(gpu::Program::Transit, DepthLayer::TransitSchemeLayer);
+  batcher.InsertTriangleList(context, state, make_ref(&provider));
+
+  GenerateLineCaps(context, segments, color, lineOffset, halfWidth, depth, batcher);
+}
+
+void TransitSchemeBuilder::GenerateStop(
+    ref_ptr<dp::GraphicsContext> context, StopNodeParamsSubway const & stopParams,
+    m2::PointD const & pivot, std::map<routing::transit::LineId, LineParams> const & lines,
+    dp::Batcher & batcher)
+{
+  bool const severalRoads = stopParams.m_stopsInfo.size() > 1;
+
   if (severalRoads)
   {
-    GenerateTransfer(context, params, pivot, batcher);
+    GenerateTransfer(context, stopParams, pivot, batcher);
     return;
   }
 
   float const kInnerScale = 0.8f;
   float const kOuterScale = 2.0f;
 
-  auto const lineId = *params.m_stopsInfo.begin()->second.m_lines.begin();
+  auto const lineId = *stopParams.m_stopsInfo.begin()->second.m_lines.begin();
   auto const colorName = df::GetTransitColorName(lines.at(lineId).m_color);
   auto const outerColor = GetColorConstant(colorName);
 
   auto const innerColor = GetColorConstant(kTransitStopInnerColor);
 
-  m2::PointD const pt = MapShape::ConvertToLocal(params.m_pivot, pivot, kShapeCoordScalar);
+  m2::PointD const pt = MapShape::ConvertToLocal(stopParams.m_pivot, pivot, kShapeCoordScalar);
 
-  m2::PointD dir = params.m_shapesInfo.begin()->second.m_direction;
+  m2::PointD dir = stopParams.m_shapesInfo.begin()->second.m_direction;
+
+  GenerateMarker(context, pt, dir, 1.0f, 1.0f, kOuterScale, kOuterScale, kOuterMarkerDepth,
+                 outerColor, batcher);
+
+  GenerateMarker(context, pt, dir, 1.0f, 1.0f, kInnerScale, kInnerScale, kInnerMarkerDepth,
+                 innerColor, batcher);
+}
+
+void TransitSchemeBuilder::GenerateStop(
+    ref_ptr<dp::GraphicsContext> context, StopNodeParamsPT const & stopParams,
+    m2::PointD const & pivot, std::map<routing::transit::LineId, LineParams> const & lines,
+    dp::Batcher & batcher)
+{
+  bool const severalRoads = stopParams.m_stopsInfo.size() > 1;
+
+  if (severalRoads)
+  {
+    GenerateTransfer(context, stopParams, pivot, batcher);
+    return;
+  }
+
+  float const kInnerScale = 0.8f;
+  float const kOuterScale = 2.0f;
+
+  ::transit::TransitId lineId = *stopParams.m_stopsInfo.begin()->second.m_lines.begin();
+
+  std::string const colorName = df::GetTransitColorName(lines.at(lineId).m_color);
+  auto const outerColor = GetColorConstant(colorName);
+
+  auto const innerColor = GetColorConstant(kTransitStopInnerColor);
+
+  m2::PointD const pt = MapShape::ConvertToLocal(stopParams.m_pivot, pivot, kShapeCoordScalar);
+
+  m2::PointD dir = stopParams.m_shapeInfo.m_direction;
 
   GenerateMarker(context, pt, dir, 1.0f, 1.0f, kOuterScale, kOuterScale, kOuterMarkerDepth,
                  outerColor, batcher);
@@ -697,7 +1206,7 @@ void TransitSchemeBuilder::GenerateStop(ref_ptr<dp::GraphicsContext> context, St
 }
 
 void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
-                                          StopNodeParams const & stopParams,
+                                          StopNodeParamsSubway const & stopParams,
                                           m2::PointD const & pivot,
                                           std::vector<m2::PointF> const & markerSizes,
                                           ref_ptr<dp::TextureManager> textures,
@@ -711,7 +1220,8 @@ void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
 
   auto const featureId = stopParams.m_stopsInfo.begin()->second.m_featureId;
 
-  auto priority = static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMin : Priority::StopMin);
+  auto priority =
+      static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMin : Priority::StopMin);
   priority += static_cast<uint16_t>(stopParams.m_stopsInfo.size());
 
   auto minVisibleScale = stopParams.m_isTransfer ? kTransferMinZoomLevel : kStopMinZoomLevel;
@@ -723,8 +1233,10 @@ void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
     priority += kFinalStationPriorityInc;
   }
 
-  ASSERT_LESS_OR_EQUAL(priority, static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMax
-                                                                               : Priority::StopMax), ());
+  ASSERT_LESS_OR_EQUAL(
+      priority,
+      static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMax : Priority::StopMax),
+      ());
 
   std::vector<m2::PointF> symbolSizes;
   symbolSizes.reserve(markerSizes.size());
@@ -753,8 +1265,9 @@ void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
     textParams.m_startOverlayRank = dp::OverlayRank0;
     textParams.m_minVisibleScale = minVisibleScale;
 
-    TextShape(stopParams.m_pivot, textParams, TileKey(), symbolSizes,
-              title.m_offset, dp::Center, kTransitOverlayIndex).Draw(context, &batcher, textures);
+    TextShape(stopParams.m_pivot, textParams, TileKey(), symbolSizes, title.m_offset, dp::Center,
+              kTransitOverlayIndex)
+        .Draw(context, &batcher, textures);
   }
 
   df::ColoredSymbolViewParams colorParams;
@@ -768,94 +1281,148 @@ void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
   colorParams.m_specialPriority = static_cast<uint16_t>(Priority::Stub);
   colorParams.m_startOverlayRank = dp::OverlayRank0;
 
-  ColoredSymbolShape(stopParams.m_pivot, colorParams, TileKey(),
-                     kTransitStubOverlayIndex, markerSizes).Draw(context, &batcher, textures);
+  ColoredSymbolShape(stopParams.m_pivot, colorParams, TileKey(), kTransitStubOverlayIndex,
+                     markerSizes)
+      .Draw(context, &batcher, textures);
 }
 
-void TransitSchemeBuilder::GenerateMarker(ref_ptr<dp::GraphicsContext> context,
-                                          m2::PointD const & pt, m2::PointD widthDir,
-                                          float linesCountWidth, float linesCountHeight,
-                                          float scaleWidth, float scaleHeight, float depth,
-                                          dp::Color const & color, dp::Batcher & batcher)
+void TransitSchemeBuilder::GenerateTitles(ref_ptr<dp::GraphicsContext> context,
+                                          StopNodeParamsPT const & stopParams,
+                                          m2::PointD const & pivot,
+                                          std::vector<m2::PointF> const & markerSizes,
+                                          ref_ptr<dp::TextureManager> textures,
+                                          dp::Batcher & batcher)
 {
-  using TV = TransitStaticVertex;
+  auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
 
-  scaleWidth = (scaleWidth - 1.0f) / linesCountWidth + 1.0f;
-  scaleHeight = (scaleHeight - 1.0f) / linesCountHeight + 1.0f;
+  auto const titles = PlaceTitles(stopParams, kTransitMarkTextSize * vs, textures);
+  if (titles.empty())
+    return;
 
-  widthDir.y = -widthDir.y;
-  m2::PointD heightDir = widthDir.Ort();
+  auto const featureId = stopParams.m_stopsInfo.begin()->second.m_featureId;
 
-  auto const v1 = -widthDir * scaleWidth * linesCountWidth - heightDir * scaleHeight * linesCountHeight;
-  auto const v2 = widthDir * scaleWidth * linesCountWidth - heightDir * scaleHeight * linesCountHeight;
-  auto const v3 = widthDir * scaleWidth * linesCountWidth + heightDir * scaleHeight * linesCountHeight;
-  auto const v4 = -widthDir * scaleWidth * linesCountWidth + heightDir * scaleHeight * linesCountHeight;
+  auto priority =
+      static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMin : Priority::StopMin);
+  priority += static_cast<uint16_t>(stopParams.m_stopsInfo.size());
 
-  glsl::vec3 const pos(pt.x, pt.y, depth);
-  auto const colorVal = glsl::vec4(color.GetRedF(), color.GetGreenF(), color.GetBlueF(), 1.0f /* alpha */ );
+  auto minVisibleScale = stopParams.m_isTransfer ? kTransferMinZoomLevel : kStopMinZoomLevel;
 
-  TGeometryBuffer geometry;
-  geometry.reserve(6);
-  geometry.emplace_back(pos, TV::TNormal(v1.x, v1.y, -linesCountWidth, -linesCountHeight), colorVal);
-  geometry.emplace_back(pos, TV::TNormal(v2.x, v2.y, linesCountWidth, -linesCountHeight), colorVal);
-  geometry.emplace_back(pos, TV::TNormal(v3.x, v3.y, linesCountWidth, linesCountHeight), colorVal);
-  geometry.emplace_back(pos, TV::TNormal(v1.x, v1.y, -linesCountWidth, -linesCountHeight), colorVal);
-  geometry.emplace_back(pos, TV::TNormal(v3.x, v3.y, linesCountWidth, linesCountHeight), colorVal);
-  geometry.emplace_back(pos, TV::TNormal(v4.x, v4.y, -linesCountWidth, linesCountHeight), colorVal);
-
-  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
-  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(), make_ref(geometry.data()));
-  auto state = CreateRenderState(gpu::Program::TransitMarker, DepthLayer::TransitSchemeLayer);
-  batcher.InsertTriangleList(context, state, make_ref(&provider));
-}
-
-void TransitSchemeBuilder::GenerateLine(ref_ptr<dp::GraphicsContext> context,
-                                        std::vector<m2::PointD> const & path,
-                                        m2::PointD const & pivot, dp::Color const & colorConst,
-                                        float lineOffset, float halfWidth, float depth,
-                                        dp::Batcher & batcher)
-{
-  using TV = TransitStaticVertex;
-
-  TGeometryBuffer geometry;
-  auto const color = glsl::vec4(colorConst.GetRedF(), colorConst.GetGreenF(), colorConst.GetBlueF(), 1.0f /* alpha */);
-  size_t const kAverageSize = path.size() * 6;
-  size_t const kAverageCapSize = 12;
-  geometry.reserve(kAverageSize + kAverageCapSize * 2);
-
-  std::vector<SchemeSegment> segments;
-  segments.reserve(path.size() - 1);
-
-  for (size_t i = 1; i < path.size(); ++i)
+  if (stopParams.m_isTerminalStop)
   {
-    if (path[i].EqualDxDy(path[i - 1], 1.0e-5))
-      continue;
-
-    SchemeSegment segment;
-    segment.m_p1 = glsl::ToVec2(MapShape::ConvertToLocal(path[i - 1], pivot, kShapeCoordScalar));
-    segment.m_p2 = glsl::ToVec2(MapShape::ConvertToLocal(path[i], pivot, kShapeCoordScalar));
-    CalculateTangentAndNormals(segment.m_p1, segment.m_p2, segment.m_tangent,
-                               segment.m_leftNormal, segment.m_rightNormal);
-
-    auto const startPivot = glsl::vec3(segment.m_p1, depth);
-    auto const endPivot = glsl::vec3(segment.m_p2, depth);
-    auto const offset = lineOffset * segment.m_rightNormal;
-
-    geometry.emplace_back(startPivot, TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0), color);
-    geometry.emplace_back(startPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
-    geometry.emplace_back(endPivot, TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0), color);
-    geometry.emplace_back(endPivot, TV::TNormal(segment.m_rightNormal * halfWidth - offset, -halfWidth, 0.0), color);
-    geometry.emplace_back(startPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
-    geometry.emplace_back(endPivot, TV::TNormal(segment.m_leftNormal * halfWidth - offset, halfWidth, 0.0), color);
-
-    segments.emplace_back(std::move(segment));
+    minVisibleScale = std::min(minVisibleScale, kFinalStationMinZoomLevel);
+    priority += kFinalStationPriorityInc;
   }
 
-  dp::AttributeProvider provider(1 /* stream count */, static_cast<uint32_t>(geometry.size()));
-  provider.InitStream(0 /* stream index */, GetTransitStaticBindingInfo(), make_ref(geometry.data()));
-  auto state = CreateRenderState(gpu::Program::Transit, DepthLayer::TransitSchemeLayer);
-  batcher.InsertTriangleList(context, state, make_ref(&provider));
+  ASSERT_LESS_OR_EQUAL(
+      priority,
+      static_cast<uint16_t>(stopParams.m_isTransfer ? Priority::TransferMax : Priority::StopMax),
+      ());
 
-  GenerateLineCaps(context, segments, color, lineOffset, halfWidth, depth, batcher);
+  std::vector<m2::PointF> symbolSizes;
+  symbolSizes.reserve(markerSizes.size());
+  for (auto const & sz : markerSizes)
+    symbolSizes.push_back(sz * 1.1f);
+
+  dp::TitleDecl titleDecl;
+  titleDecl.m_primaryOptional = true;
+  titleDecl.m_primaryTextFont.m_color = df::GetColorConstant(kTransitMarkText);
+  titleDecl.m_primaryTextFont.m_outlineColor = df::GetColorConstant(kTransitMarkTextOutline);
+  titleDecl.m_primaryTextFont.m_size = kTransitMarkTextSize * vs;
+  titleDecl.m_anchor = dp::Left;
+
+  for (auto const & title : titles)
+  {
+    TextViewParams textParams;
+    textParams.m_featureID = featureId;
+    textParams.m_tileCenter = pivot;
+    textParams.m_titleDecl = titleDecl;
+    textParams.m_titleDecl.m_primaryText = title.m_text;
+    textParams.m_titleDecl.m_anchor = title.m_anchor;
+    textParams.m_depthTestEnabled = false;
+    textParams.m_depthLayer = DepthLayer::TransitSchemeLayer;
+    textParams.m_specialDisplacement = SpecialDisplacement::SpecialModeUserMark;
+    textParams.m_specialPriority = priority;
+    textParams.m_startOverlayRank = dp::OverlayRank0;
+    textParams.m_minVisibleScale = minVisibleScale;
+
+    TextShape(stopParams.m_pivot, textParams, TileKey(), symbolSizes, title.m_offset, dp::Center,
+              kTransitOverlayIndex)
+        .Draw(context, &batcher, textures);
+  }
+
+  df::ColoredSymbolViewParams colorParams;
+  colorParams.m_radiusInPixels = markerSizes.front().x * 0.5f;
+  colorParams.m_color = dp::Color::Transparent();
+  colorParams.m_featureID = featureId;
+  colorParams.m_tileCenter = pivot;
+  colorParams.m_depthTestEnabled = false;
+  colorParams.m_depthLayer = DepthLayer::TransitSchemeLayer;
+  colorParams.m_specialDisplacement = SpecialDisplacement::SpecialModeUserMark;
+  colorParams.m_specialPriority = static_cast<uint16_t>(Priority::Stub);
+  colorParams.m_startOverlayRank = dp::OverlayRank0;
+
+  ColoredSymbolShape(stopParams.m_pivot, colorParams, TileKey(), kTransitStubOverlayIndex,
+                     markerSizes)
+      .Draw(context, &batcher, textures);
+}
+
+void TransitSchemeBuilder::GenerateTransfer(ref_ptr<dp::GraphicsContext> context,
+                                            StopNodeParamsSubway const & stopParams,
+                                            m2::PointD const & pivot, dp::Batcher & batcher)
+{
+  m2::PointD const pt = MapShape::ConvertToLocal(stopParams.m_pivot, pivot, kShapeCoordScalar);
+
+  size_t maxLinesCount = 0;
+  m2::PointD dir;
+  for (auto const & shapeInfo : stopParams.m_shapesInfo)
+  {
+    if (shapeInfo.second.m_linesCount > maxLinesCount)
+    {
+      dir = shapeInfo.second.m_direction;
+      maxLinesCount = shapeInfo.second.m_linesCount;
+    }
+  }
+
+  float const kInnerScale = 1.0f;
+  float const kOuterScale = 1.5f;
+
+  auto const outerColor = GetColorConstant(kTransitTransferOuterColor);
+  auto const innerColor = GetColorConstant(kTransitTransferInnerColor);
+
+  float const widthLinesCount = maxLinesCount > 3 ? 1.6f : 1.0f;
+  float const innerScale = maxLinesCount == 1 ? 1.4f : kInnerScale;
+  float const outerScale = maxLinesCount == 1 ? 1.9f : kOuterScale;
+
+  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, outerScale, outerScale,
+                 kOuterMarkerDepth, outerColor, batcher);
+
+  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, innerScale, innerScale,
+                 kInnerMarkerDepth, innerColor, batcher);
+}
+
+void TransitSchemeBuilder::GenerateTransfer(ref_ptr<dp::GraphicsContext> context,
+                                            StopNodeParamsPT const & stopParams,
+                                            m2::PointD const & pivot, dp::Batcher & batcher)
+{
+  m2::PointD const pt = MapShape::ConvertToLocal(stopParams.m_pivot, pivot, kShapeCoordScalar);
+
+  size_t const maxLinesCount = stopParams.m_shapeInfo.m_linesCount;
+  m2::PointD const & dir = stopParams.m_shapeInfo.m_direction;
+
+  float const kInnerScale = 1.0f;
+  float const kOuterScale = 1.5f;
+
+  auto const outerColor = GetColorConstant(kTransitTransferOuterColor);
+  auto const innerColor = GetColorConstant(kTransitTransferInnerColor);
+
+  float const widthLinesCount = maxLinesCount > 3 ? 1.6f : 1.0f;
+  float const innerScale = maxLinesCount == 1 ? 1.4f : kInnerScale;
+  float const outerScale = maxLinesCount == 1 ? 1.9f : kOuterScale;
+
+  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, outerScale, outerScale,
+                 kOuterMarkerDepth, outerColor, batcher);
+
+  GenerateMarker(context, pt, dir, widthLinesCount, maxLinesCount, innerScale, innerScale,
+                 kInnerMarkerDepth, innerColor, batcher);
 }
 }  // namespace df

--- a/drape_frontend/transit_scheme_builder.hpp
+++ b/drape_frontend/transit_scheme_builder.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "drape_frontend/visual_params.hpp"
+
 #include "drape/batcher.hpp"
 #include "drape/render_bucket.hpp"
 #include "drape/render_state.hpp"
 #include "drape/texture_manager.hpp"
 
 #include "transit/transit_display_info.hpp"
+#include "transit/transit_version.hpp"
 
 #include <functional>
 #include <map>
@@ -56,7 +59,8 @@ struct LineParams
     : m_color(color), m_depth(depth)
   {}
   std::string m_color;
-  float m_depth;
+  float m_depth = 0.0;
+  std::vector<::transit::TransitId> m_stopIds;
 };
 
 struct ShapeParams
@@ -69,7 +73,7 @@ struct ShapeParams
 struct ShapeInfo
 {
   m2::PointD m_direction;
-  size_t m_linesCount;
+  size_t m_linesCount = 0;
 };
 
 struct StopInfo
@@ -85,12 +89,57 @@ struct StopInfo
   std::set<routing::transit::LineId> m_lines;
 };
 
-struct StopNodeParams
+struct StopNodeParamsSubway
 {
   bool m_isTransfer = false;
   m2::PointD m_pivot;
   std::map<routing::transit::ShapeId, ShapeInfo> m_shapesInfo;
   std::map<uint32_t, StopInfo> m_stopsInfo;
+};
+
+struct StopNodeParamsPT
+{
+  bool m_isTransfer = false;
+  bool m_isTerminalStop = false;
+  m2::PointD m_pivot;
+  ShapeInfo m_shapeInfo;
+  // Route id to StopInfo mapping.
+  std::map<::transit::TransitId, StopInfo> m_stopsInfo;
+};
+
+using IdToIdSet = std::unordered_map<::transit::TransitId, ::transit::IdSet>;
+
+struct RouteSegment
+{
+  int m_order = 0;
+  std::vector<m2::PointD> m_polyline;
+};
+
+struct RouteData
+{
+  std::string m_color;
+  std::vector<RouteSegment> m_routeShapes;
+};
+
+inline std::vector<m2::PointF> GetTransitMarkerSizes(float markerScale, float maxRouteWidth)
+{
+  auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
+  std::vector<m2::PointF> markerSizes;
+  markerSizes.reserve(df::kTransitLinesWidthInPixel.size());
+
+  for (auto const halfWidth : df::kTransitLinesWidthInPixel)
+  {
+    float const d = 2.0f * std::min(halfWidth * vs, maxRouteWidth * 0.5f) * markerScale;
+    markerSizes.emplace_back(d, d);
+  }
+
+  return markerSizes;
+}
+
+struct LinesDataPT
+{
+  IdToIdSet m_stopToLineIds;
+  std::set<::transit::TransitId> m_terminalStops;
 };
 
 class TransitSchemeBuilder
@@ -125,23 +174,51 @@ public:
 private:
   struct MwmSchemeData
   {
+    std::string GetLineColor(::transit::TransitId lineId) const;
+    float GetLineDepth(::transit::TransitId lineId) const;
+
     m2::PointD m_pivot;
 
-    std::map<routing::transit::LineId, LineParams> m_lines;
-    std::map<routing::transit::ShapeId, ShapeParams> m_shapes;
-    std::map<routing::transit::StopId, StopNodeParams> m_stops;
-    std::map<routing::transit::TransferId, StopNodeParams> m_transfers;
+    ::transit::TransitVersion m_transitVersion;
+
+    std::map<routing::transit::LineId, LineParams> m_linesSubway;
+    std::map<routing::transit::ShapeId, ShapeParams> m_shapesSubway;
+    std::map<routing::transit::StopId, StopNodeParamsSubway> m_stopsSubway;
+    std::map<routing::transit::TransferId, StopNodeParamsSubway> m_transfersSubway;
+
+    std::map<::transit::TransitId, LineParams> m_linesPT;
+    // Route id to shapes params.
+    std::map<::transit::TransitId, RouteData> m_shapeHierarchyPT;
+    std::map<::transit::TransitId, StopNodeParamsPT> m_stopsPT;
+    std::map<::transit::TransitId, StopNodeParamsPT> m_transfersPT;
   };
 
   void BuildScheme(ref_ptr<dp::GraphicsContext> context, MwmSet::MwmId const & mwmId,
                    ref_ptr<dp::TextureManager> textures);
 
-  void CollectStops(TransitDisplayInfo const & transitDisplayInfo,
-                    MwmSet::MwmId const & mwmId, MwmSchemeData & scheme);
+  void GenerateLinesSubway(MwmSchemeData const & scheme, dp::Batcher & batcher,
+                           ref_ptr<dp::GraphicsContext> context);
 
-  void CollectLines(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+  void GenerateLinesPT(MwmSchemeData const & scheme, dp::Batcher & batcher,
+                       ref_ptr<dp::GraphicsContext> context);
 
-  void CollectShapes(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+  template <class F, class S, class T, class L>
+  void GenerateLocationsWithTitles(ref_ptr<dp::GraphicsContext> context,
+                                   ref_ptr<dp::TextureManager> textures, dp::Batcher & batcher,
+                                   F && flusher, MwmSchemeData const & scheme, S const & stops,
+                                   T const & transfers, L const & lines);
+
+  void CollectStopsSubway(TransitDisplayInfo const & transitDisplayInfo,
+                          MwmSet::MwmId const & mwmId, MwmSchemeData & scheme);
+  void CollectStopsPT(TransitDisplayInfo const & transitDisplayInfo, LinesDataPT const & linesData,
+                      MwmSet::MwmId const & mwmId, MwmSchemeData & scheme);
+
+  void CollectLinesSubway(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+  LinesDataPT CollectLinesPT(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+
+  void CollectShapesSubway(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+  void CollectShapesPT(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
+
   void FindShapes(routing::transit::StopId stop1Id, routing::transit::StopId stop2Id,
                   routing::transit::LineId lineId,
                   std::vector<routing::transit::LineId> const & sameLines,
@@ -149,7 +226,8 @@ private:
   void AddShape(TransitDisplayInfo const & transitDisplayInfo, routing::transit::StopId stop1Id,
                 routing::transit::StopId stop2Id, routing::transit::LineId lineId, MwmSchemeData & scheme);
 
-  void PrepareScheme(MwmSchemeData & scheme);
+  void PrepareSchemeSubway(MwmSchemeData & scheme);
+  void PrepareSchemePT(TransitDisplayInfo const & transitDisplayInfo, MwmSchemeData & scheme);
 
   void GenerateShapes(ref_ptr<dp::GraphicsContext> context, MwmSet::MwmId const & mwmId);
 
@@ -161,15 +239,28 @@ private:
                       float scaleWidth, float scaleHeight, float depth, dp::Color const & color,
                       dp::Batcher & batcher);
 
-  void GenerateTransfer(ref_ptr<dp::GraphicsContext> context, StopNodeParams const & params,
+  void GenerateTransfer(ref_ptr<dp::GraphicsContext> context,
+                        StopNodeParamsSubway const & stopParams, m2::PointD const & pivot,
+                        dp::Batcher & batcher);
+
+  void GenerateTransfer(ref_ptr<dp::GraphicsContext> context, StopNodeParamsPT const & stopParams,
                         m2::PointD const & pivot, dp::Batcher & batcher);
 
-  void GenerateStop(ref_ptr<dp::GraphicsContext> context, StopNodeParams const & params,
+  void GenerateStop(ref_ptr<dp::GraphicsContext> context, StopNodeParamsSubway const & stopParams,
                     m2::PointD const & pivot,
                     std::map<routing::transit::LineId, LineParams> const & lines,
                     dp::Batcher & batcher);
 
-  void GenerateTitles(ref_ptr<dp::GraphicsContext> context, StopNodeParams const & params,
+  void GenerateStop(ref_ptr<dp::GraphicsContext> context, StopNodeParamsPT const & stopParams,
+                    m2::PointD const & pivot,
+                    std::map<routing::transit::LineId, LineParams> const & lines,
+                    dp::Batcher & batcher);
+
+  void GenerateTitles(ref_ptr<dp::GraphicsContext> context, StopNodeParamsSubway const & stopParams,
+                      m2::PointD const & pivot, std::vector<m2::PointF> const & markerSizes,
+                      ref_ptr<dp::TextureManager> textures, dp::Batcher & batcher);
+
+  void GenerateTitles(ref_ptr<dp::GraphicsContext> context, StopNodeParamsPT const & stopParams,
                       m2::PointD const & pivot, std::vector<m2::PointF> const & markerSizes,
                       ref_ptr<dp::TextureManager> textures, dp::Batcher & batcher);
 
@@ -184,4 +275,46 @@ private:
 
   uint32_t m_recacheId = 0;
 };
+
+template <class F, class S, class T, class L>
+void TransitSchemeBuilder::GenerateLocationsWithTitles(ref_ptr<dp::GraphicsContext> context,
+                                                       ref_ptr<dp::TextureManager> textures,
+                                                       dp::Batcher & batcher, F && flusher,
+                                                       MwmSchemeData const & scheme,
+                                                       S const & stops, T const & transfers,
+                                                       L const & lines)
+{
+  dp::SessionGuard guard(context, batcher, flusher);
+
+  float constexpr kStopScale = 2.5f;
+  float constexpr kTransferScale = 3.0f;
+
+  std::vector<m2::PointF> const transferMarkerSizes = GetTransitMarkerSizes(kTransferScale, 1000);
+  std::vector<m2::PointF> const stopMarkerSizes = GetTransitMarkerSizes(kStopScale, 1000);
+
+  for (auto const & stop : stops)
+  {
+    if (scheme.m_transitVersion == ::transit::TransitVersion::OnlySubway)
+    {
+      GenerateStop(context, stop.second, scheme.m_pivot, lines, batcher);
+    }
+    else if (scheme.m_transitVersion == ::transit::TransitVersion::AllPublicTransport)
+    {
+      GenerateStop(context, stop.second, scheme.m_pivot, lines, batcher);
+    }
+    else
+    {
+      UNREACHABLE();
+    }
+
+    GenerateTitles(context, stop.second, scheme.m_pivot, stopMarkerSizes, textures, batcher);
+  }
+
+  for (auto const & transfer : transfers)
+  {
+    GenerateTransfer(context, transfer.second, scheme.m_pivot, batcher);
+    GenerateTitles(context, transfer.second, scheme.m_pivot, transferMarkerSizes, textures,
+                   batcher);
+  }
+}
 }  // namespace df

--- a/drape_frontend/transit_scheme_renderer.cpp
+++ b/drape_frontend/transit_scheme_renderer.cpp
@@ -7,7 +7,6 @@
 
 #include "drape/graphics_context.hpp"
 #include "drape/overlay_tree.hpp"
-#include "drape/vertex_array_buffer.hpp"
 
 #include <algorithm>
 

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -83,6 +83,8 @@ void ReadTransitTask::Do()
   auto const transitHeaderVersion = ::transit::GetVersion(*reader.GetPtr());
   if (transitHeaderVersion == ::transit::TransitVersion::OnlySubway)
   {
+    m_transitInfo->m_transitVersion = ::transit::TransitVersion::OnlySubway;
+
     routing::transit::GraphData graphData;
     graphData.DeserializeForRendering(*reader.GetPtr());
 
@@ -104,10 +106,30 @@ void ReadTransitTask::Do()
   }
   else if (transitHeaderVersion == ::transit::TransitVersion::AllPublicTransport)
   {
+    m_transitInfo->m_transitVersion = ::transit::TransitVersion::AllPublicTransport;
+
     ::transit::experimental::TransitData transitData;
     transitData.DeserializeForRendering(*reader.GetPtr());
 
     FillItemsByIdMap(transitData.GetStops(), m_transitInfo->m_stopsPT);
+
+    for (auto const & edge : transitData.GetEdges())
+    {
+      ::transit::EdgeId const edgeId(edge.GetStop1Id(), edge.GetStop2Id(), edge.GetLineId());
+      ::transit::EdgeData const edgeData(edge.GetShapeLink(), edge.GetWeight());
+
+      if (!m_loadSubset)
+      {
+        m_transitInfo->m_edgesPT.emplace(edgeId, edgeData);
+      }
+      else
+      {
+        auto it = m_transitInfo->m_edgesPT.find(edgeId);
+        if (it != m_transitInfo->m_edgesPT.end())
+          it->second = edgeData;
+      }
+    }
+
     for (auto const & stop : m_transitInfo->m_stopsPT)
     {
       if (stop.second.GetFeatureId() != ::transit::experimental::kInvalidFeatureId)
@@ -116,7 +138,11 @@ void ReadTransitTask::Do()
         m_transitInfo->m_features[featureId] = {};
       }
 
-      // TODO(o.khlopkova) Add transfers implementation.
+      if (m_loadSubset && !stop.second.GetTransferIds().empty())
+      {
+        for (auto const transferId : stop.second.GetTransferIds())
+          m_transitInfo->m_transfersPT[transferId] = {};
+      }
     }
     FillItemsByIdMap(transitData.GetTransfers(), m_transitInfo->m_transfersPT);
     FillItemsByIdMap(transitData.GetShapes(), m_transitInfo->m_shapesPT);
@@ -169,16 +195,13 @@ unique_ptr<TransitDisplayInfo> && ReadTransitTask::GetTransitInfo()
 void ReadTransitTask::FillLinesAndRoutes(::transit::experimental::TransitData const & transitData)
 {
   auto const & routes = transitData.GetRoutes();
+  auto const & linesMeta = transitData.GetLinesMetadata();
 
   for (auto const & line : transitData.GetLines())
   {
     transit::TransitId const routeId = line.GetRouteId();
-    auto const itRoute = std::find_if(routes.begin(), routes.end(),
-                                      [routeId](::transit::experimental::Route const & route) {
-                                        return route.GetId() == routeId;
-                                      });
-
-    CHECK(itRoute != routes.end(), (line));
+    auto const itRoute = ::transit::FindById(routes, routeId);
+    auto const itLineMetadata = ::transit::FindById(linesMeta, line.GetId(), false /*exists*/);
 
     if (m_loadSubset)
     {
@@ -188,12 +211,16 @@ void ReadTransitTask::FillLinesAndRoutes(::transit::experimental::TransitData co
       {
         it->second = line;
         m_transitInfo->m_routesPT.emplace(routeId, *itRoute);
+        if (itLineMetadata != linesMeta.end())
+          m_transitInfo->m_linesMetadataPT.emplace(itLineMetadata->GetId(), *itLineMetadata);
       }
     }
     else
     {
       m_transitInfo->m_linesPT.emplace(line.GetId(), line);
       m_transitInfo->m_routesPT.emplace(routeId, *itRoute);
+      if (itLineMetadata != linesMeta.end())
+        m_transitInfo->m_linesMetadataPT.emplace(itLineMetadata->GetId(), *itLineMetadata);
     }
   }
 }
@@ -333,13 +360,20 @@ void TransitReadManager::UpdateViewport(ScreenBase const & screen)
     GetTransitDisplayInfo(newTransitData);
 
     TransitDisplayInfos validTransitData;
-    for (auto & transitDataItem : newTransitData)
+    for (auto & [mwmId, transitInfo] : newTransitData)
     {
-      auto & transitInfo = transitDataItem.second;
-      if (!transitInfo || transitInfo->m_linesSubway.empty())
+      if (!transitInfo)
         continue;
 
-      auto it = m_mwmCache.find(transitDataItem.first);
+      if (transitInfo->m_transitVersion == ::transit::TransitVersion::OnlySubway &&
+          transitInfo->m_linesSubway.empty())
+        continue;
+
+      if (transitInfo->m_transitVersion == ::transit::TransitVersion::AllPublicTransport &&
+          transitInfo->m_linesPT.empty())
+        continue;
+
+      auto it = m_mwmCache.find(mwmId);
 
       it->second.m_isLoaded = true;
 
@@ -347,7 +381,7 @@ void TransitReadManager::UpdateViewport(ScreenBase const & screen)
       it->second.m_dataSize = dataSize;
       m_cacheSize += dataSize;
 
-      validTransitData[transitDataItem.first] = std::move(transitInfo);
+      validTransitData[mwmId] = std::move(transitInfo);
     }
 
     if (!validTransitData.empty())

--- a/transit/transit_display_info.hpp
+++ b/transit/transit_display_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "transit/experimental/transit_types_experimental.hpp"
+#include "transit/transit_entities.hpp"
 #include "transit/transit_types.hpp"
 #include "transit/transit_version.hpp"
 
@@ -34,9 +35,12 @@ using TransitStopsInfoPT = std::map<::transit::TransitId, ::transit::experimenta
 using TransitTransfersInfoPT = std::map<::transit::TransitId, ::transit::experimental::Transfer>;
 using TransitShapesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Shape>;
 using TransitLinesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Line>;
+using TransitLinesMetadataInfoPT =
+    std::map<::transit::TransitId, ::transit::experimental::LineMetadata>;
 using TransitRoutesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Route>;
 using TransitNetworksInfoPT = std::map<::transit::TransitId, ::transit::experimental::Network>;
-
+using TransitEdgesInfoPT =
+    std::unordered_map<::transit::EdgeId, ::transit::EdgeData, ::transit::EdgeIdHasher>;
 struct TransitDisplayInfo
 {
   ::transit::TransitVersion m_transitVersion;
@@ -51,10 +55,12 @@ struct TransitDisplayInfo
 
   TransitNetworksInfoPT m_networksPT;
   TransitLinesInfoPT m_linesPT;
+  TransitLinesMetadataInfoPT m_linesMetadataPT;
   TransitRoutesInfoPT m_routesPT;
   TransitStopsInfoPT m_stopsPT;
   TransitTransfersInfoPT m_transfersPT;
   TransitShapesInfoPT m_shapesPT;
+  TransitEdgesInfoPT m_edgesPT;
 };
 
 using TransitDisplayInfos = std::map<MwmSet::MwmId, std::unique_ptr<TransitDisplayInfo>>;

--- a/transit/world_feed/subway_converter.cpp
+++ b/transit/world_feed/subway_converter.cpp
@@ -9,38 +9,46 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 
 #include "3party/jansson/myjansson.hpp"
 #include "3party/opening_hours/opening_hours.hpp"
 
 namespace
 {
+double constexpr kEps = 1e-5;
+
+uint32_t GetSubwayRouteId(routing::transit::LineId lineId)
+{
+  return static_cast<uint32_t>(lineId >> 4);
+}
+
 // Returns the index of the |point| in the |shape| polyline.
 size_t FindPointIndex(std::vector<m2::PointD> const & shape, m2::PointD const & point)
 {
-  static double constexpr eps = 1e-6;
   auto it = std::find_if(shape.begin(), shape.end(), [&point](m2::PointD const & p) {
-    return base::AlmostEqualAbs(p, point, eps);
+    return base::AlmostEqualAbs(p, point, kEps);
   });
 
-  CHECK(it != shape.end(), (point));
+  if (it == shape.end())
+  {
+    size_t minDistIdx = 0;
+    double minDist = std::numeric_limits<double>::max();
+
+    for (size_t i = 0; i < shape.size(); ++i)
+    {
+      double dist = mercator::DistanceOnEarth(shape[i], point);
+      if (dist < minDist)
+      {
+        minDist = dist;
+        minDistIdx = i;
+      }
+    }
+
+    return minDistIdx;
+  }
 
   return std::distance(shape.begin(), it);
-}
-
-// Returns polyline found by pair of stop ids.
-std::vector<m2::PointD> GetShapeByStops(std::vector<routing::transit::Shape> const & shapes,
-                                        routing::transit::StopId stopId1,
-                                        routing::transit::StopId stopId2)
-{
-  auto const itShape = std::find_if(
-      shapes.begin(), shapes.end(), [stopId1, stopId2](routing::transit::Shape const & shape) {
-        return shape.GetId().GetStop1Id() == stopId1 && shape.GetId().GetStop2Id() == stopId2;
-      });
-
-  CHECK(itShape != shapes.end(), (stopId1, stopId2));
-
-  return itShape->GetPolyline();
 }
 }  // namespace
 
@@ -72,6 +80,8 @@ bool SubwayConverter::Convert()
 
   m_feed.ModifyLinesAndShapes();
 
+  MirrorReversedLines();
+
   if (!ConvertStops())
     return false;
 
@@ -82,7 +92,14 @@ bool SubwayConverter::Convert()
   if (!ConvertGates())
     return false;
 
-  return ConvertEdges();
+  if (!ConvertEdges())
+    return false;
+
+  m_feed.SplitFeedIntoRegions();
+
+  PrepareLinesMetadata();
+
+  return true;
 }
 
 bool SubwayConverter::ConvertNetworks()
@@ -122,13 +139,15 @@ bool SubwayConverter::SplitEdges()
 std::pair<TransitId, RouteData> SubwayConverter::MakeRoute(
     routing::transit::Line const & lineSubway)
 {
-  std::string const & routeTitle = lineSubway.GetNumber();
-  std::string const routeHash =
-      BuildHash(kHashPrefix, std::to_string(lineSubway.GetNetworkId()), routeTitle);
+  uint32_t routeSubwayId = GetSubwayRouteId(lineSubway.GetId());
+
+  std::string const routeHash = BuildHash(kHashPrefix, std::to_string(lineSubway.GetNetworkId()),
+                                          std::to_string(routeSubwayId));
+
   TransitId const routeId = m_feed.m_idGenerator.MakeId(routeHash);
 
   RouteData routeData;
-  routeData.m_title = {{kDefaultLang, routeTitle}};
+  routeData.m_title = {{kDefaultLang, lineSubway.GetNumber()}};
   routeData.m_routeType = kSubwayRouteType;
   routeData.m_networkId = lineSubway.GetNetworkId();
   routeData.m_color = lineSubway.GetColor();
@@ -232,6 +251,9 @@ std::pair<TransitId, StopData> SubwayConverter::MakeStop(routing::transit::Stop 
   stopData.m_point = stopSubway.GetPoint();
   stopData.m_osmId = stopSubway.GetOsmId();
 
+  if (stopSubway.GetFeatureId() != routing::transit::kInvalidFeatureId)
+    stopData.m_featureId = stopSubway.GetFeatureId();
+
   return {stopId, stopData};
 }
 
@@ -241,11 +263,24 @@ bool SubwayConverter::ConvertLinesBasedData()
   m_feed.m_lines.m_data.reserve(linesSubway.size());
   m_feed.m_shapes.m_data.reserve(linesSubway.size());
 
+  std::unordered_map<TransitId, IdList> routesToLines;
+
+  for (auto const & lineSubway : linesSubway)
+  {
+    auto const lineId = lineSubway.GetId();
+    auto const [routeId, routeData] = MakeRoute(lineSubway);
+    auto & lineIdList = routesToLines[routeId];
+    auto it = std::find(lineIdList.begin(), lineIdList.end(), lineId);
+    if (it != lineIdList.end())
+      lineIdList.push_back(lineId);
+  }
+
   auto const & shapesSubway = m_graphData.GetShapes();
 
   for (auto const & lineSubway : linesSubway)
   {
     auto const [routeId, routeData] = MakeRoute(lineSubway);
+
     m_feed.m_routes.m_data.emplace(routeId, routeData);
 
     auto [lineId, lineData] = MakeLine(lineSubway, routeId);
@@ -259,37 +294,63 @@ bool SubwayConverter::ConvertLinesBasedData()
 
     CHECK_EQUAL(lineSubway.GetStopIds().size(), 1, ("Line shouldn't be split into ranges."));
 
-    auto const & rangeSubway = lineSubway.GetStopIds().front();
-    CHECK_GREATER(rangeSubway.size(), 1, ("Range must include at least two stops."));
+    auto const & stopIdsSubway = lineSubway.GetStopIds().front();
 
-    for (size_t i = 0; i < rangeSubway.size(); ++i)
+    CHECK_GREATER(stopIdsSubway.size(), 1, ("Range must include at least two stops."));
+
+    for (size_t i = 0; i < stopIdsSubway.size(); ++i)
     {
-      auto const stopIdSubway = rangeSubway[i];
+      auto const stopIdSubway = stopIdsSubway[i];
       std::string const stopHash = BuildHash(kHashPrefix, std::to_string(stopIdSubway));
       TransitId const stopId = m_feed.m_idGenerator.MakeId(stopHash);
+
       lineData.m_stopIds.emplace_back(stopId);
       m_stopIdMapping.emplace(stopIdSubway, stopId);
 
       if (i == 0)
         continue;
 
-      auto const stopIdSubwayPrev = rangeSubway[i - 1];
+      auto const stopIdSubwayPrev = stopIdsSubway[i - 1];
+
+      CHECK(stopIdSubwayPrev != stopIdSubway, (stopIdSubway));
+
       auto const & edge = FindEdge(stopIdSubwayPrev, stopIdSubway, lineId);
 
-      for (auto const & id : edge.GetShapeIds())
+      CHECK_LESS_OR_EQUAL(edge.GetShapeIds().size(), 1, (edge));
+
+      EdgePoints edgePoints;
+
+      m2::PointD const prevPoint = FindById(m_graphData.GetStops(), stopIdSubwayPrev)->GetPoint();
+      m2::PointD const curPoint = FindById(m_graphData.GetStops(), stopIdSubway)->GetPoint();
+
+      if (edge.GetShapeIds().empty())
       {
-        auto const & polyline = GetShapeByStops(shapesSubway, id.GetStop1Id(), id.GetStop2Id());
-        CHECK(!polyline.empty(), ());
+        edgePoints = EdgePoints(prevPoint, curPoint);
+      }
+      else
+      {
+        routing::transit::ShapeId shapeIdSubway = edge.GetShapeIds().back();
+
+        auto polyline = FindById(shapesSubway, shapeIdSubway)->GetPolyline();
+
+        CHECK(polyline.size() > 1, ());
+
+        double const distToPrevStop = mercator::DistanceOnEarth(polyline.front(), prevPoint);
+        double const distToNextStop = mercator::DistanceOnEarth(polyline.front(), curPoint);
+
+        if (distToPrevStop > distToNextStop)
+          std::reverse(polyline.begin(), polyline.end());
 
         // We remove duplicate point from the shape before appending polyline to it.
         if (!shapeData.m_points.empty() && shapeData.m_points.back() == polyline.front())
           shapeData.m_points.pop_back();
 
         shapeData.m_points.insert(shapeData.m_points.end(), polyline.begin(), polyline.end());
+
+        edgePoints = EdgePoints(polyline.front(), polyline.back());
       }
 
       EdgeId const curEdge(m_stopIdMapping[stopIdSubwayPrev], stopId, lineId);
-      EdgePoints const edgePoints(shapeData.m_points.front(), shapeData.m_points.back());
 
       if (!m_edgesOnShapes.emplace(curEdge, edgePoints).second)
       {
@@ -375,6 +436,395 @@ bool SubwayConverter::ConvertEdges()
               "edges from subways to transfer edges in public transport."));
 
   return !m_feed.m_edges.m_data.empty() && !m_feed.m_edgesTransfers.m_data.empty();
+}
+
+void SubwayConverter::MirrorReversedLines()
+{
+  for (auto & [lineId, lineData] : m_feed.m_lines.m_data)
+  {
+    if (lineData.m_shapeLink.m_startIndex < lineData.m_shapeLink.m_endIndex)
+      continue;
+
+    auto revStopIds = lineData.m_stopIds;
+    std::reverse(revStopIds.begin(), revStopIds.end());
+
+    bool reversed = false;
+
+    for (auto const & [lineIdStraight, lineDataStraight] : m_feed.m_lines.m_data)
+    {
+      if (lineIdStraight == lineId ||
+          lineDataStraight.m_shapeLink.m_startIndex > lineDataStraight.m_shapeLink.m_endIndex ||
+          lineDataStraight.m_shapeLink.m_shapeId != lineData.m_shapeLink.m_shapeId)
+        continue;
+
+      if (revStopIds == lineDataStraight.m_stopIds)
+      {
+        lineData.m_shapeLink = lineDataStraight.m_shapeLink;
+        LOG(LDEBUG, ("Reversed line", lineId, "to line", lineIdStraight, "shapeLink",
+                     lineData.m_shapeLink));
+        reversed = true;
+        break;
+      }
+    }
+
+    if (!reversed)
+    {
+      std::swap(lineData.m_shapeLink.m_startIndex, lineData.m_shapeLink.m_endIndex);
+      LOG(LDEBUG, ("Reversed line", lineId, "shapeLink", lineData.m_shapeLink));
+    }
+  }
+}
+
+std::vector<LineSchemeData> SubwayConverter::GetLinesOnScheme(
+    std::unordered_map<TransitId, IdList> const & lineIdToStops) const
+{
+  // Route id to shape link and one of line ids with this link.
+  std::map<TransitId, std::map<ShapeLink, TransitId>> routeToLines;
+
+  for (auto const & lineAndStops : lineIdToStops)
+  {
+    TransitId const lineId = lineAndStops.first;
+    LineData const & line = m_feed.m_lines.m_data.at(lineId);
+
+    TransitId const routeId = line.m_routeId;
+    ShapeLink const & newShapeLink = line.m_shapeLink;
+
+    auto [it, inserted] = routeToLines.emplace(routeId, std::map<ShapeLink, TransitId>());
+
+    if (inserted)
+    {
+      it->second[newShapeLink] = lineId;
+      continue;
+    }
+
+    bool insert = true;
+    std::vector<ShapeLink> linksForRemoval;
+
+    for (auto const & [shapeLink, lineId] : it->second)
+    {
+      if (shapeLink.m_shapeId != newShapeLink.m_shapeId)
+        continue;
+
+      // New shape link is fully included into the existing one.
+      if (shapeLink.m_startIndex <= newShapeLink.m_startIndex &&
+          shapeLink.m_endIndex >= newShapeLink.m_endIndex)
+      {
+        insert = false;
+        continue;
+      }
+
+      // Existing shape link is fully included into the new one. It should be removed.
+      if (newShapeLink.m_startIndex <= shapeLink.m_startIndex &&
+          newShapeLink.m_endIndex >= shapeLink.m_endIndex)
+        linksForRemoval.push_back(shapeLink);
+    }
+
+    for (auto const sl : linksForRemoval)
+      it->second.erase(sl);
+
+    if (insert)
+      it->second[newShapeLink] = lineId;
+  }
+
+  std::vector<LineSchemeData> linesOnScheme;
+
+  for (auto const & [routeId, linksToLines] : routeToLines)
+  {
+    CHECK(!linksToLines.empty(), (routeId));
+
+    for (auto const & [shapeLink, lineId] : linksToLines)
+    {
+      LineSchemeData data;
+      data.m_lineId = lineId;
+      data.m_routeId = routeId;
+      data.m_shapeLink = shapeLink;
+
+      linesOnScheme.push_back(data);
+    }
+  }
+
+  return linesOnScheme;
+}
+
+enum class LineSegmentState
+{
+  Start = 0,
+  Finish
+};
+
+struct LineSegmentInfo
+{
+  LineSegmentInfo() = default;
+  LineSegmentInfo(LineSegmentState const & state, bool codirectional)
+    : m_state(state), m_codirectional(codirectional)
+  {
+  }
+
+  LineSegmentState m_state = LineSegmentState::Start;
+  bool m_codirectional = false;
+};
+
+struct LinePointState
+{
+  std::map<TransitId, LineSegmentInfo> parallelLineStates;
+  m2::PointD m_firstPoint;
+};
+
+using LineGeometry = std::vector<m2::PointD>;
+using RouteToLinepartsCache = std::map<TransitId, std::vector<LineGeometry>>;
+
+bool Equal(LineGeometry const & line1, LineGeometry const & line2)
+{
+  if (line1.size() != line2.size())
+    return false;
+
+  for (size_t i = 0; i < line1.size(); ++i)
+  {
+    if (!base::AlmostEqualAbs(line1[i], line2[i], kEps))
+      return false;
+  }
+
+  return true;
+}
+
+bool AddToCache(TransitId routeId, LineGeometry const & linePart, RouteToLinepartsCache & cache)
+{
+  auto [it, inserted] = cache.emplace(routeId, std::vector<LineGeometry>());
+
+  if (inserted)
+  {
+    it->second.push_back(linePart);
+    return true;
+  }
+
+  std::vector<m2::PointD> linePartRev = linePart;
+  std::reverse(linePartRev.begin(), linePartRev.end());
+
+  for (LineGeometry const & cachedPart : it->second)
+  {
+    if (Equal(cachedPart, linePart) || Equal(cachedPart, linePartRev))
+      return false;
+  }
+
+  it->second.push_back(linePart);
+  return true;
+}
+
+void SubwayConverter::CalculateLinePriorities(std::vector<LineSchemeData> const & linesOnScheme)
+{
+  RouteToLinepartsCache routeSegmentsCache;
+
+  for (auto const & lineSchemeData : linesOnScheme)
+  {
+    auto const lineId = lineSchemeData.m_lineId;
+    std::map<size_t, LinePointState> linePoints;
+
+    for (auto const & linePart : lineSchemeData.m_lineParts)
+    {
+      auto & startPointState = linePoints[linePart.m_segment.m_startIdx];
+      auto & endPointState = linePoints[linePart.m_segment.m_endIdx];
+
+      startPointState.m_firstPoint = linePart.m_firstPoint;
+
+      for (auto const & [parallelLineId, parallelFirstPoint] : linePart.m_commonLines)
+      {
+        bool const codirectional =
+            base::AlmostEqualAbs(linePart.m_firstPoint, parallelFirstPoint, kEps);
+
+        startPointState.parallelLineStates[parallelLineId] =
+            LineSegmentInfo(LineSegmentState::Start, codirectional);
+        endPointState.parallelLineStates[parallelLineId] =
+            LineSegmentInfo(LineSegmentState::Finish, codirectional);
+      }
+    }
+
+    linePoints.emplace(0, LinePointState());
+    linePoints.emplace(lineSchemeData.m_shapeLink.m_endIndex, LinePointState());
+
+    std::map<TransitId, bool> parallelLines;
+
+    for (auto it = linePoints.begin(); it != linePoints.end(); ++it)
+    {
+      auto itNext = std::next(it);
+      if (itNext == linePoints.end())
+        break;
+
+      auto & startLinePointState = it->second;
+      size_t startIndex = it->first;
+      size_t endIndex = itNext->first;
+
+      for (auto const & [id, info] : startLinePointState.parallelLineStates)
+      {
+        if (info.m_state == LineSegmentState::Start)
+        {
+          auto [itParLine, insertedParLine] = parallelLines.emplace(id, info.m_codirectional);
+          if (!insertedParLine)
+            CHECK_EQUAL(itParLine->second, info.m_codirectional, ());
+        }
+        else
+        {
+          parallelLines.erase(id);
+        }
+      }
+
+      TransitId routeId = m_feed.m_lines.m_data.at(lineId).m_routeId;
+
+      std::map<TransitId, bool> routeIds{{routeId, true /* codirectional */}};
+
+      for (auto const & [id, codirectional] : parallelLines)
+        routeIds.emplace(m_feed.m_lines.m_data.at(id).m_routeId, codirectional);
+
+      LineSegmentOrder lso;
+      lso.m_segment = LineSegment(startIndex, endIndex);
+
+      auto const & polyline =
+          m_feed.m_shapes.m_data.at(lineSchemeData.m_shapeLink.m_shapeId).m_points;
+
+      if (!AddToCache(routeId,
+                      GetPolylinePart(polyline, lso.m_segment.m_startIdx, lso.m_segment.m_endIdx),
+                      routeSegmentsCache))
+      {
+        continue;
+      }
+
+      auto itRoute = routeIds.find(routeId);
+      CHECK(itRoute != routeIds.end(), ());
+
+      size_t const index = std::distance(routeIds.begin(), itRoute);
+
+      lso.m_order = CalcSegmentOrder(index, routeIds.size());
+
+      bool reversed = false;
+
+      if (index > 0 && !routeIds.begin()->second)
+      {
+        lso.m_order = -lso.m_order;
+        reversed = true;
+      }
+
+      m_feed.m_linesMetadata.m_data[lineId].push_back(lso);
+
+      LOG(LINFO,
+          ("routeId", routeId, "lineId", lineId, "start", startIndex, "end", endIndex, "len",
+           endIndex - startIndex + 1, "order", lso.m_order, "index", index, "reversed", reversed,
+           "|| lines count:", parallelLines.size(), "routes count:", routeIds.size()));
+    }
+  }
+}
+
+void SubwayConverter::PrepareLinesMetadata()
+{
+  for (auto const & [region, lineIdToStops] : m_feed.m_splitting.m_lines)
+  {
+    LOG(LINFO, ("Handling", region, "region"));
+
+    std::vector<LineSchemeData> linesOnScheme = GetLinesOnScheme(lineIdToStops);
+
+    for (size_t i = 0; i < linesOnScheme.size() - 1; ++i)
+    {
+      auto & line1 = linesOnScheme[i];
+
+      auto const & shapeLink1 = line1.m_shapeLink;
+
+      auto const polyline1 =
+          GetPolylinePart(m_feed.m_shapes.m_data.at(shapeLink1.m_shapeId).m_points,
+                          shapeLink1.m_startIndex, shapeLink1.m_endIndex);
+
+      for (size_t j = i + 1; j < linesOnScheme.size(); ++j)
+      {
+        auto & line2 = linesOnScheme[j];
+
+        if (line1.m_routeId == line2.m_routeId)
+          continue;
+
+        auto const & shapeLink2 = line2.m_shapeLink;
+
+        if (line1.m_shapeLink.m_shapeId == line2.m_shapeLink.m_shapeId)
+        {
+          CHECK_LESS(shapeLink1.m_startIndex, shapeLink1.m_endIndex, ());
+          CHECK_LESS(shapeLink2.m_startIndex, shapeLink2.m_endIndex, ());
+
+          std::optional<LineSegment> inter =
+              GetIntersection(shapeLink1.m_startIndex, shapeLink1.m_endIndex,
+                              shapeLink2.m_startIndex, shapeLink2.m_endIndex);
+
+          if (inter != std::nullopt)
+          {
+            LineSegment const segment = inter.value();
+            m2::PointD const & startPoint = polyline1[segment.m_startIdx];
+
+            UpdateLinePart(line1.m_lineParts, segment, startPoint, line2.m_lineId, startPoint);
+            UpdateLinePart(line2.m_lineParts, segment, startPoint, line1.m_lineId, startPoint);
+          }
+        }
+        else
+        {
+          auto polyline2 = GetPolylinePart(m_feed.m_shapes.m_data.at(shapeLink2.m_shapeId).m_points,
+                                           shapeLink2.m_startIndex, shapeLink2.m_endIndex);
+
+          auto [segments1, segments2] = FindIntersections(polyline1, polyline2);
+
+          if (segments1.empty())
+          {
+            auto polyline2Rev = polyline2;
+            std::reverse(polyline2Rev.begin(), polyline2Rev.end());
+            std::tie(segments1, segments2) = FindIntersections(polyline1, polyline2Rev);
+
+            if (!segments1.empty())
+            {
+              for (auto & seg : segments2)
+              {
+                size_t len = seg.m_endIdx - seg.m_startIdx + 1;
+                seg.m_endIdx = polyline2.size() - seg.m_startIdx - 1;
+                seg.m_startIdx = seg.m_endIdx - len + 1;
+
+                CHECK_GREATER(seg.m_endIdx, seg.m_startIdx, ());
+                CHECK_GREATER(polyline2.size(), seg.m_endIdx, ());
+              }
+            }
+          }
+
+          CHECK_EQUAL(segments1.size(), segments2.size(), ());
+
+          if (!segments1.empty())
+          {
+            for (size_t k = 0; k < segments1.size(); ++k)
+            {
+              m2::PointD const & startPoint1 = polyline1[segments1[k].m_startIdx];
+              m2::PointD const & endPoint1 = polyline1[segments1[k].m_endIdx];
+
+              m2::PointD const & startPoint2 = polyline2[segments2[k].m_startIdx];
+              m2::PointD const & endPoint2 = polyline2[segments2[k].m_endIdx];
+
+              CHECK(base::AlmostEqualAbs(startPoint1, startPoint2, kEps) &&
+                            base::AlmostEqualAbs(endPoint1, endPoint2, kEps) ||
+                        base::AlmostEqualAbs(startPoint1, endPoint2, kEps) &&
+                            base::AlmostEqualAbs(endPoint1, startPoint2, kEps),
+                    ());
+
+              segments1[k].m_startIdx += shapeLink1.m_startIndex;
+              segments1[k].m_endIdx += shapeLink1.m_startIndex;
+
+              segments2[k].m_startIdx += shapeLink2.m_startIndex;
+              segments2[k].m_endIdx += shapeLink2.m_startIndex;
+
+              UpdateLinePart(line1.m_lineParts, segments1[k], startPoint1, line2.m_lineId,
+                             startPoint2);
+              UpdateLinePart(line2.m_lineParts, segments2[k], startPoint2, line1.m_lineId,
+                             startPoint1);
+            }
+
+            LOG(LINFO, ("Line", line1.m_lineId, "route", line1.m_routeId, "overlaps line",
+                        line2.m_lineId, "route", line2.m_routeId));
+          }
+        }
+      }
+    }
+
+    LOG(LINFO, ("Started calculating line priorities in", region));
+    CalculateLinePriorities(linesOnScheme);
+    LOG(LINFO, ("Prepared metadata for lines in", region));
+  }
 }
 
 routing::transit::Edge SubwayConverter::FindEdge(routing::transit::StopId stop1Id,

--- a/transit/world_feed/subway_converter.hpp
+++ b/transit/world_feed/subway_converter.hpp
@@ -4,6 +4,7 @@
 
 #include "transit/transit_entities.hpp"
 #include "transit/transit_graph_data.hpp"
+#include "transit/world_feed/feed_helpers.hpp"
 #include "transit/world_feed/world_feed.hpp"
 
 #include "geometry/mercator.hpp"
@@ -45,6 +46,21 @@ private:
   bool ConvertTransfers();
   bool ConvertGates();
   bool ConvertEdges();
+  // We try to minimize the reversed lines count.
+  void MirrorReversedLines();
+  // Returns line ids with corresponding shape links and route ids. There can be may lines inside
+  // the route with same shapeLink. We keep only one of them. These line ids are used in
+  // |PrepareLinesMetadata()|.
+  std::vector<LineSchemeData> GetLinesOnScheme(
+      std::unordered_map<TransitId, IdList> const & lineIdToStops) const;
+  // Finds common overlapping (parallel on the subway layer) segments on polylines. Motivation:
+  // we shouldn't draw parallel lines of different routes on top of each other so the user can’t
+  // tell which lines go where (the only visible line is the one that is drawn last). We need these
+  // lines to be drawn in parallel in corresponding routes colours.
+  void PrepareLinesMetadata();
+  // Calculates order for each of the parallel lines in the overlapping segment. In drape frontend
+  // we use this order as an offset for drawing line.
+  void CalculateLinePriorities(std::vector<LineSchemeData> const & linesOnScheme);
 
   // Methods for creating id & data pairs for |m_feed| based on the subway items.
   std::pair<TransitId, RouteData> MakeRoute(routing::transit::Line const & lineSubway);


### PR DESCRIPTION
### Реквест про отрисовку слоя метро на новой версии транзитной секции.

Логика такая: в рамках маршрута (route) есть от одной до нескольких линий (line). К каждой линии привязан отрезок полилинии (shapeLink), по которой эта линия пролегает: айди полилинии и индексы начальной и конечной точкек. Линии разных маршрутов на некоторых участках могут накладываться друг на друга, а нам нужно рисовать их параллельно. 

Для этого на этапе gtfs_converter для всех линий ищутся геометрически совпадающие отрезки. По каждому из таких отрезков проходит от двух линий. Для каждой из этих линий на отрезке рассчитывается ее порядок относительно других, чтобы в drape frontend рисовать их с правильными смещениями. Некоторые линии могут совпадать, но иметь разное направление. Условно ABCDE, EDCBA. Для таких полилиний нужно также правильно высчитывать смещение.


### Метро Сан-Франциско, мвм US_California_Santa_Clara_Palo Alto

1. В версии с метро лишний сегмент голубой линии, которого быть не должно. Это именно баг отрисовки, потому что  в данных голубая полилиния по этому отрезку пути не проходит. В версии с ОТ сегмент голубой линии отсутствует:

| Версия с метро  | Версия с ОТ |
| ------------- | ------------- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/54934129/90640887-39dcb400-e239-11ea-984b-33f51311c932.png">  | <img width="512" alt="image" src="https://user-images.githubusercontent.com/54934129/90661612-16713380-e250-11ea-805f-5550f5e93471.png"> |

Тот же участок на схеме от яндекса:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/54934129/90642130-adcb8c00-e23a-11ea-98bf-e1906c9f498d.png">

2. В версии ОТ чуть больше названий остановок, отображающихся на зуме 10. Это связано с тем, что алгоритм определения, является ли остановка "терминальной", отличается от варианта метро. Но это хорошо, потому что они все равно не конфликтуют друг с другом и не засоряют карту, зато дают больше инфы, чтобы было удобнее ориентироваться по схеме.

| Сан-Франциско целиком (версия с метро) |
| ------------- |
| <img width="1022" alt="Screenshot 2020-07-29 at 10 30 44" src="https://user-images.githubusercontent.com/54934129/90862504-2e52cf80-e396-11ea-97ff-d6a77048388a.png">  |

| Сан-Франциско целиком (версия с ОТ) |
| ------------- |
| <img width="904" alt="Screenshot 2020-08-21 at 10 06 40" src="https://user-images.githubusercontent.com/54934129/90862550-40347280-e396-11ea-8422-6daacbb13ce5.png"> |

| Москва (версия с метро) |
| ------------- |
|  <img width="746" alt="Screenshot 2020-08-23 at 10 27 38" src="https://user-images.githubusercontent.com/54934129/90973552-be764d80-e52b-11ea-844c-9346e541ce5d.png"> |

| Моска (версия с ОТ) |
| ------------- |
| <img width="777" alt="Screenshot 2020-08-23 at 10 25 53" src="https://user-images.githubusercontent.com/54934129/90973559-cdf59680-e52b-11ea-8b6f-91dd0ff2e7f9.png"> |
