### PR TITLE
[drape] [Booking] Shift non-Booking and non-hotels searchmarks vertically to fit selection geometry

### DIFF
--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -241,6 +241,13 @@ SearchMarkPoint::SearchMarkPoint(m2::PointD const & ptOrg)
 {
 }
 
+m2::PointD SearchMarkPoint::GetPixelOffset() const
+{
+  if (!IsBookingSpecialMark() && !IsHotel())
+    return {0.0, 4.0};
+  return {};
+}
+
 drape_ptr<df::UserPointMark::SymbolNameZoomInfo> SearchMarkPoint::GetSymbolNames() const
 {
   auto const symbolName = GetSymbolName();
@@ -354,6 +361,14 @@ drape_ptr<df::UserPointMark::BageInfo> SearchMarkPoint::GetBadgeInfo() const
   }
   
   return nullptr;
+}
+
+drape_ptr<df::UserPointMark::SymbolOffsets> SearchMarkPoint::GetSymbolOffsets() const
+{
+  m2::PointF offset;
+  if (!IsBookingSpecialMark() && !IsHotel())
+    offset = m2::PointF{0.0, 1.0};
+  return make_unique_dp<SymbolOffsets>(static_cast<size_t>(scales::UPPER_STYLE_SCALE), offset);
 }
 
 bool SearchMarkPoint::IsMarkAboveText() const

--- a/map/search_mark.hpp
+++ b/map/search_mark.hpp
@@ -30,12 +30,14 @@ public:
 
   explicit SearchMarkPoint(m2::PointD const & ptOrg);
 
+  m2::PointD GetPixelOffset() const override;
   drape_ptr<SymbolNameZoomInfo> GetSymbolNames() const override;
   df::ColorConstant GetColorConstant() const override;
   drape_ptr<TitlesInfo> GetTitleDecl() const override;
   int GetMinTitleZoom() const override;
   df::DepthLayer GetDepthLayer() const override;
   drape_ptr<BageInfo> GetBadgeInfo() const override;
+  drape_ptr<SymbolOffsets> GetSymbolOffsets() const override;
   bool GetDepthTestEnabled() const override { return false; }
   bool IsMarkAboveText() const override;
   float GetSymbolOpacity() const override;


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14776