### PR TITLE
[drape] [Vulkan] Make rendering and presentation conditions the same

### DIFF
--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -477,7 +477,7 @@ void VulkanBaseContext::ApplyFramebuffer(std::string const & framebufferLabel)
 
 void VulkanBaseContext::Present()
 {
-  if (m_needPresent && m_presentAvailable)
+  if (m_needPresent)
   {
     VkPresentInfoKHR presentInfo = {};
     presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;


### PR DESCRIPTION
Баг:
 - В `FrontendRenderer::RenderFrame()` вызов `VulkanBaseContext::BeginRendering()` был вызван успешно (иначе был бы ранний выход и до выполнения `EndRendering` и `Present` не дошло бы), следовательно `m_presentAvailable == true`. `VulkanBaseContext::EndRendering()` также выполнился успешно и установил флаг `m_needPresent == true`, при этом командный буффер был отправлен на выполнение (асинхронное по отношению к текущему потоку). О завершении его выполнения просигнализирует семафор (строка `submitInfo.pSignalSemaphores = &m_renderSemaphores[m_inflightFrameIndex];`).
 - При скачивании карты отображается баннер. При клике по баннеру, если в системе не выбран браузер по умолчанию, показывается системное меню выбора браузера, модальное по отношению к приложению. При этом вызывается `MapFragment::onPause()` -> `m_vulkanContextFactory->SetPresentAvailable(false);`. Это происходит во `FrontendRenderer::RenderFrame()` между вызовами `VulkanBaseContext::EndRendering()` и `VulkanBaseContext::Present()` при ожидании на condvar в `FrontendRenderer::MessageAcceptor::ProcessSingleMessage()` (`MessageQueue::PopMessage`).
 - В `VulkanBaseContext::Present()` семафор не сбрасывается, т.к. `presentInfo.pWaitSemaphores = &m_renderSemaphores[m_inflightFrameIndex];` и вызов `vkQueuePresentKHR` находятся под условием `m_presentAvailable`, которое было `true` во время выполнения `BeginRendereing` и `EndRendering`, но `false` к данному моменту времени. Семафор остаётся в сигнальном состоянии с этого момента.
 - Далее, при закрытии (кнопкой "Назад") окна выбора браузера, вызывается `MapFragment::onResume()`, которое приводит к `m_presentAvailable == true`. В `EndRendering` семафор в сигнальном состоянии отдаётся в `vkQueueSubmit`, что является ошибкой.

При включенных validation layers (`#define ENABLE_VULKAN_DIAGNOSTICS` `#define ENABLE_VULKAN_DEBUG_DIAGNOSTICS_MESSAGES`) происходит ошибка с текстом:

    Vulkan Diagnostics [ Validation ] [ SEMAPHORE ] [OBJ: 381 LOC: 0 ]:  [ UNASSIGNED-CoreValidation-DrawState-QueueForwardProgress ] Object: 0x17d (Type = 5) | VkQueue 0xbd70adf8[] is signaling VkNonDispatchableHandle 0x17d[] that was previously signaled by VkQueue 0xbd70adf8[] but has not since been waited on by any queue.

При выключенных validation layers рендеринг и presentation не синхронизированы до пересоздания контекста. Это приводит к наведённым ошибкам, которые репортятся со стороны Java. Карта при этом не отображается.

Фикс:
Не проверять условие `m_presentAvailable` в `Present()`.

https://jira.mail.ru/browse/MAPSME-14673