### PR TITLE
[editor] Disable operator editing for some object types.

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -139,12 +139,10 @@
       <type id="aeroway-aerodrome" editable="no">
         <include group="poi" />
         <include field="ele" />
-        <include field="operator" />
       </type>
       <type id="aeroway-airport" editable="no">
         <include group="poi" />
         <include field="ele" />
-        <include field="operator" />
       </type>
       <type id="amenity-atm" group="banking" priority="low">
         <include field="opening_hours" />
@@ -152,7 +150,6 @@
       </type>
       <type id="amenity-bank" group="banking">
         <include group="poi" />
-        <include field="operator" />
         <!-- Uncomment this and other atm fields when the code supports it. -->
         <!--include field="atm" /-->
       </type>
@@ -173,13 +170,11 @@
       </type>
       <type id="amenity-bus_station">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-cafe" group="food">
         <include group="poi" />
         <include field="cuisine" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-car_rental">
@@ -194,22 +189,18 @@
       </type>
       <type id="amenity-casino">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-cinema">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-clinic" group="health">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-college" group="education">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-doctors" group="health">
         <include group="poi" />
@@ -227,13 +218,11 @@
       </type>
       <type id="amenity-fast_food" group="food">
         <include group="poi" />
-        <include field="operator" />
         <include field="cuisine" />
         <include field="internet" />
       </type>
       <type id="amenity-ferry_terminal" can_add="no">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-fire_station">
@@ -260,7 +249,6 @@
       </type>
       <type id="amenity-kindergarten" group="education">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-library">
         <include group="poi" />
@@ -268,20 +256,16 @@
       </type>
       <type id="amenity-marketplace" group="big_shop" can_add="no">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-nightclub">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="amenity-parking" can_add="no">
         <include field="name" />
-        <include field="operator" />
       </type>
       <type id="amenity-pharmacy" group="shop">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-place_of_worship">
         <include group="poi" />
@@ -291,7 +275,6 @@
       </type>
       <type id="amenity-post_box">
         <include field="name" />
-        <include field="operator" />
         <include field="postcode" />
       </type>
       <type id="amenity-post_office">
@@ -302,7 +285,6 @@
       </type>
       <type id="amenity-pub" group="food">
         <include group="poi" />
-        <include field="operator" />
         <include field="cuisine" />
         <include field="internet" />
       </type>
@@ -314,27 +296,22 @@
       </type>
       <type id="amenity-restaurant" group="food">
         <include group="poi" />
-        <include field="operator" />
         <include field="cuisine" />
         <include field="internet" />
       </type>
       <type id="amenity-school" group="education">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-taxi" can_add="no">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-telephone">
-        <include field="operator" />
         <include field="phone" />
       </type>
       <type id="amenity-theatre">
         <include group="poi" />
       </type>
       <type id="amenity-toilets">
-        <include field="operator" />
         <include field="opening_hours" />
       </type>
       <type id="amenity-townhall" can_add="no">
@@ -344,7 +321,6 @@
         <include group="poi" />
       </type>
       <type id="amenity-waste_disposal">
-        <include field="operator" />
       </type>
       <type id="amenity-waste_basket" />
       <type id="amenity-car_wash">
@@ -360,7 +336,6 @@
         <include field="internet" />
       </type>
       <type id="amenity-charging_station">
-        <include field="operator" />
       </type>
       <type id="craft" can_add="no">
         <include group="poi" />
@@ -400,7 +375,6 @@
       </type>
       <type id="highway-bus_stop">
         <include field="name" />
-        <include field="operator" />
       </type>
       <type id="historic-archaeological_site" group="historic" can_add="no">
         <include group="poi" />
@@ -438,11 +412,9 @@
       <type id="leisure-stadium" can_add="no">
         <include group="poi" />
         <include field="wikipedia" />
-        <include field="operator" />
       </type>
       <type id="leisure-swimming_pool" can_add="no">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="natural-geyser">
         <include field="name" />
@@ -488,7 +460,6 @@
       <type id="office-telecommunication" group="office">
         <include group="poi" />
         <include field="internet" />
-        <include field="operator" />
       </type>
       <type id="place-farm" can_add="no">
         <include group="poi" />
