### PR TITLE
[RELEASE_ONLY] [search] Make HotelsClassifier look at the query too (and not only at results).

### DIFF
--- a/search/emitter.hpp
+++ b/search/emitter.hpp
@@ -6,7 +6,8 @@
 #include "base/logging.hpp"
 #include "base/timer.hpp"
 
-#include <utility>
+#include <string>
+#include <vector>
 
 namespace search
 {
@@ -30,6 +31,8 @@ public:
   void AddResultNoChecks(Result && res) { m_results.AddResultNoChecks(std::move(res)); }
 
   void AddBookmarkResult(bookmarks::Result const & result) { m_results.AddBookmarkResult(result); }
+
+  void PrecheckHotelQuery(std::vector<uint32_t> const & types) { m_results.PrecheckHotelQuery(types); }
 
   void Emit(bool force = false)
   {

--- a/search/hotels_classifier.cpp
+++ b/search/hotels_classifier.cpp
@@ -2,18 +2,14 @@
 
 #include "search/result.hpp"
 
+#include "indexer/ftypes_matcher.hpp"
+
+#include "base/logging.hpp"
+
+using namespace std;
+
 namespace search
 {
-// static
-bool HotelsClassifier::IsHotelResults(Results const & results)
-{
-  HotelsClassifier classifier;
-  for (auto const & r : results)
-    classifier.Add(r);
-
-  return classifier.IsHotelResults();
-}
-
 void HotelsClassifier::Add(Result const & result)
 {
   if (result.m_details.m_isHotel)
@@ -22,14 +18,23 @@ void HotelsClassifier::Add(Result const & result)
   ++m_numResults;
 }
 
+void HotelsClassifier::PrecheckHotelQuery(vector<uint32_t> const & types)
+{
+  m_looksLikeHotelQuery = ftypes::IsHotelChecker::Instance()(types);
+}
+
 void HotelsClassifier::Clear()
 {
   m_numHotels = 0;
   m_numResults = 0;
+  m_looksLikeHotelQuery = false;
 }
 
 bool HotelsClassifier::IsHotelResults() const
 {
+  if (m_looksLikeHotelQuery)
+    return true;
+
   // Threshold used to activate hotels mode. Probably is too strict,
   // but we don't have statistics now.
   double const kThreshold = 0.75;

--- a/search/hotels_classifier.hpp
+++ b/search/hotels_classifier.hpp
@@ -1,21 +1,30 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 namespace search
 {
 class Result;
 class Results;
+
 // A binary classifier that can be used in conjunction with search
-// engine to decide whether the majority of results are hotels or not.
+// engine to decide whether the query is related to hotel search.
+//
+// Two ways we use to decide whether the user was searching for hotels:
+// 1. We may infer it from the query text.
+// 2. We may infer it from the query results: if the majority are hotels,
+//    probably the query was too.
 //
 // *NOTE* This class is NOT thread safe.
 class HotelsClassifier
 {
 public:
-  static bool IsHotelResults(Results const & results);
-
   void Add(Result const & result);
+
+  // The types are parsed from the original query in search::Processor.
+  void PrecheckHotelQuery(std::vector<uint32_t> const & types);
+
   void Clear();
 
   bool IsHotelResults() const;
@@ -23,5 +32,6 @@ public:
 private:
   uint64_t m_numHotels = 0;
   uint64_t m_numResults = 0;
+  bool m_looksLikeHotelQuery = false;
 };
 }  // namespace search

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -315,6 +315,9 @@ void Processor::SetQuery(string const & query)
   if (!m_isCategorialRequest)
     ForEachCategoryType(tokenSlice, [&](size_t, uint32_t t) { m_preferredTypes.push_back(t); });
 
+  if (m_isCategorialRequest)
+    m_emitter.PrecheckHotelQuery(m_preferredTypes);
+
   base::SortUnique(m_preferredTypes);
 }
 

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -218,6 +218,8 @@ public:
 
   void AddBookmarkResult(bookmarks::Result const & result);
 
+  void PrecheckHotelQuery(std::vector<uint32_t> const & types) { m_hotelsClassif.PrecheckHotelQuery(types); }
+
   void Clear();
 
   Iter begin() { return m_results.begin(); }


### PR DESCRIPTION
The main reason is to avoid flickering of the filter button when
zoomed in to an area without hotels.