### PR TITLE
[transit][subway generator] Split lines into segments for rendering on the subway layer.

### DIFF
--- a/drape_frontend/transit_scheme_builder.hpp
+++ b/drape_frontend/transit_scheme_builder.hpp
@@ -264,6 +264,8 @@ private:
                     m2::PointD const & pivot, dp::Color const & colorConst, float lineOffset,
                     float halfWidth, float depth, dp::Batcher & batcher);
 
+  StopNodeParamsPT & GetStopOrTransfer(MwmSchemeData & scheme, ::transit::TransitId id);
+
   using TransitSchemes = std::map<MwmSet::MwmId, MwmSchemeData>;
   TransitSchemes m_schemes;
 

--- a/transit/experimental/transit_data.cpp
+++ b/transit/experimental/transit_data.cpp
@@ -163,7 +163,10 @@ std::vector<m2::PointD> GetPointsFromJson(json_t * obj)
 
 TimeTable GetTimeTableFromJson(json_t * obj)
 {
-  json_t * arr = base::GetJSONObligatoryField(obj, "timetable");
+  json_t * arr = base::GetJSONOptionalField(obj, "timetable");
+  if (!arr)
+    return TimeTable{};
+
   CHECK(json_is_array(arr), ());
 
   TimeTable timetable;

--- a/transit/world_feed/feed_helpers.hpp
+++ b/transit/world_feed/feed_helpers.hpp
@@ -97,7 +97,7 @@ LineParts::iterator FindLinePart(LineParts & lineParts, LineSegment const & segm
 struct LineSchemeData
 {
   TransitId m_lineId = 0;
-  TransitId m_routeId = 0;
+  std::string m_color;
   ShapeLink m_shapeLink;
 
   LineParts m_lineParts;
@@ -122,4 +122,29 @@ std::optional<LineSegment> GetIntersection(size_t start1, size_t finish1, size_t
 // total parallel lines count. Line order must be symmetrical with respect to the сentral axis of
 // the polyline.
 int CalcSegmentOrder(size_t segIndex, size_t totalSegCount);
+
+// Returns true if |stopIndex| doesn't equal size_t maximum value.
+bool StopIndexIsSet(size_t stopIndex);
+
+// Gets interval of stop indexes on the line with |lineStopIds| which belong to the region and
+// its vicinity. |stopIdsInRegion| is set of all stop ids in the region.
+std::pair<size_t, size_t> GetStopsRange(IdList const & lineStopIds, IdSet const & stopIdsInRegion);
+
+// Returns indexes of points |p1| and |p2| on the |shape| polyline. If there are more then 1
+// occurrences of |p1| or |p2| in |shape|, indexes with minimum distance are returned.
+std::pair<size_t, size_t> FindPointsOnShape(std::vector<m2::PointD> const & shape,
+                                            m2::PointD const & p1, m2::PointD const & p2);
+
+// Returns indexes of first and last points of |segment| in the |shape| polyline. If |edgeShape|
+// is not found returns pair of zeroes.
+std::pair<size_t, size_t> FindSegmentOnShape(std::vector<m2::PointD> const & shape,
+                                             std::vector<m2::PointD> const & segment);
+
+// Returns reversed vector.
+template <class T>
+std::vector<T> GetReversed(std::vector<T> vec)
+{
+  std::reverse(vec.begin(), vec.end());
+  return vec;
+}
 }  // namespace transit

--- a/transit/world_feed/subway_converter.cpp
+++ b/transit/world_feed/subway_converter.cpp
@@ -9,38 +9,54 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 
 #include "3party/jansson/myjansson.hpp"
 #include "3party/opening_hours/opening_hours.hpp"
 
 namespace
 {
-// Returns the index of the |point| in the |shape| polyline.
-size_t FindPointIndex(std::vector<m2::PointD> const & shape, m2::PointD const & point)
+double constexpr kEps = 1e-5;
+
+// Returns route id of the line. Route id is calculated in the same way as in the script
+// tools/transit/transit_graph_generator.py.
+uint32_t GetSubwayRouteId(routing::transit::LineId lineId)
 {
-  static double constexpr eps = 1e-6;
-  auto it = std::find_if(shape.begin(), shape.end(), [&point](m2::PointD const & p) {
-    return base::AlmostEqualAbs(p, point, eps);
-  });
-
-  CHECK(it != shape.end(), (point));
-
-  return std::distance(shape.begin(), it);
+  return static_cast<uint32_t>(lineId >> 4);
 }
 
-// Returns polyline found by pair of stop ids.
-std::vector<m2::PointD> GetShapeByStops(std::vector<routing::transit::Shape> const & shapes,
-                                        routing::transit::StopId stopId1,
-                                        routing::transit::StopId stopId2)
+// Increments |lineSegment| indexes by |shapeLink| start index.
+void ShiftSegmentOnShape(transit::LineSegment & lineSegment, transit::ShapeLink const & shapeLink)
 {
-  auto const itShape = std::find_if(
-      shapes.begin(), shapes.end(), [stopId1, stopId2](routing::transit::Shape const & shape) {
-        return shape.GetId().GetStop1Id() == stopId1 && shape.GetId().GetStop2Id() == stopId2;
-      });
+  lineSegment.m_startIdx += shapeLink.m_startIndex;
+  lineSegment.m_endIdx += shapeLink.m_startIndex;
+}
 
-  CHECK(itShape != shapes.end(), (stopId1, stopId2));
+// Returns segment edge points on the polyline.
+std::pair<m2::PointD, m2::PointD> GetSegmentEdgesOnPolyline(
+    std::vector<m2::PointD> const & polyline, transit::LineSegment const & segment)
+{
+  CHECK_GREATER(polyline.size(), std::max(segment.m_startIdx, segment.m_endIdx), ());
 
-  return itShape->GetPolyline();
+  m2::PointD const startPoint = polyline[segment.m_startIdx];
+  m2::PointD const endPoint = polyline[segment.m_endIdx];
+
+  return {startPoint, endPoint};
+}
+
+// Calculates |segment| start and end indexes on the polyline with length |polylineSize| in
+// assumption that this segment is reversed. Example: we have polyline [1, 2, 3, 4, 5, 6] and
+// segment [5, 4]. We reversed this segment so it transformed to [4, 5] and found it on polyline.
+// Its start and end indexes on the polyline are 3, 4. We want to calculate start and end indexes of
+// the original segment [5, 4]. These indexes are 4, 3.
+void UpdateReversedSegmentIndexes(transit::LineSegment & segment, size_t polylineSize)
+{
+  size_t const len = segment.m_endIdx - segment.m_startIdx + 1;
+  segment.m_endIdx = static_cast<uint32_t>(polylineSize - segment.m_startIdx - 1);
+  segment.m_startIdx = static_cast<uint32_t>(segment.m_endIdx - len + 1);
+
+  CHECK_GREATER(segment.m_endIdx, segment.m_startIdx, ());
+  CHECK_GREATER(polylineSize, segment.m_endIdx, ());
 }
 }  // namespace
 
@@ -72,6 +88,8 @@ bool SubwayConverter::Convert()
 
   m_feed.ModifyLinesAndShapes();
 
+  MinimizeReversedLinesCount();
+
   if (!ConvertStops())
     return false;
 
@@ -82,7 +100,14 @@ bool SubwayConverter::Convert()
   if (!ConvertGates())
     return false;
 
-  return ConvertEdges();
+  if (!ConvertEdges())
+    return false;
+
+  m_feed.SplitFeedIntoRegions();
+
+  PrepareLinesMetadata();
+
+  return true;
 }
 
 bool SubwayConverter::ConvertNetworks()
@@ -121,13 +146,15 @@ bool SubwayConverter::SplitEdges()
 std::pair<TransitId, RouteData> SubwayConverter::MakeRoute(
     routing::transit::Line const & lineSubway)
 {
-  std::string const & routeTitle = lineSubway.GetNumber();
-  std::string const routeHash =
-      BuildHash(kHashPrefix, std::to_string(lineSubway.GetNetworkId()), routeTitle);
+  uint32_t routeSubwayId = GetSubwayRouteId(lineSubway.GetId());
+
+  std::string const routeHash = BuildHash(kHashPrefix, std::to_string(lineSubway.GetNetworkId()),
+                                          std::to_string(routeSubwayId));
+
   TransitId const routeId = m_feed.m_idGenerator.MakeId(routeHash);
 
   RouteData routeData;
-  routeData.m_title = routeTitle;
+  routeData.m_title = lineSubway.GetNumber();
   routeData.m_routeType = kSubwayRouteType;
   routeData.m_networkId = lineSubway.GetNetworkId();
   routeData.m_color = lineSubway.GetColor();
@@ -193,22 +220,9 @@ std::pair<EdgeId, EdgeData> SubwayConverter::MakeEdge(routing::transit::Edge con
   EdgeData edgeData;
   edgeData.m_weight = edgeSubway.GetWeight();
 
-  auto const it = m_edgesOnShapes.find(edgeId);
-  CHECK(it != m_edgesOnShapes.end(), (lineId));
-
-  m2::PointD const pointStart = it->second.first;
-  m2::PointD const pointEnd = it->second.second;
+  CHECK(m_feed.m_edgesOnShapes.find(edgeId) != m_feed.m_edgesOnShapes.end(), (lineId));
 
   edgeData.m_shapeLink.m_shapeId = m_feed.m_lines.m_data[lineId].m_shapeLink.m_shapeId;
-
-  auto itShape = m_feed.m_shapes.m_data.find(edgeData.m_shapeLink.m_shapeId);
-  CHECK(itShape != m_feed.m_shapes.m_data.end(), ("Shape does not exist."));
-
-  auto const & shapePoints = itShape->second.m_points;
-  CHECK(!shapePoints.empty(), ("Shape is empty."));
-
-  edgeData.m_shapeLink.m_startIndex = FindPointIndex(shapePoints, pointStart);
-  edgeData.m_shapeLink.m_endIndex = FindPointIndex(shapePoints, pointEnd);
 
   return {edgeId, edgeData};
 }
@@ -228,6 +242,9 @@ std::pair<TransitId, StopData> SubwayConverter::MakeStop(routing::transit::Stop 
   StopData stopData;
   stopData.m_point = stopSubway.GetPoint();
   stopData.m_osmId = stopSubway.GetOsmId();
+
+  if (stopSubway.GetFeatureId() != routing::transit::kInvalidFeatureId)
+    stopData.m_featureId = stopSubway.GetFeatureId();
 
   return {stopId, stopData};
 }
@@ -256,40 +273,69 @@ bool SubwayConverter::ConvertLinesBasedData()
 
     CHECK_EQUAL(lineSubway.GetStopIds().size(), 1, ("Line shouldn't be split into ranges."));
 
-    auto const & rangeSubway = lineSubway.GetStopIds().front();
-    CHECK_GREATER(rangeSubway.size(), 1, ("Range must include at least two stops."));
+    auto const & stopIdsSubway = lineSubway.GetStopIds().front();
 
-    for (size_t i = 0; i < rangeSubway.size(); ++i)
+    CHECK_GREATER(stopIdsSubway.size(), 1, ("Range must include at least two stops."));
+
+    for (size_t i = 0; i < stopIdsSubway.size(); ++i)
     {
-      auto const stopIdSubway = rangeSubway[i];
+      auto const stopIdSubway = stopIdsSubway[i];
       std::string const stopHash = BuildHash(kHashPrefix, std::to_string(stopIdSubway));
       TransitId const stopId = m_feed.m_idGenerator.MakeId(stopHash);
+
       lineData.m_stopIds.emplace_back(stopId);
       m_stopIdMapping.emplace(stopIdSubway, stopId);
 
       if (i == 0)
         continue;
 
-      auto const stopIdSubwayPrev = rangeSubway[i - 1];
+      auto const stopIdSubwayPrev = stopIdsSubway[i - 1];
+      CHECK(stopIdSubwayPrev != stopIdSubway, (stopIdSubway));
+
       auto const & edge = FindEdge(stopIdSubwayPrev, stopIdSubway, lineId);
 
-      for (auto const & id : edge.GetShapeIds())
+      CHECK_LESS_OR_EQUAL(edge.GetShapeIds().size(), 1, (edge));
+
+      std::vector<m2::PointD> edgePoints;
+
+      m2::PointD const prevPoint = FindById(m_graphData.GetStops(), stopIdSubwayPrev)->GetPoint();
+      m2::PointD const curPoint = FindById(m_graphData.GetStops(), stopIdSubway)->GetPoint();
+
+      if (edge.GetShapeIds().empty())
       {
-        auto const & polyline = GetShapeByStops(shapesSubway, id.GetStop1Id(), id.GetStop2Id());
-        CHECK(!polyline.empty(), ());
+        edgePoints.push_back(prevPoint);
+        edgePoints.push_back(curPoint);
+      }
+      else
+      {
+        routing::transit::ShapeId shapeIdSubway = edge.GetShapeIds().back();
+
+        auto polyline = FindById(shapesSubway, shapeIdSubway)->GetPolyline();
+
+        CHECK(polyline.size() > 1, ());
+
+        double const distToPrevStop = mercator::DistanceOnEarth(polyline.front(), prevPoint);
+        double const distToNextStop = mercator::DistanceOnEarth(polyline.front(), curPoint);
+
+        if (distToPrevStop > distToNextStop)
+          std::reverse(polyline.begin(), polyline.end());
 
         // We remove duplicate point from the shape before appending polyline to it.
         if (!shapeData.m_points.empty() && shapeData.m_points.back() == polyline.front())
           shapeData.m_points.pop_back();
 
         shapeData.m_points.insert(shapeData.m_points.end(), polyline.begin(), polyline.end());
+
+        edgePoints = polyline;
       }
 
       EdgeId const curEdge(m_stopIdMapping[stopIdSubwayPrev], stopId, lineId);
-      EdgePoints const edgePoints(shapeData.m_points.front(), shapeData.m_points.back());
 
-      if (!m_edgesOnShapes.emplace(curEdge, edgePoints).second)
+      auto [itEdgeOnShape, inserted] =
+          m_feed.m_edgesOnShapes.emplace(curEdge, std::vector<std::vector<m2::PointD>>{edgePoints});
+      if (inserted)
       {
+        itEdgeOnShape->second.push_back(edgePoints);
         LOG(LWARNING, ("Edge duplicate in subways. stop1_id", stopIdSubwayPrev, "stop2_id",
                        stopIdSubway, "line_id", lineId));
       }
@@ -300,7 +346,7 @@ bool SubwayConverter::ConvertLinesBasedData()
   }
 
   LOG(LDEBUG, ("Converted", m_feed.m_routes.m_data.size(), "routes,", m_feed.m_lines.m_data.size(),
-               "lines from subways to public transport."));
+               "lines."));
 
   return !m_feed.m_lines.m_data.empty();
 }
