### PR TITLE
 [strings] Remove duplicates for Bolivia_North, Bolivia_South

### DIFF
--- a/data/countries-strings/ar.json/localize.json
+++ b/data/countries-strings/ar.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"ستيريا — ليوبن",
 "Austria_Upper Austria_Linz":"النمسا العليا — لينتز",
 "Austria_Upper Austria_Wels":"النمسا العليا — فيلس",
-"Bolivia_North":"بوليفيا — شمال",
-"Bolivia_South":"بوليفيا — جنوب",
 "Brazil_Goias_Brasilia":"غوياس — برازيليا",
 "Brazil_Goias_North":"غوياس — شمال",
 "Brazil_North Region_East":"المنطقة الشمالية — شرق",

--- a/data/countries-strings/cs.json/localize.json
+++ b/data/countries-strings/cs.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Štýrsko — Leoben",
 "Austria_Upper Austria_Linz":"Horní Rakousy — Linec",
 "Austria_Upper Austria_Wels":"Horní Rakousy — Wels",
-"Bolivia_North":"Bolívie — Sever",
-"Bolivia_South":"Bolívie — Jih",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Sever",
 "Brazil_North Region_East":"Severní region — Východ",

--- a/data/countries-strings/da.json/localize.json
+++ b/data/countries-strings/da.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Oberösterreich — Linz",
 "Austria_Upper Austria_Wels":"Oberösterreich — Wels",
-"Bolivia_North":"Bolivia — Nord",
-"Bolivia_South":"Bolivia — Syd",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Norte — Øst",

--- a/data/countries-strings/de.json/localize.json
+++ b/data/countries-strings/de.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Oberösterreich — Linz",
 "Austria_Upper Austria_Wels":"Oberösterreich — Wels",
-"Bolivia_North":"Bolivien — Norden",
-"Bolivia_South":"Bolivien — Süden",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Norden",
 "Brazil_North Region_East":"Norden — Osten",

--- a/data/countries-strings/el.json/localize.json
+++ b/data/countries-strings/el.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Στυρία — Λεόμπεν",
 "Austria_Upper Austria_Linz":"Άνω Αυστρία – Λινζ",
 "Austria_Upper Austria_Wels":"Άνω Αυστρία — Βελς",
-"Bolivia_North":"Βολιβία - Βόρεια",
-"Bolivia_South":"Βολιβία - Νότια",
 "Brazil_Goias_Brasilia":"Γκόιας - Μπραζίλια",
 "Brazil_Goias_North":"Γκόιας - Βόρεια",
 "Brazil_North Region_East":"Βόρεια περιοχή — Ανατολική",

--- a/data/countries-strings/en.json/localize.json
+++ b/data/countries-strings/en.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Styria — Leoben",
 "Austria_Upper Austria_Linz":"Upper Austria — Linz",
 "Austria_Upper Austria_Wels":"Upper Austria — Wels",
-"Bolivia_North":"Bolivia — North",
-"Bolivia_South":"Bolivia — South",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — North",
 "Brazil_North Region_East":"North Region — East",

--- a/data/countries-strings/es.json/localize.json
+++ b/data/countries-strings/es.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Estiria — Leoben",
 "Austria_Upper Austria_Linz":"Alta Austria — Linz",
 "Austria_Upper Austria_Wels":"Alta Austria — Wels",
-"Bolivia_North":"Bolivia — Norte",
-"Bolivia_South":"Bolivia — Sur",
 "Brazil_Goias_Brasilia":"Goiás — Brasilia",
 "Brazil_Goias_North":"Goiás — Norte",
 "Brazil_North Region_East":"Región Norte de Brasil — Este",

--- a/data/countries-strings/fi.json/localize.json
+++ b/data/countries-strings/fi.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Ylä-Itävalta — Linz",
 "Austria_Upper Austria_Wels":"Ylä-Itävalta — Wels",
-"Bolivia_North":"Bolivia — Pohjoinen",
-"Bolivia_South":"Bolivia — Etelä",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Pohjoinen",
 "Brazil_North Region_East":"Pohjoinen alue — Itä",

--- a/data/countries-strings/fr.json/localize.json
+++ b/data/countries-strings/fr.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Styrie — Leoben",
 "Austria_Upper Austria_Linz":"Haute-Autriche — Linz",
 "Austria_Upper Austria_Wels":"Haute-Autriche — Wels",
-"Bolivia_North":"Bolivie — Nord",
-"Bolivia_South":"Bolivie — Sud",
 "Brazil_Goias_Brasilia":"Goiás — Brasilia",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Région Nord — Est",

