### PR TITLE
[android] Added fade view for background on search fragment that will…

### DIFF
--- a/android/res/layout/fragment_search.xml
+++ b/android/res/layout/fragment_search.xml
@@ -86,6 +86,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
     </FrameLayout>
+    <com.mapswithme.maps.widget.FadeView
+      android:id="@+id/fade_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@android:color/black"
+      android:visibility="gone"/>
     <include layout="@layout/guests_and_rooms_menu_bottom_sheet" />
   </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </FrameLayout>

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -743,17 +743,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private void initMap(boolean isLaunchByDeepLink)
   {
     mFadeView = findViewById(R.id.fade_view);
-    mFadeView.setListener(new FadeView.Listener()
-    {
-      @Override
-      public boolean onTouch()
-      {
-        if (!getMainMenuController().isClosed())
-          getMainMenuController().close();
-
-        return getCurrentMenu().close(true);
-      }
-    });
+    mFadeView.setListener(this::onFadeViewTouch);
 
     mMapFragment = (MapFragment) getSupportFragmentManager().findFragmentByTag(MapFragment.class.getName());
     if (mMapFragment == null)
@@ -772,6 +762,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
     {
       container.setOnTouchListener(this);
     }
+  }
+
+  private boolean onFadeViewTouch()
+  {
+    if (!getMainMenuController().isClosed())
+      getMainMenuController().close();
+    mSearchController.closeBottomMenu();
+    return getCurrentMenu().close(true);
   }
 
   public boolean isMapAttached()

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1588,13 +1588,19 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (mSearchController != null && mSearchController.hide())
+    if (mSearchController != null)
     {
-      SearchEngine.INSTANCE.cancelInteractiveSearch();
-      if (mFilterController != null)
-        mFilterController.resetFilterAndParams();
-      mSearchController.clear();
-      return;
+      if (mSearchController.closeBottomMenu())
+        return;
+
+      if (mSearchController.hide())
+      {
+        SearchEngine.INSTANCE.cancelInteractiveSearch();
+        if (mFilterController != null)
+          mFilterController.resetFilterAndParams();
+        mSearchController.clear();
+        return;
+      }
     }
 
     boolean isRoutingCancelled = RoutingController.get().cancel();

--- a/android/src/com/mapswithme/maps/search/SearchFragment.java
+++ b/android/src/com/mapswithme/maps/search/SearchFragment.java
@@ -32,6 +32,7 @@ import com.mapswithme.maps.downloader.MapManager;
 import com.mapswithme.maps.location.LocationHelper;
 import com.mapswithme.maps.location.LocationListener;
 import com.mapswithme.maps.routing.RoutingController;
+import com.mapswithme.maps.widget.FadeView;
 import com.mapswithme.maps.widget.PlaceholderView;
 import com.mapswithme.maps.widget.SearchToolbarController;
 import com.mapswithme.util.SharedPropertiesUtils;
@@ -316,7 +317,8 @@ public class SearchFragment extends BaseMwmFragment
     ViewPager pager = mTabFrame.findViewById(R.id.pages);
 
     mToolbarController = new ToolbarController(view);
-
+    FadeView fadeView = root.findViewById(R.id.fade_view);
+    fadeView.setListener(this::onFadeViewTouch);
     TabLayout tabLayout = root.findViewById(R.id.tabs);
     final TabAdapter tabAdapter = new TabAdapter(getChildFragmentManager(), pager, tabLayout);
 
@@ -401,6 +403,11 @@ public class SearchFragment extends BaseMwmFragment
 
     if (mInitialSearchOnMap)
       showAllResultsOnMap();
