### PR TITLE
[transit] Implement cross-mwm routing for new transit version.

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -459,10 +459,12 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
     if (!FLAGS_srtm_path.empty())
       routing::BuildRoadAltitudes(dataFile, FLAGS_srtm_path);
 
+    transit::experimental::EdgeIdToFeatureId transitEdgeFeatureIds;
+
     if (!FLAGS_transit_path_experimental.empty())
     {
-      transit::experimental::BuildTransit(path, country, osmToFeatureFilename,
-                                          FLAGS_transit_path_experimental);
+      transitEdgeFeatureIds = transit::experimental::BuildTransit(
+          path, country, osmToFeatureFilename, FLAGS_transit_path_experimental);
     }
     else if (!FLAGS_transit_path.empty())
     {
@@ -543,11 +545,12 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
       if (FLAGS_make_transit_cross_mwm_experimental)
       {
         routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter,
-                                             true /* experimentalTransit */);
+                                             transitEdgeFeatureIds, true /* experimentalTransit */);
       }
       else if (FLAGS_make_transit_cross_mwm)
       {
         routing::BuildTransitCrossMwmSection(path, dataFile, country, *countryParentGetter,
+                                             transitEdgeFeatureIds,
                                              false /* experimentalTransit */);
       }
     }

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -709,7 +709,7 @@ void BuildRoutingCrossMwmSection(string const & path, string const & mwmFile,
   vector<CrossMwmConnectorSerializer::Transition<CrossMwmId>> transitions;
 
   CalcCrossMwmConnectors(path, mwmFile, intermediateDir, country, countryParentNameGetterFn,
-                         osmToFeatureFile, {} /*edgeIdToFeatureId */, transitions, connectors);
+                         osmToFeatureFile, {} /* edgeIdToFeatureId */, transitions, connectors);
 
   // We use leaps for cars only. To use leaps for other vehicle types add weights generation
   // here and change WorldGraph mode selection rule in IndexRouter::CalculateSubroute.

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -379,9 +379,9 @@ void CalcCrossMwmTransitions(
 void CalcCrossMwmTransitionsExperimental(
     string const & mwmFile, vector<m2::RegionD> const & borders, string const & country,
     routing::CountryParentNameGetterFn const & /* countryParentNameGetterFn */,
+    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId,
     vector<routing::CrossMwmConnectorSerializer::Transition<routing::connector::TransitId>> &
-        transitions,
-    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId)
+        transitions)
 {
   try
   {
@@ -445,8 +445,8 @@ void CalcCrossMwmTransitionsExperimental(
 void CalcCrossMwmTransitionsExperimental(
     string const & mwmFile, vector<m2::RegionD> const & borders, string const & country,
     routing::CountryParentNameGetterFn const & countryParentNameGetterFn,
-    vector<routing::CrossMwmConnectorSerializer::Transition<base::GeoObjectId>> & transitions,
-    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId)
+    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId,
+    vector<routing::CrossMwmConnectorSerializer::Transition<base::GeoObjectId>> & transitions)
 {
   CHECK(false, ("This is dummy specialization and it shouldn't be called."));
 }
@@ -461,9 +461,9 @@ void CalcCrossMwmConnectors(
     string const & path, string const & mwmFile, string const & intermediateDir,
     string const & country, routing::CountryParentNameGetterFn const & countryParentNameGetterFn,
     string const & mappingFile,
+    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId,
     vector<routing::CrossMwmConnectorSerializer::Transition<CrossMwmId>> & transitions,
     routing::CrossMwmConnectorPerVehicleType<CrossMwmId> & connectors,
-    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId,
     bool experimentalTransit = false)
 {
   base::Timer timer;
@@ -486,7 +486,7 @@ void CalcCrossMwmConnectors(
     CHECK(!edgeIdToFeatureId.empty(),
           ("Edge id to feature id must be filled before building cross-mwm transit section."));
     CalcCrossMwmTransitionsExperimental(mwmFile, borders, country, countryParentNameGetterFn,
-                                        transitions, edgeIdToFeatureId);
+                                        edgeIdToFeatureId, transitions);
   }
   else
   {
@@ -709,7 +709,7 @@ void BuildRoutingCrossMwmSection(string const & path, string const & mwmFile,
   vector<CrossMwmConnectorSerializer::Transition<CrossMwmId>> transitions;
 
   CalcCrossMwmConnectors(path, mwmFile, intermediateDir, country, countryParentNameGetterFn,
-                         osmToFeatureFile, transitions, connectors, {} /*edgeIdToFeatureId */);
+                         osmToFeatureFile, {} /*edgeIdToFeatureId */, transitions, connectors);
 
   // We use leaps for cars only. To use leaps for other vehicle types add weights generation
   // here and change WorldGraph mode selection rule in IndexRouter::CalculateSubroute.
@@ -731,8 +731,8 @@ void BuildTransitCrossMwmSection(
   vector<CrossMwmConnectorSerializer::Transition<CrossMwmId>> transitions;
 
   CalcCrossMwmConnectors(path, mwmFile, "" /* intermediateDir */, country,
-                         countryParentNameGetterFn, "" /* mapping file */, transitions, connectors,
-                         edgeIdToFeatureId, experimentalTransit);
+                         countryParentNameGetterFn, "" /* mapping file */, edgeIdToFeatureId,
+                         transitions, connectors, experimentalTransit);
 
   CHECK(connectors[static_cast<size_t>(VehicleType::Pedestrian)].IsEmpty(), ());
   CHECK(connectors[static_cast<size_t>(VehicleType::Bicycle)].IsEmpty(), ());

--- a/generator/routing_index_generator.hpp
+++ b/generator/routing_index_generator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "transit/experimental/transit_data.hpp"
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -22,8 +24,9 @@ void BuildRoutingCrossMwmSection(std::string const & path, std::string const & m
                                  bool disableCrossMwmProgress);
 /// \brief Builds TRANSIT_CROSS_MWM_FILE_TAG section.
 /// \note Before a call of this method TRANSIT_FILE_TAG should be built.
-void BuildTransitCrossMwmSection(std::string const & path, std::string const & mwmFile,
-                                 std::string const & country,
-                                 CountryParentNameGetterFn const & countryParentNameGetterFn,
-                                 bool experimentalTransit = false);
+void BuildTransitCrossMwmSection(
+    std::string const & path, std::string const & mwmFile, std::string const & country,
+    CountryParentNameGetterFn const & countryParentNameGetterFn,
+    ::transit::experimental::EdgeIdToFeatureId const & edgeIdToFeatureId,
+    bool experimentalTransit = false);
 }  // namespace routing

--- a/generator/transit_generator_experimental.cpp
+++ b/generator/transit_generator_experimental.cpp
@@ -161,8 +161,9 @@ void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const
   data.DeserializeFromJson(transitJsonsPath, mapping);
 }
 
-void BuildTransit(std::string const & mwmDir, CountryId const & countryId,
-                  std::string const & osmIdToFeatureIdsPath, std::string const & transitDir)
+EdgeIdToFeatureId BuildTransit(std::string const & mwmDir, CountryId const & countryId,
+                               std::string const & osmIdToFeatureIdsPath,
+                               std::string const & transitDir)
 {
   LOG(LINFO, ("Building experimental transit section for", countryId, "mwmDir:", mwmDir));
   std::string const mwmPath = GetMwmPath(mwmDir, countryId);
@@ -175,7 +176,7 @@ void BuildTransit(std::string const & mwmDir, CountryId const & countryId,
 
   // Transit section can be empty.
   if (data.IsEmpty())
-    return;
+    return {};
 
   CalculateBestPedestrianSegments(mwmPath, countryId, data);
 
@@ -188,6 +189,8 @@ void BuildTransit(std::string const & mwmDir, CountryId const & countryId,
   FilesContainerW container(mwmPath, FileWriter::OP_WRITE_EXISTING);
   auto writer = container.GetWriter(TRANSIT_FILE_TAG);
   data.Serialize(*writer);
+  CHECK_EQUAL(data.GetEdgeIdToFeatureId().size(), data.GetEdges().size(), ());
+  return data.GetEdgeIdToFeatureId();
 }
 }  // namespace experimental
 }  // namespace transit

--- a/generator/transit_generator_experimental.cpp
+++ b/generator/transit_generator_experimental.cpp
@@ -171,8 +171,12 @@ EdgeIdToFeatureId BuildTransit(std::string const & mwmDir, CountryId const & cou
   OsmIdToFeatureIdsMap mapping;
   FillOsmIdToFeatureIdsMap(osmIdToFeatureIdsPath, mapping);
 
+  std::string const transitPath = base::JoinPath(transitDir, countryId);
+  if (!Platform::IsFileExistsByFullPath(transitPath))
+    return {};
+
   TransitData data;
-  DeserializeFromJson(mapping, base::JoinPath(transitDir, countryId), data);
+  DeserializeFromJson(mapping, transitPath, data);
 
   // Transit section can be empty.
   if (data.IsEmpty())

--- a/generator/transit_generator_experimental.cpp
+++ b/generator/transit_generator_experimental.cpp
@@ -173,14 +173,20 @@ EdgeIdToFeatureId BuildTransit(std::string const & mwmDir, CountryId const & cou
 
   std::string const transitPath = base::JoinPath(transitDir, countryId);
   if (!Platform::IsFileExistsByFullPath(transitPath))
+  {
+    LOG(LWARNING, ("Path to experimental transit files doesn't exist:", transitPath));
     return {};
+  }
 
   TransitData data;
   DeserializeFromJson(mapping, transitPath, data);
 
   // Transit section can be empty.
   if (data.IsEmpty())
+  {
+    LOG(LWARNING, ("Experimental transit data deserialized from jsons is empty:", transitPath));
     return {};
+  }
 
   CalculateBestPedestrianSegments(mwmPath, countryId, data);
 

--- a/generator/transit_generator_experimental.hpp
+++ b/generator/transit_generator_experimental.hpp
@@ -27,7 +27,8 @@ void DeserializeFromJson(OsmIdToFeatureIdsMap const & mapping, std::string const
 /// \note An mwm pointed by |mwmPath| should contain:
 /// * feature geometry
 /// * index graph (ROUTING_FILE_TAG)
-void BuildTransit(std::string const & mwmDir, storage::CountryId const & countryId,
-                  std::string const & osmIdToFeatureIdsPath, std::string const & transitDir);
+EdgeIdToFeatureId BuildTransit(std::string const & mwmDir, storage::CountryId const & countryId,
+                               std::string const & osmIdToFeatureIdsPath,
+                               std::string const & transitDir);
 }  // namespace experimental
 }  // namespace transit

--- a/transit/experimental/transit_data.cpp
+++ b/transit/experimental/transit_data.cpp
@@ -425,7 +425,7 @@ void Read(base::Json const & obj, std::vector<Edge> & edges, EdgeIdToFeatureId &
   FromJSONObjectOptionalField(obj.get(), "line_id", lineId);
 
   TransitId featureId = kInvalidFeatureId;
-  FromJSONObjectOptionalField(obj.get(), "feature_id", featureId);
+  FromJSONObject(obj.get(), "feature_id", featureId);
 
   if (lineId == 0)
   {

--- a/transit/experimental/transit_data.cpp
+++ b/transit/experimental/transit_data.cpp
@@ -408,7 +408,7 @@ void Read(base::Json const & obj, std::vector<Shape> & shapes)
   shapes.emplace_back(id, polyline);
 }
 
-void Read(base::Json const & obj, std::vector<Edge> & edges)
+void Read(base::Json const & obj, std::vector<Edge> & edges, EdgeIdToFeatureId & edgeFeatureIds)
 {
   TransitId stopFrom = kInvalidTransitId;
   TransitId stopTo = kInvalidTransitId;
@@ -423,6 +423,10 @@ void Read(base::Json const & obj, std::vector<Edge> & edges)
   bool isTransfer = false;
 
   FromJSONObjectOptionalField(obj.get(), "line_id", lineId);
+
+  TransitId featureId = kInvalidFeatureId;
+  FromJSONObjectOptionalField(obj.get(), "feature_id", featureId);
+
   if (lineId == 0)
   {
     lineId = kInvalidTransitId;
@@ -434,6 +438,7 @@ void Read(base::Json const & obj, std::vector<Edge> & edges)
   }
 
   edges.emplace_back(stopFrom, stopTo, weight, lineId, isTransfer, shapeLink);
+  edgeFeatureIds.emplace(EdgeId(stopFrom, stopTo, lineId), featureId);
 }
 
 void Read(base::Json const & obj, std::vector<Transfer> & transfers)
@@ -501,8 +506,8 @@ void TransitData::DeserializeFromJson(std::string const & dirWithJsons,
   ReadData(base::JoinPath(dirWithJsons, kLinesMetadataFile), m_linesMetadata);
   ReadData(base::JoinPath(dirWithJsons, kStopsFile), m_stops, mapping);
   ReadData(base::JoinPath(dirWithJsons, kShapesFile), m_shapes);
-  ReadData(base::JoinPath(dirWithJsons, kEdgesFile), m_edges);
-  ReadData(base::JoinPath(dirWithJsons, kEdgesTransferFile), m_edges);
+  ReadData(base::JoinPath(dirWithJsons, kEdgesFile), m_edges, m_edgeFeatureIds);
+  ReadData(base::JoinPath(dirWithJsons, kEdgesTransferFile), m_edges, m_edgeFeatureIds);
   ReadData(base::JoinPath(dirWithJsons, kTransfersFile), m_transfers);
   ReadData(base::JoinPath(dirWithJsons, kGatesFile), m_gates, mapping);
 }

--- a/transit/experimental/transit_data.hpp
+++ b/transit/experimental/transit_data.hpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include "3party/jansson/myjansson.hpp"
@@ -26,7 +27,7 @@ namespace transit
 namespace experimental
 {
 using OsmIdToFeatureIdsMap = std::map<base::GeoObjectId, std::vector<FeatureId>>;
-
+using EdgeIdToFeatureId = std::unordered_map<EdgeId, uint32_t, EdgeIdHasher>;
 // Functions for parsing one line of line-by-line json and creating corresponding item in container.
 void Read(base::Json const & obj, std::vector<Network> & networks);
 void Read(base::Json const & obj, std::vector<Route> & routes);
@@ -34,7 +35,7 @@ void Read(base::Json const & obj, std::vector<Line> & lines);
 void Read(base::Json const & obj, std::vector<LineMetadata> & linesMetadata);
 void Read(base::Json const & obj, std::vector<Stop> & stops, OsmIdToFeatureIdsMap const & mapping);
 void Read(base::Json const & obj, std::vector<Shape> & shapes);
-void Read(base::Json const & obj, std::vector<Edge> & edges);
+void Read(base::Json const & obj, std::vector<Edge> & edges, EdgeIdToFeatureId & edgeFeatureIds);
 void Read(base::Json const & obj, std::vector<Transfer> & transfers);
 void Read(base::Json const & obj, std::vector<Gate> & gates, OsmIdToFeatureIdsMap const & mapping);
 
@@ -68,6 +69,8 @@ public:
   std::vector<Shape> const & GetShapes() const { return m_shapes; }
   std::vector<Route> const & GetRoutes() const { return m_routes; }
   std::vector<Network> const & GetNetworks() const { return m_networks; }
+
+  EdgeIdToFeatureId const & GetEdgeIdToFeatureId() const { return m_edgeFeatureIds; }
 
 private:
   DECLARE_VISITOR_AND_DEBUG_PRINT(TransitData, visitor(m_stops, "stops"), visitor(m_gates, "gates"),
@@ -106,6 +109,8 @@ private:
   std::vector<Line> m_lines;
   std::vector<LineMetadata> m_linesMetadata;
   std::vector<Shape> m_shapes;
+
+  EdgeIdToFeatureId m_edgeFeatureIds;
 };
 }  // namespace experimental
 }  // namespace transit

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -158,7 +158,7 @@ struct EdgeData
 
   // Feature id for cross-mwm transit section. It is used in Segment class as a feature id for
   // transit routing case.
-  uint32_t m_featureId = 0;
+  uint32_t m_featureId = std::numeric_limits<uint32_t>::max();
 };
 
 struct LineSegment

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -152,7 +152,7 @@ struct EdgeData
   }
 
   explicit EdgeData(EdgeWeight const & weight) : m_weight(weight) {}
