### PR TITLE
[search] Choose street name language in the same way as result language.

### DIFF
--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -307,8 +307,13 @@ class RankerResultMaker
 {
 public:
   RankerResultMaker(Ranker & ranker, DataSource const & dataSource,
-                    storage::CountryInfoGetter const & infoGetter, Geocoder::Params const & params)
-    : m_ranker(ranker), m_dataSource(dataSource), m_infoGetter(infoGetter), m_params(params)
+                    storage::CountryInfoGetter const & infoGetter,
+                    ReverseGeocoder const & reverseGeocoder, Geocoder::Params const & params)
+    : m_ranker(ranker)
+    , m_dataSource(dataSource)
+    , m_infoGetter(infoGetter)
+    , m_reverseGeocoder(reverseGeocoder)
+    , m_params(params)
   {
   }
 
@@ -355,6 +360,22 @@ private:
 
     center = feature::GetCenter(*ft);
     m_ranker.GetBestMatchName(*ft, name);
+
+    // Insert exact address (street and house number) instead of empty result name.
+    if (name.empty())
+    {
+      ReverseGeocoder::Address addr;
+      LazyAddressGetter addressGetter(m_reverseGeocoder, center);
+      if (addressGetter.GetExactAddress(addr))
+      {
+        if (auto streetFeature = LoadFeature(addr.m_street.m_id))
+        {
+          string streetName;
+          m_ranker.GetBestMatchName(*streetFeature, streetName);
+          name = streetName + ", " + addr.GetHouseNumber();
+        }
+      }
+    }
 
     // Country (region) name is a file name if feature isn't from
     // World.mwm.
@@ -538,6 +559,7 @@ private:
   Ranker & m_ranker;
   DataSource const & m_dataSource;
   storage::CountryInfoGetter const & m_infoGetter;
+  ReverseGeocoder const & m_reverseGeocoder;
   Geocoder::Params const & m_params;
 
   unique_ptr<FeaturesLoaderGuard> m_loader;
@@ -584,14 +606,6 @@ Result Ranker::MakeResult(RankerResult const & rankerResult, bool needAddress,
   if (needAddress)
   {
     LazyAddressGetter addressGetter(m_reverseGeocoder, rankerResult.GetCenter());
-
-    // Insert exact address (street and house number) instead of empty result name.
-    if (name.empty())
-    {
-      ReverseGeocoder::Address addr;
-      if (addressGetter.GetExactAddress(addr))
-        name = FormatStreetAndHouse(addr);
-    }
 
     address = GetLocalizedRegionInfoForResult(rankerResult);
 
@@ -736,7 +750,7 @@ void Ranker::LoadCountriesTree() { m_regionInfoGetter.LoadCountriesTree(); }
 void Ranker::MakeRankerResults(Geocoder::Params const & geocoderParams,
                                vector<RankerResult> & results)
 {
-  RankerResultMaker maker(*this, m_dataSource, m_infoGetter, geocoderParams);
+  RankerResultMaker maker(*this, m_dataSource, m_infoGetter, m_reverseGeocoder, geocoderParams);
   for (auto const & r : m_preRankerResults)
   {
     auto p = maker(r);


### PR DESCRIPTION
Решили пока выбирать имя улицы которое написано в основной строке результата поиска в зависимости от языка запроса.
Адрес в нижней строке решили оставить на языке устройства, т.к. если он написан на языке/алфавите на котором пользователь читает, то и так понятно. А если на языке/алфавите на котором пользователь не читает, то возможно лучше более понятное название региона на родном языке, чем более близкое к запросу, но иероглифыи т.п.
https://docs.google.com/document/d/1m5OaIT1FMt4jr64_eezvGjysJt1qwcrEV_Vfp6WpipM/edit
https://confluence.mail.ru/pages/viewpage.action?pageId=508174374

было:
<img width="627" alt="Снимок экрана 2020-08-13 в 16 47 51" src="https://user-images.githubusercontent.com/9213190/90143181-f93af180-dd85-11ea-8f71-65d0e805d066.png">
<img width="627" alt="Снимок экрана 2020-08-13 в 16 47 45" src="https://user-images.githubusercontent.com/9213190/90143178-f809c480-dd85-11ea-93df-e34471051eef.png">

стало:
<img width="627" alt="Снимок экрана 2020-08-13 в 16 48 27" src="https://user-images.githubusercontent.com/9213190/90143186-fa6c1e80-dd85-11ea-8cae-f4d92993006a.png">
<img width="627" alt="Снимок экрана 2020-08-13 в 16 48 37" src="https://user-images.githubusercontent.com/9213190/90143192-fb04b500-dd85-11ea-84d7-ebcdcc6ef043.png">
