### PR TITLE
[generator_integration_tests] Fix CheckGeneratedData

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -378,7 +378,7 @@ public:
     TEST(rawGenerator.Execute(), ());
 
     TestGeneratedFile(cameraToWays, 0 /* fileSize */);
-    TestGeneratedFile(citiesAreas, 18705 /* fileSize */);
+    TestGeneratedFile(citiesAreas, 18601 /* fileSize */);
     TestGeneratedFile(maxSpeeds, 1301515 /* fileSize */);
     TestGeneratedFile(metalines, 288032 /* fileSize */);
     TestGeneratedFile(restrictions, 371110 /* fileSize */);


### PR DESCRIPTION
сломалось после https://github.com/mapsme/omim/pull/13477

