### PR TITLE
[transit] Replace osmoh::OpeningHours with Schedule.

### DIFF
--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -12,6 +12,7 @@
 #include "transit/experimental/transit_data.hpp"
 #include "transit/experimental/transit_types_experimental.hpp"
 #include "transit/transit_graph_data.hpp"
+#include "transit/transit_schedule.hpp"
 #include "transit/transit_types.hpp"
 #include "transit/transit_version.hpp"
 
@@ -109,7 +110,7 @@ private:
   std::map<Segment, ::transit::experimental::Edge> m_segmentToEdgePT;
   std::map<Segment, ::transit::experimental::Gate> m_segmentToGatePT;
   std::map<Segment, ::transit::experimental::Stop> m_segmentToStopPT;
-  std::map<::transit::TransitId, std::vector<::transit::LineInterval>> m_transferPenaltiesPT;
+  std::map<::transit::TransitId, ::transit::Schedule> m_transferPenaltiesPT;
 };
 
 void MakeGateEndings(std::vector<transit::Gate> const & gates, NumMwmId mwmId,

--- a/transit/experimental/transit_types_experimental.cpp
+++ b/transit/experimental/transit_types_experimental.cpp
@@ -131,16 +131,14 @@ std::string const & Route::GetColor() const { return m_color; }
 TransitId Route::GetNetworkId() const { return m_networkId; }
 
 // Line --------------------------------------------------------------------------------------------
-Line::Line(TransitId id, TransitId routeId, ShapeLink shapeLink, std::string const & title,
-           IdList stopIds, std::vector<LineInterval> const & intervals,
-           osmoh::OpeningHours const & serviceDays)
+Line::Line(TransitId id, TransitId routeId, ShapeLink const & shapeLink, std::string const & title,
+           IdList const & stopIds, Schedule const & schedule)
   : m_id(id)
   , m_routeId(routeId)
   , m_shapeLink(shapeLink)
   , m_title(title)
   , m_stopIds(stopIds)
-  , m_intervals(intervals)
-  , m_serviceDays(serviceDays)
+  , m_schedule(schedule)
 {
 }
 
@@ -164,9 +162,7 @@ ShapeLink const & Line::GetShapeLink() const { return m_shapeLink; }
 
 IdList const & Line::GetStopIds() const { return m_stopIds; }
 
-std::vector<LineInterval> Line::GetIntervals() const { return m_intervals; }
-
-osmoh::OpeningHours Line::GetServiceDays() const { return m_serviceDays; }
+Schedule const & Line::GetSchedule() const { return m_schedule; }
 
 // LineMetadata ------------------------------------------------------------------------------------
 LineMetadata::LineMetadata(TransitId id, LineSegmentsOrder const & segmentsOrder)

--- a/transit/experimental/transit_types_experimental.hpp
+++ b/transit/experimental/transit_types_experimental.hpp
@@ -195,9 +195,8 @@ class Line
 {
 public:
   Line() = default;
-  Line(TransitId id, TransitId routeId, ShapeLink shapeLink, std::string const & title,
-       IdList stopIds, std::vector<LineInterval> const & intervals,
-       osmoh::OpeningHours const & serviceDays);
+  Line(TransitId id, TransitId routeId, ShapeLink const & shapeLink, std::string const & title,
+       IdList const & stopIds, Schedule const & schedule);
 
   bool operator<(Line const & rhs) const;
   bool operator==(Line const & rhs) const;
@@ -209,22 +208,19 @@ public:
   TransitId GetRouteId() const;
   ShapeLink const & GetShapeLink() const;
   IdList const & GetStopIds() const;
-  std::vector<LineInterval> GetIntervals() const;
-  osmoh::OpeningHours GetServiceDays() const;
+  Schedule const & GetSchedule() const;
 
 private:
   DECLARE_TRANSIT_TYPES_FRIENDS
   DECLARE_VISITOR_AND_DEBUG_PRINT(Line, visitor(m_id, "id"), visitor(m_routeId, "route_id"),
                                   visitor(m_shapeLink, "shape_link"), visitor(m_title, "title"),
-                                  visitor(m_stopIds, "stop_ids"), visitor(m_intervals, "intervals"),
-                                  visitor(m_serviceDays, "service_days"))
+                                  visitor(m_stopIds, "stop_ids"), visitor(m_schedule, "schedule"))
   TransitId m_id = kInvalidTransitId;
   TransitId m_routeId = kInvalidTransitId;
   ShapeLink m_shapeLink;
   std::string m_title;
   IdList m_stopIds;
-  std::vector<LineInterval> m_intervals;
-  osmoh::OpeningHours m_serviceDays;
+  Schedule m_schedule;
 };
 
 class LineMetadata