--- a/data/countries-strings/he.json/localize.json
+++ b/data/countries-strings/he.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"שטיריה — לאובן",
 "Austria_Upper Austria_Linz":"אוסטריה עילית — לינץ",
 "Austria_Upper Austria_Wels":"אוסטריה עילית — ולס",
-"Bolivia_North":"בוליביה — צָפוֹן",
-"Bolivia_South":"בוליביה — דָרוֹם",
 "Brazil_Goias_Brasilia":"גויאס — ברזיליה",
 "Brazil_Goias_North":"גויאס — צָפוֹן",
 "Brazil_North Region_East":"האזור הצפוני (ברזיל) — מִזְרָח",

--- a/data/countries-strings/hu.json/localize.json
+++ b/data/countries-strings/hu.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Stájerország — Leoben",
 "Austria_Upper Austria_Linz":"Felső-Ausztria — Linz",
 "Austria_Upper Austria_Wels":"Felső-Ausztria — Wels",
-"Bolivia_North":"Bolívia — Észak",
-"Bolivia_South":"Bolívia — Dél",
 "Brazil_Goias_Brasilia":"Goiás — Brazília",
 "Brazil_Goias_North":"Goiás — Észak",
 "Brazil_North Region_East":"Északi régió — Kelet",

--- a/data/countries-strings/id.json/localize.json
+++ b/data/countries-strings/id.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Styria — Leoben",
 "Austria_Upper Austria_Linz":"Austria Hulu — Linz",
 "Austria_Upper Austria_Wels":"Austria Hulu — Wels",
-"Bolivia_North":"Bolivia — Utara",
-"Bolivia_South":"Bolivia — Selatan",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Utara",
 "Brazil_North Region_East":"Wilayah Utara — Timur",

--- a/data/countries-strings/it.json/localize.json
+++ b/data/countries-strings/it.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Stiria — Leoben",
 "Austria_Upper Austria_Linz":"Alta Austria — Linz",
 "Austria_Upper Austria_Wels":"Alta Austria — Wels",
-"Bolivia_North":"Bolivia — Nord",
-"Bolivia_South":"Bolivia — Sud",
 "Brazil_Goias_Brasilia":"Goiás — Brasilia",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Regione Nord del Brasile — Est",

--- a/data/countries-strings/ja.json/localize.json
+++ b/data/countries-strings/ja.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"シュタイアーマルク州・レオーベン",
 "Austria_Upper Austria_Linz":"オーバーエスターライヒ州・リンツ",
 "Austria_Upper Austria_Wels":"オーバーエスターライヒ州・ヴェルス",
-"Bolivia_North":"ボリビア・北部",
-"Bolivia_South":"ボリビア・南部",
 "Brazil_Goias_Brasilia":"ゴイアス州・ブラジリア",
 "Brazil_Goias_North":"ゴイアス州・北部",
 "Brazil_North Region_East":"北部 — 東",

--- a/data/countries-strings/ko.json/localize.json
+++ b/data/countries-strings/ko.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"슈타이어마르크 주 — 레오벤",
 "Austria_Upper Austria_Linz":"오버외스터라이히 주 — 린츠",
 "Austria_Upper Austria_Wels":"오버외스터라이히 주 — 벨스",
-"Bolivia_North":"볼리비아 — 북",
-"Bolivia_South":"볼리비아 — 남",
 "Brazil_Goias_Brasilia":"고이아스 주 — 브라질리아",
 "Brazil_Goias_North":"고이아스 주 — 북",
 "Brazil_North Region_East":"노르치 지방 — 동",

--- a/data/countries-strings/nb.json/localize.json
+++ b/data/countries-strings/nb.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Oberösterreich — Linz",
 "Austria_Upper Austria_Wels":"Oberösterreich — Wels",
-"Bolivia_North":"Bolivia — Nord",
-"Bolivia_South":"Bolivia — Sør",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Norte — Øst",

--- a/data/countries-strings/nl.json/localize.json
+++ b/data/countries-strings/nl.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Stiermarken — Leoben",
 "Austria_Upper Austria_Linz":"Opper-Oostenrijk — Linz",
 "Austria_Upper Austria_Wels":"Opper-Oostenrijk — Wels",
-"Bolivia_North":"Bolivia — Noord",
-"Bolivia_South":"Bolivia — Zuid",
 "Brazil_Goias_Brasilia":"Goiás — Brasilia",
 "Brazil_Goias_North":"Goiás — Noord",
 "Brazil_North Region_East":"Regio Noord — Oost",

--- a/data/countries-strings/pl.json/localize.json
+++ b/data/countries-strings/pl.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Styria — Leoben",
 "Austria_Upper Austria_Linz":"Górna Austria — Linz",
 "Austria_Upper Austria_Wels":"Górna Austria — Wels",