-  
+
   ShapeLink m_shapeLink;
   EdgeWeight m_weight = 0;
 

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -150,8 +150,15 @@ struct EdgeData
     : m_shapeLink(shapeLink), m_weight(weight)
   {
   }
+
+  explicit EdgeData(EdgeWeight const & weight) : m_weight(weight) {}
+  
   ShapeLink m_shapeLink;
   EdgeWeight m_weight = 0;
+
+  // Feature id for cross-mwm transit section. It is used in Segment class as a feature id for
+  // transit routing case.
+  uint32_t m_featureId = 0;
 };
 
 struct LineSegment

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -252,8 +252,9 @@ UNIT_TEST(ReadJson_Edge)
            ShapeLink(kInvalidTransitId /* shapeId */, 0 /* startIndex */, 0 /* endIndex */))};
 
   std::vector<Edge> edgesFact;
+  EdgeIdToFeatureId edgeIdToFeatureId;
 
-  FillContainer(lineByLineJson, edgesFact);
+  FillContainer(lineByLineJson, edgesFact, edgeIdToFeatureId);
   TestEqual(edgesFact, edgesPlan);
 }
 

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -229,6 +229,7 @@ UNIT_TEST(ReadJson_Edge)
            "line_id":4036591958,
            "stop_id_from":4036592295,
            "stop_id_to":4036592296,