--- a/transit/transit_entities.hpp
+++ b/transit/transit_entities.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "transit/transit_schedule.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "base/macros.hpp"
@@ -69,33 +71,9 @@ struct TimeFromGateToStop
   size_t m_timeSeconds = 0;
 };
 
-struct LineInterval
-{
-  LineInterval() = default;
-  LineInterval(size_t headwayS, osmoh::OpeningHours const & timeIntervals)
-    : m_headwayS(headwayS), m_timeIntervals(timeIntervals)
-  {
-  }
-
-  bool operator==(LineInterval const & rhs) const
-  {
-    return std::tie(m_headwayS, m_timeIntervals) == std::tie(rhs.m_headwayS, rhs.m_timeIntervals);
-  }
-
-  DECLARE_VISITOR_AND_DEBUG_PRINT(LineInterval, visitor(m_headwayS, "headwayS"),
-                                  visitor(m_timeIntervals, "timeIntervals"))
-  // Service interval in seconds between departures from the same stop (headway) for the line,
-  // during the time interval specified by |m_timeIntervals|.
-  size_t m_headwayS = 0;
-  // Time interval for the |m_headwayS|. Multiple headways for the same trip are allowed, but may
-  // not overlap in time.
-  osmoh::OpeningHours m_timeIntervals;
-};
-
-using LineIntervals = std::vector<LineInterval>;
 using IdList = std::vector<TransitId>;
 using IdSet = std::unordered_set<TransitId>;
-using TimeTable = std::unordered_map<TransitId, osmoh::OpeningHours>;
+using TimeTable = std::unordered_map<TransitId, std::vector<TimeInterval>>;
 using EdgeWeight = uint32_t;
 
 // Link to the shape: shape id and indexes in the corresponding polyline.

--- a/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
+++ b/transit/transit_experimental_tests/parse_transit_from_json_tests.cpp
@@ -90,24 +90,34 @@ UNIT_TEST(ReadJson_Line)
              4036592572,
              4036592573
            ],
-           "service_days":"2021 Nov 25-2021 Nov 26, 2021 Dec 24-2021 Dec 25 closed",
-           "intervals":[
-                         {
-                           "interval_s":3600,
-                           "service_hours":"06:40-18:40 open"
-                         }
-                       ]
+           "schedule":{
+             "def_frequency":4060,
+             "intervals":[
+               {
+                "dates_interval":75007489,
+                "time_intervals":[{"time_interval":6530334760, "frequency":3000}]
+               }],
+               "exceptions":[
+                {"exception":519, "time_intervals": []},
+                {"exception":357, "time_intervals": []}
+               ]
+             }
          })"};
+
+  FrequencyIntervals frequencies;
+  frequencies.AddInterval(TimeInterval(6530334760), 3000);
+
+  Schedule schedule;
+  schedule.SetDefaultFrequency(4060);
+
+  schedule.AddDatesInterval(DatesInterval(75007489), frequencies);
+  schedule.AddDateException(DateException(519), {});
+  schedule.AddDateException(DateException(357), {});
 
   std::vector<Line> const linesPlan = {
       Line(4036591532 /* id */, 4036591423 /* routeId */,
            ShapeLink(4036591460 /* id */, 415 /* startIndex */, 1691 /* endIndex */),
-           "Downtown" /* title */, IdList{4036592571, 4036592572, 4036592573},
-           std::vector<LineInterval>{LineInterval(
-               3600 /* headwayS */,
-               osmoh::OpeningHours("06:40-18:40 open") /* timeIntervals */)} /* intervals */,
-           osmoh::OpeningHours(
-               "2021 Nov 25-2021 Nov 26, 2021 Dec 24-2021 Dec 25 closed") /* serviceDays */)};
+           "Downtown" /* title */, IdList{4036592571, 4036592572, 4036592573}, schedule)};
 
   std::vector<Line> linesFact;
 
