### PR TITLE
[android] Reduced restriction on non-null download url when onPaymenR…

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/DefaultBookmarkDownloadController.java
+++ b/android/src/com/mapswithme/maps/bookmarks/DefaultBookmarkDownloadController.java
@@ -122,7 +122,7 @@ class DefaultBookmarkDownloadController implements BookmarkDownloadController,
   {
     LOGGER.i(TAG, "Payment required for bookmark purchase");
     if (TextUtils.isEmpty(mDownloadUrl))
-      throw new IllegalStateException("Download url must be non-null if payment required!");
+      return;
 
     if (mCallback != null)
     {


### PR DESCRIPTION
…equired called. It's possible when we quickly get out from catalog fragment after pressing the buy/download button and callback came to another fragment

https://jira.mail.ru/browse/MAPSME-14782

Убрал ассерт, проверяющий что downloadUrl не null. Т.к. вполне возможно случаи когда download url в контроллере будет null в момент onPaymentRequred от сервера. STR:

1. Находясь в каталоге, нажимаем кнопку купить/скачать маршрут и тут же жмем крестик, закрывая тем самым фрагмент каталога.
2. Возвращаемся на экран списка категорий букмарок, экран быстро подписывается на колбэки скачки и в этот экран прилетает ошибка payment required, но url в этом инстансе контроллера уже отсутствует, т.к. скачка запускалась с другого инстанса (каталога) и урл остался там.