### PR TITLE
[transit] Schedule class for (de)serialization of transit timetables.

### DIFF
--- a/transit/CMakeLists.txt
+++ b/transit/CMakeLists.txt
@@ -17,6 +17,8 @@ set(
   transit_serdes.hpp
   transit_types.cpp
   transit_types.hpp
+  transit_schedule.cpp
+  transit_schedule.hpp
   transit_version.cpp
   transit_version.hpp
 )

--- a/transit/transit_schedule.cpp
+++ b/transit/transit_schedule.cpp
@@ -1,0 +1,360 @@
+#include "transit/transit_schedule.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+
+namespace
+{
+// Constant which is added to the year value while deserizlizing from the unsigned int.
+uint32_t constexpr kEpochStartYear = 2020;
+
+uint32_t constexpr kMask4bits = 0xf;
+uint32_t constexpr kMask5bits = 0x1f;
+uint32_t constexpr kMask6bits = 0x3F;
+
+std::tm ToCalendarTime(time_t const & ts)
+{
+  std::tm tm;
+  localtime_r(&ts, &tm);
+  return tm;
+}
+
+uint8_t GetRawStatus(gtfs::CalendarAvailability const & status)
+{
+  return status == gtfs::CalendarAvailability::Available ? 1 : 0;
+}
+
+uint8_t GetRawStatus(gtfs::CalendarDateException const & status)
+{
+  return status == gtfs::CalendarDateException::Added ? 1 : 0;
+}
+
+enum class DateTimeRelation
+{
+  // First element is earlier in time, later or is equal.
+  Earlier,
+  Later,
+  Equal
+};
+
+DateTimeRelation GetDatesRelation(transit::Date const & date1, transit::Date const & date2)
+{
+  if (date1.m_year < date2.m_year)
+    return DateTimeRelation::Earlier;
+  if (date1.m_year > date2.m_year)
+    return DateTimeRelation::Later;
+
+  if (date1.m_month < date2.m_month)
+    return DateTimeRelation::Earlier;
+  if (date1.m_month > date2.m_month)
+    return DateTimeRelation::Later;
+
+  if (date1.m_day < date2.m_day)
+    return DateTimeRelation::Earlier;
+  if (date1.m_day > date2.m_day)
+    return DateTimeRelation::Later;
+
+  return DateTimeRelation::Equal;
+}
+
+DateTimeRelation GetTimesRelation(transit::Time const & time1, transit::Time const & time2)
+{
+  if (time1.m_hour < time2.m_hour)
+    return DateTimeRelation::Earlier;
+  if (time1.m_hour > time2.m_hour)
+    return DateTimeRelation::Later;
+
+  if (time1.m_minute < time2.m_minute)
+    return DateTimeRelation::Earlier;
+  if (time1.m_minute > time2.m_minute)
+    return DateTimeRelation::Later;
+
+  if (time1.m_second < time2.m_second)
+    return DateTimeRelation::Earlier;
+  if (time1.m_second > time2.m_second)
+    return DateTimeRelation::Later;
+
+  return DateTimeRelation::Equal;
+}
+
+transit::Date GetDate(std::tm const & tm)
+{
+  return transit::Date(tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
+}
+
+transit::Time GetTime(std::tm const & tm)
+{
+  return transit::Time(tm.tm_hour, tm.tm_min, tm.tm_sec);
+}
+}  // namespace
+
+namespace transit
+{
+// Status ------------------------------------------------------------------------------------------
+std::string DebugPrint(Status const & status)
+{
+  switch (status)
+  {
+  case Status::Open: return "Open";
+  case Status::Closed: return "Closed";
+  case Status::Unknown: return "Unknown";
+  }
+  UNREACHABLE();
+}
+
+// DatesInterval -----------------------------------------------------------------------------------
+DatesInterval::DatesInterval(gtfs::CalendarItem const & calendarItem)
+{
+  uint32_t y1 = 0;
+  uint32_t m1 = 0;
+  uint32_t d1 = 0;
+  uint32_t y2 = 0;
+  uint32_t m2 = 0;
+  uint32_t d2 = 0;
+
+  std::tie(y1, m1, d1) = calendarItem.start_date.get_yyyy_mm_dd();
+  std::tie(y2, m2, d2) = calendarItem.end_date.get_yyyy_mm_dd();
+
+  y1 -= kEpochStartYear;
+  y2 -= kEpochStartYear;
+
+  uint8_t const yDelta = y2 - y1;
+
+  // From high bit to the least significant bit (from 31 to 0):
+  // year1 (4 bits), month1 (4 bits), day1 (5 bits), year delta (3 bits), month2 (4 bits), day2 (5
+  // bits), sunday, monday, ..., saturday - 7 bits, each week day is 1 bit.
+  m_data = y1 << 28 | m1 << 24 | d1 << 19 | yDelta << 16 | m2 << 12 | d2 << 7 |
+           GetRawStatus(calendarItem.sunday) << 6 | GetRawStatus(calendarItem.monday) << 5 |
+           GetRawStatus(calendarItem.tuesday) << 4 | GetRawStatus(calendarItem.wednesday) << 3 |
+           GetRawStatus(calendarItem.thursday) << 2 | GetRawStatus(calendarItem.friday) << 1 |
+           GetRawStatus(calendarItem.saturday);
+}
+
+std::tuple<Date, Date, WeekSchedule> DatesInterval::Extract() const
+{
+  Date date1;
+  Date date2;
+
+  WeekSchedule week;
+
+  static uint32_t constexpr mask3bits = 0x7;
+
+  date1.m_year = (m_data >> 28) + kEpochStartYear;
+  date1.m_month = (m_data >> 24) & kMask4bits;
+  date1.m_day = (m_data >> 19) & kMask5bits;
+  uint8_t yDelta = (m_data >> 16) & mask3bits;
+  date2.m_year = date1.m_year + yDelta;
+  date2.m_month = (m_data >> 12) & kMask4bits;
+  date2.m_day = (m_data >> 7) & kMask5bits;
+
+  week[0] = m_data & 0x40;
+  week[1] = m_data & 0x20;
+  week[2] = m_data & 0x10;
+  week[3] = m_data & 0x8;
+  week[4] = m_data & 0x4;
+  week[5] = m_data & 0x2;
+  week[6] = m_data & 0x1;
+
+  return {date1, date2, week};
+}
+
+Status DatesInterval::GetStatusInInterval(Date const & date, uint8_t wdIndex) const
+{
+  auto const & [date1, date2, wd] = Extract();
+
+  if (GetDatesRelation(date, date1) != DateTimeRelation::Earlier &&
+      GetDatesRelation(date, date2) != DateTimeRelation::Later)
+  {
+    return wd[wdIndex] ? Status::Open : Status::Closed;
+  }
+
+  return Status::Closed;
+}
+
+bool DatesInterval::operator==(DatesInterval const & rhs) const { return m_data == rhs.m_data; }
+
+// DateException -----------------------------------------------------------------------------------
+DateException::DateException(gtfs::Date const & date, gtfs::CalendarDateException const & exception)
+{
+  uint32_t y = 0;
+  uint32_t m = 0;
+  uint32_t d = 0;
+
+  std::tie(y, m, d) = date.get_yyyy_mm_dd();
+
+  y -= kEpochStartYear;
+
+  // From high bit - 1 to the least significant bit (from 14 to 0):
+  // year1 (4 bits), month1 (4 bits), day1 (5 bits), exctption statys (1 bit).
+  m_data = y << 10 | m << 6 | d << 1 | GetRawStatus(exception);
+}
+
+bool DateException::operator==(DateException const & rhs) const { return m_data == rhs.m_data; }
+
+std::tuple<Date, bool> DateException::Extract() const
+{
+  Date date;
+
+  date.m_year = (m_data >> 10) + kEpochStartYear;
+  date.m_month = (m_data >> 6) & kMask4bits;
+  date.m_day = (m_data >> 1) & kMask5bits;
+  bool const isOpen = m_data & 0x1;
+
+  return {date, isOpen};
+}
+
+Status DateException::GetExceptionStatus(Date const & date) const
+{
+  auto const & [dateExc, isOpen] = Extract();
+
+  if (GetDatesRelation(date, dateExc) == DateTimeRelation::Equal)
+    return isOpen ? Status::Open : Status::Closed;
+
+  return Status::Unknown;
+}
+
+// TimeInterval ------------------------------------------------------------------------------------
+TimeInterval::TimeInterval(gtfs::Time const & startTime, gtfs::Time const & endTime)
+{
+  uint64_t h1 = 0;
+  uint64_t m1 = 0;
+  uint64_t s1 = 0;
+
+  uint64_t h2 = 0;
+  uint64_t m2 = 0;
+  uint64_t s2 = 0;
+
+  std::tie(h1, m1, s1) = startTime.get_hh_mm_ss();
+  std::tie(h2, m2, s2) = endTime.get_hh_mm_ss();
+
+  // From 33 bit to 0 bit:
+  // hour1 (5 bits), minute1 (6 bits), second1 (6 bits), hour2 (5 bits), minute2 (6 bits), second2
+  // (6 bits).
+  m_data = h1 << 29 | m1 << 23 | s1 << 17 | h2 << 12 | m2 << 6 | s2;
+}
+
+bool TimeInterval::operator<(TimeInterval const & rhs) const { return m_data < rhs.m_data; }
+
+std::pair<Time, Time> TimeInterval::Extract() const
+{
+  Time startTime;
+  Time endTime;
+
+  startTime.m_hour = (m_data >> 29) & kMask5bits;
+  startTime.m_minute = (m_data >> 23) & kMask6bits;
+  startTime.m_second = (m_data >> 17) & kMask6bits;
+
+  endTime.m_hour = (m_data >> 12) & kMask5bits;
+  endTime.m_minute = (m_data >> 6) & kMask6bits;
+  endTime.m_second = m_data & kMask6bits;
+
+  return {startTime, endTime};
+}
+
+Status TimeInterval::GetTimeStatus(Time const & time) const
+{
+  auto const & [startTime, endTime] = Extract();
+  if (GetTimesRelation(time, startTime) != DateTimeRelation::Earlier &&
+      GetTimesRelation(time, endTime) != DateTimeRelation::Later)
+  {
+    return Status::Open;
+  }
+
+  return Status::Closed;
+}
+
+// FrequencyIntervals ------------------------------------------------------------------------------
+FrequencyIntervals::FrequencyIntervals(gtfs::Frequencies const & frequencies)
+{
+  for (auto const & freq : frequencies)
+  {
+    CHECK_GREATER(freq.headway_secs, 0, ());
+    m_intervals.emplace(TimeInterval(freq.start_time, freq.end_time), freq.headway_secs);
+  }
+}
+
+Frequency FrequencyIntervals::GetFrequency(Time const & time) const
+{
+  for (auto const & [interval, freq] : m_intervals)
+  {
+    if (interval.GetTimeStatus(time) == Status::Open)
+      return freq;
+  }
+
+  return kDefaultFrequency;
+}
+
+// Schedule ----------------------------------------------------------------------------------------
+void Schedule::AddDatesInterval(gtfs::CalendarItem const & calendarItem,
+                                gtfs::Frequencies const & frequencies)
+{
+  m_serviceIntervals.emplace(DatesInterval(calendarItem), FrequencyIntervals(frequencies));
+}
+
+void Schedule::AddDateException(gtfs::Date const & date,
+                                gtfs::CalendarDateException const & exception,
+                                gtfs::Frequencies const & frequencies)
+{
+  m_serviceExceptions.emplace(DateException(date, exception), FrequencyIntervals(frequencies));
+}
+
+Status Schedule::GetStatus(time_t const & time) const
+{
+  auto const & [date, wdIndex] = GetDateAndWeekIndex(time);
+
+  for (auto const & [dateException, freq] : m_serviceExceptions)
+  {
+    Status const & status = dateException.GetExceptionStatus(date);
+
+    if (status != Status::Unknown)
+      return status;
+  }
+
+  Status res = Status::Unknown;
+
+  for (auto const & [datesInterval, freq] : m_serviceIntervals)
+  {
+    Status const & status = datesInterval.GetStatusInInterval(date, wdIndex);
+
+    if (status != Status::Unknown)
+      res = status;
+
+    if (res == Status::Open)
+      return res;
+  }
+
+  return res;
+}
+
+Frequency Schedule::GetFrequency(time_t const & time) const
+{
+  auto const & [date, timeHms, wdIndex] = GetDateTimeAndWeekIndex(time);
+
+  for (auto const & [dateException, freqInts] : m_serviceExceptions)
+  {
+    if (dateException.GetExceptionStatus(date) == Status::Open)
+      return freqInts.GetFrequency(timeHms);
+  }
+
+  for (auto const & [datesInterval, freqInts] : m_serviceIntervals)
+  {
+    if (datesInterval.GetStatusInInterval(date, wdIndex) == Status::Open)
+      return freqInts.GetFrequency(timeHms);
+  }
+
+  LOG(LWARNING, ("No frequency for date", date, "time", timeHms));
+  return m_defaultFrequency;
+}
+
+std::pair<Date, uint8_t> Schedule::GetDateAndWeekIndex(time_t const & time) const
+{
+  std::tm const tm = ToCalendarTime(time);
+  return {GetDate(tm), tm.tm_wday};
+}
+
+std::tuple<Date, Time, uint8_t> Schedule::GetDateTimeAndWeekIndex(time_t const & time) const
+{
+  std::tm const tm = ToCalendarTime(time);
+  return {GetDate(tm), GetTime(tm), tm.tm_wday};
+}
+}  // namespace transit

--- a/transit/transit_schedule.hpp
+++ b/transit/transit_schedule.hpp
@@ -1,0 +1,218 @@
+#pragma once
+
+#include "base/macros.hpp"
+#include "base/newtype.hpp"
+#include "base/visitor.hpp"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <map>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "3party/just_gtfs/just_gtfs.h"
+
+// This is the implementation of the Schedule class and its helpers for handling transit service
+// days and stops timetables.
+namespace routing
+{
+namespace transit
+{
+template <class Sink>
+class Serializer;
+template <class Source>
+class Deserializer;
+template <typename Sink>
+class FixedSizeSerializer;
+template <typename Sink>
+class FixedSizeDeserializer;
+}  // namespace transit
+}  // namespace routing
+
+namespace transit
+{
+#define DECLARE_SCHEDULE_TYPES_FRIENDS                \
+  template <class Sink>                               \
+  friend class routing::transit::Serializer;          \
+  template <class Source>                             \
+  friend class routing::transit::Deserializer;        \
+  template <typename Sink>                            \
+  friend class routing::transit::FixedSizeSerializer; \
+  template <typename Sink>                            \
+  friend class routing::transit::FixedSizeDeserializer;
+
+// Status of some transit itinerary (e.g. line) in the moment of time.
+enum class Status : uint8_t
+{
+  Open,
+  Closed,
+  Unknown
+};
+
+std::string DebugPrint(Status const & status);
+
+struct Date
+{
+  Date() = default;
+  Date(uint32_t year, uint8_t month, uint16_t day) : m_year(year), m_month(month), m_day(day) {}
+
+  DECLARE_SCHEDULE_TYPES_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Date, visitor(m_year, "y"), visitor(m_month, "m"),
+                                  visitor(m_day, "d"))
+
+  uint32_t m_year = 0;
+  uint8_t m_month = 0;
+  uint16_t m_day = 0;
+};
+
+struct Time
+{
+  Time() = default;
+  Time(uint8_t hour, uint8_t minute, uint8_t second)
+    : m_hour(hour), m_minute(minute), m_second(second)
+  {
+  }
+
+  DECLARE_SCHEDULE_TYPES_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(Time, visitor(m_hour, "h"), visitor(m_minute, "m"),
+                                  visitor(m_second, "s"))
+
+  uint8_t m_hour = 0;
+  uint8_t m_minute = 0;
+  uint8_t m_second = 0;
+};
+
+using WeekSchedule = std::array<bool, 7>;
+// Service dates specified using a weekly schedule with start and end dates. Dates range is
+// specified by the start_date and end_date fields in the GTFS calendar.txt.
+// Dates interval and open/closed states for week days are stored |m_data|.
+class DatesInterval
+{
+public:
+  DatesInterval() = default;
+  explicit DatesInterval(gtfs::CalendarItem const & calendarItem);
+
+  bool operator==(DatesInterval const & rhs) const;
+
+  std::tuple<Date, Date, WeekSchedule> Extract() const;
+  uint32_t GetRaw() const { return m_data; }
+
+  Status GetStatusInInterval(Date const & date, uint8_t wdIndex) const;
+
+private:
+  DECLARE_SCHEDULE_TYPES_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(DatesInterval, visitor(m_data, "m_data"))
+
+  // From greater indexes to smaller: year1, month1, day1, years delta (year2 - year1), month2,
+  // day2, weekdays. Week indexes start from sunday = 0.
+  uint32_t m_data = 0;
+};
+
+struct DatesIntervalHasher
+{
+  size_t operator()(DatesInterval const & key) const { return key.GetRaw(); }
+};
+
+// Exceptions for the services defined in the calendar.txt. If calendar.txt is not used, it may
+// contain all dates of service. Exception date and its type (added/removed) are stored in |m_data|.
+class DateException
+{
+public:
+  DateException() = default;
+  DateException(gtfs::Date const & date, gtfs::CalendarDateException const & exception);
+
+  bool operator==(DateException const & rhs) const;
+
+  std::tuple<Date, bool> Extract() const;
+  uint32_t GetRaw() const { return m_data; }
+
+  Status GetExceptionStatus(Date const & date) const;
+
+private:
+  DECLARE_SCHEDULE_TYPES_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(DateException, visitor(m_data, "m_data"))
+
+  // From greater indexes to smaller: year, month, day, status
+  uint16_t m_data = 0;
+};
+
+struct DateExceptionHasher
+{
+  size_t operator()(DateException const & key) const { return key.GetRaw(); }
+};
+
+// Time range for lines frequencies or stop timetables. Start time and end time are stored in
+// m_data.
+class TimeInterval
+{
+public:
+  TimeInterval() = default;
+  TimeInterval(gtfs::Time const & startTime, gtfs::Time const & endTime);
+
+  bool operator<(TimeInterval const & rhs) const;
+
+  std::pair<Time, Time> Extract() const;
+  uint64_t GetRaw() const { return m_data; }
+
+  Status GetTimeStatus(Time const & time) const;
+
+private:
+  DECLARE_SCHEDULE_TYPES_FRIENDS
+  DECLARE_VISITOR_AND_DEBUG_PRINT(TimeInterval, visitor(m_data, "m_data"))
+
+  // From greater indexes to smaller: start time, end time.
+  uint64_t m_data = 0;
+};
+
+using Frequency = uint32_t;
+inline Frequency constexpr kDefaultFrequency = 0;
+
+// Headway (interval between times that a vehicle arrives at and departs from stops) for
+// headway-based service or a compressed representation of fixed-schedule service. For each time
+// range there is a frequency value.
+class FrequencyIntervals
+{
+public:
+  FrequencyIntervals() = default;
+  FrequencyIntervals(gtfs::Frequencies const & frequencies);
+
+  Frequency GetFrequency(Time const & time) const;
+
+private:
+  std::map<TimeInterval, Frequency> m_intervals;
+};
+
+// Line schedule with line service days (as DatesInterval ranges) and exceptions in service days
+// (as DateException items). For each date there are frequency intervals (time ranges with headway
+// in seconds). This schedule is useful while building transit routes based on particular route
+// start time.
+class Schedule
+{
+public:
+  void AddDatesInterval(gtfs::CalendarItem const & calendarItem,
+                        gtfs::Frequencies const & frequencies);
+  void AddDateException(gtfs::Date const & date, gtfs::CalendarDateException const & exception,
+                        gtfs::Frequencies const & frequencies);
+
+  Status GetStatus(time_t const & time) const;
+  Frequency GetFrequency(time_t const & time) const;
+  Frequency GetFrequency() const { return m_defaultFrequency; }
+
+  void SetDefaultFrequency(Frequency const & frequency) { m_defaultFrequency = frequency; }
+
+private:
+  std::pair<Date, uint8_t> GetDateAndWeekIndex(time_t const & time) const;
+  std::tuple<Date, Time, uint8_t> GetDateTimeAndWeekIndex(time_t const & time) const;
+
+  std::unordered_map<DatesInterval, FrequencyIntervals, DatesIntervalHasher> m_serviceIntervals;
+  std::unordered_map<DateException, FrequencyIntervals, DateExceptionHasher> m_serviceExceptions;
+
+  Frequency m_defaultFrequency = kDefaultFrequency;
+};
+
+#undef DECLARE_SCHEDULE_TYPES_FRIENDS
+}  // namespace transit

