### PR TITLE
[iOS] Replaced localization of terms in Outdoor subscription screen

### DIFF
--- a/iphone/Maps/UI/Subscription/AllPass/AllPassSubscriptionViewController.swift
+++ b/iphone/Maps/UI/Subscription/AllPass/AllPassSubscriptionViewController.swift
@@ -145,7 +145,7 @@ extension AllPassSubscriptionViewController: SubscriptionViewProtocol {
       trialSubscriptionButton.isHidden = false
       trialSubscriptionLabel.isHidden = false
       stackTopOffset.constant = stackTopOffsetTrial
-      trialSubscriptionLabel.text = String(format: L("guides_trial_message"), trialData.price)
+      trialSubscriptionLabel.text = String(coreFormat: L("guides_trial_message"), arguments: [trialData.price])
     }
   }
 }

--- a/iphone/Maps/UI/Subscription/AllPass/AllPassSubscriptionViewController.xib
+++ b/iphone/Maps/UI/Subscription/AllPass/AllPassSubscriptionViewController.xib
@@ -354,7 +354,7 @@
                                     <nil key="highlightedColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AllPassSubscriptionTerms"/>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="subscription_terms_guides"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="subscription_terms_guides_outdoor"/>
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2O1-n3-hBU" userLabel="TermsOfUse">


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14484