### PR TITLE
[android] Fix subtitle for available hotels without rating.

### DIFF
--- a/android/src/com/mapswithme/maps/search/SearchAdapter.java
+++ b/android/src/com/mapswithme/maps/search/SearchAdapter.java
@@ -225,9 +225,9 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
         {
           Resources rs = itemView.getResources();
           String s = itemView.getResources().getString(R.string.hotel_available);
-          if (tail.length() > 0)
-            tail.append(" • ");
-          tail.append(colorizeString(s, rs.getColor(R.color.base_green)));
+          tail
+            .append(" • ")
+            .append(colorizeString(s, rs.getColor(R.color.base_green)));
         }
       }
       else if (!TextUtils.isEmpty(result.description.airportIata))


### PR DESCRIPTION
Если tail пустой точка всё равно нужна, т.к. перед tail будет тип размещения.

было:
![photo_2020-08-18_14-05-08](https://user-images.githubusercontent.com/9213190/90505768-db8dd380-e15b-11ea-9992-d0434dd30ebb.jpg)

стало:
![photo_2020-08-18_14-05-11](https://user-images.githubusercontent.com/9213190/90505763-d7fa4c80-e15b-11ea-877a-303c21c2db1a.jpg)

баг Саша Блинчиков заведёт, добавлю его сюда когда будет.