--- a/transit/transit_tests/CMakeLists.txt
+++ b/transit/transit_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(
   SRC
   transit_graph_test.cpp
   transit_json_parsing_test.cpp
+  transit_schedule_tests.cpp
   transit_test.cpp
   transit_tools.hpp
 )

--- a/transit/transit_tests/transit_schedule_tests.cpp
+++ b/transit/transit_tests/transit_schedule_tests.cpp
@@ -1,0 +1,247 @@
+#include "testing/testing.hpp"
+
+#include "transit/transit_schedule.hpp"
+
+#include "base/assert.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "3party/just_gtfs/just_gtfs.h"
+
+using namespace transit;
+
+namespace
+{
+// String dates are provided in GTFS date format YYYYMMDD.
+// String times are provided in GTFS time format HH:MM:SS.
+uint32_t GetYear(std::string const & date) { return std::stoi(date.substr(0, 4)); }
+
+uint32_t GetMonth(std::string const & date) { return std::stoi(date.substr(4, 2)); }
+
+uint32_t GetDay(std::string const & date) { return std::stoi(date.substr(6)); }
+
+uint32_t GetHour(std::string const & time) { return std::stoi(time.substr(0, 2)); }
+
+uint32_t GetMinute(std::string const & time) { return std::stoi(time.substr(3, 2)); }
+
+uint32_t GetSecond(std::string const & time) { return std::stoi(time.substr(6)); }
+
+gtfs::Frequency GetFrequency(std::string const & startTime, std::string const & endTime,
+                             Frequency headwayS)
+{
+  gtfs::Frequency freq;
+  freq.start_time = gtfs::Time(startTime);
+  freq.end_time = gtfs::Time(endTime);
+  freq.headway_secs = headwayS;
+
+  return freq;
+}
+
+gtfs::CalendarAvailability GetAvailability(bool available)
+{
+  return available ? gtfs::CalendarAvailability::Available
+                   : gtfs::CalendarAvailability::NotAvailable;
+}
+
+void TestDatesInterval(std::string const & date1, std::string const & date2, WeekSchedule weekDays)
+{
+  CHECK_EQUAL(date1.size(), 8, ());
+  CHECK_EQUAL(date2.size(), 8, ());
+
+  gtfs::CalendarItem ci;
+
+  ci.start_date = gtfs::Date(date1);
+  ci.end_date = gtfs::Date(date2);
+
+  ci.sunday = GetAvailability(weekDays[0]);
+  ci.monday = GetAvailability(weekDays[1]);
+  ci.tuesday = GetAvailability(weekDays[2]);
+  ci.wednesday = GetAvailability(weekDays[3]);
+  ci.thursday = GetAvailability(weekDays[4]);
+  ci.friday = GetAvailability(weekDays[5]);
+  ci.saturday = GetAvailability(weekDays[6]);
+
+  DatesInterval const interval(ci);
+
+  auto const & [intervalDate1, intervalDate2, wd] = interval.Extract();
+
+  TEST_EQUAL(intervalDate1.m_year, GetYear(date1), ());
+  TEST_EQUAL(intervalDate1.m_month, GetMonth(date1), ());
+  TEST_EQUAL(intervalDate1.m_day, GetDay(date1), ());
+
+  TEST_EQUAL(intervalDate2.m_year, GetYear(date2), ());
+  TEST_EQUAL(intervalDate2.m_month, GetMonth(date2), ());
+  TEST_EQUAL(intervalDate2.m_day, GetDay(date2), ());
+
+  for (size_t i = 0; i < wd.size(); ++i)
+    TEST_EQUAL(wd[i], weekDays[i], ());
+}
+
+void TestDateException(std::string const & date, bool isOpen)
+{
+  gtfs::CalendarDateException const ex =
+      isOpen ? gtfs::CalendarDateException::Added : gtfs::CalendarDateException::Removed;
+
+  DateException const dateException(gtfs::Date(date), ex);
+
+  auto const & [exDate, exStatus] = dateException.Extract();
+
+  TEST_EQUAL(exDate.m_year, GetYear(date), ());
+  TEST_EQUAL(exDate.m_month, GetMonth(date), ());
+  TEST_EQUAL(exDate.m_day, GetDay(date), ());
+
+  TEST_EQUAL(exStatus, isOpen, ());
+}
+
+void TestTime(std::string const & timePlan, Time const & timeFact)
+{
+  TEST_EQUAL(timeFact.m_hour, GetHour(timePlan), ());
+  TEST_EQUAL(timeFact.m_minute, GetMinute(timePlan), ());
+  TEST_EQUAL(timeFact.m_second, GetSecond(timePlan), ());
+}
+
+void TestTimeInterval(std::string const & time1, std::string const & time2)
+{
+  CHECK_EQUAL(time1.size(), 8, ());
+  CHECK_EQUAL(time2.size(), 8, ());
+
+  auto const & [startTime, endTime] = TimeInterval(gtfs::Time(time1), gtfs::Time(time2)).Extract();
+
+  TestTime(time1, startTime);
+  TestTime(time2, endTime);
+}
+
+UNIT_TEST(TransitSchedule_DatesInterval)
+{
+  TestDatesInterval(
+      "20200902", "20210531",
+      {
+          false /* sunday */, true /* monday */, false /* tuesday */, true /* wednesday */,
+          false /* thursday */, false /* friday */, false /* saturday */
+      });
+
+  TestDatesInterval(
+      "20201101", "20201130",
+      {
+          true /* sunday */, false /* monday */, false /* tuesday */, false /* wednesday */,
+          false /* thursday */, false /* friday */, true /* saturday */
+      });
+
+  TestDatesInterval(
+      "20210101", "20210228",
+      {
+          false /* sunday */, true /* monday */, true /* tuesday */, true /* wednesday */,
+          true /* thursday */, true /* friday */, false /* saturday */
+      });
+
+  TestDatesInterval(
+      "20220101", "20240101",
+      {
+          false /* sunday */, false /* monday */, false /* tuesday */, false /* wednesday */,
+          true /* thursday */, true /* friday */, true /* saturday */
+      });
+}
+
+UNIT_TEST(TransitSchedule_DateException)
+{
+  TestDateException("20210316", true);
+  TestDateException("20210101", false);
+  TestDateException("20221231", true);
+  TestDateException("20221231", false);
+}
+
+UNIT_TEST(TransitSchedule_TimeInterval)
+{
+  TestTimeInterval("14:30:00", "14:30:30");
+  TestTimeInterval("00:00:00", "21:45:40");
+  TestTimeInterval("07:10:30", "11:25:00");
+  TestTimeInterval("13:00:00", "13:50:00");
+  TestTimeInterval("23:40:50", "23:59:59");
+}
+
+UNIT_TEST(TransitSchedule_FrequencyIntervals)
+{
+  gtfs::Frequencies const frequencies{GetFrequency("14:40:00", "15:55:30", 600),
+                                      GetFrequency("15:55:40", "17:00:00", 1200),
+                                      GetFrequency("21:10:20", "22:45:40", 300)};
+
+  FrequencyIntervals const intervals(frequencies);
+
+  TEST_EQUAL(intervals.GetFrequency(Time(13, 15, 30)), kDefaultFrequency, ());
+
+  TEST_EQUAL(intervals.GetFrequency(Time(14, 55, 0)), 600, ());
+  TEST_EQUAL(intervals.GetFrequency(Time(15, 0, 55)), 600, ());
+
+  TEST_EQUAL(intervals.GetFrequency(Time(15, 55, 39)), kDefaultFrequency, ());
+  TEST_EQUAL(intervals.GetFrequency(Time(15, 55, 40)), 1200, ());
+  TEST_EQUAL(intervals.GetFrequency(Time(16, 0, 0)), 1200, ());
+
+  TEST_EQUAL(intervals.GetFrequency(Time(21, 50, 0)), 300, ());
+  TEST_EQUAL(intervals.GetFrequency(Time(22, 14, 20)), 300, ());
+  TEST_EQUAL(intervals.GetFrequency(Time(22, 50, 10)), kDefaultFrequency, ());
+}
+
+UNIT_TEST(TransitSchedule_Schedule_DatesInterval_Status)
+{
+  gtfs::CalendarItem calendarItem1;
+  calendarItem1.start_date = gtfs::Date("20200401");
+  calendarItem1.end_date = gtfs::Date("20201120");
+  calendarItem1.friday = gtfs::CalendarAvailability::Available;
+  calendarItem1.saturday = gtfs::CalendarAvailability::Available;
+
+  gtfs::CalendarItem calendarItem2;
+  calendarItem2.start_date = gtfs::Date("20201121");
+  calendarItem2.end_date = gtfs::Date("20201231");
+  calendarItem2.wednesday = gtfs::CalendarAvailability::Available;
+
+  gtfs::Frequencies const frequencies1{GetFrequency("12:10:30", "16:00:40", 4500),
+                                       GetFrequency("18:00:00", "19:00:00", 1800)};
+
+  gtfs::Frequencies const frequencies2{GetFrequency("07:25:00", "12:10:00", 2700)};
+
+  Schedule busSchedule;
+  busSchedule.AddDatesInterval(calendarItem1, frequencies1);
+  busSchedule.AddDatesInterval(calendarItem2, frequencies2);
+
+  // 11.04.2020, saturday.
+  TEST_EQUAL(busSchedule.GetStatus(time_t(1586600488)), Status::Open, ());
+  // 12.04.2020, sunday.
+  TEST_EQUAL(busSchedule.GetStatus(time_t(1586686888)), Status::Closed, ());
+  // 07.08.2020, friday.
+  TEST_EQUAL(busSchedule.GetStatus(time_t(1596795688)), Status::Open, ());
+  // 08.08.2020, saturday.
+  TEST_EQUAL(busSchedule.GetStatus(time_t(1596882088)), Status::Open, ());
+  // 09.08.2020, sunday.
+  TEST_EQUAL(busSchedule.GetStatus(time_t(1596968488)), Status::Closed, ());
+}
+
+UNIT_TEST(TransitSchedule_Schedule_DateException_Status)
+{
+  gtfs::Frequencies const emptyFrequencies;
+
+  Schedule busSchedule;
+  busSchedule.AddDateException(gtfs::Date("20200606"), gtfs::CalendarDateException::Added,
+                               emptyFrequencies);
+  busSchedule.AddDateException(gtfs::Date("20200607"), gtfs::CalendarDateException::Removed,
+                               emptyFrequencies);
+  busSchedule.AddDateException(gtfs::Date("20211029"), gtfs::CalendarDateException::Added,
+                               emptyFrequencies);
+  busSchedule.AddDateException(gtfs::Date("20211128"), gtfs::CalendarDateException::Removed,
+                               emptyFrequencies);
+
+  // 06.06.2020.
+  TEST(busSchedule.GetStatus(time_t(1591438888)) == Status::Open, ());
+  // 07.06.2020.
+  TEST(busSchedule.GetStatus(time_t(1591525288)) == Status::Closed, ());
+  // 29.10.2021.
+  TEST(busSchedule.GetStatus(time_t(1635502888)) == Status::Open, ());
+  // 28.11.2021.
+  TEST(busSchedule.GetStatus(time_t(1638094888)) == Status::Closed, ());
+  // 01.03.2021.
+  TEST(busSchedule.GetStatus(time_t(1614594088)) == Status::Unknown, ());
+  // 01.01.2020.
+  TEST(busSchedule.GetStatus(time_t(1577874088)) == Status::Unknown, ());
+}
+}  // namespace

