### PR TITLE
[drape] crash fix in df::CacheUserMarks

### DIFF
--- a/drape_frontend/user_mark_shapes.cpp
+++ b/drape_frontend/user_mark_shapes.cpp
@@ -231,7 +231,7 @@ void GeneratePoiSymbolShape(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Te
   PoiSymbolViewParams params(renderInfo.m_featureId);
   params.m_offset = symbolOffset;
 
-  if (renderInfo.m_badgeInfo->m_badgeTitleIndex)
+  if (renderInfo.m_badgeInfo != nullptr && renderInfo.m_badgeInfo->m_badgeTitleIndex)
   {
     size_t const badgeTitleIndex = *renderInfo.m_badgeInfo->m_badgeTitleIndex;
     CHECK_LESS(badgeTitleIndex, renderInfo.m_titleDecl->size(), ());


### PR DESCRIPTION
`GeneratePoiSymbolShape` используется в двух местах: для основного символа и для бэйджа. Добавил проверку указателя на непустоту.

https://jira.mail.ru/browse/MAPSME-14487