@@ -313,8 +359,7 @@ bool SubwayConverter::ConvertStops()
   for (auto const & stopSubway : stopsSubway)
     m_feed.m_stops.m_data.emplace(MakeStop(stopSubway));
 
-  LOG(LINFO,
-      ("Converted", m_feed.m_stops.m_data.size(), "stops from subways to public transport."));
+  LOG(LINFO, ("Converted", m_feed.m_stops.m_data.size(), "stops."));
 
   return !m_feed.m_stops.m_data.empty();
 }
@@ -327,6 +372,28 @@ bool SubwayConverter::ConvertTransfers()
   for (auto const & transferSubway : transfersSubway)
   {
     auto const [transferId, transferData] = MakeTransfer(transferSubway);
+
+    std::map<TransitId, std::set<TransitId>> routeToStops;
+
+    for (auto const & stopId : transferData.m_stopsIds)
+    {
+      for (auto const & [lineId, lineData] : m_feed.m_lines.m_data)
+      {
+        auto it = std::find(lineData.m_stopIds.begin(), lineData.m_stopIds.end(), stopId);
+        if (it != lineData.m_stopIds.end())
+        {
+          routeToStops[lineData.m_routeId].insert(stopId);
+        }
+      }
+    }
+
+    // We don't count as transfers tranfer points between lines on the same route, so we skip them.
+    if (routeToStops.size() < 2)
+    {
+      LOG(LINFO, ("Skip transfer on route", transferId));
+      continue;
+    }
+
     m_feed.m_transfers.m_data.emplace(transferId, transferData);
 
     // All stops are already present in |m_feed| before the |ConvertTransfers()| call.
@@ -334,8 +401,7 @@ bool SubwayConverter::ConvertTransfers()
       LinkTransferIdToStop(m_feed.m_stops.m_data.at(stopId), transferId);
   }
 