--- a/xcode/transit/transit.xcodeproj/project.pbxproj
+++ b/xcode/transit/transit.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		D56AD1DC24CB02C00057F2E0 /* transit_data.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D56AD1D824CB02BF0057F2E0 /* transit_data.hpp */; };
 		D56AD1DD24CB02C00057F2E0 /* transit_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D56AD1D924CB02BF0057F2E0 /* transit_data.cpp */; };
 		D56AD1DE24CB02C00057F2E0 /* transit_types_experimental.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D56AD1DA24CB02BF0057F2E0 /* transit_types_experimental.cpp */; };
+		D5E1DDB024F6A0E9001F72D5 /* transit_schedule.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D5E1DDAE24F6A0E9001F72D5 /* transit_schedule.hpp */; };
+		D5E1DDB124F6A0E9001F72D5 /* transit_schedule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D5E1DDAF24F6A0E9001F72D5 /* transit_schedule.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,8 @@
 		D56AD1D824CB02BF0057F2E0 /* transit_data.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_data.hpp; sourceTree = "<group>"; };
 		D56AD1D924CB02BF0057F2E0 /* transit_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_data.cpp; sourceTree = "<group>"; };
 		D56AD1DA24CB02BF0057F2E0 /* transit_types_experimental.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_types_experimental.cpp; sourceTree = "<group>"; };
+		D5E1DDAE24F6A0E9001F72D5 /* transit_schedule.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transit_schedule.hpp; sourceTree = "<group>"; };
+		D5E1DDAF24F6A0E9001F72D5 /* transit_schedule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transit_schedule.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +81,8 @@
 			children = (
 				D56AD1D624CB02BF0057F2E0 /* experimental */,
 				D55B290524CACF9E000E2EBE /* transit_display_info.hpp */,
