### PR TITLE
[search] Support multiple semicolon separated alt/old names.

### DIFF
--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -38,7 +38,16 @@ template <typename Slice>
 void UpdateNameScores(string const & name, uint8_t lang, Slice const & slice,
                       NameScores & bestScores)
 {
-  bestScores.UpdateIfBetter(GetNameScores(name, lang, slice));
+  if (lang == StringUtf8Multilang::kAltNameCode || lang == StringUtf8Multilang::kOldNameCode)
+  {
+    auto const names = strings::Tokenize(name, ";");
+    for (auto const & n : names)
+      bestScores.UpdateIfBetter(GetNameScores(n, lang, slice));
+  }
+  else
+  {
+    bestScores.UpdateIfBetter(GetNameScores(name, lang, slice));
+  }
 }
 
 template <typename Slice>
@@ -107,19 +116,32 @@ pair<NameScores, size_t> GetNameScores(FeatureType & ft, Geocoder::Params const 
     string name;
     if (!ft.GetName(lang, name))
       continue;
-    vector<strings::UniString> tokens;
-    PrepareStringForMatching(name, tokens);
-
-    UpdateNameScores(tokens, lang, slice, bestScores);
-    UpdateNameScores(tokens, lang, sliceNoCategories, bestScores);
-
-    if (type == Model::TYPE_STREET)
+    vector<vector<strings::UniString>> tokens(1);
+    if (lang == StringUtf8Multilang::kAltNameCode || lang == StringUtf8Multilang::kOldNameCode)
     {
-      auto const variants = ModifyStrasse(tokens);
-      for (auto const & variant : variants)
+      auto const names = strings::Tokenize(name, ";");
+      tokens.resize(names.size());
+      for (size_t i = 0; i < names.size(); ++i)
+        PrepareStringForMatching(names[i], tokens[i]);
+    }
+    else
+    {
+      PrepareStringForMatching(name, tokens[0]);
+    }
+
+    for (auto const & t : tokens)
+    {
+      UpdateNameScores(t, lang, slice, bestScores);
+      UpdateNameScores(t, lang, sliceNoCategories, bestScores);
+
+      if (type == Model::TYPE_STREET)
       {
-        UpdateNameScores(variant, lang, slice, bestScores);
-        UpdateNameScores(variant, lang, sliceNoCategories, bestScores);
+        auto const variants = ModifyStrasse(t);
+        for (auto const & variant : variants)
+        {
+          UpdateNameScores(variant, lang, slice, bestScores);
+          UpdateNameScores(variant, lang, sliceNoCategories, bestScores);
+        }
       }
     }
   }
@@ -771,7 +793,17 @@ void Ranker::GetBestMatchName(FeatureType & f, string & name) const
   };
 
   auto bestNameFinder = [&](int8_t lang, string const & s) {
-    updateScore(lang, s, true /* force */);
+    if (lang == StringUtf8Multilang::kAltNameCode || lang == StringUtf8Multilang::kOldNameCode)
+    {
+      auto const names = strings::Tokenize(s, ";");
+      for (auto const & n : names)
+        updateScore(lang, n, true /* force */);
+    }
+    else
+    {
+      updateScore(lang, s, true /* force */);
+    }
+
     // Default name should be written in the regional language.
     if (lang == StringUtf8Multilang::kDefaultCode)
     {


### PR DESCRIPTION
было:
<img width="649" alt="Снимок экрана 2020-08-06 в 14 58 14" src="https://user-images.githubusercontent.com/9213190/89529368-4868ab80-d7f5-11ea-9848-8000ec754f3a.png">


стало:
<img width="649" alt="Снимок экрана 2020-08-06 в 13 34 21" src="https://user-images.githubusercontent.com/9213190/89529023-afd22b80-d7f4-11ea-8206-10f2ac392c92.png">

Сделать одинаковые UpdateNameScores не придумала как, потому что во втором мы предварительно делаем нормализацию. Если убрать PrepareStringForMatching/ModifyStrasse внутрь второго UpdateNameScores, они всё равно получаются не единообразными. Если вытащить обработку alt/old name из первого, получится много дублирования кода.