### PR TITLE
[transit] Read lines metadata for subway layer rendering.

### DIFF
--- a/drape_frontend/transit_scheme_renderer.cpp
+++ b/drape_frontend/transit_scheme_renderer.cpp
@@ -7,7 +7,6 @@
 
 #include "drape/graphics_context.hpp"
 #include "drape/overlay_tree.hpp"
-#include "drape/vertex_array_buffer.hpp"
 
 #include <algorithm>
 

--- a/transit/transit_display_info.hpp
+++ b/transit/transit_display_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "transit/experimental/transit_types_experimental.hpp"
+#include "transit/transit_entities.hpp"
 #include "transit/transit_types.hpp"
 #include "transit/transit_version.hpp"
 
@@ -34,9 +35,12 @@ using TransitStopsInfoPT = std::map<::transit::TransitId, ::transit::experimenta
 using TransitTransfersInfoPT = std::map<::transit::TransitId, ::transit::experimental::Transfer>;
 using TransitShapesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Shape>;
 using TransitLinesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Line>;
+using TransitLinesMetadataInfoPT =
+    std::map<::transit::TransitId, ::transit::experimental::LineMetadata>;
 using TransitRoutesInfoPT = std::map<::transit::TransitId, ::transit::experimental::Route>;
 using TransitNetworksInfoPT = std::map<::transit::TransitId, ::transit::experimental::Network>;
-
+using TransitEdgesInfoPT =
+    std::unordered_map<::transit::EdgeId, ::transit::EdgeData, ::transit::EdgeIdHasher>;
 struct TransitDisplayInfo
 {
   ::transit::TransitVersion m_transitVersion;
@@ -51,10 +55,12 @@ struct TransitDisplayInfo
 
   TransitNetworksInfoPT m_networksPT;
   TransitLinesInfoPT m_linesPT;
+  TransitLinesMetadataInfoPT m_linesMetadataPT;
   TransitRoutesInfoPT m_routesPT;
   TransitStopsInfoPT m_stopsPT;
   TransitTransfersInfoPT m_transfersPT;
   TransitShapesInfoPT m_shapesPT;
+  TransitEdgesInfoPT m_edgesPT;
 };
 
 using TransitDisplayInfos = std::map<MwmSet::MwmId, std::unique_ptr<TransitDisplayInfo>>;


### PR DESCRIPTION
Декомпозиция большого реквеста про отрисовку слоя метро на новой версии транзитной секции: #13476

Чтение метадаты линий для работы с ней в transit_scheme_builder. Метадата линий - это разбиение линий на кусочки, для каждого из которых определено смещение.
Выдержка из lines_metadata.transit.json:
`{"id":1869729,"shape_segments":[{"order":-3,"start_index": 396,"end_index":1894}]}`
Означает, что у линии 1869729 есть сегмент с 396 по 1894 индексы на полилинии (айди полилинии находится в lines.transit.json), который в дрейпе должен отрисоваться со смещением -3.

А также чтение ребер и пересадок (долг с прошлых реквестов).