@@ -154,16 +164,7 @@ UNIT_TEST(ReadJson_Stop)
              "y":41.042765953900343
            },
            "title":"Balfour Rd & Foothill Dr",
-           "timetable":[
-             {
-               "line_id":4036591493,
-               "arrivals":"13:23-13:23 open"
-             },
-             {
-               "line_id":4036591562,
-               "arrivals":"15:23-15:23 open"
-             }
-           ],
+           "timetable":[{"line_id":204,"intervals":[11400205248]}],
            "transfer_ids":[
              4036593809,
              4036595406
@@ -173,8 +174,7 @@ UNIT_TEST(ReadJson_Stop)
   std::vector<Stop> const stopsPlan = {
       Stop(4036592706 /* id */, kInvalidFeatureId /* featureId */, kInvalidOsmId /* osmId */,
            "Balfour Rd & Foothill Dr",
-           TimeTable{{4036591493, osmoh::OpeningHours("13:23-13:23 open")},
-                     {4036591562, osmoh::OpeningHours("15:23-15:23 open")}},
+           TimeTable{{204, std::vector<TimeInterval>{TimeInterval(11400205248)}}},
            m2::PointD(-121.74124, 41.04276), {4036593809, 4036595406} /* transferIds */)};
 
   std::vector<Stop> stopsFact;

--- a/transit/transit_experimental_tests/transit_serdes_tests.cpp
+++ b/transit/transit_experimental_tests/transit_serdes_tests.cpp
@@ -111,17 +111,20 @@ TransitData FillTestTransitData()
                    Route(4027700599 /* id */, 4032061671 /* networkId */, "ferry" /* routeType */,
                          "Киевский вокзал - парк Зарядье" /* title */, "purple" /* color */)};
 