+				D5E1DDAF24F6A0E9001F72D5 /* transit_schedule.cpp */,
+				D5E1DDAE24F6A0E9001F72D5 /* transit_schedule.hpp */,
 				D55B290924CACF9E000E2EBE /* transit_entities.hpp */,
 				D55B290724CACF9E000E2EBE /* transit_version.cpp */,
 				D55B290624CACF9E000E2EBE /* transit_version.hpp */,
@@ -112,6 +118,7 @@
 				D56AD1DC24CB02C00057F2E0 /* transit_data.hpp in Headers */,
 				D55B290D24CACF9E000E2EBE /* transit_entities.hpp in Headers */,
 				56EE14CC1FE7F2900036F20C /* transit_types.hpp in Headers */,
+				D5E1DDB024F6A0E9001F72D5 /* transit_schedule.hpp in Headers */,
 				D56AD1DB24CB02C00057F2E0 /* transit_types_experimental.hpp in Headers */,
 				562DDBDD1FE8EA0A0091F566 /* transit_graph_data.hpp in Headers */,
 				D55B290A24CACF9E000E2EBE /* transit_display_info.hpp in Headers */,
@@ -182,6 +189,7 @@
 				562DDBDC1FE8EA0A0091F566 /* transit_graph_data.cpp in Sources */,
 				56EE14CB1FE7F2900036F20C /* transit_types.cpp in Sources */,
 				D56AD1DD24CB02C00057F2E0 /* transit_data.cpp in Sources */,
+				D5E1DDB124F6A0E9001F72D5 /* transit_schedule.cpp in Sources */,
 				D56AD1DE24CB02C00057F2E0 /* transit_types_experimental.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Класс расписания линий маршрутов  (пункт 2 для ужатия транзитной секции #13474). 

Применение этих классов будет добавлено в следующем реквесте: они заменят `osmoh::OpeningHours` в `gtfs_converter` и классах транзита из `omim/transit/experimental/transit_types_experimental.hpp/cpp`. Кроме того, теперь можно будет склеивать линии с одинаковой геометрией и последовательностью остановок, но разными рабочими днями. 

Иерархия дней работы линии и частоты курсирования по ней транспорта в классе Schedule: есть интервалы дней (формат день, месяц, год), и к ним привязаны дни недели, по которым транспорт ходит. А есть исключения в расписании - не интервалы, а отдельные даты. И к интервалам, и к исключениями привязаны интервалы в сутках, внутри которых транспорт ходит с определенной частотой.

@bykoianko @maksimandrianov PTAL