-  LOG(LINFO, ("Converted", m_feed.m_transfers.m_data.size(),
-              "transfers from subways to public transport."));
+  LOG(LINFO, ("Converted", m_feed.m_transfers.m_data.size(), "transfers."));
 
   return !m_feed.m_transfers.m_data.empty();
 }
@@ -351,8 +417,7 @@ bool SubwayConverter::ConvertGates()
     m_feed.m_gates.m_data.emplace(gateId, gateData);
   }
 
-  LOG(LINFO,
-      ("Converted", m_feed.m_gates.m_data.size(), "gates from subways to public transport."));
+  LOG(LINFO, ("Converted", m_feed.m_gates.m_data.size(), "gates."));
 
   return !m_feed.m_gates.m_data.empty();
 }
@@ -362,16 +427,411 @@ bool SubwayConverter::ConvertEdges()
   for (auto const & edgeSubway : m_edgesSubway)
     m_feed.m_edges.m_data.emplace(MakeEdge(edgeSubway));
 
-  LOG(LINFO,
-      ("Converted", m_feed.m_edges.m_data.size(), "edges from subways to public transport."));
+  LOG(LINFO, ("Converted", m_feed.m_edges.m_data.size(), "edges."));
 
   for (auto const & edgeTransferSubway : m_edgesTransferSubway)
     m_feed.m_edgesTransfers.m_data.emplace(MakeEdgeTransfer(edgeTransferSubway));
 
