### PR TITLE
[generator] Generate clockwise roundabouts in countries with left-hand traffic.

### DIFF
--- a/generator/final_processor_country.cpp
+++ b/generator/final_processor_country.cpp
@@ -9,18 +9,17 @@
 #include "generator/node_mixer.hpp"
 #include "generator/osm2type.hpp"
 #include "generator/promo_catalog_cities.hpp"
+#include "generator/region_meta.hpp"
 #include "generator/routing_city_boundaries_processor.hpp"
 
 #include "routing/routing_helpers.hpp"
 #include "routing/speed_camera_prohibition.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/feature_algo.hpp"
 
 #include "base/file_name_utils.hpp"
 #include "base/thread_pool_computational.hpp"
 
-#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -149,6 +148,11 @@ void CountryFinalProcessor::ProcessRoundabouts()
       return;
 
     MiniRoundaboutTransformer transformer(roundabouts.GetData(), *m_affiliations);
+
+    RegionData data;
+
+    if (ReadRegionData(name, data))
+      transformer.SetLeftHandTraffic(data.Get(RegionData::Type::RD_DRIVING) == "l");
 
     FeatureBuilderWriter<serialization_policy::MaxAccuracy> writer(path, true /* mangleName */);
     ForEachFeatureRawFormat<serialization_policy::MaxAccuracy>(path, [&](auto && fb, auto /* pos */) {

--- a/generator/mini_roundabout_transformer.hpp
+++ b/generator/mini_roundabout_transformer.hpp
@@ -56,6 +56,8 @@ public:
   /// These features are obtained from points with highway=mini_roundabout.
   std::vector<feature::FeatureBuilder> ProcessRoundabouts();
 
+  void SetLeftHandTraffic(bool isLeftHand) { m_leftHandTraffic = isLeftHand; }
+
 private:
   /// \brief Sets |road_type| to |found_type| if it is a more important road type.
   void UpdateRoadType(FeatureParams::Types const & foundTypes, uint32_t & roadType);
@@ -78,6 +80,7 @@ private:
   double const m_radiusMercator = 0.0;
   feature::AffiliationInterface const * m_affiliation = nullptr;
   std::vector<feature::FeatureBuilder> m_roads;
+  bool m_leftHandTraffic = false;
 };
 
 /// \brief Calculates Euclidean distance between 2 points on plane.


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-13070

**Баг:** в странах с левосторонним движением (Англия, Индия и тд) мы генерим раундэбауты - линии из мини-раундэбаутов - точек с полилинией, направленной в противоположную сторону. Роутинг ведет по таким раундэбаутам как по дорогам с правосторонним движением, то есть против движения. 

**Фикс:** на этапе генерации раундэбаутов учитывать лево- или право-стороннее движение в стране. 

Пример: [раундэбаут в Англии.](https://www.openstreetmap.org/node/220512990#map=8/50.799/0.297)
| До реквеста | После реквеста |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2020-08-27 at 13 31 53" src="https://user-images.githubusercontent.com/54934129/91433272-b855d900-e86b-11ea-814b-f9baed7d8250.png">  | <img width="320" alt="Screenshot 2020-08-27 at 13 39 44" src="https://user-images.githubusercontent.com/54934129/91433316-c73c8b80-e86b-11ea-8075-3af7d7238182.png">  |