### PR TITLE
[editor] Fix International/Alternative/Old name load for edited feature.

### DIFF
--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -124,6 +124,12 @@ public:
         func(key.substr(kPrefixLen), tag.node().attribute("v").value());
       else if (key == kDefaultName)
         func(kDefaultLang, tag.node().attribute("v").value());
+      else if (key == kIntlName)
+        func(kIntlLang, tag.node().attribute("v").value());
+      else if (key == kAltName)
+        func(kAltLang, tag.node().attribute("v").value());
+      else if (key == kOldName)
+        func(kOldLang, tag.node().attribute("v").value());
     }
   }
 


### PR DESCRIPTION
сохранение/отправка правок в alt/old name работала, а загрузка патча к отредактированной фиче -- нет (и для international name, который у нас давно то же самое)

https://jira.mail.ru/browse/MAPSME-14100