### PR TITLE
speedup compilation with help of cmake 3.6 pch support

### DIFF
--- a/qt/qt_precompiled_header.hpp
+++ b/qt/qt_precompiled_header.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "testing/testing.hpp"
+
+#include "map/framework.hpp"
+
+#include "platform/platform.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/macros.hpp"
+#include "base/stl_helpers.hpp"
+#include "base/string_utils.hpp"
+
+#include <QtCore/QObject>
+#include <QtWidgets/QWidget>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>


### PR DESCRIPTION
Since cmake 3.16 there is cross-platform support of precompiled
headers in cmake. So I add code to check version of cmake,
and if it is recent enough build system switches to cmake's pch
support.

I tested with such command:
touch qt/main.cpp && time ninja MAPS.ME
Before: ~ 35 seconds on my machine (average)
After: ~ 21 seconds (average)

What make this speedup possible:
1. With cmake's pch support generation of precompiled headers
  happens only if something changed, while current PCH script cause
  recompilation of headers every run of ninja. It takes ~ 4 seconds
2. Now it is possible to set precompiled headers per target,
   and I include map/framework.hpp for "qt".