-  LOG(LINFO, ("Converted", m_feed.m_edgesTransfers.m_data.size(),
-              "edges from subways to transfer edges in public transport."));
+  LOG(LINFO, ("Converted", m_feed.m_edgesTransfers.m_data.size(), "transfer edges."));
 
   return !m_feed.m_edges.m_data.empty() && !m_feed.m_edgesTransfers.m_data.empty();
+}
+
+void SubwayConverter::MinimizeReversedLinesCount()
+{
+  for (auto & [lineId, lineData] : m_feed.m_lines.m_data)
+  {
+    if (lineData.m_shapeLink.m_startIndex < lineData.m_shapeLink.m_endIndex)
+      continue;
+
+    auto revStopIds = GetReversed(lineData.m_stopIds);
+
+    bool reversed = false;
+
+    for (auto const & [lineIdStraight, lineDataStraight] : m_feed.m_lines.m_data)
+    {
+      if (lineIdStraight == lineId ||
+          lineDataStraight.m_shapeLink.m_startIndex > lineDataStraight.m_shapeLink.m_endIndex ||
+          lineDataStraight.m_shapeLink.m_shapeId != lineData.m_shapeLink.m_shapeId)
+      {
+        continue;
+      }
+
+      if (revStopIds == lineDataStraight.m_stopIds)
+      {
+        lineData.m_shapeLink = lineDataStraight.m_shapeLink;
+        LOG(LDEBUG, ("Reversed line", lineId, "to line", lineIdStraight, "shapeLink",
+                     lineData.m_shapeLink));
+        reversed = true;
+        break;
+      }
+    }
+
+    if (!reversed)
+    {
+      std::swap(lineData.m_shapeLink.m_startIndex, lineData.m_shapeLink.m_endIndex);
+      LOG(LDEBUG, ("Reversed line", lineId, "shapeLink", lineData.m_shapeLink));
+    }
+  }
+}
+
+std::vector<LineSchemeData> SubwayConverter::GetLinesOnScheme(
+    std::unordered_map<TransitId, LineSegmentInRegion> const & linesInRegion) const
+{
+  // Color of line to shape link and one of line ids with this link.
+  std::map<std::string, std::map<ShapeLink, TransitId>> colorsToLines;
+
+  for (auto const & [lineId, lineData] : linesInRegion)
+  {
+    if (lineData.m_splineParent)
+    {
+      LOG(LINFO, ("Line is short spline. We skip it. Id", lineId));
+      continue;
+    }
+
+    auto itLine = m_feed.m_lines.m_data.find(lineId);
+    CHECK(itLine != m_feed.m_lines.m_data.end(), ());
+
+    TransitId const routeId = itLine->second.m_routeId;
+    auto itRoute = m_feed.m_routes.m_data.find(routeId);
+    CHECK(itRoute != m_feed.m_routes.m_data.end(), ());
+    std::string const & color = itRoute->second.m_color;
+
+    ShapeLink const & newShapeLink = lineData.m_shapeLink;
+
+    auto [it, inserted] = colorsToLines.emplace(color, std::map<ShapeLink, TransitId>());
+
+    if (inserted)
+    {
+      it->second[newShapeLink] = lineId;
+      continue;
+    }
+
+    bool insert = true;
+    std::vector<ShapeLink> linksForRemoval;
+
+    for (auto const & [shapeLink, lineId] : it->second)
+    {
+      if (shapeLink.m_shapeId != newShapeLink.m_shapeId)
+        continue;
+
+      // New shape link is fully included into the existing one.
+      if (shapeLink.m_startIndex <= newShapeLink.m_startIndex &&
+          shapeLink.m_endIndex >= newShapeLink.m_endIndex)
+      {
+        insert = false;
+        continue;
+      }
+
+      // Existing shape link is fully included into the new one. It should be removed.
+      if (newShapeLink.m_startIndex <= shapeLink.m_startIndex &&
+          newShapeLink.m_endIndex >= shapeLink.m_endIndex)
+      {
+        linksForRemoval.push_back(shapeLink);
+      }
+    }
+
+    for (auto const sl : linksForRemoval)
+      it->second.erase(sl);
+
+    if (insert)
+      it->second[newShapeLink] = lineId;
+  }
+
+  std::vector<LineSchemeData> linesOnScheme;
+
+  for (auto const & [color, linksToLines] : colorsToLines)
+  {
+    CHECK(!linksToLines.empty(), (color));
+
+    for (auto const & [shapeLink, lineId] : linksToLines)
+    {
+      LineSchemeData data;
+      data.m_lineId = lineId;
+      data.m_color = color;
+      data.m_shapeLink = shapeLink;
+
+      linesOnScheme.push_back(data);
+    }
+  }
+
+  return linesOnScheme;
+}
+
+enum class LineSegmentState
+{
+  Start = 0,
+  Finish
+};
+
+struct LineSegmentInfo
+{
+  LineSegmentInfo() = default;
+  LineSegmentInfo(LineSegmentState const & state, bool codirectional)
+    : m_state(state), m_codirectional(codirectional)
+  {
+  }
+
+  LineSegmentState m_state = LineSegmentState::Start;
+  bool m_codirectional = false;
+};
+
+struct LinePointState
+{
+  std::map<TransitId, LineSegmentInfo> parallelLineStates;
+  m2::PointD m_firstPoint;
+};
+
+using LineGeometry = std::vector<m2::PointD>;
+using ColorToLinepartsCache = std::map<std::string, std::vector<LineGeometry>>;
+
+bool Equal(LineGeometry const & line1, LineGeometry const & line2)
+{
+  if (line1.size() != line2.size())
+    return false;
+
+  for (size_t i = 0; i < line1.size(); ++i)
+  {
+    if (!base::AlmostEqualAbs(line1[i], line2[i], kEps))
+      return false;
+  }
+
+  return true;
+}
+
+bool AddToCache(std::string const & color, LineGeometry const & linePart,
+                ColorToLinepartsCache & cache)
+{
+  auto [it, inserted] = cache.emplace(color, std::vector<LineGeometry>());
+
+  if (inserted)
+  {
+    it->second.push_back(linePart);
+    return true;
+  }
+
+  std::vector<m2::PointD> linePartRev = GetReversed(linePart);
+
+  for (LineGeometry const & cachedPart : it->second)
+  {
+    if (Equal(cachedPart, linePart) || Equal(cachedPart, linePartRev))
+      return false;
+  }
+
+  it->second.push_back(linePart);
+  return true;
+}
+
+void SubwayConverter::CalculateLinePriorities(std::vector<LineSchemeData> const & linesOnScheme)
+{
+  ColorToLinepartsCache routeSegmentsCache;
+
+  for (auto const & lineSchemeData : linesOnScheme)
+  {
+    auto const lineId = lineSchemeData.m_lineId;
+    std::map<size_t, LinePointState> linePoints;
+
+    for (auto const & linePart : lineSchemeData.m_lineParts)
+    {
+      auto & startPointState = linePoints[linePart.m_segment.m_startIdx];
+      auto & endPointState = linePoints[linePart.m_segment.m_endIdx];
+
+      startPointState.m_firstPoint = linePart.m_firstPoint;
+
+      for (auto const & [parallelLineId, parallelFirstPoint] : linePart.m_commonLines)
+      {
+        bool const codirectional =
+            base::AlmostEqualAbs(linePart.m_firstPoint, parallelFirstPoint, kEps);
+
+        startPointState.parallelLineStates[parallelLineId] =
+            LineSegmentInfo(LineSegmentState::Start, codirectional);
+        endPointState.parallelLineStates[parallelLineId] =
+            LineSegmentInfo(LineSegmentState::Finish, codirectional);
+      }
+    }
+
+    linePoints.emplace(lineSchemeData.m_shapeLink.m_startIndex, LinePointState());
+    linePoints.emplace(lineSchemeData.m_shapeLink.m_endIndex, LinePointState());
+
+    std::map<TransitId, bool> parallelLines;
+
+    for (auto it = linePoints.begin(); it != linePoints.end(); ++it)
+    {
+      auto itNext = std::next(it);
+      if (itNext == linePoints.end())
+        break;
+
+      auto & startLinePointState = it->second;
+      size_t startIndex = it->first;
+      size_t endIndex = itNext->first;
+
+      for (auto const & [id, info] : startLinePointState.parallelLineStates)
+      {
+        if (info.m_state == LineSegmentState::Start)
+        {
+          auto [itParLine, insertedParLine] = parallelLines.emplace(id, info.m_codirectional);
+          if (!insertedParLine)
+            CHECK_EQUAL(itParLine->second, info.m_codirectional, ());
+        }
+        else
+        {
+          parallelLines.erase(id);
+        }
+      }
+
+      TransitId const routeId = m_feed.m_lines.m_data.at(lineId).m_routeId;
+      std::string color = m_feed.m_routes.m_data.at(routeId).m_color;
+
+      std::map<std::string, bool> colors{{color, true /* codirectional */}};
+      bool colorCopy = false;
+
+      for (auto const & [id, codirectional] : parallelLines)
+      {
+        TransitId const parallelRoute = m_feed.m_lines.m_data.at(id).m_routeId;
+        auto const parallelColor = m_feed.m_routes.m_data.at(parallelRoute).m_color;
+        colors.emplace(parallelColor, codirectional);
+
+        if (parallelColor == color && id < lineId)
+          colorCopy = true;
+      }
+
+      if (colorCopy)
+      {
+        LOG(LINFO, ("Skip line segment with color copy", color, "line id", lineId));
+        continue;
+      }
+
+      LineSegmentOrder lso;
+      lso.m_segment =
+          LineSegment(static_cast<uint32_t>(startIndex), static_cast<uint32_t>(endIndex));
+
+      auto const & polyline =
+          m_feed.m_shapes.m_data.at(lineSchemeData.m_shapeLink.m_shapeId).m_points;
+
+      if (!AddToCache(color,
+                      GetPolylinePart(polyline, lso.m_segment.m_startIdx, lso.m_segment.m_endIdx),
+                      routeSegmentsCache))
+      {
+        continue;
+      }
+
+      auto itColor = colors.find(color);
+      CHECK(itColor != colors.end(), ());
+
+      size_t const index = std::distance(colors.begin(), itColor);
+
+      lso.m_order = CalcSegmentOrder(index, colors.size());
+
+      bool reversed = false;
+
+      if (index > 0 && !colors.begin()->second /* codirectional */)
+      {
+        lso.m_order = -lso.m_order;
+        reversed = true;
+      }
+
+      m_feed.m_linesMetadata.m_data[lineId].push_back(lso);
+
+      LOG(LINFO,
+          ("routeId", routeId, "lineId", lineId, "start", startIndex, "end", endIndex, "len",
+           endIndex - startIndex + 1, "order", lso.m_order, "index", index, "reversed", reversed,
+           "|| lines count:", parallelLines.size(), "colors count:", colors.size()));
+    }
+  }
+}
+
+void SubwayConverter::PrepareLinesMetadata()
+{
+  for (auto const & [region, linesInRegion] : m_feed.m_splitting.m_lines)
+  {
+    LOG(LINFO, ("Handling", region, "region"));
+
+    std::vector<LineSchemeData> linesOnScheme = GetLinesOnScheme(linesInRegion);
+
+    for (size_t i = 0; i < linesOnScheme.size() - 1; ++i)
+    {
+      auto & line1 = linesOnScheme[i];
+      auto const & shapeLink1 = linesInRegion.at(line1.m_lineId).m_shapeLink;
+
+      // |polyline1| is sub-polyline of the shapeLink1 geometry.
+      auto const polyline1 =
+          GetPolylinePart(m_feed.m_shapes.m_data.at(shapeLink1.m_shapeId).m_points,
+                          shapeLink1.m_startIndex, shapeLink1.m_endIndex);
+
+      for (size_t j = i + 1; j < linesOnScheme.size(); ++j)
+      {
+        auto & line2 = linesOnScheme[j];
+        auto const & shapeLink2 = linesInRegion.at(line2.m_lineId).m_shapeLink;
+
+        if (line1.m_shapeLink.m_shapeId == line2.m_shapeLink.m_shapeId)
+        {
+          CHECK_LESS(shapeLink1.m_startIndex, shapeLink1.m_endIndex, ());
+          CHECK_LESS(shapeLink2.m_startIndex, shapeLink2.m_endIndex, ());
+
+          std::optional<LineSegment> inter =
+              GetIntersection(shapeLink1.m_startIndex, shapeLink1.m_endIndex,
+                              shapeLink2.m_startIndex, shapeLink2.m_endIndex);
+
+          if (inter != std::nullopt)
+          {
+            LineSegment const segment = inter.value();
+            m2::PointD const & startPoint = polyline1[segment.m_startIdx];
+
+            UpdateLinePart(line1.m_lineParts, segment, startPoint, line2.m_lineId, startPoint);
+            UpdateLinePart(line2.m_lineParts, segment, startPoint, line1.m_lineId, startPoint);
+          }
+        }
+        else
+        {
+          // |polyline2| is sub-polyline of the shapeLink2 geometry.
+          auto polyline2 = GetPolylinePart(m_feed.m_shapes.m_data.at(shapeLink2.m_shapeId).m_points,
+                                           shapeLink2.m_startIndex, shapeLink2.m_endIndex);
+
+          auto [segments1, segments2] = FindIntersections(polyline1, polyline2);
+
+          if (segments1.empty())
+          {
+            auto polyline2Rev = GetReversed(polyline2);
+            std::tie(segments1, segments2) = FindIntersections(polyline1, polyline2Rev);
+
+            if (!segments1.empty())
+            {
+              for (auto & seg : segments2)
+                UpdateReversedSegmentIndexes(seg, polyline2.size());
+            }
+          }
+
+          if (!segments1.empty())
+          {
+            for (size_t k = 0; k < segments1.size(); ++k)
+            {
+              auto const & [startPoint1, endPoint1] =
+                  GetSegmentEdgesOnPolyline(polyline1, segments1[k]);
+              auto const & [startPoint2, endPoint2] =
+                  GetSegmentEdgesOnPolyline(polyline2, segments2[k]);
+
+              CHECK(base::AlmostEqualAbs(startPoint1, startPoint2, kEps) &&
+                            base::AlmostEqualAbs(endPoint1, endPoint2, kEps) ||
+                        base::AlmostEqualAbs(startPoint1, endPoint2, kEps) &&
+                            base::AlmostEqualAbs(endPoint1, startPoint2, kEps),
+                    ());
+
+              ShiftSegmentOnShape(segments1[k], shapeLink1);
+              ShiftSegmentOnShape(segments2[k], shapeLink2);
+
+              UpdateLinePart(line1.m_lineParts, segments1[k], startPoint1, line2.m_lineId,
+                             startPoint2);
+              UpdateLinePart(line2.m_lineParts, segments2[k], startPoint2, line1.m_lineId,
+                             startPoint1);
+            }
+          }
+        }
+      }
+    }
+
+    CalculateLinePriorities(linesOnScheme);
+    LOG(LINFO, ("Prepared metadata for lines in", region));
+  }
 }
 
 routing::transit::Edge SubwayConverter::FindEdge(routing::transit::StopId stop1Id,

--- a/transit/world_feed/subway_converter.cpp
+++ b/transit/world_feed/subway_converter.cpp
@@ -93,8 +93,7 @@ bool SubwayConverter::Convert()
   if (!ConvertStops())
     return false;
 
-  if (!ConvertTransfers())
-    return false;
+  ConvertTransfers();
 
   // In contrast to the GTFS gates OSM gates for subways shouldn't be empty.
   if (!ConvertGates())
@@ -387,7 +386,7 @@ bool SubwayConverter::ConvertTransfers()
       }
     }
 