@@ -507,16 +478,13 @@
       </type>
       <type id="railway-station" editable="no" can_add="no">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="railway-subway_entrance" editable="no" can_add="no">
         <include field="name" />
-        <include field="operator" />
       </type>
       <!-- Tram stops should be inside tram lines, which our editor cannot do. -->
       <type id="railway-tram_stop" can_add="no">
         <include field="name" />
-        <include field="operator" />
       </type>
       <type id="shop" can_add="no">
         <include group="poi" />
@@ -540,12 +508,10 @@
       </type>
       <type id="shop-bicycle" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-books" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-butcher" group="shop">
@@ -554,12 +520,10 @@
       </type>
       <type id="shop-car" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-car_repair">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <!-- Add translations before setting can_add=yes. It's hard to translate though.-->
@@ -569,7 +533,6 @@
       </type>
       <type id="shop-clothes" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-computer" group="shop">
@@ -582,22 +545,18 @@
       </type>
       <type id="shop-convenience" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-department_store" group="big_shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-doityourself" group="shop" can_add="no">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-electronics" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-florist" group="shop">
@@ -634,22 +593,18 @@
       </type>
       <type id="shop-kiosk" group="shop" can_add="no">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-laundry" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-mall" group="big_shop" can_add="no">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-mobile_phone" group="shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-optician" group="shop">
@@ -666,7 +621,6 @@
       </type>
       <type id="shop-supermarket" group="big_shop">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="shop-toys" group="shop">
@@ -699,13 +653,11 @@
         <include group="poi" />
         <include field="ele" />
         <include field="opening_hours" />
-        <include field="operator" />
         <include field="website" />
         <include field="internet" />
       </type>
       <type id="tourism-apartment" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-artwork">
@@ -718,7 +670,6 @@
       </type>
       <type id="tourism-camp_site" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="website" />
         <include field="opening_hours" />
         <include field="internet" />
@@ -726,27 +677,22 @@
       <type id="tourism-caravan_site" group="accomodation">
         <include group="poi" />
         <include field="website" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-chalet" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-guest_house" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-hostel" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-hotel" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-information">
@@ -754,12 +700,10 @@
       </type>
       <type id="tourism-motel" group="accomodation">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-museum">
         <include group="poi" />
-        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="tourism-viewpoint">
@@ -779,7 +723,6 @@
         <include field="opening_hours" />
       </type>
       <type id="amenity-bicycle_parking">
-        <include field="operator" />
       </type>
       <type id="amenity-biergarten" group="food">
         <include group="poi" />
@@ -797,10 +740,8 @@
       </type>
       <type id="amenity-internet_cafe">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <type id="amenity-motorcycle_parking">
-        <include field="operator" />
       </type>
       <type id="amenity-ice_cream" group="shop">
         <include group="poi" />
@@ -817,7 +758,6 @@
       <type id="amenity-water_point">
         <include group="poi" />
         <include field="internet" />
-        <include field="operator" />
       </type>
       <type id="emergency-defibrillator">
       </type>
@@ -825,7 +765,6 @@
       </type>
       <type id="emergency-phone">
         <include field="phone" />
-        <include field="operator" />
       </type>
       <type id="highway-rest_area">
         <include field="internet" />
@@ -907,7 +846,6 @@
       </type>
       <type id="shop-car_parts" group="shop">
         <include group="poi" />
-        <include field="operator" />
       </type>
       <!-- Uncomment this after our editor core supports complex types
       <type id="amenity-vending_machine-cigarettes">
@@ -977,7 +915,6 @@
       <type id="tourism-theme_park" can_add="no">
         <include group="poi" />
         <include field="internet" />
-        <include field="operator" />
       </type>
       <type id="tourism-wilderness_hut" group="accomodation">
         <include group="poi" />


### PR DESCRIPTION
Сейчас мы сохраняем operator из osm только для банкоматов и заправок и при этом позволяем его редактировать для гораздо более широкого круга объектов. Это плохо т.к. мы предлагаем пользователю заполнить то что сами из осма не подтянули -- можно делать дублирующиеся или почти дублирующиеся правки, можно корректное значение заменить на значение хуже и т.п.
В этом реквесте прореживание типов для которых мы даем редактировать operator, отдельно сделаю сохранение оператора из osm для "уцелевших" типов.