+  FrequencyIntervals frequencies;
+  frequencies.AddInterval(TimeInterval(6530334760), 3000);
+
+  Schedule schedule;
+  schedule.SetDefaultFrequency(4060);
+
+  schedule.AddDatesInterval(DatesInterval(75007489), frequencies);
+
   data.m_lines = {
       Line(4036598626 /* id */, 4036206872 /* routeId */,
            ShapeLink(4036591460 /* id */, 0 /* startIndex */, 2690 /* endIndex */),
            "740G" /* title */,
            IdList{4036592571, 4036592572, 4036592573, 4036592574, 4036592575, 4036592576},
-           std::vector<LineInterval>{LineInterval(
-               10060 /* headwayS */,
-               osmoh::OpeningHours("08:30-19:00 open") /* timeIntervals */)} /* intervals */,
-           osmoh::OpeningHours("2020 May 01-2020 May 01, 2020 May 25-2020 May 25, 2020 Jun 15-2020 "
-                               "Jun 15, 2020 Jun 20-2020 Jun 20, 2020 Jul 09-2020 Jul 09, 2020 Aug "
-                               "17-2020 Aug 17, 2020 Oct 12-2020 Oct 12") /* serviceDays */),
+           schedule),
       Line(
           4036598627 /* id */, 4036206872 /* routeId */,
           ShapeLink(4036591461 /* id */, 356 /* startIndex */, 40690 /* endIndex */),
@@ -129,17 +132,7 @@ TransitData FillTestTransitData()
           IdList{4027013783, 4027013784, 4027013785, 4027013786, 4027013787, 4027013788, 4027013789,
                  4027013790, 4027013791, 4027013792, 4027013793, 4027013794, 4027013795, 4027013796,
                  4027013797, 4027013798, 4027013799, 4027013800, 4027013801},
-          std::vector<LineInterval>{} /* intervals */,
-          osmoh::OpeningHours(
-              "2020 Apr 20-2020 Apr 24, 2020 Apr 27-2020 Apr 30, 2020 May 04-2020 May 08, 2020 May "
-              "11-2020 May 15, 2020 May 18-2020 May 22, 2020 May 26-2020 May 29, 2020 Jun 01-2020 "
-              "Jun 05, 2020 Jun 08-2020 Jun 12, 2020 Jun 16-2020 Jun 19, 2020 Jun 22-2020 Jun 26, "
-              "2020 Jun 29-2020 Jul 03, 2020 Jul 06-2020 Jul 08, 2020 Jul 10-2020 Jul 10, 2020 Jul "
-              "13-2020 Jul 17, 2020 Jul 20-2020 Jul 24, 2020 Jul 27-2020 Jul 31, 2020 Aug 03-2020 "
-              "Aug 07, 2020 Aug 10-2020 Aug 14, 2020 Aug 18-2020 Aug 21, 2020 Aug 24-2020 Aug 28, "
-              "2020 Aug 31-2020 Sep 04, 2020 Sep 07-2020 Sep 11, 2020 Sep 14-2020 Sep 18, 2020 Sep "
-              "21-2020 Sep 25, 2020 Sep 28-2020 Oct 02, 2020 Oct 05-2020 Oct 09, 2020 Oct 13-2020 "
-              "Oct 16, 2020 Oct 19-2020 Oct 20") /* serviceDays */)};
+          schedule)};
 
   data.m_linesMetadata = {
       LineMetadata(4036598626 /* id */, LineSegmentsOrder{LineSegmentOrder({0, 100}, 0),
@@ -148,10 +141,7 @@ TransitData FillTestTransitData()
 
   data.m_stops = {Stop(4026990853 /* id */, kInvalidFeatureId /* featureId */,
                        kInvalidOsmId /* osmId */, "CARLOS DIHEL 2500-2598" /* title */,
-                       TimeTable{{4026763635, osmoh::OpeningHours("06:00-06:00 open")},
-                                 {4026636458, osmoh::OpeningHours("05:00-05:00 open")},
-                                 {4026636458, osmoh::OpeningHours("05:30-05:30 open")},
-                                 {4026952369, osmoh::OpeningHours("15:30-15:30 open")}},
+                       TimeTable{{204, std::vector<TimeInterval>{TimeInterval(11400205248)}}},
                        m2::PointD(-58.57196, -36.82596), {} /* transferIds */),
                   Stop(4026990854 /* id */, kInvalidFeatureId /* featureId */,
                        kInvalidOsmId /* osmId */, "QUIROGA 1901-1999" /* title */, TimeTable{},

--- a/transit/transit_schedule.cpp
+++ b/transit/transit_schedule.cpp
@@ -147,13 +147,13 @@ std::tuple<Date, Date, WeekSchedule> DatesInterval::Extract() const
   date2.m_month = (m_data >> 12) & kMask4bits;
   date2.m_day = (m_data >> 7) & kMask5bits;
 
-  week[0] = m_data & 0x40;
-  week[1] = m_data & 0x20;
-  week[2] = m_data & 0x10;
-  week[3] = m_data & 0x8;
-  week[4] = m_data & 0x4;
-  week[5] = m_data & 0x2;
-  week[6] = m_data & 0x1;
+  week[WeekDays::Sunday] = m_data & 0x40;
+  week[WeekDays::Monday] = m_data & 0x20;
+  week[WeekDays::Tuesday] = m_data & 0x10;
+  week[WeekDays::Wednesday] = m_data & 0x8;
+  week[WeekDays::Thursday] = m_data & 0x4;
+  week[WeekDays::Friday] = m_data & 0x2;
+  week[WeekDays::Saturday] = m_data & 0x1;
 
   return {date1, date2, week};
 }

--- a/transit/transit_schedule.hpp
+++ b/transit/transit_schedule.hpp
@@ -87,6 +87,17 @@ struct Time
 };
 
 using WeekSchedule = std::array<bool, 7>;
+
+enum WeekDays
+{
+  Sunday = 0,
+  Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday
+};
 // Service dates specified using a weekly schedule with start and end dates. Dates range is
 // specified by the start_date and end_date fields in the GTFS calendar.txt.
 // Dates interval and open/closed states for week days are stored |m_data|.

--- a/transit/transit_tests/transit_tools.hpp
+++ b/transit/transit_tests/transit_tools.hpp
@@ -51,9 +51,9 @@ inline bool Equal(Route const & r1, Route const & r2)
 inline bool Equal(Line const & l1, Line const & l2)
 {
   return std::make_tuple(l1.GetId(), l1.GetRouteId(), l1.GetTitle(), l1.GetStopIds(),
-                         l1.GetIntervals(), l1.GetServiceDays(), l1.GetShapeLink()) ==
+                         l1.GetSchedule(), l1.GetShapeLink()) ==
          std::make_tuple(l2.GetId(), l2.GetRouteId(), l2.GetTitle(), l2.GetStopIds(),
-                         l2.GetIntervals(), l2.GetServiceDays(), l2.GetShapeLink());
+                         l2.GetSchedule(), l2.GetShapeLink());
 }
 
 inline bool Equal(LineMetadata const & lm1, LineMetadata const & lm2)

--- a/transit/world_feed/subway_converter.cpp
+++ b/transit/world_feed/subway_converter.cpp
@@ -180,9 +180,7 @@ std::pair<TransitId, LineData> SubwayConverter::MakeLine(routing::transit::Line 
   LineData lineData;
   lineData.m_routeId = routeId;
   lineData.m_title = lineSubway.GetTitle();
-  lineData.m_intervals = {LineInterval(lineSubway.GetInterval() /* headwayS */,
-                                       osmoh::OpeningHours(kDefaultHours) /* timeIntervals */)};
-  lineData.m_serviceDays = osmoh::OpeningHours(kDefaultHours);
+  lineData.m_schedule.SetDefaultFrequency(lineSubway.GetInterval());
 
   return {lineId, lineData};
 }

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -81,13 +81,13 @@ public:
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 21, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 87, ());
     // All trips have unique service_id so each line corresponds to some trip.