+           "feature_id":10731,
            "weight":69,
            "shape":{
              "id":4036591484,
@@ -239,6 +240,7 @@ UNIT_TEST(ReadJson_Edge)
       R"({
            "stop_id_from":4030648032,
            "stop_id_to":4030648073,
+           "feature_id":860522,
            "weight":40
          }
       )"};

--- a/transit/world_feed/subway_converter.hpp
+++ b/transit/world_feed/subway_converter.hpp
@@ -67,8 +67,9 @@ private:
       routing::transit::Transfer const & transferSubway);
   static std::pair<TransitId, LineData> MakeLine(routing::transit::Line const & lineSubway,
                                                  TransitId routeId);
-  std::pair<EdgeId, EdgeData> MakeEdge(routing::transit::Edge const & edgeSubway);
-  std::pair<EdgeTransferId, size_t> MakeEdgeTransfer(routing::transit::Edge const & edgeSubway);
+  std::pair<EdgeId, EdgeData> MakeEdge(routing::transit::Edge const & edgeSubway, uint32_t index);
+  std::pair<EdgeTransferId, EdgeData> MakeEdgeTransfer(routing::transit::Edge const & edgeSubway,
+                                                       uint32_t index);
   std::pair<TransitId, StopData> MakeStop(routing::transit::Stop const & stopSubway);
 
   routing::transit::Edge FindEdge(routing::transit::StopId stop1Id,
@@ -84,8 +85,8 @@ private:
   // Mapping of subway stop id to transit stop id.
   std::unordered_map<routing::transit::StopId, TransitId> m_stopIdMapping;
   // Subset of the |m_graphData| edges with no transfers.
-  std::vector<routing::transit::Edge> m_edgesSubway;
+  std::map<routing::transit::Edge, uint32_t> m_edgesSubway;
   // Subset of the |m_graphData| edges with transfers.
-  std::vector<routing::transit::Edge> m_edgesTransferSubway;
+  std::map<routing::transit::Edge, uint32_t> m_edgesTransferSubway;
 };
 }  // namespace transit