-    // We don't count as transfers tranfer points between lines on the same route, so we skip them.
+    // We don't count as transfers transfer points between lines on the same route, so we skip them.
     if (routeToStops.size() < 2)
     {
       LOG(LINFO, ("Skip transfer on route", transferId));

--- a/transit/world_feed/world_feed.cpp
+++ b/transit/world_feed/world_feed.cpp
@@ -762,8 +762,7 @@ void WorldFeed::ModifyLinesAndShapes()
     }
 
     auto const & pointsNeedle = m_shapes.m_data[shapeIdNeedle].m_points;
-    auto pointsNeedleRev = pointsNeedle;
-    std::reverse(pointsNeedleRev.begin(), pointsNeedleRev.end());
+    auto const pointsNeedleRev = GetReversed(pointsNeedle);
 
     for (size_t j = 0; j < i; ++j)
     {
@@ -1735,7 +1734,8 @@ bool WorldFeed::PrepareEdgesInRegion(std::string const & region)
     CHECK(!shapePoints.empty(), ("Shape is empty."));
 
     auto const it = m_edgesOnShapes.find(edgeId);
-    CHECK(it != m_edgesOnShapes.end(), (edgeId.m_lineId));
+    if (it == m_edgesOnShapes.end())
+      continue;
 
     for (auto const & polyline : it->second)
     {
@@ -1749,10 +1749,8 @@ bool WorldFeed::PrepareEdgesInRegion(std::string const & region)
     {
       for (auto const & polyline : it->second)
       {
-        auto r = polyline;
-        std::reverse(r.begin(), r.end());
         std::tie(edgeData.m_shapeLink.m_startIndex, edgeData.m_shapeLink.m_endIndex) =
-            FindSegmentOnShape(shapePoints, r);
+            FindSegmentOnShape(shapePoints, GetReversed(polyline));
         if (!(edgeData.m_shapeLink.m_startIndex == 0 && edgeData.m_shapeLink.m_endIndex == 0))
           break;
       }

--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -379,7 +379,7 @@ private:
   Transfers m_transfers;
   Gates m_gates;
 
-  // Mapping of the edge to its ending points on the shape polyline.
+  // Mapping of the edge to its points on the shape polyline.
   std::unordered_map<EdgeId, std::vector<std::vector<m2::PointD>>, EdgeIdHasher> m_edgesOnShapes;
 
   // Ids of entities for json'izing, split by regions.

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -119,16 +119,16 @@ public:
 
     // First and last stops are connected through 1 edge with 1 nearest stop.
     // Stops in the middle are connected through 2 edges with 2 nearest stops.
-    TEST_EQUAL(stopsInRegions["Switzerland_Ticino"].size(), 2, ());
+    TEST_EQUAL(stopsInRegions["Switzerland_Ticino"].size(), 3, ());
     TEST_EQUAL(edgesInRegions["Switzerland_Ticino"].size(), 1, ());
 
-    TEST_EQUAL(stopsInRegions["Switzerland_Eastern"].size(), 3, ());
+    TEST_EQUAL(stopsInRegions["Switzerland_Eastern"].size(), 4, ());
     TEST_EQUAL(edgesInRegions["Switzerland_Eastern"].size(), 2, ());
 
-    TEST_EQUAL(stopsInRegions["Italy_Lombardy_Como"].size(), 3, ());
+    TEST_EQUAL(stopsInRegions["Italy_Lombardy_Como"].size(), 4, ());
     TEST_EQUAL(edgesInRegions["Italy_Lombardy_Como"].size(), 2, ());
 
-    TEST_EQUAL(stopsInRegions["Italy_Lombardy_Monza and Brianza"].size(), 2, ());
+    TEST_EQUAL(stopsInRegions["Italy_Lombardy_Monza and Brianza"].size(), 3, ());
     TEST_EQUAL(edgesInRegions["Italy_Lombardy_Monza and Brianza"].size(), 1, ());
   }
 

--- a/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
+++ b/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
@@ -345,7 +345,7 @@ public:
     TEST_EQUAL(feed.m_stops.m_data.size(), 5, ());
     TEST_EQUAL(feed.m_edges.m_data.size(), 4, ());
     TEST_EQUAL(feed.m_edgesTransfers.m_data.size(), 1, ());
-    TEST_EQUAL(feed.m_transfers.m_data.size(), 1, ());
+    TEST_EQUAL(feed.m_transfers.m_data.size(), 0, ());
     TEST_EQUAL(feed.m_gates.m_data.size(), 1, ());
 
     // Two initial shapes must be merged into one.

--- a/transit/world_feed/world_feed_tests/world_feed_tests.cpp
+++ b/transit/world_feed/world_feed_tests/world_feed_tests.cpp
@@ -78,6 +78,14 @@ void TestPlanFact(size_t planIndex, bool planInsert, std::pair<size_t, bool> con
   TEST_EQUAL(factRes.second, planInsert, ());
 }
 
+void TestStopsRange(IdList const & stopsOnLine, IdSet const & stopsInRegion, size_t firstIdxPlan,
+                    size_t lastIdxPlan)
+{
+  auto const & [firstIdxFact, lastIdxFact] = GetStopsRange(stopsOnLine, stopsInRegion);
+  TEST_EQUAL(firstIdxFact, firstIdxPlan, ());
+  TEST_EQUAL(lastIdxFact, lastIdxPlan, ());
+}
+
 UNIT_TEST(Transit_GTFS_OpenCloseInterval1)
 {
   auto const & intervals = GetOpenCloseIntervals(GetCalendarAvailability({1, 1, 1, 1, 1, 0, 0}));
@@ -477,5 +485,15 @@ UNIT_TEST(CalcSegmentOrder)
   TEST_EQUAL(CalcSegmentOrder(2 /* segIndex */, 5 /* totalSegCount */), 0, ());
   TEST_EQUAL(CalcSegmentOrder(3 /* segIndex */, 5 /* totalSegCount */), 2, ());
   TEST_EQUAL(CalcSegmentOrder(4 /* segIndex */, 5 /* totalSegCount */), 4, ());
+}
+
+UNIT_TEST(SplitLineToRegions)
+{
+  TestStopsRange({1, 2, 3, 4, 5} /* stopsOnLine */, {1, 2, 3, 4, 5} /* stopsInRegion */,
+                 0 /* firstIdxPlan */, 4 /* lastIdxPlan */);
+  TestStopsRange({1, 2, 3, 4, 5, 6, 7} /* stopsOnLine */, {1, 2, 3} /* stopsInRegion */,
+                 0 /* firstIdxPlan */, 3 /* lastIdxPlan */);
+  TestStopsRange({1, 2, 3, 4, 5, 6, 7} /* stopsOnLine */, {3, 4} /* stopsInRegion */,
+                 1 /* firstIdxPlan */, 4 /* lastIdxPlan */);
 }
 }  // namespace


### PR DESCRIPTION
### О чем реквест
В этом реквесте реализованы изменения в конвертации старого формата метро в новый формат ОТ для корректного рендеринга секции ОТ на слое метро. Рендеринг реализован в замерженном реквесте #13591.

### Какие изменения потребовались и почему

**1. Разбиение линии маршрута на отрезки в зависимости от того, на каком из отрезков сколько имеется параллельных ей линий другого цвета. Сохранение этой информации в lines_metadata.transit.json** 

В формате метро у нас есть 1 большой json-файл с данными о метро по всему миру. В нем полилинии геометрии метро (shapes) не хранятся целиком: каждая линия (line) разбита на ребра (edges), и каждое ребро ссылается на соответствующий отрезок геометрии. Пример ребра, соединяющего две остановки на линии:

```json
        {
            "line_id": 79174371,
            "shape_ids": [
                {
                    "stop1_id": 2678030,
                    "stop2_id": 35859318
                }
            ],
            "stop1_id": 35859318,
            "stop2_id": 2678030,
            "transfer": false,
            "weight": 196
        },
```

Для новой версии транзитной секции мы отказались от разбиения полилиний маршрутов на минимальные отрезки "от остановки i - до остановки i+1". Теперь в данных хранится полилиния пути целиком, а отдельные линии маршрутов и ребра ссылаются на нее через shapeLink: id полилинии, индекс первой точки на ней и индекс последней точки. 

При таком подходе необходимо реализовать алгоритм, при котором параллельные отрезки разных линий не накладываются друг на друга при рендеринге, а имеют каждый свое смещение относительно оси симметрии:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/54934129/90952272-ddf97180-e46a-11ea-949f-2acf283de51b.png">

Решено эти расчеты унести в офлайн, на стадию препроцессинга метро и подмешивания его к gtfs-данным в результирующий json для генератора. Офлайновая составляющая позволит в будущем реализовать алгоритм расчитывания смещений линий так, чтобы минимизировать их пересечения на карте (в текущей реализации метро это невозможно). Полученные отрезки сохраняются в lines_metadata.transit.json. **Только линии, айди которых есть в этом файле (а далее - секции mwm), попадают на схему метро.**

Алгоритм добавлен в subway_converter.cpp `SubwayConverter::PrepareLinesMetadata()` и состоит из шагов:
1. Сортируем маршруты по цвету `GetLinesOnScheme(linesInRegion)`. Это нужно, чтобы для каждой линии маршрута знать ее индекс среди других линий. На схеме метро линии одного цвета не должны идти параллельно. 
<img width=600 src=https://user-images.githubusercontent.com/54934129/90952386-d1c1e400-e46b-11ea-8899-64ecfc0e674b.jpeg>

2. Находим пересекающиеся отрезки на линиях (цилк в `PrepareLinesMetadata()` после вызова `GetLinesOnScheme(linesInRegion)`. У каждой линии сохраняется набор отрезков и айди параллельных ей линий на этих отрезках.
<img width=600 src=https://user-images.githubusercontent.com/54934129/90952407-f1f1a300-e46b-11ea-8c4a-beace77d34c1.jpeg>

3. Зная отрезки, количество линий на отрезке и индекс данной линии среди других, можно расчитать ее порядок (приоритет) `CalculateLinePriorities(linesOnScheme)`. Порядок рассчитывается так, чтобы его значение было симметрично относительно центральной линии.
<img width=600 src=https://user-images.githubusercontent.com/54934129/90952413-fe75fb80-e46b-11ea-8ffe-d99ab63138e8.jpeg>

4. Значение порядка используется в качестве `offset` на этапе рендеринга слоя метро.

@tomilov @darina В чем состоял баг, когда линии при описанном подходе почему-то все равно накладывались друг на друга или находились на не равном расстоянии друг от друга: я не учитывала, что некоторые отрезки могут совпадать, но иметь противоположную направленнсть. Для них значение order нужно умножать на -1. Пример: есть сегмент `ABCDEFG` линии 1, и есть сегмент `TTEDCT` линии 2. У них идут параллельно отрезки `CDE` и `EDC` соответственно. Но направление `EDC` противоположно направлению `CDE`, и если мы присвоим отрезкам смещение -1 и 1, то они будут наложены друг на друга. А если -1 и -1, то будут идти рядом параллельно. Потому что смещение отсчитывается от самой линии, и ее направленность имеет значение.



**2. Отсеивать для п.1 "укороченные сплайны": они не должны быть отрисованы на схеме метро.**
Откуда взялись укороченные линии, можно посмотреть в Дашином докладе (ссылка с временной меткой):
https://youtu.be/oODvvV0_7rk?t=481

Отсеивание укороченных сплайнов для схемы теперь вынесено в офлайн. Они не попадают в lines_metadata.transit.json. Методы для нахождения исходной линии для укороченной: `GetParentLineForSpline(lineId)`, `GetSplineParent(lineId, region)`.



**3. Исправлена логика добавления остановок и пересадок в mwm:** раньше был баг, из-за которого линии, вылезающие за границы mwm, мы добавляли целиком (а не обрезали до "соседней" по ту сторону границы остановки), а некоторые остановки за пределами границы - наоборот не добавляли. Для решений этой проблемы добавлен метод `GetStopsRange( lineStopIds, stopIdsInRegion)`, и исправлен метод `SplitLinesBasedData()`.