-"Bolivia_North":"Boliwia — Północ",
-"Bolivia_South":"Boliwia — Południe",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Północ",
 "Brazil_North Region_East":"Region Północny — Wschód",

--- a/data/countries-strings/pt.json/localize.json
+++ b/data/countries-strings/pt.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Estíria — Leoben",
 "Austria_Upper Austria_Linz":"Alta Áustria — Linz",
 "Austria_Upper Austria_Wels":"Alta Áustria — Wels",
-"Bolivia_North":"Bolívia — Norte",
-"Bolivia_South":"Bolívia — Sul",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Norte",
 "Brazil_North Region_East":"Região Norte do Brasil — Leste",

--- a/data/countries-strings/ro.json/localize.json
+++ b/data/countries-strings/ro.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Stiria — Leoben",
 "Austria_Upper Austria_Linz":"Austria Superioară — Linz",
 "Austria_Upper Austria_Wels":"Austria Superioară — Wels",
-"Bolivia_North":"Bolivia — Nord",
-"Bolivia_South":"Bolivia — Sud",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Regiunea de Nord — partea estică",

--- a/data/countries-strings/ru.json/localize.json
+++ b/data/countries-strings/ru.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Штирия — Леобен",
 "Austria_Upper Austria_Linz":"Верхняя Австрия — Линц",
 "Austria_Upper Austria_Wels":"Верхняя Австрия — Вельс",
-"Bolivia_North":"Боливия — Север",
-"Bolivia_South":"Боливия — Юг",
 "Brazil_Goias_Brasilia":"Гояс — Бразилиа",
 "Brazil_Goias_North":"Гояс — Север",
 "Brazil_North Region_East":"Северный регион — Восток",

--- a/data/countries-strings/sk.json/localize.json
+++ b/data/countries-strings/sk.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Štajersko — Leoben",
 "Austria_Upper Austria_Linz":"Horné Rakúsko — Linz",
 "Austria_Upper Austria_Wels":"Horné Rakúsko — Wels",
-"Bolivia_North":"Bolívia — Sever",
-"Bolivia_South":"Bolívia — Juh",
 "Brazil_Goias_Brasilia":"Goiás — Brazília",
 "Brazil_Goias_North":"Goiás — Sever",
 "Brazil_North Region_East":"Severný región - východ",

--- a/data/countries-strings/sv.json/localize.json
+++ b/data/countries-strings/sv.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Oberösterreich — Linz",
 "Austria_Upper Austria_Wels":"Oberösterreich — Wels",
-"Bolivia_North":"Bolivia — Nord",
-"Bolivia_South":"Bolivia — Syd",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Nord",
 "Brazil_North Region_East":"Norra regionen — Öst",

--- a/data/countries-strings/th.json/localize.json
+++ b/data/countries-strings/th.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"สตีเรีย — ลีโอเบน",
 "Austria_Upper Austria_Linz":"รัฐอัปเปอร์ออสเตรีย — ลินซ์",
 "Austria_Upper Austria_Wels":"ออสเตรียรเหนือ — เวลส์",
-"Bolivia_North":"ประเทศโบลิเวีย — เหนือ",
-"Bolivia_South":"ประเทศโบลิเวีย — ใต้",
 "Brazil_Goias_Brasilia":"รัฐโกยาส — บราซีเลีย",
 "Brazil_Goias_North":"รัฐโกยาส — เหนือ",
 "Brazil_North Region_East":"ภูมิภาคเหนือ — ตะวันออก",

--- a/data/countries-strings/tr.json/localize.json
+++ b/data/countries-strings/tr.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Styria — Leoben",
 "Austria_Upper Austria_Linz":"Yukarı Avusturya — Linz",
 "Austria_Upper Austria_Wels":"Yukarı Avusturya — Wels",
-"Bolivia_North":"Bolivya — Kuzey",
-"Bolivia_South":"Bolivya — Güney",
 "Brazil_Goias_Brasilia":"Goiás — Brasília",
 "Brazil_Goias_North":"Goiás — Kuzey",
 "Brazil_North Region_East":"Kuzey Bölgesi — Doğu",

--- a/data/countries-strings/uk.json/localize.json
+++ b/data/countries-strings/uk.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Штирія — Леобен",
 "Austria_Upper Austria_Linz":"Верхня Австрія — Лінц",
 "Austria_Upper Austria_Wels":"Верхня Австрія — Вельс",
-"Bolivia_North":"Болівія — Північ",
-"Bolivia_South":"Болівія — Південь",
 "Brazil_Goias_Brasilia":"Гояс — Бразиліа",
 "Brazil_Goias_North":"Гояс — Північ",
 "Brazil_North Region_East":"Північний регіон Бразилії — Схід",