-    TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 980, ());
+    TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 392, ());
     TEST_EQUAL(m_globalFeed.m_stops.m_data.size(), 1008, ());
     // 64 shapes contained in other shapes should be skipped.
     TEST_EQUAL(m_globalFeed.m_shapes.m_data.size(), 329, ());
     TEST_EQUAL(m_globalFeed.m_gates.m_data.size(), 0, ());
     TEST_EQUAL(m_globalFeed.m_transfers.m_data.size(), 0, ());
-    TEST_EQUAL(m_globalFeed.m_edges.m_data.size(), 10079, ());
+    TEST_EQUAL(m_globalFeed.m_edges.m_data.size(), 3999, ());
     TEST_EQUAL(m_globalFeed.m_edgesTransfers.m_data.size(), 0, ());
   }
 


### PR DESCRIPTION
Заключительный реквест по ужатию транзитной секции из серии #13474. Использование пункта 2 (класс Schedule вместо osmoh::OpeningHours) в пункте 3 (склеивание расписаний для линий).

1. Различные trips из GTFS теперь объединяются в одну line при соблюдении условий:

- Одинаковый route id (маршрут один и тот же)
- Одинаковая последовательность остановок (везет по одним и тем же остановкам, без пропусков)
- Одинаковый shape id (полилиния маршрута совпадает)

До этого trip соответствовал line (матчинг по trip id). Поэтому у совпадающих по перечисленным выше параметрам линий могли быть различные service id, а соответственно и расписания. Теперь (что более логично) для одной линии эти расписания склеиваются в общее.

2. В TimeTable остановок osmoh::OpeningHours заменен на вектор объектов нового класса TimeInterval, хранящие время прибытия и отчаливания от остановки. 
3. m_intervals и m_serviceDays линий  заменены на объект класса Schedule, хранящий "в какие serviceDays какие ходят m_intervals".
4. Для всего это написаны (де)сериализаторы и обновлены юнит тесты.