--- a/transit/world_feed/world_feed.cpp
+++ b/transit/world_feed/world_feed.cpp
@@ -347,12 +347,6 @@ TransitId IdGenerator::MakeId(const std::string & hash)
   return it->second;
 }
 
-void IdGenerator::SetCurId(TransitId curId)
-{
-  if (curId > m_curId)
-    m_curId = curId;
-}
-
 void IdGenerator::Save()
 {
   LOG(LINFO, ("Started saving", m_hashToId.size(), "mappings to", m_idMappingPath));

--- a/transit/world_feed/world_feed.cpp
+++ b/transit/world_feed/world_feed.cpp
@@ -1569,8 +1569,9 @@ void Edges::Write(IdEdgeSet const & ids, std::ofstream & stream) const
     ToJSONObject(*node, "stop_id_from", edgeId.m_fromStopId);
     ToJSONObject(*node, "stop_id_to", edgeId.m_toStopId);
 
-    if (edge.m_featureId != 0)
-      ToJSONObject(*node, "feature_id", edge.m_featureId);
+    CHECK_NOT_EQUAL(edge.m_featureId, std::numeric_limits<uint32_t>::max(),
+                   (edgeId.m_lineId, edgeId.m_fromStopId, edgeId.m_toStopId));
+    ToJSONObject(*node, "feature_id", edge.m_featureId);
 
     CHECK_GREATER(edge.m_weight, 0, (edgeId.m_fromStopId, edgeId.m_toStopId, edgeId.m_lineId));
     ToJSONObject(*node, "weight", edge.m_weight);
@@ -1592,8 +1593,9 @@ void EdgesTransfer::Write(IdEdgeTransferSet const & ids, std::ofstream & stream)
     ToJSONObject(*node, "stop_id_to", edgeTransferId.m_toStopId);
     ToJSONObject(*node, "weight", edgeData.m_weight);
 
-    if (edgeData.m_featureId != 0)
-      ToJSONObject(*node, "feature_id", edgeData.m_featureId);
+    CHECK_NOT_EQUAL(edgeData.m_featureId, std::numeric_limits<uint32_t>::max(),
+                   (edgeTransferId.m_fromStopId, edgeTransferId.m_toStopId));
+    ToJSONObject(*node, "feature_id", edgeData.m_featureId);
 
     WriteJson(node.get(), stream);
   }