--- a/data/countries-strings/vi.json/localize.json
+++ b/data/countries-strings/vi.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"Steiermark — Leoben",
 "Austria_Upper Austria_Linz":"Oberösterreich — Linz",
 "Austria_Upper Austria_Wels":"Oberösterreich — Wels",
-"Bolivia_North":"Bolivia — Bắc",
-"Bolivia_South":"Bolivia — Nam",
 "Brazil_Goias_Brasilia":"Goiás — Brasilia",
 "Brazil_Goias_North":"Goiás — Bắc",
 "Brazil_North Region_East":"North Region — Đông",

--- a/data/countries-strings/zh-Hans.json/localize.json
+++ b/data/countries-strings/zh-Hans.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"施蒂利亚州 — 莱奥本",
 "Austria_Upper Austria_Linz":"上奥地利 — 林茨",
 "Austria_Upper Austria_Wels":"上奥地利 — 韦尔斯",
-"Bolivia_North":"保加利亚 - 东",
-"Bolivia_South":"保加利亚 - 西",
 "Brazil_Goias_Brasilia":"戈亚斯 — 巴西利亚",
 "Brazil_Goias_North":"戈亚斯 - 北",
 "Brazil_North Region_East":"北部地区 - 东",

--- a/data/countries-strings/zh-Hant.json/localize.json
+++ b/data/countries-strings/zh-Hant.json/localize.json
@@ -1199,8 +1199,6 @@
 "Austria_Styria_Leoben":"施蒂利亞州 — 萊奧本",
 "Austria_Upper Austria_Linz":"上奧地利 — 林茨",
 "Austria_Upper Austria_Wels":"上奧地利 — 韋爾斯",
-"Bolivia_North":"保加利亞 - 東",
-"Bolivia_South":"保加利亞 - 西",
 "Brazil_Goias_Brasilia":"戈亞斯 — 巴西利亞",
 "Brazil_Goias_North":"戈亞斯 - 北",
 "Brazil_North Region_East":"北部地區 - 東",

--- a/data/countries_names.txt
+++ b/data/countries_names.txt
@@ -37211,68 +37211,6 @@
   he = אוסטריה עילית — ולס
   sk = Horné Rakúsko — Wels
 
-[Bolivia_North]
-  en = Bolivia — North
-  ru = Боливия — Север
-  ar = بوليفيا — شمال
-  cs = Bolívie — Sever
-  da = Bolivia — Nord
-  nl = Bolivia — Noord
-  fi = Bolivia — Pohjoinen
-  fr = Bolivie — Nord
-  de = Bolivien — Norden
-  hu = Bolívia — Észak
-  id = Bolivia — Utara
-  it = Bolivia — Nord
-  ja = ボリビア・北部
-  ko = 볼리비아 — 북
-  nb = Bolivia — Nord
-  pl = Boliwia — Północ
-  pt = Bolívia — Norte
-  ro = Bolivia — Nord
-  es = Bolivia — Norte
-  sv = Bolivia — Nord
-  th = ประเทศโบลิเวีย — เหนือ
-  tr = Bolivya — Kuzey
-  uk = Болівія — Північ
-  vi = Bolivia — Bắc
-  zh-Hans = 保加利亚 - 东
-  zh-Hant = 保加利亞 - 東
-  el = Βολιβία - Βόρεια
-  he = בוליביה — צָפוֹן
-  sk = Bolívia — Sever
-
-[Bolivia_South]
-  en = Bolivia — South
-  ru = Боливия — Юг
-  ar = بوليفيا — جنوب
-  cs = Bolívie — Jih
-  da = Bolivia — Syd
-  nl = Bolivia — Zuid
-  fi = Bolivia — Etelä
-  fr = Bolivie — Sud
-  de = Bolivien — Süden
-  hu = Bolívia — Dél
-  id = Bolivia — Selatan
-  it = Bolivia — Sud
-  ja = ボリビア・南部
-  ko = 볼리비아 — 남
-  nb = Bolivia — Sør
-  pl = Boliwia — Południe
-  pt = Bolívia — Sul
-  ro = Bolivia — Sud
-  es = Bolivia — Sur
-  sv = Bolivia — Syd
-  th = ประเทศโบลิเวีย — ใต้
-  tr = Bolivya — Güney
-  uk = Болівія — Південь
-  vi = Bolivia — Nam
-  zh-Hans = 保加利亚 - 西
-  zh-Hant = 保加利亞 - 西
-  el = Βολιβία - Νότια
-  he = בוליביה — דָרוֹם
-  sk = Bolívia — Juh
-
 [Brazil_Goias_Brasilia]
   en = Goiás — Brasília
   ru = Гояс — Бразилиа


### PR DESCRIPTION
в файле с переводами переводы для боливии были два раза, в "старых" был неправильный перевод на китайский