+  }
+
+  private boolean onFadeViewTouch()
+  {
+    return mToolbarController.closeBottomMenu();
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/search/SearchFragment.java
+++ b/android/src/com/mapswithme/maps/search/SearchFragment.java
@@ -711,6 +711,9 @@ public class SearchFragment extends BaseMwmFragment
   @Override
   public boolean onBackPressed()
   {
+    if (mToolbarController.closeBottomMenu())
+      return true;
+
     if (mToolbarController.hasQuery())
     {
       mToolbarController.clear();

--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -26,6 +26,7 @@ import com.mapswithme.maps.search.FilterUtils;
 import com.mapswithme.maps.widget.menu.MenuController;
 import com.mapswithme.maps.widget.menu.MenuControllerFactory;
 import com.mapswithme.maps.widget.menu.MenuRoomsGuestsListener;
+import com.mapswithme.maps.widget.menu.MenuStateObserver;
 import com.mapswithme.util.ConnectionState;
 import com.mapswithme.util.InputUtils;
 import com.mapswithme.util.StringUtils;
@@ -179,8 +180,9 @@ public class SearchToolbarController extends ToolbarController
 
     showProgress(false);
     updateButtons(true);
+    MenuStateObserver stateObserver = new RoomsGuestsMenuStateObserver(getActivity());
     mGuiestsRoomsMenuController
-        = MenuControllerFactory.createGuestsRoomsMenuController(this, this);
+        = MenuControllerFactory.createGuestsRoomsMenuController(this, stateObserver, this);
     mGuiestsRoomsMenuController.initialize(getActivity().findViewById(R.id.coordinator));
   }
 
@@ -381,6 +383,17 @@ public class SearchToolbarController extends ToolbarController
                                             mRoomGuestCounts);
   }
 
+  public boolean closeBottomMenu()
+  {
+    if (!mGuiestsRoomsMenuController.isClosed())
+    {
+      mGuiestsRoomsMenuController.close();
+      return true;
+    }
+
+    return false;
+  }
+
   public interface FilterParamsChangedListener
   {
     void onBookingParamsChanged();
@@ -431,6 +444,37 @@ public class SearchToolbarController extends ToolbarController
         Objects.requireNonNull(mChooseDatesChip);
         mChooseDatesChip.setText(mPicker.getHeaderText());
       }
+    }
+  }
+
+  private static class RoomsGuestsMenuStateObserver implements MenuStateObserver
+  {
+    @NonNull
+    private final Activity mActivity;
+
+    private RoomsGuestsMenuStateObserver(@NonNull Activity activity)
+    {
+      mActivity = activity;
+    }
+
+    @Override
+    public void onMenuOpen()
+    {
+      FadeView fadeView = mActivity.findViewById(R.id.fade_view);
+      if (fadeView == null)
+        return;
+
+      fadeView.fadeIn();
+    }
+
+    @Override
+    public void onMenuClosed()
+    {
+      FadeView fadeView = mActivity.findViewById(R.id.fade_view);
+      if (fadeView == null)
+        return;
+
+      fadeView.fadeOut();
     }
   }
 }

--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -94,7 +94,7 @@ public class SearchToolbarController extends ToolbarController
   @NonNull
   private List<FilterParamsChangedListener> mFilterParamsChangedListeners = new ArrayList<>();
   @NonNull
-  private MenuController mGuiestsRoomsMenuController;
+  private MenuController mGuestsRoomsMenuController;
   @NonNull
   private final View.OnClickListener mRoomsClickListener = v -> {
     if (!ConnectionState.isConnected())
@@ -105,10 +105,10 @@ public class SearchToolbarController extends ToolbarController
 
     InputUtils.hideKeyboard(v);
 
-    if (!mGuiestsRoomsMenuController.isClosed())
+    if (!mGuestsRoomsMenuController.isClosed())
       return;
 
-    mGuiestsRoomsMenuController.open();
+    mGuestsRoomsMenuController.open();
   };
 
   @Override
@@ -183,9 +183,9 @@ public class SearchToolbarController extends ToolbarController
     showProgress(false);
     updateButtons(true);
     MenuStateObserver stateObserver = new RoomsGuestsMenuStateObserver(getActivity());
