### PR TITLE
[routing][integration tests] Update for new mwm version.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -64,7 +64,7 @@ UNIT_TEST(NetherlandsAmsterdamBicycleYes)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 301.8, 1.0), (route.GetTotalTimeSec()));
+  TEST(base::AlmostEqualAbs(route.GetTotalTimeSec(), 304.2, 1.0), (route.GetTotalTimeSec()));
 }
 
 // This test on tag cycleway=opposite for a streets which have oneway=yes.

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -173,7 +173,7 @@ UNIT_TEST(BelarusMinksBarURatushiToMoscowBusStation)
   integration::CalculateRouteAndTestRouteLength(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(53.9045, 27.5569), {0., 0.},
-      mercator::FromLatLon(53.889, 27.5466), 2677.57);
+      mercator::FromLatLon(53.889, 27.5466), 2395.3);
 }
 
 UNIT_TEST(BelarusBobruisk50LetVlksmToSanatoryShinnik)
@@ -515,7 +515,7 @@ UNIT_TEST(RussiaPriut11Elbrus)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(43.31475, 42.46035), {0., 0.},
-      mercator::FromLatLon(43.35254, 42.43788), 32588.6 /* expectedTimeSeconds */);
+      mercator::FromLatLon(43.35254, 42.43788), 37753.4 /* expectedTimeSeconds */);
 }
 
 // Test on going down from Elbrus mountain to Priut11.
@@ -524,7 +524,7 @@ UNIT_TEST(RussiaElbrusPriut11)
   integration::CalculateRouteAndTestRouteTime(
       integration::GetVehicleComponents(VehicleType::Pedestrian),
       mercator::FromLatLon(43.35254, 42.43788), {0., 0.},
-      mercator::FromLatLon(43.31475, 42.46035), 13708.4 /* expectedTimeSeconds */);
+      mercator::FromLatLon(43.31475, 42.46035), 15878.9 /* expectedTimeSeconds */);
 }
 
 // Test on going straight forward on primary road.

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -59,7 +59,7 @@ namespace
     integration::CalculateRouteAndTestRouteLength(
         integration::GetVehicleComponents(VehicleType::Car),
         mercator::FromLatLon(55.97310, 37.41460), {0.0, 0.0},
-        mercator::FromLatLon(55.75100, 37.61790), 33763.7);
+        mercator::FromLatLon(55.75100, 37.61790), 42732.6);
   }
 
   // Restrictions tests. Check restrictions generation, if there are any errors.
@@ -520,7 +520,7 @@ namespace
 
     integration::CalculateRouteAndTestRouteLength(
         vehicleComponents, mercator::FromLatLon(55.93934, 37.406), {0.0, 0.0},
-        mercator::FromLatLon(55.93952, 37.45089), 8987.7);
+        mercator::FromLatLon(55.93952, 37.45089), 10713.9);
   }
 
   // Test on necessity calling RectCoversPolyline() after DataSource::ForEachInRect()
@@ -532,7 +532,7 @@ namespace
 
     integration::CalculateRouteAndTestRouteLength(
         vehicleComponents, mercator::FromLatLon(55.93885, 37.40588), {0.0, 0.0},
-        mercator::FromLatLon(55.93706, 37.45339), 9168.15);
+        mercator::FromLatLon(55.93706, 37.45339), 10894.3);
   }
 
   UNIT_TEST(NoCrash_RioGrandeCosmopolis)

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -177,8 +177,8 @@ UNIT_TEST(RussiaMoscowNoTurnsOnMKADTurnTest)
   RouterResultCode const result = routeResult.second;
 
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0)
+  integration::TestTurnCount(route, 2 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 1)
       .TestValid()
       .TestPoint({37.68276, 67.14062})
       .TestDirection(CarDirection::ExitHighwayToRight);


### PR DESCRIPTION
Новая версия данных сломала 8 интеграционных тестов роутинга:

**RussiaMoscowNoTurnsOnMKADTurnTest.** Количество поворотов - 2 вместо 1.
Добавлен маневр TurnSlightLeft, потому что в ОСМ у дублера МКАДа поменялся тип с линк на транк:
https://www.openstreetmap.org/changeset/88025306#map=15/55.6095/37.4940
<img width="400" alt="Screenshot 2020-08-28 at 12 31 35" src="https://user-images.githubusercontent.com/54934129/91559411-b873d880-e940-11ea-94b8-6c1f4a560e24.png">

Сам тест проверяет съезд с МКАД вправо, который теперь считается не 1ым маневром, а 2ым.

**NetherlandsAmsterdamBicycleYes.** Разница в ETA ~3 секунды. Было 301.8, стало 304.296. В рамках погрешности, все ок. Сам путь не изменился.

**BelarusMinksBarURatushiToMoscowBusStation** - разница в длине маршрута 187 метров. Было 2677.57, стало 2395.3.
Домапили пешую дорожку, теперь не надо строить крюк.

Было:
<img width="226" alt="image" src="https://user-images.githubusercontent.com/54934129/91559640-20c2ba00-e941-11ea-902c-e44ce04d49de.png">
Стало:
<img width="230" alt="image" src="https://user-images.githubusercontent.com/54934129/91559661-2a4c2200-e941-11ea-8c36-8a99b2923765.png">
**RussiaPriut11Elbrus** - пеший. Время. Было: 32588.6 стало: 37753.4 разница: 2281 с
**RussiaElbrusPriut11** - пеший. Время. Было 13708.4 стало: 15878.9 разница: 959 с

В ОСМ обновили тропы, в том числе https://www.openstreetmap.org/way/805937198

Было:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/54934129/91559771-59629380-e941-11ea-8930-c62130dd6a16.png">
Стало:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/54934129/91559796-64b5bf00-e941-11ea-9856-1f67f72db2fe.png">
**RussiaMoscowNotCrossingTollRoadTest**. Расстояние. Было 8987.7 Стало: 10713.9 Разница: 629 м
**RussiaMoscowNecessityRectCoversPolylineTest** Расстояние. Было: 9168.15 Стало: 10894.3 разница: 641 м.

RussiaMoscowNotCrossingTollRoadTest - план маршрута, маневры и тд остались прежними. Увеличилось расстояние на 600 м. Это связано с изменениями в геометрии дорог в ОСМ.
RussiaMoscowNecessityRectCoversPolylineTest - Была отредактирована информация о дорогах, проходящих через КПП на М-11. Поэтому вместо съезда и короткой фейковой дуги фейковая дуга подлиннее.
https://www.openstreetmap.org/changeset/88257508#map=15/55.9422/37.4425
Маршруты в одном районе. Там было активное обновление ОСМа. 

Было:
<img width="208" alt="image" src="https://user-images.githubusercontent.com/54934129/91560990-74ce9e00-e943-11ea-90b9-33548a2c8c64.png">

Стало:
<img width="175" alt="image" src="https://user-images.githubusercontent.com/54934129/91561019-80ba6000-e943-11ea-9656-9f65ae2e0e98.png">

**MoscowToSVOAirport**. Расстояние. Было: 33763.7 Стало: 42732.6 разница: 2363 м
На территории аэропорта замапили новую дорогу, и теперь вместо длинной фейковой дуги до другой дороги и выезда через нее мы достраиваем дугу до этой дороги и выезжаем по ней. Путь получился длиннее, но более правильный.

Было:
<img width="340" alt="image" src="https://user-images.githubusercontent.com/54934129/91559930-9c246b80-e941-11ea-818b-9769f481298b.png">

Стало:
<img width="294" alt="image" src="https://user-images.githubusercontent.com/54934129/91559956-ab0b1e00-e941-11ea-816a-573c9f68f670.png">
