### PR TITLE
[generator] Save old_name:dates.

### DIFF
--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -888,6 +888,24 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_OldName)
     params.name.GetString(StringUtf8Multilang::GetLangIndex("old_name"), s);
     TEST_EQUAL(s, "Царская Ветка", ());
   }
+  {
+    Tags const tags = {{"place", "city"},
+                       {"name", "Санкт-Петербург"},
+                       {"old_name:1914-08-31--1924-01-26", "Петроград"},
+                       {"old_name:1924-01-26--1991-09-06", "Ленинград"},
+                       {"old_name:en:1914-08-31--1924-01-26", "Petrograd"},
+                       {"old_name:en:1924-01-26--1991-09-06", "Leningrad"},
+                       {"old_name:fr", "Pétrograd;Léningrad"}};
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Санкт-Петербург", ());
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("old_name"), s);
+    // We ignore old_name:lang and old_name:lang:dates but support old_name:dates.
+    TEST_EQUAL(s, "Петроград;Ленинград", ());
+  }
 }
 
 UNIT_CLASS_TEST(TestWithClassificator, OsmType_AltName)


### PR DESCRIPTION
В некоторых случаях для old_name указывают даты, например
https://www.openstreetmap.org/relation/421007

сейчас мы такое не сохраняем, а хотелось бы

т.к. отдельных ключей под это в StringUtf8Multilang нет, но мы поддерживаем несколько alt/old name через точку с запятой, предлагается все old_name:dates запихивать в old_name через точку с запятой.

Единственное что плохо -- это может давать side effect на редактор -- если мы собрали old_name из old_name:dates, а потом пользователь его отредактировал, то правка в osm будет отправлена как просто old_name с несколькими разделенными точкой с запятой значениями (сам такой формат ок, но то что оно будет дублироваться с old_name:dates не хорошо, хотя ошибкой мапинга формально вроде не является).