### PR TITLE
[categories] Remove confusing castle synonym.

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2604,7 +2604,7 @@ fa:سایت باستان شناسی
 
 historic-castle|@tourism
 en:Castle|Palace|Fortress|U+1F3EF|U+1F3F0|U+1F451|U+1F478
-ru:Замок|Дворец|Крепость|Кремль
+ru:Замок|Дворец|Крепость
 ar:قلعة|سياحة|أماكن جذابة|مناظر
 cs:Zámek|zajímavost
 da:Slot|borg


### PR DESCRIPTION
Неожиданно когда по запросу кремль находится что-то что не содержит в названии слово кремль и кремлем не является (и при этом не находится то что содержит в названии слово кремль).

![Screenshot_20200808_163914_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/89711962-4427c400-d996-11ea-84cb-88e92ee67629.jpg)
![Screenshot_20200808_163849_com mapswithme maps pro](https://user-images.githubusercontent.com/9213190/89711963-47bb4b00-d996-11ea-8372-fec7dcd5c159.jpg)
