### PR TITLE
[cmake] fix build with USE_PCH=On on Linux/gcc

### DIFF
--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -277,8 +277,8 @@ function(add_precompiled_headers header pch_target_name)
   export_directory_flags("${pch_flags_file}")
   set(compiler_flags "@${pch_flags_file}")
 
-  # CMAKE_CXX_STANDARD 14 flags:
-  set(c_standard_flags "-std=c++14" "-std=gnu++14")
+  # CMAKE_CXX_STANDARD 17 flags:
+  set(c_standard_flags "-std=c++17")
   get_filename_component(pch_file_name ${header} NAME)
 
   add_pic_pch_target(${header} ${pch_target_name} ${pch_file_name} lib "-fPIC")


### PR DESCRIPTION
The project builds using c++17 standard, so if compile headers with
-std=c++14 compiler complains about "optional" and so on things,
that part of c++17 standard