--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -34,7 +34,6 @@ public:
   void Save();
 
   TransitId MakeId(std::string const & hash);
-  void SetCurId(TransitId curId);
 
 private:
   std::unordered_map<std::string, TransitId> m_hashToId;

--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -34,6 +34,7 @@ public:
   void Save();
 
   TransitId MakeId(std::string const & hash);
+  void SetCurId(TransitId curId);
 
 private:
   std::unordered_map<std::string, TransitId> m_hashToId;
@@ -187,8 +188,8 @@ using IdEdgeTransferSet = std::unordered_set<EdgeTransferId, EdgeTransferIdHashe
 struct EdgesTransfer
 {
   void Write(IdEdgeTransferSet const & ids, std::ofstream & stream) const;
-  // Key is pair of stops and value is weight (in seconds).
-  std::unordered_map<EdgeTransferId, size_t, EdgeTransferIdHasher> m_data;
+  // Key is pair of stops and value is |EdgeData|, containing weight (in seconds).
+  std::unordered_map<EdgeTransferId, EdgeData, EdgeTransferIdHasher> m_data;
 };
 
 struct TransferData
@@ -280,7 +281,7 @@ using EdgePoints = std::pair<m2::PointD, m2::PointD>;
 class WorldFeed
 {
 public:
-  WorldFeed(IdGenerator & generator, ColorPicker & colorPicker,
+  WorldFeed(IdGenerator & generator, IdGenerator & generatorEdges, ColorPicker & colorPicker,
             feature::CountriesFilesAffiliation & mwmMatcher);
   // Transforms GTFS feed into the global feed.
   bool SetFeed(gtfs::Feed && feed);
@@ -387,6 +388,8 @@ private:
 
   // Generator of ids, globally unique and constant between re-runs.
   IdGenerator & m_idGenerator;
+  // Generator of ids for edges only.
+  IdGenerator & m_idGeneratorEdges;
   // Color name picker of the nearest color for route RBG from our constant list of transfer colors.
   ColorPicker & m_colorPicker;
   // Mwm matcher for m2:Points representing stops and other entities.

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -30,7 +30,7 @@ class WorldFeedIntegrationTests
 public:
   WorldFeedIntegrationTests()
     : m_mwmMatcher(GetTestingOptions().m_resourcePath, false /* haveBordersForWholeWorld */)
-    , m_globalFeed(m_generator, m_colorPicker, m_mwmMatcher)
+    , m_globalFeed(m_generator, m_generatorEdges, m_colorPicker, m_mwmMatcher)
   {
     auto const & options = GetTestingOptions();
 
@@ -39,6 +39,7 @@ public:
     CHECK(GetPlatform().MkDirRecursively(m_testPath), ());
 
     m_generator = IdGenerator(base::JoinPath(m_testPath, "mapping.txt"));
+    m_generatorEdges = IdGenerator(base::JoinPath(m_testPath, "mapping_edges.txt"));
 
     auto const src = base::JoinPath(options.m_resourcePath, kArchiveWithFeeds + ".zip");
     ZipFileReader::FileList filesAndSizes;
@@ -135,6 +136,7 @@ public:
 private:
   std::string m_testPath;
   IdGenerator m_generator;
+  IdGenerator m_generatorEdges;
   transit::ColorPicker m_colorPicker;
   feature::CountriesFilesAffiliation m_mwmMatcher;
   WorldFeed m_globalFeed;

--- a/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
+++ b/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
@@ -18,7 +18,7 @@ namespace
 std::string const kSubwayTestsDir = "transit_subway_converter_tests";
 std::string const kSubwayJsonFile = "subways.json";
 std::string const kMappingFile = "mapping.txt";
-std::string const kMappingEdgesFile = "mapping.txt";
+std::string const kMappingEdgesFile = "mapping_edges.txt";
 
 void WriteStringToFile(std::string const & fileName, std::string const & data)
 {

--- a/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
+++ b/transit/world_feed/world_feed_tests/subway_converter_tests.cpp
@@ -18,6 +18,7 @@ namespace
 std::string const kSubwayTestsDir = "transit_subway_converter_tests";
 std::string const kSubwayJsonFile = "subways.json";
 std::string const kMappingFile = "mapping.txt";
+std::string const kMappingEdgesFile = "mapping.txt";
 
 void WriteStringToFile(std::string const & fileName, std::string const & data)
 {
@@ -42,6 +43,7 @@ public:
     CHECK(Platform::MkDirChecked(kSubwayTestsDir),
           ("Could not create directory for test data:", kSubwayTestsDir));
     m_generator = transit::IdGenerator(base::JoinPath(kSubwayTestsDir, kMappingFile));
+    m_generatorEdges = transit::IdGenerator(base::JoinPath(kSubwayTestsDir, kMappingEdgesFile));
   }
 
   ~SubwayConverterTests() { Platform::RmDirRecursively(kSubwayTestsDir); }
@@ -60,7 +62,7 @@ public:
 
     auto const & filePath = base::JoinPath(kSubwayTestsDir, kSubwayJsonFile);
     WriteStringToFile(filePath, emptySubway);
-    transit::WorldFeed feed(m_generator, m_colorPicker, m_mwmMatcher);
+    transit::WorldFeed feed(m_generator, m_generatorEdges, m_colorPicker, m_mwmMatcher);
     transit::SubwayConverter converter(filePath, feed);
     TEST(!converter.Convert(), ());
   }
@@ -332,7 +334,7 @@ public:
 
     auto const & filePath = base::JoinPath(kSubwayTestsDir, kSubwayJsonFile);
     WriteStringToFile(filePath, validSubway);
-    transit::WorldFeed feed(m_generator, m_colorPicker, m_mwmMatcher);
+    transit::WorldFeed feed(m_generator, m_generatorEdges, m_colorPicker, m_mwmMatcher);
     transit::SubwayConverter converter(filePath, feed);
 
     // We check that the conversion between old and new formats is successful.
@@ -374,6 +376,7 @@ public:
 
 private:
   transit::IdGenerator m_generator;
+  transit::IdGenerator m_generatorEdges;
   transit::ColorPicker m_colorPicker;
   feature::CountriesFilesAffiliation m_mwmMatcher;
 };


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14521

Задача: прокладывать маршруты между mwm со старой версией секции транзит (метро-онли) и mwm с новой версией секции (в будущем весь общественный транспорт, пока только метро).

Кросс-мвм маршрут между старой и новой версией транзита:
<img width="694" alt="Screenshot 2020-10-22 at 10 09 09" src="https://user-images.githubusercontent.com/54934129/97016649-a8016800-1555-11eb-9d37-10f25ec58b26.png">
