### PR TITLE
[editor] Fix recycling centre and recycling container.

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -312,6 +312,11 @@
         <include field="website" />
         <include field="phone" />
       </type>
+      <type id="amenity-recycling_container">
+        <include field="name" />
+        <include field="website" />
+        <include field="phone" />
+      </type>
       <type id="amenity-restaurant" group="food">
         <include group="poi" />
         <include field="operator" />

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -97,8 +97,10 @@ string MetadataTagProcessorImpl::ValidateAndFormat_operator(string const & v) co
 {
   auto const & isATM = ftypes::IsATMChecker::Instance();
   auto const & isFuelStation = ftypes::IsFuelStationChecker::Instance();
+  auto const & isRecyclingCentre = ftypes::IsRecyclingCentreChecker::Instance();
 
-  if (!(isATM(m_params.m_types) || isFuelStation(m_params.m_types)))
+  auto const & t = m_params.m_types;
+  if (!isATM(t) && !isFuelStation(t) && !isRecyclingCentre(t))
     return string();
 
   return v;

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -208,6 +208,22 @@ IsFuelStationChecker::IsFuelStationChecker()
   m_types.push_back(c.GetTypeByPath({"amenity", "fuel"}));
 }
 
+IsRecyclingCentreChecker::IsRecyclingCentreChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"amenity", "recycling"}));
+}
+
+uint32_t IsRecyclingCentreChecker::GetType() const { return m_types[0]; }
+
+IsRecyclingContainerChecker::IsRecyclingContainerChecker()
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"amenity", "recycling_container"}));
+}
+
+uint32_t IsRecyclingContainerChecker::GetType() const { return m_types[0]; }
+
 IsRailwayStationChecker::IsRailwayStationChecker()
 {
   Classificator const & c = classif();

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -84,6 +84,26 @@ public:
   DECLARE_CHECKER_INSTANCE(IsFuelStationChecker);
 };
 
+class IsRecyclingCentreChecker : public BaseChecker
+{
+  IsRecyclingCentreChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsRecyclingCentreChecker);
+
+  uint32_t GetType() const;
+};
+
+class IsRecyclingContainerChecker : public BaseChecker
+{
+  IsRecyclingContainerChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsRecyclingContainerChecker);
+
+  uint32_t GetType() const;
+};
+
 class IsRailwayStationChecker : public BaseChecker
 {
   IsRailwayStationChecker();


### PR DESCRIPTION
Исправила редактирование recycling centre -- от него при редактировании отваливался recycling_type.
Добавила возможность создавать/редактировать recycling container.
Добавила сохранение оператора для recycling centre + будет в отдельном реквесте приведение в соответствие операторов которые мы подгружаем из osm и которые мы даем редактировать.