-    mGuiestsRoomsMenuController
+    mGuestsRoomsMenuController
         = MenuControllerFactory.createGuestsRoomsMenuController(this, stateObserver, this);
-    mGuiestsRoomsMenuController.initialize(getActivity().findViewById(R.id.coordinator));
+    mGuestsRoomsMenuController.initialize(getActivity().findViewById(R.id.coordinator));
   }
 
   public void setFilterParams(@NonNull BookingFilterParams params)
@@ -387,9 +387,9 @@ public class SearchToolbarController extends ToolbarController
 
   public boolean closeBottomMenu()
   {
-    if (!mGuiestsRoomsMenuController.isClosed())
+    if (!mGuestsRoomsMenuController.isClosed())
     {
-      mGuiestsRoomsMenuController.close();
+      mGuestsRoomsMenuController.close();
       return true;
     }
 

--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -103,6 +103,8 @@ public class SearchToolbarController extends ToolbarController
       return;
     }
 
+    InputUtils.hideKeyboard(v);
+
     if (!mGuiestsRoomsMenuController.isClosed())
       return;
 

--- a/android/src/com/mapswithme/maps/widget/menu/MenuControllerFactory.java
+++ b/android/src/com/mapswithme/maps/widget/menu/MenuControllerFactory.java
@@ -20,10 +20,11 @@ public class MenuControllerFactory
 
   @NonNull
   public static MenuController createGuestsRoomsMenuController(
-      @NonNull MenuRoomsGuestsListener listener,
+      @NonNull MenuRoomsGuestsListener listener, @NonNull MenuStateObserver stateObserver,
       @NonNull FilterUtils.RoomsGuestsCountProvider provider)
   {
     return new BottomSheetMenuController(R.id.guests_and_rooms_menu_sheet,
-                                         new GuestsRoomsMenuRenderer(listener, provider), null);
+                                         new GuestsRoomsMenuRenderer(listener, provider),
+                                         stateObserver);
   }
 }


### PR DESCRIPTION
… be shown when rooms picker is opened
https://jira.mail.ru/browse/MAPSME-14187

- [ ] Реализовать заглушечные методы toCounts/toRooms, распределяющие выбранных гостей(взрослых и детей) по выбранным комнатам и собирающих распределенных ранее гостей по комнатам в структура count( @tatiana-yan этот пункт сделаю скорее всего в другом PR, чтобы не задерживать более создание release ветки)

- [x] При открытие меню остальная часть экрана должна затемняться

- [x] Обработать кейсы закрытия меню, кроме пальца: нажатия на крестик в поисковой строке, стирание поисковой строки и т.д. **Это проблема перестала существовать с добавлением затемнения**. Любой клик в темную область, как раз под которой поле ввода и крестик для стирания, приводит к скрытию пикера.

- [x] Реализовать закрытие rooms/guests пикера по хардварной кнопке Back

- [x] Cкрывать клавиатуру при нажатии на чипсу "Rooms"

@keksikex скорее всего, дефолтные значения для даты и комнат надо будет установливать сразу при отображение кнопок в тулбаре, т.е. строки "Choose dates/Rooms" использоваться не будут, в принципе. Это понимание пришло, когда я столкнулся с таким кейсом: тапаем на Rooms->открывается rooms bottoms sheet->просто закрываем rooms bottoms sheet и в кнопку Rooms в тулбаре вставляется автоматом 2 - это выглядит странным, поэтому надо будет скорее всего сразу дефолтные значения проставлятьв даты и румы, что скажешь? @tatiana-yan fyi

_- [ ] Выставлять дефолтные даты и румы сразу в кнопки в тулбаре при их отображении._ С @keksikex согласовано. **Решили не делать так**. Оставляем текущее поведение, по скрытию пикера с комнатами безусловно проставятся дефолтные значения из него в кнопку Rooms.