### PR TITLE
[iOS] Fixed headers resend in WebView

### DIFF
--- a/iphone/Maps/Bookmarks/Catalog/CatalogWebViewController.swift
+++ b/iphone/Maps/Bookmarks/Catalog/CatalogWebViewController.swift
@@ -265,6 +265,7 @@ final class CatalogWebViewController: WebViewController {
         if let s = self, let navBar = s.navigationController?.navigationBar {
           s.signup(anchor: navBar, source: .guideCatalogue, onComplete: {
             if $0 {
+              s.reloadFromOrigin()
               s.handlePendingTransactions(completion: completion)
             } else {
               MWMAlertViewController.activeAlert().presentInfoAlert(L("title_error_downloading_bookmarks"),
@@ -327,7 +328,10 @@ final class CatalogWebViewController: WebViewController {
           case .needAuth:
             if let s = self, let navBar = s.navigationController?.navigationBar {
               s.signup(anchor: navBar, source: .guideCatalogue) {
-                if $0 { s.download() }
+                if $0 {
+                  s.reloadFromOrigin()
+                  s.download()
+                }
               }
             }
           case .needPayment:
@@ -391,7 +395,7 @@ final class CatalogWebViewController: WebViewController {
                                                                 source: kStatWebView,
                                                                 successDialog: .none) { [weak self] success in
                                                                   if success {
-                                                                    self?.webView.reloadFromOrigin()
+                                                                    self?.reloadFromOrigin()
                                                                     self?.download()
                                                                   }
     }
@@ -404,7 +408,7 @@ final class CatalogWebViewController: WebViewController {
                                                                 source: kStatWebView,
                                                                 successDialog: .success) { [weak self] success in
                                                                   if success {
-                                                                    self?.webView.reloadFromOrigin()
+                                                                    self?.reloadFromOrigin()
                                                                   }
     }
     present(subscribeViewController, animated: true)
@@ -475,7 +479,7 @@ extension CatalogWebViewController: PaidRouteViewControllerDelegate {
   func didCompleteSubscription(_ viewController: PaidRouteViewController) {
     dismiss(animated: true)
     download()
-    webView.reloadFromOrigin()
+    reloadFromOrigin()
   }
 
   func didCompletePurchase(_ viewController: PaidRouteViewController) {

--- a/iphone/Maps/Common/WebViewController.h
+++ b/iphone/Maps/Common/WebViewController.h
@@ -25,6 +25,7 @@ typedef void (^WebViewControllerWillLoadBlock)(BOOL, NSDictionary<NSString *, NS
 - (BOOL)shouldAddAccessToken;
 - (void)forward;
 - (void)back;
+- (void)reloadFromOrigin;
 - (NSString *)configuredHtmlWithText:(NSString *)htmlText;
 - (void)performURLRequest;
 

--- a/iphone/Maps/Common/WebViewController.m
+++ b/iphone/Maps/Common/WebViewController.m
@@ -8,6 +8,7 @@
 @property(copy, nonatomic) MWMStringBlock onSuccess;
 @property(nonatomic) BOOL authorized;
 @property(nonatomic) WKWebView *webView;
+@property(nonatomic) BOOL shouldResendHeaders;
 
 @end
 
@@ -161,12 +162,13 @@
     return;
   }
 
-  if ([inRequest.URL isEqual:_m_url]) {
+  if (!self.shouldResendHeaders) {
     decisionHandler(WKNavigationActionPolicyAllow);
   } else {
     _m_url = inRequest.URL;
-    [self performURLRequest];
+    self.shouldResendHeaders = NO;
     decisionHandler(WKNavigationActionPolicyCancel);
+    [self performURLRequest];
   }
 }
 
@@ -176,6 +178,11 @@
 
 - (void)back {
   [self.webView goBack];
+}
+
+- (void)reloadFromOrigin {
+  self.shouldResendHeaders = YES;
+  [self.webView reloadFromOrigin];
 }
 
 #if DEBUG


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14513

Пересылать заголовки при каждом переходе было не лучшей идеей. Добавил флаг на обновление заголовков только на перезагрузке текущей страницы.